### PR TITLE
chore(release): v0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release v0.11.1

Patch — one bugfix since v0.11.0:

- **#166** fix(protocol): accept `system`-role messages in Anthropic input. Claude Code sends injected system content (MCP server instructions, system-reminders) as a `role:"system"` message in the `messages` array; the inbound schema only allowed `user|assistant`, so every Claude Code request 400'd with `invalid_value messages[].role` and the client reported the model as unavailable. Now folded into the system prompt.

Merging lands the bump on main; `publish.yml` auto-cuts tag `v0.11.1` + Release + `:0.11.1`/`:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
