### PR TITLE
chore(release): v0.12.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Cut release **v0.12.8** for the 4-protocol review fixes merged in #234.

Bumps root `package.json` 0.12.7 → 0.12.8. On merge, `publish.yml` auto-builds
`ghcr.io/easymetaau/helm-api:0.12.8` + `:latest` and cuts the `v0.12.8` tag + GitHub
Release (auto notes).

## What's in this release (#234)

**Functional bug fixes (TDD red→green):**
- STREAM-01 — accumulate `cache_creation_input_tokens` in Anthropic stream→IR (billing accuracy)
- GEM-05 — emit generated `message.images`/`audio` in the Gemini response builder
- MULTI-01 — stop collapsing multimodal tool-results to text en route to Gemini
- RESP-01 — fold Responses `input_audio` into an IR audio part
- ANT-02 — canonicalize Anthropic inbound `tool_choice` to IR
- GEM-02 — route remote `audio/*` `fileData` as audio modality, not document
- PT-08 — keep `response.id` self-consistent on Responses stream passthrough

**Stale comment corrections:** MEM-08/09/10/11 (trailing `<system-reminder>` model), PT-07 (passthrough default ON).

No `config/` touched. `implementation-notes.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)