### PR TITLE
Admin UX overhaul: design-token system + clarity pass + visual QA

### DIFF
--- a/apps/admin/src/lib/components/PolicyRow.svelte
+++ b/apps/admin/src/lib/components/PolicyRow.svelte
@@ -110,7 +110,7 @@
     >
     <button
       type="button"
-      class="btn-icon text-red-600"
+      class="rounded px-2.5 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
       aria-label={$t('remove')}
       onclick={() => onremove(index)}>{$t('Remove')}</button
     >

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -22,6 +22,8 @@
   "Decided by": "决策层",
   "Lane": "通道",
   "Final model": "最终模型",
+  "Requested model": "请求模型",
+  "Served model": "最终模型",
   "Status": "状态",
   "Latency": "延迟",
   "Cost": "成本",


### PR DESCRIPTION
## Summary

Makes the Helm admin UI genuinely easy to use for a non-expert operator: a real design-token foundation, a full design-token pass over every page, plain-language copy, and a browser-driven visual QA pass.

> **Note on scope:** the foundation + page-refactor commits (`8ba7623`, `7115e5a`, `557ccac`) already landed on `main` via an earlier merge, so this PR's *diff* is the final visual-QA commit (`783e30e`). The summary below covers the whole initiative for review context.

## What changed

**Foundation — Tailwind v3 → v4 + token layer** (`8ba7623`)
- Migrated to `tailwindcss@4` + the first-party `@tailwindcss/vite` plugin (dropped `postcss.config`/`tailwind.config`/`autoprefixer`).
- `app.css` now defines the design language as the single source of truth: semantic `@theme` color roles (brand vs action kept distinct, ink scale, status, two-tier radius) + `@layer` component recipes (`.card`, `.btn-*`, `.input`, `.select`, `.badge-*`, `.table-*`, `.section-header/.section-desc`, `.alert-*`, `.empty-state`, `.link-inline`).

**Design-token + clarity pass over all 8 surfaces** (`7115e5a`)
- Every page refactored to the recipes; removed `rounded-xl`; reclaimed indigo for brand/active-nav only (links → sky, chips → neutral).
- Plain-English relabel of raw schema vocab (`max_lane`/`needs_json`/`use_lane`/`org_id`…) + per-field helper text so the config is readable and authorable.
- Added empty states, "Saved" confirmations, and a `decided_by` legend (rules/eval/fallback) on Dashboard, Requests, and Request-detail.
- 97 new Simplified-Chinese translations.

**Visual QA pass** (`783e30e` — this PR's diff)
- **PolicyRow**: the Remove button used `.btn-icon` (a fixed `h-7 w-7` glyph square), so its text overflowed and misaligned with the ↑↓ icons → switched to a compact text-danger button on the same baseline.
- **Requests**: the only two untranslated headers ("Requested model"/"Served model") rendered as uppercase English amid Chinese headers → added `zh-hans` (请求模型/最终模型) to match the Dashboard table.

## Verification
- typecheck **0** · svelte-check **0** · admin tests **78/78** · admin build **0**.
- Browser-verified live on the running gateway across all pages; data preserved.

## Deliberate non-changes
- `rules`/`eval`/`fallback` badges stay English — they are the literal `decided_by` values, explained by the on-page legend (same rationale as keeping "lane").

🤖 Generated with [Claude Code](https://claude.com/claude-code)