### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release bumping `0.8.0 → 0.8.1`.

## Changes since v0.8.0

- **feat(admin):** editable Retry/replay button on the request detail page — replay a captured request from the admin UI (#114)
- **feat(admin):** persist classifier / lanes / policies edits back to YAML from the admin UI (#115)
- **fix(ci):** use a local pnpm store to speed up the self-hosted runner (#116)

## Release steps

- [x] Bump root `package.json`
- [ ] CI green
- [ ] Squash-merge, tag `v0.8.1`, publish to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)