### PR TITLE
fix(quota): show Anthropic data (null windows) + drop /usage orphans

### DIFF
--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -858,6 +858,42 @@ describe("admin.api oauth usage", () => {
     expect(body.usage[0]?.rpm).toBeLessThan(5);
   });
 
+  it("GET /oauth/usage returns only BOUND accounts (drops orphan rows)", async () => {
+    const day = Date.now() - (Date.now() % 86_400_000);
+    const row = (account: string, requests: number) => ({
+      providerId: "openai-codex",
+      account,
+      day,
+      requests,
+      tokens: 0,
+      costUsd: null,
+      firstSeenMs: Date.now() - 60 * 60_000,
+      updatedAt: Date.now(),
+    });
+    const oauthUsage = {
+      record: async () => {},
+      queryDay: async () => [row("mylukin", 4), row("default", 9)], // default = orphan
+    } as unknown as AdminApiDeps["oauthUsage"];
+    const acct = (account: string) => ({
+      account,
+      expiresAt: null,
+      updatedAt: 0,
+      healthy: true,
+      priority: 50,
+      schedulable: true,
+    });
+    const oauth = {
+      listStatus: async () => [
+        { id: "openai-codex", name: "C", flow: "manual_paste", accounts: [acct("mylukin")] },
+      ],
+    } as unknown as AdminApiDeps["oauth"];
+    const app = buildApp(buildDeps({ oauthUsage, oauth }));
+    const res = await app.request("/admin/api/oauth/usage");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { usage: Array<{ account: string }> };
+    expect(body.usage.map((u) => u.account)).toEqual(["mylukin"]);
+  });
+
   it("GET /oauth/usage fails open to [] when no usage store is wired", async () => {
     const app = buildApp(buildDeps());
     const res = await app.request("/admin/api/oauth/usage");

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -65,19 +65,36 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     if (!store) return c.json({ usage: [] });
     const now = Date.now();
     const dayMs = now - (now % 86_400_000); // UTC midnight (epoch ms is UTC)
+    // Restrict to currently-bound accounts (listStatus = the OAuth tokens) so a
+    // renamed / re-bound account does NOT linger as a phantom usage row — the same
+    // guard the /quota route applies. Fail-open: no seam / a listing failure leaves
+    // `bound` null and every row is returned (never hide data behind the filter).
+    const usageKey = (providerId: string, account: string) => JSON.stringify([providerId, account]);
+    let bound: Set<string> | null = null;
+    const s = seam();
+    if (s) {
+      try {
+        const status = await s.listStatus();
+        bound = new Set(status.flatMap((p) => p.accounts.map((a) => usageKey(p.id, a.account))));
+      } catch {
+        // fail-open: a listing failure returns all rows rather than hiding data
+      }
+    }
     try {
       const rows = await store.queryDay(dayMs);
-      const usage = rows.map((r) => {
-        const minutes = Math.max(1, (now - r.firstSeenMs) / 60_000);
-        return {
-          providerId: r.providerId,
-          account: r.account,
-          requests: r.requests,
-          tokens: r.tokens,
-          costUsd: r.costUsd,
-          rpm: Math.round((r.requests / minutes) * 100) / 100,
-        };
-      });
+      const usage = rows
+        .filter((r) => !bound || bound.has(usageKey(r.providerId, r.account)))
+        .map((r) => {
+          const minutes = Math.max(1, (now - r.firstSeenMs) / 60_000);
+          return {
+            providerId: r.providerId,
+            account: r.account,
+            requests: r.requests,
+            tokens: r.tokens,
+            costUsd: r.costUsd,
+            rpm: Math.round((r.requests / minutes) * 100) / 100,
+          };
+        });
       return c.json({ usage });
     } catch {
       return c.json({ usage: [] });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,22 @@
 
 ---
 
+## 2026-06-04 · Anthropic null 窗口解析回归 + /usage 孤儿过滤（providers 页, spec docs/11）
+
+两个收尾修复：
+
+1. **Anthropic 额度一直显示 "—" 的真因（自己引入的回归）**：实测用解密 token 直连 usage 端点返回 200，
+   但 helm 解析后为空。原因是之前给 schema 加的 seven_day_opus 字段用了 .optional()，而真实响应里
+   该字段是显式 null（无 Opus 周限的套餐）。Zod 的 .optional() 只接受 undefined、不接受 null，于是整个
+   body 校验失败、parseAnthropicUsageBody 返回 []，页面空白。改为四个窗口字段全部 .nullish()
+   （nullable + optional）。新增回归测试：带 null opus + 额外前向兼容键的真实 body 仍能解析出 5h/7d/sonnet。
+
+2. **/usage（Tier 2）也有孤儿账户**：和 /quota 一样，account 改名/重绑后旧行残留，页面显示成两个 codex。
+   给 /usage 路由加上同样的 listStatus 绑定过滤（fail-open：listStatus 不可用则返回全部）。用 JSON.stringify
+   做账户 key，避免再次手滑写出裸 NUL 字节（上一条 commit 在 quota 路由踩过这个坑）。
+
+---
+
 ## 2026-06-04 · OAuth 额度孤儿快照清理（providers 页 Tier 3, spec docs/11）
 
 `/admin/api/oauth/quota` 旧逻辑直接返回 `oauthQuota.getAll()`——**所有**存储的快照行。问题：

--- a/packages/core/src/provider/oauth/anthropic-quota.test.ts
+++ b/packages/core/src/provider/oauth/anthropic-quota.test.ts
@@ -24,6 +24,29 @@ describe("parseAnthropicUsageBody", () => {
     ]);
   });
 
+  it("parses the real-world body where seven_day_opus is null + unknown windows exist", () => {
+    // Mirrors a live response: opus is `null` (no Opus cap on this plan) and the API
+    // ships extra forward-compat keys. A strict `.optional()` schema would REJECT the
+    // null and drop EVERYTHING — this guards that regression (page went blank).
+    const out = parseAnthropicUsageBody(
+      {
+        five_hour: { utilization: 6, resets_at: RESET },
+        seven_day: { utilization: 18, resets_at: RESET },
+        seven_day_opus: null,
+        seven_day_sonnet: { utilization: 0, resets_at: RESET },
+        seven_day_oauth_apps: null,
+        tangelo: null,
+        extra_usage: { is_enabled: true, monthly_limit: null, used_credits: 0, currency: "AUD" },
+      },
+      NOW,
+    );
+    expect(out).toEqual([
+      { key: "5h", usedPercent: 6, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d", usedPercent: 18, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d-sonnet", usedPercent: 0, resetsAtMs: RESET_MS, windowMinutes: null },
+    ]);
+  });
+
   it("clamps an out-of-range utilization into 0–100 without re-scaling", () => {
     const out = parseAnthropicUsageBody({ five_hour: { utilization: 130, resets_at: RESET } }, NOW);
     expect(out).toEqual([

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -65,8 +65,10 @@ export type OAuthQuotaSnapshot = z.infer<typeof OAuthQuotaSnapshotSchema>;
 // ── Anthropic usage-endpoint response (GET /api/oauth/usage) ─────────────────
 
 // The (untrusted) shape Anthropic's OAuth usage endpoint returns. Parsed
-// fail-open: any field may be absent (e.g. `seven_day_opus` is null on plans
-// without a separate Opus weekly cap). `utilization` is already a 0–100 PERCENT
+// fail-open: every window may be absent OR explicitly `null` (the API returns
+// `"seven_day_opus": null` on plans without a separate Opus weekly cap), so each
+// field is `.nullish()` — a strict `.optional()` would REJECT the null and fail the
+// whole parse, leaving the page blank. `utilization` is already a 0–100 PERCENT
 // (e.g. 33.0), NOT a 0–1 fraction — do not re-scale on ingest. `resets_at` is an
 // ISO-8601 timestamp. Windows: five_hour / seven_day / seven_day_opus /
 // seven_day_sonnet (mirrors the official Claude /usage display).
@@ -79,10 +81,10 @@ const AnthropicWindowSchema = z
 
 export const AnthropicOAuthUsageSchema = z
   .object({
-    five_hour: AnthropicWindowSchema.optional(),
-    seven_day: AnthropicWindowSchema.optional(),
-    seven_day_opus: AnthropicWindowSchema.optional(),
-    seven_day_sonnet: AnthropicWindowSchema.optional(),
+    five_hour: AnthropicWindowSchema.nullish(),
+    seven_day: AnthropicWindowSchema.nullish(),
+    seven_day_opus: AnthropicWindowSchema.nullish(),
+    seven_day_sonnet: AnthropicWindowSchema.nullish(),
   })
   .loose();
 


### PR DESCRIPTION
Final two bugs in the providers-page quota/usage display.

## 1. Anthropic quota stuck on "—" (regression from #76)
A direct call to the usage endpoint with the decrypted token returns **HTTP 200** with real data — yet helm rendered nothing. Cause: PR #76 added `seven_day_opus` (+ siblings) to the schema as `.optional()`, but the live API returns them as explicit **`null`** on plans without that cap. Zod `.optional()` accepts `undefined`, **not `null`**, so the entire body failed validation → `parseAnthropicUsageBody` returned `[]` → blank.

Fix: all four window fields are now `.nullish()` (nullable + optional). Regression test added with a real-world body (`seven_day_opus: null` + forward-compat keys) → parses `5h` / `7d` / `7d-sonnet`.

## 2. /usage (Tier 2) showed phantom accounts
Same orphan bug as `/quota` (#78), but on the usage endpoint: a renamed/re-bound account left a stale daily row, so one Codex account rendered as two. The `/usage` route now filters to currently-bound accounts (`listStatus`), fail-open if unavailable.

## Tests
45 oauth/quota tests pass · shared+core+gateway typecheck clean · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)