### PR TITLE
feat(admin): add refresh + auto-refresh control to requests page

### DIFF
--- a/apps/admin/src/lib/components/RefreshControl.svelte
+++ b/apps/admin/src/lib/components/RefreshControl.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { t } from '$lib/i18n';
+
+  // Split refresh control (Grafana-style): the left button refreshes the page
+  // now, the caret opens a menu that picks an auto-refresh cadence. The parent
+  // owns what "refresh" means (the requests list re-runs its loader via
+  // invalidateAll); this component only schedules the calls and reports state.
+  // Stateless w.r.t. data — purely a trigger, so it stays reusable across pages.
+  let {
+    onRefresh,
+  }: {
+    onRefresh: () => void | Promise<void>;
+  } = $props();
+
+  // Cadence choices in seconds (0 handled separately as "Off"). Labels are
+  // language-neutral literals (like RangeFilter's 1h/6h), so they need no i18n.
+  const INTERVALS: { seconds: number; label: string }[] = [
+    { seconds: 5, label: '5s' },
+    { seconds: 10, label: '10s' },
+    { seconds: 30, label: '30s' },
+    { seconds: 60, label: '1m' },
+    { seconds: 300, label: '5m' },
+    { seconds: 900, label: '15m' },
+    { seconds: 1800, label: '30m' },
+    { seconds: 3600, label: '1h' },
+    { seconds: 7200, label: '2h' },
+    { seconds: 86400, label: '1d' },
+  ];
+
+  let open = $state(false);
+  let refreshing = $state(false);
+  // Active cadence in seconds; 0 = auto-refresh off.
+  let intervalSeconds = $state(0);
+  let root = $state<HTMLElement>();
+
+  // setInterval handle for the active cadence; null when off.
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const activeLabel = $derived(INTERVALS.find((o) => o.seconds === intervalSeconds)?.label ?? null);
+
+  // Run a refresh, guarding against overlap so a slow load never stacks ticks.
+  async function runRefresh(): Promise<void> {
+    if (refreshing) return;
+    refreshing = true;
+    try {
+      await onRefresh();
+    } finally {
+      refreshing = false;
+    }
+  }
+
+  function stopTimer(): void {
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  // Apply a cadence: 0 stops auto-refresh, anything else (re)starts the timer.
+  // Selecting a cadence sets the rhythm only — the first tick fires one interval
+  // later, matching how monitoring dashboards behave (no surprise burst on pick).
+  function selectInterval(seconds: number): void {
+    intervalSeconds = seconds;
+    open = false;
+    stopTimer();
+    if (seconds > 0) {
+      timer = setInterval(() => {
+        void runRefresh();
+      }, seconds * 1000);
+    }
+  }
+
+  // Close the menu on any pointer-down outside the control (click-outside).
+  function onWindowPointerDown(event: PointerEvent): void {
+    if (!open) return;
+    const target = event.target as Node | null;
+    if (root && target && !root.contains(target)) open = false;
+  }
+
+  onDestroy(stopTimer);
+</script>
+
+<svelte:window
+  onpointerdown={onWindowPointerDown}
+  onkeydown={(e) => e.key === 'Escape' && (open = false)}
+/>
+
+<div bind:this={root} data-testid="refresh-control" class="relative inline-flex">
+  <!-- Refresh now. The arrow-path icon spins while a refresh is in flight. -->
+  <button
+    type="button"
+    data-testid="refresh-now"
+    class="btn-secondary rounded-r-none"
+    aria-label={$t('Refresh')}
+    onclick={() => void runRefresh()}
+  >
+    <svg
+      class="h-4 w-4 {refreshing ? 'animate-spin' : ''}"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.8"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M16.023 9.348h4.992V4.356M3.86 14.652H8.85m11.297-5.304a8.25 8.25 0 0 0-15.357-2.244M3.86 14.652a8.25 8.25 0 0 0 15.357 2.244"
+      />
+    </svg>
+    {$t('Refresh')}
+    {#if activeLabel}
+      <span data-testid="refresh-active" class="font-medium text-indigo-600">· {activeLabel}</span>
+    {/if}
+  </button>
+
+  <!-- Caret: opens the cadence menu. Shares its left border with the button. -->
+  <button
+    type="button"
+    data-testid="refresh-toggle"
+    class="btn-secondary -ml-px rounded-l-none px-1.5"
+    aria-haspopup="menu"
+    aria-expanded={open}
+    aria-label={$t('Auto refresh')}
+    onclick={() => (open = !open)}
+  >
+    <svg
+      class="h-4 w-4 transition-transform {open ? 'rotate-180' : ''}"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="2"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      data-testid="refresh-menu"
+      role="menu"
+      class="absolute right-0 top-full z-20 mt-1 w-32 overflow-hidden rounded-md border border-slate-200 bg-white py-1 shadow-lg"
+    >
+      <button
+        type="button"
+        data-testid="refresh-interval-off"
+        role="menuitemradio"
+        aria-checked={intervalSeconds === 0}
+        class="flex w-full items-center justify-between px-3 py-1.5 text-sm transition-colors hover:bg-slate-50 {intervalSeconds ===
+        0
+          ? 'font-medium text-indigo-600'
+          : 'text-slate-700'}"
+        onclick={() => selectInterval(0)}
+      >
+        {$t('Off')}
+        {#if intervalSeconds === 0}<span aria-hidden="true">✓</span>{/if}
+      </button>
+
+      <div class="my-1 border-t border-slate-100"></div>
+      <p class="px-3 pb-1 text-xs font-medium uppercase tracking-wide text-slate-400">
+        {$t('Auto refresh')}
+      </p>
+
+      {#each INTERVALS as opt (opt.seconds)}
+        <button
+          type="button"
+          data-testid="refresh-interval-{opt.seconds}"
+          role="menuitemradio"
+          aria-checked={intervalSeconds === opt.seconds}
+          class="flex w-full items-center justify-between px-3 py-1.5 text-sm transition-colors hover:bg-slate-50 {intervalSeconds ===
+          opt.seconds
+            ? 'font-medium text-indigo-600'
+            : 'text-slate-700'}"
+          onclick={() => selectInterval(opt.seconds)}
+        >
+          {opt.label}
+          {#if intervalSeconds === opt.seconds}<span aria-hidden="true">✓</span>{/if}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/apps/admin/src/lib/components/RefreshControl.test.ts
+++ b/apps/admin/src/lib/components/RefreshControl.test.ts
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RefreshControl from './RefreshControl.svelte';
+
+// Split refresh control: the left button refreshes now (calls `onRefresh`), the
+// caret opens a menu that picks an auto-refresh cadence. These tests pin the two
+// behaviours that carry real logic — the manual click and the timer-driven auto
+// refresh (start on select, stop on Off) — plus the active-interval feedback.
+// The dropdown markup itself is glue and only lightly asserted.
+
+describe('RefreshControl', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('invokes onRefresh once when the Refresh button is clicked', async () => {
+    const onRefresh = vi.fn();
+    render(RefreshControl, { onRefresh });
+    await fireEvent.click(screen.getByTestId('refresh-now'));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a menu listing Off and the auto-refresh intervals', async () => {
+    render(RefreshControl, { onRefresh: vi.fn() });
+    expect(screen.queryByTestId('refresh-menu')).not.toBeInTheDocument();
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    const menu = screen.getByTestId('refresh-menu');
+    expect(menu).toBeInTheDocument();
+    expect(screen.getByTestId('refresh-interval-off')).toBeInTheDocument();
+    // A representative spread of the cadence options (seconds as the key).
+    expect(screen.getByTestId('refresh-interval-5')).toHaveTextContent('5s');
+    expect(screen.getByTestId('refresh-interval-60')).toHaveTextContent('1m');
+    expect(screen.getByTestId('refresh-interval-86400')).toHaveTextContent('1d');
+  });
+
+  it('does not auto-refresh until an interval is selected', async () => {
+    const onRefresh = vi.fn();
+    render(RefreshControl, { onRefresh });
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('selecting an interval refreshes on each tick (not immediately)', async () => {
+    const onRefresh = vi.fn();
+    render(RefreshControl, { onRefresh });
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    await fireEvent.click(screen.getByTestId('refresh-interval-5'));
+    // Selecting the cadence must not fire an immediate refresh.
+    expect(onRefresh).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the active cadence and closes the menu after selecting', async () => {
+    render(RefreshControl, { onRefresh: vi.fn() });
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    await fireEvent.click(screen.getByTestId('refresh-interval-30'));
+    expect(screen.queryByTestId('refresh-menu')).not.toBeInTheDocument();
+    expect(screen.getByTestId('refresh-active')).toHaveTextContent('30s');
+  });
+
+  it('selecting Off stops auto-refresh', async () => {
+    const onRefresh = vi.fn();
+    render(RefreshControl, { onRefresh });
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    await fireEvent.click(screen.getByTestId('refresh-interval-5'));
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    await fireEvent.click(screen.getByTestId('refresh-interval-off'));
+    expect(screen.queryByTestId('refresh-active')).not.toBeInTheDocument();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onRefresh).toHaveBeenCalledTimes(1); // no further ticks
+  });
+
+  it('stops the timer when unmounted (no refresh after teardown)', async () => {
+    const onRefresh = vi.fn();
+    const { unmount } = render(RefreshControl, { onRefresh });
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    await fireEvent.click(screen.getByTestId('refresh-interval-5'));
+    unmount();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -40,6 +40,7 @@
   "Apply the configured per-key request and token limits.": "Apply the configured per-key request and token limits.",
   "Assembled": "Assembled",
   "Auto (derive from client signals)": "Auto (derive from client signals)",
+  "Auto refresh": "Auto refresh",
   "auto thread": "auto thread",
   "auto-renews": "auto-renews",
   "Avg latency": "Avg latency",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -39,6 +39,7 @@
   "Apply the configured per-key request and token limits.": "設定されたキーごとのリクエスト数とトークン数の制限を適用します。",
   "Assembled": "結合結果",
   "Auto (derive from client signals)": "自動（クライアント信号から派生）",
+  "Auto refresh": "自動更新",
   "auto thread": "スレッド自動推定",
   "auto-renews": "自動更新",
   "Avg latency": "平均レイテンシ",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -39,6 +39,7 @@
   "Apply the configured per-key request and token limits.": "구성된 키별 요청 및 토큰 제한을 적용합니다.",
   "Assembled": "조합 결과",
   "Auto (derive from client signals)": "자동(클라이언트 신호에서 파생)",
+  "Auto refresh": "자동 새로고침",
   "auto thread": "스레드 자동 추론",
   "auto-renews": "자동 갱신",
   "Avg latency": "평균 지연",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -40,6 +40,7 @@
   "Apply the configured per-key request and token limits.": "应用已配置的每个密钥请求和令牌限制。",
   "Assembled": "合并结果",
   "Auto (derive from client signals)": "自动（从客户端信号推导）",
+  "Auto refresh": "自动刷新",
   "auto thread": "线程自动推导",
   "auto-renews": "自动续订",
   "Avg latency": "平均延迟",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -39,6 +39,7 @@
   "Apply the configured per-key request and token limits.": "套用已設定的每個金鑰請求和權杖限制。",
   "Assembled": "合併結果",
   "Auto (derive from client signals)": "自動（從客戶端信號推導）",
+  "Auto refresh": "自動重新整理",
   "auto thread": "執行緒自動推導",
   "auto-renews": "自動續訂",
   "Avg latency": "平均延遲",

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { untrack } from 'svelte';
-  import { goto } from '$app/navigation';
+  import { goto, invalidateAll } from '$app/navigation';
   import { base } from '$app/paths';
   import type { RequestListItem } from '$lib/api/requests.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
+  import RefreshControl from '$lib/components/RefreshControl.svelte';
   import { formatTimestamp, formatUsd } from '$lib/format.js';
   import { paginationItems } from '$lib/pagination.js';
   import {
@@ -139,13 +140,20 @@
 </script>
 
 <section class="flex w-full flex-col gap-4 px-4 py-6 md:px-8">
-  <header>
-    <h1 class="page-title">{$t('Requests')}</h1>
-    <p class="section-desc">
-      {$t(
-        'Routing trail for each request — classification layer, lane, served model, fallbacks, cost and errors. Keys are shown by prefix only.',
-      )}
-    </p>
+  <header class="flex items-start justify-between gap-3">
+    <div class="min-w-0">
+      <h1 class="page-title">{$t('Requests')}</h1>
+      <p class="section-desc">
+        {$t(
+          'Routing trail for each request — classification layer, lane, served model, fallbacks, cost and errors. Keys are shown by prefix only.',
+        )}
+      </p>
+    </div>
+    <!-- Refresh now + auto-refresh cadence. Re-runs the loader (invalidateAll),
+         which re-reads the URL filters and refetches the current page. -->
+    <div class="shrink-0">
+      <RefreshControl onRefresh={() => invalidateAll()} />
+    </div>
   </header>
 
   <!-- Date-range presets, pulled out as a standalone button row (the shared

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-11 · 请求页自动刷新控件 RefreshControl（admin UX；CLAUDE.md 原则 1）
+
+- **缘起**：用户要求在 `/admin/requests` 页右上角加一个刷新按钮，支持自动刷新，样式参考某监控面板的「Refresh ▾」分体按钮（下拉含 关/Auto/5s…1d）。
+- **实现**：新增可复用 `RefreshControl.svelte`——分体按钮：左「↻ Refresh」立即刷新（在途时图标 `animate-spin`），右「▾」开下拉选自动刷新节奏（关 + 5s/10s/30s/1m/5m/15m/30m/1h/2h/1d）。`setInterval` 驱动，`onDestroy` 清理；选中节奏后主按钮显示「· 30s」激活反馈。`<svelte:window onpointerdown>` 做 click-outside、Escape 关闭。组件**对数据无状态**（纯触发器），parent 通过 `onRefresh` 注入语义；请求页传 `() => invalidateAll()`——重跑 `+page.ts` loader，按 URL filter 重取当前页。请求页 `<header>` 改 `flex justify-between`，控件居右（仿 providers 页）。
+- **取舍（关键）**：① 参考图里的「Auto」判为**分组标题而非可选项**（图中顶部高亮的是当前选中的「关」，Auto 是其下区间列表的小标题），故下拉做成「关 + Auto refresh 分组 + 区间」，不引入语义含糊的「Auto」选项（呼应 CLAUDE.md「会撒谎的旋钮比没有旋钮更糟」）。② 选中节奏**只设定节拍、不立即刷一次**（仿 Grafana，避免点选即触发的意外突发）；`runRefresh` 带 `refreshing` 重入守卫，慢加载不堆叠 tick。③ 区间标签（5s/1h…）是语言中性字面量，**不进 i18n**（仿 RangeFilter 的 1h/6h）；只「Auto refresh」入 5 语言包。
+- **坑/TODO**：① 纯 admin 静态资源改动，需发新 admin 镜像才生效（部署见 [[deploy-never-overwrite-config]]）。② 自动刷新仅本页生命周期内有效，离开页面即停；刷新节奏不持久化（刻意——避免后台无意义轮询）。③ 控件通用，后续可复用到 Dashboard/Providers 等页。
+- **验证**：TDD 红→绿。新 `RefreshControl.test.ts`(7，fake timers)：手动点击触发 onRefresh、菜单开列区间、选中后逐 tick 刷新（非立即）、激活标签、选「关」停、卸载清理。requests 页 17 例不回归；admin 全量 **304 绿**；svelte-check 对新文件零错（仅既有 oauth.test.ts 3 处预存错，未触碰）；Biome lint(432 文件) + Prettier(.svelte) + vite build 全绿。
+
 ## 2026-06-11 · 记忆消息重复写入根治 + 历史脏数据清理（CLAUDE.md 原则 1/3；docs/08）
 
 - **缘起**：线上 la.atmy.work「死循环」排查（直连 helm.db + 源码 + 容器日志）锁定根因在**记忆入站写入**：`observeInbound`（`memory/observe.ts`）每轮把客户端重发的**整段历史全量盲插入**，`appendMessage/appendMessages` 用全新随机 UUID 插入、**无幂等键/冲突处理**。Claude Code 每轮重发完整 transcript → `memory_messages` 呈 **O(n²)** 增长（实测 57,560 行 / 1,543 distinct = **97.3% 重复**，DB **489MB**）。重复行带**全新 id + created_at**，永不被旧 observation 的 `source_message_range` 覆盖（`observer.ts` `alreadyObservedMessageIds` 按 id 区间判覆盖）→ observer 每分钟 `memory_formation` 反复压缩同一线程（`measured_retention 0.6%`、`prior_compaction_count 9→17`）——这就是用户看到的「一直做同一件事」。
@@ -29,21 +37,13 @@
 - **Codex review 二次修复（两处 P1）**：① 写队列批量 insert 容错——`insertMany` 整批多行写到唯一列，单条重复 `request_id`（客户端复用 `X-Request-Id`→trace_id）会让整批抛错、原实现 catch 后丢掉整个 25ms 窗口的无关行；改为 `writeTelemetry/writePayloads` **批量失败回退逐条**（多行 INSERT 原子，失败不提交，回退不双写），只丢肇事行。② 优雅停机时序——`index.ts` 原先 `server.close()` 未 await 就 dispose（停队列+关 store），在途请求的响应后 enqueue 会被丢、同步 settle 可能打到已关闭 DB；抽 `runtime/shutdown.ts::closeServer`（先丢空闲 keep-alive、await 在途排空、超 `HELM_SHUTDOWN_DRAIN_MS` 默认 10s 再 force-close），**先 await closeServer 再 dispose**。
 - **验证**：TDD 红→绿。新单测：cached-keystore(10)、write-queue(10，含批量回退)、shutdown(3)、egress(3)、createSseCapture(3)、telemetry batch 契约（sqlite+PGlite）、chat/recordServed 延迟路径。全量 `pnpm test` 2935 测试（9 个 PGlite 5s 超时是 [[pnpm-test-pglite-flake]]，隔离重跑 143 全绿）；typecheck（4 包）/ lint(Biome) / build（admin+core+gateway）全绿。
 
-## 2026-06-10 · SQLite 写入热路径性能修复（Phase A，无 Redis；CLAUDE.md 原则 1/8）
-
-- **缘起**：用户反馈线上 la.atmy.work「两个并发就很慢」，怀疑写入太多，提议参考 [[la-atmy-work-deployment]] 旁的 claude-relay-service 引入 Redis 写缓冲再落 SQLite。诊断后发现**根因不是 SQLite 并发能力**，而是 **better-sqlite3 同步阻塞 Node 单线程 + 默认 `synchronous=FULL`（每次 commit 都 fsync）**：写代价由整个进程（含其它在途请求的事件循环）承担。对 Claude Code 这类**每轮重发整段历史 + 工具定义**的客户端，`capture_payloads`（默认开）把数百 KB~MB 的 request_json 同步 + fsync 落库，直接冻结事件循环；memory observe 又**逐条消息**同步写（inbound 在上游调用前、关键路径上）。两个并发流互相卡 fsync，无法重叠。
-- **取舍（已与用户拍板：先量后扩）**：**本 PR = Phase A：只做 SQLite 快修，不开发 Redis**（用户明确「先修慢的问题 redis 先不开发」）。Redis 写回层留作 Phase B——它真正的收益是**多实例横向扩展**（跨进程共享限流/预算状态），而非单机吞吐；单机慢用一行 PRAGMA + 批量写即可解。保住「自托管、默认 SQLite、零配置」身份（原则 1）。
-- **修复 1（头号）**：`migrate.ts` 抽 `applyPragmas()`，对每个连接设 `journal_mode=WAL` + **`synchronous=NORMAL`**（WAL 下安全：崩溃/断电最多丢最后几条 commit，绝不损坏文件）+ `busy_timeout=5000` + `temp_store=MEMORY` + `cache_size=-16000`。NORMAL 去掉 per-commit fsync，是消除事件循环阻塞的关键。`createSqliteDb` 与 `runMigrations` 同源应用。
-- **修复 2**：`MemoryStore` 端口加**可选** `appendMessages(inputs[])` 批量写：sqlite 走单个 `$sqlite.transaction`、postgres 走单条多行 INSERT，整轮一次 commit（替代 N 次）。`createdAt` 按 `base+i` 落戳，保证 `listMessages`（按 createdAt,id 排序）严格还原插入顺序（**比旧逐条循环更确定**——旧路径同毫秒碰撞后退化为随机 UUID 排序）。`observe.ts` 抽 `toMessageInputs` + `persistMessages`：有 `appendMessages` 走批量，否则回退逐条循环（端口可选，旧 store/测试 fake 零改动仍可用）。inbound/outbound 同享，inbound 在关键路径上收益最大。
-- **未做（有意，Phase A 范围外）**：① 非流式 post-serve 写入「后置/fire-and-forget」——Claude Code 用流式，post-serve 写已在 stream 结束后、不在客户端延迟路径上，故略；② payload 压缩/截断——原则 8 要求全量正文可审计，不静默截断；③ Redis（Phase B）。
-- **坑/TODO**：① PRAGMA 为内部性能调优、硬编码（同 `journal_mode` 既有做法），不暴露 config（与 observer 自适应同理，不加「会撒谎的旋钮」）。② 重新部署 la.atmy.work 后需**实测两并发延迟**确认收益，再决定是否上 Phase B Redis（部署只 pull + up，不覆盖 operator config，见 [[deploy-never-overwrite-config]]）。③ `synchronous=NORMAL` 的弱持久性已知并接受（遥测/用量记账可容忍丢尾）。
-- **验证**：TDD 红→绿。新增 `migrate.pragmas.test.ts`(3)、store-contract 批量有序/空批 2 例（双驱动 sqlite+pglite）、observe 批量 inbound/outbound 2 例（+既有 fallback/fail-open 用例覆盖回退路径）。core store+memory 487 绿、gateway memory 路由 73 绿、**全量 node 2601 绿**（唯 4 例 admin-static 因 worktree 未构建 admin SPA 假红，`pnpm --filter @helm/admin build` 后转绿）、typecheck（core+gateway）+ biome 绿。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-10 · SQLite 写入热路径性能修复（Phase A，无 Redis）：根因非 SQLite 并发能力，而是 better-sqlite3 同步阻塞 Node 单线程 + 默认 `synchronous=FULL`（每 commit fsync）；修复 = `migrate.ts::applyPragmas()` 每连接设 WAL + `synchronous=NORMAL` + busy_timeout/temp_store/cache_size，外加 `MemoryStore` 可选 `appendMessages` 批量写（单事务 / 多行 INSERT，N commit→1，`createdAt=base+i` 保序）。坑：PRAGMA 硬编码不入 config；NORMAL 弱持久性已接受；部署后需实测两并发延迟再定 Phase B（Redis 是多实例扩展、非单机吞吐）。migrate.pragmas.test(3)+store-contract/observe 批量例、全量 2601 绿。
 
 ### 2026-06-10 · admin 导航进度条 NavProgress：纯消费 SvelteKit `navigating` store 的顶部细进度条（8% 起跳→trickle 逼近 92%→resolve 补满淡出），`$effect` 仅依赖 `$navigating` + `untrack` 防 trickle 自触发，挂 `+layout.svelte` 最顶层；**只覆盖路由导航（含其 `load` 内 API），不做全局 fetch 拦截**（Occam，~70 行无 nprogress 依赖）。坑：页内非导航 fetch 不反映；改页内手动取数的页将不触发；需发新 admin 镜像。NavProgress.test 3 绿。
 


### PR DESCRIPTION
## What

Adds a **refresh button with auto-refresh** to the top-right of `/admin/requests`, as requested.

A new reusable `RefreshControl.svelte` split button:
- **Left `↻ Refresh`** — refreshes now (re-runs the page loader via `invalidateAll`, honoring the active URL filters). The icon spins while a load is in flight.
- **Right caret `▾`** — opens a dropdown to pick an auto-refresh cadence: **Off** + an *Auto refresh* group with `5s / 10s / 30s / 1m / 5m / 15m / 30m / 1h / 2h / 1d`.
- Active cadence is shown as feedback (e.g. `↻ Refresh · 30s`). Closes on click-outside / Escape; the timer is cleared on unmount.

The requests page header was restructured to `flex justify-between` (mirrors the Providers page) so the control sits cleanly on the right.

## Design decisions

1. **The "Auto" in the reference screenshot is a section heading, not a selectable option** — the highlighted top row there was the current selection (Off); "Auto" just labels the interval list. So the menu is `Off + Auto refresh group + intervals`, with no ambiguous "Auto" item.
2. **Selecting a cadence sets the rhythm only — no immediate burst** (Grafana-style). A re-entrancy guard stops a slow load from stacking ticks.
3. **Interval labels (`5s`…`1d`) are language-neutral literals** (like `RangeFilter`'s `1h`/`6h`) and stay out of i18n; only `"Auto refresh"` was added to all five locale bundles.

## Testing

- `RefreshControl.test.ts` — **7 tests** (fake timers): manual click fires `onRefresh`, menu lists intervals, interval selection ticks (not immediate), Off stops it, active-cadence label, unmount cleanup.
- Requests page tests unchanged; full admin suite **304 passing**.
- `svelte-check` clean for the new files, Biome lint (432 files), Prettier (.svelte), and `vite build` all green.

## Deploy note

Pure admin static-asset change — takes effect once a new admin image is built and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)