### PR TITLE
docs: correct model-field usage + document routing headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Open-source · self-hosted · MIT
 
 **What Helm does.** Helm sits between your app and the model providers. Your app sends a normal OpenAI or Anthropic request to Helm; Helm decides which model should handle it, calls that provider (and switches to a backup if it fails), and records every decision. Your app only ever sets its `base_url` and API key — all the routing lives in a config file you control.
 
-Instead of naming a model, you name a **lane** — a tier like `economy`, `balanced`, or `premium`. Helm maps each lane to a real model behind the scenes, so you can change models without changing your app.
+You don't pick the model. Your app sends `model: "auto"`, and Helm sorts the request into a **lane** — a tier like `economy`, `balanced`, or `premium`. You decide in config how each lane maps to a real model, so you can change models, costs, and fallbacks without touching your app. (Need a specific model for one call? A key with the right permission can name it directly — see [Calling the gateway](#calling-the-gateway).)
 
 ```python
 # Your app: the same OpenAI client, just a new base_url and key.
 client = OpenAI(base_url="http://localhost:8080/v1", api_key="<helm-key>")
-client.chat.completions.create(model="balanced", messages=[...])   # Helm picks the model
+client.chat.completions.create(model="auto", messages=[...])   # Helm classifies and routes
 ```
 
 ---
@@ -98,13 +98,13 @@ curl http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer $HELM_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "balanced",
+    "model": "auto",
     "messages": [{"role": "user", "content": "Explain consistent hashing in two sentences."}],
     "stream": true
   }'
 ```
 
-Put a **lane** name in the `model` field, not a vendor model id:
+Three endpoints, all authenticated with a Helm API key:
 
 | Endpoint | Protocol | Streaming |
 |---|---|---|
@@ -112,7 +112,28 @@ Put a **lane** name in the `model` field, not a vendor model id:
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ❌ not yet (0.1) |
 
-> Use `economy`, `balanced`, `premium`, or a task lane like `coding`. Leave it blank (or send a name Helm doesn't know) and Helm picks a lane for you. A Gemini adapter exists in the core but isn't exposed as a route yet — see the [roadmap](docs/09-roadmap.md).
+**What to put in the `model` field:**
+
+| Value | What Helm does |
+|---|---|
+| `auto` *(recommended)* | Classifies the request and routes it to the best lane automatically. |
+| a model alias, e.g. `openai-crs/gpt-5.5` | Uses exactly that model and skips routing — only for API keys granted custom-model permission. |
+
+> With a standard key the routing is automatic no matter what you send, so just use `auto`. The lanes themselves (`economy`, `balanced`, `premium`, `coding`, …) are configured by the operator in `lanes.yaml` and the dashboard — Helm assigns each request to one; clients don't choose a lane per call. A Gemini adapter exists in the core but isn't routed yet — see the [roadmap](docs/09-roadmap.md).
+
+### Seeing how a request was routed
+
+Every `/v1/chat/completions` response carries headers that explain the decision — quick debugging without opening the dashboard:
+
+| Header | Meaning |
+|---|---|
+| `x-helm-lane` | The lane the request landed in |
+| `x-helm-final-model` | The model alias that actually answered |
+| `x-helm-provider-model` | The upstream model id sent on the wire |
+| `x-helm-decided-by` | How the lane was chosen (`rules`, `eval`, `fallback`, …) |
+| `x-helm-fallback-reason` | Why it fell back, when it did |
+
+When rate limiting is on, responses also include `x-ratelimit-limit`, `x-ratelimit-remaining`, and `x-ratelimit-reset` (plus `retry-after` on a 429).
 
 ## Configuration
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,12 +20,12 @@
 
 **Helm 做的事。** Helm 站在你的应用和各家模型供应商中间。应用照常把 OpenAI 或 Anthropic 请求发给 Helm；Helm 判断这条请求该用哪个模型，调用对应的供应商（失败就自动换备用），并记录每一次决策。你的应用始终只需要设置 `base_url` 和 API key——所有路由逻辑都放在一份你自己掌控的配置文件里。
 
-你填的不再是某个模型名，而是一条 **lane**（车道）——比如 `economy`、`balanced`、`premium` 这样的档位。Helm 会在背后把每条 lane 对应到真实的模型，所以你换模型的时候，应用一行都不用改。
+模型不用你来选。应用发 `model: "auto"`，Helm 就把这条请求归入一条 **lane**（车道）——比如 `economy`、`balanced`、`premium` 这样的档位。每条 lane 对应哪个真实模型，由你在配置里说了算，所以换模型、调成本、改回退链，都不用动应用代码。（某次调用就想用某个具体模型？给 key 开了权限就能直接点名——见下方“怎么调用”。）
 
 ```python
 # 你的应用：还是同一个 OpenAI 客户端，只换 base_url 和 key。
 client = OpenAI(base_url="http://localhost:8080/v1", api_key="<helm-key>")
-client.chat.completions.create(model="balanced", messages=[...])   # 用哪个模型，交给 Helm
+client.chat.completions.create(model="auto", messages=[...])   # 交给 Helm 分类并路由
 ```
 
 ---
@@ -98,13 +98,13 @@ curl http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer $HELM_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "balanced",
+    "model": "auto",
     "messages": [{"role": "user", "content": "用两句话解释一致性哈希。"}],
     "stream": true
   }'
 ```
 
-`model` 字段填的是 **lane** 名，而不是某家厂商的具体型号：
+三个端点，都用 Helm 的 API key 鉴权：
 
 | 端点 | 协议 | 流式 |
 |---|---|---|
@@ -112,7 +112,28 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ❌ 暂不支持（0.1） |
 
-> 可以填 `economy`、`balanced`、`premium`，或者像 `coding` 这样的任务 lane。留空（或填一个 Helm 不认识的名字），Helm 就自己替你选一条 lane。核心里已经有 Gemini 适配器，只是还没接成路由——见[路线图](docs/09-roadmap.md)。
+**`model` 字段填什么：**
+
+| 取值 | Helm 怎么处理 |
+|---|---|
+| `auto`（推荐） | 自动分类这条请求，并路由到最合适的 lane。 |
+| 某个模型别名，例如 `openai-crs/gpt-5.5` | 跳过路由，直接用这个模型——仅限被授予自定义模型权限的 key。 |
+
+> 用普通 key 时，不管填什么都会自动路由，所以直接填 `auto` 就行。lane 本身（`economy`、`balanced`、`premium`、`coding`……）由运维在 `lanes.yaml` 和控制台里配置——Helm 负责把每条请求归入某条 lane，客户端不用逐次去选。核心里已经有 Gemini 适配器，只是还没接成路由——见[路线图](docs/09-roadmap.md)。
+
+### 看清一条请求是怎么路由的
+
+每个 `/v1/chat/completions` 响应都会带上能解释这次决策的头部，不打开控制台也能快速排查：
+
+| 头部 | 含义 |
+|---|---|
+| `x-helm-lane` | 请求最终落在哪条 lane |
+| `x-helm-final-model` | 真正应答的模型别名 |
+| `x-helm-provider-model` | 实际发给上游的模型 id |
+| `x-helm-decided-by` | lane 是怎么定下来的（`rules`、`eval`、`fallback`……） |
+| `x-helm-fallback-reason` | 如果发生了回退，原因是什么 |
+
+开启限流后，响应还会带上 `x-ratelimit-limit`、`x-ratelimit-remaining`、`x-ratelimit-reset`（429 时再加 `retry-after`）。
 
 ## 配置
 


### PR DESCRIPTION
The README told clients to put a lane name in the `model` field, but the code (`route-request.ts`) never honors that — a standard key always auto-routes, and only a custom-model key can name a model. This fixes the README and documents features that were missing.

- **`model` field**: `auto` (recommended — Helm classifies and routes) and explicit model passthrough by alias (custom-model keys only); `auto` is never treated as explicit.
- Clarify that lanes are operator-configured (`lanes.yaml` / dashboard) — clients don't choose a lane per call.
- New **"Seeing how a request was routed"** section: `x-helm-lane`, `x-helm-final-model`, `x-helm-provider-model`, `x-helm-decided-by`, `x-helm-fallback-reason`, plus the `x-ratelimit-*` / `retry-after` headers.
- EN + idiomatic zh-CN. Docs-only; `docs/04` was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)