### PR TITLE
chore(release): bump version 0.8.3 → 0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release 0.8.4:

- **fix(routing): eval fast-probe** — config-driven `extra_body` passthrough disables the eval model's reasoning; `eval_timeout` / `eval_not_json` fixed at the root, timeouts tightened to 1500/2000 (#125)
- **fix(routing): stream idle/stall liveness guard** — a wedged mid-stream upstream is reclaimed instead of hanging forever; terminal SSE events stop the reader; timeout classification preserved in stream error frames (#125)
- **fix(admin): viewer-local timestamps** everywhere in the admin UI (#123)
- **fix(admin): retry dialog** long waits feel alive and are cancellable (#124)

🤖 Generated with [Claude Code](https://claude.com/claude-code)