### PR TITLE
fix(config): openai-codex lane/目录对齐到订阅实际暴露的模型（#73 跟进）

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -29,6 +29,11 @@
 # id `openai-codex`). They go through the openai-responses executor (NOT the old
 # stream-only relay), so no `requiresStreaming` constraint applies. `deepseek/*`
 # are the official DeepSeek API models (providers[0]).
+#
+# These three are EXACTLY the curated Codex set the subscription exposes
+# (packages/core/src/provider/oauth/models.ts — the ChatGPT-account Codex backend
+# 400s on legacy `*-codex`/`*-pro` slugs, verified live), so every exposed alias
+# an operator can pick has a capability + pricing entry here.
 openai-codex/gpt-5.5:
   supportsTools: true
   supportsJsonMode: true
@@ -43,13 +48,13 @@ openai-codex/gpt-5.4:
   supportsStreaming: true
   maxContextTokens: 400000
   maxOutputTokens: 128000
-openai-codex/gpt-5.3-codex-spark:
+openai-codex/gpt-5.4-mini:
   supportsTools: true
   supportsJsonMode: true
   supportsVision: true
   supportsStreaming: true
   maxContextTokens: 400000
-  maxOutputTokens: 128000
+  maxOutputTokens: 65536
 deepseek/deepseek-v4-pro:
   supportsTools: true
   supportsJsonMode: true

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -24,7 +24,7 @@
 economy:
   purpose: Cheap and fast for simple tasks
   primary: deepseek/deepseek-v4-flash
-  fallback: [openai-codex/gpt-5.4, balanced]
+  fallback: [openai-codex/gpt-5.4-mini, balanced]
 
 balanced:
   purpose: Default quality/cost tradeoff (classification fallback terminal)
@@ -40,7 +40,9 @@ premium:
 #    classified task_type onto a same-named lane — docs/04) ——
 coding:
   purpose: Coding-capable models for code generation / editing
-  primary: openai-codex/gpt-5.3-codex-spark
+  # gpt-5.5 is the strongest model the Codex subscription actually exposes; the
+  # legacy `*-codex` slugs 400 on the ChatGPT-account backend, so they are NOT used.
+  primary: openai-codex/gpt-5.5
   fallback: [premium, balanced]
 
 json:

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -21,11 +21,11 @@ openai-codex/gpt-5.5:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 30.0
 openai-codex/gpt-5.4:
+  inputPerMTokUsd: 2.5
+  outputPerMTokUsd: 15.0
+openai-codex/gpt-5.4-mini:
   inputPerMTokUsd: 0.75
   outputPerMTokUsd: 4.5
-openai-codex/gpt-5.3-codex-spark:
-  inputPerMTokUsd: 1.75
-  outputPerMTokUsd: 14.0
 deepseek/deepseek-v4-pro:
   inputPerMTokUsd: 0.435
   outputPerMTokUsd: 0.87

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -187,9 +187,10 @@ providers:
   #
   # ChatGPT Plus/Pro — Codex (browser login + paste redirect URL).
   # This is the default lane channel for premium/coding/tool_use (config/lanes.yaml
-  # references openai-codex/gpt-5.5, openai-codex/gpt-5.3-codex-spark, …). Just
-  # connect it in the admin UI (Providers → Connect) — the pool is SYNTHESIZED and
-  # its models become `openai-codex/<model>` aliases automatically; NO YAML needed.
+  # references openai-codex/gpt-5.5, openai-codex/gpt-5.4, openai-codex/gpt-5.4-mini
+  # — the models the Codex subscription actually exposes). Just connect it in the
+  # admin UI (Providers → Connect) — the pool is SYNTHESIZED and its models become
+  # `openai-codex/<model>` aliases automatically; NO YAML needed.
   # Declare a static block ONLY to pin a custom alias to a specific upstream id:
   # - name: chatgpt-codex
   #   type: openai

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -138,7 +138,7 @@ classifier:
 
   eval:
     enabled: false                 # OFF by default (non-negotiable)
-    model: deepseek-flash          # cheap, fast, reliable JSON; sent directly to the primary provider
+    model: deepseek-v4-flash       # a real bare id the primary (official DeepSeek) accepts; sent directly to it
     temperature: 0
     max_tokens: 256                # one JSON object; caps the cost
     timeout_ms: 250                # inner runner timeout

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -44,7 +44,7 @@ The shipped quality/cost lanes:
 economy:
   purpose: Cheap and fast for simple tasks
   primary: deepseek/deepseek-v4-flash
-  fallback: [openai-codex/gpt-5.4, balanced]
+  fallback: [openai-codex/gpt-5.4-mini, balanced]
 
 balanced:
   purpose: Default quality/cost tradeoff (classification fallback terminal)
@@ -66,7 +66,7 @@ same-named lane):
 ```yaml
 coding:
   purpose: Coding-capable models for code generation / editing
-  primary: openai-codex/gpt-5.3-codex-spark
+  primary: openai-codex/gpt-5.5
   fallback: [premium, balanced]
 
 json:

--- a/packages/shared/src/config/eval-config.schema.test.ts
+++ b/packages/shared/src/config/eval-config.schema.test.ts
@@ -94,7 +94,7 @@ describe("EvalConfigSchema", () => {
   });
 
   it("defaults the outer timeout strictly above the inner (backstop ordering)", () => {
-    const parsed = EvalConfigSchema.parse({ model: "deepseek-flash" });
+    const parsed = EvalConfigSchema.parse({ model: "deepseek-v4-flash" });
     expect(parsed.outer_timeout_ms).toBeGreaterThan(parsed.timeout_ms);
   });
 


### PR DESCRIPTION
## 背景

这是 **#73 的跟进修复**。#73 在 Codex review 的修复提交（`0615e4c`）push 之前**约 11 分钟就被合并了**，所以那批修复没进 main——目前 `main` 仍带着 Codex 指出的几个问题。本 PR 把它们补上。

> 即：#73 已合并，但合并版本是 review 修复**之前**的状态，本 PR 仅包含那批修复（config + docs，无源码逻辑改动）。

## 修复的问题（Codex review）

- **P1（真 bug）** `coding` lane 主模型从 `openai-codex/gpt-5.3-codex-spark` 改为 `openai-codex/gpt-5.5`。
  Codex 订阅默认只暴露 `gpt-5.4 / gpt-5.4-mini / gpt-5.5`（见 `packages/core/src/provider/oauth/models.ts`，#64 已实测旧的 `*-codex` slug 在 ChatGPT 账号后端会 **400**）。原主模型永远会被 `provider_unavailable` 跳过，coding 请求拿不到它。
- **P2** capabilities / pricing 对齐到实际暴露的三个模型：补上 `openai-codex/gpt-5.4-mini`，删除未暴露的 `openai-codex/gpt-5.3-codex-spark`。现在 lane 用到的、运维在编辑器 / custom-model key 里能选的每个 `openai-codex` 别名都有 catalog 条目（能力过滤 + 成本估算不再缺失）。`economy` 兜底也换成更合适的 `gpt-5.4-mini`，让三个暴露模型全部被实际用到。
- **P3** `docs/03-classification.md` 的 eval 示例 `deepseek-flash` → `deepseek-v4-flash`，与官方 DeepSeek 主 provider 一致；同步 eval-config schema 测试里的裸 id。

顺手修了 `config/providers.yaml` 注释里残留的 `gpt-5.3-codex-spark` 引用。

## 对齐结果

`{gpt-5.4, gpt-5.4-mini, gpt-5.5}` —— lanes 使用、capabilities、pricing 三处**完全一致**。

## 验证

- ✅ `pnpm typecheck` / `pnpm lint`
- ✅ `pnpm test` — **1816 通过**
- ✅ e2e routing + eval — **13 通过**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
