### PR TITLE
fix(protocol): tolerant reasoning-effort (xhigh/max) + forward to Codex + Responses total_tokens

### DIFF
--- a/packages/core/src/protocol/anthropic/request.test.ts
+++ b/packages/core/src/protocol/anthropic/request.test.ts
@@ -570,6 +570,16 @@ describe("anthropic transformRequestIn — P4 params", () => {
     expect(budget("low")).toBe(1024);
     expect(budget("medium")).toBe(2048);
     expect(budget("high")).toBe(4096);
+    // Extended tiers (litellm parity): xhigh=8192, max=16384.
+    expect(budget("xhigh")).toBe(8192);
+    expect(budget("max")).toBe(16384);
+    // `none` disables thinking entirely (no type:"enabled" with a 0 budget).
+    const noneOut = transformRequestIn({
+      model: "claude-3-7-sonnet",
+      messages: [{ role: "user", content: "hi" }],
+      reasoning_effort: "none",
+    });
+    expect(noneOut.thinking).toBeUndefined();
   });
 
   // order 10: client parallel_tool_calls:false -> Anthropic disable_parallel_tool_use.

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -592,19 +592,22 @@ export interface AnthropicOutboundRequest {
 
 const DEFAULT_MAX_TOKENS = 4096;
 
-// reasoning_effort -> Anthropic extended-thinking budget (tokens). The IR enum is
-// minimal|low|medium|high; LiteLLM derives a per-tier budget (referenced, NOT copied).
-// All non-disabled efforts emit type:"enabled" with a positive budget so the request
-// is a valid extended-thinking call.
-// Exact litellm parity (constants.py + _map_reasoning_effort): minimal/low both
-// floor at ANTHROPIC_MIN_THINKING_BUDGET_TOKENS=1024, medium=2048, high=4096. The
-// previous helm values (low:2048, medium:8192, high:16384) over-budgeted 2-4x —
-// a direct billing/latency inflation since thinking tokens are charged output.
+// reasoning_effort -> Anthropic extended-thinking budget (tokens). Anthropic has no
+// native effort tiers, so each IR tier maps to a thinking budget (LiteLLM referenced,
+// NOT copied). A positive budget emits type:"enabled"; `none` (budget 0) disables
+// thinking (handled in thinkingFromIR).
+// Exact litellm parity (constants.py + _map_reasoning_effort): minimal/low both floor
+// at ANTHROPIC_MIN_THINKING_BUDGET_TOKENS=1024, medium=2048, high=4096, xhigh=8192,
+// max=16384, none=0. (The previous helm values low:2048/medium:8192/high:16384 over-
+// budgeted 2-4x — a direct billing/latency inflation since thinking tokens bill as output.)
 const REASONING_EFFORT_TO_BUDGET: Record<string, number> = {
+  none: 0,
   minimal: 1024,
   low: 1024,
   medium: 2048,
   high: 4096,
+  xhigh: 8192,
+  max: 16384,
 };
 
 function thinkingFromIR(ir: IRRequest): AnthropicThinkingConfigOut | undefined {
@@ -620,9 +623,11 @@ function thinkingFromIR(ir: IRRequest): AnthropicThinkingConfigOut | undefined {
     }
   }
   // Otherwise derive a budget from reasoning_effort (the cross-protocol knob).
+  // `none` maps to budget 0 = disable thinking entirely (Anthropic rejects
+  // type:"enabled" with a 0 budget), so only a POSITIVE budget enables it.
   if (ir.reasoning_effort !== undefined) {
     const budget = REASONING_EFFORT_TO_BUDGET[ir.reasoning_effort];
-    if (budget !== undefined) return { type: "enabled", budget_tokens: budget };
+    if (budget !== undefined && budget > 0) return { type: "enabled", budget_tokens: budget };
   }
   return undefined;
 }

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -1,4 +1,11 @@
-import type { IRContentPart, IRMessage, IRRequest, IRResponse, IRToolCall } from "../ir.js";
+import type {
+  IRContentPart,
+  IRMessage,
+  IRReasoningEffort,
+  IRRequest,
+  IRResponse,
+  IRToolCall,
+} from "../ir.js";
 import { IRRequestSchema, IRResponseSchema } from "../ir.js";
 import { liftReasoningToFlat, resolveReasoning } from "../reasoning.js";
 import type { Transformer } from "../transformer.js";
@@ -133,18 +140,26 @@ const GEMINI_TO_IR_MODALITY: Record<string, "text" | "image" | "audio" | "video"
 // increasing defaults (minimal < low < medium < high) so the level is honored and
 // budgets order correctly. The raw effort survives in provider_raw at the request
 // layer if needed; here we only need a valid, ordered thinkingConfig.
-const REASONING_EFFORT_BUDGET: Record<"minimal" | "low" | "medium" | "high", number> = {
+// Keyed over the FULL IR effort union (exhaustive) so it never indexes to an
+// undefined budget when a newer tier (xhigh/max) or `none` reaches Gemini. Budgets
+// are representative + monotonically increasing; xhigh/max sit at Gemini's ceiling.
+const REASONING_EFFORT_BUDGET: Record<IRReasoningEffort, number> = {
+  none: 0,
   minimal: 128,
   low: 1024,
   medium: 8192,
   high: 24576,
+  xhigh: 32768,
+  max: 32768,
 };
 
 function reasoningEffortToThinkingConfig(
-  effort: "minimal" | "low" | "medium" | "high" | undefined,
+  effort: IRReasoningEffort | undefined,
 ): { thinkingBudget: number; includeThoughts: boolean } | undefined {
   if (effort === undefined) return undefined;
-  return { thinkingBudget: REASONING_EFFORT_BUDGET[effort], includeThoughts: true };
+  const thinkingBudget = REASONING_EFFORT_BUDGET[effort];
+  // `none` => budget 0 disables Gemini thinking (and no thought summaries).
+  return { thinkingBudget, includeThoughts: thinkingBudget > 0 };
 }
 
 function thinkingConfigToReasoningEffort(

--- a/packages/core/src/protocol/ir.test.ts
+++ b/packages/core/src/protocol/ir.test.ts
@@ -117,14 +117,24 @@ describe("IRRequestSchema — litellm parity request params (all optional)", () 
     expect(parsed.stop).toBe("END");
   });
 
-  it("rejects an illegal reasoning_effort value (fail-closed)", () => {
-    expect(() =>
-      IRRequestSchema.parse({
+  it("accepts extended reasoning_effort tiers and clamps unknowns to high (litellm parity)", () => {
+    // Tolerant passthrough: known tiers (incl. none/xhigh/max) round-trip losslessly...
+    for (const effort of ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const) {
+      const parsed = IRRequestSchema.parse({
         model: "m",
         messages: [{ role: "user", content: "x" }],
-        reasoning_effort: "ultra",
-      }),
-    ).toThrow(ZodError);
+        reasoning_effort: effort,
+      });
+      expect(parsed.reasoning_effort).toBe(effort);
+    }
+    // ...and an unrecognized FUTURE tier clamps to "high" instead of 400ing the request
+    // (the over-strict enum is exactly what broke Codex with effort:"xhigh").
+    const clamped = IRRequestSchema.parse({
+      model: "m",
+      messages: [{ role: "user", content: "x" }],
+      reasoning_effort: "ultra",
+    });
+    expect(clamped.reasoning_effort).toBe("high");
   });
 });
 

--- a/packages/core/src/protocol/ir.ts
+++ b/packages/core/src/protocol/ir.ts
@@ -91,8 +91,35 @@ export type IRContentPart = z.infer<typeof IRContentPartSchema>;
 // detail have ONE shape across every protocol. All permissive (.passthrough() where
 // upstreams add fields) and fail-open on unknown extras. ——————————————————————————
 
-/** Reasoning effort knob (OpenAI o-series / Anthropic budget / Gemini level). */
-export const IRReasoningEffortSchema = z.enum(["minimal", "low", "medium", "high"]);
+/**
+ * Reasoning effort knob (OpenAI o-series / Anthropic budget / Gemini level).
+ *
+ * Tolerant by design (litellm parity): the type stays a finite union — so budget
+ * tables and the Gemini thinking-config map stay exhaustive/type-safe — but the
+ * PARSE never throws. Real clients ship new tiers over time (Codex added `xhigh`;
+ * `max` exists too), so any UNRECOGNIZED string is clamped to `high` instead of
+ * 400ing the request (an over-strict enum is exactly what broke Codex with
+ * `effort:"xhigh"`). Known tiers (incl. none/xhigh/max) round-trip losslessly and
+ * are forwarded to upstreams that understand them; budget-based providers
+ * (Anthropic/Gemini) map them to a thinking budget. Mirrors litellm
+ * REASONING_EFFORT = none|minimal|low|medium|high|xhigh (+max) and its
+ * passthrough-or-clamp model — never a hard reject.
+ */
+export const IR_REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+export const IRReasoningEffortSchema = z.preprocess(
+  (v) =>
+    typeof v === "string" && !(IR_REASONING_EFFORTS as readonly string[]).includes(v) ? "high" : v,
+  z.enum(IR_REASONING_EFFORTS),
+);
+export type IRReasoningEffort = z.infer<typeof IRReasoningEffortSchema>;
 
 /** A thinking/redacted-thinking block (Anthropic-shaped; reused for streaming). */
 export const IRThinkingBlockSchema = z

--- a/packages/core/src/protocol/responses-stream.test.ts
+++ b/packages/core/src/protocol/responses-stream.test.ts
@@ -759,7 +759,11 @@ describe("synthesizeResponsesSSEFromJSON — isomorphic with the live stream", (
       "response.completed",
     ]);
     const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
-    expect(completed.response.usage).toEqual({ input_tokens: 7, output_tokens: 2, total_tokens: 9 });
+    expect(completed.response.usage).toEqual({
+      input_tokens: 7,
+      output_tokens: 2,
+      total_tokens: 9,
+    });
   });
 
   it("tool-only response → function_call item sequence", async () => {

--- a/packages/core/src/protocol/responses-stream.test.ts
+++ b/packages/core/src/protocol/responses-stream.test.ts
@@ -223,7 +223,13 @@ describe("convertOpenAIStreamToResponses — text event sequence", () => {
     const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
     expect(completed.type).toBe("response.completed");
     expect(completed.response.status).toBe("completed");
-    expect(completed.response.usage).toEqual({ input_tokens: 10, output_tokens: 4 });
+    // total_tokens is REQUIRED by OpenAI's Responses usage shape (Codex rejects a
+    // completed response without it: "missing field total_tokens").
+    expect(completed.response.usage).toEqual({
+      input_tokens: 10,
+      output_tokens: 4,
+      total_tokens: 14,
+    });
   });
 
   // order 21: reasoning_tokens (output) + cache read/write (input) must ride the
@@ -753,7 +759,7 @@ describe("synthesizeResponsesSSEFromJSON — isomorphic with the live stream", (
       "response.completed",
     ]);
     const completed = events.at(-1) as Extract<ResponsesSSEEvent, { type: "response.completed" }>;
-    expect(completed.response.usage).toEqual({ input_tokens: 7, output_tokens: 2 });
+    expect(completed.response.usage).toEqual({ input_tokens: 7, output_tokens: 2, total_tokens: 9 });
   });
 
   it("tool-only response → function_call item sequence", async () => {

--- a/packages/core/src/protocol/responses-stream.ts
+++ b/packages/core/src/protocol/responses-stream.ts
@@ -92,6 +92,10 @@ const ResponsesOutputItemSchema = z.union([
 const ResponsesUsageSchema = z.object({
   input_tokens: z.number().int().nonnegative(),
   output_tokens: z.number().int().nonnegative(),
+  // OpenAI's Responses usage always carries total_tokens; Codex's strict deserializer
+  // rejects a response.completed without it. Optional on the schema (tolerant inbound)
+  // but ALWAYS emitted by projectUsage below.
+  total_tokens: z.number().int().nonnegative().optional(),
   input_tokens_details: z
     .object({
       cached_tokens: z.number().int().nonnegative().optional(),
@@ -390,10 +394,13 @@ function projectUsage(usage: IRUsage | null): z.infer<typeof ResponsesUsageSchem
   if (cacheCreation > 0) inputDetails.cache_creation_input_tokens = cacheCreation;
   const outputDetails: Record<string, number> = {};
   if (usage.reasoning_tokens !== undefined) outputDetails.reasoning_tokens = usage.reasoning_tokens;
+  // Reconstruct the FULL input (cached + non-cached); state buffered prompt as non-cached.
+  const inputTokens = (usage.prompt_tokens ?? 0) + cached + cacheCreation;
+  const outputTokens = usage.completion_tokens ?? 0;
   return {
-    // Reconstruct the FULL input (cached + non-cached); state buffered prompt as non-cached.
-    input_tokens: (usage.prompt_tokens ?? 0) + cached + cacheCreation,
-    output_tokens: usage.completion_tokens ?? 0,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: inputTokens + outputTokens,
     ...(Object.keys(inputDetails).length > 0 ? { input_tokens_details: inputDetails } : {}),
     ...(Object.keys(outputDetails).length > 0 ? { output_tokens_details: outputDetails } : {}),
   };

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   type IRContentPart,
   type IRMessage,
+  IRReasoningEffortSchema,
   type IRRequest,
   IRRequestSchema,
   type IRResponse,
@@ -154,7 +155,10 @@ const ResponsesRequestSchema = z
     // full object (incl summary) rides provider_raw for lossless reconstruction.
     reasoning: z
       .object({
-        effort: z.enum(["minimal", "low", "medium", "high"]).optional(),
+        // Tolerant (litellm parity): a real client (Codex) sends newer tiers like
+        // `xhigh`; the shared IR schema accepts any string and clamps unknowns to
+        // `high` rather than 400ing. Known tiers (incl. xhigh/max/none) survive.
+        effort: IRReasoningEffortSchema.optional(),
         summary: z.union([z.boolean(), z.string()]).optional(),
       })
       .passthrough()
@@ -697,9 +701,14 @@ function toResponsesResponse(res: IRResponse): NativeResponse {
     if (cacheCreation > 0) inputDetails.cache_creation_input_tokens = cacheCreation;
     const outputDetails: Record<string, number> = {};
     if (u.reasoning_tokens !== undefined) outputDetails.reasoning_tokens = u.reasoning_tokens;
+    const inputTokens = (u.prompt_tokens ?? 0) + cached + cacheCreation;
+    const outputTokens = u.completion_tokens ?? 0;
     usage = {
-      input_tokens: (u.prompt_tokens ?? 0) + cached + cacheCreation,
-      output_tokens: u.completion_tokens ?? 0,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      // total_tokens is part of OpenAI's Responses usage shape — Codex's deserializer
+      // rejects a completed response without it ("missing field total_tokens").
+      total_tokens: inputTokens + outputTokens,
       ...(Object.keys(inputDetails).length > 0 ? { input_tokens_details: inputDetails } : {}),
       ...(Object.keys(outputDetails).length > 0 ? { output_tokens_details: outputDetails } : {}),
     };
@@ -738,6 +747,7 @@ const ResponsesUsageSchema = z
   .object({
     input_tokens: z.number().int().nonnegative().optional(),
     output_tokens: z.number().int().nonnegative().optional(),
+    total_tokens: z.number().int().nonnegative().optional(),
     input_tokens_details: z
       .object({
         cached_tokens: z.number().int().nonnegative().optional(),

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -70,6 +70,24 @@ describe("openaiToResponsesRequest", () => {
     });
   });
 
+  it("forwards reasoning_effort to the Codex body as reasoning.effort (incl. xhigh)", () => {
+    // Load-bearing: the Codex subscription speaks Responses; without this map the
+    // client's effort was silently dropped and the backend ran at its default.
+    const withEffort = openaiToResponsesRequest({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "Hi" }],
+      reasoning_effort: "xhigh",
+    });
+    expect(withEffort.reasoning).toEqual({ effort: "xhigh" });
+    // Absent -> no reasoning key (preserve the existing Codex contract).
+    const without = openaiToResponsesRequest({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "Hi" }],
+    });
+    expect(without.reasoning).toBeUndefined();
+    expect(without.text).toEqual({ verbosity: "low" });
+  });
+
   it("sets prompt_cache_key from a stable sessionId (omitted when absent)", () => {
     const withSession = openaiToResponsesRequest(
       { model: "gpt-5.5", messages: [{ role: "user", content: "Hi" }] },

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -209,6 +209,12 @@ export function openaiToResponsesRequest(
   if (typeof r.prompt_cache_retention === "string")
     body.prompt_cache_retention = r.prompt_cache_retention;
   if (typeof r.temperature === "number") body.temperature = r.temperature;
+  // Forward the client's reasoning effort to the Codex backend (Responses speaks
+  // `reasoning.effort`). Without this the subscription always ran at its DEFAULT —
+  // a real Codex `model_reasoning_effort` (incl. high/xhigh/max) was silently
+  // dropped here. The IR has already normalized any unknown tier to a known one.
+  if (typeof r.reasoning_effort === "string" && r.reasoning_effort.length > 0)
+    body.reasoning = { effort: r.reasoning_effort };
   if (Array.isArray(r.tools)) {
     const tools = (r.tools as Array<Record<string, unknown>>).flatMap((t) => {
       const fn = (t.function ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
Fixes Codex failing against the gateway, plus two related Responses-path defects — all grounded in litellm's tolerant model.

### 1. Over-strict reasoning-effort enum → 400 (the reported error)
The IR hub + Responses/OpenAI inbound schemas only accepted `minimal|low|medium|high`, so Codex's `reasoning.effort:"xhigh"` returned `400 invalid_value` (surfaced as *"model may not exist"*). litellm (`types/llms/openai.py`) uses a broader set and **passes through / clamps**, never 400s.
- `IRReasoningEffortSchema` is now tolerant (litellm parity): accepts `none|minimal|low|medium|high|xhigh|max` and **clamps any unknown future tier to `high`** instead of rejecting — closed TS *type*, open *parse*. Reused at the Responses + OpenAI inbound boundaries.
- Extended the Anthropic + **Gemini** thinking-budget tables (`xhigh=8192, max=16384, none=0`, litellm constants) and widened Gemini's typed union (it *type-errored* on the new tiers — confirming the Gemini path was also wrong).

### 2. Effort silently dropped before the Codex backend (load-bearing)
`openaiToResponsesRequest` hardcoded the Codex body and never forwarded `reasoning_effort`, so the subscription always ran at its default regardless of the client's setting. Now maps `reasoning_effort → reasoning.effort` on the Codex Responses body.

### 3. Responses `usage` missing `total_tokens`
Codex's deserializer requires it (`failed to parse ResponseCompleted: missing field total_tokens`). Added `total_tokens = input+output` to both the stream (`projectUsage`) and non-stream usage projections + schemas.

## Test
- New/updated: IR schema (extended tiers + unknown→`high`, no longer throws), Codex forwarding (`reasoning_effort:"xhigh"` → `reasoning:{effort:"xhigh"}`), Anthropic per-tier budget (xhigh/max/none), Responses `total_tokens` (stream + non-stream).
- Protocol + provider suites **716/716 green**, `typecheck` + `biome` clean. (Local `store/sqlite/*` reds are a `better-sqlite3` NODE_MODULE_VERSION ABI skew in the dev box's nvm Node — unrelated; CI rebuilds natives.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
