### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps the root `package.json` `0.3.0 → 0.3.1`. Merge + tag `v0.3.1` triggers the **Publish image** workflow to push `ghcr.io/easymetaau/helm-api:0.3.1` + `:latest`, then the GitHub release is cut.

## What's in 0.3.1 (2 commits since v0.3.0)

- **fix(lanes)** — update fallback models across economy / balanced / premium / coding / json / vision / tool_use lanes (f0d0cc6)
- **feat(capabilities, pricing, providers)** — add OpenRouter-hosted DeepSeek models + zenmux fallbacks, updated pricing (68098a4)

Both are config / generated-catalog / pricing **data** updates — no gateway code touched. This PR itself is version-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)