### PR TITLE
fix(providers): pull Codex usage from /wham/usage so quota renders

### DIFF
--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -5,6 +5,7 @@ import {
   beginOpenAICodexLogin,
   type ConfigStore,
   type CopilotDeviceStart,
+  codexAccountIdFromToken,
   completeAnthropicLogin,
   completeOpenAICodexLogin,
   createTokenManager,
@@ -17,6 +18,7 @@ import {
   type OAuthTokenStore,
   type ProxyConfig,
   parseAnthropicUsageBody,
+  parseCodexUsageBody,
   pollCopilotDeviceOnce,
   refreshGitHubCopilotToken,
   validateProxyConfig,
@@ -59,6 +61,19 @@ const ANTHROPIC_USAGE_HEADERS = {
   "user-agent": "claude-cli/2.0.53 (external, cli)",
   accept: "application/json",
   "accept-language": "en-US,en;q=0.9",
+} as const;
+
+// Codex usage endpoint (providers page Tier 3 quota PULL) — the same payload the
+// Codex CLI's /status reads. The on-demand counterpart of the `x-codex-*` header
+// PUSH (provider/oauth/codex-quota.ts): without it an account that has served no
+// traffic yet renders "—" forever. Gated on a Codex-client originator/UA pair
+// (verified live 2026-06-04) plus the per-account `chatgpt-account-id` header
+// (decoded from the access-token JWT, same as the execution path).
+const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const CODEX_USAGE_HEADERS = {
+  originator: "codex_cli_rs",
+  "user-agent": "codex_cli_rs",
+  accept: "application/json",
 } as const;
 
 // Manual-paste (authorization-code) providers and their begin/complete step-fns.
@@ -444,6 +459,54 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       }
       // Cache the outcome (success OR failure) so the next page open within the TTL
       // is served from memory rather than re-hitting the rate-limited endpoint.
+      quotaCache.set(key, { at: now(), windows });
+      return windows;
+    },
+
+    async fetchCodexQuota({ account }): Promise<OAuthQuotaWindow[] | null> {
+      // Twin of fetchAnthropicQuota above — same 5-min cache (success AND failure),
+      // same bounded timeout, same per-account proxy reuse. Codex-specific bits:
+      // the endpoint keys on `chatgpt-account-id` (decoded from the access-token
+      // JWT, exactly like the execution path in core/provider/openai-responses).
+      const key = `${CODEX} ${account}`;
+      const cached = quotaCache.get(key);
+      if (cached && now() - cached.at < QUOTA_TTL_MS) return cached.windows;
+      const provider = getOAuthProvider(CODEX);
+      if (!provider) return null;
+      let windows: OAuthQuotaWindow[] | null = null;
+      try {
+        const tm = createTokenManager({
+          oauth: { kind: "preset", providerId: CODEX, account },
+          tokenStore: deps.store,
+          encKey: deps.encKey,
+          oauthProvider: provider,
+          now,
+        });
+        const authorization = await tm.getAuthHeader(); // "Bearer <access>"
+        const accountId = codexAccountIdFromToken(authorization.replace(/^Bearer\s+/i, ""));
+        const proxy = getAccountSettings(
+          await loadAccountSettings(deps.config, deps.encKey),
+          CODEX,
+          account,
+        ).proxy;
+        const doFetch = proxy ? makeProxyFetch(proxy) : fetch;
+        const res = await doFetch(CODEX_USAGE_URL, {
+          headers: {
+            ...CODEX_USAGE_HEADERS,
+            authorization,
+            ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+          },
+          signal: AbortSignal.timeout(QUOTA_FETCH_TIMEOUT_MS),
+        });
+        if (res.ok) {
+          const body: unknown = await res.json();
+          windows = parseCodexUsageBody(body, now());
+        } else {
+          await res.body?.cancel().catch(() => {}); // 429/4xx/5xx → cache the miss
+        }
+      } catch {
+        windows = null; // dead token / network / malformed body → page renders "—"
+      }
       quotaCache.set(key, { at: now(), windows });
       return windows;
     },

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -967,6 +967,51 @@ describe("admin.api oauth quota", () => {
     expect(deletes).toEqual([["openai-codex", "default"]]);
   });
 
+  it("GET /oauth/quota also refreshes the Codex PULL (source 'codex')", async () => {
+    const upserts: unknown[] = [];
+    const oauthQuota = {
+      upsert: async (s: unknown) => {
+        upserts.push(s);
+      },
+      get: async () => null,
+      getAll: async () => [],
+      delete: async () => {},
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const oauth = {
+      listStatus: async () => [
+        {
+          id: "openai-codex",
+          name: "C",
+          flow: "manual_paste",
+          accounts: [
+            {
+              account: "mylukin",
+              expiresAt: null,
+              updatedAt: 0,
+              healthy: true,
+              priority: 50,
+              schedulable: true,
+            },
+          ],
+        },
+      ],
+      // The PULL twin of the x-codex-* header PUSH: same window keys.
+      fetchCodexQuota: async () => [
+        { key: "primary", usedPercent: 1, resetsAtMs: 9_000, windowMinutes: 300 },
+        { key: "secondary", usedPercent: 14, resetsAtMs: 99_000, windowMinutes: 10_080 },
+      ],
+    } as unknown as AdminApiDeps["oauth"];
+    const app = buildApp(buildDeps({ oauthQuota, oauth }));
+    const res = await app.request("/admin/api/oauth/quota");
+    expect(res.status).toBe(200);
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      providerId: "openai-codex",
+      account: "mylukin",
+      source: "codex",
+    });
+  });
+
   it("GET /oauth/quota fails open to [] when no quota store is wired", async () => {
     const app = buildApp(buildDeps());
     const res = await app.request("/admin/api/oauth/quota");

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -155,12 +155,15 @@ export interface OAuthAdminAccess {
     schedulable?: boolean;
   }): Promise<void>;
   // Pull the Anthropic OAuth usage endpoint for one account → quota windows
-  // (providers page Tier 3). Unlike Codex (which PUSHes quota headers on every
-  // reply), Claude exposes a dedicated usage endpoint, so this is an on-demand PULL
-  // behind a short TTL cache. FAIL-OPEN: returns null on any failure (dead token,
-  // network, malformed body) so the page renders "—" rather than erroring. Optional
-  // so unit-test seams can omit it.
+  // (providers page Tier 3). Claude exposes a dedicated usage endpoint, so this is
+  // an on-demand PULL behind a short TTL cache. FAIL-OPEN: returns null on any
+  // failure (dead token, network, malformed body) so the page renders "—" rather
+  // than erroring. Optional so unit-test seams can omit it.
   fetchAnthropicQuota?(input: { account: string }): Promise<OAuthQuotaWindow[] | null>;
+  // Same PULL for Codex (chatgpt.com/backend-api/wham/usage — what the Codex CLI
+  // /status reads). Complements the `x-codex-*` header PUSH so quota renders even
+  // before an account has served any traffic. Same TTL cache + fail-open contract.
+  fetchCodexQuota?(input: { account: string }): Promise<OAuthQuotaWindow[] | null>;
 }
 
 // The effective scheduling for one account: defaults applied (priority 50,

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -102,10 +102,11 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   });
 
   // GET /oauth/quota -> latest rate-limit window snapshot per account (providers
-  // page Tier 3). Two sources merge in the quota store: Codex PUSHes `x-codex-*`
-  // headers on every reply; Anthropic exposes a PULL usage endpoint, so we refresh
-  // it on read (5-min cached in the seam) before returning. FAIL-OPEN throughout —
-  // a dead token / absent store yields fewer windows or [], never an error.
+  // page Tier 3). Sources merge in the quota store: Codex PUSHes `x-codex-*`
+  // headers on every reply, and BOTH Anthropic and Codex expose PULL usage
+  // endpoints we refresh on read (5-min cached in the seam) before returning.
+  // FAIL-OPEN throughout — a dead token / absent store yields fewer windows or
+  // [], never an error.
   app.get("/admin/api/oauth/quota", async (c) => {
     const store = deps.oauthQuota;
     if (!store) return c.json({ quota: [] });
@@ -120,27 +121,34 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       try {
         const status = await s.listStatus();
         bound = new Set(status.flatMap((p) => p.accounts.map((a) => acctKey(p.id, a.account))));
-        // Refresh the Anthropic PULL for each connected Claude account (cached). Codex
-        // snapshots are already in the store from the live request path (no pull).
-        if (s.fetchAnthropicQuota) {
-          const anthropic = status.find((p) => p.id === "anthropic");
-          await Promise.all(
-            (anthropic?.accounts ?? []).map(async (a) => {
-              const windows = await s.fetchAnthropicQuota?.({ account: a.account });
+        // Refresh the usage-endpoint PULL for each connected account (cached in the
+        // seam). Anthropic and Codex both expose one; the Codex `x-codex-*` header
+        // PUSH still updates the same store on live traffic — the PULL covers
+        // accounts that have served nothing yet (else they render "—" forever).
+        const pulls = [
+          { providerId: "anthropic", source: "anthropic" as const, fetch: s.fetchAnthropicQuota },
+          { providerId: "openai-codex", source: "codex" as const, fetch: s.fetchCodexQuota },
+        ];
+        await Promise.all(
+          pulls.flatMap((p) => {
+            if (!p.fetch) return [];
+            const accounts = status.find((x) => x.id === p.providerId)?.accounts ?? [];
+            return accounts.map(async (a) => {
+              const windows = await p.fetch?.({ account: a.account });
               if (windows && windows.length > 0) {
                 await store
                   .upsert({
-                    providerId: "anthropic",
+                    providerId: p.providerId,
                     account: a.account,
                     windows,
                     capturedAt: Date.now(),
-                    source: "anthropic",
+                    source: p.source,
                   })
                   .catch(() => {});
               }
-            }),
-          );
-        }
+            });
+          }),
+        );
       } catch {
         // fail-open: a refresh/listing failure still returns whatever is stored
       }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 2026-06-04 · Codex 额度改为「PULL + PUSH 双源」（spec 未覆盖；issue #38 OAuth 订阅）
+
+**问题**：providers 页 Codex 账户的额度列永远显示「—」，刷新按钮无效。根因：Codex 额度此前**只有 PUSH 源**——从每次 `/responses` 响应的 `x-codex-*` 头里刮（`codex-quota.ts`），账户没流量就永远没有快照；而刷新按钮（#88）只重跑页面加载，其中的主动 PULL 只覆盖 Anthropic。参考项目 claude-relay-service 同样只刮头，**没有**主动拉取可抄。
+
+**方案**：从 Codex CLI 二进制（v0.136.0 strings）找到官方用量端点 `GET https://chatgpt.com/backend-api/wham/usage`（即 CLI `/status` 的数据源；`/backend-api/codex/usage` 别名实测 403），鉴权为 `Bearer <access>` + `chatgpt-account-id`（沿用执行路径从 JWT 解出的 claim）+ codex 客户端 originator/UA。已用本地真实账户验证 200 与响应形态（2026-06-04）。
+
+- shared：`CodexOAuthUsageSchema`（loose、fail-open）；`OAuthQuotaSnapshot.source` 枚举加 `"codex"`。
+- core：`parseCodexUsageBody` / `codexUsageToWindows`——window key 沿用 PUSH 路径的 `primary`/`secondary`（UI 按 windowMinutes 标 5h/Weekly，两源一致）；`reset_at`（epoch 秒）优先于 `reset_after_seconds`；`limit_window_seconds`→分钟。
+- gateway：`fetchCodexQuota` 是 `fetchAnthropicQuota` 的孪生（同 5 分钟正负缓存、同 8s 超时、同代理复用）；`/admin/api/oauth/quota` 的刷新块泛化为 anthropic+codex 两个 PULL 并行。
+- **取舍**：PULL upsert 无条件覆盖快照——活跃流量期间 PUSH 实时性更好、PULL 缓存最多 5 分钟旧，可能短暂回写略旧的百分比；窗口数据变化慢，不值得为此引入 capturedAt 比较的复杂度。
+- **坑**：`wham` 端点是逆向产物（同 ToS 警示已存在于 openai-codex.ts 头部），上游可能改形态——schema 全 loose + fail-open，坏了最多回到「—」。
+
 ## 2026-06-04 · 公开端点：落地页 + `/v1/models` + OpenAPI/Swagger 文档（spec 未覆盖；docs/06 安全、docs/04 lane）
 
 网关此前根路径 `/` 直接 404（Hono 默认 → OpenAI 错误信封），也没有任何「可用 API 一览」与可调试文档。本次在独立 worktree 补三块公开能力，均为 gateway 层薄胶水，core 不变（principle 1）：

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -374,6 +374,7 @@ export {
   openaiCodexOAuthProvider,
   parseAnthropicUsageBody,
   parseCodexQuotaHeaders,
+  parseCodexUsageBody,
   parseOAuthAuthorizationInput,
   pollCopilotDeviceOnce,
   refreshGitHubCopilotToken,

--- a/packages/core/src/provider/oauth/codex-quota.test.ts
+++ b/packages/core/src/provider/oauth/codex-quota.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseCodexQuotaHeaders } from "./codex-quota.js";
+import { parseCodexQuotaHeaders, parseCodexUsageBody } from "./codex-quota.js";
 
 const NOW = 1_000_000;
 
@@ -42,5 +42,79 @@ describe("parseCodexQuotaHeaders", () => {
       parseCodexQuotaHeaders(headers({ "x-codex-primary-used-percent": "nope" }), NOW),
     ).toEqual([]);
     expect(parseCodexQuotaHeaders(headers({}), NOW)).toEqual([]);
+  });
+});
+
+describe("parseCodexUsageBody", () => {
+  // Live shape captured 2026-06-04 from GET chatgpt.com/backend-api/wham/usage
+  // (the same payload the Codex CLI /status reads). reset_at is epoch SECONDS.
+  const LIVE_BODY = {
+    user_id: "user-x",
+    email: "a@b.c",
+    plan_type: "pro",
+    rate_limit: {
+      allowed: true,
+      limit_reached: false,
+      primary_window: {
+        used_percent: 1,
+        limit_window_seconds: 18000,
+        reset_after_seconds: 5057,
+        reset_at: 1780568997,
+      },
+      secondary_window: {
+        used_percent: 14,
+        limit_window_seconds: 604800,
+        reset_after_seconds: 573663,
+        reset_at: 1781137603,
+      },
+    },
+    code_review_rate_limit: null,
+    additional_rate_limits: [{ limit_name: "GPT-5.3-Codex-Spark" }],
+    credits: { has_credits: true },
+  };
+
+  it("maps the primary + secondary windows (same keys as the header PUSH path)", () => {
+    expect(parseCodexUsageBody(LIVE_BODY, NOW)).toEqual([
+      { key: "primary", usedPercent: 1, resetsAtMs: 1_780_568_997_000, windowMinutes: 300 },
+      { key: "secondary", usedPercent: 14, resetsAtMs: 1_781_137_603_000, windowMinutes: 10_080 },
+    ]);
+  });
+
+  it("falls back to now + reset_after_seconds when reset_at is absent; nulls when both are", () => {
+    const out = parseCodexUsageBody(
+      {
+        rate_limit: {
+          primary_window: { used_percent: 7, reset_after_seconds: 120 },
+          secondary_window: { used_percent: 9 },
+        },
+      },
+      NOW,
+    );
+    expect(out).toEqual([
+      { key: "primary", usedPercent: 7, resetsAtMs: NOW + 120_000, windowMinutes: null },
+      { key: "secondary", usedPercent: 9, resetsAtMs: null, windowMinutes: null },
+    ]);
+  });
+
+  it("emits a window only when used_percent is present, and clamps to 0–100", () => {
+    const out = parseCodexUsageBody(
+      {
+        rate_limit: {
+          primary_window: { used_percent: 150, reset_after_seconds: 1 },
+          secondary_window: { limit_window_seconds: 604800 }, // no usage signal → skipped
+        },
+      },
+      NOW,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.usedPercent).toBe(100);
+  });
+
+  it("fails open on malformed / empty / null bodies", () => {
+    expect(parseCodexUsageBody(null, NOW)).toEqual([]);
+    expect(parseCodexUsageBody("garbage", NOW)).toEqual([]);
+    expect(parseCodexUsageBody({}, NOW)).toEqual([]);
+    expect(parseCodexUsageBody({ rate_limit: null }, NOW)).toEqual([]);
+    expect(parseCodexUsageBody({ rate_limit: { primary_window: null } }, NOW)).toEqual([]);
   });
 });

--- a/packages/core/src/provider/oauth/codex-quota.ts
+++ b/packages/core/src/provider/oauth/codex-quota.ts
@@ -1,4 +1,4 @@
-import type { OAuthQuotaWindow } from "@helm/shared";
+import { type CodexOAuthUsage, CodexOAuthUsageSchema, type OAuthQuotaWindow } from "@helm/shared";
 
 // Codex (ChatGPT) rate-limit window headers (providers page Tier 3). The Codex
 // backend stamps these `x-codex-*` headers on EVERY /responses reply (the same set
@@ -49,4 +49,52 @@ export function parseCodexQuotaHeaders(headers: Headers, nowMs: number): OAuthQu
     });
   }
   return out;
+}
+
+// ── Active PULL: GET chatgpt.com/backend-api/wham/usage (providers page) ──────
+// The same payload the Codex CLI's /status reads — the on-demand counterpart of
+// the header PUSH above, so quota renders even for an account that has served no
+// traffic yet. Window keys ("primary"/"secondary") match the PUSH path exactly:
+// the providers page labels them by windowMinutes (5h / Weekly) either way.
+//
+// Mapping per window (emitted only when used_percent parses — same rule as the
+// headers): `reset_at` (epoch SECONDS, absolute) wins over `reset_after_seconds`
+// (relative, anchored at nowMs); `limit_window_seconds` → whole minutes.
+const USAGE_WINDOWS = [
+  { key: "primary", src: "primary_window" },
+  { key: "secondary", src: "secondary_window" },
+] as const;
+
+export function codexUsageToWindows(usage: CodexOAuthUsage, nowMs: number): OAuthQuotaWindow[] {
+  const out: OAuthQuotaWindow[] = [];
+  for (const w of USAGE_WINDOWS) {
+    const win = usage.rate_limit?.[w.src];
+    if (!win || typeof win.used_percent !== "number" || !Number.isFinite(win.used_percent)) {
+      continue; // no usage signal → skip this window
+    }
+    const resetsAtMs = Number.isFinite(win.reset_at)
+      ? Math.round((win.reset_at as number) * 1000)
+      : Number.isFinite(win.reset_after_seconds)
+        ? Math.round(nowMs + (win.reset_after_seconds as number) * 1000)
+        : null;
+    const windowSeconds = win.limit_window_seconds;
+    out.push({
+      key: w.key,
+      usedPercent: Math.min(100, Math.max(0, win.used_percent)),
+      resetsAtMs,
+      windowMinutes:
+        Number.isFinite(windowSeconds) && (windowSeconds as number) > 0
+          ? Math.round((windowSeconds as number) / 60)
+          : null,
+    });
+  }
+  return out;
+}
+
+// Parse a raw (untrusted) usage-endpoint body into windows. Returns [] on any Zod
+// failure (fail-open — a malformed body must never break the providers page).
+export function parseCodexUsageBody(body: unknown, nowMs: number): OAuthQuotaWindow[] {
+  const parsed = CodexOAuthUsageSchema.safeParse(body);
+  if (!parsed.success) return [];
+  return codexUsageToWindows(parsed.data, nowMs);
 }

--- a/packages/core/src/provider/oauth/index.ts
+++ b/packages/core/src/provider/oauth/index.ts
@@ -10,7 +10,7 @@ export {
   refreshAnthropicToken,
 } from "./anthropic.js";
 export { anthropicUsageToWindows, parseAnthropicUsageBody } from "./anthropic-quota.js";
-export { parseCodexQuotaHeaders } from "./codex-quota.js";
+export { codexUsageToWindows, parseCodexQuotaHeaders, parseCodexUsageBody } from "./codex-quota.js";
 export {
   beginCopilotDeviceLogin,
   COPILOT_HEADERS,

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -226,7 +226,7 @@ export const oauthQuota = pgTable(
     account: text("account").notNull(),
     windows: jsonb("windows").$type<unknown[]>().notNull(), // OAuthQuotaWindow[]
     capturedAt: bigint("captured_at", { mode: "number" }).notNull(),
-    source: text("source").notNull(), // 'anthropic' | 'codex-headers'
+    source: text("source").notNull(), // 'anthropic' | 'codex' | 'codex-headers'
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -168,8 +168,8 @@ export const oauthUsage = sqliteTable(
 // Per-account OAuth subscription QUOTA snapshot (providers page Tier 3). One row
 // per (provider_id, account): the LATEST rate-limit window snapshot. `windows` is
 // a JSON-text array of { key, usedPercent, resetsAtMs, windowMinutes } (SQLite has
-// no native array). `source` = how it was captured (anthropic pull / codex-headers
-// push). Latest-wins upsert; no history. Pure observability — no secret column.
+// no native array). `source` = how it was captured (anthropic pull / codex pull /
+// codex-headers push). Latest-wins upsert; no history. Pure observability — no secret column.
 export const oauthQuota = sqliteTable(
   "oauth_quota",
   {
@@ -177,7 +177,7 @@ export const oauthQuota = sqliteTable(
     account: text("account").notNull(),
     windows: text("windows").notNull(), // JSON text: OAuthQuotaWindow[]
     capturedAt: integer("captured_at").notNull(),
-    source: text("source").notNull(), // 'anthropic' | 'codex-headers'
+    source: text("source").notNull(), // 'anthropic' | 'codex' | 'codex-headers'
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -211,6 +211,8 @@ export {
 export {
   type AnthropicOAuthUsage,
   AnthropicOAuthUsageSchema,
+  type CodexOAuthUsage,
+  CodexOAuthUsageSchema,
   type OAuthQuotaSnapshot,
   OAuthQuotaSnapshotSchema,
   type OAuthQuotaWindow,

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -56,7 +56,7 @@ export const OAuthQuotaSnapshotSchema = z
     account: z.string(),
     windows: z.array(OAuthQuotaWindowSchema),
     capturedAt: z.number().int(), // epoch ms the snapshot was taken
-    source: z.enum(["anthropic", "codex-headers"]),
+    source: z.enum(["anthropic", "codex-headers", "codex"]),
   })
   .strict();
 
@@ -89,3 +89,34 @@ export const AnthropicOAuthUsageSchema = z
   .loose();
 
 export type AnthropicOAuthUsage = z.infer<typeof AnthropicOAuthUsageSchema>;
+
+// ── Codex usage-endpoint response (GET chatgpt.com/backend-api/wham/usage) ────
+
+// The (untrusted) shape ChatGPT's Codex usage endpoint returns — the same payload
+// the Codex CLI's /status display reads (active PULL counterpart of the
+// `x-codex-*` header PUSH). Parsed fail-open and `.loose()` throughout: the
+// endpoint also carries plan/credits/additional_rate_limits fields we ignore, and
+// any of them may appear/vanish without breaking the providers page. `reset_at`
+// is epoch SECONDS; `used_percent` is already 0–100.
+const CodexRateLimitWindowSchema = z
+  .object({
+    used_percent: z.number().optional(),
+    limit_window_seconds: z.number().optional(),
+    reset_after_seconds: z.number().optional(),
+    reset_at: z.number().optional(),
+  })
+  .loose();
+
+export const CodexOAuthUsageSchema = z
+  .object({
+    rate_limit: z
+      .object({
+        primary_window: CodexRateLimitWindowSchema.nullish(),
+        secondary_window: CodexRateLimitWindowSchema.nullish(),
+      })
+      .loose()
+      .nullish(),
+  })
+  .loose();
+
+export type CodexOAuthUsage = z.infer<typeof CodexOAuthUsageSchema>;


### PR DESCRIPTION
## Problem

The **Quota** column for ChatGPT Plus/Pro (Codex) accounts on the providers page always showed `—`, and the Refresh button didn't help.

**Root cause:** Codex quota only had a **PUSH** source — scraped from `x-codex-*` headers on each `/responses` reply (`core/provider/oauth/codex-quota.ts`). An account that had served no traffic yet never produced a snapshot, and the Refresh button (#88) only re-pulls the **Anthropic** usage endpoint. The reference project `claude-relay-service` has the same gap (it also only scrapes headers).

## Fix

Add the active **PULL** the Codex CLI's `/status` uses — `GET https://chatgpt.com/backend-api/wham/usage` (`Bearer <access>` + `chatgpt-account-id` + codex originator/UA). Endpoint + response shape verified live against a real account (2026-06-04).

- **shared** — `CodexOAuthUsageSchema` (loose, fail-open); quota `source` enum gains `"codex"`
- **core** — `parseCodexUsageBody` → `primary`/`secondary` windows (same keys as the header PUSH, so the 5h/Weekly labels work for both sources); `reset_at` (epoch s) preferred over `reset_after_seconds`; `limit_window_seconds` → minutes
- **gateway** — `fetchCodexQuota` mirrors `fetchAnthropicQuota` (5-min cache incl. negative, 8s timeout, per-account proxy reuse); `/admin/api/oauth/quota` now refreshes Anthropic + Codex PULLs in parallel

Fail-open throughout (Principle 3): a dead token / changed upstream shape degrades back to `—`, never errors.

## Test plan

- [x] TDD — parser unit tests (live-captured body) + a route test asserting the Codex PULL upserts with `source: "codex"`
- [x] `pnpm test` — 2120 passed; `pnpm typecheck` + `pnpm lint` clean
- [x] Local Docker: `/admin/api/oauth/quota` returns Codex windows; providers page renders **5h 1% / Weekly 1%** with reset countdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)