### PR TITLE
feat: /v1/responses 原生 SSE 流式 (closes #35)

### DIFF
--- a/apps/gateway/e2e/protocol.spec.ts
+++ b/apps/gateway/e2e/protocol.spec.ts
@@ -184,6 +184,104 @@ test.describe("OpenAI client → upstream", () => {
   });
 });
 
+// ── OpenAI Responses client → Helm → upstream (SSE streaming) ───────────────
+// The Responses surface is the THIRD client protocol. Streaming emits the native
+// `response.*` event sequence via the second IR→SSE state machine. This proves the
+// seam end-to-end: created → … → completed, monotonic sequence_number, delta
+// concatenation, tool-call streaming, and the OpenAI error envelope on failure
+// (docs/05 §Responses item expansion, principle 8).
+test.describe("OpenAI Responses client → upstream (streaming)", () => {
+  // Parse an SSE body into ordered { event, data } frames.
+  function parseSSE(text: string): Array<{ event: string; data: string }> {
+    const frames: Array<{ event: string; data: string }> = [];
+    for (const block of text.split("\n\n")) {
+      if (block.trim() === "") continue;
+      let event = "message";
+      let data = "";
+      for (const line of block.split("\n")) {
+        if (line.startsWith("event:")) event = line.slice(6).trim();
+        else if (line.startsWith("data:")) data += line.slice(5).trim();
+      }
+      frames.push({ event, data });
+    }
+    return frames;
+  }
+
+  test("text stream: response.created … response.completed, monotonic sequence_number", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1/responses", {
+      headers: OPENAI_AUTH,
+      data: {
+        model: "auto",
+        input: "translate this sentence to french: hola",
+        stream: true,
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    expect(res.headers()["content-type"]).toContain("text/event-stream");
+    const text = await res.text();
+    const frames = parseSSE(text);
+
+    // ordered envelope boundaries (no [DONE] sentinel on the Responses surface).
+    expect(frames[0]?.event).toBe("response.created");
+    expect(frames.at(-1)?.event).toBe("response.completed");
+    expect(text).not.toContain("[DONE]");
+    // never leak a raw OpenAI chunk through the Responses surface.
+    expect(text).not.toContain("chat.completion.chunk");
+
+    // sequence_number is strictly monotonic across every event.
+    const seqs = frames.map(
+      (f) => (JSON.parse(f.data) as { sequence_number: number }).sequence_number,
+    );
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]).toBe((seqs[i - 1] ?? -1) + 1);
+    }
+
+    // output_text.delta concatenation equals the output_text.done full text.
+    const deltas = frames
+      .filter((f) => f.event === "response.output_text.delta")
+      .map((f) => (JSON.parse(f.data) as { delta: string }).delta)
+      .join("");
+    const doneFrame = frames.find((f) => f.event === "response.output_text.done");
+    expect(doneFrame).toBeDefined();
+    const doneText = (JSON.parse(doneFrame?.data ?? "{}") as { text?: string }).text;
+    expect(doneText).toBe(deltas);
+  });
+
+  test("tool-call stream: function_call item + arguments deltas", async ({ request }) => {
+    const res = await request.post("/v1/responses", {
+      headers: OPENAI_AUTH,
+      data: {
+        model: "auto",
+        input: `look up the weather ${TOOL_CALL_SENTINEL}`,
+        tools: [
+          {
+            type: "function",
+            name: "get_weather",
+            parameters: { type: "object", properties: { city: { type: "string" } } },
+          },
+        ],
+        stream: true,
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const text = await res.text();
+    const frames = parseSSE(text);
+
+    const added = frames.find((f) => f.event === "response.output_item.added");
+    expect(added).toBeDefined();
+    const item = (JSON.parse(added?.data ?? "{}") as { item?: { type?: string; name?: string } })
+      .item;
+    expect(item?.type).toBe("function_call");
+    expect(item?.name).toBe("get_weather");
+    // arguments arrive as function_call_arguments.delta and close with .done.
+    expect(text).toContain("response.function_call_arguments.delta");
+    expect(text).toContain("response.function_call_arguments.done");
+    expect(frames.at(-1)?.event).toBe("response.completed");
+  });
+});
+
 // ── Bidirectional isomorphism: same logical chat, two client protocols, ONE
 //    normalized upstream shape (proves a unified IR hub, not N×N direct). ─────
 test.describe("bidirectional isomorphism", () => {

--- a/apps/gateway/src/middleware/error-handler.ts
+++ b/apps/gateway/src/middleware/error-handler.ts
@@ -30,6 +30,24 @@ function isClientDisconnect(err: unknown): boolean {
   return false;
 }
 
+// Build the OpenAI error envelope (the `{ error: { message, type, code,
+// trace_id } }` body) for a given class/message/trace. Extracted so the SSE
+// streaming paths — which cannot throw to onError once the stream has started —
+// can write the SAME envelope as a terminal `event: error` frame. The HTTP status
+// is returned alongside for the non-stream (throw → onError) path.
+export function openAIErrorEnvelope(args: {
+  error_class: ErrorClass;
+  message: string;
+  trace_id: string;
+}): {
+  status: number;
+  body: { error: { message: string; type: string; code: string; trace_id: string } };
+} {
+  // Delegate to the canonical core mapping (SINGLE SOURCE OF TRUTH) so the SSE
+  // terminal error frame and the non-stream onError envelope cannot drift.
+  return makeOpenAIError(args);
+}
+
 function asHelmError(err: unknown): HelmError | null {
   // Unwrap the throwable wrapper, or accept a bare HelmError-shaped object.
   const candidate = err instanceof HelmHttpError ? err.helm : err;

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -96,6 +96,35 @@ describe("createMessagesPipeline — streamIR protocol branch", () => {
     expect(types.at(-1)).toBe("response.completed");
     expect(types.some((t) => t.startsWith("message_"))).toBe(false);
   });
+
+  it("parses OpenAI SSE with CRLF separators and multi-data lines", async () => {
+    const splitJson = JSON.stringify({
+      id: "chatcmpl-x",
+      model: "gpt-x",
+      choices: [{ index: 0, delta: { content: "hi" } }],
+    });
+    const finishJson = JSON.stringify({
+      id: "chatcmpl-x",
+      model: "gpt-x",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    });
+    const stream = (async function* () {
+      yield `data: ${splitJson.slice(0, 20)}\r\n`;
+      yield `data: ${splitJson.slice(20)}\r\n\r\n`;
+      yield `event: ignored\r\n`;
+      yield `data: ${finishJson}\r\n\r\n`;
+    })();
+    const route: RouteFn = async () => streamOkResult(stream);
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const run = await pipeline.run(irOf({ stream: true }), IDENTITY, new AbortController().signal);
+    const events = [];
+    for await (const ev of run.streamIR()) events.push(ev);
+    const delta = events.find((e) => e.type === "response.output_text.delta") as
+      | { delta?: string }
+      | undefined;
+    expect(delta?.delta).toBe("hi");
+    expect(events.at(-1)?.type).toBe("response.completed");
+  });
 });
 
 describe("createMessagesPipeline — failure surfaces", () => {

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -70,9 +70,9 @@ function streamOkResult(stream: AsyncIterable<string>): ExecutionResult {
   };
 }
 
-async function drain(it: AsyncIterable<{ type: string }>): Promise<string[]> {
+async function drain(it: AsyncIterable<Record<string, unknown>>): Promise<string[]> {
   const out: string[] = [];
-  for await (const ev of it) out.push(ev.type);
+  for await (const ev of it) out.push(String(ev.type));
   return out;
 }
 

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -47,6 +47,57 @@ function errorResult(stream: AsyncIterable<string> | null = null): ExecutionResu
   };
 }
 
+// A minimal OpenAI SSE text stream (one content delta + a stop frame). The
+// pipeline parses these via parseOpenAISSE and feeds the chosen state machine.
+function sseTextStream(): AsyncIterable<string> {
+  const frames = [
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: "hi" } }] })}\n\n`,
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  return (async function* () {
+    for (const f of frames) yield f;
+  })();
+}
+
+function streamOkResult(stream: AsyncIterable<string>): ExecutionResult {
+  return {
+    decision: { lane: { selected_lane: "balanced" } } as unknown as ExecutionResult["decision"],
+    final: { status: "ok", alias: "x" },
+    body: null,
+    stream,
+    error: null,
+  };
+}
+
+async function drain(it: AsyncIterable<{ type: string }>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const ev of it) out.push(ev.type);
+  return out;
+}
+
+describe("createMessagesPipeline — streamIR protocol branch", () => {
+  it("default (anthropic_messages) yields Anthropic message_* events", async () => {
+    const route: RouteFn = async () => streamOkResult(sseTextStream());
+    const pipeline = createMessagesPipeline(route);
+    const run = await pipeline.run(irOf({ stream: true }), IDENTITY, new AbortController().signal);
+    const types = await drain(run.streamIR());
+    expect(types[0]).toBe("message_start");
+    expect(types).toContain("message_stop");
+    expect(types.some((t) => t.startsWith("response."))).toBe(false);
+  });
+
+  it("openai_responses yields Responses response.* events", async () => {
+    const route: RouteFn = async () => streamOkResult(sseTextStream());
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const run = await pipeline.run(irOf({ stream: true }), IDENTITY, new AbortController().signal);
+    const types = await drain(run.streamIR());
+    expect(types[0]).toBe("response.created");
+    expect(types.at(-1)).toBe("response.completed");
+    expect(types.some((t) => t.startsWith("message_"))).toBe(false);
+  });
+});
+
 describe("createMessagesPipeline — failure surfaces", () => {
   it("collect() throws a structured PipelineError when routing fails (no empty 200)", async () => {
     const route: RouteFn = async () => errorResult();

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -1,6 +1,7 @@
 import {
   type AnthropicSSEEvent,
   convertOpenAIStreamToAnthropic,
+  convertOpenAIStreamToResponses,
   type ExecutionResult,
   geminiTransformer,
   type IRChunk,
@@ -10,6 +11,7 @@ import {
   type ObserveDeps,
   observeInbound,
   observeOutbound,
+  type ResponsesSSEEvent,
   type RouteOptions,
   resolveMemoryMode,
 } from "@helm/core";
@@ -381,10 +383,14 @@ export function createMessagesPipeline(
                 yield snapshot as Record<string, unknown>;
               }
             } else {
-              for await (const ev of convertOpenAIStreamToAnthropic(
-                source as AsyncIterable<never>,
-              )) {
-                yield ev as AnthropicSSEEvent & { type: string };
+              // openai_responses / anthropic both yield typed SSE events; the route
+              // treats them as an opaque {type,...} bag, so the branch lives here.
+              const events =
+                protocol === "openai_responses"
+                  ? convertOpenAIStreamToResponses(source as AsyncIterable<never>)
+                  : convertOpenAIStreamToAnthropic(source as AsyncIterable<never>);
+              for await (const ev of events) {
+                yield ev as (AnthropicSSEEvent | ResponsesSSEEvent) & { type: string };
               }
             }
           } finally {

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -221,15 +221,14 @@ function openAIBodyToIR(body: unknown): IRResponse {
 }
 
 // —— Raw OpenAI SSE text stream → parsed OpenAIChunk objects. The provider yields
-// decoded byte chunks (NOT line-aligned), so we buffer across chunks, split on
-// blank-line SSE event boundaries, drop the `data: ` prefix, skip `[DONE]`, and
-// JSON.parse each frame. A malformed frame is skipped (fail-open) rather than
-// 5xx'ing the stream. The shape is fed verbatim into the Anthropic state machine.
+// decoded byte chunks (NOT line-aligned), so we normalize CRLF, buffer across
+// chunks, split on blank-line SSE event boundaries, collect all `data:` lines,
+// skip `[DONE]`, and JSON.parse each frame. Malformed frames are skipped
+// (fail-open) rather than 5xx'ing the stream.
 async function* parseOpenAISSE(raw: AsyncIterable<string>): AsyncIterable<Record<string, unknown>> {
   let buffer = "";
   for await (const piece of raw) {
-    buffer += piece;
-    // SSE events are separated by a blank line.
+    buffer += piece.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
     let sep = buffer.indexOf("\n\n");
     while (sep !== -1) {
       const event = buffer.slice(0, sep);
@@ -239,21 +238,25 @@ async function* parseOpenAISSE(raw: AsyncIterable<string>): AsyncIterable<Record
       sep = buffer.indexOf("\n\n");
     }
   }
-  // flush any trailing event without a terminating blank line.
   const tail = parseFrame(buffer);
   if (tail !== null) yield tail;
 }
 
 function parseFrame(event: string): Record<string, unknown> | null {
+  const dataLines: string[] = [];
   for (const line of event.split("\n")) {
     const trimmed = line.trimStart();
     if (!trimmed.startsWith("data:")) continue;
-    const payload = trimmed.slice(5).trim();
-    if (payload === "" || payload === "[DONE]") continue;
+    dataLines.push(trimmed.slice(5).replace(/^ /, ""));
+  }
+  if (dataLines.length === 0) return null;
+  const payload = dataLines.join("\n").trim();
+  if (payload === "" || payload === "[DONE]") return null;
+  for (const candidate of [payload, dataLines.join("").trim()]) {
     try {
-      return JSON.parse(payload) as Record<string, unknown>;
+      return JSON.parse(candidate) as Record<string, unknown>;
     } catch {
-      return null; // malformed frame: skip (fail-open).
+      // Try the next legal/compat concatenation form before failing open.
     }
   }
   return null;
@@ -385,9 +388,13 @@ export function createMessagesPipeline(
             } else {
               // openai_responses / anthropic both yield typed SSE events; the route
               // treats them as an opaque {type,...} bag, so the branch lives here.
+              // The Responses machine also gets the requested model so its
+              // synthesized envelope carries it (review-blocker fix d55332e).
               const events =
                 protocol === "openai_responses"
-                  ? convertOpenAIStreamToResponses(source as AsyncIterable<never>)
+                  ? convertOpenAIStreamToResponses(source as AsyncIterable<never>, {
+                      model: typeof ir.model === "string" && ir.model.length > 0 ? ir.model : "auto",
+                    })
                   : convertOpenAIStreamToAnthropic(source as AsyncIterable<never>);
               for await (const ev of events) {
                 yield ev as (AnthropicSSEEvent | ResponsesSSEEvent) & { type: string };

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -393,7 +393,8 @@ export function createMessagesPipeline(
               const events =
                 protocol === "openai_responses"
                   ? convertOpenAIStreamToResponses(source as AsyncIterable<never>, {
-                      model: typeof ir.model === "string" && ir.model.length > 0 ? ir.model : "auto",
+                      model:
+                        typeof ir.model === "string" && ir.model.length > 0 ? ir.model : "auto",
                     })
                   : convertOpenAIStreamToAnthropic(source as AsyncIterable<never>);
               for await (const ev of events) {

--- a/apps/gateway/src/routes/responses.memory.test.ts
+++ b/apps/gateway/src/routes/responses.memory.test.ts
@@ -66,10 +66,35 @@ function captureRoute(body: unknown): { route: RouteFn; seen: InternalRequest[] 
   return { route, seen };
 }
 
+// A route that returns an OpenAI SSE stream (one assistant text delta + stop). The
+// pipeline parses it and feeds the Responses state machine; the streamed assistant
+// text is what observeOutbound must persist in the `finally` of streamIR.
+function streamingRoute(text: string): { route: RouteFn; seen: InternalRequest[] } {
+  const seen: InternalRequest[] = [];
+  const frames = [
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: text } }] })}\n\n`,
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  const route: RouteFn = async (req: InternalRequest, _opts: RouteOptions) => {
+    seen.push(req);
+    return {
+      decision: { lane: { selected_lane: "balanced" } },
+      final: { status: "ok" },
+      body: null,
+      stream: (async function* () {
+        for (const f of frames) yield f;
+      })(),
+      error: null,
+    } as unknown as ExecutionResult;
+  };
+  return { route, seen };
+}
+
 // Real pipeline (with the memory dep injected) behind the Responses route, plus a
 // pass-through transformer that keeps `messages`/`metadata` so the route can stamp
 // the memory scope and the pipeline can read it back — observe runs end to end.
-function buildApp(opts: { route: RouteFn; memory?: { observe: ObserveDeps } }) {
+function buildApp(opts: { route: RouteFn; memory?: { observe: ObserveDeps }; stream?: boolean }) {
   const pipeline = createMessagesPipeline(opts.route, "openai_responses", opts.memory);
   const deps: ResponsesRouteDeps = {
     auth: { resolve: async () => ({ keyId: "k1", accountId: "acct" }) },
@@ -79,7 +104,7 @@ function buildApp(opts: { route: RouteFn; memory?: { observe: ObserveDeps } }) {
         return {
           model: typeof n.model === "string" ? n.model : "auto",
           messages: [{ role: "user", content: "hi" }],
-          stream: false,
+          stream: opts.stream === true,
           metadata: {},
         };
       },
@@ -89,6 +114,10 @@ function buildApp(opts: { route: RouteFn; memory?: { observe: ObserveDeps } }) {
         status: "completed",
         output: [],
         __ir: ir,
+      }),
+      transformStreamOut: (event) => ({
+        event: (event as { type: string }).type,
+        data: JSON.stringify(event),
       }),
     },
     pipeline,
@@ -122,6 +151,29 @@ describe("gateway.responses.memory — observe reaches /v1/responses", () => {
     // Inbound user message + outbound assistant message both persisted to the thread.
     expect(messages.some((m) => m.threadId === "thread-1" && m.role === "user")).toBe(true);
     expect(messages.some((m) => m.role === "assistant" && m.content === "hello")).toBe(true);
+  });
+
+  it("STREAMING: persists the streamed assistant turn via observeOutbound in finally", async () => {
+    const { store, threads, messages } = makeFakeStore();
+    const { route } = streamingRoute("hello world");
+    const app = buildApp({ route, memory: { observe: observeDeps(store) }, stream: true });
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { ...AUTH, ...MEM_HEADERS },
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    // Drain the stream so the streamIR `finally` (observeOutbound) actually runs.
+    const text = await res.text();
+    expect(text).toContain("response.completed");
+    // The streamed assistant text was accumulated and persisted (the FIRST time the
+    // Responses surface exercises the streaming observe path).
+    expect(threads[0]?.id).toBe("thread-1");
+    expect(messages.some((m) => m.threadId === "thread-1" && m.role === "user")).toBe(true);
+    expect(messages.some((m) => m.role === "assistant" && m.content === "hello world")).toBe(true);
   });
 
   it("off-mode (no memory headers) is a pure no-op: zero store touches", async () => {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -15,6 +15,7 @@ function makeDeps(
     authed?: boolean;
     transformRequestOut?: (n: unknown) => { stream?: boolean; metadata?: Record<string, unknown> };
     collect?: () => Promise<unknown>;
+    streamIR?: () => AsyncIterable<{ type: string; [k: string]: unknown }>;
     rateLimiter?: ResponsesRouteDeps["rateLimiter"];
     identity?: MessagesIdentity;
   } = {},
@@ -40,19 +41,45 @@ function makeDeps(
         order.push("translate-back");
         return { id: "resp_1", object: "response", status: "completed", output: [], __ir: ir };
       },
+      // Serialize ONE Responses SSE event into its wire event/data pair (mirrors
+      // the server wiring: event = the response.* type, data = the whole event).
+      transformStreamOut: (event) => ({
+        event: (event as { type: string }).type,
+        data: JSON.stringify(event),
+      }),
     },
     pipeline: {
       run: async (_ir, _identity, _signal) => {
         order.push("route");
         return {
           collect: over.collect ?? (async () => ({ id: "ir-resp", choices: [] })),
-          // streamIR is never consumed by the Responses route (non-stream only).
-          streamIR: async function* () {},
+          streamIR:
+            over.streamIR ??
+            async function* () {
+              yield { type: "response.created", sequence_number: 0 };
+              yield { type: "response.completed", sequence_number: 1 };
+            },
         };
       },
     },
   };
   return { deps, order };
+}
+
+// Parse an SSE response body into [event, dataJSON] frames.
+function parseSSE(text: string): Array<{ event: string; data: string }> {
+  const frames: Array<{ event: string; data: string }> = [];
+  for (const block of text.split("\n\n")) {
+    if (block.trim() === "") continue;
+    let event = "message";
+    let data = "";
+    for (const line of block.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      else if (line.startsWith("data:")) data += line.slice(5).trim();
+    }
+    frames.push({ event, data });
+  }
+  return frames;
 }
 
 function buildApp(deps: ResponsesRouteDeps) {
@@ -106,9 +133,14 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(order).not.toContain("route");
   });
 
-  it("rejects stream:true with a structured 400 (Responses streaming not yet supported)", async () => {
-    const { deps, order } = makeDeps({
-      transformRequestOut: () => ({ stream: true, metadata: {} }),
+  it("stream:true returns text/event-stream with the response.* event sequence (no 400)", async () => {
+    const { deps } = makeDeps({
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
     });
     const app = buildApp(deps);
     const res = await app.request("/v1/responses", {
@@ -116,11 +148,93 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       headers: AUTH,
       body: JSON.stringify({ ...REQ, stream: true }),
     });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: { code: string; message: string } };
-    expect(body.error.code).toBe("invalid_request");
-    expect(body.error.message).toContain("streaming");
-    expect(order).not.toContain("route");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const frames = parseSSE(await res.text());
+    expect(frames[0]?.event).toBe("response.created");
+    expect(frames.at(-1)?.event).toBe("response.completed");
+    // No [DONE] sentinel on the Responses surface.
+    expect(frames.some((f) => f.data === "[DONE]")).toBe(false);
+  });
+
+  it("mid-stream provider failure emits exactly one OpenAI-envelope error frame", async () => {
+    const { deps } = makeDeps({
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      streamIR: async function* () {
+        yield { type: "response.created", sequence_number: 0 };
+        throw new Error("upstream exploded");
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    expect(res.status).toBe(200);
+    const frames = parseSSE(await res.text());
+    const errorFrames = frames.filter((f) => f.event === "error");
+    expect(errorFrames).toHaveLength(1);
+    const env = JSON.parse(errorFrames[0]!.data) as { error: { code: string } };
+    // OpenAI error envelope, NOT the Anthropic shape.
+    expect(env.error.code).toBeDefined();
+  });
+
+  it("pre-stream all_providers_failed surfaces a single terminal OpenAI error frame", async () => {
+    const { deps } = makeDeps({
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      // biome-ignore lint/correctness/useYield: throw-only generator (failure before first event)
+      streamIR: async function* () {
+        throw new PipelineError("all_providers_failed", "all providers failed", "trace-1");
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    const frames = parseSSE(await res.text());
+    const errorFrames = frames.filter((f) => f.event === "error");
+    expect(errorFrames).toHaveLength(1);
+    const env = JSON.parse(errorFrames[0]!.data) as { error: { code: string } };
+    expect(env.error.code).toBe("all_providers_failed");
+  });
+
+  it("client abort emits NO error frame (benign non-provider fault)", async () => {
+    const ac = new AbortController();
+    const { deps } = makeDeps({
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      streamIR: async function* () {
+        yield { type: "response.created", sequence_number: 0 };
+        ac.abort();
+        throw new Error("aborted");
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+      signal: ac.signal,
+    });
+    const frames = parseSSE(await res.text());
+    expect(frames.some((f) => f.event === "error")).toBe(false);
   });
 
   it("maps a structurally invalid Responses body (transformer throws) to 400", async () => {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -157,7 +157,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(frames.some((f) => f.data === "[DONE]")).toBe(false);
   });
 
-  it("mid-stream provider failure emits exactly one OpenAI-envelope error frame", async () => {
+  it("mid-stream provider failure emits exactly one Responses-shaped error frame", async () => {
     const { deps } = makeDeps({
       transformRequestOut: () => ({
         stream: true,
@@ -180,12 +180,19 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     const frames = parseSSE(await res.text());
     const errorFrames = frames.filter((f) => f.event === "error");
     expect(errorFrames).toHaveLength(1);
-    const env = JSON.parse(errorFrames[0]!.data) as { error: { code: string } };
-    // OpenAI error envelope, NOT the Anthropic shape.
-    expect(env.error.code).toBeDefined();
+    const env = JSON.parse(errorFrames[0]?.data ?? "{}") as {
+      type: string;
+      code: string;
+      message: string;
+      param: null;
+      sequence_number: number;
+    };
+    expect(env).toMatchObject({ type: "error", code: "internal_error", param: null });
+    expect(env.message).toBe("upstream exploded");
+    expect(typeof env.sequence_number).toBe("number");
   });
 
-  it("pre-stream all_providers_failed surfaces a single terminal OpenAI error frame", async () => {
+  it("pre-stream all_providers_failed surfaces a single terminal Responses-shaped error frame", async () => {
     const { deps } = makeDeps({
       transformRequestOut: () => ({
         stream: true,
@@ -207,8 +214,12 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     const frames = parseSSE(await res.text());
     const errorFrames = frames.filter((f) => f.event === "error");
     expect(errorFrames).toHaveLength(1);
-    const env = JSON.parse(errorFrames[0]!.data) as { error: { code: string } };
-    expect(env.error.code).toBe("all_providers_failed");
+    const env = JSON.parse(errorFrames[0]?.data ?? "{}") as {
+      type: string;
+      code: string;
+      param: null;
+    };
+    expect(env).toMatchObject({ type: "error", code: "all_providers_failed", param: null });
   });
 
   it("client abort emits NO error frame (benign non-provider fault)", async () => {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -3,7 +3,7 @@ import { type ErrorClass, ErrorClassSchema, makeHelmError } from "@helm/shared";
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../app.js";
-import { HelmHttpError, openAIErrorEnvelope } from "../middleware/error-handler.js";
+import { HelmHttpError } from "../middleware/error-handler.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
@@ -98,6 +98,23 @@ function coerceErrorClass(value: string): ErrorClass {
 // A PipelineError surfaced across the pipeline seam → a throwable HelmHttpError so
 // the global onError serializes it in the OpenAI envelope (all_providers_failed →
 // 502, invalid_request → 400, …) instead of degrading to an empty 200.
+
+function responsesStreamError(args: {
+  code: string;
+  message: string;
+  traceId: string;
+  sequenceNumber: number;
+}): Record<string, unknown> {
+  return {
+    type: "error",
+    code: args.code,
+    message: args.message,
+    param: null,
+    sequence_number: args.sequenceNumber,
+    trace_id: args.traceId,
+  };
+}
+
 function pipelineToHelm(err: PipelineError, traceId: string): HelmHttpError {
   return new HelmHttpError(
     makeHelmError({
@@ -202,32 +219,36 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         // pipeline already ran the Responses state machine (principle 8 — we never
         // forward a raw upstream chunk). There is NO [DONE] sentinel; the terminal
         // response.completed closes the stream.
+        let nextErrorSequence = 0;
         try {
           for await (const event of result.streamIR()) {
+            if (typeof event.sequence_number === "number")
+              nextErrorSequence = event.sequence_number + 1;
             const frame = deps.transformer.transformStreamOut(event);
             await sse.writeSSE({ event: frame.event, data: frame.data });
           }
         } catch (err) {
           // A client disconnect / abort is benign (docs/02): emit NO error frame.
           // Any other throw — incl. a PipelineError when all providers failed
-          // before the stream started — writes a SINGLE terminal OpenAI-envelope
-          // error frame DIRECTLY into the stream. We CANNOT throw here (the stream
-          // has already started; onError would never see it), so the serializable
-          // makeHelmError body is written as an `event: error` frame instead.
+          // before the stream started — writes a SINGLE terminal Responses-shaped
+          // error event DIRECTLY into the stream. We CANNOT throw here (the stream
+          // has already started; onError would never see it).
           if (!isAbort(err, c.req.raw.signal)) {
-            const envelope =
+            const body =
               err instanceof PipelineError
-                ? openAIErrorEnvelope({
-                    error_class: coerceErrorClass(err.error_class),
+                ? responsesStreamError({
+                    code: coerceErrorClass(err.error_class),
                     message: err.message,
-                    trace_id: traceId,
+                    traceId,
+                    sequenceNumber: nextErrorSequence,
                   })
-                : openAIErrorEnvelope({
-                    error_class: "upstream_error",
-                    message: "upstream error",
-                    trace_id: traceId,
+                : responsesStreamError({
+                    code: "internal_error",
+                    message: err instanceof Error ? err.message : "upstream error",
+                    traceId,
+                    sequenceNumber: nextErrorSequence,
                   });
-            await sse.writeSSE({ event: "error", data: JSON.stringify(envelope.body) });
+            await sse.writeSSE({ event: "error", data: JSON.stringify(body) });
           }
         }
       });

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -49,7 +49,7 @@ export interface ResponsesRouteDeps {
     transformResponseOut(ir: unknown): unknown;
     /** ONE IR stream event → ONE Responses SSE frame (event/data pair). The
      *  pipeline already produced the response.* events; this only serializes. */
-    transformStreamOut(event: { type: string; [k: string]: unknown }): {
+    transformStreamOut(event: Record<string, unknown>): {
       event: string;
       data: string;
     };

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -1,8 +1,9 @@
 import type { RateLimitProbe, RateLimitResult } from "@helm/core";
 import { type ErrorClass, ErrorClassSchema, makeHelmError } from "@helm/shared";
 import type { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../app.js";
-import { HelmHttpError } from "../middleware/error-handler.js";
+import { HelmHttpError, openAIErrorEnvelope } from "../middleware/error-handler.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
@@ -17,10 +18,12 @@ import { PipelineError } from "./messages-pipeline.js";
 // envelope (a thrown HelmHttpError handled by the global onError) — identical to
 // /v1/chat, NOT the Anthropic envelope.
 //
-// MVP scope: NON-STREAMING only. The Responses streaming protocol (response.*
-// SSE events) has no transformer yet, so a `stream:true` request is rejected with
-// a structured 400 rather than silently mis-served (principle 2, fail-closed). The
-// non-stream path is fully wired and routed.
+// Streaming: a `stream:true` request is served as `text/event-stream`, emitting
+// the native Responses `response.*` event sequence (the pipeline runs the second
+// IR→SSE state machine, stamped openai_responses). Errors in the stream use the
+// OpenAI error envelope written DIRECTLY into the SSE stream — once the stream has
+// started we can no longer throw to onError, so the serializable envelope body is
+// written as a terminal `event: error` frame (docs/05, docs/07).
 
 interface ResponsesIRLike {
   stream?: boolean;
@@ -44,6 +47,12 @@ export interface ResponsesRouteDeps {
     transformRequestOut(native: unknown): ResponsesIRLike;
     /** IR response → native Responses response. */
     transformResponseOut(ir: unknown): unknown;
+    /** ONE IR stream event → ONE Responses SSE frame (event/data pair). The
+     *  pipeline already produced the response.* events; this only serializes. */
+    transformStreamOut(event: { type: string; [k: string]: unknown }): {
+      event: string;
+      data: string;
+    };
   };
   pipeline: {
     run(
@@ -52,6 +61,13 @@ export interface ResponsesRouteDeps {
       signal: AbortSignal,
     ): Promise<PipelineRunResult>;
   };
+}
+
+// Client disconnect / abort detection — mirrors messages.ts. Used to suppress a
+// terminal error frame for a benign disconnect (NOT a provider fault, docs/02).
+function isAbort(err: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return true;
+  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
 }
 
 function extractCredential(auth: string | undefined): string | null {
@@ -165,22 +181,12 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       memory_mode: memoryScope.mode,
     };
 
-    // 3) Streaming is not yet implemented for Responses (no SSE transformer). Reject
-    //    explicitly rather than degrade a stream client to a single JSON body.
-    if (ir.stream === true) {
-      throw helmError(
-        "invalid_request",
-        "streaming is not yet supported on /v1/responses; retry with stream:false",
-        traceId,
-      );
-    }
-
-    // 4) Route through the shared core, then translate the IR response back to the
-    //    native Responses shape. The pipeline throws a PipelineError when routing
-    //    failed (all_providers_failed) or for an empty request (invalid_request) —
-    //    surface it as the matching OpenAI envelope instead of an empty 200. `run`
-    //    throws for the empty-request case; `collect` throws for the routing-failure
-    //    case (the seam that previously synthesized an empty assistant message).
+    // 3) Route through the shared core. The pipeline throws a PipelineError when
+    //    routing failed (all_providers_failed) or for an empty request
+    //    (invalid_request) — surface it as the matching OpenAI envelope instead of
+    //    an empty 200. `run` itself throws for the empty-request case (pre-stream,
+    //    so it still reaches onError as a 400/502); the per-accessor failure
+    //    (collect/streamIR) covers the routing-failure case.
     let result: PipelineRunResult;
     try {
       result = await deps.pipeline.run(ir, identity, c.req.raw.signal);
@@ -188,6 +194,48 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       if (err instanceof PipelineError) throw pipelineToHelm(err, traceId);
       throw err;
     }
+
+    // 4) Outbound: stream vs non-stream, isomorphic shape.
+    if (ir.stream === true) {
+      return streamSSE(c, async (sse) => {
+        // Each IR event is serialized by the transformer's stream mapping; the
+        // pipeline already ran the Responses state machine (principle 8 — we never
+        // forward a raw upstream chunk). There is NO [DONE] sentinel; the terminal
+        // response.completed closes the stream.
+        try {
+          for await (const event of result.streamIR()) {
+            const frame = deps.transformer.transformStreamOut(event);
+            await sse.writeSSE({ event: frame.event, data: frame.data });
+          }
+        } catch (err) {
+          // A client disconnect / abort is benign (docs/02): emit NO error frame.
+          // Any other throw — incl. a PipelineError when all providers failed
+          // before the stream started — writes a SINGLE terminal OpenAI-envelope
+          // error frame DIRECTLY into the stream. We CANNOT throw here (the stream
+          // has already started; onError would never see it), so the serializable
+          // makeHelmError body is written as an `event: error` frame instead.
+          if (!isAbort(err, c.req.raw.signal)) {
+            const envelope =
+              err instanceof PipelineError
+                ? openAIErrorEnvelope({
+                    error_class: coerceErrorClass(err.error_class),
+                    message: err.message,
+                    trace_id: traceId,
+                  })
+                : openAIErrorEnvelope({
+                    error_class: "upstream_error",
+                    message: "upstream error",
+                    trace_id: traceId,
+                  });
+            await sse.writeSSE({ event: "error", data: JSON.stringify(envelope.body) });
+          }
+        }
+      });
+    }
+
+    // Non-stream: collect() throws a PipelineError when routing failed (all
+    // providers failed) — surface it as the OpenAI envelope instead of the empty
+    // 200 a synthesized placeholder body would produce.
     let collected: unknown;
     try {
       collected = await result.collect();

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -43,6 +43,7 @@ import {
   type ProxyConfig,
   parseLanesConfig,
   type ProviderRegistryConfig as RegistryProviderConfig,
+  type ResponsesSSEEvent,
   type RouteOptions,
   redact,
   resolveCostUsd,
@@ -1078,8 +1079,8 @@ export async function buildServer(
 
   // OpenAI Responses route (/v1/responses). Reuses the SAME routing core via a
   // pipeline stamped with the openai_responses protocol, and the Responses
-  // transformer for IR↔native translation. Non-streaming only (no Responses SSE
-  // transformer yet); a stream:true request is rejected with a structured 400.
+  // transformer for IR↔native translation. Streaming (stream:true) emits the
+  // native response.* SSE event sequence via the second IR→SSE state machine.
   const responsesPipeline = createMessagesPipeline(route, "openai_responses", { observe });
   registerResponsesRoute(app, {
     // Same per-key limiter, same cast rationale as the messages route above —
@@ -1112,6 +1113,12 @@ export async function buildServer(
       transformRequestOut: (native) =>
         responsesTransformer.transformRequestOut(native) as { metadata?: Record<string, unknown> },
       transformResponseOut: (ir) => responsesTransformer.transformResponseOut(ir as IRResponse),
+      // The pipeline already produced Responses SSE events; here we only serialize
+      // ONE event into its wire event/data pair (event = the response.* type).
+      transformStreamOut: (event) => {
+        const ev = event as ResponsesSSEEvent & { type: string };
+        return { event: ev.type, data: JSON.stringify(ev) };
+      },
     },
     pipeline: responsesPipeline,
   } as Parameters<typeof registerResponsesRoute>[1] & { rateLimiter: RateLimiterPort });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -292,6 +292,33 @@ protocol + gateway routes 406 tests green; typecheck clean; `pnpm lint` exit 0.
 
 ---
 
+## 2026-06-01 · `/v1/responses` SSE streaming (docs/05, `protocol.responses`, Principle 8)
+
+**Context**: `/v1/responses` previously hard-rejected `stream:true` with a 400 (no Responses SSE transformer). This adds the native `response.*` event stream — the SECOND IR→SSE state machine alongside the Anthropic one — reusing the shared pipeline and branching by the stamped surface protocol.
+
+**What was added**:
+- `packages/core/src/protocol/responses-stream.ts` — `convertOpenAIStreamToResponses` (the state machine) + `synthesizeResponsesSSEFromJSON` (cache-hit / non-stream upstream) + `ResponsesSSEEventSchema` (Zod discriminated union, the output alphabet). Exported from `packages/core/src/index.ts`.
+- `messages-pipeline.ts` — `streamIR()` now branches on `protocol`: `openai_responses` → Responses machine, else Anthropic (unchanged). Same post-`parseOpenAISSE` `source` feed, same memory-accumulation wrapper; only the output alphabet differs.
+- `apps/gateway/src/routes/responses.ts` — removed the `stream:true` reject; added a `streamSSE` branch + `isAbort` + `transformStreamOut` on the transformer dep. Error frames use the **OpenAI envelope written directly into the stream** (cannot `throw`→onError once the stream has started).
+- `apps/gateway/src/middleware/error-handler.ts` — extracted `openAIErrorEnvelope({error_class,message,trace_id})` so the SSE error path and `handleError` build the identical `{error:{message,type,code,trace_id}}` body (DRY).
+- `server.ts` — wired `transformStreamOut` for the responses transformer.
+
+**Open-question decisions (from the issue plan)**:
+1. **`sequence_number` starts at `0`**, single global counter, +1 per emitted event (`response.created` consumes index 0).
+2. **`response.in_progress` is always emitted** (one cheap event; avoids stalling SDK parsers that wait for it). `response.created` + `response.in_progress` fire UNCONDITIONALLY before the chunk loop, so an empty/zero-chunk stream still yields a legal `created…completed` envelope (the Anthropic machine gates `message_start` inside the loop → no analogue here).
+3. **Response `id`**: the synthesizer seeds the generator with the IR `id` so a cache-hit's `created`/`completed` match the non-stream body; the live stream synthesizes a stable `resp_*` id reused across the whole stream (created == completed).
+4. **Usage** is buffered and flushed ONLY on `response.completed` (never mid-stream, pit #2), projected as `{input_tokens, output_tokens}` (the same shape the unexported `toResponsesResponse` produces — inlined, NOT a reference to a non-existent `mapRes_usage`). Terminal `status` comes from the exported `mapResponsesStatus`, so streaming/non-streaming statuses cannot diverge (`length`→`incomplete`, else `completed`). If the upstream omits usage, `completed` carries `0`s.
+5. **Reasoning streaming is deferred** — the non-stream path already emits a reasoning item; streamed `reasoning.*` events are a follow-up.
+6. **Payload capture out of scope** — SSE bodies are not written to `request_payloads` in this issue.
+
+**Why NOT reuse `streaming.ts`'s `createStreamState`/`safeClose`**: the Anthropic machine carries its own local `StreamState`; for stylistic consistency the Responses machine does the same, with idempotent close enforced by a local `openItems: Set<number>` (each `output_item.done` and the terminal `completed` emitted at most once). Tool items defer `output_item.added` until id/name are settled and skip empty husks — same discipline as `anthropic/stream.ts`.
+
+**Build note**: `@helm/core`'s `exports` resolves `.` to `./dist/index.js` outside the `development` condition, and the e2e webServer (`tsx`) hits that path — so the gateway/e2e need `pnpm --filter @helm/core build` after changing core exports. Unit tests (vitest, source) don't.
+
+**Test results (local)**: typecheck clean, lint clean (warnings pre-exist), unit `1348 passed`. e2e: the two new Responses SSE specs pass; `38 passed / 1 failed` overall — the single failure is the unrelated `admin.spec.ts` pagination test (seeded-row count from reused non-CI data dir, untouched by this change).
+
+---
+
 ## 2026-06-01 · Pagination + error/role filters for the admin requests list (docs/07, Principle 1)
 
 **Context**: `/admin/requests` fetched a hardcoded `queryRecent(100)` and rendered all rows at once; the UI had dead cursor/"Load more" plumbing that never fired. No way to page past 100 requests or isolate errors / a time window — unusable for real debugging. Added numbered pagination (time DESC) plus Date-range / Status / Decided-by / Lane / Model filters, all applied at the SQL layer so totals stay correct.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -283,6 +283,15 @@ export {
 // OpenAI Responses transformer — the third client presentation surface (docs/05);
 // folds the flat input[] item stream into the IR and explodes it back out.
 export { mapResponsesStatus, responsesTransformer } from "./protocol/responses.js";
+// OpenAI Responses streaming state machine (docs/05): the SECOND IR→SSE machine,
+// emitting the `response.*` event sequence + a JSON→SSE synthesizer for cache
+// hits / non-streaming upstreams. Framework-agnostic (principle 1).
+export {
+  convertOpenAIStreamToResponses,
+  type ResponsesSSEEvent,
+  ResponsesSSEEventSchema,
+  synthesizeResponsesSSEFromJSON,
+} from "./protocol/responses-stream.js";
 // Streaming primitives (docs/05): generic SSE splitter, shared per-direction
 // state machine + idempotent close guards, and the JSON->SSE synthesizer for
 // cache hits / non-streaming upstreams. Framework-agnostic (Web ReadableStream).

--- a/packages/core/src/protocol/responses-stream.test.ts
+++ b/packages/core/src/protocol/responses-stream.test.ts
@@ -87,6 +87,45 @@ describe("convertOpenAIStreamToResponses — text event sequence", () => {
     );
   });
 
+  it("created/in_progress/completed carry the same non-empty model from the request seed", async () => {
+    const events = await collect(
+      convertOpenAIStreamToResponses(feed([textChunk("hi"), textChunk("", "stop")]), {
+        model: "gpt-seeded",
+      }),
+    );
+    const responseEvents = events.filter(
+      (
+        e,
+      ): e is Extract<
+        ResponsesSSEEvent,
+        { type: "response.created" | "response.in_progress" | "response.completed" }
+      > =>
+        e.type === "response.created" ||
+        e.type === "response.in_progress" ||
+        e.type === "response.completed",
+    );
+    expect(responseEvents.map((e) => e.response.model)).toEqual([
+      "gpt-seeded",
+      "gpt-seeded",
+      "gpt-seeded",
+    ]);
+  });
+
+  it("done item and final response output mark message items completed", async () => {
+    const events = await collect(
+      convertOpenAIStreamToResponses(feed([textChunk("hi"), textChunk("", "stop")]), {
+        model: "gpt-x",
+      }),
+    );
+    const done = events.find((e) => e.type === "response.output_item.done") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.done" }
+    >;
+    expect(done.item).toMatchObject({ type: "message", status: "completed" });
+    const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
+    expect(completed.response.output[0]).toMatchObject({ type: "message", status: "completed" });
+  });
+
   it("response.completed carries terminal status completed + usage projection", async () => {
     const usageChunk: OpenAIChunk = {
       id: "chatcmpl-x",
@@ -164,6 +203,75 @@ describe("convertOpenAIStreamToResponses — tool calls", () => {
     expect(done.output_index).toBe(0);
   });
 
+  it("marks function_call added as in_progress and done/final output as completed", async () => {
+    const chunks: OpenAIChunk[] = [
+      {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, id: "call_ping", function: { name: "ping", arguments: "{}" } },
+              ],
+            },
+          },
+        ],
+      },
+      { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+    ];
+    const events = await collect(convertOpenAIStreamToResponses(feed(chunks), { model: "gpt-x" }));
+    const added = events.find((e) => e.type === "response.output_item.added") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.added" }
+    >;
+    expect(added.item).toMatchObject({ type: "function_call", status: "in_progress" });
+    const done = events.find((e) => e.type === "response.output_item.done") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.done" }
+    >;
+    expect(done.item).toMatchObject({ type: "function_call", status: "completed" });
+    const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
+    expect(completed.response.output[0]).toMatchObject({
+      type: "function_call",
+      status: "completed",
+    });
+  });
+
+  it("keeps no-argument function_call items when name/call_id arrives with empty arguments", async () => {
+    const chunks: OpenAIChunk[] = [
+      {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, id: "call_empty", function: { name: "ping", arguments: "" } },
+              ],
+            },
+          },
+        ],
+      },
+      { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+    ];
+    const events = await collect(convertOpenAIStreamToResponses(feed(chunks), { model: "gpt-x" }));
+    const added = events.find((e) => e.type === "response.output_item.added") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.added" }
+    >;
+    expect(added.item).toMatchObject({
+      type: "function_call",
+      call_id: "call_empty",
+      name: "ping",
+      arguments: "",
+    });
+    const argsDone = events.find(
+      (e) => e.type === "response.function_call_arguments.done",
+    ) as Extract<ResponsesSSEEvent, { type: "response.function_call_arguments.done" }>;
+    expect(argsDone.arguments).toBe("");
+    const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
+    expect(completed.response.output).toHaveLength(1);
+  });
+
   it("assigns stable, non-reused output_index across multiple tool calls", async () => {
     const chunks: OpenAIChunk[] = [
       {
@@ -187,8 +295,8 @@ describe("convertOpenAIStreamToResponses — tool calls", () => {
       { type: "response.output_item.added" }
     >[];
     expect(added.map((e) => e.output_index)).toEqual([0, 1]);
-    expect((added[0]!.item as { call_id?: string }).call_id).toBe("c0");
-    expect((added[1]!.item as { call_id?: string }).call_id).toBe("c1");
+    expect((added[0]?.item as { call_id?: string }).call_id).toBe("c0");
+    expect((added[1]?.item as { call_id?: string }).call_id).toBe("c1");
   });
 
   it("drops an empty-husk tool (announced index/id but no name and no arguments)", async () => {

--- a/packages/core/src/protocol/responses-stream.test.ts
+++ b/packages/core/src/protocol/responses-stream.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from "vitest";
+import type { OpenAIChunk } from "./anthropic/stream.js";
+import type { IRResponse } from "./ir.js";
+import {
+  convertOpenAIStreamToResponses,
+  type ResponsesSSEEvent,
+  synthesizeResponsesSSEFromJSON,
+} from "./responses-stream.js";
+
+// —— helpers ————————————————————————————————————————————————————————————————
+
+/** Wrap an array of chunks as an async iterable (the upstream OpenAI chunk feed). */
+async function* feed(chunks: OpenAIChunk[]): AsyncIterable<OpenAIChunk> {
+  for (const c of chunks) yield c;
+}
+
+/** Drain an async iterable into an array. */
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const v of it) out.push(v);
+  return out;
+}
+
+/** A text-only OpenAI chunk carrying a content delta. */
+function textChunk(content: string, finish: string | null = null): OpenAIChunk {
+  return {
+    id: "chatcmpl-x",
+    model: "gpt-x",
+    choices: [{ index: 0, delta: { content }, finish_reason: finish }],
+  };
+}
+
+function seqs(events: ResponsesSSEEvent[]): number[] {
+  return events.map((e) => e.sequence_number);
+}
+
+// —— 1. event sequence: pure text ————————————————————————————————————————————
+
+describe("convertOpenAIStreamToResponses — text event sequence", () => {
+  it("emits the canonical TEXT sequence created→in_progress→item/part open→delta×N→done×→completed", async () => {
+    const events = await collect(
+      convertOpenAIStreamToResponses(
+        feed([textChunk("Hel"), textChunk("lo"), textChunk("", "stop")]),
+      ),
+    );
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+  });
+
+  it("assigns a strictly monotonic sequence_number starting at 0", async () => {
+    const events = await collect(
+      convertOpenAIStreamToResponses(feed([textChunk("a"), textChunk("b", "stop")])),
+    );
+    const s = seqs(events);
+    expect(s[0]).toBe(0);
+    for (let i = 1; i < s.length; i++) {
+      expect(s[i]).toBe((s[i - 1] as number) + 1);
+    }
+  });
+
+  it("output_text.delta concatenation equals output_text.done full text", async () => {
+    const events = await collect(
+      convertOpenAIStreamToResponses(
+        feed([textChunk("Hel"), textChunk("lo"), textChunk("", "stop")]),
+      ),
+    );
+    const deltas = events
+      .filter((e) => e.type === "response.output_text.delta")
+      .map((e) => (e as Extract<ResponsesSSEEvent, { type: "response.output_text.delta" }>).delta)
+      .join("");
+    expect(deltas).toBe("Hello");
+    const done = events.find((e) => e.type === "response.output_text.done");
+    expect(done).toBeDefined();
+    expect((done as Extract<ResponsesSSEEvent, { type: "response.output_text.done" }>).text).toBe(
+      "Hello",
+    );
+  });
+
+  it("response.completed carries terminal status completed + usage projection", async () => {
+    const usageChunk: OpenAIChunk = {
+      id: "chatcmpl-x",
+      model: "gpt-x",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 10, completion_tokens: 4 },
+    };
+    const events = await collect(
+      convertOpenAIStreamToResponses(feed([textChunk("hi"), usageChunk])),
+    );
+    const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
+    expect(completed.type).toBe("response.completed");
+    expect(completed.response.status).toBe("completed");
+    expect(completed.response.usage).toEqual({ input_tokens: 10, output_tokens: 4 });
+  });
+});
+
+// —— 2. tool calls ————————————————————————————————————————————————————————————
+
+describe("convertOpenAIStreamToResponses — tool calls", () => {
+  it("emits added→arguments.delta*→arguments.done→item.done with stable call_id/name/args", async () => {
+    const chunks: OpenAIChunk[] = [
+      {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, id: "call_abc", function: { name: "get_weather", arguments: '{"ci' } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [{ index: 0, function: { arguments: 'ty":"NYC"}' } }] },
+          },
+        ],
+      },
+      { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+    ];
+    const events = await collect(convertOpenAIStreamToResponses(feed(chunks)));
+    const toolTypes = events
+      .map((e) => e.type)
+      .filter(
+        (t) => t.startsWith("response.output_item") || t.startsWith("response.function_call"),
+      );
+    expect(toolTypes).toEqual([
+      "response.output_item.added",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+    ]);
+
+    const added = events.find((e) => e.type === "response.output_item.added") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.added" }
+    >;
+    expect(added.item).toMatchObject({
+      type: "function_call",
+      name: "get_weather",
+      call_id: "call_abc",
+    });
+    expect(added.output_index).toBe(0);
+
+    const done = events.find((e) => e.type === "response.function_call_arguments.done") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.function_call_arguments.done" }
+    >;
+    expect(done.arguments).toBe('{"city":"NYC"}');
+    expect(done.output_index).toBe(0);
+  });
+
+  it("assigns stable, non-reused output_index across multiple tool calls", async () => {
+    const chunks: OpenAIChunk[] = [
+      {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, id: "c0", function: { name: "f0", arguments: "{}" } },
+                { index: 1, id: "c1", function: { name: "f1", arguments: "{}" } },
+              ],
+            },
+          },
+        ],
+      },
+      { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+    ];
+    const events = await collect(convertOpenAIStreamToResponses(feed(chunks)));
+    const added = events.filter((e) => e.type === "response.output_item.added") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.added" }
+    >[];
+    expect(added.map((e) => e.output_index)).toEqual([0, 1]);
+    expect((added[0]!.item as { call_id?: string }).call_id).toBe("c0");
+    expect((added[1]!.item as { call_id?: string }).call_id).toBe("c1");
+  });
+
+  it("drops an empty-husk tool (announced index/id but no name and no arguments)", async () => {
+    const chunks: OpenAIChunk[] = [
+      { choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "ghost" }] } }] },
+      { choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+    ];
+    const events = await collect(convertOpenAIStreamToResponses(feed(chunks)));
+    expect(events.some((e) => e.type === "response.output_item.added")).toBe(false);
+    // still terminates cleanly.
+    expect(events.at(-1)?.type).toBe("response.completed");
+  });
+
+  it("interleaves text then tool call with distinct output_index slots", async () => {
+    const chunks: OpenAIChunk[] = [
+      { choices: [{ index: 0, delta: { content: "thinking" } }] },
+      {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: 0, id: "c0", function: { name: "f", arguments: "{}" } }],
+            },
+          },
+        ],
+      },
+      { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+    ];
+    const events = await collect(convertOpenAIStreamToResponses(feed(chunks)));
+    const textItem = events.find((e) => e.type === "response.output_item.added") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.added" }
+    >;
+    expect(textItem.output_index).toBe(0);
+    const toolItem = events
+      .filter((e) => e.type === "response.output_item.added")
+      .at(-1) as Extract<ResponsesSSEEvent, { type: "response.output_item.added" }>;
+    expect(toolItem.output_index).toBe(1);
+  });
+});
+
+// —— 3. terminal mapping + boundary sequences ————————————————————————————————
+
+describe("convertOpenAIStreamToResponses — terminal mapping & edge sequences", () => {
+  it("maps finish_reason length → status incomplete", async () => {
+    const events = await collect(
+      convertOpenAIStreamToResponses(feed([textChunk("x"), textChunk("", "length")])),
+    );
+    const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
+    expect(completed.response.status).toBe("incomplete");
+  });
+
+  it("empty stream still produces a legal created…completed sequence", async () => {
+    const events = await collect(convertOpenAIStreamToResponses(feed([])));
+    const types = events.map((e) => e.type);
+    expect(types[0]).toBe("response.created");
+    expect(types[1]).toBe("response.in_progress");
+    expect(types.at(-1)).toBe("response.completed");
+    // no orphan item/part events for an empty stream.
+    expect(types).not.toContain("response.output_item.added");
+  });
+
+  it("emits each output_item.done at most once (idempotent close)", async () => {
+    const chunks: OpenAIChunk[] = [
+      { choices: [{ index: 0, delta: { content: "a" } }] },
+      {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: 0, id: "c0", function: { name: "f", arguments: "{}" } }],
+            },
+          },
+        ],
+      },
+      { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+    ];
+    const events = await collect(convertOpenAIStreamToResponses(feed(chunks)));
+    const doneIndexes = events
+      .filter((e) => e.type === "response.output_item.done")
+      .map(
+        (e) =>
+          (e as Extract<ResponsesSSEEvent, { type: "response.output_item.done" }>).output_index,
+      );
+    expect(new Set(doneIndexes).size).toBe(doneIndexes.length);
+  });
+});
+
+// —— 4. synthesizer (cache hit / non-streaming upstream) ——————————————————————
+
+describe("synthesizeResponsesSSEFromJSON — isomorphic with the live stream", () => {
+  it("text-only response → identical canonical TEXT sequence", async () => {
+    const resp: IRResponse = {
+      id: "resp_abc",
+      model: "gpt-x",
+      choices: [
+        { index: 0, message: { role: "assistant", content: "Hello world" }, finish_reason: "stop" },
+      ],
+      usage: { prompt_tokens: 7, completion_tokens: 2 },
+    };
+    const events = await collect(synthesizeResponsesSSEFromJSON(resp));
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+      "response.output_item.done",
+      "response.completed",
+    ]);
+    const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
+    expect(completed.response.usage).toEqual({ input_tokens: 7, output_tokens: 2 });
+  });
+
+  it("tool-only response → function_call item sequence", async () => {
+    const resp: IRResponse = {
+      id: "resp_t",
+      model: "gpt-x",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              { id: "call_z", type: "function", function: { name: "do_it", arguments: '{"k":1}' } },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+    const events = await collect(synthesizeResponsesSSEFromJSON(resp));
+    const added = events.find((e) => e.type === "response.output_item.added") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.added" }
+    >;
+    expect(added.item).toMatchObject({ type: "function_call", name: "do_it", call_id: "call_z" });
+    const argsDone = events.find(
+      (e) => e.type === "response.function_call_arguments.done",
+    ) as Extract<ResponsesSSEEvent, { type: "response.function_call_arguments.done" }>;
+    expect(argsDone.arguments).toBe('{"k":1}');
+  });
+
+  it("mixed text + tool response → both item kinds present, terminal completed", async () => {
+    const resp: IRResponse = {
+      id: "resp_m",
+      model: "gpt-x",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "here",
+            tool_calls: [
+              { id: "call_m", type: "function", function: { name: "g", arguments: "{}" } },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+    const events = await collect(synthesizeResponsesSSEFromJSON(resp));
+    expect(events.some((e) => e.type === "response.output_text.delta")).toBe(true);
+    expect(
+      events.some(
+        (e) =>
+          e.type === "response.output_item.added" &&
+          (e as Extract<ResponsesSSEEvent, { type: "response.output_item.added" }>).item.type ===
+            "function_call",
+      ),
+    ).toBe(true);
+    expect(events.at(-1)?.type).toBe("response.completed");
+  });
+});

--- a/packages/core/src/protocol/responses-stream.test.ts
+++ b/packages/core/src/protocol/responses-stream.test.ts
@@ -299,15 +299,39 @@ describe("convertOpenAIStreamToResponses — tool calls", () => {
     expect((added[1]?.item as { call_id?: string }).call_id).toBe("c1");
   });
 
-  it("drops an empty-husk tool (announced index/id but no name and no arguments)", async () => {
+  it("keeps function_call when call_id arrives without arguments/name", async () => {
     const chunks: OpenAIChunk[] = [
-      { choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "ghost" }] } }] },
-      { choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+      { choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_only" }] } }] },
+      { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
     ];
     const events = await collect(convertOpenAIStreamToResponses(feed(chunks)));
-    expect(events.some((e) => e.type === "response.output_item.added")).toBe(false);
-    // still terminates cleanly.
-    expect(events.at(-1)?.type).toBe("response.completed");
+    const added = events.find((e) => e.type === "response.output_item.added") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.added" }
+    >;
+    expect(added.item).toMatchObject({
+      type: "function_call",
+      call_id: "call_only",
+      name: "",
+      status: "in_progress",
+      arguments: "",
+    });
+    const argsDone = events.find(
+      (e) => e.type === "response.function_call_arguments.done",
+    ) as Extract<ResponsesSSEEvent, { type: "response.function_call_arguments.done" }>;
+    expect(argsDone.arguments).toBe("");
+    const done = events.find((e) => e.type === "response.output_item.done") as Extract<
+      ResponsesSSEEvent,
+      { type: "response.output_item.done" }
+    >;
+    expect(done.item).toMatchObject({
+      type: "function_call",
+      call_id: "call_only",
+      status: "completed",
+      arguments: "",
+    });
+    const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
+    expect(completed.response.output).toEqual([expect.objectContaining(done.item)]);
   });
 
   it("interleaves text then tool call with distinct output_index slots", async () => {

--- a/packages/core/src/protocol/responses-stream.ts
+++ b/packages/core/src/protocol/responses-stream.ts
@@ -387,8 +387,13 @@ export async function* convertOpenAIStreamToResponses(
       }
 
       const args = tc.function?.arguments;
-      if (args !== undefined || slot.name !== "") {
-        // First meaningful tool signal: settle id/name and emit output_item.added before
+      const hasMeaningfulToolSignal =
+        args !== undefined ||
+        tc.function?.name !== undefined ||
+        tc.id !== undefined ||
+        slot.callId !== "";
+      if (hasMeaningfulToolSignal) {
+        // First meaningful tool signal: settle id/name/call_id and emit output_item.added before
         // any argument delta (item added ALWAYS precedes its deltas, pit #4).
         if (!slot.started) {
           slot.started = true;

--- a/packages/core/src/protocol/responses-stream.ts
+++ b/packages/core/src/protocol/responses-stream.ts
@@ -1,0 +1,570 @@
+import { z } from "zod";
+import { type OpenAIChunk, OpenAIChunkSchema } from "./anthropic/stream.js";
+import type { IRResponse, IRUsage } from "./ir.js";
+import { mapResponsesStatus } from "./responses.js";
+
+// OpenAI chunk → OpenAI **Responses** (`response.*`) SSE event stream: the SECOND
+// explicit IR→SSE state machine (the first being the Anthropic alphabet in
+// `anthropic/stream.ts`). Streaming is protocol translation's #1 risk (CLAUDE.md
+// principle 8, docs/05): an upstream OpenAI `data: {chunk}` feed is turned, frame
+// by frame, into the deterministic Responses event sequence
+//
+//   response.created
+//   response.in_progress
+//     (TEXT)  response.output_item.added(message)
+//             response.content_part.added(output_text)
+//             response.output_text.delta × N
+//             response.output_text.done   (accumulated full text)
+//             response.content_part.done
+//             response.output_item.done
+//     (TOOL)  response.output_item.added(function_call, name, call_id)
+//             response.function_call_arguments.delta × N
+//             response.function_call_arguments.done (accumulated arguments)
+//             response.output_item.done
+//   response.completed   (terminal response object + status + usage)
+//
+// There is NO `[DONE]` sentinel: the terminal `response.completed` closes the
+// stream. Every event carries a strictly monotonic `sequence_number` allocated
+// from the state counter (the Anthropic machine has no analogue).
+//
+// All the difficulty is in the STATE (docs/05 pits #2/#3/#4 + research-notes):
+//   • output_index is allocated monotonically, never reused;
+//   • OpenAI's integer tool_call `index` maps to a STABLE Responses output_index,
+//     so fragmented argument deltas never cross items;
+//   • a tool-call id/name may only arrive on a later fragment — we DEFER the
+//     `output_item.added` for a tool item until the id/name are settled (same
+//     discipline as the Anthropic machine), and SKIP an empty husk item that
+//     never produced a name or any argument fragment;
+//   • usage is BUFFERED and flushed ONLY on `response.completed` (never billed
+//     mid-stream, so a cache read is not double-counted, pit #2);
+//   • close is IDEMPOTENT: every `output_item.done` and the terminal
+//     `response.completed` is emitted at most once (`openItems` guard, pit #4);
+//   • `response.created` + `response.in_progress` are emitted UNCONDITIONALLY
+//     before the loop — an empty/zero-chunk stream must still produce a legal
+//     `created…completed` envelope (the Anthropic machine gates `message_start`
+//     inside the loop and so would emit NOTHING for an empty stream).
+//
+// Pure logic, framework-agnostic (CLAUDE.md principle 1): produces event OBJECTS
+// only, NOT coupled to Hono's `streamSSE` — that wiring lives in the gateway. The
+// terminal status reuses `mapResponsesStatus` from responses.ts so the streaming
+// and non-streaming paths cannot diverge; the usage projection inlines the same
+// 2-line shape `toResponsesResponse` produces (that helper is not exported).
+// Reimplemented from the docs, NOT copied from musistudio/llms or litellm. No `any`.
+
+// —— Output alphabet: Responses `response.*` SSE events. ———————————————————————
+// One discriminated union on `type`, mirroring `AnthropicSSEEventSchema`. Building
+// each event THROUGH the schema means a malformed event fails in tests, not in
+// production. `sequence_number` rides every event (the Responses wire contract).
+
+const ResponsesMessageItemSchema = z.object({
+  type: z.literal("message"),
+  id: z.string(),
+  status: z.literal("in_progress"),
+  role: z.literal("assistant"),
+  content: z.array(z.unknown()),
+});
+
+const ResponsesFunctionCallItemSchema = z.object({
+  type: z.literal("function_call"),
+  id: z.string(),
+  call_id: z.string(),
+  name: z.string(),
+  arguments: z.string(),
+});
+
+const ResponsesOutputItemSchema = z.union([
+  ResponsesMessageItemSchema,
+  ResponsesFunctionCallItemSchema,
+]);
+
+const ResponsesUsageSchema = z.object({
+  input_tokens: z.number().int().nonnegative(),
+  output_tokens: z.number().int().nonnegative(),
+});
+
+const ResponseObjectSchema = z.object({
+  id: z.string(),
+  object: z.literal("response"),
+  model: z.string(),
+  status: z.string(),
+  output: z.array(z.unknown()),
+  usage: ResponsesUsageSchema.optional(),
+});
+
+const ResponseCreatedSchema = z.object({
+  type: z.literal("response.created"),
+  sequence_number: z.number().int().nonnegative(),
+  response: ResponseObjectSchema,
+});
+const ResponseInProgressSchema = z.object({
+  type: z.literal("response.in_progress"),
+  sequence_number: z.number().int().nonnegative(),
+  response: ResponseObjectSchema,
+});
+const OutputItemAddedSchema = z.object({
+  type: z.literal("response.output_item.added"),
+  sequence_number: z.number().int().nonnegative(),
+  output_index: z.number().int().nonnegative(),
+  item: ResponsesOutputItemSchema,
+});
+const ContentPartAddedSchema = z.object({
+  type: z.literal("response.content_part.added"),
+  sequence_number: z.number().int().nonnegative(),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  content_index: z.number().int().nonnegative(),
+  part: z.object({ type: z.literal("output_text"), text: z.literal("") }),
+});
+const OutputTextDeltaSchema = z.object({
+  type: z.literal("response.output_text.delta"),
+  sequence_number: z.number().int().nonnegative(),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  content_index: z.number().int().nonnegative(),
+  delta: z.string(),
+});
+const OutputTextDoneSchema = z.object({
+  type: z.literal("response.output_text.done"),
+  sequence_number: z.number().int().nonnegative(),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  content_index: z.number().int().nonnegative(),
+  text: z.string(),
+});
+const ContentPartDoneSchema = z.object({
+  type: z.literal("response.content_part.done"),
+  sequence_number: z.number().int().nonnegative(),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  content_index: z.number().int().nonnegative(),
+  part: z.object({ type: z.literal("output_text"), text: z.string() }),
+});
+const FunctionCallArgumentsDeltaSchema = z.object({
+  type: z.literal("response.function_call_arguments.delta"),
+  sequence_number: z.number().int().nonnegative(),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  delta: z.string(),
+});
+const FunctionCallArgumentsDoneSchema = z.object({
+  type: z.literal("response.function_call_arguments.done"),
+  sequence_number: z.number().int().nonnegative(),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  arguments: z.string(),
+});
+const OutputItemDoneSchema = z.object({
+  type: z.literal("response.output_item.done"),
+  sequence_number: z.number().int().nonnegative(),
+  output_index: z.number().int().nonnegative(),
+  item: ResponsesOutputItemSchema,
+});
+const ResponseCompletedSchema = z.object({
+  type: z.literal("response.completed"),
+  sequence_number: z.number().int().nonnegative(),
+  response: ResponseObjectSchema,
+});
+
+export const ResponsesSSEEventSchema = z.discriminatedUnion("type", [
+  ResponseCreatedSchema,
+  ResponseInProgressSchema,
+  OutputItemAddedSchema,
+  ContentPartAddedSchema,
+  OutputTextDeltaSchema,
+  OutputTextDoneSchema,
+  ContentPartDoneSchema,
+  FunctionCallArgumentsDeltaSchema,
+  FunctionCallArgumentsDoneSchema,
+  OutputItemDoneSchema,
+  ResponseCompletedSchema,
+]);
+export type ResponsesSSEEvent = z.infer<typeof ResponsesSSEEventSchema>;
+
+type ResponsesOutputItem = z.infer<typeof ResponsesOutputItemSchema>;
+
+// —— State object (docs/05). Pure data; the generator drives the transitions. ————
+
+interface TextSlot {
+  outputIndex: number;
+  itemId: string;
+  started: boolean; // output_item.added + content_part.added emitted?
+  textBuffer: string; // accumulated text (flushed on output_text.done)
+}
+
+interface ToolSlot {
+  outputIndex: number;
+  itemId: string;
+  started: boolean; // output_item.added emitted?
+  callId: string; // real id (a temp id until the upstream supplies one)
+  name: string;
+  argBuffer: string; // accumulated argument fragments (tolerates partial JSON)
+}
+
+interface StreamState {
+  sequenceNumber: number; // monotonic per-event counter (allocated on emit)
+  responseId: string; // stable response id reused on created + completed
+  model: string;
+  nextOutputIndex: number; // monotonic output-index allocator
+  openItems: Set<number>; // started-but-not-done items (close guard)
+  textSlot: TextSlot | null; // lazily allocated text item
+  toolIndexToSlot: Map<number, ToolSlot>; // OpenAI tool index → output slot
+  finishReason: string | null; // terminal status source
+  usage: IRUsage | null; // buffered; flushed on response.completed
+}
+
+function createState(): StreamState {
+  return {
+    sequenceNumber: 0,
+    responseId: "",
+    model: "",
+    nextOutputIndex: 0,
+    openItems: new Set(),
+    textSlot: null,
+    toolIndexToSlot: new Map(),
+    finishReason: null,
+    usage: null,
+  };
+}
+
+function nextSeq(state: StreamState): number {
+  const s = state.sequenceNumber;
+  state.sequenceNumber += 1;
+  return s;
+}
+
+function allocOutputIndex(state: StreamState): number {
+  const i = state.nextOutputIndex;
+  state.nextOutputIndex += 1;
+  state.openItems.add(i);
+  return i;
+}
+
+// A monotonically-unique synthesized id when the upstream supplies none. Stable
+// across the whole stream once allocated.
+function synthResponseId(): string {
+  return `resp_${Math.random().toString(36).slice(2, 14)}`;
+}
+function synthCallId(outputIndex: number): string {
+  return `call_${outputIndex}`;
+}
+function itemId(outputIndex: number): string {
+  return `item_${outputIndex}`;
+}
+
+// —— usage projection: IR usage → Responses { input_tokens, output_tokens }. The
+// same 2-line shape `toResponsesResponse` produces (that helper is unexported, so
+// inline it rather than reference a non-existent symbol). ——————————————————————
+function projectUsage(usage: IRUsage | null): z.infer<typeof ResponsesUsageSchema> | undefined {
+  if (usage === null) return undefined;
+  return {
+    input_tokens: usage.prompt_tokens ?? 0,
+    output_tokens: usage.completion_tokens ?? 0,
+  };
+}
+
+function responseObject(
+  state: StreamState,
+  opts: { status: string; output?: unknown[]; usage?: z.infer<typeof ResponsesUsageSchema> },
+): z.infer<typeof ResponseObjectSchema> {
+  return {
+    id: state.responseId,
+    object: "response",
+    model: state.model,
+    status: opts.status,
+    output: opts.output ?? [],
+    ...(opts.usage !== undefined ? { usage: opts.usage } : {}),
+  };
+}
+
+// —— The state machine ————————————————————————————————————————————————————————
+
+/**
+ * Turn an async OpenAI chunk stream into a Responses `response.*` SSE event
+ * stream. Pure generator — NOT bound to Hono's streamSSE. Deterministic event
+ * sequence with a monotonic output-index allocator, a stable tool-index→item map,
+ * deferred tool-item start (id/name settled before the consumer sees `.added`),
+ * buffered terminal usage, and idempotent close guards. `response.created` +
+ * `response.in_progress` are emitted unconditionally so an empty stream still
+ * yields a legal envelope.
+ */
+export async function* convertOpenAIStreamToResponses(
+  chunks: AsyncIterable<OpenAIChunk>,
+  // Optional seed id (open question 3): the synthesizer passes the IR response id
+  // so a cache-hit's created/completed match the non-stream body; the live stream
+  // omits it and a stable synthesized `resp_*` id is reused across created…completed.
+  seedId?: string,
+): AsyncIterable<ResponsesSSEEvent> {
+  const state = createState();
+  state.responseId = seedId !== undefined && seedId !== "" ? seedId : synthResponseId();
+
+  // Unconditional prelude: an empty/zero-chunk stream still terminates cleanly.
+  yield ResponsesSSEEventSchema.parse({
+    type: "response.created",
+    sequence_number: nextSeq(state),
+    response: responseObject(state, { status: "in_progress" }),
+  });
+  yield ResponsesSSEEventSchema.parse({
+    type: "response.in_progress",
+    sequence_number: nextSeq(state),
+    response: responseObject(state, { status: "in_progress" }),
+  });
+
+  for await (const raw of chunks) {
+    const chunk = OpenAIChunkSchema.parse(raw);
+    if (state.model === "" && typeof chunk.model === "string") state.model = chunk.model;
+
+    const choice = chunk.choices?.[0];
+    const delta = choice?.delta;
+
+    // —— text: lazily open the text item + content part, then stream deltas. ——
+    if (delta?.content) {
+      if (state.textSlot === null) {
+        const outputIndex = allocOutputIndex(state);
+        const slot: TextSlot = {
+          outputIndex,
+          itemId: itemId(outputIndex),
+          started: true,
+          textBuffer: "",
+        };
+        state.textSlot = slot;
+        yield ResponsesSSEEventSchema.parse({
+          type: "response.output_item.added",
+          sequence_number: nextSeq(state),
+          output_index: slot.outputIndex,
+          item: {
+            type: "message",
+            id: slot.itemId,
+            status: "in_progress",
+            role: "assistant",
+            content: [],
+          },
+        });
+        yield ResponsesSSEEventSchema.parse({
+          type: "response.content_part.added",
+          sequence_number: nextSeq(state),
+          item_id: slot.itemId,
+          output_index: slot.outputIndex,
+          content_index: 0,
+          part: { type: "output_text", text: "" },
+        });
+      }
+      const slot = state.textSlot;
+      slot.textBuffer += delta.content;
+      yield ResponsesSSEEventSchema.parse({
+        type: "response.output_text.delta",
+        sequence_number: nextSeq(state),
+        item_id: slot.itemId,
+        output_index: slot.outputIndex,
+        content_index: 0,
+        delta: delta.content,
+      });
+    }
+
+    // —— tool calls: integer index → stable output item; temp id → real upgrade. ——
+    for (const tc of delta?.tool_calls ?? []) {
+      let slot = state.toolIndexToSlot.get(tc.index);
+      if (slot === undefined) {
+        const outputIndex = allocOutputIndex(state);
+        slot = {
+          outputIndex,
+          itemId: itemId(outputIndex),
+          started: false,
+          callId: tc.id ?? "",
+          name: tc.function?.name ?? "",
+          argBuffer: "",
+        };
+        state.toolIndexToSlot.set(tc.index, slot);
+      } else {
+        if (tc.id !== undefined && tc.id !== "") slot.callId = tc.id;
+        if (tc.function?.name !== undefined && tc.function.name !== "")
+          slot.name = tc.function.name;
+      }
+
+      const args = tc.function?.arguments;
+      if (args !== undefined && args !== "") {
+        // First argument fragment: settle id/name and emit output_item.added before
+        // any argument delta (item added ALWAYS precedes its deltas, pit #4).
+        if (!slot.started) {
+          slot.started = true;
+          yield ResponsesSSEEventSchema.parse({
+            type: "response.output_item.added",
+            sequence_number: nextSeq(state),
+            output_index: slot.outputIndex,
+            item: {
+              type: "function_call",
+              id: slot.itemId,
+              call_id: slot.callId !== "" ? slot.callId : synthCallId(slot.outputIndex),
+              name: slot.name,
+              arguments: "",
+            },
+          });
+        }
+        slot.argBuffer += args;
+        yield ResponsesSSEEventSchema.parse({
+          type: "response.function_call_arguments.delta",
+          sequence_number: nextSeq(state),
+          item_id: slot.itemId,
+          output_index: slot.outputIndex,
+          delta: args,
+        });
+      }
+    }
+
+    // Buffer usage; never billed mid-stream (pit #2). Raw upstream prompt_tokens is
+    // the FULL prompt; normalize prompt = max(0, prompt − cached) so the projection
+    // matches the non-stream toResponsesResponse path.
+    if (chunk.usage) {
+      const u = chunk.usage;
+      const cached = u.cached_tokens ?? u.prompt_tokens_details?.cached_tokens ?? 0;
+      state.usage = {
+        ...(u.prompt_tokens !== undefined
+          ? { prompt_tokens: Math.max(0, u.prompt_tokens - cached) }
+          : {}),
+        ...(u.completion_tokens !== undefined ? { completion_tokens: u.completion_tokens } : {}),
+        ...(cached > 0 ? { cached_tokens: cached } : {}),
+      };
+    }
+    if (choice?.finish_reason != null) state.finishReason = choice.finish_reason;
+  }
+
+  // —— Stream end: close the text item (text done → part done → item done). ——
+  const finalOutput: ResponsesOutputItem[] = [];
+  if (state.textSlot !== null && state.openItems.has(state.textSlot.outputIndex)) {
+    const slot = state.textSlot;
+    yield ResponsesSSEEventSchema.parse({
+      type: "response.output_text.done",
+      sequence_number: nextSeq(state),
+      item_id: slot.itemId,
+      output_index: slot.outputIndex,
+      content_index: 0,
+      text: slot.textBuffer,
+    });
+    yield ResponsesSSEEventSchema.parse({
+      type: "response.content_part.done",
+      sequence_number: nextSeq(state),
+      item_id: slot.itemId,
+      output_index: slot.outputIndex,
+      content_index: 0,
+      part: { type: "output_text", text: slot.textBuffer },
+    });
+    const item: ResponsesOutputItem = {
+      type: "message",
+      id: slot.itemId,
+      status: "in_progress",
+      role: "assistant",
+      content: [{ type: "output_text", text: slot.textBuffer }],
+    };
+    state.openItems.delete(slot.outputIndex);
+    yield ResponsesSSEEventSchema.parse({
+      type: "response.output_item.done",
+      sequence_number: nextSeq(state),
+      output_index: slot.outputIndex,
+      item,
+    });
+    finalOutput.push(item);
+  }
+
+  // —— Close each started tool item; drop empty husks. Iterate in allocation order
+  // so output ordering is deterministic. ——
+  const toolSlots = [...state.toolIndexToSlot.values()].sort(
+    (a, b) => a.outputIndex - b.outputIndex,
+  );
+  for (const slot of toolSlots) {
+    if (!slot.started) {
+      // A husk that never produced a name AND never produced an argument fragment:
+      // drop it entirely (never started, so no .added was emitted — pit #4).
+      state.openItems.delete(slot.outputIndex);
+      continue;
+    }
+    if (!state.openItems.has(slot.outputIndex)) continue;
+    const callId = slot.callId !== "" ? slot.callId : synthCallId(slot.outputIndex);
+    yield ResponsesSSEEventSchema.parse({
+      type: "response.function_call_arguments.done",
+      sequence_number: nextSeq(state),
+      item_id: slot.itemId,
+      output_index: slot.outputIndex,
+      arguments: slot.argBuffer,
+    });
+    const item: ResponsesOutputItem = {
+      type: "function_call",
+      id: slot.itemId,
+      call_id: callId,
+      name: slot.name,
+      arguments: slot.argBuffer,
+    };
+    state.openItems.delete(slot.outputIndex);
+    yield ResponsesSSEEventSchema.parse({
+      type: "response.output_item.done",
+      sequence_number: nextSeq(state),
+      output_index: slot.outputIndex,
+      item,
+    });
+    finalOutput.push(item);
+  }
+
+  // —— Terminal response.completed: status via mapResponsesStatus (cannot diverge
+  // from the non-stream path), usage flushed exactly once here. ——
+  const { status } = mapResponsesStatus(state.finishReason);
+  yield ResponsesSSEEventSchema.parse({
+    type: "response.completed",
+    sequence_number: nextSeq(state),
+    response: responseObject(state, {
+      status,
+      output: finalOutput,
+      ...(projectUsage(state.usage) !== undefined ? { usage: projectUsage(state.usage) } : {}),
+    }),
+  });
+}
+
+// —— JSON → SSE synthesizer (cache hit / non-streaming upstream). ————————————————
+
+/**
+ * Explode ONE complete IR response into the SAME deterministic event sequence a
+ * real stream would produce, so a streaming Responses client cannot tell a cache
+ * hit / a non-streaming upstream apart. Reuses `convertOpenAIStreamToResponses` by
+ * synthesizing a single-chunk feed, guaranteeing the two paths are isomorphic.
+ */
+export async function* synthesizeResponsesSSEFromJSON(
+  resp: IRResponse,
+): AsyncIterable<ResponsesSSEEvent> {
+  const choice = resp.choices[0];
+  const message = choice?.message;
+
+  const delta: NonNullable<NonNullable<OpenAIChunk["choices"]>[number]["delta"]> = {
+    role: "assistant",
+  };
+
+  const content = message?.content;
+  if (typeof content === "string") {
+    if (content !== "") delta.content = content;
+  } else if (Array.isArray(content)) {
+    const text = content
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    if (text !== "") delta.content = text;
+  }
+
+  const toolCalls = message?.tool_calls ?? [];
+  if (toolCalls.length > 0) {
+    delta.tool_calls = toolCalls.map((tc, i) => ({
+      index: i,
+      id: tc.id,
+      type: "function" as const,
+      function: { name: tc.function.name, arguments: tc.function.arguments },
+    }));
+  }
+
+  const chunk: OpenAIChunk = {
+    ...(resp.id !== undefined ? { id: resp.id } : {}),
+    ...(resp.model !== undefined ? { model: resp.model } : {}),
+    choices: [{ index: 0, delta, finish_reason: choice?.finish_reason ?? "stop" }],
+    ...(resp.usage !== undefined ? { usage: resp.usage } : {}),
+  };
+
+  async function* single(): AsyncIterable<OpenAIChunk> {
+    yield chunk;
+  }
+
+  yield* convertOpenAIStreamToResponses(single(), resp.id);
+}

--- a/packages/core/src/protocol/responses-stream.ts
+++ b/packages/core/src/protocol/responses-stream.ts
@@ -59,7 +59,7 @@ import { mapResponsesStatus } from "./responses.js";
 const ResponsesMessageItemSchema = z.object({
   type: z.literal("message"),
   id: z.string(),
-  status: z.literal("in_progress"),
+  status: z.enum(["in_progress", "completed"]),
   role: z.literal("assistant"),
   content: z.array(z.unknown()),
 });
@@ -67,6 +67,7 @@ const ResponsesMessageItemSchema = z.object({
 const ResponsesFunctionCallItemSchema = z.object({
   type: z.literal("function_call"),
   id: z.string(),
+  status: z.enum(["in_progress", "completed"]),
   call_id: z.string(),
   name: z.string(),
   arguments: z.string(),
@@ -212,11 +213,11 @@ interface StreamState {
   usage: IRUsage | null; // buffered; flushed on response.completed
 }
 
-function createState(): StreamState {
+function createState(model = "unknown"): StreamState {
   return {
     sequenceNumber: 0,
     responseId: "",
-    model: "",
+    model,
     nextOutputIndex: 0,
     openItems: new Set(),
     textSlot: null,
@@ -289,12 +290,17 @@ function responseObject(
  */
 export async function* convertOpenAIStreamToResponses(
   chunks: AsyncIterable<OpenAIChunk>,
-  // Optional seed id (open question 3): the synthesizer passes the IR response id
-  // so a cache-hit's created/completed match the non-stream body; the live stream
-  // omits it and a stable synthesized `resp_*` id is reused across created…completed.
-  seedId?: string,
+  // Optional seed: the synthesizer passes the IR response id/model so cache-hit
+  // created/completed matches the non-stream body; live streams pass request model
+  // so prelude events never expose an empty model before the first upstream chunk.
+  seed?: string | { id?: string; model?: string },
 ): AsyncIterable<ResponsesSSEEvent> {
-  const state = createState();
+  const seedId = typeof seed === "string" ? seed : seed?.id;
+  const seedModel =
+    typeof seed === "object" && seed.model !== undefined && seed.model !== ""
+      ? seed.model
+      : "unknown";
+  const state = createState(seedModel);
   state.responseId = seedId !== undefined && seedId !== "" ? seedId : synthResponseId();
 
   // Unconditional prelude: an empty/zero-chunk stream still terminates cleanly.
@@ -381,8 +387,8 @@ export async function* convertOpenAIStreamToResponses(
       }
 
       const args = tc.function?.arguments;
-      if (args !== undefined && args !== "") {
-        // First argument fragment: settle id/name and emit output_item.added before
+      if (args !== undefined || slot.name !== "") {
+        // First meaningful tool signal: settle id/name and emit output_item.added before
         // any argument delta (item added ALWAYS precedes its deltas, pit #4).
         if (!slot.started) {
           slot.started = true;
@@ -395,18 +401,21 @@ export async function* convertOpenAIStreamToResponses(
               id: slot.itemId,
               call_id: slot.callId !== "" ? slot.callId : synthCallId(slot.outputIndex),
               name: slot.name,
+              status: "in_progress",
               arguments: "",
             },
           });
         }
-        slot.argBuffer += args;
-        yield ResponsesSSEEventSchema.parse({
-          type: "response.function_call_arguments.delta",
-          sequence_number: nextSeq(state),
-          item_id: slot.itemId,
-          output_index: slot.outputIndex,
-          delta: args,
-        });
+        if (args !== undefined && args !== "") {
+          slot.argBuffer += args;
+          yield ResponsesSSEEventSchema.parse({
+            type: "response.function_call_arguments.delta",
+            sequence_number: nextSeq(state),
+            item_id: slot.itemId,
+            output_index: slot.outputIndex,
+            delta: args,
+          });
+        }
       }
     }
 
@@ -450,7 +459,7 @@ export async function* convertOpenAIStreamToResponses(
     const item: ResponsesOutputItem = {
       type: "message",
       id: slot.itemId,
-      status: "in_progress",
+      status: "completed",
       role: "assistant",
       content: [{ type: "output_text", text: slot.textBuffer }],
     };
@@ -489,6 +498,7 @@ export async function* convertOpenAIStreamToResponses(
       type: "function_call",
       id: slot.itemId,
       call_id: callId,
+      status: "completed",
       name: slot.name,
       arguments: slot.argBuffer,
     };
@@ -566,5 +576,5 @@ export async function* synthesizeResponsesSSEFromJSON(
     yield chunk;
   }
 
-  yield* convertOpenAIStreamToResponses(single(), resp.id);
+  yield* convertOpenAIStreamToResponses(single(), { id: resp.id, model: resp.model });
 }


### PR DESCRIPTION
## 做了什么

给 `/v1/responses` 加上原生 `response.*` SSE 流式 —— 它此前对 `stream:true` 直接以 400 硬拒绝。本 PR 构建了**第二套 IR→SSE 状态机**（与 Anthropic 那套并列），复用共享路由管线，并按盖戳的表面协议分流（原则 5 —— 绝不混淆表面）。

## 逐文件说明

- **`packages/core/src/protocol/responses-stream.ts`**（新增）—— `convertOpenAIStreamToResponses` 状态机：TEXT 路径（`output_item.added` → `content_part.added` → `output_text.delta*` → `output_text.done` → `content_part.done` → `output_item.done`）与 TOOL 路径（`output_item.added` → `function_call_arguments.delta*` → `.done` → `output_item.done`）。`sequence_number` 从 0 单调递增；每个 OpenAI tool index 对应稳定的 `output_index`；tool item 延迟起手直到 id/name 落定；跳过空壳；usage 缓冲、仅在 `response.completed` 刷出（坑 #2）；经 `openItems` 幂等关闭（坑 #4）；循环前无条件发 `response.created`+`response.in_progress`，因此空流也能产出合法信封。另含 `synthesizeResponsesSSEFromJSON`（缓存命中 / 非流式上游）与 `ResponsesSSEEventSchema`。终态 `status` 复用已导出的 `mapResponsesStatus`，使流式 / 非流式不可能分叉。
- **`packages/core/src/index.ts`** —— 导出这三个新符号。
- **`apps/gateway/src/routes/messages-pipeline.ts`** —— `streamIR()` 按 `protocol` 分流：`openai_responses` → Responses 机，否则 Anthropic（不变）。沿用同一个 `parseOpenAISSE` 之后的 feed + memory 累积包装。
- **`apps/gateway/src/routes/responses.ts`** —— 删除 `stream:true` 拒绝；新增 `streamSSE` 分支 + `isAbort` + `transformStreamOut`。流中 / 开流前的错误把 OpenAI 信封直接写入流（一旦开流就不再 throw→onError）；客户端断连不发错误帧（docs/02）。
- **`apps/gateway/src/middleware/error-handler.ts`** —— 抽出 `openAIErrorEnvelope()`，让 SSE 错误路径与 `handleError` 构造完全相同的信封（DRY）。
- **`apps/gateway/src/server.ts`** —— 为 responses transformer 接线 `transformStreamOut`。

## 测试（TDD 红→绿）

- **core** `responses-stream.test.ts`（14）：文本序列 / 单调 seq / delta==done / usage；tool 的 added·delta·done·item-done、稳定 output_index、丢空壳、交错；终态 `length`→`incomplete`、空流、幂等关闭；合成器 文本/tool/混合 同构。
- **pipeline** `messages-pipeline.test.ts`：`openai_responses` → `response.*`，默认仍 Anthropic（回归守护）。
- **route** `responses.test.ts`：stream:true → `text/event-stream`（无 400）；流中失败 → 恰好一个 OpenAI 错误帧；开流前 `all_providers_failed` → 单个终止帧；断连 → 不发错误帧。
- **memory** `responses.memory.test.ts`：流式 assistant 轮次在 `finally` 里经 `observeOutbound` 持久化。
- **e2e** `protocol.spec.ts`：真实 `POST /v1/responses` + `stream:true` → 有序的 `created…completed`、单调 `sequence_number`、delta 拼接 == `output_text.done`；tool-call 流 → `function_call` item + 参数 delta。

## 本地结果

- `pnpm typecheck`：**通过**（无 `any`）
- `pnpm lint`：**通过**（警告均为既有）
- `pnpm test`：**1348 通过 / 1348**
- e2e：2 个新增 Responses SSE 用例**通过**。全量套件显示 `38 通过 / 1 失败`；唯一失败是无关、既有的 `admin.spec.ts` 分页测试（断言一个 seeded-row 计数，被先跑的用例往共享临时数据目录写遥测后就会失败 —— **在 origin/main 上同样失败**，本 PR 未触碰）。

## 待定问题的决策

`sequence_number` 从 0；`response.in_progress` 总是发；response id = IR id（合成器）/ 稳定合成的 `resp_*`（实时），created==completed；usage 总在 `completed`（上游缺省则为 0）；`reasoning` 流式推迟；payload 捕获不在本 PR 范围。已记入 `implementation-notes.md`（docs/05，`protocol.responses`）。

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
