### PR TITLE
Fix Responses passthrough accounting

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1,6 +1,6 @@
 import type { CircuitBreaker, ExecutionPlan, ProviderClient, ProviderRegistry } from "@helm/core";
 import { createCircuitBreaker, UpstreamError } from "@helm/core";
-import type { CatalogEntry, InternalRequest } from "@helm/shared";
+import type { CatalogEntry, InternalRequest, TargetProviderProtocol } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import { createExecute, detectRequestModalities } from "./execute.js";
 
@@ -1290,7 +1290,7 @@ describe("createExecute — native protocol passthrough (#217)", () => {
   function protocolRegistry(
     map: Record<
       string,
-      { providerName: string; providerModel: string; targetProviderProtocol: string }
+      { providerName: string; providerModel: string; targetProviderProtocol: TargetProviderProtocol }
     >,
   ): ProviderRegistry {
     return {
@@ -1305,9 +1305,7 @@ describe("createExecute — native protocol passthrough (#217)", () => {
             providerModel: hit.providerModel,
             baseUrl: "http://x",
             apiKeyEnv: "X",
-            targetProviderProtocol: hit.targetProviderProtocol as
-              | "openai_chat"
-              | "anthropic_messages",
+            targetProviderProtocol: hit.targetProviderProtocol,
             providerRequiresCompatibilityRewrite: false,
           },
         };
@@ -1638,6 +1636,80 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(out.final.status).toBe("ok");
     expect(out.nativePassthrough).toBe(true);
     expect(out.attempts[0]?.cost_usd).toBeCloseTo(0.0075, 12);
+  });
+
+  it("prices native Responses passthrough with Responses cache details", async () => {
+    const responsesBody = {
+      id: "resp_1",
+      object: "response",
+      status: "completed",
+      output: [
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+      ],
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        input_tokens_details: { cached_tokens: 600, cache_creation_input_tokens: 100 },
+      },
+    };
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["codex", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "codex",
+          providerModel: "gpt-5-codex",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map([
+        [
+          "r",
+          {
+            modelKey: "r",
+            capabilities: {
+              supportsTools: true,
+              supportsJsonMode: true,
+              supportsVision: true,
+              supportsStreaming: true,
+              maxContextTokens: 200000,
+              maxOutputTokens: 8192,
+            },
+            pricing: {
+              inputPerMTokUsd: 10,
+              outputPerMTokUsd: 20,
+              cacheReadPerMTokUsd: 1,
+              cacheWritePerMTokUsd: 5,
+            },
+            source: "generated",
+          } satisfies CatalogEntry,
+        ],
+      ]),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["r"]),
+      req({
+        protocol: "openai_responses",
+        native_request: { model: "codex/gpt-5-codex", input: "hi" },
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    expect(out.nativePassthrough).toBe(true);
+    expect(provider.nativePassthrough.mock.calls[0]?.[0]).toMatchObject({ model: "gpt-5-codex" });
+    // Responses input_tokens already include cache tokens: regular=300, cached=600,
+    // cache write=100, output=500 => 0.003 + 0.0006 + 0.0005 + 0.01 = 0.0141.
+    expect(out.attempts[0]?.cost_usd).toBeCloseTo(0.0141, 12);
   });
 
   it("flag ON but provider has NO nativePassthrough → translates, reason provider_lacks_passthrough", async () => {

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1290,7 +1290,11 @@ describe("createExecute — native protocol passthrough (#217)", () => {
   function protocolRegistry(
     map: Record<
       string,
-      { providerName: string; providerModel: string; targetProviderProtocol: TargetProviderProtocol }
+      {
+        providerName: string;
+        providerModel: string;
+        targetProviderProtocol: TargetProviderProtocol;
+      }
     >,
   ): ProviderRegistry {
     return {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -21,7 +21,7 @@ import type {
   TargetProviderProtocol,
 } from "@helm/shared";
 import { makeHelmError } from "@helm/shared";
-import { usageFromAnthropicResponse } from "./payload-capture.js";
+import { usageFromAnthropicResponse, usageFromResponsesResponse } from "./payload-capture.js";
 
 // Gateway execution adapter — the `execute` injected into routeRequest. It walks
 // the resolved candidate chain (ExecutionPlan.candidate_chain) honoring the
@@ -653,7 +653,10 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // alias. Everything else verbatim. Mirrors stripInternal's `model: providerModel`.
           const body = await passthroughInvoke({ ...nativeBody, model: providerModel }, { signal });
           breaker.recordSuccess(alias);
-          const usage = usageFromAnthropicResponse(body);
+          const usage =
+            req.protocol === "openai_responses"
+              ? usageFromResponsesResponse(body)
+              : usageFromAnthropicResponse(body);
           const pricedBody = usage ? { ...body, usage } : body;
           attempts.push(okRow(alias, elapsed(), costOf(alias, pricedBody), passthrough));
           return {

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -78,6 +78,28 @@ describe("responsesTransformer — input_audio content (RESP-01)", () => {
     const parts = Array.isArray(userMsg?.content) ? userMsg?.content : [];
     expect(parts).toContainEqual({ type: "audio", data: "AUDIO64", format: "mp3" });
   });
+
+  it("renders an IR audio part back to native Responses input_audio", async () => {
+    const native = (await responsesTransformer.transformRequestIn({
+      model: "gpt-4o-audio",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "transcribe this" },
+            { type: "audio", data: "AUDIO64", format: "mp3" },
+          ],
+        },
+      ],
+    } as IRRequest)) as {
+      input: Array<{ content?: Array<Record<string, unknown>> }>;
+    };
+
+    expect(native.input[0]?.content).toContainEqual({
+      type: "input_audio",
+      input_audio: { data: "AUDIO64", format: "mp3" },
+    });
+  });
 });
 
 describe("responsesTransformer — function tool canonicalization", () => {

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -666,9 +666,10 @@ function contentToFunctionCallOutput(
 }
 
 // IR content -> Responses content parts, PRESERVING multimodality (order 25): text ->
-// input_text/output_text, image -> input_image, document -> input_file. Collapsing to
-// a single text part dropped images/files silently. audio/video/thinking have no
-// Responses input surface and are omitted (text already carries the prompt).
+// input_text/output_text, image -> input_image, audio -> input_audio, document ->
+// input_file. Collapsing to a single text part dropped media silently. video/thinking
+// have no Responses input surface and are omitted (text already carries the prompt;
+// response-side thinking renders as reasoning items elsewhere).
 function contentToResponsesParts(
   content: IRMessage["content"],
   isAssistant: boolean,
@@ -684,6 +685,11 @@ function contentToResponsesParts(
         type: "input_image",
         image_url: p.url,
         ...(p.detail !== undefined ? { detail: p.detail } : {}),
+      });
+    } else if (p.type === "audio") {
+      parts.push({
+        type: "input_audio",
+        input_audio: { data: p.data, format: p.format },
       });
     } else if (p.type === "document") {
       const name = p.filename !== undefined ? { filename: p.filename } : {};


### PR DESCRIPTION
## Summary
- normalize native Responses passthrough usage with the Responses parser so cached token pricing is preserved
- render IR audio parts back to native Responses `input_audio`
- add regression coverage for cached Responses passthrough cost and Responses audio request round-trip

## Verification
- `pnpm test -- apps/gateway/src/routes/execute.test.ts packages/core/src/protocol/responses.test.ts`
- `pnpm typecheck`