### PR TITLE
chore(release): v0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.12.2.

Unreleased changes since v0.12.1:
- fix(anthropic): stop the Claude Code billing header from busting prompt cache (#208)
- chore(config): bump `max_request_bytes` default 2MB → 20MB (#211)
- feat(admin): surface proxy + effective models on /admin/providers list (#210)
- feat(admin): surface concurrency, memory defaults, and budget window on the keys list (#209)

Merging to `main` bumps `package.json` to a not-yet-released version, which auto-cuts tag `v0.12.2` + GitHub Release + `:0.12.2`/`:latest` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)