### PR TITLE
style(admin): unify form & button design language

### DIFF
--- a/apps/admin/src/app.css
+++ b/apps/admin/src/app.css
@@ -79,14 +79,40 @@
   .input {
     @apply w-full rounded border border-slate-300 px-2 py-1.5 text-sm text-slate-900 transition-colors placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200;
   }
+  /* Compact variant of .input for inline/table use (per-key rate limits, the
+     latency cap). Same border + focus ring as .input — ONLY the padding is
+     tighter — so every text/number field shares one height + one focus state.
+     Width is set by the caller (e.g. `input-sm w-24`). */
+  .input-sm {
+    @apply rounded border border-slate-300 px-2 py-1 text-sm text-slate-900 transition-colors placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200;
+  }
   .select {
     @apply w-full rounded border border-slate-300 bg-white px-2 py-1.5 text-sm text-slate-700 transition-colors focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200;
+  }
+  /* Native checkbox, sized + brand-neutral accent + matching focus ring so every
+     checkbox reads the same across pages (was raw browser default before). */
+  .checkbox {
+    @apply h-4 w-4 rounded border-slate-300 accent-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400;
+  }
+  /* "[box] label" inline group. Pair with .checkbox on the input. */
+  .checkbox-field {
+    @apply flex items-center gap-2 text-sm text-slate-700;
+  }
+  /* Vertical label → control → help group. The canonical form field stack. */
+  .field {
+    @apply flex flex-col gap-1;
   }
   .field-label {
     @apply text-sm font-medium text-slate-700;
   }
   .field-help {
     @apply text-xs text-slate-500;
+  }
+  /* Standard card footer: a right-aligned action row (Save / Cancel) divided from
+     the fields above. Used at the bottom of every editable card so the primary
+     action sits in one consistent place app-wide. */
+  .card-actions {
+    @apply mt-1 flex items-center justify-end gap-3 border-t border-slate-100 pt-3;
   }
 
   /* — Badges / pills (self-contained, single class) — */

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -167,9 +167,10 @@
         >
       </label>
 
-      <label class="flex items-center gap-2 text-sm">
+      <label class="checkbox-field">
         <input
           type="checkbox"
+          class="checkbox"
           bind:checked={allowCustomModel}
           aria-label={$t('allow custom model')}
         />
@@ -190,7 +191,7 @@
             step="1"
             aria-label={$t('Requests per minute (RPM)')}
             placeholder={$t('Default')}
-            class="select"
+            class="input"
             bind:value={rpmInput}
           />
         </label>
@@ -202,7 +203,7 @@
             step="1"
             aria-label={$t('Tokens per minute (TPM)')}
             placeholder={$t('Default')}
-            class="select"
+            class="input"
             bind:value={tpmInput}
           />
         </label>

--- a/apps/admin/src/lib/components/LaneEditor.svelte
+++ b/apps/admin/src/lib/components/LaneEditor.svelte
@@ -184,34 +184,34 @@
     </div>
   </fieldset>
 
-  <div class="flex flex-col gap-1">
+  <div class="flex flex-col gap-2">
     <span class="field-label">{$t('Constraints')}</span>
     <span class="field-help">
       {$t('Optional requirements a model must meet for this lane to use it.')}
     </span>
-    <div class="flex flex-wrap items-center gap-4 text-sm">
-      <label class="flex items-center gap-2">
-        <input type="checkbox" bind:checked={requireTools} />
+    <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
+      <label class="checkbox-field">
+        <input type="checkbox" class="checkbox" bind:checked={requireTools} />
         <span>{$t('Require tools')}</span>
       </label>
-      <label class="flex items-center gap-2">
-        <input type="checkbox" bind:checked={requireJson} />
+      <label class="checkbox-field">
+        <input type="checkbox" class="checkbox" bind:checked={requireJson} />
         <span>{$t('Require JSON')}</span>
       </label>
-      <label class="flex items-center gap-2">
-        <span>{$t('Max latency (ms)')}</span>
-        <input
-          type="number"
-          min="1"
-          class="input w-24"
-          value={maxLatency ?? ''}
-          oninput={(e) => {
-            const v = (e.currentTarget as HTMLInputElement).value;
-            maxLatency = v === '' ? null : Number(v);
-          }}
-        />
-      </label>
     </div>
+    <label class="field">
+      <span class="field-label">{$t('Max latency (ms)')}</span>
+      <input
+        type="number"
+        min="1"
+        class="input-sm w-32"
+        value={maxLatency ?? ''}
+        oninput={(e) => {
+          const v = (e.currentTarget as HTMLInputElement).value;
+          maxLatency = v === '' ? null : Number(v);
+        }}
+      />
+    </label>
   </div>
 
   {#if primaryEmpty}
@@ -228,10 +228,10 @@
     </p>
   {/if}
 
-  <div class="flex items-center gap-3">
-    <button type="submit" class="btn-primary" disabled={!valid}>{$t('Save')}</button>
+  <div class="card-actions">
     {#if saved}
       <span data-testid="lane-saved" role="status" class="badge-ok">{$t('Saved')}</span>
     {/if}
+    <button type="submit" class="btn-primary" disabled={!valid}>{$t('Save')}</button>
   </div>
 </form>

--- a/apps/admin/src/lib/components/PolicyRow.svelte
+++ b/apps/admin/src/lib/components/PolicyRow.svelte
@@ -110,9 +110,9 @@
     >
     <button
       type="button"
-      class="rounded px-2.5 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+      class="btn-icon hover:bg-red-50 hover:text-red-600"
       aria-label={$t('remove')}
-      onclick={() => onremove(index)}>{$t('Remove')}</button
+      onclick={() => onremove(index)}>✕</button
     >
   </header>
 
@@ -127,8 +127,8 @@
   <fieldset class="flex flex-col gap-3">
     <legend class="field-label">{$t('When a request matches ALL of:')}</legend>
 
-    <div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
-      <label class="flex flex-col gap-1 text-sm">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <label class="field">
         <span class="field-label">{$t('Task type')}</span>
         <select
           class="select"
@@ -142,7 +142,7 @@
         </select>
       </label>
 
-      <label class="flex flex-col gap-1 text-sm">
+      <label class="field">
         <span class="field-label">{$t('Complexity')}</span>
         <select
           class="select"
@@ -156,20 +156,7 @@
         </select>
       </label>
 
-      <label class="flex items-start gap-2 text-sm">
-        <input
-          type="checkbox"
-          class="mt-0.5"
-          checked={match.needs_json === true}
-          onchange={(e) => emitMatch({ needs_json: e.currentTarget.checked ? true : undefined })}
-        />
-        <span class="flex flex-col">
-          <span class="field-label">{$t('Requires JSON output')}</span>
-          <span class="field-help">{$t('Match requests that ask for a JSON response.')}</span>
-        </span>
-      </label>
-
-      <label class="flex flex-col gap-1 text-sm">
+      <label class="field">
         <span class="field-label">{$t('User ID')}</span>
         <input
           class="input"
@@ -179,7 +166,7 @@
         <span class="field-help">{$t('Match a single end-user by their ID.')}</span>
       </label>
 
-      <label class="flex flex-col gap-1 text-sm">
+      <label class="field">
         <span class="field-label">{$t('Organization ID')}</span>
         <input
           class="input"
@@ -189,6 +176,19 @@
         <span class="field-help">{$t('Match every request from one organization.')}</span>
       </label>
     </div>
+
+    <label class="checkbox-field items-start">
+      <input
+        type="checkbox"
+        class="checkbox mt-0.5"
+        checked={match.needs_json === true}
+        onchange={(e) => emitMatch({ needs_json: e.currentTarget.checked ? true : undefined })}
+      />
+      <span class="flex flex-col">
+        <span class="field-label">{$t('Requires JSON output')}</span>
+        <span class="field-help">{$t('Match requests that ask for a JSON response.')}</span>
+      </span>
+    </label>
   </fieldset>
 
   <fieldset class="flex flex-col gap-2">
@@ -199,8 +199,8 @@
       )}
     </p>
 
-    <div class="flex flex-wrap items-start gap-6">
-      <label class="flex flex-col gap-1 text-sm">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <label class="field">
         <span
           class="field-label"
           class:text-ink-strong={action === 'use_lane'}
@@ -221,7 +221,7 @@
         </select>
       </label>
 
-      <label class="flex flex-col gap-1 text-sm">
+      <label class="field">
         <span
           class="field-label"
           class:text-ink-strong={action === 'max_lane'}

--- a/apps/admin/src/routes/classifier/+page.svelte
+++ b/apps/admin/src/routes/classifier/+page.svelte
@@ -86,7 +86,7 @@
     </div>
 
     <label class="flex items-center gap-3">
-      <input type="checkbox" name="eval_enabled" bind:checked={evalEnabled} />
+      <input type="checkbox" class="checkbox" name="eval_enabled" bind:checked={evalEnabled} />
       <span class="field-label">{$t('Enable Layer-2 eval')}</span>
       <span class="badge-eval">{$t('Layer-2')}</span>
     </label>
@@ -121,7 +121,10 @@
       {/if}
     </label>
 
-    <div class="flex items-center gap-3">
+    <div class="card-actions">
+      {#if saved}
+        <span class="badge-ok" role="status">{$t('Saved')}</span>
+      {/if}
       <button
         type="button"
         onclick={handleSave}
@@ -130,9 +133,6 @@
       >
         {saving ? $t('Saving…') : $t('Save')}
       </button>
-      {#if saved}
-        <span class="badge-ok" role="status">{$t('Saved')}</span>
-      {/if}
     </div>
   </div>
 

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -180,7 +180,7 @@
                         step="1"
                         aria-label={$t('RPM')}
                         placeholder={$t('Default')}
-                        class="w-24 rounded border border-slate-300 px-2 py-1"
+                        class="input-sm w-24"
                         bind:value={editRpm}
                       />
                     </label>
@@ -192,7 +192,7 @@
                         step="1"
                         aria-label={$t('TPM')}
                         placeholder={$t('Default')}
-                        class="w-24 rounded border border-slate-300 px-2 py-1"
+                        class="input-sm w-24"
                         bind:value={editTpm}
                       />
                     </label>
@@ -214,7 +214,7 @@
                   {#if !key.disabled}
                     <button
                       type="button"
-                      class="mt-1 text-xs text-indigo-600 hover:underline"
+                      class="link-inline mt-1 text-xs"
                       onclick={() => startEditLimits(key)}>{$t('Edit limits')}</button
                     >
                   {/if}

--- a/apps/admin/src/routes/policies/+page.svelte
+++ b/apps/admin/src/routes/policies/+page.svelte
@@ -40,8 +40,8 @@
     // (server requires at least one of use_lane/max_lane). Appended LAST so it
     // gets the lowest priority (first-match order) and can't shadow existing rules.
     policies = [...policies, { match: { task_type: TASK_TYPE_OPTIONS[0] }, use_lane: lanes[0] }];
-    // The Add button lives in the header; with a long list the new row lands far
-    // below the fold, so the click looks like a no-op. Scroll it into view for
+    // The new row appends to the end of a potentially long list, so the click can
+    // land below the fold and look like a no-op. Scroll it into view for
     // immediate feedback.
     await tick();
     const rows = document.querySelectorAll('[data-testid="policy-row"]');
@@ -68,24 +68,13 @@
 
 <section class="flex w-full flex-col gap-4 px-4 py-6 md:px-8">
   <header class="flex flex-col gap-2">
-    <div class="flex flex-wrap items-start justify-between gap-3">
-      <div class="min-w-0">
-        <h1 class="page-title">{$t('Policies')}</h1>
-        <p class="section-desc">
-          {$t(
-            'Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.',
-          )}
-        </p>
-      </div>
-      <div class="flex shrink-0 items-center gap-2">
-        <button type="button" class="btn-secondary" onclick={addRow}>{$t('Add policy')}</button>
-        <button type="button" class="btn-primary" onclick={handleSave} disabled={saving}
-          >{$t('Save policies')}</button
-        >
-        {#if saved}
-          <span class="badge-ok" data-testid="policies-saved" role="status">{$t('Saved')}</span>
-        {/if}
-      </div>
+    <div class="min-w-0">
+      <h1 class="page-title">{$t('Policies')}</h1>
+      <p class="section-desc">
+        {$t(
+          'Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.',
+        )}
+      </p>
     </div>
     <p class="card text-sm text-ink-body" data-testid="first-match-explainer">
       {$t('Rules are evaluated top to bottom; the')}
@@ -125,5 +114,17 @@
         onmove={moveRow}
       />
     {/each}
+  </div>
+
+  <div class="flex items-center justify-between gap-3">
+    <button type="button" class="btn-secondary" onclick={addRow}>{$t('Add policy')}</button>
+    <div class="flex items-center gap-3">
+      {#if saved}
+        <span class="badge-ok" data-testid="policies-saved" role="status">{$t('Saved')}</span>
+      {/if}
+      <button type="button" class="btn-primary" onclick={handleSave} disabled={saving}
+        >{$t('Save policies')}</button
+      >
+    </div>
   </div>
 </section>

--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -51,14 +51,6 @@
     <p class="section-desc">
       {$t('Runtime settings that take effect immediately — no restart needed.')}
     </p>
-    <div class="flex items-center gap-2">
-      <button class="btn-primary" onclick={handleSave} disabled={saving || !data.settings}>
-        {$t('Save settings')}
-      </button>
-      {#if saved}
-        <span class="badge-ok" role="status">{$t('Saved')}</span>
-      {/if}
-    </div>
   </header>
 
   {#if error}
@@ -74,7 +66,7 @@
         <input
           type="checkbox"
           data-testid="capture-payloads"
-          class="mt-1"
+          class="checkbox mt-0.5"
           bind:checked={form.capture_payloads}
         />
         <span>
@@ -99,7 +91,7 @@
           min="1"
           max="3650"
           data-testid="retention-days"
-          class="w-32 rounded border border-slate-300 px-2 py-1"
+          class="input-sm w-32"
           bind:value={form.payload_retention_days}
         />
         <span class="field-help">{$t('Older bodies are deleted automatically.')}</span>
@@ -114,7 +106,7 @@
         <input
           type="checkbox"
           data-testid="rate-limit-enabled"
-          class="mt-1"
+          class="checkbox mt-0.5"
           bind:checked={form.rate_limit_enabled}
         />
         <span>
@@ -133,7 +125,7 @@
             min="0"
             step="1"
             data-testid="rate-limit-default-rpm"
-            class="w-32 rounded border border-slate-300 px-2 py-1"
+            class="input-sm w-32"
             bind:value={form.rate_limit_default_rpm}
           />
         </label>
@@ -144,7 +136,7 @@
             min="0"
             step="1"
             data-testid="rate-limit-default-tpm"
-            class="w-32 rounded border border-slate-300 px-2 py-1"
+            class="input-sm w-32"
             bind:value={form.rate_limit_default_tpm}
           />
         </label>
@@ -157,11 +149,7 @@
 
       <label class="flex flex-col gap-1">
         <span class="font-medium">{$t('Log level')}</span>
-        <select
-          data-testid="log-level"
-          class="w-40 rounded border border-slate-300 px-2 py-1"
-          bind:value={form.log_level}
-        >
+        <select data-testid="log-level" class="select w-40" bind:value={form.log_level}>
           {#each LOG_LEVEL_OPTIONS as level (level)}
             <option value={level}>{level}</option>
           {/each}
@@ -169,5 +157,14 @@
         <span class="field-help">{$t('How much detail the gateway writes to its logs.')}</span>
       </label>
     </section>
+
+    <div class="card-actions border-t-0 pt-0">
+      {#if saved}
+        <span class="badge-ok" role="status">{$t('Saved')}</span>
+      {/if}
+      <button class="btn-primary" onclick={handleSave} disabled={saving || !data.settings}>
+        {$t('Save settings')}
+      </button>
+    </div>
   {/if}
 </section>


### PR DESCRIPTION
## Why

The form-heavy admin pages *felt* messy: inputs sat at two different heights (some without a focus ring), the **Save** button lived in a different place on each page, **Remove** was bare red text next to proper icon buttons, and the lane-constraints / policy-match layouts were misaligned.

Screenshotting every page (via Playwright with mocked `/admin/api/*`) confirmed the root cause: `app.css` already has a solid semantic recipe layer (`.btn-*`, `.input`, `.select`, `.card`, tokens) — but several pages **hand-roll markup instead of composing it**, and there was no recipe for checkboxes or a card action row. So this **unifies usage**, it does not reinvent the look.

## Changes

- **`app.css`** — add 5 recipes: `.input-sm`, `.checkbox`, `.checkbox-field`, `.field`, `.card-actions`
- **Inputs/checkboxes** — replace hand-rolled `px-2 py-1` inputs and raw native checkboxes with the recipes (`settings`, `keys`, `CreateKeyDialog`, `classifier`, `LaneEditor`) → one height + one focus state everywhere
- **Save placement** — unified into a bottom-right action row on every page (was a top toolbar on policies/settings; bottom-of-card on lanes/classifier)
- **`PolicyRow`** — `Remove` → `✕` icon button matching the reorder arrows; align match + action selects into consistent 2-col grids
- **`LaneEditor`** — split the crammed constraints row so "Max latency (ms)" is its own labeled field
- **`keys`** — "Edit limits" uses the shared `.link-inline` (was ad-hoc indigo)

### Decisions (confirmed with maintainer)
- Primary buttons stay **neutral slate-800**; brand indigo stays for logo/nav only
- Action placement: **right-aligned row at the bottom of each card**
- Scope: unify recipes + fix the two broken layouts — **no** modal, no token/spacing reinvention

## Out of scope / guarantees
- No API-client or business-logic changes — admin stays a pure consumer (Principle 1)
- Tokens unchanged; every `data-testid` / `aria-label` preserved

## Verification
- `svelte-check`: 0 errors (1 pre-existing warning, untouched line)
- Prettier: all 8 edited files clean
- Vitest: **1283 passing** (the 4 `admin-static` failures were just the missing SPA build in a fresh checkout — green after `pnpm build`, which also confirms the new Tailwind recipes compile)
- Re-screenshotted every page to confirm consistent inputs, checkboxes, Save placement, and aligned grids

🤖 Generated with [Claude Code](https://claude.com/claude-code)