### PR TITLE
feat(keys): mint new keys with memory thread_source=auto

### DIFF
--- a/apps/admin/src/lib/api/keys.ts
+++ b/apps/admin/src/lib/api/keys.ts
@@ -66,7 +66,8 @@ export interface CreateKeyInput {
   degrade_lane?: string;
   // Optional max in-flight requests at mint time. Omitted => unlimited.
   concurrency_limit?: number;
-  // Optional per-key memory defaults at mint time (issue #97). Omitted => off.
+  // Optional per-key memory defaults at mint time (issue #97). Omitted => the server
+  // mints the new-key defaults (mode 'inject', thread_source 'auto').
   memory_mode?: 'off' | 'observe' | 'inject';
   memory_project_id?: string;
   memory_thread_source?: 'header' | 'auto';

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -67,7 +67,9 @@
     if (form.concurrencyLimit != null) input.concurrency_limit = form.concurrencyLimit;
     if (form.memoryMode !== 'off') input.memory_mode = form.memoryMode;
     if (form.memoryProject.length > 0) input.memory_project_id = form.memoryProject;
-    if (form.memoryThreadSource !== 'header') input.memory_thread_source = form.memoryThreadSource;
+    // Send only when the operator opts out of the default ('auto'); omitted => the
+    // keystore mints 'auto'.
+    if (form.memoryThreadSource !== 'auto') input.memory_thread_source = form.memoryThreadSource;
     try {
       revealed = await createKey(input);
     } catch (e) {

--- a/apps/admin/src/lib/components/KeyCapsForm.svelte
+++ b/apps/admin/src/lib/components/KeyCapsForm.svelte
@@ -37,7 +37,9 @@
       degradeLane: '',
       memoryMode: 'off',
       memoryProject: '',
-      memoryThreadSource: 'header',
+      // Mirrors the keystore mint-default: a new key derives its thread automatically
+      // (issue #97). The operator can switch to 'header' to opt out.
+      memoryThreadSource: 'auto',
     };
   }
 

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -144,7 +144,7 @@ Stored on the API key (admin UI → key dialog → "Memory defaults"):
 ```text
 memory_mode:          off | observe | inject     (default inject — new keys)
 memory_project_id:    <string> | null            (default null)
-memory_thread_source: header | auto              (default header)
+memory_thread_source: header | auto              (default auto — new keys)
 ```
 
 Explicit `x-memory-*` request headers always override the key defaults —

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-06 · 记忆 thread source 新 key 默认 auto（配合「记忆默认开启」；用户决策；docs/08）
+
+- **动机**：承接同日「记忆默认开启」（新 key `memory_mode` mint 默认 `inject`）。但 `memory_thread_source` 仍 mint 默认 `header`——新 key 记忆开了却**不自动推导 thread**（缺 `x-thread-id` 时不回退信号链 → 无 per-conversation 记忆），等于开了个寂寞。把新 key 的 thread source mint 默认翻 `header → auto`，让记忆真正开箱即用。
+- **范围 = 仅新 key（用户拍板，不迁移既有 key）**：改两个 keystore 的 `createKey` mint 默认 `?? "header" → ?? "auto"`（sqlite + pg），与紧邻的 `memoryMode ?? "inject"` 同一档（**mint-default**）。**Zod `ApiKeyRecordSchema.default("header")` 保持不动**（**parse-default**，镜像 `memory_mode` 的 `.default("off")`）——既有 key 列默认与已应用迁移仍 `header`、不重写。
+- **parse-default vs mint-default 分离（沿用 memory_mode 既有模式）**：docs/06 列的是 schema parse-defaults（off/header，照旧准确，不动）；docs/08 列的是新 key mint 行为（inject/auto），只改这一行 `(default header) → (default auto — new keys)`。两文档各自内部自洽。
+- **admin UI 诚实化**：`KeyCapsForm.emptyKeyCaps` 的 thread source `'header' → 'auto'` + `CreateKeyDialog` 省略 guard `!== 'header' → !== 'auto'`——下拉默认显示 **Auto** = 实际落库值，**避免重蹈 memory_mode 的 UI 错位**（emptyKeyCaps `memoryMode:'off'` + guard `!=='off'` 省略 → keystore 实际 mint `inject`，UI 显示 Off 却落 inject；本次不碰该 pre-existing 错位，仅 thread source 做对）。EditKeyDialog 不动（按存储值预填）。
+- **测试/验证**：`store-contract`（真 sqlite+pglite keystore）断言无记忆字段 create → `memory_thread_source === "auto"`；`schema.test` 维持 parse-default `header`（未动）；admin/ports 的 **fake keystore 保守桩仍 `?? "header"`**（与其 `memoryMode ?? "off"` 桩一致，本就不冒充真 mint 默认，不动）；`memory-scope` 测试显式传 threadSource、两分支俱存，未受影响。typecheck/build/svelte-check 全绿，101 store-contract+keystore 串行通过。
+
+---
+
 ## 2026-06-06 · 记忆默认开启（eval 维持默认关闭——依赖已配置 eval 模型）（用户决策；docs/08）
 
 - **动机**：用户要求「记忆 + 小模型 eval 默认都打开」，复核后**只开记忆、eval 仍默认关**。
@@ -31,19 +41,11 @@
 
 ---
 
-## 2026-06-06 · API key 增加可编辑 name 字段（docs/06）
-
-- **动机**：`/admin/keys` 创建的密钥只有不透明的 `prefix`，运营者记不住某把 key 属于哪个项目。新增 `api_keys.name`——**纯展示标签，绝非鉴权/路由输入**（与 budgets/memory 同档：present-but-nullable）。迁移 **sqlite v19 / pg v18**（additive nullable，pg `ADD COLUMN IF NOT EXISTS`）。
-- **贯穿全栈一处加字段**：3 个 Zod schema 共用 `KeyNameSchema = z.string().trim().min(1).max(100)`（**服务端 trim**：`.trim()` 在 `.min(1)` 前跑，纯空白塌成 `""` 被拒、padded 标签落库归一——Codex P3 修复）；record `.nullable().default(null)`（`.default(null)` 让 legacy 行/既有 fixture 仍解析）；create `.optional()`；update `.nullable().optional()` = 省略不动 / null 清空 → ports `CreateKeyInput.name?` / `KeyPatch.name?:string|null` → 两个 keystore 的 create/update/toRecord → admin route POST/PATCH/toSummary + `KeySummary` → admin api client（`ApiKeyView`/`normalizeView` 读侧也 trim/`toServerBody` 空串不发）→ Create/Edit 对话框（trim，空=null 清空；Edit 预填可改）→ keys 列表新增 **Name 列**（空显示 `Unnamed` 占位）。
-- **i18n**：新增 `Name`/`Unnamed`/帮助句三键，`pnpm i18n:extract`+`i18n:update` 机械登记后手译 zh-hans/zh-hant/ja/ko（占位符复用既有 `Optional`，少一键）。
-- **坑（测试侧，三类）**：① 最小种子迁移测试（sqlite schema.test.ts 第 28 例、memory-schema.test.ts、pg migrate.test.ts）按既有约定把**触及 api_keys 的迁移预标记为已应用**（种子无 api_keys 表）——v19/v18 必须并入预标记集，否则 `ALTER api_keys` 撞「无表」。② 6 个 gateway 测试各自的 `ApiKeyRecord` fixture 字面量缺 `name`（现为 required）→ 补 `name:null`。③ api client 测试**复用单个 `Response` 实例**（body 单次可读）→ 双调用改 `mockResolvedValueOnce` 各给新 Response。
-- **验证**：typecheck / build / svelte-check 全绿；my 改动文件 biome 干净（仓库残留的 reflector-facts noUnusedImports 错误非本次引入）。满载并行下 PGlite(pg) 测试偶发 5s 超时（每跑失败集不同）——隔离串行跑 54/54 全过，确认是 wasm 负载抖动而非逻辑回归。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-06 · API key 增加可编辑 name 字段（docs/06）：新增 `api_keys.name`（纯展示标签，非鉴权/路由）+迁移 sqlite v19/pg v18（additive nullable）；3 个 schema 共用 `KeyNameSchema=z.string().trim().min(1).max(100)`（服务端 trim，纯空白塌成 "" 被拒——Codex P3）；record `.nullable().default(null)`、create `.optional()`、update `.nullable().optional()`(null 清空)；贯穿 ports/两 keystore/admin route(POST/PATCH/toSummary)/api client(normalizeView 读侧也 trim)/Create+Edit 对话框/列表 Name 列(空显 Unnamed)。坑：最小种子迁移测试须把 v19/v18 并入预标记集（种子无 api_keys 表）；6 个 gateway fixture 补 `name:null`；api client 测试复用单 Response(body 单读)→ mockResolvedValueOnce。
 
 ### 2026-06-05 · live 集成测试上线记忆段 + 脱敏器吞数字计数的生产 bug（scripts/integration-live.mjs；docs/07/08/12）：integration-live 新增「Memory middleware」段（observe/inject/写回/fail-open/default-safe/不泄漏正文哨兵）首跑即抓真 bug——脱敏器把 `memory_tokens_injected` 数字计数 mangle 成对象 → DecisionRecord 解析失败 → `/admin/api/requests` 整页 502（#41 起潜伏，fake store 不过脱敏回环故单测/e2e 全未踩）。双侧修：写侧 redactNode 放行 secret-key 命中的标量（number/bool/null 不携凭证，顺救 max_tokens），读侧 schema 对 legacy 损坏行 preprocess→0、非 legacy 垃圾仍 fail-closed。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -14,6 +14,7 @@
 - **parse-default vs mint-default 分离（沿用 memory_mode 既有模式）**：docs/06 列的是 schema parse-defaults（off/header，照旧准确，不动）；docs/08 列的是新 key mint 行为（inject/auto），只改这一行 `(default header) → (default auto — new keys)`。两文档各自内部自洽。
 - **admin UI 诚实化**：`KeyCapsForm.emptyKeyCaps` 的 thread source `'header' → 'auto'` + `CreateKeyDialog` 省略 guard `!== 'header' → !== 'auto'`——下拉默认显示 **Auto** = 实际落库值，**避免重蹈 memory_mode 的 UI 错位**（emptyKeyCaps `memoryMode:'off'` + guard `!=='off'` 省略 → keystore 实际 mint `inject`，UI 显示 Off 却落 inject；本次不碰该 pre-existing 错位，仅 thread source 做对）。EditKeyDialog 不动（按存储值预填）。
 - **测试/验证**：`store-contract`（真 sqlite+pglite keystore）断言无记忆字段 create → `memory_thread_source === "auto"`；`schema.test` 维持 parse-default `header`（未动）；admin/ports 的 **fake keystore 保守桩仍 `?? "header"`**（与其 `memoryMode ?? "off"` 桩一致，本就不冒充真 mint 默认，不动）；`memory-scope` 测试显式传 threadSource、两分支俱存，未受影响。typecheck/build/svelte-check 全绿，101 store-contract+keystore 串行通过。
+- **Codex review 修复（2 项）**：(P2) `bootstrapRootKey` 不传记忆字段 → 继承新默认会让 root key 落 `inject`+`auto`；但 root key 是**管理/引导面**（日志明示「勿用于生产流量」），显式置 `memoryMode:"off"`+`memoryThreadSource:"header"` 让其记忆惰性（+bootstrap 测试断言 off/header）。inject 根因来自 #106，本 PR 的 auto 放大了它，就地一并堵上。(P3) 请求层 contract 注释（`ports.CreateKeyInput` / `CreateKeyRequest` / admin api `CreateKeyInput`）自 #106 起仍写「Omitted => off / memory stays off」属误导——改为如实写「省略 ⇒ keystore mint 新 key 默认 inject/auto」。**fake keystore 保守桩**（无测试依赖真 mint 默认，真值由 store-contract 对真 keystore 覆盖）与 **docs/06**（记的是 record schema parse-default off/header，仍准）维持不动。
 
 ---
 

--- a/packages/core/src/auth/bootstrap.test.ts
+++ b/packages/core/src/auth/bootstrap.test.ts
@@ -23,6 +23,16 @@ describe("bootstrapRootKey", () => {
     expect(all[0]?.role).toBe("root");
   });
 
+  it("root key opts OUT of memory (management plane: no inject/auto-thread)", async () => {
+    const keyStore = freshKeyStore();
+    await bootstrapRootKey({ keyStore, generateKey, now: () => new Date(), log: () => {} });
+    const stored = (await keyStore.list())[0];
+    // Despite the keystore minting inject/auto for normal new keys, the bootstrap
+    // root key is explicitly management-plane and must stay memory-inert.
+    expect(stored?.memory_mode).toBe("off");
+    expect(stored?.memory_thread_source).toBe("header");
+  });
+
   it("prints the plaintext exactly once and never persists it", async () => {
     const keyStore = freshKeyStore();
     const fixed = generateKey();

--- a/packages/core/src/auth/bootstrap.ts
+++ b/packages/core/src/auth/bootstrap.ts
@@ -36,6 +36,12 @@ export async function bootstrapRootKey(deps: BootstrapDeps): Promise<BootstrapRe
     accountId: "acct_default",
     role: "root",
     allowCustomModel: true,
+    // The root key is the management/bootstrap plane ("do not use for production
+    // traffic", logged below) — opt it OUT of the new-key memory mint defaults
+    // (mode "inject" / thread_source "auto"). A management key must never
+    // observe/inject memory or derive conversation threads from request signals.
+    memoryMode: "off",
+    memoryThreadSource: "header",
   });
 
   // Print the plaintext exactly once for the operator to capture.

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -125,8 +125,9 @@ export interface CreateKeyInput {
   degradeLane?: string;
   // Max in-flight requests (issue #93). Omitted => stored NULL => unlimited.
   concurrencyLimit?: number;
-  // Per-key memory defaults (issue #97). Omitted => off / none / header — memory
-  // stays off for this key; explicit x-memory-* headers always override.
+  // Per-key memory defaults (issue #97). Omitted => the keystore mints the NEW-KEY
+  // defaults (mode "inject", project none, thread_source "auto"); pass these
+  // explicitly to opt out. Explicit x-memory-* headers always override.
   memoryMode?: "off" | "observe" | "inject";
   memoryProjectId?: string;
   memoryThreadSource?: "header" | "auto";

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -47,7 +47,9 @@ export class PgKeyStore implements KeyStore {
       // override (e.g. "off"/"observe"). Existing keys keep their stored value.
       memoryMode: input.memoryMode ?? "inject",
       memoryProjectId: input.memoryProjectId ?? null,
-      memoryThreadSource: input.memoryThreadSource ?? "header",
+      // undefined => "auto": a memory-on key derives its thread from client signals
+      // out of the box (issue #97). Pass "header" explicitly to opt out.
+      memoryThreadSource: input.memoryThreadSource ?? "auto",
       createdAt: this.now().getTime(),
     };
     await this.db.insert(apiKeys).values(row);

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -46,7 +46,9 @@ export class SqliteKeyStore implements KeyStore {
       // override (e.g. "off"/"observe"). Existing keys keep their stored value.
       memoryMode: input.memoryMode ?? "inject",
       memoryProjectId: input.memoryProjectId ?? null,
-      memoryThreadSource: input.memoryThreadSource ?? "header",
+      // undefined => "auto": a memory-on key derives its thread from client signals
+      // out of the box (issue #97). Pass "header" explicitly to opt out.
+      memoryThreadSource: input.memoryThreadSource ?? "auto",
       createdAt: this.now(),
     };
     this.db.insert(apiKeys).values(row).run();

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -337,9 +337,10 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(got?.rate_limit_rpm).toBe(9);
     });
 
-    it("memory defaults (issue #97): omitted -> inject/null/header, set at create round-trips, updateKey edits + clears", async () => {
+    it("memory defaults (issue #97): omitted -> inject/null/auto, set at create round-trips, updateKey edits + clears", async () => {
       ctx = await make();
-      // omitted -> a new key opts INTO memory by default (mode inject)
+      // omitted -> a new key opts INTO memory by default (mode inject) and derives
+      // its thread automatically (thread source auto), so memory works out of the box
       await ctx.stores.keys.createKey({
         keyId: "k1",
         hash: "h1",
@@ -350,7 +351,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       let got = await ctx.stores.keys.getByHash("h1");
       expect(got?.memory_mode).toBe("inject");
       expect(got?.memory_project_id).toBeNull();
-      expect(got?.memory_thread_source).toBe("header");
+      expect(got?.memory_thread_source).toBe("auto");
       // set at create
       await ctx.stores.keys.createKey({
         keyId: "k2",

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -13,11 +13,13 @@ export const KeyRoleSchema = z.enum(["root", "user"]);
 export const OverBudgetBehaviorSchema = z.enum(["degrade", "reject"]);
 
 // Where the memory THREAD anchor comes from when x-thread-id is absent (issue #97).
-// `header` (default): only the explicit header — exactly the pre-#97 behavior.
 // `auto`: derive from signals the client already sends (body metadata.thread_id /
 // conversation_id → x-session-key → OpenAI prompt_cache_key → Anthropic
 // metadata.user_id) so static-header-only clients (Claude Code / Codex) and
-// zero-config clients still get per-conversation memory.
+// zero-config clients still get per-conversation memory. `header`: only the explicit
+// x-thread-id header (opt out of derivation — the pre-#97 behavior). NEW keys are
+// minted with `auto` (set in the keystores, mirroring memory_mode minting `inject`)
+// so a key works out of the box the moment memory is on; moot while memory is off.
 export const MemoryThreadSourceSchema = z.enum(["header", "auto"]);
 
 // Human-readable key label (docs/06) — cosmetic only, never an auth/routing input.
@@ -80,6 +82,10 @@ export const ApiKeyRecordSchema = z.object({
   // rows predating the migration still parse with memory off.
   memory_mode: MemoryModeSchema.default("off"),
   memory_project_id: z.string().min(1).nullable().default(null),
+  // Zod parse-default is the conservative `header` (legacy rows / record fixtures
+  // that omit the column — mirrors memory_mode parse-defaulting to `off`). NEW keys
+  // are minted with `auto` in the keystores, so a memory-on key derives its thread
+  // out of the box; existing keys keep their stored value.
   memory_thread_source: MemoryThreadSourceSchema.default("header"),
 });
 

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -122,8 +122,9 @@ export const CreateKeyRequestSchema = z
     // Optional max in-flight requests at mint time. Omitted => unlimited (null);
     // must be strictly positive (0 rejected — null already means unlimited).
     concurrency_limit: z.number().int().positive().optional(),
-    // Optional per-key memory defaults at mint time (issue #97). Omitted => memory
-    // off (zero behavior change). Explicit x-memory-* headers always override.
+    // Optional per-key memory defaults at mint time (issue #97). Omitted => the
+    // keystore mints the NEW-KEY defaults (mode "inject", thread_source "auto"); pass
+    // these explicitly to opt out. Explicit x-memory-* headers always override.
     memory_mode: MemoryModeSchema.optional(),
     memory_project_id: z.string().min(1).optional(),
     memory_thread_source: MemoryThreadSourceSchema.optional(),


### PR DESCRIPTION
## What & why

New keys already default to `memory_mode=inject` (memory is on out of the box, PR #106). But they still minted with `memory_thread_source=header`, so a memory-on key did **not** auto-derive its thread — it required an explicit `x-thread-id`. That defeats zero-config per-conversation memory for static-header clients (Claude Code / Codex): memory was "on" but effectively inert.

This flips the **new-key mint default** for thread source from `header` → `auto`, so memory genuinely works out of the box the moment a key is created.

## Scope: new keys only

- **Keystore mint-default** `?? "header"` → `?? "auto"` in both adapters (sqlite + pg), sitting right next to `memoryMode ?? "inject"` — same lever, same pattern.
- **Zod `ApiKeyRecordSchema` parse-default stays `header`** (legacy rows / record fixtures that omit the column), mirroring exactly how `memory_mode` keeps its `off` parse-default while minting `inject`. So:
  - existing keys keep their stored value — **no migration, no backfill**;
  - `docs/06` (schema parse-defaults: `off`/`header`) stays accurate; `docs/08` (new-key mint behavior) updated to `auto — new keys`.

## Admin UI honesty

The create dialog's thread-source dropdown now defaults to **Auto** (`emptyKeyCaps` + the "omit the default" guard), so the UI reflects what the key actually becomes — avoiding the pre-existing `memory_mode` mismatch (dropdown shows "Off" but the key mints `inject`), which is left untouched here. The edit dialog is unchanged (pre-fills from the stored value).

## Tests & verification

- `store-contract.test.ts` (real sqlite **and** pglite keystores) now asserts a memory-field-less `createKey` yields `memory_thread_source === "auto"`.
- `schema.test.ts` keeps asserting the `header` parse-default (unchanged); `memory-scope` resolver tests pass `threadSource` explicitly (both branches still covered).
- `pnpm typecheck` ✅ · `pnpm build` ✅ · `svelte-check` ✅ (0 errors) · changed files biome-clean. 101 store-contract + keystore tests pass serially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)