### PR TITLE
feat(admin): add refresh button to subscription providers page

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -301,6 +301,8 @@
   "Recent requests": "Recent requests",
   "Record full request and response bodies": "Record full request and response bodies",
   "redacted": "redacted",
+  "Refresh": "Refresh",
+  "Refreshing…": "Refreshing…",
   "reject": "reject",
   "Reject (429)": "Reject (429)",
   "remove": "remove",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -301,6 +301,8 @@
   "Recent requests": "最近のリクエスト",
   "Record full request and response bodies": "完全なリクエスト本文とレスポンス本文を記録する",
   "redacted": "編集済み",
+  "Refresh": "更新",
+  "Refreshing…": "更新中…",
   "reject": "拒否",
   "Reject (429)": "拒否（429）",
   "remove": "削除",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -301,6 +301,8 @@
   "Recent requests": "최근 요청",
   "Record full request and response bodies": "전체 요청 및 응답 본문 기록",
   "redacted": "편집됨",
+  "Refresh": "새로고침",
+  "Refreshing…": "새로고침 중…",
   "reject": "거부",
   "Reject (429)": "거부(429)",
   "remove": "제거",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -301,6 +301,8 @@
   "Recent requests": "最近请求",
   "Record full request and response bodies": "记录完整的请求和响应正文",
   "redacted": "已脱敏",
+  "Refresh": "刷新",
+  "Refreshing…": "刷新中…",
   "reject": "拒绝",
   "Reject (429)": "拒绝（429）",
   "remove": "移除",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -301,6 +301,8 @@
   "Recent requests": "最近請求",
   "Record full request and response bodies": "記錄完整的請求和回應本文",
   "redacted": "已遮蔽",
+  "Refresh": "重新整理",
+  "Refreshing…": "重新整理中…",
   "reject": "拒絕",
   "Reject (429)": "拒絕（429）",
   "remove": "移除",

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -34,6 +34,7 @@
   } = $props();
 
   let error = $state<string | null>(untrack(() => data.loadError ?? null));
+  let refreshing = $state<boolean>(false);
   let showConnect = $state<boolean>(false);
   let managing = $state<{ providerId: string; providerName: string; account: string } | null>(null);
   let confirming = $state<{ providerId: string; account: string } | null>(null);
@@ -133,6 +134,22 @@
     void invalidateAll();
   }
 
+  // Manual refresh: re-run the page load (status + today's usage + quota windows in
+  // parallel). Usage counters are read live; the Anthropic quota PULL stays behind
+  // the gateway's 5-min debounce (the upstream endpoint rate-limits aggressively),
+  // so within that window the bars re-render from the cached snapshot. The load
+  // itself never throws (fail-open) — `loadError` carries the only failure signal.
+  async function refresh(): Promise<void> {
+    refreshing = true;
+    error = null;
+    try {
+      await invalidateAll();
+      error = data.loadError ?? null;
+    } finally {
+      refreshing = false;
+    }
+  }
+
   function onManaged(): void {
     managing = null;
     void invalidateAll();
@@ -207,12 +224,17 @@
         )}
       </p>
     </div>
-    <button
-      type="button"
-      class="btn-primary shrink-0"
-      disabled={!data.configured}
-      onclick={() => (showConnect = true)}>{$t('Connect')}</button
-    >
+    <div class="flex shrink-0 gap-2">
+      <button type="button" class="btn-secondary" disabled={refreshing} onclick={refresh}
+        >{refreshing ? $t('Refreshing…') : $t('Refresh')}</button
+      >
+      <button
+        type="button"
+        class="btn-primary"
+        disabled={!data.configured}
+        onclick={() => (showConnect = true)}>{$t('Connect')}</button
+      >
+    </div>
   </header>
 
   {#if error}


### PR DESCRIPTION
## Summary

- Adds a global **Refresh** button next to **Connect** on `/admin/providers` that re-runs the page load (status + today's usage + quota windows in parallel) via `invalidateAll()`, with a disabled "Refreshing…" state and `loadError` propagation.
- Adds `Refresh` / `Refreshing…` translation keys to all five locales (en, zh-hans, zh-hant, ja, ko).

## Behavior notes

- **Usage counters** ("Today" column) are read live from the store — every click is genuinely fresh.
- **Anthropic quota bars** intentionally stay behind the gateway's existing 5-minute debounce (`QUOTA_TTL_MS`) — the upstream usage endpoint rate-limits aggressively, so repeated clicks never re-hit it. Codex quota is pushed from live request headers (nothing to pull).
- UI-only change: no gateway/seam code touched.

## Test plan

- [x] `svelte-check` — 0 errors / 0 warnings
- [x] `pnpm lint` + `pnpm build` pass
- [x] `pnpm test` — 2100/2100 pass
- [x] Manual verification against the built gateway: one click triggers exactly one re-fetch batch (`/oauth` + `/usage` + `/quota`); button renders correctly in English and 简体中文

No new tests: the button is pure UI glue (`invalidateAll()`), exempt from mandatory coverage per CLAUDE.md, and the providers page has no existing e2e spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)