### PR TITLE
fix(admin): render Gemini-native SSE in the payload viewer

### DIFF
--- a/apps/admin/src/lib/sse.test.ts
+++ b/apps/admin/src/lib/sse.test.ts
@@ -155,6 +155,50 @@ const RESPONSES_STREAM = [
   })}\n\n`,
 ].join('');
 
+// Gemini native streaming: bare `data:` lines (no `event:`, no top-level `type`)
+// whose payload carries `candidates[].content.parts[]`. Reasoning parts are
+// flagged `thought: true`; tool calls are `functionCall` with an *object* `args`;
+// usage is the top-level `usageMetadata`; model is `modelVersion`. This is the
+// format a Gemini-CLI client speaks end-to-end — the gateway stores it verbatim.
+const GEMINI_STREAM = [
+  `data: ${JSON.stringify({
+    candidates: [{ content: { role: 'model', parts: [{ text: 'Hello!' }] }, index: 0 }],
+    modelVersion: 'gemini-3.5-flash',
+  })}\n\n`,
+  `data: ${JSON.stringify({
+    candidates: [{ content: { role: 'model', parts: [{ text: ' I am Gemini.' }] }, index: 0 }],
+  })}\n\n`,
+  `data: ${JSON.stringify({
+    candidates: [{ content: { role: 'model', parts: [] }, finishReason: 'STOP', index: 0 }],
+    usageMetadata: {
+      promptTokenCount: 10051,
+      candidatesTokenCount: 321,
+      totalTokenCount: 10372,
+    },
+  })}\n\n`,
+].join('');
+
+const GEMINI_TOOL_STREAM = [
+  `data: ${JSON.stringify({
+    candidates: [
+      { content: { role: 'model', parts: [{ thought: true, text: 'Need the weather.' }] }, index: 0 },
+    ],
+  })}\n\n`,
+  `data: ${JSON.stringify({
+    candidates: [
+      {
+        content: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'get_weather', args: { city: 'Paris' } } }],
+        },
+        finishReason: 'STOP',
+        index: 0,
+      },
+    ],
+    usageMetadata: { promptTokenCount: 8, candidatesTokenCount: 12, totalTokenCount: 20 },
+  })}\n\n`,
+].join('');
+
 describe('isSseStream', () => {
   it('detects OpenAI-style data: streams', () => {
     expect(isSseStream(OPENAI_STREAM)).toBe(true);
@@ -166,6 +210,10 @@ describe('isSseStream', () => {
 
   it('detects OpenAI Responses API event streams', () => {
     expect(isSseStream(RESPONSES_STREAM)).toBe(true);
+  });
+
+  it('detects Gemini-native data: streams', () => {
+    expect(isSseStream(GEMINI_STREAM)).toBe(true);
   });
 
   it('rejects plain JSON bodies, objects, and unrelated strings', () => {
@@ -261,6 +309,39 @@ describe('parseSseStream — OpenAI Responses API events', () => {
       'content',
       'finish',
     ]);
+  });
+});
+
+describe('parseSseStream — Gemini native events', () => {
+  const parsed = parseSseStream(GEMINI_STREAM);
+
+  it('assembles parts[].text into the visible final content', () => {
+    expect(parsed.assembled.protocol).toBe('gemini');
+    expect(parsed.assembled.content).toBe('Hello! I am Gemini.');
+    expect(parsed.assembled.reasoning).toBe('');
+  });
+
+  it('captures finishReason, usageMetadata and modelVersion', () => {
+    expect(parsed.assembled.finishReason).toBe('STOP');
+    expect(parsed.assembled.usage).toMatchObject({ totalTokenCount: 10372 });
+    expect(parsed.assembled.model).toBe('gemini-3.5-flash');
+  });
+
+  it('classifies each event for the chunk table', () => {
+    expect(parsed.events.map((e) => e.kind)).toEqual(['content', 'content', 'finish']);
+    expect(parsed.events[0]?.text).toBe('Hello!');
+    expect(parsed.events[2]?.text).toBe('STOP');
+  });
+
+  it('separates thought parts as reasoning and serializes functionCall args', () => {
+    const tools = parseSseStream(GEMINI_TOOL_STREAM);
+    expect(tools.assembled.reasoning).toBe('Need the weather.');
+    expect(tools.assembled.content).toBe('');
+    expect(tools.assembled.toolCalls).toEqual([
+      { id: null, name: 'get_weather', arguments: '{"city":"Paris"}' },
+    ]);
+    expect(tools.assembled.finishReason).toBe('STOP');
+    expect(tools.events.map((e) => e.kind)).toEqual(['reasoning', 'tool_call']);
   });
 });
 

--- a/apps/admin/src/lib/sse.ts
+++ b/apps/admin/src/lib/sse.ts
@@ -3,8 +3,10 @@
 // The payload store keeps streaming bodies verbatim (the raw `data:` wire text —
 // immutable source of truth, Principle 7). This module is the *view* layer's pure
 // counterpart: it never throws (fail-soft like JsonViewer), recomputes nothing the
-// gateway decided, and understands both client protocols the gateway speaks
-// (docs/05): OpenAI `chat.completion.chunk` and Anthropic `event:`-typed messages.
+// gateway decided, and understands every client protocol the gateway speaks
+// (docs/05): OpenAI `chat.completion.chunk`, OpenAI Responses `response.*`,
+// Anthropic `event:`-typed messages, and Gemini-native `candidates[].parts[]`
+// (a Gemini-CLI client talks this end-to-end; the gateway stores it verbatim).
 
 /** How a single SSE event participates in the stream, for the chunk table. */
 export type SseEventKind =
@@ -37,7 +39,7 @@ export interface AssembledToolCall {
 }
 
 export interface AssembledStream {
-  protocol: 'openai' | 'anthropic' | 'unknown';
+  protocol: 'openai' | 'anthropic' | 'gemini' | 'unknown';
   /** Concatenated reasoning/thinking deltas. */
   reasoning: string;
   /** Concatenated visible text deltas — the final answer. */
@@ -345,6 +347,62 @@ function consumeAnthropicEvent(
   }
 }
 
+/** Classify + accumulate one Gemini-native streamGenerateContent chunk.
+ * Gemini chunks carry no `type`/`event:` field — they are bare `data:` JSON with
+ * a `candidates[]` array whose `content.parts[]` hold text (`thought: true` marks
+ * reasoning), `functionCall` tool calls (args is an *object*, not a string), and
+ * the candidate's `finishReason`; usage is the top-level `usageMetadata`. */
+function consumeGeminiEvent(
+  payload: Record<string, unknown>,
+  acc: Accumulator,
+): Omit<SseEvent, 'index' | 'event' | 'data' | 'raw'> {
+  acc.assembled.protocol = 'gemini';
+  acc.assembled.model ??= str(payload.modelVersion);
+  if (payload.usageMetadata) mergeUsage(acc, payload.usageMetadata);
+
+  const candidate = asRecord((payload.candidates as unknown[] | undefined)?.[0]);
+  const parts = Array.isArray(asRecord(candidate?.content)?.parts)
+    ? (asRecord(candidate?.content)?.parts as unknown[])
+    : [];
+
+  // A chunk can carry several parts; accumulate all, then report the highest-
+  // priority kind for the chunk table (tool_call > reasoning > content).
+  let kind: SseEventKind | null = null;
+  let label = '';
+  for (const rawPart of parts) {
+    const part = asRecord(rawPart);
+    if (!part) continue;
+    const fnCall = asRecord(part.functionCall);
+    const text = str(part.text);
+    if (fnCall) {
+      const args = fnCall.args;
+      const call: AssembledToolCall = {
+        id: null,
+        name: str(fnCall.name) ?? '',
+        arguments: args === undefined ? '' : JSON.stringify(args),
+      };
+      acc.assembled.toolCalls.push(call);
+      kind = 'tool_call';
+      label = call.name;
+    } else if (part.thought === true && text !== null) {
+      acc.assembled.reasoning += text;
+      if (kind !== 'tool_call') kind = 'reasoning';
+      if (kind === 'reasoning') label = text;
+    } else if (text !== null) {
+      acc.assembled.content += text;
+      if (kind === null) kind = 'content';
+      if (kind === 'content') label = text;
+    }
+  }
+
+  const finish = str(candidate?.finishReason);
+  if (finish) acc.assembled.finishReason = finish;
+
+  if (kind) return { kind, text: label };
+  if (finish) return { kind: 'finish', text: finish };
+  return { kind: 'meta', text: '' };
+}
+
 /** Parse a raw SSE body into classified events + the assembled final message.
  * Never throws: broken lines become `other` events and assembly continues. */
 export function parseSseStream(raw: string): ParsedSseStream {
@@ -383,11 +441,18 @@ export function parseSseStream(raw: string): ParsedSseStream {
     // for Anthropic and render as "No visible output".
     const type = str(payload.type);
     const isResponsesEvent = type?.startsWith('response.') || wire.event?.startsWith('response.');
+    // Gemini native: bare `data:` JSON (no `type`, no `event:`) with a
+    // `candidates[]` array — route before the OpenAI fallback, which would find
+    // no `choices` and render "No visible output".
+    const isGeminiEvent =
+      type === null && wire.event === null && Array.isArray(payload.candidates);
     const consumed = isResponsesEvent
       ? consumeOpenAiResponseEvent(payload, acc)
-      : typeof payload.type === 'string' || wire.event !== null
-        ? consumeAnthropicEvent(payload, acc)
-        : consumeOpenAiChunk(payload, acc);
+      : isGeminiEvent
+        ? consumeGeminiEvent(payload, acc)
+        : typeof payload.type === 'string' || wire.event !== null
+          ? consumeAnthropicEvent(payload, acc)
+          : consumeOpenAiChunk(payload, acc);
     events.push({ ...base, ...consumed, data: payload });
   }
 


### PR DESCRIPTION
## 问题

请求 `ba4b5892` 的响应在管理界面显示为 *"No visible output (stream carried no text content)"*，但数据其实完好无损。

## 根因

Gemini-CLI 客户端端到端讲 Gemini 协议（请求是 `contents`/`parts`，流式响应是 `candidates[].content.parts[].text`）。网关原样存了下来，但 admin 的 SSE 解析器 `sse.ts` 只认三种格式：

- OpenAI `choices[].delta`
- OpenAI Responses `response.*`
- Anthropic `event:`-typed

Gemini 事件**既没有 `type` 也没有 `event:` 行**，于是落到 OpenAI 兜底分支 `consumeOpenAiChunk`——找不到 `choices` → content 为空 → 渲染成那句斜体提示。**消息从未丢失，只是读者听不懂那门语言。**

## 修复

新增 `consumeGeminiEvent` 分支，排在 OpenAI 兜底之前（`type === null && event === null && Array.isArray(candidates)`）：

| Gemini 字段 | 映射到 |
|---|---|
| `parts[].text` | content |
| `parts[].thought` | reasoning |
| `parts[].functionCall`（args 是对象 → `JSON.stringify`） | tool calls |
| candidate `finishReason` | finish |
| 顶层 `usageMetadata` | usage |
| `modelVersion` | model |

`StreamViewer.svelte` 基于 `assembled` 渲染，协议无关，无需改动即可正确显示。

## 验证

- `sse.test.ts` **21/21**（4 个新 Gemini case：文本拼装 / finish+usage+model / 事件分类 / thought+functionCall）
- admin 全量单测 **309/309**
- svelte-check 仅 3 个 `oauth.test.ts` 既有报错（与本次无关，`main` 上同样存在）

🤖 Generated with [Claude Code](https://claude.com/claude-code)