### PR TITLE
feat(config): gpt-5.4 and gpt-5.4-mini vendor-family lanes

### DIFF
--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -131,3 +131,23 @@ claude-haiku:
   fallback:
     - zenmux/gpt-5.5
     - premium
+
+# GPT-5.4 — strong reasoning one tier below 5.5 ($2.5/$15 vs 5.5's $5/$30). Leads
+# with the Codex subscription's real gpt-5.4. ZenMux exposes NO 5.4 static key, so
+# it degrades to the GPT-led `premium` lane (gpt-5.5 -> static zenmux/gpt-5.5 ->
+# Opus) rather than dropping straight to the cheap tier on the first hiccup.
+"gpt-5.4":
+  purpose: OpenAI GPT-5.4 tier — strong reasoning
+  primary: openai-codex/gpt-5.4
+  fallback:
+    - premium
+
+# GPT-5.4-mini — the cheap/fast GPT tier ($0.75/$4.5). Leads with the Codex
+# subscription's real gpt-5.4-mini, then degrades to `economy` (where this SAME
+# model already sits as a fallback), keeping a mini request cheap instead of
+# bumping it onto a premium model.
+"gpt-5.4-mini":
+  purpose: OpenAI GPT-5.4 mini tier — cheap/fast
+  primary: openai-codex/gpt-5.4-mini
+  fallback:
+    - economy

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -38,8 +38,17 @@
 "claude-*": balanced # catch-all for any other / future Claude id
 
 # ── OpenAI-compatible clients (Codex, Cursor, …) ─────────────────────────────
-# Bare GPT ids → lanes. Comment these out if you don't front any GPT clients.
-"gpt-5.5": gpt-5.5 # dedicated vendor-family lane (config/lanes.yaml)
+# Bare GPT ids → lanes (config/lanes.yaml). Each named family maps to its DEDICATED
+# vendor-family lane so the request LEADS with that family's real model; the `-*`
+# globs absorb any dated/suffixed id. The cheap `gpt-5.4-mini` needs its OWN mapping
+# (it is more literal than `gpt-5*`, so longest-literal-wins routes it to the cheap
+# lane, NOT the expensive `premium` catch-all). Comment these out if you don't front
+# any GPT clients.
+"gpt-5.5": gpt-5.5
+"gpt-5.4-mini": gpt-5.4-mini
+"gpt-5.4-mini-*": gpt-5.4-mini
+"gpt-5.4": gpt-5.4
+"gpt-5.4-*": gpt-5.4
 "gpt-5-codex": coding
 "gpt-5*": premium
 "gpt-*": balanced

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -79,9 +79,25 @@ describe("checked-in config samples", () => {
     // with a date suffix (the common dated Haiku id shape) — the haiku-specific glob
     // wins over the broad claude-* catch-all (which still falls through to balanced).
     expect(resolveModelAlias("claude-3-5-haiku-20241022", aliases)).toBe("claude-haiku");
+    // GPT families route to their dedicated vendor-family lanes. The cheap mini must
+    // NOT be swallowed by the broad `gpt-5*` -> premium catch-all (longest-literal
+    // wins): a dated mini id still lands on the cheap gpt-5.4-mini lane.
+    expect(resolveModelAlias("gpt-5.4", aliases)).toBe("gpt-5.4");
+    expect(resolveModelAlias("gpt-5.4-mini", aliases)).toBe("gpt-5.4-mini");
+    expect(resolveModelAlias("gpt-5.4-mini-2026-01-01", aliases)).toBe("gpt-5.4-mini");
     // The shipped aliases must validate against the SHIPPED lanes (no drift): every
     // target is a configured lane or "auto", or the gateway would refuse to boot.
     expect(validateModelAliasTargets(aliases, laneNames)).toEqual([]);
+  });
+
+  it("loads the shipped gpt-5.4 vendor-family lanes leading with the real codex models", () => {
+    const cfg = loadConfig({ configDir, env: {} });
+    const lanes = cfg.lanes;
+    if (lanes === undefined) throw new Error("config/lanes.yaml must load into config.lanes");
+    expect(lanes["gpt-5.4"]?.primary).toBe("openai-codex/gpt-5.4");
+    expect(lanes["gpt-5.4"]?.fallback).toEqual(["premium"]);
+    expect(lanes["gpt-5.4-mini"]?.primary).toBe("openai-codex/gpt-5.4-mini");
+    expect(lanes["gpt-5.4-mini"]?.fallback).toEqual(["economy"]);
   });
 
   it("loads the shipped policies.yaml as first-match rules", () => {


### PR DESCRIPTION
## What

Adds dedicated **vendor-family lanes** + virtual aliases for the two GPT-5.4-class models the Codex subscription exposes. `openai-codex/gpt-5.4` and `openai-codex/gpt-5.4-mini` already carry capabilities + pricing on `main` (5.4 = \$2.5/\$15, mini = \$0.75/\$4.5) but had **no lane and no virtual alias** — so a client sending `gpt-5.4-mini` hit the broad `gpt-5* → premium` catch-all and got bumped onto an expensive model, and `gpt-5.4` landed on the gpt-5.5 lane.

### Lanes (`config/lanes.yaml`)
- **`gpt-5.4`** → `openai-codex/gpt-5.4`, fallback `[premium]` — strong reasoning one tier below 5.5; ZenMux has no static 5.4 key, so it degrades through the GPT-led `premium` lane rather than dropping to the cheap tier.
- **`gpt-5.4-mini`** → `openai-codex/gpt-5.4-mini`, fallback `[economy]` — the cheap/fast tier degrades to `economy`, where the same model already sits as a fallback, keeping a mini request cheap.

### Aliases (`config/model-aliases.yaml`)
- `gpt-5.4 → gpt-5.4`, `gpt-5.4-mini → gpt-5.4-mini`, plus `-*` globs for dated ids.
- Longest-literal precedence verified: `gpt-5.4-mini-*` (and the exact key) beat `gpt-5.4-*` and the broad `gpt-5*`, so a mini id never routes to the expensive 5.4/premium lane.

## Tests
`samples.test.ts` extended to pin the shipped-config resolution; every alias target resolves to a real lane (boot fail-closed validation passes).

**Verification**: typecheck ✓, lint ✓, build ✓, config + routing + lanes + catalog suites **217 green**. (Store/sqlite suites were red locally only due to a `better-sqlite3` Node-ABI mismatch in the worktree — environmental, not from this change; CI builds its own native modules.)

## Notes
- `capabilities.yaml` / `pricing.yaml` entries for these models are already on `main` — unchanged here.
- Deploy: operator-owned config dir isn't overwritten by deploy, so to activate on an existing install, add these lanes/aliases there (or rely on `auto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)