### PR TITLE
feat(config): add Gemini Pro/Flash virtual models and routing

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -137,6 +137,16 @@ zenmux/gemini-3.5-flash:
   modalities: [audio, video, document]
   maxContextTokens: 1048576
   maxOutputTokens: 65536
+zenmux/gemini-3.1-pro:
+  supportsTools: true
+  supportsJsonMode: true
+  supportsVision: true
+  supportsStreaming: true
+  supportsCachedContent: true
+  # Same fully-multimodal input as 3.5-flash (audio, video, documents; P7).
+  modalities: [audio, video, document]
+  maxContextTokens: 1048576
+  maxOutputTokens: 65536
 # */auto aggregators: JSON-INCAPABLE on purpose — the capability filter prunes
 # them for strict-JSON requests so a json lane lands on a deterministic model.
 zenmux/auto:

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -149,3 +149,21 @@ claude-haiku:
   primary: openai-codex/gpt-5.4-mini
   fallback:
     - economy
+
+# Google Gemini has NO subscription channel in Helm; both tiers lead with the
+# static ZenMux key (the only Gemini upstream wired here), then degrade to the
+# matching generic quality lane. gemini-3.1-pro is the latest Pro ZenMux serves
+# (3.5 Pro is announced but not yet GA upstream); gemini-3.5-flash is the latest
+# GA Flash. Both are fully multimodal, so a vision/audio/video request that pins a
+# Gemini id stays on Gemini before the capability filter takes over downstream.
+gemini-pro:
+  purpose: Google Gemini Pro tier — strong multimodal reasoning
+  primary: zenmux/gemini-3.1-pro
+  fallback:
+    - premium
+
+gemini-flash:
+  purpose: Google Gemini Flash tier — fast multimodal
+  primary: zenmux/gemini-3.5-flash
+  fallback:
+    - balanced

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -52,3 +52,14 @@
 "gpt-5-codex": coding
 "gpt-5*": premium
 "gpt-*": balanced
+
+# ── Google Gemini (Gemini CLI, AI Studio / Vertex SDKs, …) ───────────────────
+# Bare Gemini ids → vendor-family lanes (config/lanes.yaml). Any `*pro*` id leads
+# with the Gemini Pro tier; any `*flash*` (incl. flash-lite) with the cheaper
+# Flash tier; the bare `gemini-*` catch-all degrades to balanced. Longest-literal
+# wins, so `gemini-*flash*` (12 literal chars) and `gemini-*pro*` (10) both beat
+# the `gemini-*` catch-all (7). The middle `*` absorbs the version + any `-preview`
+# / `-latest` / date suffix (gemini-3.1-pro-preview, gemini-3.5-flash, gemini-2.5-pro…).
+"gemini-*flash*": gemini-flash
+"gemini-*pro*": gemini-pro
+"gemini-*": balanced

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -53,6 +53,9 @@ zenmux/gpt-5.5:
 zenmux/gemini-3.5-flash:
   inputPerMTokUsd: 1.5
   outputPerMTokUsd: 9.0
+zenmux/gemini-3.1-pro:
+  inputPerMTokUsd: 2.0
+  outputPerMTokUsd: 12.0
 zenmux/auto:
   inputPerMTokUsd: 2.5
   outputPerMTokUsd: 15.0

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -89,9 +89,16 @@ providers:
       # (zenmux real id).
       - alias: zenmux/gpt-5.5
         provider_model: openai/gpt-5.5
-      # google/gemini-3.5-flash — vision lane primary (multimodal; zenmux real id).
+      # google/gemini-3.5-flash — vision lane + gemini-flash lane primary (latest
+      # GA Flash, multimodal; zenmux real id).
       - alias: zenmux/gemini-3.5-flash
         provider_model: google/gemini-3.5-flash
+      # gemini-3.1-pro — gemini-pro lane primary. The latest Gemini Pro ZenMux
+      # serves (3.5 Pro is announced but not yet GA upstream). The alias keeps the
+      # clean `gemini-3.1-pro` routing key; the upstream id is still the `-preview`
+      # slug, so only provider_model changes when it graduates to GA.
+      - alias: zenmux/gemini-3.1-pro
+        provider_model: google/gemini-3.1-pro-preview
       # auto — platform auto-route. JSON-INCAPABLE on purpose (see
       # catalog supports_json_schema:false): the capability filter skips it for
       # strict-JSON requests so the `json` lane prunes to a deterministic model.

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -100,6 +100,29 @@ describe("checked-in config samples", () => {
     expect(lanes["gpt-5.4-mini"]?.fallback).toEqual(["economy"]);
   });
 
+  it("routes bare Gemini ids onto the gemini vendor-family lanes (pro vs flash vs catch-all)", () => {
+    const cfg = loadConfig({ configDir, env: {} });
+    const lanes = cfg.lanes;
+    const aliases = cfg.model_aliases;
+    if (lanes === undefined) throw new Error("config/lanes.yaml must load into config.lanes");
+    if (aliases === undefined) throw new Error("config/model-aliases.yaml must load");
+    // Vendor-family lanes lead with the static ZenMux Gemini keys (the only Gemini
+    // upstream wired): pro -> gemini-3.1-pro (latest Pro ZenMux serves), flash ->
+    // gemini-3.5-flash (latest GA Flash).
+    expect(lanes["gemini-pro"]?.primary).toBe("zenmux/gemini-3.1-pro");
+    expect(lanes["gemini-pro"]?.fallback).toEqual(["premium"]);
+    expect(lanes["gemini-flash"]?.primary).toBe("zenmux/gemini-3.5-flash");
+    expect(lanes["gemini-flash"]?.fallback).toEqual(["balanced"]);
+    // Longest-literal wins: `*pro*` / `*flash*` beat the `gemini-*` catch-all, and
+    // the middle `*` absorbs the version + any -preview/-latest suffix.
+    expect(resolveModelAlias("gemini-3.1-pro-preview", aliases)).toBe("gemini-pro");
+    expect(resolveModelAlias("gemini-2.5-pro", aliases)).toBe("gemini-pro");
+    expect(resolveModelAlias("gemini-3.5-flash", aliases)).toBe("gemini-flash");
+    expect(resolveModelAlias("gemini-3.1-flash-lite", aliases)).toBe("gemini-flash");
+    // An id matching neither tier falls through the catch-all to balanced.
+    expect(resolveModelAlias("gemini-embedding-001", aliases)).toBe("balanced");
+  });
+
   it("loads the shipped policies.yaml as first-match rules", () => {
     const cfg = loadConfig({ configDir, env: {} });
     const ids = cfg.policies.policies.map((p) => p.id);


### PR DESCRIPTION
## What

Wire the **Google Gemini** family end to end in `config/` so a fixed-model Gemini client (Gemini CLI, AI Studio/Vertex SDKs) routes by lane instead of getting a `400 unknown model`. Triggered by a live Gemini request that had no virtual-model mapping.

## Changes

| File | Change |
|---|---|
| `model-aliases.yaml` | `gemini-*flash*` → `gemini-flash`, `gemini-*pro*` → `gemini-pro`, `gemini-*` → `balanced` (catch-all). Longest-literal wins; the middle `*` absorbs the version + any `-preview`/`-latest`/date suffix. |
| `lanes.yaml` | New vendor-family lanes `gemini-pro` (→ `premium`) and `gemini-flash` (→ `balanced`), each leading with the static ZenMux key (the only Gemini upstream wired). |
| `providers.yaml` | New alias `zenmux/gemini-3.1-pro` → `google/gemini-3.1-pro-preview`. Clean routing key; only `provider_model` changes when 3.1 Pro graduates from preview to GA. |
| `capabilities.yaml` / `pricing.yaml` | Entries for the new Pro alias (multimodal: audio/video/document, 1M ctx; \$2.0/\$12.0 per 1M). |
| `samples.test.ts` | Pins pro/flash/catch-all routing + the new lane primaries/fallbacks. |

## Version notes

Confirmed against ZenMux `/v1/models` + OpenRouter pricing:
- **Flash** — `gemini-3.5-flash` is the latest **GA** Flash (already wired for the `vision` lane); now gets a dedicated `gemini-flash` family lane.
- **Pro** — **Gemini 3.5 Pro is announced but not yet GA** and ZenMux doesn't serve it, so `gemini-pro` leads with `gemini-3.1-pro-preview`, the newest Pro ZenMux actually serves.

Config-only and operator-authorized, so **any** key can address these Gemini ids — `allow_custom_model` is not required (a key's `allowed_lanes` whitelist still applies).

## Test

`pnpm vitest run packages/core/src/config packages/core/src/routing` → **151 passed** (incl. the new Gemini routing case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)