### PR TITLE
fix(admin): label Codex windows as 5h / Weekly

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -346,7 +346,7 @@
   "Schedule": "Schedule",
   "Search model": "Search model",
   "Secondary": "Secondary",
-  "See the full decision trail for every request the gateway handled.": "See the full decision trail for every request the gateway handled.",
+  "Weekly": "Weekly",  "See the full decision trail for every request the gateway handled.": "See the full decision trail for every request the gateway handled.",
   "Served model": "Served model",
   "Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.": "Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.",
   "Set the primary model and fallback chain for each quality and cost tier.": "Set the primary model and fallback chain for each quality and cost tier.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -345,7 +345,7 @@
   "Schedule": "スケジュール",
   "Search model": "モデルを検索",
   "Secondary": "セカンダリ",
-  "See the full decision trail for every request the gateway handled.": "ゲートウェイが処理したすべてのリクエストの完全な判断経路を確認します。",
+  "Weekly": "週間",  "See the full decision trail for every request the gateway handled.": "ゲートウェイが処理したすべてのリクエストの完全な判断経路を確認します。",
   "Served model": "提供モデル",
   "Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.": "サーバーサイドのルーティング規則。各規則は 条件 → アクション（レーンの強制または上限）です。ポリシーはタスクレーンを上書きしますが、実行フォールバック チェーンは上書きしません。",
   "Set the primary model and fallback chain for each quality and cost tier.": "各品質およびコストティアのプライマリモデルとフォールバックチェーンを設定します。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -345,7 +345,7 @@
   "Schedule": "일정",
   "Search model": "모델 검색",
   "Secondary": "보조",
-  "See the full decision trail for every request the gateway handled.": "게이트웨이가 처리한 모든 요청의 전체 결정 추적을 확인하세요.",
+  "Weekly": "주간",  "See the full decision trail for every request the gateway handled.": "게이트웨이가 처리한 모든 요청의 전체 결정 추적을 확인하세요.",
   "Served model": "제공된 모델",
   "Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.": "서버 측 라우팅 규칙. 각 규칙은 조건 → 동작(레인 강제 또는 상한)입니다. 정책은 작업 레인을 재정의하지만 실행 폴백 체인은 재정의하지 않습니다.",
   "Set the primary model and fallback chain for each quality and cost tier.": "각 품질 및 비용 티어에 대한 기본 모델과 대체 체인을 설정하세요.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -346,7 +346,7 @@
   "Schedule": "计划",
   "Search model": "搜索模型",
   "Secondary": "次窗口",
-  "See the full decision trail for every request the gateway handled.": "查看网关处理的每个请求的完整决策轨迹。",
+  "Weekly": "周限",  "See the full decision trail for every request the gateway handled.": "查看网关处理的每个请求的完整决策轨迹。",
   "Served model": "最终模型",
   "Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.": "服务端路由规则。每条都是 条件 → 动作（强制或封顶某条通道）。策略会覆盖任务通道，但绝不覆盖执行回退链。",
   "Set the primary model and fallback chain for each quality and cost tier.": "为每个质量和成本层级设置主模型和备用链。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -345,7 +345,7 @@
   "Schedule": "計劃",
   "Search model": "搜尋模型",
   "Secondary": "次視窗",
-  "See the full decision trail for every request the gateway handled.": "查看閘道處理的每個請求的完整決策軌跡。",
+  "Weekly": "週限",  "See the full decision trail for every request the gateway handled.": "查看閘道處理的每個請求的完整決策軌跡。",
   "Served model": "最終模型",
   "Server-side routing rules. Each is a condition → action (force or cap a lane). Policies override task lanes but never the execution fallback chain.": "伺服器端路由規則。每條都是 條件 → 動作（強制或封頂某條通道）。策略會覆蓋任務通道，但絕不覆蓋執行回退鏈。",
   "Set the primary model and fallback chain for each quality and cost tier.": "為每個品質和成本層級設定主模型和備用鏈。",

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -97,8 +97,10 @@
       '7d': '7d',
       '7d-opus': '7d · Opus',
       '7d-sonnet': '7d · Sonnet',
-      primary: $t('Primary'),
-      secondary: $t('Secondary'),
+      // Codex windows: `primary` is the 5-hour rolling window (windowMinutes 300),
+      // `secondary` is the weekly limit (windowMinutes 10080) — matching the Codex UI.
+      primary: '5h',
+      secondary: $t('Weekly'),
     };
     return map[key] ?? key;
   }


### PR DESCRIPTION
Codex's `primary` window is the 5-hour rolling window (windowMinutes 300) and `secondary` is the weekly limit (windowMinutes 10080). The page showed generic "Primary / Secondary"; the official Codex UI shows **5h / Weekly**. Relabel `primary` → "5h" and `secondary` → new translatable "Weekly" key (zh-hans 周限, ja 週間, ko 주간, zh-hant 週限). svelte-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)