### PR TITLE
Add Preview modal for multi-line strings in request detail

### DIFF
--- a/apps/admin/src/lib/components/JsonTree.svelte
+++ b/apps/admin/src/lib/components/JsonTree.svelte
@@ -2,6 +2,7 @@
   import { untrack } from 'svelte';
   import { t } from '$lib/i18n';
   import Self from './JsonTree.svelte';
+  import TextPreview from './TextPreview.svelte';
 
   // One node of the collapsible JSON tree (ported from llm-router's vanilla-JS
   // detail viewer, src/api/admin/views/detail.ts). Recursive: objects/arrays render
@@ -40,6 +41,11 @@
   let expandedStr = $state(false);
 
   const isLongString = $derived(kind === 'string' && (value as string).length > STRING_LIMIT);
+  // A "Preview" opens the DECODED text (real line breaks) in a roomy modal. Offer it
+  // whenever the inline escaped form is hard to read: multi-line OR long strings.
+  const previewable = $derived(
+    kind === 'string' && ((value as string).includes('\n') || isLongString),
+  );
   const scalarText = $derived.by(() => {
     if (kind === 'string') {
       const s = value as string;
@@ -95,6 +101,9 @@
         onclick={() => (expandedStr = !expandedStr)}
         >{expandedStr ? $t('Collapse') : $t('Expand')}</button
       >
+    {/if}
+    {#if previewable}
+      <TextPreview text={value as string} label={name} />
     {/if}
   </div>
 {/if}

--- a/apps/admin/src/lib/components/JsonTree.test.ts
+++ b/apps/admin/src/lib/components/JsonTree.test.ts
@@ -56,6 +56,19 @@ describe('JsonTree', () => {
     expect(scalar.className).toContain('[overflow-wrap:anywhere]');
   });
 
+  it('offers a Preview affordance for a multi-line string (even when short)', () => {
+    render(JsonTree, { value: 'first line\nsecond line', name: 'content' });
+    // Short enough that there is no inline Expand toggle, but multi-line — so the
+    // roomy decoded Preview is what makes it readable.
+    expect(screen.queryByRole('button', { name: /Expand/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId('text-preview-open')).toBeInTheDocument();
+  });
+
+  it('does not offer Preview for a plain short single-line string', () => {
+    render(JsonTree, { value: 'hello', name: 'greeting' });
+    expect(screen.queryByTestId('text-preview-open')).not.toBeInTheDocument();
+  });
+
   it('paginates large arrays at 200 entries with a "show remaining" control', async () => {
     const big = Array.from({ length: 250 }, (_, i) => i);
     render(JsonTree, { value: big });

--- a/apps/admin/src/lib/components/Modal.svelte
+++ b/apps/admin/src/lib/components/Modal.svelte
@@ -10,15 +10,20 @@
   // be acknowledged (e.g. the one-time API-key plaintext reveal — CLAUDE.md 原则7):
   // there is then no scrim and Escape is ignored, so the only exit is an explicit
   // action the caller wires up.
+  // `wide` widens the panel from the default max-w-lg to max-w-3xl, for content
+  // that reads better with room (e.g. a multi-line prompt preview). The utility
+  // is appended so it overrides the @apply max-w-lg baked into .modal-panel.
   let {
     label,
     onclose,
     dismissible = true,
+    wide = false,
     children,
   }: {
     label: string;
     onclose: () => void;
     dismissible?: boolean;
+    wide?: boolean;
     children: Snippet;
   } = $props();
 
@@ -59,7 +64,7 @@
   {/if}
   <div
     bind:this={panel}
-    class="modal-panel"
+    class={`modal-panel${wide ? ' max-w-3xl' : ''}`}
     role="dialog"
     aria-modal="true"
     aria-label={label}

--- a/apps/admin/src/lib/components/TextPreview.svelte
+++ b/apps/admin/src/lib/components/TextPreview.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { t } from '$lib/i18n';
+  import Modal from './Modal.svelte';
+
+  // "Read it like text" affordance for the JSON tree. String values are shown
+  // JSON-escaped there, so real newlines render as the literal two chars `\n` —
+  // unbearable for a long system prompt. This pops a roomy modal that renders the
+  // DECODED string verbatim (whitespace-pre-wrap, real line breaks) plus a
+  // one-click copy. Read-only — never mutates the value.
+  let { text, label }: { text: string; label?: string } = $props();
+
+  let open = $state(false);
+  let copied = $state(false);
+
+  function show(): void {
+    copied = false;
+    open = true;
+  }
+
+  function close(): void {
+    open = false;
+    copied = false;
+  }
+
+  async function copy(): Promise<void> {
+    try {
+      await navigator.clipboard?.writeText(text);
+      copied = true;
+    } catch {
+      // clipboard unavailable (insecure context / private mode) — degrade silently
+    }
+  }
+</script>
+
+<button
+  type="button"
+  class="ml-2 text-link underline"
+  data-testid="text-preview-open"
+  onclick={show}>{$t('Preview')}</button
+>
+
+{#if open}
+  <Modal label={label ?? $t('Preview')} onclose={close} wide>
+    <div class="flex max-h-[80vh] flex-col">
+      <div class="mb-3 flex items-center justify-between gap-2">
+        <h2 class="truncate font-mono text-sm text-ink-body">{label ?? $t('Preview')}</h2>
+        <div class="flex shrink-0 items-center gap-2">
+          <button type="button" class="btn-secondary" onclick={copy}
+            >{copied ? $t('Copied') : $t('Copy')}</button
+          >
+          <button
+            type="button"
+            class="btn-secondary"
+            data-testid="text-preview-close"
+            onclick={close}>{$t('Close')}</button
+          >
+        </div>
+      </div>
+      <pre
+        data-testid="text-preview-body"
+        class="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words rounded bg-canvas p-3 font-mono text-xs leading-relaxed text-ink-body [overflow-wrap:anywhere]">{text}</pre>
+    </div>
+  </Modal>
+{/if}

--- a/apps/admin/src/lib/components/TextPreview.test.ts
+++ b/apps/admin/src/lib/components/TextPreview.test.ts
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import TextPreview from './TextPreview.svelte';
+
+// TextPreview is the "read it like text" affordance for the JSON tree: string
+// values are shown JSON-escaped there (real newlines become the literal two
+// chars `\n`), which is unreadable for system prompts. This opens a roomy modal
+// rendering the DECODED text with real line breaks, plus a one-click copy.
+// i18n falls back to the English key in tests (messages store empty), so we
+// assert on English strings.
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TextPreview', () => {
+  it('renders a Preview button and keeps the modal closed initially', () => {
+    render(TextPreview, { text: 'line one\nline two' });
+    expect(screen.getByTestId('text-preview-open')).toBeInTheDocument();
+    expect(screen.queryByTestId('text-preview-body')).not.toBeInTheDocument();
+  });
+
+  it('opens a modal whose body holds the DECODED multi-line text', async () => {
+    render(TextPreview, { text: 'line one\nline two' });
+    await fireEvent.click(screen.getByTestId('text-preview-open'));
+    const body = screen.getByTestId('text-preview-body');
+    // The raw string is rendered verbatim — a real newline, not the chars `\n`.
+    expect(body.textContent).toBe('line one\nline two');
+    expect(body.textContent).not.toContain('\\n');
+    expect(body.className).toContain('whitespace-pre-wrap');
+  });
+
+  it('uses a wide modal panel for comfortable reading', async () => {
+    render(TextPreview, { text: 'a\nb' });
+    await fireEvent.click(screen.getByTestId('text-preview-open'));
+    expect(screen.getByRole('dialog').className).toContain('max-w-3xl');
+  });
+
+  it('copies the raw text and flips the label to Copied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    render(TextPreview, { text: 'alpha\nbeta' });
+    await fireEvent.click(screen.getByTestId('text-preview-open'));
+    await fireEvent.click(screen.getByRole('button', { name: /Copy/i }));
+    expect(writeText).toHaveBeenCalledWith('alpha\nbeta');
+    expect(await screen.findByRole('button', { name: /Copied/i })).toBeInTheDocument();
+  });
+
+  it('dismisses the modal via the Close button', async () => {
+    render(TextPreview, { text: 'x\ny' });
+    await fireEvent.click(screen.getByTestId('text-preview-open'));
+    expect(screen.getByTestId('text-preview-body')).toBeInTheDocument();
+    await fireEvent.click(screen.getByTestId('text-preview-close'));
+    expect(screen.queryByTestId('text-preview-body')).not.toBeInTheDocument();
+  });
+
+  it('shows the label as the modal title when provided', async () => {
+    render(TextPreview, { text: 'a\nb', label: 'content' });
+    await fireEvent.click(screen.getByTestId('text-preview-open'));
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-label', 'content');
+  });
+});

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -319,6 +319,7 @@
   "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.",
   "Policies": "Policies",
   "Port": "Port",
+  "Preview": "Preview",
   "Previous": "Previous",
   "Primary": "Primary",
   "Primary is required and cannot be empty.": "Primary is required and cannot be empty.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -313,6 +313,7 @@
   "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "キーごとのレート制限。空欄の場合はシステムのデフォルトを使用します。0 はその項目が無制限であることを意味します。",
   "Policies": "ポリシー",
   "Port": "ポート",
+  "Preview": "プレビュー",
   "Previous": "前へ",
   "Primary": "プライマリ",
   "Primary is required and cannot be empty.": "プライマリは必須で、空にできません。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -313,6 +313,7 @@
   "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "키별 속도 제한입니다. 비워 두면 시스템 기본값을 사용합니다. 0은 해당 항목이 무제한임을 의미합니다.",
   "Policies": "정책",
   "Port": "포트",
+  "Preview": "미리보기",
   "Previous": "이전",
   "Primary": "기본",
   "Primary is required and cannot be empty.": "기본은 필수이며 비워둘 수 없습니다.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -319,6 +319,7 @@
   "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "每个密钥的速率限制。留空则使用系统默认值。0 表示该维度不限。",
   "Policies": "策略",
   "Port": "端口",
+  "Preview": "预览",
   "Previous": "上一页",
   "Primary": "主用",
   "Primary is required and cannot be empty.": "主用为必填，不能为空。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -313,6 +313,7 @@
   "Per-key rate limits. Leave blank to use the system default. 0 means unlimited for that dimension.": "每個金鑰的速率限制。留空則使用系統預設值。0 表示該維度不限。",
   "Policies": "策略",
   "Port": "連接埠",
+  "Preview": "預覽",
   "Previous": "上一頁",
   "Primary": "主用",
   "Primary is required and cannot be empty.": "主用為必填，不能為空。",

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-10 · 请求详情页：多行/长字符串「预览」弹窗（docs/07 可观测性；docs/11 管理界面）
+
+- **缘起**：请求详情页 JSON 树里，字符串值用 `JSON.stringify(s)` 渲染，真实换行被转义成字面量两字符 `\n`，长 system/developer prompt 挤成一坨；`whitespace-pre-wrap` 无真换行可断，用户每次都要 copy 出来手动把 `\n` 换成回车才能读。
+- **修复**：新增 `TextPreview.svelte`——对多行或长（>512）字符串在树节点旁挂一个「Preview」按钮，点开复用 `Modal` 渲染**解码后原文**（`whitespace-pre-wrap` 真换行）+ 一键 Copy。`Modal` 加可选 `wide` prop（`max-w-3xl`，靠 utility 层覆盖 `.modal-panel` 的 `@apply max-w-lg`）。`JsonTree` 触发条件 `includes('\n') || isLongString`；保留原 inline Expand（仍显示转义 JSON 形态）不动，避免破坏既有测试。修复落在 `JsonTree`，请求与响应两个 `JsonViewer` 自动都受益。
+- **取舍**：只读视图，零 core/config 改动；短单行标量不挂按钮保持干净。i18n 仅新增 `Preview` 一个 key（Copy/Copied/Close 复用），五语言齐补。
+- **验证**：TDD 先红后绿——`TextPreview.test.ts`（解码换行、wide 面板、Copy 调 clipboard、Close 关闭、label 作标题）+ `JsonTree.test.ts` 扩两例（多行短串有按钮、单行短串无按钮）。admin 全量 31 文件 279 绿；`pnpm lint`、Prettier check 绿；`svelte-check` 仅剩 3 条**预存在**的 `oauth.test.ts` tuple 报错（main 上已有，CI 的 `tsc` typecheck 跳过 `*.test.ts`，与本改无关）。
+- **部署提示**：admin 静态资源改动，线上需构建发布新 admin/网关镜像才生效。
+
+---
+
 ## 2026-06-10 · Responses API flat function tools 规范化为 Chat tools（docs/05 协议互译；docs/04 路由执行兜底；CLAUDE.md 原则 2/3/8）
 
 - **缘起**：线上 trace `9b18966a-6f1a-40b0-bae1-d69455005571` 已经不再卡在 DeepSeek `developer` 角色，但官方 DeepSeek 首选候选仍 HTTP 400：`tools[0]: missing field function`。根因是 OpenAI Responses API 的 function tool 输入是扁平形状（`{type:"function", name, description, parameters, strict}`），而网关把它折进 OpenAI-Chat-shaped IR 后又原样发给 Chat Completions upstream；DeepSeek 期望的是 Chat tools 形状（`{type:"function", function:{...}}`）。
@@ -27,19 +37,11 @@
 
 ---
 
-## 2026-06-09 · 请求详情页 Responses API 流式回放与 JSON 换行修复（docs/05 协议互译；docs/07 可观测性；docs/11 管理界面）
-
-- **缘起**：线上请求详情页的 captured payload 里，响应是 OpenAI Responses API SSE（`event: response.output_text.delta` / `response.completed`），但 admin 侧 `StreamViewer` 只会组装 OpenAI Chat chunk 与 Anthropic events；`response.*` 事件被误走 Anthropic 分支，最终显示 “No visible output”。同页请求 JSON viewer 使用 `overflow-auto` + `<pre>` 默认不换行，长 prompt/request body 触发横向滚动条。
-- **修复**：`parseSseStream` 新增 Responses API `response.*` 分支，在 Anthropic 分支前匹配，累积 `response.output_text.delta` 为最终可见 content，并读取 `response.completed.response.usage/model/status`；`output_text.done` / `content_part.done` / `output_item.done` 只作截断捕获的兜底快照，不把完成态全文再次 append，避免重复。顺带支持 Responses API reasoning 与 function_call argument delta 的基础合并。
-- **UI 取舍**：`JsonViewer` 三个 tab 统一 `overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words [overflow-wrap:anywhere]`；`JsonTree` scalar 同样允许长字符串强制断行。保留垂直最大高度滚动，移除横向滚动；长不可断 token 也会按 anywhere 折行。
-- **验证**：TDD 新增 Responses API SSE parser / StreamViewer 用例，以及 JSON formatted/raw panel 与 scalar wrap 用例。定向 Vitest 40/40 绿；Prettier check 绿；同一线上 trace 的 payload 经本地新 parser 解析为 37 events、`protocol=openai`、`finishReason=completed`、content 正常非空。
-- **部署提示**：本次只改本地源码与测试，未执行生产部署。线上要生效需构建并发布新的 admin 静态资源/网关镜像。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-09 · 请求详情页 Responses API 流式回放与 JSON 换行修复：`parseSseStream` 加 Responses `response.*` 分支（Anthropic 前匹配，累积 `output_text.delta`、读 `response.completed` usage/model/status、done 事件仅兜底快照不重复 append）；`JsonViewer` 三 tab 与 `JsonTree` scalar 统一 `whitespace-pre-wrap break-words [overflow-wrap:anywhere]` 去横向滚动。Vitest 40/40 绿。
 
 ### 2026-06-09 · LLM 记忆提取/压缩接线与可配置模型：新增默认关闭的 `memory.llm`，后台 Observer/Reflector/facts 可用配置模型替代 deterministic stub；LLM 失败/无效 JSON/空白输出均 fail-open 回 stub，prompt 去掉 `previous_reflection` 并强制 fact citation 命中 active observation。
 


### PR DESCRIPTION
## Problem

On the request detail page (`请求轨迹`), the JSON tree renders string values via `JSON.stringify(s)`, which escapes real newlines into the literal two characters `\n`. So `whitespace-pre-wrap` has nothing to wrap on — long system/developer prompts render as one unreadable run. Today the only workaround is to copy the value out and replace `\n` with real line breaks by hand.

## Change

Add a **Preview** (预览) affordance next to multi-line or long (>512) string scalars. Clicking opens a roomy, scrollable modal that renders the **decoded** text with real line breaks, plus a one-click **Copy**.

- New `TextPreview.svelte` (button + modal). Trigger: `value.includes('\n') || isLongString`.
- `Modal.svelte` gains an optional `wide` prop (`max-w-3xl`, overrides the `@apply max-w-lg` baked into `.modal-panel`).
- Wired into `JsonTree.svelte` — so **both** Request and Response viewers benefit automatically.
- Inline `Expand` toggle (escaped JSON form) is kept unchanged.
- One new i18n key `Preview` across all 5 locales; `Copy`/`Copied`/`Close` reused.

Read-only view; no core or config changes.

## Tests

- TDD red→green: new `TextPreview.test.ts` (decoded newlines, wide panel, Copy→clipboard, Close, label as title) + extended `JsonTree.test.ts` (multi-line short string shows Preview; plain single-line does not).
- Admin Vitest suite: **279/279 green**. `pnpm lint` + Prettier clean.
- `svelte-check`: only 3 **pre-existing** `oauth.test.ts` tuple errors remain (already on `main`; CI's `tsc` typecheck excludes `*.test.ts`) — unrelated to this change.

## Deploy note

Admin static-asset change — requires building/publishing a new admin/gateway image to take effect online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)