### PR TITLE
feat(admin): per-account Test button on Subscription Providers (streaming)

### DIFF
--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -190,6 +190,90 @@ export async function logoutOAuth(provider: string, account = 'default'): Promis
   if (!res.ok && res.status !== 204) await asJson(res);
 }
 
+// ── per-account connectivity test (providers page "Test" button) ─────────────
+
+// One normalized event from POST /oauth/:provider/test, mirroring the gateway's
+// oauth-test event shapes. The dialog appends `content` deltas live and ends on
+// `done` (success) or `error` (failure surfaced in-band, never a thrown 5xx).
+export type AccountTestEvent =
+  | { type: 'start'; model?: string }
+  | { type: 'content'; text: string }
+  | { type: 'finish'; reason?: string }
+  | { type: 'usage'; promptTokens?: number; completionTokens?: number; totalTokens?: number }
+  | { type: 'done'; durationMs?: number }
+  | { type: 'error'; error: string };
+
+// Pull one normalized event out of an SSE `data:` line (ignores comments, blanks,
+// `[DONE]`, and unparseable payloads — fail-open like the gateway parser).
+function parseTestLine(line: string): AccountTestEvent | null {
+  if (!line.startsWith('data:')) return null;
+  const payload = line.slice(5).trim();
+  if (!payload || payload === '[DONE]') return null;
+  try {
+    const obj = JSON.parse(payload) as AccountTestEvent;
+    return obj && typeof obj === 'object' && typeof obj.type === 'string' ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+// POST /oauth/:provider/test → stream the test reply, yielding each parsed event.
+// A pre-flight failure (503 oauth-off / 400 bad input) is normalized into a single
+// `error` event so the caller has ONE uniform channel. An abort (modal close / Stop)
+// ends the generator quietly. Never throws — every failure becomes an `error` event.
+export async function* streamAccountTest(
+  provider: string,
+  body: { account: string; model: string; prompt?: string },
+  signal?: AbortSignal,
+): AsyncGenerator<AccountTestEvent> {
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}/${encodeURIComponent(provider)}/test`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (e) {
+    if (signal?.aborted) return;
+    yield { type: 'error', error: e instanceof Error ? e.message : 'request failed' };
+    return;
+  }
+  if (!res.ok || !res.body) {
+    let detail = `test failed (${res.status})`;
+    try {
+      const j = (await res.json()) as { error?: unknown };
+      if (typeof j.error === 'string') detail = j.error;
+    } catch {
+      // not JSON — keep the status-only detail
+    }
+    yield { type: 'error', error: detail };
+    return;
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl = buf.indexOf('\n');
+      while (nl !== -1) {
+        const ev = parseTestLine(buf.slice(0, nl).trimEnd());
+        buf = buf.slice(nl + 1);
+        if (ev) yield ev;
+        nl = buf.indexOf('\n');
+      }
+    }
+    const last = parseTestLine(buf.trim());
+    if (last) yield last;
+  } catch (e) {
+    if (signal?.aborted) return;
+    yield { type: 'error', error: e instanceof Error ? e.message : 'stream interrupted' };
+  }
+}
+
 // ── per-account model curation ───────────────────────────────────────────────
 
 // The discovered models for one account + the operator's exposed subset.

--- a/apps/admin/src/lib/components/TestAccountDialog.svelte
+++ b/apps/admin/src/lib/components/TestAccountDialog.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import { streamAccountTest } from '$lib/api/oauth.js';
+  import Modal from '$lib/components/Modal.svelte';
+  import { t } from '$lib/i18n';
+
+  // Per-account connectivity test (providers page "Test" button). Streams a single
+  // short completion through ONE subscription account and shows the REAL streamed
+  // reply (not a bare "ok"), with a status pill + latency. Pure consumer (Principle
+  // 1): all execution is the gateway's; this dialog only POSTs and renders the SSE
+  // it streams back. Closing/Stop aborts the in-flight request (not a provider fault).
+  let {
+    provider,
+    providerName,
+    account,
+    models,
+    onclose,
+  }: {
+    provider: string;
+    providerName: string;
+    account: string;
+    models: string[];
+    onclose: () => void;
+  } = $props();
+
+  type Status = 'idle' | 'running' | 'success' | 'error';
+
+  // The dialog is remounted per open ({#if testing} in the page), so capturing the
+  // first model ONCE at mount is correct (matches EditKeyDialog) — thereafter `model`
+  // is the user's selection.
+  let model = $state(untrack(() => models[0] ?? ''));
+  let prompt = $state('');
+  let status = $state<Status>('idle');
+  let response = $state('');
+  let errorMsg = $state('');
+  let durationMs = $state<number | null>(null);
+  let controller: AbortController | null = null;
+
+  const running = $derived(status === 'running');
+  const canRun = $derived(model.length > 0 && !running);
+
+  async function run(): Promise<void> {
+    if (!canRun) return;
+    controller?.abort();
+    controller = new AbortController();
+    status = 'running';
+    response = '';
+    errorMsg = '';
+    durationMs = null;
+    const startedAt = performance.now();
+    try {
+      for await (const ev of streamAccountTest(
+        provider,
+        { account, model, prompt: prompt.trim() || undefined },
+        controller.signal,
+      )) {
+        if (ev.type === 'content') {
+          response += ev.text;
+        } else if (ev.type === 'error') {
+          status = 'error';
+          errorMsg = ev.error;
+        } else if (ev.type === 'done') {
+          durationMs = ev.durationMs ?? Math.round(performance.now() - startedAt);
+          // A `done` that arrives after an `error` keeps the failed status.
+          if (status === 'running') status = 'success';
+        }
+      }
+      // Stream ended without a terminal event (e.g. an abort) — settle to idle.
+      if (status === 'running') status = 'idle';
+    } finally {
+      controller = null;
+    }
+  }
+
+  function stop(): void {
+    controller?.abort();
+    controller = null;
+    if (status === 'running') status = 'idle';
+  }
+
+  function close(): void {
+    controller?.abort();
+    onclose();
+  }
+</script>
+
+<Modal label={$t('Test connection')} onclose={close} dismissible={!running}>
+  <h2 class="section-header">{$t('Test connection')}</h2>
+  <p class="section-desc mt-1">
+    {$t('Send a short message through this account and stream the reply.')}
+  </p>
+
+  <div class="mt-3 flex flex-col gap-3">
+    <!-- Which account is under test (read-only context). -->
+    <div class="flex items-baseline gap-4 text-sm">
+      <div class="flex flex-col gap-1">
+        <span class="field-label">{$t('Provider')}</span>
+        <span class="text-ink-body">{providerName}</span>
+      </div>
+      <div class="flex flex-col gap-1">
+        <span class="field-label">{$t('Account')}</span>
+        <code class="font-mono text-xs text-ink-strong">{account}</code>
+      </div>
+    </div>
+
+    {#if models.length === 0}
+      <p class="alert-warn">{$t('No routable models for this account.')}</p>
+    {:else}
+      <label class="flex flex-col gap-1 text-sm">
+        <span class="field-label">{$t('Model')}</span>
+        <select class="input" bind:value={model} disabled={running}>
+          {#each models as m (m)}
+            <option value={m}>{m}</option>
+          {/each}
+        </select>
+      </label>
+    {/if}
+
+    <label class="flex flex-col gap-1 text-sm">
+      <span class="field-label">{$t('Message')}</span>
+      <input
+        type="text"
+        class="input"
+        placeholder={$t('Optional')}
+        bind:value={prompt}
+        disabled={running}
+      />
+    </label>
+
+    <!-- Result: status pill + latency + live char count, then the streamed reply. -->
+    <div class="flex flex-col gap-1">
+      <div class="flex items-center justify-between text-xs">
+        <span class="flex items-center gap-2">
+          {#if status === 'idle'}
+            <span class="text-ink-muted">{$t('Ready')}</span>
+          {:else if status === 'running'}
+            <span class="badge-neutral">{$t('Testing…')}</span>
+          {:else if status === 'success'}
+            <span class="badge-ok">{$t('Success')}</span>
+          {:else}
+            <span class="badge-error">{$t('Failed')}</span>
+          {/if}
+          {#if durationMs !== null}
+            <span class="text-ink-muted">{$t('Done in {ms} ms', { ms: durationMs })}</span>
+          {/if}
+        </span>
+        <span class="text-ink-muted">{$t('{n} chars', { n: response.length })}</span>
+      </div>
+      <!-- prettier-ignore -->
+      <div
+        class="max-h-48 min-h-16 overflow-auto rounded border border-slate-200 bg-slate-50 p-2 font-mono text-xs whitespace-pre-wrap text-ink-body"
+        data-testid="test-response"
+      >{response}{#if running}<span class="animate-pulse">▋</span>{/if}{#if !response && !running}<span class="text-ink-muted">{$t('Waiting for response…')}</span>{/if}</div>
+      {#if errorMsg}
+        <p class="alert-error" role="alert">{errorMsg}</p>
+      {/if}
+    </div>
+  </div>
+
+  <div class="mt-4 flex justify-end gap-2">
+    {#if running}
+      <button type="button" class="btn-secondary" onclick={stop}>{$t('Stop')}</button>
+    {:else}
+      <button type="button" class="btn-secondary" onclick={close}>{$t('Close')}</button>
+    {/if}
+    <button type="button" class="btn-primary" disabled={!canRun} onclick={run}>
+      {running ? $t('Testing…') : $t('Run test')}
+    </button>
+  </div>
+</Modal>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -559,5 +559,18 @@
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.",
   "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.",
   "Concurrency": "Concurrency",
-  "Memory": "Memory"
+  "Memory": "Memory",
+  "Test": "Test",
+  "Test connection": "Test connection",
+  "Run test": "Run test",
+  "Testing…": "Testing…",
+  "Stop": "Stop",
+  "Ready": "Ready",
+  "Success": "Success",
+  "Failed": "Failed",
+  "Waiting for response…": "Waiting for response…",
+  "No routable models for this account.": "No routable models for this account.",
+  "Done in {ms} ms": "Done in {ms} ms",
+  "{n} chars": "{n} chars",
+  "Send a short message through this account and stream the reply.": "Send a short message through this account and stream the reply."
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -546,5 +546,18 @@
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "OpenAI 互換の provider を設定します。base URL は /v1 で終わります。Anthropic 経路の場合はオリジンそのままを使ってください。",
   "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI または Anthropic 互換の SDK ならどれでも使えます——変えるのは base URL とキーだけ。OpenAI の base URL には /v1 が付き、Anthropic には付かない点に注意してください。",
   "Concurrency": "同時実行",
-  "Memory": "メモリ"
+  "Memory": "メモリ",
+  "Test": "テスト",
+  "Test connection": "接続テスト",
+  "Run test": "テスト実行",
+  "Testing…": "テスト中…",
+  "Stop": "停止",
+  "Ready": "準備完了",
+  "Success": "成功",
+  "Failed": "失敗",
+  "Waiting for response…": "応答を待機中…",
+  "No routable models for this account.": "このアカウントにルーティング可能なモデルがありません。",
+  "Done in {ms} ms": "{ms} ms で完了",
+  "{n} chars": "{n} 文字",
+  "Send a short message through this account and stream the reply.": "このアカウント経由で短いメッセージを送信し、応答をストリーミング表示します。"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -546,5 +546,18 @@
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "OpenAI 호환 provider를 설정하세요. base URL은 /v1로 끝납니다. Anthropic 경로에서는 오리진 그대로를 사용하세요.",
   "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "OpenAI 또는 Anthropic 호환 SDK라면 무엇이든 동작합니다 — base URL과 키만 바꾸면 됩니다. OpenAI base URL에는 /v1이 붙고 Anthropic에는 붙지 않는 점에 유의하세요.",
   "Concurrency": "동시성",
-  "Memory": "메모리"
+  "Memory": "메모리",
+  "Test": "테스트",
+  "Test connection": "연결 테스트",
+  "Run test": "테스트 실행",
+  "Testing…": "테스트 중…",
+  "Stop": "중지",
+  "Ready": "준비됨",
+  "Success": "성공",
+  "Failed": "실패",
+  "Waiting for response…": "응답 대기 중…",
+  "No routable models for this account.": "이 계정에 라우팅 가능한 모델이 없습니다.",
+  "Done in {ms} ms": "{ms} ms 소요",
+  "{n} chars": "{n}자",
+  "Send a short message through this account and stream the reply.": "이 계정으로 짧은 메시지를 보내고 응답을 스트리밍합니다."
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -559,5 +559,18 @@
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "配置一个兼容 OpenAI 的 provider。base URL 以 /v1 结尾；若走 Anthropic 路径，则改用裸域名。",
   "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何兼容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密钥。留意：OpenAI 的 base URL 带 /v1，Anthropic 的不带。",
   "Concurrency": "并发",
-  "Memory": "记忆"
+  "Memory": "记忆",
+  "Test": "测试",
+  "Test connection": "连通性测试",
+  "Run test": "开始测试",
+  "Testing…": "测试中…",
+  "Stop": "停止",
+  "Ready": "就绪",
+  "Success": "测试成功",
+  "Failed": "测试失败",
+  "Waiting for response…": "等待响应…",
+  "No routable models for this account.": "该账号暂无可路由的模型。",
+  "Done in {ms} ms": "耗时 {ms} 毫秒",
+  "{n} chars": "{n} 字符",
+  "Send a short message through this account and stream the reply.": "通过该账号发送一条简短消息，并流式显示返回结果。"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -553,5 +553,18 @@
   "Configure an OpenAI-compatible provider. The base URL ends in /v1; for the Anthropic path, use the bare origin instead.": "設定一個相容 OpenAI 的 provider。base URL 以 /v1 結尾；若走 Anthropic 路徑，則改用裸網域。",
   "Any OpenAI- or Anthropic-compatible SDK works — only the base URL and key change. Note the /v1 on the OpenAI base URL and its absence on the Anthropic one.": "任何相容 OpenAI 或 Anthropic 的 SDK 都能用——只需改 base URL 和密鑰。留意：OpenAI 的 base URL 帶 /v1，Anthropic 的不帶。",
   "Concurrency": "並發",
-  "Memory": "記憶"
+  "Memory": "記憶",
+  "Test": "測試",
+  "Test connection": "連線測試",
+  "Run test": "開始測試",
+  "Testing…": "測試中…",
+  "Stop": "停止",
+  "Ready": "就緒",
+  "Success": "測試成功",
+  "Failed": "測試失敗",
+  "Waiting for response…": "等待回應…",
+  "No routable models for this account.": "此帳號暫無可路由的模型。",
+  "Done in {ms} ms": "耗時 {ms} 毫秒",
+  "{n} chars": "{n} 字元",
+  "Send a short message through this account and stream the reply.": "透過此帳號傳送一則簡短訊息，並串流顯示回應。"
 }

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -12,6 +12,7 @@
   import ConnectProviderDialog from '$lib/components/ConnectProviderDialog.svelte';
   import ManageAccountDialog from '$lib/components/ManageAccountDialog.svelte';
   import Modal from '$lib/components/Modal.svelte';
+  import TestAccountDialog from '$lib/components/TestAccountDialog.svelte';
   import { durationParts, formatCount, formatTokens, formatUsd } from '$lib/format';
   import { t } from '$lib/i18n';
 
@@ -37,6 +38,15 @@
   let refreshing = $state<boolean>(false);
   let showConnect = $state<boolean>(false);
   let managing = $state<{ providerId: string; providerName: string; account: string } | null>(null);
+  // The account whose connectivity-test dialog is open (providers page "Test"
+  // button). Carries the row's effective models so the dialog's picker offers only
+  // routable ids — no extra fetch.
+  let testing = $state<{
+    providerId: string;
+    providerName: string;
+    account: string;
+    models: string[];
+  } | null>(null);
   let confirming = $state<{ providerId: string; account: string } | null>(null);
   let disconnecting = $state<boolean>(false);
   // Accounts whose inline schedule edit is in flight (keyed provider/account) — used
@@ -276,6 +286,16 @@
     />
   {/if}
 
+  {#if testing}
+    <TestAccountDialog
+      provider={testing.providerId}
+      providerName={testing.providerName}
+      account={testing.account}
+      models={testing.models}
+      onclose={() => (testing = null)}
+    />
+  {/if}
+
   {#if rows.length === 0}
     <div class="empty-state">
       <p>
@@ -435,6 +455,17 @@
               <!-- Actions -->
               <td class="px-3 py-3 text-right">
                 <div class="inline-flex gap-2">
+                  <button
+                    type="button"
+                    class="btn-secondary"
+                    onclick={() =>
+                      (testing = {
+                        providerId: row.provider.id,
+                        providerName: row.provider.name,
+                        account: row.account.account,
+                        models: row.account.models,
+                      })}>{$t('Test')}</button
+                  >
                   <button
                     type="button"
                     class="btn-secondary"

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -6,6 +6,7 @@ import ProvidersPage from './+page.svelte';
 
 const logoutOAuth = vi.fn();
 const setAccountSchedule = vi.fn();
+const streamAccountTest = vi.fn();
 vi.mock('$lib/api/oauth.js', () => ({
   completeManualPaste: vi.fn(),
   getAccountModels: vi.fn(),
@@ -18,6 +19,7 @@ vi.mock('$lib/api/oauth.js', () => ({
   setAccountSchedule: (...args: unknown[]) => setAccountSchedule(...args),
   startDeviceCode: vi.fn(),
   startManualPaste: vi.fn(),
+  streamAccountTest: (...args: unknown[]) => streamAccountTest(...args),
 }));
 
 const invalidateAllMock = vi.mocked(invalidateAll);
@@ -92,6 +94,7 @@ describe('providers page', () => {
   beforeEach(() => {
     logoutOAuth.mockReset();
     setAccountSchedule.mockReset();
+    streamAccountTest.mockReset();
     invalidateAllMock.mockReset();
     logoutOAuth.mockResolvedValue(undefined);
     setAccountSchedule.mockResolvedValue(undefined);
@@ -191,6 +194,46 @@ describe('providers page', () => {
       }),
     );
     expect(invalidateAllMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the Test dialog seeded with the account’s routable models', async () => {
+    renderPage();
+    const row = screen.getByTestId('provider-account-row');
+
+    await fireEvent.click(within(row).getByRole('button', { name: /^test$/i }));
+
+    const dialog = screen.getByRole('dialog', { name: /test connection/i });
+    expect(within(dialog).getByText('acct-claude')).toBeInTheDocument();
+    // The picker offers the row's effective models; the first is selected by default.
+    expect(within(dialog).getByRole('option', { name: 'claude-opus-4-6' })).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /run test/i })).toBeInTheDocument();
+  });
+
+  it('streams the test reply through the gateway and reports success', async () => {
+    streamAccountTest.mockImplementation(async function* () {
+      yield { type: 'content', text: 'Hello' };
+      yield { type: 'content', text: ' there' };
+      yield { type: 'done', durationMs: 12 };
+    });
+    renderPage();
+    await fireEvent.click(
+      within(screen.getByTestId('provider-account-row')).getByRole('button', { name: /^test$/i }),
+    );
+    const dialog = screen.getByRole('dialog', { name: /test connection/i });
+
+    await fireEvent.click(within(dialog).getByRole('button', { name: /run test/i }));
+
+    await waitFor(() =>
+      expect(streamAccountTest).toHaveBeenCalledWith(
+        'anthropic',
+        { account: 'acct-claude', model: 'claude-opus-4-6', prompt: undefined },
+        expect.any(AbortSignal),
+      ),
+    );
+    await waitFor(() =>
+      expect(within(dialog).getByTestId('test-response')).toHaveTextContent('Hello there'),
+    );
+    expect(within(dialog).getByText('Success')).toBeInTheDocument();
   });
 
   it('confirms and disconnects a stored account credential', async () => {

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -18,6 +18,7 @@ import type {
 } from "@helm/shared";
 import type { ModelOption } from "../../oauth/effective-models.js";
 import type { PayloadCaptureDeps } from "../payload-capture.js";
+import type { OAuthTester } from "./oauth-test.js";
 
 // Injected dependency contracts for the admin API. Per CLAUDE.md principle 1 the
 // route files are PURE HTTP glue — they own no business logic and never touch the
@@ -261,6 +262,12 @@ export interface AdminApiDeps {
   // list when absent (fail-open; never 503 the whole page over observability).
   oauthUsage?: OAuthUsageStore;
   oauthQuota?: OAuthQuotaStore;
+  // Per-account connectivity tester (Subscription Providers "Test" button). Streams
+  // a single short completion through a FRESH, isolated per-account client — its own
+  // token + proxy + executor type, and its OWN no-op breaker — so a test records NO
+  // telemetry / request_payloads and never perturbs the live routing pool. Optional:
+  // the /oauth/:provider/test route 503s when absent (present iff OAuth is wired).
+  oauthTester?: OAuthTester;
   // The catalog of routable model options the Lanes admin UI offers as combobox
   // suggestions (so an operator picks a real alias instead of hand-typing one — a
   // typo would silently break a fallback chain). Each option is `{ alias, accounts }`

--- a/apps/gateway/src/routes/admin/oauth-test-route.test.ts
+++ b/apps/gateway/src/routes/admin/oauth-test-route.test.ts
@@ -1,0 +1,116 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../../app.js";
+import type { AdminApiDeps } from "./deps.js";
+import { registerOAuthRoutes } from "./oauth.js";
+import type { OAuthTester, TestStreamEvent } from "./oauth-test.js";
+
+function app(deps: Partial<AdminApiDeps>) {
+  const a = new Hono<AppEnv>();
+  registerOAuthRoutes(a, deps as AdminApiDeps);
+  return a;
+}
+
+const JSONH = { "Content-Type": "application/json" };
+
+// Build an OAuthTester whose test() replays a fixed event list, or runs a custom
+// async generator (for the mid-stream error case). vi.fn so we can assert params.
+function testerOf(events: TestStreamEvent[] | (() => AsyncIterable<TestStreamEvent>)): OAuthTester {
+  const gen = (): AsyncIterable<TestStreamEvent> => {
+    if (typeof events === "function") return events();
+    return (async function* () {
+      for (const e of events) yield e;
+    })();
+  };
+  return { test: vi.fn(() => gen()) };
+}
+
+// Pull the JSON payloads out of the `data:` lines of an SSE response body.
+function sseEvents(body: string): Array<Record<string, unknown>> {
+  return body
+    .split("\n")
+    .filter((l) => l.startsWith("data:"))
+    .map((l) => JSON.parse(l.slice(5).trim()) as Record<string, unknown>);
+}
+
+describe("POST /admin/api/oauth/:provider/test", () => {
+  it("503s when no tester is wired (OAuth disabled)", async () => {
+    const res = await app({}).request("/admin/api/oauth/anthropic/test", {
+      method: "POST",
+      headers: JSONH,
+      body: JSON.stringify({ account: "default", model: "m" }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it("400s when account or model is missing", async () => {
+    const a = app({ oauthTester: testerOf([]) });
+    const noAccount = await a.request("/admin/api/oauth/anthropic/test", {
+      method: "POST",
+      headers: JSONH,
+      body: JSON.stringify({ model: "m" }),
+    });
+    expect(noAccount.status).toBe(400);
+    const noModel = await a.request("/admin/api/oauth/anthropic/test", {
+      method: "POST",
+      headers: JSONH,
+      body: JSON.stringify({ account: "default" }),
+    });
+    expect(noModel.status).toBe(400);
+  });
+
+  it("streams start -> content -> finish -> done as SSE and forwards the params", async () => {
+    const tester = testerOf([
+      { type: "content", text: "He" },
+      { type: "content", text: "llo" },
+      { type: "finish", reason: "stop" },
+    ]);
+    const res = await app({ oauthTester: tester }).request("/admin/api/oauth/anthropic/test", {
+      method: "POST",
+      headers: JSONH,
+      body: JSON.stringify({ account: "default", model: "claude-x", prompt: "yo" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    const events = sseEvents(await res.text());
+    expect(events[0]).toMatchObject({ type: "start", model: "claude-x" });
+    expect(
+      events
+        .filter((e) => e.type === "content")
+        .map((e) => e.text)
+        .join(""),
+    ).toBe("Hello");
+    expect(events.some((e) => e.type === "finish")).toBe(true);
+    expect(events.at(-1)).toMatchObject({ type: "done" });
+
+    expect(tester.test).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "anthropic",
+        account: "default",
+        model: "claude-x",
+        prompt: "yo",
+      }),
+    );
+  });
+
+  it("emits an in-band error event (HTTP 200, not 5xx) when the tester throws mid-stream", async () => {
+    const tester = testerOf(() =>
+      (async function* () {
+        yield { type: "content", text: "partial" } as TestStreamEvent;
+        throw new Error("upstream returned 429");
+      })(),
+    );
+    const res = await app({ oauthTester: tester }).request("/admin/api/oauth/anthropic/test", {
+      method: "POST",
+      headers: JSONH,
+      body: JSON.stringify({ account: "default", model: "m" }),
+    });
+    expect(res.status).toBe(200);
+    const events = sseEvents(await res.text());
+    const err = events.find((e) => e.type === "error");
+    expect(err?.error).toMatch(/429/);
+    // No spurious done event after a failure.
+    expect(events.some((e) => e.type === "done")).toBe(false);
+  });
+});

--- a/apps/gateway/src/routes/admin/oauth-test.test.ts
+++ b/apps/gateway/src/routes/admin/oauth-test.test.ts
@@ -1,0 +1,180 @@
+import type { ChatCompletionRequest, ProviderClient } from "@helm/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createOAuthAccountTester,
+  createOpenAiStreamParser,
+  DEFAULT_TEST_MAX_TOKENS,
+  DEFAULT_TEST_PROMPT,
+  type TestStreamEvent,
+} from "./oauth-test.js";
+
+// One OpenAI `chat.completion.chunk` SSE frame, terminated with the blank line a
+// real upstream sends.
+function frame(obj: unknown): string {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+function delta(content: string): unknown {
+  return { choices: [{ index: 0, delta: { content }, finish_reason: null }] };
+}
+
+// Drain a parser over a list of raw byte-chunks (push) + a final flush.
+function run(
+  parser: ReturnType<typeof createOpenAiStreamParser>,
+  chunks: string[],
+): TestStreamEvent[] {
+  const out: TestStreamEvent[] = [];
+  for (const c of chunks) out.push(...parser.push(c));
+  out.push(...parser.flush());
+  return out;
+}
+
+describe("createOpenAiStreamParser — normalizes OpenAI chunk SSE to test events", () => {
+  it("extracts a content delta from a single complete frame", () => {
+    const p = createOpenAiStreamParser();
+    expect(run(p, [frame(delta("Hello"))])).toEqual([{ type: "content", text: "Hello" }]);
+  });
+
+  it("reassembles a frame split arbitrarily across byte-chunks (not frame-aligned)", () => {
+    // The upstream body is decoded in chunks that DO NOT align to SSE frames; the
+    // parser must buffer the partial `data:` line until its newline arrives.
+    const raw = frame(delta("Hi")) + frame(delta(" there"));
+    const a = raw.slice(0, 10);
+    const b = raw.slice(10, 25);
+    const c = raw.slice(25);
+    expect(run(createOpenAiStreamParser(), [a, b, c])).toEqual([
+      { type: "content", text: "Hi" },
+      { type: "content", text: " there" },
+    ]);
+  });
+
+  it("emits content + finish + usage across multiple frames in one push", () => {
+    const p = createOpenAiStreamParser();
+    const chunk =
+      frame(delta("Hi")) +
+      frame({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }) +
+      frame({
+        choices: [],
+        usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+      }) +
+      "data: [DONE]\n\n";
+    expect(run(p, [chunk])).toEqual([
+      { type: "content", text: "Hi" },
+      { type: "finish", reason: "stop" },
+      { type: "usage", promptTokens: 12, completionTokens: 3, totalTokens: 15 },
+    ]);
+  });
+
+  it("ignores [DONE], comments, and unparseable data lines (fail-open)", () => {
+    const p = createOpenAiStreamParser();
+    const chunk = ": keep-alive\n\n" + "data: not-json\n\n" + "data: [DONE]\n\n";
+    expect(run(p, [chunk])).toEqual([]);
+  });
+
+  it("flush() drains a trailing frame that arrived without a final newline", () => {
+    const p = createOpenAiStreamParser();
+    // No trailing \n — some upstreams close the socket right after the last frame.
+    expect(run(p, [`data: ${JSON.stringify(delta("bye"))}`])).toEqual([
+      { type: "content", text: "bye" },
+    ]);
+  });
+
+  it("skips empty content deltas (e.g. the priming role-only frame)", () => {
+    const p = createOpenAiStreamParser();
+    const chunk =
+      frame({ choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] }) +
+      frame(delta("ok"));
+    expect(run(p, [chunk])).toEqual([{ type: "content", text: "ok" }]);
+  });
+});
+
+// A fake ProviderClient whose stream yields the given raw chunks. Only
+// chatCompletionStream is exercised by the tester.
+function fakeClient(
+  chunks: string[],
+  capture?: (req: ChatCompletionRequest) => void,
+): ProviderClient {
+  return {
+    chatCompletion: vi.fn(),
+    async *chatCompletionStream(req: ChatCompletionRequest) {
+      capture?.(req);
+      for (const c of chunks) yield c;
+    },
+  } as unknown as ProviderClient;
+}
+
+describe("createOAuthAccountTester — streams a real completion through one account", () => {
+  it("builds the account client and yields normalized content events", async () => {
+    let seen: ChatCompletionRequest | undefined;
+    const tester = createOAuthAccountTester({
+      buildClient: async () =>
+        fakeClient(
+          [`data: ${JSON.stringify({ choices: [{ delta: { content: "Hey" } }] })}\n\n`],
+          (r) => {
+            seen = r;
+          },
+        ),
+    });
+    const out: TestStreamEvent[] = [];
+    for await (const ev of tester.test({
+      providerId: "anthropic",
+      account: "default",
+      model: "claude-x",
+    })) {
+      out.push(ev);
+    }
+    expect(out).toEqual([{ type: "content", text: "Hey" }]);
+    // The request carries the chosen model, a single user turn, stream:true and the
+    // default prompt + token cap.
+    expect(seen?.model).toBe("claude-x");
+    expect(seen?.stream).toBe(true);
+    expect(seen?.max_tokens).toBe(DEFAULT_TEST_MAX_TOKENS);
+    expect(seen?.messages).toEqual([{ role: "user", content: DEFAULT_TEST_PROMPT }]);
+  });
+
+  it("uses the operator-supplied prompt when present (trimmed, non-empty)", async () => {
+    let seen: ChatCompletionRequest | undefined;
+    const tester = createOAuthAccountTester({
+      buildClient: async () =>
+        fakeClient([], (r) => {
+          seen = r;
+        }),
+    });
+    for await (const _ of tester.test({
+      providerId: "anthropic",
+      account: "default",
+      model: "m",
+      prompt: "  ping?  ",
+    })) {
+      // drain
+    }
+    expect(seen?.messages).toEqual([{ role: "user", content: "ping?" }]);
+  });
+
+  it("throws a clear error when the account has no buildable client (not connected)", async () => {
+    const tester = createOAuthAccountTester({ buildClient: async () => null });
+    await expect(async () => {
+      for await (const _ of tester.test({ providerId: "x", account: "default", model: "m" })) {
+        // drain
+      }
+    }).rejects.toThrow(/not connected/i);
+  });
+
+  it("propagates an upstream stream error to the caller", async () => {
+    const tester = createOAuthAccountTester({
+      buildClient: async () =>
+        ({
+          chatCompletion: vi.fn(),
+          // biome-ignore lint/correctness/useYield: deliberately throws before yielding (error path)
+          async *chatCompletionStream() {
+            throw new Error("upstream returned 401");
+          },
+        }) as unknown as ProviderClient,
+    });
+    await expect(async () => {
+      for await (const _ of tester.test({ providerId: "x", account: "default", model: "m" })) {
+        // drain
+      }
+    }).rejects.toThrow(/401/);
+  });
+});

--- a/apps/gateway/src/routes/admin/oauth-test.ts
+++ b/apps/gateway/src/routes/admin/oauth-test.ts
@@ -1,0 +1,169 @@
+// Admin "Test account" surface (per-account connectivity check for the Subscription
+// Providers page). Two framework-free pieces, kept here so they unit-test without
+// Hono or the composition root:
+//
+//   1. createOpenAiStreamParser — a buffering parser that turns the provider
+//      client's streamed OpenAI `chat.completion.chunk` SSE into a tiny normalized
+//      event stream (content / finish / usage). Every executor-backed OAuth client
+//      (Anthropic, Codex, Copilot) yields OpenAI-shaped chunks (the protocol layer
+//      normalizes upstream Anthropic/Responses frames), so ONE parser covers all.
+//
+//   2. createOAuthAccountTester — given a `buildClient` seam that mints a FRESH,
+//      standalone per-account client (its own token + proxy + executor type, and —
+//      crucially — its OWN, no-op circuit breaker), it streams a single short user
+//      turn and yields the normalized events. Building a fresh client means the test
+//      records NO telemetry / request_payloads and never perturbs the live routing
+//      pool's breaker state (the breaker lives in the executor layer, not the raw
+//      client). The anti-ban shaping (Claude-Code system spoof + stable identity)
+//      rides inside the provider client, so a bare user turn is accepted by Claude
+//      Max / Codex OAuth unchanged.
+
+import type { ChatCompletionRequest, ProviderClient } from "@helm/core";
+
+// The normalized event the admin UI renders. `content` deltas stream into the
+// response box; `finish`/`usage` are metadata the dialog may surface. Reasoning
+// deltas are intentionally dropped (a connectivity test shows the visible answer).
+export type TestStreamEvent =
+  | { type: "content"; text: string }
+  | { type: "finish"; reason?: string }
+  | {
+      type: "usage";
+      promptTokens?: number;
+      completionTokens?: number;
+      totalTokens?: number;
+    };
+
+// A short, cheap prompt — enough to prove the credential routes and streams, with a
+// low token cap so a test costs almost nothing. Both overridable by the caller.
+export const DEFAULT_TEST_PROMPT = "Hi! Reply with a short one-sentence greeting.";
+export const DEFAULT_TEST_MAX_TOKENS = 512;
+
+export interface OpenAiStreamParser {
+  // Feed a raw decoded body chunk (NOT necessarily frame-aligned). Returns the
+  // events completed by this chunk.
+  push(chunk: string): TestStreamEvent[];
+  // Drain a trailing frame that arrived without a final newline (some upstreams
+  // close the socket right after the last `data:` line).
+  flush(): TestStreamEvent[];
+}
+
+// Pull the normalized events out of ONE parsed chunk object. A single frame can
+// carry a content delta AND a finish_reason AND (on the terminal frame) usage.
+function eventsFromChunk(json: unknown): TestStreamEvent[] {
+  if (typeof json !== "object" || json === null) return [];
+  const obj = json as { choices?: unknown; usage?: unknown };
+  const out: TestStreamEvent[] = [];
+
+  const choices = Array.isArray(obj.choices) ? obj.choices : [];
+  const first = choices[0] as { delta?: unknown; finish_reason?: unknown } | undefined;
+  if (first) {
+    const delta = (first.delta ?? {}) as { content?: unknown };
+    if (typeof delta.content === "string" && delta.content.length > 0) {
+      out.push({ type: "content", text: delta.content });
+    }
+    if (typeof first.finish_reason === "string" && first.finish_reason.length > 0) {
+      out.push({ type: "finish", reason: first.finish_reason });
+    }
+  }
+
+  const usage = obj.usage as
+    | { prompt_tokens?: unknown; completion_tokens?: unknown; total_tokens?: unknown }
+    | undefined;
+  if (usage && typeof usage === "object") {
+    const num = (v: unknown): number | undefined => (typeof v === "number" ? v : undefined);
+    out.push({
+      type: "usage",
+      promptTokens: num(usage.prompt_tokens),
+      completionTokens: num(usage.completion_tokens),
+      totalTokens: num(usage.total_tokens),
+    });
+  }
+  return out;
+}
+
+export function createOpenAiStreamParser(): OpenAiStreamParser {
+  let buffer = "";
+
+  // Parse ONE complete SSE line. Non-`data:` lines (comments `:`, blank lines,
+  // `event:` fields) and `[DONE]` / unparseable payloads are ignored (fail-open —
+  // a malformed frame must never abort the test stream).
+  function handleLine(line: string): TestStreamEvent[] {
+    const text = line.endsWith("\r") ? line.slice(0, -1) : line;
+    if (!text.startsWith("data:")) return [];
+    const payload = text.slice(5).trim();
+    if (payload.length === 0 || payload === "[DONE]") return [];
+    try {
+      return eventsFromChunk(JSON.parse(payload));
+    } catch {
+      return [];
+    }
+  }
+
+  return {
+    push(chunk: string): TestStreamEvent[] {
+      buffer += chunk;
+      const out: TestStreamEvent[] = [];
+      let nl = buffer.indexOf("\n");
+      while (nl !== -1) {
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        out.push(...handleLine(line));
+        nl = buffer.indexOf("\n");
+      }
+      return out;
+    },
+    flush(): TestStreamEvent[] {
+      const rest = buffer;
+      buffer = "";
+      return rest.length > 0 ? handleLine(rest) : [];
+    },
+  };
+}
+
+export interface OAuthTestParams {
+  providerId: string;
+  account: string;
+  // An upstream model id from the account's effective routable set (UI-supplied).
+  model: string;
+  // Optional operator-typed prompt; blank ⇒ DEFAULT_TEST_PROMPT.
+  prompt?: string;
+  // Client-disconnect / modal-close propagation (an abort is not a failure).
+  signal?: AbortSignal;
+}
+
+export interface OAuthTester {
+  test(params: OAuthTestParams): AsyncIterable<TestStreamEvent>;
+}
+
+export interface OAuthAccountTesterDeps {
+  // Mint a FRESH standalone client for (providerId, account), or null when the
+  // account is not connected / cannot be built. The gateway wires this to the same
+  // per-account binding synthesis uses (proxy + identity + executor type) so the
+  // test path is faithful to production routing.
+  buildClient(providerId: string, account: string): Promise<ProviderClient | null>;
+  defaultPrompt?: string;
+  maxTokens?: number;
+}
+
+export function createOAuthAccountTester(deps: OAuthAccountTesterDeps): OAuthTester {
+  const defaultPrompt = deps.defaultPrompt ?? DEFAULT_TEST_PROMPT;
+  const maxTokens = deps.maxTokens ?? DEFAULT_TEST_MAX_TOKENS;
+  return {
+    async *test({ providerId, account, model, prompt, signal }): AsyncIterable<TestStreamEvent> {
+      const client = await deps.buildClient(providerId, account);
+      if (!client) throw new Error(`account "${account}" is not connected`);
+      const content = (prompt ?? "").trim() || defaultPrompt;
+      const req: ChatCompletionRequest = {
+        model,
+        messages: [{ role: "user", content }],
+        stream: true,
+        max_tokens: maxTokens,
+      };
+      const parser = createOpenAiStreamParser();
+      for await (const chunk of client.chatCompletionStream(req, { signal })) {
+        for (const ev of parser.push(chunk)) yield ev;
+      }
+      for (const ev of parser.flush()) yield ev;
+    },
+  };
+}

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -1,4 +1,5 @@
 import type { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
 import type { AccountProxyInput, AdminApiDeps, OAuthAdminAccess } from "./deps.js";
 
@@ -19,6 +20,14 @@ const DEFAULT_ACCOUNT = "default";
 // so echoing the message is safe; anything else degrades to a generic string.
 function errMessage(e: unknown): string {
   return e instanceof Error ? e.message : "oauth request failed";
+}
+
+// A client disconnect / modal close surfaces as an aborted signal or an AbortError.
+// Treated as NOT a provider failure (Principle: client disconnect ≠ upstream fault),
+// so the /test stream ends silently instead of emitting a spurious error event.
+function isAbort(e: unknown, signal: AbortSignal): boolean {
+  if (signal.aborted) return true;
+  return e instanceof Error && (e.name === "AbortError" || /abort/i.test(e.message));
 }
 
 // A malformed proxy body — thrown by parseProxyInput, caught at the route to map to
@@ -447,6 +456,43 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     } catch (e) {
       return c.json({ error: errMessage(e) }, 400);
     }
+  });
+
+  // POST /oauth/:provider/test -> SSE connectivity check for ONE account. Streams a
+  // single short completion through a FRESH isolated client (deps.oauthTester) and
+  // relays normalized events so the admin UI shows the real, streamed reply — not a
+  // bare "ok". Fail-open (Principle 3): a missing tester 503s before streaming;
+  // missing account/model 400s; any upstream failure is surfaced as an in-band
+  // `error` event (HTTP 200, never a 5xx) so the dialog can show what went wrong. A
+  // client/modal abort is silent (not a provider fault). No telemetry is recorded —
+  // the fresh client carries its own no-op breaker (see oauth-test.ts).
+  app.post("/admin/api/oauth/:provider/test", async (c) => {
+    const tester = deps.oauthTester;
+    if (!tester) return c.json({ error: "oauth login not configured" }, 503);
+    const providerId = c.req.param("provider");
+    const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+    const account = typeof body.account === "string" ? body.account : "";
+    const model = typeof body.model === "string" ? body.model : "";
+    const prompt = typeof body.prompt === "string" ? body.prompt : undefined;
+    if (!account) return c.json({ error: "account is required" }, 400);
+    if (!model) return c.json({ error: "model is required" }, 400);
+    const signal = c.req.raw.signal;
+    return streamSSE(c, async (sse) => {
+      const startedAt = Date.now();
+      await sse.writeSSE({ data: JSON.stringify({ type: "start", model }) });
+      try {
+        for await (const ev of tester.test({ providerId, account, model, prompt, signal })) {
+          await sse.writeSSE({ data: JSON.stringify(ev) });
+        }
+        await sse.writeSSE({
+          data: JSON.stringify({ type: "done", durationMs: Date.now() - startedAt }),
+        });
+      } catch (e) {
+        // A client disconnect / modal close is not a provider failure — stay quiet.
+        if (isAbort(e, signal)) return;
+        await sse.writeSSE({ data: JSON.stringify({ type: "error", error: errMessage(e) }) });
+      }
+    });
   });
 
   // DELETE /oauth/:provider?account=... -> 204 (log out / forget a credential)

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -105,6 +105,7 @@ import { createOAuthAdmin } from "./oauth/admin-oauth.js";
 import { anthropicMetadataUserId, stableSessionId } from "./oauth/device-identity.js";
 import { effectiveOAuthModelOptions, type ModelOption } from "./oauth/effective-models.js";
 import { registerAdminApi } from "./routes/admin/index.js";
+import { createOAuthAccountTester, type OAuthTester } from "./routes/admin/oauth-test.js";
 import { createRuntimeRuleStore } from "./routes/admin/rule-store.js";
 import { createYamlRulePersister } from "./routes/admin/yaml-writeback.js";
 import { ADMIN_BUILD_ROOT, mountAdminStatic } from "./routes/admin-static.js";
@@ -305,6 +306,55 @@ export interface SynthesizedOAuth {
   poolClients: Map<string, ProviderClient>;
 }
 
+// Build a FRESH, standalone executor client for ONE oauth account: its token manager
+// + egress proxy + executor type + stable anti-ban identity — exactly the per-account
+// binding the routing pool uses, minus the pool/serial wrap. Shared by
+// synthesizeOAuthProviders (production routing) AND the admin connectivity tester so
+// the test path is FAITHFUL to production and the two never drift. Returns null when
+// no credential can be built (fail-open). The raw client carries NO circuit breaker
+// (that lives in the executor layer), so a one-off test client is fully isolated from
+// the live pool's breaker/telemetry state.
+function buildOAuthAccountClient(
+  providerId: string,
+  account: string,
+  oauthCtx: OAuthRuntimeCtx,
+  proxy: ProxyConfig | undefined,
+  base: { baseUrl: string; timeoutMs: number },
+  onResponseMeta?: (headers: Headers) => void,
+): ProviderClient | null {
+  const spec = ROUTABLE_OAUTH[providerId];
+  if (!spec) return null;
+  const accountConfig = {
+    name: providerId,
+    alias: providerId,
+    type: spec.type,
+    base_url: spec.baseUrl,
+    oauth: { provider: providerId, account },
+    models: [],
+    targetProviderProtocol: spec.targetProviderProtocol,
+    providerRequiresCompatibilityRewrite: spec.providerRequiresCompatibilityRewrite,
+  } as unknown as ProviderConfigShared;
+  const cred = buildCredential(accountConfig, oauthCtx, proxy);
+  if (!cred) return null;
+  // Stable per-account anti-ban identity (never rotates): Anthropic gets a
+  // metadata.user_id; Codex a stable session_id. Both deterministic from
+  // (providerId, account) salted by the at-rest key — no DB write-back.
+  const identity =
+    providerId === "anthropic"
+      ? { metadataUserId: anthropicMetadataUserId(providerId, account, oauthCtx.encKey) }
+      : providerId === "openai-codex"
+        ? { sessionId: stableSessionId(providerId, account, oauthCtx.encKey) }
+        : undefined;
+  return createProviderClient(
+    accountConfig,
+    { baseUrl: spec.baseUrl ?? base.baseUrl, timeoutMs: base.timeoutMs },
+    cred,
+    proxy,
+    identity,
+    onResponseMeta,
+  );
+}
+
 // Turn bound subscription credentials into routable providers (issue #38, "connect
 // = routable"): for each executor-ready provider NOT already declared in
 // providers.yaml, build a POOL over ALL its SCHEDULABLE bound accounts. Each
@@ -408,44 +458,24 @@ export async function synthesizeOAuthProviders(
         continue;
       }
       for (const m of discovered) unionModels.add(m);
-      // The per-account config drives createProviderClient (type + oauth preset +
-      // base). The egress proxy (resolved above) is threaded into the credential's
-      // token manager AND the executor client, so refresh + execution egress alike.
-      const accountConfig = {
-        name: providerId,
-        alias: providerId,
-        type: spec.type,
-        base_url: spec.baseUrl,
-        oauth: { provider: providerId, account },
-        models: [],
-        targetProviderProtocol: spec.targetProviderProtocol,
-        providerRequiresCompatibilityRewrite: spec.providerRequiresCompatibilityRewrite,
-      } as unknown as ProviderConfigShared;
-      const cred = buildCredential(accountConfig, oauthCtx, proxy);
-      if (!cred) continue; // unreachable (token just refreshed) — fail-open guard
-      // Stable per-account anti-ban identity (never rotates): Anthropic gets a
-      // metadata.user_id; Codex a stable session_id. Both deterministic from
-      // (providerId, account) salted by the at-rest key — no DB write-back.
-      const identity =
-        providerId === "anthropic"
-          ? { metadataUserId: anthropicMetadataUserId(providerId, account, oauthCtx.encKey) }
-          : providerId === "openai-codex"
-            ? { sessionId: stableSessionId(providerId, account, oauthCtx.encKey) }
-            : undefined;
       // Bind the quota-header scrape to THIS account (providers page Tier 3): the
       // Codex client invokes it with each reply's headers; synthesis closes over the
       // account so the snapshot is attributed correctly. undefined ⇒ no capture.
       const onResponseMeta = onQuotaHeaders
         ? (headers: Headers) => onQuotaHeaders(providerId, account, headers)
         : undefined;
-      const client = createProviderClient(
-        accountConfig,
-        { baseUrl: spec.baseUrl ?? fallbackBaseUrl, timeoutMs },
-        cred,
+      // Per-account executor client: type + oauth preset + base, threaded with the
+      // egress proxy + stable anti-ban identity. Extracted to buildOAuthAccountClient
+      // so the admin connectivity tester binds IDENTICALLY (it shares this builder).
+      const client = buildOAuthAccountClient(
+        providerId,
+        account,
+        oauthCtx,
         proxy,
-        identity,
+        { baseUrl: fallbackBaseUrl, timeoutMs },
         onResponseMeta,
       );
+      if (!client) continue; // unreachable (token just refreshed) — fail-open guard
       // Serialize user-message requests per account (issue #93, feature B). The
       // wrap sits INSIDE the pool member so the gate key is the concrete account
       // the pool selected; non-user turns and a disabled setting pass through.
@@ -1509,6 +1539,29 @@ export async function buildServer(
       for (const opt of oauthOptions) byAlias.set(opt.alias, opt);
       return [...byAlias.values()].sort((a, b) => a.alias.localeCompare(b.alias));
     };
+    // Per-account connectivity tester for the providers page "Test" button. Builds a
+    // FRESH, isolated client per test (its own token + CURRENT proxy + executor type)
+    // via buildOAuthAccountClient — the same binding synthesis uses — so a test is
+    // faithful to production yet records no telemetry and never perturbs the routing
+    // pool. Account settings are reloaded per call so a just-saved proxy edit applies
+    // without a restart. Present only when OAuth is configured (mirrors `oauth`).
+    let oauthTester: OAuthTester | undefined;
+    if (oauthCtx) {
+      const ctx = oauthCtx;
+      oauthTester = createOAuthAccountTester({
+        buildClient: async (providerId, account) => {
+          const acctSettings = await loadAccountSettings(store.config, ctx.encKey);
+          const proxy = resolveProviderProxy(
+            { oauth: { provider: providerId, account } } as unknown as ProviderConfigShared,
+            acctSettings,
+          );
+          return buildOAuthAccountClient(providerId, account, ctx, proxy, {
+            baseUrl: synthBaseUrl,
+            timeoutMs,
+          });
+        },
+      });
+    }
     registerAdminApi(app, {
       rules: ruleStore,
       keyStore,
@@ -1562,6 +1615,8 @@ export async function buildServer(
       // /oauth/usage + /oauth/quota admin routes (fail-open to empty when absent).
       oauthUsage: store.oauthUsage,
       oauthQuota: store.oauthQuota,
+      // Per-account connectivity tester (providers page "Test" button); see above.
+      oauthTester,
       // Hot-reload the routable OAuth pool after any admin mutation (proxy /
       // priority / schedulable / curation / connect / disconnect) so it applies on
       // the next request without a restart.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-14 · Subscription Providers 账号「测试」按钮 + 流式连通性检查（docs/06/11；原则 1/3/7）
+
+- **背景**：用户要求在 providers 列表给每个 provider 加「测试」按钮，弹层点测试后发一条测试内容、流式输出**真实返回**（参考 claude-relay-service，简单为主，不要只出「测试成功」）。截图里那种 API-key provider 配置列表（qwen/zhipuai/… 带 Enabled/Edit/Delete）**helm 并不存在**（查遍所有分支）；helm 唯一 provider 列表是 OAuth『Subscription Providers』页（按账号一行，Manage/Disconnect）。**用户拍板：按钮加在该页、按账号测**。
+- **后端（三件，TDD）**：① `routes/admin/oauth-test.ts` 纯件——`createOpenAiStreamParser`（缓冲式把 provider client 的 OpenAI `chat.completion.chunk` SSE 归一成 content/finish/usage 事件，跨**非帧对齐**字节块重组、`[DONE]`/注释/不可解析帧 fail-open）+ `createOAuthAccountTester`（注入 `buildClient` 造账号 client，发单条 user turn 流式产事件）。② `routes/admin/oauth.ts` 加 `POST /admin/api/oauth/:provider/test` → `streamSSE` 发 start/content/finish/usage/done/error；无 tester→503、缺 account/model→400、上游失败→**带内 `error` 事件（HTTP 200 不 5xx）**、客户端断连静默。③ `server.ts` 抽模块级 `buildOAuthAccountClient`（synthesis 与 tester **共用**，绑定 100% 一致，behavior-preserving 重构），`buildServer` 内按 `oauthCtx` 造 tester（每次测试**重载 account settings 取当前 proxy** → 改完代理不必重启）穿进 `AdminApiDeps.oauthTester`。
+- **隔离与防封号（关键设计，已核对代码）**：测试走**全新一次性 client**而非 routing pool 成员——raw provider client **本就无熔断器**（熔断在 executor 层，openai.ts 头注释明示），故测试**不写 telemetry/request_payloads、不扰动生产 pool 熔断/健康**；anti-ban 由 provider client 自动注入（`anthropic.ts` 的 `openaiToAnthropicRequest` 自动加「You are Claude Code」spoof + 计费块 + 稳定 `metadata.user_id`，Codex 走稳定 session_id），所以**裸 `{role:user}` 测试请求对 Claude Max/Codex OAuth 即被接受**。停泊（parked）账号也可测（按需构建，不受 schedulable 限制）。
+- **前端**：`lib/api/oauth.ts` 加 `streamAccountTest`（POST + 读 ReadableStream 缓冲分行 parse，**永不抛**、pre-flight 503/400 归一成单 error 事件、断连静默）；`lib/components/TestAccountDialog.svelte`（Modal，模型选择来自该行 effective models、可选 prompt、实时流式响应框 + 状态 idle/testing/success/failed + 耗时 + 字符数，关闭/停止即 abort；`untrack` 取首个 model 同 EditKeyDialog 约定）；providers 页 Actions 加「Test」按钮 + 弹层接线；i18n **13** 新串补齐 en/zh-hans/zh-hant/ja/ko（zh 意译）。
+- **取舍 / 坑**：测试请求是**真实上游调用**（真实计费/配额扣减），只是不入 Requests 日志；默认 prompt 常量 + `max_tokens:512`（够看到可见流式内容，含 reasoning 模型）；只 surface `content` delta（reasoning 不展示，留作后续）；模型不做严格校验（admin-only + 来自该行 models，仅要求非空）。
+- **验证**：红→绿 TDD。gateway 全量 **732 绿**（含 parser 10 + route 4 + synthesis 12 未回归）、admin 全量 **358 绿**（providers 页 +2：开弹层 / 流式成功）；`pnpm typecheck` 绿、`pnpm lint`(biome) 绿、admin `pnpm build` 绿（弹层/页 prod 编译通过）。admin svelte-check 仅剩 `oauth.test.ts` 3 处**既有**报错（`vi.fn` mock.calls 元组类型，与 origin/main 逐字相同，且 admin 不在 `-r typecheck` CI 门禁），**非本次回归**。分支 `feat/oauth-account-test-button`（git worktree）。
+- **TODO**：未提交/未部署（用户要求时再 commit/push）；e2e（Playwright）真账号手验待做；reasoning delta 展示 + 模型严格校验为可选增强。
+
 ## 2026-06-14 · 原生直通保真实施 + 可执行验收（docs/native-passthrough-fidelity-spec；原则 7/8）
 
 - **背景**：用户要求 Anthropic Messages 和 OpenAI Responses 的 native passthrough 尽量保持客户端原协议与原请求内容，同时保留 Helm 自身治理、优化和 memory 注入，并参考 `claude-relay-service` 的账号安全策略（尤其防封号策略）。本次按 TDD 先补可执行验收，再收敛实现。
@@ -26,20 +36,13 @@
 - **验证**：红→绿 TDD 全程；`pnpm typecheck` 干净；`pnpm lint` 446 文件绿；focused 全绿——protocol 全量 585（含 interop matrix 176，ANT-02 改 IR `tool_choice` 形**不破** matrix）、gateway execute/passthrough/pipeline 105、touched 套件 256。`.passthrough()` 的 TS 6385 弃用是既存全仓告警、非本次引入、非 error。改动严格限于协议层 + memory 注释 + execute 模态检测（**未碰 config**）。分支 `review-fixes-protocol-memory`，未提交。
 - **TODO**：PT-08/GEM-04 设计决定待用户拍板；若补，STREAM-02/03 matrix 流式覆盖与 GEM-04 ProtocolWarning 基建是后续小项。
 
-## 2026-06-13 · 原生协议直通默认 ON + 系统设置开关（runtime-settings；原则 2）
-
-- **背景**：原生协议直通（同协议 verbatim 转发，Phase 1–3 已落地）此前 schema 默认 `false`（"merge ≠ enable" 的保守姿态）、且 admin 无可见开关，只能改 API。用户拍板：默认翻 `true`，并在「系统设置」加可见开关。
-- **改动（单一真源 + 加性 UI）**：① `packages/shared/.../runtime-settings.schema.ts` 的 `native_protocol_passthrough` `.default(false)→.default(true)`（z.infer 自动传播到所有消费方）；② admin 客户端 `settings.ts` 的 `normalize()` 由 `=== true`→`!== false`（与同为 default-true 的 `capture_payloads` 一致，legacy/partial 缺字段回落 true，且**仍命名该字段**防 #225 静默重置）；③ `settings/+page.svelte` 新增独立「Protocol passthrough」section（checkbox `data-testid=native-protocol-passthrough` + 两段 field-help），`DEFAULTS` 同步 true；④ i18n：en（identity）/zh-hans/zh-hant 加 4 串（zh 意译，help 串经脚本从 svelte 提取保 U+2019/→/— 字节一致；ja/ko 走英文回退）。
-- **安全论证（已写进开关文案）**：默认 ON 安全——`openai_chat` 入站（OpenAI SDK + `model=lane`）走**两道独立闸**（`/v1/chat/completions` 不捕获 `native_request` + 守卫 `source_protocol_is_lingua_franca`）永远翻译 + 正常 lane 路由；跨协议、异构 fallback 链同样自动退回翻译。直通只替换 execute 的 invoke，分类/路由/治理全程保留、fail-open。
-- **prod 盲区（运维坑）**：翻 schema 默认只影响**无持久化 runtime_settings 行、或行内未显式写该字段**的部署（`loadRuntimeSettings` = `{...defaults, ...overlay}`，overlay 显式 `false` 会赢）。若 la.atmy.work 之前存过带 `native_protocol_passthrough:false` 的设置 blob，默认翻转**不改变它**——须部署后在 admin 开关手动打开。
-- **验证**：TDD 红→绿——4 个断言默认派生值的测试 `false→true`（shared schema / gateway server / core settings `defaultSettingsFromConfig` / admin settings client「defaults missing fields」；显式传 `false` 的 fixture 不动）。分包单测 + `pnpm typecheck` + `pnpm lint`。
-- **不在本次范围**：部署到 prod（需 cut release + build 镜像）、ja/ko 文案补全。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-13 · 原生协议直通默认 ON + 系统设置开关（runtime-settings；原则 2）：`native_protocol_passthrough` schema 默认 `false→true`（z.infer 传播）、admin 客户端 normalize `===true→!==false`（仍命名该字段防 #225 静默重置）、settings 页加独立「Protocol passthrough」开关（`data-testid=native-protocol-passthrough`）+ i18n en/zh。安全论证：`openai_chat` 入站两道独立闸恒翻译、跨协议/异构 fallback 自动退翻译，直通只换 execute invoke、分类/路由/治理/fail-open 全留。prod 坑：仅影响无持久 runtime_settings 行或行内未显式写该字段的部署（overlay 显式 false 仍赢）→ la.atmy.work 若存过 false 须 admin 手动开。TDD 4 个默认派生值断言 false→true 绿。
 
 ### 2026-06-13 · memory prompt-cache 优化 — 系统前缀注入 → 尾部 system-reminder（docs/08；原则 8）：用户拍板尾部 `<system-reminder>`，translate 路和 native passthrough 路都把 memory 追加到对话末尾而非前置 system，保住 Anthropic/Responses prompt-cache 前缀；`wrapMemoryReminder` 成单一真相源，system/instructions 与历史回合逐字不动。TDD 覆盖 inject bridge/native-memory/chat/messages/pipeline，typecheck/lint 绿；TODO 是 live e2e 手验缓存命中与 memory 召回。
 


### PR DESCRIPTION
## What

Adds a **Test** button to each OAuth account row on the **Subscription Providers** page. Clicking it opens a modal; **Run test** streams a single short completion through *that specific account* and renders the real reply **token-by-token** — with status (testing / success / failed), latency, and a live char count. Mirrors `claude-relay-service`'s account-test UX, kept intentionally simple. It shows the actual streamed result, not a bare "ok".

## Why this is safe (verified against the code)

- **No side effects.** The test runs through a **fresh, one-off provider client**. The raw client carries **no circuit breaker** (the breaker lives in the executor layer), so a test records **no telemetry / `request_payloads`** and **never perturbs the live routing pool's** breaker/health state.
- **Anti-ban is automatic.** `anthropic.ts` injects the "You are Claude Code" system spoof + billing block + stable `metadata.user_id` when shaping an OpenAI-style request (Codex gets its stable session id), so a bare `{role:"user"}` test turn is accepted by Claude Max / Codex OAuth — no special payload needed.
- **DRY binding.** `buildOAuthAccountClient` is extracted and shared by `synthesizeOAuthProviders` (production routing) **and** the tester, so the per-account binding (token + current proxy + executor type + identity) stays identical. Parked accounts are testable too.

## Changes

**Backend (`apps/gateway`)**
- `routes/admin/oauth-test.ts` — a pure buffering SSE parser (OpenAI `chat.completion.chunk` → `content`/`finish`/`usage`, fail-open) + `createOAuthAccountTester`.
- `routes/admin/oauth.ts` — `POST /admin/api/oauth/:provider/test` via `streamSSE`; emits `start`/`content`/`finish`/`usage`/`done`/`error`. 503 when OAuth is off, 400 on missing account/model, upstream failures surfaced as an **in-band `error` event (HTTP 200, never 5xx)**, client abort is silent.
- `routes/admin/deps.ts`, `server.ts` — `oauthTester` wired through `AdminApiDeps` (proxy reloaded per test so a just-saved proxy applies without restart).

**Frontend (`apps/admin`)**
- `lib/api/oauth.ts` — `streamAccountTest` async-generator (POST + buffered SSE parse, never throws).
- `lib/components/TestAccountDialog.svelte` — model picker (from the row's effective models), optional prompt, live streamed response box, status + latency + char count, abort-on-close.
- `routes/providers/+page.svelte` — the **Test** button + dialog wiring.
- i18n — 13 new strings across `en` / `zh-hans` / `zh-hant` / `ja` / `ko`.

## Notes / trade-offs

- A test is a **real upstream call** (counts against real billing/quota) — it just stays out of the Requests log.
- Default prompt + `max_tokens: 512`; only `content` deltas are shown (reasoning hidden); model isn't strictly validated (admin-only, sourced from the row's models).

## Testing

TDD red→green throughout.

- `pnpm typecheck` ✅ · `pnpm lint` (Biome) ✅ · admin `pnpm build` ✅
- Gateway unit: **732 pass** (incl. parser 10, route 4, and the 12 synthesis tests unchanged — proving the `buildOAuthAccountClient` extraction is behavior-preserving)
- Admin unit: **358 pass** (providers page +2: opens the dialog / streams to success)

The only admin `svelte-check` errors (3 in `oauth.test.ts`) are **pre-existing** — byte-identical to `origin/main` (a `vi.fn` mock-tuple typing quirk), and admin isn't in the `pnpm typecheck` (`-r`) CI gate. Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
