### PR TITLE
feat(gateway): restyle landing page to match admin design language

### DIFF
--- a/apps/gateway/src/routes/landing.ts
+++ b/apps/gateway/src/routes/landing.ts
@@ -7,10 +7,11 @@ import type { AppEnv } from "../app.js";
 // reflects the LIVE gateway state. Principle 1 (the gateway is headless-capable):
 // this is presentation-only glue, never imports core routing.
 //
-// Design goal: calm, minimal, trustworthy — a status-page aesthetic (generous
-// whitespace, hairline-divided rows, one restrained accent), not a busy template.
-// It is intentionally ONE string constant so it costs nothing to serve and can
-// never drift from a separate file.
+// Design goal: visually CONTINUOUS with the admin UI (apps/admin/src/app.css) —
+// same light slate canvas, white cards on slate-200 borders, the indigo brand
+// square, emerald/amber status badges, two-tier radius. The values below are the
+// admin's Tailwind tokens inlined (slate/indigo/emerald/amber), so a visitor
+// clicking through to /admin sees one product, not two designs.
 
 const PAGE = `<!doctype html>
 <html lang="en">
@@ -18,58 +19,83 @@ const PAGE = `<!doctype html>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Helm API</title>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%230b0c0e'/%3E%3Cpath d='M11 9v14M21 9v14M11 16h10' stroke='%23e6e8eb' stroke-width='2.4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%234f46e5'/%3E%3Cpath d='M11 9v14M21 9v14M11 16h10' stroke='%23fff' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E" />
 <style>
+  /* Admin design tokens (apps/admin/src/app.css), inlined. */
   :root {
-    --bg: #0a0b0d; --fg: #e9ebee; --muted: #8b929b; --faint: #5a616b;
-    --line: #1b1e23; --line-strong: #262a31; --accent: #5b87f5; --ok: #2ea043; --warn: #d29922;
+    --canvas: #f8fafc;        /* slate-50  — app shell */
+    --surface: #ffffff;       /* white     — cards */
+    --border: #e2e8f0;        /* slate-200 — container outline */
+    --border-hair: #f1f5f9;   /* slate-100 — row divider */
+    --ink: #0f172a;           /* slate-900 — titles */
+    --ink-strong: #334155;    /* slate-700 — labels */
+    --ink-body: #475569;      /* slate-600 — body */
+    --ink-muted: #64748b;     /* slate-500 — descriptions */
+    --ink-faint: #94a3b8;     /* slate-400 — muted glyphs */
+    --brand: #4f46e5;         /* indigo-600 — logo + accents ONLY */
+    --ok-bg: #d1fae5; --ok-fg: #047857;     /* emerald-100 / emerald-700 */
+    --warn-bg: #fef3c7; --warn-fg: #92400e; /* amber-100 / amber-800 */
+    --neutral-bg: #e2e8f0; --neutral-fg: #475569; /* slate badge */
+    --radius-control: 0.25rem; --radius-container: 0.5rem;
   }
   * { box-sizing: border-box; }
   html, body { height: 100%; }
   body {
-    margin: 0; background: var(--bg); color: var(--fg);
-    font: 15px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    margin: 0; background: var(--canvas); color: var(--ink-body);
+    font: 14px/1.6 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
-    display: flex; justify-content: center; padding: 12vh 24px 8vh;
+    display: flex; justify-content: center; padding: 10vh 24px 8vh;
   }
   .mono { font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace; }
-  main { width: 100%; max-width: 540px; }
+  main { width: 100%; max-width: 560px; }
 
-  .mark { display: flex; align-items: center; gap: 11px; margin-bottom: 26px; }
-  .mark svg { width: 26px; height: 26px; display: block; }
-  .mark .name { font-size: 16px; font-weight: 600; letter-spacing: 0.02em; }
-
-  h1 { font-size: 30px; line-height: 1.25; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 14px; }
-  .lede { color: var(--muted); font-size: 16px; margin: 0 0 26px; max-width: 460px; }
-
-  .status {
-    display: inline-flex; align-items: center; gap: 9px; margin-bottom: 44px;
-    font-size: 13px; color: var(--muted);
+  /* Brand mark — identical recipe to the admin sidebar header. */
+  .mark { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .mark .tile {
+    display: flex; align-items: center; justify-content: center; flex: none;
+    width: 32px; height: 32px; border-radius: var(--radius-container);
+    background: var(--brand); color: #fff;
   }
-  .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--faint); flex: none; transition: background .2s; }
-  .dot.ok { background: var(--ok); box-shadow: 0 0 0 4px rgba(46,160,67,.15); }
-  .dot.bad { background: var(--warn); box-shadow: 0 0 0 4px rgba(210,153,34,.15); }
-  .status .sep { color: var(--line-strong); }
+  .mark .tile svg { width: 18px; height: 18px; display: block; }
+  .mark .name { font-size: 14px; font-weight: 600; letter-spacing: -0.01em; color: var(--ink); line-height: 1.3; }
+  .mark .sub { font-size: 12px; color: var(--ink-faint); line-height: 1.3; }
 
-  nav { border-top: 1px solid var(--line); }
+  h1 { font-size: 28px; line-height: 1.25; font-weight: 600; letter-spacing: -0.025em; color: var(--ink); margin: 0 0 12px; }
+  .lede { color: var(--ink-muted); font-size: 15px; margin: 0 0 22px; max-width: 480px; }
+
+  /* Status badge — admin .badge-ok / .badge-fallback / .badge-neutral. */
+  .status { display: inline-flex; align-items: center; margin-bottom: 36px; }
+  .badge {
+    display: inline-flex; align-items: center; gap: 7px;
+    border-radius: var(--radius-control); padding: 3px 9px;
+    font-size: 12px; font-weight: 500;
+    background: var(--neutral-bg); color: var(--neutral-fg);
+  }
+  .badge.ok { background: var(--ok-bg); color: var(--ok-fg); }
+  .badge.bad { background: var(--warn-bg); color: var(--warn-fg); }
+  .dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; flex: none; }
+  .status .ver { margin-left: 10px; font-size: 12px; color: var(--ink-faint); }
+
+  /* Link list — an admin card: white, slate-200 border, hairline-divided rows. */
+  nav { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-container); overflow: hidden; }
   nav a {
-    display: flex; align-items: baseline; gap: 16px; padding: 17px 4px;
-    border-bottom: 1px solid var(--line); text-decoration: none; color: inherit;
-    transition: padding-left .18s ease, border-color .18s ease;
+    display: flex; align-items: baseline; gap: 14px; padding: 14px 16px;
+    text-decoration: none; color: inherit; transition: background .15s ease;
   }
-  nav a:hover { padding-left: 10px; border-color: var(--line-strong); }
-  nav .label { font-weight: 540; font-size: 15px; }
-  nav .desc { color: var(--muted); font-size: 13.5px; flex: 1; }
-  nav .path { color: var(--faint); font-size: 12.5px; transition: color .18s; }
-  nav a:hover .path { color: var(--accent); }
+  nav a + a { border-top: 1px solid var(--border-hair); }
+  nav a:hover { background: var(--canvas); }
+  nav .label { font-weight: 500; font-size: 14px; color: var(--ink); }
+  nav .desc { color: var(--ink-muted); font-size: 13px; flex: 1; }
+  nav .path { color: var(--ink-faint); font-size: 12px; transition: color .15s; }
+  nav a:hover .path { color: var(--brand); }
 
-  footer { margin-top: 40px; color: var(--faint); font-size: 12.5px; }
-  footer .mono { color: var(--muted); }
+  footer { margin-top: 28px; color: var(--ink-faint); font-size: 12px; }
+  footer .mono { color: var(--ink-muted); }
 
   @media (max-width: 480px) {
-    body { padding: 8vh 20px; }
-    h1 { font-size: 25px; }
-    nav a { flex-direction: column; gap: 4px; }
+    body { padding: 7vh 20px; }
+    h1 { font-size: 23px; }
+    nav a { flex-direction: column; gap: 3px; }
     nav .desc { flex: none; }
   }
 </style>
@@ -77,18 +103,19 @@ const PAGE = `<!doctype html>
 <body>
   <main>
     <div class="mark">
-      <svg viewBox="0 0 32 32" aria-hidden="true"><path d="M11 9v14M21 9v14M11 16h10" stroke="#e6e8eb" stroke-width="2.4" stroke-linecap="round"/></svg>
-      <span class="name">Helm&nbsp;API</span>
+      <span class="tile"><svg viewBox="0 0 32 32" aria-hidden="true"><path d="M11 9v14M21 9v14M11 16h10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/></svg></span>
+      <span>
+        <span class="name">Helm&nbsp;API</span>
+        <br /><span class="sub">LLM Gateway</span>
+      </span>
     </div>
 
     <h1>One gateway in front of<br />all your LLM providers.</h1>
     <p class="lede">Open-source, self-hosted routing for OpenAI, Anthropic, and Gemini traffic — pick models by config, not code.</p>
 
     <div class="status">
-      <span id="dot" class="dot"></span>
-      <span id="status-text">Checking status…</span>
-      <span class="sep" id="ver-sep" hidden>·</span>
-      <span class="mono" id="version" hidden></span>
+      <span id="badge" class="badge"><span class="dot"></span><span id="status-text">Checking status…</span></span>
+      <span class="ver mono" id="version" hidden></span>
     </div>
 
     <nav>
@@ -119,21 +146,18 @@ const PAGE = `<!doctype html>
 
   <script>
     (async () => {
-      const dot = document.getElementById('dot');
+      const badge = document.getElementById('badge');
       const text = document.getElementById('status-text');
       try {
         const r = await fetch('/healthz', { headers: { accept: 'application/json' } });
         const j = await r.json();
-        if (r.ok && j.ready) { dot.className = 'dot ok'; text.textContent = 'All systems operational'; }
-        else { dot.className = 'dot bad'; text.textContent = 'Degraded'; }
-      } catch { dot.className = 'dot bad'; text.textContent = 'Unreachable'; }
+        if (r.ok && j.ready) { badge.className = 'badge ok'; text.textContent = 'All systems operational'; }
+        else { badge.className = 'badge bad'; text.textContent = 'Degraded'; }
+      } catch { badge.className = 'badge bad'; text.textContent = 'Unreachable'; }
       try {
         const v = await (await fetch('/version', { headers: { accept: 'application/json' } })).json();
         const ver = v.version && v.version !== 'unknown' ? 'v' + v.version : (v.gitSha && v.gitSha !== 'unknown' ? v.gitSha.slice(0, 7) : '');
-        if (ver) {
-          const el = document.getElementById('version'); el.textContent = ver;
-          el.hidden = false; document.getElementById('ver-sep').hidden = false;
-        }
+        if (ver) { const el = document.getElementById('version'); el.textContent = ver; el.hidden = false; }
       } catch { /* version is best-effort */ }
     })();
   </script>


### PR DESCRIPTION
## Summary

The landing page (#86-era `/`) shipped with its own dark, near-black theme — visually disconnected from the light admin UI it links to. This PR rebuilds it on the admin's design tokens (`apps/admin/src/app.css`), inlined into the self-contained page:

| Element | Before (dark) | After (admin-matched) |
|---|---|---|
| Canvas | near-black `#0a0b0d` | slate-50, same as admin shell |
| Brand mark | bare white glyph | indigo-600 rounded tile + "LLM Gateway" subtitle, identical to the sidebar logo |
| Status | floating dot | emerald/amber badge pills (`.badge-ok` / `.badge-fallback` recipes) |
| Link list | hairline dark rows | white card, slate-200 border, slate-100 dividers, slate-50 hover |
| Favicon | black square | indigo-600 rounded square |

Structure, links, and the live `/healthz` + `/version` polling are unchanged.

## Test plan

- [x] `landing.test.ts` passes unchanged (2/2) — asserts links + product name
- [x] Deployed locally via Docker; screenshot-verified the badge renders "All systems operational" + version chip, and the page reads as one product with `/admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)