### PR TITLE
feat(admin): present API-key create/edit/revoke as a centered modal

### DIFF
--- a/apps/admin/src/app.css
+++ b/apps/admin/src/app.css
@@ -50,6 +50,16 @@
   .dialog {
     @apply rounded-lg border border-slate-300 bg-white p-5 shadow-sm;
   }
+  /* — Modal: centered overlay built from a fixed backdrop + scrim + panel — */
+  .modal-backdrop {
+    @apply fixed inset-0 z-50 flex items-center justify-center p-4;
+  }
+  .modal-scrim {
+    @apply absolute inset-0 cursor-default bg-slate-900/40;
+  }
+  .modal-panel {
+    @apply relative z-10 max-h-[calc(100vh-2rem)] w-full max-w-lg overflow-y-auto rounded-lg border border-slate-300 bg-white p-5 shadow-lg focus:outline-none;
+  }
 
   /* — Buttons — */
   .btn-primary {

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -5,6 +5,7 @@
     createKey,
     type CreatedKey,
   } from '$lib/api/keys.js';
+  import Modal from '$lib/components/Modal.svelte';
   import { t } from '$lib/i18n';
 
   // Create-key dialog: owns the caps form AND the ONE-TIME plaintext reveal.
@@ -101,7 +102,10 @@
   }
 </script>
 
-<div class="dialog" role="dialog" aria-label={$t('Create API key')}>
+<!-- While the plaintext is revealed the modal is non-dismissible: no scrim, Escape
+     ignored. The operator must click "I saved it" (confirmSaved) to bubble the
+     redacted view and wipe the secret — see CLAUDE.md 原则7 / docs/06. -->
+<Modal label={$t('Create API key')} {onclose} dismissible={!revealed}>
   {#if revealed}
     <h2 class="section-header">{$t('Your new API key')}</h2>
     <p class="mt-1 text-sm text-amber-700">
@@ -222,4 +226,4 @@
       >
     </div>
   {/if}
-</div>
+</Modal>

--- a/apps/admin/src/lib/components/CreateKeyDialog.test.ts
+++ b/apps/admin/src/lib/components/CreateKeyDialog.test.ts
@@ -83,6 +83,26 @@ describe('CreateKeyDialog', () => {
     expect(onclose).toHaveBeenCalled();
   });
 
+  it('renders the create form inside a dismissible modal (scrim + Escape close)', async () => {
+    const { onclose } = setup();
+    expect(screen.getByRole('dialog', { name: /create api key/i })).toBeInTheDocument();
+    await fireEvent.click(screen.getByTestId('modal-scrim'));
+    expect(onclose).toHaveBeenCalledTimes(1);
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onclose).toHaveBeenCalledTimes(2);
+  });
+
+  it('locks the one-time plaintext reveal — modal is NOT dismissible (must acknowledge)', async () => {
+    const { onclose } = setup();
+    await fireEvent.click(screen.getByRole('button', { name: /create key/i }));
+    await waitFor(() => expect(screen.getByTestId('plaintext-reveal')).toBeInTheDocument());
+    // No scrim to click, and Escape must not dismiss the secret reveal.
+    expect(screen.queryByTestId('modal-scrim')).not.toBeInTheDocument();
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onclose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('plaintext-reveal')).toBeInTheDocument();
+  });
+
   it('shows an error and reveals no plaintext when createKey fails (fail-closed)', async () => {
     createKey.mockRejectedValue(new Error('400 invalid key request'));
     setup();

--- a/apps/admin/src/lib/components/EditKeyDialog.svelte
+++ b/apps/admin/src/lib/components/EditKeyDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import { type ApiKeyView, type UpdateKeyInput, updateKey } from '$lib/api/keys.js';
+  import Modal from '$lib/components/Modal.svelte';
   import { t } from '$lib/i18n';
 
   // Edit-key dialog: edits every per-key cap of an EXISTING key in one place. The
@@ -77,7 +78,7 @@
   }
 </script>
 
-<div class="dialog" role="dialog" aria-label={$t('Edit key')}>
+<Modal label={$t('Edit key')} {onclose}>
   <h2 class="section-header">{$t('Edit key')}</h2>
 
   {#if error}
@@ -95,7 +96,11 @@
     <div class="flex flex-col gap-1 text-sm">
       <span class="field-label">{$t('Role')}</span>
       <span class="text-ink-body">{key.role}</span>
-      <span class="field-help">{$t('Role is fixed for the life of a key — rotate by revoking and minting a new one.')}</span>
+      <span class="field-help"
+        >{$t(
+          'Role is fixed for the life of a key — rotate by revoking and minting a new one.',
+        )}</span
+      >
     </div>
 
     <label class="flex flex-col gap-1 text-sm">
@@ -135,7 +140,11 @@
     </fieldset>
 
     <label class="flex items-center gap-2 text-sm">
-      <input type="checkbox" bind:checked={allowCustomModel} aria-label={$t('allow custom model')} />
+      <input
+        type="checkbox"
+        bind:checked={allowCustomModel}
+        aria-label={$t('allow custom model')}
+      />
       <span class="text-ink-body">{$t('Allow explicit client-specified model passthrough')}</span>
     </label>
 
@@ -178,4 +187,4 @@
       >{$t('Save changes')}</button
     >
   </div>
-</div>
+</Modal>

--- a/apps/admin/src/lib/components/Modal.svelte
+++ b/apps/admin/src/lib/components/Modal.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { t } from '$lib/i18n';
+
+  // Reusable centered modal: fixed full-screen backdrop, a scrim that dismisses on
+  // click, Escape-to-close, and body scroll-lock while open. The panel carries the
+  // `role="dialog"` + aria-label so callers render plain content inside it.
+  //
+  // `dismissible` gates BOTH the scrim and Escape. Set it false when the dialog must
+  // be acknowledged (e.g. the one-time API-key plaintext reveal — CLAUDE.md 原则7):
+  // there is then no scrim and Escape is ignored, so the only exit is an explicit
+  // action the caller wires up.
+  let {
+    label,
+    onclose,
+    dismissible = true,
+    children,
+  }: {
+    label: string;
+    onclose: () => void;
+    dismissible?: boolean;
+    children: Snippet;
+  } = $props();
+
+  let panel = $state<HTMLDivElement | null>(null);
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (dismissible && e.key === 'Escape') {
+      e.stopPropagation();
+      onclose();
+    }
+  }
+
+  // Lock background scroll and move focus into the panel while the modal is open;
+  // both are restored when it unmounts.
+  $effect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    panel?.focus();
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  });
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<div class="modal-backdrop">
+  {#if dismissible}
+    <!-- A real button (not a click-handler on the scrim div) keeps this keyboard-
+         reachable and a11y-clean; it sits behind the panel and fills the backdrop. -->
+    <button
+      type="button"
+      class="modal-scrim"
+      data-testid="modal-scrim"
+      aria-label={$t('Close')}
+      onclick={onclose}
+    ></button>
+  {/if}
+  <div
+    bind:this={panel}
+    class="modal-panel"
+    role="dialog"
+    aria-modal="true"
+    aria-label={label}
+    tabindex="-1"
+  >
+    {@render children()}
+  </div>
+</div>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -27,6 +27,7 @@
   "Cache": "Cache",
   "cache:": "cache:",
   "Cancel": "Cancel",
+  "Close": "Close",
   "Cap lane (maximum)": "Cap lane (maximum)",
   "Caps": "Caps",
   "Chosen by deterministic Layer-1 rules.": "Chosen by deterministic Layer-1 rules.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -27,6 +27,7 @@
   "Cache": "キャッシュ",
   "cache:": "キャッシュ：",
   "Cancel": "キャンセル",
+  "Close": "閉じる",
   "Cap lane (maximum)": "上限レーン（最大）",
   "Caps": "上限",
   "Chosen by deterministic Layer-1 rules.": "決定論的なLayer-1ルールによって選択されました。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -27,6 +27,7 @@
   "Cache": "캐시",
   "cache:": "캐시:",
   "Cancel": "취소",
+  "Close": "닫기",
   "Cap lane (maximum)": "레인 제한(최대)",
   "Caps": "상한",
   "Chosen by deterministic Layer-1 rules.": "결정론적 Layer-1 규칙에 의해 선택됨.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -27,6 +27,7 @@
   "Cache": "缓存",
   "cache:": "缓存：",
   "Cancel": "取消",
+  "Close": "关闭",
   "Cap lane (maximum)": "限制车道上限（最高）",
   "Caps": "上限",
   "Chosen by deterministic Layer-1 rules.": "由确定性的第一层规则选定。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -27,6 +27,7 @@
   "Cache": "快取",
   "cache:": "快取：",
   "Cancel": "取消",
+  "Close": "關閉",
   "Cap lane (maximum)": "限制車道上限（最高）",
   "Caps": "上限",
   "Chosen by deterministic Layer-1 rules.": "由確定性的第一層規則選定。",

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -3,6 +3,7 @@
   import { type ApiKeyView, revokeKey } from '$lib/api/keys.js';
   import CreateKeyDialog from '$lib/components/CreateKeyDialog.svelte';
   import EditKeyDialog from '$lib/components/EditKeyDialog.svelte';
+  import Modal from '$lib/components/Modal.svelte';
   import { t } from '$lib/i18n';
 
   // API key management view. HARD security line (CLAUDE.md Principle 7 / docs/06): the
@@ -162,10 +163,8 @@
               <td class="px-3 py-2 text-right">
                 {#if !key.disabled}
                   <div class="flex justify-end gap-2">
-                    <button
-                      type="button"
-                      class="btn-secondary"
-                      onclick={() => startEdit(key)}>{$t('Edit')}</button
+                    <button type="button" class="btn-secondary" onclick={() => startEdit(key)}
+                      >{$t('Edit')}</button
                     >
                     <button
                       type="button"
@@ -184,14 +183,19 @@
   {/if}
 
   {#if confirmingRevoke}
-    <div class="alert-warn" role="dialog" aria-label={$t('Confirm revoke')}>
-      <p class="text-sm text-amber-800">
+    <Modal
+      label={$t('Confirm revoke')}
+      onclose={cancelRevoke}
+      dismissible={revoking !== confirmingRevoke}
+    >
+      <h2 class="section-header">{$t('Confirm revoke')}</h2>
+      <p class="mt-2 text-sm text-amber-800">
         {$t('Revoke key')}
         <code class="font-mono">{confirmingPrefix}</code>{$t(
           '? It will be disabled (kept for audit, not deleted). Mint a fresh key to rotate.',
         )}
       </p>
-      <div class="mt-3 flex justify-end gap-2">
+      <div class="mt-4 flex justify-end gap-2">
         <button
           type="button"
           class="btn-secondary"
@@ -206,6 +210,6 @@
           >{revoking === confirmingRevoke ? $t('Revoking…') : $t('Confirm revoke')}</button
         >
       </div>
-    </div>
+    </Modal>
   {/if}
 </section>

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -160,6 +160,38 @@ describe('keys page', () => {
     );
   });
 
+  it('presents the Edit dialog as a centered modal dismissible via scrim and Escape', async () => {
+    renderPage([key('k1')]);
+    await fireEvent.click(within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }));
+    expect(screen.getByRole('dialog', { name: /edit key/i })).toBeInTheDocument();
+    // Clicking the backdrop scrim closes the modal.
+    await fireEvent.click(screen.getByTestId('modal-scrim'));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /edit key/i })).not.toBeInTheDocument(),
+    );
+
+    // Re-open and close via Escape.
+    await fireEvent.click(within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }));
+    expect(screen.getByRole('dialog', { name: /edit key/i })).toBeInTheDocument();
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /edit key/i })).not.toBeInTheDocument(),
+    );
+  });
+
+  it('presents the revoke confirmation as a centered modal', async () => {
+    renderPage([key('k1', { prefix: 'helm_live_ab12' })]);
+    await fireEvent.click(within(screen.getByTestId('key-row')).getByRole('button', { name: /revoke/i }));
+    const dialog = screen.getByRole('dialog', { name: /confirm revoke/i });
+    expect(within(dialog).getByRole('button', { name: /confirm/i })).toBeInTheDocument();
+    // The scrim dismisses the confirmation (same as Cancel) without revoking.
+    await fireEvent.click(screen.getByTestId('modal-scrim'));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /confirm revoke/i })).not.toBeInTheDocument(),
+    );
+    expect(revokeKey).not.toHaveBeenCalled();
+  });
+
   it('does not offer Edit on a revoked (disabled) key', () => {
     renderPage([key('k1', { disabled: true })]);
     const row = screen.getByTestId('key-row');

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 2026-06-02 · Admin: API-key create/edit/revoke moved into a centered modal (spec docs/06, docs/11 — UI)
+
+**Context**: On `/admin/keys` the create/edit dialogs and the revoke confirmation rendered inline in the page flow (a plain `.dialog` card injected between the header and the table), so they shoved the content down and read as "stuck at the top". Requested change: present them as a centered overlay modal.
+
+- New reusable `apps/admin/src/lib/components/Modal.svelte`: a fixed full-screen backdrop (`.modal-backdrop`) + a dismiss **scrim rendered as a real `<button>`** (`.modal-scrim`, not a click-handler on a `<div>` — keeps svelte-check a11y clean, 0 warnings) + a centered, scrollable `.modal-panel` carrying `role="dialog"` / `aria-modal` / `aria-label`. It locks body scroll and focuses the panel on mount (`$effect` restores on unmount), and closes on Escape via `<svelte:window onkeydown>`.
+- **`dismissible` prop gates BOTH scrim and Escape.** `CreateKeyDialog` passes `dismissible={!revealed}`: while the one-time plaintext is shown there is no scrim and Escape is ignored, so the operator MUST click "I saved it" (`confirmSaved`) — preserving the must-acknowledge UX for the secret (CLAUDE.md 原则7). The revoke modal sets `dismissible={revoking !== confirmingRevoke}` so it can't be dismissed mid-request.
+- `role="dialog"` + aria-label moved off the inner `.dialog` div onto the Modal panel (single dialog node — `getByRole('dialog')` stays unambiguous). The old inline `.dialog` wrapper is gone from both key dialogs; the revoke confirm dropped its inline `alert-warn` card for the Modal.
+- New i18n key `Close` (scrim aria-label) added to all 5 locales. CSS `.modal-*` utilities live next to `.dialog` in `app.css`.
+- TDD: added modal-behavior tests first (scrim+Escape dismiss for edit & revoke; non-dismissible reveal for create). Full admin suite 170/170 green, svelte-check 0/0, prettier clean.
+
+---
+
 ## 2026-06-02 · Fix two Codex-review P1s in the #59 Anthropic bidirectional work (spec docs/05)
 
 A `/codex:review` of PR #60 (merged) found two real correctness bugs that the unit tests masked:


### PR DESCRIPTION
## What

On `/admin/keys` the **create / edit** dialogs and the **revoke confirmation** rendered inline in the page flow (a `.dialog` card injected between the header and the table), so they pushed the content down and read as "stuck at the top". This presents all three as a **centered modal over a dimmed backdrop**.

## How

- New reusable `apps/admin/src/lib/components/Modal.svelte`:
  - fixed full-screen backdrop + a dismiss **scrim rendered as a real `<button>`** (not a click-handler on a `<div>` — keeps svelte-check a11y clean)
  - centered, scrollable `.modal-panel` carrying `role="dialog"` / `aria-modal` / `aria-label`
  - locks body scroll, focuses the panel on mount, closes on **Escape** or **scrim click**
- Wired into `CreateKeyDialog`, `EditKeyDialog`, and the revoke confirmation in `keys/+page.svelte`. `role`/`aria-label` moved off the inner `.dialog` onto the Modal panel (single dialog node).
- **`dismissible` prop gates BOTH scrim and Escape**:
  - `CreateKeyDialog` passes `dismissible={!revealed}` — while the one-time plaintext key is shown there is no scrim and Escape is ignored, so the operator MUST click **"I saved it"**. Preserves the must-acknowledge UX for the secret (CLAUDE.md 原则7 / docs/06).
  - the revoke modal sets `dismissible={revoking !== confirmingRevoke}` so it can't be dismissed mid-request.
- New i18n key `Close` (scrim aria-label) added to all 5 locales. `.modal-*` utilities live next to `.dialog` in `app.css`.

## Tests

TDD — modal-behavior tests added first:
- edit & revoke close via scrim click and Escape
- create reveal is **non-dismissible** (no scrim, Escape ignored) until acknowledged

`pnpm vitest` (admin) **170/170 green** · `svelte-check` **0 errors / 0 warnings** · prettier clean.

## Verification

Booted the full stack (gateway serving the built admin SPA) and confirmed the Edit, Create, and Revoke modals render centered over a dimmed backdrop, with the scrim correctly blocking background interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)