### PR TITLE
chore(release): v0.11.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.11.11** — root version bump 0.11.10 → 0.11.11.

Ships the unreleased fix that landed after v0.11.10:

- **#199 fix(protocol): harden Responses stream compatibility** — gateway `/v1/responses` route + core `responses-stream` + `openai-responses` provider hardening (Codex co-authored).

`publish.yml` will auto-cut tag `v0.11.11` + GitHub Release + GHCR `:0.11.11`/`:latest` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)