### PR TITLE
fix(memory): make message ingest idempotent to stop O(n²) re-ingestion

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,17 @@
 
 ---
 
+## 2026-06-11 · 记忆消息重复写入根治 + 历史脏数据清理（CLAUDE.md 原则 1/3；docs/08）
+
+- **缘起**：线上 la.atmy.work「死循环」排查（直连 helm.db + 源码 + 容器日志）锁定根因在**记忆入站写入**：`observeInbound`（`memory/observe.ts`）每轮把客户端重发的**整段历史全量盲插入**，`appendMessage/appendMessages` 用全新随机 UUID 插入、**无幂等键/冲突处理**。Claude Code 每轮重发完整 transcript → `memory_messages` 呈 **O(n²)** 增长（实测 57,560 行 / 1,543 distinct = **97.3% 重复**，DB **489MB**）。重复行带**全新 id + created_at**，永不被旧 observation 的 `source_message_range` 覆盖（`observer.ts` `alreadyObservedMessageIds` 按 id 区间判覆盖）→ observer 每分钟 `memory_formation` 反复压缩同一线程（`measured_retention 0.6%`、`prior_compaction_count 9→17`）——这就是用户看到的「一直做同一件事」。
+- **用户拍板**：① 清理范围 = 去重消息 + **清空 bug 期 observation** 让 observer 在干净数据上重建（保留 threads/keys/facts）；② 修复 = **去重根治即可**，不碰 observer 经济学核心（`compaction-policy.ts`/`AUTO_PRIORS`/`netBenefitUsd` 一律不动）。
+- **修复（防复发护栏在 DB 层）**：新 `memory/message-hash.ts::sha256Hex`（逐字节 sha256，**不 normalize/不 lowercase**，区别于 facts 的 `normalizeFactText`——消息是精确文本/代码，与 eval 缓存键约定一致）；两方言 `memory_messages` 加 `content_hash` 列 + `UNIQUE(thread_id, role, content_hash)`；`appendMessage/appendMessages` 算 hash + `onConflictDoNothing`。pg 多行 INSERT 额外做**批内去重**（ON CONFLICT 只挡**已存在**行，挡不住同批内重复）。用 hash 而非 raw content 做索引键：**pg btree 索引行 ~2704B 上限**，大 TEXT 不可直接索引。
+- **迁移（sqlite v21 / pg v20，纯 SQL，有序）**：窗口函数 `ROW_NUMBER()` DELETE 去重保留最早行 → `ADD COLUMN content_hash`（可空）→ `CREATE UNIQUE INDEX`。**坑：迁移 SQL 算不了 sha256**（better-sqlite3 无 sha256 函数 / pg 需 pgcrypto），故历史行 hash 留 NULL——**两方言 UNIQUE 索引里 NULL 互不冲突**，索引照建于去重后的历史行；新写入带真 hash 向后去重；残留边界（历史 NULL-hash 行被回填前不与未来同内容写入去重）由运维脚本关闭。
+- **运维脚本** `store/sqlite/dedup-memory-messages.ts`（`pnpm memory:dedup <db>`，放 sqlite 适配器内而非 `scripts/` 以解析 better-sqlite3）：回填历史 hash（`UPDATE OR IGNORE`，碰撞历史行留 NULL 后 DELETE——它是已 hash 行的重复）+ 清空 observations + 删 done/failed jobs + `VACUUM`；`--dry-run`；幂等。
+- **取舍**：`appendMessages` 返回值仍**每 input 一个生成 id**（length 不变），冲突跳过的 id 为「惰性」（行未落库）——唯一调用方 `persistMessages` 丢弃返回值，端口契约/测试不破。**注意 inject 非元凶**：D7 纯文本闸门对带工具调用的 turn 跳过注入（日志 `memory.inject.skipped_non_plain_text`），损害全在 observe 写入侧——observe 与 inject 两模式都会触发它。
+- **部署顺序/坑**：先合代码+迁移（启动即去重+加约束+新写入停止累积）→ **再**跑运维脚本（**先备份** helm.db/-wal/-shm → dry-run → 正式 → VACUUM，空闲窗口；VACUUM 取排他锁、重写整库、不能在事务内）。
+- **验证**：TDD 红→绿。新测 `message-hash`(6)、store-contract 双驱动去重 3 例、`observe` 真实 store 重灌 1 例、sqlite/pg 迁移升级各测、dedup 脚本 smoke 2 例；修了 4 个既有迁移 fixture（pre-mark v21/v20 applied——同 v18/v20 既有做法，这些 fixture 标 v2 applied 即不建 memory_messages）。全量 **2954 绿**（首跑 1 红是 [[pnpm-test-pglite-flake]]，复跑全绿）、typecheck（4 包）/ lint(Biome) / build(admin+core+gateway) 全绿。
+
 ## 2026-06-11 · 四个 AI API 高并发热路径性能优化（Phase B；CLAUDE.md 原则 1/3/7/8）
 
 - **缘起**：用户要求四个对 AI 的 API（`/v1/chat/completions`、`/v1/messages`、`/v1/responses`、`/v1beta/…:generateContent`）支持高并发，且 SQLite 写入绝不拖慢响应。全链路 review（鉴权中间件 / store / 路由执行 / 流式四面）确认根因仍是 [[sqlite-write-perf-root-cause]]：**better-sqlite3 同步阻塞事件循环**——每请求 1 次未缓存鉴权读 +（provider 已应答后）同步 telemetry/payload 写都 `await` 在响应关键路径上；memory observeInbound 在路由前同步提交。承接 Phase A（PRAGMA + memory 批量）。
@@ -30,17 +41,11 @@
 
 ---
 
-## 2026-06-10 · admin 导航进度条 NavProgress（admin UX；CLAUDE.md 原则 1）
-
-- **缘起**：用户点击侧栏链接切换页面时没有任何加载反馈——页面在 `+page.ts` 的 `load`（即发起 admin API 请求处）跑完前看起来"卡住"，操作者无法判断点击是否生效、是否在请求 API。
-- **实现**：新增 `NavProgress.svelte`，纯消费 SvelteKit `navigating` store（导航开始→`load` 跑完期间非 null），渲染为固定在顶部的细进度条（indigo、`fixed inset-x-0 top-0 z-50 h-[3px]`）。导航开始立即跳 8% 让点击"被确认"，随后 trickle 异步逼近 92%（永不到顶），导航 resolve 时瞬间补满 100%、短暂保持后淡出归零。`$effect` 仅以 `$navigating` 为依赖（`untrack` 包住 `active`/`progress` 写入，避免 trickle 自触发重启）。挂在 `+layout.svelte` shell 最顶层。
-- **取舍（关键）**：进度条**只覆盖路由导航**（含其 `load` 内的 API 调用），**不**做全局 fetch 拦截器。理由：用户诉求是"点链接没反馈"，导航正是 `navigating` 的语义边界；页内动作（保存/创建/重试、StatusCluster 30s 轮询）各有自己的按钮 loading 态，套全局条反而误导。Occam's razor——不引入 nprogress 依赖，~70 行自给自足。
-- **坑/TODO**：① 不反映页内非导航 fetch（刻意为之，见上）。② 依赖 `navigating`，若将来某页改用页内手动 fetch 取数而非 `load`，该页切换将不再触发进度条。③ 纯 admin 静态资源改动，需发新 admin 镜像才生效。
-- **验证**：TDD 先红后绿——`NavProgress.test.ts`(3) 用可写 `navigating` mock 断言：idle 隐藏且归零、导航起→可见且进度>0、resolve→补满 100% 后隐藏。admin 全量 296 绿、Biome lint 绿、typecheck（4 包）绿、build（admin static + gateway + core）绿。
-
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-10 · admin 导航进度条 NavProgress：纯消费 SvelteKit `navigating` store 的顶部细进度条（8% 起跳→trickle 逼近 92%→resolve 补满淡出），`$effect` 仅依赖 `$navigating` + `untrack` 防 trickle 自触发，挂 `+layout.svelte` 最顶层；**只覆盖路由导航（含其 `load` 内 API），不做全局 fetch 拦截**（Occam，~70 行无 nprogress 依赖）。坑：页内非导航 fetch 不反映；改页内手动取数的页将不触发；需发新 admin 镜像。NavProgress.test 3 绿。
 
 ### 2026-06-10 · Anthropic tool_result 邻接兼容修复：`transformRequestOut` 对混合 user turn 先发 fanned-out `role:"tool"` 结果再发尾随文本；订阅 provider `openaiToAnthropicRequest` 合并相邻同角色（连续 OpenAI tool→单个 Anthropic user turn，`tool_result` 块先于文本），修线上 `messages.N` 的 `tool_use` 无紧邻 `tool_result` 的 400；纯结构归一化、不拒绝 payload、不丢用户文本，纯 tool-result turn 行为不变。core 63 绿。
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "format": "biome format --write .",
     "lint:fix": "biome check --write .",
     "build": "pnpm -r build",
-    "sync:catalog": "tsx scripts/sync-catalog.ts"
+    "sync:catalog": "tsx scripts/sync-catalog.ts",
+    "memory:dedup": "tsx packages/core/src/store/sqlite/dedup-memory-messages.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/packages/core/src/memory/message-hash.test.ts
+++ b/packages/core/src/memory/message-hash.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { sha256Hex } from "./message-hash.js";
+
+describe("sha256Hex (memory message dedup fingerprint)", () => {
+  it("is deterministic for identical input", () => {
+    expect(sha256Hex("hello world")).toBe(sha256Hex("hello world"));
+  });
+
+  it("returns a 64-char lowercase hex string", () => {
+    const h = sha256Hex("anything");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("matches the known sha256 vector for an empty string", () => {
+    // Guards against accidental normalization/encoding drift.
+    expect(sha256Hex("")).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  });
+
+  it("is CASE-sensitive (must NOT normalize like fact hashing)", () => {
+    expect(sha256Hex("Hello")).not.toBe(sha256Hex("hello"));
+  });
+
+  it("is WHITESPACE-sensitive (verbatim content, no collapse/trim)", () => {
+    expect(sha256Hex("a  b")).not.toBe(sha256Hex("a b"));
+    expect(sha256Hex(" a")).not.toBe(sha256Hex("a"));
+  });
+
+  it("distinguishes different content", () => {
+    expect(sha256Hex("a")).not.toBe(sha256Hex("b"));
+  });
+});

--- a/packages/core/src/memory/message-hash.ts
+++ b/packages/core/src/memory/message-hash.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+
+// Dedup fingerprint for raw memory messages (the idempotency key behind the
+// memory_messages UNIQUE(thread_id, role, content_hash) constraint). The client
+// re-sends the FULL transcript every turn; without an idempotency key the store
+// blind-inserts the whole history each time (O(n²) row growth — the re-ingestion
+// bug). Hashing content lets the write path collapse a re-sent message to a
+// no-op via ON CONFLICT DO NOTHING.
+//
+// DELIBERATELY VERBATIM — unlike forgetting/facts.ts `normalizeFactText`, this
+// does NOT lowercase or collapse whitespace. Memory messages are exact text /
+// serialized JSON / code; two turns differing only in whitespace or case are
+// genuinely different messages and must NOT collide. Mirrors the eval-cache-key
+// convention (stable key, no lowercasing). Hex sha256 of the exact UTF-8 bytes.
+export function sha256Hex(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}

--- a/packages/core/src/memory/observe.test.ts
+++ b/packages/core/src/memory/observe.test.ts
@@ -2,6 +2,8 @@ import type { MemoryMessageInput, MemoryThreadInput } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import type { IRMessage } from "../protocol/ir.js";
 import type { MemoryStore } from "../store/ports.js";
+import { SqliteMemoryStore } from "../store/sqlite/memory-store.js";
+import { createSqliteDb } from "../store/sqlite/migrate.js";
 import { type ObserveDeps, observeInbound, observeOutbound, resolveMemoryMode } from "./observe.js";
 import type { MemoryScope } from "./types.js";
 
@@ -321,5 +323,60 @@ describe("resolveMemoryMode (gateway header normalization helper)", () => {
     expect(resolveMemoryMode("off")).toBe("off");
     expect(resolveMemoryMode("observe")).toBe("observe");
     expect(resolveMemoryMode("inject")).toBe("inject");
+  });
+});
+
+// End-to-end re-ingestion guard against the REAL sqlite store (the fakes blindly
+// push, so only a real store proves the dedup constraint actually holds). This is
+// the regression test for the production O(n²) bug: a client re-sending its full
+// transcript every turn must NOT duplicate rows — only the new delta persists.
+describe("observeInbound re-ingestion (real SqliteMemoryStore)", () => {
+  function realDeps(): ObserveDeps {
+    const db = createSqliteDb(":memory:");
+    let seq = 0;
+    const store = new SqliteMemoryStore(
+      db,
+      () => `id-${++seq}`,
+      () => new Date("2026-01-01T00:00:00.000Z"),
+    );
+    return {
+      memoryStore: store,
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+      estimateTokens: (t) => t.length,
+      log: vi.fn(),
+    };
+  }
+
+  it("re-sending the full transcript every turn persists only the new delta", async () => {
+    const deps = realDeps();
+    const sc = scope();
+
+    // Turn 1: user asks.
+    await observeInbound(deps, sc, [
+      { role: "system", content: "you are helpful" }, // policy, never persisted
+      { role: "user", content: "u1" },
+    ]);
+    // Turn 2: client re-sends turn 1 + the assistant reply + a new user message.
+    await observeInbound(deps, sc, [
+      { role: "system", content: "you are helpful" },
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+    ]);
+    // Turn 3: re-send everything again + one more.
+    await observeInbound(deps, sc, [
+      { role: "system", content: "you are helpful" },
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+      { role: "assistant", content: "a2" },
+    ]);
+
+    const msgs = await deps.memoryStore.listMessages({
+      threadId: "acct-a:thread-1",
+      accountId: "acct-a",
+    });
+    // 4 distinct turns (u1,a1,u2,a2) — NOT 2+4+5=11 blind re-inserts.
+    expect(msgs.map((m) => m.content)).toEqual(["u1", "a1", "u2", "a2"]);
   });
 });

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -314,16 +314,24 @@ export interface SignalStore {
 export interface MemoryStore {
   // Idempotent upsert of a thread; safe to call on every observed request.
   ensureThread(input: MemoryThreadInput): Promise<void>;
-  // Persist one raw message; returns the generated message id.
+  // Persist one raw message; returns the generated message id. Ingest is
+  // IDEMPOTENT: a row duplicating an existing (thread_id, role, content) is a
+  // no-op (UNIQUE(thread_id, role, content_hash) + ON CONFLICT DO NOTHING) — the
+  // client re-sends the whole transcript each turn, so without this the store
+  // grows O(n²). The returned id is generated per call; ON a conflict it is inert
+  // (the existing row keeps its original id — callers must not assume it persisted).
   appendMessage(input: MemoryMessageInput): Promise<string>;
   // Batch variant of appendMessage: persist a whole turn's messages in ONE
   // transaction (a single commit/fsync) instead of N. observe's INBOUND path runs
   // BEFORE the upstream call, so on a long thread the per-message loop adds N
   // synchronous commits of latency to every request (better-sqlite3 blocks the
-  // event loop per commit). Returns the generated ids in input order; an empty
-  // batch is a no-op returning []. OPTIONAL on the port: callers fall back to
-  // appendMessage in a loop when an adapter (or a pre-existing test fake) does not
-  // implement it, so adding it never breaks an existing MemoryStore fixture.
+  // event loop per commit). Returns ONE generated id per input, in input order
+  // (length preserved); an id for a row skipped on conflict is inert. Ingest is
+  // idempotent like appendMessage — re-sent and intra-batch duplicate messages
+  // collapse to one row. An empty batch is a no-op returning []. OPTIONAL on the
+  // port: callers fall back to appendMessage in a loop when an adapter (or a
+  // pre-existing test fake) does not implement it, so adding it never breaks an
+  // existing MemoryStore fixture.
   appendMessages?(inputs: MemoryMessageInput[]): Promise<string[]>;
   // POST-MVP Phase 2 (Observer). Read a thread's raw messages oldest-first so the
   // background Observer can compress the older ones into an observation. Returns

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -16,6 +16,7 @@ import {
   type ReflectionUpsertInput,
 } from "@helm/shared";
 import { and, asc, desc, eq, isNull, type SQL, sql } from "drizzle-orm";
+import { sha256Hex } from "../../memory/message-hash.js";
 import type { MemoryJobStatus, MemoryStore } from "../ports.js";
 import type { PgDb } from "./migrate.js";
 import {
@@ -158,14 +159,22 @@ export class PgMemoryStore implements MemoryStore {
 
   async appendMessage(input: MemoryMessageInput): Promise<string> {
     const id = this.genId();
-    await this.db.insert(memoryMessages).values({
-      id,
-      threadId: input.threadId,
-      role: input.role,
-      content: input.content,
-      tokenEstimate: input.tokenEstimate,
-      createdAt: this.now().getTime(),
-    });
+    // Idempotent ingest (pg v20 mirror of sqlite v21): a re-sent
+    // (thread_id, role, content) collapses to a no-op via the UNIQUE index.
+    await this.db
+      .insert(memoryMessages)
+      .values({
+        id,
+        threadId: input.threadId,
+        role: input.role,
+        content: input.content,
+        tokenEstimate: input.tokenEstimate,
+        createdAt: this.now().getTime(),
+        contentHash: sha256Hex(input.content),
+      })
+      .onConflictDoNothing({
+        target: [memoryMessages.threadId, memoryMessages.role, memoryMessages.contentHash],
+      });
     return id;
   }
 
@@ -177,19 +186,45 @@ export class PgMemoryStore implements MemoryStore {
     if (inputs.length === 0) return [];
     const base = this.now().getTime();
     const ids: string[] = [];
-    const rows = inputs.map((input, i) => {
+    // ON CONFLICT DO NOTHING dedupes against EXISTING rows, but a single pg
+    // multi-row INSERT cannot dedupe rows against EACH OTHER within the same
+    // VALUES list — two identical messages in one turn (e.g. a repeated empty
+    // assistant turn) would both be inserted. So collapse intra-batch dups by
+    // (thread_id, role, content_hash) here, keeping the first. ids stays one-per-
+    // input (caller discards it; the contract only requires length + uniqueness).
+    const seen = new Set<string>();
+    const rows: Array<{
+      id: string;
+      threadId: string;
+      role: MemoryMessageInput["role"];
+      content: string;
+      tokenEstimate: number;
+      createdAt: number;
+      contentHash: string;
+    }> = [];
+    inputs.forEach((input, i) => {
       const id = this.genId();
       ids.push(id);
-      return {
+      const contentHash = sha256Hex(input.content);
+      const key = `${input.threadId} ${input.role} ${contentHash}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      rows.push({
         id,
         threadId: input.threadId,
         role: input.role,
         content: input.content,
         tokenEstimate: input.tokenEstimate,
         createdAt: base + i,
-      };
+        contentHash,
+      });
     });
-    await this.db.insert(memoryMessages).values(rows);
+    await this.db
+      .insert(memoryMessages)
+      .values(rows)
+      .onConflictDoNothing({
+        target: [memoryMessages.threadId, memoryMessages.role, memoryMessages.contentHash],
+      });
     return ids;
   }
 

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -121,7 +121,10 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // pre-marked applied to keep this test scoped to the v13–v15 jobs upgrade.
     // v19 (memory_threads.last_served_model) is also pre-marked: this fixture
     // never creates memory_threads, so the v19 ALTER would fail — out of scope.
-    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19]) {
+    // v20 (memory_messages dedup) likewise: this fixture never creates
+    // memory_messages, so its dedup DELETE would fail — out of scope here (it has
+    // its own dedicated test below).
+    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
       );
@@ -198,6 +201,66 @@ describe("runPgMigrations — per-migration atomicity", () => {
         ),
       ),
     ).resolves.toBeDefined();
+    await db.$close();
+  });
+
+  it("upgrades a real pre-v20 memory_messages table: dedupes + adds the unique index", async () => {
+    const client = new PGlite();
+    const db = Object.assign(drizzlePglite(client), { $close: () => client.close() });
+    await db.execute(
+      sql.raw("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at BIGINT NOT NULL)"),
+    );
+    // Mark everything EXCEPT v20 applied so only the dedup migration runs. This
+    // fixture only creates memory_messages, so other migrations' tables are absent
+    // — pre-marking keeps the test scoped to the v20 message-dedup upgrade.
+    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]) {
+      await db.execute(
+        sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
+      );
+    }
+    await db.execute(
+      sql.raw(`
+        CREATE TABLE memory_messages (
+          id TEXT PRIMARY KEY,
+          thread_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          content TEXT NOT NULL,
+          token_estimate INTEGER NOT NULL,
+          created_at BIGINT NOT NULL
+        )
+      `),
+    );
+    await db.execute(
+      sql.raw(`
+        INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at) VALUES
+        ('first', 't1', 'user', 'dup', 1, 100),
+        ('second', 't1', 'user', 'dup', 1, 200),
+        ('third', 't1', 'user', 'dup', 1, 300),
+        ('other', 't1', 'assistant', 'unique', 1, 150)
+      `),
+    );
+
+    await expect(runPgMigrations(db)).resolves.toBeUndefined();
+
+    // dup group collapsed to its earliest row; distinct row kept.
+    const rows = (await db.execute(sql.raw("SELECT id FROM memory_messages ORDER BY id"))) as {
+      rows: Array<{ id: string }>;
+    };
+    expect(rows.rows.map((r) => r.id)).toEqual(["first", "other"]);
+
+    // The UNIQUE index rejects a duplicate (thread_id, role, content_hash).
+    await db.execute(
+      sql.raw(
+        "INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at, content_hash) VALUES ('h1', 't2', 'user', 'x', 1, 1, 'hash-x')",
+      ),
+    );
+    await expect(
+      db.execute(
+        sql.raw(
+          "INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at, content_hash) VALUES ('h2', 't2', 'user', 'x', 1, 2, 'hash-x')",
+        ),
+      ),
+    ).rejects.toThrow();
     await db.$close();
   });
 });

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -412,6 +412,34 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE memory_threads ADD COLUMN IF NOT EXISTS last_served_model TEXT;
     `,
   },
+  {
+    // Idempotent memory-message ingest — pg mirror of the sqlite v21 fix. (a) The
+    // dedup DELETE is ONE statement (CTE + DELETE): splitStatements splits on ';',
+    // so it must carry no internal ';'. (b) ADD COLUMN IF NOT EXISTS (idempotent).
+    // (c) the UNIQUE index the write path targets. Historical rows keep
+    // content_hash NULL (no sha256 SQL fn without pgcrypto; the ops script
+    // backfills); NULLs are DISTINCT in a pg UNIQUE index, so it builds fine and
+    // app-layer writes (which carry a real hash) dedupe going forward.
+    version: 20,
+    sql: `
+      WITH ranked AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY thread_id, role, content
+                 ORDER BY created_at ASC, id ASC
+               ) AS rn
+        FROM memory_messages
+      )
+      DELETE FROM memory_messages
+      USING ranked
+      WHERE memory_messages.id = ranked.id AND ranked.rn > 1;
+
+      ALTER TABLE memory_messages ADD COLUMN IF NOT EXISTS content_hash TEXT;
+
+      CREATE UNIQUE INDEX IF NOT EXISTS uniq_memory_messages_thread_role_hash
+        ON memory_messages (thread_id, role, content_hash);
+    `,
+  },
 ];
 
 // Anything that can run a raw SQL string against the Postgres connection. Both

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -7,6 +7,7 @@ import {
   pgTable,
   primaryKey,
   text,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 // Postgres (Drizzle pg-core) table definitions for the supabase Store adapter.
@@ -130,14 +131,25 @@ export const memoryThreads = pgTable("memory_threads", {
   updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
 });
 
-export const memoryMessages = pgTable("memory_messages", {
-  id: text("id").primaryKey(),
-  threadId: text("thread_id").notNull(), // references memory_threads.id only
-  role: text("role").notNull(), // 'user' | 'assistant' | 'tool' (IR-aligned)
-  content: text("content").notNull(),
-  tokenEstimate: integer("token_estimate").notNull(),
-  createdAt: bigint("created_at", { mode: "number" }).notNull(),
-});
+export const memoryMessages = pgTable(
+  "memory_messages",
+  {
+    id: text("id").primaryKey(),
+    threadId: text("thread_id").notNull(), // references memory_threads.id only
+    role: text("role").notNull(), // 'user' | 'assistant' | 'tool' (IR-aligned)
+    content: text("content").notNull(),
+    tokenEstimate: integer("token_estimate").notNull(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+    // Idempotency key (pg v20): sha256(content) hex, NO normalization. pg mirror
+    // of the sqlite v21 dedup column — UNIQUE(thread_id, role, content_hash) +
+    // ON CONFLICT DO NOTHING collapses the re-sent transcript to a no-op. hash
+    // (not raw content) because a pg btree index row is capped at ~2704 bytes.
+    contentHash: text("content_hash"),
+  },
+  (t) => [
+    uniqueIndex("uniq_memory_messages_thread_role_hash").on(t.threadId, t.role, t.contentHash),
+  ],
+);
 
 export const memoryObservations = pgTable("memory_observations", {
   id: text("id").primaryKey(),

--- a/packages/core/src/store/sqlite/dedup-memory-messages.test.ts
+++ b/packages/core/src/store/sqlite/dedup-memory-messages.test.ts
@@ -1,0 +1,94 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { dedupMemory } from "./dedup-memory-messages.js";
+import { createSqliteDb } from "./migrate.js";
+
+// Smoke test for the ops cleanup script against the REAL post-migration sqlite
+// schema (createSqliteDb runs every migration incl. v21's content_hash + unique
+// index). Seeds historical NULL-hash rows — including a collision twin the
+// gateway could have re-inserted before the script runs — observations and jobs.
+
+const sha256Hex = (s: string) => createHash("sha256").update(s, "utf8").digest("hex");
+
+function seed() {
+  const db = createSqliteDb(":memory:");
+  const s = db.$sqlite;
+  // memory_messages.thread_id has an FK to memory_threads — seed the thread.
+  s.prepare("INSERT INTO memory_threads (id, created_at, updated_at) VALUES ('t1', 1, 1)").run();
+  const insMsg = s.prepare(
+    "INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at, content_hash) VALUES (?, ?, ?, ?, 1, ?, ?)",
+  );
+  // Historical NULL-hash rows (pre-v21-backfill state).
+  insMsg.run("h-y", "t1", "user", "y", 1, null); // unique → backfilled
+  insMsg.run("h-x", "t1", "user", "x", 2, null); // collides with the hashed twin below
+  // A row the running gateway already re-inserted post-migration WITH a hash.
+  insMsg.run("app-x", "t1", "user", "x", 3, sha256Hex("x"));
+
+  s.prepare(
+    "INSERT INTO memory_observations (id, thread_id, source_message_range, observation_text, observed_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("o1", "t1", JSON.stringify(["h-y", "h-x"]), "stale obs", 1);
+
+  const insJob = s.prepare(
+    "INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at) VALUES (?, 'observer', ?, ?, 1, 1)",
+  );
+  insJob.run("j-done", "s1", "done");
+  insJob.run("j-pending", "s2", "pending");
+  return db;
+}
+
+describe("dedupMemory ops script", () => {
+  it("dry-run makes no changes", () => {
+    const db = seed();
+    try {
+      const out = dedupMemory(db.$sqlite, { dryRun: true });
+      expect(out.backfilled).toBe(0);
+      expect(
+        (db.$sqlite.prepare("SELECT COUNT(*) AS c FROM memory_observations").get() as { c: number })
+          .c,
+      ).toBe(1);
+    } finally {
+      db.$sqlite.close();
+    }
+  });
+
+  it("backfills hashes, drops collision duplicates, wipes observations, prunes terminal jobs", () => {
+    const db = seed();
+    const s = db.$sqlite;
+    try {
+      const out = dedupMemory(s, {});
+
+      // "y" got a hash; the historical "x" duplicate (collides with app-x) was deleted.
+      expect(out.backfilled).toBe(1);
+      expect(out.deletedDuplicates).toBe(1);
+      const yHash = (
+        s.prepare("SELECT content_hash AS h FROM memory_messages WHERE id='h-y'").get() as {
+          h: string | null;
+        }
+      ).h;
+      expect(yHash).toBe(sha256Hex("y"));
+      const xRows = s.prepare("SELECT id FROM memory_messages WHERE content='x'").all() as Array<{
+        id: string;
+      }>;
+      expect(xRows.map((r) => r.id)).toEqual(["app-x"]); // only the hashed twin survives
+      expect(
+        (
+          s
+            .prepare("SELECT COUNT(*) AS c FROM memory_messages WHERE content_hash IS NULL")
+            .get() as { c: number }
+        ).c,
+      ).toBe(0);
+
+      // Observations wiped, terminal jobs pruned, pending job kept.
+      expect(out.wipedObservations).toBe(1);
+      expect(
+        (s.prepare("SELECT COUNT(*) AS c FROM memory_observations").get() as { c: number }).c,
+      ).toBe(0);
+      expect(out.prunedJobs).toBe(1);
+      const jobs = s.prepare("SELECT id FROM memory_jobs").all() as Array<{ id: string }>;
+      expect(jobs.map((j) => j.id)).toEqual(["j-pending"]);
+      expect(out.vacuumed).toBe(true);
+    } finally {
+      s.close();
+    }
+  });
+});

--- a/packages/core/src/store/sqlite/dedup-memory-messages.ts
+++ b/packages/core/src/store/sqlite/dedup-memory-messages.ts
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+import Database from "better-sqlite3";
+
+// One-time production maintenance for the memory_messages re-ingestion bug
+// (fix/memory-message-dedup). The v21 migration already (a) collapsed exact
+// duplicate rows and (b) added UNIQUE(thread_id, role, content_hash) on STARTUP —
+// but historical rows keep content_hash = NULL (no sha256 SQL fn in sqlite). This
+// closes the loop on a live helm.db:
+//
+//   1. Backfill content_hash for every historical NULL-hash row (JS sha256,
+//      batched). UPDATE OR IGNORE: a historical row whose hash would collide with
+//      an already-hashed twin (one the running gateway re-inserted between the
+//      migration and this run) is left NULL …
+//   2. … then deleted — a NULL-hash row that survives backfill is, by definition,
+//      a duplicate of a hashed row.
+//   3. Wipe memory_observations — they were formed from the duplicate-laden data
+//      (measured_retention ~0.6%); the observer rebuilds them on clean data.
+//   4. Prune terminal (done/failed) memory_jobs.
+//   5. VACUUM to reclaim the bloat.
+//
+// Lives under the sqlite adapter (not scripts/) so better-sqlite3 resolves; run
+// via `pnpm memory:dedup <db>` (tsx) or the gateway image's own node inside the
+// container. Idempotent + supports --dry-run. NEVER run at request time.
+
+const BACKFILL_BATCH = 5000;
+
+const sha256Hex = (s: string): string => createHash("sha256").update(s, "utf8").digest("hex");
+
+export interface DedupOptions {
+  dryRun?: boolean;
+  log?: (line: string) => void;
+}
+
+export interface DedupSummary {
+  backfilled: number;
+  deletedDuplicates: number;
+  wipedObservations: number;
+  prunedJobs: number;
+  vacuumed: boolean;
+}
+
+// Operate on an OPEN better-sqlite3 handle so tests can pass an in-memory DB.
+export function dedupMemory(db: Database.Database, opts: DedupOptions = {}): DedupSummary {
+  const dryRun = opts.dryRun === true;
+  const log = opts.log ?? (() => {});
+
+  const nullCount = (
+    db.prepare("SELECT COUNT(*) AS c FROM memory_messages WHERE content_hash IS NULL").get() as {
+      c: number;
+    }
+  ).c;
+  log(`memory_messages with NULL content_hash: ${nullCount}`);
+
+  const summary: DedupSummary = {
+    backfilled: 0,
+    deletedDuplicates: 0,
+    wipedObservations: 0,
+    prunedJobs: 0,
+    vacuumed: false,
+  };
+
+  if (dryRun) {
+    const obs = (db.prepare("SELECT COUNT(*) AS c FROM memory_observations").get() as { c: number })
+      .c;
+    const jobs = (
+      db
+        .prepare("SELECT COUNT(*) AS c FROM memory_jobs WHERE status IN ('done','failed')")
+        .get() as { c: number }
+    ).c;
+    log(
+      `[dry-run] would backfill ${nullCount} hashes, wipe ${obs} observations, prune ${jobs} jobs`,
+    );
+    return summary;
+  }
+
+  // 1+2. Backfill in batches. UPDATE OR IGNORE leaves a colliding historical row
+  // NULL; we delete those leftovers afterwards (they duplicate a hashed twin).
+  const selectBatch = db.prepare(
+    "SELECT id, content FROM memory_messages WHERE content_hash IS NULL LIMIT ?",
+  );
+  const update = db.prepare("UPDATE OR IGNORE memory_messages SET content_hash = ? WHERE id = ?");
+  for (;;) {
+    const rows = selectBatch.all(BACKFILL_BATCH) as Array<{ id: string; content: string }>;
+    if (rows.length === 0) break;
+    const tx = db.transaction((batch: typeof rows) => {
+      for (const r of batch) {
+        const res = update.run(sha256Hex(r.content), r.id);
+        if (res.changes === 1) summary.backfilled += 1;
+      }
+    });
+    tx(rows);
+    if (rows.length < BACKFILL_BATCH) break;
+  }
+  summary.deletedDuplicates = db
+    .prepare("DELETE FROM memory_messages WHERE content_hash IS NULL")
+    .run().changes;
+  log(
+    `backfilled ${summary.backfilled} hashes, deleted ${summary.deletedDuplicates} leftover duplicates`,
+  );
+
+  // 3. Observations were built from duplicate-laden data — let the observer rebuild.
+  summary.wipedObservations = db.prepare("DELETE FROM memory_observations").run().changes;
+  log(`wiped ${summary.wipedObservations} observations (observer will rebuild)`);
+
+  // 4. Terminal jobs are pure history; drop them.
+  summary.prunedJobs = db
+    .prepare("DELETE FROM memory_jobs WHERE status IN ('done','failed')")
+    .run().changes;
+  log(`pruned ${summary.prunedJobs} terminal jobs`);
+
+  // 5. Reclaim space. VACUUM cannot run inside a transaction; it takes an
+  // exclusive lock and rewrites the whole file — run during an idle window.
+  db.exec("VACUUM");
+  summary.vacuumed = true;
+  log("vacuumed");
+
+  return summary;
+}
+
+// CLI: `tsx packages/core/src/store/sqlite/dedup-memory-messages.ts <db-path> [--dry-run]`
+// (or via the gateway image's node). Back up helm.db / -wal / -shm first.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const dbPath = process.argv.find((a, i) => i >= 2 && !a.startsWith("--")) ?? "./helm.db";
+  const dryRun = process.argv.includes("--dry-run");
+  const db = new Database(dbPath);
+  db.pragma("busy_timeout = 10000");
+  try {
+    // eslint-disable-next-line no-console
+    const summary = dedupMemory(db, { dryRun, log: (l) => console.log(`[dedup-memory] ${l}`) });
+    // eslint-disable-next-line no-console
+    console.log(`[dedup-memory] done ${JSON.stringify(summary)}`);
+  } finally {
+    db.close();
+  }
+}

--- a/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
+++ b/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
@@ -1,0 +1,93 @@
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSqliteDb } from "./migrate.js";
+
+// Migration v21 upgrade path: a real pre-v21 memory_messages table (no
+// content_hash, no unique index) carrying duplicate rows must, on upgrade,
+// (a) collapse exact duplicates keeping the EARLIEST row, (b) gain the
+// content_hash column, (c) gain the UNIQUE(thread_id, role, content_hash) index.
+// Mirrors the postgres migrate.test.ts pre-unique-index upgrade test.
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+// Seed a pre-v21 DB on disk (two connections can't share ":memory:") with the
+// v1–v20 ledger marked applied so createSqliteDb runs ONLY v21.
+function seedPreV21(): string {
+  const dir = mkdtempSync(join(tmpdir(), "helm-dedup-"));
+  dirs.push(dir);
+  const dbPath = join(dir, "test.db");
+  const raw = new Database(dbPath);
+  raw.exec("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);");
+  const ins = raw.prepare("INSERT INTO _migrations (version, applied_at) VALUES (?, 1)");
+  for (let v = 1; v <= 20; v += 1) ins.run(v);
+  raw.exec(`
+    CREATE TABLE memory_messages (
+      id TEXT PRIMARY KEY,
+      thread_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+  `);
+  const insMsg = raw.prepare(
+    "INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+  );
+  // Three copies of the SAME (thread, role, content) at increasing created_at,
+  // plus one distinct message. Earliest of the dup group is "first".
+  insMsg.run("first", "t1", "user", "dup", 1, 100);
+  insMsg.run("second", "t1", "user", "dup", 1, 200);
+  insMsg.run("third", "t1", "user", "dup", 1, 300);
+  insMsg.run("other", "t1", "assistant", "unique", 1, 150);
+  raw.close();
+  return dbPath;
+}
+
+describe("memory_messages dedup migration (v21)", () => {
+  it("collapses duplicates to the earliest row and adds the content_hash column", () => {
+    const db = createSqliteDb(seedPreV21());
+    try {
+      const rows = db.$sqlite
+        .prepare("SELECT id, content FROM memory_messages ORDER BY created_at")
+        .all() as Array<{ id: string; content: string }>;
+      // dup group collapsed to its earliest ("first"); distinct row kept.
+      expect(rows.map((r) => r.id).sort()).toEqual(["first", "other"]);
+
+      const cols = (
+        db.$sqlite.prepare("PRAGMA table_info(memory_messages)").all() as Array<{ name: string }>
+      ).map((c) => c.name);
+      expect(cols).toContain("content_hash");
+    } finally {
+      db.$sqlite.close();
+    }
+  });
+
+  it("creates the UNIQUE index that rejects a duplicate (thread, role, content_hash)", () => {
+    const db = createSqliteDb(seedPreV21());
+    try {
+      const idx = db.$sqlite
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name=?")
+        .get("uniq_memory_messages_thread_role_hash");
+      expect(idx).toBeDefined();
+
+      // A raw duplicate insert (same thread/role/content_hash) must be rejected.
+      const ins = db.$sqlite.prepare(
+        "INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at, content_hash) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      );
+      ins.run(randomUUID(), "t2", "user", "x", 1, 1, "hash-x");
+      expect(() => ins.run(randomUUID(), "t2", "user", "x", 1, 2, "hash-x")).toThrow();
+      // Different hash on the same (thread, role) is fine.
+      expect(() => ins.run(randomUUID(), "t2", "user", "y", 1, 3, "hash-y")).not.toThrow();
+    } finally {
+      db.$sqlite.close();
+    }
+  });
+});

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -344,6 +344,9 @@ describe("sqlite v18 forgetting schema deltas", () => {
       // v19 (api_keys.name) is pre-marked applied too: this minimal seed has no
       // api_keys table, so its ALTER would fail — keep the test scoped to v18.
       rec.run(19, Date.now());
+      // v21 dedups memory_messages, which this fixture never creates → pre-mark
+      // applied (out of scope for the v18 forgetting-deltas test).
+      rec.run(21, Date.now());
       seed.close();
 
       expect(() => runMigrations(path)).not.toThrow();

--- a/packages/core/src/store/sqlite/memory-schema.ts
+++ b/packages/core/src/store/sqlite/memory-schema.ts
@@ -1,4 +1,4 @@
-import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { integer, real, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 // SQLite (Drizzle) table definitions for the memory middleware (docs/08
 // "storage model"). POST-MVP persistence floor: build + migrate only — no read /
@@ -21,14 +21,26 @@ export const memoryThreads = sqliteTable("memory_threads", {
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
 });
 
-export const memoryMessages = sqliteTable("memory_messages", {
-  id: text("id").primaryKey(),
-  threadId: text("thread_id").notNull(), // references memory_threads.id only
-  role: text("role").notNull(), // 'user' | 'assistant' | 'tool' (IR-aligned)
-  content: text("content").notNull(), // raw message text / JSON
-  tokenEstimate: integer("token_estimate").notNull(),
-  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
-});
+export const memoryMessages = sqliteTable(
+  "memory_messages",
+  {
+    id: text("id").primaryKey(),
+    threadId: text("thread_id").notNull(), // references memory_threads.id only
+    role: text("role").notNull(), // 'user' | 'assistant' | 'tool' (IR-aligned)
+    content: text("content").notNull(), // raw message text / JSON
+    tokenEstimate: integer("token_estimate").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    // Idempotency key (v21): sha256(content) hex, NO normalization. The client
+    // re-sends the full transcript every turn; the UNIQUE(thread_id, role,
+    // content_hash) index + ON CONFLICT DO NOTHING collapses re-ingestion to a
+    // no-op (fixes O(n²) row growth). NULL only for pre-v21 rows the ops script
+    // backfills — NULLs are distinct in a UNIQUE index, so the index still builds.
+    contentHash: text("content_hash"),
+  },
+  (t) => [
+    uniqueIndex("uniq_memory_messages_thread_role_hash").on(t.threadId, t.role, t.contentHash),
+  ],
+);
 
 export const memoryObservations = sqliteTable("memory_observations", {
   id: text("id").primaryKey(),

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -16,6 +16,7 @@ import {
   type ReflectionUpsertInput,
 } from "@helm/shared";
 import { and, asc, desc, eq, isNull, type SQL, sql } from "drizzle-orm";
+import { sha256Hex } from "../../memory/message-hash.js";
 import type { MemoryJobStatus, MemoryStore } from "../ports.js";
 import {
   memoryFacts,
@@ -166,6 +167,9 @@ export class SqliteMemoryStore implements MemoryStore {
 
   async appendMessage(input: MemoryMessageInput): Promise<string> {
     const id = this.genId();
+    // Idempotent ingest: a re-sent (thread_id, role, content) collapses to a
+    // no-op via the v21 UNIQUE index (re-ingestion fix). Returned id is still
+    // generated per call; on conflict it is inert (the row was left untouched).
     this.db
       .insert(memoryMessages)
       .values({
@@ -175,6 +179,10 @@ export class SqliteMemoryStore implements MemoryStore {
         content: input.content,
         tokenEstimate: input.tokenEstimate,
         createdAt: this.now(),
+        contentHash: sha256Hex(input.content),
+      })
+      .onConflictDoNothing({
+        target: [memoryMessages.threadId, memoryMessages.role, memoryMessages.contentHash],
       })
       .run();
     return id;
@@ -202,6 +210,10 @@ export class SqliteMemoryStore implements MemoryStore {
             content: input.content,
             tokenEstimate: input.tokenEstimate,
             createdAt: new Date(base + i),
+            contentHash: sha256Hex(input.content),
+          })
+          .onConflictDoNothing({
+            target: [memoryMessages.threadId, memoryMessages.role, memoryMessages.contentHash],
           })
           .run();
       });

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -473,6 +473,38 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE memory_threads ADD COLUMN last_served_model TEXT;
     `,
   },
+  {
+    // Idempotent memory-message ingest (re-ingestion bug fix). The client re-sends
+    // the FULL transcript every turn; the old blind INSERT grew memory_messages
+    // O(n²) (97% duplicate rows in prod) and starved the observer (re-inserted
+    // rows get new ids, never covered by old observations → endless re-compaction).
+    // Steps, ORDERED: (a) collapse existing exact duplicates keeping the EARLIEST
+    // row per (thread_id, role, content); (b) add the content_hash dedup key
+    // (nullable — there is no sha256 SQL fn in better-sqlite3, so historical rows
+    // stay NULL and the ops script backfills them; NULLs are DISTINCT in a sqlite
+    // UNIQUE index, so the index still builds over deduped historical rows); (c)
+    // the UNIQUE boundary the write path targets via ON CONFLICT DO NOTHING.
+    version: 21,
+    sql: `
+      DELETE FROM memory_messages
+      WHERE rowid IN (
+        SELECT rowid FROM (
+          SELECT rowid,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY thread_id, role, content
+                   ORDER BY created_at ASC, id ASC
+                 ) AS rn
+          FROM memory_messages
+        )
+        WHERE rn > 1
+      );
+
+      ALTER TABLE memory_messages ADD COLUMN content_hash TEXT;
+
+      CREATE UNIQUE INDEX IF NOT EXISTS uniq_memory_messages_thread_role_hash
+        ON memory_messages (thread_id, role, content_hash);
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database): void {

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -53,7 +53,9 @@ describe("sqlite schema + migrations", () => {
       // v20 (memory_threads.last_served_model) is also pre-marked: this fixture
       // never creates memory_threads (v2 is marked applied without the CREATE),
       // so the v20 ALTER would fail — out of scope for this v14–v16 test.
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20])
+      // v21 (memory_messages dedup) likewise: v2 is applied without the
+      // memory_messages CREATE, so its dedup DELETE would fail — out of scope.
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21])
         rec.run(v, Date.now());
       const insert = seed.prepare(
         "INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -191,7 +193,9 @@ describe("sqlite schema + migrations", () => {
       // from this minimal fixture, so v18 is pre-marked applied to keep the test
       // scoped to v6's cost_usd rebuild.
       // v20 alters memory_threads (absent from this fixture) → pre-mark applied.
-      for (const v of [1, 2, 3, 4, 5, 18, 20]) rec.run(v, Date.now());
+      // v21 dedups memory_messages (absent: v2 marked applied without the CREATE)
+      // → pre-mark applied.
+      for (const v of [1, 2, 3, 4, 5, 18, 20, 21]) rec.run(v, Date.now());
       seed
         .prepare(
           "INSERT INTO telemetry (id, request_id, api_key_id, decision_json, cost_usd, created_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -252,7 +256,8 @@ describe("sqlite schema + migrations", () => {
       // memory tables (absent here), so v18 is pre-marked applied to keep the
       // test scoped to v10's max_lane DROP COLUMN forward step.
       // v20 alters memory_threads (absent from this fixture) → pre-mark applied.
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20]) rec.run(v, Date.now());
+      // v21 dedups memory_messages (absent here) → pre-mark applied.
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21]) rec.run(v, Date.now());
       seed
         .prepare(
           `INSERT INTO api_keys (key_id, hash, prefix, account_id, role, max_lane, allowed_lanes, created_at)

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -888,6 +888,85 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       );
     });
 
+    it("appendMessage is idempotent on re-ingest of the same (thread, role, content)", async () => {
+      // The re-ingestion fix: the client re-sends the whole transcript each turn.
+      // Persisting the same message twice must collapse to ONE row, not two.
+      ctx = await make();
+      const store = ctx.stores.memory;
+      await store.ensureThread({ id: "dup-t", ownerId: "acct-a" });
+      await store.appendMessage({
+        threadId: "dup-t",
+        role: "user",
+        content: "same",
+        tokenEstimate: 1,
+      });
+      await store.appendMessage({
+        threadId: "dup-t",
+        role: "user",
+        content: "same",
+        tokenEstimate: 1,
+      });
+      const msgs = await store.listMessages({ threadId: "dup-t", accountId: "acct-a" });
+      expect(msgs).toHaveLength(1);
+    });
+
+    it("appendMessages dedupes re-sent history and intra-batch duplicates, length preserved", async () => {
+      ctx = await make();
+      const store = ctx.stores.memory;
+      await store.ensureThread({ id: "redup-t", ownerId: "acct-a" });
+      // Turn 1 includes an intra-batch duplicate (m0 twice).
+      const ids1 = await store.appendMessages?.([
+        { threadId: "redup-t", role: "user", content: "m0", tokenEstimate: 1 },
+        { threadId: "redup-t", role: "user", content: "m0", tokenEstimate: 1 },
+        { threadId: "redup-t", role: "assistant", content: "m1", tokenEstimate: 1 },
+      ]);
+      // Contract: one id per input (length preserved), all distinct.
+      expect(ids1).toHaveLength(3);
+      expect(new Set(ids1).size).toBe(3);
+      // Turn 2 re-sends the full history + one new message (mirrors a real client).
+      await store.appendMessages?.([
+        { threadId: "redup-t", role: "user", content: "m0", tokenEstimate: 1 },
+        { threadId: "redup-t", role: "assistant", content: "m1", tokenEstimate: 1 },
+        { threadId: "redup-t", role: "user", content: "m2", tokenEstimate: 1 },
+      ]);
+      const msgs = await store.listMessages({ threadId: "redup-t", accountId: "acct-a" });
+      // Only the 3 distinct contents survive — no O(n²) re-ingestion.
+      expect(msgs.map((m) => m.content)).toEqual(["m0", "m1", "m2"]);
+    });
+
+    it("dedup is scoped by thread and by role (same content elsewhere still persists)", async () => {
+      ctx = await make();
+      const store = ctx.stores.memory;
+      await store.ensureThread({ id: "scope-a", ownerId: "acct-a" });
+      await store.ensureThread({ id: "scope-b", ownerId: "acct-a" });
+      await store.appendMessage({
+        threadId: "scope-a",
+        role: "user",
+        content: "x",
+        tokenEstimate: 1,
+      });
+      // Same content, DIFFERENT thread -> distinct row.
+      await store.appendMessage({
+        threadId: "scope-b",
+        role: "user",
+        content: "x",
+        tokenEstimate: 1,
+      });
+      // Same content + thread, DIFFERENT role -> distinct row.
+      await store.appendMessage({
+        threadId: "scope-a",
+        role: "assistant",
+        content: "x",
+        tokenEstimate: 1,
+      });
+      expect(await store.listMessages({ threadId: "scope-a", accountId: "acct-a" })).toHaveLength(
+        2,
+      );
+      expect(await store.listMessages({ threadId: "scope-b", accountId: "acct-a" })).toHaveLength(
+        1,
+      );
+    });
+
     it("ensureThread fills missing owner/project/resource scope when the same id is re-seen", async () => {
       ctx = await make();
       await ctx.stores.memory.ensureThread({ id: "t-upsert" });


### PR DESCRIPTION
## 背景

线上 la.atmy.work「死循环」排查（直连 helm.db + 源码 + 容器日志）锁定根因在**记忆入站写入**：`observeInbound`（`packages/core/src/memory/observe.ts`）每轮把客户端重发的整段对话历史**全量盲插入**，`appendMessage/appendMessages` 用全新随机 UUID 插入、**无幂等键/冲突处理**。Claude Code 每轮重发完整 transcript → `memory_messages` 呈 **O(n²)** 增长。

实测：**57,560 行 / 1,543 distinct = 97.3% 重复，DB 489 MB**。重复行带全新 `id + created_at`，永不被旧 observation 的 `source_message_range` 覆盖 → observer 每分钟 `memory_formation` 反复压缩同一线程（`measured_retention 0.6%`、`prior_compaction_count 9→17`）——这就是用户看到的「一直做同一件事」。

## 方案（去重根治；防复发护栏落在 DB 层）

- 新 `memory/message-hash.ts::sha256Hex`：逐字节 sha256，**不 normalize/不 lowercase**（消息是精确文本/代码）。
- 两方言 `memory_messages` 加 `content_hash` 列 + `UNIQUE(thread_id, role, content_hash)`；写入 `onConflictDoNothing`。pg 多行 INSERT 额外做**批内去重**。用 hash 而非 raw content：pg btree 索引行 ~2704B 上限。
- 迁移 **sqlite v21 / pg v20**：窗口函数 DELETE 去重保留最早行 → `ADD COLUMN content_hash`（可空）→ `CREATE UNIQUE INDEX`。SQL 算不了 sha256，历史行 hash 留 NULL（两方言 UNIQUE 索引 NULL 互不冲突，索引照建），新写入向后去重。
- 运维脚本 `store/sqlite/dedup-memory-messages.ts`（`pnpm memory:dedup <db>`）：回填历史 hash + 清空 bug 期 observations（observer 重建）+ 删 done/failed jobs + VACUUM；`--dry-run`、幂等。
- **observer 经济学核心（`compaction-policy.ts`/`AUTO_PRIORS`）刻意不动**——掐断重复入流即止住压缩跑步机。
- 注：**inject 非元凶**（D7 纯文本闸门对工具调用 turn 跳过注入），损害全在 observe 写入侧（observe/inject 两模式都会触发）。

## 部署顺序

1. 合代码 + 迁移 → 启动即去重 + 加约束 + 新写入停止累积。
2. 再跑运维脚本（**先备份** `helm.db`/`-wal`/`-shm` → `--dry-run` → 正式 → VACUUM，空闲窗口）。

## 验证

TDD 红→绿。新测 message-hash(6)、store-contract 双驱动去重(3)、observe 真实 store 重灌(1)、sqlite/pg 迁移升级、dedup 脚本 smoke(2)；修 4 个既有迁移 fixture（pre-mark v21/v20）。**全量 2954 绿**、typecheck/lint/build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)