### PR TITLE
chore(release): v0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.12.3.

Patch bump for the admin-only feature merged in #213:

- **feat(admin): format large numbers with K/M/B units** across keys, dashboard, and providers pages (#213)

No gateway/core/config/infra changes — `git diff v0.12.2..main -- config/ docker-compose* Dockerfile*` is empty.

On merge, publish.yml auto-cuts tag `v0.12.3` + GitHub Release + GHCR `:0.12.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)