### PR TITLE
Fix cursor on request-detail Expand/Preview links

### DIFF
--- a/apps/admin/src/lib/components/JsonTree.svelte
+++ b/apps/admin/src/lib/components/JsonTree.svelte
@@ -97,7 +97,7 @@
     {#if isLongString}
       <button
         type="button"
-        class="ml-2 text-link underline"
+        class="ml-2 cursor-pointer text-link underline"
         onclick={() => (expandedStr = !expandedStr)}
         >{expandedStr ? $t('Collapse') : $t('Expand')}</button
       >

--- a/apps/admin/src/lib/components/TextPreview.svelte
+++ b/apps/admin/src/lib/components/TextPreview.svelte
@@ -34,7 +34,7 @@
 
 <button
   type="button"
-  class="ml-2 text-link underline"
+  class="ml-2 cursor-pointer text-link underline"
   data-testid="text-preview-open"
   onclick={show}>{$t('Preview')}</button
 >


### PR DESCRIPTION
The **Expand** and **Preview** affordances in the request-detail JSON tree are `<button>` elements styled to look like anchor links (`text-link underline`), but a `<button>` defaults to the arrow cursor rather than the pointer (hand) cursor a real link shows on hover. This made them feel non-clickable.

Adds `cursor-pointer` to both buttons (`JsonTree.svelte` Expand, `TextPreview.svelte` Preview). Applied to the buttons themselves — **not** the shared `.text-link` class, which is also used on non-clickable spans like the JSON key label.

Pure presentation fix; no logic/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)