### PR TITLE
feat(gateway): Gemini protocol endpoint (closes #34, supersedes #39, resolves #52)

### DIFF
--- a/apps/gateway/e2e/gemini.spec.ts
+++ b/apps/gateway/e2e/gemini.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "@playwright/test";
+import {
+  CAPTURE_PATH,
+  TOOL_CALL_SENTINEL,
+  type UpstreamCapture,
+} from "./fixtures/mock-upstream.js";
+
+// e2e.gemini — black-box the WHOLE Gemini protocol-translation chain over real
+// HTTP into a real gateway + the deterministic OpenAI-shaped mock upstream (issue
+// #34). The unit tests prove the transformer / route / pipeline in isolation; this
+// proves the seams hold end-to-end across the two high-risk paths docs/05 calls
+// out: snapshot streaming SSE and tool-calls (CLAUDE.md §Testing / docs/05).
+//
+// We assert BOTH sides of the translation:
+//   (a) the client RESPONSE matches the Gemini wire shape (candidates[].content.
+//       parts, finishReason, usageMetadata);
+//   (b) the request the gateway forwarded UPSTREAM is the unified normalized
+//       (OpenAI-Chat IR) shape — read back from the mock's capture endpoint —
+//       proving nativeIn → IR → nativeOut (one hub, not N×N direct), with the
+//       PATH model backfilled (not the transformer's default "gemini").
+//
+// Auth uses x-goog-api-key (Gemini SDK default), NOT Authorization: Bearer.
+
+const TEST_KEY = "helm_live_e2e_testkey";
+const GEMINI_AUTH = { "x-goog-api-key": TEST_KEY, "Content-Type": "application/json" };
+
+const MOCK_BASE_URL = `http://127.0.0.1:${process.env.MOCK_PORT ?? "8181"}`;
+
+async function lastUpstreamRequest(request: {
+  get: (url: string) => Promise<{ json: () => Promise<UpstreamCapture> }>;
+}): Promise<UpstreamCapture> {
+  const res = await request.get(`${MOCK_BASE_URL}${CAPTURE_PATH}`);
+  return res.json();
+}
+
+test.describe("Gemini client → upstream", () => {
+  test("non-stream: generateContent round-trip + normalized upstream request", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: GEMINI_AUTH,
+      data: {
+        contents: [{ role: "user", parts: [{ text: "translate this sentence to french: hello" }] }],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    // (a) client sees the native Gemini shape.
+    expect(Array.isArray(body.candidates)).toBeTruthy();
+    expect(body.candidates[0].content.role).toBe("model");
+    expect(typeof body.candidates[0].content.parts[0].text).toBe("string");
+    expect(body.candidates[0].finishReason).toBe("STOP");
+
+    // (b) upstream got the normalized OpenAI-Chat request with a RESOLVED provider
+    // model (not the path-derived "gemini-2.0-flash" and not the default "gemini").
+    const upstream = await lastUpstreamRequest(request);
+    expect(Array.isArray(upstream.body.messages)).toBeTruthy();
+    expect(typeof upstream.body.model).toBe("string");
+    expect(upstream.body.model).not.toBe("gemini");
+  });
+
+  test("stream: alt=sse emits snapshot data frames with NO event: name and NO [DONE]", async ({
+    request,
+  }) => {
+    const res = await request.post(
+      "/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse",
+      {
+        headers: GEMINI_AUTH,
+        data: {
+          contents: [
+            { role: "user", parts: [{ text: "translate this sentence to french: hola" }] },
+          ],
+        },
+      },
+    );
+    expect(res.ok()).toBeTruthy();
+    expect(res.headers()["content-type"]).toContain("text/event-stream");
+    const text = await res.text();
+    // Gemini wire form: nameless data: frames, NO event: names, NO [DONE].
+    expect(text).toContain("data:");
+    expect(text).not.toContain("event:");
+    expect(text).not.toContain("[DONE]");
+    // never leak a raw OpenAI chunk through the Gemini surface.
+    expect(text).not.toContain("chat.completion.chunk");
+    // each frame is a full snapshot carrying candidates[].
+    expect(text).toContain("candidates");
+    // the terminal snapshot carries the mapped finishReason.
+    expect(text).toContain("STOP");
+  });
+
+  test("tool-call: upstream function call → client sees a functionCall part", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: GEMINI_AUTH,
+      data: {
+        contents: [
+          { role: "user", parts: [{ text: `look up the weather ${TOOL_CALL_SENTINEL}` }] },
+        ],
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: "get_weather",
+                description: "get the weather",
+                parameters: { type: "object", properties: { city: { type: "string" } } },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    const parts = body.candidates[0].content.parts as Array<{
+      functionCall?: { name: string; args: Record<string, unknown> };
+    }>;
+    const fc = parts.find((p) => p.functionCall)?.functionCall;
+    expect(fc).toBeDefined();
+    expect(fc?.name).toBe("get_weather");
+    // arguments parsed into an object (docs/05 pit #3).
+    expect(typeof fc?.args).toBe("object");
+  });
+});
+
+test.describe("Gemini auth + error envelopes", () => {
+  test("missing key on generateContent is rejected (401 UNAUTHENTICATED envelope)", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: { "Content-Type": "application/json" },
+      data: { contents: [{ role: "user", parts: [{ text: "hi" }] }] },
+    });
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.error.status).toBe("UNAUTHENTICATED");
+    expect(body.error.code).toBe(401);
+  });
+
+  test("a non-generateContent operation returns 404 (Gemini NOT_FOUND envelope)", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:countTokens", {
+      headers: GEMINI_AUTH,
+      data: { contents: [{ role: "user", parts: [{ text: "hi" }] }] },
+    });
+    expect(res.status()).toBe(404);
+    const body = await res.json();
+    expect(body.error.status).toBe("NOT_FOUND");
+  });
+
+  test("a structurally invalid body returns 400 INVALID_ARGUMENT", async ({ request }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:generateContent", {
+      headers: GEMINI_AUTH,
+      // contents is required by the Gemini schema; an empty object fails the parse.
+      data: { not: "a gemini request" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+  });
+});

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../app.js";
+import { type GeminiRouteDeps, registerGeminiRoute } from "./gemini.js";
+import type { MessagesIdentity } from "./messages.js";
+import { PipelineError } from "./messages-pipeline.js";
+
+// POST /v1beta/models/{model}:{generateContent|streamGenerateContent} — Gemini
+// inbound (issue #34). These tests pin the route CONTRACT: auth (x-goog-api-key
+// preferred, Bearer fallback) → translate-out → MODEL BACKFILL → route →
+// translate-back, with all business logic stubbed. The route is PURE HTTP glue
+// (CLAUDE.md principle 1). Streaming snapshots are written as nameless `data:`
+// frames with NO `event:` name and NO [DONE] (Gemini wire form, docs/05).
+
+const GEMINI_AUTH = { "x-goog-api-key": "helm_live_secret", "Content-Type": "application/json" };
+
+const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
+
+const REQ_BODY = { contents: [{ role: "user", parts: [{ text: "hi" }] }] };
+
+// A canned Gemini-native response the stub responseOut produces.
+const GEMINI_RESPONSE = {
+  candidates: [{ content: { role: "model", parts: [{ text: "hello" }] }, finishReason: "STOP" }],
+  usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+};
+
+interface Harness {
+  order: string[];
+  pipelineSawIR: Record<string, unknown> | null;
+  pipelineSawAbort: boolean;
+}
+
+function makeDeps(
+  over: {
+    collect?: () => Promise<unknown>;
+    streamEvents?: () => AsyncIterable<Record<string, unknown>>;
+    authed?: boolean;
+    abort?: boolean;
+    transformRequestOut?: (native: unknown) => unknown;
+    identity?: MessagesIdentity;
+    rateLimiter?: GeminiRouteDeps["rateLimiter"];
+  } = {},
+): { deps: GeminiRouteDeps; harness: Harness } {
+  const harness: Harness = { order: [], pipelineSawIR: null, pipelineSawAbort: false };
+
+  const deps: GeminiRouteDeps = {
+    rateLimiter: over.rateLimiter,
+    auth: {
+      resolve: async (cred) => {
+        harness.order.push(`auth:${cred ?? "null"}`);
+        return over.authed === false ? null : (over.identity ?? IDENTITY);
+      },
+    },
+    transformer: {
+      transformRequestOut: (native) => {
+        harness.order.push("translate-out");
+        if (over.transformRequestOut)
+          return over.transformRequestOut(native) as Record<string, unknown>;
+        // The real transformer defaults model:"gemini"; the route must backfill the
+        // path model. Return that default so the backfill assertion is meaningful.
+        return { model: "gemini", messages: [{ role: "user", content: "hi" }], metadata: {} };
+      },
+      transformResponseOut: (ir) => {
+        harness.order.push("translate-back");
+        return { ...GEMINI_RESPONSE, __ir: ir };
+      },
+      transformErrorOut: (err) => {
+        const status =
+          err.error_class === "auth_error"
+            ? 401
+            : err.error_class === "invalid_request"
+              ? 400
+              : err.error_class === "rate_limited"
+                ? 429
+                : 502;
+        const gstatus =
+          err.error_class === "auth_error"
+            ? "UNAUTHENTICATED"
+            : err.error_class === "invalid_request"
+              ? "INVALID_ARGUMENT"
+              : err.error_class === "rate_limited"
+                ? "RESOURCE_EXHAUSTED"
+                : "UNAVAILABLE";
+        return { status, body: { error: { code: status, message: err.message, status: gstatus } } };
+      },
+    },
+    pipeline: {
+      run: async (ir, _identity, signal) => {
+        harness.order.push("route");
+        harness.pipelineSawIR = ir;
+        if (over.abort === true) {
+          if (signal.aborted) harness.pipelineSawAbort = true;
+          signal.addEventListener("abort", () => {
+            harness.pipelineSawAbort = true;
+          });
+        }
+        return {
+          collect: over.collect ?? (async () => ({ id: "ir-resp" })),
+          streamIR:
+            over.streamEvents ??
+            async function* () {
+              yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+            },
+        };
+      },
+    },
+  };
+  return { deps, harness };
+}
+
+function buildApp(deps: GeminiRouteDeps) {
+  const app = createApp({ logger: { log: () => {} } });
+  registerGeminiRoute(app, deps);
+  return app;
+}
+
+describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
+  it("non-stream: auth → translate-out → route → translate-back, returns Gemini JSON", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      candidates: Array<{ content: { parts: Array<{ text: string }> } }>;
+    };
+    expect(body.candidates[0]?.content.parts[0]?.text).toBe("hello");
+    expect(harness.order).toEqual([
+      "auth:helm_live_secret",
+      "translate-out",
+      "route",
+      "translate-back",
+    ]);
+  });
+
+  it("backfills the path model into the IR the pipeline receives", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    await app.request("/v1beta/models/gemini-1.5-pro:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    // Must NOT leak the transformer's default model:"gemini" to the router.
+    expect(harness.pipelineSawIR?.model).toBe("gemini-1.5-pro");
+  });
+
+  it("prefers x-goog-api-key but falls back to Authorization: Bearer", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: { Authorization: "Bearer bearer_key", "Content-Type": "application/json" },
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(harness.order[0]).toBe("auth:bearer_key");
+  });
+
+  it("rejects a missing/invalid key with a 401 Gemini error and never routes", async () => {
+    const { deps, harness } = makeDeps({ authed: false });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: { "x-goog-api-key": "wrong", "Content-Type": "application/json" },
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("UNAUTHENTICATED");
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("returns 404 for a non-generateContent path (parseGeminiPath null)", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:countTokens", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(404);
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("rate-limits after auth with a 429 Gemini envelope and limit headers, without translating or routing", async () => {
+    const { deps, harness } = makeDeps({
+      rateLimiter: {
+        check: async (probe) => {
+          harness.order.push(`rate-limit:${probe.keyId}`);
+          return {
+            allowed: false,
+            limitedBy: "rpm",
+            limit: 60,
+            remaining: 0,
+            resetSeconds: 42,
+            retryAfterSeconds: 12,
+          };
+        },
+      },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("12");
+    expect(res.headers.get("x-ratelimit-limit")).toBe("60");
+    expect(res.headers.get("x-ratelimit-remaining")).toBe("0");
+    expect(res.headers.get("x-ratelimit-reset")).toBe("42");
+    const body = (await res.json()) as { error: { code: number; status: string } };
+    expect(body.error).toMatchObject({ code: 429, status: "RESOURCE_EXHAUSTED" });
+    expect(harness.order).toEqual(["auth:helm_live_secret", "rate-limit:k1"]);
+    expect(harness.pipelineSawIR).toBeNull();
+  });
+
+  it("maps a malformed JSON body to 400 INVALID_ARGUMENT, after auth, without routing", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: "{not valid json",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("maps a structurally invalid body (transformRequestOut throws) to a 400 Gemini error", async () => {
+    const { deps, harness } = makeDeps({
+      transformRequestOut: () => {
+        throw new Error("contents: too_small");
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify({ contents: [] }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("surfaces an all-providers-failed pipeline error as a Gemini envelope (not empty 200)", async () => {
+    const { deps } = makeDeps({
+      collect: async () => {
+        throw new PipelineError("all_providers_failed", "all providers failed", "trace-1");
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("UNAVAILABLE");
+  });
+});
+
+describe("POST /v1beta/models/{model}:streamGenerateContent?alt=sse (Gemini stream)", () => {
+  it("writes nameless data: frames with NO event: name and NO [DONE]", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hel" }] } }] };
+      yield {
+        candidates: [
+          { content: { role: "model", parts: [{ text: "Hello" }] }, finishReason: "STOP" },
+        ],
+        usageMetadata: { candidatesTokenCount: 2 },
+      };
+    }
+    const { deps } = makeDeps({ streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const text = await res.text();
+    expect(text).toContain("data:");
+    expect(text).not.toContain("event:");
+    expect(text).not.toContain("[DONE]");
+    // Each frame is a full snapshot; the final carries finishReason.
+    expect(text).toContain("STOP");
+  });
+
+  it("passes the abort signal to the pipeline and emits NO error frame on client disconnect", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    }
+    const { deps } = makeDeps({ streamEvents: events, abort: true });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    const text = await res.text();
+    // A benign abort must NOT write an error envelope into the stream.
+    expect(text).not.toContain("UNAVAILABLE");
+    expect(text).not.toContain('"error"');
+  });
+
+  it("emits a terminal Gemini error frame when the stream throws (non-abort)", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+      throw new PipelineError("all_providers_failed", "all providers failed", "trace-1");
+    }
+    const { deps } = makeDeps({ streamEvents: events });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    const text = await res.text();
+    expect(text).toContain("error");
+    expect(text).toContain("UNAVAILABLE");
+  });
+});

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -1,0 +1,270 @@
+import {
+  type GeminiRoute,
+  parseGeminiPath,
+  type RateLimitProbe,
+  type RateLimitResult,
+} from "@helm/core";
+import type { Context, Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import type { AppEnv } from "../app.js";
+import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
+import { resolveMemoryScope } from "./memory-scope.js";
+import type { MessagesIdentity, PipelineRunResult, RouteError } from "./messages.js";
+import { PipelineError } from "./messages-pipeline.js";
+
+// POST /v1beta/models/{model}:generateContent / :streamGenerateContent — Google
+// Gemini inbound, translated to IR, routed through the SAME core pipeline as
+// /v1/chat and /v1/messages, then translated back to the native Gemini wire shape
+// (docs/05, issue #34). The FOURTH client-presentation surface.
+//
+// PURE HTTP ↔ IR glue (CLAUDE.md principle 1): auth → translate(out) → route →
+// translate(back). No classify/route/translate logic lives here; each business
+// step is an injected dependency. Wiring order is the docs/02 contract: auth →
+// translate(out) → route → translate(back).
+//
+// Gemini diverges from the other surfaces in three HTTP-level ways the route owns:
+//   • the model + operation are in the PATH (`{model}:{op}`), parsed by the core
+//     pure function `parseGeminiPath` (core never reads a Hono object, principle 1);
+//   • auth is `x-goog-api-key` (NOT Authorization: Bearer; Bearer is a fallback);
+//   • streaming events are FULL-SNAPSHOT `data:` frames with NO `event:` name and
+//     NO `[DONE]` sentinel (docs/05 — Gemini's wire form differs from OpenAI /
+//     Anthropic SSE).
+
+/** One Gemini error envelope plus the HTTP status to send it with. Error
+ *  translation is protocol logic (docs/05) — injected, never hand-assembled. */
+export interface GeminiErrorOut {
+  status: number;
+  body: unknown;
+}
+
+/** Per-key rate limiter (core, framework-agnostic). Same instance the OpenAI chat
+ *  middleware uses; injected so the self-authenticating Gemini route meters the
+ *  resolved key AFTER auth. Optional — omitted = no metering. */
+export interface GeminiRateLimiterPort {
+  check(probe: RateLimitProbe): Promise<RateLimitResult>;
+}
+
+// The route treats the IR as an opaque bag with the fields it must read/stamp.
+interface GeminiIRLike {
+  stream?: boolean;
+  model?: unknown;
+  metadata?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+export interface GeminiRouteDeps {
+  rateLimiter?: GeminiRateLimiterPort;
+  auth: {
+    /** Resolve the request credential to an identity, or null when invalid. */
+    resolve(credential: string | null): Promise<MessagesIdentity | null>;
+  };
+  transformer: {
+    /** Native Gemini request → IR (throws on a structurally invalid body). */
+    transformRequestOut(native: unknown): GeminiIRLike;
+    /** IR response → native Gemini response. */
+    transformResponseOut(ir: unknown): unknown;
+    /** Structured internal error → Gemini error envelope + status. */
+    transformErrorOut(err: RouteError): GeminiErrorOut;
+  };
+  pipeline: {
+    run(
+      ir: GeminiIRLike,
+      identity: MessagesIdentity,
+      signal: AbortSignal,
+    ): Promise<PipelineRunResult>;
+  };
+}
+
+// Extract the plaintext credential from x-goog-api-key (Gemini SDK default) or the
+// Authorization: Bearer header (friendlier for own clients). Case-sensitive: never
+// trim/lowercase a key.
+function extractCredential(googKey: string | undefined, auth: string | undefined): string | null {
+  if (googKey) return googKey;
+  if (auth) {
+    const m = /^Bearer\s+(.+)$/.exec(auth);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
+// Client disconnect / abort detection — mirrors messages.ts. Used to suppress a
+// terminal error frame for a benign disconnect (NOT a provider fault, docs/02).
+function isAbort(err: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return true;
+  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
+}
+
+export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): void {
+  const { transformer } = deps;
+
+  const sendError = (c: Context<AppEnv>, err: RouteError): Response => {
+    const out = transformer.transformErrorOut(err);
+    return c.json(out.body as Record<string, unknown>, out.status as 400 | 401 | 404 | 429 | 502);
+  };
+
+  // Hono cannot match the literal ':' in `{model}:generateContent` with a named
+  // param, so we mount a catch-all under /v1beta/models and hand the full path +
+  // query to the core `parseGeminiPath`. A non-Gemini path → null → 404 (never a
+  // silent 200 on a mis-routed /v1beta/* request).
+  app.post("/v1beta/models/:rest{.+}", async (c) => {
+    const traceId = c.get("trace_id");
+
+    // 0) Route parse FIRST (cheap, pure). The pathname is the part before '?'; the
+    //    query carries `alt=sse`. parseGeminiPath returns null for any path that is
+    //    not :generateContent / :streamGenerateContent → 404.
+    const url = new URL(c.req.url);
+    const route: GeminiRoute | null = parseGeminiPath(url.pathname, url.search.replace(/^\?/, ""));
+    if (route === null) {
+      // A /v1beta/models/* path that is NOT :generateContent / :streamGenerateContent
+      // (e.g. :countTokens, :embedContent) is an endpoint Helm does not serve → 404
+      // in the Gemini error wire shape. Never a silent 200 on a mis-routed path.
+      // NOT_FOUND is not one of the 8 routing ErrorClasses (it is an HTTP-routing
+      // concern, not a routing-pipeline failure), so it is assembled here directly.
+      return c.json(
+        {
+          error: {
+            code: 404,
+            message: "not a Gemini generateContent endpoint",
+            status: "NOT_FOUND",
+          },
+        },
+        404,
+      );
+    }
+
+    // 1) Auth (docs/02 pipeline order). x-goog-api-key preferred, Bearer fallback.
+    const credential = extractCredential(
+      c.req.header("x-goog-api-key"),
+      c.req.header("Authorization"),
+    );
+    const identity = await deps.auth.resolve(credential);
+    if (identity === null) {
+      return sendError(c, {
+        error_class: "auth_error",
+        message: "missing or invalid API key",
+        trace_id: traceId,
+      });
+    }
+
+    // 1b) Rate limit AFTER auth (needs the resolved key_id), BEFORE translate/route.
+    if (deps.rateLimiter !== undefined) {
+      const rl = await deps.rateLimiter.check({
+        keyId: identity.keyId,
+        estimatedTokens: estimateRequestTokens(c),
+        now: Date.now(),
+        override: identity.caps?.rateLimit
+          ? { rpm: identity.caps.rateLimit.rpm, tpm: identity.caps.rateLimit.tpm }
+          : undefined,
+      });
+      if (!(rl.allowed && rl.limit === 0)) {
+        c.header("x-ratelimit-limit", String(rl.limit));
+        c.header("x-ratelimit-remaining", String(rl.remaining));
+        c.header("x-ratelimit-reset", String(rl.resetSeconds));
+        if (!rl.allowed) {
+          c.header("retry-after", String(rl.retryAfterSeconds));
+          return sendError(c, {
+            error_class: "rate_limited",
+            message: `rate limit exceeded (${rl.limitedBy})`,
+            trace_id: traceId,
+          });
+        }
+      }
+    }
+
+    // 2) Parse + translate inbound. A malformed JSON body OR a structurally invalid
+    //    Gemini request (the transformer's Zod parse throws) is a CLIENT error →
+    //    400 INVALID_ARGUMENT, before routing (docs/07, principle 2 fail-closed).
+    let native: unknown;
+    try {
+      native = await c.req.json();
+    } catch {
+      return sendError(c, {
+        error_class: "invalid_request",
+        message: "malformed JSON request body",
+        trace_id: traceId,
+      });
+    }
+    let ir: GeminiIRLike;
+    try {
+      ir = transformer.transformRequestOut(native);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : "invalid Gemini request";
+      return sendError(c, { error_class: "invalid_request", message: detail, trace_id: traceId });
+    }
+
+    // 2b) Backfill the PATH model + the parsed stream flag onto the IR. The
+    //     transformer defaults model:"gemini" (the path-derived model is supplied
+    //     by the route layer — see gemini-transformer.ts). Without this the router
+    //     would always receive "gemini" and routing would degrade.
+    ir.model = route.model;
+    ir.stream = route.stream;
+    ir.metadata = { ...(ir.metadata ?? {}), trace_id: traceId };
+
+    // Memory scope (docs/08 Phase 1): parse the four memory headers and stamp them
+    // onto the IR metadata bag (mirrors /v1/messages) so the SHARED pipeline's
+    // observe phase reads the scope off ir.metadata without touching HTTP.
+    const memoryScope = resolveMemoryScope((name) => c.req.header(name));
+    ir.metadata.thread_id = memoryScope.threadId;
+    ir.metadata.resource_id = memoryScope.resourceId;
+    ir.metadata.project_id = memoryScope.projectId;
+    ir.metadata.memory_mode = memoryScope.mode;
+
+    // 3) Route through the shared core. The per-request abort signal rides along so
+    //    a client disconnect is a non-provider fault (docs/02). run() throws a
+    //    PipelineError(invalid_request) for an empty request.
+    let result: PipelineRunResult;
+    try {
+      result = await deps.pipeline.run(ir, identity, c.req.raw.signal);
+    } catch (err) {
+      if (err instanceof PipelineError) {
+        return sendError(c, {
+          error_class: err.error_class,
+          message: err.message,
+          trace_id: traceId,
+        });
+      }
+      throw err;
+    }
+
+    // 4) Protocol Adapter (outbound). Gemini streaming events are FULL snapshots,
+    //    written as nameless `data:` frames — NO `event:` name, NO `[DONE]`.
+    if (route.stream) {
+      return streamSSE(c, async (sse) => {
+        try {
+          for await (const snapshot of result.streamIR()) {
+            await sse.writeSSE({ data: JSON.stringify(snapshot) });
+          }
+        } catch (err) {
+          // A client disconnect / abort is a benign non-provider fault (docs/02):
+          // emit NO error frame. Any other throw emits ONE terminal Gemini error
+          // frame so the client never sees a silently truncated stream.
+          if (!isAbort(err, c.req.raw.signal)) {
+            const re: RouteError =
+              err instanceof PipelineError
+                ? { error_class: err.error_class, message: err.message, trace_id: traceId }
+                : { error_class: "upstream_error", message: "upstream error", trace_id: traceId };
+            const out = transformer.transformErrorOut(re);
+            await sse.writeSSE({ data: JSON.stringify(out.body) });
+          }
+        }
+      });
+    }
+
+    // Non-stream: collect() throws a PipelineError when routing failed (all
+    // providers failed) — surface it as the Gemini envelope, never an empty 200.
+    let body: unknown;
+    try {
+      body = transformer.transformResponseOut(await result.collect());
+    } catch (err) {
+      if (err instanceof PipelineError) {
+        return sendError(c, {
+          error_class: err.error_class,
+          message: err.message,
+          trace_id: traceId,
+        });
+      }
+      throw err;
+    }
+    return c.json(body as Record<string, unknown>);
+  });
+}

--- a/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
@@ -1,0 +1,101 @@
+import type { ExecutionResult } from "@helm/core";
+import { describe, expect, it } from "vitest";
+import type { MessagesIdentity } from "./messages.js";
+import { createMessagesPipeline, type RouteFn } from "./messages-pipeline.js";
+
+// messages-pipeline (gemini branch) — issue #34 step 3. When the pipeline is
+// stamped with the `gemini` protocol, streamIR() must map the upstream OpenAI SSE
+// chunks into GEMINI snapshot events (via geminiTransformer.transformStreamOut),
+// NOT Anthropic events. Each snapshot is a FULL response (text accumulates frame to
+// frame); the terminal snapshot carries finishReason + usageMetadata exactly once;
+// there is no `event:` name and no `[DONE]` sentinel (those are the route's job —
+// here we only assert the produced snapshot objects). CLAUDE.md principle 8.
+
+const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
+
+function irOf(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    model: "gemini-2.0-flash",
+    messages: [{ role: "user", content: "hi" }],
+    stream: true,
+    metadata: { trace_id: "trace-g" },
+    ...over,
+  };
+}
+
+// Raw OpenAI SSE text the mock upstream / executor yields. Text fragments then a
+// terminal usage+finish frame and the [DONE] sentinel — the same wire the
+// Anthropic pipeline consumes.
+async function* openAISSE(frames: string[]): AsyncIterable<string> {
+  for (const f of frames) yield f;
+}
+
+function streamResult(stream: AsyncIterable<string>): ExecutionResult {
+  return {
+    decision: { lane: { selected_lane: "balanced" } } as unknown as ExecutionResult["decision"],
+    final: { status: "ok", alias: "x" } as unknown as ExecutionResult["final"],
+    body: null,
+    stream,
+    error: null,
+  };
+}
+
+describe("createMessagesPipeline (gemini) — streamIR yields Gemini snapshots", () => {
+  it("accumulates text across snapshots and ends with finishReason + usageMetadata", async () => {
+    const frames = [
+      'data: {"id":"c","choices":[{"delta":{"role":"assistant"}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"content":"Hel"}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"content":"lo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const route: RouteFn = async () => streamResult(openAISSE(frames));
+    const pipeline = createMessagesPipeline(route, "gemini");
+    const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const ev of run.streamIR()) events.push(ev as Record<string, unknown>);
+
+    expect(events.length).toBeGreaterThan(0);
+    // Each event is a full snapshot; the LAST carries the complete accumulated text.
+    const last = events[events.length - 1] as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> }; finishReason?: string }>;
+      usageMetadata?: { candidatesTokenCount?: number };
+    };
+    const text = (last.candidates?.[0]?.content?.parts ?? []).map((p) => p.text ?? "").join("");
+    expect(text).toBe("Hello");
+    expect(last.candidates?.[0]?.finishReason).toBe("STOP");
+    expect(last.usageMetadata?.candidatesTokenCount).toBe(2);
+
+    // No Anthropic event names leaked through the Gemini surface.
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain("message_start");
+    expect(serialized).not.toContain("content_block_delta");
+  });
+
+  it("emits a functionCall part accumulated across fragmented tool-call chunks", async () => {
+    const frames = [
+      'data: {"id":"c","choices":[{"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_0","type":"function","function":{"name":"get_weather"}}]}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"ci"}}]}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ty\\":\\"SF\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const route: RouteFn = async () => streamResult(openAISSE(frames));
+    const pipeline = createMessagesPipeline(route, "gemini");
+    const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const ev of run.streamIR()) events.push(ev as Record<string, unknown>);
+
+    const last = events[events.length - 1] as {
+      candidates?: Array<{
+        content?: { parts?: Array<{ functionCall?: { name: string; args: unknown } }> };
+        finishReason?: string;
+      }>;
+    };
+    const fc = (last.candidates?.[0]?.content?.parts ?? []).find(
+      (p) => p.functionCall,
+    )?.functionCall;
+    expect(fc?.name).toBe("get_weather");
+    expect(fc?.args).toEqual({ city: "SF" });
+  });
+});

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -2,6 +2,8 @@ import {
   type AnthropicSSEEvent,
   convertOpenAIStreamToAnthropic,
   type ExecutionResult,
+  geminiTransformer,
+  type IRChunk,
   type IRMessage,
   type IRResponse,
   type MemoryScope,
@@ -345,13 +347,13 @@ export function createMessagesPipeline(
           }
           return irResponse;
         },
-        async *streamIR(): AsyncIterable<{ type: string; [k: string]: unknown }> {
+        async *streamIR(): AsyncIterable<Record<string, unknown>> {
           // Surface a routing failure BEFORE any event is emitted, so the route
           // can write a terminal error frame instead of an empty (silent) stream.
           if (failure !== null) throw failure;
           if (result.stream === null) return;
           // Accumulate the assistant text from the OpenAI-side chunks (one
-          // accumulator serves BOTH protocols) WITHOUT buffering or altering the
+          // accumulator serves ALL protocols) WITHOUT buffering or altering the
           // events forwarded downstream (principle 8). observeOutbound runs in a
           // finally so a client disconnect mid-stream still records what arrived.
           const assistant = { text: "" };
@@ -366,8 +368,25 @@ export function createMessagesPipeline(
                   }
                 })();
           try {
-            for await (const ev of convertOpenAIStreamToAnthropic(source as AsyncIterable<never>)) {
-              yield ev as AnthropicSSEEvent & { type: string };
+            // Outbound stream mapping is chosen by the pipeline's stamped protocol
+            // (principle 5: surfaces never conflate). Gemini consumes the SAME
+            // OpenAI-shaped chunks parseOpenAISSE produces (its IRChunk IS the
+            // OpenAI chat.completion.chunk), so we feed them straight into the
+            // Gemini snapshot state machine — no Anthropic adapter (docs/05). Each
+            // yielded object is a full GenerateContentResponse snapshot (no `type`);
+            // the route writes it as a nameless `data:` SSE frame with no [DONE].
+            if (protocol === "gemini") {
+              for await (const snapshot of geminiTransformer.transformStreamOut(
+                source as AsyncIterable<IRChunk>,
+              )) {
+                yield snapshot as Record<string, unknown>;
+              }
+            } else {
+              for await (const ev of convertOpenAIStreamToAnthropic(
+                source as AsyncIterable<never>,
+              )) {
+                yield ev as AnthropicSSEEvent & { type: string };
+              }
             }
           } finally {
             if (memory !== undefined && assistant.text.length > 0) {

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -62,8 +62,10 @@ export interface RouteError {
 export interface PipelineRunResult {
   /** Drain the full (non-stream) result into ONE IR response object. */
   collect(): Promise<unknown>;
-  /** The IR-level event stream (one object per Anthropic SSE event source). */
-  streamIR(): AsyncIterable<{ type: string; [k: string]: unknown }>;
+  /** The outbound-protocol event stream: one object per wire event. For Anthropic
+   *  each carries a `type` (the SSE event name); for Gemini each is a full snapshot
+   *  GenerateContentResponse (no `type`). The route serializes them per protocol. */
+  streamIR(): AsyncIterable<Record<string, unknown>>;
 }
 
 /** Per-key rate limiter (core, framework-agnostic). Same instance the OpenAI
@@ -90,7 +92,7 @@ export interface MessagesRouteDeps {
       /** IR response → native Anthropic response (outbound Protocol Adapter). */
       transformResponseOut(ir: unknown): unknown | Promise<unknown>;
       /** ONE IR stream event → ONE Anthropic SSE frame (state-machine mapped). */
-      transformStreamOut(event: { type: string; [k: string]: unknown }): AnthropicSSEFrame;
+      transformStreamOut(event: Record<string, unknown>): AnthropicSSEFrame;
       /** Structured internal error → Anthropic error envelope + status. */
       transformErrorOut(err: RouteError): AnthropicErrorOut;
     };

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -14,6 +14,8 @@ import {
   createStore,
   createTokenManager,
   DEFAULT_LANES,
+  type GeminiGenerateContentResponse,
+  geminiTransformer,
   generateKey,
   getOAuthProvider,
   hashKey,
@@ -25,6 +27,7 @@ import {
   loadRuntimeCatalog,
   loadRuntimeSettings,
   makeAnthropicError,
+  makeGeminiError,
   type OAuthTokenStore,
   type ObserveDeps,
   type PoliciesConfig,
@@ -64,6 +67,7 @@ import { ADMIN_BUILD_ROOT, mountAdminStatic } from "./routes/admin-static.js";
 import { registerChatRoutes } from "./routes/chat.js";
 import { buildClassifyAdapter } from "./routes/classify.js";
 import { createExecute } from "./routes/execute.js";
+import { registerGeminiRoute } from "./routes/gemini.js";
 import type { MessagesIdentity, RouteError } from "./routes/messages.js";
 import { registerMessagesRoute } from "./routes/messages.js";
 import { createMessagesPipeline } from "./routes/messages-pipeline.js";
@@ -798,6 +802,55 @@ export async function buildServer(
     },
     pipeline: responsesPipeline,
   } as Parameters<typeof registerResponsesRoute>[1] & { rateLimiter: RateLimiterPort });
+
+  // Gemini route (/v1beta/models/{model}:generateContent | :streamGenerateContent).
+  // The FOURTH client surface. Reuses the SAME routing core via a pipeline stamped
+  // with the `gemini` protocol (so streamIR yields Gemini snapshot events), and the
+  // Gemini transformer for IR↔native translation + the Gemini error envelope. Self-
+  // auth (x-goog-api-key preferred, Bearer fallback) so a missing key is rejected as
+  // a Gemini error envelope (docs/05, docs/07).
+  const geminiPipeline = createMessagesPipeline(route, "gemini", { observe });
+  registerGeminiRoute(app, {
+    rateLimiter,
+    auth: {
+      resolve: async (credential): Promise<MessagesIdentity | null> => {
+        if (credential === null) return null;
+        const record = await keyStore.getByHash(hashKey(credential));
+        if (record === null || record.disabled) return null;
+        return {
+          keyId: record.key_id,
+          keyPrefix: record.prefix,
+          accountId: record.account_id,
+          orgId: null,
+          userId: null,
+          role: record.role,
+          caps: {
+            maxLane: record.max_lane,
+            allowedLanes: record.allowed_lanes,
+            allowCustomModel: record.allow_custom_model,
+            rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
+          },
+        };
+      },
+    },
+    transformer: {
+      transformRequestOut: (native) => geminiTransformer.transformRequestOut(native),
+      transformResponseOut: (ir) =>
+        geminiTransformer.transformResponseOut(ir as IRResponse) as GeminiGenerateContentResponse,
+      transformErrorOut: (err: RouteError) =>
+        makeGeminiError({
+          // Pass the precise error_class straight through; makeGeminiError maps all
+          // 8 ErrorClass values to the right status + Google canonical status. A
+          // RouteError.error_class is a plain string, so validate it against the
+          // schema; an unrecognized value falls back to upstream_error (502) rather
+          // than throwing (fail-open, principle 3).
+          error_class: coerceErrorClass(err.error_class),
+          message: err.message,
+          trace_id: err.trace_id,
+        }),
+    },
+    pipeline: geminiPipeline,
+  } as Parameters<typeof registerGeminiRoute>[1] & { rateLimiter: RateLimiterPort });
 
   // Start the Agentic Signals background scheduler — the OFF-the-request-path
   // trigger. It periodically asks the collector to aggregate the just-elapsed

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,23 @@
 
 ---
 
+## 2026-06-02 · Gemini endpoint — superseded #39 (issue #52/#34, spec docs/05)
+
+**Context**: PR #39 (`feat/issue-34-gemini`) built the entire Gemini surface — core transformer/error/types/path-parser AND the gateway route layer — in one branch. Between then and now, the CORE half of that work landed on `main` separately via #49/#51/#54: `protocol/gemini/{gemini-transformer,error,gemini-types}.ts` already exist, `index.ts` already exports the Gemini ERROR symbols (`makeGeminiError`, `geminiTransformErrorOut`, `GeminiErrorEnvelope`), `@helm/shared` `ProtocolSchema` already includes `"gemini"`, and `server.ts` already has `coerceErrorClass`. The decision on #52 is **supersede #39**: port only the GATEWAY route layer onto current `main`, do not re-create the core pieces. #39 stays **closed/superseded** (no push/merge).
+
+**Migrated FROM #39 (gateway only)**:
+- `apps/gateway/src/routes/gemini.ts` — the thin HTTP↔IR route glue (catch-all `POST /v1beta/models/:rest{.+}` → `parseGeminiPath` → 404 on non-`generateContent`; `x-goog-api-key` preferred / `Bearer` fallback auth; rate-limit AFTER auth; malformed-JSON → 400; `transformRequestOut`; backfill `route.model`+`route.stream`+memory scope onto `ir.metadata`; `pipeline.run`; streaming via `streamSSE` writing NAMELESS `data:` frames with NO `[DONE]`; non-abort stream error → ONE terminal Gemini error frame; abort → no frame; non-stream → `transformResponseOut`). Ported verbatim — its imports already align with current `main`'s APIs.
+- `server.ts` wiring — `registerGeminiRoute` import + the `geminiPipeline = createMessagesPipeline(route, "gemini", { observe })` block after the responses route (auth mirrors the messages route's `keyStore.getByHash(hashKey(credential))`; `transformErrorOut` = `makeGeminiError(coerceErrorClass(err.error_class), …)`).
+- `messages-pipeline.ts` gemini branch — `streamIR()` widened to `AsyncIterable<Record<string, unknown>>`; when `protocol === "gemini"` it feeds the OpenAI-shaped `parseOpenAISSE` chunks straight into `geminiTransformer.transformStreamOut` (its `IRChunk` IS the OpenAI `chat.completion.chunk`), no Anthropic adapter. observe/finally accumulator untouched.
+- `messages.ts` — `PipelineRunResult.streamIR()` + Anthropic `transformStreamOut` param widened to `Record<string, unknown>` (the Anthropic route still typechecks; it reads `.type` off the object).
+- Tests: `gemini.test.ts` (12), `messages-pipeline.gemini.test.ts` (2), `e2e/gemini.spec.ts` (6) — all green.
+
+**Already-on-main (NOT re-added, would be duplicate exports / compile errors)**: the transformer, error envelope, wire types, and path parser in `protocol/gemini/*`, plus the Gemini ERROR exports in `index.ts`. Step 1 of this task only added the still-MISSING barrel exports (`geminiTransformer`/`parseGeminiPath`/`GEMINI_ENDPOINT`/`GEMINI_API_KEY_HEADER`/`GeminiRoute` + the wire types incl. `IRChunk`); the error exports were left alone.
+
+**Did NOT apply #39's server.ts OAuth churn**: #39's full `server.ts` diff also REVERTED the #38 subscription-OAuth wiring (`buildCredential`/`createProviderClient`/`oauthCtx`/preset enc-key). That OAuth work is on current `main` (#55) and must stay — only the Gemini-specific additions were cherry-picked.
+
+---
+
 ## 2026-06-02 · OpenAI + Gemini native error-envelope transformers + cross-protocol error fixtures flipped (issue #51, spec docs/05+07)
 
 **Context**: The error half of the Protocol Adapter only existed for Anthropic (`protocol/anthropic/error.ts`). The cross-protocol fixture matrix therefore had four `error` TODOs whose `todoReason` literally said "No OpenAI/Gemini-native error envelope transformer exists" (anthropic→openai, gemini→openai, openai→gemini, anthropic→gemini). The matrix error test hard-coded `expect(to).toBe("anthropic")`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -216,6 +216,26 @@ export {
   makeGeminiError,
   transformErrorOut as geminiTransformErrorOut,
 } from "./protocol/gemini/error.js";
+// Gemini transformer + route parser (docs/05, issue #34/#52). nativeIn -> IR ->
+// nativeOut, plus the pure path parser the gateway hands `{model}:{op}` to.
+export {
+  GEMINI_API_KEY_HEADER,
+  GEMINI_ENDPOINT,
+  type GeminiRoute,
+  geminiTransformer,
+  parseGeminiPath,
+} from "./protocol/gemini/gemini-transformer.js";
+// Gemini wire types (docs/05). GenerateContentRequest/Response + the snapshot SSE
+// event + the OpenAI-shaped IRChunk the snapshot state machine consumes.
+export {
+  type GeminiGenerateContentRequest,
+  GeminiGenerateContentRequestSchema,
+  type GeminiGenerateContentResponse,
+  GeminiGenerateContentResponseSchema,
+  type GeminiSSEEvent,
+  GeminiSSEEventSchema,
+  type IRChunk,
+} from "./protocol/gemini/gemini-types.js";
 // Protocol IR — the single central representation (docs/05). All translation
 // goes nativeIn -> IR -> nativeOut. Types are z.infer of these schemas.
 export {


### PR DESCRIPTION
Closes #34. Resolves #52. **Supersedes #39.** Refs #45.

## 背景 / What this is
执行 #52 的处置决策：**不直接合冻结的 PR #39**，而是把它的**网关路由层**移植到当前 `main` 上——当前 main 已经通过 #49/#51/#54 带上了 Gemini 的 transformer / 错误信封 / wire 类型 / 路径解析器。这是 Helm 的**第四个客户端协议入口**。

## 改动
**网关：**
- **`routes/gemini.ts`** (`registerGeminiRoute`)：薄薄一层 HTTP↔IR 胶水，对齐 `messages.ts`。先 `parseGeminiPath`（非 `:generateContent` 路径 → 404 Gemini 信封）；`x-goog-api-key`（`Bearer` 兜底）自鉴权；鉴权后再限流；坏 JSON → 400 `INVALID_ARGUMENT`；把**路径里的 model** + stream 标志 + memory scope 回填到 IR；走共享 pipeline；流式输出为**无名 `data:` 快照帧**（无 `event:` 名、无 `[DONE]`）；客户端 abort 不发错误帧，非 abort 的流内错误发**一帧** Gemini 终止错误。
- **`messages-pipeline.ts`**：`streamIR()` 按 pipeline 标记的协议分支——`gemini` 把 OpenAI 形态的 chunk 喂给 `geminiTransformer.transformStreamOut`（它的 `IRChunk` 就是 chat.completion.chunk），其余保持 `convertOpenAIStreamToAnthropic`。
- **`messages.ts`**：把 `PipelineRunResult.streamIR()` / `transformStreamOut` 放宽到 `Record<string,unknown>`（Gemini 快照没有 `type` 字段）；Anthropic 路径不变。
- **`server.ts`**：接线 `gemini` 标记的 pipeline + `registerGeminiRoute`（鉴权解析、限流、`makeGeminiError(coerceErrorClass(...))` 信封）。

**core barrel（仅导出）：** 导出 `geminiTransformer` / `parseGeminiPath` / `GEMINI_*` / `GeminiRoute` + Gemini wire 类型 + `IRChunk`。Gemini **错误**导出在 #51 已存在，**未重复**。

## 与 #39 的关系（migrate vs 不复用）
- **迁移自 #39**：route handler 结构、server 接线、pipeline 的 gemini 分支、流式快照逻辑、e2e 模板。
- **不复用 #39**：core 层的 error.ts / transformer / 类型 / 路径解析器（已在 main，避免重复/冲突）；#39 的 core 级测试未照搬（main 已覆盖）。

## 测试
- `gemini.test.ts` (12) + `messages-pipeline.gemini.test.ts` (2) + e2e `gemini.spec.ts` (6) 全绿；
- 完整 gateway + protocol 套件绿；`pnpm typecheck` 全绿；Biome 干净。
- 经过一轮对抗式 review（无遗留 bug、无重复导出）。

不引入/vendor LiteLLM 代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)