### PR TITLE
Fix Responses function tools for chat upstreams

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-10 · Responses API flat function tools 规范化为 Chat tools（docs/05 协议互译；docs/04 路由执行兜底；CLAUDE.md 原则 2/3/8）
+
+- **缘起**：线上 trace `9b18966a-6f1a-40b0-bae1-d69455005571` 已经不再卡在 DeepSeek `developer` 角色，但官方 DeepSeek 首选候选仍 HTTP 400：`tools[0]: missing field function`。根因是 OpenAI Responses API 的 function tool 输入是扁平形状（`{type:"function", name, description, parameters, strict}`），而网关把它折进 OpenAI-Chat-shaped IR 后又原样发给 Chat Completions upstream；DeepSeek 期望的是 Chat tools 形状（`{type:"function", function:{...}}`）。
+- **修复**：`responsesTransformer.transformRequestOut` 在 Responses → IR 时把扁平 function tools 规范化为 Chat tools，确保所有 OpenAI-compatible Chat upstream 都收到合法 `tools[].function`；原始 Responses tools 同时存入 `provider_raw.responses_tools`，`transformRequestIn` 优先用该原文恢复，避免 Responses round-trip 变形。
+- **取舍**：只转换 `type:"function"` 且带 `name` 的扁平 tool；未知/未来 tool 类型继续 fail-open 保留原样，不在协议层臆造能力。非 Responses 来源的 Chat tools 在输出到 Responses 时会尽量反向扁平化；已有 raw Responses tools 时以 raw 为准。
+- **测试/验证**：TDD 新增 Responses flat function tool → IR Chat tool → Responses raw tool 的回归测试；定向 `pnpm exec vitest run packages/core/src/protocol/responses.test.ts --project node` 43/43 绿；`@helm/core` typecheck 绿。部署前还用生产 DeepSeek key 直连验证：包含 Chat-shaped tools、`reasoning_effort`、`store:false` 的 `deepseek-v4-flash` 请求返回 200。
+- **部署提示**：这是代码路径修复，不是配置修复；线上需要发布新镜像/重启后才会消除 DeepSeek `tools[0].function` 400。历史 trace 仍会保留旧错误。
+
+---
+
 ## 2026-06-09 · DeepSeek provider developer-role 兼容开关（docs/05 协议互译；docs/04 路由执行兜底；CLAUDE.md 原则 2/3/5）
 
 - **缘起**：线上 trace `f51049a7-0d14-4250-9d93-2e057d153f3e` 进入 `economy` lane，首选 `deepseek/deepseek-v4-flash` 失败后 fallback 到 `openai-codex/gpt-5.4-mini` 成功。DeepSeek 真实错误为 HTTP 400：`messages[0].role: unknown variant developer`。根因是 OpenAI Responses/OpenAI Chat 请求中的 `developer` 角色被 OpenAI-compatible client 原样透传给官方 DeepSeek，而 DeepSeek 只接受 `system/user/assistant/tool/...`。
@@ -27,20 +37,11 @@
 
 ---
 
-## 2026-06-09 · LLM 记忆提取/压缩接线与可配置模型（docs/08 记忆；docs/12 遗忘/事实层；CLAUDE.md 原则 2/3/7）
-
-- **缘起**：记忆 observe/inject、worker、compaction trigger、forgetting/facts 已是生产接线，但 Observer/Reflector 仍用确定性 stub 做 summarize/merge/extractFacts；这让“记忆提取/压缩”可用但不具备真正 LLM 归纳能力。
-- **修复**：新增 `memory.llm` 配置子树（默认 `enabled:false`），支持 `model` 基础模型与 `observation_model` / `reflection_model` / `facts_model` 分任务覆盖；同组 `HELM_MEMORY_LLM_*` 环境变量可覆盖模型/开关/超时/温度/max_tokens。网关新增 `memory-llm.ts`，后台 Observer 用 LLM 压缩 raw messages -> observation，Reflector 用 LLM 合并 observations -> reflection，并用 LLM 提取 atomic facts。
-- **安全/降级**：LLM 调用只发生在 memory worker 后台 job，绝不进请求路径；配置错误 fail-closed（Zod strict + enabled 必须有 model），运行时模型不可用、上游失败、超时或 JSON 无效全部 fail-open 回原确定性 stub。日志只写 task/model alias/error class 等安全元数据，不写 prompt/response/memory 正文。
-- **模型解析**：memory model alias 复用执行层语义：OAuth 订阅别名受 live `oauthAliasSet` gate，providers.yaml alias 经 registry 解析，`provider/model` 结构化别名走对应 provider client，裸模型名走 primary provider passthrough；不会因为记忆任务跨过订阅/凭证边界。
-- **PR 评审修复**：LLM merge/fact prompt 不再包含 `previous_reflection`，避免旧 reflection 中已归档/剪枝内容绕过 active-observation filter 复活；LLM facts 强制 `valid_from_observation_id` 且必须命中 active observation，否则整次回退确定性 extractor；observation/reflection/fact 文本改 trim 后 min(1)，纯空白输出触发 fallback；LLM `priority` 标尺改 0–10，对齐 Observer 的 `priority/10` salience 推导。
-- **测试/取舍**：TDD 覆盖 schema 默认关闭与 fail-closed、loader YAML/env 覆盖、observer 使用配置模型、reflection JSON 无效 fallback、fact `valid_from_observation_id` 映射 observation 时间与 `[obs_id, obs_id]` 审计范围、模型不可用 fallback。暂不把 LLM usage 精确计入 cost bucket，沿用 observer/reflector 现有启发式 token 账本；后续若要精确计费可扩展 deps 成本接口。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-09 · LLM 记忆提取/压缩接线与可配置模型：新增默认关闭的 `memory.llm`，后台 Observer/Reflector/facts 可用配置模型替代 deterministic stub；LLM 失败/无效 JSON/空白输出均 fail-open 回 stub，prompt 去掉 `previous_reflection` 并强制 fact citation 命中 active observation。
 
 ### 2026-06-09 · Agentic Signals 反馈接入 ranked-lane 路由：新增默认关闭的 `runtime.signal_feedback`，请求路径读取聚合 signals 后仅可在 ranked lane 内健康提升，不降级、不越过 policy/key/budget caps；读取异常 fail-open。TODO：若后续支持 task lane 反馈，需先定义 task lane → ranked lane 映射。
 

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -60,6 +60,44 @@ describe("responsesTransformer — text.format structured output canonicalizatio
   });
 });
 
+describe("responsesTransformer — function tool canonicalization", () => {
+  it("maps Responses flat function tools to OpenAI Chat tools and preserves the raw shape", async () => {
+    const flatTool = {
+      type: "function",
+      name: "read",
+      description: "Read a file",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+      strict: false,
+    };
+
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: "read README.md",
+      tools: [flatTool],
+    });
+
+    expect(ir.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read a file",
+          parameters: flatTool.parameters,
+          strict: false,
+        },
+      },
+    ]);
+    expect(ir.provider_raw?.responses_tools).toEqual([flatTool]);
+
+    const back = (await responsesTransformer.transformRequestIn?.(ir)) as { tools?: unknown[] };
+    expect(back.tools).toEqual([flatTool]);
+  });
+});
+
 // OpenAI Responses transformer (docs/05). Responses is a DIFFERENT request shape
 // from Chat Completions: instead of `messages[]` (role + content), the
 // conversation is flattened into a top-level `input[]` ITEM stream — user/

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -228,6 +228,46 @@ function responseFormatToResponsesText(rf: unknown): unknown {
   return undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Responses function tools are flat (`{type:"function", name, parameters}`), while
+// Chat Completions upstreams require `{type:"function", function:{...}}`.
+function responsesToolToChatTool(tool: unknown): unknown {
+  if (!isRecord(tool) || tool.type !== "function" || isRecord(tool.function)) return tool;
+  if (typeof tool.name !== "string") return tool;
+
+  const fn: Record<string, unknown> = { name: tool.name };
+  if (typeof tool.description === "string") fn.description = tool.description;
+  if (tool.parameters !== undefined) fn.parameters = tool.parameters;
+  if (tool.strict !== undefined) fn.strict = tool.strict;
+  return { type: "function", function: fn };
+}
+
+function chatToolToResponsesTool(tool: unknown): unknown {
+  if (!isRecord(tool) || tool.type !== "function") return tool;
+  if (typeof tool.name === "string" && !isRecord(tool.function)) return tool;
+  if (!isRecord(tool.function) || typeof tool.function.name !== "string") return tool;
+
+  const fn = tool.function;
+  const out: Record<string, unknown> = { type: "function", name: fn.name };
+  if (typeof fn.description === "string") out.description = fn.description;
+  if (fn.parameters !== undefined) out.parameters = fn.parameters;
+  if (fn.strict !== undefined) out.strict = fn.strict;
+  return out;
+}
+
+function normalizeResponsesTools(tools: unknown[] | undefined): {
+  tools?: unknown[];
+  rawTools?: unknown[];
+} {
+  if (tools === undefined) return {};
+  const normalized = tools.map(responsesToolToChatTool);
+  const changed = normalized.some((tool, index) => tool !== tools[index]);
+  return { tools: normalized, ...(changed ? { rawTools: tools } : {}) };
+}
+
 // —— content-part folding: Responses parts -> IR parts. Unknown parts degrade to a
 // JSON text placeholder so nothing is silently dropped (fail-open). ————————————————
 function foldContentPart(part: z.infer<typeof ResponsesContentPartSchema>): IRContentPart {
@@ -269,6 +309,7 @@ function foldMessageContent(
 function toIRRequest(req: NativeRequest): IRRequest {
   // fail-closed: a structurally invalid request never enters the pipeline.
   const parsed = ResponsesRequestSchema.parse(req);
+  const normalizedTools = normalizeResponsesTools(parsed.tools);
 
   const messages: IRMessage[] = [];
   const thinking: IRThinkingExt[] = [];
@@ -358,6 +399,8 @@ function toIRRequest(req: NativeRequest): IRRequest {
   if (parsed.logit_bias !== undefined) providerRaw.logit_bias = parsed.logit_bias;
   if (parsed.context_management !== undefined)
     providerRaw.context_management = parsed.context_management;
+  if (normalizedTools.rawTools !== undefined)
+    providerRaw.responses_tools = normalizedTools.rawTools;
   // Reasoning config + truncation have no IR field of their own; preserve verbatim.
   // NB: a distinct key — provider_raw.reasoning already holds inbound reasoning ITEMS.
   if (parsed.reasoning !== undefined) providerRaw.reasoning_config = parsed.reasoning;
@@ -371,7 +414,7 @@ function toIRRequest(req: NativeRequest): IRRequest {
   const ir: IRRequest = {
     model: parsed.model,
     messages,
-    ...(parsed.tools !== undefined ? { tools: parsed.tools } : {}),
+    ...(normalizedTools.tools !== undefined ? { tools: normalizedTools.tools } : {}),
     ...(parsed.tool_choice !== undefined ? { tool_choice: parsed.tool_choice } : {}),
     ...(parsed.temperature !== undefined ? { temperature: parsed.temperature } : {}),
     ...(parsed.max_output_tokens !== undefined ? { max_tokens: parsed.max_output_tokens } : {}),
@@ -468,7 +511,11 @@ function toResponsesRequest(ir: IRRequest): NativeRequest {
     ...(instructions !== undefined ? { instructions } : {}),
     input,
     ...(text !== undefined ? { text } : {}),
-    ...(parsed.tools !== undefined ? { tools: parsed.tools } : {}),
+    ...(Array.isArray(raw?.responses_tools)
+      ? { tools: raw.responses_tools }
+      : parsed.tools !== undefined
+        ? { tools: parsed.tools.map(chatToolToResponsesTool) }
+        : {}),
     ...(parsed.tool_choice !== undefined ? { tool_choice: parsed.tool_choice } : {}),
     ...(parsed.temperature !== undefined ? { temperature: parsed.temperature } : {}),
     ...(parsed.max_tokens !== undefined ? { max_output_tokens: parsed.max_tokens } : {}),


### PR DESCRIPTION
## Summary
- Normalize OpenAI Responses flat function tools into Chat Completions tool objects before routing to OpenAI-compatible upstreams.
- Preserve the raw Responses tool shape in provider_raw.responses_tools so Responses round-trips stay lossless.
- Document the production DeepSeek trace failure in implementation notes.

## Verification
- pnpm exec vitest run packages/core/src/protocol/responses.test.ts --project node
- pnpm typecheck
- pnpm lint
- pnpm build
- Direct DeepSeek smoke via production container: Chat-shaped tools + reasoning_effort + store:false returned HTTP 200.

## Live Trace
- Fixes DeepSeek HTTP 400 on trace 9b18966a-6f1a-40b0-bae1-d69455005571: tools[0]: missing field function.