### PR TITLE
fix(gateway): drop orphaned OAuth quota snapshots (phantom accounts)

### DIFF
--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -867,13 +867,29 @@ describe("admin.api oauth usage", () => {
 });
 
 describe("admin.api oauth quota", () => {
-  it("GET /oauth/quota refreshes the Anthropic PULL, upserts, and returns all snapshots", async () => {
+  it("GET /oauth/quota refreshes Anthropic, returns only BOUND accounts, and prunes orphans", async () => {
     const upserts: unknown[] = [];
+    const deletes: Array<[string, string]> = [];
+    const acct = (account: string) => ({
+      account,
+      expiresAt: null,
+      updatedAt: 0,
+      healthy: true,
+      priority: 50,
+      schedulable: true,
+    });
     const stored = [
       {
         providerId: "openai-codex",
-        account: "default",
+        account: "mylukin", // BOUND → kept
         windows: [{ key: "primary", usedPercent: 5, resetsAtMs: 9_000, windowMinutes: 300 }],
+        capturedAt: 1,
+        source: "codex-headers" as const,
+      },
+      {
+        providerId: "openai-codex",
+        account: "default", // ORPHAN (no token) → filtered out + pruned
+        windows: [{ key: "primary", usedPercent: 9, resetsAtMs: 9_000, windowMinutes: 300 }],
         capturedAt: 1,
         source: "codex-headers" as const,
       },
@@ -884,25 +900,15 @@ describe("admin.api oauth quota", () => {
       },
       get: async () => null,
       getAll: async () => stored,
+      delete: async (providerId: string, account: string) => {
+        deletes.push([providerId, account]);
+      },
     } as unknown as AdminApiDeps["oauthQuota"];
-    // Minimal seam: only the two methods the quota route touches.
+    // Bound accounts: anthropic/mylukin + openai-codex/mylukin (NOT codex/default).
     const oauth = {
       listStatus: async () => [
-        {
-          id: "anthropic",
-          name: "A",
-          flow: "manual_paste",
-          accounts: [
-            {
-              account: "default",
-              expiresAt: null,
-              updatedAt: 0,
-              healthy: true,
-              priority: 50,
-              schedulable: true,
-            },
-          ],
-        },
+        { id: "anthropic", name: "A", flow: "manual_paste", accounts: [acct("mylukin")] },
+        { id: "openai-codex", name: "C", flow: "manual_paste", accounts: [acct("mylukin")] },
       ],
       fetchAnthropicQuota: async () => [
         { key: "5h", usedPercent: 6, resetsAtMs: 5_000, windowMinutes: null },
@@ -915,12 +921,14 @@ describe("admin.api oauth quota", () => {
     expect(upserts).toHaveLength(1);
     expect(upserts[0]).toMatchObject({
       providerId: "anthropic",
-      account: "default",
+      account: "mylukin",
       source: "anthropic",
     });
-    // The response returns the store's full snapshot set.
-    const body = (await res.json()) as { quota: Array<{ providerId: string }> };
-    expect(body.quota.map((q) => q.providerId)).toContain("openai-codex");
+    // Only BOUND snapshots are returned; the orphan codex/default is dropped.
+    const body = (await res.json()) as { quota: Array<{ providerId: string; account: string }> };
+    expect(body.quota.map((q) => `${q.providerId}/${q.account}`)).toEqual(["openai-codex/mylukin"]);
+    // …and the orphan row is pruned from the store.
+    expect(deletes).toEqual([["openai-codex", "default"]]);
   });
 
   it("GET /oauth/quota fails open to [] when no quota store is wired", async () => {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -93,33 +93,53 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     const store = deps.oauthQuota;
     if (!store) return c.json({ quota: [] });
     const s = seam();
-    // Refresh the Anthropic PULL for each connected Claude account (cached). Codex
-    // snapshots are already in the store from the live request path (no pull).
-    if (s?.fetchAnthropicQuota) {
+    // listStatus (the bound OAuth tokens) is the source of truth for "which accounts
+    // exist". We use it BOTH to refresh the Anthropic PULL and to drop ORPHANED
+    // snapshots: a renamed / logged-out account otherwise leaves a stale row (e.g. a
+    // Codex push captured under an old label) that would show as a phantom account.
+    const acctKey = (providerId: string, account: string) => `${providerId}\u0000${account}`;
+    let bound: Set<string> | null = null;
+    if (s) {
       try {
-        const anthropic = (await s.listStatus()).find((p) => p.id === "anthropic");
-        await Promise.all(
-          (anthropic?.accounts ?? []).map(async (a) => {
-            const windows = await s.fetchAnthropicQuota?.({ account: a.account });
-            if (windows && windows.length > 0) {
-              await store
-                .upsert({
-                  providerId: "anthropic",
-                  account: a.account,
-                  windows,
-                  capturedAt: Date.now(),
-                  source: "anthropic",
-                })
-                .catch(() => {});
-            }
-          }),
-        );
+        const status = await s.listStatus();
+        bound = new Set(status.flatMap((p) => p.accounts.map((a) => acctKey(p.id, a.account))));
+        // Refresh the Anthropic PULL for each connected Claude account (cached). Codex
+        // snapshots are already in the store from the live request path (no pull).
+        if (s.fetchAnthropicQuota) {
+          const anthropic = status.find((p) => p.id === "anthropic");
+          await Promise.all(
+            (anthropic?.accounts ?? []).map(async (a) => {
+              const windows = await s.fetchAnthropicQuota?.({ account: a.account });
+              if (windows && windows.length > 0) {
+                await store
+                  .upsert({
+                    providerId: "anthropic",
+                    account: a.account,
+                    windows,
+                    capturedAt: Date.now(),
+                    source: "anthropic",
+                  })
+                  .catch(() => {});
+              }
+            }),
+          );
+        }
       } catch {
-        // fail-open: a refresh failure still returns whatever is already stored
+        // fail-open: a refresh/listing failure still returns whatever is stored
       }
     }
     try {
-      return c.json({ quota: await store.getAll() });
+      const all = await store.getAll();
+      // No binding view (no seam / listStatus failed) → fail-open, return everything.
+      if (!bound) return c.json({ quota: all });
+      const live = all.filter((q) => bound.has(acctKey(q.providerId, q.account)));
+      // Best-effort prune so orphans don't accumulate; never block the read on it.
+      await Promise.all(
+        all
+          .filter((q) => !bound.has(acctKey(q.providerId, q.account)))
+          .map((o) => store.delete(o.providerId, o.account).catch(() => {})),
+      );
+      return c.json({ quota: live });
     } catch {
       return c.json({ quota: [] });
     }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,26 @@
 
 ---
 
+## 2026-06-04 · OAuth 额度孤儿快照清理（providers 页 Tier 3, spec docs/11）
+
+`/admin/api/oauth/quota` 旧逻辑直接返回 `oauthQuota.getAll()`——**所有**存储的快照行。问题：
+Codex 额度是按 `(provider, account)` 通过响应头 PUSH 写入的；当账户被改名/重新绑定（如 `default` →
+`mylukin`），旧标签的行不会被清理，于是页面出现一个**幽灵账户**（用户实际只绑了 1 个 codex，却显示 2 个）。
+
+修复：以 `listStatus()`（已绑定的 OAuth token）为唯一真相，路由现在
+(1) 只返回属于已绑定账户的快照；(2) 顺手 `delete` 掉孤儿行（best-effort，不阻塞读取）。
+新增 `OAuthQuotaStore.delete(providerId, account)` 端口方法 + sqlite/postgres 两个适配器实现。
+`listStatus` 缺失（无 seam / 异常）时 fail-open 返回全部，绝不因清理逻辑隐藏数据。
+
+坑（自己踩的）：路由里 `acctKey` 分隔符一度被写成裸 NUL 字节（`${p}\x00${a}`），导致 git 把
+`oauth.ts` 当二进制、grep 失效；改成 ASCII 转义 `\u0000`（运行时键不变、源码恢复纯文本）。
+
+另：本轮还确认 Anthropic usage 端点本身工作正常（用解密后的 token 直连得到 HTTP 200，
+`five_hour/seven_day/seven_day_sonnet` 均有值，`seven_day_opus` 为 null）；之前页面显示 "—" 纯属
+前面压测把上游限流打挂 + 负缓存的 null 还没过期，并非代码缺陷——部署本修复后会自动刷新回填。
+
+---
+
 ## 2026-06-04 · OAuth 额度刷新负缓存（对齐 claude-relay-service, spec docs/11）
 
 对照参考实现 `/Users/lukin/Projects/claude-relay-service`，确认了两点并补了一处缺陷：

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -351,6 +351,10 @@ export interface OAuthQuotaStore {
   get(providerId: string, account: string): Promise<OAuthQuotaSnapshot | null>;
   // All accounts' latest snapshots (the providers page reads them in one shot).
   getAll(): Promise<OAuthQuotaSnapshot[]>;
+  // Remove the snapshot for a (provider_id, account). Used to prune ORPHANS — a
+  // renamed / logged-out account otherwise leaves a stale row (e.g. a Codex push
+  // under an old label) that would surface as a phantom account on the page.
+  delete(providerId: string, account: string): Promise<void>;
 }
 
 export interface OAuthTokenStore {

--- a/packages/core/src/store/postgres/oauth-quota.ts
+++ b/packages/core/src/store/postgres/oauth-quota.ts
@@ -47,6 +47,12 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
     return rows.map((r) => this.toSnapshot(r));
   }
 
+  async delete(providerId: string, account: string): Promise<void> {
+    await this.db
+      .delete(oauthQuota)
+      .where(and(eq(oauthQuota.providerId, providerId), eq(oauthQuota.account, account)));
+  }
+
   private toSnapshot(row: QuotaRow): OAuthQuotaSnapshot {
     return OAuthQuotaSnapshotSchema.parse({
       providerId: row.providerId,

--- a/packages/core/src/store/sqlite/oauth-quota.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.test.ts
@@ -57,4 +57,20 @@ describe("SqliteOAuthQuotaStore", () => {
     expect(await store.getAll()).toHaveLength(2);
     close();
   });
+
+  it("delete removes one (provider, account) row and leaves siblings intact", async () => {
+    const { store, close } = freshStore();
+    await store.upsert(snap({ account: "keep" }));
+    await store.upsert(
+      snap({ providerId: "openai-codex", account: "orphan", source: "codex-headers" }),
+    );
+    await store.delete("openai-codex", "orphan");
+    expect(await store.get("openai-codex", "orphan")).toBeNull();
+    expect((await store.getAll()).map((q) => `${q.providerId}/${q.account}`)).toEqual([
+      "anthropic/keep",
+    ]);
+    // Deleting a non-existent row is a no-op (idempotent), never throws.
+    await store.delete("openai-codex", "orphan");
+    close();
+  });
 });

--- a/packages/core/src/store/sqlite/oauth-quota.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.ts
@@ -49,6 +49,13 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
       .map((r) => this.toSnapshot(r));
   }
 
+  async delete(providerId: string, account: string): Promise<void> {
+    this.db
+      .delete(oauthQuota)
+      .where(and(eq(oauthQuota.providerId, providerId), eq(oauthQuota.account, account)))
+      .run();
+  }
+
   // Row -> OAuthQuotaSnapshot. Re-validates through the shared schema so a
   // corrupted row surfaces loudly rather than leaking a malformed shape.
   private toSnapshot(row: QuotaRow): OAuthQuotaSnapshot {


### PR DESCRIPTION
## Problem
The providers page showed a **phantom Codex account** — one bound `openai-codex` account rendered as two (`default` + `mylukin`).

Root cause: `GET /admin/api/oauth/quota` returned `oauthQuota.getAll()` **unconditionally**. Codex quota is PUSH-captured per `(provider, account)` on each reply, so when an account is renamed / re-bound (`default` → `mylukin`), the old-label row is never cleaned up and the route returns it as a ghost.

## Fix
Use `listStatus()` (the bound OAuth tokens) as the source of truth. The route now:
1. returns **only** snapshots for currently-bound accounts, and
2. best-effort **prunes** orphan rows (never blocks the read).

Adds `OAuthQuotaStore.delete(providerId, account)` with sqlite + postgres implementations. **Fail-open**: if `listStatus` is unavailable, return everything (never hide data behind cleanup).

## Tests
- Route returns only bound accounts and prunes the orphan (`delete` called with the orphan key).
- sqlite `delete` is scoped to one `(provider, account)` and idempotent.
- 43 oauth/quota tests pass · core+gateway typecheck clean · biome clean.

## Note
Separately confirmed Anthropic's usage endpoint works (direct call with the decrypted token → HTTP 200, real `five_hour`/`seven_day`/`seven_day_sonnet`); the earlier "—" was rate-limit cooldown + a cached null, not a bug. Deploying this (which refreshes on page open) repopulates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)