### PR TITLE
docs: correct README + docs for v0.2.0 (and bump version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,27 @@ AI app developers don't want to manage hundreds of models, per-provider quirks, 
 
 ## Status
 
-Helm API is **0.1** and early-stage, but it is a real implementation, not a scaffold — the full pipeline (config → auth → classify → route → execute with circuit-breaking and fallback → protocol translation → telemetry) is wired end-to-end and backed by an extensive Vitest unit suite plus Playwright e2e specs. See [Features](#features) for exactly what ships today versus what is roadmap-only.
+Helm API is **0.2** and early-stage, but it is a real implementation, not a scaffold — the full pipeline (config → auth → classify → route → execute with circuit-breaking and fallback → protocol translation → telemetry) is wired end-to-end and backed by an extensive Vitest unit suite plus Playwright e2e specs. See [Features](#features) for exactly what ships today versus what is roadmap-only.
 
 ## Features
 
 **Shipped:**
 
-- **Three client protocols** — `POST /v1/chat/completions` (OpenAI Chat, streaming + non-streaming), `POST /v1/messages` (Anthropic Messages, streaming + non-streaming), `POST /v1/responses` (OpenAI Responses, non-streaming).
-- **Cross-protocol translation** — normalize to one internal IR; consistent output shape across backends, with SSE streaming for the chat and messages surfaces.
+- **Four client protocols** — `POST /v1/chat/completions` (OpenAI Chat), `POST /v1/messages` (Anthropic Messages), and `POST /v1/responses` (OpenAI Responses) — all streaming + non-streaming — plus `POST /v1beta/models/{model}:generateContent` (Google Gemini, non-streaming).
+- **Cross-protocol translation** — normalize to one internal IR; consistent output shape across backends, with SSE streaming on the chat, messages, and responses surfaces.
 - **Three-layer classification** — deterministic rules always on; optional small-model eval (off by default) for uncertain cases; `balanced`-lane fallback.
 - **Lane + policy routing** — first-match policies that pin, cap, or restrict lanes; default lanes shipped: `economy`, `balanced`, `premium`, plus task lanes `coding`, `json`, `vision`, `tool_use`. (`balanced` is the required, always-available fallback lane.)
 - **Provider execution with fallback** — primary + fallback chains across OpenAI-compatible upstreams, with a circuit breaker (OPEN/HALF_OPEN), a capability filter (skip candidates lacking JSON / tools / vision / context size with an explicit reason), and `:free`-tier 429 skipping. Client disconnects are treated as non-provider faults.
-- **Mandatory API-key auth** — keys stored as SHA-256 hashes only; a root key is generated and printed once on first boot. Per-key caps (`max_lane`, `allowed_lanes`, custom-model permission) and optional per-key RPM/TPM rate limits.
+- **Mandatory API-key auth** — keys stored as SHA-256 hashes only; a root key is generated and printed once on first boot. Per-key caps (an `allowed_lanes` whitelist and custom-model permission) and optional per-key RPM/TPM rate limits.
+- **OAuth subscription providers** — route your Claude Pro/Max, ChatGPT Codex, and GitHub Copilot **subscriptions** as backends: log in from the dashboard, pool several accounts per provider, and curate models / set an egress proxy / set scheduling per account — all of which **hot-reload** (no restart). See [the section below](#oauth-subscription-providers-claude-promax-chatgpt-codex-github-copilot). *(Opt-in; may violate provider ToS — read the warning.)*
 - **Observability** — a redacted decision record per request (classifier, policy, lane, provider attempts, latency, fallback count, cost breakdown) plus optional verbatim payload capture to a dedicated store, aged out by retention.
 - **Admin dashboard** — a SvelteKit + Tailwind SPA served at `/admin` behind HTTP Basic: live overview, API-key CRUD with per-key limits, lane and policy editors, classifier settings, and a drill-down request log. Available in 5 languages (English default, Simplified & Traditional Chinese, Japanese, Korean). Edits re-bind the live config and apply on the next request — no restart.
 - **Storage** — SQLite by default (local file); Postgres / Supabase optional, via a shared Store-port abstraction.
 
 **Roadmap / not yet wired:**
 
-- **Gemini** — a transformer exists in core but is routed to no endpoint; Google/Gemini-format clients cannot hit the gateway today.
-- **Streaming for `/v1/responses`** — `stream: true` is rejected with a structured `400` in 0.1.
 - **Memory middleware** — the observe (write) phase is wired; the inject (read-back-into-prompt) and reflector phases exist in core but are not yet reachable in the running gateway.
-- Finer-grained quotas / billing, and OAuth-subscription providers, are future work.
+- Finer-grained quotas / billing are future work.
 
 See [09 Roadmap](docs/09-roadmap.md) for details.
 
@@ -133,7 +132,8 @@ curl http://localhost:8080/v1/chat/completions \
 |---|---|---|
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
-| `POST /v1/responses` | OpenAI Responses | ❌ not yet (0.1) |
+| `POST /v1/responses` | OpenAI Responses | ✅ |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ❌ non-streaming |
 
 **What to put in the `model` field:**
 
@@ -183,9 +183,11 @@ To enable it, set **`HELM_OAUTH_ENC_KEY`** to a 32-byte key (base64, or 64 hex c
 
 You can connect **several accounts of one provider** and Helm pools them. Each account, via **Providers → Manage**, has its own:
 
-- **Models** — curate exactly which discovered models that account exposes to your lanes.
+- **Models** — curate exactly which models that account exposes to your lanes. The curated list is authoritative: a model you remove stops routing immediately, and an uncurated model is refused (fail-closed) — so curation is a live allow-list, not just a display filter.
 - **Proxy** — route that account's upstream traffic through an HTTP/HTTPS/SOCKS5 proxy so it egresses from a distinct IP (avoids ban-correlation when accounts share a host).
 - **Schedule** — a `priority` (lower = served first) and a `schedulable` toggle. Helm picks the lowest-priority account, round-robin (least-recently-used) within an equal priority; parking an account keeps it connected but out of rotation.
+
+**Everything here hot-reloads.** Connecting, disconnecting, curation, proxy, and scheduling changes **apply on the next request — no restart.** And to look like a first-party client, Helm mirrors the official client's identity headers and sends a **stable, per-account device identity** (it never rotates mid-stream), reducing ban-correlation risk.
 
 > ⚠️ **Terms of service.** Routing a Claude/ChatGPT/Copilot **subscription** through a third-party gateway may violate the provider's terms of service, which can be grounds for account suspension. This is an opt-in feature for self-hosted, personal use — **you are responsible** for ensuring your usage complies with your provider agreements. When in doubt, use a normal API key (`api_key_env`) instead.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,28 +49,27 @@ AI 应用开发者不想在每个客户端里维护成百上千个模型、各�
 
 ## 项目状态
 
-Helm API 目前是 **0.1**、尚处早期，但它是一套真实实现，而非空架子 —— 完整链路（配置 → 鉴权 → 分类 → 路由 → 执行（含熔断与兜底）→ 协议互译 → 遥测）已端到端打通，背后有一套相当完整的 Vitest 单测和 Playwright e2e 用例兜底。具体哪些已上线、哪些还只在路线图上，见 [功能](#功能)。
+Helm API 目前是 **0.2**、尚处早期，但它是一套真实实现，而非空架子 —— 完整链路（配置 → 鉴权 → 分类 → 路由 → 执行（含熔断与兜底）→ 协议互译 → 遥测）已端到端打通，背后有一套相当完整的 Vitest 单测和 Playwright e2e 用例兜底。具体哪些已上线、哪些还只在路线图上，见 [功能](#功能)。
 
 ## 功能
 
 **已上线：**
 
-- **三种客户端协议** —— `POST /v1/chat/completions`（OpenAI Chat，流式 + 非流式）、`POST /v1/messages`（Anthropic Messages，流式 + 非流式）、`POST /v1/responses`（OpenAI Responses，仅非流式）。
-- **跨协议互译** —— 归一到一套内部 IR；跨后端输出格式一致，chat 与 messages 两个面支持 SSE 流式。
+- **四种客户端协议** —— `POST /v1/chat/completions`（OpenAI Chat）、`POST /v1/messages`（Anthropic Messages）、`POST /v1/responses`（OpenAI Responses）三者均支持流式 + 非流式，外加 `POST /v1beta/models/{model}:generateContent`（Google Gemini，非流式）。
+- **跨协议互译** —— 归一到一套内部 IR；跨后端输出格式一致，chat、messages、responses 三个面均支持 SSE 流式。
 - **三层分类** —— 确定性规则常驻；不确定时走可选的小模型 eval（默认关闭）；最后兜底到 `balanced` lane。
 - **Lane + 策略路由** —— 首条命中的策略可以钉死、设上限或限定 lane；内置默认 lane：`economy`、`balanced`、`premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`（`balanced` 是必须存在、永远兜底的那条）。
 - **带兜底的 provider 执行** —— 在多个 OpenAI 兼容上游之间走「主 + 兜底」链，配有熔断器（OPEN/HALF_OPEN）、能力过滤（缺 JSON / 工具 / 视觉 / 上下文长度的候选会被显式跳过并记原因）、以及 `:free` 档 429 跳过。客户端断连不算 provider 故障。
-- **强制 API key 鉴权** —— key 只存 SHA-256 哈希；首次启动会生成并打印一次 root key。支持按 key 设权限（`max_lane`、`allowed_lanes`、是否允许自定义模型），以及可选的按 key RPM/TPM 限流。
+- **强制 API key 鉴权** —— key 只存 SHA-256 哈希；首次启动会生成并打印一次 root key。支持按 key 设权限（`allowed_lanes` 白名单、是否允许自定义模型），以及可选的按 key RPM/TPM 限流。
+- **OAuth 订阅类供应商** —— 把你的 Claude Pro/Max、ChatGPT Codex、GitHub Copilot **订阅**当作后端来路由：在面板里登录，每个供应商可接入多个账号组成池，逐账号策展模型 / 设出口代理 / 设调度优先级 —— 这些改动全部**热重载**（无需重启）。详见[下文](#oauth-订阅类供应商claude-promaxchatgpt-codexgithub-copilot)。*（可选功能，可能违反供应商服务条款，务必阅读警告。）*
 - **可观测性** —— 每个请求一条脱敏决策记录（分类、策略、lane、各次 provider 尝试、延迟、兜底次数、成本拆分），外加可选的正文逐字捕获（单独存表、按保留期清理）。
 - **管理面板** —— 一个 SvelteKit + Tailwind 的 SPA，挂在 `/admin`、用 HTTP Basic 保护：实时概览、API key 增删改（含按 key 限额）、lane 与策略编辑器、分类器设置、可下钻的请求日志。支持 5 种语言（默认英文，简繁中文、日文、韩文）。改动会重新绑定到运行中的配置，下一个请求即生效，无需重启。
 - **存储** —— 默认 SQLite（本地文件）；可选 Postgres / Supabase，通过统一的 Store 端口抽象切换。
 
 **路线图 / 尚未接通：**
 
-- **Gemini** —— core 里有 transformer，但还没接到任何端点；Google/Gemini 格式的客户端目前还打不进网关。
-- **`/v1/responses` 的流式** —— 0.1 里 `stream: true` 会被一个结构化 `400` 拒掉。
 - **Memory 中间件** —— observe（写入）阶段已接通；inject（把记忆读回 prompt）和 reflector 阶段在 core 里已实现，但运行中的网关还触达不到。
-- 更细粒度的配额 / 计费，以及 OAuth 订阅类供应商，都属于后续工作。
+- 更细粒度的配额 / 计费属于后续工作。
 
 详见 [09 路线图](docs/09-roadmap.md)。
 
@@ -133,7 +132,8 @@ curl http://localhost:8080/v1/chat/completions \
 |---|---|---|
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
-| `POST /v1/responses` | OpenAI Responses | ❌ 暂未支持（0.1） |
+| `POST /v1/responses` | OpenAI Responses | ✅ |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ❌ 非流式 |
 
 **`model` 字段里填什么：**
 
@@ -174,6 +174,22 @@ curl http://localhost:8080/v1/chat/completions \
 > **存储。** 默认 SQLite（`better-sqlite3`，`./data` 下的本地文件）。要用 Postgres/Supabase，把 `HELM_STORE_DRIVER` 设成 `supabase`，再让 `HELM_STORE_URL_ENV` 指向存放 DSN 的环境变量。未知驱动在启动时 fail-closed。
 >
 > **凭证。** 供应商 key 在 `providers.yaml` 里只按环境变量*名*引用 —— 绝不以明文写进仓库或镜像。
+
+### OAuth 订阅类供应商（Claude Pro/Max、ChatGPT Codex、GitHub Copilot）
+
+除了静态 API key，供应商还能用你在面板里登录的 **OAuth 订阅**来鉴权（**提供商 → 连接**）。Claude Pro/Max 和 ChatGPT Codex 走「浏览器登录 + 粘贴回跳 URL」；GitHub Copilot 走设备码。Helm 把（会轮换的）refresh token **加密存盘**，并自动刷新短时的 access token。
+
+启用前需把 **`HELM_OAUTH_ENC_KEY`** 设成一把 32 字节的密钥（base64，或 64 位十六进制）—— Helm 用它加密存储的 token；若配置了订阅类供应商却没设这把 key，会**拒绝启动**。在供应商上配一个 `oauth: { provider: anthropic | github-copilot | openai-codex }` 块（参见 `config/providers.yaml` 里注释掉的示例）；Claude 用 `type: anthropic`。
+
+同一个供应商可以**接入多个账号**，Helm 把它们组成池。每个账号在 **提供商 → 管理** 里都有各自的：
+
+- **模型** —— 精确策展这个账号向你的 lane 暴露哪些模型。这份策展清单是权威的：移除某个模型后它会立刻不再被路由，未策展的模型会被拒（fail-closed）—— 所以策展是一份**实时白名单**，而不只是显示层的过滤。
+- **代理** —— 让这个账号的上游流量走 HTTP/HTTPS/SOCKS5 代理，从不同的 IP 出口（多个账号共用一台主机时，避免被关联封号）。
+- **调度** —— 一个 `priority`（越小越优先）和一个 `schedulable` 开关。Helm 选优先级最低的账号，同优先级内按 LRU 轮询；把账号「停泊」则保持连接但不参与轮换。
+
+**这里的一切都热重载。** 连接、断开、模型策展、代理、调度的改动都在**下一个请求即生效 —— 无需重启**。另外，为了表现得像一方官方客户端，Helm 会照搬官方客户端的身份头，并发送一个**稳定的、按账号固定的设备标识**（绝不会在请求之间乱变），以降低被关联封号的风险。
+
+> ⚠️ **服务条款。** 把 Claude/ChatGPT/Copilot **订阅**通过第三方网关来路由，可能违反供应商的服务条款，并可能成为账号被封的理由。这是面向自托管、个人使用的可选功能 —— **你需自行负责**确保用法符合你与供应商的协议。拿不准时，就改用普通的 API key（`api_key_env`）。
 
 ## 管理面板
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -44,18 +44,16 @@ you run yourself that manages model traffic through configuration".
 
 ## Client-facing API surface
 
-Helm exposes standard AI API shapes. Three client protocols are wired and routed
+Helm exposes standard AI API shapes. Four client protocols are wired and routed
 today:
 
 - **OpenAI Chat Completions** — `POST /v1/chat/completions` (streaming and
   non-streaming).
 - **Anthropic Messages** — `POST /v1/messages` (streaming and non-streaming).
-- **OpenAI Responses** — `POST /v1/responses` (**non-streaming only** in 0.1; a
-  `stream:true` request is rejected with a structured 400).
-
-A **Gemini** transformer exists in the codebase but is not yet routed to an
-endpoint; native Gemini support is on the roadmap (see
-[09 · Roadmap](09-roadmap.md)), not a usable endpoint today.
+- **OpenAI Responses** — `POST /v1/responses` (streaming and non-streaming; the
+  SSE stream terminates with a `response.completed` event).
+- **Google Gemini** — `POST /v1beta/models/{model}:generateContent` (non-streaming;
+  `:streamGenerateContent` is not yet implemented).
 
 Clients should only need to change their `base_url` and API key. A client never
 needs to know which provider or model actually executed the request.
@@ -69,8 +67,10 @@ Provider adapters can target:
 - OpenAI-compatible providers: OpenRouter, ZenMux, vLLM, DeepSeek, Qwen, local
   models, custom endpoints.
 - Anthropic native.
+- OAuth subscription providers — Claude Pro/Max, ChatGPT Codex, GitHub Copilot —
+  via interactive login + a pooled, hot-reloadable, per-account credential store
+  (see [09 · Roadmap](09-roadmap.md) "Delivered in 0.2").
 - Gemini native (future).
-- Future OAuth/subscription providers such as Claude Code, Codex, or Copilot.
 
 Provider aliases are an internal supply-chain detail. They are not the primary
 user-facing surface.

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -8,25 +8,25 @@ in [Research Notes](research-notes.md). The implementation lives in
 
 ## Wired protocols
 
-Three client protocols are wired and routed in 0.1:
+Four client protocols are wired and routed in 0.2:
 
 | Endpoint | Protocol | Streaming |
 |----------|----------|-----------|
 | `POST /v1/chat/completions` | OpenAI Chat Completions | Yes (SSE) and non-stream |
 | `POST /v1/messages` | Anthropic Messages | Yes (SSE) and non-stream |
-| `POST /v1/responses` | OpenAI Responses | **Non-streaming only** |
+| `POST /v1/responses` | OpenAI Responses | Yes (SSE) and non-stream |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | Non-streaming |
 
-For **OpenAI Responses**, streaming is not yet implemented: there is no Responses
-SSE (`response.*` event) transformer, so a `stream:true` request is rejected with
-a structured `400 invalid_request` ("streaming is not yet supported on
-/v1/responses; retry with stream:false") rather than being silently mis-served
-(fail-closed, principle 2). The non-streaming path is fully wired and routed. See
-`apps/gateway/src/routes/responses.ts`.
+For **OpenAI Responses**, streaming is now wired (0.2): a `stream:true` request
+returns a native Responses SSE stream of `response.*` events terminated by a
+`response.completed` event — **not** the Chat-Completions `[DONE]` sentinel. The
+`response.*` SSE transformer lives in `packages/core/src/protocol/responses-stream.ts`;
+see `apps/gateway/src/routes/responses.ts` for the route.
 
-A **Gemini** transformer exists in `packages/core/src/protocol/gemini/`, but it is
-**not** exported from the core entry point and **not** routed to any endpoint.
-Native Gemini support (request/response plus a streaming state machine) is on the
-roadmap; it is not a usable endpoint today. See [09 · Roadmap](09-roadmap.md).
+**Gemini** is now an inbound route (0.2): `POST /v1beta/models/{model}:generateContent`
+(issue #58), backed by the transformers in `packages/core/src/protocol/gemini/`.
+Streaming (`:streamGenerateContent`) is not implemented — the endpoint is
+non-streaming only. See `apps/gateway/src/routes/gemini.ts`.
 
 ## Responsibilities
 

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -1,9 +1,9 @@
 # 09 · Roadmap
 
-> Status: **0.1 is implemented.** Phases 0–4 are done; the gateway routes real
-> traffic, translates protocols, classifies and routes with fallback and circuit
-> breaking, supports optional eval, and ships an admin UI. The "remaining" list
-> below is what is deferred past 0.1.
+> Status: **0.2 is implemented.** Phases 0–4 (the 0.1 core) are done; 0.2 adds the
+> Gemini inbound route, native OpenAI Responses streaming, full OAuth subscription
+> providers (multi-account pools + hot-reload), and an admin-UI overhaul. The
+> "remaining" list below is what is still deferred.
 
 ## Delivered in 0.1 (phases 0–4)
 
@@ -32,19 +32,35 @@ The build followed an order where each phase runs on its own.
   management (lanes / policies / classifier / keys / system settings) plus request
   debugging (list / detail / decision trail). See [11 · Admin UI](11-admin-ui.md).
 
-## Remaining / deferred past 0.1
+## Delivered in 0.2
+
+Net-new since 0.1 — all verified live (see `implementation-notes.md`):
+
+- **Gemini inbound route.** `POST /v1beta/models/{model}:generateContent` is mounted
+  (issue #58) — Google/Gemini-format clients now reach the gateway (non-streaming).
+  The earlier "transformer exists but no endpoint" gap is closed. See
+  [05 · Protocol Translation](05-protocol-translation.md).
+- **OpenAI Responses streaming.** `stream: true` on `/v1/responses` now returns a
+  native `response.*` SSE stream terminated by a `response.completed` event (not the
+  Chat-Completions `[DONE]` sentinel). The structured-400 rejection is gone.
+- **OAuth subscription providers (issue #38).** Now a complete feature, not the
+  deferred sketch the 0.1 note described: **interactive login** from the dashboard
+  (Claude Pro/Max + ChatGPT Codex paste-the-redirect, GitHub Copilot device-code), a
+  **persistent encrypted token store** (survives restarts), **multi-account pools**
+  with per-account model curation / egress proxy / priority+schedulable, **hot-reload**
+  of all of those (no restart), fail-closed subscription routing, and a stable
+  per-account anti-ban device identity. ChatGPT Codex routes via the OpenAI Responses
+  backend; GitHub Copilot via its OpenAI-compatible endpoint.
+- **Admin UI overhaul.** Unified Providers UI + modals (key create/edit,
+  connect/disconnect/manage), requests-list pagination + filters, editable key caps,
+  and the per-key `max_lane` ceiling retired in favor of an allowed-lanes whitelist.
+- **Classifier.** Multilingual non-Latin fallback guard + CJK word-boundary fixes +
+  an expanded Layer-1 keyword vocabulary.
+
+## Remaining / deferred
 
 Verified against the code and `implementation-notes.md`:
 
-- **Gemini client route.** The Gemini protocol transformer exists and is
-  unit-tested (`packages/core/src/protocol/gemini/`), but it is **not mounted as
-  an inbound route** yet — there is no `/v1beta/models/...` endpoint. A
-  `parseGeminiPath` helper and the `x-goog-api-key` header constant are in place;
-  the gateway wiring is the remaining work.
-- **OpenAI Responses streaming.** The Responses route is wired for non-streaming
-  only. A `stream: true` Responses request returns a structured 400 (it does not
-  silently downgrade, per Principle 2) because the `response.*` SSE transformer
-  is not implemented yet.
 - **Memory inject phase.** The `observe` phase is wired; the `inject` phase
   (`assembleInjectedContext`) and the background Observer/Reflector jobs are not.
   See [08 · Memory Middleware](08-memory-middleware.md).
@@ -53,14 +69,6 @@ Verified against the code and `implementation-notes.md`:
   [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md).
 - **Agentic Signals feedback layer.** The store ports and the redacted
   `RoutingSignal` shape exist, but nothing reads signals back into routing yet.
-- **OAuth subscription providers (added past 0.1, issue #38).** Net-new scope not
-  in the original roadmap. A provider may now reference an `oauth` block instead of
-  `api_key_env`; Helm refreshes the token **non-interactively** (`refresh_token` /
-  `client_credentials`) and injects a dynamic Bearer per request, with a single
-  refresh-on-401 retry. **Deferred within this feature**: the interactive
-  `authorization_code` (browser) flow, and a **persistent token store** (the v1
-  cache is in-memory, so a rotating refresh token is lost on restart — see
-  `implementation-notes.md` D3). See `config/providers.yaml` for the example block.
 
 ## Success criteria (met by 0.1)
 

--- a/docs/11-admin-ui.md
+++ b/docs/11-admin-ui.md
@@ -88,6 +88,21 @@ Rule edits go through a runtime rule store that re-binds the live `lanes` /
 `policies` / `classifier` config the router reads — applied on the very next
 request, no restart. Changes are persisted, keeping "config-as-code".
 
+### Providers (OAuth subscriptions)
+
+- **Providers** (`/providers`) — connect and manage **OAuth subscription** backends
+  (Claude Pro/Max, ChatGPT Codex, GitHub Copilot). **Connect** runs the login flow
+  (manual paste-the-redirect for Claude/Codex, device-code for Copilot); **Manage**
+  opens a per-account dialog with three tabs — **Models** (curate the exposed set — a
+  live allow-list, not just a display filter), **Proxy** (per-account HTTP/HTTPS/SOCKS5
+  egress), and **Schedule** (`priority` + a `schedulable` toggle). Several accounts per
+  provider are pooled (priority asc, then LRU). Every change here — connect, disconnect,
+  curation, proxy, scheduling — **hot-reloads**: it re-synthesizes the live provider
+  pool and applies on the next request, no restart. Tokens are stored encrypted and are
+  never returned to the UI (proxy passwords included: read shows only `hasPassword`).
+  See [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md) and the
+  README's OAuth subscription section.
+
 ### System settings
 
 - **Settings** (`/settings`) — the runtime-mutable settings the operator can
@@ -109,7 +124,7 @@ request, no restart. Changes are persisted, keeping "config-as-code".
   `capture_payloads` is on, the detail can load the full captured request/response
   bodies (`/admin/api/requests/:traceId/payload`).
 
-## Boundaries (0.1)
+## Boundaries (0.2)
 
 - Basic rule management and request inspection only — no multi-tenancy and no
   fine-grained RBAC.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

48 commits landed since `v0.1.0` and the docs still described the **0.1** world — making several now-**false** claims. This corrects README (EN + zh-CN) + the affected docs to match what actually ships, and bumps `package.json` to **0.2.0** so the next `v0.2.0` tag publishes a correctly-versioned image.

### Corrected (all now true)
- **Protocols: three → four.** Added Gemini `POST /v1beta/models/{model}:generateContent` (#58). `/v1/responses` now **streams** (#40) — native `response.*` SSE terminated by `response.completed`, not `[DONE]`. Updated the endpoint tables + protocol docs.
- **OAuth subscriptions are SHIPPED**, not "future work": dashboard login, persistent encrypted token store, multi-account pools, per-account model curation / egress proxy / priority+schedulable, **hot-reload**, fail-closed routing, stable anti-ban device identity. The zh-CN README was **missing the whole OAuth section** — added it (idiomatic).
- **Per-key caps:** `max_lane` was retired (#63) → documented as the `allowed_lanes` whitelist.
- **Status 0.1 → 0.2**; `docs/09-roadmap` moves Gemini / Responses-streaming / OAuth into a new **"Delivered in 0.2"** section; remaining list trimmed to memory-inject + quota/billing + Agentic Signals.
- Added the **Providers / subscriptions** surface to `docs/11`; refreshed `docs/01` + `docs/05`.

### Release flow
Docs-only + version bump. After this merges: tag `v0.2.0` → `publish.yml` builds & pushes `ghcr.io/easymetaau/helm-api:0.2.0` + `:latest`, and I'll build the image locally too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)