### PR TITLE
feat(admin): persist classifier/lanes/policies edits back to YAML

### DIFF
--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -121,9 +121,10 @@ test.describe("admin request list filtering + pagination", () => {
       .filter({ has: page.locator(`a[href$="/requests/${SEED_TRACE_ID}"]`) });
     await expect(seededRow).toBeVisible();
 
-    // Filter controls + numbered pager are present.
+    // Filter controls + numbered pager are present. The date range is the shared
+    // RangeFilter preset-button row (testid range-<key>), not a select.
     await expect(page.getByTestId("filter-status")).toBeVisible();
-    await expect(page.getByTestId("filter-range")).toBeVisible();
+    await expect(page.getByTestId("range-24h")).toBeVisible();
     // Only the one seeded row exists → single page, Next disabled.
     await expect(page.getByTestId("pager-status")).toContainText("1 requests");
     await expect(page.getByTestId("pager-next")).toBeDisabled();

--- a/apps/gateway/e2e/fixtures/test-server.ts
+++ b/apps/gateway/e2e/fixtures/test-server.ts
@@ -2,7 +2,7 @@
 // tests don't have to scrape the bootstrap log. Provider base_url points at the
 // local mock upstream. Offline + deterministic.
 
-import { mkdirSync, rmSync } from "node:fs";
+import { cpSync, mkdirSync, rmSync } from "node:fs";
 import { hashKey } from "@helm/core";
 import { serve } from "@hono/node-server";
 import type Database from "better-sqlite3";
@@ -83,7 +83,10 @@ await keyStore.createKey({
 const telemetry = new SqliteTelemetryStore(seedDb);
 await telemetry.insert({
   apiKeyId: "k_e2e",
-  createdAt: new Date("2026-05-31T00:00:00.000Z"),
+  // One hour ago, NOT a fixed date: the requests list defaults to a 24h window,
+  // so a hard-coded timestamp silently ages out of view and the admin specs
+  // start failing (time bomb — happened with the original 2026-05-31 seed).
+  createdAt: new Date(Date.now() - 3_600_000),
   decision: {
     request_id: SEED_TRACE_ID,
     trace_id: SEED_TRACE_ID,
@@ -123,12 +126,17 @@ await telemetry.insert({
 (seedDb as unknown as { $sqlite: Database.Database }).$sqlite.close();
 
 const { buildServer } = await import("../../src/server.js");
-// Resolve the repo-root config dir regardless of cwd. The eval e2e raises the
-// effective Layer-1 confidence threshold PER REQUEST via the e2e-only
+// Boot from a THROWAWAY COPY of the repo-root config dir (fresh each run, like
+// the DB above): admin rule edits now WRITE BACK to config/*.yaml (yaml-writeback),
+// so e2e admin saves (e.g. the lane edit in admin.spec) must land in the copy —
+// never in the checked-in config. The eval e2e additionally raises the effective
+// Layer-1 confidence threshold PER REQUEST via the e2e-only
 // `x-helm-rules-threshold` header (gated by HELM_E2E) so it reaches Layer-2 eval
-// WITHOUT mutating the checked-in config — other specs (routing) keep the spec
+// without any config mutation at all — other specs (routing) keep the spec
 // default 0.45. See implementation-notes (2026-05-31 · e2e.eval).
-const configDir = new URL("../../../../config", import.meta.url).pathname;
+const repoConfigDir = new URL("../../../../config", import.meta.url).pathname;
+const configDir = `${DATA_DIR}/config`;
+cpSync(repoConfigDir, configDir, { recursive: true });
 const { app, port, host } = await buildServer({ configDir });
 serve({ fetch: app.fetch, port, hostname: host });
 process.stdout.write(`e2e gateway listening on ${host}:${port}\n`);

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -15,6 +15,7 @@
     "@hono/node-server": "^2.0.4",
     "@hono/swagger-ui": "^0.6.1",
     "hono": "^4.12.23",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/gateway/src/routes/admin/rule-store.test.ts
+++ b/apps/gateway/src/routes/admin/rule-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRuntimeRuleStore } from "./rule-store.js";
+
+// Runtime RuleStore + YAML persistence ordering. The persist hook is the
+// fail-closed gate: it runs BEFORE the in-memory rebind, so a YAML write failure
+// rejects the set* call and leaves the live config (and onChange listeners)
+// untouched — file and memory never diverge (CLAUDE.md principle 2).
+
+const CLASSIFIER_A = { rules: { enabled: true }, eval: { enabled: false } } as never;
+const CLASSIFIER_B = { rules: { enabled: true }, eval: { enabled: true } } as never;
+
+describe("createRuntimeRuleStore — persist hooks", () => {
+  it("persists BEFORE rebinding, then notifies onChange", async () => {
+    const calls: string[] = [];
+    const store = createRuntimeRuleStore({
+      lanes: {},
+      policies: { policies: [] },
+      classifier: CLASSIFIER_A,
+      persistClassifier: async () => {
+        calls.push("persist");
+      },
+      onClassifier: () => {
+        calls.push("rebind");
+      },
+    });
+
+    await store.setClassifier(CLASSIFIER_B);
+    expect(calls).toEqual(["persist", "rebind"]);
+    expect(await store.getClassifier()).toBe(CLASSIFIER_B);
+  });
+
+  it("a persist failure rejects and leaves the live value + listeners untouched (fail-closed)", async () => {
+    const onClassifier = vi.fn();
+    const store = createRuntimeRuleStore({
+      lanes: {},
+      policies: { policies: [] },
+      classifier: CLASSIFIER_A,
+      persistClassifier: async () => {
+        throw new Error("EACCES: read-only config dir");
+      },
+      onClassifier,
+    });
+
+    await expect(store.setClassifier(CLASSIFIER_B)).rejects.toThrow("EACCES");
+    expect(await store.getClassifier()).toBe(CLASSIFIER_A); // unchanged
+    expect(onClassifier).not.toHaveBeenCalled();
+  });
+
+  it("lanes + policies follow the same contract", async () => {
+    const persistLanes = vi.fn().mockRejectedValue(new Error("disk full"));
+    const persistPolicies = vi.fn().mockResolvedValue(undefined);
+    const store = createRuntimeRuleStore({
+      lanes: { balanced: { primary: "a/b" } as never },
+      policies: { policies: [] },
+      classifier: CLASSIFIER_A,
+      persistLanes,
+      persistPolicies,
+    });
+
+    await expect(store.setLanes({} as never)).rejects.toThrow("disk full");
+    expect(Object.keys(await store.getLanes())).toEqual(["balanced"]); // unchanged
+
+    const nextPolicies = { policies: [{ match: {}, use_lane: "json" }] } as never;
+    await store.setPolicies(nextPolicies);
+    expect(persistPolicies).toHaveBeenCalledWith(nextPolicies);
+    expect(await store.getPolicies()).toBe(nextPolicies);
+  });
+
+  it("without persist hooks behaves exactly as before (in-memory only)", async () => {
+    const store = createRuntimeRuleStore({
+      lanes: {},
+      policies: { policies: [] },
+      classifier: CLASSIFIER_A,
+    });
+    await store.setClassifier(CLASSIFIER_B);
+    expect(await store.getClassifier()).toBe(CLASSIFIER_B);
+  });
+});

--- a/apps/gateway/src/routes/admin/rule-store.ts
+++ b/apps/gateway/src/routes/admin/rule-store.ts
@@ -2,12 +2,14 @@ import type { Lane, PoliciesConfig } from "@helm/core";
 import type { ClassifierConfig } from "@helm/shared";
 import type { RuleStore } from "./deps.js";
 
-// Runtime (in-process) RuleStore — the MVP backing for the admin rule-config
-// endpoints. The task explicitly permits "config/*.yaml or a runtime ConfigStore";
-// this is the latter: edits update the live in-memory config the router reads, so
-// changes take effect without a restart. Per CLAUDE.md Principle 2 the canonical persistence target is
-// still the rule config (NOT the DB). A future YAML write-back adapter can replace
-// this without touching the routes (they depend only on the RuleStore interface).
+// Runtime RuleStore backing the admin rule-config endpoints. Edits update the
+// live in-memory config the router reads (no restart), and — when the optional
+// `persist*` hooks are wired (yaml-writeback.ts) — are FIRST written back to the
+// canonical config/*.yaml (CLAUDE.md Principle 2: the file, not the DB, is the
+// persistence target). Ordering is FAIL-CLOSED: persist BEFORE rebind, so a
+// failed write rejects the set* call with the live config (and onChange
+// listeners) untouched — file and memory never diverge, and a restart re-loads
+// exactly what the operator last saved.
 //
 // `onChange` callbacks let the caller re-bind the live routing closures (lanes /
 // policies / classifier) so an admin edit is observed by subsequent requests.
@@ -18,6 +20,10 @@ export interface RuntimeRuleStoreInit {
   onLanes?: (lanes: Record<string, Lane>) => void;
   onPolicies?: (policies: PoliciesConfig) => void;
   onClassifier?: (cfg: ClassifierConfig) => void;
+  // Optional write-back to the canonical yaml files. Throwing aborts the edit.
+  persistLanes?: (lanes: Record<string, Lane>) => Promise<void>;
+  persistPolicies?: (policies: PoliciesConfig) => Promise<void>;
+  persistClassifier?: (cfg: ClassifierConfig) => Promise<void>;
 }
 
 export function createRuntimeRuleStore(init: RuntimeRuleStoreInit): RuleStore {
@@ -27,16 +33,19 @@ export function createRuntimeRuleStore(init: RuntimeRuleStoreInit): RuleStore {
   return {
     getLanes: async () => lanes,
     setLanes: async (next) => {
+      await init.persistLanes?.(next);
       lanes = next;
       init.onLanes?.(next);
     },
     getPolicies: async () => policies,
     setPolicies: async (next) => {
+      await init.persistPolicies?.(next);
       policies = next;
       init.onPolicies?.(next);
     },
     getClassifier: async () => classifier,
     setClassifier: async (next) => {
+      await init.persistClassifier?.(next);
       classifier = next;
       init.onClassifier?.(next);
     },

--- a/apps/gateway/src/routes/admin/yaml-writeback.test.ts
+++ b/apps/gateway/src/routes/admin/yaml-writeback.test.ts
@@ -1,0 +1,174 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import { createYamlRulePersister } from "./yaml-writeback.js";
+
+// yaml-writeback — the YAML write-back adapter foreshadowed in rule-store.ts:
+// admin rule edits (lanes / policies / classifier) persist to config/*.yaml so
+// the FILE stays the canonical config (CLAUDE.md principle 2, 配置即代码) and a
+// restart re-loads exactly what the operator saved. Writes are comment-PRESERVING
+// (yaml Document API — the shipped files are heavily documented) and atomic
+// (tmp + rename, never a torn file). A write failure THROWS so the route can
+// fail-closed (500, live config unchanged) — file and memory never diverge.
+
+const LANES_FIXTURE = `# lanes.yaml — top-of-file comment that must survive writes.
+economy:
+  # economy lane comment
+  purpose: Cheap and fast
+  primary: deepseek/deepseek-v4-flash
+  fallback:
+    - balanced
+
+balanced:
+  purpose: Default tradeoff
+  primary: deepseek/deepseek-v4-pro
+  fallback: []
+`;
+
+const POLICIES_FIXTURE = `# policies.yaml — header comment that must survive writes.
+policies:
+  - match: { needs_json: true }
+    use_lane: json
+`;
+
+const CLASSIFIER_FIXTURE = `# classifier.yaml — header comment that must survive writes.
+classifier:
+  rules:
+    enabled: true
+    # threshold comment that must survive a value edit on the SAME key
+    confidence_threshold: 0.42
+    sigmoid_k: 12
+  eval:
+    enabled: false
+    model: deepseek-v4-flash
+`;
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "helm-yaml-writeback-"));
+  writeFileSync(join(dir, "lanes.yaml"), LANES_FIXTURE);
+  writeFileSync(join(dir, "policies.yaml"), POLICIES_FIXTURE);
+  writeFileSync(join(dir, "classifier.yaml"), CLASSIFIER_FIXTURE);
+});
+
+afterEach(() => {
+  // restore perms so rm never fails after the read-only test
+  chmodSync(dir, 0o755);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("createYamlRulePersister — classifier", () => {
+  it("updates edited values in place, preserving comments and untouched keys", async () => {
+    const p = createYamlRulePersister(dir);
+    await p.persistClassifier({
+      rules: { enabled: true, confidence_threshold: 0.5, sigmoid_k: 12 },
+      eval: { enabled: true, model: "deepseek-v4-flash" },
+    } as never);
+
+    const text = readFileSync(join(dir, "classifier.yaml"), "utf8");
+    expect(text).toContain("header comment that must survive writes");
+    expect(text).toContain("threshold comment that must survive");
+
+    const parsed = parseYaml(text) as {
+      classifier: {
+        rules: { confidence_threshold: number; sigmoid_k: number };
+        eval: { enabled: boolean; model: string };
+      };
+    };
+    expect(parsed.classifier.rules.confidence_threshold).toBe(0.5);
+    expect(parsed.classifier.eval.enabled).toBe(true);
+    // untouched siblings survive
+    expect(parsed.classifier.rules.sigmoid_k).toBe(12);
+    expect(parsed.classifier.eval.model).toBe("deepseek-v4-flash");
+  });
+
+  it("leaves no tmp file behind (atomic rename)", async () => {
+    const p = createYamlRulePersister(dir);
+    await p.persistClassifier({ rules: { enabled: true }, eval: { enabled: false } } as never);
+    const leftovers = readdirSync(dir).filter((f) => f.includes(".tmp"));
+    expect(leftovers).toEqual([]);
+  });
+});
+
+describe("createYamlRulePersister — lanes (flat top-level map)", () => {
+  it("edits, adds and DELETES lanes so the file mirrors the saved set exactly", async () => {
+    const p = createYamlRulePersister(dir);
+    await p.persistLanes({
+      economy: { purpose: "Cheap and fast", primary: "openrouter/x", fallback: ["balanced"] },
+      premium: { purpose: "Best quality", primary: "anthropic/claude", fallback: [] },
+      // `balanced` intentionally absent -> must be deleted from the file
+    } as never);
+
+    const text = readFileSync(join(dir, "lanes.yaml"), "utf8");
+    expect(text).toContain("top-of-file comment that must survive");
+    expect(text).toContain("economy lane comment"); // comment on a surviving, edited lane
+
+    const parsed = parseYaml(text) as Record<string, { primary: string } | undefined>;
+    expect(parsed.economy?.primary).toBe("openrouter/x");
+    expect(parsed.premium?.primary).toBe("anthropic/claude");
+    expect(parsed.balanced).toBeUndefined();
+    expect(Object.keys(parsed).sort()).toEqual(["economy", "premium"]);
+  });
+});
+
+describe("createYamlRulePersister — policies", () => {
+  it("replaces the policies list, preserving the header comment", async () => {
+    const p = createYamlRulePersister(dir);
+    await p.persistPolicies({
+      policies: [
+        { match: { task_type: "coding" }, use_lane: "coding" },
+        { match: {}, max_lane: "balanced" },
+      ],
+    } as never);
+
+    const text = readFileSync(join(dir, "policies.yaml"), "utf8");
+    expect(text).toContain("header comment that must survive");
+    const parsed = parseYaml(text) as { policies: Array<Record<string, unknown>> };
+    expect(parsed.policies).toHaveLength(2);
+    expect(parsed.policies[0]).toMatchObject({ use_lane: "coding" });
+  });
+});
+
+describe("createYamlRulePersister — edge cases", () => {
+  it("creates the file when it does not exist yet", async () => {
+    const fresh = mkdtempSync(join(tmpdir(), "helm-yaml-fresh-"));
+    try {
+      const p = createYamlRulePersister(fresh);
+      await p.persistLanes({
+        balanced: { purpose: "d", primary: "a/b", fallback: [] },
+      } as never);
+      expect(existsSync(join(fresh, "lanes.yaml"))).toBe(true);
+      const parsed = parseYaml(readFileSync(join(fresh, "lanes.yaml"), "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(parsed.balanced).toBeDefined();
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  });
+
+  it("THROWS on an unwritable config dir (fail-closed: the route must 500)", async () => {
+    chmodSync(dir, 0o555); // read + execute only
+    const p = createYamlRulePersister(dir);
+    await expect(
+      p.persistClassifier({ rules: { enabled: true }, eval: { enabled: false } } as never),
+    ).rejects.toThrow();
+    // the original file is untouched
+    const parsed = parseYaml(readFileSync(join(dir, "classifier.yaml"), "utf8")) as {
+      classifier: { eval: { enabled: boolean } };
+    };
+    expect(parsed.classifier.eval.enabled).toBe(false);
+  });
+});

--- a/apps/gateway/src/routes/admin/yaml-writeback.ts
+++ b/apps/gateway/src/routes/admin/yaml-writeback.ts
@@ -1,0 +1,125 @@
+import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Lane, PoliciesConfig } from "@helm/core";
+import type { ClassifierConfig } from "@helm/shared";
+import { Document, isMap, parseDocument, type YAMLMap } from "yaml";
+
+// YAML write-back adapter — the "future adapter" foreshadowed in rule-store.ts.
+// Admin rule edits (lanes / policies / classifier) persist to config/*.yaml so the
+// FILE stays the canonical config (CLAUDE.md principle 2, 配置即代码): a restart
+// re-loads exactly what the operator saved, and `docker compose` operators keep a
+// single source of truth under ./config.
+//
+// Three properties the routes rely on:
+//   • COMMENT-PRESERVING — the shipped yamls are heavily documented; edits go
+//     through the yaml Document API (in-place `setIn` on existing nodes keeps
+//     their comments) instead of a destructive parse → dump round-trip.
+//   • ATOMIC — write to a same-dir tmp file then rename, so a crash mid-write can
+//     never leave a torn file for the next boot's fail-closed loader to reject.
+//   • FAIL-CLOSED — any error THROWS to the caller; the RuleStore persists BEFORE
+//     rebinding, so a failed write returns 500 with the live config unchanged and
+//     file/memory never diverge.
+//
+// File shapes mirror the loader (packages/core/src/config/loader.ts):
+//   lanes.yaml      = FLAT map  (lane name -> lane)  → mounted at config.lanes
+//   policies.yaml   = { policies: [...] }            → mounted at config.policies
+//   classifier.yaml = { classifier: {...} }          → mounted at config root
+
+export interface YamlRulePersister {
+  persistLanes(lanes: Record<string, Lane>): Promise<void>;
+  persistPolicies(policies: PoliciesConfig): Promise<void>;
+  persistClassifier(cfg: ClassifierConfig): Promise<void>;
+}
+
+// Deep-assign a plain object into the document at `path`, key by key, so existing
+// nested scalar nodes are UPDATED IN PLACE (their comments survive). Arrays and
+// scalars are set wholesale (an array edit replaces the sequence — per-item
+// comments inside a replaced list are the documented, accepted loss).
+function deepAssign(doc: Document, path: Array<string | number>, value: unknown): void {
+  if (isPlainObject(value) && isMap(doc.getIn(path, true))) {
+    for (const [k, v] of Object.entries(value)) {
+      deepAssign(doc, [...path, k], v);
+    }
+    // drop keys the new object no longer carries (e.g. a removed optional field)
+    const node = doc.getIn(path, true);
+    if (isMap(node)) {
+      for (const stale of staleKeys(node, value)) doc.deleteIn([...path, stale]);
+    }
+    return;
+  }
+  doc.setIn(path, value);
+}
+
+function staleKeys(node: YAMLMap, next: Record<string, unknown>): string[] {
+  const keep = new Set(Object.keys(next));
+  const stale: string[] = [];
+  for (const item of node.items) {
+    const key = String((item.key as { value?: unknown })?.value ?? item.key);
+    if (!keep.has(key)) stale.push(key);
+  }
+  return stale;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// Load the existing document (preserving its comments) or start a fresh one.
+function loadDoc(file: string): Document {
+  if (existsSync(file)) {
+    const doc = parseDocument(readFileSync(file, "utf8"));
+    // A torn/invalid file would silently round-trip its errors; refuse instead
+    // (fail-closed — the operator must fix the file before admin edits resume).
+    if (doc.errors.length > 0) {
+      throw new Error(`refusing to edit invalid yaml ${file}: ${doc.errors[0]?.message}`);
+    }
+    return doc;
+  }
+  return new Document({});
+}
+
+// Atomic write: same-dir tmp + rename. Cleans the tmp on failure (best-effort).
+function writeAtomic(file: string, text: string): void {
+  const tmp = `${file}.tmp-${process.pid}`;
+  try {
+    writeFileSync(tmp, text, "utf8");
+    renameSync(tmp, file);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // tmp never got created (e.g. EACCES on the dir) — nothing to clean
+    }
+    throw err;
+  }
+}
+
+export function createYamlRulePersister(configDir: string): YamlRulePersister {
+  const persist = (fileName: string, apply: (doc: Document) => void): void => {
+    const file = join(configDir, fileName);
+    const doc = loadDoc(file);
+    apply(doc);
+    writeAtomic(file, doc.toString());
+  };
+
+  return {
+    // lanes.yaml is a flat top-level map: the saved set REPLACES the file's lane
+    // set exactly — edited lanes update in place, new lanes append, lanes absent
+    // from the save are deleted (the admin delete action must reach the file).
+    persistLanes: async (lanes) => {
+      persist("lanes.yaml", (doc) => {
+        deepAssign(doc, [], lanes);
+      });
+    },
+    persistPolicies: async (policies) => {
+      persist("policies.yaml", (doc) => {
+        deepAssign(doc, [], { policies: policies.policies });
+      });
+    },
+    persistClassifier: async (cfg) => {
+      persist("classifier.yaml", (doc) => {
+        deepAssign(doc, ["classifier"], cfg);
+      });
+    },
+  };
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -105,6 +105,7 @@ import { anthropicMetadataUserId, stableSessionId } from "./oauth/device-identit
 import { effectiveOAuthModelOptions, type ModelOption } from "./oauth/effective-models.js";
 import { registerAdminApi } from "./routes/admin/index.js";
 import { createRuntimeRuleStore } from "./routes/admin/rule-store.js";
+import { createYamlRulePersister } from "./routes/admin/yaml-writeback.js";
 import { ADMIN_BUILD_ROOT, mountAdminStatic } from "./routes/admin-static.js";
 import { registerChatRoutes } from "./routes/chat.js";
 import { buildClassifyAdapter } from "./routes/classify.js";
@@ -1410,10 +1411,18 @@ export async function buildServer(
   // Otherwise it is NOT mounted at all (/admin and /admin/api → 404), so the
   // key-management + telemetry endpoints can never be reached unauthenticated.
   if (adminAuth.enabled) {
+    // Rule edits write back to the canonical config/*.yaml FIRST (comment-
+    // preserving, atomic, fail-closed — see yaml-writeback.ts), THEN rebind the
+    // live config. A failed write 500s with nothing changed, so the file always
+    // equals the running config and a restart re-loads exactly what was saved.
+    const yamlPersister = createYamlRulePersister(opts.configDir ?? "./config");
     const ruleStore = createRuntimeRuleStore({
       lanes: lanes as Record<string, Lane>,
       policies,
       classifier: classifierConfig,
+      persistLanes: yamlPersister.persistLanes,
+      persistPolicies: yamlPersister.persistPolicies,
+      persistClassifier: yamlPersister.persistClassifier,
       onLanes: (next) => {
         lanes = next as LanesConfig;
       },

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,18 @@
 
 ---
 
+## 2026-06-06 · 管理界面规则编辑写回 YAML（修复「保存只活在内存、重启即回滚」；用户决策；docs/11；CLAUDE.md 原则 2）
+
+- **Bug（用户报告）**：分类器/Lanes/Policies 三页的「保存」只经 `createRuntimeRuleStore` 重绑**内存变量**（rule-store.ts 自注 "MVP…future YAML write-back adapter"），不落任何持久层——重启即回滚到 yaml。其余面（System Settings → config_kv、Keys/OAuth → DB）本就持久，仅这三页挥发。
+- **方案（用户拍板：YAML 写回，文件即真相）**：新增 `yaml-writeback.ts`（gateway admin），三特性：**保留注释**（eemeli/yaml Document API，`setIn` 原位改值，发行 yaml 重注释不可毁）、**原子写**（同目录 tmp + rename，绝不留半截文件给 fail-closed loader）、**fail-closed**（写失败 throw）。`RuntimeRuleStoreInit` 加可选 `persist*` 钩子，**先持久化后重绑**——写失败 → 路由 500、live config 不动，文件与内存永不分叉；重启 loader 读回的就是上次保存值。server.ts 用 `opts.configDir` 构造 persister（仅 adminAuth.enabled 时）。
+- **文件形状对齐 loader**：lanes.yaml = 顶层平铺 map（保存集合**精确镜像**：改原位、增追加、**缺失即删**——admin 删 lane 必须落文件）；policies.yaml = `{policies:[...]}`（列表整体替换，列表内逐项注释为文档化可接受损失）；classifier.yaml = `classifier:` 包裹（逐 scalar 原位）。Zod round-trip 会把可选字段的显式默认写进文件（如 lane `constraints.require_*: false`）——无害、自文档化。
+- **e2e 防误伤（关键）**：test-server.ts 原以**仓库签入 config/ 为 configDir**——写回上线后 admin.spec 的 lane 保存会改库内文件！改为每次拷贝 config → `.e2e-data/config`（与 DB 同抛弃式）。已验证：UI 保存后编辑落在拷贝、仓库 config 无 diff。
+- **顺手修 admin.spec 两个 pre-existing 本地挂**（e2e 不在 CI 门禁，无人发现）：① 种子 DecisionRecord 写死 `2026-05-31` + 请求列表默认 24h 窗 → 种子行老化出窗（**定时炸弹**），改 `Date.now()-1h`；② spec 仍找 `filter-range` testid，但 06-03 已重构成共享 RangeFilter 预设按钮（`range-<key>`），改断言 `range-24h`。admin.spec 现 9/9 绿。
+- **验证**：新增 yaml-writeback.test（注释存活/原子/缺文件创建/只读目录 throw 且原文件不动）+ rule-store.test（persist 先于 rebind；persist 失败 → 旧值保持 + onChange 不调）共 10 例 TDD 先红后绿；typecheck/lint 净；全量单测仅 PGlite 已知并行 flake（隔离 103/103 绿）。gateway 新增直接依赖 `yaml@^2.9`。
+- **部署坑（la.atmy.work）**：`/opt/helm-api/config` 现为 **root 属主**，容器用户 10001 无写权限 → 管理界面保存会 fail-closed 500。上线本特性前需 `chown` config 目录（与 data/ 同 10001 属主）；fail-closed 设计保证权限没改好时只是保存报错，绝不静默分叉。
+
+---
+
 ## 2026-06-06 · 请求详情页「重试」按钮（可编辑重发 + 隔离重跑；用户决策；docs/07）
 
 - **动机**：线上调试（deepseek-v4-pro 把 5000 `max_tokens` 全烧在 reasoning，`finish:length`、正文为空，详情页正确显示「无可见输出」）后，需要在 admin 内「改一下（如调高 max_tokens）再发一次」并看新结果，无需离开界面/手搓 curl。
@@ -31,20 +43,11 @@
 
 ---
 
-## 2026-06-06 · 记忆 thread source 新 key 默认 auto（配合「记忆默认开启」；用户决策；docs/08）
-
-- **动机**：承接同日「记忆默认开启」（新 key `memory_mode` mint 默认 `inject`）。但 `memory_thread_source` 仍 mint 默认 `header`——新 key 记忆开了却**不自动推导 thread**（缺 `x-thread-id` 时不回退信号链 → 无 per-conversation 记忆），等于开了个寂寞。把新 key 的 thread source mint 默认翻 `header → auto`，让记忆真正开箱即用。
-- **范围 = 仅新 key（用户拍板，不迁移既有 key）**：改两个 keystore 的 `createKey` mint 默认 `?? "header" → ?? "auto"`（sqlite + pg），与紧邻的 `memoryMode ?? "inject"` 同一档（**mint-default**）。**Zod `ApiKeyRecordSchema.default("header")` 保持不动**（**parse-default**，镜像 `memory_mode` 的 `.default("off")`）——既有 key 列默认与已应用迁移仍 `header`、不重写。
-- **parse-default vs mint-default 分离（沿用 memory_mode 既有模式）**：docs/06 列的是 schema parse-defaults（off/header，照旧准确，不动）；docs/08 列的是新 key mint 行为（inject/auto），只改这一行 `(default header) → (default auto — new keys)`。两文档各自内部自洽。
-- **admin UI 诚实化**：`KeyCapsForm.emptyKeyCaps` 的 thread source `'header' → 'auto'` + `CreateKeyDialog` 省略 guard `!== 'header' → !== 'auto'`——下拉默认显示 **Auto** = 实际落库值，**避免重蹈 memory_mode 的 UI 错位**（emptyKeyCaps `memoryMode:'off'` + guard `!=='off'` 省略 → keystore 实际 mint `inject`，UI 显示 Off 却落 inject；本次不碰该 pre-existing 错位，仅 thread source 做对）。EditKeyDialog 不动（按存储值预填）。
-- **测试/验证**：`store-contract`（真 sqlite+pglite keystore）断言无记忆字段 create → `memory_thread_source === "auto"`；`schema.test` 维持 parse-default `header`（未动）；admin/ports 的 **fake keystore 保守桩仍 `?? "header"`**（与其 `memoryMode ?? "off"` 桩一致，本就不冒充真 mint 默认，不动）；`memory-scope` 测试显式传 threadSource、两分支俱存，未受影响。typecheck/build/svelte-check 全绿，101 store-contract+keystore 串行通过。
-- **Codex review 修复（2 项）**：(P2) `bootstrapRootKey` 不传记忆字段 → 继承新默认会让 root key 落 `inject`+`auto`；但 root key 是**管理/引导面**（日志明示「勿用于生产流量」），显式置 `memoryMode:"off"`+`memoryThreadSource:"header"` 让其记忆惰性（+bootstrap 测试断言 off/header）。inject 根因来自 #106，本 PR 的 auto 放大了它，就地一并堵上。(P3) 请求层 contract 注释（`ports.CreateKeyInput` / `CreateKeyRequest` / admin api `CreateKeyInput`）自 #106 起仍写「Omitted => off / memory stays off」属误导——改为如实写「省略 ⇒ keystore mint 新 key 默认 inject/auto」。**fake keystore 保守桩**（无测试依赖真 mint 默认，真值由 store-contract 对真 keystore 覆盖）与 **docs/06**（记的是 record schema parse-default off/header，仍准）维持不动。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-06 · 记忆 thread source 新 key 默认 auto（配合「记忆默认开启」；用户决策；docs/08）：新 key `memory_mode=inject` 却 thread source 仍 `header` = 缺 `x-thread-id` 不回退信号链、无 per-conversation 记忆——两 keystore `createKey` mint 默认 `?? "header" → ?? "auto"`（仅新 key；Zod parse-default `header` 不动，既有 key/迁移不重写）。admin UI 诚实化：KeyCapsForm/CreateKeyDialog 默认显 Auto = 实际落库值。Codex 修复：(P2) `bootstrapRootKey` 显式置 `off`+`header` 让 root key 记忆惰性（root key 勿用于生产流量）；(P3) CreateKeyInput 各层注释自 #106 起误写「omitted => off」→ 改如实「省略 ⇒ mint 默认 inject/auto」。
 
 ### 2026-06-06 · 记忆默认开启（eval 维持默认关闭——依赖已配置 eval 模型）（用户决策；docs/08）：只开记忆不开 eval——Layer-2 eval 客户端把 `model`(deepseek-v4-flash) 直发 providers[0]，无配好 DeepSeek 兼容 provider 时每个 uncertain 请求先打一通失败再 fail-open 回 balanced，故 eval **必须有可用模型才开**、留 per-deployment opt-in（原则 4）。memory 无全局开关：新 key `keystore.create` mint `off→inject`（sqlite+pg）+ 请求兜底 `memory-scope` `?? off → ?? inject`，**仅新 key+兜底、不迁移既有 key**（DB 列默认/迁移仍 off）；显式 `x-memory-mode` 仍优先、非法头归一 off，`inject` 在 threadId===null 时自闸 no-op。`config/memory.yaml enabled` 早前置 true 配套。测试 store-contract/memory-scope/messages.memory 随翻转，2474 绿；README+docs/01/02/08/12 记忆表述改「默认开启」、eval 维持「off by default」。
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       hono:
         specifier: ^4.12.23
         version: 4.12.23
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Problem
Clicking **Save** on the admin Classifier / Lanes / Policies pages only rebound the **in-memory** config (`createRuntimeRuleStore` — the MVP store self-documented as awaiting a "future YAML write-back adapter"). The edit took effect live but **never persisted**, so a service restart reverted everything to the on-disk YAML. The other admin surfaces already persist (System Settings → `config_kv`; Keys/Providers → DB); only these three rule pages were volatile.

## Fix (YAML write-back — the file stays canonical, 配置即代码 / principle 2)
- **`yaml-writeback.ts`** (new): saves write `config/{classifier,lanes,policies}.yaml` with three guarantees:
  - **Comment-preserving** — edits go through the `yaml` Document API (`setIn` in place), so the heavily-documented shipped files keep their comments instead of a destructive parse→dump.
  - **Atomic** — same-dir tmp file + rename, never a torn file for the next boot's fail-closed loader.
  - **Fail-closed** — any write error throws.
- **`rule-store.ts`**: optional `persist*` hooks run **before** the in-memory rebind. A failed write rejects the `set*` call with the live config (and `onChange` listeners) untouched — file and memory never diverge, and a restart re-loads exactly what was saved. Lanes deletion propagates to the file.
- **`server.ts`**: wire the persister from `opts.configDir` when admin is enabled.

## Collateral fixes
- **e2e isolation:** the e2e gateway pointed `configDir` at the **checked-in `config/`** — with write-back live, admin saves would mutate tracked files. Now boots from a throwaway copy under `.e2e-data/config` (like the DB). Verified: a UI lane-save lands in the copy, repo `config/` shows no diff.
- **Two pre-existing `admin.spec` failures** (e2e isn't in the CI gate, so they went unnoticed): a decision-record seeded with a fixed `2026-05-31` date that aged out of the requests list's default 24h window (time bomb → now `Date.now()-1h`), and a stale `filter-range` testid replaced by the shared RangeFilter preset buttons (`range-<key>`). admin.spec is now 9/9.

## Tests
- New TDD coverage (red→green): `yaml-writeback.test.ts` (comment survival, atomic no-tmp-leftover, file creation, **unwritable dir throws + original untouched**) and `rule-store.test.ts` (persist-before-rebind ordering; persist failure leaves live value + listeners untouched). **10/10 pass.**
- Full unit suite green (only the documented PGlite parallel flake; isolated re-run clean); typecheck + lint clean; admin e2e 9/9.
- Codex review: no blocking findings.

## ⚠️ Deployment prerequisite
On la.atmy.work, `/opt/helm-api/config` is **root-owned**; the container runs as user `10001` and cannot write it — saves would fail-closed with a 500. The config dir needs a `chown` to the container user (same as `data/`) before this ships. The fail-closed design means a missed chown only surfaces as a save error, never silent divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)