### PR TITLE
feat(admin): persist requests auto-refresh cadence across navigation

### DIFF
--- a/apps/admin/src/lib/components/RefreshControl.svelte
+++ b/apps/admin/src/lib/components/RefreshControl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import { t } from '$lib/i18n';
 
   // Split refresh control (Grafana-style): the left button refreshes the page
@@ -9,8 +9,13 @@
   // Stateless w.r.t. data — purely a trigger, so it stays reusable across pages.
   let {
     onRefresh,
+    storageKey,
   }: {
     onRefresh: () => void | Promise<void>;
+    // When set, the chosen cadence is persisted to localStorage under this key and
+    // restored on mount, so the setting survives navigation (e.g. opening a request
+    // detail and coming back). Omit it to keep the control purely in-memory/reusable.
+    storageKey?: string;
   } = $props();
 
   // Cadence choices in seconds (0 handled separately as "Off"). Labels are
@@ -57,12 +62,9 @@
     }
   }
 
-  // Apply a cadence: 0 stops auto-refresh, anything else (re)starts the timer.
-  // Selecting a cadence sets the rhythm only — the first tick fires one interval
-  // later, matching how monitoring dashboards behave (no surprise burst on pick).
-  function selectInterval(seconds: number): void {
-    intervalSeconds = seconds;
-    open = false;
+  // (Re)start the timer for the active cadence: 0 stops auto-refresh, anything
+  // else schedules ticks. First tick fires one interval later (no surprise burst).
+  function applyTimer(seconds: number): void {
     stopTimer();
     if (seconds > 0) {
       timer = setInterval(() => {
@@ -70,6 +72,50 @@
       }, seconds * 1000);
     }
   }
+
+  // Persist the cadence so it survives navigation. Best-effort: storage may be
+  // unavailable (private mode) — the setting still applies for the session.
+  function persist(seconds: number): void {
+    if (!storageKey || typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(storageKey, String(seconds));
+    } catch {
+      // ignore — auto-refresh keeps working without persistence
+    }
+  }
+
+  // Apply a cadence chosen from the menu: update state, restart the timer, persist.
+  function selectInterval(seconds: number): void {
+    intervalSeconds = seconds;
+    open = false;
+    applyTimer(seconds);
+    persist(seconds);
+  }
+
+  // Restore a saved cadence on mount and resume ticking. A missing/corrupt value
+  // (legacy, hand-edited, unknown option) is ignored — we stay Off rather than guess.
+  // `storageKey` is a fixed prop, so reading its initial value once (untrack) is the
+  // intent — this is a one-shot init, not a reactive effect. The read is best-effort:
+  // localStorage access can throw (private mode, or jsdom's opaque-origin stub), so a
+  // failure just leaves auto-refresh Off rather than breaking the whole page render.
+  untrack(() => {
+    if (!storageKey || typeof localStorage === 'undefined') return;
+    let saved: string | null = null;
+    try {
+      saved = localStorage.getItem(storageKey);
+    } catch {
+      return; // storage unavailable — stay Off for the session
+    }
+    if (saved === null) return;
+    const seconds = Number(saved);
+    if (
+      Number.isFinite(seconds) &&
+      (seconds === 0 || INTERVALS.some((o) => o.seconds === seconds))
+    ) {
+      intervalSeconds = seconds;
+      applyTimer(seconds);
+    }
+  });
 
   // Close the menu on any pointer-down outside the control (click-outside).
   function onWindowPointerDown(event: PointerEvent): void {

--- a/apps/admin/src/lib/components/RefreshControl.test.ts
+++ b/apps/admin/src/lib/components/RefreshControl.test.ts
@@ -88,4 +88,68 @@ describe('RefreshControl', () => {
     await vi.advanceTimersByTimeAsync(30_000);
     expect(onRefresh).not.toHaveBeenCalled();
   });
+
+  // When a storageKey is supplied the chosen cadence survives navigation: it is
+  // written to localStorage on every pick and restored (timer resumed) on mount,
+  // so leaving for a detail page and coming back keeps auto-refresh running.
+  describe('persistence (storageKey)', () => {
+    const KEY = 'helm_admin_requests_refresh_interval';
+
+    // jsdom's localStorage is non-functional under the opaque `about:blank`
+    // origin this suite runs in (methods are undefined), so install a real
+    // in-memory Storage on the global — same approach as github.test.ts.
+    beforeEach(() => {
+      const map = new Map<string, string>();
+      vi.stubGlobal('localStorage', {
+        getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+        setItem: (k: string, v: string) => void map.set(k, String(v)),
+        removeItem: (k: string) => void map.delete(k),
+        clear: () => map.clear(),
+        key: (i: number) => [...map.keys()][i] ?? null,
+        get length() {
+          return map.size;
+        },
+      } as Storage);
+    });
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('persists the selected cadence to localStorage', async () => {
+      render(RefreshControl, { onRefresh: vi.fn(), storageKey: KEY });
+      await fireEvent.click(screen.getByTestId('refresh-toggle'));
+      await fireEvent.click(screen.getByTestId('refresh-interval-30'));
+      expect(localStorage.getItem(KEY)).toBe('30');
+    });
+
+    it('persists Off (0) when auto-refresh is turned off', async () => {
+      render(RefreshControl, { onRefresh: vi.fn(), storageKey: KEY });
+      await fireEvent.click(screen.getByTestId('refresh-toggle'));
+      await fireEvent.click(screen.getByTestId('refresh-interval-30'));
+      await fireEvent.click(screen.getByTestId('refresh-toggle'));
+      await fireEvent.click(screen.getByTestId('refresh-interval-off'));
+      expect(localStorage.getItem(KEY)).toBe('0');
+    });
+
+    it('restores the saved cadence on mount and resumes ticking', async () => {
+      localStorage.setItem(KEY, '5');
+      const onRefresh = vi.fn();
+      render(RefreshControl, { onRefresh, storageKey: KEY });
+      // Cadence reflected immediately, timer already running.
+      expect(screen.getByTestId('refresh-active')).toHaveTextContent('5s');
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores a corrupt / unknown stored value', async () => {
+      localStorage.setItem(KEY, 'not-a-number');
+      render(RefreshControl, { onRefresh: vi.fn(), storageKey: KEY });
+      expect(screen.queryByTestId('refresh-active')).not.toBeInTheDocument();
+    });
+
+    it('does not persist when no storageKey is given', async () => {
+      render(RefreshControl, { onRefresh: vi.fn() });
+      await fireEvent.click(screen.getByTestId('refresh-toggle'));
+      await fireEvent.click(screen.getByTestId('refresh-interval-30'));
+      expect(localStorage.getItem(KEY)).toBeNull();
+    });
+  });
 });

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -152,7 +152,10 @@
     <!-- Refresh now + auto-refresh cadence. Re-runs the loader (invalidateAll),
          which re-reads the URL filters and refetches the current page. -->
     <div class="shrink-0">
-      <RefreshControl onRefresh={() => invalidateAll()} />
+      <RefreshControl
+        onRefresh={() => invalidateAll()}
+        storageKey="helm_admin_requests_refresh_interval"
+      />
     </div>
   </header>
 


### PR DESCRIPTION
## What

The `/admin/requests` auto-refresh cadence now survives navigation. Pick a cadence, open a request detail, come back — it's still ticking, no re-pick needed.

## Why

`RefreshControl` held the chosen cadence purely in memory, so leaving the requests list and returning remounted it fresh at **Off**, forcing a manual re-pick every time.

## How

- Added an optional `storageKey` prop to `RefreshControl`: when set, the cadence is written to `localStorage` on every pick and restored (timer resumed) on mount. Without a key the control stays purely in-memory/reusable.
- All storage access is best-effort (`try/catch`) — private-mode or opaque-origin failures leave it Off rather than breaking the page render.
- The requests page passes `helm_admin_requests_refresh_interval`, matching the existing i18n locale storage convention.
- Chose **localStorage over Cookie**: it's the established pattern here (i18n locale uses the same SSR-safe shape) and the cadence is a pure client-side preference that never needs to reach the server.

## Tests

- Added 5 persistence cases to `RefreshControl.test.ts` (persist on pick, persist Off, restore + resume ticking, ignore corrupt value, no-op without key). jsdom's opaque-origin `localStorage` is non-functional, so the suite stubs a real in-memory `Storage` — same approach `github.test.ts` already uses.
- `RefreshControl.test.ts`: 12/12 ✓ · full admin suite: 309/309 ✓ · prettier clean ✓

> Pre-existing (not touched by this PR): `svelte-check` reports 3 tuple-index errors in `oauth.test.ts`, already present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)