### PR TITLE
chore(release): v0.11.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.11.6 — bumps root `package.json`; `publish.yml` auto-cuts tag `v0.11.6` + GitHub Release + GHCR `:0.11.6`/`:latest`.

## Changes since v0.11.5
- fix: anthropic MCP tool names (#189)
- fix(admin): make Retry work for all four client protocols (#188)
- feat(admin): show key name in requests list when set (#187)
- feat(admin): persist requests auto-refresh cadence across navigation (#186)
- fix(admin): render Gemini-native SSE in the payload viewer (#185)

🤖 Generated with [Claude Code](https://claude.com/claude-code)