### PR TITLE
chore(release): v0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release v0.8.3

Patch release. Root `package.json` bumped `0.8.2 → 0.8.3`.

### Changes since v0.8.2

- **fix(admin)**: surface YAML write-back persist failures as an actionable **500** instead of a misclassified **502 `upstream_error`** (#121). When the mounted `./config` dir is root-owned (uid 10001 container can't write), admin saves to lanes/policies/classifier hit `EACCES`; previously `app.onError` fell through to the redacted upstream-error fallback and masqueraded as a provider outage. Now it returns a clear, operator-actionable message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)