### PR TITLE
chore(release): v0.11.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.11.7. Includes #191 (render base64 images in request payload preview).

Bumps root `package.json` 0.11.6 → 0.11.7. On merge, `publish.yml` auto-cuts tag `v0.11.7` + GitHub Release + `ghcr.io/easymetaau/helm-api:0.11.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)