### PR TITLE
chore(release): bump version 0.8.4 → 0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release 0.8.5 — contains #127 (request detail: surface the Layer-2 eval model + verdict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)