### PR TITLE
fix(admin): silence state_referenced_locally warning in settings page

### DIFF
--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -26,7 +26,7 @@
   // $state initializer doesn't capture the reactive `data` prop reference).
   let form = $state<RuntimeSettings>(untrack(() => ({ ...(data.settings ?? DEFAULTS) })));
 
-  let error = $state<string | null>(data.loadError ?? null);
+  let error = $state<string | null>(untrack(() => data.loadError ?? null));
   let saving = $state(false);
   let saved = $state(false);
 


### PR DESCRIPTION
The settings page had a long-standing `state_referenced_locally` warning (the only `svelte-check` warning left after merging #26/#28/#29/#31).

**Cause**: `let error = $state(data.loadError ?? null)` reads the reactive `data` prop inside a `$state` initializer, which only captures the initial value — exactly the pattern Svelte flags.

**Fix**: wrap the read in `untrack(...)`, mirroring the existing `form` initializer two lines above. The value is intentionally a one-time snapshot.

`svelte-check` now reports **0 errors, 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)