### PR TITLE
fix(admin): open image in new tab no longer blank

### DIFF
--- a/apps/admin/src/lib/components/ImagePreview.svelte
+++ b/apps/admin/src/lib/components/ImagePreview.svelte
@@ -67,8 +67,12 @@
   // pop a blank window and drop the decoded <img> into it rather than linking the
   // data: URL directly (which would just be blocked or download).
   function openInNewTab(): void {
-    const win = window.open('', '_blank', 'noopener,noreferrer');
+    // NB: do NOT pass `noopener` — a no-opener window is spec'd to return null, which
+    // would leave us no handle to write the <img> into and the tab would stay blank.
+    // We sever `opener` ourselves instead; the page only ever shows our own data: URL.
+    const win = window.open('', '_blank');
     if (!win) return;
+    win.opener = null;
     win.document.title = label ?? 'image';
     win.document.body.style.margin = '0';
     win.document.body.style.background = '#0b0b0b';

--- a/apps/admin/src/lib/components/ImagePreview.test.ts
+++ b/apps/admin/src/lib/components/ImagePreview.test.ts
@@ -90,6 +90,10 @@ describe('ImagePreview', () => {
     await fireEvent.click(screen.getByTestId('image-preview-open-tab'));
 
     expect(openSpy).toHaveBeenCalledOnce();
+    // Must NOT pass `noopener`: a no-opener window is spec'd to return null, so we'd
+    // never get the handle needed to write the <img> — the tab would stay blank.
+    const features = openSpy.mock.calls[0][2] ?? '';
+    expect(features).not.toContain('noopener');
     expect(appended).toHaveLength(1);
     expect(appended[0].src).toBe(SRC);
     openSpy.mockRestore();


### PR DESCRIPTION
## Problem

Clicking **Open in new tab** in the image preview opened a blank tab with no content.

## Root cause

`apps/admin/src/lib/components/ImagePreview.svelte`

```js
const win = window.open('', '_blank', 'noopener,noreferrer');
```

Per the HTML spec, `window.open` returns **`null` whenever `noopener` is set** — a no-opener window intentionally gives no handle back. So `win` was always `null`, `if (!win) return` fired immediately, and the code that writes the `<img>` never ran → blank tab.

The original test didn't catch this because it **mocked** `window.open` to return a fake window, hiding the real null return.

## Fix

- Drop `noopener,noreferrer` so we actually receive the window handle.
- Sever `opener` manually (`win.opener = null`) instead — safe, since the page only ever shows our own `data:` URL.
- Add a regression assertion pinning the contract: `window.open` must not be called with `noopener`.

## Test

`pnpm vitest run src/lib/components/ImagePreview.test.ts` → 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)