### PR TITLE
feat(routing): explicit lane-as-model + strict passthrough validation

### DIFF
--- a/apps/gateway/e2e/fixtures/test-server.ts
+++ b/apps/gateway/e2e/fixtures/test-server.ts
@@ -53,6 +53,28 @@ await keyStore.createKey({
   overBudgetBehavior: "reject",
 });
 
+// Explicit-passthrough keys (docs/04 lane-as-model + strict model validation).
+// `k_custom` may name any known model OR lane; `k_custom_capped` additionally
+// confines explicit lanes to allowed_lanes=[economy] — naming another lane is a
+// 400 invalid_request (loud reject, never a silent downgrade).
+await keyStore.createKey({
+  keyId: "k_custom",
+  hash: hashKey("helm_live_e2e_custom"),
+  prefix: "helm_live_cu",
+  accountId: "acct_e2e",
+  role: "user",
+  allowCustomModel: true,
+});
+await keyStore.createKey({
+  keyId: "k_custom_capped",
+  hash: hashKey("helm_live_e2e_custom_capped"),
+  prefix: "helm_live_cc",
+  accountId: "acct_e2e",
+  role: "user",
+  allowCustomModel: true,
+  allowedLanes: ["economy"],
+});
+
 // Seed one full decision record for the admin requests views (e2e.admin). It is
 // a pre-built, redacted DecisionRecord — NOT a live upstream call — so the admin
 // request list/detail have a deterministic row with a trace_id, a classified

--- a/apps/gateway/e2e/routing.spec.ts
+++ b/apps/gateway/e2e/routing.spec.ts
@@ -148,6 +148,66 @@ test.describe("routing e2e", () => {
     expect(res.headers()["x-helm-provider-model"]).toBe(ECONOMY_NEXT_WIRE);
   });
 
+  // ── Scenario 4b: explicit lane-as-model (allow_custom_model) ─────────────────
+  // An allow_custom_model key may name a LANE in the model field: classification
+  // is skipped and the lane's expanded chain executes (docs/04 explicit
+  // model/lane). The auth header switches to the dedicated k_custom key.
+  const CUSTOM_AUTH = {
+    Authorization: "Bearer helm_live_e2e_custom",
+    "Content-Type": "application/json",
+  };
+  const CAPPED_AUTH = {
+    Authorization: "Bearer helm_live_e2e_custom_capped",
+    "Content-Type": "application/json",
+  };
+
+  test("explicit lane-as-model -> lane chain serves (allow_custom_model)", async ({ request }) => {
+    const res = await request.post("/v1/chat/completions", {
+      // The prompt is clearly COMPLEX — if classification ran it would pick
+      // premium; landing on economy proves the explicit lane bypassed it.
+      data: chat("Prove step by step the theorem and derive the integral.", { model: "economy" }),
+      headers: CUSTOM_AUTH,
+    });
+    expect(res.status()).toBe(200);
+    expect(res.headers()["x-helm-lane"]).toBe("economy");
+    expect(res.headers()["x-helm-final-model"]).toBe(ECONOMY_HEAD);
+    expect(res.headers()["x-helm-provider-model"]).toBe(ECONOMY_HEAD_WIRE);
+  });
+
+  test("explicit lane outside the key's allowed_lanes -> 400 invalid_request (no silent downgrade)", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1/chat/completions", {
+      data: chat("hi thanks, ok", { model: "premium" }),
+      headers: CAPPED_AUTH,
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toContain("premium");
+  });
+
+  test("explicit UNKNOWN model -> 400 invalid_request (strict, no Phase-0 fall-through)", async ({
+    request,
+  }) => {
+    const res = await request.post("/v1/chat/completions", {
+      data: chat("hi thanks, ok", { model: "totally-made-up-model" }),
+      headers: CUSTOM_AUTH,
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toContain("totally-made-up-model");
+  });
+
+  test("explicit KNOWN model alias still passes through verbatim", async ({ request }) => {
+    const res = await request.post("/v1/chat/completions", {
+      data: chat("hi thanks, ok", { model: ECONOMY_HEAD }),
+      headers: CUSTOM_AUTH,
+    });
+    expect(res.status()).toBe(200);
+    expect(res.headers()["x-helm-final-model"]).toBe(ECONOMY_HEAD);
+    expect(res.headers()["x-helm-provider-model"]).toBe(ECONOMY_HEAD_WIRE);
+  });
+
   // ── Scenario 5: unclassifiable prompt → balanced (classification fallback) ──
   // A contentless/degenerate prompt is genuinely unclassifiable: the classify
   // adapter fails open (principle 3) and the resolver pins `balanced` via the

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1018,6 +1018,21 @@ export async function buildServer(
           }),
           now: () => new Date(),
           log: (record) => logger.log("info", "route.decision", { trace_id: record.request_id }),
+          // Strict explicit-model validation (docs/04): mirrors the executor's
+          // resolvability rules so plan-time acceptance == execute-time routability.
+          // Reads the LIVE oauthAliasSet/providerClients bindings (reassigned on
+          // OAuth curation changes), exactly like the executor's oauthAliases thunk.
+          isKnownModel: (alias) => {
+            if (oauthAliasSet.has(alias)) return true; // live curated OAuth set
+            const slash = alias.indexOf("/");
+            const prefix = slash > 0 ? alias.slice(0, slash) : "";
+            // Un-curated subscription alias: fail closed (executor would skip it).
+            if (prefix && ROUTABLE_OAUTH_IDS.has(prefix)) return false;
+            if (registry.resolve(alias).ok) return true; // providers.yaml alias
+            // Structural `provider/...` fallback: the named client forwards the bare id.
+            if (prefix && providerClients.has(prefix)) return true;
+            return false; // bare unknown name: rejected (no Phase-0 silent fallback)
+          },
         },
         routeOpts,
       ),

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -21,12 +21,32 @@ guaranteed to exist.
 
 ### Explicit client model has the highest priority
 
-When a client specifies a concrete model, classification and policy are skipped
-and the model is executed directly (the nginx pass-through equivalent). Whether
-this is allowed is controlled by the key's `allow_custom_model` capability (see
+When a client specifies a concrete model **or a lane name**, classification and
+policy are skipped and the request is executed directly (the nginx pass-through
+equivalent). Whether this is allowed is controlled by the key's
+`allow_custom_model` capability (see
 [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md)). The sentinel
 value `auto` is never treated as an explicit model — it means "let the router
 decide" and falls through to classification.
+
+For an `allow_custom_model` key the `model` field resolves in this order:
+
+1. **Lane name** (lanes shadow same-named model aliases): the lane's chain is
+   expanded and executed with full fallback semantics. The lane must sit inside
+   the key's `allowed_lanes` whitelist — an explicit ask for a forbidden lane is
+   rejected with `invalid_request` (400), **never silently downgraded** (only
+   classified routing clamps via `applyCaps`).
+2. **Model alias**: executed as a single-candidate chain (no fallback). The name
+   is validated against what the deployment can actually serve (providers.yaml
+   registry ∪ live curated OAuth aliases ∪ `provider/`-prefixed aliases whose
+   client is registered); an unknown name is rejected with `invalid_request`
+   (400) instead of silently falling through to the default provider.
+3. Over-budget `degrade` (docs/06) suppresses BOTH forms of explicit passthrough
+   — the request is forced onto the degrade lane.
+
+Keys **without** `allow_custom_model` ignore the `model` field entirely (any
+value behaves like `auto` and routes via classification); it is recorded in
+telemetry as `requested_model` only.
 
 ## Lanes
 

--- a/docs/06-auth-and-rate-limits.md
+++ b/docs/06-auth-and-rate-limits.md
@@ -75,7 +75,7 @@ The stored record (`ApiKeyRecord`, single source of truth in
   account_id: string,
   role: "root" | "user",
   allowed_lanes: string[] | null, // allow-list of lanes (empty/null = any lane)
-  allow_custom_model: boolean,    // may the client pin a model directly?
+  allow_custom_model: boolean,    // may the client pin a model OR lane directly?
   disabled: boolean,
   rate_limit_rpm: number | null,  // per-key override; null = inherit default
   rate_limit_tpm: number | null,  // 0 = explicitly unlimited
@@ -87,7 +87,10 @@ The stored record (`ApiKeyRecord`, single source of truth in
   key. The plaintext of a freshly minted key is returned to the admin caller
   exactly once and then discarded.
 - **Per-key caps.** `allowed_lanes` and `allow_custom_model` constrain how a key
-  may route (resolved into `AuthIdentity.caps`). (A per-key `max_lane` ceiling was
+  may route (resolved into `AuthIdentity.caps`). `allow_custom_model` lets the
+  `model` field name a concrete model alias or a lane (docs/04); an explicit
+  lane is still bounded by `allowed_lanes` and a violation is a 400, not a
+  silent downgrade. (A per-key `max_lane` ceiling was
   retired — lanes are parallel, not a strict hierarchy, so the whitelist subsumes
   it; see implementation-notes.md.)
 - **Rotation & revocation never mutate in place.** `KeyStore.disable` is a soft

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,30 @@
 
 ---
 
+## 2026-06-04 · 显式 lane-as-model + 透传严格校验（spec docs/04 / docs/06）
+
+docs/04 路由优先级表第一行写的是 "explicit **model/lane**"，但实现里透传分支从未做 lane 展开：
+`model: "premium"` 会被当成字面模型名原样发给上游（4xx），未知裸模型名则静默落到
+defaultProvider（Phase-0 fail-open）。本次补齐 lane 半边并收紧校验（与用户拍板）：
+
+- **lane-as-model**（仅 `allow_custom_model=true` 的 key）：`model` 命中 lane 名 →
+  跳过分类/policy，但走 `expandChain` 完整 fallback 链。**lane 名遮蔽同名模型别名**
+  （先查 lane 再查模型）。
+- **`allowed_lanes` 硬约束**：显式点名一个不在白名单里的 lane → `invalid_request`(400)
+  **响亮拒绝**，不像分类路由那样经 `applyCaps` 静默降级——显式请求被偷偷换 lane 是更糟的语义。
+  空数组视为未启用（与 `applyCaps` 激活规则一致）。
+- **未知模型严格拒绝**：新增 `RouteDeps.isKnownModel?`（core 可选注入，headless 不强制；
+  gateway 必注入）。判定镜像执行器的可路由规则：live OAuth 别名集 ∪ providers.yaml registry
+  ∪ 有已注册 client 的 `provider/` 前缀；未捕捉的 subscription 前缀 fail-closed。
+  **裸未知名不再静默透传给 defaultProvider** ——显式透传路径的 Phase-0 fail-open 被移除
+  （分类路由产生的链不受影响，执行器语义未动）。
+- **不变**：`auto` 哨兵、普通 key（`allow_custom_model=false`）继续忽略 model 字段走分类、
+  超预算 degrade 同时压制模型与 lane 两种显式透传。
+- 拒绝同样落一条完整 DecisionRecord（final.status=error / error_reason=invalid_request /
+  空链 / 零 attempts），Debug UI 可见。
+
+---
+
 ## 2026-06-04 · Anthropic null 窗口解析回归 + /usage 孤儿过滤（providers 页, spec docs/11）
 
 两个收尾修复：

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -397,6 +397,139 @@ describe("routeRequest — orchestration", () => {
     expect(plan.selected_lane).toBe("coding");
   });
 
+  it("explicit LANE passthrough expands the lane's chain (full fallback semantics)", async () => {
+    // model = a lane name + allow_custom_model: skip classify/policy, but run the
+    // lane's expanded chain — NOT a [premium] literal candidate.
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "premium" }), d, {
+      allowCustomModel: true,
+    });
+
+    expect(d.classify).not.toHaveBeenCalled();
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+    expect(plan.explicit_model).toBeNull(); // a lane is not a single explicit model
+    // premium.primary, then balanced (lane ref) expanded; cycle back to premium cut.
+    expect(plan.candidate_chain).toEqual(["best_reasoning_model", "default_good_model"]);
+
+    const rec = (d.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.lane.selected_lane).toBe("premium");
+    expect(rec.classifier.task_type).toBe("passthrough");
+    expect(result.final.status).toBe("ok");
+  });
+
+  it("explicit lane is rejected with invalid_request when NOT in the key's allowedLanes (no silent downgrade)", async () => {
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "premium" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: ["economy"] },
+    });
+
+    expect(d.execute).not.toHaveBeenCalled();
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(result.error?.message).toContain("premium");
+
+    // The rejection is still observable: a decision record is logged.
+    expect(d.log).toHaveBeenCalledOnce();
+    const rec = (d.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.final.status).toBe("error");
+    expect(rec.final.error_reason).toBe("invalid_request");
+    expect(rec.lane.selected_lane).toBe("premium");
+    expect(rec.lane.candidate_chain).toEqual([]);
+    expect(rec.provider_attempts).toHaveLength(0);
+  });
+
+  it("explicit lane inside the key's allowedLanes is served", async () => {
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "economy" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: ["economy", "balanced"] },
+    });
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+    expect(plan.candidate_chain[0]).toBe("cheap_model");
+    expect(result.final.status).toBe("ok");
+  });
+
+  it("an EMPTY allowedLanes array is inactive for explicit lanes (mirrors applyCaps)", async () => {
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "premium" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: [] },
+    });
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+  });
+
+  it("explicit lane works even when isKnownModel does not know it (lanes shadow model aliases)", async () => {
+    const d = deps({ isKnownModel: () => false });
+    const result = await routeRequest(req({ requested_model: "economy" }), d, {
+      allowCustomModel: true,
+    });
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+  });
+
+  it("explicit UNKNOWN model is rejected with invalid_request (strict — no Phase-0 silent fallback)", async () => {
+    const d = deps({ isKnownModel: (alias) => alias === "deepseek/deepseek-v4-pro" });
+    const result = await routeRequest(req({ requested_model: "gpt-4o" }), d, {
+      allowCustomModel: true,
+    });
+
+    expect(d.execute).not.toHaveBeenCalled();
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(result.error?.message).toContain("gpt-4o");
+
+    const rec = (d.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.final.error_reason).toBe("invalid_request");
+    expect(rec.lane.candidate_chain).toEqual([]);
+  });
+
+  it("explicit KNOWN model passes through; isKnownModel ABSENT keeps legacy passthrough (back-compat)", async () => {
+    const known = deps({ isKnownModel: (alias) => alias === "deepseek/deepseek-v4-pro" });
+    const okKnown = await routeRequest(
+      req({ requested_model: "deepseek/deepseek-v4-pro" }),
+      known,
+      {
+        allowCustomModel: true,
+      },
+    );
+    expect(okKnown.final.status).toBe("ok");
+    const plan = (known.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.candidate_chain).toEqual(["deepseek/deepseek-v4-pro"]);
+
+    // No isKnownModel wired (headless core / older callers): no validation.
+    const legacy = deps();
+    const okLegacy = await routeRequest(req({ requested_model: "anything" }), legacy, {
+      allowCustomModel: true,
+    });
+    expect(okLegacy.final.status).toBe("ok");
+  });
+
+  it("keyCaps.degradeLane suppresses explicit LANE passthrough too (no over-budget bypass)", async () => {
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "premium" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: null, degradeLane: "economy" },
+    });
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+  });
+
+  it("a lane name WITHOUT allow_custom_model stays ignored — classified routing as before", async () => {
+    const d = deps();
+    await routeRequest(req({ requested_model: "premium" }), d, { allowCustomModel: false });
+    expect(d.classify).toHaveBeenCalledOnce();
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("coding");
+  });
+
   it("populates the rich telemetry fields (latency total, fallback_count, cost split, key_prefix)", async () => {
     const d = deps({
       classify: vi.fn(async () => classification({ eval_usd: 0.00003 })),

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -1,4 +1,10 @@
-import type { AttemptErrorDetail, DecisionRecord, HelmError, InternalRequest } from "@helm/shared";
+import {
+  type AttemptErrorDetail,
+  type DecisionRecord,
+  type HelmError,
+  type InternalRequest,
+  makeHelmError,
+} from "@helm/shared";
 import type { LanesConfig } from "../lanes/schema.js";
 import { type Classification as ResolverClassification, resolveLane } from "./lane-resolver.js";
 import { applyCaps, evaluatePolicies, type PolicyContext } from "./policy-engine.js";
@@ -54,9 +60,11 @@ export interface Classification {
   explanation: unknown[];
 }
 
-// The resolved execution plan handed to execute(). For explicit passthrough the
-// chain is exactly [explicit_model]; otherwise it is the selected lane's primary
-// plus its (recursively expanded, deduped, cycle-safe) fallback aliases.
+// The resolved execution plan handed to execute(). For explicit MODEL
+// passthrough the chain is exactly [explicit_model]; for an explicit LANE
+// (model field names a lane, docs/04) and for classified routing it is the
+// selected lane's primary plus its (recursively expanded, deduped, cycle-safe)
+// fallback aliases — explicit_model stays null in both lane cases.
 export interface ExecutionPlan {
   selected_lane: string;
   candidate_chain: string[];
@@ -114,6 +122,14 @@ export interface RouteDeps {
   /** telemetry sink — record is ALREADY redacted upstream is the caller's job;
    *  this never logs plaintext key/payload (principle 7). */
   log: (record: DecisionRecord) => void;
+  /** Is this string a model the deployment can actually serve? Used ONLY to
+   *  validate an explicit-model passthrough (allow_custom_model): an unknown
+   *  model is rejected with invalid_request instead of silently falling through
+   *  to the default provider (docs/04 — strict, no silent fallback). The gateway
+   *  wires it from registry + live OAuth curation + provider-prefix structure;
+   *  absent (headless core / tests) → validation is skipped. Lane names are
+   *  checked FIRST and never reach this. */
+  isKnownModel?: (alias: string) => boolean;
 }
 
 export interface RouteOptions {
@@ -243,6 +259,38 @@ interface PlanDecision {
   evalUsd: number | null;
 }
 
+// An explicit passthrough rejected BEFORE execution (unknown model / lane not in
+// the key's allowed_lanes — docs/04 strict validation). Carries everything the
+// orchestrator needs to log a complete error DecisionRecord without executing:
+// `selectedLane` is the requested name (chain stays empty — nothing was planned).
+interface PlanRejection {
+  reject: HelmError;
+  selectedLane: string;
+}
+
+function isRejection(p: PlanDecision | PlanRejection): p is PlanRejection {
+  return "reject" in p;
+}
+
+// The classifier segment shared by ALL explicit-passthrough outcomes (model,
+// lane, and their rejections). task_type:"passthrough" (NOT decided_by) is the
+// disambiguator: explicit passthrough and the classifier-crash fail-open BOTH
+// record decided_by:"default", so do not read decided_by to tell them apart —
+// passthrough is uniquely identified by task_type/complexity:"passthrough"
+// (crash fail-open uses task_type:"general", complexity:"medium").
+function passthroughClassifier(): DecisionRecord["classifier"] {
+  return {
+    task_type: "passthrough",
+    complexity: "passthrough",
+    confidence: 1,
+    decided_by: "default",
+    eval_cache_hit: null,
+    fallback_reason: null,
+    constraints: {},
+    explanation: [],
+  };
+}
+
 // Compute the execution plan + the classifier/policy decision segments. Explicit
 // passthrough short-circuits classify/policy/resolver entirely (docs/04: highest
 // priority, gated by allow_custom_model).
@@ -250,16 +298,19 @@ async function plan(
   req: InternalRequest,
   deps: RouteDeps,
   opts: RouteOptions,
-): Promise<PlanDecision> {
-  // 1) Explicit passthrough — bypass the whole routing brain.
+): Promise<PlanDecision | PlanRejection> {
+  // 1) Explicit passthrough — bypass the whole routing brain. The model field
+  //    may name a concrete MODEL (chain = [model]) or a LANE (chain = the lane's
+  //    expanded fallback chain, docs/04 "explicit model/lane").
   //    `auto` is the canonical "let the router decide" sentinel and must NEVER be
   //    treated as an explicit model, even for an allow_custom_model key — otherwise
   //    it short-circuits classify/lane-resolve and gets sent upstream as the literal
   //    model "auto" (the llm-router #391 regression). Fall through to classify.
   //    A key that is OVER its usage budget and set to `degrade` (opts.keyCaps.
   //    degradeLane is populated for this request) must NOT be able to bypass the
-  //    downgrade by naming an expensive explicit model — so suppress passthrough
-  //    while degrading and fall through to the forced degrade lane below (docs/06).
+  //    downgrade by naming an expensive explicit model OR lane — so suppress
+  //    passthrough while degrading and fall through to the forced degrade lane
+  //    below (docs/06).
   if (
     opts.allowCustomModel === true &&
     req.requested_model.length > 0 &&
@@ -267,23 +318,53 @@ async function plan(
     (opts.keyCaps?.degradeLane === undefined || opts.keyCaps.degradeLane === null)
   ) {
     const model = req.requested_model;
+
+    // 1a) Explicit LANE — lanes shadow same-named model aliases. The lane runs
+    //     with full fallback semantics (expandChain), but must sit inside the
+    //     key's allowed_lanes whitelist: unlike classified routing (where
+    //     applyCaps silently clamps), an EXPLICIT ask for a forbidden lane is a
+    //     client error and is rejected loudly (no silent downgrade). An empty
+    //     allowedLanes array is inactive, mirroring applyCaps' activation rule.
+    if (Object.hasOwn(deps.lanes, model)) {
+      const allowed = opts.keyCaps?.allowedLanes;
+      if (allowed != null && allowed.length > 0 && !allowed.includes(model)) {
+        return {
+          reject: makeHelmError({
+            error_class: "invalid_request",
+            message: `lane "${model}" is not permitted for this key (allowed_lanes)`,
+            trace_id: req.request_id,
+          }),
+          selectedLane: model,
+        };
+      }
+      return {
+        plan: {
+          selected_lane: model,
+          candidate_chain: expandChain(model, deps.lanes),
+          explicit_model: null,
+        },
+        classifier: passthroughClassifier(),
+        policy: { matched_policy_id: null, reason: "explicit lane passthrough" },
+        evalUsd: null,
+      };
+    }
+
+    // 1b) Explicit MODEL — strict validation when the deployment wired
+    //     isKnownModel: an unknown name is a client error (invalid_request),
+    //     NEVER a silent Phase-0 fall-through to the default provider.
+    if (deps.isKnownModel !== undefined && !deps.isKnownModel(model)) {
+      return {
+        reject: makeHelmError({
+          error_class: "invalid_request",
+          message: `unknown model or lane "${model}"`,
+          trace_id: req.request_id,
+        }),
+        selectedLane: model,
+      };
+    }
     return {
       plan: { selected_lane: model, candidate_chain: [model], explicit_model: model },
-      classifier: {
-        // task_type:"passthrough" (NOT decided_by) is the disambiguator here:
-        // explicit passthrough and the classifier-crash fail-open BOTH record
-        // decided_by:"default", so do not read decided_by to tell them apart —
-        // passthrough is uniquely identified by task_type/complexity:"passthrough"
-        // (crash fail-open uses task_type:"general", complexity:"medium").
-        task_type: "passthrough",
-        complexity: "passthrough",
-        confidence: 1,
-        decided_by: "default",
-        eval_cache_hit: null,
-        fallback_reason: null,
-        constraints: {},
-        explanation: [],
-      },
+      classifier: passthroughClassifier(),
       policy: { matched_policy_id: null, reason: "explicit model passthrough" },
       evalUsd: null,
     };
@@ -353,7 +434,43 @@ export async function routeRequest(
   deps: RouteDeps,
   opts: RouteOptions = {},
 ): Promise<ExecutionResult> {
-  const { plan: execPlan, classifier, policy, evalUsd } = await plan(req, deps, opts);
+  const planned = await plan(req, deps, opts);
+
+  // Explicit passthrough rejected before execution (unknown model / lane not
+  // permitted): no provider was attempted, but the rejection is still a routing
+  // decision — log a complete error record (empty chain, no attempts, costs
+  // unknown) so it shows up in the Debug UI like any other terminal error.
+  if (isRejection(planned)) {
+    const decision: DecisionRecord = {
+      request_id: req.request_id,
+      trace_id: req.request_id,
+      requested_model: req.requested_model,
+      key_prefix: opts.keyPrefix ?? null,
+      classifier: passthroughClassifier(),
+      policy: { matched_policy_id: null, reason: "explicit passthrough rejected" },
+      lane: { selected_lane: planned.selectedLane, candidate_chain: [] },
+      provider_attempts: [],
+      final: {
+        model_alias: null,
+        provider_model: null,
+        status: "error",
+        error_reason: planned.reject.error_class,
+      },
+      latency_total_ms: 0,
+      fallback_count: 0,
+      cost_breakdown: { eval_usd: null, completion_usd: null, total_usd: null },
+    };
+    deps.log(decision);
+    return {
+      decision,
+      final: { status: "error" },
+      body: null,
+      stream: null,
+      error: planned.reject,
+    };
+  }
+
+  const { plan: execPlan, classifier, policy, evalUsd } = planned;
 
   const outcome = await deps.execute(execPlan, req);
 


### PR DESCRIPTION
## Summary

Closes the docs/04 spec gap ("explicit **model/lane**" — the lane half was never implemented). For `allow_custom_model=true` keys, the `model` field now resolves as:

1. **Lane name** (lanes shadow same-named aliases) → classify/policy skipped, the lane's `expandChain`'d chain executes with full fallback semantics. Bounded by the key's `allowed_lanes`: an explicit ask for a forbidden lane is a **400 `invalid_request`** — loud reject, never an `applyCaps`-style silent downgrade.
2. **Model alias** → validated via the new optional `RouteDeps.isKnownModel` (gateway wires it from live curated OAuth aliases ∪ providers.yaml registry ∪ registered `provider/` prefixes, mirroring the executor's resolvability rules). Unknown names → **400**; the Phase-0 silent fall-through to `defaultProvider` is removed for explicit passthrough only (classified chains / executor semantics untouched).

Unchanged: the `auto` sentinel, normal keys (model field still ignored → classified routing), over-budget `degrade` suppressing both explicit forms. Rejections still log a complete `DecisionRecord` (empty chain, `error_reason=invalid_request`) so they surface in the Debug UI.

## Changes

- `packages/core/src/routing/route-request.ts` — lane/model branches in `plan()`, `PlanRejection` early-return with decision logging, `RouteDeps.isKnownModel?` (optional: headless core unaffected)
- `apps/gateway/src/server.ts` — `isKnownModel` closure (reads live `oauthAliasSet`/`providerClients`)
- `apps/gateway/e2e/*` — two seeded keys (`k_custom`, `k_custom_capped`), 4 new routing scenarios
- `docs/04`, `docs/06`, `implementation-notes.md` — semantics + strictness decision recorded

## Test plan

- [x] TDD: +9 unit cases in `route-request.test.ts` (26/26)
- [x] Full vitest sweep: 2079/2079
- [x] e2e `routing.spec.ts`: 9/9 (lane-as-model 200, forbidden lane 400, unknown model 400, known alias passthrough)
- [x] `pnpm typecheck` + `pnpm lint` clean (20 pre-existing warnings)
- [x] Codex review: no findings
- Note: full local Playwright runs fail `admin.spec.ts` "filters narrow the list" identically on clean `main` (cross-spec telemetry pollution) — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)