### PR TITLE
fix(telemetry): record served requests for /v1/responses, /v1/messages & gemini (pipeline faces)

### DIFF
--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import { type GeminiRouteDeps, registerGeminiRoute } from "./gemini.js";
 import type { MessagesIdentity } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import type { RecordServedDeps } from "./payload-capture.js";
 
 // POST /v1beta/models/{model}:{generateContent|streamGenerateContent} — Gemini
 // inbound (issue #34). These tests pin the route CONTRACT: auth (x-goog-api-key
@@ -16,6 +17,10 @@ const GEMINI_AUTH = { "x-goog-api-key": "helm_live_secret", "Content-Type": "app
 const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
 
 const REQ_BODY = { contents: [{ role: "user", parts: [{ text: "hi" }] }] };
+
+// A fake DecisionRecord stand-in the route hands opaquely to recordServed →
+// redact → telemetry.insert (it never inspects fields).
+const FAKE_DECISION = { final: { status: "ok", model_alias: "gemini-2.0-flash" } } as never;
 
 // A canned Gemini-native response the stub responseOut produces.
 const GEMINI_RESPONSE = {
@@ -38,12 +43,14 @@ function makeDeps(
     transformRequestOut?: (native: unknown) => unknown;
     identity?: MessagesIdentity;
     rateLimiter?: GeminiRouteDeps["rateLimiter"];
+    record?: RecordServedDeps;
   } = {},
 ): { deps: GeminiRouteDeps; harness: Harness } {
   const harness: Harness = { order: [], pipelineSawIR: null, pipelineSawAbort: false };
 
   const deps: GeminiRouteDeps = {
     rateLimiter: over.rateLimiter,
+    record: over.record,
     auth: {
       resolve: async (cred) => {
         harness.order.push(`auth:${cred ?? "null"}`);
@@ -94,6 +101,7 @@ function makeDeps(
           });
         }
         return {
+          decision: FAKE_DECISION,
           collect: over.collect ?? (async () => ({ id: "ir-resp" })),
           streamIR:
             over.streamEvents ??
@@ -111,6 +119,26 @@ function buildApp(deps: GeminiRouteDeps) {
   const app = createApp({ logger: { log: () => {} } });
   registerGeminiRoute(app, deps);
   return app;
+}
+
+// Recording dep with insert + insertPayload spies (mirrors the chat telemetry
+// harness). redact is the identity so a test can assert it ran on the decision.
+function makeRecord(over: { capturePayloads?: boolean } = {}): {
+  record: RecordServedDeps;
+  insert: ReturnType<typeof vi.fn>;
+  insertPayload: ReturnType<typeof vi.fn>;
+  redact: ReturnType<typeof vi.fn>;
+} {
+  const insert = vi.fn().mockResolvedValue({ id: "1" });
+  const insertPayload = vi.fn().mockResolvedValue(undefined);
+  const redact = vi.fn((x: unknown) => x);
+  const record: RecordServedDeps = {
+    telemetry: { insert, insertPayload } as never,
+    redact: redact as never,
+    now: () => 1000,
+    capturePayloads: () => over.capturePayloads ?? true,
+  };
+  return { record, insert, insertPayload, redact };
 }
 
 describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
@@ -274,6 +302,62 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     expect(res.status).toBe(502);
     const body = (await res.json()) as { error: { status: string } };
     expect(body.error.status).toBe("UNAVAILABLE");
+  });
+
+  // ── Telemetry recording (the /admin/requests bug). The gemini face served LLM
+  //    traffic but never recorded a telemetry row, so it was invisible in the
+  //    admin Debug list. recordServed must fire on every served request.
+  it("records a redacted telemetry row + payload for a served NON-STREAM request", async () => {
+    const { record, insert, insertPayload, redact } = makeRecord();
+    const { deps } = makeDeps({ record });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insert).toHaveBeenCalledOnce();
+    const arg = insert.mock.calls[0]?.[0] as { apiKeyId: string };
+    expect(arg.apiKeyId).toBe("k1");
+    expect(redact).toHaveBeenCalled();
+    // The plaintext key must never reach the persisted telemetry row.
+    expect(JSON.stringify(arg)).not.toContain("helm_live_secret");
+    expect(insertPayload).toHaveBeenCalledOnce();
+  });
+
+  it("records a telemetry row for a served STREAM request after the stream drains", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+    }
+    const { record, insert } = makeRecord();
+    const { deps } = makeDeps({ record, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    // Drain the stream fully so the finally (where recording lives) runs.
+    await res.text();
+
+    expect(insert).toHaveBeenCalledOnce();
+    const arg = insert.mock.calls[0]?.[0] as { apiKeyId: string };
+    expect(arg.apiKeyId).toBe("k1");
+  });
+
+  it("does not record when no record dep is wired (existing tests stay green)", async () => {
+    const { deps } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(200);
   });
 });
 

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -359,6 +359,53 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  // ── Capture-payloads gating (review P2). With capture_payloads OFF the route
+  //    must still write the telemetry row but NOT buffer/persist the body — the
+  //    stream buffer is the unbounded growth vector this gate closes.
+  it("capture_payloads OFF: a served stream records the telemetry row but NOT the payload", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+    }
+    const { record, insert, insertPayload } = makeRecord({ capturePayloads: false });
+    const { deps } = makeDeps({ record, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    await res.text();
+
+    expect(insert).toHaveBeenCalledOnce();
+    expect(insertPayload).not.toHaveBeenCalled();
+  });
+
+  // ── Terminal stream error frame must be appended to the captured body (review
+  //    P2). A mid-stream error writes a nameless `data:` error frame to the
+  //    client; that frame has to land in the persisted responseJson too.
+  it("stream error frame is captured in the payload", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
+      throw new PipelineError("all_providers_failed", "all providers failed", "trace-1");
+    }
+    const { record, insertPayload } = makeRecord({ capturePayloads: true });
+    const { deps } = makeDeps({ record, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    await res.text();
+
+    expect(insertPayload).toHaveBeenCalledOnce();
+    const arg = insertPayload.mock.calls[0]?.[0] as { responseJson: string };
+    expect(arg.responseJson).toContain("UNAVAILABLE");
+    expect(arg.responseJson).toContain("all providers failed");
+  });
 });
 
 describe("POST /v1beta/models/{model}:streamGenerateContent?alt=sse (Gemini stream)", () => {

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -12,7 +12,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult, RouteError } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
-import { type RecordServedDeps, recordServed } from "./payload-capture.js";
+import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1beta/models/{model}:generateContent / :streamGenerateContent — Google
@@ -269,6 +269,12 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       throw err;
     }
 
+    // Capture the verbatim request/response bodies only when capture_payloads is ON
+    // (the telemetry row is always written regardless). Gating the buffering here
+    // stops long/concurrent streams from accumulating the full body when capture is
+    // off (review P2).
+    const captureBodies = deps.record !== undefined && captureEnabled(deps.record);
+
     // 4) Protocol Adapter (outbound). Gemini streaming events are incremental deltas,
     //    written as nameless `data:` frames — NO `event:` name, NO `[DONE]`.
     if (route.stream) {
@@ -284,7 +290,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
         try {
           for await (const snapshot of result.streamIR()) {
             const data = JSON.stringify(snapshot);
-            if (deps.record) captured.push(`data: ${data}\n\n`);
+            if (captureBodies) captured.push(`data: ${data}\n\n`);
             await sse.writeSSE({ data });
           }
         } catch (err) {
@@ -302,7 +308,9 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
                     trace_id: traceId,
                   };
             const out = transformer.transformErrorOut(re);
-            await sse.writeSSE({ data: JSON.stringify(out.body) });
+            const data = JSON.stringify(out.body);
+            if (captureBodies) captured.push(`data: ${data}\n\n`);
+            await sse.writeSSE({ data });
           }
         } finally {
           releaseConcurrency?.();
@@ -318,7 +326,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
                 apiKeyId: identity.keyId,
                 decision: result.decision,
                 requestJson: JSON.stringify(native),
-                responseJson: captured.join(""),
+                responseJson: captureBodies ? captured.join("") : null,
               },
               (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
             );
@@ -369,7 +377,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
           apiKeyId: identity.keyId,
           decision: result.decision,
           requestJson: JSON.stringify(native),
-          responseJson: JSON.stringify(body),
+          responseJson: captureBodies ? JSON.stringify(body) : null,
         },
         (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
       );

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -12,6 +12,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult, RouteError } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1beta/models/{model}:generateContent / :streamGenerateContent — Google
@@ -59,6 +60,10 @@ export interface GeminiRouteDeps {
   /** Per-key concurrency overflow queue (issue #93) — the SAME process-wide gate
    *  as the chat middleware. Optional — omitted = no gating. */
   concurrencyGate?: ConcurrencyGatePort;
+  /** Telemetry + payload recorder (the /admin/requests fix). Optional so existing
+   *  tests that omit it record nothing; when wired, every served request (success
+   *  OR failure, stream OR non-stream) writes a telemetry row. */
+  record?: RecordServedDeps;
   auth: {
     /** Resolve the request credential to an identity, or null when invalid. */
     resolve(credential: string | null): Promise<MessagesIdentity | null>;
@@ -272,9 +277,15 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       const releaseConcurrency = c.get("concurrencyRelease");
       c.set("concurrencyRelease", undefined);
       return streamSSE(c, async (sse) => {
+        // Accumulate the serialized wire frames so the served response body can be
+        // captured (verbatim) alongside the telemetry row in the finally below.
+        // Gemini frames are nameless `data:` frames (no `event:` name, no [DONE]).
+        const captured: string[] = [];
         try {
           for await (const snapshot of result.streamIR()) {
-            await sse.writeSSE({ data: JSON.stringify(snapshot) });
+            const data = JSON.stringify(snapshot);
+            if (deps.record) captured.push(`data: ${data}\n\n`);
+            await sse.writeSSE({ data });
           }
         } catch (err) {
           // A client disconnect / abort is a benign non-provider fault (docs/02):
@@ -295,6 +306,23 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
           }
         } finally {
           releaseConcurrency?.();
+          // Record AFTER releaseConcurrency (never extend the hold) and AFTER the
+          // for-await loop ended so the pipeline's own streamIR finally (cost
+          // backfill) already mutated result.decision. result.decision exists even
+          // on a pre-stream failure, so a failed stream still records. Fail-open.
+          if (deps.record) {
+            await recordServed(
+              deps.record,
+              {
+                requestId: traceId,
+                apiKeyId: identity.keyId,
+                decision: result.decision,
+                requestJson: JSON.stringify(native),
+                responseJson: captured.join(""),
+              },
+              (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+            );
+          }
         }
       });
     }
@@ -305,6 +333,23 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     try {
       body = transformer.transformResponseOut(await result.collect());
     } catch (err) {
+      // Record the FAILED served request before surfacing the error (mirrors
+      // chat.ts) so an all-providers-failed request still appears in
+      // /admin/requests. responseJson null = no body. result.decision exists even
+      // on failure. Fail-open inside recordServed.
+      if (deps.record) {
+        await recordServed(
+          deps.record,
+          {
+            requestId: traceId,
+            apiKeyId: identity.keyId,
+            decision: result.decision,
+            requestJson: JSON.stringify(native),
+            responseJson: null,
+          },
+          (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+        );
+      }
       if (err instanceof PipelineError) {
         return sendError(c, {
           error_class: err.error_class,
@@ -313,6 +358,21 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
         });
       }
       throw err;
+    }
+    // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
+    // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
+    if (deps.record) {
+      await recordServed(
+        deps.record,
+        {
+          requestId: traceId,
+          apiKeyId: identity.keyId,
+          decision: result.decision,
+          requestJson: JSON.stringify(native),
+          responseJson: JSON.stringify(body),
+        },
+        (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+      );
     }
     return c.json(body as Record<string, unknown>);
   });

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -496,6 +496,10 @@ export function createMessagesPipeline(
           : null;
 
       return {
+        // The LIVE decision reference (mutated in place by backfillCompletionCost
+        // in the stream finally below), exposed so the route records the FINAL
+        // decision after consumption. Present even on a routing failure.
+        decision: result.decision,
         async collect(): Promise<unknown> {
           if (failure !== null) throw failure;
           // The route surfaces the OpenAI body; project it into the IR the

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -571,4 +571,52 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  // ── Capture-payloads gating (review P2). With capture_payloads OFF the route
+  //    must still write the telemetry row but NOT buffer/persist the body — the
+  //    stream buffer is the unbounded growth vector this gate closes.
+  it("capture_payloads OFF: a served stream records the telemetry row but NOT the payload", async () => {
+    async function* events() {
+      yield { type: "message_start" };
+      yield { type: "message_stop" };
+    }
+    const { record, insert, insertPayload } = makeRecord({ capturePayloads: false });
+    const { deps } = makeDeps({ record, isStream: true, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ_BODY, stream: true }),
+    });
+    await res.text();
+
+    expect(insert).toHaveBeenCalledOnce();
+    expect(insertPayload).not.toHaveBeenCalled();
+  });
+
+  // ── Terminal stream error frame must be appended to the captured body (review
+  //    P2). A mid-stream upstream error writes an `event: error` frame to the
+  //    client; that frame has to land in the persisted responseJson too.
+  it("stream error frame is captured in the payload", async () => {
+    async function* events(): AsyncIterable<{ type: string }> {
+      yield { type: "message_start" };
+      throw new Error("upstream blew up mid-stream");
+    }
+    const { record, insertPayload } = makeRecord({ capturePayloads: true });
+    const { deps } = makeDeps({ record, isStream: true, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ_BODY, stream: true }),
+    });
+    await res.text();
+
+    expect(insertPayload).toHaveBeenCalledOnce();
+    const arg = insertPayload.mock.calls[0]?.[0] as { responseJson: string };
+    expect(arg.responseJson).toContain("event: error");
+    expect(arg.responseJson).toContain("error");
+  });
 });

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import {
   type MessagesIdentity,
@@ -6,6 +6,7 @@ import {
   registerMessagesRoute,
 } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import type { RecordServedDeps } from "./payload-capture.js";
 
 // POST /v1/messages — Anthropic Messages inbound. These tests pin the route's
 // CONTRACT: auth → translate(out) → route → translate(back), with all business
@@ -15,6 +16,10 @@ import { PipelineError } from "./messages-pipeline.js";
 const AUTH = { "x-api-key": "helm_live_secret", "Content-Type": "application/json" };
 
 const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
+
+// A fake DecisionRecord stand-in the route hands opaquely to recordServed →
+// redact → telemetry.insert (it never inspects fields).
+const FAKE_DECISION = { final: { status: "ok", model_alias: "claude-3-5-sonnet" } } as never;
 
 // A minimal IR-ish object the stub transformer returns; the route must thread it
 // to the pipeline untouched (save trace_id) and never inspect its internals.
@@ -57,6 +62,7 @@ function makeDeps(
     transformRequestOut?: (native: unknown) => unknown;
     rateLimiter?: MessagesRouteDeps["rateLimiter"];
     identity?: MessagesIdentity;
+    record?: RecordServedDeps;
   } = {},
 ): { deps: MessagesRouteDeps; harness: Harness } {
   const harness: Harness = {
@@ -68,6 +74,7 @@ function makeDeps(
 
   const deps: MessagesRouteDeps = {
     rateLimiter: over.rateLimiter,
+    record: over.record,
     auth: {
       resolve: async (_key: string | null) => {
         harness.order.push("auth");
@@ -135,6 +142,7 @@ function makeDeps(
           });
         }
         return {
+          decision: FAKE_DECISION,
           collect: over.collect ?? (async () => ({ id: "ir-resp" })),
           streamIR:
             over.streamEvents ??
@@ -152,6 +160,26 @@ function buildApp(deps: MessagesRouteDeps) {
   const app = createApp({ logger: { log: () => {} } });
   registerMessagesRoute(app, deps);
   return app;
+}
+
+// Recording dep with insert + insertPayload spies (mirrors the chat telemetry
+// harness). redact is the identity so a test can assert it ran on the decision.
+function makeRecord(over: { capturePayloads?: boolean } = {}): {
+  record: RecordServedDeps;
+  insert: ReturnType<typeof vi.fn>;
+  insertPayload: ReturnType<typeof vi.fn>;
+  redact: ReturnType<typeof vi.fn>;
+} {
+  const insert = vi.fn().mockResolvedValue({ id: "1" });
+  const insertPayload = vi.fn().mockResolvedValue(undefined);
+  const redact = vi.fn((x: unknown) => x);
+  const record: RecordServedDeps = {
+    telemetry: { insert, insertPayload } as never,
+    redact: redact as never,
+    now: () => 1000,
+    capturePayloads: () => over.capturePayloads ?? true,
+  };
+  return { record, insert, insertPayload, redact };
 }
 
 const REQ_BODY = {
@@ -485,5 +513,62 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     });
     expect(res.status).toBe(200);
     expect(harness.order).toContain("route");
+  });
+
+  // ── Telemetry recording (the /admin/requests bug). /v1/messages served LLM
+  //    traffic but never recorded a telemetry row, so it was invisible in the
+  //    admin Debug list. recordServed must fire on every served request.
+  it("records a redacted telemetry row + payload for a served NON-STREAM request", async () => {
+    const { record, insert, insertPayload, redact } = makeRecord();
+    const { deps } = makeDeps({ record });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insert).toHaveBeenCalledOnce();
+    const arg = insert.mock.calls[0]?.[0] as { apiKeyId: string };
+    expect(arg.apiKeyId).toBe("k1");
+    expect(redact).toHaveBeenCalled();
+    // The plaintext key must never reach the persisted telemetry row.
+    expect(JSON.stringify(arg)).not.toContain("helm_live_secret");
+    expect(insertPayload).toHaveBeenCalledOnce();
+  });
+
+  it("records a telemetry row for a served STREAM request after the stream drains", async () => {
+    async function* events() {
+      yield { type: "message_start" };
+      yield { type: "message_stop" };
+    }
+    const { record, insert } = makeRecord();
+    const { deps } = makeDeps({ record, isStream: true, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ_BODY, stream: true }),
+    });
+    // Drain the stream fully so the finally (where recording lives) runs.
+    await res.text();
+
+    expect(insert).toHaveBeenCalledOnce();
+    const arg = insert.mock.calls[0]?.[0] as { apiKeyId: string };
+    expect(arg.apiKeyId).toBe("k1");
+  });
+
+  it("does not record when no record dep is wired (existing tests stay green)", async () => {
+    const { deps } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -1,4 +1,4 @@
-import type { BudgetCaps, RateLimitProbe, RateLimitResult } from "@helm/core";
+import type { BudgetCaps, DecisionRecord, RateLimitProbe, RateLimitResult } from "@helm/core";
 import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -7,6 +7,7 @@ import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1/messages — Anthropic Messages inbound, translated to IR, routed, and
@@ -70,6 +71,12 @@ export interface RouteError {
 /** Outcome of one routing run. Stream vs non-stream is decided by the caller via
  *  the IR's `stream` flag; the route consumes exactly one of the two accessors. */
 export interface PipelineRunResult {
+  /** The live DecisionRecord for this run (docs/07). Exposed so the three pipeline
+   *  faces can record telemetry AFTER consumption — the SAME object the pipeline
+   *  mutates in place (backfillCompletionCost during the stream finally), so once
+   *  the stream/collect has drained it carries the final cost. Present even on a
+   *  routing failure (final.status === "error"), so a failed face still records. */
+  readonly decision: DecisionRecord;
   /** Drain the full (non-stream) result into ONE IR response object. */
   collect(): Promise<unknown>;
   /** The outbound-protocol event stream: one object per wire event. For Anthropic
@@ -93,6 +100,10 @@ export interface MessagesRouteDeps {
    *  the chat middleware uses, so a key's in-flight count spans every surface.
    *  Optional — omitted = no gating (the gate also no-ops while disabled). */
   concurrencyGate?: ConcurrencyGatePort;
+  /** Telemetry + payload recorder (the /admin/requests fix). Optional so existing
+   *  tests that omit it record nothing; when wired, every served request (success
+   *  OR failure, stream OR non-stream) writes a telemetry row. */
+  record?: RecordServedDeps;
   auth: {
     /** Resolve the request credential to an identity, or null when invalid.
      *  Mandatory auth: a null result short-circuits to a 401 (no anonymous
@@ -324,12 +335,16 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       const releaseConcurrency = c.get("concurrencyRelease");
       c.set("concurrencyRelease", undefined);
       return streamSSE(c, async (sse) => {
+        // Accumulate the serialized wire frames so the served response body can be
+        // captured (verbatim) alongside the telemetry row in the finally below.
+        const captured: string[] = [];
         // Every IR event is mapped by the transformer's explicit state machine;
         // we NEVER forward a raw upstream chunk (CLAUDE.md principle 8). The
         // transformer already guards start-before-delta and idempotent close.
         try {
           for await (const event of result.streamIR()) {
             const frame = anthropic.transformStreamOut(event);
+            if (deps.record) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
             await sse.writeSSE({ event: frame.event, data: frame.data });
           }
         } catch (err) {
@@ -352,6 +367,23 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
           }
         } finally {
           releaseConcurrency?.();
+          // Record AFTER releaseConcurrency (never extend the hold) and AFTER the
+          // for-await loop ended so the pipeline's own streamIR finally (cost
+          // backfill) already mutated result.decision. result.decision exists even
+          // on a pre-stream failure, so a failed stream still records. Fail-open.
+          if (deps.record) {
+            await recordServed(
+              deps.record,
+              {
+                requestId: traceId,
+                apiKeyId: identity.keyId,
+                decision: result.decision,
+                requestJson: JSON.stringify(native),
+                responseJson: captured.join(""),
+              },
+              (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+            );
+          }
         }
       });
     }
@@ -363,6 +395,23 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     try {
       body = await anthropic.transformResponseOut(await result.collect());
     } catch (err) {
+      // Record the FAILED served request before surfacing the error (mirrors
+      // chat.ts) so an all-providers-failed request still appears in
+      // /admin/requests. responseJson null = no body. result.decision exists even
+      // on failure. Fail-open inside recordServed.
+      if (deps.record) {
+        await recordServed(
+          deps.record,
+          {
+            requestId: traceId,
+            apiKeyId: identity.keyId,
+            decision: result.decision,
+            requestJson: JSON.stringify(native),
+            responseJson: null,
+          },
+          (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+        );
+      }
       if (err instanceof PipelineError) {
         return sendError(c, {
           error_class: err.error_class,
@@ -371,6 +420,21 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         });
       }
       throw err;
+    }
+    // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
+    // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
+    if (deps.record) {
+      await recordServed(
+        deps.record,
+        {
+          requestId: traceId,
+          apiKeyId: identity.keyId,
+          decision: result.decision,
+          requestJson: JSON.stringify(native),
+          responseJson: JSON.stringify(body),
+        },
+        (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+      );
     }
     return c.json(body as Record<string, unknown>);
   });

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -7,7 +7,7 @@ import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
 import { PipelineError } from "./messages-pipeline.js";
-import { type RecordServedDeps, recordServed } from "./payload-capture.js";
+import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1/messages — Anthropic Messages inbound, translated to IR, routed, and
@@ -327,6 +327,12 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       throw err;
     }
 
+    // Capture the verbatim request/response bodies only when capture_payloads is ON
+    // (the telemetry row is always written regardless). Gating the buffering here
+    // stops long/concurrent streams from accumulating the full body when capture is
+    // off (review P2).
+    const captureBodies = deps.record !== undefined && captureEnabled(deps.record);
+
     // 4) Protocol Adapter (outbound): stream vs non-stream, isomorphic shape.
     if (ir.stream === true) {
       // Claim the concurrency lease (issue #93): the guard middleware fires as
@@ -344,7 +350,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         try {
           for await (const event of result.streamIR()) {
             const frame = anthropic.transformStreamOut(event);
-            if (deps.record) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
+            if (captureBodies) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
             await sse.writeSSE({ event: frame.event, data: frame.data });
           }
         } catch (err) {
@@ -363,7 +369,9 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
                     trace_id: traceId,
                   };
             const out = anthropic.transformErrorOut(re);
-            await sse.writeSSE({ event: "error", data: JSON.stringify(out.body) });
+            const data = JSON.stringify(out.body);
+            if (captureBodies) captured.push(`event: error\ndata: ${data}\n\n`);
+            await sse.writeSSE({ event: "error", data });
           }
         } finally {
           releaseConcurrency?.();
@@ -379,7 +387,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
                 apiKeyId: identity.keyId,
                 decision: result.decision,
                 requestJson: JSON.stringify(native),
-                responseJson: captured.join(""),
+                responseJson: captureBodies ? captured.join("") : null,
               },
               (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
             );
@@ -431,7 +439,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
           apiKeyId: identity.keyId,
           decision: result.decision,
           requestJson: JSON.stringify(native),
-          responseJson: JSON.stringify(body),
+          responseJson: captureBodies ? JSON.stringify(body) : null,
         },
         (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
       );

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -37,6 +37,51 @@ export function captureEnabled(deps: PayloadCaptureDeps): boolean {
   return deps.capturePayloads?.() === true;
 }
 
+export interface RecordServedDeps extends PayloadCaptureDeps {
+  /** Redactor for the decision before it is persisted to telemetry (never store a
+   *  plaintext key / secret). Same redactor the chat route uses. */
+  redact: (decision: DecisionRecord) => DecisionRecord;
+  now: () => number;
+}
+
+// Record ONE served request: the telemetry row (always — this is what makes the
+// request appear in /admin/requests) plus the verbatim request/response payload
+// (gated by capture_payloads). Shared by the three pipeline faces (/v1/responses,
+// /v1/messages, gemini) so the recording logic can never drift between them again.
+// Fully FAIL-OPEN: a telemetry/payload failure must never turn a served response
+// into a 5xx or break a stream.
+export async function recordServed(
+  deps: RecordServedDeps,
+  args: {
+    requestId: string;
+    apiKeyId: string;
+    decision: DecisionRecord;
+    requestJson: string;
+    responseJson: string | null;
+  },
+  log: (msg: string) => void,
+): Promise<void> {
+  await persistPayload(
+    deps,
+    {
+      requestId: args.requestId,
+      requestJson: args.requestJson,
+      responseJson: args.responseJson,
+      now: deps.now(),
+    },
+    log,
+  );
+  try {
+    await deps.telemetry.insert({
+      decision: deps.redact(args.decision),
+      apiKeyId: args.apiKeyId,
+      createdAt: new Date(deps.now()),
+    });
+  } catch {
+    log("telemetry.insert_failed");
+  }
+}
+
 // Total served tokens (prompt + completion) from an OpenAI-style usage object, for
 // the per-key token budget (docs/06). Tolerant of a missing/partial usage: a field
 // absent counts as 0. Used by every face's post-served budget settle — the usage

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import type { MessagesIdentity } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import type { RecordServedDeps } from "./payload-capture.js";
 import { type ResponsesRouteDeps, registerResponsesRoute } from "./responses.js";
 
 // POST /v1/responses contract: auth → translate(out) → route → translate(back),
@@ -9,6 +10,12 @@ import { type ResponsesRouteDeps, registerResponsesRoute } from "./responses.js"
 // route must be pure HTTP glue (CLAUDE.md principle 1).
 
 const AUTH = { Authorization: "Bearer helm_live_secret", "Content-Type": "application/json" };
+
+// A fake DecisionRecord stand-in: the route treats it as an opaque bag it hands
+// to recordServed → redact → telemetry.insert (it never inspects fields). The
+// `model_alias` marker lets a test assert the redacted decision actually rode the
+// insert call.
+const FAKE_DECISION = { final: { status: "ok", model_alias: "gpt-4o" } } as never;
 
 function makeDeps(
   over: {
@@ -18,11 +25,13 @@ function makeDeps(
     streamIR?: () => AsyncIterable<{ type: string; [k: string]: unknown }>;
     rateLimiter?: ResponsesRouteDeps["rateLimiter"];
     identity?: MessagesIdentity;
+    record?: RecordServedDeps;
   } = {},
 ): { deps: ResponsesRouteDeps; order: string[] } {
   const order: string[] = [];
   const deps: ResponsesRouteDeps = {
     rateLimiter: over.rateLimiter,
+    record: over.record,
     auth: {
       resolve: async (cred) => {
         order.push("auth");
@@ -52,6 +61,7 @@ function makeDeps(
       run: async (_ir, _identity, _signal) => {
         order.push("route");
         return {
+          decision: FAKE_DECISION,
           collect: over.collect ?? (async () => ({ id: "ir-resp", choices: [] })),
           streamIR:
             over.streamIR ??
@@ -86,6 +96,27 @@ function buildApp(deps: ResponsesRouteDeps) {
   const app = createApp({ logger: { log: () => {} } });
   registerResponsesRoute(app, deps);
   return app;
+}
+
+// Build a recording dep with insert + insertPayload spies (mirrors the chat
+// route's telemetry harness). `redact` is the identity so a test can assert it
+// was invoked on the decision before persistence.
+function makeRecord(over: { capturePayloads?: boolean } = {}): {
+  record: RecordServedDeps;
+  insert: ReturnType<typeof vi.fn>;
+  insertPayload: ReturnType<typeof vi.fn>;
+  redact: ReturnType<typeof vi.fn>;
+} {
+  const insert = vi.fn().mockResolvedValue({ id: "1" });
+  const insertPayload = vi.fn().mockResolvedValue(undefined);
+  const redact = vi.fn((x: unknown) => x);
+  const record: RecordServedDeps = {
+    telemetry: { insert, insertPayload } as never,
+    redact: redact as never,
+    now: () => 1000,
+    capturePayloads: () => over.capturePayloads ?? true,
+  };
+  return { record, insert, insertPayload, redact };
 }
 
 const REQ = { model: "auto", input: "Say hello", max_output_tokens: 16 };
@@ -348,5 +379,67 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       body: JSON.stringify(REQ),
     });
     expect(capturedOverride).toEqual({ rpm: 1, tpm: null });
+  });
+
+  // ── Telemetry recording (the /admin/requests bug). /v1/responses serves LLM
+  //    traffic but never recorded a telemetry row, so it was invisible in the
+  //    admin Debug list. recordServed must fire on every served request.
+  it("records a redacted telemetry row + payload for a served NON-STREAM request", async () => {
+    const { record, insert, insertPayload, redact } = makeRecord();
+    const { deps } = makeDeps({ record });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insert).toHaveBeenCalledOnce();
+    const arg = insert.mock.calls[0]?.[0] as { apiKeyId: string };
+    expect(arg.apiKeyId).toBe("k1");
+    expect(redact).toHaveBeenCalled();
+    // The plaintext bearer must never reach the persisted telemetry row.
+    expect(JSON.stringify(arg)).not.toContain("helm_live_secret");
+    // capture_payloads ON → the verbatim request/response body is persisted too.
+    expect(insertPayload).toHaveBeenCalledOnce();
+  });
+
+  it("records a telemetry row for a served STREAM request after the stream drains", async () => {
+    const { record, insert } = makeRecord();
+    const { deps } = makeDeps({
+      record,
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    // Drain the stream fully so the finally (where recording lives) runs.
+    await res.text();
+
+    expect(insert).toHaveBeenCalledOnce();
+    const arg = insert.mock.calls[0]?.[0] as { apiKeyId: string };
+    expect(arg.apiKeyId).toBe("k1");
+  });
+
+  it("does not record when no record dep is wired (existing tests stay green)", async () => {
+    const { deps } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -442,4 +442,88 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  // ── Capture-payloads gating (review P2). With capture_payloads OFF the route
+  //    must still write the telemetry row but NOT buffer/persist the body — the
+  //    stream buffer is the unbounded growth vector this gate closes.
+  it("capture_payloads OFF: a served stream records the telemetry row but NOT the payload", async () => {
+    const { record, insert, insertPayload } = makeRecord({ capturePayloads: false });
+    const { deps } = makeDeps({
+      record,
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    await res.text();
+
+    expect(insert).toHaveBeenCalledOnce();
+    expect(insertPayload).not.toHaveBeenCalled();
+  });
+
+  // ── Terminal stream error frame must be appended to the captured body (review
+  //    P2). A mid-stream upstream error writes an `event: error` frame to the
+  //    client; that frame has to land in the persisted responseJson too.
+  it("stream error frame is captured in the payload", async () => {
+    const { record, insertPayload } = makeRecord({ capturePayloads: true });
+    const { deps } = makeDeps({
+      record,
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      streamIR: async function* () {
+        yield { type: "response.created", sequence_number: 0 };
+        throw new Error("upstream exploded");
+      },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    await res.text();
+
+    expect(insertPayload).toHaveBeenCalledOnce();
+    const arg = insertPayload.mock.calls[0]?.[0] as { responseJson: string };
+    expect(arg.responseJson).toContain("event: error");
+    expect(arg.responseJson).toContain("upstream exploded");
+  });
+
+  // ── Finding 3: the non-stream outbound transform must run INSIDE the failure-
+  //    recording try, so a transformer throw after a provider result was collected
+  //    still writes a telemetry row (consistent with messages/gemini).
+  it("non-stream: an outbound transform failure still records telemetry", async () => {
+    const { record, insert } = makeRecord();
+    const { deps } = makeDeps({ record });
+    deps.transformer.transformResponseOut = () => {
+      throw new Error("transform blew up");
+    };
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+
+    // The transform throw is not a PipelineError → it escapes to onError (a 5xx).
+    // The point of Finding 3 is that the telemetry row was STILL written because
+    // the transform now runs inside the failure-recording try.
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(insert).toHaveBeenCalledOnce();
+  });
 });

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -9,6 +9,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1/responses — OpenAI Responses API inbound, translated to IR, routed
@@ -46,6 +47,10 @@ export interface ResponsesRouteDeps {
   /** Per-key concurrency overflow queue (issue #93) — the SAME process-wide gate
    *  as the chat middleware. Optional — omitted = no gating. */
   concurrencyGate?: ConcurrencyGatePort;
+  /** Telemetry + payload recorder (the /admin/requests fix). Optional so existing
+   *  tests that omit it record nothing; when wired, every served request (success
+   *  OR failure, stream OR non-stream) writes a telemetry row. */
+  record?: RecordServedDeps;
   auth: { resolve(credential: string | null): Promise<MessagesIdentity | null> };
   transformer: {
     /** native Responses request → IR (throws on a structurally invalid body). */
@@ -274,11 +279,15 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         // forward a raw upstream chunk). There is NO [DONE] sentinel; the terminal
         // response.completed closes the stream.
         let nextErrorSequence = 0;
+        // Accumulate the serialized wire frames so the served response body can be
+        // captured (verbatim) alongside the telemetry row in the finally below.
+        const captured: string[] = [];
         try {
           for await (const event of result.streamIR()) {
             if (typeof event.sequence_number === "number")
               nextErrorSequence = event.sequence_number + 1;
             const frame = deps.transformer.transformStreamOut(event);
+            if (deps.record) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
             await sse.writeSSE({ event: frame.event, data: frame.data });
           }
         } catch (err) {
@@ -307,6 +316,24 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           }
         } finally {
           releaseConcurrency?.();
+          // Record AFTER releaseConcurrency so the bookkeeping never extends the
+          // concurrency hold, and AFTER the for-await loop ended so the pipeline's
+          // own streamIR finally (cost backfill) already mutated result.decision.
+          // result.decision exists even on a pre-stream failure, so a failed stream
+          // still records. Fail-open inside recordServed.
+          if (deps.record) {
+            await recordServed(
+              deps.record,
+              {
+                requestId: traceId,
+                apiKeyId: identity.keyId,
+                decision: result.decision,
+                requestJson: JSON.stringify(native),
+                responseJson: captured.join(""),
+              },
+              (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+            );
+          }
         }
       });
     }
@@ -318,10 +345,42 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     try {
       collected = await result.collect();
     } catch (err) {
+      // Record the FAILED served request before surfacing the error (mirrors
+      // chat.ts, which records failures too) so an all-providers-failed request
+      // still appears in /admin/requests. responseJson null = no body produced.
+      // result.decision exists even on failure. Fail-open inside recordServed.
+      if (deps.record) {
+        await recordServed(
+          deps.record,
+          {
+            requestId: traceId,
+            apiKeyId: identity.keyId,
+            decision: result.decision,
+            requestJson: JSON.stringify(native),
+            responseJson: null,
+          },
+          (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+        );
+      }
       if (err instanceof PipelineError) throw pipelineToHelm(err, traceId);
       throw err;
     }
     const body = deps.transformer.transformResponseOut(collected);
+    // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
+    // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
+    if (deps.record) {
+      await recordServed(
+        deps.record,
+        {
+          requestId: traceId,
+          apiKeyId: identity.keyId,
+          decision: result.decision,
+          requestJson: JSON.stringify(native),
+          responseJson: JSON.stringify(body),
+        },
+        (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+      );
+    }
     return c.json(body as Record<string, unknown>);
   });
 }

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -9,7 +9,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
-import { type RecordServedDeps, recordServed } from "./payload-capture.js";
+import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
 // POST /v1/responses — OpenAI Responses API inbound, translated to IR, routed
@@ -267,6 +267,12 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       throw err;
     }
 
+    // Capture the verbatim request/response bodies only when capture_payloads is ON
+    // (the telemetry row is always written regardless). Gating the buffering here
+    // stops long/concurrent streams from accumulating the full body when capture is
+    // off (review P2).
+    const captureBodies = deps.record !== undefined && captureEnabled(deps.record);
+
     // 4) Outbound: stream vs non-stream, isomorphic shape.
     if (ir.stream === true) {
       // Claim the concurrency lease (issue #93): hold the slot until the stream
@@ -287,7 +293,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
             if (typeof event.sequence_number === "number")
               nextErrorSequence = event.sequence_number + 1;
             const frame = deps.transformer.transformStreamOut(event);
-            if (deps.record) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
+            if (captureBodies) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
             await sse.writeSSE({ event: frame.event, data: frame.data });
           }
         } catch (err) {
@@ -312,7 +318,9 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     traceId,
                     sequenceNumber: nextErrorSequence,
                   });
-            await sse.writeSSE({ event: "error", data: JSON.stringify(body) });
+            const data = JSON.stringify(body);
+            if (captureBodies) captured.push(`event: error\ndata: ${data}\n\n`);
+            await sse.writeSSE({ event: "error", data });
           }
         } finally {
           releaseConcurrency?.();
@@ -329,7 +337,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                 apiKeyId: identity.keyId,
                 decision: result.decision,
                 requestJson: JSON.stringify(native),
-                responseJson: captured.join(""),
+                responseJson: captureBodies ? captured.join("") : null,
               },
               (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
             );
@@ -340,10 +348,13 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
 
     // Non-stream: collect() throws a PipelineError when routing failed (all
     // providers failed) — surface it as the OpenAI envelope instead of the empty
-    // 200 a synthesized placeholder body would produce.
-    let collected: unknown;
+    // 200 a synthesized placeholder body would produce. The outbound transform
+    // runs INSIDE this try too, so a transformer throw after a provider result was
+    // collected is ALSO recorded (review P3) — consistent with messages/gemini.
+    let body: Record<string, unknown>;
     try {
-      collected = await result.collect();
+      const collected = await result.collect();
+      body = deps.transformer.transformResponseOut(collected) as Record<string, unknown>;
     } catch (err) {
       // Record the FAILED served request before surfacing the error (mirrors
       // chat.ts, which records failures too) so an all-providers-failed request
@@ -365,7 +376,6 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       if (err instanceof PipelineError) throw pipelineToHelm(err, traceId);
       throw err;
     }
-    const body = deps.transformer.transformResponseOut(collected);
     // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
     // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
     if (deps.record) {
@@ -376,11 +386,11 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           apiKeyId: identity.keyId,
           decision: result.decision,
           requestJson: JSON.stringify(native),
-          responseJson: JSON.stringify(body),
+          responseJson: captureBodies ? JSON.stringify(body) : null,
         },
         (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
       );
     }
-    return c.json(body as Record<string, unknown>);
+    return c.json(body);
   });
 }

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1608,6 +1608,15 @@ export async function buildServer(
       },
     },
     pipeline: messagesPipeline,
+    // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
+    // chat route uses, so /v1/messages records served requests like /v1/chat does.
+    record: {
+      telemetry,
+      redact: (payload) => redact(payload),
+      now: () => Date.now(),
+      capturePayloads: () => settings.capture_payloads,
+      payloadRetentionMs: () => settings.payload_retention_days * 86_400_000,
+    },
   } as Parameters<typeof registerMessagesRoute>[1] & { rateLimiter: RateLimiterPort });
 
   // OpenAI Responses route (/v1/responses). Reuses the SAME routing core via a
@@ -1680,6 +1689,15 @@ export async function buildServer(
       },
     },
     pipeline: responsesPipeline,
+    // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
+    // chat route uses, so /v1/responses records served requests like /v1/chat does.
+    record: {
+      telemetry,
+      redact: (payload) => redact(payload),
+      now: () => Date.now(),
+      capturePayloads: () => settings.capture_payloads,
+      payloadRetentionMs: () => settings.payload_retention_days * 86_400_000,
+    },
   } as Parameters<typeof registerResponsesRoute>[1] & { rateLimiter: RateLimiterPort });
 
   // Gemini route (/v1beta/models/{model}:generateContent | :streamGenerateContent).
@@ -1752,6 +1770,15 @@ export async function buildServer(
         }),
     },
     pipeline: geminiPipeline,
+    // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
+    // chat route uses, so the gemini face records served requests like /v1/chat does.
+    record: {
+      telemetry,
+      redact: (payload) => redact(payload),
+      now: () => Date.now(),
+      capturePayloads: () => settings.capture_payloads,
+      payloadRetentionMs: () => settings.payload_retention_days * 86_400_000,
+    },
   } as Parameters<typeof registerGeminiRoute>[1] & { rateLimiter: RateLimiterPort });
 
   // Start the Agentic Signals background scheduler — the OFF-the-request-path


### PR DESCRIPTION
## Problem

Only `POST /v1/chat/completions` writes telemetry. **`/v1/responses`, `/v1/messages`, and the gemini face (`/v1beta/models/*:generateContent`) serve traffic successfully but record NOTHING** — no `telemetry` row, no `request_payloads` row — so they never appear in `/admin/requests`.

Found in production: clients get correct replies, but the admin request log shows nothing. SQLite proof on the live gateway: of 51 recorded payloads, **51 were chat-shaped, 0 were responses/messages/gemini-shaped**, while the access log showed many `POST /v1/responses → 200`.

## Root cause

The three faces all delegate to the shared `createMessagesPipeline` (`apps/gateway/src/routes/messages-pipeline.ts`), which has **no telemetry dependency** and writes nothing on either the `collect()` (non-stream) or `streamIR()` (stream) branch. `server.ts` threads `telemetry`/`redact`/capture getters only into `registerChatRoutes`, never into the pipeline faces. There is **no global/central recorder** to backstop it (confirmed: no middleware, no after-response hook; `persistDecision` in core is dead code). And **zero tests** guarded recording on these faces — that's how it rotted unnoticed.

Full audit (every inbound path):
- **Records:** `/v1/chat/completions`, admin `…/replay`
- **Missing (this PR):** `/v1/responses`, `/v1/messages`, gemini
- **N/A:** `/v1/models`, read-only admin endpoints, `/healthz` `/version` `/` static

## Fix

Record in each face via **one shared helper**, mirroring `chat.ts` exactly (native request + native response bodies live in the routes):

1. Expose the final `DecisionRecord` as `decision` on `PipelineRunResult` (the live, in-place-mutated reference — final after the stream's cost-backfill).
2. New shared `recordServed(deps, args, log)` in `payload-capture.ts`: `persistPayload(...)` (gated by `capture_payloads`) + `telemetry.insert({ decision: redact(decision), apiKeyId, createdAt })`. **Fail-open** — a telemetry/payload failure never 5xxes or breaks a stream. One helper ⇒ the three faces can't drift again.
3. `responses.ts` / `messages.ts` / `gemini.ts` call it on: non-stream success, non-stream failure (records the failed decision before rethrowing, so all-providers-failed still shows in `/admin/requests`), and the stream `finally` (after backfill, after concurrency release).
4. `server.ts`: pass the same `telemetry`/`redact`/`capturePayloads`/`payloadRetentionMs`/`now` block (already used by chat) into the three `register*Route` calls. `record?` is optional, so existing tests are unaffected.

## Tests (TDD — failing tests committed first)

`responses.test.ts`, `messages.test.ts`, `gemini.test.ts` now assert each face records `telemetry.insert` (once, redacted, correct `apiKeyId`) + `insertPayload` on **both** stream and non-stream, plus a "no `record` dep ⇒ records nothing" guard. RED before the fix, GREEN after.

Verified: targeted suites **49 passed**; full gateway suite **440 passed** (the 4 `admin-static` failures are pre-existing/environmental — they need the gitignored admin SPA build that CI produces via `pnpm build` before tests); `tsc` clean; `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)