### PR TITLE
修复 Anthropic 原生请求多模态透传

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -159,7 +159,15 @@ describe("createExecute — gateway execution adapter", () => {
         include_server_side_tool_invocations: true,
         verbosity: "low",
         safety_identifier: "safe-user",
-        provider_raw: { metadata: { prompt_version: "v1" }, store: false },
+        provider_raw: {
+          metadata: { prompt_version: "v1" },
+          store: false,
+          context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+          mcp_servers: [{ type: "url", url: "https://mcp.example.test" }],
+          container: { id: "container_123" },
+          speed: "fast",
+          output_config: { effort: "xhigh" },
+        },
       }),
     );
 
@@ -198,6 +206,11 @@ describe("createExecute — gateway execution adapter", () => {
       safety_identifier: "safe-user",
       metadata: { prompt_version: "v1" },
       store: false,
+      context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+      mcp_servers: [{ type: "url", url: "https://mcp.example.test" }],
+      container: { id: "container_123" },
+      speed: "fast",
+      output_config: { effort: "xhigh" },
     });
   });
 

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -585,7 +585,15 @@ const FORWARDED_REQUEST_PARAM_KEYS = [
   "safety_identifier",
 ] as const satisfies ReadonlyArray<keyof InternalRequest>;
 
-const PROVIDER_RAW_FORWARD_KEYS = ["metadata", "store", "context_management"] as const;
+const PROVIDER_RAW_FORWARD_KEYS = [
+  "metadata",
+  "store",
+  "context_management",
+  "mcp_servers",
+  "container",
+  "speed",
+  "output_config",
+] as const;
 
 function stripInternal(req: InternalRequest, providerModel: string): Record<string, unknown> {
   const body: Record<string, unknown> = {

--- a/apps/gateway/src/routes/internal-request-params.ts
+++ b/apps/gateway/src/routes/internal-request-params.ts
@@ -61,8 +61,27 @@ export function providerRawFromRequest(
   // has gateway metadata. Keep the provider value in provider_raw to avoid collision.
   const keys =
     options.includeMetadata === false
-      ? ["store", "previous_response_id", "truncation", "context_management"]
-      : ["metadata", "store", "previous_response_id", "truncation", "context_management"];
+      ? [
+          "store",
+          "previous_response_id",
+          "truncation",
+          "context_management",
+          "mcp_servers",
+          "container",
+          "speed",
+          "output_config",
+        ]
+      : [
+          "metadata",
+          "store",
+          "previous_response_id",
+          "truncation",
+          "context_management",
+          "mcp_servers",
+          "container",
+          "speed",
+          "output_config",
+        ];
   for (const key of keys) {
     const value = source[key];
     if (value !== undefined) raw[key] = value;

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -249,6 +249,11 @@ describe("createMessagesPipeline — production IR params", () => {
         user: "user-123",
         service_tier: "auto",
         web_search_options: { search_context_size: "low" },
+        context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+        mcp_servers: [{ type: "url", url: "https://mcp.example.test" }],
+        container: { id: "container_123" },
+        speed: "fast",
+        output_config: { effort: "xhigh" },
         provider_raw: { metadata: { request_id: "client-meta" } },
       }),
       IDENTITY,
@@ -272,5 +277,14 @@ describe("createMessagesPipeline — production IR params", () => {
     expect(captured.service_tier).toBe("auto");
     expect(captured.web_search_options).toEqual({ search_context_size: "low" });
     expect(captured.provider_raw?.metadata).toEqual({ request_id: "client-meta" });
+    expect(captured.provider_raw?.context_management).toEqual({
+      edits: [{ type: "clear_tool_uses_20250919" }],
+    });
+    expect(captured.provider_raw?.mcp_servers).toEqual([
+      { type: "url", url: "https://mcp.example.test" },
+    ]);
+    expect(captured.provider_raw?.container).toEqual({ id: "container_123" });
+    expect(captured.provider_raw?.speed).toBe("fast");
+    expect(captured.provider_raw?.output_config).toEqual({ effort: "xhigh" });
   });
 });

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -88,6 +88,39 @@ describe("openaiToAnthropicRequest", () => {
     ]);
   });
 
+  it("keeps image parts when a tool-result continuation carries a fresh user correction", () => {
+    const body = openaiToAnthropicRequest({
+      model: "m",
+      messages: [
+        {
+          role: "assistant",
+          content: "I will inspect the chart.",
+          tool_calls: [{ id: "t1", type: "function", function: { name: "Bash", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "t1", content: "ok" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "这些图表上的数字都应该格式化一下" },
+            { type: "image", url: "data:image/png;base64,abc123", mediaType: "image/png" },
+          ],
+        },
+      ],
+    });
+
+    const msgs = body.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    expect(msgs.map((m) => m.role)).toEqual(["assistant", "user"]);
+    expect(msgs[1]?.content).toContainEqual({
+      type: "tool_result",
+      tool_use_id: "t1",
+      content: "ok",
+    });
+    expect(msgs[1]?.content).toContainEqual({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "abc123" },
+    });
+  });
+
   it("emits metadata.user_id when provided, omits it otherwise (anti-ban stable device identity)", () => {
     // The Claude subscription anti-ban measure (ref claude-relay-service): a STABLE
     // per-account identity travels in metadata.user_id. The transformer only forwards

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -93,6 +93,63 @@ function normalizeAnthropicContextManagement(value: unknown): unknown {
   return Array.isArray(value) ? { edits: value } : value;
 }
 
+function dataUrlSource(url: string): { mediaType: string; data: string } | null {
+  const m = url.match(/^data:([^;]+);base64,(.*)$/);
+  return m?.[1] !== undefined && m[2] !== undefined ? { mediaType: m[1], data: m[2] } : null;
+}
+
+function imageBlockFromPart(part: Record<string, unknown>): AnthropicBlock | null {
+  if (typeof part.data === "string") {
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: typeof part.mediaType === "string" ? part.mediaType : "image/png",
+        data: part.data,
+      },
+    };
+  }
+  if (typeof part.url === "string") {
+    const source = dataUrlSource(part.url);
+    if (source !== null) {
+      return {
+        type: "image",
+        source: { type: "base64", media_type: source.mediaType, data: source.data },
+      };
+    }
+  }
+  return null;
+}
+
+function documentBlockFromPart(part: Record<string, unknown>): AnthropicBlock | null {
+  if (typeof part.fileId === "string") {
+    return { type: "document", source: { type: "file", file_id: part.fileId } };
+  }
+  if (typeof part.data === "string") {
+    return {
+      type: "document",
+      source: {
+        type: "base64",
+        media_type: typeof part.mediaType === "string" ? part.mediaType : "application/pdf",
+        data: part.data,
+      },
+      ...(typeof part.filename === "string" ? { title: part.filename } : {}),
+    };
+  }
+  if (typeof part.url === "string") {
+    const source = dataUrlSource(part.url);
+    if (source !== null) {
+      return {
+        type: "document",
+        source: { type: "base64", media_type: source.mediaType, data: source.data },
+        ...(typeof part.filename === "string" ? { title: part.filename } : {}),
+      };
+    }
+    return { type: "document", source: { type: "url", url: part.url } };
+  }
+  return null;
+}
+
 function contextManagementEdits(value: unknown): unknown[] {
   const normalized = normalizeAnthropicContextManagement(value);
   if (normalized && typeof normalized === "object" && !Array.isArray(normalized)) {
@@ -127,15 +184,26 @@ function textBlocksFromContent(content: unknown, messageCacheControl?: unknown):
         const cacheControl = p.cache_control ?? messageCacheControl;
         if (p.type === "text" && typeof p.text === "string")
           return [withCacheControl({ type: "text", text: p.text }, cacheControl)];
+        if (p.type === "image") {
+          const block = imageBlockFromPart(p);
+          return block === null ? [] : [withCacheControl(block, cacheControl)];
+        }
+        if (p.type === "document") {
+          const block = documentBlockFromPart(p);
+          return block === null ? [] : [withCacheControl(block, cacheControl)];
+        }
         // image_url -> anthropic image block (base64 data URLs only; http passes through name)
         if (p.type === "image_url" && p.image_url && typeof p.image_url === "object") {
           const urlVal = (p.image_url as Record<string, unknown>).url;
           if (typeof urlVal === "string" && urlVal.startsWith("data:")) {
-            const m = urlVal.match(/^data:([^;]+);base64,(.*)$/);
-            if (m) {
+            const source = dataUrlSource(urlVal);
+            if (source !== null) {
               return [
                 withCacheControl(
-                  { type: "image", source: { type: "base64", media_type: m[1], data: m[2] } },
+                  {
+                    type: "image",
+                    source: { type: "base64", media_type: source.mediaType, data: source.data },
+                  },
                   cacheControl,
                 ),
               ];


### PR DESCRIPTION
## 背景

线上 Claude session `6e414716-6d7d-4a5f-843b-099163c33ed3` 中，用户发送了带截图的图表数字格式化反馈，但后续模型反复进行工具调用。排查发现 Helm 没有内部重试；每次都是客户端发起的新请求，且每个请求只有一次成功 provider attempt。

根因是 Anthropic 原生请求在进入 IR 时保留了图片，但 native Anthropic provider 重新组装上游请求时只处理 text / image_url，丢掉了 IR 原生 `image` part，导致上游模型实际没有看到用户截图。

## 修改

- 在 Anthropic provider 请求组装中保留 IR 原生 `image` 和 `document` 内容。
- 补充工具结果续写 + 新用户纠正 + 图片的回归测试。
- 补齐 `provider_raw` 中 Anthropic 原生控制字段的两段透传：`mcp_servers`、`container`、`speed`、`output_config`。

## 验证

```bash
pnpm exec vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/provider/anthropic.test.ts apps/gateway/src/routes/messages-pipeline.test.ts apps/gateway/src/routes/execute.test.ts
```

结果：130 tests passed。