### PR TITLE
feat: 增加 provider protocol fast path 前置元数据

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -44,6 +44,7 @@ function registry(map: Record<string, string>): ProviderRegistry {
           providerModel: pm,
           baseUrl: "http://x",
           apiKeyEnv: "X",
+          targetProviderProtocol: "openai_chat",
         },
       };
     },
@@ -66,6 +67,7 @@ function registryWithProviders(
           providerModel: hit.providerModel,
           baseUrl: "http://x",
           apiKeyEnv: "X",
+          targetProviderProtocol: "openai_chat",
         },
       };
     },
@@ -516,6 +518,7 @@ describe("createExecute — gateway execution adapter", () => {
               providerModel: "model-a",
               baseUrl: "http://a",
               apiKeyEnv: "A_KEY",
+              targetProviderProtocol: "openai_chat",
             },
           };
         if (alias === "b")
@@ -527,6 +530,7 @@ describe("createExecute — gateway execution adapter", () => {
               providerModel: "model-b",
               baseUrl: "http://b",
               apiKeyEnv: "B_KEY",
+              targetProviderProtocol: "openai_chat",
             },
           };
         return { ok: false, error: { kind: "unknown_alias", alias } };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -481,6 +481,12 @@ export {
   openaiToResponsesRequest,
   translateResponsesSSE,
 } from "./provider/openai-responses.js";
+export {
+  canUseSameProtocolSerializationFastPath,
+  type SameProtocolSerializationFastPathDecision,
+  type SameProtocolSerializationFastPathDecisionInput,
+  type SameProtocolSerializationFastPathDisableReason,
+} from "./provider/protocol.js";
 // Per-account egress proxy (issue #38 follow-up): a drop-in `fetch` that tunnels
 // upstream traffic through an http/https/socks5 proxy, so distinct subscription
 // accounts can leave from distinct IPs. Injected into the executors' `fetch` seam.

--- a/packages/core/src/provider/protocol.test.ts
+++ b/packages/core/src/provider/protocol.test.ts
@@ -1,0 +1,117 @@
+import type { InternalRequest } from "@helm/shared";
+import { describe, expect, it } from "vitest";
+import {
+  canUseSameProtocolSerializationFastPath,
+  type SameProtocolSerializationFastPathDecisionInput,
+} from "./protocol.js";
+
+function request(overrides: Partial<InternalRequest> = {}): InternalRequest {
+  return {
+    request_id: "req-1",
+    protocol: "openai_chat",
+    account_id: "acct-1",
+    api_key_id: "key-1",
+    user_id: null,
+    org_id: null,
+    requested_model: "auto",
+    messages: [{ role: "user", content: "hi" }],
+    tools: null,
+    response_format: null,
+    attachments: null,
+    max_tokens: null,
+    stream: false,
+    metadata: {
+      conversation_id: null,
+      thread_id: null,
+      resource_id: null,
+      project_id: null,
+      memory_mode: "observe",
+    },
+    ...overrides,
+  };
+}
+
+function input(
+  overrides: Partial<SameProtocolSerializationFastPathDecisionInput> = {},
+): SameProtocolSerializationFastPathDecisionInput {
+  return {
+    request: request(),
+    responseProtocol: "openai_chat",
+    targetProviderProtocol: "openai_chat",
+    fallbackMayUseDifferentProviderProtocol: false,
+    providerRequiresCompatibilityRewrite: false,
+    ...overrides,
+  };
+}
+
+describe("canUseSameProtocolSerializationFastPath", () => {
+  it("enables only openai_chat -> OpenAI-compatible chat non-stream serialization", () => {
+    expect(canUseSameProtocolSerializationFastPath(input())).toEqual({ ok: true });
+  });
+
+  it("disables stream requests in the prep PR until stream fast path is implemented", () => {
+    expect(
+      canUseSameProtocolSerializationFastPath(input({ request: request({ stream: true }) })),
+    ).toEqual({ ok: false, reason: "stream_not_supported_in_prep_pr" });
+  });
+
+  it("disables memory inject because it can rewrite messages before execute serialization", () => {
+    expect(
+      canUseSameProtocolSerializationFastPath(
+        input({ request: request({ metadata: { ...request().metadata, memory_mode: "inject" } }) }),
+      ),
+    ).toEqual({ ok: false, reason: "memory_inject_may_rewrite_request" });
+  });
+
+  it("disables when fallback or retry may select a non OpenAI-compatible provider wire", () => {
+    expect(
+      canUseSameProtocolSerializationFastPath(
+        input({ fallbackMayUseDifferentProviderProtocol: true }),
+      ),
+    ).toEqual({ ok: false, reason: "fallback_may_change_provider_protocol" });
+  });
+
+  it.each([
+    "anthropic_messages",
+    "gemini",
+    "openai_responses",
+  ] as const)("disables cross-protocol source %s", (protocol) => {
+    expect(
+      canUseSameProtocolSerializationFastPath(input({ request: request({ protocol }) })),
+    ).toEqual({ ok: false, reason: "source_protocol_not_openai_chat" });
+  });
+
+  it.each([
+    "anthropic_messages",
+    "gemini",
+    "openai_responses",
+  ] as const)("disables non-chat target provider protocol %s", (targetProviderProtocol) => {
+    expect(canUseSameProtocolSerializationFastPath(input({ targetProviderProtocol }))).toEqual({
+      ok: false,
+      reason: "target_provider_protocol_not_openai_chat",
+    });
+  });
+
+  it("disables provider compatibility rewrites such as developer-role or tool/schema remaps", () => {
+    expect(
+      canUseSameProtocolSerializationFastPath(
+        input({ providerRequiresCompatibilityRewrite: true }),
+      ),
+    ).toEqual({ ok: false, reason: "provider_requires_compatibility_rewrite" });
+  });
+
+  it("is only a serialization-layer decision and does not replace governance", () => {
+    const decision = canUseSameProtocolSerializationFastPath(input());
+
+    expect(decision).toEqual({ ok: true });
+    // Governance remains outside this helper: auth, routing, budget, telemetry,
+    // memory, fallback and breaker must already have run before execute asks this.
+    expect(Object.keys(input()).sort()).toEqual([
+      "fallbackMayUseDifferentProviderProtocol",
+      "providerRequiresCompatibilityRewrite",
+      "request",
+      "responseProtocol",
+      "targetProviderProtocol",
+    ]);
+  });
+});

--- a/packages/core/src/provider/protocol.test.ts
+++ b/packages/core/src/provider/protocol.test.ts
@@ -92,6 +92,17 @@ describe("canUseSameProtocolSerializationFastPath", () => {
     });
   });
 
+  it.each([
+    "anthropic_messages",
+    "gemini",
+    "openai_responses",
+  ] as const)("disables non-chat response protocol %s", (responseProtocol) => {
+    expect(canUseSameProtocolSerializationFastPath(input({ responseProtocol }))).toEqual({
+      ok: false,
+      reason: "response_protocol_not_openai_chat",
+    });
+  });
+
   it("disables provider compatibility rewrites such as developer-role or tool/schema remaps", () => {
     expect(
       canUseSameProtocolSerializationFastPath(

--- a/packages/core/src/provider/protocol.ts
+++ b/packages/core/src/provider/protocol.ts
@@ -1,0 +1,52 @@
+import type { InternalRequest, Protocol, TargetProviderProtocol } from "@helm/shared";
+
+export type SameProtocolSerializationFastPathDisableReason =
+  | "source_protocol_not_openai_chat"
+  | "response_protocol_not_openai_chat"
+  | "target_provider_protocol_not_openai_chat"
+  | "stream_not_supported_in_prep_pr"
+  | "memory_inject_may_rewrite_request"
+  | "fallback_may_change_provider_protocol"
+  | "provider_requires_compatibility_rewrite";
+
+export type SameProtocolSerializationFastPathDecision =
+  | { ok: true }
+  | { ok: false; reason: SameProtocolSerializationFastPathDisableReason };
+
+export interface SameProtocolSerializationFastPathDecisionInput {
+  request: InternalRequest;
+  responseProtocol: Protocol;
+  targetProviderProtocol: TargetProviderProtocol;
+  fallbackMayUseDifferentProviderProtocol: boolean;
+  providerRequiresCompatibilityRewrite: boolean;
+}
+
+// #217 first PR only defines the serialization-layer guard. It does not replace
+// auth/routing/budget/telemetry/memory/fallback/breaker and is not wired into
+// execute yet; later fast-path code must call it after routing selects a candidate.
+export function canUseSameProtocolSerializationFastPath(
+  input: SameProtocolSerializationFastPathDecisionInput,
+): SameProtocolSerializationFastPathDecision {
+  if (input.request.protocol !== "openai_chat") {
+    return { ok: false, reason: "source_protocol_not_openai_chat" };
+  }
+  if (input.responseProtocol !== "openai_chat") {
+    return { ok: false, reason: "response_protocol_not_openai_chat" };
+  }
+  if (input.targetProviderProtocol !== "openai_chat") {
+    return { ok: false, reason: "target_provider_protocol_not_openai_chat" };
+  }
+  if (input.request.stream) {
+    return { ok: false, reason: "stream_not_supported_in_prep_pr" };
+  }
+  if (input.request.metadata.memory_mode === "inject") {
+    return { ok: false, reason: "memory_inject_may_rewrite_request" };
+  }
+  if (input.fallbackMayUseDifferentProviderProtocol) {
+    return { ok: false, reason: "fallback_may_change_provider_protocol" };
+  }
+  if (input.providerRequiresCompatibilityRewrite) {
+    return { ok: false, reason: "provider_requires_compatibility_rewrite" };
+  }
+  return { ok: true };
+}

--- a/packages/core/src/provider/registry.test.ts
+++ b/packages/core/src/provider/registry.test.ts
@@ -28,7 +28,7 @@ const anthropic: ProviderConfig = {
 };
 
 describe("createProviderRegistry / resolve", () => {
-  it("resolves an alias to its provider + model + base_url + api_key_env", () => {
+  it("resolves an alias to provider metadata including targetProviderProtocol", () => {
     const reg = createProviderRegistry([openai]);
     const res = reg.resolve("cheap_model");
     expect(res.ok).toBe(true);
@@ -39,8 +39,26 @@ describe("createProviderRegistry / resolve", () => {
         providerModel: "gpt-4o-mini",
         baseUrl: "https://api.openai.com/v1",
         apiKeyEnv: "OPENAI_API_KEY",
+        targetProviderProtocol: "openai_chat",
       });
     }
+  });
+
+  it("distinguishes Codex Responses from OpenAI-compatible chat providers", () => {
+    const codex: ProviderConfig = {
+      name: "openai-codex",
+      base_url: "https://chatgpt.com/backend-api/codex",
+      api_key_env: "OPENAI_CODEX_TOKEN",
+      targetProviderProtocol: "openai_responses",
+      models: [{ alias: "openai-codex/gpt-5.5", provider_model: "gpt-5.5" }],
+    };
+    const reg = createProviderRegistry([openai, codex]);
+
+    const chat = reg.resolve("cheap_model");
+    const responses = reg.resolve("openai-codex/gpt-5.5");
+
+    expect(chat.ok && chat.value.targetProviderProtocol).toBe("openai_chat");
+    expect(responses.ok && responses.value.targetProviderProtocol).toBe("openai_responses");
   });
 
   it("returns a structured unknown_alias error (no throw) for an unknown alias", () => {

--- a/packages/core/src/provider/registry.ts
+++ b/packages/core/src/provider/registry.ts
@@ -15,7 +15,7 @@
 //    (principle 2), rather than letting a later provider silently shadow an
 //    earlier one at runtime.
 
-import type { ProviderConfig as SharedProviderConfig } from "@helm/shared";
+import type { ProviderConfig as SharedProviderConfig, TargetProviderProtocol } from "@helm/shared";
 
 // A single provider's config (post-validation). This is structurally a SUBSET of
 // `@helm/shared`'s unified ProviderConfig (which now also carries name + models[]
@@ -30,6 +30,7 @@ export interface ProviderConfig {
   // (the per-name client is pre-built in providerClients), so an empty value is
   // acceptable for OAuth providers.
   api_key_env?: string;
+  targetProviderProtocol?: TargetProviderProtocol;
   models: Array<{
     alias: string; // internal alias, e.g. "cheap_model", "openai/auto"
     provider_model: string; // the provider's real model id, e.g. "gpt-4o-mini"
@@ -47,6 +48,7 @@ export interface ResolvedProvider {
   // (issue #38) carry no api_key_env and the executor never reads it (it dispatches
   // by providerName to a pre-built client).
   apiKeyEnv?: string;
+  targetProviderProtocol: TargetProviderProtocol;
 }
 
 // Structured resolve/build errors — unknown alias (resolve-time) and duplicate
@@ -92,6 +94,7 @@ export function createProviderRegistry(providers: ProviderConfig[]): ProviderReg
         providerModel: model.provider_model,
         baseUrl: provider.base_url,
         apiKeyEnv: provider.api_key_env,
+        targetProviderProtocol: provider.targetProviderProtocol ?? "openai_chat",
       });
     }
   }
@@ -137,6 +140,7 @@ export function toRegistryProviders(
     // registry never reads it to fetch a credential (the per-name client is
     // pre-built in providerClients).
     api_key_env: p.api_key_env ?? "",
+    targetProviderProtocol: p.targetProviderProtocol,
     models: p.models.map((m) => ({ alias: m.alias, provider_model: m.provider_model })),
   }));
 }

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { HelmConfigSchema, isOAuthPreset, ProviderConfigSchema, type OAuthConfig } from "./schema.js";
+import {
+  HelmConfigSchema,
+  isOAuthPreset,
+  ProviderConfigSchema,
+  type OAuthConfig,
+} from "./schema.js";
 
 // Narrow a provider's oauth union to the CONFIDENTIAL block for assertions
 // (fails loudly if it is actually a preset block).

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   HelmConfigSchema,
   isOAuthPreset,
-  ProviderConfigSchema,
   type OAuthConfig,
+  ProviderConfigSchema,
 } from "./schema.js";
 
 // Narrow a provider's oauth union to the CONFIDENTIAL block for assertions

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { HelmConfigSchema, isOAuthPreset, type OAuthConfig } from "./schema.js";
+import { HelmConfigSchema, isOAuthPreset, ProviderConfigSchema, type OAuthConfig } from "./schema.js";
 
 // Narrow a provider's oauth union to the CONFIDENTIAL block for assertions
 // (fails loudly if it is actually a preset block).
@@ -50,6 +50,40 @@ function minimalConfig() {
     runtime: { rate_limit: { default: {} } },
   };
 }
+
+describe("ProviderConfigSchema targetProviderProtocol", () => {
+  function provider(overrides: Record<string, unknown> = {}) {
+    return ProviderConfigSchema.parse({
+      name: "provider",
+      api_key_env: "PROVIDER_API_KEY",
+      ...overrides,
+    });
+  }
+
+  it("uses openai_chat for default and explicit openai provider types", () => {
+    expect(provider().targetProviderProtocol).toBe("openai_chat");
+    expect(provider({ type: "openai" }).targetProviderProtocol).toBe("openai_chat");
+  });
+
+  it.each([
+    ["openai-responses", "openai_responses"],
+    ["anthropic", "anthropic_messages"],
+    ["gemini", "gemini"],
+  ] as const)("infers targetProviderProtocol for type %s", (type, targetProviderProtocol) => {
+    expect(provider({ type }).targetProviderProtocol).toBe(targetProviderProtocol);
+  });
+
+  it("transforms explicit target_provider_protocol override to targetProviderProtocol", () => {
+    expect(
+      provider({ type: "openai", target_provider_protocol: "openai_responses" })
+        .targetProviderProtocol,
+    ).toBe("openai_responses");
+  });
+
+  it("intentionally defaults unknown provider type to openai_chat", () => {
+    expect(provider({ type: "unknown-provider" }).targetProviderProtocol).toBe("openai_chat");
+  });
+});
 
 describe("HelmConfigSchema", () => {
   it("accepts a full valid config", () => {

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { TargetProviderProtocolSchema } from "../request/schema.js";
 import { ClassifierConfigSchema } from "./classifier-schema.js";
 import { LanesConfigSchema } from "./lanes-schema.js";
 import { MemoryConfigSchema } from "./memory-schema.js";
@@ -39,6 +40,13 @@ export const ProviderModelSchema = z.object({
   alias: z.string().min(1),
   provider_model: z.string().min(1),
 });
+
+function inferTargetProviderProtocol(type: string): z.infer<typeof TargetProviderProtocolSchema> {
+  if (type === "openai-responses") return "openai_responses";
+  if (type === "anthropic") return "anthropic_messages";
+  if (type === "gemini") return "gemini";
+  return "openai_chat";
+}
 
 // OAuth credential reference for subscription / SSO upstreams (issue #38). Like
 // api_key_env, this carries env-var NAMES only — never a plaintext token, secret,
@@ -143,6 +151,10 @@ export const ProviderConfigSchema = z
     api_key_env: z.string().min(1).optional(),
     oauth: OAuthCredentialSchema.optional(),
     models: z.array(ProviderModelSchema).default([]),
+    // Provider wire protocol for #217 same-protocol serialization decisions.
+    // OpenAI-compatible chat providers default to openai_chat; Codex/native
+    // Responses and other provider wires must be distinguishable metadata.
+    target_provider_protocol: TargetProviderProtocolSchema.optional(),
     map_developer_role_to_system: z.boolean().default(false),
   })
   .refine((p) => p.name !== undefined || p.alias !== undefined, {
@@ -164,6 +176,7 @@ export const ProviderConfigSchema = z
     ...p,
     name: p.name ?? (p.alias as string),
     alias: p.alias ?? (p.name as string),
+    targetProviderProtocol: p.target_provider_protocol ?? inferTargetProviderProtocol(p.type),
   }));
 
 // A single quota dimension pair. 0 = that dimension is unlimited (skip the check).

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -266,6 +266,8 @@ export {
   ProtocolSchema,
   type RequestMetadata,
   RequestMetadataSchema,
+  type TargetProviderProtocol,
+  TargetProviderProtocolSchema,
 } from "./request/schema.js";
 // Routing signal (POST-MVP Agentic Signals feedback layer; docs/02 telemetry).
 export { type RoutingSignal, RoutingSignalSchema } from "./signals/schema.js";

--- a/packages/shared/src/request/schema.test.ts
+++ b/packages/shared/src/request/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { InternalRequestSchema } from "./schema.js";
+import { InternalRequestSchema, ProtocolSchema, TargetProviderProtocolSchema } from "./schema.js";
 
 // Minimal valid normalized request: every optional field is explicitly present
 // (nullable, not omitted) per the "fields always present" contract.
@@ -97,5 +97,17 @@ describe("InternalRequestSchema", () => {
     if (!res.success) {
       expect(res.error.issues[0]?.path).toEqual(["messages"]);
     }
+  });
+});
+
+describe("TargetProviderProtocolSchema", () => {
+  it("is a provider wire protocol enum independent from the inbound ProtocolSchema", () => {
+    expect(TargetProviderProtocolSchema).not.toBe(ProtocolSchema);
+    expect(TargetProviderProtocolSchema.options).toEqual([
+      "openai_chat",
+      "anthropic_messages",
+      "openai_responses",
+      "gemini",
+    ]);
   });
 });

--- a/packages/shared/src/request/schema.ts
+++ b/packages/shared/src/request/schema.ts
@@ -15,7 +15,12 @@ export const ProtocolSchema = z.enum([
 
 // Provider wire protocol selected by routing/execution. This is intentionally
 // separate from the inbound source protocol and the client response protocol.
-export const TargetProviderProtocolSchema = ProtocolSchema;
+export const TargetProviderProtocolSchema = z.enum([
+  "openai_chat",
+  "anthropic_messages",
+  "openai_responses",
+  "gemini",
+]);
 
 export const MemoryModeSchema = z.enum(["off", "observe", "inject"]);
 

--- a/packages/shared/src/request/schema.ts
+++ b/packages/shared/src/request/schema.ts
@@ -13,6 +13,10 @@ export const ProtocolSchema = z.enum([
   "gemini",
 ]);
 
+// Provider wire protocol selected by routing/execution. This is intentionally
+// separate from the inbound source protocol and the client response protocol.
+export const TargetProviderProtocolSchema = ProtocolSchema;
+
 export const MemoryModeSchema = z.enum(["off", "observe", "inject"]);
 
 // MVP does not deep-validate message/tool internals: keep the normalized shape
@@ -151,6 +155,7 @@ export type OpenAIChatRequest = z.infer<typeof OpenAIChatRequestSchema>;
 
 // Single source of truth: types via z.infer — no duplicate interfaces.
 export type Protocol = z.infer<typeof ProtocolSchema>;
+export type TargetProviderProtocol = z.infer<typeof TargetProviderProtocolSchema>;
 export type MemoryMode = z.infer<typeof MemoryModeSchema>;
 export type RequestMetadata = z.infer<typeof RequestMetadataSchema>;
 export type InternalRequest = z.infer<typeof InternalRequestSchema>;


### PR DESCRIPTION
## Phase 0 定性

本 PR 只是 #217 的 **Phase 0 metadata prep**：补 provider wire protocol 元数据、决策 helper 和禁用条件测试。它 **不改变 runtime behavior**，不接入 `execute.ts` fast path，不绕过 `InternalRequest` / routing / budget / telemetry / memory / fallback / breaker 主干。

真正减少 `openai_chat -> openai_chat` 转换的实现另开 follow-up（Phase 1），只做 OpenAI Chat non-stream provider-attempt fast path。

## 做了什么

- 新增 `TargetProviderProtocol` / `targetProviderProtocol` 元数据，区分入口 `sourceProtocol`、provider wire protocol、响应协议。
- provider registry 解析结果透出 `targetProviderProtocol`，OpenAI-compatible provider 默认 `openai_chat`，Codex Responses 可标记为 `openai_responses`。
- 新增 `canUseSameProtocolSerializationFastPath()` 决策函数，只定义 #217 第一刀 enable/disable 边界。
- 补充单元测试覆盖 OpenAI Chat enable、stream/memory/fallback/cross-protocol/compat rewrite disable，以及治理不被 helper 替代的约束。

## 为什么改

#217 后续要做 same-protocol serialization fast path；第一步必须先把 provider wire protocol 变成一等元数据，避免靠入口协议或模型名猜测，并先用测试锁死禁用条件。

当前真实代码里，`execute.ts` 仍固定用 `stripInternal(req, providerModel)` 生成 provider body；本 PR 不改发送路径，只为后续 Phase 1 提供可验证边界。

Refs #217

## Acceptance Criteria

- [x] 明确 `sourceProtocol` / `targetProviderProtocol` / `responseProtocol` 三个概念边界。
- [x] provider/candidate metadata 能区分 OpenAI-compatible Chat 与 Codex Responses wire。
- [x] `canUseSameProtocolSerializationFastPath()` 只允许 `openai_chat -> openai_chat` non-stream 前置场景。
- [x] stream 请求在第一刀禁用 fast path，不实现 stream fast path。
- [x] memory inject / fallback 到不同 provider protocol / Anthropic / Gemini / Responses / provider compatibility rewrite 均禁用 fast path。
- [x] 测试/注释明确该 helper 不替代 auth、routing、budget、telemetry、memory、fallback、breaker。
- [x] 未修改 `stripInternal()`、response/stream transform、execute provider body/response serialization。
- [x] runtime behavior unchanged：当前 provider 调用链仍走 `stripInternal()`。

## 验证证据

- 已 rebase 到当前 `origin/main`（含 #221/#222 协议保真修复），head `1eab4dc1e62c63d3e493e6bc3379dccc26ce97b3`。
- `pnpm exec vitest run packages/core/src/provider/protocol.test.ts packages/core/src/provider/registry.test.ts apps/gateway/src/routes/execute.test.ts packages/shared/src/config/schema.test.ts packages/shared/src/request/schema.test.ts --reporter=dot` 通过：5 files / 119 tests。
- `pnpm typecheck` 通过。
- `pnpm lint` 通过。
- `git diff --check` 通过。
- 二进制证据检查无命中：`git diff --name-only origin/main...HEAD | grep -E '\.(png|jpg|jpeg|gif|webp|mp4|mov|webm|avif|bmp|tiff)$'`。

说明：曾误用 `pnpm test -- <files>` 跑到全量测试，只有既有 `apps/admin/build` 缺失导致 `admin-static.test.ts` 4 个用例失败；上述定向测试、typecheck、lint 均通过。

## 风险点

- `targetProviderProtocol` 目前只是前置元数据和决策 helper，尚未接入 execute 实际 fast path。
- Provider `type` 到 protocol 的默认推断只覆盖当前已知 `openai` / `openai-responses` / `anthropic` / `gemini`，新 provider wire 后续需要显式扩展或配置。
- Phase 1 不能使用入口 raw body；必须使用治理后可证明等价的 native payload，否则禁用 fast path。

## 人类 Review 关注点

- 是否接受本 PR 作为 Phase 0 合并：metadata / guard / tests only。
- `targetProviderProtocol` 命名/默认推断是否符合 Trent 设计表。
- disable reason 是否覆盖 #217 第一刀边界，尤其 stream 和 memory inject。
- 是否严格未越界到发送路径。

## 合并策略

- 小 PR 直接 squash merge；后续 PR 再基于该元数据接入 `execute.ts` provider-attempt fast path。
