### PR TITLE
chore(release): v0.12.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release bundling changes since v0.12.8.

## Included
- **#240** feat(protocol): harden native passthrough fidelity — new native-passthrough modules + additive request/decision schema changes; no new gateway surface
- **#238** fix(memory): occurrence-count window dedup, exclude system/developer turns
- **#237** fix(responses): Responses passthrough accounting
- **#239** test: raise core + gateway unit coverage to ~91%, ratchet thresholds

## Release mechanics
On squash-merge, `publish.yml` auto-cuts tag `v0.12.9` + GitHub Release + GHCR `:0.12.9` and `:latest`. No manual tag/release.

Zero config/infra diff since last deploy — la.atmy.work deploy is a clean `pull + up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)