### PR TITLE
feat(gemini): native SSE streaming for :streamGenerateContent (incremental deltas)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Helm API is **0.2** and early-stage, but it is a real implementation, not a scaf
 
 **Shipped:**
 
-- **Four client protocols** — `POST /v1/chat/completions` (OpenAI Chat), `POST /v1/messages` (Anthropic Messages), and `POST /v1/responses` (OpenAI Responses) — all streaming + non-streaming — plus `POST /v1beta/models/{model}:generateContent` (Google Gemini, non-streaming).
+- **Four client protocols** — `POST /v1/chat/completions` (OpenAI Chat), `POST /v1/messages` (Anthropic Messages), `POST /v1/responses` (OpenAI Responses), and `POST /v1beta/models/{model}:generateContent` (Google Gemini) — all streaming + non-streaming. (Gemini streaming is the `:streamGenerateContent?alt=sse` operation.)
 - **Cross-protocol translation** — normalize to one internal IR; consistent output shape across backends, with SSE streaming on the chat, messages, and responses surfaces.
 - **Three-layer classification** — deterministic rules always on; optional small-model eval (off by default) for uncertain cases; `balanced`-lane fallback.
 - **Lane + policy routing** — first-match policies that pin, cap, or restrict lanes; default lanes shipped: `economy`, `balanced`, `premium`, plus task lanes `coding`, `json`, `vision`, `tool_use`. (`balanced` is the required, always-available fallback lane.)
@@ -133,7 +133,7 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ❌ non-streaming |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅ (via `:streamGenerateContent?alt=sse`) |
 
 **What to put in the `model` field:**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,8 +55,8 @@ Helm API 目前是 **0.2**、尚处早期，但它是一套真实实现，而非
 
 **已上线：**
 
-- **四种客户端协议** —— `POST /v1/chat/completions`（OpenAI Chat）、`POST /v1/messages`（Anthropic Messages）、`POST /v1/responses`（OpenAI Responses）三者均支持流式 + 非流式，外加 `POST /v1beta/models/{model}:generateContent`（Google Gemini，非流式）。
-- **跨协议互译** —— 归一到一套内部 IR；跨后端输出格式一致，chat、messages、responses 三个面均支持 SSE 流式。
+- **四种客户端协议** —— `POST /v1/chat/completions`（OpenAI Chat）、`POST /v1/messages`（Anthropic Messages）、`POST /v1/responses`（OpenAI Responses）、`POST /v1beta/models/{model}:generateContent`（Google Gemini）—— 四者均支持流式 + 非流式（Gemini 的流式即 `:streamGenerateContent?alt=sse`）。
+- **跨协议互译** —— 归一到一套内部 IR；跨后端输出格式一致，chat、messages、responses、Gemini 四个面均支持 SSE 流式。
 - **三层分类** —— 确定性规则常驻；不确定时走可选的小模型 eval（默认关闭）；最后兜底到 `balanced` lane。
 - **Lane + 策略路由** —— 首条命中的策略可以钉死、设上限或限定 lane；内置默认 lane：`economy`、`balanced`、`premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`（`balanced` 是必须存在、永远兜底的那条）。
 - **带兜底的 provider 执行** —— 在多个 OpenAI 兼容上游之间走「主 + 兜底」链，配有熔断器（OPEN/HALF_OPEN）、能力过滤（缺 JSON / 工具 / 视觉 / 上下文长度的候选会被显式跳过并记原因）、以及 `:free` 档 429 跳过。客户端断连不算 provider 故障。
@@ -133,7 +133,7 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ❌ 非流式 |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅（走 `:streamGenerateContent?alt=sse`） |
 
 **`model` 字段里填什么：**
 

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -26,9 +26,9 @@ import { PipelineError } from "./messages-pipeline.js";
 //   • the model + operation are in the PATH (`{model}:{op}`), parsed by the core
 //     pure function `parseGeminiPath` (core never reads a Hono object, principle 1);
 //   • auth is `x-goog-api-key` (NOT Authorization: Bearer; Bearer is a fallback);
-//   • streaming events are FULL-SNAPSHOT `data:` frames with NO `event:` name and
+//   • streaming events are incremental-delta `data:` frames with NO `event:` name and
 //     NO `[DONE]` sentinel (docs/05 — Gemini's wire form differs from OpenAI /
-//     Anthropic SSE).
+//     Anthropic SSE; each frame is a `GenerateContentResponse` the client accumulates).
 
 /** One Gemini error envelope plus the HTTP status to send it with. Error
  *  translation is protocol logic (docs/05) — injected, never hand-assembled. */
@@ -226,7 +226,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       throw err;
     }
 
-    // 4) Protocol Adapter (outbound). Gemini streaming events are FULL snapshots,
+    // 4) Protocol Adapter (outbound). Gemini streaming events are incremental deltas,
     //    written as nameless `data:` frames — NO `event:` name, NO `[DONE]`.
     if (route.stream) {
       return streamSSE(c, async (sse) => {

--- a/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
@@ -5,11 +5,12 @@ import { createMessagesPipeline, type RouteFn } from "./messages-pipeline.js";
 
 // messages-pipeline (gemini branch) — issue #34 step 3. When the pipeline is
 // stamped with the `gemini` protocol, streamIR() must map the upstream OpenAI SSE
-// chunks into GEMINI snapshot events (via geminiTransformer.transformStreamOut),
-// NOT Anthropic events. Each snapshot is a FULL response (text accumulates frame to
-// frame); the terminal snapshot carries finishReason + usageMetadata exactly once;
-// there is no `event:` name and no `[DONE]` sentinel (those are the route's job —
-// here we only assert the produced snapshot objects). CLAUDE.md principle 8.
+// chunks into GEMINI delta events (via geminiTransformer.transformStreamOut),
+// NOT Anthropic events. Each event carries an INCREMENTAL text delta (the client
+// accumulates `chunk.text` — events do NOT repeat the running text); the terminal
+// event carries finishReason + usageMetadata exactly once; there is no `event:` name
+// and no `[DONE]` sentinel (those are the route's job — here we only assert the
+// produced delta objects). CLAUDE.md principle 8.
 
 const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
 
@@ -30,6 +31,13 @@ async function* openAISSE(frames: string[]): AsyncIterable<string> {
   for (const f of frames) yield f;
 }
 
+// Drain streamIR() into an array of plain objects.
+async function drain(src: AsyncIterable<Record<string, unknown>>): Promise<unknown[]> {
+  const out: unknown[] = [];
+  for await (const ev of src) out.push(ev);
+  return out;
+}
+
 function streamResult(stream: AsyncIterable<string>): ExecutionResult {
   return {
     decision: { lane: { selected_lane: "balanced" } } as unknown as ExecutionResult["decision"],
@@ -40,8 +48,8 @@ function streamResult(stream: AsyncIterable<string>): ExecutionResult {
   };
 }
 
-describe("createMessagesPipeline (gemini) — streamIR yields Gemini snapshots", () => {
-  it("accumulates text across snapshots and ends with finishReason + usageMetadata", async () => {
+describe("createMessagesPipeline (gemini) — streamIR yields Gemini delta events", () => {
+  it("streams incremental text deltas and ends with finishReason + usageMetadata once", async () => {
     const frames = [
       'data: {"id":"c","choices":[{"delta":{"role":"assistant"}}]}\n\n',
       'data: {"id":"c","choices":[{"delta":{"content":"Hel"}}]}\n\n',
@@ -52,19 +60,28 @@ describe("createMessagesPipeline (gemini) — streamIR yields Gemini snapshots",
     const pipeline = createMessagesPipeline(route, "gemini");
     const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
 
-    const events: Array<Record<string, unknown>> = [];
-    for await (const ev of run.streamIR()) events.push(ev as Record<string, unknown>);
-
-    expect(events.length).toBeGreaterThan(0);
-    // Each event is a full snapshot; the LAST carries the complete accumulated text.
-    const last = events[events.length - 1] as {
+    const events = (await drain(run.streamIR())) as Array<{
       candidates?: Array<{ content?: { parts?: Array<{ text?: string }> }; finishReason?: string }>;
       usageMetadata?: { candidatesTokenCount?: number };
-    };
-    const text = (last.candidates?.[0]?.content?.parts ?? []).map((p) => p.text ?? "").join("");
+    }>;
+
+    expect(events.length).toBeGreaterThan(0);
+    // Events are INCREMENTAL deltas: concatenating every event's text yields the full
+    // body with no duplication (a cumulative-snapshot impl would yield "HelHello").
+    const text = events
+      .flatMap((e) => e.candidates?.[0]?.content?.parts ?? [])
+      .map((p) => p.text ?? "")
+      .join("");
     expect(text).toBe("Hello");
-    expect(last.candidates?.[0]?.finishReason).toBe("STOP");
-    expect(last.usageMetadata?.candidatesTokenCount).toBe(2);
+    // finishReason + usageMetadata ride on exactly ONE terminal event (never a STOP
+    // frame followed by a stray usage-only frame).
+    const withFinish = events.filter((e) => e.candidates?.[0]?.finishReason !== undefined);
+    expect(withFinish).toHaveLength(1);
+    expect(withFinish[0]?.candidates?.[0]?.finishReason).toBe("STOP");
+    const withUsage = events.filter((e) => e.usageMetadata !== undefined);
+    expect(withUsage).toHaveLength(1);
+    expect(withUsage[0]).toBe(withFinish[0]); // same terminal event
+    expect(withUsage[0]?.usageMetadata?.candidatesTokenCount).toBe(2);
 
     // No Anthropic event names leaked through the Gemini surface.
     const serialized = JSON.stringify(events);
@@ -83,19 +100,20 @@ describe("createMessagesPipeline (gemini) — streamIR yields Gemini snapshots",
     const pipeline = createMessagesPipeline(route, "gemini");
     const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
 
-    const events: Array<Record<string, unknown>> = [];
-    for await (const ev of run.streamIR()) events.push(ev as Record<string, unknown>);
-
-    const last = events[events.length - 1] as {
+    const events = (await drain(run.streamIR())) as Array<{
       candidates?: Array<{
         content?: { parts?: Array<{ functionCall?: { name: string; args: unknown } }> };
         finishReason?: string;
       }>;
-    };
-    const fc = (last.candidates?.[0]?.content?.parts ?? []).find(
-      (p) => p.functionCall,
-    )?.functionCall;
-    expect(fc?.name).toBe("get_weather");
-    expect(fc?.args).toEqual({ city: "SF" });
+    }>;
+
+    // The functionCall surfaces in EXACTLY ONE event (a delta), with complete args.
+    const fcs = events
+      .flatMap((e) => e.candidates?.[0]?.content?.parts ?? [])
+      .map((p) => p.functionCall)
+      .filter((fc): fc is { name: string; args: unknown } => fc !== undefined);
+    expect(fcs).toHaveLength(1);
+    expect(fcs[0]?.name).toBe("get_weather");
+    expect(fcs[0]?.args).toEqual({ city: "SF" });
   });
 });

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -477,8 +477,8 @@ export function createMessagesPipeline(
             // (principle 5: surfaces never conflate). Gemini consumes the SAME
             // OpenAI-shaped chunks parseOpenAISSE produces (its IRChunk IS the
             // OpenAI chat.completion.chunk), so we feed them straight into the
-            // Gemini snapshot state machine — no Anthropic adapter (docs/05). Each
-            // yielded object is a full GenerateContentResponse snapshot (no `type`);
+            // Gemini delta state machine — no Anthropic adapter (docs/05). Each
+            // yielded object is a GenerateContentResponse delta frame (no `type`);
             // the route writes it as a nameless `data:` SSE frame with no [DONE].
             if (protocol === "gemini") {
               for await (const snapshot of geminiTransformer.transformStreamOut(

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1344,7 +1344,7 @@ export async function buildServer(
 
   // Gemini route (/v1beta/models/{model}:generateContent | :streamGenerateContent).
   // The FOURTH client surface. Reuses the SAME routing core via a pipeline stamped
-  // with the `gemini` protocol (so streamIR yields Gemini snapshot events), and the
+  // with the `gemini` protocol (so streamIR yields Gemini delta events), and the
   // Gemini transformer for IR↔native translation + the Gemini error envelope. Self-
   // auth (x-goog-api-key preferred, Bearer fallback) so a missing key is rejected as
   // a Gemini error envelope (docs/05, docs/07).

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -15,7 +15,7 @@ Four client protocols are wired and routed in 0.2:
 | `POST /v1/chat/completions` | OpenAI Chat Completions | Yes (SSE) and non-stream |
 | `POST /v1/messages` | Anthropic Messages | Yes (SSE) and non-stream |
 | `POST /v1/responses` | OpenAI Responses | Yes (SSE) and non-stream |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | Non-streaming |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | Yes (SSE via `:streamGenerateContent?alt=sse`) and non-stream |
 
 For **OpenAI Responses**, streaming is now wired (0.2): a `stream:true` request
 returns a native Responses SSE stream of `response.*` events terminated by a
@@ -25,8 +25,13 @@ see `apps/gateway/src/routes/responses.ts` for the route.
 
 **Gemini** is now an inbound route (0.2): `POST /v1beta/models/{model}:generateContent`
 (issue #58), backed by the transformers in `packages/core/src/protocol/gemini/`.
-Streaming (`:streamGenerateContent`) is not implemented — the endpoint is
-non-streaming only. See `apps/gateway/src/routes/gemini.ts`.
+Streaming is wired via `:streamGenerateContent?alt=sse`: each SSE frame is a nameless
+`data:` `GenerateContentResponse` carrying an **incremental** text delta (matching real
+Gemini — clients accumulate `chunk.text`), with **no** `event:` name and **no** `[DONE]`
+sentinel. The terminal frame carries the completed `functionCall` parts, `finishReason`,
+and `usageMetadata`. The delta mapper is `transformStreamOut` in
+`packages/core/src/protocol/gemini/gemini-transformer.ts`; see
+`apps/gateway/src/routes/gemini.ts` for the route.
 
 ## Responsibilities
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -178,6 +178,20 @@ regression; typecheck + lint clean; admin svelte-check 0/0.
 
 ---
 
+## 2026-06-03 · Gemini inbound streaming — fix cumulative-snapshot bug, emit real deltas (docs/05)
+
+**Context**: The Gemini surface (`:streamGenerateContent?alt=sse`) was fully *wired* end-to-end since #58 — path parser recognizes the op, `gemini.ts` branches on `route.stream`, `messages-pipeline.ts` feeds OpenAI-shaped chunks into `geminiTransformer.transformStreamOut`, and route+transformer streaming tests existed — yet README/docs/05 marked it **❌ non-streaming**. The reason was a **wire-format correctness bug**, not a missing endpoint.
+
+**The bug**: `transformStreamOut` emitted **cumulative full snapshots** (`text += content`; every event carried the *entire* accumulated text). But real Google Gemini `streamGenerateContent?alt=sse` emits **incremental deltas** — each event holds only the new text and clients accumulate (`text += chunk.text`, confirmed against the official Google cookbook/SDK). A genuine Gemini client pointed at our endpoint would see massively duplicated text (`"Hi"` → `"HiHi there"`). The team correctly judged it not-truly-compatible and documented ❌ rather than ship broken streaming.
+
+**Fix** (`packages/core/src/protocol/gemini/gemini-transformer.ts`): rewrote `transformStreamOut` to forward each IR text delta verbatim (no accumulator). Tool-call arg fragments are still buffered per IR index and flushed as ONE complete `functionCall` part — but now only on the **terminal** chunk (with `finishReason` + `usageMetadata`), never re-emitted per snapshot. A role-only / tool-arg-fragment chunk (no text, no finish, no usage) is skipped (Gemini has no empty frame). A defensive post-loop flush surfaces tool calls if the IR stream ends without a finish chunk.
+
+**Inbound side untouched**: `transformStreamIn` already tolerates both shapes — its diff has a non-prefix fallback that emits the whole part when a chunk isn't a prefix of the accumulated text, so a delta stream and a snapshot stream both decode correctly. Only the outbound mapper was wrong.
+
+**Tests**: the two `transformStreamOut` tests were rewritten from snapshot assertions (last-event-carries-all) to delta assertions (concat across ALL events == full text, no single event carries the whole text, exactly one `finishReason`, exactly one `functionCall` part). Docs/05 + README (EN/zh-CN) flipped to ✅. No route change needed — the route already writes each yielded object as a nameless `data:` frame with no `[DONE]`.
+
+---
+
 ## 2026-06-03 · Hot-reload the OAuth subscription pool (proxy / priority / schedulable / connect / disconnect) — no restart (issue #38)
 
 **Context**: The operator's rule — anything editable in an admin page form must hot-apply on Save, never need a restart. Audited every admin form vs its runtime consumption: **lanes, policies, classifier, API keys, System Settings (capture/retention/rate-limit/log-level), and OAuth model curation were ALREADY hot** (RuleStore re-bind callbacks / live keystore reads / per-request thunks). The **only gap** was the OAuth pool: `synthesizeOAuthProviders()` ran once at startup and froze each account's proxy/priority/schedulable + the connected-account set into the pool; the admin PUT handlers only persisted.

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -592,7 +592,15 @@ describe("streaming alt=sse (snapshot events -> IR chunks)", () => {
 });
 
 describe("transformStreamOut (IR chunks -> Gemini SSE events)", () => {
-  it("emits Gemini snapshot events from IR chunks", async () => {
+  // Concatenate text parts across ALL events — the real Gemini wire contract: clients
+  // accumulate `chunk.text`, so events must carry incremental deltas, not snapshots.
+  const concatText = (events: GeminiSSEEvent[]): string =>
+    events
+      .flatMap((e) => e.candidates?.[0]?.content?.parts ?? [])
+      .map((p) => ("text" in p ? (p.text ?? "") : ""))
+      .join("");
+
+  it("emits INCREMENTAL text deltas, not cumulative snapshots (no duplication)", async () => {
     const chunks: IRChunk[] = [
       { id: "c", model: "m", choices: [{ index: 0, delta: { role: "assistant", content: "Hi" } }] },
       {
@@ -602,17 +610,26 @@ describe("transformStreamOut (IR chunks -> Gemini SSE events)", () => {
       },
     ];
     const events = await collect(geminiTransformer.transformStreamOut(fromArray(chunks)));
-    // Gemini events are FULL snapshots: the last event carries the complete text.
-    const last = events[events.length - 1];
-    const text = (last?.candidates?.[0]?.content?.parts ?? [])
-      .map((p) => ("text" in p ? p.text : ""))
-      .join("");
-    expect(text).toBe("Hi there");
-    expect(last?.candidates?.[0]?.finishReason).toBe("STOP");
+    // Real Gemini emits deltas a client concatenates → the running join is the full
+    // text with NO duplication. (A cumulative-snapshot impl would yield "HiHi there".)
+    expect(concatText(events)).toBe("Hi there");
+    // No single event may carry the whole accumulated text — that would double-count
+    // on a client that appends each chunk.
+    for (const ev of events) {
+      const t = (ev.candidates?.[0]?.content?.parts ?? [])
+        .map((p) => ("text" in p ? (p.text ?? "") : ""))
+        .join("");
+      expect(t).not.toBe("Hi there");
+    }
+    // finishReason rides on exactly one (the terminal) event.
+    const withFinish = events.filter((e) => e.candidates?.[0]?.finishReason !== undefined);
+    expect(withFinish).toHaveLength(1);
+    expect(withFinish[0]?.candidates?.[0]?.finishReason).toBe("STOP");
   });
 
-  // test #4: outbound streaming must surface tool calls as functionCall parts.
-  it("emits a functionCall part in the cumulative snapshot from streamed tool_calls", async () => {
+  // test #4: outbound streaming must surface tool calls as a complete functionCall part
+  // (one delta event), flushed once args are complete — never a half-parsed JSON.
+  it("emits a single complete functionCall part from streamed tool_calls", async () => {
     const chunks: IRChunk[] = [
       {
         id: "c",
@@ -647,16 +664,20 @@ describe("transformStreamOut (IR chunks -> Gemini SSE events)", () => {
       },
     ];
     const events = await collect(geminiTransformer.transformStreamOut(fromArray(chunks)));
-    const last = events[events.length - 1];
-    const parts = last?.candidates?.[0]?.content?.parts ?? [];
-    const fcPart = parts.find((p) => "functionCall" in p) as
-      | { functionCall: { name: string; args: Record<string, unknown> } }
-      | undefined;
-    expect(fcPart).toBeDefined();
-    expect(fcPart?.functionCall.name).toBe("get_weather");
-    // complete args flushed on the finish chunk
-    expect(fcPart?.functionCall.args).toEqual({ city: "SF" });
-    expect(last?.candidates?.[0]?.finishReason).toBe("STOP");
+    // The functionCall part appears in EXACTLY ONE event (a delta), never re-emitted
+    // across snapshots, and only once its args are a complete parseable JSON.
+    const fcParts = events
+      .flatMap((e) => e.candidates?.[0]?.content?.parts ?? [])
+      .filter((p) => "functionCall" in p) as Array<{
+      functionCall: { name: string; args: Record<string, unknown> };
+    }>;
+    expect(fcParts).toHaveLength(1);
+    expect(fcParts[0]?.functionCall.name).toBe("get_weather");
+    expect(fcParts[0]?.functionCall.args).toEqual({ city: "SF" });
+    // finishReason rides on exactly one (the terminal) event.
+    const withFinish = events.filter((e) => e.candidates?.[0]?.finishReason !== undefined);
+    expect(withFinish).toHaveLength(1);
+    expect(withFinish[0]?.candidates?.[0]?.finishReason).toBe("STOP");
   });
 });
 

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -25,8 +25,9 @@ import { sanitizeSchema } from "./schema-sanitize.js";
 //   • roles user|model (no system; system is a top-level systemInstruction);
 //   • tool calls have NO stable id — functionCall/functionResponse pair by NAME, so
 //     we SYNTHESIZE deterministic ids (call_<name>_<n>) and drop them outbound;
-//   • streaming is snapshot-based (?alt=sse): each event is a FULL response, so we
-//     diff snapshots into the IR start->delta->stop sequence with idempotent close;
+//   • streaming (?alt=sse) is delta-based both ways: outbound emits INCREMENTAL deltas
+//     (clients accumulate `chunk.text`); inbound diffs provider frames into the IR
+//     start->delta->stop sequence, tolerating either delta or snapshot framing;
 //   • JSON-Schema `format` (date/date-time) is unsupported -> sanitizeSchema strips it;
 //   • finishReason / usageMetadata are remapped, raw preserved in provider_raw.
 //
@@ -670,10 +671,17 @@ async function* transformStreamIn(src: AsyncIterable<GeminiSSEEvent>): AsyncIter
   };
 }
 
-// —— Streaming outbound: IR chunks -> Gemini snapshot events. ——————————————————————
-// We accumulate IR deltas into a growing snapshot and emit one Gemini event per IR
-// chunk (Gemini clients expect full-snapshot events). The final chunk's
-// finish_reason is mapped onto the candidate.
+// —— Streaming outbound: IR chunks -> Gemini SSE delta events. ————————————————————————
+// Real Gemini `streamGenerateContent?alt=sse` emits INCREMENTAL deltas — each event
+// carries only the NEW text in candidates[0].content.parts, and clients accumulate
+// (`text += chunk.text`). So we forward each IR text delta verbatim (NEVER a growing
+// snapshot — that would double-count on the client). Tool-call fragments are buffered
+// and flushed as ONE complete functionCall part on the terminal frame, which also
+// carries `finishReason` + `usageMetadata`. CRUCIAL: the OpenAI source (with
+// `stream_options.include_usage`, always set by execute.ts) delivers usage on a
+// SEPARATE trailing chunk AFTER the finish chunk — so we hold the terminal frame until
+// the stream ends and merge that late usage in, emitting exactly ONE terminal frame
+// (never a `STOP` frame followed by a stray empty `usageMetadata` frame).
 
 interface OutToolSlot {
   index: number;
@@ -682,16 +690,37 @@ interface OutToolSlot {
 }
 
 async function* transformStreamOut(src: AsyncIterable<IRChunk>): AsyncIterable<GeminiSSEEvent> {
-  let text = "";
   // Tool-call fragments arrive split across chunks (id/name early, arguments later);
-  // buffer per IR tool index — mirroring the inbound side — and re-serialize the
-  // accumulated args into functionCall parts on every cumulative snapshot.
+  // buffer per IR tool index — mirroring the inbound side — and emit each as a single
+  // complete functionCall part once the stream finishes (never a half-parsed snapshot).
   const toolIndexToSlot = new Map<number, OutToolSlot>();
+
+  // Build the completed functionCall parts in allocation order (skip un-named slots).
+  const flushToolParts = (): GeminiPart[] => {
+    const parts: GeminiPart[] = [];
+    for (const slot of [...toolIndexToSlot.values()].sort((a, b) => a.index - b.index)) {
+      if (slot.name === "") continue;
+      parts.push({ functionCall: { name: slot.name, args: parseArgs(slot.argBuffer) } });
+    }
+    return parts;
+  };
+
+  const toUsageMetadata = (usage: NonNullable<IRChunk["usage"]>): GeminiUsageMetadata => ({
+    ...(usage.prompt_tokens !== undefined ? { promptTokenCount: usage.prompt_tokens } : {}),
+    ...(usage.completion_tokens !== undefined
+      ? { candidatesTokenCount: usage.completion_tokens }
+      : {}),
+  });
+
+  // The terminal frame (text delta + functionCall parts + finishReason) is held back
+  // until stream end so a late usage-only chunk merges into it as ONE frame.
+  let terminalParts: GeminiPart[] | null = null;
+  let terminalFinish: string | undefined;
+  let latestUsage: GeminiUsageMetadata | undefined;
 
   for await (const chunk of src) {
     const choice = chunk.choices?.[0];
     const content = choice?.delta?.content;
-    if (typeof content === "string") text += content;
 
     for (const tc of choice?.delta?.tool_calls ?? []) {
       let slot = toolIndexToSlot.get(tc.index);
@@ -704,35 +733,46 @@ async function* transformStreamOut(src: AsyncIterable<IRChunk>): AsyncIterable<G
       if (tc.function?.arguments !== undefined) slot.argBuffer += tc.function.arguments;
     }
 
-    const parts: GeminiPart[] = text !== "" ? [{ text }] : [];
-    // Emit functionCall parts in allocation order; tolerate partial JSON via parseArgs
-    // so a mid-stream snapshot never throws (complete args land on the finish chunk).
-    for (const slot of [...toolIndexToSlot.values()].sort((a, b) => a.index - b.index)) {
-      if (slot.name === "") continue;
-      parts.push({ functionCall: { name: slot.name, args: parseArgs(slot.argBuffer) } });
+    if (chunk.usage != null) latestUsage = toUsageMetadata(chunk.usage);
+
+    if (choice?.finish_reason != null) {
+      // Terminal chunk: assemble the final frame but hold it (usage may still trail).
+      terminalParts = [];
+      if (typeof content === "string" && content !== "") terminalParts.push({ text: content });
+      terminalParts.push(...flushToolParts());
+      terminalFinish = mapFinishReasonToGemini(choice.finish_reason) ?? "STOP";
+      continue;
     }
 
-    const candidate: GeminiCandidate = {
-      content: { role: "model", parts },
-      ...(choice?.finish_reason != null
-        ? { finishReason: mapFinishReasonToGemini(choice.finish_reason) ?? "STOP" }
-        : {}),
-      index: 0,
-    };
+    // Non-terminal: forward only a real text delta. Role-only announcements, tool-arg
+    // fragments, and usage-only chunks carry no Gemini frame (Gemini has no empty/role
+    // frame; their payload surfaces on the terminal frame instead).
+    if (typeof content === "string" && content !== "") {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: content }] }, index: 0 }] };
+    }
+  }
+
+  if (terminalParts !== null) {
     yield {
-      candidates: [candidate],
-      ...(chunk.usage != null
-        ? {
-            usageMetadata: {
-              ...(chunk.usage.prompt_tokens !== undefined
-                ? { promptTokenCount: chunk.usage.prompt_tokens }
-                : {}),
-              ...(chunk.usage.completion_tokens !== undefined
-                ? { candidatesTokenCount: chunk.usage.completion_tokens }
-                : {}),
-            },
-          }
-        : {}),
+      candidates: [
+        {
+          content: { role: "model", parts: terminalParts },
+          finishReason: terminalFinish,
+          index: 0,
+        },
+      ],
+      ...(latestUsage !== undefined ? { usageMetadata: latestUsage } : {}),
+    };
+    return;
+  }
+
+  // Defensive: the IR stream ended WITHOUT a finish chunk (e.g. an abort). Still
+  // surface any buffered tool calls + usage once so the client loses nothing.
+  const parts = flushToolParts();
+  if (parts.length > 0 || latestUsage !== undefined) {
+    yield {
+      candidates: [{ content: { role: "model", parts }, index: 0 }],
+      ...(latestUsage !== undefined ? { usageMetadata: latestUsage } : {}),
     };
   }
 }

--- a/packages/core/src/protocol/gemini/gemini-types.ts
+++ b/packages/core/src/protocol/gemini/gemini-types.ts
@@ -129,8 +129,9 @@ export const GeminiGenerateContentResponseSchema = z
   .passthrough();
 export type GeminiGenerateContentResponse = z.infer<typeof GeminiGenerateContentResponseSchema>;
 
-// —— Streaming (?alt=sse): each SSE event is a COMPLETE GenerateContentResponse
-// snapshot, so the SSE event schema is the response schema itself. ————————————————
+// —— Streaming (?alt=sse): each SSE event is a GenerateContentResponse carrying an
+// INCREMENTAL delta (clients accumulate text frame to frame). The event shape equals
+// the response shape, so the SSE event schema reuses the response schema. ——————————
 
 export const GeminiSSEEventSchema = GeminiGenerateContentResponseSchema;
 export type GeminiSSEEvent = z.infer<typeof GeminiSSEEventSchema>;


### PR DESCRIPTION
## Why

The README/docs marked `POST /v1beta/models/{model}:generateContent` (Google Gemini) as **❌ non-streaming**. The endpoint was actually wired end-to-end since #58 — what was missing was **wire-format correctness**:

> `transformStreamOut` emitted **cumulative snapshots** (every event carried the *entire* accumulated text), but real Gemini `streamGenerateContent?alt=sse` emits **incremental deltas** that clients concatenate (`text += chunk.text`). A genuine Gemini SDK client pointed at our endpoint would have seen massively duplicated text (`"Hi"` → `"HiHi there"`). The team correctly documented ❌ rather than ship broken streaming.

## What

Rewrote `transformStreamOut` to emit **deltas**:
- forward each IR text delta verbatim (no accumulator);
- buffer tool-call arg fragments and flush **one** complete `functionCall` part on the terminal frame;
- **hold the terminal frame until stream end** and merge the trailing `stream_options.include_usage` chunk, so `finishReason` + `usageMetadata` land on a **single** terminal frame (never a `STOP` frame followed by a stray usage-only frame);
- defensive flush when the IR stream ends without a finish chunk (abort).

The inbound `transformStreamIn` already tolerates both shapes (non-prefix fallback), so only the outbound mapper changed.

## Tests & docs

- `gemini-transformer.test.ts` + `messages-pipeline.gemini.test.ts` rewritten from snapshot → **delta** assertions (concat-all == full text, no duplication, exactly one `finishReason`/`usageMetadata`/`functionCall`).
- `README.md` / `README.zh-CN.md` Gemini row → ✅; `docs/05`, `implementation-notes.md`, and stale "snapshot/full response" code comments updated.

## Verification

- `pnpm typecheck` ✅
- Biome ✅
- **46 Gemini tests pass** (transformer + route + pipeline)

## Addressed in review

This PR already incorporates a Codex review pass: the dual-terminal-frame usage bug (P1), the stale cumulative-snapshot pipeline test (P1), and four stale "snapshot" comments (P2) are all fixed here.

> ⚠️ Tests are unit-level only — recommend a live smoke test against a real Gemini SDK client before relying on it in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)