### PR TITLE
chore(release): bump version 0.6.0 → 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.7.0.

## Since v0.6.0
- **Memory on by default** (#106, #107, #108): new API keys default to `memory_mode: "inject"`; the forgetting/tiering layer is enabled in the shipped config. Layer-2 eval **stays off** by default (needs a configured eval model). Existing keys keep their stored mode; `x-memory-mode` header still overrides.
- **OAuth subscription flow fully behind the egress proxy** (#105, issue #38): binding's first network call, token exchange/refresh, quota — no real-IP leak.
- **Editable name field for API keys** (#104).
- Docs accuracy audit follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)