### PR TITLE
fix(admin): fall back to the root key when replaying a request whose key is gone

### DIFF
--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -510,8 +510,9 @@ export async function getRequestPayload(traceId: string): Promise<RequestPayload
 // (optionally edited) request body through the gateway as an ISOLATED debug re-run
 // and returns the NEW trace id so the page can navigate to the recorded result.
 // The `request` is the full OpenAI chat body the operator confirmed in the dialog;
-// identity/caps are reconstructed server-side from the ORIGINAL request's key (the
-// browser never handles a plaintext key — Principle 7).
+// identity/caps are reconstructed server-side from the ORIGINAL request's key, or —
+// when that key was deleted/revoked — from a live root key (409 only if neither
+// exists). Either way the browser never handles a plaintext key — Principle 7.
 // `signal` lets the dialog's Cancel abort the wait — the gateway sees the request
 // abort and cancels the in-flight upstream run (the route forwards its own signal).
 export async function replayRequest(

--- a/apps/gateway/src/routes/admin/replay.test.ts
+++ b/apps/gateway/src/routes/admin/replay.test.ts
@@ -253,30 +253,130 @@ describe("runReplay", () => {
     expect(rec.routeCalls).toHaveLength(0);
   });
 
-  it("409s when the original key was deleted or revoked", async () => {
+  it("falls back to a live root key when the original key was deleted", async () => {
+    const rec = emptyRec();
+    const root = fakeKey({
+      key_id: "k_root",
+      prefix: "helm_live_root",
+      role: "root",
+      allow_custom_model: true,
+    });
+    const route: ReplayWiring["route"] = async (req) => ({
+      decision: decision(req.request_id),
+      final: { status: "ok", alias: "openai/gpt-4" },
+      body: { ok: true },
+      stream: null,
+      error: null,
+    });
+    const logged: string[] = [];
+    const out = await runReplay(
+      {
+        replay: wiring(route, rec),
+        telemetry: fakeTelemetry("key_1", rec),
+        keyStore: fakeKeyStore([root]), // original key_1 deleted; only root remains
+      },
+      {
+        originalTraceId: "orig",
+        body: okBody,
+        signal: new AbortController().signal,
+        log: (m) => logged.push(m),
+      },
+    );
+    expect(out).toEqual({ ok: true, traceId: "new_trace" });
+    // Routed under the ROOT key's identity + caps (not the dead key's).
+    expect(rec.routeCalls[0]?.opts).toEqual({
+      allowCustomModel: true,
+      keyPrefix: "helm_live_root",
+      keyCaps: { allowedLanes: null, degradeLane: null },
+    });
+    expect(rec.routeCalls[0]?.req.api_key_id).toBe("k_root");
+    // Telemetry attributes the replay to the key ACTUALLY used.
+    expect(rec.inserts[0]?.apiKeyId).toBe("k_root");
+    // The fallback is logged for the audit trail.
+    expect(logged).toContain("replay.root_key_fallback");
+  });
+
+  it("falls back to a live root key when the original key is revoked", async () => {
+    const rec = emptyRec();
+    const root = fakeKey({
+      key_id: "k_root",
+      prefix: "helm_live_root",
+      role: "root",
+      allow_custom_model: true,
+    });
+    const route: ReplayWiring["route"] = async (req) => ({
+      decision: decision(req.request_id),
+      final: { status: "ok", alias: "openai/gpt-4" },
+      body: { ok: true },
+      stream: null,
+      error: null,
+    });
+    const out = await runReplay(
+      {
+        replay: wiring(route, rec),
+        telemetry: fakeTelemetry("key_1", rec),
+        keyStore: fakeKeyStore([fakeKey({ disabled: true }), root]),
+      },
+      { originalTraceId: "orig", body: okBody, signal: new AbortController().signal, log: noop },
+    );
+    expect(out).toEqual({ ok: true, traceId: "new_trace" });
+    expect(rec.inserts[0]?.apiKeyId).toBe("k_root");
+  });
+
+  it("skips DISABLED root keys when picking the fallback", async () => {
+    const rec = emptyRec();
+    const deadRoot = fakeKey({ key_id: "k_root_old", role: "root", disabled: true });
+    const liveRoot = fakeKey({ key_id: "k_root_new", prefix: "helm_live_root2", role: "root" });
+    const route: ReplayWiring["route"] = async (req) => ({
+      decision: decision(req.request_id),
+      final: { status: "ok", alias: "openai/gpt-4" },
+      body: { ok: true },
+      stream: null,
+      error: null,
+    });
+    const out = await runReplay(
+      {
+        replay: wiring(route, rec),
+        telemetry: fakeTelemetry("key_1", rec),
+        keyStore: fakeKeyStore([deadRoot, liveRoot]),
+      },
+      { originalTraceId: "orig", body: okBody, signal: new AbortController().signal, log: noop },
+    );
+    expect(out).toEqual({ ok: true, traceId: "new_trace" });
+    expect(rec.inserts[0]?.apiKeyId).toBe("k_root_new");
+  });
+
+  it("409s only when the original key AND every root key are unavailable", async () => {
+    // Empty store: nothing to route as.
     const recA = emptyRec();
     const missing = await runReplay(
       {
         replay: wiring(async () => ({}) as never, recA),
         telemetry: fakeTelemetry("key_1", recA),
-        keyStore: fakeKeyStore([]), // deleted
+        keyStore: fakeKeyStore([]),
       },
       { originalTraceId: "orig", body: okBody, signal: new AbortController().signal, log: noop },
     );
     expect(missing.ok).toBe(false);
     if (!missing.ok) expect(missing.status).toBe(409);
+    expect(recA.routeCalls).toHaveLength(0);
 
+    // Original revoked + the only root key revoked too: still blocked.
     const recB = emptyRec();
     const revoked = await runReplay(
       {
         replay: wiring(async () => ({}) as never, recB),
         telemetry: fakeTelemetry("key_1", recB),
-        keyStore: fakeKeyStore([fakeKey({ disabled: true })]),
+        keyStore: fakeKeyStore([
+          fakeKey({ disabled: true }),
+          fakeKey({ key_id: "k_root", role: "root", disabled: true }),
+        ]),
       },
       { originalTraceId: "orig", body: okBody, signal: new AbortController().signal, log: noop },
     );
     expect(revoked.ok).toBe(false);
     if (!revoked.ok) expect(revoked.status).toBe(409);
+    expect(recB.routeCalls).toHaveLength(0);
   });
 
   it("skips payload capture when capture_payloads is off (still records telemetry)", async () => {

--- a/apps/gateway/src/routes/admin/replay.ts
+++ b/apps/gateway/src/routes/admin/replay.ts
@@ -25,8 +25,13 @@ import type { AdminApiDeps, ReplayWiring } from "./deps.js";
 // It is an ISOLATED debug re-run (Principle 3 + the operator's choice): no usage
 // budget is charged and no conversation memory is written/injected. Identity +
 // caps are reconstructed from the ORIGINAL request's key so routing (lane
-// whitelist / allow_custom_model) is faithful; a deleted/revoked key blocks the
-// replay rather than silently widening permissions.
+// whitelist / allow_custom_model) is faithful. When that key is gone (deleted or
+// revoked), the replay FALLS BACK to a live root key instead of refusing: the
+// operator behind the admin Basic auth already holds root-equivalent power, and
+// what they want from a retry is the RESULT — a 409 tells them nothing. The
+// trade-off is routing fidelity (root caps, no lane whitelist), so the fallback
+// is logged and the new trace is attributed to the key ACTUALLY used. Only when
+// no live root key exists either does the replay 409.
 //
 // DELIBERATE BYPASSES (debug, not client traffic): besides the budget gate/settle
 // and memory, a replay also skips the per-key RATE LIMIT (rate_limit_rpm/tpm) and
@@ -73,10 +78,25 @@ export async function runReplay(
   if (keyId === null) return { ok: false, status: 404, error: "original request not found" };
 
   // 3. Reconstruct identity from the still-live key so the re-run routes with the
-  //    SAME caps. A missing/disabled key blocks replay (never widen permissions).
-  const key = (await deps.keyStore.list()).find((k) => k.key_id === keyId);
-  if (!key || key.disabled) {
-    return { ok: false, status: 409, error: "original key is unavailable (deleted or revoked)" };
+  //    SAME caps. If the original key is gone (deleted or revoked), fall back to a
+  //    live root key — see the header comment for why this is the operator's
+  //    deliberate choice, not a permission leak. 409 only when neither exists.
+  const keys = await deps.keyStore.list();
+  const original = keys.find((k) => k.key_id === keyId);
+  let key: ApiKeyRecord;
+  if (original && !original.disabled) {
+    key = original;
+  } else {
+    const root = keys.find((k) => k.role === "root" && !k.disabled);
+    if (!root) {
+      return {
+        ok: false,
+        status: 409,
+        error: "original key is unavailable (deleted or revoked) and no active root key exists",
+      };
+    }
+    key = root;
+    args.log("replay.root_key_fallback");
   }
 
   // 4. Build a fresh InternalRequest under a NEW trace id. Memory OFF + no session
@@ -157,7 +177,10 @@ export async function runReplay(
   try {
     await deps.telemetry.insert({
       decision: deps.replay.redact(result.decision) as DecisionRecord,
-      apiKeyId: keyId,
+      // Attribute the NEW trace to the key ACTUALLY used — on a root-key
+      // fallback that is the root key, not the dead original (honest audit
+      // trail, no dangling key_id reference).
+      apiKeyId: key.key_id,
       createdAt: new Date(deps.replay.now()),
     });
   } catch {
@@ -212,8 +235,8 @@ function buildInternal(
 
 export function registerReplayRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
   // POST /requests/:traceId/replay  body: { request: <openai chat body> } ->
-  // { trace_id } | { error } (400 bad body, 404 unknown request, 409 key gone,
-  // 500 result not recorded, 503 replay not wired).
+  // { trace_id } | { error } (400 bad body, 404 unknown request, 409 original
+  // key gone AND no live root key, 500 result not recorded, 503 replay not wired).
   app.post("/admin/api/requests/:traceId/replay", async (c) => {
     if (deps.replay === undefined) return c.json({ error: "replay not available" }, 503);
     const originalTraceId = c.req.param("traceId");

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-07 · 重试请求：原 key 失效时回退 root key（用户决策；docs/07；改写 2026-06-06「重试」条目的 409 行为）
+
+- **需求（用户拍板）**：重试一条原 key 已被删除/吊销的请求时返回 409「original key is unavailable」——对管理员毫无意义：他要的是**重试的结果**，不是一个解释为什么不能重试的错误。原 key 还活着就照旧用它（路由忠实）；不在了就用 root key 调试。
+- **方案**（`apps/gateway/src/routes/admin/replay.ts` 第 3 步）：原 key 存活 → 照旧；已删/已吊销 → 回退到**第一把存活的 root key**（`role==="root" && !disabled`，禁用的 root key 跳过），记日志 `replay.root_key_fallback`；只有连存活 root key 都没有（实际部署几乎不可能）才 409（错误文案改为 "…and no active root key exists"）。
+- **取舍（有意偏离原「绝不放宽权限」立场）**：原实现注释明写 "a deleted/revoked key blocks the replay rather than silently widening permissions"。推翻理由：replay 在 admin Basic auth 之后，**操作者本就持有 root 等价权力**（能看明文 payload、能铸 key），回退 root 是其主动调试选择而非提权泄露。代价是路由保真度（root 无 lane 白名单、`allow_custom_model:true`）——以日志 + 归因补偿。
+- **遥测归因改为「实际使用的 key」**：新 trace 的 `apiKeyId` 从原 keyId 改为 `key.key_id`——回退时诚实记在 root key 名下，且避免对已硬删 key 的悬空引用（审计链上「谁的身份发起了这次调用」必须真实）。
+- **验证**：TDD 先红后绿——4 个新 case（删除回退 / 吊销回退 / 跳过禁用 root / 双双失效才 409）+ 归因断言；replay 15/15、admin 路由 78/78 绿；typecheck/lint 净。前端零改动（弹窗只渲染服务端错误串）。
+
+---
+
 ## 2026-06-07 · eval 快探针：关推理 + 配置驱动 extra_body 透传（修复线上恒 fallback；docs/03 Layer 2；CLAUDE.md 原则 2/4）
 
 - **现象（la.atmy.work 实测）**：`model:"auto"` 的中文请求详情页恒显 `fallback`，`fallback_reason: eval_timeout`。逐层定位：Layer-1 非拉丁守卫 → 升级 eval；eval 内层超时只有 **250ms**，而 eval 模型 `deepseek-v4-flash` 是**推理模型**（temperature:0 也吐 `reasoning_content`），LA 主机到 DeepSeek 真实往返 ~2–3s → 必然 `eval_timeout` → 降级 balanced。即「分类兜底」，**非执行兜底**（`fallback_count:0`，provider 全 ok），与流式无关。
@@ -29,21 +39,15 @@
 
 ---
 
-## 2026-06-07 · 请求详情页时间显示「未记录时间」（修复；docs/07）
-
-- **Bug（用户报告）**：请求详情页头部恒显「未记录时间」。根因两处：① 网关详情接口 `GET /admin/api/requests/:traceId` 直接吐 `getByRequestId` 返回的 `DecisionRecord`，而该 record **schema 本身不含时间戳**（时间在独立的 `createdAt` 列里）；列表接口 `GET /requests` 早已 `created_at: r.createdAt.getTime()` 拍平上去，详情接口没拍。② 前端 `toDetail` 把 `ts` **写死成 `''`**（`toListItem` 早已正确从 `created_at` 映射），于是详情页永远落入 `{d.ts || '未记录时间'}` 兜底。
-- **方案（窄查询，对齐列表数据源）**：新增 Store 端口方法 `getCreatedAt(requestId): Promise<Date | null>`，仿 `getApiKeyId` 只 select 单列、不反序列化 decision blob；sqlite 直接返回 Date 列，postgres 列是 epoch-ms bigint 需 `new Date(ms)` 包回。网关详情接口改为 `{ ...rec, created_at: createdAt.getTime() }`（缺失则不加字段）。前端 `toDetail` 改成与 `toListItem` 同款 `created_at → ISO`；legacy 无值仍空串 → 仍走「未记录时间」兜底（绝不伪造时间）。**详情与列表时间同源同值，必然一致。**
-- **验证**：TDD 先红后绿——store-contract（双适配器 getCreatedAt 命中/未命中）、gateway 详情断言 `created_at`、前端 toDetail ts 映射；同步给 4 处 TelemetryStore mock 补 `getCreatedAt`。typecheck/lint 净，全量单测 2515 绿（唯 4 例 `admin-static.test` 红——需先 `pnpm build` 出 SPA 产物，与本改无关）。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
+### 2026-06-07 · 请求详情页时间显示「未记录时间」（修复；docs/07）：根因①详情接口直吐 `DecisionRecord`（schema 无时间戳，时间在独立 `createdAt` 列）②前端 `toDetail` 把 `ts` 写死 `''`。修：新增窄查询端口 `getCreatedAt(requestId)`（仿 getApiKeyId 单列 select；pg 列为 epoch-ms bigint 需 `new Date(ms)` 包回），详情接口拍平 `created_at`，前端与 `toListItem` 同款映射；legacy 无值仍兜底（绝不伪造时间）。TDD 双适配器契约 + 4 处 TelemetryStore mock 补 `getCreatedAt`。
+
 ### 2026-06-06 · 管理界面规则编辑写回 YAML（修复「保存只活内存、重启即回滚」；用户决策；docs/11；原则 2）：三页（分类器/Lanes/Policies）保存只重绑内存、重启回滚 → 新增 `yaml-writeback.ts`（保留注释 eemeli/yaml `setIn` + 原子 tmp+rename + fail-closed 写失败 throw），RuntimeRuleStore **先持久化后重绑**（写失败→500、内存不动、文件内存不分叉）。文件形状对齐 loader（lanes 平铺 map 缺失即删 / policies 列表整替 / classifier 包裹逐 scalar）。e2e 防误伤：test-server configDir 改拷贝到 `.e2e-data/config` 不碰仓库 config。部署坑：`/opt/helm-api/config` 须 `chown` 10001（root 属主则保存 fail-closed 500）。gateway 新增依赖 `yaml@^2.9`。
 
-### 2026-06-06 · 请求详情页「重试」按钮（可编辑重发 + 隔离重跑；用户决策；docs/07）：弹窗预填录制请求体可改 max_tokens/messages 再发；隔离 debug 重跑走真路由+真 provider、记新 trace+payload 但**不计 budget/不写记忆**，身份/caps 从原 key 重建（lane 白名单/allow_custom_model 仍生效，key 删/吊 → 409）。后端 `getApiKeyId` 窄查询重建身份 + `admin/replay.ts`（判别式 outcome 400/404/409，insert 失败 fail-closed 500 因交付物就是那条记录）；范围 v1=openai_chat（按体 schema 推断，无需新存 protocol）。Codex 修复：限流/并发门一并绕过属有意取舍（运维动作非客户端面）已成文；流式 drain try/catch 部分字节照存。
+### 2026-06-06 · 请求详情页「重试」按钮（可编辑重发 + 隔离重跑；用户决策；docs/07）：弹窗预填录制请求体可改 max_tokens/messages 再发；隔离 debug 重跑走真路由+真 provider、记新 trace+payload 但**不计 budget/不写记忆**，身份/caps 从原 key 重建（lane 白名单/allow_custom_model 仍生效；key 删/吊当时 → 409，**2026-06-07 已改为回退 root key**，见顶部条目）。后端 `getApiKeyId` 窄查询重建身份 + `admin/replay.ts`（判别式 outcome 400/404/409，insert 失败 fail-closed 500 因交付物就是那条记录）；范围 v1=openai_chat（按体 schema 推断，无需新存 protocol）。Codex 修复：限流/并发门一并绕过属有意取舍（运维动作非客户端面）已成文；流式 drain try/catch 部分字节照存。
 
 ### 2026-06-06 · 已吊销 key 允许永久删除（两步销毁；用户决策；docs/06）：软吊销 `DELETE /:id` 契约不动，硬删作 `?purge=true` 旗标；路由 gate `list().find`——未找 404 / active 409（必先吊销）/ disabled 才 deleteKey。「必先吊销」是路由策略不进 store；UI 仅 disabled 行显 Delete 但 server 独立校验（纵深防御）。审计存活靠 telemetry/payload 的 `api_key_id` 是无 FK 纯文本列，硬删不级联、悬空引用仍可审计。贯穿 core `KeyStore.deleteKey`(throw on unknown)→admin route→api client→+page。坑：选旗标不破 revoke 契约；read→delete TOCTOU 在单管理员场景可忽略 + deleteKey throw 兜底。
 


### PR DESCRIPTION
## Problem

Retrying a request from the admin detail page fails with `409 original key is unavailable (deleted or revoked)` when the original API key no longer exists. For the operator this error is meaningless — the whole point of a retry is to see the **result**, not an explanation of why it can't run.

## Behavior change

| Scenario | Before | After |
|----------|--------|-------|
| Original key live | Use it (faithful caps) | Unchanged |
| Original key deleted/revoked | 409 | **Fall back to the first live root key**, log `replay.root_key_fallback` |
| No live root key either | 409 | 409 with a clearer message (practically unreachable) |

## Design decisions

- **Telemetry attribution** now records the key *actually used* — a root-fallback replay shows up under the root key's id, not a dangling reference to a hard-deleted key (honest audit trail).
- **Disabled root keys are skipped** when picking the fallback; only `role === "root" && !disabled` qualifies.
- This deliberately overturns the previous "a dead key blocks the replay rather than silently widening permissions" stance: the operator behind the admin Basic auth already holds root-equivalent power (can read plaintext payloads, mint keys), so the fallback is their deliberate debugging choice, not a permission leak. The trade-off — lost routing fidelity (root has no lane whitelist) — is logged and documented in `implementation-notes.md` (new top entry; the stale 2026-06-06 archive line updated too).

## Tests

TDD red-first: 4 new cases in `replay.test.ts` —
- deleted key → root fallback (caps + identity + attribution + log asserted)
- revoked key → root fallback
- disabled root keys skipped when picking the fallback
- 409 only when the original key AND every root key are unavailable

Replay suite 15/15 ✅, admin routes 78/78 ✅, typecheck + lint clean. No UI change needed (the dialog renders the server's error string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)