### PR TITLE
Remove JSON tree blank rows

### DIFF
--- a/apps/admin/src/lib/components/JsonViewer.svelte
+++ b/apps/admin/src/lib/components/JsonViewer.svelte
@@ -50,8 +50,12 @@
 
   const tabActive = 'border-action bg-action text-white';
   const tabInactive = 'border-border bg-surface text-ink-muted hover:bg-canvas';
-  const panelCls =
-    'max-h-96 overflow-y-auto overflow-x-hidden rounded bg-canvas p-2 font-mono text-xs whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-ink-body';
+  const basePanelCls =
+    'max-h-96 overflow-y-auto overflow-x-hidden rounded bg-canvas p-2 font-mono text-xs break-words [overflow-wrap:anywhere] text-ink-body';
+  // Tree markup contains recursive <details> with template newlines between nodes.
+  // Keep whitespace normal here so those source newlines do not render as blank rows.
+  const treePanelCls = `${basePanelCls} whitespace-normal`;
+  const textPanelCls = `${basePanelCls} whitespace-pre-wrap`;
 </script>
 
 <div data-testid={testid}>
@@ -65,7 +69,7 @@
     {/each}
   </div>
 
-  <div data-testid="jsonviewer-tree" hidden={tab !== 'tree'} class={panelCls}>
+  <div data-testid="jsonviewer-tree" hidden={tab !== 'tree'} class={treePanelCls}>
     {#if emptyPlaceholder}
       <div class="text-ink-muted">{emptyPlaceholder}</div>
     {:else}
@@ -76,7 +80,9 @@
   <pre
     data-testid="jsonviewer-formatted"
     hidden={tab !== 'formatted'}
-    class={panelCls}>{formatted}</pre>
+    class={textPanelCls}>{formatted}</pre>
 
-  <pre data-testid="jsonviewer-raw" hidden={tab !== 'raw'} class={panelCls}>{normalized.raw}</pre>
+  <pre data-testid="jsonviewer-raw" hidden={tab !== 'raw'} class={textPanelCls}
+    >{normalized.raw}</pre
+  >
 </div>

--- a/apps/admin/src/lib/components/JsonViewer.test.ts
+++ b/apps/admin/src/lib/components/JsonViewer.test.ts
@@ -72,4 +72,11 @@ describe('JsonViewer', () => {
     expect(raw.className).toContain('whitespace-pre-wrap');
     expect(raw.className).toContain('[overflow-wrap:anywhere]');
   });
+
+  it('does not preserve template whitespace in the Tree panel', () => {
+    render(JsonViewer, { value: { input: [{ role: 'user', content: 'hi' }] } });
+    const tree = screen.getByTestId('jsonviewer-tree');
+    expect(tree.className).toContain('whitespace-normal');
+    expect(tree.className).not.toContain('whitespace-pre-wrap');
+  });
 });


### PR DESCRIPTION
## Summary
- Split JsonViewer panel whitespace handling so the Tree tab uses normal whitespace and no longer renders template newlines as blank rows.
- Keep Formatted and Raw tabs on pre-wrap so long JSON still wraps without horizontal scrolling.
- Add a regression test for the Tree panel whitespace class.

## Verification
- pnpm exec vitest run apps/admin/src/lib/components/JsonViewer.test.ts apps/admin/src/lib/components/JsonTree.test.ts --project admin
- pnpm typecheck
- pnpm lint
- pnpm build