### PR TITLE
fix(protocol): harden Responses stream compatibility

### DIFF
--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -152,6 +152,41 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     }
   });
 
+  it("returns OpenAI-shaped errors for unsupported Responses lifecycle endpoints", async () => {
+    const cases: Array<[string, string]> = [
+      ["GET", "/v1/responses/resp_123"],
+      ["DELETE", "/v1/responses/resp_123"],
+      ["POST", "/v1/responses/resp_123/cancel"],
+      ["GET", "/v1/responses/resp_123/input_items"],
+      ["POST", "/v1/responses/compact"],
+      ["POST", "/v1/responses/input_tokens"],
+      ["GET", "/responses/resp_123"],
+      ["DELETE", "/openai/v1/responses/resp_123"],
+    ];
+
+    for (const [method, path] of cases) {
+      const { deps, order } = makeDeps();
+      const app = buildApp(deps);
+      const res = await app.request(path, { method, headers: AUTH });
+      expect(res.status, `${method} ${path}`).toBe(400);
+      const body = (await res.json()) as { error: Record<string, string> };
+      expect(body.error.type).toBe("invalid_request_error");
+      expect(body.error.code).toBe("invalid_request");
+      expect(body.error.message).toContain("not implemented");
+      expect(order).toEqual(["auth"]);
+    }
+  });
+
+  it("authenticates unsupported Responses lifecycle endpoints before returning unsupported", async () => {
+    const { deps, order } = makeDeps({ authed: false });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses/resp_123", { method: "GET" });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: Record<string, string> };
+    expect(body.error.code).toBe("invalid_api_key");
+    expect(order).toEqual(["auth"]);
+  });
+
   it("rejects a missing key with 401 (OpenAI error envelope) and never routes", async () => {
     const { deps, order } = makeDeps({ authed: false });
     const app = buildApp(deps);

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -142,13 +142,33 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
   app.use("/responses", concurrencyReleaseGuard());
   app.use("/openai/v1/responses", concurrencyReleaseGuard());
 
+  const authenticateResponsesRequest = async (c: Context<AppEnv>): Promise<MessagesIdentity> => {
+    const traceId = c.get("trace_id");
+    const credential = extractCredential(c.req.header("Authorization"));
+    const identity = await deps.auth.resolve(credential);
+    if (identity === null) throw helmError("auth_error", "missing or invalid API key", traceId);
+    return identity;
+  };
+
+  const unsupportedLifecycle = (operation: string) => async (c: Context<AppEnv>) => {
+    const traceId = c.get("trace_id");
+
+    // Match OpenAI/LiteLLM route coverage while failing closed for lifecycle
+    // state Helm does not persist yet. Auth still runs first so unsupported
+    // operations do not become unauthenticated route probes.
+    await authenticateResponsesRequest(c);
+    throw helmError(
+      "invalid_request",
+      `Responses ${operation} is not implemented by this Helm API deployment`,
+      traceId,
+    );
+  };
+
   const handleResponses = async (c: Context<AppEnv>) => {
     const traceId = c.get("trace_id");
 
     // 1) Auth FIRST (docs/02 pipeline order).
-    const credential = extractCredential(c.req.header("Authorization"));
-    const identity = await deps.auth.resolve(credential);
-    if (identity === null) throw helmError("auth_error", "missing or invalid API key", traceId);
+    const identity = await authenticateResponsesRequest(c);
 
     // 1b) Rate limit AFTER auth (needs the resolved key_id) and BEFORE translate/
     //     route. OpenAI surface → the structured rate_limited envelope via onError
@@ -398,7 +418,13 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     return c.json(body);
   };
 
-  app.post("/v1/responses", handleResponses);
-  app.post("/responses", handleResponses);
-  app.post("/openai/v1/responses", handleResponses);
+  for (const prefix of ["/v1/responses", "/responses", "/openai/v1/responses"]) {
+    app.post(`${prefix}/compact`, unsupportedLifecycle("compact"));
+    app.post(`${prefix}/input_tokens`, unsupportedLifecycle("input_tokens"));
+    app.get(`${prefix}/:response_id/input_items`, unsupportedLifecycle("input_items"));
+    app.post(`${prefix}/:response_id/cancel`, unsupportedLifecycle("cancel"));
+    app.get(`${prefix}/:response_id`, unsupportedLifecycle("retrieve"));
+    app.delete(`${prefix}/:response_id`, unsupportedLifecycle("delete"));
+    app.post(prefix, handleResponses);
+  }
 }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-12 · Codex/Responses 流式兼容修复（状态可见 + 生命周期路由形状；CLAUDE.md 原则 1/7/8；docs/05/07）
+
+- **缘起**：继续按官方 OpenAI OpenAPI / openai-node、LiteLLM Responses 实现和既有 wiki review 四协议兼容性。用户侧现象是 Codex 经常看不到状态、感觉 API 慢；代码侧问题集中在 native Codex Responses SSE 解析和 Helm `/v1/responses` route family 的协议形状。
+- **修复**：`openai-responses` provider 的 SSE reader 不再只找第一条 `data:`，现在支持 CRLF、multi-line `data:`、`event:` fallback（JSON 无 `type` 时）、最后一个未以空行终止的 SSE frame；`response.reasoning_summary.delta` / `response.reasoning_summary_text.delta` / `response.reasoning_text.delta` 都映射到 OpenAI Chat `reasoning_content`，非流式聚合也保留 `message.reasoning_content`。共享 Responses reverse bridge 同步接受官方 `response.reasoning_text.delta`，避免 native Responses 上游的推理文本被 drop。gateway 现在注册官方/LiteLLM Responses lifecycle/helper URL family（retrieve/delete/cancel/input_items/input_tokens/compact，含 `/v1/responses`、`/responses`、`/openai/v1/responses` 前缀），先鉴权再返回 OpenAI-shaped `invalid_request`，不再漏成 Hono raw 404。
+- **取舍/仍开放**：这不是完整 Responses object store 或 token counter。GET/DELETE/cancel/input_items/input_tokens/compact 目前是**协议形状兼容 + fail-closed unsupported**，不是假成功；真实现需要 response-object 存储、background polling 状态、provider-native executor contract、cursor/input-items 数据源，或 Responses-native token counting。Codex “慢”的主要结构性原因仍是 subscription Codex backend stream-only：非流式 Helm 请求必须聚合完整 upstream SSE 后才能返回一个 Chat response；客户端要低首 token 延迟应使用 `stream:true`。
+- **验证**：TDD 红→绿。新增/更新 provider、shared Responses stream、gateway route 测试覆盖 CRLF/multi-line/tail SSE、event fallback、reasoning deltas、lifecycle endpoint auth-first structured unsupported。定向 `responses.test.ts` 与 `responses-stream.test.ts` 已通过；提交前还需跑四协议 focused suite + typecheck/lint/build/full unit/e2e。
+
 ## 2026-06-12 · LiteLLM 协议兼容面修复（四协议路由 + Gemini usage；CLAUDE.md 原则 1/7/8；docs/05/07）
 
 - **缘起**：基于 `/Users/lukin/Projects/llm-router-packages/wiki/comparisons/protocol-compatibility-gap-analysis.md` 对照 LiteLLM，当前 `main` 仍有几类 drop-in 兼容缺口：Gemini 只认 `/v1beta/models/{singleSegment}` 且 `streamGenerateContent` 没有 `alt=sse` 会被当成非流；Gemini 流式出站 usage 没把 cache read/write 加回 `promptTokenCount`；OpenAI Chat / Responses create 缺 LiteLLM 常用别名；Anthropic `/api/event_logging/batch` 与 `/v1/messages/count_tokens` 缺兼容端点。
@@ -21,22 +28,13 @@
 - **修复**：`sanitizeAnthropicToolName` 不再折叠 `_+`，仍保留非法字符替换、首尾 `_` 裁剪、空名兜底和冲突 hash 后缀。这样 `search-web`/`search web` 仍按既有行为产生冲突后缀，而 `mcp__server__tool` 这类合法名称原样通过。
 - **验证**：TDD 红→绿。新增 streaming 回归测试钉死 `mcp__codegraph__codegraph_context` 在 `content_block_start(tool_use)` 中原样返回；扩展 response-level sanitizer 测试确认 MCP 双下划线名可正向/反向 round-trip。定向 `pnpm vitest run packages/core/src/protocol/anthropic/stream.test.ts packages/core/src/protocol/anthropic/response.test.ts packages/core/src/protocol/anthropic/request.test.ts` 通过。
 
-## 2026-06-11 · 「重试」按钮支持全部四协议（faithful 原生回放；CLAUDE.md 原则 1/5/7；docs/05/07）
-
-- **缘起**：admin 请求详情页「重试」按钮对所有 GPT 请求禁用、对所有 Claude 请求可用（生产 la.atmy.work 实证）。根因：回放只认 OpenAI chat 形状——客户端 `canRetry` 要求 `messages[]`（Responses 的 `input[]`、Gemini 的 `contents[]` 落空），服务端 `runReplay` 用 `OpenAIChatRequestSchema` 校验且**硬编码 `protocol:"openai_chat"`**。顺带挖出潜伏 bug：Claude 回放其实也走 openai_chat 路径，**静默丢掉顶层 `system` 提示词 + 错形 Anthropic 工具**——只因 `messages[]` 碰巧过 schema 才「看起来能用」。
-- **修复思路（faithful 原生回放）**：复用 live 路由的同一套入站/出站翻译器（`anthropicTransformer`/`responsesTransformer`/`geminiTransformer` 单例）+ 共享 `createMessagesPipeline`，让回放在请求的**原生协议形状**下重发并记录，而非归一成 OpenAI。
-- **协议恢复（零迁移）**：协议本未持久化。给 `DecisionRecordSchema` 加可选 `protocol`（`.nullable().default(null)`，沿用既有向后兼容约定），在 `route-request.ts` 两处 + `telemetry/decision.ts` builder 用 `req.protocol` 盖戳。它随 `decision_json` 落库、经既有 `getByRequestId` 取回——**无需 DB 迁移、无需新端口方法**；`redact()` 保留它（非密钥串，已加测试钉死）。旧记录无 protocol → 按 body 形状推断（`input[]`→responses、`contents[]`→gemini、否则 openai_chat，与旧行为一致并 log）。
-- **服务端 dispatch（`replay.ts`）**：openai_chat 走原有直连路径不变；anthropic/responses/gemini 走 `transformRequestOut → createMessagesPipeline(route, protocol)（不接 memory/budget/oauth/writes，保持隔离调试语义）→ 原生出站捕获`（非流式 `transformResponseOut`，流式按各面序列化：anthropic/responses 为 `event: <type>\ndata: …`、gemini 为无名 `data:` 帧）。坏 body → 400（transformer 抛 ZodError）；路由失败仍记一条可查的失败 trace（responseJson null/partial）。
-- **Gemini 特例**：Gemini 的 model 与 stream-ness 走 URL 不在 body，故捕获的 body 两者皆缺——model 从原 decision 的 `requested_model` 恢复（缺省 `auto` 重分类），回放固定**非流式**（调试要的是完整响应）。
-- **客户端 `canRetry`**：放宽为「捕获到对象 body 即可重试」（不再枚举形状，避免误禁 string-`input` 的 Responses body）；服务端为协议权威，真无法回放时回精确 400。
-- **取舍/已知限制**：非 chat 的**流式**回放不回填 `completion_usd`（pipeline 仅在接了 budget dep 时回填，回放有意不接——与无预算 key 的 live 行为一致）；openai_chat 回放保留 `usageFromSSE` 成本回填。
-- **验证**：TDD 红→绿。新测：shared decision schema 协议 round-trip(3)、core redaction 保留 protocol(1)、gateway replay 四协议（Anthropic system 保真 + input[] 推断 + Gemini model 恢复 + 坏 body 400 + Responses 流式原生 SSE，共 6 例）、admin canRetry 放宽 1 例；补了 6 个既有 DecisionRecord fixture 的 protocol（**core/gateway typecheck 含 test**）。gateway 路由 166 绿、admin 39 绿、replay 21 绿；typecheck（shared+core+gateway）/ lint / build 全绿。**坑：admin svelte-check 3 个 `oauth.test.ts` 报错是 main 既有（与本改无关）；需发新 admin 镜像生效。**
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-11 · 「重试」按钮支持全部四协议：admin retry 从 OpenAI-chat-only 改为 faithful 原生回放；DecisionRecord 增可选 `protocol` 零迁移盖戳，旧记录按 body 形状推断；Anthropic/Responses/Gemini 复用 live transformers + shared pipeline 捕获原生响应，客户端 `canRetry` 放宽为对象 body 即可；限制是非 chat 流式回放不回填 `completion_usd`，需发新 admin 镜像。
 
 ### 2026-06-11 · 请求页自动刷新控件 RefreshControl：新增请求页分体刷新按钮 + 下拉自动刷新节奏（关/5s…1d），`onRefresh` 注入 `invalidateAll()`，定时器生命周期内有效且不持久化；admin tests/build/lint 当时通过，需发新 admin 镜像生效。
 

--- a/packages/core/src/protocol/responses-stream.test.ts
+++ b/packages/core/src/protocol/responses-stream.test.ts
@@ -714,6 +714,34 @@ describe("convertResponsesEventStreamToOpenAI — reasoning delta -> IR (reverse
       .join("");
     expect(reasoning).toBe("deep thought");
   });
+
+  it("folds response.reasoning_text.delta back into an IR chunk reasoning_content", async () => {
+    async function* events(): AsyncIterable<ResponsesSSEEvent> {
+      yield {
+        type: "response.reasoning_text.delta",
+        sequence_number: 0,
+        item_id: "rs_1",
+        output_index: 0,
+        content_index: 0,
+        delta: "visible ",
+      } as ResponsesSSEEvent;
+      yield {
+        type: "response.reasoning_text.delta",
+        sequence_number: 1,
+        item_id: "rs_1",
+        output_index: 0,
+        content_index: 0,
+        delta: "reasoning",
+      } as ResponsesSSEEvent;
+    }
+    const chunks = await collect(convertResponsesEventStreamToOpenAI(events()));
+    const reasoning = chunks
+      .flatMap((c) => c.choices ?? [])
+      .map((ch) => ch.delta?.reasoning_content)
+      .filter((r): r is string => typeof r === "string")
+      .join("");
+    expect(reasoning).toBe("visible reasoning");
+  });
 });
 
 describe("convertOpenAIStreamToResponses — mid-stream error event", () => {

--- a/packages/core/src/protocol/responses-stream.ts
+++ b/packages/core/src/protocol/responses-stream.ts
@@ -224,6 +224,14 @@ const ReasoningSummaryTextDeltaSchema = z.object({
   summary_index: z.number().int().nonnegative(),
   delta: z.string(),
 });
+const ReasoningTextDeltaSchema = z.object({
+  type: z.literal("response.reasoning_text.delta"),
+  sequence_number: z.number().int().nonnegative(),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  content_index: z.number().int().nonnegative().optional(),
+  delta: z.string(),
+});
 const ReasoningSummaryTextDoneSchema = z.object({
   type: z.literal("response.reasoning_summary_text.done"),
   sequence_number: z.number().int().nonnegative(),
@@ -274,6 +282,7 @@ export const ResponsesSSEEventSchema = z.discriminatedUnion("type", [
   OutputTextDoneSchema,
   ContentPartDoneSchema,
   ReasoningSummaryTextDeltaSchema,
+  ReasoningTextDeltaSchema,
   ReasoningSummaryTextDoneSchema,
   FunctionCallArgumentsDeltaSchema,
   FunctionCallArgumentsDoneSchema,
@@ -969,6 +978,7 @@ export async function* synthesizeResponsesSSEFromJSON(
 // consumer sees a uniform feed:
 //   • output_text.delta              → choices[0].delta.content
 //   • reasoning_summary_text.delta   → choices[0].delta.reasoning_content
+//   • reasoning_text.delta           → choices[0].delta.reasoning_content
 //   • function_call_arguments.delta  → choices[0].delta.tool_calls[].function.arguments
 //   • output_item.added(function_call)→ choices[0].delta.tool_calls[] (id + name)
 //   • completed                      → finish_reason + usage (flushed once)
@@ -990,6 +1000,12 @@ export async function* convertResponsesEventStreamToOpenAI(
         break;
       }
       case "response.reasoning_summary_text.delta": {
+        yield {
+          choices: [{ index: 0, delta: { reasoning_content: ev.delta }, finish_reason: null }],
+        };
+        break;
+      }
+      case "response.reasoning_text.delta": {
         yield {
           choices: [{ index: 0, delta: { reasoning_content: ev.delta }, finish_reason: null }],
         };

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -5,6 +5,7 @@ import {
   codexAccountIdFromToken,
   createCodexResponsesClient,
   openaiToResponsesRequest,
+  readResponsesEvents,
   translateResponsesSSE,
 } from "./openai-responses.js";
 
@@ -19,6 +20,10 @@ function jwt(accountId: string): string {
 // Codex Responses SSE: one `data: {json}` block per event.
 function sseResponse(events: object[]): Response {
   const body = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+  return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+function rawSSEResponse(body: string): Response {
   return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } });
 }
 
@@ -158,6 +163,26 @@ describe("openaiToResponsesRequest", () => {
 });
 
 describe("translateResponsesSSE", () => {
+  it("parses CRLF, multi-line data, event fallback, and an unterminated tail event", async () => {
+    const res = rawSSEResponse(
+      [
+        "event: response.output_text.delta\r\n",
+        'data: {"delta":"Hel"}\r\n',
+        "\r\n",
+        'data: {"type":"response.completed",\r\n',
+        'data: "response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":1}}}',
+      ].join(""),
+    );
+    const events: Array<Record<string, unknown>> = [];
+    for await (const evt of readResponsesEvents(res)) events.push(evt);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ type: "response.output_text.delta", delta: "Hel" });
+    expect(events[1]).toMatchObject({
+      type: "response.completed",
+      response: { status: "completed", usage: { input_tokens: 2, output_tokens: 1 } },
+    });
+  });
+
   it("maps output_text deltas + completed to OpenAI chunks + finish + [DONE]", async () => {
     const res = sseResponse([
       { type: "response.created", response: { id: "resp_1" } },
@@ -174,6 +199,21 @@ describe("translateResponsesSSE", () => {
     expect(joined).toContain('"content":"lo"');
     expect(joined).toContain('"finish_reason":"stop"');
     expect(joined.trimEnd().endsWith("data: [DONE]")).toBe(true);
+  });
+
+  it("maps Responses reasoning deltas to OpenAI reasoning_content chunks", async () => {
+    const res = sseResponse([
+      { type: "response.reasoning_summary_text.delta", delta: "plan " },
+      { type: "response.reasoning_text.delta", delta: "more" },
+      { type: "response.output_text.delta", delta: "Answer" },
+      { type: "response.completed", response: { status: "completed", usage: {} } },
+    ]);
+    const chunks: string[] = [];
+    for await (const c of translateResponsesSSE(res, "gpt-5.5")) chunks.push(c);
+    const joined = chunks.join("");
+    expect(joined).toContain('"reasoning_content":"plan "');
+    expect(joined).toContain('"reasoning_content":"more"');
+    expect(joined).toContain('"content":"Answer"');
   });
 
   // order 14: include_usage — a terminal usage chunk (choices:[] + usage) must
@@ -391,6 +431,22 @@ describe("aggregateResponsesStream", () => {
       total_tokens: 7,
       prompt_tokens_details: { cached_tokens: 1, cache_creation_tokens: 1 },
     });
+  });
+
+  it("folds Responses reasoning deltas onto message.reasoning_content", async () => {
+    const res = sseResponse([
+      { type: "response.reasoning_summary_text.delta", delta: "think " },
+      { type: "response.reasoning_text.delta", delta: "hard" },
+      { type: "response.output_text.delta", delta: "done" },
+      { type: "response.completed", response: { status: "completed", usage: {} } },
+    ]);
+    const out = await aggregateResponsesStream(res, "m");
+    const msg = (out.choices as Array<Record<string, unknown>>)[0]?.message as Record<
+      string,
+      unknown
+    >;
+    expect(msg.content).toBe("done");
+    expect(msg.reasoning_content).toBe("think hard");
   });
 
   it("folds a function_call into tool_calls with finish_reason tool_calls", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -63,6 +63,12 @@ const ORIGINATOR = "helm"; // matches the OAuth login `originator` (openai-codex
 // originator/UA/body — impersonating codex_cli_rs changed nothing.)
 const DEFAULT_USER_AGENT = "helm-codex/1.0.0";
 
+const RESPONSES_REASONING_DELTA_TYPES = new Set([
+  "response.reasoning_summary.delta",
+  "response.reasoning_summary_text.delta",
+  "response.reasoning_text.delta",
+]);
+
 // ── account id from the access-token JWT (chatgpt_account_id claim) ───────────
 // Same recipe as the login-time capture in oauth/openai-codex.ts, applied at
 // request time so it always reflects the current token. Returns "" when absent.
@@ -406,6 +412,41 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
 
 // ── low-level SSE event reader (shared by stream + aggregate) ─────────────────
 
+function parseResponsesSSEFrame(raw: string): Record<string, unknown> | null {
+  let eventName = "";
+  const dataLines: string[] = [];
+  for (const line of raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")) {
+    if (line === "" || line.startsWith(":")) continue;
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? "" : line.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+    if (field === "event") eventName = value;
+    else if (field === "data") dataLines.push(value);
+  }
+
+  const payload = dataLines.join("\n");
+  const trimmed = payload.trim();
+  if (trimmed === "" || trimmed === "[DONE]") return null;
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const evt = parsed as Record<string, unknown>;
+    if (typeof evt.type !== "string" && eventName !== "") return { ...evt, type: eventName };
+    return evt;
+  } catch {
+    // skip malformed event
+    return null;
+  }
+}
+
+function splitCompleteSSEFrames(buffer: string): { frames: string[]; tail: string } {
+  const normalized = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const parts = normalized.split("\n\n");
+  const tail = parts.pop() ?? "";
+  return { frames: parts, tail };
+}
+
 export async function* readResponsesEvents(
   res: Response,
   // Inter-chunk liveness deadline (ms); 0 disables. Threaded from the client's
@@ -428,20 +469,20 @@ export async function* readResponsesEvents(
         throw err;
       }
       const { done, value } = read;
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const events = buffer.split("\n\n");
-      buffer = events.pop() ?? "";
-      for (const raw of events) {
-        const dataLine = raw.split("\n").find((l) => l.startsWith("data:"));
-        if (!dataLine) continue;
-        const payload = dataLine.slice(5).trim();
-        if (!payload || payload === "[DONE]") continue;
-        try {
-          yield JSON.parse(payload) as Record<string, unknown>;
-        } catch {
-          // skip malformed event
+      if (done) {
+        buffer += decoder.decode();
+        if (buffer.trim() !== "") {
+          const evt = parseResponsesSSEFrame(buffer);
+          if (evt !== null) yield evt;
         }
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      const { frames, tail } = splitCompleteSSEFrames(buffer);
+      buffer = tail;
+      for (const raw of frames) {
+        const evt = parseResponsesSSEFrame(raw);
+        if (evt !== null) yield evt;
       }
     }
   } finally {
@@ -539,6 +580,10 @@ export async function* translateResponsesSSE(
       }
     } else if (type === "response.output_text.delta") {
       if (typeof evt.delta === "string") yield openaiChunk(model, { content: evt.delta }, null);
+    } else if (typeof type === "string" && RESPONSES_REASONING_DELTA_TYPES.has(type)) {
+      if (typeof evt.delta === "string") {
+        yield openaiChunk(model, { reasoning_content: evt.delta }, null);
+      }
     } else if (type === "response.function_call_arguments.delta") {
       if (typeof evt.delta === "string") {
         yield openaiChunk(
@@ -591,6 +636,7 @@ export async function aggregateResponsesStream(
   let outTok = 0;
   let cacheRead = 0;
   let cacheCreation = 0;
+  let reasoning = "";
   // call_id -> accumulated arguments, preserving first-seen order.
   const toolOrder: string[] = [];
   const toolById = new Map<string, { id: string; name: string; arguments: string }>();
@@ -616,6 +662,8 @@ export async function aggregateResponsesStream(
       }
     } else if (type === "response.output_text.delta") {
       if (typeof evt.delta === "string") text += evt.delta;
+    } else if (typeof type === "string" && RESPONSES_REASONING_DELTA_TYPES.has(type)) {
+      if (typeof evt.delta === "string") reasoning += evt.delta;
     } else if (type === "response.function_call_arguments.delta") {
       const tc = toolById.get(currentCallId);
       if (tc && typeof evt.delta === "string") tc.arguments += evt.delta;
@@ -659,6 +707,7 @@ export async function aggregateResponsesStream(
     };
   });
   const message: Record<string, unknown> = { role: "assistant", content: text || null };
+  if (reasoning !== "") message.reasoning_content = reasoning;
   if (toolCalls.length) message.tool_calls = toolCalls;
   return {
     id,


### PR DESCRIPTION
## Summary

- harden the native Codex/OpenAI Responses SSE reader for CRLF, multi-line `data:`, `event:` fallback, and final unterminated frames
- preserve Responses reasoning deltas (`response.reasoning_summary*` and `response.reasoning_text.delta`) as OpenAI Chat `reasoning_content` in streaming and aggregation paths
- register official/LiteLLM Responses lifecycle/helper URL shapes under `/v1/responses`, `/responses`, and `/openai/v1/responses`, authenticating first and returning OpenAI-shaped `invalid_request` until stored lifecycle support exists
- update implementation notes; local wiki pages under `/Users/lukin/Projects/llm-router-packages/wiki` were also refreshed with the new Responses findings

## Notes

This PR intentionally does not fake full Responses object lifecycle support. `retrieve`, `delete`, `cancel`, `input_items`, `input_tokens`, and `compact` now produce structured authenticated unsupported errors instead of raw 404s. Real support still needs response-object storage/provider-native lifecycle contracts.

The perceived Codex slowness for non-stream requests is still structurally expected: the Codex subscription endpoint is stream-only, so Helm has to aggregate upstream SSE before returning one non-stream Chat response. Streaming clients should use `stream:true` for earlier visible status/deltas.

## Verification

- `pnpm exec vitest run apps/gateway/src/routes/responses.test.ts`
- `pnpm exec vitest run packages/core/src/protocol/responses-stream.test.ts`
- `pnpm exec vitest run apps/gateway/src/routes/responses.test.ts packages/core/src/protocol/responses-stream.test.ts packages/core/src/provider/openai-responses.test.ts`
- focused four-protocol suites: 606 tests passed
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (3026 tests passed)
- `pnpm test:e2e` (64 Playwright tests passed)
