### PR TITLE
feat(config): 删除 openai-crs 中转，lane 改走 openai-codex 订阅 + 官方 DeepSeek

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,15 @@ HELM_ADMIN_USER=admin
 HELM_ADMIN_PASSWORD=change-me        # CHANGE THIS before deploying
 
 # —— Upstream provider credentials (injected via env, never in the repo) ——
-# Each maps to a providers.yaml entry's `api_key_env`. OPENAI_API_KEY is the
-# PRIMARY (openai-crs) credential and is mandatory; the others back the
+# Each maps to a providers.yaml entry's `api_key_env`. DEEPSEEK_API_KEY is the
+# PRIMARY (deepseek) credential and is mandatory — it backs the default path, the
+# Layer-2 eval call, and the Phase-0 passthrough. The others back the
 # cross-provider fallbacks (zenmux / openrouter) and may be omitted (those
 # providers are then skipped — their aliases fall back to the primary client).
-OPENAI_API_KEY=sk-...
+# To route premium/coding lanes through a ChatGPT/Codex subscription, connect it
+# in the admin UI (Providers → Connect) — that needs HELM_OAUTH_ENC_KEY below, not
+# an api key here.
+DEEPSEEK_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
 ZENMUX_API_KEY=sk-...
 OPENROUTER_API_KEY=sk-or-...
@@ -32,8 +36,8 @@ HELM_STORE_DRIVER=sqlite
 #   HELM_STORE_URL=postgresql://user:pass@host:5432/dbname
 
 # —— OAuth subscription providers (issue #38) ——
-# Required ONLY if you connect a Claude Pro/Max or GitHub Copilot subscription
-# (admin dashboard → Providers). Encrypts the stored (rotating) refresh tokens at
+# Required ONLY if you connect a ChatGPT/Codex, Claude Pro/Max, or GitHub Copilot
+# subscription (admin dashboard → Providers). Encrypts the stored (rotating) refresh tokens at
 # rest with AES-256-GCM. 32 bytes, as base64 OR 64 hex chars. The gateway refuses
 # to start if a subscription provider is configured without it. Generate one:
 #   openssl rand -base64 32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           docker rm -f helm-ci 2>/dev/null || true
           docker run -d --name helm-ci \
             -p 8080:8080 \
-            -e OPENAI_API_KEY=sk-ci-smoke-test \
+            -e DEEPSEEK_API_KEY=sk-ci-smoke-test \
             helm-api:ci
       - name: Wait for /healthz to be healthy
         run: |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A request flows: **auth → rate limit → classify → route → execute (with 
 # 1. Clone and create your env file
 git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
 cp .env.example .env
-#    In .env, set HELM_ADMIN_PASSWORD and at least OPENAI_API_KEY
+#    In .env, set HELM_ADMIN_PASSWORD and at least DEEPSEEK_API_KEY
 
 # 2. Start it
 docker compose up -d
@@ -140,7 +140,7 @@ curl http://localhost:8080/v1/chat/completions \
 | Value | What Helm does |
 |---|---|
 | `auto` *(recommended)* | Classifies the request and routes it to the best lane automatically. |
-| a model alias, e.g. `openai-crs/gpt-5.5` | Uses exactly that model and skips routing — only for keys granted custom-model permission. |
+| a model alias, e.g. `openai-codex/gpt-5.5` | Uses exactly that model and skips routing — only for keys granted custom-model permission. |
 
 > With a standard key, routing is automatic no matter what you send — just use `auto`. Lanes are configured by the operator in `lanes.yaml` and the dashboard; clients don't choose a lane per call.
 
@@ -163,7 +163,7 @@ Most-used environment variables (env wins over YAML; full list in [`.env.example
 
 | Variable | Purpose |
 |---|---|
-| `OPENAI_API_KEY` | Primary provider credential (**required**) |
+| `DEEPSEEK_API_KEY` | Primary provider credential (**required**) |
 | `ZENMUX_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY` | Optional provider credentials (provider is skipped if missing) |
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | Dashboard login (Basic auth) |
 | `HELM_HOST` / `HELM_PORT` | Server binding (default `0.0.0.0:8080`) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,7 +98,7 @@ helm-api/
 # 1. 克隆并创建环境变量文件
 git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
 cp .env.example .env
-#    在 .env 里至少设好 HELM_ADMIN_PASSWORD 和 OPENAI_API_KEY
+#    在 .env 里至少设好 HELM_ADMIN_PASSWORD 和 DEEPSEEK_API_KEY
 
 # 2. 启动
 docker compose up -d
@@ -140,7 +140,7 @@ curl http://localhost:8080/v1/chat/completions \
 | 取值 | Helm 的行为 |
 |---|---|
 | `auto`（推荐） | 对请求做分类，自动路由到最合适的 lane。 |
-| 模型别名，如 `openai-crs/gpt-5.5` | 精确使用该模型、跳过路由 —— 仅对获授「自定义模型」权限的 key 有效。 |
+| 模型别名，如 `openai-codex/gpt-5.5` | 精确使用该模型、跳过路由 —— 仅对获授「自定义模型」权限的 key 有效。 |
 
 > 用普通 key 时，无论你发什么，路由都是自动的 —— 直接用 `auto` 即可。Lane 由运维方在 `lanes.yaml` 和面板里配置，客户端不在单次调用里挑 lane。
 
@@ -163,7 +163,7 @@ curl http://localhost:8080/v1/chat/completions \
 
 | 变量 | 用途 |
 |---|---|
-| `OPENAI_API_KEY` | 主供应商凭证（**必填**） |
+| `DEEPSEEK_API_KEY` | 主供应商凭证（**必填**） |
 | `ZENMUX_API_KEY`、`OPENROUTER_API_KEY`、`ANTHROPIC_API_KEY` | 可选供应商凭证（缺失则跳过该供应商） |
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | 面板登录（Basic auth） |
 | `HELM_HOST` / `HELM_PORT` | 服务绑定（默认 `0.0.0.0:8080`） |

--- a/apps/admin/src/lib/api/models.test.ts
+++ b/apps/admin/src/lib/api/models.test.ts
@@ -15,7 +15,7 @@ describe('models api client', () => {
 
   it('listModels GETs /admin/api/models and returns model options (alias + accounts)', async () => {
     const rows = [
-      { alias: 'openai-crs/gpt-5.4-mini', accounts: [] },
+      { alias: 'deepseek/deepseek-v4-flash', accounts: [] },
       { alias: 'anthropic/claude-opus-4-8', accounts: ['default', 'work'] },
     ];
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(

--- a/apps/admin/src/lib/components/LaneEditor.test.ts
+++ b/apps/admin/src/lib/components/LaneEditor.test.ts
@@ -79,7 +79,7 @@ describe('LaneEditor', () => {
   });
 
   it('offers the model catalog as combobox suggestions on primary + fallback inputs', () => {
-    const aliases = ['openai-crs/gpt-5.4-mini', 'deepseek-crs/deepseek-pro', 'zenmux/auto'];
+    const aliases = ['deepseek/deepseek-v4-flash', 'openai-codex/gpt-5.5', 'zenmux/auto'];
     const models = aliases.map((alias) => ({ alias, accounts: [] }));
     const { container } = render(LaneEditor, { lane: makeLane(), models, onsave: vi.fn() });
 
@@ -99,7 +99,7 @@ describe('LaneEditor', () => {
   });
 
   it('also offers other lanes (excluding itself) as combobox targets, labelled as lanes', () => {
-    const aliases = ['openai-crs/gpt-5.4-mini', 'deepseek-crs/deepseek-pro'];
+    const aliases = ['deepseek/deepseek-v4-flash', 'openai-codex/gpt-5.5'];
     const models = aliases.map((alias) => ({ alias, accounts: [] }));
     const laneNames = ['economy', 'balanced', 'coding', 'premium'];
     const { container } = render(LaneEditor, {
@@ -132,7 +132,7 @@ describe('LaneEditor', () => {
     const models = [
       { alias: 'anthropic/claude-opus-4-8', accounts: ['default'] },
       { alias: 'openai-codex/gpt-5.5', accounts: ['default', 'mylukin'] },
-      { alias: 'openai-crs/gpt-5.4-mini', accounts: [] }, // configured → provider as label
+      { alias: 'deepseek/deepseek-v4-flash', accounts: [] }, // configured → provider as label
     ];
     const { container } = render(LaneEditor, { lane: makeLane(), models, onsave: vi.fn() });
     const options = Array.from(
@@ -141,7 +141,7 @@ describe('LaneEditor', () => {
     const labelOf = (v: string) => options.find((o) => o.value === v)?.label ?? '';
     expect(labelOf('anthropic/claude-opus-4-8')).toBe('default');
     expect(labelOf('openai-codex/gpt-5.5')).toBe('default, mylukin');
-    expect(labelOf('openai-crs/gpt-5.4-mini')).toBe('openai-crs');
+    expect(labelOf('deepseek/deepseek-v4-flash')).toBe('deepseek');
   });
 
   it('still works as a plain text input when no models are provided (graceful default)', () => {

--- a/apps/admin/src/routes/lanes/lanes.test.ts
+++ b/apps/admin/src/routes/lanes/lanes.test.ts
@@ -42,7 +42,7 @@ describe('lanes page', () => {
   });
 
   it('threads the model catalog into each lane card as combobox suggestions', () => {
-    const aliases = ['openai-crs/gpt-5.4-mini', 'deepseek-crs/deepseek-pro'];
+    const aliases = ['deepseek/deepseek-v4-flash', 'openai-codex/gpt-5.5'];
     const models = aliases.map((alias) => ({ alias, accounts: [] }));
     const { container } = renderPage([lane('economy'), lane('balanced')], models);
     // Every card gets a populated <datalist> sourced from data.models.

--- a/apps/gateway/e2e/eval.spec.ts
+++ b/apps/gateway/e2e/eval.spec.ts
@@ -47,8 +47,13 @@ const UNCERTAIN = { ...AUTH, "x-helm-rules-threshold": "0.99" };
 // Shipped config/lanes.yaml candidate heads (alias-namespace alignment,
 // 2026-05-31). Keep in lockstep with config/lanes.yaml `balanced`/`premium`
 // primaries.
-const BALANCED_HEAD = "deepseek-crs/deepseek-pro";
-const PREMIUM_HEAD = "openai-crs/gpt-5.5";
+// These e2e run with NO subscription connected, so a lane's nominal `openai-codex/*`
+// primary is SKIPPED (provider_unavailable) and the lane serves its first STATIC
+// fallback. premium's nominal primary is openai-codex/gpt-5.5 → it serves
+// deepseek/deepseek-v4-pro (the same model balanced serves; the lanes are told
+// apart by the x-helm-lane header, not the served model).
+const BALANCED_HEAD = "deepseek/deepseek-v4-pro";
+const PREMIUM_HEAD = "deepseek/deepseek-v4-pro";
 
 // An intentionally ambiguous prompt: no strong Layer-1 keyword signal. Paired
 // with the UNCERTAIN header (rules threshold 0.99) the cascade is guaranteed to
@@ -106,11 +111,10 @@ test.describe("eval cascade e2e", () => {
     request,
   }) => {
     const res = await request.post("/v1/chat/completions", {
-      // Stream: the premium head (openai-crs/gpt-5.5) is stream-only, so a
-      // non-stream request would skip it (no_nonstream_support) and serve a
-      // fallback; streaming keeps the asserted final model the lane head. The
-      // internal eval call is a separate non-stream classify request, unaffected.
-      data: chat(ambiguous("s2"), { stream: true }),
+      // The eval verdict picks the premium LANE; premium's openai-codex head is
+      // skipped (no subscription) so it serves the static fallback PREMIUM_HEAD.
+      // The internal eval call is a separate non-stream classify request.
+      data: chat(ambiguous("s2")),
       headers: { ...UNCERTAIN, "x-helm-eval": "on" },
     });
     expect(res.status()).toBe(200);

--- a/apps/gateway/e2e/fixtures/mock-upstream.ts
+++ b/apps/gateway/e2e/fixtures/mock-upstream.ts
@@ -42,14 +42,14 @@ export function echoResponse(model: string) {
 // gateway to fall forward to the next in-chain candidate. Exported so the spec
 // and the mock stay in lockstep.
 //
-// The economy lane head is the alias `openai-crs/gpt-5.4-mini`, whose RESOLVED
-// provider_model is the BARE upstream id `gpt-5.4-mini` (fix-upstream-model-id
-// 2026-05-31: alias != provider_model — the relay only accepts the bare id). The
-// gateway forwards that resolved provider_model upstream as `model`, so the mock
-// must match on the BARE id. Keep in lockstep with config/providers.yaml's
-// `provider_model` for config/lanes.yaml `economy.primary`.
+// The economy lane head is the alias `deepseek/deepseek-v4-flash`, whose RESOLVED
+// provider_model is the BARE upstream id `deepseek-v4-flash` (alias != provider_
+// model — the upstream accepts the bare id). The gateway forwards that resolved
+// provider_model upstream as `model`, so the mock must match on the BARE id. Keep
+// in lockstep with config/providers.yaml's `provider_model` for config/lanes.yaml
+// `economy.primary`.
 export const FAIL_PRIMARY_SENTINEL = "__HELM_FAIL_PRIMARY__";
-export const FAIL_PRIMARY_MODEL = "gpt-5.4-mini";
+export const FAIL_PRIMARY_MODEL = "deepseek-v4-flash";
 
 function messagesText(body: { messages?: unknown }): string {
   if (!Array.isArray(body.messages)) return "";
@@ -271,7 +271,7 @@ export function createMockUpstream() {
     // ── Layer-2 eval branch: the request is the internal classify call. We key
     //    on the eval SYSTEM-PROMPT marker ("Classify the request.", see
     //    apps/gateway/src/routes/classify.ts) — NOT the model id — so the eval
-    //    model can be a real model that ALSO serves a lane (e.g. deepseek-flash)
+    //    model can be a real model that ALSO serves a lane (e.g. deepseek-v4-flash)
     //    without the mock mistaking a normal routed request for an eval call
     //    (fix-upstream-model-id 2026-05-31). Returns a strict JSON judgment; the
     //    slow sentinel makes it exceed the eval timeout.

--- a/apps/gateway/e2e/routing.spec.ts
+++ b/apps/gateway/e2e/routing.spec.ts
@@ -19,27 +19,32 @@ import { FAIL_PRIMARY_SENTINEL } from "./fixtures/mock-upstream.js";
 const TEST_KEY = "helm_live_e2e_testkey";
 const AUTH = { Authorization: `Bearer ${TEST_KEY}`, "Content-Type": "application/json" };
 
-// Shipped config/lanes.yaml candidate aliases per lane (post chain-expansion
-// head). The router resolves an alias which the executor sends to the upstream
-// (the resolved provider_model == the alias, by the alias-namespace convention);
-// the mock echoes it back as `model`. Keep these in lockstep with the lane
-// primaries in config/lanes.yaml.
-const ECONOMY_HEAD = "openai-crs/gpt-5.4-mini";
-const PREMIUM_HEAD = "openai-crs/gpt-5.5";
-const BALANCED_HEAD = "deepseek-crs/deepseek-pro";
-// economy chain = [openai-crs/gpt-5.4-mini, deepseek-crs/deepseek-flash,
-// balanced...]; the in-chain candidate AFTER the economy head is the one that
-// serves when the head is fault-injected (scenario 4, EXECUTION fallback).
-const ECONOMY_NEXT = "deepseek-crs/deepseek-flash";
+// NO-SUBSCRIPTION FAIL-OPEN (the CI reality). These e2e run with NO subscription
+// connected, so the `openai-codex/*` lane heads (premium/coding/tool_use primaries
+// in config/lanes.yaml) are NOT routable: the executor SKIPS them with
+// skip_reason=provider_unavailable (never forwarding a prefixed id to the primary)
+// and the lane falls open to its first STATIC fallback. So the model that actually
+// SERVES each lane below is the deepseek/* (or zenmux/openrouter) static candidate,
+// not the nominal openai-codex primary. With a subscription connected, the codex
+// head would serve instead.
+const ECONOMY_HEAD = "deepseek/deepseek-v4-flash"; // economy static primary serves
+// premium's nominal primary is openai-codex/gpt-5.5 — skipped w/o a subscription,
+// so premium serves its first static fallback, deepseek/deepseek-v4-pro.
+const PREMIUM_HEAD = "deepseek/deepseek-v4-pro";
+const BALANCED_HEAD = "deepseek/deepseek-v4-pro"; // balanced static primary serves
+// economy chain = [deepseek/deepseek-v4-flash, openai-codex/gpt-5.4, balanced...].
+// On fault injection (scenario 4) the economy head 5xxs, the next candidate
+// openai-codex/gpt-5.4 is SKIPPED (no subscription), so the in-chain model that
+// actually serves is balanced's primary, deepseek/deepseek-v4-pro.
+const ECONOMY_NEXT = "deepseek/deepseek-v4-pro";
 
-// The upstream WIRE model ids the gateway actually sends (config/providers.yaml
-// `provider_model`), which the mock echoes back verbatim in the response `model`
-// field. Since fix-upstream-model-id decoupled alias from wire id, body.model is
-// the bare wire id; the routing ALIAS is surfaced separately via the
-// `x-helm-final-model` header (asserted above each body.model check).
-const ECONOMY_HEAD_WIRE = "gpt-5.4-mini";
-const PREMIUM_HEAD_WIRE = "gpt-5.5";
-const ECONOMY_NEXT_WIRE = "deepseek-flash";
+// The upstream WIRE model ids the gateway sends (config/providers.yaml
+// `provider_model`), echoed back by the mock as `model`. All served candidates
+// here are EXPLICIT deepseek/* entries, so the wire id is the bare provider_model.
+// The routing ALIAS is surfaced separately via `x-helm-final-model`.
+const ECONOMY_HEAD_WIRE = "deepseek-v4-flash";
+const PREMIUM_HEAD_WIRE = "deepseek-v4-pro";
+const ECONOMY_NEXT_WIRE = "deepseek-v4-pro";
 
 function chat(content: string, extra: Record<string, unknown> = {}) {
   return {
@@ -52,18 +57,14 @@ function chat(content: string, extra: Record<string, unknown> = {}) {
 
 test.describe("routing e2e", () => {
   // ── Scenario 1: simple prompt → economy lane ────────────────────────────────
-  // The economy head (openai-crs/gpt-5.4-mini) is STREAM-ONLY on the relay
-  // (capabilities.yaml requiresStreaming:true), so exercise it with a STREAMING
-  // request — a non-stream request would (correctly) skip the head with
-  // skip_reason no_nonstream_support and fall to the next in-chain candidate
-  // (covered by the non-stream paths elsewhere). Routing is asserted via the
-  // debug headers, which the gateway emits BEFORE the SSE body; the resolved bare
-  // wire id is surfaced separately as x-helm-provider-model.
+  // The economy head (deepseek/deepseek-v4-flash) is json + non-stream capable, so
+  // a plain non-stream request serves it directly. Routing is asserted via the
+  // debug headers; the resolved bare wire id is surfaced as x-helm-provider-model.
   test("simple prompt -> economy lane", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
       // Clearly-simple: strong simple-keyword signals (hi/thanks/ok) push the
       // score well below the `standard` boundary -> confident `simple` -> economy.
-      data: chat("hi thanks, translate to spanish: ok", { stream: true }),
+      data: chat("hi thanks, translate to spanish: ok"),
       headers: AUTH,
     });
     expect(res.status()).toBe(200);
@@ -74,12 +75,15 @@ test.describe("routing e2e", () => {
   });
 
   // ── Scenario 2: complex prompt → premium lane ───────────────────────────────
-  // Premium head (openai-crs/gpt-5.5) is likewise stream-only — exercise via streaming.
+  // Premium's nominal primary (openai-codex/gpt-5.5) is the subscription channel;
+  // with no subscription connected it is SKIPPED (provider_unavailable) and premium
+  // fails open to its first static fallback, deepseek/deepseek-v4-pro. The lane is
+  // still `premium` (asserted via the header) — only the served model is the
+  // fallback.
   test("complex prompt -> premium lane", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
       data: chat(
         "Prove step by step the theorem and derive the integral, reason about the matrix equation and analyze the implications first then finally compile the proof.",
-        { stream: true },
       ),
       headers: AUTH,
     });
@@ -116,21 +120,22 @@ test.describe("routing e2e", () => {
   });
 
   // ── Scenario 4: primary provider error → EXECUTION fallback serves ──────────
-  // Mock injects a one-shot 5xx for the economy head (`openai-crs/gpt-5.4-mini`);
-  // the chain's NEXT candidate (`deepseek-crs/deepseek-flash`) must serve. Lane
+  // Mock injects a one-shot 5xx for the economy head (`deepseek/deepseek-v4-flash`);
+  // the next candidate `openai-codex/gpt-5.4` is skipped (no subscription), so the
+  // first STATIC in-chain candidate that serves is `deepseek/deepseek-v4-pro`. Lane
   // stays `economy` (execution fallback ≠ classification fallback, principle 5).
   test("primary provider error -> fallback model serves (execution fallback)", async ({
     request,
   }) => {
     // The prompt routes to economy (simple) AND carries the fail sentinel so the
     // mock 5xxs the economy head. The gateway only forwards model+messages
-    // upstream, so the fault is steered through the prompt. STREAMING so the
-    // stream-only economy head is actually INVOKED (and then 5xxs) — a non-stream
-    // request would skip the head on capability grounds and never exercise the
-    // upstream-error fallback this scenario is about.
+    // upstream, so the fault is steered through the prompt. The economy head is
+    // invoked (non-stream) and 5xxs, so the gateway falls forward past the skipped
+    // codex candidate to the next static one — the upstream-error fallback this
+    // scenario is about.
     const res = await request.post("/v1/chat/completions", {
       // Same clearly-simple economy prompt as scenario 1, plus the fail sentinel.
-      data: chat(`hi thanks, translate to spanish: ok ${FAIL_PRIMARY_SENTINEL}`, { stream: true }),
+      data: chat(`hi thanks, translate to spanish: ok ${FAIL_PRIMARY_SENTINEL}`),
       headers: AUTH,
     });
     expect(res.status()).toBe(200);

--- a/apps/gateway/playwright.config.ts
+++ b/apps/gateway/playwright.config.ts
@@ -19,7 +19,10 @@ const e2eEnv = {
   // Resolved against the gateway CWD (repo root, set on the webServer below).
   HELM_DATA_DIR: "./apps/gateway/.e2e-data",
   HELM_TEST_KEY: "helm_live_e2e_testkey",
-  OPENAI_API_KEY: "sk-upstream-mock-key",
+  // PRIMARY (deepseek) provider credential — mandatory; the gateway fail-closes
+  // without it. A dummy value is enough: HELM_PROVIDER_BASE_URL points every
+  // provider at the offline mock, so no real key is ever used.
+  DEEPSEEK_API_KEY: "sk-upstream-mock-key",
   HELM_PROVIDER_BASE_URL: `http://127.0.0.1:${MOCK_PORT}`,
   // e2e-only: lets the `x-helm-eval` request header toggle Layer-2 eval per
   // request so e2e.eval can black-box the cascade without a config reload.

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -230,7 +230,7 @@ function buildDeps(over: Partial<AdminApiDeps> = {}): AdminApiDeps {
     accountId: "acct_default",
     modelAliases: () =>
       Promise.resolve(
-        ["openai-crs/gpt-5.4-mini", "deepseek-crs/deepseek-pro", "zenmux/auto"].map((alias) => ({
+        ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro", "zenmux/auto"].map((alias) => ({
           alias,
           accounts: [],
         })),

--- a/apps/gateway/src/routes/execute.default-config.test.ts
+++ b/apps/gateway/src/routes/execute.default-config.test.ts
@@ -170,11 +170,11 @@ describe("default config activates capability filter + cost (alias-namespace ali
   it("sanity: the shipped catalog is keyed by the SAME provider/model aliases the lanes use", () => {
     // Pre-alignment these were absent (lane aliases like `cheap_model` had no
     // catalog entry). Now every lane candidate alias resolves in the catalog.
-    expect(catalog.get("openai-crs/gpt-5.4-mini")?.capabilities.supportsJsonMode).toBe(true);
+    expect(catalog.get("deepseek/deepseek-v4-flash")?.capabilities.supportsJsonMode).toBe(true);
     expect(catalog.get("zenmux/auto")?.capabilities.supportsJsonMode).toBe(false);
     expect(catalog.get("openrouter/auto")?.capabilities.supportsJsonMode).toBe(false);
     // pricing is populated (so cost can be computed, not null).
-    expect(catalog.get("openai-crs/gpt-5.4-mini")?.pricing.inputPerMTokUsd).toBeGreaterThan(0);
+    expect(catalog.get("deepseek/deepseek-v4-flash")?.pricing.inputPerMTokUsd).toBeGreaterThan(0);
   });
 
   it("PRUNES a json-incapable */auto candidate and lands on a json-capable model (skip_reason recorded)", async () => {
@@ -193,24 +193,22 @@ describe("default config activates capability filter + cost (alias-namespace ali
     // A chain that puts the json-INCAPABLE auto FIRST, then a json-capable model.
     // A needs_json request must SKIP the auto (skip_reason no_json_support) and
     // land on the capable model — proving the filter prunes on the real catalog.
-    // The landing model is deepseek-crs/deepseek-pro (json + non-stream capable);
-    // the gpt-5.x relay heads are stream-ONLY (requiresStreaming) so a non-stream
-    // request would skip them too (covered by the json-lane test below).
-    const chain = ["zenmux/auto", "deepseek-crs/deepseek-pro"];
+    // The landing model is deepseek/deepseek-v4-pro (json-capable).
+    const chain = ["zenmux/auto", "deepseek/deepseek-v4-pro"];
     const out = await execute(plan(chain), req({ response_format: { type: "json_object" } }));
 
     expect(out.attempts[0]?.alias).toBe("zenmux/auto");
     expect(out.attempts[0]?.skipped).toBe(true);
     expect(out.attempts[0]?.skip_reason).toBe("no_json_support");
     expect(out.final.status).toBe("ok");
-    if (out.final.status === "ok") expect(out.final.alias).toBe("deepseek-crs/deepseek-pro");
+    if (out.final.status === "ok") expect(out.final.alias).toBe("deepseek/deepseek-v4-pro");
     // The pruned auto must NEVER have been invoked upstream. The upstream `model`
-    // is the RESOLVED bare provider_model (`deepseek-pro`), not the alias.
-    expect(calls).toEqual(["deepseek-pro"]);
+    // is the RESOLVED bare provider_model (`deepseek-v4-pro`), not the alias.
+    expect(calls).toEqual(["deepseek-v4-pro"]);
   });
 
-  it("the shipped `json` lane chain prunes its */auto tail for a needs_json request", async () => {
-    const { client } = stubProvider();
+  it("the shipped `json` lane serves its json-capable primary and never reaches the */auto tail", async () => {
+    const { client, calls } = stubProvider();
     const execute = createExecute({
       defaultProvider: client,
       providers: providerClients(client),
@@ -220,23 +218,20 @@ describe("default config activates capability filter + cost (alias-namespace ali
       now: clock(),
       signal: new AbortController().signal,
     });
-    // Expand the REAL shipped `json` lane: primary openai-crs/gpt-5.4-mini, then
+    // Expand the REAL shipped `json` lane: primary deepseek/deepseek-v4-flash, then
     // balanced (whose tail is zenmux/auto + openrouter/auto, both json-incapable).
     const chain = expandChain("json");
-    expect(chain).toContain("openai-crs/gpt-5.4-mini");
+    expect(chain).toContain("deepseek/deepseek-v4-flash");
     expect(chain).toContain("zenmux/auto");
     expect(chain).toContain("openrouter/auto");
     const out = await execute(plan(chain), req({ response_format: { type: "json_object" } }));
     expect(out.final.status).toBe("ok");
-    // The json primary openai-crs/gpt-5.4-mini is stream-ONLY (requiresStreaming),
-    // so a non-stream request SKIPS it (no_nonstream_support) without invoking it,
-    // and the chain lands on the next json + non-stream capable model,
-    // deepseek-crs/deepseek-pro. The json-incapable */auto tails are pruned too
-    // (no_json_support, proven head-on by the previous test) but are never reached.
-    const primary = out.attempts.find((a) => a.alias === "openai-crs/gpt-5.4-mini");
-    expect(primary?.skipped).toBe(true);
-    expect(primary?.skip_reason).toBe("no_nonstream_support");
-    if (out.final.status === "ok") expect(out.final.alias).toBe("deepseek-crs/deepseek-pro");
+    // The json primary deepseek/deepseek-v4-flash is json-capable AND serves
+    // non-stream requests, so it lands FIRST — the json-incapable */auto tails
+    // (which WOULD be pruned, proven head-on by the previous test) are never
+    // reached. The upstream `model` is the bare provider_model.
+    if (out.final.status === "ok") expect(out.final.alias).toBe("deepseek/deepseek-v4-flash");
+    expect(calls).toEqual(["deepseek-v4-flash"]);
   });
 
   it("a chain of ONLY json-incapable candidates → capability_unsatisfiable (422 class)", async () => {
@@ -277,10 +272,9 @@ describe("default config activates capability filter + cost (alias-namespace ali
       now: clock(),
       signal: new AbortController().signal,
     });
-    // Serve a plain (non-stream) request on the balanced json head
-    // deepseek-crs/deepseek-pro. The gpt-5.x relay heads are stream-ONLY
-    // (requiresStreaming) so they can't serve this non-stream request.
-    const out = await execute(plan(["deepseek-crs/deepseek-pro"]), req());
+    // Serve a plain (non-stream) request on the balanced head
+    // deepseek/deepseek-v4-pro (json-capable, non-stream OK).
+    const out = await execute(plan(["deepseek/deepseek-v4-pro"]), req());
     expect(out.final.status).toBe("ok");
     const served = out.attempts.find((a) => a.status === "ok");
     expect(served).toBeDefined();

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -160,8 +160,8 @@ export function createExecute(deps: ExecuteAdapterDeps) {
 
   // Cost of one served attempt = provider usage × catalog pricing (docs/07).
   // Keyed by the candidate ALIAS — the catalog/pricing modelKey is the routing
-  // alias (e.g. `openai-crs/gpt-5.4-mini`), NOT the bare upstream model id we send
-  // on the wire (`gpt-5.4-mini`). See the resolve block below.
+  // alias (e.g. `deepseek/deepseek-v4-flash`), NOT the bare upstream model id we
+  // send on the wire (`deepseek-v4-flash`). See the resolve block below.
   // Prefer an upstream-BILLED cost the response carried (real money charged —
   // `usage.cost_usd` / OpenRouter `usage.cost` / top-level `cost_usd`); otherwise
   // estimate from token usage × catalog pricing (resolveCostUsd, the single
@@ -208,11 +208,11 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       // out and must not be conflated (fix-upstream-model-id 2026-05-31):
       //   • alias        — the ROUTING key. The catalog/pricing modelKey, the
       //     circuit-breaker key, and the decision-record id are ALL the alias
-      //     (e.g. `openai-crs/gpt-5.4-mini`). This is what the rest of the system
+      //     (e.g. `deepseek/deepseek-v4-flash`). This is what the rest of the system
       //     keys on; the generated catalog is keyed by it.
       //   • providerModel — the provider's REAL upstream model id (e.g.
-      //     `gpt-5.4-mini`). The ONLY thing it is used for is the wire `model`
-      //     field we send upstream. The relay rejects anything else with a 500.
+      //     `deepseek-v4-flash`). The ONLY thing it is used for is the wire `model`
+      //     field we send upstream. The upstream rejects anything else with a 4xx/5xx.
       // An unknown alias is a config gap: keep the alias as the upstream model id
       // too and use the default provider (fail-open — never substitute a different
       // model silently). A resolved alias selects BOTH the upstream model id AND
@@ -261,6 +261,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           providerModel = alias.slice(slash + 1);
           provider = providers.get(prefix);
         } else {
+          // A BARE alias (no provider prefix): Phase-0 passthrough to the default
+          // provider with the alias as the upstream model id (single-provider
+          // deploys; never substitute a different model silently).
           providerModel = alias;
           provider = defaultProvider;
         }

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -18,53 +18,46 @@
 #   maxOutputTokens: 4096
 
 # ─────────────────────────────────────────────────────────────────────────────
-# RELAY / SELF-HOSTED MODELS (fix-upstream-model-id+catalog-reuse 2026-05-31).
-# These live HERE (the manual override layer), NOT in the generated catalog:
-# they are crs/aggregator relay aliases the LiteLLM-sourced `pnpm sync:catalog`
+# SUBSCRIPTION / AGGREGATOR MODELS (drop-openai-crs-relay 2026-06-03). These live
+# HERE (the manual override layer), NOT in the generated catalog: they are
+# subscription + aggregator aliases the LiteLLM-sourced `pnpm sync:catalog`
 # artifact cannot know about, so a sync would wipe them. Keyed by the routing
-# ALIAS (== the catalog modelKey the executor looks up; see execute.ts). Values
-# are the curated, battle-tested data from the sibling **llm-router** project
-# (`llm-router/config/providers.yaml` inline capabilities + provider-capabilities
-# .generated.yaml) — single source of truth; keep in step when llm-router changes.
+# ALIAS (== the catalog modelKey the executor looks up; see execute.ts).
 #
-# NOTE: gpt-5.x on the la.atmy.work relay are STREAM-ONLY (non-stream → 400 "Stream
-# must be set to true"). That is a relay request constraint, NOT a capability gap —
-# `supportsStreaming` stays true (the model DOES stream; it merely requires it).
-# `requiresStreaming: true` makes the capability filter SKIP these for a non-stream
-# request (skip_reason no_nonstream_support) instead of letting the attempt 400 and
-# poison the circuit breaker; streaming requests still use them normally.
-openai-crs/gpt-5.5:
+# `openai-codex/*` are the ChatGPT/Codex SUBSCRIPTION models (synthesized at
+# runtime when the subscription is connected — alias prefix == the OAuth provider
+# id `openai-codex`). They go through the openai-responses executor (NOT the old
+# stream-only relay), so no `requiresStreaming` constraint applies. `deepseek/*`
+# are the official DeepSeek API models (providers[0]).
+openai-codex/gpt-5.5:
   supportsTools: true
   supportsJsonMode: true
   supportsVision: true
   supportsStreaming: true
-  requiresStreaming: true
   maxContextTokens: 1050000
   maxOutputTokens: 128000
-openai-crs/gpt-5.4-mini:
+openai-codex/gpt-5.4:
   supportsTools: true
   supportsJsonMode: true
   supportsVision: true
   supportsStreaming: true
-  requiresStreaming: true
   maxContextTokens: 400000
   maxOutputTokens: 128000
-openai-crs/gpt-5.3-codex-spark:
+openai-codex/gpt-5.3-codex-spark:
   supportsTools: true
   supportsJsonMode: true
   supportsVision: true
   supportsStreaming: true
-  requiresStreaming: true
   maxContextTokens: 400000
   maxOutputTokens: 128000
-deepseek-crs/deepseek-pro:
+deepseek/deepseek-v4-pro:
   supportsTools: true
   supportsJsonMode: true
   supportsVision: false
   supportsStreaming: true
   maxContextTokens: 1048576
   maxOutputTokens: 384000
-deepseek-crs/deepseek-flash:
+deepseek/deepseek-v4-flash:
   supportsTools: true
   supportsJsonMode: true
   supportsVision: false

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -175,12 +175,11 @@ classifier:
   eval:
     enabled: false                 # default OFF (non-negotiable)
     # The eval client sends this id DIRECTLY on the wire to the primary provider
-    # (the crs relay), bypassing the registry — so it MUST be a real bare upstream
-    # id the relay accepts (fix-upstream-model-id 2026-05-31). `deepseek-flash` is
-    # the relay's cheap/fast tier (non-stream OK, json-capable); its eval_usd is
-    # priced via the bare `deepseek-flash` key in pricing.yaml. The old
-    # `deepseek/deepseek-v4-flash` was an OpenRouter id and 500'd on this relay.
-    model: deepseek-flash
+    # (official DeepSeek, providers[0]), bypassing the registry — so it MUST be a
+    # real bare upstream id DeepSeek accepts. `deepseek-v4-flash` is the cheap/fast
+    # tier (non-stream OK, json-capable); its eval_usd is priced via the bare
+    # `deepseek-v4-flash` key in pricing.yaml.
+    model: deepseek-v4-flash
     temperature: 0
     max_tokens: 256
     timeout_ms: 250                # inner (runner) timeout

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -9,36 +9,38 @@
 # gateway refuses to boot (fail-closed, principle 2). `balanced` is REQUIRED: it
 # is the terminal of the classification fallback.
 #
-# ALIAS-NAMESPACE ALIGNMENT (2026-05-31): every candidate below is a
-# `provider/model` alias that ALSO keys providers.yaml, the capability+pricing
-# catalog, and pricing — so the capability filter + cost path resolve by the lane
-# candidate alias at runtime (no more "unknown -> fail-open"). Each lane ends in a
-# `*/auto` tail fallback; those auto aliases are deliberately JSON-INCAPABLE
+# PROVIDER MIX (2026-06-03, task drop-openai-crs-relay): the cheap/default lanes
+# anchor on the ALWAYS-AVAILABLE official `deepseek` primary (static key — works in
+# dev, e2e, and a fresh install with NO subscription). premium / coding / tool_use
+# lead with the `openai-codex` SUBSCRIPTION channel (connect it in admin →
+# Providers), each backed by a static fallback so the lane degrades gracefully when
+# no subscription is bound: an unconnected `openai-codex/*` candidate fails OPEN
+# (Phase-0 back-fill / skip to the next fallback), never a 5xx. Each lane still ends
+# in a `*/auto` tail fallback; those auto aliases are deliberately JSON-INCAPABLE
 # (catalog supports_json_schema:false), so a strict-JSON request prunes them and
-# lands on a deterministic json-capable model (docs/02 security rule: `*/auto`
-# only at the tail).
+# lands on a deterministic json-capable model (docs/02: `*/auto` only at the tail).
 
 # —— quality/cost lanes ——
 economy:
   purpose: Cheap and fast for simple tasks
-  primary: openai-crs/gpt-5.4-mini
-  fallback: [deepseek-crs/deepseek-flash, balanced]
+  primary: deepseek/deepseek-v4-flash
+  fallback: [openai-codex/gpt-5.4, balanced]
 
 balanced:
   purpose: Default quality/cost tradeoff (classification fallback terminal)
-  primary: deepseek-crs/deepseek-pro
-  fallback: [openai-crs/gpt-5.4-mini, zenmux/auto, openrouter/auto]
+  primary: deepseek/deepseek-v4-pro
+  fallback: [openai-codex/gpt-5.4, zenmux/auto, openrouter/auto]
 
 premium:
   purpose: Strong reasoning and high quality
-  primary: openai-crs/gpt-5.5
-  fallback: [zenmux/claude-opus-4.7, zenmux/auto, openrouter/auto]
+  primary: openai-codex/gpt-5.5
+  fallback: [deepseek/deepseek-v4-pro, zenmux/claude-opus-4.7, zenmux/auto, openrouter/auto]
 
 # —— task lanes (named after detected task_type; the lane resolver maps a
 #    classified task_type onto a same-named lane — docs/04) ——
 coding:
   purpose: Coding-capable models for code generation / editing
-  primary: openai-crs/gpt-5.3-codex-spark
+  primary: openai-codex/gpt-5.3-codex-spark
   fallback: [premium, balanced]
 
 json:
@@ -47,7 +49,7 @@ json:
   # request lands deterministically. The chain then drops through balanced, whose
   # tail `*/auto` aliases are json-INCAPABLE and get PRUNED by the capability
   # filter — proving the filter fires on the default config.
-  primary: openai-crs/gpt-5.4-mini
+  primary: deepseek/deepseek-v4-flash
   fallback: [balanced]
   constraints:
     require_json: true
@@ -61,7 +63,7 @@ vision:
 
 tool_use:
   purpose: Reliable function / tool calling
-  primary: openai-crs/gpt-5.5
+  primary: openai-codex/gpt-5.5
   fallback: [premium]
   constraints:
     require_tools: true

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -12,24 +12,24 @@
 #   outputPerMTokUsd: 0.0
 
 # ─────────────────────────────────────────────────────────────────────────────
-# RELAY / SELF-HOSTED MODEL PRICING (catalog-reuse 2026-05-31). Keyed by the
-# routing ALIAS (== catalog modelKey). Values from the sibling **llm-router**
-# (`llm-router/config/pricing-overrides.yaml` representative_text_pricing),
-# USD per 1M tokens. Lives in this manual layer, not the generated catalog (see
-# capabilities.yaml header). Cost telemetry only — never drives selection.
-openai-crs/gpt-5.5:
+# SUBSCRIPTION / AGGREGATOR MODEL PRICING (drop-openai-crs-relay 2026-06-03).
+# Keyed by the routing ALIAS (== catalog modelKey), USD per 1M tokens. Lives in
+# this manual layer, not the generated catalog (see capabilities.yaml header).
+# Cost telemetry only — never drives selection. (deepseek numbers carried over
+# from the prior relay entries; verify against official DeepSeek pricing.)
+openai-codex/gpt-5.5:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 30.0
-openai-crs/gpt-5.4-mini:
+openai-codex/gpt-5.4:
   inputPerMTokUsd: 0.75
   outputPerMTokUsd: 4.5
-openai-crs/gpt-5.3-codex-spark:
+openai-codex/gpt-5.3-codex-spark:
   inputPerMTokUsd: 1.75
   outputPerMTokUsd: 14.0
-deepseek-crs/deepseek-pro:
+deepseek/deepseek-v4-pro:
   inputPerMTokUsd: 0.435
   outputPerMTokUsd: 0.87
-deepseek-crs/deepseek-flash:
+deepseek/deepseek-v4-flash:
   inputPerMTokUsd: 0.1
   outputPerMTokUsd: 0.2
 zenmux/claude-opus-4.7:
@@ -46,8 +46,9 @@ openrouter/auto:
   outputPerMTokUsd: 15.0
 # Bare upstream id keyed for the Layer-2 EVAL self-cost (eval_usd): the eval
 # client (classifier.yaml `eval.model`) bypasses the registry and sends the wire
-# id `deepseek-flash` directly, so eval_usd resolves via this bare key (same
-# numbers as deepseek-crs/deepseek-flash). See classify.ts / route-request eval_usd.
-deepseek-flash:
+# id `deepseek-v4-flash` directly to the primary (official DeepSeek), so eval_usd
+# resolves via this bare key (same numbers as deepseek/deepseek-v4-flash).
+# See classify.ts / route-request eval_usd.
+deepseek-v4-flash:
   inputPerMTokUsd: 0.1
   outputPerMTokUsd: 0.2

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -16,58 +16,54 @@
 #
 # REVERSED 2026-05-31 (task fix-upstream-model-id — see implementation-notes):
 # alias and provider_model are NOT equal. The earlier "align everything to the
-# prefixed alias" convention sent the prefixed string (e.g. `openai-crs/gpt-5.4-
-# mini`) upstream as `model`, and the la.atmy.work relay only knows the BARE id
-# (`gpt-5.4-mini`) — an unknown model makes the relay return a generic 500. The
+# prefixed alias" convention sent the prefixed string (e.g. `deepseek/deepseek-v4-
+# flash`) upstream as `model`, but a provider only knows the BARE id
+# (`deepseek-v4-flash`) — an unknown model makes the upstream return a 4xx/5xx. The
 # executor (apps/gateway/src/routes/execute.ts) sends the RESOLVED `provider_model`
 # upstream verbatim, so it MUST be the real bare id. The alias keeps the prefixed
 # `provider/model` form because it is the routing key (lanes candidates, decision
-# record, catalog/pricing lookup). The claimed "catalog resolves by alias" benefit
-# never materialized — capabilities.yaml/pricing.yaml are empty and the generated
-# catalog has none of these models, so `catalog.get()` already misses and fails
-# open. To pin a lane to a different upstream id, change only that entry's
-# `provider_model` (no code change; principle 2, config-as-code).
+# record, catalog/pricing lookup). To pin a lane to a different upstream id, change
+# only that entry's `provider_model` (no code change; principle 2, config-as-code).
 #
 # Unified shape (HelmConfigSchema.ProviderConfig): name, type (openai|anthropic),
 # base_url?, api_key_env (env-var NAME), models[] { alias -> provider_model }.
 # A duplicate alias across providers is rejected at build time (fail-closed,
 # principle 2). The test/e2e harness overrides every provider's base_url via
 # HELM_PROVIDER_BASE_URL so the mock upstream serves all of them.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# PRIMARY = official DeepSeek; premium/coding lanes route through the openai-codex
+# SUBSCRIPTION channel (2026-06-03, task drop-openai-crs-relay). The former
+# self-built `openai-crs` relay (la.atmy.work) was deleted: it WAS just a proxy in
+# front of a ChatGPT/Codex subscription, which Helm now connects natively via the
+# built-in `openai-codex` OAuth preset (admin → Providers → Connect). That preset
+# is SYNTHESIZED at runtime — it exposes its models as `openai-codex/<model>`
+# aliases keyed by the OAuth provider id — so it must NOT be declared as a static
+# provider here, or the duplicate alias would fail-closed. Lanes may reference
+# `openai-codex/*` even before a subscription is connected: an unconnected alias
+# fails OPEN (Phase-0 back-fill / skip to the next fallback), never a 5xx.
 providers:
   # PRIMARY provider (providers[0]). Backs the default path, the Layer-2 eval
-  # call, and the Phase-0 passthrough; its credential (OPENAI_API_KEY) is
-  # mandatory (fail-closed if unset). Self-built OpenAI-compatible relay; it
-  # fronts the openai-crs/* + deepseek-crs/* model families (the deepseek-crs
-  # relay speaks the Anthropic wire upstream but is reached through the same
-  # credential, mirroring llm-router's providers.yaml). real upstream ids in
-  # comments.
-  - name: openai-crs
+  # call, and the Phase-0 passthrough; its credential (DEEPSEEK_API_KEY) is
+  # mandatory (fail-closed if unset). Official DeepSeek OpenAI-compatible API
+  # (https://api.deepseek.com). alias == catalog/pricing key; provider_model is
+  # the real upstream id sent on the wire.
+  - name: deepseek
     type: openai
-    base_url: https://la.atmy.work/ai/openai/v1
-    api_key_env: OPENAI_API_KEY
+    base_url: https://api.deepseek.com/v1
+    api_key_env: DEEPSEEK_API_KEY
     models:
-      # gpt-5.5 — premium primary (json-capable, multimodal:image). STREAM-ONLY on
-      # this relay (non-stream → 400 "Stream must be set to true").
-      - alias: openai-crs/gpt-5.5
-        provider_model: gpt-5.5
-      # gpt-5.4-mini — economy/cheap, json-capable. STREAM-ONLY on this relay.
-      - alias: openai-crs/gpt-5.4-mini
-        provider_model: gpt-5.4-mini
-      # gpt-5.3-codex-spark — coding-capable, json-capable. STREAM-ONLY on this relay.
-      - alias: openai-crs/gpt-5.3-codex-spark
-        provider_model: gpt-5.3-codex-spark
-      # deepseek-pro — balanced primary, json-capable, big context. stream + non-stream.
-      - alias: deepseek-crs/deepseek-pro
-        provider_model: deepseek-pro
-      # deepseek-flash — fast/cheap fallback, json-capable. stream + non-stream.
-      - alias: deepseek-crs/deepseek-flash
-        provider_model: deepseek-flash
-      # NOTE (catalog-reuse 2026-05-31): the Layer-2 eval small-model is NOT
-      # registered here. The eval client (classifier.yaml `eval.model`) bypasses
-      # the registry and sends its id directly on the wire to THIS primary
-      # provider's base_url; it is now `deepseek-flash` (a real relay id), priced
-      # for eval_usd via the bare `deepseek-flash` key in pricing.yaml. The former
-      # `deepseek/deepseek-v4-flash` entry was an OpenRouter id that 500'd here.
+      # deepseek-v4-pro — balanced/default primary, json-capable, big context.
+      - alias: deepseek/deepseek-v4-pro
+        provider_model: deepseek-v4-pro
+      # deepseek-v4-flash — economy/cheap + the Layer-2 eval small-model, json-capable.
+      - alias: deepseek/deepseek-v4-flash
+        provider_model: deepseek-v4-flash
+      # NOTE: the Layer-2 eval small-model is NOT a registry alias. The eval client
+      # (classifier.yaml `eval.model`) bypasses the registry and sends its id
+      # directly on the wire to THIS primary provider's base_url; it is
+      # `deepseek-v4-flash` (a real DeepSeek id), priced for eval_usd via the bare
+      # `deepseek-v4-flash` key in pricing.yaml.
 
   # SECONDARY provider — ZenMux aggregator. A genuinely DIFFERENT upstream with
   # its own credential, proving a fallback chain can CROSS providers. Carries the
@@ -189,7 +185,12 @@ providers:
   #     - alias: copilot/gpt
   #       provider_model: gpt-4o
   #
-  # ChatGPT Plus/Pro — Codex (browser login + paste redirect URL):
+  # ChatGPT Plus/Pro — Codex (browser login + paste redirect URL).
+  # This is the default lane channel for premium/coding/tool_use (config/lanes.yaml
+  # references openai-codex/gpt-5.5, openai-codex/gpt-5.3-codex-spark, …). Just
+  # connect it in the admin UI (Providers → Connect) — the pool is SYNTHESIZED and
+  # its models become `openai-codex/<model>` aliases automatically; NO YAML needed.
+  # Declare a static block ONLY to pin a custom alias to a specific upstream id:
   # - name: chatgpt-codex
   #   type: openai
   #   oauth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
       # Admin UI (docs/11; consumed in Phase 4)
       HELM_ADMIN_USER: ${HELM_ADMIN_USER:-admin}
       HELM_ADMIN_PASSWORD: ${HELM_ADMIN_PASSWORD:?set HELM_ADMIN_PASSWORD in .env}
-      # Upstream provider credential (env-injected, never in the repo)
-      OPENAI_API_KEY: ${OPENAI_API_KEY:?set OPENAI_API_KEY in .env}
+      # Upstream provider credential (env-injected, never in the repo). The PRIMARY
+      # (deepseek) credential is mandatory — fail-closed if unset.
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:?set DEEPSEEK_API_KEY in .env}
     restart: unless-stopped
     healthcheck:
       test:

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -43,18 +43,18 @@ The shipped quality/cost lanes:
 ```yaml
 economy:
   purpose: Cheap and fast for simple tasks
-  primary: openai-crs/gpt-5.4-mini
-  fallback: [deepseek-crs/deepseek-flash, balanced]
+  primary: deepseek/deepseek-v4-flash
+  fallback: [openai-codex/gpt-5.4, balanced]
 
 balanced:
   purpose: Default quality/cost tradeoff (classification fallback terminal)
-  primary: deepseek-crs/deepseek-pro
-  fallback: [openai-crs/gpt-5.4-mini, zenmux/auto, openrouter/auto]
+  primary: deepseek/deepseek-v4-pro
+  fallback: [openai-codex/gpt-5.4, zenmux/auto, openrouter/auto]
 
 premium:
   purpose: Strong reasoning and high quality
-  primary: openai-crs/gpt-5.5
-  fallback: [zenmux/claude-opus-4.7, zenmux/auto, openrouter/auto]
+  primary: openai-codex/gpt-5.5
+  fallback: [deepseek/deepseek-v4-pro, zenmux/claude-opus-4.7, zenmux/auto, openrouter/auto]
 ```
 
 `balanced` is **required** and must be healthy — it is the terminal of the
@@ -66,12 +66,12 @@ same-named lane):
 ```yaml
 coding:
   purpose: Coding-capable models for code generation / editing
-  primary: openai-crs/gpt-5.3-codex-spark
+  primary: openai-codex/gpt-5.3-codex-spark
   fallback: [premium, balanced]
 
 json:
   purpose: Strict structured-output (JSON) responses
-  primary: openai-crs/gpt-5.4-mini
+  primary: deepseek/deepseek-v4-flash
   fallback: [balanced]
   constraints:
     require_json: true
@@ -85,7 +85,7 @@ vision:
 
 tool_use:
   purpose: Reliable function / tool calling
-  primary: openai-crs/gpt-5.5
+  primary: openai-codex/gpt-5.5
   fallback: [premium]
   constraints:
     require_tools: true

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -27,7 +27,7 @@ docker run -d --name helm \
   -v "$(pwd)/data:/app/data" \       # telemetry, keys, sqlite — persisted
   -e HELM_ADMIN_USER=admin \         # admin UI Basic auth (see 11)
   -e HELM_ADMIN_PASSWORD=change-me \
-  -e OPENAI_API_KEY=sk-... \         # upstream provider credential
+  -e DEEPSEEK_API_KEY=sk-... \       # primary provider credential (required)
   ghcr.io/easymetaau/helm-api:latest
 ```
 
@@ -40,7 +40,7 @@ mounting their own directory at `/app/config`.
 
 A `docker-compose.yml` is provided. It defaults to the published image (uncomment
 `build: .` for local builds), mounts the two volumes, and injects credentials from
-a `.env` file. `HELM_ADMIN_PASSWORD` and `OPENAI_API_KEY` are required (compose
+a `.env` file. `HELM_ADMIN_PASSWORD` and `DEEPSEEK_API_KEY` are required (compose
 fails fast if they are unset):
 
 ```yaml
@@ -57,7 +57,7 @@ services:
     environment:
       HELM_ADMIN_USER: ${HELM_ADMIN_USER:-admin}
       HELM_ADMIN_PASSWORD: ${HELM_ADMIN_PASSWORD:?set HELM_ADMIN_PASSWORD in .env}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:?set OPENAI_API_KEY in .env}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:?set DEEPSEEK_API_KEY in .env}
     restart: unless-stopped
 ```
 
@@ -83,10 +83,12 @@ Configuration comes from **files** and **environment variables**, and env vars
   - `HELM_RATE_LIMIT_ENABLED`, `HELM_REQUEST_TIMEOUT_MS`, `HELM_MAX_REQUEST_BYTES`
   - `HELM_STORE_DRIVER` (`sqlite` | `supabase`), `HELM_STORE_URL_ENV`
   - `HELM_KEYS_PERSIST_TO`
-  - Upstream credentials such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+  - Upstream credentials such as `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY`,
     `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` — each maps to a `providers.yaml`
-    entry's `api_key_env`. `OPENAI_API_KEY` is the primary credential and is
+    entry's `api_key_env`. `DEEPSEEK_API_KEY` is the primary credential and is
     required; the others are optional (their providers are skipped if absent).
+    (Premium/coding lanes route through the `openai-codex` subscription — connect
+    it in the admin UI, which needs `HELM_OAUTH_ENC_KEY`, not an API key here.)
 
 Invalid configuration is rejected at startup (Zod-validated, fail-closed) — Helm
 never runs in a half-broken state (Principle 2).

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,23 @@
 
 ---
 
+## 2026-06-03 · Drop the `openai-crs` relay; route via the `openai-codex` subscription + official DeepSeek (spec docs/03, docs/04, docs/10)
+
+**Context**: `config/providers.yaml` shipped a single self-built relay named `openai-crs` (`la.atmy.work`, `OPENAI_API_KEY`) that fronted both `openai-crs/*` (gpt-5.x) and `deepseek-crs/*` model families under one credential, and was `providers[0]` (the mandatory primary backing eval + Phase-0 passthrough). The relay was really just a proxy in front of a ChatGPT/Codex subscription — which Helm already connects natively via the built-in `openai-codex` OAuth preset (wired end-to-end in #64/#65) — so it was redundant. Per the maintainer: delete the relay, route the premium/coding lanes through the `openai-codex` subscription channel, and point the deepseek models at the **official** DeepSeek API.
+
+- **`openai-codex` is NOT declared statically**. The OAuth preset is synthesized at runtime when a subscription is connected, and its aliases are `openai-codex/<model>` keyed by the OAuth provider id. So lanes reference `openai-codex/*` and rely on fail-open: with no subscription connected, the executor's subscription-prefix gate (`knownOAuthPrefixes` + `oauthAliases()`, from #64/#65) finds the alias is not exposed and SKIPS it (`provider_unavailable`) — it never reaches the registry/primary and never forwards a prefixed id upstream — so the lane falls open to its next static fallback, never a 5xx and never a bogus upstream call. Config load does **not** cross-check lane aliases against providers, so referencing them is safe at boot.
+- **New primary = official `deepseek`** (`providers[0]`, `https://api.deepseek.com/v1`, `DEEPSEEK_API_KEY`, models `deepseek-v4-pro` / `deepseek-v4-flash`). It is a real static key, so dev/e2e/fresh-install all boot without any subscription. The eval small-model (`classifier.yaml eval.model`) moved `deepseek-flash` → `deepseek-v4-flash` (a real DeepSeek id sent bare to the primary, bypassing the registry); its `eval_usd` resolves via the bare `deepseek-v4-flash` pricing key.
+- **Lane mix**: cheap/default lanes (economy/balanced/json) anchor on the always-available `deepseek` primary; premium/coding/tool_use lead with `openai-codex/*` and keep a static fallback so they degrade gracefully when no subscription is bound.
+- **Capability change**: the old `openai-crs/*` heads carried `requiresStreaming: true` (a `la.atmy.work` relay quirk — non-stream → 400). The `openai-codex` subscription goes through the `openai-responses` executor with no such constraint, so the new `openai-codex/*` capability entries DROP `requiresStreaming`. This flipped one integration test: the json lane now SERVES its non-stream primary (`deepseek-v4-flash`) directly instead of skipping it (`execute.default-config.test.ts`).
+- **e2e under no subscription**: the routing/eval specs run with no subscription connected, so the `openai-codex/*` lane heads skip and each lane serves its first STATIC `deepseek/*` fallback. The specs assert that fail-open behavior (premium serves `deepseek-v4-pro`), so CI genuinely covers the unconnected path.
+- **Credential rename `OPENAI_API_KEY` → `DEEPSEEK_API_KEY`** propagated to the mandatory-primary path: `.env.example`, `docker-compose.yml` (`${DEEPSEEK_API_KEY:?…}`), CI docker smoke job (`.github/workflows/ci.yml`), `playwright.config.ts` e2e env, README/docs/10, and the compose/CI/dockerfile contract tests. Self-contained unit fixtures that build their own provider config with `OPENAI_API_KEY` were left as-is (arbitrary).
+- **No DB migration**: `openai-crs` was a static-key provider (no stored OAuth credential); telemetry rows keep their historical `openai-crs/*` alias strings as-is (immutable audit trail).
+- **Live-verified (2026-06-03)** against `https://api.deepseek.com` with the test key: `GET /models` returns exactly `deepseek-v4-flash` + `deepseek-v4-pro`, and `POST /chat/completions` on both returns HTTP 200. So the `deepseek-v4-*` ids are correct (NOT the public `deepseek-chat`/`deepseek-reasoner` names).
+- **⚠️ Caveat — `deepseek-v4-flash` is a REASONING model**: it emits `reasoning_content` and burns ~180+ reasoning tokens even on a trivial prompt BEFORE any `content`. With a small client `max_tokens` the reply comes back with empty `content` and `finish_reason: "length"` (e.g. `max_tokens: 120` → empty; `800` → real content). Since the economy/json lanes lead with `deepseek-v4-flash`, a client that caps `max_tokens` low will get empty completions. Operational tuning concern, not a gateway bug; `capabilities.yaml` maxOutputTokens (16384) leaves room when the client doesn't force a tiny cap.
+- **TODO**: DeepSeek capability/pricing numbers were carried over from the prior relay entries — still worth confirming against official pricing.
+
+---
+
 ## 2026-06-03 · Request-list defaults to the last 24h (not all) (admin)
 
 **Context**: `/admin/requests` opened on `range=all`, which grows unwieldy; the operator wanted the last 24 hours by default.
@@ -110,7 +127,6 @@
 **Verified LIVE on local Docker (no restart, all observed via `oauth.pool.select` / `oauth.pool.rebuilt` logs)**: (1) park `openai-codex/default` → next requests go 100% to `mylukin`; (2) set `default` priority=1 → 100% to `default`; (3) set a dead proxy (`192.0.2.1:1080`) on `default` → routing to it fails `all_providers_failed` (proves egress now flows through the proxy), clear → serves again; (4) revert → `codex/gpt-5.4 → "pong"`, live suite 49/49. Test: `server.oauth.test.ts` "re-synthesis reflects a schedulable change made AFTER the first build (no restart)" + disconnect drops the provider.
 
 **Cost note**: a rebuild re-runs the per-account token-refresh/discovery pass — acceptable for an infrequent admin action; the save awaits it so the UI reflects "applied".
-
 ---
 
 ## 2026-06-03 · Retire the per-key `max_lane` ceiling; add allowed-lanes checkboxes to the create dialog (spec docs/06, docs/04)

--- a/packages/core/src/catalog/index.test.ts
+++ b/packages/core/src/catalog/index.test.ts
@@ -86,14 +86,14 @@ describe("loadCatalog", () => {
   });
 
   it("propagates a requiresStreaming override into the merged catalog entry", () => {
-    // The stream-only relay flag (capabilities.yaml) must survive the merge so the
+    // A requiresStreaming override (capabilities.yaml) must survive the merge so the
     // executor's capability filter can read it (catalog.get(alias).capabilities).
     const cat = loadCatalog({
       generated,
-      capabilitiesOverride: { "openai-crs/gpt-5.4-mini": { requiresStreaming: true } },
+      capabilitiesOverride: { "openai-codex/gpt-5.5": { requiresStreaming: true } },
       pricingOverride: {},
     });
-    const entry = cat.get("openai-crs/gpt-5.4-mini");
+    const entry = cat.get("openai-codex/gpt-5.5");
     expect(entry?.capabilities.requiresStreaming).toBe(true);
   });
 

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -47,7 +47,7 @@ describe("checked-in config samples", () => {
     const cfg = loadConfig({ configDir, env: {} });
     expect(cfg.auth.require_api_key).toBe(true);
     expect(cfg.server.port).toBe(8080);
-    expect(cfg.providers[0]?.api_key_env).toBe("OPENAI_API_KEY");
+    expect(cfg.providers[0]?.api_key_env).toBe("DEEPSEEK_API_KEY");
   });
 
   it("loads the shipped lanes.yaml (economy/balanced/premium + task lanes)", () => {

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -354,7 +354,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       const withDetail = decision("req_detail", {
         provider_attempts: [
           {
-            alias: "openai-crs/gpt-5.4-mini",
+            alias: "deepseek/deepseek-v4-flash",
             skipped: false,
             skip_reason: null,
             status: "error",
@@ -368,7 +368,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
             },
           },
           {
-            alias: "deepseek-crs/deepseek-pro",
+            alias: "deepseek/deepseek-v4-pro",
             skipped: false,
             skip_reason: null,
             status: "ok",

--- a/packages/core/src/telemetry/decision.test.ts
+++ b/packages/core/src/telemetry/decision.test.ts
@@ -254,7 +254,7 @@ describe("buildDecisionRecord", () => {
 
   it("6b. redaction: a secret echoed in a per-attempt error_detail.provider_raw is fingerprinted, status/message survive", () => {
     const failed: AttemptRecord = {
-      alias: "openai-crs/gpt-5.4-mini",
+      alias: "deepseek/deepseek-v4-flash",
       skipped: false,
       skip_reason: null,
       status: "error",
@@ -271,7 +271,7 @@ describe("buildDecisionRecord", () => {
         },
       },
     };
-    const record = buildDecisionRecord(parts({ attempts: [failed, okAttempt("deepseek-crs")] }));
+    const record = buildDecisionRecord(parts({ attempts: [failed, okAttempt("deepseek")] }));
     const serialized = JSON.stringify(record);
     // The leaked key is gone; the diagnostic status + message are preserved.
     expect(serialized).not.toContain("sk-live-PLAINTEXT-SECRET-123");

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -39,7 +39,7 @@ describe("CI workflow", () => {
     expect(raw).toContain("docker build");
     expect(raw).toContain("docker run");
     // Boots with the required provider credential env and hits /healthz.
-    expect(raw).toContain("OPENAI_API_KEY");
+    expect(raw).toContain("DEEPSEEK_API_KEY");
     expect(raw).toContain("/healthz");
     // Cleans the container up afterwards.
     expect(raw).toContain("docker stop");

--- a/packages/shared/src/compose.test.ts
+++ b/packages/shared/src/compose.test.ts
@@ -21,7 +21,7 @@ describe("docker-compose contract", () => {
   });
 
   it("injects provider + admin credentials via env (fail-closed when unset)", () => {
-    expect(compose).toMatch(/OPENAI_API_KEY:\s*\$\{OPENAI_API_KEY:\?/);
+    expect(compose).toMatch(/DEEPSEEK_API_KEY:\s*\$\{DEEPSEEK_API_KEY:\?/);
     expect(compose).toMatch(/HELM_ADMIN_PASSWORD:\s*\$\{HELM_ADMIN_PASSWORD:\?/);
   });
 

--- a/packages/shared/src/config/classifier-schema.ts
+++ b/packages/shared/src/config/classifier-schema.ts
@@ -94,8 +94,11 @@ export const ClassifierConfigSchema = z.object({
   }),
   // prefault with the default model: the eval schema requires `model` (an enabled
   // eval with no model is a lie), so an omitted block must still carry one to
-  // parse through inner defaults. enabled stays false regardless.
-  eval: ClassifierEvalConfigSchema.prefault({ model: "deepseek/deepseek-v4-flash" }),
+  // parse through inner defaults. enabled stays false regardless. The eval client
+  // sends this id DIRECTLY on the wire to the primary provider (bypassing the
+  // registry), so it MUST be a bare upstream id the primary accepts — `deepseek-v4-
+  // flash` (official DeepSeek), matching config/classifier.yaml + pricing.yaml.
+  eval: ClassifierEvalConfigSchema.prefault({ model: "deepseek-v4-flash" }),
 });
 
 // Strict full-replace variant for the admin PUT /admin/api/classifier endpoint.

--- a/packages/shared/src/dockerfile.test.ts
+++ b/packages/shared/src/dockerfile.test.ts
@@ -37,7 +37,7 @@ describe("Dockerfile contract", () => {
   });
 
   it("embeds no plaintext credentials", () => {
-    expect(dockerfile).not.toMatch(/OPENAI_API_KEY\s*=/);
+    expect(dockerfile).not.toMatch(/DEEPSEEK_API_KEY\s*=/);
     expect(dockerfile).not.toMatch(/HELM_ADMIN_PASSWORD\s*=/);
     expect(dockerfile).not.toContain("sk-");
   });


### PR DESCRIPTION
## 背景

`config/providers.yaml` 里一直有一个自建中转 provider **`openai-crs`**（`la.atmy.work`，`OPENAI_API_KEY`），它用一把凭证同时代理 `openai-crs/*`（gpt-5.x）和 `deepseek-crs/*` 两组模型，并且是 `providers[0]`（承载 eval 与 Phase-0 passthrough 的必填主 provider）。

这个中转**本质上只是 ChatGPT/Codex 订阅的代理**——而 Helm 已经在 #64 / #65 里把内置的 `openai-codex` OAuth 订阅通道端到端打通了，所以这个中转是多余的。

本 PR 按 maintainer 的要求：**删掉中转，lane 直接走 `openai-codex` 订阅通道，deepseek 模型改用官方 DeepSeek API。**

> ⚠️ 本 PR **只改配置、测试与文档，不改路由代码**。未连接订阅时的 fail-open 行为，复用的是 #64/#65 已经实现的 executor 订阅前缀闸门（`knownOAuthPrefixes` + `oauthAliases`）。

## 改了什么

- **删除 `openai-crs` 中转 provider。**
- **主 provider 改为官方 DeepSeek**：`providers[0]` = `deepseek`（`https://api.deepseek.com/v1`，`DEEPSEEK_API_KEY`，模型 `deepseek-v4-pro` / `deepseek-v4-flash`）。它是一把真实静态 key，所以 dev / e2e / 全新部署**无需任何订阅即可启动**。
- **lane 重新编排**（`config/lanes.yaml`）：
  - `premium` / `coding` / `tool_use` → 主用 `openai-codex/*` 订阅通道；
  - `economy` / `balanced` / `json` → 锚定在永远可用的 `deepseek` 主 provider 上；
  - 每条用 `openai-codex/*` 的 lane 都保留一个静态 fallback。
- **`deepseek-crs` 中转 → 官方 DeepSeek API**；`capabilities.yaml` / `pricing.yaml` 同步更新；eval 小模型 `classifier.yaml eval.model` → `deepseek-v4-flash`（裸 wire id，绕过 registry 直发主 provider）。
- **能力变化**：旧的 `openai-crs/*` 头带 `requiresStreaming: true`（是 `la.atmy.work` 中转的限制，非流式会 400）。`openai-codex` 订阅走 `openai-responses` executor 没有这个限制，所以新的 `openai-codex/*` 能力项**去掉了 `requiresStreaming`**。
- **凭证重命名 `OPENAI_API_KEY` → `DEEPSEEK_API_KEY`**：`.env.example`、`docker-compose.yml`、CI docker 冒烟任务、`playwright.config.ts` e2e env、README / `docs/10`，以及 compose/CI/dockerfile 契约测试。
- `classifier-schema.ts` 的 `eval.model` prefault 默认值也改成裸 `deepseek-v4-flash`。

## 关键设计点

- **`openai-codex` 不做静态声明**：它是订阅连接后在运行时合成的（别名 `openai-codex/<model>`，以 OAuth provider id 为前缀）。静态再声明一个会撞别名 → fail-closed。所以 lane 直接引用 `openai-codex/*`，靠 fail-open：**未连接订阅时**，executor 的订阅前缀闸门发现该别名未暴露 → 干净跳过（`provider_unavailable`），lane 落到下一个静态 fallback——**不会 5xx，也不会向上游发伪造 model**。
- **无需 DB 迁移**：`openai-crs` 是静态 key provider，没有存储凭证；历史遥测记录里的 `openai-crs/*` 别名作为不可变审计留存。

## 验证

- ✅ `pnpm typecheck` / `pnpm lint`
- ✅ `pnpm test` — **1789 通过**
- ✅ e2e（gateway project）— **42 通过**，含 routing / eval / protocol / oauth / gemini / smoke
- ✅ e2e 在「未连接订阅」场景下验证了 fail-open：`openai-codex/*` 头被跳过，lane 落到静态 `deepseek/*` fallback
- ✅ **官方 DeepSeek API 实测**（用测试 key）：`GET /models` 返回 `deepseek-v4-flash` + `deepseek-v4-pro`；两者 `POST /chat/completions` 均 **HTTP 200**

## ⚠️ 已知注意点

`deepseek-v4-flash` 是**推理模型**：即便很简单的 prompt，也会先吃掉约 180+ 个 `reasoning_content` token 才产出正文。客户端 `max_tokens` 给太小（如 120）会拿到**空 `content` + `finish_reason: "length"`**；给够（如 800）才有正文。economy/json lane 用的就是它，运维需注意别把 `max_tokens` 压太低。详见 `implementation-notes.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
