### PR TITLE
docs: English-default README + docs, English-ize codebase for 0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,206 @@
+<div align="center">
+
 # Helm API
 
-> 开源、自托管的 LLM 路由网关 · Docker 部署 · MIT License
+**English** · [简体中文](README.zh-CN.md)
 
-Helm API 是一个**开源、自托管**的 LLM 路由网关——你可以把它理解成"LLM 世界的 nginx"：用**配置**（而非代码）来分配和调度模型流量。它接收标准的 AI API 请求，按确定性规则（必要时辅以默认关闭的小模型评估）对任务类型与复杂度分类，将每个请求路由到可配置的 lane，通过带回退机制的 provider 适配器执行，并记录完整的请求与调试遥测。
+> An open-source, self-hosted LLM routing gateway — *nginx for the LLM world*.
 
-- **开箱即用**：默认三条 lane（economy / balanced / premium），LLM 评估默认关闭。
-- **自托管**：Docker 一键部署，配置即代码；不依赖外部服务即可跑起来。
-- **统一接口**：客户端只改 `base_url` + API key；OpenAI / Anthropic 等协议互译。
-- **自带管理界面**：启动后即有 Web 控制台，做基本规则管理 + 请求调试（HTTP Basic 账号密码）。
-- **MIT 协议**：自由部署、修改、商用；不做 SaaS、不售卖。
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](tsconfig.base.json)
+[![Built with Hono](https://img.shields.io/badge/gateway-Hono-ff5e00.svg)](https://hono.dev)
+[![Admin: SvelteKit](https://img.shields.io/badge/admin-SvelteKit-ff3e00.svg)](https://kit.svelte.dev)
 
-本仓库目前存放产品与技术规格文档（spec-first），待 MVP 范围锁定后实现。
+</div>
 
-## 部署
+Helm API sits in front of your LLM providers and decides — by **configuration, not code** — where each request should go. It accepts standard AI API requests (OpenAI Chat Completions, Anthropic Messages, OpenAI Responses), classifies each one by task type and complexity using deterministic rules (optionally backed by a small-model evaluation that is **off by default**), routes it to a configurable **lane**, executes it through provider adapters with **automatic fallback** and a **circuit breaker**, and records full, debuggable telemetry for every decision.
 
-Docker 一键部署，配置与持久化通过挂载卷管理，账号密码经环境变量注入。详见 [10 · 部署](docs/10-deployment.md)。
+Your clients only change their `base_url` and API key. Everything else — model selection, cost/quality tradeoffs, provider failover, protocol translation — happens inside Helm.
 
-## Specs
+---
 
-文档按编号排序，建议按顺序阅读；完整索引见 [docs/README.md](docs/README.md)。
+## Why Helm?
 
-- [01 · 总览与定位](docs/01-overview.md)
-- [02 · 架构](docs/02-architecture.md)
-- [03 · 分类级联](docs/03-classification.md)
-- [04 · 路由与 Lane](docs/04-routing-and-lanes.md)
-- [05 · 协议互译](docs/05-protocol-translation.md)
-- [06 · 鉴权、API Key 与限流](docs/06-auth-and-rate-limits.md)
-- [07 · 错误模型与可观测性](docs/07-observability.md)
-- [08 · 记忆中间件（MVP 之后）](docs/08-memory-middleware.md)
-- [09 · MVP 路线图与成功标准](docs/09-roadmap.md)
-- [10 · 部署（自托管 / Docker）](docs/10-deployment.md)
-- [11 · 管理界面（Admin UI）](docs/11-admin-ui.md)
-- [调研笔记（附录）](docs/research-notes.md)
+- **Lanes, not a model marketplace.** Clients pick an intent (`economy` / `balanced` / `premium`); provider aliases are an internal supply-chain detail.
+- **Config as code.** Behavior is driven by `config/*.yaml` + environment variables, validated with Zod. Invalid config **fails closed** (the gateway refuses to boot) — it never runs in a broken state.
+- **Fail-open routing.** If classification, eval, or cache fails, the request degrades to the `balanced` lane and is logged — it never returns a 5xx for an auxiliary failure. Only "all providers failed" produces a structured error.
+- **Deterministic first.** Layer-1 routing is a pure, zero-network, unit-tested function. The optional Layer-2 eval runs at `temperature: 0`, is cached, and is disabled by default.
+- **Secrets safe, bodies observable.** API keys are stored as SHA-256 hashes only — never in logs, telemetry, or payload tables. Full request/response bodies are captured to a separate table (toggleable, with retention) for debugging and audit.
+- **Headless-capable core.** The routing/classification/execution/translation/storage core is framework-agnostic and runs without the admin UI.
+- **MIT-licensed & self-hosted.** Deploy with Docker, run it entirely in-house. No SaaS, no phone-home.
+
+## Features
+
+- **Drop-in compatibility** with the OpenAI Chat Completions, Anthropic Messages, and OpenAI Responses APIs, including SSE streaming (Chat & Messages).
+- **Cross-protocol translation** through a unified internal representation, with careful SSE event mapping.
+- **Three-layer classification cascade**: deterministic rules → optional small-model eval → `balanced` fallback.
+- **Lane-based routing** with first-match policies and per-org caps.
+- **Multi-provider execution** with cross-provider fallback chains, capability filtering (JSON / tools / vision / context / streaming), and a per-model circuit breaker.
+- **Pluggable storage**: SQLite by default, Postgres/Supabase optional, behind a single Store port interface.
+- **Mandatory API-key auth**, root-key bootstrap on first run, and optional per-key rate limits (RPM/TPM).
+- **Built-in admin UI** (SvelteKit SPA) for keys, lanes, policies, classifier tuning, request debugging, and system settings — protected by HTTP Basic auth, localized in 5 languages.
+
+## Architecture
+
+```
+        ┌──────────────────────────── Helm API gateway (Hono) ───────────────────────────┐
+        │                                                                                  │
+client ─┤  /v1/chat/completions ─┐                                                         │
+(OpenAI/ │  /v1/messages ─────────┼─▶ auth ─▶ rate limit ─▶ classify ─▶ route ─▶ execute ──┼─▶ upstream
+ Anthropic) /v1/responses ────────┘     │         │            │          │         │       │   providers
+        │                               │         │            │          │         │       │  (openai-crs,
+        │   /admin (SPA, HTTP Basic) ───┘   per-key RPM/TPM   3-layer    lane +    provider  │   zenmux,
+        │   /admin/api/*                                      cascade   policies   fallback  │   openrouter…)
+        │   /healthz  /version                                                    + breaker  │
+        │                                                                                    │
+        └──────────────────────────── Store (SQLite default · Postgres optional) ───────────┘
+              keys · decision telemetry · request payloads · rate-limit buckets · memory
+```
+
+The core (`packages/core`) holds all routing/classification/provider/translation/storage logic and depends on no web framework. The gateway (`apps/gateway`) is a thin Hono layer that also serves the admin SPA.
+
+## Quick start (Docker)
+
+```bash
+# 1. Get the config and an env file
+git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
+cp .env.example .env
+#    edit .env — set HELM_ADMIN_PASSWORD and at least OPENAI_API_KEY
+
+# 2. Run it
+docker compose up -d
+
+# 3. On first boot Helm prints a root API key ONCE — copy it from the logs
+docker compose logs helm | grep -i "root key"
+```
+
+- Gateway: `http://localhost:8080`
+- Admin UI: `http://localhost:8080/admin` (log in with `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD`)
+- Health / version: `GET /healthz`, `GET /version`
+
+`docker-compose.yml` mounts `./config` and `./data` as volumes, so your configuration and SQLite database persist across restarts. Credentials are injected via environment variables only — never baked into the image.
+
+## Using the gateway
+
+Point any OpenAI-compatible client at Helm and use a Helm API key:
+
+```bash
+curl http://localhost:8080/v1/chat/completions \
+  -H "Authorization: Bearer $HELM_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "balanced",
+    "messages": [{"role": "user", "content": "Explain consistent hashing in two sentences."}],
+    "stream": true
+  }'
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="<your-helm-key>")
+client.chat.completions.create(
+    model="balanced",                       # or economy / premium / a task lane
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+| Endpoint | Protocol | Streaming |
+|---|---|---|
+| `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ SSE |
+| `POST /v1/messages` | Anthropic Messages | ✅ SSE |
+| `POST /v1/responses` | OpenAI Responses | ❌ non-streaming (0.1) |
+
+> The `model` field accepts a **lane** name (`economy`, `balanced`, `premium`, or a task lane such as `coding`). If omitted or unknown, Helm classifies the request and picks a lane for you. A Gemini adapter exists in the core but is not yet exposed as a route — see the [Roadmap](docs/09-roadmap.md).
+
+## Configuration
+
+Everything is config-as-code in `config/*.yaml` (validated by Zod; invalid config fails closed). Hot-reloadable files can also be edited live in the admin UI.
+
+| File | Purpose | Live-editable |
+|---|---|---|
+| `server.yaml` | Host / port / base path | — |
+| `auth.yaml` | Mandatory API key + root-key bootstrap | — |
+| `runtime.yaml` | Request limits, rate-limit defaults, store driver | partial |
+| `providers.yaml` | Upstream providers + model aliases (credentials by env-var **name** only) | — |
+| `lanes.yaml` | Lane definitions (primary + fallback chain, constraints) | ✅ |
+| `policies.yaml` | First-match routing policies | ✅ |
+| `classifier.yaml` | Layer-1 rules + Layer-2 eval settings | ✅ |
+| `capabilities.yaml` / `pricing.yaml` | Manual overrides on the generated model catalog | — |
+
+Key environment variables (see [`.env.example`](.env.example) for the full list):
+
+| Variable | Purpose |
+|---|---|
+| `OPENAI_API_KEY` | Primary provider credential (**required**) |
+| `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` | Optional fallback-provider credentials |
+| `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | Admin UI HTTP Basic credentials |
+| `HELM_PORT` / `HELM_HOST` | Server binding (default `0.0.0.0:8080`) |
+| `HELM_STORE_DRIVER` | `sqlite` (default) or `supabase` |
+| `HELM_RATE_LIMIT_ENABLED` | Master rate-limit switch (default off) |
+
+Default lanes: **economy** / **balanced** / **premium**, plus task lanes **coding** / **json** / **vision** / **tool_use**. `balanced` is the required classification-fallback terminal.
+
+## Admin UI
+
+Served at `/admin` behind HTTP Basic auth. Pages: dashboard, API keys (create / revoke / per-key limits), lanes, policies, classifier tuning, request telemetry (list + decision-chain detail), and system settings (payload capture, retention, rate-limit switch). Localized in English (default), Simplified/Traditional Chinese, Japanese, and Korean.
+
+## Project layout
+
+```
+helm-api/
+├─ apps/
+│  ├─ gateway/   # Hono API + serves the admin SPA + /healthz, /version
+│  └─ admin/     # SvelteKit + Tailwind admin UI (adapter-static SPA)
+├─ packages/
+│  ├─ core/      # routing · classification · providers · protocol translation · Store ports (framework-agnostic)
+│  └─ shared/    # Zod schemas + shared types (single source of truth)
+├─ config/       # default lanes / policies / classifier / providers / … YAML
+├─ docs/         # documentation (read 01 → 11)
+└─ scripts/      # sync:catalog and other build-time tools
+```
+
+## Development
+
+Requires **Node ≥ 22** and **pnpm**.
+
+```bash
+pnpm install
+pnpm dev          # admin UI dev server
+pnpm test         # Vitest unit tests
+pnpm test:e2e     # Playwright end-to-end tests
+pnpm typecheck    # tsc --noEmit across the workspace
+pnpm lint         # Biome
+pnpm build        # build gateway + admin static assets
+pnpm sync:catalog # refresh the generated model catalog (capabilities + pricing)
+```
+
+The codebase is developed test-first (Vitest for the core, Playwright for end-to-end flows). See [`docs/`](docs/README.md) for the full specification and [`implementation-notes.md`](implementation-notes.md) for design decisions and trade-offs.
+
+## Documentation
+
+Read the docs in order — start at [`docs/README.md`](docs/README.md):
+
+[01 Overview](docs/01-overview.md) ·
+[02 Architecture](docs/02-architecture.md) ·
+[03 Classification](docs/03-classification.md) ·
+[04 Routing & Lanes](docs/04-routing-and-lanes.md) ·
+[05 Protocol Translation](docs/05-protocol-translation.md) ·
+[06 Auth & Rate Limits](docs/06-auth-and-rate-limits.md) ·
+[07 Observability](docs/07-observability.md) ·
+[08 Memory Middleware](docs/08-memory-middleware.md) ·
+[09 Roadmap](docs/09-roadmap.md) ·
+[10 Deployment](docs/10-deployment.md) ·
+[11 Admin UI](docs/11-admin-ui.md)
+
+## Roadmap
+
+0.1 ships the full routing gateway, three client protocols, multi-provider fallback, the admin UI, and the observational-memory **observe** phase. Planned next: a Gemini client route, streaming for `/v1/responses`, the memory **inject** phase, and richer quota/rate-limit controls. See [09 Roadmap](docs/09-roadmap.md).
+
+## Contributing
+
+Issues and pull requests are welcome. Please develop on a branch and ensure CI is green (`pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e`) before opening a PR.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,209 @@
+<div align="center">
+
+# Helm API
+
+[English](README.md) · **简体中文**
+
+> 开源、自托管的 LLM 路由网关 —— *LLM 世界的 nginx*。
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](tsconfig.base.json)
+[![Built with Hono](https://img.shields.io/badge/gateway-Hono-ff5e00.svg)](https://hono.dev)
+[![Admin: SvelteKit](https://img.shields.io/badge/admin-SvelteKit-ff3e00.svg)](https://kit.svelte.dev)
+
+</div>
+
+Helm API 站在你的 LLM 供应商前面，用**配置而非代码**决定每个请求该去哪里。它接收标准的 AI API 请求（OpenAI Chat Completions、Anthropic Messages、OpenAI Responses），用确定性规则（可选地辅以**默认关闭**的小模型评估）按任务类型与复杂度分类，将其路由到一个可配置的 **lane**，通过带**自动回退**与**熔断器**的 provider 适配器执行，并为每一次决策记录完整、可调试的遥测。
+
+你的客户端只需更改 `base_url` 和 API key。其余的一切——模型选择、成本/质量权衡、provider 故障转移、协议互译——都发生在 Helm 内部。
+
+---
+
+## 为什么是 Helm？
+
+- **暴露 lane，而非模型市场。** 客户端只选意图（`economy` / `balanced` / `premium`）；provider 别名是内部供应链细节。
+- **配置即代码。** 行为由 `config/*.yaml` + 环境变量驱动，并用 Zod 校验。非法配置**拒绝启动（fail-closed）**——绝不带病运行。
+- **fail-open 路由。** 分类、eval、缓存等任一辅助环节失败，请求都会降级到 `balanced` lane 并记录日志——绝不为辅助失败返回 5xx。只有"所有 provider 都失败"才产生结构化错误。
+- **确定性优先。** 第 1 层路由是纯函数、零网络、可单测；可选的第 2 层 eval 以 `temperature: 0` 运行、带缓存，且默认关闭。
+- **密钥安全、正文可观测。** API key 只存 SHA-256 哈希——日志、遥测、payload 表里绝不出现明文。完整的请求/响应正文记录到独立的表（可开关、可设保留期），便于调试与审计。
+- **核心可无界面运行。** 路由/分类/执行/翻译/存储核心与框架无关，脱离管理界面也能跑。
+- **MIT 协议、自托管。** Docker 部署，完全在内部运行。不做 SaaS、不回传。
+
+## 特性
+
+- **直接兼容** OpenAI Chat Completions、Anthropic Messages、OpenAI Responses，含 SSE 流式（Chat 与 Messages）。
+- **跨协议互译**：经统一的内部表示，精细映射 SSE 事件。
+- **三层分类级联**：确定性规则 → 可选小模型 eval → `balanced` 兜底。
+- **基于 lane 的路由**：首条匹配策略 + 按组织的上限封顶。
+- **多 provider 执行**：跨 provider 回退链、能力过滤（JSON / 工具 / 视觉 / 上下文 / 流式）、按模型的熔断器。
+- **可插拔存储**：默认 SQLite，可选 Postgres/Supabase，统一藏在 Store 端口接口之后。
+- **强制 API key 鉴权**、首次启动引导 root key、可选的 per-key 限流（RPM/TPM）。
+- **自带管理界面**（SvelteKit SPA）：管理 key、lane、策略、分类器调参、请求调试、系统设置——由 HTTP Basic 鉴权保护，支持 5 种语言。
+
+## 架构
+
+```
+        ┌──────────────────────────── Helm API 网关 (Hono) ───────────────────────────────┐
+        │                                                                                  │
+客户端 ─┤  /v1/chat/completions ─┐                                                          │
+(OpenAI/ │  /v1/messages ─────────┼─▶ 鉴权 ─▶ 限流 ─▶ 分类 ─▶ 路由 ─▶ 执行 ───────────────┼─▶ 上游
+ Anthropic) /v1/responses ────────┘     │        │        │        │        │              │   provider
+        │                               │        │        │        │        │              │  (openai-crs,
+        │   /admin (SPA, HTTP Basic) ───┘   per-key RPM/TPM 三层级联 lane+策略 provider 回退 │   zenmux,
+        │   /admin/api/*                                                    + 熔断器        │   openrouter…)
+        │   /healthz  /version                                                              │
+        │                                                                                   │
+        └──────────────────────────── 存储（默认 SQLite · 可选 Postgres）────────────────────┘
+              key · 决策遥测 · 请求正文 · 限流桶 · 记忆
+```
+
+核心（`packages/core`）承载所有路由/分类/provider/翻译/存储逻辑，不依赖任何 Web 框架。网关（`apps/gateway`）是一层轻薄的 Hono，并负责托管管理界面 SPA。
+
+## 快速开始（Docker）
+
+```bash
+# 1. 获取配置与 env 文件
+git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
+cp .env.example .env
+#    编辑 .env —— 设置 HELM_ADMIN_PASSWORD，至少填好 OPENAI_API_KEY
+
+# 2. 运行
+docker compose up -d
+
+# 3. 首次启动会打印一次 root API key —— 从日志里复制下来
+docker compose logs helm | grep -i "root key"
+```
+
+- 网关：`http://localhost:8080`
+- 管理界面：`http://localhost:8080/admin`（用 `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` 登录）
+- 健康/版本：`GET /healthz`、`GET /version`
+
+`docker-compose.yml` 将 `./config` 与 `./data` 挂载为卷，配置与 SQLite 数据库会在重启间持久化。凭证仅经环境变量注入——绝不写进镜像。
+
+## 使用网关
+
+把任意 OpenAI 兼容客户端指向 Helm，并使用 Helm 的 API key：
+
+```bash
+curl http://localhost:8080/v1/chat/completions \
+  -H "Authorization: Bearer $HELM_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "balanced",
+    "messages": [{"role": "user", "content": "用两句话解释一致性哈希。"}],
+    "stream": true
+  }'
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="<你的-helm-key>")
+client.chat.completions.create(
+    model="balanced",                       # 或 economy / premium / 某个任务 lane
+    messages=[{"role": "user", "content": "你好"}],
+)
+```
+
+| 端点 | 协议 | 流式 |
+|---|---|---|
+| `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ SSE |
+| `POST /v1/messages` | Anthropic Messages | ✅ SSE |
+| `POST /v1/responses` | OpenAI Responses | ❌ 非流式（0.1） |
+
+> `model` 字段接受一个 **lane** 名（`economy`、`balanced`、`premium`，或如 `coding` 的任务 lane）。若省略或无法识别，Helm 会自行分类并为你选 lane。核心中已有 Gemini 适配器，但尚未暴露为路由——见[路线图](docs/09-roadmap.md)。
+
+## 配置
+
+一切皆为 `config/*.yaml` 中的配置即代码（由 Zod 校验；非法配置拒绝启动）。可热重载的文件也能在管理界面中实时编辑。
+
+| 文件 | 用途 | 可实时编辑 |
+|---|---|---|
+| `server.yaml` | 主机 / 端口 / base path | — |
+| `auth.yaml` | 强制 API key + root key 引导 | — |
+| `runtime.yaml` | 请求限制、限流默认值、存储驱动 | 部分 |
+| `providers.yaml` | 上游 provider + 模型别名（凭证只填环境变量**名**） | — |
+| `lanes.yaml` | lane 定义（primary + fallback 链、约束） | ✅ |
+| `policies.yaml` | 首条匹配的路由策略 | ✅ |
+| `classifier.yaml` | 第 1 层规则 + 第 2 层 eval 设置 | ✅ |
+| `capabilities.yaml` / `pricing.yaml` | 对生成的模型目录的手动覆盖 | — |
+
+关键环境变量（完整列表见 [`.env.example`](.env.example)）：
+
+| 变量 | 用途 |
+|---|---|
+| `OPENAI_API_KEY` | 主 provider 凭证（**必填**） |
+| `ZENMUX_API_KEY`、`OPENROUTER_API_KEY` | 可选的回退 provider 凭证 |
+| `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | 管理界面 HTTP Basic 凭证 |
+| `HELM_PORT` / `HELM_HOST` | 服务绑定（默认 `0.0.0.0:8080`） |
+| `HELM_STORE_DRIVER` | `sqlite`（默认）或 `supabase` |
+| `HELM_RATE_LIMIT_ENABLED` | 限流总开关（默认关闭） |
+
+默认 lane：**economy** / **balanced** / **premium**，外加任务 lane **coding** / **json** / **vision** / **tool_use**。`balanced` 是分类兜底的终点（必需）。
+
+## 管理界面
+
+托管于 `/admin`，由 HTTP Basic 鉴权保护。页面：仪表盘、API key（创建 / 吊销 / per-key 限流）、lane、策略、分类器调参、请求遥测（列表 + 决策链详情）、系统设置（正文抓取、保留期、限流开关）。支持英文（默认）、简体/繁体中文、日语、韩语。
+
+## 仓库结构
+
+```
+helm-api/
+├─ apps/
+│  ├─ gateway/   # Hono API + 托管管理界面 SPA + /healthz、/version
+│  └─ admin/     # SvelteKit + Tailwind 管理界面（adapter-static SPA）
+├─ packages/
+│  ├─ core/      # 路由 · 分类 · provider · 协议互译 · Store 端口（框架无关）
+│  └─ shared/    # Zod schema + 共享类型（类型唯一来源）
+├─ config/       # 默认 lanes / policies / classifier / providers / … YAML
+├─ docs/         # 文档（按 01 → 11 阅读）
+└─ scripts/      # sync:catalog 等构建期工具
+```
+
+## 开发
+
+需要 **Node ≥ 22** 与 **pnpm**。
+
+```bash
+pnpm install
+pnpm dev          # 管理界面开发服务器
+pnpm test         # Vitest 单测
+pnpm test:e2e     # Playwright 端到端测试
+pnpm typecheck    # 全仓 tsc --noEmit
+pnpm lint         # Biome
+pnpm build        # 构建网关 + 管理界面静态资源
+pnpm sync:catalog # 刷新生成的模型目录（能力 + 定价）
+```
+
+项目以测试先行的方式开发（核心用 Vitest，端到端流程用 Playwright）。完整规格见 [`docs/`](docs/README.md)，设计决策与取舍见 [`implementation-notes.md`](implementation-notes.md)。
+
+## 文档
+
+请按顺序阅读——从 [`docs/README.md`](docs/README.md) 开始：
+
+[01 总览](docs/01-overview.md) ·
+[02 架构](docs/02-architecture.md) ·
+[03 分类](docs/03-classification.md) ·
+[04 路由与 Lane](docs/04-routing-and-lanes.md) ·
+[05 协议互译](docs/05-protocol-translation.md) ·
+[06 鉴权与限流](docs/06-auth-and-rate-limits.md) ·
+[07 可观测性](docs/07-observability.md) ·
+[08 记忆中间件](docs/08-memory-middleware.md) ·
+[09 路线图](docs/09-roadmap.md) ·
+[10 部署](docs/10-deployment.md) ·
+[11 管理界面](docs/11-admin-ui.md)
+
+> 文档正文为英文（开源社区通用语言）；本中文 README 提供项目概览。
+
+## 路线图
+
+0.1 交付完整的路由网关、三种客户端协议、多 provider 回退、管理界面，以及观察式记忆的 **observe** 阶段。后续计划：Gemini 客户端路由、`/v1/responses` 流式、记忆 **inject** 阶段，以及更丰富的配额/限流控制。见 [09 路线图](docs/09-roadmap.md)。
+
+## 贡献
+
+欢迎提交 issue 与 PR。请在分支上开发，并在开 PR 前确保 CI 全绿（`pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e`）。
+
+## 许可证
+
+[MIT](LICENSE) © 2026 EasyMeta AU / 路田（上海）网络科技有限公司

--- a/apps/admin/src/lib/api/classifier.ts
+++ b/apps/admin/src/lib/api/classifier.ts
@@ -1,6 +1,6 @@
 // Admin classifier API client. The admin UI is a pure consumer of the gateway's
 // /admin/api/* HTTP surface — it imports NO core/gateway business logic and runs
-// NO classification (CLAUDE.md 原则1). The server round-trips the FULL classifier
+// NO classification (CLAUDE.md Principle 1). The server round-trips the FULL classifier
 // config (ClassifierConfigSchema, the single source of truth); this client
 // projects that into a small read-only UI view and, on save, merges the two
 // editable knobs (eval on/off, rules.confidence_threshold) back onto the current
@@ -98,7 +98,7 @@ export async function getClassifier(): Promise<ClassifierConfig> {
 
 // PUT /admin/api/classifier <- the FULL config. The server schema is the source
 // of truth and validates the whole object (out-of-range threshold -> 400, config
-// unchanged: fail-closed, 原则2). We re-read the current config, apply only the
+// unchanged: fail-closed, Principle 2). We re-read the current config, apply only the
 // two editable knobs, and write the merged object back so no server-only field is
 // lost. Returns the projected, persisted view.
 export async function saveClassifier(patch: {

--- a/apps/admin/src/lib/api/keys.test.ts
+++ b/apps/admin/src/lib/api/keys.test.ts
@@ -7,7 +7,7 @@ import { createKey, listKeys, revokeKey, updateKeyRateLimit } from './keys.js';
 // backend is the single source of truth: GET returns a redacted KeySummary[]
 // (prefix only, no hash/plaintext), POST returns { key_id, plaintext } ONCE, and
 // revoke is a soft DELETE that returns { revoked: id } — the UI marks the row
-// disabled locally (轮转语义: generate-new + old disabled, never in-place rewrite).
+// disabled locally (rotation semantics: generate-new + old disabled, never in-place rewrite).
 
 function summaryRow(
   keyId: string,

--- a/apps/admin/src/lib/api/keys.ts
+++ b/apps/admin/src/lib/api/keys.ts
@@ -1,14 +1,14 @@
 // Admin API key client. The admin UI is a pure consumer of the gateway's
 // /admin/api/* HTTP surface — it imports NO core/gateway business logic and owns
-// NO auth logic (CLAUDE.md 原则1). The backend (apps/gateway admin/keys.ts) is the
-// single source of truth and enforces CLAUDE.md 原则7 / docs/06:
+// NO auth logic (CLAUDE.md Principle 1). The backend (apps/gateway admin/keys.ts) is the
+// single source of truth and enforces CLAUDE.md Principle 7 / docs/06:
 //   - keys are stored as sha256 hash + display prefix ONLY; the list view
 //     projects to a redacted KeySummary (prefix only — NEVER hash full-text or
 //     plaintext);
 //   - the plaintext is minted server-side and returned EXACTLY ONCE in the POST
 //     response, never persisted or echoed again;
 //   - revocation is a soft DELETE (disabled:true), never a physical delete or
-//     in-place rewrite (轮转/吊销语义).
+//     in-place rewrite (rotation/revocation semantics).
 // We define UI-facing types here rather than depend on @helm/core (admin must not
 // import core); the role enum mirrors the server KeyRoleSchema (root | user).
 
@@ -89,7 +89,7 @@ function normalizeView(raw: Record<string, unknown>): ApiKeyView {
 }
 
 // Send only the caps the operator set. The server CreateKeyRequestSchema is
-// `.strict()`, so empty/undefined optional fields must be omitted (原则2 fail-closed).
+// `.strict()`, so empty/undefined optional fields must be omitted (Principle 2 fail-closed).
 function toServerBody(input: CreateKeyInput): Record<string, unknown> {
   const out: Record<string, unknown> = { role: input.role ?? 'user' };
   if (input.max_lane) out.max_lane = input.max_lane;

--- a/apps/admin/src/lib/api/lanes.ts
+++ b/apps/admin/src/lib/api/lanes.ts
@@ -3,7 +3,7 @@
 // lane shape mirrors the gateway's Zod schema (the single source of truth);
 // these UI-facing types match docs/04 + the admin.lanes-ui contract. Extra
 // server-only constraint fields (e.g. require_vision, min_context_tokens) are
-// round-tripped untouched so a PUT never drops them (CLAUDE.md 原则1, 原则6).
+// round-tripped untouched so a PUT never drops them (CLAUDE.md Principle 1, Principle 6).
 
 // Server constraint shape uses optional/omitted for "unset". The UI prefers an
 // explicit `max_latency_ms: number | null` (null = cleared); we translate at

--- a/apps/admin/src/lib/api/models.ts
+++ b/apps/admin/src/lib/api/models.ts
@@ -1,7 +1,7 @@
 // Admin models API client. The catalog of routable `provider/model` aliases the
 // gateway exposes at /admin/api/models (sourced from config/providers.yaml). The
 // Lanes UI uses it for combobox suggestions so an operator picks a real alias
-// instead of hand-typing one. The admin UI stays a pure HTTP consumer (原则1) —
+// instead of hand-typing one. The admin UI stays a pure HTTP consumer (Principle 1) —
 // no core/gateway import.
 
 const ENDPOINT = '/admin/api/models';

--- a/apps/admin/src/lib/api/policies.test.ts
+++ b/apps/admin/src/lib/api/policies.test.ts
@@ -9,7 +9,7 @@ import { listPolicies, savePolicies, TASK_TYPE_OPTIONS } from './policies.js';
 
 describe('task_type dropdown contract', () => {
   // The dropdown options are hardcoded in this client (admin must NOT import
-  // @helm/shared, 原则1), so they can silently drift from the gateway's canonical
+  // @helm/shared, Principle 1), so they can silently drift from the gateway's canonical
   // TaskTypeSchema (@helm/shared classifier/eval-output.schema.ts). This guard
   // pins the FULL set: a config policy whose task_type has no matching <option>
   // renders the <select> blank (e.g. `security` policies showed empty). Keep this

--- a/apps/admin/src/lib/api/policies.ts
+++ b/apps/admin/src/lib/api/policies.ts
@@ -3,7 +3,7 @@
 // NO matching (first-match resolution lives in headless core). The Policy shape
 // mirrors the gateway's Zod schema (the single source of truth; @helm/core
 // PolicySchema) — duplicated here as a UI-facing type only because admin must
-// not import core (CLAUDE.md 原则1). Per docs/04 the policy list is ORDERED and
+// not import core (CLAUDE.md Principle 1). Per docs/04 the policy list is ORDERED and
 // the order IS the match priority, so the client preserves order on the wire and
 // the gateway PUTs the whole set (no per-item patch that could lose priority).
 
@@ -24,7 +24,7 @@ export interface Policy {
 
 // Dropdown enums. task_type MUST mirror the gateway's canonical TaskTypeSchema
 // (@helm/shared classifier/eval-output.schema.ts — also @helm/core TaskType);
-// admin can't import it (原则1), so it is duplicated here and guarded by a test.
+// admin can't import it (Principle 1), so it is duplicated here and guarded by a test.
 // A config policy whose task_type is absent here renders the <select> blank
 // (e.g. a `security` policy showed empty). complexity mirrors the SERVER
 // PolicyMatchSchema enum (simple|medium|complex) — the gateway fail-closes (400)

--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -4,7 +4,7 @@ import { toDetail, toListItem } from './requests.js';
 // The API client maps the backend DecisionRecord -> the docs/07 UI contract. Since
 // admin.requests-richfields the record carries the real telemetry fields
 // (key_prefix, latency_total_ms, fallback_count, cost_breakdown{eval/completion}),
-// so the client now reads them instead of placeholders. 原则7: key_prefix is
+// so the client now reads them instead of placeholders. Principle 7: key_prefix is
 // prefix-only, never the plaintext key; provider_raw stays redacted.
 
 function rawRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -1,6 +1,6 @@
 // Admin request-debug API client. The admin UI is a PURE consumer of the
 // gateway's /admin/api/* HTTP surface — it imports NO core/gateway business logic
-// and re-computes NO classification/routing/cost (CLAUDE.md 原则1). It only renders
+// and re-computes NO classification/routing/cost (CLAUDE.md Principle 1). It only renders
 // the trail the backend already recorded.
 //
 // Real backend contract (apps/gateway/src/routes/admin/requests.ts):
@@ -15,10 +15,10 @@
 // (pre-enrichment) records — never fabricating data. See implementation-notes.md
 // for the field map.
 //
-// CLAUDE.md 原则5: classification fallback (`decided_by`) and execution fallback
+// CLAUDE.md Principle 5: classification fallback (`decided_by`) and execution fallback
 // (`provider_attempts`/`fallback_count`) are SEPARATE — they are surfaced as
 // distinct UI concepts here and never conflated.
-// CLAUDE.md 原则7: redaction — `key_prefix` is prefix-only (the recorded display
+// CLAUDE.md Principle 7: redaction — `key_prefix` is prefix-only (the recorded display
 // prefix, e.g. helm_live_ab12, NEVER the plaintext key; '—' when absent);
 // `payload_summary` is a summary placeholder, never the full private payload;
 // `provider_raw` is redacted.
@@ -27,17 +27,17 @@
 
 export interface RequestListItem {
   trace_id: string;
-  ts: string; // 时间
+  ts: string; // timestamp
   key_prefix: string; // display prefix only — NEVER plaintext
   user_id?: string;
   org_id?: string;
   requested_model: string | null;
   task_type: string;
   complexity: string;
-  decided_by: 'rules' | 'eval' | 'default' | 'fallback'; // 决策层级 (分类阶段)
+  decided_by: 'rules' | 'eval' | 'default' | 'fallback'; // decision layer (classification stage)
   lane: string;
   final_model: string | null;
-  fallback_count: number; // 执行兜底次数 (provider attempts - 1)
+  fallback_count: number; // execution fallback count (provider attempts - 1)
   status: 'ok' | 'error';
   latency_ms: number;
   // null = NOT measured (no pricing / usage unknown — e.g. an unpriced model),
@@ -49,7 +49,7 @@ export interface RequestListItem {
 
 // Redacted per-attempt upstream failure detail (admin-debug-error-detail).
 // Present only for an attempt that failed at the upstream; the backend has
-// already key-scrubbed `provider_raw` (原则7), so this is safe to display.
+// already key-scrubbed `provider_raw` (Principle 7), so this is safe to display.
 export interface AttemptErrorDetail {
   upstream_status: number | null; // real upstream HTTP status (e.g. 429); null for timeout/network
   message: string; // redacted, human-readable
@@ -129,7 +129,7 @@ interface RawDecisionRecord {
   created_at?: number;
   requested_model?: string;
   // Display prefix only (helm_live_ab12) — the record NEVER carries the plaintext
-  // key (原则7). Null/absent on legacy (pre-enrichment) records.
+  // key (Principle 7). Null/absent on legacy (pre-enrichment) records.
   key_prefix?: string | null;
   // Enriched telemetry (admin.requests-richfields): Σ attempt latency, execution
   // fallback count, and the eval/completion cost split. Absent on legacy records.
@@ -202,7 +202,7 @@ function sumLatency(attempts: RawAttempt[]): number {
 }
 
 // Execution-stage fallback count = real (non-skipped) attempts beyond the first.
-// Distinct from classification `decided_by` (原则5).
+// Distinct from classification `decided_by` (Principle 5).
 function fallbackCount(attempts: RawAttempt[]): number {
   const tried = attempts.filter((a) => a.skipped !== true).length;
   return Math.max(0, tried - 1);
@@ -210,7 +210,7 @@ function fallbackCount(attempts: RawAttempt[]): number {
 
 // Normalize the recorded error_detail -> the UI shape. Absent/null (ok, skipped,
 // or legacy records) maps to null. The backend has already redacted the body
-// (原则7); the UI only displays it, never recomputes.
+// (Principle 7); the UI only displays it, never recomputes.
 function attemptErrorDetail(a: RawAttempt): AttemptErrorDetail | null {
   const d = a.error_detail;
   if (!d) return null;
@@ -233,7 +233,7 @@ function attemptOutcome(a: RawAttempt): ProviderAttempt['outcome'] {
   return 'error';
 }
 
-// Project the raw DecisionRecord -> the list row (docs/07 列表字段). Fields the
+// Project the raw DecisionRecord -> the list row (docs/07 list fields). Fields the
 // record does not carry are derived or safely defaulted; NEVER fabricated.
 export function toListItem(raw: RawDecisionRecord): RequestListItem {
   const attempts = Array.isArray(raw.provider_attempts) ? raw.provider_attempts : [];
@@ -251,7 +251,7 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     // display. '' when the record carries none (legacy) — never fabricated.
     ts: typeof raw.created_at === 'number' ? new Date(raw.created_at).toISOString() : '',
     // Real display prefix from the recorded auth identity — PREFIX ONLY, never the
-    // plaintext key (原则7). '—' when the record carries none (legacy / unknown).
+    // plaintext key (Principle 7). '—' when the record carries none (legacy / unknown).
     key_prefix:
       typeof raw.key_prefix === 'string' && raw.key_prefix.length > 0 ? raw.key_prefix : '—',
     requested_model: raw.requested_model ?? null,
@@ -261,7 +261,7 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     lane: raw.lane?.selected_lane ?? '',
     final_model: raw.final?.model_alias ?? null,
     // Prefer the recorded value; fall back to deriving from attempts for legacy
-    // records (原则5: execution-stage count, distinct from decided_by).
+    // records (Principle 5: execution-stage count, distinct from decided_by).
     fallback_count:
       typeof raw.fallback_count === 'number' ? raw.fallback_count : fallbackCount(attempts),
     status,
@@ -280,7 +280,7 @@ function normalizeConstraints(raw: Record<string, unknown> | undefined): Record<
 }
 
 // Redacted, non-sensitive request metadata for the detail header. We DELIBERATELY
-// expose only routing-relevant fields — never any private payload (原则7).
+// expose only routing-relevant fields — never any private payload (Principle 7).
 function buildRequestMeta(raw: RawDecisionRecord): Record<string, unknown> {
   return {
     requested_model: raw.requested_model ?? null,
@@ -289,7 +289,7 @@ function buildRequestMeta(raw: RawDecisionRecord): Record<string, unknown> {
 }
 
 // Map the recorded cost split -> the docs/07 cost breakdown. eval self-cost stays
-// SEPARATE from completion (原则5). null parts render as 0 (visible, not hidden);
+// SEPARATE from completion (Principle 5). null parts render as 0 (visible, not hidden);
 // `completionFallback` is the summed attempt cost for legacy records that predate
 // the recorded cost_breakdown.
 function buildCostBreakdown(
@@ -315,7 +315,7 @@ export function toDetail(raw: RawDecisionRecord): RequestDetail {
     ts: '',
     request_meta: buildRequestMeta(raw),
     // The backend does not persist a payload; we render a redaction placeholder so
-    // the operator knows it was intentionally withheld (原则7).
+    // the operator knows it was intentionally withheld (Principle 7).
     payload_summary: 'payload withheld (redacted — only routing metadata is stored)',
     classifier_output: {
       task_type: raw.classifier?.task_type ?? '',
@@ -352,11 +352,11 @@ export function toDetail(raw: RawDecisionRecord): RequestDetail {
             error_class: String(raw.final?.error_reason ?? 'upstream_error'),
             http_status: 0, // backend does not record the upstream http status yet
             message: String(raw.final?.error_reason ?? 'request failed'), // already redacted
-            provider_raw: null, // redacted — never surface raw upstream bodies (原则7)
+            provider_raw: null, // redacted — never surface raw upstream bodies (Principle 7)
           }
         : null,
-    // Cost split from the record (docs/07「成本拆分（含 eval 成本）」): eval self-cost is
-    // SEPARATE from completion cost (原则5). Unknown (null) parts render as 0 so all
+    // Cost split from the record (docs/07 "cost breakdown (incl. eval cost)"): eval self-cost is
+    // SEPARATE from completion cost (Principle 5). Unknown (null) parts render as 0 so all
     // four lines stay visible; legacy records (no cost_breakdown) fall back to the
     // summed attempts as completion. The backend does not bill a separate routing
     // self-cost, so routing_usd stays 0.

--- a/apps/admin/src/lib/api/settings.ts
+++ b/apps/admin/src/lib/api/settings.ts
@@ -1,5 +1,5 @@
 // Admin System Settings API client. The admin UI is a PURE consumer of the
-// gateway's /admin/api/settings surface (CLAUDE.md 原则1) — it imports NO core
+// gateway's /admin/api/settings surface (CLAUDE.md Principle 1) — it imports NO core
 // logic. The RuntimeSettings shape mirrors the gateway's Zod schema (@helm/shared
 // RuntimeSettingsSchema, the single source of truth), duplicated here as a
 // UI-facing type only because admin must not import core. The gateway validates

--- a/apps/admin/src/lib/components/CostBreakdown.svelte
+++ b/apps/admin/src/lib/components/CostBreakdown.svelte
@@ -3,7 +3,7 @@
   import type { RequestDetail } from '$lib/api/requests.js';
   import { t } from '$lib/i18n';
 
-  // Cost breakdown for one request (docs/07「成本拆分，含 eval 评估自身的成本」).
+  // Cost breakdown for one request (docs/07 "cost breakdown, including eval's own cost").
   // Read-only: renders exactly the figures the backend recorded — no re-computation.
   let { cost }: { cost: RequestDetail['cost_breakdown'] } = $props();
 

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -8,7 +8,7 @@
   import { t } from '$lib/i18n';
 
   // Create-key dialog: owns the caps form AND the ONE-TIME plaintext reveal.
-  // CLAUDE.md 原则7 / docs/06: the plaintext is returned by the create response
+  // CLAUDE.md Principle 7 / docs/06: the plaintext is returned by the create response
   // exactly once, shown once, then wiped from component state on close — it is
   // never persisted, re-fetchable, or surfaced anywhere else. The dialog bubbles
   // the redacted view (prefix only, NO plaintext) up via `oncreated`.

--- a/apps/admin/src/lib/components/CreateKeyDialog.test.ts
+++ b/apps/admin/src/lib/components/CreateKeyDialog.test.ts
@@ -5,7 +5,7 @@ import CreateKeyDialog from './CreateKeyDialog.svelte';
 // The dialog owns the create form + the ONE-TIME plaintext reveal. It calls the
 // injected `createKey` and bubbles the new key view up via `oncreated`. The
 // plaintext is shown exactly once and wiped from component state on close
-// (CLAUDE.md 原则7 / docs/06: plaintext returns once, never re-viewable).
+// (CLAUDE.md Principle 7 / docs/06: plaintext returns once, never re-viewable).
 
 const createKey = vi.fn();
 vi.mock('$lib/api/keys.js', () => ({

--- a/apps/admin/src/lib/components/DecisionChain.svelte
+++ b/apps/admin/src/lib/components/DecisionChain.svelte
@@ -5,7 +5,7 @@
   // Visualises the recorded decision trail in order:
   //   classifier output -> eval -> matched policy -> lane candidates -> provider
   //   attempts.
-  // CLAUDE.md 原则5: the classification-stage decision (classifier/eval/policy) and
+  // CLAUDE.md Principle 5: the classification-stage decision (classifier/eval/policy) and
   // the execution-stage provider fallback (attempts) live in SEPARATE sections and
   // are never conflated. Read-only: nothing here is recomputed.
   let { detail }: { detail: RequestDetail } = $props();
@@ -25,7 +25,7 @@
 
   // Pretty-print the (already redacted) upstream error body for the expandable
   // detail panel. An object → indented JSON; a raw string → verbatim. READ-ONLY:
-  // the backend has key-scrubbed this (原则7); we only display it.
+  // the backend has key-scrubbed this (Principle 7); we only display it.
   function showRaw(value: unknown): string {
     if (typeof value === 'string') return value;
     try {
@@ -37,7 +37,7 @@
 </script>
 
 <div class="flex flex-col gap-4">
-  <!-- 1. Classification stage (原则5: NOT execution fallback) -->
+  <!-- 1. Classification stage (Principle 5: NOT execution fallback) -->
   <section data-testid="chain-classifier" class="card">
     <h3 class="text-sm font-semibold text-ink-strong">
       {$t('Classifier (classification stage)')}
@@ -119,7 +119,7 @@
     </ol>
   </section>
 
-  <!-- 5. Execution stage: provider attempts (原则5: distinct from classification) -->
+  <!-- 5. Execution stage: provider attempts (Principle 5: distinct from classification) -->
   <section data-testid="chain-attempts" class="card">
     <h3 class="text-sm font-semibold text-ink-strong">
       {$t('Provider attempts (execution fallback)')}
@@ -143,7 +143,7 @@
           </div>
           <!-- Expandable upstream failure detail for THIS attempt — the only
                record of WHY a candidate failed when a later one served. Already
-               redacted by the backend (原则7). -->
+               redacted by the backend (Principle 7). -->
           {#if a.error_detail}
             {@const ed = a.error_detail}
             <details

--- a/apps/admin/src/lib/components/DecisionChain.test.ts
+++ b/apps/admin/src/lib/components/DecisionChain.test.ts
@@ -4,12 +4,12 @@ import type { RequestDetail } from '$lib/api/requests.js';
 import DecisionChain from './DecisionChain.svelte';
 
 // DecisionChain visualises, in order, the trail the backend recorded:
-//   classifier output (含 confidence + matched_dimensions)
+//   classifier output (incl. confidence + matched_dimensions)
 //   -> eval (triggered / cache hit)
 //   -> matched policy
 //   -> lane candidate chain
-//   -> provider attempts (含 outcome / skip_reason / latency)
-// CLAUDE.md 原则5: the classification-stage decision (`decided_by`) and the
+//   -> provider attempts (incl. outcome / skip_reason / latency)
+// CLAUDE.md Principle 5: the classification-stage decision (`decided_by`) and the
 // execution-stage provider fallback are shown in SEPARATE sections.
 
 function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
@@ -122,7 +122,7 @@ describe('DecisionChain', () => {
     expect(within(rows[1]).queryByTestId('attempt-error-detail')).toBeNull();
   });
 
-  it('keeps classification-stage and execution-stage fallback in separate sections (原则5)', () => {
+  it('keeps classification-stage and execution-stage fallback in separate sections (Principle 5)', () => {
     render(DecisionChain, { detail: detail() });
     // Two clearly distinct regions exist; the classifier section is not the
     // attempts section.

--- a/apps/admin/src/lib/components/LaneEditor.svelte
+++ b/apps/admin/src/lib/components/LaneEditor.svelte
@@ -33,7 +33,7 @@
   let maxLatency = $state<number | null>(initial.constraints.max_latency_ms ?? null);
   let newFallback = $state('');
   // Per-card success flag: set when the parent's save resolves without throwing.
-  // It is the visible "成功提示" the operator (and the e2e) waits for.
+  // It is the visible "success notice" the operator (and the e2e) waits for.
   let saved = $state(false);
 
   const isBalanced = initial.name === 'balanced';
@@ -41,7 +41,7 @@
   // combobox on both the primary and fallback-add inputs.
   const modelsListId = `lane-models-${initial.name}`;
 
-  // Validation. `balanced` must keep a primary (docs/04 红线); other lanes also
+  // Validation. `balanced` must keep a primary (docs/04 hard line); other lanes also
   // need a non-empty primary to be coherent. The hint text differs so ops sees
   // *why* balanced is special.
   const trimmedPrimary = $derived(primary.trim());

--- a/apps/admin/src/lib/components/PolicyRow.svelte
+++ b/apps/admin/src/lib/components/PolicyRow.svelte
@@ -9,7 +9,7 @@
   import { t } from '$lib/i18n';
 
   // Single ordered policy row: a pure "condition → action" editor. It owns NO
-  // matching logic (first-match resolution lives in headless core, 原则1/原则5);
+  // matching logic (first-match resolution lives in headless core, Principle 1/Principle 5);
   // it only enforces enum constraints (no free text) and the use_lane/max_lane
   // mutual exclusion, then bubbles changes up so the parent owns the ordered list.
   let {

--- a/apps/admin/src/routes/classifier/+page.svelte
+++ b/apps/admin/src/routes/classifier/+page.svelte
@@ -5,7 +5,7 @@
   import { t } from '$lib/i18n';
 
   // Data comes from `+page.ts`'s load (mocked via the `data` prop in tests). The
-  // page runs NO classification logic (原则1): it only flips eval on/off, edits
+  // page runs NO classification logic (Principle 1): it only flips eval on/off, edits
   // the confidence threshold within [0,1], and renders the read-only rule
   // dimensions / eval details. It writes back via the API client only.
   let { data }: { data: { classifier: ClassifierConfig } } = $props();
@@ -21,7 +21,7 @@
   let saved = $state(false);
 
   // Validation: threshold must parse to a finite number in [0,1] (fail-closed,
-  // 原则2 — the UI never guesses a legal value for the operator).
+  // Principle 2 — the UI never guesses a legal value for the operator).
   // `bind:value` on a number input yields a number (or NaN when blank/invalid);
   // normalize to a string for parsing so validation is robust either way.
   const thresholdStr = $derived(String(thresholdText));

--- a/apps/admin/src/routes/classifier/classifier.test.ts
+++ b/apps/admin/src/routes/classifier/classifier.test.ts
@@ -95,7 +95,7 @@ describe('classifier page', () => {
     await fireEvent.input(threshold, { target: { value: '-0.1' } });
     await waitFor(() => expect(save.disabled).toBe(true));
 
-    // Even a forced click does not fire the API call (fail-closed, 原则2).
+    // Even a forced click does not fire the API call (fail-closed, Principle 2).
     await fireEvent.click(save);
     expect(saveClassifier).not.toHaveBeenCalled();
   });

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -4,11 +4,11 @@
   import CreateKeyDialog from '$lib/components/CreateKeyDialog.svelte';
   import { t } from '$lib/i18n';
 
-  // API key management view. HARD security line (CLAUDE.md 原则7 / docs/06): the
+  // API key management view. HARD security line (CLAUDE.md Principle 7 / docs/06): the
   // list shows ONLY the display prefix + sha256-backed reference — never plaintext.
   // The plaintext is shown once by the create dialog at mint time, then wiped.
   // Revocation is a SOFT disable (server flips disabled:true) — the row is kept,
-  // never removed or rewritten in place (轮转/吊销审计可追溯). This view is a pure
+  // never removed or rewritten in place (rotation/revocation stays auditable). This view is a pure
   // consumer of /admin/api/* — it owns no auth logic and persists no credentials.
   let { data }: { data: { keys: ApiKeyView[]; lanes: string[] } } = $props();
 

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -4,7 +4,7 @@ import type { ApiKeyView } from '$lib/api/keys.js';
 import KeysPage from './+page.svelte';
 
 // The page consumes data from `load` (mocked via the `data` prop) and writes
-// through the keys API client (mocked). Hard security line (原则7 / docs/06):
+// through the keys API client (mocked). Hard security line (Principle 7 / docs/06):
 // list & detail expose ONLY the prefix + sha256 reference — never plaintext.
 
 const createKey = vi.fn();

--- a/apps/admin/src/routes/policies/+page.svelte
+++ b/apps/admin/src/routes/policies/+page.svelte
@@ -6,7 +6,7 @@
 
   // Data comes from `+page.ts`'s load (mocked via the `data` prop in tests).
   // The page owns the ORDERED working list — order IS the match priority
-  // (docs/04 first-match). It contains NO matching logic (原则1/原则5): it only
+  // (docs/04 first-match). It contains NO matching logic (Principle 1/Principle 5): it only
   // edits/reorders the list and writes the whole set back via the API client.
   let { data }: { data: { policies: Policy[]; lanes?: string[] } } = $props();
 

--- a/apps/admin/src/routes/policies/policies.test.ts
+++ b/apps/admin/src/routes/policies/policies.test.ts
@@ -41,8 +41,8 @@ describe('policies page', () => {
   it('makes the first-match semantics visible (no scoring language)', () => {
     renderPage([policy()]);
     const explainer = screen.getByTestId('first-match-explainer');
-    expect(explainer.textContent ?? '').toMatch(/first[- ]?match|top to bottom|自上而下|首条命中/i);
-    expect(explainer.textContent ?? '').not.toMatch(/score|scoring|打分/i);
+    expect(explainer.textContent ?? '').toMatch(/first[- ]?match|top to bottom/i);
+    expect(explainer.textContent ?? '').not.toMatch(/score|scoring/i);
   });
 
   it("editing a row's match and saving PUTs the whole ordered list", async () => {

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -6,9 +6,9 @@
   import { formatUsd } from '$lib/format.js';
   import { t } from '$lib/i18n';
 
-  // Request debug list (docs/07 列表). READ-ONLY consumer of /admin/api/* — every
-  // column is a field the backend recorded; nothing is recomputed (原则1). 原则7:
-  // the key is shown by display prefix only, never plaintext. 原则5: `decided_by`
+  // Request debug list (docs/07 list). READ-ONLY consumer of /admin/api/* — every
+  // column is a field the backend recorded; nothing is recomputed (Principle 1). Principle 7:
+  // the key is shown by display prefix only, never plaintext. Principle 5: `decided_by`
   // (classification stage) is shown distinctly from `fallback_count` (execution
   // stage).
   let { data }: { data: { items: RequestListItem[]; nextCursor?: string } } = $props();
@@ -33,7 +33,7 @@
     void goto(detailHref(traceId));
   }
 
-  // Recorded time for the 「时间」 column: format the ISO ts for the local locale;
+  // Recorded time for the "timestamp" column: format the ISO ts for the local locale;
   // '—' when the record carried none (legacy row).
   function formatTs(ts: string): string {
     if (!ts) return '—';
@@ -41,7 +41,7 @@
     return Number.isNaN(d.getTime()) ? ts : d.toLocaleString();
   }
 
-  // Distinct label styling per classification-stage decision layer (原则5).
+  // Distinct label styling per classification-stage decision layer (Principle 5).
   function decidedByClass(d: RequestListItem['decided_by']): string {
     switch (d) {
       case 'rules':

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -6,11 +6,11 @@
   import DecisionChain from '$lib/components/DecisionChain.svelte';
   import JsonViewer from '$lib/components/JsonViewer.svelte';
 
-  // Request detail (docs/07 详情). READ-ONLY consumer — renders the recorded trail
-  // and recomputes nothing (原则1). When capture_payloads is on, the full request +
+  // Request detail (docs/07 detail). READ-ONLY consumer — renders the recorded trail
+  // and recomputes nothing (Principle 1). When capture_payloads is on, the full request +
   // response bodies are shown; when off, a clear "not recorded" notice. The key
   // never appears in plaintext (it lives in the Authorization header, not the body).
-  // 原则5: classification vs execution fallback stay separate (DecisionChain).
+  // Principle 5: classification vs execution fallback stay separate (DecisionChain).
   let {
     data,
   }: {

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -6,9 +6,9 @@ import DetailPage from './[traceId]/+page.svelte';
 import ListPage from './+page.svelte';
 
 // The Debug UI is a READ-ONLY consumer of /admin/api/* — it renders the trail the
-// backend recorded and re-computes nothing (docs/07, 原则1). The list/detail
-// clients are mocked; we assert docs/07 列表/详情 fields, the 原则5 separation of
-// classification-stage vs execution-stage fallback, and 原则7 redaction.
+// backend recorded and re-computes nothing (docs/07, Principle 1). The list/detail
+// clients are mocked; we assert docs/07 list/detail fields, the Principle 5 separation of
+// classification-stage vs execution-stage fallback, and Principle 7 redaction.
 
 const getRequest = vi.fn();
 vi.mock('$lib/api/requests.js', () => ({
@@ -174,7 +174,7 @@ describe('requests detail page', () => {
     getRequest.mockReset();
   });
 
-  it('renders the decision chain, cost breakdown (含 eval) and a not-recorded notice when capture is off', () => {
+  it('renders the decision chain, cost breakdown (incl. eval) and a not-recorded notice when capture is off', () => {
     render(DetailPage, {
       data: { detail: detail(), payload: { captured: false }, traceId: 'tr_1' },
     });

--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -10,7 +10,7 @@
 
   // System Settings — runtime-mutable config that applies WITHOUT a restart
   // (capture_payloads, payload_retention_days, rate_limit_enabled, log_level).
-  // Pure consumer (原则1): edits a local working copy, PUTs the whole object on Save;
+  // Pure consumer (Principle 1): edits a local working copy, PUTs the whole object on Save;
   // the gateway validates + applies it live.
   let { data }: { data: { settings: RuntimeSettings | null; loadError?: string } } = $props();
 

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -90,7 +90,7 @@ test.describe("admin request debugging", () => {
       .getByTestId("request-row")
       .filter({ has: page.locator(`a[href$="/requests/${SEED_TRACE_ID}"]`) });
     await expect(row).toBeVisible();
-    // Classification-stage decision layer is shown (decided_by column, 原则5).
+    // Classification-stage decision layer is shown (decided_by column, Principle 5).
     await expect(row.getByTestId("decided-by")).toHaveText("rules");
 
     // Drill into the detail by deep-linking the trace id (SPA fallback route).

--- a/apps/gateway/e2e/eval.spec.ts
+++ b/apps/gateway/e2e/eval.spec.ts
@@ -106,7 +106,11 @@ test.describe("eval cascade e2e", () => {
     request,
   }) => {
     const res = await request.post("/v1/chat/completions", {
-      data: chat(ambiguous("s2")),
+      // Stream: the premium head (openai-crs/gpt-5.5) is stream-only, so a
+      // non-stream request would skip it (no_nonstream_support) and serve a
+      // fallback; streaming keeps the asserted final model the lane head. The
+      // internal eval call is a separate non-stream classify request, unaffected.
+      data: chat(ambiguous("s2"), { stream: true }),
       headers: { ...UNCERTAIN, "x-helm-eval": "on" },
     });
     expect(res.status()).toBe(200);

--- a/apps/gateway/e2e/fixtures/admin.ts
+++ b/apps/gateway/e2e/fixtures/admin.ts
@@ -17,7 +17,7 @@ export const ADMIN_PASSWORD = "e2e-admin-pw";
 
 // A test-only API-key PREFIX we expect to see (prefix-only) in the request
 // debug views. The full plaintext below must NEVER appear in any admin page
-// (原则7 脱敏冒烟) — only its prefix may.
+// (Principle 7 redaction smoke test) — only its prefix may.
 export const SEED_KEY_PREFIX = "helm_live_seed";
 export const SEED_KEY_PLAINTEXT = "helm_live_seed_PLAINTEXT_MUST_NOT_LEAK_abcdef";
 

--- a/apps/gateway/e2e/fixtures/test-server.ts
+++ b/apps/gateway/e2e/fixtures/test-server.ts
@@ -32,7 +32,7 @@ await keyStore.createKey({
 // a pre-built, redacted DecisionRecord — NOT a live upstream call — so the admin
 // request list/detail have a deterministic row with a trace_id, a classified
 // lane, a candidate chain, a provider attempt, and a cost. The record carries no
-// plaintext key/payload (原则7); the views surface key by prefix only.
+// plaintext key/payload (Principle 7); the views surface key by prefix only.
 const telemetry = new SqliteTelemetryStore(seedDb);
 await telemetry.insert({
   apiKeyId: "k_e2e",

--- a/apps/gateway/e2e/protocol.spec.ts
+++ b/apps/gateway/e2e/protocol.spec.ts
@@ -10,7 +10,7 @@ import {
 // tests prove each transformer in isolation; only this spec proves the seams
 // hold once stitched end-to-end, in BOTH client directions, across the two
 // high-risk paths the docs call out: streaming SSE and tool-calls (CLAUDE.md
-// §测试要求 / docs/05).
+// §Testing Requirements / docs/05 Protocol Translation).
 //
 // We assert BOTH sides of the translation:
 //   (a) the client RESPONSE matches its own protocol shape (Anthropic vs OpenAI);
@@ -40,7 +40,7 @@ async function lastUpstreamRequest(request: {
 }
 
 // ── Anthropic client → Helm → upstream ──────────────────────────────────────
-test.describe("Anthropic 客户端 → 上游", () => {
+test.describe("Anthropic client → upstream", () => {
   test("non-stream: messages round-trip + normalized upstream request", async ({ request }) => {
     const res = await request.post("/v1/messages", {
       headers: ANTHROPIC_AUTH,
@@ -122,7 +122,7 @@ test.describe("Anthropic 客户端 → 上游", () => {
 });
 
 // ── OpenAI client → Helm → upstream ─────────────────────────────────────────
-test.describe("OpenAI 客户端 → 上游", () => {
+test.describe("OpenAI client → upstream", () => {
   test("non-stream: chat.completions round-trip", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
       headers: OPENAI_AUTH,
@@ -186,7 +186,7 @@ test.describe("OpenAI 客户端 → 上游", () => {
 
 // ── Bidirectional isomorphism: same logical chat, two client protocols, ONE
 //    normalized upstream shape (proves a unified IR hub, not N×N direct). ─────
-test.describe("双向同构", () => {
+test.describe("bidirectional isomorphism", () => {
   test("both client protocols normalize to the same upstream request shape", async ({
     request,
   }) => {

--- a/apps/gateway/e2e/routing.spec.ts
+++ b/apps/gateway/e2e/routing.spec.ts
@@ -10,7 +10,7 @@ import { FAIL_PRIMARY_SENTINEL } from "./fixtures/mock-upstream.js";
 //
 // Determinism (CI-safe): the mock upstream is fixed/offline, the key is
 // pre-seeded, and every prompt is chosen to be CLEARLY-TYPED so Layer-1 rules
-// hit-stop with confidence ABOVE the default 0.45 gate (eval is OFF) and the
+// hit-stop with confidence ABOVE the default 0.42 gate (eval is OFF) and the
 // selected lane is reproducible. After classifier.confidence-fix a boundary-
 // hugging prompt would instead fall open to `balanced`, so these prompts lean on
 // strong simple/reasoning signals to stay far from the tier boundaries. See task
@@ -52,34 +52,41 @@ function chat(content: string, extra: Record<string, unknown> = {}) {
 
 test.describe("routing e2e", () => {
   // ── Scenario 1: simple prompt → economy lane ────────────────────────────────
+  // The economy head (openai-crs/gpt-5.4-mini) is STREAM-ONLY on the relay
+  // (capabilities.yaml requiresStreaming:true), so exercise it with a STREAMING
+  // request — a non-stream request would (correctly) skip the head with
+  // skip_reason no_nonstream_support and fall to the next in-chain candidate
+  // (covered by the non-stream paths elsewhere). Routing is asserted via the
+  // debug headers, which the gateway emits BEFORE the SSE body; the resolved bare
+  // wire id is surfaced separately as x-helm-provider-model.
   test("simple prompt -> economy lane", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
       // Clearly-simple: strong simple-keyword signals (hi/thanks/ok) push the
       // score well below the `standard` boundary -> confident `simple` -> economy.
-      data: chat("hi thanks, translate to spanish: ok"),
+      data: chat("hi thanks, translate to spanish: ok", { stream: true }),
       headers: AUTH,
     });
     expect(res.status()).toBe(200);
     expect(res.headers()["x-helm-lane"]).toBe("economy");
-    // final model is the economy head and is echoed back by the mock.
+    // final model is the economy head; its resolved provider_model is the bare id.
     expect(res.headers()["x-helm-final-model"]).toBe(ECONOMY_HEAD);
-    const body = await res.json();
-    expect(body.model).toBe(ECONOMY_HEAD_WIRE);
+    expect(res.headers()["x-helm-provider-model"]).toBe(ECONOMY_HEAD_WIRE);
   });
 
   // ── Scenario 2: complex prompt → premium lane ───────────────────────────────
+  // Premium head (openai-crs/gpt-5.5) is likewise stream-only — exercise via streaming.
   test("complex prompt -> premium lane", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
       data: chat(
         "Prove step by step the theorem and derive the integral, reason about the matrix equation and analyze the implications first then finally compile the proof.",
+        { stream: true },
       ),
       headers: AUTH,
     });
     expect(res.status()).toBe(200);
     expect(res.headers()["x-helm-lane"]).toBe("premium");
     expect(res.headers()["x-helm-final-model"]).toBe(PREMIUM_HEAD);
-    const body = await res.json();
-    expect(body.model).toBe(PREMIUM_HEAD_WIRE);
+    expect(res.headers()["x-helm-provider-model"]).toBe(PREMIUM_HEAD_WIRE);
   });
 
   // ── Scenario 3: response_format=json_object → json lane + valid JSON shape ───
@@ -117,10 +124,13 @@ test.describe("routing e2e", () => {
   }) => {
     // The prompt routes to economy (simple) AND carries the fail sentinel so the
     // mock 5xxs the economy head. The gateway only forwards model+messages
-    // upstream, so the fault is steered through the prompt.
+    // upstream, so the fault is steered through the prompt. STREAMING so the
+    // stream-only economy head is actually INVOKED (and then 5xxs) — a non-stream
+    // request would skip the head on capability grounds and never exercise the
+    // upstream-error fallback this scenario is about.
     const res = await request.post("/v1/chat/completions", {
       // Same clearly-simple economy prompt as scenario 1, plus the fail sentinel.
-      data: chat(`hi thanks, translate to spanish: ok ${FAIL_PRIMARY_SENTINEL}`),
+      data: chat(`hi thanks, translate to spanish: ok ${FAIL_PRIMARY_SENTINEL}`, { stream: true }),
       headers: AUTH,
     });
     expect(res.status()).toBe(200);
@@ -130,8 +140,7 @@ test.describe("routing e2e", () => {
     const finalModel = res.headers()["x-helm-final-model"];
     expect(finalModel).not.toBe(ECONOMY_HEAD);
     expect(finalModel).toBe(ECONOMY_NEXT);
-    const body = await res.json();
-    expect(body.model).toBe(ECONOMY_NEXT_WIRE);
+    expect(res.headers()["x-helm-provider-model"]).toBe(ECONOMY_NEXT_WIRE);
   });
 
   // ── Scenario 5: unclassifiable prompt → balanced (classification fallback) ──

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -66,7 +66,7 @@ export function createApp(deps: AppDeps): Hono<AppEnv> {
 
   // /admin (admin API + static SPA) is wired by server.ts (it needs the resolved
   // adminAuth config + Store deps). createApp stays framework-glue only and does
-  // NOT mount admin so headless callers can opt out entirely (CLAUDE.md 原则1).
+  // NOT mount admin so headless callers can opt out entirely (CLAUDE.md Principle 1).
 
   app.onError((err, c) => handleError(err, c));
 

--- a/apps/gateway/src/routes/admin-static.test.ts
+++ b/apps/gateway/src/routes/admin-static.test.ts
@@ -4,15 +4,15 @@ import { describe, expect, it } from "vitest";
 import type { AdminAuthConfig } from "../middleware/basic-auth.js";
 import { mountAdminStatic } from "./admin-static.js";
 
-// admin.static-serve — Hono 在 /admin 托管 admin SPA（替换 Phase 0 占位）。
-// 这些测试钉住契约（DoD 场景 1-7）：
-//   1. 带凭证 GET /admin -> 200 index.html (text/html)
-//   2. 静态资源 (_app/immutable/assets/*.css) -> 200 + 正确 MIME
-//   3. SPA fallback：未命中物理文件的子路由 (/admin/keys) -> 200 index.html，不 404
-//   4. 未认证 -> 401 + WWW-Authenticate，且不泄露任何静态内容
-//   5. Phase 0 占位文案不再出现（catch-all 静态托管已接管）
-//   6. /admin/api/* 不被静态 fallback 吞（API 路由先注册时优先）
-//   7. admin.enabled:false -> Basic 不拦，/admin 仍发静态
+// admin.static-serve — Hono serves the admin SPA at /admin (replacing the Phase 0
+// placeholder). These tests pin the contract (DoD scenarios 1-7):
+//   1. With credentials, GET /admin -> 200 index.html (text/html)
+//   2. Static assets (_app/immutable/assets/*.css) -> 200 + correct MIME
+//   3. SPA fallback: a sub-route with no physical file (/admin/keys) -> 200 index.html, not 404
+//   4. Unauthenticated -> 401 + WWW-Authenticate, and leaks no static content
+//   5. The Phase 0 placeholder text no longer appears (catch-all static serving has taken over)
+//   6. /admin/api/* is not swallowed by the static fallback (API routes win when registered first)
+//   7. admin.enabled:false -> Basic does not block, /admin still serves static files
 
 const ENABLED: AdminAuthConfig = { enabled: true, username: "admin", password: "s3cret" };
 const DISABLED: AdminAuthConfig = { enabled: false, username: null, password: null };

--- a/apps/gateway/src/routes/admin-static.ts
+++ b/apps/gateway/src/routes/admin-static.ts
@@ -2,28 +2,35 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { type AdminAuthConfig, basicAuth } from "../middleware/basic-auth.js";
 
-// admin.static-serve — Hono 在 /admin 托管 admin SPA 的静态产物（apps/admin/build/，
-// 来自 adapter-static）。CLAUDE.md 原则1：gateway 只发静态文件，绝不在进程内跑
-// SvelteKit SSR/运行时（不 import SvelteKit）。整个 /admin 先过 HTTP Basic（admin.auth），
-// 未认证一律拦死，绝不先发文件再校验。
+// admin.static-serve — Hono serves the admin SPA's static build at /admin
+// (apps/admin/build/, produced by adapter-static). CLAUDE.md Principle 1: the
+// gateway only serves static files and NEVER runs SvelteKit SSR/runtime in-process
+// (does not import SvelteKit). The whole /admin goes through HTTP Basic (admin.auth)
+// first; unauthenticated requests are always blocked, never serve a file before
+// validating.
 //
-// 路径处理：本子应用通过 `app.route('/admin', mountAdminStatic(auth))` 挂载，但 Hono
-// 在子应用里仍以**完整**路径（`/admin/...`）暴露 `c.req.path`，而 serveStatic 用该路径
-// 去 root 下查文件。因此把 `/admin` 前缀剥掉，再以 `apps/admin/build` 为 root 解析——
-// 与 admin.scaffold 的 `paths.base:'/admin'` 一致。
+// Path handling: this sub-app is mounted via `app.route('/admin', mountAdminStatic(auth))`,
+// but inside the sub-app Hono still exposes `c.req.path` as the **full** path
+// (`/admin/...`), and serveStatic uses that path to look up files under root.
+// So we strip the `/admin` prefix and resolve against `apps/admin/build` as root —
+// matching admin.scaffold's `paths.base:'/admin'`.
 //
-// SPA 深链接刷新（/admin/keys 等无对应物理文件的子路由）必须回落 index.html，由前端
-// 路由接管，不能 404。`/admin/api/*` 是 admin.api 的端点：调用方在挂载本子应用**之前**
-// 注册 API 路由（Hono 按注册顺序匹配），故子应用收不到 API 请求；这里的 fallback 仍对
-// `/api/*` 放行（next()）作为纵深防御，避免被当成页面回 index.html。
+// SPA deep-link refresh (sub-routes with no physical file, e.g. /admin/keys) must
+// fall back to index.html and let the frontend router take over, not 404.
+// `/admin/api/*` are admin.api endpoints: the caller registers the API routes
+// **before** mounting this sub-app (Hono matches in registration order), so the
+// sub-app never receives API requests; the fallback here still lets `/api/*`
+// through (next()) as defense in depth, to avoid treating it as a page and
+// returning index.html.
 
-// serveStatic 的 root 相对启动进程的 cwd（仓库根）解析。导出以便 server.ts 做
-// 启动期「构建产物缺失」告警，避免路径字符串两处漂移。
+// serveStatic's root resolves relative to the launching process's cwd (repo root).
+// Exported so server.ts can emit a startup "build artifacts missing" warning and
+// avoid drifting the path string in two places.
 export const ADMIN_BUILD_ROOT = "./apps/admin/build";
 const INDEX_PATH = `${ADMIN_BUILD_ROOT}/index.html`;
 
-// 剥掉挂载前缀，把 `/admin/_app/x.js` 映射到 `apps/admin/build/_app/x.js`；
-// `/admin` 本身映射到 root 目录（serveStatic 会回落到 index.html）。
+// Strip the mount prefix, mapping `/admin/_app/x.js` to `apps/admin/build/_app/x.js`;
+// `/admin` itself maps to the root directory (serveStatic falls back to index.html).
 function stripAdminPrefix(path: string): string {
   const rest = path.replace(/^\/admin/, "");
   return rest === "" ? "/" : rest;
@@ -32,10 +39,10 @@ function stripAdminPrefix(path: string): string {
 export function mountAdminStatic(auth: AdminAuthConfig): Hono {
   const admin = new Hono();
 
-  // 1) 整个 /admin 先过 Basic（最前）：未认证 401 + WWW-Authenticate，不泄露内容。
+  // 1) The whole /admin goes through Basic first (foremost): unauthenticated -> 401 + WWW-Authenticate, no content leaked.
   admin.use("*", basicAuth(auth));
 
-  // 2) 命中真实文件（/admin/_app/...、.js/.css）→ 直接发该文件并带正确 MIME。
+  // 2) Real file hit (/admin/_app/..., .js/.css) -> serve that file directly with the correct MIME.
   admin.use(
     "/*",
     serveStatic({
@@ -44,8 +51,8 @@ export function mountAdminStatic(auth: AdminAuthConfig): Hono {
     }),
   );
 
-  // 3) SPA fallback：未命中物理文件的非 API 路由 → 回落 index.html（前端路由接管）。
-  //    `/admin/api/*` 放行，避免吞掉 API 端点。
+  // 3) SPA fallback: non-API routes with no physical file -> fall back to index.html (frontend router takes over).
+  //    `/admin/api/*` is let through, to avoid swallowing API endpoints.
   admin.get("*", (c, next) => {
     if (c.req.path.startsWith("/admin/api/")) return next();
     return serveStatic({ path: INDEX_PATH })(c, next);

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -10,9 +10,10 @@ import type { AdminApiDeps, RuleStore, SettingsAccess } from "./deps.js";
 import { registerAdminApi } from "./index.js";
 
 // admin.api — the gateway management API. These tests pin the CONTRACT (DoD
-// scenarios 1-8): CRUD lanes/policies/classifier落到 config; keys/requests落到
-// Store; invalid input -> 400 不落地; keys绝不回显明文/hash全文; 吊销不就地改写;
-// requests只读含 trace_id; all端点 behind basicAuth.
+// scenarios 1-8): CRUD lanes/policies/classifier persist to config; keys/requests
+// persist to the Store; invalid input -> 400 with nothing written; keys never echo
+// plaintext/full hash; revocation does not rewrite in place; requests are read-only
+// and include trace_id; all endpoints behind basicAuth.
 
 // ── In-memory fakes (no IO; routes are pure glue) ────────────────────────────
 
@@ -261,7 +262,7 @@ describe("admin.api lanes", () => {
   });
 
   it("refuses to DELETE the `balanced` fallback terminal (409) and writes nothing", async () => {
-    // 原则5: `balanced` is the classification-fallback terminal; deleting it would
+    // Principle 5: `balanced` is the classification-fallback terminal; deleting it would
     // leave LanesConfigSchema unsatisfiable. The whole-map re-validation must catch
     // this and leave config untouched (fail-closed).
     const deps = buildDeps();
@@ -549,7 +550,7 @@ describe("admin.api requests", () => {
 
     // The list returns the full (already-redacted) DecisionRecord per row so the
     // SPA can surface the classification stage / candidate chain / cost without
-    // recomputing them (原则1, 原则5). It carries no plaintext key/payload (原则7).
+    // recomputing them (Principle 1, Principle 5). It carries no plaintext key/payload (Principle 7).
     const list = (await (await app.request("/admin/api/requests")).json()) as Array<
       DecisionRecord & { created_at: number }
     >;
@@ -558,16 +559,16 @@ describe("admin.api requests", () => {
     expect(list[0]?.lane.selected_lane).toBe("premium");
     expect(list[0]?.classifier.decided_by).toBe("rules");
     expect(list[0]?.provider_attempts[0]?.cost_usd).toBeCloseTo(0.002);
-    // Each row carries the recorded timestamp (epoch ms) for the UI 「时间」 column.
+    // Each row carries the recorded timestamp (epoch ms) for the UI "Time" column.
     expect(typeof list[0]?.created_at).toBe("number");
 
     const detail = (await (
       await app.request("/admin/api/requests/trace-1")
     ).json()) as DecisionRecord;
     expect(detail.trace_id).toBe("trace-1");
-    expect(detail.classifier.task_type).toBe("coding"); // 分类层级
-    expect(detail.lane.candidate_chain).toEqual(["premium", "balanced"]); // lane 候选链
-    expect(detail.provider_attempts).toHaveLength(1); // provider 尝试
+    expect(detail.classifier.task_type).toBe("coding"); // classification stage
+    expect(detail.lane.candidate_chain).toEqual(["premium", "balanced"]); // lane candidate chain
+    expect(detail.provider_attempts).toHaveLength(1); // provider attempts
   });
 
   it("returns 404 for an unknown trace id", async () => {

--- a/apps/gateway/src/routes/admin/classifier.ts
+++ b/apps/gateway/src/routes/admin/classifier.ts
@@ -13,7 +13,7 @@ import type { AdminApiDeps } from "./deps.js";
 
 // /admin/api/classifier — read/write the classifier config (config/classifier.yaml
 // via RuleStore, NEVER the DB). The toggle for Layer-2 eval, confidence_threshold,
-// and rule weights all live here as data (原则2/4). An out-of-range threshold or
+// and rule weights all live here as data (Principle 2/4). An out-of-range threshold or
 // any schema violation -> 400, config unchanged (fail-closed). ClassifierConfigSchema
 // is the single type source (z.infer); no duplicate shape.
 

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -3,8 +3,8 @@ import type { ClassifierConfig, DecisionRecord, RuntimeSettings } from "@helm/sh
 
 // Injected dependency contracts for the admin API. Per CLAUDE.md principle 1 the
 // route files are PURE HTTP glue — they own no business logic and never touch the
-// filesystem or DB directly. Two落点 are deliberately separate (CLAUDE.md 原则2
-// 配置即代码):
+// filesystem or DB directly. The two persistence targets are deliberately separate
+// (CLAUDE.md Principle 2, config-as-code):
 //   - RULE config (lanes / policies / classifier) -> RuleStore (config/*.yaml or
 //     a runtime ConfigStore). Versionable, never the DB.
 //   - RUNTIME state (keys / telemetry) -> KeyStore / TelemetryStore. Never yaml.
@@ -14,7 +14,7 @@ import type { ClassifierConfig, DecisionRecord, RuntimeSettings } from "@helm/sh
 // A typed read/write seam for the rule configs. Each accessor returns/accepts an
 // already-validated config object — the routes Zod-validate the inbound body
 // BEFORE calling `set*` so an invalid config is rejected (400) and never written
-// (fail-closed, 原则2). `lanes` is a name->Lane map matching LanesConfig minus the
+// (fail-closed, Principle 2). `lanes` is a name->Lane map matching LanesConfig minus the
 // `balanced`-required refinement concern (the route enforces shape via LaneSchema).
 export interface RuleStore {
   getLanes(): Promise<Record<string, Lane>>;
@@ -29,7 +29,7 @@ export interface RuleStore {
 // `get` returns the LIVE value; `save` validates + persists to the config_kv
 // store + applies live (logger level, rate-limit switch) — all wired in server.ts.
 // The route Zod-validates the inbound body against RuntimeSettingsSchema BEFORE
-// calling save (fail-closed, 原则2), so an invalid object is rejected (400) and
+// calling save (fail-closed, Principle 2), so an invalid object is rejected (400) and
 // never persisted nor applied.
 export interface SettingsAccess {
   get(): RuntimeSettings;
@@ -53,7 +53,7 @@ export interface AdminApiDeps {
   // deduped + sorted at startup. Read-only: the Lanes admin UI offers these as
   // combobox suggestions so an operator picks a real alias instead of hand-typing
   // one (a typo would silently break a fallback chain). A supply-chain detail
-  // (原则6) exposed only to the authenticated admin surface, never to API clients.
+  // (Principle 6) exposed only to the authenticated admin surface, never to API clients.
   modelAliases: string[];
   // Mint a fresh key (crypto). Injected for testability + single-source plaintext.
   genKey: () => GeneratedKeyParts;
@@ -72,7 +72,7 @@ export type { CreateKeyInput };
 // ── Wire shapes (admin-API-only response/request projections) ────────────────
 
 // A redacted key summary for the list view: prefix only, NEVER hash full-text or
-// plaintext (原则7, docs/06). `key_id` identifies the row for revocation.
+// plaintext (Principle 7, docs/06). `key_id` identifies the row for revocation.
 export interface KeySummary {
   key_id: string;
   prefix: string;
@@ -96,7 +96,8 @@ export interface CreatedKey {
 
 // Request-debug detail: the full decision trail (docs/07). BOTH the list and the
 // detail endpoints return the whole DecisionRecord — it already carries
-// classification层级, 命中策略, lane 候选链, provider 尝试, 成本, 错误, trace_id and
-// contains NO plaintext key/payload, so the SPA stays a pure consumer (原则1) and
-// the two fallback stages stay distinct (原则5) without backend re-projection.
+// the classification stage, matched policy, lane candidate chain, provider attempts,
+// cost, error, and trace_id, and contains NO plaintext key/payload, so the SPA stays
+// a pure consumer (Principle 1) and the two fallback stages stay distinct (Principle 5)
+// without backend re-projection.
 export type RequestDetail = DecisionRecord;

--- a/apps/gateway/src/routes/admin/index.ts
+++ b/apps/gateway/src/routes/admin/index.ts
@@ -11,10 +11,10 @@ import { registerSettingsRoutes } from "./settings.js";
 
 // /admin/api/* — the gateway management API. All endpoints are registered here
 // and MUST sit behind the admin basicAuth middleware (mounted by the caller on
-// the `/admin/api/*` path; see app/server wiring). Two落点 stay separate by file:
+// the `/admin/api/*` path; see app/server wiring). The two persistence targets stay separate by file:
 //   - rules (lanes/policies/classifier) -> RuleStore (config/*.yaml)
 //   - runtime (keys/requests)           -> KeyStore / TelemetryStore
-// The route files own ONLY HTTP↔domain glue (CLAUDE.md 原则1); no business logic,
+// The route files own ONLY HTTP↔domain glue (CLAUDE.md Principle 1); no business logic,
 // no IO — every dependency is injected via AdminApiDeps.
 
 export function registerAdminApi(app: Hono<AppEnv>, deps: AdminApiDeps): void {

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -3,12 +3,12 @@ import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps, KeySummary } from "./deps.js";
 
-// /admin/api/keys — manage API keys (KeyStore, NEVER yaml). CLAUDE.md 原则7: keys
+// /admin/api/keys — manage API keys (KeyStore, NEVER yaml). CLAUDE.md Principle 7: keys
 // are stored as sha256 hash + display prefix ONLY. The plaintext is minted here,
 // returned EXACTLY ONCE in the POST response, and never persisted or echoed again.
 // The list view projects to a redacted KeySummary — no hash full-text, no plaintext.
 // Revocation is a soft disable (disabled:true), never a physical delete or in-place
-// rewrite (docs/06 轮转吊销).
+// rewrite (docs/06 key rotation/revocation).
 
 // Redact a stored record to the summary the list view exposes. Deliberately omits
 // `hash` and `account_id` internals beyond what the UI needs; NEVER plaintext.

--- a/apps/gateway/src/routes/admin/lanes.ts
+++ b/apps/gateway/src/routes/admin/lanes.ts
@@ -4,7 +4,7 @@ import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
 
 // /admin/api/lanes — CRUD over the lane config (config/lanes.yaml via RuleStore,
-// NEVER the DB; CLAUDE.md 原则2 配置即代码). Pure HTTP glue: every read/write goes
+// NEVER the DB; CLAUDE.md Principle 2, config-as-code). Pure HTTP glue: every read/write goes
 // through the injected RuleStore; the route only validates the body against the
 // shared LaneSchema and translates to HTTP. Invalid body -> 400, nothing written
 // (fail-closed). LaneSchema is the single type source (z.infer); no duplicate shape.
@@ -35,8 +35,8 @@ export function registerLanesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     const lanes = { ...(await deps.rules.getLanes()), [name]: parsed.data };
     // Re-validate the WHOLE map before writing: a single-lane edit can still break
     // the map-level invariant (LanesConfigSchema requires `balanced`, the
-    // classification-fallback terminal — 原则5). Fail-closed: nothing written on a
-    // violation (原则2).
+    // classification-fallback terminal — Principle 5). Fail-closed: nothing written on a
+    // violation (Principle 2).
     const map = LanesConfigSchema.safeParse(lanes);
     if (!map.success) {
       return c.json({ error: "invalid lanes config", issues: map.error.issues }, 400);
@@ -53,7 +53,7 @@ export function registerLanesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     delete lanes[name];
     // Re-validate the mutated map BEFORE writing. Deleting `balanced` (or any edit
     // that breaks the map-level invariant) must be rejected with nothing written —
-    // it is the classification-fallback terminal (原则5, fail-closed 原则2).
+    // it is the classification-fallback terminal (Principle 5, fail-closed Principle 2).
     const map = LanesConfigSchema.safeParse(lanes);
     if (!map.success) {
       return c.json({ error: "invalid lanes config", issues: map.error.issues }, 409);

--- a/apps/gateway/src/routes/admin/models.ts
+++ b/apps/gateway/src/routes/admin/models.ts
@@ -4,11 +4,11 @@ import type { AdminApiDeps } from "./deps.js";
 
 // /admin/api/models — read-only catalog of routable model aliases
 // (config.providers[].models[].alias), deduped + sorted at startup and injected
-// via AdminApiDeps. Pure HTTP glue (CLAUDE.md 原则1): the route owns no logic and
+// via AdminApiDeps. Pure HTTP glue (CLAUDE.md Principle 1): the route owns no logic and
 // touches no config/DB — it just echoes the pre-computed list. Consumed by the
 // Lanes admin UI to offer combobox suggestions so an operator picks a real alias
 // instead of hand-typing one. Sits behind the same /admin/api/* basicAuth as its
-// siblings; provider supply-chain detail (原则6) is never exposed to API clients.
+// siblings; provider supply-chain detail (Principle 6) is never exposed to API clients.
 
 export function registerModelsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
   app.get("/admin/api/models", (c) => c.json(deps.modelAliases));

--- a/apps/gateway/src/routes/admin/policies.ts
+++ b/apps/gateway/src/routes/admin/policies.ts
@@ -7,7 +7,7 @@ import type { AdminApiDeps } from "./deps.js";
 // RuleStore, NEVER the DB). The wire shape is a bare Policy[] (the editor edits a
 // list); we wrap/unwrap the `{ policies: [...] }` config envelope at this seam and
 // validate the whole set with the shared PoliciesConfigSchema. An unknown `match`
-// field (strict schema) -> 400, config unchanged (fail-closed, 原则2).
+// field (strict schema) -> 400, config unchanged (fail-closed, Principle 2).
 
 export function registerPoliciesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
   // GET /policies -> Policy[]

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -3,16 +3,16 @@ import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
 
 // /admin/api/requests — request debugging (TelemetryStore, READ-ONLY). Surfaces
-// the docs/07 decision fields: 分类层级, 命中策略, lane 候选链, provider 尝试, 成本,
-// 错误, trace_id.
+// the docs/07 decision fields: classification stage, matched policy, lane candidate
+// chain, provider attempts, cost, error, trace_id.
 //
 // Both the list and the detail return the full (already-redacted) DecisionRecord:
-// it carries NO plaintext key or private payload (原则7), so there is nothing to
+// it carries NO plaintext key or private payload (Principle 7), so there is nothing to
 // strip. The list view in the SPA needs the per-row classification stage
 // (`decided_by`), candidate lane, fallback count and cost — all of which live in
 // the record — so projecting to a 4-field summary here would force the UI to
 // recompute/guess them (and conflate classification vs execution fallback,
-// breaking 原则5). Returning the records keeps the UI a pure consumer (原则1).
+// breaking Principle 5). Returning the records keeps the UI a pure consumer (Principle 1).
 
 const DEFAULT_LIMIT = 100;
 
@@ -20,9 +20,9 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
   // GET /requests -> (DecisionRecord & { created_at })[] (most recent first;
   // already redacted). The store pairs each record with its recorded timestamp
   // (a separate column, kept out of the redacted record); we flatten it onto the
-  // row as `created_at` (epoch ms) so the Debug UI can render the 「时间」 column
-  // without recomputing or fabricating it (原则1). created_at is a routing
-  // timestamp — it carries no plaintext key/payload (原则7).
+  // row as `created_at` (epoch ms) so the Debug UI can render the "Time" column
+  // without recomputing or fabricating it (Principle 1). created_at is a routing
+  // timestamp — it carries no plaintext key/payload (Principle 7).
   app.get("/admin/api/requests", async (c) => {
     const records = await deps.telemetry.queryRecent(DEFAULT_LIMIT);
     return c.json(records.map((r) => ({ ...r.record, created_at: r.createdAt.getTime() })));

--- a/apps/gateway/src/routes/admin/rule-store.ts
+++ b/apps/gateway/src/routes/admin/rule-store.ts
@@ -3,9 +3,9 @@ import type { ClassifierConfig } from "@helm/shared";
 import type { RuleStore } from "./deps.js";
 
 // Runtime (in-process) RuleStore — the MVP backing for the admin rule-config
-// endpoints. The task explicitly permits "config/*.yaml 或运行时 ConfigStore";
+// endpoints. The task explicitly permits "config/*.yaml or a runtime ConfigStore";
 // this is the latter: edits update the live in-memory config the router reads, so
-// changes take effect without a restart. Per CLAUDE.md 原则2 the canonical落点 is
+// changes take effect without a restart. Per CLAUDE.md Principle 2 the canonical persistence target is
 // still the rule config (NOT the DB). A future YAML write-back adapter can replace
 // this without touching the routes (they depend only on the RuleStore interface).
 //

--- a/apps/gateway/src/routes/admin/settings.ts
+++ b/apps/gateway/src/routes/admin/settings.ts
@@ -4,7 +4,7 @@ import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
 
 // /admin/api/settings — the System Settings surface (runtime-mutable config that
-// applies WITHOUT a restart). PURE HTTP glue (原则1): validate → save → echo. The
+// applies WITHOUT a restart). PURE HTTP glue (Principle 1): validate → save → echo. The
 // save seam (deps.settings.save) validates+persists to config_kv and applies live
 // (logger level, rate-limit switch); it is wired in server.ts.
 
@@ -15,7 +15,7 @@ export function registerSettingsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
   });
 
   // PUT /settings -> validate the WHOLE object against the schema, persist+apply,
-  // echo the validated result. Fail-closed (原则2): an invalid body is rejected
+  // echo the validated result. Fail-closed (Principle 2): an invalid body is rejected
   // (400) and never written nor applied to the live closures.
   app.put("/admin/api/settings", async (c) => {
     const body = await c.req.json().catch(() => null);

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -61,7 +61,7 @@ export interface ChatRouteDeps {
    *  Gated by HELM_E2E in the composition root; production never sets this so
    *  classification stays config-driven (fail-closed). */
   evalHeaderOverride?: boolean;
-  /** Memory observe-phase wiring (docs/08 阶段 1). Optional — absent = no-op
+  /** Memory observe-phase wiring (docs/08 Phase 1). Optional — absent = no-op
    *  (existing tests run unchanged). When present, observeInbound persists the
    *  request before routing and observeOutbound persists the assistant turn
    *  after; both self-gate on the resolved MemoryScope mode and are fail-open
@@ -281,7 +281,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     const sessionKey =
       headerSessionKey !== undefined && headerSessionKey.length > 0 ? headerSessionKey : null;
 
-    // Memory scope (docs/08 阶段 1): parse the four memory headers at this HTTP
+    // Memory scope (docs/08 Phase 1): parse the four memory headers at this HTTP
     // boundary into a resolved MemoryScope (core never reads headers, principle
     // 1). The scope ids/mode ride the InternalRequest metadata AND gate the
     // observe calls below; absent/illegal headers → off + null (default-safe).
@@ -324,7 +324,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     }
 
     // Memory observe (inbound): persist the request's raw messages BEFORE routing
-    // (docs/08 阶段 1). observe is write-only — it NEVER mutates `internal.messages`
+    // (docs/08 Phase 1). observe is write-only — it NEVER mutates `internal.messages`
     // nor changes routing, and self-gates to a no-op on mode=off / threadId=null.
     // It never throws (fail-open inside core), so no try/catch is needed here.
     if (deps.memory !== undefined) {

--- a/apps/gateway/src/routes/execute.default-config.test.ts
+++ b/apps/gateway/src/routes/execute.default-config.test.ts
@@ -188,17 +188,20 @@ describe("default config activates capability filter + cost (alias-namespace ali
     // A chain that puts the json-INCAPABLE auto FIRST, then a json-capable model.
     // A needs_json request must SKIP the auto (skip_reason no_json_support) and
     // land on the capable model — proving the filter prunes on the real catalog.
-    const chain = ["zenmux/auto", "openai-crs/gpt-5.4-mini"];
+    // The capable model is deepseek-crs/deepseek-pro: json-capable AND non-stream-
+    // capable, so a non-stream request lands on it cleanly (the openai-crs heads
+    // are stream-only — see the dedicated no_nonstream_support test).
+    const chain = ["zenmux/auto", "deepseek-crs/deepseek-pro"];
     const out = await execute(plan(chain), req({ response_format: { type: "json_object" } }));
 
     expect(out.attempts[0]?.alias).toBe("zenmux/auto");
     expect(out.attempts[0]?.skipped).toBe(true);
     expect(out.attempts[0]?.skip_reason).toBe("no_json_support");
     expect(out.final.status).toBe("ok");
-    if (out.final.status === "ok") expect(out.final.alias).toBe("openai-crs/gpt-5.4-mini");
+    if (out.final.status === "ok") expect(out.final.alias).toBe("deepseek-crs/deepseek-pro");
     // The pruned auto must NEVER have been invoked upstream. The upstream `model`
-    // is the RESOLVED bare provider_model (`gpt-5.4-mini`), not the alias.
-    expect(calls).toEqual(["gpt-5.4-mini"]);
+    // is the RESOLVED bare provider_model (`deepseek-pro`), not the alias.
+    expect(calls).toEqual(["deepseek-pro"]);
   });
 
   it("the shipped `json` lane chain prunes its */auto tail for a needs_json request", async () => {
@@ -218,10 +221,12 @@ describe("default config activates capability filter + cost (alias-namespace ali
     expect(chain).toContain("openrouter/auto");
     const out = await execute(plan(chain), req({ response_format: { type: "json_object" } }));
     expect(out.final.status).toBe("ok");
-    // Lands on the json-capable primary; the auto tails are never reached here,
-    // but the chain demonstrably CONTAINS json-incapable candidates the filter
-    // would prune (proven head-on by the previous test).
-    if (out.final.status === "ok") expect(out.final.alias).toBe("openai-crs/gpt-5.4-mini");
+    // The json lane primary (openai-crs/gpt-5.4-mini) is stream-only, so this
+    // NON-stream request skips it (no_nonstream_support) and lands on the next
+    // json-capable candidate — balanced's primary deepseek-crs/deepseek-pro. The
+    // auto tails are never reached, but the chain demonstrably CONTAINS json-
+    // incapable candidates the filter would prune (proven head-on by the prior test).
+    if (out.final.status === "ok") expect(out.final.alias).toBe("deepseek-crs/deepseek-pro");
   });
 
   it("a chain of ONLY json-incapable candidates → capability_unsatisfiable (422 class)", async () => {
@@ -260,14 +265,16 @@ describe("default config activates capability filter + cost (alias-namespace ali
       now: clock(),
       signal: new AbortController().signal,
     });
-    // Serve a plain request on the economy head (openai-crs/gpt-5.4-mini).
-    const out = await execute(plan(["openai-crs/gpt-5.4-mini"]), req());
+    // Serve a plain (non-stream) request on a non-stream-capable model. The
+    // openai-crs heads are stream-only (skipped on non-stream), so use balanced's
+    // primary deepseek-crs/deepseek-pro, which serves and prices deterministically.
+    const out = await execute(plan(["deepseek-crs/deepseek-pro"]), req());
     expect(out.final.status).toBe("ok");
     const served = out.attempts.find((a) => a.status === "ok");
     expect(served).toBeDefined();
-    // pricing: input 0.75/MTok, output 4.5/MTok; usage 1000 prompt + 500 compl.
-    // cost = 1000/1e6*0.75 + 500/1e6*4.5 = 0.00075 + 0.00225 = 0.003.
+    // pricing: input 0.435/MTok, output 0.87/MTok; usage 1000 prompt + 500 compl.
+    // cost = 1000/1e6*0.435 + 500/1e6*0.87 = 0.000435 + 0.000435 = 0.00087.
     expect(served?.cost_usd).not.toBeNull();
-    expect(served?.cost_usd).toBeCloseTo(0.003, 9);
+    expect(served?.cost_usd).toBeCloseTo(0.00087, 9);
   });
 });

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -264,7 +264,7 @@ export function createMessagesPipeline(
   // Default anthropic_messages (the /v1/messages caller); /v1/responses passes
   // openai_responses so telemetry attributes the surface correctly (principle 5).
   protocol: Protocol = "anthropic_messages",
-  // Memory observe-phase wiring (docs/08 阶段 1). Optional — absent = no-op (the
+  // Memory observe-phase wiring (docs/08 Phase 1). Optional — absent = no-op (the
   // pipeline's existing tests run unchanged). When present, observeInbound
   // persists the request before routing and observeOutbound persists the
   // assistant turn after; both self-gate on the resolved MemoryScope and are
@@ -290,7 +290,7 @@ export function createMessagesPipeline(
       const internal = toInternalRequest(ir, identity, traceId, protocol);
 
       // Memory observe (inbound): persist the request's raw messages BEFORE
-      // routing (docs/08 阶段 1). observe is write-only — it never mutates the
+      // routing (docs/08 Phase 1). observe is write-only — it never mutates the
       // messages nor changes routing, self-gates to a no-op on off/null-thread,
       // and never throws (fail-open inside core). The scope rides ir.metadata,
       // already stamped by the route from the request headers.

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -225,7 +225,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       }
     }
 
-    // Memory scope (docs/08 阶段 1): parse the four memory headers at this HTTP
+    // Memory scope (docs/08 Phase 1): parse the four memory headers at this HTTP
     // boundary and stamp them onto the IR metadata bag (mirrors conversation_id),
     // so the framework-agnostic pipeline can read the scope off ir.metadata
     // without ever touching HTTP (CLAUDE.md principle 1). Absent/illegal headers

--- a/apps/gateway/src/routes/responses.memory.test.ts
+++ b/apps/gateway/src/routes/responses.memory.test.ts
@@ -10,7 +10,7 @@ import { type ResponsesRouteDeps, registerResponsesRoute } from "./responses.js"
 // stamp the four memory headers onto ir.metadata before pipeline.run. Without that
 // stamping the observe deps were wired (server.ts) yet never received a scope, so
 // `x-memory-mode: observe` persisted nothing on this surface (CLAUDE.md principle 8
-// observability gap / docs/08 阶段 1 dead on /v1/responses).
+// observability gap / docs/08 Phase 1 dead on /v1/responses).
 
 const AUTH = { Authorization: "Bearer helm_live_secret", "Content-Type": "application/json" };
 const MEM_HEADERS = {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -149,7 +149,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       const detail = err instanceof Error ? err.message : "invalid Responses request";
       throw helmError("invalid_request", detail, traceId);
     }
-    // Memory scope (docs/08 阶段 1): parse the four memory headers at this HTTP
+    // Memory scope (docs/08 Phase 1): parse the four memory headers at this HTTP
     // boundary and stamp them onto the IR metadata bag (mirrors /v1/messages), so
     // the SHARED pipeline's observe phase can read the scope off ir.metadata
     // without touching HTTP (principle 1). Without this, /v1/responses was wired

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -174,7 +174,7 @@ export async function buildServer(
   const logger = opts.logger ?? createJsonLogger();
   const config = loadConfig({ configDir: opts.configDir ?? "./config" });
 
-  // Store adapter set, chosen by config (CLAUDE.md "DB 抽象层"): sqlite (default,
+  // Store adapter set, chosen by config (CLAUDE.md "DB abstraction layer"): sqlite (default,
   // local file) or supabase (hosted Postgres). The factory fails CLOSED on an
   // unknown driver / a missing supabase credential (principle 2). The supabase
   // connection string is referenced by env-var NAME (runtime.store.url_env) and
@@ -247,7 +247,7 @@ export async function buildServer(
     store: store.rateLimit,
   });
 
-  // Memory observe-phase deps (docs/08 阶段 1), built ONCE process-wide and shared
+  // Memory observe-phase deps (docs/08 Phase 1), built ONCE process-wide and shared
   // by every request surface (chat / messages / responses). store.memory is the
   // live MemoryStore createStore already returns for both sqlite + postgres — no
   // extra adapter wiring. estimateTokens is a deterministic chars/4 heuristic (NOT
@@ -322,7 +322,7 @@ export async function buildServer(
   // Live classifier config. `let` so an admin edit (via the runtime RuleStore's
   // onClassifier callback below) re-binds the value the classify adapter reads
   // per request — classifier changes hot-apply WITHOUT a restart (closes the
-  // admin.api TODO: "admin 改 classifier 不热生效"). The adapter rebuilds its eval
+  // admin.api TODO: "admin classifier edits do not hot-apply"). The adapter rebuilds its eval
   // cache when this value changes, so a verdict from the old config is never served.
   let classifierConfig: ClassifierConfig = config.classifier;
   // Session-momentum soft-state. Instantiated ONCE here (process-wide singleton,
@@ -471,7 +471,7 @@ export async function buildServer(
   // from API-key auth (different credential source, no RBAC). Rule edits go through
   // a runtime RuleStore that re-binds the live `lanes`/`policies` the router reads;
   // keys/requests go to the Store. The plaintext of a freshly minted key is the
-  // ONLY secret ever returned, once (原则7).
+  // ONLY secret ever returned, once (Principle 7).
   const adminAuth = resolveAdminAuth(config as { admin?: Record<string, unknown> }, process.env);
   warnIfAdminUnconfigured(adminAuth, (line) => logger.log("warn", "admin.auth", { line }));
   // SECURITY: only mount the admin surface (API + SPA) when admin is enabled — i.e.
@@ -531,7 +531,7 @@ export async function buildServer(
     // the more-specific /admin/api/* routes win (Hono matches in registration
     // order); the static catch-all would otherwise return index.html for them. The
     // sub-app re-applies basicAuth so the page + assets are also gated. We never run
-    // SvelteKit here — just serve the adapter-static build (CLAUDE.md 原则1).
+    // SvelteKit here — just serve the adapter-static build (CLAUDE.md Principle 1).
     if (!existsSync(ADMIN_BUILD_ROOT)) {
       logger.log("warn", "admin.static_missing", {
         dir: ADMIN_BUILD_ROOT,

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,86 +1,124 @@
-# 01 · 总览与定位
+# 01 · Overview & Positioning
 
-## 一句话定义
+## One-line definition
 
-Helm API 是一个**开源、自托管**的 LLM 路由网关（MIT 协议，Docker 部署）。你可以把它理解成"**LLM 世界的 nginx**"：用简单的 YAML 配置完成模型的分配与调度，对客户端则始终是统一的标准与输出。
+Helm API is an **open-source, self-hosted** LLM routing gateway (MIT license,
+deployed with Docker). Think of it as "**nginx for the LLM world**": simple YAML
+configuration drives how models are assigned and dispatched, while clients always
+see one standard interface and output shape.
 
-它接收标准的 AI API 请求，识别任务类型与复杂度，将每个请求路由到合适的 lane，通过 provider 适配器执行，并记录完整的请求日志以便调试。启动后还自带一个管理界面，做基本规则管理。
+It accepts standard AI API requests, identifies each request's task type and
+complexity, routes it to the appropriate lane, executes it through a provider
+adapter, and records full request logs for debugging. A management interface
+ships alongside the gateway for basic rule management.
 
-把流量当**配置**来管，而不是当**代码**来写。
+Manage traffic as **configuration**, not as **code**.
 
-## 问题
+## The problem
 
-AI 应用开发者不想在每个客户端里管理上百个模型、各家 provider 的怪癖、fallback 行为、成本权衡以及长期的路由决策。他们想要的是一个 API：足够便宜、足够可靠、默认就够用，并且在出问题时可以调试。
+AI application developers do not want to manage hundreds of models, the quirks of
+each provider, fallback behavior, cost trade-offs, and long-term routing
+decisions inside every client. They want one API that is cheap enough, reliable
+enough, sensible by default, and debuggable when something goes wrong.
 
-之前的 llm-router 方向变得过于宽泛：provider 别名太多、太偏向于模型市场的思路，而且路由核心里塞了太多逻辑。Helm API 应该更聚焦、更收敛。
+The earlier `llm-router` project drifted too broad: too many provider aliases, a
+model-marketplace mindset, and too much logic stuffed into the routing core. Helm
+API is deliberately more focused and convergent.
 
-## 类比：LLM 世界的 nginx
+## Analogy: nginx for the LLM world
 
-这个类比帮助理解 Helm 是什么、不是什么——它约束了产品边界：
+This analogy explains what Helm is and is not — it constrains the product
+boundary:
 
-- nginx 不托管内容 → Helm **不拥有模型**，对外暴露的是 lane 抽象，不是模型市场。
-- nginx 配置是声明式的 → 一切都在 `lanes.yaml` / `policies.yaml`，不写代码。
-- nginx 有 upstream + 健康检查 + 故障转移 → lane 的 `primary + fallback[]` + 熔断器。
-- nginx 是你自己部署的"无聊但可靠"的基础设施 → Helm 同样**开源自托管**，不是 SaaS、不是平台。
+- nginx does not host content → Helm **does not own models**; it exposes a lane
+  abstraction, not a model marketplace.
+- nginx configuration is declarative → everything lives in `lanes.yaml` /
+  `policies.yaml`; no code changes.
+- nginx has upstreams + health checks + failover → a lane has `primary +
+  fallback[]` plus a circuit breaker.
+- nginx is the "boring but reliable" infrastructure you deploy yourself → Helm is
+  likewise **open-source and self-hosted**, not a SaaS or platform.
 
-如果你不熟悉 nginx 也没关系：把 Helm 当成"一个你自己跑的、用配置管理模型流量的 API 网关"即可。
+If you are not familiar with nginx, that is fine: treat Helm as "an API gateway
+you run yourself that manages model traffic through configuration".
 
-## 客户端 API 呈现面
+## Client-facing API surface
 
-Helm 应当支持标准的 AI API 形态：
+Helm exposes standard AI API shapes. Three client protocols are wired and routed
+today:
 
-- OpenAI Chat Completions
-- Anthropic Messages
-- OpenAI Responses
-- Gemini API（后续支持）
+- **OpenAI Chat Completions** — `POST /v1/chat/completions` (streaming and
+  non-streaming).
+- **Anthropic Messages** — `POST /v1/messages` (streaming and non-streaming).
+- **OpenAI Responses** — `POST /v1/responses` (**non-streaming only** in 0.1; a
+  `stream:true` request is rejected with a structured 400).
 
-客户端应当只需要修改 `base_url` 和 API key。客户端无需知道实际由哪个 provider 或模型来执行请求。各协议之间的互译见 [05 · 协议互译](05-protocol-translation.md)。
+A **Gemini** transformer exists in the codebase but is not yet routed to an
+endpoint; native Gemini support is on the roadmap (see
+[09 · Roadmap](09-roadmap.md)), not a usable endpoint today.
 
-## Provider 呈现面
+Clients should only need to change their `base_url` and API key. A client never
+needs to know which provider or model actually executed the request.
+Cross-protocol translation is described in
+[05 · Protocol Translation](05-protocol-translation.md).
 
-Provider 适配器可以支持：
+## Provider-facing surface
 
-- OpenAI 兼容的 provider：OpenRouter、ZenMux、vLLM、DeepSeek、Qwen、本地模型、自定义 endpoint
-- Anthropic 原生
-- Gemini 原生
-- 未来的 OAuth provider，例如 Claude Code、Codex、Copilot，或类似的基于订阅的 provider
+Provider adapters can target:
 
-Provider 别名属于内部的供应链细节。它们不是面向用户的主要产品呈现面。
+- OpenAI-compatible providers: OpenRouter, ZenMux, vLLM, DeepSeek, Qwen, local
+  models, custom endpoints.
+- Anthropic native.
+- Gemini native (future).
+- Future OAuth/subscription providers such as Claude Code, Codex, or Copilot.
 
-## MVP 目标
+Provider aliases are an internal supply-chain detail. They are not the primary
+user-facing surface.
 
-1. 以最小的迁移成本支持标准客户端 API（只改 `base_url` 和 API key）。
-2. 用确定性规则对每个请求做第一层分类；规则不确定时，可选地用小模型评估；都判不出来则落到 balanced。
-3. 通过可配置的 lane 路由请求，而不是直接暴露原始的 provider 别名。
-4. 通过主用和 fallback provider 执行每条 lane。
-5. 记录每一次路由决策和每一次 provider 尝试，以便调试。
-6. 开箱即用：默认三条 lane，默认**不开启** LLM 评估。
-7. 启动时强制存在 API key；不允许匿名访问。
-8. 开源、自托管：Docker 一键部署，配置即代码，不强依赖外部服务（见 [10 · 部署](10-deployment.md)）。
-9. 启动后自带管理界面，做基本规则管理，认证用 HTTP Basic 账号密码（见 [11 · 管理界面](11-admin-ui.md)）。
-10. 将 Memory、Guardrails、Signals、agent 编排以及 IM 控制保持在 MVP 之外。
+## Goals
 
-## 非目标
+1. Support the standard client APIs with minimal migration cost (change only
+   `base_url` and the API key).
+2. Classify every request with deterministic rules (Layer 1); when the rules are
+   uncertain, optionally consult a small-model eval (Layer 2); if nothing decides,
+   fall back to `balanced` (Layer 3).
+3. Route requests through configurable lanes rather than exposing raw provider
+   aliases.
+4. Execute each lane through a primary plus fallback providers.
+5. Record every routing decision and every provider attempt for debugging.
+6. Work out of the box: three default lanes shipped, and the LLM eval **off** by
+   default.
+7. Enforce that an API key exists at startup; no anonymous access.
+8. Open-source and self-hosted: one-command Docker deployment, config-as-code, no
+   hard dependency on external services (see [10 · Deployment](10-deployment.md)).
+9. Ship a management interface for basic rule management, authenticated with HTTP
+   Basic credentials (see [11 · Admin UI](11-admin-ui.md)).
+10. Keep memory as opt-in middleware (see [08 · Memory Middleware](08-memory-middleware.md)).
 
-- 不构建模型市场。
-- 不把上百个 provider 别名作为产品对外的呈现面。
-- 不在路由核心中实现完整的 RAG 产品。
-- 不在 MVP 中实现 Memory（它是 MVP 之后的中间件，见 [08 · 记忆中间件](08-memory-middleware.md)）。
-- 不在 MVP 中构建完整的 agent 编排平台。
-- 第一层路由不依赖黑盒 LLM 分类器（确定性规则优先）。
-- 不把 provider 基准测试作为主要的运行时决策机制。
-- 不做 SaaS、不售卖、不做托管多租户平台（开源自托管，MIT 协议）。
+## Non-goals
 
-## 核心产品闭环
+- Do not build a model marketplace.
+- Do not make hundreds of provider aliases the user-facing surface.
+- Do not implement a full RAG product inside the routing core.
+- Do not make the first routing layer depend on a black-box LLM classifier
+  (deterministic rules come first).
+- Do not use provider benchmarks as the primary runtime decision mechanism.
+- Do not become a SaaS, a hosted multi-tenant platform, or a commercial product
+  (open-source, self-hosted, MIT).
+
+## The core product loop
 
 ```text
 Client request
-  -> Protocol Adapter        # 协议归一化
-  -> Auth / API Key          # 鉴权，启动时强制有 key
-  -> Task Classifier         # 三层分类级联
-  -> Policy / Lane Router     # 选择 lane
-  -> Provider Adapter + Fallback   # 执行 + 链内回退
-  -> Request Log / Debug UI   # 全量遥测
+  -> Protocol Adapter        # normalize the client protocol to the internal IR
+  -> Auth / API Key          # mandatory; a key must exist at startup
+  -> Task Classifier         # the three-layer classification cascade
+  -> Policy / Lane Router    # select a lane
+  -> Provider Adapter + Fallback   # execute + in-chain fallback
+  -> Request Log / Debug UI  # full telemetry
 ```
 
-各组件的职责与数据结构见 [02 · 架构](02-architecture.md)；分类见 [03](03-classification.md)，路由与 lane 见 [04](04-routing-and-lanes.md)。
+Component responsibilities and data structures are in
+[02 · Architecture](02-architecture.md); classification is in
+[03 · Classification Cascade](03-classification.md); routing and lanes are in
+[04 · Routing & Lanes](04-routing-and-lanes.md).

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -1,117 +1,149 @@
-# 02 · 架构
+# 02 · Architecture
 
-## 架构概览
+## Overview
 
 ```text
 Client
-  -> API Gateway
-  -> Auth Resolver               # 强制 API key（启动时引导生成）
-  -> Rate Limiter                # 可选，默认关闭
+  -> API Gateway (Hono)
+  -> Auth Resolver               # mandatory API key (bootstrapped at first start)
+  -> Rate Limiter                # per-key; off by default
   -> Protocol Adapter
-  -> Task Classifier             # 三层级联：rules -> eval -> balanced
+  -> Task Classifier             # three-layer cascade: rules -> eval -> balanced
   -> Policy Engine
   -> Lane Resolver
   -> Capability Filter
   -> Circuit Breaker
   -> Provider Executor
   -> Telemetry / Request Log
-  -> (Memory Middleware)         # MVP 之后；MVP 不接入
+  -> (Memory Middleware)         # observe phase wired on every surface
 ```
 
-定位：Helm 是 **LLM 的 nginx**——声明式配置驱动的模型网关。客户端只见统一标准与输出，模型分配/调度全部由 YAML 配置和上述流水线完成。
+Positioning: Helm is **nginx for LLMs** — a declaratively-configured model
+gateway. Clients see one standard interface and output shape; model assignment
+and dispatch are driven entirely by the YAML configuration and the pipeline above.
 
-## 组件
+The gateway (`apps/gateway`) is a thin Hono adaptation layer. The entire routing
+brain lives in `packages/core` and imports no web framework: `routeRequest` (in
+`packages/core/src/routing/route-request.ts`) is the single framework-agnostic
+orchestrator, so the core can run headless. This separation is principle 1.
 
-各组件此处只列**职责概要**；深入设计见对应专章。
+## Components
+
+Each component is summarized here; deeper design lives in its own chapter.
 
 ### API Gateway
 
-API 网关。职责：
+Built on Hono. Responsibilities:
 
-- 接收标准 API 请求。
-- 规范化请求头和请求 ID。
-- 施加请求大小和超时限制。
-- 转发到正确的协议适配器。
+- Accept the standard API requests on `/v1/chat/completions`, `/v1/messages`, and
+  `/v1/responses`.
+- Normalize request headers and the request/trace id.
+- Apply request-size and timeout limits (`runtime.max_request_bytes`,
+  `runtime.request_timeout_ms`).
+- Dispatch to the correct protocol adapter.
+
+It also serves `/healthz` and `/version`, and (when admin credentials are
+configured) mounts the Admin UI and admin API under `/admin`.
 
 ### Protocol Adapter
 
-协议适配器。职责：归一化各客户端协议为内部请求结构，并把响应转换回客户端协议，保持流式语义。详见 [05 · 协议互译](05-protocol-translation.md)。
+Normalizes each client protocol into the internal IR and translates responses
+back to the client protocol, preserving streaming semantics. See
+[05 · Protocol Translation](05-protocol-translation.md).
 
 ### Auth Resolver
 
-鉴权解析器。职责：解析 API key 身份，附加账户/组织/用户/权限元数据，强制鉴权，遥测中绝不存明文 key。详见 [06 · 鉴权与限流](06-auth-and-rate-limits.md)。
+Resolves an API key to an identity, attaches account/org/user/role and capability
+metadata, and enforces authentication. API keys are stored only as a sha256 hash;
+the plaintext key never appears in telemetry or logs. See
+[06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md).
 
 ### Rate Limiter
 
-限流器（可选，默认关闭）。位于 Auth 之后、分类之前；触发即返回 `rate_limited`。详见 [06](06-auth-and-rate-limits.md)。
+Per-key limiter (`packages/core/src/ratelimit`). Off by default
+(`runtime.rate_limit.enabled`) — a zero-overhead pass-through when disabled. It
+sits **after** auth (it needs the resolved `key_id`) and **before** classification
+(so cost is cut off before any classify/eval call). It enforces both the system
+default and any per-key RPM/TPM override on all three request surfaces. See
+[06](06-auth-and-rate-limits.md).
 
 ### Task Classifier
 
-任务分类器。三层级联（rules → eval → balanced），计算 `task_type`/`complexity`/`confidence`/`constraints`。详见 [03 · 分类级联](03-classification.md)。
+The three-layer classification cascade (rules → optional eval → balanced),
+producing `task_type` / `complexity` / `confidence` / `constraints`. See
+[03 · Classification Cascade](03-classification.md).
 
 ### Policy Engine
 
-策略引擎。职责：
+Applies explicit server-side policies. Responsibilities:
 
-- 应用明确的服务端策略规则。
-- 解析组织/用户/项目级别的覆盖项。
-- 强制执行上限，例如 `max_lane` 或允许的 lane。
-- 为遥测生成单条匹配的策略记录。
+- Walk the policy list in declaration order; the **first** policy whose `match`
+  fully holds wins the lane pin (`use_lane`).
+- Accumulate caps (`max_lane` / `allowed_lanes`) across **every** matching policy,
+  so a cap policy placed after a pin policy still binds.
+- Produce a single matched-policy record for telemetry.
 
 ### Lane Resolver
 
-Lane 解析器。职责：
+Collapses the classifier + policy outcome into exactly one lane. Responsibilities:
 
-- 选择目标 lane。
-- 当缺少特定任务的 lane 时使用默认 lane。
-- 保持声明的 primary/fallback 顺序。
-- 避免将 `*/auto` 提供方别名的评分排在明确指定的 primary 模型之上。
+- Apply the routing priority (policy pin → task lane → complexity-fallback lane).
+- Fall back to `balanced` when the classifier itself fell back, or when no lane
+  resolves.
+- Preserve the lane's declared primary/fallback order (chain expansion happens in
+  the orchestrator, not here).
+
+The resolver itself never trips circuit breakers or calls providers; that is the
+execution stage's job.
 
 ### Capability Filter
 
-能力过滤器。职责：
-
-- 检查 tools 支持情况。
-- 检查 JSON / 结构化输出支持情况。
-- 检查视觉/多模态支持情况。
-- 检查上下文长度。
-- 检查流式支持情况。
-- 返回明确的跳过原因。
+Prunes candidates that cannot satisfy the request (`packages/core/src/capability`).
+It checks tool support, JSON / structured-output support, vision / multimodal
+support, and context length, returning an explicit skip reason. A candidate with
+no catalog entry stays fail-open (it is not over-pruned).
 
 ### Circuit Breaker
 
-熔断器。职责：
+Tracks per-provider-model health (`packages/core/src/circuit`). Responsibilities:
 
-- 跟踪每个提供方/模型的健康状况。
-- 跳过处于 `OPEN` 状态的熔断电路。
-- 在真实调用前使用 `HALF_OPEN` 探测锁。
-- 在收到首个有效的提供方数据块之前记录失败。
-- 仅在收到有效响应/数据块之后记录成功。
-- 将客户端中止视为非提供方故障。
+- Skip a circuit in the `OPEN` state.
+- Use a `HALF_OPEN` probe lock before a real call.
+- Record a failure only **before** the first valid provider chunk; record success
+  only **after** a valid chunk/response.
+- Treat a client abort as a non-provider fault (it never trips the breaker).
 
 ### Provider Executor
 
-提供方执行器。职责：
+Executes candidates in lane order (`packages/core/src/executor`,
+`apps/gateway/src/routes/execute.ts`). Responsibilities:
 
-- 按 lane 顺序执行各提供方。
-- 将请求转换为提供方原生协议。
-- 一致地处理流式和非流式路径。
-- 返回结构化的尝试记录。
+- Walk the candidate chain (primary → fallback[]), in declaration order.
+- Translate the request to the provider's native protocol.
+- Handle streaming and non-streaming paths consistently.
+- Return a structured attempt record per candidate.
 
 ### Telemetry / Request Log
 
-遥测 / 请求日志。职责：持久化路由决策、提供方尝试链、鉴权/key 身份、成本与延迟；脱敏密钥与私有载荷。错误模型与 Debug UI 见 [07 · 可观测性](07-observability.md)。
+Persists the routing decision, the provider-attempt chain, the auth/key identity,
+and cost & latency. Secrets are redacted; the decision record carries no message
+bodies. Full request/response payloads are captured separately (governed by the
+`capture_payloads` runtime setting, on by default) into a dedicated payload store
+and aged out per `payload_retention_days`. The error model and Debug UI are in
+[07 · Error Model & Observability](07-observability.md).
 
-## 内部请求结构
+## Internal request shape
+
+The normalized `InternalRequest` that every protocol adapter produces:
 
 ```yaml
 request_id: string
-protocol: openai_chat | anthropic_messages | openai_responses | gemini
+protocol: openai_chat | anthropic_messages | openai_responses
 account_id: string
 api_key_id: string
 user_id: string | null
 org_id: string | null
-requested_model: string
+requested_model: string         # "auto" means "let the router decide"
 messages: array
 tools: array | null
 response_format: object | null
@@ -119,25 +151,35 @@ attachments: array | null
 max_tokens: number | null
 stream: boolean
 metadata:
-  conversation_id: string | null
-  # 以下 memory 字段在 MVP 中仅预留，不接入（见 08-memory-middleware.md）
+  conversation_id: string | null   # from x-session-key; drives session momentum
+  # memory-scope fields (docs/08), parsed from request headers:
   thread_id: string | null
   resource_id: string | null
   project_id: string | null
   memory_mode: off | observe | inject
 ```
 
-## 决策记录
+> Note: `protocol` is one of the three wired protocols. A Gemini value is not
+> emitted today (the Gemini transformer is unrouted; see
+> [01 · Overview](01-overview.md)).
+
+## Decision record
+
+Every routed request produces a redacted `DecisionRecord` (no message bodies),
+which feeds telemetry and the Debug UI:
 
 ```yaml
 request_id: string
+trace_id: string
 requested_model: string
+key_prefix: string | null          # display prefix only, never the plaintext key
 classifier:
   task_type: string
   complexity: string
   confidence: number
-  decided_by: rules | eval | default   # 哪一层定的 lane
-  eval_cache_hit: boolean | null       # 触发 eval 时是否命中缓存
+  decided_by: rules | eval | default | fallback   # which layer picked the lane
+  eval_cache_hit: boolean | null     # only meaningful when eval ran
+  fallback_reason: string | null     # eval_disabled / eval_<reason> (only on "fallback")
   constraints: object
   explanation: array
 policy:
@@ -145,48 +187,80 @@ policy:
   reason: string
 lane:
   selected_lane: string
-  candidate_chain: array
+  candidate_chain: array             # expanded primary + fallback aliases
 provider_attempts:
   - alias: string
     skipped: boolean
-    skip_reason: string | null
+    skip_reason: string | null       # circuit_open | capability:<reason> | free_429 | ...
     status: ok | error
     error_class: string | null
     latency_ms: number
     cost_usd: number | null
+    error_detail: object | null      # redacted upstream failure detail
 final:
   model_alias: string | null
   provider_model: string | null
   status: ok | error
   error_reason: string | null
+latency_total_ms: number
+fallback_count: number               # EXECUTION-stage swaps (served attempts - 1)
+cost_breakdown:
+  eval_usd: number | null            # Layer-2 small-model self-cost
+  completion_usd: number | null      # sum of served attempts' cost
+  total_usd: number | null
 ```
 
-## 配置文件
+`decided_by` describes **only** the classification stage. The execution-stage
+provider fallback is a separate mechanism recorded under `provider_attempts` /
+`fallback_count`; the two fallbacks are never conflated (principle 5). See
+[04 · Routing & Lanes](04-routing-and-lanes.md).
 
-预期的配置拆分：
+## Configuration files
+
+Configuration lives in `config/` and is loaded and Zod-validated at startup. An
+invalid file fails closed: the gateway refuses to boot (principle 2).
 
 ```text
 config/
-  lanes.yaml           # 默认 lane 与任务 lane 的定义
-  policies.yaml        # 服务端路由策略
-  classifier.yaml      # 分类器：rules 维度/权重/阈值 + eval 小模型与缓存
-  providers.yaml       # 提供方别名与凭证引用
-  capabilities.yaml    # 模型/提供方能力元数据
-  pricing.yaml         # 定价元数据与覆盖项
-  auth.yaml            # require_api_key + 启动引导 key（或经环境变量/DB）
+  lanes.yaml           # default lanes + task lanes (the lane abstraction)
+  policies.yaml        # server-side routing policies
+  classifier.yaml      # Layer-1 rule dimensions/weights/boundaries + Layer-2 eval + cache
+  providers.yaml       # provider aliases and credential (env-var) references
+  capabilities.yaml    # manual capability overrides over the generated catalog
+  pricing.yaml         # manual pricing overrides over the generated catalog
+  auth.yaml            # require_api_key + admin auth source
+  runtime.yaml         # store driver, rate limit, timeouts, request size, payload capture
+  server.yaml          # host / port
 ```
 
-## 安全规则
+Capability and pricing data originate from a checked-in **generated catalog**
+(`packages/core/src/catalog/generated/catalog.json`), synced from upstream and
+treated as a supply-chain input. At runtime, manual entries in `capabilities.yaml`
+/ `pricing.yaml` override the generated catalog per field. The catalog is never
+fetched at runtime.
 
-- 生产环境路由仅使用激活的 lane 和激活的允许列表（allowlist）。
-- 目录（catalog）元数据绝不直接进入运行时选择。
-- 提供方 auto 别名是 fallback 末端，除非另有明确配置。
-- 生成的目录属于供应链输入，而非策略。
-- 调试 UI 必须解释某个提供方为何被选中或被跳过。
-- 密钥绝不能以明文记录。
+## Security rules
 
-## 管理面与部署
+- Production routing uses only active lanes and active allowlists.
+- Generated catalog metadata never directly drives runtime selection.
+- Provider `*/auto` aliases sit only at the tail of a fallback chain unless
+  explicitly configured otherwise.
+- The generated catalog is a supply-chain input, not policy.
+- The Debug UI must explain why a provider was selected or skipped.
+- Secrets are never logged in plaintext; API keys are stored as a sha256 hash.
 
-除请求流水线外，Helm 还有一个**管理面**（Admin UI）：一个 Web 控制台，做基本规则管理（lane / policy / classifier / key）与请求调试。它独立于 API 流量，认证用 HTTP Basic 账号密码（配置文件 / 环境变量）。详见 [11 · 管理界面](11-admin-ui.md)。
+## Admin surface and deployment
 
-部署形态：**开源、自托管，Docker 一键部署**，配置即代码，默认本地存储、不强依赖外部服务。详见 [10 · 部署](10-deployment.md)。
+Beyond the request pipeline, Helm has a **management plane** (Admin UI): a web
+console for basic rule management (lanes / policies / classifier / keys) and
+request debugging, plus a "System Settings" page for runtime-mutable settings
+(payload capture, retention, the rate-limit switch, log level) that apply without
+a restart. It is independent of API traffic and authenticated with HTTP Basic
+credentials (file / environment). The admin surface is mounted **only** when
+credentials are configured; otherwise `/admin` and `/admin/api` return 404. See
+[11 · Admin UI](11-admin-ui.md).
+
+Deployment: **open-source, self-hosted, one-command Docker**, config-as-code,
+local storage by default (SQLite), no hard dependency on external services. A
+Supabase/Postgres store driver is also supported. See
+[10 · Deployment](10-deployment.md).

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -1,33 +1,47 @@
-# 03 · 分类级联
+# 03 · Classification Cascade
 
-## 分类级联（Classification cascade）
+## The classification cascade
 
-这是 Helm 的核心。请求进入后，按三层顺序决定 lane，命中即停：
+This is Helm's core. When a request arrives, the cascade decides a lane in three
+ordered layers, stopping at the first one that commits (hit-stop):
 
 ```text
-请求进入
-  → 第 1 层：确定性规则（rules）            [始终开启，零成本、零延迟]
-        命中且 confidence ≥ 阈值 → 直接进对应 lane
-  → 第 2 层：小模型评估（eval）              [默认关闭，带缓存]
-        小模型判出 complexity / task_type → 进对应 lane
-  → 第 3 层：兜底 → balanced lane           ← 永远安全的默认
+Request in
+  → Layer 1: deterministic rules            [always on; zero cost, zero latency]
+        confidence ≥ threshold → go straight to the resolved lane
+  → Layer 2: small-model eval               [OFF by default; cached]
+        the small model decides complexity / task_type → resolved lane
+  → Layer 3: fallback → balanced lane       ← always-safe default
 ```
 
-**关键区分：两种 fallback 是两件事，必须分开记录。**
+The cascade itself is framework-agnostic
+(`packages/core/src/classifier/cascade.ts`), driven by the live, Zod-validated
+configuration in `config/classifier.yaml`. With the default config
+(`eval.enabled: false`), the cascade degrades to the two-layer "rules + balanced"
+path — Layer 2 is a pure additive switch.
 
-- **分类兜底（classification fallback）**：我不知道这是什么任务 → 落到 balanced lane。
-- **执行兜底（provider fallback）**：选中的 provider 挂了 / 超时 / 限流 → 走 lane 链内的下一个 model。
+**Key distinction: the two fallbacks are different things and are recorded
+separately.**
 
-第一个发生在"选 lane"阶段，第二个发生在"执行 lane"阶段。两套机制、两套日志字段，绝不能混淆。执行兜底见 [04 · 路由与 Lane](04-routing-and-lanes.md)。
+- **Classification fallback**: "I cannot tell what this task is" → fall to the
+  `balanced` lane. Recorded as `decided_by: fallback` (with a precise
+  `fallback_reason`).
+- **Execution fallback** (provider fallback): "the selected provider failed /
+  timed out / was rate-limited" → try the next model in the lane chain. Recorded
+  under `provider_attempts` / `fallback_count`.
 
-## 任务分类
+The first happens while *choosing* a lane; the second happens while *executing*
+one. Two mechanisms, two sets of log fields — never conflated (principle 5).
+Execution fallback is covered in [04 · Routing & Lanes](04-routing-and-lanes.md).
 
-分类器输出：
+## Classifier output
+
+The classifier produces:
 
 ```yaml
 complexity: simple | standard | complex | reasoning
-task_type: chat | coding | math | writing | extraction | tool_use | vision | web | data
-confidence: number          # [0,1]，低于阈值则进入下一层
+task_type: chat | coding | math | writing | extraction | tool_use | vision | web | data | security
+confidence: number          # [0,1); below the threshold cascades to the next layer
 constraints:
   needs_tools: boolean
   needs_json: boolean
@@ -37,57 +51,115 @@ constraints:
   low_cost: boolean
 ```
 
-分类器的输入可以使用：
+> The classifier emits four complexity tiers (`simple | standard | complex |
+> reasoning`). For lane routing these collapse to three: `standard → medium`,
+> and both `complex` and `reasoning → complex` (see
+> `apps/gateway/src/routes/classify.ts`). The `reasoning` tier is parked high in
+> the score distribution to keep the high-score cluster away from any boundary; it
+> does not change lane routing.
 
-- 当前用户消息
-- 最近的若干条消息
-- 工具定义
-- 响应格式
-- 最大 token 目标
-- 附件 / 多模态元数据
+The classifier's inputs are the last user message and recent messages, the tool
+definitions, the response format, the max-token target, and attachment / vision
+metadata.
 
-## 第 1 层：确定性规则（参考 Manifest）
+## Layer 1: deterministic rules
 
-第一层是本地、确定性、零成本的加权评分，借鉴开源 Manifest 模型路由器的设计：
+Layer 1 is a local, deterministic, zero-cost weighted scorer
+(`packages/core/src/classifier/`, the `dimensions` → `momentum` → `tiers` →
+`overrides` → `taskdetect` pipeline composed by `engine.ts`). It is a pure
+function fed by the already-parsed config (principle 4), and every sub-step is
+wrapped so a degenerate input yields a safe default instead of throwing
+(fail-open).
 
-- **加权维度评分**：一组关键词 / 结构 / 上下文维度，每个维度有权重和方向，累加成一个 `rawScore`。
-- **四档复杂度**：用固定边界把分数映射到 `simple | standard | complex | reasoning`。
-- **任务检测**：按关键词集合、工具名前缀、结构信号（URL、代码块、文件路径、堆栈）识别 `coding / web / data / vision` 等任务类型。
-- **会话动量（momentum）**：短的后续消息按历史会话倾向加权，避免单条短消息把分类带偏。
-- **硬覆盖与捷径**：心跳类（如 `HEARTBEAT_OK`）直接判 simple；形式逻辑关键词直接判 reasoning；带 tools 的请求下限为 standard；超长上下文（如 > 50k token）下限为 complex。
-- **置信度闸门**：`confidence = 2·sigmoid(k·到最近边界的距离) − 1`，归一化到 `[0,1)`——贴边界（距离→0）≈0（最不确定），远离边界≈1（最确定）；低于阈值（默认 `0.45`）视为"不确定"，进入第 2 层。（注：旧实现用裸 `sigmoid`，落域 `[0.5,1)`，默认阈值 0.45 永不触发——已由 `classifier.confidence-fix` 修正，见 implementation-notes。）
+- **Weighted dimension scoring** (`dimensions.ts`): a set of keyword,
+  structural, and context dimensions, each with a weight (the sign is the
+  direction) and a `[0,1]` signal strength. Their contributions sum to a
+  `rawScore`. Keyword dimensions and their weights are data in
+  `classifier.yaml`; structural-signal detectors (code block, URL, stack trace,
+  file path, math notation, table, JSON response format, etc.) are code.
+- **Four complexity tiers** (`tiers.ts`): fixed half-open boundaries map the
+  `rawScore` onto `simple | standard | complex | reasoning`.
+- **Task detection** (`taskdetect.ts`): three independent evidence paths fuse —
+  keyword sets (data), tool-name prefixes (data, e.g. `browser_` / `code_` /
+  `sql_`), and structural signals (code). The highest score that clears its
+  activation threshold wins; otherwise the task is `chat`. Some tasks have a
+  raised activation threshold (e.g. `web` and `security`) so a single weak signal
+  cannot false-trigger them.
+- **Session momentum** (`momentum.ts`): a short follow-up message is weighted by
+  the session's recent classification history (keyed by
+  `metadata.conversation_id`, which maps from the `x-session-key` header) so one
+  short message does not drag classification off course. It is best-effort soft
+  state held only as `complexity` / `rawScore` / timestamp — never message
+  content.
+- **Hard overrides and shortcuts** (`overrides.ts`): heartbeat tokens (e.g.
+  `HEARTBEAT_OK`) snap to `simple`; formal-logic markers snap to `reasoning`; a
+  request carrying tools has a floor of `standard`; a very long context
+  (`long_context_token_threshold`) raises the floor to `complex`.
+- **Confidence gate** (`tiers.ts`): confidence is computed as
+  `2·sigmoid(k·distance-to-nearest-boundary) − 1`, normalized to `[0,1)` — a
+  score hugging a boundary (distance → 0) is ≈ 0 (most uncertain), a score far
+  from any boundary approaches 1 (most certain). When confidence is below
+  `rules.confidence_threshold`, Layer 1 is treated as uncertain and the cascade
+  enters Layer 2 (if eval is enabled), otherwise Layer 3.
 
-可移植性：维度名/权重/关键词列表/边界/阈值都是**数据**，应当放进 `classifier.yaml`，可调而不需改代码；少量结构信号正则和控制流是代码实现。具体维度/阈值见 [调研笔记](research-notes.md)。
+### Tunables live in config
 
-## 第 2 层：小模型评估（LLM eval）
+Dimension names, weights, keyword lists, tier boundaries, the sigmoid slope `k`,
+and the confidence threshold are all **data** in
+[`config/classifier.yaml`](../config/classifier.yaml) — adjust them without
+touching code (principle 2). The shipped values are calibrated against a golden
+prompt set; rather than reproduce numbers that drift, read the live file. As of
+the calibration that ships with 0.1, the salient values are
+`confidence_threshold: 0.42`, `sigmoid_k: 12`, and tier boundaries
+`{ standard: -0.06, complex: 0.30, reasoning: 0.85 }`. Treat `classifier.yaml` as
+the source of truth.
 
-当第 1 层不确定时，用一个便宜的小模型对内容做一次评估，结果决定 lane。**默认关闭**。
+## Layer 2: small-model eval
+
+When Layer 1 is uncertain (and `eval.enabled` is true), a cheap small model
+evaluates the content once, and its verdict decides the lane. It is **off by
+default**. The relevant block of `config/classifier.yaml`:
 
 ```yaml
 classifier:
   rules:
     enabled: true
-    confidence_threshold: 0.45     # 低于此值才进入 eval
+    confidence_threshold: 0.42     # below this, the cascade may enter eval
 
   eval:
-    enabled: false                 # 默认关闭
-    model: deepseek/deepseek-v4-flash   # 便宜、快、JSON 可靠；可替换
+    enabled: false                 # OFF by default (non-negotiable)
+    model: deepseek-flash          # cheap, fast, reliable JSON; sent directly to the primary provider
     temperature: 0
-    max_tokens: 256                # 只输出一个 JSON，封顶成本
-    timeout_ms: 300                # 超时即放弃，不阻塞主路径
-    on_failure: balanced           # 超时/解析失败 → 默认 lane
+    max_tokens: 256                # one JSON object; caps the cost
+    timeout_ms: 250                # inner runner timeout
+    outer_timeout_ms: 350          # outer backstop (strictly later than the inner)
+    on_failure: balanced           # timeout / parse failure → balanced
     cache:
       enabled: true
-      key: content_hash            # 规范化(最后用户消息 + tools 签名)
-      ttl_sec: 300                 # 不必每次都评估
+      key: content_hash            # canonical(last user message + tools signature, …)
+      ttl_sec: 300
+      max_entries: 5000            # LRU capacity
 ```
 
-设计要点（借鉴 llm-router 的 probe，但改为可决策）：
+Design notes:
 
-- 输出严格 JSON：`{ complexity, task_type, confidence }`，校验失败即 fail-open 到 `balanced`。
-- `temperature: 0`、非流式，结果可缓存。
-- 与 llm-router 的 probe 不同：probe 是"仅咨询、不改路由"；Helm 的 eval 是"可决策"——它的输出直接选 lane。
-- 缓存按 **content-hash**（而非 conversation_id），因为网关是无状态的；同样/相似请求命中缓存，不重复评估。
-- 评估调用本身也经过一个 provider，因此它在配置上是一个内部的小模型，不属于对外的三条 lane。
+- The eval output is strict JSON `{ complexity, task_type, confidence }`; a
+  validation failure fails open to `balanced`.
+- `temperature: 0`, non-streaming, and cacheable.
+- The verdict is **decisive**: unlike a pure advisory probe, the eval output
+  directly selects a lane.
+- The cache key is a **content hash** (not a `conversation_id`), since the gateway
+  is stateless. Identical or near-identical requests hit the cache and skip a
+  repeat eval. The cache is held per process and is rebuilt whenever the live
+  classifier config changes (so a stale verdict computed under old config is never
+  served).
+- The eval call goes through the primary provider as an internal small-model call
+  (the eval model id is sent directly on the wire); it is not one of the
+  user-facing lanes. Its own token usage is converted to a separate `eval_usd`
+  cost, kept distinct from completion cost (see
+  [07 · Error Model & Observability](07-observability.md)).
 
-probe 复用细节见 [调研笔记](research-notes.md)。
+Whenever the cascade falls to `balanced`, the decision record distinguishes why:
+`eval_disabled` (uncertain but eval is off, so no Layer 2 ran) versus
+`eval_<timeout|provider_error|circuit_open|not_json|schema_invalid>` (eval ran but
+failed open).

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -1,113 +1,185 @@
-# 04 · 路由与 Lane
+# 04 · Routing & Lanes
 
-分类（见 [03](03-classification.md)）产出 `task_type`/`complexity`/`constraints` 后，路由层据此选出一条 lane，再按 lane 的有序链路执行。
+Once classification ([03](03-classification.md)) has produced `task_type` /
+`complexity` / `constraints`, the routing layer selects one lane and then executes
+its ordered chain. The framework-agnostic orchestrator is `routeRequest`
+(`packages/core/src/routing/route-request.ts`); lane selection is in
+`routing/lane-resolver.ts` and policy evaluation in `routing/policy-engine.ts`.
 
-## Lane 路由优先级
-
-路由优先级顺序：
+## Lane routing priority
 
 ```text
-explicit model/lane           # 客户端显式指定，跳过一切规则
-  > server-side custom policy  # 服务端策略
-  > task-specific lane         # 任务专属 lane
-  > complexity fallback lane   # 复杂度兜底 lane
+explicit model/lane           # client specified a concrete model; skips all rules
+  > server-side policy         # a policy pin (use_lane)
+  > task-specific lane         # a lane named after the detected task_type
+  > complexity-fallback lane   # simple→economy / medium→balanced / complex→premium
 ```
 
-默认 lane 应当数量少且易于理解。
+Default lanes are deliberately few and easy to reason about. Any selected lane
+name that does not exist is skipped (fail-open); the terminal `balanced` is
+guaranteed to exist.
 
-## 默认 lane
+### Explicit client model has the highest priority
+
+When a client specifies a concrete model, classification and policy are skipped
+and the model is executed directly (the nginx pass-through equivalent). Whether
+this is allowed is controlled by the key's `allow_custom_model` capability (see
+[06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md)). The sentinel
+value `auto` is never treated as an explicit model — it means "let the router
+decide" and falls through to classification.
+
+## Lanes
+
+Lanes are defined in [`config/lanes.yaml`](../config/lanes.yaml) and validated by
+`LanesConfigSchema` at load time — an invalid file fails the gateway boot
+(principle 2). A lane is a declarative chain: a `primary` plus an ordered
+`fallback[]`, where each element is either a model **alias** (`provider/model`,
+resolved via `config/providers.yaml`) or the name of another lane (expanded
+recursively, deduped, cycle-safe). Optional `constraints` drive the Capability
+Filter (`require_tools` / `require_json` / `require_vision`).
+
+The shipped quality/cost lanes:
 
 ```yaml
 economy:
   purpose: Cheap and fast for simple tasks
-  primary: cheap_model
-  fallback: [balanced_model]
+  primary: openai-crs/gpt-5.4-mini
+  fallback: [deepseek-crs/deepseek-flash, balanced]
 
 balanced:
-  purpose: Default quality/cost tradeoff
-  primary: default_good_model
-  fallback: [premium_model, economy_model]
+  purpose: Default quality/cost tradeoff (classification fallback terminal)
+  primary: deepseek-crs/deepseek-pro
+  fallback: [openai-crs/gpt-5.4-mini, zenmux/auto, openrouter/auto]
 
 premium:
   purpose: Strong reasoning and high quality
-  primary: best_reasoning_model
-  fallback: [balanced_model]
+  primary: openai-crs/gpt-5.5
+  fallback: [zenmux/claude-opus-4.7, zenmux/auto, openrouter/auto]
 ```
 
-`balanced` 永远必须配置且健康——它是分类兜底的终点。
+`balanced` is **required** and must be healthy — it is the terminal of the
+classification fallback.
 
-## 可选的任务 lane
+The shipped task lanes (the lane resolver maps a classified `task_type` onto a
+same-named lane):
 
 ```yaml
 coding:
-  primary: coding_model
+  purpose: Coding-capable models for code generation / editing
+  primary: openai-crs/gpt-5.3-codex-spark
   fallback: [premium, balanced]
 
+json:
+  purpose: Strict structured-output (JSON) responses
+  primary: openai-crs/gpt-5.4-mini
+  fallback: [balanced]
+  constraints:
+    require_json: true
+
 vision:
-  primary: vision_model
+  purpose: Multimodal / image understanding
+  primary: zenmux/gemini-3.5-flash
   fallback: [premium]
+  constraints:
+    require_vision: true
 
 tool_use:
-  primary: tool_capable_model
+  purpose: Reliable function / tool calling
+  primary: openai-crs/gpt-5.5
   fallback: [premium]
-
-json:
-  primary: strict_json_model
-  fallback: [balanced]
+  constraints:
+    require_tools: true
 ```
 
-如果没有配置任务专属的 lane，路由器会回退到三条默认 lane。
+If no task-specific lane is configured, the resolver falls back to the three
+default lanes by complexity (`simple → economy`, `medium → balanced`, `complex →
+premium`).
 
-## 策略配置
+Note the deliberate design where each lane's tail fallback is a `*/auto` alias
+(e.g. `zenmux/auto`, `openrouter/auto`). Those auto aliases are intentionally
+JSON-incapable in the catalog, so a strict-JSON request prunes them via the
+Capability Filter and lands on a deterministic JSON-capable model — proving the
+filter fires on the default config. `*/auto` aliases live only at the tail.
 
-策略（Policy）让你在不修改客户端代码的情况下进行服务端定制。
+## Policies
 
-示例：
+Policies (`config/policies.yaml`) let operators customize routing server-side
+without touching client code. Each policy is a **first-match** rule: the engine
+walks the list top-to-bottom, and the first policy whose `match` fully holds (an
+AND of every written field) wins the lane pin. A policy must declare at least one
+action — a pin (`use_lane`) and/or a cap (`max_lane` / `allowed_lanes`). The file
+is `.strict()`-validated, so a typo in a field name fails the gateway boot.
+
+Caps behave differently from pins: while the **first** matching policy wins the
+pin, caps **accumulate** across every matching policy (intersect `allowed_lanes`,
+keep the strictest `max_lane`), so a cap policy placed after a pin policy still
+binds.
+
+The shipped policies illustrate the pattern (`task_type × complexity → lane`,
+plus a JSON-contract pin and a budget-org cap):
 
 ```yaml
 policies:
-  - match:
-      task_type: coding
-      complexity: complex
-    use_lane: coding
-
-  - match:
-      needs_json: true
+  - id: json_constrained_to_json_lane     # JSON is a hard output contract; kept first
+    match: { needs_json: true }
     use_lane: json
 
-  - match:
-      user_id: vip_user
+  - id: coding_complex_to_coding_lane
+    match: { task_type: coding, complexity: complex }
+    use_lane: coding
+
+  - id: math_complex_to_premium
+    match: { task_type: math, complexity: complex }
     use_lane: premium
 
-  - match:
-      org_id: low_cost_org
+  - id: chat_simple_to_economy
+    match: { task_type: chat, complexity: simple }
+    use_lane: economy
+
+  - id: budget_org_cap                     # caps-only; clamps the classified lane
+    match: { org_id: budget_org }
     max_lane: balanced
 ```
 
-策略必须保持显式且可检视。它不应把难以调试的模型打分行为藏在某种魔法背后。
+Policies must stay explicit and inspectable; there is no hidden, hard-to-debug
+model scoring behind them. Note that the policy `complexity` field uses the
+collapsed routing tiers (`simple | medium | complex`), matching the classifier's
+mapped output (see [03](03-classification.md)).
 
-**客户端显式指定模型**优先级最高：当客户端直接指定一个具体模型时，跳过分类与策略，直接执行（等价于 nginx 的直通）。是否允许由 key 的 `allow_custom_model` 控制，见 [06](06-auth-and-rate-limits.md)。
+## Caps: policy then key
 
-## 执行模型
+Two cap layers apply, in order:
 
-每条 lane 都有一条声明好的有序链路：
+1. **Policy caps** narrow the resolver's lane choice (`max_lane` /
+   `allowed_lanes`).
+2. **Per-key caps** apply **last** as the outer, non-negotiable bound from the
+   API key's auth record, so a key confined to (for example) `maxLane: economy`
+   is honored even over a policy `use_lane` pin. See
+   [06](06-auth-and-rate-limits.md).
 
-```yaml
-lane:
-  primary: model_a
-  fallback:
-    - model_b
-    - model_c
-  constraints:
-    require_tools: true
-    require_json: false
-    max_latency_ms: 30000
-```
+## Execution model and the two fallbacks
 
-执行规则：
+The selected lane is expanded into an ordered candidate chain (primary →
+fallback[], with lane references expanded recursively). The executor
+(`packages/core/src/executor/fallback.ts`) then walks the chain:
 
-1. 先尝试 primary。
-2. 跳过不满足能力约束（capability constraints）的候选。
-3. 当遇到 provider 错误、超时、限流，或熔断器处于打开状态时，尝试下一个 fallback。
-4. 如果所有候选都失败，返回一个结构化错误（见 [07 · 可观测性](07-observability.md)）。
-5. 记录每一次尝试，包含原因和耗时。
+1. Try the primary.
+2. Skip a candidate the Capability Filter rejects (with an explicit skip reason).
+3. Skip a candidate whose circuit breaker is `OPEN`.
+4. On a provider error, timeout, or rate limit before the first valid chunk,
+   record the failure on the breaker and try the next candidate.
+5. A `:free` alias that returns 429 is skipped without recording a breaker failure
+   (free-tier throttling is not a health signal).
+6. A client abort terminates the chain as a non-provider fault — it records
+   neither a failure nor a success and is **not** counted as
+   `all_providers_failed`.
+7. If every candidate fails, return a structured `all_providers_failed` error; an
+   empty chain returns `lane_unavailable` (see
+   [07 · Error Model & Observability](07-observability.md)).
+8. Record every attempt with its reason and latency.
+
+This in-chain model swap is the **execution fallback** — it never rewrites the
+lane. The **classification fallback** (→ `balanced`) is the separate mechanism
+from [03](03-classification.md). Their fields in the decision record are distinct:
+classification fallback shows up as `classifier.decided_by` / `fallback_reason`,
+while execution fallback shows up as `provider_attempts` / `fallback_count`.

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -1,30 +1,90 @@
-# 05 · 协议互译
+# 05 · Protocol Translation
 
-Protocol Adapter 把多种客户端协议与任意上游 provider 协议互译，让客户端只见统一的标准与输出。各协议互译的开源参考、覆盖矩阵与坑位清单见 [调研笔记](research-notes.md)。
+The Protocol Adapter translates between client protocols and arbitrary upstream
+provider protocols, so a client always sees one standard interface and output
+shape. Open-source references, the coverage matrix, and the footgun checklist are
+in [Research Notes](research-notes.md). The implementation lives in
+`packages/core/src/protocol/`.
 
-## 职责
+## Wired protocols
 
-- 将 OpenAI / Anthropic / Responses / 未来的 Gemini 请求归一化为统一的内部请求结构。
-- 将提供方的响应转换回客户端所请求的协议。
-- 保持流式语义（SSE 事件跨协议映射）。
+Three client protocols are wired and routed in 0.1:
 
-## 设计
+| Endpoint | Protocol | Streaming |
+|----------|----------|-----------|
+| `POST /v1/chat/completions` | OpenAI Chat Completions | Yes (SSE) and non-stream |
+| `POST /v1/messages` | Anthropic Messages | Yes (SSE) and non-stream |
+| `POST /v1/responses` | OpenAI Responses | **Non-streaming only** |
 
-以 **musistudio/llms** 为架构蓝本，**litellm** 作正确性规范；不抄代码，自行重写。
+For **OpenAI Responses**, streaming is not yet implemented: there is no Responses
+SSE (`response.*` event) transformer, so a `stream:true` request is rejected with
+a structured `400 invalid_request` ("streaming is not yet supported on
+/v1/responses; retry with stream:false") rather than being silently mis-served
+(fail-closed, principle 2). The non-streaming path is fully wired and routed. See
+`apps/gateway/src/routes/responses.ts`.
 
-- **统一中枢（IR）用 OpenAI Chat 形态**，扩展 thinking/推理块、多部件 content、tool-call ID、`provider_raw` 透传袋（装上游原生 `stop_reason`/`usage`）。
-- **每协议一个类、5 方法契约**（`transformRequestOut/In`、`transformResponseOut/In`、`endPoint`），入站+出站同处一文件。
-- **翻译永远 `nativeIn → IR → nativeOut`**，绝不 N×N 直连（N 协议 = 2N 变换函数）。
-- **流式 = 显式状态机**：content-block index 分配器、tool-call-index→block-index 映射、临时 id→真 id 升级、幂等关闭守卫；为缓存命中/非流式上游提供 JSON→SSE 合成器。
-- **横切关注点做成可叠加 transformer**（max-token 钳制、tool-use 归一、reasoning 注入）。
+A **Gemini** transformer exists in `packages/core/src/protocol/gemini/`, but it is
+**not** exported from the core entry point and **not** routed to any endpoint.
+Native Gemini support (request/response plus a streaming state machine) is on the
+roadmap; it is not a usable endpoint today. See [09 · Roadmap](09-roadmap.md).
 
-## 必须处理的坑
+## Responsibilities
 
-- finish_reason / stop_reason 枚举错配（映射成合法枚举 **并** 把原始值存进 `provider_raw`）。
-- usage 字段翻译与缓存计费（`input = prompt − cached`，流式末事件 buffer usage）。
-- tool-call 流式的 index/ID 协调（维护映射、临时 id 后补升级、容忍残缺 JSON）。
-- 流式 block/part ID 与 role 一致性（先 start 再 delta 后 stop；OpenAI 首片带 `role:"assistant"`）。
-- system 提示与多模态结构错配（Anthropic 顶层 `system`、禁连续同角色；图像 `image_url` vs `source:{base64}`）。
-- Responses API item 展开（照 litellm 的 spec 补齐）。
+- Normalize each wired client request (OpenAI Chat / Anthropic Messages / OpenAI
+  Responses) into the unified internal representation (IR).
+- Translate the provider's response back to the protocol the client requested.
+- Preserve streaming semantics — mapping SSE events across protocols where
+  streaming is supported.
 
-错误也要按客户端协议形态翻译，见 [07 · 可观测性](07-observability.md)。
+## Design
+
+The architecture is modeled on `musistudio/llms`, with `litellm` as the
+correctness reference; the code is a clean reimplementation, not a copy.
+
+- **The IR uses the OpenAI Chat shape as its hub**
+  (`packages/core/src/protocol/ir.ts`), extended with thinking/reasoning blocks,
+  typed multipart content (text/image/thinking), tool-call IDs, cache-control,
+  and a `provider_raw` passthrough bag that carries upstream-native fields (raw
+  `stop_reason` / `usage`) that cannot be mapped losslessly. The IR is the single
+  Zod type source for the whole protocol layer.
+- **One class per protocol, a five-member contract**
+  (`transformRequestOut` / `transformResponseOut` / `transformRequestIn` /
+  `transformResponseIn` / `endPoint`; see `protocol/transformer.ts`), with inbound
+  and outbound translation in the same file.
+- **Translation always goes `nativeIn → IR → nativeOut`**, never N×N direct
+  conversion (N protocols need 2N transform functions, not N²).
+- **Streaming is an explicit state machine** (`protocol/streaming.ts` plus the
+  per-direction machines, e.g. `protocol/anthropic/stream.ts`): a monotonic
+  content-block index allocator, an OpenAI-tool-index → Anthropic-block-index map,
+  a temp-id → real-id upgrade table, and idempotent close guards. A JSON → SSE
+  synthesizer (`synthesizeSSE`) covers cache hits and non-streaming upstreams so a
+  streaming client is none the wiser.
+- **Cross-cutting concerns are stackable behavior transformers** (max-token
+  clamping, tool-use normalization, reasoning injection) that operate on the IR
+  only.
+
+## Footguns that are handled
+
+These are the protocol-translation pits the implementation and its tests cover:
+
+- **finish_reason / stop_reason enum mismatches** — mapped to a legal enum **and**
+  the original value is kept in `provider_raw`.
+- **Usage fields and cache billing** — `input = prompt − cached`; usage is
+  buffered to the terminal stream event so a cache read is not double-counted.
+- **Tool-call streaming index/ID reconciliation** — maintain the index→block map,
+  upgrade a temporary id once the real id arrives on a later fragment, and
+  tolerate fragmented/partial argument JSON.
+- **Stream block/part ID and role consistency** — `start` before `delta` before
+  `stop`; the first OpenAI chunk carries `role: "assistant"`.
+- **System prompt and multimodal structural mismatches** — Anthropic's top-level
+  `system`, the ban on consecutive same-role messages, and image `image_url` vs
+  `source: {base64}`.
+- **Responses API item expansion** — the flat `input[]` item stream folds into the
+  IR and explodes back out.
+- **Idempotent stream close** — every `content_block_stop` and `message_stop` is
+  emitted at most once, guarding against the "controller already closed" bug.
+
+Errors are also translated into each client protocol's native shape (the OpenAI
+error envelope for `/v1/chat/completions` and `/v1/responses`, the Anthropic error
+envelope for `/v1/messages`). See
+[07 · Error Model & Observability](07-observability.md).

--- a/docs/06-auth-and-rate-limits.md
+++ b/docs/06-auth-and-rate-limits.md
@@ -1,57 +1,161 @@
-# 06 · 鉴权、API Key 与限流
+# 06 · Auth, API Keys & Rate Limits
 
-## 鉴权与 API Key
+> Status: **implemented (0.1)**. Mandatory API-key auth, root-key bootstrap, and
+> per-key rate limits all ship in the gateway.
 
-Helm 默认**不允许匿名访问**。
+Helm never allows anonymous access. Every request to the API surface
+(`/v1/chat/completions`, `/v1/messages`, `/v1/responses`) must carry a valid
+API key. The admin UI is a separate surface with its own HTTP Basic credentials
+(see [11 · Admin UI](11-admin-ui.md)).
 
-- `require_api_key: true`：所有请求都必须带 key。
-- **启动引导（bootstrap）**：服务启动时若不存在任何 key，自动生成一把 root key，并**仅打印/持久化一次**，供运维取走。
-- key 通过 Auth Resolver 解析为账户/组织/用户身份；遥测中绝不存明文 key。
+## Authentication
+
+Auth is enforced by a Hono middleware (`apps/gateway/src/middleware/auth.ts`)
+registered **before** rate limiting and classification, so an unauthenticated
+request is short-circuited before it can cost anything.
+
+- The key is read from `Authorization: Bearer <key>` (preferred) or from the
+  `x-api-key` header. It is treated as case-sensitive and is never trimmed or
+  lowercased before hashing.
+- The plaintext key is hashed with sha256 and looked up via
+  `KeyStore.getByHash`. A missing, unknown, or `disabled` key yields a
+  structured `auth_error` (HTTP 401); see [07 · Error Model &
+  Observability](07-observability.md).
+- On success, an `AuthIdentity` is attached to the request context: `keyId`,
+  `keyPrefix` (display prefix only — **never** the plaintext key), `accountId`,
+  `role`, the per-key caps, and the per-key rate-limit override. Downstream
+  middleware reads this instead of touching the store again.
+
+Per **Principle 7**, the plaintext key lives only in the `Authorization` header.
+It is never logged, never echoed in a response, and never written to telemetry
+or the captured payload tables. Logs reference a key by `key_id` or `keyPrefix`
+only.
 
 ```yaml
-auth:
-  require_api_key: true
-  bootstrap:
-    generate_if_missing: true        # 启动时无 key 则生成一把 root key
-    persist_to: ./data/helm-keys.json   # 或环境变量 / 数据库
-    print_once: true                 # 首次生成时打印到启动日志一次
+# config/auth.yaml
+require_api_key: true
+bootstrap:
+  generate_if_missing: true            # on first start with no keys, mint a root key
+  persist_to: ./data/helm-keys.json    # written to the mounted ./data volume
+  print_once: true                     # plaintext printed to the boot log exactly once
 ```
 
-## Key 管理
+## Root-key bootstrap
 
-- **多 key**：支持任意数量的 key，每把绑定身份（account / org / user）。
-- **哈希存储**：只存 key 的哈希（如 sha256）+ 前缀（如 `helm_live_xxxx`）用于展示/排障；绝不存明文。
-- **每 key 上限**：可选 `max_lane`（封顶到某条 lane）/ `allowed_lanes`（白名单）/ `allow_custom_model`（是否允许客户端显式指定模型直通）。
-- **轮转与吊销**：生成新 key + `disabled: true` 吊销旧 key；不就地改写。
-- root key 仅用于引导和管理面，不建议直接喂生产流量。
+On first start, if the `KeyStore` contains **no** keys, the gateway mints a
+single `role=root` key (`bootstrapRootKey` in
+`packages/core/src/auth/bootstrap.ts`):
 
-```yaml
-# key 记录（存储层，示意）
-api_keys:
-  - key_id: k_root
-    hash: sha256:...
-    account_id: acct_default
-    role: root
-    disabled: false
-  - key_id: k_app1
-    hash: sha256:...
-    account_id: acct_default
-    max_lane: balanced          # 封顶，禁止 premium
-    allow_custom_model: false   # 不允许跳过规则直通模型
-    disabled: false
+- Only the sha256 **hash** and the display **prefix** are persisted — never the
+  plaintext.
+- The plaintext is printed to the boot log **exactly once** for the operator to
+  capture. It is not recoverable afterward.
+- The check is idempotent: if any key already exists, bootstrap does nothing
+  across restarts.
+- A store read failure aborts startup (fail-closed) — Helm never degrades to
+  anonymous access.
+
+The root key is meant for bootstrap and admin tasks; mint scoped `user` keys for
+production traffic rather than using the root key directly.
+
+## Key management
+
+Keys are managed through the KeyStore port (`packages/core/src/store/ports.ts`),
+backed by either the SQLite or the Postgres adapter, and surfaced in the admin UI
+(see [11 · Admin UI](11-admin-ui.md)).
+
+The stored record (`ApiKeyRecord`, single source of truth in
+`packages/shared/src/key/schema.ts`):
+
+```ts
+{
+  key_id: string,
+  hash: string,             // sha256(plaintext) hex — never the plaintext
+  prefix: string,           // e.g. helm_live_ab12 — display/debug only
+  account_id: string,
+  role: "root" | "user",
+  max_lane: string | null,        // cap routing at this lane
+  allowed_lanes: string[] | null, // allow-list of lanes
+  allow_custom_model: boolean,    // may the client pin a model directly?
+  disabled: boolean,
+  rate_limit_rpm: number | null,  // per-key override; null = inherit default
+  rate_limit_tpm: number | null,  // 0 = explicitly unlimited
+}
 ```
 
-## 限流与配额
+- **Hashed storage only.** The store port's `CreateKeyInput` has no plaintext
+  field, so the persistence layer is structurally unable to store a plaintext
+  key. The plaintext of a freshly minted key is returned to the admin caller
+  exactly once and then discarded.
+- **Per-key caps.** `max_lane`, `allowed_lanes`, and `allow_custom_model`
+  constrain how a key may route (resolved into `AuthIdentity.caps`).
+- **Rotation & revocation never mutate in place.** `KeyStore.disable` is a soft
+  revoke (`disabled = true`); rotate by minting a new key and disabling the old
+  one. `updateRateLimit` is a partial PATCH that touches only the rate-limit
+  columns, never role/caps.
 
-`nginx for LLM` 自然需要 per-key 限流，但不能成为"开箱即用"的摩擦。
+## Rate limits & quotas
 
-**决策**：MVP 内置**轻量 per-key 限流**（令牌桶 RPM/TPM），**默认关闭**；完整的配额 / 计费 / 信用体系**推迟到 MVP 之后**。限流器位于 Auth 之后、分类之前；触发即返回 `rate_limited`。
+A "nginx for LLM" needs per-key rate limiting, but it must not become
+out-of-the-box friction. Helm ships lightweight per-key limiting (token-bucket
+RPM/TPM) that is **disabled by default**. Full quota/billing/credit accounting is
+on the [roadmap](09-roadmap.md), not in 0.1.
+
+The limiter lives in core (`packages/core/src/ratelimit/`), behind a store-backed
+token bucket; the gateway middleware
+(`apps/gateway/src/middleware/rate-limit.ts`) is glue only. Position is a
+contract: **after** auth (it needs the resolved `key_id`) and **before**
+classify/route (so it cuts off cost before classification or eval).
+
+### Configuration & precedence
+
+The master switch and the system default quota are **runtime-mutable** via the
+admin "System Settings" page (`rate_limit_enabled`, `rate_limit_default_rpm`,
+`rate_limit_default_tpm` in `RuntimeSettingsSchema`), seeded at boot from
+`config/runtime.yaml`:
 
 ```yaml
+# config/runtime.yaml
 rate_limit:
-  enabled: false            # 默认关闭，零摩擦
+  enabled: false          # master switch (default OFF). Env: HELM_RATE_LIMIT_ENABLED
   default:
-    rpm: 0                  # 0 = 不限
+    rpm: 0                 # 0 = unlimited
     tpm: 0
-  # 可按 key 覆盖
+  overrides: {}           # yaml per-key overrides, keyed by key_id (config-only fallback)
 ```
+
+Quota resolution per dimension (`resolveQuota` in `ratelimit/limiter.ts`):
+
+1. If the request carries a **per-key override** (resolved by auth from the key's
+   DB record), that is authoritative: each dimension resolves
+   `override.<dim> ?? system_default.<dim>`. A `null` dimension means "inherit the
+   system default" — it deliberately does **not** fall back to a yaml
+   `overrides[key_id]` entry, so clearing a key's limit in the admin UI truly
+   returns it to the fleet default. `0` is a real value (explicitly unlimited),
+   not "inherit".
+2. If **no** per-key override is carried (e.g. a config-only / headless caller),
+   fall back to `config.overrides[key_id]`, then to `config.default`.
+
+### Behavior
+
+- When the master switch is off, or both dimensions resolve to `0` (unlimited),
+  the limiter returns "allowed" and **never touches the store** — a zero-overhead
+  fast path with no `x-ratelimit-*` headers.
+- When active, both buckets must admit the request. RPM is debited first
+  (1 request = 1 token); only if RPM admits is the TPM bucket charged the
+  pre-classification token estimate. Either shortfall rejects.
+- A successful metered request emits `x-ratelimit-limit`, `x-ratelimit-remaining`,
+  and `x-ratelimit-reset` describing the **tighter** of the two dimensions.
+- A rejected request returns HTTP 429 `rate_limited` (with `limited_by` =
+  `rpm`/`tpm`, a `retry-after` header, and the rate-limit headers).
+- The bucket store is **fail-closed**: a read/write failure propagates and the
+  request is rejected — it never silently degrades to "unlimited".
+- Counters persist in the store, so they survive restarts.
+
+## Admin authentication is separate
+
+API-key auth (this chapter) governs API traffic. The admin UI is gated by HTTP
+Basic credentials from config/env — a different header, a different credential
+source, and no RBAC. The two never cross: the API path never consults the admin
+credentials, and the admin path never consults the KeyStore. See [11 · Admin
+UI](11-admin-ui.md).

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -1,65 +1,137 @@
-# 07 · 错误模型与可观测性
+# 07 · Error Model & Observability
 
-决策记录（每个请求的完整路由轨迹）的结构见 [02 · 架构](02-architecture.md)。本章覆盖错误模型与 Debug UI。
+> Status: **implemented (0.1)**. The structured error model, the redacted
+> decision record, and the separate full-payload capture all ship.
 
-## 错误模型
+The full per-request routing trail (the decision record) is described
+structurally in [02 · Architecture](02-architecture.md). This chapter covers the
+error model, the redacted decision record, the separate payload capture, and what
+the Debug UI surfaces.
 
-所有错误都是**结构化的**，并以**客户端所用协议的错误形态**返回（OpenAI 客户端拿到 OpenAI 错误形状，Anthropic 客户端拿到 Anthropic 错误形状），让现有 SDK 能直接解析。
+## Error model
 
-统一内部错误结构：
+Every error is **structured** and is returned in the **error shape of the
+protocol the client used** (an OpenAI client gets an OpenAI-shaped error; an
+Anthropic client gets an Anthropic-shaped error), so existing SDKs parse it
+without special casing.
 
-```yaml
-error:
-  error_class: auth_error | invalid_request | lane_unavailable
-              | all_providers_failed | capability_unsatisfiable
-              | upstream_error | timeout | rate_limited
-  http_status: number          # 见下表
-  message: string              # 脱敏后的人类可读信息
-  trace_id: string             # 关联决策记录，可在 Debug UI 还原
-  provider_raw: object | null  # 上游原始错误（脱敏），便于排障
+The unified internal error (`HelmError`, single source of truth in
+`packages/shared/src/error/schema.ts`):
+
+```ts
+{
+  error_class: "auth_error" | "invalid_request" | "lane_unavailable"
+             | "all_providers_failed" | "capability_unsatisfiable"
+             | "upstream_error" | "timeout" | "rate_limited",
+  http_status: number,                          // mapped from error_class (see below)
+  message: string,                              // redacted, human-readable
+  trace_id: string,                             // links the decision record; restorable in the Debug UI
+  provider_raw: Record<string, unknown> | null, // upstream raw error (redacted), for debugging
+}
 ```
 
-错误分类（`error_class`）及建议 HTTP 状态：
+The `error_class → HTTP status` map is authoritative (`ERROR_CLASS_HTTP_STATUS`),
+and `makeHelmError` guarantees `http_status` always agrees with the class —
+callers cannot supply a mismatched status:
 
-| error_class | HTTP | 含义 |
+| `error_class` | HTTP | Meaning |
 |---|---|---|
-| `auth_error` | 401 | 缺/错 key |
-| `invalid_request` | 400 | 请求不合法 / 协议字段错误 |
-| `lane_unavailable` | 503 | 选中的 lane 无可用候选 |
-| `all_providers_failed` | 502 | 候选链全部失败 |
-| `capability_unsatisfiable` | 422 | 无候选满足能力约束（如强制 JSON / vision） |
-| `upstream_error` | 502 | 上游 provider 返回错误 |
-| `timeout` | 504 | 超时 |
-| `rate_limited` | 429 | 触发限流 |
+| `auth_error` | 401 | Missing / invalid key |
+| `invalid_request` | 400 | Malformed request / protocol field error |
+| `lane_unavailable` | 503 | The selected lane has no usable candidate |
+| `all_providers_failed` | 502 | The whole candidate chain failed |
+| `capability_unsatisfiable` | 422 | No candidate satisfies the capability constraints (e.g. forced JSON / vision) |
+| `upstream_error` | 502 | An upstream provider returned an error |
+| `timeout` | 504 | Timed out |
+| `rate_limited` | 429 | Rate limit tripped |
 
-Protocol Adapter 的 `responseOut` 负责把统一错误翻成各协议的错误形状（见 [05](05-protocol-translation.md)）。
+Per **Principle 7**, `message` and `provider_raw` must already be redacted by the
+producer. The Protocol Adapter's response-out stage translates this unified error
+into each client protocol's error shape (see [05 · Protocol
+Translation](05-protocol-translation.md)).
 
-## Debug UI 需求
+A client-initiated disconnect is **not** treated as a server timeout: the timeout
+middleware (`apps/gateway/src/middleware/limits.ts`) checks the client's own
+abort signal and does not synthesize a 504 (see [02 ·
+Architecture](02-architecture.md)).
 
-请求列表应当展示：
+## Decision record (redacted)
 
-- 时间
-- API key / 用户 / 组织
-- 请求的模型
-- 分类得到的任务类型
-- 复杂度
-- **决策层级**：rules / eval / default（哪一层定的 lane）
-- 选中的 lane
-- 最终模型
-- fallback 次数
-- 状态
-- 延迟
-- 成本
-- 错误原因
+For every request the gateway persists a `DecisionRecord` (single source of truth
+in `packages/shared/src/decision/schema.ts`) via the `TelemetryStore`. It is the
+full routing trail and is **redacted** as defence-in-depth — it carries no
+plaintext key and no private payload. The record holds:
 
-请求详情应当展示：
+- `request_id` / `trace_id` (correlation across logs and the Debug UI);
+  `requested_model`; `key_prefix` (display prefix only, never the plaintext key).
+- `classifier`: `task_type`, `complexity`, `confidence`, **`decided_by`**
+  (`rules` / `eval` / `default` / `fallback`), `eval_cache_hit`,
+  `fallback_reason`, `constraints`, and `explanation` (matched dimensions /
+  signals).
+- `policy`: the matched policy id and a reason.
+- `lane`: the selected lane and the ordered candidate chain.
+- `provider_attempts[]`: per attempt — alias, `skipped` + `skip_reason`, status,
+  `error_class`, latency, cost, and `error_detail` (the real upstream status +
+  redacted message + redacted `provider_raw`, captured even when a later
+  candidate served the request).
+- `final`: the served model alias / provider model, status, and error reason.
+- `latency_total_ms`, `fallback_count` (execution-stage count), and
+  `cost_breakdown` (`eval_usd` / `completion_usd` / `total_usd`).
 
-- 原始请求元数据，以及脱敏后的 payload 摘要
-- 分类器输出（含置信度与命中的维度/信号）
-- 是否触发 eval、eval 是否命中缓存
-- 命中的策略
-- lane 候选链路
-- provider 尝试记录
-- 最终响应元数据，或结构化错误
-- 成本拆分（含 eval 评估自身的成本）
-- Trace ID
+Per **Principle 5**, the **classification** fallback (`classifier.decided_by` /
+`fallback_reason`) and the **execution** fallback (`provider_attempts` /
+`fallback_count`) are separate fields and are never conflated.
+
+### Redaction
+
+`packages/core/src/telemetry/redaction.ts` is the last gate before anything is
+persisted or logged. It is pure (never mutates its input) and framework-agnostic:
+
+- Plaintext keys / credentials → irreversible `sha256:<prefix>` fingerprints
+  (reconcilable with the keystore hash, not reversible to plaintext).
+- Private payload fields (`messages`, `attachments`, `prompt`, `content`,
+  `input`) → summaries (kind + size), not their contents.
+- Keys matching the secret pattern (`api_key`, `authorization`, `password`,
+  `secret`, `token`, `credential`) are fingerprinted or summarized.
+- Non-sensitive fields (`trace_id`, latency, cost, status, …) pass through
+  verbatim.
+
+## Full payload capture
+
+Separately from the redacted decision record, Helm can record the **complete,
+verbatim** request and response bodies into a dedicated `request_payloads` table
+(`InsertPayloadInput` / `getPayload` / `prunePayloads` on the `TelemetryStore`).
+This is deliberately split from the decision record so it prunes independently and
+never bloats the decision JSON.
+
+- `capture_payloads` defaults to **ON** (`RuntimeSettingsSchema`). For a
+  self-hosted gateway the operator owns the data on their own box; capture makes
+  debugging and auditing straightforward. It can be toggled off at runtime from
+  the admin "System Settings" page, in which case the capture path is skipped
+  entirely (zero storage).
+- `payload_retention_days` (default 30) bounds the storage footprint and the
+  exposure window; older payloads are auto-pruned.
+- Capture is **not** redacted — it is the verbatim client request body plus the
+  assembled provider response. It still carries no plaintext API key, because the
+  bearer key lives in the `Authorization` header, never in the chat body that is
+  stored.
+- Writes are idempotent (upsert by `request_id`): a streamed response may write
+  the request first, then backfill the assembled response.
+
+## Debug UI
+
+The admin Debug UI ([11 · Admin UI](11-admin-ui.md)) is a pure consumer of the
+redacted decision record plus the optional captured payload.
+
+The request **list** shows per row: time, key prefix, requested model, classified
+task type, complexity, the decision stage (`decided_by`: rules / eval / default /
+fallback), selected lane, final model, fallback count, status, latency, cost, and
+error reason.
+
+The request **detail** shows: request metadata, the classifier output (with
+confidence and matched dimensions/signals), whether eval ran and whether it hit
+the cache, the matched policy, the lane candidate chain, every provider attempt
+(including upstream `error_detail`), the final response metadata or structured
+error, the cost split (including eval's own self-cost), and the trace id. When
+`capture_payloads` is on and the row is present, the detail can also load the full
+captured request/response bodies.

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -1,12 +1,30 @@
-# 08 · 记忆中间件（MVP 之后）
+# 08 · Memory Middleware
 
-> 状态：**不在 MVP 内**。本章描述 MVP 之后的可选中间件设计；MVP 不实现记忆的读写与注入。
+> Status (0.1): the **observe** phase is **implemented and wired** into the
+> gateway request path; the **inject** phase is **on the roadmap** (see
+> [09 · Roadmap](09-roadmap.md)). This chapter describes the design and marks the
+> true state of each part.
 >
-> **实现状态（2026-05-31）**：core 侧逻辑已实现并单测覆盖（`packages/core/src/memory/` 的 `observeInbound`/`observeOutbound`/`assembleInjectedContext`/`resolveMemoryMode`，并从 `@helm/core` 导出），但**尚未接入网关请求路径**——`chat.ts` / `messages-pipeline.ts` 仍把 `memory_mode` 硬编码为 `"off"`、scope id 全为 null，故 observe/inject 在运行时**不可达（dead at runtime）**。对比之下 signals 子系统已接线。**接线工作已延后**为独立任务：解析 `x-thread-id`/`x-resource-id`/`x-project-id`/`x-memory-mode`（经 `resolveMemoryMode`）入 `metadata`，在路由前后调用 observe、在分类前调用 inject，并补路由级测试。见 `implementation-notes.md` 的「全模块审计 + 41 项修复」条目与本仓 TODO。
+> What is live: the four memory headers are parsed at the gateway boundary
+> (`apps/gateway/src/routes/memory-scope.ts`), the resolved scope/mode is threaded
+> through, and `observeInbound` / `observeOutbound`
+> (`packages/core/src/memory/observe.ts`) are called from the OpenAI Chat route
+> (`chat.ts`), the Anthropic/Responses pipeline (`messages-pipeline.ts`), and the
+> Anthropic/Responses surfaces (`messages.ts`, `responses.ts`). In `observe`/
+> `inject` mode the gateway persists raw request/response/tool messages into the
+> `memory_*` tables.
+>
+> What is **not** wired yet: the **inject** phase. `assembleInjectedContext`
+> exists, is unit-tested, and is exported from `@helm/core`, but it is **not
+> called from any gateway route**. So today `inject` mode behaves like `observe`
+> (it persists but does not hydrate); `memory_hydrated` is always `false` and the
+> inject-phase counters stay at their null/zero defaults. The background Observer /
+> Reflector jobs are also roadmap.
 
-## 定位
+## Positioning
 
-记忆并不属于 MVP 路由核心。记忆是一个可选的中间件，它在分类和执行之前为请求提供足够的上下文。
+Memory is not part of the routing core. It is an optional middleware that gives a
+request enough context to be understood before classification and execution.
 
 ```text
 Memory helps the request be understood.
@@ -15,62 +33,73 @@ Provider executes.
 Logs explain what happened.
 ```
 
-## 来源 issue
+Memory must never rewrite lane rules. For example, an entitlement-based route
+belongs to the Policy Engine, not to memory.
 
-本规范基于 llm-router issue #362：Memory Gateway / Observational Memory（记忆网关 / 观察式记忆）。
+## Origin
 
-Issue: https://github.com/EasyMetaAu/llm-router/issues/362
+The design follows llm-router issue #362 (Memory Gateway / Observational Memory)
+and is inspired by Mastra's Observational Memory:
+<https://github.com/EasyMetaAu/llm-router/issues/362>.
 
-## 核心思路
+## Core idea
 
-采用受 Mastra Observational Memory 启发的网关级记忆层：
+A gateway-level memory layer inspired by Mastra Observational Memory:
 
-- 客户端传入稳定的 ID，例如 `x-thread-id`、`x-resource-id` 和 `x-project-id`。
-- 网关存储原始消息和工具结果。
-- 后台 Observer 将旧的原始历史压缩为带日期的观察记录。
-- 后台 Reflector 将观察记录合并为稳定的反思。
-- Provider 上下文由反思、观察记录、近期原始消息以及当前消息组装而成。
+- The client passes stable IDs such as `x-thread-id`, `x-resource-id`, and
+  `x-project-id`.
+- The gateway stores raw messages and tool results.
+- A background Observer compresses old raw history into dated observations.
+- A background Reflector merges observations into stable reflections.
+- The provider context is assembled from reflections, observations, recent raw
+  messages, and the current message.
 
-在 MVP 方向上这并不是动态 RAG。目标是构建一个稳定、对缓存友好的上下文前缀。
+This is deliberately not dynamic RAG. The goal is a stable, cache-friendly context
+prefix.
 
-## 请求头
+## Request headers
 
 ```http
-x-thread-id: current conversation or task thread
-x-resource-id: current document, asset, issue, or workspace object
-x-project-id: project-level memory scope
+x-thread-id:   the current conversation or task thread
+x-resource-id: the current document, asset, issue, or workspace object
+x-project-id:  the project-level memory scope
 x-memory-mode: off | observe | inject
 ```
 
-默认值：
+Default: `x-memory-mode = off`. Mode normalization is centralized in core's
+`resolveMemoryMode`; an absent, illegal, or wrong-case value falls back safely to
+`off`. An empty `x-thread-id` yields `null` (never a fabricated thread id), and
+`observe` self-gates to a no-op when there is no thread scope.
 
-```text
-x-memory-mode = off
-```
+Modes:
 
-模式：
+- `off` — no memory read/write; routing behavior is unchanged. Zero DB touch.
+- `observe` — record messages and tool outputs, but do not inject memory.
+  **Implemented and wired.**
+- `inject` — load memory context, assemble the prompt, and enqueue the
+  write-back. **Roadmap.** Today `inject` is accepted and persists like `observe`,
+  but the inject phase is not invoked, so nothing is hydrated.
 
-- `off`：不进行记忆读写；保持当前路由行为。
-- `observe`：记录消息和工具输出，但不注入记忆。
-- `inject`：加载记忆上下文、组装 prompt，并将回写任务入队。
-
-## 流水线
+## Pipeline (target design)
 
 ```text
 Request comes in
-  -> save raw message if observe/inject
-  -> if inject:
+  -> save raw message if observe/inject        # implemented (observeInbound)
+  -> if inject:                                 # roadmap
        load reflection + active observations
        assemble stable context
   -> classifier uses current message + short memory context
   -> route + provider execute
-  -> save response/tool result
-  -> enqueue observer job
-  -> observer compresses raw history into observations
-  -> reflector periodically merges observations into reflection
+  -> save response/tool result                  # implemented (observeOutbound)
+  -> enqueue observer job                       # roadmap
+  -> observer compresses raw history into observations   # roadmap
+  -> reflector periodically merges observations into reflection  # roadmap
 ```
 
-## 上下文组装顺序
+Persistence is **fail-open** (Principle 3): a memory store failure degrades to
+"continue without memory" plus a logged failure — never a 5xx.
+
+## Context assembly order (inject phase, roadmap)
 
 ```text
 system prompt
@@ -81,17 +110,18 @@ system prompt
 + current user message
 ```
 
-规则：
+Rules:
 
-- 反思应当稳定且缓慢变化。
-- 必须保留近期原始消息，以避免压缩造成信息丢失。
-- 观察记录文本应包含时间锚点。
-- 记忆注入应保持在 token 预算范围内。
-- 如果记忆加载失败，主请求应在无记忆的情况下继续执行，并记录该失败。
+- Reflections should be stable and slow-changing.
+- Recent raw messages must be retained so compression cannot lose information.
+- Observation text should carry a time anchor.
+- Injected memory must stay within a token budget.
+- If memory loading fails, the main request continues without memory and the
+  failure is recorded.
 
-## 存储模型
+## Storage model
 
-最小表集合：
+Minimal table set (see `MemoryStore` in `packages/core/src/store/ports.ts`):
 
 ```text
 memory_threads
@@ -112,38 +142,27 @@ memory_jobs
   id, type, scope_id, status, error, created_at, updated_at
 ```
 
-`source_message_range` 是必填字段，这样压缩后的记忆才能与原始消息进行审计核对。
+`source_message_range` is required so compressed memory can be audited against the
+original raw messages. The `observe` path uses `ensureThread` + `appendMessage`
+today; the read/compress/reflect methods back the roadmap Observer/Reflector.
 
-## 路由集成
+## Routing integration
 
-分类器可以使用：
+The classifier may use the current message, recent raw turns, a short memory
+summary, and tool/request metadata. The routing output is unchanged
+(`task_type` / `complexity` / `constraints` / `lane`). Memory must not directly
+rewrite lane rules.
 
-- 当前消息。
-- 近期的原始对话轮次。
-- 简短的记忆摘要。
-- 工具/请求元数据。
+## Debug UI fields
 
-路由输出保持不变：
-
-```text
-task_type
-complexity
-constraints
-lane
-```
-
-记忆不得直接改写 lane 规则。例如，用户权益路由应归属于 Policy Engine，而非记忆。
-
-## 调试 UI 字段
-
-新增请求级别的记忆元数据：
+Request-level memory metadata (`MemoryMeta`):
 
 ```text
 memory_mode
 thread_id
 resource_id
 project_id
-memory_hydrated
+memory_hydrated            # always false until the inject phase ships
 reflection_version
 observation_count
 memory_tokens_injected
@@ -151,47 +170,43 @@ observer_job_id
 memory_writeback_status
 ```
 
-请求详情默认可以展示记忆元数据。完整的记忆内容应需要显式授权，并且应被审计。
+The request detail may show memory metadata by default. Full memory **content**
+requires explicit authorization and is audited (see [07 · Error Model &
+Observability](07-observability.md)).
 
-## 成本核算
+## Cost accounting (roadmap)
 
-独立的 token/成本分桶：
+Memory maintenance gets its own token/cost buckets so it is visible in cost
+reports and not hidden inside provider execution cost: actor request tokens, actor
+response tokens, memory hydrate tokens, Observer tokens, Reflector tokens.
 
-- Actor 请求 token。
-- Actor 响应 token。
-- 记忆补水（hydrate）token。
-- Observer token。
-- Reflector token。
+## Phases
 
-记忆维护必须在成本报告中可见，且不应隐藏在 Provider 执行成本之中。
+### Phase 1 — Memory-ready · implemented
 
-## 阶段计划
+- Accept the memory headers.
+- Persist raw messages in `observe` mode.
+- Surface memory metadata in the request log.
+- Do not inject memory yet.
 
-### 阶段 1：记忆就绪（Memory-ready）
+### Phase 2 — Observational Memory MVP · roadmap
 
-- 接受记忆请求头。
-- 在 observe 模式下持久化原始消息。
-- 在请求日志中展示记忆元数据。
-- 暂不注入记忆。
+- Implement the Observer: raw messages → observations.
+- Implement the Reflector: observations → reflections.
+- Implement inject-phase context assembly (call `assembleInjectedContext`).
+- Run only when `x-memory-mode=inject` is explicitly set.
 
-### 阶段 2：观察式记忆 MVP（Observational Memory MVP）
+### Phase 3 — Project memory · roadmap
 
-- 实现 Observer：原始消息 -> 观察记录。
-- 实现 Reflector：观察记录 -> 反思。
-- 实现 inject 模式的上下文组装。
-- 仅在显式设置 `x-memory-mode=inject` 时运行。
+- Project / resource / thread scope hierarchy.
+- Structured facts and an asset graph.
+- Creative / project workspace support.
 
-### 阶段 3：项目记忆（Project memory）
+## Non-goals
 
-- 项目/资源/线程的作用域层级。
-- 结构化事实与资产图谱。
-- 创意/项目工作区支持。
-
-## 非目标
-
-- 不在路由核心中构建完整的 RAG 产品。
-- 默认不进行逐轮的动态检索。
-- 不进行跨项目的记忆共享。
-- 首个版本中不引入全局用户画像。
-- 不在主请求路径中引入同步的 Observer。
-- 不在记忆中间件中进行 agent 编排。
+- No full RAG product inside the routing core.
+- No per-turn dynamic retrieval by default.
+- No cross-project memory sharing.
+- No global user profile in the first version.
+- No synchronous Observer on the main request path.
+- No agent orchestration inside the memory middleware.

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -1,23 +1,75 @@
-# 09 · MVP 路线图与成功标准
+# 09 · Roadmap
 
-## MVP 路线图（分阶段）
+> Status: **0.1 is implemented.** Phases 0–4 are done; the gateway routes real
+> traffic, translates protocols, classifies and routes with fallback and circuit
+> breaking, supports optional eval, and ships an admin UI. The "remaining" list
+> below is what is deferred past 0.1.
 
-按"每阶段都能独立跑起来"的顺序推进，不追求一次到位：
+## Delivered in 0.1 (phases 0–4)
 
-- **Phase 0 — 骨架**：HTTP 网关 + Auth（启动引导 key、强制鉴权）+ 单协议直通（OpenAI Chat）+ 遥测落库 + **Docker 部署**（配置/数据挂载卷）。能鉴权、能转发、能记日志、能容器化跑起来。
-- **Phase 1 — 路由核心**：第 1 层确定性规则分类器 + 三条默认 lane + Provider 执行器 + 能力过滤 + 熔断器 + fallback 链。可服务真实流量；分类不确定落 balanced。
-- **Phase 2 — 协议互译**：Protocol Adapter（OpenAI ↔ Anthropic 双向 + 流式），按 musistudio 蓝本重写。客户端可混用 SDK。
-- **Phase 3 — eval 层**：第 2 层小模型评估 + content-hash 缓存（默认关闭）。开启后判定能选 lane。
-- **Phase 4 — 管理界面**：Web 控制台（HTTP Basic 认证）= 基本规则管理（lane / policy / classifier / key）+ 请求调试（列表/详情/决策链）。
-- **MVP 之后**：Gemini 协议、Memory 中间件、限流/配额完整化、Signals 反馈层。
+The build followed an order where each phase runs on its own.
 
-## MVP 成功标准
+- **Phase 0 — Skeleton · done.** HTTP gateway + mandatory API-key auth (with
+  root-key bootstrap) + single-protocol passthrough (OpenAI Chat) + telemetry
+  persistence + Docker deployment (config/data volumes). It authenticates,
+  forwards, logs, and runs in a container. See
+  [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md) and
+  [10 · Deployment](10-deployment.md).
+- **Phase 1 — Routing core · done.** Layer-1 deterministic rule classifier + the
+  default lanes + the provider executor + capability filtering + circuit breaker +
+  the in-chain fallback. It serves real traffic; an uncertain classification falls
+  open to `balanced`. See [03 · Classification Cascade](03-classification.md) and
+  [04 · Routing & Lanes](04-routing-and-lanes.md).
+- **Phase 2 — Protocol translation · done.** The Protocol Adapter translates
+  OpenAI Chat, Anthropic Messages, and OpenAI Responses (with streaming for Chat
+  and Messages), rewritten with musistudio/llms as the architecture blueprint and
+  litellm as the correctness spec. Clients can mix SDKs. See
+  [05 · Protocol Translation](05-protocol-translation.md).
+- **Phase 3 — Eval layer · done.** The Layer-2 small-model evaluator with a
+  content-hash cache (disabled by default). When enabled, its verdict selects a
+  lane; identical requests hit the cache instead of re-evaluating.
+- **Phase 4 — Admin UI · done.** A web console (HTTP Basic auth) for basic rule
+  management (lanes / policies / classifier / keys / system settings) plus request
+  debugging (list / detail / decision trail). See [11 · Admin UI](11-admin-ui.md).
 
-- 新客户端可以把一个 OpenAI 兼容的 SDK 指向 Helm，无需自定义配置即可获得可用的路由。
-- 默认的 economy / balanced / premium lane 开箱即用，且 LLM 评估默认关闭。
-- 启动时若无 key，自动生成一把 root key；无 key 的请求被拒绝。
-- 第 1 层规则能确定分类时直接进对应 lane；不确定且 eval 关闭时落到 balanced。
-- 开启 eval 后，小模型的判定能选 lane，且相同请求命中缓存不重复评估。
-- 一个 coding 请求在配置了 coding lane 时能路由到该 lane，否则回退到 premium 或 balanced。
-- 一个带 JSON 约束的请求绝不会悄无声息地被路由到一个会忽略 JSON 约束的模型。
-- 任何出乎意料的 provider 选择都能从请求日志中得到解释（包括是哪一层、哪条规则、哪个 provider 尝试导致的）。
+## Remaining / deferred past 0.1
+
+Verified against the code and `implementation-notes.md`:
+
+- **Gemini client route.** The Gemini protocol transformer exists and is
+  unit-tested (`packages/core/src/protocol/gemini/`), but it is **not mounted as
+  an inbound route** yet — there is no `/v1beta/models/...` endpoint. A
+  `parseGeminiPath` helper and the `x-goog-api-key` header constant are in place;
+  the gateway wiring is the remaining work.
+- **OpenAI Responses streaming.** The Responses route is wired for non-streaming
+  only. A `stream: true` Responses request returns a structured 400 (it does not
+  silently downgrade, per Principle 2) because the `response.*` SSE transformer
+  is not implemented yet.
+- **Memory inject phase.** The `observe` phase is wired; the `inject` phase
+  (`assembleInjectedContext`) and the background Observer/Reflector jobs are not.
+  See [08 · Memory Middleware](08-memory-middleware.md).
+- **Fuller quota / rate-limit features.** Per-key RPM/TPM limiting ships
+  (disabled by default); full quota / billing / credit accounting is deferred. See
+  [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md).
+- **Agentic Signals feedback layer.** The store ports and the redacted
+  `RoutingSignal` shape exist, but nothing reads signals back into routing yet.
+
+## Success criteria (met by 0.1)
+
+- A new client can point an OpenAI-compatible SDK at Helm and get usable routing
+  with no custom config.
+- The default economy / balanced / premium lanes work out of the box, with LLM
+  evaluation off by default.
+- On first start with no key, a root key is generated; requests without a key are
+  rejected.
+- Layer-1 rules route directly to the matching lane when classification is
+  certain; an uncertain request with eval off falls to `balanced`.
+- With eval on, the small model's verdict selects a lane, and an identical request
+  hits the cache instead of re-evaluating.
+- A coding request routes to a coding lane when one is configured, otherwise it
+  falls back to premium or balanced.
+- A request with a JSON constraint is never silently routed to a model that would
+  ignore that constraint.
+- Any surprising provider choice can be explained from the request log (which
+  layer, which rule, which provider attempt). See [07 · Error Model &
+  Observability](07-observability.md).

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -1,42 +1,118 @@
-# 10 · 部署（自托管 / Docker）
+# 10 · Deployment (Self-Hosted / Docker)
 
-Helm 是**开源、自托管**项目（MIT 协议）。不提供 SaaS、不售卖，任何人都可以自己部署、修改、商用。部署方式以 **Docker** 为主。
+Helm is an **open-source, self-hosted** project (MIT). There is no SaaS and
+nothing to buy — anyone can deploy, modify, and run it commercially. The primary
+deployment is **Docker**.
 
-## 设计原则
+## Design principles
 
-- **单容器、配置即代码**：一个镜像 + 一份配置目录即可跑起来；像 nginx 一样改配置、重启生效。
-- **轻量、可自托管**：默认用本地存储（如 SQLite / 本地文件）落遥测与 key，不强依赖外部数据库。
-- **零额外服务**：MVP 不依赖 Redis / 消息队列；限流、缓存先用进程内实现。
+- **Single container, config-as-code.** One image plus one config directory boots
+  the gateway; you change configuration and restart, like nginx.
+- **Lightweight, self-hostable.** The default store is SQLite (a local file under
+  the data volume), so there is no hard dependency on an external database.
+  Postgres/Supabase is available via the same store abstraction (see [02 ·
+  Architecture](02-architecture.md)).
+- **No extra services required.** 0.1 needs no Redis or message queue; rate
+  limiting and caches are in-process / store-backed.
 
-## Docker 部署
+## Docker
+
+The published image is `ghcr.io/easymetaau/helm-api`. It is built on **Node 22**
+(`node:22-slim`), runs as a non-root `helm` user, and exposes port `8080`.
 
 ```bash
 docker run -d --name helm \
   -p 8080:8080 \
-  -v $(pwd)/config:/app/config \   # lanes/policies/classifier/providers...
-  -v $(pwd)/data:/app/data \       # 遥测、key 等持久化
-  -e HELM_ADMIN_USER=admin \       # 管理界面账号（见 11）
+  -v "$(pwd)/config:/app/config" \   # lanes/policies/classifier/providers/...
+  -v "$(pwd)/data:/app/data" \       # telemetry, keys, sqlite — persisted
+  -e HELM_ADMIN_USER=admin \         # admin UI Basic auth (see 11)
   -e HELM_ADMIN_PASSWORD=change-me \
-  -e OPENAI_API_KEY=sk-... \       # 上游 provider 凭证
+  -e OPENAI_API_KEY=sk-... \         # upstream provider credential
   ghcr.io/easymetaau/helm-api:latest
 ```
 
-也提供 `docker-compose.yml` 形态，便于挂载配置与持久化卷。
+The image bakes the default `config/*.yaml` so it boots standalone on first run.
+That is safe because `providers.yaml` references credentials by **env-var name
+only**, never a plaintext key (Principle 7). Operators override the defaults by
+mounting their own directory at `/app/config`.
 
-## 配置来源
+### docker-compose
 
-配置可来自**文件**或**环境变量**，环境变量优先（便于容器化与密钥注入）：
+A `docker-compose.yml` is provided. It defaults to the published image (uncomment
+`build: .` for local builds), mounts the two volumes, and injects credentials from
+a `.env` file. `HELM_ADMIN_PASSWORD` and `OPENAI_API_KEY` are required (compose
+fails fast if they are unset):
 
-- `config/*.yaml`：lanes、policies、classifier、providers、capabilities、pricing、auth（见 [02 · 架构](02-architecture.md)）。
-- 环境变量：provider 凭证、管理界面账号密码、可选的存储/端口覆盖。
+```yaml
+services:
+  helm:
+    image: ghcr.io/easymetaau/helm-api:latest
+    # build: .
+    container_name: helm
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config:/app/config
+      - ./data:/app/data
+    environment:
+      HELM_ADMIN_USER: ${HELM_ADMIN_USER:-admin}
+      HELM_ADMIN_PASSWORD: ${HELM_ADMIN_PASSWORD:?set HELM_ADMIN_PASSWORD in .env}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?set OPENAI_API_KEY in .env}
+    restart: unless-stopped
+```
 
-## 启动行为
+## Volumes
 
-1. 加载配置（文件 + 环境变量）。
-2. 若不存在任何 API key，**生成一把 root key 并打印一次**（见 [06](06-auth-and-rate-limits.md)）。
-3. 启动 HTTP 服务（API + 管理界面，见 [11 · 管理界面](11-admin-ui.md)）。
-4. 健康检查端点就绪后开始服务流量。
+- `/app/config` — the YAML config tree: `lanes`, `policies`, `classifier`,
+  `providers`, `capabilities`, `pricing`, `auth`, `runtime`, `server`.
+- `/app/data` — persisted state: SQLite database, telemetry, captured payloads,
+  and the bootstrapped key file (`./data/helm-keys.json`).
 
-## 升级
+## Configuration sources
 
-像 llm-router 的 SOP 一样：拉新镜像 → 重建容器 → 校验 `/healthz` 与版本；保留挂载的 `config/` 与 `data/`，不覆盖。
+Configuration comes from **files** and **environment variables**, and env vars
+**win** (this is what makes containerized deployment and secret injection clean):
+
+- `config/*.yaml` — lanes, policies, classifier, providers, capabilities,
+  pricing, auth, runtime, server (see [02 · Architecture](02-architecture.md)).
+- Environment variables — upstream provider credentials, the admin Basic-auth
+  user/password, the store driver, and optional bind/limit overrides. See
+  `.env.example` for the full list, including:
+  - `HELM_HOST`, `HELM_PORT`, `HELM_BASE_PATH`
+  - `HELM_ADMIN_USER`, `HELM_ADMIN_PASSWORD`, `HELM_ADMIN_ENABLED`
+  - `HELM_RATE_LIMIT_ENABLED`, `HELM_REQUEST_TIMEOUT_MS`, `HELM_MAX_REQUEST_BYTES`
+  - `HELM_STORE_DRIVER` (`sqlite` | `supabase`), `HELM_STORE_URL_ENV`
+  - `HELM_KEYS_PERSIST_TO`
+  - Upstream credentials such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+    `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` — each maps to a `providers.yaml`
+    entry's `api_key_env`. `OPENAI_API_KEY` is the primary credential and is
+    required; the others are optional (their providers are skipped if absent).
+
+Invalid configuration is rejected at startup (Zod-validated, fail-closed) — Helm
+never runs in a half-broken state (Principle 2).
+
+## Startup behavior
+
+1. Load configuration (files + environment variables, env wins).
+2. If no API key exists, **mint a root key and print it once** (see [06 · Auth,
+   API Keys & Rate Limits](06-auth-and-rate-limits.md)).
+3. Start the HTTP server (the API plus the admin UI when admin credentials are
+   configured; see [11 · Admin UI](11-admin-ui.md)).
+4. Begin serving once the health endpoint reports ready.
+
+## Health & version
+
+- `GET /healthz` — unauthenticated readiness probe. Returns `200` when ready,
+  `503` when degraded (fail-closed: a probe failure reports not-ready, never a
+  hang or 500). The container `HEALTHCHECK` hits this endpoint.
+- `GET /version` — unauthenticated build info (`version`, `gitSha`, `builtAt`),
+  injected at build time. No config or credentials are exposed.
+
+## Upgrading
+
+Pull the new image → recreate the container → verify `/healthz` and `/version`.
+Keep the mounted `config/` and `data/` directories; they are not overwritten.
+
+> Note: telemetry and captured payloads persist on the `data` volume across
+> redeploys. When debugging, filter the request log by the container's start time
+> so rows written by an older image are not mistaken for current behavior.

--- a/docs/11-admin-ui.md
+++ b/docs/11-admin-ui.md
@@ -1,50 +1,118 @@
-# 11 · 管理界面（Admin UI）
+# 11 · Admin UI
 
-启动后，Helm 自带一个**管理界面**（Web 控制台），用于做基本的规则管理与请求调试。它面向**内部使用**，认证用简单的 HTTP Basic 账号密码即可。
+> Status: **implemented (0.1).** A SvelteKit + Tailwind SPA (`adapter-static`),
+> built into `apps/admin/build` and served by the gateway under `/admin`.
 
-## 认证：HTTP Basic（账号密码）
+After it boots, Helm ships a web console for basic rule management and request
+debugging. It is meant for **internal** use and is gated by HTTP Basic
+credentials.
 
-管理界面的认证**独立于 API 流量的 API key**（见 [06](06-auth-and-rate-limits.md)）：
+## Authentication: HTTP Basic
 
-- 用 **HTTP Basic** 认证（浏览器原生弹窗即可）。
-- 账号密码在**配置文件或环境变量**里配，内部使用，不做复杂权限体系。
-- 环境变量优先（容器化注入）。
+The admin UI's authentication is **deliberately separate** from the API-key auth
+used for API traffic (see [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md)):
+a different header (Basic vs. Bearer), a different credential source (config/env
+vs. the KeyStore), and no RBAC. The admin path never consults the KeyStore, and
+API traffic never consults these credentials.
+
+Credentials are resolved by `resolveAdminAuth`
+(`apps/gateway/src/middleware/basic-auth.ts`), with environment variables taking
+priority over config:
 
 ```yaml
-# config/auth.yaml （或用环境变量覆盖）
+# config/auth.yaml — optional admin block (env overrides take priority)
 admin:
   enabled: true
-  username: admin                 # 或环境变量 HELM_ADMIN_USER
-  password: change-me             # 或环境变量 HELM_ADMIN_PASSWORD
+  username: admin       # or HELM_ADMIN_USER
+  password: change-me   # or HELM_ADMIN_PASSWORD
 ```
 
 ```bash
-# 环境变量形态（推荐用于 Docker）
+# Environment form (recommended for Docker)
 HELM_ADMIN_USER=admin
 HELM_ADMIN_PASSWORD=change-me
+HELM_ADMIN_ENABLED=true   # optional explicit toggle
 ```
 
-- 未配置账号密码且 `admin.enabled: true` 时，启动应给出明确告警（避免裸奔）。
-- 管理界面建议只监听内网 / 反代后访问。
+Enable / mount rules:
 
-## 管理界面能做什么
+- **Configuring credentials auto-enables the admin surface.** Setting
+  `HELM_ADMIN_USER` + `HELM_ADMIN_PASSWORD` is the obvious "protect admin" action,
+  so it turns the surface on. Precedence: an explicit env flag
+  (`HELM_ADMIN_ENABLED`) > an explicit config flag (`admin.enabled`) > "credentials
+  present".
+- **When admin is not enabled, it is not mounted at all** — both `/admin` and
+  `/admin/api/*` return 404, so the key-management and telemetry endpoints can
+  never be reached unauthenticated.
+- **When enabled but credentials are missing**, the gateway still boots but emits
+  a single explicit warning, and every admin request fails closed (401) — never
+  silently open.
+- Credentials are compared in constant time and the password is never logged.
+- The Basic gate covers both the API (`/admin/api/*`) and the SPA page + assets
+  (`/admin`). Run the admin UI behind a reverse proxy / on an internal network.
 
-### 规则管理（基本）
+## Internationalization
 
-- **Lane 管理**：查看/编辑默认与任务 lane 的 `primary + fallback[]`（见 [04](04-routing-and-lanes.md)）。
-- **策略管理**：查看/编辑 policies 匹配规则（task_type / complexity / user / org → lane）。
-- **分类器配置**：开关 eval、调 `confidence_threshold`、看 rules 维度/权重（见 [03](03-classification.md)）。
-- **Provider / 凭证**：查看 provider 别名与健康（凭证只读引用，不回显明文）。
-- **API Key 管理**：新建 / 吊销 key，设置每 key 上限（见 [06](06-auth-and-rate-limits.md)）。
+The SPA ships in five languages, English by default
+(`apps/admin/src/lib/config/languages.ts`): English (`en`), Simplified Chinese
+(`zh-hans`), Traditional Chinese (`zh-hant`), Japanese (`ja`), and Korean (`ko`).
+An unrecognized browser/stored language tag falls back to `en`.
 
-改动落到 `config/*.yaml`（或运行时配置存储），保持"配置即代码"，可被版本管理。
+## What the admin UI can do
 
-### 请求调试（Debug）
+The SPA pages (`apps/admin/src/routes/`) are pure consumers of the gateway's
+`/admin/api/*` endpoints.
 
-复用 [07 · 可观测性](07-observability.md) 定义的请求列表与详情：分类层级、命中策略、lane 候选链、provider 尝试、成本、错误与 `trace_id`。
+### Dashboard
 
-## 边界（MVP）
+The landing page (`/`) gives an at-a-glance overview.
 
-- 只做**基本**规则管理 + 请求查看，不做多租户、不做细粒度 RBAC。
-- 不在管理界面里放 Memory / agent 编排（MVP 之外）。
-- 复杂的配置仍可直接改 `config/*.yaml` 后重启——管理界面是便利层，不是唯一入口。
+### Rule management
+
+- **Keys** (`/keys`) — create and revoke API keys and set per-key rate limits.
+  Backed by the KeyStore (`/admin/api/keys` `GET` / `POST` / `PATCH` / `DELETE`),
+  never YAML. The plaintext of a freshly minted key is returned exactly once
+  (Principle 7); revocation is a soft disable. See [06 · Auth, API Keys & Rate
+  Limits](06-auth-and-rate-limits.md).
+- **Lanes** (`/lanes`) — view/edit each lane's `primary + fallback[]`
+  (`/admin/api/lanes` CRUD). The model combobox is populated from a read-only
+  catalog of routable aliases (`/admin/api/models`). See [04 · Routing &
+  Lanes](04-routing-and-lanes.md).
+- **Policies** (`/policies`) — view/edit the policy matching rules
+  (`task_type` / `complexity` / `user` / `org` → lane) via `/admin/api/policies`.
+- **Classifier** (`/classifier`) — toggle eval, tune `confidence_threshold`, and
+  inspect the rule dimensions/weights (`/admin/api/classifier`). See [03 ·
+  Classification Cascade](03-classification.md).
+
+Rule edits go through a runtime rule store that re-binds the live `lanes` /
+`policies` / `classifier` config the router reads — applied on the very next
+request, no restart. Changes are persisted, keeping "config-as-code".
+
+### System settings
+
+- **Settings** (`/settings`) — the runtime-mutable settings the operator can
+  change without a restart (`/admin/api/settings`, validated against
+  `RuntimeSettingsSchema`, fail-closed on an invalid body): `capture_payloads`
+  (default on), `payload_retention_days`, the rate-limit master switch
+  (`rate_limit_enabled`) and system default quota
+  (`rate_limit_default_rpm`/`_tpm`), and `log_level`. See [07 · Error Model &
+  Observability](07-observability.md) and [06 · Auth, API Keys & Rate
+  Limits](06-auth-and-rate-limits.md).
+
+### Request debugging
+
+- **Requests** (`/requests`) — the request list, plus a per-request detail page
+  (`/requests/[traceId]`), reading the read-only `/admin/api/requests` endpoints.
+  This reuses the observability surface from [07 · Error Model &
+  Observability](07-observability.md): classification stage, matched policy, lane
+  candidate chain, provider attempts, cost, error, and `trace_id`. When
+  `capture_payloads` is on, the detail can load the full captured request/response
+  bodies (`/admin/api/requests/:traceId/payload`).
+
+## Boundaries (0.1)
+
+- Basic rule management and request inspection only — no multi-tenancy and no
+  fine-grained RBAC.
+- No Memory / agent orchestration in the admin UI.
+- Complex configuration can still be edited directly in `config/*.yaml` and
+  reloaded — the admin UI is a convenience layer, not the only entry point.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,43 +1,63 @@
-# Helm API 文档
+# Helm API Documentation
 
-本目录存放 Helm API 的产品与技术规范。本仓库采用 **spec-first（规范先行）** 模式：这些文档定义了 MVP 的范围与架构，待范围锁定后再开始实现。文档按编号排序，建议按顺序阅读。
+This directory holds the product and technical specification for Helm API. The
+project is **implemented and at the 0.1 release**: the gateway, routing brain,
+classifier, protocol translation, store layer, and Admin UI are all built and
+covered by tests. The numbered documents below describe the system as it ships;
+read them in order.
 
-## 一段话讲清 Helm 是什么
+## Helm in one paragraph
 
-Helm API 是一个**开源、自托管**的 LLM 路由网关（MIT 协议，Docker 部署）——可以理解成"LLM 世界的 nginx"。它接收标准的 AI API 请求（OpenAI Chat、Anthropic Messages、OpenAI Responses，后续支持 Gemini），用确定性规则（必要时辅以默认关闭的小模型评估）按任务类型和复杂度分类，将其路由到一个可配置的 **lane** 而非裸的 provider 别名，通过主用和 fallback provider 执行，并记录每一次路由决策以便调试。客户端只需更改 `base_url` 和 API key。启动后自带管理界面，做基本规则管理。
+Helm API is an **open-source, self-hosted** LLM routing gateway (MIT license,
+deployed with Docker) — think of it as "**nginx for the LLM world**". It accepts
+standard AI API requests (OpenAI Chat Completions, Anthropic Messages, and
+OpenAI Responses today; Gemini is on the roadmap), uses deterministic rules
+(optionally aided by a small-model evaluation that is **off by default**) to
+classify each request by task type and complexity, and routes it to a
+configurable **lane** rather than to a bare provider alias. It executes the lane
+through a primary plus fallback providers and records every routing decision for
+debugging. Clients only change their `base_url` and API key. A management
+interface ships with the gateway for basic rule management.
 
-## 阅读顺序
+## Reading order
 
-| # | 文档 | 内容 |
-|---|---|---|
-| 01 | [总览与定位](01-overview.md) | Helm 是什么、nginx 定位、MVP 目标与非目标、核心闭环。 |
-| 02 | [架构](02-architecture.md) | 流水线、组件职责、内部请求结构、决策记录、配置布局、安全规则。 |
-| 03 | [分类级联](03-classification.md) | 三层级联（rules → eval → balanced）、任务分类、Manifest 规则引擎、小模型评估。 |
-| 04 | [路由与 Lane](04-routing-and-lanes.md) | 路由优先级、默认/任务 lane、策略、执行与回退。 |
-| 05 | [协议互译](05-protocol-translation.md) | Protocol Adapter 设计、统一 IR、流式状态机、必处理的坑。 |
-| 06 | [鉴权、API Key 与限流](06-auth-and-rate-limits.md) | 强制鉴权、启动引导 key、Key 管理、per-key 限流。 |
-| 07 | [错误模型与可观测性](07-observability.md) | 结构化错误、错误分类表、Debug UI。 |
-| 08 | [记忆中间件](08-memory-middleware.md) | MVP 之后的可选记忆层（不在 MVP 内）。 |
-| 09 | [MVP 路线图与成功标准](09-roadmap.md) | 分阶段路线图与验收标准。 |
-| 10 | [部署（自托管 / Docker）](10-deployment.md) | Docker 部署、配置来源、启动行为、升级。 |
-| 11 | [管理界面（Admin UI）](11-admin-ui.md) | Web 控制台、规则管理、HTTP Basic 认证。 |
-| — | [调研笔记](research-notes.md) | 附录：Manifest、协议互译、probe 等开源参考与对比。 |
+| # | Document | Contents |
+|---|----------|----------|
+| 01 | [Overview & Positioning](01-overview.md) | What Helm is, the nginx analogy, goals & non-goals, the core product loop. |
+| 02 | [Architecture](02-architecture.md) | Pipeline, component responsibilities, internal request shape, decision record, config layout, security rules. |
+| 03 | [Classification Cascade](03-classification.md) | The three-layer cascade (rules → optional eval → balanced fallback), task detection, the rule engine, small-model eval. |
+| 04 | [Routing & Lanes](04-routing-and-lanes.md) | Routing priority, default & task lanes, policies, execution and the two fallbacks. |
+| 05 | [Protocol Translation](05-protocol-translation.md) | Protocol Adapter design, the unified IR, the streaming state machine, the footguns that are handled. |
+| 06 | [Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md) | Mandatory auth, the bootstrap key, key management, per-key rate limits. |
+| 07 | [Error Model & Observability](07-observability.md) | Structured errors, the error-class table, the Debug UI. |
+| 08 | [Memory Middleware](08-memory-middleware.md) | The optional memory layer (observe / inject). |
+| 09 | [Roadmap](09-roadmap.md) | Phased roadmap and success criteria. |
+| 10 | [Deployment (Self-hosted / Docker)](10-deployment.md) | Docker deployment, configuration sources, startup behavior, upgrades. |
+| 11 | [Admin UI](11-admin-ui.md) | Web console, rule management, HTTP Basic auth. |
+| — | [Research Notes](research-notes.md) | Appendix: open-source references and comparisons for the rule engine, protocol translation, probes, etc. |
 
-## 设计原则
+## Design principles
 
-让 Helm 比前身 `llm-router` 更聚焦：
+These keep Helm more focused than its predecessor `llm-router`:
 
-- **开源自托管，不做 SaaS。** MIT 协议，Docker 自部署，内部使用。
-- **对外暴露 lane 抽象，而非模型市场。** 用户选 `economy / balanced / premium`；provider 别名是内部供应链细节。
-- **路由内核精简且可解释。** 策略显式可检视，运行时无黑盒打分。
-- **确定性分类优先。** 本地规则定第一层，小模型评估默认关闭、置于其后。
-- **记忆是中间件，不进 MVP。** 它帮请求被理解，绝不重写 lane 规则。
-- **任何出人意料的 provider 选择都能从日志解释。**
+- **Open-source and self-hosted, not SaaS.** MIT-licensed, deployed by Docker,
+  for internal use.
+- **Expose the lane abstraction, not a model marketplace.** Users choose
+  `economy / balanced / premium`; provider aliases are an internal supply-chain
+  detail.
+- **A small, explainable routing core.** Policies are explicit and inspectable;
+  there is no black-box scoring at runtime.
+- **Deterministic classification first.** Local rules form Layer 1; the
+  small-model eval is off by default and sits behind them.
+- **Memory is middleware.** It helps a request be understood; it never rewrites
+  lane rules.
+- **Every surprising provider choice is explainable from the logs.**
 
-## 状态
+## Status
 
-| 阶段 | 状态 |
-|---|---|
-| 规格 | 已起草（即这些文档） |
-| MVP 范围锁定 | 待定 |
-| 实现 | 尚未开始 |
+| Stage | Status |
+|-------|--------|
+| Specification | Implemented (these documents describe the shipping system) |
+| Core gateway (routing, classification, protocol translation, store) | Implemented |
+| Admin UI | Implemented |
+| Release | 0.1 |

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -1,210 +1,324 @@
-# 调研笔记
+# Research Notes
+
+> Appendix / reference material: open-source projects studied while designing
+> Helm, with what to borrow and what to avoid. We do not copy code — we study the
+> approach and architecture and rewrite.
 
 ## Manifest
 
-GitHub: https://github.com/mnfst/manifest
+GitHub: <https://github.com/mnfst/manifest>
 
-Manifest 是一个面向智能体和 AI 应用的智能模型路由器。它会把每个请求路由到能够处理它的最便宜的模型上。
+Manifest is an intelligent model router for agents and AI applications. It routes
+each request to the cheapest model that can handle it.
 
-有价值的思路：
+Valuable ideas:
 
-- 本地、确定性的复杂度打分。
-- 23 个维度：关键词、结构以及上下文信号。
-- 四个层级：简单、标准、复杂、推理。
-- 针对具体任务的检测，涵盖编程、网页浏览、数据分析、图像生成、视频生成、社交媒体、邮件、日历以及交易。
-- 针对简短后续消息的会话惯性（session momentum）。
+- Local, deterministic complexity scoring.
+- 23 dimensions: keyword, structural, and contextual signals.
+- Four tiers: simple, standard, complex, reasoning.
+- Task-specific detection covering coding, web browsing, data analysis, image
+  generation, video generation, social media, email, calendar, and transactions.
+- Session momentum for short follow-up messages.
 
-值得借鉴：
+Worth borrowing:
 
-- 廉价的本地分类器。
-- 可解释的复杂度与任务信号。
-- 针对简短后续消息的惯性机制。
+- A cheap local classifier.
+- Explainable complexity and task signals.
+- Momentum for short follow-up messages.
 
-不要盲目照搬：
+Do not copy blindly:
 
-- 模型市场（model-market）的定位。
-- 把广泛的供应商接入作为产品的主要呈现面。
+- The model-market positioning.
+- Making broad provider coverage the product's primary surface.
 
-落地补充（扫描源码后确认）：
+Landing notes (confirmed after scanning the source):
 
-- 仓库确认即 `mnfst/manifest`（TypeScript，NestJS + SolidJS，**MIT**，可借鉴）。companion 测试器在 `mnfst/wingman`。
-- "23 维" = 14 个关键词维度 + 9 个结构/上下文维度；关键词通过一棵 trie 一次性匹配。
-- 四档边界（`scoring/config.ts`）：`simple < -0.10 ≤ standard < 0.08 ≤ complex < 0.35 ≤ reasoning`。
-- 置信度：`confidence = sigmoid(k=8 · 到最近边界的距离)`；< 0.45 视为不确定，降级到 standard。
-- 硬覆盖：`HEARTBEAT_OK` → simple；形式逻辑关键词 → reasoning；带 tools → 下限 standard；> 50k token → 下限 complex；< 50 字符且无复杂信号 → simple。
-- 会话动量：按 `x-session-key` 存最近 5 条、30 分钟 TTL；短消息（< 30 字符）历史权重最高可达 60%，> 100 字符则关闭动量。
-- 任务检测：维度→类目映射 + 工具名前缀（`browser_`/`code_`/`gmail_`…）+ 结构信号（URL、≥40 字符代码块、文件路径、堆栈）；`web_browsing` 激活阈值特意调高到 3.0。
-- **可移植边界**：维度名/权重/关键词/边界/阈值都是数据，可直接搬成 `classifier.yaml`（约 90% 调参面）；约 9 个结构打分函数、正则信号、覆盖控制流需要用代码实现。
+- The repo is `mnfst/manifest` (TypeScript, NestJS + SolidJS, **MIT**, usable as
+  reference). The companion tester is `mnfst/wingman`.
+- The "23 dimensions" = 14 keyword dimensions + 9 structural/contextual
+  dimensions; keywords are matched in one pass via a trie.
+- Four-tier boundaries (`scoring/config.ts`):
+  `simple < -0.10 ≤ standard < 0.08 ≤ complex < 0.35 ≤ reasoning`.
+- Confidence: `confidence = sigmoid(k=8 · distance to the nearest boundary)`;
+  `< 0.45` is treated as uncertain and degrades to standard.
+- Hard overrides: `HEARTBEAT_OK` → simple; formal-logic keywords → reasoning;
+  presence of tools → floor of standard; `> 50k` tokens → floor of complex;
+  `< 50` characters with no complexity signal → simple.
+- Session momentum: keeps the last 5 messages per `x-session-key` with a 30-minute
+  TTL; for short messages (`< 30` chars) history weight can reach 60%, and for
+  `> 100` chars momentum is turned off.
+- Task detection: dimension → category mapping + tool-name prefixes
+  (`browser_` / `code_` / `gmail_` …) + structural signals (URLs, code blocks
+  `≥ 40` chars, file paths, stack traces); the `web_browsing` activation threshold
+  is intentionally raised to 3.0.
+- **Portable surface**: dimension names/weights/keywords/boundaries/thresholds are
+  all data and can be lifted straight into a `classifier.yaml` (~90% of the tuning
+  surface); roughly 9 structural scoring functions, regex signals, and override
+  control flow need to be implemented in code.
 
-## llm-router probe（评估小模型的来源）
+## llm-router probe (origin of the eval small model)
 
-llm-router 的 5 段流水线里第 2 段 "probe" 就是一个经济型 LLM 预分类器，是 Helm 第 2 层 eval 的直接参考。
+In llm-router's 5-stage pipeline, the second stage — "probe" — is an economy LLM
+pre-classifier, and it is the direct reference for Helm's Layer-2 eval.
 
-复用的设计：
+Designs reused:
 
-- strict-JSON 输出 + Zod 校验；`temperature:0`、非流式。
-- 双超时硬化：runner 内 `Promise.race`（500/300ms）+ consumer 独立外层 `Promise.race`（250ms）。
-- fail-open：超时/provider 错误/熔断/解析失败一律 → `advisory=null`，主路径继续。
-- L1 缓存：按 `conversation_id`、60s TTL、LRU 5000 条。
+- Strict-JSON output + Zod validation; `temperature:0`, non-streaming.
+- Double-timeout hardening: a runner-internal `Promise.race` (500/300ms) + an
+  independent outer consumer `Promise.race` (250ms).
+- Fail-open: a timeout / provider error / circuit-open / parse failure all yield
+  `advisory=null`, and the main path continues.
+- L1 cache: keyed by `conversation_id`, 60s TTL, LRU of 5000 entries.
 
-为 Helm 要改的点：
+What Helm changes:
 
-- probe 是**仅咨询**（不改路由）；Helm 的 eval 改为**可决策**，输出直接选 lane。
-- 缓存键从 `conversation_id` 改为 **content-hash**（无状态网关更合适）。
-- probe 调用**无 `max_tokens` 上限**（规模化成本风险）→ Helm 必须加上限。
-- probe 的 `fallbacks` / `production_timeout_ms` 是"配了但没接线"→ Helm 要么实现要么删掉，不要让配置说谎。
+- The probe is **advisory only** (it does not change routing); Helm's eval is
+  **decision-making** — its output selects a lane directly.
+- The cache key moves from `conversation_id` to a **content hash** (better for a
+  stateless gateway).
+- The probe call has **no `max_tokens` cap** (a cost risk at scale) → Helm must
+  add a cap.
+- The probe's `fallbacks` / `production_timeout_ms` are "configured but not wired"
+  → Helm must either implement them or drop them; configuration must not lie.
 
-## 协议互译实现参考（Protocol translation）
+## Protocol translation references
 
-调研开源的 OpenAI / Anthropic / Responses / Gemini 协议互译实现（含流式 SSE），用于设计 Protocol Adapter。**我们不抄代码，自己重写——参考其实现思路与架构**（授权问题另行处理，不作为选型约束）。以"完整度 + 正确性 + 架构清晰度"为标尺做了覆盖矩阵对比。
+Survey of open-source OpenAI / Anthropic / Responses / Gemini protocol
+translators (including streaming SSE), used to design the Protocol Adapter. **We do
+not copy code — we rewrite, referencing the approach and architecture** (licensing
+is handled separately and is not a selection constraint). A coverage matrix was
+compared on "completeness + correctness + architectural clarity".
 
-### 👑 参考标杆：musistudio/llms
+### Reference benchmark: musistudio/llms
 
-`https://github.com/musistudio/llms`（TypeScript，claude-code-router 的翻译引擎）。它是唯一**存在意义就是协议互译**的项目，契约最干净、双向、且已是我们的目标语言。
+`https://github.com/musistudio/llms` (TypeScript, the translation engine behind
+claude-code-router). It is the only project whose entire reason to exist is
+protocol translation — the cleanest contract, bidirectional, and already in our
+target language.
 
-为什么它在"我们这个具体问题"上完整度最高：
+Why it is the most complete for our specific problem:
 
-- 每个协议 = 一个类，实现 **5 方法契约**：`transformRequestOut`（native 入站 → 统一 IR）、`transformRequestIn`（IR → native 出站）、`transformResponseIn`、`transformResponseOut`、`endPoint`（它负责的入站路由，如 `/v1/messages`、`/v1beta/models/:modelAndAction`）。入站与出站翻译在同一个文件里，一个协议一处描述完——这正是它"可重写"的原因。
-- 统一中枢 = **OpenAI Chat Completions 形态**。litellm / Portkey / new-api / one-api / Bifrost 五个独立实现都收敛到同一个 IR，所以这是事实标准；选它意味着遇到边界 case 还能交叉参考其他五个实现。
-- **流式状态机最值得啃**且很成熟：`anthropic.transformer.ts` 的 `convertOpenAIStreamToAnthropic` 用单调 `contentIndex` 分配器 + `toolCallIndexToContentBlockIndex` 映射（并行/流式工具调用的正确解法）+ 临时 id 后补升级 + `safeClose/safeEnqueue` 幂等关闭守卫。这恰好是 litellm 踩错的那类 bug（Gemini `input_json_delta` 丢失 #25561）的正面参照。
+- Each protocol = one class implementing a **5-method contract**:
+  `transformRequestOut` (native inbound → unified IR), `transformRequestIn` (IR →
+  native outbound), `transformResponseIn`, `transformResponseOut`, and `endPoint`
+  (the inbound route it owns, e.g. `/v1/messages`,
+  `/v1beta/models/:modelAndAction`). Inbound and outbound translation live in the
+  same file — one protocol fully described in one place — which is exactly why it
+  is rewritable.
+- The unified hub = the **OpenAI Chat Completions** shape. Five independent
+  implementations (litellm, Portkey, new-api, one-api, Bifrost) all converge on
+  the same IR, so this is the de facto standard; choosing it means edge cases can
+  be cross-referenced against the other five.
+- The **streaming state machine** is the most worth studying and is mature:
+  `anthropic.transformer.ts`'s `convertOpenAIStreamToAnthropic` uses a monotonic
+  `contentIndex` allocator + a `toolCallIndexToContentBlockIndex` map (the correct
+  solution for parallel / streamed tool calls) + temporary-id upgrade-on-arrival +
+  idempotent `safeClose/safeEnqueue` guards. This is exactly the class of bug
+  litellm got wrong (Gemini `input_json_delta` loss, #25561).
 
-弱点：Responses API 比 litellm 浅、文档稀疏（要读源码）、单人维护（靠 claude-code-router 用户量实战）。
+Weaknesses: the Responses API is shallower than litellm and thinly documented
+(read the source); single-maintainer (battle-tested via claude-code-router's user
+base).
 
-### 🥈 正确性规范：BerriAI/litellm
+### Correctness spec: BerriAI/litellm
 
-`https://github.com/BerriAI/litellm`（Python）。架构耦合进大框架不适合当模板，但**边界 case 的正确性最全**，当"checklist"用：
+`https://github.com/BerriAI/litellm` (Python). Its architecture is coupled into a
+large framework and is unsuitable as a template, but its **edge-case correctness is
+the most complete** — use it as the "checklist":
 
-- 唯一有**真正完整的 Responses API 翻译深度**：Anthropic `/v1/messages` → `/responses` 的 item 展开、`tool_use`/`tool_result` 提升为顶层 item、`budget_tokens`→effort、reasoning item、compaction 形状映射（doc: `anthropic_unified/messages_to_responses_mapping`）。即便我们用 TS 实现，也要照它的 spec 级清单补齐。
-- 正确性 helper：`truncate_tool_name`（OpenAI 64 字符上限 vs Anthropic 无限制，SHA-256 防碰撞截断 + 响应时还原）、`_add_additional_properties_false`（递归强制 OpenAI strict-mode JSON schema）、按模型族 gate `cache_control`。
+- The only one with **truly complete Responses API translation depth**: Anthropic
+  `/v1/messages` → `/responses` item expansion, promoting `tool_use` / `tool_result`
+  to top-level items, `budget_tokens` → effort, reasoning items, and compaction
+  shape mapping (doc: `anthropic_unified/messages_to_responses_mapping`). Even
+  implementing in TS, match its spec-level checklist.
+- Correctness helpers: `truncate_tool_name` (OpenAI's 64-char limit vs. Anthropic's
+  unlimited — SHA-256 collision-safe truncation + restore on response),
+  `_add_additional_properties_false` (recursively forcing OpenAI strict-mode JSON
+  schema), and gating `cache_control` by model family.
 
-第三参照：**QuantumNous/new-api**（Go），其 adaptor 显式暴露 `ConvertOpenAIRequest`/`ConvertClaudeRequest`/`ConvertGeminiRequest`，验证 any-to-any 入站矩阵。
+Third reference: **QuantumNous/new-api** (Go), whose adaptor explicitly exposes
+`ConvertOpenAIRequest` / `ConvertClaudeRequest` / `ConvertGeminiRequest`,
+validating the any-to-any inbound matrix.
 
-### 要啃的源码（musistudio/llms，`src/transformer/`）
+### Source to study (musistudio/llms, `src/transformer/`)
 
-- `anthropic.transformer.ts` — 核心。`transformRequestOut`（system 数组→system 消息、`tool_result`→`role:"tool"`、`tool_use`→`tool_calls`、thinking+signature）、`convertOpenAIResponseToAnthropic`（finish-reason 映射、usage 拆分 `input = prompt − cached`）、`convertOpenAIStreamToAnthropic`（流式状态机）。
-- `gemini.transformer.ts` + `utils/gemini.util.ts` — `alt=sse`、`x-goog-api-key`、无 tool-call ID、schema `format` 限制。
-- `openai.transformer.ts` + `openai.responses.transformer.ts` — 中枢恒等变换 + Responses 面。
-- `tooluse / reasoning / maxtoken / streamoptions ...transformer.ts` — **可叠加的横切行为 transformer** 管线模式。
-- `index.ts`（transformer 注册表）、`server.ts`（`endPoint` 如何挂成入站路由）。
+- `anthropic.transformer.ts` — the core. `transformRequestOut` (system array →
+  system message, `tool_result` → `role:"tool"`, `tool_use` → `tool_calls`,
+  thinking + signature), `convertOpenAIResponseToAnthropic` (finish-reason mapping,
+  usage split `input = prompt − cached`), `convertOpenAIStreamToAnthropic` (the
+  streaming state machine).
+- `gemini.transformer.ts` + `utils/gemini.util.ts` — `alt=sse`, `x-goog-api-key`,
+  no tool-call IDs, schema `format` restrictions.
+- `openai.transformer.ts` + `openai.responses.transformer.ts` — the hub identity
+  transform + the Responses surface.
+- `tooluse / reasoning / maxtoken / streamoptions ...transformer.ts` — the
+  **stackable cross-cutting behavior transformer** pipeline pattern.
+- `index.ts` (the transformer registry) and `server.ts` (how `endPoint` is mounted
+  as an inbound route).
 
-### 要 lift 的架构模式（思路，非代码）
+### Architecture patterns to lift (the approach, not the code)
 
-1. **唯一 IR = OpenAI Chat 形态**（5 个独立实现共同验证）。
-2. **每协议一个类、5 方法契约**，入站+出站同处一文件。
-3. **翻译永远走 `nativeIn → IR → nativeOut`**，绝不做 N×N 直连对：N 个协议 = **2N 个变换函数,不是 N² 个适配器**——这是最重要的设计决策。
-4. **流式 = 显式的每方向状态机**（不是透传）：维护 content-block index 分配器、tool-call-index→block-index 映射、临时 id→真 id 升级、幂等关闭守卫；确定性地发 `message_start → content_block_start/delta/stop → message_delta → message_stop`。
-5. **横切关注点做成可叠加的行为 transformer**（max-token 钳制、tool-use 归一、reasoning 注入）叠在协议 transformer 之上。
+1. **One IR = the OpenAI Chat shape** (validated by five independent
+   implementations).
+2. **One class per protocol, a 5-method contract**, inbound + outbound in one
+   file.
+3. **Translation always goes `nativeIn → IR → nativeOut`**, never N×N direct
+   pairs: N protocols = **2N transform functions, not N²** — the single most
+   important design decision.
+4. **Streaming = an explicit per-direction state machine** (not passthrough):
+   maintain a content-block index allocator, a tool-call-index → block-index map,
+   temporary-id → real-id upgrades, and idempotent close guards; deterministically
+   emit `message_start → content_block_start/delta/stop → message_delta →
+   message_stop`.
+5. **Cross-cutting concerns as stackable behavior transformers** (max-token
+   clamping, tool-use normalization, reasoning injection) layered on top of the
+   protocol transformers.
 
-补充要点（在上述 5 点之上）：
+Additional points (on top of the five above):
 
-- 统一 IR 在 OpenAI Chat 形态基础上**扩展可选字段**：thinking/推理块、多部件 typed content（图像/文档）、tool-call ID、cache-control、`provider_raw` 透传袋（装上游原生 `stop_reason`/`usage`，供 agent 客户端还原）。
-- 若一个协议既可作入站（client）又可作出站（provider），就是 2N 变换函数；若入站集合与出站集合分开，则是 N+M 适配器——本质都是"经中枢中转，绝不 N×N 直连"。
-- 为"客户端要流式但上游是单 JSON（缓存命中 / 非流式 provider）"准备 **JSON→SSE 合成器**。
+- The unified IR extends the OpenAI Chat shape with **optional fields**: thinking /
+  reasoning blocks, multipart typed content (image / document), tool-call IDs,
+  cache-control, and a `provider_raw` passthrough bag (carrying the upstream native
+  `stop_reason` / `usage` so agent clients can reconstruct them).
+- If a protocol can act as both inbound (client) and outbound (provider), it is 2N
+  transform functions; if the inbound and outbound sets are disjoint, it is N+M
+  adapters — either way, everything routes through the hub, never N×N direct.
+- Provide a **JSON → SSE synthesizer** for "the client wants streaming but the
+  upstream returned a single JSON" (cache hit / non-streaming provider).
 
-**必须处理的 5 个流式 / 边界坑**：
+**Five streaming / edge-case pitfalls that must be handled:**
 
-1. **finish_reason / stop_reason 枚举错配**：OpenAI SDK 对非法枚举会丢弃整个响应（含已生成内容）；全塌成 `stop` 又会让 agent 静默误判。→ 映射成合法枚举**并**把原始值存进 `provider_raw`。
-2. **token usage 字段翻译与缓存重复计费**：Anthropic 的 `input_tokens/cache_read_input_tokens` vs OpenAI 的 `prompt_tokens/prompt_tokens_details.cached_tokens`；流式下曾把缓存读当全价输入导致 ~10× 成本错误。→ 显式翻译、`input = prompt − cached`、流式末事件 buffer usage。
-3. **tool-call 流式的 index/ID 协调**：OpenAI 按整数 index 流、id/name 可能只在首片、参数分片到达；Anthropic 需先 `tool_use` 块带 id+name 再 `input_json_delta`。→ 维护 index→block 映射、合成临时 id/name 后覆盖、容忍残缺 JSON（jsonrepair）。
-4. **流式 block/part ID 与 role 一致性**：每个块必须先 start 再 delta 后 stop，缺 start 的 delta 会被严格消费方静默丢弃；OpenAI 首片 delta 必须带 `role:"assistant"` 否则 LangChain 检测不到工具调用。→ 跟踪开块状态 + 关闭守卫防"controller already closed"。
-5. **system 提示与多模态结构错配**：OpenAI 把 system 放 `messages[0]`，Anthropic 用顶层 `system` 且禁止连续同角色消息（需合并连续 user/tool_result）；图像 `image_url` vs `source:{base64}` 要拆字段；Gemini 无 tool-call ID 需合成、`format` 仅支持 date/date-time。
+1. **finish_reason / stop_reason enum mismatch**: the OpenAI SDK discards the
+   entire response (including already-generated content) on an illegal enum;
+   collapsing everything to `stop` makes agents silently misjudge. → Map to a legal
+   enum **and** store the original value in `provider_raw`.
+2. **Token-usage field translation and cache double-billing**: Anthropic's
+   `input_tokens` / `cache_read_input_tokens` vs. OpenAI's `prompt_tokens` /
+   `prompt_tokens_details.cached_tokens`; in streaming, cache reads were once
+   counted as full-price input, causing a ~10× cost error. → Translate explicitly,
+   `input = prompt − cached`, and buffer usage in the final streaming event.
+3. **Tool-call streaming index/ID coordination**: OpenAI streams by integer index,
+   id/name may appear only in the first chunk, and arguments arrive in fragments;
+   Anthropic needs a `tool_use` block carrying id + name first, then
+   `input_json_delta`. → Maintain an index → block map, synthesize a temporary
+   id/name and overwrite it later, and tolerate incomplete JSON (jsonrepair).
+4. **Streaming block/part ID and role consistency**: every block must be started
+   before delta and stopped after; a delta with no start is silently dropped by
+   strict consumers; the first OpenAI delta must carry `role:"assistant"` or
+   LangChain will not detect the tool call. → Track open-block state + a close
+   guard to prevent "controller already closed".
+5. **System prompt and multimodal structure mismatch**: OpenAI puts system in
+   `messages[0]`, Anthropic uses a top-level `system` and forbids consecutive
+   same-role messages (merge consecutive user/tool_result); image `image_url` vs.
+   `source:{base64}` must be split; Gemini has no tool-call IDs (synthesize them)
+   and `format` only supports date/date-time.
 
-参考源：
-- https://github.com/musistudio/llms — `src/transformer/anthropic.transformer.ts`
-- https://github.com/Portkey-AI/gateway — `src/handlers/streamHandler.ts`、`src/handlers/responseHandlers.ts`
-- https://github.com/BerriAI/litellm — usage/finish_reason 坑的 issue 来源
-- https://github.com/maxnowack/anthropic-proxy
+References:
+
+- <https://github.com/musistudio/llms> — `src/transformer/anthropic.transformer.ts`
+- <https://github.com/Portkey-AI/gateway> — `src/handlers/streamHandler.ts`,
+  `src/handlers/responseHandlers.ts`
+- <https://github.com/BerriAI/litellm> — source of the usage / finish_reason pitfall
+  issues
+- <https://github.com/maxnowack/anthropic-proxy>
 
 ## Plano
 
-GitHub: https://github.com/katanemo/plano
+GitHub: <https://github.com/katanemo/plano>
 
-Plano 是一个面向智能体应用、AI 原生的代理与数据平面。它包含智能体编排、模型路由、过滤链、可观测性以及信号（signals）。
+Plano is an AI-native proxy and data plane for agentic applications. It includes
+agent orchestration, model routing, filter chains, observability, and signals.
 
-有价值的思路：
+Valuable ideas:
 
-- 智能体 / 数据平面的框架视角。
-- 把过滤链作为中间件。
-- 语义别名与偏好感知的路由。
-- 用 Agentic Signals 实现低成本的生产环境反馈。
+- An agent / data-plane framing.
+- Filter chains as middleware.
+- Semantic aliases and preference-aware routing.
+- Low-cost production feedback via Agentic Signals.
 
-值得借鉴：
+Worth borrowing:
 
-- 为 Memory / Guardrails 设立的中间件边界。
-- 把 Signals 作为未来的反馈层。
-- 通道（lane）/ 别名抽象。
+- A middleware boundary for Memory / Guardrails.
+- Signals as a future feedback layer.
+- The lane / alias abstraction.
 
-不要盲目照搬：
+Do not copy blindly:
 
-- 庞大的平台范围。
-- 在 MVP 阶段就内置智能体编排。
+- The sprawling platform scope.
+- Building in agent orchestration at the MVP stage.
 
 ## Portkey
 
-Website: https://portkey.ai/
+Website: <https://portkey.ai/>
 
-Portkey 是一个企业级 AI 网关 / LLMOps 平台。
+Portkey is an enterprise AI gateway / LLMOps platform.
 
-有价值的思路：
+Valuable ideas:
 
-- 统一的供应商网关。
-- 重试、回退、负载均衡、条件路由。
-- 可观测性、成本、护栏以及密钥管理。
+- A unified provider gateway.
+- Retries, fallbacks, load balancing, conditional routing.
+- Observability, cost, guardrails, and key management.
 
-值得借鉴：
+Worth borrowing:
 
-- 请求追踪与成本看板。
-- 虚拟密钥管理。
-- 回退策略的相关概念。
+- Request tracing and a cost dashboard.
+- Virtual key management.
+- The concepts behind fallback strategies.
 
-不要盲目照搬：
+Do not copy blindly:
 
-- 在 MVP 阶段就铺开企业级控制平面。
+- Rolling out an enterprise control plane at the MVP stage.
 
 ## Tingly Box
 
-GitHub: https://github.com/tingly-dev/tingly-box
+GitHub: <https://github.com/tingly-dev/tingly-box>
 
-Tingly Box 是一个本地 / 自托管的 Agent Gateway 与控制盒。它把模型代理、OAuth 供应商复用、Web UI、远程 IM 控制、智能体配置档（agent profiles）、护栏以及用量分析结合在一起。
+Tingly Box is a local / self-hosted Agent Gateway and control box. It combines a
+model proxy, OAuth provider reuse, a web UI, remote IM control, agent profiles,
+guardrails, and usage analytics.
 
-有价值的思路：
+Valuable ideas:
 
-- 复用 OAuth 订阅配额。
-- 智能体配置档管理。
-- 用户 token 与模型 token 的分离。
-- 用于管理供应商、路由、别名和 token 的 Web UI。
+- Reusing OAuth subscription quotas.
+- Agent profile management.
+- Separation of user tokens and model tokens.
+- A web UI to manage providers, routing, aliases, and tokens.
 
-值得借鉴：
+Worth borrowing:
 
-- OAuth 供应商集成的模式。
-- 本地控制平面的交互体验思路。
-- token 分离。
+- The OAuth provider integration pattern.
+- The UX ideas for a local control plane.
+- Token separation.
 
-不要盲目照搬：
+Do not copy blindly:
 
-- IM 远程控制以及完整的智能体控制盒范围。
-- 在 MVP 阶段就引入庞大的安全面。
+- IM remote control and the full agent-control-box scope.
+- Introducing a large security surface at the MVP stage.
 
 ## Mastra Observational Memory
 
-Issue: https://github.com/EasyMetaAu/llm-router/issues/362
-Docs: https://mastra.ai/docs/memory/observational-memory
-Research: https://mastra.ai/research/observational-memory
+- Issue: <https://github.com/EasyMetaAu/llm-router/issues/362>
+- Docs: <https://mastra.ai/docs/memory/observational-memory>
+- Research: <https://mastra.ai/research/observational-memory>
 
-有价值的思路：
+Valuable ideas:
 
-- 网关层的记忆。
-- Observer 与 Reflector 后台智能体。
-- 稳定、对缓存友好的记忆上下文。
-- 用观测（observations）与反思（reflections）代替完整的原始历史。
+- Gateway-level memory.
+- Observer and Reflector background agents.
+- A stable, cache-friendly memory context.
+- Replacing the full raw history with observations and reflections.
 
-值得借鉴：
+Worth borrowing:
 
-- 把记忆作为可选的中间件。
-- `thread/resource/project` 记忆作用域。
-- 观测 + 反思的流水线。
+- Memory as an optional middleware.
+- `thread` / `resource` / `project` memory scopes.
+- The observation + reflection pipeline.
 
-不要盲目照搬：
+Do not copy blindly:
 
-- 在 MVP 的核心路径中引入记忆。
-- 把动态 RAG 作为默认的记忆策略。
+- Putting memory in the MVP core path.
+- Making dynamic RAG the default memory strategy.
+
+> See [08 · Memory Middleware](08-memory-middleware.md) for how these ideas map to
+> Helm: the observe phase is implemented, the inject phase / Observer / Reflector
+> are on the roadmap.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,51 @@
 
 ---
 
+## 2026-06-01 · Reconcile stream-only capability gate with routing/cost tests (docs/03/04/07, Principle 5)
+
+**Context**: the stream-only capability gate (commit `3eb15ab`, `no_nonstream_support`) left **6 tests red on `main`** — they predated the gate and asserted that the `openai-crs/*` heads (gpt-5.4-mini, gpt-5.5; `requiresStreaming: true` in `capabilities.yaml`) serve **non-stream** requests. They no longer can: a non-stream request correctly SKIPS them and falls forward. Surfaced during the 0.1 doc-audit verification run.
+
+**Root cause (not a product bug — the gateway is behaving correctly)**: `capability/filter.ts` gate 6 skips a `requiresStreaming` model when `req.stream !== true`. So a non-stream economy request lands on `deepseek-crs/deepseek-flash`; a non-stream premium request lands on `zenmux/claude-opus-4.7`. The tests, not the runtime, were stale.
+
+**Fix (tests only — zero runtime change)**:
+- `apps/gateway/e2e/routing.spec.ts` scenarios 1/2/4 + `eval.spec.ts` scenario 2: send the requests as **streaming** (`stream: true`) so the stream-only lane HEAD is eligible and actually serves, preserving each test's "lane → its head model" intent. Assertions now read the debug headers (`x-helm-lane` / `x-helm-final-model` / `x-helm-provider-model`), which the gateway emits before the SSE body, instead of parsing a JSON body. Scenario 4 now genuinely exercises EXECUTION fallback: streaming means the head is actually invoked, 5xxs on the fail sentinel (the mock's injection runs before its stream branch), and the chain falls forward to `deepseek-flash` — previously it passed only because the non-stream head was skip-not-failed. Also corrected a stale `0.45` → `0.42` gate reference in the file header.
+- `apps/gateway/src/routes/execute.default-config.test.ts` (3 cases): these isolate JSON capability filtering + cost on the SHIPPED config and used `openai-crs/gpt-5.4-mini` as the "json-capable model that serves" — incidental, and now stream-only. Kept them NON-stream (the cost path backfills streamed cost in the route, not in `execute()`, so a non-stream served attempt is the right cost oracle) and switched the landing model to `deepseek-crs/deepseek-pro` (json-capable AND non-stream-capable). Cost expectation updated to deepseek-pro pricing (0.435/0.87 → `0.00087` for 1000+500 tokens).
+
+**Gate**: `pnpm test` 1255/1255; `pnpm test:e2e` 36/36; `pnpm typecheck` clean; `pnpm lint` exit 0.
+
+---
+
+## 2026-06-01 · 0.1 release — doc/code audit & English-ization (README, docs/01–11, all code comments)
+
+**Context**: preparing the 0.1 open-source release. The README and every `docs/*.md` were Chinese and **stale** (several still claimed the project was spec-first / not yet implemented), and ~93 source files carried Chinese in comments and test names. This pass produced an English-default bilingual README, rewrote all docs into English with **code as the source of truth**, and translated the codebase to 100% English. **No runtime behavior changed** — edits were limited to docs, comments, test-description strings, and two dead regex branches.
+
+**What was done**:
+- **README**: rewrote `README.md` (English, standard MIT-OSS layout) + new `README.zh-CN.md`, cross-linked with a language switch. Accurate to code: 3 wired client protocols, Responses non-streaming, default lanes, eval off by default, SQLite default.
+- **docs/**: rewrote `docs/README.md` + `01`–`11` + `research-notes.md` into English, corrected against code. Status tables updated from "not started" to "implemented / 0.1".
+- **Code**: translated Chinese → English in comments and test descriptions across `packages/shared`, `packages/core`, `apps/gateway`, `apps/admin`. Confirmed **zero hard-coded user-facing Chinese** — all admin UI text already flows through the i18n system (`apps/admin/src/locales/*.json`), which is left untouched, as are the `native` language display names in `apps/admin/src/lib/config/languages.ts`.
+
+**Doc ↔ code discrepancies found & corrected** (code is authoritative):
+1. **Stale status** (README, docs/README, docs/09): "spec-first / 尚未开始 / 待定" → the gateway, admin UI, core and stores are fully implemented and tested.
+2. **Client protocols** (docs/01, 05): only **3** are routed — `POST /v1/chat/completions` (OpenAI Chat), `POST /v1/messages` (Anthropic Messages), `POST /v1/responses` (OpenAI Responses). A Gemini transformer exists in `packages/core/src/protocol/gemini/` but is **not mounted** (no route in `apps/gateway/src/server.ts`) → documented as roadmap.
+3. **Responses is non-streaming only** (docs/05): `stream:true` on `/v1/responses` returns a structured 400 (`apps/gateway/src/routes/responses.ts`). Chat + Messages stream via SSE.
+4. **Memory middleware** (docs/08): old doc said `memory_mode` was hardcoded `off` / dead. Reality: the **observe** phase is wired & active (`resolveMemoryScope` + `observeInbound`/`observeOutbound` in `chat.ts`, `messages-pipeline.ts`, `messages.ts`, `responses.ts`); only the **inject** phase (`assembleInjectedContext`) is never called → observe = implemented, inject = roadmap.
+5. **Classifier calibration drift** (docs/03): live `config/classifier.yaml` is `confidence_threshold 0.42`, `sigmoid_k 12`, tier boundaries `standard:-0.06 / complex:0.30 / reasoning:0.85`; eval model id is `deepseek-flash` (old docs said `deepseek/deepseek-v4-flash`). Docs now describe the mechanism and point at the YAML rather than hardcoding drift-prone numbers.
+6. **Complexity tier collapse 4 → 3**: classifier emits `simple | standard | complex | reasoning`, but routing only understands `simple | medium | complex` via `mapComplexity` (`apps/gateway/src/routes/classify.ts`); `reasoning` collapses to `complex` and is routing-inert. Documented in 03/04.
+7. **Explicit `auto` is not a passthrough model**: `routing/route-request.ts` excludes `requested_model === "auto"` from explicit passthrough (falls through to classification). Documented in 04.
+8. **Per-key lane cap beats policy `use_lane` pin** (`route-request.ts`): key caps apply after policy caps. Documented in 04.
+9. **`security` task type without a `security` lane**: `taskdetect.ts` can emit `task_type: security`, but `policies.yaml` pins complex security to `premium` instead. Documented in 03.
+10. **Decision record fields** (docs/02, 07): reconciled to the real `DecisionRecord` (`trace_id`, `key_prefix`, `fallback_reason`, `provider_attempts[].error_detail`, `latency_total_ms`, `fallback_count`, `cost_breakdown`).
+11. **Admin config shape** (docs/06, 11): `config/auth.yaml` ships only `require_api_key` + `bootstrap` — there is **no `admin:` block**, yet `resolveAdminAuth` (`apps/gateway/src/middleware/basic-auth.ts`) reads `cfg.admin.{enabled,username,password}`. In practice admin is configured via env (`HELM_ADMIN_USER`/`HELM_ADMIN_PASSWORD`), and **credentials being present auto-enables the admin surface** (when disabled, `/admin` + `/admin/api/*` are not mounted → 404). Docs treat the `admin:` block as optional and emphasize the env path. *Open item for maintainer: either add an `admin:` block to `auth.yaml` or document admin config as env-only.*
+
+**Decisions / notes**:
+- **This file (`implementation-notes.md`) stays in Chinese** for its historical entries — it is an internal engineering log, not in `docs/`, and 227k of retro-translation is out of scope/risk for 0.1. New entries (like this one) are written in English going forward.
+- **`apps/admin/src/routes/policies/policies.test.ts`**: removed the now-dead Chinese alternation branches from two regexes (`|自上而下|首条命中`, `|打分`); tests run under the `en` locale so the English branches already match.
+- **Kept verbatim**: i18n locale JSON, `native` language names (`简体中文` etc.), and the Chinese legal-entity name in the MIT copyright line (matches `LICENSE`).
+
+**Gate**: see the same-day verification run (typecheck / lint / test / e2e) below in the session; residual-CJK grep over tracked `*.ts`/`*.svelte`/`*.js` returns only the intentional `languages.ts` native names.
+
+---
+
 ## 2026-06-01 · stream-only 上游：能力过滤新增 `no_nonstream_support` 门（docs/03/07，原则 3/5）
 
 **背景**：`la.atmy.work` relay 的 `gpt-5.x`（gpt-5.5 / gpt-5.4-mini / gpt-5.3-codex-spark）是 **STREAM-ONLY**——非流式请求被上游 400 `"Stream must be set to true"`。而 `gpt-5.4-mini` 是 economy/balanced 的 **primary**，故每个**非流式**请求都在第一跳 400 后才 fail-over。客户端拿到 200（fail-over 有效），但每次 400 都 `breaker.recordFailure`，**持续非流式流量会把该 alias 的熔断器打到 OPEN**，进而连**流式**请求也被 `circuit_open` 跳过——一个被非流式流量误伤流式可用性的隐患（实弹集成测试 + 遥测 `error_detail` 排查发现）。

--- a/packages/core/src/capability/filter.ts
+++ b/packages/core/src/capability/filter.ts
@@ -8,7 +8,7 @@ import type { CatalogEntry } from "@helm/shared";
 // policy). For each candidate it walks the gates in a fixed order; the first
 // unmet gate short-circuits and returns a structured skip reason. That reason
 // is written into the decision record's `provider_attempts[].skip_reason` so
-// the debug UI can explain why a provider was skipped (docs/02 安全规则).
+// the debug UI can explain why a provider was skipped (docs/02 security rules).
 //
 // Framework-/network-/IO-free, deterministic: same input → same output
 // (principle 1 + principle 4). Capability data comes solely from `catalog.sync`

--- a/packages/core/src/catalog/cost.ts
+++ b/packages/core/src/catalog/cost.ts
@@ -1,6 +1,6 @@
 import type { Pricing } from "@helm/shared";
 
-// Cost conversion: provider token usage × catalog pricing (docs/07 「成本拆分」).
+// Cost conversion: provider token usage × catalog pricing (docs/07 "cost breakdown").
 // Framework-/network-free (principle 1). Pricing is quoted per MILLION tokens
 // (LiteLLM-derived generated catalog + manual overrides), so we divide by 1e6.
 //
@@ -50,8 +50,9 @@ export function usageFromBody(body: unknown): TokenUsage {
 // relay's OWN computed price, in USD. Different relays surface it differently, so
 // we probe, in precedence order: `usage.cost_usd` → `usage.cost` (OpenRouter) →
 // top-level `cost_usd`. When present this is AUTHORITATIVE (real money charged)
-// and must OVERRIDE our catalog estimate (CLAUDE.md 成本约定: 上游返回了就用它覆盖,
-// 没返回才用预制 pricing). Defensive (principle 3/7): only a finite, non-negative
+// and must OVERRIDE our catalog estimate (CLAUDE.md cost convention: if the upstream
+// returns cost use it to override; otherwise fall back to the prepared pricing).
+// Defensive (principle 3/7): only a finite, non-negative
 // number counts — anything else → null so the caller falls back to the estimate.
 // Never throws, never reads message content.
 export function billedCostFromBody(body: unknown): number | null {

--- a/packages/core/src/catalog/load.ts
+++ b/packages/core/src/catalog/load.ts
@@ -10,7 +10,7 @@ import { CatalogError, loadCatalog } from "./index.js";
 // with the two manual OVERRIDE yamls (capabilities.yaml / pricing.yaml). The pure
 // merge lives in `loadCatalog` (IO-free); this thin module only does the file IO
 // (mirrors config/loader.ts — core may read files, it just may not import a web
-// framework, principle 1). Manual entries win per-field (CLAUDE.md 实现约定); an
+// framework, principle 1). Manual entries win per-field (CLAUDE.md implementation conventions); an
 // invalid override fails closed (principle 2). Capability metadata flows from here
 // into the routing pipeline's capability filter — replacing the empty Map that
 // made the filter fail-open-skip every candidate.

--- a/packages/core/src/classifier/cascade.ts
+++ b/packages/core/src/classifier/cascade.ts
@@ -4,7 +4,7 @@ import type { EvalDecision } from "./eval/client.js";
 import type { TaskType } from "./taskdetect.js";
 import type { Complexity } from "./tiers.js";
 
-// eval.cascade — the THREE-layer classification cascade (docs/03 §分类级联),
+// eval.cascade — the THREE-layer classification cascade (docs/03 §Classification Cascade),
 // hit-stop: Layer 1 rules (always-on, zero-network, pure) → Layer 2 eval (ONLY
 // when rules are uncertain AND eval is enabled) → Layer 3 `balanced` fail-open.
 // This is the eval module's "final assembly": the SINGLE place that references

--- a/packages/core/src/classifier/eval/cache-key.ts
+++ b/packages/core/src/classifier/eval/cache-key.ts
@@ -11,7 +11,7 @@ import type { InternalRequest } from "@helm/shared";
 // The hash covers EXACTLY the 5 inputs that influence classification, pinned in
 // implementation-notes (2026-05-30):
 //   1. last_user_message  — last user message, trim()ed, NOT lowercased
-//   2. turn_count         — number of user-role messages (fixed 口径, see below)
+//   2. turn_count         — number of user-role messages (fixed convention, see below)
 //   3. tool_names         — tool names only (no schema), lexicographically sorted
 //   4. response_format_json — whether response_format requests JSON
 //   5. has_attachments    — whether an image/vision attachment is present
@@ -81,7 +81,7 @@ function lastUserMessage(messages: ClassifierInput["messages"]): string {
   return "";
 }
 
-// turn_count 口径 (fixed): number of role==="user" messages. This is the
+// turn_count convention (fixed): number of role==="user" messages. This is the
 // classification-relevant turn measure; documented here so eval.cascade and any
 // future consumer use the SAME counting rule and the key never drifts.
 function userTurnCount(messages: ClassifierInput["messages"]): number {

--- a/packages/core/src/classifier/momentum.ts
+++ b/packages/core/src/classifier/momentum.ts
@@ -1,7 +1,7 @@
 import type { ClassifierRulesConfig } from "@helm/shared";
 import type { Complexity } from "./tiers.js";
 
-// Session momentum — a single short follow-up ("yes", "go on", "再写一段") would,
+// Session momentum — a single short follow-up ("yes", "go on", "write another paragraph") would,
 // if classified in isolation, get scored `simple` and drag a complex/reasoning
 // conversation off-course. Momentum maintains a short, TTL'd classification
 // history per `x-session-key` and, when THIS message is short, blends the

--- a/packages/core/src/classifier/overrides.ts
+++ b/packages/core/src/classifier/overrides.ts
@@ -4,7 +4,7 @@ import type { Complexity } from "./tiers.js";
 
 // Layer-1 hard overrides & shortcuts — the deterministic signals that BYPASS the
 // weighted dimension score and pin (or floor) a tier directly. Per the Manifest
-// "硬覆盖与捷径": heartbeat → simple, formal logic → reasoning, tools → ≥standard,
+// "hard overrides & shortcuts": heartbeat → simple, formal logic → reasoning, tools → ≥standard,
 // long context → ≥complex, very-short-no-signal → simple. Keywords/thresholds/
 // floor tiers are DATA (classifier.yaml.overrides); matching and the tier-order
 // control flow are CODE here (CLAUDE.md principle 4 — a pure, network-free,

--- a/packages/core/src/classifier/signals.ts
+++ b/packages/core/src/classifier/signals.ts
@@ -2,7 +2,7 @@
 // Layer-1 structural regexes. Both `dimensions.ts` (complexity scoring) and
 // `taskdetect.ts` (task_type detection) consume THESE functions so the two
 // paths can never drift apart with two copies of the same regex (task spec:
-// "结构信号函数与 dimensions 共享同一实现"). Pure: same input => same output,
+// "structural-signal functions share one implementation with dimensions"). Pure: same input => same output,
 // zero I/O, no clock, no randomness (CLAUDE.md principle 4). Each detector
 // returns a [0,1] signal — 1 when the structure is present, 0 otherwise.
 

--- a/packages/core/src/classifier/taskdetect.ts
+++ b/packages/core/src/classifier/taskdetect.ts
@@ -4,7 +4,7 @@ import { detectCodeBlock, detectFilePath, detectStackTrace, detectUrl } from "./
 // Task-type detection — orthogonal to complexity tiers (this module produces NO
 // rawScore and reads none). It fuses three independent evidence paths, borrowing
 // Manifest's "dimension→category mapping + tool-name prefix + structural signal"
-// approach (docs/03 §第1层任务检测, research-notes §Manifest):
+// approach (docs/03 §Layer-1 task detection, research-notes §Manifest):
 //   1. keyword sets       — DATA in cfg.task_keywords
 //   2. tool-name prefixes — DATA in cfg.tool_prefixes (browser_/code_/sql_…)
 //   3. structural signals — CODE here (shared regexes from ./signals.ts)
@@ -200,7 +200,7 @@ function collectStrings(content: unknown, out: string[]): void {
 
 // Tool name lives at tools[].function.name (OpenAI shape) or tools[].name. The
 // MVP keeps `tools` an open array, so every access is defensive: malformed /
-// missing entries are simply skipped (no throw — task spec 边界).
+// missing entries are simply skipped (no throw — task spec boundary).
 function extractToolNames(tools: DetectInput["tools"]): string[] {
   if (!Array.isArray(tools)) return [];
   const names: string[] = [];

--- a/packages/core/src/config/env-map.ts
+++ b/packages/core/src/config/env-map.ts
@@ -35,7 +35,7 @@ export const ENV_MAPPINGS: readonly EnvMapping[] = [
     path: ["runtime", "rate_limit", "enabled"],
     kind: "boolean",
   },
-  // Store driver selection (DB 抽象层). HELM_STORE_DRIVER picks the adapter set
+  // Store driver selection (DB abstraction layer). HELM_STORE_DRIVER picks the adapter set
   // ('sqlite' | 'supabase'); an unknown value is fail-closed by the enum. The
   // connection string itself is referenced indirectly via HELM_STORE_URL_ENV
   // (the NAME of the env var holding the DSN) so no plaintext DSN lands in

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,7 +148,7 @@ export {
   LanesConfigSchema,
   parseLanesConfig,
 } from "./lanes/schema.js";
-// Memory middleware — inject phase (docs/08 阶段 2). Synchronous on the request
+// Memory middleware — inject phase (docs/08 Phase 2). Synchronous on the request
 // path: load + assemble a budgeted, cache-friendly context prefix in the fixed
 // docs/08 order, enqueue write-back, fail-open. Framework-agnostic; never touches
 // routing/lane state.
@@ -158,7 +158,7 @@ export {
   type InjectInput,
   type InjectResult,
 } from "./memory/inject.js";
-// Memory middleware — observe phase (docs/08 阶段 1). Framework-agnostic
+// Memory middleware — observe phase (docs/08 Phase 1). Framework-agnostic
 // write-only persistence; never injects memory or changes routing.
 export {
   type IRToolResult,
@@ -167,7 +167,7 @@ export {
   observeOutbound,
   resolveMemoryMode,
 } from "./memory/observe.js";
-// Memory middleware — background Reflector (docs/08 阶段 2). Periodically merges a
+// Memory middleware — background Reflector (docs/08 Phase 2). Periodically merges a
 // scope's observations into a stable, versioned reflection; off the main request
 // path, fail-open. Framework-agnostic; never touches routing/lane state.
 export {
@@ -347,7 +347,7 @@ export {
   saveRuntimeSettings,
 } from "./settings/runtime-settings.js";
 // Agentic Signals — POST-MVP low-cost production feedback layer (docs/02,
-// research-notes「Plano」). Pure aggregator + background collector that distill
+// research-notes "Plano"). Pure aggregator + background collector that distill
 // REDACTED routing signals from already-persisted decision records, ASYNCHRONOUS
 // and OFF the request path. Observe-only: this task never feeds signals back into
 // routing. Framework-agnostic; fail-open.

--- a/packages/core/src/lanes/schema.ts
+++ b/packages/core/src/lanes/schema.ts
@@ -11,7 +11,7 @@ import type { z } from "zod";
 
 // The lane Zod schema is the single source of truth in @helm/shared (so
 // HelmConfigSchema validates config against the SAME shape the router consumes;
-// schema-first, no duplicate definitions — CLAUDE.md 代码规范). This module
+// schema-first, no duplicate definitions — CLAUDE.md code style). This module
 // re-exports it for core's routing code and keeps the checked-in DEFAULT_LANES
 // constant, which is a CORE concern (first-boot baseline / fallback), not a
 // config shape. See docs/04-routing-and-lanes.md, packages/shared lanes-schema.

--- a/packages/core/src/memory/inject.ts
+++ b/packages/core/src/memory/inject.ts
@@ -1,7 +1,7 @@
 import type { AssembledMessage, Observation, RawMessage, Reflection } from "@helm/shared";
 import type { MemoryStore } from "../store/ports.js";
 
-// Memory middleware — INJECT phase (docs/08 阶段 2「观察式记忆 MVP」). When
+// Memory middleware — INJECT phase (docs/08 Phase 2 "observational-memory MVP"). When
 // x-memory-mode=inject, this runs SYNCHRONOUSLY on the main request path, BEFORE
 // classification/execution, and does three things:
 //   1. load memory (project/resource reflections + thread observations + recent
@@ -35,7 +35,7 @@ export interface InjectDeps {
   // Enqueue the background observer job; returns observer_job_id. Inject NEVER
   // awaits the compression itself — it only enqueues (Observer stays background).
   enqueueObserverJob: (scope: InjectInput["scope"]) => Promise<string>;
-  // Hydrate tokens are a SEPARATE cost bucket (docs/08「成本核算」): they must NOT
+  // Hydrate tokens are a SEPARATE cost bucket (docs/08 "cost accounting"): they must NOT
   // be mixed into the actor / observer / reflector buckets.
   costSink: (bucket: "hydrate", tokens: number) => void;
   now: () => Date;
@@ -158,7 +158,7 @@ export async function assembleInjectedContext(
         memory_tokens_injected: 0,
         observer_job_id: writeback.observerJobId,
         // Memory load failed → the whole memory step is a degraded path; mark the
-        // writeback status as failed (docs/08「合理降级」 + record the failure).
+        // writeback status as failed (docs/08 "graceful degradation" + record the failure).
         // EXCEPT when there was no writeback target at all (no threadId): nothing
         // could be enqueued, so it stays an honest "skipped", not "failed".
         memory_writeback_status: writeback.status === "skipped" ? "skipped" : "failed",
@@ -193,7 +193,7 @@ export async function assembleInjectedContext(
     source: "thread_observation" as const,
   }));
 
-  // Recent raw messages are kept verbatim, in order (docs/08「必须保留近期原始消息」).
+  // Recent raw messages are kept verbatim, in order (docs/08 "recent raw messages must be preserved").
   const recentRawMessages: AssembledMessage[] = recentMessages.map((m) => ({
     role: m.role,
     content: m.content,
@@ -202,8 +202,8 @@ export async function assembleInjectedContext(
 
   // ── budget trim ──────────────────────────────────────────────────────────
   // HARD cap on INJECTED tokens (system + current are excluded from the budget).
-  // Priority — recent raw is spec-mandated and ALWAYS survives (docs/08「必须保留
-  // 近期原始消息」). Everything else yields to the budget in this order:
+  // Priority — recent raw is spec-mandated and ALWAYS survives (docs/08 "recent raw
+  // messages must be preserved"). Everything else yields to the budget in this order:
   //   1. resource reflection (sacrificed first under pressure),
   //   2. project reflection,
   //   3. observations (oldest-first) get whatever remains.

--- a/packages/core/src/memory/observe.ts
+++ b/packages/core/src/memory/observe.ts
@@ -3,13 +3,13 @@ import type { IRMessage } from "../protocol/ir.js";
 import type { MemoryStore } from "../store/ports.js";
 import type { MemoryMeta, MemoryScope } from "./types.js";
 
-// observe mode (docs/08 阶段 1). Persists raw request/response/tool messages into
+// observe mode (docs/08 Phase 1). Persists raw request/response/tool messages into
 // the memory_* tables but NEVER injects memory or changes routing — observe is a
 // write-only middleware. Framework-agnostic: this module receives an already
 // resolved MemoryScope (the gateway parses the HTTP headers); it imports no web
 // framework (CLAUDE.md principle 1). Persistence is fail-open: a store failure
 // degrades to "continue without memory" + a logged failure, never a 5xx
-// (CLAUDE.md principle 3; docs/08 "记忆加载失败，主请求应在无记忆的情况下继续").
+// (CLAUDE.md principle 3; docs/08 "if memory load fails, the main request must continue without memory").
 
 // A tool result in the IR is just an IRMessage with role="tool" (carrying
 // tool_call_id). Aliased for a readable outbound contract.
@@ -20,7 +20,7 @@ export interface ObserveDeps {
   now: () => Date;
   estimateTokens: (text: string) => number;
   // Structured logger; callers thread trace_id through meta. Must not log full
-  // memory content verbatim (docs/08 完整记忆需显式授权并审计).
+  // memory content verbatim (docs/08 full memory requires explicit authorization and auditing).
   log: (line: string, meta?: object) => void;
 }
 
@@ -51,7 +51,7 @@ function serializeContent(content: IRMessage["content"]): string {
 
 function memoryMeta(scope: MemoryScope): MemoryMeta {
   // observe NEVER hydrates — memory_hydrated is always false and every
-  // inject-phase counter stays at its null/zero default (docs/08 调试 UI 字段).
+  // inject-phase counter stays at its null/zero default (docs/08 debug-UI field).
   return {
     memory_mode: scope.mode,
     thread_id: scope.threadId,
@@ -115,7 +115,7 @@ export async function observeInbound(
 
 // Outbound: on observe/inject, persist the response messages + tool results. off
 // is a no-op. Fail-open — a store failure is logged, never thrown. observe does
-// NOT enqueue an observer job (that is docs/08 阶段 2).
+// NOT enqueue an observer job (that is docs/08 Phase 2).
 export async function observeOutbound(
   deps: ObserveDeps,
   scope: MemoryScope,
@@ -146,7 +146,7 @@ export async function observeOutbound(
 
 // Gateway boundary helper: normalize a raw x-memory-mode header value to a legal
 // MemoryMode. Missing / illegal / wrong-case values fail safe to "off" (docs/08
-// 默认 x-memory-mode = off; default-safe). Kept here so the gateway adapter has
+// default x-memory-mode = off; default-safe). Kept here so the gateway adapter has
 // one source of truth without importing a web framework into core.
 export function resolveMemoryMode(raw: string | null | undefined): MemoryScope["mode"] {
   const parsed = MemoryModeSchema.safeParse(raw);

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -1,7 +1,7 @@
 import type { RawMessage } from "@helm/shared";
 import type { MemoryStore } from "../store/ports.js";
 
-// Background Observer (docs/08 阶段 2「观察式记忆 MVP」). This is an OFF-the-main-
+// Background Observer (docs/08 Phase 2 "observational-memory MVP"). This is an OFF-the-main-
 // request-path job: the request path only persists raw messages and enqueues an
 // observer job; this function runs LATER, in a background worker, compressing a
 // thread's OLDER raw messages into a single time-anchored observation. It never
@@ -12,7 +12,7 @@ import type { MemoryStore } from "../store/ports.js";
 // touches routing/lane state (memory is a MIDDLEWARE).
 
 // How many of the most recent raw messages are PRESERVED uncompressed, so inject
-// can still serve them verbatim (docs/08「必须保留近期原始消息，以避免压缩造成信息丢失」).
+// can still serve them verbatim (docs/08 "recent raw messages must be preserved, to avoid information loss from compression").
 const RECENT_KEEP = 2;
 
 // A background job: a pointer to the thread whose older history should be
@@ -31,7 +31,7 @@ export interface ObserverDeps {
     messages: RawMessage[];
     now: Date;
   }) => Promise<{ observationText: string; priority?: number; tags?: string[] }>;
-  // Observer tokens are a SEPARATE cost bucket (docs/08「成本核算」): they must
+  // Observer tokens are a SEPARATE cost bucket (docs/08 "cost accounting"): they must
   // NOT be hidden inside actor/provider execution cost.
   costSink: (bucket: "observer", tokens: number) => void;
   // Injected clock — observed_at + the summary's time anchor come from here.

--- a/packages/core/src/memory/reflector.ts
+++ b/packages/core/src/memory/reflector.ts
@@ -1,7 +1,7 @@
 import type { Observation, Reflection, ReflectionScope } from "@helm/shared";
 import type { MemoryStore } from "../store/ports.js";
 
-// Background Reflector (docs/08 阶段 2「观察式记忆 MVP」). This is an OFF-the-main-
+// Background Reflector (docs/08 Phase 2 "observational-memory MVP"). This is an OFF-the-main-
 // request-path job: a scheduler triggers it PERIODICALLY to merge a scope's many
 // observations into ONE stable, slowly-changing, VERSIONED reflection — the
 // cache-friendly "stable layer" the inject phase prefixes onto context. It never
@@ -30,7 +30,7 @@ export interface ReflectorDeps {
     previousReflection: Reflection | null;
     now: Date;
   }) => Promise<{ reflectionText: string; tokenEstimate: number }>;
-  // Reflector tokens are a SEPARATE cost bucket (docs/08「成本核算」): they must
+  // Reflector tokens are a SEPARATE cost bucket (docs/08 "cost accounting"): they must
   // NOT be hidden inside actor/observer/provider execution cost.
   costSink: (bucket: "reflector", tokens: number) => void;
   // Injected clock — the new reflection's updated_at + the merge's time anchor
@@ -48,7 +48,7 @@ export interface ReflectorResult {
 // Take a scope's active observations + the current reflection, merge them, and —
 // ONLY when the merged text actually changed — write a version+1 reflection. If
 // the text is identical the version is NOT bumped and no row is written, keeping
-// the injected prefix stable + cache-friendly (docs/08「反思应当稳定且缓慢变化」).
+// the injected prefix stable + cache-friendly (docs/08 "reflections should be stable and slow-changing").
 // Reflector tokens are booked into the 'reflector' bucket. Success OR failure both
 // update memory_jobs.status; failure is recorded + logged and NEVER thrown
 // (fail-open — Reflector failure never affects any in-flight request).

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -21,7 +21,7 @@ export const MemoryScopeSchema = z.object({
 export type MemoryScope = z.infer<typeof MemoryScopeSchema>;
 
 // Request-level memory metadata surfaced to the request log / debug UI (docs/08
-// "调试 UI 字段"). observe NEVER hydrates, so memory_hydrated is always false and
+// "debug-UI field"). observe NEVER hydrates, so memory_hydrated is always false and
 // the hydrate/observer/reflector counters stay at their null/zero defaults until
 // the inject phase lights them up. This object carries NO injectable prompt.
 export const MemoryMetaSchema = z.object({

--- a/packages/core/src/protocol/anthropic/error.ts
+++ b/packages/core/src/protocol/anthropic/error.ts
@@ -1,6 +1,6 @@
 import { type ErrorClass, type HelmError, makeHelmError } from "@helm/shared";
 
-// HelmError -> native Anthropic error shape (docs/05 §错误也按客户端协议形态翻译,
+// HelmError -> native Anthropic error shape (docs/05 §errors are also translated into the client protocol's shape,
 // docs/07). The outbound error half of the Protocol Adapter: a structured internal
 // error becomes the wire envelope the Anthropic SDK expects
 //

--- a/packages/core/src/protocol/anthropic/footguns.test.ts
+++ b/packages/core/src/protocol/anthropic/footguns.test.ts
@@ -8,12 +8,15 @@ import {
   type OpenAIChunk,
 } from "./stream.js";
 
-// —— 协议互译 5 大坑专项回归测试矩阵 (docs/05「必须处理的坑」全 5 条) ————————————
+// —— Dedicated regression matrix for the 5 big protocol-translation footguns (all 5 from docs/05 "footguns that must be handled") ————————————
 //
-// 这套测试是协议互译层的"防回归护城河"：即便底层 request/response/stream 被重构,
-// 只要这 5 个反复让其他实现翻车的坑之一复活, 这里就会变红。断言措辞针对"坑的本质
-// 行为"(不双算 / 无孤儿 delta / 不产出非法枚举), 而非实现细节, 以避免脆性。
-// 复用既有导出, 不新增产品代码 (task protocol.footgun-tests)。
+// This suite is the protocol-translation layer's "anti-regression moat": even if the
+// underlying request/response/stream code is refactored, the moment one of these 5
+// footguns that have repeatedly tripped up other implementations comes back to life,
+// this turns red. Assertions are worded against the "essential behavior of the footgun"
+// (no double-counting / no orphan delta / no illegal enum produced) rather than
+// implementation details, to avoid brittleness. Reuses existing exports; adds no new
+// product code (task protocol.footgun-tests).
 
 // —— shared helpers ——————————————————————————————————————————————————————————
 
@@ -42,9 +45,10 @@ function textChunk(content: string, finish: string | null = null): OpenAIChunk {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// 坑 #1 — finish/stop 枚举错配
-//   OpenAI SDK 遇到非法 stop_reason 枚举会 DROP 整个响应。映射必须永远落在合法枚举,
-//   未知/null 兜底 end_turn, 且原始值始终入 provider_raw.stop_reason。
+// Footgun #1 — finish/stop enum mismatch
+//   The OpenAI SDK DROPS the whole response on an illegal stop_reason enum. The mapping
+//   must ALWAYS land on a legal enum, fall back to end_turn for unknown/null, and the
+//   original value must always go into provider_raw.stop_reason.
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("footgun #1 — finish/stop enum mismatch never produces an illegal enum", () => {
@@ -103,9 +107,10 @@ describe("footgun #1 — finish/stop enum mismatch never produces an illegal enu
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// 坑 #2 — usage 缓存双重计费 (~10× 成本错误)
-//   缓存读 token 被当全价输入算 → ~10× 成本。input_tokens = prompt − cached,
-//   cache_read 单列, 缓存读绝不计入 input。非流式与流式两路必须一致, 都不双算。
+// Footgun #2 — usage cache double-billing (~10× cost error)
+//   Cache-read tokens counted as full-price input → ~10× cost. input_tokens = prompt − cached,
+//   cache_read is its own line, and cache reads are NEVER counted into input. The non-streaming
+//   and streaming paths must agree — neither double-counts.
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("footgun #2 — cached tokens are never double-billed as full-price input", () => {
@@ -198,9 +203,10 @@ describe("footgun #2 — cached tokens are never double-billed as full-price inp
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// 坑 #3 — tool-call 流式 index/id 错配
-//   并行 tool 的 OpenAI 整数 index 必须稳定映射到 Anthropic block, 分片不串;
-//   id 仅首片缺失时用临时 id 后补升级; 截断 partial_json 累积容忍不崩。
+// Footgun #3 — tool-call streaming index/id mismatch
+//   OpenAI integer indexes for parallel tools must map STABLY to Anthropic blocks, with
+//   no cross-contaminated fragments; a temp id is used only when the first fragment lacks
+//   one and is later upgraded; truncated partial_json accumulation is tolerated without crashing.
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("footgun #3 — parallel tool-call index/id reconciliation", () => {
@@ -313,9 +319,10 @@ describe("footgun #3 — parallel tool-call index/id reconciliation", () => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// 坑 #4 — block/role 一致性 (孤儿 delta + 重复 stop)
-//   每个 content_block_delta 前必有同 index 的 content_block_start (无孤儿 delta);
-//   start/stop 配对; 关闭守卫幂等 (无重复 stop)。首片带 role:"assistant" 语义。
+// Footgun #4 — block/role consistency (orphan delta + duplicate stop)
+//   Every content_block_delta must be preceded by a same-index content_block_start (no orphan delta);
+//   start/stop are paired; the close guard is idempotent (no duplicate stop). The first event carries
+//   role:"assistant" semantics.
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("footgun #4 — block/role consistency: no orphan delta, idempotent close", () => {
@@ -383,9 +390,9 @@ describe("footgun #4 — block/role consistency: no orphan delta, idempotent clo
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// 坑 #5 — system + 多模态结构错配
-//   顶层 system 提升为 IR system 消息; 连续同角色被合并 (无连续 user/tool);
-//   图像 source:{base64} 字段拆分保留 media_type/data。
+// Footgun #5 — system + multimodal structure mismatch
+//   Top-level system is hoisted to an IR system message; consecutive same-role turns are merged
+//   (no consecutive user/tool); the image source:{base64} fields are split out, preserving media_type/data.
 // ════════════════════════════════════════════════════════════════════════════
 
 describe("footgun #5 — system hoist, same-role merge, image source split", () => {

--- a/packages/core/src/routing/policy-schema.ts
+++ b/packages/core/src/routing/policy-schema.ts
@@ -1,7 +1,7 @@
 // The policy Zod schema is the single source of truth in @helm/shared (so
 // HelmConfigSchema validates config/policies.yaml against the SAME shape the
 // policy engine consumes; schema-first, no duplicate definitions — CLAUDE.md
-// 代码规范). This module re-exports it for core's routing code (policy-engine,
+// code style). This module re-exports it for core's routing code (policy-engine,
 // route-request). See docs/04-routing-and-lanes.md, packages/shared policy-schema.
 export {
   type PoliciesConfig,

--- a/packages/core/src/store/factory.test.ts
+++ b/packages/core/src/store/factory.test.ts
@@ -7,7 +7,7 @@ import { createStore } from "./factory.js";
 import { SqliteKeyStore } from "./sqlite/keystore.js";
 
 // The factory is the single config-driven switch point: core depends only on the
-// Store ports, the factory binds the concrete driver ONCE (CLAUDE.md "DB 抽象层").
+// Store ports, the factory binds the concrete driver ONCE (CLAUDE.md "DB abstraction layer").
 // Fail-closed is the contract: an unknown driver, or a supabase driver with no
 // resolved connection string, must THROW — never silently fall back to a wrong
 // store (principle 2). The Pg* adapters themselves are exercised end-to-end by

--- a/packages/core/src/store/factory.ts
+++ b/packages/core/src/store/factory.ts
@@ -26,7 +26,7 @@ import { SqliteTelemetryStore } from "./sqlite/telemetry.js";
 // The full set of Store-port implementations the gateway needs, plus a `close`
 // lifecycle hook. The driver (sqlite vs supabase) is chosen ONCE here by config;
 // every caller depends only on the port interfaces, never on a concrete adapter
-// (CLAUDE.md "DB 抽象层": core depends on interfaces, not a specific DB).
+// (CLAUDE.md "DB abstraction layer": core depends on interfaces, not a specific DB).
 export interface StoreSet {
   readonly keys: KeyStore;
   readonly telemetry: TelemetryStore;

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -48,7 +48,7 @@ export interface RateLimitStore {
 // Store ports (repository pattern). core depends ONLY on these interfaces; the
 // sqlite and supabase adapters each implement the same contract. This file is
 // pure types — no SQL, no Drizzle import, no web framework. All structured data
-// types come from @helm/shared via z.infer. See CLAUDE.md "DB 抽象层".
+// types come from @helm/shared via z.infer. See CLAUDE.md "DB abstraction layer".
 
 // Input for creating a key: accepts hash + prefix only — NO plaintext field, so
 // the port layer cannot persist a plaintext key (principle 7).
@@ -75,7 +75,7 @@ export interface KeyStore {
   // Used for bootstrap emptiness check / admin display. Never includes plaintext.
   list(): Promise<ApiKeyRecord[]>;
   // Soft revoke: set disabled=true. Never physically deletes, never rewrites
-  // other fields in place ("轮转吊销不就地改写").
+  // other fields in place ("rotation/revocation never mutates in place").
   disable(keyId: string): Promise<void>;
   // Edit a key's per-key rate-limit override (docs/06). PARTIAL: only the
   // dimensions PRESENT in `patch` are written; an omitted dimension is left
@@ -125,9 +125,9 @@ export interface RequestPayload {
 
 // A recent decision row paired with the time the gateway recorded it. `createdAt`
 // is STORE metadata (a separate column), deliberately kept OUT of the redacted
-// DecisionRecord schema; the Debug UI list needs it for the 「时间」 column, so the
+// DecisionRecord schema; the Debug UI list needs it for the "Time" column, so the
 // recent-list port surfaces it alongside the record instead of forcing the UI to
-// fabricate a timestamp (原则1: UI re-computes nothing).
+// fabricate a timestamp (Principle 1: UI re-computes nothing).
 export interface RecentDecisionRecord {
   record: DecisionRecord;
   createdAt: Date;
@@ -153,7 +153,7 @@ export interface TelemetryStore {
 }
 
 // SignalStore — persistence for the POST-MVP Agentic Signals feedback layer
-// (docs/02; research-notes「Plano」). A signal is an aggregated, REDACTED
+// (docs/02; research-notes "Plano"). A signal is an aggregated, REDACTED
 // observation rolled up by (taskType, lane). This is an OBSERVABILITY artifact:
 // the collector writes it asynchronously off the request path, and (this task)
 // nothing reads it back into routing — `getSignal` exists for a FUTURE
@@ -168,7 +168,7 @@ export interface SignalStore {
   getSignal(taskType: string, lane: string): Promise<RoutingSignal | null>;
 }
 
-// Memory middleware store (docs/08 "存储模型"). POST-MVP persistence floor: this
+// Memory middleware store (docs/08 "storage model"). POST-MVP persistence floor: this
 // phase only ensures threads + appends raw messages (observe writes originals).
 // Read/inject/compress methods are added by the observe/inject tasks. Memory is
 // a MIDDLEWARE — these methods never touch routing/lane state. Input types come
@@ -178,14 +178,14 @@ export interface MemoryStore {
   ensureThread(input: MemoryThreadInput): Promise<void>;
   // Persist one raw message; returns the generated message id.
   appendMessage(input: MemoryMessageInput): Promise<string>;
-  // POST-MVP 阶段 2 (Observer). Read a thread's raw messages oldest-first so the
+  // POST-MVP Phase 2 (Observer). Read a thread's raw messages oldest-first so the
   // background Observer can compress the older ones into an observation. Returns
   // the persisted rows (with ids + createdAt) for an auditable source range.
   listMessages(threadId: string): Promise<RawMessage[]>;
   // Persist one compressed observation; returns its generated id. source range
   // is REQUIRED on the input (docs/08) so memory can be audited against originals.
   appendObservation(input: MemoryObservationInput): Promise<string>;
-  // POST-MVP 阶段 2 (Reflector). Read a scope's ACTIVE observations so the
+  // POST-MVP Phase 2 (Reflector). Read a scope's ACTIVE observations so the
   // background Reflector can merge them into a stable reflection. Scope is
   // project / resource / thread (one or more levels); never cross-project.
   listObservations(scope: ReflectionScope): Promise<Observation[]>;

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -180,7 +180,7 @@ const MIGRATIONS: readonly Migration[] = [
     `,
   },
   {
-    // Per-key rate-limit OVERRIDE columns on api_keys (docs/06 "限流与配额"). Two
+    // Per-key rate-limit OVERRIDE columns on api_keys (docs/06 "rate limits & quotas"). Two
     // nullable integer columns: NULL = inherit the system default at check time;
     // a value (0 = unlimited) overrides that one dimension for this key. Additive
     // — existing rows get NULL and keep inheriting the default. Mirrors the sqlite

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -14,7 +14,7 @@ import {
 // schema.ts) — supabase == hosted Postgres — but expressed with native pg types:
 // real booleans, jsonb for arrays/objects, double precision for fractional
 // counters. Dialect quirks are encapsulated HERE so core and the sqlite adapter
-// never see them (CLAUDE.md "DB 抽象层"). Epoch-millisecond timestamps are stored
+// never see them (CLAUDE.md "DB abstraction layer"). Epoch-millisecond timestamps are stored
 // as bigint (mode: "number") so the value space matches the sqlite timestamp_ms
 // columns exactly and the port contract is byte-for-byte identical across
 // drivers. Per principle 7: NO plaintext column anywhere — only hash + prefix.

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { SqliteMemoryStore } from "./memory-store.js";
 import { createSqliteDb, runMigrations } from "./migrate.js";
 
-// docs/08 "存储模型" — the 5 memory tables, their exact column sets, the
+// docs/08 "storage model" — the 5 memory tables, their exact column sets, the
 // source_message_range NOT NULL invariant, and isolation from routing/key tables.
 
 function tableCols(raw: ReturnType<typeof createSqliteDb>["$sqlite"], table: string): string[] {

--- a/packages/core/src/store/sqlite/memory-schema.ts
+++ b/packages/core/src/store/sqlite/memory-schema.ts
@@ -1,7 +1,7 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 // SQLite (Drizzle) table definitions for the memory middleware (docs/08
-// "存储模型"). POST-MVP persistence floor: build + migrate only — no read /
+// "storage model"). POST-MVP persistence floor: build + migrate only — no read /
 // inject / compress here. These tables are deliberately ISOLATED from the
 // routing/key tables (lanes/policies/api_keys): memory is a MIDDLEWARE, not a
 // routing strategy, and must never reach into lane rules (docs/08, CLAUDE.md).

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -93,7 +93,7 @@ export class SqliteMemoryStore implements MemoryStore {
     return id;
   }
 
-  // POST-MVP 阶段 2 (Observer): read a thread's raw messages oldest-first.
+  // POST-MVP Phase 2 (Observer): read a thread's raw messages oldest-first.
   async listMessages(threadId: string): Promise<RawMessage[]> {
     const rows = this.db
       .select()
@@ -133,7 +133,7 @@ export class SqliteMemoryStore implements MemoryStore {
     return id;
   }
 
-  // POST-MVP 阶段 2 (Reflector): read a scope's active observations oldest-first.
+  // POST-MVP Phase 2 (Reflector): read a scope's active observations oldest-first.
   // Scope is matched on thread_id only here (observations are thread-anchored in
   // storage); the Reflector merges them into a scope-level reflection. Returns
   // empty when the scope has no thread anchor.
@@ -161,7 +161,7 @@ export class SqliteMemoryStore implements MemoryStore {
 
   // Read the latest (highest-version) reflection for an EXACT scope match. Absent
   // scope levels must be NULL in storage (never a different scope's row) so the
-  // Reflector never crosses project/resource/thread boundaries (docs/08 隔离).
+  // Reflector never crosses project/resource/thread boundaries (docs/08 isolation).
   async getReflection(scope: ReflectionScope): Promise<Reflection | null> {
     const row = this.db
       .select()

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -51,7 +51,7 @@ const MIGRATIONS: readonly Migration[] = [
     `,
   },
   {
-    // Memory middleware tables (docs/08 "存储模型"). POST-MVP persistence floor:
+    // Memory middleware tables (docs/08 "storage model"). POST-MVP persistence floor:
     // build only — no read/inject. Deliberately ISOLATED from routing/key
     // tables (no FK to lanes/policies/api_keys); memory_messages references
     // memory_threads ONLY. source_message_range is NOT NULL so compressed
@@ -113,7 +113,7 @@ const MIGRATIONS: readonly Migration[] = [
     `,
   },
   {
-    // Per-key rate-limit token buckets (docs/06 "限流与配额"). One row per
+    // Per-key rate-limit token buckets (docs/06 "rate limits & quotas"). One row per
     // (key_id, dim); tokens is REAL so fractional refill survives reads. key_id
     // only — NEVER a plaintext/hashed key (principle 7). Counters live here (not
     // process memory) so windows survive restarts and span instances.
@@ -129,7 +129,7 @@ const MIGRATIONS: readonly Migration[] = [
     `,
   },
   {
-    // Agentic Signals (POST-MVP feedback layer; docs/02, research-notes「Plano」).
+    // Agentic Signals (POST-MVP feedback layer; docs/02, research-notes "Plano").
     // One row per (task_type, lane): the latest rolled-up, REDACTED observation,
     // written ASYNCHRONOUSLY by the background collector — never on the request
     // path. NO key/payload column (principle 7); only aggregate dimensions. Two
@@ -217,7 +217,7 @@ const MIGRATIONS: readonly Migration[] = [
     `,
   },
   {
-    // Per-key rate-limit OVERRIDE columns on api_keys (docs/06 "限流与配额"). Two
+    // Per-key rate-limit OVERRIDE columns on api_keys (docs/06 "rate limits & quotas"). Two
     // nullable integer columns: NULL = inherit the system default at check time;
     // a value (0 = unlimited) overrides that one dimension for this key. Additive
     // — existing rows get NULL and therefore keep inheriting the default. Distinct

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -64,7 +64,7 @@ describe("SqliteTelemetryStore", () => {
     expect(recent[0]?.record).toEqual(decision("req_1"));
     expect(recent[0]?.record.provider_attempts).toHaveLength(2);
     // queryRecent surfaces the recorded timestamp alongside the record so the
-    // Debug UI can render the 「时间」 column without fabricating it.
+    // Debug UI can render the "Time" column without fabricating it.
     expect(recent[0]?.createdAt.getTime()).toBe(at.getTime());
   });
 

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -23,7 +23,7 @@ import { SqliteRateLimitStore } from "./sqlite/rate-limit.js";
 import { SqliteSignalStore } from "./sqlite/signals.js";
 import { SqliteTelemetryStore } from "./sqlite/telemetry.js";
 
-// ONE contract, BOTH real drivers. The DoD ("sqlite 与 supabase 同一契约测试") is
+// ONE contract, BOTH real drivers. The DoD ("sqlite and supabase share one contract test") is
 // met here: the SAME assertions run against the sqlite adapter AND against the
 // Postgres adapters on an in-process PGlite database. supabase == hosted
 // Postgres, so the pglite pg-dialect coverage validates the supabase path WITHOUT

--- a/packages/core/src/telemetry/redaction.test.ts
+++ b/packages/core/src/telemetry/redaction.test.ts
@@ -36,12 +36,12 @@ describe("redact", () => {
 
   it("summarizes private payload fields", () => {
     const out = redact({
-      messages: [{ role: "user", content: "私密内容" }],
+      messages: [{ role: "user", content: "private content" }],
       attachments: ["blobdata"],
     });
     expect(out.messages).toEqual({ redacted: true, kind: "array", itemCount: 1 });
     expect(out.attachments).toEqual({ redacted: true, kind: "array", itemCount: 1 });
-    expect(JSON.stringify(out)).not.toContain("私密内容");
+    expect(JSON.stringify(out)).not.toContain("private content");
     expect(JSON.stringify(out)).not.toContain("blobdata");
   });
 

--- a/packages/shared/src/catalog/schema.ts
+++ b/packages/shared/src/catalog/schema.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 //                   via `pnpm sync:catalog`, checked into the repo. Supply-chain
 //                   INPUT, never read at request time to pick a model.
 //   2. override   — manual config/capabilities.yaml + config/pricing.yaml.
-//                   Manual entries ALWAYS WIN (CLAUDE.md 实现约定).
-// Invalid override → fail-closed (principle 2). See docs/02 安全规则.
+//                   Manual entries ALWAYS WIN (CLAUDE.md implementation conventions).
+// Invalid override → fail-closed (principle 2). See docs/02 security rules.
 
 export const CapabilitiesSchema = z.object({
   supportsTools: z.boolean(),

--- a/packages/shared/src/classifier/eval-output.schema.ts
+++ b/packages/shared/src/classifier/eval-output.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-// Layer-2 eval output schema (docs/03 §「任务分类」). The small eval model emits
+// Layer-2 eval output schema (docs/03 §Task classification). The small eval model emits
 // a strict JSON object judging the request's lane. This output is UNTRUSTED
 // external input — it is validated here and, on any failure, the consumer
 // (eval.cascade) fails open to balanced (CLAUDE.md principle 3). Zod is the

--- a/packages/shared/src/config/policy-schema.ts
+++ b/packages/shared/src/config/policy-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 // policies.yaml schema — server-side custom policies let operators customize
-// routing WITHOUT touching client code (docs/04 "策略配置"). A policy declares a
+// routing WITHOUT touching client code (docs/04 "policy configuration"). A policy declares a
 // `match` (AND of all written fields) and at least one action: pin a lane
 // (`use_lane`) and/or cap the candidate (`max_lane` / `allowed_lanes`).
 //

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -99,7 +99,7 @@ export const RateLimitConfigSchema = z.object({
   overrides: z.record(z.string(), RateLimitQuotaOverrideSchema).default({}),
 });
 
-// DB abstraction layer (CLAUDE.md "DB 抽象层"). The gateway switches its Store
+// DB abstraction layer (CLAUDE.md "DB abstraction layer"). The gateway switches its Store
 // adapter set by config: `sqlite` (default, local file) or `supabase` (hosted
 // Postgres). The connection string is referenced by ENV VAR NAME (`url_env`) —
 // NEVER a plaintext DSN in config/yaml (mirrors providers[].api_key_env,

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -81,7 +81,7 @@ export const FinalDecisionSchema = z.object({
   error_reason: z.string().nullable(),
 });
 
-// Cost split (docs/07 「成本拆分（含 eval 评估自身的成本）」). `eval_usd` isolates the
+// Cost split (docs/07 "cost split (including eval's own self-cost)"). `eval_usd` isolates the
 // Layer-2 small-model self-cost (non-null ONLY when eval actually ran; null when
 // eval was skipped/disabled) from `completion_usd` (Σ of the served provider
 // attempts' cost). `total_usd` is their sum. Each is nullable because upstream
@@ -101,7 +101,7 @@ export const DecisionRecordSchema = z.object({
   trace_id: z.string().min(1),
   requested_model: z.string(),
   // Display-only key fingerprint for the Debug UI key column (docs/07
-  // 「API key / 用户 / 组织」). PREFIX ONLY — the resolved auth identity's
+  // "API key / user / org"). PREFIX ONLY — the resolved auth identity's
   // ApiKeyRecord.prefix (e.g. helm_live_ab12), NEVER the plaintext key
   // (principle 7). Null when the key/prefix is unknown. `.default(null)` keeps
   // pre-existing (pre-enrichment) records valid.
@@ -111,7 +111,7 @@ export const DecisionRecordSchema = z.object({
   lane: LaneDecisionSchema,
   provider_attempts: z.array(ProviderAttemptSchema),
   final: FinalDecisionSchema,
-  // Total served latency = Σ provider_attempts.latency_ms (docs/07 延迟).
+  // Total served latency = Σ provider_attempts.latency_ms (docs/07 latency).
   // `.default(0)` so legacy records validate; the builder computes the real sum.
   latency_total_ms: z.number().nonnegative().default(0),
   // EXECUTION-stage fallback count (principle 5; NEVER the classification

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,7 +4,7 @@
 export const SHARED_PACKAGE = "@helm/shared" as const;
 
 // Catalog model — capabilities + pricing, generated (supply-chain) + override
-// (manual wins). See CLAUDE.md 实现约定, docs/02 安全规则.
+// (manual wins). See CLAUDE.md implementation conventions, docs/02 security rules.
 export {
   type Capabilities,
   type CapabilitiesOverride,
@@ -24,7 +24,7 @@ export {
   PricingSchema,
 } from "./catalog/schema.js";
 
-// Layer-2 eval output model (docs/03 §任务分类) — strict JSON the eval model
+// Layer-2 eval output model (docs/03 §Task classification) — strict JSON the eval model
 // emits; validated as untrusted external input, fail-open on any failure.
 export {
   type Complexity,

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -28,9 +28,9 @@ export const ApiKeyRecordSchema = z.object({
 export type KeyRole = z.infer<typeof KeyRoleSchema>;
 export type ApiKeyRecord = z.infer<typeof ApiKeyRecordSchema>;
 
-// Admin-facing create-key request (docs/06 Key 管理). The plaintext is minted
+// Admin-facing create-key request (docs/06 Key management). The plaintext is minted
 // server-side; the operator only specifies role + per-key caps. `.strict()` so an
-// unknown field fails closed (原则2). role defaults to "user" — root keys are not
+// unknown field fails closed (Principle 2). role defaults to "user" — root keys are not
 // minted casually through the admin UI.
 export const CreateKeyRequestSchema = z
   .object({
@@ -39,7 +39,7 @@ export const CreateKeyRequestSchema = z
     allowed_lanes: z.array(z.string().min(1)).optional(),
     allow_custom_model: z.boolean().optional(),
     // Optional per-key rate limits at mint time. Omitted => inherit the system
-    // default. 0 => explicitly unlimited for that dimension (原则2 fail-closed on
+    // default. 0 => explicitly unlimited for that dimension (Principle 2 fail-closed on
     // a negative/non-int value).
     rate_limit_rpm: z.number().int().nonnegative().optional(),
     rate_limit_tpm: z.number().int().nonnegative().optional(),

--- a/packages/shared/src/memory/schema.ts
+++ b/packages/shared/src/memory/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-// Memory middleware storage contracts (docs/08 "存储模型"). POST-MVP: these
+// Memory middleware storage contracts (docs/08 "storage model"). POST-MVP: these
 // shapes back the persistence floor for the observe/inject phases — this layer
 // only models thread + message inputs (no read/inject/compress here). Per
 // CLAUDE.md the Zod schema is the single source of truth; types come from
@@ -11,7 +11,7 @@ export const MemoryRoleSchema = z.enum(["user", "assistant", "tool"]);
 
 // Input to create/ensure a thread. project/resource/owner are optional so a
 // thread can be scoped at request time without forcing a global user profile
-// (docs/08 非目标: no cross-project / global profile).
+// (docs/08 non-goals: no cross-project / global profile).
 export const MemoryThreadInputSchema = z.object({
   id: z.string().min(1),
   projectId: z.string().min(1).optional(),
@@ -27,7 +27,7 @@ export const MemoryMessageInputSchema = z.object({
   tokenEstimate: z.number().int().nonnegative(),
 });
 
-// A persisted raw message row read back from the store (docs/08 阶段 2 Observer
+// A persisted raw message row read back from the store (docs/08 Phase 2 Observer
 // reads originals to compress). Distinct from MemoryMessageInput: it carries the
 // generated id + createdAt the store assigned, so the Observer can record a
 // precise, auditable source_message_range against the originals.
@@ -40,7 +40,7 @@ export const RawMessageSchema = z.object({
   createdAt: z.date(),
 });
 
-// Input to persist one compressed observation (docs/08 阶段 2). source_message_range
+// Input to persist one compressed observation (docs/08 Phase 2). source_message_range
 // is REQUIRED so compressed memory is auditable against its originals; observedAt
 // is the time anchor; priority/tags are optional ranking hints.
 export const MemoryObservationInputSchema = z.object({
@@ -53,7 +53,7 @@ export const MemoryObservationInputSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
-// A persisted observation row read back from the store (docs/08 阶段 2). The
+// A persisted observation row read back from the store (docs/08 Phase 2). The
 // background Reflector reads a scope's active observations to merge them into a
 // stable reflection; distinct from MemoryObservationInput it carries the
 // generated id the store assigned. observedAt is the time anchor.
@@ -67,11 +67,11 @@ export const ObservationSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
-// A persisted reflection row read back from the store (docs/08 "存储模型":
+// A persisted reflection row read back from the store (docs/08 "storage model":
 // memory_reflections). Reflections are VERSIONED + slowly-changing: the
 // Reflector only bumps `version` when the merged text actually changes, keeping
 // the injected prefix cache-friendly. Scoped at project / resource / thread
-// level (no global / cross-project profile — docs/08 非目标).
+// level (no global / cross-project profile — docs/08 non-goals).
 export const ReflectionSchema = z.object({
   id: z.string().min(1),
   projectId: z.string().min(1).nullable(),
@@ -102,13 +102,13 @@ export const ReflectionUpsertInputSchema = ReflectionScopeSchema.extend({
   updatedAt: z.date(),
 });
 
-// The fixed layers of the inject-phase context prefix (docs/08 「上下文组装顺序」).
+// The fixed layers of the inject-phase context prefix (docs/08 "context assembly order").
 // The order of these literals is LOAD-BEARING: the inject assembler emits messages
 // strictly in this sequence — system → project reflection → resource reflection →
 // thread observations → recent raw → current. `source` tags which memory layer a
 // message came from so the debug UI + tests can assert the order/provenance, and
 // so budget trimming can target the oldest observations first while NEVER dropping
-// recent raw / current (docs/08 「必须保留近期原始消息」).
+// recent raw / current (docs/08 "recent raw messages must be retained").
 export const AssembledMessageSourceSchema = z.enum([
   "system",
   "project_reflection",


### PR DESCRIPTION
Prepare the project for its 0.1 open-source release.

- Rewrite README.md (English, standard MIT OSS layout) and add a README.zh-CN.md companion, cross-linked with a language switch.
- Rewrite docs/README + 01-11 + research-notes into English, corrected against the code (code is the source of truth): 3 wired client protocols (Gemini transformer exists but is unrouted -> roadmap), /v1/responses is non-streaming only, memory observe phase is live (inject is roadmap), classifier calibration + decision-record fields reconciled.
- Translate all code comments and test descriptions to English (~92 files); preserve the admin i18n locale data and the native language display names.
- Fix 6 pre-existing stream-only test failures (tests only, no runtime change): stream the stream-only lane heads in routing/eval e2e; land on deepseek-crs/deepseek-pro for the non-stream execute.default-config unit tests.
- implementation-notes.md: log the doc/code audit (11 discrepancies) and the test reconciliation.

Verified: pnpm typecheck clean, lint exit 0, test 1255/1255, e2e 36/36, build OK.