### PR TITLE
chore(release): v0.10.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.10.5 (patch). Bumps root `package.json` only — CI auto-cuts tag + GitHub Release on merge (#158 flow).

## Included since v0.10.4
- Keep the root node open on Collapse all (#161)

🤖 Generated with [Claude Code](https://claude.com/claude-code)