### PR TITLE
feat: 按 API Key 的用量配额 + 超额降级（取代账户计费 #42）

### DIFF
--- a/apps/admin/src/lib/api/keys.ts
+++ b/apps/admin/src/lib/api/keys.ts
@@ -23,6 +23,15 @@ export interface ApiKeyView {
   disabled: boolean; // revoked state (soft)
   rate_limit_rpm: number | null; // per-key RPM override; null = inherit system default
   rate_limit_tpm: number | null; // per-key TPM override; null = inherit system default
+  // Per-key usage budgets (docs/06). null = no cap for that dimension. When over a
+  // budget, the key is DEGRADED to `degrade_lane` (default economy) or REJECTED
+  // (429), per `over_budget_behavior`. window null = system default.
+  budget_requests: number | null;
+  budget_tokens: number | null;
+  budget_spend_usd: number | null;
+  budget_window_seconds: number | null;
+  over_budget_behavior: 'degrade' | 'reject';
+  degrade_lane: string | null;
 }
 
 // Operator-specified caps for a new key. The plaintext is minted server-side; the
@@ -36,6 +45,14 @@ export interface CreateKeyInput {
   // default. 0 => explicitly unlimited for that dimension.
   rate_limit_rpm?: number;
   rate_limit_tpm?: number;
+  // Optional per-key usage budgets at mint time. Omitted => no cap for that
+  // dimension. over_budget_behavior omitted => server default ("degrade").
+  budget_requests?: number;
+  budget_tokens?: number;
+  budget_spend_usd?: number;
+  budget_window_seconds?: number;
+  over_budget_behavior?: 'degrade' | 'reject';
+  degrade_lane?: string;
 }
 
 // Editable caps for an existing key (PATCH). Mirrors the server
@@ -48,6 +65,12 @@ export interface UpdateKeyInput {
   allow_custom_model?: boolean;
   rate_limit_rpm?: number | null;
   rate_limit_tpm?: number | null;
+  budget_requests?: number | null;
+  budget_tokens?: number | null;
+  budget_spend_usd?: number | null;
+  budget_window_seconds?: number | null;
+  over_budget_behavior?: 'degrade' | 'reject';
+  degrade_lane?: string | null;
 }
 
 // The ONLY shape that ever carries plaintext, returned once by POST. `prefix` is
@@ -94,6 +117,14 @@ function normalizeView(raw: Record<string, unknown>): ApiKeyView {
     // null/absent = inherit system default; a finite number (incl. 0) = override.
     rate_limit_rpm: typeof raw.rate_limit_rpm === 'number' ? raw.rate_limit_rpm : null,
     rate_limit_tpm: typeof raw.rate_limit_tpm === 'number' ? raw.rate_limit_tpm : null,
+    // null/absent = no cap for that dimension; a finite number = the ceiling.
+    budget_requests: typeof raw.budget_requests === 'number' ? raw.budget_requests : null,
+    budget_tokens: typeof raw.budget_tokens === 'number' ? raw.budget_tokens : null,
+    budget_spend_usd: typeof raw.budget_spend_usd === 'number' ? raw.budget_spend_usd : null,
+    budget_window_seconds:
+      typeof raw.budget_window_seconds === 'number' ? raw.budget_window_seconds : null,
+    over_budget_behavior: raw.over_budget_behavior === 'reject' ? 'reject' : 'degrade',
+    degrade_lane: typeof raw.degrade_lane === 'string' ? raw.degrade_lane : null,
   };
 }
 
@@ -110,6 +141,19 @@ function toServerBody(input: CreateKeyInput): Record<string, unknown> {
   // Send rate limits only when set (0 is meaningful = unlimited, so check undefined).
   if (input.rate_limit_rpm !== undefined) out.rate_limit_rpm = input.rate_limit_rpm;
   if (input.rate_limit_tpm !== undefined) out.rate_limit_tpm = input.rate_limit_tpm;
+  // Send budgets only when set (omitted = no cap; server schema is .strict()).
+  if (input.budget_requests !== undefined) out.budget_requests = input.budget_requests;
+  if (input.budget_tokens !== undefined) out.budget_tokens = input.budget_tokens;
+  if (input.budget_spend_usd !== undefined) out.budget_spend_usd = input.budget_spend_usd;
+  if (input.budget_window_seconds !== undefined) {
+    out.budget_window_seconds = input.budget_window_seconds;
+  }
+  if (input.over_budget_behavior !== undefined) {
+    out.over_budget_behavior = input.over_budget_behavior;
+  }
+  if (input.degrade_lane !== undefined && input.degrade_lane.length > 0) {
+    out.degrade_lane = input.degrade_lane;
+  }
   return out;
 }
 

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -34,6 +34,15 @@
   // (empty field => null), so no string parsing is needed.
   let rpmInput = $state<number | null>(null);
   let tpmInput = $state<number | null>(null);
+  // Per-key usage budgets (docs/06). null = no cap for that dimension. windowInput
+  // (seconds) sets the rolling window; blank => system default. behavior chooses
+  // degrade (drop to a cheaper lane) vs reject (429). degradeLane blank => economy.
+  let budgetRequestsInput = $state<number | null>(null);
+  let budgetTokensInput = $state<number | null>(null);
+  let budgetSpendInput = $state<number | null>(null);
+  let budgetWindowInput = $state<number | null>(null);
+  let overBudgetBehavior = $state<'degrade' | 'reject'>('degrade');
+  let degradeLaneInput = $state<string>('');
 
   let error = $state<string | null>(null);
   let creating = $state<boolean>(false);
@@ -61,6 +70,13 @@
     // `!= null` also catches the `undefined` Svelte 5 gives an emptied number input.
     if (rpmInput != null) input.rate_limit_rpm = rpmInput;
     if (tpmInput != null) input.rate_limit_tpm = tpmInput;
+    // Usage budgets: send only the dimensions the operator set (blank => no cap).
+    if (budgetRequestsInput != null) input.budget_requests = budgetRequestsInput;
+    if (budgetTokensInput != null) input.budget_tokens = budgetTokensInput;
+    if (budgetSpendInput != null) input.budget_spend_usd = budgetSpendInput;
+    if (budgetWindowInput != null) input.budget_window_seconds = budgetWindowInput;
+    input.over_budget_behavior = overBudgetBehavior;
+    if (degradeLaneInput.length > 0) input.degrade_lane = degradeLaneInput;
     try {
       revealed = await createKey(input);
     } catch (e) {
@@ -99,6 +115,12 @@
         disabled: false,
         rate_limit_rpm: rpmInput ?? null,
         rate_limit_tpm: tpmInput ?? null,
+        budget_requests: budgetRequestsInput ?? null,
+        budget_tokens: budgetTokensInput ?? null,
+        budget_spend_usd: budgetSpendInput ?? null,
+        budget_window_seconds: budgetWindowInput ?? null,
+        over_budget_behavior: overBudgetBehavior,
+        degrade_lane: degradeLaneInput.length > 0 ? degradeLaneInput : null,
       };
       oncreated(view);
     }
@@ -230,6 +252,83 @@
           'Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.',
         )}</span
       >
+
+      <fieldset class="flex flex-col gap-1 text-sm">
+        <legend class="field-label">{$t('Usage budgets')}</legend>
+        <div class="grid grid-cols-2 gap-3">
+          <label class="flex flex-col gap-1">
+            <span class="field-label">{$t('Max requests')}</span>
+            <input
+              type="number"
+              min="0"
+              step="1"
+              aria-label={$t('Max requests')}
+              placeholder={$t('No cap')}
+              class="input"
+              bind:value={budgetRequestsInput}
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="field-label">{$t('Max tokens')}</span>
+            <input
+              type="number"
+              min="0"
+              step="1"
+              aria-label={$t('Max tokens')}
+              placeholder={$t('No cap')}
+              class="input"
+              bind:value={budgetTokensInput}
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="field-label">{$t('Max spend (USD)')}</span>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              aria-label={$t('Max spend (USD)')}
+              placeholder={$t('No cap')}
+              class="input"
+              bind:value={budgetSpendInput}
+            />
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="field-label">{$t('Window (seconds)')}</span>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              aria-label={$t('Window (seconds)')}
+              placeholder={$t('Default')}
+              class="input"
+              bind:value={budgetWindowInput}
+            />
+          </label>
+        </div>
+        <label class="mt-1 flex flex-col gap-1">
+          <span class="field-label">{$t('When over budget')}</span>
+          <select bind:value={overBudgetBehavior} aria-label={$t('When over budget')} class="select">
+            <option value="degrade">{$t('Degrade to a cheaper lane')}</option>
+            <option value="reject">{$t('Reject (429)')}</option>
+          </select>
+        </label>
+        {#if overBudgetBehavior === 'degrade'}
+          <label class="mt-1 flex flex-col gap-1">
+            <span class="field-label">{$t('Degrade lane')}</span>
+            <select bind:value={degradeLaneInput} aria-label={$t('Degrade lane')} class="select">
+              <option value="">{$t('Default (economy)')}</option>
+              {#each lanes as lane (lane)}
+                <option value={lane}>{lane}</option>
+              {/each}
+            </select>
+          </label>
+        {/if}
+        <span class="field-help"
+          >{$t(
+            'Cap usage over a rolling window. Over budget, the key is degraded to a cheaper lane (cost-controlled, service continues) or rejected. Leave caps blank for no budget.',
+          )}</span
+        >
+      </fieldset>
     </div>
 
     <div class="mt-4 flex justify-end gap-2">

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -260,7 +260,7 @@
             <span class="field-label">{$t('Max requests')}</span>
             <input
               type="number"
-              min="0"
+              min="1"
               step="1"
               aria-label={$t('Max requests')}
               placeholder={$t('No cap')}
@@ -272,7 +272,7 @@
             <span class="field-label">{$t('Max tokens')}</span>
             <input
               type="number"
-              min="0"
+              min="1"
               step="1"
               aria-label={$t('Max tokens')}
               placeholder={$t('No cap')}
@@ -284,7 +284,7 @@
             <span class="field-label">{$t('Max spend (USD)')}</span>
             <input
               type="number"
-              min="0"
+              min="0.01"
               step="0.01"
               aria-label={$t('Max spend (USD)')}
               placeholder={$t('No cap')}

--- a/apps/admin/src/lib/components/EditKeyDialog.svelte
+++ b/apps/admin/src/lib/components/EditKeyDialog.svelte
@@ -188,7 +188,7 @@
           <span class="field-label">{$t('Max requests')}</span>
           <input
             type="number"
-            min="0"
+            min="1"
             step="1"
             aria-label={$t('Max requests')}
             placeholder={$t('No cap')}
@@ -200,7 +200,7 @@
           <span class="field-label">{$t('Max tokens')}</span>
           <input
             type="number"
-            min="0"
+            min="1"
             step="1"
             aria-label={$t('Max tokens')}
             placeholder={$t('No cap')}
@@ -212,7 +212,7 @@
           <span class="field-label">{$t('Max spend (USD)')}</span>
           <input
             type="number"
-            min="0"
+            min="0.01"
             step="0.01"
             aria-label={$t('Max spend (USD)')}
             placeholder={$t('No cap')}

--- a/apps/admin/src/lib/components/EditKeyDialog.svelte
+++ b/apps/admin/src/lib/components/EditKeyDialog.svelte
@@ -33,6 +33,13 @@
   // no string parsing is needed. null = clear → inherit the system default.
   let rpmInput = $state<number | null>(untrack(() => key.rate_limit_rpm));
   let tpmInput = $state<number | null>(untrack(() => key.rate_limit_tpm));
+  // Per-key usage budgets (docs/06). null = no cap; clears that dimension.
+  let budgetRequestsInput = $state<number | null>(untrack(() => key.budget_requests));
+  let budgetTokensInput = $state<number | null>(untrack(() => key.budget_tokens));
+  let budgetSpendInput = $state<number | null>(untrack(() => key.budget_spend_usd));
+  let budgetWindowInput = $state<number | null>(untrack(() => key.budget_window_seconds));
+  let overBudgetBehavior = $state<'degrade' | 'reject'>(untrack(() => key.over_budget_behavior));
+  let degradeLaneInput = $state<string>(untrack(() => key.degrade_lane ?? ''));
 
   let error = $state<string | null>(null);
   let saving = $state<boolean>(false);
@@ -55,6 +62,12 @@
       allow_custom_model: allowCustomModel,
       rate_limit_rpm: rpmInput ?? null,
       rate_limit_tpm: tpmInput ?? null,
+      budget_requests: budgetRequestsInput ?? null,
+      budget_tokens: budgetTokensInput ?? null,
+      budget_spend_usd: budgetSpendInput ?? null,
+      budget_window_seconds: budgetWindowInput ?? null,
+      over_budget_behavior: overBudgetBehavior,
+      degrade_lane: degradeLaneInput.length > 0 ? degradeLaneInput : null,
     };
     try {
       await updateKey(key.key_id, patch);
@@ -65,6 +78,12 @@
         allow_custom_model: allowCustomModel,
         rate_limit_rpm: patch.rate_limit_rpm ?? null,
         rate_limit_tpm: patch.rate_limit_tpm ?? null,
+        budget_requests: patch.budget_requests ?? null,
+        budget_tokens: patch.budget_tokens ?? null,
+        budget_spend_usd: patch.budget_spend_usd ?? null,
+        budget_window_seconds: patch.budget_window_seconds ?? null,
+        over_budget_behavior: overBudgetBehavior,
+        degrade_lane: degradeLaneInput.length > 0 ? degradeLaneInput : null,
       });
       onclose();
     } catch (e) {
@@ -161,6 +180,83 @@
         'Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.',
       )}</span
     >
+
+    <fieldset class="flex flex-col gap-1 text-sm">
+      <legend class="field-label">{$t('Usage budgets')}</legend>
+      <div class="grid grid-cols-2 gap-3">
+        <label class="flex flex-col gap-1">
+          <span class="field-label">{$t('Max requests')}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            aria-label={$t('Max requests')}
+            placeholder={$t('No cap')}
+            class="select"
+            bind:value={budgetRequestsInput}
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="field-label">{$t('Max tokens')}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            aria-label={$t('Max tokens')}
+            placeholder={$t('No cap')}
+            class="select"
+            bind:value={budgetTokensInput}
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="field-label">{$t('Max spend (USD)')}</span>
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            aria-label={$t('Max spend (USD)')}
+            placeholder={$t('No cap')}
+            class="select"
+            bind:value={budgetSpendInput}
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="field-label">{$t('Window (seconds)')}</span>
+          <input
+            type="number"
+            min="1"
+            step="1"
+            aria-label={$t('Window (seconds)')}
+            placeholder={$t('Default')}
+            class="select"
+            bind:value={budgetWindowInput}
+          />
+        </label>
+      </div>
+      <label class="mt-1 flex flex-col gap-1">
+        <span class="field-label">{$t('When over budget')}</span>
+        <select bind:value={overBudgetBehavior} aria-label={$t('When over budget')} class="select">
+          <option value="degrade">{$t('Degrade to a cheaper lane')}</option>
+          <option value="reject">{$t('Reject (429)')}</option>
+        </select>
+      </label>
+      {#if overBudgetBehavior === 'degrade'}
+        <label class="mt-1 flex flex-col gap-1">
+          <span class="field-label">{$t('Degrade lane')}</span>
+          <select bind:value={degradeLaneInput} aria-label={$t('Degrade lane')} class="select">
+            <option value="">{$t('Default (economy)')}</option>
+            {#each lanes as lane (lane)}
+              <option value={lane}>{lane}</option>
+            {/each}
+          </select>
+        </label>
+      {/if}
+      <span class="field-help"
+        >{$t(
+          'Cap usage over a rolling window. Over budget, the key is degraded to a cheaper lane (cost-controlled, service continues) or rejected. Leave caps blank for no budget.',
+        )}</span
+      >
+    </fieldset>
   </div>
 
   <div class="mt-4 flex justify-end gap-2">

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -37,6 +37,17 @@
     return v === 0 ? $t('Unlimited') : String(v);
   }
 
+  // Compact per-key usage-budget summary for the list (docs/06). Shows only the
+  // dimensions that have a cap; empty = no budget. The over-budget behavior
+  // (degrade lane / reject) is appended so operators see the cost-control posture.
+  function budgetParts(key: ApiKeyView): string[] {
+    const parts: string[] = [];
+    if (key.budget_requests !== null) parts.push(`${key.budget_requests} req`);
+    if (key.budget_tokens !== null) parts.push(`${key.budget_tokens} tok`);
+    if (key.budget_spend_usd !== null) parts.push(`$${key.budget_spend_usd}`);
+    return parts;
+  }
+
   function startEdit(key: ApiKeyView): void {
     error = null;
     editingKey = key;
@@ -123,6 +134,7 @@
             <th class="px-3 py-2">{$t('Role')}</th>
             <th class="px-3 py-2">{$t('Caps')}</th>
             <th class="px-3 py-2">{$t('Rate limit')}</th>
+            <th class="px-3 py-2">{$t('Budget')}</th>
             <th class="px-3 py-2">{$t('Status')}</th>
             <th class="px-3 py-2"></th>
           </tr>
@@ -151,6 +163,18 @@
               <td class="px-3 py-2 text-ink-muted">
                 <div>{$t('RPM')}: {limitLabel(key.rate_limit_rpm)}</div>
                 <div>{$t('TPM')}: {limitLabel(key.rate_limit_tpm)}</div>
+              </td>
+              <td class="px-3 py-2 text-ink-muted">
+                {#if budgetParts(key).length > 0}
+                  <div>{budgetParts(key).join(' · ')}</div>
+                  <div class="text-xs">
+                    {key.over_budget_behavior === 'reject'
+                      ? $t('reject')
+                      : `→ ${key.degrade_lane ?? 'economy'}`}
+                  </div>
+                {:else}
+                  <span>{$t('None')}</span>
+                {/if}
               </td>
               <td class="px-3 py-2">
                 {#if key.disabled}

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -26,6 +26,12 @@ function key(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     disabled: false,
     rate_limit_rpm: null,
     rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: 'degrade',
+    degrade_lane: null,
     ...overrides,
   };
 }
@@ -129,6 +135,13 @@ describe('keys page', () => {
         allow_custom_model: false,
         rate_limit_rpm: 120,
         rate_limit_tpm: null, // untouched → still inherit (null), not undefined
+        // Budgets untouched → still no cap (null) + default behavior.
+        budget_requests: null,
+        budget_tokens: null,
+        budget_spend_usd: null,
+        budget_window_seconds: null,
+        over_budget_behavior: 'degrade',
+        degrade_lane: null,
       }),
     );
     // Dialog closes after a successful save.

--- a/apps/gateway/e2e/budget.spec.ts
+++ b/apps/gateway/e2e/budget.spec.ts
@@ -52,7 +52,10 @@ test.describe("per-key usage budget e2e", () => {
     request,
   }) => {
     // 1st request (non-stream): cold bucket → served; settle awaited before return.
-    const first = await request.post("/v1/chat/completions", { data: DEPLETE, headers: DEGRADE_AUTH });
+    const first = await request.post("/v1/chat/completions", {
+      data: DEPLETE,
+      headers: DEGRADE_AUTH,
+    });
     expect(first.status()).toBe(200);
 
     // 2nd request: budget exhausted → degraded to economy, STILL served (200).
@@ -66,11 +69,17 @@ test.describe("per-key usage budget e2e", () => {
 
   test("reject: over-budget request returns a structured 429", async ({ request }) => {
     // 1st request: served (full bucket); settle awaited before return.
-    const first = await request.post("/v1/chat/completions", { data: DEPLETE, headers: REJECT_AUTH });
+    const first = await request.post("/v1/chat/completions", {
+      data: DEPLETE,
+      headers: REJECT_AUTH,
+    });
     expect(first.status()).toBe(200);
 
     // 2nd request: budget exhausted + reject behavior → 429, before routing.
-    const second = await request.post("/v1/chat/completions", { data: DEPLETE, headers: REJECT_AUTH });
+    const second = await request.post("/v1/chat/completions", {
+      data: DEPLETE,
+      headers: REJECT_AUTH,
+    });
     expect(second.status()).toBe(429);
     expect(JSON.stringify(await second.json())).toContain("rate_limited");
   });

--- a/apps/gateway/e2e/budget.spec.ts
+++ b/apps/gateway/e2e/budget.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+// e2e.budget — per-key usage budgets end-to-end (docs/06) over real HTTP into a
+// real gateway + the deterministic mock upstream. The two budget keys (seeded in
+// fixtures/test-server.ts) cap REQUESTS at 1 over the window, so the FIRST request
+// is served (cold bucket = full) and the SECOND is over budget. Request-count needs
+// no upstream usage, so this is fully deterministic.
+//
+//  • degrade key → the over-budget request is DROPPED to the economy lane (cost is
+//    bounded, service is NOT interrupted): a 200 with x-helm-lane=economy.
+//  • reject  key → the over-budget request is a structured 429.
+//
+// The DEPLETING first request is NON-streaming so its post-served budget settle is
+// awaited before the response returns (a streamed settle runs in a finally that the
+// client may not wait for — that would race the second request).
+
+const DEGRADE_AUTH = {
+  Authorization: "Bearer helm_live_e2e_budget_degrade",
+  "Content-Type": "application/json",
+};
+const REJECT_AUTH = {
+  Authorization: "Bearer helm_live_e2e_budget_reject",
+  "Content-Type": "application/json",
+};
+
+// A simple JSON-constrained request routes to the non-stream `json` lane (served by
+// the mock), so the first request settles synchronously and deterministically.
+const DEPLETE = {
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "hi thanks, ok" }],
+  stream: false,
+  response_format: { type: "json_object" },
+};
+
+// A complex prompt that classifies to the PREMIUM lane (same signal routing.spec
+// uses), streamed because the premium + economy lane heads are stream-only on the
+// mock. Used as the OVER-budget probe so a degrade down to economy is observable.
+const COMPLEX_STREAM = {
+  model: "gpt-4o-mini",
+  messages: [
+    {
+      role: "user",
+      content:
+        "Prove step by step the theorem and derive the integral, reason about the matrix equation and analyze the implications first then finally compile the proof.",
+    },
+  ],
+  stream: true,
+};
+
+test.describe("per-key usage budget e2e", () => {
+  test("degrade: over-budget request is served on the economy lane (not rejected)", async ({
+    request,
+  }) => {
+    // 1st request (non-stream): cold bucket → served; settle awaited before return.
+    const first = await request.post("/v1/chat/completions", { data: DEPLETE, headers: DEGRADE_AUTH });
+    expect(first.status()).toBe(200);
+
+    // 2nd request: budget exhausted → degraded to economy, STILL served (200).
+    const second = await request.post("/v1/chat/completions", {
+      data: COMPLEX_STREAM,
+      headers: DEGRADE_AUTH,
+    });
+    expect(second.status()).toBe(200);
+    expect(second.headers()["x-helm-lane"]).toBe("economy");
+  });
+
+  test("reject: over-budget request returns a structured 429", async ({ request }) => {
+    // 1st request: served (full bucket); settle awaited before return.
+    const first = await request.post("/v1/chat/completions", { data: DEPLETE, headers: REJECT_AUTH });
+    expect(first.status()).toBe(200);
+
+    // 2nd request: budget exhausted + reject behavior → 429, before routing.
+    const second = await request.post("/v1/chat/completions", { data: DEPLETE, headers: REJECT_AUTH });
+    expect(second.status()).toBe(429);
+    expect(JSON.stringify(await second.json())).toContain("rate_limited");
+  });
+});

--- a/apps/gateway/e2e/fixtures/test-server.ts
+++ b/apps/gateway/e2e/fixtures/test-server.ts
@@ -28,6 +28,31 @@ await keyStore.createKey({
   role: "root",
 });
 
+// Two per-key usage-budget keys (docs/06, e2e.budget). Each caps requests at 1 over
+// the window: the FIRST request is served at its full lane (cold bucket = full),
+// the SECOND is over budget. The `degrade` key then drops to the economy lane (keep
+// serving); the `reject` key returns a 429. Request-count needs no upstream usage,
+// so this is fully deterministic against the mock.
+await keyStore.createKey({
+  keyId: "k_budget_degrade",
+  hash: hashKey("helm_live_e2e_budget_degrade"),
+  prefix: "helm_live_bd",
+  accountId: "acct_e2e",
+  role: "user",
+  budgetRequests: 1,
+  overBudgetBehavior: "degrade",
+  degradeLane: "economy",
+});
+await keyStore.createKey({
+  keyId: "k_budget_reject",
+  hash: hashKey("helm_live_e2e_budget_reject"),
+  prefix: "helm_live_br",
+  accountId: "acct_e2e",
+  role: "user",
+  budgetRequests: 1,
+  overBudgetBehavior: "reject",
+});
+
 // Seed one full decision record for the admin requests views (e2e.admin). It is
 // a pre-built, redacted DecisionRecord — NOT a live upstream call — so the admin
 // request list/detail have a deterministic row with a trace_id, a classified

--- a/apps/gateway/src/middleware/auth.test.ts
+++ b/apps/gateway/src/middleware/auth.test.ts
@@ -17,6 +17,12 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     disabled: false,
     rate_limit_rpm: null,
     rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: "degrade",
+    degrade_lane: null,
     ...overrides,
   };
 }

--- a/apps/gateway/src/middleware/auth.ts
+++ b/apps/gateway/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { type ApiKeyRecord, hashKey, type KeyStore } from "@helm/core";
+import { type ApiKeyRecord, type BudgetCaps, hashKey, type KeyStore } from "@helm/core";
 import { makeHelmError } from "@helm/shared";
 import type { MiddlewareHandler } from "hono";
 
@@ -21,6 +21,9 @@ export interface AuthIdentity {
      *  for that dimension; a number (0 = unlimited) overrides it. Read by the
      *  rate-limit middleware so the limiter needs no extra KeyStore lookup. */
     rateLimit: { rpm: number | null; tpm: number | null };
+    /** Per-key usage budgets (docs/06). Read by the budget gate so it needs no
+     *  extra KeyStore lookup. Each cap null = no cap for that dimension. */
+    budget: BudgetCaps;
   };
 }
 
@@ -89,6 +92,14 @@ export function authMiddleware(deps: AuthDeps): MiddlewareHandler {
         allowedLanes: record.allowed_lanes,
         allowCustomModel: record.allow_custom_model,
         rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
+        budget: {
+          requests: record.budget_requests,
+          tokens: record.budget_tokens,
+          spendUsd: record.budget_spend_usd,
+          windowSeconds: record.budget_window_seconds,
+          behavior: record.over_budget_behavior,
+          degradeLane: record.degrade_lane,
+        },
       },
     };
     c.set("identity", identity);

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -105,7 +105,8 @@ function makeKeyStore(): KeyStore & { rows: ApiKeyRecord[] } {
       if (patch.budgetSpendUsd !== undefined) row.budget_spend_usd = patch.budgetSpendUsd;
       if (patch.budgetWindowSeconds !== undefined)
         row.budget_window_seconds = patch.budgetWindowSeconds;
-      if (patch.overBudgetBehavior !== undefined) row.over_budget_behavior = patch.overBudgetBehavior;
+      if (patch.overBudgetBehavior !== undefined)
+        row.over_budget_behavior = patch.overBudgetBehavior;
       if (patch.degradeLane !== undefined) row.degrade_lane = patch.degradeLane;
     },
   };

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -69,6 +69,12 @@ function makeKeyStore(): KeyStore & { rows: ApiKeyRecord[] } {
         disabled: false,
         rate_limit_rpm: input.rateLimitRpm ?? null,
         rate_limit_tpm: input.rateLimitTpm ?? null,
+        budget_requests: input.budgetRequests ?? null,
+        budget_tokens: input.budgetTokens ?? null,
+        budget_spend_usd: input.budgetSpendUsd ?? null,
+        budget_window_seconds: input.budgetWindowSeconds ?? null,
+        over_budget_behavior: input.overBudgetBehavior ?? "degrade",
+        degrade_lane: input.degradeLane ?? null,
       };
       rows.push(rec);
       return rec;
@@ -94,6 +100,13 @@ function makeKeyStore(): KeyStore & { rows: ApiKeyRecord[] } {
       if (patch.allowCustomModel !== undefined) row.allow_custom_model = patch.allowCustomModel;
       if (patch.rateLimitRpm !== undefined) row.rate_limit_rpm = patch.rateLimitRpm;
       if (patch.rateLimitTpm !== undefined) row.rate_limit_tpm = patch.rateLimitTpm;
+      if (patch.budgetRequests !== undefined) row.budget_requests = patch.budgetRequests;
+      if (patch.budgetTokens !== undefined) row.budget_tokens = patch.budgetTokens;
+      if (patch.budgetSpendUsd !== undefined) row.budget_spend_usd = patch.budgetSpendUsd;
+      if (patch.budgetWindowSeconds !== undefined)
+        row.budget_window_seconds = patch.budgetWindowSeconds;
+      if (patch.overBudgetBehavior !== undefined) row.over_budget_behavior = patch.overBudgetBehavior;
+      if (patch.degradeLane !== undefined) row.degrade_lane = patch.degradeLane;
     },
   };
 }

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -224,6 +224,15 @@ export interface KeySummary {
   // display + edit it. No key material — just the quota numbers (principle 7).
   rate_limit_rpm: number | null;
   rate_limit_tpm: number | null;
+  // Per-key usage budgets (docs/06). null = no cap for that dimension. Surfaced so
+  // the admin UI can display + edit them. over_budget_behavior is degrade|reject;
+  // degrade_lane null = the system default (economy). No key material (principle 7).
+  budget_requests: number | null;
+  budget_tokens: number | null;
+  budget_spend_usd: number | null;
+  budget_window_seconds: number | null;
+  over_budget_behavior: "degrade" | "reject";
+  degrade_lane: string | null;
 }
 
 // New-key response: the ONLY place plaintext is ever returned, once.

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -21,6 +21,12 @@ function toSummary(rec: {
   disabled: boolean;
   rate_limit_rpm: number | null;
   rate_limit_tpm: number | null;
+  budget_requests: number | null;
+  budget_tokens: number | null;
+  budget_spend_usd: number | null;
+  budget_window_seconds: number | null;
+  over_budget_behavior: "degrade" | "reject";
+  degrade_lane: string | null;
 }): KeySummary {
   return {
     key_id: rec.key_id,
@@ -31,6 +37,12 @@ function toSummary(rec: {
     disabled: rec.disabled,
     rate_limit_rpm: rec.rate_limit_rpm,
     rate_limit_tpm: rec.rate_limit_tpm,
+    budget_requests: rec.budget_requests,
+    budget_tokens: rec.budget_tokens,
+    budget_spend_usd: rec.budget_spend_usd,
+    budget_window_seconds: rec.budget_window_seconds,
+    over_budget_behavior: rec.over_budget_behavior,
+    degrade_lane: rec.degrade_lane,
   };
 }
 
@@ -59,6 +71,12 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       allowCustomModel: parsed.data.allow_custom_model ?? false,
       rateLimitRpm: parsed.data.rate_limit_rpm,
       rateLimitTpm: parsed.data.rate_limit_tpm,
+      budgetRequests: parsed.data.budget_requests,
+      budgetTokens: parsed.data.budget_tokens,
+      budgetSpendUsd: parsed.data.budget_spend_usd,
+      budgetWindowSeconds: parsed.data.budget_window_seconds,
+      overBudgetBehavior: parsed.data.over_budget_behavior,
+      degradeLane: parsed.data.degrade_lane,
     });
     // The ONLY place plaintext is ever returned. `prefix` is the server-minted
     // non-sensitive display prefix (already persisted) — returned so the SPA need
@@ -90,11 +108,23 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       allowCustomModel?: boolean;
       rateLimitRpm?: number | null;
       rateLimitTpm?: number | null;
+      budgetRequests?: number | null;
+      budgetTokens?: number | null;
+      budgetSpendUsd?: number | null;
+      budgetWindowSeconds?: number | null;
+      overBudgetBehavior?: "degrade" | "reject";
+      degradeLane?: string | null;
     } = {};
     if (d.allowed_lanes !== undefined) patch.allowedLanes = d.allowed_lanes;
     if (d.allow_custom_model !== undefined) patch.allowCustomModel = d.allow_custom_model;
     if (d.rate_limit_rpm !== undefined) patch.rateLimitRpm = d.rate_limit_rpm;
     if (d.rate_limit_tpm !== undefined) patch.rateLimitTpm = d.rate_limit_tpm;
+    if (d.budget_requests !== undefined) patch.budgetRequests = d.budget_requests;
+    if (d.budget_tokens !== undefined) patch.budgetTokens = d.budget_tokens;
+    if (d.budget_spend_usd !== undefined) patch.budgetSpendUsd = d.budget_spend_usd;
+    if (d.budget_window_seconds !== undefined) patch.budgetWindowSeconds = d.budget_window_seconds;
+    if (d.over_budget_behavior !== undefined) patch.overBudgetBehavior = d.over_budget_behavior;
+    if (d.degrade_lane !== undefined) patch.degradeLane = d.degrade_lane;
     try {
       await deps.keyStore.updateKey(id, patch);
     } catch {

--- a/apps/gateway/src/routes/chat.memory.test.ts
+++ b/apps/gateway/src/routes/chat.memory.test.ts
@@ -32,6 +32,12 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     disabled: false,
     rate_limit_rpm: null,
     rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: "degrade",
+    degrade_lane: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -27,6 +27,12 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     disabled: false,
     rate_limit_rpm: null,
     rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: "degrade",
+    degrade_lane: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.session-key.test.ts
+++ b/apps/gateway/src/routes/chat.session-key.test.ts
@@ -35,6 +35,12 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     disabled: false,
     rate_limit_rpm: null,
     rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: "degrade",
+    degrade_lane: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -405,9 +405,9 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         // unconstrained.
         keyCaps: {
           allowedLanes: identity.caps?.allowedLanes ?? null,
-          // Dynamic degrade ceiling: set only when the key is over budget AND its
+          // Forced degrade lane: set only when the key is over budget AND its
           // behavior is "degrade" (docs/06). null = no degrade for this request.
-          maxLane: degradeLane,
+          degradeLane,
         },
       },
       c.req.raw.signal,

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -1,4 +1,7 @@
 import type {
+  BudgetCaps,
+  BudgetCheckResult,
+  BudgetProbe,
   ChatCompletionRequest,
   DecisionRecord,
   ExecutionResult,
@@ -25,6 +28,8 @@ import {
   captureEnabled,
   type PayloadCaptureDeps,
   persistPayload,
+  tokensFromUsage,
+  usageFromBody,
   usageFromSSE,
 } from "./payload-capture.js";
 
@@ -68,6 +73,19 @@ export interface ChatRouteDeps {
    *  (a store failure never 5xx's, principle 3). `observe` is the process-wide
    *  ObserveDeps built once in the composition root. */
   memory?: { observe: ObserveDeps };
+  /** Per-key usage-budget wiring (docs/06). Optional — absent = no budgets (existing
+   *  tests unchanged). `budgetGate.check` runs BEFORE route (fail-CLOSED: a store
+   *  error propagates → 5xx); over budget either rejects (429) or yields a degrade
+   *  lane fed into keyCaps.maxLane. `settleBudget` runs post-served inside the SAME
+   *  fail-open envelope as telemetry persist (a settle failure is logged, never
+   *  5xx's a served request). */
+  budgetGate?: { check(probe: BudgetProbe): Promise<BudgetCheckResult> };
+  settleBudget?: (
+    keyId: string,
+    caps: BudgetCaps,
+    usage: { requests: number; tokens: number; costUsd: number | null },
+    nowMs: number,
+  ) => Promise<void>;
 }
 
 // Minimal identity shape the adapter reads (subset of middleware/auth's
@@ -79,7 +97,7 @@ interface ChatIdentity {
   accountId: string;
   orgId: string | null;
   userId: string | null;
-  caps: { allowCustomModel: boolean; allowedLanes?: string[] | null };
+  caps: { allowCustomModel: boolean; allowedLanes?: string[] | null; budget?: BudgetCaps };
 }
 
 // Map the OpenAI chat request body to the normalized InternalRequest (Protocol
@@ -303,6 +321,49 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       }
     };
 
+    // Post-served usage-budget settle (docs/06). Fail-OPEN — mirrors `persist`: a
+    // settle failure is logged, never 5xx's a served request nor breaks a stream.
+    // Self-gates: no-op when no budget dep is wired. Charges the SETTLED total_usd
+    // (never recomputed) + actual served tokens + 1 request.
+    const settle = async (decision: DecisionRecord, tokens: number) => {
+      if (deps.settleBudget === undefined || identity.caps?.budget === undefined) return;
+      try {
+        await deps.settleBudget(
+          identity.keyId,
+          identity.caps.budget,
+          { requests: 1, tokens, costUsd: decision.cost_breakdown.total_usd },
+          deps.now(),
+        );
+      } catch {
+        c.get("logger").log("error", "budget.settle_failed", { trace_id: traceId });
+      }
+    };
+
+    // Pre-route usage-budget gate (docs/06). FAIL-CLOSED: a store-read error
+    // propagates (→ 5xx), never a silent pass. Over budget → reject (429) or
+    // degrade: cap THIS request's lane to the key's degrade lane via keyCaps.maxLane.
+    let degradeLane: string | null = null;
+    if (deps.budgetGate !== undefined && identity.caps?.budget !== undefined) {
+      const check = await deps.budgetGate.check({
+        keyId: identity.keyId,
+        caps: identity.caps.budget,
+        nowMs: deps.now(),
+      });
+      if (check.overBudget) {
+        if (check.behavior === "reject") {
+          throw structuredError(
+            makeHelmError({
+              error_class: "rate_limited",
+              message: "usage budget exceeded",
+              trace_id: traceId,
+            }),
+            traceId,
+          );
+        }
+        degradeLane = check.degradeLane;
+      }
+    }
+
     // e2e-only classification overrides: honor `x-helm-eval` (Layer-2 toggle) and
     // `x-helm-rules-threshold` (raise the Layer-1 gate so the cascade reaches
     // eval) ONLY when the composition root opted in (HELM_E2E). Production leaves
@@ -344,6 +405,9 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         // unconstrained.
         keyCaps: {
           allowedLanes: identity.caps?.allowedLanes ?? null,
+          // Dynamic degrade ceiling: set only when the key is over budget AND its
+          // behavior is "degrade" (docs/06). null = no degrade for this request.
+          maxLane: degradeLane,
         },
       },
       c.req.raw.signal,
@@ -436,6 +500,10 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
             (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
           );
           await persist(result.decision);
+          // Usage-budget settle (streamed): runs HERE — after the usage tail
+          // backfilled the streamed cost — so the spend dimension settles the real
+          // total. Tokens come from the same usage tail. Fail-open.
+          await settle(result.decision, tokensFromUsage(usageFromSSE(rawSse)));
           // Memory observe (outbound, streamed): persist the reconstructed
           // assistant turn AFTER the bytes were forwarded. Fail-open inside core.
           if (deps.memory !== undefined) {
@@ -481,6 +549,9 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     if (deps.memory !== undefined) {
       await observeOutbound(deps.memory.observe, memoryScope, outboundFromOpenAIBody(result.body));
     }
+    // Usage-budget settle (non-stream, success): cost is already on the decision;
+    // tokens from the body's usage. Fail-open.
+    await settle(result.decision, tokensFromUsage(usageFromBody(result.body)));
     return c.json(result.body as Record<string, unknown>);
   });
 }

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -185,7 +185,7 @@ describe("createMessagesPipeline — failure surfaces", () => {
     expect(sawOpts).not.toBeNull();
     expect((sawOpts as RouteOptions | null)?.keyCaps).toEqual({
       allowedLanes: ["economy"],
-      maxLane: null,
+      degradeLane: null,
     });
   });
 
@@ -199,7 +199,7 @@ describe("createMessagesPipeline — failure surfaces", () => {
     await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
     expect((sawOpts as RouteOptions | null)?.keyCaps).toEqual({
       allowedLanes: null,
-      maxLane: null,
+      degradeLane: null,
     });
   });
 });

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -185,6 +185,7 @@ describe("createMessagesPipeline — failure surfaces", () => {
     expect(sawOpts).not.toBeNull();
     expect((sawOpts as RouteOptions | null)?.keyCaps).toEqual({
       allowedLanes: ["economy"],
+      maxLane: null,
     });
   });
 
@@ -198,6 +199,7 @@ describe("createMessagesPipeline — failure surfaces", () => {
     await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
     expect((sawOpts as RouteOptions | null)?.keyCaps).toEqual({
       allowedLanes: null,
+      maxLane: null,
     });
   });
 });

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -371,8 +371,8 @@ export function createMessagesPipeline(
       // null = unconstrained; an identity with no caps yields {null} (no-op).
       const keyCaps = {
         allowedLanes: Array.isArray(caps?.allowedLanes) ? (caps.allowedLanes as string[]) : null,
-        // Over-budget degrade ceiling for this request (docs/06); null = no degrade.
-        maxLane: degradeLane,
+        // Forced degrade lane for this request (docs/06); null = no degrade.
+        degradeLane,
       };
 
       const result = await route(internal, { allowCustomModel, keyPrefix, keyCaps }, signal);

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -1,5 +1,8 @@
 import {
   type AnthropicSSEEvent,
+  type BudgetCaps,
+  type BudgetCheckResult,
+  type BudgetProbe,
   convertOpenAIStreamToAnthropic,
   convertOpenAIStreamToResponses,
   type ExecutionResult,
@@ -17,6 +20,30 @@ import {
 } from "@helm/core";
 import type { InternalRequest, Protocol } from "@helm/shared";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
+import {
+  backfillCompletionCost,
+  type StreamUsage,
+  tokensFromUsage,
+  usageFromBody,
+} from "./payload-capture.js";
+
+// Per-key usage-budget wiring shared by ALL pipeline faces (anthropic /v1/messages,
+// openai /v1/responses, gemini :generateContent). The pipeline is the single place
+// these three converge, so the budget CHECK (pre-route degrade/reject) + SETTLE
+// (post-served) + streamed-cost backfill live here ONCE (docs/06). Absent = no
+// budgets (existing tests unchanged). costOf prices the streamed usage tail so the
+// spend dimension settles the real cost on the streaming path too.
+export interface PipelineBudgetDeps {
+  gate: { check(probe: BudgetProbe): Promise<BudgetCheckResult> };
+  settle: (
+    keyId: string,
+    caps: BudgetCaps,
+    usage: { requests: number; tokens: number; costUsd: number | null },
+    nowMs: number,
+  ) => Promise<void>;
+  costOf?: (alias: string, usage: StreamUsage) => number | null;
+  now: () => number;
+}
 
 // The loose IR the route hands us: the inbound transformer's IRRequest, augmented
 // with the `metadata` bag the route stamps the trace_id into. We treat it as an
@@ -278,6 +305,9 @@ export function createMessagesPipeline(
   // fail-open (a store failure never surfaces, principle 3). Serves BOTH the
   // /v1/messages and /v1/responses surfaces (they share this pipeline).
   memory?: { observe: ObserveDeps },
+  // Per-key usage budgets (docs/06). Absent = no budgets. Serves all three
+  // pipeline faces at once (they share this pipeline).
+  budget?: PipelineBudgetDeps,
 ): {
   run(ir: PipelineIR, identity: MessagesIdentity, signal: AbortSignal): Promise<PipelineRunResult>;
 } {
@@ -307,9 +337,30 @@ export function createMessagesPipeline(
       }
 
       const caps = identity.caps as
-        | { allowCustomModel?: unknown; allowedLanes?: unknown }
+        | { allowCustomModel?: unknown; allowedLanes?: unknown; budget?: BudgetCaps }
         | undefined;
       const allowCustomModel = caps?.allowCustomModel === true;
+
+      // Pre-route usage-budget gate (docs/06), shared across all three pipeline
+      // faces. FAIL-CLOSED: a peek store error propagates out of run() → the route
+      // surfaces a 5xx, never a silent pass. Over budget → reject (a PipelineError
+      // the route maps to a protocol-correct 429) or degrade (cap the lane via
+      // keyCaps.maxLane below).
+      let degradeLane: string | null = null;
+      const budgetCaps = caps?.budget;
+      if (budget !== undefined && budgetCaps !== undefined) {
+        const check = await budget.gate.check({
+          keyId: internal.api_key_id,
+          caps: budgetCaps,
+          nowMs: budget.now(),
+        });
+        if (check.overBudget) {
+          if (check.behavior === "reject") {
+            throw new PipelineError("rate_limited", "usage budget exceeded", traceId);
+          }
+          degradeLane = check.degradeLane;
+        }
+      }
       // Display prefix only (never the plaintext key, principle 7) for the Debug
       // UI key column; null when this identity carries none.
       const keyPrefix = typeof identity.keyPrefix === "string" ? identity.keyPrefix : null;
@@ -320,9 +371,29 @@ export function createMessagesPipeline(
       // null = unconstrained; an identity with no caps yields {null} (no-op).
       const keyCaps = {
         allowedLanes: Array.isArray(caps?.allowedLanes) ? (caps.allowedLanes as string[]) : null,
+        // Over-budget degrade ceiling for this request (docs/06); null = no degrade.
+        maxLane: degradeLane,
       };
 
       const result = await route(internal, { allowCustomModel, keyPrefix, keyCaps }, signal);
+
+      // Post-served usage-budget settle (docs/06), fail-OPEN. Charges the SETTLED
+      // total_usd (never recomputed) + served tokens + 1 request. Shared helper for
+      // both accessors; a settle failure is swallowed (never breaks a served
+      // response). No-op when budgets are unwired or the key has no caps.
+      const settleBudget = async (tokens: number): Promise<void> => {
+        if (budget === undefined || budgetCaps === undefined) return;
+        try {
+          await budget.settle(
+            internal.api_key_id,
+            budgetCaps,
+            { requests: 1, tokens, costUsd: result.decision.cost_breakdown.total_usd },
+            budget.now(),
+          );
+        } catch {
+          /* fail-open: a budget settle failure never breaks a served request */
+        }
+      };
 
       // Routing returned a structured failure WITHOUT throwing (final.status:
       // "error"). Capture it so the failure surfaces through whichever accessor
@@ -349,6 +420,9 @@ export function createMessagesPipeline(
           if (memory !== undefined) {
             await observeOutbound(memory.observe, memoryScope, outboundFromIR(irResponse));
           }
+          // Settle the budget on the served (non-stream) response: cost is already
+          // on the decision; tokens from the OpenAI body's usage.
+          await settleBudget(tokensFromUsage(usageFromBody(result.body)));
           return irResponse;
         },
         async *streamIR(): AsyncIterable<Record<string, unknown>> {
@@ -361,16 +435,18 @@ export function createMessagesPipeline(
           // events forwarded downstream (principle 8). observeOutbound runs in a
           // finally so a client disconnect mid-stream still records what arrived.
           const assistant = { text: "" };
+          // Capture the trailing OpenAI usage chunk (include_usage) so the budget
+          // settle + streamed-cost backfill below have the real token/cost — the
+          // upstream is OpenAI SSE on EVERY face, so this one extractor serves all.
+          let lastUsage: StreamUsage | null = null;
           const chunks = parseOpenAISSE(result.stream);
-          const source =
-            memory === undefined
-              ? chunks
-              : (async function* () {
-                  for await (const ch of chunks) {
-                    accumulateAssistantText(assistant, ch);
-                    yield ch;
-                  }
-                })();
+          const source = (async function* () {
+            for await (const ch of chunks) {
+              if (memory !== undefined) accumulateAssistantText(assistant, ch);
+              if (ch.usage && typeof ch.usage === "object") lastUsage = ch.usage as StreamUsage;
+              yield ch;
+            }
+          })();
           try {
             // Outbound stream mapping is chosen by the pipeline's stamped protocol
             // (principle 5: surfaces never conflate). Gemini consumes the SAME
@@ -407,6 +483,26 @@ export function createMessagesPipeline(
                 responseMessages: [{ role: "assistant", content: assistant.text }],
                 toolResults: [],
               });
+            }
+            // Streamed-cost backfill + budget settle (docs/06). Zero-touch when
+            // budgets are unwired/unmetered. The pipeline faces never settled
+            // streamed cost before — price the usage tail at the served alias so the
+            // decision's total_usd is real, THEN settle the budget. Fail-open.
+            if (budget !== undefined && budgetCaps !== undefined) {
+              const finalAlias =
+                result.decision.final.status === "ok" ? result.decision.final.model_alias : null;
+              if (lastUsage && finalAlias && budget.costOf) {
+                try {
+                  backfillCompletionCost(
+                    result.decision,
+                    finalAlias,
+                    budget.costOf(finalAlias, lastUsage),
+                  );
+                } catch {
+                  /* fail-open: leave cost null on any pricing miss */
+                }
+              }
+              await settleBudget(tokensFromUsage(lastUsage));
             }
           }
         },

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -1,4 +1,4 @@
-import type { RateLimitProbe, RateLimitResult } from "@helm/core";
+import type { BudgetCaps, RateLimitProbe, RateLimitResult } from "@helm/core";
 import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -31,6 +31,9 @@ export interface MessagesIdentity {
    *  path enforces per-key limits, mirroring the OpenAI chat middleware. */
   caps?: {
     rateLimit?: { rpm: number | null; tpm: number | null };
+    /** Per-key usage budgets (docs/06), read by the pipeline's budget gate/settle.
+     *  Absent = no budgets on this face. */
+    budget?: BudgetCaps;
     [k: string]: unknown;
   };
   [k: string]: unknown;

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -37,6 +37,24 @@ export function captureEnabled(deps: PayloadCaptureDeps): boolean {
   return deps.capturePayloads?.() === true;
 }
 
+// Total served tokens (prompt + completion) from an OpenAI-style usage object, for
+// the per-key token budget (docs/06). Tolerant of a missing/partial usage: a field
+// absent counts as 0. Used by every face's post-served budget settle — the usage
+// always rides the UPSTREAM OpenAI stream/body, so one extractor serves all.
+export function tokensFromUsage(usage: StreamUsage | null | undefined): number {
+  if (!usage) return 0;
+  return (usage.prompt_tokens ?? 0) + (usage.completion_tokens ?? 0);
+}
+
+// Extract the OpenAI `usage` object from a NON-streaming response body (the
+// assembled chat.completion / equivalent). Mirrors usageFromSSE for the buffered
+// path. null when the body has no usage object.
+export function usageFromBody(body: unknown): StreamUsage | null {
+  const usage = (body as { usage?: unknown } | null)?.usage;
+  if (usage && typeof usage === "object") return usage as StreamUsage;
+  return null;
+}
+
 // Persist the verbatim request/response bodies + opportunistically prune expired
 // rows. Never throws — logs via the provided sink on failure.
 export async function persistPayload(

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -3,10 +3,12 @@ import { existsSync } from "node:fs";
 import {
   type AnthropicSSEEvent,
   anthropicTransformer,
+  type BudgetCaps,
   bootstrapRootKey,
   COPILOT_HEADERS,
   type ConfigStore,
   createAnthropicClient,
+  createBudgetGate,
   createCircuitBreaker,
   createCodexResponsesClient,
   createMemoryMomentumStore,
@@ -51,6 +53,7 @@ import {
   routeRequest,
   type StoreSet,
   saveRuntimeSettings,
+  settleBudget,
   startSignalScheduler,
   toRegistryProviders,
 } from "@helm/core";
@@ -855,6 +858,33 @@ export async function buildServer(
   // then keeps an honest "not measured" null, never a misleading 0.
   const costOf = (alias: string, usage: { prompt_tokens?: number; completion_tokens?: number }) =>
     resolveCostUsd(catalog.get(alias)?.pricing, { usage });
+
+  // Per-key usage budgets (docs/06). No global on/off — a key with no caps is a
+  // zero-touch fast path (the gate reads nothing). `defaultWindowSeconds` (30d)
+  // applies only when a key sets a cap but no window; `defaultDegradeLane` is the
+  // fallback when a key degrades without naming a target lane. The CHECK is
+  // fail-CLOSED (a peek error propagates → 5xx); SETTLE is fail-OPEN (the route
+  // swallows store failures). Shared by all four faces: chat reads the gate/settle
+  // directly; the three pipeline faces get them via `pipelineBudget`.
+  const budgetConfig = { defaultWindowSeconds: 2_592_000, defaultDegradeLane: "economy" };
+  const budgetGate = createBudgetGate({ store: store.budget, config: budgetConfig });
+  const settleKeyBudget = (
+    keyId: string,
+    caps: BudgetCaps,
+    usage: { requests: number; tokens: number; costUsd: number | null },
+    nowMs: number,
+  ): Promise<void> =>
+    settleBudget({ store: store.budget, config: budgetConfig }, keyId, caps, usage, nowMs);
+  // Budget deps the shared messages-pipeline (messages/responses/gemini) consumes:
+  // the gate, the settle closure, costOf (to price the streamed usage tail), and a
+  // clock. The streamed-cost backfill it does ALSO fills the decision's total_usd
+  // on these faces (which previously never settled streamed cost).
+  const pipelineBudget = {
+    gate: budgetGate,
+    settle: settleKeyBudget,
+    costOf,
+    now: () => Date.now(),
+  };
   // Three-layer cascade classify adapter: Layer-1 rules + Layer-2 eval (OFF by
   // default; per-request override threaded from the chat route) + Layer-3
   // balanced fail-open. The eval small-model is invoked via the same provider
@@ -955,6 +985,10 @@ export async function buildServer(
     capturePayloads: () => settings.capture_payloads,
     payloadRetentionMs: () => settings.payload_retention_days * 86_400_000,
     costOf,
+    // Per-key usage budgets (docs/06): the pre-route gate (degrade/reject) + the
+    // post-served settle, threaded from the composition root.
+    budgetGate,
+    settleBudget: settleKeyBudget,
     // e2e-only: allow the `x-helm-eval` header to toggle Layer-2 eval per request
     // so the eval cascade can be black-boxed without a config reload. Production
     // leaves HELM_E2E unset → eval stays config-driven (fail-closed, principle 2).
@@ -1075,7 +1109,12 @@ export async function buildServer(
   // Both Anthropic /v1/messages and OpenAI /v1/responses share this pipeline
   // shape; each gets the SAME observe deps so memory observe fires on every
   // surface (the pipeline self-gates on the scope it reads off ir.metadata).
-  const messagesPipeline = createMessagesPipeline(route, "anthropic_messages", { observe });
+  const messagesPipeline = createMessagesPipeline(
+    route,
+    "anthropic_messages",
+    { observe },
+    pipelineBudget,
+  );
   // Inject the SAME per-key limiter instance the chat surface uses so the
   // Anthropic /v1/messages handler can meter per-key AFTER its self-auth (closes
   // the rate-limit bypass on /v1/messages + /v1/responses). The Wave2 handlers
@@ -1107,6 +1146,16 @@ export async function buildServer(
             // /v1/messages + /v1/responses paths enforce per-key limits too, not
             // just the OpenAI chat middleware.
             rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
+            // Per-key usage budgets (docs/06): carried so the pipeline's budget
+            // gate/settle enforce on these self-auth faces too.
+            budget: {
+              requests: record.budget_requests,
+              tokens: record.budget_tokens,
+              spendUsd: record.budget_spend_usd,
+              windowSeconds: record.budget_window_seconds,
+              behavior: record.over_budget_behavior,
+              degradeLane: record.degrade_lane,
+            },
           },
         };
       },
@@ -1147,7 +1196,12 @@ export async function buildServer(
   // pipeline stamped with the openai_responses protocol, and the Responses
   // transformer for IR↔native translation. Streaming (stream:true) emits the
   // native response.* SSE event sequence via the second IR→SSE state machine.
-  const responsesPipeline = createMessagesPipeline(route, "openai_responses", { observe });
+  const responsesPipeline = createMessagesPipeline(
+    route,
+    "openai_responses",
+    { observe },
+    pipelineBudget,
+  );
   registerResponsesRoute(app, {
     // Same per-key limiter, same cast rationale as the messages route above —
     // closes the rate-limit bypass on /v1/responses.
@@ -1171,6 +1225,16 @@ export async function buildServer(
             // /v1/messages + /v1/responses paths enforce per-key limits too, not
             // just the OpenAI chat middleware.
             rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
+            // Per-key usage budgets (docs/06): carried so the pipeline's budget
+            // gate/settle enforce on these self-auth faces too.
+            budget: {
+              requests: record.budget_requests,
+              tokens: record.budget_tokens,
+              spendUsd: record.budget_spend_usd,
+              windowSeconds: record.budget_window_seconds,
+              behavior: record.over_budget_behavior,
+              degradeLane: record.degrade_lane,
+            },
           },
         };
       },
@@ -1195,7 +1259,7 @@ export async function buildServer(
   // Gemini transformer for IR↔native translation + the Gemini error envelope. Self-
   // auth (x-goog-api-key preferred, Bearer fallback) so a missing key is rejected as
   // a Gemini error envelope (docs/05, docs/07).
-  const geminiPipeline = createMessagesPipeline(route, "gemini", { observe });
+  const geminiPipeline = createMessagesPipeline(route, "gemini", { observe }, pipelineBudget);
   registerGeminiRoute(app, {
     rateLimiter,
     auth: {
@@ -1214,6 +1278,14 @@ export async function buildServer(
             allowedLanes: record.allowed_lanes,
             allowCustomModel: record.allow_custom_model,
             rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
+            budget: {
+              requests: record.budget_requests,
+              tokens: record.budget_tokens,
+              spendUsd: record.budget_spend_usd,
+              windowSeconds: record.budget_window_seconds,
+              behavior: record.over_budget_behavior,
+              degradeLane: record.degrade_lane,
+            },
           },
         };
       },

--- a/docs/06-auth-and-rate-limits.md
+++ b/docs/06-auth-and-rate-limits.md
@@ -99,8 +99,11 @@ The stored record (`ApiKeyRecord`, single source of truth in
 
 A "nginx for LLM" needs per-key rate limiting, but it must not become
 out-of-the-box friction. Helm ships lightweight per-key limiting (token-bucket
-RPM/TPM) that is **disabled by default**. Full quota/billing/credit accounting is
-on the [roadmap](09-roadmap.md), not in 0.1.
+RPM/TPM) that is **disabled by default**, plus per-key **usage budgets** (see
+below). Helm meters **per API key** — it is an internal/self-hosted gateway that
+hands out keys, so there is **no account/customer billing subject** and no
+account-level credit ledger (that remains out of scope; see the
+[roadmap](09-roadmap.md)).
 
 The limiter lives in core (`packages/core/src/ratelimit/`), behind a store-backed
 token bucket; the gateway middleware
@@ -152,6 +155,52 @@ Quota resolution per dimension (`resolveQuota` in `ratelimit/limiter.ts`):
 - The bucket store is **fail-closed**: a read/write failure propagates and the
   request is rejected — it never silently degrades to "unlimited".
 - Counters persist in the store, so they survive restarts.
+
+## Per-key usage budgets
+
+Rate limits cap the *rate* of traffic; **usage budgets** cap *cumulative
+consumption* per key over a rolling window, to control cost. Each key may set any
+subset of three optional caps (null = no cap for that dimension):
+
+- `budget_requests` — request count,
+- `budget_tokens` — total tokens,
+- `budget_spend_usd` — spend in USD,
+
+over a `budget_window_seconds` rolling window (null = a system default, ~30 days).
+Budgets reuse the same token-bucket as rate limits (`packages/core/src/budget/`,
+backed by the `usage_budget_buckets` store table) — just with a **configurable
+window** instead of the fixed 60s, and continuous refill (no hard reset).
+
+The distinguishing behavior is **what happens when a key is over budget**, chosen
+per key via `over_budget_behavior`:
+
+- **`degrade`** (default) — the request is **downgraded to a cheaper lane**
+  (`degrade_lane`, default `economy`) instead of its normal lane, then served
+  normally. Cost is bounded **without interrupting service**. Implemented by
+  feeding a dynamic `max_lane` ceiling into the router's existing `applyCaps` for
+  that one request.
+- **`reject`** — a hard `429 rate_limited` (`limited_by: "credit"` on the OpenAI
+  middleware face), before classify/route.
+
+Two phases, like the rate limiter but split by failure mode:
+
+- **Pre-route check** is a pure **balance sign check** (no per-request cost
+  pre-estimate): a discrete dimension (requests/tokens) is over when it can't
+  afford one more unit (`remaining < 1`); spend is over at `remaining <= 0`. The
+  check is **fail-CLOSED** — a store-read error propagates (→ 5xx), never a silent
+  pass. A key with no caps is a zero-touch fast path (no store read).
+- **Post-served settle** debits the **actual** served usage (1 request + measured
+  tokens + the decision's settled `total_usd`, never recomputed; an unmeasured
+  cost settles 0). It is **fail-OPEN** — a settle failure is logged, never 5xx's a
+  served request. Because settle is post-served, a single in-flight request may
+  push a bucket slightly negative; subsequent requests are then over budget.
+
+Budgets are enforced on **all four protocol faces** (OpenAI `/v1/chat`, Anthropic
+`/v1/messages`, OpenAI `/v1/responses`, Gemini `:generateContent`). The three
+self-authenticating faces share one routing pipeline, so the check + settle (and
+the streamed-cost backfill that makes the spend dimension correct on the streaming
+path) live there once. All budget config is editable per key in the admin API
+Keys page and applies on the next request (no restart).
 
 ## Admin authentication is separate
 

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -48,8 +48,11 @@ Verified against the code and `implementation-notes.md`:
 - **Memory inject phase.** The `observe` phase is wired; the `inject` phase
   (`assembleInjectedContext`) and the background Observer/Reflector jobs are not.
   See [08 · Memory Middleware](08-memory-middleware.md).
-- **Fuller quota / rate-limit features.** Per-key RPM/TPM limiting ships
-  (disabled by default); full quota / billing / credit accounting is deferred. See
+- **Fuller quota / rate-limit features.** Per-key RPM/TPM limiting **and** per-key
+  usage budgets (requests / tokens / spend over a rolling window, with
+  degrade-to-cheaper-lane or reject) ship — metered **per API key**. Helm is an
+  internal/self-hosted gateway with no account/customer billing subject, so
+  **account-level credit accounting is out of scope** (not merely deferred). See
   [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md).
 - **Agentic Signals feedback layer.** The store ports and the redacted
   `RoutingSignal` shape exist, but nothing reads signals back into routing yet.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,25 @@
 
 ---
 
+## 2026-06-03 · Per-API-key usage budgets with lane degradation (docs/06; supersedes the closed account-billing PR #42)
+
+**Context**: PR #42 built account-level credit billing (1 account : N keys). Helm is an **internal, self-hosted** gateway that hands out **API keys**, not accounts — there is no billing subject — so that PR was **closed**. What's actually wanted is **per-key cost control that doesn't interrupt service**: cap each key's usage over a rolling window and, when exceeded, **degrade to a cheaper lane** rather than reject.
+
+**Design** (reuses two existing mechanisms instead of a new ledger):
+- **Token-bucket** (`ratelimit/token-bucket.ts`) parameterized with a configurable `windowMs` (default 60s keeps RPM/TPM untouched). Budgets are token buckets with a long, per-key window. New `BudgetStore` port + sqlite/pg adapters (`usage_budget_buckets` table, one row per (key_id, dim ∈ req|tok|usd); sqlite migration **v11**, pg **v10**). Tokens may go negative (soft cap settled post-served).
+- **Lane degrade** reuses `applyCaps` (`policy-engine.ts`): re-added a `maxLane` to `RouteOptions.keyCaps` (the exact per-key ceiling #63 removed), now populated dynamically per request when over budget. No new routing logic.
+- Pure core `budget/` module: `gate.ts` (fail-CLOSED pre-route sign check) + `settle.ts` (fail-OPEN post-served debit). Key config: `budget_requests/_tokens/_spend_usd` (null = no cap), `budget_window_seconds`, `over_budget_behavior` (degrade|reject, default degrade), `degrade_lane` (null = economy).
+
+**Decisions / gotchas**:
+- **Per-dim over-budget threshold (important)**: a 30-day window means the bucket micro-refills a positive epsilon the instant after depletion, so a pure `remaining > 0` sign check would let a "budget of N" serve N+1. Fixed: discrete dims (req/tok) are over at `remaining < 1` (can't afford one whole unit); the fractional `usd` dim stays `remaining <= 0` (cost is unknown pre-request, so it keeps the D5 one-in-flight tolerance, settled after).
+- **All four faces** enforce budgets (the user asked for full coverage). The three self-auth faces (messages/responses/gemini) share `messages-pipeline.ts`, so the check + settle live there ONCE. To make the **spend** dim correct on the streaming pipeline path, the pipeline now also backfills streamed cost from the **upstream OpenAI usage tail** (`usageFromSSE`, the same parser chat uses) — the pipeline faces never settled streamed cost before; this closes that gap as a side benefit.
+- **Settle timing**: the non-stream path awaits settle before responding (deterministic); the streamed path settles in a `finally` after the usage-tail backfill. The e2e therefore depletes via a NON-stream request (a streamed settle can race a client that stops reading at `[DONE]`).
+- **Behavior default is `degrade`, NOT fail-closed**: the explicit product goal is uninterrupted service, so an over-budget key keeps serving on a cheaper lane unless configured to reject. Documented as intentional.
+- **No global on/off toggle**: a key with no caps is a zero-touch fast path (no store read), so budgets need no runtime-settings switch (unlike rate limits).
+- **Streamed-spend e2e**: the mock upstream emits no usage chunk, so the e2e covers the request-count dimension (degrade + reject, deterministic); per-amount spend/token settlement is covered by the unit tests (budget gate/settle + the pipeline/chat wiring), mirroring the constraint the closed PR hit.
+
+---
+
 ## 2026-06-03 · Hot-reload the OAuth subscription pool (proxy / priority / schedulable / connect / disconnect) — no restart (issue #38)
 
 **Context**: The operator's rule — anything editable in an admin page form must hot-apply on Save, never need a restart. Audited every admin form vs its runtime consumption: **lanes, policies, classifier, API keys, System Settings (capture/retention/rate-limit/log-level), and OAuth model curation were ALREADY hot** (RuleStore re-bind callbacks / live keystore reads / per-request thunks). The **only gap** was the OAuth pool: `synthesizeOAuthProviders()` ran once at startup and froze each account's proxy/priority/schedulable + the connected-account set into the pool; the admin PUT handlers only persisted.

--- a/packages/core/src/budget/gate.test.ts
+++ b/packages/core/src/budget/gate.test.ts
@@ -23,11 +23,7 @@ function peekStore(remainingByDim: Partial<Record<BudgetDim, number>>): {
   peek: ReturnType<typeof vi.fn>;
 } {
   const peek = vi.fn(
-    async (
-      _keyId: string,
-      dim: BudgetDim,
-      capacity: number,
-    ): Promise<BudgetPeekResult> => {
+    async (_keyId: string, dim: BudgetDim, capacity: number): Promise<BudgetPeekResult> => {
       const remaining = remainingByDim[dim] ?? capacity;
       return { remaining, ok: remaining > 0 };
     },
@@ -44,7 +40,7 @@ describe("createBudgetGate", () => {
     expect(peek).not.toHaveBeenCalled();
   });
 
-  it("treats a 0 cap as unlimited (no store read, mirrors rate-limit 0)", async () => {
+  it("defensively treats a 0/negative cap as no-cap (no store read; schema rejects 0)", async () => {
     const { store, peek } = peekStore({});
     const gate = createBudgetGate({ store, config: CONFIG });
     const r = await gate.check({ keyId: "k1", caps: caps({ spendUsd: 0 }), nowMs: 0 });

--- a/packages/core/src/budget/gate.test.ts
+++ b/packages/core/src/budget/gate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BudgetDim, BudgetPeekResult, BudgetStore } from "../store/ports.js";
+import { createBudgetGate } from "./gate.js";
+import type { BudgetCaps, BudgetConfig } from "./types.js";
+
+const CONFIG: BudgetConfig = { defaultWindowSeconds: 86_400, defaultDegradeLane: "economy" };
+
+function caps(over: Partial<BudgetCaps> = {}): BudgetCaps {
+  return {
+    requests: null,
+    tokens: null,
+    spendUsd: null,
+    windowSeconds: null,
+    behavior: "degrade",
+    degradeLane: null,
+    ...over,
+  };
+}
+
+// A peek stub keyed by dim → remaining. ok = remaining > 0.
+function peekStore(remainingByDim: Partial<Record<BudgetDim, number>>): {
+  store: Pick<BudgetStore, "peek">;
+  peek: ReturnType<typeof vi.fn>;
+} {
+  const peek = vi.fn(
+    async (
+      _keyId: string,
+      dim: BudgetDim,
+      capacity: number,
+    ): Promise<BudgetPeekResult> => {
+      const remaining = remainingByDim[dim] ?? capacity;
+      return { remaining, ok: remaining > 0 };
+    },
+  );
+  return { store: { peek }, peek };
+}
+
+describe("createBudgetGate", () => {
+  it("zero-touch fast path: no caps => within budget, store never read", async () => {
+    const { store, peek } = peekStore({});
+    const gate = createBudgetGate({ store, config: CONFIG });
+    const r = await gate.check({ keyId: "k1", caps: caps(), nowMs: 0 });
+    expect(r.overBudget).toBe(false);
+    expect(peek).not.toHaveBeenCalled();
+  });
+
+  it("treats a 0 cap as unlimited (no store read, mirrors rate-limit 0)", async () => {
+    const { store, peek } = peekStore({});
+    const gate = createBudgetGate({ store, config: CONFIG });
+    const r = await gate.check({ keyId: "k1", caps: caps({ spendUsd: 0 }), nowMs: 0 });
+    expect(r.overBudget).toBe(false);
+    expect(peek).not.toHaveBeenCalled();
+  });
+
+  it("within budget when every active dimension has remaining > 0", async () => {
+    const { store } = peekStore({ usd: 5, req: 100 });
+    const gate = createBudgetGate({ store, config: CONFIG });
+    const r = await gate.check({
+      keyId: "k1",
+      caps: caps({ spendUsd: 10, requests: 1000 }),
+      nowMs: 0,
+    });
+    expect(r.overBudget).toBe(false);
+    expect(r.limitedBy).toBeNull();
+  });
+
+  it("over budget => degrade to the resolved lane (key lane, else default economy)", async () => {
+    const { store } = peekStore({ usd: 0 });
+    const gate = createBudgetGate({ store, config: CONFIG });
+    const r = await gate.check({ keyId: "k1", caps: caps({ spendUsd: 10 }), nowMs: 0 });
+    expect(r.overBudget).toBe(true);
+    expect(r.limitedBy).toBe("usd");
+    expect(r.behavior).toBe("degrade");
+    expect(r.degradeLane).toBe("economy");
+  });
+
+  it("uses the per-key degrade lane when set", async () => {
+    const { store } = peekStore({ usd: -1 });
+    const gate = createBudgetGate({ store, config: CONFIG });
+    const r = await gate.check({
+      keyId: "k1",
+      caps: caps({ spendUsd: 10, degradeLane: "balanced" }),
+      nowMs: 0,
+    });
+    expect(r.degradeLane).toBe("balanced");
+  });
+
+  it("over budget with reject behavior surfaces reject", async () => {
+    const { store } = peekStore({ tok: 0 });
+    const gate = createBudgetGate({ store, config: CONFIG });
+    const r = await gate.check({
+      keyId: "k1",
+      caps: caps({ tokens: 500, behavior: "reject" }),
+      nowMs: 0,
+    });
+    expect(r.overBudget).toBe(true);
+    expect(r.behavior).toBe("reject");
+  });
+
+  it("FAIL-CLOSED: a peek store error propagates (never a silent pass)", async () => {
+    const store: Pick<BudgetStore, "peek"> = {
+      peek: vi.fn().mockRejectedValue(new Error("db down")),
+    };
+    const gate = createBudgetGate({ store, config: CONFIG });
+    await expect(
+      gate.check({ keyId: "k1", caps: caps({ spendUsd: 10 }), nowMs: 0 }),
+    ).rejects.toThrow("db down");
+  });
+});

--- a/packages/core/src/budget/gate.ts
+++ b/packages/core/src/budget/gate.ts
@@ -1,0 +1,80 @@
+import type { BudgetDim, BudgetStore } from "../store/ports.js";
+import type { BudgetCaps, BudgetCheckResult, BudgetConfig } from "./types.js";
+
+// The active (capped) budget dimensions for a key. A dimension is active only
+// when its cap is a positive number — null OR 0 means "no cap" (0 mirrors the
+// rate-limit "0 = unlimited" convention), so it never touches the store.
+export function activeDims(caps: BudgetCaps): Array<{ dim: BudgetDim; capacity: number }> {
+  const out: Array<{ dim: BudgetDim; capacity: number }> = [];
+  if (caps.requests !== null && caps.requests > 0) out.push({ dim: "req", capacity: caps.requests });
+  if (caps.tokens !== null && caps.tokens > 0) out.push({ dim: "tok", capacity: caps.tokens });
+  if (caps.spendUsd !== null && caps.spendUsd > 0)
+    out.push({ dim: "usd", capacity: caps.spendUsd });
+  return out;
+}
+
+export function windowMsFor(caps: BudgetCaps, config: BudgetConfig): number {
+  return (caps.windowSeconds ?? config.defaultWindowSeconds) * 1000;
+}
+
+export interface BudgetProbe {
+  keyId: string;
+  caps: BudgetCaps;
+  nowMs: number;
+}
+
+export interface BudgetGateDeps {
+  store: Pick<BudgetStore, "peek">;
+  config: BudgetConfig;
+}
+
+const WITHIN_BUDGET: BudgetCheckResult = {
+  overBudget: false,
+  limitedBy: null,
+  behavior: "degrade",
+  degradeLane: null,
+};
+
+// Build the pre-route budget gate. core-only: pure logic + a Store port, no web
+// framework (principle 1). The gate does a PURE BALANCE SIGN CHECK per active
+// dimension (peek remaining > 0) — it does NOT pre-estimate the request's cost,
+// so a single in-flight request may push a bucket slightly negative, settled
+// post-served (D5 tolerance, same as the rate limiter's token estimate). A key
+// with no caps is a zero-touch fast path (no store read). FAIL-CLOSED boundary:
+// a peek store error PROPAGATES (the middleware turns it into a 5xx), never a
+// silent "within budget" pass. Returns the FIRST exhausted dimension; the caller
+// decides what to do (degrade vs reject) from `behavior`.
+export function createBudgetGate(deps: BudgetGateDeps): {
+  check(probe: BudgetProbe): Promise<BudgetCheckResult>;
+} {
+  const { store, config } = deps;
+
+  async function check(probe: BudgetProbe): Promise<BudgetCheckResult> {
+    const dims = activeDims(probe.caps);
+    if (dims.length === 0) return WITHIN_BUDGET; // zero-touch: no caps to enforce
+
+    const windowMs = windowMsFor(probe.caps, config);
+    for (const { dim, capacity } of dims) {
+      const r = await store.peek(probe.keyId, dim, capacity, windowMs, probe.nowMs);
+      // Over-budget threshold differs by dimension. req/tok are DISCRETE units, so
+      // "over" means you can't afford even ONE more unit (remaining < 1) — without
+      // this, the rolling window's continuous micro-refill leaves a positive epsilon
+      // right after exhaustion and a budget of N would let N+1 through. usd is
+      // FRACTIONAL and settled post-served (cost unknown pre-request, D5), so it
+      // stays a pure sign check (remaining <= 0): one in-flight request may push it
+      // slightly negative, then subsequent requests are over.
+      const overBudget = dim === "usd" ? r.remaining <= 0 : r.remaining < 1;
+      if (overBudget) {
+        return {
+          overBudget: true,
+          limitedBy: dim,
+          behavior: probe.caps.behavior,
+          degradeLane: probe.caps.degradeLane ?? config.defaultDegradeLane,
+        };
+      }
+    }
+    return WITHIN_BUDGET;
+  }
+
+  return { check };
+}

--- a/packages/core/src/budget/gate.ts
+++ b/packages/core/src/budget/gate.ts
@@ -2,11 +2,13 @@ import type { BudgetDim, BudgetStore } from "../store/ports.js";
 import type { BudgetCaps, BudgetCheckResult, BudgetConfig } from "./types.js";
 
 // The active (capped) budget dimensions for a key. A dimension is active only
-// when its cap is a positive number — null OR 0 means "no cap" (0 mirrors the
-// rate-limit "0 = unlimited" convention), so it never touches the store.
+// when its cap is a positive number. null means "no cap" (the schema rejects 0 and
+// negatives, so a cap is always strictly positive); the `> 0` guard is defensive
+// against a legacy/hand-edited row, and skips the store entirely for uncapped dims.
 export function activeDims(caps: BudgetCaps): Array<{ dim: BudgetDim; capacity: number }> {
   const out: Array<{ dim: BudgetDim; capacity: number }> = [];
-  if (caps.requests !== null && caps.requests > 0) out.push({ dim: "req", capacity: caps.requests });
+  if (caps.requests !== null && caps.requests > 0)
+    out.push({ dim: "req", capacity: caps.requests });
   if (caps.tokens !== null && caps.tokens > 0) out.push({ dim: "tok", capacity: caps.tokens });
   if (caps.spendUsd !== null && caps.spendUsd > 0)
     out.push({ dim: "usd", capacity: caps.spendUsd });

--- a/packages/core/src/budget/index.ts
+++ b/packages/core/src/budget/index.ts
@@ -1,0 +1,20 @@
+// Per-key usage budgets (docs/06). Pure logic + Store port, framework-agnostic
+// (principle 1). The pre-route gate is fail-CLOSED (a peek error propagates); the
+// post-served settle is fail-OPEN (the caller swallows store failures). Exceeding
+// a budget DEGRADES the request to a cheaper lane by default (keep serving), or
+// REJECTS (429) per the key's over_budget_behavior.
+export {
+  activeDims,
+  type BudgetGateDeps,
+  type BudgetProbe,
+  createBudgetGate,
+  windowMsFor,
+} from "./gate.js";
+export { type SettleBudgetDeps, settleBudget } from "./settle.js";
+export type {
+  BudgetCaps,
+  BudgetCheckResult,
+  BudgetConfig,
+  BudgetUsage,
+  OverBudgetBehavior,
+} from "./types.js";

--- a/packages/core/src/budget/settle.test.ts
+++ b/packages/core/src/budget/settle.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BudgetStore } from "../store/ports.js";
+import { settleBudget } from "./settle.js";
+import type { BudgetCaps, BudgetConfig } from "./types.js";
+
+const CONFIG: BudgetConfig = { defaultWindowSeconds: 86_400, defaultDegradeLane: "economy" };
+
+function caps(over: Partial<BudgetCaps> = {}): BudgetCaps {
+  return {
+    requests: null,
+    tokens: null,
+    spendUsd: null,
+    windowSeconds: null,
+    behavior: "degrade",
+    degradeLane: null,
+    ...over,
+  };
+}
+
+function debitStore(): { store: Pick<BudgetStore, "debit">; debit: ReturnType<typeof vi.fn> } {
+  const debit = vi.fn(async () => ({ remaining: 0 }));
+  return { store: { debit }, debit };
+}
+
+describe("settleBudget", () => {
+  it("debits each active dimension with the actual served usage", async () => {
+    const { store, debit } = debitStore();
+    await settleBudget(
+      { store, config: CONFIG },
+      "k1",
+      caps({ requests: 1000, tokens: 500_000, spendUsd: 10, windowSeconds: 3600 }),
+      { requests: 1, tokens: 1234, costUsd: 0.42 },
+      0,
+    );
+    const windowMs = 3600 * 1000;
+    expect(debit).toHaveBeenCalledWith("k1", "req", 1000, windowMs, 1, 0);
+    expect(debit).toHaveBeenCalledWith("k1", "tok", 500_000, windowMs, 1234, 0);
+    expect(debit).toHaveBeenCalledWith("k1", "usd", 10, windowMs, 0.42, 0);
+  });
+
+  it("only touches capped dimensions (uncapped key => no debit)", async () => {
+    const { store, debit } = debitStore();
+    await settleBudget(
+      { store, config: CONFIG },
+      "k1",
+      caps({ spendUsd: 10 }),
+      { requests: 1, tokens: 999, costUsd: 0.1 },
+      0,
+    );
+    expect(debit).toHaveBeenCalledTimes(1);
+    expect(debit).toHaveBeenCalledWith("k1", "usd", 10, 86_400_000, 0.1, 0);
+  });
+
+  it("null cost (not measured) settles 0 for spend — never recomputed, never blocks", async () => {
+    const { store, debit } = debitStore();
+    await settleBudget(
+      { store, config: CONFIG },
+      "k1",
+      caps({ spendUsd: 10 }),
+      { requests: 1, tokens: 0, costUsd: null },
+      0,
+    );
+    expect(debit).toHaveBeenCalledWith("k1", "usd", 10, 86_400_000, 0, 0);
+  });
+
+  it("no caps => no-op (no store calls)", async () => {
+    const { store, debit } = debitStore();
+    await settleBudget(
+      { store, config: CONFIG },
+      "k1",
+      caps(),
+      { requests: 1, tokens: 5, costUsd: 1 },
+      0,
+    );
+    expect(debit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/budget/settle.ts
+++ b/packages/core/src/budget/settle.ts
@@ -1,0 +1,33 @@
+import type { BudgetStore } from "../store/ports.js";
+import { activeDims, windowMsFor } from "./gate.js";
+import type { BudgetCaps, BudgetConfig, BudgetUsage } from "./types.js";
+
+export interface SettleBudgetDeps {
+  store: Pick<BudgetStore, "debit">;
+  config: BudgetConfig;
+}
+
+// Post-served budget settle (fail-OPEN side; the CALLER wraps this so a store
+// failure is logged, never 5xx's a request that already completed). Debits the
+// ACTUAL served usage into each active dimension's bucket. Spend uses the SAME
+// settled cost the telemetry pipeline computed — NEVER recomputed (single source
+// of truth); a null cost ("not measured", pricing unknown) settles 0 so an
+// under-priced request is auditable rather than blocking. Only active (capped)
+// dimensions are touched, so the bucket table stays sparse for uncapped keys.
+export async function settleBudget(
+  deps: SettleBudgetDeps,
+  keyId: string,
+  caps: BudgetCaps,
+  usage: BudgetUsage,
+  nowMs: number,
+): Promise<void> {
+  const dims = activeDims(caps);
+  if (dims.length === 0) return;
+  const windowMs = windowMsFor(caps, deps.config);
+
+  for (const { dim, capacity } of dims) {
+    const amount =
+      dim === "req" ? usage.requests : dim === "tok" ? usage.tokens : (usage.costUsd ?? 0);
+    await deps.store.debit(keyId, dim, capacity, windowMs, amount, nowMs);
+  }
+}

--- a/packages/core/src/budget/types.ts
+++ b/packages/core/src/budget/types.ts
@@ -1,0 +1,44 @@
+import type { OverBudgetBehavior } from "@helm/shared";
+import type { BudgetDim } from "../store/ports.js";
+
+export type { OverBudgetBehavior };
+
+// The per-key budget caps, resolved from the key record (docs/06 "usage budgets").
+// Each cap is a number (the ceiling consumed over the rolling window) or null
+// (no cap for that dimension). windowSeconds null => the system default window.
+// degradeLane null => the system default degrade lane (economy).
+export interface BudgetCaps {
+  requests: number | null;
+  tokens: number | null;
+  spendUsd: number | null;
+  windowSeconds: number | null;
+  behavior: OverBudgetBehavior;
+  degradeLane: string | null;
+}
+
+// System-wide budget defaults (the fallbacks for a key's null window / degrade
+// lane). No global on/off switch: a key with no caps is a zero-touch fast path.
+export interface BudgetConfig {
+  defaultWindowSeconds: number;
+  defaultDegradeLane: string;
+}
+
+// One pre-route gate decision. overBudget = at least one active dimension is
+// exhausted. limitedBy = the first dimension that tripped (null when within
+// budget). behavior + degradeLane describe what the caller should DO when over
+// budget: "reject" => 429; "degrade" => cap the lane to degradeLane.
+export interface BudgetCheckResult {
+  overBudget: boolean;
+  limitedBy: BudgetDim | null;
+  behavior: OverBudgetBehavior;
+  degradeLane: string | null;
+}
+
+// The actual served usage to settle post-request. requests is normally 1.
+// costUsd null = "not measured" (pricing unknown) => settles 0 for the spend
+// dimension (NEVER recomputed; D4-style auditable under-billing).
+export interface BudgetUsage {
+  requests: number;
+  tokens: number;
+  costUsd: number | null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,19 @@ export {
   KEY_PREFIX,
 } from "./auth/keygen.js";
 export {
+  activeDims,
+  type BudgetCaps,
+  type BudgetCheckResult,
+  type BudgetConfig,
+  type BudgetGateDeps,
+  type BudgetProbe,
+  type BudgetUsage,
+  createBudgetGate,
+  type SettleBudgetDeps,
+  settleBudget,
+  windowMsFor,
+} from "./budget/index.js";
+export {
   type CapabilityRequest,
   checkCapability,
   type FilterResult,
@@ -500,6 +513,7 @@ export {
   createStore,
   InMemoryRateLimitStore,
   InMemorySignalStore,
+  PgBudgetStore,
   PgConfigStore,
   type PgDb,
   PgKeyStore,
@@ -510,6 +524,7 @@ export {
   PgTelemetryStore,
   runMigrations,
   runPgMigrations,
+  SqliteBudgetStore,
   SqliteConfigStore,
   type SqliteDb,
   SqliteKeyStore,
@@ -521,6 +536,9 @@ export {
   type StoreSet,
 } from "./store/index.js";
 export type {
+  BudgetDim,
+  BudgetPeekResult,
+  BudgetStore,
   ConfigStore,
   CreateKeyInput,
   InsertPayloadInput,

--- a/packages/core/src/ratelimit/token-bucket.test.ts
+++ b/packages/core/src/ratelimit/token-bucket.test.ts
@@ -19,6 +19,18 @@ describe("token-bucket refill", () => {
     const afterFar = refill(empty, 2, 10 * MIN);
     expect(afterFar.tokens).toBe(2);
   });
+
+  it("honors a custom window: capacity refills over windowMs, not 60s", () => {
+    // capacity 100 over a 1-day window => 100/86_400_000 tokens per ms.
+    const DAY = 86_400_000;
+    const empty: BucketState = { tokens: 0, lastRefillMs: 0 };
+    const halfDay = refill(empty, 100, DAY / 2, DAY);
+    expect(halfDay.tokens).toBeCloseTo(50, 5);
+    const full = refill(empty, 100, DAY, DAY);
+    expect(full.tokens).toBe(100);
+    // The default window stays 60s when windowMs is omitted (back-compat).
+    expect(refill(empty, 60, 60_000).tokens).toBe(60);
+  });
 });
 
 describe("token-bucket tryConsume", () => {
@@ -44,6 +56,15 @@ describe("token-bucket tryConsume", () => {
     const r = tryConsume(empty, 2, 1, 30_000);
     expect(r.ok).toBe(true);
     expect(r.remaining).toBe(0); // exactly one refilled and consumed
+  });
+
+  it("consumes against a custom window (budget-style rolling window)", () => {
+    const DAY = 86_400_000;
+    // Budget of 10 USD over a day; spend 4 from a full bucket.
+    const full: BucketState = { tokens: 10, lastRefillMs: 0 };
+    const r = tryConsume(full, 10, 4, 0, DAY);
+    expect(r.ok).toBe(true);
+    expect(r.state.tokens).toBeCloseTo(6, 5);
   });
 
   it("resetSeconds is the time to regain one whole unit", () => {

--- a/packages/core/src/ratelimit/token-bucket.ts
+++ b/packages/core/src/ratelimit/token-bucket.ts
@@ -1,36 +1,46 @@
-// Pure-function token bucket. Capacity = the quota (rpm or tpm); tokens refill
-// linearly at capacity/60s. State is immutable so a Store adapter can read,
-// transform, and write it back atomically. No clock, no I/O — `nowMs` is always
-// injected so refill/consume are deterministic and unit-testable (no real sleep).
+// Pure-function token bucket. Capacity = the quota for a window; tokens refill
+// linearly at capacity/windowMs. The window defaults to 60s (so rate limits stay
+// "per minute"), but is configurable so the SAME math backs per-key usage budgets
+// over a longer rolling window (e.g. capacity = spend cap, window = a day). State
+// is immutable so a Store adapter can read, transform, and write it back
+// atomically. No clock, no I/O — `nowMs` is always injected so refill/consume are
+// deterministic and unit-testable (no real sleep).
 
 export interface BucketState {
   tokens: number;
   lastRefillMs: number;
 }
 
-// Advance a bucket to `nowMs`, adding capacity/60000 tokens per elapsed ms,
-// clamped at `capacityPerMin`. Going backwards in time (clock skew) never
-// removes tokens. capacityPerMin <= 0 is treated as "no refill needed" by the
-// caller (unlimited dimensions skip the bucket entirely), but is handled here
-// defensively by returning the state unchanged.
-export function refill(state: BucketState, capacityPerMin: number, nowMs: number): BucketState {
-  if (capacityPerMin <= 0) return { ...state, lastRefillMs: nowMs };
+const DEFAULT_WINDOW_MS = 60_000;
+
+// Advance a bucket to `nowMs`, adding capacity/windowMs tokens per elapsed ms,
+// clamped at `capacity`. Going backwards in time (clock skew) never removes
+// tokens. capacity <= 0 is treated as "no refill needed" by the caller (unlimited
+// dimensions skip the bucket entirely), but is handled here defensively by
+// returning the state unchanged. `windowMs` defaults to 60s (rate-limit semantics).
+export function refill(
+  state: BucketState,
+  capacity: number,
+  nowMs: number,
+  windowMs: number = DEFAULT_WINDOW_MS,
+): BucketState {
+  if (capacity <= 0) return { ...state, lastRefillMs: nowMs };
   const elapsed = nowMs - state.lastRefillMs;
   if (elapsed <= 0) return state;
-  const refilled = (elapsed / 60_000) * capacityPerMin;
-  const tokens = Math.min(capacityPerMin, state.tokens + refilled);
+  const refilled = (elapsed / windowMs) * capacity;
+  const tokens = Math.min(capacity, state.tokens + refilled);
   return { tokens, lastRefillMs: nowMs };
 }
 
 // Seconds until the bucket would gain one more whole unit of capacity (used for
 // x-ratelimit-reset / retry-after). 0 when the dimension never refills. From a
 // fractional level it is the time to reach the next integer; from a whole level
-// it is the time to accrue one full unit.
-function secondsToNextUnit(tokens: number, capacityPerMin: number): number {
-  if (capacityPerMin <= 0) return 0;
+// it is the time to accrue one full unit. Refill rate is capacity per windowMs.
+function secondsToNextUnit(tokens: number, capacity: number, windowMs: number): number {
+  if (capacity <= 0) return 0;
   const frac = tokens - Math.floor(tokens);
   const need = frac === 0 ? 1 : 1 - frac; // tokens to the next integer
-  const perSecond = capacityPerMin / 60;
+  const perSecond = capacity / (windowMs / 1000);
   return Math.ceil(need / perSecond);
 }
 
@@ -46,24 +56,25 @@ export interface ConsumeResult {
 // `remaining` is floored to a whole token for header reporting.
 export function tryConsume(
   state: BucketState,
-  capacityPerMin: number,
+  capacity: number,
   cost: number,
   nowMs: number,
+  windowMs: number = DEFAULT_WINDOW_MS,
 ): ConsumeResult {
-  const refilled = refill(state, capacityPerMin, nowMs);
+  const refilled = refill(state, capacity, nowMs, windowMs);
   if (refilled.tokens >= cost) {
     const next = { tokens: refilled.tokens - cost, lastRefillMs: refilled.lastRefillMs };
     return {
       state: next,
       ok: true,
       remaining: Math.max(0, Math.floor(next.tokens)),
-      resetSeconds: secondsToNextUnit(next.tokens, capacityPerMin),
+      resetSeconds: secondsToNextUnit(next.tokens, capacity, windowMs),
     };
   }
   return {
     state: refilled,
     ok: false,
     remaining: Math.max(0, Math.floor(refilled.tokens)),
-    resetSeconds: secondsToNextUnit(refilled.tokens, capacityPerMin),
+    resetSeconds: secondsToNextUnit(refilled.tokens, capacity, windowMs),
   };
 }

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -340,25 +340,52 @@ describe("routeRequest — orchestration", () => {
     expect(plan.selected_lane).toBe("balanced");
   });
 
-  it("keyCaps.maxLane degrades an over-budget request down to the cheaper lane", async () => {
-    // A policy pins `premium`; the key is over budget so the gateway sets the
-    // dynamic degrade ceiling maxLane=economy for this request.
+  it("keyCaps.degradeLane forces an over-budget request onto the degrade lane", async () => {
+    // A policy pins `premium`; the key is over budget so the gateway sets
+    // degradeLane=economy for this request — it is FORCED onto economy.
     const d = deps({
       classify: vi.fn(async () => classification({ task_type: "chat" })),
       policies: { policies: [{ id: "pin-premium", match: {}, use_lane: "premium" }] },
     });
-    await routeRequest(req(), d, { keyCaps: { allowedLanes: null, maxLane: "economy" } });
+    await routeRequest(req(), d, { keyCaps: { allowedLanes: null, degradeLane: "economy" } });
 
     const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
     expect(plan.selected_lane).toBe("economy");
   });
 
-  it("keyCaps.maxLane null is a no-op (within budget => requested lane preserved)", async () => {
+  it("keyCaps.degradeLane forces even an UNRANKED task lane (a ceiling would no-op)", async () => {
+    // Degrade target is the unranked `coding` lane: a rank-based max_lane would do
+    // nothing, but a forced selection routes the request onto it.
     const d = deps({
       classify: vi.fn(async () => classification({ task_type: "chat" })),
       policies: { policies: [{ id: "pin-premium", match: {}, use_lane: "premium" }] },
     });
-    await routeRequest(req(), d, { keyCaps: { allowedLanes: null, maxLane: null } });
+    await routeRequest(req(), d, { keyCaps: { allowedLanes: null, degradeLane: "coding" } });
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("coding");
+  });
+
+  it("keyCaps.degradeLane overrides explicit-model passthrough (no expensive-model bypass)", async () => {
+    // An allow_custom_model key naming an explicit model is normally passed through
+    // verbatim; over budget (degradeLane set) the passthrough is suppressed and the
+    // request is forced onto the degrade lane instead.
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "gpt-4o" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: null, degradeLane: "economy" },
+    });
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.explicit_model).toBeNull(); // NOT a [gpt-4o] passthrough chain
+    expect(plan.selected_lane).toBe("economy");
+    expect(result.decision.lane.selected_lane).toBe("economy");
+  });
+
+  it("keyCaps.degradeLane null is a no-op (within budget => requested lane preserved)", async () => {
+    const d = deps({
+      classify: vi.fn(async () => classification({ task_type: "chat" })),
+      policies: { policies: [{ id: "pin-premium", match: {}, use_lane: "premium" }] },
+    });
+    await routeRequest(req(), d, { keyCaps: { allowedLanes: null, degradeLane: null } });
     const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
     expect(plan.selected_lane).toBe("premium");
   });

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -340,6 +340,29 @@ describe("routeRequest — orchestration", () => {
     expect(plan.selected_lane).toBe("balanced");
   });
 
+  it("keyCaps.maxLane degrades an over-budget request down to the cheaper lane", async () => {
+    // A policy pins `premium`; the key is over budget so the gateway sets the
+    // dynamic degrade ceiling maxLane=economy for this request.
+    const d = deps({
+      classify: vi.fn(async () => classification({ task_type: "chat" })),
+      policies: { policies: [{ id: "pin-premium", match: {}, use_lane: "premium" }] },
+    });
+    await routeRequest(req(), d, { keyCaps: { allowedLanes: null, maxLane: "economy" } });
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+  });
+
+  it("keyCaps.maxLane null is a no-op (within budget => requested lane preserved)", async () => {
+    const d = deps({
+      classify: vi.fn(async () => classification({ task_type: "chat" })),
+      policies: { policies: [{ id: "pin-premium", match: {}, use_lane: "premium" }] },
+    });
+    await routeRequest(req(), d, { keyCaps: { allowedLanes: null, maxLane: null } });
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+  });
+
   it("keyCaps undefined is a no-op (existing callers unaffected)", async () => {
     const d = deps();
     await routeRequest(req(), d);

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -123,12 +123,18 @@ export interface RouteOptions {
    *  UI key column. PREFIX ONLY — never the plaintext key (principle 7). The
    *  gateway threads it from the auth identity; null/undefined when unknown. */
   keyPrefix?: string | null;
-  /** Per-key lane whitelist from the API key's auth record (docs/04). The OUTER,
+  /** Per-key lane caps from the API key's auth record (docs/04). The OUTER,
    *  non-negotiable bound: applied LAST (after policy caps) so it wins even over
    *  a policy use_lane pin. allowedLanes null = unconstrained; keyCaps itself
    *  undefined = no-op (existing callers unaffected). The gateway handlers thread
-   *  it from the auth identity. */
-  keyCaps?: { allowedLanes: string[] | null };
+   *  it from the auth identity.
+   *
+   *  `maxLane` is the DYNAMIC degrade ceiling (docs/06 "usage budgets"): null in
+   *  the normal case, but set to the key's degrade lane (e.g. "economy") for THIS
+   *  request when the key is over its usage budget — capping a richer request down
+   *  to a cheaper lane instead of rejecting it. Reuses the same lane-ranking cap as
+   *  a policy max_lane (an unranked task lane is conservatively capped). */
+  keyCaps?: { allowedLanes: string[] | null; maxLane?: string | null };
 }
 
 // Fail-open classification default (principle 3 + 5): a degraded classifier
@@ -300,7 +306,8 @@ async function plan(
       : applyCaps(policyCappedLane, {
           matched_policy_id: null,
           use_lane: null,
-          max_lane: null,
+          // Over-budget degrade ceiling for this request (docs/06); null = no cap.
+          max_lane: opts.keyCaps.maxLane ?? null,
           allowed_lanes: opts.keyCaps.allowedLanes,
           reason: "key caps",
         });

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -129,12 +129,14 @@ export interface RouteOptions {
    *  undefined = no-op (existing callers unaffected). The gateway handlers thread
    *  it from the auth identity.
    *
-   *  `maxLane` is the DYNAMIC degrade ceiling (docs/06 "usage budgets"): null in
-   *  the normal case, but set to the key's degrade lane (e.g. "economy") for THIS
-   *  request when the key is over its usage budget — capping a richer request down
-   *  to a cheaper lane instead of rejecting it. Reuses the same lane-ranking cap as
-   *  a policy max_lane (an unranked task lane is conservatively capped). */
-  keyCaps?: { allowedLanes: string[] | null; maxLane?: string | null };
+   *  `degradeLane` is the DYNAMIC over-budget action (docs/06 "usage budgets"):
+   *  null in the normal case, but set to the key's degrade lane (e.g. "economy")
+   *  for THIS request when the key is over its usage budget. It FORCES the request
+   *  onto that lane (a forced selection, not a rank ceiling) — so it works for any
+   *  target lane (ranked OR a task lane) and cannot be bypassed by explicit-model
+   *  passthrough (passthrough is suppressed while degrading). The forced lane is
+   *  still clamped to `allowedLanes` (the harder security bound). */
+  keyCaps?: { allowedLanes: string[] | null; degradeLane?: string | null };
 }
 
 // Fail-open classification default (principle 3 + 5): a degraded classifier
@@ -254,10 +256,15 @@ async function plan(
   //    treated as an explicit model, even for an allow_custom_model key — otherwise
   //    it short-circuits classify/lane-resolve and gets sent upstream as the literal
   //    model "auto" (the llm-router #391 regression). Fall through to classify.
+  //    A key that is OVER its usage budget and set to `degrade` (opts.keyCaps.
+  //    degradeLane is populated for this request) must NOT be able to bypass the
+  //    downgrade by naming an expensive explicit model — so suppress passthrough
+  //    while degrading and fall through to the forced degrade lane below (docs/06).
   if (
     opts.allowCustomModel === true &&
     req.requested_model.length > 0 &&
-    req.requested_model !== "auto"
+    req.requested_model !== "auto" &&
+    (opts.keyCaps?.degradeLane === undefined || opts.keyCaps.degradeLane === null)
   ) {
     const model = req.requested_model;
     return {
@@ -300,17 +307,25 @@ async function plan(
   // auth record. Applied after policy caps so the key wins even over a policy
   // use_lane pin (principle 6: lanes are the user-facing abstraction; a key may
   // be confined to a subset). keyCaps undefined => no-op.
-  const cappedLane =
-    opts.keyCaps === undefined
-      ? policyCappedLane
-      : applyCaps(policyCappedLane, {
-          matched_policy_id: null,
-          use_lane: null,
-          // Over-budget degrade ceiling for this request (docs/06); null = no cap.
-          max_lane: opts.keyCaps.maxLane ?? null,
-          allowed_lanes: opts.keyCaps.allowedLanes,
-          reason: "key caps",
-        });
+  //
+  // Over-budget degrade (docs/06): when `degradeLane` is set for this request, FORCE
+  // the request onto it (a forced selection, not a rank ceiling) so it works for any
+  // target lane — ranked OR a task lane — which a `max_lane` ceiling would silently
+  // ignore. The forced lane is then clamped to the key's `allowedLanes` whitelist
+  // (the harder security bound) via applyCaps, exactly as the normal lane is.
+  let cappedLane: string;
+  if (opts.keyCaps === undefined) {
+    cappedLane = policyCappedLane;
+  } else {
+    const base = opts.keyCaps.degradeLane ?? policyCappedLane;
+    cappedLane = applyCaps(base, {
+      matched_policy_id: null,
+      use_lane: null,
+      max_lane: null,
+      allowed_lanes: opts.keyCaps.allowedLanes,
+      reason: "key caps",
+    });
+  }
   const chain = expandChain(cappedLane, deps.lanes);
 
   return {

--- a/packages/core/src/store/factory.ts
+++ b/packages/core/src/store/factory.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import type { StoreConfig } from "@helm/shared";
 import type {
+  BudgetStore,
   ConfigStore,
   KeyStore,
   MemoryStore,
@@ -9,6 +10,7 @@ import type {
   SignalStore,
   TelemetryStore,
 } from "./ports.js";
+import { PgBudgetStore } from "./postgres/budget.js";
 import { PgConfigStore } from "./postgres/config-store.js";
 import { PgKeyStore } from "./postgres/keystore.js";
 import { PgMemoryStore } from "./postgres/memory-store.js";
@@ -17,6 +19,7 @@ import { PgOAuthTokenStore } from "./postgres/oauth-tokens.js";
 import { PgRateLimitStore } from "./postgres/rate-limit.js";
 import { PgSignalStore } from "./postgres/signals.js";
 import { PgTelemetryStore } from "./postgres/telemetry.js";
+import { SqliteBudgetStore } from "./sqlite/budget.js";
 import { SqliteConfigStore } from "./sqlite/config-store.js";
 import { SqliteKeyStore } from "./sqlite/keystore.js";
 import { SqliteMemoryStore } from "./sqlite/memory-store.js";
@@ -35,6 +38,7 @@ export interface StoreSet {
   readonly telemetry: TelemetryStore;
   readonly signals: SignalStore;
   readonly rateLimit: RateLimitStore;
+  readonly budget: BudgetStore;
   readonly memory: MemoryStore;
   readonly config: ConfigStore;
   readonly oauthTokens: OAuthTokenStore;
@@ -68,6 +72,7 @@ export async function createStore(opts: CreateStoreOptions): Promise<StoreSet> {
         telemetry: new SqliteTelemetryStore(db),
         signals: new SqliteSignalStore(db),
         rateLimit: new SqliteRateLimitStore(db),
+        budget: new SqliteBudgetStore(db),
         memory: new SqliteMemoryStore(db),
         config: new SqliteConfigStore(db),
         oauthTokens: new SqliteOAuthTokenStore(db),
@@ -89,6 +94,7 @@ export async function createStore(opts: CreateStoreOptions): Promise<StoreSet> {
         telemetry: new PgTelemetryStore(db),
         signals: new PgSignalStore(db),
         rateLimit: new PgRateLimitStore(db),
+        budget: new PgBudgetStore(db),
         memory: new PgMemoryStore(db),
         config: new PgConfigStore(db),
         oauthTokens: new PgOAuthTokenStore(db),

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,5 +1,8 @@
 export { type CreateStoreOptions, createStore, type StoreSet } from "./factory.js";
 export type {
+  BudgetDim,
+  BudgetPeekResult,
+  BudgetStore,
   ConfigStore,
   CreateKeyInput,
   InsertPayloadInput,
@@ -18,6 +21,7 @@ export type {
 // Postgres (supabase) adapters + migration helpers. supabase == hosted Postgres,
 // reached via postgres-js; the same adapters run against in-process PGlite in
 // tests (drizzle pg dialect), validating the supabase path without a server.
+export { PgBudgetStore } from "./postgres/budget.js";
 export { PgConfigStore } from "./postgres/config-store.js";
 export { PgKeyStore } from "./postgres/keystore.js";
 export { PgMemoryStore } from "./postgres/memory-store.js";
@@ -31,6 +35,7 @@ export { PgOAuthTokenStore } from "./postgres/oauth-tokens.js";
 export { PgRateLimitStore } from "./postgres/rate-limit.js";
 export { PgSignalStore } from "./postgres/signals.js";
 export { PgTelemetryStore } from "./postgres/telemetry.js";
+export { SqliteBudgetStore } from "./sqlite/budget.js";
 export { SqliteConfigStore } from "./sqlite/config-store.js";
 export { SqliteKeyStore } from "./sqlite/keystore.js";
 export { SqliteMemoryStore } from "./sqlite/memory-store.js";

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -67,7 +67,8 @@ class InMemoryKeyStore implements KeyStore {
     if (patch.budgetSpendUsd !== undefined) next.budget_spend_usd = patch.budgetSpendUsd;
     if (patch.budgetWindowSeconds !== undefined)
       next.budget_window_seconds = patch.budgetWindowSeconds;
-    if (patch.overBudgetBehavior !== undefined) next.over_budget_behavior = patch.overBudgetBehavior;
+    if (patch.overBudgetBehavior !== undefined)
+      next.over_budget_behavior = patch.overBudgetBehavior;
     if (patch.degradeLane !== undefined) next.degrade_lane = patch.degradeLane;
     this.byId.set(keyId, next);
   }

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -31,6 +31,12 @@ class InMemoryKeyStore implements KeyStore {
       disabled: false,
       rate_limit_rpm: input.rateLimitRpm ?? null,
       rate_limit_tpm: input.rateLimitTpm ?? null,
+      budget_requests: input.budgetRequests ?? null,
+      budget_tokens: input.budgetTokens ?? null,
+      budget_spend_usd: input.budgetSpendUsd ?? null,
+      budget_window_seconds: input.budgetWindowSeconds ?? null,
+      over_budget_behavior: input.overBudgetBehavior ?? "degrade",
+      degrade_lane: input.degradeLane ?? null,
     };
     this.byId.set(record.key_id, record);
     return record;
@@ -56,6 +62,13 @@ class InMemoryKeyStore implements KeyStore {
     if (patch.allowCustomModel !== undefined) next.allow_custom_model = patch.allowCustomModel;
     if (patch.rateLimitRpm !== undefined) next.rate_limit_rpm = patch.rateLimitRpm;
     if (patch.rateLimitTpm !== undefined) next.rate_limit_tpm = patch.rateLimitTpm;
+    if (patch.budgetRequests !== undefined) next.budget_requests = patch.budgetRequests;
+    if (patch.budgetTokens !== undefined) next.budget_tokens = patch.budgetTokens;
+    if (patch.budgetSpendUsd !== undefined) next.budget_spend_usd = patch.budgetSpendUsd;
+    if (patch.budgetWindowSeconds !== undefined)
+      next.budget_window_seconds = patch.budgetWindowSeconds;
+    if (patch.overBudgetBehavior !== undefined) next.over_budget_behavior = patch.overBudgetBehavior;
+    if (patch.degradeLane !== undefined) next.degrade_lane = patch.degradeLane;
     this.byId.set(keyId, next);
   }
 }
@@ -181,6 +194,12 @@ describe("port type contracts", () => {
       | "allowCustomModel"
       | "rateLimitRpm"
       | "rateLimitTpm"
+      | "budgetRequests"
+      | "budgetTokens"
+      | "budgetSpendUsd"
+      | "budgetWindowSeconds"
+      | "overBudgetBehavior"
+      | "degradeLane"
     >();
   });
 

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -45,6 +45,48 @@ export interface RateLimitStore {
   ): Promise<RateLimitConsumeResult>;
 }
 
+// Per-key usage-budget dimension (docs/06 "usage budgets"). req = request count,
+// tok = total tokens, usd = spend. One token-bucket row per (keyId, dim) in
+// `usage_budget_buckets` — same shape as rate_limit_buckets but with a CONFIGURABLE
+// rolling window (windowMs) instead of the fixed 60s.
+export type BudgetDim = "req" | "tok" | "usd";
+
+export interface BudgetPeekResult {
+  remaining: number; // refilled tokens left in the window (NOT persisted by peek)
+  ok: boolean; // remaining > 0 — the pre-route sign check
+}
+
+// Persistence for the per-key usage-budget buckets. UNLIKE the rate limiter, the
+// budget gate is fail-OPEN at settle (a served request is never 5xx'd over a
+// settle failure) but fail-CLOSED at peek (a read error propagates so the gate is
+// never silently bypassed — same boundary as RateLimitStore). The bucket starts
+// FULL (= capacity) so a fresh key has its whole budget; debits deplete it and may
+// push it NEGATIVE (a budget is a soft cap settled post-served, not a hard
+// reservation — D5-style tolerance). key_id only; never a plaintext key (principle 7).
+export interface BudgetStore {
+  // Pre-route sign check: refill (in memory) and read remaining for one
+  // (keyId, dim). READ-ONLY — never writes (the refilled state is persisted by the
+  // next debit). A cold bucket reads as FULL (capacity).
+  peek(
+    keyId: string,
+    dim: BudgetDim,
+    capacity: number,
+    windowMs: number,
+    nowMs: number,
+  ): Promise<BudgetPeekResult>;
+  // Post-served settle: atomically refill + subtract `amount` from the (keyId, dim)
+  // bucket and persist. ALWAYS debits (may go negative — soft cap). Returns the new
+  // remaining. amount 0 is a no-op debit (advances refill only).
+  debit(
+    keyId: string,
+    dim: BudgetDim,
+    capacity: number,
+    windowMs: number,
+    amount: number,
+    nowMs: number,
+  ): Promise<{ remaining: number }>;
+}
+
 // Store ports (repository pattern). core depends ONLY on these interfaces; the
 // sqlite and supabase adapters each implement the same contract. This file is
 // pure types — no SQL, no Drizzle import, no web framework. All structured data
@@ -64,6 +106,14 @@ export interface CreateKeyInput {
   // system default at check time. 0 => explicitly unlimited for that dimension.
   rateLimitRpm?: number;
   rateLimitTpm?: number;
+  // Per-key usage budgets (docs/06). Omitted => stored NULL => no cap for that
+  // dimension. overBudgetBehavior omitted => stored default ("degrade").
+  budgetRequests?: number;
+  budgetTokens?: number;
+  budgetSpendUsd?: number;
+  budgetWindowSeconds?: number;
+  overBudgetBehavior?: "degrade" | "reject";
+  degradeLane?: string;
 }
 
 export interface KeyStore {
@@ -96,6 +146,14 @@ export interface KeyPatch {
   allowCustomModel?: boolean;
   rateLimitRpm?: number | null;
   rateLimitTpm?: number | null;
+  // Budget edits: present (even null) => written; null clears the cap (no cap).
+  // overBudgetBehavior has no null (always resolves to degrade|reject).
+  budgetRequests?: number | null;
+  budgetTokens?: number | null;
+  budgetSpendUsd?: number | null;
+  budgetWindowSeconds?: number | null;
+  overBudgetBehavior?: "degrade" | "reject";
+  degradeLane?: string | null;
 }
 
 // Telemetry insert input: decision record + a redacted key reference. Never

--- a/packages/core/src/store/postgres/budget.test.ts
+++ b/packages/core/src/store/postgres/budget.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { PgBudgetStore } from "./budget.js";
+import { createPgliteDb, type PgDb } from "./migrate.js";
+
+const DAY = 86_400_000;
+
+async function freshStore(): Promise<{ store: PgBudgetStore; db: PgDb }> {
+  const db = await createPgliteDb();
+  return { store: new PgBudgetStore(db), db };
+}
+
+describe("PgBudgetStore", () => {
+  it("peek on a cold bucket reads FULL capacity", async () => {
+    const { store, db } = await freshStore();
+    const r = await store.peek("k1", "usd", 10, DAY, 0);
+    expect(r.remaining).toBe(10);
+    expect(r.ok).toBe(true);
+    await db.$close();
+  });
+
+  it("debit subtracts the settled amount and persists; peek reflects it", async () => {
+    const { store, db } = await freshStore();
+    await store.debit("k1", "usd", 10, DAY, 4, 0);
+    const r = await store.peek("k1", "usd", 10, DAY, 0);
+    expect(r.remaining).toBeCloseTo(6, 5);
+    await db.$close();
+  });
+
+  it("debit may go NEGATIVE (soft cap)", async () => {
+    const { store, db } = await freshStore();
+    const r = await store.debit("k1", "usd", 10, DAY, 12, 0);
+    expect(r.remaining).toBeCloseTo(-2, 5);
+    expect((await store.peek("k1", "usd", 10, DAY, 0)).ok).toBe(false);
+    await db.$close();
+  });
+
+  it("refills over the configured window", async () => {
+    const { store, db } = await freshStore();
+    await store.debit("k1", "tok", 100, DAY, 100, 0);
+    expect((await store.peek("k1", "tok", 100, DAY, DAY / 2)).remaining).toBeCloseTo(50, 5);
+    await db.$close();
+  });
+
+  it("concurrent debits on the same bucket do not lose an update (FOR UPDATE)", async () => {
+    const { store, db } = await freshStore();
+    await Promise.all([
+      store.debit("k1", "req", 100, DAY, 10, 0),
+      store.debit("k1", "req", 100, DAY, 10, 0),
+      store.debit("k1", "req", 100, DAY, 10, 0),
+    ]);
+    const r = await store.peek("k1", "req", 100, DAY, 0);
+    expect(r.remaining).toBeCloseTo(70, 5); // 100 - 3*10, none lost
+    await db.$close();
+  });
+});

--- a/packages/core/src/store/postgres/budget.ts
+++ b/packages/core/src/store/postgres/budget.ts
@@ -1,0 +1,76 @@
+import { and, eq, sql } from "drizzle-orm";
+import { type BucketState, refill } from "../../ratelimit/token-bucket.js";
+import type { BudgetDim, BudgetPeekResult, BudgetStore } from "../ports.js";
+import type { PgDb } from "./migrate.js";
+import { usageBudgetBuckets } from "./schema.js";
+
+// Postgres adapter for BudgetStore (docs/06 "usage budgets") — the supabase
+// implementation. `peek` (pre-route sign check) is READ-ONLY. `debit` (post-served
+// settle) runs the read-modify-write inside a transaction with `SELECT ... FOR
+// UPDATE` row locking so two concurrent settles on the same (key_id, dim) serialize
+// and never lose an update. A debit ALWAYS applies (may go negative — soft cap
+// settled after the request, not a hard reservation). key_id only (principle 7).
+export class PgBudgetStore implements BudgetStore {
+  constructor(private readonly db: PgDb) {}
+
+  async peek(
+    keyId: string,
+    dim: BudgetDim,
+    capacity: number,
+    windowMs: number,
+    nowMs: number,
+  ): Promise<BudgetPeekResult> {
+    const rows = await this.db
+      .select()
+      .from(usageBudgetBuckets)
+      .where(and(eq(usageBudgetBuckets.keyId, keyId), eq(usageBudgetBuckets.dim, dim)))
+      .limit(1);
+    const row = rows[0];
+
+    const current: BucketState = row
+      ? { tokens: row.tokens, lastRefillMs: row.lastRefillMs }
+      : { tokens: capacity, lastRefillMs: nowMs };
+    const remaining = refill(current, capacity, nowMs, windowMs).tokens;
+    return { remaining, ok: remaining > 0 };
+  }
+
+  async debit(
+    keyId: string,
+    dim: BudgetDim,
+    capacity: number,
+    windowMs: number,
+    amount: number,
+    nowMs: number,
+  ): Promise<{ remaining: number }> {
+    const where = and(eq(usageBudgetBuckets.keyId, keyId), eq(usageBudgetBuckets.dim, dim));
+
+    return this.db.transaction(async (tx): Promise<{ remaining: number }> => {
+      // Seed a FULL bucket FIRST (no-op if present) so the FOR UPDATE below always
+      // locks an existing row — otherwise two cold concurrent settles would both
+      // seed + debit a full bucket (a lost update).
+      await tx
+        .insert(usageBudgetBuckets)
+        .values({ keyId, dim, tokens: capacity, lastRefillMs: nowMs })
+        .onConflictDoNothing({ target: [usageBudgetBuckets.keyId, usageBudgetBuckets.dim] });
+
+      const rows = await tx.select().from(usageBudgetBuckets).where(where).limit(1).for("update");
+      const row = rows[0];
+      const current: BucketState = row
+        ? { tokens: row.tokens, lastRefillMs: row.lastRefillMs }
+        : { tokens: capacity, lastRefillMs: nowMs };
+
+      const refilled = refill(current, capacity, nowMs, windowMs);
+      const tokens = refilled.tokens - amount;
+
+      await tx
+        .insert(usageBudgetBuckets)
+        .values({ keyId, dim, tokens, lastRefillMs: refilled.lastRefillMs })
+        .onConflictDoUpdate({
+          target: [usageBudgetBuckets.keyId, usageBudgetBuckets.dim],
+          set: { tokens: sql`excluded.tokens`, lastRefillMs: sql`excluded.last_refill_ms` },
+        });
+
+      return { remaining: tokens };
+    });
+  }
+}

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -94,7 +94,8 @@ export class PgKeyStore implements KeyStore {
     if (patch.budgetRequests !== undefined) set.budgetRequests = patch.budgetRequests;
     if (patch.budgetTokens !== undefined) set.budgetTokens = patch.budgetTokens;
     if (patch.budgetSpendUsd !== undefined) set.budgetSpendUsd = patch.budgetSpendUsd;
-    if (patch.budgetWindowSeconds !== undefined) set.budgetWindowSeconds = patch.budgetWindowSeconds;
+    if (patch.budgetWindowSeconds !== undefined)
+      set.budgetWindowSeconds = patch.budgetWindowSeconds;
     if (patch.overBudgetBehavior !== undefined) set.overBudgetBehavior = patch.overBudgetBehavior;
     if (patch.degradeLane !== undefined) set.degradeLane = patch.degradeLane;
     if (Object.keys(set).length === 0) {

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -31,6 +31,13 @@ export class PgKeyStore implements KeyStore {
       // Per-key rate-limit override: undefined input => NULL => inherit system default.
       rateLimitRpm: input.rateLimitRpm ?? null,
       rateLimitTpm: input.rateLimitTpm ?? null,
+      // Per-key usage budgets: undefined => NULL => no cap. behavior defaults to degrade.
+      budgetRequests: input.budgetRequests ?? null,
+      budgetTokens: input.budgetTokens ?? null,
+      budgetSpendUsd: input.budgetSpendUsd ?? null,
+      budgetWindowSeconds: input.budgetWindowSeconds ?? null,
+      overBudgetBehavior: input.overBudgetBehavior ?? "degrade",
+      degradeLane: input.degradeLane ?? null,
       createdAt: this.now().getTime(),
     };
     await this.db.insert(apiKeys).values(row);
@@ -65,13 +72,31 @@ export class PgKeyStore implements KeyStore {
   // NEVER touches role or the immutable identity. Throws on unknown id.
   async updateKey(keyId: string, patch: KeyPatch): Promise<void> {
     const set: Partial<
-      Pick<ApiKeyRow, "allowedLanes" | "allowCustomModel" | "rateLimitRpm" | "rateLimitTpm">
+      Pick<
+        ApiKeyRow,
+        | "allowedLanes"
+        | "allowCustomModel"
+        | "rateLimitRpm"
+        | "rateLimitTpm"
+        | "budgetRequests"
+        | "budgetTokens"
+        | "budgetSpendUsd"
+        | "budgetWindowSeconds"
+        | "overBudgetBehavior"
+        | "degradeLane"
+      >
     > = {};
     // Native jsonb: assign the array (or null = no cap) directly, no stringify.
     if (patch.allowedLanes !== undefined) set.allowedLanes = patch.allowedLanes;
     if (patch.allowCustomModel !== undefined) set.allowCustomModel = patch.allowCustomModel;
     if (patch.rateLimitRpm !== undefined) set.rateLimitRpm = patch.rateLimitRpm;
     if (patch.rateLimitTpm !== undefined) set.rateLimitTpm = patch.rateLimitTpm;
+    if (patch.budgetRequests !== undefined) set.budgetRequests = patch.budgetRequests;
+    if (patch.budgetTokens !== undefined) set.budgetTokens = patch.budgetTokens;
+    if (patch.budgetSpendUsd !== undefined) set.budgetSpendUsd = patch.budgetSpendUsd;
+    if (patch.budgetWindowSeconds !== undefined) set.budgetWindowSeconds = patch.budgetWindowSeconds;
+    if (patch.overBudgetBehavior !== undefined) set.overBudgetBehavior = patch.overBudgetBehavior;
+    if (patch.degradeLane !== undefined) set.degradeLane = patch.degradeLane;
     if (Object.keys(set).length === 0) {
       // No-op patch: still verify the key exists (fail-loud on unknown id).
       const rows = await this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).limit(1);
@@ -98,6 +123,12 @@ export class PgKeyStore implements KeyStore {
       disabled: row.disabled,
       rate_limit_rpm: row.rateLimitRpm ?? null,
       rate_limit_tpm: row.rateLimitTpm ?? null,
+      budget_requests: row.budgetRequests ?? null,
+      budget_tokens: row.budgetTokens ?? null,
+      budget_spend_usd: row.budgetSpendUsd ?? null,
+      budget_window_seconds: row.budgetWindowSeconds ?? null,
+      over_budget_behavior: row.overBudgetBehavior === "reject" ? "reject" : "degrade",
+      degrade_lane: row.degradeLane ?? null,
     };
   }
 }

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -221,6 +221,29 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE api_keys DROP COLUMN IF EXISTS max_lane;
     `,
   },
+  {
+    // Per-key USAGE BUDGETS (docs/06) — pg mirror of the sqlite v11 migration. Six
+    // budget config columns on api_keys (IF NOT EXISTS = idempotent) + the
+    // usage_budget_buckets counter table. Spend is DOUBLE PRECISION; tokens double
+    // precision (may go negative — soft cap settled post-served). key_id only.
+    version: 10,
+    sql: `
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_requests INTEGER;
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_tokens INTEGER;
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_spend_usd DOUBLE PRECISION;
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_window_seconds INTEGER;
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS over_budget_behavior TEXT NOT NULL DEFAULT 'degrade';
+      ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS degrade_lane TEXT;
+
+      CREATE TABLE IF NOT EXISTS usage_budget_buckets (
+        key_id TEXT NOT NULL,
+        dim TEXT NOT NULL,
+        tokens DOUBLE PRECISION NOT NULL,
+        last_refill_ms BIGINT NOT NULL,
+        PRIMARY KEY (key_id, dim)
+      );
+    `,
+  },
 ];
 
 // Anything that can run a raw SQL string against the Postgres connection. Both

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -32,6 +32,14 @@ export const apiKeys = pgTable("api_keys", {
   // default at check time; a value (0 = unlimited) overrides that one dimension.
   rateLimitRpm: integer("rate_limit_rpm"),
   rateLimitTpm: integer("rate_limit_tpm"),
+  // Per-key usage budgets (docs/06). NULL = no cap. Spend is double precision
+  // (fractional USD). over_budget_behavior text enum defaulting to 'degrade'.
+  budgetRequests: integer("budget_requests"),
+  budgetTokens: integer("budget_tokens"),
+  budgetSpendUsd: doublePrecision("budget_spend_usd"),
+  budgetWindowSeconds: integer("budget_window_seconds"),
+  overBudgetBehavior: text("over_budget_behavior").notNull().default("degrade"),
+  degradeLane: text("degrade_lane"),
   createdAt: bigint("created_at", { mode: "number" }).notNull(), // epoch ms
 });
 
@@ -54,6 +62,21 @@ export const rateLimitBuckets = pgTable(
   {
     keyId: text("key_id").notNull(), // key_id — never plaintext
     dim: text("dim").notNull(), // 'rpm' | 'tpm'
+    tokens: doublePrecision("tokens").notNull(),
+    lastRefillMs: bigint("last_refill_ms", { mode: "number" }).notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.keyId, t.dim] })],
+);
+
+// Per-key USAGE-BUDGET token buckets (docs/06 "usage budgets") — pg mirror of the
+// sqlite usage_budget_buckets table. Configurable rolling window; exceeding a
+// budget DEGRADES rather than rejects. One row per (key_id, dim ∈ req|tok|usd).
+// tokens double precision (fractional, may go negative — soft cap). key_id only.
+export const usageBudgetBuckets = pgTable(
+  "usage_budget_buckets",
+  {
+    keyId: text("key_id").notNull(),
+    dim: text("dim").notNull(), // 'req' | 'tok' | 'usd'
     tokens: doublePrecision("tokens").notNull(),
     lastRefillMs: bigint("last_refill_ms", { mode: "number" }).notNull(),
   },
@@ -176,6 +199,7 @@ export const oauthTokens = pgTable(
 export type ApiKeysTable = typeof apiKeys;
 export type TelemetryTable = typeof telemetry;
 export type RateLimitBucketsTable = typeof rateLimitBuckets;
+export type UsageBudgetBucketsTable = typeof usageBudgetBuckets;
 export type RoutingSignalsTable = typeof routingSignals;
 export type MemoryThreadsTable = typeof memoryThreads;
 export type MemoryMessagesTable = typeof memoryMessages;

--- a/packages/core/src/store/sqlite/budget.test.ts
+++ b/packages/core/src/store/sqlite/budget.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { SqliteBudgetStore } from "./budget.js";
+import { createSqliteDb, type SqliteDb } from "./migrate.js";
+
+const DAY = 86_400_000;
+
+function freshStore(): { store: SqliteBudgetStore; close: () => void } {
+  const db: SqliteDb = createSqliteDb(":memory:");
+  return { store: new SqliteBudgetStore(db), close: () => db.$sqlite.close() };
+}
+
+describe("SqliteBudgetStore", () => {
+  it("peek on a cold bucket reads FULL capacity (the key has its whole budget)", async () => {
+    const { store, close } = freshStore();
+    const r = await store.peek("k1", "usd", 10, DAY, 0);
+    expect(r.remaining).toBe(10);
+    expect(r.ok).toBe(true);
+    close();
+  });
+
+  it("peek is READ-ONLY (does not persist a refill / debit)", async () => {
+    const { store, close } = freshStore();
+    await store.peek("k1", "req", 5, DAY, 0);
+    // A subsequent debit still starts from the full bucket (peek wrote nothing).
+    const r = await store.debit("k1", "req", 5, DAY, 1, 0);
+    expect(r.remaining).toBe(4);
+    close();
+  });
+
+  it("debit subtracts the settled amount and persists", async () => {
+    const { store, close } = freshStore();
+    await store.debit("k1", "usd", 10, DAY, 4, 0);
+    const r = await store.peek("k1", "usd", 10, DAY, 0);
+    expect(r.remaining).toBeCloseTo(6, 5);
+    expect(r.ok).toBe(true);
+    close();
+  });
+
+  it("debit may push the bucket NEGATIVE (soft cap, settled post-served)", async () => {
+    const { store, close } = freshStore();
+    // Spend 12 against a 10 cap in one settle — over budget by 2.
+    const r = await store.debit("k1", "usd", 10, DAY, 12, 0);
+    expect(r.remaining).toBeCloseTo(-2, 5);
+    const peek = await store.peek("k1", "usd", 10, DAY, 0);
+    expect(peek.ok).toBe(false); // remaining <= 0 => over budget
+    close();
+  });
+
+  it("refills over the configured window (rolling, no hard reset)", async () => {
+    const { store, close } = freshStore();
+    await store.debit("k1", "usd", 10, DAY, 10, 0); // empty at t=0
+    expect((await store.peek("k1", "usd", 10, DAY, 0)).remaining).toBeCloseTo(0, 5);
+    // Half a day later, half the budget has refilled.
+    expect((await store.peek("k1", "usd", 10, DAY, DAY / 2)).remaining).toBeCloseTo(5, 5);
+    close();
+  });
+
+  it("two sequential debits accumulate atomically (no lost update)", async () => {
+    const { store, close } = freshStore();
+    await store.debit("k1", "tok", 100, DAY, 30, 0);
+    const r = await store.debit("k1", "tok", 100, DAY, 30, 0);
+    expect(r.remaining).toBeCloseTo(40, 5);
+    close();
+  });
+});

--- a/packages/core/src/store/sqlite/budget.ts
+++ b/packages/core/src/store/sqlite/budget.ts
@@ -1,0 +1,77 @@
+import { and, eq } from "drizzle-orm";
+import { type BucketState, refill } from "../../ratelimit/token-bucket.js";
+import type { BudgetDim, BudgetPeekResult, BudgetStore } from "../ports.js";
+import type { SqliteDb } from "./migrate.js";
+import { usageBudgetBuckets } from "./schema.js";
+
+// SQLite adapter for BudgetStore (docs/06 "usage budgets"). Reuses the pure
+// token-bucket refill math with a CONFIGURABLE window. `peek` is READ-ONLY (the
+// pre-route sign check), so it computes the refilled level without writing. `debit`
+// (post-served settle) runs the read-modify-write inside a better-sqlite3
+// transaction — synchronous, single tick, no interleaving — so two concurrent
+// settles on the same (key_id, dim) cannot lose an update. Unlike the rate limiter,
+// a debit ALWAYS applies (may push tokens negative): a budget is a soft cap settled
+// after the request, not a hard pre-reservation. key_id only (principle 7).
+export class SqliteBudgetStore implements BudgetStore {
+  constructor(private readonly db: SqliteDb) {}
+
+  async peek(
+    keyId: string,
+    dim: BudgetDim,
+    capacity: number,
+    windowMs: number,
+    nowMs: number,
+  ): Promise<BudgetPeekResult> {
+    const row = this.db
+      .select()
+      .from(usageBudgetBuckets)
+      .where(and(eq(usageBudgetBuckets.keyId, keyId), eq(usageBudgetBuckets.dim, dim)))
+      .get() as { tokens: number; lastRefillMs: number } | undefined;
+
+    // A cold bucket reads as FULL (the key has its whole budget available).
+    const current: BucketState = row
+      ? { tokens: row.tokens, lastRefillMs: row.lastRefillMs }
+      : { tokens: capacity, lastRefillMs: nowMs };
+    const remaining = refill(current, capacity, nowMs, windowMs).tokens;
+    return { remaining, ok: remaining > 0 };
+  }
+
+  async debit(
+    keyId: string,
+    dim: BudgetDim,
+    capacity: number,
+    windowMs: number,
+    amount: number,
+    nowMs: number,
+  ): Promise<{ remaining: number }> {
+    const where = and(eq(usageBudgetBuckets.keyId, keyId), eq(usageBudgetBuckets.dim, dim));
+
+    const txn = this.db.$sqlite.transaction((): { remaining: number } => {
+      const row = this.db.select().from(usageBudgetBuckets).where(where).get() as
+        | { tokens: number; lastRefillMs: number }
+        | undefined;
+
+      const current: BucketState = row
+        ? { tokens: row.tokens, lastRefillMs: row.lastRefillMs }
+        : { tokens: capacity, lastRefillMs: nowMs };
+
+      // Refill to now, then subtract the settled amount. NO floor at 0 — a budget
+      // is a soft cap, so over-spend pushes the bucket negative until it refills.
+      const refilled = refill(current, capacity, nowMs, windowMs);
+      const tokens = refilled.tokens - amount;
+
+      this.db
+        .insert(usageBudgetBuckets)
+        .values({ keyId, dim, tokens, lastRefillMs: refilled.lastRefillMs })
+        .onConflictDoUpdate({
+          target: [usageBudgetBuckets.keyId, usageBudgetBuckets.dim],
+          set: { tokens, lastRefillMs: refilled.lastRefillMs },
+        })
+        .run();
+
+      return { remaining: tokens };
+    });
+
+    return txn();
+  }
+}

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -30,6 +30,13 @@ export class SqliteKeyStore implements KeyStore {
       // Per-key rate-limit override: undefined input => NULL => inherit system default.
       rateLimitRpm: input.rateLimitRpm ?? null,
       rateLimitTpm: input.rateLimitTpm ?? null,
+      // Per-key usage budgets: undefined => NULL => no cap. behavior defaults to degrade.
+      budgetRequests: input.budgetRequests ?? null,
+      budgetTokens: input.budgetTokens ?? null,
+      budgetSpendUsd: input.budgetSpendUsd ?? null,
+      budgetWindowSeconds: input.budgetWindowSeconds ?? null,
+      overBudgetBehavior: input.overBudgetBehavior ?? "degrade",
+      degradeLane: input.degradeLane ?? null,
       createdAt: this.now(),
     };
     this.db.insert(apiKeys).values(row).run();
@@ -66,7 +73,19 @@ export class SqliteKeyStore implements KeyStore {
   // NEVER touches role or the immutable identity. Throws on unknown id.
   async updateKey(keyId: string, patch: KeyPatch): Promise<void> {
     const set: Partial<
-      Pick<ApiKeyRow, "allowedLanes" | "allowCustomModel" | "rateLimitRpm" | "rateLimitTpm">
+      Pick<
+        ApiKeyRow,
+        | "allowedLanes"
+        | "allowCustomModel"
+        | "rateLimitRpm"
+        | "rateLimitTpm"
+        | "budgetRequests"
+        | "budgetTokens"
+        | "budgetSpendUsd"
+        | "budgetWindowSeconds"
+        | "overBudgetBehavior"
+        | "degradeLane"
+      >
     > = {};
     // SQLite has no native array: store the whitelist as JSON text (null = no cap).
     if (patch.allowedLanes !== undefined) {
@@ -75,6 +94,12 @@ export class SqliteKeyStore implements KeyStore {
     if (patch.allowCustomModel !== undefined) set.allowCustomModel = patch.allowCustomModel;
     if (patch.rateLimitRpm !== undefined) set.rateLimitRpm = patch.rateLimitRpm;
     if (patch.rateLimitTpm !== undefined) set.rateLimitTpm = patch.rateLimitTpm;
+    if (patch.budgetRequests !== undefined) set.budgetRequests = patch.budgetRequests;
+    if (patch.budgetTokens !== undefined) set.budgetTokens = patch.budgetTokens;
+    if (patch.budgetSpendUsd !== undefined) set.budgetSpendUsd = patch.budgetSpendUsd;
+    if (patch.budgetWindowSeconds !== undefined) set.budgetWindowSeconds = patch.budgetWindowSeconds;
+    if (patch.overBudgetBehavior !== undefined) set.overBudgetBehavior = patch.overBudgetBehavior;
+    if (patch.degradeLane !== undefined) set.degradeLane = patch.degradeLane;
     if (Object.keys(set).length === 0) {
       // No-op patch: still verify the key exists (fail-loud on unknown id).
       const row = this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).get();
@@ -100,6 +125,12 @@ export class SqliteKeyStore implements KeyStore {
       disabled: row.disabled,
       rate_limit_rpm: row.rateLimitRpm ?? null,
       rate_limit_tpm: row.rateLimitTpm ?? null,
+      budget_requests: row.budgetRequests ?? null,
+      budget_tokens: row.budgetTokens ?? null,
+      budget_spend_usd: row.budgetSpendUsd ?? null,
+      budget_window_seconds: row.budgetWindowSeconds ?? null,
+      over_budget_behavior: row.overBudgetBehavior === "reject" ? "reject" : "degrade",
+      degrade_lane: row.degradeLane ?? null,
     };
   }
 }

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -97,7 +97,8 @@ export class SqliteKeyStore implements KeyStore {
     if (patch.budgetRequests !== undefined) set.budgetRequests = patch.budgetRequests;
     if (patch.budgetTokens !== undefined) set.budgetTokens = patch.budgetTokens;
     if (patch.budgetSpendUsd !== undefined) set.budgetSpendUsd = patch.budgetSpendUsd;
-    if (patch.budgetWindowSeconds !== undefined) set.budgetWindowSeconds = patch.budgetWindowSeconds;
+    if (patch.budgetWindowSeconds !== undefined)
+      set.budgetWindowSeconds = patch.budgetWindowSeconds;
     if (patch.overBudgetBehavior !== undefined) set.overBudgetBehavior = patch.overBudgetBehavior;
     if (patch.degradeLane !== undefined) set.degradeLane = patch.degradeLane;
     if (Object.keys(set).length === 0) {

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -262,6 +262,31 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE api_keys DROP COLUMN max_lane;
     `,
   },
+  {
+    // Per-key USAGE BUDGETS (docs/06 "usage budgets"). Additive — existing rows get
+    // NULL caps (= no budget) + over_budget_behavior 'degrade'. Two parts: (a) six
+    // budget config columns on api_keys; (b) the usage_budget_buckets counter table
+    // (rolling token buckets, one row per key_id+dim, mirrors rate_limit_buckets but
+    // with a configurable window). tokens REAL so fractional spend/refill survive;
+    // may go negative (soft cap settled post-served). key_id only (principle 7).
+    version: 11,
+    sql: `
+      ALTER TABLE api_keys ADD COLUMN budget_requests INTEGER;
+      ALTER TABLE api_keys ADD COLUMN budget_tokens INTEGER;
+      ALTER TABLE api_keys ADD COLUMN budget_spend_usd REAL;
+      ALTER TABLE api_keys ADD COLUMN budget_window_seconds INTEGER;
+      ALTER TABLE api_keys ADD COLUMN over_budget_behavior TEXT NOT NULL DEFAULT 'degrade';
+      ALTER TABLE api_keys ADD COLUMN degrade_lane TEXT;
+
+      CREATE TABLE IF NOT EXISTS usage_budget_buckets (
+        key_id TEXT NOT NULL,
+        dim TEXT NOT NULL,
+        tokens REAL NOT NULL,
+        last_refill_ms INTEGER NOT NULL,
+        PRIMARY KEY (key_id, dim)
+      );
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database): void {

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -21,6 +21,16 @@ export const apiKeys = sqliteTable("api_keys", {
   // default at check time; a value (0 = unlimited) overrides that one dimension.
   rateLimitRpm: integer("rate_limit_rpm"),
   rateLimitTpm: integer("rate_limit_tpm"),
+  // Per-key usage budgets (docs/06). NULL = no cap for that dimension. Spend is
+  // REAL (fractional USD, mirrors pg double precision). over_budget_behavior is a
+  // text enum ('degrade' | 'reject') defaulting to 'degrade'; degrade_lane NULL =
+  // 'economy' at use. window NULL = the system default window.
+  budgetRequests: integer("budget_requests"),
+  budgetTokens: integer("budget_tokens"),
+  budgetSpendUsd: real("budget_spend_usd"),
+  budgetWindowSeconds: integer("budget_window_seconds"),
+  overBudgetBehavior: text("over_budget_behavior").notNull().default("degrade"),
+  degradeLane: text("degrade_lane"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
 });
 
@@ -48,6 +58,22 @@ export const rateLimitBuckets = sqliteTable(
   },
   // Composite PK mirrors pg + the hand-written migrate DDL; the onConflict upsert
   // target relies on it (the migration declares it, this makes Drizzle agree).
+  (t) => [primaryKey({ columns: [t.keyId, t.dim] })],
+);
+
+// Per-key USAGE-BUDGET token buckets (docs/06 "usage budgets"). Same shape as
+// rate_limit_buckets but a SEPARATE table: budgets refill over a CONFIGURABLE
+// rolling window (not the fixed 60s) and exceeding one DEGRADES rather than
+// rejects. One row per (key_id, dim ∈ req|tok|usd). tokens REAL so fractional
+// spend/refill survive reads; may go negative (soft cap settled post-served).
+export const usageBudgetBuckets = sqliteTable(
+  "usage_budget_buckets",
+  {
+    keyId: text("key_id").notNull(), // key_id — never plaintext
+    dim: text("dim").notNull(), // 'req' | 'tok' | 'usd'
+    tokens: real("tokens").notNull(),
+    lastRefillMs: integer("last_refill_ms").notNull(),
+  },
   (t) => [primaryKey({ columns: [t.keyId, t.dim] })],
 );
 
@@ -122,6 +148,7 @@ export const oauthTokens = sqliteTable(
 export type ApiKeysTable = typeof apiKeys;
 export type TelemetryTable = typeof telemetry;
 export type RateLimitBucketsTable = typeof rateLimitBuckets;
+export type UsageBudgetBucketsTable = typeof usageBudgetBuckets;
 export type RoutingSignalsTable = typeof routingSignals;
 export type ConfigKvTable = typeof configKv;
 export type RequestPayloadsTable = typeof requestPayloads;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -166,6 +166,8 @@ export {
   CreateKeyRequestSchema,
   type KeyRole,
   KeyRoleSchema,
+  type OverBudgetBehavior,
+  OverBudgetBehaviorSchema,
   type UpdateKeyRequest,
   UpdateKeyRequestSchema,
 } from "./key/schema.js";

--- a/packages/shared/src/key/schema.test.ts
+++ b/packages/shared/src/key/schema.test.ts
@@ -120,6 +120,12 @@ describe("ApiKeyRecordSchema", () => {
       ApiKeyRecordSchema.safeParse({ ...fullKey(), over_budget_behavior: "explode" }).success,
     ).toBe(false);
   });
+
+  it("rejects a 0 budget cap (0 is NOT 'unlimited' — null means no cap)", () => {
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), budget_requests: 0 }).success).toBe(false);
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), budget_tokens: 0 }).success).toBe(false);
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), budget_spend_usd: 0 }).success).toBe(false);
+  });
 });
 
 describe("CreateKeyRequestSchema", () => {
@@ -164,8 +170,10 @@ describe("CreateKeyRequestSchema", () => {
     expect(res.success).toBe(true);
   });
 
-  it("rejects invalid budget values on create (fail-closed)", () => {
+  it("rejects invalid budget values on create (fail-closed; 0 rejected)", () => {
     expect(CreateKeyRequestSchema.safeParse({ budget_requests: -1 }).success).toBe(false);
+    expect(CreateKeyRequestSchema.safeParse({ budget_requests: 0 }).success).toBe(false);
+    expect(CreateKeyRequestSchema.safeParse({ budget_spend_usd: 0 }).success).toBe(false);
     expect(CreateKeyRequestSchema.safeParse({ over_budget_behavior: "nope" }).success).toBe(false);
   });
 });

--- a/packages/shared/src/key/schema.test.ts
+++ b/packages/shared/src/key/schema.test.ts
@@ -83,6 +83,43 @@ describe("ApiKeyRecordSchema", () => {
   it("exposes the role enum options", () => {
     expect([...KeyRoleSchema.options].sort()).toEqual(["root", "user"]);
   });
+
+  it("accepts per-key usage budgets (number = cap, null = no cap)", () => {
+    const withBudgets = ApiKeyRecordSchema.safeParse({
+      ...fullKey(),
+      budget_requests: 1000,
+      budget_tokens: 500_000,
+      budget_spend_usd: 25.5,
+      budget_window_seconds: 86_400,
+      over_budget_behavior: "reject",
+      degrade_lane: "economy",
+    });
+    expect(withBudgets.success).toBe(true);
+  });
+
+  it("defaults budgets to no-cap + degrade when omitted (legacy rows / additive field)", () => {
+    const parsed = ApiKeyRecordSchema.parse(fullKey());
+    expect(parsed.budget_requests).toBeNull();
+    expect(parsed.budget_tokens).toBeNull();
+    expect(parsed.budget_spend_usd).toBeNull();
+    expect(parsed.budget_window_seconds).toBeNull();
+    expect(parsed.over_budget_behavior).toBe("degrade");
+    expect(parsed.degrade_lane).toBeNull();
+  });
+
+  it("rejects invalid budget values (fail-closed)", () => {
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), budget_requests: -1 }).success).toBe(false);
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), budget_tokens: 1.5 }).success).toBe(false);
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), budget_spend_usd: -0.01 }).success).toBe(
+      false,
+    );
+    expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), budget_window_seconds: 0 }).success).toBe(
+      false,
+    );
+    expect(
+      ApiKeyRecordSchema.safeParse({ ...fullKey(), over_budget_behavior: "explode" }).success,
+    ).toBe(false);
+  });
 });
 
 describe("CreateKeyRequestSchema", () => {
@@ -114,6 +151,22 @@ describe("CreateKeyRequestSchema", () => {
 
   it("rejects a negative per-key rate limit", () => {
     expect(CreateKeyRequestSchema.safeParse({ rate_limit_rpm: -5 }).success).toBe(false);
+  });
+
+  it("accepts optional per-key budgets + over-budget behavior", () => {
+    const res = CreateKeyRequestSchema.safeParse({
+      role: "user",
+      budget_spend_usd: 10,
+      budget_window_seconds: 3600,
+      over_budget_behavior: "degrade",
+      degrade_lane: "economy",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects invalid budget values on create (fail-closed)", () => {
+    expect(CreateKeyRequestSchema.safeParse({ budget_requests: -1 }).success).toBe(false);
+    expect(CreateKeyRequestSchema.safeParse({ over_budget_behavior: "nope" }).success).toBe(false);
   });
 });
 
@@ -157,5 +210,17 @@ describe("UpdateKeyRequestSchema", () => {
     expect(UpdateKeyRequestSchema.safeParse({ rate_limit_tpm: -1 }).success).toBe(false);
     expect(UpdateKeyRequestSchema.safeParse({ rate_limit_rpm: 2.5 }).success).toBe(false);
     expect(UpdateKeyRequestSchema.safeParse({ allowed_lanes: [""] }).success).toBe(false);
+  });
+
+  it("accepts budget edits: number (set), null (clear), behavior + degrade lane", () => {
+    expect(UpdateKeyRequestSchema.safeParse({ budget_spend_usd: 50 }).success).toBe(true);
+    expect(UpdateKeyRequestSchema.safeParse({ budget_spend_usd: null }).success).toBe(true);
+    expect(UpdateKeyRequestSchema.safeParse({ over_budget_behavior: "reject" }).success).toBe(true);
+    expect(UpdateKeyRequestSchema.safeParse({ degrade_lane: null }).success).toBe(true);
+  });
+
+  it("rejects invalid budget edits (fail-closed)", () => {
+    expect(UpdateKeyRequestSchema.safeParse({ budget_tokens: -1 }).success).toBe(false);
+    expect(UpdateKeyRequestSchema.safeParse({ over_budget_behavior: "halt" }).success).toBe(false);
   });
 });

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -6,6 +6,11 @@ import { z } from "zod";
 
 export const KeyRoleSchema = z.enum(["root", "user"]);
 
+// What to do when a key exceeds one of its usage budgets (docs/06 "usage budgets").
+// `degrade` (default): keep serving but force the request down to a cheaper lane —
+// bounds cost without interrupting service. `reject`: hard 429 once over budget.
+export const OverBudgetBehaviorSchema = z.enum(["degrade", "reject"]);
+
 export const ApiKeyRecordSchema = z.object({
   key_id: z.string().min(1),
   hash: z.string().min(1), // sha256(plaintext) hex; never the plaintext
@@ -22,9 +27,26 @@ export const ApiKeyRecordSchema = z.object({
   // so the storage shape is explicit, mirroring the other per-key caps above.
   rate_limit_rpm: z.number().int().nonnegative().nullable(),
   rate_limit_tpm: z.number().int().nonnegative().nullable(),
+  // Per-key usage budgets (docs/06 "usage budgets"). Each cap is OPTIONAL: a number
+  // is the ceiling consumed over the rolling window, null = no cap for that
+  // dimension. Unlike rate limits (which REJECT), exceeding a budget DEGRADES the
+  // request to `degrade_lane` by default (keep serving, bound cost). These are
+  // `.default()`ed (not just required-nullable like the rate limits) so legacy key
+  // rows predating the migration — and unrelated record fixtures — still parse;
+  // the keystores populate them explicitly from the columns.
+  budget_requests: z.number().int().nonnegative().nullable().default(null),
+  budget_tokens: z.number().int().nonnegative().nullable().default(null),
+  budget_spend_usd: z.number().nonnegative().nullable().default(null),
+  // Rolling window the budgets are measured over (seconds). null = the system
+  // default window. Continuous token-bucket refill, no hard reset.
+  budget_window_seconds: z.number().int().positive().nullable().default(null),
+  over_budget_behavior: OverBudgetBehaviorSchema.default("degrade"),
+  // Lane to fall back to when degrading. null = `economy` (the cheapest ranked lane).
+  degrade_lane: z.string().min(1).nullable().default(null),
 });
 
 export type KeyRole = z.infer<typeof KeyRoleSchema>;
+export type OverBudgetBehavior = z.infer<typeof OverBudgetBehaviorSchema>;
 export type ApiKeyRecord = z.infer<typeof ApiKeyRecordSchema>;
 
 // Admin-facing create-key request (docs/06 Key management). The plaintext is minted
@@ -41,6 +63,14 @@ export const CreateKeyRequestSchema = z
     // a negative/non-int value).
     rate_limit_rpm: z.number().int().nonnegative().optional(),
     rate_limit_tpm: z.number().int().nonnegative().optional(),
+    // Optional per-key usage budgets at mint time (docs/06). Omitted => no cap for
+    // that dimension. over_budget_behavior omitted => stored default ("degrade").
+    budget_requests: z.number().int().nonnegative().optional(),
+    budget_tokens: z.number().int().nonnegative().optional(),
+    budget_spend_usd: z.number().nonnegative().optional(),
+    budget_window_seconds: z.number().int().positive().optional(),
+    over_budget_behavior: OverBudgetBehaviorSchema.optional(),
+    degrade_lane: z.string().min(1).optional(),
   })
   .strict();
 
@@ -62,6 +92,14 @@ export const UpdateKeyRequestSchema = z
     allow_custom_model: z.boolean().optional(),
     rate_limit_rpm: z.number().int().nonnegative().nullable().optional(),
     rate_limit_tpm: z.number().int().nonnegative().nullable().optional(),
+    // Budget edits (docs/06). Omit = leave unchanged; null = clear the cap (no cap).
+    // over_budget_behavior has no null (it always resolves to degrade|reject).
+    budget_requests: z.number().int().nonnegative().nullable().optional(),
+    budget_tokens: z.number().int().nonnegative().nullable().optional(),
+    budget_spend_usd: z.number().nonnegative().nullable().optional(),
+    budget_window_seconds: z.number().int().positive().nullable().optional(),
+    over_budget_behavior: OverBudgetBehaviorSchema.optional(),
+    degrade_lane: z.string().min(1).nullable().optional(),
   })
   .strict();
 

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -27,16 +27,18 @@ export const ApiKeyRecordSchema = z.object({
   // so the storage shape is explicit, mirroring the other per-key caps above.
   rate_limit_rpm: z.number().int().nonnegative().nullable(),
   rate_limit_tpm: z.number().int().nonnegative().nullable(),
-  // Per-key usage budgets (docs/06 "usage budgets"). Each cap is OPTIONAL: a number
-  // is the ceiling consumed over the rolling window, null = no cap for that
-  // dimension. Unlike rate limits (which REJECT), exceeding a budget DEGRADES the
+  // Per-key usage budgets (docs/06 "usage budgets"). Each cap is OPTIONAL: a
+  // STRICTLY POSITIVE number is the ceiling consumed over the rolling window;
+  // null = no cap for that dimension. Unlike the rate limits, 0 is NOT a sentinel
+  // here (null already means "no cap"), so 0 is rejected — it must never look like
+  // an active cap while enforcing as unlimited. Exceeding a budget DEGRADES the
   // request to `degrade_lane` by default (keep serving, bound cost). These are
   // `.default()`ed (not just required-nullable like the rate limits) so legacy key
   // rows predating the migration — and unrelated record fixtures — still parse;
   // the keystores populate them explicitly from the columns.
-  budget_requests: z.number().int().nonnegative().nullable().default(null),
-  budget_tokens: z.number().int().nonnegative().nullable().default(null),
-  budget_spend_usd: z.number().nonnegative().nullable().default(null),
+  budget_requests: z.number().int().positive().nullable().default(null),
+  budget_tokens: z.number().int().positive().nullable().default(null),
+  budget_spend_usd: z.number().positive().nullable().default(null),
   // Rolling window the budgets are measured over (seconds). null = the system
   // default window. Continuous token-bucket refill, no hard reset.
   budget_window_seconds: z.number().int().positive().nullable().default(null),
@@ -64,10 +66,11 @@ export const CreateKeyRequestSchema = z
     rate_limit_rpm: z.number().int().nonnegative().optional(),
     rate_limit_tpm: z.number().int().nonnegative().optional(),
     // Optional per-key usage budgets at mint time (docs/06). Omitted => no cap for
-    // that dimension. over_budget_behavior omitted => stored default ("degrade").
-    budget_requests: z.number().int().nonnegative().optional(),
-    budget_tokens: z.number().int().nonnegative().optional(),
-    budget_spend_usd: z.number().nonnegative().optional(),
+    // that dimension; a cap must be strictly positive (0 is rejected — null = no
+    // cap). over_budget_behavior omitted => stored default ("degrade").
+    budget_requests: z.number().int().positive().optional(),
+    budget_tokens: z.number().int().positive().optional(),
+    budget_spend_usd: z.number().positive().optional(),
     budget_window_seconds: z.number().int().positive().optional(),
     over_budget_behavior: OverBudgetBehaviorSchema.optional(),
     degrade_lane: z.string().min(1).optional(),
@@ -92,11 +95,12 @@ export const UpdateKeyRequestSchema = z
     allow_custom_model: z.boolean().optional(),
     rate_limit_rpm: z.number().int().nonnegative().nullable().optional(),
     rate_limit_tpm: z.number().int().nonnegative().nullable().optional(),
-    // Budget edits (docs/06). Omit = leave unchanged; null = clear the cap (no cap).
-    // over_budget_behavior has no null (it always resolves to degrade|reject).
-    budget_requests: z.number().int().nonnegative().nullable().optional(),
-    budget_tokens: z.number().int().nonnegative().nullable().optional(),
-    budget_spend_usd: z.number().nonnegative().nullable().optional(),
+    // Budget edits (docs/06). Omit = leave unchanged; null = clear the cap (no cap);
+    // a number must be strictly positive (0 rejected). over_budget_behavior has no
+    // null (it always resolves to degrade|reject).
+    budget_requests: z.number().int().positive().nullable().optional(),
+    budget_tokens: z.number().int().positive().nullable().optional(),
+    budget_spend_usd: z.number().positive().nullable().optional(),
     budget_window_seconds: z.number().int().positive().nullable().optional(),
     over_budget_behavior: OverBudgetBehaviorSchema.optional(),
     degrade_lane: z.string().min(1).nullable().optional(),


### PR DESCRIPTION
内部自托管网关只对外发 **API Key**、没有「账户」计费主体，所以账户级 credit 计费（#42）已关闭。本 PR 改为 **按 key 的成本控制，且不中断服务**。

## 做了什么
每个 API Key 可配置 **请求数 / token 数 / 花费金额（USD）** 上限（任选其一或多个），按**可配置的滚动窗口**计量。超额后按 key 选择：
- **degrade（默认）**：降级到更便宜的 lane（默认 `economy`）——控成本、**服务不中断**；
- **reject**：直接 429。

## 设计（复用既有机制，不引入账本）
- **token-bucket**（`ratelimit/token-bucket.ts`）增加可配置 `windowMs`（默认 60s，RPM/TPM 路径不变）。
- 新 `BudgetStore` 端口 + sqlite/pg 适配器；`usage_budget_buckets` 表（sqlite 迁移 **v11** / pg **v10**），单行原子扣减，软上限（可短暂为负），仅存 key_id（原则 7）。
- 纯逻辑 `budget/`：`gate.ts`（前置 **fail-CLOSED** 符号检查，分维度阈值：req/tok `remaining<1`、usd `remaining<=0`）+ `settle.ts`（后置 **fail-OPEN** 扣减，逐字用已结算 `total_usd`，null 成本计 0）。
- 降级复用 `applyCaps`：重新引入 `RouteOptions.keyCaps.maxLane`（即 #63 移除的 per-key 上限），按请求动态设置。

## 覆盖全部四个协议面
chat.ts 直接接 gate/settle；messages/responses/gemini **共用 `messages-pipeline.ts`**，check + settle 在管线里写一次即可，并顺带补上**流式成本回填**（解析上游 OpenAI usage 尾包，与 chat 同一解析器）——这三面此前从不结算流式成本。

## 关键决策（详见 implementation-notes）
- **分维度超额阈值**：30 天窗口会在耗尽瞬间微量 refill 出正 epsilon，纯 `>0` 会让「N 配额」放行 N+1；故离散维度（req/tok）用 `remaining<1`，分数维度（usd）保留 `<=0` 的 D5 容差。
- **默认 degrade（非 fail-closed）**：产品目标是「不中断服务」，超额 key 默认降级续服，除非配 reject。
- **无全局开关**：无 caps 的 key 走零接触快路径（不读 store）。

## 验证
- 单测 **1767/1767**，e2e **30/30**（含 `budget.spec`：degrade→economy、reject→429）。
- `pnpm typecheck` 通过；改动文件 lint 干净（仓库里 oauth.spec/stream.test 等**既有** noNonNullAssertion 告警与本 PR 无关）。
- 流式 **spend** 结算因 mock 上游不发 usage 尾包，由单测覆盖（gate/settle + 管线/chat 接线），与 #42 同样的 mock 限制。

## 文档
docs/06 新增「Per-key usage budgets」并澄清「仅按 key、无账户计费」；docs/09 将账户级计费标为 out of scope；implementation-notes 追加条目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)