### PR TITLE
docs: full accuracy audit against 0.8.0 code + README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 **English** · [简体中文](README.zh-CN.md)
 
-### One gateway in front of all your LLM providers — pick models by config, not code.
+### One gateway in front of every LLM provider. Pick models by config, not code.
 
 Open-source · self-hosted · MIT
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)](package.json)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](tsconfig.base.json)
 [![Built with Hono](https://img.shields.io/badge/gateway-Hono-ff5e00.svg)](https://hono.dev)
@@ -16,7 +17,9 @@ Open-source · self-hosted · MIT
 
 </div>
 
-Helm API is an open-source, self-hosted **LLM routing gateway** — think of it as **"nginx for the LLM world."** Your app sends a normal OpenAI, Anthropic, or Gemini request to Helm; a single declarative YAML config decides which model should handle it, calls that provider (switching to a backup if it fails), translates protocols as needed, and records every decision. Clients always see one standard interface and output shape, and only ever set their `base_url` and API key — all the routing lives in config you control.
+You maintain fallback logic, provider quirks, cost trade-offs, and model churn — copied into every client. That work belongs in one place, behind one interface.
+
+Helm API is that place: an open-source, self-hosted **LLM routing gateway** — *nginx for the LLM world*. Your app sends a normal OpenAI, Anthropic, or Gemini request. A declarative YAML config decides which model answers, fails over when a provider breaks, translates protocols both ways, and records every decision. Clients set a `base_url` and an API key. Nothing else.
 
 > **Manage traffic as configuration, not as code.**
 
@@ -26,30 +29,63 @@ client = OpenAI(base_url="http://localhost:8080/v1", api_key="<helm-key>")
 client.chat.completions.create(model="auto", messages=[...])   # Helm classifies and routes
 ```
 
----
+Change the model behind a lane? Edit one YAML line — or click in the dashboard. Your apps never notice.
 
-## Why Helm
+## Quickstart
 
-AI app developers don't want to manage hundreds of models, per-provider quirks, fallback behavior, cost trade-offs, and routing decisions inside every client. They want **one API that is cheap enough, reliable enough, sensible by default, and debuggable when something goes wrong.** Helm gives you that:
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/), or **Node ≥ 22** + **pnpm 10** to build from source.
 
-- **Change models without changing code.** Point a lane at a different model in a config file — your apps never notice.
-- **Two failure disciplines, applied deliberately.** Configuration and credentials are **fail-closed** — invalid config or a missing required key refuses to start, never runs half-configured. The request path is **fail-open** — any optional step that stumbles (classification, scoring, memory, cache) quietly degrades to the `balanced` lane; you only get a structured error when *every* provider is genuinely down.
-- **Safe by default.** API keys are stored only as SHA-256 hashes — plaintext never touches logs or telemetry. Rate limiting, usage budgets, the optional scoring model, and memory are all off until you turn them on.
-- **Every decision is observable.** Each request persists a redacted decision record — the lane it took, the model that answered, why, fallbacks, and cost — browsable in the dashboard. Full request/response payloads are captured to a separate local table (on by default, 30-day retention) for debugging and audit.
-- **Runs on your own infrastructure.** MIT-licensed, deployed with Docker. No SaaS, no multi-tenant cloud — nothing leaves your servers.
+```bash
+# 1. Clone and create your env file
+git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
+cp .env.example .env
+#    In .env, set HELM_ADMIN_PASSWORD and at least DEEPSEEK_API_KEY
 
-## Key concepts
+# 2. Start it
+docker compose up -d
 
-- **Lanes** — Requests route through configurable *lanes* (quality/cost tiers `economy`, `balanced`, `premium`, or task lanes `coding`, `json`, `vision`, `tool_use`), never raw provider names. You decide in config how each lane maps to a primary model plus a fallback chain. Provider aliases are an internal supply-chain detail, never the client-facing surface.
-- **Classification cascade** — Three layers pick the lane: **(1)** deterministic rules (a pure, zero-network, unit-tested scorer — always on); **(2)** an optional small-model "second opinion" eval (`temperature: 0`, cached, **off by default** — it needs a configured eval model), consulted only when the rules are uncertain; **(3)** the `balanced` lane as the fail-open sink.
-- **Two fallbacks, never conflated** — *Classification fallback* degrades an undecided request to the `balanced` lane; *execution fallback* swaps to the next model in the chain when a provider fails. They live in separate decision-record fields so you can always tell which one fired.
-- **Protocol translation** — Four inbound protocols normalize to one OpenAI-Chat-shaped internal representation (IR), so a single client reaches many backends and gets a consistent output shape — streaming SSE included.
-- **Config-as-code** — Behavior lives in `config/*.yaml`, Zod-validated at startup; an invalid file fails closed and the gateway refuses to boot.
-- **Headless core** — The entire routing brain (classification, routing, provider execution, protocol translation, storage) lives in `packages/core` and imports no web framework — an architecture test enforces it. The Hono gateway and SvelteKit dashboard are thin, optional layers on top.
+# 3. Copy the root API key — generated and printed once on first boot
+docker compose logs helm | grep -i "root API key"
+```
+
+| What | Where |
+|---|---|
+| Gateway | `http://localhost:8080` (status landing page at `/`) |
+| Dashboard | `http://localhost:8080/admin` — `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` |
+| API docs | `GET /docs` (Swagger UI) · `GET /openapi.json` (OpenAPI 3.1, generated from the same Zod schemas the gateway validates with) |
+| Health / version | `GET /healthz` · `GET /version` |
+
+`docker-compose.yml` mounts `./config` and `./data` — config and database survive restarts. Credentials enter via environment variables only, never the image.
+
+## What you get
+
+|  | Feature | Detail |
+| :---: | :--- | :--- |
+| 🔀 | **Four client protocols** | OpenAI Chat, Anthropic Messages, OpenAI Responses, Google Gemini — all streaming + non-streaming. One IR in the middle: any client reaches any backend with a consistent output shape, SSE included. |
+| 🧭 | **Three-layer classification** | Deterministic rules (pure, zero-network, unit-tested — always on) → optional small-model eval (`temperature: 0`, cached, off by default — needs a configured eval model) → `balanced` lane as the fail-open sink. |
+| 🛣️ | **Lanes + policies** | Requests route through lanes (`economy` / `balanced` / `premium`, plus task lanes `coding`, `json`, `vision`, `tool_use`), never raw provider names. First-match policies pin or cap the lane. Each lane = a primary model + a fallback chain, all in config. |
+| 🛡️ | **Resilient execution** | Circuit breaker (OPEN/HALF_OPEN + single probe), capability filter with explicit skip reasons, `:free`-tier 429 skipping, per-key concurrency queueing. Client disconnects are never counted as provider faults. |
+| 🔐 | **OAuth subscriptions** | Route your Claude Pro/Max, ChatGPT Codex, and GitHub Copilot subscriptions as backends — pooled accounts, per-account model curation / egress proxy / scheduling, all hot-reloaded. *(Opt-in; read the [ToS warning](#oauth-subscription-providers-claude-promax-chatgpt-codex-github-copilot).)* |
+| 🔑 | **Keys with teeth** | Mandatory auth; keys stored as SHA-256 hashes only. Per key: lane whitelist, custom-model permission, RPM/TPM limits, usage budgets (degrade or reject), concurrency cap, memory mode. Revoke softly, then delete permanently. |
+| 🧠 | **Memory middleware** | On by default: remembered context is injected before routing; a background worker compresses and consolidates; a forgetting/tiering layer (decay, reinforcement, retention) keeps it honest. Opt out per key or per request (`x-memory-mode: off`). |
+| 📊 | **Total observability** | A redacted decision record per request — classifier, policy, lane, every provider attempt, latency, fallbacks, cost. Verbatim payload capture to a separate table (on by default, 30-day retention). An editable **Retry** button replays any captured request. |
+| 🖥️ | **Admin dashboard** | SvelteKit SPA at `/admin` behind HTTP Basic: overview, key CRUD, lane/policy/classifier editors, system settings, drill-down request log. Edits **write back to `config/*.yaml`** (comment-preserving, atomic) and rebind live — no restart, and they survive one. Five languages. |
+| 💾 | **Storage** | SQLite by default (one local file). Postgres / Supabase behind the same Store-port abstraction — switch with one env var. |
+
+**Roadmap:** LLM-backed memory summarization (today's observer/reflector summarize step is a deterministic stub) · finer-grained quotas / account-level billing. See [09 Roadmap](docs/09-roadmap.md).
+
+## Two failure disciplines
+
+This is the design rule everything else hangs off:
+
+- **Config and credentials are fail-closed.** Invalid YAML, a missing required key, an unknown store driver — the gateway refuses to start. It never runs half-configured.
+- **The request path is fail-open.** Classification, eval, memory, cache — any optional step that stumbles degrades quietly to the `balanced` lane and gets logged. A client sees a structured error only when *every* provider in the chain is genuinely down.
+
+And two fallbacks that are never conflated: *classification fallback* (undecided → `balanced` lane) and *execution fallback* (provider failed → next model in the chain). Separate mechanisms, separate decision-record fields — you can always tell which one fired.
 
 ## Architecture
 
-Four client protocols enter one stable interface; one framework-agnostic core does the work; everything is driven by config and recorded on the way out.
+Four client protocols enter one stable interface; one framework-agnostic core does the work; config drives every stage.
 
 ```text
 CLIENT ── OpenAI · Anthropic · OpenAI Responses · Google Gemini
@@ -74,11 +110,13 @@ CORE      packages/core · the routing brain (imports no web framework)
 RESULT ── streamed/JSON response, in the client's own protocol
              │
              ├─▶ telemetry   redacted decision record + verbatim payload capture
-             ├─▶ memory      write back the turn (opt-in)
+             ├─▶ memory      write back the turn
              └─▶ upstream    static API keys + OAuth subscriptions (pooled · hot-reload)
 
 config/*.yaml drives every stage · Zod-validated · invalid config refuses to boot (fail-closed)
 ```
+
+The core is **headless by contract**: routing, classification, provider execution, protocol translation, and storage live in `packages/core` and import no web framework — an architecture test enforces it. Hono and SvelteKit are thin, optional shells.
 
 ```text
 helm-api/
@@ -93,60 +131,9 @@ helm-api/
 └─ scripts/      # sync:catalog and other build-time tools
 ```
 
-## Status
+## Calling the gateway
 
-Helm API is at **0.6** and is a real, end-to-end implementation — not a scaffold. The full pipeline (config → auth → classify → route → execute with circuit-breaking and fallback → protocol translation → telemetry) is wired and backed by an extensive Vitest unit suite plus Playwright e2e specs. See [Features](#features) for exactly what ships today versus what is roadmap-only.
-
-## Features
-
-**Shipped:**
-
-- **Four client protocols** — `POST /v1/chat/completions` (OpenAI Chat), `POST /v1/messages` (Anthropic Messages), `POST /v1/responses` (OpenAI Responses), and `POST /v1beta/models/{model}:generateContent` (Google Gemini) — all streaming + non-streaming. (Gemini streaming is the `:streamGenerateContent?alt=sse` operation; the Gemini surface authenticates with `x-goog-api-key`.)
-- **Cross-protocol translation** — normalize to one OpenAI-Chat-shaped IR; consistent output across backends with SSE on all four surfaces. Aligned to litellm's field coverage: sampling knobs, usage detail (reasoning / cache / per-modality), a unified reasoning/thinking bridge, full multimodal I/O, and both-ways `finish_reason` maps. Unmappable knobs degrade observably (e.g. Anthropic caps `n>1` and warns on `logprobs`/`modalities`) rather than erroring — see the [Protocol Compatibility](docs/protocol-compatibility.md) matrix.
-- **Three-layer classification** — deterministic rules always on; optional small-model eval (off by default; needs a configured eval model) for uncertain cases; `balanced`-lane fail-open sink.
-- **Lane + policy routing** — first-match policies that pin or cap lanes; shipped lanes `economy`, `balanced`, `premium` plus task lanes `coding`, `json`, `vision`, `tool_use` (`balanced` is the required, always-available fallback terminal).
-- **Provider execution with fallback** — primary + fallback chains across OpenAI-compatible upstreams, with a circuit breaker (OPEN/HALF_OPEN + single-probe), a capability filter (skip candidates lacking JSON / tools / vision / a modality / context size / streaming, with an explicit reason), and `:free`-tier 429 skipping. Client disconnects are treated as non-provider faults.
-- **OAuth subscription providers** — route your Claude Pro/Max, ChatGPT Codex, and GitHub Copilot **subscriptions** as backends: log in from the dashboard, pool several accounts per provider, and curate models / set an egress proxy / set scheduling per account — all of which **hot-reload**. See [the section below](#oauth-subscription-providers-claude-promax-chatgpt-codex-github-copilot). *(Opt-in; may violate provider ToS — read the warning.)*
-- **Mandatory API-key auth + per-key caps** — keys stored as SHA-256 hashes only; a root key is generated and printed once on first boot. Each key carries an `allowed_lanes` whitelist, custom-model permission, optional RPM/TPM rate limits, usage budgets (requests/tokens/spend, with degrade-or-reject), a concurrency limit, and a memory mode.
-- **Memory middleware (on by default)** — `inject` (the default) reads remembered context back into the prompt before routing; `observe` writes the turn only. Overridable per request via the `x-memory-mode` header (including `off`). A background worker compresses (observer) and consolidates (reflector) memory; the forgetting/tiering layer (decay, retention, fact extraction), gated behind `config.memory.forgetting.enabled`, is now on by default. Summarization is a deterministic stub today — the LLM path is roadmap.
-- **Observability** — a redacted decision record per request (classifier, policy, lane, provider attempts, latency, fallback count, cost breakdown, memory counts) plus optional verbatim payload capture to a dedicated table, aged out by retention.
-- **Admin dashboard** — a SvelteKit + Tailwind SPA served at `/admin` behind HTTP Basic: live overview, API-key CRUD with per-key caps, lane/policy editors, classifier and system settings, and a drill-down request log. Five languages (English, Simplified & Traditional Chinese, Japanese, Korean). Edits re-bind the live config and apply on the next request — no restart.
-- **Storage** — SQLite by default (local file); Postgres / Supabase optional, via a shared Store-port abstraction.
-
-**Roadmap:**
-
-- **LLM-backed memory** — observer/reflector summarization and fact extraction are deterministic stubs today; the real small-model path is future work.
-- Finer-grained quotas / account-level billing.
-
-See [09 Roadmap](docs/09-roadmap.md) for details.
-
-## Quickstart
-
-**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) (for the quickest start), or **Node ≥ 22** and **pnpm 10** to build from source.
-
-```bash
-# 1. Clone and create your env file
-git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
-cp .env.example .env
-#    In .env, set HELM_ADMIN_PASSWORD and at least DEEPSEEK_API_KEY
-
-# 2. Start it
-docker compose up -d
-
-# 3. Copy the root API key — generated and printed once on first boot
-docker compose logs helm | grep -i "root API key"
-```
-
-- **Gateway** → `http://localhost:8080` (a status landing page lives at `/`)
-- **Dashboard** → `http://localhost:8080/admin` (log in with `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD`)
-- **API docs** → `GET /docs` (interactive Swagger UI) · `GET /openapi.json` (OpenAPI 3.1, generated from the same Zod schemas the gateway validates against)
-- **Health / version** → `GET /healthz`, `GET /version`
-
-`docker-compose.yml` mounts `./config` and `./data`, so your config and database survive restarts. Credentials are passed in as environment variables only — never built into the image.
-
-### Calling the gateway
-
-Any OpenAI-compatible client works. Point it at Helm and use a Helm API key:
+Any OpenAI-compatible client works. Point it at Helm with a Helm key:
 
 ```bash
 curl http://localhost:8080/v1/chat/completions \
@@ -164,47 +151,39 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅ (via `:streamGenerateContent?alt=sse`) |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅ (via `:streamGenerateContent?alt=sse`; auth via `x-goog-api-key`) |
 
-**What to put in the `model` field:**
+**What to put in `model`:**
 
 | Value | What Helm does |
 |---|---|
-| `auto` *(recommended)* | Classifies the request and routes it to the best lane automatically. |
-| a model alias, e.g. `deepseek/deepseek-v4-pro` | Uses exactly that model and skips routing — only for keys granted custom-model permission. |
+| `auto` *(recommended)* | Classifies the request and routes it to the best lane. |
+| a model alias, e.g. `deepseek/deepseek-v4-pro` | Uses exactly that model, skipping routing — only for keys with custom-model permission. |
 
-> With a standard key, routing is automatic no matter what you send — just use `auto`. Lanes are configured by the operator in `lanes.yaml` and the dashboard; clients don't choose a lane per call.
+> With a standard key, routing is always automatic — just use `auto`. Lanes are operator config (`lanes.yaml` + dashboard); clients don't pick lanes per call.
 
-### API surface
-
-Every endpoint is documented interactively at **`/docs`**, with the raw spec at **`/openapi.json`**.
+**Other endpoints** (full interactive docs at `/docs`, raw spec at `/openapi.json`):
 
 | Endpoint | Auth | Purpose |
 |---|---|---|
-| `GET /` | — | Status landing page |
-| `GET /healthz` · `GET /version` | — | Readiness probe · build info |
-| `GET /docs` · `GET /openapi.json` | — | Interactive docs · OpenAPI 3.1 spec |
-| `GET /v1/models` · `GET /v1/models/{id}` | API key | List models the key can route to (lanes + `auto`; concrete aliases with capabilities & pricing for custom-model keys) |
-| `POST /v1/chat/completions` | API key | OpenAI Chat Completions |
-| `POST /v1/messages` | API key | Anthropic Messages |
-| `POST /v1/responses` | API key | OpenAI Responses |
-| `POST /v1beta/models/{model}:generateContent` | API key | Google Gemini |
+| `GET /` · `GET /healthz` · `GET /version` | — | Landing page · readiness · build info |
+| `GET /v1/models` · `GET /v1/models/{id}` | API key | Models the key can route to (lanes + `auto`; concrete aliases with capabilities & pricing for custom-model keys) |
 | `/admin` · `/admin/api/*` | Basic auth | Dashboard + its JSON backend (mounted only when admin credentials are set) |
 
 ## Configuration
 
-Everything is configured in `config/*.yaml`. Files are Zod-validated on load, and **invalid config stops the gateway from starting (fail-closed)**. Lanes, policies, the classifier, and system settings can also be edited live in the dashboard and apply on the next request.
+Everything lives in `config/*.yaml`, Zod-validated on load. **Invalid config stops the gateway from starting.** Lanes, policies, the classifier, and system settings are also editable live in the dashboard — edits persist back to the YAML files (comments preserved) and apply on the next request.
 
-| File | What it controls | Live-editable |
+| File | Controls | Live-editable |
 |---|---|---|
 | `server.yaml` | Host / port / base path | — |
 | `auth.yaml` | API key requirement + first-run root key | — |
 | `runtime.yaml` | Request limits, rate-limit defaults, storage driver | partial |
 | `providers.yaml` | Upstream providers + model aliases (credentials by env-var **name** only) | — |
-| `lanes.yaml` | Lanes — each lane's primary model and its fallback chain | ✅ |
-| `policies.yaml` | First-match rules that pick or cap the lane | ✅ |
-| `classifier.yaml` | The built-in rules and the optional eval model | ✅ |
-| `memory.yaml` | Memory forgetting/tiering knobs (the whole layer is on by default) | ✅ |
+| `lanes.yaml` | Each lane's primary model + fallback chain | ✅ persists |
+| `policies.yaml` | First-match rules that pick or cap the lane | ✅ persists |
+| `classifier.yaml` | Built-in rules + the optional eval model | ✅ persists |
+| `memory.yaml` | Observer compaction + forgetting/tiering knobs (on in the shipped config) | ✅ |
 | `capabilities.yaml` / `pricing.yaml` | Manual overrides on the model catalog | — |
 
 Most-used environment variables (env wins over YAML; full list in [`.env.example`](.env.example)):
@@ -212,37 +191,33 @@ Most-used environment variables (env wins over YAML; full list in [`.env.example
 | Variable | Purpose |
 |---|---|
 | `DEEPSEEK_API_KEY` | Primary provider credential (**required**) |
-| `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` | Optional provider credentials (provider is skipped if missing) |
+| `ZENMUX_API_KEY`, `OPENROUTER_API_KEY` | Optional provider credentials (provider skipped if missing) |
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | Dashboard login (Basic auth) |
 | `HELM_HOST` / `HELM_PORT` | Server binding (default `0.0.0.0:8080`) |
 | `HELM_STORE_DRIVER` | `sqlite` (default) or `supabase` |
 | `HELM_STORE_URL_ENV` | For `supabase`: the **name** of the env var holding the Postgres DSN |
 | `HELM_RATE_LIMIT_ENABLED` | Turn rate limiting on (off by default) |
-| `HELM_OAUTH_ENC_KEY` | 32-byte key to encrypt stored OAuth tokens (**required** if any subscription provider is configured) |
+| `HELM_OAUTH_ENC_KEY` | 32-byte key encrypting stored OAuth tokens (**required** if any subscription provider is configured) |
 
-> **Storage.** SQLite (`better-sqlite3`, a `helm.db` file under `./data`) is the default. For Postgres/Supabase, set `HELM_STORE_DRIVER=supabase` and point `HELM_STORE_URL_ENV` at the env var that holds your DSN. An unknown driver fails closed at startup.
+> **Storage.** SQLite (`better-sqlite3`, a `helm.db` file under `./data`) is the default. For Postgres/Supabase, set `HELM_STORE_DRIVER=supabase` and point `HELM_STORE_URL_ENV` at the env var holding your DSN. Unknown drivers fail closed at startup.
 >
-> **Credentials.** Provider keys are referenced by env-var *name* in `providers.yaml` — never written as plaintext into the repo or image.
+> **Credentials.** Provider keys are referenced by env-var *name* in `providers.yaml` — plaintext never enters the repo or the image.
 
 ### OAuth subscription providers (Claude Pro/Max, ChatGPT Codex, GitHub Copilot)
 
-Instead of a static API key, a provider can authenticate with an **OAuth subscription** you log into from the dashboard (**Providers → Connect**). Claude Pro/Max and ChatGPT Codex use a manual authorization-code paste; GitHub Copilot uses a device code. Helm stores the (rotating) refresh token **encrypted at rest** and refreshes the short-lived access token automatically.
+A provider can authenticate with an **OAuth subscription** instead of a static key: log in from the dashboard (**Providers → Connect**). Claude Pro/Max and ChatGPT Codex use an authorization-code paste; GitHub Copilot uses a device code. Helm stores the rotating refresh token **encrypted at rest** and refreshes access tokens automatically.
 
-To enable it, set **`HELM_OAUTH_ENC_KEY`** to a 32-byte key (base64, or 64 hex chars) — Helm uses it to encrypt stored tokens and **refuses to start** if a subscription provider is configured without it. Configure the provider with an `oauth: { provider: anthropic | github-copilot | openai-codex }` block (see the commented examples in `config/providers.yaml`); for Claude use `type: anthropic`.
+Set **`HELM_OAUTH_ENC_KEY`** (32 bytes: base64 or 64 hex chars) — Helm refuses to start if a subscription provider is configured without it. Then add an `oauth: { provider: anthropic | github-copilot | openai-codex }` block to the provider (commented examples in `config/providers.yaml`; for Claude use `type: anthropic`).
 
-You can connect **several accounts of one provider** and Helm pools them. Each account, via **Providers → Manage**, has its own:
+Pool **several accounts per provider**. Each account (**Providers → Manage**) gets its own:
 
-- **Models** — curate exactly which models that account exposes to your lanes. The curated list is authoritative: a model you remove stops routing immediately, and an uncurated model is refused (fail-closed) — a live allow-list, not just a display filter.
-- **Proxy** — route that account's upstream traffic through an HTTP/HTTPS/SOCKS5 proxy so it egresses from a distinct IP (avoids ban-correlation when accounts share a host).
-- **Schedule** — a `priority` (lower = served first) and a `schedulable` toggle. Helm picks the lowest-priority account, round-robin (least-recently-used) within an equal priority; parking an account keeps it connected but out of rotation.
+- **Models** — a live allow-list, not a display filter: a removed model stops routing immediately; an uncurated model is refused (fail-closed).
+- **Proxy** — HTTP/HTTPS/SOCKS5 egress per account, used across the entire subscription flow, so co-hosted accounts exit from distinct IPs.
+- **Schedule** — `priority` (lower serves first) + a `schedulable` toggle; round-robin (LRU) within equal priority. Park an account to keep it connected but out of rotation.
 
-**Everything here hot-reloads** — connecting, disconnecting, curation, proxy, and scheduling changes apply on the next request, no restart. And to look like a first-party client, Helm mirrors the official client's identity headers and sends a **stable, per-account device identity** (it never rotates mid-stream), reducing ban-correlation risk.
+Everything hot-reloads — connect, disconnect, curation, proxy, scheduling — next request, no restart. Helm also mirrors each official client's identity headers and sends a **stable per-account device identity** (never rotated mid-stream) to reduce ban-correlation risk.
 
-> ⚠️ **Terms of service.** Routing a Claude/ChatGPT/Copilot **subscription** through a third-party gateway may violate the provider's terms of service, which can be grounds for account suspension. This is an opt-in feature for self-hosted, personal use — **you are responsible** for ensuring your usage complies with your provider agreements. When in doubt, use a normal API key (`api_key_env`) instead.
-
-## The dashboard
-
-At `/admin`, behind HTTP Basic auth: a live overview, API-key management (create, revoke, set per-key caps), lane/policy editors, classifier and system settings, and a request log you can drill into to see how each request was routed. The dashboard mounts **only when** admin credentials are set; otherwise `/admin` and `/admin/api/*` return `404`. See [11 Admin UI](docs/11-admin-ui.md).
+> ⚠️ **Terms of service.** Routing a Claude/ChatGPT/Copilot **subscription** through a third-party gateway may violate the provider's ToS and can get accounts suspended. This is an opt-in feature for self-hosted personal use — **you are responsible** for compliance with your provider agreements. When in doubt, use a normal API key (`api_key_env`).
 
 ## Development
 
@@ -259,9 +234,9 @@ pnpm build        # build the gateway + dashboard
 pnpm sync:catalog # refresh the generated model catalog (capabilities + pricing)
 ```
 
-> `pnpm dev` starts only the admin SPA. There is no watch script for the gateway; run it built (`pnpm build` then `node apps/gateway/dist/index.js`) or via Docker.
+> `pnpm dev` starts only the admin SPA. The gateway has no watch script — run it built (`pnpm build` then `node apps/gateway/dist/index.js`) or via Docker.
 
-Tests come first (Vitest for the core, Playwright for full flows). Design decisions are logged in [`implementation-notes.md`](implementation-notes.md). Before opening a PR, make sure all checks pass:
+Tests come first: Vitest for the core, Playwright for full flows. Design decisions live in [`implementation-notes.md`](implementation-notes.md). Before a PR:
 
 ```bash
 pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
@@ -269,7 +244,7 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 
 ## Documentation
 
-Read in order, starting at [`docs/README.md`](docs/README.md):
+Start at [`docs/README.md`](docs/README.md) and read in order:
 
 [01 Overview](docs/01-overview.md) ·
 [02 Architecture](docs/02-architecture.md) ·
@@ -284,6 +259,10 @@ Read in order, starting at [`docs/README.md`](docs/README.md):
 [11 Admin UI](docs/11-admin-ui.md) ·
 [12 Memory Forgetting & Tiering](docs/12-memory-forgetting-and-tiering.md) ·
 [Protocol Compatibility](docs/protocol-compatibility.md)
+
+## Status
+
+Helm API is at **0.8.0** — a real, end-to-end implementation, not a scaffold. The full pipeline (config → auth → classify → route → execute with circuit-breaking and fallback → protocol translation → telemetry) is wired and covered by an extensive Vitest suite plus Playwright e2e specs.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,11 +4,12 @@
 
 [English](README.md) · **简体中文**
 
-### 一个网关，挡在你所有 LLM 供应商前面 —— 用配置而非代码来选模型。
+### 一个网关，挡在所有 LLM 供应商前面。选模型靠配置，不靠改代码。
 
 开源 · 自托管 · MIT
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)](package.json)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](tsconfig.base.json)
 [![Built with Hono](https://img.shields.io/badge/gateway-Hono-ff5e00.svg)](https://hono.dev)
@@ -16,7 +17,9 @@
 
 </div>
 
-Helm API 是一个开源、自托管的 **LLM 路由网关** —— 可以把它理解成 **“LLM 世界的 nginx”**。你的应用照常向 Helm 发一个 OpenAI、Anthropic 或 Gemini 请求，剩下的交给一份声明式 YAML 配置：由它决定该用哪个模型、调用对应供应商（失败就自动切到备用）、按需做协议互译，并把每一次决策都记录下来。客户端始终面对同一套接口和同一种输出格式，只需改 `base_url` 和 API key —— 所有路由逻辑都在你自己掌控的配置里。
+兜底逻辑、各家供应商的怪癖、成本权衡、模型更替——这些东西，你正在往每一个客户端里重复维护。它们本该集中在一个地方，藏在一个接口后面。
+
+Helm API 就是这个地方：一个开源、自托管的 **LLM 路由网关**——*LLM 世界的 nginx*。你的应用照常发一个 OpenAI、Anthropic 或 Gemini 请求；由一份声明式 YAML 配置决定哪个模型来应答、供应商挂了切到哪个备用、协议怎么双向互译，并把每一次决策记录在案。客户端只设 `base_url` 和 API key，别的什么都不用管。
 
 > **把流量当配置来管，而不是当代码来改。**
 
@@ -26,30 +29,63 @@ client = OpenAI(base_url="http://localhost:8080/v1", api_key="<helm-key>")
 client.chat.completions.create(model="auto", messages=[...])   # Helm 负责分类与路由
 ```
 
----
+要换 lane 背后的模型？改一行 YAML，或在面板里点一下。应用毫无感知。
 
-## 为什么用 Helm
+## 快速上手
 
-AI 应用开发者不想在每个客户端里维护成百上千个模型、各家供应商的怪癖、兜底逻辑、成本权衡和路由判断。他们要的是**一个接口：足够便宜、足够可靠、默认就够聪明，出问题时还查得清楚。** Helm 给的正是这些：
+**前置条件：** [Docker](https://docs.docker.com/get-docker/)；或 **Node ≥ 22** + **pnpm 10** 从源码构建。
 
-- **换模型不用改代码。** 在配置文件里把某条 lane 指向另一个模型即可，应用毫无感知。
-- **两套失败纪律，各司其职。** 配置与凭证是 **fail-closed** —— 配置非法、或缺了必填的 key，就拒绝启动，绝不带病运行。请求路径是 **fail-open** —— 任何可选环节出岔子（分类、打分、记忆、缓存），都会悄悄降级到 `balanced` lane；只有**所有**供应商都真的挂了，你才会拿到一个结构化错误。
-- **默认就安全。** API key 只存 SHA-256 哈希，明文绝不进日志或遥测；限流、用量预算、可选的打分模型和记忆，统统默认关闭，要用才开。
-- **每个决策都可观测。** 每个请求都会落一条脱敏的决策记录 —— 走了哪条 lane、最终哪个模型应答、为什么、有没有兜底、花了多少 —— 都能在面板里翻查。完整的请求/响应正文会单独存到本地一张表（默认开启，保留 30 天），方便调试与审计。
-- **跑在你自己的机器上。** MIT 许可、Docker 部署。没有 SaaS、没有多租户云，任何数据都不出你的服务器。
+```bash
+# 1. 克隆并创建环境变量文件
+git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
+cp .env.example .env
+#    在 .env 里至少设好 HELM_ADMIN_PASSWORD 和 DEEPSEEK_API_KEY
 
-## 核心概念
+# 2. 启动
+docker compose up -d
 
-- **Lane（车道）** —— 请求走的是可配置的 *lane*（质量/成本档位 `economy`、`balanced`、`premium`，或任务档位 `coding`、`json`、`vision`、`tool_use`），而不是裸的供应商名。每条 lane 如何映射到「一个主模型 + 一条兜底链」，由你在配置里定。供应商别名只是内部供应链细节，从不暴露给客户端。
-- **分类级联** —— 三层挑 lane：**①** 确定性规则（纯函数、零网络、有单测，常驻开启）；**②** 可选的小模型「二次意见」eval（`temperature: 0`、带缓存、**默认关闭**），只在规则拿不准时才咨询；**③** 用 `balanced` lane 作为 fail-open 兜底口。
-- **两套兜底，绝不混淆** —— *分类兜底*把没定下来的请求降级到 `balanced` lane；*执行兜底*在某个供应商失败时切到链里的下一个模型。它们记在决策记录的不同字段里，所以你永远分得清是哪一个触发了。
-- **协议互译** —— 四种进站协议归一成一套 OpenAI-Chat 形态的内部表示（IR），于是一个客户端就能触达多种后端，并拿到一致的输出格式 —— 含流式 SSE。
-- **配置即代码** —— 行为都写在 `config/*.yaml` 里，启动时用 Zod 校验；非法配置 fail-closed，网关拒绝启动。
-- **无头内核** —— 整个路由大脑（分类、路由、provider 执行、协议互译、存储）都在 `packages/core` 里，不 import 任何 Web 框架 —— 有架构测试盯着这条线。Hono 网关和 SvelteKit 面板只是薄薄一层、可选的外壳。
+# 3. 复制 root API key —— 首次启动时生成，只打印一次
+docker compose logs helm | grep -i "root API key"
+```
+
+| 入口 | 地址 |
+|---|---|
+| 网关 | `http://localhost:8080`（`/` 是状态落地页） |
+| 管理面板 | `http://localhost:8080/admin` —— 用 `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` 登录 |
+| API 文档 | `GET /docs`（Swagger UI）· `GET /openapi.json`（OpenAPI 3.1，与网关校验所用为同一套 Zod schema） |
+| 健康 / 版本 | `GET /healthz` · `GET /version` |
+
+`docker-compose.yml` 挂载了 `./config` 和 `./data`——配置和数据库都能跨重启保留。凭证只经环境变量注入，绝不打进镜像。
+
+## 你能得到什么
+
+|  | 功能 | 说明 |
+| :---: | :--- | :--- |
+| 🔀 | **四种客户端协议** | OpenAI Chat、Anthropic Messages、OpenAI Responses、Google Gemini——全部支持流式 + 非流式。中间是同一套 IR：任意客户端触达任意后端，输出格式一致，SSE 也不例外。 |
+| 🧭 | **三层分类** | 确定性规则（纯函数、零网络、有单测——常驻开启）→ 可选的小模型 eval（`temperature: 0`、带缓存、默认关闭——需要先配好 eval 模型）→ `balanced` lane 作为 fail-open 兜底口。 |
+| 🛣️ | **Lane + 策略路由** | 请求走 lane（`economy` / `balanced` / `premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`），从不直接面对供应商名。首条命中的策略可以钉死或封顶 lane。每条 lane = 一个主模型 + 一条兜底链，全在配置里。 |
+| 🛡️ | **稳健的执行层** | 熔断器（OPEN/HALF_OPEN + 单探针）、能力过滤（跳过候选时记下明确原因）、`:free` 档 429 跳过、按 key 并发排队。客户端断连永远不算供应商故障。 |
+| 🔐 | **OAuth 订阅** | 把 Claude Pro/Max、ChatGPT Codex、GitHub Copilot 的**订阅**当后端来路由——多账号组池，逐账号做模型策展 / 出口代理 / 调度，全部热重载。*（可选功能，先读 [ToS 警告](#oauth-订阅类供应商claude-promaxchatgpt-codexgithub-copilot)。）* |
+| 🔑 | **带约束力的 key** | 强制鉴权；key 只存 SHA-256 哈希。每把 key 可设：lane 白名单、自定义模型权限、RPM/TPM 限流、用量预算（降级或拒绝）、并发上限、记忆模式。先软吊销，再永久删除。 |
+| 🧠 | **Memory 中间件** | 默认开启：路由前把记忆注入上下文；后台 worker 负责压缩与归并；遗忘/分层机制（衰减、强化、保留期）防止记忆膨胀。可按 key 或按请求关闭（`x-memory-mode: off`）。 |
+| 📊 | **全程可观测** | 每个请求一条脱敏决策记录——分类、策略、lane、每次供应商尝试、延迟、兜底、成本。正文逐字捕获单独存表（默认开，保留 30 天）。可编辑的 **Retry** 按钮能重放任何已捕获的请求。 |
+| 🖥️ | **管理面板** | `/admin` 上的 SvelteKit SPA，HTTP Basic 把守：概览、key 增删改、lane / 策略 / 分类器编辑器、系统设置、可下钻的请求日志。编辑会**写回 `config/*.yaml`**（保留注释、原子写入）并实时重绑——无需重启，重启也不丢。支持 5 种语言。 |
+| 💾 | **存储** | 默认 SQLite（一个本地文件）。Postgres / Supabase 走同一套 Store 端口抽象——改一个环境变量即可切换。 |
+
+**路线图：** 接 LLM 的记忆摘要（observer/reflector 的摘要步骤目前是确定性桩）· 更细粒度的配额 / 账户级计费。详见 [09 路线图](docs/09-roadmap.md)。
+
+## 两套失败纪律
+
+整个设计都挂在这条规则上：
+
+- **配置与凭证 fail-closed。** YAML 非法、缺必填 key、存储驱动未知——网关直接拒绝启动，绝不带病运行。
+- **请求路径 fail-open。** 分类、eval、记忆、缓存——任何可选环节出岔子，都悄悄降级到 `balanced` lane 并记入日志。只有链上**所有**供应商都真的挂了，客户端才会拿到一个结构化错误。
+
+还有两套绝不混淆的兜底：*分类兜底*（拿不准 → `balanced` lane）和*执行兜底*（供应商失败 → 链内下一个模型）。机制分开、决策记录字段分开——永远分得清是哪一个触发了。
 
 ## 架构
 
-四种客户端协议进入同一套稳定接口；一个不依赖框架的内核干所有活；一切由配置驱动，并在出站时被记录下来。
+四种客户端协议进入同一套稳定接口；一个不依赖框架的内核干所有活；配置驱动每一个阶段。
 
 ```text
 CLIENT ── OpenAI · Anthropic · OpenAI Responses · Google Gemini
@@ -61,24 +97,26 @@ GATEWAY   apps/gateway（Hono）· 薄薄一层 HTTP 外壳 —— 顺带托管 
              ▼
 CORE      packages/core · 路由大脑（不 import 任何 Web 框架）
              │
-             ├─ auth        校验 sha256 key、加载按 key 限额      · fail-closed
-             ├─ gate        限流（默认关）· 用量预算（默认关）     · fail-closed
-             ├─ memory      把记忆注入 prompt（可选，默认关）      · fail-open
+             ├─ auth        校验 sha256 key、加载按 key 限额        · fail-closed
+             ├─ gate        限流（默认关）· 用量预算（默认关）       · fail-closed
+             ├─ memory      把记忆注入上下文（默认开）               · fail-open
              ├─ classify    L1 规则 ─不确定→ L2 eval（默认关）─→ balanced · fail-open
              ├─ resolve     首条命中策略 → lane → 限额 → 兜底链
              ├─ execute     能力过滤 → 熔断器 → provider
-             │                  └── 失败时：切到链里的下一个模型
+             │                  └── 失败时：切到链内下一个模型
              └─ translate   provider 原生  ⇄  IR  ⇄  客户端协议（流式 SSE）
              │
              ▼
 RESULT ── 按客户端自己的协议，流式 / JSON 返回
              │
              ├─▶ telemetry   脱敏决策记录 + 正文逐字捕获
-             ├─▶ memory      把这轮对话写回（可选）
+             ├─▶ memory      把这一轮写回记忆
              └─▶ upstream    静态 API key + OAuth 订阅（组池 · 热重载）
 
 config/*.yaml 驱动每一个阶段 · 经 Zod 校验 · 非法配置拒绝启动（fail-closed）
 ```
+
+内核**契约级无头**：路由、分类、provider 执行、协议互译、存储全在 `packages/core` 里，不 import 任何 Web 框架——有架构测试盯着这条线。Hono 和 SvelteKit 只是薄薄一层、可选的外壳。
 
 ```text
 helm-api/
@@ -93,60 +131,9 @@ helm-api/
 └─ scripts/      # sync:catalog 等构建期工具
 ```
 
-## 项目状态
+## 调用网关
 
-Helm API 已到 **0.6**，是一套端到端的真实实现，而非空架子。完整链路（配置 → 鉴权 → 分类 → 路由 → 执行（含熔断与兜底）→ 协议互译 → 遥测）已打通，背后有一套相当完整的 Vitest 单测和 Playwright e2e 用例兜底。具体哪些已上线、哪些还只在路线图上，见 [功能](#功能)。
-
-## 功能
-
-**已上线：**
-
-- **四种客户端协议** —— `POST /v1/chat/completions`（OpenAI Chat）、`POST /v1/messages`（Anthropic Messages）、`POST /v1/responses`（OpenAI Responses）、`POST /v1beta/models/{model}:generateContent`（Google Gemini）—— 四者均支持流式 + 非流式（Gemini 的流式即 `:streamGenerateContent?alt=sse`；Gemini 面用 `x-goog-api-key` 鉴权）。
-- **跨协议互译** —— 归一到一套 OpenAI-Chat 形态的 IR；跨后端输出格式一致，四个面均支持 SSE。字段覆盖对齐 litellm：采样旋钮、usage 明细（reasoning / cache / 逐模态）、统一的 reasoning/thinking 桥、全量多模态 I/O，以及 `finish_reason` 两向映射。无法映射的旋钮**有据可查地降级**（如 Anthropic 把 `n>1` 钳到 1、对 `logprobs`/`modalities` 报 warning），而不是直接报错——见[协议兼容性](docs/protocol-compatibility.md)矩阵。
-- **三层分类** —— 确定性规则常驻；不确定时走可选的小模型 eval（默认关闭）；最后用 `balanced` lane 作 fail-open 兜底口。
-- **Lane + 策略路由** —— 首条命中的策略可以钉死或封顶 lane；内置 lane `economy`、`balanced`、`premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`（`balanced` 是必须存在、永远兜底的那条）。
-- **带兜底的 provider 执行** —— 在多个 OpenAI 兼容上游之间走「主 + 兜底」链，配有熔断器（OPEN/HALF_OPEN + 单探针）、能力过滤（缺 JSON / 工具 / 视觉 / 某模态 / 上下文长度 / 流式的候选会被显式跳过并记原因）、以及 `:free` 档 429 跳过。客户端断连不算 provider 故障。
-- **OAuth 订阅类供应商** —— 把你的 Claude Pro/Max、ChatGPT Codex、GitHub Copilot **订阅**当作后端来路由：在面板里登录，每个供应商可接入多个账号组成池，逐账号策展模型 / 设出口代理 / 设调度优先级 —— 这些改动全部**热重载**。详见[下文](#oauth-订阅类供应商claude-promaxchatgpt-codexgithub-copilot)。*（可选功能，可能违反供应商服务条款，务必阅读警告。）*
-- **强制 API key 鉴权 + 按 key 限额** —— key 只存 SHA-256 哈希；首次启动生成并只打印一次 root key。每把 key 都带 `allowed_lanes` 白名单、是否允许自定义模型、可选的 RPM/TPM 限流、用量预算（请求数/token/花费，可降级或拒绝）、并发上限，以及一个记忆模式。
-- **Memory 中间件（可选）** —— 按请求经 `x-memory-mode` 头开启（默认 `off`）：`observe` 写入这轮对话，`inject` 在路由前把记忆读回 prompt。后台 worker 负责压缩（observer）与归并（reflector）；可选的遗忘/分层（衰减、保留期、事实抽取）由 `config.memory.forgetting.enabled` 把守（默认关）。摘要目前是确定性桩 —— 接 LLM 的版本属路线图。
-- **可观测性** —— 每个请求一条脱敏决策记录（分类、策略、lane、各次 provider 尝试、延迟、兜底次数、成本拆分、记忆计数），外加可选的正文逐字捕获（单独存表、按保留期清理）。
-- **管理面板** —— 一个 SvelteKit + Tailwind 的 SPA，挂在 `/admin`、用 HTTP Basic 保护：实时概览、API key 增删改（含按 key 限额）、lane 与策略编辑器、分类器与系统设置、可下钻的请求日志。支持 5 种语言（英文、简繁中文、日文、韩文）。改动会重新绑定到运行中的配置，下一个请求即生效，无需重启。
-- **存储** —— 默认 SQLite（本地文件）；可选 Postgres / Supabase，通过统一的 Store 端口抽象切换。
-
-**路线图：**
-
-- **接 LLM 的记忆** —— observer/reflector 的摘要与事实抽取目前是确定性桩；接小模型的真实版本属后续工作。
-- 更细粒度的配额 / 账户级计费。
-
-详见 [09 路线图](docs/09-roadmap.md)。
-
-## 快速上手
-
-**前置条件：** [Docker](https://docs.docker.com/get-docker/)（最快的起步方式），或 **Node ≥ 22** 加 **pnpm 10** 从源码构建。
-
-```bash
-# 1. 克隆并创建环境变量文件
-git clone https://github.com/EasyMetaAu/helm-api.git && cd helm-api
-cp .env.example .env
-#    在 .env 里至少设好 HELM_ADMIN_PASSWORD 和 DEEPSEEK_API_KEY
-
-# 2. 启动
-docker compose up -d
-
-# 3. 复制 root API key —— 首次启动时生成并只打印一次
-docker compose logs helm | grep -i "root API key"
-```
-
-- **网关** → `http://localhost:8080`（`/` 有一个状态落地页）
-- **面板** → `http://localhost:8080/admin`（用 `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` 登录）
-- **API 文档** → `GET /docs`（交互式 Swagger UI）· `GET /openapi.json`（OpenAPI 3.1，由网关校验所用的同一套 Zod schema 生成）
-- **健康 / 版本** → `GET /healthz`、`GET /version`
-
-`docker-compose.yml` 挂载了 `./config` 和 `./data`，所以配置和数据库都能跨重启保留。凭证只通过环境变量注入，绝不打进镜像。
-
-### 调用网关
-
-任何 OpenAI 兼容客户端都能用。把它指向 Helm，再带上一把 Helm API key：
+任何 OpenAI 兼容客户端都能用。指向 Helm，带上一把 Helm key：
 
 ```bash
 curl http://localhost:8080/v1/chat/completions \
@@ -164,47 +151,39 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅（走 `:streamGenerateContent?alt=sse`） |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅（走 `:streamGenerateContent?alt=sse`；用 `x-goog-api-key` 鉴权） |
 
-**`model` 字段里填什么：**
+**`model` 字段填什么：**
 
 | 取值 | Helm 的行为 |
 |---|---|
-| `auto`（推荐） | 对请求做分类，自动路由到最合适的 lane。 |
-| 模型别名，如 `deepseek/deepseek-v4-pro` | 精确使用该模型、跳过路由 —— 仅对获授「自定义模型」权限的 key 有效。 |
+| `auto`（推荐） | 对请求做分类，路由到最合适的 lane。 |
+| 模型别名，如 `deepseek/deepseek-v4-pro` | 精确使用该模型、跳过路由——仅对有「自定义模型」权限的 key 生效。 |
 
-> 用普通 key 时，无论你发什么，路由都是自动的 —— 直接用 `auto` 即可。Lane 由运维方在 `lanes.yaml` 和面板里配置，客户端不在单次调用里挑 lane。
+> 用普通 key 时，路由永远是自动的——直接填 `auto`。Lane 由运维方配置（`lanes.yaml` + 面板），客户端不在单次调用里挑 lane。
 
-### API 一览
-
-每个端点都在 **`/docs`** 有交互式文档，原始规格在 **`/openapi.json`**。
+**其余端点**（交互式文档在 `/docs`，原始规格在 `/openapi.json`）：
 
 | 端点 | 鉴权 | 用途 |
 |---|---|---|
-| `GET /` | — | 状态落地页 |
-| `GET /healthz` · `GET /version` | — | 就绪探针 · 构建信息 |
-| `GET /docs` · `GET /openapi.json` | — | 交互式文档 · OpenAPI 3.1 规格 |
+| `GET /` · `GET /healthz` · `GET /version` | — | 落地页 · 就绪探针 · 构建信息 |
 | `GET /v1/models` · `GET /v1/models/{id}` | API key | 列出该 key 能路由到的模型（lane + `auto`；自定义模型 key 还会看到带能力与定价的具体别名） |
-| `POST /v1/chat/completions` | API key | OpenAI Chat Completions |
-| `POST /v1/messages` | API key | Anthropic Messages |
-| `POST /v1/responses` | API key | OpenAI Responses |
-| `POST /v1beta/models/{model}:generateContent` | API key | Google Gemini |
 | `/admin` · `/admin/api/*` | Basic auth | 面板 + 其 JSON 后端（仅在设置了面板凭证时才挂载） |
 
 ## 配置
 
-一切都配在 `config/*.yaml` 里。文件加载时经 Zod 校验，**非法配置会让网关无法启动（fail-closed）**。Lane、策略、分类器和系统设置还能在面板里实时编辑，下一个请求即生效。
+一切都在 `config/*.yaml` 里，加载时经 Zod 校验。**非法配置直接让网关无法启动。** Lane、策略、分类器和系统设置还能在面板里实时编辑——改动会写回 YAML 文件（注释原样保留），下一个请求即生效。
 
 | 文件 | 控制什么 | 可实时改 |
 |---|---|---|
 | `server.yaml` | 主机 / 端口 / base path | — |
-| `auth.yaml` | 是否要求 API key + 首次的 root key | — |
+| `auth.yaml` | 是否强制 API key + 首次启动的 root key | — |
 | `runtime.yaml` | 请求限额、限流默认值、存储驱动 | 部分 |
 | `providers.yaml` | 上游供应商 + 模型别名（凭证只引用环境变量**名**） | — |
-| `lanes.yaml` | Lane —— 每条 lane 的主模型及其兜底链 | ✅ |
-| `policies.yaml` | 首条命中、用来挑选或封顶 lane 的规则 | ✅ |
-| `classifier.yaml` | 内置规则与可选的 eval 模型 | ✅ |
-| `memory.yaml` | 记忆遗忘/分层的旋钮（整层默认关闭） | ✅ |
+| `lanes.yaml` | 每条 lane 的主模型 + 兜底链 | ✅ 持久化 |
+| `policies.yaml` | 首条命中、用来挑选或封顶 lane 的规则 | ✅ 持久化 |
+| `classifier.yaml` | 内置规则 + 可选的 eval 模型 | ✅ 持久化 |
+| `memory.yaml` | Observer 压缩 + 遗忘/分层旋钮（出厂配置即开启） | ✅ |
 | `capabilities.yaml` / `pricing.yaml` | 对模型目录的手动覆盖项 | — |
 
 最常用的环境变量（env 优先于 YAML；完整列表见 [`.env.example`](.env.example)）：
@@ -216,33 +195,29 @@ curl http://localhost:8080/v1/chat/completions \
 | `HELM_ADMIN_USER` / `HELM_ADMIN_PASSWORD` | 面板登录（Basic auth） |
 | `HELM_HOST` / `HELM_PORT` | 服务绑定（默认 `0.0.0.0:8080`） |
 | `HELM_STORE_DRIVER` | `sqlite`（默认）或 `supabase` |
-| `HELM_STORE_URL_ENV` | 用 `supabase` 时：存放 Postgres DSN 的那个环境变量的**名字** |
+| `HELM_STORE_URL_ENV` | 用 `supabase` 时：存放 Postgres DSN 的环境变量**名** |
 | `HELM_RATE_LIMIT_ENABLED` | 打开限流（默认关闭） |
 | `HELM_OAUTH_ENC_KEY` | 加密所存 OAuth token 的 32 字节密钥（配了订阅类供应商时**必填**） |
 
-> **存储。** 默认 SQLite（`better-sqlite3`，`./data` 下的 `helm.db` 文件）。要用 Postgres/Supabase，把 `HELM_STORE_DRIVER` 设成 `supabase`，再让 `HELM_STORE_URL_ENV` 指向存放 DSN 的环境变量。未知驱动在启动时 fail-closed。
+> **存储。** 默认 SQLite（`better-sqlite3`，`./data` 下的 `helm.db` 文件）。要用 Postgres/Supabase：`HELM_STORE_DRIVER=supabase`，再让 `HELM_STORE_URL_ENV` 指向存放 DSN 的环境变量。未知驱动在启动时 fail-closed。
 >
-> **凭证。** 供应商 key 在 `providers.yaml` 里只按环境变量*名*引用 —— 绝不以明文写进仓库或镜像。
+> **凭证。** 供应商 key 在 `providers.yaml` 里只按环境变量*名*引用——明文绝不进仓库、不进镜像。
 
 ### OAuth 订阅类供应商（Claude Pro/Max、ChatGPT Codex、GitHub Copilot）
 
-除了静态 API key，供应商还能用你在面板里登录的 **OAuth 订阅**来鉴权（**提供商 → 连接**）。Claude Pro/Max 和 ChatGPT Codex 走「粘贴授权码」；GitHub Copilot 走设备码。Helm 把（会轮换的）refresh token **加密存盘**，并自动刷新短时的 access token。
+供应商除了静态 key，还能用 **OAuth 订阅**鉴权：在面板里登录（**提供商 → 连接**）。Claude Pro/Max 和 ChatGPT Codex 走「粘贴授权码」，GitHub Copilot 走设备码。Helm 把会轮换的 refresh token **加密存盘**，并自动刷新短时的 access token。
 
-启用前需把 **`HELM_OAUTH_ENC_KEY`** 设成一把 32 字节的密钥（base64，或 64 位十六进制）—— Helm 用它加密存储的 token；若配置了订阅类供应商却没设这把 key，会**拒绝启动**。在供应商上配一个 `oauth: { provider: anthropic | github-copilot | openai-codex }` 块（参见 `config/providers.yaml` 里注释掉的示例）；Claude 用 `type: anthropic`。
+先设 **`HELM_OAUTH_ENC_KEY`**（32 字节：base64 或 64 位十六进制）——配置了订阅类供应商却没设这把密钥，Helm 拒绝启动。然后给供应商加一个 `oauth: { provider: anthropic | github-copilot | openai-codex }` 块（`config/providers.yaml` 里有注释掉的示例；Claude 用 `type: anthropic`）。
 
-同一个供应商可以**接入多个账号**，Helm 把它们组成池。每个账号在 **提供商 → 管理** 里都有各自的：
+同一供应商可以**接入多个账号**组成池。每个账号（**提供商 → 管理**）各有：
 
-- **模型** —— 精确策展这个账号向你的 lane 暴露哪些模型。这份策展清单是权威的：移除某个模型后它会立刻不再被路由，未策展的模型会被拒（fail-closed）—— 是一份**实时白名单**，而不只是显示层的过滤。
-- **代理** —— 让这个账号的上游流量走 HTTP/HTTPS/SOCKS5 代理，从不同的 IP 出口（多个账号共用一台主机时，避免被关联封号）。
-- **调度** —— 一个 `priority`（越小越优先）和一个 `schedulable` 开关。Helm 选优先级最低的账号，同优先级内按 LRU 轮询；把账号「停泊」则保持连接但不参与轮换。
+- **模型** —— 一份实时白名单，不是显示层过滤：移除的模型立刻停止路由，未策展的模型直接被拒（fail-closed）。
+- **代理** —— 按账号设 HTTP/HTTPS/SOCKS5 出口，整条订阅链路都走它，让同机的多个账号从不同 IP 出去。
+- **调度** —— `priority`（越小越优先）+ `schedulable` 开关；同优先级内按 LRU 轮询。「停泊」一个账号即保持连接但退出轮换。
 
-**这里的一切都热重载** —— 连接、断开、模型策展、代理、调度的改动都在下一个请求即生效，无需重启。另外，为了表现得像一方官方客户端，Helm 会照搬官方客户端的身份头，并发送一个**稳定的、按账号固定的设备标识**（绝不会在请求之间乱变），以降低被关联封号的风险。
+这里的一切都热重载——连接、断开、策展、代理、调度——下一个请求即生效，无需重启。Helm 还会照搬官方客户端的身份头，并发送**稳定的按账号设备标识**（绝不中途轮换），以降低被关联封号的风险。
 
-> ⚠️ **服务条款。** 把 Claude/ChatGPT/Copilot **订阅**通过第三方网关来路由，可能违反供应商的服务条款，并可能成为账号被封的理由。这是面向自托管、个人使用的可选功能 —— **你需自行负责**确保用法符合你与供应商的协议。拿不准时，就改用普通的 API key（`api_key_env`）。
-
-## 管理面板
-
-挂在 `/admin`、由 HTTP Basic auth 把守：实时概览、API key（创建、吊销、设按 key 限额）、lane 与策略编辑器、分类器与系统设置，以及可下钻的请求日志 —— 点进去就能看每个请求是怎么被路由的。**仅当**设置了面板凭证时才挂载，否则 `/admin` 和 `/admin/api/*` 返回 `404`。详见 [11 管理界面](docs/11-admin-ui.md)。
+> ⚠️ **服务条款。** 把 Claude/ChatGPT/Copilot 的**订阅**通过第三方网关路由，可能违反供应商 ToS，并可能导致账号被封。这是面向自托管、个人使用的可选功能——**合规责任在你自己**。拿不准时，用普通 API key（`api_key_env`）。
 
 ## 开发
 
@@ -259,11 +234,11 @@ pnpm build        # 构建网关 + 面板
 pnpm sync:catalog # 刷新生成的模型目录（能力 + 定价）
 ```
 
-> `pnpm dev` 只起 admin SPA。网关没有 watch 脚本；要么构建后运行（`pnpm build` 再 `node apps/gateway/dist/index.js`），要么用 Docker。
+> `pnpm dev` 只起 admin SPA。网关没有 watch 脚本——构建后运行（`pnpm build` 再 `node apps/gateway/dist/index.js`），或用 Docker。
 >
 > 文档目前仅有英文版。
 
-测试先行（core 用 Vitest，完整链路用 Playwright）。设计决策记录在 [`implementation-notes.md`](implementation-notes.md)。开 PR 前，先确认所有检查通过：
+测试先行：core 用 Vitest，完整链路用 Playwright。设计决策记录在 [`implementation-notes.md`](implementation-notes.md)。开 PR 前：
 
 ```bash
 pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
@@ -286,6 +261,10 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 [11 管理界面](docs/11-admin-ui.md) ·
 [12 记忆的遗忘与分层](docs/12-memory-forgetting-and-tiering.md) ·
 [协议兼容性](docs/protocol-compatibility.md)
+
+## 项目状态
+
+Helm API 当前版本 **0.8.0**——一套端到端的真实实现，不是空架子。完整链路（配置 → 鉴权 → 分类 → 路由 → 执行（含熔断与兜底）→ 协议互译 → 遥测）已全部打通，背后是一套相当完整的 Vitest 单测加 Playwright e2e 用例。
 
 ## 许可
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -88,9 +88,11 @@ user-facing surface.
 Memory is **per-request and on by default (`inject`)**, overridable via header. The `x-memory-mode`
 header selects `off` (zero DB touch), `observe` (write-only), or `inject`
 (read-back that hydrates the message array before routing, then writes). The
-forgetting / tiering layer (short / mid / long term, decay) has **shipped** but is
-opt-in behind a config flag that defaults to off — with forgetting off, runtime
-is byte-identical to before. See [08 · Memory Middleware](08-memory-middleware.md).
+forgetting / tiering layer (short / mid / long term, decay) has **shipped** and is
+**enabled** in the shipped default config (`config/memory.yaml`:
+`forgetting.enabled: true`). Its Zod schema fallback is off, so set
+`forgetting.enabled: false` (or remove the YAML block) to get byte-identical
+pre-forgetting behavior. See [08 · Memory Middleware](08-memory-middleware.md).
 
 ## Goals
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -155,14 +155,17 @@ through. The chains live in `config/lanes.yaml`; see
 
 ## Memory middleware
 
-Memory is **opt-in per request** via the `x-memory-mode` header, normalized in
-core. `off` (the default) touches no storage. `observe` writes the turn back to
+Memory is **on by default** and overridable per request via the `x-memory-mode`
+header, normalized in core. Absent a header and a per-key default, the mode
+resolves to `inject`; newly created API keys are also minted with `inject`.
+Setting `x-memory-mode: off` (or a key default of `off`) touches no storage.
+`observe` writes the turn back to
 memory; `inject` additionally does a synchronous read-back that **fully replaces
 the message array before routing**, then also writes. Both phases are wired on the
 chat, messages, and responses surfaces (when the mode is `observe`/`inject`) — not
 on the Gemini or models surfaces. A background `MemoryWorker` (observer / reflector
 / decay jobs) runs process-wide by default and can be disabled via env. See
-[08 · Memory](08-memory.md).
+[08 · Memory](08-memory-middleware.md).
 
 ## Internal request shape
 
@@ -222,6 +225,7 @@ config/
   auth.yaml            # require_api_key + admin auth source
   runtime.yaml         # store driver, rate limit, timeouts, request size
   server.yaml          # host / port
+  memory.yaml          # observer compaction + forgetting/decay layer
 ```
 
 Capability and pricing data originate from a checked-in **generated catalog**

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -9,19 +9,24 @@ its ordered chain. The framework-agnostic orchestrator is `routeRequest`
 ## Lane routing priority
 
 ```text
-classifier short-circuit       # decided_by 'default' | 'fallback' → straight to balanced
-  > explicit model/lane        # client specified a concrete model; skips all rules
+explicit model/lane            # client specified a concrete model/lane; skips classify + policy entirely
+  > classifier short-circuit   # decided_by 'default' | 'fallback' → straight to balanced (classified branch only)
   > server-side policy         # a policy pin (use_lane)
   > task-specific lane         # a lane named after the detected task_type
   > complexity-fallback lane   # simple→economy / medium→balanced / complex→premium
   > balanced                   # final default
 ```
 
-The resolver's **priority-0** short-circuit comes first: if the classifier
-`decided_by` is `default` (classify() itself threw — hard fail-open) or
-`fallback` (eval/rules abstained), the request goes **straight to `balanced`**
-without re-deriving a lane. Both signals mean "we are not confident enough to
-steer," so they collapse to the safe terminal.
+Explicit model/lane passthrough is the **priority-0** short-circuit: a request
+that names a concrete model or lane (gated by `allow_custom_model`, and
+suppressed while degrading) skips classification and policy entirely and is
+executed directly, so the classifier never runs for it.
+
+Within the classified branch, the resolver applies its own priority-0
+short-circuit: if the classifier `decided_by` is `default` (classify() itself
+threw — hard fail-open) or `fallback` (eval/rules abstained), the request goes
+**straight to `balanced`** without re-deriving a lane. Both signals mean "we are
+not confident enough to steer," so they collapse to the safe terminal.
 
 Default lanes are deliberately few and easy to reason about. Any selected lane
 name that does not exist is skipped (fail-open); the terminal `balanced` is
@@ -245,7 +250,8 @@ attempt with its reason and latency:
    empty chain returns `lane_unavailable` (see
    [07 · Error Model & Observability](07-observability.md)).
 
-`fallback_count` counts only **non-skipped, served** attempts beyond the first —
+`fallback_count` counts only **non-skipped** attempts beyond the first (i.e.
+candidates actually attempted upstream, whether they succeeded or failed) —
 candidates pruned by the Capability Filter or skipped for an OPEN breaker do not
 increment it.
 

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -81,7 +81,9 @@ correctness reference; the code is a clean reimplementation, not a copy.
   `{type:"thinking"}` content parts and the flat `message.reasoning_content` /
   `thinking_blocks` are kept in sync, so reasoning survives every cross-protocol
   hop (OpenAI ↔ Anthropic ↔ Responses ↔ Gemini), streaming and non-streaming.
-  `reasoning_effort` maps to a per-protocol thinking-budget band — Anthropic
+  `reasoning_effort` maps to a per-protocol thinking-budget band
+  (`anthropic/request.ts` `REASONING_EFFORT_TO_BUDGET` and
+  `gemini/gemini-transformer.ts` `REASONING_EFFORT_BUDGET`) — Anthropic
   `{minimal:1024, low:2048, medium:8192, high:16384}`, Gemini
   `{minimal:128, low:1024, medium:8192, high:24576}`.
 - **Non-mappable knobs degrade observably, never silently**

--- a/docs/06-auth-and-rate-limits.md
+++ b/docs/06-auth-and-rate-limits.md
@@ -44,7 +44,6 @@ only.
 require_api_key: true
 bootstrap:
   generate_if_missing: true            # on first start with no keys, mint a root key
-  persist_to: ./data/helm-keys.json    # written to the mounted ./data volume
   print_once: true                     # plaintext printed to the boot log exactly once
 ```
 
@@ -103,9 +102,9 @@ The stored record (`ApiKeyRecord`, single source of truth in
   concurrency_limit: number | null,
 
   // Per-key memory defaults (issue #97) — x-memory-* headers override these
-  memory_mode: "off" | "observe" | "inject",   // default "off"
+  memory_mode: "off" | "observe" | "inject",   // new keys mint "inject"; root key forced "off"; legacy rows parse-default "off"
   memory_project_id: string | null,
-  memory_thread_source: "header" | ...,        // default "header"
+  memory_thread_source: "header" | "auto",     // new keys mint "auto"; root key forced "header"; legacy rows parse-default "header"
 }
 ```
 

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -88,7 +88,7 @@ plaintext key and no private payload. The record holds:
   `memory_tokens_injected`, `observer_job_id`, `memory_writeback_status`
   (`queued` / `skipped` / `failed`), `degraded`, and `thread_source` (which
   fallback-chain link produced the thread anchor). See [08 ·
-  Memory](08-memory.md).
+  Memory](08-memory-middleware.md).
 
 Per **Principle 5**, the **classification** fallback (`classifier.decided_by` /
 `fallback_reason`) and the **execution** fallback (`provider_attempts` /

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -1,8 +1,8 @@
 # 08 · Memory Middleware
 
-> Status: **implemented, opt-in.** `observe` and `inject` are both wired
-> end-to-end across the OpenAI Chat, Anthropic Messages, and OpenAI Responses
-> surfaces (Gemini is not wired), together with a process-wide background
+> Status: **implemented; on by default.** `observe` and `inject` are both wired
+> end-to-end across the OpenAI Chat, Anthropic Messages, OpenAI Responses, and
+> Gemini generateContent surfaces, together with a process-wide background
 > `MemoryWorker` that drains the `memory_jobs` queue (observer / reflector /
 > decay jobs). The four memory headers are parsed at the gateway boundary
 > (`apps/gateway/src/routes/memory-scope.ts`); mode normalization and
@@ -14,8 +14,11 @@
 > interface. Swapping in an LLM is a drop-in replacement.
 >
 > The forgetting & tiering layer ([12 · Memory: Forgetting & Tiering](12-memory-forgetting-and-tiering.md))
-> has also shipped, gated behind `config.memory.forgetting.enabled` whose schema
-> default is `false`. With forgetting off, runtime is byte-identical to before.
+> has also shipped, gated behind `config.memory.forgetting.enabled`. Although the
+> Zod schema default is `false`, the shipped `config/memory.yaml` sets
+> `forgetting.enabled: true`, so the default deployment runs with forgetting **ON**
+> (decay sweeps, reinforcement, fact extraction). Set it to `false` for the legacy
+> byte-identical-to-before behavior.
 
 ## Positioning
 
@@ -50,9 +53,12 @@ x-project-id:  the project-level memory scope
 x-memory-mode: off | observe | inject
 ```
 
-Default: `x-memory-mode = off`. Mode normalization is centralized in core's
-`resolveMemoryMode`; an absent, illegal, or wrong-case value falls back safely to
-`off`. An empty `x-thread-id` yields `null` (never a fabricated thread id), and
+Default mode: an absent `x-memory-mode` resolves to the API key's stored default;
+keys created through the app default to `inject` (memory on), and the
+no-key-config path also falls back to `inject`. Only a present-but-illegal or
+wrong-case header value normalizes to `off` (centralized in core's
+`resolveMemoryMode` — a typo must never silently inherit a more permissive mode).
+An empty `x-thread-id` yields `null` (never a fabricated thread id), and
 `observe` self-gates to a no-op when there is no thread scope.
 
 Modes:
@@ -228,13 +234,14 @@ memory_observations
   reference_count, importance, status (active | archived), archived_at, expired_at
 
 memory_reflections
-  id, project_id, resource_id, thread_id, reflection_text, version,
+  id, owner_id, project_id, resource_id, thread_id, reflection_text, version,
   token_estimate, updated_at,
   referenced_at, reference_count, status
 
 memory_facts
-  id, owner_id, subject_key, content_hash, content,
-  valid_from, invalid_at, expired_at, status
+  id, owner_id, project_id, resource_id, thread_id, subject_key,
+  content_hash, fact_text, importance, reference_count, referenced_at,
+  source_observation_range, valid_from, invalid_at, expired_at, status
 
 memory_jobs
   id, type (observer | reflector | decay), scope_id, status, error,
@@ -303,7 +310,7 @@ until the LLM summarizer lands.
 - Project / resource / thread scope hierarchy.
 - Structured facts (`memory_facts`) and scope aggregation.
 
-### Phase 4 — Forgetting & tiering · implemented (opt-in)
+### Phase 4 — Forgetting & tiering · implemented (on by default in the shipped config)
 
 - Short / mid / long-term tiers mapped onto recent_raw / observations /
   reflections + facts.
@@ -311,7 +318,8 @@ until the LLM summarizer lands.
   access reinforcement) driving score-based inject trimming, an off-hot-path
   decay sweep, soft-archive, and bi-temporal supersede.
 - See [12 · Memory: Forgetting & Tiering](12-memory-forgetting-and-tiering.md).
-  Gated behind `config.memory.forgetting.enabled` (schema default `false`).
+  Gated behind `config.memory.forgetting.enabled` (Zod schema default `false`, but
+  the shipped `config/memory.yaml` sets it `true` — on by default).
 
 ## Non-goals
 

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -1,12 +1,14 @@
 # 09 · Roadmap
 
-> Status: **shipped — 0.6.0.** The core gateway (routing, classification, provider
+> Status: **shipped — 0.8.0.** The core gateway (routing, classification, provider
 > execution, protocol translation, telemetry) runs in production, and several major
 > subsystems have landed since the early releases: a memory middleware (observe +
-> inject + background workers, opt-in), per-key budgets / rate limits / concurrency
-> limiting, runtime hot-reload settings, verbatim payload capture, four streaming
-> inbound protocols, full OAuth subscription providers, and an admin-UI overhaul.
-> The "deferred" list below is what is genuinely still out of scope or not yet wired.
+> inject + background workers, on by default), per-key budgets / rate limits /
+> concurrency limiting, runtime hot-reload settings with admin YAML write-back,
+> verbatim payload capture, four streaming inbound protocols, full OAuth subscription
+> providers, an admin-UI overhaul, observer-economy compaction, and permanent delete
+> of revoked keys. The "deferred" list below is what is genuinely still out of scope
+> or not yet wired.
 
 ## Delivered
 
@@ -42,16 +44,20 @@ Clients can mix SDKs; cross-protocol SSE conversion is covered per direction. Se
 
 ### Memory middleware
 
-Opt-in per request via the `x-memory-mode` header (default `off` — zero DB touch):
+Memory defaults to **inject** for new keys and for requests with no `x-memory-mode`
+header (memory-on-by-default since #107); send `x-memory-mode: off` or set a per-key
+default of `off` to opt out (zero DB touch):
 
 - **`observe`** — write-only capture of inbound/outbound turns.
 - **`inject`** — synchronous read-back that full-replaces the message array before
   routing, then also writes. Wired on the chat, Messages, and Responses surfaces.
 - **Background `MemoryWorker`** runs process-wide by default (disable via
   `HELM_MEMORY_WORKER_DISABLED=1`), dispatching observer / reflector / decay jobs.
-- **Forgetting & tiering** (short / mid / long, see [12 · Memory Tiering](12-memory-tiering.md))
-  has shipped, gated behind `config.memory.forgetting.enabled` — **default `false`**,
-  so with forgetting off the runtime is byte-identical to before.
+- **Forgetting & tiering** (short / mid / long, see [12 · Memory Tiering](12-memory-forgetting-and-tiering.md))
+  has shipped, gated behind `config.memory.forgetting.enabled`. The Zod schema
+  default is `false` (fail-safe), but the shipped `config/memory.yaml` enables it
+  (`true`) since #106, so a default deployment runs decay/reinforcement; set it to
+  `false` to get pre-docs/12 byte-identical behavior.
 - The `DecisionRecord` carries a redacted `memory` block (counts / ids only, never
   content). See [08 · Memory Middleware](08-memory-middleware.md).
 
@@ -80,7 +86,10 @@ and OpenAI Codex (ChatGPT):
   degrade-to-cheaper-lane or reject), and concurrency limiting — all metered **per
   API key**.
 - **Runtime hot-reload settings.** Lanes, policies, classifier, and system settings
-  re-bind the live config and apply on the next request — no restart.
+  re-bind the live config and apply on the next request — no restart. Since #115,
+  classifier/lanes/policies edits are also persisted back to `config/*.yaml`
+  (comment-preserving, atomic, fail-closed) before the live config rebinds, so they
+  survive restarts rather than being reverted on restart.
 - **Verbatim payload capture.** Full request/response bodies recorded to a separate
   `request_payloads` table (default on, 30-day retention), toggleable in System
   Settings.

--- a/docs/11-admin-ui.md
+++ b/docs/11-admin-ui.md
@@ -75,7 +75,10 @@ The landing page (`/`) gives an at-a-glance overview.
   (`off` / `observe` / `inject` with project id and thread source). Backed by the
   KeyStore (`/admin/api/keys` `GET` / `POST` / `PATCH` / `DELETE`), never YAML.
   The plaintext of a freshly minted key is returned exactly once (Principle 7);
-  revocation is a soft disable. See [06 · Auth, API Keys & Rate
+  revocation is a soft disable. A revoked key can then be permanently deleted as
+  an explicit second step (DELETE `?purge=true`); the server refuses to purge an
+  active key (409 'key must be revoked before deletion'). Telemetry keeps an
+  unlinked key_id reference for audit history. See [06 · Auth, API Keys & Rate
   Limits](06-auth-and-rate-limits.md).
 - **Lanes** (`/lanes`) — view/edit each lane's `primary + fallback[]`
   (`/admin/api/lanes` CRUD). The model combobox is populated from a read-only
@@ -87,12 +90,12 @@ The landing page (`/`) gives an at-a-glance overview.
   inspect the rule dimensions/weights (`/admin/api/classifier`). See [03 ·
   Classification Cascade](03-classification.md).
 
-Rule edits go through a runtime rule store that re-binds the live `lanes` /
-`policies` / `classifier` config the router reads — applied on the very next
-request, no restart. These edits are held in-process only and are **not**
-persisted across restarts; YAML write-back is future work. For durable changes,
-edit `config/*.yaml` directly. (The runtime **Settings** below are the exception
-— they are persisted to the config store.)
+Rule edits go through a runtime rule store that FIRST writes the change back to
+the canonical `config/*.yaml` (comment-preserving, atomic, fail-closed) and then
+re-binds the live `lanes` / `policies` / `classifier` config the router reads —
+applied on the very next request, no restart, and durable across restarts. A
+failed write rejects the edit with the live config unchanged, so file and memory
+never diverge.
 
 ### Providers (OAuth subscriptions)
 
@@ -138,7 +141,10 @@ edit `config/*.yaml` directly. (The runtime **Settings** below are the exception
   Observability](07-observability.md): classification stage, matched policy, lane
   candidate chain, provider attempts, cost, error, and `trace_id`. When
   `capture_payloads` is on, the detail can load the full captured request/response
-  bodies (`/admin/api/requests/:traceId/payload`).
+  bodies (`/admin/api/requests/:traceId/payload`). When the full request body was
+  captured and is an OpenAI-chat request (a `messages` array), the detail page
+  offers an editable **Retry** button that re-sends the (optionally edited) body
+  as an isolated, newly-traced debug re-run via the server replay endpoint.
 
 ## Boundaries
 

--- a/docs/12-memory-forgetting-and-tiering.md
+++ b/docs/12-memory-forgetting-and-tiering.md
@@ -31,7 +31,7 @@
 | Retention (tombstone obs / hard-delete facts) | `packages/core/src/memory/forgetting/retention.ts` → `pruneRetainedMemory` |
 | Deterministic fact-extractor stub | `extractFactsFromObservations` in `apps/gateway/src/server.ts` |
 | Scheduler dispatch (`type='decay'`) + sweep `onTick` | `startMemoryWorker` wiring in `apps/gateway/src/server.ts` |
-| Config schema (snake_case, `.strict()`) | `packages/shared/src/config/schema.ts` (`ForgettingSchema`) |
+| Config schema (snake_case, `.strict()`) | `packages/shared/src/config/memory-schema.ts` (`ForgettingSchema`; re-exported from `config/schema.ts`) |
 | Migration v18 + Zod row deltas | `packages/core/src/store/sqlite/migrate.ts`, `packages/shared/src/memory/schema.ts` |
 
 ## Why this exists
@@ -462,10 +462,15 @@ excluded) and is read in `apps/gateway/src/server.ts`.
 
 Zod sketch (single source of truth; types via `z.infer`). **Keys are snake_case to
 match the YAML** and every object is `.strict()` — exactly the repo convention
-(`packages/shared/src/config/schema.ts`). snake_case + `.strict()` is what makes
+(`ForgettingSchema` / `ScoreSchema` are defined in
+`packages/shared/src/config/memory-schema.ts`, re-exported from `config/schema.ts`).
+snake_case + `.strict()` is what makes
 config-as-code fail-closed: a misspelled key throws at startup instead of being
 silently stripped to the default, and a real `half_life_s: 3600` actually takes
-effect (tests assert both the round-trip and the unknown-key rejection).
+effect (tests assert both the round-trip and the unknown-key rejection). Every
+nested block uses `.prefault({})` (not `.default({})`) so its inner field defaults
+actually fire when the block is omitted — a bare `.default({})` would hand back a
+literal `{}` with undefined inner fields (`half_life_s` would be `undefined`).
 
 ```ts
 const ScoreSchema = z.object({
@@ -477,27 +482,27 @@ const ScoreSchema = z.object({
 
 export const ForgettingSchema = z.object({
   enabled: z.boolean().default(false),
-  score:   ScoreSchema.default({}),
-  inject:  z.object({ drop_order: z.enum(["score", "oldest"]).default("score") }).strict().default({}),
+  score:   ScoreSchema.prefault({}),
+  inject:  z.object({ drop_order: z.enum(["score", "oldest"]).default("score") }).strict().prefault({}),
   decay:   z.object({
     archive_threshold:    z.number().min(0).max(1).default(0.05),
     trigger_observations: z.number().int().positive().default(50),
     trigger_interval_s:   z.number().int().positive().default(3600),
-  }).strict().default({}),
+  }).strict().prefault({}),
   consolidate: z.object({
     trigger_tokens:       z.number().int().positive().default(1024),
     max_facts_per_subject: z.number().int().positive().default(8),
     enable_llm_supersede: z.literal(false).default(false), // deferred — `true` refuses startup (no lying knobs)
-  }).strict().default({}),
+  }).strict().prefault({}),
   retention: z.object({
     archived_days:      z.number().int().positive().default(30),
     facts_expired_days: z.number().int().positive().default(90),
-  }).strict().default({}),
+  }).strict().prefault({}),
   sweep: z.object({
     max_iterations:         z.number().int().positive().default(200),
     max_wallclock_s:        z.number().int().positive().default(900),
     max_consecutive_errors: z.number().int().positive().default(5),
-  }).strict().default({}),
+  }).strict().prefault({}),
 }).strict();
 export type ForgettingConfig = z.infer<typeof ForgettingSchema>;
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,4 +59,4 @@ These keep Helm more focused than its predecessor `llm-router`:
 | Specification | Implemented (these documents describe the shipping system) |
 | Core gateway (routing, classification, protocol translation, store) | Implemented |
 | Admin UI | Implemented |
-| Release | 0.6 |
+| Release | 0.8.0 |

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -132,9 +132,10 @@ Of the four transformers only Gemini exposes **both** `transformStreamIn` and
 
 ## Tool / function calling
 
-- **Anthropic** tool names are sanitized to `^[A-Za-z0-9_-]` with a max length of
-  64; collisions are disambiguated with an FNV-1a hash suffix so distinct source
-  names stay distinct after sanitization.
+- **Anthropic** tool names are sanitized to `^[A-Za-z0-9_]+` — letters, digits,
+  and underscore only (hyphens and other characters become `_`) — with a max
+  length of 64; collisions are disambiguated with an FNV-1a hash suffix so
+  distinct source names stay distinct after sanitization.
 - **Gemini** tool calls have **no wire id**. Inbound, Helm synthesizes a
   deterministic `call_<name>_<occurrence>` id; outbound, that synthetic id is
   dropped (Gemini never sees it).

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -320,5 +320,6 @@ Do not copy blindly:
 - Making dynamic RAG the default memory strategy.
 
 > See [08 · Memory Middleware](08-memory-middleware.md) for how these ideas map to
-> Helm: the observe phase is implemented, the inject phase / Observer / Reflector
-> are on the roadmap.
+> Helm: observe and inject are both implemented end-to-end with a background
+> Observer/Reflector worker (opt-in); only the real LLM summarize/merge step
+> remains a deterministic stub.


### PR DESCRIPTION
## Summary

Every doc in `docs/` was audited claim-by-claim against the 0.8.0 implementation (multi-agent audit → adversarial confirmation → per-file fix), then both READMEs were rewritten. **Docs only — zero code changes.**

## Doc corrections (all code-verified)

| Doc | Fix |
|---|---|
| 01 / 02 / 08 / 09 | Memory is **on by default** since #107 (new keys mint `inject`; `x-memory-mode: off` opts out); forgetting is **enabled in the shipped `config/memory.yaml`** since #106 (Zod default stays `false` as fail-safe) — docs claimed "opt-in / off by default" |
| 04 | Lane-priority order: explicit model/lane passthrough is the true priority-0 short-circuit *before* classification (`route-request.ts`); the `decided_by default\|fallback` short-circuit is scoped to the classified branch; `fallback_count` wording corrected |
| 05 | `reasoning_effort` budget bands attributed to their real homes (`anthropic/request.ts`, `gemini/gemini-transformer.ts`) |
| 06 | `persist_to: helm-keys.json` is parsed-but-unused — root key persists via KeyStore (hash+prefix only); per-key memory field comments now distinguish mint vs parse vs root defaults |
| 11 | Rule edits persist back to `config/*.yaml` since #115 (doc said "future work"); added permanent key purge (#112) and editable Retry (#114) |
| 12 | Schema pointer → `config/memory-schema.ts`; Zod sketch `.default({})` → `.prefault({})` to match shipping code |
| protocol-compatibility | Anthropic tool-name sanitizer replaces hyphens with `_` (`[A-Za-z0-9_]`, not `[A-Za-z0-9_-]`) |
| docs/README, 09 | Release 0.6 → **0.8.0** |
| — | Fixed 3 pre-existing broken links (`08-memory.md` ×2, `12-memory-tiering.md`); all relative `.md` links now resolve |

Clean after audit (no changes needed): 03, 07, 10.

## README rewrite (en + zh-CN)

- Quickstart-first structure, feature table, "two failure disciplines" promoted to its own section.
- Updated to 0.8.0 reality: memory defaults, admin YAML write-back, Retry button, key purge — the old README contradicted itself on the memory default (off in "Why Helm", on in "Features").
- zh-CN is an idiomatic re-translation (意译) in a serious, concise register, not a literal mirror; the old zh-CN had missed the entire 0.7 reconciliation.

## Verification

- Every correction cites code evidence (file/line, schema default, or commit) and survived an adversarial verification pass.
- Link check: all relative `.md` links in `docs/` + READMEs resolve.
- No source files touched: `git diff main --stat` shows only `README.md`, `README.zh-CN.md`, and `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)