### PR TITLE
chore: drop secondary copyright entity, keep "EasyMeta AU"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 EasyMeta AU / 路田（上海）网络科技有限公司
+Copyright (c) 2026 EasyMeta AU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -229,4 +229,4 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 
 ## License
 
-[MIT](LICENSE) © 2026 EasyMeta AU / 路田（上海）网络科技有限公司
+[MIT](LICENSE) © 2026 EasyMeta AU

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -229,4 +229,4 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 
 ## 许可证
 
-[MIT](LICENSE) © 2026 EasyMeta AU / 路田（上海）网络科技有限公司
+[MIT](LICENSE) © 2026 EasyMeta AU


### PR DESCRIPTION
Remove "路田（上海）网络科技有限公司" project-wide. Copyright now reads "EasyMeta AU" in `LICENSE`, `README.md`, and `README.zh-CN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)