### PR TITLE
docs: clearer, user-first README (EN + idiomatic zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **English** · [简体中文](README.zh-CN.md)
 
-### Route every LLM request to the right model — by config, not code.
+### One gateway in front of all your LLM providers — pick models by config, not code.
 
-*Think **nginx**, but for LLM traffic.* Open-source, self-hosted, MIT.
+Open-source · self-hosted · MIT
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
@@ -16,40 +16,38 @@
 
 </div>
 
-You wired your app to one model. Then a cheaper one shipped, a provider started rate-limiting you, one request needed vision, the bill crept up — and every change meant another redeploy. **Helm API puts a thin, fast gateway in front of your providers so those decisions live in config, not code.**
+**The problem.** Your app is hard-wired to one model. The day you want a cheaper model for easy requests, a stronger one for hard requests, or an automatic backup when a provider goes down, you have to change code and redeploy.
 
-Point your client at Helm and send a normal OpenAI or Anthropic request. Helm sizes up how hard it is, drops it into a **lane** (`economy` / `balanced` / `premium` …), runs it through provider adapters with automatic failover, and logs *why* every request went where it did. Your app only ever touches its `base_url` and API key — everything else is yours to tune from a config file or the built-in dashboard.
+**What Helm does.** Helm sits between your app and the model providers. Your app sends a normal OpenAI or Anthropic request to Helm; Helm decides which model should handle it, calls that provider (and switches to a backup if it fails), and records every decision. Your app only ever sets its `base_url` and API key — all the routing lives in a config file you control.
 
-```bash
-# your app, unchanged — just a new base_url + key
+Instead of naming a model, you name a **lane** — a tier like `economy`, `balanced`, or `premium`. Helm maps each lane to a real model behind the scenes, so you can change models without changing your app.
+
+```python
+# Your app: the same OpenAI client, just a new base_url and key.
 client = OpenAI(base_url="http://localhost:8080/v1", api_key="<helm-key>")
 client.chat.completions.create(model="balanced", messages=[...])   # Helm picks the model
 ```
 
 ---
 
-## ✨ Why Helm
+## Why teams use it
 
-- **Lanes, not a model catalog.** Callers ask for an *intent* — `economy`, `balanced`, `premium` — and never need to know which provider or model actually answered. Swap models behind a lane without touching a single client.
-- **Config is the product.** Routing, lanes, policies, providers — all live in `config/*.yaml`, validated by Zod. Misconfigure something and Helm **refuses to boot** instead of misbehaving in production.
-- **Nothing 5xxs on a side-quest.** If classification, eval, or the cache hiccups, the request quietly drops to the `balanced` lane and keeps going. You only get a hard error when *every* provider is truly down.
-- **Fast path is deterministic.** Routing decisions are a pure, zero-network, unit-tested function. The optional small-model "second opinion" runs at `temperature: 0`, is cached, and ships **off by default** — no surprise latency or spend.
-- **Keys hashed, bodies kept.** API keys are stored as SHA-256 hashes — never logged, never echoed. Full request/response bodies land in a separate, toggleable table with retention, so you can actually debug what happened.
-- **Headless or hands-on.** The whole routing engine is framework-free and runs fine without a UI — but there's a polished admin dashboard when you want one.
-- **Yours to run.** MIT-licensed, Docker-deployed, no SaaS, no phone-home. It's your gateway on your infra.
+- **Change models without changing code.** Point a lane at a different model in a config file — your apps never notice.
+- **It won't fail by accident.** If an optional step has trouble (classification, scoring, cache), the request quietly falls back to the `balanced` lane. You only get an error when every provider is genuinely down.
+- **Safe by default.** Invalid config refuses to start. API keys are stored only as hashes. Rate limiting and the optional scoring model are off until you turn them on.
+- **Every decision is visible.** Each request records the lane it took, the model that answered, why, and what it cost — all browsable in the dashboard.
+- **Runs on your own infrastructure.** MIT-licensed and deployed with Docker. No SaaS, and no data leaves your servers.
 
-## 🧩 What's inside
+## What it does
 
-- 🔌 **Drop-in compatible** with OpenAI Chat Completions, Anthropic Messages, and OpenAI Responses — including SSE streaming for Chat & Messages.
-- 🔁 **Speaks every dialect** via one internal representation, with SSE event mapping handled for you.
-- 🧭 **Three-layer routing**: deterministic rules → optional small-model eval → `balanced` safety net.
-- 🛣️ **Lane + policy engine** with first-match rules and per-org caps.
-- 🪂 **Multi-provider failover** across providers, with capability filtering (JSON / tools / vision / context / streaming) and a per-model circuit breaker.
-- 💾 **Bring your own store**: SQLite out of the box, Postgres/Supabase when you scale — one interface, swap freely.
-- 🔒 **Auth that's on by default**: mandatory API keys, a root key minted on first boot, optional per-key RPM/TPM limits.
-- 📊 **A real dashboard** (SvelteKit) for keys, lanes, policies, classifier tuning, and request debugging — HTTP Basic auth, localized in 5 languages.
+- Accepts **OpenAI Chat Completions**, **Anthropic Messages**, and **OpenAI Responses** requests — with streaming for the first two.
+- Translates between protocols, so one client can reach many different backends.
+- Picks a lane with fast built-in rules (plus an optional small model for a second opinion — off by default).
+- Falls back across providers automatically, checking each candidate's capabilities (JSON, tools, vision, context size) and skipping ones that are failing.
+- Stores everything in SQLite by default, or Postgres/Supabase when you grow.
+- Comes with a web dashboard for keys, lanes, policies, and request debugging — in 5 languages.
 
-## 🗺️ How a request flows
+## How a request flows
 
 ```
         ┌──────────────────────────── Helm API gateway (Hono) ───────────────────────────┐
@@ -58,44 +56,42 @@ client ─┤  /v1/chat/completions ─┐                                      
 (OpenAI/ │  /v1/messages ─────────┼─▶ auth ─▶ rate limit ─▶ classify ─▶ route ─▶ execute ──┼─▶ upstream
  Anthropic) /v1/responses ────────┘     │         │            │          │         │       │   providers
         │                               │         │            │          │         │       │  (openai-crs,
-        │   /admin (SPA, HTTP Basic) ───┘   per-key RPM/TPM   3-layer    lane +    provider  │   zenmux,
-        │   /admin/api/*                                      cascade   policies   fallback  │   openrouter…)
-        │   /healthz  /version                                                    + breaker  │
+        │   /admin (SPA, HTTP Basic) ───┘   per-key RPM/TPM   pick a     apply     try, then │   zenmux,
+        │   /admin/api/*                                       lane     policies  fall back  │   openrouter…)
+        │   /healthz  /version                                                               │
         │                                                                                    │
         └──────────────────────────── Store (SQLite default · Postgres optional) ───────────┘
-              keys · decision telemetry · request payloads · rate-limit buckets · memory
+              keys · decision logs · request payloads · rate-limit counters · memory
 ```
 
-The routing brain lives in `packages/core` and depends on no web framework. `apps/gateway` is a thin Hono shell that also serves the dashboard.
+The routing logic lives in `packages/core` and depends on no web framework. `apps/gateway` is a thin Hono layer that also serves the dashboard.
 
-## 🚀 Quick start
+## Quick start
 
-Up and running in three commands:
+Three commands to a running gateway:
 
 ```bash
-# 1. clone + create your env file
+# 1. Clone and create your env file
 git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
 cp .env.example .env
-#    set HELM_ADMIN_PASSWORD and at least OPENAI_API_KEY in .env
+#    In .env, set HELM_ADMIN_PASSWORD and at least OPENAI_API_KEY
 
-# 2. launch
+# 2. Start it
 docker compose up -d
 
-# 3. grab the root API key Helm prints ONCE on first boot
+# 3. Copy the root API key — it is printed once, on first boot
 docker compose logs helm | grep -i "root key"
 ```
 
-That's it:
-
 - **Gateway** → `http://localhost:8080`
-- **Dashboard** → `http://localhost:8080/admin` (`HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD`)
+- **Dashboard** → `http://localhost:8080/admin` (log in with `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD`)
 - **Health / version** → `GET /healthz`, `GET /version`
 
-`docker-compose.yml` mounts `./config` and `./data`, so your config and SQLite database survive restarts. Credentials are injected via env vars only — never baked into the image.
+`docker-compose.yml` mounts `./config` and `./data`, so your config and database survive restarts. Credentials are passed in as environment variables only — never built into the image.
 
-## 🔗 Calling it
+## Calling the gateway
 
-Any OpenAI-compatible client works — just point it at Helm with a Helm key:
+Any OpenAI-compatible client works. Point it at Helm and use a Helm API key:
 
 ```bash
 curl http://localhost:8080/v1/chat/completions \
@@ -108,66 +104,66 @@ curl http://localhost:8080/v1/chat/completions \
   }'
 ```
 
-The `model` field takes a **lane** name, not a vendor model id:
+Put a **lane** name in the `model` field, not a vendor model id:
 
 | Endpoint | Protocol | Streaming |
 |---|---|---|
-| `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ SSE |
-| `POST /v1/messages` | Anthropic Messages | ✅ SSE |
-| `POST /v1/responses` | OpenAI Responses | ❌ non-streaming (0.1) |
+| `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
+| `POST /v1/messages` | Anthropic Messages | ✅ |
+| `POST /v1/responses` | OpenAI Responses | ❌ not yet (0.1) |
 
-> Pass `economy`, `balanced`, `premium`, or a task lane like `coding`. Leave it off (or send something unknown) and Helm classifies the request and picks a lane for you. A Gemini adapter already lives in the core but isn't routed yet — see the [roadmap](docs/09-roadmap.md).
+> Use `economy`, `balanced`, `premium`, or a task lane like `coding`. Leave it blank (or send a name Helm doesn't know) and Helm picks a lane for you. A Gemini adapter exists in the core but isn't exposed as a route yet — see the [roadmap](docs/09-roadmap.md).
 
-## ⚙️ Configuration
+## Configuration
 
-Everything is config-as-code in `config/*.yaml` — Zod-validated, fail-closed. The hot-reloadable ones can also be edited live from the dashboard.
+Everything is configured in `config/*.yaml`. Files are validated on load, and invalid config stops the gateway from starting. The lanes, policies, and classifier can also be edited live in the dashboard.
 
 | File | What it controls | Live-editable |
 |---|---|---|
 | `server.yaml` | Host / port / base path | — |
-| `auth.yaml` | Mandatory API key + root-key bootstrap | — |
-| `runtime.yaml` | Request limits, rate-limit defaults, store driver | partial |
-| `providers.yaml` | Upstream providers + model aliases (creds by env-var **name** only) | — |
-| `lanes.yaml` | Lanes (primary + fallback chain, constraints) | ✅ |
-| `policies.yaml` | First-match routing rules | ✅ |
-| `classifier.yaml` | Layer-1 rules + Layer-2 eval | ✅ |
+| `auth.yaml` | API key requirement + first-run root key | — |
+| `runtime.yaml` | Request limits, rate-limit defaults, storage driver | partial |
+| `providers.yaml` | Upstream providers + model aliases (credentials by env-var **name** only) | — |
+| `lanes.yaml` | Lanes — each lane's main model and its backup chain | ✅ |
+| `policies.yaml` | Rules that pick or cap the lane | ✅ |
+| `classifier.yaml` | The built-in rules and the optional scoring model | ✅ |
 | `capabilities.yaml` / `pricing.yaml` | Manual overrides on the model catalog | — |
 
-Most-used env vars (full list in [`.env.example`](.env.example)):
+Most-used environment variables (full list in [`.env.example`](.env.example)):
 
 | Variable | Purpose |
 |---|---|
-| `OPENAI_API_KEY` | Primary provider credential (**required**) |
-| `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` | Optional fallback-provider credentials |
+| `OPENAI_API_KEY` | Main provider credential (**required**) |
+| `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` | Backup provider credentials (optional) |
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | Dashboard login |
 | `HELM_PORT` / `HELM_HOST` | Server binding (default `0.0.0.0:8080`) |
 | `HELM_STORE_DRIVER` | `sqlite` (default) or `supabase` |
-| `HELM_RATE_LIMIT_ENABLED` | Master rate-limit switch (default off) |
+| `HELM_RATE_LIMIT_ENABLED` | Turn rate limiting on (off by default) |
 
-Ships with lanes **economy** / **balanced** / **premium**, plus task lanes **coding** / **json** / **vision** / **tool_use**. `balanced` is the guaranteed safety net every classification can fall back to.
+Helm ships with the lanes **economy**, **balanced**, and **premium**, plus task lanes **coding**, **json**, **vision**, and **tool_use**. `balanced` is the lane every request can safely fall back to.
 
-## 🖥️ The dashboard
+## The dashboard
 
-At `/admin`, behind HTTP Basic auth: a live dashboard, API keys (create / revoke / per-key limits), lane and policy editors, classifier tuning, request telemetry with full decision-chain drill-down, and system settings (payload capture, retention, rate-limit switch). Localized in English (default), Simplified & Traditional Chinese, Japanese, and Korean.
+At `/admin`, behind a username/password (HTTP Basic): a live overview, API keys (create, revoke, set per-key limits), lane and policy editors, classifier settings, and a request log you can drill into to see exactly how each request was routed. Available in English (default), Simplified and Traditional Chinese, Japanese, and Korean.
 
-## 🗂️ Project layout
+## Project layout
 
 ```
 helm-api/
 ├─ apps/
 │  ├─ gateway/   # Hono API + serves the dashboard + /healthz, /version
-│  └─ admin/     # SvelteKit + Tailwind dashboard (adapter-static SPA)
+│  └─ admin/     # SvelteKit + Tailwind dashboard (static SPA)
 ├─ packages/
-│  ├─ core/      # routing · classification · providers · protocol translation · Store ports (framework-free)
+│  ├─ core/      # routing, classification, providers, protocol translation, storage ports (no framework)
 │  └─ shared/    # Zod schemas + shared types (single source of truth)
 ├─ config/       # default lanes / policies / classifier / providers / … YAML
 ├─ docs/         # documentation (read 01 → 11)
 └─ scripts/      # sync:catalog and other build-time tools
 ```
 
-## 🛠️ Development
+## Development
 
-Needs **Node ≥ 22** and **pnpm**.
+Requires **Node ≥ 22** and **pnpm**.
 
 ```bash
 pnpm install
@@ -176,13 +172,13 @@ pnpm test         # Vitest unit tests
 pnpm test:e2e     # Playwright end-to-end tests
 pnpm typecheck    # tsc --noEmit across the workspace
 pnpm lint         # Biome
-pnpm build        # build gateway + dashboard assets
+pnpm build        # build the gateway + dashboard
 pnpm sync:catalog # refresh the generated model catalog (capabilities + pricing)
 ```
 
-Built test-first (Vitest for the core, Playwright for the flows). The full spec lives in [`docs/`](docs/README.md); design decisions and trade-offs are logged in [`implementation-notes.md`](implementation-notes.md).
+Tests come first (Vitest for the core, Playwright for full flows). The full spec is in [`docs/`](docs/README.md), and design decisions are logged in [`implementation-notes.md`](implementation-notes.md).
 
-## 📚 Documentation
+## Documentation
 
 Read in order, starting at [`docs/README.md`](docs/README.md):
 
@@ -198,18 +194,18 @@ Read in order, starting at [`docs/README.md`](docs/README.md):
 [10 Deployment](docs/10-deployment.md) ·
 [11 Admin UI](docs/11-admin-ui.md)
 
-## 🧭 Roadmap
+## Roadmap
 
-**0.1** ships the full routing gateway, three client protocols, multi-provider failover, the dashboard, and the observational-memory *observe* phase. Next up: a Gemini client route, streaming for `/v1/responses`, the memory *inject* phase, and richer quota controls. Details in [09 Roadmap](docs/09-roadmap.md).
+**0.1** includes the full routing gateway, three client protocols, multi-provider fallback, the dashboard, and the first half of the memory feature (observe). Coming next: a Gemini route, streaming for `/v1/responses`, the second half of memory (inject), and finer-grained quotas. See [09 Roadmap](docs/09-roadmap.md).
 
-## 🤝 Contributing
+## Contributing
 
-Issues and PRs welcome. Work on a branch and make sure CI is green before opening a PR:
+Issues and pull requests are welcome. Work on a branch, and make sure the checks pass before opening a PR:
 
 ```bash
 pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 ```
 
-## 📄 License
+## License
 
 [MIT](LICENSE) © 2026 EasyMeta AU / 路田（上海）网络科技有限公司

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,9 @@
 
 [English](README.md) · **简体中文**
 
-### 用一份配置，把每个 LLM 请求送到最合适的模型——而不是写死在代码里。
+### 一个网关，挡在你所有大模型供应商前面——用配置选模型，而不是改代码。
 
-*给大模型流量配个 **nginx**。* 开源、自托管、MIT。
+开源 · 自托管 · MIT
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
@@ -16,40 +16,38 @@
 
 </div>
 
-你把应用接到了某个模型，然后呢——出了更便宜的新模型、供应商开始限流、某条请求要用上视觉、账单悄悄往上涨……每改一次，都得重新发一次版。**Helm API 在你的供应商前面架一层又快又薄的网关，把这些选择从代码里挪进配置里。**
+**痛点。** 你的应用写死了一个模型。等哪天你想给简单的请求换个更便宜的模型、给难的请求上更强的模型，或者在某个供应商挂掉时自动切到备用——你都得改代码、重新部署。
 
-客户端照常发 OpenAI 或 Anthropic 请求，Helm 先掂量这条请求有多"重"，把它分到对应的 **lane**（`economy` / `balanced` / `premium` ……），交给带自动故障转移的 provider 适配器执行，并把"为什么这条请求走了这条路"原原本本记下来。你的应用自始至终只动 `base_url` 和 API key，其余的随你在配置文件或自带控制台里慢慢调。
+**Helm 做的事。** Helm 站在你的应用和各家模型供应商中间。应用照常把 OpenAI 或 Anthropic 请求发给 Helm；Helm 判断这条请求该用哪个模型，调用对应的供应商（失败就自动换备用），并记录每一次决策。你的应用始终只需要设置 `base_url` 和 API key——所有路由逻辑都放在一份你自己掌控的配置文件里。
 
-```bash
-# 应用代码原封不动，只换 base_url 和 key
+你填的不再是某个模型名，而是一条 **lane**（车道）——比如 `economy`、`balanced`、`premium` 这样的档位。Helm 会在背后把每条 lane 对应到真实的模型，所以你换模型的时候，应用一行都不用改。
+
+```python
+# 你的应用：还是同一个 OpenAI 客户端，只换 base_url 和 key。
 client = OpenAI(base_url="http://localhost:8080/v1", api_key="<helm-key>")
 client.chat.completions.create(model="balanced", messages=[...])   # 用哪个模型，交给 Helm
 ```
 
 ---
 
-## ✨ 为什么用 Helm
+## 为什么用它
 
-- **对外给的是 lane，不是模型清单。** 调用方只说意图——`economy`、`balanced`、`premium`——根本不用关心背后是哪家供应商、哪个型号。想换模型？改 lane 就行，客户端一行都不用动。
-- **配置才是主角，配错就别想起来。** 路由、lane、策略、供应商全写在 `config/*.yaml` 里，由 Zod 校验。配置不合法，Helm 宁可**拒绝启动**，也绝不带病上线。
-- **旁路出岔子，主流程不背锅。** 分类、eval、缓存任意一环抽风，请求都会悄悄降级到 `balanced` 继续跑，绝不为这点小事甩你一个 5xx。只有当**所有供应商**真的全挂了，才会给出结构化错误。
-- **快路径是确定性的。** 路由判断是个纯函数：零网络、可单测、跑多少遍结果都一样。那个可选的"小模型复核"以 `temperature: 0` 运行、带缓存，而且**默认关闭**——不偷偷加延迟，也不偷偷烧钱。
-- **密钥只存哈希，正文照样留底。** API key 只以 SHA-256 哈希落库，日志里不打、响应里不回显；完整的请求/响应正文进单独的表，可开关、可设保留期——出了问题真能查。
-- **能无头跑，也能有面子。** 整套路由引擎不依赖任何 Web 框架，没界面照样跑；想要的时候，又有一个像样的管理控制台等着你。
-- **跑在自己手里。** MIT 协议、Docker 部署，不做 SaaS、不回传数据。你的网关，你的机器。
+- **换模型不用改代码。** 在配置文件里把某条 lane 指到另一个模型即可，客户端完全无感。
+- **不会无故报错。** 万一某个可选环节出问题（分类、打分、缓存），请求会自动退回 `balanced` 这条 lane 继续跑。只有当所有供应商都真的不可用时，才会返回错误。
+- **默认就是安全的。** 配置不合法就拒绝启动；API key 只保存哈希值；限流和那个可选的打分模型默认都关着，需要时你再打开。
+- **每一次决策都看得见。** 每条请求都会记录走了哪条 lane、最终用了哪个模型、为什么、花了多少钱，在控制台里都能查到。
+- **跑在你自己的机器上。** MIT 协议、Docker 部署，不做 SaaS，数据不会离开你的服务器。
 
-## 🧩 都有些什么
+## 它能做什么
 
-- 🔌 **直接兼容** OpenAI Chat Completions、Anthropic Messages、OpenAI Responses——Chat 与 Messages 还支持 SSE 流式。
-- 🔁 **各种"方言"通吃**：统一收敛到一套内部表示，SSE 事件映射帮你处理好。
-- 🧭 **三层路由**：确定性规则 → 可选的小模型 eval → `balanced` 兜底。
-- 🛣️ **lane + 策略引擎**：首条匹配规则，外加按组织封顶。
-- 🪂 **跨供应商故障转移**：能力过滤（JSON / 工具 / 视觉 / 上下文 / 流式）一应俱全，每个模型还各有一只熔断器。
-- 💾 **存储随你换**：开箱即用 SQLite，规模上来了换 Postgres/Supabase——同一套接口，说换就换。
-- 🔒 **鉴权默认就开**：强制 API key，首次启动自动生成一把 root key，可选的 per-key RPM/TPM 限流。
-- 📊 **一个真能用的控制台**（SvelteKit）：管 key、调 lane 与策略、调分类器、扒请求详情——HTTP Basic 鉴权，支持 5 种语言。
+- 接收 **OpenAI Chat Completions**、**Anthropic Messages**、**OpenAI Responses** 请求——前两者支持流式。
+- 在不同协议之间互译，一个客户端就能对接多家后端。
+- 用内置的快速规则挑选 lane（还可以加一个小模型做二次确认，默认关闭）。
+- 自动在多个供应商之间回退，会先检查每个候选模型的能力（JSON、工具、视觉、上下文长度），并跳过正在故障的。
+- 默认用 SQLite 存储，规模上来了可以换成 Postgres/Supabase。
+- 自带网页控制台，用来管理 key、lane、策略和排查请求——支持 5 种语言。
 
-## 🗺️ 一条请求是怎么流动的
+## 一条请求是怎么流动的
 
 ```
         ┌──────────────────────────── Helm API 网关 (Hono) ───────────────────────────────┐
@@ -58,42 +56,42 @@ client.chat.completions.create(model="balanced", messages=[...])   # 用哪个�
 (OpenAI/ │  /v1/messages ─────────┼─▶ 鉴权 ─▶ 限流 ─▶ 分类 ─▶ 路由 ─▶ 执行 ───────────────┼─▶ 上游
  Anthropic) /v1/responses ────────┘     │        │        │        │        │              │   provider
         │                               │        │        │        │        │              │  (openai-crs,
-        │   /admin (SPA, HTTP Basic) ───┘   per-key RPM/TPM 三层级联 lane+策略 provider 回退 │   zenmux,
-        │   /admin/api/*                                                    + 熔断器        │   openrouter…)
+        │   /admin (SPA, HTTP Basic) ───┘  per-key RPM/TPM 选一条 lane 应用策略 逐个尝试，   │   zenmux,
+        │   /admin/api/*                                                  失败就回退        │   openrouter…)
         │   /healthz  /version                                                              │
         │                                                                                   │
         └──────────────────────────── 存储（默认 SQLite · 可选 Postgres）────────────────────┘
-              key · 决策遥测 · 请求正文 · 限流桶 · 记忆
+              key · 决策日志 · 请求正文 · 限流计数 · 记忆
 ```
 
-路由的"大脑"在 `packages/core` 里，不依赖任何 Web 框架；`apps/gateway` 只是一层薄薄的 Hono 外壳，顺带托管控制台。
+路由逻辑都在 `packages/core` 里，不依赖任何 Web 框架；`apps/gateway` 只是一层很薄的 Hono，顺带托管控制台。
 
-## 🚀 三步跑起来
+## 快速开始
+
+三条命令把网关跑起来：
 
 ```bash
-# 1. 克隆 + 准备 env 文件
+# 1. 克隆并准备 env 文件
 git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
 cp .env.example .env
-#    在 .env 里填好 HELM_ADMIN_PASSWORD，至少再填上 OPENAI_API_KEY
+#    在 .env 里设置 HELM_ADMIN_PASSWORD，并至少填上 OPENAI_API_KEY
 
-# 2. 起服务
+# 2. 启动
 docker compose up -d
 
-# 3. 把首次启动只打印一次的 root API key 抄下来
+# 3. 复制 root API key——它只在首次启动时打印一次
 docker compose logs helm | grep -i "root key"
 ```
-
-搞定：
 
 - **网关** → `http://localhost:8080`
 - **控制台** → `http://localhost:8080/admin`（用 `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` 登录）
 - **健康 / 版本** → `GET /healthz`、`GET /version`
 
-`docker-compose.yml` 把 `./config` 和 `./data` 挂成卷，配置和 SQLite 数据库重启都还在。凭证只经环境变量注入，绝不打进镜像。
+`docker-compose.yml` 把 `./config` 和 `./data` 挂成卷，所以配置和数据库重启后都还在。凭证只通过环境变量传入，不会打进镜像。
 
-## 🔗 怎么调用
+## 怎么调用
 
-任意 OpenAI 兼容客户端都行，把地址指向 Helm、带上 Helm 的 key 就好：
+任何 OpenAI 兼容的客户端都行。把地址指向 Helm，用 Helm 的 key 即可：
 
 ```bash
 curl http://localhost:8080/v1/chat/completions \
@@ -110,25 +108,25 @@ curl http://localhost:8080/v1/chat/completions \
 
 | 端点 | 协议 | 流式 |
 |---|---|---|
-| `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ SSE |
-| `POST /v1/messages` | Anthropic Messages | ✅ SSE |
-| `POST /v1/responses` | OpenAI Responses | ❌ 非流式（0.1） |
+| `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
+| `POST /v1/messages` | Anthropic Messages | ✅ |
+| `POST /v1/responses` | OpenAI Responses | ❌ 暂不支持（0.1） |
 
-> 填 `economy`、`balanced`、`premium`，或像 `coding` 这样的任务 lane 都行。不填（或填个不认识的），Helm 就自己分类、替你挑一条 lane。核心里已经有 Gemini 适配器，只是还没接成路由——见[路线图](docs/09-roadmap.md)。
+> 可以填 `economy`、`balanced`、`premium`，或者像 `coding` 这样的任务 lane。留空（或填一个 Helm 不认识的名字），Helm 就自己替你选一条 lane。核心里已经有 Gemini 适配器，只是还没接成路由——见[路线图](docs/09-roadmap.md)。
 
-## ⚙️ 配置
+## 配置
 
-一切皆为 `config/*.yaml` 里的配置即代码——Zod 校验、配错即拒。可热重载的那几个，也能直接在控制台里改。
+所有配置都在 `config/*.yaml` 里。文件加载时会校验，配置不合法就不让网关启动。其中 lane、策略、分类器还能直接在控制台里改。
 
 | 文件 | 管什么 | 可热改 |
 |---|---|---|
 | `server.yaml` | 主机 / 端口 / base path | — |
-| `auth.yaml` | 强制 API key + root key 引导 | — |
+| `auth.yaml` | 是否强制 API key + 首次启动生成 root key | — |
 | `runtime.yaml` | 请求上限、限流默认值、存储驱动 | 部分 |
 | `providers.yaml` | 上游供应商 + 模型别名（凭证只填环境变量**名**） | — |
-| `lanes.yaml` | lane（primary + fallback 链、约束） | ✅ |
-| `policies.yaml` | 首条匹配的路由规则 | ✅ |
-| `classifier.yaml` | 第 1 层规则 + 第 2 层 eval | ✅ |
+| `lanes.yaml` | lane——每条 lane 的主模型和它的备用链 | ✅ |
+| `policies.yaml` | 选择或封顶 lane 的规则 | ✅ |
+| `classifier.yaml` | 内置规则 + 可选的打分模型 | ✅ |
 | `capabilities.yaml` / `pricing.yaml` | 对模型目录的手动覆盖 | — |
 
 最常用的环境变量（完整清单见 [`.env.example`](.env.example)）：
@@ -140,30 +138,30 @@ curl http://localhost:8080/v1/chat/completions \
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | 控制台登录 |
 | `HELM_PORT` / `HELM_HOST` | 服务绑定（默认 `0.0.0.0:8080`） |
 | `HELM_STORE_DRIVER` | `sqlite`（默认）或 `supabase` |
-| `HELM_RATE_LIMIT_ENABLED` | 限流总开关（默认关闭） |
+| `HELM_RATE_LIMIT_ENABLED` | 打开限流（默认关闭） |
 
-默认带 **economy** / **balanced** / **premium** 三条 lane，外加任务 lane **coding** / **json** / **vision** / **tool_use**。`balanced` 是每次分类都能稳稳退守的那条兜底线。
+Helm 自带 **economy**、**balanced**、**premium** 三条 lane，外加任务 lane **coding**、**json**、**vision**、**tool_use**。`balanced` 是每条请求都能安全退回的那条 lane。
 
-## 🖥️ 控制台
+## 控制台
 
-在 `/admin`，HTTP Basic 鉴权后面：实时仪表盘、API key 管理（创建 / 吊销 / per-key 限流）、lane 与策略编辑器、分类器调参、带完整决策链下钻的请求遥测，以及系统设置（正文抓取、保留期、限流开关）。界面支持英文（默认）、简体与繁体中文、日语、韩语。
+在 `/admin`，用账号密码（HTTP Basic）登录后：实时概览、API key 管理（创建、吊销、设置单个 key 的限额）、lane 与策略编辑器、分类器设置，以及一份能逐条下钻、看清每个请求是怎么被路由的请求日志。支持英文（默认）、简体与繁体中文、日语、韩语。
 
-## 🗂️ 仓库结构
+## 仓库结构
 
 ```
 helm-api/
 ├─ apps/
 │  ├─ gateway/   # Hono API + 托管控制台 + /healthz、/version
-│  └─ admin/     # SvelteKit + Tailwind 控制台（adapter-static SPA）
+│  └─ admin/     # SvelteKit + Tailwind 控制台（静态 SPA）
 ├─ packages/
-│  ├─ core/      # 路由 · 分类 · provider · 协议互译 · Store 端口（不依赖框架）
+│  ├─ core/      # 路由、分类、provider、协议互译、存储端口（不依赖框架）
 │  └─ shared/    # Zod schema + 共享类型（类型唯一来源）
 ├─ config/       # 默认 lanes / policies / classifier / providers / … YAML
 ├─ docs/         # 文档（按 01 → 11 阅读）
 └─ scripts/      # sync:catalog 等构建期工具
 ```
 
-## 🛠️ 本地开发
+## 本地开发
 
 需要 **Node ≥ 22** 和 **pnpm**。
 
@@ -174,15 +172,15 @@ pnpm test         # Vitest 单测
 pnpm test:e2e     # Playwright 端到端测试
 pnpm typecheck    # 全仓 tsc --noEmit
 pnpm lint         # Biome
-pnpm build        # 构建网关 + 控制台资源
+pnpm build        # 构建网关 + 控制台
 pnpm sync:catalog # 刷新生成的模型目录（能力 + 定价）
 ```
 
-测试先行（核心用 Vitest，链路用 Playwright）。完整规格见 [`docs/`](docs/README.md)，设计决策与取舍记在 [`implementation-notes.md`](implementation-notes.md)。文档正文为英文（开源社区通用语），本页提供中文导览。
+测试先行（核心用 Vitest，完整链路用 Playwright）。完整规格见 [`docs/`](docs/README.md)，设计决策记录在 [`implementation-notes.md`](implementation-notes.md)。文档正文是英文（开源社区通用语），本页提供中文导览。
 
-## 📚 文档
+## 文档
 
-建议按顺序读，从 [`docs/README.md`](docs/README.md) 起步：
+建议按顺序读，从 [`docs/README.md`](docs/README.md) 开始：
 
 [01 总览](docs/01-overview.md) ·
 [02 架构](docs/02-architecture.md) ·
@@ -196,18 +194,18 @@ pnpm sync:catalog # 刷新生成的模型目录（能力 + 定价）
 [10 部署](docs/10-deployment.md) ·
 [11 管理界面](docs/11-admin-ui.md)
 
-## 🧭 路线图
+## 路线图
 
-**0.1** 交付完整的路由网关、三种客户端协议、跨供应商故障转移、控制台，以及观察式记忆的 *observe* 阶段。接下来：Gemini 客户端路由、`/v1/responses` 流式、记忆的 *inject* 阶段，以及更细的配额控制。详见 [09 路线图](docs/09-roadmap.md)。
+**0.1** 包含完整的路由网关、三种客户端协议、多供应商回退、控制台，以及记忆功能的前半部分（observe，观察）。接下来：Gemini 路由、`/v1/responses` 流式、记忆的后半部分（inject，注入），以及更细的配额控制。详见 [09 路线图](docs/09-roadmap.md)。
 
-## 🤝 参与贡献
+## 参与贡献
 
-欢迎提 issue 和 PR。请在分支上开发，开 PR 前先把 CI 跑绿：
+欢迎提 issue 和 PR。请在分支上开发，开 PR 前先确保各项检查通过：
 
 ```bash
 pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 ```
 
-## 📄 许可证
+## 许可证
 
 [MIT](LICENSE) © 2026 EasyMeta AU / 路田（上海）网络科技有限公司


### PR DESCRIPTION
A clarity pass on the README based on feedback that it was too clever/formal and not written from the user's point of view.

- Lead with the user's problem and what Helm does, in plain language; explain "lane" the moment it first appears.
- Remove clever/slangy phrasing that hurt clarity; shorter, clearer sentences.
- zh-CN: idiomatic but plain rewrite; fix awkward wording and a wrong measure word.
- Facts, tables, links, and badges unchanged. Docs-only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)