### PR TITLE
fix(protocol): align LiteLLM-compatible route surfaces

### DIFF
--- a/apps/gateway/e2e/eval.spec.ts
+++ b/apps/gateway/e2e/eval.spec.ts
@@ -70,7 +70,7 @@ function ambiguous(tag: string): string {
 }
 
 function chat(content: string, extra: Record<string, unknown> = {}) {
-  return { model: "gpt-4o-mini", messages: [{ role: "user", content }], stream: false, ...extra };
+  return { model: "auto", messages: [{ role: "user", content }], stream: false, ...extra };
 }
 
 // Read + reset the mock's eval-endpoint call counter (the hardest external

--- a/apps/gateway/e2e/gemini.spec.ts
+++ b/apps/gateway/e2e/gemini.spec.ts
@@ -59,6 +59,22 @@ test.describe("Gemini client → upstream", () => {
     expect(upstream.body.model).not.toBe("gemini");
   });
 
+  test("LiteLLM-compatible /models alias accepts path-style model names", async ({ request }) => {
+    const res = await request.post("/models/google/gemini-2.5-pro:generateContent", {
+      headers: GEMINI_AUTH,
+      data: {
+        contents: [{ role: "user", parts: [{ text: "translate this sentence to french: hello" }] }],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.candidates[0].content.role).toBe("model");
+
+    const upstream = await lastUpstreamRequest(request);
+    expect(Array.isArray(upstream.body.messages)).toBeTruthy();
+    expect(upstream.body.model).not.toBe("gemini");
+  });
+
   test("stream: alt=sse emits snapshot data frames with NO event: name and NO [DONE]", async ({
     request,
   }) => {
@@ -86,6 +102,21 @@ test.describe("Gemini client → upstream", () => {
     expect(text).toContain("candidates");
     // the terminal snapshot carries the mapped finishReason.
     expect(text).toContain("STOP");
+  });
+
+  test("streamGenerateContent streams even without alt=sse", async ({ request }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:streamGenerateContent", {
+      headers: GEMINI_AUTH,
+      data: {
+        contents: [{ role: "user", parts: [{ text: "translate this sentence to french: hola" }] }],
+      },
+    });
+    expect(res.ok()).toBeTruthy();
+    expect(res.headers()["content-type"]).toContain("text/event-stream");
+    const text = await res.text();
+    expect(text).toContain("data:");
+    expect(text).toContain("candidates");
+    expect(text).not.toContain("[DONE]");
   });
 
   test("tool-call: upstream function call → client sees a functionCall part", async ({

--- a/apps/gateway/e2e/protocol.spec.ts
+++ b/apps/gateway/e2e/protocol.spec.ts
@@ -138,6 +138,31 @@ test.describe("OpenAI client → upstream", () => {
     expect(typeof body.choices[0].message.content).toBe("string");
   });
 
+  test("LiteLLM aliases: /chat/completions and engine path model override", async ({ request }) => {
+    const aliasRes = await request.post("/chat/completions", {
+      headers: OPENAI_AUTH,
+      data: {
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "translate this sentence to french: hello" }],
+        stream: false,
+      },
+    });
+    expect(aliasRes.ok()).toBeTruthy();
+    expect((await aliasRes.json()).choices[0].message.role).toBe("assistant");
+
+    const engineRes = await request.post("/engines/gpt-5.4-mini/chat/completions", {
+      headers: OPENAI_AUTH,
+      data: {
+        model: "ignored-body-model",
+        messages: [{ role: "user", content: "translate this sentence to french: hello" }],
+        stream: false,
+      },
+    });
+    expect(engineRes.ok()).toBeTruthy();
+    const upstream = await lastUpstreamRequest(request);
+    expect(upstream.body.model).toBe("deepseek-v4-flash");
+  });
+
   test("stream: first chunk carries role, last carries finish_reason, ends [DONE]", async ({
     request,
   }) => {
@@ -249,6 +274,23 @@ test.describe("OpenAI Responses client → upstream (streaming)", () => {
     expect(doneText).toBe(deltas);
   });
 
+  test("create aliases /responses and /openai/v1/responses are accepted", async ({ request }) => {
+    for (const path of ["/responses", "/openai/v1/responses"]) {
+      const res = await request.post(path, {
+        headers: OPENAI_AUTH,
+        data: {
+          model: "auto",
+          input: "translate this sentence to french: hello",
+          stream: false,
+        },
+      });
+      expect(res.ok()).toBeTruthy();
+      const body = await res.json();
+      expect(body.object).toBe("response");
+      expect(body.status).toBe("completed");
+    }
+  });
+
   test("tool-call stream: function_call item + arguments deltas", async ({ request }) => {
     const res = await request.post("/v1/responses", {
       headers: OPENAI_AUTH,
@@ -336,5 +378,29 @@ test.describe("bidirectional isomorphism", () => {
     // Anthropic-shaped error envelope.
     expect(body.type).toBe("error");
     expect(body.error.type).toBe("authentication_error");
+  });
+
+  test("Anthropic compatibility helpers are authenticated and protocol-shaped", async ({
+    request,
+  }) => {
+    const eventLog = await request.post("/api/event_logging/batch", {
+      headers: ANTHROPIC_AUTH,
+      data: { events: [{ type: "client_event" }] },
+    });
+    expect(eventLog.ok()).toBeTruthy();
+    expect(await eventLog.json()).toEqual({ status: "ok" });
+
+    const count = await request.post("/v1/messages/count_tokens", {
+      headers: ANTHROPIC_AUTH,
+      data: {
+        model: "claude-3-5-sonnet",
+        max_tokens: 64,
+        messages: [{ role: "user", content: "translate this sentence to french: hello" }],
+      },
+    });
+    expect(count.ok()).toBeTruthy();
+    const body = (await count.json()) as { input_tokens?: number };
+    expect(typeof body.input_tokens).toBe("number");
+    expect(body.input_tokens).toBeGreaterThan(0);
   });
 });

--- a/apps/gateway/e2e/routing.spec.ts
+++ b/apps/gateway/e2e/routing.spec.ts
@@ -48,7 +48,7 @@ const ECONOMY_NEXT_WIRE = "deepseek-v4-pro";
 
 function chat(content: string, extra: Record<string, unknown> = {}) {
   return {
-    model: "gpt-4o-mini",
+    model: "auto",
     messages: [{ role: "user", content }],
     stream: false,
     ...extra,

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -115,7 +115,9 @@ function buildApp(
   const getByHash = vi
     .fn()
     .mockResolvedValue(opts.authed === false ? null : keyRecord(opts.record ?? {}));
-  app.use("/v1/*", authMiddleware({ keyStore: { getByHash }, log: () => {} }));
+  for (const pattern of ["/v1/*", "/chat/*", "/engines/*", "/openai/deployments/*"]) {
+    app.use(pattern, authMiddleware({ keyStore: { getByHash }, log: () => {} }));
+  }
   registerChatRoutes(app, d);
   return app;
 }
@@ -283,6 +285,57 @@ describe("POST /v1/chat/completions (routing pipeline)", () => {
     const plan = harness.execute.mock.calls[0]?.[0] as ExecutionPlan;
     expect(plan.selected_lane).toBe("balanced");
     expect(harness.log).toHaveBeenCalledOnce();
+  });
+
+  it("accepts the LiteLLM-compatible /chat/completions alias", async () => {
+    const upstream = { id: "cmpl-1", choices: [{ message: { content: "hello" } }] };
+    const { deps: d, harness } = deps();
+    harness.execute.mockResolvedValue(nonStreamOutcome(upstream));
+    const app = buildApp(d);
+
+    const res = await app.request("/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(upstream);
+    expect(harness.execute).toHaveBeenCalledOnce();
+  });
+
+  it("uses the /engines/{model}/chat/completions path model as the effective request model", async () => {
+    const { deps: d, harness } = deps();
+    harness.execute.mockResolvedValue(nonStreamOutcome({ ok: true }));
+    const app = buildApp(d, { record: { allow_custom_model: true } });
+
+    const res = await app.request("/engines/openai/gpt-4.1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...NONSTREAM_BODY, model: "ignored-body-model" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(harness.classify).not.toHaveBeenCalled();
+    const plan = harness.execute.mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.candidate_chain).toEqual(["openai/gpt-4.1"]);
+  });
+
+  it("uses the Azure /openai/deployments/{model}/chat/completions path model", async () => {
+    const { deps: d, harness } = deps();
+    harness.execute.mockResolvedValue(nonStreamOutcome({ ok: true }));
+    const app = buildApp(d, { record: { allow_custom_model: true } });
+
+    const res = await app.request("/openai/deployments/azure-gpt-4o/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...NONSTREAM_BODY, model: "ignored-body-model" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(harness.classify).not.toHaveBeenCalled();
+    const plan = harness.execute.mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.candidate_chain).toEqual(["azure-gpt-4o"]);
   });
 
   it("keeps SSE end-to-end for stream:true and ends with [DONE]", async () => {

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -28,7 +28,7 @@ import {
   makeHelmError,
   OpenAIChatRequestSchema,
 } from "@helm/shared";
-import type { Hono } from "hono";
+import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../app.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
@@ -321,7 +321,7 @@ function flushOpenAIChunk(buffer: SSEAccumulator): void {
 }
 
 export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void {
-  app.post("/v1/chat/completions", async (c) => {
+  const handleChat = async (c: Context<AppEnv>, pathModel?: string) => {
     const traceId = c.get("trace_id");
     const identity = c.get("identity") as unknown as ChatIdentity;
 
@@ -337,6 +337,9 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       raw = JSON.parse(requestJson);
     } catch {
       throw invalidRequest("malformed JSON request body", traceId);
+    }
+    if (pathModel !== undefined && raw !== null && typeof raw === "object") {
+      raw = { ...(raw as Record<string, unknown>), model: decodeURIComponent(pathModel) };
     }
     const parsed = OpenAIChatRequestSchema.safeParse(raw);
     if (!parsed.success) {
@@ -759,5 +762,12 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     // tokens from the body's usage. Fail-open.
     await settle(result.decision, tokensFromUsage(usageFromBody(result.body)));
     return c.json(result.body as Record<string, unknown>);
-  });
+  };
+
+  app.post("/v1/chat/completions", (c) => handleChat(c));
+  app.post("/chat/completions", (c) => handleChat(c));
+  app.post("/engines/:model{.+}/chat/completions", (c) => handleChat(c, c.req.param("model")));
+  app.post("/openai/deployments/:model{.+}/chat/completions", (c) =>
+    handleChat(c, c.req.param("model")),
+  );
 }

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -181,6 +181,20 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     expect(harness.pipelineSawIR?.model).toBe("gemini-1.5-pro");
   });
 
+  it("accepts the LiteLLM-compatible /models alias and path-style model names", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/models/google/gemini-2.5-pro:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(harness.pipelineSawIR?.model).toBe("google/gemini-2.5-pro");
+  });
+
   it("prefers x-goog-api-key but falls back to Authorization: Bearer", async () => {
     const { deps, harness } = makeDeps();
     const app = buildApp(deps);
@@ -464,6 +478,27 @@ describe("POST /v1beta/models/{model}:streamGenerateContent?alt=sse (Gemini stre
     expect(text).not.toContain("[DONE]");
     // Each frame is a full snapshot; the final carries finishReason.
     expect(text).toContain("STOP");
+  });
+
+  it("treats streamGenerateContent without alt=sse as streaming", async () => {
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield { candidates: [{ content: { role: "model", parts: [{ text: "Hel" }] } }] };
+      yield {
+        candidates: [{ content: { role: "model", parts: [{ text: "lo" }] }, finishReason: "STOP" }],
+      };
+    }
+    const { deps, harness } = makeDeps({ streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    expect(harness.pipelineSawIR?.stream).toBe(true);
   });
 
   it("passes the abort signal to the pipeline and emits NO error frame on client disconnect", async () => {

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -15,10 +15,11 @@ import { PipelineError } from "./messages-pipeline.js";
 import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
-// POST /v1beta/models/{model}:generateContent / :streamGenerateContent — Google
-// Gemini inbound, translated to IR, routed through the SAME core pipeline as
-// /v1/chat and /v1/messages, then translated back to the native Gemini wire shape
-// (docs/05, issue #34). The FOURTH client-presentation surface.
+// POST /v1beta/models/{model}:generateContent / :streamGenerateContent and
+// POST /models/{model}:generateContent / :streamGenerateContent — Google Gemini
+// inbound, translated to IR, routed through the SAME core pipeline as /v1/chat
+// and /v1/messages, then translated back to the native Gemini wire shape (docs/05,
+// issue #34). The FOURTH client-presentation surface.
 //
 // PURE HTTP ↔ IR glue (CLAUDE.md principle 1): auth → translate(out) → route →
 // translate(back). No classify/route/translate logic lives here; each business
@@ -115,12 +116,13 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
   // Frees an unclaimed concurrency lease on every exit path (the handler below
   // acquires AFTER its self-auth).
   app.use("/v1beta/models/*", concurrencyReleaseGuard());
+  app.use("/models/*", concurrencyReleaseGuard());
 
   // Hono cannot match the literal ':' in `{model}:generateContent` with a named
-  // param, so we mount a catch-all under /v1beta/models and hand the full path +
-  // query to the core `parseGeminiPath`. A non-Gemini path → null → 404 (never a
-  // silent 200 on a mis-routed /v1beta/* request).
-  app.post("/v1beta/models/:rest{.+}", async (c) => {
+  // param, so we mount catch-alls under both Gemini path families and hand the
+  // full path + query to the core `parseGeminiPath`. A non-Gemini path → null →
+  // 404 (never a silent 200 on a mis-routed Gemini request).
+  const handleGemini = async (c: Context<AppEnv>) => {
     const traceId = c.get("trace_id");
 
     // 0) Route parse FIRST (cheap, pure). The pathname is the part before '?'; the
@@ -385,5 +387,8 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       );
     }
     return c.json(body as Record<string, unknown>);
-  });
+  };
+
+  app.post("/v1beta/models/:rest{.+}", handleGemini);
+  app.post("/models/:rest{.+}", handleGemini);
 }

--- a/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.gemini.test.ts
@@ -89,6 +89,30 @@ describe("createMessagesPipeline (gemini) — streamIR yields Gemini delta event
     expect(serialized).not.toContain("content_block_delta");
   });
 
+  it("does not double-count cached tokens from raw OpenAI streaming usage", async () => {
+    const frames = [
+      'data: {"id":"c","choices":[{"delta":{"role":"assistant","content":"Hi"}}]}\n\n',
+      'data: {"id":"c","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":20,"prompt_tokens_details":{"cached_tokens":30,"cache_creation_tokens":10}}}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const route: RouteFn = async () => streamResult(openAISSE(frames));
+    const pipeline = createMessagesPipeline(route, "gemini");
+    const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
+
+    const events = (await drain(run.streamIR())) as Array<{
+      usageMetadata?: {
+        promptTokenCount?: number;
+        cachedContentTokenCount?: number;
+        totalTokenCount?: number;
+      };
+    }>;
+    const terminal = events.find((e) => e.usageMetadata !== undefined);
+
+    expect(terminal?.usageMetadata?.promptTokenCount).toBe(100);
+    expect(terminal?.usageMetadata?.cachedContentTokenCount).toBe(30);
+    expect(terminal?.usageMetadata?.totalTokenCount).toBe(120);
+  });
+
   it("emits a functionCall part accumulated across fragmented tool-call chunks", async () => {
     const frames = [
       'data: {"id":"c","choices":[{"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_0","type":"function","function":{"name":"get_weather"}}]}}]}\n\n',

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -324,6 +324,50 @@ function parseFrame(event: string): Record<string, unknown> | null {
   return null;
 }
 
+function nonNegativeToken(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function normalizeOpenAIStreamUsageForIR(chunk: Record<string, unknown>): Record<string, unknown> {
+  const usage = objectRecord(chunk.usage);
+  if (usage === undefined) return chunk;
+  const promptDetails = objectRecord(usage.prompt_tokens_details);
+  const completionDetails = objectRecord(usage.completion_tokens_details);
+  const cached =
+    nonNegativeToken(usage.cached_tokens) ?? nonNegativeToken(promptDetails?.cached_tokens) ?? 0;
+  const cacheCreation =
+    nonNegativeToken(usage.cache_creation_tokens) ??
+    nonNegativeToken(promptDetails?.cache_creation_tokens) ??
+    nonNegativeToken(promptDetails?.cache_creation_input_tokens) ??
+    nonNegativeToken(promptDetails?.cache_write_tokens) ??
+    0;
+  const prompt = nonNegativeToken(usage.prompt_tokens);
+  const completion = nonNegativeToken(usage.completion_tokens);
+  const reasoning =
+    nonNegativeToken(usage.reasoning_tokens) ??
+    nonNegativeToken(completionDetails?.reasoning_tokens);
+  return {
+    ...chunk,
+    usage: {
+      ...(prompt !== undefined
+        ? { prompt_tokens: Math.max(0, prompt - cached - cacheCreation) }
+        : {}),
+      ...(completion !== undefined ? { completion_tokens: completion } : {}),
+      ...(cached > 0 ? { cached_tokens: cached } : {}),
+      ...(cacheCreation > 0 ? { cache_creation_tokens: cacheCreation } : {}),
+      ...(promptDetails !== undefined ? { prompt_tokens_details: promptDetails } : {}),
+      ...(reasoning !== undefined ? { reasoning_tokens: reasoning } : {}),
+      ...(completionDetails !== undefined ? { completion_tokens_details: completionDetails } : {}),
+    },
+  };
+}
+
 // Build the pipeline the Anthropic route consumes. `run` returns the two-accessor
 // PipelineRunResult: `collect` (non-stream IR response) and `streamIR` (Anthropic
 // SSE events). The route picks exactly one based on the IR's stream flag.
@@ -578,17 +622,18 @@ export function createMessagesPipeline(
             for await (const ch of chunks) {
               if (memory !== undefined) accumulateAssistantText(assistant, ch);
               if (ch.usage && typeof ch.usage === "object") lastUsage = ch.usage as StreamUsage;
-              yield ch;
+              yield protocol === "gemini" ? normalizeOpenAIStreamUsageForIR(ch) : ch;
             }
           })();
           try {
             // Outbound stream mapping is chosen by the pipeline's stamped protocol
             // (principle 5: surfaces never conflate). Gemini consumes the SAME
             // OpenAI-shaped chunks parseOpenAISSE produces (its IRChunk IS the
-            // OpenAI chat.completion.chunk), so we feed them straight into the
-            // Gemini delta state machine — no Anthropic adapter (docs/05). Each
-            // yielded object is a GenerateContentResponse delta frame (no `type`);
-            // the route writes it as a nameless `data:` SSE frame with no [DONE].
+            // OpenAI chat.completion.chunk). The source generator above normalizes
+            // raw OpenAI usage into IR usage first, then feeds the Gemini delta
+            // state machine — no Anthropic adapter (docs/05). Each yielded object
+            // is a GenerateContentResponse delta frame (no `type`); the route
+            // writes it as a nameless `data:` SSE frame with no [DONE].
             if (protocol === "gemini") {
               for await (const snapshot of geminiTransformer.transformStreamOut(
                 source as AsyncIterable<IRChunk>,

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -191,6 +191,70 @@ const REQ_BODY = {
 };
 
 describe("POST /v1/messages (Anthropic inbound)", () => {
+  it("accepts the Claude Code event logging compatibility endpoint after auth", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/api/event_logging/batch", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ events: [{ type: "client_event" }] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+    expect(harness.order).toEqual(["auth"]);
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("requires auth on the event logging compatibility endpoint", async () => {
+    const { deps, harness } = makeDeps({ authed: false });
+    const app = buildApp(deps);
+
+    const res = await app.request("/api/event_logging/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ events: [] }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(harness.order).toEqual(["auth"]);
+  });
+
+  it("returns an authenticated Anthropic count_tokens estimate without routing", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages/count_tokens", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { input_tokens: number };
+    expect(body.input_tokens).toBeGreaterThan(0);
+    expect(harness.order).toEqual(["auth"]);
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("validates count_tokens requests before returning an estimate", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages/count_tokens", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ model: "claude-3-5-sonnet", messages: [] }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { type: string; message: string } };
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("messages parameter is required");
+    expect(harness.order).toEqual(["auth"]);
+  });
+
   it("non-stream: auth → translate-out → route → translate-back, returns Anthropic JSON", async () => {
     const { deps, harness } = makeDeps();
     const app = buildApp(deps);

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -149,6 +149,30 @@ function extractCredential(apiKey: string | undefined, auth: string | undefined)
   return null;
 }
 
+function estimateAnthropicInputTokens(value: unknown): number {
+  const seen = new WeakSet<object>();
+  const collect = (v: unknown): string => {
+    if (typeof v === "string") return v;
+    if (typeof v === "number" || typeof v === "boolean") return String(v);
+    if (v === null || v === undefined) return "";
+    if (Array.isArray(v)) return v.map(collect).join("\n");
+    if (typeof v === "object") {
+      if (seen.has(v)) return "";
+      seen.add(v);
+      return Object.values(v as Record<string, unknown>)
+        .map(collect)
+        .join("\n");
+    }
+    return "";
+  };
+  const obj = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  const text = [obj.system, obj.messages, obj.tools, obj.tool_choice]
+    .map(collect)
+    .filter((s) => s.length > 0)
+    .join("\n");
+  return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
+}
+
 // Client disconnect / abort detection — mirrors chat.ts. Used to suppress a
 // terminal error frame for a benign disconnect (NOT a provider fault, docs/02).
 function isAbort(err: unknown, signal: AbortSignal): boolean {
@@ -169,13 +193,68 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
   // acquires AFTER its self-auth, so the slot cannot be taken by middleware).
   app.use("/v1/messages", concurrencyReleaseGuard());
 
+  const resolveIdentity = async (c: Context<AppEnv>): Promise<MessagesIdentity | null> => {
+    const credential = extractCredential(c.req.header("x-api-key"), c.req.header("Authorization"));
+    return deps.auth.resolve(credential);
+  };
+
+  app.post("/api/event_logging/batch", async (c) => {
+    const traceId = c.get("trace_id");
+    const identity = await resolveIdentity(c);
+    if (identity === null) {
+      return sendError(c, {
+        error_class: "auth_error",
+        message: "missing or invalid API key",
+        trace_id: traceId,
+      });
+    }
+    return c.json({ status: "ok" });
+  });
+
+  app.post("/v1/messages/count_tokens", async (c) => {
+    const traceId = c.get("trace_id");
+    const identity = await resolveIdentity(c);
+    if (identity === null) {
+      return sendError(c, {
+        error_class: "auth_error",
+        message: "missing or invalid API key",
+        trace_id: traceId,
+      });
+    }
+    let native: unknown;
+    try {
+      native = JSON.parse(await c.req.text());
+    } catch {
+      return sendError(c, {
+        error_class: "invalid_request",
+        message: "malformed JSON request body",
+        trace_id: traceId,
+      });
+    }
+    const obj = native && typeof native === "object" ? (native as Record<string, unknown>) : null;
+    if (obj === null || typeof obj.model !== "string" || obj.model.length === 0) {
+      return sendError(c, {
+        error_class: "invalid_request",
+        message: "model parameter is required",
+        trace_id: traceId,
+      });
+    }
+    if (!Array.isArray(obj.messages) || obj.messages.length === 0) {
+      return sendError(c, {
+        error_class: "invalid_request",
+        message: "messages parameter is required",
+        trace_id: traceId,
+      });
+    }
+    return c.json({ input_tokens: estimateAnthropicInputTokens(native) });
+  });
+
   app.post("/v1/messages", async (c) => {
     const traceId = c.get("trace_id");
 
     // 1) Auth FIRST (docs/02 pipeline: Auth precedes the Protocol Adapter). A
     //    missing/invalid key never reaches the translator or the pipeline.
-    const credential = extractCredential(c.req.header("x-api-key"), c.req.header("Authorization"));
-    const identity = await deps.auth.resolve(credential);
+    const identity = await resolveIdentity(c);
     if (identity === null) {
       return sendError(c, {
         error_class: "auth_error",

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -138,6 +138,20 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(order).toEqual(["auth", "translate-out", "route", "translate-back"]);
   });
 
+  it("accepts LiteLLM-compatible create aliases", async () => {
+    for (const path of ["/responses", "/openai/v1/responses"]) {
+      const { deps, order } = makeDeps();
+      const app = buildApp(deps);
+      const res = await app.request(path, {
+        method: "POST",
+        headers: AUTH,
+        body: JSON.stringify(REQ),
+      });
+      expect(res.status).toBe(200);
+      expect(order).toEqual(["auth", "translate-out", "route", "translate-back"]);
+    }
+  });
+
   it("rejects a missing key with 401 (OpenAI error envelope) and never routes", async () => {
     const { deps, order } = makeDeps({ authed: false });
     const app = buildApp(deps);

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -1,6 +1,6 @@
 import type { RateLimitProbe, RateLimitResult } from "@helm/core";
 import { type ErrorClass, ErrorClassSchema, makeHelmError } from "@helm/shared";
-import type { Hono } from "hono";
+import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
@@ -139,8 +139,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
   // Frees an unclaimed concurrency lease on every exit path — incl. a throw into
   // onError (the handler below acquires AFTER its self-auth).
   app.use("/v1/responses", concurrencyReleaseGuard());
+  app.use("/responses", concurrencyReleaseGuard());
+  app.use("/openai/v1/responses", concurrencyReleaseGuard());
 
-  app.post("/v1/responses", async (c) => {
+  const handleResponses = async (c: Context<AppEnv>) => {
     const traceId = c.get("trace_id");
 
     // 1) Auth FIRST (docs/02 pipeline order).
@@ -394,5 +396,9 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       );
     }
     return c.json(body);
-  });
+  };
+
+  app.post("/v1/responses", handleResponses);
+  app.post("/responses", handleResponses);
+  app.post("/openai/v1/responses", handleResponses);
 }

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1190,18 +1190,29 @@ export async function buildServer(
   });
 
   // Mandatory auth for the OpenAI chat surface (Hono middleware -> HelmError on
-  // failure). The Anthropic /v1/messages route self-authenticates so its errors
-  // are translated to the Anthropic envelope (docs/07) — see registerMessagesRoute.
-  app.use(
+  // failure). Includes LiteLLM-compatible chat aliases; Anthropic /v1/messages
+  // self-authenticates so its errors are translated to the Anthropic envelope
+  // (docs/07) — see registerMessagesRoute.
+  const chatRoutePatterns = [
     "/v1/chat/*",
-    authMiddleware({ keyStore, log: (l) => logger.log("warn", "auth", { line: l }) }),
-  );
+    "/chat/*",
+    "/engines/*",
+    "/openai/deployments/*",
+  ] as const;
+  for (const pattern of chatRoutePatterns) {
+    app.use(
+      pattern,
+      authMiddleware({ keyStore, log: (l) => logger.log("warn", "auth", { line: l }) }),
+    );
+  }
   // Rate limit AFTER auth (needs the resolved key_id) and BEFORE classify/route
   // (cut off cost before classification/eval). No-op when disabled (docs/06).
-  app.use(
-    "/v1/chat/*",
-    rateLimitMiddleware({ limiter: rateLimiter, estimateTokens: estimateRequestTokens }),
-  );
+  for (const pattern of chatRoutePatterns) {
+    app.use(
+      pattern,
+      rateLimitMiddleware({ limiter: rateLimiter, estimateTokens: estimateRequestTokens }),
+    );
+  }
   // Per-key concurrency overflow queue (issue #93, feature A): AFTER rate-limit
   // (a hard-rejected request must not hold a queue slot), BEFORE classify/route.
   // ONE process-wide gate shared with the self-auth routes (messages / responses
@@ -1218,7 +1229,9 @@ export async function buildServer(
       waitTimeoutMs: settings.concurrency_queue_wait_timeout_ms,
     }),
   });
-  app.use("/v1/chat/*", concurrencyMiddleware(concurrencyGate));
+  for (const pattern of chatRoutePatterns) {
+    app.use(pattern, concurrencyMiddleware(concurrencyGate));
+  }
 
   // Model discovery (GET /v1/models) is key-aware: it requires the SAME mandatory
   // key auth as the chat surface so the listing reflects the authenticated key's

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-12 · LiteLLM 协议兼容面修复（四协议路由 + Gemini usage；CLAUDE.md 原则 1/7/8；docs/05/07）
+
+- **缘起**：基于 `/Users/lukin/Projects/llm-router-packages/wiki/comparisons/protocol-compatibility-gap-analysis.md` 对照 LiteLLM，当前 `main` 仍有几类 drop-in 兼容缺口：Gemini 只认 `/v1beta/models/{singleSegment}` 且 `streamGenerateContent` 没有 `alt=sse` 会被当成非流；Gemini 流式出站 usage 没把 cache read/write 加回 `promptTokenCount`；OpenAI Chat / Responses create 缺 LiteLLM 常用别名；Anthropic `/api/event_logging/batch` 与 `/v1/messages/count_tokens` 缺兼容端点。
+- **修复**：Gemini `parseGeminiPath` 支持 `/v1beta/models/{model:path}` 与 `/models/{model:path}`，`streamGenerateContent` 按操作名一律流式；gateway 同一 handler 挂载两套 Gemini 路径，保持 auth/rate-limit/concurrency/memory/telemetry/payload 语义一致。Gemini `transformStreamOut` 的 `usageMetadata.promptTokenCount` 改为 `prompt_tokens + cached_tokens + cache_creation_tokens`（与非流式一致），仍保留 `cachedContentTokenCount`；gateway Gemini 流式分支在渲染前把原始 OpenAI SSE usage 先标准化为 IR usage，避免 `prompt_tokens` 已含 cached/write tokens 时被重复加回。OpenAI Chat 增加 `/chat/completions`、`/engines/{model:path}/chat/completions`、`/openai/deployments/{model:path}/chat/completions`，并在 server 组合根给这些别名挂同一套 auth/rate-limit/concurrency 中间件；engine/deployment 路径 model 覆盖 body model，但 payload capture 保留原始 body。Responses create 增加 `/responses` 与 `/openai/v1/responses` 别名。Anthropic 增加已鉴权的 Claude Code event logging stub（`{"status":"ok"}`）和本地确定性 `count_tokens` 估算端点。
+- **取舍/仍开放**：LiteLLM 的 Responses GET/DELETE/cancel/input_items/compact/background polling/Cursor bridge 需要 response-object store 或 provider-native executor 合同，不能用假 stub 冒充已实现；本轮只补 create aliases。Gemini `countTokens` 仍是显式未实现的 SDK 兼容缺口。LiteLLM 会 fetch 远程媒体并转 base64；Helm core transformer 仍不做网络 fetch，远程 http(s) 图像到 Gemini nativeOut 继续文档化降级为文本占位，避免在协议层引入隐式网络 I/O。
+- **验证**：新增/更新 route + protocol regression：Gemini `/models`、path-style model、`streamGenerateContent` 无 `alt=sse`、流式 cached usage；Chat 三类别名 + 路径 model 覆盖；Responses create aliases；Anthropic event logging/count_tokens。TDD 红例覆盖 Gemini gateway 流式 double-count（先见 `expected 140 to be 100`，再最小修复）。已跑 `pnpm typecheck`、`pnpm lint`、`pnpm -r build`、`pnpm test`（3020 绿）、`pnpm --filter @helm/gateway test:e2e`（64 绿）、`git diff --check`。
+
 ## 2026-06-12 · Anthropic streaming 保留 MCP 双下划线工具名（CLAUDE.md 原则 8；docs/05）
 
 - **缘起**：线上 Claude Code 经 Helm 调用 `codegraph` MCP 时，工具 schema 是正确的 `mcp__codegraph__codegraph_context`，但返回给客户端的流式 `tool_use.name` 变成 `mcp_codegraph_codegraph_context`。Claude Code 无法执行该单下划线工具名，连续把 `No such tool available` 带回下一轮，模型反复输出 “Worktree created / worktree is ready” 并再次调用错误工具。
@@ -25,19 +32,13 @@
 - **取舍/已知限制**：非 chat 的**流式**回放不回填 `completion_usd`（pipeline 仅在接了 budget dep 时回填，回放有意不接——与无预算 key 的 live 行为一致）；openai_chat 回放保留 `usageFromSSE` 成本回填。
 - **验证**：TDD 红→绿。新测：shared decision schema 协议 round-trip(3)、core redaction 保留 protocol(1)、gateway replay 四协议（Anthropic system 保真 + input[] 推断 + Gemini model 恢复 + 坏 body 400 + Responses 流式原生 SSE，共 6 例）、admin canRetry 放宽 1 例；补了 6 个既有 DecisionRecord fixture 的 protocol（**core/gateway typecheck 含 test**）。gateway 路由 166 绿、admin 39 绿、replay 21 绿；typecheck（shared+core+gateway）/ lint / build 全绿。**坑：admin svelte-check 3 个 `oauth.test.ts` 报错是 main 既有（与本改无关）；需发新 admin 镜像生效。**
 
-## 2026-06-11 · 请求页自动刷新控件 RefreshControl（admin UX；CLAUDE.md 原则 1）
-
-- **缘起**：用户要求在 `/admin/requests` 页右上角加一个刷新按钮，支持自动刷新，样式参考某监控面板的「Refresh ▾」分体按钮（下拉含 关/Auto/5s…1d）。
-- **实现**：新增可复用 `RefreshControl.svelte`——分体按钮：左「↻ Refresh」立即刷新（在途时图标 `animate-spin`），右「▾」开下拉选自动刷新节奏（关 + 5s/10s/30s/1m/5m/15m/30m/1h/2h/1d）。`setInterval` 驱动，`onDestroy` 清理；选中节奏后主按钮显示「· 30s」激活反馈。`<svelte:window onpointerdown>` 做 click-outside、Escape 关闭。组件**对数据无状态**（纯触发器），parent 通过 `onRefresh` 注入语义；请求页传 `() => invalidateAll()`——重跑 `+page.ts` loader，按 URL filter 重取当前页。请求页 `<header>` 改 `flex justify-between`，控件居右（仿 providers 页）。
-- **取舍（关键）**：① 参考图里的「Auto」判为**分组标题而非可选项**（图中顶部高亮的是当前选中的「关」，Auto 是其下区间列表的小标题），故下拉做成「关 + Auto refresh 分组 + 区间」，不引入语义含糊的「Auto」选项（呼应 CLAUDE.md「会撒谎的旋钮比没有旋钮更糟」）。② 选中节奏**只设定节拍、不立即刷一次**（仿 Grafana，避免点选即触发的意外突发）；`runRefresh` 带 `refreshing` 重入守卫，慢加载不堆叠 tick。③ 区间标签（5s/1h…）是语言中性字面量，**不进 i18n**（仿 RangeFilter 的 1h/6h）；只「Auto refresh」入 5 语言包。
-- **坑/TODO**：① 纯 admin 静态资源改动，需发新 admin 镜像才生效（部署见 [[deploy-never-overwrite-config]]）。② 自动刷新仅本页生命周期内有效，离开页面即停；刷新节奏不持久化（刻意——避免后台无意义轮询）。③ 控件通用，后续可复用到 Dashboard/Providers 等页。
-- **验证**：TDD 红→绿。新 `RefreshControl.test.ts`(7，fake timers)：手动点击触发 onRefresh、菜单开列区间、选中后逐 tick 刷新（非立即）、激活标签、选「关」停、卸载清理。requests 页 17 例不回归；admin 全量 **304 绿**；svelte-check 对新文件零错（仅既有 oauth.test.ts 3 处预存错，未触碰）；Biome lint(432 文件) + Prettier(.svelte) + vite build 全绿。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-11 · 请求页自动刷新控件 RefreshControl：新增请求页分体刷新按钮 + 下拉自动刷新节奏（关/5s…1d），`onRefresh` 注入 `invalidateAll()`，定时器生命周期内有效且不持久化；admin tests/build/lint 当时通过，需发新 admin 镜像生效。
 
 ### 2026-06-11 · 记忆消息重复写入根治 + 历史脏数据清理：根因是 observeInbound 全量盲插客户端重发 transcript，`memory_messages` O(n²) 膨胀并让 observer 反复压缩；修复为 `message_index + content_hash` 幂等键、sqlite/pg 迁移与 dedup 运维脚本，清理 observations 后重建。坑：历史 NULL hash 需脚本补齐；部署先迁移后备份/dry-run/正式/VACUUM。
 

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -642,7 +642,7 @@ describe("transformStreamOut (IR chunks -> Gemini SSE events)", () => {
     expect(withFinish[0]?.candidates?.[0]?.finishReason).toBe("STOP");
   });
 
-  it("emits cached token counts from OpenAI-style streaming usage details", async () => {
+  it("reconstructs full Gemini promptTokenCount from streaming cache usage details", async () => {
     const chunks: IRChunk[] = [
       {
         id: "c",
@@ -662,9 +662,9 @@ describe("transformStreamOut (IR chunks -> Gemini SSE events)", () => {
     ];
     const events = await collect(geminiTransformer.transformStreamOut(fromArray(chunks)));
     const terminal = events.find((e) => e.usageMetadata !== undefined);
-    expect(terminal?.usageMetadata?.promptTokenCount).toBe(100);
+    expect(terminal?.usageMetadata?.promptTokenCount).toBe(140);
     expect(terminal?.usageMetadata?.cachedContentTokenCount).toBe(30);
-    expect(terminal?.usageMetadata?.totalTokenCount).toBe(120);
+    expect(terminal?.usageMetadata?.totalTokenCount).toBe(160);
   });
 
   // test #4: outbound streaming must surface tool calls as a complete functionCall part
@@ -1082,6 +1082,11 @@ describe("endPoint routing (/v1beta/...)", () => {
     expect(parsed?.stream).toBe(false);
   });
 
+  it("parses LiteLLM-compatible /models paths and path-style model names", () => {
+    const parsed = parseGeminiPath("/models/google/gemini-2.5-pro:generateContent", "");
+    expect(parsed).toEqual({ model: "google/gemini-2.5-pro", stream: false });
+  });
+
   it("parses streamGenerateContent?alt=sse path: streaming true", () => {
     const parsed = parseGeminiPath(
       "/v1beta/models/gemini-1.5-pro:streamGenerateContent",
@@ -1089,6 +1094,11 @@ describe("endPoint routing (/v1beta/...)", () => {
     );
     expect(parsed?.model).toBe("gemini-1.5-pro");
     expect(parsed?.stream).toBe(true);
+  });
+
+  it("treats streamGenerateContent as streaming even without alt=sse", () => {
+    const parsed = parseGeminiPath("/v1beta/models/gemini-1.5-pro:streamGenerateContent", "");
+    expect(parsed).toEqual({ model: "gemini-1.5-pro", stream: true });
   });
 
   it("returns null for a non-Gemini path", () => {

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -56,23 +56,28 @@ export const GEMINI_API_KEY_HEADER = "x-goog-api-key" as const;
 export interface GeminiRoute {
   /** model parsed out of the `{model}` path segment, fed into IR.model. */
   model: string;
-  /** true for :streamGenerateContent with ?alt=sse. */
+  /** true for :streamGenerateContent; alt=sse is not required for compatibility. */
   stream: boolean;
 }
 
 /**
- * Parse a Gemini `/v1beta/models/{model}:{op}` path. Returns the model and whether
- * it is a streaming call (`:streamGenerateContent` + `alt=sse`), or null if the path
- * is not a Gemini generateContent endpoint. Pure string parsing — the gateway maps
- * its framework request onto this (core never reads a framework object).
+ * Parse a Gemini `/v1beta/models/{model}:{op}` or `/models/{model}:{op}` path.
+ * Returns the model and whether it is a streaming call, or null if the path is not
+ * a Gemini generateContent endpoint. Pure string parsing — the gateway maps its
+ * framework request onto this (core never reads a framework object).
  */
 export function parseGeminiPath(pathname: string, query: string): GeminiRoute | null {
-  const m = /^\/v1beta\/models\/([^:/?]+):(generateContent|streamGenerateContent)$/.exec(pathname);
+  const m = /^\/(?:v1beta\/models|models)\/(.+):(generateContent|streamGenerateContent)$/.exec(
+    pathname,
+  );
   if (m === null || m[1] === undefined || m[2] === undefined) return null;
   const model = decodeURIComponent(m[1]);
   const op = m[2];
-  const params = new URLSearchParams(query);
-  const stream = op === "streamGenerateContent" && params.get("alt") === "sse";
+  // LiteLLM's Gemini stream route forces stream=true from the operation name. The
+  // `alt=sse` query affects the Google wire format, but silently downgrading a
+  // `streamGenerateContent` request to non-stream corrupts client expectations.
+  void query;
+  const stream = op === "streamGenerateContent";
   return { model, stream };
 }
 
@@ -172,6 +177,10 @@ function thinkingConfigToReasoningEffort(
   if (budget <= REASONING_EFFORT_BUDGET.low) return "low";
   if (budget <= REASONING_EFFORT_BUDGET.medium) return "medium";
   return "high";
+}
+
+function nonNegativeToken(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 // —— Synthesize a deterministic tool-call id. Gemini functionCall has no id; we make
@@ -1180,8 +1189,16 @@ async function* transformStreamOut(src: AsyncIterable<IRChunk>): AsyncIterable<G
 
   const toUsageMetadata = (usage: NonNullable<IRChunk["usage"]>): GeminiUsageMetadata => {
     const nestedPromptDetails = usage.prompt_tokens_details;
-    const cached = usage.cached_tokens ?? nestedPromptDetails?.cached_tokens;
-    const prompt = usage.prompt_tokens;
+    const cached = usage.cached_tokens ?? nonNegativeToken(nestedPromptDetails?.cached_tokens);
+    const cacheCreation =
+      usage.cache_creation_tokens ??
+      nonNegativeToken(nestedPromptDetails?.cache_creation_tokens) ??
+      nonNegativeToken(nestedPromptDetails?.cache_creation_input_tokens) ??
+      nonNegativeToken(nestedPromptDetails?.cache_write_tokens);
+    const prompt =
+      usage.prompt_tokens !== undefined
+        ? usage.prompt_tokens + (cached ?? 0) + (cacheCreation ?? 0)
+        : undefined;
     const candidates = usage.completion_tokens;
     return {
       ...(prompt !== undefined ? { promptTokenCount: prompt } : {}),

--- a/packages/core/src/protocol/protocol-matrix.test.ts
+++ b/packages/core/src/protocol/protocol-matrix.test.ts
@@ -621,7 +621,8 @@ describe("protocol cross-path executable harness", () => {
     expect(anthropicSerialized).toContain("Melbourne");
     expect(anthropicSerialized).toContain('"input_tokens":7');
     expect(anthropicSerialized).toContain('"cache_read_input_tokens":3');
-    expect(geminiEvents.at(-1)?.usageMetadata?.promptTokenCount).toBe(10);
+    expect(geminiEvents.at(-1)?.usageMetadata?.promptTokenCount).toBe(13);
+    expect(geminiEvents.at(-1)?.usageMetadata?.cachedContentTokenCount).toBe(3);
     expect(geminiSerialized).toContain("functionCall");
     expect(geminiSerialized).toContain("get_weather");
     expect(geminiSerialized).toContain("Melbourne");


### PR DESCRIPTION
## Summary
- add LiteLLM-compatible OpenAI Chat aliases, Responses create aliases, and Anthropic helper endpoints
- support Gemini /models paths, path-style model names, and streamGenerateContent without alt=sse
- normalize raw OpenAI streaming usage before Gemini rendering to avoid cached-token double counting
- expand unit and e2e coverage for the four protocol surfaces and alias middleware paths

## Verification
- git diff --check
- pnpm lint
- pnpm typecheck
- pnpm -r build
- pnpm test (3020 passed)
- pnpm --filter @helm/gateway test:e2e (64 passed)

## Open Product-Scope Gaps
- Responses stateful lifecycle APIs remain unimplemented
- Gemini countTokens remains unimplemented
- Gemini remote media fetch-to-base64 remains an explicit non-goal for core transformers