### PR TITLE
feat(protocol): 补齐 Gemini toolConfig/schema/multimodal 兼容

### DIFF
--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -371,6 +371,24 @@ describe("schema format sanitize (date / date-time pit)", () => {
     expect(props.merged?.properties).toEqual({ ok: { type: "boolean" } });
   });
 
+  it("merges allOf object shape with sibling properties and required fields", () => {
+    const schema = {
+      allOf: [
+        {
+          type: "object",
+          properties: { a: { type: "string" } },
+          required: ["a"],
+        },
+      ],
+      properties: { b: { type: "number" } },
+      required: ["b"],
+    };
+
+    const cleaned = sanitizeSchema(schema) as Record<string, unknown>;
+    expect(cleaned.properties).toEqual({ a: { type: "string" }, b: { type: "number" } });
+    expect(cleaned.required).toEqual(["a", "b"]);
+  });
+
   it("sanitizes functionDeclarations parameters on the outbound request", () => {
     const ir: IRRequest = {
       model: "gemini-1.5-pro",

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -240,6 +240,32 @@ describe("tool-call id synthesis (the core pit)", () => {
     });
   });
 
+  it("uses the original function name, not tool_call_id, when emitting Gemini functionResponse", () => {
+    const ir: IRRequest = {
+      model: "gemini-1.5-pro",
+      messages: [
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_weather_0",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"SF"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_weather_0", content: "72F sunny" },
+      ],
+    };
+
+    const native = geminiTransformer.transformRequestIn(ir) as GeminiGenerateContentRequest;
+    const response = native.contents[1]?.parts[0] as {
+      functionResponse: { name: string; response: unknown };
+    };
+    expect(response.functionResponse.name).toBe("get_weather");
+  });
+
   it("drops synthesized ids when going IR -> Gemini (outbound)", () => {
     const ir: IRRequest = {
       model: "gemini-1.5-pro",
@@ -314,6 +340,35 @@ describe("schema format sanitize (date / date-time pit)", () => {
     expect(props.email?.format).toBeUndefined();
     expect(props.email?.pattern).toBeUndefined();
     expect(props.choice?.anyOf).toBeUndefined();
+  });
+
+  it("resolves local refs and folds combinators instead of silently weakening schema", () => {
+    const schema = {
+      type: "object",
+      $defs: {
+        City: { type: "string", description: "city name", minLength: 1 },
+        Place: {
+          type: "object",
+          properties: { city: { $ref: "#/$defs/City" } },
+          required: ["city"],
+        },
+      },
+      properties: {
+        place: { $ref: "#/$defs/Place" },
+        choice: { oneOf: [{ $ref: "#/$defs/City" }, { type: "number" }] },
+        merged: { allOf: [{ type: "object" }, { properties: { ok: { type: "boolean" } } }] },
+      },
+    };
+
+    const cleaned = sanitizeSchema(schema) as Record<string, unknown>;
+    expect(cleaned.$defs).toBeUndefined();
+    const props = cleaned.properties as Record<string, Record<string, unknown> | undefined>;
+    expect(props.place?.type).toBe("object");
+    const placeProps = props.place?.properties as Record<string, Record<string, unknown>>;
+    expect(placeProps.city).toEqual({ type: "string", description: "city name" });
+    expect(props.choice).toEqual({ type: "string", description: "city name" });
+    expect(props.merged?.type).toBe("object");
+    expect(props.merged?.properties).toEqual({ ok: { type: "boolean" } });
   });
 
   it("sanitizes functionDeclarations parameters on the outbound request", () => {

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -63,6 +63,28 @@ describe("GeminiTransformer.transformRequestOut (Gemini generateContent -> IR)",
     // generationConfig.maxOutputTokens -> max_tokens
     expect(ir.max_tokens).toBe(256);
   });
+
+  it("normalizes Gemini toolConfig functionCallingConfig into IR tool_choice", () => {
+    expect(
+      (
+        geminiTransformer.transformRequestOut({
+          contents: [{ role: "user", parts: [{ text: "x" }] }],
+          toolConfig: { functionCallingConfig: { mode: "NONE" } },
+        }) as IRRequest
+      ).tool_choice,
+    ).toBe("none");
+
+    expect(
+      (
+        geminiTransformer.transformRequestOut({
+          contents: [{ role: "user", parts: [{ text: "x" }] }],
+          toolConfig: {
+            functionCallingConfig: { mode: "ANY", allowedFunctionNames: ["get_weather"] },
+          },
+        }) as IRRequest
+      ).tool_choice,
+    ).toEqual({ type: "function", function: { name: "get_weather" } });
+  });
 });
 
 describe("GeminiTransformer.transformResponseOut (IR -> Gemini response)", () => {
@@ -170,6 +192,54 @@ describe("tool-call id synthesis (the core pit)", () => {
     expect(toolMsgs[1]?.tool_call_id).toBe(id1);
   });
 
+  it("maps OpenAI tool_choice into Gemini functionCallingConfig", () => {
+    const base: IRRequest = {
+      model: "gemini-1.5-pro",
+      messages: [{ role: "user", content: "weather?" }],
+      tools: [
+        {
+          type: "function",
+          function: { name: "get_weather", parameters: { type: "object" } },
+        },
+      ],
+    };
+
+    expect(
+      (
+        geminiTransformer.transformRequestIn({
+          ...base,
+          tool_choice: "auto",
+        }) as GeminiGenerateContentRequest
+      ).toolConfig,
+    ).toEqual({ functionCallingConfig: { mode: "AUTO" } });
+    expect(
+      (
+        geminiTransformer.transformRequestIn({
+          ...base,
+          tool_choice: "none",
+        }) as GeminiGenerateContentRequest
+      ).toolConfig,
+    ).toEqual({ functionCallingConfig: { mode: "NONE" } });
+    expect(
+      (
+        geminiTransformer.transformRequestIn({
+          ...base,
+          tool_choice: "required",
+        }) as GeminiGenerateContentRequest
+      ).toolConfig,
+    ).toEqual({ functionCallingConfig: { mode: "ANY" } });
+    expect(
+      (
+        geminiTransformer.transformRequestIn({
+          ...base,
+          tool_choice: { type: "function", function: { name: "get_weather" } },
+        }) as GeminiGenerateContentRequest
+      ).toolConfig,
+    ).toEqual({
+      functionCallingConfig: { mode: "ANY", allowedFunctionNames: ["get_weather"] },
+    });
+  });
+
   it("drops synthesized ids when going IR -> Gemini (outbound)", () => {
     const ir: IRRequest = {
       model: "gemini-1.5-pro",
@@ -226,6 +296,26 @@ describe("schema format sanitize (date / date-time pit)", () => {
     expect(items.type).toBe("string");
   });
 
+  it("strips Gemini-unsupported schema keywords recursively", () => {
+    const schema = {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        email: { type: "string", format: "email", pattern: "@" },
+        choice: { anyOf: [{ type: "string" }, { type: "number" }] },
+      },
+    };
+
+    const cleaned = sanitizeSchema(schema) as Record<string, unknown>;
+    expect(cleaned.$schema).toBeUndefined();
+    expect(cleaned.additionalProperties).toBeUndefined();
+    const props = cleaned.properties as Record<string, Record<string, unknown> | undefined>;
+    expect(props.email?.format).toBeUndefined();
+    expect(props.email?.pattern).toBeUndefined();
+    expect(props.choice?.anyOf).toBeUndefined();
+  });
+
   it("sanitizes functionDeclarations parameters on the outbound request", () => {
     const ir: IRRequest = {
       model: "gemini-1.5-pro",
@@ -250,6 +340,52 @@ describe("schema format sanitize (date / date-time pit)", () => {
     };
     expect(params.properties.date?.format).toBeUndefined();
     expect(params.properties.date?.type).toBe("string");
+  });
+
+  it("emits sanitized Gemini responseSchema from IR response_format json_schema", () => {
+    const ir: IRRequest = {
+      model: "gemini-1.5-pro",
+      messages: [{ role: "user", content: "return json" }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "answer",
+          schema: {
+            type: "object",
+            properties: { when: { type: "string", format: "date-time" } },
+            required: ["when"],
+          },
+        },
+      },
+    };
+
+    const native = geminiTransformer.transformRequestIn(ir) as GeminiGenerateContentRequest;
+    expect(native.generationConfig?.responseMimeType).toBe("application/json");
+    const schema = native.generationConfig?.responseSchema as {
+      properties: Record<string, Record<string, unknown> | undefined>;
+    };
+    expect(schema.properties.when?.format).toBeUndefined();
+    expect(schema.properties.when?.description).toContain("format: date-time");
+  });
+
+  it("keeps remote image outbound as explicit text non-goal instead of invalid inlineData", () => {
+    const ir: IRRequest = {
+      model: "gemini-1.5-pro",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "describe" },
+            { type: "image", url: "https://example.com/cat.png", mediaType: "image/png" },
+          ],
+        },
+      ],
+    };
+
+    const native = geminiTransformer.transformRequestIn(ir) as GeminiGenerateContentRequest;
+    expect(JSON.stringify(native)).not.toContain("inlineData");
+    expect(JSON.stringify(native)).toContain("remote image unsupported");
+    expect(JSON.stringify(native)).toContain("https://example.com/cat.png");
   });
 });
 

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -223,6 +223,9 @@ function transformRequestOut(native: unknown): IRRequest {
     ...(gc?.temperature !== undefined ? { temperature: gc.temperature } : {}),
     ...(gc?.maxOutputTokens !== undefined ? { max_tokens: gc.maxOutputTokens } : {}),
     ...(responseFormat !== undefined ? { response_format: responseFormat } : {}),
+    ...(geminiToolConfigToToolChoice(req.toolConfig) !== undefined
+      ? { tool_choice: geminiToolConfigToToolChoice(req.toolConfig) }
+      : {}),
   };
 
   return IRRequestSchema.parse(ir);
@@ -266,7 +269,9 @@ function irMessageToParts(message: IRMessage): GeminiPart[] {
         const match = /^data:([^;]+);base64,(.*)$/.exec(part.url);
         if (match !== null && match[1] !== undefined && match[2] !== undefined) {
           parts.push({ inlineData: { mimeType: match[1], data: match[2] } });
-        } else parts.push({ text: part.url });
+        } else {
+          parts.push({ text: `[remote image unsupported by Gemini nativeOut: ${part.url}]` });
+        }
       }
     }
   }
@@ -287,6 +292,66 @@ function parseArgs(raw: string): unknown {
   } catch {
     return {};
   }
+}
+
+function geminiToolConfigToToolChoice(toolConfig: unknown): unknown {
+  if (typeof toolConfig !== "object" || toolConfig === null) return undefined;
+  const config = (toolConfig as { functionCallingConfig?: unknown }).functionCallingConfig;
+  if (typeof config !== "object" || config === null) return undefined;
+  const fcc = config as { mode?: unknown; allowedFunctionNames?: unknown };
+  if (fcc.mode === "NONE") return "none";
+  if (fcc.mode === "AUTO") return "auto";
+  if (fcc.mode === "ANY") {
+    const names = Array.isArray(fcc.allowedFunctionNames)
+      ? fcc.allowedFunctionNames.filter((name): name is string => typeof name === "string")
+      : [];
+    if (names.length === 1) return { type: "function", function: { name: names[0] } };
+    return "required";
+  }
+  return undefined;
+}
+
+function irToolChoiceToGeminiToolConfig(toolChoice: unknown): unknown {
+  if (toolChoice === "auto") return { functionCallingConfig: { mode: "AUTO" } };
+  if (toolChoice === "none") return { functionCallingConfig: { mode: "NONE" } };
+  if (toolChoice === "required") return { functionCallingConfig: { mode: "ANY" } };
+  if (typeof toolChoice === "object" && toolChoice !== null) {
+    const choice = toolChoice as { type?: unknown; function?: { name?: unknown } };
+    const name = choice.function?.name;
+    if (choice.type === "function" && typeof name === "string" && name !== "") {
+      return { functionCallingConfig: { mode: "ANY", allowedFunctionNames: [name] } };
+    }
+  }
+  return undefined;
+}
+
+function responseFormatToGenerationConfig(
+  responseFormat: unknown,
+): Record<string, unknown> | undefined {
+  if (typeof responseFormat !== "object" || responseFormat === null) return undefined;
+  const rf = responseFormat as { type?: unknown; json_schema?: unknown };
+  if (rf.type === "json_object") return { responseMimeType: "application/json" };
+  if (rf.type !== "json_schema") return undefined;
+
+  const rawSchema = rf.json_schema;
+  const schema =
+    typeof rawSchema === "object" && rawSchema !== null && "schema" in rawSchema
+      ? (rawSchema as { schema?: unknown }).schema
+      : rawSchema;
+  return {
+    responseMimeType: "application/json",
+    ...(schema !== undefined ? { responseSchema: sanitizeSchema(schema) } : {}),
+  };
+}
+
+function mergeGenerationConfig(
+  ...configs: Array<Record<string, unknown> | undefined>
+): Record<string, unknown> | undefined {
+  const merged = Object.assign(
+    {},
+    ...configs.filter((c): c is Record<string, unknown> => c !== undefined),
+  );
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
 function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
@@ -325,18 +390,22 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
       ? [{ functionDeclarations: parsed.tools.map(irToolToFunctionDeclaration) }]
       : undefined;
 
-  const generationConfig =
+  const generationConfig = mergeGenerationConfig(
     parsed.temperature !== undefined || parsed.max_tokens !== undefined
       ? {
           ...(parsed.temperature !== undefined ? { temperature: parsed.temperature } : {}),
           ...(parsed.max_tokens !== undefined ? { maxOutputTokens: parsed.max_tokens } : {}),
         }
-      : undefined;
+      : undefined,
+    responseFormatToGenerationConfig(parsed.response_format),
+  );
+  const toolConfig = irToolChoiceToGeminiToolConfig(parsed.tool_choice);
 
   return {
     contents,
     ...(systemInstruction !== undefined ? { systemInstruction } : {}),
     ...(tools !== undefined ? { tools } : {}),
+    ...(toolConfig !== undefined ? { toolConfig } : {}),
     ...(generationConfig !== undefined ? { generationConfig } : {}),
   };
 }

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -359,8 +359,12 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
 
   const contents: GeminiContent[] = [];
   let systemInstruction: GeminiContent | undefined;
+  const toolNameById = new Map<string, string>();
 
   for (const message of parsed.messages) {
+    for (const call of message.tool_calls ?? []) {
+      toolNameById.set(call.id, call.function.name);
+    }
     if (message.role === "system") {
       const text = irMessageContentToText(message.content);
       if (text !== "") systemInstruction = { parts: [{ text }] };
@@ -373,7 +377,12 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
         parts: [
           {
             functionResponse: {
-              name: message.name ?? message.tool_call_id ?? "tool",
+              name:
+                message.name ??
+                (message.tool_call_id !== undefined
+                  ? toolNameById.get(message.tool_call_id)
+                  : undefined) ??
+                "tool",
               response: { content: irMessageContentToText(message.content) },
             },
           },

--- a/packages/core/src/protocol/gemini/schema-sanitize.ts
+++ b/packages/core/src/protocol/gemini/schema-sanitize.ts
@@ -18,6 +18,39 @@ const SUPPORTED_FORMATS = new Set(["int32", "int64", "float", "double", "enum"])
 // the field is a string, record the intent in `description` so it isn't fully lost.
 const DATE_FORMATS = new Set(["date", "date-time", "time", "duration"]);
 
+// Gemini accepts a narrow OpenAPI-ish schema subset. Strip JSON Schema draft and
+// validation keywords that Gemini does not understand instead of forwarding a
+// request that upstream rejects with 400.
+const UNSUPPORTED_KEYS = new Set([
+  "$schema",
+  "$id",
+  "$ref",
+  "$defs",
+  "definitions",
+  "additionalProperties",
+  "patternProperties",
+  "unevaluatedProperties",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "not",
+  "pattern",
+  "minLength",
+  "maxLength",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "contains",
+  "const",
+  "default",
+  "examples",
+]);
+
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
@@ -39,6 +72,7 @@ export function sanitizeSchema(schema: unknown): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(schema)) {
+    if (UNSUPPORTED_KEYS.has(key)) continue;
     if (key === "format") continue; // handled explicitly below
     if (key === "properties" && isPlainObject(value)) {
       const props: Record<string, unknown> = {};

--- a/packages/core/src/protocol/gemini/schema-sanitize.ts
+++ b/packages/core/src/protocol/gemini/schema-sanitize.ts
@@ -117,6 +117,7 @@ function sanitize(schema: unknown, root: unknown, seen: Set<string>): unknown {
     if (isPlainObject(picked)) Object.assign(out, picked);
   }
 
+  const siblings: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(working)) {
     if (key === "$ref" || key === "allOf" || key === "oneOf" || key === "anyOf") continue;
     if (UNSUPPORTED_KEYS.has(key)) continue;
@@ -126,29 +127,29 @@ function sanitize(schema: unknown, root: unknown, seen: Set<string>): unknown {
       for (const [propName, propSchema] of Object.entries(value)) {
         props[propName] = sanitize(propSchema, root, seen);
       }
-      out[key] = props;
+      siblings[key] = props;
       continue;
     }
     if (key === "items" && (isPlainObject(value) || Array.isArray(value))) {
-      out[key] = sanitize(value, root, seen);
+      siblings[key] = sanitize(value, root, seen);
       continue;
     }
-    out[key] = value;
+    siblings[key] = value;
   }
 
   const format = working.format;
   if (typeof format === "string" && format !== "") {
     if (SUPPORTED_FORMATS.has(format)) {
-      out.format = format;
+      siblings.format = format;
     } else if (DATE_FORMATS.has(format)) {
-      if (out.type === undefined || out.type === "string") out.type = "string";
-      const existing = typeof out.description === "string" ? out.description : "";
+      if (siblings.type === undefined || siblings.type === "string") siblings.type = "string";
+      const existing = typeof siblings.description === "string" ? siblings.description : "";
       const hint = `format: ${format}`;
-      out.description = existing === "" ? hint : `${existing} (${hint})`;
+      siblings.description = existing === "" ? hint : `${existing} (${hint})`;
     }
   }
 
-  return out;
+  return mergeObjects(out, siblings);
 }
 
 /**

--- a/packages/core/src/protocol/gemini/schema-sanitize.ts
+++ b/packages/core/src/protocol/gemini/schema-sanitize.ts
@@ -1,14 +1,6 @@
-// JSON-Schema `format` sanitizer (docs/05 "cross-cutting concerns as stackable
-// transformers"). Gemini's functionDeclarations[].parameters accept only an
-// OpenAPI 3.0 subset: the JSON-Schema `format` keyword is largely unsupported, and
-// passing e.g. `format:"date"` / `"date-time"` makes the upstream reject the
-// request with a 400. The contract from the task spec: STRIP unsupported `format`
-// values and DOWNGRADE date/date-time string fields to a plain string (folding the
-// lost semantic into `description` so the model still gets the hint). It is better
-// to degrade the semantic than to let the upstream 400 (fail-open, principle 3).
-//
-// Pure, recursive, framework-agnostic (principle 1). It is protocol-agnostic on
-// purpose — any provider that needs OpenAPI-subset schemas can reuse it. No `any`.
+// Gemini accepts a narrow OpenAPI-ish schema subset for function parameters and
+// responseSchema. This sanitizer keeps requests out of upstream 400s while
+// preserving as much shape as possible from common OpenAI/Zod JSON Schema.
 
 // The small set of `format` values Gemini's OpenAPI subset does accept (numbers).
 // Everything else is stripped. Kept deliberately narrow: when in doubt, strip.
@@ -18,21 +10,16 @@ const SUPPORTED_FORMATS = new Set(["int32", "int64", "float", "double", "enum"])
 // the field is a string, record the intent in `description` so it isn't fully lost.
 const DATE_FORMATS = new Set(["date", "date-time", "time", "duration"]);
 
-// Gemini accepts a narrow OpenAPI-ish schema subset. Strip JSON Schema draft and
-// validation keywords that Gemini does not understand instead of forwarding a
-// request that upstream rejects with 400.
+// Unsupported keywords that cannot be lowered safely. `$ref` and combinators are
+// handled before this strip list so common schemas do not collapse to `{}`.
 const UNSUPPORTED_KEYS = new Set([
   "$schema",
   "$id",
-  "$ref",
   "$defs",
   "definitions",
   "additionalProperties",
   "patternProperties",
   "unevaluatedProperties",
-  "anyOf",
-  "oneOf",
-  "allOf",
   "not",
   "pattern",
   "minLength",
@@ -55,65 +42,124 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-/**
- * Recursively sanitize a JSON Schema for the Gemini OpenAPI subset. Returns a NEW
- * value (never mutates the input, so it is composable like a behavior transformer).
- * - Unsupported `format` keywords are removed.
- * - A `date`/`date-time`/`time`/`duration` format on a string degrades to a plain
- *   string and the original format is appended to `description` as a hint.
- * - Recurses through `properties`, `items`, `$defs`/`definitions`, and the
- *   `anyOf`/`oneOf`/`allOf` combinators; all other structure is preserved verbatim.
- */
-export function sanitizeSchema(schema: unknown): unknown {
-  if (Array.isArray(schema)) {
-    return schema.map((s) => sanitizeSchema(s));
+function localRef(root: unknown, ref: string): unknown {
+  if (!ref.startsWith("#/")) return undefined;
+  let cur: unknown = root;
+  for (const raw of ref.slice(2).split("/")) {
+    if (!isPlainObject(cur)) return undefined;
+    const key = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+    cur = cur[key];
   }
+  return cur;
+}
+
+function mergeObjects(left: Record<string, unknown>, right: Record<string, unknown>) {
+  const out: Record<string, unknown> = { ...left, ...right };
+  if (isPlainObject(left.properties) || isPlainObject(right.properties)) {
+    out.properties = {
+      ...(isPlainObject(left.properties) ? left.properties : {}),
+      ...(isPlainObject(right.properties) ? right.properties : {}),
+    };
+  }
+  const leftRequired = Array.isArray(left.required) ? left.required : [];
+  const rightRequired = Array.isArray(right.required) ? right.required : [];
+  if (leftRequired.length > 0 || rightRequired.length > 0) {
+    out.required = Array.from(new Set([...leftRequired, ...rightRequired]));
+  }
+  return out;
+}
+
+function mergeSanitizedBranches(branches: unknown[]) {
+  return branches.reduce<Record<string, unknown>>((acc, branch) => {
+    if (!isPlainObject(branch)) return acc;
+    return mergeObjects(acc, branch);
+  }, {});
+}
+
+function firstRepresentable(branches: unknown[]) {
+  return branches.find((branch) => {
+    if (!isPlainObject(branch)) return branch !== undefined;
+    if (branch.type === "null") return false;
+    return Object.keys(branch).length > 0;
+  });
+}
+
+function sanitize(schema: unknown, root: unknown, seen: Set<string>): unknown {
+  if (Array.isArray(schema)) return schema.map((s) => sanitize(s, root, seen));
   if (!isPlainObject(schema)) return schema;
 
+  let working: Record<string, unknown> = schema;
+  const ref = typeof schema.$ref === "string" ? schema.$ref : undefined;
+  if (ref !== undefined && !seen.has(ref)) {
+    const resolved = localRef(root, ref);
+    if (resolved !== undefined) {
+      const siblings = { ...schema };
+      delete siblings.$ref;
+      seen.add(ref);
+      const base = sanitize(resolved, root, seen);
+      seen.delete(ref);
+      working = isPlainObject(base) ? mergeObjects(base, siblings) : siblings;
+    }
+  }
+
   const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(schema)) {
+
+  if (Array.isArray(working.allOf)) {
+    Object.assign(out, mergeSanitizedBranches(working.allOf.map((s) => sanitize(s, root, seen))));
+  }
+  const unionBranches = Array.isArray(working.oneOf)
+    ? working.oneOf
+    : Array.isArray(working.anyOf)
+      ? working.anyOf
+      : undefined;
+  if (unionBranches !== undefined) {
+    const picked = firstRepresentable(unionBranches.map((s) => sanitize(s, root, seen)));
+    if (isPlainObject(picked)) Object.assign(out, picked);
+  }
+
+  for (const [key, value] of Object.entries(working)) {
+    if (key === "$ref" || key === "allOf" || key === "oneOf" || key === "anyOf") continue;
     if (UNSUPPORTED_KEYS.has(key)) continue;
     if (key === "format") continue; // handled explicitly below
     if (key === "properties" && isPlainObject(value)) {
       const props: Record<string, unknown> = {};
       for (const [propName, propSchema] of Object.entries(value)) {
-        props[propName] = sanitizeSchema(propSchema);
+        props[propName] = sanitize(propSchema, root, seen);
       }
       out[key] = props;
       continue;
     }
-    if (
-      (key === "items" ||
-        key === "additionalProperties" ||
-        key === "not" ||
-        key === "$defs" ||
-        key === "definitions") &&
-      (isPlainObject(value) || Array.isArray(value))
-    ) {
-      out[key] = sanitizeSchema(value);
-      continue;
-    }
-    if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
-      out[key] = value.map((s) => sanitizeSchema(s));
+    if (key === "items" && (isPlainObject(value) || Array.isArray(value))) {
+      out[key] = sanitize(value, root, seen);
       continue;
     }
     out[key] = value;
   }
 
-  // Now decide what to do with the original `format`, if any.
-  const format = schema.format;
+  const format = working.format;
   if (typeof format === "string" && format !== "") {
     if (SUPPORTED_FORMATS.has(format)) {
-      out.format = format; // keep the few formats Gemini understands
+      out.format = format;
     } else if (DATE_FORMATS.has(format)) {
-      // Downgrade to a plain string; fold the semantic into description.
       if (out.type === undefined || out.type === "string") out.type = "string";
       const existing = typeof out.description === "string" ? out.description : "";
       const hint = `format: ${format}`;
       out.description = existing === "" ? hint : `${existing} (${hint})`;
     }
-    // any other unsupported format is simply dropped (already skipped above).
   }
 
   return out;
+}
+
+/**
+ * Recursively sanitize a JSON Schema for the Gemini OpenAPI subset. Returns a NEW
+ * value and never mutates the input.
+ * - Unsupported `format` keywords are removed.
+ * - date/time string formats are downgraded to plain strings with description hints.
+ * - Local `$ref` entries are resolved before unsupported keywords are stripped.
+ * - `allOf` branches are merged; `oneOf`/`anyOf` choose the first representable
+ *   non-null branch so common Zod/OpenAI schemas do not become `{}`.
+ */
+export function sanitizeSchema(schema: unknown): unknown {
+  return sanitize(schema, schema, new Set());
 }

--- a/packages/core/src/protocol/protocol-matrix.fixtures.ts
+++ b/packages/core/src/protocol/protocol-matrix.fixtures.ts
@@ -130,14 +130,13 @@ const openaiToGemini = path("openai", "gemini", [
   fixture(
     "multimodal",
     "todo",
-    "OpenAI remote image_url outbound to Gemini is lossy today",
-    "PR A records the gap; issue #45 routes the fix to a later Gemini compatibility PR.",
+    "OpenAI remote image_url outbound to Gemini is an explicit non-goal",
+    "Remote image fetch/proxy is a non-goal for issue #49; Gemini nativeOut emits an explicit text placeholder until a later fetch/proxy design exists.",
   ),
   fixture(
     "json-schema",
-    "todo",
-    "OpenAI response_format JSON schema to Gemini responseSchema is not emitted today",
-    "PR A records the gap; adding Gemini request nativeOut behavior belongs to a later PR.",
+    "passing",
+    "OpenAI response_format JSON schema renders as Gemini generationConfig.responseSchema",
   ),
   fixture(
     "error",

--- a/packages/core/src/protocol/protocol-matrix.test.ts
+++ b/packages/core/src/protocol/protocol-matrix.test.ts
@@ -365,7 +365,8 @@ describe("protocol cross-path executable harness", () => {
     const toNative = requestIn[to];
     expect(toNative).toBeDefined();
     const native = await toNative?.(ir);
-    expectSerializedField(native, "response_format");
+    if (to === "gemini") expectSerializedField(native, "responseSchema");
+    else expectSerializedField(native, "response_format");
     expect(JSON.stringify(native)).toContain("summary");
   });
 


### PR DESCRIPTION
Refs #49

## 做了什么

- 补齐 Gemini `toolConfig.functionCallingConfig` 与 IR `tool_choice` 的双向映射：`auto`/`none`/`required`/指定 function name。
- 将 IR `response_format` 的 `json_object` / `json_schema` 映射到 Gemini `generationConfig.responseMimeType` / `responseSchema`，并复用 sanitizer。
- 扩展 Gemini schema sanitizer，递归剔除 Gemini 不支持的 JSON Schema 草案/校验关键字，避免静默发出坏 schema。
- 明确 remote image 仍是 non-goal：Gemini nativeOut 不伪造 `inlineData`，而是输出显式文本占位；matrix fixture 写清 todoReason。
- 补充 Gemini fixture 回归，覆盖 toolConfig、schema、inline image/remote image、usageMetadata/functionCall/functionResponse 既有路径。

## Acceptance Criteria

- [x] tool choice / function calling mode 有明确映射和测试。
- [x] schema 中 Gemini 不支持字段会被安全剔除，不静默生成坏 schema。
- [x] text + inline image 路径有 golden / fixture 回归覆盖。
- [x] remote image 不支持时有明确 non-goal / todoReason，nativeOut 不生成非法 inlineData。
- [x] Gemini usageMetadata / functionCall / functionResponse fixture 回归保持通过。
- [x] 不改 #39，不 copy / vendor LiteLLM 代码。

## 测试方法

- [x] `pnpm test packages/core/src/protocol/protocol-matrix.test.ts packages/core/src/protocol/gemini/gemini-transformer.test.ts`（72 passed）
- [x] `pnpm --filter @helm/core typecheck`
- [x] `pnpm lint`（通过；仓库既有 14 个 noNonNullAssertion warning）
- [x] `git diff --check`
- [x] `git diff --name-only origin/main...HEAD | grep -E '\.(png|jpg|jpeg|gif|webp|mp4|mov|webm|avif|bmp|tiff)$'`（无输出）

## 备注

- `pnpm test` 全量在本地失败，失败点是 admin 构建产物缺失：`apps/admin/.svelte-kit/tsconfig.json` 与 `apps/admin/build` 不存在；本 PR 相关 core/gemini 测试已通过。
