### PR TITLE
Fix admin request detail stream display

### DIFF
--- a/apps/admin/src/lib/components/JsonTree.svelte
+++ b/apps/admin/src/lib/components/JsonTree.svelte
@@ -13,11 +13,7 @@
   const STRING_LIMIT = 512;
   const MAX_RENDER_DEPTH = 24;
 
-  let {
-    value,
-    name,
-    depth = 0,
-  }: { value: unknown; name?: string; depth?: number } = $props();
+  let { value, name, depth = 0 }: { value: unknown; name?: string; depth?: number } = $props();
 
   type Kind = 'object' | 'array' | 'string' | 'number' | 'boolean' | 'null';
   function kindOf(v: unknown): Kind {
@@ -88,14 +84,16 @@
   </div>
 {:else}
   <div class="json-node" data-testid="json-node">
-    {#if name != null}<span class="text-link">{name}: </span>{/if}<span class="json-scalar"
+    {#if name != null}<span class="text-link">{name}: </span>{/if}<span
+      class="json-scalar whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
       >{scalarText}</span
     >
     {#if isLongString}
       <button
         type="button"
         class="ml-2 text-link underline"
-        onclick={() => (expandedStr = !expandedStr)}>{expandedStr ? $t('Collapse') : $t('Expand')}</button
+        onclick={() => (expandedStr = !expandedStr)}
+        >{expandedStr ? $t('Collapse') : $t('Expand')}</button
       >
     {/if}
   </div>

--- a/apps/admin/src/lib/components/JsonTree.test.ts
+++ b/apps/admin/src/lib/components/JsonTree.test.ts
@@ -47,6 +47,15 @@ describe('JsonTree', () => {
     expect(screen.getByText(/NEEDLE/)).toBeInTheDocument();
   });
 
+  it('allows long scalar strings to wrap instead of forcing horizontal scroll', async () => {
+    const long = `${'a'.repeat(520)}NEEDLE`;
+    render(JsonTree, { value: long, name: 'blob' });
+    await fireEvent.click(screen.getByRole('button', { name: /Expand/i }));
+    const scalar = screen.getByText(/NEEDLE/);
+    expect(scalar.className).toContain('whitespace-pre-wrap');
+    expect(scalar.className).toContain('[overflow-wrap:anywhere]');
+  });
+
   it('paginates large arrays at 200 entries with a "show remaining" control', async () => {
     const big = Array.from({ length: 250 }, (_, i) => i);
     render(JsonTree, { value: big });

--- a/apps/admin/src/lib/components/JsonViewer.svelte
+++ b/apps/admin/src/lib/components/JsonViewer.svelte
@@ -31,7 +31,9 @@
   });
 
   const data = $derived(normalized.data);
-  const formatted = $derived(normalized.parsedOk ? JSON.stringify(data, null, 2) : (data as string));
+  const formatted = $derived(
+    normalized.parsedOk ? JSON.stringify(data, null, 2) : (data as string),
+  );
 
   // Empty/null get a friendly placeholder instead of a bare, confusing tree root.
   const emptyPlaceholder = $derived.by((): string | null => {
@@ -48,7 +50,8 @@
 
   const tabActive = 'border-action bg-action text-white';
   const tabInactive = 'border-border bg-surface text-ink-muted hover:bg-canvas';
-  const panelCls = 'max-h-96 overflow-auto rounded bg-canvas p-2 font-mono text-xs text-ink-body';
+  const panelCls =
+    'max-h-96 overflow-y-auto overflow-x-hidden rounded bg-canvas p-2 font-mono text-xs whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-ink-body';
 </script>
 
 <div data-testid={testid}>
@@ -70,7 +73,10 @@
     {/if}
   </div>
 
-  <pre data-testid="jsonviewer-formatted" hidden={tab !== 'formatted'} class={panelCls}>{formatted}</pre>
+  <pre
+    data-testid="jsonviewer-formatted"
+    hidden={tab !== 'formatted'}
+    class={panelCls}>{formatted}</pre>
 
   <pre data-testid="jsonviewer-raw" hidden={tab !== 'raw'} class={panelCls}>{normalized.raw}</pre>
 </div>

--- a/apps/admin/src/lib/components/JsonViewer.test.ts
+++ b/apps/admin/src/lib/components/JsonViewer.test.ts
@@ -47,17 +47,29 @@ describe('JsonViewer', () => {
   });
 
   it('renders placeholders for empty / null values', () => {
-    expect(
-      render(JsonViewer, { value: {} }).getByText('(empty object)'),
-    ).toBeInTheDocument();
-    expect(
-      render(JsonViewer, { value: [] }).getByText('(empty array)'),
-    ).toBeInTheDocument();
+    expect(render(JsonViewer, { value: {} }).getByText('(empty object)')).toBeInTheDocument();
+    expect(render(JsonViewer, { value: [] }).getByText('(empty array)')).toBeInTheDocument();
     expect(render(JsonViewer, { value: null }).getByText('(null)')).toBeInTheDocument();
   });
 
   it('passes a testid through to its root for e2e selectors', () => {
     render(JsonViewer, { value: { ok: true }, testid: 'request-body' });
     expect(screen.getByTestId('request-body')).toBeInTheDocument();
+  });
+
+  it('wraps formatted/raw JSON panels without horizontal scrolling', async () => {
+    render(JsonViewer, { value: { prompt: 'x'.repeat(1200) } });
+
+    await fireEvent.click(screen.getByRole('button', { name: /Formatted/i }));
+    const formatted = screen.getByTestId('jsonviewer-formatted');
+    expect(formatted.className).toContain('overflow-x-hidden');
+    expect(formatted.className).toContain('whitespace-pre-wrap');
+    expect(formatted.className).toContain('[overflow-wrap:anywhere]');
+
+    await fireEvent.click(screen.getByRole('button', { name: /Raw/i }));
+    const raw = screen.getByTestId('jsonviewer-raw');
+    expect(raw.className).toContain('overflow-x-hidden');
+    expect(raw.className).toContain('whitespace-pre-wrap');
+    expect(raw.className).toContain('[overflow-wrap:anywhere]');
   });
 });

--- a/apps/admin/src/lib/components/StreamViewer.test.ts
+++ b/apps/admin/src/lib/components/StreamViewer.test.ts
@@ -28,6 +28,24 @@ const STREAM = [
   'data: [DONE]\n\n',
 ].join('');
 
+const RESPONSES_STREAM = [
+  `event: response.output_text.delta\ndata: ${JSON.stringify({
+    type: 'response.output_text.delta',
+    sequence_number: 0,
+    delta: '我',
+  })}\n\n`,
+  `event: response.output_text.delta\ndata: ${JSON.stringify({
+    type: 'response.output_text.delta',
+    sequence_number: 1,
+    delta: '在',
+  })}\n\n`,
+  `event: response.completed\ndata: ${JSON.stringify({
+    type: 'response.completed',
+    sequence_number: 2,
+    response: { model: 'gpt-5.5', status: 'completed' },
+  })}\n\n`,
+].join('');
+
 describe('StreamViewer', () => {
   it('defaults to the Assembled tab with the final content prominent', () => {
     render(StreamViewer, { raw: STREAM });
@@ -100,5 +118,11 @@ describe('StreamViewer', () => {
   it('passes a testid through to its root for e2e selectors', () => {
     render(StreamViewer, { raw: STREAM, testid: 'response-body' });
     expect(screen.getByTestId('response-body')).toBeInTheDocument();
+  });
+
+  it('renders OpenAI Responses API output_text.delta streams as assembled content', () => {
+    render(StreamViewer, { raw: RESPONSES_STREAM });
+    expect(screen.getByTestId('stream-final-content')).toHaveTextContent('我在');
+    expect(screen.queryByText(/No visible output/)).not.toBeInTheDocument();
   });
 });

--- a/apps/admin/src/lib/sse.test.ts
+++ b/apps/admin/src/lib/sse.test.ts
@@ -106,6 +106,55 @@ const ANTHROPIC_STREAM = [
   `event: message_stop\ndata: ${JSON.stringify({ type: 'message_stop' })}\n\n`,
 ].join('');
 
+const RESPONSES_STREAM = [
+  `event: response.created\ndata: ${JSON.stringify({
+    type: 'response.created',
+    sequence_number: 0,
+    response: { id: 'resp_1', object: 'response', model: 'gpt-5.5', status: 'in_progress' },
+  })}\n\n`,
+  `event: response.output_item.added\ndata: ${JSON.stringify({
+    type: 'response.output_item.added',
+    sequence_number: 1,
+    output_index: 0,
+    item: { type: 'message', id: 'item_0', status: 'in_progress', role: 'assistant' },
+  })}\n\n`,
+  `event: response.output_text.delta\ndata: ${JSON.stringify({
+    type: 'response.output_text.delta',
+    sequence_number: 2,
+    item_id: 'item_0',
+    output_index: 0,
+    content_index: 0,
+    delta: '我',
+  })}\n\n`,
+  `event: response.output_text.delta\ndata: ${JSON.stringify({
+    type: 'response.output_text.delta',
+    sequence_number: 3,
+    item_id: 'item_0',
+    output_index: 0,
+    content_index: 0,
+    delta: '在',
+  })}\n\n`,
+  `event: response.output_text.done\ndata: ${JSON.stringify({
+    type: 'response.output_text.done',
+    sequence_number: 4,
+    item_id: 'item_0',
+    output_index: 0,
+    content_index: 0,
+    text: '我在',
+  })}\n\n`,
+  `event: response.completed\ndata: ${JSON.stringify({
+    type: 'response.completed',
+    sequence_number: 5,
+    response: {
+      id: 'resp_1',
+      object: 'response',
+      model: 'gpt-5.5',
+      status: 'completed',
+      usage: { input_tokens: 10, output_tokens: 2 },
+    },
+  })}\n\n`,
+].join('');
+
 describe('isSseStream', () => {
   it('detects OpenAI-style data: streams', () => {
     expect(isSseStream(OPENAI_STREAM)).toBe(true);
@@ -113,6 +162,10 @@ describe('isSseStream', () => {
 
   it('detects Anthropic-style event: streams', () => {
     expect(isSseStream(ANTHROPIC_STREAM)).toBe(true);
+  });
+
+  it('detects OpenAI Responses API event streams', () => {
+    expect(isSseStream(RESPONSES_STREAM)).toBe(true);
   });
 
   it('rejects plain JSON bodies, objects, and unrelated strings', () => {
@@ -185,6 +238,29 @@ describe('parseSseStream — Anthropic events', () => {
     expect(kinds).toContain('reasoning');
     expect(kinds).toContain('content');
     expect(kinds[kinds.length - 2]).toBe('finish'); // message_delta w/ stop_reason
+  });
+});
+
+describe('parseSseStream — OpenAI Responses API events', () => {
+  const parsed = parseSseStream(RESPONSES_STREAM);
+
+  it('assembles output_text deltas into the visible final content', () => {
+    expect(parsed.assembled.protocol).toBe('openai');
+    expect(parsed.assembled.content).toBe('我在');
+  });
+
+  it('captures model, usage, completion status and per-event kinds', () => {
+    expect(parsed.assembled.model).toBe('gpt-5.5');
+    expect(parsed.assembled.usage).toMatchObject({ input_tokens: 10, output_tokens: 2 });
+    expect(parsed.assembled.finishReason).toBe('completed');
+    expect(parsed.events.map((e) => e.kind)).toEqual([
+      'meta',
+      'meta',
+      'content',
+      'content',
+      'content',
+      'finish',
+    ]);
   });
 });
 

--- a/apps/admin/src/lib/sse.ts
+++ b/apps/admin/src/lib/sse.ts
@@ -121,6 +121,31 @@ function mergeUsage(acc: Accumulator, usage: unknown): void {
   acc.assembled.usage = { ...(acc.assembled.usage ?? {}), ...u };
 }
 
+function extractOutputText(value: unknown): string {
+  const record = asRecord(value);
+  if (!record) return '';
+
+  const direct = str(record.text);
+  if (direct !== null) return direct;
+
+  const content = Array.isArray(record.content) ? record.content : [];
+  let out = '';
+  for (const part of content) out += extractOutputText(part);
+
+  const output = Array.isArray(record.output) ? record.output : [];
+  for (const item of output) out += extractOutputText(item);
+
+  return out;
+}
+
+function fillContentFromFinalText(acc: Accumulator, value: unknown): string {
+  const text = extractOutputText(value);
+  // Responses API sends both token deltas and authoritative done snapshots. The
+  // snapshot is a fallback for truncated captures, not another delta to append.
+  if (text && !acc.assembled.content) acc.assembled.content = text;
+  return text;
+}
+
 /** Classify + accumulate one OpenAI `chat.completion.chunk`. */
 function consumeOpenAiChunk(
   chunk: Record<string, unknown>,
@@ -171,6 +196,85 @@ function consumeOpenAiChunk(
   }
   // role opener / empty keep-alive chunk
   return { kind: 'meta', text: str(delta.role) ?? '' };
+}
+
+/** Classify + accumulate OpenAI Responses API `response.*` SSE events. */
+function consumeOpenAiResponseEvent(
+  payload: Record<string, unknown>,
+  acc: Accumulator,
+): Omit<SseEvent, 'index' | 'event' | 'data' | 'raw'> {
+  acc.assembled.protocol = 'openai';
+  const type = str(payload.type) ?? '';
+  const response = asRecord(payload.response);
+  acc.assembled.model ??= str(response?.model);
+  if (payload.usage) mergeUsage(acc, payload.usage);
+  if (response?.usage) mergeUsage(acc, response.usage);
+
+  switch (type) {
+    case 'response.output_text.delta': {
+      const delta = str(payload.delta) ?? '';
+      acc.assembled.content += delta;
+      return { kind: 'content', text: delta };
+    }
+    case 'response.output_text.done': {
+      const text = str(payload.text) ?? '';
+      if (text && !acc.assembled.content) acc.assembled.content = text;
+      return { kind: 'content', text };
+    }
+    case 'response.reasoning_summary_text.delta':
+    case 'response.reasoning_text.delta': {
+      const delta = str(payload.delta) ?? '';
+      acc.assembled.reasoning += delta;
+      return { kind: 'reasoning', text: delta };
+    }
+    case 'response.reasoning_summary_text.done':
+    case 'response.reasoning_text.done': {
+      const text = str(payload.text) ?? '';
+      if (text && !acc.assembled.reasoning) acc.assembled.reasoning = text;
+      return { kind: 'reasoning', text };
+    }
+    case 'response.function_call_arguments.delta': {
+      const delta = str(payload.delta) ?? '';
+      const last = acc.assembled.toolCalls[acc.assembled.toolCalls.length - 1];
+      if (last) last.arguments += delta;
+      return { kind: 'tool_call', text: delta };
+    }
+    case 'response.function_call_arguments.done': {
+      const args = str(payload.arguments) ?? '';
+      const last = acc.assembled.toolCalls[acc.assembled.toolCalls.length - 1];
+      if (last && args && !last.arguments) last.arguments = args;
+      return { kind: 'tool_call', text: args };
+    }
+    case 'response.output_item.added': {
+      const item = asRecord(payload.item);
+      if (str(item?.type) === 'function_call') {
+        acc.assembled.toolCalls.push({
+          id: str(item?.call_id) ?? str(item?.id),
+          name: str(item?.name) ?? '',
+          arguments: str(item?.arguments) ?? '',
+        });
+        return { kind: 'tool_call', text: str(item?.name) ?? '' };
+      }
+      return { kind: 'meta', text: type };
+    }
+    case 'response.content_part.done': {
+      const text = fillContentFromFinalText(acc, payload.part);
+      return text ? { kind: 'content', text } : { kind: 'meta', text: type };
+    }
+    case 'response.output_item.done': {
+      const text = fillContentFromFinalText(acc, payload.item);
+      return text ? { kind: 'content', text } : { kind: 'meta', text: type };
+    }
+    case 'response.completed':
+    case 'response.incomplete':
+    case 'response.failed': {
+      fillContentFromFinalText(acc, response);
+      acc.assembled.finishReason = str(response?.status) ?? type.replace('response.', '');
+      return { kind: 'finish', text: acc.assembled.finishReason };
+    }
+    default:
+      return { kind: 'meta', text: type };
+  }
 }
 
 /** Classify + accumulate one Anthropic stream event (by its `type`). */
@@ -274,10 +378,14 @@ export function parseSseStream(raw: string): ParsedSseStream {
       events.push({ ...base, kind: 'other', text: wire.data, data: null });
       continue;
     }
-    // Anthropic events carry a `type` discriminator (or an `event:` field);
-    // OpenAI chunks carry `choices`. Prefer the explicit discriminator.
-    const consumed =
-      typeof payload.type === 'string' || wire.event !== null
+    // OpenAI Responses API events and Anthropic events both carry `event:` /
+    // `type`; route `response.*` first so Responses streams do not get mistaken
+    // for Anthropic and render as "No visible output".
+    const type = str(payload.type);
+    const isResponsesEvent = type?.startsWith('response.') || wire.event?.startsWith('response.');
+    const consumed = isResponsesEvent
+      ? consumeOpenAiResponseEvent(payload, acc)
+      : typeof payload.type === 'string' || wire.event !== null
         ? consumeAnthropicEvent(payload, acc)
         : consumeOpenAiChunk(payload, acc);
     events.push({ ...base, ...consumed, data: payload });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-09 · 请求详情页 Responses API 流式回放与 JSON 换行修复（docs/05 协议互译；docs/07 可观测性；docs/11 管理界面）
+
+- **缘起**：线上请求详情页的 captured payload 里，响应是 OpenAI Responses API SSE（`event: response.output_text.delta` / `response.completed`），但 admin 侧 `StreamViewer` 只会组装 OpenAI Chat chunk 与 Anthropic events；`response.*` 事件被误走 Anthropic 分支，最终显示 “No visible output”。同页请求 JSON viewer 使用 `overflow-auto` + `<pre>` 默认不换行，长 prompt/request body 触发横向滚动条。
+- **修复**：`parseSseStream` 新增 Responses API `response.*` 分支，在 Anthropic 分支前匹配，累积 `response.output_text.delta` 为最终可见 content，并读取 `response.completed.response.usage/model/status`；`output_text.done` / `content_part.done` / `output_item.done` 只作截断捕获的兜底快照，不把完成态全文再次 append，避免重复。顺带支持 Responses API reasoning 与 function_call argument delta 的基础合并。
+- **UI 取舍**：`JsonViewer` 三个 tab 统一 `overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words [overflow-wrap:anywhere]`；`JsonTree` scalar 同样允许长字符串强制断行。保留垂直最大高度滚动，移除横向滚动；长不可断 token 也会按 anywhere 折行。
+- **验证**：TDD 新增 Responses API SSE parser / StreamViewer 用例，以及 JSON formatted/raw panel 与 scalar wrap 用例。定向 Vitest 40/40 绿；Prettier check 绿；同一线上 trace 的 payload 经本地新 parser 解析为 37 events、`protocol=openai`、`finishReason=completed`、content 正常非空。
+- **部署提示**：本次只改本地源码与测试，未执行生产部署。线上要生效需构建并发布新的 admin 静态资源/网关镜像。
+
+---
+
 ## 2026-06-09 · LLM 记忆提取/压缩接线与可配置模型（docs/08 记忆；docs/12 遗忘/事实层；CLAUDE.md 原则 2/3/7）
 
 - **缘起**：记忆 observe/inject、worker、compaction trigger、forgetting/facts 已是生产接线，但 Observer/Reflector 仍用确定性 stub 做 summarize/merge/extractFacts；这让“记忆提取/压缩”可用但不具备真正 LLM 归纳能力。
@@ -28,19 +38,11 @@
 
 ---
 
-## 2026-06-09 · 生产路径四协议 LiteLLM 参数保真 + payload 原文记录修复（docs/05 协议互译；docs/07 可观测性；CLAUDE.md 原则 7/8）
-
-- **缘起**：复审发现 transformer 层已覆盖大量 OpenAI/Anthropic/Responses/Gemini 字段，但生产路径 `route -> InternalRequest -> execute` 仍只保留 `messages/tools/response_format/max_tokens/stream`，导致 `temperature/top_p/tool_choice/parallel_tool_calls/reasoning_effort/max_completion_tokens` 等 LiteLLM/OpenAI 参数被静默丢弃；同时 payload capture 用 `JSON.stringify(parsed)` 重建请求体，不符合 docs/07 的 verbatim 记录承诺。
-- **修复**：扩展 `InternalRequestSchema` 与 OpenAI Chat 边界 schema，新增共享 `copyLiteLLMRequestParams`/`providerRawFromRequest`，让 OpenAI Chat、Anthropic Messages、OpenAI Responses、Gemini 三条 pipeline face 都把 LiteLLM 兼容参数带进执行层；`execute.stripInternal` 转发这些字段，并对流式请求合并客户端 `stream_options` 后强制 `include_usage:true` 以保留成本回填；Responses transformer 补 `user/service_tier/web_search_options/context_management`，Anthropic native provider 补 `max_completion_tokens -> max_tokens`、`top_k/thinking/tool_choice/parallel_tool_calls:false`。
-- **记录修复**：四个 HTTP route 改为先读取 `c.req.text()` 再 `JSON.parse`，payload 表保存原始请求 JSON 文本（保留空白/顺序等原文细节），响应仍保存实际组装出的响应体；记录路径仍 fail-open，`capture_payloads` 关闭时不写 payload 但 telemetry row 保持。
-- **测试**：新增/加强生产边界测试：OpenAI Chat route -> execution request、三种非 chat protocol pipeline -> InternalRequest、execute -> provider request body、四 route payload requestJson 原文断言，以及 OpenAI/Responses/Anthropic provider 参数回归。重点锁定“transformer 测试通过但生产路径丢参”的老问题。
-- **取舍/TODO**：`metadata` 与网关内部 `metadata` 字段同名，provider metadata 存在 `provider_raw.metadata`，执行前再恢复到上游 body，避免污染 memory/session metadata。未把 auth/rate-limit/concurrency 等 pre-pipeline 拒绝统一写入 request history；当前修复范围是已认证且进入协议/路由面的 served/failure 请求。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-09 · 生产路径四协议 LiteLLM 参数保真 + payload 原文记录修复：生产路径补齐 OpenAI Chat/Anthropic/Responses/Gemini LiteLLM 参数透传，流式强制 usage 回填，payload 表保存原始请求 JSON 文本；TDD 覆盖 route/pipeline/execute/provider/payload 边界。TODO：pre-pipeline 拒绝仍未统一写入 request history。
 
 ### 2026-06-08 · 四协议完整性审计 + 逐条修复：Workflow 扇出审计 4 个 wire 协议，对照 LiteLLM 找到并 TDD 修复 31 项生产协议/流式/usage/多模态缺口；最终 core 1744 绿、typecheck/lint/build 通过。
 


### PR DESCRIPTION
## Summary

- add OpenAI Responses API `response.*` SSE parsing in the admin stream viewer path
- assemble `response.output_text.delta` into visible final content instead of showing an empty stream
- make JSON request/response panels wrap long formatted/raw/tree scalar text without horizontal scrolling
- record the spec-adjacent implementation note

## Validation

- `pnpm --filter @helm/admin exec vitest run src/lib/sse.test.ts src/lib/components/StreamViewer.test.ts src/lib/components/JsonViewer.test.ts src/lib/components/JsonTree.test.ts`
- `pnpm --filter @helm/admin exec prettier --check src/lib/sse.ts src/lib/sse.test.ts src/lib/components/StreamViewer.test.ts src/lib/components/JsonViewer.test.ts src/lib/components/JsonTree.test.ts src/lib/components/JsonViewer.svelte src/lib/components/JsonTree.svelte`
- `pnpm --filter @helm/admin build`
- verified the reported production payload shape locally via the admin API: 37 SSE events, `protocol=openai`, non-empty assembled content, `finishReason=completed`

## Notes

- `pnpm --filter @helm/admin check` is still blocked by unrelated pre-existing type errors in `apps/admin/src/lib/api/oauth.test.ts` around tuple access in OAuth tests.
