### PR TITLE
feat(gateway): public landing page, /v1/models, and OpenAPI/Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ docker compose up -d
 docker compose logs helm | grep -i "root API key"
 ```
 
-- **Gateway** → `http://localhost:8080`
+- **Gateway** → `http://localhost:8080` (a status landing page lives at `/`)
 - **Dashboard** → `http://localhost:8080/admin` (log in with `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD`)
+- **API docs** → `GET /docs` (interactive Swagger UI) · `GET /openapi.json` (OpenAPI 3.1 spec)
 - **Health / version** → `GET /healthz`, `GET /version`
 
 `docker-compose.yml` mounts `./config` and `./data`, so your config and database survive restarts. Credentials are passed in as environment variables only — never built into the image.
@@ -143,6 +144,22 @@ curl http://localhost:8080/v1/chat/completions \
 | a model alias, e.g. `openai-codex/gpt-5.5` | Uses exactly that model and skips routing — only for keys granted custom-model permission. |
 
 > With a standard key, routing is automatic no matter what you send — just use `auto`. Lanes are configured by the operator in `lanes.yaml` and the dashboard; clients don't choose a lane per call.
+
+### API surface
+
+Every endpoint is documented interactively at **`/docs`** (Swagger UI, "Try it out"), with the raw spec at **`/openapi.json`** (OpenAPI 3.1, generated from the same Zod schemas the gateway validates against).
+
+| Endpoint | Auth | Purpose |
+|---|---|---|
+| `GET /` | — | Status landing page |
+| `GET /healthz` · `GET /version` | — | Readiness probe · build info |
+| `GET /docs` · `GET /openapi.json` | — | Interactive docs · OpenAPI 3.1 spec |
+| `GET /v1/models` · `GET /v1/models/{id}` | API key | List models the key can route to (lanes + `auto`; concrete aliases with capabilities & pricing for custom-model keys) |
+| `POST /v1/chat/completions` | API key | OpenAI Chat Completions |
+| `POST /v1/messages` | API key | Anthropic Messages |
+| `POST /v1/responses` | API key | OpenAI Responses |
+| `POST /v1beta/models/{model}:generateContent` | API key | Google Gemini |
+| `/admin` · `/admin/api/*` | Basic auth | Dashboard + its JSON backend (mounted only when admin credentials are set) |
 
 ## Configuration
 

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -13,7 +13,9 @@
     "@helm/core": "workspace:*",
     "@helm/shared": "workspace:*",
     "@hono/node-server": "^2.0.4",
-    "hono": "^4.12.23"
+    "@hono/swagger-ui": "^0.6.1",
+    "hono": "^4.12.23",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -8,6 +8,8 @@ import { normalizeHeaders } from "./middleware/normalize-headers.js";
 import { requestLoggerMiddleware } from "./middleware/request-logger.js";
 import { traceIdMiddleware } from "./middleware/trace-id.js";
 import { type HealthDeps, registerHealthRoutes } from "./routes/health.js";
+import { registerLandingRoute } from "./routes/landing.js";
+import { registerOpenApiRoutes } from "./routes/openapi.js";
 
 export interface AppDeps {
   logger: Logger;
@@ -63,6 +65,15 @@ export function createApp(deps: AppDeps): Hono<AppEnv> {
     buildInfo: readBuildInfo(),
   };
   registerHealthRoutes(app, health);
+
+  // Public landing page at "/" (status dashboard). Unauthenticated, static HTML;
+  // replaces the bare 404 the root used to return. Headless callers simply never
+  // see it — it adds no dependency on routing/admin (Principle 1).
+  registerLandingRoute(app);
+
+  // Public API docs: GET /openapi.json (3.1 spec generated from the Zod schemas)
+  // and GET /docs (Swagger UI). Schema-only, no data — safe to expose unauth.
+  registerOpenApiRoutes(app, { buildInfo: health.buildInfo });
 
   // /admin (admin API + static SPA) is wired by server.ts (it needs the resolved
   // adminAuth config + Store deps). createApp stays framework-glue only and does

--- a/apps/gateway/src/routes/landing.test.ts
+++ b/apps/gateway/src/routes/landing.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../app.js";
+
+describe("GET / (landing page)", () => {
+  it("returns 200 HTML with the product name and links to the public surface", async () => {
+    const app = createApp({ logger: { log: () => {} } });
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("Helm API");
+    // Links to the documented public + admin surface.
+    for (const path of ["/docs", "/v1/models", "/healthz", "/admin"]) {
+      expect(html).toContain(`href="${path}"`);
+    }
+    // /version is surfaced (referenced in the dashboard copy + fetched live).
+    expect(html).toContain("/version");
+  });
+
+  it("is unauthenticated (no key required)", async () => {
+    const app = createApp({ logger: { log: () => {} } });
+    const res = await app.request("/"); // no Authorization header
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/gateway/src/routes/landing.ts
+++ b/apps/gateway/src/routes/landing.ts
@@ -1,0 +1,145 @@
+import type { Hono } from "hono";
+import type { AppEnv } from "../app.js";
+
+// Public landing page at GET / — replaces the bare 404 a visitor used to hit. A
+// self-contained status page (no framework, no build step, no auth, zero external
+// assets): inline CSS + a tiny script that polls /healthz and /version so the page
+// reflects the LIVE gateway state. Principle 1 (the gateway is headless-capable):
+// this is presentation-only glue, never imports core routing.
+//
+// Design goal: calm, minimal, trustworthy — a status-page aesthetic (generous
+// whitespace, hairline-divided rows, one restrained accent), not a busy template.
+// It is intentionally ONE string constant so it costs nothing to serve and can
+// never drift from a separate file.
+
+const PAGE = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Helm API</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%230b0c0e'/%3E%3Cpath d='M11 9v14M21 9v14M11 16h10' stroke='%23e6e8eb' stroke-width='2.4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<style>
+  :root {
+    --bg: #0a0b0d; --fg: #e9ebee; --muted: #8b929b; --faint: #5a616b;
+    --line: #1b1e23; --line-strong: #262a31; --accent: #5b87f5; --ok: #2ea043; --warn: #d29922;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font: 15px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+    display: flex; justify-content: center; padding: 12vh 24px 8vh;
+  }
+  .mono { font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace; }
+  main { width: 100%; max-width: 540px; }
+
+  .mark { display: flex; align-items: center; gap: 11px; margin-bottom: 26px; }
+  .mark svg { width: 26px; height: 26px; display: block; }
+  .mark .name { font-size: 16px; font-weight: 600; letter-spacing: 0.02em; }
+
+  h1 { font-size: 30px; line-height: 1.25; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 14px; }
+  .lede { color: var(--muted); font-size: 16px; margin: 0 0 26px; max-width: 460px; }
+
+  .status {
+    display: inline-flex; align-items: center; gap: 9px; margin-bottom: 44px;
+    font-size: 13px; color: var(--muted);
+  }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--faint); flex: none; transition: background .2s; }
+  .dot.ok { background: var(--ok); box-shadow: 0 0 0 4px rgba(46,160,67,.15); }
+  .dot.bad { background: var(--warn); box-shadow: 0 0 0 4px rgba(210,153,34,.15); }
+  .status .sep { color: var(--line-strong); }
+
+  nav { border-top: 1px solid var(--line); }
+  nav a {
+    display: flex; align-items: baseline; gap: 16px; padding: 17px 4px;
+    border-bottom: 1px solid var(--line); text-decoration: none; color: inherit;
+    transition: padding-left .18s ease, border-color .18s ease;
+  }
+  nav a:hover { padding-left: 10px; border-color: var(--line-strong); }
+  nav .label { font-weight: 540; font-size: 15px; }
+  nav .desc { color: var(--muted); font-size: 13.5px; flex: 1; }
+  nav .path { color: var(--faint); font-size: 12.5px; transition: color .18s; }
+  nav a:hover .path { color: var(--accent); }
+
+  footer { margin-top: 40px; color: var(--faint); font-size: 12.5px; }
+  footer .mono { color: var(--muted); }
+
+  @media (max-width: 480px) {
+    body { padding: 8vh 20px; }
+    h1 { font-size: 25px; }
+    nav a { flex-direction: column; gap: 4px; }
+    nav .desc { flex: none; }
+  }
+</style>
+</head>
+<body>
+  <main>
+    <div class="mark">
+      <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M11 9v14M21 9v14M11 16h10" stroke="#e6e8eb" stroke-width="2.4" stroke-linecap="round"/></svg>
+      <span class="name">Helm&nbsp;API</span>
+    </div>
+
+    <h1>One gateway in front of<br />all your LLM providers.</h1>
+    <p class="lede">Open-source, self-hosted routing for OpenAI, Anthropic, and Gemini traffic — pick models by config, not code.</p>
+
+    <div class="status">
+      <span id="dot" class="dot"></span>
+      <span id="status-text">Checking status…</span>
+      <span class="sep" id="ver-sep" hidden>·</span>
+      <span class="mono" id="version" hidden></span>
+    </div>
+
+    <nav>
+      <a href="/docs">
+        <span class="label">Documentation</span>
+        <span class="desc">Interactive API reference &amp; playground</span>
+        <span class="path mono">/docs</span>
+      </a>
+      <a href="/v1/models">
+        <span class="label">Models</span>
+        <span class="desc">Models your key can route to</span>
+        <span class="path mono">/v1/models</span>
+      </a>
+      <a href="/admin">
+        <span class="label">Dashboard</span>
+        <span class="desc">Lanes, keys &amp; request telemetry</span>
+        <span class="path mono">/admin</span>
+      </a>
+      <a href="/healthz">
+        <span class="label">Health</span>
+        <span class="desc">Readiness &amp; build info</span>
+        <span class="path mono">/healthz</span>
+      </a>
+    </nav>
+
+    <footer>OpenAI · Anthropic · Gemini compatible &nbsp;·&nbsp; <span class="mono">/v1/chat/completions</span></footer>
+  </main>
+
+  <script>
+    (async () => {
+      const dot = document.getElementById('dot');
+      const text = document.getElementById('status-text');
+      try {
+        const r = await fetch('/healthz', { headers: { accept: 'application/json' } });
+        const j = await r.json();
+        if (r.ok && j.ready) { dot.className = 'dot ok'; text.textContent = 'All systems operational'; }
+        else { dot.className = 'dot bad'; text.textContent = 'Degraded'; }
+      } catch { dot.className = 'dot bad'; text.textContent = 'Unreachable'; }
+      try {
+        const v = await (await fetch('/version', { headers: { accept: 'application/json' } })).json();
+        const ver = v.version && v.version !== 'unknown' ? 'v' + v.version : (v.gitSha && v.gitSha !== 'unknown' ? v.gitSha.slice(0, 7) : '');
+        if (ver) {
+          const el = document.getElementById('version'); el.textContent = ver;
+          el.hidden = false; document.getElementById('ver-sep').hidden = false;
+        }
+      } catch { /* version is best-effort */ }
+    })();
+  </script>
+</body>
+</html>`;
+
+export function registerLandingRoute(app: Hono<AppEnv>): void {
+  app.get("/", (c) => c.html(PAGE));
+}

--- a/apps/gateway/src/routes/models.test.ts
+++ b/apps/gateway/src/routes/models.test.ts
@@ -1,0 +1,111 @@
+import { type ApiKeyRecord, hashKey, parseLanesConfig } from "@helm/core";
+import type { CatalogEntry, ModelsList } from "@helm/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createApp } from "../app.js";
+import { authMiddleware } from "../middleware/auth.js";
+import { registerModelsRoute } from "./models.js";
+
+const lanes = parseLanesConfig({
+  economy: { primary: "deepseek/flash", fallback: ["balanced"] },
+  balanced: { primary: "deepseek/pro", fallback: [] },
+});
+
+const catalog = new Map<string, CatalogEntry>([
+  [
+    "deepseek/pro",
+    {
+      modelKey: "deepseek/pro",
+      capabilities: {
+        supportsTools: true,
+        supportsJsonMode: true,
+        supportsVision: false,
+        supportsStreaming: true,
+        maxContextTokens: 128_000,
+        maxOutputTokens: 8_000,
+      },
+      pricing: { inputPerMTokUsd: 0.5, outputPerMTokUsd: 1.5 },
+      source: "override",
+    },
+  ],
+]);
+
+const providerAliases = ["deepseek/pro", "deepseek/flash"];
+
+function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
+  return {
+    key_id: "k1",
+    hash: hashKey("helm_live_secret"),
+    prefix: "helm_live_ab",
+    account_id: "acct",
+    role: "user",
+    allowed_lanes: null,
+    allow_custom_model: false,
+    disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: "degrade",
+    degrade_lane: null,
+    ...overrides,
+  };
+}
+
+function buildApp(rec: ApiKeyRecord | null) {
+  const getByHash = vi.fn().mockResolvedValue(rec);
+  const app = createApp({ logger: { log: () => {} } });
+  const auth = authMiddleware({ keyStore: { getByHash }, log: () => {} });
+  app.use("/v1/models", auth);
+  app.use("/v1/models/*", auth);
+  registerModelsRoute(app, { lanes: () => lanes, catalog, providerAliases });
+  return app;
+}
+
+const AUTH = { Authorization: "Bearer helm_live_secret" } as const;
+
+describe("GET /v1/models", () => {
+  it("requires auth: 401 without a key", async () => {
+    const res = await buildApp(record()).request("/v1/models");
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as Record<string, unknown>).error_class).toBe("auth_error");
+  });
+
+  it("normal key: lists lanes + auto only (no concrete aliases)", async () => {
+    const res = await buildApp(record()).request("/v1/models", { headers: AUTH });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ModelsList;
+    expect(body.object).toBe("list");
+    expect(body.data.map((m) => m.id)).toEqual(["economy", "balanced", "auto"]);
+    expect(body.data.every((m) => m.type === "lane")).toBe(true);
+  });
+
+  it("allow_custom_model key: appends aliases with capabilities + pricing", async () => {
+    const res = await buildApp(record({ allow_custom_model: true })).request("/v1/models", {
+      headers: AUTH,
+    });
+    const body = (await res.json()) as ModelsList;
+    const ids = body.data.map((m) => m.id);
+    expect(ids).toContain("deepseek/pro");
+    expect(ids).toContain("deepseek/flash");
+    const pro = body.data.find((m) => m.id === "deepseek/pro");
+    expect(pro?.type).toBe("model");
+    expect(pro?.pricing?.inputPerMTokUsd).toBe(0.5);
+    expect(pro?.lanes?.sort()).toEqual(["balanced", "economy"]);
+  });
+
+  it("retrieve: GET /v1/models/:id returns one model", async () => {
+    const res = await buildApp(record()).request("/v1/models/balanced", { headers: AUTH });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { id: string }).id).toBe("balanced");
+  });
+
+  it("retrieve: unknown/forbidden id -> structured error (OpenAI envelope)", async () => {
+    // A normal key cannot see concrete aliases, so this id is not in its listing.
+    const res = await buildApp(record()).request("/v1/models/deepseek%2Fpro", { headers: AUTH });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { type: string; trace_id: string } };
+    expect(body.error.trace_id.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/gateway/src/routes/models.ts
+++ b/apps/gateway/src/routes/models.ts
@@ -1,0 +1,54 @@
+import type { LanesConfig } from "@helm/core";
+import { buildModelsList } from "@helm/core";
+import { type CatalogEntry, makeHelmError } from "@helm/shared";
+import type { Context, Hono } from "hono";
+import type { AppEnv } from "../app.js";
+import { HelmHttpError } from "../middleware/error-handler.js";
+
+// GET /v1/models — OpenAI-compatible model discovery. Behind API-key auth (mounted
+// in server.ts) so the listing is KEY-AWARE: the authenticated identity's
+// allow_custom_model + allowed_lanes caps decide what buildModelsList returns
+// (lanes always; concrete aliases only for keys that may name a model). Pure
+// presentation glue — all policy lives in core (principle 1).
+export interface ModelsRouteDeps {
+  // Live lanes thunk: admin edits rebind the router's lanes at runtime, so read
+  // it per request rather than capturing a snapshot.
+  lanes: () => LanesConfig;
+  // Capability/pricing catalog (loadRuntimeCatalog), immutable for the process.
+  catalog: Map<string, CatalogEntry>;
+  // Configured provider aliases: config.providers[].models[].alias.
+  providerAliases: string[];
+}
+
+export function registerModelsRoute(app: Hono<AppEnv>, deps: ModelsRouteDeps): void {
+  const build = (c: Context<AppEnv>) => {
+    const identity = c.get("identity");
+    return buildModelsList({
+      lanes: deps.lanes(),
+      catalog: deps.catalog,
+      providerAliases: deps.providerAliases,
+      allowCustomModel: identity.caps.allowCustomModel,
+      allowedLanes: identity.caps.allowedLanes,
+    });
+  };
+
+  app.get("/v1/models", (c) => c.json(build(c), 200));
+
+  // Retrieve a single model the key can use. An id outside the key's listing is
+  // reported as invalid_request (the structured error taxonomy has no 404 class);
+  // the OpenAI envelope is rendered by the global handler.
+  app.get("/v1/models/:id", (c) => {
+    const id = c.req.param("id");
+    const model = build(c).data.find((m) => m.id === id);
+    if (!model) {
+      throw new HelmHttpError(
+        makeHelmError({
+          error_class: "invalid_request",
+          message: `model '${id}' not found or not available to this key`,
+          trace_id: c.get("trace_id"),
+        }),
+      );
+    }
+    return c.json(model, 200);
+  });
+}

--- a/apps/gateway/src/routes/openapi.test.ts
+++ b/apps/gateway/src/routes/openapi.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../app.js";
+import { buildOpenApiDocument } from "./openapi.js";
+
+describe("OpenAPI docs", () => {
+  it("GET /openapi.json returns a 3.1 spec covering the public surface", async () => {
+    const app = createApp({ logger: { log: () => {} } });
+    const res = await app.request("/openapi.json");
+    expect(res.status).toBe(200);
+    const doc = (await res.json()) as {
+      openapi: string;
+      paths: Record<string, { get: { security: unknown } }>;
+      components: { schemas: Record<string, Record<string, unknown>> };
+    };
+    expect(doc.openapi).toBe("3.1.0");
+    for (const path of ["/", "/healthz", "/version", "/v1/models", "/v1/chat/completions"]) {
+      expect(doc.paths[path]).toBeDefined();
+    }
+    // Components are generated from the Zod schemas; the meta `$schema` is stripped.
+    const modelsList = doc.components.schemas.ModelsList;
+    expect(modelsList).toBeDefined();
+    expect(modelsList?.$schema).toBeUndefined();
+    // /v1/models is marked as bearer-secured; / is public.
+    expect(doc.paths["/v1/models"]?.get.security).toEqual([{ bearerAuth: [] }]);
+    expect(doc.paths["/"]?.get.security).toEqual([]);
+  });
+
+  it("GET /docs serves Swagger UI HTML", async () => {
+    const app = createApp({ logger: { log: () => {} } });
+    const res = await app.request("/docs");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("swagger");
+  });
+
+  it("buildOpenApiDocument stamps the build version into info", () => {
+    const doc = buildOpenApiDocument({ version: "1.2.3", gitSha: "abc", builtAt: "now" });
+    expect((doc.info as { version: string }).version).toBe("1.2.3");
+  });
+});

--- a/apps/gateway/src/routes/openapi.ts
+++ b/apps/gateway/src/routes/openapi.ts
@@ -1,0 +1,218 @@
+import { ModelObjectSchema, ModelsListSchema, OpenAIChatRequestSchema } from "@helm/shared";
+import { swaggerUI } from "@hono/swagger-ui";
+import type { Hono } from "hono";
+import { z } from "zod";
+import type { AppEnv } from "../app.js";
+import type { BuildInfo } from "../build-info.js";
+
+// OpenAPI 3.1 spec + Swagger UI for the public API surface. The spec is BUILT
+// FROM the Zod schemas (z.toJSONSchema) so request/response shapes stay a single
+// source of truth (CLAUDE.md): the docs cannot drift from what the router
+// actually validates. 3.1 is chosen deliberately — it is a superset of JSON
+// Schema draft-2020-12, exactly what z.toJSONSchema emits, so generated component
+// schemas drop in without translation. Paths are hand-described (the existing
+// routes are plain Hono handlers, not OpenAPIHono) and cover the PRIMARY surface;
+// admin endpoints are intentionally omitted (internal). All three doc endpoints
+// (/openapi.json, /docs) are PUBLIC — they expose only the schema, never data.
+
+type JsonSchema = Record<string, unknown>;
+
+// Convert a Zod schema to a JSON-Schema component. z.toJSONSchema emits a top-level
+// `$schema` (meta) we strip — OpenAPI components must not carry it.
+function component(schema: z.ZodType): JsonSchema {
+  const js = z.toJSONSchema(schema, { target: "draft-2020-12" }) as JsonSchema;
+  delete js.$schema;
+  return js;
+}
+
+// The OpenAI error envelope (`{ error: { message, type, code, trace_id } }`) — the
+// wire shape every gateway error is rendered into (middleware/error-handler). Hand-
+// authored: it is a protocol-layer shape, not a Zod-validated input.
+const ERROR_ENVELOPE: JsonSchema = {
+  type: "object",
+  properties: {
+    error: {
+      type: "object",
+      properties: {
+        message: { type: "string" },
+        type: { type: "string" },
+        code: { type: "string" },
+        trace_id: { type: "string" },
+      },
+      required: ["message", "type", "code", "trace_id"],
+    },
+  },
+  required: ["error"],
+};
+
+const errorResponse = (description: string) => ({
+  description,
+  content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } },
+});
+
+export function buildOpenApiDocument(buildInfo?: BuildInfo): JsonSchema {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Helm API",
+      version: buildInfo?.version ?? "unknown",
+      description:
+        "Open-source, self-hosted LLM router gateway. Send OpenAI, Anthropic, or " +
+        "Gemini-shaped requests; Helm classifies and routes them across providers. " +
+        "Authenticate protected endpoints with `Authorization: Bearer <api-key>`.",
+    },
+    servers: [{ url: "/", description: "This gateway" }],
+    components: {
+      securitySchemes: {
+        bearerAuth: { type: "http", scheme: "bearer", description: "Helm API key" },
+      },
+      schemas: {
+        ModelsList: component(ModelsListSchema),
+        ModelObject: component(ModelObjectSchema),
+        ChatCompletionRequest: component(OpenAIChatRequestSchema),
+        ErrorEnvelope: ERROR_ENVELOPE,
+      },
+    },
+    paths: {
+      "/": {
+        get: {
+          tags: ["Meta"],
+          summary: "Landing page",
+          description: "Public status dashboard (HTML).",
+          security: [],
+          responses: { "200": { description: "HTML status dashboard" } },
+        },
+      },
+      "/healthz": {
+        get: {
+          tags: ["Meta"],
+          summary: "Readiness probe",
+          security: [],
+          responses: {
+            "200": { description: "Ready" },
+            "503": { description: "Not ready / degraded" },
+          },
+        },
+      },
+      "/version": {
+        get: {
+          tags: ["Meta"],
+          summary: "Build info",
+          security: [],
+          responses: { "200": { description: "version / gitSha / builtAt" } },
+        },
+      },
+      "/v1/models": {
+        get: {
+          tags: ["Models"],
+          summary: "List available models",
+          description:
+            "Key-aware listing. Every key sees the lanes (economy, balanced, …) plus " +
+            "`auto`. Keys with `allow_custom_model` also see concrete provider aliases " +
+            "with capabilities and pricing.",
+          security: [{ bearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "Model list",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/ModelsList" } },
+              },
+            },
+            "401": errorResponse("Missing or invalid API key"),
+          },
+        },
+      },
+      "/v1/models/{id}": {
+        get: {
+          tags: ["Models"],
+          summary: "Retrieve a model",
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "A lane name, `auto`, or (for allow_custom_model keys) a model alias.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Model object",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/ModelObject" } },
+              },
+            },
+            "400": errorResponse("Unknown model / not available to this key"),
+            "401": errorResponse("Missing or invalid API key"),
+          },
+        },
+      },
+      "/v1/chat/completions": {
+        post: {
+          tags: ["Inference"],
+          summary: "OpenAI-compatible chat completions",
+          description:
+            "Set `stream: true` for an SSE stream (`text/event-stream`). The `model` " +
+            "field may be a lane, `auto`, or — for allow_custom_model keys — a model alias.",
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ChatCompletionRequest" },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Chat completion (JSON) or SSE stream when stream=true" },
+            "401": errorResponse("Missing or invalid API key"),
+            "502": errorResponse("All providers failed"),
+          },
+        },
+      },
+      "/v1/messages": {
+        post: {
+          tags: ["Inference"],
+          summary: "Anthropic-compatible Messages API",
+          description: "Self-authenticated; errors render as the Anthropic error envelope.",
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+          responses: {
+            "200": { description: "Anthropic message (JSON) or SSE stream" },
+            "401": { description: "Missing or invalid API key" },
+          },
+        },
+      },
+      "/v1/responses": {
+        post: {
+          tags: ["Inference"],
+          summary: "OpenAI Responses API",
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+          responses: {
+            "200": { description: "Response (JSON) or SSE stream" },
+            "401": errorResponse("Missing or invalid API key"),
+          },
+        },
+      },
+    },
+  };
+}
+
+export interface OpenApiRouteDeps {
+  buildInfo?: BuildInfo;
+}
+
+export function registerOpenApiRoutes(app: Hono<AppEnv>, deps: OpenApiRouteDeps = {}): void {
+  // Build once at registration — the spec is static for the process lifetime.
+  const doc = buildOpenApiDocument(deps.buildInfo);
+  app.get("/openapi.json", (c) => c.json(doc));
+  app.get("/docs", swaggerUI({ url: "/openapi.json" }));
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -92,6 +92,7 @@ import { registerGeminiRoute } from "./routes/gemini.js";
 import type { MessagesIdentity, RouteError } from "./routes/messages.js";
 import { registerMessagesRoute } from "./routes/messages.js";
 import { createMessagesPipeline } from "./routes/messages-pipeline.js";
+import { registerModelsRoute } from "./routes/models.js";
 import { registerResponsesRoute } from "./routes/responses.js";
 import {
   markServingAccount,
@@ -977,6 +978,23 @@ export async function buildServer(
     "/v1/chat/*",
     rateLimitMiddleware({ limiter: rateLimiter, estimateTokens: estimateRequestTokens }),
   );
+
+  // Model discovery (GET /v1/models) is key-aware: it requires the SAME mandatory
+  // key auth as the chat surface so the listing reflects the authenticated key's
+  // caps (allow_custom_model / allowed_lanes). Read-only, so no rate-limit gate.
+  app.use(
+    "/v1/models",
+    authMiddleware({ keyStore, log: (l) => logger.log("warn", "auth", { line: l }) }),
+  );
+  app.use(
+    "/v1/models/*",
+    authMiddleware({ keyStore, log: (l) => logger.log("warn", "auth", { line: l }) }),
+  );
+  registerModelsRoute(app, {
+    lanes: () => lanes,
+    catalog,
+    providerAliases: config.providers.flatMap((p) => p.models.map((m) => m.alias)),
+  });
 
   // The per-request `route`: bind a fresh `execute` to the request's abort
   // signal (client disconnect), then run the framework-agnostic orchestrator.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,21 @@
 
 ---
 
+## 2026-06-04 · 公开端点：落地页 + `/v1/models` + OpenAPI/Swagger 文档（spec 未覆盖；docs/06 安全、docs/04 lane）
+
+网关此前根路径 `/` 直接 404（Hono 默认 → OpenAI 错误信封），也没有任何「可用 API 一览」与可调试文档。本次在独立 worktree 补三块公开能力，均为 gateway 层薄胶水，core 不变（principle 1）：
+
+- **落地页 `GET /`（公开）**：自包含静态 HTML 状态页（无框架、无构建、零外部资源），内联脚本拉 `/healthz` + `/version` 渲染实时状态。设计走极简 status-page 风格（用户要求「简洁大气、稳重、可信」），改过一版后定稿。注册在 `createApp()`，headless 调用方不受影响。
+- **`GET /v1/models` + `/v1/models/{id}`（key-aware，需鉴权）**：与用户确认采「**key 感知**」方案以调和 principle 6（暴露 lane、不暴露模型市场）与「想看到所有可用模型」的诉求——
+  - 默认 key 只见 **lanes + `auto`**（`owned_by: "helm"`，`type: "lane"`，不带 capabilities/pricing，避免供应链/定价泄露）；
+  - `allow_custom_model=true` 的 key 额外见 `config.providers[].models[].alias` 具体别名，附 catalog 的 capabilities/pricing 与「该别名被哪些 lane 链命中」的 lane 成员关系（这些 key 本就可越过 lane 抽象点名模型，故一致而非泄露）；
+  - `allowed_lanes` 进一步收窄可见 lane 集合与成员计算——列表只反映该 key 真能用的；
+  - 纯逻辑落在 core 的 `buildModelsList`（`packages/core/src/catalog/models-list.ts`，框架无关、TDD），gateway 路由只做鉴权+序列化。`{id}` 未命中按 `invalid_request`(400) 报（结构化错误模型无 404 class）。
+  - **限制/TODO**：当前只列 `providers.yaml` 配置别名；OAuth 订阅合成别名（如 `openai-codex/gpt-5.5`）**未纳入** `/v1/models`（它们是运行时动态发现，admin 的 `/admin/api/models` 另算）——后续可选合并。
+- **OpenAPI 3.1 + Swagger UI（`GET /openapi.json` + `GET /docs`，公开）**：选 3.1 是因为它是 JSON Schema draft-2020-12 的超集，正好等于 Zod 4 `z.toJSONSchema()` 的输出，组件 schema 直接落地、零翻译（schema 即唯一真源）。现有路由是普通 Hono handler 而非 OpenAPIHono，故 **paths 手写**、只覆盖主要公开面（admin 内部端点不收录）；错误信封 `ErrorEnvelope` 手写（它是协议层线形，非 Zod 输入）。新增依赖 `@hono/swagger-ui`，并把 `zod` 提为 gateway 直接依赖。
+- **lane 链展开抽取**：`route-request.ts` 里私有的 `expandChain` 抽到 `packages/core/src/lanes/expand-chain.ts` 导出复用（路由与模型列表共用一份），行为不变，route-request/fallback 既有测试全绿。
+- **坑**：`admin-static.test.ts` 的 4 个用例依赖已构建的 admin SPA（`apps/admin/build`），全新 worktree 未 `pnpm build` 前 `scandir ENOENT` 失败——属环境前置，非本次改动；`pnpm build` 后全绿（2115/2115）。gateway 自身 tsconfig **包含** test 文件（与根 typecheck 不同），故 `*.test.ts` 也要过 `noUncheckedIndexedAccess`。
+
 ## 2026-06-04 · 显式 lane-as-model + 透传严格校验（spec docs/04 / docs/06）
 
 docs/04 路由优先级表第一行写的是 "explicit **model/lane**"，但实现里透传分支从未做 lane 展开：

--- a/packages/core/src/catalog/models-list.test.ts
+++ b/packages/core/src/catalog/models-list.test.ts
@@ -1,0 +1,140 @@
+import type { CatalogEntry } from "@helm/shared";
+import { describe, expect, it } from "vitest";
+import { parseLanesConfig } from "../lanes/schema.js";
+import { buildModelsList } from "./models-list.js";
+
+// A small lane graph exercising: a plain lane, a lane that references ANOTHER
+// lane in its fallback (nested expansion), and the required `balanced` terminal.
+const lanes = parseLanesConfig({
+  economy: { primary: "deepseek/flash", fallback: ["balanced"] },
+  balanced: { primary: "deepseek/pro", fallback: [] },
+  premium: { primary: "openai/o", fallback: ["balanced"] }, // nested -> deepseek/pro
+});
+
+function entry(modelKey: string, over: Partial<CatalogEntry["capabilities"]> = {}): CatalogEntry {
+  return {
+    modelKey,
+    capabilities: {
+      supportsTools: true,
+      supportsJsonMode: true,
+      supportsVision: false,
+      supportsStreaming: true,
+      maxContextTokens: 128_000,
+      maxOutputTokens: 8_000,
+      ...over,
+    },
+    pricing: { inputPerMTokUsd: 0.5, outputPerMTokUsd: 1.5 },
+    source: "override",
+  };
+}
+
+const catalog = new Map<string, CatalogEntry>([
+  ["deepseek/flash", entry("deepseek/flash")],
+  ["deepseek/pro", entry("deepseek/pro")],
+  ["openai/o", entry("openai/o", { supportsVision: true })],
+]);
+
+const providerAliases = ["deepseek/flash", "deepseek/pro", "openai/o"];
+
+describe("buildModelsList", () => {
+  it("normal key: lists lanes + auto only, no concrete aliases, no pricing leaked", () => {
+    const list = buildModelsList({
+      lanes,
+      catalog,
+      providerAliases,
+      allowCustomModel: false,
+    });
+
+    expect(list.object).toBe("list");
+    const ids = list.data.map((m) => m.id);
+    // lanes (config order) then auto; NO provider aliases.
+    expect(ids).toEqual(["economy", "balanced", "premium", "auto"]);
+
+    for (const m of list.data) {
+      expect(m.object).toBe("model");
+      expect(m.type).toBe("lane");
+      expect(m.owned_by).toBe("helm");
+      // Principle 6 / 7: lanes never carry supply-chain pricing or capabilities.
+      expect(m.pricing).toBeUndefined();
+      expect(m.capabilities).toBeUndefined();
+    }
+    // A lane entry's membership is itself; `auto` carries none.
+    expect(list.data.find((m) => m.id === "balanced")?.lanes).toEqual(["balanced"]);
+    expect(list.data.find((m) => m.id === "auto")?.lanes).toBeUndefined();
+  });
+
+  it("allow_custom_model key: appends concrete aliases with capabilities/pricing + lane membership", () => {
+    const list = buildModelsList({
+      lanes,
+      catalog,
+      providerAliases,
+      allowCustomModel: true,
+    });
+
+    const ids = list.data.map((m) => m.id);
+    // lanes + auto, then aliases sorted alphabetically.
+    expect(ids).toEqual([
+      "economy",
+      "balanced",
+      "premium",
+      "auto",
+      "deepseek/flash",
+      "deepseek/pro",
+      "openai/o",
+    ]);
+
+    const pro = list.data.find((m) => m.id === "deepseek/pro");
+    expect(pro?.type).toBe("model");
+    expect(pro?.owned_by).toBe("deepseek");
+    expect(pro?.capabilities?.maxContextTokens).toBe(128_000);
+    expect(pro?.pricing?.inputPerMTokUsd).toBe(0.5);
+    // deepseek/pro is balanced.primary AND the nested target of premium + economy.
+    expect(pro?.lanes?.sort()).toEqual(["balanced", "economy", "premium"]);
+
+    const flash = list.data.find((m) => m.id === "deepseek/flash");
+    expect(flash?.lanes).toEqual(["economy"]);
+  });
+
+  it("nested lane references expand to leaf aliases for membership", () => {
+    const list = buildModelsList({
+      lanes,
+      catalog,
+      providerAliases,
+      allowCustomModel: true,
+    });
+    // openai/o is premium.primary only (no other lane references it).
+    expect(list.data.find((m) => m.id === "openai/o")?.lanes).toEqual(["premium"]);
+  });
+
+  it("respects allowedLanes: restricts visible lanes and membership", () => {
+    const list = buildModelsList({
+      lanes,
+      catalog,
+      providerAliases,
+      allowCustomModel: true,
+      allowedLanes: ["economy"],
+    });
+    const ids = list.data.map((m) => m.id);
+    // Only the economy lane + auto are visible.
+    expect(ids).toContain("economy");
+    expect(ids).not.toContain("balanced");
+    expect(ids).not.toContain("premium");
+    expect(ids).toContain("auto");
+    // economy expands to deepseek/flash -> deepseek/pro, so membership is economy-only.
+    expect(list.data.find((m) => m.id === "deepseek/pro")?.lanes).toEqual(["economy"]);
+  });
+
+  it("an alias absent from the catalog still lists (no capabilities/pricing)", () => {
+    const list = buildModelsList({
+      lanes,
+      catalog,
+      providerAliases: [...providerAliases, "mystery/x"],
+      allowCustomModel: true,
+    });
+    const mystery = list.data.find((m) => m.id === "mystery/x");
+    expect(mystery?.type).toBe("model");
+    expect(mystery?.capabilities).toBeUndefined();
+    expect(mystery?.pricing).toBeUndefined();
+    expect(mystery?.lanes).toEqual([]); // reachable only by explicit model
+  });
+});

--- a/packages/core/src/catalog/models-list.ts
+++ b/packages/core/src/catalog/models-list.ts
@@ -1,0 +1,108 @@
+import type { CatalogEntry, ModelObject, ModelsList } from "@helm/shared";
+import { expandLaneChain } from "../lanes/expand-chain.js";
+import type { LanesConfig } from "../lanes/schema.js";
+
+// buildModelsList — the pure data builder behind GET /v1/models. Framework-free
+// (principle 1): the gateway route serializes the result; this module decides
+// WHAT a given key may see, honoring principle 6 (lanes are the public face; a
+// concrete provider alias is supply-chain detail) and principle 7 (lanes never
+// leak pricing/capabilities).
+//
+//   • Default key  → lanes (config order) + the `auto` directive. Nothing else.
+//   • allow_custom_model key → the above, PLUS every configured provider alias
+//     (sorted) enriched with catalog capabilities/pricing and the set of lanes
+//     that can route to it. Those keys already bypass the lane abstraction, so
+//     exposing the aliases they can name is consistent, not a leak.
+//   • allowedLanes (per-key cap) restricts which lanes are visible AND the lane
+//     membership reported for each alias — the listing reflects what the key can
+//     actually use, never more.
+
+// The OpenAI model object requires a `created` timestamp; Helm has no per-model
+// creation date, so a stable constant is used (clients only need the field).
+const CREATED = 0;
+// The "let the router decide" directive — a first-class selectable id, not a lane.
+const AUTO_ID = "auto";
+const OWNER_HELM = "helm";
+
+export interface BuildModelsListInput {
+  lanes: LanesConfig;
+  /** Capability/pricing metadata keyed by model alias (loadRuntimeCatalog). */
+  catalog: Map<string, CatalogEntry>;
+  /** Configured provider aliases: config.providers[].models[].alias. */
+  providerAliases: string[];
+  /** The authenticated key's allow_custom_model cap. */
+  allowCustomModel: boolean;
+  /** The key's allowed_lanes cap; null/undefined = unconstrained. */
+  allowedLanes?: string[] | null;
+}
+
+// Provider name an alias is owned by: the prefix before the first "/" (e.g.
+// "deepseek/pro" → "deepseek"). Falls back to the whole id if unprefixed.
+function ownerOf(alias: string): string {
+  const slash = alias.indexOf("/");
+  return slash > 0 ? alias.slice(0, slash) : alias;
+}
+
+export function buildModelsList(input: BuildModelsListInput): ModelsList {
+  const { lanes, catalog, providerAliases, allowCustomModel } = input;
+
+  // Visible lanes: config (insertion) order, narrowed by the key's allowed_lanes.
+  const allowed = input.allowedLanes ?? null;
+  const visibleLanes = Object.keys(lanes).filter(
+    (name) => allowed === null || allowed.includes(name),
+  );
+
+  const data: ModelObject[] = [];
+
+  // 1) Lane entries (the public abstraction) — no pricing/capabilities.
+  for (const name of visibleLanes) {
+    data.push({
+      id: name,
+      object: "model",
+      created: CREATED,
+      owned_by: OWNER_HELM,
+      type: "lane",
+      lanes: [name],
+    });
+  }
+
+  // 2) The `auto` directive — always selectable; the router picks within the
+  //    key's allowed lanes. Carries no lane membership.
+  data.push({
+    id: AUTO_ID,
+    object: "model",
+    created: CREATED,
+    owned_by: OWNER_HELM,
+    type: "lane",
+  });
+
+  // 3) Concrete aliases — only for keys allowed to name a model directly.
+  if (allowCustomModel) {
+    // Precompute alias → visible lanes that can route to it, by expanding each
+    // visible lane's chain to its leaf aliases once.
+    const membership = new Map<string, string[]>();
+    for (const name of visibleLanes) {
+      for (const alias of expandLaneChain(name, lanes)) {
+        const arr = membership.get(alias);
+        if (arr) arr.push(name);
+        else membership.set(alias, [name]);
+      }
+    }
+
+    const uniqueAliases = [...new Set(providerAliases)].sort((a, b) => a.localeCompare(b));
+    for (const alias of uniqueAliases) {
+      const meta = catalog.get(alias);
+      data.push({
+        id: alias,
+        object: "model",
+        created: CREATED,
+        owned_by: ownerOf(alias),
+        type: "model",
+        lanes: membership.get(alias) ?? [],
+        ...(meta ? { capabilities: meta.capabilities, pricing: meta.pricing } : {}),
+      });
+    }
+  }
+
+  return { object: "list", data };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export {
 } from "./catalog/cost.js";
 export { CatalogError, type LoadCatalogDeps, loadCatalog } from "./catalog/index.js";
 export { type LoadRuntimeCatalogOptions, loadRuntimeCatalog } from "./catalog/load.js";
+export { type BuildModelsListInput, buildModelsList } from "./catalog/models-list.js";
 export {
   type AttemptDecision,
   type BreakerDeps,

--- a/packages/core/src/lanes/expand-chain.ts
+++ b/packages/core/src/lanes/expand-chain.ts
@@ -1,0 +1,46 @@
+import type { LanesConfig } from "./schema.js";
+
+// Expand a selected lane into an ordered candidate chain of MODEL ALIASES. Each
+// primary/fallback element may name a model alias OR another lane (docs/04). Lane
+// references are expanded recursively; model aliases are appended. Dedup keeps
+// first occurrence; a `visited` set bounds recursion so `a→b→a` cannot loop.
+//
+// Pure, deterministic, zero-network (principle 4). This is the EXECUTION-fallback
+// chain shape — the same expansion the router feeds executor.fallback — extracted
+// here so it has one definition shared by routing (route-request) and the public
+// model listing (catalog/models-list). It does NOT trip breakers or filter by
+// capability; it only flattens the declarative lane graph to leaf aliases.
+export function expandLaneChain(laneName: string, lanes: LanesConfig): string[] {
+  const chain: string[] = [];
+  const seen = new Set<string>();
+
+  const push = (alias: string): void => {
+    if (!seen.has(alias)) {
+      seen.add(alias);
+      chain.push(alias);
+    }
+  };
+
+  const visit = (name: string, visitedLanes: Set<string>): void => {
+    if (visitedLanes.has(name)) return; // cycle guard
+    visitedLanes.add(name);
+    const lane = lanes[name];
+    if (lane === undefined) {
+      // Not a lane → it is a model alias; append it.
+      push(name);
+      return;
+    }
+    // Lane: primary then fallback, each possibly a lane or an alias.
+    const elements = [lane.primary, ...lane.fallback];
+    for (const el of elements) {
+      if (Object.hasOwn(lanes, el)) {
+        visit(el, visitedLanes);
+      } else {
+        push(el);
+      }
+    }
+  };
+
+  visit(laneName, new Set<string>());
+  return chain;
+}

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -5,6 +5,7 @@ import {
   type InternalRequest,
   makeHelmError,
 } from "@helm/shared";
+import { expandLaneChain } from "../lanes/expand-chain.js";
 import type { LanesConfig } from "../lanes/schema.js";
 import { type Classification as ResolverClassification, resolveLane } from "./lane-resolver.js";
 import { applyCaps, evaluatePolicies, type PolicyContext } from "./policy-engine.js";
@@ -181,44 +182,11 @@ async function classifySafe(
   }
 }
 
-// Expand a selected lane into an ordered candidate chain. Each primary/fallback
-// element may name a model alias OR another lane (docs/04). Lane references are
-// expanded recursively; model aliases are appended. Dedup keeps first
-// occurrence; a `visited` set bounds recursion so `a→b→a` cannot loop.
-function expandChain(laneName: string, lanes: LanesConfig): string[] {
-  const chain: string[] = [];
-  const seen = new Set<string>();
-
-  const push = (alias: string): void => {
-    if (!seen.has(alias)) {
-      seen.add(alias);
-      chain.push(alias);
-    }
-  };
-
-  const visit = (name: string, visitedLanes: Set<string>): void => {
-    if (visitedLanes.has(name)) return; // cycle guard
-    visitedLanes.add(name);
-    const lane = lanes[name];
-    if (lane === undefined) {
-      // Not a lane → it is a model alias; append it.
-      push(name);
-      return;
-    }
-    // Lane: primary then fallback, each possibly a lane or an alias.
-    const elements = [lane.primary, ...lane.fallback];
-    for (const el of elements) {
-      if (Object.hasOwn(lanes, el)) {
-        visit(el, visitedLanes);
-      } else {
-        push(el);
-      }
-    }
-  };
-
-  visit(laneName, new Set<string>());
-  return chain;
-}
+// Expand a selected lane into an ordered candidate chain (primary/fallback,
+// recursive lane refs, deduped, cycle-safe). The implementation lives in
+// lanes/expand-chain so routing and the public model listing share one
+// definition (docs/04).
+const expandChain = expandLaneChain;
 
 // Build the PolicyContext the engine matches on, from the classification.
 function policyContext(req: InternalRequest, cls: Classification): PolicyContext {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,7 +23,6 @@ export {
   PricingOverrideSchema,
   PricingSchema,
 } from "./catalog/schema.js";
-
 // Layer-2 eval output model (docs/03 §Task classification) — strict JSON the eval model
 // emits; validated as untrusted external input, fail-open on any failure.
 export {
@@ -196,6 +195,16 @@ export {
   type ReflectionUpsertInput,
   ReflectionUpsertInputSchema,
 } from "./memory/schema.js";
+// Public model-listing model (GET /v1/models) — OpenAI-compatible discovery
+// envelope; lanes are first-class, concrete aliases are key-gated (principle 6).
+export {
+  type ModelKind,
+  ModelKindSchema,
+  type ModelObject,
+  ModelObjectSchema,
+  type ModelsList,
+  ModelsListSchema,
+} from "./models/schema.js";
 // Per-account OAuth subscription usage + quota observability (providers page).
 // Fail-open artifacts: usage = today's served traffic; quota = latest rate-limit
 // window snapshot; plus the (untrusted) Anthropic usage-endpoint response shape.

--- a/packages/shared/src/models/schema.ts
+++ b/packages/shared/src/models/schema.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import { CapabilitiesSchema, PricingSchema } from "../catalog/schema.js";
+
+// Public model-listing schema for GET /v1/models — the OpenAI-compatible model
+// discovery endpoint. Single source of truth via z.infer (no hand-written types).
+//
+// Principle 6 (expose the lane abstraction, NOT the model market): the listing's
+// FIRST-CLASS entries are LANES (economy/balanced/premium/…) plus the `auto`
+// directive — that is all a default key ever sees. Concrete provider aliases
+// (a supply-chain detail) are emitted ONLY for keys with allow_custom_model
+// (they already bypass the lane abstraction by design), enriched with the
+// capability/pricing metadata those keys need to choose a model. The gateway
+// route decides which set to include per authenticated key; this schema only
+// describes the shape.
+
+// Distinguishes a lane/`auto` selector (`lane`) from a concrete provider alias
+// (`model`). A Helm extension to the OpenAI model object — OpenAI clients ignore
+// unknown fields, so the response stays drop-in compatible.
+export const ModelKindSchema = z.enum(["lane", "model"]);
+export type ModelKind = z.infer<typeof ModelKindSchema>;
+
+// One entry in the listing. The first four fields are the OpenAI model object
+// (`id`/`object`/`created`/`owned_by`); the rest are Helm extensions. `created`
+// is a stable constant (Helm has no per-model creation date) — OpenAI clients
+// only require the field to be present.
+export const ModelObjectSchema = z.object({
+  id: z.string().min(1),
+  object: z.literal("model"),
+  created: z.number().int().nonnegative(),
+  // "helm" for lanes/`auto`; the provider name (alias prefix) for a concrete model.
+  owned_by: z.string().min(1),
+  type: ModelKindSchema,
+  // Lanes whose expanded chain includes this entry. For a lane entry it is the
+  // lane itself; for a model alias it is every lane that can route to it. Omitted
+  // for `auto`.
+  lanes: z.array(z.string().min(1)).optional(),
+  // Capability + pricing metadata, present only for concrete model aliases that
+  // have a catalog entry (lanes carry none — they are an abstraction).
+  capabilities: CapabilitiesSchema.optional(),
+  pricing: PricingSchema.optional(),
+});
+export type ModelObject = z.infer<typeof ModelObjectSchema>;
+
+// Top-level GET /v1/models envelope — OpenAI-compatible `{ object: "list", data }`.
+export const ModelsListSchema = z.object({
+  object: z.literal("list"),
+  data: z.array(ModelObjectSchema),
+});
+export type ModelsList = z.infer<typeof ModelsListSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,15 @@ importers:
       '@hono/node-server':
         specifier: ^2.0.4
         version: 2.0.4(hono@4.12.23)
+      '@hono/swagger-ui':
+        specifier: ^0.6.1
+        version: 0.6.1(hono@4.12.23)
       hono:
         specifier: ^4.12.23
         version: 4.12.23
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -613,6 +619,11 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
+
+  '@hono/swagger-ui@0.6.1':
+    resolution: {integrity: sha512-sJTvldu1GPeEPfyeLG7gRj+W4vEuD+JDi+JjJ3TJs/DvMUtBLs0KJO5yokGegWWdy5qrbdnQGekbhgNRmPmYKQ==}
+    peerDependencies:
+      hono: '>=4.0.0'
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2515,6 +2526,10 @@ snapshots:
     optional: true
 
   '@hono/node-server@2.0.4(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
+
+  '@hono/swagger-ui@0.6.1(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
 


### PR DESCRIPTION
## Context

The gateway's root path `/` returned a bare 404 (Hono default → OpenAI error envelope), there was **no public way to discover available models**, and **no API documentation**. This adds the public-facing surface a self-hosted gateway should have — all as thin `apps/gateway` glue; `packages/core` stays framework-free (principle 1).

## What's included

### 1. Status landing page — `GET /` (public)
Self-contained HTML (no framework, no external assets), minimal status-page aesthetic. An inline script polls `/healthz` + `/version` for a live "operational" indicator, with quiet links to docs / models / dashboard / health.

### 2. `GET /v1/models` + `/v1/models/{id}` — key-aware (auth required)
OpenAI-compatible discovery that reconciles "see available models" with principle 6 (expose lanes, not the model market):
- **Default keys** → lanes (`economy`, `balanced`, …) + `auto` only.
- **`allow_custom_model` keys** → also concrete provider aliases with **capabilities + pricing + lane membership** (those keys already bypass the lane abstraction by design).
- **`allowed_lanes`** narrows the visible set.
- Pure builder `buildModelsList` lives in core (TDD); the route only authenticates + serializes.

### 3. OpenAPI 3.1 + Swagger UI — `GET /docs`, `GET /openapi.json` (public)
Component schemas **generated from the existing Zod schemas** via `z.toJSONSchema()` (schema stays the single source of truth); served with `@hono/swagger-ui` ("Try it out"). Paths hand-described for the primary public surface; admin endpoints intentionally omitted.

### 4. Refactor + docs
- Extracted `expandLaneChain` into `packages/core/src/lanes/expand-chain.ts`, reused by routing and the model listing (routing behavior unchanged — route-request/fallback tests green).
- README: consolidated **API-surface table**; `implementation-notes.md` entry.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ (0 errors) · `pnpm test` ✅ **2115/2115** (after `pnpm build` produces the admin SPA the `admin-static` tests require).
- Live smoke on a booted gateway: landing, `/docs` (Swagger UI renders), `/openapi.json`, `/v1/models` (401 without key; lanes-only vs alias+pricing with key), retrieve + 400 envelope — all confirmed.

## Follow-ups (out of scope)
- `/v1/models` lists **configured** provider aliases only; OAuth-subscription synthesized aliases (e.g. `openai-codex/gpt-5.5`) are not yet included.
- `README.zh-CN.md` not yet mirrored with the new API-surface table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)