### PR TITLE
fix(admin): cache-control so a deploy takes effect in an open browser

### DIFF
--- a/apps/gateway/src/routes/admin-static.test.ts
+++ b/apps/gateway/src/routes/admin-static.test.ts
@@ -106,4 +106,33 @@ describe("mountAdminStatic", () => {
     const body = await res.text();
     expect(body).toContain("<!doctype html>");
   });
+
+  // Cache policy (DoD: a deploy must take effect in an already-open browser).
+  // The SPA shell (index.html) hard-codes the current build's hashed chunk URLs;
+  // if it is heuristically cached the browser keeps replaying the OLD build after
+  // a deploy. So the shell must revalidate every load, while the content-hashed
+  // immutable assets (hash == content) can be cached for a year.
+  it("sets Cache-Control: no-cache on the SPA shell so a deploy is picked up", async () => {
+    const res = await appWith(ENABLED).request("/admin", { headers: { Authorization: CRED } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect(res.headers.get("Cache-Control")).toBe("no-cache");
+  });
+
+  it("sets Cache-Control: no-cache on SPA deep-link fallbacks (index.html)", async () => {
+    const res = await appWith(ENABLED).request("/admin/keys", {
+      headers: { Authorization: CRED },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect(res.headers.get("Cache-Control")).toBe("no-cache");
+  });
+
+  it("caches content-hashed immutable assets for a year", async () => {
+    const res = await appWith(ENABLED).request(findCssAsset(), {
+      headers: { Authorization: CRED },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+  });
 });

--- a/apps/gateway/src/routes/admin-static.ts
+++ b/apps/gateway/src/routes/admin-static.ts
@@ -1,5 +1,5 @@
 import { serveStatic } from "@hono/node-server/serve-static";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { type AdminAuthConfig, basicAuth } from "../middleware/basic-auth.js";
 
 // admin.static-serve — Hono serves the admin SPA's static build at /admin
@@ -36,13 +36,46 @@ function stripAdminPrefix(path: string): string {
   return rest === "" ? "/" : rest;
 }
 
+// Cache policy for the admin SPA — the missing piece that made a deploy "not take"
+// in an already-open browser:
+//   • /admin/_app/immutable/** are content-hashed build artifacts: a given URL's
+//     bytes never change (the hash IS the content), so cache them for a year as
+//     `immutable` — the browser never even revalidates them.
+//   • Everything else — crucially index.html, the SPA *shell* that hard-codes the
+//     current build's hashed chunk URLs — MUST be revalidated on every load. By
+//     default serveStatic emits only Last-Modified (no Cache-Control), so the
+//     browser applies heuristic freshness and keeps replaying the OLD shell across
+//     a deploy → it points at the previous build's chunks → the UI looks unchanged
+//     until a manual hard-refresh. `no-cache` ("store, but always revalidate")
+//     keeps the cheap 304 when nothing changed, yet picks up a new shell — and thus
+//     the new chunks — the instant we ship.
+//
+// MUST run as middleware BEFORE serveStatic, not via its `onFound` hook:
+// @hono/node-server's serveStatic fires `onFound` AFTER it has already built the
+// response with `c.body(...)`, so a `c.header()` there never lands on the response.
+// Setting it in a pre-pass (while `c.res` is still unset) buffers the header into
+// `c.#headers`, which c.body() then merges — so it actually ships.
+function setSpaCacheHeaders(c: Context): void {
+  if (c.req.path.includes("/_app/immutable/")) {
+    c.header("Cache-Control", "public, max-age=31536000, immutable");
+  } else {
+    c.header("Cache-Control", "no-cache");
+  }
+}
+
 export function mountAdminStatic(auth: AdminAuthConfig): Hono {
   const admin = new Hono();
 
   // 1) The whole /admin goes through Basic first (foremost): unauthenticated -> 401 + WWW-Authenticate, no content leaked.
   admin.use("*", basicAuth(auth));
 
-  // 2) Real file hit (/admin/_app/..., .js/.css) -> serve that file directly with the correct MIME.
+  // 2) Cache policy, set BEFORE the static handlers build the body (see setSpaCacheHeaders).
+  admin.use("/*", async (c, next) => {
+    setSpaCacheHeaders(c);
+    await next();
+  });
+
+  // 3) Real file hit (/admin/_app/..., .js/.css) -> serve that file directly with the correct MIME.
   admin.use(
     "/*",
     serveStatic({
@@ -51,7 +84,7 @@ export function mountAdminStatic(auth: AdminAuthConfig): Hono {
     }),
   );
 
-  // 3) SPA fallback: non-API routes with no physical file -> fall back to index.html (frontend router takes over).
+  // 4) SPA fallback: non-API routes with no physical file -> fall back to index.html (frontend router takes over).
   //    `/admin/api/*` is let through, to avoid swallowing API endpoints.
   admin.get("*", (c, next) => {
     if (c.req.path.startsWith("/admin/api/")) return next();


### PR DESCRIPTION
## What

The gateway served the admin SPA shell (`index.html`) with **no `Cache-Control`** — only `Last-Modified`. Browsers then apply *heuristic freshness* and keep replaying the **old** shell across a deploy. The stale shell hard-codes the **previous** build's content-hashed JS chunk URLs, so the UI looks unchanged until a manual hard-refresh.

This is exactly what made the chart-number-format fix (v0.12.5) appear "not deployed" — the code **was** live (verified by reading the deployed DOM: Y-axis `0 / 5M / 10M / 15M`, tooltip `输入 3.8M`), but an already-open browser kept loading the pre-fix chunk.

## Fix

A pre-pass middleware sets `Cache-Control` **before** the static handlers build the body:

| Path | Header | Why |
|------|--------|-----|
| `index.html` / SPA fallbacks | `no-cache` | store but **revalidate every load** → cheap 304 when unchanged, picks up a new shell (and thus new chunks) the instant we ship |
| `/_app/immutable/**` | `public, max-age=31536000, immutable` | the hash **is** the content → safe to cache for a year, never revalidated |

### Why middleware, not `serveStatic`'s `onFound`
`@hono/node-server`'s `serveStatic` fires `onFound` **after** it has already built the response with `c.body(...)`, so a `c.header()` there never lands. Setting it in a pre-pass (while `c.res` is still unset) buffers the header into `c`'s header map, which `c.body()` then merges.

## Tests

+3 cases (11/11 pass): `no-cache` on the shell + on a deep-link fallback, and the 1-year `immutable` header on a hashed asset. Existing 8 contract cases untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)