### PR TITLE
fix(memory): occurrence-count window dedup, exclude system/developer turns

### DIFF
--- a/packages/core/src/memory/inject-bridge.test.ts
+++ b/packages/core/src/memory/inject-bridge.test.ts
@@ -8,9 +8,9 @@ import { serializeContent } from "./observe.js";
 // bridge that wires the inject assembler onto the IR message array shared by all three
 // request surfaces (chat / messages / responses). Under the trailing-reminder model the
 // bridge:
-//   1. computes the current request's live-window content_hashes (the SAME way
-//      storage hashes a message) and hands them to the assembler for window-aware
-//      dedup;
+//   1. computes the current request's live-window content_hash occurrence counts
+//      (the SAME way storage hashes a message) and hands them to the assembler for
+//      window-aware dedup;
 //   2. keeps the live conversation VERBATIM (tool_calls / images / tool results /
 //      developer turns are never destroyed — there is no D7 plain-text gate);
 //   3. APPENDS the assembled memory TEXT BLOCK as ONE trailing `<system-reminder>`
@@ -145,7 +145,7 @@ describe("injectIntoIR — trailing-reminder model", () => {
     expect(result.messages.at(-1)).toEqual({ role: "user", content: wrapMemoryReminder(BLOCK) });
   });
 
-  it("passes the live-window content_hashes (storage-equivalent) to the assembler", async () => {
+  it("passes live-window content_hash occurrence counts (storage-equivalent) to the assembler", async () => {
     const assemble = vi.fn<InjectBridgeDeps["assemble"]>(async () => ({
       memoryBlock: BLOCK,
       metadata: {
@@ -169,11 +169,70 @@ describe("injectIntoIR — trailing-reminder model", () => {
     const input = assemble.mock.calls[0]?.[0];
     expect(input?.tokenBudget).toBe(4000);
     expect(input?.scope).toEqual(SCOPE);
-    const hashes = input?.windowContentHashes;
-    expect(hashes).toBeInstanceOf(Set);
+    const counts = input?.windowContentHashCounts;
+    expect(counts).toBeInstanceOf(Map);
     // Hashes match storage's sha256Hex(serializeContent(content)).
-    expect(hashes?.has(hashOf("hi there"))).toBe(true);
-    expect(hashes?.has(hashOf("hello"))).toBe(true);
+    expect(counts?.get(hashOf("hi there"))).toBe(1);
+    expect(counts?.get(hashOf("hello"))).toBe(1);
+  });
+
+  it("counts repeated live-window content occurrences instead of collapsing them", async () => {
+    const assemble = vi.fn<InjectBridgeDeps["assemble"]>(async () => ({
+      memoryBlock: BLOCK,
+      metadata: {
+        memory_hydrated: true,
+        reflection_version: 1,
+        observation_count: 0,
+        memory_tokens_injected: 10,
+        observer_job_id: "job-1",
+        memory_writeback_status: "queued" as const,
+        degraded: false,
+      },
+    }));
+    const deps = makeDeps(BLOCK, { assemble });
+    await injectIntoIR(
+      [
+        { role: "user", content: "yes" },
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "yes" },
+      ],
+      "",
+      SCOPE,
+      deps,
+    );
+
+    const counts = assemble.mock.calls[0]?.[0]?.windowContentHashCounts;
+    expect(counts?.get(hashOf("yes"))).toBe(2);
+    expect(counts?.get(hashOf("ok"))).toBe(1);
+  });
+
+  it("does not count system/developer turns in the live-window dedup view", async () => {
+    const assemble = vi.fn<InjectBridgeDeps["assemble"]>(async () => ({
+      memoryBlock: BLOCK,
+      metadata: {
+        memory_hydrated: true,
+        reflection_version: 1,
+        observation_count: 0,
+        memory_tokens_injected: 10,
+        observer_job_id: "job-1",
+        memory_writeback_status: "queued" as const,
+        degraded: false,
+      },
+    }));
+    const deps = makeDeps(BLOCK, { assemble });
+    await injectIntoIR(
+      [
+        { role: "system", content: "same" },
+        { role: "developer", content: "same" },
+        { role: "user", content: "same" },
+      ],
+      "same",
+      SCOPE,
+      deps,
+    );
+
+    const counts = assemble.mock.calls[0]?.[0]?.windowContentHashCounts;
+    expect(counts?.get(hashOf("same"))).toBe(1);
   });
 
   it("window-hashes a MULTIPART message via serializeContent (JSON-stringified)", async () => {
@@ -196,8 +255,8 @@ describe("injectIntoIR — trailing-reminder model", () => {
     };
     await injectIntoIR([multipart], "", SCOPE, deps);
 
-    const hashes = assemble.mock.calls[0]?.[0]?.windowContentHashes;
-    expect(hashes?.has(hashOf([{ type: "text", text: "now" }]))).toBe(true);
+    const counts = assemble.mock.calls[0]?.[0]?.windowContentHashCounts;
+    expect(counts?.get(hashOf([{ type: "text", text: "now" }]))).toBe(1);
   });
 
   it("no-memory: null block → messages UNCHANGED (same array) and block null", async () => {

--- a/packages/core/src/memory/inject-bridge.ts
+++ b/packages/core/src/memory/inject-bridge.ts
@@ -75,20 +75,22 @@ export interface InjectBridgeResult {
   metadata: InjectResult["metadata"] | null;
 }
 
-// Fingerprint the current request's live messages as the dedup WINDOW. Each hash is
-// sha256Hex(serializeContent(content)) — byte-identical to how observe.ts persisted
-// the turn's content_hash — so a stored thread observation whose covered turns are
-// all still in this window is recognized as redundant by the assembler (the client
-// re-sends them verbatim; injecting the summary too would duplicate). Roles that
-// storage drops (system/developer) are still hashed; extra entries are harmless
-// (they can only collide with genuinely identical content) and keep this a pure,
-// allocation-cheap projection of the request.
-function windowContentHashes(messages: IRMessage[]): Set<string> {
-  const hashes = new Set<string>();
+// Fingerprint the current request's persisted live messages as the dedup WINDOW.
+// Each hash is sha256Hex(serializeContent(content)) — byte-identical to how
+// observe.ts persisted the turn's content_hash — so a stored thread observation
+// whose covered turns are all still in this window is recognized as redundant by
+// the assembler (the client re-sends them verbatim; injecting the summary too
+// would duplicate). Occurrence counts matter: one live "yes" cannot satisfy two
+// historical "yes" turns. Only storage-persisted roles are counted; system/
+// developer policy text must never suppress user-memory recall.
+function windowContentHashCounts(messages: IRMessage[]): Map<string, number> {
+  const counts = new Map<string, number>();
   for (const m of messages) {
-    hashes.add(sha256Hex(serializeContent(m.content)));
+    if (m.role !== "user" && m.role !== "assistant" && m.role !== "tool") continue;
+    const hash = sha256Hex(serializeContent(m.content));
+    counts.set(hash, (counts.get(hash) ?? 0) + 1);
   }
-  return hashes;
+  return counts;
 }
 
 // Wrap the assembled memory block in a `<system-reminder>` envelope — the single
@@ -140,7 +142,7 @@ export async function injectIntoIR(
     const result = await deps.assemble({
       scope,
       tokenBudget: deps.tokenBudget,
-      windowContentHashes: windowContentHashes(messages),
+      windowContentHashCounts: windowContentHashCounts(messages),
     });
 
     // Nothing to inject (no memory) or a degraded load: keep the live conversation

--- a/packages/core/src/memory/inject-forgetting.test.ts
+++ b/packages/core/src/memory/inject-forgetting.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./inject.js";
 
 // docs/12 P3 (Access reinforcement) + P4 (score-driven inject trim), under the
-// #217 Phase 4 PREFIX model. The two inject-path forgetting changes are ALL gated
+// #217 Phase 4 trailing-reminder model. The two inject-path forgetting changes are ALL gated
 // behind forgetting.enabled. With the flag off (or absent) the assembler trims
 // observations oldest-first and never reinforces. With the flag on:
 //   P4 — the observation budget trim drops LOWEST-SCORE-first instead of
@@ -116,7 +116,7 @@ function injectedObservationIds(block: string | null, ids: string[]): string[] {
   return ids.filter((id) => block.includes(id));
 }
 
-describe("assembleInjectedContext — forgetting gated (P3 + P4), prefix model", () => {
+describe("assembleInjectedContext — forgetting gated (P3 + P4), trailing-reminder model", () => {
   it("flag OFF (no forgetting dep): legacy oldest-first trim and never bumps", async () => {
     const bumpReferences = vi.fn(async () => {});
     const store = makeFakeStore(

--- a/packages/core/src/memory/inject.test.ts
+++ b/packages/core/src/memory/inject.test.ts
@@ -4,10 +4,10 @@ import type { MemoryStore } from "../store/ports.js";
 import { assembleInjectedContext, type InjectDeps, type InjectInput } from "./inject.js";
 import { sha256Hex } from "./message-hash.js";
 
-// docs/08 Phase 2 (#217 Phase 4) — the inject assembler PREFIX model. The assembler
+// docs/08 Phase 2 (#217 Phase 4) — the inject assembler TRAILING-REMINDER model. The assembler
 // no longer FULL-REPLACES the conversation: it produces ONE system-level memory TEXT
 // BLOCK (reflections + window-deduped thread observations, trimmed to a token
-// budget) which the pipeline PREPENDS to the client's verbatim live conversation.
+// budget) which the pipeline appends after the client's verbatim live conversation.
 // The live messages (tool_calls, images, tool results) are never reassembled here —
 // so the assembler is structure-agnostic and works for every turn type. These tests
 // pin the block FORMAT, the window-aware dedup, the budget trim, the empty/degraded
@@ -125,7 +125,7 @@ function baseInput(over: Partial<InjectInput> = {}): InjectInput {
   };
 }
 
-describe("assembleInjectedContext — memory TEXT BLOCK (prefix model)", () => {
+describe("assembleInjectedContext — memory TEXT BLOCK (trailing-reminder model)", () => {
   it("assembles a single system-level block with section headers in deterministic order", async () => {
     const store = makeFakeStore({
       projectReflection: makeReflection({ projectId: "proj-1", reflectionText: "project memory" }),
@@ -191,7 +191,7 @@ describe("assembleInjectedContext — memory TEXT BLOCK (prefix model)", () => {
     });
     // Even with a non-empty window, reflections are never deduped against it.
     const out = await assembleInjectedContext(
-      baseInput({ windowContentHashes: new Set([sha256Hex("anything")]) }),
+      baseInput({ windowContentHashCounts: new Map([[sha256Hex("anything"), 1]]) }),
       makeDeps(store),
     );
     const block = out.memoryBlock ?? "";
@@ -212,8 +212,69 @@ describe("assembleInjectedContext — memory TEXT BLOCK (prefix model)", () => {
     ]);
     const store = makeFakeStore({ observations: [obs], threadMessages });
 
-    const windowContentHashes = new Set([sha256Hex("turn one"), sha256Hex("reply one")]);
-    const out = await assembleInjectedContext(baseInput({ windowContentHashes }), makeDeps(store));
+    const windowContentHashCounts = new Map([
+      [sha256Hex("turn one"), 1],
+      [sha256Hex("reply one"), 1],
+    ]);
+    const out = await assembleInjectedContext(
+      baseInput({ windowContentHashCounts }),
+      makeDeps(store),
+    );
+
+    expect(out.memoryBlock).toBeNull();
+    expect(out.metadata.observation_count).toBe(0);
+  });
+
+  it("INCLUDES an observation when repeated covered content appears fewer times in the live window", async () => {
+    const threadMessages = [
+      makeRaw("r1", "user", "yes"),
+      makeRaw("r2", "assistant", "ok"),
+      makeRaw("r3", "user", "yes"),
+    ];
+    const obs = makeObservation("o1", "compressed repeated yes turns", "2026-05-30T00:00:00.000Z", [
+      "r1",
+      "r3",
+    ]);
+    const store = makeFakeStore({ observations: [obs], threadMessages });
+
+    // The range r1..r3 covers both "yes" turns AND the "ok" turn between them.
+    // The client kept "ok" and only ONE "yes" occurrence. The observation still
+    // recalls the other "yes", so a set-based hash check would wrongly suppress it.
+    const windowContentHashCounts = new Map([
+      [sha256Hex("yes"), 1],
+      [sha256Hex("ok"), 1],
+    ]);
+    const out = await assembleInjectedContext(
+      baseInput({ windowContentHashCounts }),
+      makeDeps(store),
+    );
+
+    expect(out.memoryBlock ?? "").toContain("compressed repeated yes turns");
+    expect(out.metadata.observation_count).toBe(1);
+  });
+
+  it("SKIPS an observation when repeated covered content appears enough times in the live window", async () => {
+    const threadMessages = [
+      makeRaw("r1", "user", "yes"),
+      makeRaw("r2", "assistant", "ok"),
+      makeRaw("r3", "user", "yes"),
+    ];
+    const obs = makeObservation("o1", "compressed repeated yes turns", "2026-05-30T00:00:00.000Z", [
+      "r1",
+      "r3",
+    ]);
+    const store = makeFakeStore({ observations: [obs], threadMessages });
+
+    // Every covered turn (both "yes" + the "ok" between them) is still present in
+    // the window with sufficient count → the observation is fully redundant.
+    const windowContentHashCounts = new Map([
+      [sha256Hex("yes"), 2],
+      [sha256Hex("ok"), 1],
+    ]);
+    const out = await assembleInjectedContext(
+      baseInput({ windowContentHashCounts }),
+      makeDeps(store),
+    );
 
     expect(out.memoryBlock).toBeNull();
     expect(out.metadata.observation_count).toBe(0);
@@ -231,8 +292,11 @@ describe("assembleInjectedContext — memory TEXT BLOCK (prefix model)", () => {
     const store = makeFakeStore({ observations: [obs], threadMessages });
 
     // The window holds NONE of the covered turns → the observation must be injected.
-    const windowContentHashes = new Set([sha256Hex("a brand new turn")]);
-    const out = await assembleInjectedContext(baseInput({ windowContentHashes }), makeDeps(store));
+    const windowContentHashCounts = new Map([[sha256Hex("a brand new turn"), 1]]);
+    const out = await assembleInjectedContext(
+      baseInput({ windowContentHashCounts }),
+      makeDeps(store),
+    );
 
     const block = out.memoryBlock ?? "";
     expect(block).toContain("compressed dropped turns");
@@ -248,8 +312,11 @@ describe("assembleInjectedContext — memory TEXT BLOCK (prefix model)", () => {
     const store = makeFakeStore({ observations: [obs], threadMessages });
 
     // Only r1 is in the window; r2 was dropped → not ALL covered → must include.
-    const windowContentHashes = new Set([sha256Hex("still in window")]);
-    const out = await assembleInjectedContext(baseInput({ windowContentHashes }), makeDeps(store));
+    const windowContentHashCounts = new Map([[sha256Hex("still in window"), 1]]);
+    const out = await assembleInjectedContext(
+      baseInput({ windowContentHashCounts }),
+      makeDeps(store),
+    );
 
     expect(out.memoryBlock ?? "").toContain("covers r1..r2");
     expect(out.metadata.observation_count).toBe(1);
@@ -310,7 +377,7 @@ describe("assembleInjectedContext — memory TEXT BLOCK (prefix model)", () => {
 
   it("produces a valid block for a TOOL / MULTIMODAL current turn (no plain-text restriction in the assembler)", async () => {
     // The assembler is window-hash + memory only; it never inspects the live turn's
-    // structure. A window containing tool/multipart hashes is just opaque strings.
+    // structure. A window containing tool/multipart hash counts is just opaque data.
     const store = makeFakeStore({
       projectReflection: makeReflection({
         projectId: "proj-1",
@@ -324,8 +391,11 @@ describe("assembleInjectedContext — memory TEXT BLOCK (prefix model)", () => {
         makeRaw("y", "tool", "tool out"),
       ],
     });
-    const windowContentHashes = new Set([sha256Hex('[{"type":"text","text":"now"}]')]);
-    const out = await assembleInjectedContext(baseInput({ windowContentHashes }), makeDeps(store));
+    const windowContentHashCounts = new Map([[sha256Hex('[{"type":"text","text":"now"}]'), 1]]);
+    const out = await assembleInjectedContext(
+      baseInput({ windowContentHashCounts }),
+      makeDeps(store),
+    );
     const block = out.memoryBlock ?? "";
     expect(block).toContain("tool-thread memory");
     expect(block).toContain("earlier tool summary");

--- a/packages/core/src/memory/inject.ts
+++ b/packages/core/src/memory/inject.ts
@@ -37,14 +37,16 @@ export interface InjectInput {
   // Upper bound for INJECTED memory tokens (the assembled block). Reflections are
   // kept first; observations get whatever remains and are trimmed under pressure.
   tokenBudget: number;
-  // WINDOW-AWARE DEDUP (#217 Phase 4). content_hashes of the current request's live
-  // messages — the client's live window. Computed the SAME way storage hashes a
-  // message (sha256Hex(serializeContent(content))) so they match
-  // memory_messages.content_hash. A thread observation whose covered turns are ALL
-  // in this set is SKIPPED (the client still sends them verbatim — injecting the
-  // summary too would duplicate). ABSENT/empty ⇒ no observation is deduped (every
-  // active observation is considered) — so a caller that has no window still works.
-  windowContentHashes?: Set<string>;
+  // WINDOW-AWARE DEDUP (#217 Phase 4). Occurrence counts of content_hashes in the
+  // current request's live messages — the client's live window. Computed the SAME
+  // way storage hashes a message (sha256Hex(serializeContent(content))) so they
+  // match memory_messages.content_hash. A thread observation whose covered turns
+  // are ALL still present in this counted window is SKIPPED (the client still
+  // sends them verbatim — injecting the summary too would duplicate). Counts matter:
+  // two historical "yes" turns require two live "yes" turns, not just one matching
+  // hash. ABSENT/empty ⇒ no observation is deduped (every active observation is
+  // considered) — so a caller that has no window still works.
+  windowContentHashCounts?: Map<string, number>;
 }
 
 // docs/12 P3 + P4 — the OPTIONAL forgetting wiring inject receives. Defaulting to
@@ -216,15 +218,20 @@ function latestReflectionVersion(
 function observationIsRedundant(
   observation: Observation,
   threadMessages: RawMessage[],
-  windowContentHashes: Set<string>,
+  windowContentHashCounts: Map<string, number>,
 ): boolean {
-  if (windowContentHashes.size === 0) return false;
+  if (windowContentHashCounts.size === 0) return false;
   const coveredIds = alreadyObservedMessageIds(threadMessages, [observation.sourceMessageRange]);
   if (coveredIds.size === 0) return false; // unresolved range → keep (don't lose recall)
+  const required = new Map<string, number>();
   for (const message of threadMessages) {
     if (!coveredIds.has(message.id)) continue;
-    // A covered turn the client no longer sends ⇒ the observation still recalls it.
-    if (!windowContentHashes.has(sha256Hex(message.content))) return false;
+    const hash = sha256Hex(message.content);
+    required.set(hash, (required.get(hash) ?? 0) + 1);
+  }
+  for (const [hash, count] of required) {
+    // A covered turn occurrence the client no longer sends ⇒ the observation still recalls it.
+    if ((windowContentHashCounts.get(hash) ?? 0) < count) return false;
   }
   return true; // every covered turn is still in the window → redundant
 }
@@ -265,7 +272,7 @@ export async function assembleInjectedContext(
 
   const { projectReflection, resourceReflection, observations, threadMessages } = loaded;
   const forgettingOn = deps.forgetting?.enabled === true;
-  const windowContentHashes = input.windowContentHashes ?? new Set<string>();
+  const windowContentHashCounts = input.windowContentHashCounts ?? new Map<string, number>();
 
   // docs/12 (P4/P7) — archived (decay), pruned (retention tombstone), and expired
   // rows are INVISIBLE to injection: a forgotten observation must never ride the
@@ -280,7 +287,7 @@ export async function assembleInjectedContext(
   // sends. Done BEFORE the budget trim so the budget is spent only on observations
   // that actually add recall (not duplicates of live turns).
   const relevantObservations = visibleObservations.filter(
-    (o) => !observationIsRedundant(o, threadMessages, windowContentHashes),
+    (o) => !observationIsRedundant(o, threadMessages, windowContentHashCounts),
   );
 
   // Observations are sorted oldest-first so the budget trimmer can drop the oldest

--- a/packages/core/src/memory/memory-loop.test.ts
+++ b/packages/core/src/memory/memory-loop.test.ts
@@ -120,8 +120,8 @@ describe("memory background loop (observer → reflector → inject)", () => {
     expect(reflection?.version).toBe(1);
 
     // And the NEXT inject request for the same scope hydrates it into the memory
-    // TEXT BLOCK (#217 Phase 4 PREFIX model — the block is prepended at the system
-    // level; the live conversation is kept verbatim by the pipeline, never here).
+    // TEXT BLOCK (#217 Phase 4 trailing-reminder model — the pipeline appends the
+    // block after the live conversation; the assembler never rebuilds messages).
     const result = await assembleInjectedContext(
       {
         scope: SCOPE,


### PR DESCRIPTION
## Summary

Window-aware inject dedup (#217 Phase 4) fingerprinted the live request into a `Set<string>` of content hashes. Two bugs followed:

1. **Repeated turns collapsed.** A set can't represent "two identical turns", so one live `"yes"` was treated as satisfying two historical `"yes"` turns — and a still-relevant thread observation got wrongly suppressed.
2. **System/developer turns counted.** The fingerprint hashed every role, so system/developer policy text could match an observation's covered turns and suppress genuine user-memory recall.

## Changes

- Bridge fingerprint is now a `Map<string, number>` of `content_hash` **occurrence counts** (`windowContentHashCounts`), counting only storage-persisted roles (`user`/`assistant`/`tool`) — byte-identical to how `observe.ts` persists `content_hash`.
- `observationIsRedundant` tallies the covered turns' required hash counts and keeps the observation unless the live window holds each hash **at least that many times**.
- Corrected stale `"PREFIX model"` comments to `"trailing-reminder model"` to match the shipped pipeline (memory block appended after the verbatim live conversation, not prepended).

## Tests

- New cases pin the occurrence-count semantics: repeated covered content is included when it appears fewer times in the window, skipped when it appears enough times; system/developer turns are excluded from the dedup view.
- `pnpm lint`, `pnpm typecheck`, and the full `packages/core/src/memory` suite (201 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)