### PR TITLE
feat: add configurable memory llm summarizer

### DIFF
--- a/apps/gateway/src/memory-llm.test.ts
+++ b/apps/gateway/src/memory-llm.test.ts
@@ -119,7 +119,7 @@ describe("createMemoryLlmRuntime", () => {
     const { runtime, client, resolveModel } = runtimeArgs({
       response: {
         observation_text: "Invoices for Project Alpha require PO #123.",
-        priority: 3,
+        priority: 8,
         importance: 0.82,
         tags: ["project-alpha", "billing"],
       },
@@ -145,10 +145,44 @@ describe("createMemoryLlmRuntime", () => {
     );
     expect(result).toEqual({
       observationText: "Invoices for Project Alpha require PO #123.",
-      priority: 3,
+      priority: 8,
       importance: 0.82,
       tags: ["project-alpha", "billing"],
     });
+  });
+
+  it("accepts the observer's 0..10 priority scale so priority can derive salience above 0.5", async () => {
+    const { runtime } = runtimeArgs({
+      response: {
+        observation_text: "The user strongly prefers bilingual explanations.",
+        priority: 10,
+        tags: ["preference"],
+      },
+      resolveAlias: "openai/observer",
+    });
+
+    const result = await runtime.summarize({
+      messages: [rawMessage("m1", "user", "Always explain in English and Chinese.")],
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(result.priority).toBe(10);
+    expect(result.importance).toBeUndefined();
+  });
+
+  it("falls back to deterministic observation text when the LLM returns whitespace-only text", async () => {
+    const { runtime, logs } = runtimeArgs({
+      response: { observation_text: "   " },
+      resolveAlias: "openai/observer",
+    });
+
+    const result = await runtime.summarize({
+      messages: [rawMessage("m1", "user", "Project Alpha invoices require PO #123.")],
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(result.observationText).toBe("user: Project Alpha invoices require PO #123.");
+    expect(logs.some((l) => l.line === "memory.llm.fallback")).toBe(true);
   });
 
   it("falls back to deterministic reflection compaction when the LLM returns invalid JSON", async () => {
@@ -179,6 +213,47 @@ describe("createMemoryLlmRuntime", () => {
 
     expect(result.reflectionText).toBe("- User prefers concise English explanations.");
     expect(result.tokenEstimate).toBe(Math.ceil(result.reflectionText.length / 4));
+    expect(logs.some((l) => l.line === "memory.llm.fallback")).toBe(true);
+  });
+
+  it("does not send previous reflection text to the LLM merge prompt", async () => {
+    const { runtime, client } = runtimeArgs({
+      response: { reflection_text: "Only active observations should survive." },
+    });
+
+    await runtime.merge({
+      observations: [
+        observation("obs-1", "Active observation stays visible.", new Date("2026-06-01")),
+      ],
+      previousReflection: {
+        ...reflection(),
+        reflectionText: "FORGOTTEN_SECRET should never be available to the model.",
+      },
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    const body = client.chatCompletion.mock.calls[0]?.[0] as {
+      messages: Array<{ content: string }>;
+    };
+    expect(JSON.stringify(body.messages)).not.toContain("FORGOTTEN_SECRET");
+    expect(JSON.stringify(body.messages)).not.toContain("previous_reflection");
+  });
+
+  it("falls back to deterministic reflection text when the LLM returns whitespace-only text", async () => {
+    const { runtime, logs } = runtimeArgs({
+      response: { reflection_text: "   " },
+    });
+    const observations = [
+      observation("obs-1", "User prefers concise English explanations.", new Date("2026-06-01")),
+    ];
+
+    const result = await runtime.merge({
+      observations,
+      previousReflection: reflection(),
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(result.reflectionText).toBe("- User prefers concise English explanations.");
     expect(logs.some((l) => l.line === "memory.llm.fallback")).toBe(true);
   });
 
@@ -221,6 +296,89 @@ describe("createMemoryLlmRuntime", () => {
         sourceObservationRange: ["obs-2", "obs-2"],
       },
     ]);
+  });
+
+  it("does not send previous reflection text to the LLM fact-extraction prompt", async () => {
+    const { runtime, client } = runtimeArgs({
+      response: {
+        facts: [
+          {
+            subject_text: "Project Alpha",
+            fact_text: "Project Alpha invoices require PO #123.",
+            valid_from_observation_id: "obs-1",
+          },
+        ],
+      },
+      resolveAlias: "openai/facts",
+    });
+
+    await runtime.extractFacts({
+      observations: [
+        observation("obs-1", "Project Alpha invoices require PO #123.", new Date("2026-06-01")),
+      ],
+      previousReflection: {
+        ...reflection(),
+        reflectionText: "FORGOTTEN_SECRET should never be available to fact extraction.",
+      },
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    const body = client.chatCompletion.mock.calls[0]?.[0] as {
+      messages: Array<{ content: string }>;
+    };
+    expect(JSON.stringify(body.messages)).not.toContain("FORGOTTEN_SECRET");
+    expect(JSON.stringify(body.messages)).not.toContain("previous_reflection");
+  });
+
+  it("falls back to deterministic facts when any LLM fact has a missing or invalid citation", async () => {
+    const { runtime, logs } = runtimeArgs({
+      response: {
+        facts: [
+          {
+            subject_text: "Hallucinated",
+            fact_text: "This fact has no valid supporting observation.",
+            valid_from_observation_id: "obs-missing",
+          },
+        ],
+      },
+      resolveAlias: "openai/facts",
+    });
+    const obsAt = new Date("2026-06-01T00:00:00Z");
+
+    const facts = await runtime.extractFacts({
+      observations: [observation("obs-1", "Project Alpha invoices require PO #123.", obsAt)],
+      previousReflection: null,
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(facts).toEqual([
+      {
+        subjectText: "project-alpha",
+        factText: "Project Alpha invoices require PO #123.",
+        validFrom: obsAt,
+        sourceObservationRange: ["obs-1", "obs-1"],
+      },
+    ]);
+    expect(logs.some((l) => l.line === "memory.llm.fact_citation_invalid")).toBe(true);
+  });
+
+  it("falls back to deterministic facts when an LLM fact omits valid_from_observation_id", async () => {
+    const { runtime } = runtimeArgs({
+      response: {
+        facts: [{ subject_text: "Hallucinated", fact_text: "This fact has no citation." }],
+      },
+      resolveAlias: "openai/facts",
+    });
+
+    const facts = await runtime.extractFacts({
+      observations: [
+        observation("obs-1", "Project Alpha invoices require PO #123.", new Date("2026-06-01")),
+      ],
+      previousReflection: null,
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(facts[0]?.factText).toBe("Project Alpha invoices require PO #123.");
   });
 
   it("falls back to deterministic fact extraction when the configured model is unavailable", async () => {

--- a/apps/gateway/src/memory-llm.test.ts
+++ b/apps/gateway/src/memory-llm.test.ts
@@ -1,0 +1,250 @@
+import type { ProviderClient } from "@helm/core";
+import type { Observation, RawMessage, Reflection } from "@helm/shared";
+import { MemoryLlmSchema } from "@helm/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createMemoryLlmRuntime } from "./memory-llm.js";
+
+function rawMessage(id: string, role: RawMessage["role"], content: string): RawMessage {
+  return {
+    id,
+    threadId: "thread-1",
+    role,
+    content,
+    tokenEstimate: Math.ceil(content.length / 4),
+    createdAt: new Date(`2026-06-0${id.slice(-1)}T00:00:00Z`),
+  };
+}
+
+function observation(id: string, text: string, observedAt: Date): Observation {
+  return {
+    id,
+    threadId: "thread-1",
+    sourceMessageRange: [`m-${id}-a`, `m-${id}-b`],
+    observationText: text,
+    observedAt,
+    priority: 1,
+    tags: ["project-alpha"],
+    referenceCount: 0,
+    importance: 0.5,
+    status: "active",
+    referencedAt: null,
+    archivedAt: null,
+    expiredAt: null,
+  };
+}
+
+function reflection(): Reflection {
+  return {
+    id: "refl-1",
+    projectId: "project-alpha",
+    resourceId: null,
+    threadId: null,
+    reflectionText: "Previous stable reflection.",
+    version: 1,
+    tokenEstimate: 7,
+    updatedAt: new Date("2026-06-01T00:00:00Z"),
+    referencedAt: null,
+    referenceCount: 0,
+    status: "active",
+  };
+}
+
+function providerWithJson(json: unknown): ProviderClient & {
+  chatCompletion: ReturnType<typeof vi.fn>;
+} {
+  const chatCompletion = vi.fn(async () => ({
+    choices: [{ message: { content: JSON.stringify(json) } }],
+  }));
+  return {
+    chatCompletion,
+    async *chatCompletionStream() {
+      // Memory LLM calls are non-streaming only.
+    },
+  };
+}
+
+function runtimeArgs(overrides: {
+  response: unknown;
+  resolveAlias?: string;
+  providerModel?: string;
+}) {
+  const client = providerWithJson(overrides.response);
+  const logs: Array<{ line: string; meta?: object }> = [];
+  const resolveModel = vi.fn((alias: string) =>
+    alias === (overrides.resolveAlias ?? "deepseek/memory-small")
+      ? { client, providerModel: overrides.providerModel ?? "memory-small" }
+      : null,
+  );
+  const runtime = createMemoryLlmRuntime({
+    config: MemoryLlmSchema.parse({
+      enabled: true,
+      model: "deepseek/memory-small",
+      observation_model: "openai/observer",
+      facts_model: "openai/facts",
+      timeout_ms: 1000,
+      temperature: 0,
+      max_tokens: { observation: 321, reflection: 654, facts: 987 },
+    }),
+    resolveModel,
+    estimateTokens: (text) => Math.ceil(text.length / 4),
+    log: (line, meta) => logs.push({ line, meta }),
+  });
+  return { runtime, client, resolveModel, logs };
+}
+
+describe("createMemoryLlmRuntime", () => {
+  it("keeps deterministic summarization when memory.llm.enabled is false", async () => {
+    const resolveModel = vi.fn();
+    const runtime = createMemoryLlmRuntime({
+      config: MemoryLlmSchema.parse({}),
+      resolveModel,
+      estimateTokens: (text) => Math.ceil(text.length / 4),
+      log: vi.fn(),
+    });
+
+    const result = await runtime.summarize({
+      messages: [
+        rawMessage("m1", "user", "Remember that invoices must use PO #123."),
+        rawMessage("m2", "assistant", "Got it."),
+      ],
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(result.observationText).toContain("user: Remember that invoices must use PO #123.");
+    expect(result.observationText).toContain("assistant: Got it.");
+    expect(resolveModel).not.toHaveBeenCalled();
+  });
+
+  it("uses the configured observation_model for observer compaction and parses JSON", async () => {
+    const { runtime, client, resolveModel } = runtimeArgs({
+      response: {
+        observation_text: "Invoices for Project Alpha require PO #123.",
+        priority: 3,
+        importance: 0.82,
+        tags: ["project-alpha", "billing"],
+      },
+      resolveAlias: "openai/observer",
+      providerModel: "gpt-observer",
+    });
+
+    const result = await runtime.summarize({
+      messages: [rawMessage("m1", "user", "Project Alpha invoices require PO #123.")],
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(resolveModel).toHaveBeenCalledWith("openai/observer");
+    expect(client.chatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-observer",
+        stream: false,
+        temperature: 0,
+        max_tokens: 321,
+        response_format: { type: "json_object" },
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result).toEqual({
+      observationText: "Invoices for Project Alpha require PO #123.",
+      priority: 3,
+      importance: 0.82,
+      tags: ["project-alpha", "billing"],
+    });
+  });
+
+  it("falls back to deterministic reflection compaction when the LLM returns invalid JSON", async () => {
+    const client: ProviderClient = {
+      chatCompletion: vi.fn(async () => ({ choices: [{ message: { content: "not json" } }] })),
+      async *chatCompletionStream() {},
+    };
+    const logs: Array<{ line: string; meta?: object }> = [];
+    const runtime = createMemoryLlmRuntime({
+      config: MemoryLlmSchema.parse({
+        enabled: true,
+        model: "deepseek/memory-small",
+        timeout_ms: 1000,
+      }),
+      resolveModel: () => ({ client, providerModel: "memory-small" }),
+      estimateTokens: (text) => Math.ceil(text.length / 4),
+      log: (line, meta) => logs.push({ line, meta }),
+    });
+    const observations = [
+      observation("obs-1", "User prefers concise English explanations.", new Date("2026-06-01")),
+    ];
+
+    const result = await runtime.merge({
+      observations,
+      previousReflection: reflection(),
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(result.reflectionText).toBe("- User prefers concise English explanations.");
+    expect(result.tokenEstimate).toBe(Math.ceil(result.reflectionText.length / 4));
+    expect(logs.some((l) => l.line === "memory.llm.fallback")).toBe(true);
+  });
+
+  it("maps fact valid_from_observation_id back to the supporting observation timestamp and id range", async () => {
+    const { runtime, client, resolveModel } = runtimeArgs({
+      response: {
+        facts: [
+          {
+            subject_text: "Project Alpha",
+            fact_text: "Project Alpha invoices require PO #123.",
+            valid_from_observation_id: "obs-2",
+          },
+        ],
+      },
+      resolveAlias: "openai/facts",
+      providerModel: "gpt-facts",
+    });
+    const obs1At = new Date("2026-06-01T00:00:00Z");
+    const obs2At = new Date("2026-06-02T00:00:00Z");
+
+    const facts = await runtime.extractFacts({
+      observations: [
+        observation("obs-1", "Project Alpha uses Net 30.", obs1At),
+        observation("obs-2", "Project Alpha invoices require PO #123.", obs2At),
+      ],
+      previousReflection: reflection(),
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(resolveModel).toHaveBeenCalledWith("openai/facts");
+    expect(client.chatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gpt-facts", max_tokens: 987 }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(facts).toEqual([
+      {
+        subjectText: "Project Alpha",
+        factText: "Project Alpha invoices require PO #123.",
+        validFrom: obs2At,
+        sourceObservationRange: ["obs-2", "obs-2"],
+      },
+    ]);
+  });
+
+  it("falls back to deterministic fact extraction when the configured model is unavailable", async () => {
+    const logs: Array<{ line: string; meta?: object }> = [];
+    const runtime = createMemoryLlmRuntime({
+      config: MemoryLlmSchema.parse({ enabled: true, model: "missing/model" }),
+      resolveModel: () => null,
+      estimateTokens: (text) => Math.ceil(text.length / 4),
+      log: (line, meta) => logs.push({ line, meta }),
+    });
+
+    const facts = await runtime.extractFacts({
+      observations: [
+        observation("obs-1", "Project Alpha invoices require PO #123.", new Date("2026-06-01")),
+      ],
+      previousReflection: null,
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(facts[0]).toMatchObject({
+      subjectText: "project-alpha",
+      factText: "Project Alpha invoices require PO #123.",
+      sourceObservationRange: ["obs-1", "obs-1"],
+    });
+    expect(logs.some((l) => l.line === "memory.llm.model_unavailable")).toBe(true);
+  });
+});

--- a/apps/gateway/src/memory-llm.ts
+++ b/apps/gateway/src/memory-llm.ts
@@ -1,0 +1,365 @@
+import type { ExtractedFact, ObserverDeps, ProviderClient, ReflectorDeps } from "@helm/core";
+import type { MemoryLlmConfig, Observation, RawMessage, Reflection } from "@helm/shared";
+import { z } from "zod";
+
+const MEMORY_SUMMARY_MAX_CHARS = 2000;
+const MEMORY_REFLECTION_MAX_CHARS = 4000;
+
+const ObservationOutputSchema = z.object({
+  observation_text: z.string().min(1),
+  priority: z.number().int().min(1).max(5).optional(),
+  importance: z.number().min(0).max(1).optional(),
+  tags: z.array(z.string().min(1)).optional(),
+});
+
+const ReflectionOutputSchema = z.object({
+  reflection_text: z.string().min(1),
+});
+
+const FactOutputSchema = z.object({
+  subject_text: z.string().min(1),
+  fact_text: z.string().min(1),
+  valid_from_observation_id: z.string().min(1).optional(),
+  source_observation_id: z.string().min(1).optional(),
+});
+
+const FactsOutputSchema = z.object({
+  facts: z.array(FactOutputSchema).default([]),
+});
+
+type ObservationOutput = z.infer<typeof ObservationOutputSchema>;
+type ReflectionOutput = z.infer<typeof ReflectionOutputSchema>;
+type FactsOutput = z.infer<typeof FactsOutputSchema>;
+
+export interface MemoryModelResolution {
+  client: ProviderClient;
+  providerModel: string;
+}
+
+export interface CreateMemoryLlmRuntimeDeps {
+  config: MemoryLlmConfig;
+  resolveModel: (alias: string) => MemoryModelResolution | null;
+  estimateTokens: (text: string) => number;
+  log: (line: string, meta?: object) => void;
+}
+
+export interface MemoryLlmRuntime {
+  summarize: ObserverDeps["summarize"];
+  merge: ReflectorDeps["merge"];
+  extractFacts: NonNullable<ReflectorDeps["extractFacts"]>;
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}\u2026` : text;
+}
+
+export function summarizeMessagesDeterministic(messages: readonly RawMessage[]): string {
+  const body = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
+  return truncate(body || "(no messages)", MEMORY_SUMMARY_MAX_CHARS);
+}
+
+export function mergeObservationsDeterministic(
+  observations: readonly Observation[],
+  _previousReflection: Reflection | null,
+): string {
+  const body = observations.map((o) => `- ${o.observationText}`).join("\n");
+  return truncate(body || "(no observations)", MEMORY_REFLECTION_MAX_CHARS);
+}
+
+export function extractFactsDeterministic(observations: readonly Observation[]): ExtractedFact[] {
+  const facts: ExtractedFact[] = [];
+  for (const o of observations) {
+    const text = o.observationText.trim();
+    if (text.length === 0 || text === "[pruned]") continue;
+    const subjectText = o.tags?.[0]?.trim() || text.split(/\s+/).slice(0, 6).join(" ") || "general";
+    facts.push({
+      subjectText,
+      factText: truncate(text, MEMORY_REFLECTION_MAX_CHARS),
+      validFrom: o.observedAt,
+      sourceObservationRange: [o.id, o.id],
+    });
+  }
+  return facts;
+}
+
+function cleanTags(tags: string[] | undefined): string[] | undefined {
+  if (!tags) return undefined;
+  const cleaned = [...new Set(tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0))].slice(
+    0,
+    16,
+  );
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+function assistantTextFromCompletion(response: Record<string, unknown>): string {
+  const choices = response.choices;
+  if (Array.isArray(choices) && choices.length > 0) {
+    const choice = choices[0] as Record<string, unknown>;
+    const message = choice.message;
+    if (message && typeof message === "object") {
+      const content = (message as Record<string, unknown>).content;
+      if (typeof content === "string") return content;
+      if (Array.isArray(content)) {
+        return content
+          .map((part) => {
+            if (typeof part === "string") return part;
+            if (part && typeof part === "object") {
+              const p = part as Record<string, unknown>;
+              if (typeof p.text === "string") return p.text;
+              if (typeof p.content === "string") return p.content;
+            }
+            return "";
+          })
+          .join("");
+      }
+    }
+  }
+  const outputText = response.output_text;
+  return typeof outputText === "string" ? outputText : "";
+}
+
+function parseJsonObject(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) throw new Error("empty LLM response");
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const candidate = (fenced?.[1] ?? trimmed).trim();
+  try {
+    return JSON.parse(candidate);
+  } catch (err) {
+    const start = candidate.indexOf("{");
+    const end = candidate.lastIndexOf("}");
+    if (start >= 0 && end > start) return JSON.parse(candidate.slice(start, end + 1));
+    throw err;
+  }
+}
+
+function safeError(err: unknown): string {
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}
+
+function taskModel(config: MemoryLlmConfig, task: "observation" | "reflection" | "facts") {
+  switch (task) {
+    case "observation":
+      return config.observation_model ?? config.model;
+    case "reflection":
+      return config.reflection_model ?? config.model;
+    case "facts":
+      return config.facts_model ?? config.model;
+  }
+}
+
+async function callJsonModel<T>(args: {
+  deps: CreateMemoryLlmRuntimeDeps;
+  task: "observation" | "reflection" | "facts";
+  maxTokens: number;
+  messages: Array<{ role: "system" | "user"; content: string }>;
+  schema: z.ZodType<T>;
+  fallback: () => T;
+}): Promise<T> {
+  const { deps, task, maxTokens, messages, schema, fallback } = args;
+  if (deps.config.enabled !== true) return fallback();
+  const modelAlias = taskModel(deps.config, task);
+  if (!modelAlias) return fallback();
+
+  const resolved = deps.resolveModel(modelAlias);
+  if (!resolved) {
+    deps.log("memory.llm.model_unavailable", { task, model_alias: modelAlias });
+    return fallback();
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), deps.config.timeout_ms);
+  try {
+    const response = await resolved.client.chatCompletion(
+      {
+        model: resolved.providerModel,
+        messages,
+        temperature: deps.config.temperature,
+        stream: false,
+        max_tokens: maxTokens,
+        response_format: { type: "json_object" },
+      },
+      { signal: controller.signal },
+    );
+    const text = assistantTextFromCompletion(response);
+    const parsed = schema.parse(parseJsonObject(text));
+    deps.log("memory.llm.completed", { task, model_alias: modelAlias });
+    return parsed;
+  } catch (err) {
+    deps.log("memory.llm.fallback", {
+      task,
+      model_alias: modelAlias,
+      error: safeError(err),
+    });
+    return fallback();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function observationPrompt(input: { messages: RawMessage[]; now: Date }) {
+  return [
+    {
+      role: "system" as const,
+      content:
+        "Compress conversation turns into one durable memory observation. Return strict JSON only.",
+    },
+    {
+      role: "user" as const,
+      content: JSON.stringify({
+        now: input.now.toISOString(),
+        schema: {
+          observation_text: "string, one concise durable memory",
+          priority: "integer 1..5, optional",
+          importance: "number 0..1, optional",
+          tags: ["short lowercase tags, optional"],
+        },
+        messages: input.messages.map((m) => ({
+          id: m.id,
+          role: m.role,
+          content: m.content,
+          created_at: m.createdAt.toISOString(),
+        })),
+      }),
+    },
+  ];
+}
+
+function reflectionPrompt(input: {
+  observations: Observation[];
+  previousReflection: Reflection | null;
+  now: Date;
+}) {
+  return [
+    {
+      role: "system" as const,
+      content:
+        "Merge active memory observations into a stable, non-duplicative reflection. Return strict JSON only.",
+    },
+    {
+      role: "user" as const,
+      content: JSON.stringify({
+        now: input.now.toISOString(),
+        schema: { reflection_text: "string, concise stable reflection" },
+        previous_reflection: input.previousReflection?.reflectionText ?? null,
+        observations: input.observations.map((o) => ({
+          id: o.id,
+          observed_at: o.observedAt.toISOString(),
+          text: o.observationText,
+          tags: o.tags ?? [],
+        })),
+      }),
+    },
+  ];
+}
+
+function factsPrompt(input: {
+  observations: Observation[];
+  previousReflection: Reflection | null;
+  now: Date;
+}) {
+  return [
+    {
+      role: "system" as const,
+      content: "Extract atomic, durable facts from memory observations. Return strict JSON only.",
+    },
+    {
+      role: "user" as const,
+      content: JSON.stringify({
+        now: input.now.toISOString(),
+        schema: {
+          facts: [
+            {
+              subject_text: "topic string",
+              fact_text: "atomic assertion string",
+              valid_from_observation_id: "id of the supporting observation",
+            },
+          ],
+        },
+        previous_reflection: input.previousReflection?.reflectionText ?? null,
+        observations: input.observations.map((o) => ({
+          id: o.id,
+          observed_at: o.observedAt.toISOString(),
+          text: o.observationText,
+          tags: o.tags ?? [],
+        })),
+      }),
+    },
+  ];
+}
+
+export function createMemoryLlmRuntime(deps: CreateMemoryLlmRuntimeDeps): MemoryLlmRuntime {
+  return {
+    summarize: async (input) => {
+      const parsed = await callJsonModel<ObservationOutput>({
+        deps,
+        task: "observation",
+        maxTokens: deps.config.max_tokens.observation,
+        messages: observationPrompt(input),
+        schema: ObservationOutputSchema,
+        fallback: () => ({ observation_text: summarizeMessagesDeterministic(input.messages) }),
+      });
+      const tags = cleanTags(parsed.tags);
+      return {
+        observationText: parsed.observation_text.trim(),
+        ...(parsed.priority !== undefined ? { priority: parsed.priority } : {}),
+        ...(parsed.importance !== undefined ? { importance: parsed.importance } : {}),
+        ...(tags !== undefined ? { tags } : {}),
+      };
+    },
+    merge: async (input) => {
+      const parsed = await callJsonModel<ReflectionOutput>({
+        deps,
+        task: "reflection",
+        maxTokens: deps.config.max_tokens.reflection,
+        messages: reflectionPrompt(input),
+        schema: ReflectionOutputSchema,
+        fallback: () => ({
+          reflection_text: mergeObservationsDeterministic(
+            input.observations,
+            input.previousReflection,
+          ),
+        }),
+      });
+      const reflectionText = parsed.reflection_text.trim();
+      return { reflectionText, tokenEstimate: deps.estimateTokens(reflectionText) };
+    },
+    extractFacts: async (input) => {
+      const parsed = await callJsonModel<FactsOutput>({
+        deps,
+        task: "facts",
+        maxTokens: deps.config.max_tokens.facts,
+        messages: factsPrompt(input),
+        schema: FactsOutputSchema,
+        fallback: () => ({
+          facts: extractFactsDeterministic(input.observations).map((fact) => ({
+            subject_text: fact.subjectText,
+            fact_text: fact.factText,
+            valid_from_observation_id: fact.sourceObservationRange?.[0],
+          })),
+        }),
+      });
+      const byObservationId = new Map(input.observations.map((o) => [o.id, o]));
+      return parsed.facts.flatMap((fact, index): ExtractedFact[] => {
+        const subjectText = fact.subject_text.trim();
+        const factText = fact.fact_text.trim();
+        if (!subjectText || !factText) return [];
+        const sourceId = fact.valid_from_observation_id ?? fact.source_observation_id;
+        const supporting =
+          (sourceId ? byObservationId.get(sourceId) : undefined) ??
+          input.observations[Math.min(index, Math.max(0, input.observations.length - 1))];
+        return [
+          {
+            subjectText,
+            factText,
+            validFrom: supporting?.observedAt ?? input.now,
+            ...(supporting !== undefined
+              ? { sourceObservationRange: [supporting.id, supporting.id] as [string, string] }
+              : {}),
+          },
+        ];
+      });
+    },
+  };
+}

--- a/apps/gateway/src/memory-llm.ts
+++ b/apps/gateway/src/memory-llm.ts
@@ -6,21 +6,21 @@ const MEMORY_SUMMARY_MAX_CHARS = 2000;
 const MEMORY_REFLECTION_MAX_CHARS = 4000;
 
 const ObservationOutputSchema = z.object({
-  observation_text: z.string().min(1),
-  priority: z.number().int().min(1).max(5).optional(),
+  observation_text: z.string().trim().min(1),
+  // Matches runObserverJob's priority/10 salience derivation.
+  priority: z.number().int().min(0).max(10).optional(),
   importance: z.number().min(0).max(1).optional(),
-  tags: z.array(z.string().min(1)).optional(),
+  tags: z.array(z.string().trim().min(1)).optional(),
 });
 
 const ReflectionOutputSchema = z.object({
-  reflection_text: z.string().min(1),
+  reflection_text: z.string().trim().min(1),
 });
 
 const FactOutputSchema = z.object({
-  subject_text: z.string().min(1),
-  fact_text: z.string().min(1),
-  valid_from_observation_id: z.string().min(1).optional(),
-  source_observation_id: z.string().min(1).optional(),
+  subject_text: z.string().trim().min(1),
+  fact_text: z.string().trim().min(1),
+  valid_from_observation_id: z.string().trim().min(1),
 });
 
 const FactsOutputSchema = z.object({
@@ -211,7 +211,7 @@ function observationPrompt(input: { messages: RawMessage[]; now: Date }) {
         now: input.now.toISOString(),
         schema: {
           observation_text: "string, one concise durable memory",
-          priority: "integer 1..5, optional",
+          priority: "integer 0..10, optional",
           importance: "number 0..1, optional",
           tags: ["short lowercase tags, optional"],
         },
@@ -226,11 +226,7 @@ function observationPrompt(input: { messages: RawMessage[]; now: Date }) {
   ];
 }
 
-function reflectionPrompt(input: {
-  observations: Observation[];
-  previousReflection: Reflection | null;
-  now: Date;
-}) {
+function reflectionPrompt(input: { observations: Observation[]; now: Date }) {
   return [
     {
       role: "system" as const,
@@ -242,7 +238,6 @@ function reflectionPrompt(input: {
       content: JSON.stringify({
         now: input.now.toISOString(),
         schema: { reflection_text: "string, concise stable reflection" },
-        previous_reflection: input.previousReflection?.reflectionText ?? null,
         observations: input.observations.map((o) => ({
           id: o.id,
           observed_at: o.observedAt.toISOString(),
@@ -254,11 +249,7 @@ function reflectionPrompt(input: {
   ];
 }
 
-function factsPrompt(input: {
-  observations: Observation[];
-  previousReflection: Reflection | null;
-  now: Date;
-}) {
+function factsPrompt(input: { observations: Observation[]; now: Date }) {
   return [
     {
       role: "system" as const,
@@ -277,7 +268,6 @@ function factsPrompt(input: {
             },
           ],
         },
-        previous_reflection: input.previousReflection?.reflectionText ?? null,
         observations: input.observations.map((o) => ({
           id: o.id,
           observed_at: o.observedAt.toISOString(),
@@ -313,7 +303,7 @@ export function createMemoryLlmRuntime(deps: CreateMemoryLlmRuntimeDeps): Memory
         deps,
         task: "reflection",
         maxTokens: deps.config.max_tokens.reflection,
-        messages: reflectionPrompt(input),
+        messages: reflectionPrompt({ observations: input.observations, now: input.now }),
         schema: ReflectionOutputSchema,
         fallback: () => ({
           reflection_text: mergeObservationsDeterministic(
@@ -330,35 +320,44 @@ export function createMemoryLlmRuntime(deps: CreateMemoryLlmRuntimeDeps): Memory
         deps,
         task: "facts",
         maxTokens: deps.config.max_tokens.facts,
-        messages: factsPrompt(input),
+        messages: factsPrompt({ observations: input.observations, now: input.now }),
         schema: FactsOutputSchema,
         fallback: () => ({
-          facts: extractFactsDeterministic(input.observations).map((fact) => ({
-            subject_text: fact.subjectText,
-            fact_text: fact.factText,
-            valid_from_observation_id: fact.sourceObservationRange?.[0],
-          })),
+          facts: extractFactsDeterministic(input.observations).flatMap((fact) => {
+            const sourceObservationId = fact.sourceObservationRange?.[0];
+            if (sourceObservationId === undefined) return [];
+            return [
+              {
+                subject_text: fact.subjectText,
+                fact_text: fact.factText,
+                valid_from_observation_id: sourceObservationId,
+              },
+            ];
+          }),
         }),
       });
       const byObservationId = new Map(input.observations.map((o) => [o.id, o]));
-      return parsed.facts.flatMap((fact, index): ExtractedFact[] => {
-        const subjectText = fact.subject_text.trim();
-        const factText = fact.fact_text.trim();
-        if (!subjectText || !factText) return [];
-        const sourceId = fact.valid_from_observation_id ?? fact.source_observation_id;
-        const supporting =
-          (sourceId ? byObservationId.get(sourceId) : undefined) ??
-          input.observations[Math.min(index, Math.max(0, input.observations.length - 1))];
-        return [
-          {
-            subjectText,
-            factText,
-            validFrom: supporting?.observedAt ?? input.now,
-            ...(supporting !== undefined
-              ? { sourceObservationRange: [supporting.id, supporting.id] as [string, string] }
-              : {}),
-          },
-        ];
+      const invalidCitation = parsed.facts.find(
+        (fact) => !byObservationId.has(fact.valid_from_observation_id),
+      );
+      if (invalidCitation !== undefined) {
+        deps.log("memory.llm.fact_citation_invalid", {
+          observation_id: invalidCitation.valid_from_observation_id,
+        });
+        return extractFactsDeterministic(input.observations);
+      }
+      return parsed.facts.map((fact): ExtractedFact => {
+        const supporting = byObservationId.get(fact.valid_from_observation_id);
+        if (supporting === undefined) {
+          // Guarded above; keep the type invariant explicit.
+          throw new Error("memory LLM fact citation disappeared");
+        }
+        return {
+          subjectText: fact.subject_text,
+          factText: fact.fact_text,
+          validFrom: supporting.observedAt,
+          sourceObservationRange: [supporting.id, supporting.id],
+        };
       });
     },
   };

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -80,16 +80,14 @@ import type {
   ClassifierConfig,
   ErrorClass,
   InternalRequest,
-  Observation,
   ProviderConfig as ProviderConfigShared,
-  RawMessage,
-  Reflection,
   RuntimeSettings,
 } from "@helm/shared";
 import { ErrorClassSchema, isOAuthPreset } from "@helm/shared";
 import { createApp } from "./app.js";
 import { readBuildInfo } from "./build-info.js";
 import { createJsonLogger, type Logger } from "./logging.js";
+import { createMemoryLlmRuntime, type MemoryModelResolution } from "./memory-llm.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { basicAuth, resolveAdminAuth, warnIfAdminUnconfigured } from "./middleware/basic-auth.js";
 import { concurrencyMiddleware, createConcurrencyGate } from "./middleware/concurrency.js";
@@ -130,80 +128,6 @@ export interface ServerHandle {
   // Stop background workers (e.g. the Agentic Signals scheduler). Optional and
   // safe to skip — the timers are unref'd so they never block process exit.
   dispose?: () => void;
-}
-
-// D11 — DETERMINISTIC, non-LLM summarize/merge for the MVP memory background jobs.
-// A real LLM path is a follow-up issue; until then these keep reflection text a
-// pure function of its inputs so the Reflector only bumps a version on a genuine
-// content change (cache-friendly, docs/08 "reflections should be stable and slow-changing").
-const MEMORY_SUMMARY_MAX_CHARS = 2000;
-const MEMORY_REFLECTION_MAX_CHARS = 4000;
-
-function truncate(text: string, max: number): string {
-  return text.length > max ? `${text.slice(0, max)}…` : text;
-}
-
-// Compress a slice of raw messages into one observation: concatenate the turns in
-// order (role-tagged), truncated to a cap. Deterministic — same input → same text.
-function summarizeMessages(messages: readonly RawMessage[]): string {
-  const body = messages.map((m) => `${m.role}: ${m.content}`).join("\n");
-  return truncate(body || "(no messages)", MEMORY_SUMMARY_MAX_CHARS);
-}
-
-// Merge a scope's observations (oldest-first) into one reflection text. Existing
-// reflection text is NOT re-prepended (it was already derived from earlier
-// observations) — we re-derive from the current observation set so the output is a
-// stable function of inputs. previousReflection is accepted for signature parity.
-function mergeObservations(
-  observations: readonly Observation[],
-  _previousReflection: Reflection | null,
-): string {
-  const body = observations.map((o) => `- ${o.observationText}`).join("\n");
-  return truncate(body || "(no observations)", MEMORY_REFLECTION_MAX_CHARS);
-}
-
-// docs/12 P6 (Codex review fix #4) — the DETERMINISTIC fact extractor wired into
-// the Reflector, mirroring the summarize/merge MVP stubs above: a real LLM
-// extractor that atomizes claims is the follow-up (docs/08 "real LLM … deferred"),
-// but the pipeline must be genuinely LIVE when forgetting.enabled, not dead config.
-// It surfaces one candidate fact per active observation — subject from its first
-// tag (else a slug of the leading words, the same key the Reflector normalizes for
-// same-subject supersede), assertion = the observation text. Pure + deterministic
-// (same observations → same facts), so content-hash dedup + supersede are stable.
-// Inert by default: the Reflector only calls this when the flag is on AND the
-// active-observation token sum crosses `consolidate.trigger_tokens`.
-function extractFactsFromObservations(observations: readonly Observation[]): Array<{
-  subjectText: string;
-  factText: string;
-  validFrom: Date;
-  sourceObservationRange: [string, string];
-}> {
-  const facts: Array<{
-    subjectText: string;
-    factText: string;
-    validFrom: Date;
-    sourceObservationRange: [string, string];
-  }> = [];
-  for (const o of observations) {
-    const text = o.observationText.trim();
-    if (text.length === 0 || text === "[pruned]") continue;
-    const subjectText = o.tags?.[0]?.trim() || text.split(/\s+/).slice(0, 6).join(" ") || "general";
-    facts.push({
-      subjectText,
-      factText: truncate(text, MEMORY_REFLECTION_MAX_CHARS),
-      // The fact became true when its observation was recorded — drives supersede
-      // ordering (Codex review fix), NOT the processing wall-clock.
-      validFrom: o.observedAt,
-      // Audit trail = the OBSERVATION's id (memory_facts.source_observation_range is
-      // [firstObservationId, lastObservationId] per the schema), NOT the raw
-      // message-id range — one fact derives from one observation here, so both ends
-      // are this observation's id. Codex review fix: previously stored
-      // o.sourceMessageRange (raw message ids), which would join against the wrong
-      // table.
-      sourceObservationRange: [o.id, o.id],
-    });
-  }
-  return facts;
 }
 
 // Pre-classification TPM token estimator. Extracted to middleware/estimate-tokens
@@ -861,44 +785,6 @@ export async function buildServer(
     Number.isFinite(injectTokenBudgetRaw) && injectTokenBudgetRaw > 0 ? injectTokenBudgetRaw : 4000;
   const inject = { deps: injectDeps, tokenBudget: injectTokenBudget };
 
-  // Observer/Reflector deps (docs/08 Phase 2). D11: MVP uses DETERMINISTIC, non-LLM
-  // summarize/merge (concatenate + truncate) so a reflection version only bumps on a
-  // real content change (cache-friendly); a real LLM path is a follow-up issue.
-  const observerDeps: ObserverDeps = {
-    memoryStore: store.memory,
-    summarize: async ({ messages }) => ({
-      observationText: summarizeMessages(messages),
-    }),
-    costSink: () => {},
-    // Auto-compaction price resolution: resolve the thread's stamped model alias
-    // against the runtime catalog. The closure captures `catalog` (declared later
-    // in this same scope, built before the worker starts), so prices are looked
-    // up per job from live catalog data instead of hand-tuned config.
-    resolvePricing: (alias) => resolveCompactionPricing(catalog, alias),
-    // Optional trigger overrides (config.memory.compaction). Empty by default —
-    // the internal AUTO_PRIORS apply; a written key is the only thing that wins.
-    compaction: config.memory.compaction,
-    now: () => new Date(),
-    log: memoryLog,
-  };
-  const reflectorDeps: ReflectorDeps = {
-    memoryStore: store.memory,
-    merge: async ({ observations, previousReflection }) => {
-      const reflectionText = mergeObservations(observations, previousReflection);
-      return { reflectionText, tokenEstimate: estimateMemoryTokens(reflectionText) };
-    },
-    costSink: () => {},
-    now: () => new Date(),
-    log: memoryLog,
-    // docs/12 P6 (Codex review fix #4) — wire the consolidate config + the
-    // deterministic extractor so fact extraction is LIVE when forgetting.enabled
-    // (default off ⇒ inert: the Reflector's gates short-circuit before any fact
-    // work, so this is byte-identical to today). `estimateTokens` matches the
-    // Observer/Reflector heuristic used for the consolidate trigger.
-    forgetting: forgettingCfg,
-    extractFacts: async ({ observations }) => extractFactsFromObservations(observations),
-    estimateTokens: estimateMemoryTokens,
-  };
   // Decay-sweep deps (docs/12 P5). The whole forgetting config drives the pure score +
   // archive threshold + the bounded-loop limits; gated behind forgetting.enabled so the
   // worker only ever receives a 'decay' job (and only ever triggers one) when the flag
@@ -1188,6 +1074,58 @@ export async function buildServer(
     lanes,
     fallbackBaseUrl,
   );
+  const resolveMemoryLlmModel = (alias: string): MemoryModelResolution | null => {
+    const slash = alias.indexOf("/");
+    const prefix = slash > 0 ? alias.slice(0, slash) : "";
+    if (prefix && ROUTABLE_OAUTH_IDS.has(prefix)) {
+      if (!oauthAliasSet.has(alias)) return null;
+      const client = providerClients.get(prefix);
+      return client ? { client, providerModel: alias.slice(slash + 1) } : null;
+    }
+
+    const resolved = registry.resolve(alias);
+    if (resolved.ok) {
+      const client = providerClients.get(resolved.value.providerName);
+      return client ? { client, providerModel: resolved.value.providerModel } : null;
+    }
+    if (prefix && providerClients.has(prefix)) {
+      const client = providerClients.get(prefix);
+      return client ? { client, providerModel: alias.slice(slash + 1) } : null;
+    }
+    return { client: provider, providerModel: alias };
+  };
+  const memoryLlm = createMemoryLlmRuntime({
+    config: config.memory.llm,
+    resolveModel: resolveMemoryLlmModel,
+    estimateTokens: estimateMemoryTokens,
+    log: memoryLog,
+  });
+
+  // Observer/Reflector deps (docs/08 Phase 2). The LLM path is opt-in via
+  // config.memory.llm and runs ONLY in these background jobs; disabled or failed
+  // model calls use the deterministic stubs in memory-llm.ts.
+  const observerDeps: ObserverDeps = {
+    memoryStore: store.memory,
+    summarize: memoryLlm.summarize,
+    costSink: () => {},
+    // Auto-compaction price resolution: resolve the thread's stamped model alias
+    // against the runtime catalog. Unknown aliases fall back to deterministic
+    // heuristics inside resolveCompactionPricing.
+    resolvePricing: (alias) => resolveCompactionPricing(catalog, alias),
+    compaction: config.memory.compaction,
+    now: () => new Date(),
+    log: memoryLog,
+  };
+  const reflectorDeps: ReflectorDeps = {
+    memoryStore: store.memory,
+    merge: memoryLlm.merge,
+    costSink: () => {},
+    now: () => new Date(),
+    log: memoryLog,
+    forgetting: forgettingCfg,
+    extractFacts: memoryLlm.extractFacts,
+    estimateTokens: estimateMemoryTokens,
+  };
   const breaker = createCircuitBreaker({
     config: { failureThreshold: 5, cooldownMs: 30_000 },
     now: () => Date.now(),

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -16,6 +16,25 @@
 #   min_recent_messages: 4      # keep floor: at least this many recent messages…
 #   min_keep_ratio: 0.25        # …and this fraction of the segment stay raw
 
+# Optional LLM-backed memory formation/extraction. Disabled keeps the
+# deterministic local summarizer/merger/fact extractor. When enabled, the worker
+# calls the configured model only from background observer/reflector jobs; runtime
+# failures, invalid JSON, or unavailable models fall back to deterministic output.
+#
+# llm:
+#   enabled: false
+#   model: deepseek/deepseek-v4-flash      # base model for all memory LLM tasks
+#   # Optional per-task overrides:
+#   # observation_model: openai/gpt-4.1-mini
+#   # reflection_model: openai/gpt-4.1-mini
+#   # facts_model: openai/gpt-4.1-nano
+#   timeout_ms: 30000
+#   temperature: 0
+#   max_tokens:
+#     observation: 800
+#     reflection: 1200
+#     facts: 1000
+
 # Memory forgetting layer (docs/12). enabled:false = byte-identical to pre-docs/12
 # behaviour; flip to true to turn on decay/reinforcement/facts. All knobs are
 # fail-closed validated (snake_case, unknown keys refuse startup).

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -13,6 +13,7 @@
 - **修复**：新增 `memory.llm` 配置子树（默认 `enabled:false`），支持 `model` 基础模型与 `observation_model` / `reflection_model` / `facts_model` 分任务覆盖；同组 `HELM_MEMORY_LLM_*` 环境变量可覆盖模型/开关/超时/温度/max_tokens。网关新增 `memory-llm.ts`，后台 Observer 用 LLM 压缩 raw messages -> observation，Reflector 用 LLM 合并 observations -> reflection，并用 LLM 提取 atomic facts。
 - **安全/降级**：LLM 调用只发生在 memory worker 后台 job，绝不进请求路径；配置错误 fail-closed（Zod strict + enabled 必须有 model），运行时模型不可用、上游失败、超时或 JSON 无效全部 fail-open 回原确定性 stub。日志只写 task/model alias/error class 等安全元数据，不写 prompt/response/memory 正文。
 - **模型解析**：memory model alias 复用执行层语义：OAuth 订阅别名受 live `oauthAliasSet` gate，providers.yaml alias 经 registry 解析，`provider/model` 结构化别名走对应 provider client，裸模型名走 primary provider passthrough；不会因为记忆任务跨过订阅/凭证边界。
+- **PR 评审修复**：LLM merge/fact prompt 不再包含 `previous_reflection`，避免旧 reflection 中已归档/剪枝内容绕过 active-observation filter 复活；LLM facts 强制 `valid_from_observation_id` 且必须命中 active observation，否则整次回退确定性 extractor；observation/reflection/fact 文本改 trim 后 min(1)，纯空白输出触发 fallback；LLM `priority` 标尺改 0–10，对齐 Observer 的 `priority/10` salience 推导。
 - **测试/取舍**：TDD 覆盖 schema 默认关闭与 fail-closed、loader YAML/env 覆盖、observer 使用配置模型、reflection JSON 无效 fallback、fact `valid_from_observation_id` 映射 observation 时间与 `[obs_id, obs_id]` 审计范围、模型不可用 fallback。暂不把 LLM usage 精确计入 cost bucket，沿用 observer/reflector 现有启发式 token 账本；后续若要精确计费可扩展 deps 成本接口。
 
 ---

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-09 · LLM 记忆提取/压缩接线与可配置模型（docs/08 记忆；docs/12 遗忘/事实层；CLAUDE.md 原则 2/3/7）
+
+- **缘起**：记忆 observe/inject、worker、compaction trigger、forgetting/facts 已是生产接线，但 Observer/Reflector 仍用确定性 stub 做 summarize/merge/extractFacts；这让“记忆提取/压缩”可用但不具备真正 LLM 归纳能力。
+- **修复**：新增 `memory.llm` 配置子树（默认 `enabled:false`），支持 `model` 基础模型与 `observation_model` / `reflection_model` / `facts_model` 分任务覆盖；同组 `HELM_MEMORY_LLM_*` 环境变量可覆盖模型/开关/超时/温度/max_tokens。网关新增 `memory-llm.ts`，后台 Observer 用 LLM 压缩 raw messages -> observation，Reflector 用 LLM 合并 observations -> reflection，并用 LLM 提取 atomic facts。
+- **安全/降级**：LLM 调用只发生在 memory worker 后台 job，绝不进请求路径；配置错误 fail-closed（Zod strict + enabled 必须有 model），运行时模型不可用、上游失败、超时或 JSON 无效全部 fail-open 回原确定性 stub。日志只写 task/model alias/error class 等安全元数据，不写 prompt/response/memory 正文。
+- **模型解析**：memory model alias 复用执行层语义：OAuth 订阅别名受 live `oauthAliasSet` gate，providers.yaml alias 经 registry 解析，`provider/model` 结构化别名走对应 provider client，裸模型名走 primary provider passthrough；不会因为记忆任务跨过订阅/凭证边界。
+- **测试/取舍**：TDD 覆盖 schema 默认关闭与 fail-closed、loader YAML/env 覆盖、observer 使用配置模型、reflection JSON 无效 fallback、fact `valid_from_observation_id` 映射 observation 时间与 `[obs_id, obs_id]` 审计范围、模型不可用 fallback。暂不把 LLM usage 精确计入 cost bucket，沿用 observer/reflector 现有启发式 token 账本；后续若要精确计费可扩展 deps 成本接口。
+
+---
+
 ## 2026-06-09 · Agentic Signals 反馈接入 ranked-lane 路由（docs/02 架构；docs/04 路由；docs/07 可观测性）
 
 - **缘起**：路线图里 `RoutingSignal` 聚合、sqlite/pg store 与后台 collector 已存在，但请求路径从不读取信号，导致 Agentic Signals 只能观测不能反馈，仍属于“未接线”功能。
@@ -27,27 +37,11 @@
 
 ---
 
-## 2026-06-08 · 四协议完整性审计 + 逐条修复（workflow 扇出审计 → worktree TDD 实现；docs/05 协议互译；CLAUDE.md 原则 5/7/8）
-
-- **缘起**：用 Workflow 扇出审计 helm 4 个 wire 协议（openai chat `/v1/chat/completions`、anthropic messages `/v1/messages`、openai-responses `/v1/responses`、gemini `/v1beta/models`）+ 统一 IR/流式核心，对照 `litellm` 参考实现找完整性缺口。51 个 agent（5 审计 + 逐发现对抗式核验 + 综合）确认 **36 条真实缺口**，去重成 **31 项依赖排序修复计划**（审计产物含本机绝对路径+修复前推理，**不签入**，完整记录见 workflow run transcript / git history）。在 git worktree（`worktree-protocol-completeness`）里 TDD 红→绿逐条实现；**修复全程留在主循环串行做**（不并行 edit agent——避免 [[workflow-shared-tree-revert-risk]] 的静默回退）。
-- **核心洞察（综合 agent）**：IR 设计本身够用——几乎所有缺口都是 transformer **没读** IR 已持有的字段，或**静默丢弃**而非记 `data_loss` 警告。故先改 IR/共享核心（order 1-8），再改依赖它们的各协议。
-- **已完成 29/31（按 tier）**：
-  - **共享 IR/核心**：Responses `text.format` → 规范 OpenAI `response_format.{type,json_schema}`（keystone：此前 Responses 结构化输出路由到 Anthropic/Gemini 被静默丢）；`service_tier`/`max_completion_tokens`/`logprobs.refusal` 进 IR（IR 无 `.catchall`，不显式加就被 inbound parse 剥掉）；OpenAI 出站从扁平 `reasoning_tokens` 反补 `completion_tokens_details`；anthropic mapStopReason 空值守卫（**已正确，加回归锁**）；protocol-guards 给 anthropic 加 `frequency_penalty/presence_penalty/seed/cache_control` 的 data_loss 警告。
-  - **Anthropic**：`REASONING_EFFORT_TO_BUDGET` 修成 litellm 精确值（minimal/low=1024、medium=2048、high=4096——原值 2-4× 虚高，**直接计费影响**）；`parallel_tool_calls:false` → `disable_parallel_tool_use`；`metadata` 出站回放；`cache_creation_input_tokens` 上 message_delta 流；per-block `cache_control` 经 IR 往返。
-  - **OpenAI chat**：`stream_options.include_usage` 终止 usage chunk——**在 provider 层** `translateAnthropicSSE` + `translateResponsesSSE` 补发 `{choices:[],usage}` 终帧（此前两 provider 把 Anthropic/Responses→OpenAI SSE 时丢掉了 usage，OpenAI 客户端 + budget settle 拿不到 token 数）；`response_format` json_schema fail-closed 校验；`openaiIndex` 上 IRToolCall（流式合成保序）。
-  - **Responses**：reasoning config→`reasoning_effort`、truncation、`incomplete_details.reason`、output_text annotations（双向）、`output_tokens_details.reasoning_tokens`（非流式+流式）、choice logprobs 上 output_text、**`response.incomplete` 独立终止事件**（此前总发 `response.completed{status:incomplete}`，不符 OpenAI 线协议；同步改反向 consumer + 2 个既有测试）、多模态出站保留（不再塌成纯文本）。
-  - **Gemini**：`TOOL_CALLS` finish_reason（非流式 STOP+functionCall 重映射 + 流式 hasSeenToolCalls 终止重映射）；流式 `promptFeedback.blockReason`→content_filter；`cacheTokensDetails` 解析进 cached（此前只读聚合 `cachedContentTokenCount`）；未知 modality token 不丢（catch-all 键）。
-- **order 22/30（最初暂缓，后用户要求全部补齐，已完成）**：
-  - **order 22**（Responses 流式 refusal/annotation 事件）：`delta.refusal`（此前被静默丢）→ `response.refusal.delta/done`（自带 message-item 的 refusal content part，附加 `refusal` 到 chunk delta schema + 内容块联合类型 + `refusalSlot` 状态）；`delta.annotations` → `response.output_text.annotation.added`（用 `ensureTextSlot` 把 text item 提取成共享 helper，annotation 挂到 output_text part，终帧 part 带 annotations）；反向 converter 两路都回投到 `delta.refusal`/`delta.annotations`。**reasoning_text 仍不补**——经核验非真缺口（helm 用 `reasoning_summary_text` 正确）。新增 4 个 SSE 测试（正反向）。
-  - **order 30**（Gemini mid-stream usage）：经核验**本就正确**——终帧 chunk 已带 `reasoning_tokens`（`thoughtsTokenCount`），且只发**一帧** usage（OpenAI 单 usage 帧约定）。中途发 usage 反而破坏该约定，故**不做**，仅加锁定测试证明终帧带 reasoning_tokens + 全程仅一帧 usage。属 order 5/7 同类「对抗式核验过报」。
-- **坑/取舍**：(1) **matrix usage 断言原本编码了 bug**——`expectTargetUsageNotDoubleBilled` 断言 Responses `input_tokens:10`（漏掉 cached:3），而 Responses API 本就有 `input_tokens_details.cached_tokens`；修复让 Responses 与 openai/gemini 一致（full 13 + cached 3），同步改断言（注 order 21）。(2) annotation 矩阵测试的 `ANNOTATION_NATIVE_SURFACE.responses` 从 `false`（documented gap）改 `true`（order 20 已原生渲染）。(3) order 5/7 经核验**本就正确**（synthesizeSSEFromJSON 已经 resolveReasoning；mapStopReason('') 已回 end_turn 保 raw）——对抗式核验过报，加回归测试锁定既有正确行为而非改实现。(4) provider 层 usage 终帧改动会让 budget settle 拿到**更准**的 token（此前 Anthropic/Responses provider 流式无 usage），属正向修正。
-- **验证**：每条 TDD 红→绿；全量 **core 1744 绿**、typecheck 净、改动文件 lint 净（仓库另有 9 条 `noNonNullAssertion` 预存于**未触碰**的 test 文件，非本次引入）、build（admin+core+gateway）通过。e2e（Playwright）本地另跑，不在此门禁。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-08 · 四协议完整性审计 + 逐条修复：Workflow 扇出审计 4 个 wire 协议，对照 LiteLLM 找到并 TDD 修复 31 项生产协议/流式/usage/多模态缺口；最终 core 1744 绿、typecheck/lint/build 通过。
 
 ### 2026-06-07 · 修复 Anthropic 订阅配额页：`resets_at:null` 让整份用量解析失败、快照永久卡旧；修为 `utilization`/`resets_at` 双 `.nullish()`，保坏类型 fail-closed；TDD 锁线上 body，oauth/shared/core 验证通过。
 

--- a/packages/core/src/config/env-map.ts
+++ b/packages/core/src/config/env-map.ts
@@ -47,6 +47,52 @@ export const ENV_MAPPINGS: readonly EnvMapping[] = [
     path: ["runtime", "signal_feedback", "enabled"],
     kind: "boolean",
   },
+  {
+    env: "HELM_MEMORY_LLM_ENABLED",
+    path: ["memory", "llm", "enabled"],
+    kind: "boolean",
+  },
+  { env: "HELM_MEMORY_LLM_MODEL", path: ["memory", "llm", "model"], kind: "string" },
+  {
+    env: "HELM_MEMORY_LLM_OBSERVATION_MODEL",
+    path: ["memory", "llm", "observation_model"],
+    kind: "string",
+  },
+  {
+    env: "HELM_MEMORY_LLM_REFLECTION_MODEL",
+    path: ["memory", "llm", "reflection_model"],
+    kind: "string",
+  },
+  {
+    env: "HELM_MEMORY_LLM_FACTS_MODEL",
+    path: ["memory", "llm", "facts_model"],
+    kind: "string",
+  },
+  {
+    env: "HELM_MEMORY_LLM_TIMEOUT_MS",
+    path: ["memory", "llm", "timeout_ms"],
+    kind: "number",
+  },
+  {
+    env: "HELM_MEMORY_LLM_TEMPERATURE",
+    path: ["memory", "llm", "temperature"],
+    kind: "number",
+  },
+  {
+    env: "HELM_MEMORY_LLM_OBSERVATION_MAX_TOKENS",
+    path: ["memory", "llm", "max_tokens", "observation"],
+    kind: "number",
+  },
+  {
+    env: "HELM_MEMORY_LLM_REFLECTION_MAX_TOKENS",
+    path: ["memory", "llm", "max_tokens", "reflection"],
+    kind: "number",
+  },
+  {
+    env: "HELM_MEMORY_LLM_FACTS_MAX_TOKENS",
+    path: ["memory", "llm", "max_tokens", "facts"],
+    kind: "number",
+  },
 ];
 
 // Coerce a string env value into the declared kind. Returns the original string

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -71,6 +71,31 @@ describe("loadConfig", () => {
     expect(cfg.runtime.signal_feedback.min_samples).toBe(20);
   });
 
+  it("lets env configure the memory LLM model and task-specific overrides", () => {
+    const cfg = loadConfig({
+      configDir: "config",
+      env: {
+        HELM_MEMORY_LLM_ENABLED: "true",
+        HELM_MEMORY_LLM_MODEL: "deepseek/deepseek-v4-flash",
+        HELM_MEMORY_LLM_OBSERVATION_MODEL: "openai/gpt-4.1-mini",
+        HELM_MEMORY_LLM_REFLECTION_MODEL: "anthropic/claude-sonnet-4",
+        HELM_MEMORY_LLM_FACTS_MODEL: "openai/gpt-4.1-nano",
+        HELM_MEMORY_LLM_TIMEOUT_MS: "12345",
+        HELM_MEMORY_LLM_TEMPERATURE: "0.2",
+        HELM_MEMORY_LLM_FACTS_MAX_TOKENS: "432",
+      },
+      readFile: fakeReadFile(VALID_YAML),
+    });
+    expect(cfg.memory.llm.enabled).toBe(true);
+    expect(cfg.memory.llm.model).toBe("deepseek/deepseek-v4-flash");
+    expect(cfg.memory.llm.observation_model).toBe("openai/gpt-4.1-mini");
+    expect(cfg.memory.llm.reflection_model).toBe("anthropic/claude-sonnet-4");
+    expect(cfg.memory.llm.facts_model).toBe("openai/gpt-4.1-nano");
+    expect(cfg.memory.llm.timeout_ms).toBe(12345);
+    expect(cfg.memory.llm.temperature).toBe(0.2);
+    expect(cfg.memory.llm.max_tokens.facts).toBe(432);
+  });
+
   it("fails closed when HELM_STORE_DRIVER is an unknown driver", () => {
     expect(() =>
       loadConfig({
@@ -202,6 +227,21 @@ describe("loadConfig", () => {
     expect(cfg.memory.forgetting.enabled).toBe(true);
     expect(cfg.memory.forgetting.score.half_life_s).toBe(3600);
     expect(cfg.memory.forgetting.inject.drop_order).toBe("score"); // untouched default
+  });
+
+  it("loads memory.yaml: memory LLM extraction/compaction model config round-trips", () => {
+    const memYaml =
+      "llm:\n  enabled: true\n  model: deepseek/deepseek-v4-flash\n  reflection_model: openai/gpt-4.1-mini\n  max_tokens:\n    observation: 512\n";
+    const cfg = loadConfig({
+      configDir: "config",
+      env: {},
+      readFile: fakeReadFile({ ...VALID_YAML, "config/memory.yaml": memYaml }),
+    });
+    expect(cfg.memory.llm.enabled).toBe(true);
+    expect(cfg.memory.llm.model).toBe("deepseek/deepseek-v4-flash");
+    expect(cfg.memory.llm.reflection_model).toBe("openai/gpt-4.1-mini");
+    expect(cfg.memory.llm.max_tokens.observation).toBe(512);
+    expect(cfg.memory.llm.max_tokens.reflection).toBe(1200);
   });
 
   it("fail-closed: an unknown/misspelled memory.yaml key (strict) throws ConfigError", () => {

--- a/packages/shared/src/config/memory-schema.test.ts
+++ b/packages/shared/src/config/memory-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ForgettingSchema, MemoryConfigSchema } from "./memory-schema.js";
+import { ForgettingSchema, MemoryConfigSchema, MemoryLlmSchema } from "./memory-schema.js";
 
 // P1 (docs/12 "Config surface"): the forgetting config is config-as-code, Zod-
 // validated, fail-closed on bad input (CLAUDE.md principle 2). snake_case keys +
@@ -109,9 +109,54 @@ describe("CompactionOverridesSchema (via MemoryConfigSchema.compaction)", () => 
   });
 });
 
+describe("MemoryLlmSchema", () => {
+  it("defaults to disabled with no model selected", () => {
+    const llm = MemoryLlmSchema.parse({});
+    expect(llm.enabled).toBe(false);
+    expect(llm.model).toBeUndefined();
+    expect(llm.timeout_ms).toBe(30_000);
+    expect(llm.temperature).toBe(0);
+    expect(llm.max_tokens.observation).toBe(800);
+    expect(llm.max_tokens.reflection).toBe(1200);
+    expect(llm.max_tokens.facts).toBe(1000);
+  });
+
+  it("accepts a base model with task-specific extraction/compaction overrides", () => {
+    const llm = MemoryLlmSchema.parse({
+      enabled: true,
+      model: "deepseek/deepseek-v4-flash",
+      observation_model: "openai/gpt-4.1-mini",
+      reflection_model: "anthropic/claude-sonnet-4",
+      facts_model: "openai/gpt-4.1-nano",
+      timeout_ms: 10_000,
+      temperature: 0.1,
+      max_tokens: { observation: 256, reflection: 512, facts: 384 },
+    });
+    expect(llm.enabled).toBe(true);
+    expect(llm.model).toBe("deepseek/deepseek-v4-flash");
+    expect(llm.observation_model).toBe("openai/gpt-4.1-mini");
+    expect(llm.reflection_model).toBe("anthropic/claude-sonnet-4");
+    expect(llm.facts_model).toBe("openai/gpt-4.1-nano");
+    expect(llm.timeout_ms).toBe(10_000);
+    expect(llm.temperature).toBe(0.1);
+    expect(llm.max_tokens.facts).toBe(384);
+  });
+
+  it("fails closed when enabled without a base model or with misspelled/invalid knobs", () => {
+    expect(() => MemoryLlmSchema.parse({ enabled: true })).toThrow();
+    expect(() => MemoryLlmSchema.parse({ enabled: true, modle: "x" })).toThrow();
+    expect(() => MemoryLlmSchema.parse({ enabled: true, model: "x", timeout_ms: 0 })).toThrow();
+    expect(() => MemoryLlmSchema.parse({ enabled: true, model: "x", temperature: 2 })).toThrow();
+    expect(() =>
+      MemoryLlmSchema.parse({ enabled: true, model: "x", max_tokens: { observation: 0 } }),
+    ).toThrow();
+  });
+});
+
 describe("MemoryConfigSchema", () => {
   it("absent block → all defaults with forgetting.enabled:false", () => {
     const m = MemoryConfigSchema.parse({});
+    expect(m.llm.enabled).toBe(false);
     expect(m.forgetting.enabled).toBe(false);
     expect(m.forgetting.score.half_life_s).toBe(86400);
   });

--- a/packages/shared/src/config/memory-schema.ts
+++ b/packages/shared/src/config/memory-schema.ts
@@ -135,6 +135,46 @@ export const CompactionOverridesSchema = z
   })
   .strict();
 
+// Optional LLM-backed memory formation. This controls ONLY the background memory
+// worker's summarize/merge/fact-extraction calls; request-path observe/inject
+// stays synchronous and deterministic. OFF by default keeps the existing
+// deterministic stubs byte-for-byte available as both the default and fail-open
+// fallback. When enabled, `model` is required and can be overridden per task:
+//   - observation_model: raw messages -> observation (Observer compaction)
+//   - reflection_model: observations -> stable reflection (Reflector compaction)
+//   - facts_model: observations -> atomic facts (memory extraction)
+// Unknown/misspelled keys are rejected at config load, but runtime model/provider
+// failures fall back to the deterministic path and log safe metadata only.
+export const MemoryLlmMaxTokensSchema = z
+  .object({
+    observation: z.number().int().positive().default(800),
+    reflection: z.number().int().positive().default(1200),
+    facts: z.number().int().positive().default(1000),
+  })
+  .strict();
+
+export const MemoryLlmSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    model: z.string().min(1).optional(),
+    observation_model: z.string().min(1).optional(),
+    reflection_model: z.string().min(1).optional(),
+    facts_model: z.string().min(1).optional(),
+    timeout_ms: z.number().int().positive().default(30_000),
+    temperature: z.number().min(0).max(1).default(0),
+    max_tokens: MemoryLlmMaxTokensSchema.prefault({}),
+  })
+  .strict()
+  .superRefine((cfg, ctx) => {
+    if (cfg.enabled === true && cfg.model === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["model"],
+        message: "memory.llm.model is required when memory.llm.enabled is true",
+      });
+    }
+  });
+
 // The `config.memory` subtree root. `compaction` carries OPTIONAL trigger
 // overrides (above); everything else about compaction is the gateway's internal
 // auto-adaptive behaviour (prices/context from the model catalog, workload
@@ -145,6 +185,7 @@ export const CompactionOverridesSchema = z
 export const MemoryConfigSchema = z
   .object({
     compaction: CompactionOverridesSchema.prefault({}),
+    llm: MemoryLlmSchema.prefault({}),
     forgetting: ForgettingSchema.prefault({}),
   })
   .strict();
@@ -152,4 +193,5 @@ export const MemoryConfigSchema = z
 export type ScoreConfig = z.infer<typeof ScoreSchema>;
 export type CompactionOverrides = z.infer<typeof CompactionOverridesSchema>;
 export type ForgettingConfig = z.infer<typeof ForgettingSchema>;
+export type MemoryLlmConfig = z.infer<typeof MemoryLlmSchema>;
 export type MemoryConfig = z.infer<typeof MemoryConfigSchema>;

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -286,4 +286,6 @@ export {
   ForgettingSchema,
   type MemoryConfig,
   MemoryConfigSchema,
+  type MemoryLlmConfig,
+  MemoryLlmSchema,
 } from "./memory-schema.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -101,6 +101,8 @@ export {
   isOAuthPreset,
   type MemoryConfig,
   MemoryConfigSchema,
+  type MemoryLlmConfig,
+  MemoryLlmSchema,
   type OAuthConfig,
   OAuthConfigSchema,
   type OAuthCredential,


### PR DESCRIPTION
## Summary
- add `memory.llm` config for LLM-backed memory observation summarization, reflection compaction, and fact extraction
- support a base model plus task-specific overrides for observation/reflection/facts, with env overrides for model, timeout, temperature, and max tokens
- wire the LLM runtime only into background memory worker jobs, with deterministic fallback on disabled config, unavailable model, upstream failure, timeout, or invalid JSON
- document the new config surface and update implementation notes

## Validation
- pnpm vitest run packages/core/src/config/loader.test.ts packages/shared/src/config/memory-schema.test.ts apps/gateway/src/memory-llm.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- pnpm test:e2e
