### PR TITLE
fix(routing): eval fast-probe + stream idle liveness guard

### DIFF
--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -6,7 +6,7 @@ import type {
   RouteDeps,
   TelemetryStore,
 } from "@helm/core";
-import { hashKey, routeRequest } from "@helm/core";
+import { hashKey, routeRequest, UpstreamError } from "@helm/core";
 import { type InternalRequest, makeHelmError } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
@@ -194,6 +194,39 @@ describe("POST /v1/chat/completions (routing pipeline)", () => {
     const text = await res.text();
     for (const ch of chunks) expect(text).toContain(ch.trim());
     expect(text.trimEnd().endsWith("[DONE]")).toBe(true);
+  });
+
+  it("preserves the timeout class in the terminal error frame when the stream stalls mid-flight", async () => {
+    // The provider idle guard throws UpstreamError("timeout") AFTER the first
+    // chunk; the route must surface that as a `timeout` frame, not a generic
+    // upstream_error (Codex P3 — the classification must survive to the client).
+    async function* sseThenTimeout(first: string): AsyncGenerator<string> {
+      yield first;
+      throw new UpstreamError("timeout", "upstream stream produced no data for 1500ms");
+    }
+    const { deps: d, harness } = deps();
+    harness.execute.mockResolvedValue({
+      ...nonStreamOutcome(null),
+      body: null,
+      stream: sseThenTimeout('data: {"a":1}\n\n'),
+    });
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(STREAM_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('data: {"a":1}'); // first chunk forwarded before the stall
+    const errLine = text.split("\n").find((l) => l.startsWith("data: ") && l.includes('"error"'));
+    expect(errLine).toBeDefined();
+    const parsed = JSON.parse((errLine as string).slice("data: ".length)) as {
+      error: { error_class: string };
+    };
+    expect(parsed.error.error_class).toBe("timeout");
   });
 
   it("does NOT bypass the pipeline (Phase 0 passthrough is gone)", async () => {

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -42,6 +42,7 @@ import {
   usageFromBody,
   usageFromSSE,
 } from "./payload-capture.js";
+import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1/chat/completions — Phase 1 routing pipeline wiring. This file is
 // PURE HTTP adaptation (CLAUDE.md principle 1): parse the OpenAI request into an
@@ -591,9 +592,12 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
           // A client disconnect / abort is NOT a provider fault: do not 5xx, do
           // not surface an error frame — the executor layer already recorded it.
           if (!isAbort(err, c.req.raw.signal)) {
+            // Preserve a mid-stream idle timeout (UpstreamError("timeout")) instead
+            // of flattening it to a generic upstream_error frame.
+            const timedOut = isUpstreamTimeout(err);
             const errBody = makeHelmError({
-              error_class: "upstream_error",
-              message: "upstream error",
+              error_class: timedOut ? "timeout" : "upstream_error",
+              message: timedOut ? "upstream timed out" : "upstream error",
               trace_id: traceId,
             });
             await sse.write(`data: ${JSON.stringify({ error: errBody })}\n\n`);

--- a/apps/gateway/src/routes/classify.test.ts
+++ b/apps/gateway/src/routes/classify.test.ts
@@ -138,4 +138,52 @@ describe("classify adapter — admin classifier hot-apply", () => {
     expect(calls.n).toBe(2); // eval re-ran -> cache was invalidated
     expect(third.eval_cache_hit).toBe(false);
   });
+
+  it("merges eval.extra_body onto the eval wire request but never lets it override locked fields", async () => {
+    const cfg = baseClassifier();
+    cfg.eval.enabled = true;
+    cfg.rules.confidence_threshold = 1; // always cascade to eval
+    // Hostile extra_body: tries to add a real knob AND clobber the locked fields.
+    cfg.eval.extra_body = {
+      thinking: { type: "disabled" },
+      model: "HACKED",
+      temperature: 0.9,
+      stream: true,
+    };
+
+    let captured: Record<string, unknown> | null = null;
+    const provider: ProviderForEval = {
+      chatCompletion: async (body) => {
+        captured = body;
+        return {
+          choices: [
+            {
+              message: {
+                content: '{"complexity":"complex","task_type":"coding","confidence":0.9}',
+              },
+            },
+          ],
+        };
+      },
+    };
+
+    const classify = buildClassifyAdapter({
+      getClassifierConfig: () => cfg,
+      lanes: LANES,
+      provider,
+      now: () => Date.now(),
+      log: () => {},
+    });
+
+    await classify(req("summarize the meeting notes please"));
+
+    expect(captured).not.toBeNull();
+    const body = captured as unknown as Record<string, unknown>;
+    // The passthrough knob made it onto the wire…
+    expect(body.thinking).toEqual({ type: "disabled" });
+    // …but the locked fields win over the hostile overrides.
+    expect(body.model).toBe("eval-model");
+    expect(body.temperature).toBe(0);
+    expect(body.stream).toBe(false);
+  });
 });

--- a/apps/gateway/src/routes/classify.ts
+++ b/apps/gateway/src/routes/classify.ts
@@ -231,6 +231,10 @@ export function buildClassifyAdapter(deps: ClassifyAdapterDeps): ClassifyFn {
   ): Promise<EvalModelResponse> => {
     const res = await provider.chatCompletion(
       {
+        // Provider-specific passthrough (config.extra_body) FIRST so the locked
+        // fields below always win — extra_body can add knobs (e.g. thinking:
+        // disabled) but can never override model/temperature/stream/max_tokens.
+        ...(modelReq.extra_body ?? {}),
         model: modelReq.model,
         messages: modelReq.messages,
         temperature: modelReq.temperature,

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -12,6 +12,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult, RouteError } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1beta/models/{model}:generateContent / :streamGenerateContent — Google
 // Gemini inbound, translated to IR, routed through the SAME core pipeline as
@@ -283,7 +284,12 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
             const re: RouteError =
               err instanceof PipelineError
                 ? { error_class: err.error_class, message: err.message, trace_id: traceId }
-                : { error_class: "upstream_error", message: "upstream error", trace_id: traceId };
+                : {
+                    // Preserve a mid-stream idle timeout instead of upstream_error.
+                    error_class: isUpstreamTimeout(err) ? "timeout" : "upstream_error",
+                    message: isUpstreamTimeout(err) ? "upstream timed out" : "upstream error",
+                    trace_id: traceId,
+                  };
             const out = transformer.transformErrorOut(re);
             await sse.writeSSE({ data: JSON.stringify(out.body) });
           }

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -7,6 +7,7 @@ import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1/messages — Anthropic Messages inbound, translated to IR, routed, and
 // translated back to the Anthropic wire shape (docs/02 §API Gateway, docs/05).
@@ -340,7 +341,12 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
             const re: RouteError =
               err instanceof PipelineError
                 ? { error_class: err.error_class, message: err.message, trace_id: traceId }
-                : { error_class: "upstream_error", message: "upstream error", trace_id: traceId };
+                : {
+                    // Preserve a mid-stream idle timeout instead of upstream_error.
+                    error_class: isUpstreamTimeout(err) ? "timeout" : "upstream_error",
+                    message: isUpstreamTimeout(err) ? "upstream timed out" : "upstream error",
+                    trace_id: traceId,
+                  };
             const out = anthropic.transformErrorOut(re);
             await sse.writeSSE({ event: "error", data: JSON.stringify(out.body) });
           }

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -9,6 +9,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1/responses — OpenAI Responses API inbound, translated to IR, routed
 // through the SAME core pipeline as /v1/chat and /v1/messages, then translated
@@ -296,7 +297,8 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     sequenceNumber: nextErrorSequence,
                   })
                 : responsesStreamError({
-                    code: "internal_error",
+                    // Preserve a mid-stream idle timeout instead of internal_error.
+                    code: isUpstreamTimeout(err) ? "timeout" : "internal_error",
                     message: err instanceof Error ? err.message : "upstream error",
                     traceId,
                     sequenceNumber: nextErrorSequence,

--- a/apps/gateway/src/routes/stream-error.test.ts
+++ b/apps/gateway/src/routes/stream-error.test.ts
@@ -1,0 +1,20 @@
+import { UpstreamError } from "@helm/core";
+import { describe, expect, it } from "vitest";
+import { isUpstreamTimeout } from "./stream-error.js";
+
+describe("isUpstreamTimeout", () => {
+  it("is true for an UpstreamError with errorClass === 'timeout'", () => {
+    expect(isUpstreamTimeout(new UpstreamError("timeout", "stalled"))).toBe(true);
+  });
+
+  it("is false for an UpstreamError with a different class", () => {
+    expect(isUpstreamTimeout(new UpstreamError("upstream_error", "boom", null, 500))).toBe(false);
+  });
+
+  it("is false for a plain Error, a string, or null", () => {
+    expect(isUpstreamTimeout(new Error("nope"))).toBe(false);
+    expect(isUpstreamTimeout("timeout")).toBe(false);
+    expect(isUpstreamTimeout(null)).toBe(false);
+    expect(isUpstreamTimeout(undefined)).toBe(false);
+  });
+});

--- a/apps/gateway/src/routes/stream-error.ts
+++ b/apps/gateway/src/routes/stream-error.ts
@@ -1,0 +1,15 @@
+import { UpstreamError } from "@helm/core";
+
+// Shared classification for a throw caught WHILE forwarding an SSE stream.
+//
+// The provider inter-chunk idle guard (provider/stream-idle.ts) throws
+// UpstreamError("timeout") when an upstream goes silent mid-stream — i.e. AFTER
+// headers / the first chunk, where a fallback is no longer possible. Each
+// streaming route maps a PipelineError to its carried error_class but flattens any
+// OTHER throw to a generic class (upstream_error / internal_error). That flatten
+// would erase the timeout signal exactly where this guard makes it observable, so
+// the routes special-case it via this predicate to keep the terminal error frame
+// honest (error_class === "timeout").
+export function isUpstreamTimeout(err: unknown): boolean {
+  return err instanceof UpstreamError && err.errorClass === "timeout";
+}

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -186,8 +186,21 @@ classifier:
     model: deepseek-v4-flash
     temperature: 0
     max_tokens: 256
-    timeout_ms: 250                # inner (runner) timeout
-    outer_timeout_ms: 350          # outer (consumer) timeout — strictly-later backstop (> inner)
+    # extra_body is merged VERBATIM onto the eval model's wire request (eval.client →
+    # the loose ProviderForEval record). `thinking:{type:disabled}` stops deepseek-v4-flash
+    # from spending its reasoning budget on a chain-of-thought the classifier throws away:
+    # with reasoning ON the 256-token budget got eaten and the JSON verdict came back
+    # truncated/empty (→ eval_not_json), and the round-trip ran ~2–3s. Disabled, a real
+    # eval call from the LA host is ~1s and returns clean JSON — so the timeouts below can
+    # stay TIGHT instead of taxing the hot path. (Locked fields model/temperature/stream/
+    # max_tokens always win over extra_body; see classify.ts invokeModel.)
+    extra_body:
+      thinking: { type: disabled }
+    timeout_ms: 1500               # inner (runner) timeout — covers a real cross-region eval
+                                    # round-trip (~1s with reasoning disabled) with margin.
+                                    # 250ms lost every race in production → eval_timeout on
+                                    # every cache-miss prompt; balanced was the only outcome.
+    outer_timeout_ms: 2000         # outer (consumer) timeout — strictly-later backstop (> inner)
     on_failure: balanced
     cache:
       enabled: true

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -159,8 +159,10 @@ classifier:
     model: deepseek-v4-flash       # a real bare id the primary (official DeepSeek) accepts; sent directly to it
     temperature: 0
     max_tokens: 256                # one JSON object; caps the cost
-    timeout_ms: 250                # inner runner timeout
-    outer_timeout_ms: 350          # outer backstop (strictly later than the inner)
+    extra_body:                    # merged VERBATIM onto the eval wire request (provider-specific knobs)
+      thinking: { type: disabled } # stop a reasoning eval model from burning max_tokens on a discarded CoT
+    timeout_ms: 1500               # inner runner timeout — covers a real ~1s round-trip with margin
+    outer_timeout_ms: 2000         # outer backstop (strictly later than the inner)
     on_failure: balanced           # timeout / parse failure → balanced
     cache:
       enabled: true
@@ -168,6 +170,16 @@ classifier:
       ttl_sec: 300
       max_entries: 5000            # LRU capacity
 ```
+
+`extra_body` is a config-driven escape hatch for provider knobs Helm does not
+model as first-class; it is merged onto the eval request **before** the locked
+fields, so `model` / `temperature` / `stream` / `max_tokens` always win over
+anything `extra_body` sets. The `thinking: { type: disabled }` above matters: an
+eval model that emits a chain-of-thought (e.g. `deepseek-v4-flash`) spends the
+256-token budget on reasoning the classifier discards, truncating the JSON
+verdict (`eval_not_json`) and adding ~2s of latency — which forces a too-tight
+`timeout_ms` to expire on every cache-miss. Disable reasoning and the call is a
+fast, clean ~1s probe, so the tight timeout is safe rather than self-defeating.
 
 The verdict is **decisive**: unlike a pure advisory probe, the eval output
 directly selects a lane (a JSON validation failure fails open to `balanced`).

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,18 @@
 
 ---
 
+## 2026-06-07 · eval 快探针：关推理 + 配置驱动 extra_body 透传（修复线上恒 fallback；docs/03 Layer 2；CLAUDE.md 原则 2/4）
+
+- **现象（la.atmy.work 实测）**：`model:"auto"` 的中文请求详情页恒显 `fallback`，`fallback_reason: eval_timeout`。逐层定位：Layer-1 非拉丁守卫 → 升级 eval；eval 内层超时只有 **250ms**，而 eval 模型 `deepseek-v4-flash` 是**推理模型**（temperature:0 也吐 `reasoning_content`），LA 主机到 DeepSeek 真实往返 ~2–3s → 必然 `eval_timeout` → 降级 balanced。即「分类兜底」，**非执行兜底**（`fallback_count:0`，provider 全 ok），与流式无关。
+- **反面教训（硬调超时不对）**：先把 250→3500ms 止血，eval 确实开始 decide，但暴露第二坑——256 的 `max_tokens` 被 reasoning 吃光，`message.content` 截断/空 → `eval_not_json`；且 3500ms 内层超时给热路径加最多 3.5s 税。`contract.ts` 的 `extractFirstObject` 已够健壮，真因在上游 reasoning 占预算/占延迟。
+- **方案（让 eval 重新变快，而非容忍慢）**：① `EvalConfigSchema` 加 `extra_body: z.record(z.string(), z.unknown()).optional()`——**配置驱动的请求体透传**，provider 无关的逃生舱；② `EvalModelRequest.extra_body` 透传，`runEval` 仅在配置存在时挂上（不改无配置部署的请求形状）；③ `classify.ts` invokeModel **把 extra_body 铺在最前、锁定字段(model/temperature/stream/max_tokens)在后覆盖**——extra_body 能加旋钮、绝不能篡改锁定项；④ classifier.yaml 设 `extra_body.thinking.{type:disabled}`，实测往返 ~1.1s 且吐干净 JSON，于是超时**收回 1500/2000**（快且可靠，不再税热路径）。`ProviderForEval.chatCompletion(req: Record<string,unknown>)` 是松类型直接 `JSON.stringify`，故透传不受 `ChatCompletionRequestSchema` 约束。
+- **验证**：TDD 先红后绿——schema（extra_body 默认缺省/任意块原样透传）、client（配置存在则转发、缺省则不挂）、classify（敌意 extra_body 既加 thinking 又试图覆盖 model/temperature/stream → 锁定字段胜）。Codex review 抓出 P1（`classifier-samples.test.ts` 仍 pin `timeout_ms===250`）+ P2（docs/03 片段未更新）已修。typecheck/lint 净，全量 2546 绿。
+- **② 流式 idle/stall 超时（同日实现）**：`withTimeout` 在收到响应头即 `cleanup`，故 TTFB 后**流式读循环此前无任何超时**——上游 mid-stream 卡死会永久挂起（网关 timeout 中间件也在响应头返回时就 resolve，管不到流体）。新增 `provider/stream-idle.ts`：`readChunkWithIdle(reader, idleMs)` 把单次 `reader.read()` 与 idle deadline race，超时则 `reader.cancel()`（回收连接）并抛 `StreamStalledError`，由三个 client 转 `UpstreamError("timeout")`。**每次 read 各自计时 → 是「逐块静默上限」而非总时长上限**（持续吐字的长流不受限）。首个 chunk 前抛 = 可 fallback 的正常失败；之后抛 = 终止已在流的响应（无法 fallback）。**作用域取舍**：复用 `request_timeout_ms`（=TTFB 同一旋钮）当 idle 值，避免给 8 处 server.ts callsite 加新字段——语义统一为「上游必须在 N ms 内产出点东西」；专用 `stream_idle_timeout_ms` 旋钮留作未来细化。三 client（openai 内联、anthropic `translateAnthropicSSE`、responses `readResponsesEvents`，后两者加 `idleMs=0` 默认参，向后兼容）全部接入。TDD：helper 5 例（chunk 透传 / done 透传 / idleMs<=0 关闭 / 超时 cancel+抛 / 逐块计时不误杀）+ 三 client 各一 stall 集成例（首块送达后静默 → UpstreamError(timeout) 504 + reader 被 cancel）。
+- **② 的 Codex 二轮复审（3 个真 bug 已修）**：(P1) 终止 SSE 事件没停止读取——idle guard 会把**已完成**的响应变成 timeout：上游发 `message_stop`/`response.completed` 后若延迟关 body，下一次 idle read 就误触发。修：anthropic `message_stop` 后 `return`、responses `aggregateResponsesStream` 的 `response.completed` 后 `break`（`translateResponsesSSE` 本就 `return`，无恙）。各补一例「终止事件后 body 保持打开 → 不超时」回归。(P2) `stream-idle.ts` 超时路径先 `await reader.cancel()` 再抛——cancel 慢/不 resolve 会让超时形同虚设：改 `void reader.cancel().catch()` fire-and-forget，立即抛（cancel 同步发起，cancelReasons/cancelled 仍可断言）。(P3) 四个流式路由把非 `PipelineError` 的 throw 一律压成 `upstream_error`/`internal_error`，丢掉新的 timeout 分类：新增 `routes/stream-error.ts` 的 `isUpstreamTimeout(err)` 谓词，chat/responses/messages/gemini 终止错误帧统一 `isUpstreamTimeout ? "timeout" : <原兜底>`。补 helper 单测 + chat 路由集成例（流式首块后抛 UpstreamError(timeout) → 错误帧 `error_class:"timeout"`）。typecheck/lint 净，全量 2552 绿。
+- **部署坑（关键 TODO）**：①透传 + ②idle **代码都只在分支**，线上 0.8.3 镜像没有——服务器 config 现仍留**临时 3500/4000**（推理仍开）+ `HELM_REQUEST_TIMEOUT_MS=300000`。等本分支构建新镜像部署后：把服务器 classifier.yaml 切到 `extra_body.thinking + 1500/2000`；`request_timeout_ms` 现在身兼 TTFB+idle，300000 偏松（mid-stream 卡死需 5min 才回收），建议部署后下调到 ~60–90s（够推理 TTFB，又让卡死连接快速回收），或后续加专用 `stream_idle_timeout_ms` 再分离。
+
+---
+
 ## 2026-06-07 · 请求详情页时间显示「未记录时间」（修复；docs/07）
 
 - **Bug（用户报告）**：请求详情页头部恒显「未记录时间」。根因两处：① 网关详情接口 `GET /admin/api/requests/:traceId` 直接吐 `getByRequestId` 返回的 `DecisionRecord`，而该 record **schema 本身不含时间戳**（时间在独立的 `createdAt` 列里）；列表接口 `GET /requests` 早已 `created_at: r.createdAt.getTime()` 拍平上去，详情接口没拍。② 前端 `toDetail` 把 `ts` **写死成 `''`**（`toListItem` 早已正确从 `created_at` 映射），于是详情页永远落入 `{d.ts || '未记录时间'}` 兜底。
@@ -27,22 +39,11 @@
 
 ---
 
-## 2026-06-06 · 请求详情页「重试」按钮（可编辑重发 + 隔离重跑；用户决策；docs/07）
-
-- **动机**：线上调试（deepseek-v4-pro 把 5000 `max_tokens` 全烧在 reasoning，`finish:length`、正文为空，详情页正确显示「无可见输出」）后，需要在 admin 内「改一下（如调高 max_tokens）再发一次」并看新结果，无需离开界面/手搓 curl。
-- **两项用户拍板**：① **可编辑后重发**（弹窗预填录制的请求体，可改 max_tokens/messages 再发）；② **隔离 debug 重跑**——走真路由 + 真 provider、记**新** trace+payload，但**不计 budget、不写/注入记忆**（observe/inject/settle/oauth-usage 全略），身份/caps 从原请求的 key 重建（lane 白名单 / `allow_custom_model` 仍生效，faithful）。key 已删/吊销 → 409 拒绝，**绝不静默放宽权限**。
-- **后端**：① `TelemetryStore.getApiKeyId(reqId)` 新窄查询——脱敏 DecisionRecord 只带 `key_prefix`，`api_key_id` 在独立列，replay 需它重建身份（port + sqlite/pg 适配器，仅 select 一列、不反序列化 blob）；**未加 `getById`**，身份用 `keyStore.list().find`（port 本无 getById、admin 非热路径、量小，沿用 delete-key 同模式）。② 新 `admin/replay.ts`：`runReplay` 返回判别式 outcome（400 体非法 / 404 原请求不存在 / 409 key 不可用），route 映射状态码；`registerReplayRoutes` 挂 `POST /admin/api/requests/:traceId/replay`，`replay` wiring 缺省时 503。复用 `payload-capture.ts` 的 `persistPayload`/`usageFromSSE`/`backfillCompletionCost`——流式服务端 drain 后回填 completion cost，与 chat 路由同。③ `server.ts` 给 `AdminApiDeps` 注入 `replay`，**复刻 chat 路由同一批闭包**（route/redact/costOf/capture getters）+ `randomUUID` 作新 trace id，零重复编排逻辑。
-- **范围 v1 = openai_chat**：body 过 `OpenAIChatRequestSchema`，非 OpenAI 形态 422；对既有记录**无需新存 protocol**（按体 schema 推断即可），按钮仅在 `payload.captured` 且含 `messages` 数组时可点，否则 disabled + 提示。
-- **前端**：`replayRequest(traceId, request)` POST `{request}`；`RetryDialog.svelte`（Modal + 预填 JSON textarea，客户端先 `JSON.parse` 防 400 往返，成功 `goto` 新 trace）；详情页头部加 Retry 按钮（`$derived` 算 `canRetry`）。i18n 9 key 全 5 locale（意译）。`untrack` 快照初始 body 文本，消除 svelte `state_referenced_locally` 警告。
-- **测试（TDD 先红）**：store-contract 加 getApiKeyId（双驱动 sqlite+pglite）；`replay.test` 10 例（非流 / 流式 cost 回填 / 400 / 404 / 409 删+吊 / capture off 不写 payload / provider 失败仍记可看 trace / route 503 / 缺 request 字段 400）；ports/decision/admin 三处 fake 补 getApiKeyId。
-- **坑/注**：`pnpm test` 全跑时 32 例 **PGlite 超时（5s）** 失败——纯并行资源争用 flake（隔离单跑 170/170 绿，含那两个超时文件），**非本次引入**（既有 admin.spec 全跑 flake 同源）。隔离重跑不计 budget/不写记忆是有意取舍（debug 不该污染/计费），已在代码注释标注；线上手测（改 max_tokens 重发 → `finish` 由 length 变 stop、正文有内容）留用户在部署上验。
-- **Codex review 修复（3×P2 + 1×P3）**：(P2) replay 同时绕过按 key **限流/并发门**（不止 budget）——属有意取舍（那些 middleware 守的是 /v1 客户端面，replay 是 Basic auth 后的一次性运维动作，dialog `sending` 已串行化点击），在 replay.ts「DELIBERATE BYPASSES」+ ReplayWiring 注释显式成文，不接入。(P2) 流式 drain 包 `try/catch`——中途上游断流不再让 runReplay 抛出跳过持久化，**部分字节照存、失败重试仍可查看**（镜像 live stream 分支 finally 语义）。(P2) `telemetry.insert` 失败由吞错改 **fail-closed 返 500**——replay 的交付物就是那条记录（UI 直接 goto 新 trace），吞错会导航到 404；与 live 路由 fail-open 的取舍差异已注释成文。(P3) ports.test 内存 fake `getApiKeyId` 误返 `request_id` → 改存/返 `input.apiKeyId` 并补断言。两新测试（流中断仍持久化 / insert 失败 500）先红后绿，replay 12 例全绿。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-06 · 请求详情页「重试」按钮（可编辑重发 + 隔离重跑；用户决策；docs/07）：弹窗预填录制请求体可改 max_tokens/messages 再发；隔离 debug 重跑走真路由+真 provider、记新 trace+payload 但**不计 budget/不写记忆**，身份/caps 从原 key 重建（lane 白名单/allow_custom_model 仍生效，key 删/吊 → 409）。后端 `getApiKeyId` 窄查询重建身份 + `admin/replay.ts`（判别式 outcome 400/404/409，insert 失败 fail-closed 500 因交付物就是那条记录）；范围 v1=openai_chat（按体 schema 推断，无需新存 protocol）。Codex 修复：限流/并发门一并绕过属有意取舍（运维动作非客户端面）已成文；流式 drain try/catch 部分字节照存。
 
 ### 2026-06-06 · 已吊销 key 允许永久删除（两步销毁；用户决策；docs/06）：软吊销 `DELETE /:id` 契约不动，硬删作 `?purge=true` 旗标；路由 gate `list().find`——未找 404 / active 409（必先吊销）/ disabled 才 deleteKey。「必先吊销」是路由策略不进 store；UI 仅 disabled 行显 Delete 但 server 独立校验（纵深防御）。审计存活靠 telemetry/payload 的 `api_key_id` 是无 FK 纯文本列，硬删不级联、悬空引用仍可审计。贯穿 core `KeyStore.deleteKey`(throw on unknown)→admin route→api client→+page。坑：选旗标不破 revoke 契约；read→delete TOCTOU 在单管理员场景可忽略 + deleteKey throw 兜底。
 

--- a/packages/core/src/classifier/eval/client.test.ts
+++ b/packages/core/src/classifier/eval/client.test.ts
@@ -110,6 +110,33 @@ describe("runEval", () => {
     expect(signal).toBeInstanceOf(AbortSignal);
   });
 
+  it("forwards config.extra_body onto the request verbatim (provider passthrough)", async () => {
+    const invokeModel = vi.fn(
+      async (_req: EvalModelRequest, _signal: AbortSignal): Promise<EvalModelResponse> => ({
+        text: SECRET_MODEL_TEXT,
+      }),
+    );
+    const deps = makeDeps({
+      config: makeConfig({ extra_body: { thinking: { type: "disabled" } } }),
+      invokeModel,
+    });
+    await runEval(INPUT, deps);
+    const [req] = invokeModel.mock.calls[0]!;
+    expect(req.extra_body).toEqual({ thinking: { type: "disabled" } });
+  });
+
+  it("omits extra_body on the request when none is configured", async () => {
+    const invokeModel = vi.fn(
+      async (_req: EvalModelRequest, _signal: AbortSignal): Promise<EvalModelResponse> => ({
+        text: SECRET_MODEL_TEXT,
+      }),
+    );
+    const deps = makeDeps({ invokeModel });
+    await runEval(INPUT, deps);
+    const [req] = invokeModel.mock.calls[0]!;
+    expect(req.extra_body).toBeUndefined();
+  });
+
   it("inner timeout fails open and aborts the upstream request (test 3)", async () => {
     let captured: AbortSignal | undefined;
     const deps = makeDeps({

--- a/packages/core/src/classifier/eval/client.ts
+++ b/packages/core/src/classifier/eval/client.ts
@@ -40,6 +40,10 @@ export interface EvalModelRequest {
   temperature: 0;
   stream: false;
   max_tokens: number;
+  /** Provider-specific body passthrough from `config.extra_body`, merged verbatim
+   *  onto the wire request by the invoker (e.g. `{ thinking: { type: disabled } }`).
+   *  Present only when configured; never set by runEval otherwise. */
+  extra_body?: Record<string, unknown>;
 }
 
 /** Raw, unparsed completion text from the small model, plus its self-cost when
@@ -126,6 +130,9 @@ export async function runEval<TInput>(
     temperature: 0,
     stream: false,
     max_tokens: config.max_tokens,
+    // Forward provider-specific passthrough ONLY when configured, so the request
+    // shape is unchanged for deployments that do not set it.
+    ...(config.extra_body ? { extra_body: config.extra_body } : {}),
   };
 
   // Inner runner: the upstream call raced against its own runner timeout. On

--- a/packages/core/src/config/classifier-samples.test.ts
+++ b/packages/core/src/config/classifier-samples.test.ts
@@ -29,7 +29,14 @@ describe("checked-in classifier.yaml sample", () => {
     const cfg = loadConfig({ configDir, env: {} });
     expect(cfg.classifier.eval.enabled).toBe(false);
     expect(cfg.classifier.eval.max_tokens).toBe(256);
-    expect(cfg.classifier.eval.timeout_ms).toBe(250);
+    // eval-fast-probe (2026-06-07): the eval timeouts were tightened from 250/350
+    // to 1500/2000 once `extra_body.thinking:disabled` removed the eval model's
+    // reasoning round-trip (~2-3s → ~1s). The tight timeout is now SAFE because the
+    // call is fast, not loose to tolerate a slow one. Pin the new values + the
+    // passthrough so a drift back to 250 (which always timed out in prod) fails CI.
+    expect(cfg.classifier.eval.timeout_ms).toBe(1500);
+    expect(cfg.classifier.eval.outer_timeout_ms).toBe(2000);
+    expect(cfg.classifier.eval.extra_body).toEqual({ thinking: { type: "disabled" } });
     expect(cfg.classifier.eval.on_failure).toBe("balanced");
     expect(cfg.classifier.eval.cache.ttl_sec).toBe(300);
   });

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -168,6 +168,69 @@ describe("translateAnthropicSSE", () => {
     expect(joined).toContain('"finish_reason":"stop"');
     expect(joined.trimEnd().endsWith("data: [DONE]")).toBe(true);
   });
+
+  it("returns at message_stop without waiting on the idle guard (terminal event stops the read)", async () => {
+    vi.useFakeTimers();
+    try {
+      const enc = new TextEncoder();
+      const events = [
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"m"}}\n\n',
+        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n',
+        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+      ];
+      // Enqueue the terminal event then DELIBERATELY hold the body open (no close):
+      // the generator must return at message_stop, never issuing the idle-guarded read.
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const e of events) controller.enqueue(enc.encode(e));
+        },
+      });
+      const res = new Response(stream, { status: 200 });
+      const chunks: string[] = [];
+      const run = (async () => {
+        for await (const c of translateAnthropicSSE(res, "m", 500)) chunks.push(c);
+      })();
+      // A regression (no early return) would pend on the next read; advancing past
+      // the deadline would then reject. With the fix, run already resolved.
+      await vi.advanceTimersByTimeAsync(500);
+      await run;
+      expect(chunks.join("").trimEnd().endsWith("data: [DONE]")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws UpstreamError(timeout) and cancels when the stream stalls past idleMs", async () => {
+    vi.useFakeTimers();
+    try {
+      let cancelled = false;
+      // Emit one event, then hang (no close) so the next read pends.
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'event: message_start\ndata: {"type":"message_start","message":{"id":"m"}}\n\n',
+            ),
+          );
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      const res = new Response(stream, { status: 200 });
+      const run = (async () => {
+        for await (const _ of translateAnthropicSSE(res, "m", 500)) {
+          // drain
+        }
+      })();
+      const assertion = expect(run).rejects.toMatchObject({ errorClass: "timeout" });
+      await vi.advanceTimersByTimeAsync(500);
+      await assertion;
+      expect(cancelled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -19,6 +19,7 @@ import {
   type ProviderClient,
   UpstreamError,
 } from "./openai.js";
+import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface AnthropicClientConfig {
   baseUrl: string; // e.g. https://api.anthropic.com (NO /v1)
@@ -369,7 +370,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
       };
       const res = await requestWithRetry(body, opts?.signal);
       if (!res.ok) throw await errorFromResponse(res);
-      yield* translateAnthropicSSE(res, model);
+      yield* translateAnthropicSSE(res, model, timeoutMs);
     },
   };
 }
@@ -387,7 +388,14 @@ function openaiChunk(model: string, delta: Record<string, unknown>, finish: stri
   return `data: ${JSON.stringify(chunk)}\n\n`;
 }
 
-export async function* translateAnthropicSSE(res: Response, model: string): AsyncGenerator<string> {
+export async function* translateAnthropicSSE(
+  res: Response,
+  model: string,
+  // Inter-chunk liveness deadline (ms); 0 disables. Threaded from the client's
+  // request timeout so a stream that wedges mid-flight is reclaimed rather than
+  // hanging forever (the connect/TTFB timeout was already cleared at headers).
+  idleMs = 0,
+): AsyncGenerator<string> {
   const body = res.body;
   if (!body) return;
   const reader = body.getReader();
@@ -398,7 +406,14 @@ export async function* translateAnthropicSSE(res: Response, model: string): Asyn
   let started = false;
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      let read: { done: boolean; value?: Uint8Array };
+      try {
+        read = await readChunkWithIdle(reader, idleMs);
+      } catch (err) {
+        if (err instanceof StreamStalledError) throw new UpstreamError("timeout", err.message);
+        throw err;
+      }
+      const { done, value } = read;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       const events = buffer.split("\n\n");
@@ -457,6 +472,10 @@ export async function* translateAnthropicSSE(res: Response, model: string): Asyn
           }
         } else if (type === "message_stop") {
           yield "data: [DONE]\n\n";
+          // Terminal event: stop reading NOW. Otherwise the next read would block
+          // on the idle guard and could turn a completed response into a spurious
+          // timeout if the upstream delays closing the HTTP body after message_stop.
+          return;
         }
       }
     }

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -174,9 +174,70 @@ describe("translateResponsesSSE", () => {
       }
     }).rejects.toBeInstanceOf(UpstreamError);
   });
+
+  it("throws UpstreamError(timeout) and cancels when the stream stalls past idleMs", async () => {
+    vi.useFakeTimers();
+    try {
+      let cancelled = false;
+      // One event, then hang so the next read pends and the idle guard fires.
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode('data: {"type":"response.created","response":{}}\n\n'),
+          );
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      const res = new Response(stream, { status: 200 });
+      const run = (async () => {
+        for await (const _ of translateResponsesSSE(res, "m", 500)) {
+          // drain
+        }
+      })();
+      const assertion = expect(run).rejects.toMatchObject({ errorClass: "timeout" });
+      await vi.advanceTimersByTimeAsync(500);
+      await assertion;
+      expect(cancelled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("aggregateResponsesStream", () => {
+  it("returns at response.completed without waiting on the idle guard (terminal event stops the read)", async () => {
+    vi.useFakeTimers();
+    try {
+      const enc = new TextEncoder();
+      const events = [
+        'data: {"type":"response.created","response":{"id":"resp_1"}}\n\n',
+        'data: {"type":"response.output_text.delta","delta":"hi"}\n\n',
+        'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ];
+      // Terminal event enqueued, then the body is held open (no close): aggregation
+      // must break at response.completed, not block on the idle-guarded next read.
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const e of events) controller.enqueue(enc.encode(e));
+        },
+      });
+      const res = new Response(stream, { status: 200 });
+      const p = aggregateResponsesStream(res, "m", 500);
+      // A regression (no break) would pend on the next read and reject here.
+      await vi.advanceTimersByTimeAsync(500);
+      const out = await p;
+      const msg = (out.choices as Array<Record<string, unknown>>)[0]?.message as Record<
+        string,
+        unknown
+      >;
+      expect(msg.content).toBe("hi");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("folds text + usage into a single chat response (Codex is stream-only)", async () => {
     const res = sseResponse([
       { type: "response.created", response: { id: "resp_7" } },

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -23,6 +23,7 @@ import {
   type ProviderClient,
   UpstreamError,
 } from "./openai.js";
+import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface CodexResponsesClientConfig {
   baseUrl: string; // e.g. https://chatgpt.com/backend-api/codex (endpoint = baseUrl + /responses)
@@ -377,7 +378,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       );
       if (!res.ok) throw await errorFromResponse(res);
       // Codex is stream-only → aggregate the SSE into a single Chat response.
-      return await aggregateResponsesStream(res, model);
+      return await aggregateResponsesStream(res, model, timeoutMs);
     },
 
     async *chatCompletionStream(req, opts) {
@@ -387,14 +388,20 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         opts?.signal,
       );
       if (!res.ok) throw await errorFromResponse(res);
-      yield* translateResponsesSSE(res, model);
+      yield* translateResponsesSSE(res, model, timeoutMs);
     },
   };
 }
 
 // ── low-level SSE event reader (shared by stream + aggregate) ─────────────────
 
-export async function* readResponsesEvents(res: Response): AsyncGenerator<Record<string, unknown>> {
+export async function* readResponsesEvents(
+  res: Response,
+  // Inter-chunk liveness deadline (ms); 0 disables. Threaded from the client's
+  // request timeout so a wedged mid-stream upstream is reclaimed, not hung
+  // (connect/TTFB timeout was already cleared at headers).
+  idleMs = 0,
+): AsyncGenerator<Record<string, unknown>> {
   const body = res.body;
   if (!body) return;
   const reader = body.getReader();
@@ -402,7 +409,14 @@ export async function* readResponsesEvents(res: Response): AsyncGenerator<Record
   let buffer = "";
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      let read: { done: boolean; value?: Uint8Array };
+      try {
+        read = await readChunkWithIdle(reader, idleMs);
+      } catch (err) {
+        if (err instanceof StreamStalledError) throw new UpstreamError("timeout", err.message);
+        throw err;
+      }
+      const { done, value } = read;
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       const events = buffer.split("\n\n");
@@ -437,12 +451,16 @@ function openaiChunk(model: string, delta: Record<string, unknown>, finish: stri
   return `data: ${JSON.stringify(chunk)}\n\n`;
 }
 
-export async function* translateResponsesSSE(res: Response, model: string): AsyncGenerator<string> {
+export async function* translateResponsesSSE(
+  res: Response,
+  model: string,
+  idleMs = 0,
+): AsyncGenerator<string> {
   let started = false;
   let toolIndex = -1;
   let hadToolCall = false;
   let status: unknown = "completed";
-  for await (const evt of readResponsesEvents(res)) {
+  for await (const evt of readResponsesEvents(res, idleMs)) {
     const type = evt.type;
     if (!started) {
       started = true;
@@ -508,6 +526,7 @@ export async function* translateResponsesSSE(res: Response, model: string): Asyn
 export async function aggregateResponsesStream(
   res: Response,
   model: string,
+  idleMs = 0,
 ): Promise<ChatCompletionResponse> {
   let text = "";
   let id = `chatcmpl-${Date.now()}`;
@@ -519,7 +538,7 @@ export async function aggregateResponsesStream(
   const toolById = new Map<string, { id: string; name: string; arguments: string }>();
   let currentCallId = "";
 
-  for await (const evt of readResponsesEvents(res)) {
+  for await (const evt of readResponsesEvents(res, idleMs)) {
     const type = evt.type;
     if (type === "response.created") {
       const response = (evt.response ?? {}) as Record<string, unknown>;
@@ -551,6 +570,9 @@ export async function aggregateResponsesStream(
       const usage = (response.usage ?? {}) as Record<string, unknown>;
       if (typeof usage.input_tokens === "number") inTok = usage.input_tokens;
       if (typeof usage.output_tokens === "number") outTok = usage.output_tokens;
+      // Terminal event: stop reading NOW so the idle guard cannot turn a completed
+      // aggregation into a timeout if the upstream delays closing the body.
+      break;
     } else if (type === "error" || type === "response.failed") {
       const msg =
         typeof evt.message === "string"

--- a/packages/core/src/provider/openai.test.ts
+++ b/packages/core/src/provider/openai.test.ts
@@ -55,6 +55,45 @@ describe("createOpenAIClient (Phase 0 passthrough)", () => {
     expect(received.join("")).toBe(chunks.join(""));
   });
 
+  it("aborts a stream that goes silent past the idle deadline with UpstreamError(timeout)", async () => {
+    vi.useFakeTimers();
+    try {
+      let cancelled = false;
+      // Emit one chunk, then hang: never enqueue more and never close, so the
+      // NEXT reader.read() pends forever — the inter-chunk idle guard must fire.
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"a":1}\n\n'));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      const fetch = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+      const client = createOpenAIClient({ config: { ...CONFIG, timeoutMs: 500 }, fetch });
+
+      const received: string[] = [];
+      const run = (async () => {
+        for await (const c of client.chatCompletionStream({ model: "m", stream: true })) {
+          received.push(c);
+        }
+      })();
+      const assertion = expect(run).rejects.toMatchObject({
+        errorClass: "timeout",
+        httpStatus: 504,
+      });
+      await vi.advanceTimersByTimeAsync(500);
+      await assertion;
+
+      // The first chunk was delivered before the stall; then the connection was
+      // cancelled to reclaim it.
+      expect(received.join("")).toBe('data: {"a":1}\n\n');
+      expect(cancelled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("maps an upstream 5xx to UpstreamError(upstream_error, 502)", async () => {
     // fresh Response per call (a Response body can only be read once)
     const fetch = vi

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -12,6 +12,8 @@
 //   - `currentSecrets`: live access + refresh tokens, used by `scrub()` to strip
 //     any echoed credential from an upstream error body (principle 7).
 // Credentials are runtime-only: from env, never persisted/logged.
+import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
+
 export interface ProviderConfig {
   baseUrl: string; // e.g. https://openrouter.ai/api/v1
   apiKey?: string; // static credential; mutually exclusive with getAuthHeader
@@ -237,10 +239,20 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       const decoder = new TextDecoder();
       try {
         while (true) {
-          const { done, value } = await reader.read();
+          // Inter-chunk liveness: `withTimeout` already cleared once headers
+          // arrived, so without this a stream that wedges mid-flight hangs forever.
+          // Reuse `timeoutMs` as the max silence between chunks (a healthy stream
+          // keeps emitting; only a real stall trips it). Pre-first-chunk it is a
+          // normal fallback-eligible failure; after, it terminates the response.
+          const { done, value } = await readChunkWithIdle(reader, timeoutMs);
           if (done) break;
           if (value) yield decoder.decode(value, { stream: true });
         }
+      } catch (err) {
+        if (err instanceof StreamStalledError) {
+          throw new UpstreamError("timeout", err.message);
+        }
+        throw err;
       } finally {
         reader.releaseLock();
       }

--- a/packages/core/src/provider/stream-idle.test.ts
+++ b/packages/core/src/provider/stream-idle.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type IdleReadResult, readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
+
+// stream-idle — the inter-chunk liveness guard for the provider SSE readers. Once
+// a stream's headers arrive the connect/TTFB timeout is cleared (see provider
+// withTimeout), so WITHOUT this a wedged upstream that stops mid-stream hangs
+// forever. readChunkWithIdle races a single reader.read() against an idle
+// deadline: a chunk in time passes through; silence past the deadline cancels the
+// reader (reclaim the connection) and throws StreamStalledError, which the client
+// maps to UpstreamError("timeout"). Each call owns a fresh timer, so the deadline
+// is PER-CHUNK silence, never a total-stream cap (a long stream that keeps
+// emitting runs unbounded). idleMs <= 0 disables the guard (plain read).
+
+type ReadResult = IdleReadResult<Uint8Array>;
+
+function fakeReader(reads: Array<() => Promise<ReadResult>>) {
+  let i = 0;
+  const cancelReasons: unknown[] = [];
+  return {
+    cancelReasons,
+    read: (): Promise<ReadResult> => (reads[i++] ?? (() => new Promise<ReadResult>(() => {})))(),
+    cancel: async (reason?: unknown): Promise<void> => {
+      cancelReasons.push(reason);
+    },
+  };
+}
+
+const chunk = (s: string): ReadResult => ({ done: false, value: new TextEncoder().encode(s) });
+const END: ReadResult = { done: true, value: undefined };
+
+describe("readChunkWithIdle", () => {
+  it("returns the chunk when read resolves before the idle deadline", async () => {
+    const reader = fakeReader([() => Promise.resolve(chunk("hi"))]);
+    const out = await readChunkWithIdle(reader, 1000);
+    expect(out.done).toBe(false);
+    expect(new TextDecoder().decode(out.value)).toBe("hi");
+    expect(reader.cancelReasons).toHaveLength(0);
+  });
+
+  it("passes a terminal done result through unchanged", async () => {
+    const reader = fakeReader([() => Promise.resolve(END)]);
+    const out = await readChunkWithIdle(reader, 1000);
+    expect(out.done).toBe(true);
+  });
+
+  it("idleMs <= 0 disables the guard: a slow read still resolves, no timer, no cancel", async () => {
+    let resolve!: (r: ReadResult) => void;
+    const reader = fakeReader([() => new Promise<ReadResult>((r) => (resolve = r))]);
+    const p = readChunkWithIdle(reader, 0);
+    resolve(chunk("late"));
+    const out = await p;
+    expect(new TextDecoder().decode(out.value)).toBe("late");
+    expect(reader.cancelReasons).toHaveLength(0);
+  });
+
+  describe("with fake timers", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("throws StreamStalledError and cancels the reader when silence passes the deadline", async () => {
+      // A read that never resolves -> the idle deadline must win.
+      const reader = fakeReader([() => new Promise<ReadResult>(() => {})]);
+      const p = readChunkWithIdle(reader, 500);
+      const assertion = expect(p).rejects.toBeInstanceOf(StreamStalledError);
+      await vi.advanceTimersByTimeAsync(500);
+      await assertion;
+      expect(reader.cancelReasons).toHaveLength(1);
+      expect(reader.cancelReasons[0]).toBeInstanceOf(StreamStalledError);
+    });
+
+    it("does not fire when each chunk arrives within the per-chunk deadline (timer resets per call)", async () => {
+      // Two sequential reads, each resolving just under the 500ms deadline; the
+      // cumulative 800ms must NOT trip the guard because each call gets a fresh timer.
+      const reader = fakeReader([
+        () => new Promise<ReadResult>((r) => setTimeout(() => r(chunk("a")), 400)),
+        () => new Promise<ReadResult>((r) => setTimeout(() => r(chunk("b")), 400)),
+      ]);
+      const p1 = readChunkWithIdle(reader, 500);
+      await vi.advanceTimersByTimeAsync(400);
+      expect(new TextDecoder().decode((await p1).value)).toBe("a");
+      const p2 = readChunkWithIdle(reader, 500);
+      await vi.advanceTimersByTimeAsync(400);
+      expect(new TextDecoder().decode((await p2).value)).toBe("b");
+      expect(reader.cancelReasons).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/provider/stream-idle.ts
+++ b/packages/core/src/provider/stream-idle.ts
@@ -1,0 +1,87 @@
+// stream-idle — inter-chunk liveness guard for the provider SSE readers.
+//
+// WHY: the provider clients clear their connect/TTFB timeout the moment response
+// headers arrive (see `withTimeout` in openai/anthropic/openai-responses), so the
+// chunk-reading loop afterwards runs with NO deadline. That is correct for a
+// healthy long stream (it keeps emitting tokens), but a wedged upstream that goes
+// silent MID-stream would otherwise hang the request indefinitely — there is no
+// total-request wall-clock on the streaming path either (the gateway timeout
+// middleware resolves once the SSE Response is returned). This guard closes that
+// gap: each `reader.read()` is raced against an idle deadline. A chunk in time
+// passes through untouched; silence past the deadline cancels the reader (so the
+// undici connection is reclaimed and stops billing) and throws StreamStalledError.
+//
+// The deadline is PER-CHUNK silence, never a total-stream cap: every call owns a
+// fresh timer, so a stream that keeps producing — however long in total — never
+// trips it. Only a gap of `idleMs` with no data does. The client converts the
+// thrown StreamStalledError into UpstreamError("timeout"); thrown BEFORE the first
+// chunk it is a normal pre-first-chunk failure (executor may fall back), thrown
+// AFTER it terminates an already-streaming response (no fallback possible). A
+// non-positive `idleMs` disables the guard entirely (a plain read).
+
+/** Marker the idle deadline resolves with; a distinct object so it can never
+ *  collide with a legitimate read result. */
+const STALLED = Symbol("stream_stalled");
+
+/** Thrown by readChunkWithIdle when the upstream produced no chunk within the
+ *  idle deadline. The provider client maps it to UpstreamError("timeout"). */
+export class StreamStalledError extends Error {
+  override readonly name = "StreamStalledError";
+  readonly idleMs: number;
+  constructor(idleMs: number) {
+    super(`upstream stream produced no data for ${idleMs}ms`);
+    this.idleMs = idleMs;
+  }
+}
+
+/** The result of one read: `{done:false, value:T}` for a chunk, `{done:true}` at
+ *  end of stream. Defined locally so the guard needs no DOM/stream lib types; a
+ *  real `ReadableStreamDefaultReader`'s read result is structurally assignable. */
+export interface IdleReadResult<T> {
+  done: boolean;
+  value?: T;
+}
+
+/** Minimal reader shape (a `ReadableStreamDefaultReader` satisfies it). Kept loose
+ *  so the readers' own `read`/`cancel` plug in directly and tests can fake them. */
+export interface IdleReader<T> {
+  read(): Promise<IdleReadResult<T>>;
+  cancel(reason?: unknown): Promise<void>;
+}
+
+/**
+ * One `reader.read()` with an idle deadline. Resolves with the read result when a
+ * chunk (or terminal `done`) arrives within `idleMs`; on a deadline win, cancels
+ * the reader and throws StreamStalledError. `idleMs <= 0` skips the race entirely.
+ */
+export async function readChunkWithIdle<T>(
+  reader: IdleReader<T>,
+  idleMs: number,
+): Promise<IdleReadResult<T>> {
+  if (!(idleMs > 0)) return reader.read();
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const idle = new Promise<typeof STALLED>((resolve) => {
+    timer = setTimeout(() => resolve(STALLED), idleMs);
+  });
+
+  const read = reader.read();
+  // If the deadline wins, `read` is still pending; swallow any later rejection so
+  // it never surfaces as an unhandled rejection after we have already thrown.
+  read.catch(() => {});
+
+  try {
+    const raced = await Promise.race([read, idle]);
+    if (raced === STALLED) {
+      const err = new StreamStalledError(idleMs);
+      // Fire-and-forget: a slow or never-resolving cancel must NOT delay the
+      // timeout — awaiting it would defeat the very liveness guarantee this guard
+      // exists for. Reclaim the connection best-effort and throw immediately.
+      void reader.cancel(err).catch(() => {});
+      throw err;
+    }
+    return raced;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/shared/src/config/eval-config.schema.test.ts
+++ b/packages/shared/src/config/eval-config.schema.test.ts
@@ -118,6 +118,19 @@ describe("EvalConfigSchema", () => {
     expect(EvalConfigSchema.safeParse(bad).success).toBe(false);
   });
 
+  it("omits extra_body by default (no passthrough unless configured)", () => {
+    const parsed = EvalConfigSchema.parse({ model: "deepseek-v4-flash" });
+    expect(parsed.extra_body).toBeUndefined();
+  });
+
+  it("passes an arbitrary extra_body block through verbatim (provider-specific knobs)", () => {
+    const parsed = EvalConfigSchema.parse({
+      model: "deepseek-v4-flash",
+      extra_body: { thinking: { type: "disabled" }, top_p: 0.1 },
+    });
+    expect(parsed.extra_body).toEqual({ thinking: { type: "disabled" }, top_p: 0.1 });
+  });
+
   it("EvalCacheConfigSchema backfills cache defaults from {}", () => {
     const parsed = EvalCacheConfigSchema.parse({});
     expect(parsed.enabled).toBe(true);

--- a/packages/shared/src/config/eval-config.schema.ts
+++ b/packages/shared/src/config/eval-config.schema.ts
@@ -51,6 +51,16 @@ export const EvalConfigSchema = z
     // defaults rather than treating it as a bare {} (Zod v4 .default short-circuits
     // inner defaults).
     cache: EvalCacheConfigSchema.prefault({}),
+    // Provider-specific request-body passthrough, merged verbatim onto the eval
+    // model's wire request (eval.client → ProviderForEval.chatCompletion, a loose
+    // Record — NOT bound by ChatCompletionRequestSchema). Config-as-code escape
+    // hatch (principle 2) for knobs Helm does not model as first-class, e.g.
+    // `{ thinking: { type: disabled } }` to stop a *reasoning* eval model from
+    // burning the max_tokens budget on a chain-of-thought the classifier discards
+    // (that truncates the JSON verdict → eval_not_json, and adds ~2s latency). OFF
+    // unless set; an OpenAI-style eval model simply omits it. Kept untyped on
+    // purpose — the upstream owns this contract, not Helm.
+    extra_body: z.record(z.string(), z.unknown()).optional(),
   })
   .refine((c) => c.outer_timeout_ms > c.timeout_ms, {
     // The outer (consumer) race is the LATER backstop: it must outlive the inner


### PR DESCRIPTION
## Problem

Production `model:"auto"` requests **always** showed `decided_by: fallback / eval_timeout` and degraded to `balanced` — the lane system was effectively inert for non-English traffic (trace `ff39abc6` on la.atmy.work).

Root-cause chain:
1. The Layer-2 eval model `deepseek-v4-flash` is a **reasoning model** (emits `reasoning_content` even at `temperature:0`), so a real eval round-trip is ~2–3s — the 250ms inner timeout lost every race, burning one wasted eval request per cache-miss.
2. Raising the timeout alone (3500ms stopgap) exposed the second failure: reasoning ate the 256 `max_tokens` budget, truncating the JSON verdict → `eval_not_json`, and taxed the hot path up to 3.5s.
3. Separately, once response headers arrive the provider connect/TTFB timeout is cleared — a **wedged mid-stream upstream previously hung forever** (the gateway timeout middleware resolves at the Response, not the stream body).

## Fix 1 — eval fast-probe (make eval fast, don't tolerate slow)

- `EvalConfigSchema` gains optional **`extra_body`**: a config-driven, provider-specific request-body passthrough (principle 2).
- `classify.ts` invokeModel spreads `extra_body` **first**, locked fields (`model`/`temperature`/`stream`/`max_tokens`) last — extra knobs allowed, locked fields can never be overridden.
- `classifier.yaml` sets `extra_body.thinking.type: disabled` and tightens timeouts to **1500/2000** (a reasoning-free round-trip is ~1.1s, measured). Fast + reliable beats loose + brittle.

## Fix 2 — stream idle/stall liveness guard (principle 8)

- New `provider/stream-idle.ts`: `readChunkWithIdle` races each `reader.read()` against a **per-chunk** idle deadline; on silence it fire-and-forget cancels the reader (reclaims the connection) and throws, mapped to `UpstreamError("timeout")` in all three clients (openai / anthropic / openai-responses).
- Per-chunk timer = max silence between chunks, **never a total-stream cap** — a long stream that keeps emitting runs unbounded. Pre-first-chunk it is a normal fallback-eligible failure; after, it terminates the response.
- **Terminal SSE events stop the read loop immediately** (`message_stop` → return, `response.completed` → break) so a completed response with a lazily-closed body is never misclassified as a stall.
- The four streaming routes (chat / responses / messages / gemini) **preserve `error_class: "timeout"`** in the terminal SSE error frame via `routes/stream-error.ts` instead of flattening to `upstream_error` / `internal_error`.

Scope choice: the idle deadline reuses `request_timeout_ms` (one liveness knob — "the upstream must produce *something* within N ms"), avoiding new plumbing through ~8 server.ts callsites; a dedicated `stream_idle_timeout_ms` is left as a future refinement (noted in implementation-notes.md).

## Review

Two Codex review rounds, all findings addressed:
- R1-P1 sample-config test pinned `timeout_ms===250`; R1-P2 docs/03 snippet drift.
- R2-P1 terminal events didn't stop the reader (completed ≠ stalled); R2-P2 `await reader.cancel()` could defeat the timeout; R2-P3 timeout classification lost in stream error frames.

## Testing

- TDD red→green throughout: schema passthrough, eval client forwarding, hostile-`extra_body` lockdown, idle helper (5 cases incl. per-chunk reset), per-client stall integration, terminal-event-then-open-body regressions, route-level timeout-frame test.
- **Full suite 2552 green**, typecheck clean, lint exit 0.

## Deploy notes (operator)

The live 0.8.3 image has neither change — the server currently runs interim stopgaps (`3500/4000`, `HELM_REQUEST_TIMEOUT_MS=300000`). After this ships: switch server classifier.yaml to `extra_body.thinking + 1500/2000`, and consider lowering `request_timeout_ms` to ~60–90s (it now governs TTFB **and** idle; 300s leaves a wedged connection held for 5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)