### PR TITLE
修复 Anthropic 互译多模态与 thinking 保真

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-13 · Anthropic 互译保真：tool_result 多模态 + thinking/redacted_thinking 历史块（docs/05；原则 1/7/8）
+
+- **缘起**：继续追查 Anthropic 原生请求经 IR 再回 Anthropic 时的保真问题。上轮已修普通 user content 的 image/document 透传，但进一步审计发现三处仍会丢 Anthropic 原生信息：`tool_result.content` 为 block[] 时只保留 text，image/document 被 JSON 字符串化；document `title` 没有进 IR `filename`；assistant 历史里的 `thinking` / `redacted_thinking` request/response block 与缓存命中合成 SSE 路径无法按原块恢复。这类丢失会让模型看不到工具返回的截图/文档，或破坏 Claude extended-thinking conversation history，属于协议根因，不是 UI/循环保护问题。
+- **修复**：`protocol/anthropic/request.ts` 把 `tool_result.content` 的 text/image/document block 映射成 IR multipart tool message，并在 `transformRequestIn` 重新输出 block[]；document `title` ↔ IR `filename` 双向保留；assistant `thinking_blocks` 改为挂在对应 IR message 上，出站时排在可见 text/tool_use 之前恢复。`provider/anthropic.ts` 同步修订 native subscription 执行器，避免生产路径继续把 multipart tool result JSON.stringify 或丢 thinking history。
+- **响应/流式补齐**：`response.ts` 与 `stream.ts` 新增 `redacted_thinking` 支持：非流式 native response 入站进 `message.thinking_blocks`，IR→Anthropic response 精确保留 redacted block；Anthropic SSE 入站把 redacted block start 映射为 IR `thinking_blocks` delta；非流式/缓存命中合成 Anthropic SSE 也通过同一状态机输出 redacted block start/stop。`reasoning.ts` 不再把 redacted block 解析成空 visible thinking，避免把 opaque payload 变成错误推理文本。
+- **验证**：TDD 红→绿，新增 request/provider/response/stream 回归覆盖 multipart tool_result、document title、assistant thinking/redacted_thinking 历史、redacted response 与 synthesized SSE。Focused 验证 203 绿（Anthropic protocol + provider + gateway pipeline/execute）；`pnpm typecheck`、`pnpm lint` 全绿。
+
 ## 2026-06-12 · Claude Code 计费归因块：入站剥离 + 透传客户端真实版本重注入「可缓存」头（docs/05；anti-ban；原则 1/4/7）
 
 - **缘起**：用户报告 admin 捕获 payload「数据全是重复的」，怀疑 helm 拼接 bug。结论：**helm 无 bug**（`messages.ts` parse 前 `c.req.text()` 原样捕获）。畸形是 Claude Code ≥2.1.29 客户端行为——把 `x-anthropic-billing-header: cc_version=<v>.<3hex>; cc_entrypoint=cli; cch=<5hex>;` 注入为 top-level `system[0]`，且 **3hex 后缀和 cch 都按请求内容哈希、逐请求轮换**（从真实 2.1.175 二进制 `z76()` 确认：`cch=00000` 是 JS 里的 sentinel，native 层 egress 前替换成真实 5hex，所以 helm 收到的 body 已是 `fd3e2`/`8f46b` 真值）。prompt cache 严格前缀匹配 → 首块每轮变 → 生产实测**每轮 `cached_tokens=0` + ~42.8K 缓存重写 + 150–200K Opus 输入全额未缓存**（≈10×）。上游已知：anthropics/claude-code#24168、#40652、motiful/cc-cache-audit。
@@ -29,18 +36,13 @@
 - **追加修复**：review 发现 non-chat 协议的 admin 流式 replay 没有 budget deps 时会跳过 streamed usage 盖戳，导致 replay telemetry 被 dashboard 少算；已把 shared `messages-pipeline` 的 token stamp 从 budget-only 分支移出，budget settle 仍保持 gated。
 - **验证**：`pnpm typecheck`/`lint` 全绿；`pnpm test` 绿（唯一 full-run 红是已知 PGlite 5s 超时 flake `memory-jobs.test.ts`，隔离重跑 8/8 过——见 [[pnpm-test-pglite-flake]]）。新覆盖：redaction guard、schema round-trip、gateway token-stamp（OpenAI+Anthropic）、aggregate contract（**两 adapter** sqlite+pglite）、stats route、`formatTokens`、dashboard locale coverage。13 个迁移-scoped 测试因预置 applied 版本列表少了 v22/v21 而红，已补齐（图表渲染本身 jsdom 不可测）。
 
-## 2026-06-12 · 四协议互译保真补丁（Responses tool_choice / Anthropic native controls / Gemini safety；CLAUDE.md 原则 1/7/8；docs/05/07）
-
-- **缘起**：继续对照本地 LiteLLM review 四协议互译缺口。剩余问题集中在“字段形状接近但不完全相同”的边缘：Responses `tool_choice` 在 Responses 与 Chat 之间形状不同；Responses `previous_response_id` 的 tool-output continuation 需要服务端历史；Anthropic native/control 参数进 IR 后丢失；Gemini `safetySettings` 没有 round-trip；Anthropic provider 使用 `context_management` / `speed:"fast"` 时缺 feature beta header。
-- **修复**：Responses transformer 把 inbound `{type:"function",name}` 规范成 OpenAI Chat `{type:"function",function:{name}}`，outbound 反向还原；Codex Responses provider 同步把 Chat `tool_choice` 发成 Responses 顶层 `name` 形状。Anthropic transformer 将 `context_management`、`mcp_servers`、`container`、`speed`、`output_config` 保存在 `provider_raw` 并在 Anthropic native out 重新发出，`context_management` 数组按 LiteLLM 兼容形状包成 `{edits:[...]}`。Anthropic provider 透传这些 native controls，并按 body 动态补 `context-management-2025-06-27`、`compact-2026-01-12`、`fast-mode-2026-02-01` beta。Gemini transformer 将 `safetySettings` 存入 `provider_raw.safety_settings` 并在 Gemini native out 恢复。
-- **取舍/仍开放**：Helm 目前没有 Responses object/session/history store，所以带 `previous_response_id` 且只提交历史 tool-output continuation 的请求不能假装可处理；本轮选择 **fail-closed**，返回明确错误，避免把缺少本地 `function_call` 上下文的 `function_call_output` 转成无效 Chat tool message。单纯携带 `previous_response_id` 的普通字符串 input 仍保留在 `provider_raw` 用于后续 Responses-native round-trip；完整 continuation 支持需要 response store、input_items/history 查询和 tool-call correlation。
-- **验证**：TDD 红→绿。新增/更新 focused regression 覆盖 Responses `tool_choice` 双向规范化、`previous_response_id` continuation fail-closed、Codex provider `tool_choice`、Anthropic native passthrough + beta headers、Gemini `safetySettings` round-trip，以及 gateway 不把 `previous_response_id` / `truncation` 泄漏到 OpenAI-compatible upstream。验证命令：focused Vitest 244 绿；`pnpm typecheck` 绿；`pnpm lint` 绿；`pnpm test` 初跑因本地 `better-sqlite3` ABI 137 vs Node 25 ABI 141 失败，执行 `pnpm --filter @helm/core rebuild better-sqlite3` 后完整 `pnpm test` 240 files / 3036 tests 绿。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-12 · 四协议互译保真补丁：Responses `tool_choice` 双向规范化、`previous_response_id` continuation fail-closed、Anthropic native controls/provider beta 透传、Gemini `safetySettings` round-trip；缺完整 Responses object/session store 前不伪装支持历史 tool-output continuation。
 
 ### 2026-06-12 · 新增 claude-fable-5 配置支持（原则 2/6；docs/04）：能力取自 OpenRouter API（ctx 1M / max_out 128K / text+image+file→document，pricing 未落库）；完全镜像 claude-opus 模式——`lanes.yaml` 新 `claude-fable` lane 以 native OAuth 别名领衔、`fallback:[premium]`，`model-aliases.yaml` 加 `claude-fable-*` glob；用户拍板**去掉 OpenRouter 静态镜像兜底**；native 别名靠运行时 OAuth pool 注册不进 providers.yaml。TDD samples+catalog 98 绿。部署坑：需手动同步 `/opt/helm-api/config` 两个 yaml（[[deploy-never-overwrite-config]]）。
 

--- a/packages/core/src/protocol/anthropic/request.test.ts
+++ b/packages/core/src/protocol/anthropic/request.test.ts
@@ -126,6 +126,31 @@ describe("anthropic transformRequestOut", () => {
     }
   });
 
+  it("preserves thinking_blocks when merging adjacent assistant messages", () => {
+    const req = {
+      model: "claude-3-5-sonnet",
+      max_tokens: 256,
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "first thought", signature: "sig-1" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "redacted_thinking", data: "encrypted-second" }],
+        },
+      ],
+    };
+
+    const ir = transformRequestOut(req);
+    const assistantMsgs = ir.messages.filter((m) => m.role === "assistant");
+    expect(assistantMsgs).toHaveLength(1);
+    expect(assistantMsgs[0]?.thinking_blocks).toEqual([
+      { type: "thinking", thinking: "first thought", signature: "sig-1" },
+      { type: "redacted_thinking", data: "encrypted-second" },
+    ]);
+  });
+
   // Rule 6 (tool_result fan-out): multiple tool_results in one user turn expand
   // to adjacent role:"tool" messages — these must NOT be merged (distinct ids).
   it("keeps multiple tool_result messages distinct (not merged) by id", () => {

--- a/packages/core/src/protocol/anthropic/request.test.ts
+++ b/packages/core/src/protocol/anthropic/request.test.ts
@@ -184,8 +184,68 @@ describe("anthropic transformRequestOut", () => {
     });
   });
 
-  // Rule 4: thinking + signature kept in the IR extension, not normal content.
-  it("preserves thinking + signature in the IR extension field", () => {
+  it("preserves multipart tool_result content through an Anthropic round-trip", () => {
+    const req = {
+      model: "claude-3-5-sonnet",
+      max_tokens: 256,
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_1", name: "inspect", input: {} }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: [
+                { type: "text", text: "chart screenshot" },
+                {
+                  type: "image",
+                  source: { type: "base64", media_type: "image/png", data: "abc123" },
+                },
+                {
+                  type: "document",
+                  source: { type: "base64", media_type: "application/pdf", data: "JVBERi0=" },
+                  title: "report.pdf",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const ir = transformRequestOut(req);
+    expect(() => IRRequestSchema.parse(ir)).not.toThrow();
+    const toolMsg = ir.messages.find((m) => m.role === "tool");
+    expect(toolMsg?.content).toEqual([
+      { type: "text", text: "chart screenshot" },
+      { type: "image", url: "data:image/png;base64,abc123", mediaType: "image/png" },
+      { type: "document", data: "JVBERi0=", mediaType: "application/pdf", filename: "report.pdf" },
+    ]);
+
+    const out = transformRequestIn(ir);
+    const outboundToolResult = out.messages[1]?.content[0] as {
+      type?: string;
+      content?: unknown;
+    };
+    expect(outboundToolResult).toMatchObject({ type: "tool_result", tool_use_id: "toolu_1" });
+    expect(outboundToolResult.content).toEqual([
+      { type: "text", text: "chart screenshot" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "abc123" } },
+      {
+        type: "document",
+        source: { type: "base64", media_type: "application/pdf", data: "JVBERi0=" },
+        title: "report.pdf",
+      },
+    ]);
+  });
+
+  // Rule 4: thinking + signature kept out of normal content, but attached to the
+  // assistant message so Anthropic conversation history can round-trip.
+  it("preserves thinking + signature on the assistant message and round-trips it", () => {
     const req = {
       model: "claude-3-5-sonnet",
       max_tokens: 256,
@@ -208,14 +268,20 @@ describe("anthropic transformRequestOut", () => {
     const parts = assistantMsg?.content as Array<Record<string, unknown>>;
     expect(parts).toEqual([{ type: "text", text: "the answer is 42" }]);
 
-    // It is retained as per-message thinking blocks in provider_raw (distinct from
-    // the request-level thinking CONFIG, which rides ir.thinking).
-    expect(ir.provider_raw?.thinking_blocks).toEqual([
-      { type: "thinking", text: "step 1: reason", signature: "sig-xyz" },
+    // It is retained on the assistant message (distinct from the request-level
+    // thinking CONFIG, which rides ir.thinking).
+    expect(assistantMsg?.thinking_blocks).toEqual([
+      { type: "thinking", thinking: "step 1: reason", signature: "sig-xyz" },
+    ]);
+
+    const out = transformRequestIn(ir);
+    expect(out.messages[0]?.content).toEqual([
+      { type: "thinking", thinking: "step 1: reason", signature: "sig-xyz" },
+      { type: "text", text: "the answer is 42" },
     ]);
   });
 
-  it("preserves redacted_thinking blocks too", () => {
+  it("preserves redacted_thinking blocks on the assistant message and round-trips them", () => {
     const req = {
       model: "claude-3-5-sonnet",
       max_tokens: 256,
@@ -231,7 +297,16 @@ describe("anthropic transformRequestOut", () => {
     };
     const ir = transformRequestOut(req);
     expect(() => IRRequestSchema.parse(ir)).not.toThrow();
-    expect(ir.provider_raw?.thinking_blocks).toHaveLength(1);
+    const assistantMsg = ir.messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.thinking_blocks).toEqual([
+      { type: "redacted_thinking", data: "encrypted-blob" },
+    ]);
+
+    const out = transformRequestIn(ir);
+    expect(out.messages[0]?.content).toEqual([
+      { type: "redacted_thinking", data: "encrypted-blob" },
+      { type: "text", text: "ok" },
+    ]);
   });
 
   // Rule 7: tools input_schema -> function.parameters; cross-cutting fields pass through.
@@ -751,6 +826,33 @@ describe("anthropic document input (P7 multimodal)", () => {
       data: "JVBERi0=",
       mediaType: "application/pdf",
     });
+  });
+
+  it("round-trips an Anthropic document title as an IR filename", () => {
+    const ir = transformRequestOut({
+      model: "claude-3-5-sonnet",
+      max_tokens: 256,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "document",
+              source: { type: "base64", media_type: "application/pdf", data: "JVBERi0=" },
+              title: "report.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    const parts = ir.messages[0]?.content;
+    if (!Array.isArray(parts)) throw new Error("expected parts");
+    expect(parts[0]).toMatchObject({ type: "document", filename: "report.pdf" });
+
+    const out = transformRequestIn(ir);
+    const block = out.messages[0]?.content[0] as { title?: string };
+    expect(block.title).toBe("report.pdf");
   });
 
   it("normalizes a url document block into an IR document part", () => {

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -55,6 +55,7 @@ const AnthropicImageBlockSchema = z
 const AnthropicDocumentBlockSchema = z
   .object({
     type: z.literal("document"),
+    title: z.string().optional(),
     source: z
       .object({
         type: z.string(),
@@ -181,9 +182,11 @@ const AnthropicMessagesRequestSchema = z
 
 export type AnthropicMessagesRequest = z.infer<typeof AnthropicMessagesRequestSchema>;
 
-// Thinking blocks are kept out of the prompt content and stashed in the IR
-// `thinking` extension (the request-level reasoning/thinking passthrough bag).
-type IRThinkingExt = { type: "thinking"; text: string; signature?: string };
+// Thinking blocks are kept out of normal prompt text but attached to their assistant
+// message so Anthropic conversation history can be reconstructed in order.
+type AnthropicThinkingHistoryBlock =
+  | { type: "thinking"; thinking: string; signature?: string }
+  | { type: "redacted_thinking"; data: string };
 
 // Claude Code ≥2.1.29 injects a per-request billing attribution block as the FIRST
 // top-level system entry: "x-anthropic-billing-header: cc_version=<v>.<3hex>;
@@ -278,14 +281,15 @@ function imagePartFromSource(
 // —— document block source -> IR document part. base64 keeps data+media_type inline;
 // a url source -> document.url; an uploaded-file source -> document.fileId, so the
 // upload handle round-trips back to a {type:"file"} source losslessly (P7). ——————————
-function documentPartFromSource(
-  source: z.infer<typeof AnthropicDocumentBlockSchema>["source"],
-): IRContentPart {
+function documentPartFromBlock(block: z.infer<typeof AnthropicDocumentBlockSchema>): IRContentPart {
+  const source = block.source;
+  const title = typeof (block as { title?: unknown }).title === "string" ? block.title : undefined;
   if (source.type === "url" && source.url !== undefined) {
     return {
       type: "document",
       url: source.url,
       ...(source.media_type ? { mediaType: source.media_type } : {}),
+      ...(title !== undefined ? { filename: title } : {}),
     };
   }
   if (source.type === "file" && source.file_id !== undefined) {
@@ -293,6 +297,7 @@ function documentPartFromSource(
       type: "document",
       fileId: source.file_id,
       ...(source.media_type ? { mediaType: source.media_type } : {}),
+      ...(title !== undefined ? { filename: title } : {}),
     };
   }
   // base64 (or any inline-data source): keep data + media_type on the IR part.
@@ -300,6 +305,7 @@ function documentPartFromSource(
     type: "document",
     data: source.data ?? "",
     ...(source.media_type ? { mediaType: source.media_type } : {}),
+    ...(title !== undefined ? { filename: title } : {}),
   };
 }
 
@@ -323,10 +329,40 @@ function normalizeToolResultContent(content: unknown): IRMessage["content"] {
     const parts: IRContentPart[] = [];
     for (const block of content) {
       if (block && typeof block === "object" && "type" in block) {
-        const b = block as { type: string; text?: string };
+        const b = block as {
+          type: string;
+          text?: string;
+          source?: unknown;
+          cache_control?: unknown;
+        };
+        const cacheControl = b.cache_control;
         if (b.type === "text" && typeof b.text === "string") {
-          parts.push({ type: "text", text: b.text });
+          parts.push({
+            type: "text",
+            text: b.text,
+            ...(cacheControl !== undefined ? { cache_control: cacheControl } : {}),
+          });
           continue;
+        }
+        if (b.type === "image") {
+          const parsed = AnthropicImageBlockSchema.safeParse(block);
+          if (parsed.success) {
+            const part = imagePartFromSource(parsed.data.source);
+            if (cacheControl !== undefined && part.type === "image")
+              part.cache_control = cacheControl;
+            parts.push(part);
+            continue;
+          }
+        }
+        if (b.type === "document") {
+          const parsed = AnthropicDocumentBlockSchema.safeParse(block);
+          if (parsed.success) {
+            const part = documentPartFromBlock(parsed.data);
+            if (cacheControl !== undefined && part.type === "document")
+              part.cache_control = cacheControl;
+            parts.push(part);
+            continue;
+          }
         }
       }
       // Unknown tool_result sub-block: degrade to a JSON text placeholder (fail-open).
@@ -397,8 +433,6 @@ export function transformRequestOut(req: unknown): IRRequest {
   const parsed = AnthropicMessagesRequestSchema.parse(req);
 
   const messages: IRMessage[] = [];
-  const thinking: IRThinkingExt[] = [];
-
   // Rule 1: hoist the top-level system prompt to the head of messages (after
   // dropping the cache-busting Claude Code billing block, see stripBillingHeader).
   if (parsed.system !== undefined) {
@@ -418,6 +452,7 @@ export function transformRequestOut(req: unknown): IRRequest {
     const parts: IRContentPart[] = [];
     const toolCalls: IRToolCall[] = [];
     const toolResults: IRMessage[] = [];
+    const thinkingBlocks: AnthropicThinkingHistoryBlock[] = [];
 
     for (const block of m.content) {
       // Per-block cache_control (prompt-cache breakpoint) is preserved onto the IR part
@@ -441,9 +476,7 @@ export function transformRequestOut(req: unknown): IRRequest {
           break;
         }
         case "document": {
-          const part = documentPartFromSource(
-            (block as z.infer<typeof AnthropicDocumentBlockSchema>).source,
-          );
+          const part = documentPartFromBlock(block as z.infer<typeof AnthropicDocumentBlockSchema>);
           if (cacheControl !== undefined && part.type === "document")
             part.cache_control = cacheControl;
           parts.push(part);
@@ -452,16 +485,16 @@ export function transformRequestOut(req: unknown): IRRequest {
         case "thinking": {
           const b = block as z.infer<typeof AnthropicThinkingBlockSchema>;
           // Rule 4: kept in the IR extension, NOT in normal content.
-          thinking.push({
+          thinkingBlocks.push({
             type: "thinking",
-            text: b.thinking,
+            thinking: b.thinking,
             ...(b.signature !== undefined ? { signature: b.signature } : {}),
           });
           break;
         }
         case "redacted_thinking": {
           const b = block as z.infer<typeof AnthropicRedactedThinkingBlockSchema>;
-          thinking.push({ type: "thinking", text: b.data });
+          thinkingBlocks.push({ type: "redacted_thinking", data: b.data });
           break;
         }
         case "tool_use":
@@ -491,6 +524,7 @@ export function transformRequestOut(req: unknown): IRRequest {
         role: "assistant",
         content: parts.length > 0 ? parts : null,
         ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        ...(thinkingBlocks.length > 0 ? { thinking_blocks: thinkingBlocks } : {}),
       });
     } else if (m.role === "system" || m.role === "developer") {
       // system/developer turn: keep the role so it folds into the system prompt
@@ -554,12 +588,6 @@ export function transformRequestOut(req: unknown): IRRequest {
     ...(Object.keys(providerRaw).length > 0 ? { provider_raw: providerRaw } : {}),
   };
 
-  // Per-message thinking BLOCKS (kept out of prompt content) live on provider_raw,
-  // never colliding with the request-level thinking CONFIG above. Merge if both.
-  if (thinking.length > 0) {
-    ir.provider_raw = { ...(ir.provider_raw ?? {}), thinking_blocks: thinking };
-  }
-
   // Final structural validation: the IR we hand downstream is always well-formed.
   return IRRequestSchema.parse(ir);
 }
@@ -603,8 +631,22 @@ export interface AnthropicDocumentBlockOut {
     | { type: "base64"; media_type: string; data: string }
     | { type: "url"; url: string }
     | { type: "file"; file_id: string };
+  title?: string;
   cache_control?: unknown;
 }
+export interface AnthropicThinkingBlockOut {
+  type: "thinking";
+  thinking: string;
+  signature?: string;
+}
+export interface AnthropicRedactedThinkingBlockOut {
+  type: "redacted_thinking";
+  data: string;
+}
+type AnthropicToolResultContentBlockOut =
+  | AnthropicTextBlockOut
+  | AnthropicImageBlockOut
+  | AnthropicDocumentBlockOut;
 export interface AnthropicToolUseBlockOut {
   type: "tool_use";
   id: string;
@@ -614,12 +656,14 @@ export interface AnthropicToolUseBlockOut {
 export interface AnthropicToolResultBlockOut {
   type: "tool_result";
   tool_use_id: string;
-  content: string;
+  content: string | AnthropicToolResultContentBlockOut[];
 }
 export type AnthropicRequestBlock =
   | AnthropicTextBlockOut
   | AnthropicImageBlockOut
   | AnthropicDocumentBlockOut
+  | AnthropicThinkingBlockOut
+  | AnthropicRedactedThinkingBlockOut
   | AnthropicToolUseBlockOut
   | AnthropicToolResultBlockOut;
 
@@ -750,7 +794,11 @@ function documentBlockFromPart(
   part: Extract<IRContentPart, { type: "document" }>,
 ): AnthropicDocumentBlockOut {
   if (part.fileId !== undefined) {
-    return { type: "document", source: { type: "file", file_id: part.fileId } };
+    return {
+      type: "document",
+      source: { type: "file", file_id: part.fileId },
+      ...(part.filename !== undefined ? { title: part.filename } : {}),
+    };
   }
   if (part.data !== undefined) {
     return {
@@ -760,9 +808,26 @@ function documentBlockFromPart(
         media_type: part.mediaType ?? "application/pdf",
         data: part.data,
       },
+      ...(part.filename !== undefined ? { title: part.filename } : {}),
     };
   }
-  return { type: "document", source: { type: "url", url: part.url ?? "" } };
+  return {
+    type: "document",
+    source: { type: "url", url: part.url ?? "" },
+    ...(part.filename !== undefined ? { title: part.filename } : {}),
+  };
+}
+
+function toolResultContentFromIR(
+  content: IRMessage["content"],
+): string | AnthropicToolResultContentBlockOut[] {
+  if (content === null) return "";
+  if (typeof content === "string") return content;
+  const blocks = contentToBlocks(content).filter(
+    (block): block is AnthropicToolResultContentBlockOut =>
+      block.type === "text" || block.type === "image" || block.type === "document",
+  );
+  return blocks.length > 0 ? blocks : "";
 }
 
 function contentToBlocks(content: IRMessage["content"]): AnthropicRequestBlock[] {
@@ -786,6 +851,37 @@ function contentToBlocks(content: IRMessage["content"]): AnthropicRequestBlock[]
     blocks.push(block);
   }
   return blocks;
+}
+
+function thinkingBlocksFromMessage(message: IRMessage): AnthropicRequestBlock[] {
+  if (message.thinking_blocks !== undefined && message.thinking_blocks.length > 0) {
+    return message.thinking_blocks.flatMap((block): AnthropicRequestBlock[] => {
+      if (block.type === "redacted_thinking" && typeof block.data === "string") {
+        return [{ type: "redacted_thinking", data: block.data }];
+      }
+      if (typeof block.thinking === "string") {
+        return [
+          {
+            type: "thinking",
+            thinking: block.thinking,
+            ...(block.signature !== undefined ? { signature: block.signature } : {}),
+          },
+        ];
+      }
+      return [];
+    });
+  }
+  if (!Array.isArray(message.content)) return [];
+  return message.content.flatMap((part): AnthropicRequestBlock[] => {
+    if (part.type !== "thinking") return [];
+    return [
+      {
+        type: "thinking",
+        thinking: part.text,
+        ...(part.signature !== undefined ? { signature: part.signature } : {}),
+      },
+    ];
+  });
 }
 
 function hasExplicitCacheControl(value: unknown): boolean {
@@ -893,22 +989,14 @@ export function transformRequestIn(ir: IRRequest): AnthropicOutboundRequest {
           {
             type: "tool_result",
             tool_use_id: m.tool_call_id ?? "",
-            content:
-              typeof m.content === "string"
-                ? m.content
-                : m.content === null
-                  ? ""
-                  : m.content
-                      .filter((p): p is { type: "text"; text: string } => p.type === "text")
-                      .map((p) => p.text)
-                      .join(""),
+            content: toolResultContentFromIR(m.content),
           },
         ],
       });
       continue;
     }
     if (m.role === "assistant") {
-      const blocks = contentToBlocks(m.content);
+      const blocks = [...thinkingBlocksFromMessage(m), ...contentToBlocks(m.content)];
       for (const call of m.tool_calls ?? []) {
         blocks.push({
           type: "tool_use",

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -411,10 +411,15 @@ function mergeConsecutiveSameRole(messages: IRMessage[]): IRMessage[] {
       // Merge: concatenate content as multipart, union tool_calls.
       const mergedParts = [...asParts(prev.content), ...asParts(msg.content)];
       const mergedCalls = [...(prev.tool_calls ?? []), ...(msg.tool_calls ?? [])];
+      const mergedThinkingBlocks = [
+        ...(prev.thinking_blocks ?? []),
+        ...(msg.thinking_blocks ?? []),
+      ];
       out[out.length - 1] = {
         ...prev,
         content: mergedParts.length > 0 ? mergedParts : null,
         ...(mergedCalls.length > 0 ? { tool_calls: mergedCalls } : {}),
+        ...(mergedThinkingBlocks.length > 0 ? { thinking_blocks: mergedThinkingBlocks } : {}),
       };
       continue;
     }

--- a/packages/core/src/protocol/anthropic/response.test.ts
+++ b/packages/core/src/protocol/anthropic/response.test.ts
@@ -316,6 +316,31 @@ describe("transformResponseIn", () => {
     expect(out.content[0]).toEqual({ type: "redacted_thinking", data: "encrypted-blob" });
     expect(out.content[1]).toEqual({ type: "text", text: "answer" });
   });
+
+  it("preserves visible reasoning_content alongside redacted_thinking blocks", () => {
+    const out = transformResponseIn(
+      makeIR({
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "answer",
+              reasoning_content: "visible reasoning",
+              thinking_blocks: [{ type: "redacted_thinking", data: "encrypted-blob" }],
+            },
+            finish_reason: "stop",
+          },
+        ],
+      }),
+    );
+
+    expect(out.content).toEqual([
+      { type: "redacted_thinking", data: "encrypted-blob" },
+      { type: "thinking", thinking: "visible reasoning" },
+      { type: "text", text: "answer" },
+    ]);
+  });
 });
 
 // —— P4: usage cache_creation breakdown + thinking_tokens ——————————————————————

--- a/packages/core/src/protocol/anthropic/response.test.ts
+++ b/packages/core/src/protocol/anthropic/response.test.ts
@@ -295,6 +295,27 @@ describe("transformResponseIn", () => {
     const text = out.content.find((b) => b.type === "text");
     expect(text).toMatchObject({ type: "text", text: "the answer is 42" });
   });
+
+  it("back-translates thinking_blocks -> redacted_thinking blocks", () => {
+    const out = transformResponseIn(
+      makeIR({
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "answer",
+              thinking_blocks: [{ type: "redacted_thinking", data: "encrypted-blob" }],
+            },
+            finish_reason: "stop",
+          },
+        ],
+      }),
+    );
+
+    expect(out.content[0]).toEqual({ type: "redacted_thinking", data: "encrypted-blob" });
+    expect(out.content[1]).toEqual({ type: "text", text: "answer" });
+  });
 });
 
 // —— P4: usage cache_creation breakdown + thinking_tokens ——————————————————————
@@ -441,6 +462,30 @@ describe("transformNativeResponseToIR — P4 usage + stop_reason", () => {
       usage: { input_tokens: 5, output_tokens: 0 },
     });
     expect(ir.provider_raw?.stop_details).toEqual({ type: "refusal", reason: "policy" });
+  });
+
+  it("preserves inbound redacted_thinking blocks in IR thinking_blocks", () => {
+    const ir = transformNativeResponseToIR({
+      id: "m",
+      type: "message",
+      role: "assistant",
+      model: "claude",
+      content: [
+        { type: "redacted_thinking", data: "encrypted-blob" },
+        { type: "text", text: "ok" },
+      ],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 5, output_tokens: 2 },
+    });
+
+    const message = ir.choices[0]?.message;
+    expect(message?.thinking_blocks).toEqual([
+      { type: "redacted_thinking", data: "encrypted-blob" },
+    ]);
+    expect(message?.content).toEqual([{ type: "text", text: "ok" }]);
+
+    const roundTrip = transformResponseIn(ir);
+    expect(roundTrip.content[0]).toEqual({ type: "redacted_thinking", data: "encrypted-blob" });
   });
 });
 

--- a/packages/core/src/protocol/anthropic/response.ts
+++ b/packages/core/src/protocol/anthropic/response.ts
@@ -78,6 +78,10 @@ const AnthropicThinkingBlockSchema = z.object({
   thinking: z.string(),
   signature: z.string().optional(),
 });
+const AnthropicRedactedThinkingBlockSchema = z.object({
+  type: z.literal("redacted_thinking"),
+  data: z.string(),
+});
 // Model-generated image block on the response (P7). source is base64 (data+media_type)
 // or a remote url; mirrors the request-side image block shape.
 const AnthropicImageBlockSchema = z.object({
@@ -95,6 +99,7 @@ const AnthropicContentBlockSchema = z.discriminatedUnion("type", [
   AnthropicTextBlockSchema,
   AnthropicToolUseBlockSchema,
   AnthropicThinkingBlockSchema,
+  AnthropicRedactedThinkingBlockSchema,
   AnthropicImageBlockSchema,
 ]);
 type AnthropicContentBlock = z.infer<typeof AnthropicContentBlockSchema>;
@@ -321,17 +326,31 @@ function toContentBlocks(
   const blocks: AnthropicContentBlock[] = [];
   const { content } = message;
 
-  // Reasoning may arrive on EITHER the content-block thinking parts OR the flat
-  // reasoning_content/thinking_blocks carriers (e.g. an OpenAI-origin response).
-  // resolveReasoning unifies them; Anthropic emits thinking blocks FIRST (the
-  // native order — reasoning precedes the answer). (P6)
-  const { thinkingParts } = resolveReasoning(message);
-  for (const part of thinkingParts) {
-    blocks.push({
-      type: "thinking",
-      thinking: part.text,
-      ...(part.signature !== undefined ? { signature: part.signature } : {}),
-    });
+  // Anthropic-native thinking history may include redacted_thinking blocks. When the
+  // structured carrier is present, render it exactly so redacted payloads do not turn
+  // into empty visible thinking blocks. Otherwise fall back to resolveReasoning for
+  // OpenAI/Gemini/Responses-origin flat reasoning. (P6)
+  if (message.thinking_blocks !== undefined && message.thinking_blocks.length > 0) {
+    for (const block of message.thinking_blocks) {
+      if (block.type === "redacted_thinking" && typeof block.data === "string") {
+        blocks.push({ type: "redacted_thinking", data: block.data });
+      } else if (typeof block.thinking === "string") {
+        blocks.push({
+          type: "thinking",
+          thinking: block.thinking,
+          ...(block.signature !== undefined ? { signature: block.signature } : {}),
+        });
+      }
+    }
+  } else {
+    const { thinkingParts } = resolveReasoning(message);
+    for (const part of thinkingParts) {
+      blocks.push({
+        type: "thinking",
+        thinking: part.text,
+        ...(part.signature !== undefined ? { signature: part.signature } : {}),
+      });
+    }
   }
 
   if (typeof content === "string") {
@@ -447,6 +466,9 @@ const InboundToolUseBlockSchema = z
 const InboundThinkingBlockSchema = z
   .object({ type: z.literal("thinking"), thinking: z.string(), signature: z.string().optional() })
   .passthrough();
+const InboundRedactedThinkingBlockSchema = z
+  .object({ type: z.literal("redacted_thinking"), data: z.string() })
+  .passthrough();
 // Model-generated image block on an inbound native response (P7) -> IRMessage.images.
 const InboundImageBlockSchema = z
   .object({
@@ -466,6 +488,7 @@ const InboundContentBlockSchema = z.union([
   InboundTextBlockSchema,
   InboundToolUseBlockSchema,
   InboundThinkingBlockSchema,
+  InboundRedactedThinkingBlockSchema,
   InboundImageBlockSchema,
   InboundUnknownBlockSchema,
 ]);
@@ -512,6 +535,7 @@ export function transformNativeResponseToIR(
   const parts: IRContentPart[] = [];
   const toolCalls: IRToolCall[] = [];
   const images: NonNullable<IRMessage["images"]> = [];
+  const redactedThinkingBlocks: NonNullable<IRMessage["thinking_blocks"]> = [];
   for (const block of res.content) {
     if (block.type === "text") {
       parts.push({ type: "text", text: (block as z.infer<typeof InboundTextBlockSchema>).text });
@@ -533,6 +557,9 @@ export function transformNativeResponseToIR(
         text: b.thinking,
         ...(b.signature !== undefined ? { signature: b.signature } : {}),
       });
+    } else if (block.type === "redacted_thinking") {
+      const b = block as z.infer<typeof InboundRedactedThinkingBlockSchema>;
+      redactedThinkingBlocks.push({ type: "redacted_thinking", data: b.data });
     } else if (block.type === "tool_use") {
       const b = block as z.infer<typeof InboundToolUseBlockSchema>;
       // Restore the ORIGINAL tool name when the request-side sanitizer map is
@@ -553,12 +580,19 @@ export function transformNativeResponseToIR(
   // Lift the thinking content parts onto the flat reasoning_content/thinking_blocks
   // carriers so a downstream OpenAI client (which reads message.reasoning_content,
   // not a content-block thinking part) receives the reasoning losslessly (P6).
-  const message: IRMessage = liftReasoningToFlat({
+  const lifted = liftReasoningToFlat({
     role: "assistant",
     content: parts.length > 0 ? parts : toolCalls.length > 0 || images.length > 0 ? null : "",
     ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
     ...(images.length > 0 ? { images } : {}),
   });
+  const message: IRMessage =
+    redactedThinkingBlocks.length > 0
+      ? {
+          ...lifted,
+          thinking_blocks: [...(lifted.thinking_blocks ?? []), ...redactedThinkingBlocks],
+        }
+      : lifted;
 
   const rawStop = res.stop_reason ?? null;
   const finishReason = rawStop !== null ? (STOP_REASON_TO_FINISH[rawStop] ?? "stop") : null;

--- a/packages/core/src/protocol/anthropic/response.ts
+++ b/packages/core/src/protocol/anthropic/response.ts
@@ -331,14 +331,26 @@ function toContentBlocks(
   // into empty visible thinking blocks. Otherwise fall back to resolveReasoning for
   // OpenAI/Gemini/Responses-origin flat reasoning. (P6)
   if (message.thinking_blocks !== undefined && message.thinking_blocks.length > 0) {
+    let emittedVisibleThinking = false;
     for (const block of message.thinking_blocks) {
       if (block.type === "redacted_thinking" && typeof block.data === "string") {
         blocks.push({ type: "redacted_thinking", data: block.data });
       } else if (typeof block.thinking === "string") {
+        emittedVisibleThinking = true;
         blocks.push({
           type: "thinking",
           thinking: block.thinking,
           ...(block.signature !== undefined ? { signature: block.signature } : {}),
+        });
+      }
+    }
+    if (!emittedVisibleThinking) {
+      const { thinkingParts } = resolveReasoning(message);
+      for (const part of thinkingParts) {
+        blocks.push({
+          type: "thinking",
+          thinking: part.text,
+          ...(part.signature !== undefined ? { signature: part.signature } : {}),
         });
       }
     }

--- a/packages/core/src/protocol/anthropic/stream.test.ts
+++ b/packages/core/src/protocol/anthropic/stream.test.ts
@@ -426,6 +426,36 @@ describe("synthesizeSSEFromJSON — cache hit / non-streaming upstream", () => {
     expect(text).toBe("let me think");
   });
 
+  it("carries redacted thinking blocks into synthesized Anthropic SSE", async () => {
+    const res: IRResponse = {
+      id: "resp_redacted",
+      model: "claude-3-7-sonnet",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "answer",
+            thinking_blocks: [{ type: "redacted_thinking", data: "encrypted-blob" }],
+          },
+          finish_reason: "stop",
+        },
+      ],
+    };
+
+    const events = await collect(synthesizeSSEFromJSON(res));
+    const redactedStart = events.find(
+      (e) => e.type === "content_block_start" && e.content_block.type === "redacted_thinking",
+    );
+    expect(redactedStart).toBeDefined();
+    if (redactedStart?.type === "content_block_start") {
+      expect(redactedStart.content_block).toEqual({
+        type: "redacted_thinking",
+        data: "encrypted-blob",
+      });
+    }
+  });
+
   it("synthesizes a tool_use block: start (id+name) before input_json_delta", async () => {
     const res: IRResponse = {
       id: "resp_2",
@@ -572,6 +602,45 @@ describe("convertAnthropicStreamToIR — thinking streaming (inbound)", () => {
       c.choices?.[0]?.delta?.thinking_blocks?.some((b) => b.signature === "sig-xyz"),
     );
     expect(sigChunk).toBeDefined();
+  });
+
+  it("maps redacted_thinking block starts to IR thinking_blocks", async () => {
+    const chunks = await collect<IRChunk>(
+      convertAnthropicStreamToIR(
+        events([
+          {
+            type: "message_start",
+            message: {
+              id: "m",
+              type: "message",
+              role: "assistant",
+              model: "claude",
+              content: [],
+              stop_reason: null,
+              stop_sequence: null,
+              usage: { input_tokens: 5, output_tokens: 1 },
+            },
+          },
+          {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "redacted_thinking", data: "encrypted-blob" },
+          },
+          { type: "content_block_stop", index: 0 },
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn", stop_sequence: null },
+            usage: { output_tokens: 7 },
+          },
+          { type: "message_stop" },
+        ]),
+      ),
+    );
+
+    const redactedChunk = chunks.find((c) =>
+      c.choices?.[0]?.delta?.thinking_blocks?.some((b) => b.data === "encrypted-blob"),
+    );
+    expect(redactedChunk).toBeDefined();
   });
 });
 

--- a/packages/core/src/protocol/anthropic/stream.ts
+++ b/packages/core/src/protocol/anthropic/stream.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import type { IRChunk } from "../gemini/gemini-types.js";
-import { IRAnnotationSchema, IRLogprobsSchema, type IRResponse, type IRUsage } from "../ir.js";
+import {
+  IRAnnotationSchema,
+  IRLogprobsSchema,
+  type IRResponse,
+  type IRThinkingBlock,
+  type IRUsage,
+} from "../ir.js";
 import { resolveReasoning } from "../reasoning.js";
 import {
   type AnthropicStopReason,
@@ -63,6 +69,12 @@ const OpenAIChunkDeltaSchema = z.object({
   // the delta. Optional + shared shapes (ir.ts) so the identity OpenAI stream carries
   // them through to every downstream protocol consumer.
   reasoning_content: z.string().nullable().optional(),
+  // Internal synthesis extension: real OpenAI chunks do not set this. It lets a
+  // cached/non-stream Anthropic response keep opaque redacted_thinking blocks while
+  // still using the same stream state machine.
+  thinking_blocks: z
+    .array(z.object({ type: z.string(), data: z.string().optional() }).passthrough())
+    .optional(),
   // refusal fragments (OpenAI safety refusal); surfaced to the Responses refusal events.
   refusal: z.string().nullable().optional(),
   annotations: z.array(IRAnnotationSchema).optional(),
@@ -125,10 +137,15 @@ const AnthropicThinkingBlockStartSchema = z.object({
   type: z.literal("thinking"),
   thinking: z.string(),
 });
+const AnthropicRedactedThinkingBlockStartSchema = z.object({
+  type: z.literal("redacted_thinking"),
+  data: z.string(),
+});
 const AnthropicStartContentBlockSchema = z.discriminatedUnion("type", [
   AnthropicTextBlockStartSchema,
   AnthropicToolUseBlockStartSchema,
   AnthropicThinkingBlockStartSchema,
+  AnthropicRedactedThinkingBlockStartSchema,
 ]);
 
 const AnthropicTextDeltaSchema = z.object({ type: z.literal("text_delta"), text: z.string() });
@@ -376,6 +393,18 @@ export async function* convertOpenAIStreamToAnthropic(
       yield thinkingDeltaEvent(state.thinkingBlockIndex, delta.reasoning_content);
     }
 
+    // —— redacted thinking: opaque block start/stop, no deltas. Used by synthesized
+    // Anthropic streams so native redacted history survives cache hits/non-stream relays.
+    for (const block of delta?.thinking_blocks ?? []) {
+      if (block.type !== "redacted_thinking" || typeof block.data !== "string") continue;
+      const i = allocBlock(state);
+      yield {
+        type: "content_block_start",
+        index: i,
+        content_block: { type: "redacted_thinking", data: block.data },
+      };
+    }
+
     // —— text: lazily open the text block, then stream text_delta. ——
     if (delta?.content) {
       if (state.textBlockIndex === null) {
@@ -518,6 +547,11 @@ export async function* synthesizeSSEFromJSON(resp: IRResponse): AsyncIterable<An
     const { reasoningText } = resolveReasoning(message);
     if (reasoningText !== undefined && reasoningText !== "")
       delta.reasoning_content = reasoningText;
+    const redactedThinking = (message.thinking_blocks ?? []).filter(
+      (block): block is IRThinkingBlock & { type: "redacted_thinking"; data: string } =>
+        block.type === "redacted_thinking" && typeof block.data === "string",
+    );
+    if (redactedThinking.length > 0) delta.thinking_blocks = redactedThinking;
   }
 
   const toolCalls = message?.tool_calls ?? [];
@@ -635,6 +669,16 @@ export async function* convertAnthropicStreamToIR(
                     },
                   ],
                 },
+              },
+            ],
+          };
+        } else if (block.type === "redacted_thinking") {
+          yield {
+            ...base(),
+            choices: [
+              {
+                index: 0,
+                delta: { thinking_blocks: [{ type: "redacted_thinking", data: block.data }] },
               },
             ],
           };

--- a/packages/core/src/protocol/openai.test.ts
+++ b/packages/core/src/protocol/openai.test.ts
@@ -92,6 +92,47 @@ describe("openaiTransformer — developer role survives + round-trips (issue #50
   });
 });
 
+describe("openaiTransformer — cross-provider private field stripping", () => {
+  it("does not leak IR thinking_blocks onto OpenAI request wire messages", async () => {
+    const wire = (await openaiTransformer.transformRequestIn({
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "assistant",
+          content: "answer",
+          reasoning_content: "visible reasoning",
+          thinking_blocks: [{ type: "redacted_thinking", data: "encrypted-blob" }],
+        },
+      ],
+    })) as { messages: Array<Record<string, unknown>> };
+
+    expect(wire.messages[0]?.thinking_blocks).toBeUndefined();
+    expect(wire.messages[0]?.reasoning_content).toBe("visible reasoning");
+  });
+
+  it("does not leak IR thinking_blocks onto OpenAI response wire messages", async () => {
+    const wire = (await openaiTransformer.transformResponseOut({
+      id: "chatcmpl-thinking",
+      model: "gpt-4o",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "answer",
+            reasoning_content: "visible reasoning",
+            thinking_blocks: [{ type: "redacted_thinking", data: "encrypted-blob" }],
+          },
+          finish_reason: "stop",
+        },
+      ],
+    })) as { choices: Array<{ message: Record<string, unknown> }> };
+
+    expect(wire.choices[0]?.message.thinking_blocks).toBeUndefined();
+    expect(wire.choices[0]?.message.reasoning_content).toBe("visible reasoning");
+  });
+});
+
 describe("openaiTransformer — response identity round-trip", () => {
   // test #2: res -> IR -> res is lossless on choices/message/finish_reason/usage.
   it("round-trips a representative response losslessly", async () => {

--- a/packages/core/src/protocol/openai.ts
+++ b/packages/core/src/protocol/openai.ts
@@ -308,13 +308,19 @@ function irPartToNative(part: IRContentPart): unknown {
   }
 }
 
+function stripOpenAIPrivateMessageFields(message: IRMessage): IRMessage {
+  const { thinking_blocks: _thinking_blocks, ...wireMessage } = message;
+  return wireMessage;
+}
+
 function normalizeMessageContentToNative(message: IRMessage): IRMessage {
-  if (!Array.isArray(message.content)) return message;
+  const wireMessage = stripOpenAIPrivateMessageFields(message);
+  if (!Array.isArray(wireMessage.content)) return wireMessage;
   // The IR message type only allows IRContentPart[]; the native shapes we emit are
   // wire-only, so we widen through unknown rather than fight the IR union here.
   return {
-    ...message,
-    content: message.content.map(irPartToNative) as unknown as IRMessage["content"],
+    ...wireMessage,
+    content: wireMessage.content.map(irPartToNative) as unknown as IRMessage["content"],
   };
 }
 
@@ -410,9 +416,10 @@ function toIRResponse(res: NativeResponse): IRResponse {
 function toOpenAIMessage(message: IRMessage): IRMessage {
   const { reasoningText } = resolveReasoning(message);
   const content = stripThinkingFromContent(message.content);
-  if (reasoningText === undefined && content === message.content) return message;
+  const wireMessage = stripOpenAIPrivateMessageFields(message);
+  if (reasoningText === undefined && content === wireMessage.content) return wireMessage;
   return {
-    ...message,
+    ...wireMessage,
     content,
     ...(reasoningText !== undefined ? { reasoning_content: reasoningText } : {}),
   };

--- a/packages/core/src/protocol/reasoning.ts
+++ b/packages/core/src/protocol/reasoning.ts
@@ -102,6 +102,16 @@ export function resolveReasoning(message: IRMessage): {
         },
       ];
     });
+    if (
+      parts.length === 0 &&
+      message.reasoning_content != null &&
+      message.reasoning_content !== ""
+    ) {
+      return {
+        reasoningText: message.reasoning_content,
+        thinkingParts: [{ type: "thinking", text: message.reasoning_content }],
+      };
+    }
     const text = parts
       .map((p) => p.text)
       .filter((t) => t !== "")

--- a/packages/core/src/protocol/reasoning.ts
+++ b/packages/core/src/protocol/reasoning.ts
@@ -92,11 +92,16 @@ export function resolveReasoning(message: IRMessage): {
   }
 
   if (message.thinking_blocks !== undefined && message.thinking_blocks.length > 0) {
-    const parts: IRThinkingPart[] = message.thinking_blocks.map((b) => ({
-      type: "thinking",
-      text: b.thinking ?? "",
-      ...(b.signature !== undefined ? { signature: b.signature } : {}),
-    }));
+    const parts: IRThinkingPart[] = message.thinking_blocks.flatMap((b): IRThinkingPart[] => {
+      if (b.type === "redacted_thinking") return [];
+      return [
+        {
+          type: "thinking",
+          text: b.thinking ?? "",
+          ...(b.signature !== undefined ? { signature: b.signature } : {}),
+        },
+      ];
+    });
     const text = parts
       .map((p) => p.text)
       .filter((t) => t !== "")

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -61,6 +61,68 @@ describe("openaiToAnthropicRequest", () => {
     expect(body.tools as unknown[]).toHaveLength(1);
   });
 
+  it("preserves multipart tool-result content blocks for native Anthropic", () => {
+    const body = openaiToAnthropicRequest({
+      model: "m",
+      messages: [
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "t1", type: "function", function: { name: "inspect", arguments: "{}" } },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "t1",
+          content: [
+            { type: "text", text: "chart screenshot" },
+            { type: "image", url: "data:image/png;base64,abc123", mediaType: "image/png" },
+            { type: "document", data: "JVBERi0=", mediaType: "application/pdf", filename: "r.pdf" },
+          ],
+        },
+      ],
+    });
+
+    const msgs = body.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    expect(msgs[1]?.content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "t1",
+      content: [
+        { type: "text", text: "chart screenshot" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "abc123" } },
+        {
+          type: "document",
+          source: { type: "base64", media_type: "application/pdf", data: "JVBERi0=" },
+          title: "r.pdf",
+        },
+      ],
+    });
+  });
+
+  it("preserves assistant thinking history blocks for native Anthropic", () => {
+    const body = openaiToAnthropicRequest({
+      model: "m",
+      messages: [
+        {
+          role: "assistant",
+          content: "visible answer",
+          thinking_blocks: [
+            { type: "thinking", thinking: "private chain", signature: "sig-1" },
+            { type: "redacted_thinking", data: "encrypted" },
+          ],
+        },
+      ],
+    });
+
+    const msgs = body.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    expect(msgs[0]?.content).toEqual([
+      { type: "thinking", thinking: "private chain", signature: "sig-1" },
+      { type: "redacted_thinking", data: "encrypted" },
+      { type: "text", text: "visible answer" },
+    ]);
+  });
+
   it("groups consecutive tool results into one immediate Anthropic user turn", () => {
     const body = openaiToAnthropicRequest({
       model: "m",

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -100,6 +100,35 @@ describe("openaiToAnthropicRequest", () => {
     });
   });
 
+  it("preserves document filename for uploaded file and remote url sources", () => {
+    const body = openaiToAnthropicRequest({
+      model: "m",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "document", fileId: "file_123", filename: "uploaded.pdf" },
+            { type: "document", url: "https://example.com/report.pdf", filename: "remote.pdf" },
+          ],
+        },
+      ],
+    });
+
+    const msgs = body.messages as Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    expect(msgs[0]?.content).toEqual([
+      {
+        type: "document",
+        source: { type: "file", file_id: "file_123" },
+        title: "uploaded.pdf",
+      },
+      {
+        type: "document",
+        source: { type: "url", url: "https://example.com/report.pdf" },
+        title: "remote.pdf",
+      },
+    ]);
+  });
+
   it("preserves assistant thinking history blocks for native Anthropic", () => {
     const body = openaiToAnthropicRequest({
       model: "m",

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -123,7 +123,11 @@ function imageBlockFromPart(part: Record<string, unknown>): AnthropicBlock | nul
 
 function documentBlockFromPart(part: Record<string, unknown>): AnthropicBlock | null {
   if (typeof part.fileId === "string") {
-    return { type: "document", source: { type: "file", file_id: part.fileId } };
+    return {
+      type: "document",
+      source: { type: "file", file_id: part.fileId },
+      ...(typeof part.filename === "string" ? { title: part.filename } : {}),
+    };
   }
   if (typeof part.data === "string") {
     return {
@@ -145,7 +149,11 @@ function documentBlockFromPart(part: Record<string, unknown>): AnthropicBlock | 
         ...(typeof part.filename === "string" ? { title: part.filename } : {}),
       };
     }
-    return { type: "document", source: { type: "url", url: part.url } };
+    return {
+      type: "document",
+      source: { type: "url", url: part.url },
+      ...(typeof part.filename === "string" ? { title: part.filename } : {}),
+    };
   }
   return null;
 }

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -217,6 +217,35 @@ function textBlocksFromContent(content: unknown, messageCacheControl?: unknown):
   return [];
 }
 
+function thinkingBlocksFromMessage(message: Record<string, unknown>): AnthropicBlock[] {
+  const blocks = message.thinking_blocks;
+  if (!Array.isArray(blocks)) return [];
+  return blocks.flatMap((block): AnthropicBlock[] => {
+    if (!block || typeof block !== "object") return [];
+    const b = block as Record<string, unknown>;
+    if (b.type === "redacted_thinking" && typeof b.data === "string") {
+      return [{ type: "redacted_thinking", data: b.data }];
+    }
+    if (typeof b.thinking === "string") {
+      return [
+        {
+          type: "thinking",
+          thinking: b.thinking,
+          ...(typeof b.signature === "string" ? { signature: b.signature } : {}),
+        },
+      ];
+    }
+    return [];
+  });
+}
+
+function toolResultContentFromContent(content: unknown): string | AnthropicBlock[] {
+  if (content === null || content === undefined) return "";
+  if (typeof content === "string") return content;
+  const blocks = textBlocksFromContent(content);
+  return blocks.length > 0 ? blocks : JSON.stringify(content);
+}
+
 // Reproduce Claude Code's `x-anthropic-billing-header` attribution block as the FIRST
 // system entry — the exact slot (system[0], ahead of the "You are Claude Code…"
 // preamble) real CC emits it. `clientIdentity` is the inbound CLI's own
@@ -306,7 +335,7 @@ function toAnthropicMessages(messages: Array<Record<string, unknown>>): Anthropi
           {
             type: "tool_result",
             tool_use_id: String(m.tool_call_id ?? ""),
-            content: typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? ""),
+            content: toolResultContentFromContent(m.content),
             ...(m.cache_control !== undefined ? { cache_control: m.cache_control } : {}),
           },
         ],
@@ -314,7 +343,10 @@ function toAnthropicMessages(messages: Array<Record<string, unknown>>): Anthropi
       continue;
     }
     if (role === "assistant") {
-      const blocks: AnthropicBlock[] = textBlocksFromContent(m.content, m.cache_control);
+      const blocks: AnthropicBlock[] = [
+        ...thinkingBlocksFromMessage(m),
+        ...textBlocksFromContent(m.content, m.cache_control),
+      ];
       const toolCalls = Array.isArray(m.tool_calls) ? m.tool_calls : [];
       for (const tc of toolCalls as Array<Record<string, unknown>>) {
         const fn = (tc.function ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
## 背景

继续审计 Anthropic 原生协议支持时发现，虽然普通 user content 的 image/document 透传已经修复，但 Anthropic → IR → Anthropic 仍存在结构化信息丢失，不是 UI 显示问题，也不是应该用循环拦截解决的问题。

## 根因

- `tool_result.content` 支持 `string | block[]`，但当前入站只保留 text block，image/document 被降级成 JSON 文本；出站与 native subscription provider 又会把 multipart IR tool message `JSON.stringify` 成字符串。
- Anthropic document block 的 `title` 没有映射到 IR `filename`，回到 Anthropic 时无法还原。
- assistant 历史中的 `thinking` / `redacted_thinking` block 被放进全局 passthrough 或直接丢弃，无法按原 assistant turn 恢复；response 与 synthesized SSE 路径也没有保留 `redacted_thinking`。

这些问题会让 Claude 看不到工具返回中的截图/文档，或破坏 extended-thinking conversation history，可能继续诱发工具调用上下文错误和重复调用。

## 修复

- Anthropic request transformer 双向保留 multipart `tool_result.content` 的 text/image/document block。
- document `title` 与 IR `filename` 双向映射。
- request/provider 路径按 assistant message 保留并恢复 `thinking` / `redacted_thinking` 历史 block。
- response/stream 路径补齐 `redacted_thinking`：native response、IR response、Anthropic SSE 入站，以及非流式/缓存命中合成 SSE 都保留该 opaque block。
- 更新 `implementation-notes.md` 记录该协议保真决策。

## 验证

- `pnpm exec vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/protocol/anthropic/response.test.ts packages/core/src/protocol/anthropic/stream.test.ts packages/core/src/protocol/anthropic/footguns.test.ts packages/core/src/provider/anthropic.test.ts apps/gateway/src/routes/messages-pipeline.test.ts apps/gateway/src/routes/execute.test.ts`
- `pnpm typecheck`
- `pnpm lint`
