### PR TITLE
feat(protocol): IR foundation for litellm parity (Phase 1)

### DIFF
--- a/packages/core/src/protocol/anthropic/stream.ts
+++ b/packages/core/src/protocol/anthropic/stream.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { IRChunk } from "../gemini/gemini-types.js";
-import type { IRResponse, IRUsage } from "../ir.js";
+import { IRAnnotationSchema, IRLogprobsSchema, type IRResponse, type IRUsage } from "../ir.js";
 import {
   type AnthropicStopReason,
   type AnthropicUsage,
@@ -58,6 +58,12 @@ const OpenAIChunkDeltaSchema = z.object({
   role: z.string().optional(),
   content: z.string().nullable().optional(),
   tool_calls: z.array(OpenAIToolCallDeltaSchema).optional(),
+  // litellm-parity: reasoning streamed by DeepSeek/o-series; citations + logprobs on
+  // the delta. Optional + shared shapes (ir.ts) so the identity OpenAI stream carries
+  // them through to every downstream protocol consumer.
+  reasoning_content: z.string().nullable().optional(),
+  annotations: z.array(IRAnnotationSchema).optional(),
+  logprobs: IRLogprobsSchema.nullable().optional(),
 });
 
 const OpenAIChunkChoiceSchema = z.object({

--- a/packages/core/src/protocol/gemini/gemini-types.ts
+++ b/packages/core/src/protocol/gemini/gemini-types.ts
@@ -1,4 +1,11 @@
 import { z } from "zod";
+import {
+  IRAnnotationSchema,
+  IRAudioOutSchema,
+  IRLogprobsSchema,
+  IRThinkingBlockSchema,
+  IRTokenDetailsSchema,
+} from "../ir.js";
 
 // Gemini generateContent / streamGenerateContent wire schemas (docs/05). Zod is the
 // SINGLE type source (CLAUDE.md): every Gemini type below is `z.infer`-ed, never a
@@ -149,6 +156,15 @@ export const IRChunkDeltaSchema = z.object({
   role: z.string().optional(),
   content: z.string().nullable().optional(),
   tool_calls: z.array(IRToolCallDeltaSchema).optional(),
+  // —— litellm-parity streaming delta extensions (all optional). reasoning_content
+  // streams ahead of text (DeepSeek/o-series); thinking_blocks/annotations/audio/
+  // logprobs ride the same delta. Shared shapes come from ir.ts so every protocol's
+  // stream machine emits/consumes ONE form. ————————————————————————————————————————
+  reasoning_content: z.string().nullable().optional(),
+  thinking_blocks: z.array(IRThinkingBlockSchema).optional(),
+  annotations: z.array(IRAnnotationSchema).optional(),
+  audio: IRAudioOutSchema.optional(),
+  logprobs: IRLogprobsSchema.nullable().optional(),
 });
 
 export const IRChunkChoiceSchema = z.object({
@@ -162,6 +178,10 @@ export const IRChunkUsageSchema = z
     prompt_tokens: z.number().int().nonnegative().optional(),
     completion_tokens: z.number().int().nonnegative().optional(),
     cached_tokens: z.number().int().nonnegative().optional(),
+    reasoning_tokens: z.number().int().nonnegative().optional(),
+    cache_creation_tokens: z.number().int().nonnegative().optional(),
+    prompt_tokens_details: IRTokenDetailsSchema.optional(),
+    completion_tokens_details: IRTokenDetailsSchema.optional(),
   })
   .partial();
 

--- a/packages/core/src/protocol/ir.test.ts
+++ b/packages/core/src/protocol/ir.test.ts
@@ -61,7 +61,120 @@ describe("IRContentPartSchema — multipart typed content", () => {
   });
 
   it("rejects an unknown content part `type` via discriminatedUnion", () => {
-    expect(() => IRContentPartSchema.parse({ type: "video", url: "x" })).toThrow(ZodError);
+    expect(() => IRContentPartSchema.parse({ type: "hologram", url: "x" })).toThrow(ZodError);
+  });
+
+  it("parses the new multimodal part types (audio / video / document)", () => {
+    expect(IRContentPartSchema.parse({ type: "audio", data: "AAAA", format: "wav" }).type).toBe(
+      "audio",
+    );
+    expect(
+      IRContentPartSchema.parse({ type: "video", url: "gs://b/v.mp4", fps: 2, startOffset: "0s" })
+        .type,
+    ).toBe("video");
+    expect(
+      IRContentPartSchema.parse({ type: "document", data: "JVBER", mediaType: "application/pdf" })
+        .type,
+    ).toBe("document");
+  });
+});
+
+describe("IRRequestSchema — litellm parity request params (all optional)", () => {
+  it("carries sampling + control params without stripping", () => {
+    const input = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hi" }],
+      top_p: 0.9,
+      top_k: 40,
+      frequency_penalty: 0.5,
+      presence_penalty: -0.5,
+      seed: 7,
+      stop: ["\n\n", "STOP"],
+      n: 1,
+      logprobs: true,
+      top_logprobs: 5,
+      parallel_tool_calls: false,
+      stream_options: { include_usage: true },
+      modalities: ["text", "audio"],
+      user: "u-123",
+      service_tier: "auto",
+      reasoning_effort: "high",
+    } as const;
+    const parsed = IRRequestSchema.parse(input);
+    expect(parsed.top_p).toBe(0.9);
+    expect(parsed.stop).toEqual(["\n\n", "STOP"]);
+    expect(parsed.stream_options?.include_usage).toBe(true);
+    expect(parsed.modalities).toContain("audio");
+    expect(parsed.reasoning_effort).toBe("high");
+  });
+
+  it("accepts a bare string `stop`", () => {
+    const parsed = IRRequestSchema.parse({
+      model: "m",
+      messages: [{ role: "user", content: "x" }],
+      stop: "END",
+    });
+    expect(parsed.stop).toBe("END");
+  });
+
+  it("rejects an illegal reasoning_effort value (fail-closed)", () => {
+    expect(() =>
+      IRRequestSchema.parse({
+        model: "m",
+        messages: [{ role: "user", content: "x" }],
+        reasoning_effort: "ultra",
+      }),
+    ).toThrow(ZodError);
+  });
+});
+
+describe("IRMessageSchema — litellm parity response fields", () => {
+  it("carries reasoning_content, thinking_blocks, annotations, images, audio", () => {
+    const parsed = IRMessageSchema.parse({
+      role: "assistant",
+      content: "answer",
+      reasoning_content: "let me think",
+      thinking_blocks: [{ type: "thinking", thinking: "step", signature: "sig" }],
+      annotations: [
+        { type: "url_citation", url: "https://x", title: "X", start_index: 0, end_index: 5 },
+      ],
+      images: [{ b64_json: "AAAA", mediaType: "image/png" }],
+      audio: { id: "a1", data: "BBBB", transcript: "hello", expires_at: 1000 },
+    });
+    expect(parsed.reasoning_content).toBe("let me think");
+    expect(parsed.thinking_blocks?.[0]?.signature).toBe("sig");
+    expect(parsed.annotations?.[0]?.url).toBe("https://x");
+    expect(parsed.images?.[0]?.b64_json).toBe("AAAA");
+    expect(parsed.audio?.transcript).toBe("hello");
+  });
+});
+
+describe("IRUsageSchema / IRChoiceSchema — litellm parity usage + logprobs", () => {
+  it("carries token detail breakdown and reasoning/cache-creation tokens", () => {
+    const parsed = IRResponseSchema.parse({
+      id: "r",
+      model: "m",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "hi" },
+          finish_reason: "stop",
+          logprobs: { content: [{ token: "hi", logprob: -0.1, top_logprobs: [] }] },
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        cached_tokens: 4,
+        reasoning_tokens: 2,
+        cache_creation_tokens: 3,
+        prompt_tokens_details: { text_tokens: 6, cached_tokens: 4, image_tokens: 0 },
+        completion_tokens_details: { text_tokens: 3, reasoning_tokens: 2 },
+      },
+    });
+    expect(parsed.usage?.reasoning_tokens).toBe(2);
+    expect(parsed.usage?.prompt_tokens_details?.text_tokens).toBe(6);
+    expect(parsed.choices[0]?.logprobs?.content?.[0]?.token).toBe("hi");
   });
 });
 

--- a/packages/core/src/protocol/ir.ts
+++ b/packages/core/src/protocol/ir.ts
@@ -40,12 +40,124 @@ export const IRThinkingPartSchema = z.object({
   signature: z.string().optional(), // Anthropic thinking signature
 });
 
+// —— Multimodal input parts (litellm parity). Audio carries inline base64 + a
+// format hint (wav/mp3/…); video/document accept a remote url OR inline base64 and
+// optional metadata. The transformer enforces per-provider rules; the IR only needs
+// a lossless home so audio/video/document survive translation. ————————————————————
+export const IRAudioPartSchema = z.object({
+  type: z.literal("audio"),
+  data: z.string(), // base64
+  format: z.string(), // wav | mp3 | aac | flac | pcm | …
+  transcript: z.string().optional(),
+});
+
+export const IRVideoPartSchema = z.object({
+  type: z.literal("video"),
+  url: z.string().optional(), // remote / gs:// reference
+  data: z.string().optional(), // OR inline base64
+  mediaType: z.string().optional(),
+  fps: z.number().optional(),
+  startOffset: z.string().optional(), // e.g. "1.5s"
+  endOffset: z.string().optional(),
+});
+
+export const IRDocumentPartSchema = z.object({
+  type: z.literal("document"),
+  url: z.string().optional(),
+  data: z.string().optional(), // base64 (e.g. PDF)
+  mediaType: z.string().optional(),
+  filename: z.string().optional(),
+});
+
 export const IRContentPartSchema = z.discriminatedUnion("type", [
   IRTextPartSchema,
   IRImagePartSchema,
   IRThinkingPartSchema,
+  IRAudioPartSchema,
+  IRVideoPartSchema,
+  IRDocumentPartSchema,
 ]);
 export type IRContentPart = z.infer<typeof IRContentPartSchema>;
+
+// —— Shared parity sub-schemas (litellm unified model). Declared once here and
+// reused by IRMessage/IRChoice/IRUsage AND the streaming chunk (gemini-types.ts) and
+// the OpenAI chunk (anthropic/stream.ts), so reasoning/citations/logprobs/usage-
+// detail have ONE shape across every protocol. All permissive (.passthrough() where
+// upstreams add fields) and fail-open on unknown extras. ——————————————————————————
+
+/** Reasoning effort knob (OpenAI o-series / Anthropic budget / Gemini level). */
+export const IRReasoningEffortSchema = z.enum(["minimal", "low", "medium", "high"]);
+
+/** A thinking/redacted-thinking block (Anthropic-shaped; reused for streaming). */
+export const IRThinkingBlockSchema = z
+  .object({
+    type: z.string(), // "thinking" | "redacted_thinking"
+    thinking: z.string().optional(),
+    data: z.string().optional(), // redacted payload
+    signature: z.string().optional(),
+  })
+  .passthrough();
+export type IRThinkingBlock = z.infer<typeof IRThinkingBlockSchema>;
+
+/** A citation/annotation (OpenAI url_citation shape; grounding folds in here). */
+export const IRAnnotationSchema = z
+  .object({
+    type: z.string(), // "url_citation" | "file_citation" | …
+    url: z.string().optional(),
+    title: z.string().optional(),
+    text: z.string().optional(),
+    start_index: z.number().int().optional(),
+    end_index: z.number().int().optional(),
+  })
+  .passthrough();
+export type IRAnnotation = z.infer<typeof IRAnnotationSchema>;
+
+/** Token-level logprobs (OpenAI ChoiceLogprobs shape). */
+export const IRTopLogprobSchema = z.object({
+  token: z.string(),
+  logprob: z.number(),
+  bytes: z.array(z.number().int()).nullable().optional(),
+});
+export const IRLogprobTokenSchema = z.object({
+  token: z.string(),
+  logprob: z.number(),
+  bytes: z.array(z.number().int()).nullable().optional(),
+  top_logprobs: z.array(IRTopLogprobSchema).optional(),
+});
+export const IRLogprobsSchema = z
+  .object({ content: z.array(IRLogprobTokenSchema).nullable().optional() })
+  .passthrough();
+export type IRLogprobs = z.infer<typeof IRLogprobsSchema>;
+
+/** A model-generated image (vision/image-out models). */
+export const IRImageOutSchema = z.object({
+  url: z.string().optional(),
+  b64_json: z.string().optional(),
+  mediaType: z.string().optional(),
+  revised_prompt: z.string().optional(),
+});
+
+/** A model-generated audio response (OpenAI ChatCompletionAudioResponse shape). */
+export const IRAudioOutSchema = z.object({
+  id: z.string().optional(),
+  data: z.string().optional(),
+  transcript: z.string().optional(),
+  expires_at: z.number().int().optional(),
+});
+
+/** Per-modality / cache token breakdown (prompt or completion side). */
+export const IRTokenDetailsSchema = z
+  .object({
+    text_tokens: z.number().int().nonnegative().optional(),
+    audio_tokens: z.number().int().nonnegative().optional(),
+    image_tokens: z.number().int().nonnegative().optional(),
+    video_tokens: z.number().int().nonnegative().optional(),
+    cached_tokens: z.number().int().nonnegative().optional(),
+    reasoning_tokens: z.number().int().nonnegative().optional(),
+    cache_creation_tokens: z.number().int().nonnegative().optional(),
+  })
+  .partial()
+  .passthrough();
 
 // —— Tool call (carries an ID; OpenAI's integer stream index is reconciled by
 // the streaming state machine, not stored here). ————————————————————————————
@@ -74,6 +186,16 @@ export const IRMessageSchema = z.object({
   tool_calls: z.array(IRToolCallSchema).optional(), // assistant initiates
   tool_call_id: z.string().optional(), // role=tool backfills the matching id
   name: z.string().optional(),
+  // —— litellm-parity response extensions (all optional). reasoning_content is the
+  // flat reasoning string (DeepSeek/Groq/o-series); thinking_blocks is the structured
+  // Anthropic form (kept in parallel, NOT folded into content). annotations carries
+  // citations/grounding. images/audio carry model-GENERATED media (distinct from the
+  // input image/audio content parts). ————————————————————————————————————————————————
+  reasoning_content: z.string().nullable().optional(),
+  thinking_blocks: z.array(IRThinkingBlockSchema).optional(),
+  annotations: z.array(IRAnnotationSchema).optional(),
+  images: z.array(IRImageOutSchema).optional(),
+  audio: IRAudioOutSchema.optional(),
 });
 export type IRMessage = z.infer<typeof IRMessageSchema>;
 
@@ -101,7 +223,25 @@ export const IRRequestSchema = z.object({
   stream: z.boolean().optional(),
   response_format: z.unknown().optional(),
   cache_control: z.unknown().optional(), // extension: cache-control passthrough
-  thinking: z.unknown().optional(), // extension: reasoning/thinking config
+  thinking: z.unknown().optional(), // extension: provider-shaped reasoning/thinking config
+  // —— litellm-parity sampling + control params (all optional). The IR holds them;
+  // each transformer maps the subset its protocol supports and warns/passes through
+  // the rest (a backend that can't honor `n>1` rejects cleanly, never silently drops).
+  top_p: z.number().optional(),
+  top_k: z.number().int().optional(),
+  frequency_penalty: z.number().optional(),
+  presence_penalty: z.number().optional(),
+  seed: z.number().int().optional(),
+  stop: z.union([z.string(), z.array(z.string())]).optional(),
+  n: z.number().int().positive().optional(),
+  logprobs: z.boolean().optional(),
+  top_logprobs: z.number().int().nonnegative().optional(),
+  parallel_tool_calls: z.boolean().optional(),
+  stream_options: z.object({ include_usage: z.boolean().optional() }).passthrough().optional(),
+  modalities: z.array(z.enum(["text", "audio", "image", "video"])).optional(),
+  reasoning_effort: IRReasoningEffortSchema.optional(),
+  user: z.string().optional(),
+  service_tier: z.string().optional(),
   provider_raw: ProviderRawSchema.optional(),
 });
 export type IRRequest = z.infer<typeof IRRequestSchema>;
@@ -115,6 +255,14 @@ export const IRUsageSchema = z
     prompt_tokens: z.number().int().nonnegative().optional(),
     completion_tokens: z.number().int().nonnegative().optional(),
     cached_tokens: z.number().int().nonnegative().optional(),
+    // —— litellm-parity usage detail (all optional). reasoning_tokens (o-series /
+    // Gemini thoughtsTokenCount), cache_creation_tokens (Anthropic ephemeral write),
+    // and per-modality breakdowns. The prompt−cached arithmetic stays the
+    // transformer's job; the IR only needs room to hold the detail. ————————————————
+    reasoning_tokens: z.number().int().nonnegative().optional(),
+    cache_creation_tokens: z.number().int().nonnegative().optional(),
+    prompt_tokens_details: IRTokenDetailsSchema.optional(),
+    completion_tokens_details: IRTokenDetailsSchema.optional(),
   })
   .partial();
 export type IRUsage = z.infer<typeof IRUsageSchema>;
@@ -128,6 +276,7 @@ export const IRChoiceSchema = z.object({
   index: z.number().int(),
   message: IRMessageSchema,
   finish_reason: z.string().nullable(),
+  logprobs: IRLogprobsSchema.nullable().optional(), // litellm-parity token logprobs
 });
 export type IRChoice = z.infer<typeof IRChoiceSchema>;
 


### PR DESCRIPTION
## Context

First slice of the **all-protocols litellm-parity roadmap**. A 6-agent audit found ~130 gaps across the four surfaces (OpenAI Chat 72%, Anthropic 62%, Responses 72%, Gemini 55–60%), all tracing back to the central **IR** being a lean OpenAI subset. This PR extends the IR + streaming-chunk schemas so the later per-protocol phases have a lossless home for every field — **no behavior change yet**, just the foundation.

## What

All additions are **optional** and Zod-validated (fail-closed); truly non-mappable upstream data still rides `provider_raw`.

- **IRContentPart** → + `audio` / `video` / `document` input parts.
- **Shared sub-schemas** (one shape across all protocols + streaming): reasoning-effort enum, `thinking_blocks`, `annotations` (citations/grounding), `logprobs`, generated `image`/`audio`, per-modality token-detail breakdown.
- **IRMessage** → + `reasoning_content`, `thinking_blocks`, `annotations`, `images`, `audio`.
- **IRRequest** → + `top_p`, `top_k`, `frequency/presence_penalty`, `seed`, `stop`, `n`, `logprobs`/`top_logprobs`, `parallel_tool_calls`, `stream_options`, `modalities`, `reasoning_effort`, `user`, `service_tier`.
- **IRUsage** → + `reasoning_tokens`, `cache_creation_tokens`, `prompt/completion_tokens_details`.
- **IRChoice** → + `logprobs`.
- **Streaming**: `IRChunkDelta`/`IRChunkUsage` (gemini-types) and the shared `OpenAIChunk` delta (anthropic/stream) gain the same fields, so the **identity OpenAI stream** carries reasoning/citations/logprobs/audio through to every downstream consumer.

## Design notes

- IR streaming chunk *is* the OpenAI `chat.completion.chunk` — so we extend the shared chunk schema rather than add a redundant OpenAI stream transformer.
- `finish_reason` stays a free string (mapping is each transformer's job); raw value in `provider_raw`.
- `n>1` is carried but will be reject-clean (cap+warn) in a later phase, never silent-drop.

## Verification

- `pnpm typecheck` ✅ · Biome ✅ · **247 protocol tests pass** (incl. new IR parity tests; all existing transformer tests green = backward-compat proof).

## Roadmap

Phase 1 of 9. Next: per-protocol request/response/streaming parity (Gemini → OpenAI Chat → Anthropic → Responses), reasoning unification, full multimodal I/O + capability routing, and the 16-path translation matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)