### PR TITLE
perf(gateway): keep SQLite off the AI hot path for high concurrency

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -15,6 +15,7 @@
     "@hono/node-server": "^2.0.4",
     "@hono/swagger-ui": "^0.6.1",
     "hono": "^4.12.23",
+    "undici": "^8.3.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -5,6 +5,8 @@
 import { serve } from "@hono/node-server";
 import { createApp } from "./app.js";
 import { createJsonLogger } from "./logging.js";
+import { configureEgress } from "./runtime/egress.js";
+import { type ClosableServer, closeServer } from "./runtime/shutdown.js";
 import { buildServer } from "./server.js";
 
 export { type AppDeps, type AppEnv, createApp } from "./app.js";
@@ -40,9 +42,39 @@ export function buildDefaultApp() {
 async function main(): Promise<void> {
   const logger = createJsonLogger();
   try {
-    const { app, port, host } = await buildServer({ logger });
-    serve({ fetch: app.fetch, port, hostname: host });
-    logger.log("info", "gateway.listening", { host, port });
+    // Tune the process-global undici dispatcher (keep-alive) BEFORE any upstream
+    // call can be made — it is a process global, so it cannot live inside buildServer.
+    configureEgress(process.env);
+    const handle = await buildServer({ logger });
+    const server = serve({ fetch: handle.app.fetch, port: handle.port, hostname: handle.host });
+    logger.log("info", "gateway.listening", { host: handle.host, port: handle.port });
+
+    // Graceful shutdown: FIRST stop accepting connections and wait for in-flight
+    // requests to finish (so their post-response enqueue()s land while the queue is
+    // still running), THEN drain the deferred write queue + close the store
+    // (handle.dispose). Ordering matters — disposing before requests drain would drop
+    // their telemetry/payload writes and run budget/store work against a closed DB.
+    // Idempotent across repeated signals. The drain is bounded by HELM_SHUTDOWN_DRAIN_MS.
+    const drainRaw = Number(process.env.HELM_SHUTDOWN_DRAIN_MS);
+    const drainMs = Number.isFinite(drainRaw) && drainRaw > 0 ? drainRaw : 10_000;
+    let shuttingDown = false;
+    const shutdown = async (signal: string): Promise<void> => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      logger.log("info", "gateway.shutdown", { signal });
+      try {
+        await closeServer(server as unknown as ClosableServer, drainMs);
+        await handle.dispose?.();
+      } catch (err) {
+        logger.log("error", "gateway.shutdown_failed", {
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        process.exit(0);
+      }
+    };
+    process.on("SIGTERM", () => void shutdown("SIGTERM"));
+    process.on("SIGINT", () => void shutdown("SIGINT"));
   } catch (err) {
     logger.log("error", "gateway.startup_failed", {
       message: err instanceof Error ? err.message : String(err),

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -11,6 +11,7 @@ import { type InternalRequest, makeHelmError } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { createWriteQueue } from "../runtime/write-queue.js";
 import { type ChatRouteDeps, registerChatRoutes } from "./chat.js";
 
 // ── auth fixtures ─────────────────────────────────────────────────────────────
@@ -759,6 +760,82 @@ describe("POST /v1/chat/completions — payload capture + streamed cost", () => 
     expect(cap.payloads).toHaveLength(1);
     expect(cap.payloads[0]?.requestJson).toBe(rawRequest);
     expect(cap.payloads[0]?.responseJson).toBe(JSON.stringify(upstream));
+  });
+});
+
+// ── deferred write queue (perf): writes leave the response's critical path ─────
+describe("POST /v1/chat/completions — deferred write queue", () => {
+  function captureTelemetry() {
+    const inserted: unknown[] = [];
+    const payloads: Array<{ requestId: string; responseJson: string | null }> = [];
+    const telemetry = {
+      insert: vi.fn(async (i: { decision: unknown }) => {
+        inserted.push(i.decision);
+        return { id: "1" };
+      }),
+      insertPayload: vi.fn(async (p: { requestId: string; responseJson: string | null }) => {
+        payloads.push({ requestId: p.requestId, responseJson: p.responseJson });
+      }),
+      prunePayloads: vi.fn(async () => {}),
+    } as unknown as TelemetryStore;
+    return { telemetry, inserted, payloads };
+  }
+
+  it("defers telemetry + payload off the response, then writes them on flush", async () => {
+    const cap = captureTelemetry();
+    const q = createWriteQueue({
+      telemetry: cap.telemetry,
+      log: () => {},
+      flushIntervalMs: 10_000,
+    });
+    const { deps: d, harness } = deps({
+      telemetry: cap.telemetry,
+      writes: q,
+      capturePayloads: () => true,
+      payloadRetentionMs: () => 1000,
+      costOf: () => 0,
+    });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "c", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(200);
+    // The response has already returned — nothing has hit the store yet.
+    expect(cap.inserted).toHaveLength(0);
+    expect(cap.payloads).toHaveLength(0);
+
+    await q.flush();
+    expect(cap.inserted).toHaveLength(1);
+    expect(cap.payloads).toHaveLength(1);
+  });
+
+  it("a failing deferred write never affects the served response (fail-open)", async () => {
+    const cap = captureTelemetry();
+    (cap.telemetry.insert as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("db down"));
+    const q = createWriteQueue({
+      telemetry: cap.telemetry,
+      log: () => {},
+      flushIntervalMs: 10_000,
+    });
+    const { deps: d, harness } = deps({ telemetry: cap.telemetry, writes: q });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "c", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(200);
+    await expect(q.flush()).resolves.toBeUndefined();
   });
 });
 

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -6,6 +6,7 @@ import type {
   DecisionRecord,
   ExecutionResult,
   InjectDeps,
+  InsertTelemetryInput,
   IRMessage,
   MemoryScope,
   ObserveDeps,
@@ -32,11 +33,13 @@ import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../app.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
 import type { ServingAccount } from "../runtime/serving-account.js";
+import type { WriteQueue } from "../runtime/write-queue.js";
 import { copyLiteLLMRequestParams, providerRawFromRequest } from "./internal-request-params.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
 import {
   backfillCompletionCost,
   captureEnabled,
+  createSseCapture,
   type PayloadCaptureDeps,
   persistPayload,
   tokensFromUsage,
@@ -65,6 +68,13 @@ export interface ChatRouteDeps {
     classifyOverrides?: { evalEnabled?: boolean; rulesThreshold?: number },
   ) => Promise<ExecutionResult & { servingAccount?: ServingAccount | null }>;
   telemetry: TelemetryStore;
+  /** Deferred + batched write queue (perf). Optional: ABSENT = today's behavior —
+   *  telemetry/payload/observe writes are awaited inline (the entire existing test
+   *  suite runs unchanged). PRESENT = those fail-open writes are enqueued to run
+   *  AFTER the response (batched), so a synchronous SQLite commit never sits on the
+   *  request's critical path. The budget `settle` is NEVER deferred (quota
+   *  correctness). Wired in the composition root. */
+  writes?: WriteQueue;
   redact: (payload: unknown) => unknown;
   now: () => number;
   /** Per-account OAuth subscription usage recorder (providers page Tier 2).
@@ -367,17 +377,66 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     const originalMessagesForMemory = [...(internal.messages as IRMessage[])];
 
     // Persist a (redacted) telemetry record. Fail-open: a telemetry failure must
-    // never turn a successful request into a 5xx or break an in-flight stream.
+    // never turn a successful request into a 5xx or break an in-flight stream. The
+    // redaction is done HERE (synchronously) so the enqueued snapshot can never be
+    // affected by anything that touches the decision after the response returns.
+    // With a write queue wired, the insert is deferred + batched off the hot path.
     const persist = async (decision: DecisionRecord) => {
+      const input: InsertTelemetryInput = {
+        decision: deps.redact(decision) as DecisionRecord,
+        apiKeyId: identity.keyId,
+        createdAt: new Date(),
+      };
+      if (deps.writes !== undefined) {
+        deps.writes.enqueueTelemetry(input);
+        return;
+      }
       try {
-        await deps.telemetry.insert({
-          decision: deps.redact(decision) as DecisionRecord,
-          apiKeyId: identity.keyId,
-          createdAt: new Date(),
-        });
+        await deps.telemetry.insert(input);
       } catch {
         c.get("logger").log("error", "telemetry.insert_failed", { trace_id: traceId });
       }
+    };
+
+    // Capture the verbatim request/response bodies. Mirrors `persist`: deferred +
+    // batched when a write queue is wired, else the inline await (today's behavior).
+    // Self-gates on capture_payloads exactly like persistPayload. The retention
+    // prune rides along as a deferred task so it never blocks the response.
+    const capturePayload = async (responseJson: string | null) => {
+      if (deps.writes !== undefined) {
+        if (!captureEnabled(deps)) return;
+        deps.writes.enqueuePayload({
+          requestId: traceId,
+          requestJson,
+          responseJson,
+          createdAt: new Date(deps.now()),
+        });
+        const retentionMs = deps.payloadRetentionMs?.();
+        if (retentionMs !== undefined && retentionMs > 0) {
+          const cutoff = deps.now() - retentionMs;
+          deps.writes.enqueueTask(() => deps.telemetry.prunePayloads(cutoff));
+        }
+        return;
+      }
+      await persistPayload(
+        deps,
+        { requestId: traceId, requestJson, responseJson, now: deps.now() },
+        (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+      );
+    };
+
+    // Run the memory observe write-back: deferred (FIFO) when a write queue is
+    // wired, else inline await (today). observeInbound/observeOutbound are fail-open
+    // inside core. FIFO ordering guarantees inbound (enqueued before route) settles
+    // before outbound (enqueued in the finally) for the same thread.
+    const runObserve = async (task: () => Promise<unknown>) => {
+      if (deps.writes !== undefined) {
+        deps.writes.enqueueTask(async () => {
+          await task();
+        });
+        return;
+      }
+      await task();
     };
 
     // Post-served usage-budget settle (docs/06). Fail-OPEN — mirrors `persist`: a
@@ -504,7 +563,8 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     // inject hydration. observe is write-only and fail-open; delaying it avoids
     // same-turn self-pollution while still capturing the turn for future calls.
     if (deps.memory !== undefined) {
-      await observeInbound(deps.memory.observe, memoryScope, originalMessagesForMemory);
+      const memoryObserve = deps.memory.observe;
+      await runObserve(() => observeInbound(memoryObserve, memoryScope, originalMessagesForMemory));
     }
 
     const result = await deps.route(
@@ -580,9 +640,11 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       // couldn't know it at peek time). This runs REGARDLESS of capture_payloads:
       // cost telemetry must not depend on full-body capture (an operator may turn
       // capture off for privacy yet still want costs). `captureOn` gates only
-      // whether the buffered body is PERSISTED, not whether it is collected.
+      // whether the buffered body is PERSISTED, not whether it is collected — so
+      // when capture is OFF we retain only a bounded TAIL (enough for usageFromSSE),
+      // not the whole response, capping per-stream memory under high concurrency.
       const captureOn = captureEnabled(deps);
-      const captured: string[] = [];
+      const captured = createSseCapture(captureOn);
       // Concurrency slot handoff (issue #93, feature A): streamSSE returns its
       // Response BEFORE the stream body finishes, so claim the lease from the
       // middleware and release it in the stream's OWN finally — the slot stays
@@ -615,7 +677,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
           releaseConcurrency?.();
           // Streamed completion-cost backfill (#6): parse the trailing usage and
           // price it at the served alias. Fail-open — leave cost null on any miss.
-          const rawSse = captured.join("");
+          const rawSse = captured.value();
           const finalAlias =
             result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
           try {
@@ -626,20 +688,12 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
           } catch {
             c.get("logger").log("warn", "cost.stream_backfill_failed", { trace_id: traceId });
           }
-          await persistPayload(
-            deps,
-            {
-              requestId: traceId,
-              requestJson,
-              responseJson: captureOn ? rawSse : null,
-              now: deps.now(),
-            },
-            (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
-          );
+          await capturePayload(captureOn ? rawSse : null);
           await persist(result.decision);
           // Usage-budget settle (streamed): runs HERE — after the usage tail
           // backfilled the streamed cost — so the spend dimension settles the real
-          // total. Tokens come from the same usage tail. Fail-open.
+          // total. Tokens come from the same usage tail. Fail-open. NEVER deferred
+          // (quota correctness): the next request's pre-route gate must see this spend.
           await settle(result.decision, tokensFromUsage(usageFromSSE(rawSse)));
           // Memory observe (outbound, streamed): persist the reconstructed
           // assistant turn AFTER the bytes were forwarded. Fail-open inside core.
@@ -651,15 +705,16 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
             // Flush the last partial event the \n\n-split loop held back, so a
             // final frame without a trailing \n\n is not dropped.
             flushOpenAIChunk(assistant);
-            await observeOutbound(
-              deps.memory.observe,
-              memoryScope,
-              {
-                responseMessages:
-                  assistant.text.length > 0 ? [{ role: "assistant", content: assistant.text }] : [],
-                toolResults: [],
-              },
-              finalAlias,
+            const memoryObserve = deps.memory.observe;
+            const responseMessages: IRMessage[] =
+              assistant.text.length > 0 ? [{ role: "assistant", content: assistant.text }] : [];
+            await runObserve(() =>
+              observeOutbound(
+                memoryObserve,
+                memoryScope,
+                { responseMessages, toolResults: [] },
+                finalAlias,
+              ),
             );
           }
         }
@@ -667,16 +722,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     }
 
     // --- non-streaming branch ---
-    await persistPayload(
-      deps,
-      {
-        requestId: traceId,
-        requestJson,
-        responseJson: result.body !== null ? JSON.stringify(result.body) : null,
-        now: deps.now(),
-      },
-      (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
-    );
+    await capturePayload(result.body !== null ? JSON.stringify(result.body) : null);
     await persist(result.decision);
     if (result.final.status === "error" || result.body === null) {
       const error =
@@ -694,12 +740,9 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     if (deps.memory !== undefined) {
       const finalAlias =
         result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
-      await observeOutbound(
-        deps.memory.observe,
-        memoryScope,
-        outboundFromOpenAIBody(result.body),
-        finalAlias,
-      );
+      const memoryObserve = deps.memory.observe;
+      const outbound = outboundFromOpenAIBody(result.body);
+      await runObserve(() => observeOutbound(memoryObserve, memoryScope, outbound, finalAlias));
     }
     // Usage-budget settle (non-stream, success): cost is already on the decision;
     // tokens from the body's usage. Fail-open.

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -25,6 +25,7 @@ import {
 } from "@helm/core";
 import type { InternalRequest, MemoryDecision, Protocol } from "@helm/shared";
 import type { ServingAccount } from "../runtime/serving-account.js";
+import type { WriteQueue } from "../runtime/write-queue.js";
 import { copyLiteLLMRequestParams, providerRawFromRequest } from "./internal-request-params.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import {
@@ -346,9 +347,25 @@ export function createMessagesPipeline(
   // no recording (existing tests unchanged). Called for EVERY served request,
   // independent of budgets; fail-open in the composition root.
   recordOAuthUsage?: RecordOAuthUsageFn,
+  // Deferred + batched write queue (perf). ABSENT = today's behavior (memory observe
+  // is awaited inline; observeInbound blocks before routing). PRESENT = the fail-open
+  // observe writes are enqueued (FIFO, so inbound still settles before outbound) to
+  // run AFTER the response. The budget settle is NEVER deferred (quota correctness).
+  writes?: WriteQueue,
 ): {
   run(ir: PipelineIR, identity: MessagesIdentity, signal: AbortSignal): Promise<PipelineRunResult>;
 } {
+  // Run a fail-open memory observe: deferred (FIFO) when a write queue is wired, else
+  // inline await (today). FIFO ordering keeps inbound before outbound per thread.
+  const runObserve = async (task: () => Promise<unknown>): Promise<void> => {
+    if (writes !== undefined) {
+      writes.enqueueTask(async () => {
+        await task();
+      });
+      return;
+    }
+    await task();
+  };
   return {
     async run(ir, identity, signal) {
       const meta = ir.metadata;
@@ -414,7 +431,10 @@ export function createMessagesPipeline(
       // Memory observe (inbound): persist the original raw messages after
       // inject. It is write-only and fail-open; delaying it prevents self-pollution.
       if (memory !== undefined) {
-        await observeInbound(memory.observe, memoryScope, originalMessagesForMemory);
+        const memoryObserve = memory.observe;
+        await runObserve(() =>
+          observeInbound(memoryObserve, memoryScope, originalMessagesForMemory),
+        );
       }
 
       const caps = identity.caps as
@@ -515,11 +535,10 @@ export function createMessagesPipeline(
           if (memory !== undefined) {
             const finalAlias =
               result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
-            await observeOutbound(
-              memory.observe,
-              memoryScope,
-              outboundFromIR(irResponse),
-              finalAlias,
+            const memoryObserve = memory.observe;
+            const outbound = outboundFromIR(irResponse);
+            await runObserve(() =>
+              observeOutbound(memoryObserve, memoryScope, outbound, finalAlias),
             );
           }
           // Settle the budget on the served (non-stream) response: cost is already
@@ -595,17 +614,16 @@ export function createMessagesPipeline(
             if (memory !== undefined) {
               const finalAlias =
                 result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
-              await observeOutbound(
-                memory.observe,
-                memoryScope,
-                {
-                  responseMessages:
-                    assistant.text.length > 0
-                      ? [{ role: "assistant", content: assistant.text }]
-                      : [],
-                  toolResults: [],
-                },
-                finalAlias,
+              const memoryObserve = memory.observe;
+              const responseMessages: IRMessage[] =
+                assistant.text.length > 0 ? [{ role: "assistant", content: assistant.text }] : [];
+              await runObserve(() =>
+                observeOutbound(
+                  memoryObserve,
+                  memoryScope,
+                  { responseMessages, toolResults: [] },
+                  finalAlias,
+                ),
               );
             }
             // Streamed-cost backfill + budget settle (docs/06). Zero-touch when

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -1,9 +1,13 @@
 import type { DecisionRecord, InsertPayloadInput } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
+import { createWriteQueue } from "../runtime/write-queue.js";
 import {
   backfillCompletionCost,
+  createSseCapture,
   type PayloadCaptureDeps,
   persistPayload,
+  type RecordServedDeps,
+  recordServed,
   tokensFromUsage,
   usageFromSSE,
 } from "./payload-capture.js";
@@ -27,6 +31,43 @@ describe("usageFromSSE", () => {
   it("skips non-JSON keepalive lines without throwing", () => {
     const sse = ': keepalive\n\ndata: {"usage":{"prompt_tokens":1,"completion_tokens":2}}\n\n';
     expect(usageFromSSE(sse)).toEqual({ prompt_tokens: 1, completion_tokens: 2 });
+  });
+});
+
+describe("createSseCapture", () => {
+  const usageFrame =
+    'data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50}}\n\n';
+
+  it("retains the FULL body when capturing (verbatim persistence)", () => {
+    const cap = createSseCapture(true);
+    const chunks = [
+      'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+      usageFrame,
+      "data: [DONE]\n\n",
+    ];
+    for (const c of chunks) cap.push(c);
+    expect(cap.value()).toBe(chunks.join(""));
+  });
+
+  it("keeps only a bounded tail when NOT capturing, still enough for usageFromSSE", () => {
+    const cap = createSseCapture(false, 1024);
+    // A big stream: 500 content frames (well over the 1KB tail) then the usage frame.
+    for (let i = 0; i < 500; i++)
+      cap.push(`data: {"choices":[{"delta":{"content":"tok${i}"}}]}\n\n`);
+    cap.push(usageFrame);
+    cap.push("data: [DONE]\n\n");
+
+    const tail = cap.value();
+    // The retained tail is bounded — nowhere near the full body...
+    expect(tail.length).toBeLessThan(4000);
+    // ...yet cost backfill still finds the usage (it scans from the end).
+    expect(usageFromSSE(tail)).toEqual({ prompt_tokens: 100, completion_tokens: 50 });
+  });
+
+  it("never drops the only/last chunk even if it exceeds the tail budget", () => {
+    const cap = createSseCapture(false, 8);
+    cap.push(usageFrame); // single chunk larger than the budget
+    expect(usageFromSSE(cap.value())).toEqual({ prompt_tokens: 100, completion_tokens: 50 });
   });
 });
 
@@ -149,5 +190,65 @@ describe("persistPayload", () => {
       persistPayload(d, { requestId: "req_1", requestJson: "{}", responseJson: null, now: 1 }, log),
     ).resolves.toBeUndefined();
     expect(log).toHaveBeenCalledWith("payload.capture_failed");
+  });
+});
+
+describe("recordServed — deferred write queue (the three pipeline faces)", () => {
+  function sink() {
+    const inserted: DecisionRecord[] = [];
+    const payloads: InsertPayloadInput[] = [];
+    const telemetry = {
+      insert: vi.fn(async (i: { decision: DecisionRecord }) => {
+        inserted.push(i.decision);
+        return { id: "1" };
+      }),
+      insertPayload: vi.fn(async (p: InsertPayloadInput) => {
+        payloads.push(p);
+      }),
+      prunePayloads: vi.fn(async () => {}),
+    } as unknown as RecordServedDeps["telemetry"];
+    return { telemetry, inserted, payloads };
+  }
+  const args = {
+    requestId: "req_1",
+    apiKeyId: "k1",
+    decision: decision(),
+    requestJson: "{}",
+    responseJson: "{}",
+  };
+
+  it("defers telemetry + payload off the response, written only on flush", async () => {
+    const s = sink();
+    const q = createWriteQueue({ telemetry: s.telemetry, log: () => {}, flushIntervalMs: 10_000 });
+    const d: RecordServedDeps = {
+      telemetry: s.telemetry,
+      writes: q,
+      redact: (x) => x,
+      now: () => 5000,
+      capturePayloads: () => true,
+      payloadRetentionMs: () => 1000,
+    };
+    await recordServed(d, args, () => {});
+    expect(s.inserted).toHaveLength(0);
+    expect(s.payloads).toHaveLength(0);
+
+    await q.flush();
+    expect(s.inserted).toHaveLength(1);
+    expect(s.payloads).toHaveLength(1);
+    expect(s.payloads[0]?.requestId).toBe("req_1");
+  });
+
+  it("writes inline (today's behavior) when no queue is wired", async () => {
+    const s = sink();
+    const d: RecordServedDeps = {
+      telemetry: s.telemetry,
+      redact: (x) => x,
+      now: () => 5000,
+      capturePayloads: () => true,
+      payloadRetentionMs: () => 1000,
+    };
+    await recordServed(d, { ...args, requestId: "req_2" }, () => {});
+    expect(s.inserted).toHaveLength(1);
+    expect(s.payloads).toHaveLength(1);
   });
 });

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -1,4 +1,5 @@
 import type { DecisionRecord, TelemetryStore } from "@helm/core";
+import type { WriteQueue } from "../runtime/write-queue.js";
 
 // Shared full request/response capture + streamed-cost backfill helpers, used by
 // BOTH the OpenAI (chat.ts) and Anthropic (messages-pipeline.ts) routes.
@@ -55,11 +56,54 @@ export function captureEnabled(deps: PayloadCaptureDeps): boolean {
   return deps.capturePayloads?.() === true;
 }
 
+// Default retained-tail size (chars) when NOT persisting the body. The trailing
+// usage frame (include_usage) is tiny and always last, so a few KB is ample for
+// usageFromSSE; this caps per-stream memory instead of pinning the whole response.
+const SSE_TAIL_CHARS = 16_384;
+
+export interface SseCapture {
+  push(chunk: string): void;
+  /** The retained text: the FULL body when capturing, else a bounded trailing tail. */
+  value(): string;
+}
+
+// Accumulate forwarded SSE chunks for end-of-stream use (verbatim capture +
+// streamed-cost backfill) WITHOUT pinning the whole response in memory when capture
+// is off. `full=true` keeps everything (it will be persisted verbatim). `full=false`
+// keeps only a bounded trailing tail — enough for usageFromSSE, which scans from the
+// END — so a large stream under high concurrency costs O(tail), not O(response). The
+// caller always feeds a COPY after writing the chunk downstream, so this never
+// touches the bytes forwarded to the client (principle 8).
+export function createSseCapture(full: boolean, tailChars: number = SSE_TAIL_CHARS): SseCapture {
+  const parts: string[] = [];
+  let size = 0;
+  return {
+    push(chunk: string): void {
+      parts.push(chunk);
+      if (full) return;
+      size += chunk.length;
+      // Drop oldest parts while over budget, but always retain at least the last one.
+      while (size > tailChars && parts.length > 1) {
+        const dropped = parts.shift();
+        if (dropped !== undefined) size -= dropped.length;
+      }
+    },
+    value(): string {
+      return parts.join("");
+    },
+  };
+}
+
 export interface RecordServedDeps extends PayloadCaptureDeps {
   /** Redactor for the decision before it is persisted to telemetry (never store a
    *  plaintext key / secret). Same redactor the chat route uses. */
   redact: (decision: DecisionRecord) => DecisionRecord;
   now: () => number;
+  /** Deferred + batched write queue (perf). ABSENT = today's behavior (the
+   *  telemetry + payload writes are awaited inline). PRESENT = both are enqueued to
+   *  run AFTER the response, batched off the request's critical path. Fail-open
+   *  either way. Wired in the composition root for the three pipeline faces. */
+  writes?: WriteQueue;
 }
 
 // Record ONE served request: the telemetry row (always — this is what makes the
@@ -79,6 +123,33 @@ export async function recordServed(
   },
   log: (msg: string) => void,
 ): Promise<void> {
+  // Deferred + batched path: enqueue both writes to run AFTER the response, off the
+  // hot path. The redaction is done HERE (synchronously) so the enqueued snapshot is
+  // independent of anything that touches the decision later.
+  const w = deps.writes;
+  if (w !== undefined) {
+    if (captureEnabled(deps)) {
+      w.enqueuePayload({
+        requestId: args.requestId,
+        requestJson: args.requestJson,
+        responseJson: args.responseJson,
+        createdAt: new Date(deps.now()),
+      });
+      const retentionMs = deps.payloadRetentionMs?.();
+      if (retentionMs !== undefined && retentionMs > 0) {
+        const cutoff = deps.now() - retentionMs;
+        w.enqueueTask(() => deps.telemetry.prunePayloads(cutoff));
+      }
+    }
+    w.enqueueTelemetry({
+      decision: deps.redact(args.decision),
+      apiKeyId: args.apiKeyId,
+      createdAt: new Date(deps.now()),
+    });
+    return;
+  }
+
+  // Inline path (no write queue): today's behavior, byte-for-byte.
   await persistPayload(
     deps,
     {

--- a/apps/gateway/src/runtime/egress.test.ts
+++ b/apps/gateway/src/runtime/egress.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { buildEgressAgentOptions } from "./egress.js";
+
+describe("buildEgressAgentOptions", () => {
+  it("uses safe keep-alive defaults and leaves the pool size at undici's default", () => {
+    const opts = buildEgressAgentOptions({});
+    expect(opts.keepAliveTimeout).toBe(30_000);
+    expect(opts.keepAliveMaxTimeout).toBe(60_000);
+    // No explicit `connections` by default → undici keeps its own default (we only
+    // tune keep-alive, never shrink the pool unless an operator opts in).
+    expect(opts.connections).toBeUndefined();
+  });
+
+  it("parses HELM_UNDICI_* overrides", () => {
+    const opts = buildEgressAgentOptions({
+      HELM_UNDICI_KEEPALIVE_MS: "10000",
+      HELM_UNDICI_KEEPALIVE_MAX_MS: "120000",
+      HELM_UNDICI_CONNECTIONS: "256",
+    });
+    expect(opts.keepAliveTimeout).toBe(10_000);
+    expect(opts.keepAliveMaxTimeout).toBe(120_000);
+    expect(opts.connections).toBe(256);
+  });
+
+  it("falls back to defaults on non-numeric / non-positive env", () => {
+    const opts = buildEgressAgentOptions({
+      HELM_UNDICI_KEEPALIVE_MS: "abc",
+      HELM_UNDICI_KEEPALIVE_MAX_MS: "-5",
+      HELM_UNDICI_CONNECTIONS: "0",
+    });
+    expect(opts.keepAliveTimeout).toBe(30_000);
+    expect(opts.keepAliveMaxTimeout).toBe(60_000);
+    expect(opts.connections).toBeUndefined(); // invalid pool size → omit, don't cap
+  });
+});

--- a/apps/gateway/src/runtime/egress.ts
+++ b/apps/gateway/src/runtime/egress.ts
@@ -1,0 +1,43 @@
+import { Agent, setGlobalDispatcher } from "undici";
+
+// Upstream egress tuning (perf). Provider clients call `globalThis.fetch` (undici)
+// with no per-request dispatcher, so every upstream call rides undici's PROCESS-GLOBAL
+// Agent. Its default keep-alive timeout is short (4s), so under bursty LLM traffic
+// idle sockets close and the next call pays a fresh TLS handshake. We install ONE
+// tuned global Agent at boot with a longer keep-alive so connections to each upstream
+// origin are reused. The pool SIZE (`connections`) is left at undici's default unless
+// an operator explicitly sets it — we never shrink the pool implicitly.
+//
+// This must run ONCE at process start (it is a process global; it cannot be per
+// request or set inside buildServer). Per-account proxy clients pass their OWN
+// dispatcher (provider/proxy.ts), so this global never overrides a proxied call.
+
+export interface EgressAgentOptions {
+  keepAliveTimeout: number;
+  keepAliveMaxTimeout: number;
+  // Max connections per origin. Omitted (undefined) → undici default. Only set when
+  // HELM_UNDICI_CONNECTIONS is an explicit positive integer.
+  connections?: number;
+}
+
+function positive(raw: string | undefined, fallback: number): number {
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function buildEgressAgentOptions(
+  env: Record<string, string | undefined>,
+): EgressAgentOptions {
+  const connRaw = Number(env.HELM_UNDICI_CONNECTIONS);
+  const opts: EgressAgentOptions = {
+    keepAliveTimeout: positive(env.HELM_UNDICI_KEEPALIVE_MS, 30_000),
+    keepAliveMaxTimeout: positive(env.HELM_UNDICI_KEEPALIVE_MAX_MS, 60_000),
+  };
+  if (Number.isFinite(connRaw) && connRaw > 0) opts.connections = connRaw;
+  return opts;
+}
+
+// Install the tuned global dispatcher. Side-effecting; call once at boot.
+export function configureEgress(env: Record<string, string | undefined>): void {
+  setGlobalDispatcher(new Agent(buildEgressAgentOptions(env)));
+}

--- a/apps/gateway/src/runtime/shutdown.test.ts
+++ b/apps/gateway/src/runtime/shutdown.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { type ClosableServer, closeServer } from "./shutdown.js";
+
+// A fake http.Server: `closeCb` controls whether/when active connections "drain".
+function fakeServer(opts: { drainsImmediately: boolean }): ClosableServer & {
+  idleClosed: number;
+  allClosed: number;
+} {
+  const state = { idleClosed: 0, allClosed: 0 };
+  return {
+    close(cb?: (err?: Error) => void) {
+      if (opts.drainsImmediately && cb) cb();
+      // else: never invokes cb (a connection is still in flight)
+    },
+    closeIdleConnections: vi.fn(() => {
+      state.idleClosed++;
+    }),
+    closeAllConnections: vi.fn(() => {
+      state.allClosed++;
+    }),
+    get idleClosed() {
+      return state.idleClosed;
+    },
+    get allClosed() {
+      return state.allClosed;
+    },
+  };
+}
+
+describe("closeServer", () => {
+  it("resolves once in-flight requests drain, dropping idle keep-alives, without force-closing", async () => {
+    const server = fakeServer({ drainsImmediately: true });
+    await expect(closeServer(server, 5_000)).resolves.toBeUndefined();
+    expect(server.idleClosed).toBe(1); // idle keep-alives dropped so close can complete
+    expect(server.allClosed).toBe(0); // active drained in time — no force-abort
+  });
+
+  it("force-closes lingering connections once the drain deadline passes", async () => {
+    const server = fakeServer({ drainsImmediately: false });
+    await expect(closeServer(server, 5)).resolves.toBeUndefined();
+    expect(server.allClosed).toBe(1); // deadline hit → force-abort the stuck connection
+  });
+
+  it("tolerates a server missing the optional connection-closing methods", async () => {
+    const minimal: ClosableServer = {
+      close(cb?: (err?: Error) => void) {
+        cb?.();
+      },
+    };
+    await expect(closeServer(minimal, 5_000)).resolves.toBeUndefined();
+  });
+});

--- a/apps/gateway/src/runtime/shutdown.ts
+++ b/apps/gateway/src/runtime/shutdown.ts
@@ -1,0 +1,40 @@
+// Graceful shutdown helper. The minimal slice of a Node http.Server we drive — the
+// optional methods exist on http.Server (Node 18.2+) but not on every member of
+// @hono/node-server's ServerType union, so they're optional + called defensively.
+export interface ClosableServer {
+  close(callback?: (err?: Error) => void): void;
+  closeIdleConnections?(): void;
+  closeAllConnections?(): void;
+}
+
+// Stop accepting new connections and WAIT for in-flight requests to finish before
+// resolving, so the caller can safely tear down the write queue + store afterwards.
+// Without this, SIGTERM would close the listener and immediately stop the queue /
+// close the DB while a request is still running — its later enqueue() calls would be
+// dropped and its synchronous budget/store work would hit a closed DB.
+//
+// Idle keep-alive sockets are dropped immediately (they would otherwise hold the
+// close callback open indefinitely). If active requests don't drain within drainMs,
+// any lingering connection is force-closed so shutdown can never hang forever.
+export function closeServer(server: ClosableServer, drainMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      resolve();
+    };
+    // Stop accepting new connections; the callback fires once active ones finish.
+    server.close(() => done());
+    // Drop idle keep-alive sockets so they don't keep the close callback pending.
+    server.closeIdleConnections?.();
+    timer = setTimeout(() => {
+      // Drain deadline hit — force-abort whatever is still connected, then proceed.
+      server.closeAllConnections?.();
+      done();
+    }, drainMs);
+    if (typeof timer.unref === "function") timer.unref();
+  });
+}

--- a/apps/gateway/src/runtime/write-queue.test.ts
+++ b/apps/gateway/src/runtime/write-queue.test.ts
@@ -1,0 +1,226 @@
+import type { InsertPayloadInput, InsertTelemetryInput } from "@helm/core";
+import { describe, expect, it, vi } from "vitest";
+import { createWriteQueue, type WriteQueueTelemetry } from "./write-queue.js";
+
+interface Sink extends WriteQueueTelemetry {
+  readonly inserts: InsertTelemetryInput[];
+  readonly manyCalls: number;
+  readonly payloadCalls: InsertPayloadInput[];
+  readonly payloadsManyCalls: number;
+}
+
+// A fake telemetry sink recording every call, with toggleable batch support so we
+// can exercise both the batched path and the per-row fallback.
+function fakeSink(opts: { batch?: boolean } = {}): Sink {
+  const inserts: InsertTelemetryInput[] = [];
+  const payloadCalls: InsertPayloadInput[] = [];
+  const counters = { manyCalls: 0, payloadsManyCalls: 0 };
+  const sink: Sink = {
+    get inserts() {
+      return inserts;
+    },
+    get payloadCalls() {
+      return payloadCalls;
+    },
+    get manyCalls() {
+      return counters.manyCalls;
+    },
+    get payloadsManyCalls() {
+      return counters.payloadsManyCalls;
+    },
+    insert: vi.fn(async (i: InsertTelemetryInput) => {
+      inserts.push(i);
+      return { id: "x" };
+    }),
+    insertPayload: vi.fn(async (i: InsertPayloadInput) => {
+      payloadCalls.push(i);
+    }),
+  };
+  if (opts.batch ?? true) {
+    sink.insertMany = vi.fn(async (xs: InsertTelemetryInput[]) => {
+      counters.manyCalls++;
+      inserts.push(...xs);
+    });
+    sink.insertPayloads = vi.fn(async (xs: InsertPayloadInput[]) => {
+      counters.payloadsManyCalls++;
+      payloadCalls.push(...xs);
+    });
+  }
+  return sink;
+}
+
+function tele(id: string): InsertTelemetryInput {
+  return {
+    // The queue treats these as opaque — a minimal decision shape is enough.
+    decision: { request_id: id } as never,
+    apiKeyId: "k1",
+    createdAt: new Date(0),
+  };
+}
+function payload(id: string): InsertPayloadInput {
+  return { requestId: id, requestJson: "{}", responseJson: null, createdAt: new Date(0) };
+}
+
+describe("createWriteQueue", () => {
+  it("defers telemetry until flush, then writes them in ONE batch", async () => {
+    const sink = fakeSink();
+    const q = createWriteQueue({ telemetry: sink, log: () => {}, flushIntervalMs: 10_000 });
+    q.enqueueTelemetry(tele("a"));
+    q.enqueueTelemetry(tele("b"));
+    expect(sink.inserts).toHaveLength(0); // nothing written yet
+
+    await q.flush();
+    expect(sink.inserts.map((i) => (i.decision as { request_id: string }).request_id)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(sink.manyCalls).toBe(1); // one commit, not two
+  });
+
+  it("batches payloads in one commit and defers them until flush", async () => {
+    const sink = fakeSink();
+    const q = createWriteQueue({ telemetry: sink, log: () => {}, flushIntervalMs: 10_000 });
+    q.enqueuePayload(payload("a"));
+    q.enqueuePayload(payload("b"));
+    expect(sink.payloadCalls).toHaveLength(0);
+    await q.flush();
+    expect(sink.payloadCalls.map((p) => p.requestId)).toEqual(["a", "b"]);
+    expect(sink.payloadsManyCalls).toBe(1);
+  });
+
+  it("auto-flushes once a buffer reaches maxBatch", async () => {
+    const sink = fakeSink();
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxBatch: 3,
+    });
+    q.enqueueTelemetry(tele("a"));
+    q.enqueueTelemetry(tele("b"));
+    q.enqueueTelemetry(tele("c")); // hits threshold → flush scheduled
+    await q.flush(); // drain the in-flight threshold flush
+    expect(sink.inserts).toHaveLength(3);
+    expect(sink.manyCalls).toBe(1);
+  });
+
+  it("runs tasks in FIFO order and flush awaits them", async () => {
+    const sink = fakeSink();
+    const q = createWriteQueue({ telemetry: sink, log: () => {}, flushIntervalMs: 10_000 });
+    const order: string[] = [];
+    q.enqueueTask(async () => {
+      await Promise.resolve();
+      order.push("first");
+    });
+    q.enqueueTask(async () => {
+      order.push("second");
+    });
+    await q.flush();
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("is fail-open: a throwing task or write never rejects flush, and siblings still run", async () => {
+    const sink = fakeSink();
+    const logs: string[] = [];
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: (m) => logs.push(m),
+      flushIntervalMs: 10_000,
+    });
+    const ran: string[] = [];
+    q.enqueueTask(async () => {
+      throw new Error("boom");
+    });
+    q.enqueueTask(async () => {
+      ran.push("ok");
+    });
+    await expect(q.flush()).resolves.toBeUndefined();
+    expect(ran).toEqual(["ok"]); // the throw did not poison the chain
+    expect(logs.some((l) => l.includes("task"))).toBe(true);
+  });
+
+  it("does not let a failing telemetry flush reject flush()", async () => {
+    const sink = fakeSink();
+    (sink.insertMany as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("db down"));
+    const logs: string[] = [];
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: (m) => logs.push(m),
+      flushIntervalMs: 10_000,
+    });
+    q.enqueueTelemetry(tele("a"));
+    await expect(q.flush()).resolves.toBeUndefined();
+    expect(logs.some((l) => l.includes("telemetry"))).toBe(true);
+  });
+
+  it("on a batched-insert failure, falls back to per-row so one bad row never drops the batch", async () => {
+    // Simulate a reused request_id in the 25ms window: the multi-row insertMany hits
+    // the unique index and throws; per-row insert throws ONLY for the duplicate id.
+    const written: string[] = [];
+    const telemetry = {
+      insert: vi.fn(async (i: InsertTelemetryInput) => {
+        const id = (i.decision as unknown as { request_id: string }).request_id;
+        if (id === "dup") throw new Error("UNIQUE constraint failed: telemetry.request_id");
+        written.push(id);
+        return { id: "x" };
+      }),
+      insertMany: vi.fn(async () => {
+        throw new Error("UNIQUE constraint failed: telemetry.request_id");
+      }),
+      insertPayload: vi.fn(async () => {}),
+      insertPayloads: vi.fn(async () => {}),
+    } as unknown as WriteQueueTelemetry;
+    const logs: string[] = [];
+    const q = createWriteQueue({ telemetry, log: (m) => logs.push(m), flushIntervalMs: 10_000 });
+
+    q.enqueueTelemetry(tele("a"));
+    q.enqueueTelemetry(tele("dup"));
+    q.enqueueTelemetry(tele("b"));
+    await q.flush();
+
+    // The duplicate is the ONLY row lost; its unrelated neighbors are preserved.
+    expect(written.sort()).toEqual(["a", "b"]);
+    expect(logs).toContain("writequeue.telemetry_batch_fallback");
+  });
+
+  it("falls back to per-row writes when the sink has no batch methods", async () => {
+    const sink = fakeSink({ batch: false });
+    const q = createWriteQueue({ telemetry: sink, log: () => {}, flushIntervalMs: 10_000 });
+    q.enqueueTelemetry(tele("a"));
+    q.enqueueTelemetry(tele("b"));
+    q.enqueuePayload(payload("p"));
+    await q.flush();
+    expect(sink.inserts).toHaveLength(2);
+    expect(sink.payloadCalls).toHaveLength(1);
+    expect(sink.manyCalls).toBe(0); // no batch method available
+  });
+
+  it("bounds depth: drops + logs under overflow, never throws", async () => {
+    const sink = fakeSink();
+    const logs: string[] = [];
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: (m) => logs.push(m),
+      flushIntervalMs: 10_000,
+      maxDepth: 2,
+    });
+    expect(() => {
+      q.enqueueTelemetry(tele("a"));
+      q.enqueueTelemetry(tele("b"));
+      q.enqueueTelemetry(tele("c")); // over depth → drop, log
+      q.enqueueTelemetry(tele("d"));
+    }).not.toThrow();
+    await q.flush();
+    expect(sink.inserts.length).toBeLessThanOrEqual(2);
+    expect(logs.some((l) => l.includes("overflow"))).toBe(true);
+  });
+
+  it("stop() flushes pending writes and stops the timer", async () => {
+    const sink = fakeSink();
+    const q = createWriteQueue({ telemetry: sink, log: () => {}, flushIntervalMs: 10_000 });
+    q.enqueueTelemetry(tele("a"));
+    q.enqueueTask(async () => {});
+    await q.stop();
+    expect(sink.inserts).toHaveLength(1);
+  });
+});

--- a/apps/gateway/src/runtime/write-queue.ts
+++ b/apps/gateway/src/runtime/write-queue.ts
@@ -1,0 +1,211 @@
+import type { InsertPayloadInput, InsertTelemetryInput, TelemetryStore } from "@helm/core";
+
+// The slice of TelemetryStore the queue drives. Batch methods are optional (the
+// queue falls back to per-row writes when an adapter lacks them).
+export type WriteQueueTelemetry = Pick<
+  TelemetryStore,
+  "insert" | "insertMany" | "insertPayload" | "insertPayloads"
+>;
+
+export interface WriteQueueDeps {
+  telemetry: WriteQueueTelemetry;
+  // Structured-log sink (fail-open diagnostics). Never throws.
+  log: (message: string) => void;
+  // Idle flush cadence for the accumulated insert buffers (ms). Default 25.
+  flushIntervalMs?: number;
+  // Flush a buffer eagerly once it reaches this many rows. Default 256.
+  maxBatch?: number;
+  // Hard cap on in-memory backlog (telemetry + payloads + queued tasks). Past it,
+  // the oldest buffered write is dropped (logged) so a write stall can never grow
+  // the heap without bound. Default 10_000.
+  maxDepth?: number;
+}
+
+export interface WriteQueue {
+  // Defer a telemetry decision insert (batched, fail-open, runs after the response).
+  enqueueTelemetry(input: InsertTelemetryInput): void;
+  // Defer a payload upsert (batched, fail-open).
+  enqueuePayload(input: InsertPayloadInput): void;
+  // Defer a fail-open side-effect (memory observe, retention prune, …). Tasks run
+  // sequentially in FIFO order, so callers can rely on inbound-before-outbound.
+  enqueueTask(task: () => Promise<void>): void;
+  // Drain everything currently buffered/queued and resolve when the DB has it.
+  flush(): Promise<void>;
+  // Stop the idle timer and flush once. Idempotent. For graceful shutdown.
+  stop(): Promise<void>;
+  // Current backlog size (for tests / metrics).
+  readonly depth: number;
+}
+
+// In-process deferred + batched write queue (perf). The four AI faces enqueue their
+// fail-open writes (telemetry, payload capture, memory observe) here AFTER the
+// response is produced, so a synchronous better-sqlite3 commit never sits on the
+// request's critical path. Telemetry and payload inserts are coalesced into a single
+// batched commit per flush (N commits → 1), which is what actually relieves the
+// single event-loop thread under concurrency. Side-effect tasks run on one sequential
+// FIFO chain so memory ordering (inbound before outbound) is preserved. Everything is
+// fail-open: a write failure is logged, never thrown — it can never break a served
+// request. Style mirrors core/queue/keyed-semaphore.ts (in-memory, injected log).
+export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
+  const { telemetry, log } = deps;
+  const flushIntervalMs = deps.flushIntervalMs ?? 25;
+  const maxBatch = deps.maxBatch ?? 256;
+  const maxDepth = deps.maxDepth ?? 10_000;
+
+  let telemetryBuf: InsertTelemetryInput[] = [];
+  let payloadBuf: InsertPayloadInput[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  // All DB writes (batch flushes) run on this serial chain so two flushes can never
+  // interleave; flush()/stop() await its tail.
+  let writeChain: Promise<void> = Promise.resolve();
+  // Side-effect tasks run on their own serial FIFO chain.
+  let taskChain: Promise<void> = Promise.resolve();
+  let pendingTasks = 0;
+
+  const depth = (): number => telemetryBuf.length + payloadBuf.length + pendingTasks;
+
+  const clearTimer = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const scheduleTimer = (): void => {
+    if (timer !== null || stopped) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void doFlush();
+    }, flushIntervalMs);
+    // Don't keep the process alive purely for a pending flush.
+    if (typeof timer.unref === "function") timer.unref();
+  };
+
+  // Write a telemetry batch as ONE commit, but fall back to per-row inserts if the
+  // batch throws. A single bad row — e.g. a reused request_id hitting the unique
+  // index — would otherwise abort the whole multi-row statement and drop EVERY
+  // unrelated row in the same flush window. Per-row fallback loses only the offending
+  // row (better-sqlite3 / pg multi-row INSERT is atomic, so nothing committed on the
+  // failed batch — the fallback never double-writes).
+  const writeTelemetry = async (batch: InsertTelemetryInput[]): Promise<void> => {
+    if (batch.length === 0) return;
+    if (telemetry.insertMany) {
+      try {
+        await telemetry.insertMany(batch);
+        return;
+      } catch {
+        log("writequeue.telemetry_batch_fallback");
+      }
+    }
+    for (const input of batch) {
+      try {
+        await telemetry.insert(input);
+      } catch {
+        log("writequeue.telemetry_insert_failed");
+      }
+    }
+  };
+
+  // Same batch-then-per-row resilience for payloads (their upsert tolerates a
+  // duplicate request_id, but any other batch error must not drop the window).
+  const writePayloads = async (batch: InsertPayloadInput[]): Promise<void> => {
+    if (batch.length === 0) return;
+    if (telemetry.insertPayloads) {
+      try {
+        await telemetry.insertPayloads(batch);
+        return;
+      } catch {
+        log("writequeue.payload_batch_fallback");
+      }
+    }
+    for (const input of batch) {
+      try {
+        await telemetry.insertPayload(input);
+      } catch {
+        log("writequeue.payload_insert_failed");
+      }
+    }
+  };
+
+  // Swap out the current buffers and append their writes to the serial chain.
+  // Returns the chain tail so callers can await a full drain.
+  const doFlush = (): Promise<void> => {
+    clearTimer();
+    if (telemetryBuf.length === 0 && payloadBuf.length === 0) return writeChain;
+    const tBatch = telemetryBuf;
+    const pBatch = payloadBuf;
+    telemetryBuf = [];
+    payloadBuf = [];
+    writeChain = writeChain.then(async () => {
+      await writeTelemetry(tBatch);
+      await writePayloads(pBatch);
+    });
+    return writeChain;
+  };
+
+  // Drop the oldest buffered insert to stay under maxDepth. Tasks are never dropped
+  // mid-chain (they're already scheduled); only buffered inserts are shed.
+  const shedIfOverflow = (): void => {
+    if (depth() < maxDepth) return;
+    if (telemetryBuf.length >= payloadBuf.length && telemetryBuf.length > 0) telemetryBuf.shift();
+    else if (payloadBuf.length > 0) payloadBuf.shift();
+    log("writequeue.overflow");
+  };
+
+  return {
+    enqueueTelemetry(input: InsertTelemetryInput): void {
+      if (stopped) return;
+      shedIfOverflow();
+      telemetryBuf.push(input);
+      if (telemetryBuf.length >= maxBatch) void doFlush();
+      else scheduleTimer();
+    },
+
+    enqueuePayload(input: InsertPayloadInput): void {
+      if (stopped) return;
+      shedIfOverflow();
+      payloadBuf.push(input);
+      if (payloadBuf.length >= maxBatch) void doFlush();
+      else scheduleTimer();
+    },
+
+    enqueueTask(task: () => Promise<void>): void {
+      if (stopped) return;
+      if (pendingTasks >= maxDepth) {
+        log("writequeue.overflow");
+        return;
+      }
+      pendingTasks++;
+      taskChain = taskChain.then(async () => {
+        try {
+          await task();
+        } catch {
+          log("writequeue.task_failed");
+        } finally {
+          pendingTasks--;
+        }
+      });
+    },
+
+    async flush(): Promise<void> {
+      // Flush buffers into the write chain, then await both chains. Tasks never
+      // enqueue inserts, so a single drain pass settles everything.
+      await doFlush();
+      await writeChain;
+      await taskChain;
+    },
+
+    async stop(): Promise<void> {
+      stopped = true;
+      clearTimer();
+      await doFlush();
+      await writeChain;
+      await taskChain;
+    },
+
+    get depth(): number {
+      return depth();
+    },
+  };
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -9,6 +9,7 @@ import {
   type ConfigStore,
   createAnthropicClient,
   createBudgetGate,
+  createCachedKeyStore,
   createCircuitBreaker,
   createCodexResponsesClient,
   createKeyedSemaphore,
@@ -121,6 +122,7 @@ import {
   servedByAccount,
   withServingAccountCapture,
 } from "./runtime/serving-account.js";
+import { createWriteQueue } from "./runtime/write-queue.js";
 
 export interface ServerHandle {
   app: ReturnType<typeof createApp>;
@@ -128,7 +130,7 @@ export interface ServerHandle {
   host: string;
   // Stop background workers (e.g. the Agentic Signals scheduler). Optional and
   // safe to skip — the timers are unref'd so they never block process exit.
-  dispose?: () => void;
+  dispose?: () => void | Promise<void>;
 }
 
 // Pre-classification TPM token estimator. Extracted to middleware/estimate-tokens
@@ -656,8 +658,33 @@ export async function buildServer(
     );
   }
   const store: StoreSet = await createStore({ store: storeCfg, dataDir, connectionString });
-  const keyStore = store.keys;
+  // Auth-lookup cache (perf): getByHash runs synchronously on the event-loop thread
+  // for EVERY request on all four AI faces (better-sqlite3 is sync). Wrap the shared
+  // KeyStore once so repeat lookups of the same bearer key hit an in-process LRU
+  // instead of the DB. Mutations flow through this SAME instance (auth + admin key
+  // routes + the self-auth faces all use `keyStore`), so an admin create/revoke/edit
+  // busts the cache automatically. TTL bounds cross-instance staleness (shared
+  // Postgres) — a revoked key keeps serving on another instance for at most TTL.
+  const authCacheTtlMs = Number(process.env.HELM_AUTH_CACHE_TTL_MS ?? 30_000);
+  const keyStore = createCachedKeyStore(store.keys, {
+    ttlMs: Number.isFinite(authCacheTtlMs) && authCacheTtlMs >= 0 ? authCacheTtlMs : 30_000,
+    maxEntries: 5_000,
+    now: () => Date.now(),
+  });
   const telemetry = store.telemetry;
+  // Deferred + batched write queue (perf): the four AI faces enqueue their fail-open
+  // telemetry/payload/observe writes here so a synchronous better-sqlite3 commit never
+  // sits on a request's critical path; batched flushes (N commits → 1) relieve the
+  // single event-loop thread under concurrency. Drained on dispose() so a graceful
+  // deploy loses nothing. Env knobs are optional (safe code defaults otherwise).
+  const flushMsEnv = Number(process.env.HELM_WRITE_QUEUE_FLUSH_MS);
+  const maxDepthEnv = Number(process.env.HELM_WRITE_QUEUE_MAX_DEPTH);
+  const writeQueue = createWriteQueue({
+    telemetry,
+    log: (message) => logger.log("warn", "writequeue", { message }),
+    flushIntervalMs: Number.isFinite(flushMsEnv) && flushMsEnv > 0 ? flushMsEnv : 25,
+    maxDepth: Number.isFinite(maxDepthEnv) && maxDepthEnv > 0 ? maxDepthEnv : 10_000,
+  });
 
   // OAuth subscription runtime (issue #38). PRESET providers store their (rotating)
   // credentials encrypted at rest, so an at-rest key is REQUIRED when any preset is
@@ -1319,6 +1346,7 @@ export async function buildServer(
   registerChatRoutes(app, {
     route,
     telemetry,
+    writes: writeQueue,
     redact: (payload) => redact(payload),
     now: () => Date.now(),
     recordOAuthUsage,
@@ -1486,6 +1514,7 @@ export async function buildServer(
     { observe, inject },
     pipelineBudget,
     recordOAuthUsage,
+    writeQueue,
   );
   // Inject the SAME per-key limiter instance the chat surface uses so the
   // Anthropic /v1/messages handler can meter per-key AFTER its self-auth (closes
@@ -1578,6 +1607,7 @@ export async function buildServer(
     // chat route uses, so /v1/messages records served requests like /v1/chat does.
     record: {
       telemetry,
+      writes: writeQueue,
       redact: (payload) => redact(payload),
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
@@ -1595,6 +1625,7 @@ export async function buildServer(
     { observe, inject },
     pipelineBudget,
     recordOAuthUsage,
+    writeQueue,
   );
   registerResponsesRoute(app, {
     // Same per-key limiter, same cast rationale as the messages route above —
@@ -1659,6 +1690,7 @@ export async function buildServer(
     // chat route uses, so /v1/responses records served requests like /v1/chat does.
     record: {
       telemetry,
+      writes: writeQueue,
       redact: (payload) => redact(payload),
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
@@ -1678,6 +1710,7 @@ export async function buildServer(
     { observe, inject },
     pipelineBudget,
     recordOAuthUsage,
+    writeQueue,
   );
   registerGeminiRoute(app, {
     rateLimiter,
@@ -1740,6 +1773,7 @@ export async function buildServer(
     // chat route uses, so the gemini face records served requests like /v1/chat does.
     record: {
       telemetry,
+      writes: writeQueue,
       redact: (payload) => redact(payload),
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
@@ -1822,12 +1856,15 @@ export async function buildServer(
     app,
     port: config.server.port,
     host: config.server.host,
-    dispose: () => {
+    dispose: async () => {
       signalScheduler?.stop();
       memoryWorker?.stop();
+      // Drain the deferred write queue BEFORE closing the DB so a graceful shutdown
+      // persists every buffered telemetry/payload/observe write (no loss on deploy).
+      await writeQueue.stop();
       // Close the underlying DB connection (sqlite file handle / pg pool). Best
       // effort: a close error must not mask a clean shutdown.
-      void store.close().catch(() => {});
+      await store.close().catch(() => {});
     },
   };
 }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,17 @@
 
 ---
 
+## 2026-06-11 · 四个 AI API 高并发热路径性能优化（Phase B；CLAUDE.md 原则 1/3/7/8）
+
+- **缘起**：用户要求四个对 AI 的 API（`/v1/chat/completions`、`/v1/messages`、`/v1/responses`、`/v1beta/…:generateContent`）支持高并发，且 SQLite 写入绝不拖慢响应。全链路 review（鉴权中间件 / store / 路由执行 / 流式四面）确认根因仍是 [[sqlite-write-perf-root-cause]]：**better-sqlite3 同步阻塞事件循环**——每请求 1 次未缓存鉴权读 +（provider 已应答后）同步 telemetry/payload 写都 `await` 在响应关键路径上；memory observeInbound 在路由前同步提交。承接 Phase A（PRAGMA + memory 批量）。
+- **修复 1 鉴权缓存**：`packages/core/src/store/cached-keystore.ts` `createCachedKeyStore` 包 KeyStore，对 `getByHash` 做 LRU+TTL（命中+未命中都缓，挡无效 key 洪水），任意 mutation 整表失效。composition root 在 `store.keys` 外包一层（同一实例被 auth 中间件 + 三个 self-auth 面 + admin key 路由共享，故 admin 改 key 自动失效）。TTL 默认 30s（`HELM_AUTH_CACHE_TTL_MS`）。**坑：多实例共享 Postgres 时，A 实例吊销的 key 在 B 实例最多续命 TTL。**
+- **修复 2 延迟+批量写队列（核心）**：`TelemetryStore` 加可选 `insertMany?`/`insertPayloads?`（sqlite 单事务 / postgres 多行，N commit→1，仿 appendMessages 先例）。新 `apps/gateway/src/runtime/write-queue.ts`：telemetry/payload 入缓冲按 25ms / 批量阈值合并 flush；副作用任务（memory observe、prune）走单条 FIFO 串行链（保 inbound 先于 outbound）；有界深度（溢出丢最旧+日志）；`flush()/stop()` 排空。chat.ts + recordServed（三面共用）+ pipeline 接**可选 `writes` dep：缺省=今日 inline await（全量存量测试零改动），存在=响应后延迟批量**。**budget settle 永不延迟**（配额正确性：下一请求 pre-route gate 必须看到本次 spend）。`index.ts` 加 SIGTERM/SIGINT → `dispose()` 先 flush 队列再关 store（优雅部署零丢，`HELM_WRITE_QUEUE_FLUSH_MS`/`_MAX_DEPTH`）。**坑：硬崩溃最多丢 flush 窗口内 telemetry/payload；memory 在 flush 窗口内最终一致（连发自动化轮可能漏最后一轮，fail-open）。**
+- **修复 3 undici 出口连接复用**：`apps/gateway/src/runtime/egress.ts` boot 时（buildServer 前）`setGlobalDispatcher(new Agent({keepAliveTimeout:30s,…}))`（`HELM_UNDICI_*`），消除默认 4s keep-alive 导致的反复 TLS 握手；pool size 默认不动（仅显式 `HELM_UNDICI_CONNECTIONS` 才设），per-account proxy 自带 dispatcher 不冲突。gateway 加 `undici` 直接依赖。
+- **修复 4 流式抓包尾缓冲**：`createSseCapture(full)`——capture 开=留全量（原文落库），capture 关=只留 ~16KB 尾（够 `usageFromSSE` 从尾扫成本回填），不再为成本回填把整条流钉内存；不碰转发字节（原则 8）。
+- **取舍/back-compat 关键**：四修复彼此独立、各藏在可选 dep / boot 调用后——任一可单独回滚；写队列出问题只需不接 `writes` dep，路由即退回 inline await。无 DB schema 改动、无客户端可见 API 改动、无新必填配置（新旋钮全是可选 env + 安全默认）。
+- **Codex review 二次修复（两处 P1）**：① 写队列批量 insert 容错——`insertMany` 整批多行写到唯一列，单条重复 `request_id`（客户端复用 `X-Request-Id`→trace_id）会让整批抛错、原实现 catch 后丢掉整个 25ms 窗口的无关行；改为 `writeTelemetry/writePayloads` **批量失败回退逐条**（多行 INSERT 原子，失败不提交，回退不双写），只丢肇事行。② 优雅停机时序——`index.ts` 原先 `server.close()` 未 await 就 dispose（停队列+关 store），在途请求的响应后 enqueue 会被丢、同步 settle 可能打到已关闭 DB；抽 `runtime/shutdown.ts::closeServer`（先丢空闲 keep-alive、await 在途排空、超 `HELM_SHUTDOWN_DRAIN_MS` 默认 10s 再 force-close），**先 await closeServer 再 dispose**。
+- **验证**：TDD 红→绿。新单测：cached-keystore(10)、write-queue(10，含批量回退)、shutdown(3)、egress(3)、createSseCapture(3)、telemetry batch 契约（sqlite+PGlite）、chat/recordServed 延迟路径。全量 `pnpm test` 2935 测试（9 个 PGlite 5s 超时是 [[pnpm-test-pglite-flake]]，隔离重跑 143 全绿）；typecheck（4 包）/ lint(Biome) / build（admin+core+gateway）全绿。
+
 ## 2026-06-10 · SQLite 写入热路径性能修复（Phase A，无 Redis；CLAUDE.md 原则 1/8）
 
 - **缘起**：用户反馈线上 la.atmy.work「两个并发就很慢」，怀疑写入太多，提议参考 [[la-atmy-work-deployment]] 旁的 claude-relay-service 引入 Redis 写缓冲再落 SQLite。诊断后发现**根因不是 SQLite 并发能力**，而是 **better-sqlite3 同步阻塞 Node 单线程 + 默认 `synchronous=FULL`（每次 commit 都 fsync）**：写代价由整个进程（含其它在途请求的事件循环）承担。对 Claude Code 这类**每轮重发整段历史 + 工具定义**的客户端，`capture_payloads`（默认开）把数百 KB~MB 的 request_json 同步 + fsync 落库，直接冻结事件循环；memory observe 又**逐条消息**同步写（inbound 在上游调用前、关键路径上）。两个并发流互相卡 fsync，无法重叠。
@@ -27,16 +38,11 @@
 - **坑/TODO**：① 不反映页内非导航 fetch（刻意为之，见上）。② 依赖 `navigating`，若将来某页改用页内手动 fetch 取数而非 `load`，该页切换将不再触发进度条。③ 纯 admin 静态资源改动，需发新 admin 镜像才生效。
 - **验证**：TDD 先红后绿——`NavProgress.test.ts`(3) 用可写 `navigating` mock 断言：idle 隐藏且归零、导航起→可见且进度>0、resolve→补满 100% 后隐藏。admin 全量 296 绿、Biome lint 绿、typecheck（4 包）绿、build（admin static + gateway + core）绿。
 
-## 2026-06-10 · Anthropic tool_result 邻接兼容修复（docs/05 协议互译；CLAUDE.md 原则 3/8）
-
-- **缘起**：线上请求 `5cd63ac6-798e-4b31-a497-575d92033f64` 在 `anthropic/claude-opus-4-8` 与 `zenmux/claude-opus-4.8` 返回 400：Anthropic 报 `messages.2` 的 `tool_use` 没有在下一条消息里紧跟对应 `tool_result`。捕获 payload 显示客户端把 114 个 `tool_result` 与新的用户文本放在同一个 Anthropic user turn；这是可兼容形态，但 Helm 入站转换先发普通 user 文本、再 fan-out tool 结果，订阅 provider 又把连续 tool 结果拆成多个 user turn，最终破坏 Anthropic 的 tool-result adjacency。
-- **修复**：`transformRequestOut` 对混合 user turn 先输出 fanned-out `role:"tool"` 结果，再输出尾随 user 文本，确保 IR 保持 assistant tool_calls → tool results → next user text 的顺序。订阅 provider 的 `openaiToAnthropicRequest` 增加相邻同角色合并，连续 OpenAI `role:"tool"` 会合并成同一个 Anthropic `role:"user"`，并在其中保持 `tool_result` 块先于尾随文本。
-- **取舍**：不拒绝这类客户端 payload，也不丢弃尾随用户文本；选择做结构化归一化，让 Anthropic strict validation 接收，同时尽量保留用户原意。若客户端已经发送纯 tool-result turn，行为不变。
-- **验证**：TDD 新增两个回归：混合 Anthropic user turn 中 `tool_result` 必须排在尾随文本前；连续 OpenAI tool results 必须合并成一个即时 Anthropic user turn。`pnpm exec vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/provider/anthropic.test.ts` → 63 passed。用线上捕获 payload 本地重放后，provider-facing Anthropic 消息变为 assistant 后紧跟 115-block user turn：前 114 个 `tool_result`，最后 1 个文本 prompt，移除 400 根因。
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-10 · Anthropic tool_result 邻接兼容修复：`transformRequestOut` 对混合 user turn 先发 fanned-out `role:"tool"` 结果再发尾随文本；订阅 provider `openaiToAnthropicRequest` 合并相邻同角色（连续 OpenAI tool→单个 Anthropic user turn，`tool_result` 块先于文本），修线上 `messages.N` 的 `tool_use` 无紧邻 `tool_result` 的 400；纯结构归一化、不拒绝 payload、不丢用户文本，纯 tool-result turn 行为不变。core 63 绿。
 
 ### 2026-06-10 · 虚拟模型别名映射 model-aliases.yaml：裸厂商 id（如 `claude-opus-4-8`）→ lane 名/`auto` 的兼容映射（`routing/model-alias.ts`），`plan()` step-0 独立 0a 分支解析，对任意 key 生效但经 `aliasPolicyContext` 跑 policy+key 双层 cap 静默 clamp（不提权，Codex review P1）；精确键优先、否则最长字面 `*`-glob、大小写敏感；`ModelAliasesSchema` 形状校验 + boot 时 `validateModelAliasTargets` 对有效 lane 集 fail-closed。出厂 `config/model-aliases.yaml` 带 claude-*/gpt-* 激活映射。**坑：线上需手动在 `/opt/helm-api/config` 放该 yaml 才生效（见 [[deploy-never-overwrite-config]]）。**
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -620,7 +620,9 @@ export {
   loadEncKeyFromEnv,
 } from "./store/crypto/token-cipher.js";
 export {
+  type CachedKeyStoreOptions,
   type CreateStoreOptions,
+  createCachedKeyStore,
   createPgDb,
   createPgliteDb,
   createSqliteDb,

--- a/packages/core/src/store/cached-keystore.test.ts
+++ b/packages/core/src/store/cached-keystore.test.ts
@@ -1,0 +1,162 @@
+import { type ApiKeyRecord, ApiKeyRecordSchema } from "@helm/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCachedKeyStore } from "./cached-keystore.js";
+import type { CreateKeyInput, KeyPatch, KeyStore } from "./ports.js";
+
+function rec(keyId: string, hash: string): ApiKeyRecord {
+  return ApiKeyRecordSchema.parse({
+    key_id: keyId,
+    hash,
+    prefix: "helm_live_xxxx",
+    account_id: "acct",
+    role: "user",
+    allowed_lanes: null,
+    allow_custom_model: false,
+    disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
+  });
+}
+
+// A fake inner KeyStore whose getByHash is a spy over a backing Map, so tests can
+// count exactly how many times the wrapper falls through to the "DB".
+function makeInner(rows: Map<string, ApiKeyRecord | null> = new Map()): KeyStore {
+  return {
+    getByHash: vi.fn(async (hash: string) => rows.get(hash) ?? null),
+    createKey: vi.fn(async (input: CreateKeyInput) => rec(input.keyId, input.hash)),
+    list: vi.fn(async () => [...rows.values()].filter((r): r is ApiKeyRecord => r !== null)),
+    disable: vi.fn(async (_keyId: string) => {}),
+    deleteKey: vi.fn(async (_keyId: string) => {}),
+    updateKey: vi.fn(async (_keyId: string, _patch: KeyPatch) => {}),
+  };
+}
+
+describe("createCachedKeyStore", () => {
+  let clock: number;
+  const now = () => clock;
+  beforeEach(() => {
+    clock = 1_000;
+  });
+
+  it("serves a repeated getByHash from cache without re-hitting the inner store", async () => {
+    const rows = new Map<string, ApiKeyRecord | null>([["h1", rec("k1", "h1")]]);
+    const inner = makeInner(rows);
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 100, now });
+
+    const a = await cached.getByHash("h1");
+    const b = await cached.getByHash("h1");
+
+    expect(a?.key_id).toBe("k1");
+    expect(b).toEqual(a);
+    expect(inner.getByHash).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches a negative (null) result so an invalid-key flood does not hammer the DB", async () => {
+    const inner = makeInner();
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 100, now });
+
+    expect(await cached.getByHash("missing")).toBeNull();
+    expect(await cached.getByHash("missing")).toBeNull();
+    expect(inner.getByHash).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads the inner store after the TTL expires", async () => {
+    const rows = new Map<string, ApiKeyRecord | null>([["h1", rec("k1", "h1")]]);
+    const inner = makeInner(rows);
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 100, now });
+
+    await cached.getByHash("h1");
+    clock += 29_999; // still inside the window
+    await cached.getByHash("h1");
+    expect(inner.getByHash).toHaveBeenCalledTimes(1);
+
+    clock += 2; // now past expireAt (1000 + 30000 = 31000; clock = 31001)
+    await cached.getByHash("h1");
+    expect(inner.getByHash).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least-recently-used entry past maxEntries", async () => {
+    const rows = new Map<string, ApiKeyRecord | null>([
+      ["h1", rec("k1", "h1")],
+      ["h2", rec("k2", "h2")],
+      ["h3", rec("k3", "h3")],
+    ]);
+    const inner = makeInner(rows);
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 2, now });
+
+    await cached.getByHash("h1");
+    await cached.getByHash("h2");
+    await cached.getByHash("h3"); // evicts h1 (LRU)
+    expect(inner.getByHash).toHaveBeenCalledTimes(3);
+
+    await cached.getByHash("h1"); // miss again — was evicted
+    expect(inner.getByHash).toHaveBeenCalledTimes(4);
+  });
+
+  it("refreshes recency on a cache hit so a hot key survives eviction", async () => {
+    const rows = new Map<string, ApiKeyRecord | null>([
+      ["h1", rec("k1", "h1")],
+      ["h2", rec("k2", "h2")],
+      ["h3", rec("k3", "h3")],
+    ]);
+    const inner = makeInner(rows);
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 2, now });
+
+    await cached.getByHash("h1");
+    await cached.getByHash("h2");
+    await cached.getByHash("h1"); // touch h1 → now h2 is LRU
+    await cached.getByHash("h3"); // evicts h2, not h1
+    await cached.getByHash("h1"); // still cached
+    expect(inner.getByHash).toHaveBeenCalledTimes(3); // h1, h2, h3 — h1 never re-read
+  });
+
+  it.each([
+    [
+      "createKey",
+      async (s: KeyStore) =>
+        s.createKey({ keyId: "k2", hash: "h2", prefix: "p", accountId: "a", role: "user" }),
+    ],
+    ["disable", async (s: KeyStore) => s.disable("k1")],
+    ["deleteKey", async (s: KeyStore) => s.deleteKey("k1")],
+    ["updateKey", async (s: KeyStore) => s.updateKey("k1", { name: "x" })],
+  ])("busts the whole cache on %s", async (_name, mutate) => {
+    const rows = new Map<string, ApiKeyRecord | null>([["h1", rec("k1", "h1")]]);
+    const inner = makeInner(rows);
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 100, now });
+
+    await cached.getByHash("h1");
+    expect(inner.getByHash).toHaveBeenCalledTimes(1);
+
+    await mutate(cached);
+
+    await cached.getByHash("h1");
+    expect(inner.getByHash).toHaveBeenCalledTimes(2); // cache was cleared
+  });
+
+  it("forwards mutations and reads to the inner store (return values + args)", async () => {
+    const inner = makeInner(new Map([["h1", rec("k1", "h1")]]));
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 100, now });
+
+    const created = await cached.createKey({
+      keyId: "k9",
+      hash: "h9",
+      prefix: "p",
+      accountId: "a",
+      role: "user",
+    });
+    expect(created.key_id).toBe("k9");
+    expect(inner.createKey).toHaveBeenCalledWith({
+      keyId: "k9",
+      hash: "h9",
+      prefix: "p",
+      accountId: "a",
+      role: "user",
+    });
+
+    await cached.updateKey("k1", { allowCustomModel: true });
+    expect(inner.updateKey).toHaveBeenCalledWith("k1", { allowCustomModel: true });
+
+    await cached.list();
+    expect(inner.list).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/store/cached-keystore.ts
+++ b/packages/core/src/store/cached-keystore.ts
@@ -1,0 +1,89 @@
+import type { ApiKeyRecord } from "@helm/shared";
+import type { CreateKeyInput, KeyPatch, KeyStore } from "./ports.js";
+
+export interface CachedKeyStoreOptions {
+  // How long a getByHash result (hit OR miss) stays fresh. Also the upper bound on
+  // cross-instance staleness when several gateways share one Postgres DB: a key
+  // revoked on instance A keeps serving on instance B for at most this long.
+  ttlMs: number;
+  // Hard cap on cached hashes; LRU-evicts past it so a flood of distinct (invalid)
+  // keys cannot grow the Map without bound.
+  maxEntries: number;
+  // Injected clock (ms) — never calls Date.now() itself, so TTL is deterministic
+  // under test, mirroring classifier/eval/cache.ts.
+  now: () => number;
+}
+
+interface Entry {
+  value: ApiKeyRecord | null;
+  expireAt: number;
+}
+
+// Wrap a KeyStore with an in-process TTL + LRU cache over getByHash — the per-request
+// auth lookup. better-sqlite3 is synchronous, so an uncached getByHash is a blocking
+// point-read on the single event-loop thread for EVERY request on all four AI faces;
+// caching collapses repeat lookups of the same bearer key to a Map hit. BOTH hits and
+// misses are cached (an invalid-key flood must not become a DB-read flood). Recency is
+// tracked by Map insertion order (delete + re-insert moves a key to most-recent), the
+// same proven pattern as createEvalCache.
+//
+// Any mutation (createKey/disable/deleteKey/updateKey) forwards to the inner store and
+// then busts the WHOLE cache: mutations are rare admin operations, and a full clear
+// avoids maintaining a keyId→hash reverse index while guaranteeing a revoked or edited
+// key is never served stale within the process (all mutations flow through this same
+// wrapped instance — see server.ts composition root).
+export function createCachedKeyStore(inner: KeyStore, opts: CachedKeyStoreOptions): KeyStore {
+  const { ttlMs, maxEntries, now } = opts;
+  const cache = new Map<string, Entry>();
+
+  return {
+    async getByHash(hash: string): Promise<ApiKeyRecord | null> {
+      const nowMs = now();
+      const hit = cache.get(hash);
+      if (hit !== undefined) {
+        if (hit.expireAt > nowMs) {
+          // Fresh hit — refresh recency (delete + re-insert → most-recent).
+          cache.delete(hash);
+          cache.set(hash, hit);
+          return hit.value;
+        }
+        // Expired — drop and fall through to a fresh read.
+        cache.delete(hash);
+      }
+      const value = await inner.getByHash(hash);
+      cache.set(hash, { value, expireAt: nowMs + ttlMs });
+      // Evict least-recently-used entries until within capacity.
+      while (cache.size > maxEntries) {
+        const oldest = cache.keys().next().value;
+        if (oldest === undefined) break;
+        cache.delete(oldest);
+      }
+      return value;
+    },
+
+    list(): Promise<ApiKeyRecord[]> {
+      return inner.list();
+    },
+
+    async createKey(input: CreateKeyInput): Promise<ApiKeyRecord> {
+      const created = await inner.createKey(input);
+      cache.clear();
+      return created;
+    },
+
+    async disable(keyId: string): Promise<void> {
+      await inner.disable(keyId);
+      cache.clear();
+    },
+
+    async deleteKey(keyId: string): Promise<void> {
+      await inner.deleteKey(keyId);
+      cache.clear();
+    },
+
+    async updateKey(keyId: string, patch: KeyPatch): Promise<void> {
+      await inner.updateKey(keyId, patch);
+      cache.clear();
+    },
+  };
+}

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,3 +1,4 @@
+export { type CachedKeyStoreOptions, createCachedKeyStore } from "./cached-keystore.js";
 export { type CreateStoreOptions, createStore, type StoreSet } from "./factory.js";
 export type {
   BudgetDim,

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -253,6 +253,12 @@ export interface TelemetryPage {
 
 export interface TelemetryStore {
   insert(input: InsertTelemetryInput): Promise<{ id: string }>;
+  // Optional batch variants (perf): collapse N rows into ONE commit on the
+  // synchronous SQLite writer, mirroring MemoryStore.appendMessages. The deferred
+  // write queue prefers these; adapters lacking them fall back to per-row insert.
+  // An empty array is a no-op.
+  insertMany?(inputs: InsertTelemetryInput[]): Promise<void>;
+  insertPayloads?(inputs: InsertPayloadInput[]): Promise<void>;
   queryRecent(limit: number): Promise<RecentDecisionRecord[]>; // most recent N, createdAt desc
   // Filtered + paginated recent list for the admin Debug UI. Same createdAt DESC
   // ordering as queryRecent; returns the page plus the full filtered total.

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -27,22 +27,35 @@ export class PgTelemetryStore implements TelemetryStore {
     private readonly genId: () => string = randomUUID,
   ) {}
 
-  async insert(input: InsertTelemetryInput): Promise<{ id: string }> {
-    const id = this.genId();
+  // Build one telemetry row (fresh id + denormalized status/cost). Shared by the
+  // single and batch inserts so they can never drift. jsonb stored natively.
+  private toRow(input: InsertTelemetryInput): typeof telemetry.$inferInsert {
     const finalCost = input.decision.provider_attempts.reduce<number | null>((acc, a) => {
       if (a.cost_usd === null) return acc;
       return (acc ?? 0) + a.cost_usd;
     }, null);
-    await this.db.insert(telemetry).values({
-      id,
+    return {
+      id: this.genId(),
       requestId: input.decision.request_id,
       apiKeyId: input.apiKeyId,
       decisionJson: input.decision,
       finalStatus: input.decision.final.status,
       costUsd: finalCost,
       createdAt: input.createdAt.getTime(),
-    });
-    return { id };
+    };
+  }
+
+  async insert(input: InsertTelemetryInput): Promise<{ id: string }> {
+    const row = this.toRow(input);
+    await this.db.insert(telemetry).values(row);
+    return { id: row.id };
+  }
+
+  // Batch insert (perf): ONE multi-row statement. Postgres is async/non-blocking,
+  // so the win is one round-trip + one txn instead of N. Empty array is a no-op.
+  async insertMany(inputs: InsertTelemetryInput[]): Promise<void> {
+    if (inputs.length === 0) return;
+    await this.db.insert(telemetry).values(inputs.map((input) => this.toRow(input)));
   }
 
   async queryRecent(limit: number): Promise<RecentDecisionRecord[]> {
@@ -168,6 +181,32 @@ export class PgTelemetryStore implements TelemetryStore {
           createdAt: input.createdAt.getTime(),
         },
       });
+  }
+
+  // Batch payload upsert (perf): all rows in ONE transaction. Per-row upsert keeps
+  // the conflict semantics identical to insertPayload. Empty array is a no-op.
+  async insertPayloads(inputs: InsertPayloadInput[]): Promise<void> {
+    if (inputs.length === 0) return;
+    await this.db.transaction(async (tx) => {
+      for (const input of inputs) {
+        await tx
+          .insert(requestPayloads)
+          .values({
+            requestId: input.requestId,
+            requestJson: input.requestJson,
+            responseJson: input.responseJson,
+            createdAt: input.createdAt.getTime(),
+          })
+          .onConflictDoUpdate({
+            target: requestPayloads.requestId,
+            set: {
+              requestJson: input.requestJson,
+              responseJson: input.responseJson,
+              createdAt: input.createdAt.getTime(),
+            },
+          });
+      }
+    });
   }
 
   async getPayload(requestId: string): Promise<RequestPayload | null> {

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -246,4 +246,49 @@ describe("SqliteTelemetryStore", () => {
     expect(got?.classifier.eval_cache_hit).toBe(true);
     expect(Array.isArray(got?.provider_attempts)).toBe(true);
   });
+
+  // Batch variants (perf): the deferred write queue collapses N inserts into ONE
+  // commit. The result must be indistinguishable from N single inserts.
+  it("insertMany persists every decision (batch == N singles)", async () => {
+    const store = freshStore();
+    const at = new Date(1717155600000);
+    await store.insertMany([
+      { decision: decision("req_a"), apiKeyId: "k1", createdAt: at },
+      { decision: decision("req_b"), apiKeyId: "k1", createdAt: at },
+      { decision: decision("req_c"), apiKeyId: "k2", createdAt: at },
+    ]);
+    const recent = await store.queryRecent(10);
+    expect(recent.map((r) => r.record.request_id).sort()).toEqual(["req_a", "req_b", "req_c"]);
+    expect(await store.getApiKeyId("req_c")).toBe("k2");
+    expect(await store.getByRequestId("req_a")).toEqual(decision("req_a"));
+  });
+
+  it("insertMany([]) is a no-op", async () => {
+    const store = freshStore();
+    await expect(store.insertMany([])).resolves.toBeUndefined();
+    expect(await store.queryRecent(10)).toHaveLength(0);
+  });
+
+  it("insertPayloads persists every payload and upserts by request_id", async () => {
+    const store = freshStore();
+    const at = new Date(1717155600000);
+    await store.insertPayloads([
+      { requestId: "req_a", requestJson: '{"a":1}', responseJson: '{"r":1}', createdAt: at },
+      { requestId: "req_b", requestJson: '{"b":2}', responseJson: null, createdAt: at },
+    ]);
+    expect((await store.getPayload("req_a"))?.responseJson).toBe('{"r":1}');
+    expect((await store.getPayload("req_b"))?.responseJson).toBeNull();
+
+    // Re-batch the same request_id with a backfilled response → upsert, not dup.
+    await store.insertPayloads([
+      { requestId: "req_b", requestJson: '{"b":2}', responseJson: '{"r":2}', createdAt: at },
+    ]);
+    expect((await store.getPayload("req_b"))?.responseJson).toBe('{"r":2}');
+  });
+
+  it("insertPayloads([]) is a no-op", async () => {
+    const store = freshStore();
+    await expect(store.insertPayloads([])).resolves.toBeUndefined();
+    expect(await store.getPayload("nope")).toBeNull();
+  });
 });

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -27,25 +27,39 @@ export class SqliteTelemetryStore implements TelemetryStore {
     private readonly genId: () => string = randomUUID,
   ) {}
 
-  async insert(input: InsertTelemetryInput): Promise<{ id: string }> {
-    const id = this.genId();
+  // Build one telemetry row (fresh id + denormalized status/cost). Shared by the
+  // single and batch inserts so they can never drift.
+  private toRow(input: InsertTelemetryInput): typeof telemetry.$inferInsert {
     const finalCost = input.decision.provider_attempts.reduce<number | null>((acc, a) => {
       if (a.cost_usd === null) return acc;
       return (acc ?? 0) + a.cost_usd;
     }, null);
+    return {
+      id: this.genId(),
+      requestId: input.decision.request_id,
+      apiKeyId: input.apiKeyId,
+      decisionJson: JSON.stringify(input.decision),
+      finalStatus: input.decision.final.status,
+      costUsd: finalCost,
+      createdAt: input.createdAt,
+    };
+  }
+
+  async insert(input: InsertTelemetryInput): Promise<{ id: string }> {
+    const row = this.toRow(input);
+    this.db.insert(telemetry).values(row).run();
+    return { id: row.id };
+  }
+
+  // Batch insert (perf): ONE multi-row statement = ONE commit on the synchronous
+  // writer (vs N from a per-row loop). No conflict handling — telemetry rows are
+  // append-only with unique ids.
+  async insertMany(inputs: InsertTelemetryInput[]): Promise<void> {
+    if (inputs.length === 0) return;
     this.db
       .insert(telemetry)
-      .values({
-        id,
-        requestId: input.decision.request_id,
-        apiKeyId: input.apiKeyId,
-        decisionJson: JSON.stringify(input.decision),
-        finalStatus: input.decision.final.status,
-        costUsd: finalCost,
-        createdAt: input.createdAt,
-      })
+      .values(inputs.map((input) => this.toRow(input)))
       .run();
-    return { id };
   }
 
   async queryRecent(limit: number): Promise<RecentDecisionRecord[]> {
@@ -150,7 +164,8 @@ export class SqliteTelemetryStore implements TelemetryStore {
   // Full-payload capture. Upsert by request_id so the stream path can write the
   // request first then backfill the assembled response. Verbatim bytes — no
   // redaction (the table holds no plaintext key; see schema/ports comments).
-  async insertPayload(input: InsertPayloadInput): Promise<void> {
+  // Upsert one payload row (request first, then response backfill — same key).
+  private upsertPayload(input: InsertPayloadInput): void {
     this.db
       .insert(requestPayloads)
       .values({
@@ -168,6 +183,20 @@ export class SqliteTelemetryStore implements TelemetryStore {
         },
       })
       .run();
+  }
+
+  async insertPayload(input: InsertPayloadInput): Promise<void> {
+    this.upsertPayload(input);
+  }
+
+  // Batch payload upsert (perf): all rows in ONE transaction = ONE commit. Reuses
+  // the single-row upsert so the per-row conflict semantics are identical.
+  async insertPayloads(inputs: InsertPayloadInput[]): Promise<void> {
+    if (inputs.length === 0) return;
+    const run = this.db.$sqlite.transaction(() => {
+      for (const input of inputs) this.upsertPayload(input);
+    });
+    run();
   }
 
   async getPayload(requestId: string): Promise<RequestPayload | null> {

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -430,6 +430,36 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(recent[0]?.createdAt).toBeInstanceOf(Date);
     });
 
+    // Batch variants the deferred write queue prefers — both adapters implement
+    // them and a batch must be indistinguishable from N single inserts/upserts.
+    it("insertMany + insertPayloads batch identically to single writes", async () => {
+      ctx = await make();
+      const t = ctx.stores.telemetry;
+      if (!t.insertMany || !t.insertPayloads) throw new Error("batch methods required");
+      const at = new Date(1_700_000_000_000);
+      await t.insertMany([
+        { decision: decision("req_a"), apiKeyId: "k1", createdAt: at },
+        { decision: decision("req_b"), apiKeyId: "k2", createdAt: at },
+      ]);
+      const recent = await t.queryRecent(10);
+      expect(recent.map((r) => r.record.request_id).sort()).toEqual(["req_a", "req_b"]);
+      expect(await t.getApiKeyId("req_b")).toBe("k2");
+
+      await t.insertPayloads([
+        { requestId: "req_a", requestJson: '{"q":1}', responseJson: '{"r":1}', createdAt: at },
+        { requestId: "req_b", requestJson: '{"q":2}', responseJson: null, createdAt: at },
+      ]);
+      expect((await t.getPayload("req_a"))?.responseJson).toBe('{"r":1}');
+      // Re-batch the same id with a backfilled response → upsert, not duplicate.
+      await t.insertPayloads([
+        { requestId: "req_b", requestJson: '{"q":2}', responseJson: '{"r":2}', createdAt: at },
+      ]);
+      expect((await t.getPayload("req_b"))?.responseJson).toBe('{"r":2}');
+
+      await expect(t.insertMany([])).resolves.toBeUndefined();
+      await expect(t.insertPayloads([])).resolves.toBeUndefined();
+    });
+
     it("round-trips a populated per-attempt error_detail (upstream status + message + raw body)", async () => {
       ctx = await make();
       const withDetail = decision("req_detail", {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       hono:
         specifier: ^4.12.23
         version: 4.12.23
+      undici:
+        specifier: ^8.3.0
+        version: 8.3.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0


### PR DESCRIPTION
## Why

The four AI-facing APIs (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1beta/…:generateContent`) must support high concurrency, and SQLite must not drag down response latency. Root cause (confirmed by a full hot-path review): the default store driver is **`better-sqlite3`, which is synchronous** — every query/commit runs on Node's single event-loop thread, so one request's DB write stalls all in-flight requests. Per served request the path did: 1 uncached sync auth read + (after the provider already answered) a sync telemetry INSERT + a sync **full request/response body** INSERT, all `await`ed **before** the client got the response; memory `observeInbound` was a sync commit **before** routing.

This takes the always-on synchronous DB work off the request critical path and cuts aggregate event-loop blocking under load. The Postgres adapter benefits too. Builds on the Phase-A PRAGMA work (`cbf775d`).

## What

| Fix | Effect |
|---|---|
| **Auth cache** | `createCachedKeyStore` wraps the shared `KeyStore` with an LRU+TTL over `getByHash` (caches hits **and** misses); any key mutation busts the whole cache. `HELM_AUTH_CACHE_TTL_MS` (30s) |
| **Deferred + batched write queue** *(core fix)* | telemetry / payload / memory-observe writes run **after** the response, coalesced **N commits → 1** via new optional `TelemetryStore.insertMany` / `insertPayloads`. Behind an optional `writes` dep — **absent = today's inline await** (existing suite unchanged). `HELM_WRITE_QUEUE_FLUSH_MS` / `_MAX_DEPTH` |
| **undici keep-alive** | one tuned global dispatcher at boot stops the 4s-keepalive TLS re-handshake to upstreams. `HELM_UNDICI_*` |
| **Bounded stream capture** | when `capture_payloads` is off, retain only a ~16KB SSE tail (enough for `usageFromSSE` cost backfill) instead of pinning the whole streamed response |
| **Graceful shutdown** | SIGTERM/SIGINT drains in-flight requests (`closeServer`) then flushes the queue + closes the store. `HELM_SHUTDOWN_DRAIN_MS` (10s) |

**Budget settle is never deferred** (quota correctness — the next request's pre-route gate must see the spend).

## Hardening (Codex review — 2× P1)

- **Batched insert falls back to per-row on any failure**, so one reused `request_id` hitting the unique index can't drop a whole 25ms flush window (only the offending row is lost).
- **Shutdown awaits the in-flight drain before disposing** the queue/store, so no late `enqueue()` is dropped and no settle runs against a closed DB.

## Safety / compatibility

- No DB schema changes, no client-visible API changes.
- All new knobs are optional env with safe defaults; each fix is independent and behind an injected dep / boot call (trivially revertible — drop the `writes` dep and routes revert to inline await).

## Testing

- New unit tests: cached-keystore (10), write-queue (10, incl. batch-failure fallback), shutdown (3), egress (3), SSE tail (3), telemetry batch contract (sqlite + PGlite), deferred-path coverage for chat + `recordServed`.
- `pnpm typecheck` (4 pkgs), `pnpm lint` (Biome), `pnpm build` (admin + core + gateway) all green.
- Full `pnpm test` green except known PGlite 5s-timeout flakes under parallel CPU load — re-ran the affected files in isolation → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)