### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release v0.11.0

Bundles the two unreleased feature PRs since v0.10.5:

- **#163** feat(routing): virtual model-alias map for vendor model ids — a client pinning a fixed vendor model id (Claude Code's `claude-opus-4-8`, an SDK locked to `gpt-5.5`) is remapped onto a lane before routing, instead of getting `400 unknown model`.
- **#164** feat(config): dedicated vendor-family lanes + zenmux opus 4.8 — new `claude-opus`/`claude-sonnet`/`claude-haiku`/`gpt-5.5` lanes (Claude lanes lead with native `anthropic/*`, ZenMux static-key backup); bump zenmux opus alias `4.7`→`4.8`; fix stale opus price `$30/$150` → live `$5/$25`.

**Minor** bump — new client-facing routing surface (virtual model-alias map + vendor-family lanes), not a bugfix.

Merging lands the version bump on main; `publish.yml` auto-cuts tag `v0.11.0` + GitHub Release + `:0.11.0`/`:latest` images. No manual tag/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
