### PR TITLE
feat: add international layer1 classifier keywords

### DIFF
--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -31,11 +31,13 @@
 # Golden set grown 29->38 (9 real-world prompts); cascade/calibrate lock 42 real
 # prompts with 0 fallbacks and confidence spread ~0.43-0.98.
 #
-# MULTILINGUAL (2026-06-02, classifier.multilingual-guard): the keyword lists are
-# ENGLISH-ONLY, so Layer-1 is an English fast path. A predominantly non-Latin prompt
-# is forced `uncertain` by the `rules.language` guard (below) → escalates to the
-# multilingual Layer-2 eval. CONTRACT: serve non-English traffic → enable `eval`;
-# with eval OFF a non-Latin prompt degrades deterministically to `balanced`.
+# CJK VOCABULARY + MULTILINGUAL GUARD (2026-06-12, classifier.zh-layer1): Layer-1
+# is now an English + high-confidence CJK fast path. Simplified/Traditional Chinese
+# keywords live in separate *_zh_kw dimensions so English keywordSignal calibration is
+# not diluted. Other non-covered languages, and Chinese prompts that miss these small
+# CJK lists, still trip `rules.language` and escalate to multilingual Layer-2 eval.
+# CONTRACT: serve broad non-English traffic → enable `eval`; with eval OFF uncovered
+# non-Latin prompts degrade deterministically to `balanced`.
 classifier:
   rules:
     enabled: true
@@ -75,6 +77,15 @@ classifier:
       analysis_kw: { weight: 0.76, keywords: ["analyze", "compare", "evaluate", "implications", "root cause", "assess", "critique", "pros and cons", "diagnose", "investigate"] }
       writing_kw: { weight: 0.14, keywords: ["essay", "rewrite", "draft", "tone", "polish", "summarize", "summary", "paraphrase", "proofread", "article", "headline", "grammar"] }
       security_kw: { weight: 1.40, keywords: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "rce", "csrf", "malware", "auth bypass", "auth check", "access control"] }
+      # CJK keyword dimensions are separate from English dimensions so they can
+      # suppress the language guard without diluting English keywordSignal.
+      coding_zh_kw: { weight: 0.56, keywords: ["重构", "重構", "调试", "除錯", "编译", "編譯", "函数", "函式", "单元测试", "單元測試", "堆栈跟踪", "堆疊追蹤"] }
+      analysis_zh_kw: { weight: 0.68, keywords: ["分析", "比較", "比较", "评估", "評估", "根因", "诊断", "診斷", "利弊", "因果关系"] }
+      writing_zh_kw: { weight: 0.12, keywords: ["改写", "改寫", "润色", "潤色", "摘要", "校对", "校對", "文章", "标题", "標題"] }
+      data_zh_kw: { weight: 0.18, keywords: ["数据集", "資料集", "聚合", "透视表", "樞紐分析表", "查询", "查詢", "电子表格", "試算表"] }
+      security_zh_kw: { weight: 1.10, keywords: ["缓冲区溢出", "緩衝區溢位", "命令注入", "权限提升", "權限提升", "越权", "越權", "恶意软件", "惡意軟體", "访问控制", "存取控制"] }
+      vision_zh_kw: { weight: 0.14, keywords: ["截图", "截圖", "屏幕截图", "螢幕截圖", "照片", "图像", "影像", "流程图", "流程圖", "图表", "圖表"] }
+      extraction_zh_kw: { weight: 0.11, keywords: ["提取字段", "擷取欄位", "抽取实体", "擷取實體", "结构化数据", "結構化資料", "解析 JSON", "抓取資料"] }
       # Short diagnostics/security fragments are meaningful despite being tiny;
       # give them enough positive signal to escape the simple/economy shortcut.
       diagnostic_short_kw: { weight: 3.60, keywords: ["no output", "no stack trace", "no auth check", "no command injection"] }
@@ -118,20 +129,20 @@ classifier:
     # match "source"/"force", so it lives ONLY in the boundary-matched
     # security_kw dimension, never here). Expanded 2026-06-02.
     task_keywords:
-      coding: ["function", "class", "bug", "compile", "npm", "git", "refactor", "debug", "implement", "unit test", "stack trace", "typescript"]
-      math: ["integral", "matrix", "equation", "derivative", "calculus", "algebra", "polynomial"]
+      coding: ["function", "class", "bug", "compile", "npm", "git", "refactor", "debug", "implement", "unit test", "stack trace", "typescript", "重构", "重構", "调试", "除錯", "编译", "編譯", "函数", "函式", "单元测试", "單元測試", "堆栈跟踪", "堆疊追蹤"]
+      math: ["integral", "matrix", "equation", "derivative", "calculus", "algebra", "polynomial", "积分", "積分", "矩阵", "矩陣", "方程", "导数", "導數"]
       # "tone" dropped from task detection: as a SUBSTRING it false-matches
       # "mile{stone}s" → spurious writing task. It stays in the writing_kw
       # dimension (word-boundary matched there, so it is safe).
-      writing: ["essay", "rewrite", "draft", "summarize", "paraphrase", "proofread", "article"]
-      extraction: ["extract", "parse", "json from", "fields", "pull out", "structured data"]
-      web: ["search the web", "browse", "look up online", "latest news", "google for"]
-      data: ["csv", "dataframe", "aggregate", "sql", "group by", "spreadsheet", "pivot table"]
-      vision: ["image", "screenshot", "this picture", "photo", "this diagram", "this chart"]
+      writing: ["essay", "rewrite", "draft", "summarize", "paraphrase", "proofread", "article", "改写", "改寫", "润色", "潤色", "校对", "校對", "文章"]
+      extraction: ["extract", "parse", "json from", "fields", "pull out", "structured data", "提取字段", "擷取欄位", "抽取实体", "擷取實體", "结构化数据", "結構化資料"]
+      web: ["search the web", "browse", "look up online", "latest news", "google for", "搜索网页", "搜尋網頁", "查找网页", "查找網頁"]
+      data: ["csv", "dataframe", "aggregate", "sql", "group by", "spreadsheet", "pivot table", "数据集", "資料集", "聚合", "透视表", "樞紐分析表", "查询", "查詢"]
+      vision: ["image", "screenshot", "this picture", "photo", "this diagram", "this chart", "截图", "截圖", "屏幕截图", "螢幕截圖", "照片", "流程图", "流程圖", "图表", "圖表"]
       # security (eval-v2 cybersecurity domain). Conservative, multi-word
       # keywords; paired with a raised task_activation.security (>= 2.0) so a
       # single lone hit (e.g. "explain what XSS is") does NOT false-activate.
-      security: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "remote code execution"]
+      security: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "remote code execution", "缓冲区溢出", "緩衝區溢位", "命令注入", "权限提升", "權限提升", "越权", "越權", "访问控制", "存取控制"]
     tool_prefixes:
       web: ["browser_", "web_"]
       coding: ["code_", "shell_", "fs_"]
@@ -142,8 +153,8 @@ classifier:
     task_activation: { web: 3.0, security: 2.0 }
     overrides:
       heartbeat_tokens: ["HEARTBEAT_OK"]
-      exact_confirmation_tokens: ["yes", "no", "sure", "got it", "ok", "thanks"]
-      formal_logic_keywords: ["⊢", "∴", "modus ponens", "first-order logic"]
+      exact_confirmation_tokens: ["yes", "no", "sure", "got it", "ok", "thanks", "是", "否", "可以", "好的", "谢谢", "謝謝"]
+      formal_logic_keywords: ["⊢", "∴", "modus ponens", "first-order logic", "充分必要", "反证法", "反證法", "归纳法", "歸納法"]
       tools_floor: standard
       long_context_token_threshold: 64000  # capability signal (NOT a task_type); bumped 50k->64k to match llm-router lanes.yaml long_context anchor
       long_context_floor: complex
@@ -155,14 +166,14 @@ classifier:
       short_message_max_chars: 30
       disable_above_chars: 100
       max_history_weight: 0.6
-    # Language-coverage guard. The keyword lists above are ENGLISH-ONLY, so a
-    # predominantly non-Latin prompt (Chinese / Japanese / Korean / Cyrillic / …)
-    # cannot be scored by them. With this on, such a prompt is forced `uncertain` →
-    # the cascade escalates to the (multilingual) Layer-2 eval. CONTRACT: if you
-    # serve non-English traffic, ENABLE eval below — with eval OFF a non-Latin prompt
-    # degrades deterministically to `balanced` (fail-open, no 5xx) rather than being
-    # routed by an English keyword score that never matched anything. The guard is
-    # suppressed for trivially-short prompts (pinned `simple`) and for prompts with a
+    # Language-coverage guard. Layer-1 has English plus small high-confidence CJK
+    # keyword lists. Non-covered languages, and CJK prompts that miss those lists,
+    # cannot be scored by keywords. With this on, such a prompt is forced `uncertain`
+    # → the cascade escalates to the (multilingual) Layer-2 eval. CONTRACT: if you
+    # serve broad non-English traffic, ENABLE eval below — with eval OFF an uncovered
+    # non-Latin prompt degrades deterministically to `balanced` (fail-open, no 5xx)
+    # rather than being routed by a keyword score that never matched anything. The
+    # guard is suppressed for trivially-short prompts (pinned `simple`) and for prompts with a
     # content-type structural signal (code block / table / attachment / …) that gives
     # real language-agnostic grip. Latin-script non-English (es/fr/de) is NOT flagged
     # by ratio; it already produces ~0 keyword signal → low confidence → eval anyway.

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -33,7 +33,7 @@
 #
 # INTERNATIONAL VOCABULARY + MULTILINGUAL GUARD (2026-06-12, classifier.intl-layer1): Layer-1
 # has an English keyword layer plus a separate international keyword layer. The
-# initial seed covers high-confidence Simplified/Traditional Chinese terms; future
+# initial seed covers high-confidence Simplified Chinese terms; future
 # Japanese/Korean/Vietnamese/etc. terms should extend the *_intl_kw dimensions, not
 # the English *_kw lists, so English keywordSignal calibration is not diluted.
 # Non-covered languages, and prompts that miss these small intl lists, still trip
@@ -73,32 +73,35 @@ classifier:
       # security request) clears its tier with confidence > threshold rather than
       # hugging the boundary and degrading to fallback.
       reasoning_kw: { weight: 0.65, keywords: ["prove", "derive", "theorem", "step by step", "reason about", "deduce", "infer", "justify", "rationale", "explain why"] }
+      reasoning_intl_kw: { weight: 0.65, keywords: ["证明", "推导", "定理", "逐步", "分步推理", "推理", "演绎", "推断", "论证", "理由", "解释原因"] }
       coding_kw: { weight: 0.62, keywords: ["refactor", "debug", "stack trace", "function", "compile", "implement", "unit test", "exception", "traceback", "syntax error", "endpoint", "regex"] }
+      coding_intl_kw: { weight: 0.62, keywords: ["重构", "调试", "堆栈跟踪", "函数", "编译", "实现", "单元测试", "异常", "回溯", "语法错误", "端点", "接口", "正则"] }
       math_kw: { weight: 0.20, keywords: ["integral", "matrix", "equation", "probability", "derivative", "calculus", "algebra", "solve for", "polynomial", "summation"] }
-      math_intl_kw: { weight: 0.20, keywords: ["积分", "積分", "矩阵", "矩陣", "方程", "导数", "導數", "代数", "代數", "推导", "推導"] }
+      math_intl_kw: { weight: 0.24, keywords: ["积分", "矩阵", "方程", "概率", "导数", "微积分", "代数", "求解", "多项式", "求和", "推导"] }
       planning_kw: { weight: 0.38, keywords: ["plan", "architecture", "design doc", "trade-off", "strategy", "roadmap", "milestone", "break down", "blueprint", "trade-offs"] }
+      planning_intl_kw: { weight: 0.38, keywords: ["计划", "架构", "设计文档", "权衡", "策略", "路线图", "里程碑", "拆解", "蓝图", "取舍", "方案设计"] }
       analysis_kw: { weight: 0.76, keywords: ["analyze", "compare", "evaluate", "implications", "root cause", "assess", "critique", "pros and cons", "diagnose", "investigate"] }
+      analysis_intl_kw: { weight: 0.76, keywords: ["分析", "比较", "评估", "影响", "根因", "评价", "批判", "利弊", "诊断", "调查", "排查", "因果关系"] }
       writing_kw: { weight: 0.14, keywords: ["essay", "rewrite", "draft", "tone", "polish", "summarize", "summary", "paraphrase", "proofread", "article", "headline", "grammar"] }
+      writing_intl_kw: { weight: 0.14, keywords: ["论文", "改写", "草稿", "语气", "润色", "总结", "摘要", "转述", "校对", "文章", "标题", "语法"] }
       security_kw: { weight: 1.40, keywords: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "rce", "csrf", "malware", "auth bypass", "auth check", "access control"] }
       # International keyword dimensions are separate from English dimensions so
       # they can suppress the language guard without diluting English keywordSignal.
-      # Current seed is Simplified/Traditional Chinese; future Japanese/Korean/
-      # Vietnamese/etc. terms should extend *_intl_kw.
-      coding_intl_kw: { weight: 0.56, keywords: ["重构", "重構", "调试", "除錯", "编译", "編譯", "函数", "函式", "单元测试", "單元測試", "堆栈跟踪", "堆疊追蹤"] }
-      analysis_intl_kw: { weight: 0.68, keywords: ["分析", "比較", "比较", "评估", "評估", "根因", "诊断", "診斷", "利弊", "因果关系"] }
-      writing_intl_kw: { weight: 0.12, keywords: ["改写", "改寫", "润色", "潤色", "摘要", "校对", "校對", "文章", "标题", "標題"] }
-      data_intl_kw: { weight: 0.18, keywords: ["数据集", "資料集", "聚合", "透视表", "樞紐分析表", "查询", "查詢", "电子表格", "試算表"] }
-      security_intl_kw: { weight: 1.10, keywords: ["缓冲区溢出", "緩衝區溢位", "命令注入", "权限提升", "權限提升", "越权", "越權", "恶意软件", "惡意軟體", "访问控制", "存取控制"] }
-      vision_intl_kw: { weight: 0.14, keywords: ["截图", "截圖", "屏幕截图", "螢幕截圖", "照片", "图像", "影像", "流程图", "流程圖", "图表", "圖表"] }
-      web_intl_kw: { weight: 0.06, keywords: ["搜索网页", "搜尋網頁", "查找网页", "查找網頁", "最新公告", "最新消息", "在线资料", "線上資料"] }
-      extraction_intl_kw: { weight: 0.11, keywords: ["提取字段", "擷取欄位", "抽取实体", "擷取實體", "结构化数据", "結構化資料", "解析 JSON", "抓取資料"] }
+      # Current seed is Simplified Chinese; future Japanese/Korean/Vietnamese/etc.
+      # terms should extend *_intl_kw.
+      security_intl_kw: { weight: 1.40, keywords: ["CVE 漏洞", "缓冲区溢出", "SQL 注入", "漏洞利用", "权限提升", "XSS 漏洞", "逆向工程", "密码分析", "CTF 题目", "命令注入", "远程代码执行", "RCE 漏洞", "CSRF 漏洞", "恶意软件", "认证绕过", "认证检查", "访问控制", "越权"] }
       # Short diagnostics/security fragments are meaningful despite being tiny;
       # give them enough positive signal to escape the simple/economy shortcut.
       diagnostic_short_kw: { weight: 3.60, keywords: ["no output", "no stack trace", "no auth check", "no command injection"] }
       extraction_kw: { weight: 0.12, keywords: ["extract", "parse", "json from", "fields", "schema", "pull out", "list all", "structured data", "named entities", "scrape"] }
+      extraction_intl_kw: { weight: 0.12, keywords: ["提取", "解析", "从 JSON", "字段", "模式", "抽取", "列出所有", "结构化数据", "命名实体", "抓取", "提取字段", "抽取实体"] }
       data_kw: { weight: 0.20, keywords: ["csv", "dataframe", "aggregate", "sql", "pivot", "group by", "spreadsheet", "histogram", "correlation", "query"] }
+      data_intl_kw: { weight: 0.20, keywords: ["数据框", "聚合", "透视表", "分组", "电子表格", "直方图", "相关性", "查询", "数据集", "SQL 查询", "CSV 文件"] }
       vision_kw: { weight: 0.16, keywords: ["image", "screenshot", "this picture", "diagram", "chart", "photo", "ocr", "figure", "graph"] }
+      vision_intl_kw: { weight: 0.16, keywords: ["图像", "截图", "这张图片", "流程图", "图表", "照片", "文字识别", "图形", "曲线图", "屏幕截图"] }
+      web_intl_kw: { weight: 0.06, keywords: ["搜索网页", "浏览", "在线查询", "最新新闻", "谷歌搜索", "查找网页", "在线资料", "最新公告", "最新消息"] }
       multistep_kw: { weight: 0.26, keywords: ["first", "then", "finally", "and then", "after that", "step 1", "lastly", "subsequently", "followed by"] }
+      multistep_intl_kw: { weight: 0.26, keywords: ["首先", "然后", "最后", "接着", "之后", "步骤 1", "第1步", "最终", "随后", "紧接着"] }
       # —— negative dimensions —— weights MAGNIFIED (not just expanded). A longer
       # list dilutes each hit toward zero, which pulls a short greeting/lookup
       # prompt's rawScore UP toward the `standard` boundary and tanks its
@@ -135,20 +138,20 @@ classifier:
     # match "source"/"force", so it lives ONLY in the boundary-matched
     # security_kw dimension, never here). Expanded 2026-06-02.
     task_keywords:
-      coding: ["function", "class", "bug", "compile", "npm", "git", "refactor", "debug", "implement", "unit test", "stack trace", "typescript", "重构", "重構", "调试", "除錯", "编译", "編譯", "函数", "函式", "单元测试", "單元測試", "堆栈跟踪", "堆疊追蹤"]
-      math: ["integral", "matrix", "equation", "derivative", "calculus", "algebra", "polynomial", "积分", "積分", "矩阵", "矩陣", "方程", "导数", "導數"]
+      coding: ["function", "class", "bug", "compile", "npm", "git", "refactor", "debug", "implement", "unit test", "stack trace", "typescript", "函数", "类", "缺陷", "编译", "重构", "调试", "实现", "单元测试", "堆栈跟踪", "类型脚本", "语法错误", "接口"]
+      math: ["integral", "matrix", "equation", "derivative", "calculus", "algebra", "polynomial", "积分", "矩阵", "方程", "导数", "微积分", "代数", "多项式", "概率", "求解"]
       # "tone" dropped from task detection: as a SUBSTRING it false-matches
       # "mile{stone}s" → spurious writing task. It stays in the writing_kw
       # dimension (word-boundary matched there, so it is safe).
-      writing: ["essay", "rewrite", "draft", "summarize", "paraphrase", "proofread", "article", "改写", "改寫", "润色", "潤色", "校对", "校對", "文章"]
-      extraction: ["extract", "parse", "json from", "fields", "pull out", "structured data", "提取字段", "擷取欄位", "抽取实体", "擷取實體", "结构化数据", "結構化資料"]
-      web: ["search the web", "browse", "look up online", "latest news", "google for", "搜索网页", "搜尋網頁", "查找网页", "查找網頁"]
-      data: ["csv", "dataframe", "aggregate", "sql", "group by", "spreadsheet", "pivot table", "数据集", "資料集", "聚合", "透视表", "樞紐分析表", "查询", "查詢"]
-      vision: ["image", "screenshot", "this picture", "photo", "this diagram", "this chart", "截图", "截圖", "屏幕截图", "螢幕截圖", "照片", "流程图", "流程圖", "图表", "圖表"]
+      writing: ["essay", "rewrite", "draft", "summarize", "paraphrase", "proofread", "article", "论文", "改写", "草稿", "总结", "转述", "校对", "文章", "润色", "标题"]
+      extraction: ["extract", "parse", "json from", "fields", "pull out", "structured data", "提取", "解析", "JSON 中", "字段", "抽取", "结构化数据", "提取字段", "抽取实体"]
+      web: ["search the web", "browse", "look up online", "latest news", "google for", "搜索网页", "浏览", "在线查询", "最新新闻", "谷歌搜索", "查找网页"]
+      data: ["csv", "dataframe", "aggregate", "sql", "group by", "spreadsheet", "pivot table", "数据框", "聚合", "分组", "电子表格", "透视表", "数据集", "查询"]
+      vision: ["image", "screenshot", "this picture", "photo", "this diagram", "this chart", "图像", "截图", "这张图片", "照片", "流程图", "图表", "屏幕截图"]
       # security (eval-v2 cybersecurity domain). Conservative, multi-word
       # keywords; paired with a raised task_activation.security (>= 2.0) so a
       # single lone hit (e.g. "explain what XSS is") does NOT false-activate.
-      security: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "remote code execution", "缓冲区溢出", "緩衝區溢位", "命令注入", "权限提升", "權限提升", "越权", "越權", "访问控制", "存取控制"]
+      security: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "remote code execution", "缓冲区溢出", "SQL 注入", "漏洞利用", "权限提升", "逆向工程", "密码分析", "命令注入", "远程代码执行", "越权", "访问控制"]
     tool_prefixes:
       web: ["browser_", "web_"]
       coding: ["code_", "shell_", "fs_"]
@@ -159,8 +162,8 @@ classifier:
     task_activation: { web: 3.0, security: 2.0 }
     overrides:
       heartbeat_tokens: ["HEARTBEAT_OK"]
-      exact_confirmation_tokens: ["yes", "no", "sure", "got it", "ok", "thanks", "是", "否", "可以", "好的", "谢谢", "謝謝"]
-      formal_logic_keywords: ["⊢", "∴", "modus ponens", "first-order logic", "充分必要", "反证法", "反證法", "归纳法", "歸納法"]
+      exact_confirmation_tokens: ["yes", "no", "sure", "got it", "ok", "thanks", "是", "否", "可以", "好的", "谢谢"]
+      formal_logic_keywords: ["⊢", "∴", "modus ponens", "first-order logic", "充分必要", "反证法", "归纳法"]
       tools_floor: standard
       long_context_token_threshold: 64000  # capability signal (NOT a task_type); bumped 50k->64k to match llm-router lanes.yaml long_context anchor
       long_context_floor: complex
@@ -173,8 +176,10 @@ classifier:
       disable_above_chars: 100
       max_history_weight: 0.6
     # Language-coverage guard. Layer-1 has English plus small high-confidence
-    # international keyword lists. Non-covered languages, and prompts that miss those lists,
-    # cannot be scored by keywords. With this on, such a prompt is forced `uncertain`
+    # international keyword lists. The current seed is Simplified Chinese; future
+    # Japanese/Korean/Vietnamese/etc. terms should extend *_intl_kw. Non-covered
+    # languages, and prompts that miss those lists, cannot be scored by keywords.
+    # With this on, such a prompt is forced `uncertain`
     # → the cascade escalates to the (multilingual) Layer-2 eval. CONTRACT: if you
     # serve broad non-English traffic, ENABLE eval below — with eval OFF an uncovered
     # non-Latin prompt degrades deterministically to `balanced` (fail-open, no 5xx)

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -31,11 +31,13 @@
 # Golden set grown 29->38 (9 real-world prompts); cascade/calibrate lock 42 real
 # prompts with 0 fallbacks and confidence spread ~0.43-0.98.
 #
-# CJK VOCABULARY + MULTILINGUAL GUARD (2026-06-12, classifier.zh-layer1): Layer-1
-# is now an English + high-confidence CJK fast path. Simplified/Traditional Chinese
-# keywords live in separate *_zh_kw dimensions so English keywordSignal calibration is
-# not diluted. Other non-covered languages, and Chinese prompts that miss these small
-# CJK lists, still trip `rules.language` and escalate to multilingual Layer-2 eval.
+# INTERNATIONAL VOCABULARY + MULTILINGUAL GUARD (2026-06-12, classifier.intl-layer1): Layer-1
+# has an English keyword layer plus a separate international keyword layer. The
+# initial seed covers high-confidence Simplified/Traditional Chinese terms; future
+# Japanese/Korean/Vietnamese/etc. terms should extend the *_intl_kw dimensions, not
+# the English *_kw lists, so English keywordSignal calibration is not diluted.
+# Non-covered languages, and prompts that miss these small intl lists, still trip
+# `rules.language` and escalate to multilingual Layer-2 eval.
 # CONTRACT: serve broad non-English traffic → enable `eval`; with eval OFF uncovered
 # non-Latin prompts degrade deterministically to `balanced`.
 classifier:
@@ -73,21 +75,21 @@ classifier:
       reasoning_kw: { weight: 0.65, keywords: ["prove", "derive", "theorem", "step by step", "reason about", "deduce", "infer", "justify", "rationale", "explain why"] }
       coding_kw: { weight: 0.62, keywords: ["refactor", "debug", "stack trace", "function", "compile", "implement", "unit test", "exception", "traceback", "syntax error", "endpoint", "regex"] }
       math_kw: { weight: 0.20, keywords: ["integral", "matrix", "equation", "probability", "derivative", "calculus", "algebra", "solve for", "polynomial", "summation"] }
-      math_zh_kw: { weight: 0.20, keywords: ["积分", "積分", "矩阵", "矩陣", "方程", "导数", "導數", "代数", "代數", "推导", "推導"] }
+      math_intl_kw: { weight: 0.20, keywords: ["积分", "積分", "矩阵", "矩陣", "方程", "导数", "導數", "代数", "代數", "推导", "推導"] }
       planning_kw: { weight: 0.38, keywords: ["plan", "architecture", "design doc", "trade-off", "strategy", "roadmap", "milestone", "break down", "blueprint", "trade-offs"] }
       analysis_kw: { weight: 0.76, keywords: ["analyze", "compare", "evaluate", "implications", "root cause", "assess", "critique", "pros and cons", "diagnose", "investigate"] }
       writing_kw: { weight: 0.14, keywords: ["essay", "rewrite", "draft", "tone", "polish", "summarize", "summary", "paraphrase", "proofread", "article", "headline", "grammar"] }
       security_kw: { weight: 1.40, keywords: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "rce", "csrf", "malware", "auth bypass", "auth check", "access control"] }
       # CJK keyword dimensions are separate from English dimensions so they can
       # suppress the language guard without diluting English keywordSignal.
-      coding_zh_kw: { weight: 0.56, keywords: ["重构", "重構", "调试", "除錯", "编译", "編譯", "函数", "函式", "单元测试", "單元測試", "堆栈跟踪", "堆疊追蹤"] }
-      analysis_zh_kw: { weight: 0.68, keywords: ["分析", "比較", "比较", "评估", "評估", "根因", "诊断", "診斷", "利弊", "因果关系"] }
-      writing_zh_kw: { weight: 0.12, keywords: ["改写", "改寫", "润色", "潤色", "摘要", "校对", "校對", "文章", "标题", "標題"] }
-      data_zh_kw: { weight: 0.18, keywords: ["数据集", "資料集", "聚合", "透视表", "樞紐分析表", "查询", "查詢", "电子表格", "試算表"] }
-      security_zh_kw: { weight: 1.10, keywords: ["缓冲区溢出", "緩衝區溢位", "命令注入", "权限提升", "權限提升", "越权", "越權", "恶意软件", "惡意軟體", "访问控制", "存取控制"] }
-      vision_zh_kw: { weight: 0.14, keywords: ["截图", "截圖", "屏幕截图", "螢幕截圖", "照片", "图像", "影像", "流程图", "流程圖", "图表", "圖表"] }
-      web_zh_kw: { weight: 0.06, keywords: ["搜索网页", "搜尋網頁", "查找网页", "查找網頁", "最新公告", "最新消息", "在线资料", "線上資料"] }
-      extraction_zh_kw: { weight: 0.11, keywords: ["提取字段", "擷取欄位", "抽取实体", "擷取實體", "结构化数据", "結構化資料", "解析 JSON", "抓取資料"] }
+      coding_intl_kw: { weight: 0.56, keywords: ["重构", "重構", "调试", "除錯", "编译", "編譯", "函数", "函式", "单元测试", "單元測試", "堆栈跟踪", "堆疊追蹤"] }
+      analysis_intl_kw: { weight: 0.68, keywords: ["分析", "比較", "比较", "评估", "評估", "根因", "诊断", "診斷", "利弊", "因果关系"] }
+      writing_intl_kw: { weight: 0.12, keywords: ["改写", "改寫", "润色", "潤色", "摘要", "校对", "校對", "文章", "标题", "標題"] }
+      data_intl_kw: { weight: 0.18, keywords: ["数据集", "資料集", "聚合", "透视表", "樞紐分析表", "查询", "查詢", "电子表格", "試算表"] }
+      security_intl_kw: { weight: 1.10, keywords: ["缓冲区溢出", "緩衝區溢位", "命令注入", "权限提升", "權限提升", "越权", "越權", "恶意软件", "惡意軟體", "访问控制", "存取控制"] }
+      vision_intl_kw: { weight: 0.14, keywords: ["截图", "截圖", "屏幕截图", "螢幕截圖", "照片", "图像", "影像", "流程图", "流程圖", "图表", "圖表"] }
+      web_intl_kw: { weight: 0.06, keywords: ["搜索网页", "搜尋網頁", "查找网页", "查找網頁", "最新公告", "最新消息", "在线资料", "線上資料"] }
+      extraction_intl_kw: { weight: 0.11, keywords: ["提取字段", "擷取欄位", "抽取实体", "擷取實體", "结构化数据", "結構化資料", "解析 JSON", "抓取資料"] }
       # Short diagnostics/security fragments are meaningful despite being tiny;
       # give them enough positive signal to escape the simple/economy shortcut.
       diagnostic_short_kw: { weight: 3.60, keywords: ["no output", "no stack trace", "no auth check", "no command injection"] }
@@ -168,8 +170,8 @@ classifier:
       short_message_max_chars: 30
       disable_above_chars: 100
       max_history_weight: 0.6
-    # Language-coverage guard. Layer-1 has English plus small high-confidence CJK
-    # keyword lists. Non-covered languages, and CJK prompts that miss those lists,
+    # Language-coverage guard. Layer-1 has English plus small high-confidence
+    # international keyword lists. Non-covered languages, and prompts that miss those lists,
     # cannot be scored by keywords. With this on, such a prompt is forced `uncertain`
     # → the cascade escalates to the (multilingual) Layer-2 eval. CONTRACT: if you
     # serve broad non-English traffic, ENABLE eval below — with eval OFF an uncovered

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -80,8 +80,10 @@ classifier:
       analysis_kw: { weight: 0.76, keywords: ["analyze", "compare", "evaluate", "implications", "root cause", "assess", "critique", "pros and cons", "diagnose", "investigate"] }
       writing_kw: { weight: 0.14, keywords: ["essay", "rewrite", "draft", "tone", "polish", "summarize", "summary", "paraphrase", "proofread", "article", "headline", "grammar"] }
       security_kw: { weight: 1.40, keywords: ["cve-", "buffer overflow", "sql injection", "exploit", "privilege escalation", "xss", "reverse engineer", "cryptanalysis", "ctf", "command injection", "rce", "csrf", "malware", "auth bypass", "auth check", "access control"] }
-      # CJK keyword dimensions are separate from English dimensions so they can
-      # suppress the language guard without diluting English keywordSignal.
+      # International keyword dimensions are separate from English dimensions so
+      # they can suppress the language guard without diluting English keywordSignal.
+      # Current seed is Simplified/Traditional Chinese; future Japanese/Korean/
+      # Vietnamese/etc. terms should extend *_intl_kw.
       coding_intl_kw: { weight: 0.56, keywords: ["重构", "重構", "调试", "除錯", "编译", "編譯", "函数", "函式", "单元测试", "單元測試", "堆栈跟踪", "堆疊追蹤"] }
       analysis_intl_kw: { weight: 0.68, keywords: ["分析", "比較", "比较", "评估", "評估", "根因", "诊断", "診斷", "利弊", "因果关系"] }
       writing_intl_kw: { weight: 0.12, keywords: ["改写", "改寫", "润色", "潤色", "摘要", "校对", "校對", "文章", "标题", "標題"] }

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -73,6 +73,7 @@ classifier:
       reasoning_kw: { weight: 0.65, keywords: ["prove", "derive", "theorem", "step by step", "reason about", "deduce", "infer", "justify", "rationale", "explain why"] }
       coding_kw: { weight: 0.62, keywords: ["refactor", "debug", "stack trace", "function", "compile", "implement", "unit test", "exception", "traceback", "syntax error", "endpoint", "regex"] }
       math_kw: { weight: 0.20, keywords: ["integral", "matrix", "equation", "probability", "derivative", "calculus", "algebra", "solve for", "polynomial", "summation"] }
+      math_zh_kw: { weight: 0.20, keywords: ["积分", "積分", "矩阵", "矩陣", "方程", "导数", "導數", "代数", "代數", "推导", "推導"] }
       planning_kw: { weight: 0.38, keywords: ["plan", "architecture", "design doc", "trade-off", "strategy", "roadmap", "milestone", "break down", "blueprint", "trade-offs"] }
       analysis_kw: { weight: 0.76, keywords: ["analyze", "compare", "evaluate", "implications", "root cause", "assess", "critique", "pros and cons", "diagnose", "investigate"] }
       writing_kw: { weight: 0.14, keywords: ["essay", "rewrite", "draft", "tone", "polish", "summarize", "summary", "paraphrase", "proofread", "article", "headline", "grammar"] }
@@ -85,6 +86,7 @@ classifier:
       data_zh_kw: { weight: 0.18, keywords: ["数据集", "資料集", "聚合", "透视表", "樞紐分析表", "查询", "查詢", "电子表格", "試算表"] }
       security_zh_kw: { weight: 1.10, keywords: ["缓冲区溢出", "緩衝區溢位", "命令注入", "权限提升", "權限提升", "越权", "越權", "恶意软件", "惡意軟體", "访问控制", "存取控制"] }
       vision_zh_kw: { weight: 0.14, keywords: ["截图", "截圖", "屏幕截图", "螢幕截圖", "照片", "图像", "影像", "流程图", "流程圖", "图表", "圖表"] }
+      web_zh_kw: { weight: 0.06, keywords: ["搜索网页", "搜尋網頁", "查找网页", "查找網頁", "最新公告", "最新消息", "在线资料", "線上資料"] }
       extraction_zh_kw: { weight: 0.11, keywords: ["提取字段", "擷取欄位", "抽取实体", "擷取實體", "结构化数据", "結構化資料", "解析 JSON", "抓取資料"] }
       # Short diagnostics/security fragments are meaningful despite being tiny;
       # give them enough positive signal to escape the simple/economy shortcut.

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -122,8 +122,7 @@ wrapped so a degenerate input yields a safe default instead of throwing
   enters Layer 2 (if eval is enabled), otherwise Layer 3.
 - **Language-coverage guard** (`engine.ts` + `signals.ts`): Layer 1 has an
   English keyword layer plus an international keyword layer. The current
-  international seed is Simplified/Traditional Chinese; future Japanese/Korean/
-  Vietnamese/etc. terms should extend `*_intl_kw`. Non-covered languages, and
+  international seed is Simplified Chinese; future Japanese/Korean/Vietnamese/etc. terms should extend `*_intl_kw`. Non-covered languages, and
   prompts that miss those lists, are forced `uncertain` (confidence 0) when no
   content-type structural grip exists, so the cascade escalates to multilingual
   Layer-2 eval. **Operator contract**: to serve broad non-English traffic, enable

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -121,15 +121,15 @@ wrapped so a degenerate input yields a safe default instead of throwing
   `rules.confidence_threshold`, Layer 1 is treated as uncertain and the cascade
   enters Layer 2 (if eval is enabled), otherwise Layer 3.
 - **Language-coverage guard** (`engine.ts` + `signals.ts`): the keyword lists are
-  **English-only**, so Layer 1 is an English fast path. A predominantly non-Latin
-  prompt (`nonLatinRatio ≥ language.non_latin_min_ratio`) with no content-type
-  structural grip is forced `uncertain` (confidence 0) so the cascade escalates to
-  the multilingual Layer-2 eval. **Operator contract**: to serve non-English
-  traffic, enable eval — with eval **off**, a non-Latin prompt degrades
-  deterministically to `balanced` (fail-open) rather than being routed by a
-  keyword score that matched nothing. (Latin-script non-English already yields ~0
-  keyword signal → low confidence → eval anyway.) The guard is suppressed for
-  trivially-short prompts (already pinned `simple`).
+  an English + small high-confidence CJK fast path. Non-covered languages, and CJK
+  prompts that miss those lists, are forced `uncertain` (confidence 0) when no
+  content-type structural grip exists, so the cascade escalates to multilingual
+  Layer-2 eval. **Operator contract**: to serve broad non-English traffic, enable
+  eval — with eval **off**, uncovered non-Latin prompts degrade deterministically
+  to `balanced` (fail-open) rather than being routed by a keyword score that
+  matched nothing. (Latin-script non-English already yields ~0 keyword signal →
+  low confidence → eval anyway.) The guard is suppressed for trivially-short
+  prompts (already pinned `simple`).
 
 ### Tunables live in config
 

--- a/docs/03-classification.md
+++ b/docs/03-classification.md
@@ -120,8 +120,10 @@ wrapped so a degenerate input yields a safe default instead of throwing
   from any boundary approaches 1 (most certain). When confidence is below
   `rules.confidence_threshold`, Layer 1 is treated as uncertain and the cascade
   enters Layer 2 (if eval is enabled), otherwise Layer 3.
-- **Language-coverage guard** (`engine.ts` + `signals.ts`): the keyword lists are
-  an English + small high-confidence CJK fast path. Non-covered languages, and CJK
+- **Language-coverage guard** (`engine.ts` + `signals.ts`): Layer 1 has an
+  English keyword layer plus an international keyword layer. The current
+  international seed is Simplified/Traditional Chinese; future Japanese/Korean/
+  Vietnamese/etc. terms should extend `*_intl_kw`. Non-covered languages, and
   prompts that miss those lists, are forced `uncertain` (confidence 0) when no
   content-type structural grip exists, so the cascade escalates to multilingual
   Layer-2 eval. **Operator contract**: to serve broad non-English traffic, enable

--- a/packages/core/src/classifier/engine.test.ts
+++ b/packages/core/src/classifier/engine.test.ts
@@ -432,22 +432,31 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
-  it("shipped intl: Traditional analysis prompt is handled by rules without language guard", () => {
+  it("shipped intl: Simplified reasoning and planning prompts are handled by rules", () => {
     const cfg = shippedRules();
-    const req = makeRequest({
+    const reasoningReq = makeRequest({
       messages: [
         {
           role: "user",
-          content: "請深入分析這家公司過去三年的現金流變化，比較產業趨勢，並評估主要風險和根因。",
+          content: "请逐步证明这个定理，并解释原因、推导过程和每一步论证的理由。",
         },
       ],
     });
-    const out = scoreRequest(req, { cfg, approxTokens: 50 });
+    const planningReq = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content: "请拆解这个项目的架构计划、路线图、里程碑和关键权衡，形成方案设计蓝图。",
+        },
+      ],
+    });
+    const reasoning = scoreRequest(reasoningReq, { cfg, approxTokens: 40 });
+    const planning = scoreRequest(planningReq, { cfg, approxTokens: 45 });
 
-    expect(out.decided_by).toBe("rules");
-    expect(out.uncertain).toBe(false);
-    expect(out.explanation.some((e) => e.detail === "analysis_intl_kw")).toBe(true);
-    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+    expect(reasoning.explanation.some((e) => e.detail === "reasoning_intl_kw")).toBe(true);
+    expect(reasoning.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+    expect(planning.explanation.some((e) => e.detail === "planning_intl_kw")).toBe(true);
+    expect(planning.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
   it("shipped intl: Simplified math prompt has dimension grip when task keywords match", () => {
@@ -469,13 +478,13 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
-  it("shipped intl: Traditional web prompt has dimension grip when task keywords match", () => {
+  it("shipped intl: Simplified web prompt has dimension grip when task keywords match", () => {
     const cfg = shippedRules();
     const req = makeRequest({
       messages: [
         {
           role: "user",
-          content: "請搜尋網頁並查找網頁上的最新公告，整理來源、時間、重點和可信度。",
+          content: "请搜索网页并查找网页上的最新公告，整理来源、时间、重点和可信度。",
         },
       ],
     });
@@ -483,6 +492,63 @@ describe("scoreRequest — Layer-1 orchestration", () => {
 
     expect(out.explanation.some((e) => e.detail === "web_intl_kw")).toBe(true);
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it("shipped intl: Simplified keyword seed contains no Traditional Chinese entries", () => {
+    const cfg = shippedRules();
+    const candidateKeywords = [
+      ...Object.entries(cfg.dimensions)
+        .filter(([name]) => name.endsWith("_intl_kw"))
+        .flatMap(([, dim]) => dim.keywords),
+      ...Object.values(cfg.task_keywords).flat(),
+      ...cfg.overrides.exact_confirmation_tokens,
+      ...cfg.overrides.formal_logic_keywords,
+    ];
+    const forbiddenTraditionalTerms = [
+      "積分",
+      "矩陣",
+      "導數",
+      "代數",
+      "推導",
+      "重構",
+      "除錯",
+      "編譯",
+      "函式",
+      "單元測試",
+      "堆疊追蹤",
+      "比較",
+      "評估",
+      "診斷",
+      "改寫",
+      "潤色",
+      "校對",
+      "標題",
+      "資料集",
+      "樞紐分析表",
+      "查詢",
+      "緩衝區溢位",
+      "權限提升",
+      "越權",
+      "惡意軟體",
+      "存取控制",
+      "截圖",
+      "螢幕截圖",
+      "流程圖",
+      "圖表",
+      "搜尋網頁",
+      "查找網頁",
+      "線上資料",
+      "擷取欄位",
+      "擷取實體",
+      "結構化資料",
+      "謝謝",
+      "反證法",
+      "歸納法",
+    ];
+
+    expect(
+      candidateKeywords.filter((kw) => forbiddenTraditionalTerms.some((term) => kw.includes(term))),
+    ).toEqual([]);
   });
 
   it("shipped intl: unmatched long Chinese still trips language guard", () => {

--- a/packages/core/src/classifier/engine.test.ts
+++ b/packages/core/src/classifier/engine.test.ts
@@ -285,8 +285,8 @@ describe("scoreRequest — Layer-1 orchestration", () => {
   });
 
   // ── language-coverage guard ────────────────────────────────────────────────
-  // Layer-1 has English plus small high-confidence CJK keyword lists. A non-covered
-  // non-Latin prompt, or a CJK prompt that misses those lists, is forced `uncertain`
+  // Layer-1 has English plus small high-confidence international keyword lists.
+  // A non-covered non-Latin prompt, or a prompt that misses those lists, is forced `uncertain`
   // (confidence 0) so the cascade escalates to multilingual Layer-2 eval — UNLESS a
   // content-type structural signal gave real grip, or the message is trivially short.
   const longZh =
@@ -410,11 +410,11 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
-  // ── shipped Chinese Layer-1 keywords ─────────────────────────────────────
-  // Config-only CJK expansion must add real positive dimensions, not merely task
-  // keywords. These tests assert Layer-1 rules catch high-confidence zh prompts
-  // and suppress low_keyword_coverage via *_zh_kw grip.
-  it("shipped zh: Simplified analysis prompt is handled by rules without language guard", () => {
+  // ── shipped international Layer-1 keywords ───────────────────────────────
+  // Config-only international expansion must add real positive dimensions, not merely task
+  // keywords. These tests assert Layer-1 rules catch high-confidence international prompts
+  // and suppress low_keyword_coverage via *_intl_kw grip.
+  it("shipped intl: Simplified analysis prompt is handled by rules without language guard", () => {
     const cfg = shippedRules();
     const req = makeRequest({
       messages: [
@@ -428,11 +428,11 @@ describe("scoreRequest — Layer-1 orchestration", () => {
 
     expect(out.decided_by).toBe("rules");
     expect(out.uncertain).toBe(false);
-    expect(out.explanation.some((e) => e.detail === "analysis_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "analysis_intl_kw")).toBe(true);
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
-  it("shipped zh: Traditional analysis prompt is handled by rules without language guard", () => {
+  it("shipped intl: Traditional analysis prompt is handled by rules without language guard", () => {
     const cfg = shippedRules();
     const req = makeRequest({
       messages: [
@@ -446,11 +446,11 @@ describe("scoreRequest — Layer-1 orchestration", () => {
 
     expect(out.decided_by).toBe("rules");
     expect(out.uncertain).toBe(false);
-    expect(out.explanation.some((e) => e.detail === "analysis_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "analysis_intl_kw")).toBe(true);
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
-  it("shipped zh: Simplified math prompt has dimension grip when task keywords match", () => {
+  it("shipped intl: Simplified math prompt has dimension grip when task keywords match", () => {
     const cfg = shippedRules();
     const req = makeRequest({
       messages: [
@@ -465,11 +465,11 @@ describe("scoreRequest — Layer-1 orchestration", () => {
 
     expect(out.task_type).toBe("math");
     expect(out.uncertain).toBe(false);
-    expect(out.explanation.some((e) => e.detail === "math_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "math_intl_kw")).toBe(true);
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
-  it("shipped zh: Traditional web prompt has dimension grip when task keywords match", () => {
+  it("shipped intl: Traditional web prompt has dimension grip when task keywords match", () => {
     const cfg = shippedRules();
     const req = makeRequest({
       messages: [
@@ -481,11 +481,11 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     });
     const out = scoreRequest(req, { cfg, approxTokens: 60 });
 
-    expect(out.explanation.some((e) => e.detail === "web_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "web_intl_kw")).toBe(true);
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
-  it("shipped zh: unmatched long Chinese still trips language guard", () => {
+  it("shipped intl: unmatched long Chinese still trips language guard", () => {
     const cfg = shippedRules();
     const req = makeRequest({ messages: [{ role: "user", content: longZh }] });
     const out = scoreRequest(req, { cfg, approxTokens: 50 });

--- a/packages/core/src/classifier/engine.test.ts
+++ b/packages/core/src/classifier/engine.test.ts
@@ -450,6 +450,41 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
   });
 
+  it("shipped zh: Simplified math prompt has dimension grip when task keywords match", () => {
+    const cfg = shippedRules();
+    const req = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content:
+            "请计算这个矩阵方程的导数和积分步骤，详细解释每一步推导过程，并说明最终结果的数学含义，还要列出可能的代数变形和校验方法",
+        },
+      ],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 70 });
+
+    expect(out.task_type).toBe("math");
+    expect(out.uncertain).toBe(false);
+    expect(out.explanation.some((e) => e.detail === "math_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it("shipped zh: Traditional web prompt has dimension grip when task keywords match", () => {
+    const cfg = shippedRules();
+    const req = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content: "請搜尋網頁並查找網頁上的最新公告，整理來源、時間、重點和可信度。",
+        },
+      ],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 60 });
+
+    expect(out.explanation.some((e) => e.detail === "web_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
   it("shipped zh: unmatched long Chinese still trips language guard", () => {
     const cfg = shippedRules();
     const req = makeRequest({ messages: [{ role: "user", content: longZh }] });

--- a/packages/core/src/classifier/engine.test.ts
+++ b/packages/core/src/classifier/engine.test.ts
@@ -1,6 +1,9 @@
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ClassifierRulesConfig, InternalRequest } from "@helm/shared";
 import { ClassifierDecisionSchema, ClassifierRulesConfigSchema } from "@helm/shared";
 import { describe, expect, it } from "vitest";
+import { loadConfig } from "../config/loader.js";
 import { type ScoreRequestDeps, scoreRequest } from "./engine.js";
 import { type MomentumDeps, type MomentumEntry, recordMomentum } from "./momentum.js";
 import { createMemoryMomentumStore } from "./momentum-store.js";
@@ -72,6 +75,11 @@ function makeRequest(over: Partial<InternalRequest> = {}): InternalRequest {
 }
 
 const NOW = 1_700_000_000_000;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../../..");
+const shippedRules = () =>
+  loadConfig({ configDir: join(repoRoot, "config"), env: {} }).classifier.rules;
 
 function momentumDeps(opts: {
   cfg: ClassifierRulesConfig;
@@ -277,13 +285,12 @@ describe("scoreRequest — Layer-1 orchestration", () => {
   });
 
   // ── language-coverage guard ────────────────────────────────────────────────
-  // The keyword lists are English-only, so a predominantly non-Latin prompt can't
-  // be scored by them. The guard forces `uncertain` (confidence 0) so the cascade
-  // escalates to the multilingual Layer-2 eval — UNLESS a content-type structural
-  // signal gave real grip, or the message is trivially short. See plan / notes
-  // (classifier.multilingual-guard).
+  // Layer-1 has English plus small high-confidence CJK keyword lists. A non-covered
+  // non-Latin prompt, or a CJK prompt that misses those lists, is forced `uncertain`
+  // (confidence 0) so the cascade escalates to multilingual Layer-2 eval — UNLESS a
+  // content-type structural signal gave real grip, or the message is trivially short.
   const longZh =
-    "请帮我详细分析这家公司过去三年的财务状况和现金流情况，并结合所在行业的整体趋势给出具体的投资建议以及主要风险点的评估和应对措施";
+    "请帮我整理这家公司过去三年的营收现金流资产负债变化以及行业背景信息，列出关键事实、时间线、主要事件和可量化指标，保持客观中立不要给投资建议";
 
   it("language guard: long non-Latin prose with no structural grip is forced uncertain", () => {
     const cfg = makeConfig();
@@ -372,7 +379,7 @@ describe("scoreRequest — Layer-1 orchestration", () => {
   it.each([
     [
       "Japanese",
-      "この会社の過去三年間の財務状況とキャッシュフローを詳しく分析し、業界動向も踏まえて投資判断と主要なリスクを具体的に説明してください",
+      "この会社の過去三年間の財務状況とキャッシュフローを詳しくまとめ、業界動向も踏まえて投資判断と主要なリスクを具体的に説明してください",
     ],
     [
       "Korean",
@@ -401,6 +408,56 @@ describe("scoreRequest — Layer-1 orchestration", () => {
     const req = makeRequest({ messages: [{ role: "user", content: longZh }] });
     const out = scoreRequest(req, { cfg, approxTokens: 40 });
     expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  // ── shipped Chinese Layer-1 keywords ─────────────────────────────────────
+  // Config-only CJK expansion must add real positive dimensions, not merely task
+  // keywords. These tests assert Layer-1 rules catch high-confidence zh prompts
+  // and suppress low_keyword_coverage via *_zh_kw grip.
+  it("shipped zh: Simplified analysis prompt is handled by rules without language guard", () => {
+    const cfg = shippedRules();
+    const req = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content: "请深入分析这家公司过去三年的现金流变化，比较行业趋势，并评估主要风险和根因。",
+        },
+      ],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 50 });
+
+    expect(out.decided_by).toBe("rules");
+    expect(out.uncertain).toBe(false);
+    expect(out.explanation.some((e) => e.detail === "analysis_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it("shipped zh: Traditional analysis prompt is handled by rules without language guard", () => {
+    const cfg = shippedRules();
+    const req = makeRequest({
+      messages: [
+        {
+          role: "user",
+          content: "請深入分析這家公司過去三年的現金流變化，比較產業趨勢，並評估主要風險和根因。",
+        },
+      ],
+    });
+    const out = scoreRequest(req, { cfg, approxTokens: 50 });
+
+    expect(out.decided_by).toBe("rules");
+    expect(out.uncertain).toBe(false);
+    expect(out.explanation.some((e) => e.detail === "analysis_zh_kw")).toBe(true);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
+  });
+
+  it("shipped zh: unmatched long Chinese still trips language guard", () => {
+    const cfg = shippedRules();
+    const req = makeRequest({ messages: [{ role: "user", content: longZh }] });
+    const out = scoreRequest(req, { cfg, approxTokens: 50 });
+
+    expect(out.uncertain).toBe(true);
+    expect(out.confidence).toBe(0);
+    expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(true);
   });
 
   it("records final tier back into momentum history (write-back)", () => {

--- a/packages/core/src/classifier/engine.ts
+++ b/packages/core/src/classifier/engine.ts
@@ -137,8 +137,8 @@ export function scoreRequest(req: InternalRequest, deps: ScoreRequestDeps): Clas
 
   // ── 5.5 language-coverage guard ───────────────────────────────────────────
   // Layer-1 has an English keyword layer plus an international keyword layer. The
-  // current seed is Simplified/Traditional Chinese; future Japanese/Korean/
-  // Vietnamese/etc. terms should extend *_intl_kw. A non-covered non-Latin prompt
+  // current seed is Simplified Chinese; future Japanese/Korean/Vietnamese/etc.
+  // terms should extend *_intl_kw. A non-covered non-Latin prompt
   // therefore cannot be scored by them, so a high-confidence keyword verdict on it
   // would be a lie. Force `uncertain` so the
   // cascade escalates to the (multilingual) Layer-2 eval — or, with eval OFF, lands

--- a/packages/core/src/classifier/engine.ts
+++ b/packages/core/src/classifier/engine.ts
@@ -136,18 +136,18 @@ export function scoreRequest(req: InternalRequest, deps: ScoreRequestDeps): Clas
   explanation.push({ source: "task", detail: task.task_type });
 
   // ── 5.5 language-coverage guard ───────────────────────────────────────────
-  // The keyword lists are ENGLISH-ONLY (CLAUDE.md: Layer-1 is the English fast
-  // path). A predominantly non-Latin prompt therefore cannot be scored by them, so
-  // a high-confidence keyword verdict on it would be a lie. Force `uncertain` so the
+  // Layer-1 has English plus small high-confidence CJK keyword lists. A non-covered
+  // non-Latin prompt therefore cannot be scored by them, so a high-confidence keyword
+  // verdict on it would be a lie. Force `uncertain` so the
   // cascade escalates to the (multilingual) Layer-2 eval — or, with eval OFF, lands
   // `balanced` deterministically rather than by luck of where the structural-only
   // rawScore fell. Suppressed when (a) the message is trivially short (already pinned
   // `simple` by the short_message override) or (b) a CONTENT-TYPE structural signal
   // gave real, language-agnostic grip (code block / stack / table / attachment / …).
   // Ambient signals (msg_length / turn_count) fire on every request and are NOT grip.
-  // Overrides the exact-confirmation / tier confidence computed above (a non-Latin
-  // prompt cannot have matched an English exact-confirmation token, so this only
-  // ever lowers confidence — never undoes a legitimate confirmation shortcut).
+  // Overrides the exact-confirmation / tier confidence computed above only when the
+  // prompt lacks English/CJK keyword grip, so legitimate CJK confirmations or keyword
+  // matches are not undone.
   if (safe(() => languageGuardTrips(req, cfg), false)) {
     confidence = 0;
     uncertain = true;

--- a/packages/core/src/classifier/engine.ts
+++ b/packages/core/src/classifier/engine.ts
@@ -136,9 +136,11 @@ export function scoreRequest(req: InternalRequest, deps: ScoreRequestDeps): Clas
   explanation.push({ source: "task", detail: task.task_type });
 
   // ── 5.5 language-coverage guard ───────────────────────────────────────────
-  // Layer-1 has English plus small high-confidence CJK keyword lists. A non-covered
-  // non-Latin prompt therefore cannot be scored by them, so a high-confidence keyword
-  // verdict on it would be a lie. Force `uncertain` so the
+  // Layer-1 has an English keyword layer plus an international keyword layer. The
+  // current seed is Simplified/Traditional Chinese; future Japanese/Korean/
+  // Vietnamese/etc. terms should extend *_intl_kw. A non-covered non-Latin prompt
+  // therefore cannot be scored by them, so a high-confidence keyword verdict on it
+  // would be a lie. Force `uncertain` so the
   // cascade escalates to the (multilingual) Layer-2 eval — or, with eval OFF, lands
   // `balanced` deterministically rather than by luck of where the structural-only
   // rawScore fell. Suppressed when (a) the message is trivially short (already pinned
@@ -146,7 +148,7 @@ export function scoreRequest(req: InternalRequest, deps: ScoreRequestDeps): Clas
   // gave real, language-agnostic grip (code block / stack / table / attachment / …).
   // Ambient signals (msg_length / turn_count) fire on every request and are NOT grip.
   // Overrides the exact-confirmation / tier confidence computed above only when the
-  // prompt lacks English/CJK keyword grip, so legitimate CJK confirmations or keyword
+  // prompt lacks English/international keyword grip, so legitimate confirmations or keyword
   // matches are not undone.
   if (safe(() => languageGuardTrips(req, cfg), false)) {
     confidence = 0;

--- a/packages/core/src/classifier/signals.test.ts
+++ b/packages/core/src/classifier/signals.test.ts
@@ -3,8 +3,8 @@ import { nonLatinRatio } from "./signals.js";
 
 // nonLatinRatio measures the fraction of *letters* (\p{L}) that are NOT Latin
 // script. It feeds the Layer-1 language-coverage guard (engine.ts): Layer-1 has
-// English plus small high-confidence CJK keyword lists, so non-covered languages and
-// CJK prompts that miss those lists must be marked uncertain → escalate to the
+// English plus small high-confidence international keyword lists, so non-covered
+// languages and prompts that miss those lists must be marked uncertain → escalate to the
 // (multilingual) Layer-2 eval. Punctuation, digits and whitespace are NOT letters,
 // so they never skew the ratio. Pure: same input => same output.
 describe("nonLatinRatio", () => {

--- a/packages/core/src/classifier/signals.test.ts
+++ b/packages/core/src/classifier/signals.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import { nonLatinRatio } from "./signals.js";
 
 // nonLatinRatio measures the fraction of *letters* (\p{L}) that are NOT Latin
-// script. It feeds the Layer-1 language-coverage guard (engine.ts): the keyword
-// lists are English-only, so a predominantly non-Latin prompt cannot be scored by
-// keywords and must be marked uncertain → escalate to the (multilingual) Layer-2
-// eval. Punctuation, digits and whitespace are NOT letters and so never skew the
-// ratio. Pure: same input => same output (CLAUDE.md principle 4).
+// script. It feeds the Layer-1 language-coverage guard (engine.ts): Layer-1 has
+// English plus small high-confidence CJK keyword lists, so non-covered languages and
+// CJK prompts that miss those lists must be marked uncertain → escalate to the
+// (multilingual) Layer-2 eval. Punctuation, digits and whitespace are NOT letters,
+// so they never skew the ratio. Pure: same input => same output.
 describe("nonLatinRatio", () => {
   it("is 0 for pure English/Latin prose", () => {
     expect(nonLatinRatio("please analyze this company's financials")).toBe(0);

--- a/packages/core/src/classifier/signals.ts
+++ b/packages/core/src/classifier/signals.ts
@@ -64,10 +64,10 @@ export function lengthSignal(text: string): number {
 
 // Fraction of LETTERS (\p{L}) that are NOT Latin script, in [0,1]; 0 when there are
 // no letters. Digits, punctuation and whitespace are ignored so they never skew the
-// ratio. The Layer-1 keyword lists are English-only, so a predominantly non-Latin
-// prompt is unscoreable by keywords — the engine's language-coverage guard uses this
-// to force `uncertain` and escalate to the (multilingual) Layer-2 eval. Pure: same
-// input => same output, zero I/O (CLAUDE.md principle 4).
+// ratio. Layer-1 has English plus small high-confidence CJK keyword lists, so a
+// non-covered non-Latin prompt is unscoreable by keywords — the engine's
+// language-coverage guard uses this to force `uncertain` and escalate to the
+// (multilingual) Layer-2 eval. Pure: same input => same output, zero I/O.
 const LETTER = /\p{L}/u;
 const LATIN_LETTER = /\p{Script=Latin}/u;
 export function nonLatinRatio(text: string): number {

--- a/packages/core/src/classifier/signals.ts
+++ b/packages/core/src/classifier/signals.ts
@@ -65,8 +65,8 @@ export function lengthSignal(text: string): number {
 // Fraction of LETTERS (\p{L}) that are NOT Latin script, in [0,1]; 0 when there are
 // no letters. Digits, punctuation and whitespace are ignored so they never skew the
 // ratio. Layer-1 has an English keyword layer plus an international keyword layer
-// (currently seeded with Simplified/Traditional Chinese, extendable for Japanese/
-// Korean/Vietnamese/etc.), so a
+// (currently seeded with Simplified Chinese, extendable for Japanese/Korean/
+// Vietnamese/etc.), so a
 // non-covered non-Latin prompt is unscoreable by keywords — the engine's
 // language-coverage guard uses this to force `uncertain` and escalate to the
 // (multilingual) Layer-2 eval. Pure: same input => same output, zero I/O.

--- a/packages/core/src/classifier/signals.ts
+++ b/packages/core/src/classifier/signals.ts
@@ -64,7 +64,9 @@ export function lengthSignal(text: string): number {
 
 // Fraction of LETTERS (\p{L}) that are NOT Latin script, in [0,1]; 0 when there are
 // no letters. Digits, punctuation and whitespace are ignored so they never skew the
-// ratio. Layer-1 has English plus small high-confidence CJK keyword lists, so a
+// ratio. Layer-1 has an English keyword layer plus an international keyword layer
+// (currently seeded with Simplified/Traditional Chinese, extendable for Japanese/
+// Korean/Vietnamese/etc.), so a
 // non-covered non-Latin prompt is unscoreable by keywords — the engine's
 // language-coverage guard uses this to force `uncertain` and escalate to the
 // (multilingual) Layer-2 eval. Pure: same input => same output, zero I/O.

--- a/packages/core/src/classifier/taskdetect.test.ts
+++ b/packages/core/src/classifier/taskdetect.test.ts
@@ -4,6 +4,7 @@ import type { ClassifierRulesConfig, InternalRequest } from "@helm/shared";
 import { ClassifierRulesConfigSchema } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import { loadConfig } from "../config/loader.js";
+import { scoreRequest } from "./engine.js";
 import { detectTask } from "./taskdetect.js";
 
 // Minimal classifier rules config mirroring config/classifier.yaml's task layer:
@@ -285,6 +286,45 @@ describe("detectTask", () => {
         shipped,
       );
       expect(res.task_type).toBe("security");
+    });
+
+    it("activates Simplified and Traditional Chinese coding keywords", () => {
+      const zhHans = detectTask(makeReq("请重构这个函数并补上单元测试"), shipped);
+      expect(zhHans.task_type).toBe("coding");
+
+      const zhHant = detectTask(makeReq("請重構這個函式並補上單元測試"), shipped);
+      expect(zhHant.task_type).toBe("coding");
+    });
+
+    it("keeps short Chinese confirmations simple at the engine layer", () => {
+      const cfg = shipped;
+      const req = {
+        request_id: "req-confirm",
+        protocol: "openai_chat",
+        account_id: "acc-1",
+        api_key_id: "key-1",
+        user_id: null,
+        org_id: null,
+        requested_model: "auto",
+        messages: [{ role: "user", content: "好的" }],
+        tools: null,
+        response_format: null,
+        attachments: null,
+        max_tokens: null,
+        stream: false,
+        metadata: {
+          conversation_id: null,
+          thread_id: null,
+          resource_id: null,
+          project_id: null,
+          memory_mode: "off",
+        },
+      } satisfies InternalRequest;
+
+      const out = scoreRequest(req, { cfg, approxTokens: 1 });
+      expect(out.complexity).toBe("simple");
+      expect(out.uncertain).toBe(false);
+      expect(out.explanation.some((e) => e.detail === "low_keyword_coverage")).toBe(false);
     });
   });
 

--- a/packages/core/src/classifier/taskdetect.test.ts
+++ b/packages/core/src/classifier/taskdetect.test.ts
@@ -288,12 +288,9 @@ describe("detectTask", () => {
       expect(res.task_type).toBe("security");
     });
 
-    it("activates Simplified and Traditional Chinese coding keywords", () => {
+    it("activates Simplified Chinese coding keywords", () => {
       const zhHans = detectTask(makeReq("请重构这个函数并补上单元测试"), shipped);
       expect(zhHans.task_type).toBe("coding");
-
-      const zhHant = detectTask(makeReq("請重構這個函式並補上單元測試"), shipped);
-      expect(zhHant.task_type).toBe("coding");
     });
 
     it("keeps short Chinese confirmations simple at the engine layer", () => {

--- a/packages/shared/src/config/classifier-schema.ts
+++ b/packages/shared/src/config/classifier-schema.ts
@@ -60,8 +60,8 @@ export const ClassifierRulesConfigSchema = z.object({
     disable_above_chars: z.number().int().positive().default(100),
     max_history_weight: z.number().min(0).max(1).default(0.6),
   }),
-  // Language-coverage guard. The keyword lists above are ENGLISH-ONLY, so a
-  // predominantly non-Latin prompt (Chinese / Japanese / Korean / Cyrillic / …)
+  // Language-coverage guard. Layer-1 has English plus small high-confidence CJK
+  // keyword lists. Non-covered languages, and CJK prompts that miss those lists,
   // cannot be scored by keywords. When `non_latin_uncertain` is on, such a prompt
   // is forced `uncertain` so the cascade escalates to the (multilingual) Layer-2
   // eval — or, with eval OFF, degrades deterministically to `balanced` instead of

--- a/packages/shared/src/config/classifier-schema.ts
+++ b/packages/shared/src/config/classifier-schema.ts
@@ -60,8 +60,10 @@ export const ClassifierRulesConfigSchema = z.object({
     disable_above_chars: z.number().int().positive().default(100),
     max_history_weight: z.number().min(0).max(1).default(0.6),
   }),
-  // Language-coverage guard. Layer-1 has English plus small high-confidence CJK
-  // keyword lists. Non-covered languages, and CJK prompts that miss those lists,
+  // Language-coverage guard. Layer-1 has an English keyword layer plus an
+  // international keyword layer. The current seed is Simplified/Traditional Chinese;
+  // future Japanese/Korean/Vietnamese/etc. terms should extend *_intl_kw.
+  // Non-covered languages, and prompts that miss those lists,
   // cannot be scored by keywords. When `non_latin_uncertain` is on, such a prompt
   // is forced `uncertain` so the cascade escalates to the (multilingual) Layer-2
   // eval — or, with eval OFF, degrades deterministically to `balanced` instead of

--- a/packages/shared/src/config/classifier-schema.ts
+++ b/packages/shared/src/config/classifier-schema.ts
@@ -61,8 +61,8 @@ export const ClassifierRulesConfigSchema = z.object({
     max_history_weight: z.number().min(0).max(1).default(0.6),
   }),
   // Language-coverage guard. Layer-1 has an English keyword layer plus an
-  // international keyword layer. The current seed is Simplified/Traditional Chinese;
-  // future Japanese/Korean/Vietnamese/etc. terms should extend *_intl_kw.
+  // international keyword layer. The current seed is Simplified Chinese; future
+  // Japanese/Korean/Vietnamese/etc. terms should extend *_intl_kw.
   // Non-covered languages, and prompts that miss those lists,
   // cannot be scored by keywords. When `non_latin_uncertain` is on, such a prompt
   // is forced `uncertain` so the cascade escalates to the (multilingual) Layer-2


### PR DESCRIPTION
## 做了什么
- 为 classifier Layer-1 新增独立“其他语言 / international”正向维度：`coding_intl_kw`、`analysis_intl_kw`、`writing_intl_kw`、`math_intl_kw`、`data_intl_kw`、`security_intl_kw`、`vision_intl_kw`、`web_intl_kw`、`extraction_intl_kw`。
- 当前运行词表 seed 只覆盖简体中文；繁体中文不保留为运行词表。后续日语、韩语、越南语等非英文词也应扩到 `*_intl_kw`，不要塞进英文 `*_kw`。
- 为 `task_keywords`、`exact_confirmation_tokens`、`formal_logic_keywords` 补充最小高置信简体中文词表。
- 同步更新 language guard 注释与分类文档：Layer-1 是 English keyword layer + international keyword layer；未覆盖语言 / 未命中 intl 词表仍走 guard。
- 补测试覆盖简中 analysis、coding、math、web、confirmation、guard，以及英文 golden/cascade 回归。

## 为什么改
- 当前 Layer-1 原口径是 English-only，非英文 prompt 即使是明确 analysis/coding/math/web 也容易触发 `low_keyword_coverage`，在 eval 关闭时退到 balanced。
- 这层不是“中文专用”，而是英文之外的高置信关键词层；命名为 `*_intl_kw`，避免以后日/韩/越等词表扩展时被 `zh` 名字误导。
- 本次按 Lukin 最新要求只保留简体中文 seed，并删除繁体中文运行词表；不引入 LLM/OpenCC/新依赖，也不稀释现有英文 keywordSignal。

## Acceptance Criteria
- [x] 简中 analysis prompt 由 rules 接住，不触发 `low_keyword_coverage`。
- [x] 简中 coding prompt 分类为 `task_type=coding`。
- [x] 简中 math prompt 分类为 `task_type=math`，命中 `math_intl_kw`，不触发 `low_keyword_coverage`。
- [x] 简中 web prompt 命中 `web_intl_kw`，不触发 `low_keyword_coverage`。
- [x] 短中文确认仍为 `simple`，且不触发 language guard。
- [x] 未命中词表的长中文仍触发 `low_keyword_coverage`，避免乱判。
- [x] 英文 golden/cascade 原样全绿，确认 international 词表不影响英文分类。
- [x] 运行词表不保留繁体中文正向 seed；繁体中文不作为本 PR 的正向覆盖目标。
- [x] 没有新增依赖、LLM、OpenCC；没有把非英文关键词追加到现有英文 `*_kw` 列表。

## 验证证据
- `pnpm exec vitest run packages/core/src/classifier` → 16 files / 238 tests passed。
- `pnpm exec vitest run packages/core/src/classifier/engine.test.ts packages/core/src/classifier/taskdetect.test.ts packages/core/src/classifier/signals.test.ts` → 3 files / 53 tests passed。
- `pnpm --filter @helm/core typecheck` → passed。
- `pnpm --filter @helm/shared typecheck` → passed。
- `pnpm lint` → passed。
- `git diff --check` → passed。
- Binary evidence check → no screenshot/video/binary evidence committed。
- GitHub CI：`verify` SUCCESS，`docker` SUCCESS。

> 备注：typecheck / test 过程中 esbuild 打印既有 `apps/admin/.svelte-kit/tsconfig.json` warning，但命令退出码为 0。

## 风险点
- `*_intl_kw` 当前是简体中文高置信 seed，不覆盖所有非英文表达；未命中时仍会按 guard 进入 eval/balanced。
- `task_keywords` 仍是 substring 匹配，所以本次避免加入“做/写/看/图/表”等单字/泛词。
- 后续扩日语、韩语、越南语等时，需要同样补维度 + guard 回归，不能只补 `task_keywords`。

## 人类 review 关注点
- 请重点看 international 词表是否足够收敛，是否存在过宽词（尤其 task_keywords substring 风险）。
- 请确认 `*_intl_kw` 这个命名是否符合“英文 + 其他语言”两层模型。
- 请确认“当前 seed 只覆盖简体中文；繁体中文不保留为运行词表”的产品边界。

## 合并策略
- 小 PR，建议 squash merge；合并前等 Trent review + CI 绿。
