### PR TITLE
fix(models): /v1/models 暴露订阅（OAuth）模型

### DIFF
--- a/apps/gateway/src/routes/models.test.ts
+++ b/apps/gateway/src/routes/models.test.ts
@@ -53,13 +53,13 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
   };
 }
 
-function buildApp(rec: ApiKeyRecord | null) {
+function buildApp(rec: ApiKeyRecord | null, oauthAliases?: () => Iterable<string>) {
   const getByHash = vi.fn().mockResolvedValue(rec);
   const app = createApp({ logger: { log: () => {} } });
   const auth = authMiddleware({ keyStore: { getByHash }, log: () => {} });
   app.use("/v1/models", auth);
   app.use("/v1/models/*", auth);
-  registerModelsRoute(app, { lanes: () => lanes, catalog, providerAliases });
+  registerModelsRoute(app, { lanes: () => lanes, catalog, providerAliases, oauthAliases });
   return app;
 }
 
@@ -93,6 +93,31 @@ describe("GET /v1/models", () => {
     expect(pro?.type).toBe("model");
     expect(pro?.pricing?.inputPerMTokUsd).toBe(0.5);
     expect(pro?.lanes?.sort()).toEqual(["balanced", "economy"]);
+  });
+
+  it("allow_custom_model key: includes live subscription (OAuth) aliases", async () => {
+    // Real subscription alias shape: `<providerId>/<model>` where providerId can
+    // contain a hyphen (ROUTABLE_OAUTH keys, e.g. `openai-codex`). owned_by must be
+    // the FULL prefix before the first slash, not a truncation.
+    const res = await buildApp(record({ allow_custom_model: true }), () => [
+      "openai-codex/gpt-5.4",
+      "deepseek/pro", // overlaps a configured alias -> deduped, listed once
+    ]).request("/v1/models", { headers: AUTH });
+    const body = (await res.json()) as ModelsList;
+    const ids = body.data.map((m) => m.id);
+    expect(ids).toContain("openai-codex/gpt-5.4");
+    expect(ids.filter((id) => id === "deepseek/pro")).toHaveLength(1);
+    const codex = body.data.find((m) => m.id === "openai-codex/gpt-5.4");
+    expect(codex?.type).toBe("model");
+    expect(codex?.owned_by).toBe("openai-codex");
+  });
+
+  it("normal key: subscription aliases stay hidden (lane abstraction)", async () => {
+    const res = await buildApp(record(), () => ["openai-codex/gpt-5.4"]).request("/v1/models", {
+      headers: AUTH,
+    });
+    const body = (await res.json()) as ModelsList;
+    expect(body.data.map((m) => m.id)).toEqual(["economy", "balanced", "auto"]);
   });
 
   it("retrieve: GET /v1/models/:id returns one model", async () => {

--- a/apps/gateway/src/routes/models.ts
+++ b/apps/gateway/src/routes/models.ts
@@ -18,15 +18,24 @@ export interface ModelsRouteDeps {
   catalog: Map<string, CatalogEntry>;
   // Configured provider aliases: config.providers[].models[].alias.
   providerAliases: string[];
+  // Live curated subscription (OAuth) aliases — `<provider>/<model>` ids synthesized
+  // from bound credentials, not config. Hot-reloadable (admin curation / connect /
+  // disconnect), so read per request like `lanes` rather than snapshotted. Optional:
+  // absent in headless/no-OAuth deployments. These are concrete aliases, so — like
+  // providerAliases — they surface only for allow_custom_model keys (buildModelsList).
+  oauthAliases?: () => Iterable<string>;
 }
 
 export function registerModelsRoute(app: Hono<AppEnv>, deps: ModelsRouteDeps): void {
   const build = (c: Context<AppEnv>) => {
     const identity = c.get("identity");
+    // Merge static config aliases with the LIVE subscription set. buildModelsList
+    // dedups + sorts, so an alias that is both configured and OAuth-curated lists once.
+    const oauth = deps.oauthAliases ? [...deps.oauthAliases()] : [];
     return buildModelsList({
       lanes: deps.lanes(),
       catalog: deps.catalog,
-      providerAliases: deps.providerAliases,
+      providerAliases: oauth.length ? [...deps.providerAliases, ...oauth] : deps.providerAliases,
       allowCustomModel: identity.caps.allowCustomModel,
       allowedLanes: identity.caps.allowedLanes,
     });

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -994,6 +994,10 @@ export async function buildServer(
     lanes: () => lanes,
     catalog,
     providerAliases: config.providers.flatMap((p) => p.models.map((m) => m.alias)),
+    // Live curated subscription aliases — the SAME hot-reloadable set the executor
+    // routes by (rebound on OAuth curation/connect/disconnect), so discovery and
+    // routability never disagree.
+    oauthAliases: () => oauthAliasSet,
   });
 
   // The per-request `route`: bind a fresh `execute` to the request's abort

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -5,6 +5,15 @@
 
 ---
 
+## 2026-06-04 · `/v1/models` 漏报订阅（OAuth）模型（bug 修复；docs/04 lane、issue #38）
+
+**问题**：`GET /v1/models` 对 `allow_custom_model` key 列出了 configured providers 的别名（deepseek/openrouter/zenmux），但**完全没有订阅（OAuth）provider 的模型**。根因：`server.ts` 给 `registerModelsRoute` 的 `providerAliases` 只取 `config.providers[].models[].alias`（静态配置），而订阅模型是另一条链路 `synthesizeOAuthProviders` 合成的，活别名存在热加载的 `oauthAliasSet` 里。执行器读它做路由（`oauthAliases: () => oauthAliasSet`），但发现端点从没拿到——于是「能路由但列不出」。
+
+**方案**：给 `ModelsRouteDeps` 加可选 `oauthAliases?: () => Iterable<string>` thunk（**活读**，与执行器同一个 `oauthAliasSet`，curation/connect/disconnect 即时生效、无需重启），route 内与静态 `providerAliases` 合并后交给 `buildModelsList`（其本就 dedup+sort，配置别名与订阅别名重叠只列一次）。
+
+- **取舍**：不改 core `buildModelsList` 契约——合并发生在 gateway 组合根，core 仍是纯函数只认一份 `providerAliases`（principle 1）。订阅别名同属「concrete alias」，因此与 provider 别名一样**只对 `allow_custom_model` key 可见**，默认 key 仍只见 lane（principle 6）。
+- **已知限制（TODO）**：订阅别名（如 `openai-codex/gpt-5.4`，前缀是 `ROUTABLE_OAUTH` 的 key，可能带连字符）通常不在 runtime catalog 里，故列出时**不带 capabilities/pricing**——诚实且不阻塞「能被发现」。若要补全，需用去前缀的 base model 在 catalog 里回查，留待后续。
+
 ## 2026-06-04 · Codex 额度改为「PULL + PUSH 双源」（spec 未覆盖；issue #38 OAuth 订阅）
 
 **问题**：providers 页 Codex 账户的额度列永远显示「—」，刷新按钮无效。根因：Codex 额度此前**只有 PUSH 源**——从每次 `/responses` 响应的 `x-codex-*` 头里刮（`codex-quota.ts`），账户没流量就永远没有快照；而刷新按钮（#88）只重跑页面加载，其中的主动 PULL 只覆盖 Anthropic。参考项目 claude-relay-service 同样只刮头，**没有**主动拉取可抄。


### PR DESCRIPTION
## 问题

`GET /v1/models` 对 `allow_custom_model` key 列出了 configured providers 的别名（deepseek/openrouter/zenmux），但**完全没有订阅（OAuth）provider 的模型**——尽管聊天执行器其实能正常路由到它们，形成「能路由、却发现不了」的割裂。

**根因**：`server.ts` 给 `registerModelsRoute` 的 `providerAliases` 只取 `config.providers[].models[].alias`（静态配置）。订阅模型是另一条链路 `synthesizeOAuthProviders` 合成的，活别名存在热加载的 `oauthAliasSet` 里。执行器读它做路由（`oauthAliases: () => oauthAliasSet`），但发现端点从没拿到这份集合。

## 方案

- 给 `ModelsRouteDeps` 加可选 `oauthAliases?: () => Iterable<string>` thunk（**活读**，与执行器同一个 `oauthAliasSet`，curation/connect/disconnect 即时生效、无需重启）。
- route 内把订阅别名与静态 `providerAliases` 合并后交给 `buildModelsList`——它本就 dedup+sort，配置别名与订阅别名重叠只列一次。
- `server.ts` 接到同一个 `oauthAliasSet`，确保**发现**与**可路由性**永不打架。

## 设计取舍

- **不改 core `buildModelsList` 契约**：合并发生在 gateway 组合根，core 仍是纯函数、只认一份 `providerAliases`（principle 1）。
- 订阅别名同属「concrete alias」，因此沿用既有规则——**只对 `allow_custom_model` key 可见**，默认 key 仍只见 lane（principle 6）。

## 已知限制（TODO）

订阅别名（如 `openai-codex/gpt-5.4`，前缀是 `ROUTABLE_OAUTH` 的 key、可能带连字符）通常不在 runtime catalog 里，故列出时**不带 capabilities/pricing**——诚实且不阻塞「能被发现」。若要补全，需用去前缀的 base model 在 catalog 里回查，留待后续。

## 测试

- `models.test.ts` 新增两例：`allow_custom_model` key 能看到订阅别名（去重、`owned_by` 取完整前缀 `openai-codex`）；默认 key 看不到。用真实别名形态（带连字符前缀）顺带覆盖 `ownerOf` 的前缀回归。
- `models.test.ts` 7/7 通过，`server*.test.ts` 16/16 通过，`pnpm typecheck` + Biome lint 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)