### PR TITLE
fix(admin): scroll a newly added policy into view

### DIFF
--- a/apps/admin/src/routes/policies/+page.svelte
+++ b/apps/admin/src/routes/policies/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { tick, untrack } from 'svelte';
   import { type Policy, savePolicies, TASK_TYPE_OPTIONS } from '$lib/api/policies.js';
   import PolicyRow from '$lib/components/PolicyRow.svelte';
   import { t } from '$lib/i18n';
@@ -35,10 +35,17 @@
     policies = next;
   }
 
-  function addRow(): void {
+  async function addRow(): Promise<void> {
     // New rule defaults to a concrete action so it is never a silent no-op
-    // (server requires at least one of use_lane/max_lane).
+    // (server requires at least one of use_lane/max_lane). Appended LAST so it
+    // gets the lowest priority (first-match order) and can't shadow existing rules.
     policies = [...policies, { match: { task_type: TASK_TYPE_OPTIONS[0] }, use_lane: lanes[0] }];
+    // The Add button lives in the header; with a long list the new row lands far
+    // below the fold, so the click looks like a no-op. Scroll it into view for
+    // immediate feedback.
+    await tick();
+    const rows = document.querySelectorAll('[data-testid="policy-row"]');
+    rows[rows.length - 1]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }
 
   // Whole-set PUT (preserves priority order; avoids per-item patch losing it).


### PR DESCRIPTION
## Problem
After the Add/Save actions moved to the Policies page header, clicking **Add policy** appended the new row at the very bottom of a long list (correct — lowest first-match priority) — far below the fold. With no scroll/feedback the button looked disabled or non-functional.

## Fix
`addRow` now `await tick()` then `scrollIntoView({ behavior: 'smooth', block: 'center' })` on the new row, so the page scrolls to reveal it immediately. Ordering semantics unchanged (still appended last; drag ↑ to raise priority).

## Verification
Clicking Add: rows 9→10 and the page scrolls so the new row is fully in view (`top 443 / bottom 796` in an 820px viewport). svelte-check **0** · policies tests **6/6** · build **0** · redeployed to Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)