### PR TITLE
feat: Gemini 协议端点 (closes #34)

### DIFF
--- a/apps/gateway/e2e/gemini.spec.ts
+++ b/apps/gateway/e2e/gemini.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "@playwright/test";
+import {
+  CAPTURE_PATH,
+  TOOL_CALL_SENTINEL,
+  type UpstreamCapture,
+} from "./fixtures/mock-upstream.js";
+
+// e2e.gemini — black-box the WHOLE Gemini protocol-translation chain over real
+// HTTP into a real gateway + the deterministic OpenAI-shaped mock upstream (issue
+// #34). The unit tests prove the transformer / route / pipeline in isolation; this
+// proves the seams hold end-to-end across the two high-risk paths docs/05 calls
+// out: snapshot streaming SSE and tool-calls (CLAUDE.md §Testing / docs/05).
+//
+// We assert BOTH sides of the translation:
+//   (a) the client RESPONSE matches the Gemini wire shape (candidates[].content.
+//       parts, finishReason, usageMetadata);
+//   (b) the request the gateway forwarded UPSTREAM is the unified normalized
+//       (OpenAI-Chat IR) shape — read back from the mock's capture endpoint —
+//       proving nativeIn → IR → nativeOut (one hub, not N×N direct), with the
+//       PATH model backfilled (not the transformer's default "gemini").
+//
+// Auth uses x-goog-api-key (Gemini SDK default), NOT Authorization: Bearer.
+
+const TEST_KEY = "helm_live_e2e_testkey";
+const GEMINI_AUTH = { "x-goog-api-key": TEST_KEY, "Content-Type": "application/json" };
+
+const MOCK_BASE_URL = `http://127.0.0.1:${process.env.MOCK_PORT ?? "8181"}`;
+
+async function lastUpstreamRequest(request: {
+  get: (url: string) => Promise<{ json: () => Promise<UpstreamCapture> }>;
+}): Promise<UpstreamCapture> {
+  const res = await request.get(`${MOCK_BASE_URL}${CAPTURE_PATH}`);
+  return res.json();
+}
+
+test.describe("Gemini client → upstream", () => {
+  test("non-stream: generateContent round-trip + normalized upstream request", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: GEMINI_AUTH,
+      data: {
+        contents: [{ role: "user", parts: [{ text: "translate this sentence to french: hello" }] }],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    // (a) client sees the native Gemini shape.
+    expect(Array.isArray(body.candidates)).toBeTruthy();
+    expect(body.candidates[0].content.role).toBe("model");
+    expect(typeof body.candidates[0].content.parts[0].text).toBe("string");
+    expect(body.candidates[0].finishReason).toBe("STOP");
+
+    // (b) upstream got the normalized OpenAI-Chat request with a RESOLVED provider
+    // model (not the path-derived "gemini-2.0-flash" and not the default "gemini").
+    const upstream = await lastUpstreamRequest(request);
+    expect(Array.isArray(upstream.body.messages)).toBeTruthy();
+    expect(typeof upstream.body.model).toBe("string");
+    expect(upstream.body.model).not.toBe("gemini");
+  });
+
+  test("stream: alt=sse emits snapshot data frames with NO event: name and NO [DONE]", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      "/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse",
+      {
+        headers: GEMINI_AUTH,
+        data: {
+          contents: [
+            { role: "user", parts: [{ text: "translate this sentence to french: hola" }] },
+          ],
+        },
+      },
+    );
+    expect(res.ok()).toBeTruthy();
+    expect(res.headers()["content-type"]).toContain("text/event-stream");
+    const text = await res.text();
+    // Gemini wire form: nameless data: frames, NO event: names, NO [DONE].
+    expect(text).toContain("data:");
+    expect(text).not.toContain("event:");
+    expect(text).not.toContain("[DONE]");
+    // never leak a raw OpenAI chunk through the Gemini surface.
+    expect(text).not.toContain("chat.completion.chunk");
+    // each frame is a full snapshot carrying candidates[].
+    expect(text).toContain("candidates");
+    // the terminal snapshot carries the mapped finishReason.
+    expect(text).toContain("STOP");
+  });
+
+  test("tool-call: upstream function call → client sees a functionCall part", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: GEMINI_AUTH,
+      data: {
+        contents: [
+          { role: "user", parts: [{ text: `look up the weather ${TOOL_CALL_SENTINEL}` }] },
+        ],
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "get_weather",
+                description: "get the weather",
+                parameters: { type: "object", properties: { city: { type: "string" } } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    const parts = body.candidates[0].content.parts as Array<{
+      functionCall?: { name: string; args: Record<string, unknown> };
+    }>;
+    const fc = parts.find((p) => p.functionCall)?.functionCall;
+    expect(fc).toBeDefined();
+    expect(fc?.name).toBe("get_weather");
+    // arguments parsed into an object (docs/05 pit #3).
+    expect(typeof fc?.args).toBe("object");
+  });
+});
+
+test.describe("Gemini auth + error envelopes", () => {
+  test("missing key on generateContent is rejected (401 UNAUTHENTICATED envelope)", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: { "Content-Type": "application/json" },
+      data: { contents: [{ role: "user", parts: [{ text: "hi" }] }] },
+    });
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error.status).toBe("UNAUTHENTICATED");
+    expect(body.error.code).toBe(401);
+  });
+
+  test("a non-generateContent operation returns 404 (Gemini NOT_FOUND envelope)", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:countTokens", {
+      headers: GEMINI_AUTH,
+      data: { contents: [{ role: "user", parts: [{ text: "hi" }] }] },
+    });
+    expect(res.status()).toBe(404);
+    const body = await res.json();
+    expect(body.error.status).toBe("NOT_FOUND");
+  });
+
+  test("a structurally invalid body returns 400 INVALID_ARGUMENT", async ({ request }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: GEMINI_AUTH,
+      // contents is required by the Gemini schema; an empty object fails the parse.
+      data: { not: "a gemini request" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+  });
+});

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -192,6 +192,41 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     expect(harness.order).not.toContain("route");
   });
 
+  it("rate-limits after auth with a 429 Gemini envelope and limit headers, without translating or routing", async () => {
+    const { deps, harness } = makeDeps({
+      rateLimiter: {
+        check: async (probe) => {
+          harness.order.push(`rate-limit:${probe.keyId}`);
+          return {
+            allowed: false,
+            limitedBy: "rpm",
+            limit: 60,
+            remaining: 0,
+            resetSeconds: 42,
+            retryAfterSeconds: 12,
+          };
+        },
+      },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("12");
+    expect(res.headers.get("x-ratelimit-limit")).toBe("60");
+    expect(res.headers.get("x-ratelimit-remaining")).toBe("0");
+    expect(res.headers.get("x-ratelimit-reset")).toBe("42");
+    const body = (await res.json()) as { error: { code: number; status: string } };
+    expect(body.error).toMatchObject({ code: 429, status: "RESOURCE_EXHAUSTED" });
+    expect(harness.order).toEqual(["auth:helm_live_secret", "rate-limit:k1"]);
+    expect(harness.pipelineSawIR).toBeNull();
+  });
+
   it("maps a malformed JSON body to 400 INVALID_ARGUMENT, after auth, without routing", async () => {
     const { deps, harness } = makeDeps();
     const app = buildApp(deps);

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../app.js";
+import { type GeminiRouteDeps, registerGeminiRoute } from "./gemini.js";
+import type { MessagesIdentity } from "./messages.js";
+import { PipelineError } from "./messages-pipeline.js";
+
+// POST /v1beta/models/{model}:{generateContent|streamGenerateContent} — Gemini
+// inbound (issue #34). These tests pin the route CONTRACT: auth (x-goog-api-key
+// preferred, Bearer fallback) → translate-out → MODEL BACKFILL → route →
+// translate-back, with all business logic stubbed. The route is PURE HTTP glue
+// (CLAUDE.md principle 1). Streaming snapshots are written as nameless `data:`
+// frames with NO `event:` name and NO [DONE] (Gemini wire form, docs/05).
+
+const GEMINI_AUTH = { "x-goog-api-key": "helm_live_secret", "Content-Type": "application/json" };
+
+const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
+
+const REQ_BODY = { contents: [{ role: "user", parts: [{ text: "hi" }] }] };
+
+// A canned Gemini-native response the stub responseOut produces.
+const GEMINI_RESPONSE = {
+  candidates: [{ content: { role: "model", parts: [{ text: "hello" }] }, finishReason: "STOP" }],
+  usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+};
+
+interface Harness {
+  order: string[];
+  pipelineSawIR: Record<string, unknown> | null;
+  pipelineSawAbort: boolean;
+}
+
+function makeDeps(
+  over: {
+    collect?: () => Promise<unknown>;
+    streamEvents?: () => AsyncIterable<Record<string, unknown>>;
+    authed?: boolean;
+    abort?: boolean;
+    transformRequestOut?: (native: unknown) => unknown;
+    identity?: MessagesIdentity;
+    rateLimiter?: GeminiRouteDeps["rateLimiter"];
+  } = {},
+): { deps: GeminiRouteDeps; harness: Harness } {
+  const harness: Harness = { order: [], pipelineSawIR: null, pipelineSawAbort: false };
+
+  const deps: GeminiRouteDeps = {
+    rateLimiter: over.rateLimiter,
+    auth: {
+      resolve: async (cred) => {
+        harness.order.push(`auth:${cred ?? "null"}`);
+        return over.authed === false ? null : (over.identity ?? IDENTITY);
+      },
+    },
+    transformer: {
+      transformRequestOut: (native) => {
+        harness.order.push("translate-out");
+        if (over.transformRequestOut)
+          return over.transformRequestOut(native) as Record<string, unknown>;
+        // The real transformer defaults model:"gemini"; the route must backfill the
+        // path model. Return that default so the backfill assertion is meaningful.
+        return { model: "gemini", messages: [{ role: "user", content: "hi" }], metadata: {} };
+      },
+      transformResponseOut: (ir) => {
+        harness.order.push("translate-back");
+        return { ...GEMINI_RESPONSE, __ir: ir };
+      },
+      transformErrorOut: (err) => {
+        const status =
+          err.error_class === "auth_error"
+            ? 401
+            : err.error_class === "invalid_request"
+              ? 400
+              : err.error_class === "rate_limited"
+                ? 429
+                : 502;
+        const gstatus =
+          err.error_class === "auth_error"
+            ? "UNAUTHENTICATED"
+            : err.error_class === "invalid_request"
+              ? "INVALID_ARGUMENT"
+              : err.error_class === "rate_limited"
+                ? "RESOURCE_EXHAUSTED"
+                : "UNAVAILABLE";
+        return { status, body: { error: { code: status, message: err.message, status: gstatus } } };
+      },
+    },
+    pipeline: {
+      run: async (ir, _identity, signal) => {
+        harness.order.push("route");
+        harness.pipelineSawIR = ir;
+        if (over.abort === true) {
+          if (signal.aborted) harness.pipelineSawAbort = true;
+          signal.addEventListener("abort", () => {
+            harness.pipelineSawAbort = true;
+          });
+        }
+        return {
+          collect: over.collect ?? (async () => ({ id: "ir-resp" })),
+          streamIR:
+            over.streamEvents ??
+            async function* () {
+              yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+            },
+        };
+      },
+    },
+  };
+  return { deps, harness };
+}
+
+function buildApp(deps: GeminiRouteDeps) {
+  const app = createApp({ logger: { log: () => {} } });
+  registerGeminiRoute(app, deps);
+  return app;
+}
+
+describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
+  it("non-stream: auth → translate-out → route → translate-back, returns Gemini JSON", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      candidates: Array<{ content: { parts: Array<{ text: string }> } }>;
+    };
+    expect(body.candidates[0]?.content.parts[0]?.text).toBe("hello");
+    expect(harness.order).toEqual([
+      "auth:helm_live_secret",
+      "translate-out",
+      "route",
+      "translate-back",
+    ]);
+  });
+
+  it("backfills the path model into the IR the pipeline receives", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    await app.request("/v1beta/models/gemini-1.5-pro:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    // Must NOT leak the transformer's default model:"gemini" to the router.
+    expect(harness.pipelineSawIR?.model).toBe("gemini-1.5-pro");
+  });
+
+  it("prefers x-goog-api-key but falls back to Authorization: Bearer", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: { Authorization: "Bearer bearer_key", "Content-Type": "application/json" },
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(harness.order[0]).toBe("auth:bearer_key");
+  });
+
+  it("rejects a missing/invalid key with a 401 Gemini error and never routes", async () => {
+    const { deps, harness } = makeDeps({ authed: false });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: { "x-goog-api-key": "wrong", "Content-Type": "application/json" },
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("UNAUTHENTICATED");
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("returns 404 for a non-generateContent path (parseGeminiPath null)", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:countTokens", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(404);
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("maps a malformed JSON body to 400 INVALID_ARGUMENT, after auth, without routing", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: "{not valid json",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("maps a structurally invalid body (transformRequestOut throws) to a 400 Gemini error", async () => {
+    const { deps, harness } = makeDeps({
+      transformRequestOut: () => {
+        throw new Error("contents: too_small");
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify({ contents: [] }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("surfaces an all-providers-failed pipeline error as a Gemini envelope (not empty 200)", async () => {
+    const { deps } = makeDeps({
+      collect: async () => {
+        throw new PipelineError("all_providers_failed", "all providers failed", "trace-1");
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("UNAVAILABLE");
+  });
+});
+
+describe("POST /v1beta/models/{model}:streamGenerateContent?alt=sse (Gemini stream)", () => {
+  it("writes nameless data: frames with NO event: name and NO [DONE]", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hel" }] } }] };
+      yield {
+        candidates: [
+          { content: { role: "model", parts: [{ text: "Hello" }] }, finishReason: "STOP" },
+        ],
+        usageMetadata: { candidatesTokenCount: 2 },
+      };
+    }
+    const { deps } = makeDeps({ streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const text = await res.text();
+    expect(text).toContain("data:");
+    expect(text).not.toContain("event:");
+    expect(text).not.toContain("[DONE]");
+    // Each frame is a full snapshot; the final carries finishReason.
+    expect(text).toContain("STOP");
+  });
+
+  it("passes the abort signal to the pipeline and emits NO error frame on client disconnect", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    }
+    const { deps } = makeDeps({ streamEvents: events, abort: true });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    const text = await res.text();
+    // A benign abort must NOT write an error envelope into the stream.
+    expect(text).not.toContain("UNAVAILABLE");
+    expect(text).not.toContain('"error"');
+  });
+
+  it("emits a terminal Gemini error frame when the stream throws (non-abort)", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+      throw new PipelineError("all_providers_failed", "all providers failed", "trace-1");
+    }
+    const { deps } = makeDeps({ streamEvents: events });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    const text = await res.text();
+    expect(text).toContain("error");
+    expect(text).toContain("UNAVAILABLE");
+  });
+});

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -1,0 +1,270 @@
+import {
+  type GeminiRoute,
+  parseGeminiPath,
+  type RateLimitProbe,
+  type RateLimitResult,
+} from "@helm/core";
+import type { Context, Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import type { AppEnv } from "../app.js";
+import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
+import { resolveMemoryScope } from "./memory-scope.js";
+import type { MessagesIdentity, PipelineRunResult, RouteError } from "./messages.js";
+import { PipelineError } from "./messages-pipeline.js";
+
+// POST /v1beta/models/{model}:generateContent / :streamGenerateContent — Google
+// Gemini inbound, translated to IR, routed through the SAME core pipeline as
+// /v1/chat and /v1/messages, then translated back to the native Gemini wire shape
+// (docs/05, issue #34). The FOURTH client-presentation surface.
+//
+// PURE HTTP ↔ IR glue (CLAUDE.md principle 1): auth → translate(out) → route →
+// translate(back). No classify/route/translate logic lives here; each business
+// step is an injected dependency. Wiring order is the docs/02 contract: auth →
+// translate(out) → route → translate(back).
+//
+// Gemini diverges from the other surfaces in three HTTP-level ways the route owns:
+//   • the model + operation are in the PATH (`{model}:{op}`), parsed by the core
+//     pure function `parseGeminiPath` (core never reads a Hono object, principle 1);
+//   • auth is `x-goog-api-key` (NOT Authorization: Bearer; Bearer is a fallback);
+//   • streaming events are FULL-SNAPSHOT `data:` frames with NO `event:` name and
+//     NO `[DONE]` sentinel (docs/05 — Gemini's wire form differs from OpenAI /
+//     Anthropic SSE).
+
+/** One Gemini error envelope plus the HTTP status to send it with. Error
+ *  translation is protocol logic (docs/05) — injected, never hand-assembled. */
+export interface GeminiErrorOut {
+  status: number;
+  body: unknown;
+}
+
+/** Per-key rate limiter (core, framework-agnostic). Same instance the OpenAI chat
+ *  middleware uses; injected so the self-authenticating Gemini route meters the
+ *  resolved key AFTER auth. Optional — omitted = no metering. */
+export interface GeminiRateLimiterPort {
+  check(probe: RateLimitProbe): Promise<RateLimitResult>;
+}
+
+// The route treats the IR as an opaque bag with the fields it must read/stamp.
+interface GeminiIRLike {
+  stream?: boolean;
+  model?: unknown;
+  metadata?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+export interface GeminiRouteDeps {
+  rateLimiter?: GeminiRateLimiterPort;
+  auth: {
+    /** Resolve the request credential to an identity, or null when invalid. */
+    resolve(credential: string | null): Promise<MessagesIdentity | null>;
+  };
+  transformer: {
+    /** Native Gemini request → IR (throws on a structurally invalid body). */
+    transformRequestOut(native: unknown): GeminiIRLike;
+    /** IR response → native Gemini response. */
+    transformResponseOut(ir: unknown): unknown;
+    /** Structured internal error → Gemini error envelope + status. */
+    transformErrorOut(err: RouteError): GeminiErrorOut;
+  };
+  pipeline: {
+    run(
+      ir: GeminiIRLike,
+      identity: MessagesIdentity,
+      signal: AbortSignal,
+    ): Promise<PipelineRunResult>;
+  };
+}
+
+// Extract the plaintext credential from x-goog-api-key (Gemini SDK default) or the
+// Authorization: Bearer header (friendlier for own clients). Case-sensitive: never
+// trim/lowercase a key.
+function extractCredential(googKey: string | undefined, auth: string | undefined): string | null {
+  if (googKey) return googKey;
+  if (auth) {
+    const m = /^Bearer\s+(.+)$/.exec(auth);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
+// Client disconnect / abort detection — mirrors messages.ts. Used to suppress a
+// terminal error frame for a benign disconnect (NOT a provider fault, docs/02).
+function isAbort(err: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return true;
+  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
+}
+
+export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): void {
+  const { transformer } = deps;
+
+  const sendError = (c: Context<AppEnv>, err: RouteError): Response => {
+    const out = transformer.transformErrorOut(err);
+    return c.json(out.body as Record<string, unknown>, out.status as 400 | 401 | 404 | 429 | 502);
+  };
+
+  // Hono cannot match the literal ':' in `{model}:generateContent` with a named
+  // param, so we mount a catch-all under /v1beta/models and hand the full path +
+  // query to the core `parseGeminiPath`. A non-Gemini path → null → 404 (never a
+  // silent 200 on a mis-routed /v1beta/* request).
+  app.post("/v1beta/models/:rest{.+}", async (c) => {
+    const traceId = c.get("trace_id");
+
+    // 0) Route parse FIRST (cheap, pure). The pathname is the part before '?'; the
+    //    query carries `alt=sse`. parseGeminiPath returns null for any path that is
+    //    not :generateContent / :streamGenerateContent → 404.
+    const url = new URL(c.req.url);
+    const route: GeminiRoute | null = parseGeminiPath(url.pathname, url.search.replace(/^\?/, ""));
+    if (route === null) {
+      // A /v1beta/models/* path that is NOT :generateContent / :streamGenerateContent
+      // (e.g. :countTokens, :embedContent) is an endpoint Helm does not serve → 404
+      // in the Gemini error wire shape. Never a silent 200 on a mis-routed path.
+      // NOT_FOUND is not one of the 8 routing ErrorClasses (it is an HTTP-routing
+      // concern, not a routing-pipeline failure), so it is assembled here directly.
+      return c.json(
+        {
+          error: {
+            code: 404,
+            message: "not a Gemini generateContent endpoint",
+            status: "NOT_FOUND",
+          },
+        },
+        404,
+      );
+    }
+
+    // 1) Auth (docs/02 pipeline order). x-goog-api-key preferred, Bearer fallback.
+    const credential = extractCredential(
+      c.req.header("x-goog-api-key"),
+      c.req.header("Authorization"),
+    );
+    const identity = await deps.auth.resolve(credential);
+    if (identity === null) {
+      return sendError(c, {
+        error_class: "auth_error",
+        message: "missing or invalid API key",
+        trace_id: traceId,
+      });
+    }
+
+    // 1b) Rate limit AFTER auth (needs the resolved key_id), BEFORE translate/route.
+    if (deps.rateLimiter !== undefined) {
+      const rl = await deps.rateLimiter.check({
+        keyId: identity.keyId,
+        estimatedTokens: estimateRequestTokens(c),
+        now: Date.now(),
+        override: identity.caps?.rateLimit
+          ? { rpm: identity.caps.rateLimit.rpm, tpm: identity.caps.rateLimit.tpm }
+          : undefined,
+      });
+      if (!(rl.allowed && rl.limit === 0)) {
+        c.header("x-ratelimit-limit", String(rl.limit));
+        c.header("x-ratelimit-remaining", String(rl.remaining));
+        c.header("x-ratelimit-reset", String(rl.resetSeconds));
+        if (!rl.allowed) {
+          c.header("retry-after", String(rl.retryAfterSeconds));
+          return sendError(c, {
+            error_class: "rate_limited",
+            message: `rate limit exceeded (${rl.limitedBy})`,
+            trace_id: traceId,
+          });
+        }
+      }
+    }
+
+    // 2) Parse + translate inbound. A malformed JSON body OR a structurally invalid
+    //    Gemini request (the transformer's Zod parse throws) is a CLIENT error →
+    //    400 INVALID_ARGUMENT, before routing (docs/07, principle 2 fail-closed).
+    let native: unknown;
+    try {
+      native = await c.req.json();
+    } catch {
+      return sendError(c, {
+        error_class: "invalid_request",
+        message: "malformed JSON request body",
+        trace_id: traceId,
+      });
+    }
+    let ir: GeminiIRLike;
+    try {
+      ir = transformer.transformRequestOut(native);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : "invalid Gemini request";
+      return sendError(c, { error_class: "invalid_request", message: detail, trace_id: traceId });
+    }
+
+    // 2b) Backfill the PATH model + the parsed stream flag onto the IR. The
+    //     transformer defaults model:"gemini" (the path-derived model is supplied
+    //     by the route layer — see gemini-transformer.ts). Without this the router
+    //     would always receive "gemini" and routing would degrade.
+    ir.model = route.model;
+    ir.stream = route.stream;
+    ir.metadata = { ...(ir.metadata ?? {}), trace_id: traceId };
+
+    // Memory scope (docs/08 Phase 1): parse the four memory headers and stamp them
+    // onto the IR metadata bag (mirrors /v1/messages) so the SHARED pipeline's
+    // observe phase reads the scope off ir.metadata without touching HTTP.
+    const memoryScope = resolveMemoryScope((name) => c.req.header(name));
+    ir.metadata.thread_id = memoryScope.threadId;
+    ir.metadata.resource_id = memoryScope.resourceId;
+    ir.metadata.project_id = memoryScope.projectId;
+    ir.metadata.memory_mode = memoryScope.mode;
+
+    // 3) Route through the shared core. The per-request abort signal rides along so
+    //    a client disconnect is a non-provider fault (docs/02). run() throws a
+    //    PipelineError(invalid_request) for an empty request.
+    let result: PipelineRunResult;
+    try {
+      result = await deps.pipeline.run(ir, identity, c.req.raw.signal);
+    } catch (err) {
+      if (err instanceof PipelineError) {
+        return sendError(c, {
+          error_class: err.error_class,
+          message: err.message,
+          trace_id: traceId,
+        });
+      }
+      throw err;
+    }
+
+    // 4) Protocol Adapter (outbound). Gemini streaming events are FULL snapshots,
+    //    written as nameless `data:` frames — NO `event:` name, NO `[DONE]`.
+    if (route.stream) {
+      return streamSSE(c, async (sse) => {
+        try {
+          for await (const snapshot of result.streamIR()) {
+            await sse.writeSSE({ data: JSON.stringify(snapshot) });
+          }
+        } catch (err) {
+          // A client disconnect / abort is a benign non-provider fault (docs/02):
+          // emit NO error frame. Any other throw emits ONE terminal Gemini error
+          // frame so the client never sees a silently truncated stream.
+          if (!isAbort(err, c.req.raw.signal)) {
+            const re: RouteError =
+              err instanceof PipelineError
+                ? { error_class: err.error_class, message: err.message, trace_id: traceId }
+                : { error_class: "upstream_error", message: "upstream error", trace_id: traceId };
+            const out = transformer.transformErrorOut(re);
+            await sse.writeSSE({ data: JSON.stringify(out.body) });
+          }
+        }
+      });
+    }
+
+    // Non-stream: collect() throws a PipelineError when routing failed (all
+    // providers failed) — surface it as the Gemini envelope, never an empty 200.
+    let body: unknown;
+    try {
+      body = transformer.transformResponseOut(await result.collect());
+    } catch (err) {
+      if (err instanceof PipelineError) {
+        return sendError(c, {
+          error_class: err.error_class,
+          message: err.message,
+          trace_id: traceId,
+        });
+      }
+      throw err;
+    }
+    return c.json(body as Record<string, unknown>);
+  });
+}

--- a/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
@@ -1,0 +1,101 @@
+import type { ExecutionResult } from "@helm/core";
+import { describe, expect, it } from "vitest";
+import type { MessagesIdentity } from "./messages.js";
+import { createMessagesPipeline, type RouteFn } from "./messages-pipeline.js";
+
+// messages-pipeline (gemini branch) — issue #34 step 3. When the pipeline is
+// stamped with the `gemini` protocol, streamIR() must map the upstream OpenAI SSE
+// chunks into GEMINI snapshot events (via geminiTransformer.transformStreamOut),
+// NOT Anthropic events. Each snapshot is a FULL response (text accumulates frame to
+// frame); the terminal snapshot carries finishReason + usageMetadata exactly once;
+// there is no `event:` name and no `[DONE]` sentinel (those are the route's job —
+// here we only assert the produced snapshot objects). CLAUDE.md principle 8.
+
+const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
+
+function irOf(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    model: "gemini-2.0-flash",
+    messages: [{ role: "user", content: "hi" }],
+    stream: true,
+    metadata: { trace_id: "trace-g" },
+    ...over,
+  };
+}
+
+// Raw OpenAI SSE text the mock upstream / executor yields. Text fragments then a
+// terminal usage+finish frame and the [DONE] sentinel — the same wire the
+// Anthropic pipeline consumes.
+async function* openAISSE(frames: string[]): AsyncIterable<string> {
+  for (const f of frames) yield f;
+}
+
+function streamResult(stream: AsyncIterable<string>): ExecutionResult {
+  return {
+    decision: { lane: { selected_lane: "balanced" } } as unknown as ExecutionResult["decision"],
+    final: { status: "ok", alias: "x" } as unknown as ExecutionResult["final"],
+    body: null,
+    stream,
+    error: null,
+  };
+}
+
+describe("createMessagesPipeline (gemini) — streamIR yields Gemini snapshots", () => {
+  it("accumulates text across snapshots and ends with finishReason + usageMetadata", async () => {
+    const frames = [
+      'data: {"id":"c","choices":[{"delta":{"role":"assistant"}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"content":"Hel"}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const route: RouteFn = async () => streamResult(openAISSE(frames));
+    const pipeline = createMessagesPipeline(route, "gemini");
+    const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const ev of run.streamIR()) events.push(ev as Record<string, unknown>);
+
+    expect(events.length).toBeGreaterThan(0);
+    // Each event is a full snapshot; the LAST carries the complete accumulated text.
+    const last = events[events.length - 1] as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> }; finishReason?: string }>;
+      usageMetadata?: { candidatesTokenCount?: number };
+    };
+    const text = (last.candidates?.[0]?.content?.parts ?? []).map((p) => p.text ?? "").join("");
+    expect(text).toBe("Hello");
+    expect(last.candidates?.[0]?.finishReason).toBe("STOP");
+    expect(last.usageMetadata?.candidatesTokenCount).toBe(2);
+
+    // No Anthropic event names leaked through the Gemini surface.
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain("message_start");
+    expect(serialized).not.toContain("content_block_delta");
+  });
+
+  it("emits a functionCall part accumulated across fragmented tool-call chunks", async () => {
+    const frames = [
+      'data: {"id":"c","choices":[{"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_0","type":"function","function":{"name":"get_weather"}}]}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"ci"}}]}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ty\\":\\"SF\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const route: RouteFn = async () => streamResult(openAISSE(frames));
+    const pipeline = createMessagesPipeline(route, "gemini");
+    const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const ev of run.streamIR()) events.push(ev as Record<string, unknown>);
+
+    const last = events[events.length - 1] as {
+      candidates?: Array<{
+        content?: { parts?: Array<{ functionCall?: { name: string; args: unknown } }> };
+        finishReason?: string;
+      }>;
+    };
+    const fc = (last.candidates?.[0]?.content?.parts ?? []).find(
+      (p) => p.functionCall,
+    )?.functionCall;
+    expect(fc?.name).toBe("get_weather");
+    expect(fc?.args).toEqual({ city: "SF" });
+  });
+});

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -2,6 +2,8 @@ import {
   type AnthropicSSEEvent,
   convertOpenAIStreamToAnthropic,
   type ExecutionResult,
+  geminiTransformer,
+  type IRChunk,
   type IRMessage,
   type IRResponse,
   type MemoryScope,
@@ -345,13 +347,13 @@ export function createMessagesPipeline(
           }
           return irResponse;
         },
-        async *streamIR(): AsyncIterable<{ type: string; [k: string]: unknown }> {
+        async *streamIR(): AsyncIterable<Record<string, unknown>> {
           // Surface a routing failure BEFORE any event is emitted, so the route
           // can write a terminal error frame instead of an empty (silent) stream.
           if (failure !== null) throw failure;
           if (result.stream === null) return;
           // Accumulate the assistant text from the OpenAI-side chunks (one
-          // accumulator serves BOTH protocols) WITHOUT buffering or altering the
+          // accumulator serves ALL protocols) WITHOUT buffering or altering the
           // events forwarded downstream (principle 8). observeOutbound runs in a
           // finally so a client disconnect mid-stream still records what arrived.
           const assistant = { text: "" };
@@ -366,8 +368,25 @@ export function createMessagesPipeline(
                   }
                 })();
           try {
-            for await (const ev of convertOpenAIStreamToAnthropic(source as AsyncIterable<never>)) {
-              yield ev as AnthropicSSEEvent & { type: string };
+            // Outbound stream mapping is chosen by the pipeline's stamped protocol
+            // (principle 5: surfaces never conflate). Gemini consumes the SAME
+            // OpenAI-shaped chunks parseOpenAISSE produces (its IRChunk IS the
+            // OpenAI chat.completion.chunk), so we feed them straight into the
+            // Gemini snapshot state machine — no Anthropic adapter (docs/05). Each
+            // yielded object is a full GenerateContentResponse snapshot (no `type`);
+            // the route writes it as a nameless `data:` SSE frame with no [DONE].
+            if (protocol === "gemini") {
+              for await (const snapshot of geminiTransformer.transformStreamOut(
+                source as AsyncIterable<IRChunk>,
+              )) {
+                yield snapshot as Record<string, unknown>;
+              }
+            } else {
+              for await (const ev of convertOpenAIStreamToAnthropic(
+                source as AsyncIterable<never>,
+              )) {
+                yield ev as AnthropicSSEEvent & { type: string };
+              }
             }
           } finally {
             if (memory !== undefined && assistant.text.length > 0) {

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -62,8 +62,10 @@ export interface RouteError {
 export interface PipelineRunResult {
   /** Drain the full (non-stream) result into ONE IR response object. */
   collect(): Promise<unknown>;
-  /** The IR-level event stream (one object per Anthropic SSE event source). */
-  streamIR(): AsyncIterable<{ type: string; [k: string]: unknown }>;
+  /** The outbound-protocol event stream: one object per wire event. For Anthropic
+   *  each carries a `type` (the SSE event name); for Gemini each is a full snapshot
+   *  GenerateContentResponse (no `type`). The route serializes them per protocol. */
+  streamIR(): AsyncIterable<Record<string, unknown>>;
 }
 
 /** Per-key rate limiter (core, framework-agnostic). Same instance the OpenAI
@@ -90,7 +92,7 @@ export interface MessagesRouteDeps {
       /** IR response → native Anthropic response (outbound Protocol Adapter). */
       transformResponseOut(ir: unknown): unknown | Promise<unknown>;
       /** ONE IR stream event → ONE Anthropic SSE frame (state-machine mapped). */
-      transformStreamOut(event: { type: string; [k: string]: unknown }): AnthropicSSEFrame;
+      transformStreamOut(event: Record<string, unknown>): AnthropicSSEFrame;
       /** Structured internal error → Anthropic error envelope + status. */
       transformErrorOut(err: RouteError): AnthropicErrorOut;
     };

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -12,6 +12,8 @@ import {
   createSignalCollector,
   createStore,
   DEFAULT_LANES,
+  type GeminiGenerateContentResponse,
+  geminiTransformer,
   generateKey,
   hashKey,
   type IRResponse,
@@ -21,6 +23,7 @@ import {
   loadRuntimeCatalog,
   loadRuntimeSettings,
   makeAnthropicError,
+  makeGeminiError,
   type ObserveDeps,
   type PoliciesConfig,
   type ProviderClient,
@@ -59,6 +62,7 @@ import { ADMIN_BUILD_ROOT, mountAdminStatic } from "./routes/admin-static.js";
 import { registerChatRoutes } from "./routes/chat.js";
 import { buildClassifyAdapter } from "./routes/classify.js";
 import { createExecute } from "./routes/execute.js";
+import { registerGeminiRoute } from "./routes/gemini.js";
 import type { MessagesIdentity, RouteError } from "./routes/messages.js";
 import { registerMessagesRoute } from "./routes/messages.js";
 import { createMessagesPipeline } from "./routes/messages-pipeline.js";
@@ -657,6 +661,55 @@ export async function buildServer(
     },
     pipeline: responsesPipeline,
   } as Parameters<typeof registerResponsesRoute>[1] & { rateLimiter: RateLimiterPort });
+
+  // Gemini route (/v1beta/models/{model}:generateContent | :streamGenerateContent).
+  // The FOURTH client surface. Reuses the SAME routing core via a pipeline stamped
+  // with the `gemini` protocol (so streamIR yields Gemini snapshot events), and the
+  // Gemini transformer for IR↔native translation + the Gemini error envelope. Self-
+  // auth (x-goog-api-key preferred, Bearer fallback) so a missing key is rejected as
+  // a Gemini error envelope (docs/05, docs/07).
+  const geminiPipeline = createMessagesPipeline(route, "gemini", { observe });
+  registerGeminiRoute(app, {
+    rateLimiter,
+    auth: {
+      resolve: async (credential): Promise<MessagesIdentity | null> => {
+        if (credential === null) return null;
+        const record = await keyStore.getByHash(hashKey(credential));
+        if (record === null || record.disabled) return null;
+        return {
+          keyId: record.key_id,
+          keyPrefix: record.prefix,
+          accountId: record.account_id,
+          orgId: null,
+          userId: null,
+          role: record.role,
+          caps: {
+            maxLane: record.max_lane,
+            allowedLanes: record.allowed_lanes,
+            allowCustomModel: record.allow_custom_model,
+            rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
+          },
+        };
+      },
+    },
+    transformer: {
+      transformRequestOut: (native) => geminiTransformer.transformRequestOut(native),
+      transformResponseOut: (ir) =>
+        geminiTransformer.transformResponseOut(ir as IRResponse) as GeminiGenerateContentResponse,
+      transformErrorOut: (err: RouteError) =>
+        makeGeminiError({
+          // Pass the precise error_class straight through; makeGeminiError maps all
+          // 8 ErrorClass values to the right status + Google canonical status. A
+          // RouteError.error_class is a plain string, so validate it against the
+          // schema; an unrecognized value falls back to upstream_error (502) rather
+          // than throwing (fail-open, principle 3).
+          error_class: coerceErrorClass(err.error_class),
+          message: err.message,
+          trace_id: err.trace_id,
+        }),
+    },
+    pipeline: geminiPipeline,
+  } as Parameters<typeof registerGeminiRoute>[1] & { rateLimiter: RateLimiterPort });
 
   // Start the Agentic Signals background scheduler — the OFF-the-request-path
   // trigger. It periodically asks the collector to aggregate the just-elapsed

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,28 @@
 
 ---
 
+## 2026-06-01 · Gemini protocol endpoint (`/v1beta/models/{model}:generateContent`) (docs/05, issue #34)
+
+**Context**: the `geminiTransformer` (the 4th protocol) was fully implemented + unit-tested in core but never **exported** from `@helm/core` and never **routed**. Gemini clients literally could not reach the gateway. This wires the existing translation pipeline into a real inbound surface.
+
+**What was added**:
+- `packages/core/src/protocol/gemini/error.ts` — `makeGeminiError` / `transformErrorOut`: the 8 `ErrorClass` values → the native Gemini envelope `{ error: { code, message, status } }` (`code` = HTTP status, `status` = Google's canonical enum: `UNAUTHENTICATED` / `INVALID_ARGUMENT` / `RESOURCE_EXHAUSTED` / `UNAVAILABLE` / `DEADLINE_EXCEEDED`). Mirrors `anthropic/error.ts`; HTTP status comes from the shared table via `makeHelmError` so status and `code` cannot drift.
+- `packages/core/src/index.ts` — exported `geminiTransformer`, `parseGeminiPath`, `GEMINI_ENDPOINT`, `GEMINI_API_KEY_HEADER`, `GeminiRoute`, the wire schemas/types, `IRChunk`, and `makeGeminiError` (+ `geminiTransformErrorOut`).
+- `apps/gateway/src/routes/gemini.ts` — `registerGeminiRoute`: thin HTTP↔IR glue mirroring `messages.ts`.
+- `apps/gateway/src/routes/messages-pipeline.ts` — `streamIR()` now branches on the stamped `protocol`: `gemini` feeds `parseOpenAISSE(result.stream)` straight into `geminiTransformer.transformStreamOut` (its `IRChunk` **is** the OpenAI chat.completion.chunk, so no Anthropic adapter is needed), everything else keeps `convertOpenAIStreamToAnthropic`.
+- `apps/gateway/src/server.ts` — wires a `gemini`-stamped pipeline + the route (auth resolver, rate limiter, error envelope).
+
+**Decisions / trade-offs**:
+- **Hono can't match the literal `:` in `{model}:generateContent`** with a named param, so the route is a single catch-all `app.post("/v1beta/models/:rest{.+}")` that hands the full `URL.pathname` + query to the core pure function `parseGeminiPath`. `null` → a **404** Gemini envelope (`status: "NOT_FOUND"`) — never a silent 200 on a mis-routed `/v1beta/*` path. `NOT_FOUND` is deliberately **not** one of the 8 routing `ErrorClass`es (it is an HTTP-routing concern), so that one body is assembled inline.
+- **Gemini SSE has no `event:` names and no `[DONE]`** (unlike OpenAI/Anthropic): each event is a **full response snapshot**. The route writes `sse.writeSSE({ data: JSON.stringify(snapshot) })` only — guarded by a stream e2e + unit test (CLAUDE.md principle 8).
+- **Auth header is `x-goog-api-key`** (Gemini SDK default), with `Authorization: Bearer` as a fallback for own clients (decision #9 in the issue).
+- **Model backfill**: `transformRequestOut` defaults `model:"gemini"` (the path model is the route layer's job). The route writes `ir.model = route.model` + `ir.stream = route.stream` before routing, or the router would always see `"gemini"` and degrade. Guarded by a dedicated test.
+- **`PipelineRunResult.streamIR()` return type widened** from `AsyncIterable<{ type: string; … }>` to `AsyncIterable<Record<string, unknown>>` — Gemini snapshots have no `type` field; the Anthropic route still reads `.type` off each object at runtime (it already casts).
+
+**Worktree note (重要)**: the e2e launcher resolves `@helm/core` via the package `exports` **`default` → `dist/index.js`** condition (tsx does not apply the `development` condition), so after changing core exports you MUST `pnpm --filter @helm/shared build && pnpm --filter @helm/core build` before `pnpm test:e2e`, or the gateway boots against a stale `dist` and throws `does not provide an export named 'geminiTransformer'`.
+
+---
+
 ## 2026-06-01 · Pagination + error/role filters for the admin requests list (docs/07, Principle 1)
 
 **Context**: `/admin/requests` fetched a hardcoded `queryRecent(100)` and rendered all rows at once; the UI had dead cursor/"Load more" plumbing that never fired. No way to page past 100 requests or isolate errors / a time window — unusable for real debugging. Added numbered pagination (time DESC) plus Date-range / Status / Decided-by / Lane / Model filters, all applied at the SQL layer so totals stay correct.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -208,6 +208,32 @@ export {
   transformRequestOut as anthropicTransformRequestOut,
   transformResponseIn as anthropicTransformResponseIn,
 } from "./protocol/anthropic/index.js";
+// Gemini generateContent transformer — the FOURTH client-presentation surface
+// (docs/05). Inbound native->IR, outbound IR->native (+ snapshot stream state
+// machines + error translation + the framework-agnostic path parser the gateway
+// turns into routes). Reimplemented from the public Gemini docs, NOT copied from a
+// vendor SDK.
+export {
+  type GeminiErrorEnvelope,
+  makeGeminiError,
+  transformErrorOut as geminiTransformErrorOut,
+} from "./protocol/gemini/error.js";
+export {
+  GEMINI_API_KEY_HEADER,
+  GEMINI_ENDPOINT,
+  type GeminiRoute,
+  geminiTransformer,
+  parseGeminiPath,
+} from "./protocol/gemini/gemini-transformer.js";
+export {
+  type GeminiGenerateContentRequest,
+  GeminiGenerateContentRequestSchema,
+  type GeminiGenerateContentResponse,
+  GeminiGenerateContentResponseSchema,
+  type GeminiSSEEvent,
+  GeminiSSEEventSchema,
+  type IRChunk,
+} from "./protocol/gemini/gemini-types.js";
 // Protocol IR — the single central representation (docs/05). All translation
 // goes nativeIn -> IR -> nativeOut. Types are z.infer of these schemas.
 export {

--- a/packages/core/src/protocol/gemini/error.test.ts
+++ b/packages/core/src/protocol/gemini/error.test.ts
@@ -1,0 +1,56 @@
+import type { ErrorClass } from "@helm/shared";
+import { describe, expect, it } from "vitest";
+import { makeGeminiError, transformErrorOut } from "./error.js";
+
+// Gemini error envelope (docs/05 §errors are translated into the client protocol's
+// shape, docs/07). The native Gemini error wire form is
+//   { "error": { "code": <http_status>, "message": <text>, "status": <ENUM> } }
+// `code` is the HTTP status integer and `status` is Google's canonical-error enum
+// string. We map all 8 Helm ErrorClass values to the correct (code, status) pair.
+
+// Expected (error_class -> [http code, google status]) per docs/07 + Google's
+// canonical error codes (https://cloud.google.com/apis/design/errors).
+const EXPECTED: ReadonlyArray<readonly [ErrorClass, number, string]> = [
+  ["auth_error", 401, "UNAUTHENTICATED"],
+  ["invalid_request", 400, "INVALID_ARGUMENT"],
+  ["lane_unavailable", 503, "UNAVAILABLE"],
+  ["all_providers_failed", 502, "UNAVAILABLE"],
+  ["capability_unsatisfiable", 422, "INVALID_ARGUMENT"],
+  ["upstream_error", 502, "UNAVAILABLE"],
+  ["timeout", 504, "DEADLINE_EXCEEDED"],
+  ["rate_limited", 429, "RESOURCE_EXHAUSTED"],
+];
+
+describe("makeGeminiError (ErrorClass -> Gemini envelope)", () => {
+  it.each(EXPECTED)("maps %s -> code %i / status %s", (cls, code, status) => {
+    const out = makeGeminiError({ error_class: cls, message: "boom", trace_id: "t1" });
+    expect(out.status).toBe(code);
+    expect(out.body.error.code).toBe(code);
+    expect(out.body.error.status).toBe(status);
+    expect(out.body.error.message).toBe("boom");
+  });
+
+  it("preserves the human-readable message verbatim", () => {
+    const out = makeGeminiError({
+      error_class: "invalid_request",
+      message: "contents must be a non-empty array",
+      trace_id: "t9",
+    });
+    expect(out.body.error.message).toBe("contents must be a non-empty array");
+  });
+});
+
+describe("transformErrorOut (HelmError -> Gemini envelope)", () => {
+  it("re-shapes a pre-built HelmError without changing the status", () => {
+    const out = transformErrorOut({
+      error_class: "rate_limited",
+      http_status: 429,
+      message: "slow down",
+      trace_id: "t1",
+      provider_raw: null,
+    });
+    expect(out.status).toBe(429);
+    expect(out.body.error.status).toBe("RESOURCE_EXHAUSTED");
+    expect(out.body.error.code).toBe(429);
+  });
+});

--- a/packages/core/src/protocol/gemini/error.ts
+++ b/packages/core/src/protocol/gemini/error.ts
@@ -1,0 +1,68 @@
+import { type ErrorClass, type HelmError, makeHelmError } from "@helm/shared";
+
+// HelmError -> native Gemini error shape (docs/05 §errors are also translated into
+// the client protocol's shape, docs/07). The outbound error half of the Gemini
+// Protocol Adapter: a structured internal error becomes the wire envelope the
+// Gemini SDK / REST client expects
+//
+//   { "error": { "code": <http_status>, "message": <text>, "status": <ENUM> } }
+//
+// `code` is the HTTP status integer; `status` is Google's canonical error enum
+// (https://cloud.google.com/apis/design/errors). Pure function: zero network, zero
+// framework (CLAUDE.md principle 1). The gateway NEVER hand-assembles an error — it
+// hands a HelmError here and serializes the result. HTTP status comes from the
+// shared ERROR_CLASS_HTTP_STATUS table (via makeHelmError) so the status and the
+// body's `code` cannot drift. Reimplemented from the public Gemini docs.
+
+// —— error_class -> Google canonical status enum. Google's set is narrower than
+// Helm's 8 classes, so several map onto the same canonical status while the precise
+// Helm class survives in the response trace_id / telemetry. Exhaustive over
+// ErrorClass (compile error if a class is added). ——————————————————————————————————
+const GEMINI_ERROR_STATUS: Record<ErrorClass, string> = {
+  auth_error: "UNAUTHENTICATED",
+  invalid_request: "INVALID_ARGUMENT",
+  lane_unavailable: "UNAVAILABLE",
+  all_providers_failed: "UNAVAILABLE",
+  capability_unsatisfiable: "INVALID_ARGUMENT",
+  upstream_error: "UNAVAILABLE",
+  timeout: "DEADLINE_EXCEEDED",
+  rate_limited: "RESOURCE_EXHAUSTED",
+};
+
+export interface GeminiErrorEnvelope {
+  error: { code: number; message: string; status: string };
+}
+
+/**
+ * Translate a HelmError into the native Gemini error envelope plus its HTTP status.
+ * Pure. The message is assumed already-redacted by the producer (principle 7); this
+ * function only re-shapes, never inspects payload.
+ */
+export function transformErrorOut(err: HelmError): {
+  status: number;
+  body: GeminiErrorEnvelope;
+} {
+  return {
+    status: err.http_status,
+    body: {
+      error: {
+        code: err.http_status,
+        message: err.message,
+        status: GEMINI_ERROR_STATUS[err.error_class],
+      },
+    },
+  };
+}
+
+/**
+ * Convenience: build a HelmError and translate it in one step. Used by the gateway's
+ * auth / short-circuit / streaming-termination paths that have only a class +
+ * message + trace_id.
+ */
+export function makeGeminiError(args: {
+  error_class: ErrorClass;
+  message: string;
+  trace_id: string;
+}): { status: number; body: GeminiErrorEnvelope } {
+  return transformErrorOut(makeHelmError(args));
+}

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -362,6 +362,28 @@ describe("transformStreamOut (IR chunks -> Gemini SSE events)", () => {
     expect(last?.candidates?.[0]?.finishReason).toBe("STOP");
   });
 
+  it("maps streaming usageMetadata with totalTokenCount and cachedContentTokenCount", async () => {
+    const chunks: IRChunk[] = [
+      { id: "c", model: "m", choices: [{ index: 0, delta: { role: "assistant" } }] },
+      {
+        id: "c",
+        model: "m",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 7, completion_tokens: 5, cached_tokens: 3 },
+      },
+    ];
+
+    const events = await collect(geminiTransformer.transformStreamOut(fromArray(chunks)));
+    const last = events[events.length - 1];
+
+    expect(last?.usageMetadata).toEqual({
+      promptTokenCount: 10,
+      candidatesTokenCount: 5,
+      totalTokenCount: 15,
+      cachedContentTokenCount: 3,
+    });
+  });
+
   // test #4: outbound streaming must surface tool calls as functionCall parts.
   it("emits a functionCall part in the cumulative snapshot from streamed tool_calls", async () => {
     const chunks: IRChunk[] = [

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -623,14 +623,7 @@ async function* transformStreamOut(src: AsyncIterable<IRChunk>): AsyncIterable<G
       candidates: [candidate],
       ...(chunk.usage != null
         ? {
-            usageMetadata: {
-              ...(chunk.usage.prompt_tokens !== undefined
-                ? { promptTokenCount: chunk.usage.prompt_tokens }
-                : {}),
-              ...(chunk.usage.completion_tokens !== undefined
-                ? { candidatesTokenCount: chunk.usage.completion_tokens }
-                : {}),
-            },
+            usageMetadata: irUsageToMetadata(chunk.usage),
           }
         : {}),
     };

--- a/packages/core/src/protocol/gemini/index-export.test.ts
+++ b/packages/core/src/protocol/gemini/index-export.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import * as core from "../../index.js";
+
+// Guards the wiring contract issue #34 step 1 requires: the Gemini transformer +
+// its routing/error/type surface must be reachable from the @helm/core barrel, or
+// the gateway can never mount a Gemini endpoint. Before this change `grep gemini
+// index.ts` was zero hits.
+describe("@helm/core barrel exports the Gemini surface", () => {
+  it("exposes the transformer with the 5-member contract + name/endPoint", () => {
+    expect(core.geminiTransformer.name).toBe("gemini");
+    expect(core.geminiTransformer.endPoint).toBe(core.GEMINI_ENDPOINT);
+    for (const m of [
+      "transformRequestOut",
+      "transformResponseOut",
+      "transformRequestIn",
+      "transformResponseIn",
+    ] as const) {
+      expect(typeof core.geminiTransformer[m]).toBe("function");
+    }
+    expect(typeof core.geminiTransformer.transformStreamOut).toBe("function");
+    expect(typeof core.geminiTransformer.transformStreamIn).toBe("function");
+  });
+
+  it("exposes the path parser + auth header constant", () => {
+    expect(core.GEMINI_API_KEY_HEADER).toBe("x-goog-api-key");
+    const parsed = core.parseGeminiPath("/v1beta/models/gemini-2.0-flash:generateContent", "");
+    expect(parsed).toEqual({ model: "gemini-2.0-flash", stream: false });
+  });
+
+  it("exposes the error factory + wire schemas", () => {
+    const err = core.makeGeminiError({
+      error_class: "invalid_request",
+      message: "bad",
+      trace_id: "t1",
+    });
+    expect(err.body.error.status).toBe("INVALID_ARGUMENT");
+    expect(typeof core.GeminiGenerateContentRequestSchema.parse).toBe("function");
+    expect(typeof core.GeminiSSEEventSchema.parse).toBe("function");
+  });
+});


### PR DESCRIPTION
## 改动内容

把已存在、但从未导出 / 从未路由的 `geminiTransformer` 接通成一个真实的入站表面。Helm 现在能把 Gemini 作为客户端协议来讲：

- `POST /v1beta/models/{model}:generateContent`（非流式）
- `POST /v1beta/models/{model}:streamGenerateContent?alt=sse`（快照式 SSE 流）

鉴权用 `x-goog-api-key`（Gemini SDK 默认），回退 `Authorization: Bearer`。复用与 `/v1/messages`、`/v1/responses` **完全相同**的 core 路由管线 —— Gemini 只是一个 OpenAI 形状的 IR 表面（`nativeIn → IR → nativeOut`，单一中枢）。

## 逐文件说明

- **`packages/core/src/protocol/gemini/error.ts`**（新增）—— `makeGeminiError` / `transformErrorOut`：把 8 个 `ErrorClass` 值映射成 Gemini 原生信封 `{ error: { code, message, status } }`（`code` = HTTP 状态码，`status` = Google 的规范枚举：`UNAUTHENTICATED` / `INVALID_ARGUMENT` / `RESOURCE_EXHAUSTED` / `UNAVAILABLE` / `DEADLINE_EXCEEDED`）。仿照 `anthropic/error.ts`。
- **`packages/core/src/index.ts`** —— 导出 `geminiTransformer`、`parseGeminiPath`、`GEMINI_ENDPOINT`、`GEMINI_API_KEY_HEADER`、`GeminiRoute`、wire schema/类型、`IRChunk` 以及错误工厂。
- **`apps/gateway/src/routes/messages-pipeline.ts`** —— `streamIR()` 按盖戳的 `protocol` 分流：`gemini` 把 `parseOpenAISSE(result.stream)` 直接喂给 `geminiTransformer.transformStreamOut`（它的 `IRChunk` **就是** OpenAI 的 chat.completion.chunk —— 无需 Anthropic 适配器）；其它协议维持 `convertOpenAIStreamToAnthropic`。
- **`apps/gateway/src/routes/gemini.ts`**（新增）—— `registerGeminiRoute`：catch-all `app.post("/v1beta/models/:rest{.+}")`（Hono 无法用具名参数匹配字面量 `:`），交给 core 的 `parseGeminiPath` 解析；`null` → 404 Gemini `NOT_FOUND` 信封。x-goog-api-key 鉴权、路径模型回填（`ir.model = route.model`）、非流式 `c.json` + **无 `event:` 名、无 `[DONE]`** 的快照 SSE，客户端断连 = 不发错误帧。
- **`apps/gateway/src/routes/messages.ts`** —— 把 `PipelineRunResult.streamIR()` 的返回类型放宽为 `AsyncIterable<Record<string, unknown>>`（Gemini 快照没有 `type` 字段；Anthropic 运行时仍读 `.type`）。
- **`apps/gateway/src/server.ts`** —— 接线一个盖了 `gemini` 戳的管线 + 路由（共享鉴权解析器、限流器、错误信封）。
- **`implementation-notes.md`** —— 决策记录（Hono 冒号路径、无 `[DONE]`、错误信封映射、e2e 需重建 dist 的坑）。

## 测试

全程 TDD 红 → 绿。

- **单测**：gemini 错误信封（8 个类）、`@helm/core` barrel 导出断言、pipeline gemini 分支（文本累积 + finishReason/usageMetadata + 分片的 tool-call 参数）、gemini 路由（鉴权顺序、x-goog-api-key vs Bearer、模型回填、404/400、全 provider 失败信封、无 `[DONE]` 的快照流、断连 = 不发错误帧、非断连抛错时的终止错误帧）。
- **e2e**（`gemini.spec.ts`）：非流式往返 + 归一化的上游请求、`alt=sse` 快照帧无 `event:`/`[DONE]`、tool-call → `functionCall` part、401/404/400 的 Gemini 信封。

## 本地结果

- `pnpm typecheck`：PASS
- `pnpm lint`：PASS（0 错误，14 个既有警告）
- `pnpm test`：**1354 通过 / 0 失败**（139 个文件）
- `pnpm test:e2e`（gateway 项目）：**34 通过 / 0 失败**（28 个既有 + 6 个新增 Gemini）

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
