### PR TITLE
chore(release): bump version 0.8.6 → 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the 0.9.0 release.

Minor bump (not a patch): this release carries a **breaking config change** — memory compaction is now fully automatic and a leftover `memory.yaml` `observer:` block refuses startup (see #131/#134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)