### PR TITLE
feat(admin): format large numbers with K/M/B units across keys, dashboard, and providers pages

### DIFF
--- a/apps/admin/src/lib/format.test.ts
+++ b/apps/admin/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { durationParts, formatTimestamp, formatTokens, formatUsd } from './format.js';
+import { durationParts, formatCount, formatTimestamp, formatTokens, formatUsd } from './format.js';
 
 describe('formatTokens — compact token counts for the dashboard', () => {
   it('renders not-measured (null/undefined/NaN) as an em dash', () => {
@@ -29,6 +29,15 @@ describe('formatTokens — compact token counts for the dashboard', () => {
 
   it('clamps a negative count to 0', () => {
     expect(formatTokens(-5)).toBe('0');
+  });
+});
+
+describe('formatCount — compact generic counts (requests, errors)', () => {
+  it('shares the token abbreviation rules: K/M/B at ~3 significant figures', () => {
+    expect(formatCount(42)).toBe('42');
+    expect(formatCount(50_000)).toBe('50K');
+    expect(formatCount(2_000_000)).toBe('2M');
+    expect(formatCount(null)).toBe('—');
   });
 });
 

--- a/apps/admin/src/lib/format.ts
+++ b/apps/admin/src/lib/format.ts
@@ -67,6 +67,13 @@ export function formatTokens(n: number | null | undefined): string {
   return String(Math.round(v));
 }
 
+// Generic compact count (requests, errors, rows…): the abbreviation rules are
+// identical to token counts, so this is the same function under a name that
+// doesn't lie about what it formats. Callers pick the alias that matches the
+// quantity so a future divergence (e.g. tokens gaining a unit suffix) only has
+// to touch one signature.
+export const formatCount = formatTokens;
+
 // Coarse, magnitude-aware breakdown of a duration (in ms) — the SINGLE source of
 // truth for "anything past 24h rolls up to days". Returns just the numbers +
 // which bucket they fall in; callers map the bucket to their own phrasing/i18n

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import type { DashboardStats } from '$lib/api/stats.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
   import TokensCell from '$lib/components/TokensCell.svelte';
-  import { formatTimestamp, formatTokens, formatUsd } from '$lib/format.js';
+  import { formatCount, formatTimestamp, formatTokens, formatUsd } from '$lib/format.js';
   import { DEFAULT_PAGE_SIZE, filtersToSearch, type RangeKey } from '$lib/requests-filters.js';
   import { t } from '$lib/i18n';
 
@@ -49,9 +49,24 @@
     })),
   );
   const TREND_SERIES = $derived([
-    { key: 'input', label: $t('Input tokens'), value: (d: TrendPoint) => d.input, color: 'hsl(217 91% 60%)' },
-    { key: 'output', label: $t('Output tokens'), value: (d: TrendPoint) => d.output, color: 'hsl(160 84% 39%)' },
-    { key: 'cached', label: $t('Cached tokens'), value: (d: TrendPoint) => d.cached, color: 'hsl(38 92% 50%)' },
+    {
+      key: 'input',
+      label: $t('Input tokens'),
+      value: (d: TrendPoint) => d.input,
+      color: 'hsl(217 91% 60%)',
+    },
+    {
+      key: 'output',
+      label: $t('Output tokens'),
+      value: (d: TrendPoint) => d.output,
+      color: 'hsl(160 84% 39%)',
+    },
+    {
+      key: 'cached',
+      label: $t('Cached tokens'),
+      value: (d: TrendPoint) => d.cached,
+      color: 'hsl(38 92% 50%)',
+    },
   ]);
 
   // By-model: total tokens per served model. Legacy/unstamped rows carry a null
@@ -162,7 +177,7 @@
   <div class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">{$t('Requests')}</div>
-      <div class="mt-1 text-2xl font-semibold text-slate-900">{stats.total}</div>
+      <div class="mt-1 text-2xl font-semibold text-slate-900">{formatCount(stats.total)}</div>
     </div>
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
@@ -172,7 +187,7 @@
         {stats.successRate === null ? '—' : `${stats.successRate}%`}
       </div>
       <div class="mt-0.5 text-xs text-slate-400">
-        {$t('Errors: {count}', { count: stats.errors })}
+        {$t('Errors: {count}', { count: formatCount(stats.errors) })}
       </div>
     </div>
     <div class="card">

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -5,6 +5,7 @@
   import CreateKeyDialog from '$lib/components/CreateKeyDialog.svelte';
   import EditKeyDialog from '$lib/components/EditKeyDialog.svelte';
   import Modal from '$lib/components/Modal.svelte';
+  import { durationParts, formatCount, formatTokens, formatUsd } from '$lib/format.js';
   import { t } from '$lib/i18n';
 
   // API key management view. HARD security line (CLAUDE.md Principle 7 / docs/06): the
@@ -42,11 +43,22 @@
   // are editable there EXCEPT the immutable identity and role (see EditKeyDialog).
   let editingKey = $state<ApiKeyView | null>(null);
 
-  // Render a stored limit for display: a number as-is (0 → "unlimited"), null as
-  // the inherit/"default" copy.
+  // Render a stored limit for display: a number compacted (a 2,000,000 TPM cap
+  // reads "2M", not a 7-digit wall), 0 → "unlimited", null → the inherit/"default"
+  // copy.
   function limitLabel(v: number | null): string {
     if (v === null) return $t('Default');
-    return v === 0 ? $t('Unlimited') : String(v);
+    return v === 0 ? $t('Unlimited') : formatCount(v);
+  }
+
+  // Budget rolling window, coarsened to the largest sensible unit ("1h", "30d") —
+  // raw seconds ("2592000s") are unreadable. Shares durationParts with the
+  // providers page so every duration label agrees on the >24h ⇒ days rule.
+  function windowText(seconds: number): string {
+    const p = durationParts(seconds * 1000);
+    if (p.unit === 'dh') return p.h > 0 ? `${p.d}d ${p.h}h` : `${p.d}d`;
+    if (p.unit === 'hm') return p.m > 0 ? `${p.h}h ${p.m}m` : `${p.h}h`;
+    return `${p.m}m`;
   }
 
   // Compact per-key usage-budget summary for the list (docs/06). Shows only the
@@ -54,12 +66,12 @@
   // (degrade lane / reject) is appended so operators see the cost-control posture.
   function budgetParts(key: ApiKeyView): string[] {
     const parts: string[] = [];
-    if (key.budget_requests !== null) parts.push(`${key.budget_requests} req`);
-    if (key.budget_tokens !== null) parts.push(`${key.budget_tokens} tok`);
-    if (key.budget_spend_usd !== null) parts.push(`$${key.budget_spend_usd}`);
+    if (key.budget_requests !== null) parts.push(`${formatCount(key.budget_requests)} req`);
+    if (key.budget_tokens !== null) parts.push(`${formatTokens(key.budget_tokens)} tok`);
+    if (key.budget_spend_usd !== null) parts.push(formatUsd(key.budget_spend_usd));
     // The rolling window only matters once a cap exists (no cap = no budget at all).
     if (parts.length > 0 && key.budget_window_seconds !== null) {
-      parts.push(`${key.budget_window_seconds}s`);
+      parts.push(windowText(key.budget_window_seconds));
     }
     return parts;
   }

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -184,11 +184,33 @@ describe('keys page', () => {
     expect(within(rows[2]).getByText(/^off$/i)).toBeInTheDocument();
   });
 
-  it('shows the budget window alongside the caps in the budget cell', () => {
+  it('shows the budget window alongside the caps in the budget cell, as a duration', () => {
     renderPage([key('k1', { budget_requests: 100, budget_window_seconds: 3600 })]);
     const row = screen.getByTestId('key-row');
     expect(within(row).getByText(/100 req/)).toBeInTheDocument();
-    expect(within(row).getByText(/3600\s*s/i)).toBeInTheDocument();
+    // The raw "3600s" is unreadable — the window renders as a coarse duration.
+    expect(within(row).getByText(/1h/)).toBeInTheDocument();
+    expect(within(row).queryByText(/3600/)).not.toBeInTheDocument();
+  });
+
+  it('abbreviates large budget caps and rate limits with K/M/B units', () => {
+    renderPage([
+      key('k1', {
+        rate_limit_tpm: 2_000_000,
+        budget_requests: 50_000,
+        budget_tokens: 100_000_000,
+        budget_spend_usd: 5,
+        budget_window_seconds: 2_592_000, // 30 days
+      }),
+    ]);
+    const row = screen.getByTestId('key-row');
+    expect(within(row).getByText(/TPM.*2M/)).toBeInTheDocument();
+    expect(within(row).getByText(/50K req/)).toBeInTheDocument();
+    expect(within(row).getByText(/100M tok/)).toBeInTheDocument();
+    expect(within(row).getByText(/\$5\.00/)).toBeInTheDocument();
+    expect(within(row).getByText(/30d/)).toBeInTheDocument();
+    // No raw long number may leak through anywhere in the row.
+    expect(row.textContent).not.toMatch(/\d{5,}/);
   });
 
   it('Edit opens a dialog and PATCHes the full editable cap set via updateKey', async () => {

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -12,7 +12,7 @@
   import ConnectProviderDialog from '$lib/components/ConnectProviderDialog.svelte';
   import ManageAccountDialog from '$lib/components/ManageAccountDialog.svelte';
   import Modal from '$lib/components/Modal.svelte';
-  import { durationParts } from '$lib/format';
+  import { durationParts, formatCount, formatTokens, formatUsd } from '$lib/format';
   import { t } from '$lib/i18n';
 
   // Subscription OAuth login (issue #38). Pure consumer (Principle 1): the gateway
@@ -103,19 +103,6 @@
     if (p.unit === 'dh') return $t('in {d}d {h}h', { d: p.d, h: p.h });
     if (p.unit === 'hm') return $t('in {h}h {m}m', { h: p.h, m: p.m });
     return $t('in {m}m', { m: p.m });
-  }
-
-  // Compact token formatting (240.09M / 18.2k / 412) so a dense cell stays readable.
-  function fmtTokens(n: number): string {
-    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-    return String(n);
-  }
-
-  // Cost is null for flat-rate subscriptions (unpriced) — show "—", not "$0".
-  function fmtCost(n: number | null): string {
-    if (n == null) return '—';
-    return n >= 0.01 || n === 0 ? `$${n.toFixed(2)}` : `$${n.toFixed(4)}`;
   }
 
   // Friendly window labels (provider-specific keys → display).
@@ -372,9 +359,11 @@
               <!-- Today's usage -->
               <td class="px-3 py-3 text-xs">
                 {#if usage && usage.requests > 0}
-                  <div class="text-ink-body">{$t('{n} req', { n: usage.requests })}</div>
-                  <div class="text-ink-muted">{fmtTokens(usage.tokens)} tok</div>
-                  <div class="text-ink-muted">{fmtCost(usage.costUsd)}</div>
+                  <div class="text-ink-body">
+                    {$t('{n} req', { n: formatCount(usage.requests) })}
+                  </div>
+                  <div class="text-ink-muted">{formatTokens(usage.tokens)} tok</div>
+                  <div class="text-ink-muted">{formatUsd(usage.costUsd)}</div>
                   <div class="text-ink-muted">{usage.rpm} RPM</div>
                 {:else}
                   <span class="text-ink-muted">—</span>
@@ -432,7 +421,11 @@
                   disabled={saving}
                   aria-label={$t('Schedulable')}
                   onchange={(e) =>
-                    toggleSchedulable(row.provider.id, row.account.account, e.currentTarget.checked)}
+                    toggleSchedulable(
+                      row.provider.id,
+                      row.account.account,
+                      e.currentTarget.checked,
+                    )}
                 />
               </td>
 

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -1,11 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { invalidateAll } from '$app/navigation';
-import type {
-  OAuthProviderStatus,
-  OAuthQuotaSnapshot,
-  OAuthUsageRow,
-} from '$lib/api/oauth.js';
+import type { OAuthProviderStatus, OAuthQuotaSnapshot, OAuthUsageRow } from '$lib/api/oauth.js';
 import ProvidersPage from './+page.svelte';
 
 const logoutOAuth = vi.fn();
@@ -64,7 +60,9 @@ const quota: OAuthQuotaSnapshot[] = [
   {
     providerId: 'anthropic',
     account: 'acct-claude',
-    windows: [{ key: '5h', usedPercent: 74, resetsAtMs: Date.now() + 3_600_000, windowMinutes: 300 }],
+    windows: [
+      { key: '5h', usedPercent: 74, resetsAtMs: Date.now() + 3_600_000, windowMinutes: 300 },
+    ],
     capturedAt: Date.now(),
     source: 'anthropic',
   },
@@ -108,8 +106,8 @@ describe('providers page', () => {
     expect(within(row).getByText('acct-claude')).toBeInTheDocument();
     expect(within(row).getByText('connected')).toBeInTheDocument();
     expect(within(row).getByText('42 req')).toBeInTheDocument();
-    expect(within(row).getByText('1.5k tok')).toBeInTheDocument();
-    expect(within(row).getByText('$0.03')).toBeInTheDocument();
+    expect(within(row).getByText('1.5K tok')).toBeInTheDocument();
+    expect(within(row).getByText('$0.034')).toBeInTheDocument();
     expect(within(row).getByText('74%')).toBeInTheDocument();
     expect(within(row).getByDisplayValue('10')).toBeInTheDocument();
     expect(within(row).getByRole('checkbox', { name: /schedulable/i })).toBeChecked();


### PR DESCRIPTION
## Problem

Large raw integers were unreadable across the admin UI — the Keys page rendered budget caps like `2000000` TPM, `100000000 tok`, and windows as raw seconds (`2592000s`); the dashboard and providers pages had the same issue (the providers page even carried its own divergent local formatter).

## Changes

- **Keys page**: rate limits (RPM/TPM) and budget caps now go through the shared compact formatters (`2M`, `50K req`, `100M tok`, `$5.00`); the budget window renders as a coarse duration (`1h`, `30d`) via the existing `durationParts` helper.
- **Dashboard**: the Requests stat card and Errors count are compacted with the same K/M/B units.
- **Providers page**: dropped the divergent local `fmtTokens`/`fmtCost` (lowercase `k`, 2-dp `M`, cost collapsing to `$0.03`) in favor of the shared `formatTokens`/`formatUsd` (`1.5K tok`, `$0.034`).
- **format.ts**: exposed `formatCount` as an alias of `formatTokens` — same abbreviation rules under a name that matches the quantity, so a future divergence only touches one signature.

## Tests

- TDD: test expectations updated first, including a new assertion that no raw 5+ digit number leaks through a key row.
- Full admin suite: 39 files / 355 tests, all green. Prettier clean on touched files.
- `svelte-check` shows 3 pre-existing errors in `src/lib/api/oauth.test.ts` — confirmed identical on `main`, file untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)