### PR TITLE
chore(release): v0.12.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.12.7**.

Bumps the root `package.json` so `publish.yml` cuts the `v0.12.7` tag + GitHub Release and pushes `ghcr.io/easymetaau/helm-api:0.12.7` (and `:latest`) on merge to main.

### Included since v0.12.6
- **#232** feat(settings): default native protocol passthrough ON + admin toggle — `native_protocol_passthrough` now defaults to `true`, with a visible「协议直通 / Protocol passthrough」toggle on the System Settings page. Same-protocol traffic (Anthropic → Anthropic, Codex → Responses) forwards verbatim for higher fidelity + better cache reuse; OpenAI-SDK `model=<lane>`, cross-protocol, and heterogeneous fallback chains still translate.

> ⚠️ Deploy note: a box with a persisted `runtime_settings` row that explicitly stored `native_protocol_passthrough: false` keeps that value after upgrade (the overlay wins over the new default) — toggle it ON in admin post-deploy if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)