### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.11.11",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.12.0** — minor bump 0.11.11 → 0.12.0.

Ships 4 commits unreleased since v0.11.11 (two `feat`s → minor):

- **#203 feat(dashboard): token accounting on the admin homepage** — new `/admin/api/stats` route, new store ports + additive SQLite/Postgres migrations, dashboard token totals.
- **feat(config): add claude-fable-5 support** — new `claude-fable` vendor-family lane (`anthropic/claude-fable-5` → `premium`) + `claude-fable-*` alias glob. New public routing surface.
- **#202 Fix protocol interop edge cases**
- **#201 fix(responses): open stream before upstream routing**

`publish.yml` will auto-cut tag `v0.12.0` + GitHub Release + GHCR `:0.12.0`/`:latest` on merge. New `claude-fable` lane config will be merged to the la.atmy.work box as a separate, diff-first step (bind-mount shadows the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)