### PR TITLE
chore(release): v0.11.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.11.8 — patch (admin-only).

## Changes since v0.11.7
- feat(admin): add zoom controls to image preview (#193)

Version bump only; `publish.yml` will auto-cut tag `v0.11.8` + GitHub Release + GHCR `:0.11.8`/`:latest` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)