### PR TITLE
chore(release): bump version 0.8.5 → 0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release 0.8.6 — contains #129 (persist the Layer-1 gate confidence + detail-page attribution fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)