### PR TITLE
fix: 使用本地 pnpm store 加速自托管 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: pnpm
+          # The self-hosted Docker runners keep /home/runner/_work on a host
+          # volume. Do not use actions/cache here: it re-downloads a ~245MB pnpm
+          # cache from GitHub on every run and costs 2+ minutes on 199.4.
+          package-manager-cache: false
+      - name: Use persistent pnpm store on runner
+        run: pnpm config set store-dir /home/runner/_work/.pnpm-store
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm lint


### PR DESCRIPTION
## 改了什么
- CI 的 `actions/setup-node@v5` 禁用 `package-manager-cache`，避免每次从 GitHub cache 下载 pnpm store。
- 新增 `pnpm config set store-dir /home/runner/_work/.pnpm-store`，让 self-hosted Docker Runner 复用宿主机持久化 work volume 里的 pnpm store。

## 为什么改
- Run 27078038118 / job 79918684960 的 Step 4 里，Node 本身命中本地缓存：`/home/runner/_work/_tool/node/22.22.2/x64`。
- 真正慢的是 `Cache hit for: node-cache-Linux-x64-pnpm-...` 之后从 GitHub cache 下载约 245MB，199.4 上约 1.9MB/s，耗时 2 分多钟。
- 自托管 Runner 已经有持久化 `/home/runner/_work`，这里应该走本地 pnpm store，不该每次拉远端 cache。

## 验证
- 已查看目标 run log，确认慢点在 GitHub cache restore，不是 Node 安装。
- 本 PR 合入前用 CI 验证：预期 `Run actions/setup-node@v5` 不再出现 245MB cache download 进度。

## 风险
- 某台 Runner 首次没有本地 store 时，第一次 `pnpm install` 会正常联网填充 store；之后复用本地 store。
- 依赖缓存从 GitHub 远端 cache 改成本机 Runner 级别缓存，不影响 lockfile 校验。

— Trent 🏛️