### PR TITLE
feat(classifier): 多语言处理 — 非拉丁文兜底守卫 + CJK 词边界修复

### DIFF
--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -13,6 +13,12 @@
 # the threshold. Tuned against the golden prompt set (scripts/calibrate-classifier.ts):
 # 29/29 prompts now reach decided_by=rules and route to their intended lanes, with a
 # healthy confidence spread (~0.44–0.91) so the gate still expresses uncertainty.
+#
+# MULTILINGUAL (2026-06-02, classifier.multilingual-guard): the keyword lists are
+# ENGLISH-ONLY, so Layer-1 is an English fast path. A predominantly non-Latin prompt
+# is forced `uncertain` by the `rules.language` guard (below) → escalates to the
+# multilingual Layer-2 eval. CONTRACT: serve non-English traffic → enable `eval`;
+# with eval OFF a non-Latin prompt degrades deterministically to `balanced`.
 classifier:
   rules:
     enabled: true
@@ -96,6 +102,20 @@ classifier:
       short_message_max_chars: 30
       disable_above_chars: 100
       max_history_weight: 0.6
+    # Language-coverage guard. The keyword lists above are ENGLISH-ONLY, so a
+    # predominantly non-Latin prompt (Chinese / Japanese / Korean / Cyrillic / …)
+    # cannot be scored by them. With this on, such a prompt is forced `uncertain` →
+    # the cascade escalates to the (multilingual) Layer-2 eval. CONTRACT: if you
+    # serve non-English traffic, ENABLE eval below — with eval OFF a non-Latin prompt
+    # degrades deterministically to `balanced` (fail-open, no 5xx) rather than being
+    # routed by an English keyword score that never matched anything. The guard is
+    # suppressed for trivially-short prompts (pinned `simple`) and for prompts with a
+    # content-type structural signal (code block / table / attachment / …) that gives
+    # real language-agnostic grip. Latin-script non-English (es/fr/de) is NOT flagged
+    # by ratio; it already produces ~0 keyword signal → low confidence → eval anyway.
+    language:
+      non_latin_uncertain: true
+      non_latin_min_ratio: 0.3
   # Layer-2 (small-model eval) — OPTIONAL, costed, OFF by default. Validated by
   # EvalConfigSchema (@helm/shared): temperature/on_failure/cache.key are locked,
   # max_tokens capped at 1024. Downstream eval modules read this parsed object.

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -101,6 +101,16 @@ wrapped so a degenerate input yields a safe default instead of throwing
   from any boundary approaches 1 (most certain). When confidence is below
   `rules.confidence_threshold`, Layer 1 is treated as uncertain and the cascade
   enters Layer 2 (if eval is enabled), otherwise Layer 3.
+- **Language-coverage guard** (`engine.ts` + `signals.ts`): the keyword lists are
+  **English-only**, so Layer 1 is an English fast path. A predominantly non-Latin
+  prompt (`nonLatinRatio ≥ language.non_latin_min_ratio`) with no content-type
+  structural grip is forced `uncertain` (confidence 0) so the cascade escalates to
+  the multilingual Layer-2 eval. **Operator contract**: serve non-English traffic →
+  enable eval. With eval **off**, a non-Latin prompt degrades deterministically to
+  `balanced` (fail-open) rather than being routed by a keyword score that matched
+  nothing. Latin-script non-English (es/fr/de) is not flagged by ratio, but already
+  yields ~0 keyword signal → low confidence → eval anyway. The guard is suppressed
+  for trivially-short prompts (already pinned `simple`).
 
 ### Tunables live in config
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,28 @@
 
 ---
 
+## 2026-06-02 · Multilingual handling for the Layer-1 classifier (docs/03, Principles 2/3/4)
+
+**Context**: PR #44 expands the **English** Layer-1 keyword vocabulary, which surfaced a pre-existing (not PR-introduced) limitation: the *entire* Layer-1 classifier is implicitly English-only. Layer-1 mixes English keyword signals with language-agnostic structural signals (code blocks, stack traces, math, tables, tools, length). A non-English **prose** request matches zero keywords, lands on the `standard` boundary, and — with eval **ON** — escalates to the multilingual Layer-2 LLM (correct), but with eval **OFF (the shipped default)** degrades to `balanced` only *by luck* of where the structural-only `rawScore` happened to fall. Separately, a latent bug made config-level CJK localization impossible. Chose Hybrid "C": keep keywords as the English fast-path, make non-Latin text *deterministically* escalate, fix the CJK bug, document the contract. Kept **separate** from PR #44 (own branch `feat/classifier-multilingual-guard`).
+
+**What was done (strict TDD, red→green)**:
+1. **CJK word-boundary fix** (`packages/core/src/classifier/dimensions.ts`): `keywordMatcher` wrapped keywords in `(?<![\p{L}\p{N}_])` / `(?![\p{L}\p{N}_])` whenever the edge char was a word char. CJK has no spaces, so a keyword like `分析` inside `请分析这个` is flanked by other `\p{L}` chars → both lookarounds fail → permanently **unmatchable**. Fix: a `CJK` regex (Han/Hiragana/Katakana/Hangul); boundaries are emitted only on a `WORD && !CJK` edge. CJK edges match as plain substrings (their "words" are 1–3 meaningful chars, so the naive-substring false-hit risk boundaries guard against for Latin does not apply). Latin protection (`"ok"`≠`"look"`) is unchanged.
+2. **`nonLatinRatio` detector** (`signals.ts`): fraction of `\p{L}` letters that are NOT `\p{Script=Latin}`; 0 when there are no letters (digits/punct/space ignored). Pure.
+3. **Language-coverage guard** (`engine.ts`, step 5.5): when `language.non_latin_uncertain` is on AND the last user message is longer than `overrides.short_message_max_chars` AND `nonLatinRatio ≥ language.non_latin_min_ratio` AND there is no positive, **non-ambient** dimension hit → force `confidence = 0`, `uncertain = true`, push explanation `low_keyword_coverage`. Forced in the engine, NOT the cascade, because the gateway `runRules` adapter returns only `{complexity, task_type, confidence}` and the cascade gates purely on `confidence` — so a 0 confidence flows through with zero wiring changes.
+4. **Schema + config**: added a prefaulted `language` block to `ClassifierRulesConfigSchema` and `config/classifier.yaml` (defaults `non_latin_uncertain: true`, `non_latin_min_ratio: 0.3`).
+
+**Decisions / trade-offs**:
+- **Why "no positive hit" excludes `msg_length` / `turn_count`**: those *ambient* dimensions fire on essentially every request, so they are not evidence the keyword classifier understood the prompt. Counting them as "grip" would make the guard never fire on long non-Latin prose. Encoded as `AMBIENT_DIMENSIONS` in `engine.ts`. Every other positive hit (keyword match OR a content-type structural signal: code/stack/table/attachment/json/tools) IS grip and correctly suppresses the guard.
+- **`confidence = 0` (maximally uncertain)** rather than a small epsilon: guarantees `< threshold` for any configured threshold, and is honest — we genuinely cannot trust a keyword score on text the keywords never matched.
+- **Rejected Option B (per-language keyword tables)**: combinatorial maintenance + per-language re-calibration (the 06-02 vocab PR shows how fragile that math is). The CJK boundary fix merely makes Option B *possible* later for a team that wants one specific language.
+- **No dedicated cascade test added**: the cascade already gates purely on `confidence` and existing tests cover "uncertain → eval-on→eval / eval-off→balanced(`eval_disabled`)". A non-Latin cascade test would re-assert that with a mocked low-confidence `runRules` — pure duplication. The novel mechanism is proven at the engine level.
+
+**Known edges / TODO**:
+- **Latin-script non-English** (Spanish/French/German) is NOT flagged by `nonLatinRatio`. It already produces ~0 keyword signal → low confidence → eval (when on), so the guard just adds a *hard guarantee* for non-Latin scripts. A future "low absolute keyword coverage" guard could cover Latin-script languages too, but risks over-triggering on legitimately simple English, so it was left out.
+- **Operator contract**: serve non-English traffic → enable Layer-2 eval. With eval off, non-Latin prompts deterministically route to `balanced`. Documented in `config/classifier.yaml` and `docs/03`.
+
+---
+
 ## 2026-06-01 · Pagination + error/role filters for the admin requests list (docs/07, Principle 1)
 
 **Context**: `/admin/requests` fetched a hardcoded `queryRecent(100)` and rendered all rows at once; the UI had dead cursor/"Load more" plumbing that never fired. No way to page past 100 requests or isolate errors / a time window — unusable for real debugging. Added numbered pagination (time DESC) plus Date-range / Status / Decided-by / Lane / Model filters, all applied at the SQL layer so totals stay correct.

--- a/packages/core/src/classifier/dimensions.test.ts
+++ b/packages/core/src/classifier/dimensions.test.ts
@@ -212,3 +212,40 @@ describe("scoreDimensions keyword matching is word-boundary aware", () => {
     ).toBeDefined();
   });
 });
+
+// CJK (Han / Hiragana / Katakana / Hangul) has NO spaces between words, so the
+// word-boundary lookarounds that protect Latin keywords ("ok" inside "look") would
+// otherwise make EVERY CJK keyword embedded in CJK text unmatchable: a keyword like
+// "分析" inside "请分析这个" is flanked by other \p{L} chars, so both boundary
+// lookarounds fail. CJK edges must therefore match as plain substrings. These pin
+// that contract so config-level localization (e.g. a Chinese keyword list) is even
+// possible — see implementation-notes (classifier.multilingual-guard).
+describe("scoreDimensions keyword matching handles CJK (no spurious boundary)", () => {
+  it("MATCHES a CJK keyword embedded mid-sentence in CJK text", () => {
+    const cfg = makeConfig({ analysis_kw: { weight: 0.4, keywords: ["分析", "评估"] } });
+    const res = scoreDimensions(makeReq("请分析这家公司的财务状况"), cfg);
+    expect(res.hits.find((h) => h.dimension === "analysis_kw")).toBeDefined();
+  });
+
+  it("MATCHES a CJK keyword at the start and end of CJK text", () => {
+    const cfg = makeConfig({ analysis_kw: { weight: 0.4, keywords: ["分析"] } });
+    expect(
+      scoreDimensions(makeReq("分析这个"), cfg).hits.find((h) => h.dimension === "analysis_kw"),
+    ).toBeDefined();
+    expect(
+      scoreDimensions(makeReq("请你分析"), cfg).hits.find((h) => h.dimension === "analysis_kw"),
+    ).toBeDefined();
+  });
+
+  it("MATCHES a Japanese (Hiragana/Kanji) keyword embedded in Japanese text", () => {
+    const cfg = makeConfig({ coding_kw: { weight: 0.3, keywords: ["実装"] } });
+    const res = scoreDimensions(makeReq("この関数を実装してください"), cfg);
+    expect(res.hits.find((h) => h.dimension === "coding_kw")).toBeDefined();
+  });
+
+  it("STILL enforces Latin word boundaries (CJK fix must not regress 'ok' in 'look')", () => {
+    const cfg = makeConfig();
+    const res = scoreDimensions(makeReq("look at the book on the shelf"), cfg);
+    expect(res.hits.find((h) => h.dimension === "simple_kw")).toBeUndefined();
+  });
+});

--- a/packages/core/src/classifier/dimensions.ts
+++ b/packages/core/src/classifier/dimensions.ts
@@ -148,12 +148,21 @@ function escapeRegExp(s: string): string {
 }
 
 const WORD = /[\p{L}\p{N}_]/u; // unicode letter/number/underscore
+// CJK scripts (Han / Hiragana / Katakana / Hangul) write words WITHOUT spaces, so a
+// CJK edge char would NEVER satisfy the word-boundary lookaround below — "分析" inside
+// "请分析这个" is flanked by other \p{L} chars, so both lookarounds fail and the keyword
+// becomes permanently unmatchable. CJK edges therefore match as plain substrings (their
+// "words" are 1–3 meaningful chars, so the naive-substring false-hit risk that boundaries
+// guard against for Latin does not apply). This is what makes config-level CJK keyword
+// lists possible at all (see implementation-notes: classifier.multilingual-guard).
+const CJK = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+const needsBoundary = (ch: string): boolean => WORD.test(ch) && !CJK.test(ch);
 const keywordMatcherCache = new Map<string, RegExp>();
 function keywordMatcher(kw: string): RegExp {
   let re = keywordMatcherCache.get(kw);
   if (re === undefined) {
-    const left = WORD.test(kw[0] ?? "") ? "(?<![\\p{L}\\p{N}_])" : "";
-    const right = WORD.test(kw[kw.length - 1] ?? "") ? "(?![\\p{L}\\p{N}_])" : "";
+    const left = needsBoundary(kw[0] ?? "") ? "(?<![\\p{L}\\p{N}_])" : "";
+    const right = needsBoundary(kw[kw.length - 1] ?? "") ? "(?![\\p{L}\\p{N}_])" : "";
     re = new RegExp(left + escapeRegExp(kw) + right, "iu");
     keywordMatcherCache.set(kw, re);
   }

--- a/packages/core/src/classifier/engine.test.ts
+++ b/packages/core/src/classifier/engine.test.ts
@@ -276,6 +276,68 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     expect(out.confidence).toBeLessThanOrEqual(1);
   });
 
+  // ── language-coverage guard ────────────────────────────────────────────────
+  // The keyword lists are English-only, so a predominantly non-Latin prompt can't
+  // be scored by them. The guard forces `uncertain` (confidence 0) so the cascade
+  // escalates to the multilingual Layer-2 eval — UNLESS a content-type structural
+  // signal gave real grip, or the message is trivially short. See plan / notes
+  // (classifier.multilingual-guard).
+  const longZh =
+    "请帮我详细分析这家公司过去三年的财务状况和现金流情况，并结合所在行业的整体趋势给出具体的投资建议以及主要风险点的评估和应对措施";
+
+  it("language guard: long non-Latin prose with no structural grip is forced uncertain", () => {
+    const cfg = makeConfig();
+    const req = makeRequest({ messages: [{ role: "user", content: longZh }] });
+    const out = scoreRequest(req, { cfg, approxTokens: 40 });
+
+    expect(out.uncertain).toBe(true);
+    expect(out.confidence).toBe(0);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(true);
+  });
+
+  it("language guard: a content-type structural hit (attachment) suppresses the guard", () => {
+    const cfg = makeConfig();
+    const req = makeRequest({
+      messages: [{ role: "user", content: longZh }],
+      attachments: [{ type: "image", url: "x" }],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 40 });
+
+    // has_attachment is real, language-agnostic grip → trust the tier, do not force.
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it("language guard: a short non-Latin greeting stays simple, guard skipped", () => {
+    const cfg = makeConfig();
+    const req = makeRequest({ messages: [{ role: "user", content: "你好" }] });
+    const out = scoreRequest(req, { cfg, approxTokens: 1 });
+
+    expect(out.complexity).toBe("simple"); // short_message override still pins simple
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it("language guard: English prose is unaffected (ratio 0)", () => {
+    const cfg = makeConfig();
+    const req = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Please give me a thorough overview of how the company performed financially across the last three fiscal years.",
+        },
+      ],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 40 });
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it("language guard: disabled via config → non-Latin prose not forced", () => {
+    const cfg = makeConfig({ language: { non_latin_uncertain: false } });
+    const req = makeRequest({ messages: [{ role: "user", content: longZh }] });
+    const out = scoreRequest(req, { cfg, approxTokens: 40 });
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
   it("records final tier back into momentum history (write-back)", () => {
     const cfg = makeConfig();
     const sessionKey = "sess-wb";

--- a/packages/core/src/classifier/engine.test.ts
+++ b/packages/core/src/classifier/engine.test.ts
@@ -331,6 +331,71 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
+  it("language guard: historical English keyword hits do not suppress current non-Latin prose", () => {
+    const cfg = makeConfig();
+    const req = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content: "Please refactor this function and prove the theorem step by step.",
+        },
+        { role: "assistant", content: "Sure, here is the coding and reasoning outline." },
+        { role: "user", content: longZh },
+      ],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 80 });
+
+    expect(out.uncertain).toBe(true);
+    expect(out.confidence).toBe(0);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(true);
+  });
+
+  it("language guard: current code block suppresses guard even after historical English hits", () => {
+    const cfg = makeConfig();
+    const req = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content: "Please refactor this function and prove the theorem step by step.",
+        },
+        {
+          role: "user",
+          content: `${longZh}\n\n\`\`\`ts\nfunction broken() { return 1 }\n\`\`\``,
+        },
+      ],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 80 });
+
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it.each([
+    [
+      "Japanese",
+      "この会社の過去三年間の財務状況とキャッシュフローを詳しく分析し、業界動向も踏まえて投資判断と主要なリスクを具体的に説明してください",
+    ],
+    [
+      "Korean",
+      "이 회사의 지난 삼 년간 재무 상태와 현금 흐름을 자세히 분석하고 업계 동향을 반영해 투자 의견과 주요 위험을 구체적으로 설명해 주세요",
+    ],
+    [
+      "mixed Chinese and English",
+      "请 analyze 这家公司过去三年的 financial performance、cash flow、资产负债变化和主要 risk，并结合行业趋势给出具体 investment 建议以及风险缓释措施",
+    ],
+    [
+      "Cyrillic",
+      "Проанализируй финансовое состояние этой компании за последние три года и подробно оцени денежные потоки, отраслевые тенденции, инвестиционные риски и возможные рекомендации",
+    ],
+  ])("language guard: %s long prose is forced uncertain", (_label, content) => {
+    const cfg = makeConfig();
+    const req = makeRequest({ messages: [{ role: "user", content }] });
+    const out = scoreRequest(req, { cfg, approxTokens: 60 });
+
+    expect(out.uncertain).toBe(true);
+    expect(out.confidence).toBe(0);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(true);
+  });
+
   it("language guard: disabled via config → non-Latin prose not forced", () => {
     const cfg = makeConfig({ language: { non_latin_uncertain: false } });
     const req = makeRequest({ messages: [{ role: "user", content: longZh }] });

--- a/packages/core/src/classifier/engine.ts
+++ b/packages/core/src/classifier/engine.ts
@@ -1,7 +1,8 @@
 import type { ClassifierRulesConfig, InternalRequest } from "@helm/shared";
-import { scoreDimensions } from "./dimensions.js";
+import { type DimensionScore, scoreDimensions } from "./dimensions.js";
 import { applyMomentum, type MomentumDeps, recordMomentum } from "./momentum.js";
 import { applyOverrides, evaluateOverrides } from "./overrides.js";
+import { nonLatinRatio } from "./signals.js";
 import { detectTask, type TaskType } from "./taskdetect.js";
 import { type Complexity, classifyTier } from "./tiers.js";
 
@@ -127,6 +128,24 @@ export function scoreRequest(req: InternalRequest, deps: ScoreRequestDeps): Clas
   const task = safe(() => detectTask(req, cfg), { task_type: "chat" as TaskType, scores: [] });
   explanation.push({ source: "task", detail: task.task_type });
 
+  // ── 5.5 language-coverage guard ───────────────────────────────────────────
+  // The keyword lists are ENGLISH-ONLY (CLAUDE.md: Layer-1 is the English fast
+  // path). A predominantly non-Latin prompt therefore cannot be scored by them, so
+  // a high-confidence keyword verdict on it would be a lie. Force `uncertain` so the
+  // cascade escalates to the (multilingual) Layer-2 eval — or, with eval OFF, lands
+  // `balanced` deterministically rather than by luck of where the structural-only
+  // rawScore fell. Suppressed when (a) the message is trivially short (already pinned
+  // `simple` by the short_message override) or (b) a CONTENT-TYPE structural signal
+  // gave real, language-agnostic grip (code block / stack / table / attachment / …).
+  // Ambient signals (msg_length / turn_count) fire on every request and are NOT grip.
+  let confidence = tier.confidence;
+  let uncertain = tier.uncertain;
+  if (safe(() => languageGuardTrips(req, cfg, dim.hits), false)) {
+    confidence = 0;
+    uncertain = true;
+    explanation.push({ source: "override", detail: "low_keyword_coverage" });
+  }
+
   // ── 6. derive constraints ─────────────────────────────────────────────────
   const constraints = deriveConstraints(req, approxTokens, cfg, complexity, overrideHits);
 
@@ -145,12 +164,39 @@ export function scoreRequest(req: InternalRequest, deps: ScoreRequestDeps): Clas
   return {
     complexity,
     task_type: task.task_type,
-    confidence: tier.confidence,
-    uncertain: tier.uncertain,
+    confidence,
+    uncertain,
     decided_by: "rules",
     constraints,
     explanation,
   };
+}
+
+// Ambient structural dimensions fire on (almost) every request, so they are NOT
+// evidence that the keyword classifier actually understood the prompt — they must
+// not suppress the language guard. Every OTHER positive-contribution dimension hit
+// (keyword match or a content-type structural signal) IS real grip.
+const AMBIENT_DIMENSIONS = new Set(["msg_length", "turn_count"]);
+
+// True when Layer-1's English keyword lists have no purchase on a non-Latin prompt
+// and nothing else gave it real grip — see step 5.5. Pure: reads only its inputs.
+function languageGuardTrips(
+  req: InternalRequest,
+  cfg: ClassifierRulesConfig,
+  hits: DimensionScore["hits"],
+): boolean {
+  // Robust to a config SUBSET (dimensions.ts contract): an absent `language` block
+  // (or an older parsed config) simply disables the guard rather than throwing.
+  const lang = cfg.language;
+  if (!lang?.non_latin_uncertain) return false;
+  const text = lastUserMessageText(req.messages).trim();
+  // Trivially short prompts are pinned `simple` by the short_message override; do
+  // not escalate them. Reuse the same char threshold so the two stay consistent.
+  if (text.length <= cfg.overrides.short_message_max_chars) return false;
+  if (nonLatinRatio(text) < lang.non_latin_min_ratio) return false;
+  // Any positive, non-ambient hit (keyword or content-type structural) = real grip.
+  const hasGrip = hits.some((h) => h.contribution > 0 && !AMBIENT_DIMENSIONS.has(h.dimension));
+  return !hasGrip;
 }
 
 // ── constraint derivation ──────────────────────────────────────────────────
@@ -200,14 +246,18 @@ function round(n: number): number {
   return Math.round(n * 1000) / 1000;
 }
 
-function lastUserMessageChars(messages: InternalRequest["messages"]): number {
+function lastUserMessageText(messages: InternalRequest["messages"]): string {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const msg = messages[i];
     if (msg && msg.role === "user") {
-      return contentToString(msg.content).trim().length;
+      return contentToString(msg.content);
     }
   }
-  return 0;
+  return "";
+}
+
+function lastUserMessageChars(messages: InternalRequest["messages"]): number {
+  return lastUserMessageText(messages).trim().length;
 }
 
 function contentToString(content: unknown): string {

--- a/packages/core/src/classifier/engine.ts
+++ b/packages/core/src/classifier/engine.ts
@@ -1,5 +1,5 @@
 import type { ClassifierRulesConfig, InternalRequest } from "@helm/shared";
-import { type DimensionScore, scoreDimensions } from "./dimensions.js";
+import { scoreDimensions } from "./dimensions.js";
 import { applyMomentum, type MomentumDeps, recordMomentum } from "./momentum.js";
 import { applyOverrides, evaluateOverrides } from "./overrides.js";
 import { nonLatinRatio } from "./signals.js";
@@ -140,7 +140,7 @@ export function scoreRequest(req: InternalRequest, deps: ScoreRequestDeps): Clas
   // Ambient signals (msg_length / turn_count) fire on every request and are NOT grip.
   let confidence = tier.confidence;
   let uncertain = tier.uncertain;
-  if (safe(() => languageGuardTrips(req, cfg, dim.hits), false)) {
+  if (safe(() => languageGuardTrips(req, cfg), false)) {
     confidence = 0;
     uncertain = true;
     explanation.push({ source: "override", detail: "low_keyword_coverage" });
@@ -180,11 +180,7 @@ const AMBIENT_DIMENSIONS = new Set(["msg_length", "turn_count"]);
 
 // True when Layer-1's English keyword lists have no purchase on a non-Latin prompt
 // and nothing else gave it real grip — see step 5.5. Pure: reads only its inputs.
-function languageGuardTrips(
-  req: InternalRequest,
-  cfg: ClassifierRulesConfig,
-  hits: DimensionScore["hits"],
-): boolean {
+function languageGuardTrips(req: InternalRequest, cfg: ClassifierRulesConfig): boolean {
   // Robust to a config SUBSET (dimensions.ts contract): an absent `language` block
   // (or an older parsed config) simply disables the guard rather than throwing.
   const lang = cfg.language;
@@ -194,8 +190,17 @@ function languageGuardTrips(
   // not escalate them. Reuse the same char threshold so the two stay consistent.
   if (text.length <= cfg.overrides.short_message_max_chars) return false;
   if (nonLatinRatio(text) < lang.non_latin_min_ratio) return false;
+
+  // Guard suppression must be based on the CURRENT user turn only. Historical
+  // English keyword hits are useful for the total score, but they are not evidence
+  // that Layer-1 understood this non-Latin prompt.
+  const currentUserMessage = lastUserMessage(req.messages);
+  if (!currentUserMessage) return false;
+  const currentHits = scoreDimensions({ ...req, messages: [currentUserMessage] }, cfg).hits;
   // Any positive, non-ambient hit (keyword or content-type structural) = real grip.
-  const hasGrip = hits.some((h) => h.contribution > 0 && !AMBIENT_DIMENSIONS.has(h.dimension));
+  const hasGrip = currentHits.some(
+    (h) => h.contribution > 0 && !AMBIENT_DIMENSIONS.has(h.dimension),
+  );
   return !hasGrip;
 }
 
@@ -246,14 +251,19 @@ function round(n: number): number {
   return Math.round(n * 1000) / 1000;
 }
 
-function lastUserMessageText(messages: InternalRequest["messages"]): string {
+function lastUserMessage(
+  messages: InternalRequest["messages"],
+): InternalRequest["messages"][number] | null {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const msg = messages[i];
-    if (msg && msg.role === "user") {
-      return contentToString(msg.content);
-    }
+    if (msg && msg.role === "user") return msg;
   }
-  return "";
+  return null;
+}
+
+function lastUserMessageText(messages: InternalRequest["messages"]): string {
+  const msg = lastUserMessage(messages);
+  return msg ? contentToString(msg.content) : "";
 }
 
 function lastUserMessageChars(messages: InternalRequest["messages"]): number {

--- a/packages/core/src/classifier/signals.test.ts
+++ b/packages/core/src/classifier/signals.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { nonLatinRatio } from "./signals.js";
+
+// nonLatinRatio measures the fraction of *letters* (\p{L}) that are NOT Latin
+// script. It feeds the Layer-1 language-coverage guard (engine.ts): the keyword
+// lists are English-only, so a predominantly non-Latin prompt cannot be scored by
+// keywords and must be marked uncertain → escalate to the (multilingual) Layer-2
+// eval. Punctuation, digits and whitespace are NOT letters and so never skew the
+// ratio. Pure: same input => same output (CLAUDE.md principle 4).
+describe("nonLatinRatio", () => {
+  it("is 0 for pure English/Latin prose", () => {
+    expect(nonLatinRatio("please analyze this company's financials")).toBe(0);
+  });
+
+  it("is ~1 for pure Chinese prose", () => {
+    expect(nonLatinRatio("请帮我分析这家公司的财务状况")).toBeGreaterThan(0.95);
+  });
+
+  it("is ~1 for Japanese / Korean prose", () => {
+    expect(nonLatinRatio("この関数を実装してください")).toBeGreaterThan(0.95);
+    expect(nonLatinRatio("이 회사를 분석해 주세요")).toBeGreaterThan(0.95);
+  });
+
+  it("is fractional for mixed-script text", () => {
+    // "analyze 这家 company" → 7+7 Latin letters, 2 Han letters → 2/16
+    const r = nonLatinRatio("analyze 这家 company");
+    expect(r).toBeGreaterThan(0);
+    expect(r).toBeLessThan(0.5);
+  });
+
+  it("is 0 when there are no letters (digits / punctuation / whitespace only)", () => {
+    expect(nonLatinRatio("12345 !!! ... \n\t")).toBe(0);
+    expect(nonLatinRatio("")).toBe(0);
+  });
+
+  it("ignores non-letter characters when computing the ratio", () => {
+    // Digits, spaces and punctuation are excluded; only the Han letters count → ~1.
+    expect(nonLatinRatio("分析：2024年第三季度报告")).toBeGreaterThan(0.95);
+  });
+});

--- a/packages/core/src/classifier/signals.ts
+++ b/packages/core/src/classifier/signals.ts
@@ -61,3 +61,22 @@ export function normalize(value: number, saturateAt: number): number {
 export function lengthSignal(text: string): number {
   return normalize(text.trim().length, 2000);
 }
+
+// Fraction of LETTERS (\p{L}) that are NOT Latin script, in [0,1]; 0 when there are
+// no letters. Digits, punctuation and whitespace are ignored so they never skew the
+// ratio. The Layer-1 keyword lists are English-only, so a predominantly non-Latin
+// prompt is unscoreable by keywords — the engine's language-coverage guard uses this
+// to force `uncertain` and escalate to the (multilingual) Layer-2 eval. Pure: same
+// input => same output, zero I/O (CLAUDE.md principle 4).
+const LETTER = /\p{L}/u;
+const LATIN_LETTER = /\p{Script=Latin}/u;
+export function nonLatinRatio(text: string): number {
+  let letters = 0;
+  let nonLatin = 0;
+  for (const ch of text) {
+    if (!LETTER.test(ch)) continue;
+    letters += 1;
+    if (!LATIN_LETTER.test(ch)) nonLatin += 1;
+  }
+  return letters === 0 ? 0 : nonLatin / letters;
+}

--- a/packages/shared/src/config/classifier-schema.ts
+++ b/packages/shared/src/config/classifier-schema.ts
@@ -57,6 +57,19 @@ export const ClassifierRulesConfigSchema = z.object({
     disable_above_chars: z.number().int().positive().default(100),
     max_history_weight: z.number().min(0).max(1).default(0.6),
   }),
+  // Language-coverage guard. The keyword lists above are ENGLISH-ONLY, so a
+  // predominantly non-Latin prompt (Chinese / Japanese / Korean / Cyrillic / …)
+  // cannot be scored by keywords. When `non_latin_uncertain` is on, such a prompt
+  // is forced `uncertain` so the cascade escalates to the (multilingual) Layer-2
+  // eval — or, with eval OFF, degrades deterministically to `balanced` instead of
+  // a misleading high-confidence keyword verdict. Prefaulted so an omitted block
+  // parses through inner defaults (fail-open, principle 3).
+  language: z
+    .object({
+      non_latin_uncertain: z.boolean().default(true),
+      non_latin_min_ratio: z.number().min(0).max(1).default(0.3),
+    })
+    .prefault({}),
 });
 
 // Layer-2 eval block — the hardened schema is the single source of truth, defined


### PR DESCRIPTION
## 背景

[PR #44](https://github.com/EasyMetaAu/helm-api/pull/44) 扩充的是 **英文** 关键词词表。这暴露了一个**早已存在、并非 #44 引入**的限制：整个 Layer-1 分类器是隐式英文-only 的。

Layer-1 混合了两类信号：**英文关键词**（`*_kw` 维度 + `task_keywords`）与**语言无关的结构信号**（代码块、堆栈、数学、表格、工具、长度）。一个非英文**散文**请求（如 `请帮我分析这家公司的财务状况并给出投资建议`）：

- 命中**零**关键词 → `rawScore ≈ 0` → 落在 `standard` 边界 → 低置信度 `uncertain`；
- eval **开** → 升级到（天然多语言的）Layer-2 LLM —— 正确；
- eval **关（出厂默认）** → `decided_by=fallback`，原因 `eval_disabled` → **永远 `balanced`**，无视真实复杂度。

是 fail-open（不 5xx），但非英文流量的 lane 系统形同虚设，且升级与否只是"碰运气"看结构信号把分数推到哪里。

另有一个潜伏 bug：`keywordMatcher` 对词字符边给关键词包上 `(?<![\p{L}\p{N}_])` / `(?![\p{L}\p{N}_])` 词边界。CJK 无空格，`分析` 嵌在 `请分析这个` 中两侧都是 `\p{L}` → 两个 lookaround 都失败 → **永不匹配**。即便有人今天手动把 config 本地化成中文，关键词也是死的。

## 方案（Hybrid C）

不再假装关键词能跨语言泛化。保留它作为**英文快路径**；让非拉丁文本**确定性地**升级到 eval；修掉 CJK bug；诚实地把契约写进文档。所有 Layer-1 改动保持纯函数（原则 4）、config 驱动（原则 2）。严格 TDD（红→绿）。

| 改动 | 文件 |
|---|---|
| CJK（Han/Hiragana/Katakana/Hangul）词边按**子串**匹配；拉丁边界保护不变 | `dimensions.ts` |
| `nonLatinRatio()` 纯检测器（非拉丁字母占比） | `signals.ts` |
| 语言覆盖守卫：长非拉丁散文 + 无内容型结构信号 → 强制 `uncertain`（置信度 0）→ 升级 Layer-2 eval。`safe()` 包裹、容忍 config 子集（fail-open） | `engine.ts` |
| 默认 `language` 配置块 + 契约注释 | `classifier-schema.ts`、`config/classifier.yaml` |
| 契约文档 | `docs/03-classification.md`、`implementation-notes.md` |

### 运维契约（已写入文档）
**服务非英文流量 → 开启 Layer-2 eval。** eval 关闭时，非拉丁文请求**确定性**降级到 `balanced`，而不是被一个从未命中的英文关键词分数瞎路由。

### 关键取舍
- **"无正向命中" 排除 `msg_length` / `turn_count`**：这两个 *ambient* 维度几乎每个请求都触发，不算分类器真正"抓住"了语义；否则守卫永远不会在长非拉丁散文上触发。其它任何正向命中（关键词 OR 内容型结构信号：代码/堆栈/表格/附件/json/工具）算真正的 grip，正确抑制守卫。
- **强制 `confidence = 0`**（而非小 epsilon）：对任意阈值都保证 `< threshold`，且诚实 —— 我们确实无法信任一个从未匹配过文本的关键词分数。
- **未采纳 Option B（按语言建关键词表）**：组合爆炸式维护 + 每种语言都要重新校准（06-02 词表 PR 已证明这套数学多脆弱）。CJK 边界修复只是让 Option B 未来**有可能**。

### 已知边界
**拉丁字母系非英文**（西/法/德）不会被 ratio 命中。它们本就产生 ~0 关键词信号 → 低置信度 → eval（开启时）仍会兜住；守卫只是为非拉丁文字系**加了一道硬保证**。已记入 implementation-notes。

## 验证

| 检查项 | 结果 |
|---|---|
| 新增 TDD 用例（4 CJK + 6 nonLatinRatio + 5 守卫） | 红→绿 |
| `pnpm test` 全量 | **1343/1343** |
| `calibrate-classifier.ts` | **29/29 lane 正确、0 fallback**（守卫从不在英文 prompt 触发，ratio=0） |
| typecheck / lint（改动文件） | 通过 / 干净 |

完整 rationale 见 `config/classifier.yaml` 头部 + `language` 块注释，以及 `implementation-notes.md`（2026-06-02 条目）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)