### PR TITLE
chore(release): v0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.10.4 (patch). Bumps root `package.json` only — CI auto-cuts the tag + GitHub Release on merge (#158 flow).

## Included since v0.10.3
- Fix cursor on request-detail Expand/Preview links (#157)
- Add Expand all / Collapse all to the JSON tree viewer (#159)

🤖 Generated with [Claude Code](https://claude.com/claude-code)