### PR TITLE
fix(admin): show request time on the detail page

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -120,6 +120,14 @@ describe('toDetail', () => {
     const d = toDetail(rawRecord());
     expect(d.provider_attempts[0]?.error_detail ?? null).toBeNull();
   });
+
+  it('maps the recorded created_at (epoch ms) to an ISO ts; legacy records stay empty', () => {
+    const d = toDetail(rawRecord({ created_at: 1717155600000 }));
+    expect(d.ts).toBe(new Date(1717155600000).toISOString());
+    // No created_at on a legacy record → empty (never fabricated), so the detail
+    // header degrades to "time not recorded" rather than showing a wrong time.
+    expect(toDetail(rawRecord()).ts).toBe('');
+  });
 });
 
 describe('listRequests', () => {

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -312,7 +312,10 @@ export function toDetail(raw: RawDecisionRecord): RequestDetail {
   const evalCacheHit = raw.classifier?.eval_cache_hit ?? null;
   return {
     trace_id: String(raw.trace_id ?? raw.request_id ?? ''),
-    ts: '',
+    // Same source as the list "Time" column (created_at, flattened by the detail
+    // endpoint). Legacy records without it stay empty → header shows the
+    // "time not recorded" placeholder rather than a fabricated time.
+    ts: typeof raw.created_at === 'number' ? new Date(raw.created_at).toISOString() : '',
     request_meta: buildRequestMeta(raw),
     // The backend does not persist a payload; we render a redaction placeholder so
     // the operator knows it was intentionally withheld (Principle 7).

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -177,6 +177,12 @@ function makeTelemetry(seed: DecisionRecord[] = []): TelemetryStore {
     async getApiKeyId(id) {
       return rows.some((r) => r.request_id === id) ? "k1" : null;
     },
+    async getCreatedAt(id) {
+      // Mirror the deterministic per-row timestamp used by queryRecent/queryPage
+      // so the detail route's created_at projection lines up with the list.
+      const i = rows.findIndex((r) => r.request_id === id);
+      return i >= 0 ? new Date(1_700_000_000_000 - i * 1000) : null;
+    },
     async queryWindow() {
       return [...rows];
     },
@@ -792,11 +798,15 @@ describe("admin.api requests", () => {
 
     const detail = (await (
       await app.request("/admin/api/requests/trace-1")
-    ).json()) as DecisionRecord;
+    ).json()) as DecisionRecord & { created_at: number };
     expect(detail.trace_id).toBe("trace-1");
     expect(detail.classifier.task_type).toBe("coding"); // classification stage
     expect(detail.lane.candidate_chain).toEqual(["premium", "balanced"]); // lane candidate chain
     expect(detail.provider_attempts).toHaveLength(1); // provider attempts
+    // The detail also carries the recorded timestamp (epoch ms) so the SPA header
+    // shows the request time instead of "time not recorded" (same source as the
+    // list "Time" column; the DecisionRecord itself has no timestamp field).
+    expect(detail.created_at).toBe(1_700_000_000_000);
   });
 
   it("forwards filters + pagination to the store and returns the page envelope", async () => {

--- a/apps/gateway/src/routes/admin/replay.test.ts
+++ b/apps/gateway/src/routes/admin/replay.test.ts
@@ -67,6 +67,9 @@ function fakeTelemetry(
     async getApiKeyId() {
       return keyId;
     },
+    async getCreatedAt() {
+      return null;
+    },
     async insert(input) {
       if (opts.failInsert) throw new Error("telemetry down");
       rec.inserts.push(input);

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -46,11 +46,16 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
     });
   });
 
-  // GET /requests/:traceId -> RequestDetail (full decision trail) | 404.
+  // GET /requests/:traceId -> RequestDetail (full decision trail) | 404. The
+  // DecisionRecord has no timestamp field, so we flatten created_at (epoch ms)
+  // onto it exactly like the list endpoint above — the SPA header shows the same
+  // request time as the list "Time" column instead of "time not recorded".
   app.get("/admin/api/requests/:traceId", async (c) => {
-    const rec = await deps.telemetry.getByRequestId(c.req.param("traceId"));
+    const traceId = c.req.param("traceId");
+    const rec = await deps.telemetry.getByRequestId(traceId);
     if (!rec) return c.json({ error: "request not found" }, 404);
-    return c.json(rec);
+    const createdAt = await deps.telemetry.getCreatedAt(traceId);
+    return c.json(createdAt ? { ...rec, created_at: createdAt.getTime() } : rec);
   });
 
   // GET /requests/:traceId/payload -> the captured full request/response bodies

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-07 · 请求详情页时间显示「未记录时间」（修复；docs/07）
+
+- **Bug（用户报告）**：请求详情页头部恒显「未记录时间」。根因两处：① 网关详情接口 `GET /admin/api/requests/:traceId` 直接吐 `getByRequestId` 返回的 `DecisionRecord`，而该 record **schema 本身不含时间戳**（时间在独立的 `createdAt` 列里）；列表接口 `GET /requests` 早已 `created_at: r.createdAt.getTime()` 拍平上去，详情接口没拍。② 前端 `toDetail` 把 `ts` **写死成 `''`**（`toListItem` 早已正确从 `created_at` 映射），于是详情页永远落入 `{d.ts || '未记录时间'}` 兜底。
+- **方案（窄查询，对齐列表数据源）**：新增 Store 端口方法 `getCreatedAt(requestId): Promise<Date | null>`，仿 `getApiKeyId` 只 select 单列、不反序列化 decision blob；sqlite 直接返回 Date 列，postgres 列是 epoch-ms bigint 需 `new Date(ms)` 包回。网关详情接口改为 `{ ...rec, created_at: createdAt.getTime() }`（缺失则不加字段）。前端 `toDetail` 改成与 `toListItem` 同款 `created_at → ISO`；legacy 无值仍空串 → 仍走「未记录时间」兜底（绝不伪造时间）。**详情与列表时间同源同值，必然一致。**
+- **验证**：TDD 先红后绿——store-contract（双适配器 getCreatedAt 命中/未命中）、gateway 详情断言 `created_at`、前端 toDetail ts 映射；同步给 4 处 TelemetryStore mock 补 `getCreatedAt`。typecheck/lint 净，全量单测 2515 绿（唯 4 例 `admin-static.test` 红——需先 `pnpm build` 出 SPA 产物，与本改无关）。
+
+---
+
 ## 2026-06-06 · 管理界面规则编辑写回 YAML（修复「保存只活在内存、重启即回滚」；用户决策；docs/11；CLAUDE.md 原则 2）
 
 - **Bug（用户报告）**：分类器/Lanes/Policies 三页的「保存」只经 `createRuntimeRuleStore` 重绑**内存变量**（rule-store.ts 自注 "MVP…future YAML write-back adapter"），不落任何持久层——重启即回滚到 yaml。其余面（System Settings → config_kv、Keys/OAuth → DB）本就持久，仅这三页挥发。
@@ -32,20 +40,11 @@
 
 ---
 
-## 2026-06-06 · 已吊销 key 允许永久删除（两步销毁；用户决策；docs/06）
-
-- **动机**：原来 key 只能软吊销（`DELETE /admin/api/keys/:id` → `disabled:true`），行永久保留，admin 列表里已吊销 key 越积越多、无从清理。用户要求「吊销后允许删除」。
-- **两步销毁（拍板）**：保留 `DELETE /:id` = 软吊销契约不动；硬删除作为同一路由的 `?purge=true` 旗标。路由侧 gate：先 `list().find` 取当前态——未找到 `404`、仍 active `409`（必须先吊销）、已 `disabled` 才 `deleteKey` → `{deleted:id}`。**「必须先吊销」是路由策略，不进 store**（沿用 getByHash 返回 disabled key、由 caller 决策的既有模式）。UI 仅在 disabled 行展示 Delete 按钮，但 server 仍独立校验（纵深防御）——active key 永不被静默清除，软吊销审计步骤不可跳过。
-- **审计存活（关键论据）**：telemetry/payload 表的 `api_key_id` 是**无 FK 的纯文本列**（schema 第 49/58 行），硬删 key 行不级联、不报错，历史决策仍保留该（现悬空）key 引用可供审计。这调和了 CLAUDE.md 原则 7 / docs/06「吊销不物理删除」——那是指吊销本身不该静默销毁；此处是**显式二次销毁**，前提是已有一条可审计的软吊销记录。
-- **贯穿层**：core `KeyStore.deleteKey`（port + sqlite `db.delete().run()` 查 `changes===0`、pg `.returning()` 查 `length===0`，均 throw on unknown）→ admin route 分支 → api client `deleteKey` 打 `?purge=true` → `+page.svelte`（disabled 行 Delete 按钮 + 确认 Modal，成功 `keys.filter` 移除行）。i18n 新增 6 key（en + zh-hans 意译，其余 locale 回退英文，留 `pnpm i18n:sync` 补）。
-- **测试（TDD 先红）**：keystore.test（删除后 getByHash→null、list 变短；删未知 reject）；admin.test（mock 加 `deleteKey` splice；purge disabled→200+行消失、purge active→409+行存、purge unknown→404；原软吊销 no-flag 用例保持绿）；keys.test（mock 加 `deleteKey`；disabled 行只显 Delete、确认后 deleteKey 被调+行消失、删除失败显错+行存 fail-closed）。
-- **坑/注**：`?purge=true` 旗标 vs 子资源路径——选旗标以保单 handler、不破既有 revoke 契约/测试。route gate 用 `list().find` 而非新增 `getById`（port 无 getById，list 量小、admin 非热路径），read→delete 之间的 TOCTOU 在自托管单管理员场景可忽略，且 deleteKey 仍 throw→catch 回 404 兜底。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-06 · 已吊销 key 允许永久删除（两步销毁；用户决策；docs/06）：软吊销 `DELETE /:id` 契约不动，硬删作 `?purge=true` 旗标；路由 gate `list().find`——未找 404 / active 409（必先吊销）/ disabled 才 deleteKey。「必先吊销」是路由策略不进 store；UI 仅 disabled 行显 Delete 但 server 独立校验（纵深防御）。审计存活靠 telemetry/payload 的 `api_key_id` 是无 FK 纯文本列，硬删不级联、悬空引用仍可审计。贯穿 core `KeyStore.deleteKey`(throw on unknown)→admin route→api client→+page。坑：选旗标不破 revoke 契约；read→delete TOCTOU 在单管理员场景可忽略 + deleteKey throw 兜底。
 
 ### 2026-06-06 · 记忆 thread source 新 key 默认 auto（配合「记忆默认开启」；用户决策；docs/08）：新 key `memory_mode=inject` 却 thread source 仍 `header` = 缺 `x-thread-id` 不回退信号链、无 per-conversation 记忆——两 keystore `createKey` mint 默认 `?? "header" → ?? "auto"`（仅新 key；Zod parse-default `header` 不动，既有 key/迁移不重写）。admin UI 诚实化：KeyCapsForm/CreateKeyDialog 默认显 Auto = 实际落库值。Codex 修复：(P2) `bootstrapRootKey` 显式置 `off`+`header` 让 root key 记忆惰性（root key 勿用于生产流量）；(P3) CreateKeyInput 各层注释自 #106 起误写「omitted => off」→ 改如实「省略 ⇒ mint 默认 inject/auto」。
 

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -123,6 +123,9 @@ class InMemoryTelemetryStore implements TelemetryStore {
   async getApiKeyId(requestId: string): Promise<string | null> {
     return this.rows.find((r) => r.rec.request_id === requestId)?.keyId ?? null;
   }
+  async getCreatedAt(requestId: string): Promise<Date | null> {
+    return this.rows.find((r) => r.rec.request_id === requestId)?.at ?? null;
+  }
   async queryWindow(startMs: number, endMs: number): Promise<DecisionRecord[]> {
     return [...this.rows]
       .filter((r) => r.at.getTime() >= startMs && r.at.getTime() < endMs)

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -264,6 +264,11 @@ export interface TelemetryStore {
   // identity/caps. key_id only — never a hash/plaintext (principle 7). null on a
   // miss (unknown/pruned request).
   getApiKeyId(requestId: string): Promise<string | null>;
+  // Resolve the recorded createdAt for one request. The redacted DecisionRecord
+  // carries no timestamp field (the time lives in its own column, flattened as
+  // created_at by the list endpoint), so the detail header uses this narrow
+  // lookup to show the request time. null on a miss (unknown/pruned request).
+  getCreatedAt(requestId: string): Promise<Date | null>;
   // POST-MVP Agentic Signals (docs/02). Read every decision record whose
   // createdAt falls in [startMs, endMs) so the background Signal Collector can
   // aggregate a window AFTER the fact. Half-open interval keeps adjacent windows

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -123,6 +123,20 @@ export class PgTelemetryStore implements TelemetryStore {
     return rows[0]?.apiKeyId ?? null;
   }
 
+  // Narrow single-column lookup of the recorded createdAt (detail header time).
+  // Selects only created_at so it never deserializes the decision blob.
+  async getCreatedAt(requestId: string): Promise<Date | null> {
+    const rows = await this.db
+      .select({ createdAt: telemetry.createdAt })
+      .from(telemetry)
+      .where(eq(telemetry.requestId, requestId))
+      .limit(1);
+    // createdAt is stored as epoch ms (bigint) here — wrap it back to a Date so
+    // the port contract is identical across adapters.
+    const ms = rows[0]?.createdAt;
+    return ms === undefined ? null : new Date(ms);
+  }
+
   // POST-MVP Agentic Signals (docs/02): records whose createdAt is in
   // [startMs, endMs). Half-open so adjacent windows never overlap → re-collects
   // stay idempotent. createdAt stored as epoch ms (bigint) → compare ms directly.

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -120,6 +120,17 @@ export class SqliteTelemetryStore implements TelemetryStore {
     return row?.apiKeyId ?? null;
   }
 
+  // Narrow single-column lookup of the recorded createdAt (detail header time).
+  // Selects only created_at so it never deserializes the decision blob.
+  async getCreatedAt(requestId: string): Promise<Date | null> {
+    const row = this.db
+      .select({ createdAt: telemetry.createdAt })
+      .from(telemetry)
+      .where(eq(telemetry.requestId, requestId))
+      .get();
+    return row?.createdAt ?? null;
+  }
+
   // POST-MVP Agentic Signals (docs/02): records whose createdAt is in
   // [startMs, endMs). Half-open so adjacent windows never overlap → the
   // background collector's re-runs stay idempotent. Read-only; never on the

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -496,6 +496,21 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(await ctx.stores.telemetry.getApiKeyId("nope")).toBeNull();
     });
 
+    it("getCreatedAt returns the recorded timestamp, null on a miss", async () => {
+      ctx = await make();
+      const stamp = new Date(1_700_000_000_000);
+      await ctx.stores.telemetry.insert({
+        decision: decision("req_1"),
+        apiKeyId: "k1",
+        createdAt: stamp,
+      });
+      // The redacted DecisionRecord has no timestamp field; the detail header
+      // resolves the request time through this narrow lookup (same column the
+      // list endpoint flattens as created_at).
+      expect((await ctx.stores.telemetry.getCreatedAt("req_1"))?.getTime()).toBe(stamp.getTime());
+      expect(await ctx.stores.telemetry.getCreatedAt("nope")).toBeNull();
+    });
+
     it("stores no plaintext key and no raw message payload", async () => {
       ctx = await make();
       await ctx.stores.telemetry.insert({

--- a/packages/core/src/telemetry/decision.test.ts
+++ b/packages/core/src/telemetry/decision.test.ts
@@ -354,6 +354,7 @@ describe("persistDecision", () => {
       queryPage: async () => ({ rows: [], total: 0 }),
       getByRequestId: async () => null,
       getApiKeyId: async () => null,
+      getCreatedAt: async () => null,
       queryWindow: async () => [],
       insertPayload: async () => {},
       getPayload: async () => null,


### PR DESCRIPTION
## 问题

请求详情页头部恒显「未记录时间」（time not recorded）。

## 根因

两处缺口叠加：

1. **网关**：详情接口 `GET /admin/api/requests/:traceId` 直接返回 `getByRequestId` 的 `DecisionRecord`，而该 record 的 schema **本身不含时间戳**——时间存在独立的 `createdAt` 列里。列表接口 `GET /requests` 早已 `created_at: r.createdAt.getTime()` 拍平上去，详情接口没拍。
2. **前端**：`toDetail` 把 `ts` **写死成 `''`**（`toListItem` 早已正确从 `created_at` 映射），于是详情页永远落入 `{d.ts || $t('time not recorded')}` 兜底。

## 方案（窄查询，对齐列表数据源）

- 新增 Store 端口方法 `getCreatedAt(requestId): Promise<Date | null>`，仿 `getApiKeyId` 只 select 单列、不反序列化 decision blob；sqlite 直接返回 Date 列，postgres 列是 epoch-ms bigint 需 `new Date(ms)` 包回。
- 网关详情接口改为 `{ ...rec, created_at: createdAt.getTime() }`（缺失则不加字段），与列表接口对齐。
- 前端 `toDetail` 改成与 `toListItem` 同款 `created_at → ISO`；legacy 无值仍空串 → 仍走「未记录时间」兜底（绝不伪造时间）。

**详情与列表时间同源同值，必然一致。**

## 测试（TDD 先红后绿）

- `store-contract`：双适配器 `getCreatedAt` 命中/未命中
- gateway 详情断言 `created_at`
- 前端 `toDetail` ts 映射
- 同步给 4 处 `TelemetryStore` mock 补 `getCreatedAt`

## 验证

- ✅ `pnpm typecheck` 净
- ✅ Biome lint：改动文件零问题
- ✅ `pnpm test`：**2515 通过**（含全部新增测试）
- ⚠️ 唯 4 例 `admin-static.test` 红——服务已构建的 SPA 产物（`apps/admin/build`），需先 `pnpm build`，**与本改无关**

🤖 Generated with [Claude Code](https://claude.com/claude-code)