### PR TITLE
feat: per-key rate limits with editable system default

### DIFF
--- a/apps/admin/src/lib/api/keys.test.ts
+++ b/apps/admin/src/lib/api/keys.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiKeyView } from './keys.js';
-import { createKey, listKeys, revokeKey } from './keys.js';
+import { createKey, listKeys, revokeKey, updateKeyRateLimit } from './keys.js';
 
 // The admin UI talks to the gateway ONLY over /admin/api/* HTTP (DoD: no core
 // import). These tests pin the client contract against a mocked fetch. The
@@ -21,6 +21,8 @@ function summaryRow(
     allowed_lanes: null,
     allow_custom_model: false,
     disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
     ...overrides,
   };
 }
@@ -97,6 +99,63 @@ describe('keys api client', () => {
     expect(body).not.toHaveProperty('max_lane');
     expect(body).not.toHaveProperty('allowed_lanes');
     expect(body.role).toBe('user');
+  });
+
+  it('listKeys surfaces per-key rate limits (null = inherit, number = override)', async () => {
+    const rows = [summaryRow('k1'), summaryRow('k2', { rate_limit_rpm: 60, rate_limit_tpm: 0 })];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(rows), { status: 200 }),
+    );
+    const keys = await listKeys();
+    expect(keys[0].rate_limit_rpm).toBeNull();
+    expect(keys[0].rate_limit_tpm).toBeNull();
+    expect(keys[1].rate_limit_rpm).toBe(60);
+    expect(keys[1].rate_limit_tpm).toBe(0);
+  });
+
+  it('createKey sends per-key rate limits when set (including 0 = unlimited)', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ key_id: 'key_1', plaintext: 'x', prefix: 'p' }), {
+        status: 201,
+      }),
+    );
+    await createKey({ role: 'user', rate_limit_rpm: 60, rate_limit_tpm: 0 });
+    const init = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    const body = JSON.parse(init.body as string);
+    expect(body.rate_limit_rpm).toBe(60);
+    expect(body.rate_limit_tpm).toBe(0);
+  });
+
+  it('createKey omits rate limits when not provided (inherit system default)', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ key_id: 'key_2', plaintext: 'x' }), { status: 201 }),
+    );
+    await createKey({ role: 'user' });
+    const body = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string);
+    expect(body).not.toHaveProperty('rate_limit_rpm');
+    expect(body).not.toHaveProperty('rate_limit_tpm');
+  });
+
+  it('updateKeyRateLimit PATCHes /admin/api/keys/:id with the rpm/tpm (null clears)', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ key_id: 'key_1', rate_limit_rpm: null, rate_limit_tpm: 100 }), {
+        status: 200,
+      }),
+    );
+    await updateKeyRateLimit('key_1', { rpm: null, tpm: 100 });
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/admin/api/keys/key_1');
+    expect(init.method).toBe('PATCH');
+    const body = JSON.parse(init.body as string);
+    expect(body.rate_limit_rpm).toBeNull();
+    expect(body.rate_limit_tpm).toBe(100);
+  });
+
+  it('updateKeyRateLimit rejects on a non-2xx response (404)', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'key not found' }), { status: 404 }),
+    );
+    await expect(updateKeyRateLimit('nope', { rpm: 1, tpm: null })).rejects.toThrow();
   });
 
   it('revokeKey DELETEs /admin/api/keys/:id and resolves to the revoked id', async () => {

--- a/apps/admin/src/lib/api/keys.ts
+++ b/apps/admin/src/lib/api/keys.ts
@@ -22,6 +22,8 @@ export interface ApiKeyView {
   allowed_lanes: string[] | null; // whitelist
   allow_custom_model: boolean; // explicit client-model passthrough
   disabled: boolean; // revoked state (soft)
+  rate_limit_rpm: number | null; // per-key RPM override; null = inherit system default
+  rate_limit_tpm: number | null; // per-key TPM override; null = inherit system default
 }
 
 // Operator-specified caps for a new key. The plaintext is minted server-side; the
@@ -32,6 +34,10 @@ export interface CreateKeyInput {
   max_lane?: string;
   allowed_lanes?: string[];
   allow_custom_model?: boolean;
+  // Optional per-key rate limits at mint time. Omitted => inherit the system
+  // default. 0 => explicitly unlimited for that dimension.
+  rate_limit_rpm?: number;
+  rate_limit_tpm?: number;
 }
 
 // The ONLY shape that ever carries plaintext, returned once by POST. `prefix` is
@@ -76,6 +82,9 @@ function normalizeView(raw: Record<string, unknown>): ApiKeyView {
     allowed_lanes: Array.isArray(allowed) ? allowed.map(String) : null,
     allow_custom_model: raw.allow_custom_model === true,
     disabled: raw.disabled === true,
+    // null/absent = inherit system default; a finite number (incl. 0) = override.
+    rate_limit_rpm: typeof raw.rate_limit_rpm === 'number' ? raw.rate_limit_rpm : null,
+    rate_limit_tpm: typeof raw.rate_limit_tpm === 'number' ? raw.rate_limit_tpm : null,
   };
 }
 
@@ -90,6 +99,9 @@ function toServerBody(input: CreateKeyInput): Record<string, unknown> {
   if (input.allow_custom_model !== undefined) {
     out.allow_custom_model = input.allow_custom_model;
   }
+  // Send rate limits only when set (0 is meaningful = unlimited, so check undefined).
+  if (input.rate_limit_rpm !== undefined) out.rate_limit_rpm = input.rate_limit_rpm;
+  if (input.rate_limit_tpm !== undefined) out.rate_limit_tpm = input.rate_limit_tpm;
   return out;
 }
 
@@ -108,6 +120,21 @@ export async function createKey(input: CreateKeyInput): Promise<CreatedKey> {
     body: JSON.stringify(toServerBody(input)),
   });
   return asJson<CreatedKey>(res);
+}
+
+// PATCH /admin/api/keys/:id -> edit a key's per-key rate-limit override. A number
+// sets an explicit limit (0 = unlimited); null clears it back to inheriting the
+// system default. Both dimensions are sent together (the server overwrites both).
+export async function updateKeyRateLimit(
+  keyId: string,
+  limits: { rpm: number | null; tpm: number | null },
+): Promise<void> {
+  const res = await fetch(`${BASE}/${encodeURIComponent(keyId)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ rate_limit_rpm: limits.rpm, rate_limit_tpm: limits.tpm }),
+  });
+  await asJson<unknown>(res);
 }
 
 // DELETE /admin/api/keys/:id -> { revoked: id } (soft disable; row is kept).

--- a/apps/admin/src/lib/api/settings.test.ts
+++ b/apps/admin/src/lib/api/settings.test.ts
@@ -9,6 +9,8 @@ const FULL: RuntimeSettings = {
   capture_payloads: false,
   payload_retention_days: 7,
   rate_limit_enabled: true,
+  rate_limit_default_rpm: 60,
+  rate_limit_default_tpm: 90000,
   log_level: 'debug',
 };
 
@@ -38,6 +40,8 @@ describe('settings api client', () => {
       capture_payloads: true,
       payload_retention_days: 30,
       rate_limit_enabled: false,
+      rate_limit_default_rpm: 0,
+      rate_limit_default_tpm: 0,
       log_level: 'info',
     });
   });

--- a/apps/admin/src/lib/api/settings.ts
+++ b/apps/admin/src/lib/api/settings.ts
@@ -11,6 +11,10 @@ export interface RuntimeSettings {
   capture_payloads: boolean;
   payload_retention_days: number;
   rate_limit_enabled: boolean;
+  // System DEFAULT quota any key without its own per-key override falls back to.
+  // 0 = unlimited (mirrors the quota convention). Runtime-editable here.
+  rate_limit_default_rpm: number;
+  rate_limit_default_tpm: number;
   log_level: LogLevel;
 }
 
@@ -40,6 +44,10 @@ function normalize(raw: Record<string, unknown>): RuntimeSettings {
     payload_retention_days:
       typeof raw.payload_retention_days === 'number' ? raw.payload_retention_days : 30,
     rate_limit_enabled: raw.rate_limit_enabled === true,
+    rate_limit_default_rpm:
+      typeof raw.rate_limit_default_rpm === 'number' ? raw.rate_limit_default_rpm : 0,
+    rate_limit_default_tpm:
+      typeof raw.rate_limit_default_tpm === 'number' ? raw.rate_limit_default_tpm : 0,
     log_level: (LOG_LEVEL_OPTIONS as readonly string[]).includes(level as string)
       ? (level as LogLevel)
       : 'info',

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -27,6 +27,10 @@
   let role = $state<Role>('user');
   let maxLane = $state<string>('');
   let allowCustomModel = $state<boolean>(false);
+  // Per-key rate limits as raw input strings ('' = leave unset → inherit system
+  // default). Parsed to an int only when non-blank; 0 is a valid value (unlimited).
+  let rpmInput = $state<string>('');
+  let tpmInput = $state<string>('');
 
   let error = $state<string | null>(null);
   let creating = $state<boolean>(false);
@@ -34,6 +38,15 @@
   // cleared on close. While set, the form is replaced by the one-time reveal.
   let revealed = $state<CreatedKey | null>(null);
   let copied = $state<boolean>(false);
+
+  // Parse a rate-limit field: blank => null (inherit), else a non-negative int
+  // (0 = unlimited). A malformed value parses to null so it never blocks submit.
+  function parseLimit(raw: string): number | null {
+    const trimmed = raw.trim();
+    if (trimmed === '') return null;
+    const n = Number(trimmed);
+    return Number.isInteger(n) && n >= 0 ? n : null;
+  }
 
   async function handleCreate(): Promise<void> {
     error = null;
@@ -43,6 +56,11 @@
       allow_custom_model: allowCustomModel,
     };
     if (maxLane) input.max_lane = maxLane;
+    // Send a rate limit only when the operator typed one; blank => inherit default.
+    const rpm = parseLimit(rpmInput);
+    const tpm = parseLimit(tpmInput);
+    if (rpm !== null) input.rate_limit_rpm = rpm;
+    if (tpm !== null) input.rate_limit_tpm = tpm;
     try {
       revealed = await createKey(input);
     } catch (e) {
@@ -80,6 +98,8 @@
         allowed_lanes: null,
         allow_custom_model: allowCustomModel,
         disabled: false,
+        rate_limit_rpm: parseLimit(rpmInput),
+        rate_limit_tpm: parseLimit(tpmInput),
       };
       oncreated(view);
     }
@@ -167,6 +187,38 @@
       <span class="field-help"
         >{$t(
           'Lets this client bypass lanes and target a specific model by name. Leave off to keep every request routed through lanes.',
+        )}</span
+      >
+
+      <div class="grid grid-cols-2 gap-3">
+        <label class="flex flex-col gap-1 text-sm">
+          <span class="field-label">{$t('Requests per minute (RPM)')}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            aria-label={$t('Requests per minute (RPM)')}
+            placeholder={$t('Default')}
+            class="select"
+            bind:value={rpmInput}
+          />
+        </label>
+        <label class="flex flex-col gap-1 text-sm">
+          <span class="field-label">{$t('Tokens per minute (TPM)')}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            aria-label={$t('Tokens per minute (TPM)')}
+            placeholder={$t('Default')}
+            class="select"
+            bind:value={tpmInput}
+          />
+        </label>
+      </div>
+      <span class="field-help"
+        >{$t(
+          'Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.',
         )}</span
       >
     </div>

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -27,10 +27,11 @@
   let role = $state<Role>('user');
   let maxLane = $state<string>('');
   let allowCustomModel = $state<boolean>(false);
-  // Per-key rate limits as raw input strings ('' = leave unset → inherit system
-  // default). Parsed to an int only when non-blank; 0 is a valid value (unlimited).
-  let rpmInput = $state<string>('');
-  let tpmInput = $state<string>('');
+  // Per-key rate limits. null = leave unset → inherit the system default; a number
+  // (0 = unlimited) sets an explicit override. A number input binds to number|null
+  // (empty field => null), so no string parsing is needed.
+  let rpmInput = $state<number | null>(null);
+  let tpmInput = $state<number | null>(null);
 
   let error = $state<string | null>(null);
   let creating = $state<boolean>(false);
@@ -38,15 +39,6 @@
   // cleared on close. While set, the form is replaced by the one-time reveal.
   let revealed = $state<CreatedKey | null>(null);
   let copied = $state<boolean>(false);
-
-  // Parse a rate-limit field: blank => null (inherit), else a non-negative int
-  // (0 = unlimited). A malformed value parses to null so it never blocks submit.
-  function parseLimit(raw: string): number | null {
-    const trimmed = raw.trim();
-    if (trimmed === '') return null;
-    const n = Number(trimmed);
-    return Number.isInteger(n) && n >= 0 ? n : null;
-  }
 
   async function handleCreate(): Promise<void> {
     error = null;
@@ -56,11 +48,9 @@
       allow_custom_model: allowCustomModel,
     };
     if (maxLane) input.max_lane = maxLane;
-    // Send a rate limit only when the operator typed one; blank => inherit default.
-    const rpm = parseLimit(rpmInput);
-    const tpm = parseLimit(tpmInput);
-    if (rpm !== null) input.rate_limit_rpm = rpm;
-    if (tpm !== null) input.rate_limit_tpm = tpm;
+    // Send a rate limit only when the operator set one; blank (null) => inherit default.
+    if (rpmInput !== null) input.rate_limit_rpm = rpmInput;
+    if (tpmInput !== null) input.rate_limit_tpm = tpmInput;
     try {
       revealed = await createKey(input);
     } catch (e) {
@@ -98,8 +88,8 @@
         allowed_lanes: null,
         allow_custom_model: allowCustomModel,
         disabled: false,
-        rate_limit_rpm: parseLimit(rpmInput),
-        rate_limit_tpm: parseLimit(tpmInput),
+        rate_limit_rpm: rpmInput,
+        rate_limit_tpm: tpmInput,
       };
       oncreated(view);
     }

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -48,9 +48,10 @@
       allow_custom_model: allowCustomModel,
     };
     if (maxLane) input.max_lane = maxLane;
-    // Send a rate limit only when the operator set one; blank (null) => inherit default.
-    if (rpmInput !== null) input.rate_limit_rpm = rpmInput;
-    if (tpmInput !== null) input.rate_limit_tpm = tpmInput;
+    // Send a rate limit only when the operator set one; blank => inherit default.
+    // `!= null` also catches the `undefined` Svelte 5 gives an emptied number input.
+    if (rpmInput != null) input.rate_limit_rpm = rpmInput;
+    if (tpmInput != null) input.rate_limit_tpm = tpmInput;
     try {
       revealed = await createKey(input);
     } catch (e) {
@@ -88,8 +89,8 @@
         allowed_lanes: null,
         allow_custom_model: allowCustomModel,
         disabled: false,
-        rate_limit_rpm: rpmInput,
-        rate_limit_tpm: tpmInput,
+        rate_limit_rpm: rpmInput ?? null,
+        rate_limit_tpm: tpmInput ?? null,
       };
       oncreated(view);
     }

--- a/apps/admin/src/lib/components/CreateKeyDialog.test.ts
+++ b/apps/admin/src/lib/components/CreateKeyDialog.test.ts
@@ -43,6 +43,19 @@ describe('CreateKeyDialog', () => {
     expect(input.allow_custom_model).toBe(false);
   });
 
+  it('submits per-key rate limits when filled, and omits them when left blank', async () => {
+    setup();
+    await fireEvent.input(screen.getByLabelText(/requests per minute|rpm/i), {
+      target: { value: '60' },
+    });
+    // Leave TPM blank -> it must be omitted (inherit the system default).
+    await fireEvent.click(screen.getByRole('button', { name: /create key/i }));
+    await waitFor(() => expect(createKey).toHaveBeenCalledTimes(1));
+    const input = createKey.mock.calls[0][0];
+    expect(input.rate_limit_rpm).toBe(60);
+    expect(input.rate_limit_tpm).toBeUndefined();
+  });
+
   it('reveals the plaintext exactly once with a copy button after creation', async () => {
     setup();
     await fireEvent.click(screen.getByRole('button', { name: /create key/i }));

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -280,5 +280,18 @@
   "Max depth reached": "Max depth reached",
   "(empty object)": "(empty object)",
   "(empty array)": "(empty array)",
-  "(null)": "(null)"
+  "(null)": "(null)",
+  "Requests per minute (RPM)": "Requests per minute (RPM)",
+  "Tokens per minute (TPM)": "Tokens per minute (TPM)",
+  "Default": "Default",
+  "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.",
+  "Rate limit": "Rate limit",
+  "RPM": "RPM",
+  "TPM": "TPM",
+  "Unlimited": "Unlimited",
+  "Edit limits": "Edit limits",
+  "Failed to update rate limit": "Failed to update rate limit",
+  "Default requests per minute (RPM)": "Default requests per minute (RPM)",
+  "Default tokens per minute (TPM)": "Default tokens per minute (TPM)",
+  "The fallback limit for any key without its own per-key value. 0 means unlimited.": "The fallback limit for any key without its own per-key value. 0 means unlimited."
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -278,5 +278,18 @@
   "Max depth reached": "最大の深さに到達しました",
   "(empty object)": "（空のオブジェクト）",
   "(empty array)": "（空の配列）",
-  "(null)": "（null）"
+  "(null)": "（null）",
+  "Requests per minute (RPM)": "1分あたりのリクエスト数 (RPM)",
+  "Tokens per minute (TPM)": "1分あたりのトークン数 (TPM)",
+  "Default": "デフォルト",
+  "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "キーごとのレート制限。空欄の場合はシステムのデフォルトを使用します。0 はその項目が無制限であることを意味します。",
+  "Rate limit": "レート制限",
+  "RPM": "RPM",
+  "TPM": "TPM",
+  "Unlimited": "無制限",
+  "Edit limits": "制限を編集",
+  "Failed to update rate limit": "レート制限の更新に失敗しました",
+  "Default requests per minute (RPM)": "デフォルトの1分あたりリクエスト数 (RPM)",
+  "Default tokens per minute (TPM)": "デフォルトの1分あたりトークン数 (TPM)",
+  "The fallback limit for any key without its own per-key value. 0 means unlimited.": "キー独自の値が設定されていないキーに適用されるフォールバック制限。0 は無制限を意味します。"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -278,5 +278,18 @@
   "Max depth reached": "최대 깊이에 도달했습니다",
   "(empty object)": "(빈 객체)",
   "(empty array)": "(빈 배열)",
-  "(null)": "(null)"
+  "(null)": "(null)",
+  "Requests per minute (RPM)": "분당 요청 수 (RPM)",
+  "Tokens per minute (TPM)": "분당 토큰 수 (TPM)",
+  "Default": "기본값",
+  "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "키별 속도 제한입니다. 비워 두면 시스템 기본값을 사용합니다. 0은 해당 항목이 무제한임을 의미합니다.",
+  "Rate limit": "속도 제한",
+  "RPM": "RPM",
+  "TPM": "TPM",
+  "Unlimited": "무제한",
+  "Edit limits": "제한 편집",
+  "Failed to update rate limit": "속도 제한 업데이트에 실패했습니다",
+  "Default requests per minute (RPM)": "기본 분당 요청 수 (RPM)",
+  "Default tokens per minute (TPM)": "기본 분당 토큰 수 (TPM)",
+  "The fallback limit for any key without its own per-key value. 0 means unlimited.": "키별 값이 없는 키에 적용되는 대체 제한입니다. 0은 무제한을 의미합니다."
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -278,5 +278,18 @@
   "Max depth reached": "已达最大深度",
   "(empty object)": "（空对象）",
   "(empty array)": "（空数组）",
-  "(null)": "（空值 null）"
+  "(null)": "（空值 null）",
+  "Requests per minute (RPM)": "每分钟请求数 (RPM)",
+  "Tokens per minute (TPM)": "每分钟令牌数 (TPM)",
+  "Default": "默认",
+  "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "每个密钥的速率限制。留空则使用系统默认值。0 表示该维度不限。",
+  "Rate limit": "速率限制",
+  "RPM": "RPM",
+  "TPM": "TPM",
+  "Unlimited": "不限",
+  "Edit limits": "编辑限制",
+  "Failed to update rate limit": "更新速率限制失败",
+  "Default requests per minute (RPM)": "默认每分钟请求数 (RPM)",
+  "Default tokens per minute (TPM)": "默认每分钟令牌数 (TPM)",
+  "The fallback limit for any key without its own per-key value. 0 means unlimited.": "未单独设置速率的密钥的兜底限制。0 表示不限。"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -278,5 +278,18 @@
   "Max depth reached": "已達最大深度",
   "(empty object)": "（空物件）",
   "(empty array)": "（空陣列）",
-  "(null)": "（空值 null）"
+  "(null)": "（空值 null）",
+  "Requests per minute (RPM)": "每分鐘請求數 (RPM)",
+  "Tokens per minute (TPM)": "每分鐘權杖數 (TPM)",
+  "Default": "預設",
+  "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "每個金鑰的速率限制。留空則使用系統預設值。0 表示該維度不限。",
+  "Rate limit": "速率限制",
+  "RPM": "RPM",
+  "TPM": "TPM",
+  "Unlimited": "不限",
+  "Edit limits": "編輯限制",
+  "Failed to update rate limit": "更新速率限制失敗",
+  "Default requests per minute (RPM)": "預設每分鐘請求數 (RPM)",
+  "Default tokens per minute (TPM)": "預設每分鐘權杖數 (TPM)",
+  "The fallback limit for any key without its own per-key value. 0 means unlimited.": "未單獨設定速率的金鑰的兜底限制。0 表示不限。"
 }

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -27,18 +27,11 @@
   // Inline per-key rate-limit editing. `editingLimits` holds the key_id under edit
   // (one row at a time); the two inputs are raw strings ('' = clear → inherit).
   let editingLimits = $state<string | null>(null);
-  let editRpm = $state<string>('');
-  let editTpm = $state<string>('');
+  // number | null: null = clear → inherit the system default; a number input binds
+  // to number|null (empty field => null), so no string parsing is needed.
+  let editRpm = $state<number | null>(null);
+  let editTpm = $state<number | null>(null);
   let savingLimits = $state<string | null>(null);
-
-  // Parse a rate-limit input: blank => null (inherit system default), else a
-  // non-negative int (0 = unlimited); a malformed value falls back to null.
-  function parseLimit(raw: string): number | null {
-    const trimmed = raw.trim();
-    if (trimmed === '') return null;
-    const n = Number(trimmed);
-    return Number.isInteger(n) && n >= 0 ? n : null;
-  }
 
   // Render a stored limit for display: a number as-is (0 → "unlimited"), null as
   // the inherit/"default" copy.
@@ -50,8 +43,8 @@
   function startEditLimits(key: ApiKeyView): void {
     error = null;
     editingLimits = key.key_id;
-    editRpm = key.rate_limit_rpm === null ? '' : String(key.rate_limit_rpm);
-    editTpm = key.rate_limit_tpm === null ? '' : String(key.rate_limit_tpm);
+    editRpm = key.rate_limit_rpm;
+    editTpm = key.rate_limit_tpm;
   }
 
   function cancelEditLimits(): void {
@@ -61,8 +54,8 @@
   async function saveLimits(keyId: string): Promise<void> {
     error = null;
     savingLimits = keyId;
-    const rpm = parseLimit(editRpm);
-    const tpm = parseLimit(editTpm);
+    const rpm = editRpm;
+    const tpm = editTpm;
     try {
       await updateKeyRateLimit(keyId, { rpm, tpm });
       keys = keys.map((k) =>
@@ -146,6 +139,7 @@
             <th class="px-3 py-2">{$t('Key (prefix)')}</th>
             <th class="px-3 py-2">{$t('Role')}</th>
             <th class="px-3 py-2">{$t('Caps')}</th>
+            <th class="px-3 py-2">{$t('Rate limit')}</th>
             <th class="px-3 py-2">{$t('Status')}</th>
             <th class="px-3 py-2"></th>
           </tr>
@@ -171,6 +165,57 @@
                 <div>{$t('Max lane')}: {key.max_lane ?? $t('No cap')}</div>
                 <div>{$t('Allowed lanes')}: {key.allowed_lanes?.join(', ') || $t('No cap')}</div>
                 <div>{$t('Custom model')}: {key.allow_custom_model ? $t('yes') : $t('no')}</div>
+              </td>
+              <td class="px-3 py-2 text-ink-muted">
+                {#if editingLimits === key.key_id}
+                  <div class="flex flex-col gap-2">
+                    <label class="flex items-center gap-2">
+                      <span class="w-12 text-xs">{$t('RPM')}</span>
+                      <input
+                        type="number"
+                        min="0"
+                        step="1"
+                        aria-label={$t('RPM')}
+                        placeholder={$t('Default')}
+                        class="w-24 rounded border border-slate-300 px-2 py-1"
+                        bind:value={editRpm}
+                      />
+                    </label>
+                    <label class="flex items-center gap-2">
+                      <span class="w-12 text-xs">{$t('TPM')}</span>
+                      <input
+                        type="number"
+                        min="0"
+                        step="1"
+                        aria-label={$t('TPM')}
+                        placeholder={$t('Default')}
+                        class="w-24 rounded border border-slate-300 px-2 py-1"
+                        bind:value={editTpm}
+                      />
+                    </label>
+                    <div class="flex gap-2">
+                      <button
+                        type="button"
+                        class="btn-primary-sm"
+                        disabled={savingLimits === key.key_id}
+                        onclick={() => saveLimits(key.key_id)}>{$t('Save')}</button
+                      >
+                      <button type="button" class="btn-secondary" onclick={cancelEditLimits}
+                        >{$t('Cancel')}</button
+                      >
+                    </div>
+                  </div>
+                {:else}
+                  <div>{$t('RPM')}: {limitLabel(key.rate_limit_rpm)}</div>
+                  <div>{$t('TPM')}: {limitLabel(key.rate_limit_tpm)}</div>
+                  {#if !key.disabled}
+                    <button
+                      type="button"
+                      class="mt-1 text-xs text-indigo-600 hover:underline"
+                      onclick={() => startEditLimits(key)}>{$t('Edit limits')}</button
+                    >
+                  {/if}
+                {/if}
               </td>
               <td class="px-3 py-2">
                 {#if key.disabled}

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { untrack } from 'svelte';
-  import { type ApiKeyView, revokeKey } from '$lib/api/keys.js';
+  import { type ApiKeyView, revokeKey, updateKeyRateLimit } from '$lib/api/keys.js';
   import CreateKeyDialog from '$lib/components/CreateKeyDialog.svelte';
   import { t } from '$lib/i18n';
 
@@ -23,6 +23,58 @@
 
   // The display prefix of the key pending revoke confirmation — purely for copy.
   let confirmingPrefix = $derived(keys.find((k) => k.key_id === confirmingRevoke)?.prefix ?? '');
+
+  // Inline per-key rate-limit editing. `editingLimits` holds the key_id under edit
+  // (one row at a time); the two inputs are raw strings ('' = clear → inherit).
+  let editingLimits = $state<string | null>(null);
+  let editRpm = $state<string>('');
+  let editTpm = $state<string>('');
+  let savingLimits = $state<string | null>(null);
+
+  // Parse a rate-limit input: blank => null (inherit system default), else a
+  // non-negative int (0 = unlimited); a malformed value falls back to null.
+  function parseLimit(raw: string): number | null {
+    const trimmed = raw.trim();
+    if (trimmed === '') return null;
+    const n = Number(trimmed);
+    return Number.isInteger(n) && n >= 0 ? n : null;
+  }
+
+  // Render a stored limit for display: a number as-is (0 → "unlimited"), null as
+  // the inherit/"default" copy.
+  function limitLabel(v: number | null): string {
+    if (v === null) return $t('Default');
+    return v === 0 ? $t('Unlimited') : String(v);
+  }
+
+  function startEditLimits(key: ApiKeyView): void {
+    error = null;
+    editingLimits = key.key_id;
+    editRpm = key.rate_limit_rpm === null ? '' : String(key.rate_limit_rpm);
+    editTpm = key.rate_limit_tpm === null ? '' : String(key.rate_limit_tpm);
+  }
+
+  function cancelEditLimits(): void {
+    editingLimits = null;
+  }
+
+  async function saveLimits(keyId: string): Promise<void> {
+    error = null;
+    savingLimits = keyId;
+    const rpm = parseLimit(editRpm);
+    const tpm = parseLimit(editTpm);
+    try {
+      await updateKeyRateLimit(keyId, { rpm, tpm });
+      keys = keys.map((k) =>
+        k.key_id === keyId ? { ...k, rate_limit_rpm: rpm, rate_limit_tpm: tpm } : k,
+      );
+      editingLimits = null;
+    } catch (e) {
+      error = e instanceof Error ? e.message : $t('Failed to update rate limit');
+    } finally {
+      savingLimits = null;
+    }
+  }
 
   function onCreated(view: ApiKeyView): void {
     // Append the new key by its redacted view (prefix only). It is also re-fetched

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -54,8 +54,11 @@
   async function saveLimits(keyId: string): Promise<void> {
     error = null;
     savingLimits = keyId;
-    const rpm = editRpm;
-    const tpm = editTpm;
+    // Svelte 5 binds an emptied number input to `undefined` (not null); normalize
+    // so a cleared field is sent as an explicit null (clear → inherit default),
+    // never omitted by JSON.stringify (which would silently keep the old value).
+    const rpm = editRpm ?? null;
+    const tpm = editTpm ?? null;
     try {
       await updateKeyRateLimit(keyId, { rpm, tpm });
       keys = keys.map((k) =>

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -104,9 +104,10 @@ describe('keys page', () => {
       key('k2'), // both null -> inherits the system default
     ]);
     const rows = screen.getAllByTestId('key-row');
-    // k1 shows its explicit RPM; k2 shows the inherit/default copy.
+    // k1 shows its explicit RPM; k2 (both null) shows the inherit/default copy
+    // on both the RPM and TPM lines.
     expect(within(rows[0]).getByText(/60/)).toBeInTheDocument();
-    expect(within(rows[1]).getByText(/default/i)).toBeInTheDocument();
+    expect(within(rows[1]).getAllByText(/default/i).length).toBeGreaterThan(0);
   });
 
   it('inline edit PATCHes the per-key rate limit via updateKeyRateLimit', async () => {

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -122,6 +122,18 @@ describe('keys page', () => {
     );
   });
 
+  it('clearing an inline rate-limit field sends null (clear → inherit), not undefined', async () => {
+    renderPage([key('k1', { rate_limit_rpm: 120, rate_limit_tpm: null })]);
+    const row = screen.getByTestId('key-row');
+    await fireEvent.click(within(row).getByRole('button', { name: /edit limits/i }));
+    // Clear the pre-filled RPM field; an emptied number input binds to undefined.
+    await fireEvent.input(within(row).getByLabelText(/rpm/i), { target: { value: '' } });
+    await fireEvent.click(within(row).getByRole('button', { name: /save/i }));
+    await waitFor(() =>
+      expect(updateKeyRateLimit).toHaveBeenCalledWith('k1', { rpm: null, tpm: null }),
+    );
+  });
+
   it('on revoke failure shows an error and leaves the row unchanged (fail-closed)', async () => {
     revokeKey.mockRejectedValue(new Error('404 key not found'));
     renderPage([key('k1')]);

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -9,9 +9,11 @@ import KeysPage from './+page.svelte';
 
 const createKey = vi.fn();
 const revokeKey = vi.fn();
+const updateKeyRateLimit = vi.fn();
 vi.mock('$lib/api/keys.js', () => ({
   createKey: (...args: unknown[]) => createKey(...args),
   revokeKey: (...args: unknown[]) => revokeKey(...args),
+  updateKeyRateLimit: (...args: unknown[]) => updateKeyRateLimit(...args),
 }));
 
 function key(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView {
@@ -23,6 +25,8 @@ function key(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     allowed_lanes: null,
     allow_custom_model: false,
     disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
     ...overrides,
   };
 }
@@ -35,6 +39,8 @@ describe('keys page', () => {
   beforeEach(() => {
     createKey.mockReset();
     revokeKey.mockReset();
+    updateKeyRateLimit.mockReset();
+    updateKeyRateLimit.mockResolvedValue(undefined);
     revokeKey.mockResolvedValue({ revoked: '' });
   });
 
@@ -90,6 +96,29 @@ describe('keys page', () => {
     expect(text).not.toContain('helm_live_TOPSECRETVALUE0000');
     // The new key now appears in the list by prefix only.
     expect(screen.getAllByTestId('key-row').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows per-key rate limits in the row (number, and "default" when null)', () => {
+    renderPage([
+      key('k1', { rate_limit_rpm: 60, rate_limit_tpm: 0 }),
+      key('k2'), // both null -> inherits the system default
+    ]);
+    const rows = screen.getAllByTestId('key-row');
+    // k1 shows its explicit RPM; k2 shows the inherit/default copy.
+    expect(within(rows[0]).getByText(/60/)).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/default/i)).toBeInTheDocument();
+  });
+
+  it('inline edit PATCHes the per-key rate limit via updateKeyRateLimit', async () => {
+    renderPage([key('k1', { rate_limit_rpm: null, rate_limit_tpm: null })]);
+    const row = screen.getByTestId('key-row');
+    await fireEvent.click(within(row).getByRole('button', { name: /edit limits/i }));
+    const rpm = within(row).getByLabelText(/rpm/i);
+    await fireEvent.input(rpm, { target: { value: '120' } });
+    await fireEvent.click(within(row).getByRole('button', { name: /save/i }));
+    await waitFor(() =>
+      expect(updateKeyRateLimit).toHaveBeenCalledWith('k1', { rpm: 120, tpm: null }),
+    );
   });
 
   it('on revoke failure shows an error and leaves the row unchanged (fail-closed)', async () => {

--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -18,6 +18,8 @@
     capture_payloads: true,
     payload_retention_days: 30,
     rate_limit_enabled: false,
+    rate_limit_default_rpm: 0,
+    rate_limit_default_tpm: 0,
     log_level: 'info' as LogLevel,
   };
   // Local working copy (snapshot the loaded settings into a NEW object so the
@@ -122,6 +124,36 @@
           >
         </span>
       </label>
+
+      <div class="flex flex-col gap-3 border-l-2 border-slate-100 pl-3 sm:flex-row sm:gap-6">
+        <label class="flex flex-col gap-1">
+          <span class="font-medium">{$t('Default requests per minute (RPM)')}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            data-testid="rate-limit-default-rpm"
+            class="w-32 rounded border border-slate-300 px-2 py-1"
+            bind:value={form.rate_limit_default_rpm}
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="font-medium">{$t('Default tokens per minute (TPM)')}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            data-testid="rate-limit-default-tpm"
+            class="w-32 rounded border border-slate-300 px-2 py-1"
+            bind:value={form.rate_limit_default_tpm}
+          />
+        </label>
+      </div>
+      <span class="field-help"
+        >{$t(
+          'The fallback limit for any key without its own per-key value. 0 means unlimited.',
+        )}</span
+      >
 
       <label class="flex flex-col gap-1">
         <span class="font-medium">{$t('Log level')}</span>

--- a/apps/gateway/src/middleware/auth.test.ts
+++ b/apps/gateway/src/middleware/auth.test.ts
@@ -16,6 +16,8 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     allowed_lanes: ["economy", "balanced"],
     allow_custom_model: false,
     disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
     ...overrides,
   };
 }

--- a/apps/gateway/src/middleware/auth.ts
+++ b/apps/gateway/src/middleware/auth.ts
@@ -18,6 +18,10 @@ export interface AuthIdentity {
     maxLane: string | null;
     allowedLanes: string[] | null;
     allowCustomModel: boolean;
+    /** Per-key rate-limit override (docs/06). null = inherit the system default
+     *  for that dimension; a number (0 = unlimited) overrides it. Read by the
+     *  rate-limit middleware so the limiter needs no extra KeyStore lookup. */
+    rateLimit: { rpm: number | null; tpm: number | null };
   };
 }
 
@@ -86,6 +90,7 @@ export function authMiddleware(deps: AuthDeps): MiddlewareHandler {
         maxLane: record.max_lane,
         allowedLanes: record.allowed_lanes,
         allowCustomModel: record.allow_custom_model,
+        rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
       },
     };
     c.set("identity", identity);

--- a/apps/gateway/src/middleware/estimate-tokens.ts
+++ b/apps/gateway/src/middleware/estimate-tokens.ts
@@ -1,0 +1,21 @@
+import type { MiddlewareHandler } from "hono";
+
+// Deterministic pre-classification token estimate for the TPM bucket. Reads the
+// declared body size from the Content-Length header — a SYNC header read that
+// NEVER consumes the request body stream, so the downstream route can still parse
+// it. The heuristic is ceil(bytes / 4): ~4 bytes per token, the standard rough
+// BPE ratio (deterministic, principle 4). It is intentionally conservative — a
+// pre-debit upper bound is acceptable for a TPM ceiling, and a request with no
+// Content-Length (chunked / unknown) estimates 0 (RPM still applies). A malformed
+// or negative header value clamps to 0, never NaN/negative (would corrupt the
+// bucket). Lives in its own module so BOTH the OpenAI chat middleware AND the
+// self-authenticating Anthropic /v1/messages + OpenAI /v1/responses routes share
+// the SAME estimator (they each call the limiter directly), without a circular
+// import through server.ts.
+export function estimateRequestTokens(c: Parameters<MiddlewareHandler>[0]): number {
+  const raw = c.req.header("content-length");
+  if (raw === undefined) return 0;
+  const bytes = Number(raw);
+  if (!Number.isFinite(bytes) || bytes <= 0) return 0;
+  return Math.ceil(bytes / 4);
+}

--- a/apps/gateway/src/middleware/rate-limit.test.ts
+++ b/apps/gateway/src/middleware/rate-limit.test.ts
@@ -82,6 +82,29 @@ describe("rateLimitMiddleware", () => {
     expect(body.error.limited_by).toBe("tpm");
   });
 
+  it("applies the per-key override carried on identity.caps.rateLimit (tighter than default)", async () => {
+    // System default is rpm:5, but this key carries its OWN override rpm:1 (from
+    // its ApiKeyRecord, surfaced by Auth). The middleware must thread that into
+    // the probe so the key is blocked on its 2nd request, not the 6th.
+    const limiter = createRateLimiter({
+      config: cfg({ default: { rpm: 5, tpm: 0 } }),
+      store: new InMemoryRateLimitStore(),
+    });
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal identity stub for the test
+      (c as any).set("identity", { keyId: "k1", caps: { rateLimit: { rpm: 1, tpm: null } } });
+      await next();
+    });
+    app.use("*", rateLimitMiddleware({ limiter, now: () => 0, estimateTokens: () => 0 }));
+    app.get("/v1/chat/completions", (c) => c.json({ ok: true }));
+
+    expect((await app.request("/v1/chat/completions")).status).toBe(200);
+    const blocked = await app.request("/v1/chat/completions");
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("x-ratelimit-limit")).toBe("1");
+  });
+
   it("is a no-op pass-through when disabled (no headers, always allowed)", async () => {
     const app = buildApp(cfg({ enabled: false, default: { rpm: 1, tpm: 0 } }));
     for (let i = 0; i < 5; i++) {

--- a/apps/gateway/src/middleware/rate-limit.ts
+++ b/apps/gateway/src/middleware/rate-limit.ts
@@ -42,7 +42,9 @@ export function rateLimitMiddleware(deps: RateLimitMiddlewareDeps): MiddlewareHa
   const estimateTokens = deps.estimateTokens ?? (() => 0);
 
   return async (c, next) => {
-    const identity = c.get("identity") as { keyId?: string } | undefined;
+    const identity = c.get("identity") as
+      | { keyId?: string; caps?: { rateLimit?: { rpm: number | null; tpm: number | null } } }
+      | undefined;
     const keyId = identity?.keyId;
     // No resolved identity (e.g. an unauthenticated route slipped in) — nothing
     // to meter; let downstream handle auth. Never invents a key.
@@ -51,10 +53,15 @@ export function rateLimitMiddleware(deps: RateLimitMiddlewareDeps): MiddlewareHa
       return;
     }
 
+    // Thread the key's OWN quota (resolved by Auth from its ApiKeyRecord) into the
+    // probe so the limiter applies it WITHOUT a second store read. Glue only —
+    // precedence/inheritance live in the limiter's resolveQuota (principle 1).
+    const keyQuota = identity?.caps?.rateLimit;
     const result = await deps.limiter.check({
       keyId,
       estimatedTokens: estimateTokens(c),
       now: now(),
+      override: keyQuota ? { rpm: keyQuota.rpm, tpm: keyQuota.tpm } : undefined,
     });
 
     // Unmetered fast path (disabled / both dimensions unlimited): the limiter

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -85,12 +85,12 @@ function makeKeyStore(): KeyStore & { rows: ApiKeyRecord[] } {
       // Soft revoke: flip disabled ONLY, never rewrite other fields in place.
       row.disabled = true;
     },
-    async updateRateLimit(keyId, rpm, tpm) {
+    async updateRateLimit(keyId, patch) {
       const row = rows.find((r) => r.key_id === keyId);
       if (!row) throw new Error(`key not found: ${keyId}`);
-      // Edit ONLY the two rate-limit columns — never role/caps.
-      row.rate_limit_rpm = rpm;
-      row.rate_limit_tpm = tpm;
+      // PARTIAL: only supplied dims change; absent dims untouched (never role/caps).
+      if (patch.rpm !== undefined) row.rate_limit_rpm = patch.rpm;
+      if (patch.tpm !== undefined) row.rate_limit_tpm = patch.tpm;
     },
   };
 }

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -67,6 +67,8 @@ function makeKeyStore(): KeyStore & { rows: ApiKeyRecord[] } {
         allowed_lanes: input.allowedLanes ?? null,
         allow_custom_model: input.allowCustomModel ?? false,
         disabled: false,
+        rate_limit_rpm: input.rateLimitRpm ?? null,
+        rate_limit_tpm: input.rateLimitTpm ?? null,
       };
       rows.push(rec);
       return rec;
@@ -82,6 +84,13 @@ function makeKeyStore(): KeyStore & { rows: ApiKeyRecord[] } {
       if (!row) throw new Error(`key not found: ${keyId}`);
       // Soft revoke: flip disabled ONLY, never rewrite other fields in place.
       row.disabled = true;
+    },
+    async updateRateLimit(keyId, rpm, tpm) {
+      const row = rows.find((r) => r.key_id === keyId);
+      if (!row) throw new Error(`key not found: ${keyId}`);
+      // Edit ONLY the two rate-limit columns — never role/caps.
+      row.rate_limit_rpm = rpm;
+      row.rate_limit_tpm = tpm;
     },
   };
 }
@@ -428,6 +437,91 @@ describe("admin.api keys", () => {
     expect(list[0]?.prefix).toBe("helm_live_PLAI");
     expect(list[0]).not.toHaveProperty("hash");
     expect(list[0]).not.toHaveProperty("plaintext");
+  });
+
+  it("POST persists per-key rate limits and the list surfaces them", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    const created = await app.request("/admin/api/keys", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ role: "user", rate_limit_rpm: 60, rate_limit_tpm: 0 }),
+    });
+    expect(created.status).toBe(201);
+    expect(keyStore.rows[0]?.rate_limit_rpm).toBe(60);
+    expect(keyStore.rows[0]?.rate_limit_tpm).toBe(0);
+    const list = (await (await app.request("/admin/api/keys")).json()) as Array<
+      Record<string, unknown>
+    >;
+    expect(list[0]?.rate_limit_rpm).toBe(60);
+    expect(list[0]?.rate_limit_tpm).toBe(0);
+  });
+
+  it("POST without rate limits leaves them null (inherit system default)", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    await app.request("/admin/api/keys", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ role: "user" }),
+    });
+    expect(keyStore.rows[0]?.rate_limit_rpm).toBeNull();
+    expect(keyStore.rows[0]?.rate_limit_tpm).toBeNull();
+  });
+
+  it("PATCH edits a key's rate limits (number sets, null clears) without touching caps", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    await app.request("/admin/api/keys", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ role: "user", max_lane: "balanced" }),
+    });
+    const set = await app.request("/admin/api/keys/key_1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ rate_limit_rpm: 120, rate_limit_tpm: 5000 }),
+    });
+    expect(set.status).toBe(200);
+    expect(keyStore.rows[0]?.rate_limit_rpm).toBe(120);
+    expect(keyStore.rows[0]?.rate_limit_tpm).toBe(5000);
+    expect(keyStore.rows[0]?.max_lane).toBe("balanced"); // caps untouched
+    // null clears one dimension back to inheriting the system default.
+    const clear = await app.request("/admin/api/keys/key_1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ rate_limit_rpm: null, rate_limit_tpm: 5000 }),
+    });
+    expect(clear.status).toBe(200);
+    expect(keyStore.rows[0]?.rate_limit_rpm).toBeNull();
+    expect(keyStore.rows[0]?.rate_limit_tpm).toBe(5000);
+  });
+
+  it("PATCH rejects an unknown field with 400 (fail-closed, strict)", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    await app.request("/admin/api/keys", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ role: "user" }),
+    });
+    const res = await app.request("/admin/api/keys/key_1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ role: "root" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH on an unknown key id returns 404", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/admin/api/keys/nope", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ rate_limit_rpm: 10 }),
+    });
+    expect(res.status).toBe(404);
   });
 
   it("DELETE revokes (disabled:true) without removing or rewriting the row", async () => {

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -81,6 +81,11 @@ export interface KeySummary {
   allowed_lanes: string[] | null;
   allow_custom_model: boolean;
   disabled: boolean;
+  // Per-key rate-limit override (docs/06). null = inherit the system default; a
+  // number (0 = unlimited) overrides that dimension. Surfaced so the admin UI can
+  // display + edit it. No key material — just the quota numbers (principle 7).
+  rate_limit_rpm: number | null;
+  rate_limit_tpm: number | null;
 }
 
 // New-key response: the ONLY place plaintext is ever returned, once.

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -1,4 +1,4 @@
-import { CreateKeyRequestSchema } from "@helm/shared";
+import { CreateKeyRequestSchema, UpdateKeyRequestSchema } from "@helm/shared";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps, KeySummary } from "./deps.js";
@@ -20,6 +20,8 @@ function toSummary(rec: {
   allowed_lanes: string[] | null;
   allow_custom_model: boolean;
   disabled: boolean;
+  rate_limit_rpm: number | null;
+  rate_limit_tpm: number | null;
 }): KeySummary {
   return {
     key_id: rec.key_id,
@@ -29,6 +31,8 @@ function toSummary(rec: {
     allowed_lanes: rec.allowed_lanes,
     allow_custom_model: rec.allow_custom_model,
     disabled: rec.disabled,
+    rate_limit_rpm: rec.rate_limit_rpm,
+    rate_limit_tpm: rec.rate_limit_tpm,
   };
 }
 
@@ -56,11 +60,43 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       maxLane: parsed.data.max_lane,
       allowedLanes: parsed.data.allowed_lanes,
       allowCustomModel: parsed.data.allow_custom_model ?? false,
+      rateLimitRpm: parsed.data.rate_limit_rpm,
+      rateLimitTpm: parsed.data.rate_limit_tpm,
     });
     // The ONLY place plaintext is ever returned. `prefix` is the server-minted
     // non-sensitive display prefix (already persisted) — returned so the SPA need
     // not slice the plaintext to build a redacted view (a redaction footgun).
     return c.json({ key_id: keyId, plaintext: minted.plaintext, prefix: minted.prefix }, 201);
+  });
+
+  // PATCH /keys/:id — edit a key's per-key rate-limit override (docs/06). Only the
+  // two rate-limit dimensions are editable after mint (role/caps are fixed; rotate
+  // by revoking + re-minting). The body is validated with .strict() so an unknown
+  // field is rejected (400, fail-closed). An omitted dimension keeps its current
+  // value; an explicit null clears the override back to inheriting the system
+  // default. A number (0 = unlimited) sets an explicit override. 404 on unknown id.
+  app.patch("/admin/api/keys/:id", async (c) => {
+    const parsed = UpdateKeyRequestSchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+      return c.json({ error: "invalid key update", issues: parsed.error.issues }, 400);
+    }
+    const id = c.req.param("id");
+    // Read the current record so an omitted dimension is preserved (the store's
+    // updateRateLimit overwrites BOTH columns). list() is the only read seam.
+    const current = (await deps.keyStore.list()).find((k) => k.key_id === id);
+    if (!current) {
+      return c.json({ error: "key not found" }, 404);
+    }
+    const rpm =
+      parsed.data.rate_limit_rpm === undefined ? current.rate_limit_rpm : parsed.data.rate_limit_rpm;
+    const tpm =
+      parsed.data.rate_limit_tpm === undefined ? current.rate_limit_tpm : parsed.data.rate_limit_tpm;
+    try {
+      await deps.keyStore.updateRateLimit(id, rpm, tpm);
+    } catch {
+      return c.json({ error: "key not found" }, 404);
+    }
+    return c.json({ key_id: id, rate_limit_rpm: rpm, rate_limit_tpm: tpm });
   });
 
   // DELETE /keys/:id — soft revoke (disabled:true). 404 when the id is unknown.

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -88,9 +88,13 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       return c.json({ error: "key not found" }, 404);
     }
     const rpm =
-      parsed.data.rate_limit_rpm === undefined ? current.rate_limit_rpm : parsed.data.rate_limit_rpm;
+      parsed.data.rate_limit_rpm === undefined
+        ? current.rate_limit_rpm
+        : parsed.data.rate_limit_rpm;
     const tpm =
-      parsed.data.rate_limit_tpm === undefined ? current.rate_limit_tpm : parsed.data.rate_limit_tpm;
+      parsed.data.rate_limit_tpm === undefined
+        ? current.rate_limit_tpm
+        : parsed.data.rate_limit_tpm;
     try {
       await deps.keyStore.updateRateLimit(id, rpm, tpm);
     } catch {

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -72,35 +72,29 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
   // PATCH /keys/:id — edit a key's per-key rate-limit override (docs/06). Only the
   // two rate-limit dimensions are editable after mint (role/caps are fixed; rotate
   // by revoking + re-minting). The body is validated with .strict() so an unknown
-  // field is rejected (400, fail-closed). An omitted dimension keeps its current
-  // value; an explicit null clears the override back to inheriting the system
-  // default. A number (0 = unlimited) sets an explicit override. 404 on unknown id.
+  // field is rejected (400, fail-closed). The patch is PARTIAL: an omitted
+  // dimension is left untouched at the store layer (no read-modify-write, so
+  // concurrent partial PATCHes can't clobber each other); an explicit null clears
+  // the override back to inheriting the system default; a number (0 = unlimited)
+  // sets an explicit override. 404 on unknown id.
   app.patch("/admin/api/keys/:id", async (c) => {
     const parsed = UpdateKeyRequestSchema.safeParse(await c.req.json().catch(() => null));
     if (!parsed.success) {
       return c.json({ error: "invalid key update", issues: parsed.error.issues }, 400);
     }
     const id = c.req.param("id");
-    // Read the current record so an omitted dimension is preserved (the store's
-    // updateRateLimit overwrites BOTH columns). list() is the only read seam.
-    const current = (await deps.keyStore.list()).find((k) => k.key_id === id);
-    if (!current) {
-      return c.json({ error: "key not found" }, 404);
-    }
-    const rpm =
-      parsed.data.rate_limit_rpm === undefined
-        ? current.rate_limit_rpm
-        : parsed.data.rate_limit_rpm;
-    const tpm =
-      parsed.data.rate_limit_tpm === undefined
-        ? current.rate_limit_tpm
-        : parsed.data.rate_limit_tpm;
+    // Forward ONLY the dimensions the client supplied (present, possibly null).
+    // Zod leaves an omitted field as `undefined`, so this distinguishes
+    // "clear to inherit" (null) from "leave unchanged" (absent).
+    const patch: { rpm?: number | null; tpm?: number | null } = {};
+    if (parsed.data.rate_limit_rpm !== undefined) patch.rpm = parsed.data.rate_limit_rpm;
+    if (parsed.data.rate_limit_tpm !== undefined) patch.tpm = parsed.data.rate_limit_tpm;
     try {
-      await deps.keyStore.updateRateLimit(id, rpm, tpm);
+      await deps.keyStore.updateRateLimit(id, patch);
     } catch {
       return c.json({ error: "key not found" }, 404);
     }
-    return c.json({ key_id: id, rate_limit_rpm: rpm, rate_limit_tpm: tpm });
+    return c.json({ key_id: id, ...parsed.data });
   });
 
   // DELETE /keys/:id — soft revoke (disabled:true). 404 when the id is unknown.

--- a/apps/gateway/src/routes/chat.memory.test.ts
+++ b/apps/gateway/src/routes/chat.memory.test.ts
@@ -31,6 +31,8 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     allowed_lanes: null,
     allow_custom_model: false,
     disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -26,6 +26,8 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     allowed_lanes: null,
     allow_custom_model: false,
     disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.session-key.test.ts
+++ b/apps/gateway/src/routes/chat.session-key.test.ts
@@ -34,6 +34,8 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     allowed_lanes: null,
     allow_custom_model: false,
     disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -56,6 +56,7 @@ function makeDeps(
     authed?: boolean;
     transformRequestOut?: (native: unknown) => unknown;
     rateLimiter?: MessagesRouteDeps["rateLimiter"];
+    identity?: MessagesIdentity;
   } = {},
 ): { deps: MessagesRouteDeps; harness: Harness } {
   const harness: Harness = {
@@ -70,7 +71,7 @@ function makeDeps(
     auth: {
       resolve: async (_key: string | null) => {
         harness.order.push("auth");
-        return over.authed === false ? null : IDENTITY;
+        return over.authed === false ? null : (over.identity ?? IDENTITY);
       },
     },
     transformers: {
@@ -434,6 +435,34 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expect(body.type).toBe("error");
     // Anthropic rate-limit envelope, and routing never ran.
     expect(harness.order).not.toContain("route");
+  });
+
+  it("threads the key's per-key rate-limit override into the limiter probe", async () => {
+    let capturedOverride: unknown;
+    const limiter: MessagesRouteDeps["rateLimiter"] = {
+      check: async (probe) => {
+        capturedOverride = probe.override;
+        return {
+          allowed: true,
+          limitedBy: null,
+          limit: 1,
+          remaining: 0,
+          resetSeconds: 30,
+          retryAfterSeconds: 0,
+        };
+      },
+    };
+    const { deps } = makeDeps({
+      rateLimiter: limiter,
+      identity: { keyId: "k1", accountId: "acct", caps: { rateLimit: { rpm: 1, tpm: null } } },
+    });
+    const app = buildApp(deps);
+    await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(capturedOverride).toEqual({ rpm: 1, tpm: null });
   });
 
   it("does not 429 when the limiter allows the key", async () => {

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -3,6 +3,7 @@ import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv } from "../app.js";
+import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import { PipelineError } from "./messages-pipeline.js";
 
@@ -25,6 +26,13 @@ import { PipelineError } from "./messages-pipeline.js";
 export interface MessagesIdentity {
   keyId: string;
   accountId: string;
+  /** Per-key caps resolved from the ApiKeyRecord. `rateLimit` carries the key's
+   *  own RPM/TPM override (null = inherit the system default) so this self-auth
+   *  path enforces per-key limits, mirroring the OpenAI chat middleware. */
+  caps?: {
+    rateLimit?: { rpm: number | null; tpm: number | null };
+    [k: string]: unknown;
+  };
   [k: string]: unknown;
 }
 
@@ -153,8 +161,14 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     if (deps.rateLimiter !== undefined) {
       const rl = await deps.rateLimiter.check({
         keyId: identity.keyId,
-        estimatedTokens: 0,
+        // Same Content-Length/4 estimate the chat middleware uses, so per-key TPM
+        // is actually metered here (not the old hard-coded 0 that left TPM open).
+        estimatedTokens: estimateRequestTokens(c),
         now: Date.now(),
+        // Per-key override carried by the resolver (null dims inherit the default).
+        override: identity.caps?.rateLimit
+          ? { rpm: identity.caps.rateLimit.rpm, tpm: identity.caps.rateLimit.tpm }
+          : undefined,
       });
       if (!(rl.allowed && rl.limit === 0)) {
         c.header("x-ratelimit-limit", String(rl.limit));

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createApp } from "../app.js";
+import type { MessagesIdentity } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
 import { type ResponsesRouteDeps, registerResponsesRoute } from "./responses.js";
 
@@ -15,6 +16,7 @@ function makeDeps(
     transformRequestOut?: (n: unknown) => { stream?: boolean; metadata?: Record<string, unknown> };
     collect?: () => Promise<unknown>;
     rateLimiter?: ResponsesRouteDeps["rateLimiter"];
+    identity?: MessagesIdentity;
   } = {},
 ): { deps: ResponsesRouteDeps; order: string[] } {
   const order: string[] = [];
@@ -23,7 +25,8 @@ function makeDeps(
     auth: {
       resolve: async (cred) => {
         order.push("auth");
-        return over.authed === false || cred === null ? null : { keyId: "k1", accountId: "acct" };
+        if (over.authed === false || cred === null) return null;
+        return over.identity ?? { keyId: "k1", accountId: "acct" };
       },
     },
     transformer: {
@@ -192,5 +195,33 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(res.headers.get("retry-after")).toBe("12");
     expect(((await res.json()) as { error: { code: string } }).error.code).toBe("rate_limited");
     expect(order).not.toContain("route");
+  });
+
+  it("threads the key's per-key rate-limit override into the limiter probe", async () => {
+    let capturedOverride: unknown;
+    const limiter: ResponsesRouteDeps["rateLimiter"] = {
+      check: async (probe) => {
+        capturedOverride = probe.override;
+        return {
+          allowed: true,
+          limitedBy: null,
+          limit: 1,
+          remaining: 0,
+          resetSeconds: 30,
+          retryAfterSeconds: 0,
+        };
+      },
+    };
+    const { deps } = makeDeps({
+      rateLimiter: limiter,
+      identity: { keyId: "k1", accountId: "acct", caps: { rateLimit: { rpm: 1, tpm: null } } },
+    });
+    const app = buildApp(deps);
+    await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+    expect(capturedOverride).toEqual({ rpm: 1, tpm: null });
   });
 });

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -3,6 +3,7 @@ import { type ErrorClass, ErrorClassSchema, makeHelmError } from "@helm/shared";
 import type { Hono } from "hono";
 import type { AppEnv } from "../app.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
+import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
@@ -107,8 +108,13 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     if (deps.rateLimiter !== undefined) {
       const rl = await deps.rateLimiter.check({
         keyId: identity.keyId,
-        estimatedTokens: 0,
+        // Content-Length/4 estimate so per-key TPM is metered here too.
+        estimatedTokens: estimateRequestTokens(c),
         now: Date.now(),
+        // Per-key override carried by the resolver (null dims inherit the default).
+        override: identity.caps?.rateLimit
+          ? { rpm: identity.caps.rateLimit.rpm, tpm: identity.caps.rateLimit.tpm }
+          : undefined,
       });
       if (!(rl.allowed && rl.limit === 0)) {
         c.header("x-ratelimit-limit", String(rl.limit));

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -46,12 +46,12 @@ import type {
   RuntimeSettings,
 } from "@helm/shared";
 import { ErrorClassSchema } from "@helm/shared";
-import type { MiddlewareHandler } from "hono";
 import { createApp } from "./app.js";
 import { readBuildInfo } from "./build-info.js";
 import { createJsonLogger, type Logger } from "./logging.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { basicAuth, resolveAdminAuth, warnIfAdminUnconfigured } from "./middleware/basic-auth.js";
+import { estimateRequestTokens } from "./middleware/estimate-tokens.js";
 import { type RateLimiterPort, rateLimitMiddleware } from "./middleware/rate-limit.js";
 import { registerAdminApi } from "./routes/admin/index.js";
 import { createRuntimeRuleStore } from "./routes/admin/rule-store.js";
@@ -73,22 +73,10 @@ export interface ServerHandle {
   dispose?: () => void;
 }
 
-// Deterministic pre-classification token estimate for the TPM bucket. Reads the
-// declared body size from the Content-Length header — a SYNC header read that
-// NEVER consumes the request body stream, so the downstream route can still parse
-// it. The heuristic is ceil(bytes / 4): ~4 bytes per token, the standard rough
-// BPE ratio (deterministic, principle 4). It is intentionally conservative — a
-// pre-debit upper bound is acceptable for a TPM ceiling, and a request with no
-// Content-Length (chunked / unknown) estimates 0 (RPM still applies). A malformed
-// or negative header value clamps to 0, never NaN/negative (would corrupt the
-// bucket). Exported so it is unit-testable in isolation.
-export function estimateRequestTokens(c: Parameters<MiddlewareHandler>[0]): number {
-  const raw = c.req.header("content-length");
-  if (raw === undefined) return 0;
-  const bytes = Number(raw);
-  if (!Number.isFinite(bytes) || bytes <= 0) return 0;
-  return Math.ceil(bytes / 4);
-}
+// Pre-classification TPM token estimator. Extracted to middleware/estimate-tokens
+// so the chat middleware AND the self-authenticating /v1/messages + /v1/responses
+// routes share ONE heuristic. Re-exported here for back-compat (server.test.ts).
+export { estimateRequestTokens };
 
 // Validate a RouteError's free-form `error_class` string against the 8 known
 // ErrorClass values so the Anthropic error transformer can map it precisely. An
@@ -589,6 +577,10 @@ export async function buildServer(
             maxLane: record.max_lane,
             allowedLanes: record.allowed_lanes,
             allowCustomModel: record.allow_custom_model,
+            // Per-key rate-limit override (docs/06): carried so the self-auth
+            // /v1/messages + /v1/responses paths enforce per-key limits too, not
+            // just the OpenAI chat middleware.
+            rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
           },
         };
       },
@@ -650,6 +642,10 @@ export async function buildServer(
             maxLane: record.max_lane,
             allowedLanes: record.allowed_lanes,
             allowCustomModel: record.allow_custom_model,
+            // Per-key rate-limit override (docs/06): carried so the self-auth
+            // /v1/messages + /v1/responses paths enforce per-key limits too, not
+            // just the OpenAI chat middleware.
+            rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
           },
         };
       },

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -215,17 +215,30 @@ export async function buildServer(
     logger.log(lvl, msg, fields),
   );
   logger.setLevel?.(settings.log_level);
-  // A MUTABLE copy of the rate-limit config: the limiter reads `.enabled` fresh on
-  // every check(), so flipping this field live applies the rate_limit_enabled
-  // toggle without a restart (seeded from settings, which seeded from yaml/env).
-  const rateLimitConfig = { ...config.runtime.rate_limit, enabled: settings.rate_limit_enabled };
+  // A MUTABLE copy of the rate-limit config: the limiter reads `.enabled` and
+  // `.default` fresh on every check(), so flipping the master switch OR retuning
+  // the system-default quota applies live without a restart (seeded from settings,
+  // which seeded from yaml/env). Per-key overrides ride in on the request probe
+  // (Auth → identity.caps.rateLimit), so they never need a re-bind here.
+  const rateLimitConfig = {
+    ...config.runtime.rate_limit,
+    enabled: settings.rate_limit_enabled,
+    default: {
+      rpm: settings.rate_limit_default_rpm,
+      tpm: settings.rate_limit_default_tpm,
+    },
+  };
   // Apply a new settings object live: re-bind `settings`, push the log level into
-  // the logger, and flip the rate-limit master switch. Called by the admin settings
-  // route after it validates + persists (see registerAdminApi below).
+  // the logger, flip the rate-limit master switch, and retune the system-default
+  // quota. Called by the admin settings route after it validates + persists.
   const applySettings = (next: RuntimeSettings): void => {
     settings = next;
     logger.setLevel?.(next.log_level);
     rateLimitConfig.enabled = next.rate_limit_enabled;
+    rateLimitConfig.default = {
+      rpm: next.rate_limit_default_rpm,
+      tpm: next.rate_limit_default_tpm,
+    };
   };
   // Agentic Signals (POST-MVP feedback layer, docs/02). The collector consumes
   // ALREADY-persisted telemetry and writes aggregated, REDACTED signals — it is

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -113,8 +113,13 @@
 - **编辑已有 key**：新增 `KeyStore.updateRateLimit(keyId, rpm, tpm)`（只改两列，不就地改写 role/caps，未知 id 抛错）+ `PATCH /admin/api/keys/:id`（`UpdateKeyRequestSchema.strict()`，未知字段 400，未知 id 404）。
 - **迁移**：additive 新版本——sqlite v8、postgres v7，给 `api_keys` 加两个 nullable INTEGER 列；老行得 NULL 即继承默认。注意是两套 ledger（sqlite/pg 版本号各自独立）。
 
+**Codex review 后续修复（同日）**：
+- **（High）`/v1/messages` + `/v1/responses` 也要执行 per-key 限流**：这两条自认证路径有各自的 auth resolver + 直接调 limiter，最初没带 override，导致 per-key 只在 `/v1/chat/*` 生效。修复：两处 resolver 的 `caps` 补 `rateLimit`，`MessagesIdentity` 类型加可选 `caps.rateLimit`，路由把它作为 `probe.override` 传入；同时把硬编码的 `estimatedTokens: 0` 换成共享的 `estimateRequestTokens(c)`（Content-Length/4），否则 per-key TPM 在这两条路径上根本不计量。估算器抽到 `middleware/estimate-tokens.ts`（server.ts 再 re-export，避免 route→server 循环依赖）。
+- **（Medium）PATCH 并发丢更新**：原实现 read(list)-modify-write 两列，两个并发 partial PATCH 会互相覆盖。改为 `KeyStore.updateRateLimit(keyId, patch)` 只写 `patch` 中**出现**的列（`undefined`=不动，`null`=清空继承）；route 不再读当前行。
+- **（Medium）"Default" 文案误导**：`resolveQuota` 原本 `probe.override ?? config.overrides[keyId] ?? default`，清空 DB override（null）会回落到 YAML `config.overrides`，与 UI「Default」不符。改为：**只要带了 `probe.override`（即解析到了 key 记录），DB 即权威**——null 维度直接落到 `config.default`，绕过 YAML override；仅在完全没有 probe override 的 headless 路径才用 YAML override 兜底。
+
 **坑/提醒**：
-- Svelte 5 里 `<input type="number" bind:value>` 绑定值是 `number | null`（空 = null），不是字符串——一开始按 string 写 `parseLimit().trim()` 直接 crash。最终把状态直接定为 `number | null`，省掉解析。
+- Svelte 5 里 `<input type="number" bind:value>` 绑定值是 `number | null`（空 = null/undefined），不是字符串——一开始按 string 写 `parseLimit().trim()` 直接 crash。最终把状态直接定为 `number | null`；清空时 `?? null` 归一化（空 number input 其实给的是 `undefined`，不归一化会被 `JSON.stringify` 省略 → 后端保留旧值，清不掉）。
 - 本任务一开始**误在共享检出里开发**，被另一个 worktree 的并发 `git rebase` 连带 reset 冲掉过未提交改动。教训：本仓库多 worktree 并存，务必在独立 worktree 里干活（已迁到 `.claude/worktrees/per-key-rate-limits`，逐层提交）。
 ---
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -101,6 +101,22 @@
 **坑 / TODO**：admin 侧两处枚举副本（`TASK_TYPE_OPTIONS` / `COMPLEXITY_OPTIONS`）与 shared schema 无自动同步，全靠这条契约测试兜底。若后续 `TaskTypeSchema` 再增删 task_type，需同时更新 `TASK_TYPE_OPTIONS` 与该测试的期望集合——可考虑用代码生成把 shared 枚举导出成 admin 可消费的纯数据常量，根除手抄漂移。
 
 ---
+## 2026-06-01 · 按 key 设置速率限制 + 系统默认可在「系统设置」调（docs/06，原则 1/2/3/7）
+
+**需求**：① 每个 API key 可单独设置 RPM/TPM；② 系统设置页可调一个通用默认 RPM/TPM；③ key 未设时回退到系统默认（再回退到无限）。
+
+**关键设计决定**：
+- **限流引擎本就支持 per-key override**（`limiter.resolveQuota` + `RateLimitQuotaOverride`）。本次没改限流算法，只补「override 从哪来 + 系统默认可运行时改」两件事。
+- **per-key override 走请求 probe，不走 Store 二次读**：Auth 中间件本来就把整条 `ApiKeyRecord` 读进 `identity`，于是把 `rate_limit_{rpm,tpm}` 顺到 `identity.caps.rateLimit → probe.override`。限流器保持纯函数（原则 1），改 key 后**下一个请求**即生效，零额外读。
+- **null vs 0 语义**：key 上的维度 `null` = 继承系统默认；数字（含 `0` = 显式无限）= 覆盖该维度。`resolveQuota` 优先级：`probe.override ?? config.overrides[keyId] ?? config.default`，只有 `null/undefined` 才继承，`0` 是真实值。
+- **系统默认可运行时改**：在 `RuntimeSettingsSchema` 加 `rate_limit_default_{rpm,tpm}`，`defaultSettingsFromConfig` 从 `runtime.rate_limit.default` 播种；server.ts 的 `applySettings` 像 `.enabled` 那样实时 re-bind `rateLimitConfig.default`（限流器每次 check 重读），无需重启。
+- **编辑已有 key**：新增 `KeyStore.updateRateLimit(keyId, rpm, tpm)`（只改两列，不就地改写 role/caps，未知 id 抛错）+ `PATCH /admin/api/keys/:id`（`UpdateKeyRequestSchema.strict()`，未知字段 400，未知 id 404）。
+- **迁移**：additive 新版本——sqlite v8、postgres v7，给 `api_keys` 加两个 nullable INTEGER 列；老行得 NULL 即继承默认。注意是两套 ledger（sqlite/pg 版本号各自独立）。
+
+**坑/提醒**：
+- Svelte 5 里 `<input type="number" bind:value>` 绑定值是 `number | null`（空 = null），不是字符串——一开始按 string 写 `parseLimit().trim()` 直接 crash。最终把状态直接定为 `number | null`，省掉解析。
+- 本任务一开始**误在共享检出里开发**，被另一个 worktree 的并发 `git rebase` 连带 reset 冲掉过未提交改动。教训：本仓库多 worktree 并存，务必在独立 worktree 里干活（已迁到 `.claude/worktrees/per-key-rate-limits`，逐层提交）。
+---
 
 ## 2026-06-01 · 请求列表：行点击进详情 + 显示请求 ID/时间（docs/07，原则 1/7）
 

--- a/packages/core/src/auth/bootstrap.test.ts
+++ b/packages/core/src/auth/bootstrap.test.ts
@@ -71,6 +71,7 @@ describe("bootstrapRootKey", () => {
       createKey: vi.fn(),
       getByHash: vi.fn(),
       disable: vi.fn(),
+      updateRateLimit: vi.fn(),
     };
     await expect(
       bootstrapRootKey({ keyStore: failing, generateKey, now: () => new Date(), log: () => {} }),

--- a/packages/core/src/ratelimit/limiter.test.ts
+++ b/packages/core/src/ratelimit/limiter.test.ts
@@ -68,6 +68,50 @@ describe("createRateLimiter — per-key overrides", () => {
   });
 });
 
+describe("createRateLimiter — probe override (per-key quota carried by Auth)", () => {
+  it("probe.override.rpm wins over both config.overrides and default", async () => {
+    const store = new InMemoryRateLimitStore();
+    const limiter = createRateLimiter({
+      // default rpm:1 AND a config override of rpm:2 — the probe asks for rpm:5,
+      // which must win (highest precedence).
+      config: cfg({ default: { rpm: 1, tpm: 0 }, overrides: { k1: { rpm: 2 } } }),
+      store,
+    });
+    const probe = { keyId: "k1", estimatedTokens: 0, now: 0, override: { rpm: 5 } };
+    for (let i = 0; i < 5; i++) {
+      expect((await limiter.check(probe)).allowed).toBe(true);
+    }
+    expect((await limiter.check(probe)).allowed).toBe(false); // 6th over rpm:5
+  });
+
+  it("an absent probe dimension falls through to the system default", async () => {
+    const store = new InMemoryRateLimitStore();
+    const limiter = createRateLimiter({ config: cfg({ default: { rpm: 2, tpm: 0 } }), store });
+    // override names only tpm (null) -> rpm inherits default:2
+    const probe = { keyId: "k1", estimatedTokens: 0, now: 0, override: { tpm: null } };
+    expect((await limiter.check(probe)).allowed).toBe(true);
+    expect((await limiter.check(probe)).allowed).toBe(true);
+    expect((await limiter.check(probe)).allowed).toBe(false); // 3rd over default rpm:2
+  });
+
+  it("probe override of 0 means explicitly UNLIMITED for that dimension", async () => {
+    const consume = vi.fn();
+    const store: RateLimitStore = { consume };
+    // default would meter rpm:1, but this key overrides rpm:0 AND tpm:0 -> the
+    // unmetered fast path: store is never touched.
+    const limiter = createRateLimiter({ config: cfg({ default: { rpm: 1, tpm: 5 } }), store });
+    const r = await limiter.check({
+      keyId: "k1",
+      estimatedTokens: 999,
+      now: 0,
+      override: { rpm: 0, tpm: 0 },
+    });
+    expect(r.allowed).toBe(true);
+    expect(r.limit).toBe(0);
+    expect(consume).not.toHaveBeenCalled();
+  });
+});
+
 describe("createRateLimiter — headers / fields", () => {
   it("remaining decreases with consumption", async () => {
     const store = new InMemoryRateLimitStore();

--- a/packages/core/src/ratelimit/limiter.test.ts
+++ b/packages/core/src/ratelimit/limiter.test.ts
@@ -94,6 +94,23 @@ describe("createRateLimiter — probe override (per-key quota carried by Auth)",
     expect((await limiter.check(probe)).allowed).toBe(false); // 3rd over default rpm:2
   });
 
+  it("a null probe dimension inherits the system DEFAULT, bypassing a yaml config.override", async () => {
+    const store = new InMemoryRateLimitStore();
+    // A stale yaml override (rpm:1) exists for k1, but the key's DB override was
+    // CLEARED (probe.override present, rpm:null). Clearing must return the key to
+    // the system default (rpm:5), NOT silently fall back to the yaml override —
+    // otherwise the admin UI's "Default" label would lie.
+    const limiter = createRateLimiter({
+      config: cfg({ default: { rpm: 5, tpm: 0 }, overrides: { k1: { rpm: 1 } } }),
+      store,
+    });
+    const probe = { keyId: "k1", estimatedTokens: 0, now: 0, override: { rpm: null, tpm: null } };
+    for (let i = 0; i < 5; i++) {
+      expect((await limiter.check(probe)).allowed).toBe(true);
+    }
+    expect((await limiter.check(probe)).allowed).toBe(false); // 6th over default rpm:5
+  });
+
   it("probe override of 0 means explicitly UNLIMITED for that dimension", async () => {
     const consume = vi.fn();
     const store: RateLimitStore = { consume };

--- a/packages/core/src/ratelimit/limiter.ts
+++ b/packages/core/src/ratelimit/limiter.ts
@@ -11,14 +11,19 @@ interface ResolvedQuota {
   tpm: number;
 }
 
-// Resolve the effective quota for a key: per-key override (partial) layered over
-// `default`. A missing override dimension falls back to default — overrides only
-// affect the dimensions they name, and only for their own key.
-function resolveQuota(config: RateLimitConfig, keyId: string): ResolvedQuota {
-  const override = config.overrides[keyId];
+// Resolve the effective quota for a probe. Per-dimension precedence (highest
+// first): the probe's OWN per-key override (from the key record, carried by Auth)
+// → a config.overrides[keyId] entry (yaml-configured) → config.default (the live
+// system default). A null/undefined dimension at one level falls through to the
+// next, so a key overriding only rpm still inherits the system tpm. 0 is a real
+// value (explicitly unlimited), NOT "inherit" — only null/undefined inherit.
+function resolveQuota(config: RateLimitConfig, probe: RateLimitProbe): ResolvedQuota {
+  const keyOverride = config.overrides[probe.keyId];
+  const probeRpm = probe.override?.rpm;
+  const probeTpm = probe.override?.tpm;
   return {
-    rpm: override?.rpm ?? config.default.rpm,
-    tpm: override?.tpm ?? config.default.tpm,
+    rpm: probeRpm ?? keyOverride?.rpm ?? config.default.rpm,
+    tpm: probeTpm ?? keyOverride?.tpm ?? config.default.tpm,
   };
 }
 
@@ -45,7 +50,7 @@ export function createRateLimiter(deps: RateLimiterDeps): {
 
   async function check(probe: RateLimitProbe): Promise<RateLimitResult> {
     if (!config.enabled) return ALLOWED;
-    const quota = resolveQuota(config, probe.keyId);
+    const quota = resolveQuota(config, probe);
     const rpmOn = quota.rpm > 0;
     const tpmOn = quota.tpm > 0;
     if (!rpmOn && !tpmOn) return ALLOWED;

--- a/packages/core/src/ratelimit/limiter.ts
+++ b/packages/core/src/ratelimit/limiter.ts
@@ -11,19 +11,31 @@ interface ResolvedQuota {
   tpm: number;
 }
 
-// Resolve the effective quota for a probe. Per-dimension precedence (highest
-// first): the probe's OWN per-key override (from the key record, carried by Auth)
-// → a config.overrides[keyId] entry (yaml-configured) → config.default (the live
-// system default). A null/undefined dimension at one level falls through to the
-// next, so a key overriding only rpm still inherits the system tpm. 0 is a real
-// value (explicitly unlimited), NOT "inherit" — only null/undefined inherit.
+// Resolve the effective quota for a probe.
+//
+// When the request carries a per-key override object (`probe.override`, set by
+// Auth from the key's DB record), THAT is the authoritative per-key layer: each
+// dimension resolves `probe.override.<dim> ?? config.default.<dim>`. A null/
+// undefined dimension means "inherit the SYSTEM DEFAULT" — it deliberately does
+// NOT fall through to a yaml `config.overrides[keyId]` entry, so clearing a key's
+// limit in the admin UI truly returns it to the fleet default (the UI's "Default"
+// label stays honest even if a stale yaml override exists). 0 is a real value
+// (explicitly unlimited), NOT "inherit".
+//
+// When NO per-key override is carried (e.g. a config-only / headless caller that
+// never resolved a key record), fall back to a yaml `config.overrides[keyId]`
+// entry, then the default — preserving the original yaml-driven behavior.
 function resolveQuota(config: RateLimitConfig, probe: RateLimitProbe): ResolvedQuota {
+  if (probe.override !== undefined) {
+    return {
+      rpm: probe.override.rpm ?? config.default.rpm,
+      tpm: probe.override.tpm ?? config.default.tpm,
+    };
+  }
   const keyOverride = config.overrides[probe.keyId];
-  const probeRpm = probe.override?.rpm;
-  const probeTpm = probe.override?.tpm;
   return {
-    rpm: probeRpm ?? keyOverride?.rpm ?? config.default.rpm,
-    tpm: probeTpm ?? keyOverride?.tpm ?? config.default.tpm,
+    rpm: keyOverride?.rpm ?? config.default.rpm,
+    tpm: keyOverride?.tpm ?? config.default.tpm,
   };
 }
 

--- a/packages/core/src/ratelimit/types.ts
+++ b/packages/core/src/ratelimit/types.ts
@@ -8,10 +8,15 @@ export type { RateLimitConfig, RateLimitQuota, RateLimitQuotaOverride };
 
 // One rate-limit decision input: the Auth-resolved key_id, a pre-classification
 // token estimate (TPM pre-debit), and an injected clock (ms) for testability.
+// `override` carries the key's OWN per-key quota (from the ApiKeyRecord, surfaced
+// by Auth) so the limiter need not read the KeyStore: a present dimension wins
+// over config.overrides[keyId] and over config.default; an absent dimension falls
+// through to those. null/undefined dimensions inherit (see resolveQuota).
 export interface RateLimitProbe {
   keyId: string;
   estimatedTokens: number;
   now: number;
+  override?: { rpm?: number | null; tpm?: number | null };
 }
 
 // One rate-limit decision output. `limit/remaining/resetSeconds` describe the

--- a/packages/core/src/settings/runtime-settings.test.ts
+++ b/packages/core/src/settings/runtime-settings.test.ts
@@ -22,9 +22,11 @@ function fakeConfigStore(seed: Record<string, string> = {}): ConfigStore & {
   };
 }
 
-// Only `runtime.rate_limit.enabled` is read by the seeder; cast a minimal tree.
-function cfg(rateLimitEnabled: boolean): HelmConfig {
-  return { runtime: { rate_limit: { enabled: rateLimitEnabled } } } as unknown as HelmConfig;
+// The seeder reads runtime.rate_limit.{enabled,default}; cast a minimal tree.
+function cfg(rateLimitEnabled: boolean, dflt: { rpm: number; tpm: number } = { rpm: 0, tpm: 0 }) {
+  return {
+    runtime: { rate_limit: { enabled: rateLimitEnabled, default: dflt } },
+  } as unknown as HelmConfig;
 }
 
 describe("defaultSettingsFromConfig", () => {
@@ -33,9 +35,17 @@ describe("defaultSettingsFromConfig", () => {
       capture_payloads: true,
       payload_retention_days: 30,
       rate_limit_enabled: true,
+      rate_limit_default_rpm: 0,
+      rate_limit_default_tpm: 0,
       log_level: "info",
     });
     expect(defaultSettingsFromConfig(cfg(false)).rate_limit_enabled).toBe(false);
+  });
+
+  it("seeds the default rpm/tpm quota from runtime.rate_limit.default", () => {
+    const seeded = defaultSettingsFromConfig(cfg(true, { rpm: 60, tpm: 90000 }));
+    expect(seeded.rate_limit_default_rpm).toBe(60);
+    expect(seeded.rate_limit_default_tpm).toBe(90000);
   });
 });
 
@@ -86,6 +96,8 @@ describe("saveRuntimeSettings", () => {
       capture_payloads: false,
       payload_retention_days: 7,
       rate_limit_enabled: true,
+      rate_limit_default_rpm: 0,
+      rate_limit_default_tpm: 0,
       log_level: "warn",
     });
     expect(saved.payload_retention_days).toBe(7);

--- a/packages/core/src/settings/runtime-settings.ts
+++ b/packages/core/src/settings/runtime-settings.ts
@@ -13,12 +13,16 @@ export type SettingsLog = (
   fields?: Record<string, unknown>,
 ) => void;
 
-// Seed the factory defaults from the boot config: rate_limit_enabled mirrors
-// runtime.rate_limit.enabled so the admin toggle starts in sync with yaml/env.
-// All other fields take their schema defaults (capture_payloads:true etc).
+// Seed the factory defaults from the boot config: rate_limit_enabled and the
+// default rpm/tpm quota mirror runtime.rate_limit.{enabled,default} so the admin
+// "System Settings" surface starts in sync with yaml/env (the operator can then
+// tune the fleet-wide fallback live without a restart). All other fields take
+// their schema defaults (capture_payloads:true etc).
 export function defaultSettingsFromConfig(config: HelmConfig): RuntimeSettings {
   return RuntimeSettingsSchema.parse({
     rate_limit_enabled: config.runtime.rate_limit.enabled,
+    rate_limit_default_rpm: config.runtime.rate_limit.default.rpm,
+    rate_limit_default_tpm: config.runtime.rate_limit.default.tpm,
   });
 }
 

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -27,6 +27,8 @@ class InMemoryKeyStore implements KeyStore {
       allowed_lanes: input.allowedLanes ?? null,
       allow_custom_model: input.allowCustomModel ?? false,
       disabled: false,
+      rate_limit_rpm: input.rateLimitRpm ?? null,
+      rate_limit_tpm: input.rateLimitTpm ?? null,
     };
     this.byId.set(record.key_id, record);
     return record;
@@ -43,6 +45,10 @@ class InMemoryKeyStore implements KeyStore {
   async disable(keyId: string): Promise<void> {
     const r = this.byId.get(keyId);
     if (r) this.byId.set(keyId, { ...r, disabled: true });
+  }
+  async updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void> {
+    const r = this.byId.get(keyId);
+    if (r) this.byId.set(keyId, { ...r, rate_limit_rpm: rpm, rate_limit_tpm: tpm });
   }
 }
 
@@ -143,6 +149,8 @@ describe("port type contracts", () => {
       | "maxLane"
       | "allowedLanes"
       | "allowCustomModel"
+      | "rateLimitRpm"
+      | "rateLimitTpm"
     >();
   });
 

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -5,6 +5,7 @@ import type {
   InsertPayloadInput,
   InsertTelemetryInput,
   KeyStore,
+  RateLimitPatch,
   RecentDecisionRecord,
   RequestPayload,
   TelemetryStore,
@@ -46,9 +47,13 @@ class InMemoryKeyStore implements KeyStore {
     const r = this.byId.get(keyId);
     if (r) this.byId.set(keyId, { ...r, disabled: true });
   }
-  async updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void> {
+  async updateRateLimit(keyId: string, patch: RateLimitPatch): Promise<void> {
     const r = this.byId.get(keyId);
-    if (r) this.byId.set(keyId, { ...r, rate_limit_rpm: rpm, rate_limit_tpm: tpm });
+    if (!r) return;
+    const next = { ...r };
+    if (patch.rpm !== undefined) next.rate_limit_rpm = patch.rpm;
+    if (patch.tpm !== undefined) next.rate_limit_tpm = patch.tpm;
+    this.byId.set(keyId, next);
   }
 }
 

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -77,11 +77,22 @@ export interface KeyStore {
   // Soft revoke: set disabled=true. Never physically deletes, never rewrites
   // other fields in place ("轮转吊销不就地改写").
   disable(keyId: string): Promise<void>;
-  // Edit a key's per-key rate-limit override (docs/06). A number sets an explicit
-  // override for that dimension (0 = unlimited); null CLEARS it back to inheriting
-  // the system default. Touches ONLY the two rate-limit columns — never role/caps.
-  // Throws if the key id is unknown (mirrors `disable`, fail-loud not silent).
-  updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void>;
+  // Edit a key's per-key rate-limit override (docs/06). PARTIAL: only the
+  // dimensions PRESENT in `patch` are written; an omitted dimension is left
+  // untouched, so two concurrent partial PATCHes on different dimensions cannot
+  // clobber each other (no read-modify-write of the sibling column). A value of
+  // null CLEARS that dimension back to inheriting the system default; a number
+  // (0 = unlimited) sets an explicit override. Touches ONLY the rate-limit
+  // columns — never role/caps. Throws if the key id is unknown (fail-loud).
+  updateRateLimit(keyId: string, patch: RateLimitPatch): Promise<void>;
+}
+
+// Partial per-key rate-limit edit. A dimension PRESENT (even as null) is written;
+// an ABSENT dimension is left untouched. Empty patch = no-op (still validates the
+// key exists, throwing on an unknown id).
+export interface RateLimitPatch {
+  rpm?: number | null;
+  tpm?: number | null;
 }
 
 // Telemetry insert input: decision record + a redacted key reference. Never

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -61,6 +61,10 @@ export interface CreateKeyInput {
   maxLane?: string;
   allowedLanes?: string[];
   allowCustomModel?: boolean;
+  // Per-key rate-limit override (docs/06). Omitted => stored NULL => inherit the
+  // system default at check time. 0 => explicitly unlimited for that dimension.
+  rateLimitRpm?: number;
+  rateLimitTpm?: number;
 }
 
 export interface KeyStore {
@@ -73,6 +77,11 @@ export interface KeyStore {
   // Soft revoke: set disabled=true. Never physically deletes, never rewrites
   // other fields in place ("轮转吊销不就地改写").
   disable(keyId: string): Promise<void>;
+  // Edit a key's per-key rate-limit override (docs/06). A number sets an explicit
+  // override for that dimension (0 = unlimited); null CLEARS it back to inheriting
+  // the system default. Touches ONLY the two rate-limit columns — never role/caps.
+  // Throws if the key id is unknown (mirrors `disable`, fail-loud not silent).
+  updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void>;
 }
 
 // Telemetry insert input: decision record + a redacted key reference. Never

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -29,6 +29,9 @@ export class PgKeyStore implements KeyStore {
       allowedLanes: input.allowedLanes ?? null,
       allowCustomModel: input.allowCustomModel ?? false,
       disabled: false,
+      // Per-key rate-limit override: undefined input => NULL => inherit system default.
+      rateLimitRpm: input.rateLimitRpm ?? null,
+      rateLimitTpm: input.rateLimitTpm ?? null,
       createdAt: this.now().getTime(),
     };
     await this.db.insert(apiKeys).values(row);
@@ -57,6 +60,23 @@ export class PgKeyStore implements KeyStore {
     }
   }
 
+  // Edit ONLY the two rate-limit columns (null clears back to inherit). Other
+  // fields untouched — no in-place rewrite of role/caps. Throws on unknown id.
+  async updateRateLimit(
+    keyId: string,
+    rpm: number | null,
+    tpm: number | null,
+  ): Promise<void> {
+    const res = await this.db
+      .update(apiKeys)
+      .set({ rateLimitRpm: rpm, rateLimitTpm: tpm })
+      .where(eq(apiKeys.keyId, keyId))
+      .returning();
+    if (res.length === 0) {
+      throw new Error(`key not found: ${keyId}`);
+    }
+  }
+
   // Row -> port record. Native jsonb/boolean restored directly; exposes hash +
   // prefix only.
   private toRecord(row: ApiKeyRow): ApiKeyRecord {
@@ -70,6 +90,8 @@ export class PgKeyStore implements KeyStore {
       allowed_lanes: row.allowedLanes ?? null,
       allow_custom_model: row.allowCustomModel,
       disabled: row.disabled,
+      rate_limit_rpm: row.rateLimitRpm ?? null,
+      rate_limit_tpm: row.rateLimitTpm ?? null,
     };
   }
 }

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -62,11 +62,7 @@ export class PgKeyStore implements KeyStore {
 
   // Edit ONLY the two rate-limit columns (null clears back to inherit). Other
   // fields untouched — no in-place rewrite of role/caps. Throws on unknown id.
-  async updateRateLimit(
-    keyId: string,
-    rpm: number | null,
-    tpm: number | null,
-  ): Promise<void> {
+  async updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void> {
     const res = await this.db
       .update(apiKeys)
       .set({ rateLimitRpm: rpm, rateLimitTpm: tpm })

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -1,6 +1,6 @@
 import type { ApiKeyRecord } from "@helm/shared";
 import { eq } from "drizzle-orm";
-import type { CreateKeyInput, KeyStore } from "../ports.js";
+import type { CreateKeyInput, KeyStore, RateLimitPatch } from "../ports.js";
 import type { PgDb } from "./migrate.js";
 import { apiKeys } from "./schema.js";
 
@@ -60,14 +60,20 @@ export class PgKeyStore implements KeyStore {
     }
   }
 
-  // Edit ONLY the two rate-limit columns (null clears back to inherit). Other
-  // fields untouched — no in-place rewrite of role/caps. Throws on unknown id.
-  async updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void> {
-    const res = await this.db
-      .update(apiKeys)
-      .set({ rateLimitRpm: rpm, rateLimitTpm: tpm })
-      .where(eq(apiKeys.keyId, keyId))
-      .returning();
+  // Edit ONLY the rate-limit columns PRESENT in `patch` (null clears back to
+  // inherit). Omitted dims are left untouched, so a partial PATCH never rewrites
+  // the sibling column (no concurrent-clobber). Throws on unknown id.
+  async updateRateLimit(keyId: string, patch: RateLimitPatch): Promise<void> {
+    const set: Partial<Pick<ApiKeyRow, "rateLimitRpm" | "rateLimitTpm">> = {};
+    if (patch.rpm !== undefined) set.rateLimitRpm = patch.rpm;
+    if (patch.tpm !== undefined) set.rateLimitTpm = patch.tpm;
+    if (Object.keys(set).length === 0) {
+      // No-op patch: still verify the key exists (fail-loud on unknown id).
+      const rows = await this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).limit(1);
+      if (rows.length === 0) throw new Error(`key not found: ${keyId}`);
+      return;
+    }
+    const res = await this.db.update(apiKeys).set(set).where(eq(apiKeys.keyId, keyId)).returning();
     if (res.length === 0) {
       throw new Error(`key not found: ${keyId}`);
     }

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -179,6 +179,19 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_request_payloads_created_at ON request_payloads (created_at);
     `,
   },
+  {
+    // Per-key rate-limit OVERRIDE columns on api_keys (docs/06 "限流与配额"). Two
+    // nullable integer columns: NULL = inherit the system default at check time;
+    // a value (0 = unlimited) overrides that one dimension for this key. Additive
+    // — existing rows get NULL and keep inheriting the default. Mirrors the sqlite
+    // v8 migration (different ledger, same logical change). Distinct from
+    // rate_limit_buckets (v3, the runtime counters); these are config.
+    version: 7,
+    sql: `
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS rate_limit_rpm INTEGER;
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS rate_limit_tpm INTEGER;
+    `,
+  },
 ];
 
 // Anything that can run a raw SQL string against the Postgres connection. Both

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -29,6 +29,10 @@ export const apiKeys = pgTable("api_keys", {
   allowedLanes: jsonb("allowed_lanes").$type<string[]>(), // native jsonb array
   allowCustomModel: boolean("allow_custom_model").notNull().default(false),
   disabled: boolean("disabled").notNull().default(false),
+  // Per-key rate-limit override (docs/06). Nullable: NULL = inherit the system
+  // default at check time; a value (0 = unlimited) overrides that one dimension.
+  rateLimitRpm: integer("rate_limit_rpm"),
+  rateLimitTpm: integer("rate_limit_tpm"),
   createdAt: bigint("created_at", { mode: "number" }).notNull(), // epoch ms
 });
 

--- a/packages/core/src/store/sqlite/keystore.test.ts
+++ b/packages/core/src/store/sqlite/keystore.test.ts
@@ -156,7 +156,7 @@ describe("SqliteKeyStore", () => {
       role: "user",
       maxLane: "balanced",
     });
-    await store.updateRateLimit("k1", 100, 5000);
+    await store.updateRateLimit("k1", { rpm: 100, tpm: 5000 });
     let got = await store.getByHash("h1");
     expect(got?.rate_limit_rpm).toBe(100);
     expect(got?.rate_limit_tpm).toBe(5000);
@@ -164,14 +164,38 @@ describe("SqliteKeyStore", () => {
     expect(got?.max_lane).toBe("balanced");
     expect(got?.disabled).toBe(false);
     // null clears the override back to inheriting the system default
-    await store.updateRateLimit("k1", null, null);
+    await store.updateRateLimit("k1", { rpm: null, tpm: null });
     got = await store.getByHash("h1");
     expect(got?.rate_limit_rpm).toBeNull();
     expect(got?.rate_limit_tpm).toBeNull();
   });
 
-  it("updateRateLimit on a missing key rejects (not silently)", async () => {
+  it("updateRateLimit is PARTIAL: an omitted dimension is left untouched", async () => {
     const store = freshStore();
-    await expect(store.updateRateLimit("nope", 1, 1)).rejects.toThrow();
+    await store.createKey({
+      keyId: "k1",
+      hash: "h1",
+      prefix: "p1",
+      accountId: "a",
+      role: "user",
+      rateLimitRpm: 10,
+      rateLimitTpm: 20,
+    });
+    // Patch only rpm; tpm must survive unchanged (no read-modify-write clobber).
+    await store.updateRateLimit("k1", { rpm: 99 });
+    let got = await store.getByHash("h1");
+    expect(got?.rate_limit_rpm).toBe(99);
+    expect(got?.rate_limit_tpm).toBe(20);
+    // Patch only tpm to null (clear); rpm must survive.
+    await store.updateRateLimit("k1", { tpm: null });
+    got = await store.getByHash("h1");
+    expect(got?.rate_limit_rpm).toBe(99);
+    expect(got?.rate_limit_tpm).toBeNull();
+  });
+
+  it("updateRateLimit on a missing key rejects — both with a patch and an empty patch", async () => {
+    const store = freshStore();
+    await expect(store.updateRateLimit("nope", { rpm: 1, tpm: 1 })).rejects.toThrow();
+    await expect(store.updateRateLimit("nope", {})).rejects.toThrow();
   });
 });

--- a/packages/core/src/store/sqlite/keystore.test.ts
+++ b/packages/core/src/store/sqlite/keystore.test.ts
@@ -121,4 +121,57 @@ describe("SqliteKeyStore", () => {
       store.createKey({ keyId: "k2", hash: "same", prefix: "p2", accountId: "a", role: "user" }),
     ).rejects.toThrow();
   });
+
+  it("defaults per-key rate limits to null (inherit system default) when omitted", async () => {
+    const store = freshStore();
+    await store.createKey({ keyId: "k1", hash: "h1", prefix: "p1", accountId: "a", role: "user" });
+    const got = await store.getByHash("h1");
+    expect(got?.rate_limit_rpm).toBeNull();
+    expect(got?.rate_limit_tpm).toBeNull();
+  });
+
+  it("round-trips per-key rate limits set at creation (0 = explicit unlimited)", async () => {
+    const store = freshStore();
+    await store.createKey({
+      keyId: "k1",
+      hash: "h1",
+      prefix: "p1",
+      accountId: "a",
+      role: "user",
+      rateLimitRpm: 60,
+      rateLimitTpm: 0,
+    });
+    const got = await store.getByHash("h1");
+    expect(got?.rate_limit_rpm).toBe(60);
+    expect(got?.rate_limit_tpm).toBe(0);
+  });
+
+  it("updateRateLimit sets, clears (null), and leaves other fields untouched", async () => {
+    const store = freshStore();
+    await store.createKey({
+      keyId: "k1",
+      hash: "h1",
+      prefix: "helm_live_a",
+      accountId: "a",
+      role: "user",
+      maxLane: "balanced",
+    });
+    await store.updateRateLimit("k1", 100, 5000);
+    let got = await store.getByHash("h1");
+    expect(got?.rate_limit_rpm).toBe(100);
+    expect(got?.rate_limit_tpm).toBe(5000);
+    // other fields untouched (no in-place rewrite of unrelated columns)
+    expect(got?.max_lane).toBe("balanced");
+    expect(got?.disabled).toBe(false);
+    // null clears the override back to inheriting the system default
+    await store.updateRateLimit("k1", null, null);
+    got = await store.getByHash("h1");
+    expect(got?.rate_limit_rpm).toBeNull();
+    expect(got?.rate_limit_tpm).toBeNull();
+  });
+
+  it("updateRateLimit on a missing key rejects (not silently)", async () => {
+    const store = freshStore();
+    await expect(store.updateRateLimit("nope", 1, 1)).rejects.toThrow();
+  });
 });

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -1,6 +1,6 @@
 import type { ApiKeyRecord } from "@helm/shared";
 import { eq } from "drizzle-orm";
-import type { CreateKeyInput, KeyStore } from "../ports.js";
+import type { CreateKeyInput, KeyStore, RateLimitPatch } from "../ports.js";
 import type { SqliteDb } from "./migrate.js";
 import { apiKeys } from "./schema.js";
 
@@ -61,14 +61,20 @@ export class SqliteKeyStore implements KeyStore {
     }
   }
 
-  // Edit ONLY the two rate-limit columns (null clears back to inherit). Other
-  // fields untouched — no in-place rewrite of role/caps. Throws on unknown id.
-  async updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void> {
-    const res = this.db
-      .update(apiKeys)
-      .set({ rateLimitRpm: rpm, rateLimitTpm: tpm })
-      .where(eq(apiKeys.keyId, keyId))
-      .run();
+  // Edit ONLY the rate-limit columns PRESENT in `patch` (null clears back to
+  // inherit). Omitted dims are left untouched, so a partial PATCH never rewrites
+  // the sibling column (no concurrent-clobber). Throws on unknown id.
+  async updateRateLimit(keyId: string, patch: RateLimitPatch): Promise<void> {
+    const set: Partial<Pick<ApiKeyRow, "rateLimitRpm" | "rateLimitTpm">> = {};
+    if (patch.rpm !== undefined) set.rateLimitRpm = patch.rpm;
+    if (patch.tpm !== undefined) set.rateLimitTpm = patch.tpm;
+    if (Object.keys(set).length === 0) {
+      // No-op patch: still verify the key exists (fail-loud on unknown id).
+      const row = this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).get();
+      if (row === undefined) throw new Error(`key not found: ${keyId}`);
+      return;
+    }
+    const res = this.db.update(apiKeys).set(set).where(eq(apiKeys.keyId, keyId)).run();
     if (res.changes === 0) {
       throw new Error(`key not found: ${keyId}`);
     }

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -28,6 +28,9 @@ export class SqliteKeyStore implements KeyStore {
       allowedLanes: input.allowedLanes ? JSON.stringify(input.allowedLanes) : null,
       allowCustomModel: input.allowCustomModel ?? false,
       disabled: false,
+      // Per-key rate-limit override: undefined input => NULL => inherit system default.
+      rateLimitRpm: input.rateLimitRpm ?? null,
+      rateLimitTpm: input.rateLimitTpm ?? null,
       createdAt: this.now(),
     };
     this.db.insert(apiKeys).values(row).run();
@@ -58,6 +61,23 @@ export class SqliteKeyStore implements KeyStore {
     }
   }
 
+  // Edit ONLY the two rate-limit columns (null clears back to inherit). Other
+  // fields untouched — no in-place rewrite of role/caps. Throws on unknown id.
+  async updateRateLimit(
+    keyId: string,
+    rpm: number | null,
+    tpm: number | null,
+  ): Promise<void> {
+    const res = this.db
+      .update(apiKeys)
+      .set({ rateLimitRpm: rpm, rateLimitTpm: tpm })
+      .where(eq(apiKeys.keyId, keyId))
+      .run();
+    if (res.changes === 0) {
+      throw new Error(`key not found: ${keyId}`);
+    }
+  }
+
   // Row -> port record. Restores dialect encodings; exposes hash + prefix only.
   private toRecord(row: ApiKeyRow): ApiKeyRecord {
     return {
@@ -70,6 +90,8 @@ export class SqliteKeyStore implements KeyStore {
       allowed_lanes: row.allowedLanes ? (JSON.parse(row.allowedLanes) as string[]) : null,
       allow_custom_model: row.allowCustomModel,
       disabled: row.disabled,
+      rate_limit_rpm: row.rateLimitRpm ?? null,
+      rate_limit_tpm: row.rateLimitTpm ?? null,
     };
   }
 }

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -63,11 +63,7 @@ export class SqliteKeyStore implements KeyStore {
 
   // Edit ONLY the two rate-limit columns (null clears back to inherit). Other
   // fields untouched — no in-place rewrite of role/caps. Throws on unknown id.
-  async updateRateLimit(
-    keyId: string,
-    rpm: number | null,
-    tpm: number | null,
-  ): Promise<void> {
+  async updateRateLimit(keyId: string, rpm: number | null, tpm: number | null): Promise<void> {
     const res = this.db
       .update(apiKeys)
       .set({ rateLimitRpm: rpm, rateLimitTpm: tpm })

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -216,6 +216,18 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_request_payloads_created_at ON request_payloads (created_at);
     `,
   },
+  {
+    // Per-key rate-limit OVERRIDE columns on api_keys (docs/06 "限流与配额"). Two
+    // nullable integer columns: NULL = inherit the system default at check time;
+    // a value (0 = unlimited) overrides that one dimension for this key. Additive
+    // — existing rows get NULL and therefore keep inheriting the default. Distinct
+    // from rate_limit_buckets (v3, the runtime counters); these are config.
+    version: 8,
+    sql: `
+      ALTER TABLE api_keys ADD COLUMN rate_limit_rpm INTEGER;
+      ALTER TABLE api_keys ADD COLUMN rate_limit_tpm INTEGER;
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database): void {

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -75,6 +75,23 @@ describe("sqlite schema + migrations", () => {
       seed.exec(
         "CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);",
       );
+      // The seed marks versions 1-5 as applied, so the v1 api_keys table must
+      // exist for the honest "old DB" simulation — later migrations (e.g. v8's
+      // ALTER TABLE api_keys) depend on it.
+      seed.exec(
+        `CREATE TABLE api_keys (
+          key_id TEXT PRIMARY KEY,
+          hash TEXT NOT NULL UNIQUE,
+          prefix TEXT NOT NULL,
+          account_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          max_lane TEXT,
+          allowed_lanes TEXT,
+          allow_custom_model INTEGER NOT NULL DEFAULT 0,
+          disabled INTEGER NOT NULL DEFAULT 0,
+          created_at INTEGER NOT NULL
+        );`,
+      );
       seed.exec(
         `CREATE TABLE telemetry (
           id TEXT PRIMARY KEY,

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -18,6 +18,10 @@ export const apiKeys = sqliteTable("api_keys", {
     .notNull()
     .default(false),
   disabled: integer("disabled", { mode: "boolean" }).notNull().default(false),
+  // Per-key rate-limit override (docs/06). Nullable: NULL = inherit the system
+  // default at check time; a value (0 = unlimited) overrides that one dimension.
+  rateLimitRpm: integer("rate_limit_rpm"),
+  rateLimitTpm: integer("rate_limit_tpm"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
 });
 

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -289,11 +289,16 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(got?.rate_limit_rpm).toBe(60);
       expect(got?.rate_limit_tpm).toBe(0);
       // edit + clear back to inherit
-      await ctx.stores.keys.updateRateLimit("k1", 100, 5000);
+      await ctx.stores.keys.updateRateLimit("k1", { rpm: 100, tpm: 5000 });
       got = await ctx.stores.keys.getByHash("h1");
       expect(got?.rate_limit_rpm).toBe(100);
       expect(got?.rate_limit_tpm).toBe(5000);
-      await ctx.stores.keys.updateRateLimit("k1", null, null);
+      // PARTIAL: patching only rpm leaves tpm untouched (no concurrent-clobber).
+      await ctx.stores.keys.updateRateLimit("k1", { rpm: 7 });
+      got = await ctx.stores.keys.getByHash("h1");
+      expect(got?.rate_limit_rpm).toBe(7);
+      expect(got?.rate_limit_tpm).toBe(5000);
+      await ctx.stores.keys.updateRateLimit("k1", { rpm: null, tpm: null });
       got = await ctx.stores.keys.getByHash("h1");
       expect(got?.rate_limit_rpm).toBeNull();
       expect(got?.rate_limit_tpm).toBeNull();
@@ -301,7 +306,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
 
     it("updateRateLimit on a missing key rejects (not silently)", async () => {
       ctx = await make();
-      await expect(ctx.stores.keys.updateRateLimit("nope", 1, 1)).rejects.toThrow();
+      await expect(ctx.stores.keys.updateRateLimit("nope", { rpm: 1, tpm: 1 })).rejects.toThrow();
     });
   });
 

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -261,6 +261,48 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         }),
       ).rejects.toThrow();
     });
+
+    it("per-key rate limits: omitted -> null, set at create round-trips, updateRateLimit edits", async () => {
+      ctx = await make();
+      // omitted -> null (inherit system default)
+      await ctx.stores.keys.createKey({
+        keyId: "k1",
+        hash: "h1",
+        prefix: "p1",
+        accountId: "a",
+        role: "user",
+      });
+      let got = await ctx.stores.keys.getByHash("h1");
+      expect(got?.rate_limit_rpm).toBeNull();
+      expect(got?.rate_limit_tpm).toBeNull();
+      // set at create (0 = explicit unlimited for that dimension)
+      await ctx.stores.keys.createKey({
+        keyId: "k2",
+        hash: "h2",
+        prefix: "p2",
+        accountId: "a",
+        role: "user",
+        rateLimitRpm: 60,
+        rateLimitTpm: 0,
+      });
+      got = await ctx.stores.keys.getByHash("h2");
+      expect(got?.rate_limit_rpm).toBe(60);
+      expect(got?.rate_limit_tpm).toBe(0);
+      // edit + clear back to inherit
+      await ctx.stores.keys.updateRateLimit("k1", 100, 5000);
+      got = await ctx.stores.keys.getByHash("h1");
+      expect(got?.rate_limit_rpm).toBe(100);
+      expect(got?.rate_limit_tpm).toBe(5000);
+      await ctx.stores.keys.updateRateLimit("k1", null, null);
+      got = await ctx.stores.keys.getByHash("h1");
+      expect(got?.rate_limit_rpm).toBeNull();
+      expect(got?.rate_limit_tpm).toBeNull();
+    });
+
+    it("updateRateLimit on a missing key rejects (not silently)", async () => {
+      ctx = await make();
+      await expect(ctx.stores.keys.updateRateLimit("nope", 1, 1)).rejects.toThrow();
+    });
   });
 
   // --- TelemetryStore -----------------------------------------------------

--- a/packages/shared/src/config/runtime-settings.schema.test.ts
+++ b/packages/shared/src/config/runtime-settings.schema.test.ts
@@ -12,6 +12,8 @@ describe("RuntimeSettingsSchema", () => {
     expect(parsed.capture_payloads).toBe(true);
     expect(parsed.payload_retention_days).toBe(30);
     expect(parsed.rate_limit_enabled).toBe(false);
+    expect(parsed.rate_limit_default_rpm).toBe(0);
+    expect(parsed.rate_limit_default_tpm).toBe(0);
     expect(parsed.log_level).toBe("info");
   });
 
@@ -20,14 +22,27 @@ describe("RuntimeSettingsSchema", () => {
       capture_payloads: false,
       payload_retention_days: 7,
       rate_limit_enabled: true,
+      rate_limit_default_rpm: 60,
+      rate_limit_default_tpm: 90000,
       log_level: "debug",
     });
     expect(parsed).toEqual({
       capture_payloads: false,
       payload_retention_days: 7,
       rate_limit_enabled: true,
+      rate_limit_default_rpm: 60,
+      rate_limit_default_tpm: 90000,
       log_level: "debug",
     });
+  });
+
+  it("rejects a negative / non-integer default rate limit (fail-closed)", () => {
+    expect(RuntimeSettingsSchema.safeParse({ rate_limit_default_rpm: -1 }).success).toBe(false);
+    expect(RuntimeSettingsSchema.safeParse({ rate_limit_default_tpm: 1.5 }).success).toBe(false);
+  });
+
+  it("accepts 0 as the default rate limit (0 = unlimited)", () => {
+    expect(RuntimeSettingsSchema.safeParse({ rate_limit_default_rpm: 0 }).success).toBe(true);
   });
 
   it("rejects a non-integer retention (fail-closed)", () => {

--- a/packages/shared/src/config/runtime-settings.schema.ts
+++ b/packages/shared/src/config/runtime-settings.schema.ts
@@ -32,6 +32,13 @@ export const RuntimeSettingsSchema = z.object({
   // admin can flip it without a restart. Seeded at boot from
   // runtime.rate_limit.enabled (see defaultSettingsFromConfig).
   rate_limit_enabled: z.boolean().default(false),
+  // System DEFAULT quota (requests/min, tokens/min) applied to any key WITHOUT
+  // its own per-key override (ApiKeyRecord.rate_limit_{rpm,tpm}). Editable at
+  // runtime so the operator can tune the fleet-wide fallback without a restart;
+  // the limiter reads config.default fresh on every check. 0 = unlimited (mirrors
+  // the quota convention). Seeded at boot from runtime.rate_limit.default.
+  rate_limit_default_rpm: z.number().int().nonnegative().default(0),
+  rate_limit_default_tpm: z.number().int().nonnegative().default(0),
   // Structured-log verbosity floor. Applied live via logger.setLevel().
   log_level: LogLevelSchema.default("info"),
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -152,6 +152,8 @@ export {
   CreateKeyRequestSchema,
   type KeyRole,
   KeyRoleSchema,
+  type UpdateKeyRequest,
+  UpdateKeyRequestSchema,
 } from "./key/schema.js";
 // Memory middleware storage contracts (docs/08) — POST-MVP persistence floor.
 export {

--- a/packages/shared/src/key/schema.test.ts
+++ b/packages/shared/src/key/schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { ApiKeyRecordSchema, KeyRoleSchema } from "./schema.js";
+import {
+  ApiKeyRecordSchema,
+  CreateKeyRequestSchema,
+  KeyRoleSchema,
+  UpdateKeyRequestSchema,
+} from "./schema.js";
 
 function fullKey() {
   return {
@@ -12,6 +17,8 @@ function fullKey() {
     allowed_lanes: null,
     allow_custom_model: false,
     disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
   };
 }
 
@@ -50,13 +57,83 @@ describe("ApiKeyRecordSchema", () => {
     "account_id",
     "role",
     "disabled",
+    "rate_limit_rpm",
+    "rate_limit_tpm",
   ])("rejects when required field %s is missing", (field) => {
     const base = fullKey() as Record<string, unknown>;
     delete base[field];
     expect(ApiKeyRecordSchema.safeParse(base).success).toBe(false);
   });
 
+  it("accepts per-key rate-limit overrides (null = inherit, number = override)", () => {
+    const inherit = ApiKeyRecordSchema.safeParse(fullKey());
+    expect(inherit.success).toBe(true);
+    const overridden = ApiKeyRecordSchema.safeParse({
+      ...fullKey(),
+      rate_limit_rpm: 60,
+      rate_limit_tpm: 0, // 0 = explicitly unlimited for this dimension
+    });
+    expect(overridden.success).toBe(true);
+  });
+
+  it("rejects a negative / non-integer per-key rate limit (fail-closed)", () => {
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), rate_limit_rpm: -1 }).success).toBe(false);
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), rate_limit_tpm: 1.5 }).success).toBe(false);
+  });
+
   it("exposes the role enum options", () => {
     expect([...KeyRoleSchema.options].sort()).toEqual(["root", "user"]);
+  });
+});
+
+describe("CreateKeyRequestSchema", () => {
+  it("accepts optional per-key rate limits", () => {
+    const res = CreateKeyRequestSchema.safeParse({
+      role: "user",
+      rate_limit_rpm: 30,
+      rate_limit_tpm: 10000,
+    });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.rate_limit_rpm).toBe(30);
+      expect(res.data.rate_limit_tpm).toBe(10000);
+    }
+  });
+
+  it("omits rate limits when not provided (inherit system default)", () => {
+    const res = CreateKeyRequestSchema.safeParse({ role: "user" });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.rate_limit_rpm).toBeUndefined();
+      expect(res.data.rate_limit_tpm).toBeUndefined();
+    }
+  });
+
+  it("rejects an unknown field (strict)", () => {
+    expect(CreateKeyRequestSchema.safeParse({ role: "user", nope: 1 }).success).toBe(false);
+  });
+
+  it("rejects a negative per-key rate limit", () => {
+    expect(CreateKeyRequestSchema.safeParse({ rate_limit_rpm: -5 }).success).toBe(false);
+  });
+});
+
+describe("UpdateKeyRequestSchema", () => {
+  it("accepts a number (override) or null (clear to inherit) per dimension", () => {
+    expect(UpdateKeyRequestSchema.safeParse({ rate_limit_rpm: 100 }).success).toBe(true);
+    expect(UpdateKeyRequestSchema.safeParse({ rate_limit_rpm: null }).success).toBe(true);
+    expect(
+      UpdateKeyRequestSchema.safeParse({ rate_limit_rpm: null, rate_limit_tpm: 5000 }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an empty object (no-op patch)", () => {
+    expect(UpdateKeyRequestSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("rejects unknown fields and invalid values (fail-closed)", () => {
+    expect(UpdateKeyRequestSchema.safeParse({ role: "root" }).success).toBe(false);
+    expect(UpdateKeyRequestSchema.safeParse({ rate_limit_tpm: -1 }).success).toBe(false);
+    expect(UpdateKeyRequestSchema.safeParse({ rate_limit_rpm: 2.5 }).success).toBe(false);
   });
 });

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -17,6 +17,12 @@ export const ApiKeyRecordSchema = z.object({
   allowed_lanes: z.array(z.string()).nullable(),
   allow_custom_model: z.boolean(),
   disabled: z.boolean(),
+  // Per-key rate-limit overrides (docs/06). NULL = inherit the system default
+  // (runtime setting rate_limit_default_{rpm,tpm}); a number overrides that ONE
+  // dimension only (0 = explicitly unlimited for this key). present-but-nullable
+  // so the storage shape is explicit, mirroring the other per-key caps above.
+  rate_limit_rpm: z.number().int().nonnegative().nullable(),
+  rate_limit_tpm: z.number().int().nonnegative().nullable(),
 });
 
 export type KeyRole = z.infer<typeof KeyRoleSchema>;
@@ -32,7 +38,27 @@ export const CreateKeyRequestSchema = z
     max_lane: z.string().min(1).optional(),
     allowed_lanes: z.array(z.string().min(1)).optional(),
     allow_custom_model: z.boolean().optional(),
+    // Optional per-key rate limits at mint time. Omitted => inherit the system
+    // default. 0 => explicitly unlimited for that dimension (原则2 fail-closed on
+    // a negative/non-int value).
+    rate_limit_rpm: z.number().int().nonnegative().optional(),
+    rate_limit_tpm: z.number().int().nonnegative().optional(),
   })
   .strict();
 
 export type CreateKeyRequest = z.infer<typeof CreateKeyRequestSchema>;
+
+// Admin-facing update-key request (docs/06). MVP scope: only the per-key rate
+// limits are editable after mint (role/caps are fixed at creation; rotate by
+// revoking + re-minting). `.strict()` so an unknown field fails closed. Each
+// dimension is OPTIONAL (omit = leave unchanged) and NULLABLE (null = clear the
+// override back to inheriting the system default); a number sets an explicit
+// override (0 = unlimited for that dimension).
+export const UpdateKeyRequestSchema = z
+  .object({
+    rate_limit_rpm: z.number().int().nonnegative().nullable().optional(),
+    rate_limit_tpm: z.number().int().nonnegative().nullable().optional(),
+  })
+  .strict();
+
+export type UpdateKeyRequest = z.infer<typeof UpdateKeyRequestSchema>;


### PR DESCRIPTION
## Why

Rate limiting today is a single global master switch; the actual RPM/TPM quota lives only in `config/*.yaml` and isn't editable in the admin UI, and individual API keys have **no** per-key limit. This adds per-key limits with a runtime-editable system default as the fallback.

**Fallback chain (per dimension):** per-key value → system default (editable in System Settings) → unlimited. `null` = inherit; a number (`0` = unlimited) = override.

## What changed (by layer)

- **shared** — `ApiKeyRecord` + `CreateKeyRequest` gain `rate_limit_rpm/tpm`; new `UpdateKeyRequestSchema`; `RuntimeSettings` gains `rate_limit_default_rpm/tpm`.
- **core** — `KeyStore.updateRateLimit` (partial patch, atomic), nullable columns + additive migrations (sqlite v8 / pg v7), limiter `probe.override` precedence, settings seed from `runtime.rate_limit.default`.
- **gateway** — Auth surfaces the key's quota into `caps.rateLimit`; the chat middleware **and** the self-authenticating `/v1/messages` + `/v1/responses` routes thread it into the limiter probe (with a shared Content-Length/4 TPM estimator); `server.ts` live-rebinds the default; `PATCH /admin/api/keys/:id`.
- **admin** — create dialog RPM/TPM inputs, Keys page "Rate limit" column + inline edit, Settings page editable default RPM/TPM, strings translated across all 5 locales.

## Design notes

- The per-key quota rides on the request **probe** (Auth already loads the key record), so the limiter stays a pure function and edits take effect on the next request — no extra DB read.
- `resolveQuota` is **DB-authoritative**: when a probe carries a per-key override, a `null` dimension resolves to the system default and bypasses any stale yaml `config.overrides[keyId]`, so the UI's "Default" label is honest.
- `updateRateLimit` writes only the dimensions present in the patch, so concurrent partial PATCHes can't clobber each other.

## Verification

- `pnpm -r typecheck` ✓ · `biome check` 0 errors · `svelte-check` 0 errors
- **1178 unit tests** pass · **36 e2e (Playwright)** pass · admin SPA + packages build ✓
- Two rounds of Codex review applied (Svelte-5 number-binding clear bug; per-key enforcement on messages/responses; atomic PATCH; DB-authoritative resolve).

See `implementation-notes.md` for the per-key entry (docs/06) covering nullable-vs-0 semantics, the probe-carried override decision, and the new migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)