### PR TITLE
feat(config): dedicated vendor-family lanes + zenmux opus 4.8

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -99,7 +99,7 @@ openrouter/deepseek-v4-flash:
   supportsStreaming: true
   maxContextTokens: 1048576
   maxOutputTokens: 131072
-zenmux/claude-opus-4.7:
+zenmux/claude-opus-4.8:
   supportsTools: true
   supportsJsonMode: true
   supportsVision: true
@@ -114,7 +114,7 @@ zenmux/claude-sonnet-4.6:
   supportsJsonMode: true
   supportsVision: true
   supportsStreaming: true
-  # Same document-input story as opus-4.7 (PDF/text, no audio/video).
+  # Same document-input story as opus-4.8 (PDF/text, no audio/video).
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -42,7 +42,7 @@ premium:
   purpose: Strong reasoning and high quality
   primary: openai-codex/gpt-5.5
   fallback:
-    - zenmux/claude-opus-4.7
+    - zenmux/claude-opus-4.8
     - zenmux/gpt-5.5
     - balanced
 
@@ -84,3 +84,50 @@ tool_use:
     - premium
   constraints:
     require_tools: true
+
+# —— vendor-family lanes (targets of config/model-aliases.yaml) ——
+# A client that pins a FIXED vendor model id (Claude Code's `claude-opus-4-8`, an
+# SDK locked to `gpt-5.5`) has its `model` rewritten onto one of THESE lanes BEFORE
+# routing (model-aliases.yaml glob -> lane). Each LEADS with the requested family's
+# real model, so an explicit `claude-opus` lands on a Claude-Opus-led chain instead
+# of the GPT-led `premium` lane, then degrades through the matching generic lane.
+# The lane abstraction still holds (principle 6): the client never names a provider
+# alias. Every chain inherits balanced's json-capable body + `*/auto` tail, so a
+# strict-JSON request still lands deterministically (the auto aliases get pruned).
+#
+# The Claude lanes LEAD with the NATIVE Anthropic subscription alias (`anthropic/*`,
+# the Claude Pro/Max OAuth pool — connect it in admin → Providers). Like the
+# `openai-codex/*` primaries above, an unconnected `anthropic/*` candidate fails
+# OPEN (skip to the next fallback), never a 5xx — so each lane is backed by a static
+# `zenmux/*` key that keeps it serving without a subscription.
+claude-opus:
+  purpose: Anthropic Claude Opus tier — strongest Claude
+  primary: anthropic/claude-opus-4-8
+  fallback:
+    - zenmux/claude-opus-4.8
+    - premium
+
+claude-sonnet:
+  purpose: Anthropic Claude Sonnet tier — balanced Claude
+  primary: anthropic/claude-sonnet-4-6
+  fallback:
+    - zenmux/claude-sonnet-4.6
+    - balanced
+
+# ZenMux exposes no Claude Haiku, so this cheap/fast tier degrades straight to
+# `economy` (deepseek-flash) after the native Anthropic Haiku.
+claude-haiku:
+  purpose: Anthropic Claude Haiku tier — cheap/fast
+  primary: anthropic/claude-haiku-4-5-20251001
+  fallback:
+    - economy
+
+# Stays on GPT-5.5 ACROSS providers (Codex subscription -> static ZenMux key) before
+# degrading to the GPT-led `premium` lane, so an explicit gpt-5.5 request is not
+# bumped onto Claude Opus on the first hiccup.
+"gpt-5.5":
+  purpose: OpenAI GPT-5.5 tier
+  primary: openai-codex/gpt-5.5
+  fallback:
+    - zenmux/gpt-5.5
+    - premium

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -21,24 +21,25 @@
 # the gateway refuses to boot. This file is OPTIONAL — delete it for no rewrite.
 #
 # NOTE: only BARE vendor ids are matched here. Internal provider aliases are
-# `provider/model` (e.g. `zenmux/claude-opus-4.7`), which never start with
+# `provider/model` (e.g. `zenmux/claude-opus-4.8`), which never start with
 # `claude`/`gpt`, so an allow_custom_model key can still address them explicitly.
 
 # ── Anthropic / Claude Code ──────────────────────────────────────────────────
 # Claude Code sends two classes: the main model and a small/fast background model
-# (ANTHROPIC_SMALL_FAST_MODEL, usually Haiku). Map the small one to economy, the
-# strong ones to premium/balanced. Tip: you can also just set ANTHROPIC_MODEL=auto
-# in Claude Code to let Helm's classifier pick per request.
-"claude-3-5-haiku": economy
-"claude-3-5-haiku-*": economy # dated id, e.g. claude-3-5-haiku-20241022
-"claude-haiku-*": economy
-"claude-opus-*": premium
-"claude-sonnet-*": balanced
+# (ANTHROPIC_SMALL_FAST_MODEL, usually Haiku). Each Claude family maps to its
+# DEDICATED vendor-family lane (config/lanes.yaml) so the request leads with that
+# family's real model and keeps its full fallback chain. Tip: you can also just set
+# ANTHROPIC_MODEL=auto in Claude Code to let Helm's classifier pick per request.
+"claude-3-5-haiku": claude-haiku
+"claude-3-5-haiku-*": claude-haiku # dated id, e.g. claude-3-5-haiku-20241022
+"claude-haiku-*": claude-haiku
+"claude-opus-*": claude-opus
+"claude-sonnet-*": claude-sonnet
 "claude-*": balanced # catch-all for any other / future Claude id
 
 # ── OpenAI-compatible clients (Codex, Cursor, …) ─────────────────────────────
 # Bare GPT ids → lanes. Comment these out if you don't front any GPT clients.
-"gpt-5.5": premium
+"gpt-5.5": gpt-5.5 # dedicated vendor-family lane (config/lanes.yaml)
 "gpt-5-codex": coding
 "gpt-5*": premium
 "gpt-*": balanced

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -41,9 +41,9 @@ openrouter/deepseek-v4-pro:
 openrouter/deepseek-v4-flash:
   inputPerMTokUsd: 0.0983
   outputPerMTokUsd: 0.1966
-zenmux/claude-opus-4.7:
-  inputPerMTokUsd: 30.0
-  outputPerMTokUsd: 150.0
+zenmux/claude-opus-4.8:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 25.0
 zenmux/claude-sonnet-4.6:
   inputPerMTokUsd: 3.0
   outputPerMTokUsd: 15.0

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -79,9 +79,9 @@ providers:
     base_url: https://zenmux.ai/api/v1
     api_key_env: ZENMUX_API_KEY
     models:
-      # anthropic/claude-opus-4.7 — premium fallback, vision+json (zenmux real id).
-      - alias: zenmux/claude-opus-4.7
-        provider_model: anthropic/claude-opus-4.7
+      # anthropic/claude-opus-4.8 — premium fallback, vision+json (zenmux real id).
+      - alias: zenmux/claude-opus-4.8
+        provider_model: anthropic/claude-opus-4.8
       # anthropic/claude-sonnet-4.6 — balanced fallback, vision+json (zenmux real id).
       - alias: zenmux/claude-sonnet-4.6
         provider_model: anthropic/claude-sonnet-4.6

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -97,7 +97,7 @@ balanced:
 premium:
   purpose: Strong reasoning and high quality
   primary: openai-codex/gpt-5.5
-  fallback: [zenmux/claude-opus-4.7, zenmux/gpt-5.5, balanced]
+  fallback: [zenmux/claude-opus-4.8, zenmux/gpt-5.5, balanced]
 ```
 
 `balanced` is **required** and must be healthy — it is the terminal of the

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -75,9 +75,10 @@ describe("checked-in config samples", () => {
     const laneNames = Object.keys(cfg.lanes ?? {});
     const opusTarget = resolveModelAlias("claude-opus-4-8", aliases);
     expect(opusTarget && laneNames.includes(opusTarget)).toBe(true);
-    // The small/fast background model maps to economy even with a date suffix
-    // (the common dated Haiku id shape) — not the broad claude-* catch-all.
-    expect(resolveModelAlias("claude-3-5-haiku-20241022", aliases)).toBe("economy");
+    // The small/fast background model maps to the dedicated claude-haiku lane even
+    // with a date suffix (the common dated Haiku id shape) — the haiku-specific glob
+    // wins over the broad claude-* catch-all (which still falls through to balanced).
+    expect(resolveModelAlias("claude-3-5-haiku-20241022", aliases)).toBe("claude-haiku");
     // The shipped aliases must validate against the SHIPPED lanes (no drift): every
     // target is a configured lane or "auto", or the gateway would refuse to boot.
     expect(validateModelAliasTargets(aliases, laneNames)).toEqual([]);


### PR DESCRIPTION
## Summary

Adds dedicated **vendor-family lanes** so clients that pin a fixed vendor model id get routed to that family's real model, and refreshes the ZenMux Claude Opus alias/pricing against live data.

### Lanes (`config/lanes.yaml`)
- New `claude-opus`, `claude-sonnet`, `claude-haiku`, `gpt-5.5` lanes.
- Claude lanes **lead with native `anthropic/*`** (Claude Pro/Max OAuth pool) and fail **open** to a static `zenmux/*` backup → `premium`/`balanced`/`economy`, so they degrade gracefully without a subscription.
- `model-aliases.yaml` repointed: `claude-opus-*` → `claude-opus`, `claude-sonnet-*` → `claude-sonnet`, the haiku ids → `claude-haiku`, `gpt-5.5` → `gpt-5.5`. Previously these hit the generic `premium`/`balanced`/`economy` lanes — so a Claude Opus request actually ran on GPT-5.5.

### ZenMux refresh (verified against `https://zenmux.ai/api/v1/models`)
- Bump opus alias `zenmux/claude-opus-4.7` → `4.8` across `providers` / `capabilities` / `pricing` / `lanes` / `docs`.
- Fix stale opus price **$30/$150 → $5/$25** (live rate; was a 6× overcharge skewing budget gating + compaction economics).
- Cross-checked sonnet / gpt-5.5 / gemini (ZenMux) and both deepseek mirrors (OpenRouter) — already accurate, no change.

### Notes
- Config-only. Lane validation is structural (fail-open at runtime), so unconnected `anthropic/*` / `openai-codex/*` primaries never 5xx.
- `claude-haiku` has no ZenMux Haiku upstream, so it degrades straight to `economy`.

## Test
- `policy-crossref` + `lanes/schema` + `model-alias` unit tests: **28 passed**.
- Validated config parses, `balanced` present, no dead model-alias targets, and every `zenmux/*` + `openrouter/*` alias wired across providers/capabilities/pricing with prices matching the live endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
