### PR TITLE
feat: wire routing signal feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ HELM_PORT=8080
 HELM_KEYS_PERSIST_TO=./data/helm-keys.json
 HELM_REQUEST_TIMEOUT_MS=60000
 HELM_RATE_LIMIT_ENABLED=false
+# Opt into Agentic Signals ranked-lane feedback. Thresholds live in config/runtime.yaml.
+HELM_SIGNAL_FEEDBACK_ENABLED=false
 
 # —— Storage driver (DB abstraction layer) ——
 # 'sqlite' (default, local file under HELM_DATA_DIR) or 'supabase' (hosted Postgres).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker compose logs helm | grep -i "root API key"
 | :---: | :--- | :--- |
 | 🔀 | **Four client protocols** | OpenAI Chat, Anthropic Messages, OpenAI Responses, Google Gemini — all streaming + non-streaming. One IR in the middle: any client reaches any backend with a consistent output shape, SSE included. |
 | 🧭 | **Three-layer classification** | Deterministic rules (pure, zero-network, unit-tested — always on) → optional small-model eval (`temperature: 0`, cached, off by default — needs a configured eval model) → `balanced` lane as the fail-open sink. |
-| 🛣️ | **Lanes + policies** | Requests route through lanes (`economy` / `balanced` / `premium`, plus task lanes `coding`, `json`, `vision`, `tool_use`), never raw provider names. First-match policies pin or cap the lane. Each lane = a primary model + a fallback chain, all in config. |
+| 🛣️ | **Lanes + policies** | Requests route through lanes (`economy` / `balanced` / `premium`, plus task lanes `coding`, `json`, `vision`, `tool_use`), never raw provider names. First-match policies pin or cap the lane. Each lane = a primary model + a fallback chain, all in config. Opt-in Agentic Signals can promote degraded ranked lanes inside those caps. |
 | 🛡️ | **Resilient execution** | Circuit breaker (OPEN/HALF_OPEN + single probe), capability filter with explicit skip reasons, `:free`-tier 429 skipping, per-key concurrency queueing. Client disconnects are never counted as provider faults. |
 | 🔐 | **OAuth subscriptions** | Route your Claude Pro/Max, ChatGPT Codex, and GitHub Copilot subscriptions as backends — pooled accounts, per-account model curation / egress proxy / scheduling, all hot-reloaded. *(Opt-in; read the [ToS warning](#oauth-subscription-providers-claude-promax-chatgpt-codex-github-copilot).)* |
 | 🔑 | **Keys with teeth** | Mandatory auth; keys stored as SHA-256 hashes only. Per key: lane whitelist, custom-model permission, RPM/TPM limits, usage budgets (degrade or reject), concurrency cap, memory mode. Revoke softly, then delete permanently. |
@@ -72,7 +72,7 @@ docker compose logs helm | grep -i "root API key"
 | 🖥️ | **Admin dashboard** | SvelteKit SPA at `/admin` behind HTTP Basic: overview, key CRUD, lane/policy/classifier editors, system settings, drill-down request log. Edits **write back to `config/*.yaml`** (comment-preserving, atomic) and rebind live — no restart, and they survive one. Five languages. |
 | 💾 | **Storage** | SQLite by default (one local file). Postgres / Supabase behind the same Store-port abstraction — switch with one env var. |
 
-**Roadmap:** LLM-backed memory summarization (today's observer/reflector summarize step is a deterministic stub) · Agentic Signals feedback into routing. Account/customer billing is intentionally out of scope. See [09 Roadmap](docs/09-roadmap.md).
+**Roadmap:** LLM-backed memory summarization (today's observer/reflector summarize step is a deterministic stub). Account/customer billing is intentionally out of scope. See [09 Roadmap](docs/09-roadmap.md).
 
 ## Two failure disciplines
 
@@ -178,7 +178,7 @@ Everything lives in `config/*.yaml`, Zod-validated on load. **Invalid config sto
 |---|---|---|
 | `server.yaml` | Host / port / base path | — |
 | `auth.yaml` | API key requirement + first-run root key | — |
-| `runtime.yaml` | Request limits, rate-limit defaults, storage driver | partial |
+| `runtime.yaml` | Request limits, rate-limit defaults, storage driver, opt-in signal feedback | partial |
 | `providers.yaml` | Upstream providers + model aliases (credentials by env-var **name** only) | — |
 | `lanes.yaml` | Each lane's primary model + fallback chain | ✅ persists |
 | `policies.yaml` | First-match rules that pick or cap the lane | ✅ persists |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,7 +63,7 @@ docker compose logs helm | grep -i "root API key"
 | :---: | :--- | :--- |
 | 🔀 | **四种客户端协议** | OpenAI Chat、Anthropic Messages、OpenAI Responses、Google Gemini——全部支持流式 + 非流式。中间是同一套 IR：任意客户端触达任意后端，输出格式一致，SSE 也不例外。 |
 | 🧭 | **三层分类** | 确定性规则（纯函数、零网络、有单测——常驻开启）→ 可选的小模型 eval（`temperature: 0`、带缓存、默认关闭——需要先配好 eval 模型）→ `balanced` lane 作为 fail-open 兜底口。 |
-| 🛣️ | **Lane + 策略路由** | 请求走 lane（`economy` / `balanced` / `premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`），从不直接面对供应商名。首条命中的策略可以钉死或封顶 lane。每条 lane = 一个主模型 + 一条兜底链，全在配置里。 |
+| 🛣️ | **Lane + 策略路由** | 请求走 lane（`economy` / `balanced` / `premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`），从不直接面对供应商名。首条命中的策略可以钉死或封顶 lane。每条 lane = 一个主模型 + 一条兜底链，全在配置里。可选的 Agentic Signals 能在这些上限内把异常的分级 lane 提升到更健康的强档 lane。 |
 | 🛡️ | **稳健的执行层** | 熔断器（OPEN/HALF_OPEN + 单探针）、能力过滤（跳过候选时记下明确原因）、`:free` 档 429 跳过、按 key 并发排队。客户端断连永远不算供应商故障。 |
 | 🔐 | **OAuth 订阅** | 把 Claude Pro/Max、ChatGPT Codex、GitHub Copilot 的**订阅**当后端来路由——多账号组池，逐账号做模型策展 / 出口代理 / 调度，全部热重载。*（可选功能，先读 [ToS 警告](#oauth-订阅类供应商claude-promaxchatgpt-codexgithub-copilot)。）* |
 | 🔑 | **带约束力的 key** | 强制鉴权；key 只存 SHA-256 哈希。每把 key 可设：lane 白名单、自定义模型权限、RPM/TPM 限流、用量预算（降级或拒绝）、并发上限、记忆模式。先软吊销，再永久删除。 |
@@ -72,7 +72,7 @@ docker compose logs helm | grep -i "root API key"
 | 🖥️ | **管理面板** | `/admin` 上的 SvelteKit SPA，HTTP Basic 把守：概览、key 增删改、lane / 策略 / 分类器编辑器、系统设置、可下钻的请求日志。编辑会**写回 `config/*.yaml`**（保留注释、原子写入）并实时重绑——无需重启，重启也不丢。支持 5 种语言。 |
 | 💾 | **存储** | 默认 SQLite（一个本地文件）。Postgres / Supabase 走同一套 Store 端口抽象——改一个环境变量即可切换。 |
 
-**路线图：** 接 LLM 的记忆摘要（observer/reflector 的摘要步骤目前是确定性桩）· Agentic Signals 反馈参与路由。账户 / 客户级计费明确不在范围内。详见 [09 路线图](docs/09-roadmap.md)。
+**路线图：** 接 LLM 的记忆摘要（observer/reflector 的摘要步骤目前是确定性桩）。账户 / 客户级计费明确不在范围内。详见 [09 路线图](docs/09-roadmap.md)。
 
 ## 两套失败纪律
 
@@ -178,7 +178,7 @@ curl http://localhost:8080/v1/chat/completions \
 |---|---|---|
 | `server.yaml` | 主机 / 端口 / base path | — |
 | `auth.yaml` | 是否强制 API key + 首次启动的 root key | — |
-| `runtime.yaml` | 请求限额、限流默认值、存储驱动 | 部分 |
+| `runtime.yaml` | 请求限额、限流默认值、存储驱动、可选信号反馈 | 部分 |
 | `providers.yaml` | 上游供应商 + 模型别名（凭证只引用环境变量**名**） | — |
 | `lanes.yaml` | 每条 lane 的主模型 + 兜底链 | ✅ 持久化 |
 | `policies.yaml` | 首条命中、用来挑选或封顶 lane 的规则 | ✅ 持久化 |

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -791,11 +791,10 @@ export async function buildServer(
       tpm: next.rate_limit_default_tpm,
     };
   };
-  // Agentic Signals (POST-MVP feedback layer, docs/02). The collector consumes
-  // ALREADY-persisted telemetry and writes aggregated, REDACTED signals — it is
-  // started as a BACKGROUND interval below (NEVER on the request path), so it
-  // adds zero latency to any served request. Observe-only this phase: nothing
-  // reads these signals back into routing.
+  // Agentic Signals (docs/02). The collector consumes ALREADY-persisted telemetry
+  // and writes aggregated, REDACTED signals in the background. The optional
+  // routing feedback consumer below reads only those aggregates and remains
+  // fail-open, so signal storage never becomes a request-path availability risk.
   const signalCollector = createSignalCollector({
     telemetry,
     signals: store.signals,
@@ -1311,6 +1310,14 @@ export async function buildServer(
             // Structural `provider/...` fallback: the named client forwards the bare id.
             if (prefix && providerClients.has(prefix)) return true;
             return false; // bare unknown name: rejected (no Phase-0 silent fallback)
+          },
+          signalFeedback: {
+            enabled: config.runtime.signal_feedback.enabled,
+            minSamples: config.runtime.signal_feedback.min_samples,
+            maxErrorRate: config.runtime.signal_feedback.max_error_rate,
+            maxFallbackRate: config.runtime.signal_feedback.max_fallback_rate,
+            minSuccessRateDelta: config.runtime.signal_feedback.min_success_rate_delta,
+            getSignal: (taskType, lane) => store.signals.getSignal(taskType, lane),
           },
         },
         routeOpts,

--- a/config/runtime.yaml
+++ b/config/runtime.yaml
@@ -24,3 +24,14 @@ store:
   driver: sqlite
   # driver: supabase
   # url_env: HELM_STORE_URL
+
+# Agentic Signals feedback is opt-in. When enabled, the router can promote a
+# degraded ranked lane (economy/balanced) to a healthier stronger ranked lane
+# inside policy/key caps. Signal reads are fail-open; invalid config fails closed.
+# Env override: HELM_SIGNAL_FEEDBACK_ENABLED.
+signal_feedback:
+  enabled: false
+  min_samples: 20
+  max_error_rate: 0.25
+  max_fallback_rate: 0.5
+  min_success_rate_delta: 0.15

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -11,6 +11,7 @@ Client
   -> Task Classifier             # cascade: rules (always on) -> optional eval -> balanced
   -> Policy Engine
   -> Lane Resolver
+  -> (Signal Feedback)           # opt-in ranked-lane health promotion
   -> Capability Filter
   -> Circuit Breaker
   -> Provider Executor
@@ -106,6 +107,16 @@ Collapses the classifier + policy outcome into exactly one lane. Responsibilitie
 
 The resolver itself never trips circuit breakers or calls providers; that is the
 execution stage's job.
+
+### Signal Feedback
+
+Agentic Signals are aggregated, redacted health observations produced by the
+background signal collector from already-persisted decision records. When
+`runtime.signal_feedback.enabled` is true, `routeRequest` reads the latest signal
+for the selected ranked lane and may promote it to a stronger ranked lane with
+healthier aggregate success/error/fallback rates. This stage is fail-open and
+bounded by explicit passthrough, classifier fallback, policy pins, budget
+degradation, and policy/key caps.
 
 ### Capability Filter
 
@@ -223,7 +234,7 @@ config/
   capabilities.yaml    # manual capability overrides over the generated catalog
   pricing.yaml         # manual pricing overrides over the generated catalog
   auth.yaml            # require_api_key + admin auth source
-  runtime.yaml         # store driver, rate limit, timeouts, request size
+  runtime.yaml         # store driver, rate limit, timeouts, request size, signal feedback
   server.yaml          # host / port
   memory.yaml          # forgetting/decay layer (observer compaction is auto, not configured)
 ```

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -14,6 +14,7 @@ explicit model/lane            # client specified a concrete model/lane; skips c
   > server-side policy         # a policy pin (use_lane)
   > task-specific lane         # a lane named after the detected task_type
   > complexity-fallback lane   # simple→economy / medium→balanced / complex→premium
+  > signal feedback (opt-in)   # promote degraded ranked lanes inside caps
   > balanced                   # final default
 ```
 
@@ -31,6 +32,14 @@ not confident enough to steer," so they collapse to the safe terminal.
 Default lanes are deliberately few and easy to reason about. Any selected lane
 name that does not exist is skipped (fail-open); the terminal `balanced` is
 guaranteed to exist.
+
+When `runtime.signal_feedback.enabled` is true, the router performs one
+fail-open read of aggregated Agentic Signals after policy/key caps are applied
+and before expanding the execution chain. It can only promote a degraded ranked
+lane (`economy` or `balanced`) to a stronger ranked lane with healthier aggregate
+success/error/fallback rates. It never runs on explicit passthrough,
+classifier-default/fallback, policy `use_lane` pins, or over-budget degradation,
+and it never escapes policy/key caps.
 
 ### Explicit client model
 

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -71,7 +71,9 @@ plaintext key and no private payload. The record holds:
 - `classifier`: `task_type`, `complexity`, `confidence`, **`decided_by`**
   (`rules` / `eval` / `default` / `fallback`), `eval_cache_hit`,
   `fallback_reason`, `constraints`, and `explanation` (matched dimensions /
-  signals).
+  signals). When opt-in Agentic Signals feedback promotes a ranked lane, the
+  explanation includes a redacted `routing_signal_feedback` item with from/to
+  lanes, thresholds, and aggregate signal summaries.
 - `policy`: the matched policy id and a reason.
 - `lane`: the selected lane and the ordered candidate chain.
 - `provider_attempts[]`: per attempt — alias, `skipped` + `skip_reason`, status,

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -6,9 +6,9 @@
 > inject + background workers, on by default), per-key budgets / rate limits /
 > concurrency limiting, runtime hot-reload settings with admin YAML write-back,
 > verbatim payload capture, four streaming inbound protocols, full OAuth subscription
-> providers, an admin-UI overhaul, observer-economy compaction, and permanent delete
-> of revoked keys. The "deferred" list below is what is genuinely still out of scope
-> or not yet wired.
+> providers, Agentic Signals feedback into ranked-lane routing, an admin-UI
+> overhaul, observer-economy compaction, and permanent delete of revoked keys. The
+> "deferred" list below is what is genuinely still out of scope or not yet wired.
 
 ## Delivered
 
@@ -90,6 +90,11 @@ and OpenAI Codex (ChatGPT):
   classifier/lanes/policies edits are also persisted back to `config/*.yaml`
   (comment-preserving, atomic, fail-closed) before the live config rebinds, so they
   survive restarts rather than being reverted on restart.
+- **Agentic Signals feedback.** The background collector aggregates redacted
+  per-(task type, lane) health signals from decision records. Opt-in
+  `runtime.signal_feedback` lets routing promote a degraded ranked lane to a
+  healthier stronger ranked lane, while preserving explicit passthrough, policy
+  pins, usage-budget degradation, and policy/key caps. Signal reads fail open.
 - **Verbatim payload capture.** Full request/response bodies recorded to a separate
   `request_payloads` table (default on, 30-day retention), toggleable in System
   Settings.
@@ -108,8 +113,6 @@ Verified against the code and `implementation-notes.md`:
   Helm is an internal/self-hosted gateway with no account/customer billing subject,
   so account-level / customer credit accounting is **out of scope** (not merely
   deferred). See [06 · Auth, API Keys & Rate Limits](06-auth-and-rate-limits.md).
-- **Agentic Signals feedback layer.** The store ports and the redacted
-  `RoutingSignal` shape exist, but nothing reads signals back into routing yet.
 
 ## Success criteria
 

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -81,6 +81,9 @@ Configuration comes from **files** and **environment variables**, and env vars
   - `HELM_HOST`, `HELM_PORT`, `HELM_BASE_PATH`
   - `HELM_ADMIN_USER`, `HELM_ADMIN_PASSWORD`, `HELM_ADMIN_ENABLED`
   - `HELM_RATE_LIMIT_ENABLED`, `HELM_REQUEST_TIMEOUT_MS`, `HELM_MAX_REQUEST_BYTES`
+  - `HELM_SIGNAL_FEEDBACK_ENABLED` — opt into Agentic Signals feedback for ranked
+    lane promotion (disabled by default; detailed thresholds live in
+    `config/runtime.yaml`).
   - `HELM_STORE_DRIVER` (`sqlite` | `supabase`), `HELM_STORE_URL_ENV`
   - `HELM_DATA_DIR` (data directory, default `./data`), `HELM_KEYS_PERSIST_TO`
   - `HELM_OAUTH_ENC_KEY` — a 32-byte key used to encrypt stored OAuth
@@ -109,9 +112,10 @@ never runs in a half-broken state (Principle 2).
    API Keys & Rate Limits](06-auth-and-rate-limits.md)).
 3. Start the HTTP server (the API plus the admin UI when admin credentials are
    configured; see [11 · Admin UI](11-admin-ui.md)).
-4. Start the two off-request-path background workers — the **signal scheduler**
-   and the **memory worker** — unless disabled by their env vars (above). Each
-   timer is unref'd and fail-open; no request ever touches them.
+4. Start the two background workers — the **signal scheduler** and the **memory
+   worker** — unless disabled by their env vars (above). Each timer is unref'd
+   and fail-open. Signal collection itself is off-request-path; routing reads the
+   aggregated rows only when `runtime.signal_feedback.enabled` is on.
 5. Begin serving once the health endpoint reports ready.
 
 ## Health & version

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -239,7 +239,7 @@ Valuable ideas:
 Worth borrowing:
 
 - A middleware boundary for Memory / Guardrails.
-- Signals as a future feedback layer.
+- Signals as a low-cost feedback layer.
 - The lane / alias abstraction.
 
 Do not copy blindly:

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-09 · Agentic Signals 反馈接入 ranked-lane 路由（docs/02 架构；docs/04 路由；docs/07 可观测性）
+
+- **缘起**：路线图里 `RoutingSignal` 聚合、sqlite/pg store 与后台 collector 已存在，但请求路径从不读取信号，导致 Agentic Signals 只能观测不能反馈，仍属于“未接线”功能。
+- **修复**：新增 `runtime.signal_feedback` 配置（默认 `enabled:false`，`HELM_SIGNAL_FEEDBACK_ENABLED` 可覆盖；阈值在 `config/runtime.yaml`），网关把 `store.signals.getSignal` 接入 `routeRequest`。启用后，只有当当前 **ranked lane**（`economy/balanced`）在同一 `task_type` 下样本数达标且 error/fallback 率超阈值时，才会提升到更强且更健康的 ranked lane；不会降级，也不会越过 explicit passthrough、policy `use_lane` pin、usage-budget degrade、policy/key caps。
+- **安全/可观测**：信号只含聚合计数/率/延迟/成本，不含 key/payload；读取异常完全 fail-open，保持原 lane 并继续请求。发生提升时在 `classifier.explanation` 追加 `routing_signal_feedback`（from/to lane、阈值、信号摘要），不新增敏感字段。
+- **取舍/TODO**：本次只做 ranked-lane 健康提升，暂不让信号改写未排名任务 lane（如 `coding`）或做成本驱动降档，避免生产反馈绕过 operator 明确策略。若后续要对 task lane 做反馈，应先定义“task lane → ranked lane”的可解释映射和更细粒度的决策字段。
+- **测试**：TDD 新增 route tests 覆盖 degraded balanced → premium、signal store fail-open、key allowed_lanes 不越界、policy pin / explicit passthrough / budget degrade 不被覆盖；config schema + loader 覆盖默认关闭、阈值 fail-closed 与 env 开关。
+
+---
+
 ## 2026-06-09 · 生产路径四协议 LiteLLM 参数保真 + payload 原文记录修复（docs/05 协议互译；docs/07 可观测性；CLAUDE.md 原则 7/8）
 
 - **缘起**：复审发现 transformer 层已覆盖大量 OpenAI/Anthropic/Responses/Gemini 字段，但生产路径 `route -> InternalRequest -> execute` 仍只保留 `messages/tools/response_format/max_tokens/stream`，导致 `temperature/top_p/tool_choice/parallel_tool_calls/reasoning_effort/max_completion_tokens` 等 LiteLLM/OpenAI 参数被静默丢弃；同时 payload capture 用 `JSON.stringify(parsed)` 重建请求体，不符合 docs/07 的 verbatim 记录承诺。
@@ -35,20 +45,11 @@
 
 ---
 
-## 2026-06-07 · 修复 Anthropic 订阅配额页：`resets_at:null` 让整份用量解析失败、快照永久卡旧（线上实测；docs/06 providers 页 Tier 3；CLAUDE.md 原则 3 fail-open）
-
-- **现象（la.atmy.work 实测）**：providers 页两个 Claude Max 账号，`mylukin@gmail.com` 配额正确（5h 7%/7d 39%），`riverathomas6094@outlook.com` 恒显 9%/44%（真值应为 5%/5%，与并存的 claude-relay-service 对照），点刷新无效。
-- **定位（直连线上数据库 + 解密 token 实打 usage 端点）**：① `oauth_quota` 表里 river 账号快照 `captured_at` 已 **22.9 小时**未更新（mylukin 是 4.9 分钟），即 PULL 从不写回；② token 正常（`updated_at` 新鲜、刷新成功）；③ 解密 river 的 access token 实打 `GET /api/oauth/usage` 返回 **200 + 合法 body**（5h 5%/7d 5%），HTTP 层无错。差异只在 body 形状：mylukin 的 `seven_day_sonnet.resets_at` 是 ISO 串，river 的是 **`null`**（周 Sonnet 额度未动用、无倒计时）。
-- **根因**：`AnthropicWindowSchema` 内层 `resets_at: z.string().optional()` —— `.optional()` 接受 `string|undefined` 但**拒绝 `null`**。顶层窗口已是 `.nullish()`（容忍整窗为 null），却漏了**存在的窗口内部字段为 null** 这一情况。river 的 `seven_day_sonnet` 是个对象（非 null）→ 进内层校验 → `resets_at:null` 失败 → 整份 `AnthropicOAuthUsageSchema.safeParse` 失败 → `parseAnthropicUsageBody` 返回 `[]` → 路由 `if (windows.length>0)` 跳过 upsert → 旧快照永久留存，每次刷新同样失败。完美解释四个症状（账号1对、账号2卡、刷新无效、快照近一天前）。
-- **修复（最小且正确）**：`utilization`/`resets_at` 双双改 `.nullish()`，接受 API 合法的 `null`。下游 `anthropicUsageToWindows` 早已健壮（`typeof utilization!=="number"` 跳过、`resets_at` 非串 → `resetsAtMs:null`），故仅 schema 一处改动。保留 `utilization:"x"`（字符串）仍失败的防御性（坏类型≠合法 null）。
-- **取舍/坑**：(1) 当前设计是「任一窗口坏 → 整份 fail-open 到 []」的全有全无，本次只把**合法 null** 从「坏」里摘出；真要每窗独立容错是更大改动，未做。(2) 路由 `if (windows && windows.length>0)` 才 upsert 的逻辑放大了本 bug——解析失败时宁可留旧也不写空，导致静默卡死且**无任何日志**（catch 全吞）。已知观测盲点，TODO：PULL 失败/空至少记一条 warn。(3) **部署**：修复在 `packages/shared`，需重建镜像部署；la.atmy.work 现有 river 旧快照会在新镜像首次成功 PULL 后自动覆盖（5min TTL 内）。
-- **验证**：TDD 先红后绿——新增「存在窗口含 `resets_at:null`（逐字照搬线上 body）」用例，修前返回 `[]`、修后正确返回 5h/7d/7d-sonnet（sonnet `resetsAtMs:null`）。anthropic-quota 6/6、oauth 全组 67/67、shared+core typecheck 净、lint 净。全量 node 项目 2376 绿（4 红均为 `apps/admin/build` 未构建的 admin-static 环境失败，与本改无关）。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-07 · 修复 Anthropic 订阅配额页：`resets_at:null` 让整份用量解析失败、快照永久卡旧；修为 `utilization`/`resets_at` 双 `.nullish()`，保坏类型 fail-closed；TDD 锁线上 body，oauth/shared/core 验证通过。
 
 ### 2026-06-07 · 记忆压缩重写为单一 auto 模式：删除 fixed/economy，改为默认零配置 auto + 少量触发覆盖；价格/上下文窗口从 catalog 自适应，三触发 size/idle/pressure，修复多轮评审发现的 idle/前沿/范围/配置漂移问题；最终 typecheck/lint/build/full test 通过。
 

--- a/packages/core/src/config/env-map.ts
+++ b/packages/core/src/config/env-map.ts
@@ -42,6 +42,11 @@ export const ENV_MAPPINGS: readonly EnvMapping[] = [
   // config — mirrors providers[].api_key_env (principle 7).
   { env: "HELM_STORE_DRIVER", path: ["runtime", "store", "driver"], kind: "string" },
   { env: "HELM_STORE_URL_ENV", path: ["runtime", "store", "url_env"], kind: "string" },
+  {
+    env: "HELM_SIGNAL_FEEDBACK_ENABLED",
+    path: ["runtime", "signal_feedback", "enabled"],
+    kind: "boolean",
+  },
 ];
 
 // Coerce a string env value into the declared kind. Returns the original string

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -59,6 +59,18 @@ describe("loadConfig", () => {
     expect(cfg.runtime.store.url_env).toBe("HELM_STORE_URL");
   });
 
+  it("defaults routing signal feedback off and lets HELM_SIGNAL_FEEDBACK_ENABLED turn it on", () => {
+    const dflt = loadConfig({ configDir: "config", env: {}, readFile: fakeReadFile(VALID_YAML) });
+    expect(dflt.runtime.signal_feedback.enabled).toBe(false);
+    const cfg = loadConfig({
+      configDir: "config",
+      env: { HELM_SIGNAL_FEEDBACK_ENABLED: "true" },
+      readFile: fakeReadFile(VALID_YAML),
+    });
+    expect(cfg.runtime.signal_feedback.enabled).toBe(true);
+    expect(cfg.runtime.signal_feedback.min_samples).toBe(20);
+  });
+
   it("fails closed when HELM_STORE_DRIVER is an unknown driver", () => {
     expect(() =>
       loadConfig({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -575,6 +575,7 @@ export {
   type ProviderAttempt as RouteProviderAttempt,
   type RouteDeps,
   type RouteOptions,
+  type RoutingSignalFeedbackDeps,
   routeRequest,
 } from "./routing/route-request.js";
 // Runtime-mutable settings (admin "System Settings") — load/seed/persist the
@@ -586,11 +587,11 @@ export {
   type SettingsLog,
   saveRuntimeSettings,
 } from "./settings/runtime-settings.js";
-// Agentic Signals — POST-MVP low-cost production feedback layer (docs/02,
-// research-notes "Plano"). Pure aggregator + background collector that distill
-// REDACTED routing signals from already-persisted decision records, ASYNCHRONOUS
-// and OFF the request path. Observe-only: this task never feeds signals back into
-// routing. Framework-agnostic; fail-open.
+// Agentic Signals — low-cost production feedback layer (docs/02, research-notes
+// "Plano"). Pure aggregator + background collector distill REDACTED routing
+// signals from already-persisted decision records off the request path. The
+// optional routeRequest consumer reads them fail-open for ranked-lane promotion.
+// Framework-agnostic; fail-open.
 export { aggregateSignals } from "./signals/aggregate.js";
 export {
   createSignalCollector,

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -1,4 +1,4 @@
-import { type InternalRequest, makeHelmError } from "@helm/shared";
+import { type InternalRequest, makeHelmError, type RoutingSignal } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import type { LanesConfig } from "../lanes/schema.js";
 import type { PoliciesConfig } from "./policy-schema.js";
@@ -57,6 +57,25 @@ function classification(over: Partial<Classification> = {}): Classification {
     decided_by: "rules",
     constraints: {},
     explanation: [],
+    ...over,
+  };
+}
+
+function routingSignal(over: Partial<RoutingSignal> = {}): RoutingSignal {
+  return {
+    taskType: "general",
+    lane: "balanced",
+    windowStart: 1,
+    windowEnd: 2,
+    samples: 100,
+    successRate: 0.95,
+    fallbackRate: 0.02,
+    classifierFallbackRate: 0,
+    errorRate: 0.03,
+    p50LatencyMs: 100,
+    p95LatencyMs: 200,
+    avgCostUsd: 0.001,
+    updatedAt: 2,
     ...over,
   };
 }
@@ -395,6 +414,139 @@ describe("routeRequest — orchestration", () => {
     await routeRequest(req(), d);
     const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
     expect(plan.selected_lane).toBe("coding");
+  });
+
+  it("signal feedback promotes a degraded ranked lane to a healthier stronger lane", async () => {
+    const getSignal = vi.fn(async (taskType: string, lane: string) => {
+      if (taskType !== "general") return null;
+      if (lane === "balanced") {
+        return routingSignal({
+          taskType,
+          lane,
+          successRate: 0.45,
+          fallbackRate: 0.7,
+          errorRate: 0.55,
+        });
+      }
+      if (lane === "premium") {
+        return routingSignal({
+          taskType,
+          lane,
+          successRate: 0.94,
+          fallbackRate: 0.03,
+          errorRate: 0.02,
+        });
+      }
+      return null;
+    });
+    const d = deps({
+      classify: vi.fn(async () =>
+        classification({ task_type: "general", complexity: "medium", constraints: {} }),
+      ),
+      policies: { policies: [] },
+      signalFeedback: {
+        enabled: true,
+        minSamples: 20,
+        getSignal,
+      },
+    });
+
+    const result = await routeRequest(req(), d);
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+    expect(plan.candidate_chain[0]).toBe("best_reasoning_model");
+    expect(result.decision.lane.selected_lane).toBe("premium");
+    expect(result.decision.classifier.explanation).toContainEqual(
+      expect.objectContaining({
+        kind: "routing_signal_feedback",
+        from_lane: "balanced",
+        to_lane: "premium",
+      }),
+    );
+    expect(getSignal).toHaveBeenCalledWith("general", "balanced");
+    expect(getSignal).toHaveBeenCalledWith("general", "premium");
+  });
+
+  it("signal feedback stays fail-open when the signal store read fails", async () => {
+    const d = deps({
+      classify: vi.fn(async () =>
+        classification({ task_type: "general", complexity: "medium", constraints: {} }),
+      ),
+      policies: { policies: [] },
+      signalFeedback: {
+        enabled: true,
+        getSignal: vi.fn(async () => {
+          throw new Error("signal store unavailable");
+        }),
+      },
+    });
+
+    const result = await routeRequest(req(), d);
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("balanced");
+    expect(result.final.status).toBe("ok");
+  });
+
+  it("signal feedback respects key allowedLanes and does not promote outside the key cap", async () => {
+    const d = deps({
+      classify: vi.fn(async () =>
+        classification({ task_type: "general", complexity: "medium", constraints: {} }),
+      ),
+      policies: { policies: [] },
+      signalFeedback: {
+        enabled: true,
+        minSamples: 20,
+        getSignal: vi.fn(async (_taskType, lane) =>
+          lane === "balanced"
+            ? routingSignal({ lane, successRate: 0.4, fallbackRate: 0.8, errorRate: 0.6 })
+            : routingSignal({ lane, successRate: 0.99, fallbackRate: 0, errorRate: 0 }),
+        ),
+      },
+    });
+
+    await routeRequest(req(), d, { keyCaps: { allowedLanes: ["economy", "balanced"] } });
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("balanced");
+  });
+
+  it("signal feedback does not override policy pins, explicit passthrough, or over-budget degradation", async () => {
+    const getSignal = vi.fn(async (_taskType: string, lane: string) =>
+      routingSignal({ lane, successRate: lane === "premium" ? 0.99 : 0.2, errorRate: 0.8 }),
+    );
+    const signalFeedback = { enabled: true, getSignal };
+
+    const pinned = deps({
+      classify: vi.fn(async () =>
+        classification({ task_type: "general", complexity: "medium", constraints: {} }),
+      ),
+      policies: { policies: [{ id: "pin-balanced", match: {}, use_lane: "balanced" }] },
+      signalFeedback,
+    });
+    await routeRequest(req(), pinned);
+    let plan = (pinned.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("balanced");
+
+    const explicit = deps({ signalFeedback });
+    await routeRequest(req({ requested_model: "gpt-4o" }), explicit, { allowCustomModel: true });
+    plan = (explicit.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.explicit_model).toBe("gpt-4o");
+
+    const degraded = deps({
+      classify: vi.fn(async () =>
+        classification({ task_type: "general", complexity: "medium", constraints: {} }),
+      ),
+      policies: { policies: [] },
+      signalFeedback,
+    });
+    await routeRequest(req(), degraded, {
+      keyCaps: { allowedLanes: null, degradeLane: "economy" },
+    });
+    plan = (degraded.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+    expect(getSignal).not.toHaveBeenCalled();
   });
 
   it("explicit LANE passthrough expands the lane's chain (full fallback semantics)", async () => {

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -4,11 +4,12 @@ import {
   type HelmError,
   type InternalRequest,
   makeHelmError,
+  type RoutingSignal,
 } from "@helm/shared";
 import { expandLaneChain } from "../lanes/expand-chain.js";
 import type { LanesConfig } from "../lanes/schema.js";
 import { type Classification as ResolverClassification, resolveLane } from "./lane-resolver.js";
-import { applyCaps, evaluatePolicies, type PolicyContext } from "./policy-engine.js";
+import { applyCaps, evaluatePolicies, LANE_RANK, type PolicyContext } from "./policy-engine.js";
 import type { PoliciesConfig } from "./policy-schema.js";
 
 // routeRequest — the SINGLE, framework-agnostic orchestrator for one request
@@ -139,6 +140,11 @@ export interface RouteDeps {
    *  absent (headless core / tests) → validation is skipped. Lane names are
    *  checked FIRST and never reach this. */
   isKnownModel?: (alias: string) => boolean;
+  /** Opt-in Agentic Signals feedback. Reads aggregated, redacted signal rows and
+   *  may promote a degraded ranked lane to a healthier stronger ranked lane,
+   *  never overriding explicit passthrough, policy pins, budget degradation, or
+   *  policy/key caps. Signal reads are fail-open. */
+  signalFeedback?: RoutingSignalFeedbackDeps;
 }
 
 export interface RouteOptions {
@@ -163,6 +169,34 @@ export interface RouteOptions {
    *  still clamped to `allowedLanes` (the harder security bound). */
   keyCaps?: { allowedLanes: string[] | null; degradeLane?: string | null };
 }
+
+export interface RoutingSignalFeedbackDeps {
+  enabled: boolean;
+  getSignal: (taskType: string, lane: string) => Promise<RoutingSignal | null>;
+  minSamples?: number;
+  maxErrorRate?: number;
+  maxFallbackRate?: number;
+  minSuccessRateDelta?: number;
+}
+
+interface SignalFeedbackThresholds {
+  minSamples: number;
+  maxErrorRate: number;
+  maxFallbackRate: number;
+  minSuccessRateDelta: number;
+}
+
+interface SignalFeedbackAdjustment {
+  lane: string;
+  explanation: Record<string, unknown>;
+}
+
+const DEFAULT_SIGNAL_FEEDBACK: SignalFeedbackThresholds = {
+  minSamples: 20,
+  maxErrorRate: 0.25,
+  maxFallbackRate: 0.5,
+  minSuccessRateDelta: 0.15,
+};
 
 // Fail-open classification default (principle 3 + 5): a degraded classifier
 // result that pins `balanced` via the resolver's decided_by==="default" path.
@@ -246,6 +280,135 @@ interface PlanRejection {
 
 function isRejection(p: PlanDecision | PlanRejection): p is PlanRejection {
   return "reject" in p;
+}
+
+function hasLane(lanes: LanesConfig, lane: string): boolean {
+  return Object.hasOwn(lanes, lane);
+}
+
+function signalThresholds(feedback: RoutingSignalFeedbackDeps): SignalFeedbackThresholds {
+  return {
+    minSamples: feedback.minSamples ?? DEFAULT_SIGNAL_FEEDBACK.minSamples,
+    maxErrorRate: feedback.maxErrorRate ?? DEFAULT_SIGNAL_FEEDBACK.maxErrorRate,
+    maxFallbackRate: feedback.maxFallbackRate ?? DEFAULT_SIGNAL_FEEDBACK.maxFallbackRate,
+    minSuccessRateDelta:
+      feedback.minSuccessRateDelta ?? DEFAULT_SIGNAL_FEEDBACK.minSuccessRateDelta,
+  };
+}
+
+function signalSummary(signal: RoutingSignal): Record<string, unknown> {
+  return {
+    samples: signal.samples,
+    success_rate: signal.successRate,
+    fallback_rate: signal.fallbackRate,
+    error_rate: signal.errorRate,
+    p95_latency_ms: signal.p95LatencyMs,
+    avg_cost_usd: signal.avgCostUsd,
+    updated_at: signal.updatedAt,
+  };
+}
+
+function isDegradedSignal(signal: RoutingSignal, thresholds: SignalFeedbackThresholds): boolean {
+  if (signal.samples < thresholds.minSamples) return false;
+  return (
+    signal.errorRate >= thresholds.maxErrorRate || signal.fallbackRate >= thresholds.maxFallbackRate
+  );
+}
+
+function isHealthyPromotion(
+  candidate: RoutingSignal,
+  current: RoutingSignal,
+  thresholds: SignalFeedbackThresholds,
+): boolean {
+  if (candidate.samples < thresholds.minSamples) return false;
+  if (candidate.errorRate >= thresholds.maxErrorRate) return false;
+  if (candidate.fallbackRate >= thresholds.maxFallbackRate) return false;
+  return candidate.successRate >= current.successRate + thresholds.minSuccessRateDelta;
+}
+
+function strongerRankedLanes(selectedLane: string, lanes: LanesConfig): string[] {
+  const selectedRank = LANE_RANK[selectedLane];
+  if (selectedRank === undefined) return [];
+  return Object.entries(LANE_RANK)
+    .filter(([lane, rank]) => rank > selectedRank && hasLane(lanes, lane))
+    .sort(([, a], [, b]) => a - b)
+    .map(([lane]) => lane);
+}
+
+function candidateAllowedByCaps(
+  candidateLane: string,
+  policyOutcome: ReturnType<typeof evaluatePolicies>,
+  keyCaps: RouteOptions["keyCaps"],
+): boolean {
+  if (applyCaps(candidateLane, policyOutcome) !== candidateLane) return false;
+  if (keyCaps === undefined) return true;
+  const capped = applyCaps(candidateLane, {
+    matched_policy_id: null,
+    use_lane: null,
+    max_lane: null,
+    allowed_lanes: keyCaps.allowedLanes,
+    reason: "key caps",
+  });
+  return capped === candidateLane;
+}
+
+async function maybeApplySignalFeedback(args: {
+  selectedLane: string;
+  classification: Classification;
+  policyOutcome: ReturnType<typeof evaluatePolicies>;
+  lanes: LanesConfig;
+  keyCaps: RouteOptions["keyCaps"];
+  feedback: RoutingSignalFeedbackDeps | undefined;
+}): Promise<SignalFeedbackAdjustment | null> {
+  const { feedback, classification, selectedLane, lanes, policyOutcome, keyCaps } = args;
+  if (feedback?.enabled !== true) return null;
+  // Never let production feedback override deterministic terminal paths or
+  // operator/client hard constraints.
+  if (classification.decided_by === "default" || classification.decided_by === "fallback") {
+    return null;
+  }
+  if (policyOutcome.use_lane !== null) return null;
+  if (keyCaps?.degradeLane !== undefined && keyCaps.degradeLane !== null) return null;
+
+  const thresholds = signalThresholds(feedback);
+  const candidates = strongerRankedLanes(selectedLane, lanes).filter((candidate) =>
+    candidateAllowedByCaps(candidate, policyOutcome, keyCaps),
+  );
+  if (candidates.length === 0) return null;
+
+  try {
+    const current = await feedback.getSignal(classification.task_type, selectedLane);
+    if (current === null || !isDegradedSignal(current, thresholds)) return null;
+
+    for (const candidateLane of candidates) {
+      const candidate = await feedback.getSignal(classification.task_type, candidateLane);
+      if (candidate === null) continue;
+      if (!isHealthyPromotion(candidate, current, thresholds)) continue;
+      return {
+        lane: candidateLane,
+        explanation: {
+          kind: "routing_signal_feedback",
+          reason: "promoted degraded ranked lane to healthier stronger lane",
+          task_type: classification.task_type,
+          from_lane: selectedLane,
+          to_lane: candidateLane,
+          selected_signal: signalSummary(current),
+          candidate_signal: signalSummary(candidate),
+          thresholds: {
+            min_samples: thresholds.minSamples,
+            max_error_rate: thresholds.maxErrorRate,
+            max_fallback_rate: thresholds.maxFallbackRate,
+            min_success_rate_delta: thresholds.minSuccessRateDelta,
+          },
+        },
+      };
+    }
+  } catch {
+    // Fail-open: stale/missing/corrupt signal storage must not change or break a
+    // request. The normal route.decision still records the unadjusted lane.
+    return null;
+  }
+  return null;
 }
 
 // The classifier segment shared by ALL explicit-passthrough outcomes (model,
@@ -387,7 +550,20 @@ async function plan(
       reason: "key caps",
     });
   }
+  const signalAdjustment = await maybeApplySignalFeedback({
+    selectedLane: cappedLane,
+    classification: cls,
+    policyOutcome: outcome,
+    lanes: deps.lanes,
+    keyCaps: opts.keyCaps,
+    feedback: deps.signalFeedback,
+  });
+  if (signalAdjustment !== null) cappedLane = signalAdjustment.lane;
   const chain = expandChain(cappedLane, deps.lanes);
+  const explanation =
+    signalAdjustment === null
+      ? cls.explanation
+      : [...cls.explanation, signalAdjustment.explanation];
 
   return {
     plan: { selected_lane: cappedLane, candidate_chain: chain, explicit_model: null },
@@ -405,7 +581,7 @@ async function plan(
       eval_latency_ms: cls.eval_latency_ms ?? null,
       fallback_reason: cls.fallback_reason ?? null,
       constraints: cls.constraints as Record<string, unknown>,
-      explanation: cls.explanation,
+      explanation,
     },
     policy: { matched_policy_id: outcome.matched_policy_id, reason: outcome.reason },
     evalUsd: cls.eval_usd ?? null,

--- a/packages/core/src/signals/types.ts
+++ b/packages/core/src/signals/types.ts
@@ -3,9 +3,9 @@ import type { DecisionRecord, RoutingSignal } from "@helm/shared";
 // Agentic Signals — POST-MVP low-cost production-feedback layer (docs/02
 // telemetry; research-notes「Plano」). A signal is an aggregated, REDACTED
 // observation rolled up by (task_type, lane) over a time window, distilled
-// ASYNCHRONOUSLY from already-persisted decision records. It NEVER adds latency
-// to the main request path and (this task) NEVER feeds back into routing —
-// observe-only. The consumption side is a future task.
+// ASYNCHRONOUSLY from already-persisted decision records. The collector never
+// adds latency to the main request path; the optional routeRequest consumer reads
+// only these aggregates and fails open when storage is unavailable.
 //
 // Zod is the single source of truth (CLAUDE.md): RoutingSignal is z.infer'd in
 // @helm/shared; we re-export it here so signals code reads one local type.

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -286,17 +286,17 @@ export interface TelemetryStore {
 
 // SignalStore — persistence for the POST-MVP Agentic Signals feedback layer
 // (docs/02; research-notes "Plano"). A signal is an aggregated, REDACTED
-// observation rolled up by (taskType, lane). This is an OBSERVABILITY artifact:
-// the collector writes it asynchronously off the request path, and (this task)
-// nothing reads it back into routing — `getSignal` exists for a FUTURE
-// consumption task. One logical row per (taskType, lane); `upsertSignals`
-// overwrites so re-collecting a window never double-counts. Pure types — no SQL.
+// observation rolled up by (taskType, lane). The collector writes it
+// asynchronously off the request path; the optional routing feedback consumer
+// reads it fail-open when runtime.signal_feedback.enabled is true. One logical
+// row per (taskType, lane); `upsertSignals` overwrites so re-collecting a window
+// never double-counts. Pure types — no SQL.
 export interface SignalStore {
   // Idempotent upsert keyed by (taskType, lane). Overwrites the prior signal for
   // each pair; a failure here is fail-open (the collector logs, never 5xx).
   upsertSignals(signals: readonly RoutingSignal[]): Promise<void>;
-  // Read the latest signal for a (taskType, lane), or null if none yet. Reserved
-  // for the future routing-feedback consumer; unused by the MVP route.
+  // Read the latest signal for a (taskType, lane), or null if none yet. Used only
+  // by opt-in routing feedback; callers must treat failures as fail-open.
   getSignal(taskType: string, lane: string): Promise<RoutingSignal | null>;
 }
 

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -89,8 +89,9 @@ export const usageBudgetBuckets = sqliteTable(
 // Agentic Signals (POST-MVP feedback layer; docs/02). One row per
 // (task_type, lane) — the latest rolled-up, REDACTED observation. NO key /
 // payload column (principle 7): only aggregate dimensions. avg_cost_usd is REAL
-// nullable. Written ASYNCHRONOUSLY by the background collector, never on the
-// request path. This table is observe-only: the MVP route never reads it.
+// nullable. Written ASYNCHRONOUSLY by the background collector. The opt-in
+// routing feedback path reads only these aggregates and fails open on storage
+// errors.
 export const routingSignals = sqliteTable(
   "routing_signals",
   {

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -69,6 +69,8 @@ describe("HelmConfigSchema", () => {
     expect(parsed.runtime.rate_limit.enabled).toBe(false);
     expect(parsed.runtime.rate_limit.default.rpm).toBe(0);
     expect(parsed.runtime.rate_limit.default.tpm).toBe(0);
+    expect(parsed.runtime.signal_feedback.enabled).toBe(false);
+    expect(parsed.runtime.signal_feedback.min_samples).toBe(20);
   });
 
   it("rejects an out-of-range port with a precise path", () => {
@@ -188,6 +190,37 @@ describe("HelmConfigSchema", () => {
     ok.runtime.store = { driver: "supabase", url_env: "HELM_STORE_URL" };
     const parsed = HelmConfigSchema.parse(ok);
     expect("url" in parsed.runtime.store).toBe(false);
+  });
+
+  it("accepts opt-in routing signal feedback thresholds", () => {
+    const ok = fullConfig() as Record<string, unknown> & { runtime: Record<string, unknown> };
+    ok.runtime.signal_feedback = {
+      enabled: true,
+      min_samples: 50,
+      max_error_rate: 0.2,
+      max_fallback_rate: 0.4,
+      min_success_rate_delta: 0.1,
+    };
+
+    const parsed = HelmConfigSchema.parse(ok);
+
+    expect(parsed.runtime.signal_feedback.enabled).toBe(true);
+    expect(parsed.runtime.signal_feedback.min_samples).toBe(50);
+    expect(parsed.runtime.signal_feedback.max_error_rate).toBe(0.2);
+  });
+
+  it("fails closed on invalid routing signal feedback thresholds", () => {
+    const bad = fullConfig() as Record<string, unknown> & { runtime: Record<string, unknown> };
+    bad.runtime.signal_feedback = { enabled: true, max_error_rate: 2 };
+
+    const res = HelmConfigSchema.safeParse(bad);
+
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(
+        res.error.issues.some((i) => i.path.join(".") === "runtime.signal_feedback.max_error_rate"),
+      ).toBe(true);
+    }
   });
 
   // --- providers-multi: unified provider shape (alias/name, type, base_url?,

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -197,6 +197,21 @@ export const StoreConfigSchema = z.object({
   url_env: z.string().min(1).optional(),
 });
 
+// Opt-in routing feedback from aggregated Agentic Signals. Disabled by default
+// so first-boot routing remains deterministic; when enabled, the core may promote
+// a degraded ranked lane to a healthier stronger ranked lane inside policy/key
+// caps. Thresholds are validated fail-closed here and consumed fail-open at
+// runtime, so a signal-store problem never 5xxs a request.
+export const RoutingSignalFeedbackConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    min_samples: z.number().int().positive().default(20),
+    max_error_rate: z.number().min(0).max(1).default(0.25),
+    max_fallback_rate: z.number().min(0).max(1).default(0.5),
+    min_success_rate_delta: z.number().min(0).max(1).default(0.15),
+  })
+  .strict();
+
 export const RuntimeConfigSchema = z.object({
   max_request_bytes: z.number().int().positive().default(2_000_000),
   request_timeout_ms: z.number().int().positive().default(60_000),
@@ -204,6 +219,7 @@ export const RuntimeConfigSchema = z.object({
   // Store driver selection. Defaulted so an absent runtime.store stays on sqlite
   // (back-compat); overridable via HELM_STORE_DRIVER (see env-map).
   store: StoreConfigSchema.prefault({ driver: "sqlite" }),
+  signal_feedback: RoutingSignalFeedbackConfigSchema.prefault({}),
 });
 
 export const HelmConfigSchema = z.object({
@@ -257,6 +273,7 @@ export type RateLimitQuota = z.infer<typeof RateLimitQuotaSchema>;
 export type RateLimitQuotaOverride = z.infer<typeof RateLimitQuotaOverrideSchema>;
 export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
 export type StoreConfig = z.infer<typeof StoreConfigSchema>;
+export type RoutingSignalFeedbackConfig = z.infer<typeof RoutingSignalFeedbackConfigSchema>;
 export type RuntimeConfig = z.infer<typeof RuntimeConfigSchema>;
 export type HelmConfig = z.infer<typeof HelmConfigSchema>;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -117,6 +117,8 @@ export {
   type RateLimitQuotaOverride,
   RateLimitQuotaOverrideSchema,
   RateLimitQuotaSchema,
+  type RoutingSignalFeedbackConfig,
+  RoutingSignalFeedbackConfigSchema,
   type RuntimeConfig,
   RuntimeConfigSchema,
   type ServerConfig,

--- a/packages/shared/src/signals/schema.ts
+++ b/packages/shared/src/signals/schema.ts
@@ -14,9 +14,10 @@ import { z } from "zod";
 // the CLASSIFICATION fallback (classifier.decided_by → balanced); that lives in
 // `classifierFallbackRate` so the two mechanisms stay separately observable.
 //
-// This task is OBSERVE-ONLY: signals are produced and persisted, never fed back
-// into routing. The consumption side (influencing lane selection) is a future
-// task — keeping the MVP route deterministic.
+// Consumption is opt-in: when runtime.signal_feedback.enabled is true, routing
+// may read these aggregates to promote a degraded ranked lane to a healthier
+// stronger ranked lane inside policy/key caps. The signal itself remains
+// redacted and aggregate-only.
 export const RoutingSignalSchema = z
   .object({
     taskType: z.string(),


### PR DESCRIPTION
## Summary

- Wire opt-in Agentic Signals feedback into `routeRequest` so degraded ranked lanes can promote to healthier stronger ranked lanes inside policy/key caps.
- Add `runtime.signal_feedback` config + `HELM_SIGNAL_FEEDBACK_ENABLED` env override, with fail-closed threshold validation.
- Update docs, README, and implementation notes to move Agentic Signals feedback out of the deferred list.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e`
