### PR TITLE
fix(protocol): accept system-role messages in Anthropic input (Claude Code)

### DIFF
--- a/packages/core/src/protocol/anthropic/request.test.ts
+++ b/packages/core/src/protocol/anthropic/request.test.ts
@@ -289,6 +289,58 @@ describe("anthropic transformRequestOut", () => {
     expect(parts[0]?.type).toBe("text");
   });
 
+  // Claude Code (and other clients) send injected system content — e.g. MCP server
+  // instructions — as a role:"system" MESSAGE in the array, alongside the top-level
+  // `system`. A compatible gateway must accept these and fold them into the system
+  // prompt (the outbound transform already does — systemFromMessages). Regression for
+  // the Claude Code boot failure: `400 invalid_value messages[1].role` (only
+  // user/assistant were accepted inbound).
+  it('accepts a role:"system" message and folds it into the system prompt', () => {
+    const req = {
+      model: "claude-opus-4-8",
+      max_tokens: 64,
+      system: "top-level system",
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "system", content: "# MCP Server Instructions" },
+      ],
+    };
+
+    // Inbound must NOT throw (the schema previously rejected role:"system").
+    const ir = transformRequestOut(req);
+    expect(() => IRRequestSchema.parse(ir)).not.toThrow();
+    const systemTexts = ir.messages
+      .filter((m) => m.role === "system")
+      .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)));
+    expect(systemTexts).toContain("top-level system");
+    expect(systemTexts).toContain("# MCP Server Instructions");
+    expect(ir.messages.some((m) => m.role === "user")).toBe(true);
+
+    // Outbound round-trip: BOTH system chunks fold into the Anthropic `system` param,
+    // leaving messages with only user/assistant turns (a valid Anthropic request).
+    const out = transformRequestIn(ir);
+    expect(out.messages.every((m) => m.role === "user" || m.role === "assistant")).toBe(true);
+    const sys = typeof out.system === "string" ? out.system : JSON.stringify(out.system);
+    expect(sys).toContain("top-level system");
+    expect(sys).toContain("# MCP Server Instructions");
+  });
+
+  // Block-array content on a system message must also map to a system IR message,
+  // not silently become a user turn (the block path used to hardcode role:"user").
+  it('maps a block-array role:"system" message to a system IR message', () => {
+    const ir = transformRequestOut({
+      model: "claude-opus-4-8",
+      max_tokens: 64,
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "system", content: [{ type: "text", text: "rules here" }] },
+      ],
+    });
+    const sys = ir.messages.find((m) => m.role === "system");
+    expect(sys).toBeDefined();
+    expect(JSON.stringify(sys?.content)).toContain("rules here");
+  });
+
   // fail-closed on a structurally invalid request (missing required fields).
   it("throws on a structurally invalid request", () => {
     expect(() => transformRequestOut({ messages: [] })).toThrow();

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -112,9 +112,15 @@ const AnthropicContentBlockSchema = z.union([
   AnthropicUnknownBlockSchema,
 ]);
 
+// Anthropic documents only user/assistant message roles (system lives top-level),
+// but real clients — notably Claude Code — inject system content (MCP server
+// instructions, system-reminders) as a role:"system" MESSAGE in the array. We accept
+// system/developer here and fold them into the system prompt downstream (transformOut
+// keeps the role; systemFromMessages collapses it), matching LiteLLM parity. Rejecting
+// them 400'd every Claude Code request ("invalid_value messages[].role").
 const AnthropicMessageSchema = z
   .object({
-    role: z.enum(["user", "assistant"]),
+    role: z.enum(["user", "assistant", "system", "developer"]),
     content: z.union([z.string(), z.array(AnthropicContentBlockSchema)]),
   })
   .passthrough();
@@ -420,6 +426,11 @@ export function transformRequestOut(req: unknown): IRRequest {
         content: parts.length > 0 ? parts : null,
         ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
       });
+    } else if (m.role === "system" || m.role === "developer") {
+      // system/developer turn: keep the role so it folds into the system prompt
+      // downstream (systemFromMessages) instead of being mistaken for a user turn.
+      // (The string-content fast path above already preserves m.role.)
+      if (parts.length > 0) messages.push({ role: m.role, content: parts });
     } else {
       // user: emit the user turn (if it has any non-tool_result content), then the
       // fanned-out tool_result messages as standalone role:"tool" turns.


### PR DESCRIPTION
## Summary
Fixes Claude Code failing against the helm gateway with `400 invalid_value messages[].role` (surfaced to the user as *"model may not exist or you may not have access"*).

**Root cause:** Claude Code sends injected system content — MCP server instructions, system-reminders — as a `role:"system"` **message in the `messages` array**, alongside the top-level `system`. The inbound Anthropic schema only allowed `user|assistant`, so the request was rejected before routing. Model-independent → opus **and** sonnet both failed identically.

**Fix:** accept `system`/`developer` message roles inbound and fold their content into the system prompt. This matches the adapter's own outbound transform, which already collapses `system`/`developer` IR messages into the Anthropic `system` param (`systemFromMessages`), and LiteLLM behavior.
- Schema: message `role` enum → `user|assistant|system|developer`.
- Transform: the block-content branch now keeps `m.role` for system/developer (it was hardcoding `user`; the string-content path already preserved it).

## Test
- New regression tests (red→green) reproducing the exact captured Claude Code payload (top-level `system` + a `role:"system"` MCP-instructions message): inbound accepted, both system chunks fold into the outbound `system`, messages stay user/assistant.
- Full anthropic protocol suite (110), protocol+routing+provider (823), `typecheck`, `biome` lint — all green.

Diagnosed by capturing Claude Code's real wire payload against a local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
