### PR TITLE
chore(release): v0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release v0.11.2

Patch — one bugfix PR since v0.11.1:

- **#168** fix(protocol): tolerant reasoning-effort (xhigh/max) + forward to Codex + Responses total_tokens. Fixes Codex `400 invalid_value` on `reasoning.effort:"xhigh"` (the effort schema is now litellm-tolerant: accepts none/minimal/low/medium/high/xhigh/max, clamps unknowns to `high`), actually forwards the effort to the openai-codex backend (was silently dropped), and adds `total_tokens` to the Responses usage (Codex's deserializer requires it). Anthropic + Gemini budget tables extended for the new tiers.

Merging cuts tag `v0.11.2` + Release + `:0.11.2`/`:latest` via publish.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
