### PR TITLE
fix(admin): render all timestamps in the viewer local timezone

### DIFF
--- a/apps/admin/src/lib/components/StatusCluster.svelte
+++ b/apps/admin/src/lib/components/StatusCluster.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { getHealth, getVersion, type BuildInfo, type HealthState } from '$lib/api/gateway.js';
   import { formatStars, getStarCount, REPO } from '$lib/api/github.js';
+  import { formatTimestamp } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import LocaleSwitcher from './LocaleSwitcher.svelte';
 
@@ -54,11 +55,7 @@
   });
 
   const dotClass = $derived(
-    health === 'online'
-      ? 'bg-emerald-500'
-      : health === 'degraded'
-        ? 'bg-amber-500'
-        : 'bg-red-500',
+    health === 'online' ? 'bg-emerald-500' : health === 'degraded' ? 'bg-amber-500' : 'bg-red-500',
   );
   const healthLabel = $derived(
     !probed
@@ -86,7 +83,7 @@
   {#if showVersion && version}
     <span
       class="hidden tabular-nums text-slate-400 sm:inline"
-      title={`${version.gitSha} · ${version.builtAt}`}
+      title={`${version.gitSha} · ${formatTimestamp(version.builtAt)}`}
       data-testid="gateway-version">v{version.version}</span
     >
   {/if}

--- a/apps/admin/src/lib/format.test.ts
+++ b/apps/admin/src/lib/format.test.ts
@@ -1,39 +1,39 @@
-import { describe, expect, it } from "vitest";
-import { durationParts, formatUsd } from "./format.js";
+import { describe, expect, it } from 'vitest';
+import { durationParts, formatTimestamp, formatUsd } from './format.js';
 
-describe("formatUsd — adaptive USD precision", () => {
-  it("renders not-measured (null/undefined/NaN) as an em dash", () => {
-    expect(formatUsd(null)).toBe("—");
-    expect(formatUsd(undefined)).toBe("—");
-    expect(formatUsd(Number.NaN)).toBe("—");
+describe('formatUsd — adaptive USD precision', () => {
+  it('renders not-measured (null/undefined/NaN) as an em dash', () => {
+    expect(formatUsd(null)).toBe('—');
+    expect(formatUsd(undefined)).toBe('—');
+    expect(formatUsd(Number.NaN)).toBe('—');
   });
 
-  it("renders a measured zero as $0.00 (distinct from not-measured)", () => {
-    expect(formatUsd(0)).toBe("$0.00");
+  it('renders a measured zero as $0.00 (distinct from not-measured)', () => {
+    expect(formatUsd(0)).toBe('$0.00');
   });
 
-  it("keeps 2 decimals for whole-dollar magnitudes", () => {
-    expect(formatUsd(12.5)).toBe("$12.50");
-    expect(formatUsd(1)).toBe("$1.00");
-    expect(formatUsd(329.4321)).toBe("$329.43");
+  it('keeps 2 decimals for whole-dollar magnitudes', () => {
+    expect(formatUsd(12.5)).toBe('$12.50');
+    expect(formatUsd(1)).toBe('$1.00');
+    expect(formatUsd(329.4321)).toBe('$329.43');
   });
 
-  it("shows tiny sub-cent costs at ~3 significant figures instead of $0.0000", () => {
+  it('shows tiny sub-cent costs at ~3 significant figures instead of $0.0000', () => {
     // The bug: these all rendered $0.0000 under toFixed(4).
-    expect(formatUsd(0.00002436)).toBe("$0.0000244");
-    expect(formatUsd(0.0000034)).toBe("$0.0000034");
-    expect(formatUsd(0.0347)).toBe("$0.0347");
+    expect(formatUsd(0.00002436)).toBe('$0.0000244');
+    expect(formatUsd(0.0000034)).toBe('$0.0000034');
+    expect(formatUsd(0.0347)).toBe('$0.0347');
   });
 
-  it("trims trailing zeros but always keeps at least 2 decimals", () => {
-    expect(formatUsd(0.5)).toBe("$0.50");
-    expect(formatUsd(0.87)).toBe("$0.87");
-    expect(formatUsd(0.001)).toBe("$0.001");
+  it('trims trailing zeros but always keeps at least 2 decimals', () => {
+    expect(formatUsd(0.5)).toBe('$0.50');
+    expect(formatUsd(0.87)).toBe('$0.87');
+    expect(formatUsd(0.001)).toBe('$0.001');
   });
 
-  it("never collapses a visible small non-zero cost to $0.00", () => {
-    expect(formatUsd(0.0000244)).not.toBe("$0.00");
-    expect(formatUsd(0.0000244)).not.toBe("$0.0000");
+  it('never collapses a visible small non-zero cost to $0.00', () => {
+    expect(formatUsd(0.0000244)).not.toBe('$0.00');
+    expect(formatUsd(0.0000244)).not.toBe('$0.0000');
   });
 });
 
@@ -41,34 +41,55 @@ const H = 3_600_000;
 const M = 60_000;
 const D = 86_400_000;
 
-describe("durationParts — coarsen a span by magnitude (>24h rolls up to days)", () => {
-  it("under an hour: minutes only", () => {
-    expect(durationParts(10 * M)).toEqual({ unit: "m", m: 10 });
-    expect(durationParts(0)).toEqual({ unit: "m", m: 0 });
-    expect(durationParts(59 * M + 59_000)).toEqual({ unit: "m", m: 59 });
+describe('durationParts — coarsen a span by magnitude (>24h rolls up to days)', () => {
+  it('under an hour: minutes only', () => {
+    expect(durationParts(10 * M)).toEqual({ unit: 'm', m: 10 });
+    expect(durationParts(0)).toEqual({ unit: 'm', m: 0 });
+    expect(durationParts(59 * M + 59_000)).toEqual({ unit: 'm', m: 59 });
   });
 
-  it("one hour up to a day: hours + minutes", () => {
-    expect(durationParts(H)).toEqual({ unit: "hm", h: 1, m: 0 });
-    expect(durationParts(6 * H + 21 * M)).toEqual({ unit: "hm", h: 6, m: 21 });
-    expect(durationParts(23 * H + 59 * M)).toEqual({ unit: "hm", h: 23, m: 59 });
+  it('one hour up to a day: hours + minutes', () => {
+    expect(durationParts(H)).toEqual({ unit: 'hm', h: 1, m: 0 });
+    expect(durationParts(6 * H + 21 * M)).toEqual({ unit: 'hm', h: 6, m: 21 });
+    expect(durationParts(23 * H + 59 * M)).toEqual({ unit: 'hm', h: 23, m: 59 });
   });
 
-  it("exactly 24h rolls up to days", () => {
-    expect(durationParts(D)).toEqual({ unit: "dh", d: 1, h: 0 });
+  it('exactly 24h rolls up to days', () => {
+    expect(durationParts(D)).toEqual({ unit: 'dh', d: 1, h: 0 });
   });
 
-  it("the bug: 238h 22m must read as days, not raw hours", () => {
+  it('the bug: 238h 22m must read as days, not raw hours', () => {
     // Screenshot regression: a Codex weekly window showed "238 小时 22 分钟后".
-    expect(durationParts(238 * H + 22 * M)).toEqual({ unit: "dh", d: 9, h: 22 });
+    expect(durationParts(238 * H + 22 * M)).toEqual({ unit: 'dh', d: 9, h: 22 });
   });
 
-  it("drops sub-hour minutes once we are in the days bucket", () => {
+  it('drops sub-hour minutes once we are in the days bucket', () => {
     // A days-scale span only carries days + hours, never trailing minutes.
-    expect(durationParts(4 * D + 14 * H + 37 * M)).toEqual({ unit: "dh", d: 4, h: 14 });
+    expect(durationParts(4 * D + 14 * H + 37 * M)).toEqual({ unit: 'dh', d: 4, h: 14 });
   });
 
-  it("clamps negative spans to zero (already elapsed)", () => {
-    expect(durationParts(-5000)).toEqual({ unit: "m", m: 0 });
+  it('clamps negative spans to zero (already elapsed)', () => {
+    expect(durationParts(-5000)).toEqual({ unit: 'm', m: 0 });
+  });
+});
+
+// formatTimestamp renders a recorded ISO timestamp in the viewer's *local*
+// timezone/locale (the request list column and the detail header both use it).
+// It is a pure passthrough to Date#toLocaleString, so the exact string is
+// environment dependent — we assert behaviour, not a fixed locale rendering.
+describe("formatTimestamp — render recorded UTC in the viewer's local zone", () => {
+  it('formats a valid ISO timestamp into the browser-local string, not raw UTC', () => {
+    const iso = '2026-06-07T02:27:19.748Z';
+    expect(formatTimestamp(iso)).toBe(new Date(iso).toLocaleString());
+    // The whole point of the fix: never surface the raw UTC ISO string.
+    expect(formatTimestamp(iso)).not.toBe(iso);
+  });
+
+  it('returns empty string for empty input (caller supplies the placeholder)', () => {
+    expect(formatTimestamp('')).toBe('');
+  });
+
+  it('passes a non-empty but unparseable value through unchanged', () => {
+    expect(formatTimestamp('not-a-date')).toBe('not-a-date');
   });
 });

--- a/apps/admin/src/lib/format.ts
+++ b/apps/admin/src/lib/format.ts
@@ -15,8 +15,8 @@
 //     mirrors the backend's null-vs-0 cost invariant, docs/07).
 //   • exactly 0              → "$0.00" (measured zero / free).
 export function formatUsd(n: number | null | undefined): string {
-  if (n === null || n === undefined || Number.isNaN(n)) return "—";
-  if (n === 0) return "$0.00";
+  if (n === null || n === undefined || Number.isNaN(n)) return '—';
+  if (n === 0) return '$0.00';
 
   const abs = Math.abs(n);
   let decimals: number;
@@ -32,8 +32,8 @@ export function formatUsd(n: number | null | undefined): string {
   // Trim trailing zeros beyond the 2nd decimal so "$0.00000340" → "$0.0000034"
   // and "$12.50" stays "$12.50" (a minimum of 2 decimals is always kept).
   let s = n.toFixed(decimals);
-  if (s.includes(".")) {
-    s = s.replace(/(\.\d{2}\d*?)0+$/, "$1");
+  if (s.includes('.')) {
+    s = s.replace(/(\.\d{2}\d*?)0+$/, '$1');
   }
   return `$${s}`;
 }
@@ -56,17 +56,30 @@ export function formatUsd(n: number | null | undefined): string {
 //   • <  1h → "m":  minutes only
 // Negative spans (already elapsed) clamp to zero.
 export type DurationParts =
-  | { readonly unit: "dh"; readonly d: number; readonly h: number }
-  | { readonly unit: "hm"; readonly h: number; readonly m: number }
-  | { readonly unit: "m"; readonly m: number };
+  | { readonly unit: 'dh'; readonly d: number; readonly h: number }
+  | { readonly unit: 'hm'; readonly h: number; readonly m: number }
+  | { readonly unit: 'm'; readonly m: number };
 
 export function durationParts(ms: number): DurationParts {
   const left = Math.max(0, ms);
   const d = Math.floor(left / 86_400_000);
   if (d > 0) {
-    return { unit: "dh", d, h: Math.floor((left % 86_400_000) / 3_600_000) };
+    return { unit: 'dh', d, h: Math.floor((left % 86_400_000) / 3_600_000) };
   }
   const h = Math.floor(left / 3_600_000);
   const m = Math.floor((left % 3_600_000) / 60_000);
-  return h > 0 ? { unit: "hm", h, m } : { unit: "m", m };
+  return h > 0 ? { unit: 'hm', h, m } : { unit: 'm', m };
+}
+
+// Render a recorded ISO timestamp in the viewer's local timezone/locale. The
+// gateway records times in UTC (ISO 8601, `…Z`); both the request list column
+// and the detail header show them through this helper so the operator reads the
+// time in their own timezone rather than raw UTC. Empty input → "" so each
+// caller supplies its own placeholder ("—" on the list, "time not recorded" on
+// the detail page); a non-empty but unparseable value passes through unchanged
+// rather than rendering "Invalid Date".
+export function formatTimestamp(ts: string): string {
+  if (!ts) return '';
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? ts : d.toLocaleString();
 }

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import { base } from '$app/paths';
   import type { RequestListItem } from '$lib/api/requests.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
-  import { formatUsd } from '$lib/format.js';
+  import { formatTimestamp, formatUsd } from '$lib/format.js';
   import { DEFAULT_PAGE_SIZE, filtersToSearch, type RangeKey } from '$lib/requests-filters.js';
   import { t } from '$lib/i18n';
 
@@ -53,12 +53,10 @@
     void goto(detailHref(traceId));
   }
 
-  // Format the recorded ISO timestamp for the local locale; '—' for a legacy row
-  // that carried none.
+  // Format the recorded ISO timestamp in the viewer's local zone (shared helper);
+  // '—' for a legacy row that carried none.
   function formatTs(ts: string): string {
-    if (!ts) return '—';
-    const d = new Date(ts);
-    return Number.isNaN(d.getTime()) ? ts : d.toLocaleString();
+    return formatTimestamp(ts) || '—';
   }
 
   function decidedByClass(d: RequestListItem['decided_by']): string {

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -4,7 +4,7 @@
   import { base } from '$app/paths';
   import type { RequestListItem } from '$lib/api/requests.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
-  import { formatUsd } from '$lib/format.js';
+  import { formatTimestamp, formatUsd } from '$lib/format.js';
   import { paginationItems } from '$lib/pagination.js';
   import {
     DEFAULT_FILTERS,
@@ -117,12 +117,10 @@
     void goto(detailHref(traceId));
   }
 
-  // Recorded time for the "timestamp" column: format the ISO ts for the local locale;
-  // '—' when the record carried none (legacy row).
+  // Recorded time for the "timestamp" column: format the ISO ts in the viewer's
+  // local zone (shared helper); '—' when the record carried none (legacy row).
   function formatTs(ts: string): string {
-    if (!ts) return '—';
-    const d = new Date(ts);
-    return Number.isNaN(d.getTime()) ? ts : d.toLocaleString();
+    return formatTimestamp(ts) || '—';
   }
 
   // Distinct label styling per classification-stage decision layer (Principle 5).

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import type { RequestDetail, RequestPayloadView } from '$lib/api/requests.js';
+  import { formatTimestamp } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import CostBreakdown from '$lib/components/CostBreakdown.svelte';
   import DecisionChain from '$lib/components/DecisionChain.svelte';
@@ -65,7 +66,9 @@
         <p class="section-desc">
           {$t('Follow how this request was classified, routed, and billed — step by step.')}
         </p>
-        <p class="mt-1 text-sm text-ink-muted">{d.ts || $t('time not recorded')}</p>
+        <p class="mt-1 text-sm text-ink-muted">
+          {formatTimestamp(d.ts) || $t('time not recorded')}
+        </p>
       </div>
       <div class="flex items-center gap-2">
         <code class="rounded bg-slate-100 px-2 py-1 font-mono text-xs text-slate-700"


### PR DESCRIPTION
## 目标（用户规则）

**所有时间展示一律按用户浏览器时区格式化；DB 一律存 UTC。**

## 改动

抽出共享 helper `formatTimestamp`（`$lib/format.ts`，与 `formatUsd`/`durationParts` 同处），用 `Date#toLocaleString()` 按浏览器时区/locale 渲染。所有展示**绝对时间**的位置统一走它：

| 位置 | 之前 | 之后 |
|---|---|---|
| 请求详情页头部 | 原始 UTC ISO `2026-06-07T02:27:19.748Z` | 本地时间 |
| 请求列表「时间」列 | 各自的 `formatTs`（重复实现） | 共享 helper |
| 首页「最近请求」列 | 各自的 `formatTs`（重复实现） | 共享 helper |
| 顶栏版本 tooltip 的 `builtAt` | 原始 UTC ISO | 本地时间 |

空值/旧记录仍走各自占位符（详情「未记录时间」、列表/首页 `—`）；非空但不可解析的值原样透传，避免 "Invalid Date"。

**未改动（有意）**：providers 页的 token/配额到期是**相对倒计时**（`expiresAt - Date.now()` → `durationParts`），是时间差不是钟点，无需时区格式化。

## DB 存储 = UTC（已核实，无需改）

- `created_at` 在两种适配器都是 **epoch-ms**（sqlite `timestamp_ms` / postgres `bigint`）——绝对时刻，无时区歧义。
- core/gateway 全程无 `toLocale*`（不存本地化时间字符串）；ISO 经 `toISOString()` 始终带 `Z`（UTC）。
- 链路：DB epoch-ms → 前端 `new Date(ms).toISOString()`(UTC) → `formatTimestamp`(本地渲染)。

## 测试

`format.test.ts` 新增 `formatTimestamp` 用例（有效 ISO=本地串且≠原始 ISO、空串→`''`、不可解析→原样）。✅ vitest 23/23、typecheck 净、svelte-check 0 错、Biome 净、Prettier 净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)