### PR TITLE
ci: bump checkout/setup-node to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     # are not used. All 9 runners carry these labels.
     runs-on: [self-hosted, Linux, X64, docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -31,7 +31,7 @@ jobs:
   docker:
     runs-on: [self-hosted, Linux, X64, docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build gateway image
         # Inject build info (docs/10) so GET /version reports real values instead
         # of "unknown": app version from package.json, the commit, and a UTC stamp.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Resolve tags + build info
         id: meta
         run: |


### PR DESCRIPTION
Resolves the Node-20 deprecation warning surfaced on recent runs:

> Node.js 20 actions are deprecated … actions/checkout@v4 … forced to Node 24 by default starting June 16th, 2026.

- `actions/checkout` `v4 → v5` (in `ci.yml` ×2 and `publish.yml`)
- `actions/setup-node` `v4 → v5` (in `ci.yml`)

Both v5 majors run on **Node 24**. No behavior change (same inputs). `pnpm/action-setup@v4` was not flagged and is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)