### PR TITLE
chore(release): v0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.11.3**.

Ships the Phase A SQLite write-latency fix (#175) to la.atmy.work:
- `synchronous=NORMAL` + `busy_timeout`/`temp_store`/`cache_size` pragmas (drops the per-commit fsync that froze Node's event loop under concurrency).
- Batched `MemoryStore.appendMessages()` — a whole turn commits once instead of N times.

Merging this bumps root `package.json` to 0.11.3, which triggers `publish.yml` to build `:0.11.3` + `:latest` and cut tag `v0.11.3` + the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)