### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps the root `package.json` `0.3.2 → 0.4.0`. Merge + tag `v0.4.0` triggers the **Publish image** workflow to push `ghcr.io/easymetaau/helm-api:0.4.0` + `:latest`, then the GitHub release is cut.

## What's in 0.4.0 (3 commits since v0.3.2)

**Features**
- **Public landing page, `/v1/models`, and OpenAPI/Swagger docs** (#89) — `GET /` is now a live status/landing page instead of a 404; `GET /v1/models` lists the models a key can route to (OpenAI-compatible); `GET /docs` serves an interactive Swagger playground over a generated OpenAPI spec.
- **Landing page restyled to match the admin design language** (#90) — same slate/indigo tokens as the admin UI, one continuous product.
- **Admin: refresh button on the subscription providers page** (#88)

Minor bump (new public gateway endpoints). This PR itself is version-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)