### PR TITLE
fix(admin): tolerate null resets_at in Anthropic OAuth usage + log quota PULL failures

### DIFF
--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -799,6 +799,7 @@ describe("createOAuthAdmin > fetchAnthropicQuota", () => {
   async function connected(usage: () => Response): Promise<{
     fetchQuota: (input: { account: string }) => Promise<OAuthQuotaWindow[] | null>;
     usageHits: () => number;
+    logs: Array<{ level: string; message: string; fields?: Record<string, unknown> }>;
   }> {
     let hits = 0;
     vi.stubGlobal(
@@ -815,12 +816,14 @@ describe("createOAuthAdmin > fetchAnthropicQuota", () => {
       ]),
     );
     let seq = 0;
+    const logs: Array<{ level: string; message: string; fields?: Record<string, unknown> }> = [];
     const admin = createOAuthAdmin({
       store: makeStore(),
       encKey: KEY,
       config: makeConfig(),
       now: () => 1000,
       genSessionId: () => `s${++seq}`,
+      log: (level, message, fields) => logs.push({ level, message, fields }),
     });
     const { sessionId, authorizeUrl } = await admin.startManualPaste({ providerId: "anthropic" });
     const state = new URL(authorizeUrl).searchParams.get("state");
@@ -831,7 +834,7 @@ describe("createOAuthAdmin > fetchAnthropicQuota", () => {
     });
     const fetchQuota = admin.fetchAnthropicQuota;
     if (!fetchQuota) throw new Error("fetchAnthropicQuota not wired");
-    return { fetchQuota, usageHits: () => hits };
+    return { fetchQuota, usageHits: () => hits, logs };
   }
 
   it("negative-caches a failed usage fetch (no upstream hammering within the TTL)", async () => {
@@ -841,6 +844,58 @@ describe("createOAuthAdmin > fetchAnthropicQuota", () => {
     expect(await fetchQuota({ account: "default" })).toBeNull();
     expect(await fetchQuota({ account: "default" })).toBeNull();
     expect(usageHits()).toBe(1); // the second open is served from the negative cache
+  });
+
+  it("warns when a 200 body yields ZERO windows (a silent parse failure froze the page for ~23h)", async () => {
+    // A schema-rejected body parses to [] — previously cached silently, leaving the
+    // stored snapshot stale forever with no log evidence. The warn is the tripwire.
+    const { fetchQuota, logs } = await connected(() =>
+      json({ five_hour: { utilization: "not-a-number" } }),
+    );
+    expect(await fetchQuota({ account: "default" })).toEqual([]);
+    expect(logs).toEqual([
+      {
+        level: "warn",
+        message: "oauth.quota.pull_empty",
+        fields: { provider_id: "anthropic", account: "default" },
+      },
+    ]);
+  });
+
+  it("warns with the HTTP status when the usage endpoint replies non-ok", async () => {
+    const { fetchQuota, logs } = await connected(
+      () => new Response("rate_limited", { status: 429 }),
+    );
+    expect(await fetchQuota({ account: "default" })).toBeNull();
+    expect(logs).toEqual([
+      {
+        level: "warn",
+        message: "oauth.quota.pull_failed",
+        fields: { provider_id: "anthropic", account: "default", status: 429 },
+      },
+    ]);
+  });
+
+  it("warns when the usage fetch throws (network / dead token)", async () => {
+    const { fetchQuota, logs } = await connected(() => {
+      throw new Error("boom");
+    });
+    expect(await fetchQuota({ account: "default" })).toBeNull();
+    expect(logs).toEqual([
+      {
+        level: "warn",
+        message: "oauth.quota.pull_failed",
+        fields: { provider_id: "anthropic", account: "default", error: "boom" },
+      },
+    ]);
+  });
+
+  it("does NOT warn on a healthy pull", async () => {
+    const { fetchQuota, logs } = await connected(() =>
+      json({ five_hour: { utilization: 3, resets_at: "2026-06-04T12:00:00.000Z" } }),
+    );
+    expect((await fetchQuota({ account: "default" }))?.length).toBe(1);
+    expect(logs).toEqual([]);
   });
 
   it("caches a successful snapshot and surfaces utilization as 0–100 percent as-is", async () => {

--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -133,6 +133,13 @@ export interface OAuthAdminDeps {
   // can assert the proxy fetch — not the real-IP global — serves the binding calls.
   // Default: makeProxyFetch when a proxy is set, else the global fetch.
   makeFetch?: (proxy?: ProxyConfig) => typeof globalThis.fetch;
+  // Structured diagnostics sink (server.ts wires the JSON logger). The quota PULLs
+  // are fail-open by design, which previously meant their failures were swallowed
+  // SILENTLY — a body the schema rejected parsed to [] and froze the providers page
+  // on a stale snapshot for ~a day with zero log evidence. Optional so the many
+  // existing unit harnesses stay untouched. Ids/labels/status only — never a body
+  // or token (principle 7).
+  log?: (level: "warn" | "error", message: string, fields?: Record<string, unknown>) => void;
 }
 
 // Split a credential into store fields. `meta` carries every key beyond the
@@ -145,6 +152,7 @@ function metaFrom(creds: OAuthCredentials): string | null {
 export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
   const now = deps.now ?? (() => Date.now());
   const genId = deps.genSessionId ?? (() => randomUUID());
+  const log = deps.log ?? (() => {});
   // Resolve the egress fetch for a (possibly absent) proxy. ONE place so the whole
   // flow — begin/complete/poll + token-manager refresh + quota — egresses alike.
   const makeFetch =
@@ -556,11 +564,28 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
         if (res.ok) {
           const body: unknown = await res.json();
           windows = parseAnthropicUsageBody(body, now());
+          // A 200 that yields ZERO windows means the schema rejected the body (or
+          // it carried no windows at all) — the upsert is skipped and the stored
+          // snapshot silently goes stale. Warn so the next shape drift is visible
+          // in logs instead of frozen percentages (no body content — principle 7).
+          if (windows.length === 0) {
+            log("warn", "oauth.quota.pull_empty", { provider_id: ANTHROPIC, account });
+          }
         } else {
           await res.body?.cancel().catch(() => {}); // 429/4xx/5xx → cache the miss
+          log("warn", "oauth.quota.pull_failed", {
+            provider_id: ANTHROPIC,
+            account,
+            status: res.status,
+          });
         }
-      } catch {
+      } catch (e) {
         windows = null; // dead token / network / malformed body → page renders "—"
+        log("warn", "oauth.quota.pull_failed", {
+          provider_id: ANTHROPIC,
+          account,
+          error: e instanceof Error ? e.message : String(e),
+        });
       }
       // Cache the outcome (success OR failure) so the next page open within the TTL
       // is served from memory rather than re-hitting the rate-limited endpoint.
@@ -607,11 +632,26 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
         if (res.ok) {
           const body: unknown = await res.json();
           windows = parseCodexUsageBody(body, now());
+          // Same tripwire as the Anthropic PULL: a 200 yielding zero windows would
+          // otherwise freeze the stored snapshot silently.
+          if (windows.length === 0) {
+            log("warn", "oauth.quota.pull_empty", { provider_id: CODEX, account });
+          }
         } else {
           await res.body?.cancel().catch(() => {}); // 429/4xx/5xx → cache the miss
+          log("warn", "oauth.quota.pull_failed", {
+            provider_id: CODEX,
+            account,
+            status: res.status,
+          });
         }
-      } catch {
+      } catch (e) {
         windows = null; // dead token / network / malformed body → page renders "—"
+        log("warn", "oauth.quota.pull_failed", {
+          provider_id: CODEX,
+          account,
+          error: e instanceof Error ? e.message : String(e),
+        });
       }
       quotaCache.set(key, { at: now(), windows });
       return windows;

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1476,6 +1476,10 @@ export async function buildServer(
             store: oauthCtx.store,
             encKey: oauthCtx.encKey,
             config: store.config,
+            // Surface the (fail-open) quota PULL failures in the JSON log — a
+            // silently-swallowed parse failure once froze a providers-page
+            // snapshot for ~a day with zero log evidence.
+            log: (lvl, msg, fields) => logger.log(lvl, msg, fields),
           })
         : undefined,
       // Per-account OAuth subscription observability stores (providers page): today's

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,17 @@
 
 ---
 
+## 2026-06-07 · 修复 Anthropic 订阅配额页：`resets_at:null` 让整份用量解析失败、快照永久卡旧（线上实测；docs/06 providers 页 Tier 3；CLAUDE.md 原则 3 fail-open）
+
+- **现象（la.atmy.work 实测）**：providers 页两个 Claude Max 账号，`mylukin@gmail.com` 配额正确（5h 7%/7d 39%），`riverathomas6094@outlook.com` 恒显 9%/44%（真值应为 5%/5%，与并存的 claude-relay-service 对照），点刷新无效。
+- **定位（直连线上数据库 + 解密 token 实打 usage 端点）**：① `oauth_quota` 表里 river 账号快照 `captured_at` 已 **22.9 小时**未更新（mylukin 是 4.9 分钟），即 PULL 从不写回；② token 正常（`updated_at` 新鲜、刷新成功）；③ 解密 river 的 access token 实打 `GET /api/oauth/usage` 返回 **200 + 合法 body**（5h 5%/7d 5%），HTTP 层无错。差异只在 body 形状：mylukin 的 `seven_day_sonnet.resets_at` 是 ISO 串，river 的是 **`null`**（周 Sonnet 额度未动用、无倒计时）。
+- **根因**：`AnthropicWindowSchema` 内层 `resets_at: z.string().optional()` —— `.optional()` 接受 `string|undefined` 但**拒绝 `null`**。顶层窗口已是 `.nullish()`（容忍整窗为 null），却漏了**存在的窗口内部字段为 null** 这一情况。river 的 `seven_day_sonnet` 是个对象（非 null）→ 进内层校验 → `resets_at:null` 失败 → 整份 `AnthropicOAuthUsageSchema.safeParse` 失败 → `parseAnthropicUsageBody` 返回 `[]` → 路由 `if (windows.length>0)` 跳过 upsert → 旧快照永久留存，每次刷新同样失败。完美解释四个症状（账号1对、账号2卡、刷新无效、快照近一天前）。
+- **修复（最小且正确）**：`utilization`/`resets_at` 双双改 `.nullish()`，接受 API 合法的 `null`。下游 `anthropicUsageToWindows` 早已健壮（`typeof utilization!=="number"` 跳过、`resets_at` 非串 → `resetsAtMs:null`），故仅 schema 一处改动。保留 `utilization:"x"`（字符串）仍失败的防御性（坏类型≠合法 null）。
+- **取舍/坑**：(1) 当前设计是「任一窗口坏 → 整份 fail-open 到 []」的全有全无，本次只把**合法 null** 从「坏」里摘出；真要每窗独立容错是更大改动，未做。(2) 路由 `if (windows && windows.length>0)` 才 upsert 的逻辑放大了本 bug——解析失败时宁可留旧也不写空，导致静默卡死且**无任何日志**（catch 全吞）。已知观测盲点，TODO：PULL 失败/空至少记一条 warn。(3) **部署**：修复在 `packages/shared`，需重建镜像部署；la.atmy.work 现有 river 旧快照会在新镜像首次成功 PULL 后自动覆盖（5min TTL 内）。
+- **验证**：TDD 先红后绿——新增「存在窗口含 `resets_at:null`（逐字照搬线上 body）」用例，修前返回 `[]`、修后正确返回 5h/7d/7d-sonnet（sonnet `resetsAtMs:null`）。anthropic-quota 6/6、oauth 全组 67/67、shared+core typecheck 净、lint 净。全量 node 项目 2376 绿（4 红均为 `apps/admin/build` 未构建的 admin-static 环境失败，与本改无关）。
+
+---
+
 ## 2026-06-07 · 记忆压缩重写为单一 auto 模式：零配置 + 价格自适应（删除 fixed/economy；docs/08/12；CLAUDE.md 原则 1/2/3/4）
 
 - **动机（四领域专家评审）**：旧 `observer.compaction` 有 `fixed`/`economy` 两模式、economy 17 个手调旋钮，从未投产，且评审发现三处「配置撒谎」级缺陷：① `prior_compaction_count` 静态 0 → 失真项永远按首压算（真值=该线程已有 observation 数，数据本就在手）；② `retention_rate:0.8` 与现实脱节——生产 summarize 是 2000 字符截断桩，压 10k token 真实保留 ~5%；③ 失真按 input 价货币化是范畴错误（模型越贵越怕遗忘，因果倒置），质量项二次方曲率与 context-rot 研究（凹形）相反，且 catalog 无 cache 价字段而 economy 最依赖它。
@@ -31,21 +42,11 @@
 
 ---
 
-## 2026-06-07 · eval 快探针：关推理 + 配置驱动 extra_body 透传（修复线上恒 fallback；docs/03 Layer 2；CLAUDE.md 原则 2/4）
-
-- **现象（la.atmy.work 实测）**：`model:"auto"` 的中文请求详情页恒显 `fallback`，`fallback_reason: eval_timeout`。逐层定位：Layer-1 非拉丁守卫 → 升级 eval；eval 内层超时只有 **250ms**，而 eval 模型 `deepseek-v4-flash` 是**推理模型**（temperature:0 也吐 `reasoning_content`），LA 主机到 DeepSeek 真实往返 ~2–3s → 必然 `eval_timeout` → 降级 balanced。即「分类兜底」，**非执行兜底**（`fallback_count:0`，provider 全 ok），与流式无关。
-- **反面教训（硬调超时不对）**：先把 250→3500ms 止血，eval 确实开始 decide，但暴露第二坑——256 的 `max_tokens` 被 reasoning 吃光，`message.content` 截断/空 → `eval_not_json`；且 3500ms 内层超时给热路径加最多 3.5s 税。`contract.ts` 的 `extractFirstObject` 已够健壮，真因在上游 reasoning 占预算/占延迟。
-- **方案（让 eval 重新变快，而非容忍慢）**：① `EvalConfigSchema` 加 `extra_body: z.record(z.string(), z.unknown()).optional()`——**配置驱动的请求体透传**，provider 无关的逃生舱；② `EvalModelRequest.extra_body` 透传，`runEval` 仅在配置存在时挂上（不改无配置部署的请求形状）；③ `classify.ts` invokeModel **把 extra_body 铺在最前、锁定字段(model/temperature/stream/max_tokens)在后覆盖**——extra_body 能加旋钮、绝不能篡改锁定项；④ classifier.yaml 设 `extra_body.thinking.{type:disabled}`，实测往返 ~1.1s 且吐干净 JSON，于是超时**收回 1500/2000**（快且可靠，不再税热路径）。`ProviderForEval.chatCompletion(req: Record<string,unknown>)` 是松类型直接 `JSON.stringify`，故透传不受 `ChatCompletionRequestSchema` 约束。
-- **验证**：TDD 先红后绿——schema（extra_body 默认缺省/任意块原样透传）、client（配置存在则转发、缺省则不挂）、classify（敌意 extra_body 既加 thinking 又试图覆盖 model/temperature/stream → 锁定字段胜）。Codex review 抓出 P1（`classifier-samples.test.ts` 仍 pin `timeout_ms===250`）+ P2（docs/03 片段未更新）已修。typecheck/lint 净，全量 2546 绿。
-- **② 流式 idle/stall 超时（同日实现）**：`withTimeout` 在收到响应头即 `cleanup`，故 TTFB 后**流式读循环此前无任何超时**——上游 mid-stream 卡死会永久挂起（网关 timeout 中间件也在响应头返回时就 resolve，管不到流体）。新增 `provider/stream-idle.ts`：`readChunkWithIdle(reader, idleMs)` 把单次 `reader.read()` 与 idle deadline race，超时则 `reader.cancel()`（回收连接）并抛 `StreamStalledError`，由三个 client 转 `UpstreamError("timeout")`。**每次 read 各自计时 → 是「逐块静默上限」而非总时长上限**（持续吐字的长流不受限）。首个 chunk 前抛 = 可 fallback 的正常失败；之后抛 = 终止已在流的响应（无法 fallback）。**作用域取舍**：复用 `request_timeout_ms`（=TTFB 同一旋钮）当 idle 值，避免给 8 处 server.ts callsite 加新字段——语义统一为「上游必须在 N ms 内产出点东西」；专用 `stream_idle_timeout_ms` 旋钮留作未来细化。三 client（openai 内联、anthropic `translateAnthropicSSE`、responses `readResponsesEvents`，后两者加 `idleMs=0` 默认参，向后兼容）全部接入。TDD：helper 5 例（chunk 透传 / done 透传 / idleMs<=0 关闭 / 超时 cancel+抛 / 逐块计时不误杀）+ 三 client 各一 stall 集成例（首块送达后静默 → UpstreamError(timeout) 504 + reader 被 cancel）。
-- **② 的 Codex 二轮复审（3 个真 bug 已修）**：(P1) 终止 SSE 事件没停止读取——idle guard 会把**已完成**的响应变成 timeout：上游发 `message_stop`/`response.completed` 后若延迟关 body，下一次 idle read 就误触发。修：anthropic `message_stop` 后 `return`、responses `aggregateResponsesStream` 的 `response.completed` 后 `break`（`translateResponsesSSE` 本就 `return`，无恙）。各补一例「终止事件后 body 保持打开 → 不超时」回归。(P2) `stream-idle.ts` 超时路径先 `await reader.cancel()` 再抛——cancel 慢/不 resolve 会让超时形同虚设：改 `void reader.cancel().catch()` fire-and-forget，立即抛（cancel 同步发起，cancelReasons/cancelled 仍可断言）。(P3) 四个流式路由把非 `PipelineError` 的 throw 一律压成 `upstream_error`/`internal_error`，丢掉新的 timeout 分类：新增 `routes/stream-error.ts` 的 `isUpstreamTimeout(err)` 谓词，chat/responses/messages/gemini 终止错误帧统一 `isUpstreamTimeout ? "timeout" : <原兜底>`。补 helper 单测 + chat 路由集成例（流式首块后抛 UpstreamError(timeout) → 错误帧 `error_class:"timeout"`）。typecheck/lint 净，全量 2552 绿。
-- **部署坑（关键 TODO）**：①透传 + ②idle **代码都只在分支**，线上 0.8.3 镜像没有——服务器 config 现仍留**临时 3500/4000**（推理仍开）+ `HELM_REQUEST_TIMEOUT_MS=300000`。等本分支构建新镜像部署后：把服务器 classifier.yaml 切到 `extra_body.thinking + 1500/2000`；`request_timeout_ms` 现在身兼 TTFB+idle，300000 偏松（mid-stream 卡死需 5min 才回收），建议部署后下调到 ~60–90s（够推理 TTFB，又让卡死连接快速回收），或后续加专用 `stream_idle_timeout_ms` 再分离。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-07 · eval 快探针 + 流式 idle 超时（修复线上恒 fallback；docs/03 Layer 2；原则 2/4）：① `model:"auto"` 中文请求恒 `eval_timeout` 降级——根因 eval 模型是推理模型、250ms 内层超时不够；方案 `EvalConfigSchema.extra_body` 配置驱动请求体透传（classify invokeModel 铺最前、锁定 model/temperature/stream/max_tokens 后覆盖），classifier.yaml 设 `thinking.{type:disabled}` 关推理 → ~1.1s 干净 JSON、超时收回 1500/2000。② 新增 `provider/stream-idle.ts` `readChunkWithIdle`：TTFB 后流式读循环此前**无超时**，mid-stream 卡死永久挂起；逐块计时（非总时长），首块前抛=可 fallback、之后抛=终止流；复用 `request_timeout_ms` 当 idle 值；三 client 接入。Codex 二轮修 3 真 bug（终止 SSE 事件后须停读否则误判 timeout、cancel 改 fire-and-forget、四路由用 `isUpstreamTimeout` 谓词保 timeout 分类）。**部署 TODO**：代码在分支，线上 0.8.3 无；新镜像部署后 classifier.yaml 切 `extra_body.thinking+1500/2000`、`request_timeout_ms` 由 300000 下调 ~60–90s（兼 TTFB+idle，卡死连接快回收）。全量 2552 绿。
 
 ### 2026-06-07 · 请求详情页展示第二层 eval 的模型与复核结论（修复；docs/03/07；原则 5/7）：cascade 用 eval verdict 覆盖 rules 输出且 eval 模型名从不持久化 → 详情页把 eval 结果误标为「第一层规则」。修：新增持久字段 `classifier.eval_model`/`eval_latency_ms`（`.default(null)` 兼容 legacy；落库在 route-request.ts `plan()` 内联），`toDetail` 透传 `decided_by`，DecisionChain 加判定来源徽章、eval 框重做（模型+缓存+耗时+verdict/fail-open 原因）。后续修正：0.8.5 上线后用户仍把 eval 的 0.95 误读为第一层置信度 → 补 `classifier.rules_confidence` 持久化触发升级的 gate 置信度 + 升级因果行（"第一层不确定(0.05)→升级 eval 复核"，legacy 无数值定性显示不伪造）；`matched_dimensions` 映射加固防 `[object Object]`。两轮共 14 处 DecisionRecord fixture 补新字段；全量 2570 绿。
 

--- a/packages/core/src/provider/oauth/anthropic-quota.test.ts
+++ b/packages/core/src/provider/oauth/anthropic-quota.test.ts
@@ -47,6 +47,30 @@ describe("parseAnthropicUsageBody", () => {
     ]);
   });
 
+  it("keeps the other windows when a PRESENT window has resets_at:null (real account body)", () => {
+    // Verbatim shape from a live account whose weekly Sonnet cap has not yet been
+    // touched: `seven_day_sonnet` is a PRESENT object but its `resets_at` is null
+    // (no countdown yet). A `z.string().optional()` inner field REJECTS that null and
+    // fails the WHOLE parse → parseAnthropicUsageBody returned [] → the providers page
+    // kept a stale snapshot forever (the 9%/44% bug). 5h/7d must still come through;
+    // the null-reset window maps with resetsAtMs:null rather than nuking everything.
+    const out = parseAnthropicUsageBody(
+      {
+        five_hour: { utilization: 5, resets_at: RESET },
+        seven_day: { utilization: 5, resets_at: RESET },
+        seven_day_opus: null,
+        seven_day_sonnet: { utilization: 0, resets_at: null },
+        extra_usage: { is_enabled: false, monthly_limit: null, used_credits: null, currency: null },
+      },
+      NOW,
+    );
+    expect(out).toEqual([
+      { key: "5h", usedPercent: 5, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d", usedPercent: 5, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d-sonnet", usedPercent: 0, resetsAtMs: null, windowMinutes: null },
+    ]);
+  });
+
   it("clamps an out-of-range utilization into 0–100 without re-scaling", () => {
     const out = parseAnthropicUsageBody({ five_hour: { utilization: 130, resets_at: RESET } }, NOW);
     expect(out).toEqual([

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -68,14 +68,18 @@ export type OAuthQuotaSnapshot = z.infer<typeof OAuthQuotaSnapshotSchema>;
 // fail-open: every window may be absent OR explicitly `null` (the API returns
 // `"seven_day_opus": null` on plans without a separate Opus weekly cap), so each
 // field is `.nullish()` — a strict `.optional()` would REJECT the null and fail the
-// whole parse, leaving the page blank. `utilization` is already a 0–100 PERCENT
+// whole parse, leaving the page blank. The SAME applies to the INNER fields: a
+// PRESENT window can still carry `"resets_at": null` (e.g. a weekly Sonnet cap not
+// yet touched, so no countdown), so both inner fields are `.nullish()` too — an
+// inner `.optional()` would reject that null and drop EVERY window, freezing the
+// providers page on a stale snapshot. `utilization` is already a 0–100 PERCENT
 // (e.g. 33.0), NOT a 0–1 fraction — do not re-scale on ingest. `resets_at` is an
 // ISO-8601 timestamp. Windows: five_hour / seven_day / seven_day_opus /
 // seven_day_sonnet (mirrors the official Claude /usage display).
 const AnthropicWindowSchema = z
   .object({
-    utilization: z.number().optional(),
-    resets_at: z.string().optional(),
+    utilization: z.number().nullish(),
+    resets_at: z.string().nullish(),
   })
   .loose();
 


### PR DESCRIPTION
## Problem (observed live on la.atmy.work)

On the providers page, the `riverathomas6094@outlook.com` Claude Max account was stuck showing **5h 9% / 7d 44%** while the true values were **5% / 5%** (cross-checked against claude-relay-service reading the same account). The refresh button had no effect. The sibling account updated normally.

## Root cause

The account's `oauth_quota` snapshot was **22.9 hours stale**. Decrypting the token and calling `GET /api/oauth/usage` directly returned a healthy 200 — but with `"seven_day_sonnet": {"utilization": 0.0, "resets_at": null}`: a **present** window whose inner `resets_at` is `null` (an untouched weekly Sonnet cap has no countdown).

`AnthropicWindowSchema` declared the inner fields as `z.string()/z.number().optional()` — `.optional()` accepts `undefined` but **rejects `null`**. The top-level windows were already `.nullish()` (a whole-window `null` is tolerated), but a null *inside* a present window failed the entire `safeParse`:

```
parse fails → parseAnthropicUsageBody returns [] → route's `windows.length > 0`
guard skips the upsert → stale snapshot persists → every refresh re-fails
```

And every failure mode in the PULL was swallowed by bare `catch {}` — zero log evidence for ~23h.

## Fix

1. **Schema** (`packages/shared`): inner `utilization`/`resets_at` → `.nullish()`. The downstream mapper already handles both null cases (skips a non-number utilization; nulls `resetsAtMs`), so this is the only behavioral change. Wrong-typed values (e.g. a string utilization) still fail — the fail-open defense stays.
2. **Observability** (`apps/gateway`): optional `log` seam on `createOAuthAdmin`, wired to the JSON logger. Both the Anthropic and Codex PULLs now warn on `oauth.quota.pull_empty` (200 but zero windows — shape drift tripwire) and `oauth.quota.pull_failed` (non-ok status / thrown fetch). Ids/labels/status only — never a body or token (principle 7).

## Verification

- TDD red→green: new schema test uses the verbatim live body (returned `[]` before, correct 3 windows after); 4 new gateway tests cover pull_empty / non-ok / throw / no-warn-on-healthy.
- `anthropic-quota` 6/6, oauth suite green, gateway admin routes green, `pnpm -r typecheck` clean, biome clean.
- Full node-project run: 2376 passed; only the 4 pre-existing `admin-static` failures from the unbuilt admin SPA in a fresh worktree (environmental, builds in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)