### PR TITLE
feat(admin): surface concurrency, memory defaults, and budget window on the keys list

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -552,5 +552,7 @@
   "Point the Gemini CLI at Helm with these environment variables. The base URL is the bare origin — the CLI appends /v1beta/models/{model}:generateContent itself.": "Point the Gemini CLI at Helm with these environment variables. The base URL is the bare origin — the CLI appends /v1beta/models/{model}:generateContent itself.",
   "Or call Helm's native Gemini route directly. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "Or call Helm's native Gemini route directly. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.",
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.",
-  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one."
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.",
+  "Concurrency": "Concurrency",
+  "Memory": "Memory"
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -543,5 +543,7 @@
   "Point the Gemini CLI at Helm with these environment variables. The base URL is the bare origin — the CLI appends /v1beta/models/{model}:generateContent itself.": "Gemini CLI を Helm に向けるには、この環境変数を設定します。base URL はオリジンそのまま——CLI が /v1beta/models/{model}:generateContent を自動で付けます。",
   "Or call Helm's native Gemini route directly. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "または Helm のネイティブ Gemini ルートを直接呼び出します。base URL はオリジンそのまま、リクエストパスに /v1beta/models/{model}:generateContent を付け、認証には x-goog-api-key を使います。",
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "OpenAI 互換の provider を設定します。base URL は /v1 で終わります。Anthropic 経路の場合はオリジンそのままを使ってください。",
-  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI または Anthropic 互換の SDK ならどれでも使えます——変えるのは base URL とキーだけ。OpenAI の base URL には /v1 が付き、Anthropic には付かない点に注意してください。"
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI または Anthropic 互換の SDK ならどれでも使えます——変えるのは base URL とキーだけ。OpenAI の base URL には /v1 が付き、Anthropic には付かない点に注意してください。",
+  "Concurrency": "同時実行",
+  "Memory": "メモリ"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -543,5 +543,7 @@
   "Point the Gemini CLI at Helm with these environment variables. The base URL is the bare origin — the CLI appends /v1beta/models/{model}:generateContent itself.": "Gemini CLI를 Helm으로 향하게 하려면 다음 환경 변수를 설정하세요. base URL은 오리진 그대로이며 — CLI가 /v1beta/models/{model}:generateContent를 자동으로 붙입니다.",
   "Or call Helm's native Gemini route directly. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "또는 Helm의 네이티브 Gemini 경로를 직접 호출하세요. base URL은 오리진 그대로이고, 요청 경로에 /v1beta/models/{model}:generateContent를 붙이며 인증은 x-goog-api-key를 사용합니다.",
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "OpenAI 호환 provider를 설정하세요. base URL은 /v1로 끝납니다. Anthropic 경로에서는 오리진 그대로를 사용하세요.",
-  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI 또는 Anthropic 호환 SDK라면 무엇이든 동작합니다 — base URL과 키만 바꾸면 됩니다. OpenAI base URL에는 /v1이 붙고 Anthropic에는 붙지 않는 점에 유의하세요."
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI 또는 Anthropic 호환 SDK라면 무엇이든 동작합니다 — base URL과 키만 바꾸면 됩니다. OpenAI base URL에는 /v1이 붙고 Anthropic에는 붙지 않는 점에 유의하세요.",
+  "Concurrency": "동시성",
+  "Memory": "메모리"
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -552,5 +552,7 @@
   "Point the Gemini CLI at Helm with these environment variables. The base URL is the bare origin — the CLI appends /v1beta/models/{model}:generateContent itself.": "把 Gemini CLI 指向 Helm，只需设置这两个环境变量。base URL 用裸域名——CLI 会自行补上 /v1beta/models/{model}:generateContent。",
   "Or call Helm's native Gemini route directly. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "或者直接调用 Helm 的原生 Gemini 路由。base URL 用裸域名；请求路径再加 /v1beta/models/{model}:generateContent，认证使用 x-goog-api-key。",
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "配置一个兼容 OpenAI 的 provider。base URL 以 /v1 结尾；若走 Anthropic 路径，则改用裸域名。",
-  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何兼容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密钥。留意：OpenAI 的 base URL 带 /v1，Anthropic 的不带。"
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何兼容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密钥。留意：OpenAI 的 base URL 带 /v1，Anthropic 的不带。",
+  "Concurrency": "并发",
+  "Memory": "记忆"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -546,5 +546,7 @@
   "Point the Gemini CLI at Helm with these environment variables. The base URL is the bare origin — the CLI appends /v1beta/models/{model}:generateContent itself.": "把 Gemini CLI 指向 Helm，只需設定這兩個環境變數。base URL 用裸網域——CLI 會自行補上 /v1beta/models/{model}:generateContent。",
   "Or call Helm's native Gemini route directly. The base URL is the bare origin; the request path adds /v1beta/models/{model}:generateContent, and auth uses x-goog-api-key.": "或者直接呼叫 Helm 的原生 Gemini 路由。base URL 用裸網域；請求路徑再加 /v1beta/models/{model}:generateContent，認證使用 x-goog-api-key。",
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "設定一個相容 OpenAI 的 provider。base URL 以 /v1 結尾；若走 Anthropic 路徑，則改用裸網域。",
-  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何相容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密鑰。留意：OpenAI 的 base URL 帶 /v1，Anthropic 的不帶。"
+  "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何相容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密鑰。留意：OpenAI 的 base URL 帶 /v1，Anthropic 的不帶。",
+  "Concurrency": "並發",
+  "Memory": "記憶"
 }

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -57,6 +57,10 @@
     if (key.budget_requests !== null) parts.push(`${key.budget_requests} req`);
     if (key.budget_tokens !== null) parts.push(`${key.budget_tokens} tok`);
     if (key.budget_spend_usd !== null) parts.push(`$${key.budget_spend_usd}`);
+    // The rolling window only matters once a cap exists (no cap = no budget at all).
+    if (parts.length > 0 && key.budget_window_seconds !== null) {
+      parts.push(`${key.budget_window_seconds}s`);
+    }
     return parts;
   }
 
@@ -183,6 +187,7 @@
             <th class="px-3 py-2">{$t('Caps')}</th>
             <th class="px-3 py-2">{$t('Rate limit')}</th>
             <th class="px-3 py-2">{$t('Budget')}</th>
+            <th class="px-3 py-2">{$t('Memory')}</th>
             <th class="px-3 py-2">{$t('Status')}</th>
             <th class="px-3 py-2"></th>
           </tr>
@@ -218,6 +223,10 @@
               <td class="px-3 py-2 text-ink-muted">
                 <div>{$t('RPM')}: {limitLabel(key.rate_limit_rpm)}</div>
                 <div>{$t('TPM')}: {limitLabel(key.rate_limit_tpm)}</div>
+                <!-- Concurrency null = unlimited (NOT inherit), unlike the rate limits above. -->
+                <div>
+                  {$t('Concurrency')}: {key.concurrency_limit ?? $t('Unlimited')}
+                </div>
               </td>
               <td class="px-3 py-2 text-ink-muted">
                 {#if budgetParts(key).length > 0}
@@ -229,6 +238,21 @@
                   </div>
                 {:else}
                   <span>{$t('None')}</span>
+                {/if}
+              </td>
+              <td class="px-3 py-2 text-ink-muted">
+                {#if key.memory_mode === 'off'}
+                  <span>{$t('Off')}</span>
+                {:else}
+                  <div>
+                    <span>{key.memory_mode === 'observe' ? $t('Observe') : $t('Inject')}</span>
+                    {#if key.memory_thread_source === 'auto'}
+                      <span class="text-xs">· {$t('auto thread')}</span>
+                    {/if}
+                  </div>
+                  {#if key.memory_project_id}
+                    <div class="text-xs"><span>{key.memory_project_id}</span></div>
+                  {/if}
                 {/if}
               </td>
               <td class="px-3 py-2">

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -72,10 +72,7 @@ describe('keys page', () => {
   });
 
   it('shows the key name in the row, and an "unnamed" placeholder when null', () => {
-    renderPage([
-      key('k1', { name: 'Production backend' }),
-      key('k2', { name: null }),
-    ]);
+    renderPage([key('k1', { name: 'Production backend' }), key('k2', { name: null })]);
     const rows = screen.getAllByTestId('key-row');
     expect(within(rows[0]).getByText('Production backend')).toBeInTheDocument();
     expect(within(rows[1]).getByText(/unnamed/i)).toBeInTheDocument();
@@ -97,7 +94,9 @@ describe('keys page', () => {
 
     // Re-open and clear the name → PATCH sends null (cleared), not undefined.
     updateKey.mockClear();
-    await fireEvent.click(within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }));
+    await fireEvent.click(
+      within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }),
+    );
     dialog = screen.getByRole('dialog', { name: /edit key/i });
     await fireEvent.input(within(dialog).getByLabelText(/^name$/i), { target: { value: '   ' } });
     await fireEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
@@ -157,6 +156,39 @@ describe('keys page', () => {
     // on both the RPM and TPM lines.
     expect(within(rows[0]).getByText(/60/)).toBeInTheDocument();
     expect(within(rows[1]).getAllByText(/default/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows the concurrency limit in the row (number, and "unlimited" when null)', () => {
+    renderPage([key('k1', { concurrency_limit: 5 }), key('k2', { concurrency_limit: null })]);
+    const rows = screen.getAllByTestId('key-row');
+    expect(within(rows[0]).getByText(/concurrency.*5/i)).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/concurrency.*unlimited/i)).toBeInTheDocument();
+  });
+
+  it('shows the memory defaults in the row (mode + thread source + project; "Off" when off)', () => {
+    renderPage([
+      key('k1', {
+        memory_mode: 'inject',
+        memory_thread_source: 'auto',
+        memory_project_id: 'proj-a',
+      }),
+      key('k2', { memory_mode: 'observe', memory_thread_source: 'header' }),
+      key('k3', { memory_mode: 'off' }),
+    ]);
+    const rows = screen.getAllByTestId('key-row');
+    expect(within(rows[0]).getByText(/inject/i)).toBeInTheDocument();
+    expect(within(rows[0]).getByText(/auto thread/i)).toBeInTheDocument();
+    expect(within(rows[0]).getByText('proj-a')).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/observe/i)).toBeInTheDocument();
+    expect(within(rows[1]).queryByText(/auto thread/i)).not.toBeInTheDocument();
+    expect(within(rows[2]).getByText(/^off$/i)).toBeInTheDocument();
+  });
+
+  it('shows the budget window alongside the caps in the budget cell', () => {
+    renderPage([key('k1', { budget_requests: 100, budget_window_seconds: 3600 })]);
+    const row = screen.getByTestId('key-row');
+    expect(within(row).getByText(/100 req/)).toBeInTheDocument();
+    expect(within(row).getByText(/3600\s*s/i)).toBeInTheDocument();
   });
 
   it('Edit opens a dialog and PATCHes the full editable cap set via updateKey', async () => {
@@ -222,7 +254,9 @@ describe('keys page', () => {
 
   it('presents the Edit dialog as a centered modal dismissible via scrim and Escape', async () => {
     renderPage([key('k1')]);
-    await fireEvent.click(within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }));
+    await fireEvent.click(
+      within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }),
+    );
     expect(screen.getByRole('dialog', { name: /edit key/i })).toBeInTheDocument();
     // Clicking the backdrop scrim closes the modal.
     await fireEvent.click(screen.getByTestId('modal-scrim'));
@@ -231,7 +265,9 @@ describe('keys page', () => {
     );
 
     // Re-open and close via Escape.
-    await fireEvent.click(within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }));
+    await fireEvent.click(
+      within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }),
+    );
     expect(screen.getByRole('dialog', { name: /edit key/i })).toBeInTheDocument();
     await fireEvent.keyDown(window, { key: 'Escape' });
     await waitFor(() =>
@@ -241,7 +277,9 @@ describe('keys page', () => {
 
   it('presents the revoke confirmation as a centered modal', async () => {
     renderPage([key('k1', { prefix: 'helm_live_ab12' })]);
-    await fireEvent.click(within(screen.getByTestId('key-row')).getByRole('button', { name: /revoke/i }));
+    await fireEvent.click(
+      within(screen.getByTestId('key-row')).getByRole('button', { name: /revoke/i }),
+    );
     const dialog = screen.getByRole('dialog', { name: /confirm revoke/i });
     expect(within(dialog).getByRole('button', { name: /confirm/i })).toBeInTheDocument();
     // The scrim dismisses the confirmation (same as Cancel) without revoking.
@@ -259,10 +297,7 @@ describe('keys page', () => {
   });
 
   it('offers Delete (not Edit/Revoke) only on a revoked key', () => {
-    renderPage([
-      key('active', { disabled: false }),
-      key('revoked', { disabled: true }),
-    ]);
+    renderPage([key('active', { disabled: false }), key('revoked', { disabled: true })]);
     const rows = screen.getAllByTestId('key-row');
     // Active row: Edit + Revoke, no Delete.
     expect(within(rows[0]).getByRole('button', { name: /^edit$/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

The /admin/keys list was missing several important per-key caps that the create/edit dialog (`KeyCapsForm`) already manages. This PR surfaces them in the list:

- **Concurrency limit** — third line in the Rate limit cell: `Concurrency: 5` or `Concurrency: Unlimited`. Copy deliberately differs from RPM/TPM, where `null` means *inherit the system default*; for concurrency `null` means *unlimited*.
- **Memory defaults** — new Memory column showing the mode (`Off` / `Observe` / `Inject`), an `· auto thread` marker when the thread source is auto-derived, and the default project id when set. Previously invisible despite changing how the gateway treats every request from the key (issue #97).
- **Budget window** — the budget cell now appends the rolling window (e.g. `100 req · 3600s`), only when at least one cap exists.

i18n: added the two new keys (`Concurrency`, `Memory`) to all five locale dictionaries; the remaining strings already had translations from the dialog.

## Test plan

- [x] 3 new tests in `keys.test.ts` (written first per TDD): concurrency display, memory defaults display, budget window display
- [x] Full admin suite: 352 tests / 39 files passing
- [x] `svelte-check`: no new errors (3 pre-existing in `oauth.test.ts`, untouched here)
- [x] Prettier formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)