### PR TITLE
chore(release): v0.11.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.11.10.

Includes #197 — fix(protocol): align LiteLLM-compatible route surfaces.

On merge, `publish.yml` auto-cuts the `v0.11.10` tag, GitHub Release, and `ghcr.io/easymetaau/helm-api:0.11.10` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)