### PR TITLE
chore(release): v0.12.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.12.6.

Patch bump carrying the four commits merged since v0.12.5:

- **fix(admin): cache-control so a deploy takes effect in an open browser** (#226) — admin SPA shell now served with `no-cache` (revalidate every load), hashed `/_app/immutable/**` with 1-year `immutable`. Fixes the 'deploy didn't change anything' symptom where an open browser kept replaying the old build.
- **feat: provider protocol fast-path 前置元数据** (#218) — internal provider-execution metadata fast-path; no new client route/lane.
- **fix: 三协议互译保真缺口** (#222) + **fix: Anthropic 互译多模态与 thinking 保真** (#221) — protocol-interop fidelity (multimodal + thinking passthrough).

No gateway/core/config/infra config changes — `git diff v0.12.5..main -- config/ docker-compose* Dockerfile*` is empty.

On merge, publish.yml auto-cuts tag `v0.12.6` + GitHub Release + GHCR `:0.12.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)