### PR TITLE
chore(release): v0.12.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release bundling changes since v0.12.9.

## Included
- **#242** feat(admin): stream a per-account connectivity test on the Providers page — a Test button + streaming modal on each Subscription Providers account row; runs through an isolated one-off client (no telemetry/`request_payloads`, no breaker impact), anti-ban shaping auto-injected. No new config/env.
- **#243** fix(protocol): tighten LiteLLM passthrough parity — Responses prelude de-dupe, target-protocol-aware `provider_raw` stripping, Anthropic empty-text-block sanitize, OpenAI `cache_control` removal.

## Release mechanics
On squash-merge, `publish.yml` auto-cuts tag `v0.12.10` + GitHub Release + GHCR `:0.12.10` and `:latest`. No manual tag/release.

Zero config/infra diff since the last deploy — la.atmy.work deploy is a clean `pull + up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
