### PR TITLE
feat(admin): collapse classifier rule dimensions with always-visible intro

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -276,6 +276,7 @@
   "Raw": "Raw",
   "Expand": "Expand",
   "Collapse": "Collapse",
+  "Show all {count} dimensions": "Show all {count} dimensions",
   "Show remaining {count} items": "Show remaining {count} items",
   "Max depth reached": "Max depth reached",
   "(empty object)": "(empty object)",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -274,6 +274,7 @@
   "Raw": "生データ",
   "Expand": "展開",
   "Collapse": "折りたたむ",
+  "Show all {count} dimensions": "全 {count} 件のディメンションを表示",
   "Show remaining {count} items": "残り {count} 件を表示",
   "Max depth reached": "最大の深さに到達しました",
   "(empty object)": "（空のオブジェクト）",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -274,6 +274,7 @@
   "Raw": "원본",
   "Expand": "펼치기",
   "Collapse": "접기",
+  "Show all {count} dimensions": "전체 {count}개 차원 보기",
   "Show remaining {count} items": "나머지 {count}개 표시",
   "Max depth reached": "최대 깊이에 도달했습니다",
   "(empty object)": "(빈 객체)",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -274,6 +274,7 @@
   "Raw": "原始",
   "Expand": "展开",
   "Collapse": "收起",
+  "Show all {count} dimensions": "展开查看全部 {count} 项",
   "Show remaining {count} items": "展开剩余 {count} 项",
   "Max depth reached": "已达最大深度",
   "(empty object)": "（空对象）",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -274,6 +274,7 @@
   "Raw": "原始",
   "Expand": "展開",
   "Collapse": "收起",
+  "Show all {count} dimensions": "展開查看全部 {count} 項",
   "Show remaining {count} items": "展開剩餘 {count} 項",
   "Max depth reached": "已達最大深度",
   "(empty object)": "（空物件）",

--- a/apps/admin/src/routes/classifier/+page.svelte
+++ b/apps/admin/src/routes/classifier/+page.svelte
@@ -136,30 +136,40 @@
     </div>
   </div>
 
-  <!-- Read-only: rule dimensions (collapsed by default — click to expand) -->
+  <!-- Read-only: rule dimensions. Title + intro stay visible; only the table is
+       collapsed (collapsed by default — click the summary or toggle row to expand). -->
   <details class="card group flex flex-col gap-2">
     <summary
-      class="flex cursor-pointer list-none items-center justify-between gap-2 [&::-webkit-details-marker]:hidden"
+      class="flex cursor-pointer list-none flex-col gap-2 [&::-webkit-details-marker]:hidden"
     >
       <h2 class="section-header">{$t('Rule dimensions')}</h2>
-      <svg
-        class="size-4 shrink-0 text-ink-muted transition-transform group-open:rotate-90"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          fill-rule="evenodd"
-          d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02Z"
-          clip-rule="evenodd"
-        />
-      </svg>
-    </summary>
-    <div class="mt-2 flex flex-col gap-2">
       <p class="section-desc">
         {$t('How Layer-1 scores each request. Read-only here — these weights are data in')}
         <code>classifier.yaml</code>{$t('; edit that file and restart the gateway to retune.')}
       </p>
+      <!-- Clear, full-width toggle affordance so operators know it expands. -->
+      <span
+        class="flex items-center gap-2 rounded-control border border-slate-200 bg-canvas px-3 py-2 text-sm text-ink-strong hover:bg-slate-100"
+      >
+        <svg
+          class="size-4 shrink-0 text-ink-muted transition-transform group-open:rotate-90"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span class="group-open:hidden"
+          >{$t('Show all {count} dimensions', { count: cfg.rules.dimensions.length })}</span
+        >
+        <span class="hidden group-open:inline">{$t('Collapse')}</span>
+      </span>
+    </summary>
+    <div class="mt-2 flex flex-col gap-2">
       <DimensionTable dimensions={cfg.rules.dimensions} />
       {#if cfg.rules.boundaries}
         <div data-testid="boundaries" class="mt-2 text-sm text-ink-body">

--- a/apps/admin/src/routes/classifier/classifier.test.ts
+++ b/apps/admin/src/routes/classifier/classifier.test.ts
@@ -110,6 +110,26 @@ describe('classifier page', () => {
     expect(table.querySelectorAll('input, select, textarea, button')).toHaveLength(0);
   });
 
+  it('keeps the rule dimensions collapsed by default with title + intro + toggle always visible', () => {
+    renderPage(config());
+    const table = screen.getByTestId('dimension-table');
+    const details = table.closest('details') as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    // Collapsed by default: the table is hidden behind the disclosure.
+    expect(details.open).toBe(false);
+    // The summary (always visible) carries the title, the intro paragraph, and a
+    // clear toggle affordance with the dimension count — so the operator knows the
+    // section is expandable even while it is collapsed.
+    const summary = details.querySelector('summary') as HTMLElement;
+    expect(summary).not.toBeNull();
+    expect(within_text(summary, 'Rule dimensions')).toBe(true);
+    expect(within_text(summary, 'How Layer-1 scores each request')).toBe(true);
+    // 2 dimensions in the mock config → "Show all 2 dimensions".
+    expect(within_text(summary, 'Show all 2 dimensions')).toBe(true);
+    // The table itself lives outside the summary (in the toggled body).
+    expect(summary.contains(table)).toBe(false);
+  });
+
   it('shows eval details read-only (model, temperature=0, timeout, on_failure, cache ttl)', () => {
     renderPage(config());
     const details = screen.getByTestId('eval-details');


### PR DESCRIPTION
## What

On the Classifier admin page (分类器), the **规则维度 (Rule Dimensions)** section was a collapsed `<details>` whose intro paragraph lived *inside* the collapsed body — so a collapsed section showed only a bare title with a subtle chevron, and operators couldn't tell it was expandable.

This PR:
- Moves the **title + intro into the `<summary>`** so they stay visible while collapsed.
- Adds a clear, full-width clickable **toggle row** — `展开查看全部 N 项`, flipping to `收起` when open — with a rotating chevron. Clicking the title, intro, or the row expands the table.
- Hides only the dimension table. Pure CSS state via `group-open:` — **no new JS, no new dependencies**; reuses the existing `<details>` pattern (as in `JsonTree` / `DecisionChain`) and design tokens.

## i18n
- Adds one key, `Show all {count} dimensions`, to all five locales (zh-hans: `展开查看全部 {count} 项`). `Collapse` already existed in every locale.

## Tests
- New TDD test in `classifier.test.ts`: the section is collapsed by default, and the always-visible `<summary>` carries the title, intro, and `Show all 2 dimensions` toggle label, with the table outside the summary.

## Verification
- Full admin Vitest suite: **120/120** green (incl. the new test).
- `svelte-check`: 0 errors (the lone warning is pre-existing in `settings/+page.svelte`).
- Prettier: clean.
- Verified live (dev server + mocked `/admin/api/classifier`, zh-hans): collapsed shows title + intro + `展开查看全部 18 项`; expanding rotates the chevron, flips the label to `收起`, and reveals the full table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)