### PR TITLE
feat(admin): show key name in requests list when set

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -75,6 +75,18 @@ describe('toListItem', () => {
     expect(row.key_prefix).toBe('—');
   });
 
+  it('reads the resolved key_name when present; null (with prefix kept) when absent/empty', () => {
+    expect(toListItem(rawRecord({ key_name: 'Production backend' })).key_name).toBe(
+      'Production backend',
+    );
+    // Prefix is still carried so the view can fall back to it.
+    const named = toListItem(rawRecord({ key_name: 'Mobile app' }));
+    expect(named.key_prefix).toBe('helm_live_ab12');
+    // Unnamed key (or legacy record) → null, never an empty-string label.
+    expect(toListItem(rawRecord()).key_name).toBeNull();
+    expect(toListItem(rawRecord({ key_name: '' })).key_name).toBeNull();
+  });
+
   it('maps the recorded created_at (epoch ms) to an ISO ts; legacy records stay empty', () => {
     const row = toListItem(rawRecord({ created_at: 1717155600000 }));
     expect(row.ts).toBe(new Date(1717155600000).toISOString());

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -29,6 +29,10 @@ export interface RequestListItem {
   trace_id: string;
   ts: string; // timestamp
   key_prefix: string; // display prefix only — NEVER plaintext
+  // Operator-assigned key NAME, resolved by the backend (api_key_id -> keystore).
+  // null when the key is unnamed (or was since deleted) — the view then falls back
+  // to key_prefix. Cosmetic label only, never key material (Principle 7).
+  key_name: string | null;
   user_id?: string;
   org_id?: string;
   requested_model: string | null;
@@ -146,6 +150,9 @@ interface RawDecisionRecord {
   // Display prefix only (helm_live_ab12) — the record NEVER carries the plaintext
   // key (Principle 7). Null/absent on legacy (pre-enrichment) records.
   key_prefix?: string | null;
+  // Operator-assigned key name, joined onto the row by GET /admin/api/requests
+  // (api_key_id -> keystore). Absent/null when the key is unnamed or was deleted.
+  key_name?: string | null;
   // Enriched telemetry (admin.requests-richfields): Σ attempt latency, execution
   // fallback count, and the eval/completion cost split. Absent on legacy records.
   latency_total_ms?: number;
@@ -273,6 +280,9 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     // plaintext key (Principle 7). '—' when the record carries none (legacy / unknown).
     key_prefix:
       typeof raw.key_prefix === 'string' && raw.key_prefix.length > 0 ? raw.key_prefix : '—',
+    // The key's display NAME when the backend resolved one; null lets the view fall
+    // back to the prefix (so an unnamed/deleted key still renders something).
+    key_name: typeof raw.key_name === 'string' && raw.key_name.length > 0 ? raw.key_name : null,
     requested_model: raw.requested_model ?? null,
     task_type: raw.classifier?.task_type ?? '',
     complexity: raw.classifier?.complexity ?? '',

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -332,7 +332,16 @@
               </td>
               <td class="px-3 py-2 text-ink-body">{formatTs(r.ts)}</td>
               <td class="px-3 py-2">
-                <code class="font-mono text-ink-strong">{r.key_prefix}</code>
+                {#if r.key_name}
+                  <!-- Operator-assigned NAME when the key has one — far more
+                       recognizable than the opaque prefix. The prefix follows as
+                       a muted subtitle so the row is still traceable to the key. -->
+                  <span class="text-ink-strong" title={r.key_prefix}>{r.key_name}</span>
+                  <code class="block font-mono text-xs text-ink-muted">{r.key_prefix}</code>
+                {:else}
+                  <!-- Unnamed (or deleted) key — fall back to the prefix as before. -->
+                  <code class="font-mono text-ink-strong">{r.key_prefix}</code>
+                {/if}
               </td>
               <td class="px-3 py-2 text-ink-body">{r.requested_model ?? '—'}</td>
               <td class="px-3 py-2 text-ink-body">{r.task_type || '—'}</td>

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -21,6 +21,7 @@ function item(traceId: string, overrides: Partial<RequestListItem> = {}): Reques
     trace_id: traceId,
     ts: '2026-05-31T10:00:00Z',
     key_prefix: 'helm_live_ab12',
+    key_name: null,
     requested_model: 'gpt-4o',
     task_type: 'coding',
     complexity: 'high',
@@ -122,6 +123,22 @@ describe('requests list page', () => {
     expect(rows[1]).toHaveTextContent('all_providers_failed');
     // No plaintext-like long secret anywhere.
     expect(document.body.textContent ?? '').not.toMatch(/helm_live_[A-Za-z0-9]{16,}/);
+  });
+
+  it('shows the key NAME when set (prefix as a subtitle), and the bare prefix when unnamed', () => {
+    render(ListPage, {
+      data: listData([
+        item('tr_named', { key_name: 'Production backend' }),
+        item('tr_unnamed', { key_name: null }),
+      ]),
+    });
+    const rows = screen.getAllByTestId('request-row');
+    // Named key: the recognizable name shows, with the prefix still present for traceability.
+    expect(rows[0]).toHaveTextContent('Production backend');
+    expect(rows[0]).toHaveTextContent('helm_live_ab12');
+    // Unnamed key: only the prefix (no stray name).
+    expect(rows[1]).toHaveTextContent('helm_live_ab12');
+    expect(rows[1]).not.toHaveTextContent('Production backend');
   });
 
   it('labels the decision layer distinctly for rules / eval / default', () => {

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -149,6 +149,7 @@ function makeTelemetry(seed: DecisionRecord[] = []): TelemetryStore {
       const stamped = rows.map((record, i) => ({
         record,
         createdAt: new Date(1_700_000_000_000 - i * 1000),
+        apiKeyId: "k1",
       }));
       const m = query.model?.toLowerCase();
       const matched = stamped.filter(({ record, createdAt }) => {
@@ -839,6 +840,33 @@ describe("admin.api requests", () => {
     expect(p2.page).toBe(2);
     expect(p2.pageSize).toBe(2);
     expect(p2.items.map((r) => r.trace_id)).toEqual(["ok-2"]);
+  });
+
+  it("resolves each row's api_key_id to the key's name (falls back to prefix when unnamed/deleted)", async () => {
+    const deps = buildDeps({ telemetry: makeTelemetry([decision("trace-1", "premium")]) });
+    // The fake telemetry records every row under api_key_id "k1"; give that key a
+    // human name so the route surfaces it for the SPA. A second, differently-id'd
+    // key proves we join by the RECORDED id, not just "any name".
+    await deps.keyStore.createKey({
+      keyId: "k1",
+      hash: "h_named",
+      prefix: "helm_live_aaaa",
+      accountId: "acct",
+      role: "user",
+      name: "Production backend",
+    });
+    const app = buildApp(deps);
+    const named = (await (await app.request("/admin/api/requests")).json()) as {
+      items: Array<{ key_name: string | null }>;
+    };
+    expect(named.items[0]?.key_name).toBe("Production backend");
+
+    // An UNNAMED key (or one since deleted) → key_name null, so the SPA shows the prefix.
+    const depsUnnamed = buildDeps({ telemetry: makeTelemetry([decision("trace-2", "premium")]) });
+    const unnamed = (await (
+      await buildApp(depsUnnamed).request("/admin/api/requests")
+    ).json()) as { items: Array<{ key_name: string | null }> };
+    expect(unnamed.items[0]?.key_name).toBeNull();
   });
 
   it("fails open on a malformed query (never 5xx) and serves page 1", async () => {

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -863,9 +863,9 @@ describe("admin.api requests", () => {
 
     // An UNNAMED key (or one since deleted) → key_name null, so the SPA shows the prefix.
     const depsUnnamed = buildDeps({ telemetry: makeTelemetry([decision("trace-2", "premium")]) });
-    const unnamed = (await (
-      await buildApp(depsUnnamed).request("/admin/api/requests")
-    ).json()) as { items: Array<{ key_name: string | null }> };
+    const unnamed = (await (await buildApp(depsUnnamed).request("/admin/api/requests")).json()) as {
+      items: Array<{ key_name: string | null }>;
+    };
     expect(unnamed.items[0]?.key_name).toBeNull();
   });
 

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -38,8 +38,21 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
       lane: q.lane,
       model: q.model,
     });
+    // Resolve each row's recorded api_key_id (key_id) to the key's human NAME so the
+    // SPA can show a recognizable label instead of the opaque prefix. The redacted
+    // DecisionRecord deliberately omits the key_id (it carries only key_prefix), so the
+    // store surfaces it per page row; we join it to the keystore HERE (the route owns
+    // keyStore — core stays headless, Principle 1). One list() per page, not per row.
+    // The name is cosmetic (no key material — Principle 7); null when the key is
+    // unnamed OR was since deleted, so the SPA falls back to the prefix.
+    const keys = await deps.keyStore.list();
+    const nameById = new Map(keys.map((k) => [k.key_id, k.name]));
     return c.json({
-      items: rows.map((r) => ({ ...r.record, created_at: r.createdAt.getTime() })),
+      items: rows.map((r) => ({
+        ...r.record,
+        created_at: r.createdAt.getTime(),
+        key_name: nameById.get(r.apiKeyId) ?? null,
+      })),
       total,
       page: q.page,
       pageSize: q.pageSize,

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -114,7 +114,7 @@ class InMemoryTelemetryStore implements TelemetryStore {
     const rows = matched
       .sort((a, b) => b.at.getTime() - a.at.getTime())
       .slice(query.offset, query.offset + query.limit)
-      .map((r) => ({ record: r.rec, createdAt: r.at }));
+      .map((r) => ({ record: r.rec, createdAt: r.at, apiKeyId: r.keyId }));
     return { rows, total: matched.length };
   }
   async getByRequestId(requestId: string): Promise<DecisionRecord | null> {

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -244,10 +244,19 @@ export interface TelemetryPageQuery {
   model?: string;
 }
 
+// One queryPage row: a recent decision record + the recorded api_key_id (key_id).
+// queryRecent's RecentDecisionRecord deliberately omits the key id (no consumer
+// needs it); the admin Debug list does — it resolves the key's human NAME for
+// display by joining this id to the keystore in the route (core stays headless,
+// Principle 1). key_id only — never a hash/plaintext (Principle 7).
+export interface TelemetryPageRow extends RecentDecisionRecord {
+  apiKeyId: string;
+}
+
 // One page of decision rows + the TOTAL matching the same filters (NOT just this
 // page) so the UI can render "Page X of Y" without a second round-trip.
 export interface TelemetryPage {
-  rows: RecentDecisionRecord[];
+  rows: TelemetryPageRow[];
   total: number;
 }
 

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -85,7 +85,11 @@ export class PgTelemetryStore implements TelemetryStore {
       .offset(query.offset);
     const totalRows = await this.db.select({ value: count() }).from(telemetry).where(where);
     return {
-      rows: rows.map((r) => ({ record: this.toDecision(r), createdAt: new Date(r.createdAt) })),
+      rows: rows.map((r) => ({
+        record: this.toDecision(r),
+        createdAt: new Date(r.createdAt),
+        apiKeyId: r.apiKeyId,
+      })),
       total: totalRows[0]?.value ?? 0,
     };
   }

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -168,8 +168,16 @@ describe("SqliteTelemetryStore", () => {
 
   it("surfaces the recorded api_key_id on each page row (for key-name resolution)", async () => {
     const store = freshStore();
-    await store.insert({ decision: decision("a"), apiKeyId: "key_alpha", createdAt: new Date(2000) });
-    await store.insert({ decision: decision("b"), apiKeyId: "key_beta", createdAt: new Date(1000) });
+    await store.insert({
+      decision: decision("a"),
+      apiKeyId: "key_alpha",
+      createdAt: new Date(2000),
+    });
+    await store.insert({
+      decision: decision("b"),
+      apiKeyId: "key_beta",
+      createdAt: new Date(1000),
+    });
     const page = await store.queryPage({ limit: 50, offset: 0 });
     // The redacted record carries only key_prefix; the page row exposes the
     // canonical api_key_id so the admin route can join it to the key's name.

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -166,6 +166,19 @@ describe("SqliteTelemetryStore", () => {
     expect(page3.rows.map((r) => r.record.request_id)).toEqual(["r0"]);
   });
 
+  it("surfaces the recorded api_key_id on each page row (for key-name resolution)", async () => {
+    const store = freshStore();
+    await store.insert({ decision: decision("a"), apiKeyId: "key_alpha", createdAt: new Date(2000) });
+    await store.insert({ decision: decision("b"), apiKeyId: "key_beta", createdAt: new Date(1000) });
+    const page = await store.queryPage({ limit: 50, offset: 0 });
+    // The redacted record carries only key_prefix; the page row exposes the
+    // canonical api_key_id so the admin route can join it to the key's name.
+    expect(page.rows.map((r) => [r.record.request_id, r.apiKeyId])).toEqual([
+      ["a", "key_alpha"],
+      ["b", "key_beta"],
+    ]);
+  });
+
   it("filters by status using the denormalized final_status column", async () => {
     const store = freshStore();
     await seed(store, "ok1", 1000, { status: "ok" });

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -86,7 +86,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
       .limit(query.limit)
       .offset(query.offset)
       .all()
-      .map((r) => ({ record: this.toDecision(r), createdAt: r.createdAt }));
+      .map((r) => ({ record: this.toDecision(r), createdAt: r.createdAt, apiKeyId: r.apiKeyId }));
     const totalRow = this.db.select({ value: count() }).from(telemetry).where(where).get();
     return { rows, total: totalRow?.value ?? 0 };
   }


### PR DESCRIPTION
## What

The Debug requests list rendered each row's key by its opaque prefix (`helm_live_ab12`). Now, when a key has an operator-assigned **name**, the row shows that name with the prefix as a muted subtitle; unnamed (or deleted) keys still fall back to the bare prefix.

![requests list now shows the key name](https://github.com/EasyMetaAu/helm-api/assets/placeholder)

## How (5 layers, minimal)

The join is by the canonical **`api_key_id`** (the telemetry column), **not** the 4-char `key_prefix` on the wire — the prefix can collide between two keys, which is exactly the ambiguity names exist to resolve. The redacted `DecisionRecord` omits the key_id, so it is threaded onto `queryPage` rows and resolved to the name in the gateway route.

1. **Port** (`ports.ts`): new `TelemetryPageRow extends RecentDecisionRecord` with `apiKeyId` — surfaced on `queryPage` rows only (`queryRecent` untouched).
2. **Adapters** (`sqlite/telemetry.ts`, `postgres/telemetry.ts`): expose `r.apiKeyId` on each page row (column already selected).
3. **Route** (`admin/requests.ts`): build a `key_id → name` map from `keyStore.list()` (one call per page) and attach `key_name` (null when unnamed/deleted). The route owns `keyStore`, so core stays headless (Principle 1); the name is cosmetic — no key material (Principle 7).
4. **API client** (`admin/src/lib/api/requests.ts`): `key_name` added to `RequestListItem` + `RawDecisionRecord` + `toListItem` (empty → null).
5. **SPA** (`requests/+page.svelte`): renders name-or-prefix.

No migration/backfill needed — existing telemetry rows already store `api_key_id`, so historical requests get names too. Only rows whose key was since deleted stay on the prefix (correct — there's no name to show).

## Tests (TDD, red→green)

| Check | Result |
|---|---|
| Core + gateway targeted (telemetry, ports, store-contract, admin) | **178 passed** |
| Admin SPA (requests client + page) | **35 passed** |
| `pnpm typecheck` (shared/core/gateway, incl. tests) | **green** |

New coverage: store surfacing `apiKeyId`, route resolving name vs. null fallback, client mapping, SPA showing name+prefix vs. bare prefix.

The 3 `svelte-check` errors in `oauth.test.ts` are pre-existing and unrelated (0 oauth files changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)