### PR TITLE
feat(docker): inject build info so /version reports real values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build gateway image
-        run: docker build -t helm-api:ci .
+        # Inject build info (docs/10) so GET /version reports real values instead
+        # of "unknown": app version from package.json, the commit, and a UTC stamp.
+        run: |
+          docker build -t helm-api:ci \
+            --build-arg HELM_VERSION="$(node -p "require('./package.json').version")" \
+            --build-arg HELM_GIT_SHA="$(git rev-parse --short HEAD)" \
+            --build-arg HELM_BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            .
       - name: Run container with required env
         # The provider credential is referenced by env NAME only (principle 7);
         # /healthz never calls upstream, so a dummy value is enough to boot. Config
@@ -57,6 +64,17 @@ jobs:
           echo "::error::gateway did not become healthy within 30s"
           docker logs helm-ci
           exit 1
+      - name: Verify /version reports injected build info
+        # Guards the build-arg wiring above: a regression that drops the args
+        # would make /version fall back to "unknown" and fail here.
+        run: |
+          body=$(curl -fsS http://127.0.0.1:8080/version)
+          echo "$body"
+          expected=$(node -p "require('./package.json').version")
+          echo "$body" | grep -q "\"version\":\"${expected}\"" \
+            || { echo "::error::/version did not report injected version ${expected}"; exit 1; }
+          echo "$body" | grep -q '"gitSha":"unknown"' \
+            && { echo "::error::/version gitSha was not injected"; exit 1; } || true
       - name: Stop container
         if: always()
         continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,17 @@ FROM node:22-slim AS runtime
 ENV NODE_ENV=production
 WORKDIR /app
 
+# Build info surfaced by GET /version (docs/10) and the admin header status cluster.
+# Read at runtime by readBuildInfo() from these env vars; injected here at build
+# time via --build-arg (CI passes the package version + commit + timestamp; see
+# .github/workflows/ci.yml). Defaults keep a bare `docker build` working.
+ARG HELM_VERSION=unknown
+ARG HELM_GIT_SHA=unknown
+ARG HELM_BUILT_AT=unknown
+ENV HELM_VERSION=$HELM_VERSION \
+    HELM_GIT_SHA=$HELM_GIT_SHA \
+    HELM_BUILT_AT=$HELM_BUILT_AT
+
 # Non-root user; pre-create the mount dirs it must read/write.
 RUN useradd --system --uid 10001 --create-home --shell /usr/sbin/nologin helm \
  && mkdir -p /app/config /app/data && chown -R helm:helm /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,13 @@
 services:
   helm:
-    # Default to the published image; for local dev uncomment `build: .`.
+    # Default to the published image; for local dev uncomment the `build` block.
     image: ghcr.io/easymetaau/helm-api:latest
-    # build: .
+    # build:
+    #   context: .
+    #   args: # surfaced by GET /version + the admin header (docs/10)
+    #     HELM_VERSION: ${HELM_VERSION:-dev}
+    #     HELM_GIT_SHA: ${HELM_GIT_SHA:-dev}
+    #     HELM_BUILT_AT: ${HELM_BUILT_AT:-dev}
     container_name: helm
     ports:
       - "8080:8080"

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -106,7 +106,10 @@ never runs in a half-broken state (Principle 2).
   `503` when degraded (fail-closed: a probe failure reports not-ready, never a
   hang or 500). The container `HEALTHCHECK` hits this endpoint.
 - `GET /version` — unauthenticated build info (`version`, `gitSha`, `builtAt`),
-  injected at build time. No config or credentials are exposed.
+  injected at build time via the `HELM_VERSION` / `HELM_GIT_SHA` / `HELM_BUILT_AT`
+  Docker build-args (CI fills them from the package version, commit, and a UTC
+  stamp; for a local `build: .` see the commented `args` in `docker-compose.yml`).
+  Defaults to `unknown` when unset. No config or credentials are exposed.
 
 ## Upgrading
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 2026-06-01 · Inject build info into the Docker image so /version is real (docs/10)
+
+**Context**: follow-up to the status cluster. After deploying, the header's **version pill never showed** and the gateway reported `GET /version → {"version":"unknown",...}`. Root cause: `readBuildInfo()` reads `HELM_VERSION`/`HELM_GIT_SHA`/`HELM_BUILT_AT` from env, but the **`Dockerfile` never set them** — so the docs' claim that build info is "injected at build time" was aspirational. (The status-cluster component intentionally hides a `"unknown"` version, which is why the pill was blank — correct behavior, missing data.)
+
+**Fix**:
+- `Dockerfile` (runtime stage): declare `ARG HELM_VERSION/HELM_GIT_SHA/HELM_BUILT_AT` (default `unknown`) → `ENV`. A bare `docker build` still works; values come from `--build-arg`.
+- `.github/workflows/ci.yml` (docker job): pass the args — `HELM_VERSION` from `package.json`, `HELM_GIT_SHA` from `git rev-parse --short HEAD`, `HELM_BUILT_AT` from a UTC stamp — and a new step asserts `/version` reports the injected version (and a non-`unknown` gitSha), guarding the wiring.
+- `docker-compose.yml`: documented the same args under a commented `build` block for local `build: .`.
+- Root `package.json` version `0.0.0` → **`0.1.0`** so the injected value is meaningful (matches the "0.1 release" framing across README/docs). This is the single source of truth the build reads.
+
+**Sibling decision (GitHub stars)**: the star count was *also* blank, but for an unrelated reason — `EasyMetaAu/helm-api` was **private**, so the unauthenticated GitHub API returned 404 and the client fail-silently hid the count. Resolved by **making the repo public** (the intended open-source state); the existing client-side fetch now shows `★ N` with no code change. The earlier "stars client-side, not gateway-proxied" decision stands.
+
+**Local deploy**: rebuilt `ghcr.io/easymetaau/helm-api:latest` with the three `--build-arg`s and recreated the compose container; `/version` now returns `0.1.0` + short sha + timestamp, and the pill renders.
+
+---
+
 ## 2026-06-01 · Unified admin status cluster in the header top-right (docs/11, Principle 3 & 7)
 
 **Context**: operator-facing meta was scattered in the sidebar footer — a `LocaleSwitcher`, a **hardcoded** "Gateway online" badge (static green dot that never reflected real health), and a GitHub link with no star count — and there was no version display despite the gateway already exposing `GET /version`. Consolidated all of it into one designed cluster in the previously-empty **header top-right**, and made the signals live.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Why

Follow-up to the admin status cluster (#22). After deploying, the header's **version pill stayed blank** and the gateway reported:

```
GET /version → {"version":"unknown","gitSha":"unknown","builtAt":"unknown"}
```

`readBuildInfo()` reads `HELM_VERSION`/`HELM_GIT_SHA`/`HELM_BUILT_AT` from env, but the **`Dockerfile` never set them** — so the docs' claim that build info is "injected at build time" was aspirational. (The status-cluster component intentionally hides an `unknown` version, so the data gap surfaced as a blank pill.)

## What

- **`Dockerfile`** (runtime stage): `ARG HELM_VERSION/HELM_GIT_SHA/HELM_BUILT_AT` (default `unknown`) → `ENV`. A bare `docker build` still works; real values come from `--build-arg`.
- **`.github/workflows/ci.yml`** (docker job): pass the args — `HELM_VERSION` from `package.json`, `HELM_GIT_SHA` from `git rev-parse --short HEAD`, `HELM_BUILT_AT` from a UTC stamp — plus a new step that **asserts `/version` reports the injected version** (and a non-`unknown` gitSha), guarding the wiring against regressions.
- **`docker-compose.yml`**: documented the same args under a commented `build` block for local `build: .`.
- **Root `package.json`**: version `0.0.0` → **`0.1.0`** (matches the "0.1 release" framing across README/docs) so the injected value is meaningful — it's the single source the build reads.
- **docs/10**: names the actual build-args.

## Verification

Built locally with the args and ran the image:
```
GET /version → {"version":"0.1.0","gitSha":"2895289","builtAt":"2026-06-01T10:17:46Z"}
```
→ the header pill renders `v0.1.0`. CI now asserts this so it can't silently regress.

> Sibling fix (no code): the GitHub **star count** was blank because the repo was **private** (unauth GitHub API → 404 → fail-silent hide). The repo is now **public**, so the existing client-side fetch shows `★ N` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)