### PR TITLE
ci: publish version-injected image to GHCR on main + tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish image
+
+# Builds the gateway image with real build info and pushes it to GHCR.
+#   - push to main      -> ghcr.io/easymetaau/helm-api:latest + :sha-<short>
+#   - push tag v1.2.3   -> ghcr.io/easymetaau/helm-api:latest + :1.2.3
+# Runs on the org self-hosted runners (same pool as CI). Build info is injected
+# via the Dockerfile build-args (docs/10) so GET /version reports real values.
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: [self-hosted, Linux, X64, docker]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve tags + build info
+        id: meta
+        run: |
+          IMAGE=ghcr.io/easymetaau/helm-api
+          VERSION=$(node -p "require('./package.json').version")
+          SHA=$(git rev-parse --short HEAD)
+          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"            # v0.1.0 -> 0.1.0
+            TAGS="${IMAGE}:latest ${IMAGE}:${VERSION}"
+          else
+            TAGS="${IMAGE}:latest ${IMAGE}:sha-${SHA}"
+          fi
+          {
+            echo "version=${VERSION}"
+            echo "sha=${SHA}"
+            echo "built_at=${BUILT_AT}"
+            echo "tags=${TAGS}"
+          } >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build & push
+        run: |
+          args=()
+          for t in ${{ steps.meta.outputs.tags }}; do args+=( -t "$t" ); done
+          docker build \
+            --build-arg HELM_VERSION="${{ steps.meta.outputs.version }}" \
+            --build-arg HELM_GIT_SHA="${{ steps.meta.outputs.sha }}" \
+            --build-arg HELM_BUILT_AT="${{ steps.meta.outputs.built_at }}" \
+            "${args[@]}" .
+          for t in ${{ steps.meta.outputs.tags }}; do docker push "$t"; done
+      - name: Summary
+        run: |
+          echo "Pushed: ${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "version=${{ steps.meta.outputs.version }} sha=${{ steps.meta.outputs.sha }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

There's no automated image publish — only `ci.yml`, which smoke-tests but never pushes. As a result `ghcr.io/easymetaau/helm-api:latest` is **stale** and was built **without** build info (so `GET /version` → `unknown`). Now that the repo is public and #24 wired the build-args, the published image should carry real build info.

## What

New `.github/workflows/publish.yml` on the **self-hosted** runners:

| Trigger | Tags pushed |
|---|---|
| push to `main` | `:latest`, `:sha-<short>` |
| push tag `vX.Y.Z` | `:latest`, `:X.Y.Z` |

Builds with `--build-arg HELM_VERSION/HELM_GIT_SHA/HELM_BUILT_AT` (docs/10), logs in to GHCR with the job's `GITHUB_TOKEN` (`packages: write`). Merging this PR publishes immediately (`:latest` + `:sha-…`).

## Follow-up (not in this PR)
The GHCR package `helm-api` is currently **private** — it must be set **public** for anonymous `docker pull` to work on the open-source repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)