### PR TITLE
fix(admin): correct OAuth quota percentages, opus/sonnet labels & day-scale reset

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -407,6 +407,7 @@
   "parked": "parked",
   "Secondary": "Secondary",
   "{n} req": "{n} req",
+  "resets in {d}d {h}h": "resets in {d}d {h}h",
   "resets in {h}h {m}m": "resets in {h}h {m}m",
   "resets in {m}m": "resets in {m}m",
   "Failed to update scheduling": "Failed to update scheduling",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -407,6 +407,7 @@
   "parked": "已停用",
   "Secondary": "次窗口",
   "{n} req": "{n} 次",
+  "resets in {d}d {h}h": "{d} 天 {h} 小时后重置",
   "resets in {h}h {m}m": "{h} 小时 {m} 分后重置",
   "resets in {m}m": "{m} 分后重置",
   "Failed to update scheduling": "更新调度失败",

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -96,6 +96,7 @@
       '5h': '5h',
       '7d': '7d',
       '7d-opus': '7d · Opus',
+      '7d-sonnet': '7d · Sonnet',
       primary: $t('Primary'),
       secondary: $t('Secondary'),
     };
@@ -109,11 +110,19 @@
     return 'bg-indigo-500';
   }
 
-  // "resets in 3h 12m" countdown from an absolute reset timestamp; null/elapsed ⇒ "".
+  // "resets in 4d 16h" countdown from an absolute reset timestamp; null/elapsed ⇒ "".
+  // Coarsens by magnitude so the unit stays legible: ≥24h shows days+hours
+  // (a 7-day window reads "4d 16h", not "112h 2m"), ≥1h shows hours+minutes,
+  // under an hour shows minutes.
   function resetIn(ms: number | null): string {
     if (ms == null) return '';
     const left = ms - Date.now();
     if (left <= 0) return '';
+    const d = Math.floor(left / 86_400_000);
+    if (d > 0) {
+      const h = Math.floor((left % 86_400_000) / 3_600_000);
+      return $t('resets in {d}d {h}h', { d, h });
+    }
     const h = Math.floor(left / 3_600_000);
     const m = Math.floor((left % 3_600_000) / 60_000);
     return h > 0 ? $t('resets in {h}h {m}m', { h, m }) : $t('resets in {m}m', { m });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,29 @@
 
 ---
 
+## 2026-06-04 · OAuth 额度展示三处修正（providers 页 Tier 3, spec docs/11）
+
+对照官方 Claude `/usage` 与 Codex 真实数据，修了三个展示 bug：
+
+1. **Anthropic `utilization` 比例被多乘 100**：`/api/oauth/usage` 的 `utilization` 字段**已经是
+   0–100 的百分数**（如 `33.0`），并非 0–1 小数。旧代码 `utilization * 100` 把 3% 算成 300% → clamp
+   到 100%，于是所有窗口都显示 100%。改为直接取值并 clamp 到 [0,100]。schema/解析注释一并更正。
+   （来源：社区逆向的 endpoint 响应，多处一致；旧测试里 `0.06` 是凭空构造的小数输入，已替换为真实量级。）
+2. **Opus/Sonnet 窗口标错**：旧映射把 `seven_day_sonnet` 错挂到 key `7d-opus`（界面显示 "7d · Opus"）。
+   实际 API 同时有 `seven_day_opus` 与 `seven_day_sonnet`。改为各自 1:1 映射
+   （`seven_day_opus → 7d-opus`、`seven_day_sonnet → 7d-sonnet`），界面新增 "7d · Sonnet" label。
+   不带 Opus 周限的套餐 `seven_day_opus` 为 null，自动跳过——与官方 `/usage` 只显示 sonnet 行一致。
+3. **重置倒计时超 24h 仍按小时**：`resetIn()` 旧逻辑只输出 `{h}h {m}m`，7 天窗口会显示
+   "112 小时 2 分后重置"。新增天级档：≥24h 显示 `{d}d {h}h`（"4 天 16 小时后重置"），<24h 维持
+   时分，<1h 维持分。新增 i18n key `resets in {d}d {h}h`（en + zh-hans；ja/ko/zh-hant 沿用既有
+   未翻译现状，回退英文 key）。
+
+坑：Anthropic 这个 endpoint 是**未文档化**的，`utilization` 量级未来可能随上游改动；若再次出现整页
+100%/全 0%，先核对该字段量级再动 `* / 100`。Codex 的 `x-codex-*-used-percent` 本来就是 0–100，未动；
+界面 2% vs 官方 3% 的细小差异是抓取时点不同（header PUSH 快照），非 bug。
+
+---
+
 ## 2026-06-03 · litellm-parity 收官：parity 计分卡 + 文档同步 (P9, spec docs/05)
 
 P9 是纯文档：把 Phases 2–8 的成果写进 docs/05、新建 `docs/protocol-compatibility.md`（逐对数据丢失矩阵）、

--- a/packages/core/src/provider/oauth/anthropic-quota.test.ts
+++ b/packages/core/src/provider/oauth/anthropic-quota.test.ts
@@ -6,25 +6,34 @@ const RESET = "2026-06-03T12:00:00.000Z";
 const RESET_MS = Date.parse(RESET);
 
 describe("parseAnthropicUsageBody", () => {
-  it("maps five_hour / seven_day / seven_day_sonnet to 5h / 7d / 7d-opus (fraction→percent)", () => {
+  it("maps the four windows to 5h / 7d / 7d-opus / 7d-sonnet (utilization is 0–100 percent)", () => {
     const out = parseAnthropicUsageBody(
       {
-        five_hour: { utilization: 0.06, resets_at: RESET },
-        seven_day: { utilization: 0.14, resets_at: RESET },
+        five_hour: { utilization: 3, resets_at: RESET },
+        seven_day: { utilization: 17, resets_at: RESET },
+        seven_day_opus: { utilization: 42, resets_at: RESET },
         seven_day_sonnet: { utilization: 0, resets_at: RESET },
       },
       NOW,
     );
     expect(out).toEqual([
-      { key: "5h", usedPercent: 6, resetsAtMs: RESET_MS, windowMinutes: null },
-      { key: "7d", usedPercent: 14.000000000000002, resetsAtMs: RESET_MS, windowMinutes: null },
-      { key: "7d-opus", usedPercent: 0, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "5h", usedPercent: 3, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d", usedPercent: 17, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d-opus", usedPercent: 42, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d-sonnet", usedPercent: 0, resetsAtMs: RESET_MS, windowMinutes: null },
+    ]);
+  });
+
+  it("clamps an out-of-range utilization into 0–100 without re-scaling", () => {
+    const out = parseAnthropicUsageBody({ five_hour: { utilization: 130, resets_at: RESET } }, NOW);
+    expect(out).toEqual([
+      { key: "5h", usedPercent: 100, resetsAtMs: RESET_MS, windowMinutes: null },
     ]);
   });
 
   it("skips an absent window and nulls an unparseable reset timestamp", () => {
     const out = parseAnthropicUsageBody(
-      { five_hour: { utilization: 0.5, resets_at: "not-a-date" } },
+      { five_hour: { utilization: 50, resets_at: "not-a-date" } },
       NOW,
     );
     expect(out).toEqual([{ key: "5h", usedPercent: 50, resetsAtMs: null, windowMinutes: null }]);

--- a/packages/core/src/provider/oauth/anthropic-quota.ts
+++ b/packages/core/src/provider/oauth/anthropic-quota.ts
@@ -5,15 +5,17 @@ import {
 } from "@helm/shared";
 
 // Map Anthropic's OAuth usage-endpoint payload (GET /api/oauth/usage) to the
-// providers-page quota windows (Tier 3). Anthropic reports `utilization` as a 0–1
-// FRACTION (scaled to a 0–100 percent here) + an ISO `resets_at`. The three windows
-// claude-relay-service surfaces map to our keys: five_hour → 5h, seven_day → 7d,
-// seven_day_sonnet → 7d-opus. PURE + FAIL-OPEN: an absent window or unparseable
-// reset timestamp is skipped/nulled, never thrown.
+// providers-page quota windows (Tier 3). Anthropic reports `utilization` as a
+// 0–100 PERCENT (e.g. 33.0), NOT a 0–1 fraction — surfaced as-is (clamped), never
+// re-scaled. Each window maps 1:1 to our keys: five_hour → 5h, seven_day → 7d,
+// seven_day_opus → 7d-opus, seven_day_sonnet → 7d-sonnet (matching the official
+// Claude /usage display). PURE + FAIL-OPEN: an absent window or unparseable reset
+// timestamp is skipped/nulled, never thrown.
 const WINDOWS = [
   { src: "five_hour", key: "5h" },
   { src: "seven_day", key: "7d" },
-  { src: "seven_day_sonnet", key: "7d-opus" },
+  { src: "seven_day_opus", key: "7d-opus" },
+  { src: "seven_day_sonnet", key: "7d-sonnet" },
 ] as const;
 
 export function anthropicUsageToWindows(
@@ -30,7 +32,7 @@ export function anthropicUsageToWindows(
     const resetMs = typeof win.resets_at === "string" ? Date.parse(win.resets_at) : Number.NaN;
     out.push({
       key: w.key,
-      usedPercent: Math.min(100, Math.max(0, win.utilization * 100)),
+      usedPercent: Math.min(100, Math.max(0, win.utilization)),
       resetsAtMs: Number.isFinite(resetMs) ? resetMs : null,
       windowMinutes: null, // Anthropic does not report a window length
     });

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -31,8 +31,8 @@ export type OAuthUsageRow = z.infer<typeof OAuthUsageRowSchema>;
 
 // ── Quota (Tier 3): latest rate-limit window snapshot per (provider, account) ─
 
-// One rate-limit window. `key` names the window (Claude: 5h / 7d / 7d-opus;
-// Codex: primary / secondary). `usedPercent` is 0–100. `resetsAtMs` is the epoch
+// One rate-limit window. `key` names the window (Claude: 5h / 7d / 7d-opus /
+// 7d-sonnet; Codex: primary / secondary). `usedPercent` is 0–100. `resetsAtMs` is the epoch
 // ms the window resets (null when unknown). `windowMinutes` is the window length
 // when the provider reports it (Codex), else null.
 export const OAuthQuotaWindowSchema = z
@@ -65,9 +65,11 @@ export type OAuthQuotaSnapshot = z.infer<typeof OAuthQuotaSnapshotSchema>;
 // ── Anthropic usage-endpoint response (GET /api/oauth/usage) ─────────────────
 
 // The (untrusted) shape Anthropic's OAuth usage endpoint returns. Parsed
-// fail-open: any field may be absent. `utilization` is a 0–1 fraction (scaled to
-// a percent on ingest); `resets_at` is an ISO-8601 timestamp. Mirrors the windows
-// claude-relay-service reads (five_hour / seven_day / seven_day_sonnet).
+// fail-open: any field may be absent (e.g. `seven_day_opus` is null on plans
+// without a separate Opus weekly cap). `utilization` is already a 0–100 PERCENT
+// (e.g. 33.0), NOT a 0–1 fraction — do not re-scale on ingest. `resets_at` is an
+// ISO-8601 timestamp. Windows: five_hour / seven_day / seven_day_opus /
+// seven_day_sonnet (mirrors the official Claude /usage display).
 const AnthropicWindowSchema = z
   .object({
     utilization: z.number().optional(),
@@ -79,6 +81,7 @@ export const AnthropicOAuthUsageSchema = z
   .object({
     five_hour: AnthropicWindowSchema.optional(),
     seven_day: AnthropicWindowSchema.optional(),
+    seven_day_opus: AnthropicWindowSchema.optional(),
     seven_day_sonnet: AnthropicWindowSchema.optional(),
   })
   .loose();


### PR DESCRIPTION
## Summary

Three display bugs on the **Subscription Providers** page (Tier 3 OAuth quota), found by comparing Helm's display against the official Claude `/usage` and Codex output.

| Window | Helm (before) | Real | After |
|---|---|---|---|
| Claude 5h | 100% | 3% | 3% |
| Claude 7d | 100% | 17% | 17% |
| Claude weekly model | "7d · Opus" 0% | sonnet 0% | "7d · Sonnet" 0% |
| reset countdown | "112 小时 2 分后重置" | 4天16小时 | "4 天 16 小时后重置" |

### 1. Anthropic `utilization` over-scaled ×100
`/api/oauth/usage` returns `utilization` already as a **0–100 percent** (e.g. `33.0`), not a 0–1 fraction. The old `utilization * 100` turned `3` into `300` → clamped to `100`, so every window read 100%. Now surfaced as-is, clamped to `[0,100]`.

### 2. Sonnet window mislabelled as Opus
The API exposes **both** `seven_day_opus` and `seven_day_sonnet`; the old code mapped `seven_day_sonnet` → key `7d-opus`. Now mapped 1:1 (`7d-opus` / `7d-sonnet`) with a new "7d · Sonnet" label. Plans without an Opus weekly cap return `null` for `seven_day_opus` and skip it — matching the official `/usage` (5h / 7d / sonnet).

### 3. Reset countdown not coarsened to days
`resetIn()` only emitted `{h}h {m}m`, so a 7-day window read "112h 2m". Added a day tier: ≥24h → `{d}d {h}h`, <24h keeps h/m, <1h keeps m. New i18n key `resets in {d}d {h}h` (en + zh-hans).

## Tests
- `anthropic-quota` test rewritten for real 0–100 values + opus/sonnet mapping (TDD red→green)
- All 52 OAuth tests pass
- `pnpm typecheck` (shared/core/gateway) ✓ · `svelte-check` 0 errors ✓ · Biome ✓

## Notes
The Anthropic usage endpoint is **undocumented**; if a future upstream change re-scales `utilization`, revisit the clamp. The Codex `x-codex-*-used-percent` headers are already 0–100 and untouched; small % deltas vs the official Codex UI are snapshot staleness (header PUSH), not a bug. Full rationale in `implementation-notes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)