### PR TITLE
chore(config): bump max_request_bytes default from 2MB to 20MB

### DIFF
--- a/config/runtime.yaml
+++ b/config/runtime.yaml
@@ -1,6 +1,6 @@
 # Runtime limits + rate limiting. Rate limiting is OFF by default (zero friction).
 # Env overrides: HELM_MAX_REQUEST_BYTES, HELM_REQUEST_TIMEOUT_MS, HELM_RATE_LIMIT_ENABLED.
-max_request_bytes: 2000000 # 2 MB
+max_request_bytes: 20000000 # 20 MB (base64 images inflate fast; stateless clients like Codex resend full history)
 request_timeout_ms: 60000
 rate_limit:
   enabled: false

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -64,7 +64,7 @@ describe("HelmConfigSchema", () => {
     expect(parsed.auth.require_api_key).toBe(true);
     expect(parsed.auth.bootstrap.generate_if_missing).toBe(true);
     expect(parsed.auth.bootstrap.print_once).toBe(true);
-    expect(parsed.runtime.max_request_bytes).toBe(2_000_000);
+    expect(parsed.runtime.max_request_bytes).toBe(20_000_000);
     expect(parsed.runtime.request_timeout_ms).toBe(60_000);
     expect(parsed.runtime.rate_limit.enabled).toBe(false);
     expect(parsed.runtime.rate_limit.default.rpm).toBe(0);

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -218,7 +218,7 @@ export const RoutingSignalFeedbackConfigSchema = z
   .strict();
 
 export const RuntimeConfigSchema = z.object({
-  max_request_bytes: z.number().int().positive().default(2_000_000),
+  max_request_bytes: z.number().int().positive().default(20_000_000),
   request_timeout_ms: z.number().int().positive().default(60_000),
   rate_limit: RateLimitConfigSchema,
   // Store driver selection. Defaulted so an absent runtime.store stays on sqlite


### PR DESCRIPTION
## Summary
- Bump `max_request_bytes` default from 2,000,000 to 20,000,000 in the Zod schema (`packages/shared/src/config/schema.ts`) and shipped `config/runtime.yaml`
- Update the schema default-value test to match

## Why
A codex session hit `request body too large` after pasting a single screenshot: base64 encoding inflates images ~33%, and stateless clients (Codex, and any OpenAI-protocol client) resend the full conversation history every turn, so one ~900KB image pushes every subsequent request near the 2MB ceiling. Upstream provider APIs accept far larger bodies (Anthropic 32MB), so 2MB rejects legitimate vision workloads while 20MB still bounds abusive payloads.

Note: deployed instances with an explicit `max_request_bytes` in their operator-owned `runtime.yaml` are unaffected by the schema default change and need their own config edit (or `HELM_MAX_REQUEST_BYTES`).

## Test plan
- [x] `pnpm vitest run` on schema, config loader, config samples, and bodyLimit middleware tests — 81/81 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)