### PR TITLE
fix(protocol): 修复 Anthropic 入站流式 usage 形状 + 工具名往返 (#59 P1)

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 2026-06-02 · Fix two Codex-review P1s in the #59 Anthropic bidirectional work (spec docs/05)
+
+A `/codex:review` of PR #60 (merged) found two real correctness bugs that the unit tests masked:
+
+- **Inbound stream usage shape was wrong** (`anthropic/stream.ts`). `convertAnthropicStreamToIR` read `input_tokens`/`cache_read_input_tokens` off `message_delta`, but **real Anthropic streams put the prompt usage on `message_start`** and send only the cumulative `output_tokens` on `message_delta`; `message_delta.delta.stop_sequence` can be a string. The old schema *required* input/cache on `message_delta`, so a real provider stream would fail to parse (or report 0 prompt tokens). Fix: `message_start.usage` now carries optional `cache_*`; `message_delta.usage` requires only `output_tokens` (input/cache optional); `stop_reason`/`stop_sequence` are nullable strings. The converter now accumulates input/cache via `Math.max` across `message_start`+`message_delta` (so a 0-skeleton start never clobbers the real value, and Helm's own outbound — which echoes usage on `message_delta` — still works) and flushes one terminal usage on `message_stop`. The matrix masking test was rewritten to the **real wire shape**.
+- **Tool-name round-trip lost the original name** (`anthropic/request.ts` + `response.ts`). The request sanitizes `db.query` → `db_query` (Anthropic's `^[a-zA-Z0-9_-]{1,128}$`), but `transformNativeResponseToIR` returned the sanitized name into IR, breaking client tool dispatch. The earlier comment claiming the map was "reconstructible from the response" was wrong (the response only carries the sanitized name). Fix: `transformNativeResponseToIR(native, toolNameMap?)` restores the original via the threaded map; the map is deterministic, so an orchestrator rebuilds it with `createAnthropicToolNameMap(<original IR tool names>)` and passes it. Stateless callers keep the sanitized name. Round-trip + stateless tests added; the misleading comment corrected.
+
+protocol + gateway routes 406 tests green; typecheck clean; `pnpm lint` exit 0.
+
+---
+
 ## 2026-06-02 · Anthropic protocol made fully bidirectional + cross-protocol matrix TODOs flipped (issue #59, follow-up of #45, spec docs/05)
 
 **Context**: The Anthropic transformer was a 4-method `Pick` (name/endPoint/transformRequestOut/transformResponseOut) — it could serve an Anthropic-API client but had NO IR→Anthropic-request path, NO Anthropic-native-response→IR, and NO Anthropic-native-stream→IR. That left 15 explicit `todo` fixtures in `protocol-matrix.fixtures.ts`. This change implements the missing halves at the PROTOCOL-transformer layer (pure, framework-free) — distinct from `provider/anthropic.ts`, which carries OAuth/identity/subscription concerns and a Claude-Code system spoof. Behavior referenced from public LiteLLM, NOT copied.

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -595,11 +595,15 @@ export function transformRequestIn(ir: IRRequest): AnthropicOutboundRequest {
   const toolChoice = mapToolChoice(parsed.tool_choice, toolNameMap);
   const outputFormat = responseFormatToOutputFormat(parsed.response_format);
 
-  // NB: the tool-name reverse map is NOT emitted onto the outbound request wire.
-  // An Anthropic Messages request has no provider_raw field, and the matrix's
-  // no-leak invariant forbids smuggling internal bookkeeping onto the wire. The map
-  // is deterministic (createAnthropicToolNameMap) and reconstructible from the same
-  // tool list on the response path, so nothing is lost.
+  // NB: the tool-name reverse map is NOT emitted onto the outbound request wire (an
+  // Anthropic Messages request has no provider_raw field, and the matrix's no-leak
+  // invariant forbids smuggling internal bookkeeping there). It is NOT recoverable
+  // from the Anthropic RESPONSE alone — that only carries the sanitized name. The map
+  // IS deterministic, though: an orchestrator that called transformRequestIn rebuilds
+  // the identical map with `createAnthropicToolNameMap(<original tool names from the
+  // IR request>)` and passes it to `transformNativeResponseToIR(res, map)`, which
+  // restores `db_query` -> `db.query`. Stateless callers (no map) keep the sanitized
+  // name. See response.ts.
   const out: AnthropicOutboundRequest = {
     model: parsed.model,
     max_tokens: parsed.max_tokens ?? DEFAULT_MAX_TOKENS,

--- a/packages/core/src/protocol/anthropic/response.test.ts
+++ b/packages/core/src/protocol/anthropic/response.test.ts
@@ -5,6 +5,7 @@ import {
   createAnthropicToolNameMap,
   mapStopReason,
   mapUsage,
+  transformNativeResponseToIR,
   transformResponseIn,
 } from "./response.js";
 
@@ -283,5 +284,35 @@ describe("transformResponseIn", () => {
     });
     const text = out.content.find((b) => b.type === "text");
     expect(text).toMatchObject({ type: "text", text: "the answer is 42" });
+  });
+});
+
+describe("transformNativeResponseToIR — tool-name round-trip (Codex P1)", () => {
+  // Anthropic requires tool names to match ^[a-zA-Z0-9_-]{1,128}$, so transformRequestIn
+  // sanitizes `db.query` -> `db_query`. Anthropic then echoes the sanitized name on the
+  // response. Without the request-side map, the original is unrecoverable; threading the
+  // SAME deterministic map restores it so client-side tool dispatch keeps working.
+  const nativeWithSanitizedTool = {
+    id: "msg_1",
+    type: "message",
+    role: "assistant",
+    model: "claude-3-5-sonnet",
+    content: [{ type: "tool_use", id: "tu_1", name: "db_query", input: { sql: "select 1" } }],
+    stop_reason: "tool_use",
+    usage: { input_tokens: 5, output_tokens: 2 },
+  };
+
+  it("restores the original tool name when the request-side map is threaded", () => {
+    // Deterministically rebuilt from the IR request's original tool list.
+    const map = createAnthropicToolNameMap(["db.query"]);
+    expect(map.toAnthropic("db.query")).toBe("db_query"); // request sanitized it thus
+
+    const ir = transformNativeResponseToIR(nativeWithSanitizedTool, map);
+    expect(ir.choices[0]?.message.tool_calls?.[0]?.function.name).toBe("db.query");
+  });
+
+  it("falls back to the sanitized name when no map is provided (stateless)", () => {
+    const ir = transformNativeResponseToIR(nativeWithSanitizedTool);
+    expect(ir.choices[0]?.message.tool_calls?.[0]?.function.name).toBe("db_query");
   });
 });

--- a/packages/core/src/protocol/anthropic/response.ts
+++ b/packages/core/src/protocol/anthropic/response.ts
@@ -397,7 +397,10 @@ const InboundResponseSchema = z
  * input on the Anthropic wire, so prompt_tokens = input_tokens and cached_tokens =
  * cache_read_input_tokens (never double-billed). Raw usage stashed in provider_raw.
  */
-export function transformNativeResponseToIR(native: unknown): IRResponse {
+export function transformNativeResponseToIR(
+  native: unknown,
+  toolNameMap?: AnthropicToolNameMap,
+): IRResponse {
   const res = InboundResponseSchema.parse(native);
 
   const parts: IRContentPart[] = [];
@@ -414,10 +417,16 @@ export function transformNativeResponseToIR(native: unknown): IRResponse {
       });
     } else if (block.type === "tool_use") {
       const b = block as z.infer<typeof InboundToolUseBlockSchema>;
+      // Restore the ORIGINAL tool name when the request-side sanitizer map is
+      // threaded in (e.g. `db.query` was sent as `db_query`). Without the map we
+      // pass Anthropic's name through unchanged — the best we can do statelessly.
       toolCalls.push({
         id: b.id,
         type: "function",
-        function: { name: b.name, arguments: JSON.stringify(b.input ?? {}) },
+        function: {
+          name: toolNameMap?.toOriginal(b.name) ?? b.name,
+          arguments: JSON.stringify(b.input ?? {}),
+        },
       });
     }
     // unknown block types are tolerated (fail-open) and dropped from content.

--- a/packages/core/src/protocol/anthropic/stream.ts
+++ b/packages/core/src/protocol/anthropic/stream.ts
@@ -126,9 +126,15 @@ const MessageStartEventSchema = z.object({
     content: z.array(z.unknown()),
     stop_reason: z.null(),
     stop_sequence: z.null(),
+    // Real Anthropic streams put the PROMPT usage on message_start: input_tokens
+    // and the cache fields are known up-front (output_tokens is the initial, ~1).
+    // cache_* are optional (absent when no prompt caching). The skeleton Helm
+    // itself emits ({input_tokens:0,output_tokens:0}) validates here too.
     usage: z.object({
       input_tokens: z.number().int().nonnegative(),
       output_tokens: z.number().int().nonnegative(),
+      cache_read_input_tokens: z.number().int().nonnegative().optional(),
+      cache_creation_input_tokens: z.number().int().nonnegative().optional(),
     }),
   }),
 });
@@ -152,11 +158,20 @@ const ContentBlockStopEventSchema = z.object({
 
 const MessageDeltaEventSchema = z.object({
   type: z.literal("message_delta"),
-  delta: z.object({ stop_reason: z.string(), stop_sequence: z.null() }),
+  // Real Anthropic: stop_sequence is the matched string (or null); stop_reason can
+  // be null on a non-terminal message_delta.
+  delta: z.object({
+    stop_reason: z.string().nullable(),
+    stop_sequence: z.string().nullable(),
+  }),
+  // Real Anthropic message_delta.usage carries ONLY the cumulative output_tokens;
+  // input_tokens / cache_* live on message_start. We keep input/cache OPTIONAL so
+  // both the real wire shape AND Helm's own outbound (which echoes them here) parse.
   usage: z.object({
-    input_tokens: z.number().int().nonnegative(),
     output_tokens: z.number().int().nonnegative(),
-    cache_read_input_tokens: z.number().int().nonnegative(),
+    input_tokens: z.number().int().nonnegative().optional(),
+    cache_read_input_tokens: z.number().int().nonnegative().optional(),
+    cache_creation_input_tokens: z.number().int().nonnegative().optional(),
   }),
 });
 
@@ -485,7 +500,15 @@ export async function* convertAnthropicStreamToIR(
   // Anthropic content-block index -> OpenAI tool_call index (only for tool blocks).
   const blockToTool = new Map<number, InboundToolState>();
   let finishReason: string | null = null;
-  let usage: IRChunk["usage"] | undefined;
+  // Usage is assembled across events: input/cache land on message_start (real
+  // Anthropic) — or echoed on message_delta (Helm's own outbound) — while the
+  // cumulative output lands on message_delta. We take the max of each input/cache
+  // sighting so a 0-skeleton message_start never clobbers the real value, then flush
+  // a single terminal usage on message_stop. `sawUsage` gates emission.
+  let inputTokens = 0;
+  let cacheTokens = 0;
+  let outputTokens = 0;
+  let sawUsage = false;
 
   function base(): IRChunk {
     return {
@@ -500,6 +523,10 @@ export async function* convertAnthropicStreamToIR(
         id = event.message.id !== "" ? event.message.id : id;
         model = event.message.model !== "" ? event.message.model : model;
         started = true;
+        // Capture the prompt usage that real Anthropic reports up-front.
+        const u = event.message.usage;
+        inputTokens = Math.max(inputTokens, u.input_tokens);
+        cacheTokens = Math.max(cacheTokens, u.cache_read_input_tokens ?? 0);
         yield { ...base(), choices: [{ index: 0, delta: { role: "assistant" } }] };
         break;
       }
@@ -561,18 +588,28 @@ export async function* convertAnthropicStreamToIR(
         // the consumer. Nothing to emit (idempotent close lives on the producer).
         break;
       case "message_delta": {
-        finishReason = STOP_REASON_TO_FINISH_STREAM[event.delta.stop_reason] ?? "stop";
-        // Anthropic input_tokens is non-cached; carry straight across.
-        usage = {
-          prompt_tokens: event.usage.input_tokens,
-          completion_tokens: event.usage.output_tokens,
-          ...(event.usage.cache_read_input_tokens > 0
-            ? { cached_tokens: event.usage.cache_read_input_tokens }
-            : {}),
-        };
+        if (event.delta.stop_reason !== null) {
+          finishReason = STOP_REASON_TO_FINISH_STREAM[event.delta.stop_reason] ?? "stop";
+        }
+        // Real Anthropic message_delta carries the cumulative output_tokens; some
+        // sources (Helm's own outbound) also echo input/cache here — fold them in.
+        outputTokens = event.usage.output_tokens;
+        inputTokens = Math.max(inputTokens, event.usage.input_tokens ?? 0);
+        cacheTokens = Math.max(cacheTokens, event.usage.cache_read_input_tokens ?? 0);
+        sawUsage = true;
         break;
       }
       case "message_stop": {
+        // Flush ONE terminal usage assembled from message_start (input/cache) +
+        // message_delta (output). prompt_tokens is already non-cached in Anthropic,
+        // so it maps straight across; cached is re-exposed, never double-billed.
+        const usage: IRChunk["usage"] | undefined = sawUsage
+          ? {
+              prompt_tokens: inputTokens,
+              completion_tokens: outputTokens,
+              ...(cacheTokens > 0 ? { cached_tokens: cacheTokens } : {}),
+            }
+          : undefined;
         yield {
           ...base(),
           choices: [{ index: 0, delta: {}, finish_reason: finishReason ?? "stop" }],

--- a/packages/core/src/protocol/protocol-matrix.test.ts
+++ b/packages/core/src/protocol/protocol-matrix.test.ts
@@ -611,7 +611,9 @@ describe("protocol cross-path executable harness", () => {
           content: [],
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 0, output_tokens: 0 },
+          // REAL Anthropic wire shape: the prompt usage (input + cache) is reported
+          // up-front on message_start; message_delta later carries only output.
+          usage: { input_tokens: 10, output_tokens: 0, cache_read_input_tokens: 3 },
         },
       },
       { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
@@ -631,7 +633,8 @@ describe("protocol cross-path executable harness", () => {
       {
         type: "message_delta",
         delta: { stop_reason: "tool_use", stop_sequence: null },
-        usage: { input_tokens: 10, output_tokens: 4, cache_read_input_tokens: 3 },
+        // REAL Anthropic message_delta carries ONLY the cumulative output_tokens.
+        usage: { output_tokens: 4 },
       },
       { type: "message_stop" },
     ];
@@ -646,7 +649,9 @@ describe("protocol cross-path executable harness", () => {
     // terminal IR chunk carries the reverse-mapped finish_reason + non-double-billed usage.
     const terminal = irChunks.at(-1);
     expect(terminal?.choices?.[0]?.finish_reason).toBe("tool_calls");
+    // input from message_start, output from message_delta, cache from message_start.
     expect(terminal?.usage?.prompt_tokens).toBe(10);
+    expect(terminal?.usage?.completion_tokens).toBe(4);
     expect(terminal?.usage?.cached_tokens).toBe(3);
 
     // anthropic -> gemini: re-serialize the IR chunks to Gemini snapshots.


### PR DESCRIPTION
修复 PR #60（已合并）经 `/codex:review` 发现的两个 P1。两个都被单测**掩盖**了。

## P1-A — 入站流式 usage 形状错误（`anthropic/stream.ts`）
`convertAnthropicStreamToIR` 从 `message_delta` 读 `input_tokens`/`cache_read_input_tokens`，但**真实 Anthropic 流**把 prompt usage（input + cache）放在 `message_start`，`message_delta` 只带累计 `output_tokens`；`stop_sequence` 可能是字符串。旧 schema 强制要求 `message_delta` 带 input/cache → 真实 provider 流**解析失败**或 prompt tokens 记成 0。

**修复**：`message_start.usage` 接受可选 `cache_*`；`message_delta.usage` 只必填 `output_tokens`（input/cache 可选）；`stop_reason`/`stop_sequence` 改 nullable string。转换器用 `Math.max` 跨 `message_start`+`message_delta` 累积 input/cache（0 骨架的 message_start 不会覆盖真实值；Helm 自己出站的形状也仍兼容），在 `message_stop` 输出**一个**终止 usage。矩阵里那个掩盖问题的测试改用**真实 wire 形状**。

## P1-B — 工具名往返丢失（`anthropic/request.ts` + `response.ts`）
请求把 `db.query` sanitize 成 `db_query`（Anthropic 名字正则），但 `transformNativeResponseToIR` 把 sanitize 后的名字写回 IR，**断了客户端工具分发**；之前"可从响应重建映射"的注释是**错的**（响应只有 sanitize 后的名字）。

**修复**：`transformNativeResponseToIR(native, toolNameMap?)` 通过**线程传入的确定性 map** 还原原始名字（orchestrator 用 IR 请求的原始工具名 `createAnthropicToolNameMap(...)` 重建同一个 map 传进来）；无 map 的无状态调用保留 sanitize 名。新增**往返 + 无状态**两个测试；错误注释已更正。

## 验证
protocol + gateway routes **406 tests green**；`pnpm typecheck` 全绿；`pnpm lint`（`biome check .`）exit 0。

Refs #59, #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)