### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps the root `package.json` `0.3.1 → 0.3.2`. Merge + tag `v0.3.2` triggers the **Publish image** workflow to push `ghcr.io/easymetaau/helm-api:0.3.2` + `:latest`, then the GitHub release is cut.

## What's in 0.3.2 (1 commit since v0.3.1)

- **feat(admin)** — stream-aware viewer for captured SSE responses (#86): the request-payload debug view renders captured streaming bodies as parsed SSE events instead of a raw text blob.

Admin-UI-only change; gateway routing behaviour unchanged. This PR itself is version-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)