### PR TITLE
fix(admin): format numbers inside the dashboard charts, not just the stat cards

### DIFF
--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -249,7 +249,19 @@
       <h2 class="section-header mb-3">{$t('Token usage over time')}</h2>
       {#if trend.length > 0}
         <div class="h-64">
-          <AreaChart data={trend} x={(d) => d.date} series={TREND_SERIES} legend />
+          <!-- Compact the Y-axis ticks (15M, not 15,000,000) and the per-series
+               tooltip values via the shared formatTokens; LayerChart formats
+               both itself unless we override props.yAxis / props.tooltip.item. -->
+          <AreaChart
+            data={trend}
+            x={(d) => d.date}
+            series={TREND_SERIES}
+            legend
+            props={{
+              yAxis: { format: formatTokens },
+              tooltip: { item: { format: formatTokens } },
+            }}
+          />
         </div>
       {:else}
         <div class="empty-state">{$t('No token usage recorded in this window yet.')}</div>
@@ -260,12 +272,15 @@
       <h2 class="section-header mb-3">{$t('Tokens by model')}</h2>
       {#if byModel.length > 0}
         <div class="h-64">
+          <!-- Slice-hover tooltip shows the model's token total — compact it
+               (1.2M) through the same formatter as everything else. -->
           <PieChart
             data={byModel}
             key={(d: ModelSlice) => d.model}
             value={(d: ModelSlice) => d.tokens}
             innerRadius={-40}
             legend
+            props={{ tooltip: { item: { format: formatTokens } } }}
           />
         </div>
       {:else}


### PR DESCRIPTION
## What

#213 wired `formatTokens` (K/M/B units) into the dashboard **stat cards** but missed the **chart internals**. On the Overview page:

- the **Token usage trend** AreaChart still rendered raw Y-axis ticks (`15,000,000`) and raw per-series tooltip values (`输入 Token 0`)
- the **Tokens by model** PieChart tooltip showed the raw slice total

LayerChart formats those itself unless a formatter is passed through `props.yAxis` / `props.tooltip.item`, so this overrides both with the shared `formatTokens` — the same helper every other number on the page already uses. Now the charts read `15M` / `1.2M`.

## Why this is the right hook

Read the installed LayerChart v1.0.13 source: `AreaChart.svelte` spreads `{...props.yAxis}` / `{...props.tooltip?.item}` **last** (overrides its built-in `format`), and `@layerstack/utils`' `format()` dispatches a **function** formatter by calling it directly — so a `(value)=>string` just works.

## Test

- `format.test.ts` 21/21 ✓ (formatter unchanged)
- `pnpm --filter @helm/admin build` ✓
- only pre-existing `oauth.test.ts` tuple errors in svelte-check (untouched)

Admin-only; zero config/core/gateway change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)