### PR TITLE
test(gateway): raise unit coverage to marginal returns (route+middleware 89%→93%)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 
 # Test / coverage
 coverage/
+.e2e-coverage/
 test-results/
 playwright-report/
 

--- a/apps/gateway/e2e/fixtures/test-server.ts
+++ b/apps/gateway/e2e/fixtures/test-server.ts
@@ -125,7 +125,12 @@ await telemetry.insert({
 // Close this handle; the server opens its own.
 (seedDb as unknown as { $sqlite: Database.Database }).$sqlite.close();
 
-const { buildServer } = await import("../../src/server.js");
+// Coverage opt-in: when V8 coverage is collecting (pnpm test:e2e:coverage), import the
+// BUILT gateway so c8 can remap via the on-disk .js.map — tsx transpiles src in-memory
+// with no disk sourcemap, which c8 cannot map. A normal e2e run imports src as before.
+const { buildServer } = process.env.NODE_V8_COVERAGE
+  ? await import("../../dist/server.js")
+  : await import("../../src/server.js");
 // Boot from a THROWAWAY COPY of the repo-root config dir (fresh each run, like
 // the DB above): admin rule edits now WRITE BACK to config/*.yaml (yaml-writeback),
 // so e2e admin saves (e.g. the lane edit in admin.spec) must land in the copy —
@@ -140,3 +145,26 @@ cpSync(repoConfigDir, configDir, { recursive: true });
 const { app, port, host } = await buildServer({ configDir });
 serve({ fetch: app.fetch, port, hostname: host });
 process.stdout.write(`e2e gateway listening on ${host}:${port}\n`);
+
+// Coverage opt-in: Playwright hard-kills (SIGKILL) this webServer at teardown, so
+// signal/exit handlers never run. Flush V8 coverage PERIODICALLY (cumulative
+// snapshots) so the latest snapshot before the kill captures the run; c8 merges them.
+if (process.env.NODE_V8_COVERAGE) {
+  const { takeCoverage } = await import("node:v8");
+  const snap = () => {
+    try {
+      takeCoverage();
+    } catch {
+      // best-effort
+    }
+  };
+  setInterval(snap, 300).unref();
+  process.on("SIGTERM", () => {
+    snap();
+    process.exit(0);
+  });
+  process.on("SIGINT", () => {
+    snap();
+    process.exit(0);
+  });
+}

--- a/apps/gateway/playwright.config.ts
+++ b/apps/gateway/playwright.config.ts
@@ -36,6 +36,11 @@ const e2eEnv = {
   // queue drain into memory_observations within the test window. Unref'd +
   // fail-open, so it never blocks the gateway or other specs.
   HELM_MEMORY_WORKER_INTERVAL_MS: "250",
+  // Coverage opt-in (pnpm test:e2e:coverage): when E2E_COVERAGE_DIR is set, route the
+  // gateway server process's V8 coverage into it. The test-server keys off the injected
+  // NODE_V8_COVERAGE to run from dist (on-disk sourcemaps) + flush periodically. Unset
+  // in a normal `pnpm test:e2e` run, so that path is completely unaffected.
+  ...(process.env.E2E_COVERAGE_DIR ? { NODE_V8_COVERAGE: process.env.E2E_COVERAGE_DIR } : {}),
 };
 
 export default defineConfig({

--- a/apps/gateway/src/app.test.ts
+++ b/apps/gateway/src/app.test.ts
@@ -1,8 +1,10 @@
 import { type ErrorClass, makeHelmError } from "@helm/shared";
+import type { Context } from "hono";
 import { describe, expect, it } from "vitest";
+import type { AppEnv } from "./app.js";
 import { createApp } from "./app.js";
 import type { LogFields, Logger, LogLevel } from "./logging.js";
-import { HelmHttpError } from "./middleware/error-handler.js";
+import { HelmHttpError, handleError, openAIErrorEnvelope } from "./middleware/error-handler.js";
 
 interface Captured {
   level: LogLevel;
@@ -16,6 +18,20 @@ function fakeLogger() {
     log: (level, message, fields = {}) => lines.push({ level, message, fields }),
   };
   return { logger, lines };
+}
+
+// Minimal Hono Context stub for calling handleError directly (the SSE paths do this).
+function mockCtx(logger: Logger, traceId: string): Context<AppEnv> {
+  const store: Record<string, unknown> = { trace_id: traceId, logger };
+  return {
+    get: (k: string) => store[k],
+    json: (body: unknown, status?: number) =>
+      new Response(JSON.stringify(body), {
+        status: status ?? 200,
+        headers: { "content-type": "application/json" },
+      }),
+    body: (b: string | null, status?: number) => new Response(b, { status: status ?? 200 }),
+  } as unknown as Context<AppEnv>;
 }
 
 describe("createApp: trace_id, logging, error handling", () => {
@@ -122,6 +138,50 @@ describe("createApp: trace_id, logging, error handling", () => {
     const text = await res.text();
     expect(text).not.toContain("helm_live_PLAINTEXT");
     expect(JSON.stringify(lines)).not.toContain("helm_live_PLAINTEXT");
+  });
+
+  it("treats a client disconnect (aborted) as 499, not a 5xx provider fault", async () => {
+    const { logger, lines } = fakeLogger();
+    const app = createApp({ logger });
+    app.get("/abort", () => {
+      // An abort surfaces as an Error whose message includes "aborted" (docs/02).
+      throw new Error("The operation was aborted");
+    });
+    const res = await app.request("/abort");
+    expect(res.status).toBe(499);
+    expect(await res.text()).toBe("");
+    // Logged as info (client_disconnect), NOT as an error.
+    expect(lines.some((l) => l.message === "request.client_disconnect")).toBe(true);
+    expect(lines.some((l) => l.level === "error")).toBe(false);
+  });
+
+  it("handleError maps a non-Error value to a redacted upstream_error(502)", async () => {
+    // Hono never delivers a non-Error to onError, but the handler is called directly
+    // from SSE paths; a bare value must not be treated as a disconnect and must
+    // redact to upstream_error (covers the isClientDisconnect non-Error fall-through).
+    const { logger, lines } = fakeLogger();
+    const c = mockCtx(logger, "trace-direct");
+    const res = handleError("a bare string, not an Error", c);
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: Record<string, string> };
+    expect(body.error.code).toBe("upstream_error");
+    expect(body.error.trace_id).toBe("trace-direct");
+    expect(lines.some((l) => l.level === "error")).toBe(true);
+  });
+
+  it("openAIErrorEnvelope builds the canonical {status, body} envelope (SSE-path reuse)", () => {
+    const { status, body } = openAIErrorEnvelope({
+      error_class: "rate_limited",
+      message: "slow down",
+      trace_id: "trace-env",
+    });
+    expect(status).toBe(429);
+    expect(body.error).toMatchObject({
+      type: "rate_limit_error",
+      code: "rate_limited",
+      trace_id: "trace-env",
+    });
+    expect(body.error.message).toBe("slow down");
   });
 
   it("does not mount /admin in createApp (server.ts wires it) nor shadow other routes", async () => {

--- a/apps/gateway/src/middleware/rate-limit.test.ts
+++ b/apps/gateway/src/middleware/rate-limit.test.ts
@@ -113,4 +113,29 @@ describe("rateLimitMiddleware", () => {
       expect(res.headers.get("x-ratelimit-limit")).toBeNull();
     }
   });
+
+  it("passes through unmetered when no identity is resolved (never invents a key)", async () => {
+    // No identity-seeding middleware → keyId is undefined: the limiter is never
+    // consulted and the request is admitted with no x-ratelimit-* headers.
+    const limiter = createRateLimiter({ config: cfg(), store: new InMemoryRateLimitStore() });
+    let checked = false;
+    const app = new Hono();
+    app.use(
+      "*",
+      rateLimitMiddleware({
+        limiter: {
+          check: async (p) => {
+            checked = true;
+            return limiter.check(p);
+          },
+        },
+        now: () => 0,
+      }),
+    );
+    app.get("/v1/chat/completions", (c) => c.json({ ok: true }));
+    const res = await app.request("/v1/chat/completions");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-ratelimit-limit")).toBeNull();
+    expect(checked).toBe(false); // limiter.check never called without a key
+  });
 });

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -1,0 +1,342 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../../app.js";
+import type { AdminApiDeps, OAuthAdminAccess } from "./deps.js";
+import { registerOAuthRoutes } from "./oauth.js";
+
+// A complete OAuthAdminAccess seam with vi.fn methods (overridable per test). The
+// routes are thin validating wrappers around this seam, so exercising them with a
+// mock seam covers the route logic (validation, error mapping, afterMutation).
+function fullSeam(over: Partial<OAuthAdminAccess> = {}): OAuthAdminAccess {
+  return {
+    listStatus: vi.fn(async () => [
+      { id: "anthropic", name: "Anthropic", accounts: [{ account: "default" }] },
+    ]),
+    startManualPaste: vi.fn(async () => ({ sessionId: "s1", authorizeUrl: "https://auth" })),
+    completeManualPaste: vi.fn(async () => {}),
+    startDeviceCode: vi.fn(async () => ({
+      sessionId: "s2",
+      userCode: "ABCD",
+      verificationUri: "https://v",
+    })),
+    pollDeviceCode: vi.fn(async () => ({ status: "pending" as const })),
+    logout: vi.fn(async () => {}),
+    listModels: vi.fn(async () => ({ available: ["m1", "m2"], enabled: ["m1"], canPull: true })),
+    setEnabledModels: vi.fn(async () => {}),
+    getAccountProxy: vi.fn(async () => null),
+    setAccountProxy: vi.fn(async () => {}),
+    getAccountSchedule: vi.fn(async () => ({ priority: 50, schedulable: true })),
+    setAccountSchedule: vi.fn(async () => {}),
+    ...over,
+  } as unknown as OAuthAdminAccess;
+}
+
+function app(deps: Partial<AdminApiDeps>) {
+  const a = new Hono<AppEnv>();
+  registerOAuthRoutes(a, deps as AdminApiDeps);
+  return a;
+}
+
+const JSONH = { "Content-Type": "application/json" };
+const VALID_PROXY = { type: "http", host: "127.0.0.1", port: 8080 };
+
+describe("admin OAuth routes — 503 when the seam is not configured", () => {
+  it.each([
+    ["GET", "/admin/api/oauth"],
+    ["POST", "/admin/api/oauth/anthropic/manual/start"],
+    ["POST", "/admin/api/oauth/anthropic/manual/complete"],
+    ["POST", "/admin/api/oauth/x/device/start"],
+    ["POST", "/admin/api/oauth/x/device/poll"],
+    ["GET", "/admin/api/oauth/x/models"],
+    ["PUT", "/admin/api/oauth/x/models"],
+    ["GET", "/admin/api/oauth/x/proxy"],
+    ["PUT", "/admin/api/oauth/x/proxy"],
+    ["GET", "/admin/api/oauth/x/account"],
+    ["PUT", "/admin/api/oauth/x/account"],
+    ["DELETE", "/admin/api/oauth/x"],
+  ])("%s %s -> 503 oauth not configured", async (method, path) => {
+    const init: RequestInit =
+      method === "GET" || method === "DELETE" ? { method } : { method, headers: JSONH, body: "{}" };
+    const res = await app({}).request(path, init);
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("admin OAuth routes — read endpoints", () => {
+  it("GET /oauth returns the provider catalog", async () => {
+    const res = await app({ oauth: fullSeam() }).request("/admin/api/oauth");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { providers: unknown[] };
+    expect(body.providers).toHaveLength(1);
+  });
+
+  it("GET /oauth/usage returns [] with no store, and bound-filtered rows with one", async () => {
+    expect(
+      (
+        (await (await app({ oauth: fullSeam() }).request("/admin/api/oauth/usage")).json()) as {
+          usage: unknown[];
+        }
+      ).usage,
+    ).toEqual([]);
+    const oauthUsage = {
+      queryDay: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "default",
+          requests: 120,
+          tokens: 10,
+          costUsd: 0.5,
+          firstSeenMs: Date.now() - 60_000,
+        },
+        {
+          providerId: "anthropic",
+          account: "ghost",
+          requests: 5,
+          tokens: 1,
+          costUsd: 0,
+          firstSeenMs: Date.now(),
+        },
+      ]),
+    } as unknown as AdminApiDeps["oauthUsage"];
+    const res = await app({ oauth: fullSeam(), oauthUsage }).request("/admin/api/oauth/usage");
+    const body = (await res.json()) as { usage: Array<{ account: string; rpm: number }> };
+    // The unbound "ghost" account is filtered out; the bound one keeps a derived rpm.
+    expect(body.usage).toHaveLength(1);
+    expect(body.usage[0]?.account).toBe("default");
+  });
+
+  it("GET /oauth/quota returns [] with no store and merges PULL windows with one", async () => {
+    expect(
+      (
+        (await (await app({ oauth: fullSeam() }).request("/admin/api/oauth/quota")).json()) as {
+          quota: unknown[];
+        }
+      ).quota,
+    ).toEqual([]);
+    const upsert = vi.fn(async () => {});
+    const oauthQuota = {
+      getAll: vi.fn(async () => [{ providerId: "anthropic", account: "default", windows: [] }]),
+      upsert,
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      fetchAnthropicQuota: vi.fn(async () => [{ kind: "5h", utilization: 0.1 }]) as never,
+    });
+    const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
+    expect(res.status).toBe(200);
+    expect(upsert).toHaveBeenCalled(); // the PULL refreshed the store
+  });
+
+  it("GET /oauth/:provider/models returns available + enabled", async () => {
+    const res = await app({ oauth: fullSeam() }).request(
+      "/admin/api/oauth/anthropic/models?account=default",
+    );
+    const body = (await res.json()) as { available: string[]; enabled: string[] };
+    expect(body.available).toEqual(["m1", "m2"]);
+    expect(body.enabled).toEqual(["m1"]);
+  });
+
+  it("GET /oauth/:provider/proxy returns {proxy:null} when none set", async () => {
+    const res = await app({ oauth: fullSeam() }).request("/admin/api/oauth/anthropic/proxy");
+    expect((await res.json()) as { proxy: null }).toEqual({ proxy: null });
+  });
+
+  it("GET /oauth/:provider/account returns the effective schedule", async () => {
+    const res = await app({ oauth: fullSeam() }).request("/admin/api/oauth/anthropic/account");
+    expect((await res.json()) as { priority: number }).toMatchObject({
+      priority: 50,
+      schedulable: true,
+    });
+  });
+});
+
+describe("admin OAuth routes — connect flows", () => {
+  it("POST manual/start returns the authorize URL; a bad proxy is 400", async () => {
+    const ok = await app({ oauth: fullSeam() }).request("/admin/api/oauth/anthropic/manual/start", {
+      method: "POST",
+      headers: JSONH,
+      body: JSON.stringify({ proxy: VALID_PROXY }),
+    });
+    expect((await ok.json()) as { authorizeUrl: string }).toMatchObject({
+      authorizeUrl: "https://auth",
+    });
+    const bad = await app({ oauth: fullSeam() }).request(
+      "/admin/api/oauth/anthropic/manual/start",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ proxy: { type: "ftp" } }),
+      },
+    );
+    expect(bad.status).toBe(400);
+  });
+
+  it("POST manual/complete 400s on missing fields, 204s on success", async () => {
+    const missing = await app({ oauth: fullSeam() }).request(
+      "/admin/api/oauth/anthropic/manual/complete",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ sessionId: "s1" }),
+      },
+    );
+    expect(missing.status).toBe(400);
+    const seam = fullSeam();
+    const res = await app({ oauth: seam }).request("/admin/api/oauth/anthropic/manual/complete", {
+      method: "POST",
+      headers: JSONH,
+      body: JSON.stringify({ sessionId: "s1", redirectInput: "https://cb?code=x" }),
+    });
+    expect(res.status).toBe(204);
+    expect(seam.completeManualPaste).toHaveBeenCalledOnce();
+  });
+
+  it("POST manual/complete returns 503 not_applied when the live rebuild fails", async () => {
+    const onOAuthMutation = vi.fn(async () => ({ applied: false }));
+    const res = await app({ oauth: fullSeam(), onOAuthMutation }).request(
+      "/admin/api/oauth/anthropic/manual/complete",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ sessionId: "s", redirectInput: "u" }),
+      },
+    );
+    expect(res.status).toBe(503);
+    expect((await res.json()) as { code: string }).toMatchObject({ code: "not_applied" });
+  });
+
+  it("POST device/start returns the device code; device/poll 400s without sessionId", async () => {
+    const start = await app({ oauth: fullSeam() }).request(
+      "/admin/api/oauth/copilot/device/start",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ enterprise: "acme" }),
+      },
+    );
+    expect((await start.json()) as { userCode: string }).toMatchObject({ userCode: "ABCD" });
+    const noSess = await app({ oauth: fullSeam() }).request(
+      "/admin/api/oauth/copilot/device/poll",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: "{}",
+      },
+    );
+    expect(noSess.status).toBe(400);
+  });
+
+  it("POST device/poll rebuilds the pool only once the status is done", async () => {
+    const onOAuthMutation = vi.fn(async () => ({ applied: true }));
+    const seam = fullSeam({ pollDeviceCode: vi.fn(async () => ({ status: "done" as const })) });
+    const res = await app({ oauth: seam, onOAuthMutation }).request(
+      "/admin/api/oauth/copilot/device/poll",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ sessionId: "s2" }),
+      },
+    );
+    expect((await res.json()) as { status: string }).toEqual({ status: "done" });
+    expect(onOAuthMutation).toHaveBeenCalledOnce();
+  });
+});
+
+describe("admin OAuth routes — mutations + validation", () => {
+  it("PUT models rejects a non-string-array, accepts a valid list (204)", async () => {
+    const bad = await app({ oauth: fullSeam() }).request("/admin/api/oauth/anthropic/models", {
+      method: "PUT",
+      headers: JSONH,
+      body: JSON.stringify({ models: [1, 2] }),
+    });
+    expect(bad.status).toBe(400);
+    const seam = fullSeam();
+    const ok = await app({ oauth: seam }).request("/admin/api/oauth/anthropic/models", {
+      method: "PUT",
+      headers: JSONH,
+      body: JSON.stringify({ account: "default", models: ["m1"] }),
+    });
+    expect(ok.status).toBe(204);
+    expect(seam.setEnabledModels).toHaveBeenCalledOnce();
+  });
+
+  it("PUT proxy clears (null) and sets (valid); a malformed proxy is 400", async () => {
+    const seam = fullSeam();
+    const cleared = await app({ oauth: seam }).request("/admin/api/oauth/anthropic/proxy", {
+      method: "PUT",
+      headers: JSONH,
+      body: JSON.stringify({ proxy: null }),
+    });
+    expect(cleared.status).toBe(204);
+    const bad = await app({ oauth: fullSeam() }).request("/admin/api/oauth/anthropic/proxy", {
+      method: "PUT",
+      headers: JSONH,
+      body: JSON.stringify({ proxy: { type: "http" } }), // missing host/port
+    });
+    expect(bad.status).toBe(400);
+  });
+
+  it("PUT account validates priority (non-negative int) and schedulable (boolean)", async () => {
+    const negPriority = await app({ oauth: fullSeam() }).request(
+      "/admin/api/oauth/anthropic/account",
+      {
+        method: "PUT",
+        headers: JSONH,
+        body: JSON.stringify({ priority: -1 }),
+      },
+    );
+    expect(negPriority.status).toBe(400);
+    const badSched = await app({ oauth: fullSeam() }).request(
+      "/admin/api/oauth/anthropic/account",
+      {
+        method: "PUT",
+        headers: JSONH,
+        body: JSON.stringify({ schedulable: "yes" }),
+      },
+    );
+    expect(badSched.status).toBe(400);
+    const seam = fullSeam();
+    const ok = await app({ oauth: seam }).request("/admin/api/oauth/anthropic/account", {
+      method: "PUT",
+      headers: JSONH,
+      body: JSON.stringify({ priority: 10, schedulable: false }),
+    });
+    expect(ok.status).toBe(204);
+    expect(seam.setAccountSchedule).toHaveBeenCalledWith({
+      providerId: "anthropic",
+      account: "default",
+      priority: 10,
+      schedulable: false,
+    });
+  });
+
+  it("DELETE /oauth/:provider logs out the account (204) and rebuilds the pool", async () => {
+    const seam = fullSeam();
+    const onOAuthMutation = vi.fn(async () => ({ applied: true }));
+    const res = await app({ oauth: seam, onOAuthMutation }).request(
+      "/admin/api/oauth/anthropic?account=default",
+      {
+        method: "DELETE",
+      },
+    );
+    expect(res.status).toBe(204);
+    expect(seam.logout).toHaveBeenCalledWith({ providerId: "anthropic", account: "default" });
+    expect(onOAuthMutation).toHaveBeenCalledOnce();
+  });
+
+  it("a seam that throws maps to a 400 with the error message", async () => {
+    const seam = fullSeam({
+      startManualPaste: vi.fn(async () => {
+        throw new Error("provider unsupported");
+      }),
+    });
+    const res = await app({ oauth: seam }).request("/admin/api/oauth/x/manual/start", {
+      method: "POST",
+      headers: JSONH,
+      body: "{}",
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toMatchObject({
+      error: "provider unsupported",
+    });
+  });
+});

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -150,6 +150,117 @@ const NONSTREAM_BODY = {
 };
 const STREAM_BODY = { ...NONSTREAM_BODY, stream: true };
 
+// A key carrying budget caps so auth populates identity.caps.budget and the gate runs.
+const BUDGET_RECORD: Partial<ApiKeyRecord> = {
+  budget_requests: 100,
+  budget_window_seconds: 60,
+  over_budget_behavior: "reject",
+};
+
+describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overrides", () => {
+  it("rejects an over-budget request with 429 before routing (behavior=reject)", async () => {
+    const budgetGate = {
+      check: vi.fn(async () => ({
+        overBudget: true,
+        limitedBy: "req" as const,
+        behavior: "reject" as const,
+        degradeLane: null,
+      })),
+    };
+    const { deps: d, harness } = deps({ budgetGate });
+    const app = buildApp(d, { record: BUDGET_RECORD });
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("rate_limited");
+    expect(budgetGate.check).toHaveBeenCalledOnce();
+    expect(harness.execute).not.toHaveBeenCalled(); // never routed
+  });
+
+  it("degrades an over-budget request to the degrade lane and still serves (behavior=degrade)", async () => {
+    const budgetGate = {
+      check: vi.fn(async () => ({
+        overBudget: true,
+        limitedBy: "req" as const,
+        behavior: "degrade" as const,
+        degradeLane: "economy",
+      })),
+    };
+    const { deps: d, harness } = deps({ budgetGate });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "c", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d, {
+      record: { ...BUDGET_RECORD, over_budget_behavior: "degrade", degrade_lane: "economy" },
+    });
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(200);
+    // The degrade lane caps THIS request's lane to economy.
+    const plan = harness.execute.mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+  });
+
+  it("records per-account OAuth usage and settles the budget on a served request", async () => {
+    const recordOAuthUsage = vi.fn();
+    const settleBudget = vi.fn(async () => {});
+    const { deps: d, harness } = deps({ recordOAuthUsage, settleBudget });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "c", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d, { record: BUDGET_RECORD });
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(200);
+    expect(recordOAuthUsage).toHaveBeenCalledOnce();
+    expect(settleBudget).toHaveBeenCalledOnce();
+  });
+
+  it("a settleBudget failure is swallowed (logged, never 5xx's a served request)", async () => {
+    const settleBudget = vi.fn(async () => {
+      throw new Error("store down");
+    });
+    const { deps: d, harness } = deps({ settleBudget });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "c", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d, { record: BUDGET_RECORD });
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(200); // settle error is fail-open
+    expect(settleBudget).toHaveBeenCalledOnce();
+  });
+
+  it("honors the e2e x-helm-eval / x-helm-rules-threshold overrides when evalHeaderOverride is on", async () => {
+    const { deps: d, harness } = deps({ evalHeaderOverride: true });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "c", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d);
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { ...AUTH, "x-helm-eval": "on", "x-helm-rules-threshold": "0.9" },
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(200);
+    // The override is threaded into route() as the 4th arg.
+    expect(harness.classify).toHaveBeenCalledOnce();
+  });
+});
+
 describe("POST /v1/chat/completions (routing pipeline)", () => {
   it("routes a non-stream request through the pipeline and returns the OpenAI body", async () => {
     const upstream = { id: "cmpl-1", choices: [{ message: { content: "hello" } }] };

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -43,6 +43,7 @@ function makeDeps(
     transformRequestOut?: (native: unknown) => unknown;
     identity?: MessagesIdentity;
     rateLimiter?: GeminiRouteDeps["rateLimiter"];
+    concurrencyGate?: GeminiRouteDeps["concurrencyGate"];
     record?: RecordServedDeps;
   } = {},
 ): { deps: GeminiRouteDeps; harness: Harness } {
@@ -50,6 +51,7 @@ function makeDeps(
 
   const deps: GeminiRouteDeps = {
     rateLimiter: over.rateLimiter,
+    concurrencyGate: over.concurrencyGate,
     record: over.record,
     auth: {
       resolve: async (cred) => {
@@ -253,6 +255,29 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     expect(body.error).toMatchObject({ code: 429, status: "RESOURCE_EXHAUSTED" });
     expect(harness.order).toEqual(["auth:helm_live_secret", "rate-limit:k1"]);
     expect(harness.pipelineSawIR).toBeNull();
+  });
+
+  it("returns a 429 RESOURCE_EXHAUSTED Gemini envelope when the concurrency gate rejects, without routing", async () => {
+    const { deps, harness } = makeDeps({
+      concurrencyGate: {
+        acquire: async () => ({
+          ok: false as const,
+          reason: "timeout" as const,
+          retryAfterSeconds: 9,
+        }),
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("9");
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("RESOURCE_EXHAUSTED");
+    expect(harness.pipelineSawIR).toBeNull(); // never routed
   });
 
   it("maps a malformed JSON body to 400 INVALID_ARGUMENT, after auth, without routing", async () => {

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -61,6 +61,7 @@ function makeDeps(
     authed?: boolean;
     transformRequestOut?: (native: unknown) => unknown;
     rateLimiter?: MessagesRouteDeps["rateLimiter"];
+    concurrencyGate?: MessagesRouteDeps["concurrencyGate"];
     identity?: MessagesIdentity;
     record?: RecordServedDeps;
   } = {},
@@ -74,6 +75,7 @@ function makeDeps(
 
   const deps: MessagesRouteDeps = {
     rateLimiter: over.rateLimiter,
+    concurrencyGate: over.concurrencyGate,
     record: over.record,
     auth: {
       resolve: async (_key: string | null) => {
@@ -436,6 +438,29 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expect(text).toContain("event: message_start");
     // A terminal Anthropic error frame must follow the partial stream.
     expect(text).toContain("event: error");
+  });
+
+  it("429s an Anthropic rate_limited envelope when the concurrency gate rejects, without routing", async () => {
+    const { deps, harness } = makeDeps({
+      concurrencyGate: {
+        acquire: async () => ({
+          ok: false as const,
+          reason: "queue_full" as const,
+          retryAfterSeconds: 4,
+        }),
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("4");
+    const body = (await res.json()) as { type: string };
+    expect(body.type).toBe("error");
+    expect(harness.order).not.toContain("route");
   });
 
   it("429s a throttled key on /v1/messages with an Anthropic rate_limited envelope", async () => {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -24,6 +24,7 @@ function makeDeps(
     collect?: () => Promise<unknown>;
     streamIR?: () => AsyncIterable<{ type: string; [k: string]: unknown }>;
     rateLimiter?: ResponsesRouteDeps["rateLimiter"];
+    concurrencyGate?: ResponsesRouteDeps["concurrencyGate"];
     identity?: MessagesIdentity;
     record?: RecordServedDeps;
   } = {},
@@ -31,6 +32,7 @@ function makeDeps(
   const order: string[] = [];
   const deps: ResponsesRouteDeps = {
     rateLimiter: over.rateLimiter,
+    concurrencyGate: over.concurrencyGate,
     record: over.record,
     auth: {
       resolve: async (cred) => {
@@ -148,6 +150,26 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(((await res.json()) as { error: { type: string } }).error.type).toBe(
       "invalid_request_error",
     );
+    expect(order).not.toContain("route");
+  });
+
+  it("returns 429 rate_limited when the concurrency gate rejects (queue full), without routing", async () => {
+    const concurrencyGate = {
+      acquire: async () => ({
+        ok: false as const,
+        reason: "queue_full" as const,
+        retryAfterSeconds: 7,
+      }),
+    };
+    const { deps, order } = makeDeps({ concurrencyGate });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("7");
     expect(order).not.toContain("route");
   });
 

--- a/apps/gateway/src/runtime/serving-account.test.ts
+++ b/apps/gateway/src/runtime/serving-account.test.ts
@@ -1,7 +1,34 @@
 import { describe, expect, it } from "vitest";
-import { servedByAccount } from "./serving-account.js";
+import {
+  markServingAccount,
+  servedByAccount,
+  withServingAccountCapture,
+} from "./serving-account.js";
 
 const ACCT = { providerId: "anthropic", account: "default" };
+
+describe("withServingAccountCapture + markServingAccount (ALS bridge)", () => {
+  it("captures the account marked by onSelect inside the run scope", async () => {
+    const { result, servingAccount } = await withServingAccountCapture(async () => {
+      // Simulates the pool's onSelect firing deep inside routeRequest/execute.
+      markServingAccount("anthropic", "default");
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(servingAccount).toEqual({ providerId: "anthropic", account: "default" });
+  });
+
+  it("captures null when nothing marks an account (configured / non-OAuth provider)", async () => {
+    const { result, servingAccount } = await withServingAccountCapture(async () => 42);
+    expect(result).toBe(42);
+    expect(servingAccount).toBeNull();
+  });
+
+  it("markServingAccount outside a run scope is a no-op (never throws)", () => {
+    // No active ALS store (e.g. a unit test / non-OAuth path) — fail-open.
+    expect(() => markServingAccount("anthropic", "default")).not.toThrow();
+  });
+});
 
 describe("servedByAccount", () => {
   it("attributes only when the served alias belongs to the marked account's provider", () => {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "pnpm --filter @helm/gateway test:e2e",
+    "test:e2e:coverage": "bash scripts/e2e-coverage.sh",
     "lint": "biome check .",
     "format": "biome format --write .",
     "lint:fix": "biome check --write .",
@@ -25,6 +26,7 @@
     "@helm/shared": "workspace:*",
     "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "c8": "^11.0.0",
     "tsx": "^4.22.3",
     "typescript": "^5.7.0",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@22.19.19)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      c8:
+        specifier: ^11.0.0
+        version: 11.0.0
       tsx:
         specifier: ^4.22.3
         version: 4.22.3
@@ -990,6 +993,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
@@ -1114,6 +1120,16 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  c8@11.0.0:
+    resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1149,6 +1165,10 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1167,6 +1187,9 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
@@ -1384,6 +1407,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
@@ -1418,6 +1445,10 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -1442,6 +1473,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -1461,6 +1496,10 @@ packages:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1673,6 +1712,10 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -1682,6 +1725,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -1779,11 +1826,23 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1792,6 +1851,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1871,6 +1934,10 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -2027,6 +2094,10 @@ packages:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
     engines: {node: '>=18'}
 
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2093,6 +2164,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2236,10 +2311,26 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -2835,6 +2926,8 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
@@ -2970,6 +3063,20 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  c8@11.0.0:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 8.0.0
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3001,6 +3108,12 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -3014,6 +3127,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@12.1.0: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie@0.6.0: {}
 
@@ -3170,6 +3285,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escalade@3.2.0: {}
+
   esm-env@1.2.2: {}
 
   esrap@2.2.9:
@@ -3189,6 +3306,11 @@ snapshots:
       picomatch: 4.0.4
 
   file-uri-to-path@1.0.0: {}
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
 
   foreground-child@3.3.1:
     dependencies:
@@ -3212,6 +3334,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
@@ -3243,6 +3367,12 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   gopd@1.2.0: {}
 
@@ -3430,6 +3560,10 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
@@ -3438,6 +3572,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.5.1: {}
 
   lz-string@1.5.0: {}
 
@@ -3521,17 +3657,32 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   package-json-from-dist@1.0.1: {}
 
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
 
+  path-exists@4.0.0: {}
+
   path-key@3.1.1: {}
 
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
       minipass: 7.1.3
 
   pathe@2.0.3: {}
@@ -3614,6 +3765,8 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  require-directory@2.1.1: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -3814,6 +3967,12 @@ snapshots:
       glob: 10.5.0
       minimatch: 10.2.5
 
+  test-exclude@8.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 13.0.6
+      minimatch: 10.2.5
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3864,6 +4023,12 @@ snapshots:
   undici@8.3.0: {}
 
   util-deprecate@1.0.2: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
 
   vite-node@3.2.4(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
@@ -3994,7 +4159,23 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
 

--- a/scripts/e2e-coverage.sh
+++ b/scripts/e2e-coverage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# E2E code coverage for the 4 wire protocols (OpenAI Chat, Anthropic Messages,
+# OpenAI Responses, Gemini). Runs the protocol + gemini Playwright specs against the
+# BUILT gateway (dist) with V8 coverage, then remaps dist -> src via on-disk source
+# maps with c8. Admin specs are intentionally excluded (API/protocol coverage only).
+#
+# Why built dist: under tsx the gateway src is transpiled in-memory with no on-disk
+# source map, so c8 cannot remap it. The e2e test-server imports dist + flushes V8
+# coverage periodically (Playwright SIGKILLs the webServer) only when NODE_V8_COVERAGE
+# is set, so a normal `pnpm test:e2e` is completely unaffected.
+#
+# Usage: pnpm test:e2e:coverage   (text summary + table; lcov in .e2e-coverage/)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+COV_DIR="${E2E_COVERAGE_DIR:-$ROOT/.e2e-coverage}"
+V8_DIR="$COV_DIR/v8"
+rm -rf "$COV_DIR"
+mkdir -p "$V8_DIR"
+
+echo "==> Building gateway + deps (dist needs on-disk source maps for remapping)…"
+pnpm --filter @helm/shared --filter @helm/core --filter @helm/gateway build
+
+echo "==> Running 4-protocol E2E specs with V8 coverage…"
+E2E_COVERAGE_DIR="$V8_DIR" \
+  pnpm --filter @helm/gateway exec playwright test protocol.spec.ts gemini.spec.ts --project=gateway
+
+echo "==> Generating coverage report (remap dist -> src)…"
+pnpm exec c8 report \
+  --temp-directory="$V8_DIR" \
+  --report-dir="$COV_DIR" \
+  --reporter=text-summary --reporter=text --reporter=lcov \
+  --exclude-after-remap \
+  --exclude='**/node_modules/**' \
+  --exclude='**/*.test.ts' \
+  --exclude='**/e2e/**' \
+  --exclude='scripts/**' \
+  --exclude='**/*.config.*' \
+  --exclude='**/dist/**'
+
+echo "==> lcov written to $COV_DIR/lcov.info"


### PR DESCRIPTION
## What

Raises `apps/gateway` **unit** coverage to the point of marginal returns (per CLAUDE.md: cover correctness-critical paths; skip pure glue). **Route + middleware unit coverage: → 93.0%** (excluding bootstrap glue). Gateway unit suite **494 passed (+43 tests)**, no regressions; typecheck + lint clean.

### Wave 1 — middleware → 100%
- `error-handler.ts` (83%→**100%**): client-disconnect → 499; non-Error redaction (`handleError` direct, as SSE paths call it); `openAIErrorEnvelope` reuse.
- `rate-limit.ts` (93%→**100%**): no-identity passthrough (never invents a key).

### Wave 2 — core request-path route handlers
- `chat.ts` (83%→**93%**): usage-budget gate (reject 429 / degrade lane), OAuth-usage settle, `settleBudget` fail-open, eval-header overrides.
- `responses.ts` (91%→**97%**), `gemini.ts` (80%→**85%**), `messages.ts` (80%→**85%**): concurrency-gate rejection (queue full / timeout → 429) per protocol envelope.

### Wave 3 — admin + oauth
- `routes/admin/oauth.ts` (45%→**91%**): new `oauth.test.ts` drives all 15 admin OAuth endpoints — 503-when-unconfigured, reads (status/usage/quota/models/proxy/account), connect flows (manual + device, done-only pool rebuild), mutations + validation (models/proxy/priority/schedulable) + `not_applied` 503 + seam-throw→400.
- `runtime/serving-account.ts` (50%→~**100%**): the AsyncLocalStorage capture bridge.

## Stopping point (marginal returns reached)
Everything still <90% is either:
- **Bootstrap/wiring glue** — `index.ts`, `server.ts`, `logging.ts`, `admin/deps.ts` (E2E-covered; unit tests add ≈0 value), or
- **Deep fail-open / streaming branches** — `oauth/admin-oauth.ts` (87%; the remaining block is the Codex/Anthropic quota PULLs — fail-open network reads needing heavy fetch/token mocking for ~0 correctness value), and `gemini.ts`/`messages.ts`/`messages-pipeline.ts` (~86%; streaming-abort / mid-stream-error branches).

> Branches on `feat/e2e-coverage` (#140) for the coverage-measurement tooling; rebases clean onto main once #140 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)