### PR TITLE
Fix DeepSeek developer role compatibility

### DIFF
--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -140,6 +140,32 @@ describe("buildProviderClients (issue #38 OAuth wiring)", () => {
     expect(clients.has("openai")).toBe(true);
     expect(clients.has("claude-sub")).toBe(false);
   });
+
+  it("threads the provider developer-role compatibility flag into OpenAI-compatible clients", async () => {
+    ADDED_KEYS.push(...setEnv({ DEEPSEEK_API_KEY: "sk-deepseek" }));
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const deepseek = provider({
+      name: "deepseek",
+      type: "openai",
+      base_url: "https://api.deepseek.com/v1",
+      api_key_env: "DEEPSEEK_API_KEY",
+      map_developer_role_to_system: true,
+      models: [{ alias: "deepseek/deepseek-v4-flash", provider_model: "deepseek-v4-flash" }],
+    });
+
+    const clients = buildProviderClients([deepseek], "https://fallback/v1", 60_000);
+    await clients.get("deepseek")?.chatCompletion({
+      model: "deepseek-v4-flash",
+      messages: [{ role: "developer", content: "Be concise." }],
+    });
+
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      messages: [{ role: "system", content: "Be concise." }],
+    });
+  });
 });
 
 // ── synthesizeOAuthProviders (Stage 3: priority + round-robin account pool) ────

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -616,13 +616,17 @@ function createProviderClient(
         ...base,
         ...cred,
         extraHeaders: () => ({ ...COPILOT_HEADERS }),
+        mapDeveloperRoleToSystem: p.map_developer_role_to_system,
         resolveBaseUrl: async () =>
           getGitHubCopilotBaseUrl((await getAuth()).replace(/^Bearer /, "")),
       },
       fetch: proxyFetch,
     });
   }
-  return createOpenAIClient({ config: { ...base, ...cred }, fetch: proxyFetch });
+  return createOpenAIClient({
+    config: { ...base, ...cred, mapDeveloperRoleToSystem: p.map_developer_role_to_system },
+    fetch: proxyFetch,
+  });
 }
 
 // Full wiring: config -> store -> bootstrap key -> provider -> routing pipeline.

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -27,6 +27,8 @@
 #
 # Unified shape (HelmConfigSchema.ProviderConfig): name, type (openai|anthropic),
 # base_url?, api_key_env (env-var NAME), models[] { alias -> provider_model }.
+# OpenAI-compatible providers that reject OpenAI's newer `developer` role can set
+# map_developer_role_to_system: true as a provider-scoped compatibility shim.
 # A duplicate alias across providers is rejected at build time (fail-closed,
 # principle 2). The test/e2e harness overrides every provider's base_url via
 # HELM_PROVIDER_BASE_URL so the mock upstream serves all of them.
@@ -52,6 +54,9 @@ providers:
     type: openai
     base_url: https://api.deepseek.com/v1
     api_key_env: DEEPSEEK_API_KEY
+    # Official DeepSeek rejects `messages[].role="developer"` with HTTP 400; map
+    # it to `system` before the upstream call while preserving true OpenAI/Codex.
+    map_developer_role_to_system: true
     models:
       # deepseek-v4-pro — balanced/default primary, json-capable, big context.
       - alias: deepseek/deepseek-v4-pro

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-09 · DeepSeek provider developer-role 兼容开关（docs/05 协议互译；docs/04 路由执行兜底；CLAUDE.md 原则 2/3/5）
+
+- **缘起**：线上 trace `f51049a7-0d14-4250-9d93-2e057d153f3e` 进入 `economy` lane，首选 `deepseek/deepseek-v4-flash` 失败后 fallback 到 `openai-codex/gpt-5.4-mini` 成功。DeepSeek 真实错误为 HTTP 400：`messages[0].role: unknown variant developer`。根因是 OpenAI Responses/OpenAI Chat 请求中的 `developer` 角色被 OpenAI-compatible client 原样透传给官方 DeepSeek，而 DeepSeek 只接受 `system/user/assistant/tool/...`。
+- **修复**：新增 provider-scoped config `map_developer_role_to_system`（默认 `false`，fail-closed Zod 校验），并在 `createOpenAIClient` 中仅当该开关开启时复制请求体，把 `messages[].role === "developer"` 改为 `system`。`config/providers.yaml` 的官方 `deepseek` provider 启用该开关；真实 OpenAI/Codex 继续保留 `developer` 语义，不做全局降级。
+- **取舍**：这是执行层 provider 兼容 shim，不改变分类与 lane 选择；DeepSeek 仍可作为 economy/balanced 候选，只是不再因角色不兼容白白失败一次。原始请求对象不被 mutate，payload/replay 仍保留客户端原文；仅上游 wire body 做兼容转换。
+- **测试/验证**：TDD 覆盖 OpenAI client opt-in 映射且不修改 caller request、config loader 默认 false/YAML true、checked-in DeepSeek sample、server.ts provider flag 接线。定向 Vitest 70/70 绿；`@helm/shared`/`@helm/core`/`@helm/gateway` typecheck 与 build 均通过。
+- **部署提示**：本次只改本地源码与默认 config，未改线上 `/opt/helm-api/config` 或执行部署。线上要消除该 400，需要发布新镜像/代码，并确保生产 DeepSeek provider 配置包含 `map_developer_role_to_system: true`。
+
+---
+
 ## 2026-06-09 · 请求详情页 Responses API 流式回放与 JSON 换行修复（docs/05 协议互译；docs/07 可观测性；docs/11 管理界面）
 
 - **缘起**：线上请求详情页的 captured payload 里，响应是 OpenAI Responses API SSE（`event: response.output_text.delta` / `response.completed`），但 admin 侧 `StreamViewer` 只会组装 OpenAI Chat chunk 与 Anthropic events；`response.*` 事件被误走 Anthropic 分支，最终显示 “No visible output”。同页请求 JSON viewer 使用 `overflow-auto` + `<pre>` 默认不换行，长 prompt/request body 触发横向滚动条。
@@ -28,19 +38,11 @@
 
 ---
 
-## 2026-06-09 · Agentic Signals 反馈接入 ranked-lane 路由（docs/02 架构；docs/04 路由；docs/07 可观测性）
-
-- **缘起**：路线图里 `RoutingSignal` 聚合、sqlite/pg store 与后台 collector 已存在，但请求路径从不读取信号，导致 Agentic Signals 只能观测不能反馈，仍属于“未接线”功能。
-- **修复**：新增 `runtime.signal_feedback` 配置（默认 `enabled:false`，`HELM_SIGNAL_FEEDBACK_ENABLED` 可覆盖；阈值在 `config/runtime.yaml`），网关把 `store.signals.getSignal` 接入 `routeRequest`。启用后，只有当当前 **ranked lane**（`economy/balanced`）在同一 `task_type` 下样本数达标且 error/fallback 率超阈值时，才会提升到更强且更健康的 ranked lane；不会降级，也不会越过 explicit passthrough、policy `use_lane` pin、usage-budget degrade、policy/key caps。
-- **安全/可观测**：信号只含聚合计数/率/延迟/成本，不含 key/payload；读取异常完全 fail-open，保持原 lane 并继续请求。发生提升时在 `classifier.explanation` 追加 `routing_signal_feedback`（from/to lane、阈值、信号摘要），不新增敏感字段。
-- **取舍/TODO**：本次只做 ranked-lane 健康提升，暂不让信号改写未排名任务 lane（如 `coding`）或做成本驱动降档，避免生产反馈绕过 operator 明确策略。若后续要对 task lane 做反馈，应先定义“task lane → ranked lane”的可解释映射和更细粒度的决策字段。
-- **测试**：TDD 新增 route tests 覆盖 degraded balanced → premium、signal store fail-open、key allowed_lanes 不越界、policy pin / explicit passthrough / budget degrade 不被覆盖；config schema + loader 覆盖默认关闭、阈值 fail-closed 与 env 开关。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-09 · Agentic Signals 反馈接入 ranked-lane 路由：新增默认关闭的 `runtime.signal_feedback`，请求路径读取聚合 signals 后仅可在 ranked lane 内健康提升，不降级、不越过 policy/key/budget caps；读取异常 fail-open。TODO：若后续支持 task lane 反馈，需先定义 task lane → ranked lane 映射。
 
 ### 2026-06-09 · 生产路径四协议 LiteLLM 参数保真 + payload 原文记录修复：生产路径补齐 OpenAI Chat/Anthropic/Responses/Gemini LiteLLM 参数透传，流式强制 usage 回填，payload 表保存原始请求 JSON 文本；TDD 覆盖 route/pipeline/execute/provider/payload 边界。TODO：pre-pipeline 拒绝仍未统一写入 request history。
 

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -35,6 +35,20 @@ describe("loadConfig", () => {
     expect(cfg.auth.require_api_key).toBe(true);
     expect(cfg.server.port).toBe(8080);
     expect(cfg.providers[0]?.api_key_env).toBe("OPENAI_API_KEY");
+    expect(cfg.providers[0]?.map_developer_role_to_system).toBe(false);
+  });
+
+  it("loads the provider developer-role compatibility flag", () => {
+    const cfg = loadConfig({
+      configDir: "config",
+      env: {},
+      readFile: fakeReadFile({
+        ...VALID_YAML,
+        "config/providers.yaml":
+          "providers:\n  - alias: deepseek\n    type: openai\n    base_url: https://api.deepseek.com/v1\n    api_key_env: DEEPSEEK_API_KEY\n    map_developer_role_to_system: true\n",
+      }),
+    });
+    expect(cfg.providers[0]?.map_developer_role_to_system).toBe(true);
   });
 
   it("lets env override file values (env wins) with coercion", () => {

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -48,6 +48,7 @@ describe("checked-in config samples", () => {
     expect(cfg.auth.require_api_key).toBe(true);
     expect(cfg.server.port).toBe(8080);
     expect(cfg.providers[0]?.api_key_env).toBe("DEEPSEEK_API_KEY");
+    expect(cfg.providers[0]?.map_developer_role_to_system).toBe(true);
   });
 
   it("loads the shipped lanes.yaml (economy/balanced/premium + task lanes)", () => {

--- a/packages/core/src/provider/openai.test.ts
+++ b/packages/core/src/provider/openai.test.ts
@@ -44,6 +44,34 @@ describe("createOpenAIClient (Phase 0 passthrough)", () => {
     expect(JSON.parse(init.body as string)).toEqual(req);
   });
 
+  it("maps developer role messages to system only when the provider opts in", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    const client = createOpenAIClient({
+      config: { ...CONFIG, mapDeveloperRoleToSystem: true },
+      fetch,
+    });
+    const req = {
+      model: "deepseek-v4-flash",
+      messages: [
+        { role: "developer", content: "Prefer concise answers." },
+        { role: "user", content: "hi" },
+      ],
+    };
+
+    await client.chatCompletion(req);
+
+    const init = fetch.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: "deepseek-v4-flash",
+      messages: [
+        { role: "system", content: "Prefer concise answers." },
+        { role: "user", content: "hi" },
+      ],
+    });
+    // The caller's request object stays immutable for telemetry/replay fidelity.
+    expect(req.messages[0]?.role).toBe("developer");
+  });
+
   it("yields upstream SSE chunks byte-for-byte (streaming)", async () => {
     const chunks = ['data: {"a":1}\n\n', 'data: {"b":2}\n\n', "data: [DONE]\n\n"];
     const fetch = vi.fn().mockResolvedValue(sseResponse(chunks));

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -30,6 +30,9 @@ export interface ProviderConfig {
   // static `baseUrl`. Copilot derives its API host from the current token's
   // `proxy-ep`, which changes when the short-lived Copilot token is re-minted.
   resolveBaseUrl?: () => Promise<string>;
+  // Compatibility shim for OpenAI-compatible providers that have not adopted the
+  // newer `developer` role. Disabled by default to keep true OpenAI passthrough.
+  mapDeveloperRoleToSystem?: boolean;
 }
 
 export interface OpenAIClientDeps {
@@ -134,6 +137,24 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     };
   }
 
+  function prepareRequest(req: ChatCompletionRequest): ChatCompletionRequest {
+    if (!cfg.mapDeveloperRoleToSystem || !Array.isArray(req.messages)) return req;
+    let changed = false;
+    const messages = req.messages.map((message) => {
+      if (
+        message !== null &&
+        typeof message === "object" &&
+        !Array.isArray(message) &&
+        (message as { role?: unknown }).role === "developer"
+      ) {
+        changed = true;
+        return { ...message, role: "system" };
+      }
+      return message;
+    });
+    return changed ? { ...req, messages } : req;
+  }
+
   // Strip any echoed credential from an upstream error body before it is carried
   // in UpstreamError.providerRaw (defense in depth; redact() is the main gate).
   // Static path scrubs the apiKey; OAuth path scrubs every LIVE token (access +
@@ -174,7 +195,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       return await doFetch(await chatUrl(), {
         method: "POST",
         headers: await headers(),
-        body: JSON.stringify(req),
+        body: JSON.stringify(prepareRequest(req)),
         signal: t.signal,
       });
     } catch (err) {

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -123,6 +123,10 @@ export function isOAuthPreset(
 //     credential (both / neither) refuses to start.
 //   - `models[]`: per-model alias mapping. OPTIONAL (defaults to []) so the
 //     Phase-0 OpenAI-compatible passthrough provider (no models[]) keeps working.
+//   - `map_developer_role_to_system`: opt-in compatibility shim for OpenAI-
+//     compatible upstreams that reject OpenAI's newer `developer` role (e.g.
+//     official DeepSeek). Kept provider-scoped so true OpenAI/Codex can preserve
+//     the higher-priority role.
 // Credentials are stored as a REFERENCE (env var name) only — never plaintext.
 export const ProviderConfigSchema = z
   .object({
@@ -139,6 +143,7 @@ export const ProviderConfigSchema = z
     api_key_env: z.string().min(1).optional(),
     oauth: OAuthCredentialSchema.optional(),
     models: z.array(ProviderModelSchema).default([]),
+    map_developer_role_to_system: z.boolean().default(false),
   })
   .refine((p) => p.name !== undefined || p.alias !== undefined, {
     message: "provider requires `name` or `alias`",


### PR DESCRIPTION
## Summary

- add provider-scoped `map_developer_role_to_system` config, defaulting to `false`
- map OpenAI `developer` messages to `system` only for OpenAI-compatible providers that opt in
- enable the compatibility shim for the checked-in official DeepSeek provider
- thread the flag through gateway provider-client construction
- document the live trace root cause and implementation decision

## Root Cause

Live trace `f51049a7-0d14-4250-9d93-2e057d153f3e` routed to `economy`; `deepseek/deepseek-v4-flash` failed with upstream HTTP 400 because DeepSeek rejected `messages[0].role = "developer"`. Execution fallback then succeeded on `openai-codex/gpt-5.4-mini`.

This is provider compatibility, not lane selection: Responses/OpenAI preserves `developer` as first-class IR, but official DeepSeek's OpenAI-compatible endpoint only accepts roles such as `system`, `user`, `assistant`, and `tool`.

## Validation

- `pnpm exec vitest run packages/core/src/provider/openai.test.ts packages/core/src/config/loader.test.ts packages/core/src/config/samples.test.ts apps/gateway/src/server.oauth.test.ts`
- `pnpm --filter @helm/shared typecheck`
- `pnpm --filter @helm/core typecheck`
- `pnpm --filter @helm/gateway typecheck`
- `pnpm --filter @helm/shared build`
- `pnpm --filter @helm/core build`
- `pnpm --filter @helm/gateway build`

## Deployment Note

Production will need the new code plus the production DeepSeek provider config containing `map_developer_role_to_system: true` for this exact HTTP 400 to disappear online.
