### PR TITLE
feat(admin): surface proxy + effective models on /admin/providers list

### DIFF
--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -16,6 +16,15 @@ export interface OAuthAccount {
   // priority = served first; schedulable false parks the account out of rotation.
   priority: number;
   schedulable: boolean;
+  // The account's egress proxy, REDACTED (never the password — only `hasPassword`),
+  // or null for a direct connection. Folded onto the row by the gateway so the list
+  // shows which proxy each account tunnels through without the per-account GET the
+  // Manage dialog uses.
+  proxy: AccountProxyView | null;
+  // The effective routable models for this account (network-free): the operator's
+  // curated subset, else the provider's curated default. The SAME set the Lanes
+  // catalog exposes, so the list never claims a model that won't route.
+  models: string[];
 }
 
 export interface OAuthProviderStatus {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -127,6 +127,7 @@
   "Device": "Device",
   "Didn't open? Reopen the sign-in page": "Didn't open? Reopen the sign-in page",
   "Dimension": "Dimension",
+  "Direct": "Direct",
   "Direction": "Direction",
   "disabled": "disabled",
   "Disconnect": "Disconnect",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -122,6 +122,7 @@
   "Device": "デバイス",
   "Didn't open? Reopen the sign-in page": "開きませんでしたか？サインインページを再度開く",
   "Dimension": "次元",
+  "Direct": "直接接続",
   "Direction": "方向",
   "disabled": "無効",
   "Disconnect": "切断",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -122,6 +122,7 @@
   "Device": "기기",
   "Didn't open? Reopen the sign-in page": "열리지 않았나요? 로그인 페이지 다시 열기",
   "Dimension": "차원",
+  "Direct": "직접 연결",
   "Direction": "방향",
   "disabled": "비활성화됨",
   "Disconnect": "연결 해제",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -127,6 +127,7 @@
   "Device": "设备码",
   "Didn't open? Reopen the sign-in page": "没有打开？重新打开登录页面",
   "Dimension": "维度",
+  "Direct": "直连",
   "Direction": "方向",
   "disabled": "已禁用",
   "Disconnect": "断开连接",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -122,6 +122,7 @@
   "Device": "裝置碼",
   "Didn't open? Reopen the sign-in page": "沒有開啟？重新開啟登入頁面",
   "Dimension": "維度",
+  "Direct": "直連",
   "Direction": "方向",
   "disabled": "已停用",
   "Disconnect": "中斷連線",

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -67,6 +67,30 @@
     return p.flow === 'device_code' ? $t('Device') : 'OAuth';
   }
 
+  // How many model pills to render inline before collapsing the rest into a "+N"
+  // pill (Copilot can expose 20+; the full list rides in the cell's title tooltip).
+  const MODELS_SHOWN = 3;
+
+  // Compact egress-proxy label ("socks5 · 10.0.0.1:1080"), or null when the account
+  // connects directly. The gateway already REDACTED the password (only `hasPassword`
+  // crosses), so nothing secret is rendered.
+  function proxyLabel(p: OAuthAccount['proxy']): string | null {
+    if (!p) return null;
+    return `${p.type} · ${p.host}:${p.port}`;
+  }
+
+  // Fuller proxy detail for the hover tooltip — adds the auth shape (username +
+  // whether a password is set) WITHOUT the secret itself.
+  function proxyTitle(p: OAuthAccount['proxy']): string {
+    if (!p) return '';
+    const auth = p.username
+      ? ` · ${p.username}${p.hasPassword ? ':••••' : ''}`
+      : p.hasPassword
+        ? ' · ••••'
+        : '';
+    return `${p.type}://${p.host}:${p.port}${auth}`;
+  }
+
   // The access token is short-lived and auto-renewed by the gateway, so a lapsed one
   // is NOT an alarm — show "auto-renews"; when valid, the remaining time hints at the
   // next renewal. Coarsening (incl. the ">24h ⇒ days" rule) lives in `durationParts`
@@ -280,6 +304,8 @@
           <tr>
             <th class="px-3 py-2">{$t('Provider')}</th>
             <th class="px-3 py-2">{$t('Status')}</th>
+            <th class="px-3 py-2">{$t('Proxy')}</th>
+            <th class="px-3 py-2">{$t('Models')}</th>
             <th class="px-3 py-2">{$t('Today')}</th>
             <th class="px-3 py-2">{$t('Quota')}</th>
             <th class="px-3 py-2">{$t('Priority')}</th>
@@ -311,6 +337,35 @@
                 {/if}
                 {#if !row.account.schedulable}
                   <div class="mt-1"><span class="badge-neutral">{$t('parked')}</span></div>
+                {/if}
+              </td>
+
+              <!-- Egress proxy (redacted; "Direct" when none) -->
+              <td class="px-3 py-3 text-xs">
+                {#if proxyLabel(row.account.proxy)}
+                  <span class="badge-neutral font-mono" title={proxyTitle(row.account.proxy)}
+                    >{proxyLabel(row.account.proxy)}</span
+                  >
+                {:else}
+                  <span class="text-ink-muted">{$t('Direct')}</span>
+                {/if}
+              </td>
+
+              <!-- Effective routable models (network-free; pills capped +N) -->
+              <td class="px-3 py-3">
+                {#if row.account.models.length > 0}
+                  {@const shown = row.account.models.slice(0, MODELS_SHOWN)}
+                  {@const extra = row.account.models.length - shown.length}
+                  <div class="flex w-48 flex-wrap gap-1" title={row.account.models.join('\n')}>
+                    {#each shown as m (m)}
+                      <span class="badge-neutral font-mono text-[10px]">{m}</span>
+                    {/each}
+                    {#if extra > 0}
+                      <span class="badge-neutral text-[10px]">+{extra}</span>
+                    {/if}
+                  </div>
+                {:else}
+                  <span class="text-xs text-ink-muted">—</span>
                 {/if}
               </td>
 

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -39,6 +39,10 @@ function provider(overrides: Partial<OAuthProviderStatus> = {}): OAuthProviderSt
         healthy: true,
         priority: 10,
         schedulable: true,
+        // Redacted egress proxy (password never crosses) + effective routable models,
+        // both folded onto the row by the gateway — the two new list columns.
+        proxy: { type: 'socks5', host: '10.0.0.1', port: 1080, hasPassword: true },
+        models: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
       },
     ],
     ...overrides,
@@ -109,6 +113,37 @@ describe('providers page', () => {
     expect(within(row).getByText('74%')).toBeInTheDocument();
     expect(within(row).getByDisplayValue('10')).toBeInTheDocument();
     expect(within(row).getByRole('checkbox', { name: /schedulable/i })).toBeChecked();
+    // Proxy column: the redacted egress hop, compact "type · host:port".
+    expect(within(row).getByText('socks5 · 10.0.0.1:1080')).toBeInTheDocument();
+    // Models column: each effective model as a pill (3 ≤ cap, so all show, no "+N").
+    expect(within(row).getByText('claude-opus-4-6')).toBeInTheDocument();
+    expect(within(row).getByText('claude-haiku-4-5')).toBeInTheDocument();
+  });
+
+  it('renders "Direct" and caps the models list with a +N pill', () => {
+    renderPage({
+      providers: [
+        provider({
+          accounts: [
+            {
+              account: 'acct-copilot',
+              expiresAt: null,
+              updatedAt: Date.now(),
+              healthy: true,
+              priority: 50,
+              schedulable: true,
+              proxy: null, // direct connection
+              models: ['m1', 'm2', 'm3', 'm4', 'm5'], // 5 > cap of 3 → "+2"
+            },
+          ],
+        }),
+      ],
+    });
+    const row = screen.getByTestId('provider-account-row');
+    expect(within(row).getByText('Direct')).toBeInTheDocument();
+    expect(within(row).getByText('m3')).toBeInTheDocument();
+    expect(within(row).queryByText('m4')).not.toBeInTheDocument(); // collapsed
+    expect(within(row).getByText('+2')).toBeInTheDocument();
   });
 
   it('shows the not-configured warning and disables Connect when OAuth is unavailable', () => {

--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -572,6 +572,63 @@ describe("createOAuthAdmin", () => {
     });
   });
 
+  it("listStatus surfaces each account's redacted proxy + effective models (network-free)", async () => {
+    const { tokens, config } = makeStores();
+    let seq = 0;
+    const admin = createOAuthAdmin({
+      store: tokens,
+      encKey: KEY,
+      config,
+      genSessionId: () => `s${++seq}`,
+    });
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([
+        [/oauth\/token/, () => json({ access_token: "AT", refresh_token: "RT", expires_in: 3600 })],
+      ]),
+    );
+    for (const account of ["proxied", "bare"]) {
+      const { sessionId, authorizeUrl } = await admin.startManualPaste({ providerId: "anthropic" });
+      const state = new URL(authorizeUrl).searchParams.get("state");
+      await admin.completeManualPaste({
+        sessionId,
+        redirectInput: `https://x/cb?code=C&state=${state}`,
+        account,
+      });
+    }
+    // One account pins a proxy (with a password) + a curated model subset; the other
+    // is left untouched (direct connection, curated-fallback models).
+    await admin.setAccountProxy({
+      providerId: "anthropic",
+      account: "proxied",
+      proxy: { type: "socks5", host: "10.0.0.1", port: 1080, username: "u", password: "secret" },
+    });
+    await admin.setEnabledModels({
+      providerId: "anthropic",
+      account: "proxied",
+      models: ["claude-opus-4-6"],
+    });
+    const accts = (await admin.listStatus()).find((p) => p.id === "anthropic")?.accounts ?? [];
+
+    const proxied = accts.find((a) => a.account === "proxied");
+    // Proxy is surfaced REDACTED (principle 7: hasPassword, never the secret).
+    expect(proxied?.proxy).toEqual({
+      type: "socks5",
+      host: "10.0.0.1",
+      port: 1080,
+      username: "u",
+      hasPassword: true,
+    });
+    expect(JSON.stringify(proxied)).not.toContain("secret");
+    // Effective models = the operator's curated subset verbatim.
+    expect(proxied?.models).toEqual(["claude-opus-4-6"]);
+
+    const bare = accts.find((a) => a.account === "bare");
+    // No proxy configured → null (direct connection); models fall back to curated.
+    expect(bare?.proxy).toBeNull();
+    expect(bare?.models).toEqual(["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"]);
+  });
+
   // ── per-account pool scheduling (Stage 3) ──────────────────────────────────
   it("getAccountSchedule returns the defaults (priority 50, schedulable true)", async () => {
     const { tokens, config } = makeStores();

--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -32,6 +32,7 @@ import type {
   OAuthAdminStatus,
 } from "../routes/admin/deps.js";
 import { getAccountSettings, loadAccountSettings, setAccountSettings } from "./account-settings.js";
+import { effectiveAccountModels } from "./effective-models.js";
 
 // Admin OAuth-login orchestration (issue #38) — the implementation behind the
 // OAuthAdminAccess seam the /admin/api/oauth routes call. Owns the ephemeral
@@ -186,6 +187,24 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     if (!proxy) return;
     await setAccountSettings(deps.config, deps.encKey, providerId, account, { proxy });
   }
+  // Project a stored proxy into the REDACTED admin view (principle 7): the password
+  // is NEVER echoed, only whether one is set. Shared by listStatus (folds it onto
+  // every row) and getAccountProxy (the Manage dialog's per-account read) so the two
+  // can never drift in what they reveal. null in ⇒ null out (direct connection).
+  function redactProxy(
+    proxy:
+      | { type: "http" | "https" | "socks5"; host: string; port: number; username?: string; password?: string }
+      | undefined,
+  ): AccountProxyView | null {
+    if (!proxy) return null;
+    return {
+      type: proxy.type,
+      host: proxy.host,
+      port: proxy.port,
+      ...(proxy.username !== undefined ? { username: proxy.username } : {}),
+      hasPassword: typeof proxy.password === "string" && proxy.password.length > 0,
+    };
+  }
   const sessions = new Map<string, Session>();
   // Per-account Anthropic quota cache (5-min TTL): key `anthropic <account>`.
   // Caches the OUTCOME of a usage fetch — windows on success, `null` on failure —
@@ -285,6 +304,13 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
             )),
             priority: sch.priority ?? 50,
             schedulable: sch.schedulable ?? true,
+            // Both folded from the SAME settings blob (zero extra network): the
+            // redacted egress proxy (principle 7) and the effective routable models
+            // — the SAME network-free set synthesizeOAuthProviders exposes to Lanes
+            // (operator curation verbatim, else the curated fallback). Live discovery
+            // stays in the Manage dialog; the list never fans out per account.
+            proxy: redactProxy(sch.proxy),
+            models: effectiveAccountModels(sch, r.providerId),
           };
         }),
       );
@@ -455,21 +481,12 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     },
 
     async getAccountProxy({ providerId, account }): Promise<AccountProxyView | null> {
-      const proxy = getAccountSettings(
-        await loadAccountSettings(deps.config, deps.encKey),
-        providerId,
-        account,
-      ).proxy;
-      if (!proxy) return null;
       // REDACT the password (principle 7): the admin read surface returns only
-      // whether one is set, never the secret itself.
-      return {
-        type: proxy.type,
-        host: proxy.host,
-        port: proxy.port,
-        ...(proxy.username !== undefined ? { username: proxy.username } : {}),
-        hasPassword: typeof proxy.password === "string" && proxy.password.length > 0,
-      };
+      // whether one is set, never the secret itself. Shared with listStatus.
+      return redactProxy(
+        getAccountSettings(await loadAccountSettings(deps.config, deps.encKey), providerId, account)
+          .proxy,
+      );
     },
 
     async setAccountProxy({ providerId, account, proxy }): Promise<void> {

--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -193,7 +193,13 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
   // can never drift in what they reveal. null in ⇒ null out (direct connection).
   function redactProxy(
     proxy:
-      | { type: "http" | "https" | "socks5"; host: string; port: number; username?: string; password?: string }
+      | {
+          type: "http" | "https" | "socks5";
+          host: string;
+          port: number;
+          username?: string;
+          password?: string;
+        }
       | undefined,
   ): AccountProxyView | null {
     if (!proxy) return null;

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -89,6 +89,17 @@ export interface OAuthAdminStatus {
     // the account (kept connected, never routed).
     priority: number;
     schedulable: boolean;
+    // The account's egress proxy, REDACTED (principle 7: never the password, only
+    // `hasPassword`) — or null for a direct connection. Folded into the list from the
+    // SAME already-loaded settings blob as priority/schedulable, so the providers page
+    // shows "which proxy" without the per-account GET the Manage dialog uses.
+    proxy: AccountProxyView | null;
+    // The effective routable models for this account (network-FREE): the operator's
+    // curated `enabledModels` verbatim, else the provider's curated fallback. Mirrors
+    // exactly what synthesizeOAuthProviders exposes to Lanes, so the list never claims
+    // a model that won't route. Live discovery (Copilot /models) stays in the Manage
+    // dialog — never on this hot-ish page load (principle 1: no network fan-out here).
+    models: string[];
   }>;
 }
 


### PR DESCRIPTION
## What

Each connected subscription account on **/admin/providers** now shows two new columns:

| Column | Shows |
|---|---|
| **Proxy** | The redacted egress proxy as a compact `socks5 · 10.0.0.1:1080` pill (full `type://host:port·user:••••` on hover), or **Direct** when none. The password never crosses the wire — only `hasPassword`. |
| **Models** | The effective routable models as pills (first 3, then `+N` with the full list on hover). |

## Why it's cheap

Both are folded onto every row from the **same per-account settings blob `listStatus()` already loads** (it reads `priority`/`schedulable` from it), so there is **zero extra network call**. The models are the network-free effective set (`settings.enabledModels ?? CURATED_OAUTH_MODELS`) — exactly what `synthesizeOAuthProviders` exposes to Lanes, so the list never claims a model that won't route. Live discovery stays in the Manage dialog.

Deduplicated the proxy redaction into one shared `redactProxy()` helper used by both `listStatus` and `getAccountProxy`, so the two read paths can't drift in what they reveal.

## Tests (TDD, red→green)

- **gateway**: `listStatus surfaces each account's redacted proxy + effective models (network-free)` — asserts the password never appears and `enabledModels` round-trips verbatim.
- **admin**: providers page renders the Proxy/Models columns; plus a "Direct" + `+N` cap case.
- All green: gateway 85/85, admin 350/350, gateway typecheck clean, locale parity 4/4. Added the `Direct` key to all five locales (en/zh-hans/zh-hant/ja/ko).

## Pre-existing diagnostics (not from this change, verified byte-identical to HEAD)

- `oauth.test.ts` tuple errors (149/179/196) — a vitest mock-typing quirk; not in the CI `tsc` gate (admin is excluded from `-r typecheck`).
- `dashboard-locales.test.ts` `cached` diagnostic — from the earlier token-accounting release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)