### PR TITLE
fix(responses): accept input messages without explicit type (OpenAI SDK / pi-ai compat)

### DIFF
--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -158,19 +158,21 @@ describe("responsesTransformer — request input items -> IR (folding)", () => {
     expect(ir.messages[0]?.content).toBe("hi");
   });
 
-  // A typeless non-message item (no `role`) must NOT be absorbed as a message —
-  // it must still fall through to the fail-open unknown branch. Guards the
-  // non-discriminated union ordering after `type` is made optional.
-  it("does not absorb a typeless item lacking role as a message", async () => {
+  // Making `type` optional on the message variant must NOT cause a typed
+  // non-message item (which lacks `role`) to be absorbed as a message. A
+  // function_call item must still lift into an assistant tool_call. Guards the
+  // non-discriminated union ordering after the change.
+  it("still routes a typed function_call item, not as a typeless message", async () => {
     const ir = await responsesTransformer.transformRequestOut({
       model: "gpt-4o",
       input: [
         { role: "user", content: "hi" },
-        { foo: "bar" },
+        { type: "function_call", call_id: "call_x", name: "f", arguments: "{}" },
       ],
     });
-    // the unknown item produces no IR message; only the user turn folds.
-    expect(ir.messages.map((m) => m.role)).toEqual(["user"]);
+    const assistant = ir.messages.find((m) => m.role === "assistant");
+    expect(assistant?.tool_calls?.[0]?.id).toBe("call_x");
+    expect(ir.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 });
 

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -136,6 +136,42 @@ describe("responsesTransformer — request input items -> IR (folding)", () => {
     expect(ir.messages.map((m) => m.role)).toEqual(["developer", "user"]);
     expect(ir.messages[0]?.content).toEqual([{ type: "text", text: "Prefer metric units." }]);
   });
+
+  // The OpenAI SDK (and pi-ai) omit `type:"message"` on input messages — it is
+  // OPTIONAL in the Responses spec. A typeless { role, content } item must fold
+  // to a message, NOT 400 with invalid_union. Regression for SDK-shaped requests.
+  it("accepts a message item that omits type (content-part array)", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    });
+    expect(ir.messages[0]?.role).toBe("user");
+    expect(ir.messages[0]?.content).toEqual([{ type: "text", text: "hi" }]);
+  });
+
+  it("accepts a message item that omits type (bare string content)", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: [{ role: "user", content: "hi" }],
+    });
+    expect(ir.messages[0]?.role).toBe("user");
+    expect(ir.messages[0]?.content).toBe("hi");
+  });
+
+  // A typeless non-message item (no `role`) must NOT be absorbed as a message —
+  // it must still fall through to the fail-open unknown branch. Guards the
+  // non-discriminated union ordering after `type` is made optional.
+  it("does not absorb a typeless item lacking role as a message", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: [
+        { role: "user", content: "hi" },
+        { foo: "bar" },
+      ],
+    });
+    // the unknown item produces no IR message; only the user turn folds.
+    expect(ir.messages.map((m) => m.role)).toEqual(["user"]);
+  });
 });
 
 describe("responsesTransformer — reasoning item inbound (test #2)", () => {

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -66,7 +66,12 @@ const ResponsesContentPartSchema = z.union([
 // —— Inbound Responses top-level items (the `input[]` stream). ————————————————————
 const ResponsesMessageItemSchema = z
   .object({
-    type: z.literal("message"),
+    // `type` is OPTIONAL per the Responses spec: the official openai SDK (and
+    // pi-ai) omit it on input messages, sending bare { role, content }. Default
+    // it to "message" so a typeless item folds here instead of 400ing on the
+    // union. The required `role` (which non-message items lack) keeps this from
+    // absorbing function_call/reasoning items in the non-discriminated union.
+    type: z.literal("message").optional().default("message"),
     role: z.enum(["user", "assistant", "system", "developer"]),
     // content may be a plain string or a content-part array.
     content: z.union([z.string(), z.array(ResponsesContentPartSchema)]),


### PR DESCRIPTION
## Problem

`POST /v1/responses` returns **HTTP 400 `invalid_union`** (rooted at path `["input"]`) for requests produced by the official `openai` Node SDK and by `pi-ai`. Those clients omit `type:"message"` on input message items — they post bare `{ role, content }` — which is **valid per the OpenAI Responses spec** (`type` is optional and defaults to `message`).

`ResponsesMessageItemSchema` pinned `type: z.literal("message")` as required, so every typeless message item failed all members of the non-discriminated `input` union and the request was rejected by the fail-closed `.parse()` before entering the pipeline. Net effect: **any OpenAI-SDK / pi-ai client calling `/v1/responses` fails on the first turn.**

This was found while pointing an AgentCrew agent (pi-ai `openai-responses` provider) at a Helm deployment.

## Root cause

`packages/core/src/protocol/responses.ts` — message variant required `type`:

```ts
type: z.literal("message"),
```

## Fix

Make `type` optional with a `"message"` default, matching the spec:

```ts
type: z.literal("message").optional().default("message"),
```

- A typeless `{ role, content }` item now folds as a message; the default means the downstream `switch (item.type)` still matches `case "message"`.
- The variant's **required `role`** (which `function_call` / `function_call_output` / `reasoning` items lack) keeps the non-discriminated union from absorbing non-message items, so ordering stays correct.
- `content` already accepted both a bare string and a content-part array — unchanged.

## Tests (TDD — failing test committed first)

Added to `responses.test.ts`:
- typeless message with a content-part array folds to an IR user message
- typeless message with bare string content folds
- a typed `function_call` item (no `role`) still lifts to an assistant `tool_call` — guards the union ordering after the change

Verified:
- `vitest run packages/core` → **1701 passed**
- `tsc --noEmit` (@helm/core) → clean
- `biome check` on changed files → clean

## Verification against the live deployment

- `input` array **without** `type` → 400 `invalid_request` (the bug)
- same array **with** explicit `type:"message"` → 200
- `/v1/chat/completions` with the same conversation → 200 (confirms it's a Responses-schema-only issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)