### PR TITLE
chore(release): v0.11.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.11.9.

## Included since v0.11.8

- fix(admin): open image in new tab no longer blank (#195) — `window.open` with `noopener` is spec'd to return `null`, leaving no handle to write the `<img>` into, so the tab stayed blank. Drop `noopener,noreferrer`, sever `opener` manually.

Admin-only fix → patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)