### PR TITLE
chore(release): v0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.11.4** — version bump only. Cuts a release for the two PRs already merged to main since v0.11.3:

- #177 perf(gateway): keep SQLite off the AI hot path for high concurrency
- #178 feat(admin): add Gemini CLI env-var snippet to Connect-a-client dialog

On merge, `publish.yml` auto-cuts tag `v0.11.4` + GitHub Release + GHCR `:0.11.4`/`:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)