### PR TITLE
fix(classifier): keep Layer-2 eval off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ AI app developers don't want to manage hundreds of models, per-provider quirks, 
 ## Key concepts
 
 - **Lanes** — Requests route through configurable *lanes* (quality/cost tiers `economy`, `balanced`, `premium`, or task lanes `coding`, `json`, `vision`, `tool_use`), never raw provider names. You decide in config how each lane maps to a primary model plus a fallback chain. Provider aliases are an internal supply-chain detail, never the client-facing surface.
-- **Classification cascade** — Three layers pick the lane: **(1)** deterministic rules (a pure, zero-network, unit-tested scorer — always on); **(2)** an optional small-model "second opinion" eval (`temperature: 0`, cached, **on by default** in the shipped config; the schema default stays off as a fail-safe), consulted only when the rules are uncertain; **(3)** the `balanced` lane as the fail-open sink.
+- **Classification cascade** — Three layers pick the lane: **(1)** deterministic rules (a pure, zero-network, unit-tested scorer — always on); **(2)** an optional small-model "second opinion" eval (`temperature: 0`, cached, **off by default** — it needs a configured eval model), consulted only when the rules are uncertain; **(3)** the `balanced` lane as the fail-open sink.
 - **Two fallbacks, never conflated** — *Classification fallback* degrades an undecided request to the `balanced` lane; *execution fallback* swaps to the next model in the chain when a provider fails. They live in separate decision-record fields so you can always tell which one fired.
 - **Protocol translation** — Four inbound protocols normalize to one OpenAI-Chat-shaped internal representation (IR), so a single client reaches many backends and gets a consistent output shape — streaming SSE included.
 - **Config-as-code** — Behavior lives in `config/*.yaml`, Zod-validated at startup; an invalid file fails closed and the gateway refuses to boot.
@@ -64,7 +64,7 @@ CORE      packages/core · the routing brain (imports no web framework)
              ├─ auth        resolve sha256 key, load per-key caps        · fail-closed
              ├─ gate        rate limit (off) · usage budget (off)        · fail-closed
              ├─ memory      inject remembered context (on by default)    · fail-open
-             ├─ classify    L1 rules ─uncertain→ L2 eval (on) ─→ balanced · fail-open
+             ├─ classify    L1 rules ─uncertain→ L2 eval (off) ─→ balanced · fail-open
              ├─ resolve     first-match policy → lane → caps → fallback chain
              ├─ execute     capability filter → circuit breaker → provider
              │                  └── on failure: advance to next model in the chain
@@ -103,7 +103,7 @@ Helm API is at **0.6** and is a real, end-to-end implementation — not a scaffo
 
 - **Four client protocols** — `POST /v1/chat/completions` (OpenAI Chat), `POST /v1/messages` (Anthropic Messages), `POST /v1/responses` (OpenAI Responses), and `POST /v1beta/models/{model}:generateContent` (Google Gemini) — all streaming + non-streaming. (Gemini streaming is the `:streamGenerateContent?alt=sse` operation; the Gemini surface authenticates with `x-goog-api-key`.)
 - **Cross-protocol translation** — normalize to one OpenAI-Chat-shaped IR; consistent output across backends with SSE on all four surfaces. Aligned to litellm's field coverage: sampling knobs, usage detail (reasoning / cache / per-modality), a unified reasoning/thinking bridge, full multimodal I/O, and both-ways `finish_reason` maps. Unmappable knobs degrade observably (e.g. Anthropic caps `n>1` and warns on `logprobs`/`modalities`) rather than erroring — see the [Protocol Compatibility](docs/protocol-compatibility.md) matrix.
-- **Three-layer classification** — deterministic rules always on; optional small-model eval (on by default in the shipped config; schema default off) for uncertain cases; `balanced`-lane fail-open sink.
+- **Three-layer classification** — deterministic rules always on; optional small-model eval (off by default; needs a configured eval model) for uncertain cases; `balanced`-lane fail-open sink.
 - **Lane + policy routing** — first-match policies that pin or cap lanes; shipped lanes `economy`, `balanced`, `premium` plus task lanes `coding`, `json`, `vision`, `tool_use` (`balanced` is the required, always-available fallback terminal).
 - **Provider execution with fallback** — primary + fallback chains across OpenAI-compatible upstreams, with a circuit breaker (OPEN/HALF_OPEN + single-probe), a capability filter (skip candidates lacking JSON / tools / vision / a modality / context size / streaming, with an explicit reason), and `:free`-tier 429 skipping. Client disconnects are treated as non-provider faults.
 - **OAuth subscription providers** — route your Claude Pro/Max, ChatGPT Codex, and GitHub Copilot **subscriptions** as backends: log in from the dashboard, pool several accounts per provider, and curate models / set an egress proxy / set scheduling per account — all of which **hot-reload**. See [the section below](#oauth-subscription-providers-claude-promax-chatgpt-codex-github-copilot). *(Opt-in; may violate provider ToS — read the warning.)*

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -173,12 +173,11 @@ classifier:
   # EvalConfigSchema (@helm/shared): temperature/on_failure/cache.key are locked,
   # max_tokens capped at 1024. Downstream eval modules read this parsed object.
   eval:
-    enabled: true                  # shipped ON. Schema default stays false (fail-safe
-                                    # for an absent block); this config opts the
-                                    # gateway in so uncertain / non-English prompts
-                                    # reach Layer-2 instead of degrading to balanced.
-                                    # Costs the eval model (providers[0]) on the
-                                    # uncertain slice; cache below bounds the spend.
+    enabled: false                 # default OFF (non-negotiable). Layer-2 needs a
+                                    # working eval model — the eval client sends
+                                    # `model` straight to providers[0] — so turning
+                                    # it on requires a configured/supported provider.
+                                    # Opt in per deployment once that model exists.
     # The eval client sends this id DIRECTLY on the wire to the primary provider
     # (official DeepSeek, providers[0]), bypassing the registry — so it MUST be a
     # real bare upstream id DeepSeek accepts. `deepseek-v4-flash` is the cheap/fast

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -73,9 +73,9 @@ default and any per-key RPM/TPM override on every request surface. See
 
 The classification cascade producing `task_type` / `complexity` / `confidence` /
 `constraints`. Layer-1 rules are **always on** (pure, zero-network); Layer-2 eval
-is **on in the shipped config** (schema default off as a fail-safe) and runs only
-when Layer-1 confidence is below the threshold; Layer-3 is the `balanced` fail-open
-sink. See [03 · Classification Cascade](03-classification.md).
+is **off by default** and runs only when Layer-1 confidence is below the threshold;
+Layer-3 is the `balanced` fail-open sink. So the live default cascade is
+**rules → balanced**. See [03 · Classification Cascade](03-classification.md).
 
 ### Policy Engine
 

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -9,16 +9,16 @@ ordered layers, stopping at the first one that commits (hit-stop):
 Request in
   → Layer 1: deterministic rules            [always on; zero cost, zero latency]
         confidence ≥ threshold → go straight to the resolved lane
-  → Layer 2: small-model eval               [ON by default (shipped); cached]
+  → Layer 2: small-model eval               [OFF by default; cached]
         the small model decides complexity / task_type → resolved lane
   → Layer 3: fallback → balanced lane       ← always-safe default
 ```
 
 The cascade itself is framework-agnostic
 (`packages/core/src/classifier/cascade.ts`), driven by the live, Zod-validated
-configuration in `config/classifier.yaml`. The shipped config sets
-`eval.enabled: true`; if eval is disabled, the cascade degrades to the two-layer
-"rules + balanced" path — Layer 2 is a pure additive switch. A **confident Layer 1 ends the cascade
+configuration in `config/classifier.yaml`. With eval off by default
+(`eval.enabled: false`), the cascade degrades to the two-layer "rules + balanced"
+path — Layer 2 is a pure additive switch. A **confident Layer 1 ends the cascade
 even when eval is enabled** — high confidence never spends an eval call.
 
 **Key distinction: the two fallbacks are different things and are recorded
@@ -155,7 +155,7 @@ classifier:
     confidence_threshold: 0.42     # below this, the cascade may enter eval
 
   eval:
-    enabled: true                  # ON by default (shipped). Schema default stays false as a fail-safe.
+    enabled: false                 # OFF by default (non-negotiable); needs a configured eval model
     model: deepseek-v4-flash       # a real bare id the primary (official DeepSeek) accepts; sent directly to it
     temperature: 0
     max_tokens: 256                # one JSON object; caps the cost

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -22,9 +22,8 @@
   [03 · Classification Cascade](03-classification.md) and
   [04 · Routing & Lanes](04-routing-and-lanes.md).
 - **Eval layer.** The Layer-2 small-model evaluator with a content-hash cache,
-  **on in the shipped config** (schema default off). It runs only when Layer-1
-  confidence is below the threshold; identical requests hit the cache instead of
-  re-evaluating.
+  **off by default**. When enabled, it runs only when Layer-1 confidence is below
+  the threshold; identical requests hit the cache instead of re-evaluating.
 
 ### Protocol translation
 
@@ -108,7 +107,7 @@ Verified against the code and `implementation-notes.md`:
 - A new client can point an OpenAI-compatible SDK at Helm and get usable routing
   with no custom config.
 - The default economy / balanced / premium lanes work out of the box, with LLM
-  evaluation on by default (shipped config).
+  evaluation off by default.
 - On first start with no key, a root key is generated; requests without a key are
   rejected.
 - Layer-1 rules route directly to the matching lane when classification is

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Helm API is an **open-source, self-hosted** LLM routing gateway (MIT license,
 deployed with Docker) — think of it as "**nginx for the LLM world**". It accepts
 standard AI API requests on four inbound protocols (OpenAI Chat Completions,
 Anthropic Messages, OpenAI Responses, and Google Gemini), uses deterministic
-rules (optionally aided by a small-model evaluation that is **on by default** in the shipped config; the schema default stays off as a fail-safe)
+rules (optionally aided by a small-model evaluation that is **off by default**)
 to classify each request by task type and complexity, and routes it to a
 configurable **lane** rather than to a bare provider alias. It executes the lane
 through a primary plus fallback providers and records every routing decision for
@@ -47,7 +47,7 @@ These keep Helm more focused than its predecessor `llm-router`:
 - **A small, explainable routing core.** Policies are explicit and inspectable;
   there is no black-box scoring at runtime.
 - **Deterministic classification first.** Local rules form Layer 1; the
-  small-model eval is on by default (shipped config) and sits behind them.
+  small-model eval is off by default and sits behind them.
 - **Memory is middleware.** It helps a request be understood; it never rewrites
   lane rules.
 - **Every surprising provider choice is explainable from the logs.**

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,14 +7,14 @@
 
 ---
 
-## 2026-06-06 · 记忆与小模型 eval 默认开启（用户决策；docs/03/08；偏离 CLAUDE.md 原则 4）
+## 2026-06-06 · 记忆默认开启（eval 维持默认关闭——依赖已配置 eval 模型）（用户决策；docs/08）
 
-- **动机**：用户明确要求「记忆 + 小模型 eval 默认都打开」。两者开关分处不同层，处理方式各异。
-- **eval（config/classifier.yaml）**：`classifier.eval.enabled: false → true`。**schema 默认仍 `false`**（`EvalConfigSchema`，缺块时的 fail-safe 不动），只把**发行配置**改成 opt-in——发动机默认关、发行版默认开。⚠️ **此处偏离 CLAUDE.md 原则 4「eval 默认关闭」与 docs/03 的「OFF by default (non-negotiable)」**；属用户明示决策，记此备查。成本：不确定/非英文切片会打 eval 模型（providers[0]），下方 cache（TTL 300s / LRU 5000）兜底封顶。
-- **memory（无全局开关，逐 key `memory_mode`）**：① 新 key 的 `keystore.create` 默认 `"off" → "inject"`（sqlite + pg 两个适配器）；② 请求兜底 `memory-scope.ts` `defaults?.mode ?? "off" → ?? "inject"`。**范围 = 仅新 key + 兜底，不迁移既有 key**：DB 列默认与已应用迁移仍保留 `"off"`（底线 + 迁移历史不重写），既有 key 维持其存储值。显式 `x-memory-mode`（含 `off`）与 key 存储 mode 仍永远优先；非法 mode 头仍归一 `off`（fail-safe，不继承宽松默认）。
+- **动机**：用户要求「记忆 + 小模型 eval 默认都打开」，复核后**只开记忆、eval 仍默认关**。
+- **eval 维持 OFF（拍板）**：原本随手把 `classifier.eval.enabled` 翻 `true`，但 Layer-2 eval 客户端把 `model`（`deepseek-v4-flash`）**直发 providers[0]**——没有配好的 DeepSeek 兼容 provider 时，每个 uncertain 请求都先打一通失败调用再 fail-open 回 `balanced`（不 5xx，但纯浪费延迟/无意义）。结论：eval **必须有可用模型才该开**，留作 per-deployment opt-in，遵守 CLAUDE.md 原则 4「eval 默认关闭」。config 注释补上该依赖说明。
+- **memory（无全局开关，逐 key `memory_mode`）**：① 新 key 的 `keystore.create` 默认 `"off" → "inject"`（sqlite + pg 两个适配器）；② 请求兜底 `memory-scope.ts` `defaults?.mode ?? "off" → ?? "inject"`。**范围 = 仅新 key + 兜底，不迁移既有 key**：DB 列默认与已应用迁移仍保留 `"off"`（底线 + 迁移历史不重写），既有 key 维持其存储值。显式 `x-memory-mode`（含 `off`）与 key 存储 mode 仍永远优先；非法 mode 头仍归一 `off`（fail-safe，不继承宽松默认）。记忆走本地 store，无外部模型依赖，故可安全默认开。
 - **forgetting**：`config/memory.yaml` `enabled` 本会话稍早已置 `true`（PR #106）——与「记忆默认开」配套（衰减/巩固/facts 生效）。
-- **测试更新（4 处断言随默认翻转）**：`classifier-samples`（eval true）、`store-contract`（新 key → inject）、`memory-scope`（无头/无默认 → inject）、`messages.memory`（无记忆头 → memory_mode inject）。全单测 **2474 绿**，typecheck 净、lint exit 0（残留 warning 非本次引入）。
-- **文档同步**：README（根）+ docs/01/02/03/09 + docs/README 的「off by default」表述改为「发行默认开启（schema/引擎默认仍 off 作 fail-safe）」。
+- **测试更新（随记忆默认翻转）**：`store-contract`（新 key → inject）、`memory-scope`（无头/无默认 → inject）、`messages.memory`（无记忆头 → memory_mode inject）；`classifier-samples` 仍断言 eval `false`（未动）。全单测 **2474 绿**，typecheck 净、lint exit 0（残留 warning 非本次引入）。
+- **文档同步**：README（根）+ docs/01/02/08 + docs/12 的记忆/遗忘「off/opt-in」表述改为「默认开启」；eval 相关（README/docs/02/03/09/README）维持「off by default」。
 - **坑/取舍**：兜底改 `inject` 触及 memory-scope 原「零回退（无配置 = off）」契约——但**真实认证流量恒携带 key 存储 mode**（auth.ts 注入 `record.memory_mode`），裸兜底仅管「完全无 key 配置」路径；且 `inject` 在 `threadId === null` 时 observe/inject 自闸为 no-op，无 thread 的请求不会真正注入。
 
 ---

--- a/packages/core/src/config/classifier-samples.test.ts
+++ b/packages/core/src/config/classifier-samples.test.ts
@@ -25,9 +25,9 @@ describe("checked-in classifier.yaml sample", () => {
     });
   });
 
-  it("ships eval enabled with documented eval defaults", () => {
+  it("ships eval disabled by default with documented eval defaults", () => {
     const cfg = loadConfig({ configDir, env: {} });
-    expect(cfg.classifier.eval.enabled).toBe(true);
+    expect(cfg.classifier.eval.enabled).toBe(false);
     expect(cfg.classifier.eval.max_tokens).toBe(256);
     expect(cfg.classifier.eval.timeout_ms).toBe(250);
     expect(cfg.classifier.eval.on_failure).toBe("balanced");


### PR DESCRIPTION
Corrects #107, which squash-merged a stale head and landed `eval.enabled: true` on `main` despite the in-PR revert (an auto-merge replication race).

Layer-2 eval must stay **off by default**: the eval client sends `model` straight to `providers[0]`, so without a configured DeepSeek-compatible provider every uncertain request burns a failed call before failing open to `balanced`. Kept off per CLAUDE.md principle 4; the config comment documents the model dependency.

- `config/classifier.yaml` → `eval.enabled: false`
- Revert the eval-related doc/test edits (memory-on-by-default from #107 is unaffected)
- `implementation-notes.md` updated: memory on; eval stays off, with rationale

2474/2474 unit tests pass; typecheck clean; lint exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)