### PR TITLE
修复 OpenAI/Responses/Gemini 协议互译保真缺口

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-13 · OpenAI/Responses/Gemini 协议互译保真补丁（docs/05；原则 1/7/8）
+
+- **缘起**：在 Anthropic 互译修复后继续核对另外三种协议的 native→IR→native 保真。确认不是页面显示问题，而是协议层存在若干“字段有原生语义但 IR 没有稳定家”的丢失点：OpenAI/Responses 图片 `detail`、Responses tool output 多模态内容与 `input_file.filename`、Gemini `functionResponse.response` 原始对象，以及 Gemini 流式同名并行 tool call。
+- **修复**：`IRImagePart` 新增 `detail`，OpenAI Chat 与 Responses 双向映射保留该字段；OpenAI `file` 内容的 `format` 随 `IRDocumentPart.mediaType` 重新发出。Responses `function_call_output.output` 如果入站是 multipart，出站仍发 content-part array（文本用 `output_text`，图片/文件保留 `input_image`/`input_file`），并在 `file_id`/`file_url` 分支保留 `filename`；入站 `reasoning` items 会在 Responses request out 重放但继续去掉 OpenAI 拒收的 `status`。Gemini tool-result message 增加 message-level `provider_raw.gemini_function_response`，用于恢复原始 object response；OpenAI 出站显式剥离 message-level `provider_raw`，避免内部元数据泄漏到 wire。Gemini `transformStreamIn` 的 tool slot 从按 function name 改为按 `name + frame occurrence` 分配，修复同名并行 functionCall 被覆盖为一个 tool call 的问题。
+- **取舍**：message-level `provider_raw` 只用于无法放入通用 IR 字段的 native tool-result 结构，不作为通用业务字段；OpenAI/Responses 可表达的内容仍优先放一等 IR 字段。Responses reasoning item 的 `status` 虽可被捕获，但继续不重放，因为 Responses input 明确拒绝它，保真与可执行性冲突时优先可执行并保留 raw。
+- **验证**：新增 TDD 回归覆盖 OpenAI `image_url.detail`/file `format`、Responses `input_image.detail`/`input_file.filename`/multipart `function_call_output`/reasoning item replay、Gemini raw `functionResponse.response` 与流式同名并行 tool call；focused protocol tests 177 绿。
+
 ## 2026-06-13 · Anthropic 互译保真：tool_result 多模态 + thinking/redacted_thinking 历史块（docs/05；原则 1/7/8）
 
 - **缘起**：继续追查 Anthropic 原生请求经 IR 再回 Anthropic 时的保真问题。上轮已修普通 user content 的 image/document 透传，但进一步审计发现三处仍会丢 Anthropic 原生信息：`tool_result.content` 为 block[] 时只保留 text，image/document 被 JSON 字符串化；document `title` 没有进 IR `filename`；assistant 历史里的 `thinking` / `redacted_thinking` request/response block 与缓存命中合成 SSE 路径无法按原块恢复。这类丢失会让模型看不到工具返回的截图/文档，或破坏 Claude extended-thinking conversation history，属于协议根因，不是 UI/循环保护问题。
@@ -25,24 +32,15 @@
 - **关键取舍（已敲定）**：真 CC 的头逐请求轮换（后缀+cch 都是内容哈希），「字节级仿真」与「命中缓存」**本质冲突**。用户选**按缓存前缀算 cch**：真实版本 + authentic-looking + 可缓存；唯一弱差异是同会话内 cch 不每轮变（cch 是归因 telemetry，几乎不可能据此封号）。**经验数据**（同会话 6 请求）证实客户端 `cc_version=2.1.173.d11` **跨请求恒定**、只有 `cch` 轮换——所以透传客户端版本既零维护又比硬编码更真（硬编码必然和客户端实际版本错位，且拿不到真实 build 后缀 `.d11`）。
 - **验证**：TDD 红→绿。新增 extract 4 例（version+entrypoint / string system / 无块→null / 注入畸形→null）+ provider 透传 2 例（回写客户端版本 / 透传时 cch 仍稳定）+ UA-from-client 1 例（UA 用客户端 semver，块带后缀，都 2.1.173 非兜底 2.1.175）；既有 fallback 路径断言不变（无 metadata → 2.1.175）。provider+protocol+gateway+shared **1071 绿**、`pnpm typecheck`/`lint` 全绿。
 
-## 2026-06-12 · 首页 Token 计量 dashboard（持久化 + 聚合端点 + LayerChart 图表；CLAUDE.md 原则 1/3/7；docs/02/07）
-
-- **缘起**：用户要在 `/admin` 首页看到「总/输入/输出/缓存 Token」与两张图（用量趋势 + 各模型占比），参考 `claude-relay-service` dashboard。阻塞点：helm-api **从不持久化 token 计数**——`catalog/cost.ts::usageFromBody()` 早就能解析 OpenAI/Anthropic 两种 usage 形状，但 `resolveCostUsd()` 只留 USD、丢掉 token 数；telemetry 表只存 `cost_usd`；无聚合端点（首页此前 client 侧 reduce ≤200 行样本）；无图表库。决策（已与用户敲定）：**cards + 2 charts / LayerChart / forward-only 不回填**。
-- **三层改动**：
-  1. **持久化**：`DecisionRecord` 加可选 `usage` 块（`TokenUsageSchema`，4 个整数计数）。**容器键必须叫 `usage`**——redactor 的 `DEFAULT_SECRET_PATTERN` 含 `token`，若键名带 "token" 整个对象会被 summarize 成 `{redacted:true}`；标量 `*_tokens` 叶子本身能原样通过（[[已修的 memory_tokens_injected]] 同理）。由 pinned redaction 测试钉死。gateway `backfillCompletionCost` 加第 4 参 `usage?`，复用 **core 的** `usageFromBody`（别名导入；gateway 本地同名函数只返回原始对象）映射后盖戳；token 盖戳与 cost **解耦**（null cost + 有 usage 仍盖 token，非流式路径也补盖）。telemetry 表反范式化 5 列（`prompt/completion/cached/cache_creation_tokens` + `served_model`）便于 SQL 聚合；迁移 **sqlite v22 / pg v21**（两套 ledger 独立编号，sqlite 因早期重建领先一号）。
-  2. **聚合端点**：`TelemetryStore.aggregate(start,end,bucket)` 返回 `{totals, series[], byModel[]}`，三条 SQL 全走 `SUM`/`COUNT`/`GROUP BY`（绝不逐行 JS）。分桶用 epoch-ms 整除（窗口大小经 `sql.raw` 内联，确保两方言都做整数除法），排序在共享 `aggregate-shape.ts` 里用 JS 做（方言无关）。token sum 用 `COALESCE(...,0)`，cost/latency 保持 nullable（「未测量」≠ 0）。新 `GET /admin/api/stats`，查询用 fail-open 的 `StatsQuerySchema`（默认末 24h / day）。
-  3. **前端**：`layerchart@^1.0.13`（Svelte5 兼容，SSR 已关无需 guard）；`lib/api/stats.ts` 客户端 + `+page.ts` loader 改调 `getStats`（recent-requests 表仍用 `listRequests`）；4 张 token card + AreaChart 趋势 + PieChart（`innerRadius:-40` 甜甜圈）各模型占比；`formatTokens`（1.2M/34.5K）；i18n en/zh-hans/zh-hant/ja/ko。
-- **坑/取舍**：**forward-only**——历史行 token 列与 `served_model` 为 NULL，趋势从部署起、by-model 旧流量归到 "unknown" 桶。avg latency 仍从 decision JSON 读（`json_extract`/`->>`），有界窗口可接受；变热再反范式化。LayerChart 的 `AreaChart`/`PieChart` 用 Svelte4 风格 props 但 runes 模式下渲染正常；类型上需给两图显式 point 类型，否则各 series accessor 把 `TData` 收窄成不同内联形状无法统一。WebFetch/Context7 当时都取不到 LayerChart API，最终读包内 `.d.ts` 作为 ground truth。
-- **追加修复**：review 发现 non-chat 协议的 admin 流式 replay 没有 budget deps 时会跳过 streamed usage 盖戳，导致 replay telemetry 被 dashboard 少算；已把 shared `messages-pipeline` 的 token stamp 从 budget-only 分支移出，budget settle 仍保持 gated。
-- **验证**：`pnpm typecheck`/`lint` 全绿；`pnpm test` 绿（唯一 full-run 红是已知 PGlite 5s 超时 flake `memory-jobs.test.ts`，隔离重跑 8/8 过——见 [[pnpm-test-pglite-flake]]）。新覆盖：redaction guard、schema round-trip、gateway token-stamp（OpenAI+Anthropic）、aggregate contract（**两 adapter** sqlite+pglite）、stats route、`formatTokens`、dashboard locale coverage。13 个迁移-scoped 测试因预置 applied 版本列表少了 v22/v21 而红，已补齐（图表渲染本身 jsdom 不可测）。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
-### 2026-06-12 · 四协议互译保真补丁：Responses `tool_choice` 双向规范化、`previous_response_id` continuation fail-closed、Anthropic native controls/provider beta 透传、Gemini `safetySettings` round-trip；缺完整 Responses object/session store 前不伪装支持历史 tool-output continuation。
+### 2026-06-12 · 首页 Token 计量 dashboard：新增 usage 反范式化持久化、`/admin/api/stats` SQL 聚合、LayerChart token 趋势/模型占比；forward-only 不回填历史，SQLite/PG 迁移分别 v22/v21，typecheck/lint/test 验证。
+
+### 2026-06-12 · 四协议互译保真补丁（Responses tool_choice / Anthropic native controls / Gemini safety；docs/05/07）：Responses `tool_choice` 双向规范化并对缺本地历史的 `previous_response_id` tool-output continuation fail-closed；Anthropic native controls 进 `provider_raw` 并补 beta header；Gemini `safetySettings` round-trip；focused 244、typecheck、lint、完整 test 绿。
 
 ### 2026-06-12 · 新增 claude-fable-5 配置支持（原则 2/6；docs/04）：能力取自 OpenRouter API（ctx 1M / max_out 128K / text+image+file→document，pricing 未落库）；完全镜像 claude-opus 模式——`lanes.yaml` 新 `claude-fable` lane 以 native OAuth 别名领衔、`fallback:[premium]`，`model-aliases.yaml` 加 `claude-fable-*` glob；用户拍板**去掉 OpenRouter 静态镜像兜底**；native 别名靠运行时 OAuth pool 注册不进 providers.yaml。TDD samples+catalog 98 绿。部署坑：需手动同步 `/opt/helm-api/config` 两个 yaml（[[deploy-never-overwrite-config]]）。
 

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -267,6 +267,41 @@ describe("tool-call id synthesis (the core pit)", () => {
     expect(response.functionResponse.name).toBe("get_weather");
   });
 
+  it("round-trips native functionResponse.response objects through provider_raw", () => {
+    const native: GeminiGenerateContentRequest = {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { name: "get_weather", args: { city: "SF" } } }],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                name: "get_weather",
+                response: { temp: 60, unit: "F", nested: { ok: true } },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const ir = geminiTransformer.transformRequestOut(native) as IRRequest;
+    const toolMsg = ir.messages.find((m) => m.role === "tool");
+    expect(toolMsg?.content).toBe(JSON.stringify({ temp: 60, unit: "F", nested: { ok: true } }));
+
+    const back = geminiTransformer.transformRequestIn(ir) as GeminiGenerateContentRequest;
+    const response = back.contents[1]?.parts[0] as {
+      functionResponse: { name: string; response: unknown };
+    };
+    expect(response.functionResponse).toEqual({
+      name: "get_weather",
+      response: { temp: 60, unit: "F", nested: { ok: true } },
+    });
+  });
+
   it("drops synthesized ids when going IR -> Gemini (outbound)", () => {
     const ir: IRRequest = {
       model: "gemini-1.5-pro",
@@ -582,6 +617,70 @@ describe("streaming alt=sse (snapshot events -> IR chunks)", () => {
       .map((tc) => tc.function?.name)
       .filter(Boolean);
     expect(toolNames).toContain("search");
+  });
+
+  it("keeps same-name parallel function calls in separate streaming slots", async () => {
+    const events: GeminiSSEEvent[] = [
+      {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [
+                { functionCall: { name: "search", args: { q: "alpha" } } },
+                { functionCall: { name: "search", args: { q: "beta" } } },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    ];
+
+    const chunks = await collect(geminiTransformer.transformStreamIn(fromArray(events)));
+    const toolCalls = chunks.flatMap((c) => c.choices?.[0]?.delta?.tool_calls ?? []);
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls.map((tc) => tc.index)).toEqual([0, 1]);
+    expect(toolCalls.map((tc) => tc.id)).toEqual(["call_search_0", "call_search_1"]);
+    expect(toolCalls.map((tc) => JSON.parse(tc.function?.arguments ?? "{}"))).toEqual([
+      { q: "alpha" },
+      { q: "beta" },
+    ]);
+  });
+
+  it("keeps same-name parallel function calls split across streaming frames", async () => {
+    const events: GeminiSSEEvent[] = [
+      {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ functionCall: { name: "search", args: { q: "alpha" } } }],
+            },
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ functionCall: { name: "search", args: { q: "beta" } } }],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    ];
+
+    const chunks = await collect(geminiTransformer.transformStreamIn(fromArray(events)));
+    const toolCalls = chunks.flatMap((c) => c.choices?.[0]?.delta?.tool_calls ?? []);
+    expect(toolCalls).toHaveLength(2);
+    expect(new Set(toolCalls.map((tc) => tc.id)).size).toBe(2);
+    expect(toolCalls.map((tc) => JSON.parse(tc.function?.arguments ?? "{}"))).toEqual([
+      { q: "alpha" },
+      { q: "beta" },
+    ]);
   });
 
   // test #3: streaming usage subtracts cachedContentTokenCount (matches non-stream).

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -402,6 +402,7 @@ function transformRequestOut(native: unknown): IRRequest {
       }
       if (part.functionResponse !== undefined) {
         const name = part.functionResponse.name;
+        const response = part.functionResponse.response;
         // Pair by name + occurrence order within this same turn's calls would not
         // span turns; the call ids were assigned in the assistant turn, so re-derive
         // the deterministic id from name + the response's own occurrence index.
@@ -409,11 +410,9 @@ function transformRequestOut(native: unknown): IRRequest {
         responseSeenByName.set(name, seen + 1);
         toolResultMessages.push({
           role: "tool",
-          content:
-            typeof part.functionResponse.response === "string"
-              ? part.functionResponse.response
-              : JSON.stringify(part.functionResponse.response ?? {}),
+          content: typeof response === "string" ? response : JSON.stringify(response ?? {}),
           tool_call_id: synthToolCallId(name, seen),
+          provider_raw: { gemini_function_response: response ?? {} },
         });
         continue;
       }
@@ -724,7 +723,9 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
                   ? toolNameById.get(message.tool_call_id)
                   : undefined) ??
                 "tool",
-              response: { content: irMessageContentToText(message.content) },
+              response: message.provider_raw?.gemini_function_response ?? {
+                content: irMessageContentToText(message.content),
+              },
             },
           },
         ],
@@ -1000,6 +1001,33 @@ interface StreamToolSlot {
   index: number;
   name: string;
   fullArgs: string; // latest complete args JSON from the most recent snapshot
+  argsValue: unknown;
+}
+
+function isSnapshotCompatible(previous: unknown, current: unknown): boolean {
+  if (Object.is(previous, current)) return true;
+  if (typeof previous === "string" && typeof current === "string") {
+    return current.startsWith(previous);
+  }
+  if (Array.isArray(previous) && Array.isArray(current)) {
+    return (
+      current.length >= previous.length &&
+      previous.every((value, index) => isSnapshotCompatible(value, current[index]))
+    );
+  }
+  if (
+    previous !== null &&
+    current !== null &&
+    typeof previous === "object" &&
+    typeof current === "object" &&
+    !Array.isArray(previous) &&
+    !Array.isArray(current)
+  ) {
+    return Object.entries(previous as Record<string, unknown>).every(([key, value]) =>
+      isSnapshotCompatible(value, (current as Record<string, unknown>)[key]),
+    );
+  }
+  return false;
 }
 
 async function* transformStreamIn(src: AsyncIterable<GeminiSSEEvent>): AsyncIterable<IRChunk> {
@@ -1015,8 +1043,11 @@ async function* transformStreamIn(src: AsyncIterable<GeminiSSEEvent>): AsyncIter
   // not as a strict prefix extension). So we BUFFER the latest full args per tool and
   // flush a single complete `arguments` string at stream end — tolerating arbitrary
   // fragmentation without ever emitting a half-parsed JSON delta (docs/05 pit:
-  // "tolerate partial JSON; accumulate to complete before parse").
-  const toolNameToSlot = new Map<string, StreamToolSlot>();
+  // "tolerate partial JSON; accumulate to complete before parse"). Duplicate parallel
+  // calls can share the same name and may arrive across separate frames. Gemini gives
+  // no stable id/index, so only reuse a same-name slot when the new args look like a
+  // compatible snapshot extension; otherwise allocate a new parallel slot.
+  const toolSlots: StreamToolSlot[] = [];
 
   for await (const raw of src) {
     const event = GeminiSSEEventSchema.parse(raw);
@@ -1062,17 +1093,26 @@ async function* transformStreamIn(src: AsyncIterable<GeminiSSEEvent>): AsyncIter
       .map((p) => p.text ?? "")
       .join("");
 
-    // —— tool-call args: buffer the latest full args per name (no mid-stream emit). ——
+    // —— tool-call args: buffer the latest full args per inferred tool slot. ——
+    const usedToolIndexes = new Set<number>();
     for (const part of parts) {
       if (part.functionCall === undefined) continue;
       hasSeenToolCalls = true;
       const name = part.functionCall.name;
-      let slot = toolNameToSlot.get(name);
+      const argsValue = part.functionCall.args ?? {};
+      let slot = toolSlots.find(
+        (candidate) =>
+          candidate.name === name &&
+          !usedToolIndexes.has(candidate.index) &&
+          isSnapshotCompatible(candidate.argsValue, argsValue),
+      );
       if (slot === undefined) {
-        slot = { index: toolNameToSlot.size, name, fullArgs: "" };
-        toolNameToSlot.set(name, slot);
+        slot = { index: toolSlots.length, name, fullArgs: "", argsValue };
+        toolSlots.push(slot);
       }
-      slot.fullArgs = JSON.stringify(part.functionCall.args ?? {});
+      usedToolIndexes.add(slot.index);
+      slot.argsValue = argsValue;
+      slot.fullArgs = JSON.stringify(argsValue);
     }
 
     const finish = mapFinishReasonToIR(candidate?.finishReason);
@@ -1125,7 +1165,7 @@ async function* transformStreamIn(src: AsyncIterable<GeminiSSEEvent>): AsyncIter
 
   // —— Stream end: flush complete tool-call args (each a fully-parseable JSON), then
   // the terminal finish_reason exactly once (idempotent close, docs/05 pit #4). ——
-  for (const slot of toolNameToSlot.values()) {
+  for (const slot of toolSlots) {
     yield {
       ...(lastModel !== undefined ? { model: lastModel } : {}),
       choices: [

--- a/packages/core/src/protocol/ir.test.ts
+++ b/packages/core/src/protocol/ir.test.ts
@@ -53,11 +53,20 @@ describe("IRContentPartSchema — multipart typed content", () => {
       role: "assistant",
       content: [
         { type: "text", text: "here" },
-        { type: "image", url: "https://example.com/a.png", mediaType: "image/png" },
+        {
+          type: "image",
+          url: "https://example.com/a.png",
+          mediaType: "image/png",
+          detail: "high",
+        },
         { type: "thinking", text: "let me reason", signature: "sig-123" },
       ],
     });
     expect(Array.isArray(parsed.content)).toBe(true);
+    expect(Array.isArray(parsed.content) ? parsed.content[1] : undefined).toMatchObject({
+      type: "image",
+      detail: "high",
+    });
   });
 
   it("rejects an unknown content part `type` via discriminatedUnion", () => {

--- a/packages/core/src/protocol/ir.ts
+++ b/packages/core/src/protocol/ir.ts
@@ -35,6 +35,10 @@ export const IRImagePartSchema = z.object({
   // original structure goes into provider_raw.
   url: z.string(),
   mediaType: z.string().optional(),
+  // OpenAI Chat and Responses both expose an image detail hint (auto/low/high today,
+  // but kept open-ended for forward compatibility). It has to live in the IR or an
+  // OpenAI/Responses self round-trip silently drops it.
+  detail: z.string().optional(),
   cache_control: z.unknown().optional(), // Anthropic per-block cache breakpoint
 });
 
@@ -216,6 +220,18 @@ export const IRToolCallSchema = z.object({
 });
 export type IRToolCall = z.infer<typeof IRToolCallSchema>;
 
+// —— provider_raw passthrough bag: upstream-native fields that cannot be mapped
+// losslessly. `.catchall(z.unknown())` is REQUIRED — without it unknown upstream
+// fields would be stripped, breaking the lossless-passthrough goal. ——————————
+
+export const ProviderRawSchema = z
+  .object({
+    stop_reason: z.unknown().optional(), // raw upstream finish/stop value (pre-mapping)
+    usage: z.unknown().optional(), // raw upstream usage (billing / reconstruction)
+  })
+  .catchall(z.unknown()); // any other native field is retained verbatim
+export type ProviderRaw = z.infer<typeof ProviderRawSchema>;
+
 // —— Message (role=tool carries tool_call_id; content is a string or multipart,
 // and may be null for an assistant turn that only emits tool_calls). `developer`
 // is OpenAI's renamed system tier — kept as a FIRST-CLASS role so it survives the
@@ -238,20 +254,9 @@ export const IRMessageSchema = z.object({
   annotations: z.array(IRAnnotationSchema).optional(),
   images: z.array(IRImageOutSchema).optional(),
   audio: IRAudioOutSchema.optional(),
+  provider_raw: ProviderRawSchema.optional(),
 });
 export type IRMessage = z.infer<typeof IRMessageSchema>;
-
-// —— provider_raw passthrough bag: upstream-native fields that cannot be mapped
-// losslessly. `.catchall(z.unknown())` is REQUIRED — without it unknown upstream
-// fields would be stripped, breaking the lossless-passthrough goal. ——————————
-
-export const ProviderRawSchema = z
-  .object({
-    stop_reason: z.unknown().optional(), // raw upstream finish/stop value (pre-mapping)
-    usage: z.unknown().optional(), // raw upstream usage (billing / reconstruction)
-  })
-  .catchall(z.unknown()); // any other native field is retained verbatim
-export type ProviderRaw = z.infer<typeof ProviderRawSchema>;
 
 // —— Request ————————————————————————————————————————————————————————————————
 

--- a/packages/core/src/protocol/openai.test.ts
+++ b/packages/core/src/protocol/openai.test.ts
@@ -93,7 +93,7 @@ describe("openaiTransformer — developer role survives + round-trips (issue #50
 });
 
 describe("openaiTransformer — cross-provider private field stripping", () => {
-  it("does not leak IR thinking_blocks onto OpenAI request wire messages", async () => {
+  it("does not leak IR thinking_blocks or provider_raw onto OpenAI request wire messages", async () => {
     const wire = (await openaiTransformer.transformRequestIn({
       model: "gpt-4o",
       messages: [
@@ -102,15 +102,17 @@ describe("openaiTransformer — cross-provider private field stripping", () => {
           content: "answer",
           reasoning_content: "visible reasoning",
           thinking_blocks: [{ type: "redacted_thinking", data: "encrypted-blob" }],
+          provider_raw: { gemini_function_response: { temp: 72 } },
         },
       ],
     })) as { messages: Array<Record<string, unknown>> };
 
     expect(wire.messages[0]?.thinking_blocks).toBeUndefined();
+    expect(wire.messages[0]?.provider_raw).toBeUndefined();
     expect(wire.messages[0]?.reasoning_content).toBe("visible reasoning");
   });
 
-  it("does not leak IR thinking_blocks onto OpenAI response wire messages", async () => {
+  it("does not leak IR thinking_blocks or provider_raw onto OpenAI response wire messages", async () => {
     const wire = (await openaiTransformer.transformResponseOut({
       id: "chatcmpl-thinking",
       model: "gpt-4o",
@@ -122,6 +124,7 @@ describe("openaiTransformer — cross-provider private field stripping", () => {
             content: "answer",
             reasoning_content: "visible reasoning",
             thinking_blocks: [{ type: "redacted_thinking", data: "encrypted-blob" }],
+            provider_raw: { gemini_function_response: { temp: 72 } },
           },
           finish_reason: "stop",
         },
@@ -129,6 +132,7 @@ describe("openaiTransformer — cross-provider private field stripping", () => {
     })) as { choices: Array<{ message: Record<string, unknown> }> };
 
     expect(wire.choices[0]?.message.thinking_blocks).toBeUndefined();
+    expect(wire.choices[0]?.message.provider_raw).toBeUndefined();
     expect(wire.choices[0]?.message.reasoning_content).toBe("visible reasoning");
   });
 });
@@ -567,6 +571,31 @@ describe("openaiTransformer — multimodal input content normalization (P7)", ()
     expect(parts[2]).toMatchObject({ type: "image", url: "https://x/y.png" });
   });
 
+  it("round-trips image_url.detail through the IR", async () => {
+    const native = {
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image_url", image_url: { url: "https://x/y.png", detail: "high" } }],
+        },
+      ],
+    };
+
+    const ir = await openaiTransformer.transformRequestOut(native);
+    const parts = ir.messages[0]?.content;
+    if (!Array.isArray(parts)) throw new Error("expected parts");
+    expect(parts[0]).toMatchObject({ type: "image", url: "https://x/y.png", detail: "high" });
+
+    const back = (await openaiTransformer.transformRequestIn(ir)) as {
+      messages: Array<{ content: Array<{ image_url?: { url?: string; detail?: string } }> }>;
+    };
+    expect(back.messages[0]?.content[0]?.image_url).toEqual({
+      url: "https://x/y.png",
+      detail: "high",
+    });
+  });
+
   it("normalizes input_audio into an IR audio part and back to native (round-trip)", async () => {
     const native = {
       model: "gpt-4o-audio-preview",
@@ -636,22 +665,32 @@ describe("openaiTransformer — multimodal input content normalization (P7)", ()
   it("round-trips an uploaded file_id reference (not corrupted into file_data)", async () => {
     const native = {
       model: "gpt-4o",
-      messages: [{ role: "user", content: [{ type: "file", file: { file_id: "file-abc123" } }] }],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "file", file: { file_id: "file-abc123", format: "application/pdf" } }],
+        },
+      ],
     };
     const ir = await openaiTransformer.transformRequestOut(native);
     const parts = ir.messages[0]?.content;
     if (!Array.isArray(parts)) throw new Error("expected parts");
-    expect(parts[0]).toMatchObject({ type: "document", fileId: "file-abc123" });
+    expect(parts[0]).toMatchObject({
+      type: "document",
+      fileId: "file-abc123",
+      mediaType: "application/pdf",
+    });
     expect((parts[0] as { url?: string }).url).toBeUndefined();
 
     const back = (await openaiTransformer.transformRequestIn(ir)) as {
       messages: Array<{ content: Array<Record<string, unknown>> }>;
     };
     const out = back.messages[0]?.content?.[0] as {
-      file?: { file_id?: string; file_data?: string };
+      file?: { file_id?: string; file_data?: string; format?: string };
     };
     expect(out.file?.file_id).toBe("file-abc123");
     expect(out.file?.file_data).toBeUndefined();
+    expect(out.file?.format).toBe("application/pdf");
   });
 });
 

--- a/packages/core/src/protocol/openai.ts
+++ b/packages/core/src/protocol/openai.ts
@@ -205,10 +205,16 @@ function nativePartToIR(part: unknown): IRContentPart {
               typeof (iu as { url?: unknown }).url === "string"
             ? (iu as { url: string }).url
             : "";
+      const detail =
+        typeof iu === "object" &&
+        iu !== null &&
+        typeof (iu as { detail?: unknown }).detail === "string"
+          ? { detail: (iu as { detail: string }).detail }
+          : {};
       const parsed = parseDataUrl(url);
       return parsed !== null
-        ? { type: "image", url, mediaType: parsed.mediaType }
-        : { type: "image", url };
+        ? { type: "image", url, mediaType: parsed.mediaType, ...detail }
+        : { type: "image", url, ...detail };
     }
     case "input_audio": {
       const ia = (p.input_audio ?? {}) as { data?: unknown; format?: unknown };
@@ -279,15 +285,19 @@ function irPartToNative(part: IRContentPart): unknown {
     case "text":
       return { type: "text", text: part.text };
     case "image":
-      return { type: "image_url", image_url: { url: part.url } };
+      return {
+        type: "image_url",
+        image_url: { url: part.url, ...(part.detail !== undefined ? { detail: part.detail } : {}) },
+      };
     case "audio":
       return { type: "input_audio", input_audio: { data: part.data, format: part.format } };
     case "document": {
       // An uploaded-file handle round-trips back to file.file_id (OpenAI's expected
       // shape); else inline base64 -> file_data data-url; else a remote url -> file_data.
       const name = part.filename !== undefined ? { filename: part.filename } : {};
+      const format = part.mediaType !== undefined ? { format: part.mediaType } : {};
       if (part.fileId !== undefined) {
-        return { type: "file", file: { file_id: part.fileId, ...name } };
+        return { type: "file", file: { file_id: part.fileId, ...name, ...format } };
       }
       const fileData =
         part.data !== undefined
@@ -298,6 +308,7 @@ function irPartToNative(part: IRContentPart): unknown {
         file: {
           ...(fileData !== undefined ? { file_data: fileData } : {}),
           ...name,
+          ...format,
         },
       };
     }
@@ -309,7 +320,11 @@ function irPartToNative(part: IRContentPart): unknown {
 }
 
 function stripOpenAIPrivateMessageFields(message: IRMessage): IRMessage {
-  const { thinking_blocks: _thinking_blocks, ...wireMessage } = message;
+  const {
+    thinking_blocks: _thinking_blocks,
+    provider_raw: _provider_raw,
+    ...wireMessage
+  } = message;
   return wireMessage;
 }
 
@@ -414,9 +429,9 @@ function toIRResponse(res: NativeResponse): IRResponse {
 // {type:"thinking"} content block. A message that already carries reasoning_content
 // (native OpenAI origin) is preserved. (P6) ————————————————————————————————————————
 function toOpenAIMessage(message: IRMessage): IRMessage {
+  const wireMessage = stripOpenAIPrivateMessageFields(message);
   const { reasoningText } = resolveReasoning(message);
   const content = stripThinkingFromContent(message.content);
-  const wireMessage = stripOpenAIPrivateMessageFields(message);
   if (reasoningText === undefined && content === wireMessage.content) return wireMessage;
   return {
     ...wireMessage,

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -356,6 +356,28 @@ describe("responsesTransformer — Tier D request/response fidelity (orders 17-2
     expect(parts.some((p) => p.type === "document" && p.fileId === "file-abc")).toBe(true);
   });
 
+  it("round-trips input_image.detail through the IR", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_image", image_url: "https://x/y.png", detail: "high" }],
+        },
+      ],
+    });
+    const parts = ir.messages.at(-1)?.content;
+    if (!Array.isArray(parts)) throw new Error("expected parts");
+    expect(parts[0]).toMatchObject({ type: "image", url: "https://x/y.png", detail: "high" });
+
+    const back = (await responsesTransformer.transformRequestIn(ir)) as {
+      input: Array<{ type: string; content?: Array<{ type: string; detail?: string }> }>;
+    };
+    const image = back.input[0]?.content?.[0];
+    expect(image).toMatchObject({ type: "input_image", detail: "high" });
+  });
+
   it("folds an inbound input_file (file_data PDF) into an IR document with base64 data", async () => {
     const ir = await responsesTransformer.transformRequestOut({
       model: "gpt-4o",
@@ -401,6 +423,42 @@ describe("responsesTransformer — Tier D request/response fidelity (orders 17-2
     const types = (msg?.content ?? []).map((c) => c.type);
     expect(types).toContain("input_text");
     expect(types).toContain("input_image");
+  });
+
+  it("round-trips input_file filename for file_id and file_url", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_file", file_id: "file-abc", filename: "uploaded.pdf" },
+            {
+              type: "input_file",
+              file_url: "https://x/r.pdf",
+              filename: "remote.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    const back = (await responsesTransformer.transformRequestIn(ir)) as {
+      input: Array<{
+        type: string;
+        content?: Array<{
+          type: string;
+          file_id?: string;
+          file_url?: string;
+          filename?: string;
+        }>;
+      }>;
+    };
+    expect(back.input[0]?.content).toEqual([
+      { type: "input_file", file_id: "file-abc", filename: "uploaded.pdf" },
+      { type: "input_file", file_url: "https://x/r.pdf", filename: "remote.pdf" },
+    ]);
   });
 });
 
@@ -491,6 +549,37 @@ describe("responsesTransformer — request input items -> IR (folding)", () => {
     const toolMsg = ir.messages.find((m) => m.role === "tool");
     expect(toolMsg?.tool_call_id).toBe("call_abc");
     expect(toolMsg?.content).toBe("72F sunny");
+  });
+
+  it("round-trips multipart function_call_output output", async () => {
+    const native = {
+      model: "gpt-4o",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_abc",
+          output: [
+            { type: "output_text", text: "chart:" },
+            { type: "input_image", image_url: "https://x/chart.png", detail: "low" },
+            { type: "input_file", file_url: "https://x/data.csv", filename: "data.csv" },
+          ],
+        },
+      ],
+    };
+
+    const ir = await responsesTransformer.transformRequestOut(native);
+    const toolMsg = ir.messages.find((m) => m.role === "tool");
+    expect(toolMsg?.tool_call_id).toBe("call_abc");
+    expect(toolMsg?.content).toEqual([
+      { type: "text", text: "chart:" },
+      { type: "image", url: "https://x/chart.png", detail: "low" },
+      { type: "document", url: "https://x/data.csv", filename: "data.csv" },
+    ]);
+
+    const back = (await responsesTransformer.transformRequestIn(ir)) as {
+      input: Array<{ type: string; output?: unknown }>;
+    };
+    expect(back.input[0]?.output).toEqual(native.input[0]?.output);
   });
 
   it("folds top-level instructions into the leading IR system message", async () => {
@@ -599,6 +688,33 @@ describe("responsesTransformer — reasoning item inbound (test #2)", () => {
     // raw reasoning item preserved (with status) in provider_raw
     const rawReasoning = ir.provider_raw?.reasoning as Array<{ status?: string }> | undefined;
     expect(rawReasoning?.[0]?.status).toBe("completed");
+  });
+
+  it("replays inbound reasoning items on a Responses request without rejected status", async () => {
+    const native = {
+      model: "gpt-4o",
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_1",
+          status: "completed",
+          summary: [{ type: "summary_text", text: "thinking about SF weather" }],
+        },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "weather?" }] },
+      ],
+    };
+
+    const ir = await responsesTransformer.transformRequestOut(native);
+    const back = (await responsesTransformer.transformRequestIn(ir)) as {
+      input: Array<Record<string, unknown>>;
+    };
+
+    expect(back.input[0]).toEqual({
+      type: "reasoning",
+      id: "rs_1",
+      summary: [{ type: "summary_text", text: "thinking about SF weather" }],
+    });
+    expect(JSON.stringify(back.input[0])).not.toContain("status");
   });
 });
 

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -322,7 +322,11 @@ function foldContentPart(part: z.infer<typeof ResponsesContentPartSchema>): IRCo
       return { type: "text", text: (part as { text: string }).text };
     case "input_image": {
       const p = part as z.infer<typeof ResponsesInputImageSchema>;
-      return { type: "image", url: p.image_url ?? "" };
+      return {
+        type: "image",
+        url: p.image_url ?? "",
+        ...(p.detail !== undefined ? { detail: p.detail } : {}),
+      };
     }
     case "input_file": {
       const p = part as z.infer<typeof ResponsesInputFileSchema>;
@@ -508,6 +512,15 @@ function toResponsesRequest(ir: IRRequest): NativeRequest {
   const input: Array<Record<string, unknown>> = [];
   let instructions: string | undefined;
 
+  const rawReasoning = parsed.provider_raw?.reasoning;
+  if (Array.isArray(rawReasoning)) {
+    for (const item of rawReasoning) {
+      if (!isRecord(item) || item.type !== "reasoning") continue;
+      const { status: _status, ...sanitized } = item;
+      input.push(sanitized);
+    }
+  }
+
   for (const m of parsed.messages) {
     if (m.role === "system") {
       // The first system message folds to top-level instructions; any later one
@@ -521,7 +534,7 @@ function toResponsesRequest(ir: IRRequest): NativeRequest {
       input.push({
         type: "function_call_output",
         ...(m.tool_call_id !== undefined ? { call_id: m.tool_call_id } : {}),
-        output: contentToText(m.content),
+        output: contentToFunctionCallOutput(m.content),
       });
       continue;
     }
@@ -624,6 +637,13 @@ function contentToText(content: IRMessage["content"]): string {
     .join("");
 }
 
+function contentToFunctionCallOutput(
+  content: IRMessage["content"],
+): string | Array<Record<string, unknown>> {
+  if (content === null || typeof content === "string") return contentToText(content);
+  return contentToResponsesParts(content, true);
+}
+
 // IR content -> Responses content parts, PRESERVING multimodality (order 25): text ->
 // input_text/output_text, image -> input_image, document -> input_file. Collapsing to
 // a single text part dropped images/files silently. audio/video/thinking have no
@@ -638,16 +658,22 @@ function contentToResponsesParts(
   const parts: Array<Record<string, unknown>> = [];
   for (const p of content) {
     if (p.type === "text") parts.push({ type: textType, text: p.text });
-    else if (p.type === "image") parts.push({ type: "input_image", image_url: p.url });
-    else if (p.type === "document") {
-      if (p.fileId !== undefined) parts.push({ type: "input_file", file_id: p.fileId });
+    else if (p.type === "image") {
+      parts.push({
+        type: "input_image",
+        image_url: p.url,
+        ...(p.detail !== undefined ? { detail: p.detail } : {}),
+      });
+    } else if (p.type === "document") {
+      const name = p.filename !== undefined ? { filename: p.filename } : {};
+      if (p.fileId !== undefined) parts.push({ type: "input_file", file_id: p.fileId, ...name });
       else if (p.data !== undefined)
         parts.push({
           type: "input_file",
-          ...(p.filename !== undefined ? { filename: p.filename } : {}),
+          ...name,
           file_data: `data:${p.mediaType ?? "application/octet-stream"};base64,${p.data}`,
         });
-      else if (p.url !== undefined) parts.push({ type: "input_file", file_url: p.url });
+      else if (p.url !== undefined) parts.push({ type: "input_file", file_url: p.url, ...name });
     }
   }
   return parts.length > 0 ? parts : [{ type: textType, text: "" }];


### PR DESCRIPTION
## 摘要
- 为 IR image part 增加 `detail`，保留 OpenAI Chat / Responses 图片精度提示
- 保留 OpenAI file `format`、Responses `input_file.filename` 与多模态 `function_call_output.output`
- 保留 Gemini `functionResponse.response` 原始对象，并修复同名并行流式 tool call 被合并的问题
- 更新 implementation-notes，并把旧完整条目压缩到历史摘要

## 验证
- `pnpm exec vitest run packages/core/src/protocol/ir.test.ts packages/core/src/protocol/openai.test.ts packages/core/src/protocol/responses.test.ts packages/core/src/protocol/responses-stream.test.ts packages/core/src/protocol/gemini/gemini-transformer.test.ts packages/core/src/protocol/protocol-matrix.test.ts packages/core/src/protocol/reasoning.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
