### PR TITLE
feat(admin): add client integration guide

### DIFF
--- a/apps/admin/src/lib/components/ConnectClientDialog.svelte
+++ b/apps/admin/src/lib/components/ConnectClientDialog.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { t } from '$lib/i18n';
+  import Modal from './Modal.svelte';
+
+  // "Connect a client" guide: a tabbed, copy-paste integration reference shown on
+  // the API Keys page. Its whole reason to exist is the ASYMMETRIC base-URL footgun
+  // (the #1 onboarding mistake): Anthropic clients (Claude Code) append /v1/messages
+  // themselves, so they take the BARE origin — a trailing /v1 yields /v1/v1/messages
+  // → 404. Codex appends /responses, so it MUST get origin + /v1. Same gateway, two
+  // conventions; we spell both out as ready-to-paste snippets so nobody has to read
+  // the spec. (See docs/08 client recipes + the helm-claude-code-base-url memo.)
+  //
+  // The key in the snippets is a placeholder by default. When opened straight from
+  // the create-key reveal, the freshly-minted plaintext is injected (one-time) so
+  // the operator can copy a complete, working config — it is passed in as a prop,
+  // never persisted or re-fetched here (CLAUDE.md 原则7 / docs/06).
+  let { plaintextKey, onclose }: { plaintextKey?: string; onclose: () => void } = $props();
+
+  type Tab = 'claude' | 'codex' | 'gemini' | 'openclaw' | 'sdk';
+  let tab = $state<Tab>('claude');
+
+  // The gateway is same-origin with this SPA (Hono serves the admin at /admin), so
+  // window.location.origin IS the public base URL. SSR-safe default for the first
+  // paint; resolved on mount. Caveat: under `pnpm dev` the admin runs on its own
+  // Vite port, so this shows the dev URL — correct only when served by the gateway.
+  let origin = $state('https://helm.example.com');
+  onMount(() => {
+    origin = window.location.origin;
+  });
+
+  // Anthropic path = bare origin (NO /v1); OpenAI/Responses path = origin + /v1.
+  let baseBare = $derived(origin);
+  let baseV1 = $derived(`${origin}/v1`);
+  // Real minted key when injected post-creation, else a copy-and-replace placeholder.
+  let keyShown = $derived(plaintextKey ?? '<your-helm-key>');
+
+  // Snippet bodies are literal template strings, NOT i18n keys — translating a URL,
+  // a flag, or TOML punctuation would silently break the config. Only the prose
+  // around them is localized.
+  let claudeEnv = $derived(
+    `export ANTHROPIC_BASE_URL="${baseBare}"\nexport ANTHROPIC_AUTH_TOKEN="${keyShown}"`,
+  );
+  let codexToml = $derived(
+    `# ~/.codex/config.toml\n[model_providers.helm]\nname = "Helm"\nbase_url = "${baseV1}"\nenv_key = "HELM_API_KEY"\nwire_api = "responses"\n\n# then, in your shell:\nexport HELM_API_KEY="${keyShown}"`,
+  );
+  let geminiCurl = $derived(
+    `curl "${baseBare}/v1beta/models/auto:generateContent" \\\n  -H "Content-Type: application/json" \\\n  -H "x-goog-api-key: ${keyShown}" \\\n  -d '{"contents":[{"parts":[{"text":"Hello from Helm"}]}]}'`,
+  );
+  let openclawCfg = $derived(
+    `base_url: ${baseV1}\napi_key: ${keyShown}\nmodel: auto`,
+  );
+  let sdkOpenai = $derived(
+    `from openai import OpenAI\n\nclient = OpenAI(base_url="${baseV1}", api_key="${keyShown}")\nclient.chat.completions.create(model="auto", messages=[...])`,
+  );
+  let sdkAnthropic = $derived(
+    `from anthropic import Anthropic\n\nclient = Anthropic(base_url="${baseBare}", auth_token="${keyShown}")\nclient.messages.create(model="auto", max_tokens=1024, messages=[...])`,
+  );
+
+  // Which code block last had its Copy pressed — drives the per-block "Copied" flip
+  // without a sub-component or per-block state. Clipboard may be unavailable in an
+  // insecure context; degrade silently and never surface the secret in an error.
+  let copiedId = $state<string | null>(null);
+  async function copy(id: string, text: string): Promise<void> {
+    try {
+      await navigator.clipboard?.writeText(text);
+      copiedId = id;
+    } catch {
+      copiedId = null;
+    }
+  }
+</script>
+
+{#snippet codeBlock(id: string, code: string, testid: string)}
+  <div class="overflow-hidden rounded-lg border border-slate-200">
+    <div class="flex items-center justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-1.5">
+      <span class="font-mono text-xs text-ink-muted">{testid.replace('snippet-', '')}</span>
+      <button type="button" class="btn-primary-sm" onclick={() => copy(id, code)}
+        >{copiedId === id ? $t('Copied') : $t('Copy')}</button
+      >
+    </div>
+    <pre
+      data-testid={testid}
+      class="overflow-auto whitespace-pre-wrap break-words bg-white p-3 font-mono text-xs leading-relaxed text-ink-strong [overflow-wrap:anywhere]">{code}</pre>
+  </div>
+{/snippet}
+
+<Modal label={$t('Connect a client')} {onclose} wide>
+  <div class="flex max-h-[80vh] flex-col">
+    <h2 class="section-header">{$t('Connect a client')}</h2>
+    <p class="mt-1 text-sm text-ink-muted">
+      {$t(
+        'Point your tool at Helm by setting its base URL and API key, then send model "auto" (or a lane name) — the gateway picks the model.',
+      )}
+    </p>
+
+    {#if plaintextKey}
+      <p data-testid="connect-secret-note" class="mt-2 text-sm text-amber-700">
+        {$t(
+          'These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.',
+        )}
+      </p>
+    {/if}
+
+    <!-- One tab per client; the base-URL convention differs across them by design. -->
+    <div class="mt-4 flex gap-4 border-b border-slate-200" role="tablist" aria-label={$t('Connect a client')}>
+      <button type="button" role="tab" class="tab-btn" aria-selected={tab === 'claude'}
+        onclick={() => (tab = 'claude')}>{$t('Claude Code')}</button
+      >
+      <button type="button" role="tab" class="tab-btn" aria-selected={tab === 'codex'}
+        onclick={() => (tab = 'codex')}>{$t('Codex CLI')}</button
+      >
+      <button type="button" role="tab" class="tab-btn" aria-selected={tab === 'gemini'}
+        onclick={() => (tab = 'gemini')}>{$t('Gemini')}</button
+      >
+      <button type="button" role="tab" class="tab-btn" aria-selected={tab === 'openclaw'}
+        onclick={() => (tab = 'openclaw')}>{$t('OpenClaw')}</button
+      >
+      <button type="button" role="tab" class="tab-btn" aria-selected={tab === 'sdk'}
+        onclick={() => (tab = 'sdk')}>{$t('OpenAI / Anthropic SDK')}</button
+      >
+    </div>
+
+    <div class="mt-4 min-h-0 flex-1 overflow-auto">
+      {#if tab === 'claude'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t('Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).')}
+        </p>
+        {@render codeBlock('claude-env', claudeEnv, 'snippet-claude')}
+      {:else if tab === 'codex'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t('Add a provider to ~/.codex/config.toml. The base URL MUST end in /v1 (Codex appends /responses).')}
+        </p>
+        {@render codeBlock('codex-toml', codexToml, 'snippet-codex')}
+      {:else if tab === 'gemini'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t('Use Helm\'s native Gemini route. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.')}
+        </p>
+        {@render codeBlock('gemini-curl', geminiCurl, 'snippet-gemini')}
+      {:else if tab === 'openclaw'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t('Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.')}
+        </p>
+        {@render codeBlock('openclaw-cfg', openclawCfg, 'snippet-openclaw')}
+      {:else}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t('Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.')}
+        </p>
+        <div class="flex flex-col gap-3">
+          {@render codeBlock('sdk-openai', sdkOpenai, 'snippet-sdk-openai')}
+          {@render codeBlock('sdk-anthropic', sdkAnthropic, 'snippet-sdk-anthropic')}
+        </div>
+      {/if}
+    </div>
+
+    <div class="mt-4 flex justify-end">
+      <button type="button" class="btn-secondary" onclick={onclose}>{$t('Close')}</button>
+    </div>
+  </div>
+</Modal>

--- a/apps/admin/src/lib/components/ConnectClientDialog.test.ts
+++ b/apps/admin/src/lib/components/ConnectClientDialog.test.ts
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ConnectClientDialog from './ConnectClientDialog.svelte';
+
+// The "Connect a client" guide: a tabbed, copy-paste integration reference shown
+// on the API Keys page. It teaches the asymmetric base-URL convention that is the
+// #1 onboarding footgun — Claude Code wants the BARE origin (no /v1), Codex wants
+// origin + /v1 (see docs/08, helm-claude-code-base-url + codex-helm-setup memos).
+//
+// The base URL is read from window.location.origin (admin is same-origin with the
+// gateway). The API key is a placeholder by default; when opened right after key
+// creation the freshly-minted plaintext is injected (one-time) — but never
+// persisted, mirroring CreateKeyDialog's reveal discipline (CLAUDE.md 原则7).
+
+const ORIGIN = 'https://helm.example.test';
+
+function stubOrigin(value: string): void {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, origin: value, href: `${value}/admin/keys` },
+  });
+}
+
+function setup(props: { plaintextKey?: string } = {}) {
+  const onclose = vi.fn();
+  render(ConnectClientDialog, { onclose, ...props });
+  return { onclose };
+}
+
+describe('ConnectClientDialog', () => {
+  beforeEach(() => {
+    stubOrigin(ORIGIN);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders inside a labelled, dismissible modal', async () => {
+    const { onclose } = setup();
+    expect(screen.getByRole('dialog', { name: /connect a client/i })).toBeInTheDocument();
+    await fireEvent.click(screen.getByTestId('modal-scrim'));
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to the Claude Code tab and shows the BARE origin with no /v1 suffix', () => {
+    setup();
+    const claudeTab = screen.getByRole('tab', { name: /claude code/i });
+    expect(claudeTab).toHaveAttribute('aria-selected', 'true');
+    // The env snippet must point ANTHROPIC_BASE_URL at the bare origin. A trailing
+    // /v1 here is the exact bug that 404s every model — assert it is absent.
+    const snippet = screen.getByTestId('snippet-claude').textContent ?? '';
+    expect(snippet).toContain(`ANTHROPIC_BASE_URL="${ORIGIN}"`);
+    expect(snippet).not.toContain(`${ORIGIN}/v1`);
+    expect(snippet).toContain('ANTHROPIC_AUTH_TOKEN');
+  });
+
+  it('renders the Codex tab with base_url ending in /v1 and wire_api = "responses"', async () => {
+    setup();
+    await fireEvent.click(screen.getByRole('tab', { name: /codex/i }));
+    const snippet = screen.getByTestId('snippet-codex').textContent ?? '';
+    expect(snippet).toContain(`base_url = "${ORIGIN}/v1"`);
+    expect(snippet).toContain('wire_api = "responses"');
+  });
+
+  it('renders the Gemini tab with the native /v1beta path and x-goog-api-key auth', async () => {
+    setup();
+    await fireEvent.click(screen.getByRole('tab', { name: /gemini/i }));
+    const snippet = screen.getByTestId('snippet-gemini').textContent ?? '';
+    expect(snippet).toContain(`${ORIGIN}/v1beta/models/auto:generateContent`);
+    expect(snippet).toContain('x-goog-api-key');
+    expect(snippet).not.toContain(`${ORIGIN}/v1/`);
+  });
+
+  it('shows a placeholder key when no plaintext is supplied (opened from the header)', () => {
+    setup();
+    expect(screen.getByTestId('snippet-claude').textContent ?? '').toContain('<your-helm-key>');
+    // No one-time-secret caption when we are only showing a placeholder.
+    expect(screen.queryByTestId('connect-secret-note')).not.toBeInTheDocument();
+  });
+
+  it('injects the freshly-minted plaintext into every tab when supplied', async () => {
+    const KEY = 'helm_live_FRESH_ONE_TIME';
+    setup({ plaintextKey: KEY });
+    // Claude (default) tab carries it…
+    expect(screen.getByTestId('snippet-claude').textContent ?? '').toContain(KEY);
+    expect(screen.getByTestId('snippet-claude').textContent ?? '').not.toContain('<your-helm-key>');
+    // …and so does the Codex tab.
+    await fireEvent.click(screen.getByRole('tab', { name: /codex/i }));
+    expect(screen.getByTestId('snippet-codex').textContent ?? '').toContain(KEY);
+    // A one-time-secret caption warns the operator to copy now.
+    expect(screen.getByTestId('connect-secret-note')).toBeInTheDocument();
+  });
+
+  it('copies the active snippet to the clipboard and flips the button to "Copied"', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    setup();
+    const copyBtn = screen.getAllByRole('button', { name: /^copy$/i })[0];
+    await fireEvent.click(copyBtn);
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).toContain(`ANTHROPIC_BASE_URL="${ORIGIN}"`);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /copied/i }).length).toBeGreaterThan(0));
+  });
+
+  it('exposes Claude Code, Codex, Gemini, OpenClaw and SDK tabs', () => {
+    setup();
+    expect(screen.getByRole('tab', { name: /claude code/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /codex/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /gemini/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /openclaw/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /sdk/i })).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -5,6 +5,7 @@
     createKey,
     type CreatedKey,
   } from '$lib/api/keys.js';
+  import ConnectClientDialog from '$lib/components/ConnectClientDialog.svelte';
   import KeyCapsForm, { emptyKeyCaps } from '$lib/components/KeyCapsForm.svelte';
   import Modal from '$lib/components/Modal.svelte';
   import { t } from '$lib/i18n';
@@ -41,6 +42,11 @@
   // cleared on close. While set, the form is replaced by the one-time reveal.
   let revealed = $state<CreatedKey | null>(null);
   let copied = $state<boolean>(false);
+  // The "Connect a client" guide, opened from the reveal step with the fresh
+  // plaintext injected (one-time). It is a child of THIS component so the secret
+  // never leaves the dialog that owns it — never lifted to the page or persisted
+  // (CLAUDE.md 原则7 / docs/06). Wiped alongside `revealed` on confirmSaved.
+  let showConnect = $state<boolean>(false);
 
   async function handleCreate(): Promise<void> {
     error = null;
@@ -125,6 +131,7 @@
     // Wipe transient secret state from the component.
     revealed = null;
     copied = false;
+    showConnect = false;
     onclose();
   }
 </script>
@@ -150,9 +157,19 @@
         >{copied ? $t('Copied') : $t('Copy')}</button
       >
     </div>
-    <div class="mt-4 flex justify-end">
+    <div class="mt-4 flex justify-end gap-2">
+      <button type="button" class="btn-secondary" onclick={() => (showConnect = true)}
+        >{$t('Connect a client')}</button
+      >
       <button type="button" class="btn-success" onclick={confirmSaved}>{$t('I saved it')}</button>
     </div>
+
+    {#if showConnect}
+      <ConnectClientDialog
+        plaintextKey={revealed.plaintext}
+        onclose={() => (showConnect = false)}
+      />
+    {/if}
   {:else}
     <h2 class="section-header">{$t('Create API key')}</h2>
 

--- a/apps/admin/src/lib/components/CreateKeyDialog.test.ts
+++ b/apps/admin/src/lib/components/CreateKeyDialog.test.ts
@@ -102,6 +102,20 @@ describe('CreateKeyDialog', () => {
     expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
   });
 
+  it('offers a "Connect a client" guide carrying the freshly-minted plaintext', async () => {
+    setup();
+    await fireEvent.click(screen.getByRole('button', { name: /create key/i }));
+    await waitFor(() => expect(screen.getByTestId('plaintext-reveal')).toBeInTheDocument());
+
+    // The reveal step offers a guide; opening it injects the real key into a snippet
+    // (one-time), so the operator can copy a complete config without leaving the flow.
+    await fireEvent.click(screen.getByRole('button', { name: /connect a client/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: /connect a client/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('snippet-claude')).toHaveTextContent(PLAINTEXT);
+  });
+
   it('wipes the plaintext from the DOM once saved/closed — not re-viewable', async () => {
     const { oncreated, onclose } = setup();
     await fireEvent.click(screen.getByRole('button', { name: /create key/i }));

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -516,5 +516,18 @@
   "The verdict that routed this request — the badge shows which layer decided it.": "The verdict that routed this request — the badge shows which layer decided it.",
   "Layer-1 rules were uncertain (confidence {confidence}) — escalated to the eval model; the verdict and confidence above are the eval model’s.": "Layer-1 rules were uncertain (confidence {confidence}) — escalated to the eval model; the verdict and confidence above are the eval model’s.",
   "Layer-1 rules were uncertain — escalated to the eval model; the verdict and confidence above are the eval model’s.": "Layer-1 rules were uncertain — escalated to the eval model; the verdict and confidence above are the eval model’s.",
-  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane."
+  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.",
+  "Connect a client": "Connect a client",
+  "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.",
+  "These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.": "These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.",
+  "Claude Code": "Claude Code",
+  "Codex CLI": "Codex CLI",
+  "Gemini": "Gemini",
+  "OpenClaw": "OpenClaw",
+  "OpenAI / Anthropic SDK": "OpenAI / Anthropic SDK",
+  "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).",
+  "Add a provider to ~/.codex/config.toml. The base URL MUST end in /v1 (Codex appends /responses).": "Add a provider to ~/.codex/config.toml. The base URL MUST end in /v1 (Codex appends /responses).",
+  "Use Helm's native Gemini route. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "Use Helm's native Gemini route. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.",
+  "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.",
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one."
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -507,5 +507,18 @@
   "The verdict that routed this request — the badge shows which layer decided it.": "このリクエストをルーティングした判定結果——バッジがどのレイヤーの判定かを示します。",
   "Layer-1 rules were uncertain (confidence {confidence}) — escalated to the eval model; the verdict and confidence above are the eval model’s.": "Layer-1ルールは不確実（信頼度 {confidence}）のため評価モデルにエスカレーション——上記の判定と信頼度は評価モデルによるものです。",
   "Layer-1 rules were uncertain — escalated to the eval model; the verdict and confidence above are the eval model’s.": "Layer-1ルールは不確実のため評価モデルにエスカレーション——上記の判定と信頼度は評価モデルによるものです。",
-  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "——評価は無効です。ルールが不確実だったため、ルーティングはbalancedレーンにフォールバックしました。"
+  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "——評価は無効です。ルールが不確実だったため、ルーティングはbalancedレーンにフォールバックしました。",
+  "Connect a client": "クライアントを接続",
+  "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "ツールの base URL と API キーを Helm に向け、model に “auto”（またはレーン名）を指定するだけ。どのモデルを使うかはゲートウェイが選びます。",
+  "These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.": "以下のスニペットには新しいキーが含まれており、表示されるのはこの一度きりです。必要なものは今すぐコピーしてください。保存するのはハッシュのみで、後から復元はできません。",
+  "Claude Code": "Claude Code",
+  "Codex CLI": "Codex CLI",
+  "Gemini": "Gemini",
+  "OpenClaw": "OpenClaw",
+  "OpenAI / Anthropic SDK": "OpenAI / Anthropic SDK",
+  "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "次の環境変数を設定します。base URL はオリジンそのままで——/v1 は付けないでください（Anthropic クライアントが自分で /v1/messages を付けます）。",
+  "Add a provider to ~/.codex/config.toml. The base URL MUST end in /v1 (Codex appends /responses).": "~/.codex/config.toml に provider を追加します。base URL は必ず /v1 で終わらせてください（Codex が /responses を付けます）。",
+  "Use Helm's native Gemini route. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "Helm のネイティブ Gemini ルートを使います。base URL はオリジンそのまま、リクエストパスに /v1beta/models/{model}:generateContent を付け、認証には x-goog-api-key を使います。",
+  "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "OpenAI 互換の provider を設定します。base URL は /v1 で終わります。Anthropic 経路の場合はオリジンそのままを使ってください。",
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI または Anthropic 互換の SDK ならどれでも使えます——変えるのは base URL とキーだけ。OpenAI の base URL には /v1 が付き、Anthropic には付かない点に注意してください。"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -507,5 +507,18 @@
   "The verdict that routed this request — the badge shows which layer decided it.": "이 요청을 라우팅한 판정 결과 — 배지가 어느 레이어의 판정인지 표시합니다.",
   "Layer-1 rules were uncertain (confidence {confidence}) — escalated to the eval model; the verdict and confidence above are the eval model’s.": "Layer-1 규칙이 불확실하여(신뢰도 {confidence}) 평가 모델로 에스컬레이션됨 — 위의 판정과 신뢰도는 평가 모델의 결과입니다.",
   "Layer-1 rules were uncertain — escalated to the eval model; the verdict and confidence above are the eval model’s.": "Layer-1 규칙이 불확실하여 평가 모델로 에스컬레이션됨 — 위의 판정과 신뢰도는 평가 모델의 결과입니다.",
-  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "— 평가가 비활성화되어 있습니다. 규칙이 불확실하여 라우팅이 balanced 레인으로 폴백되었습니다."
+  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "— 평가가 비활성화되어 있습니다. 규칙이 불확실하여 라우팅이 balanced 레인으로 폴백되었습니다.",
+  "Connect a client": "클라이언트 연결",
+  "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "도구의 base URL과 API 키를 Helm으로 설정한 뒤 model에 “auto”(또는 레인 이름)를 보내세요. 어떤 모델을 쓸지는 게이트웨이가 고릅니다.",
+  "These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.": "아래 스니펫에는 새 키가 포함되어 있으며 이번 한 번만 표시됩니다. 필요한 것은 지금 복사하세요. 해시만 저장하므로 나중에 복구할 수 없습니다.",
+  "Claude Code": "Claude Code",
+  "Codex CLI": "Codex CLI",
+  "Gemini": "Gemini",
+  "OpenClaw": "OpenClaw",
+  "OpenAI / Anthropic SDK": "OpenAI / Anthropic SDK",
+  "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "다음 환경 변수를 설정하세요. base URL은 오리진 그대로이며 /v1을 붙이지 마세요(Anthropic 클라이언트가 /v1/messages를 직접 붙입니다).",
+  "Add a provider to ~/.codex/config.toml. The base URL MUST end in /v1 (Codex appends /responses).": "~/.codex/config.toml에 provider를 추가하세요. base URL은 반드시 /v1로 끝나야 합니다(Codex가 /responses를 붙입니다).",
+  "Use Helm's native Gemini route. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "Helm의 네이티브 Gemini 경로를 사용하세요. base URL은 오리진 그대로이고, 요청 경로에 /v1beta/models/{model}:generateContent를 붙이며 인증은 x-goog-api-key를 사용합니다.",
+  "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "OpenAI 호환 provider를 설정하세요. base URL은 /v1로 끝납니다. Anthropic 경로에서는 오리진 그대로를 사용하세요.",
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI 또는 Anthropic 호환 SDK라면 무엇이든 동작합니다 — base URL과 키만 바꾸면 됩니다. OpenAI base URL에는 /v1이 붙고 Anthropic에는 붙지 않는 점에 유의하세요."
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -516,5 +516,18 @@
   "The verdict that routed this request — the badge shows which layer decided it.": "本请求最终采用的分类结论——徽章标明由哪一层判定。",
   "Layer-1 rules were uncertain (confidence {confidence}) — escalated to the eval model; the verdict and confidence above are the eval model’s.": "第一层规则不确定（置信度 {confidence}），已升级到 eval 模型复核；上方的结论与置信度均为 eval 模型给出。",
   "Layer-1 rules were uncertain — escalated to the eval model; the verdict and confidence above are the eval model’s.": "第一层规则不确定，已升级到 eval 模型复核；上方的结论与置信度均为 eval 模型给出。",
-  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "——eval 未启用；第一层规则不确定，路由已回退到 balanced lane。"
+  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "——eval 未启用；第一层规则不确定，路由已回退到 balanced lane。",
+  "Connect a client": "接入客户端",
+  "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "把你的工具指向 Helm：填好 base URL 和 API key，再把 model 设为 “auto”（或某个 lane 名称）——具体用哪个模型交给网关来挑。",
+  "These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.": "下面的代码已经带上了你的新密钥，且仅此一次展示。需要的现在就复制——我们只保存哈希，之后无法找回。",
+  "Claude Code": "Claude Code",
+  "Codex CLI": "Codex CLI",
+  "Gemini": "Gemini",
+  "OpenClaw": "OpenClaw",
+  "OpenAI / Anthropic SDK": "OpenAI / Anthropic SDK",
+  "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "设置下面这几个环境变量。base URL 用裸域名即可——千万别加 /v1（Anthropic 客户端会自己补上 /v1/messages）。",
+  "Add a provider to ~/.codex/config.toml. The base URL MUST end in /v1 (Codex appends /responses).": "在 ~/.codex/config.toml 里加一个 provider。base URL 必须以 /v1 结尾（Codex 会自己补上 /responses）。",
+  "Use Helm's native Gemini route. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "使用 Helm 的原生 Gemini 路由。base URL 用裸域名；请求路径再加 /v1beta/models/{model}:generateContent，认证使用 x-goog-api-key。",
+  "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "配置一个兼容 OpenAI 的 provider。base URL 以 /v1 结尾；若走 Anthropic 路径，则改用裸域名。",
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何兼容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密钥。留意：OpenAI 的 base URL 带 /v1，Anthropic 的不带。"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -510,5 +510,18 @@
   "The verdict that routed this request — the badge shows which layer decided it.": "本請求最終採用的分類結論——徽章標明由哪一層判定。",
   "Layer-1 rules were uncertain (confidence {confidence}) — escalated to the eval model; the verdict and confidence above are the eval model’s.": "第一層規則不確定（信心度 {confidence}），已升級到 eval 模型複核；上方的結論與信心度均為 eval 模型給出。",
   "Layer-1 rules were uncertain — escalated to the eval model; the verdict and confidence above are the eval model’s.": "第一層規則不確定，已升級到 eval 模型複核；上方的結論與信心度均為 eval 模型給出。",
-  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "——eval 未啟用；第一層規則不確定，路由已回退到 balanced lane。"
+  "— eval is disabled; rules were uncertain, so routing fell back to the balanced lane.": "——eval 未啟用；第一層規則不確定，路由已回退到 balanced lane。",
+  "Connect a client": "接入用戶端",
+  "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "把你的工具指向 Helm：填好 base URL 和 API key，再把 model 設為 “auto”（或某個 lane 名稱）——具體用哪個模型交給閘道來挑。",
+  "These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.": "下面的程式碼已經帶上了你的新密鑰，且僅此一次顯示。需要的現在就複製——我們只保存雜湊，之後無法找回。",
+  "Claude Code": "Claude Code",
+  "Codex CLI": "Codex CLI",
+  "Gemini": "Gemini",
+  "OpenClaw": "OpenClaw",
+  "OpenAI / Anthropic SDK": "OpenAI / Anthropic SDK",
+  "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "設定下面這幾個環境變數。base URL 用裸網域即可——千萬別加 /v1（Anthropic 用戶端會自己補上 /v1/messages）。",
+  "Add a provider to ~/.codex/config.toml. The base URL MUST end in /v1 (Codex appends /responses).": "在 ~/.codex/config.toml 裡加一個 provider。base URL 必須以 /v1 結尾（Codex 會自己補上 /responses）。",
+  "Use Helm's native Gemini route. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "使用 Helm 的原生 Gemini 路由。base URL 用裸網域；請求路徑再加 /v1beta/models/{model}:generateContent，認證使用 x-goog-api-key。",
+  "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "設定一個相容 OpenAI 的 provider。base URL 以 /v1 結尾；若走 Anthropic 路徑，則改用裸網域。",
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何相容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密鑰。留意：OpenAI 的 base URL 帶 /v1，Anthropic 的不帶。"
 }

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import { type ApiKeyView, deleteKey, revokeKey } from '$lib/api/keys.js';
+  import ConnectClientDialog from '$lib/components/ConnectClientDialog.svelte';
   import CreateKeyDialog from '$lib/components/CreateKeyDialog.svelte';
   import EditKeyDialog from '$lib/components/EditKeyDialog.svelte';
   import Modal from '$lib/components/Modal.svelte';
@@ -19,6 +20,10 @@
 
   let error = $state<string | null>(null);
   let showCreate = $state<boolean>(false);
+  // The "Connect a client" guide, opened from the header with no minted key (so it
+  // shows a <your-helm-key> placeholder). The post-creation flow opens its own
+  // instance pre-filled with the fresh plaintext (see CreateKeyDialog).
+  let showConnect = $state<boolean>(false);
   // The key_id currently pending a revoke confirmation, if any.
   let confirmingRevoke = $state<string | null>(null);
   let revoking = $state<string | null>(null);
@@ -135,9 +140,14 @@
         )}
       </p>
     </div>
-    <button type="button" class="btn-primary shrink-0" onclick={() => (showCreate = true)}
-      >{$t('New key')}</button
-    >
+    <div class="flex shrink-0 gap-2">
+      <button type="button" class="btn-secondary" onclick={() => (showConnect = true)}
+        >{$t('Connect a client')}</button
+      >
+      <button type="button" class="btn-primary" onclick={() => (showCreate = true)}
+        >{$t('New key')}</button
+      >
+    </div>
   </header>
 
   {#if error}
@@ -148,6 +158,10 @@
 
   {#if showCreate}
     <CreateKeyDialog {lanes} oncreated={onCreated} onclose={() => (showCreate = false)} />
+  {/if}
+
+  {#if showConnect}
+    <ConnectClientDialog onclose={() => (showConnect = false)} />
   {/if}
 
   {#if editingKey}

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -206,6 +206,24 @@ export ANTHROPIC_AUTH_TOKEN="helm_live_..."
 export ANTHROPIC_CUSTOM_HEADERS="x-project-id: my-project"  # optional
 ```
 
+**Gemini native REST / SDKs** — Helm exposes the native Gemini surface, not the
+OpenAI-compatible Gemini shim. Use the bare origin plus `/v1beta/models/...`;
+auth is `x-goog-api-key` (Gemini SDK / REST default), with `Authorization: Bearer`
+as a Helm fallback:
+
+```bash
+curl "https://helm.example.com/v1beta/models/auto:generateContent" \
+  -H "Content-Type: application/json" \
+  -H "x-goog-api-key: helm_live_..." \
+  -d '{"contents":[{"parts":[{"text":"Hello from Helm"}]}]}'
+```
+
+Streaming uses the Gemini SSE endpoint:
+
+```text
+POST /v1beta/models/auto:streamGenerateContent?alt=sse
+```
+
 **OpenClaw** — static headers via provider `request.headers`; thread derives from
 `prompt_cache_key` (OpenAI path) or `metadata.user_id` (Anthropic path). OpenClaw
 also ships its own local vector memory — gateway memory is the cross-agent shared


### PR DESCRIPTION
## Summary

- Add an API Keys "Connect a client" modal with copy-paste recipes for Claude Code, Codex CLI, Gemini, OpenClaw, and OpenAI/Anthropic SDKs
- Wire the guide from the API Keys header and the one-time key reveal flow, injecting the freshly minted plaintext only in that transient reveal path
- Document Gemini native REST in docs/08: bare origin + /v1beta/models/{model}:generateContent, x-goog-api-key auth, and streaming endpoint
- Add i18n strings across en, zh-hans, zh-hant, ja, and ko

## Verification

- pnpm --filter @helm/admin exec vitest run: 293 passed
- pnpm typecheck: passed
- pnpm lint: passed
- pnpm build: passed
- Locale JSON validation: passed for all 5 locales
- svelte-check: still fails only on pre-existing apps/admin/src/lib/api/oauth.test.ts tuple errors (untouched by this change)

## Gemini references

- Google Gemini API key docs: x-goog-api-key and GEMINI_API_KEY / GOOGLE_API_KEY
- Google Gemini OpenAI compatibility docs: /v1beta/openai/ is Google’s OpenAI-compatible shim; Helm’s existing native Gemini route is /v1beta/models/{model}:generateContent

🤖 Generated with [Claude Code](https://claude.com/claude-code)