### PR TITLE
feat: OAuth 订阅类供应商 — M2M / SSO refresh (part of #38)

### DIFF
--- a/apps/gateway/e2e/fixtures/mock-upstream.ts
+++ b/apps/gateway/e2e/fixtures/mock-upstream.ts
@@ -166,6 +166,23 @@ export const EVAL_RESET_PATH = "/__eval_reset";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// —— OAuth subscription provider stand-in (e2e.oauth, issue #38) ——————————————
+// The same mock doubles as an OAuth token endpoint + a credential-checked upstream.
+//   • POST OAUTH_TOKEN_PATH → issues a fresh access token (monotonic counter so the
+//     spec can prove a refresh happened). The mock counts every token mint.
+//   • /chat/completions checks the Authorization Bearer: a request whose prompt
+//     carries OAUTH_401_ONCE_SENTINEL is answered 401 the FIRST time and 200
+//     afterwards — exercising the client's invalidate + single-retry-with-fresh-
+//     token path (the retry mints a new token, then succeeds).
+// All env-NAME-only, deterministic, offline.
+export const OAUTH_TOKEN_PATH = "/oauth/token";
+export const OAUTH_BEARER_PREFIX = "mock-oauth-access-";
+export const OAUTH_TOKEN_COUNT_PATH = "/__oauth_token_count";
+export const OAUTH_RESET_PATH = "/__oauth_reset";
+// A prompt carrying this sentinel makes the mock 401 the FIRST chat call (per
+// process), forcing the OAuth client to refresh + retry exactly once.
+export const OAUTH_401_ONCE_SENTINEL = "__HELM_OAUTH_401_ONCE__";
+
 // —— upstream request capture (e2e.protocol) —————————————————————————————————
 // The path the spec GETs to read back the LAST request the gateway forwarded
 // upstream. Lets the e2e assert the NORMALIZED (OpenAI-Chat IR) request shape
@@ -186,6 +203,12 @@ export function createMockUpstream() {
   // BEFORE any slow-path delay, so a timed-out call still counts (the spec
   // asserts a fail-open is re-called, not cached).
   let evalCallCount = 0;
+  // OAuth token mints (e2e.oauth). Incremented on every token endpoint POST so the
+  // spec can prove a refresh happened (a 401-retry mints a second token).
+  let oauthTokenCount = 0;
+  // Whether the OAuth-401-once branch has already fired in THIS process. Reset via
+  // OAUTH_RESET_PATH between spec cases.
+  let oauth401Fired = false;
 
   // Readiness probe for Playwright's webServer wait.
   app.get("/", (c) => c.text("mock upstream ok"));
@@ -198,6 +221,26 @@ export function createMockUpstream() {
     return c.json({ ok: true });
   });
 
+  // OAuth token endpoint (e2e.oauth): mint a fresh access token each call. The
+  // token id encodes the mint count so the spec / mock can prove a refresh.
+  app.post(OAUTH_TOKEN_PATH, async (c) => {
+    oauthTokenCount += 1;
+    // Drain the body (grant_type/client_id/…) so the connection closes cleanly;
+    // we never echo it (it carries the client secret / refresh token).
+    await c.req.text().catch(() => "");
+    return c.json({
+      access_token: `${OAUTH_BEARER_PREFIX}${oauthTokenCount}`,
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+  });
+  app.get(OAUTH_TOKEN_COUNT_PATH, (c) => c.json({ count: oauthTokenCount }));
+  app.post(OAUTH_RESET_PATH, (c) => {
+    oauthTokenCount = 0;
+    oauth401Fired = false;
+    return c.json({ ok: true });
+  });
+
   app.post("/chat/completions", async (c) => {
     const body = (await c.req.json()) as {
       stream?: boolean;
@@ -207,6 +250,23 @@ export function createMockUpstream() {
     const model = typeof body.model === "string" ? body.model : "mock-model";
 
     const promptText = messagesText(body);
+
+    // ── OAuth 401-once branch (e2e.oauth, issue #38): a request carrying the
+    //    sentinel is answered 401 the FIRST time, forcing the gateway's OAuth
+    //    client to invalidate + refresh + retry exactly once. The retry mints a
+    //    new token and is served normally. We also assert the Authorization header
+    //    is the mock-issued Bearer (never a plaintext static key).
+    if (promptText.includes(OAUTH_401_ONCE_SENTINEL)) {
+      const auth = c.req.header("authorization") ?? "";
+      if (!auth.startsWith(`Bearer ${OAUTH_BEARER_PREFIX}`)) {
+        return c.json({ error: { message: "missing oauth bearer" } }, 401);
+      }
+      if (!oauth401Fired) {
+        oauth401Fired = true;
+        return c.json({ error: { message: "token expired" } }, 401);
+      }
+      return c.json(echoResponse(model));
+    }
 
     // ── Layer-2 eval branch: the request is the internal classify call. We key
     //    on the eval SYSTEM-PROMPT marker ("Classify the request.", see

--- a/apps/gateway/e2e/oauth.spec.ts
+++ b/apps/gateway/e2e/oauth.spec.ts
@@ -1,0 +1,187 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hashKey } from "@helm/core";
+import { expect, test } from "@playwright/test";
+import {
+  OAUTH_401_ONCE_SENTINEL,
+  OAUTH_BEARER_PREFIX,
+  OAUTH_RESET_PATH,
+  OAUTH_TOKEN_COUNT_PATH,
+  OAUTH_TOKEN_PATH,
+} from "./fixtures/mock-upstream.js";
+
+// e2e.oauth — black-box the OAuth subscription-provider path (issue #38) over a
+// REAL in-process gateway whose PRIMARY provider authenticates via OAuth (env
+// NAMEs → token manager → dynamic per-request Bearer). The gateway is built
+// in-process here (NOT the shared Playwright webServer) so we can point a bespoke
+// OAuth config at the SAME deterministic mock upstream (port 8181) without
+// touching the shipped config. The mock is the OAuth token endpoint AND the
+// credential-checked chat upstream; a sentinel prompt makes it 401 once so we can
+// observe the invalidate + single-retry-with-fresh-token path.
+
+const MOCK = "http://127.0.0.1:8181";
+const TEST_KEY = "helm_live_oauth_e2e";
+const AUTH = { Authorization: `Bearer ${TEST_KEY}`, "Content-Type": "application/json" };
+
+// biome-ignore lint/suspicious/noExplicitAny: Hono app handle from buildServer
+let app: { fetch: (req: Request) => Promise<Response> } | null = null;
+let dataDir = "";
+let configDir = "";
+
+function writeConfig(dir: string): void {
+  writeFileSync(join(dir, "server.yaml"), "host: 127.0.0.1\nport: 8099\nbase_path: /\n");
+  writeFileSync(
+    join(dir, "auth.yaml"),
+    "require_api_key: true\nbootstrap:\n  generate_if_missing: false\n  persist_to: ./oauth-keys.json\n  print_once: false\n",
+  );
+  writeFileSync(
+    join(dir, "runtime.yaml"),
+    "max_request_bytes: 2000000\nrequest_timeout_ms: 60000\nrate_limit:\n  enabled: false\n  default:\n    rpm: 0\n    tpm: 0\n",
+  );
+  // PRIMARY provider authenticates via OAuth (env NAMEs only). base_url is
+  // overridden by HELM_PROVIDER_BASE_URL at boot to point at the mock; token_url
+  // points directly at the mock's token endpoint.
+  writeFileSync(
+    join(dir, "providers.yaml"),
+    [
+      "providers:",
+      "  - name: oauth-primary",
+      "    type: openai",
+      `    base_url: ${MOCK}`,
+      "    oauth:",
+      "      grant: refresh_token",
+      `      token_url: ${MOCK}${OAUTH_TOKEN_PATH}`,
+      "      client_id_env: OAUTH_E2E_CLIENT_ID",
+      "      client_secret_env: OAUTH_E2E_CLIENT_SECRET",
+      "      refresh_token_env: OAUTH_E2E_REFRESH_TOKEN",
+      "",
+    ].join("\n"),
+  );
+}
+
+test.beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), "helm-oauth-data-"));
+  configDir = mkdtempSync(join(tmpdir(), "helm-oauth-cfg-"));
+  writeConfig(configDir);
+
+  // OAuth secrets (env NAMEs resolved here at the composition root, principle 7).
+  process.env.OAUTH_E2E_CLIENT_ID = "cid-e2e";
+  process.env.OAUTH_E2E_CLIENT_SECRET = "csecret-e2e";
+  process.env.OAUTH_E2E_REFRESH_TOKEN = "rtok-e2e";
+  process.env.HELM_DATA_DIR = dataDir;
+  process.env.HELM_PROVIDER_BASE_URL = MOCK;
+  process.env.HELM_SIGNALS_DISABLED = "1";
+
+  // Seed the deterministic API key directly so the gateway never has to bootstrap.
+  const { createSqliteDb, SqliteKeyStore } = await import("@helm/core");
+  const db = createSqliteDb(join(dataDir, "helm.db"));
+  const keyStore = new SqliteKeyStore(db);
+  await keyStore.createKey({
+    keyId: "k_oauth_e2e",
+    hash: hashKey(TEST_KEY),
+    prefix: "helm_live_oauth",
+    accountId: "acct_oauth",
+    role: "root",
+  });
+  (db as unknown as { $sqlite: { close: () => void } }).$sqlite.close();
+
+  const { buildServer } = await import("../src/server.js");
+  const handle = await buildServer({ configDir });
+  app = handle.app as unknown as { fetch: (req: Request) => Promise<Response> };
+
+  // Reset mock OAuth counters for a clean run.
+  await fetch(`${MOCK}${OAUTH_RESET_PATH}`, { method: "POST" });
+});
+
+test.afterAll(() => {
+  for (const k of [
+    "OAUTH_E2E_CLIENT_ID",
+    "OAUTH_E2E_CLIENT_SECRET",
+    "OAUTH_E2E_REFRESH_TOKEN",
+    "HELM_PROVIDER_BASE_URL",
+    "HELM_DATA_DIR",
+    "HELM_SIGNALS_DISABLED",
+  ]) {
+    delete process.env[k];
+  }
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+});
+
+function chat(content: string, extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content }],
+    stream: false,
+    ...extra,
+  });
+}
+
+test("routes an OpenAI request through an OAuth provider with a fetched Bearer", async () => {
+  expect(app).not.toBeNull();
+  const res = await app!.fetch(
+    new Request("http://local/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: chat("Say hi."),
+    }),
+  );
+  expect(res.status).toBe(200);
+  // The mock minted at least one token (the gateway fetched a Bearer to call it).
+  const count = await fetch(`${MOCK}${OAUTH_TOKEN_COUNT_PATH}`).then((r) => r.json());
+  expect((count as { count: number }).count).toBeGreaterThanOrEqual(1);
+});
+
+test("refreshes + retries once on an upstream 401 and succeeds", async () => {
+  expect(app).not.toBeNull();
+  await fetch(`${MOCK}${OAUTH_RESET_PATH}`, { method: "POST" });
+  const res = await app!.fetch(
+    new Request("http://local/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: chat(`Trigger one 401 then succeed ${OAUTH_401_ONCE_SENTINEL}`),
+    }),
+  );
+  // First upstream call 401s → client invalidates, mints a fresh token, retries
+  // once → 200. The end-to-end success ALONE proves the refresh+retry fired: the
+  // mock only serves this prompt after it has 401'd once, and the retry must carry
+  // a fresh mock-issued Bearer (the 401 branch rejects a missing/stale prefix).
+  expect(res.status).toBe(200);
+  const count = (await fetch(`${MOCK}${OAUTH_TOKEN_COUNT_PATH}`).then((r) => r.json())) as {
+    count: number;
+  };
+  // The invalidate() forced at least one fresh mint AFTER the reset above.
+  expect(count.count).toBeGreaterThanOrEqual(1);
+});
+
+test("streams through an OAuth provider end-to-end", async () => {
+  expect(app).not.toBeNull();
+  const res = await app!.fetch(
+    new Request("http://local/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: chat("Stream please.", { stream: true }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  const text = await res.text();
+  // The mock SSE stream ends with [DONE]; the bytes must flow through intact.
+  expect(text).toContain("data:");
+  expect(text).toContain("[DONE]");
+});
+
+test("never leaks the OAuth Bearer prefix into the response body", async () => {
+  // Defense-in-depth sanity: the dynamic Bearer lives in the Authorization header,
+  // never in the chat body (principle 7). The echoed mock body must not carry it.
+  expect(app).not.toBeNull();
+  const res = await app!.fetch(
+    new Request("http://local/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: chat("plain"),
+    }),
+  );
+  const text = await res.text();
+  expect(text).not.toContain(OAUTH_BEARER_PREFIX);
+});

--- a/apps/gateway/src/routes/execute.default-config.test.ts
+++ b/apps/gateway/src/routes/execute.default-config.test.ts
@@ -162,6 +162,10 @@ function stubProvider(): { client: ProviderClient; calls: string[] } {
   return { client, calls };
 }
 
+function providerClients(client: ProviderClient): Map<string, ProviderClient> {
+  return new Map(config.providers.map((p) => [p.name, client]));
+}
+
 describe("default config activates capability filter + cost (alias-namespace alignment)", () => {
   it("sanity: the shipped catalog is keyed by the SAME provider/model aliases the lanes use", () => {
     // Pre-alignment these were absent (lane aliases like `cheap_model` had no
@@ -178,6 +182,7 @@ describe("default config activates capability filter + cost (alias-namespace ali
     const registry = buildRegistry();
     const execute = createExecute({
       defaultProvider: client,
+      providers: providerClients(client),
       registry,
       breaker: breaker(),
       catalog,
@@ -208,6 +213,7 @@ describe("default config activates capability filter + cost (alias-namespace ali
     const { client } = stubProvider();
     const execute = createExecute({
       defaultProvider: client,
+      providers: providerClients(client),
       registry: buildRegistry(),
       breaker: breaker(),
       catalog,
@@ -237,6 +243,7 @@ describe("default config activates capability filter + cost (alias-namespace ali
     const { client, calls } = stubProvider();
     const execute = createExecute({
       defaultProvider: client,
+      providers: providerClients(client),
       registry: buildRegistry(),
       breaker: breaker(),
       catalog,
@@ -263,6 +270,7 @@ describe("default config activates capability filter + cost (alias-namespace ali
     const { client } = stubProvider();
     const execute = createExecute({
       defaultProvider: client,
+      providers: providerClients(client),
       registry: buildRegistry(),
       breaker: breaker(),
       catalog,

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -98,6 +98,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ default_good_model: "gpt-x" }),
       breaker: breaker(),
       catalog: new Map(),
@@ -121,6 +122,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: breaker(),
       catalog: new Map(),
@@ -150,6 +152,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: breaker(),
       catalog: new Map(),
@@ -177,6 +180,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a" }),
       breaker: breaker(),
       catalog: new Map(),
@@ -199,6 +203,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: breaker(),
       catalog: new Map(),
@@ -233,6 +238,7 @@ describe("createExecute — gateway execution adapter", () => {
     };
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: breaker(),
       catalog: new Map([["a", noTools]]),
@@ -254,6 +260,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a" }),
       breaker: breaker(),
       catalog: new Map(),
@@ -288,6 +295,7 @@ describe("createExecute — gateway execution adapter", () => {
     const logs: Array<{ level: string; msg: string; fields: Record<string, unknown> }> = [];
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a" }),
       breaker: cb,
       catalog: new Map(),
@@ -447,6 +455,35 @@ describe("createExecute — gateway execution adapter", () => {
     }
   });
 
+  it("does not fall back to default when a resolved provider has no client and providers are omitted", async () => {
+    const defaultProvider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "default" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider,
+      registry: registryWithProviders({
+        oauth_alias: { providerName: "oauth-sub", providerModel: "gpt-sub" },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["oauth_alias"]), req());
+    expect(defaultProvider.chatCompletion).not.toHaveBeenCalled();
+    expect(out.attempts[0]).toMatchObject({
+      alias: "oauth_alias",
+      skipped: true,
+      skip_reason: "provider_unavailable",
+    });
+    expect(out.final.status).toBe("error");
+    if (out.final.status === "error") {
+      expect(out.final.error.error_class).toBe("all_providers_failed");
+    }
+  });
+
   it("treats a client abort as a non-provider fault (no all_providers_failed)", async () => {
     const ac = new AbortController();
     const abortErr = new Error("aborted");
@@ -459,6 +496,7 @@ describe("createExecute — gateway execution adapter", () => {
     const recordFailure = vi.spyOn(cb, "recordFailure");
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a" }),
       breaker: cb,
       catalog: new Map(),
@@ -491,6 +529,7 @@ describe("createExecute — gateway execution adapter", () => {
     const recordFailure = vi.spyOn(cb, "recordFailure");
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ "free-model:free": "m-free", paid: "m-paid" }),
       breaker: cb,
       catalog: new Map(),
@@ -521,6 +560,7 @@ describe("createExecute — gateway execution adapter", () => {
     const recordFailure = vi.spyOn(cb, "recordFailure");
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ "free-model:free": "m-free", b: "m-b" }),
       breaker: cb,
       catalog: new Map(),
@@ -553,6 +593,7 @@ describe("createExecute — gateway execution adapter", () => {
     const recordFailure = vi.spyOn(cb, "recordFailure");
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: cb,
       catalog: new Map(),
@@ -582,6 +623,7 @@ describe("createExecute — gateway execution adapter", () => {
     const recordFailure = vi.spyOn(cb, "recordFailure");
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: cb,
       catalog: new Map(),
@@ -624,6 +666,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: breaker(),
       // Catalog is keyed by the candidate ALIAS (the modelKey), not the resolved
@@ -653,6 +696,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ text: "m-text", vis: "m-vis" }),
       breaker: breaker(),
       catalog: new Map([
@@ -682,6 +726,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: breaker(),
       catalog: new Map([
@@ -713,6 +758,7 @@ describe("createExecute — gateway execution adapter", () => {
     // over-prune) rather than declaring capability_unsatisfiable.
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", u: "m-unknown" }),
       breaker: breaker(),
       catalog: new Map([["a", entry("a", { supportsJsonMode: false })]]),
@@ -755,6 +801,7 @@ describe("createExecute — gateway execution adapter", () => {
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ good: "gpt-4o" }),
       breaker: breaker(),
       catalog: new Map([["good", priced("good", { inputPerMTokUsd: 2.5, outputPerMTokUsd: 10 })]]),
@@ -777,6 +824,7 @@ describe("createExecute — gateway execution adapter", () => {
     // Catalog has NO entry for the resolved model → pricing unknown → null.
     const execute = createExecute({
       defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
       registry: registry({ unknown_model: "m-unpriced" }),
       breaker: breaker(),
       catalog: new Map(),

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -51,6 +51,28 @@ function registry(map: Record<string, string>): ProviderRegistry {
   };
 }
 
+function registryWithProviders(
+  map: Record<string, { providerName: string; providerModel: string }>,
+): ProviderRegistry {
+  return {
+    resolve(alias: string) {
+      const hit = map[alias];
+      if (hit === undefined) return { ok: false, error: { kind: "unknown_alias", alias } };
+      return {
+        ok: true,
+        value: {
+          alias,
+          providerName: hit.providerName,
+          providerModel: hit.providerModel,
+          baseUrl: "http://x",
+          apiKeyEnv: "X",
+        },
+      };
+    },
+    list: () => Object.keys(map),
+  };
+}
+
 function plan(chain: string[]): ExecutionPlan {
   return { selected_lane: "balanced", candidate_chain: chain, explicit_model: null };
 }
@@ -393,6 +415,36 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.final.status).toBe("ok");
     expect(out.body).toEqual({ id: "default" });
     expect(defaultProvider.chatCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fall back to default when a resolved provider has no client", async () => {
+    const defaultProvider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "default" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider,
+      providers: new Map(),
+      registry: registryWithProviders({
+        oauth_alias: { providerName: "oauth-sub", providerModel: "gpt-sub" },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["oauth_alias"]), req());
+    expect(defaultProvider.chatCompletion).not.toHaveBeenCalled();
+    expect(out.attempts[0]).toMatchObject({
+      alias: "oauth_alias",
+      skipped: true,
+      skip_reason: "provider_unavailable",
+    });
+    expect(out.final.status).toBe("error");
+    if (out.final.status === "error") {
+      expect(out.final.error.error_class).toBe("all_providers_failed");
+    }
   });
 
   it("treats a client abort as a non-provider fault (no all_providers_failed)", async () => {

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -485,6 +485,36 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.final.status).toBe("ok");
   });
 
+  it("classifies a persistent upstream 401 as auth_error and records exactly one breaker failure", async () => {
+    // OAuth (issue #38): the client already retried once with a fresh token before
+    // surfacing this 401, so the executor sees a single failure. It must classify
+    // the attempt as `auth_error` (D5) and record EXACTLY one breaker failure (D6 —
+    // no extra executor branch / no double-count), then advance the chain.
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(new UpstreamError("upstream_error", "401", null, 401))
+        .mockResolvedValueOnce({ id: "second" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      registry: registry({ a: "m-a", b: "m-b" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["a", "b"]), req());
+    expect(out.attempts[0]?.error_class).toBe("auth_error");
+    expect(recordFailure).toHaveBeenCalledTimes(1);
+    expect(recordFailure).toHaveBeenCalledWith("a");
+    expect(out.final.status).toBe("ok");
+  });
+
   it("does NOT treat a generic 'aborted' message as a client abort (only signal/name)", async () => {
     // Over-broad heuristic fix: an upstream error whose message merely contains
     // 'aborted' must be a normal provider failure (breaker.recordFailure), NOT a

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -98,7 +98,16 @@ function upstreamStatusOf(err: unknown): number | null {
 }
 
 function errorClassOf(err: unknown): string {
-  if (err instanceof UpstreamError) return err.errorClass;
+  if (err instanceof UpstreamError) {
+    // OAuth (issue #38, D5): a persistent upstream 401 — the client already
+    // refreshed + retried once — is an authentication failure, not a generic
+    // upstream error. Classify it as `auth_error` (an existing ErrorClass) so the
+    // decision record / client error reflects the real cause. This is a pure
+    // relabel at the existing classification chokepoint; breaker counting and
+    // chain advancement are unchanged (D6 — no new executor branch).
+    if (err.upstreamStatus === 401) return "auth_error";
+    return err.errorClass;
+  }
   return "upstream_error";
 }
 

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -37,8 +37,9 @@ export interface ExecuteAdapterDeps {
    *  (Phase-0 single-provider passthrough). */
   defaultProvider: ProviderClient;
   /** Per-provider clients keyed by provider NAME (registry providerName). When a
-   *  candidate resolves to one of these, its client is used → chains cross
-   *  providers. Optional: absent/empty => everything uses defaultProvider. */
+   *  candidate resolves to one of these, its client is used -> chains cross
+   *  providers. Missing clients fail closed; defaultProvider is only for unknown
+   *  aliases in Phase-0 passthrough. */
   providers?: Map<string, ProviderClient>;
   registry: ProviderRegistry;
   breaker: CircuitBreaker;
@@ -207,11 +208,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       // default would cross credential/subscription boundaries.
       const resolved = registry.resolve(alias);
       const providerModel = resolved.ok ? resolved.value.providerModel : alias;
-      const provider = resolved.ok
-        ? providers
-          ? providers.get(resolved.value.providerName)
-          : defaultProvider
-        : defaultProvider;
+      const provider = resolved.ok ? providers?.get(resolved.value.providerName) : defaultProvider;
       if (!provider) {
         attempts.push(skipRow(alias, "provider_unavailable", elapsed()));
         continue;

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -23,9 +23,9 @@ import { makeHelmError } from "@helm/shared";
 // Multi-provider (providers-multi): each candidate alias resolves (via registry)
 // to a provider name + upstream model id. The executor invokes THAT provider's
 // client — so a fallback chain like [deepseek/.., openai/..] hits two different
-// upstreams in order. When the alias is unknown to the registry, or no client is
-// registered for the resolved provider, it falls back to `defaultProvider` (the
-// Phase-0 single-provider passthrough: lane aliases map 1:1 to the one upstream).
+// upstreams in order. Unknown aliases still fall back to `defaultProvider` for
+// Phase-0 passthrough; a resolved provider with no registered client is skipped
+// fail-closed, never silently served with another provider's credential.
 //
 // Streaming (principle 8): for stream:true the provider stream is forwarded
 // UNBUFFERED. We peek the FIRST chunk to decide success vs. pre-first-chunk
@@ -33,8 +33,8 @@ import { makeHelmError } from "@helm/shared";
 // re-emits that first chunk followed by the rest — byte-for-byte, in order.
 
 export interface ExecuteAdapterDeps {
-  /** Default/fallback provider client: used for an unknown alias OR a resolved
-   *  provider with no registered client (Phase-0 single-provider passthrough). */
+  /** Default/fallback provider client: used only for unknown aliases
+   *  (Phase-0 single-provider passthrough). */
   defaultProvider: ProviderClient;
   /** Per-provider clients keyed by provider NAME (registry providerName). When a
    *  candidate resolves to one of these, its client is used → chains cross
@@ -202,12 +202,20 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       // An unknown alias is a config gap: keep the alias as the upstream model id
       // too and use the default provider (fail-open — never substitute a different
       // model silently). A resolved alias selects BOTH the upstream model id AND
-      // the provider client (so the fallback chain can cross providers). When the
-      // resolved provider has no registered client, fall back to the default too.
+      // the provider client (so the fallback chain can cross providers). If that
+      // resolved provider has no client, skip fail-closed; falling back to the
+      // default would cross credential/subscription boundaries.
       const resolved = registry.resolve(alias);
       const providerModel = resolved.ok ? resolved.value.providerModel : alias;
-      const provider =
-        (resolved.ok ? providers?.get(resolved.value.providerName) : undefined) ?? defaultProvider;
+      const provider = resolved.ok
+        ? providers
+          ? providers.get(resolved.value.providerName)
+          : defaultProvider
+        : defaultProvider;
+      if (!provider) {
+        attempts.push(skipRow(alias, "provider_unavailable", elapsed()));
+        continue;
+      }
 
       // 1) Circuit breaker gate (keyed by alias — the routing unit).
       const gate = breaker.canAttempt(alias);

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1,0 +1,131 @@
+import type { ProviderConfig as ProviderConfigShared } from "@helm/shared";
+import { ProviderConfigSchema } from "@helm/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildCredential, buildProviderClients } from "./server.js";
+
+// Compose a validated shared ProviderConfig (so tests exercise the real schema
+// shape, not a hand-rolled object). Parse never fails for these fixtures.
+function provider(raw: Record<string, unknown>): ProviderConfigShared {
+  return ProviderConfigSchema.parse(raw);
+}
+
+const OAUTH_PROVIDER = provider({
+  name: "claude-sub",
+  type: "openai",
+  base_url: "https://oauth.example.com/v1",
+  oauth: {
+    grant: "refresh_token",
+    token_url: "https://oauth.example.com/token",
+    client_id_env: "OA_CLIENT_ID",
+    client_secret_env: "OA_CLIENT_SECRET",
+    refresh_token_env: "OA_REFRESH_TOKEN",
+  },
+  models: [{ alias: "claude-sub/opus", provider_model: "claude-opus" }],
+});
+
+const KEY_PROVIDER = provider({
+  name: "openai",
+  type: "openai",
+  base_url: "https://api.openai.com/v1",
+  api_key_env: "OPENAI_API_KEY",
+  models: [{ alias: "openai/gpt", provider_model: "gpt-4o" }],
+});
+
+const OAUTH_ENV = {
+  OA_CLIENT_ID: "cid",
+  OA_CLIENT_SECRET: "csecret",
+  OA_REFRESH_TOKEN: "rtok",
+};
+
+function setEnv(env: Record<string, string>): string[] {
+  const keys: string[] = [];
+  for (const [k, v] of Object.entries(env)) {
+    process.env[k] = v;
+    keys.push(k);
+  }
+  return keys;
+}
+
+const ADDED_KEYS: string[] = [];
+afterEach(() => {
+  for (const k of ADDED_KEYS.splice(0)) delete process.env[k];
+  vi.restoreAllMocks();
+});
+
+describe("buildCredential (issue #38 OAuth wiring)", () => {
+  it("returns a static apiKey credential when api_key_env is set", () => {
+    ADDED_KEYS.push(...setEnv({ OPENAI_API_KEY: "sk-static" }));
+    const cred = buildCredential(KEY_PROVIDER);
+    expect(cred).toEqual({ apiKey: "sk-static" });
+  });
+
+  it("returns null when a key provider's env is unset (fail-open at caller)", () => {
+    const cred = buildCredential(KEY_PROVIDER);
+    expect(cred).toBeNull();
+  });
+
+  it("builds a dynamic OAuth credential when all secrets are present", () => {
+    ADDED_KEYS.push(...setEnv(OAUTH_ENV));
+    const cred = buildCredential(OAUTH_PROVIDER);
+    expect(cred).not.toBeNull();
+    if (cred && "getAuthHeader" in cred) {
+      expect(typeof cred.getAuthHeader).toBe("function");
+      expect(typeof cred.onUnauthorized).toBe("function");
+      expect(typeof cred.currentSecrets).toBe("function");
+    } else {
+      throw new Error("expected a dynamic OAuth credential");
+    }
+  });
+
+  it("returns null when a required OAuth secret env is unset (fail-open)", () => {
+    ADDED_KEYS.push(...setEnv({ OA_CLIENT_ID: "cid", OA_CLIENT_SECRET: "csecret" }));
+    // refresh_token_env missing for a refresh_token grant → cannot build.
+    const cred = buildCredential(OAUTH_PROVIDER);
+    expect(cred).toBeNull();
+  });
+});
+
+describe("buildProviderClients (issue #38 OAuth wiring)", () => {
+  it("builds an OAuth client that requests with a fetched Bearer", async () => {
+    ADDED_KEYS.push(...setEnv(OAUTH_ENV));
+    // Intercept BOTH the token endpoint and the chat endpoint.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/token")) {
+          return new Response(JSON.stringify({ access_token: "fetched-at", expires_in: 3600 }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ id: "ok" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+    const clients = buildProviderClients([OAUTH_PROVIDER], "https://fallback/v1", 60_000);
+    const client = clients.get("claude-sub");
+    expect(client).toBeDefined();
+    await client?.chatCompletion({ model: "m" });
+    // Find the chat call and assert it carried the fetched Bearer.
+    const chatCall = fetchSpy.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("/chat/completions"),
+    );
+    expect(chatCall).toBeDefined();
+    const init = chatCall?.[1] as RequestInit & { headers: Record<string, string> };
+    expect(init.headers.Authorization).toBe("Bearer fetched-at");
+  });
+
+  it("skips an OAuth provider whose secret is unset but keeps the others (fail-open)", () => {
+    ADDED_KEYS.push(...setEnv({ OPENAI_API_KEY: "sk-static" }));
+    // OAUTH_ENV intentionally NOT set → the OAuth provider is skipped.
+    const clients = buildProviderClients(
+      [KEY_PROVIDER, OAUTH_PROVIDER],
+      "https://fallback/v1",
+      60_000,
+    );
+    expect(clients.has("openai")).toBe(true);
+    expect(clients.has("claude-sub")).toBe(false);
+  });
+});

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -11,6 +11,7 @@ import {
   createRateLimiter,
   createSignalCollector,
   createStore,
+  createTokenManager,
   DEFAULT_LANES,
   generateKey,
   hashKey,
@@ -107,7 +108,10 @@ function buildRegistry(
   providers: ReadonlyArray<ProviderConfigShared>,
   primaryName: string,
   primaryBaseUrl: string,
-  primaryApiKeyEnv: string,
+  // OPTIONAL (issue #38): an OAuth primary has no api_key_env. The registry never
+  // reads this to fetch a credential (the per-name client is pre-built), so the
+  // back-fill entry stores "" when absent.
+  primaryApiKeyEnv: string | undefined,
   lanes: LanesConfig,
   fallbackBaseUrl: string,
 ) {
@@ -133,32 +137,84 @@ function buildRegistry(
     cfgs.push({
       name: primaryName,
       base_url: primaryBaseUrl,
-      api_key_env: primaryApiKeyEnv,
+      api_key_env: primaryApiKeyEnv ?? "", // OAuth primary has none; registry never reads it
       models: [...backfill].map((alias) => ({ alias, provider_model: alias })),
     });
   }
   return createProviderRegistry(cfgs);
 }
 
+// A resolved provider credential, ready to splice into a ProviderConfig. Either a
+// static `apiKey` (key path) or the dynamic OAuth trio (getAuthHeader / on401 /
+// currentSecrets). The env→plaintext resolution happens HERE (composition root,
+// principle 7); core never sees an env var name.
+type ProviderCredential =
+  | { apiKey: string }
+  | {
+      getAuthHeader: () => Promise<string>;
+      onUnauthorized: () => void;
+      currentSecrets: () => string[];
+    };
+
+// Resolve a provider's credential from env (issue #38). Returns null when a
+// required secret env is unset — the caller decides fail-open (skip a non-primary
+// provider, mirroring the old `if (!apiKey) continue`) vs fail-closed (throw for
+// the primary). Each OAuth provider gets ONE process-level TokenManager (1:1 with
+// its client), shared across all requests — lazy refresh, no background timer.
+// Exported for unit tests (server.oauth.test.ts); not part of the public API.
+export function buildCredential(p: ProviderConfigShared): ProviderCredential | null {
+  if (p.oauth) {
+    const o = p.oauth;
+    const clientId = process.env[o.client_id_env];
+    const clientSecret = process.env[o.client_secret_env];
+    const refreshToken = o.refresh_token_env ? process.env[o.refresh_token_env] : undefined;
+    // Any REQUIRED secret unset → cannot build (fail-open at the caller).
+    if (!clientId || !clientSecret) return null;
+    if (o.grant === "refresh_token" && !refreshToken) return null;
+    const tm = createTokenManager({
+      oauth: {
+        grant: o.grant,
+        tokenUrl: o.token_url,
+        clientId,
+        clientSecret,
+        refreshToken,
+        scopes: o.scopes,
+        audience: o.audience,
+      },
+      now: () => Date.now(),
+    });
+    return {
+      getAuthHeader: () => tm.getAuthHeader(),
+      onUnauthorized: () => tm.invalidate(),
+      currentSecrets: () => tm.currentSecrets(),
+    };
+  }
+  // Static key path: env var NAME → plaintext key (or null when unset).
+  const apiKey = p.api_key_env ? process.env[p.api_key_env] : undefined;
+  if (!apiKey) return null;
+  return { apiKey };
+}
+
 // Build one OpenAI-compatible client per configured provider, keyed by provider
 // NAME, so the executor can dispatch each resolved candidate to the right
-// upstream (cross-provider fallback). Credentials come ONLY from the env var each
-// provider's api_key_env points at (principle 7 — never plaintext in config). A
-// provider whose credential env is unset is SKIPPED (it cannot be invoked); its
-// aliases will fail open at resolve/execute time rather than blocking startup of
-// the others. The PRIMARY provider's missing credential is still fatal (handled
-// by the caller) since it backs the default path.
-function buildProviderClients(
+// upstream (cross-provider fallback). Credentials come ONLY from env (principle 7
+// — never plaintext in config), resolved by buildCredential (static key OR OAuth
+// token manager). A provider whose required credential env is unset is SKIPPED (it
+// cannot be invoked); its aliases will fail open at resolve/execute time rather
+// than blocking startup of the others. The PRIMARY provider's missing credential
+// is still fatal (handled by the caller) since it backs the default path.
+// Exported for unit tests (server.oauth.test.ts); not part of the public API.
+export function buildProviderClients(
   providers: ReadonlyArray<ProviderConfigShared>,
   fallbackBaseUrl: string,
   timeoutMs: number,
 ): Map<string, ProviderClient> {
   const clients = new Map<string, ProviderClient>();
   for (const p of providers) {
-    const apiKey = process.env[p.api_key_env];
-    if (!apiKey) continue; // no credential → cannot build a client; skip.
+    const cred = buildCredential(p);
+    if (!cred) continue; // no credential → cannot build a client; skip.
     const baseUrl = p.base_url ?? fallbackBaseUrl;
-    clients.set(p.name, createOpenAIClient({ config: { baseUrl, apiKey, timeoutMs } }));
+    clients.set(p.name, createOpenAIClient({ config: { baseUrl, timeoutMs, ...cred } }));
   }
   return clients;
 }
@@ -282,16 +338,23 @@ export async function buildServer(
   // the shared fallback base_url when a provider omits one).
   const first = config.providers[0];
   if (!first) throw new Error("no provider configured");
-  const apiKey = process.env[first.api_key_env];
-  if (!apiKey) throw new Error(`missing provider credential env: ${first.api_key_env}`);
+  // Primary credential is MANDATORY (fail-closed, principle 2): it backs the
+  // default/eval/passthrough path. Static key OR OAuth — buildCredential returns
+  // null only when a required secret env is unset, which is fatal for the primary.
+  const primaryCred = buildCredential(first);
+  if (!primaryCred) {
+    throw new Error(`missing provider credential for primary provider ${first.name}`);
+  }
   // HELM_PROVIDER_BASE_URL (test/e2e) overrides EVERY provider's base_url so the
   // mock upstream serves all of them; otherwise each provider uses its own.
   const baseUrlOverride = process.env.HELM_PROVIDER_BASE_URL;
   const fallbackBaseUrl = baseUrlOverride ?? "https://api.openai.com/v1";
   const baseUrl = baseUrlOverride ?? first.base_url ?? fallbackBaseUrl;
   const timeoutMs = config.runtime.request_timeout_ms;
-  const providerConfig: ProviderConfig = { baseUrl, apiKey, timeoutMs };
-  // The default/primary client (eval + passthrough + back-fill aliases).
+  const providerConfig: ProviderConfig = { baseUrl, timeoutMs, ...primaryCred };
+  // The default/primary client (eval + passthrough + back-fill aliases). When the
+  // primary is OAuth, this SAME dynamic-header client backs the eval/classify path
+  // below, so eval auth never silently fails (acceptance criterion 9).
   const provider = createOpenAIClient({ config: providerConfig });
   // Per-provider clients keyed by provider NAME. When HELM_PROVIDER_BASE_URL is
   // set (test/e2e), force the override so cross-provider candidates still hit the

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -102,3 +102,50 @@ providers:
       # last-resort tail fallback shared by every lane.
       - alias: openrouter/auto
         provider_model: openrouter/auto
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # OAUTH SUBSCRIPTION PROVIDER (issue #38) — EXAMPLE, COMMENTED OUT.
+  # For subscription / SSO upstreams that issue SHORT-LIVED OAuth access tokens
+  # (Claude/ChatGPT subscriptions, enterprise SSO gateways), reference an `oauth`
+  # block INSTEAD of `api_key_env`. Helm refreshes the token NON-INTERACTIVELY and
+  # injects a dynamic Bearer per request. A provider must carry EXACTLY ONE of
+  # `api_key_env` or `oauth` (fail-closed otherwise; principle 2).
+  #
+  # SECURITY (principle 7): every field below is an env var NAME — NEVER a plaintext
+  # client id / secret / token. Set the actual values in the environment:
+  #   PROVIDER_X_CLIENT_ID, PROVIDER_X_CLIENT_SECRET, PROVIDER_X_REFRESH_TOKEN.
+  #
+  # KNOWN LIMITATION (v1, see implementation-notes D3): the token cache is IN-MEMORY
+  # only. A provider that ROTATES refresh tokens on each refresh will lose the
+  # rotated token on a process restart; Helm then re-derives from the env value,
+  # which fails if the upstream already retired it. A persistent TokenStore is a
+  # follow-up. The interactive authorization_code (browser) flow is OUT OF SCOPE.
+  #
+  # - name: claude-subscription
+  #   type: openai
+  #   base_url: https://example-subscription.test/v1
+  #   oauth:
+  #     grant: refresh_token            # refresh_token (default) | client_credentials
+  #     token_url: https://example-subscription.test/oauth/token
+  #     client_id_env: PROVIDER_X_CLIENT_ID
+  #     client_secret_env: PROVIDER_X_CLIENT_SECRET
+  #     refresh_token_env: PROVIDER_X_REFRESH_TOKEN   # required for refresh_token grant
+  #     scopes: []                      # optional OAuth scopes
+  #     # audience: https://example-subscription.test/api   # optional
+  #   models:
+  #     - alias: claude-subscription/opus
+  #       provider_model: claude-opus
+  #
+  # client_credentials variant (machine-to-machine; no refresh_token needed):
+  # - name: sso-gateway
+  #   type: openai
+  #   base_url: https://sso.example.test/v1
+  #   oauth:
+  #     grant: client_credentials
+  #     token_url: https://sso.example.test/oauth/token
+  #     client_id_env: SSO_CLIENT_ID
+  #     client_secret_env: SSO_CLIENT_SECRET
+  #     scopes: ["models.read"]
+  #   models:
+  #     - alias: sso-gateway/default
+  #       provider_model: default-model

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -53,6 +53,14 @@ Verified against the code and `implementation-notes.md`:
   [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md).
 - **Agentic Signals feedback layer.** The store ports and the redacted
   `RoutingSignal` shape exist, but nothing reads signals back into routing yet.
+- **OAuth subscription providers (added past 0.1, issue #38).** Net-new scope not
+  in the original roadmap. A provider may now reference an `oauth` block instead of
+  `api_key_env`; Helm refreshes the token **non-interactively** (`refresh_token` /
+  `client_credentials`) and injects a dynamic Bearer per request, with a single
+  refresh-on-401 retry. **Deferred within this feature**: the interactive
+  `authorization_code` (browser) flow, and a **persistent token store** (the v1
+  cache is in-memory, so a rotating refresh token is lost on restart — see
+  `implementation-notes.md` D3). See `config/providers.yaml` for the example block.
 
 ## Success criteria (met by 0.1)
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,30 @@
 
 ---
 
+## 2026-06-02 · OAuth subscription providers (issue #38, docs/02/05/07, Principles 1/2/3/7/8)
+
+**Context**: Helm only supported static API keys (env-var NAME references) as upstream credentials. Subscription/SSO providers (Claude/ChatGPT subscriptions, enterprise SSO gateways) hand out short-lived OAuth access tokens that expire and rotate. This change makes the upstream auth header **dynamic, per-request** so Helm can refresh non-interactively and inject a fresh Bearer.
+
+**What was added**:
+- `packages/shared/src/config/schema.ts` — `OAuthConfigSchema` (env-NAME-only: `token_url`, `client_id_env`, `client_secret_env`, `refresh_token_env?`, `grant` default `refresh_token`, `scopes`, `audience?`); inner `.refine` requires `refresh_token_env` for the `refresh_token` grant. `ProviderConfigSchema.api_key_env` relaxed to optional; new `oauth?`; top-level `.refine` enforces **exactly one** of `{api_key_env, oauth}` (fail-closed, Principle 2). Refine placed BEFORE the existing name/alias `.transform` so it reads the raw fields.
+- `packages/core/src/provider/token-manager.ts` — framework-agnostic `createTokenManager`: lazy refresh (no background timer), injected `now` clock, **single-flight** refresh lock (mirrors `breaker.ts` inFlightProbe) so N concurrent expired callers → 1 fetch. `getAuthHeader()` / `currentSecrets()` (for redaction) / `invalidate()` (401). `TokenRefreshError` message is scrubbed by construction (never contains token/secret material; Principle 7).
+- `packages/core/src/provider/openai.ts` — `ProviderConfig` now takes EITHER `apiKey` OR `getAuthHeader` + `onUnauthorized` + `currentSecrets` (construct-time fail-closed guard: exactly one). `headers()` is async (per-request token). `scrub()` generalized to iterate the live secret set (access+refresh), skipping secrets <4 chars so an empty/tiny token can't blow the body away. **401 single retry** (D2): on a 401 with `onUnauthorized`, invalidate + replay the SAME request exactly once with the new header — for streaming this happens BEFORE `getReader()`/any chunk yield (Principle 8).
+- `apps/gateway/src/server.ts` — `buildCredential(p)` resolves env→plaintext (Principle 7: env resolution stays in the composition root); returns `null` when a required secret env is unset (fail-OPEN skip for non-primary, fail-CLOSED throw for primary). Each OAuth provider gets ONE process-level `TokenManager` 1:1 with its client. The primary's same `cred` backs the eval/classify client so OAuth-primary eval auth never silently fails (acceptance criterion 9).
+- `apps/gateway/src/routes/execute.ts` — `errorClassOf` relabels a persistent upstream 401 → `auth_error` (D5) at the existing chokepoint; breaker counting / chain advance unchanged (D6, no new executor branch).
+- registry types relaxed: `api_key_env`/`apiKeyEnv` optional (the registry never reads them to fetch a credential — the per-name client is pre-built).
+
+**Decisions (maintainer to confirm)**:
+- **D1** — non-interactive grants only (`refresh_token`/`client_credentials`). Interactive `authorization_code` (browser redirect/callback) is out of scope (Helm is headless; no callback route). Separate issue.
+- **D2** — refresh-on-401 retry lives in the CLIENT (transport-level single replay with the new header); the token manager only refreshes. Executor/registry stay credential-agnostic.
+- **D3** — token cache is **in-memory only** (v1). **Known limitation**: a provider that ROTATES its refresh token loses the rotated value on a process restart and re-derives from the env value; if the upstream already retired it, refresh fails and that provider is skipped (fail-open). A persistent `TokenStore` port is the follow-up.
+- **D4** — credential discriminated by the `{api_key_env, oauth}` exactly-one refine (NOT reusing `type`, which is the protocol hint and must stay orthogonal to the auth mechanism).
+- **D5** — persistent post-refresh 401 reuses the existing `auth_error` class (no new `auth_failed`).
+- **D6** — `executor/fallback.ts` untouched; `execute.ts` inlines its own loop and gains no new branch.
+
+**Deviation from docs/09**: OAuth was net-new scope not on the roadmap; recorded in `docs/09-roadmap.md` under deferred/added.
+
+---
+
 ## 2026-06-01 · Pagination + error/role filters for the admin requests list (docs/07, Principle 1)
 
 **Context**: `/admin/requests` fetched a hardcoded `queryRecent(100)` and rendered all rows at once; the UI had dead cursor/"Load more" plumbing that never fired. No way to page past 100 requests or isolate errors / a time window — unusable for real debugging. Added numbered pagination (time DESC) plus Date-range / Status / Decided-by / Lane / Model filters, all applied at the SQL layer so totals stay correct.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -287,6 +287,16 @@ export {
   type ResolveResult,
   toRegistryProviders,
 } from "./provider/registry.js";
+// OAuth subscription providers (issue #38): non-interactive token manager
+// (refresh_token / client_credentials), single-flight refresh, injected clock.
+// Framework-agnostic; env→secret resolution stays in the composition root.
+export {
+  createTokenManager,
+  type ResolvedOAuth,
+  type TokenManager,
+  type TokenManagerDeps,
+  TokenRefreshError,
+} from "./provider/token-manager.js";
 export {
   createRateLimiter,
   type RateLimiterDeps,

--- a/packages/core/src/provider/openai.test.ts
+++ b/packages/core/src/provider/openai.test.ts
@@ -147,4 +147,180 @@ describe("createOpenAIClient (Phase 0 passthrough)", () => {
     const init = fetch.mock.calls[0]?.[1] as RequestInit;
     expect(init.signal).toBeInstanceOf(AbortSignal);
   });
+
+  it("does not retry a 401 on a static-key client (no onUnauthorized)", async () => {
+    const fetch = vi
+      .fn()
+      .mockImplementation(async () => jsonResponse({ error: { message: "nope" } }, 401));
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+    await expect(client.chatCompletion({ model: "m" })).rejects.toMatchObject({
+      errorClass: "upstream_error",
+      upstreamStatus: 401,
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- OAuth dynamic-credential client (issue #38). The auth header becomes a
+// per-request async lookup, and a single upstream 401 triggers an invalidate +
+// one retry with a freshly fetched token. Static-key clients are unchanged.
+describe("createOpenAIClient (OAuth dynamic credential)", () => {
+  const OAUTH_BASE = { baseUrl: "https://upstream.test/v1" };
+
+  function jsonRes(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  function sse(chunks: string[], status = 200): Response {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const enc = new TextEncoder();
+        for (const c of chunks) controller.enqueue(enc.encode(c));
+        controller.close();
+      },
+    });
+    return new Response(stream, { status });
+  }
+
+  it("awaits getAuthHeader() and sends the dynamic Bearer (non-streaming)", async () => {
+    const getAuthHeader = vi.fn().mockResolvedValue("Bearer fetched-token-1");
+    const fetch = vi.fn().mockResolvedValue(jsonRes({ ok: true }));
+    const client = createOpenAIClient({ config: { ...OAUTH_BASE, getAuthHeader }, fetch });
+    await client.chatCompletion({ model: "m" });
+    const init = fetch.mock.calls[0]?.[1] as RequestInit & { headers: Record<string, string> };
+    expect(init.headers.Authorization).toBe("Bearer fetched-token-1");
+    expect(getAuthHeader).toHaveBeenCalled();
+  });
+
+  it("recomputes the header per request (refreshed token on the next call)", async () => {
+    const getAuthHeader = vi
+      .fn()
+      .mockResolvedValueOnce("Bearer token-A")
+      .mockResolvedValueOnce("Bearer token-B");
+    // Fresh Response per call: a Response body can only be read once.
+    const fetch = vi.fn().mockImplementation(async () => jsonRes({ ok: true }));
+    const client = createOpenAIClient({ config: { ...OAUTH_BASE, getAuthHeader }, fetch });
+    await client.chatCompletion({ model: "m" });
+    await client.chatCompletion({ model: "m" });
+    const h0 = (fetch.mock.calls[0]?.[1] as { headers: Record<string, string> }).headers;
+    const h1 = (fetch.mock.calls[1]?.[1] as { headers: Record<string, string> }).headers;
+    expect(h0.Authorization).toBe("Bearer token-A");
+    expect(h1.Authorization).toBe("Bearer token-B");
+  });
+
+  it("on a 401: invalidates, retries once with a new token, succeeds (non-streaming)", async () => {
+    const onUnauthorized = vi.fn();
+    const getAuthHeader = vi
+      .fn()
+      .mockResolvedValueOnce("Bearer stale")
+      .mockResolvedValueOnce("Bearer fresh");
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ error: "unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonRes({ id: "ok" }, 200));
+    const client = createOpenAIClient({
+      config: { ...OAUTH_BASE, getAuthHeader, onUnauthorized },
+      fetch,
+    });
+    const out = await client.chatCompletion({ model: "m" });
+    expect(out).toEqual({ id: "ok" });
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const retryHeaders = (fetch.mock.calls[1]?.[1] as { headers: Record<string, string> }).headers;
+    expect(retryHeaders.Authorization).toBe("Bearer fresh");
+  });
+
+  it("on a persistent 401: retries once then throws UpstreamError(upstreamStatus=401)", async () => {
+    const onUnauthorized = vi.fn();
+    const getAuthHeader = vi.fn().mockResolvedValue("Bearer whatever");
+    const fetch = vi.fn().mockImplementation(async () => jsonRes({ error: "unauthorized" }, 401));
+    const client = createOpenAIClient({
+      config: { ...OAUTH_BASE, getAuthHeader, onUnauthorized },
+      fetch,
+    });
+    await expect(client.chatCompletion({ model: "m" })).rejects.toMatchObject({
+      errorClass: "upstream_error",
+      upstreamStatus: 401,
+    });
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2); // original + exactly one retry
+  });
+
+  it("scrubs access + refresh tokens from an echoed upstream error body", async () => {
+    const currentSecrets = vi.fn().mockReturnValue(["access-XYZ", "refresh-ABC"]);
+    const getAuthHeader = vi.fn().mockResolvedValue("Bearer access-XYZ");
+    const fetch = vi
+      .fn()
+      .mockImplementation(async () =>
+        jsonRes({ error: { echoed: "access-XYZ and refresh-ABC leaked" } }, 502),
+      );
+    const client = createOpenAIClient({
+      config: { ...OAUTH_BASE, getAuthHeader, currentSecrets },
+      fetch,
+    });
+    try {
+      await client.chatCompletion({ model: "m" });
+    } catch (e) {
+      const raw = JSON.stringify((e as UpstreamError).providerRaw);
+      expect(raw).not.toContain("access-XYZ");
+      expect(raw).not.toContain("refresh-ABC");
+    }
+  });
+
+  it("streaming 401 retries before the first chunk and yields the full stream", async () => {
+    const onUnauthorized = vi.fn();
+    const getAuthHeader = vi
+      .fn()
+      .mockResolvedValueOnce("Bearer stale")
+      .mockResolvedValueOnce("Bearer fresh");
+    const chunks = ['data: {"a":1}\n\n', 'data: {"b":2}\n\n', "data: [DONE]\n\n"];
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes({ error: "unauthorized" }, 401))
+      .mockResolvedValueOnce(sse(chunks));
+    const client = createOpenAIClient({
+      config: { ...OAUTH_BASE, getAuthHeader, onUnauthorized },
+      fetch,
+    });
+    const received: string[] = [];
+    for await (const c of client.chatCompletionStream({ model: "m", stream: true })) {
+      received.push(c);
+    }
+    expect(received.join("")).toBe(chunks.join(""));
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const retryHeaders = (fetch.mock.calls[1]?.[1] as { headers: Record<string, string> }).headers;
+    expect(retryHeaders.Authorization).toBe("Bearer fresh");
+  });
+
+  it("streaming non-401 error throws before any chunk (breaker contract intact)", async () => {
+    const onUnauthorized = vi.fn();
+    const getAuthHeader = vi.fn().mockResolvedValue("Bearer t");
+    const fetch = vi.fn().mockImplementation(async () => jsonRes({ error: "boom" }, 503));
+    const client = createOpenAIClient({
+      config: { ...OAUTH_BASE, getAuthHeader, onUnauthorized },
+      fetch,
+    });
+    const iter = client.chatCompletionStream({ model: "m", stream: true });
+    await expect(iter[Symbol.asyncIterator]().next()).rejects.toMatchObject({
+      errorClass: "upstream_error",
+      upstreamStatus: 503,
+    });
+    expect(onUnauthorized).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a config that supplies both apiKey and getAuthHeader (fail-closed)", () => {
+    const getAuthHeader = vi.fn().mockResolvedValue("Bearer t");
+    expect(() =>
+      createOpenAIClient({ config: { ...OAUTH_BASE, apiKey: "sk-x", getAuthHeader } }),
+    ).toThrow();
+  });
+
+  it("rejects a config that supplies neither apiKey nor getAuthHeader (fail-closed)", () => {
+    expect(() => createOpenAIClient({ config: { ...OAUTH_BASE } })).toThrow();
+  });
 });

--- a/packages/core/src/provider/openai.test.ts
+++ b/packages/core/src/provider/openai.test.ts
@@ -121,6 +121,16 @@ describe("createOpenAIClient (Phase 0 passthrough)", () => {
     }
   });
 
+  it("scrubs a static apiKey from a string upstream error body", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse("upstream echoed sk-secret-key", 502));
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+    try {
+      await client.chatCompletion({ model: "m" });
+    } catch (e) {
+      expect((e as UpstreamError).providerRaw).toBe("upstream echoed [redacted]");
+    }
+  });
+
   it("passes the caller's abort signal through and rethrows AbortError (not UpstreamError)", async () => {
     const fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
       // observe the signal then reject as aborted
@@ -267,6 +277,23 @@ describe("createOpenAIClient (OAuth dynamic credential)", () => {
       const raw = JSON.stringify((e as UpstreamError).providerRaw);
       expect(raw).not.toContain("access-XYZ");
       expect(raw).not.toContain("refresh-ABC");
+    }
+  });
+
+  it("scrubs OAuth secrets from a string upstream error body", async () => {
+    const currentSecrets = vi.fn().mockReturnValue(["access-XYZ", "refresh-ABC"]);
+    const getAuthHeader = vi.fn().mockResolvedValue("Bearer access-XYZ");
+    const fetch = vi
+      .fn()
+      .mockImplementation(async () => jsonRes("access-XYZ and refresh-ABC leaked", 502));
+    const client = createOpenAIClient({
+      config: { ...OAUTH_BASE, getAuthHeader, currentSecrets },
+      fetch,
+    });
+    try {
+      await client.chatCompletion({ model: "m" });
+    } catch (e) {
+      expect((e as UpstreamError).providerRaw).toBe("[redacted] and [redacted] leaked");
     }
   });
 

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -122,21 +122,29 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
   // refresh). Empty / very-short secrets are skipped so an empty token never
   // replaces the whole body and a 1-char token never over-redacts.
   function scrub(raw: unknown): unknown {
-    if (raw === null || typeof raw !== "object") return raw;
+    if (raw === null) return raw;
     const secrets = cfg.currentSecrets ? cfg.currentSecrets() : [];
     if (cfg.apiKey !== undefined) secrets.push(cfg.apiKey);
-    let json = JSON.stringify(raw);
-    let changed = false;
-    for (const secret of secrets) {
-      // Skip empty/too-short secrets: an empty string would blow the body away,
-      // and a single character would redact unrelated content.
-      if (secret.length < 4) continue;
-      if (json.includes(secret)) {
-        json = json.split(secret).join("[redacted]");
-        changed = true;
+    const replaceSecrets = (value: string): { value: string; changed: boolean } => {
+      let redacted = value;
+      let changed = false;
+      for (const secret of secrets) {
+        // Skip empty/too-short secrets: an empty string would blow the body away,
+        // and a single character would redact unrelated content.
+        if (secret.length < 4) continue;
+        if (redacted.includes(secret)) {
+          redacted = redacted.split(secret).join("[redacted]");
+          changed = true;
+        }
       }
-    }
-    return changed ? JSON.parse(json) : raw;
+      return { value: redacted, changed };
+    };
+
+    if (typeof raw === "string") return replaceSecrets(raw).value;
+    if (typeof raw !== "object") return raw;
+
+    const { value, changed } = replaceSecrets(JSON.stringify(raw));
+    return changed ? JSON.parse(value) : raw;
   }
 
   async function request(

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -3,9 +3,21 @@
 // (all Phase 1/2). Framework-agnostic (no Hono). Credentials come only from the
 // injected config (env-sourced) and are never logged or echoed. See docs/02.
 
+// Provider credential: EXACTLY ONE of a static `apiKey` or a dynamic
+// `getAuthHeader` (issue #38 OAuth). The dynamic path also accepts:
+//   - `onUnauthorized`: invoked once on an upstream 401 to force a token refresh
+//     (the manager's invalidate), after which the request is retried exactly once
+//     with the freshly fetched header (D2 — the retry lives here in the client,
+//     not the executor, so the SAME request is replayed with the new token).
+//   - `currentSecrets`: live access + refresh tokens, used by `scrub()` to strip
+//     any echoed credential from an upstream error body (principle 7).
+// Credentials are runtime-only: from env, never persisted/logged.
 export interface ProviderConfig {
   baseUrl: string; // e.g. https://openrouter.ai/api/v1
-  apiKey: string; // runtime-only; from env; never persisted/logged
+  apiKey?: string; // static credential; mutually exclusive with getAuthHeader
+  getAuthHeader?: () => Promise<string>; // dynamic "Bearer <token>" (OAuth)
+  onUnauthorized?: () => void; // 401 hook (force refresh); only with getAuthHeader
+  currentSecrets?: () => string[]; // live token set for redaction (OAuth)
   timeoutMs?: number; // default 60_000
 }
 
@@ -76,26 +88,55 @@ function withTimeout(timeoutMs: number, external?: AbortSignal) {
 
 export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
   const doFetch = deps.fetch ?? globalThis.fetch;
-  const timeoutMs = deps.config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const url = `${deps.config.baseUrl}/chat/completions`;
+  const cfg = deps.config;
+  const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const url = `${cfg.baseUrl}/chat/completions`;
 
-  function headers(): Record<string, string> {
+  // Fail-closed credential guard (principle 2): EXACTLY ONE of static apiKey or
+  // dynamic getAuthHeader. A client built with both / neither cannot resolve an
+  // unambiguous auth header, so refuse construction rather than silently pick one.
+  const hasStatic = cfg.apiKey !== undefined;
+  const hasDynamic = cfg.getAuthHeader !== undefined;
+  if (hasStatic === hasDynamic) {
+    throw new Error("provider client requires exactly one of `apiKey` or `getAuthHeader`");
+  }
+
+  // Per-request auth header. Static path returns the constant key; dynamic path
+  // awaits the (possibly refreshed) OAuth token so two requests separated by a
+  // refresh carry different Bearers (acceptance criterion 3).
+  async function authHeader(): Promise<string> {
+    if (cfg.getAuthHeader !== undefined) return await cfg.getAuthHeader();
+    return `Bearer ${cfg.apiKey}`;
+  }
+
+  async function headers(): Promise<Record<string, string>> {
     return {
-      Authorization: `Bearer ${deps.config.apiKey}`,
+      Authorization: await authHeader(),
       "Content-Type": "application/json",
     };
   }
 
   // Strip any echoed credential from an upstream error body before it is carried
   // in UpstreamError.providerRaw (defense in depth; redact() is the main gate).
+  // Static path scrubs the apiKey; OAuth path scrubs every LIVE token (access +
+  // refresh). Empty / very-short secrets are skipped so an empty token never
+  // replaces the whole body and a 1-char token never over-redacts.
   function scrub(raw: unknown): unknown {
     if (raw === null || typeof raw !== "object") return raw;
-    const key = deps.config.apiKey;
-    const json = JSON.stringify(raw);
-    if (key.length > 0 && json.includes(key)) {
-      return JSON.parse(json.split(key).join("[redacted]"));
+    const secrets = cfg.currentSecrets ? cfg.currentSecrets() : [];
+    if (cfg.apiKey !== undefined) secrets.push(cfg.apiKey);
+    let json = JSON.stringify(raw);
+    let changed = false;
+    for (const secret of secrets) {
+      // Skip empty/too-short secrets: an empty string would blow the body away,
+      // and a single character would redact unrelated content.
+      if (secret.length < 4) continue;
+      if (json.includes(secret)) {
+        json = json.split(secret).join("[redacted]");
+        changed = true;
+      }
     }
-    return raw;
+    return changed ? JSON.parse(json) : raw;
   }
 
   async function request(
@@ -106,7 +147,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     try {
       return await doFetch(url, {
         method: "POST",
-        headers: headers(),
+        headers: await headers(),
         body: JSON.stringify(req),
         signal: t.signal,
       });
@@ -121,38 +162,51 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     }
   }
 
+  // Issue the request, applying the OAuth 401 single-retry (D2): on a 401 with an
+  // onUnauthorized hook, force a token refresh and replay the SAME request exactly
+  // once with the new header. `allowRetry` is false on the replay so a persistent
+  // 401 falls through to the normal error path (one retry, never a loop). Returns
+  // the Response with res.ok already true OR a non-401 / exhausted-retry error res.
+  async function requestWithAuthRetry(
+    req: ChatCompletionRequest,
+    external: AbortSignal | undefined,
+  ): Promise<Response> {
+    const res = await request(req, external);
+    if (res.status === 401 && cfg.onUnauthorized !== undefined) {
+      // Discard the 401 body (it may echo the credential) before refreshing.
+      await res.body?.cancel().catch(() => {});
+      cfg.onUnauthorized();
+      return await request(req, external); // exactly one retry with the new token
+    }
+    return res;
+  }
+
+  async function errorFromResponse(res: Response): Promise<UpstreamError> {
+    const providerRaw = await res
+      .json()
+      .catch(() => null)
+      .then(scrub);
+    return new UpstreamError(
+      "upstream_error",
+      `upstream returned ${res.status}`,
+      providerRaw,
+      res.status,
+    );
+  }
+
   return {
     async chatCompletion(req, opts) {
-      const res = await request(req, opts?.signal);
-      if (!res.ok) {
-        const providerRaw = await res
-          .json()
-          .catch(() => null)
-          .then(scrub);
-        throw new UpstreamError(
-          "upstream_error",
-          `upstream returned ${res.status}`,
-          providerRaw,
-          res.status,
-        );
-      }
+      const res = await requestWithAuthRetry(req, opts?.signal);
+      if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as ChatCompletionResponse;
     },
 
     async *chatCompletionStream(req, opts) {
-      const res = await request(req, opts?.signal);
-      if (!res.ok) {
-        const providerRaw = await res
-          .json()
-          .catch(() => null)
-          .then(scrub);
-        throw new UpstreamError(
-          "upstream_error",
-          `upstream returned ${res.status}`,
-          providerRaw,
-          res.status,
-        );
-      }
+      // 401-retry happens here, BEFORE getReader() / any chunk is yielded, so the
+      // SSE stream is replayed cleanly from the start (principle 8 — no duplicated
+      // or half-emitted events).
+      const res = await requestWithAuthRetry(req, opts?.signal);
+      if (!res.ok) throw await errorFromResponse(res);
       const body = res.body;
       if (!body) return;
       const reader = body.getReader();

--- a/packages/core/src/provider/registry.ts
+++ b/packages/core/src/provider/registry.ts
@@ -24,7 +24,12 @@ import type { ProviderConfig as SharedProviderConfig } from "@helm/shared";
 export interface ProviderConfig {
   name: string; // provider id, e.g. "openai" / "anthropic" / "openrouter"
   base_url: string;
-  api_key_env: string; // credential reference: env var NAME — never a plaintext key
+  // Credential reference: env var NAME — never a plaintext key. OPTIONAL because an
+  // OAuth provider (issue #38) has no api_key_env; its client is built separately
+  // in the composition root. The registry NEVER reads this to fetch a credential
+  // (the per-name client is pre-built in providerClients), so an empty value is
+  // acceptable for OAuth providers.
+  api_key_env?: string;
   models: Array<{
     alias: string; // internal alias, e.g. "cheap_model", "openai/auto"
     provider_model: string; // the provider's real model id, e.g. "gpt-4o-mini"
@@ -38,7 +43,10 @@ export interface ResolvedProvider {
   providerName: string;
   providerModel: string; // the provider's real model id
   baseUrl: string;
-  apiKeyEnv: string; // credential env NAME — value is NOT echoed here
+  // Credential env NAME — value is NOT echoed here. OPTIONAL: OAuth providers
+  // (issue #38) carry no api_key_env and the executor never reads it (it dispatches
+  // by providerName to a pre-built client).
+  apiKeyEnv?: string;
 }
 
 // Structured resolve/build errors — unknown alias (resolve-time) and duplicate
@@ -125,7 +133,10 @@ export function toRegistryProviders(
   return providers.map((p) => ({
     name: p.name,
     base_url: p.base_url ?? opts.fallbackBaseUrl ?? "",
-    api_key_env: p.api_key_env,
+    // OAuth providers (issue #38) have no api_key_env; default to "" since the
+    // registry never reads it to fetch a credential (the per-name client is
+    // pre-built in providerClients).
+    api_key_env: p.api_key_env ?? "",
     models: p.models.map((m) => ({ alias: m.alias, provider_model: m.provider_model })),
   }));
 }

--- a/packages/core/src/provider/token-manager.test.ts
+++ b/packages/core/src/provider/token-manager.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTokenManager, type ResolvedOAuth, TokenRefreshError } from "./token-manager.js";
+
+const REFRESH_OAUTH: ResolvedOAuth = {
+  grant: "refresh_token",
+  tokenUrl: "https://oauth.test/token",
+  clientId: "cid-123",
+  clientSecret: "csecret-456",
+  refreshToken: "rtok-initial",
+  scopes: [],
+};
+
+const CC_OAUTH: ResolvedOAuth = {
+  grant: "client_credentials",
+  tokenUrl: "https://oauth.test/token",
+  clientId: "cid-123",
+  clientSecret: "csecret-456",
+  scopes: ["models.read"],
+  audience: "https://api.test",
+};
+
+function tokenResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("createTokenManager", () => {
+  it("refreshes on first call and returns a Bearer header", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(tokenResponse({ access_token: "at-1", expires_in: 3600 }));
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => 0 });
+    const header = await tm.getAuthHeader();
+    expect(header).toBe("Bearer at-1");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves the cached token within its TTL (no second refresh)", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(tokenResponse({ access_token: "at-1", expires_in: 3600 }));
+    let clock = 0;
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => clock });
+    await tm.getAuthHeader();
+    clock = 1000 * 1000; // +1000s, still inside 3600s - 60s skew
+    await tm.getAuthHeader();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes again once the token is within the expiry skew window", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(tokenResponse({ access_token: "at-1", expires_in: 3600 }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "at-2", expires_in: 3600 }));
+    let clock = 0;
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => clock });
+    expect(await tm.getAuthHeader()).toBe("Bearer at-1");
+    clock = 3600 * 1000; // at/after expiry
+    expect(await tm.getAuthHeader()).toBe("Bearer at-2");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("single-flights N concurrent expired calls into exactly one refresh", async () => {
+    let resolve!: (r: Response) => void;
+    const fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise<Response>((res) => {
+          resolve = res;
+        }),
+    );
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => 0 });
+    const calls = Promise.all([tm.getAuthHeader(), tm.getAuthHeader(), tm.getAuthHeader()]);
+    // All three should be waiting on the single in-flight fetch.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    resolve(tokenResponse({ access_token: "at-1", expires_in: 3600 }));
+    const headers = await calls;
+    expect(headers).toEqual(["Bearer at-1", "Bearer at-1", "Bearer at-1"]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidate() forces the next call to refresh", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(tokenResponse({ access_token: "at-1", expires_in: 3600 }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "at-2", expires_in: 3600 }));
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => 0 });
+    expect(await tm.getAuthHeader()).toBe("Bearer at-1");
+    tm.invalidate();
+    expect(await tm.getAuthHeader()).toBe("Bearer at-2");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a scrubbed TokenRefreshError on an HTTP error (no token leak)", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        tokenResponse({ error: "invalid_grant", refresh_token: "rtok-initial" }, 401),
+      );
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => 0 });
+    await expect(tm.getAuthHeader()).rejects.toBeInstanceOf(TokenRefreshError);
+    try {
+      await tm.getAuthHeader();
+    } catch (e) {
+      const err = e as TokenRefreshError;
+      expect(err.message).not.toContain("rtok-initial");
+      expect(err.message).not.toContain("csecret-456");
+      expect(err.httpStatus).toBe(401);
+    }
+  });
+
+  it("client_credentials body has no refresh_token and includes scope + audience", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(tokenResponse({ access_token: "at-1", expires_in: 3600 }));
+    const tm = createTokenManager({ oauth: CC_OAUTH, fetch, now: () => 0 });
+    await tm.getAuthHeader();
+    const init = fetch.mock.calls[0]?.[1] as RequestInit;
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("client_credentials");
+    expect(body.get("refresh_token")).toBeNull();
+    expect(body.get("scope")).toBe("models.read");
+    expect(body.get("audience")).toBe("https://api.test");
+  });
+
+  it("adopts a rotated refresh_token and exposes live secrets for redaction", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        tokenResponse({ access_token: "at-1", expires_in: 3600, refresh_token: "rtok-rotated" }),
+      )
+      .mockResolvedValueOnce(tokenResponse({ access_token: "at-2", expires_in: 3600 }));
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => 0 });
+    await tm.getAuthHeader();
+    expect(tm.currentSecrets()).toContain("at-1");
+    expect(tm.currentSecrets()).toContain("rtok-rotated");
+    tm.invalidate();
+    await tm.getAuthHeader();
+    // Second refresh must have used the ROTATED token, not the initial one.
+    const secondBody = new URLSearchParams(fetch.mock.calls[1]?.[1]?.body as string);
+    expect(secondBody.get("refresh_token")).toBe("rtok-rotated");
+  });
+
+  it("surfaces a network error as a scrubbed TokenRefreshError", async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED https://oauth.test/token"));
+    const tm = createTokenManager({ oauth: REFRESH_OAUTH, fetch, now: () => 0 });
+    await expect(tm.getAuthHeader()).rejects.toBeInstanceOf(TokenRefreshError);
+  });
+});

--- a/packages/core/src/provider/token-manager.ts
+++ b/packages/core/src/provider/token-manager.ts
@@ -1,0 +1,177 @@
+// OAuth token manager — framework-agnostic (packages/core, principle 1). Caches a
+// non-interactive OAuth access token and refreshes it lazily (no background
+// timers) when it is missing / expired / explicitly invalidated. Mirrors the
+// circuit breaker's single-probe lock (breaker.ts) for refresh single-flight and
+// its injected `now` clock for deterministic tests.
+//
+// SECURITY (principle 7): this module only ever receives ALREADY-RESOLVED plaintext
+// secrets (the env→value resolution stays in apps/gateway/src/server.ts). Tokens
+// live in memory only and are NEVER logged: TokenRefreshError carries a scrubbed
+// message with no token material, and `currentSecrets()` hands the live access +
+// refresh tokens to the client's `scrub()` so they can be stripped from any echoed
+// upstream error body.
+//
+// Decisions D1–D3 (see implementation-notes): non-interactive grants only
+// (refresh_token / client_credentials); refresh logic lives here, the 401 retry
+// trigger lives in the client; in-memory only (a rotating refresh token is lost on
+// restart — documented limitation).
+
+// Already-resolved OAuth credential values (NOT env var names — the composition
+// root resolves those). `refreshToken` is present for the refresh_token grant.
+export interface ResolvedOAuth {
+  grant: "refresh_token" | "client_credentials";
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  refreshToken?: string;
+  scopes: string[];
+  audience?: string;
+}
+
+export interface TokenManagerDeps {
+  oauth: ResolvedOAuth;
+  fetch?: typeof globalThis.fetch;
+  /** Injected clock (ms epoch) for deterministic expiry windows in tests. */
+  now?: () => number;
+  /** Refresh `skew` ms before the reported expiry so a token never expires mid-flight. */
+  expirySkewMs?: number;
+}
+
+export interface TokenManager {
+  /** "Bearer <access-token>"; refreshes first if the token is missing/expired. */
+  getAuthHeader(): Promise<string>;
+  /** Live access + refresh tokens, for redaction of echoed upstream bodies. */
+  currentSecrets(): string[];
+  /** Force the next getAuthHeader() to refresh (e.g. after an upstream 401). */
+  invalidate(): void;
+}
+
+// Refresh failure. The message is SCRUBBED by construction — it never contains the
+// access token, refresh token, or client secret (principle 7). Carries the HTTP
+// status (when there was a response) for the caller's diagnostics.
+export class TokenRefreshError extends Error {
+  readonly httpStatus: number | null;
+  constructor(message: string, httpStatus: number | null = null) {
+    super(message);
+    this.name = "TokenRefreshError";
+    this.httpStatus = httpStatus;
+  }
+}
+
+const DEFAULT_EXPIRY_SKEW_MS = 60_000;
+// Fallback lifetime when the token endpoint omits expires_in (rare). Short so a
+// missing TTL degrades to "refresh often", never "cache a token forever".
+const DEFAULT_EXPIRES_IN_S = 3600;
+
+interface TokenEndpointResponse {
+  access_token?: unknown;
+  expires_in?: unknown;
+  refresh_token?: unknown;
+}
+
+export function createTokenManager(deps: TokenManagerDeps): TokenManager {
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const now = deps.now ?? (() => Date.now());
+  const skew = deps.expirySkewMs ?? DEFAULT_EXPIRY_SKEW_MS;
+  const oauth = deps.oauth;
+
+  let accessToken: string | null = null;
+  let expiresAt = 0; // ms epoch; 0 => no cached token
+  // Refresh tokens may ROTATE: the endpoint can hand back a new one each refresh.
+  // Hold the live value in memory (D3: lost on restart — documented limitation).
+  let refreshToken: string | undefined = oauth.refreshToken;
+  // Single-flight lock: concurrent callers hitting an expired token await the SAME
+  // in-flight refresh (mirrors breaker.ts inFlightProbe) so N callers => 1 fetch.
+  let refreshing: Promise<void> | null = null;
+
+  function buildBody(): URLSearchParams {
+    const body = new URLSearchParams();
+    body.set("grant_type", oauth.grant);
+    body.set("client_id", oauth.clientId);
+    body.set("client_secret", oauth.clientSecret);
+    if (oauth.grant === "refresh_token") {
+      // refreshToken is guaranteed present for this grant (config refine), but
+      // guard anyway so a desync never sends "undefined" on the wire.
+      if (refreshToken !== undefined) body.set("refresh_token", refreshToken);
+    }
+    if (oauth.scopes.length > 0) body.set("scope", oauth.scopes.join(" "));
+    if (oauth.audience !== undefined) body.set("audience", oauth.audience);
+    return body;
+  }
+
+  async function doRefresh(): Promise<void> {
+    let res: Response;
+    try {
+      res = await doFetch(oauth.tokenUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: buildBody().toString(),
+      });
+    } catch {
+      // Network / DNS / abort: never echo the cause (could carry the URL with a
+      // secret query — keep it generic; principle 7).
+      throw new TokenRefreshError("oauth token request failed (network error)");
+    }
+    if (!res.ok) {
+      // Drain + discard the body: an OAuth error body can echo the credential.
+      await res.text().catch(() => "");
+      throw new TokenRefreshError(`oauth token request failed (status ${res.status})`, res.status);
+    }
+    let parsed: TokenEndpointResponse;
+    try {
+      parsed = (await res.json()) as TokenEndpointResponse;
+    } catch {
+      throw new TokenRefreshError("oauth token response was not valid JSON", res.status);
+    }
+    if (typeof parsed.access_token !== "string" || parsed.access_token.length === 0) {
+      throw new TokenRefreshError("oauth token response missing access_token", res.status);
+    }
+    accessToken = parsed.access_token;
+    const expiresInS =
+      typeof parsed.expires_in === "number" && parsed.expires_in > 0
+        ? parsed.expires_in
+        : DEFAULT_EXPIRES_IN_S;
+    expiresAt = now() + expiresInS * 1000;
+    // Rotated refresh token: adopt the new value for subsequent refreshes.
+    if (typeof parsed.refresh_token === "string" && parsed.refresh_token.length > 0) {
+      refreshToken = parsed.refresh_token;
+    }
+  }
+
+  function isExpired(): boolean {
+    return accessToken === null || now() + skew >= expiresAt;
+  }
+
+  async function ensureFresh(): Promise<void> {
+    if (!isExpired()) return;
+    // Coalesce concurrent refreshes. The first caller starts the fetch; everyone
+    // else awaits the same promise. Cleared in finally so a later expiry refreshes
+    // again (and a failed refresh does not poison the lock).
+    if (refreshing === null) {
+      refreshing = doRefresh().finally(() => {
+        refreshing = null;
+      });
+    }
+    await refreshing;
+  }
+
+  return {
+    async getAuthHeader(): Promise<string> {
+      await ensureFresh();
+      return `Bearer ${accessToken}`;
+    },
+    currentSecrets(): string[] {
+      const out: string[] = [];
+      if (accessToken !== null) out.push(accessToken);
+      if (refreshToken !== undefined) out.push(refreshToken);
+      return out;
+    },
+    invalidate(): void {
+      // Force the next getAuthHeader() to refresh. Do NOT clear the cached token
+      // synchronously: an in-flight refresh (if any) still resolves to the new one;
+      // expiring it is enough to make the next call refetch.
+      expiresAt = 0;
+      accessToken = null;
+    },
+  };
+}

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -265,4 +265,150 @@ describe("HelmConfigSchema", () => {
     expect(JSON.stringify(parsed.providers)).not.toMatch(/sk-/);
     expect(parsed.providers[0] && "api_key" in parsed.providers[0]).toBe(false);
   });
+
+  // --- OAuth subscription providers (issue #38). A provider may reference an
+  // OAuth credential (env-NAME-only) INSTEAD of a static api_key_env. The two are
+  // mutually exclusive and exactly-one is required (fail-closed, principle 2).
+
+  it("accepts a provider with an oauth credential (refresh_token grant)", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "claude-sub",
+        type: "openai",
+        base_url: "https://oauth.example.com/v1",
+        oauth: {
+          grant: "refresh_token",
+          token_url: "https://oauth.example.com/token",
+          client_id_env: "CLAUDE_SUB_CLIENT_ID",
+          client_secret_env: "CLAUDE_SUB_CLIENT_SECRET",
+          refresh_token_env: "CLAUDE_SUB_REFRESH_TOKEN",
+        },
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      const p0 = res.data.providers[0];
+      expect(p0?.oauth?.grant).toBe("refresh_token");
+      expect(p0?.oauth?.token_url).toBe("https://oauth.example.com/token");
+      expect(p0?.oauth?.scopes).toEqual([]); // defaulted
+      expect(p0?.api_key_env).toBeUndefined();
+    }
+  });
+
+  it("defaults the oauth grant to refresh_token", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "claude-sub",
+        type: "openai",
+        base_url: "https://oauth.example.com/v1",
+        oauth: {
+          token_url: "https://oauth.example.com/token",
+          client_id_env: "CLIENT_ID",
+          client_secret_env: "CLIENT_SECRET",
+          refresh_token_env: "REFRESH_TOKEN",
+        },
+      },
+    ];
+    const parsed = HelmConfigSchema.parse(cfg);
+    expect(parsed.providers[0]?.oauth?.grant).toBe("refresh_token");
+  });
+
+  it("accepts a client_credentials oauth provider with no refresh_token_env", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "sso-gw",
+        type: "openai",
+        base_url: "https://sso.example.com/v1",
+        oauth: {
+          grant: "client_credentials",
+          token_url: "https://sso.example.com/token",
+          client_id_env: "SSO_CLIENT_ID",
+          client_secret_env: "SSO_CLIENT_SECRET",
+          scopes: ["models.read"],
+          audience: "https://sso.example.com/api",
+        },
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.providers[0]?.oauth?.grant).toBe("client_credentials");
+      expect(res.data.providers[0]?.oauth?.scopes).toEqual(["models.read"]);
+    }
+  });
+
+  it("rejects a provider that has BOTH api_key_env and oauth (fail-closed)", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "ambiguous",
+        type: "openai",
+        base_url: "https://x.example.com/v1",
+        api_key_env: "X_API_KEY",
+        oauth: {
+          grant: "client_credentials",
+          token_url: "https://x.example.com/token",
+          client_id_env: "X_CLIENT_ID",
+          client_secret_env: "X_CLIENT_SECRET",
+        },
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects a provider that has NEITHER api_key_env nor oauth (fail-closed)", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "credless",
+        type: "openai",
+        base_url: "https://x.example.com/v1",
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects a refresh_token grant missing refresh_token_env (fail-closed)", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "claude-sub",
+        type: "openai",
+        base_url: "https://oauth.example.com/v1",
+        oauth: {
+          grant: "refresh_token",
+          token_url: "https://oauth.example.com/token",
+          client_id_env: "CLIENT_ID",
+          client_secret_env: "CLIENT_SECRET",
+          // refresh_token_env intentionally omitted
+        },
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects an oauth block with a non-url token_url (fail-closed)", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "claude-sub",
+        type: "openai",
+        oauth: {
+          token_url: "not-a-url",
+          client_id_env: "CLIENT_ID",
+          client_secret_env: "CLIENT_SECRET",
+          refresh_token_env: "REFRESH_TOKEN",
+        },
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(false);
+  });
 });

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -411,4 +411,40 @@ describe("HelmConfigSchema", () => {
     const res = HelmConfigSchema.safeParse(cfg);
     expect(res.success).toBe(false);
   });
+
+  it("rejects a non-localhost http oauth token_url (fail-closed)", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "claude-sub",
+        type: "openai",
+        oauth: {
+          token_url: "http://oauth.example.com/token",
+          client_id_env: "CLIENT_ID",
+          client_secret_env: "CLIENT_SECRET",
+          refresh_token_env: "REFRESH_TOKEN",
+        },
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(false);
+  });
+
+  it("allows localhost http oauth token_url for local tests", () => {
+    const cfg = fullConfig() as Record<string, unknown>;
+    cfg.providers = [
+      {
+        name: "local-oauth",
+        type: "openai",
+        oauth: {
+          token_url: "http://127.0.0.1:9876/token",
+          client_id_env: "CLIENT_ID",
+          client_secret_env: "CLIENT_SECRET",
+          refresh_token_env: "REFRESH_TOKEN",
+        },
+      },
+    ];
+    const res = HelmConfigSchema.safeParse(cfg);
+    expect(res.success).toBe(true);
+  });
 });

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -430,14 +430,18 @@ describe("HelmConfigSchema", () => {
     expect(res.success).toBe(false);
   });
 
-  it("allows localhost http oauth token_url for local tests", () => {
+  it.each([
+    "http://127.0.0.1:9876/token",
+    "http://localhost:9876/token",
+    "http://[::1]:9876/token",
+  ])("allows localhost http oauth token_url for local tests: %s", (tokenUrl) => {
     const cfg = fullConfig() as Record<string, unknown>;
     cfg.providers = [
       {
         name: "local-oauth",
         type: "openai",
         oauth: {
-          token_url: "http://127.0.0.1:9876/token",
+          token_url: tokenUrl,
           client_id_env: "CLIENT_ID",
           client_secret_env: "CLIENT_SECRET",
           refresh_token_env: "REFRESH_TOKEN",

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -39,6 +39,33 @@ export const ProviderModelSchema = z.object({
   provider_model: z.string().min(1),
 });
 
+// OAuth credential reference for subscription / SSO upstreams (issue #38). Like
+// api_key_env, this carries env-var NAMES only — never a plaintext token, secret,
+// or client id (principle 7). Helm refreshes the access token non-interactively
+// (refresh_token / client_credentials grants); the interactive authorization_code
+// flow is out of scope (no redirect/callback route — see implementation-notes D1).
+//   - grant: which non-interactive grant to use (default refresh_token).
+//   - token_url: the OAuth token endpoint (URL, validated).
+//   - client_id_env / client_secret_env: env var NAMES holding the OAuth client
+//     credentials (both required — the token request is client-authenticated).
+//   - refresh_token_env: env var NAME holding the refresh token. REQUIRED for the
+//     refresh_token grant (enforced below); unused by client_credentials.
+//   - scopes / audience: optional OAuth parameters forwarded in the token request.
+export const OAuthConfigSchema = z
+  .object({
+    grant: z.enum(["refresh_token", "client_credentials"]).default("refresh_token"),
+    token_url: z.url(),
+    client_id_env: z.string().min(1), // env var NAME, not a plaintext client id
+    client_secret_env: z.string().min(1), // env var NAME, not a plaintext secret
+    refresh_token_env: z.string().min(1).optional(), // env var NAME; required for refresh_token
+    scopes: z.array(z.string()).default([]),
+    audience: z.string().min(1).optional(),
+  })
+  .refine((o) => o.grant !== "refresh_token" || o.refresh_token_env !== undefined, {
+    message: "oauth grant `refresh_token` requires `refresh_token_env`",
+    path: ["refresh_token_env"],
+  });
+
 // Unified provider config — the SINGLE shape both config-loader and the provider
 // registry agree on (reconciles the two divergent ProviderConfig shapes noted in
 // implementation-notes provider.registry). A provider carries:
@@ -46,8 +73,11 @@ export const ProviderModelSchema = z.object({
 //     used `alias`); when only `alias` is given, `name` is derived from it so the
 //     registry always has a provider id.
 //   - `type` (openai | anthropic | ...): optional, defaults to "openai".
-//   - `base_url?`, `api_key_env` (credential REFERENCE — env var NAME, never a
-//     plaintext key, principle 7).
+//   - `base_url?`, and EXACTLY ONE credential reference:
+//       * `api_key_env` (static key — env var NAME, never a plaintext key), OR
+//       * `oauth` (OAuth subscription/SSO credential — env var NAMES only).
+//     The exactly-one rule is fail-closed below (principle 2): a half-specified
+//     credential (both / neither) refuses to start.
 //   - `models[]`: per-model alias mapping. OPTIONAL (defaults to []) so the
 //     Phase-0 OpenAI-compatible passthrough provider (no models[]) keeps working.
 // Credentials are stored as a REFERENCE (env var name) only — never plaintext.
@@ -60,12 +90,24 @@ export const ProviderConfigSchema = z
     alias: z.string().min(1).optional(),
     type: z.string().min(1).default("openai"), // openai | anthropic | ... (not locked in MVP)
     base_url: z.url().optional(),
-    api_key_env: z.string().min(1), // credential reference: env var name, not plaintext
+    // Credential reference: env var name, not plaintext. OPTIONAL now that an
+    // `oauth` block is an alternative; the exactly-one refine below keeps a
+    // provider from booting with both / neither.
+    api_key_env: z.string().min(1).optional(),
+    oauth: OAuthConfigSchema.optional(),
     models: z.array(ProviderModelSchema).default([]),
   })
   .refine((p) => p.name !== undefined || p.alias !== undefined, {
     message: "provider requires `name` or `alias`",
     path: ["name"],
+  })
+  // Exactly one credential mechanism. Applied BEFORE the transform so it reads the
+  // raw `api_key_env`/`oauth` fields (the transform only re-keys name/alias and
+  // does not touch credentials, but ordering the refine first keeps the guard on
+  // the original shape). A provider with both OR neither fails closed (principle 2).
+  .refine((p) => (p.api_key_env !== undefined) !== (p.oauth !== undefined), {
+    message: "provider requires exactly one of `api_key_env` or `oauth`",
+    path: ["api_key_env"],
   })
   .transform((p) => ({
     // Single source of truth for the provider id: prefer `name`, fall back to the
@@ -158,6 +200,7 @@ export type ServerConfig = z.infer<typeof ServerConfigSchema>;
 export type BootstrapConfig = z.infer<typeof BootstrapConfigSchema>;
 export type AuthConfig = z.infer<typeof AuthConfigSchema>;
 export type ProviderModel = z.infer<typeof ProviderModelSchema>;
+export type OAuthConfig = z.infer<typeof OAuthConfigSchema>;
 export type ProviderConfig = z.infer<typeof ProviderConfigSchema>;
 export type RateLimitQuota = z.infer<typeof RateLimitQuotaSchema>;
 export type RateLimitQuotaOverride = z.infer<typeof RateLimitQuotaOverrideSchema>;

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -60,12 +60,12 @@ export const OAuthConfigSchema = z
           const parsed = new URL(url);
           if (parsed.protocol === "https:") return true;
           if (parsed.protocol !== "http:") return false;
-          return ["localhost", "127.0.0.1", "::1"].includes(parsed.hostname);
+          return ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
         } catch {
           return false;
         }
       },
-      { message: "oauth token_url must use https except localhost/127.0.0.1" },
+      { message: "oauth token_url must use https except localhost/127.0.0.1/[::1]" },
     ),
     client_id_env: z.string().min(1), // env var NAME, not a plaintext client id
     client_secret_env: z.string().min(1), // env var NAME, not a plaintext secret

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -54,7 +54,19 @@ export const ProviderModelSchema = z.object({
 export const OAuthConfigSchema = z
   .object({
     grant: z.enum(["refresh_token", "client_credentials"]).default("refresh_token"),
-    token_url: z.url(),
+    token_url: z.url().refine(
+      (url) => {
+        try {
+          const parsed = new URL(url);
+          if (parsed.protocol === "https:") return true;
+          if (parsed.protocol !== "http:") return false;
+          return ["localhost", "127.0.0.1", "::1"].includes(parsed.hostname);
+        } catch {
+          return false;
+        }
+      },
+      { message: "oauth token_url must use https except localhost/127.0.0.1" },
+    ),
     client_id_env: z.string().min(1), // env var NAME, not a plaintext client id
     client_secret_env: z.string().min(1), // env var NAME, not a plaintext secret
     refresh_token_env: z.string().min(1).optional(), // env var NAME; required for refresh_token

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -95,6 +95,8 @@ export {
   BootstrapConfigSchema,
   type HelmConfig,
   HelmConfigSchema,
+  type OAuthConfig,
+  OAuthConfigSchema,
   type ProviderConfig,
   ProviderConfigSchema,
   type ProviderModel,


### PR DESCRIPTION
## 做了什么

把上游 auth 头改成**动态、按请求**计算，从而能路由那些颁发短时 OAuth access token 的订阅 / SSO 供应商（Claude/ChatGPT 订阅、企业 SSO 网关）。Helm 以**非交互**方式刷新 token（`refresh_token` / `client_credentials`）并注入新的 Bearer，配一次 refresh-on-401 重试。token 管理器位于框架无关的 `packages/core`；env→secret 的解析留在 composition root（原则 7）。

## 逐文件说明

- **`packages/shared/src/config/schema.ts`** —— 新增 `OAuthConfigSchema`（只引用 env 名：`token_url`、`client_id_env`、`client_secret_env`、`refresh_token_env?`、`grant` 默认 `refresh_token`、`scopes`、`audience?`；内层 refine 要求 refresh_token grant 必须有 `refresh_token_env`）。`ProviderConfigSchema.api_key_env` 放宽为可选、新增 `oauth?`，顶层 refine 强制 `{api_key_env, oauth}` **恰好其一**（fail-closed，置于既有 name/alias transform 之前）。导出 `OAuthConfig`。
- **`packages/core/src/provider/token-manager.ts`**（新增）—— `createTokenManager`：惰性刷新（无后台定时器）、注入的 `now` 时钟、**单飞**刷新锁（N 个并发过期 caller → 1 次 fetch）、`getAuthHeader` / `currentSecrets`（脱敏用）/ `invalidate`（401）。`TokenRefreshError` 构造时即脱敏（绝不携带 token/secret 内容）。
- **`packages/core/src/provider/openai.ts`** —— `ProviderConfig` 接受静态 `apiKey` 或动态 `getAuthHeader` + `onUnauthorized` + `currentSecrets`（构造期恰好其一的守卫）。`headers()` 变 async（按请求取 token）。`scrub()` 泛化为遍历 live secret 集合（access+refresh），跳过 <4 字符的 secret。**401 单次重试**（D2）：invalidate 后带新头重发**同一请求**一次 —— 流式场景下这发生在 `getReader()` / 任何 chunk **之前**（原则 8）。
- **`apps/gateway/src/server.ts`** —— `buildCredential(p)` 解析 env→明文；必填 secret 未设时返回 `null`（非 primary fail-open 跳过，primary fail-closed 抛错）。每个 OAuth provider 一个 `TokenManager`（与其 client 1:1）；primary 的同一 `cred` 也支撑 eval/classify client（验收 9）。`buildCredential`/`buildProviderClients` 导出供单测。
- **`apps/gateway/src/routes/execute.ts`** —— `errorClassOf` 在既有 chokepoint 把持续的上游 401 → `auth_error`（D5）；熔断计数 / 链推进不变（D6，无新 executor 分支）。
- **`packages/core/src/provider/registry.ts`** —— `api_key_env` / `apiKeyEnv` 改可选（registry 从不读它们去取凭证）。
- **文档** —— `config/providers.yaml` 注释的 OAuth 示例（只写 env 名）、`implementation-notes.md` 的 D1–D6 + 内存 token 限制（轮换 refresh token 重启即丢）、`docs/09-roadmap.md` 条目。

## 测试（TDD 红→绿）

- shared schema：oauth 接受 / 恰好其一（两者皆有被拒、两者皆无被拒）/ 缺 refresh_token_env / 坏 token_url。既有 schema 测试不变。
- token-manager：首次刷新 + 缓存、TTL 命中、过期刷新、**N 并发单飞 = 1 次 fetch**、invalidate、脱敏的 HTTP/网络错误、client_credentials body、轮换 refresh token。
- openai client：动态头被 await、按请求重算、401 invalidate+重试+200、持续 401 → UpstreamError(401)、token 脱敏、**流式 401 在首 chunk 前重试**、流式非 401 在任何 chunk 前抛出、恰好其一守卫。静态 key client 不变（不做 401 重试）。
- execute：持续 401 → `auth_error` + 恰好一次 breaker failure。
- gateway 接线：buildCredential 静态/oauth/缺 secret；buildProviderClients 的 OAuth client 发出 fetched Bearer；非 primary 缺 secret 被跳过（fail-open）。
- **e2e** `oauth.spec.ts`：进程内网关、OAuth primary 打 mock —— 用 fetched Bearer 路由、401-once 时刷新+重试、端到端流式、无 Bearer 泄漏。mock 增加 token 端点 + 401-once 分支。

## 本地结果

- `pnpm typecheck` —— PASS
- `pnpm lint` —— PASS（0 错误；19 个既有警告）
- `pnpm test` —— **PASS，1361/1361**
- e2e `oauth.spec.ts` —— **4/4 通过**（单独跑与全量跑都稳定）

## 推迟项 / 备注

- **订阅 / account 绑定边界（v1 明确取舍）**：本轮实现的是全局 provider-level OAuth credential；TokenManager 按 provider 进程级构建，不做 account-level subscription isolation，也不新增 `allowed_provider_aliases` key caps。已补 fail-closed 防线：alias 已解析到 OAuth/subscription provider 但 client 缺失时不会回落 default credential。若 #38 后续要求“订阅 key 与 account 绑定”，需要独立补 key caps / account-provider 绑定。
- v1 的 token 缓存**仅在内存**（D3）：轮换 refresh token 重启即丢、从 env 重新派生 —— 已记录的限制；持久化 `TokenStore` 是后续。
- 交互式 `authorization_code`（浏览器）流程不在范围（D1；Helm 是 headless，无 callback 路由）。
- 一个无关、对时序敏感的 eval e2e（`eval.spec.ts › timeout fail-open … re-calls`）在全量 e2e 跑里偶发抖动一次，但单独跑 8/8 通过 —— 本 PR 未触碰。admin-static 单测需先 `pnpm build`（admin SPA），与 CI 一致。

Part of #38 — the interactive subscription login that completes it lands in #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


