### PR TITLE
chore(release): v0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release v0.8.2

Patch release. Root `package.json` bumped `0.8.1 → 0.8.2`.

### Changes since v0.8.1

- **fix(admin)**: request detail page no longer shows "未记录时间" / "time not recorded" (#119). The detail endpoint now flattens `created_at` onto the response (mirroring the list endpoint) via a new narrow `getCreatedAt` store port method, and the SPA's `toDetail` maps it. The detail header shows the same request time as the list "Time" column; legacy records without a timestamp keep the placeholder rather than a fabricated time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)