### PR TITLE
docs: sync all Markdown docs with the implemented 0.2 reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ helm-api/
 
 ```bash
 pnpm install
-pnpm dev            # 起网关 + admin
+pnpm dev            # 仅起 admin 开发服务器（网关无 watch：跑构建产物或 Docker）
 pnpm test           # Vitest 单测
 pnpm test:e2e       # Playwright
 pnpm typecheck      # tsc --noEmit
@@ -107,9 +107,9 @@ pnpm build          # 构建网关 + admin 静态资源
 
 ## Git 工作流
 
-- 在分支上开发，开 PR，**CI 全绿（typecheck + lint + 单测 + e2e）方可合并**；不直接推 `main`。
+- 在分支上开发，开 PR，**CI 全绿（typecheck + lint + build + 单测 + Docker smoke）方可合并**；e2e（Playwright）在本地跑，不在 CI 门禁内；不直接推 `main`。
 - Commit message 结尾带：
-  `Co-Authored-By: Codex Opus 4.8 (1M context) <noreply@anthropic.com>`
+  `Co-Authored-By: Codex <noreply@openai.com>`
 - 只有用户明确要求时才提交/推送。
 
 ---
@@ -130,7 +130,7 @@ pnpm build          # 构建网关 + admin 静态资源
 ## 实现约定（已拍板，细节见 implementation-notes.md）
 
 - **能力与定价数据源**：上游取 LiteLLM 的 `model_prices_and_context_window.json`，经 `pnpm sync:catalog` 同步成**签入的 generated catalog**；运行时读 `capabilities.yaml` / `pricing.yaml`，**手动条目覆盖生成项**。**不在运行时拉取**（生成目录是供应链输入，不直接进运行时选择）。
-- **provider 执行层**：在 `packages/core/providers` **重写**，移植 llm-router 的久经考验语义（熔断 OPEN/HALF_OPEN + 探测锁、首个有效 chunk 前记失败/后记成功、能力过滤显式 skip reason、`:free` 429 跳过、abort 不算故障）；用其现有测试当行为 checklist。**不 import llm-router**。
+- **provider 执行层**：在 `packages/core/src/provider` **重写**，移植 llm-router 的久经考验语义（熔断 OPEN/HALF_OPEN + 探测锁、首个有效 chunk 前记失败/后记成功、能力过滤显式 skip reason、`:free` 429 跳过、abort 不算故障）；用其现有测试当行为 checklist。**不 import llm-router**。
 - **eval 缓存键**：`sha256(canonical-json)`，只哈希分类依赖输入——末条 user 消息(trim)、turn 数、排序后的 tool 名、`response_format` 是否 JSON、是否含附件/vision；稳定键序、排除易变字段、不 lowercase。TTL 默认 300s，字段集可配，实现后验命中率。
 
 ## 仍需用户决定

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ helm-api/
 
 ```bash
 pnpm install
-pnpm dev            # 起网关 + admin
+pnpm dev            # 仅起 admin 开发服务器（网关无 watch：跑构建产物或 Docker）
 pnpm test           # Vitest 单测
 pnpm test:e2e       # Playwright
 pnpm typecheck      # tsc --noEmit
@@ -107,7 +107,7 @@ pnpm build          # 构建网关 + admin 静态资源
 
 ## Git 工作流
 
-- 在分支上开发，开 PR，**CI 全绿（typecheck + lint + 单测 + e2e）方可合并**；不直接推 `main`。
+- 在分支上开发，开 PR，**CI 全绿（typecheck + lint + build + 单测 + Docker smoke）方可合并**；e2e（Playwright）在本地跑，不在 CI 门禁内；不直接推 `main`。
 - Commit message 结尾带：
   `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
 - 只有用户明确要求时才提交/推送。
@@ -130,7 +130,7 @@ pnpm build          # 构建网关 + admin 静态资源
 ## 实现约定（已拍板，细节见 implementation-notes.md）
 
 - **能力与定价数据源**：上游取 LiteLLM 的 `model_prices_and_context_window.json`，经 `pnpm sync:catalog` 同步成**签入的 generated catalog**；运行时读 `capabilities.yaml` / `pricing.yaml`，**手动条目覆盖生成项**。**不在运行时拉取**（生成目录是供应链输入，不直接进运行时选择）。
-- **provider 执行层**：在 `packages/core/providers` **重写**，移植 llm-router 的久经考验语义（熔断 OPEN/HALF_OPEN + 探测锁、首个有效 chunk 前记失败/后记成功、能力过滤显式 skip reason、`:free` 429 跳过、abort 不算故障）；用其现有测试当行为 checklist。**不 import llm-router**。
+- **provider 执行层**：在 `packages/core/src/provider` **重写**，移植 llm-router 的久经考验语义（熔断 OPEN/HALF_OPEN + 探测锁、首个有效 chunk 前记失败/后记成功、能力过滤显式 skip reason、`:free` 429 跳过、abort 不算故障）；用其现有测试当行为 checklist。**不 import llm-router**。
 - **eval 缓存键**：`sha256(canonical-json)`，只哈希分类依赖输入——末条 user 消息(trim)、turn 数、排序后的 tool 名、`response_format` 是否 JSON、是否含附件/vision；稳定键序、排除易变字段、不 lowercase。TTL 默认 300s，字段集可配，实现后验命中率。
 
 ## 仍需用户决定

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Most-used environment variables (env wins over YAML; full list in [`.env.example
 | Variable | Purpose |
 |---|---|
 | `DEEPSEEK_API_KEY` | Primary provider credential (**required**) |
-| `ZENMUX_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY` | Optional provider credentials (provider is skipped if missing) |
+| `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` | Optional provider credentials (provider is skipped if missing) |
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | Dashboard login (Basic auth) |
 | `HELM_HOST` / `HELM_PORT` | Server binding (default `0.0.0.0:8080`) |
 | `HELM_STORE_DRIVER` | `sqlite` (default) or `supabase` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -164,7 +164,7 @@ curl http://localhost:8080/v1/chat/completions \
 | 变量 | 用途 |
 |---|---|
 | `DEEPSEEK_API_KEY` | 主供应商凭证（**必填**） |
-| `ZENMUX_API_KEY`、`OPENROUTER_API_KEY`、`ANTHROPIC_API_KEY` | 可选供应商凭证（缺失则跳过该供应商） |
+| `ZENMUX_API_KEY`、`OPENROUTER_API_KEY` | 可选供应商凭证（缺失则跳过该供应商，继续走 fallback 链） |
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | 面板登录（Basic auth） |
 | `HELM_HOST` / `HELM_PORT` | 服务绑定（默认 `0.0.0.0:8080`） |
 | `HELM_STORE_DRIVER` | `sqlite`（默认）或 `supabase` |

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -52,8 +52,9 @@ today:
 - **Anthropic Messages** — `POST /v1/messages` (streaming and non-streaming).
 - **OpenAI Responses** — `POST /v1/responses` (streaming and non-streaming; the
   SSE stream terminates with a `response.completed` event).
-- **Google Gemini** — `POST /v1beta/models/{model}:generateContent` (non-streaming;
-  `:streamGenerateContent` is not yet implemented).
+- **Google Gemini** — `POST /v1beta/models/{model}:generateContent` (non-streaming)
+  and `:streamGenerateContent` (streaming via `?alt=sse`, emitted as nameless `data:`
+  delta frames).
 
 Clients should only need to change their `base_url` and API key. A client never
 needs to know which provider or model actually executed the request.
@@ -86,8 +87,9 @@ user-facing surface.
    aliases.
 4. Execute each lane through a primary plus fallback providers.
 5. Record every routing decision and every provider attempt for debugging.
-6. Work out of the box: three default lanes shipped, and the LLM eval **off** by
-   default.
+6. Work out of the box: default lanes shipped (three quality/cost tiers — economy,
+   balanced, premium — plus task lanes such as coding, json, vision, tool_use), and
+   the LLM eval **off** by default.
 7. Enforce that an API key exists at startup; no anonymous access.
 8. Open-source and self-hosted: one-command Docker deployment, config-as-code, no
    hard dependency on external services (see [10 · Deployment](10-deployment.md)).

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -35,8 +35,8 @@ Each component is summarized here; deeper design lives in its own chapter.
 
 Built on Hono. Responsibilities:
 
-- Accept the standard API requests on `/v1/chat/completions`, `/v1/messages`, and
-  `/v1/responses`.
+- Accept the standard API requests on `/v1/chat/completions`, `/v1/messages`,
+  `/v1/responses`, and `/v1beta/models/{model}:generateContent` (Gemini).
 - Normalize request headers and the request/trace id.
 - Apply request-size and timeout limits (`runtime.max_request_bytes`,
   `runtime.request_timeout_ms`).
@@ -64,7 +64,7 @@ Per-key limiter (`packages/core/src/ratelimit`). Off by default
 (`runtime.rate_limit.enabled`) — a zero-overhead pass-through when disabled. It
 sits **after** auth (it needs the resolved `key_id`) and **before** classification
 (so cost is cut off before any classify/eval call). It enforces both the system
-default and any per-key RPM/TPM override on all three request surfaces. See
+default and any per-key RPM/TPM override on every request surface. See
 [06](06-auth-and-rate-limits.md).
 
 ### Task Classifier
@@ -138,7 +138,7 @@ The normalized `InternalRequest` that every protocol adapter produces:
 
 ```yaml
 request_id: string
-protocol: openai_chat | anthropic_messages | openai_responses
+protocol: openai_chat | anthropic_messages | openai_responses | gemini
 account_id: string
 api_key_id: string
 user_id: string | null
@@ -159,8 +159,9 @@ metadata:
   memory_mode: off | observe | inject
 ```
 
-> Note: `protocol` is one of the three wired protocols. A Gemini value is not
-> emitted today (the Gemini transformer is unrouted; see
+> Note: `protocol` is one of the four wired protocols. The Gemini value is
+> emitted by the Gemini inbound surface (`POST /v1beta/models/{model}:generateContent`),
+> which is routed through the same core pipeline (see
 > [01 · Overview](01-overview.md)).
 
 ## Decision record
@@ -229,7 +230,7 @@ config/
   capabilities.yaml    # manual capability overrides over the generated catalog
   pricing.yaml         # manual pricing overrides over the generated catalog
   auth.yaml            # require_api_key + admin auth source
-  runtime.yaml         # store driver, rate limit, timeouts, request size, payload capture
+  runtime.yaml         # store driver, rate limit, timeouts, request size
   server.yaml          # host / port
 ```
 

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -153,8 +153,8 @@ Two cap layers apply, in order:
 1. **Policy caps** narrow the resolver's lane choice (`max_lane` /
    `allowed_lanes`).
 2. **Per-key caps** apply **last** as the outer, non-negotiable bound from the
-   API key's auth record, so a key confined to (for example) `maxLane: economy`
-   is honored even over a policy `use_lane` pin. See
+   API key's auth record, so a key whose `allowed_lanes` whitelist is confined
+   to (for example) `[economy]` is honored even over a policy `use_lane` pin. See
    [06](06-auth-and-rate-limits.md).
 
 ## Execution model and the two fallbacks

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -64,12 +64,13 @@ correctness reference; the code is a clean reimplementation, not a copy.
   that carries upstream-native fields (raw `stop_reason` / `usage` and
   provider-only echoes) that cannot be mapped losslessly. The IR is the single Zod
   type source for the whole protocol layer.
-- **One transformer per protocol, a six-method contract** — three request/response
-  pairs covering the three directions: `transformRequestOut` / `transformRequestIn`
-  (native ↔ IR request), `transformResponseOut` / `transformResponseIn`
-  (IR ↔ native response), and `transformStreamOut` / `transformStreamIn`
-  (IR chunks ↔ native SSE). Inbound and outbound translation live in the same file;
-  see `protocol/transformer.ts`.
+- **One transformer per protocol, a four-method contract** — two request/response
+  pairs covering both directions: `transformRequestOut` / `transformRequestIn`
+  (native ↔ IR request) and `transformResponseOut` / `transformResponseIn`
+  (IR ↔ native response). Streaming-capable protocols (Anthropic, Gemini)
+  additionally expose `transformStreamIn` / `transformStreamOut`
+  (native SSE ↔ IR chunks) as extensions on top of the base contract. Inbound and
+  outbound translation live in the same file; see `protocol/transformer.ts`.
 - **Reasoning crosses the IR through one bridge** (`protocol/reasoning.ts`):
   `{type:"thinking"}` content parts and the flat `message.reasoning_content` /
   `thinking_blocks` are kept in sync, so reasoning survives every cross-protocol

--- a/docs/06-auth-and-rate-limits.md
+++ b/docs/06-auth-and-rate-limits.md
@@ -92,8 +92,10 @@ The stored record (`ApiKeyRecord`, single source of truth in
   it; see implementation-notes.md.)
 - **Rotation & revocation never mutate in place.** `KeyStore.disable` is a soft
   revoke (`disabled = true`); rotate by minting a new key and disabling the old
-  one. `updateRateLimit` is a partial PATCH that touches only the rate-limit
-  columns, never role/caps.
+  one. `KeyStore.updateKey` is a partial PATCH that writes only the per-key cap
+  columns present in the patch (rate limits, allowed lanes, custom-model flag,
+  budgets), leaving omitted columns untouched; it never mutates `role` or the
+  immutable identity (`key_id`/`hash`/`prefix`/`account_id`).
 
 ## Rate limits & quotas
 
@@ -179,8 +181,8 @@ per key via `over_budget_behavior`:
   normally. Cost is bounded **without interrupting service**. Implemented by
   feeding a dynamic `max_lane` ceiling into the router's existing `applyCaps` for
   that one request.
-- **`reject`** — a hard `429 rate_limited` (`limited_by: "credit"` on the OpenAI
-  middleware face), before classify/route.
+- **`reject`** — a hard `429 rate_limited` (message `usage budget exceeded`),
+  before classify/route.
 
 Two phases, like the rate limiter but split by failure mode:
 

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -9,8 +9,9 @@
 > (`apps/gateway/src/routes/memory-scope.ts`), the resolved scope/mode is threaded
 > through, and `observeInbound` / `observeOutbound`
 > (`packages/core/src/memory/observe.ts`) are called from the OpenAI Chat route
-> (`chat.ts`), the Anthropic/Responses pipeline (`messages-pipeline.ts`), and the
-> Anthropic/Responses surfaces (`messages.ts`, `responses.ts`). In `observe`/
+> (`chat.ts`) and from the shared protocol pipeline
+> (`messages-pipeline.ts`), which backs the Anthropic, OpenAI-Responses, and
+> Gemini surfaces (`messages.ts`, `responses.ts`, `gemini.ts`). In `observe`/
 > `inject` mode the gateway persists raw request/response/tool messages into the
 > `memory_*` tables.
 >

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -1,7 +1,7 @@
 # 09 · Roadmap
 
 > Status: **0.2 is implemented.** Phases 0–4 (the 0.1 core) are done; 0.2 adds the
-> Gemini inbound route, native OpenAI Responses streaming, full OAuth subscription
+> Gemini inbound route (with streaming), native OpenAI Responses streaming, full OAuth subscription
 > providers (multi-account pools + hot-reload), and an admin-UI overhaul. The
 > "remaining" list below is what is still deferred.
 
@@ -36,8 +36,9 @@ The build followed an order where each phase runs on its own.
 
 Net-new since 0.1 — all verified live (see `implementation-notes.md`):
 
-- **Gemini inbound route.** `POST /v1beta/models/{model}:generateContent` is mounted
-  (issue #58) — Google/Gemini-format clients now reach the gateway (non-streaming).
+- **Gemini inbound route.** `POST /v1beta/models/{model}:generateContent` and
+  `:streamGenerateContent` are mounted (issue #58) — Google/Gemini-format clients now
+  reach the gateway, including native `alt=sse` streaming (incremental-delta frames).
   The earlier "transformer exists but no endpoint" gap is closed. See
   [05 · Protocol Translation](05-protocol-translation.md).
 - **OpenAI Responses streaming.** `stream: true` on `/v1/responses` now returns a

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -39,7 +39,7 @@ mounting their own directory at `/app/config`.
 ### docker-compose
 
 A `docker-compose.yml` is provided. It defaults to the published image (uncomment
-`build: .` for local builds), mounts the two volumes, and injects credentials from
+the `build:` block for local builds), mounts the two volumes, and injects credentials from
 a `.env` file. `HELM_ADMIN_PASSWORD` and `DEEPSEEK_API_KEY` are required (compose
 fails fast if they are unset):
 
@@ -76,8 +76,8 @@ Configuration comes from **files** and **environment variables**, and env vars
 - `config/*.yaml` — lanes, policies, classifier, providers, capabilities,
   pricing, auth, runtime, server (see [02 · Architecture](02-architecture.md)).
 - Environment variables — upstream provider credentials, the admin Basic-auth
-  user/password, the store driver, and optional bind/limit overrides. See
-  `.env.example` for the full list, including:
+  user/password, the store driver, and optional bind/limit overrides.
+  `.env.example` covers the common ones; additional overrides include:
   - `HELM_HOST`, `HELM_PORT`, `HELM_BASE_PATH`
   - `HELM_ADMIN_USER`, `HELM_ADMIN_PASSWORD`, `HELM_ADMIN_ENABLED`
   - `HELM_RATE_LIMIT_ENABLED`, `HELM_REQUEST_TIMEOUT_MS`, `HELM_MAX_REQUEST_BYTES`

--- a/docs/11-admin-ui.md
+++ b/docs/11-admin-ui.md
@@ -86,7 +86,10 @@ The landing page (`/`) gives an at-a-glance overview.
 
 Rule edits go through a runtime rule store that re-binds the live `lanes` /
 `policies` / `classifier` config the router reads — applied on the very next
-request, no restart. Changes are persisted, keeping "config-as-code".
+request, no restart. In 0.2 these edits are held in-process only and are **not**
+persisted across restarts; YAML write-back is future work. For durable changes,
+edit `config/*.yaml` directly. (The runtime **Settings** below are the exception
+— they are persisted to the config store.)
 
 ### Providers (OAuth subscriptions)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Helm API Documentation
 
 This directory holds the product and technical specification for Helm API. The
-project is **implemented and at the 0.1 release**: the gateway, routing brain,
+project is **implemented and at the 0.2 release**: the gateway, routing brain,
 classifier, protocol translation, store layer, and Admin UI are all built and
 covered by tests. The numbered documents below describe the system as it ships;
 read them in order.
@@ -11,7 +11,7 @@ read them in order.
 Helm API is an **open-source, self-hosted** LLM routing gateway (MIT license,
 deployed with Docker) — think of it as "**nginx for the LLM world**". It accepts
 standard AI API requests (OpenAI Chat Completions, Anthropic Messages, and
-OpenAI Responses today; Gemini is on the roadmap), uses deterministic rules
+OpenAI Responses, and Google Gemini today), uses deterministic rules
 (optionally aided by a small-model evaluation that is **off by default**) to
 classify each request by task type and complexity, and routes it to a
 configurable **lane** rather than to a bare provider alias. It executes the lane
@@ -61,4 +61,4 @@ These keep Helm more focused than its predecessor `llm-router`:
 | Specification | Implemented (these documents describe the shipping system) |
 | Core gateway (routing, classification, protocol translation, store) | Implemented |
 | Admin UI | Implemented |
-| Release | 0.1 |
+| Release | 0.2 |


### PR DESCRIPTION
## Summary

Full accuracy audit of every Markdown doc against the codebase: a 35-agent workflow (7 parallel code scanners → 1 verifier per doc → surgical fixers), followed by manual review of the entire diff. **14 files, +55/−44** — corrections only, no rewrites, each doc keeps its original language and tone.

## Corrections by theme

### Gemini is live, not roadmap (the most pervasive drift)
`:streamGenerateContent` (`?alt=sse`) streaming is fully wired (`apps/gateway/src/routes/gemini.ts`, `gemini-transformer.ts`), but five docs still said "not yet implemented / non-streaming / unrouted":
- `docs/README.md`, `docs/01-overview.md`, `docs/02-architecture.md`, `docs/09-roadmap.md` — Gemini now described as the fourth wired surface, with streaming; `protocol` enum lists all 4 values

### Factual API/behavior fixes
- `docs/11`: admin rule edits (lanes/policies/classifier) are **in-memory only** and lost on restart (`rule-store.ts`); only Settings persist to `config_kv` — doc claimed the opposite
- `docs/06`: `KeyStore.updateRateLimit` → `updateKey` (patches the full cap set); budget `reject` surfaces `usage budget exceeded` — `limited_by: "credit"` exists nowhere in the code
- `docs/04`: per-key cap is the `allowed_lanes` whitelist; there is no per-key `maxLane`
- `docs/05`: transformer contract is four methods; stream methods are per-protocol extensions (anthropic, gemini)
- `docs/02`: `runtime.yaml` does not hold payload capture (runtime-mutable admin setting)

### Stale details
- `docs/README.md`: release 0.1 → 0.2 (×2)
- Both READMEs: drop `ANTHROPIC_API_KEY` (consumed nowhere — only a test fixture)
- `docs/01`: "three default lanes" → the shipped seven; `docs/10`: compose `build:` block + `.env.example` framing; `docs/08`: observe also covers the Gemini surface

### Convention files
- `CLAUDE.md`/`AGENTS.md`: `pnpm dev` starts admin only (`package.json:11`); CI gate is typecheck+lint+build+unit+Docker smoke — e2e runs locally, not in CI (`ci.yml`); AGENTS.md attribution fixed to a proper Codex sign-off; provider path → `packages/core/src/provider`

## Verified clean (zero findings)
`README.md` (en), `docs/03-classification.md`, `docs/07-observability.md`, `docs/protocol-compatibility.md`. `implementation-notes.md` / `docs/research-notes.md` untouched (append-only logs).

## Test plan
- [x] Docs-only change — every correction backed by a code citation, re-verified before applying
- [x] CI: typecheck + lint + build + unit + Docker smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)