### PR TITLE
fix(admin): surface YAML persist failures as actionable 500 instead of 502

### DIFF
--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -6,6 +6,7 @@ import { Hono } from "hono";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { AppEnv } from "../../app.js";
 import { basicAuth } from "../../middleware/basic-auth.js";
+import { handleError } from "../../middleware/error-handler.js";
 import type { AdminApiDeps, RuleStore, SettingsAccess } from "./deps.js";
 import { registerAdminApi } from "./index.js";
 
@@ -1191,5 +1192,137 @@ describe("admin.api oauth schedule validation", () => {
     });
     expect(res.status).toBe(204);
     expect(captured).toEqual([{ priority: 0 }]);
+  });
+});
+
+describe("admin.api rule persist failures", () => {
+  // The YAML write-back (yaml-writeback.ts) throws when config/*.yaml cannot be
+  // written — most commonly EACCES: the mounted ./config dir is owned by root
+  // while the container runs as uid 10001. That is a LOCAL fault: it must
+  // surface as a 500 with an operator-actionable message, NOT fall through
+  // app.onError's redacted upstream_error(502) fallback and masquerade as a
+  // provider outage (observed in production: PUT /admin/api/classifier -> 502).
+  function eacces(): Error {
+    const err: Error & { code?: string } = new Error(
+      "EACCES: permission denied, open '/app/config/lanes.yaml.tmp-7'",
+    );
+    err.code = "EACCES";
+    return err;
+  }
+
+  // RuleStore whose writes fail like a root-owned ./config mount; reads work.
+  function failingRules(err: Error): RuleStore {
+    const inner = makeRuleStore();
+    return {
+      ...inner,
+      setLanes: async () => {
+        throw err;
+      },
+      setPolicies: async () => {
+        throw err;
+      },
+      setClassifier: async () => {
+        throw err;
+      },
+    };
+  }
+
+  // Mirror production wiring: logger + trace_id context vars and the global
+  // onError fallback (app.ts), so an uncaught route throw renders exactly as it
+  // would on a deployed gateway (502 upstream_error) — pinning the regression.
+  function buildAppWithOnError(deps: AdminApiDeps) {
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("trace_id", "trace-test");
+      c.set("logger", { log: () => {} });
+      await next();
+    });
+    registerAdminApi(app, deps);
+    app.onError((err, c) => handleError(err, c));
+    return app;
+  }
+
+  async function expectActionable500(res: Response): Promise<void> {
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error?: unknown };
+    // Admin error shape ({ error: string }), not the OpenAI envelope.
+    expect(typeof body.error).toBe("string");
+    const msg = body.error as string;
+    expect(msg).toContain("EACCES");
+    expect(msg).toContain("not writable"); // actionable hint, not redacted
+  }
+
+  it("PUT /lanes/:name surfaces a persist EACCES as an actionable 500, not 502", async () => {
+    const app = buildAppWithOnError(buildDeps({ rules: failingRules(eacces()) }));
+    const body: Lane = {
+      primary: "best_reasoning_model",
+      fallback: [],
+      constraints: { require_tools: false, require_json: false, require_vision: false },
+    };
+    const res = await app.request("/admin/api/lanes/balanced", {
+      method: "PUT",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    });
+    await expectActionable500(res);
+  });
+
+  it("DELETE /lanes/:name surfaces a persist EACCES as an actionable 500, not 502", async () => {
+    const app = buildAppWithOnError(buildDeps({ rules: failingRules(eacces()) }));
+    const res = await app.request("/admin/api/lanes/economy", { method: "DELETE" });
+    await expectActionable500(res);
+  });
+
+  it("PUT /policies surfaces a persist EACCES as an actionable 500, not 502", async () => {
+    const app = buildAppWithOnError(buildDeps({ rules: failingRules(eacces()) }));
+    const res = await app.request("/admin/api/policies", {
+      method: "PUT",
+      headers: JSON_HEADERS,
+      body: JSON.stringify([]),
+    });
+    await expectActionable500(res);
+  });
+
+  it("DELETE /policies/:id surfaces a persist EACCES as an actionable 500, not 502", async () => {
+    const store = failingRules(eacces());
+    // Seed a deletable policy so the route reaches the failing write.
+    const seeded: RuleStore = {
+      ...store,
+      getPolicies: async () => ({ policies: [{ id: "p1", match: {} }] }),
+    };
+    const app = buildAppWithOnError(buildDeps({ rules: seeded }));
+    const res = await app.request("/admin/api/policies/p1", { method: "DELETE" });
+    await expectActionable500(res);
+  });
+
+  it("PUT /classifier surfaces a persist EACCES as an actionable 500, not 502", async () => {
+    const app = buildAppWithOnError(buildDeps({ rules: failingRules(eacces()) }));
+    const res = await app.request("/admin/api/classifier", {
+      method: "PUT",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(ClassifierConfigSchema.parse({})),
+    });
+    await expectActionable500(res);
+  });
+
+  it("a non-permission persist failure still returns 500 with the message, no chown hint", async () => {
+    const app = buildAppWithOnError(
+      buildDeps({ rules: failingRules(new Error("disk full while writing lanes.yaml")) }),
+    );
+    const body: Lane = {
+      primary: "best_reasoning_model",
+      fallback: [],
+      constraints: { require_tools: false, require_json: false, require_vision: false },
+    };
+    const res = await app.request("/admin/api/lanes/balanced", {
+      method: "PUT",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(500);
+    const json = (await res.json()) as { error?: unknown };
+    expect(typeof json.error).toBe("string");
+    expect(json.error as string).toContain("disk full while writing lanes.yaml");
+    expect(json.error as string).not.toContain("not writable");
   });
 });

--- a/apps/gateway/src/routes/admin/classifier.ts
+++ b/apps/gateway/src/routes/admin/classifier.ts
@@ -2,6 +2,7 @@ import { ClassifierConfigStrictSchema } from "@helm/shared";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
+import { rulePersistErrorResponse } from "./persist-error.js";
 
 // PUT is a full REPLACE of the classifier config, so it uses the STRICT schema
 // (both `rules` and `eval` required, unknown keys rejected). The base
@@ -27,7 +28,12 @@ export function registerClassifierRoutes(app: Hono<AppEnv>, deps: AdminApiDeps):
     if (!parsed.success) {
       return c.json({ error: "invalid classifier config", issues: parsed.error.issues }, 400);
     }
-    await deps.rules.setClassifier(parsed.data);
+    try {
+      await deps.rules.setClassifier(parsed.data);
+    } catch (err) {
+      // Persist failure (e.g. unwritable config mount) is a local 500, not a 502.
+      return rulePersistErrorResponse(c, err);
+    }
     return c.json(parsed.data);
   });
 }

--- a/apps/gateway/src/routes/admin/lanes.ts
+++ b/apps/gateway/src/routes/admin/lanes.ts
@@ -2,6 +2,7 @@ import { LaneSchema, LanesConfigSchema } from "@helm/core";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
+import { rulePersistErrorResponse } from "./persist-error.js";
 
 // /admin/api/lanes — CRUD over the lane config (config/lanes.yaml via RuleStore,
 // NEVER the DB; CLAUDE.md Principle 2, config-as-code). Pure HTTP glue: every read/write goes
@@ -41,7 +42,12 @@ export function registerLanesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     if (!map.success) {
       return c.json({ error: "invalid lanes config", issues: map.error.issues }, 400);
     }
-    await deps.rules.setLanes(lanes);
+    try {
+      await deps.rules.setLanes(lanes);
+    } catch (err) {
+      // Persist failure (e.g. unwritable config mount) is a local 500, not a 502.
+      return rulePersistErrorResponse(c, err);
+    }
     return c.json(parsed.data);
   });
 
@@ -58,7 +64,11 @@ export function registerLanesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     if (!map.success) {
       return c.json({ error: "invalid lanes config", issues: map.error.issues }, 409);
     }
-    await deps.rules.setLanes(lanes);
+    try {
+      await deps.rules.setLanes(lanes);
+    } catch (err) {
+      return rulePersistErrorResponse(c, err);
+    }
     return c.json({ deleted: name });
   });
 }

--- a/apps/gateway/src/routes/admin/persist-error.ts
+++ b/apps/gateway/src/routes/admin/persist-error.ts
@@ -1,0 +1,41 @@
+import type { Context } from "hono";
+import type { AppEnv } from "../../app.js";
+
+// Rule-config writes (RuleStore.set* → yaml-writeback.ts) persist to the mounted
+// config/*.yaml BEFORE rebinding the live config (rule-store.ts, fail-closed). A
+// persist failure is therefore a LOCAL fault — most commonly EACCES because the
+// docker-compose ./config volume is owned by root while the container runs as
+// uid 10001 — NOT an upstream provider error. Without this guard the throw falls
+// through app.onError's redacted upstream_error(502) fallback and masquerades as
+// a provider outage, hiding the actual fix from the operator.
+//
+// The admin plane is operator-facing (behind basic auth), so surfacing the raw
+// fs error message here is the point, not a leak — it names the file that could
+// not be written. The data-plane HelmError model (docs/07) is deliberately NOT
+// used: admin endpoints speak the plain `{ error: string }` shape.
+
+const FS_PERMISSION_CODES = new Set(["EACCES", "EPERM", "EROFS"]);
+
+const NOT_WRITABLE_HINT =
+  " — the config directory is not writable by the gateway process; fix ownership of the mounted ./config volume (e.g. `chown -R 10001:999 config`)";
+
+function errnoCode(err: unknown): string | null {
+  if (err instanceof Error && "code" in err) {
+    const code = (err as Error & { code?: unknown }).code;
+    if (typeof code === "string") return code;
+  }
+  return null;
+}
+
+// Render a rule-persist failure as an actionable admin 500. Also logs one
+// structured error line (the direct c.json return bypasses app.onError's log).
+export function rulePersistErrorResponse(c: Context<AppEnv>, err: unknown): Response {
+  const message = err instanceof Error ? err.message : String(err);
+  const code = errnoCode(err);
+  const hint = code !== null && FS_PERMISSION_CODES.has(code) ? NOT_WRITABLE_HINT : "";
+  c.get("logger").log("error", "admin.rule_persist_failed", {
+    trace_id: c.get("trace_id"),
+    message,
+  });
+  return c.json({ error: `failed to persist rule config: ${message}${hint}` }, 500);
+}

--- a/apps/gateway/src/routes/admin/policies.ts
+++ b/apps/gateway/src/routes/admin/policies.ts
@@ -2,6 +2,7 @@ import { PoliciesConfigSchema } from "@helm/core";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
+import { rulePersistErrorResponse } from "./persist-error.js";
 
 // /admin/api/policies — read/write the policy list (config/policies.yaml via
 // RuleStore, NEVER the DB). The wire shape is a bare Policy[] (the editor edits a
@@ -23,7 +24,12 @@ export function registerPoliciesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
     if (!parsed.success) {
       return c.json({ error: "invalid policies", issues: parsed.error.issues }, 400);
     }
-    await deps.rules.setPolicies(parsed.data);
+    try {
+      await deps.rules.setPolicies(parsed.data);
+    } catch (err) {
+      // Persist failure (e.g. unwritable config mount) is a local 500, not a 502.
+      return rulePersistErrorResponse(c, err);
+    }
     return c.json(parsed.data.policies);
   });
 
@@ -52,7 +58,11 @@ export function registerPoliciesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
       }
       return c.json({ error: "policy not found" }, 404);
     }
-    await deps.rules.setPolicies({ policies: remaining });
+    try {
+      await deps.rules.setPolicies({ policies: remaining });
+    } catch (err) {
+      return rulePersistErrorResponse(c, err);
+    }
     return c.json({ deleted: id });
   });
 }


### PR DESCRIPTION
## Problem

On a docker-compose deploy with a root-owned `./config` volume (container runs as uid 10001), every admin YAML save — `PUT /admin/api/classifier`, `/admin/api/lanes/:name`, `/admin/api/policies` — failed with **502 `upstream_error`** and zero actionable detail:

```json
{"message":"request.error","error_class":"upstream_error","http_status":502,
 "method":"PUT","path":"/admin/api/classifier"}
```

The YAML write-back (`yaml-writeback.ts`) correctly throws on EACCES (fail-closed, live config untouched), but the throw fell through `app.onError`'s redacted `upstream_error(502)` fallback — a purely **local** filesystem fault masquerading as a provider outage. `yaml-writeback.ts` even documents *"a failed write returns 500"*; the code diverged from its own contract.

## Fix

- New `routes/admin/persist-error.ts`: renders persist failures as **500** in the admin `{ error: string }` shape (not the data-plane OpenAI envelope), with the raw fs message plus an actionable hint for EACCES/EPERM/EROFS (*"config directory is not writable… `chown -R 10001:999 config`"*), and one structured `admin.rule_persist_failed` log line.
- All five rule write sites wrapped: lanes PUT/DELETE, policies PUT/DELETE, classifier PUT.

## Tests (TDD)

6 new tests in `admin.test.ts` using a RuleStore whose writes throw like a root-owned config mount, with the production `onError` wired so the regression is pinned: all six failed with 502 before the fix, pass with 500 + actionable message after. Non-permission failures keep the message but skip the chown hint.

- 83 admin route tests pass; full gateway suite 417 pass; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)