### PR TITLE
feat(routing): virtual model-alias map for vendor model ids

### DIFF
--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -74,6 +74,7 @@ import {
   startMemoryWorker,
   startSignalScheduler,
   toRegistryProviders,
+  validateModelAliasTargets,
 } from "@helm/core";
 import type {
   CatalogEntry,
@@ -989,6 +990,21 @@ export async function buildServer(
   // via the schema, so an absent policies.yaml is a no-op.
   let lanes: LanesConfig = config.lanes ?? parseLanesConfig(DEFAULT_LANES);
   let policies: PoliciesConfig = config.policies;
+  // Virtual model aliases (docs/04 compatibility shim): a fixed-model client
+  // (Claude CLI, an SDK pinned to a vendor id like "claude-opus-4-8") has its
+  // `model` rewritten onto a lane/"auto" before routing, so it no longer 400s.
+  // Validate every target against the EFFECTIVE lane set (config.lanes or
+  // DEFAULT_LANES) — fail-closed (principle 2) so a typo'd target refuses to boot
+  // rather than 400ing per request. Static config (not admin-editable), so it is
+  // captured once; an admin lane deletion that orphans an alias degrades to a
+  // request-time 400 for that one vendor id, never a crash.
+  const modelAliases = config.model_aliases;
+  const aliasErrors = validateModelAliasTargets(modelAliases, Object.keys(lanes));
+  if (aliasErrors.length > 0) {
+    throw new Error(
+      `invalid model-aliases.yaml:\n${aliasErrors.map((e) => `  - ${e}`).join("\n")}`,
+    );
+  }
   // Live classifier config. `let` so an admin edit (via the runtime RuleStore's
   // onClassifier callback below) re-binds the value the classify adapter reads
   // per request — classifier changes hot-apply WITHOUT a restart (closes the
@@ -1221,6 +1237,7 @@ export async function buildServer(
           classify: (r) => classify(r, classifyOverrides),
           policies,
           lanes,
+          modelAliases,
           execute: createExecute({
             defaultProvider: provider,
             providers: providerClients,

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -1,0 +1,44 @@
+# model-aliases.yaml — virtual model map (docs/04 compatibility shim).
+#
+# A flat map of an inbound VENDOR model id -> a LANE name (config/lanes.yaml) or
+# the "auto" sentinel. Clients that send a FIXED model id (Claude Code's
+# `claude-opus-4-8`, an SDK pinned to a vendor model) don't know Helm's lanes or
+# provider aliases — so their `model` field is rewritten onto a lane BEFORE
+# routing, and they stop getting `400 unknown model`.
+#
+# WHY a lane (not a provider model): Helm exposes the LANE abstraction, never the
+# model market (principle 6). A virtual id maps to a lane and keeps the lane's full
+# fallback chain + failover. The mapping is operator-authorized, so it works for
+# ANY key (allow_custom_model NOT required); a key's `allowed_lanes` whitelist is
+# still enforced.
+#
+# MATCHING: an exact key wins; otherwise the matching `*`-glob with the most
+# literal characters wins (so `claude-opus-*` beats `claude-*` regardless of
+# order). `*` = any run of chars (incl. empty) — it absorbs the date suffix Claude
+# Code appends (`claude-opus-4-8-20260115`). Case-sensitive.
+#
+# FAIL-CLOSED (principle 2): every target must be a configured lane or "auto", or
+# the gateway refuses to boot. This file is OPTIONAL — delete it for no rewrite.
+#
+# NOTE: only BARE vendor ids are matched here. Internal provider aliases are
+# `provider/model` (e.g. `zenmux/claude-opus-4.7`), which never start with
+# `claude`/`gpt`, so an allow_custom_model key can still address them explicitly.
+
+# ── Anthropic / Claude Code ──────────────────────────────────────────────────
+# Claude Code sends two classes: the main model and a small/fast background model
+# (ANTHROPIC_SMALL_FAST_MODEL, usually Haiku). Map the small one to economy, the
+# strong ones to premium/balanced. Tip: you can also just set ANTHROPIC_MODEL=auto
+# in Claude Code to let Helm's classifier pick per request.
+"claude-3-5-haiku": economy
+"claude-3-5-haiku-*": economy # dated id, e.g. claude-3-5-haiku-20241022
+"claude-haiku-*": economy
+"claude-opus-*": premium
+"claude-sonnet-*": balanced
+"claude-*": balanced # catch-all for any other / future Claude id
+
+# ── OpenAI-compatible clients (Codex, Cursor, …) ─────────────────────────────
+# Bare GPT ids → lanes. Comment these out if you don't front any GPT clients.
+"gpt-5.5": premium
+"gpt-5-codex": coding
+"gpt-5*": premium
+"gpt-*": balanced

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,21 @@
 
 ---
 
+## 2026-06-10 · 虚拟模型别名映射 model-aliases.yaml（docs/04 路由；CLAUDE.md 原则 1/2/6）
+
+- **缘起**：用户把网关接入 Claude CLI 失败——CLI 发来 `model: "claude-opus-4-8"`（裸厂商 id），但网关只认三种 `model`：`auto`、lane 名、内部 `provider/model` 别名。在 `allow_custom_model` key 上 `claude-opus-4-8` 命中 `route-request.ts` 的 explicit-MODEL 严格校验（`isKnownModel` 假）→ 400 `unknown model`。需要一层「虚拟名 → 真实目标」映射做兼容。
+- **决定（关键取舍）**：映射目标限定为 **lane 名或 `auto`**，**不**映射到具体 provider 别名——守住「只暴露 lane 抽象、不暴露模型市场」（原则 6），且天然保留 lane 的 fallback/failover。新增纯函数模块 `packages/core/src/routing/model-alias.ts`：`resolveModelAlias(model, map)` + `validateModelAliasTargets(map, laneNames)`。
+- **解析位置 + cap-bounded（关键，含 Codex review P1 修复）**：在 `plan()` 最顶端 step-0 解析，alias→lane 走**独立的 0a 分支**——**不是** `allow_custom_model` 直通。它对**任何 key**生效（操作者配置即授权），但**不绕过路由大脑的 cap**：用 `aliasPolicyContext(req)`（中性 `task_type:"passthrough"`，只带真实 org_id/user_id）跑 `evaluatePolicies` + `applyCaps`，再叠加 key 的 `allowed_lanes`，**两层 cap 都静默 clamp**（与分类路径一致）。⇒ 身份维度的 policy cap（如出厂 `budget_org_cap`）与 key cap 仍然约束别名 lane，标准 key 无法借别名越过它本应受的 cap。任务/复杂度维度的 policy 不命中（别名请求未分类，本就不该被重分类）。`req.requested_model` 不改写（DecisionRecord 记原值），`policy.reason` 记 `model alias "x" -> lane "y"`（被 clamp 时追加 `(capped to "z")`）。
+- **与 explicit/auto 的边界**：`allow_custom_model` 显式分支（1a/1b）**保持原样不变**（back-compat）——只有裸厂商 id 命中别名表才走 0a，allow_custom_model key 仍可直接发 lane 名/内部 `provider/model` 别名走显式直通。alias→`auto` 不进 0a，也被显式分支用 `!aliasToAuto` 排除，落到 classify（不会把原始厂商 id 当显式 model 透传）。degradeLane（超预算）压制 0a，落到强制降级 lane，杜绝绕过。
+- **匹配规则**：精确键优先；否则取「字面字符最多」的 `*`-glob（`claude-opus-*` 胜过 `claude-*`，与声明顺序无关），吸收 Claude Code 追加的日期后缀；大小写敏感（沿用 eval-cache-key「不 lowercase」约定）；glob 把模型名当字面串匹配（`gpt-5.5` 的 `.` 不是通配）。
+- **fail-closed**：`ModelAliasesSchema = z.record(string,string)` 只校验形状；语义校验（每个目标是已配置 lane 或 `auto`）在 server boot 用 `validateModelAliasTargets` 对**有效 lane 集**（`config.lanes` 或 `DEFAULT_LANES`）跑，非法即抛、拒绝启动（原则 2）。`config/model-aliases.yaml` 可选，缺省即不改写（行为与今日一致）。
+- **Codex review P3 修复**：出厂 Haiku 映射补 `claude-3-5-haiku-*: economy`，覆盖带日期的 `claude-3-5-haiku-20241022`（否则落到宽泛 `claude-*: balanced`，small/fast 后台模型映射不完整）。samples.test 加断言锁定。
+- **默认配置**：仓库 `config/model-aliases.yaml` 出厂带激活映射（claude-haiku→economy、claude-opus→premium、claude-sonnet/claude-*→balanced、gpt-* 若干），让新装 + Claude CLI 开箱即用。裸 id 才匹配；内部别名是 `provider/model`（不以 `claude`/`gpt` 开头），allow_custom_model key 仍可显式寻址。
+- **坑/TODO**：① 模型别名为**静态配置**（非 admin 可改），boot 时一次性校验；admin 运行时删 lane 若孤立某别名，仅对该裸 id 退化为请求时 400，不崩。② `/v1/models` 未列出虚拟别名（Claude CLI 不靠它路由），有需要可后续补。③ **线上 la.atmy.work 部署不会覆盖 operator 的 `config/` 目录（见 [[deploy-never-overwrite-config]]）——需手动在 `/opt/helm-api/config` 放 `model-aliases.yaml` 才生效**。
+- **验证**：TDD 先红后绿——`model-alias.test.ts`(12) + `route-request.test.ts` 新增「虚拟别名」8 例（默认 key 命中、先于 400 解析、glob、`auto` 走分类、allowed_lanes 静默 clamp、**policy cap 约束/不越权 review P1**、不匹配落分类、degradeLane 压制）+ samples.test 加出厂 yaml↔lanes 一致性 + 日期 Haiku→economy 守卫。core 全量 1812 绿、gateway 路由/server boot 绿、typecheck/lint 绿。
+
+---
+
 ## 2026-06-10 · publish.yml 版本号升级自动发布 Release（CI/CD；CLAUDE.md Git 工作流 / 原则 2）
 
 - **缘起**：用户发现 push main 触发的 `publish.yml` 只刷 GHCR `:latest` + `:sha-<short>`，**从不创建 GitHub Release**；版本 tag 与 Release 一直靠手工 `git tag` + `gh release create`（见 [[release-procedure]]）。用户希望「提交后自动发」。AskUserQuestion 选定**「版本号自动发布」**方案。
@@ -32,19 +47,11 @@
 
 ---
 
-## 2026-06-10 · 请求详情页：多行/长字符串「预览」弹窗（docs/07 可观测性；docs/11 管理界面）
-
-- **缘起**：请求详情页 JSON 树里，字符串值用 `JSON.stringify(s)` 渲染，真实换行被转义成字面量两字符 `\n`，长 system/developer prompt 挤成一坨；`whitespace-pre-wrap` 无真换行可断，用户每次都要 copy 出来手动把 `\n` 换成回车才能读。
-- **修复**：新增 `TextPreview.svelte`——对多行或长（>512）字符串在树节点旁挂一个「Preview」按钮，点开复用 `Modal` 渲染**解码后原文**（`whitespace-pre-wrap` 真换行）+ 一键 Copy。`Modal` 加可选 `wide` prop（`max-w-3xl`，靠 utility 层覆盖 `.modal-panel` 的 `@apply max-w-lg`）。`JsonTree` 触发条件 `includes('\n') || isLongString`；保留原 inline Expand（仍显示转义 JSON 形态）不动，避免破坏既有测试。修复落在 `JsonTree`，请求与响应两个 `JsonViewer` 自动都受益。
-- **取舍**：只读视图，零 core/config 改动；短单行标量不挂按钮保持干净。i18n 仅新增 `Preview` 一个 key（Copy/Copied/Close 复用），五语言齐补。
-- **验证**：TDD 先红后绿——`TextPreview.test.ts`（解码换行、wide 面板、Copy 调 clipboard、Close 关闭、label 作标题）+ `JsonTree.test.ts` 扩两例（多行短串有按钮、单行短串无按钮）。admin 全量 31 文件 279 绿；`pnpm lint`、Prettier check 绿；`svelte-check` 仅剩 3 条**预存在**的 `oauth.test.ts` tuple 报错（main 上已有，CI 的 `tsc` typecheck 跳过 `*.test.ts`，与本改无关）。
-- **部署提示**：admin 静态资源改动，线上需构建发布新 admin/网关镜像才生效。
-
----
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-10 · 请求详情页多行/长字符串「预览」弹窗：新增 `TextPreview.svelte`，对多行或 >512 字符串在 `JsonTree` 节点挂「Preview」按钮，复用 `Modal`（新增 `wide` prop）渲染解码后原文 + Copy；只读、零 core/config 改动；admin 279 绿。需发新 admin 镜像生效。
 
 ### 2026-06-10 · Responses API flat function tools 规范化为 Chat tools：`responsesTransformer.transformRequestOut` 把扁平 `{type:"function",name,...}` 规范成 Chat `tools[].function`（修官方 DeepSeek `tools[0]: missing field function` 400），原文存 `provider_raw.responses_tools` 供 round-trip 恢复；只转带 name 的 function tool，未知类型 fail-open。core 43/43 绿，生产 DeepSeek 直连 200。需发新镜像生效。
 

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -53,6 +53,12 @@ const CONFIG_FILES: ReadonlyArray<{
   // applies (forgetting.enabled:false → behaviour identical to today; the gateway
   // still boots). A present-but-invalid file fails closed (strict/refine throws).
   { file: "memory.yaml", key: "memory", optional: true },
+  // model-aliases.yaml is a FLAT map (vendor model id -> lane | "auto"), so the
+  // whole file becomes the `model_aliases` key (mirrors lanes.yaml). Optional:
+  // absent → config.model_aliases undefined → no virtual rewrite. A present-but-
+  // invalid file (non-string entries) fails closed; the lane-target semantic check
+  // is fail-closed at boot (validateModelAliasTargets, server wiring).
+  { file: "model-aliases.yaml", key: "model_aliases", optional: true },
 ];
 
 type Mutable = Record<string, unknown>;

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { HelmConfigSchema } from "@helm/shared";
 import { describe, expect, it } from "vitest";
 import { parse as parseYaml } from "yaml";
+import { resolveModelAlias, validateModelAliasTargets } from "../routing/model-alias.js";
 import { loadConfig } from "./loader.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -64,6 +65,22 @@ describe("checked-in config samples", () => {
     expect(lanes.json?.constraints.require_json).toBe(true);
     expect(lanes.vision?.constraints.require_vision).toBe(true);
     expect(lanes.tool_use?.constraints.require_tools).toBe(true);
+  });
+
+  it("loads the shipped model-aliases.yaml with every target a real shipped lane or auto", () => {
+    const cfg = loadConfig({ configDir, env: {} });
+    const aliases = cfg.model_aliases;
+    if (aliases === undefined) throw new Error("config/model-aliases.yaml must load");
+    // Covers the Claude Code default (claude-opus-4-8 -> a lane), proving the shim.
+    const laneNames = Object.keys(cfg.lanes ?? {});
+    const opusTarget = resolveModelAlias("claude-opus-4-8", aliases);
+    expect(opusTarget && laneNames.includes(opusTarget)).toBe(true);
+    // The small/fast background model maps to economy even with a date suffix
+    // (the common dated Haiku id shape) — not the broad claude-* catch-all.
+    expect(resolveModelAlias("claude-3-5-haiku-20241022", aliases)).toBe("economy");
+    // The shipped aliases must validate against the SHIPPED lanes (no drift): every
+    // target is a configured lane or "auto", or the gateway would refuse to boot.
+    expect(validateModelAliasTargets(aliases, laneNames)).toEqual([]);
   });
 
   it("loads the shipped policies.yaml as first-match rules", () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -551,6 +551,14 @@ export {
   type ResolveLaneInput,
   resolveLane,
 } from "./routing/lane-resolver.js";
+// Virtual model-alias map (docs/04 compatibility shim) — resolver + boot-time
+// fail-closed target validator, consumed by route-request (rewrite) and the
+// gateway composition root (boot validation).
+export {
+  type ModelAliasMap,
+  resolveModelAlias,
+  validateModelAliasTargets,
+} from "./routing/model-alias.js";
 export {
   applyCaps,
   evaluatePolicies,

--- a/packages/core/src/routing/model-alias.test.ts
+++ b/packages/core/src/routing/model-alias.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelAlias, validateModelAliasTargets } from "./model-alias.js";
+
+describe("resolveModelAlias", () => {
+  it("returns null when no map is configured", () => {
+    expect(resolveModelAlias("claude-opus-4-8", undefined)).toBeNull();
+    expect(resolveModelAlias("claude-opus-4-8", {})).toBeNull();
+  });
+
+  it("resolves an exact match", () => {
+    expect(resolveModelAlias("claude-opus-4-8", { "claude-opus-4-8": "premium" })).toBe("premium");
+  });
+
+  it("resolves a single-* glob match", () => {
+    expect(resolveModelAlias("claude-sonnet-4-6", { "claude-sonnet-*": "balanced" })).toBe(
+      "balanced",
+    );
+    // `*` also matches a trailing date suffix Claude Code appends.
+    expect(resolveModelAlias("claude-opus-4-8-20260115", { "claude-opus-*": "premium" })).toBe(
+      "premium",
+    );
+  });
+
+  it("an exact key wins over a matching glob", () => {
+    const map = { "claude-*": "balanced", "claude-opus-4-8": "premium" };
+    expect(resolveModelAlias("claude-opus-4-8", map)).toBe("premium");
+  });
+
+  it("prefers the glob with the most literal characters, regardless of declaration order", () => {
+    const general = { "claude-*": "balanced", "claude-opus-*": "premium" };
+    const reversed = { "claude-opus-*": "premium", "claude-*": "balanced" };
+    expect(resolveModelAlias("claude-opus-4-8", general)).toBe("premium");
+    expect(resolveModelAlias("claude-opus-4-8", reversed)).toBe("premium");
+    // A non-opus claude id still falls to the general catch-all.
+    expect(resolveModelAlias("claude-haiku-4-5", general)).toBe("balanced");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(resolveModelAlias("gpt-5.5", { "claude-*": "balanced" })).toBeNull();
+  });
+
+  it("is case-sensitive (no lowercasing, mirroring the eval-cache-key convention)", () => {
+    expect(resolveModelAlias("Claude-Opus", { "claude-*": "balanced" })).toBeNull();
+  });
+
+  it("can map a virtual name onto the auto sentinel", () => {
+    expect(resolveModelAlias("claude-opus-4-8", { "claude-*": "auto" })).toBe("auto");
+  });
+
+  it("treats regex metacharacters in the model name literally", () => {
+    // The model is matched as a literal string; `.` in the id is not a wildcard.
+    expect(resolveModelAlias("gpt-5.5", { "gpt-5.5": "premium" })).toBe("premium");
+    expect(resolveModelAlias("gpt-5x5", { "gpt-5.5": "premium" })).toBeNull();
+  });
+});
+
+describe("validateModelAliasTargets", () => {
+  const lanes = ["economy", "balanced", "premium"];
+
+  it("returns no errors when every target is a known lane or auto", () => {
+    const map = { "claude-opus-*": "premium", "claude-*": "balanced", legacy: "auto" };
+    expect(validateModelAliasTargets(map, lanes)).toEqual([]);
+  });
+
+  it("returns no errors for an absent map", () => {
+    expect(validateModelAliasTargets(undefined, lanes)).toEqual([]);
+  });
+
+  it("flags a target that is neither a known lane nor auto", () => {
+    const errors = validateModelAliasTargets({ "claude-*": "ultra" }, lanes);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("claude-*");
+    expect(errors[0]).toContain("ultra");
+  });
+});

--- a/packages/core/src/routing/model-alias.ts
+++ b/packages/core/src/routing/model-alias.ts
@@ -1,0 +1,70 @@
+// Virtual model-alias map (docs/04) — an operator-configured compatibility shim
+// that rewrites an inbound VENDOR model id (e.g. Claude Code's "claude-opus-4-8",
+// which is neither a lane nor an internal provider alias) onto a LANE name or the
+// "auto" sentinel BEFORE routing. It lets a fixed-model client — Claude CLI, an
+// SDK pinned to a vendor id — talk to Helm without a 400, while keeping the lane
+// abstraction intact (principle 6): a virtual name resolves to a lane, NEVER to a
+// raw provider/model. Targets are validated at boot (validateModelAliasTargets) to
+// be a known lane or "auto" — an unknown target refuses to start (principle 2).
+//
+// The map is pure routing config; this module is framework-agnostic and consumed
+// by route-request's plan() (the rewrite) and the gateway composition root (boot
+// validation).
+
+export type ModelAliasMap = Record<string, string>;
+
+// Match order, given an inbound model id:
+//   1. an EXACT map key wins outright;
+//   2. otherwise the matching glob pattern (`*` = any run of chars, incl. empty)
+//      with the most LITERAL (non-`*`) characters wins — so "claude-opus-*" beats
+//      "claude-*" regardless of declaration order; ties break on declaration order.
+// Case-sensitive (mirrors the eval-cache-key convention: no lowercasing). Returns
+// the target string (a lane name or "auto"), or null when nothing matches.
+export function resolveModelAlias(model: string, map: ModelAliasMap | undefined): string | null {
+  if (map === undefined) return null;
+  // 1) exact key wins — no glob scan needed.
+  if (Object.hasOwn(map, model)) return map[model] as string;
+  // 2) longest-literal glob. Object.entries preserves insertion order, so a tie
+  //    on literal count resolves to whoever was written first (stable).
+  let best: { target: string; literals: number } | null = null;
+  for (const [pattern, target] of Object.entries(map)) {
+    if (!pattern.includes("*")) continue; // exact patterns already handled above
+    if (!globMatch(pattern, model)) continue;
+    const literals = pattern.length - starCount(pattern);
+    if (best === null || literals > best.literals) best = { target, literals };
+  }
+  return best?.target ?? null;
+}
+
+// Boot-time, fail-closed (principle 2): every alias target must be a configured
+// lane or the "auto" sentinel. Returns a list of human-readable error lines (empty
+// = valid). The caller throws on a non-empty list so a typo'd lane never boots.
+export function validateModelAliasTargets(
+  map: ModelAliasMap | undefined,
+  laneNames: Iterable<string>,
+): string[] {
+  if (map === undefined) return [];
+  const lanes = new Set(laneNames);
+  const errors: string[] = [];
+  for (const [pattern, target] of Object.entries(map)) {
+    if (target === "auto" || lanes.has(target)) continue;
+    errors.push(
+      `model alias "${pattern}" -> unknown lane "${target}" (expected a lane name or "auto")`,
+    );
+  }
+  return errors;
+}
+
+function starCount(pattern: string): number {
+  let n = 0;
+  for (const ch of pattern) if (ch === "*") n++;
+  return n;
+}
+
+// Glob → anchored RegExp: escape every regex metachar in the pattern, then turn
+// the (now-escaped) `*` back into `.*`. So the model id is matched as a literal
+// string except for the wildcard — a `.` in "gpt-5.5" is a literal dot, not "any".
+function globMatch(pattern: string, model: string): boolean {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\\\*/g, ".*");
+  return new RegExp(`^${escaped}$`).test(model);
+}

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -725,3 +725,124 @@ describe("routeRequest — orchestration", () => {
     expect(rec.key_prefix).toBe("helm_live_ab12");
   });
 });
+
+// Virtual model-alias map (docs/04): a vendor model id (e.g. Claude Code's
+// "claude-opus-4-8") is rewritten onto a lane / "auto" BEFORE the passthrough
+// gate, so a fixed-model client routes without a 400 even on a default key.
+describe("routeRequest — virtual model aliases", () => {
+  it("maps a vendor model id onto a lane for a DEFAULT key (no allow_custom_model)", async () => {
+    const d = deps({ modelAliases: { "claude-opus-4-8": "premium" } });
+    const result = await routeRequest(req({ requested_model: "claude-opus-4-8" }), d, {
+      allowCustomModel: false,
+    });
+
+    // Resolved as a lane passthrough — classifier never runs.
+    expect(d.classify).not.toHaveBeenCalled();
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+    expect(plan.explicit_model).toBeNull();
+    expect(plan.candidate_chain).toEqual(["best_reasoning_model", "default_good_model"]);
+    expect(result.final.status).toBe("ok");
+
+    // The decision records the ORIGINAL vendor id, and the reason names the alias.
+    const rec = (d.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.requested_model).toBe("claude-opus-4-8");
+    expect(rec.lane.selected_lane).toBe("premium");
+    expect(rec.policy.reason).toContain("alias");
+  });
+
+  it("resolves the alias BEFORE the unknown-model 400 on an allow_custom_model key", async () => {
+    // The exact bug: claude-opus-4-8 is not a known model, so without the alias an
+    // allow_custom_model key 400s. The alias rewrite must win first.
+    const d = deps({
+      isKnownModel: () => false,
+      modelAliases: { "claude-opus-4-8": "premium" },
+    });
+    const result = await routeRequest(req({ requested_model: "claude-opus-4-8" }), d, {
+      allowCustomModel: true,
+    });
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+  });
+
+  it("matches a glob alias (Claude Code appends a date suffix)", async () => {
+    const d = deps({ modelAliases: { "claude-opus-*": "premium" } });
+    const result = await routeRequest(req({ requested_model: "claude-opus-4-8-20260115" }), d, {
+      allowCustomModel: false,
+    });
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+    expect(result.final.status).toBe("ok");
+  });
+
+  it("an alias mapped to `auto` runs the classifier (does not short-circuit)", async () => {
+    const d = deps({ modelAliases: { "claude-*": "auto" } });
+    await routeRequest(req({ requested_model: "claude-opus-4-8" }), d, {
+      allowCustomModel: false,
+    });
+    expect(d.classify).toHaveBeenCalledOnce();
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("coding"); // from the default classification + policy
+  });
+
+  it("an alias-mapped lane is CLAMPED (not rejected) by the key's allowedLanes", async () => {
+    // Unlike an EXPLICIT lane ask (which loud-rejects a forbidden lane), an alias
+    // is a compatibility convenience: it silently clamps to the permitted set so a
+    // fixed-model client keeps working instead of 400ing.
+    const d = deps({ modelAliases: { "claude-opus-4-8": "premium" } });
+    const result = await routeRequest(req({ requested_model: "claude-opus-4-8" }), d, {
+      allowCustomModel: false,
+      keyCaps: { allowedLanes: ["economy"] },
+    });
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+  });
+
+  it("an alias-mapped lane is bounded by a POLICY cap — no cap bypass (review P1)", async () => {
+    // An identity-scoped policy caps org 'acme' to balanced. A standard key must
+    // NOT be able to use the operator alias to escape that cap up to premium.
+    const orgCap: PoliciesConfig = {
+      policies: [{ id: "org-cap", match: { org_id: "acme" }, max_lane: "balanced" }],
+    };
+    const capped = deps({ modelAliases: { "claude-opus-4-8": "premium" }, policies: orgCap });
+    const result = await routeRequest(
+      req({ requested_model: "claude-opus-4-8", org_id: "acme" }),
+      capped,
+      { allowCustomModel: false },
+    );
+    expect(result.final.status).toBe("ok");
+    const plan = (capped.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("balanced"); // premium clamped down by the org cap
+    const rec = (capped.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.policy.reason).toContain("capped");
+
+    // Control: a DIFFERENT org is not bound by that cap → the alias keeps premium.
+    const free = deps({ modelAliases: { "claude-opus-4-8": "premium" }, policies: orgCap });
+    await routeRequest(req({ requested_model: "claude-opus-4-8", org_id: "other" }), free, {
+      allowCustomModel: false,
+    });
+    const plan2 = (free.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan2.selected_lane).toBe("premium");
+  });
+
+  it("a non-matching model with a map present falls through to classified routing", async () => {
+    const d = deps({ modelAliases: { "claude-*": "premium" } });
+    await routeRequest(req({ requested_model: "gpt-4o" }), d, { allowCustomModel: false });
+    expect(d.classify).toHaveBeenCalledOnce();
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("coding");
+  });
+
+  it("keyCaps.degradeLane suppresses an alias-mapped lane too (no over-budget bypass)", async () => {
+    const d = deps({ modelAliases: { "claude-opus-4-8": "premium" } });
+    const result = await routeRequest(req({ requested_model: "claude-opus-4-8" }), d, {
+      allowCustomModel: false,
+      keyCaps: { allowedLanes: null, degradeLane: "economy" },
+    });
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("economy");
+  });
+});

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -9,6 +9,7 @@ import {
 import { expandLaneChain } from "../lanes/expand-chain.js";
 import type { LanesConfig } from "../lanes/schema.js";
 import { type Classification as ResolverClassification, resolveLane } from "./lane-resolver.js";
+import { type ModelAliasMap, resolveModelAlias } from "./model-alias.js";
 import { applyCaps, evaluatePolicies, LANE_RANK, type PolicyContext } from "./policy-engine.js";
 import type { PoliciesConfig } from "./policy-schema.js";
 
@@ -140,6 +141,15 @@ export interface RouteDeps {
    *  absent (headless core / tests) → validation is skipped. Lane names are
    *  checked FIRST and never reach this. */
   isKnownModel?: (alias: string) => boolean;
+  /** Operator-configured virtual model-name map (docs/04 compatibility shim).
+   *  Rewrites an inbound VENDOR model id (e.g. Claude Code's "claude-opus-4-8",
+   *  which is neither a lane nor an internal alias) onto a LANE name or "auto"
+   *  BEFORE the allow_custom_model gate — so a fixed-model client routes without a
+   *  400 even on a default key. Targets are validated at boot (the gateway calls
+   *  validateModelAliasTargets) to be a known lane or "auto", fail-closed. Absent
+   *  (headless core / tests) → no rewrite. See model-alias.resolveModelAlias for
+   *  the exact/glob match order. */
+  modelAliases?: ModelAliasMap;
   /** Opt-in Agentic Signals feedback. Reads aggregated, redacted signal rows and
    *  may promote a degraded ranked lane to a healthier stronger ranked lane,
    *  never overriding explicit passthrough, policy pins, budget degradation, or
@@ -246,6 +256,25 @@ function policyContext(req: InternalRequest, cls: Classification): PolicyContext
     // — memory must never rewrite routing (docs/08). user_id/org_id come from the
     // trusted auth identity; project-scoped routing needs an equivalent trusted
     // source (auth/account), which does not exist yet, so it is null.
+    project_id: null,
+  };
+}
+
+// PolicyContext for an alias-mapped lane (step 0a). An alias request is NOT
+// classified, so task/complexity/needs_* are neutral (`task_type:"passthrough"`
+// matches no shipped task policy) — only IDENTITY-scoped policies (org_id/user_id,
+// e.g. the shipped budget_org_cap) match, and their caps still clamp the lane.
+// This is what keeps an operator alias from becoming a policy-cap bypass.
+function aliasPolicyContext(req: InternalRequest): PolicyContext {
+  return {
+    task_type: "passthrough",
+    complexity: "medium",
+    needs_json: false,
+    needs_tools: false,
+    needs_vision: false,
+    user_id: req.user_id,
+    org_id: req.org_id,
+    // project_id stays a non-routing memory field (mirrors policyContext above).
     project_id: null,
   };
 }
@@ -442,6 +471,59 @@ async function plan(
   deps: RouteDeps,
   opts: RouteOptions,
 ): Promise<PlanDecision | PlanRejection> {
+  // 0) Virtual model-alias resolution (docs/04 compatibility shim). An operator
+  //    map rewrites an inbound vendor model id (e.g. Claude Code's "claude-opus-4-8")
+  //    onto a LANE name or the "auto" sentinel so a fixed-model client routes
+  //    without a 400. Boot-validated to a lane or "auto".
+  const aliasTarget = resolveModelAlias(req.requested_model, deps.modelAliases);
+  const aliasToAuto = aliasTarget === "auto";
+
+  // 0a) Alias -> LANE: a CAP-BOUNDED lane selection — NOT an allow_custom_model
+  //     passthrough. It works for ANY key (the operator authorized it by
+  //     configuring the map), but unlike explicit passthrough it does NOT bypass
+  //     the routing brain's caps: policy caps (identity-scoped org/user caps still
+  //     bind; task/complexity-scoped policies do NOT fire — an alias request is not
+  //     classified) AND the key's allowed_lanes both SILENTLY clamp the lane, just
+  //     like classified routing. So a standard key can never use an operator alias
+  //     to escape a policy/key cap it would otherwise be bound by. The original
+  //     req.requested_model is preserved for the DecisionRecord. Suppressed while
+  //     over-budget degrading (no bypass — fall through to the forced degrade lane)
+  //     and for an alias to "auto" (handled by classification below).
+  if (
+    aliasTarget !== null &&
+    !aliasToAuto &&
+    Object.hasOwn(deps.lanes, aliasTarget) &&
+    (opts.keyCaps?.degradeLane === undefined || opts.keyCaps.degradeLane === null)
+  ) {
+    const outcome = evaluatePolicies(aliasPolicyContext(req), deps.policies);
+    let lane = applyCaps(aliasTarget, outcome);
+    if (opts.keyCaps !== undefined) {
+      lane = applyCaps(lane, {
+        matched_policy_id: null,
+        use_lane: null,
+        max_lane: null,
+        allowed_lanes: opts.keyCaps.allowedLanes,
+        reason: "key caps",
+      });
+    }
+    const clamped = lane !== aliasTarget;
+    return {
+      plan: {
+        selected_lane: lane,
+        candidate_chain: expandChain(lane, deps.lanes),
+        explicit_model: null,
+      },
+      classifier: passthroughClassifier(),
+      policy: {
+        matched_policy_id: outcome.matched_policy_id,
+        reason: clamped
+          ? `model alias "${req.requested_model}" -> lane "${aliasTarget}" (capped to "${lane}")`
+          : `model alias "${req.requested_model}" -> lane "${aliasTarget}"`,
+      },
+      evalUsd: null,
+    };
+  }
+
   // 1) Explicit passthrough — bypass the whole routing brain. The model field
   //    may name a concrete MODEL (chain = [model]) or a LANE (chain = the lane's
   //    expanded fallback chain, docs/04 "explicit model/lane").
@@ -449,6 +531,8 @@ async function plan(
   //    treated as an explicit model, even for an allow_custom_model key — otherwise
   //    it short-circuits classify/lane-resolve and gets sent upstream as the literal
   //    model "auto" (the llm-router #391 regression). Fall through to classify.
+  //    An alias that resolved to "auto" likewise must classify, never passthrough
+  //    the original vendor id — so it is excluded here too.
   //    A key that is OVER its usage budget and set to `degrade` (opts.keyCaps.
   //    degradeLane is populated for this request) must NOT be able to bypass the
   //    downgrade by naming an expensive explicit model OR lane — so suppress
@@ -456,6 +540,7 @@ async function plan(
   //    below (docs/06).
   if (
     opts.allowCustomModel === true &&
+    !aliasToAuto &&
     req.requested_model.length > 0 &&
     req.requested_model !== "auto" &&
     (opts.keyCaps?.degradeLane === undefined || opts.keyCaps.degradeLane === null)

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -227,6 +227,18 @@ export const RuntimeConfigSchema = z.object({
   signal_feedback: RoutingSignalFeedbackConfigSchema.prefault({}),
 });
 
+// Virtual model-alias map (docs/04) — config/model-aliases.yaml, a FLAT map of an
+// inbound VENDOR model id (an exact key OR a single-`*` glob) -> a lane name or the
+// "auto" sentinel. A compatibility shim: a fixed-model client (Claude CLI, an SDK
+// pinned to a vendor id like "claude-opus-4-8") has its `model` field rewritten
+// onto a lane BEFORE routing, so it no longer 400s on an unknown model. Only the
+// SHAPE is validated here (non-empty string keys/values); the SEMANTIC check —
+// every target is a configured lane or "auto" — runs fail-closed at boot
+// (validateModelAliasTargets in @helm/core), where the effective lane set (incl.
+// DEFAULT_LANES) is known. Optional at the config level: absent => no rewrite
+// (behaviour identical to today). Resolver: @helm/core model-alias.resolveModelAlias.
+export const ModelAliasesSchema = z.record(z.string().min(1), z.string().min(1));
+
 export const HelmConfigSchema = z.object({
   server: ServerConfigSchema,
   auth: AuthConfigSchema,
@@ -264,6 +276,11 @@ export const HelmConfigSchema = z.object({
   // invalid file still fails closed (principle 2). Empty prefault lets
   // MemoryConfigSchema's own field defaults supply the nested tree.
   memory: MemoryConfigSchema.prefault({}),
+  // Virtual model aliases (config/model-aliases.yaml). OPTIONAL: absent →
+  // config.model_aliases undefined → no rewrite (today's behaviour). A present-
+  // but-malformed file (non-string key/value) fails closed here; the lane-target
+  // semantic check is fail-closed at boot (validateModelAliasTargets).
+  model_aliases: ModelAliasesSchema.optional(),
 });
 
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
@@ -280,6 +297,7 @@ export type RateLimitConfig = z.infer<typeof RateLimitConfigSchema>;
 export type StoreConfig = z.infer<typeof StoreConfigSchema>;
 export type RoutingSignalFeedbackConfig = z.infer<typeof RoutingSignalFeedbackConfigSchema>;
 export type RuntimeConfig = z.infer<typeof RuntimeConfigSchema>;
+export type ModelAliases = z.infer<typeof ModelAliasesSchema>;
 export type HelmConfig = z.infer<typeof HelmConfigSchema>;
 
 // Re-export the memory subtree's public surface from the config barrel so


### PR DESCRIPTION
## Problem

Pointing **Claude CLI** (or any client pinned to a vendor model id) at the gateway fails: a request with `model: "claude-opus-4-8"` returns `400 unknown model`. The router only understands three forms of `model`: `auto`, a **lane** name, or an internal **`provider/model`** alias. A bare vendor id is none of those.

## Solution

A new optional `config/model-aliases.yaml`: a flat map of vendor model id (exact key **or** single-`*` glob) → a **lane** name or `auto`, resolved before routing so a fixed-model client routes without the 400.

```yaml
"claude-opus-*":  premium
"claude-sonnet-*": balanced
"claude-3-5-haiku-*": economy   # small/fast background model
"claude-*": balanced            # catch-all
```

### Design (docs/04; principles 1/2/6)

- **Maps to a lane, not a provider model** — keeps the lane abstraction and preserves the fallback chain. Works for **any key** (operator-authorized).
- **An alias is a cap-bounded lane selection, NOT an `allow_custom_model` passthrough.** Policy caps (identity-scoped org/user caps bind; task-scoped policies don't fire on an unclassified request) **and** the key's `allowed_lanes` both **silently clamp** the lane — so a standard key can never use an operator alias to escape a cap it would otherwise be bound by. `degradeLane` (over-budget) still suppresses it.
- **Match order**: exact key wins; else the glob with the most literal characters (`claude-opus-*` beats `claude-*`), absorbing Claude Code's date suffix (`...-20260115`). Case-sensitive.
- **Fail-closed**: every target must be a configured lane or `auto`, validated at boot against the effective lane set (`config.lanes` or `DEFAULT_LANES`), or the gateway refuses to start.
- `req.requested_model` is preserved for the `DecisionRecord`; `policy.reason` records the mapping and any cap clamp.
- The `allow_custom_model` explicit branches are unchanged (back-compat); only a bare vendor id matching the map takes the new branch.

Ships sensible defaults so a fresh install + Claude CLI works out of the box.

## Tests (TDD)

- `model-alias.test.ts` — resolver (exact/longest-literal glob, case sensitivity, regex-meta safety) + boot validator.
- `route-request.test.ts` — "virtual model aliases": default-key hit, resolution **before** the unknown-model 400, glob, `auto → classify`, `allowed_lanes` silent clamp, **policy-cap bound / no bypass**, non-match fall-through, `degradeLane` suppression.
- `samples.test.ts` — shipped `model-aliases.yaml` ↔ `lanes.yaml` consistency + dated-Haiku → economy guard.

**Green**: typecheck ✓, lint ✓, core **1812**, gateway routes + server boot ✓.

## Reviewed

Addressed a Codex review pass:
- **P1** — alias no longer bypasses policy caps (cap-bounded branch + regression test).
- **P3** — dated Haiku ids (`claude-3-5-haiku-20241022`) map to economy.

## Deploy note

The deploy doesn't overwrite the operator-owned config dir, so to activate on an existing install, place `model-aliases.yaml` in that deployment's `config/` (or set `ANTHROPIC_MODEL=auto` in Claude Code, which already works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)