### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps the root `package.json` version `0.2.0 → 0.3.0`. Merging this then tagging `v0.3.0` triggers the **Publish image** workflow to build & push `ghcr.io/easymetaau/helm-api:0.3.0` + `:latest`, after which the GitHub release is cut.

## What's in 0.3.0 (18 commits since v0.2.0)

**Features**
- Explicit lane-as-model + strict passthrough validation (#83)
- Full litellm protocol parity across all four protocols, Phases 0–9 (#75)
- IR foundation for litellm parity (#71)
- Native Gemini SSE streaming for `:streamGenerateContent` (#69)
- Per-key usage quotas + over-budget degrade (#68)
- OAuth subscription providers: usage, remaining quota & scheduling in admin (#72)
- Route lanes via openai-codex subscription + official DeepSeek; drop openai-crs relay (#73)
- Dashboard range filter, clickable recent requests, numbered pager (#70)

**Fixes / polish**
- Admin duration formatter >24h → days (#81); Codex window labels 5h/Weekly (#80)
- Quota: null Anthropic windows + orphan filtering on /usage & /quota (#76–#79)
- OAuth usage negative-cache + i18n ja/ko/zh-hant (#77)
- Config: align openai-codex lanes/catalog to exposed Codex set (#74)
- Docs synced to the implemented 0.2 reality (#82); AGENTS.md added

Version-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)