### PR TITLE
feat(protocol): harden native passthrough fidelity

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1716,6 +1716,62 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(out.attempts[0]?.cost_usd).toBeCloseTo(0.0141, 12);
   });
 
+  it("records model/store mutations on an OpenAI Responses native carrier", async () => {
+    const responsesBody = {
+      id: "resp_1",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["codex", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "codex",
+          providerModel: "gpt-5-codex",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body: { model: "codex/gpt-5-codex", input: "hi", store: true },
+      raw_body: '{"model":"codex/gpt-5-codex","input":"hi","store":true}',
+      headers: { authorization: "Bearer client" },
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["r"]),
+      req({
+        protocol: "openai_responses",
+        native_request: carrier,
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body).toEqual({ model: "gpt-5-codex", input: "hi", store: false });
+    expect(forwarded.raw_body).toBeUndefined();
+    expect(forwarded.mutations).toMatchObject({
+      model_rewritten: { from: "codex/gpt-5-codex", to: "gpt-5-codex" },
+      body_shims_applied: ["store_forced_false"],
+    });
+    expect(out.attempts[0]?.passthrough_mutations).toMatchObject(forwarded.mutations);
+  });
+
   it("flag ON but provider has NO nativePassthrough → translates, reason provider_lacks_passthrough", async () => {
     const provider = {
       chatCompletion: vi.fn().mockResolvedValue({ id: "translated" }),
@@ -1868,6 +1924,50 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(okRow?.cost_usd).toBeNull();
     expect(okRow?.source_protocol).toBe("anthropic_messages");
     expect(okRow?.target_provider_protocol).toBe("anthropic_messages");
+  });
+
+  it("records model rewrite + stream reframing mutations on a native stream carrier", async () => {
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(gen(SSE)),
+    } as unknown as ProviderClient & {
+      nativePassthroughStream: ReturnType<typeof vi.fn>;
+    };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["anthro", provider]]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "anthropic_messages" as const,
+      body: { ...NATIVE_STREAM },
+      raw_body: JSON.stringify(NATIVE_STREAM),
+      headers: { "x-api-key": "client" },
+      mutations: {},
+    };
+
+    const out = await execute(plan(["a"]), anthropicStreamReq({ native_request: carrier }));
+
+    const forwarded = provider.nativePassthroughStream.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body).toEqual({ ...NATIVE_STREAM, model: "claude-x" });
+    expect(forwarded.mutations).toMatchObject({
+      model_rewritten: { from: "anthropic/claude-x", to: "claude-x" },
+      stream_reframed: true,
+    });
+    expect(out.attempts[0]?.passthrough_mutations).toMatchObject(forwarded.mutations);
   });
 
   it("flag OFF + stream → chatCompletionStream(stripInternal) translate path, passthrough_used:false, nativePassthrough absent", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -17,10 +17,18 @@ import type {
   AttemptErrorDetail,
   CatalogEntry,
   InternalRequest,
+  NativePassthroughCarrier,
   Protocol,
   TargetProviderProtocol,
 } from "@helm/shared";
-import { makeHelmError } from "@helm/shared";
+import {
+  appendMutationList,
+  cloneCarrierWithBody,
+  isNativePassthroughCarrier,
+  makeHelmError,
+  nativePassthroughBody,
+  nativePassthroughMutations,
+} from "@helm/shared";
 import { usageFromAnthropicResponse, usageFromResponsesResponse } from "./payload-capture.js";
 
 // Gateway execution adapter — the `execute` injected into routeRequest. It walks
@@ -119,6 +127,7 @@ interface PassthroughTelemetry {
   response_protocol: Protocol | null;
   provider_name: string | null;
   provider_model: string | null;
+  passthrough_mutations?: NativePassthroughCarrier["mutations"];
 }
 
 function approxPromptTokens(req: InternalRequest): number {
@@ -358,7 +367,51 @@ function decideNativePassthroughForAttempt(input: {
     response_protocol: req.protocol,
     provider_name: target.providerName,
     provider_model: target.providerModel,
+    passthrough_mutations: nativePassthroughMutations(req.native_request as never),
   };
+}
+
+function prepareNativeRequestForUpstream(
+  nativeRequest: InternalRequest["native_request"],
+  providerModel: string,
+  protocol: Protocol,
+  streamReframed: boolean,
+): NativePassthroughCarrier | Record<string, unknown> {
+  if (nativeRequest === undefined) {
+    throw new Error("native passthrough invoked without a native request");
+  }
+  const nativeBody = nativePassthroughBody(nativeRequest);
+  let body = nativeBody;
+  let bodyChanged = false;
+  const carrier = isNativePassthroughCarrier(nativeRequest) ? nativeRequest : null;
+  const mutations = carrier?.mutations;
+
+  if (nativeBody.model !== providerModel) {
+    body = { ...body, model: providerModel };
+    bodyChanged = true;
+    if (mutations) {
+      mutations.model_rewritten = {
+        from: typeof nativeBody.model === "string" ? nativeBody.model : null,
+        to: providerModel,
+      };
+    }
+  }
+
+  if (protocol === "openai_responses" && body.store !== false) {
+    body = { ...body, store: false };
+    bodyChanged = true;
+    if (mutations) {
+      appendMutationList(mutations, "body_shims_applied", ["store_forced_false"]);
+      mutations.provider_profile_applied = "codex_official_safe";
+    }
+  }
+
+  if (streamReframed && mutations) mutations.stream_reframed = true;
+
+  if (carrier === null) return body;
+  return bodyChanged
+    ? cloneCarrierWithBody(carrier, body)
+    : cloneCarrierWithBody(carrier, body, { preserveRawBody: true });
 }
 
 function upstreamStatusOf(err: unknown): number | null {
@@ -595,7 +648,13 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // the client's `model` is the routing alias (e.g. `anthropic/claude-…`), not
           // a real upstream model id. Everything else is forwarded verbatim. Mirrors
           // stripInternal's `model: providerModel`; without it the upstream 404s.
-          const passthroughBody = { ...nativeBody, model: providerModel };
+          const passthroughBody = prepareNativeRequestForUpstream(
+            nativeBody,
+            providerModel,
+            req.protocol,
+            true,
+          );
+          passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
           const stream = await peekStream(
             () => passthroughStream(passthroughBody, { signal }),
             signal,
@@ -651,7 +710,14 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // `model` is the routing alias (e.g. `anthropic/claude-…`), but the gateway
           // picked this upstream model — forward it so the upstream doesn't 404 on the
           // alias. Everything else verbatim. Mirrors stripInternal's `model: providerModel`.
-          const body = await passthroughInvoke({ ...nativeBody, model: providerModel }, { signal });
+          const passthroughBody = prepareNativeRequestForUpstream(
+            nativeBody,
+            providerModel,
+            req.protocol,
+            false,
+          );
+          passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
+          const body = await passthroughInvoke(passthroughBody, { signal });
           breaker.recordSuccess(alias);
           const usage =
             req.protocol === "openai_responses"

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -466,6 +466,37 @@ describe("createMessagesPipeline — native passthrough streamIR()", () => {
     expect((frames[0] as unknown as { type?: unknown }).type).toBeUndefined();
   });
 
+  it("preserves no-data native SSE comment/keepalive frames for the route raw writer", async () => {
+    async function* stream(): AsyncIterable<string> {
+      yield [
+        ": keepalive\r\n\r\n",
+        "event: ping\r\n\r\n",
+        'event: message_start\r\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\r\n\r\n',
+      ].join("");
+    }
+    const route: RouteFn = async () => passthroughStreamResult(stream());
+    const pipeline = createMessagesPipeline(route);
+    const run = await pipeline.run(irOf({ stream: true }), IDENTITY, new AbortController().signal);
+    const frames: Array<{ event: string; data: string; raw?: string; hasData?: boolean }> = [];
+    for await (const ev of run.streamIR()) {
+      frames.push(ev as { event: string; data: string; raw?: string; hasData?: boolean });
+    }
+
+    expect(frames[0]).toMatchObject({
+      event: "",
+      data: "",
+      hasData: false,
+      raw: ": keepalive\r\n\r\n",
+    });
+    expect(frames[1]).toMatchObject({
+      event: "ping",
+      data: "",
+      hasData: false,
+      raw: "event: ping\r\n\r\n",
+    });
+    expect(frames[2]?.raw).toContain("\r\n");
+  });
+
   it("backfills the decision usage from the native SSE (input from message_start, output from message_delta)", async () => {
     const decisionRef = passthroughStreamResult().decision;
     const pipeline = createMessagesPipeline(
@@ -1037,6 +1068,57 @@ describe("createMessagesPipeline — memory inject additive trailing reminder", 
     expect((run as { nativePassthrough?: boolean }).nativePassthrough).toBe(true);
     const body = (await run.collect()) as Record<string, unknown>;
     expect(body).toBe(NATIVE_ANTHROPIC_BODY);
+  });
+
+  it("anthropic passthrough carrier: records memory_appended and invalidates raw_body", async () => {
+    const NATIVE = {
+      model: "claude-x",
+      system: "be terse",
+      messages: [{ role: "user", content: "hi" }],
+    };
+    let seen: InternalRequest | null = null;
+    const route: RouteFn = async (req) => {
+      seen = req;
+      return passthroughOkResult();
+    };
+    const store = injectStore();
+    const pipeline = createMessagesPipeline(route, "anthropic_messages", {
+      observe: makeObserveSpy().observe,
+      inject: injectWiring(store),
+    });
+
+    const run = await pipeline.run(
+      irOf({
+        metadata: {
+          ...INJECT_META,
+          native_request: {
+            protocol: "anthropic_messages",
+            body: NATIVE,
+            raw_body: JSON.stringify(NATIVE),
+            headers: { "content-type": "application/json" },
+            mutations: {},
+          },
+        },
+        messages: [
+          { role: "system", content: "be terse" },
+          { role: "user", content: "hi" },
+        ],
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+    await run.collect();
+
+    const carrier = (seen as InternalRequest | null)?.native_request as
+      | {
+          body?: { messages?: Array<{ role: string; content: string }> };
+          raw_body?: string;
+          mutations?: { memory_appended?: boolean };
+        }
+      | undefined;
+    expect(carrier?.body?.messages?.[1]?.content).toContain("PROJECT MEMORY");
+    expect(carrier?.raw_body).toBeUndefined();
+    expect(carrier?.mutations?.memory_appended).toBe(true);
   });
 
   it("anthropic passthrough: native system ARRAY kept VERBATIM, reminder appended to messages", async () => {

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -477,21 +477,19 @@ describe("createMessagesPipeline — native passthrough streamIR()", () => {
     const route: RouteFn = async () => passthroughStreamResult(stream());
     const pipeline = createMessagesPipeline(route);
     const run = await pipeline.run(irOf({ stream: true }), IDENTITY, new AbortController().signal);
-    const frames: Array<{ event: string; data: string; raw?: string; hasData?: boolean }> = [];
+    const frames: Array<{ event: string; data: string; raw?: string }> = [];
     for await (const ev of run.streamIR()) {
-      frames.push(ev as { event: string; data: string; raw?: string; hasData?: boolean });
+      frames.push(ev as { event: string; data: string; raw?: string });
     }
 
     expect(frames[0]).toMatchObject({
       event: "",
       data: "",
-      hasData: false,
       raw: ": keepalive\r\n\r\n",
     });
     expect(frames[1]).toMatchObject({
       event: "ping",
       data: "",
-      hasData: false,
       raw: "event: ping\r\n\r\n",
     });
     expect(frames[2]?.raw).toContain("\r\n");

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -415,10 +415,8 @@ interface RawSSEFrame {
   event: string;
   /** The verbatim `data:` payload string (the exact upstream JSON), unparsed. */
   data: string;
-  /** Whether this frame had at least one data line; comments/keepalives do not. */
-  hasData: boolean;
-  /** The frame's raw text incl. event/data lines + trailing blank line, for the
-   *  usage tee (usageFromAnthropicSSE scans data lines off this). */
+  /** The frame's raw text incl. event/data lines + trailing blank line. The route's
+   *  raw writer forwards this byte-for-byte; the usage tee scans data lines off it. */
   raw: string;
 }
 
@@ -434,7 +432,7 @@ function parseRawSSEFrame(event: string, raw: string): RawSSEFrame | null {
     }
   }
   // Multi-line data is joined with \n per the SSE spec (both protocols use single-line).
-  return { event: evtName, data: dataLines.join("\n"), hasData: dataLines.length > 0, raw };
+  return { event: evtName, data: dataLines.join("\n"), raw };
 }
 
 function nextSSEBoundary(buffer: string): { index: number; length: number } | null {
@@ -937,7 +935,6 @@ export function createMessagesPipeline(
                   event: frame.event,
                   data: frame.data,
                   raw: frame.raw,
-                  hasData: frame.hasData,
                 };
               }
             } finally {

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -24,6 +24,11 @@ import {
   resolveMemoryMode,
 } from "@helm/core";
 import type { InternalRequest, MemoryDecision, Protocol } from "@helm/shared";
+import {
+  cloneCarrierWithBody,
+  isNativePassthroughCarrier,
+  nativePassthroughBody,
+} from "@helm/shared";
 import type { ServingAccount } from "../runtime/serving-account.js";
 import type { WriteQueue } from "../runtime/write-queue.js";
 import { copyLiteLLMRequestParams, providerRawFromRequest } from "./internal-request-params.js";
@@ -177,7 +182,7 @@ function toInternalRequest(
     ir.metadata?.native_request !== null &&
     typeof ir.metadata?.native_request === "object" &&
     !Array.isArray(ir.metadata.native_request)
-      ? (ir.metadata.native_request as Record<string, unknown>)
+      ? (ir.metadata.native_request as InternalRequest["native_request"])
       : undefined;
 
   return {
@@ -410,42 +415,53 @@ interface RawSSEFrame {
   event: string;
   /** The verbatim `data:` payload string (the exact upstream JSON), unparsed. */
   data: string;
+  /** Whether this frame had at least one data line; comments/keepalives do not. */
+  hasData: boolean;
   /** The frame's raw text incl. event/data lines + trailing blank line, for the
    *  usage tee (usageFromAnthropicSSE scans data lines off this). */
   raw: string;
 }
 
-function parseRawSSEFrame(event: string): RawSSEFrame | null {
+function parseRawSSEFrame(event: string, raw: string): RawSSEFrame | null {
+  if (event.length === 0 && raw.length === 0) return null;
   let evtName = "";
   const dataLines: string[] = [];
-  for (const line of event.split("\n")) {
+  for (const line of event.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n")) {
     if (line.startsWith("event:")) {
       evtName = line.slice("event:".length).replace(/^ /, "");
     } else if (line.startsWith("data:")) {
       dataLines.push(line.slice("data:".length).replace(/^ /, ""));
     }
   }
-  // A frame with no data line (a bare `event:` or a keepalive) carries nothing to
-  // forward — skip it. Anthropic + Responses always pair event+data, so this only
-  // drops pings/keepalives.
-  if (dataLines.length === 0) return null;
   // Multi-line data is joined with \n per the SSE spec (both protocols use single-line).
-  return { event: evtName, data: dataLines.join("\n"), raw: `${event}\n\n` };
+  return { event: evtName, data: dataLines.join("\n"), hasData: dataLines.length > 0, raw };
+}
+
+function nextSSEBoundary(buffer: string): { index: number; length: number } | null {
+  const candidates = [
+    { index: buffer.indexOf("\r\n\r\n"), length: 4 },
+    { index: buffer.indexOf("\n\n"), length: 2 },
+    { index: buffer.indexOf("\r\r"), length: 2 },
+  ].filter((candidate) => candidate.index >= 0);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => a.index - b.index || b.length - a.length);
+  return candidates[0] ?? null;
 }
 
 async function* splitSSEFrames(raw: AsyncIterable<string>): AsyncIterable<RawSSEFrame> {
   let buffer = "";
   for await (const piece of raw) {
-    buffer += piece.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-    let sep = buffer.indexOf("\n\n");
-    while (sep !== -1) {
-      const frame = parseRawSSEFrame(buffer.slice(0, sep));
-      buffer = buffer.slice(sep + 2);
+    buffer += piece;
+    let sep = nextSSEBoundary(buffer);
+    while (sep !== null) {
+      const rawFrame = buffer.slice(0, sep.index + sep.length);
+      const frame = parseRawSSEFrame(buffer.slice(0, sep.index), rawFrame);
+      buffer = buffer.slice(sep.index + sep.length);
       if (frame !== null) yield frame;
-      sep = buffer.indexOf("\n\n");
+      sep = nextSSEBoundary(buffer);
     }
   }
-  const tail = parseRawSSEFrame(buffer);
+  const tail = parseRawSSEFrame(buffer, buffer);
   if (tail !== null) yield tail;
 }
 
@@ -646,16 +662,20 @@ export function createMessagesPipeline(
         // Reassign the spliced (NEW) body; absent block / absent native_request / a
         // non-native protocol ⇒ leave native_request as-is.
         if (injected.memoryBlock !== null && internal.native_request !== undefined) {
+          const nativeBody = nativePassthroughBody(internal.native_request);
           if (protocol === "anthropic_messages") {
-            internal.native_request = appendMemoryToAnthropicBody(
-              internal.native_request,
-              injected.memoryBlock,
-            );
+            const body = appendMemoryToAnthropicBody(nativeBody, injected.memoryBlock);
+            internal.native_request = isNativePassthroughCarrier(internal.native_request)
+              ? cloneCarrierWithBody(internal.native_request, body)
+              : body;
           } else if (protocol === "openai_responses") {
-            internal.native_request = appendMemoryToResponsesBody(
-              internal.native_request,
-              injected.memoryBlock,
-            );
+            const body = appendMemoryToResponsesBody(nativeBody, injected.memoryBlock);
+            internal.native_request = isNativePassthroughCarrier(internal.native_request)
+              ? cloneCarrierWithBody(internal.native_request, body)
+              : body;
+          }
+          if (isNativePassthroughCarrier(internal.native_request)) {
+            internal.native_request.mutations.memory_appended = true;
           }
         }
       }
@@ -911,8 +931,14 @@ export function createMessagesPipeline(
                     accumulateAnthropicAssistantText(passthroughAssistant, frame.data);
                   }
                 }
-                // Yield the VERBATIM frame: data is the exact upstream JSON string.
-                yield { event: frame.event, data: frame.data };
+                // Yield the VERBATIM frame: routes use `raw` when present, so comment
+                // frames / keepalives / CRLF boundaries survive the Hono boundary too.
+                yield {
+                  event: frame.event,
+                  data: frame.data,
+                  raw: frame.raw,
+                  hasData: frame.hasData,
+                };
               }
             } finally {
               // Mirror the non-passthrough finally below: observe-outbound (assistant

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -195,6 +195,26 @@ const REQ_BODY = {
   max_tokens: 64,
 };
 
+function expectNativeCarrier(
+  value: unknown,
+  protocol: "anthropic_messages",
+  body: Record<string, unknown>,
+): void {
+  const carrier = value as {
+    protocol?: unknown;
+    body?: unknown;
+    raw_body?: unknown;
+    headers?: Record<string, string>;
+    mutations?: unknown;
+  };
+  expect(carrier.protocol).toBe(protocol);
+  expect(carrier.body).toEqual(body);
+  expect(carrier.raw_body).toBe(JSON.stringify(body));
+  expect(carrier.headers?.["content-type"]).toBe("application/json");
+  expect(carrier.headers?.["x-api-key"]).toBe("helm_live_secret");
+  expect(carrier.mutations).toEqual({});
+}
+
 describe("POST /v1/messages (Anthropic inbound)", () => {
   it("accepts the Claude Code event logging compatibility endpoint after auth", async () => {
     const { deps, harness } = makeDeps();
@@ -755,8 +775,8 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     });
 
     const meta = (harness.pipelineSawIR?.metadata ?? {}) as { native_request?: unknown };
-    // The carrier the core guard/executor reads: the verbatim parsed inbound body.
-    expect(meta.native_request).toEqual(REQ_BODY);
+    // The core guard/executor reads a carrier: parsed body + raw body + client headers.
+    expectNativeCarrier(meta.native_request, "anthropic_messages", REQ_BODY);
   });
 
   it("stamps native_request on a STREAMING request too (Phase 2 streaming passthrough)", async () => {
@@ -773,7 +793,7 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     await res.text();
 
     const meta = (harness.pipelineSawIR?.metadata ?? {}) as { native_request?: unknown };
-    expect(meta.native_request).toEqual({ ...REQ_BODY, stream: true });
+    expectNativeCarrier(meta.native_request, "anthropic_messages", { ...REQ_BODY, stream: true });
   });
 
   // ── Native protocol passthrough STREAMING (#217 Phase 2, C3). When the pipeline
@@ -823,7 +843,7 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expect(payload.responseJson).toContain(`data: ${startData}`);
     // native_request stamped on the streaming IR (Phase 2 carrier).
     const meta = (harness.pipelineSawIR?.metadata ?? {}) as { native_request?: unknown };
-    expect(meta.native_request).toEqual({ ...REQ_BODY, stream: true });
+    expectNativeCarrier(meta.native_request, "anthropic_messages", { ...REQ_BODY, stream: true });
   });
 
   it("stream NON-passthrough (flag OFF): still maps via transformStreamOut as today", async () => {

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -13,6 +13,7 @@ import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { nativeCarrierFromParsedBody } from "./native-carrier.js";
 import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
@@ -417,8 +418,14 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     // BOTH stream and non-stream (Phase 2 added streaming passthrough): the native
     // streaming body already carries stream:true, so the same verbatim body is the
     // carrier — the guard + executor decide whether to actually forward it.
-    if (native !== null && typeof native === "object") {
-      ir.metadata.native_request = native;
+    const nativeCarrier = nativeCarrierFromParsedBody({
+      protocol: "anthropic_messages",
+      native,
+      rawBody: requestJson,
+      headers: c.req.raw.headers,
+    });
+    if (nativeCarrier !== null) {
+      ir.metadata.native_request = nativeCarrier;
     }
 
     // 3) Routing pipeline (framework-agnostic core). The per-request abort signal
@@ -473,10 +480,16 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
           for await (const event of result.streamIR()) {
             const frame =
               result.nativePassthrough === true
-                ? (event as { event: string; data: string })
-                : anthropic.transformStreamOut(event);
-            if (captureBodies) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
-            await sse.writeSSE({ event: frame.event, data: frame.data });
+                ? (event as { event: string; data: string; raw?: string })
+                : { ...anthropic.transformStreamOut(event), raw: undefined };
+            const raw = frame.raw;
+            if (captureBodies)
+              captured.push(raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`);
+            if (raw !== undefined) {
+              await sse.write(raw);
+            } else {
+              await sse.writeSSE({ event: frame.event, data: frame.data });
+            }
           }
         } catch (err) {
           // A client disconnect / abort is a benign non-provider fault (docs/02):

--- a/apps/gateway/src/routes/native-carrier.ts
+++ b/apps/gateway/src/routes/native-carrier.ts
@@ -1,0 +1,26 @@
+import { createNativePassthroughCarrier, type NativePassthroughCarrier } from "@helm/shared";
+
+export function headersFromRequest(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+}
+
+export function nativeCarrierFromParsedBody(args: {
+  protocol: NativePassthroughCarrier["protocol"];
+  native: unknown;
+  rawBody: string;
+  headers: Headers;
+}): NativePassthroughCarrier | null {
+  if (args.native === null || typeof args.native !== "object" || Array.isArray(args.native)) {
+    return null;
+  }
+  return createNativePassthroughCarrier({
+    protocol: args.protocol,
+    body: args.native as Record<string, unknown>,
+    rawBody: args.rawBody,
+    headers: headersFromRequest(args.headers),
+  });
+}

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -142,6 +142,26 @@ function makeRecord(over: { capturePayloads?: boolean } = {}): {
 
 const REQ = { model: "auto", input: "Say hello", max_output_tokens: 16 };
 
+function expectNativeCarrier(
+  value: unknown,
+  protocol: "openai_responses",
+  body: Record<string, unknown>,
+): void {
+  const carrier = value as {
+    protocol?: unknown;
+    body?: unknown;
+    raw_body?: unknown;
+    headers?: Record<string, string>;
+    mutations?: unknown;
+  };
+  expect(carrier.protocol).toBe(protocol);
+  expect(carrier.body).toEqual(body);
+  expect(carrier.raw_body).toBe(JSON.stringify(body));
+  expect(carrier.headers?.authorization).toBe("Bearer helm_live_secret");
+  expect(carrier.headers?.["content-type"]).toBe("application/json");
+  expect(carrier.mutations).toEqual({});
+}
+
 describe("POST /v1/responses (OpenAI Responses inbound)", () => {
   it("non-stream: auth → translate-out → route → translate-back, returns Responses JSON", async () => {
     const { deps, order } = makeDeps();
@@ -278,7 +298,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(frames.some((f) => f.data === "[DONE]")).toBe(false);
   });
 
-  it("stream:true opens the Responses SSE before routing resolves", async () => {
+  it("stream:true waits for routing before writing the first Responses SSE frame", async () => {
     let releaseRoute!: () => void;
     const routeStarted = deferred<void>();
     const routeMayFinish = new Promise<void>((resolve) => {
@@ -318,12 +338,16 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
 
     const reader = res.body?.getReader();
     expect(reader).toBeDefined();
+    const firstReadBeforeRoute = await Promise.race([reader?.read(), shortTimeout()]);
+    expect(firstReadBeforeRoute).toBe("timeout");
+    await routeStarted.promise;
+    releaseRoute();
     const firstRead = await Promise.race([reader?.read(), shortTimeout()]);
     expect(firstRead).not.toBe("timeout");
     const firstText = new TextDecoder().decode((firstRead as { value?: Uint8Array }).value);
-    expect(parseSSE(firstText)[0]?.event).toBe("response.created");
-    await routeStarted.promise;
-    releaseRoute();
+    expect(["response.created", "response.in_progress", "response.completed"]).toContain(
+      parseSSE(firstText)[0]?.event,
+    );
     await reader?.cancel();
   });
 
@@ -686,7 +710,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
 
     const meta = (harness.pipelineSawIR as { metadata?: { native_request?: unknown } } | null)
       ?.metadata;
-    expect(meta?.native_request).toEqual(REQ);
+    expectNativeCarrier(meta?.native_request, "openai_responses", REQ);
   });
 
   it("stamps native_request on a STREAMING request too (Codex is stream-only)", async () => {
@@ -709,7 +733,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
 
     const meta = (harness.pipelineSawIR as { metadata?: { native_request?: unknown } } | null)
       ?.metadata;
-    expect(meta?.native_request).toEqual({ ...REQ, stream: true });
+    expectNativeCarrier(meta?.native_request, "openai_responses", { ...REQ, stream: true });
   });
 
   it("non-stream passthrough: returns the verbatim native Responses body, skipping translate-back", async () => {
@@ -756,8 +780,6 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     const completedData =
       '{"type":"response.completed","response":{"status":"completed","usage":{ "input_tokens":5 ,"output_tokens":4}}}';
     async function* events(): AsyncIterable<Record<string, unknown>> {
-      // The upstream's OWN response.created must be dropped (the route already emitted a
-      // synthetic prelude) — assert it does NOT duplicate below.
       yield { event: "response.created", data: '{"type":"response.created"}' };
       yield { event: "response.output_text.delta", data: deltaData };
       yield { event: "response.completed", data: completedData };
@@ -788,20 +810,16 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(text).toContain(`event: response.output_text.delta\ndata: ${deltaData}`);
     expect(text).toContain(`event: response.completed\ndata: ${completedData}`);
     const frames = parseSSE(text);
-    // Exactly ONE response.created (the synthetic prelude); the upstream's own
-    // response.created prelude frame is dropped to avoid a duplicate.
+    // Exactly ONE response.created: the upstream's own native prelude. The route
+    // must not synthesize, drop, or rewrite it on the passthrough path.
     expect(frames.filter((f) => f.event === "response.created")).toHaveLength(1);
-    // The synthetic prelude's response.created is the IR-shaped one (JSON object), NOT
-    // the upstream's verbatim '{"type":"response.created"}' — proves dedup hit upstream.
     const created = frames.find((f) => f.event === "response.created");
-    expect(created?.data).not.toBe('{"type":"response.created"}');
+    expect(created?.data).toBe('{"type":"response.created"}');
   });
 
-  it("stream passthrough: rewrites upstream response.id on relayed frames to match the synthetic prelude (PT-08)", async () => {
-    // The upstream completed frame carries the UPSTREAM's response.id; the synthetic
-    // prelude used the route-assigned id. Without a rewrite the client sees two different
-    // response.id values in one stream. The route must splice the prelude id onto relayed
-    // id-bearing lifecycle frames so the stream is self-consistent.
+  it("stream passthrough: preserves upstream response.id without a synthetic prelude", async () => {
+    // Native passthrough keeps the upstream Responses stream authoritative: no route
+    // prelude and no response.id rewrite.
     const completedData = JSON.stringify({
       type: "response.completed",
       response: {
@@ -832,20 +850,13 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
 
     const frames = parseSSE(await res.text());
-    const preludeId = (
-      JSON.parse(frames.find((f) => f.event === "response.created")?.data ?? "{}") as {
-        response?: { id?: string };
-      }
-    ).response?.id;
     const completedId = (
       JSON.parse(frames.find((f) => f.event === "response.completed")?.data ?? "{}") as {
         response?: { id?: string };
       }
     ).response?.id;
-    expect(preludeId).toBeTruthy();
-    // The relayed completed frame now carries the route id, not the upstream's.
-    expect(completedId).toBe(preludeId);
-    expect(completedId).not.toBe("resp_upstream_xyz");
+    expect(frames.some((f) => f.event === "response.created")).toBe(false);
+    expect(completedId).toBe("resp_upstream_xyz");
   });
 
   it("stream NON-passthrough (default): still maps via transformStreamOut as today", async () => {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -10,6 +10,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { nativeCarrierFromParsedBody } from "./native-carrier.js";
 import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
@@ -146,42 +147,6 @@ function responseStreamPrelude(args: {
     { type: "response.created", sequence_number: 0, response },
     { type: "response.in_progress", sequence_number: 1, response },
   ];
-}
-
-// PT-08: the synthetic prelude announced the route-assigned responseId, but a
-// verbatim-relayed upstream lifecycle frame (response.completed / .incomplete / …)
-// carries the UPSTREAM's own response.id — leaving the client with TWO different
-// response.id values in one stream. Splice the route id onto any relayed frame that
-// carries a `response.id` so the stream is self-consistent. FAIL-OPEN: a frame that
-// is not parseable JSON, or carries no `response.id` (every delta / content frame, and
-// the no-id terminal frames), is returned BYTE-FOR-BYTE untouched — this is the ONLY
-// spot native passthrough trades byte-fidelity for protocol self-consistency, and it
-// only fires on the small set of id-bearing envelope frames. `response.model` is left
-// as the upstream's real value (more truthful than the client-supplied alias).
-function rewriteRelayedResponseId(data: string, responseId: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(data);
-  } catch {
-    return data; // not JSON we understand — relay verbatim
-  }
-  const obj = parsed as { response?: { id?: unknown } };
-  if (typeof obj?.response?.id !== "string" || obj.response.id === responseId) {
-    return data; // no id to rewrite (or already matches) — relay verbatim, no reshape
-  }
-  obj.response.id = responseId;
-  return JSON.stringify(obj);
-}
-
-function isResponsesPreludeEvent(event: Record<string, unknown>): boolean {
-  // Translate path: the pipeline yields IR events keyed by `type`. Native-passthrough
-  // path (#217 Phase 3): the pipeline yields VERBATIM {event,data} frames keyed by
-  // `event`. Either way the route already emitted a synthetic prelude (with the route-
-  // assigned response id), so the upstream's own response.created / response.in_progress
-  // is dropped to avoid a duplicate prelude — the rest of the upstream stream (content,
-  // deltas, the terminal response.completed) is relayed byte-for-byte.
-  const name = typeof event.type === "string" ? event.type : event.event;
-  return name === "response.created" || name === "response.in_progress";
 }
 
 function pipelineToHelm(err: PipelineError, traceId: string): HelmHttpError {
@@ -344,8 +309,14 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     // real Codex CLI is stream-only (store:false + stream:true), so the same verbatim
     // body is the carrier on either branch — the guard + executor decide whether to
     // actually forward it.
-    if (native !== null && typeof native === "object") {
-      ir.metadata.native_request = native;
+    const nativeCarrier = nativeCarrierFromParsedBody({
+      protocol: "openai_responses",
+      native,
+      rawBody: requestJson,
+      headers: c.req.raw.headers,
+    });
+    if (nativeCarrier !== null) {
+      ir.metadata.native_request = nativeCarrier;
     }
 
     // Capture the verbatim request/response bodies only when capture_payloads is ON
@@ -372,41 +343,45 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         // upstream Codex Responses SSE into VERBATIM {event,data} frames (the data
         // payload is the exact upstream JSON string, INCLUDING reasoning.encrypted_content
         // and native tool-call events) — forward them directly, BYPASSING transformStreamOut
-        // so the bytes reach the client byte-for-byte. The synthetic prelude is still
-        // emitted (the stream opens before routing resolves); the upstream's own
-        // response.created / response.in_progress is dropped by isResponsesPreludeEvent to
-        // avoid a duplicate. Capture stays native on both ends; an upstream error mid-
-        // passthrough still surfaces the Responses terminal error frame below (catch
-        // is unchanged).
+        // so the bytes reach the client byte-for-byte. Native passthrough deliberately
+        // suppresses Helm's synthetic prelude, keeping the upstream response.created /
+        // response.in_progress authoritative. Capture stays native on both ends; an
+        // upstream error mid-passthrough still surfaces the Responses terminal error
+        // frame below (catch is unchanged).
         let nextErrorSequence = 0;
         // Accumulate the serialized wire frames so the served response body can be
         // captured (verbatim) alongside the telemetry row in the finally below.
         const captured: string[] = [];
         let result: PipelineRunResult | null = null;
         try {
-          for (const event of responseStreamPrelude({ responseId, model: responseModel })) {
-            nextErrorSequence = 2;
-            const frame = deps.transformer.transformStreamOut(event);
-            if (captureBodies) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
-            await sse.writeSSE({ event: frame.event, data: frame.data });
-          }
           result = await deps.pipeline.run(ir, identity, c.req.raw.signal);
+          if (result.nativePassthrough !== true) {
+            for (const event of responseStreamPrelude({ responseId, model: responseModel })) {
+              nextErrorSequence = 2;
+              const frame = deps.transformer.transformStreamOut(event);
+              if (captureBodies) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
+              await sse.writeSSE({ event: frame.event, data: frame.data });
+            }
+          }
           for await (const event of result.streamIR()) {
-            if (isResponsesPreludeEvent(event)) continue;
             if (typeof event.sequence_number === "number")
               nextErrorSequence = event.sequence_number + 1;
             const frame =
               result.nativePassthrough === true
                 ? {
                     event: (event as { event: string }).event,
-                    // PT-08: keep the stream's response.id self-consistent — splice the
-                    // route id onto any relayed id-bearing lifecycle frame (the synthetic
-                    // prelude announced it). Frames with no response.id are byte-identical.
-                    data: rewriteRelayedResponseId((event as { data: string }).data, responseId),
+                    data: (event as { data: string }).data,
+                    raw: (event as { raw?: string }).raw,
                   }
-                : deps.transformer.transformStreamOut(event);
-            if (captureBodies) captured.push(`event: ${frame.event}\ndata: ${frame.data}\n\n`);
-            await sse.writeSSE({ event: frame.event, data: frame.data });
+                : { ...deps.transformer.transformStreamOut(event), raw: undefined };
+            const raw = frame.raw;
+            if (captureBodies)
+              captured.push(raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`);
+            if (raw !== undefined) {
+              await sse.write(raw);
+            } else {
+              await sse.writeSSE({ event: frame.event, data: frame.data });
+            }
           }
         } catch (err) {
           // A client disconnect / abort is benign (docs/02): emit NO error frame.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ interface ships with the gateway for basic rule management.
 | 11 | [Admin UI](11-admin-ui.md) | Web console, rule management, HTTP Basic auth. |
 | 12 | [Memory: Forgetting & Tiering](12-memory-forgetting-and-tiering.md) | Short/mid/long-term tiers + a deterministic forgetting strategy (decay, reinforcement, soft-archive, supersede) layered on 08. **Shipped but opt-in** — gated by `config.memory.forgetting.enabled` (schema default `false`); with it off, runtime is byte-identical to before. |
 | — | [Protocol Compatibility](protocol-compatibility.md) | Per-pair data-loss matrix, the `n>1` cap / `data_loss` warning policy, the `provider_raw` passthrough list, capability-gated modalities, and the litellm parity scorecard. |
+| — | [原生直通保真规范](native-passthrough-fidelity-spec.md) | Anthropic Messages 和 OpenAI Responses 原生直通的中文设计草案：header/body 保真、允许的修改、流式策略、治理边界、CRS 借鉴项和验收标准。 |
 | — | [Research Notes](research-notes.md) | Appendix: open-source references and comparisons for the rule engine, protocol translation, probes, etc. |
 
 ## Design principles

--- a/docs/native-passthrough-fidelity-spec.md
+++ b/docs/native-passthrough-fidelity-spec.md
@@ -1,0 +1,689 @@
+# 原生直通保真规范
+
+状态：本 PR 的实施与验收规格。本文档记录 Anthropic Messages 和 OpenAI Responses
+原生直通的目标契约、自动化验收方法和已确认产品决策。
+
+## 问题
+
+当入站原生协议被路由到同协议 provider 时，Helm API 应该是治理网关，
+而不是无意中介入协议转换的适配器。对于原生直通，客户端期望上游请求
+和响应尽量保持它发送时的原始协议形态。
+
+当前网关已经有原生直通路径，但它仍会重新构造 provider headers、解析
+并重新序列化 request body、修补 `model`、可能注入记忆，并且在 Responses
+流式路径中生成 Helm 合成前导事件、改写 response id。其中一部分属于有意
+的网关行为，另一部分应该收窄范围或显式化。
+
+## 目标
+
+1. 在原生直通中保留客户端可见的协议表面。
+2. 尽可能安全地保留客户端请求 headers。
+3. 保留 request body 字段，包括未来协议新增的未知字段。
+4. 保留原生流式事件顺序和 payload，避免协议重映射。
+5. 保留 Helm 治理能力：鉴权、按 key 限流、预算、路由、fallback 安全、
+   telemetry、payload capture 和记忆注入。
+6. 所有不可避免的修改都必须显式、可测试、可观测。
+7. 仅在不静默改变客户端语义时借鉴 `claude-relay-service` 的账号安全策略；
+   如果会改变语义，则必须放在显式 provider compatibility profile 后面。
+
+## 非目标
+
+- 不把 Helm 变成盲目的 TCP/HTTP 代理；Helm 仍然负责鉴权、授权、路由、
+  预算和记录请求。
+- 不把客户端的 Helm 凭证转发给上游 provider。
+- 不启用跨协议原生直通。如果源协议和目标 provider 协议不同，必须走
+  transformed path。
+- 默认不复制 relay 实现中激进的 prompt/system 改写策略。
+
+## 原生直通契约
+
+只有同时满足以下条件时，才能启用原生直通：
+
+- `native_protocol_passthrough` 已启用。
+- 入站 route 已写入 native request carrier。
+- 入站协议不是 `openai_chat`。
+- 入站协议等于解析后的 provider wire protocol。
+- fallback 链不能切换到其他 provider protocol。
+- provider 不要求 compatibility rewrite。
+- provider 针对 stream 或 non-stream 实现了对应 native 方法。
+
+当启用原生直通时，Helm 应该：
+
+- request、response、stream data 都避免协议 transformer；
+- 只带着文档化的修改转发客户端 body；
+- 只带着文档化的覆盖转发清理后的客户端 headers；
+- 不生成合成协议事件，直接转发上游 bytes/events；
+- 尽量把治理和可观测性放在协议 payload 之外。
+
+## 允许的修改
+
+默认原生直通只允许以下修改：
+
+| 修改 | 原因 | 范围 |
+|---|---|---|
+| 替换上游鉴权 headers | 防止泄露 Helm API key，并使用 provider 凭证 | 仅 headers |
+| 删除 hop-by-hop headers | HTTP proxy 规则要求 | 仅 headers |
+| 重新计算 `content-length` | 允许修改 body 后需要重新序列化 | 仅 headers |
+| 将 `model` 改成解析后的 provider model | 客户端 model 可能是 Helm alias 或 lane target | 仅 body |
+| 添加记忆提醒 | Helm memory injection 是产品功能 | 仅 body，尾部追加 |
+| 统一 timeout/abort 处理 | 网关可靠性 | 仅传输层 |
+
+任何其他修改都必须放在显式 provider profile 后面，并记录到 telemetry。
+
+## 修改账本
+
+每一次 native attempt 都应该携带 mutation ledger，方便调试和管理界面检查。
+建议字段：
+
+- `model_rewritten`: `{ from, to }`
+- `memory_appended`: boolean
+- `headers_dropped`: string[]
+- `headers_overwritten`: string[]
+- `auth_replaced`: boolean
+- `content_length_recomputed`: boolean
+- `accept_encoding_forced_identity`: boolean
+- `provider_profile_applied`: string | null
+- `body_shims_applied`: string[]
+- `stream_reframed`: boolean
+
+mutation ledger 绝不能包含 secrets 或完整 body 内容。
+
+## Header 策略
+
+### 默认规则
+
+除非 header 不安全、属于传输层、属于 Helm 内部 header，或必须被 provider
+凭证覆盖，否则全部转发客户端 header。
+
+### 拒绝列表
+
+永远不要把这些客户端 headers 转发给上游：
+
+- `authorization`
+- `proxy-authorization`
+- `x-api-key`
+- `x-cr-api-key`
+- `host`
+- `content-length`
+- `connection`
+- `keep-alive`
+- `proxy-connection`
+- `transfer-encoding`
+- `te`
+- `trailer`
+- `upgrade`
+- `sec-websocket-key`
+- `sec-websocket-version`
+- `sec-websocket-extensions`
+- `sec-websocket-protocol`
+- `x-helm-*`
+- `cookie`
+- `set-cookie`
+- secret-like client headers（例如包含 `authorization`，或形如 `*-auth`、
+  `*-token`、`*-secret`、`*-credential`、`*-api-key` / `*-apikey`）
+
+provider client 可以针对特定上游增加拒绝列表，但必须文档化并测试覆盖。
+
+### Provider 覆盖
+
+provider 凭证必须覆盖客户端鉴权。例如：
+
+- Anthropic static key：从 provider config 设置上游 `x-api-key`。
+- Anthropic OAuth/subscription：从账号设置上游 `authorization`。
+- ChatGPT/Codex Responses：从选中的账号设置上游 `authorization` 和
+  `chatgpt-account-id`。
+
+### Anthropic Headers
+
+默认保留客户端传入的身份和 SDK headers，包括：
+
+- `user-agent`
+- `accept`
+- `accept-language`
+- `anthropic-version`
+- `anthropic-beta`
+- `anthropic-dangerous-direct-browser-access`
+- `x-app`
+- `x-stainless-*`
+
+如果 Helm 需要添加 provider 必需的 beta 值，应该与客户端 `anthropic-beta`
+合并，而不是替换。重复 beta token 应去重，同时保持稳定顺序。
+
+对于官方 Anthropic subscription profile，Helm 可以强制
+`accept-encoding: identity`，避免压缩 SSE 损坏。该行为必须记录为
+`accept_encoding_forced_identity`。
+
+### Responses / Codex Headers
+
+默认保留客户端传入的身份和 session headers，包括：
+
+- `user-agent`
+- `accept`
+- `accept-language`
+- `openai-beta`
+- `version`
+- `session_id`
+- `x-session-id`
+- `x-client-request-id`
+- `originator`，前提是对选中的 backend 安全
+
+对于 ChatGPT/Codex backend，Helm 可以设置必要的 backend identity headers，
+例如 `chatgpt-account-id`、`originator` 和 `OpenAI-Beta`，但不应覆盖语义等价的
+客户端 headers，除非 provider profile 明确要求。
+
+## Body 策略
+
+### 默认规则
+
+保留所有解析后的 native body 字段，包括未来协议新增的未知字段。native path
+不得运行 request protocol transformer。
+
+### Raw Body 保留
+
+如果不需要修改 body，优先转发原始 JSON 文本，以保留空白、key 顺序和数字写法。
+如果 `model`、memory 或 provider profile 改变了 body，则重新序列化最小修改后的
+对象，并记录 mutation ledger。
+
+### Model 改写
+
+Helm 可以将 `body.model` 替换为解析后的 provider model。当客户端发送 Helm alias、
+lane 或 provider-prefixed model，而上游不接受该值时，这是必要的。
+
+如果客户端 model 已经等于解析后的 provider model，则不要把它记录为 rewritten。
+
+### 记忆注入
+
+记忆注入保留，但必须是追加式：
+
+- Anthropic：追加一个尾部 user message，包含 memory reminder。
+- Responses：追加一个尾部 input item/message，包含 memory reminder。
+- 绝不改写 `system`、`instructions`、历史对话、tools、cache-control prefix 或
+  provider-specific state。
+- 记录 `memory_appended: true`。
+
+### 可选 Provider Profiles
+
+provider profile 可以应用额外 shim，但默认关闭，必须显式配置。候选 profile：
+
+#### `anthropic_official_safe`
+
+值得考虑的 CRS 风格安全 shim：
+
+- 限制不可能的 `max_tokens` 值；
+- 移除不支持的 `cache_control.ttl`；
+- 强制 Anthropic cache-control block 数量限制；
+- 合并必需 beta headers；
+- 流式场景强制 `accept-encoding: identity`；
+- 保留真实的 Claude Code user-agent 和 app headers。
+
+默认不要启用这些行为：
+
+- 用 Claude Code prompt 替换客户端 `system` prompt；
+- 把原始 `system` prompt 移入 messages；
+- 注入合成 `metadata.user_id`；
+- 改写 tool names；
+- 一看到 `top_p` 就删除。
+
+这些行为是在用协议保真换账号安全伪装。如果确实需要，应放在更强的 profile
+后面，例如 `anthropic_official_compat`，并清楚标注为语义改写。
+
+#### `codex_official_safe`
+
+值得考虑的 CRS 风格安全 shim：
+
+- 对 ChatGPT/Codex Responses，在缺失时设置 `store: false`；
+- 保留 Codex CLI user-agent 和 session headers；
+- 每个账号/session 使用稳定的 `session_id` / `x-client-request-id`；
+- 捕获 rate-limit errors，用于账号 cooldown。
+
+如果客户端显式发送 `store: true`，在 `codex_official_safe` profile 下 Helm 应覆盖为
+`store: false`，避免触发 ChatGPT/Codex backend 的账号风险。该覆盖对客户端响应不额外暴露，
+但必须写入 mutation ledger，例如 `body_shims_applied: ["store_forced_false"]`。
+
+## Streaming 策略
+
+native streaming 应该是 raw 或接近 raw 的传输路径。
+
+### 必需行为
+
+- 不运行 stream protocol transformers。
+- 不在上游 stream 开始前合成协议事件。
+- 不丢弃上游 lifecycle events。
+- 不改写上游 response ids。
+- 在传输 API 允许时，转发 comments、keepalives、no-data frames 和未知事件。
+- tee stream 用于 usage parsing 和 payload capture，但不改变客户端收到的内容。
+
+### Responses 专项规则
+
+原生 Responses streams 不得发送 Helm 生成的 `response.created` 或
+`response.in_progress` frames。不得改写上游 `response.completed`、
+`response.incomplete` 或其他带 id frame 中的 `response.id`。
+
+trace 关联应该写到 telemetry，例如 `trace_id`、`provider_response_id`，而不是写进
+客户端可见的上游 frames。
+
+### Anthropic 专项规则
+
+原生 Anthropic streams 应该按收到的内容转发上游 `event:` 和 `data:` frames。
+如果框架无法保留完全 byte-identical 的 chunk 边界，至少必须精确保留 event names
+和 data payload strings，并在 mutation ledger 中标记 `stream_reframed: true`。
+
+## 治理和 Fallback
+
+Helm 治理在 passthrough 前后仍然生效：
+
+- API-key 鉴权和 role/cap 检查；
+- 按 key 的 RPM/TPM 和并发限制；
+- 按 key 的使用预算和 degrade rules；
+- 路由和 provider 选择；
+- same-protocol fallback guard；
+- provider breaker/cooldown 行为；
+- telemetry 和 payload capture；
+- 客户端 abort 作为非 provider failure 处理。
+
+如果某个 native attempt 在第一个 streamed chunk 之前失败，并且 fallback 链保持同一
+provider protocol，Helm 可以带着同一个 native carrier 尝试下一个 candidate。如果
+fallback 可能切换协议，必须从第一个 attempt 开始禁用 native passthrough，改走
+transformed path。
+
+## 从 CRS 借鉴的账号安全策略
+
+这些策略有价值，并且与 Helm 的网关模型兼容：
+
+1. 对 subscription/OAuth 账号使用 sticky session routing，key 可以来自
+   `session_id`、`x-session-id`、`prompt_cache_key`、`conversation_id` 或稳定
+   metadata。
+2. 对 429、529、401/403 和 5xx 使用不同的账号 cooldown 状态。
+3. raw stream 转发的同时并行解析 usage。
+4. 通过 header passthrough 保留真实客户端 fingerprint。
+5. 为官方 subscription backend 增加可选 provider profiles。
+
+这些策略不应作为默认行为复制，因为它们会改变语义：
+
+1. Prompt/system 替换。
+2. 合成 metadata identity 注入。
+3. native passthrough 中改写 tool names。
+4. 静默删除客户端 sampling 参数。
+5. 静默覆盖客户端显式 storage 设置。
+
+## 自动化验收方案
+
+原生直通的正确性必须通过可执行程序验收，不能只靠人工 review 或单元测试推断。
+验收框架必须是确定性的：不依赖真实 Anthropic、OpenAI 或 ChatGPT/Codex 上游，
+不需要真实 provider credentials，所有上游行为由本地 fake upstream 控制。
+
+### 验收核心模型
+
+每个 golden case 都要同时捕获并比较三份数据：
+
+1. 客户端发给 Helm 的请求。
+2. Helm 发给 fake upstream 的请求。
+3. Helm 返回给客户端的响应。
+
+只有三者都满足保真规则，case 才能通过。
+
+### 可执行命令
+
+实现必须提供可本地执行的自动化命令：
+
+```bash
+pnpm test:passthrough:unit
+pnpm test:passthrough:e2e
+pnpm test:passthrough
+pnpm test:passthrough:live:claude-cli
+pnpm test:passthrough:live:codex-cli
+pnpm test:passthrough:live
+pnpm test:passthrough:final
+```
+
+命令含义：
+
+- `pnpm test:passthrough:unit`：运行 helper、provider、route、pipeline 的快速单元测试。
+- `pnpm test:passthrough:e2e`：启动 fake upstream + Helm 测试实例，运行 golden e2e cases。
+- `pnpm test:passthrough`：运行上述两类确定性测试，作为无需真实 provider 的本地验收命令。
+- `pnpm test:passthrough:live:claude-cli`：用真实 Claude CLI 调用本地 Helm，执行 live E2E。
+- `pnpm test:passthrough:live:codex-cli`：用真实 Codex CLI 调用本地 Helm，执行 live E2E。
+- `pnpm test:passthrough:live`：运行 Claude CLI 和 Codex CLI 两类 live E2E。
+- `pnpm test:passthrough:final`：先运行 `pnpm test:passthrough`，再运行
+  `pnpm test:passthrough:live`，作为合并/发布前最终验收命令。
+
+`unit`、`e2e` 和 `test:passthrough` 必须能在没有真实 provider key 的环境中运行。
+`live` 和 `final` 必须使用真实 CLI、真实 Helm 本地实例和真实 upstream credentials；
+缺少 CLI 或 credentials 时，最终验收失败，不能静默跳过。
+
+### Fake Upstream
+
+验收框架需要一个本地 fake upstream server，至少支持：
+
+- Anthropic `/v1/messages` non-stream 和 stream；
+- Responses `/responses` 或 `/v1/responses` non-stream 和 stream；
+- 捕获 method、url、headers、raw body bytes、parsed body；
+- 返回 fixture 定义的 JSON 或 SSE；
+- 模拟 401、429、529、5xx、stream 前失败、stream 中断；
+- 暴露 captured requests 给测试断言。
+
+捕获结构建议：
+
+```ts
+interface CapturedUpstreamRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[]>;
+  rawBody: Buffer;
+  parsedBody?: unknown;
+}
+```
+
+### Golden Fixtures
+
+建议 fixture 目录结构：
+
+```text
+tests/fixtures/native-passthrough/
+  anthropic/
+    non-stream-raw-body/
+      client-headers.json
+      client-body.raw.json
+      upstream-response.raw.json
+      expected-upstream-headers.json
+      expected-upstream-body.raw.json
+      expected-client-response.raw.json
+    stream-raw-sse/
+      client-headers.json
+      client-body.raw.json
+      upstream-sse.raw
+      expected-client-sse.raw
+  responses/
+    codex-store-forced-false/
+      client-headers.json
+      client-body.raw.json
+      expected-upstream-body.raw.json
+    stream-lifecycle-fidelity/
+      client-headers.json
+      client-body.raw.json
+      upstream-sse.raw
+      expected-client-sse.raw
+```
+
+fixture 必须故意覆盖容易出错的输入：
+
+- 非标准 key 顺序；
+- 未知 top-level 和 nested 字段；
+- 多行字符串；
+- 显式 `store: true`；
+- session headers；
+- SDK/fingerprint headers；
+- denylisted headers；
+- SSE comments、keepalives、unknown events；
+- Responses lifecycle events，包括 upstream 自己的 `response.created`、`response.in_progress`、
+  `response.completed` 和 upstream `response.id`。
+
+### 自动断言规则
+
+#### Headers
+
+- header 比较必须大小写不敏感。
+- denylisted headers 必须不存在于 upstream request。
+- provider auth 必须覆盖客户端 auth。
+- 非 denylisted 的客户端 identity/session headers 必须出现在 upstream request。
+- `x-helm-*`、客户端 `authorization`、客户端 `x-api-key` 一旦到达 upstream，测试必须失败。
+
+#### Body
+
+- 如果 mutation ledger 表示 body 未修改，必须逐字节比较 upstream `rawBody` 和
+  `client-body.raw.json`。
+- 如果 body 被允许修改，比较 parsed JSON，并额外断言只有允许字段发生变化。
+- 未知字段必须保留。
+- `model` rewrite、memory append、`store_forced_false` 必须在 mutation ledger 中有记录。
+- mutation ledger 中不得出现 secrets 或完整 body 内容。
+
+#### Streaming
+
+- Responses native stream 必须逐事件或逐字节证明：没有 Helm synthetic prelude、没有丢弃
+  upstream prelude、没有改写 upstream `response.id`。
+- Anthropic native stream 应优先逐字节比较客户端收到的 SSE 与 upstream SSE。
+- 如果框架无法保证完全 byte-identical，则必须比较 event order、event names、data payload
+  strings，并断言 mutation ledger 标记 `stream_reframed: true`。
+- TCP chunk boundary 不作为断言目标，因为它不是稳定 HTTP 契约。
+
+#### Governance
+
+- 无效 Helm API key：fake upstream 不得收到请求。
+- 被 rate limit 或 budget 拒绝的请求：fake upstream 不得收到请求。
+- heterogeneous fallback chain：native passthrough 必须被禁用。
+- 客户端 abort：不得记录为 provider breaker failure。
+
+### 最小必过 E2E Cases
+
+1. Anthropic non-stream，无 body mutation：raw body text 原样到 upstream，headers 按策略转发。
+2. Anthropic non-stream，有 model rewrite：只有 `model` 改变，其他字段保留，ledger 记录。
+3. Anthropic stream：SSE event/data、comments、keepalives、unknown events 按策略保留。
+4. Responses non-stream，客户端 `store: true`：Codex profile 上游收到 `store: false`，
+   ledger 记录 `store_forced_false`。
+5. Responses stream lifecycle：客户端收到 upstream lifecycle events；无 Helm prelude；无 id rewrite。
+6. Security negative：客户端 auth、`x-api-key`、`x-helm-*`、hop-by-hop headers 不到 upstream。
+7. Governance negative：鉴权/限流/预算/fallback guard 能阻止不该发生的 upstream call。
+
+### Live CLI E2E 最终验收
+
+fake upstream 验收证明 Helm 的协议保真；live CLI 验收证明真实客户端能通过 Helm 工作。
+两者缺一不可。最终合并/发布前必须执行 live CLI E2E，不能只用 curl 或模拟客户端替代。
+
+#### Claude CLI
+
+`pnpm test:passthrough:live:claude-cli` 必须：
+
+- 调用本机安装的 `claude` CLI，而不是手写 Anthropic request。
+- 将 Claude CLI 的 base URL / API key 指向本地 Helm 测试实例。
+- 使用真实可用的 Anthropic/Claude upstream provider 配置。
+- 发送一个低成本、确定性 prompt，例如要求模型回复固定短文本。
+- 至少覆盖一次 streaming 响应。
+- 断言 CLI 输出包含固定 sentinel，例如 `HELM_LIVE_OK`。
+- 从 Helm telemetry/request detail 中提取 trace，断言该请求使用
+  `anthropic_messages` native passthrough。
+- 断言 mutation ledger 中只出现允许 mutation，例如 provider auth 替换、必要 header drop、
+  model rewrite 或 memory append。
+- 断言没有走 transformed path，没有泄露客户端 Helm credentials。
+
+#### Codex CLI
+
+`pnpm test:passthrough:live:codex-cli` 必须：
+
+- 调用本机安装的 `codex` CLI，而不是手写 Responses request。
+- 将 Codex CLI 的 base URL / API key 指向本地 Helm 测试实例。
+- 使用真实可用的 ChatGPT/Codex 或 OpenAI Responses upstream provider 配置。
+- 发送一个低成本、确定性 prompt，例如要求模型回复固定短文本。
+- 至少覆盖一次 Responses streaming 响应。
+- 断言 CLI 输出包含固定 sentinel，例如 `HELM_LIVE_OK`。
+- 从 Helm telemetry/request detail 中提取 trace，断言该请求使用
+  `openai_responses` native passthrough。
+- 断言 Responses native stream 没有 Helm synthetic prelude、没有 id rewrite；若 CLI 本身
+  不暴露原始 SSE，则必须通过 Helm payload capture 或 debug trace 验证。
+- 对 ChatGPT/Codex backend，确定性 fake-upstream case 必须覆盖客户端显式
+  `store: true` 时 `store_forced_false` 写入 mutation ledger；live CLI case 如果真实 CLI
+  请求没有触发该 shim，则只断言 native passthrough 与 mutation ledger 无 secrets。
+
+#### Live 验收产物
+
+live 脚本必须输出机器可读报告，例如
+`artifacts/passthrough-live-report.json`，至少包含：
+
+- CLI 名称和版本；
+- Helm base URL；
+- trace id；
+- provider alias/model；
+- native passthrough 是否启用；
+- mutation ledger 摘要；
+- CLI 退出码；
+- stdout/stderr 摘要；
+- 固定 sentinel 输出断言；
+- 是否通过每条断言。
+
+报告不得包含 provider secrets、Helm API keys 或完整用户 prompt。
+
+#### Live 验收边界
+
+- live E2E 可以使用短 prompt 和低 token 上限控制成本。
+- live E2E 允许因为真实 provider 暂时性 429/5xx 重试，但重试次数必须有限。
+- 如果 provider 不可用，最终验收不能标记为通过；只能明确记录 blocked/fail。
+- deterministic fake-upstream tests 仍然是 CI 级别的保真证明；live tests 是发布前真实客户端兼容性证明。
+
+### TDD 开发要求
+
+开发必须遵循红灯、绿灯、重构：
+
+1. 先写验收测试和单元测试，确认它们在当前实现上失败。
+2. 每个失败测试必须对应一个明确的 spec invariant。
+3. 只写让当前红灯变绿的最小实现。
+4. 绿灯后再重构，重构过程中保持 `pnpm test:passthrough` 通过。
+5. 禁止先改实现再补测试。
+6. 每个阶段完成时，都必须在 PR 或变更说明中列出运行过的验收命令。
+
+本功能的开发完成定义不是“代码看起来符合 spec”，而是
+`pnpm test:passthrough` 可重复通过；合并/发布前最终完成定义是
+`pnpm test:passthrough:final` 通过。
+
+## 实施计划
+
+### Phase 1: TDD 自动化验收测试
+
+先实现 `pnpm test:passthrough:unit`、`pnpm test:passthrough:e2e`、`pnpm test:passthrough`、
+`pnpm test:passthrough:live:*` 和 `pnpm test:passthrough:final`。
+在任何实现改动前，新增失败测试覆盖：
+
+- native headers 除 denylisted/overwritten headers 外都被保留；
+- 未知 native body 字段被保留；
+- memory 关闭时，`model` 是默认唯一 body rewrite；
+- memory injection 是尾部追加式；
+- Anthropic native stream 保留 event/data payload，并在支持时保留 keepalives；
+- Responses native stream 不合成 prelude、不丢弃上游 prelude、不改写 `response.id`；
+- mutation ledger 记录每个修改且不包含 secrets。
+
+### Phase 2: Native Carrier
+
+用 typed native carrier 替换松散的 `metadata.native_request` object：
+
+```ts
+interface NativePassthroughCarrier {
+  protocol: "anthropic_messages" | "openai_responses";
+  body: Record<string, unknown>;
+  rawBody?: string;
+  headers: Record<string, string | string[]>;
+  mutations: NativePassthroughMutationLedger;
+}
+```
+
+route 应在可行时先捕获 raw body text，再解析 JSON。
+
+### Phase 3: Header Passthrough Merge
+
+新增共享 header 清理和 provider-specific merge 函数：
+
+- `sanitizeNativePassthroughHeaders(headers)`
+- `mergeAnthropicNativeHeaders(clientHeaders, providerHeaders, profile)`
+- `mergeResponsesNativeHeaders(clientHeaders, providerHeaders, profile)`
+
+### Phase 4: Raw Native Stream Branch
+
+provider native stream 方法应该在 route 可以原样转发时暴露 upstream raw bytes/chunks。
+route 应该 tee bytes 做 usage 和 payload capture，而不是拆分并重建协议事件。
+
+如果框架路径无法保留 raw bytes，则保留当前 event/data splitter 作为 fallback，但标记
+`stream_reframed: true`。
+
+### Phase 5: Provider Profiles
+
+增加显式 provider passthrough profile 配置，例如：
+
+```yaml
+providers:
+  anthropic-official:
+    native_passthrough:
+      profile: anthropic_official_safe
+      force_accept_encoding_identity: true
+      merge_required_beta_headers: true
+  codex-official:
+    native_passthrough:
+      profile: codex_official_safe
+      default_store_false: true
+```
+
+### Phase 6: Docs 和 Admin 可见性
+
+在 `implementation-notes.md`、provider config docs 和 admin request detail 中记录最终契约。
+Admin telemetry 应显示是否使用 native passthrough，以及应用了哪些 mutations。
+
+## 验收标准
+
+- `pnpm test:passthrough` 是本功能的确定性自动化验收命令，并且必须稳定通过。
+- `pnpm test:passthrough:final` 是合并/发布前最终验收命令，必须运行 Claude CLI 和 Codex CLI live E2E。
+- Anthropic 和 Responses native passthrough 测试在实现前失败，实现后通过。
+- native path 不会把客户端 Helm credentials 转发到上游。
+- 未知字段能通过 native passthrough 保留。
+- 客户端 identity/session headers 会保留，除非被显式 deny 或 overwrite。
+- Responses native streams 不再收到 Helm synthetic prelude 或 id rewrite。
+- memory injection 保持追加式，并在 mutation ledger 中可见。
+- same-protocol fallback safety 继续强制执行。
+- provider profile shims 默认关闭。
+- fake upstream 验收不依赖真实 provider credentials 或外网服务。
+- 所有允许 mutation 都必须在 mutation ledger 中可程序化断言。
+- 最终验收必须生成 live CLI 机器可读报告，且报告不得包含 secrets。
+
+## 已确认决策
+
+### 1. ChatGPT/Codex Responses 中客户端显式发送 `store: true` 时怎么处理？
+
+决策：选项 C。对 ChatGPT/Codex backend，静默覆盖为 `store: false`。
+
+实现要求：
+
+- 仅在 ChatGPT/Codex backend 或 `codex_official_safe` profile 生效。
+- 如果客户端缺失 `store`，也设置为 `false`。
+- 如果客户端显式发送 `store: true`，覆盖为 `false`。
+- 对客户端不返回额外错误，但在 mutation ledger 中记录，例如
+  `body_shims_applied: ["store_forced_false"]`。
+
+理由：这是账号安全优先的特例。它会牺牲一点 body fidelity，但可以降低 Codex backend
+因 storage 行为触发风险的概率。
+
+### 2. 只有 headers 改变、body 不变时，是否转发原始 JSON 文本？
+
+决策：选项 A。只要 body 未被修改，就转发 raw body text。
+
+实现要求：
+
+- route 捕获 raw body text。
+- 如果没有 `model` 改写、memory injection、provider profile body shim，则 provider 转发
+  raw body text。
+- 如果 body 被修改，则重新序列化修改后的对象，并记录对应 mutation。
+
+理由：这是最高保真策略，可以保留 key 顺序、空白和数字写法；安全风险不增加，
+因为 Helm 已经解析过 JSON 用于验证和路由。
+
+### 3. `accept-encoding: identity` 应该默认用于所有 native SSE providers，还是只用于官方 subscription profiles？
+
+决策：选项 B。只在官方 subscription profiles 中强制 `identity`。
+
+实现要求：
+
+- 默认保留客户端 `accept-encoding`，除非 denylist 或 provider profile 要求覆盖。
+- 在 `anthropic_official_safe` 等官方 subscription profile 中，可以强制
+  `accept-encoding: identity`。
+- 强制覆盖时记录 `accept_encoding_forced_identity: true`。
+
+理由：CRS 的经验主要针对官方 subscription/Cloudflare SSE 稳定性；对所有 provider
+默认强制会过度干预 header fidelity。
+
+### 4. Sticky session routing 应该放在 provider OAuth account selection，还是 generic routing layer？
+
+决策：选项 C。generic layer 提取 session key，provider/account layer 使用它。
+
+实现要求：
+
+- generic 层统一提取 session key，来源包括 `session_id`、`x-session-id`、
+  `prompt_cache_key`、`conversation_id` 和稳定 metadata。
+- provider/account 层负责 sticky account 选择、账号池状态、cooldown 和凭证可用性。
+- 不同 provider 可以共享 session key 提取逻辑，但保留各自账号调度策略。
+
+理由：session key 提取规则可以共享，避免重复实现；真正的 sticky account 选择属于
+provider/account 层，因为不同 provider 的账号池、冷却和凭证状态不同。

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-06-14 · 原生直通保真实施 + 可执行验收（docs/native-passthrough-fidelity-spec；原则 7/8）
+
+- **背景**：用户要求 Anthropic Messages 和 OpenAI Responses 的 native passthrough 尽量保持客户端原协议与原请求内容，同时保留 Helm 自身治理、优化和 memory 注入，并参考 `claude-relay-service` 的账号安全策略（尤其防封号策略）。本次按 TDD 先补可执行验收，再收敛实现。
+- **核心改动**：① 新增 typed `NativePassthroughCarrier`（`protocol/body/raw_body/headers/mutations`）和共享 helper，route 在 `/v1/messages`、`/v1/responses` 盖戳 raw body + client headers；② provider native 请求统一走 `prepareNativePassthroughRequest`，drop auth/hop-by-hop/`x-helm-*`/cookie/secret-like client headers，替换 provider auth，默认保留安全 identity/session headers（UA、accept、session_id、x-client-request-id、originator 等），合并 Anthropic/OpenAI beta，并在 body 未变时转发 raw JSON text；③ streaming native path 改为 route 可写 raw SSE frame，comments/keepalives/no-data frames 与 CRLF 边界不再被 splitter 丢弃，Responses native stream 不再合成 prelude、不改写 upstream id；④ Responses/Codex profile 对 `store:true` 强制 `store:false` 并记录 `body_shims_applied:["store_forced_false"]` + `provider_profile_applied:"codex_official_safe"`；Anthropic dynamic-auth stream 的 `accept-encoding: identity` 仅在 official-safe profile 触发并记录；⑤ OAuth pool 增加 native sticky session（session_id/x-session-id/x-client-request-id/prompt_cache_key/conversation_id/metadata），同一 session 在 TTL 内绑定同一账号。
+- **治理与可观测性**：native path 仍经过 auth、rate limit、concurrency、budget、route/fallback guard、payload capture、memory inject/observe 和 telemetry；每次 attempt 的 `passthrough_*` 字段与 mutation ledger 进 `DecisionRecord.provider_attempts[]`，ledger 只记录修改类型，不写 secrets 或完整 body。memory 注入保持尾部 `<system-reminder>` 追加；修改 body 时自动清掉 raw body，避免伪装 byte-identical。
+- **验收体系**：新增 `scripts/passthrough/*` 和 package scripts：`test:passthrough:unit`（helper/provider/route/pipeline focused tests）、`test:passthrough:e2e`（fake upstream + route/execute deterministic golden cases）、`test:passthrough:live:*`（真实 Claude CLI / Codex CLI + telemetry proof）和 `test:passthrough:final`。live 脚本 fail-closed：必须看到 CLI sentinel、真实 CLI exit 0、admin telemetry 中 `passthrough_used:true`、协议一致、ledger 不含 Helm API key；live report 的 stdout/stderr 只写长度/行数/hash/sentinel/secret-redaction 摘要，不写完整 prompt 或输出正文。
+- **验证**：`ast-grep` 已用于 native carrier / route glue / mutation ledger 检查；`pnpm lint` 绿；`pnpm typecheck` 绿；`pnpm build` 绿；`pnpm test:passthrough` 绿（323 focused unit + 11 deterministic e2e）；`pnpm test` 绿（255 files / 3578 tests）；`pnpm test:passthrough:final` 绿。live final 使用本地 Helm 测试实例代理真实 upstream，Claude Code `2.1.175` 与 Codex CLI `0.139.0` 均返回 `HELM_LIVE_OK`，并从本地 admin telemetry 证明 `anthropic_messages` / `openai_responses` native passthrough。live 报告只作验收产物，不提交。
+- **取舍 / TODO**：provider profile 目前以代码路径记录（`codex_official_safe` / `anthropic_official_safe`），尚未做成完整 YAML 配置面；admin request detail 已有原始 attempt 字段，但 SPA 专门展示 passthrough ledger 可作为后续 UX 增强；Responses live CLI 本身未必发送 `store:true`，因此 `store_forced_false` 的强断言放在 deterministic fake-upstream case。
+
 ## 2026-06-14 · 协议层 review 修复：4 协议保真 + memory 注释纠偏（多 spec；原则 1/7/8）
 
 - **背景**：用 Workflow（codex finder + opus 对抗验证）做人类式 review，覆盖 4 协议客户端支持（多模态/工具）、互译完整性、原生直通、memory 注入/压缩、治理限额。25 条经对抗验证 confirmed；验证把**所有 high 降级**——真问题止于 medium。本次修复全部 confirmed 功能 bug + 过期注释（红→绿 TDD），设计取舍类只 surface。
@@ -26,20 +35,13 @@
 - **验证**：TDD 红→绿——4 个断言默认派生值的测试 `false→true`（shared schema / gateway server / core settings `defaultSettingsFromConfig` / admin settings client「defaults missing fields」；显式传 `false` 的 fixture 不动）。分包单测 + `pnpm typecheck` + `pnpm lint`。
 - **不在本次范围**：部署到 prod（需 cut release + build 镜像）、ja/ko 文案补全。
 
-## 2026-06-13 · memory prompt-cache 优化 — 系统前缀注入 → 尾部 system-reminder（docs/08；原则 8）
-
-- **问题（Phase 4 遗留权衡）**：Phase 4 把 memory 前置进 `system`（translate 路 `mergeMemoryIntoSystem` / 直通路 `prependMemoryTo{Anthropic,Responses}Body`）。Anthropic/Responses prompt cache 是**严格前缀匹配**（`tools→system→messages`），前缀任一字节变动使其后全部失效。前置 memory **位移客户端缓存前缀**（Claude Code 给 `system` 块打的 `cache_control` 断点），每个 memory 回合都 bust 掉 system+messages 缓存；而 memory 块本身**窗口可变**（window-dedup 集随客户端窗口滑动而变），永远无法落进可缓存前缀。
-- **修复（用户在 3 选项里拍板「尾部 system-reminder 块」——最稳）**：memory 改为**追加**为对话**末尾一条** `<system-reminder>` 包裹的 user 回合，落在客户端缓存前缀**之后**——`tools`/`system`（及其 `cache_control` 断点）与整段历史**逐字节不变** → 上游缓存照命中，只有那条小小的 reminder 回合不缓存。`<system-reminder>` 框定给 memory **系统权威**语义（Claude 训练为视其为注入的 operator 上下文、非用户发言），且**无需** model-gated 的 `mid-conversation-system` beta（`role:"system"` 消息对 Sonnet/旧模型会 400，与 fail-open 直通冲突；尾部 reminder 全模型通用、零 beta）。
-- **落点（两路同改，单一 wrap 真相源 = core `wrapMemoryReminder`，从 `@helm/core` 导出）**：translate 路 `injectIntoIR`（core `inject-bridge.ts`）`mergeMemoryIntoSystem` → `appendMemoryReminder`（追加一条尾部 user IR 消息；leading system 及所有回合按引用、原序保留）；直通路（gateway `native-memory-inject.ts`）`prependMemoryTo{Anthropic,Responses}Body` → `appendMemoryTo*`（Anthropic 追加尾部 `messages` user 回合；Responses `input` array→追加 user item、string→尾部文本拼接；`system`/`instructions` 逐字不动）。`messages-pipeline.ts` 调用点与注释同步改名。
-- **取舍 / 边界**：① memory 现出现在用户当前问题**之后**（而非 system 前言）——`<system-reminder>` 框定 + Claude 读完整 message 数组后再答，召回语义保持；② 连续两条 user 回合（客户端末条 + reminder）由 Anthropic API 合并为一个 turn，合法；③ Responses string-input 用尾部文本拼接保前缀；④ 这是 **Phase-4 决定 #3 的「位置面」修订**（仍「系统权威」语义、但位于缓存前缀**之后**而非 `system` 最前），docs/08 三节（Inject is additive / Tradeoff / Native passthrough）+ Phases changelog 同步重写（PREFIX→TRAILING-REMINDER，缓存「警示」改「保留」）。
-- **验证**：TDD 红→绿。重写落点断言：`inject-bridge.test.ts`(13)、`native-memory-inject.test.ts`(10)、`chat.inject.test.ts`(11)、`messages.inject.test.ts`(14)、`messages-pipeline.test.ts`(36)（system 合并→尾部 reminder）。`pnpm typecheck` + `pnpm lint` 干净；`pnpm test` 仅 7 红、全在 classifier（engine/taskdetect/classifier-samples）——证为工作树未提交的**生产 `config/classifier.yaml`**（docker 用，不提交）所致：临时 `git checkout HEAD config/classifier.yaml` 后 50/50 全绿、再恢复生产 config（[[config-edits-run-config-samples-test]]）。改动文件严格限于 memory/inject + docs + notes（**未碰 config**）。
-- **TODO**：live e2e 手验——真实 Claude Code/Codex 指向本网关 + memory inject ON + 直通 ON，确认 `usage.cache_read_input_tokens > 0`（memory 回合缓存命中恢复）且 memory 仍被召回（`memory_hydrated:true`）。需重建 docker 镜像。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-13 · memory prompt-cache 优化 — 系统前缀注入 → 尾部 system-reminder（docs/08；原则 8）：用户拍板尾部 `<system-reminder>`，translate 路和 native passthrough 路都把 memory 追加到对话末尾而非前置 system，保住 Anthropic/Responses prompt-cache 前缀；`wrapMemoryReminder` 成单一真相源，system/instructions 与历史回合逐字不动。TDD 覆盖 inject bridge/native-memory/chat/messages/pipeline，typecheck/lint 绿；TODO 是 live e2e 手验缓存命中与 memory 召回。
 
 ### 2026-06-13 · Phase 4 — memory 前缀注入（docs/08；tool/多模态 + 直通；原则 1/3/7/8）：inject 从 full-replace 改**加性前缀**——assembler 不再重建会话，只产一个系统级 memory 文本块（`buildMemoryBlock`，确定性/缓存友好），pipeline 前置到逐字保留的实时会话之上 → 删 D7 纯文本闸、tool/多模态/直通回合一视同仁注入。**窗口感知去重**：project/resource reflection 恒注入、thread observation 仅当覆盖回合已不在实时窗口才注入，指纹 `sha256Hex(serializeContent)` 与 storage `content_hash` 字节恒等；无法解析覆盖范围则保留、无窗口不去重。落点：translate `injectIntoIR`（前置/插 leading system）、直通 `native-memory-inject.ts`（Anthropic `system`/Responses `instructions`，`messages`/`input` 逐字）；guard 删 `memory_mode==="inject"` 禁用项 → **直通可与 memory 同触发**。observe 路零改。取舍：放弃实时会话压缩（helm 只贡献长期召回）、memory 前置**位移 prompt-cache 前缀**（次日 [[尾部 system-reminder 修订]]改为缓存保留）。旧 full-replace/D7/recent_raw 测试全按前缀模型重写、新增 `native-memory-inject.test.ts`；3263/3264 绿（唯一红=admin-oauth 预存 flake）。
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,14 @@
     "build": "pnpm -r build",
     "sync:catalog": "tsx scripts/sync-catalog.ts",
     "memory:dedup": "tsx packages/core/src/store/sqlite/dedup-memory-messages.ts",
-    "memory:dedup:pg": "tsx packages/core/src/store/postgres/dedup-memory-messages.ts"
+    "memory:dedup:pg": "tsx packages/core/src/store/postgres/dedup-memory-messages.ts",
+    "test:passthrough:unit": "vitest run --config scripts/passthrough/vitest.unit.config.ts",
+    "test:passthrough:e2e": "NODE_OPTIONS=--conditions=development tsx scripts/passthrough/deterministic-e2e.ts",
+    "test:passthrough": "pnpm test:passthrough:unit && pnpm test:passthrough:e2e",
+    "test:passthrough:live:claude-cli": "NODE_OPTIONS=--conditions=development tsx scripts/passthrough/live-cli.ts claude-cli",
+    "test:passthrough:live:codex-cli": "NODE_OPTIONS=--conditions=development tsx scripts/passthrough/live-cli.ts codex-cli",
+    "test:passthrough:live": "NODE_OPTIONS=--conditions=development tsx scripts/passthrough/live-cli.ts all",
+    "test:passthrough:final": "pnpm test:passthrough && pnpm test:passthrough:live"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -1523,6 +1523,79 @@ describe("createAnthropicClient — nativePassthrough", () => {
     expect(h.get("user-agent")).toBe("claude-cli/2.1.173 (external, cli)");
   });
 
+  it("preserves client headers/raw body through the native carrier while replacing auth", async () => {
+    const body = nativeBody();
+    const rawBody = JSON.stringify(body, null, 2);
+    let sentBody = "";
+    let seen: Headers | null = null;
+    const carrier = {
+      protocol: "anthropic_messages" as const,
+      body,
+      raw_body: rawBody,
+      headers: {
+        "content-type": "application/json",
+        "anthropic-beta": "client-beta-2026-01-01",
+        "user-agent": "client-claude/9.9.9",
+        "x-client-feature": "keep-me",
+        authorization: "Bearer client-secret",
+        "x-api-key": "client-key",
+        connection: "keep-alive",
+        "content-length": "999",
+        "x-helm-trace": "internal",
+      },
+      mutations: {},
+    };
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      sentBody = String(init?.body);
+      seen = new Headers(init?.headers);
+      return jsonResponse({
+        id: "m",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", getAuthHeader: async () => "Bearer ATX" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.nativePassthrough?.(carrier);
+
+    const h = seen as unknown as Headers;
+    expect(sentBody).toBe(rawBody);
+    expect(h.get("x-client-feature")).toBe("keep-me");
+    expect(h.get("Authorization")).toBe("Bearer ATX");
+    expect(h.get("x-api-key")).toBeNull();
+    expect(h.get("connection")).toBeNull();
+    expect(h.get("content-length")).toBeNull();
+    expect(h.get("x-helm-trace")).toBeNull();
+    expect(h.get("user-agent")).toBe("client-claude/9.9.9");
+    const beta = h.get("anthropic-beta") ?? "";
+    expect(beta).toContain("client-beta-2026-01-01");
+    expect(beta).toContain("oauth-2025-04-20");
+    expect(beta).toContain("context-management-2025-06-27");
+    expect(carrier.mutations).toMatchObject({
+      auth_replaced: true,
+      content_length_recomputed: true,
+    });
+    expect((carrier.mutations as Record<string, unknown>).headers_dropped).toEqual(
+      expect.arrayContaining([
+        "authorization",
+        "content-length",
+        "connection",
+        "x-api-key",
+        "x-helm-trace",
+      ]),
+    );
+    expect((carrier.mutations as Record<string, unknown>).headers_overwritten).toEqual(
+      expect.arrayContaining(["anthropic-beta"]),
+    );
+    expect((carrier.mutations as Record<string, unknown>).headers_overwritten).not.toContain(
+      "user-agent",
+    );
+  });
+
   it("throws UpstreamError with the real upstreamStatus + scrubbed body on a non-2xx", async () => {
     const client = createAnthropicClient({
       config: {
@@ -1779,6 +1852,35 @@ describe("createAnthropicClient — nativePassthroughStream", () => {
     expect(beta).toContain("context-management-2025-06-27");
     expect(beta).toContain("fast-mode-2026-02-01");
     expect(h.get("user-agent")).toBe("claude-cli/2.1.173 (external, cli)");
+  });
+
+  it("forces accept-encoding: identity only for dynamic-auth native streams", async () => {
+    let seen: Headers | null = null;
+    const carrier = {
+      protocol: "anthropic_messages" as const,
+      body: nativeStreamBody(),
+      raw_body: JSON.stringify(nativeStreamBody(), null, 2),
+      headers: {
+        "accept-encoding": "br, gzip",
+        "content-type": "application/json",
+      },
+      mutations: {},
+    };
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      seen = new Headers(init?.headers);
+      return sseStreamResponse(['event: message_stop\ndata: {"type":"message_stop"}\n\n']);
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", getAuthHeader: async () => "Bearer ATX" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    for await (const _ of client.nativePassthroughStream?.(carrier) ?? []) {
+      // drain
+    }
+
+    expect((seen as unknown as Headers).get("accept-encoding")).toBe("identity");
+    expect(carrier.mutations).toMatchObject({ accept_encoding_forced_identity: true });
   });
 
   it("throws UpstreamError with the real upstreamStatus + scrubbed body before the first chunk on a non-2xx", async () => {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -14,6 +14,8 @@
 // (see README disclaimer). Identity recipe ported from openclaw (MIT).
 
 import { createHash } from "node:crypto";
+import { type NativePassthroughInput, nativePassthroughBody } from "@helm/shared";
+import { prepareNativePassthroughRequest } from "./native-passthrough.js";
 import {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
@@ -615,13 +617,21 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     return changed ? JSON.parse(value) : raw;
   }
 
-  async function request(body: Record<string, unknown>, external?: AbortSignal): Promise<Response> {
+  async function request(input: NativePassthroughInput, external?: AbortSignal): Promise<Response> {
+    const body = nativePassthroughBody(input);
+    const prepared = prepareNativePassthroughRequest(input, await headers(body), {
+      mergeHeaders: ["anthropic-beta"],
+      forceAcceptEncodingIdentity: cfg.getAuthHeader !== undefined && body.stream === true,
+      ...(cfg.getAuthHeader !== undefined && body.stream === true
+        ? { providerProfileApplied: "anthropic_official_safe" }
+        : {}),
+    });
     const t = withTimeout(timeoutMs, external);
     try {
       return await doFetch(url, {
         method: "POST",
-        headers: await headers(body),
-        body: JSON.stringify(body),
+        headers: prepared.headers,
+        body: prepared.bodyText,
         signal: t.signal,
       });
     } catch (err) {
@@ -635,7 +645,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
   }
 
   async function requestWithRetry(
-    body: Record<string, unknown>,
+    body: NativePassthroughInput,
     external?: AbortSignal,
   ): Promise<Response> {
     const res = await request(body, external);

--- a/packages/core/src/provider/native-passthrough.ts
+++ b/packages/core/src/provider/native-passthrough.ts
@@ -5,6 +5,16 @@ import {
   type NativePassthroughInput,
 } from "@helm/shared";
 
+// Client-header handling is FORWARD-BY-DEFAULT (for fingerprint fidelity) MINUS the
+// exclusions below — an allowlist-by-exclusion, not a strict allowlist. The
+// load-bearing guarantee (principle 7) is that the Helm credential, cookies, and
+// obviously secret-shaped headers NEVER leave the gateway; provider auth replaces the
+// upstream credential. Limitation by design: the secret detection in
+// `isUnsafeClientHeader` is shape-based, so a generic secret header that matches none
+// of these shapes (e.g. `x-functions-key`) can still ride to the upstream. That is
+// acceptable because the only passthrough upstreams are trusted first-party providers
+// (Anthropic / ChatGPT), and broadening to a bare `*-key` would wrongly drop legitimate
+// headers (`idempotency-key`, beta/feature keys, …). Keep the shapes tight + explicit.
 const DENY_HEADERS = new Set([
   "authorization",
   "proxy-authorization",

--- a/packages/core/src/provider/native-passthrough.ts
+++ b/packages/core/src/provider/native-passthrough.ts
@@ -1,0 +1,177 @@
+import {
+  appendMutationList,
+  isNativePassthroughCarrier,
+  type NativePassthroughCarrier,
+  type NativePassthroughInput,
+} from "@helm/shared";
+
+const DENY_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-api-key",
+  "x-cr-api-key",
+  "host",
+  "content-length",
+  "connection",
+  "keep-alive",
+  "proxy-connection",
+  "transfer-encoding",
+  "te",
+  "trailer",
+  "upgrade",
+  "sec-websocket-key",
+  "sec-websocket-version",
+  "sec-websocket-extensions",
+  "sec-websocket-protocol",
+]);
+
+function isUnsafeClientHeader(lower: string): boolean {
+  if (lower.startsWith("x-helm-") || DENY_HEADERS.has(lower)) return true;
+  if (lower === "cookie" || lower === "set-cookie") return true;
+  if (lower.includes("authorization")) return true;
+  if (lower === "apikey" || lower === "api-key" || lower.endsWith("-apikey")) return true;
+  if (lower.endsWith("-api-key")) return true;
+  if (lower === "auth" || lower.endsWith("-auth") || lower.includes("-auth-")) return true;
+  if (lower === "token" || lower.endsWith("-token") || lower.includes("-token-")) return true;
+  if (lower === "secret" || lower.endsWith("-secret") || lower.includes("-secret-")) return true;
+  if (lower === "credential" || lower.endsWith("-credential") || lower.includes("-credential-")) {
+    return true;
+  }
+  return false;
+}
+
+export interface PreparedNativePassthroughRequest {
+  body: Record<string, unknown>;
+  bodyText: string;
+  headers: Record<string, string>;
+  carrier: NativePassthroughCarrier | null;
+}
+
+function headerValueToString(value: string | string[]): string {
+  return Array.isArray(value) ? value.join(", ") : value;
+}
+
+function setHeader(headers: Record<string, string>, key: string, value: string): string | null {
+  const lower = key.toLowerCase();
+  for (const existing of Object.keys(headers)) {
+    if (existing.toLowerCase() === lower) {
+      if (existing !== key) {
+        delete headers[existing];
+      }
+      headers[key] = value;
+      return existing;
+    }
+  }
+  headers[key] = value;
+  return null;
+}
+
+function getHeader(headers: Record<string, string>, key: string): string | undefined {
+  const lower = key.toLowerCase();
+  const found = Object.keys(headers).find((name) => name.toLowerCase() === lower);
+  return found ? headers[found] : undefined;
+}
+
+function stripHeader(headers: Record<string, string>, key: string): void {
+  const lower = key.toLowerCase();
+  for (const existing of Object.keys(headers)) {
+    if (existing.toLowerCase() === lower) delete headers[existing];
+  }
+}
+
+function mergeCsvHeader(
+  clientValue: string | undefined,
+  providerValue: string | undefined,
+): string {
+  const values = new Set<string>();
+  for (const raw of [clientValue, providerValue]) {
+    if (!raw) continue;
+    for (const part of raw.split(",")) {
+      const token = part.trim();
+      if (token.length > 0) values.add(token);
+    }
+  }
+  return [...values].join(", ");
+}
+
+export function prepareNativePassthroughRequest(
+  input: NativePassthroughInput,
+  providerHeaders: Record<string, string>,
+  options: {
+    mergeHeaders?: string[];
+    forceAcceptEncodingIdentity?: boolean;
+    preserveClientHeaders?: string[];
+    providerProfileApplied?: string;
+  } = {},
+): PreparedNativePassthroughRequest {
+  const carrier = isNativePassthroughCarrier(input) ? input : null;
+  const body = carrier ? carrier.body : (input as Record<string, unknown>);
+  const ledger = carrier?.mutations;
+  const headers: Record<string, string> = {};
+  const dropped: string[] = [];
+
+  if (carrier) {
+    for (const [key, value] of Object.entries(carrier.headers)) {
+      const lower = key.toLowerCase();
+      if (isUnsafeClientHeader(lower)) {
+        dropped.push(lower);
+        continue;
+      }
+      headers[key] = headerValueToString(value);
+    }
+  }
+
+  if (options.forceAcceptEncodingIdentity === true) {
+    const previous = getHeader(headers, "accept-encoding");
+    setHeader(headers, "accept-encoding", "identity");
+    if (previous !== "identity" && ledger) ledger.accept_encoding_forced_identity = true;
+  }
+
+  const overwritten: string[] = [];
+  const mergeHeaders = new Set((options.mergeHeaders ?? []).map((h) => h.toLowerCase()));
+  const preserveClientHeaders = new Set(
+    (
+      options.preserveClientHeaders ?? [
+        "accept",
+        "accept-language",
+        "originator",
+        "session_id",
+        "user-agent",
+        "x-client-request-id",
+        "x-session-id",
+      ]
+    ).map((h) => h.toLowerCase()),
+  );
+  for (const [key, providerValue] of Object.entries(providerHeaders)) {
+    const lower = key.toLowerCase();
+    const clientValue = getHeader(headers, key);
+    const nextValue = mergeHeaders.has(lower)
+      ? mergeCsvHeader(clientValue, providerValue)
+      : clientValue !== undefined && preserveClientHeaders.has(lower)
+        ? clientValue
+        : providerValue;
+    setHeader(headers, key, nextValue);
+    if (clientValue !== undefined && nextValue !== clientValue) overwritten.push(lower);
+    if ((lower === "authorization" || lower === "x-api-key") && ledger) {
+      ledger.auth_replaced = true;
+    }
+  }
+
+  stripHeader(headers, "content-length");
+  if (dropped.includes("content-length") && ledger) ledger.content_length_recomputed = true;
+
+  if (ledger) {
+    appendMutationList(ledger, "headers_dropped", dropped);
+    appendMutationList(ledger, "headers_overwritten", overwritten);
+    if (options.providerProfileApplied !== undefined) {
+      ledger.provider_profile_applied = options.providerProfileApplied;
+    }
+  }
+
+  return {
+    body,
+    bodyText: carrier?.raw_body ?? JSON.stringify(body),
+    headers,
+    carrier,
+  };
+}

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -146,6 +146,61 @@ describe("createOAuthPoolClient — nativePassthrough", () => {
     expect(r2).toEqual({ served_by: "b", body: NATIVE });
   });
 
+  it("keeps the same native session on the same OAuth account while the sticky TTL is live", async () => {
+    const pt: string[] = [];
+    const selected: string[] = [];
+    let clock = 1_000;
+    const pool = createOAuthPoolClient({
+      members: [ptMember("a", 50, pt), ptMember("b", 50, pt)],
+      now: () => clock,
+      stickyTtlMs: 100,
+      onSelect: (acc) => selected.push(acc),
+    });
+    const firstSession = {
+      protocol: "openai_responses" as const,
+      body: { model: "gpt-5-codex", input: "hi" },
+      headers: { session_id: "sess-1" },
+      mutations: {},
+    };
+    const secondSession = {
+      protocol: "openai_responses" as const,
+      body: { model: "gpt-5-codex", input: "hi" },
+      headers: { session_id: "sess-2" },
+      mutations: {},
+    };
+
+    await pool.nativePassthrough?.(firstSession);
+    clock += 10;
+    await pool.nativePassthrough?.(firstSession);
+    clock += 10;
+    await pool.nativePassthrough?.(secondSession);
+
+    expect(pt).toEqual(["a", "a", "b"]);
+    expect(selected).toEqual(["a", "a", "b"]);
+  });
+
+  it("expires native sticky sessions and returns to LRU selection", async () => {
+    const pt: string[] = [];
+    let clock = 1_000;
+    const pool = createOAuthPoolClient({
+      members: [ptMember("a", 50, pt), ptMember("b", 50, pt)],
+      now: () => clock,
+      stickyTtlMs: 50,
+    });
+    const native = {
+      protocol: "anthropic_messages" as const,
+      body: { model: "claude", messages: [] },
+      headers: { "x-session-id": "sess-expire" },
+      mutations: {},
+    };
+
+    await pool.nativePassthrough?.(native);
+    clock += 100;
+    await pool.nativePassthrough?.(native);
+
+    expect(pt).toEqual(["a", "b"]);
+  });
+
   it("throws fail-closed when the selected member lacks nativePassthrough (never falls back to a sibling)", async () => {
     const pt: string[] = [];
     // The lowest-priority (preferred) member has NO nativePassthrough; the pool must

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -15,6 +15,11 @@
 // silently picks a parked account. Streaming and non-streaming share the SAME
 // selection (one pick per call), so a streamed request also rotates the pool.
 
+import {
+  isNativePassthroughCarrier,
+  type NativePassthroughInput,
+  nativePassthroughBody,
+} from "@helm/shared";
 import type { ChatCompletionRequest, ChatCompletionResponse, ProviderClient } from "../openai.js";
 
 // One account in the pool: its scheduling knobs plus the fully-wired client that
@@ -32,6 +37,9 @@ export interface OAuthPoolDeps {
   members: OAuthPoolMember[];
   // Injected clock (default Date.now) so the LRU cursor is testable.
   now?: () => number;
+  // Native CLI safety: bind repeated requests with the same client/session
+  // fingerprint to the same OAuth account for this TTL.
+  stickyTtlMs?: number;
   // Fires with the selected account on each served call — the seam the gateway
   // uses to record the serving subscription in telemetry / logs (no secrets).
   onSelect?: (account: string) => void;
@@ -45,13 +53,81 @@ interface PoolEntry {
 
 export function createOAuthPoolClient(deps: OAuthPoolDeps): ProviderClient {
   const now = deps.now ?? (() => Date.now());
+  const stickyTtlMs = deps.stickyTtlMs ?? 10 * 60 * 1000;
   const entries: PoolEntry[] = deps.members.map((member) => ({ member, lastUsedAt: 0 }));
+  const stickySessions = new Map<string, { account: string; expiresAt: number }>();
+
+  function headerValue(headers: Record<string, string | string[]>, name: string): string | null {
+    const lower = name.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() !== lower) continue;
+      const text = Array.isArray(value) ? value[0] : value;
+      return text && text.trim().length > 0 ? text.trim() : null;
+    }
+    return null;
+  }
+
+  function bodyString(body: Record<string, unknown>, key: string): string | null {
+    const value = body[key];
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+  }
+
+  function stickyKeyFromNative(input: NativePassthroughInput): string | null {
+    const body = nativePassthroughBody(input);
+    if (isNativePassthroughCarrier(input)) {
+      for (const header of [
+        "session_id",
+        "x-session-id",
+        "x-client-request-id",
+        "prompt_cache_key",
+        "conversation_id",
+      ]) {
+        const value = headerValue(input.headers, header);
+        if (value !== null) return `${header}:${value}`;
+      }
+    }
+    for (const key of [
+      "session_id",
+      "prompt_cache_key",
+      "conversation_id",
+      "previous_response_id",
+    ]) {
+      const value = bodyString(body, key);
+      if (value !== null) return `${key}:${value}`;
+    }
+    const metadata = body.metadata;
+    if (metadata !== null && typeof metadata === "object" && !Array.isArray(metadata)) {
+      for (const key of ["session_id", "conversation_id", "thread_id"]) {
+        const value = bodyString(metadata as Record<string, unknown>, key);
+        if (value !== null) return `metadata.${key}:${value}`;
+      }
+    }
+    return null;
+  }
 
   // Pick the next account: lowest priority, then oldest lastUsedAt (LRU round-
   // robin within equal priority). Bumps the winner's cursor and notifies onSelect.
   // Throws when no member is schedulable (fail-closed — the caller treats it as a
   // provider failure and advances the fallback chain).
-  function select(): PoolEntry {
+  function select(stickyKey?: string | null): PoolEntry {
+    const nowMs = now();
+    if (stickyKey) {
+      const sticky = stickySessions.get(stickyKey);
+      if (sticky !== undefined && sticky.expiresAt > nowMs) {
+        const entry = entries.find(
+          (candidate) =>
+            candidate.member.account === sticky.account && candidate.member.schedulable,
+        );
+        if (entry !== undefined) {
+          entry.lastUsedAt = nowMs;
+          sticky.expiresAt = nowMs + stickyTtlMs;
+          deps.onSelect?.(entry.member.account);
+          return entry;
+        }
+      }
+      stickySessions.delete(stickyKey);
+    }
+
     let best: PoolEntry | undefined;
     for (const e of entries) {
       if (!e.member.schedulable) continue;
@@ -64,7 +140,13 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): ProviderClient {
       }
     }
     if (!best) throw new Error("oauth pool has no schedulable account");
-    best.lastUsedAt = now();
+    best.lastUsedAt = nowMs;
+    if (stickyKey) {
+      stickySessions.set(stickyKey, {
+        account: best.member.account,
+        expiresAt: nowMs + stickyTtlMs,
+      });
+    }
     deps.onSelect?.(best.member.account);
     return best;
   }
@@ -94,12 +176,12 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): ProviderClient {
     // whole pool's provider speaks the same native protocol, so a missing method here
     // signals a real wiring fault, not a normal heterogeneous-chain case.
     async nativePassthrough(
-      body: Record<string, unknown>,
+      body: NativePassthroughInput,
       opts?: { signal?: AbortSignal },
     ): Promise<ChatCompletionResponse> {
       // select() runs SYNCHRONOUSLY at the top of the async body (before any await),
       // so rotation + onSelect fire on the call turn, exactly like the other methods.
-      const { client } = select().member;
+      const { client } = select(stickyKeyFromNative(body)).member;
       if (!client.nativePassthrough) {
         throw new Error("oauth pool member does not support native passthrough");
       }
@@ -111,10 +193,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): ProviderClient {
     // deferring select() into an async body would skip rotation until the consumer drains.
     // Fail-closed (principle 2) if the picked member lacks the method, on the call turn.
     nativePassthroughStream(
-      body: Record<string, unknown>,
+      body: NativePassthroughInput,
       opts?: { signal?: AbortSignal },
     ): AsyncIterable<string> {
-      const { client } = select().member;
+      const { client } = select(stickyKeyFromNative(body)).member;
       if (!client.nativePassthroughStream) {
         throw new Error("oauth pool member does not support native passthrough streaming");
       }

--- a/packages/core/src/provider/oauth/serialize-client.ts
+++ b/packages/core/src/provider/oauth/serialize-client.ts
@@ -15,6 +15,7 @@
 // request flows unserialized with a warn (principle 3 — an auxiliary mechanism
 // must never 5xx a request).
 
+import { nativePassthroughBody } from "@helm/shared";
 import type { KeyedSerialGate, SerialAcquireResult } from "../../queue/keyed-serial-gate.js";
 import type { ChatCompletionRequest, ChatCompletionResponse, ProviderClient } from "../openai.js";
 
@@ -127,7 +128,7 @@ export function createSerializingClient(deps: SerializeClientDeps): ProviderClie
   const innerNative = deps.inner.nativePassthrough;
   if (innerNative) {
     client.nativePassthrough = async (req, opts) => {
-      const lease = await admit(req, opts?.signal);
+      const lease = await admit(nativePassthroughBody(req), opts?.signal);
       if (lease === null) return innerNative(req, opts);
       try {
         return await innerNative(req, opts);
@@ -141,7 +142,7 @@ export function createSerializingClient(deps: SerializeClientDeps): ProviderClie
   if (innerNativeStream) {
     client.nativePassthroughStream = (req, opts) =>
       (async function* () {
-        const lease = await admit(req, opts?.signal);
+        const lease = await admit(nativePassthroughBody(req), opts?.signal);
         if (lease === null) {
           yield* innerNativeStream(req, opts);
           return;

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1415,6 +1415,79 @@ describe("createCodexResponsesClient — nativePassthroughStream", () => {
     expect(h.get("session_id")).toBe("sess-z");
   });
 
+  it("preserves client headers/raw body through the native carrier while replacing auth", async () => {
+    const body = nativeStreamBody();
+    const rawBody = JSON.stringify(body, null, 2);
+    let sentBody = "";
+    let seen: Headers | null = null;
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body,
+      raw_body: rawBody,
+      headers: {
+        authorization: "Bearer client-secret",
+        "content-type": "application/json",
+        accept: "application/json",
+        "openai-beta": "client-beta=1",
+        "user-agent": "codex-client/9.9.9",
+        session_id: "client-session",
+        "x-client-request-id": "client-request-id",
+        "x-client-feature": "keep-me",
+        "x-helm-trace": "internal",
+        "content-length": "999",
+      },
+      mutations: {},
+    };
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      sentBody = String(init?.body);
+      seen = new Headers(init?.headers);
+      return sseStreamResponse([
+        'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n\n',
+      ]);
+    });
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_carrier")}`,
+        sessionId: "sess-z",
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    for await (const _ of client.nativePassthroughStream?.(carrier) ?? []) {
+      // drain
+    }
+
+    const h = seen as unknown as Headers;
+    expect(sentBody).toBe(rawBody);
+    expect(h.get("x-client-feature")).toBe("keep-me");
+    expect(h.get("Authorization")).toContain("Bearer ");
+    expect(h.get("Authorization")).not.toContain("client-secret");
+    expect(h.get("chatgpt-account-id")).toBe("acct_carrier");
+    expect(h.get("user-agent")).toBe("codex-client/9.9.9");
+    expect(h.get("session_id")).toBe("client-session");
+    expect(h.get("x-client-request-id")).toBe("client-request-id");
+    expect(h.get("content-length")).toBeNull();
+    expect(h.get("x-helm-trace")).toBeNull();
+    expect(h.get("accept")).toBe("application/json");
+    const beta = h.get("openai-beta") ?? "";
+    expect(beta).toContain("client-beta=1");
+    expect(beta).toContain("responses=experimental");
+    expect(carrier.mutations).toMatchObject({
+      auth_replaced: true,
+      content_length_recomputed: true,
+    });
+    expect((carrier.mutations as Record<string, unknown>).headers_dropped).toEqual(
+      expect.arrayContaining(["authorization", "content-length", "x-helm-trace"]),
+    );
+    expect((carrier.mutations as Record<string, unknown>).headers_overwritten).toEqual(
+      expect.arrayContaining(["openai-beta"]),
+    );
+    expect((carrier.mutations as Record<string, unknown>).headers_overwritten).not.toEqual(
+      expect.arrayContaining(["accept", "session_id", "x-client-request-id", "user-agent"]),
+    );
+  });
+
   it("throws UpstreamError with the real upstreamStatus + scrubbed body before the first chunk on a non-2xx", async () => {
     const token = jwt("acct_secret_value_1234");
     const client = createCodexResponsesClient({

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -17,6 +17,8 @@
 // ⚠️ ToS: reverse-engineered first-party Codex client; the operator opts in (issue
 // #38 README disclaimer). Request/SSE shapes + identity ported from openclaw (MIT).
 
+import { isNativePassthroughCarrier, type NativePassthroughInput } from "@helm/shared";
+import { prepareNativePassthroughRequest } from "./native-passthrough.js";
 import {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
@@ -331,13 +333,23 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     return changed ? JSON.parse(value) : raw;
   }
 
-  async function request(body: Record<string, unknown>, external?: AbortSignal): Promise<Response> {
+  async function request(input: NativePassthroughInput, external?: AbortSignal): Promise<Response> {
+    const providerHeaders = await headers();
+    if (isNativePassthroughCarrier(input) && cfg.userAgent === undefined) {
+      const hasClientUserAgent = Object.keys(input.headers).some(
+        (name) => name.toLowerCase() === "user-agent",
+      );
+      if (hasClientUserAgent) delete providerHeaders["User-Agent"];
+    }
+    const prepared = prepareNativePassthroughRequest(input, providerHeaders, {
+      mergeHeaders: ["openai-beta"],
+    });
     const t = withTimeout(timeoutMs, external);
     try {
       return await doFetch(url, {
         method: "POST",
-        headers: await headers(),
-        body: JSON.stringify(body),
+        headers: prepared.headers,
+        body: prepared.bodyText,
         signal: t.signal,
       });
     } catch (err) {
@@ -364,7 +376,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   }
 
   async function requestWithRetry(
-    body: Record<string, unknown>,
+    body: NativePassthroughInput,
     external?: AbortSignal,
   ): Promise<Response> {
     const res = await request(body, external);

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -3,6 +3,7 @@
 // (all Phase 1/2). Framework-agnostic (no Hono). Credentials come only from the
 // injected config (env-sourced) and are never logged or echoed. See docs/02.
 
+import type { NativePassthroughInput } from "@helm/shared";
 // Provider credential: EXACTLY ONE of a static `apiKey` or a dynamic
 // `getAuthHeader` (issue #38 OAuth). The dynamic path also accepts:
 //   - `onUnauthorized`: invoked once on an upstream 401 to force a token refresh
@@ -59,7 +60,7 @@ export interface ProviderClient {
   // untranslated. Only same-protocol native clients (Anthropic→Anthropic in Phase 1)
   // implement it; the guard (canUseNativePassthrough) gates when it may be used.
   nativePassthrough?(
-    body: Record<string, unknown>,
+    request: NativePassthroughInput,
     opts?: { signal?: AbortSignal },
   ): Promise<Record<string, unknown>>;
   // Streaming native protocol passthrough (issue #217, Phase 2). The streaming sibling
@@ -69,7 +70,7 @@ export interface ProviderClient {
   // replacing it. OPTIONAL (feature-detected by the executor); only same-protocol native
   // clients implement it, gated by the same guard as nativePassthrough.
   nativePassthroughStream?(
-    body: Record<string, unknown>,
+    request: NativePassthroughInput,
     opts?: { signal?: AbortSignal },
   ): AsyncIterable<string>;
 }

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -4,6 +4,7 @@ import {
   type HelmError,
   type InternalRequest,
   makeHelmError,
+  type NativePassthroughMutationLedger,
   type RoutingSignal,
 } from "@helm/shared";
 import { expandLaneChain } from "../lanes/expand-chain.js";
@@ -109,6 +110,7 @@ export interface ProviderAttempt {
   response_protocol?: InternalRequest["protocol"] | null;
   provider_name?: string | null;
   provider_model?: string | null;
+  passthrough_mutations?: NativePassthroughMutationLedger;
 }
 
 // What execute() returns: the provider_attempts trail, the final landing, and

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { ProtocolSchema, TargetProviderProtocolSchema } from "../request/schema.js";
+import {
+  NativePassthroughMutationLedgerSchema,
+  ProtocolSchema,
+  TargetProviderProtocolSchema,
+} from "../request/schema.js";
 
 // Decision record — the full routing trail for one request: classification,
 // matched policy, selected lane + candidate chain, every provider attempt, and
@@ -106,6 +110,7 @@ export const ProviderAttemptSchema = z.object({
   response_protocol: ProtocolSchema.nullable().optional(),
   provider_name: z.string().nullable().optional(),
   provider_model: z.string().nullable().optional(),
+  passthrough_mutations: NativePassthroughMutationLedgerSchema.optional(),
 });
 
 export const FinalDecisionSchema = z.object({

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -239,6 +239,15 @@ export {
   type ModelsList,
   ModelsListSchema,
 } from "./models/schema.js";
+export {
+  appendMutationList,
+  cloneCarrierWithBody,
+  createNativePassthroughCarrier,
+  isNativePassthroughCarrier,
+  type NativePassthroughInput,
+  nativePassthroughBody,
+  nativePassthroughMutations,
+} from "./native-passthrough.js";
 // Per-account OAuth subscription usage + quota observability (providers page).
 // Fail-open artifacts: usage = today's served traffic; quota = latest rate-limit
 // window snapshot; plus the (untrusted) Anthropic usage-endpoint response shape.
@@ -260,6 +269,10 @@ export {
   InternalRequestSchema,
   type MemoryMode,
   MemoryModeSchema,
+  type NativePassthroughCarrier,
+  NativePassthroughCarrierSchema,
+  type NativePassthroughMutationLedger,
+  NativePassthroughMutationLedgerSchema,
   type OpenAIChatRequest,
   OpenAIChatRequestSchema,
   type Protocol,

--- a/packages/shared/src/native-passthrough.ts
+++ b/packages/shared/src/native-passthrough.ts
@@ -1,0 +1,92 @@
+import type { Protocol } from "./request/schema.js";
+
+export interface NativePassthroughMutationLedger {
+  model_rewritten?: { from: string | null; to: string };
+  memory_appended?: boolean;
+  headers_dropped?: string[];
+  headers_overwritten?: string[];
+  auth_replaced?: boolean;
+  content_length_recomputed?: boolean;
+  accept_encoding_forced_identity?: boolean;
+  provider_profile_applied?: string | null;
+  body_shims_applied?: string[];
+  stream_reframed?: boolean;
+  [key: string]: unknown;
+}
+
+export interface NativePassthroughCarrier {
+  protocol: Extract<Protocol, "anthropic_messages" | "openai_responses">;
+  body: Record<string, unknown>;
+  raw_body?: string;
+  headers: Record<string, string | string[]>;
+  mutations: NativePassthroughMutationLedger;
+}
+
+export type NativePassthroughInput = NativePassthroughCarrier | Record<string, unknown>;
+
+export function isNativePassthroughCarrier(value: unknown): value is NativePassthroughCarrier {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.protocol === "anthropic_messages" || record.protocol === "openai_responses") &&
+    record.body !== null &&
+    typeof record.body === "object" &&
+    !Array.isArray(record.body) &&
+    record.headers !== null &&
+    typeof record.headers === "object" &&
+    !Array.isArray(record.headers) &&
+    record.mutations !== null &&
+    typeof record.mutations === "object" &&
+    !Array.isArray(record.mutations)
+  );
+}
+
+export function nativePassthroughBody(value: NativePassthroughInput): Record<string, unknown> {
+  return isNativePassthroughCarrier(value) ? value.body : value;
+}
+
+export function nativePassthroughMutations(
+  value: NativePassthroughInput,
+): NativePassthroughMutationLedger | undefined {
+  return isNativePassthroughCarrier(value) ? value.mutations : undefined;
+}
+
+export function appendMutationList(
+  ledger: NativePassthroughMutationLedger,
+  key: "headers_dropped" | "headers_overwritten" | "body_shims_applied",
+  values: Iterable<string>,
+): void {
+  const next = new Set([...(ledger[key] ?? [])]);
+  for (const value of values) {
+    if (value.length > 0) next.add(value);
+  }
+  if (next.size > 0) ledger[key] = [...next].sort();
+}
+
+export function cloneCarrierWithBody(
+  carrier: NativePassthroughCarrier,
+  body: Record<string, unknown>,
+  options: { preserveRawBody?: boolean } = {},
+): NativePassthroughCarrier {
+  return {
+    ...carrier,
+    body,
+    ...(options.preserveRawBody === true ? {} : { raw_body: undefined }),
+    mutations: { ...carrier.mutations },
+  };
+}
+
+export function createNativePassthroughCarrier(args: {
+  protocol: NativePassthroughCarrier["protocol"];
+  body: Record<string, unknown>;
+  rawBody?: string;
+  headers: Record<string, string | string[]>;
+}): NativePassthroughCarrier {
+  return {
+    protocol: args.protocol,
+    body: args.body,
+    ...(args.rawBody !== undefined ? { raw_body: args.rawBody } : {}),
+    headers: args.headers,
+    mutations: {},
+  };
+}

--- a/packages/shared/src/request/schema.ts
+++ b/packages/shared/src/request/schema.ts
@@ -31,6 +31,32 @@ const MessageSchema = z.looseObject({ role: z.string(), content: z.unknown() });
 const UnknownRecordSchema = z.record(z.string(), z.unknown());
 const StreamOptionsSchema = z.object({ include_usage: z.boolean().optional() }).passthrough();
 const StopSchema = z.union([z.string(), z.array(z.string())]);
+const NativeHeaderValueSchema = z.union([z.string(), z.array(z.string())]);
+
+export const NativePassthroughMutationLedgerSchema = z
+  .object({
+    model_rewritten: z.object({ from: z.string().nullable(), to: z.string() }).optional(),
+    memory_appended: z.boolean().optional(),
+    headers_dropped: z.array(z.string()).optional(),
+    headers_overwritten: z.array(z.string()).optional(),
+    auth_replaced: z.boolean().optional(),
+    content_length_recomputed: z.boolean().optional(),
+    accept_encoding_forced_identity: z.boolean().optional(),
+    provider_profile_applied: z.string().nullable().optional(),
+    body_shims_applied: z.array(z.string()).optional(),
+    stream_reframed: z.boolean().optional(),
+  })
+  .passthrough();
+
+export const NativePassthroughCarrierSchema = z.object({
+  protocol: z.enum(["anthropic_messages", "openai_responses"]),
+  body: UnknownRecordSchema,
+  raw_body: z.string().optional(),
+  headers: z.record(z.string(), NativeHeaderValueSchema),
+  mutations: NativePassthroughMutationLedgerSchema,
+});
+
+const NativeRequestSchema = z.union([NativePassthroughCarrierSchema, UnknownRecordSchema]);
 
 export const RequestMetadataSchema = z.object({
   conversation_id: z.string().nullable(),
@@ -102,7 +128,7 @@ export const InternalRequestSchema = z.object({
   // Verbatim native request body in InternalRequest.protocol, captured at the
   // route boundary; used ONLY by execute's native-passthrough branch after
   // governance gates prove same-protocol non-stream safe.
-  native_request: UnknownRecordSchema.optional(),
+  native_request: NativeRequestSchema.optional(),
   stream: z.boolean(),
   metadata: RequestMetadataSchema,
 });
@@ -168,3 +194,5 @@ export type TargetProviderProtocol = z.infer<typeof TargetProviderProtocolSchema
 export type MemoryMode = z.infer<typeof MemoryModeSchema>;
 export type RequestMetadata = z.infer<typeof RequestMetadataSchema>;
 export type InternalRequest = z.infer<typeof InternalRequestSchema>;
+export type NativePassthroughCarrier = z.infer<typeof NativePassthroughCarrierSchema>;
+export type NativePassthroughMutationLedger = z.infer<typeof NativePassthroughMutationLedgerSchema>;

--- a/scripts/passthrough/README.md
+++ b/scripts/passthrough/README.md
@@ -1,0 +1,23 @@
+# Native Passthrough Acceptance Scripts
+
+Deterministic checks do not require real provider credentials:
+
+```bash
+pnpm test:passthrough:unit
+pnpm test:passthrough:e2e
+pnpm test:passthrough
+```
+
+Live checks are intentionally fail-closed. They create `artifacts/passthrough-live-report.json` and fail unless the real CLI binary and required local Helm environment are present:
+
+- `HELM_PASSTHROUGH_BASE_URL` - local Helm base URL used by the CLI.
+- `HELM_PASSTHROUGH_API_KEY` - local Helm API key passed to the CLI environment.
+- `HELM_PASSTHROUGH_ADMIN_BASE_URL` - optional admin/API base URL for telemetry checks; defaults to `HELM_PASSTHROUGH_BASE_URL`.
+- `HELM_PASSTHROUGH_ADMIN_BASIC` - optional Basic auth value for `/admin/api/requests`.
+- `HELM_PASSTHROUGH_CLAUDE_COMMAND` - shell command that invokes the installed `claude` CLI against the local Helm instance.
+- `HELM_PASSTHROUGH_CODEX_COMMAND` - shell command that invokes the installed `codex` CLI against the local Helm instance.
+- `HELM_PASSTHROUGH_LIVE_ASSERTIONS_FILE` - optional telemetry JSON if admin access is not exposed to the script. It must contain either a top-level `claude-cli` / `codex-cli` object or a `reports[]` entry with `nativePassthrough: true`, plus optional `traceId`, `providerAlias`, `providerModel`, and `mutationLedger`.
+- Optional `HELM_PASSTHROUGH_EXPECTED_OUTPUT` - sentinel the CLI output must contain; default `HELM_LIVE_OK`.
+- Optional `HELM_PASSTHROUGH_LIVE_TIMEOUT_MS` - per-CLI timeout, default `120000`.
+
+For deterministic local development only, set `HELM_PASSTHROUGH_LIVE_DRY_RUN=1` to write the report without invoking the CLIs. Do not use dry-run for merge or release acceptance.

--- a/scripts/passthrough/deterministic-e2e.ts
+++ b/scripts/passthrough/deterministic-e2e.ts
@@ -1,0 +1,848 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { once } from "node:events";
+import { strict as assert } from "node:assert";
+import { createNativePassthroughCarrier } from "../../packages/shared/src/native-passthrough.js";
+import { createApp } from "../../apps/gateway/src/app.js";
+import { registerMessagesRoute, type MessagesRouteDeps } from "../../apps/gateway/src/routes/messages.js";
+import { registerResponsesRoute, type ResponsesRouteDeps } from "../../apps/gateway/src/routes/responses.js";
+import { createAnthropicClient } from "../../packages/core/src/provider/anthropic.js";
+import { createCodexResponsesClient } from "../../packages/core/src/provider/openai-responses.js";
+import { createCircuitBreaker } from "../../packages/core/src/circuit/breaker.js";
+import type { ProviderClient } from "../../packages/core/src/provider/openai.js";
+import type { ProviderRegistry } from "../../packages/core/src/provider/registry.js";
+import type { InternalRequest, TargetProviderProtocol } from "../../packages/shared/src/request/schema.js";
+import { createExecute } from "../../apps/gateway/src/routes/execute.js";
+
+interface CapturedUpstreamRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[]>;
+  rawBody: Buffer;
+  parsedBody?: unknown;
+}
+
+type Handler = (captured: CapturedUpstreamRequest, res: ServerResponse) => void;
+
+function lowerHeaders(headers: Record<string, string | string[]>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key.toLowerCase()] = Array.isArray(value) ? value.join(", ") : value;
+  }
+  return out;
+}
+
+function jsonResponse(res: ServerResponse, body: unknown, status = 200): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function sseResponse(res: ServerResponse, body: string): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache",
+  });
+  res.end(body);
+}
+
+async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+async function withFakeUpstream<T>(handler: Handler, run: (baseUrl: string, captured: CapturedUpstreamRequest[]) => Promise<T>): Promise<T> {
+  const captured: CapturedUpstreamRequest[] = [];
+  const server = createServer(async (req, res) => {
+    try {
+      const rawBody = await readBody(req);
+      const record: CapturedUpstreamRequest = {
+        method: req.method ?? "",
+        url: req.url ?? "",
+        headers: req.headers as Record<string, string | string[]>,
+        rawBody,
+      };
+      try {
+        record.parsedBody = JSON.parse(rawBody.toString("utf8"));
+      } catch {
+        // Raw bytes are the assertion target for malformed or non-JSON fixtures.
+      }
+      captured.push(record);
+      handler(record, res);
+    } catch (error) {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+    }
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const addr = server.address();
+  assert(addr && typeof addr === "object", "fake upstream did not bind a TCP port");
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+  try {
+    return await run(baseUrl, captured);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+}
+
+function jwt(accountId: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+  ).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+async function collect(iterable: AsyncIterable<string>): Promise<string> {
+  let out = "";
+  for await (const chunk of iterable) out += chunk;
+  return out;
+}
+
+function registry(args: {
+  alias: string;
+  providerName: string;
+  providerModel: string;
+  targetProviderProtocol: TargetProviderProtocol;
+}): ProviderRegistry {
+  return {
+    resolve(alias: string) {
+      if (alias !== args.alias) return { ok: false, error: { kind: "unknown_alias", alias } };
+      return {
+        ok: true,
+        value: {
+          alias,
+          providerName: args.providerName,
+          providerModel: args.providerModel,
+          baseUrl: "http://fake",
+          apiKeyEnv: "FAKE",
+          targetProviderProtocol: args.targetProviderProtocol,
+          providerRequiresCompatibilityRewrite: false,
+        },
+      };
+    },
+    list: () => [args.alias],
+  };
+}
+
+function internalRequest(over: Partial<InternalRequest>): InternalRequest {
+  return {
+    request_id: "passthrough-e2e",
+    protocol: "anthropic_messages",
+    account_id: "acct",
+    api_key_id: "key",
+    user_id: null,
+    org_id: null,
+    requested_model: "auto",
+    messages: [{ role: "user", content: "hi" }],
+    tools: null,
+    response_format: null,
+    attachments: null,
+    max_tokens: null,
+    stream: false,
+    metadata: {
+      conversation_id: null,
+      thread_id: null,
+      resource_id: null,
+      project_id: null,
+      memory_mode: "off",
+    },
+    ...over,
+  };
+}
+
+function executeWithProvider(args: {
+  alias: string;
+  providerName: string;
+  providerModel: string;
+  targetProviderProtocol: TargetProviderProtocol;
+  provider: ProviderClient;
+}) {
+  return createExecute({
+    defaultProvider: args.provider,
+    providers: new Map([[args.providerName, args.provider]]),
+    registry: registry(args),
+    breaker: createCircuitBreaker({ config: { failureThreshold: 5, cooldownMs: 1_000 } }),
+    catalog: new Map(),
+    now: () => 0,
+    signal: new AbortController().signal,
+    nativeProtocolPassthroughEnabled: () => true,
+  });
+}
+
+const ROUTE_DECISION = { final: { status: "ok", model_alias: "native-route" } } as never;
+
+function routeApp() {
+  return createApp({ logger: { log: () => {} }, genTraceId: () => "trace-route-passthrough" });
+}
+
+async function* rawSseFrames(raw: string): AsyncIterable<Record<string, unknown>> {
+  const normalized = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  for (const block of normalized.split("\n\n")) {
+    if (block === "") continue;
+    const frameRaw = `${block}\n\n`;
+    let event = "";
+    const dataLines: string[] = [];
+    for (const line of block.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice("event:".length).replace(/^ /, "");
+      else if (line.startsWith("data:")) {
+        dataLines.push(line.slice("data:".length).replace(/^ /, ""));
+      }
+    }
+    if (dataLines.length === 0) {
+      yield { raw: frameRaw };
+    } else {
+      yield { event, data: dataLines.join("\n"), raw: frameRaw };
+    }
+  }
+}
+
+function messagesErrorOut(err: {
+  error_class: string;
+  message: string;
+  trace_id: string;
+}): { status: number; body: unknown } {
+  const status =
+    err.error_class === "auth_error"
+      ? 401
+      : err.error_class === "invalid_request"
+        ? 400
+        : err.error_class === "rate_limited"
+          ? 429
+          : 502;
+  return {
+    status,
+    body: { type: "error", error: { type: err.error_class, message: err.message } },
+  };
+}
+
+function routeRejectLimiter() {
+  return {
+    check: async () => ({
+      allowed: false,
+      limit: 1,
+      remaining: 0,
+      resetSeconds: 60,
+      retryAfterSeconds: 60,
+      limitedBy: "rpm" as const,
+    }),
+  };
+}
+
+async function testAnthropicNonStream(): Promise<void> {
+  const rawBody = '{\n  "model":"claude-client-alias",\n  "max_tokens":8,\n  "messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],\n  "future_field":{"nested":true}\n}';
+  const upstream = {
+    id: "msg_passthrough_acceptance",
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+
+  await withFakeUpstream(
+    (captured, res) => {
+      assert.equal(captured.url, "/v1/messages");
+      jsonResponse(res, upstream);
+    },
+    async (baseUrl, captured) => {
+      const carrier = createNativePassthroughCarrier({
+        protocol: "anthropic_messages",
+        body: JSON.parse(rawBody) as Record<string, unknown>,
+        rawBody,
+        headers: {
+          authorization: "Bearer helm-client-key",
+          "x-api-key": "client-upstream-key",
+          "x-helm-trace-id": "trace-client",
+          connection: "keep-alive",
+          "content-length": "999",
+          "accept-language": "en-US",
+          "anthropic-beta": "client-beta",
+        },
+      });
+      const client = createAnthropicClient({
+        config: { baseUrl, apiKey: "provider-anthropic-key", timeoutMs: 2_000 },
+      });
+
+      const response = await client.nativePassthrough?.(carrier);
+      assert.deepEqual(response, upstream);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0]?.rawBody.toString("utf8"), rawBody);
+      const headers = lowerHeaders(captured[0]?.headers ?? {});
+      assert.equal(headers["x-api-key"], "provider-anthropic-key");
+      assert.equal(headers["authorization"], undefined);
+      assert.equal(headers["x-helm-trace-id"], undefined);
+      assert.equal(headers["accept-language"], "en-US");
+      assert.equal(carrier.mutations.auth_replaced, true);
+      assert.equal(JSON.stringify(carrier.mutations).includes("helm-client-key"), false);
+    },
+  );
+}
+
+async function testAnthropicExecuteModelRewrite(): Promise<void> {
+  const clientBody = {
+    model: "anthropic/claude-client-alias",
+    max_tokens: 8,
+    messages: [{ role: "user", content: "hi" }],
+    future_field: { nested: true },
+  };
+  const upstream = {
+    id: "msg_rewrite_acceptance",
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+
+  await withFakeUpstream(
+    (_captured, res) => jsonResponse(res, upstream),
+    async (baseUrl, captured) => {
+      const carrier = createNativePassthroughCarrier({
+        protocol: "anthropic_messages",
+        body: clientBody,
+        rawBody: JSON.stringify(clientBody),
+        headers: { "x-api-key": "client-key", "x-client-feature": "keep" },
+      });
+      const provider = createAnthropicClient({
+        config: { baseUrl, apiKey: "provider-key", timeoutMs: 2_000 },
+      });
+      const execute = executeWithProvider({
+        alias: "a",
+        providerName: "anthropic",
+        providerModel: "claude-upstream",
+        targetProviderProtocol: "anthropic_messages",
+        provider,
+      });
+
+      const out = await execute(
+        { selected_lane: "balanced", candidate_chain: ["a"], explicit_model: null },
+        internalRequest({
+          protocol: "anthropic_messages",
+          native_request: carrier,
+        }),
+      );
+
+      assert.equal(out.nativePassthrough, true);
+      assert.equal(captured.length, 1);
+      const parsed = captured[0]?.parsedBody as Record<string, unknown>;
+      assert.equal(parsed.model, "claude-upstream");
+      assert.deepEqual(parsed.future_field, { nested: true });
+      assert.deepEqual(carrier.mutations.model_rewritten, {
+        from: "anthropic/claude-client-alias",
+        to: "claude-upstream",
+      });
+      assert.equal(out.attempts[0]?.passthrough_mutations?.model_rewritten?.to, "claude-upstream");
+    },
+  );
+}
+
+async function testAnthropicStreamSafetyHeaders(): Promise<void> {
+  const rawBody =
+    '{"model":"claude-upstream","stream":true,"max_tokens":8,"messages":[{"role":"user","content":"hi"}]}';
+  const upstreamSse =
+    'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stream"}}\n\n' +
+    'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+
+  await withFakeUpstream(
+    (_captured, res) => sseResponse(res, upstreamSse),
+    async (baseUrl, captured) => {
+      const carrier = createNativePassthroughCarrier({
+        protocol: "anthropic_messages",
+        body: JSON.parse(rawBody) as Record<string, unknown>,
+        rawBody,
+        headers: {
+          "accept-encoding": "br, gzip",
+          "anthropic-beta": "client-beta",
+          "x-client-feature": "keep",
+        },
+      });
+      const client = createAnthropicClient({
+        config: { baseUrl, getAuthHeader: async () => "Bearer provider-oauth", timeoutMs: 2_000 },
+      });
+
+      const response = await collect(client.nativePassthroughStream?.(carrier) ?? []);
+
+      assert.equal(response, upstreamSse);
+      assert.equal(captured.length, 1);
+      const headers = lowerHeaders(captured[0]?.headers ?? {});
+      assert.equal(headers["accept-encoding"], "identity");
+      assert.equal(headers["x-client-feature"], "keep");
+      assert.equal(headers["anthropic-beta"]?.includes("client-beta"), true);
+      assert.equal(carrier.mutations.accept_encoding_forced_identity, true);
+    },
+  );
+}
+
+async function testResponsesStreamLifecycle(): Promise<void> {
+  const rawBody = '{"model":"gpt-5-codex","input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}],"stream":true,"store":false,"unknown_top":{"kept":true}}';
+  const upstreamSse = [
+    ": upstream keepalive\n\n",
+    'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_upstream_123","status":"in_progress"}}\n\n',
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","response_id":"resp_upstream_123","delta":"ok"}\n\n',
+    'event: vendor.unknown\ndata: {"opaque":true}\n\n',
+    'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_upstream_123","status":"completed"}}\n\n',
+  ].join("");
+
+  await withFakeUpstream(
+    (captured, res) => {
+      assert.equal(captured.url, "/responses");
+      sseResponse(res, upstreamSse);
+    },
+    async (baseUrl, captured) => {
+      const carrier = createNativePassthroughCarrier({
+        protocol: "openai_responses",
+        body: JSON.parse(rawBody) as Record<string, unknown>,
+        rawBody,
+        headers: {
+          authorization: "Bearer helm-client-key",
+          "x-api-key": "client-upstream-key",
+          "x-helm-internal": "drop-me",
+          "user-agent": "codex-cli/0.1.0",
+          "x-session-id": "sess-client",
+          "openai-beta": "client-beta",
+        },
+      });
+      const client = createCodexResponsesClient({
+        config: {
+          baseUrl,
+          getAuthHeader: async () => `Bearer ${jwt("acct_passthrough")}`,
+          timeoutMs: 2_000,
+        },
+      });
+
+      const response = await collect(client.nativePassthroughStream?.(carrier) ?? []);
+      assert.equal(response, upstreamSse);
+      assert.equal(response.includes("helm"), false);
+      assert.equal(response.includes("resp_upstream_123"), true);
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0]?.rawBody.toString("utf8"), rawBody);
+      const headers = lowerHeaders(captured[0]?.headers ?? {});
+      assert.equal(headers.authorization?.startsWith("Bearer "), true);
+      assert.equal(headers["x-api-key"], undefined);
+      assert.equal(headers["x-helm-internal"], undefined);
+      assert.equal(headers["x-session-id"], "sess-client");
+      assert.equal(headers["openai-beta"], "client-beta, responses=experimental");
+      assert.equal(carrier.mutations.auth_replaced, true);
+      assert.equal(JSON.stringify(carrier.mutations).includes("helm-client-key"), false);
+    },
+  );
+}
+
+async function testResponsesExecuteStoreForcedFalse(): Promise<void> {
+  const clientBody = {
+    model: "codex/gpt-client-alias",
+    input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    store: true,
+    future_field: { preserved: true },
+  };
+  const upstream = {
+    id: "resp_store_false",
+    object: "response",
+    status: "completed",
+    output: [],
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+
+  await withFakeUpstream(
+    (_captured, res) => jsonResponse(res, upstream),
+    async (baseUrl, captured) => {
+      const carrier = createNativePassthroughCarrier({
+        protocol: "openai_responses",
+        body: clientBody,
+        rawBody: JSON.stringify(clientBody),
+        headers: {
+          authorization: "Bearer client-key",
+          "x-helm-internal": "drop",
+          "x-session-id": "sess-client",
+        },
+      });
+      const provider = createCodexResponsesClient({
+        config: {
+          baseUrl,
+          getAuthHeader: async () => `Bearer ${jwt("acct_store")}`,
+          timeoutMs: 2_000,
+        },
+      });
+      const execute = executeWithProvider({
+        alias: "r",
+        providerName: "codex",
+        providerModel: "gpt-5-codex",
+        targetProviderProtocol: "openai_responses",
+        provider,
+      });
+
+      const out = await execute(
+        { selected_lane: "balanced", candidate_chain: ["r"], explicit_model: null },
+        internalRequest({
+          protocol: "openai_responses",
+          native_request: carrier,
+        }),
+      );
+
+      assert.equal(out.nativePassthrough, true);
+      assert.equal(captured.length, 1);
+      const parsed = captured[0]?.parsedBody as Record<string, unknown>;
+      assert.equal(parsed.model, "gpt-5-codex");
+      assert.equal(parsed.store, false);
+      assert.deepEqual(parsed.future_field, { preserved: true });
+      assert.deepEqual(carrier.mutations.body_shims_applied, ["store_forced_false"]);
+      assert.equal(carrier.mutations.model_rewritten?.to, "gpt-5-codex");
+      const headers = lowerHeaders(captured[0]?.headers ?? {});
+      assert.equal(headers["x-helm-internal"], undefined);
+      assert.equal(headers["x-session-id"], "sess-client");
+    },
+  );
+}
+
+async function testResponsesExecuteStreamReframed(): Promise<void> {
+  const rawBody =
+    '{"model":"codex/gpt-client-alias","input":"hi","stream":true,"store":false,"unknown":1}';
+  const upstreamSse =
+    'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_stream","status":"completed"}}\n\n';
+
+  await withFakeUpstream(
+    (_captured, res) => sseResponse(res, upstreamSse),
+    async (baseUrl, captured) => {
+      const carrier = createNativePassthroughCarrier({
+        protocol: "openai_responses",
+        body: JSON.parse(rawBody) as Record<string, unknown>,
+        rawBody,
+        headers: { authorization: "Bearer client-key" },
+      });
+      const provider = createCodexResponsesClient({
+        config: {
+          baseUrl,
+          getAuthHeader: async () => `Bearer ${jwt("acct_stream")}`,
+          timeoutMs: 2_000,
+        },
+      });
+      const execute = executeWithProvider({
+        alias: "r",
+        providerName: "codex",
+        providerModel: "gpt-5-codex",
+        targetProviderProtocol: "openai_responses",
+        provider,
+      });
+
+      const out = await execute(
+        { selected_lane: "balanced", candidate_chain: ["r"], explicit_model: null },
+        internalRequest({
+          protocol: "openai_responses",
+          stream: true,
+          native_request: carrier,
+        }),
+      );
+
+      assert.equal(out.nativePassthrough, true);
+      assert.equal(await collect(out.stream ?? []), upstreamSse);
+      assert.equal(captured.length, 1);
+      const parsed = captured[0]?.parsedBody as Record<string, unknown>;
+      assert.equal(parsed.model, "gpt-5-codex");
+      assert.equal(parsed.unknown, 1);
+      assert.equal(carrier.mutations.stream_reframed, true);
+    },
+  );
+}
+
+async function testGovernanceDisabledPassthroughAvoidsUpstream(): Promise<void> {
+  await withFakeUpstream(
+    () => {
+      throw new Error("upstream must not be called");
+    },
+    async (_baseUrl, captured) => {
+      const provider: ProviderClient = {
+        chatCompletion: async () => ({ id: "translated" }),
+        chatCompletionStream: async function* () {
+          yield 'event: translated\ndata: {}\n\n';
+        },
+        nativePassthrough: async () => {
+          throw new Error("native passthrough should be disabled");
+        },
+        nativePassthroughStream: async function* () {
+          throw new Error("native passthrough stream should be disabled");
+        },
+      };
+      const execute = createExecute({
+        defaultProvider: provider,
+        providers: new Map([["codex", provider]]),
+        registry: registry({
+          alias: "r",
+          providerName: "codex",
+          providerModel: "gpt-5-codex",
+          targetProviderProtocol: "openai_responses",
+        }),
+        breaker: createCircuitBreaker({ config: { failureThreshold: 5, cooldownMs: 1_000 } }),
+        catalog: new Map(),
+        now: () => 0,
+        signal: new AbortController().signal,
+        nativeProtocolPassthroughEnabled: () => false,
+      });
+
+      await execute(
+        { selected_lane: "balanced", candidate_chain: ["r"], explicit_model: null },
+        internalRequest({
+          protocol: "openai_responses",
+          native_request: createNativePassthroughCarrier({
+            protocol: "openai_responses",
+            body: { model: "codex/gpt-client-alias", input: "hi" },
+            headers: {},
+          }),
+        }),
+      ).catch(() => undefined);
+
+      assert.equal(captured.length, 0);
+    },
+  );
+}
+
+async function testMessagesRouteNativeStreamPreservesRawSseFrames(): Promise<void> {
+  const body = {
+    model: "claude-client-alias",
+    stream: true,
+    max_tokens: 8,
+    messages: [{ role: "user", content: "hi" }],
+    future_field: { nested: true },
+  };
+  const upstreamSse = [
+    ": upstream keepalive\n\n",
+    'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_route_1"}}\n\n',
+    'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}\n\n',
+    ": upstream heartbeat\n\n",
+    'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+  ].join("");
+  let pipelineCalls = 0;
+  let transformBackCalls = 0;
+  let streamTransformCalls = 0;
+
+  const deps: MessagesRouteDeps = {
+    auth: { resolve: async (credential) => (credential === "route-key" ? { keyId: "k1", accountId: "acct" } : null) },
+    transformers: {
+      anthropic: {
+        transformRequestOut: (native) => ({
+          model: (native as { model?: string }).model,
+          messages: (native as { messages?: unknown }).messages,
+          stream: (native as { stream?: boolean }).stream,
+          metadata: {},
+        }),
+        transformResponseOut: (ir) => {
+          transformBackCalls += 1;
+          return ir;
+        },
+        transformStreamOut: (event) => {
+          streamTransformCalls += 1;
+          return { event: String(event.type ?? "translated"), data: JSON.stringify(event) };
+        },
+        transformErrorOut: messagesErrorOut,
+      },
+    },
+    pipeline: {
+      run: async (ir) => {
+        pipelineCalls += 1;
+        const carrier = ir.metadata?.native_request as { protocol?: string; body?: unknown } | undefined;
+        assert.equal(carrier?.protocol, "anthropic_messages");
+        assert.deepEqual(carrier?.body, body);
+        return {
+          decision: ROUTE_DECISION,
+          nativePassthrough: true,
+          collect: async () => {
+            throw new Error("streaming route must not collect");
+          },
+          streamIR: () => rawSseFrames(upstreamSse),
+        };
+      },
+    },
+  };
+  const app = routeApp();
+  registerMessagesRoute(app, deps);
+
+  const res = await app.request("/v1/messages", {
+    method: "POST",
+    headers: { "x-api-key": "route-key", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), upstreamSse);
+  assert.equal(pipelineCalls, 1);
+  assert.equal(transformBackCalls, 0);
+  assert.equal(streamTransformCalls, 0);
+}
+
+async function testResponsesRouteNativeStreamPreservesRawSseFrames(): Promise<void> {
+  const body = {
+    model: "codex/gpt-client-alias",
+    input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    stream: true,
+    store: false,
+    future_field: { nested: true },
+  };
+  const upstreamSse = [
+    ": upstream keepalive\n\n",
+    'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_route_1","status":"in_progress"}}\n\n',
+    'event: response.in_progress\ndata: {"type":"response.in_progress","response":{"id":"resp_route_1","status":"in_progress"}}\n\n',
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","response_id":"resp_route_1","delta":"ok"}\n\n',
+    ": upstream heartbeat\n\n",
+    'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_route_1","status":"completed"}}\n\n',
+  ].join("");
+  let pipelineCalls = 0;
+  let transformBackCalls = 0;
+  let streamTransformCalls = 0;
+
+  const deps: ResponsesRouteDeps = {
+    auth: { resolve: async (credential) => (credential === "route-key" ? { keyId: "k1", accountId: "acct" } : null) },
+    transformer: {
+      transformRequestOut: (native) => ({
+        model: (native as { model?: string }).model,
+        messages: [{ role: "user", content: "hi" }],
+        stream: (native as { stream?: boolean }).stream,
+        metadata: {},
+      }),
+      transformResponseOut: (ir) => {
+        transformBackCalls += 1;
+        return ir;
+      },
+      transformStreamOut: (event) => {
+        streamTransformCalls += 1;
+        return { event: String(event.type ?? "translated"), data: JSON.stringify(event) };
+      },
+    },
+    pipeline: {
+      run: async (ir) => {
+        pipelineCalls += 1;
+        const carrier = ir.metadata?.native_request as { protocol?: string; body?: unknown } | undefined;
+        assert.equal(carrier?.protocol, "openai_responses");
+        assert.deepEqual(carrier?.body, body);
+        return {
+          decision: ROUTE_DECISION,
+          nativePassthrough: true,
+          collect: async () => {
+            throw new Error("streaming route must not collect");
+          },
+          streamIR: () => rawSseFrames(upstreamSse),
+        };
+      },
+    },
+  };
+  const app = routeApp();
+  registerResponsesRoute(app, deps);
+
+  const res = await app.request("/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer route-key", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), upstreamSse);
+  assert.equal(pipelineCalls, 1);
+  assert.equal(transformBackCalls, 0);
+  assert.equal(streamTransformCalls, 0);
+}
+
+async function testMessagesRouteGovernanceRejectAvoidsPipelineForwarding(): Promise<void> {
+  let transformCalls = 0;
+  let pipelineCalls = 0;
+  const app = routeApp();
+  registerMessagesRoute(app, {
+    rateLimiter: routeRejectLimiter(),
+    auth: { resolve: async () => ({ keyId: "k1", accountId: "acct" }) },
+    transformers: {
+      anthropic: {
+        transformRequestOut: () => {
+          transformCalls += 1;
+          return { model: "m", messages: [{ role: "user", content: "hi" }], stream: true, metadata: {} };
+        },
+        transformResponseOut: (ir) => ir,
+        transformStreamOut: (event) => ({ event: String(event.type ?? "translated"), data: JSON.stringify(event) }),
+        transformErrorOut: messagesErrorOut,
+      },
+    },
+    pipeline: {
+      run: async () => {
+        pipelineCalls += 1;
+        throw new Error("governance reject must not reach the pipeline");
+      },
+    },
+  });
+
+  const res = await app.request("/v1/messages", {
+    method: "POST",
+    headers: { "x-api-key": "route-key", "content-type": "application/json" },
+    body: JSON.stringify({ model: "claude", stream: true, max_tokens: 8, messages: [{ role: "user", content: "hi" }] }),
+  });
+
+  assert.equal(res.status, 429);
+  assert.equal(transformCalls, 0);
+  assert.equal(pipelineCalls, 0);
+}
+
+async function testResponsesRouteGovernanceRejectAvoidsPipelineForwarding(): Promise<void> {
+  let transformCalls = 0;
+  let pipelineCalls = 0;
+  const app = routeApp();
+  registerResponsesRoute(app, {
+    rateLimiter: routeRejectLimiter(),
+    auth: { resolve: async () => ({ keyId: "k1", accountId: "acct" }) },
+    transformer: {
+      transformRequestOut: () => {
+        transformCalls += 1;
+        return { model: "m", messages: [{ role: "user", content: "hi" }], stream: true, metadata: {} };
+      },
+      transformResponseOut: (ir) => ir,
+      transformStreamOut: (event) => ({ event: String(event.type ?? "translated"), data: JSON.stringify(event) }),
+    },
+    pipeline: {
+      run: async () => {
+        pipelineCalls += 1;
+        throw new Error("governance reject must not reach the pipeline");
+      },
+    },
+  });
+
+  const res = await app.request("/v1/responses", {
+    method: "POST",
+    headers: { authorization: "Bearer route-key", "content-type": "application/json" },
+    body: JSON.stringify({ model: "gpt", input: "hi", stream: true, store: false }),
+  });
+
+  assert.equal(res.status, 429);
+  assert.equal(transformCalls, 0);
+  assert.equal(pipelineCalls, 0);
+}
+
+async function main(): Promise<void> {
+  const tests = [
+    testAnthropicNonStream,
+    testAnthropicExecuteModelRewrite,
+    testAnthropicStreamSafetyHeaders,
+    testResponsesStreamLifecycle,
+    testResponsesExecuteStoreForcedFalse,
+    testResponsesExecuteStreamReframed,
+    testGovernanceDisabledPassthroughAvoidsUpstream,
+    testMessagesRouteNativeStreamPreservesRawSseFrames,
+    testResponsesRouteNativeStreamPreservesRawSseFrames,
+    testMessagesRouteGovernanceRejectAvoidsPipelineForwarding,
+    testResponsesRouteGovernanceRejectAvoidsPipelineForwarding,
+  ];
+  let failures = 0;
+  for (const test of tests) {
+    try {
+      await test();
+      console.log(`ok - ${test.name}`);
+    } catch (error) {
+      failures += 1;
+      console.error(`not ok - ${test.name}`);
+      console.error(error);
+    }
+  }
+  if (failures > 0) throw new Error(`passthrough deterministic e2e failed (${failures} cases)`);
+  console.log(`ok - passthrough deterministic e2e (${tests.length} cases)`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/passthrough/live-cli.ts
+++ b/scripts/passthrough/live-cli.ts
@@ -1,0 +1,365 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+type Mode = "claude-cli" | "codex-cli";
+
+type Assertion = {
+  name: string;
+  passed: boolean;
+  details?: string;
+};
+
+type CliReport = {
+  cli: Mode;
+  version: string | null;
+  helmBaseUrl: string | null;
+  traceId: string | null;
+  providerAlias: string | null;
+  providerModel: string | null;
+  nativePassthrough: boolean | null;
+  mutationLedger: Record<string, unknown> | null;
+  exitCode: number | null;
+  stdoutSummary: string;
+  stderrSummary: string;
+  dryRun: boolean;
+  assertions: Assertion[];
+};
+
+type LiveReport = {
+  generatedAt: string;
+  status: "passed" | "failed" | "dry-run";
+  reports: CliReport[];
+};
+
+const REPORT_PATH = resolve("artifacts/passthrough-live-report.json");
+const DRY_RUN_ENV = "HELM_PASSTHROUGH_LIVE_DRY_RUN";
+const COMMON_REQUIRED_ENV = ["HELM_PASSTHROUGH_BASE_URL", "HELM_PASSTHROUGH_API_KEY"];
+const ASSERTIONS_FILE_ENV = "HELM_PASSTHROUGH_LIVE_ASSERTIONS_FILE";
+const EXPECTED_OUTPUT_ENV = "HELM_PASSTHROUGH_EXPECTED_OUTPUT";
+const CLI_CONFIG: Record<Mode, { binary: string; commandEnv: string; protocol: string }> = {
+  "claude-cli": {
+    binary: "claude",
+    commandEnv: "HELM_PASSTHROUGH_CLAUDE_COMMAND",
+    protocol: "anthropic_messages",
+  },
+  "codex-cli": {
+    binary: "codex",
+    commandEnv: "HELM_PASSTHROUGH_CODEX_COMMAND",
+    protocol: "openai_responses",
+  },
+};
+
+function summarize(value: string, limit = 1_000): string {
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  return trimmed.length <= limit ? trimmed : `${trimmed.slice(0, limit)}...`;
+}
+
+function secretEnvValues(): string[] {
+  return Object.entries(process.env)
+    .filter(([key, value]) => {
+      if (!value || value.length < 4) return false;
+      return /(key|token|secret|password|credential|authorization|auth|basic)/i.test(key);
+    })
+    .map(([, value]) => value as string)
+    .filter((value, index, all) => all.indexOf(value) === index);
+}
+
+export function summarizeCliOutput(value: string, expectedOutput: string): string {
+  const bytes = Buffer.byteLength(value);
+  const lines = value.length === 0 ? 0 : value.split(/\r\n|\r|\n/).length;
+  const digest = createHash("sha256").update(value).digest("hex").slice(0, 16);
+  const redacted = secretEnvValues().reduce(
+    (text, secret) => text.split(secret).join("[redacted]"),
+    value,
+  );
+  const leakedSecret = redacted !== value;
+  const sentinelPresent = value.includes(expectedOutput);
+  return [
+    "redacted output summary",
+    `bytes:${bytes}`,
+    `lines:${lines}`,
+    `sha256:${digest}`,
+    `sentinel_present:${sentinelPresent}`,
+    `secret_redacted:${leakedSecret}`,
+  ].join(", ");
+}
+
+function assertionEvidenceFor(mode: Mode): Record<string, unknown> | null {
+  const file = process.env[ASSERTIONS_FILE_ENV];
+  if (!file) return null;
+  if (!existsSync(file)) return null;
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>;
+  const direct = parsed[mode];
+  if (direct && typeof direct === "object" && !Array.isArray(direct)) {
+    return direct as Record<string, unknown>;
+  }
+  const reports = parsed.reports;
+  if (Array.isArray(reports)) {
+    const found = reports.find(
+      (item): item is Record<string, unknown> =>
+        item !== null &&
+        typeof item === "object" &&
+        !Array.isArray(item) &&
+        item.cli === mode,
+    );
+    return found ?? null;
+  }
+  return null;
+}
+
+function applyTelemetryEvidence(report: CliReport, evidence: Record<string, unknown> | null): boolean {
+  if (evidence === null) return false;
+  if (typeof evidence.traceId === "string") report.traceId = evidence.traceId;
+  if (typeof evidence.trace_id === "string") report.traceId = evidence.trace_id;
+  if (typeof evidence.providerAlias === "string") report.providerAlias = evidence.providerAlias;
+  if (typeof evidence.provider_name === "string") report.providerAlias = evidence.provider_name;
+  if (typeof evidence.providerModel === "string") report.providerModel = evidence.providerModel;
+  if (typeof evidence.provider_model === "string") report.providerModel = evidence.provider_model;
+  if (typeof evidence.nativePassthrough === "boolean") {
+    report.nativePassthrough = evidence.nativePassthrough;
+  }
+  if (typeof evidence.passthrough_used === "boolean") {
+    report.nativePassthrough = evidence.passthrough_used;
+  }
+  const ledger = evidence.mutationLedger ?? evidence.passthrough_mutations;
+  if (ledger && typeof ledger === "object" && !Array.isArray(ledger)) {
+    report.mutationLedger = ledger as Record<string, unknown>;
+  }
+  return report.nativePassthrough === true;
+}
+
+function commandExists(binary: string): { exists: boolean; version: string | null; stderr: string } {
+  const which = spawnSync("which", [binary], { encoding: "utf8" });
+  if (which.status !== 0) {
+    return { exists: false, version: null, stderr: summarize(which.stderr) };
+  }
+  const version = spawnSync(binary, ["--version"], { encoding: "utf8", timeout: 5_000 });
+  return {
+    exists: true,
+    version: summarize(version.stdout || version.stderr) || null,
+    stderr: summarize(version.stderr),
+  };
+}
+
+function baseReport(mode: Mode, dryRun: boolean): CliReport {
+  return {
+    cli: mode,
+    version: null,
+    helmBaseUrl: process.env.HELM_PASSTHROUGH_BASE_URL ?? null,
+    traceId: null,
+    providerAlias: process.env[`HELM_PASSTHROUGH_${mode === "claude-cli" ? "CLAUDE" : "CODEX"}_PROVIDER_ALIAS`] ?? null,
+    providerModel: process.env[`HELM_PASSTHROUGH_${mode === "claude-cli" ? "CLAUDE" : "CODEX"}_MODEL`] ?? null,
+    nativePassthrough: null,
+    mutationLedger: null,
+    exitCode: null,
+    stdoutSummary: "",
+    stderrSummary: "",
+    dryRun,
+    assertions: [],
+  };
+}
+
+function addAssertion(report: CliReport, name: string, passed: boolean, details?: string): void {
+  report.assertions.push({ name, passed, ...(details ? { details } : {}) });
+}
+
+function adminBaseUrl(): string | null {
+  return process.env.HELM_PASSTHROUGH_ADMIN_BASE_URL ?? process.env.HELM_PASSTHROUGH_BASE_URL ?? null;
+}
+
+function adminHeaders(): Record<string, string> {
+  const basic = process.env.HELM_PASSTHROUGH_ADMIN_BASIC;
+  if (!basic) return {};
+  return {
+    authorization: basic.startsWith("Basic ")
+      ? basic
+      : `Basic ${Buffer.from(basic).toString("base64")}`,
+  };
+}
+
+function attemptMatchesProtocol(attempt: unknown, protocol: string): boolean {
+  const record = attempt as Record<string, unknown>;
+  return (
+    record.passthrough_used === true &&
+    record.source_protocol === protocol &&
+    record.response_protocol === protocol
+  );
+}
+
+async function fetchAdminJson(path: string): Promise<unknown> {
+  const base = adminBaseUrl();
+  if (!base) throw new Error("missing HELM_PASSTHROUGH_ADMIN_BASE_URL/HELM_PASSTHROUGH_BASE_URL");
+  const res = await fetch(`${base.replace(/\/$/, "")}${path}`, { headers: adminHeaders() });
+  if (!res.ok) throw new Error(`admin ${path} returned HTTP ${res.status}`);
+  return await res.json();
+}
+
+async function telemetryEvidenceFromAdmin(
+  traceId: string | null,
+  protocol: string,
+): Promise<Record<string, unknown> | null> {
+  let detail: Record<string, unknown> | null = null;
+  if (traceId) {
+    detail = (await fetchAdminJson(`/admin/api/requests/${encodeURIComponent(traceId)}`)) as Record<
+      string,
+      unknown
+    >;
+  } else {
+    const page = (await fetchAdminJson("/admin/api/requests?pageSize=20")) as { items?: unknown[] };
+    detail =
+      ((page.items ?? []).find((item) =>
+        ((item as { provider_attempts?: unknown[] }).provider_attempts ?? []).some((attempt) =>
+          attemptMatchesProtocol(attempt, protocol),
+        ),
+      ) as Record<string, unknown> | undefined) ?? null;
+  }
+  if (detail === null) return null;
+  const attempts = (detail.provider_attempts as unknown[] | undefined) ?? [];
+  const attempt = attempts.find((a) => attemptMatchesProtocol(a, protocol)) as
+    | Record<string, unknown>
+    | undefined;
+  if (!attempt) return null;
+  return {
+    traceId: detail.trace_id,
+    providerAlias: attempt.provider_name,
+    providerModel: attempt.provider_model,
+    nativePassthrough: true,
+    mutationLedger: attempt.passthrough_mutations ?? null,
+  };
+}
+
+function traceFromText(text: string): string | null {
+  const traceMatch = text.match(/trace[_ -]?id[=: ]+([a-zA-Z0-9_-]+)/i);
+  return traceMatch?.[1] ?? null;
+}
+
+async function runMode(mode: Mode, dryRun: boolean): Promise<CliReport> {
+  const config = CLI_CONFIG[mode];
+  const report = baseReport(mode, dryRun);
+  const binary = commandExists(config.binary);
+  report.version = binary.version;
+  addAssertion(report, `${config.binary} binary is installed`, binary.exists, binary.stderr);
+
+  const missingEnv = COMMON_REQUIRED_ENV.filter((name) => !process.env[name]);
+  const commandTemplate = process.env[config.commandEnv];
+  if (!commandTemplate) missingEnv.push(config.commandEnv);
+  addAssertion(
+    report,
+    "required live environment is configured",
+    missingEnv.length === 0,
+    missingEnv.length > 0 ? `missing: ${missingEnv.join(", ")}` : undefined,
+  );
+
+  if (dryRun) {
+    report.exitCode = 0;
+    report.stdoutSummary = `dry-run only; set ${DRY_RUN_ENV}=0 to execute ${config.binary}`;
+    report.nativePassthrough = null;
+    addAssertion(report, "dry-run explicitly enabled", true);
+    return report;
+  }
+
+  if (!binary.exists || missingEnv.length > 0 || !commandTemplate) {
+    report.exitCode = 1;
+    addAssertion(report, "live CLI execution completed", false, "preflight failed");
+    addAssertion(
+      report,
+      `telemetry proves ${config.protocol} native passthrough`,
+      false,
+      "not checked because preflight failed",
+    );
+    return report;
+  }
+
+  const expected = process.env[EXPECTED_OUTPUT_ENV] ?? "HELM_LIVE_OK";
+  const child = spawnSync(commandTemplate, {
+    shell: true,
+    encoding: "utf8",
+    timeout: Number(process.env.HELM_PASSTHROUGH_LIVE_TIMEOUT_MS ?? "120000"),
+    env: {
+      ...process.env,
+      ANTHROPIC_BASE_URL: process.env.HELM_PASSTHROUGH_BASE_URL,
+      ANTHROPIC_API_KEY: process.env.HELM_PASSTHROUGH_API_KEY,
+      OPENAI_BASE_URL: process.env.HELM_PASSTHROUGH_BASE_URL,
+      OPENAI_API_KEY: process.env.HELM_PASSTHROUGH_API_KEY,
+    },
+  });
+  report.exitCode = child.status ?? 1;
+  report.stdoutSummary = summarizeCliOutput(child.stdout, expected);
+  report.stderrSummary = summarizeCliOutput(child.stderr || child.error?.message || "", expected);
+  addAssertion(report, "live CLI execution completed", report.exitCode === 0);
+  addAssertion(
+    report,
+    "live CLI returned the expected sentinel",
+    `${child.stdout}\n${child.stderr}`.includes(expected),
+    `expected output marker length: ${expected.length}`,
+  );
+
+  report.traceId = traceFromText(`${child.stdout}\n${child.stderr}`);
+  const evidence =
+    assertionEvidenceFor(mode) ?? (await telemetryEvidenceFromAdmin(report.traceId, config.protocol).catch(() => null));
+  const telemetryPassed = applyTelemetryEvidence(report, evidence);
+  addAssertion(
+    report,
+    "trace id was discoverable",
+    report.traceId !== null,
+    report.traceId === null ? `missing trace; provide ${ASSERTIONS_FILE_ENV}` : undefined,
+  );
+  addAssertion(
+    report,
+    `telemetry proves ${config.protocol} native passthrough`,
+    telemetryPassed,
+    telemetryPassed ? undefined : `missing nativePassthrough:true evidence in ${ASSERTIONS_FILE_ENV}`,
+  );
+  const serializedEvidence = JSON.stringify(evidence ?? {});
+  const leakedKey = process.env.HELM_PASSTHROUGH_API_KEY
+    ? serializedEvidence.includes(process.env.HELM_PASSTHROUGH_API_KEY)
+    : false;
+  addAssertion(report, "telemetry evidence does not contain Helm API key", !leakedKey);
+  return report;
+}
+
+function writeReport(report: LiveReport): void {
+  mkdirSync(dirname(REPORT_PATH), { recursive: true });
+  writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+function selectedModes(arg: string | undefined): Mode[] {
+  if (arg === "claude-cli" || arg === "codex-cli") return [arg];
+  if (arg === "all" || arg === undefined) return ["claude-cli", "codex-cli"];
+  throw new Error(`unknown passthrough live mode: ${arg}`);
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.env[DRY_RUN_ENV] === "1" || process.env[DRY_RUN_ENV] === "true";
+  const reports = await Promise.all(
+    selectedModes(process.argv[2]).map((mode) => runMode(mode, dryRun)),
+  );
+  const allPassed = reports.every((report) => report.assertions.every((a) => a.passed));
+  const liveReport: LiveReport = {
+    generatedAt: new Date().toISOString(),
+    status: dryRun ? "dry-run" : allPassed ? "passed" : "failed",
+    reports,
+  };
+  writeReport(liveReport);
+  console.log(`wrote ${REPORT_PATH}`);
+  if (!dryRun && !allPassed) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const failed: LiveReport = {
+      generatedAt: new Date().toISOString(),
+      status: "failed",
+      reports: [],
+    };
+    writeReport(failed);
+    console.error(message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/passthrough/unit.test.ts
+++ b/scripts/passthrough/unit.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  cloneCarrierWithBody,
+  createNativePassthroughCarrier,
+  nativePassthroughBody,
+  nativePassthroughMutations,
+} from "../../packages/shared/src/native-passthrough.js";
+import { prepareNativePassthroughRequest } from "../../packages/core/src/provider/native-passthrough.js";
+import { summarizeCliOutput } from "./live-cli.js";
+
+describe("native passthrough helper acceptance", () => {
+  it("keeps the raw body when no body mutation is required", () => {
+    const rawBody = '{"model":"claude-3-5-haiku-latest","unknown":{"b":2,"a":1}}';
+    const carrier = createNativePassthroughCarrier({
+      protocol: "anthropic_messages",
+      body: { model: "claude-3-5-haiku-latest", unknown: { b: 2, a: 1 } },
+      rawBody,
+      headers: {},
+    });
+
+    const cloned = cloneCarrierWithBody(carrier, carrier.body, { preserveRawBody: true });
+
+    expect(nativePassthroughBody(cloned)).toEqual(carrier.body);
+    expect(cloned.raw_body).toBe(rawBody);
+    expect(nativePassthroughMutations(cloned)).toEqual({});
+  });
+
+  it("drops unsafe headers, preserves safe client headers, and records a mutation ledger", () => {
+    const carrier = createNativePassthroughCarrier({
+      protocol: "openai_responses",
+      body: { model: "gpt-5-codex", input: "hi", stream: true },
+      rawBody: '{"model":"gpt-5-codex","input":"hi","stream":true}',
+      headers: {
+        authorization: "Bearer helm-client-key",
+        "x-api-key": "client-upstream-key",
+        cookie: "sid=client-cookie",
+        "x-auth-token": "client-auth-token",
+        "x-client-secret": "client-secret",
+        "x-helm-trace-id": "trace-client",
+        connection: "keep-alive",
+        "content-length": "999",
+        "user-agent": "codex-cli/0.1.0",
+        accept: "text/event-stream",
+        originator: "client-originator",
+        session_id: "client-session",
+        "x-client-request-id": "client-request-id",
+        "x-session-id": "sess-client",
+        "openai-beta": "client-beta",
+      },
+    });
+
+    const prepared = prepareNativePassthroughRequest(
+      carrier,
+      {
+        Authorization: "Bearer provider-token",
+        accept: "application/json",
+        "OpenAI-Beta": "responses=experimental",
+        originator: "helm",
+        session_id: "provider-session",
+        "x-client-request-id": "provider-request-id",
+      },
+      { mergeHeaders: ["openai-beta"] },
+    );
+
+    const headerNames = Object.keys(prepared.headers).map((h) => h.toLowerCase());
+    expect(headerNames).not.toContain("x-api-key");
+    expect(headerNames).not.toContain("cookie");
+    expect(headerNames).not.toContain("x-auth-token");
+    expect(headerNames).not.toContain("x-client-secret");
+    expect(headerNames).not.toContain("x-helm-trace-id");
+    expect(headerNames).not.toContain("connection");
+    expect(headerNames).not.toContain("content-length");
+    expect(prepared.headers.authorization).toBeUndefined();
+    expect(prepared.headers.Authorization).toBe("Bearer provider-token");
+    expect(prepared.headers["user-agent"]).toBe("codex-cli/0.1.0");
+    expect(prepared.headers.accept).toBe("text/event-stream");
+    expect(prepared.headers.originator).toBe("client-originator");
+    expect(prepared.headers.session_id).toBe("client-session");
+    expect(prepared.headers["x-client-request-id"]).toBe("client-request-id");
+    expect(prepared.headers["x-session-id"]).toBe("sess-client");
+    expect(prepared.headers["OpenAI-Beta"]).toBe("client-beta, responses=experimental");
+    expect(prepared.bodyText).toBe(carrier.raw_body);
+    expect(carrier.mutations).toMatchObject({
+      auth_replaced: true,
+      content_length_recomputed: true,
+      headers_overwritten: ["openai-beta"],
+    });
+    expect(carrier.mutations.headers_dropped).toEqual(
+      expect.arrayContaining([
+        "authorization",
+        "connection",
+        "content-length",
+        "cookie",
+        "x-auth-token",
+        "x-api-key",
+        "x-client-secret",
+        "x-helm-trace-id",
+      ]),
+    );
+    expect(JSON.stringify(carrier.mutations)).not.toContain("helm-client-key");
+    expect(JSON.stringify(carrier.mutations)).not.toContain("provider-token");
+  });
+
+  it("summarizes live CLI output without embedding secrets or full prompts", () => {
+    const previousKey = process.env.HELM_PASSTHROUGH_API_KEY;
+    const previousToken = process.env.PROVIDER_ACCESS_TOKEN;
+    process.env.HELM_PASSTHROUGH_API_KEY = "helm-secret-key-1234";
+    process.env.PROVIDER_ACCESS_TOKEN = "provider-secret-token-5678";
+    try {
+      const summary = summarizeCliOutput(
+        'prompt: "Please process private customer data"\nkey=helm-secret-key-1234\nHELM_LIVE_OK\nprovider-secret-token-5678',
+        "HELM_LIVE_OK",
+      );
+
+      expect(summary).toContain("sentinel_present:true");
+      expect(summary).toContain("bytes");
+      expect(summary).not.toContain("Please process private customer data");
+      expect(summary).not.toContain("helm-secret-key-1234");
+      expect(summary).not.toContain("provider-secret-token-5678");
+    } finally {
+      if (previousKey === undefined) delete process.env.HELM_PASSTHROUGH_API_KEY;
+      else process.env.HELM_PASSTHROUGH_API_KEY = previousKey;
+      if (previousToken === undefined) delete process.env.PROVIDER_ACCESS_TOKEN;
+      else process.env.PROVIDER_ACCESS_TOKEN = previousToken;
+    }
+  });
+});

--- a/scripts/passthrough/vitest.unit.config.ts
+++ b/scripts/passthrough/vitest.unit.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [
+      "scripts/passthrough/unit.test.ts",
+      "packages/core/src/provider/protocol.test.ts",
+      "packages/core/src/provider/anthropic.test.ts",
+      "packages/core/src/provider/openai-responses.test.ts",
+      "apps/gateway/src/routes/execute.test.ts",
+      "apps/gateway/src/routes/messages-pipeline.test.ts",
+      "apps/gateway/src/routes/messages.test.ts",
+      "apps/gateway/src/routes/responses.test.ts",
+    ],
+    environment: "node",
+    server: {
+      deps: {
+        external: ["better-sqlite3"],
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Implements the native passthrough fidelity spec for Anthropic Messages and OpenAI Responses/Codex.
- Adds a typed native carrier with raw body + client headers + mutation ledger, then threads it through `/v1/messages`, `/v1/responses`, execute, provider clients, telemetry, and memory injection.
- Preserves raw JSON/SSE when the body is unchanged, records all allowed shims, and hardens header handling by dropping auth/hop-by-hop/Helm/cookie/secret-like client headers while preserving safe identity/session/beta headers.
- Adds deterministic and live acceptance harnesses, including Claude CLI and Codex CLI final validation.

## Validation

- `ast-grep --lang ts -p '{ native_request: $VALUE }' apps/gateway packages/core packages/shared`
- `ast-grep --lang ts -p 'result.nativePassthrough === true' apps/gateway packages/core packages/shared`
- `ast-grep --lang ts -p '$A.passthrough_mutations' apps/gateway packages/core packages/shared`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:passthrough` — 323 focused unit tests + 11 deterministic e2e cases passed.
- `pnpm test` — 255 files / 3578 tests passed.
- `pnpm test:passthrough:final` — passed against a local Helm instance with live Claude CLI and Codex CLI:
  - Claude Code `2.1.175`, trace `3370ee6e-e499-4ccc-b0e6-78490284ca93`, provider `local-anthropic`, model `claude-haiku`, `nativePassthrough:true`.
  - Codex CLI `0.139.0`, trace `0c8b5d69-d55f-4392-beac-645a640c92c3`, provider `local-codex`, model `gpt-5.4-mini`, `nativePassthrough:true`.

## Notes

- Live report artifact is intentionally not committed.
- Branch was rebased onto `origin/main` at `5322dcd` before final validation.
