### PR TITLE
chore(release): v0.12.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.12.5.

Patch bump carrying the two commits merged since v0.12.4:

- **fix(admin): format numbers inside the dashboard charts, not just the stat cards** (#223) — AreaChart Y-axis ticks (15,000,000 → 15M) + per-series tooltip values, and PieChart slice-total tooltip, now go through the shared `formatTokens`.
- **feat: add international layer1 classifier keywords** (#216) — classifier-only; config + core, additive.

On merge, publish.yml auto-cuts tag `v0.12.5` + GitHub Release + GHCR `:0.12.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)