### PR TITLE
chore(config): drop ZenMux fallbacks from Claude lanes, repoint GPT-5.5

### DIFF
--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -104,14 +104,12 @@ claude-opus:
   purpose: Anthropic Claude Opus tier — strongest Claude
   primary: anthropic/claude-opus-4-8
   fallback:
-    - zenmux/claude-opus-4.8
     - premium
 
 claude-sonnet:
   purpose: Anthropic Claude Sonnet tier — balanced Claude
   primary: anthropic/claude-sonnet-4-6
   fallback:
-    - zenmux/claude-sonnet-4.6
     - balanced
 
 # ZenMux exposes no Claude Haiku, so this cheap/fast tier degrades straight to
@@ -129,5 +127,5 @@ claude-haiku:
   purpose: OpenAI GPT-5.5 tier
   primary: openai-codex/gpt-5.5
   fallback:
-    - zenmux/gpt-5.5
+    - anthropic/claude-opus-4-8
     - premium


### PR DESCRIPTION
## What

- Remove `zenmux/claude-opus-4.8` and `zenmux/claude-sonnet-4.6` from the `claude-opus` / `claude-sonnet` fallback chains.
- Repoint the GPT-5.5 lane fallback from `zenmux/gpt-5.5` to `anthropic/claude-opus-4-8`.

## Why

ZenMux fallbacks are being retired from the Claude lanes; the GPT-5.5 lane now degrades to Anthropic Opus instead.

## Validation

- `samples.test.ts` + `rules-routing.test.ts` green (12 tests) — shipped-config routing unchanged where it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)