### PR TITLE
Keep the root node open on Collapse all

### DIFF
--- a/apps/admin/src/lib/components/JsonTree.svelte
+++ b/apps/admin/src/lib/components/JsonTree.svelte
@@ -46,7 +46,8 @@
   // mount (nonce 0) — that keeps each node's default depth-based open state on first
   // render. Expanding cascades for free: opening a node renders its children, which
   // mount and read the still-active command. Scalars carry an unused `open`, so the
-  // assignment is harmless for them.
+  // assignment is harmless for them. Collapse all keeps the root (depth 0) open so
+  // the top-level keys stay visible — only the descendants fold.
   const treeCtl = getJsonTreeCtl();
   let appliedNonce = 0;
   $effect(() => {
@@ -54,7 +55,7 @@
     const n = treeCtl.nonce;
     if (n === 0 || n === appliedNonce) return;
     appliedNonce = n;
-    open = treeCtl.allOpen;
+    open = treeCtl.allOpen || depth === 0;
   });
 
   const isLongString = $derived(kind === 'string' && (value as string).length > STRING_LIMIT);

--- a/apps/admin/src/lib/components/JsonViewer.test.ts
+++ b/apps/admin/src/lib/components/JsonViewer.test.ts
@@ -89,20 +89,24 @@ describe('JsonViewer', () => {
     expect(screen.getByText(/c:/)).toBeInTheDocument();
   });
 
-  it('folds the tree back to the root when Collapse all is clicked', async () => {
-    render(JsonViewer, { value: { a: { b: 1 } } });
-    // a/b are open by default at depth < 2
-    expect(screen.getByText(/a:/)).toBeInTheDocument();
+  it('folds descendants but keeps the root open on Collapse all', async () => {
+    render(JsonViewer, { value: { a: { b: { c: 1 } } } });
+    // expand everything first so the deep nodes are in the DOM
+    await fireEvent.click(screen.getByRole('button', { name: /Expand all/i }));
+    expect(screen.getByText(/c:/)).toBeInTheDocument();
     await fireEvent.click(screen.getByRole('button', { name: /Collapse all/i }));
-    // every node folds, including the root — only the Object(1) summary remains
-    expect(screen.queryByText(/a:/)).not.toBeInTheDocument();
-    expect(screen.getByText(/Object\(1\)/)).toBeInTheDocument();
+    // the root stays open, so its direct children are still visible...
+    expect(screen.getByText(/a:/)).toBeInTheDocument();
+    // ...but everything below the root is folded away
+    expect(screen.queryByText(/b:/)).not.toBeInTheDocument();
   });
 
   it('re-expands after a collapse all (broadcast nonce re-fires)', async () => {
     render(JsonViewer, { value: { a: { b: { c: 1 } } } });
     await fireEvent.click(screen.getByRole('button', { name: /Collapse all/i }));
-    expect(screen.queryByText(/a:/)).not.toBeInTheDocument();
+    // root stays open (a visible) but its subtree is collapsed (b hidden)
+    expect(screen.getByText(/a:/)).toBeInTheDocument();
+    expect(screen.queryByText(/b:/)).not.toBeInTheDocument();
     await fireEvent.click(screen.getByRole('button', { name: /Expand all/i }));
     expect(screen.getByText(/c:/)).toBeInTheDocument();
   });


### PR DESCRIPTION
Follow-up to #159. **Collapse all** folded every node including the root, hiding the top-level keys entirely. Now the root (depth 0) stays open so its immediate children remain visible and only the descendants fold — the conventional "collapse all" behaviour.

One-line change in `JsonTree.svelte`'s broadcast effect (`open = treeCtl.allOpen || depth === 0`), plus updated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)