### PR TITLE
test: 添加三协议互转 fixture 矩阵

### DIFF
--- a/packages/core/src/protocol/protocol-matrix.fixtures.ts
+++ b/packages/core/src/protocol/protocol-matrix.fixtures.ts
@@ -107,8 +107,9 @@ const anthropicToOpenai = path("anthropic", "openai", [
   ),
   fixture(
     "error",
-    "passing",
-    "Anthropic-native client errors map through Helm ErrorClass to OpenAI envelope",
+    "todo",
+    "Anthropic-native client errors to OpenAI error envelope need a dedicated renderer",
+    "No OpenAI-native error envelope transformer exists to assert in PR A without adding behavior.",
   ),
   fixture("usage", "passing", "Anthropic cache_read_input_tokens can stay distinct in IR usage"),
 ]);
@@ -138,7 +139,12 @@ const openaiToGemini = path("openai", "gemini", [
     "OpenAI response_format JSON schema to Gemini responseSchema is not emitted today",
     "PR A records the gap; adding Gemini request nativeOut behavior belongs to a later PR.",
   ),
-  fixture("error", "passing", "Helm ErrorClass can render a Gemini-native error envelope"),
+  fixture(
+    "error",
+    "todo",
+    "Helm ErrorClass to Gemini-native error envelope needs a dedicated renderer",
+    "No Gemini-native error envelope transformer exists to assert in PR A without adding behavior.",
+  ),
   fixture(
     "usage",
     "passing",
@@ -172,8 +178,9 @@ const geminiToOpenai = path("gemini", "openai", [
   ),
   fixture(
     "error",
-    "passing",
-    "Gemini-native client errors map through Helm ErrorClass to OpenAI envelope",
+    "todo",
+    "Gemini-native client errors to OpenAI error envelope need a dedicated renderer",
+    "No OpenAI-native error envelope transformer exists to assert in PR A without adding behavior.",
   ),
   fixture("usage", "passing", "Gemini cachedContentTokenCount remains distinct in IR usage"),
 ]);
@@ -210,8 +217,9 @@ const anthropicToGemini = path("anthropic", "gemini", [
   ),
   fixture(
     "error",
-    "passing",
-    "Helm ErrorClass can render Gemini-native envelopes for Anthropic-origin failures",
+    "todo",
+    "Helm ErrorClass to Gemini-native envelopes for Anthropic-origin failures needs a renderer",
+    "No Gemini-native error envelope transformer exists to assert in PR A without adding behavior.",
   ),
   fixture("usage", "passing", "IR cached usage can render to Gemini usageMetadata"),
 ]);

--- a/packages/core/src/protocol/protocol-matrix.fixtures.ts
+++ b/packages/core/src/protocol/protocol-matrix.fixtures.ts
@@ -1,0 +1,352 @@
+import type { IRRequest, IRResponse } from "./ir.js";
+
+export const protocols = ["openai", "anthropic", "gemini"] as const;
+export type ProtocolName = (typeof protocols)[number];
+
+export const protocolMatrixDimensions = [
+  "request",
+  "response",
+  "streaming",
+  "tool-call",
+  "multimodal",
+  "json-schema",
+  "error",
+  "usage",
+] as const;
+export type ProtocolMatrixDimension = (typeof protocolMatrixDimensions)[number];
+
+export type FixtureStatus = "passing" | "todo";
+
+export interface ProtocolMatrixFixture {
+  readonly id: string;
+  readonly dimension: ProtocolMatrixDimension;
+  readonly status: FixtureStatus;
+  readonly assertion: string;
+  readonly todoReason?: string;
+}
+
+export interface ProtocolMatrixPath {
+  readonly from: ProtocolName;
+  readonly to: ProtocolName;
+  readonly fixtures: readonly ProtocolMatrixFixture[];
+}
+
+export const protocolMatrixProvenance =
+  "Fixture matrix is based on public LiteLLM behavior/checklist observations only; no LiteLLM code is copied, vendored, or translated.";
+
+function fixture(
+  dimension: ProtocolMatrixDimension,
+  status: FixtureStatus,
+  assertion: string,
+  todoReason?: string,
+): ProtocolMatrixFixture {
+  return {
+    id: `${dimension}:${status}:${assertion.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+    dimension,
+    status,
+    assertion,
+    ...(todoReason !== undefined ? { todoReason } : {}),
+  };
+}
+
+function path(
+  from: ProtocolName,
+  to: ProtocolName,
+  fixtures: readonly ProtocolMatrixFixture[],
+): ProtocolMatrixPath {
+  return { from, to, fixtures };
+}
+
+const openaiToAnthropic = path("openai", "anthropic", [
+  fixture(
+    "request",
+    "todo",
+    "OpenAI request can be normalized to IR; Anthropic request nativeOut is not implemented yet",
+    "PR A records the gap only; adding IR->Anthropic request behavior belongs to a later PR.",
+  ),
+  fixture("response", "passing", "IR assistant response renders as Anthropic message response"),
+  fixture("streaming", "passing", "OpenAI chunks render as ordered Anthropic SSE events"),
+  fixture("tool-call", "passing", "OpenAI tool_calls render as Anthropic tool_use blocks"),
+  fixture(
+    "multimodal",
+    "todo",
+    "OpenAI image_url to Anthropic image source requires request nativeOut support",
+    "Keep as matrix coverage until IR->Anthropic request conversion is designed.",
+  ),
+  fixture(
+    "json-schema",
+    "todo",
+    "OpenAI response_format to Anthropic JSON mode/output_format strategy is undecided",
+    "Issue #45 requires Trent policy before silent mapping.",
+  ),
+  fixture("error", "passing", "Helm ErrorClass can render an Anthropic-native error envelope"),
+  fixture("usage", "passing", "Cached prompt tokens stay separate in Anthropic usage"),
+]);
+
+const anthropicToOpenai = path("anthropic", "openai", [
+  fixture("request", "passing", "Anthropic request normalizes to IR and OpenAI request nativeOut"),
+  fixture(
+    "response",
+    "todo",
+    "Anthropic provider-native response to IR is not implemented",
+    "Current Anthropic response module is IR->Anthropic only.",
+  ),
+  fixture(
+    "streaming",
+    "todo",
+    "Anthropic inbound stream to OpenAI chunk conversion is not implemented",
+    "Current stream module covers OpenAI chunks -> Anthropic events.",
+  ),
+  fixture("tool-call", "passing", "Anthropic tool_use/tool_result normalizes to OpenAI-shaped IR"),
+  fixture("multimodal", "passing", "Anthropic base64 image source normalizes to IR image data URL"),
+  fixture(
+    "json-schema",
+    "todo",
+    "Anthropic JSON mode/output_format to OpenAI response_format fixture is pending",
+    "No current transformer behavior to exercise without changing behavior.",
+  ),
+  fixture(
+    "error",
+    "passing",
+    "Anthropic-native client errors map through Helm ErrorClass to OpenAI envelope",
+  ),
+  fixture("usage", "passing", "Anthropic cache_read_input_tokens can stay distinct in IR usage"),
+]);
+
+const openaiToGemini = path("openai", "gemini", [
+  fixture(
+    "request",
+    "passing",
+    "OpenAI request normalizes to IR and Gemini generateContent nativeOut",
+  ),
+  fixture(
+    "response",
+    "passing",
+    "IR assistant response renders as Gemini generateContent response",
+  ),
+  fixture("streaming", "passing", "OpenAI chunks render as Gemini full-snapshot SSE events"),
+  fixture("tool-call", "passing", "OpenAI tool_calls render as Gemini functionCall parts"),
+  fixture(
+    "multimodal",
+    "todo",
+    "OpenAI remote image_url outbound to Gemini is lossy today",
+    "PR A records the gap; issue #45 routes the fix to a later Gemini compatibility PR.",
+  ),
+  fixture(
+    "json-schema",
+    "todo",
+    "OpenAI response_format JSON schema to Gemini responseSchema is not emitted today",
+    "PR A records the gap; adding Gemini request nativeOut behavior belongs to a later PR.",
+  ),
+  fixture("error", "passing", "Helm ErrorClass can render a Gemini-native error envelope"),
+  fixture(
+    "usage",
+    "passing",
+    "IR usage renders as Gemini usageMetadata without double-counting cache",
+  ),
+]);
+
+const geminiToOpenai = path("gemini", "openai", [
+  fixture(
+    "request",
+    "passing",
+    "Gemini generateContent normalizes to IR and OpenAI request nativeOut",
+  ),
+  fixture("response", "passing", "Gemini response normalizes to IR and OpenAI response nativeOut"),
+  fixture(
+    "streaming",
+    "todo",
+    "Gemini snapshot stream to OpenAI chunks is not exposed as a target fixture yet",
+    "Current Gemini stream helper normalizes snapshots to IR chunks; OpenAI SSE serialization is gateway-level.",
+  ),
+  fixture(
+    "tool-call",
+    "passing",
+    "Gemini functionCall/functionResponse normalizes with synthesized tool ids",
+  ),
+  fixture("multimodal", "passing", "Gemini inlineData normalizes to IR image data URL"),
+  fixture(
+    "json-schema",
+    "passing",
+    "Gemini responseSchema/functionDeclarations normalize into IR fields",
+  ),
+  fixture(
+    "error",
+    "passing",
+    "Gemini-native client errors map through Helm ErrorClass to OpenAI envelope",
+  ),
+  fixture("usage", "passing", "Gemini cachedContentTokenCount remains distinct in IR usage"),
+]);
+
+const anthropicToGemini = path("anthropic", "gemini", [
+  fixture("request", "passing", "Anthropic request normalizes to IR and Gemini request nativeOut"),
+  fixture(
+    "response",
+    "todo",
+    "Anthropic provider-native response to Gemini response is not implemented",
+    "Current Anthropic response module is IR->Anthropic only.",
+  ),
+  fixture(
+    "streaming",
+    "todo",
+    "Anthropic stream to Gemini snapshot stream has no implemented source stream normalizer",
+    "PR A records the cross-stream gap only.",
+  ),
+  fixture(
+    "tool-call",
+    "passing",
+    "Anthropic tool_use/tool_result can become Gemini functionCall/functionResponse via IR",
+  ),
+  fixture(
+    "multimodal",
+    "passing",
+    "Anthropic base64 image source can become Gemini inlineData via IR",
+  ),
+  fixture(
+    "json-schema",
+    "todo",
+    "Anthropic JSON mode/output_format to Gemini responseSchema strategy is pending",
+    "No current transformer behavior to exercise without changing behavior.",
+  ),
+  fixture(
+    "error",
+    "passing",
+    "Helm ErrorClass can render Gemini-native envelopes for Anthropic-origin failures",
+  ),
+  fixture("usage", "passing", "IR cached usage can render to Gemini usageMetadata"),
+]);
+
+const geminiToAnthropic = path("gemini", "anthropic", [
+  fixture(
+    "request",
+    "todo",
+    "Gemini request normalizes to IR; Anthropic request nativeOut is not implemented yet",
+    "PR A records the gap only; adding IR->Anthropic request behavior belongs to a later PR.",
+  ),
+  fixture(
+    "response",
+    "passing",
+    "Gemini response can normalize to IR and render as Anthropic response",
+  ),
+  fixture(
+    "streaming",
+    "todo",
+    "Gemini snapshot stream to Anthropic events needs a source stream normalizer plus target renderer",
+    "Current helpers do not expose that full path without new behavior.",
+  ),
+  fixture(
+    "tool-call",
+    "passing",
+    "Gemini functionCall can render as Anthropic tool_use through IR",
+  ),
+  fixture(
+    "multimodal",
+    "passing",
+    "Gemini inlineData normalizes to IR image data URL for Anthropic policy decisions",
+  ),
+  fixture(
+    "json-schema",
+    "todo",
+    "Gemini responseSchema to Anthropic JSON mode/output_format strategy is pending",
+    "No current transformer behavior to exercise without changing behavior.",
+  ),
+  fixture(
+    "error",
+    "passing",
+    "Helm ErrorClass can render Anthropic-native envelopes for Gemini-origin failures",
+  ),
+  fixture(
+    "usage",
+    "passing",
+    "Gemini cached usage can render as Anthropic cache_read_input_tokens",
+  ),
+]);
+
+export const protocolCrossPathMatrix = [
+  openaiToAnthropic,
+  anthropicToOpenai,
+  openaiToGemini,
+  geminiToOpenai,
+  anthropicToGemini,
+  geminiToAnthropic,
+] as const;
+
+export const canonicalRequestIR: IRRequest = {
+  model: "matrix-model",
+  messages: [
+    { role: "system", content: "Be precise." },
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Describe this image and call the tool." },
+        { type: "image", url: "data:image/png;base64,AAAA", mediaType: "image/png" },
+      ],
+    },
+    {
+      role: "assistant",
+      content: "Calling weather.",
+      tool_calls: [
+        {
+          id: "call_weather_0",
+          type: "function",
+          function: { name: "get_weather", arguments: '{"city":"Melbourne"}' },
+        },
+      ],
+    },
+    { role: "tool", tool_call_id: "call_weather_0", content: "18C" },
+  ],
+  tools: [
+    {
+      type: "function",
+      function: {
+        name: "get_weather",
+        description: "Get weather by city.",
+        parameters: {
+          type: "object",
+          properties: { city: { type: "string", format: "city-name" } },
+          required: ["city"],
+        },
+      },
+    },
+  ],
+  tool_choice: "auto",
+  response_format: {
+    type: "json_schema",
+    json_schema: {
+      name: "weather_answer",
+      schema: {
+        type: "object",
+        properties: { summary: { type: "string" } },
+        required: ["summary"],
+      },
+    },
+  },
+  stream: true,
+};
+
+export const canonicalResponseIR: IRResponse = {
+  id: "matrix-response-1",
+  model: "matrix-model",
+  choices: [
+    {
+      index: 0,
+      message: {
+        role: "assistant",
+        content: "Here is the answer.",
+        tool_calls: [
+          {
+            id: "call_weather_0",
+            type: "function",
+            function: { name: "get_weather", arguments: '{"city":"Melbourne"}' },
+          },
+        ],
+      },
+      finish_reason: "tool_calls",
+    },
+  ],
+  usage: { prompt_tokens: 10, cached_tokens: 3, completion_tokens: 4 },
+  provider_raw: {
+    stop_reason: "tool_calls",
+    usage: { prompt_tokens: 13, completion_tokens: 4, total_tokens: 17 },
+  },
+};

--- a/packages/core/src/protocol/protocol-matrix.test.ts
+++ b/packages/core/src/protocol/protocol-matrix.test.ts
@@ -1,5 +1,10 @@
+import { makeHelmError } from "@helm/shared";
 import { describe, expect, it } from "vitest";
-import { anthropicTransformer, convertOpenAIStreamToAnthropic } from "./anthropic/index.js";
+import {
+  anthropicTransformer,
+  convertOpenAIStreamToAnthropic,
+  transformErrorOut as transformAnthropicErrorOut,
+} from "./anthropic/index.js";
 import { geminiTransformer } from "./gemini/gemini-transformer.js";
 import type { IRChunk as GeminiIRChunk } from "./gemini/gemini-types.js";
 import type { IRRequest, IRResponse } from "./ir.js";
@@ -8,6 +13,8 @@ import { openaiTransformer } from "./openai.js";
 import {
   canonicalRequestIR,
   canonicalResponseIR,
+  type ProtocolMatrixDimension,
+  type ProtocolMatrixPath,
   type ProtocolName,
   protocolCrossPathMatrix,
   protocolMatrixDimensions,
@@ -194,6 +201,62 @@ function nativeResponse(protocol: ProtocolName): unknown {
   return undefined;
 }
 
+function hasPassingFixture(path: ProtocolMatrixPath, dimension: ProtocolMatrixDimension): boolean {
+  return path.fixtures.some(
+    (fixture) => fixture.dimension === dimension && fixture.status === "passing",
+  );
+}
+
+function expectSerializedField(value: unknown, field: string): void {
+  expect(JSON.stringify(value)).toContain(`"${field}"`);
+}
+
+function expectIrToolCall(ir: IRRequest | IRResponse): void {
+  const serialized = JSON.stringify(ir);
+  expectSerializedField(ir, "tool_calls");
+  expect(serialized).toContain("get_weather");
+  expect(serialized).toContain("Melbourne");
+}
+
+function expectIrImageDataUrl(ir: IRRequest): void {
+  expect(JSON.stringify(ir)).toContain("data:image/png;base64,AAAA");
+}
+
+function expectIrUsageNotDoubleBilled(ir: IRResponse): void {
+  expect(ir.usage?.prompt_tokens).toBe(10);
+  expect(ir.usage?.cached_tokens).toBe(3);
+  expect(ir.usage?.completion_tokens).toBe(4);
+}
+
+function expectTargetToolCall(protocol: ProtocolName, native: unknown): void {
+  const serialized = JSON.stringify(native);
+  expect(serialized).toContain("get_weather");
+  expect(serialized).toContain("Melbourne");
+  if (protocol === "openai") expectSerializedField(native, "tool_calls");
+  if (protocol === "anthropic") expect(serialized).toContain("tool_use");
+  if (protocol === "gemini") expectSerializedField(native, "functionCall");
+}
+
+function expectTargetUsageNotDoubleBilled(protocol: ProtocolName, native: unknown): void {
+  const serialized = JSON.stringify(native);
+  if (protocol === "openai") {
+    expect(serialized).toContain('"prompt_tokens":13');
+    expect(serialized).toContain('"completion_tokens":4');
+    expect(serialized).toContain('"cached_tokens":3');
+  }
+  if (protocol === "anthropic") {
+    expect(serialized).toContain('"input_tokens":10');
+    expect(serialized).toContain('"output_tokens":4');
+    expect(serialized).toContain('"cache_read_input_tokens":3');
+  }
+  if (protocol === "gemini") {
+    expect(serialized).toContain('"promptTokenCount":13');
+    expect(serialized).toContain('"candidatesTokenCount":4');
+    expect(serialized).toContain('"cachedContentTokenCount":3');
+    expect(serialized).toContain('"totalTokenCount":17');
+  }
+}
+
 describe("protocol cross-path fixture matrix", () => {
   it("documents LiteLLM provenance without vendoring code", () => {
     expect(protocolMatrixProvenance).toContain("behavior/checklist");
@@ -269,12 +332,74 @@ describe("protocol cross-path executable harness", () => {
   });
 
   it.each(
+    protocolCrossPathMatrix.filter((path) => hasPassingFixture(path, "tool-call")),
+  )("guards passing tool-call fixtures for $from->$to", async ({ from, to }) => {
+    const ir = await requestOut[from](nativeRequest(from));
+    expectIrToolCall(ir);
+
+    const native = await responseOut[to](canonicalResponseIR);
+    expectTargetToolCall(to, native);
+  });
+
+  it.each(
+    protocolCrossPathMatrix.filter((path) => hasPassingFixture(path, "multimodal")),
+  )("guards passing multimodal fixtures for $from->$to", async ({ from, to }) => {
+    const ir = await requestOut[from](nativeRequest(from));
+    expectIrImageDataUrl(ir);
+
+    const toNative = requestIn[to];
+    if (toNative !== undefined) {
+      const native = await toNative(ir);
+      if (to === "openai") expect(JSON.stringify(native)).toContain("data:image/png;base64,AAAA");
+      if (to === "gemini") expectSerializedField(native, "inlineData");
+    }
+  });
+
+  it.each(
+    protocolCrossPathMatrix.filter((path) => hasPassingFixture(path, "json-schema")),
+  )("guards passing JSON schema fixtures for $from->$to", async ({ from, to }) => {
+    const ir = await requestOut[from](nativeRequest(from));
+    expect(ir.response_format).toBeDefined();
+    expect(JSON.stringify(ir.response_format)).toContain("summary");
+
+    const toNative = requestIn[to];
+    expect(toNative).toBeDefined();
+    const native = await toNative?.(ir);
+    expectSerializedField(native, "response_format");
+    expect(JSON.stringify(native)).toContain("summary");
+  });
+
+  it.each(
     protocolCrossPathMatrix,
   )("renders canonical IR responses as $to native responses for $from->$to", async ({ to }) => {
     const native = await responseOut[to](canonicalResponseIR);
     const serialized = JSON.stringify(native);
     expect(native).toBeDefined();
     expect(serialized).toContain("Here is the answer");
+  });
+
+  it.each(
+    protocolCrossPathMatrix.filter((path) => hasPassingFixture(path, "response")),
+  )("guards passing response fixtures for $from->$to", async ({ to }) => {
+    const native = await responseOut[to](canonicalResponseIR);
+    expectTargetToolCall(to, native);
+    expectTargetUsageNotDoubleBilled(to, native);
+  });
+
+  it.each(
+    protocolCrossPathMatrix.filter((path) => hasPassingFixture(path, "usage")),
+  )("guards passing usage fixtures for $from->$to", async ({ from, to }) => {
+    const source = nativeResponse(from);
+    if (source !== undefined) {
+      const ir =
+        from === "openai"
+          ? await openaiTransformer.transformResponseIn(source)
+          : await geminiTransformer.transformResponseIn(source);
+      expectIrUsageNotDoubleBilled(ir);
+    }
+
+    const native = await responseOut[to](canonicalResponseIR);
+    expectTargetUsageNotDoubleBilled(to, native);
   });
 
   it.each(
@@ -341,9 +466,39 @@ describe("protocol cross-path executable harness", () => {
     const anthropicEvents = await collect(convertOpenAIStreamToAnthropic(fromArray(chunks)));
     const geminiEvents = await collect(geminiTransformer.transformStreamOut(fromArray(chunks)));
 
+    const anthropicSerialized = JSON.stringify(anthropicEvents);
+    const geminiSerialized = JSON.stringify(geminiEvents);
+
     expect(anthropicEvents.map((event) => event.type)).toContain("message_stop");
-    expect(JSON.stringify(anthropicEvents)).toContain("input_json_delta");
+    expect(anthropicSerialized).toContain("input_json_delta");
+    expect(anthropicSerialized).toContain("tool_use");
+    expect(anthropicSerialized).toContain("get_weather");
+    expect(anthropicSerialized).toContain("Melbourne");
+    expect(anthropicSerialized).toContain('"input_tokens":7');
+    expect(anthropicSerialized).toContain('"cache_read_input_tokens":3');
     expect(geminiEvents.at(-1)?.usageMetadata?.promptTokenCount).toBe(10);
-    expect(JSON.stringify(geminiEvents)).not.toContain("[DONE]");
+    expect(geminiSerialized).toContain("functionCall");
+    expect(geminiSerialized).toContain("get_weather");
+    expect(geminiSerialized).toContain("Melbourne");
+    expect(geminiSerialized).not.toContain("[DONE]");
+  });
+
+  it.each(
+    protocolCrossPathMatrix.filter((path) => hasPassingFixture(path, "error")),
+  )("guards passing error fixtures for $from->$to", ({ to }) => {
+    expect(to).toBe("anthropic");
+    const out = transformAnthropicErrorOut(
+      makeHelmError({
+        error_class: "rate_limited",
+        message: "matrix rate limit",
+        trace_id: "trace-matrix",
+      }),
+    );
+
+    expect(out.status).toBe(429);
+    expect(out.body).toEqual({
+      type: "error",
+      error: { type: "rate_limit_error", message: "matrix rate limit" },
+    });
   });
 });

--- a/packages/core/src/protocol/protocol-matrix.test.ts
+++ b/packages/core/src/protocol/protocol-matrix.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "vitest";
+import { anthropicTransformer, convertOpenAIStreamToAnthropic } from "./anthropic/index.js";
+import { geminiTransformer } from "./gemini/gemini-transformer.js";
+import type { IRChunk as GeminiIRChunk } from "./gemini/gemini-types.js";
+import type { IRRequest, IRResponse } from "./ir.js";
+import { IRRequestSchema, IRResponseSchema } from "./ir.js";
+import { openaiTransformer } from "./openai.js";
+import {
+  canonicalRequestIR,
+  canonicalResponseIR,
+  type ProtocolName,
+  protocolCrossPathMatrix,
+  protocolMatrixDimensions,
+  protocolMatrixProvenance,
+  protocols,
+} from "./protocol-matrix.fixtures.js";
+import type { Transformer } from "./transformer.js";
+
+async function collect<T>(src: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of src) out.push(item);
+  return out;
+}
+
+async function* fromArray<T>(items: readonly T[]): AsyncIterable<T> {
+  for (const item of items) yield item;
+}
+
+const requestOut: Record<ProtocolName, (native: unknown) => IRRequest | Promise<IRRequest>> = {
+  openai: (native) => openaiTransformer.transformRequestOut(native),
+  anthropic: (native) => anthropicTransformer.transformRequestOut(native),
+  gemini: (native) => geminiTransformer.transformRequestOut(native),
+};
+
+const responseOut: Record<ProtocolName, (ir: IRResponse) => unknown | Promise<unknown>> = {
+  openai: (ir) => openaiTransformer.transformResponseOut(ir),
+  anthropic: (ir) => anthropicTransformer.transformResponseOut(ir),
+  gemini: (ir) => geminiTransformer.transformResponseOut(ir),
+};
+
+const requestIn: Partial<Record<ProtocolName, Transformer["transformRequestIn"]>> = {
+  openai: (ir) => openaiTransformer.transformRequestIn(ir),
+  gemini: (ir) => geminiTransformer.transformRequestIn(ir),
+};
+
+function nativeRequest(protocol: ProtocolName): unknown {
+  if (protocol === "openai") {
+    return {
+      model: "matrix-model",
+      messages: canonicalRequestIR.messages,
+      tools: canonicalRequestIR.tools,
+      tool_choice: "auto",
+      response_format: canonicalRequestIR.response_format,
+      stream: true,
+    };
+  }
+
+  if (protocol === "anthropic") {
+    return {
+      model: "claude-3-5-sonnet",
+      max_tokens: 256,
+      system: "Be precise.",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this image and call the tool." },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Calling weather." },
+            {
+              type: "tool_use",
+              id: "call_weather_0",
+              name: "get_weather",
+              input: { city: "Melbourne" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "call_weather_0", content: "18C" }],
+        },
+      ],
+      tools: [
+        {
+          name: "get_weather",
+          description: "Get weather by city.",
+          input_schema: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+          },
+        },
+      ],
+    };
+  }
+
+  return {
+    systemInstruction: { parts: [{ text: "Be precise." }] },
+    contents: [
+      {
+        role: "user",
+        parts: [
+          { text: "Describe this image and call the tool." },
+          { inlineData: { mimeType: "image/png", data: "AAAA" } },
+        ],
+      },
+      {
+        role: "model",
+        parts: [
+          { text: "Calling weather." },
+          { functionCall: { name: "get_weather", args: { city: "Melbourne" } } },
+        ],
+      },
+      {
+        role: "user",
+        parts: [{ functionResponse: { name: "get_weather", response: { content: "18C" } } }],
+      },
+    ],
+    tools: [
+      {
+        functionDeclarations: [
+          {
+            name: "get_weather",
+            description: "Get weather by city.",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string", format: "city-name" } },
+              required: ["city"],
+            },
+          },
+        ],
+      },
+    ],
+    generationConfig: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: "object",
+        properties: { summary: { type: "string" } },
+        required: ["summary"],
+      },
+    },
+  };
+}
+
+function nativeResponse(protocol: ProtocolName): unknown {
+  if (protocol === "openai") {
+    return {
+      id: "matrix-openai-response",
+      model: "matrix-model",
+      choices: [
+        {
+          index: 0,
+          message: canonicalResponseIR.choices[0]?.message,
+          finish_reason: "tool_calls",
+        },
+      ],
+      usage: {
+        prompt_tokens: 13,
+        completion_tokens: 4,
+        total_tokens: 17,
+        prompt_tokens_details: { cached_tokens: 3 },
+      },
+    };
+  }
+
+  if (protocol === "gemini") {
+    return {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              { text: "Here is the answer." },
+              { functionCall: { name: "get_weather", args: { city: "Melbourne" } } },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 13,
+        cachedContentTokenCount: 3,
+        candidatesTokenCount: 4,
+        totalTokenCount: 17,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+describe("protocol cross-path fixture matrix", () => {
+  it("documents LiteLLM provenance without vendoring code", () => {
+    expect(protocolMatrixProvenance).toContain("behavior/checklist");
+    expect(protocolMatrixProvenance).toContain("no LiteLLM code is copied");
+  });
+
+  it("covers exactly the six non-identity protocol paths", () => {
+    const expected = new Set([
+      "openai->anthropic",
+      "anthropic->openai",
+      "openai->gemini",
+      "gemini->openai",
+      "anthropic->gemini",
+      "gemini->anthropic",
+    ]);
+    const actual = new Set(protocolCrossPathMatrix.map((entry) => `${entry.from}->${entry.to}`));
+
+    expect(actual).toEqual(expected);
+    for (const protocol of protocols) {
+      expect(actual.has(`${protocol}->${protocol}`)).toBe(false);
+    }
+  });
+
+  it("covers every required dimension on every path", () => {
+    for (const path of protocolCrossPathMatrix) {
+      const dimensions = new Set(path.fixtures.map((fixture) => fixture.dimension));
+      expect(dimensions).toEqual(new Set(protocolMatrixDimensions));
+      expect(path.fixtures).toHaveLength(protocolMatrixDimensions.length);
+    }
+  });
+
+  it("keeps todo/failing coverage explicit instead of silently passing gaps", () => {
+    const todos = protocolCrossPathMatrix.flatMap((path) =>
+      path.fixtures.filter((fixture) => fixture.status === "todo"),
+    );
+    expect(todos.length).toBeGreaterThan(0);
+    for (const fixture of todos) {
+      expect(fixture.todoReason).toBeDefined();
+      expect(fixture.todoReason?.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("uses unique fixture ids so future golden files can target one gap at a time", () => {
+    const ids = protocolCrossPathMatrix.flatMap((path) =>
+      path.fixtures.map((fixture) => `${path.from}->${path.to}:${fixture.id}`),
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("protocol cross-path executable harness", () => {
+  it.each(
+    protocolCrossPathMatrix,
+  )("normalizes $from requests to IR before any target nativeOut checks", async ({ from }) => {
+    const ir = await requestOut[from](nativeRequest(from));
+    expect(() => IRRequestSchema.parse(ir)).not.toThrow();
+    expect(ir.messages.length).toBeGreaterThan(0);
+  });
+
+  it.each(
+    protocolCrossPathMatrix.filter((path) => requestIn[path.to] !== undefined),
+  )("converts $from request IR to $to native request without leaking provider_raw", async ({
+    from,
+    to,
+  }) => {
+    const ir = await requestOut[from](nativeRequest(from));
+    const toNative = requestIn[to];
+    expect(toNative).toBeDefined();
+    const native = await toNative?.(ir);
+
+    expect(native).toBeDefined();
+    expect(JSON.stringify(native)).not.toContain("provider_raw");
+  });
+
+  it.each(
+    protocolCrossPathMatrix,
+  )("renders canonical IR responses as $to native responses for $from->$to", async ({ to }) => {
+    const native = await responseOut[to](canonicalResponseIR);
+    const serialized = JSON.stringify(native);
+    expect(native).toBeDefined();
+    expect(serialized).toContain("Here is the answer");
+  });
+
+  it.each(
+    protocolCrossPathMatrix.filter((path) => nativeResponse(path.from) !== undefined),
+  )("normalizes $from provider-native responses before rendering $to native responses", async ({
+    from,
+    to,
+  }) => {
+    const source = nativeResponse(from);
+    const ir =
+      from === "openai"
+        ? await openaiTransformer.transformResponseIn(source)
+        : await geminiTransformer.transformResponseIn(source);
+    expect(() => IRResponseSchema.parse(ir)).not.toThrow();
+
+    const native = await responseOut[to](ir);
+    const serialized = JSON.stringify(native);
+    expect(native).toBeDefined();
+    expect(serialized).toContain("Here is the answer");
+  });
+
+  it("renders OpenAI-style streaming chunks to Anthropic and Gemini target streams", async () => {
+    const chunks: GeminiIRChunk[] = [
+      {
+        id: "chatcmpl-matrix",
+        model: "matrix-model",
+        choices: [{ index: 0, delta: { role: "assistant", content: "Hello" } }],
+      },
+      {
+        id: "chatcmpl-matrix",
+        model: "matrix-model",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_weather_0",
+                  type: "function",
+                  function: { name: "get_weather", arguments: '{"city"' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-matrix",
+        model: "matrix-model",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: 0, function: { arguments: ':"Melbourne"}' } }],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 4, cached_tokens: 3 },
+      },
+    ];
+
+    const anthropicEvents = await collect(convertOpenAIStreamToAnthropic(fromArray(chunks)));
+    const geminiEvents = await collect(geminiTransformer.transformStreamOut(fromArray(chunks)));
+
+    expect(anthropicEvents.map((event) => event.type)).toContain("message_stop");
+    expect(JSON.stringify(anthropicEvents)).toContain("input_json_delta");
+    expect(geminiEvents.at(-1)?.usageMetadata?.promptTokenCount).toBe(10);
+    expect(JSON.stringify(geminiEvents)).not.toContain("[DONE]");
+  });
+});


### PR DESCRIPTION
Refs #45

## 做了什么

- 新增 `packages/core/src/protocol/protocol-matrix.fixtures.ts`，定义 OpenAI / Anthropic / Gemini 六条非 identity 互转路径的 fixture matrix。
- 新增 `packages/core/src/protocol/protocol-matrix.test.ts`，提供 executable harness：校验 6-path matrix 完整性、每条路径覆盖 8 个维度，并对当前已实现的 request / response / streaming 转换做 smoke 验证。
- 明确把当前缺口记录为 `todo` fixture，并要求 `todoReason`，避免 PR A 顺手改 transformer 行为。

## Acceptance Criteria

- [x] 建立 6 条路径矩阵：OpenAI→Anthropic、Anthropic→OpenAI、OpenAI→Gemini、Gemini→OpenAI、Anthropic→Gemini、Gemini→Anthropic。
- [x] 每条路径覆盖 request、response、streaming、tool-call、multimodal、JSON schema、error、usage 8 个维度。
- [x] `todo`/gap fixture 显式写原因，不静默当作通过。
- [x] executable harness 跑当前已实现转换：source request→IR、target response nativeOut、OpenAI/Gemini provider response→IR→target response、OpenAI-style stream→Anthropic/Gemini target stream。
- [x] 不改 gateway / transformer / runtime / pipeline 行为代码。
- [x] provenance 写明只参考 LiteLLM 行为矩阵/compat checklist，不复制、不 vendor LiteLLM 代码。
- [x] 未引入新依赖，未加入截图/录屏/二进制证据。

## 测试

- [x] `pnpm test packages/core/src/protocol/protocol-matrix.test.ts` — 26 passed（有既存 SvelteKit tsconfig warning）
- [x] `pnpm typecheck`
- [x] `pnpm exec biome check packages/core/src/protocol/protocol-matrix.fixtures.ts packages/core/src/protocol/protocol-matrix.test.ts`
- [x] `pnpm lint` — 通过；仍打印仓库既存 `noNonNullAssertion` warnings（非本 PR 新增）
- [x] `git diff --check origin/main...HEAD`

## Provenance

参考 LiteLLM 的公开行为矩阵、compat checklist 和风险点；没有复制、翻译、vendor LiteLLM 代码。

## 边界确认

- 不改行为：本 PR 只加 fixture harness + matrix。
- 不碰 #39：没有 checkout #39 head，没有改 #39 PR body/comment，没有 push #39 分支。
