### PR TITLE
fix(protocol): preserve interop edge cases

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -201,6 +201,37 @@ describe("createExecute — gateway execution adapter", () => {
     });
   });
 
+  it("does not forward Responses-only previous_response_id/truncation to OpenAI-compatible upstreams", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ default_good_model: "gpt-x" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    await execute(
+      plan(["default_good_model"]),
+      req({
+        provider_raw: { previous_response_id: "resp_prev", truncation: "auto", store: false },
+      }),
+    );
+
+    const body = (provider.chatCompletion as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.previous_response_id).toBeUndefined();
+    expect(body.truncation).toBeUndefined();
+    expect(body.store).toBe(false);
+  });
+
   it("merges streamed client stream_options while forcing include_usage for cost capture", async () => {
     const provider = {
       chatCompletion: vi.fn(),

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-12 · 四协议互译保真补丁（Responses tool_choice / Anthropic native controls / Gemini safety；CLAUDE.md 原则 1/7/8；docs/05/07）
+
+- **缘起**：继续对照本地 LiteLLM review 四协议互译缺口。剩余问题集中在“字段形状接近但不完全相同”的边缘：Responses `tool_choice` 在 Responses 与 Chat 之间形状不同；Responses `previous_response_id` 的 tool-output continuation 需要服务端历史；Anthropic native/control 参数进 IR 后丢失；Gemini `safetySettings` 没有 round-trip；Anthropic provider 使用 `context_management` / `speed:"fast"` 时缺 feature beta header。
+- **修复**：Responses transformer 把 inbound `{type:"function",name}` 规范成 OpenAI Chat `{type:"function",function:{name}}`，outbound 反向还原；Codex Responses provider 同步把 Chat `tool_choice` 发成 Responses 顶层 `name` 形状。Anthropic transformer 将 `context_management`、`mcp_servers`、`container`、`speed`、`output_config` 保存在 `provider_raw` 并在 Anthropic native out 重新发出，`context_management` 数组按 LiteLLM 兼容形状包成 `{edits:[...]}`。Anthropic provider 透传这些 native controls，并按 body 动态补 `context-management-2025-06-27`、`compact-2026-01-12`、`fast-mode-2026-02-01` beta。Gemini transformer 将 `safetySettings` 存入 `provider_raw.safety_settings` 并在 Gemini native out 恢复。
+- **取舍/仍开放**：Helm 目前没有 Responses object/session/history store，所以带 `previous_response_id` 且只提交历史 tool-output continuation 的请求不能假装可处理；本轮选择 **fail-closed**，返回明确错误，避免把缺少本地 `function_call` 上下文的 `function_call_output` 转成无效 Chat tool message。单纯携带 `previous_response_id` 的普通字符串 input 仍保留在 `provider_raw` 用于后续 Responses-native round-trip；完整 continuation 支持需要 response store、input_items/history 查询和 tool-call correlation。
+- **验证**：TDD 红→绿。新增/更新 focused regression 覆盖 Responses `tool_choice` 双向规范化、`previous_response_id` continuation fail-closed、Codex provider `tool_choice`、Anthropic native passthrough + beta headers、Gemini `safetySettings` round-trip，以及 gateway 不把 `previous_response_id` / `truncation` 泄漏到 OpenAI-compatible upstream。验证命令：focused Vitest 244 绿；`pnpm typecheck` 绿；`pnpm lint` 绿；`pnpm test` 初跑因本地 `better-sqlite3` ABI 137 vs Node 25 ABI 141 失败，执行 `pnpm --filter @helm/core rebuild better-sqlite3` 后完整 `pnpm test` 240 files / 3036 tests 绿。
+
 ## 2026-06-12 · Codex/Responses 流式兼容修复（状态可见 + 生命周期路由形状；CLAUDE.md 原则 1/7/8；docs/05/07）
 
 - **缘起**：继续按官方 OpenAI OpenAPI / openai-node、LiteLLM Responses 实现和既有 wiki review 四协议兼容性。用户侧现象是 Codex 经常看不到状态、感觉 API 慢；代码侧问题集中在 native Codex Responses SSE 解析和 Helm `/v1/responses` route family 的协议形状。
@@ -22,18 +29,13 @@
 - **取舍/仍开放**：LiteLLM 的 Responses GET/DELETE/cancel/input_items/compact/background polling/Cursor bridge 需要 response-object store 或 provider-native executor 合同，不能用假 stub 冒充已实现；本轮只补 create aliases。Gemini `countTokens` 仍是显式未实现的 SDK 兼容缺口。LiteLLM 会 fetch 远程媒体并转 base64；Helm core transformer 仍不做网络 fetch，远程 http(s) 图像到 Gemini nativeOut 继续文档化降级为文本占位，避免在协议层引入隐式网络 I/O。
 - **验证**：新增/更新 route + protocol regression：Gemini `/models`、path-style model、`streamGenerateContent` 无 `alt=sse`、流式 cached usage；Chat 三类别名 + 路径 model 覆盖；Responses create aliases；Anthropic event logging/count_tokens。TDD 红例覆盖 Gemini gateway 流式 double-count（先见 `expected 140 to be 100`，再最小修复）。已跑 `pnpm typecheck`、`pnpm lint`、`pnpm -r build`、`pnpm test`（3020 绿）、`pnpm --filter @helm/gateway test:e2e`（64 绿）、`git diff --check`。
 
-## 2026-06-12 · Anthropic streaming 保留 MCP 双下划线工具名（CLAUDE.md 原则 8；docs/05）
-
-- **缘起**：线上 Claude Code 经 Helm 调用 `codegraph` MCP 时，工具 schema 是正确的 `mcp__codegraph__codegraph_context`，但返回给客户端的流式 `tool_use.name` 变成 `mcp_codegraph_codegraph_context`。Claude Code 无法执行该单下划线工具名，连续把 `No such tool available` 带回下一轮，模型反复输出 “Worktree created / worktree is ready” 并再次调用错误工具。
-- **根因**：Anthropic 出站 stream 转换复用 `createAnthropicToolNameMap()`，其 sanitizer 把非法字符替换为 `_` 后又折叠连续 `_`。连续下划线在 Anthropic tool name 规则里本来合法，且 MCP 工具名把双下划线作为命名空间分隔符；折叠它会破坏工具名语义。
-- **修复**：`sanitizeAnthropicToolName` 不再折叠 `_+`，仍保留非法字符替换、首尾 `_` 裁剪、空名兜底和冲突 hash 后缀。这样 `search-web`/`search web` 仍按既有行为产生冲突后缀，而 `mcp__server__tool` 这类合法名称原样通过。
-- **验证**：TDD 红→绿。新增 streaming 回归测试钉死 `mcp__codegraph__codegraph_context` 在 `content_block_start(tool_use)` 中原样返回；扩展 response-level sanitizer 测试确认 MCP 双下划线名可正向/反向 round-trip。定向 `pnpm vitest run packages/core/src/protocol/anthropic/stream.test.ts packages/core/src/protocol/anthropic/response.test.ts packages/core/src/protocol/anthropic/request.test.ts` 通过。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-12 · Anthropic streaming 保留 MCP 双下划线工具名：修复出站 stream sanitizer 折叠连续 `_` 导致 `mcp__server__tool` 变 `mcp_server_tool`、Claude Code 无法执行 MCP 工具；保留合法双下划线，非法字符替换/首尾裁剪/冲突 hash 仍保留；定向 Anthropic stream/response/request 测试绿。
 
 ### 2026-06-11 · 「重试」按钮支持全部四协议：admin retry 从 OpenAI-chat-only 改为 faithful 原生回放；DecisionRecord 增可选 `protocol` 零迁移盖戳，旧记录按 body 形状推断；Anthropic/Responses/Gemini 复用 live transformers + shared pipeline 捕获原生响应，客户端 `canRetry` 放宽为对象 body 即可；限制是非 chat 流式回放不回填 `completion_usd`，需发新 admin 镜像。
 

--- a/packages/core/src/protocol/anthropic/request.test.ts
+++ b/packages/core/src/protocol/anthropic/request.test.ts
@@ -422,14 +422,28 @@ describe("anthropic transformRequestOut", () => {
     expect(ir.service_tier).toBe("standard_only");
   });
 
-  it("preserves metadata in provider_raw (only documented Anthropic field)", () => {
+  it("preserves Anthropic-native passthrough params in provider_raw", () => {
     const ir = transformRequestOut({
       model: "claude-3-5-sonnet",
       max_tokens: 64,
       metadata: { user_id: "u-123" },
+      context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+      mcp_servers: [{ type: "url", url: "https://mcp.example/sse", name: "docs" }],
+      container: { id: "container_1" },
+      speed: "fast",
+      output_config: { effort: "medium" },
       messages: [{ role: "user", content: "hi" }],
     });
     expect(ir.provider_raw?.metadata).toEqual({ user_id: "u-123" });
+    expect(ir.provider_raw?.context_management).toEqual({
+      edits: [{ type: "clear_tool_uses_20250919" }],
+    });
+    expect(ir.provider_raw?.mcp_servers).toEqual([
+      { type: "url", url: "https://mcp.example/sse", name: "docs" },
+    ]);
+    expect(ir.provider_raw?.container).toEqual({ id: "container_1" });
+    expect(ir.provider_raw?.speed).toBe("fast");
+    expect(ir.provider_raw?.output_config).toEqual({ effort: "medium" });
   });
 
   it("preserves top-level cache_control for automatic prompt caching", () => {
@@ -651,9 +665,25 @@ describe("anthropic transformRequestIn — P4 params", () => {
     const out = transformRequestIn({
       model: "claude-3-5-sonnet",
       messages: [{ role: "user", content: "hi" }],
-      provider_raw: { metadata: { user_id: "u-123" } },
+      provider_raw: {
+        metadata: { user_id: "u-123" },
+        context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+        mcp_servers: [{ type: "url", url: "https://mcp.example/sse", name: "docs" }],
+        container: { id: "container_1" },
+        speed: "fast",
+        output_config: { effort: "medium" },
+      },
     });
     expect((out as { metadata?: unknown }).metadata).toEqual({ user_id: "u-123" });
+    expect((out as { context_management?: unknown }).context_management).toEqual({
+      edits: [{ type: "clear_tool_uses_20250919" }],
+    });
+    expect((out as { mcp_servers?: unknown }).mcp_servers).toEqual([
+      { type: "url", url: "https://mcp.example/sse", name: "docs" },
+    ]);
+    expect((out as { container?: unknown }).container).toEqual({ id: "container_1" });
+    expect((out as { speed?: unknown }).speed).toBe("fast");
+    expect((out as { output_config?: unknown }).output_config).toEqual({ effort: "medium" });
   });
 
   it("passes IR.service_tier through to the outbound request", () => {

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -171,6 +171,11 @@ const AnthropicMessagesRequestSchema = z
     service_tier: z.string().optional(),
     cache_control: z.unknown().optional(),
     metadata: z.unknown().optional(),
+    context_management: z.unknown().optional(),
+    mcp_servers: z.unknown().optional(),
+    container: z.unknown().optional(),
+    speed: z.unknown().optional(),
+    output_config: z.unknown().optional(),
   })
   .passthrough();
 
@@ -454,9 +459,17 @@ export function transformRequestOut(req: unknown): IRRequest {
         }
       : undefined;
 
-  // metadata has no IR home (Anthropic-only user-attribution); preserve it verbatim
-  // in provider_raw so an anthropic->anthropic round-trip is lossless.
-  const providerRaw = parsed.metadata !== undefined ? { metadata: parsed.metadata } : undefined;
+  // Anthropic-native controls with no IR home are preserved in provider_raw so an
+  // anthropic->anthropic round-trip is lossless.
+  const providerRaw: Record<string, unknown> = {};
+  if (parsed.metadata !== undefined) providerRaw.metadata = parsed.metadata;
+  if (parsed.context_management !== undefined) {
+    providerRaw.context_management = normalizeAnthropicContextManagement(parsed.context_management);
+  }
+  if (parsed.mcp_servers !== undefined) providerRaw.mcp_servers = parsed.mcp_servers;
+  if (parsed.container !== undefined) providerRaw.container = parsed.container;
+  if (parsed.speed !== undefined) providerRaw.speed = parsed.speed;
+  if (parsed.output_config !== undefined) providerRaw.output_config = parsed.output_config;
 
   const ir: IRRequest = {
     model: parsed.model,
@@ -477,7 +490,7 @@ export function transformRequestOut(req: unknown): IRRequest {
     ...(parsed.thinking !== undefined ? { thinking: parsed.thinking } : {}),
     ...(parsed.service_tier !== undefined ? { service_tier: parsed.service_tier } : {}),
     ...(parsed.cache_control !== undefined ? { cache_control: parsed.cache_control } : {}),
-    ...(providerRaw !== undefined ? { provider_raw: providerRaw } : {}),
+    ...(Object.keys(providerRaw).length > 0 ? { provider_raw: providerRaw } : {}),
   };
 
   // Per-message thinking BLOCKS (kept out of prompt content) live on provider_raw,
@@ -589,6 +602,11 @@ export interface AnthropicOutboundRequest {
   service_tier?: string;
   cache_control?: unknown;
   metadata?: unknown;
+  context_management?: unknown;
+  mcp_servers?: unknown;
+  container?: unknown;
+  speed?: unknown;
+  output_config?: unknown;
 }
 
 const DEFAULT_MAX_TOKENS = 4096;
@@ -637,6 +655,10 @@ function thinkingFromIR(ir: IRRequest): AnthropicThinkingConfigOut | undefined {
 function stopSequencesFromIR(stop: IRRequest["stop"]): string[] | undefined {
   if (stop === undefined) return undefined;
   return typeof stop === "string" ? [stop] : stop;
+}
+
+function normalizeAnthropicContextManagement(value: unknown): unknown {
+  return Array.isArray(value) ? { edits: value } : value;
 }
 
 function parseToolInput(raw: string): unknown {
@@ -911,6 +933,23 @@ export function transformRequestIn(ir: IRRequest): AnthropicOutboundRequest {
     // metadata (Anthropic user-attribution) was stashed in provider_raw inbound; re-emit it.
     ...(parsed.provider_raw?.metadata !== undefined
       ? { metadata: parsed.provider_raw.metadata }
+      : {}),
+    ...(parsed.provider_raw?.context_management !== undefined
+      ? {
+          context_management: normalizeAnthropicContextManagement(
+            parsed.provider_raw.context_management,
+          ),
+        }
+      : {}),
+    ...(parsed.provider_raw?.mcp_servers !== undefined
+      ? { mcp_servers: parsed.provider_raw.mcp_servers }
+      : {}),
+    ...(parsed.provider_raw?.container !== undefined
+      ? { container: parsed.provider_raw.container }
+      : {}),
+    ...(parsed.provider_raw?.speed !== undefined ? { speed: parsed.provider_raw.speed } : {}),
+    ...(parsed.provider_raw?.output_config !== undefined
+      ? { output_config: parsed.provider_raw.output_config }
       : {}),
   };
   return out;

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -776,6 +776,22 @@ describe("generationConfig param round-trip (litellm parity)", () => {
     expect(nativeOut.cachedContent).toBe("cachedContents/context-123");
   });
 
+  it("round-trips Gemini safetySettings through provider_raw", () => {
+    const safetySettings = [
+      { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_ONLY_HIGH" },
+    ];
+    const nativeIn: GeminiGenerateContentRequest = {
+      safetySettings,
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+    };
+
+    const ir = geminiTransformer.transformRequestOut(nativeIn) as IRRequest;
+    expect(ir.provider_raw?.safety_settings).toEqual(safetySettings);
+
+    const nativeOut = geminiTransformer.transformRequestIn(ir) as GeminiGenerateContentRequest;
+    expect(nativeOut.safetySettings).toEqual(safetySettings);
+  });
+
   it("maps reasoning_effort -> thinkingConfig (low/medium/high), minimal allowed", () => {
     const mk = (effort: "minimal" | "low" | "medium" | "high"): GeminiGenerateContentRequest =>
       geminiTransformer.transformRequestIn({

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -483,6 +483,9 @@ function transformRequestOut(native: unknown): IRRequest {
     ...(geminiToolConfigToToolChoice(req.toolConfig) !== undefined
       ? { tool_choice: geminiToolConfigToToolChoice(req.toolConfig) }
       : {}),
+    ...(req.safetySettings !== undefined
+      ? { provider_raw: { safety_settings: req.safetySettings } }
+      : {}),
   };
 
   return IRRequestSchema.parse(ir);
@@ -775,6 +778,9 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
     responseFormatToGenerationConfig(parsed.response_format),
   );
   const toolConfig = irToolChoiceToGeminiToolConfig(parsed.tool_choice);
+  const safetySettings = Array.isArray(parsed.provider_raw?.safety_settings)
+    ? parsed.provider_raw.safety_settings
+    : undefined;
 
   return {
     contents,
@@ -783,6 +789,7 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
     ...(toolConfig !== undefined ? { toolConfig } : {}),
     ...(generationConfig !== undefined ? { generationConfig } : {}),
     ...(parsed.cached_content !== undefined ? { cachedContent: parsed.cached_content } : {}),
+    ...(safetySettings !== undefined ? { safetySettings } : {}),
   };
 }
 

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -861,6 +861,36 @@ describe("responsesTransformer — request sampling/control params (litellm pari
     expect(native.web_search_options).toEqual({ search_context_size: "low" });
     expect(native.context_management).toEqual({ truncation: "auto" });
   });
+
+  it("normalizes Responses tool_choice into OpenAI Chat format on inbound conversion", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: "weather?",
+      tool_choice: { type: "function", name: "get_weather" },
+    });
+
+    expect(ir.tool_choice).toEqual({ type: "function", function: { name: "get_weather" } });
+  });
+
+  it("normalizes OpenAI Chat tool_choice into Responses format on outbound conversion", async () => {
+    const native = (await responsesTransformer.transformRequestIn?.({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "weather?" }],
+      tool_choice: { type: "function", function: { name: "get_weather" } },
+    })) as { tool_choice?: unknown };
+
+    expect(native.tool_choice).toEqual({ type: "function", name: "get_weather" });
+  });
+
+  it("rejects stateful tool-output continuation when previous_response_id history is unavailable", async () => {
+    expect(() =>
+      responsesTransformer.transformRequestOut({
+        model: "gpt-4o",
+        previous_response_id: "resp_prev",
+        input: [{ type: "function_call_output", call_id: "call_1", output: "done" }],
+      }),
+    ).toThrow(/previous_response_id continuation is not supported/);
+  });
 });
 
 describe("responsesTransformer — usage detail mapping (transformResponseIn)", () => {

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -264,6 +264,45 @@ function chatToolToResponsesTool(tool: unknown): unknown {
   return out;
 }
 
+function responsesToolChoiceToChat(toolChoice: unknown): unknown {
+  if (!isRecord(toolChoice) || toolChoice.type !== "function") return toolChoice;
+  if (typeof toolChoice.name !== "string" || isRecord(toolChoice.function)) return toolChoice;
+  return { type: "function", function: { name: toolChoice.name } };
+}
+
+function chatToolChoiceToResponses(toolChoice: unknown): unknown {
+  if (!isRecord(toolChoice) || toolChoice.type !== "function") return toolChoice;
+  if (typeof toolChoice.name === "string" && !isRecord(toolChoice.function)) return toolChoice;
+  if (!isRecord(toolChoice.function) || typeof toolChoice.function.name !== "string") {
+    return toolChoice;
+  }
+  return { type: "function", name: toolChoice.function.name };
+}
+
+function rejectUnsupportedPreviousResponseContinuation(
+  parsed: z.infer<typeof ResponsesRequestSchema>,
+): void {
+  if (parsed.previous_response_id === undefined || typeof parsed.input === "string") return;
+
+  const localFunctionCalls = new Set<string>();
+  for (const item of parsed.input) {
+    if (item.type === "function_call") {
+      const call = item as z.infer<typeof ResponsesFunctionCallItemSchema>;
+      const id = call.call_id ?? call.id;
+      if (id !== undefined) localFunctionCalls.add(id);
+      continue;
+    }
+    if (item.type !== "function_call_output") continue;
+
+    const output = item as z.infer<typeof ResponsesFunctionCallOutputItemSchema>;
+    if (output.call_id === undefined || !localFunctionCalls.has(output.call_id)) {
+      throw new Error(
+        "previous_response_id continuation is not supported without local function_call history",
+      );
+    }
+  }
+}
+
 function normalizeResponsesTools(tools: unknown[] | undefined): {
   tools?: unknown[];
   rawTools?: unknown[];
@@ -315,6 +354,7 @@ function foldMessageContent(
 function toIRRequest(req: NativeRequest): IRRequest {
   // fail-closed: a structurally invalid request never enters the pipeline.
   const parsed = ResponsesRequestSchema.parse(req);
+  rejectUnsupportedPreviousResponseContinuation(parsed);
   const normalizedTools = normalizeResponsesTools(parsed.tools);
 
   const messages: IRMessage[] = [];
@@ -421,7 +461,9 @@ function toIRRequest(req: NativeRequest): IRRequest {
     model: parsed.model,
     messages,
     ...(normalizedTools.tools !== undefined ? { tools: normalizedTools.tools } : {}),
-    ...(parsed.tool_choice !== undefined ? { tool_choice: parsed.tool_choice } : {}),
+    ...(parsed.tool_choice !== undefined
+      ? { tool_choice: responsesToolChoiceToChat(parsed.tool_choice) }
+      : {}),
     ...(parsed.temperature !== undefined ? { temperature: parsed.temperature } : {}),
     ...(parsed.max_output_tokens !== undefined ? { max_tokens: parsed.max_output_tokens } : {}),
     ...(parsed.stream !== undefined ? { stream: parsed.stream } : {}),
@@ -526,7 +568,9 @@ function toResponsesRequest(ir: IRRequest): NativeRequest {
       : parsed.tools !== undefined
         ? { tools: parsed.tools.map(chatToolToResponsesTool) }
         : {}),
-    ...(parsed.tool_choice !== undefined ? { tool_choice: parsed.tool_choice } : {}),
+    ...(parsed.tool_choice !== undefined
+      ? { tool_choice: chatToolChoiceToResponses(parsed.tool_choice) }
+      : {}),
     ...(parsed.temperature !== undefined ? { temperature: parsed.temperature } : {}),
     ...(parsed.max_tokens !== undefined ? { max_output_tokens: parsed.max_tokens } : {}),
     ...(parsed.stream !== undefined ? { stream: parsed.stream } : {}),

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -132,6 +132,28 @@ describe("openaiToAnthropicRequest", () => {
     });
   });
 
+  it("forwards Anthropic-native context, speed, output_config, mcp, and container controls", () => {
+    const body = openaiToAnthropicRequest({
+      model: "m",
+      messages: [{ role: "user", content: "hi" }],
+      context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+      speed: "fast",
+      output_config: { effort: "medium" },
+      mcp_servers: [{ type: "url", url: "https://mcp.example/sse", name: "docs" }],
+      container: { id: "container_1" },
+    });
+
+    expect(body.context_management).toEqual({
+      edits: [{ type: "clear_tool_uses_20250919" }],
+    });
+    expect(body.speed).toBe("fast");
+    expect(body.output_config).toEqual({ effort: "medium" });
+    expect(body.mcp_servers).toEqual([
+      { type: "url", url: "https://mcp.example/sse", name: "docs" },
+    ]);
+    expect(body.container).toEqual({ id: "container_1" });
+  });
+
   it("preserves top-level automatic cache_control when no explicit cache breakpoints exist", () => {
     const body = openaiToAnthropicRequest({
       model: "m",
@@ -495,6 +517,34 @@ describe("createAnthropicClient", () => {
     expect(seenMeta).toHaveLength(2);
     expect(seenMeta[0]).toEqual({ user_id: uid });
     expect(seenMeta[1]).toEqual(seenMeta[0]); // identical across requests → no rotation
+  });
+
+  it("adds feature beta headers for Anthropic context_management and fast mode", async () => {
+    let seen: Headers | null = null;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      seen = new Headers(init?.headers);
+      return jsonResponse({
+        id: "m",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.chatCompletion({
+      model: "m",
+      messages: [{ role: "user", content: "hi" }],
+      context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+      speed: "fast",
+    });
+
+    const beta = (seen as unknown as Headers).get("anthropic-beta") ?? "";
+    expect(beta).toContain("context-management-2025-06-27");
+    expect(beta).toContain("fast-mode-2026-02-01");
   });
 
   it("throws UpstreamError on a persistent non-401 error", async () => {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -48,6 +48,9 @@ const ANTHROPIC_VERSION = "2023-06-01";
 // for the OAuth subscription endpoint — without them it 401/403s.
 const CLAUDE_CODE_VERSION = "1.0.0";
 const OAUTH_BETA = "claude-code-20250219,oauth-2025-04-20";
+const CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27";
+const COMPACT_BETA = "compact-2026-01-12";
+const FAST_MODE_BETA = "fast-mode-2026-02-01";
 const SYSTEM_SPOOF = "You are Claude Code, Anthropic's official CLI for Claude.";
 
 // ── request translation: OpenAI-Chat IR -> Anthropic Messages ────────────────
@@ -72,6 +75,34 @@ function hasExplicitCacheControl(value: unknown): boolean {
   const obj = value as Record<string, unknown>;
   if (Object.hasOwn(obj, "cache_control")) return true;
   return Object.values(obj).some(hasExplicitCacheControl);
+}
+
+function normalizeAnthropicContextManagement(value: unknown): unknown {
+  return Array.isArray(value) ? { edits: value } : value;
+}
+
+function contextManagementEdits(value: unknown): unknown[] {
+  const normalized = normalizeAnthropicContextManagement(value);
+  if (normalized && typeof normalized === "object" && !Array.isArray(normalized)) {
+    const edits = (normalized as Record<string, unknown>).edits;
+    return Array.isArray(edits) ? edits : [];
+  }
+  return [];
+}
+
+function betaHeaderForBody(body: Record<string, unknown>): string {
+  const betas = new Set(OAUTH_BETA.split(","));
+  if (body.context_management !== undefined) {
+    betas.add(CONTEXT_MANAGEMENT_BETA);
+    for (const edit of contextManagementEdits(body.context_management)) {
+      if (edit && typeof edit === "object") {
+        const type = (edit as Record<string, unknown>).type;
+        if (type === "compact_20260112" || type === "compaction") betas.add(COMPACT_BETA);
+      }
+    }
+  }
+  if (body.speed === "fast") betas.add(FAST_MODE_BETA);
+  return [...betas].join(",");
 }
 
 function textBlocksFromContent(content: unknown, messageCacheControl?: unknown): AnthropicBlock[] {
@@ -207,6 +238,13 @@ export function openaiToAnthropicRequest(
   if (typeof r.top_p === "number") body.top_p = r.top_p;
   if (typeof r.top_k === "number") body.top_k = r.top_k;
   if (r.thinking && typeof r.thinking === "object") body.thinking = r.thinking;
+  if (r.context_management !== undefined) {
+    body.context_management = normalizeAnthropicContextManagement(r.context_management);
+  }
+  if (r.mcp_servers !== undefined) body.mcp_servers = r.mcp_servers;
+  if (r.container !== undefined) body.container = r.container;
+  if (r.speed !== undefined) body.speed = r.speed;
+  if (r.output_config !== undefined) body.output_config = r.output_config;
   if (r.stream === true) body.stream = true;
   if (typeof r.stop === "string") body.stop_sequences = [r.stop];
   else if (Array.isArray(r.stop)) body.stop_sequences = r.stop;
@@ -358,7 +396,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     throw new Error("anthropic client requires exactly one of `apiKey` or `getAuthHeader`");
   }
 
-  async function headers(): Promise<Record<string, string>> {
+  async function headers(body: Record<string, unknown>): Promise<Record<string, string>> {
     const h: Record<string, string> = {
       "Content-Type": "application/json",
       // Header parity with openclaw's OAuth recipe — both are load-bearing for the
@@ -366,7 +404,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
       accept: "application/json",
       "anthropic-dangerous-direct-browser-access": "true",
       "anthropic-version": ANTHROPIC_VERSION,
-      "anthropic-beta": OAUTH_BETA,
+      "anthropic-beta": betaHeaderForBody(body),
       "user-agent": `claude-cli/${CLAUDE_CODE_VERSION}`,
       "x-app": "cli",
     };
@@ -402,7 +440,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     try {
       return await doFetch(url, {
         method: "POST",
-        headers: await headers(),
+        headers: await headers(body),
         body: JSON.stringify(body),
         signal: t.signal,
       });

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -153,6 +153,19 @@ describe("openaiToResponsesRequest", () => {
     });
   });
 
+  it("normalizes Chat tool_choice to the Responses top-level-name shape", () => {
+    const body = openaiToResponsesRequest({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "weather?" }],
+      tools: [
+        { type: "function", function: { name: "get_weather", parameters: { type: "object" } } },
+      ],
+      tool_choice: { type: "function", function: { name: "get_weather" } },
+    });
+
+    expect(body.tool_choice).toEqual({ type: "function", name: "get_weather" });
+  });
+
   it("defaults instructions when no system message is present", () => {
     const body = openaiToResponsesRequest({
       model: "m",

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -184,6 +184,18 @@ function toResponsesInput(messages: Array<Record<string, unknown>>): ResponsesIt
   return out;
 }
 
+function chatToolChoiceToResponses(toolChoice: unknown): unknown {
+  if (typeof toolChoice !== "object" || toolChoice === null || Array.isArray(toolChoice)) {
+    return toolChoice;
+  }
+  const choice = toolChoice as { type?: unknown; name?: unknown; function?: unknown };
+  if (choice.type !== "function") return toolChoice;
+  if (typeof choice.name === "string") return toolChoice;
+  if (typeof choice.function !== "object" || choice.function === null) return toolChoice;
+  const fn = choice.function as { name?: unknown };
+  return typeof fn.name === "string" ? { type: "function", name: fn.name } : toolChoice;
+}
+
 export function openaiToResponsesRequest(
   req: ChatCompletionRequest,
   opts?: { sessionId?: string },
@@ -221,6 +233,7 @@ export function openaiToResponsesRequest(
   // dropped here. The IR has already normalized any unknown tier to a known one.
   if (typeof r.reasoning_effort === "string" && r.reasoning_effort.length > 0)
     body.reasoning = { effort: r.reasoning_effort };
+  if (r.tool_choice !== undefined) body.tool_choice = chatToolChoiceToResponses(r.tool_choice);
   if (Array.isArray(r.tools)) {
     const tools = (r.tools as Array<Record<string, unknown>>).flatMap((t) => {
       const fn = (t.function ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Normalize Responses function `tool_choice` both ways and make Codex Responses provider emit the Responses-native shape.
- Preserve Anthropic native controls through `provider_raw`, forward them in the Anthropic provider, and add request-scoped beta headers.
- Round-trip Gemini `safetySettings` and fail closed for unsupported `previous_response_id` tool-output continuation.

## Validation
- `pnpm vitest run packages/core/src/protocol/responses.test.ts packages/core/src/protocol/anthropic/request.test.ts packages/core/src/protocol/gemini/gemini-transformer.test.ts packages/core/src/provider/openai-responses.test.ts packages/core/src/provider/anthropic.test.ts apps/gateway/src/routes/execute.test.ts`
- Prior validation before follow-up branch: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm --filter @helm/gateway test:e2e`

## Notes
This is a follow-up branch because `fix/codex-stream-ttfb` is already attached to merged PR #201, so new commits there do not produce a new open review surface.
