### PR TITLE
修复原生直通按 attempt 判断

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1465,9 +1465,10 @@ describe("createExecute — gateway execution adapter", () => {
 // Native protocol passthrough (issue #217, Phase 1). The executor forwards a
 // VERBATIM native Anthropic body to an Anthropic upstream (skipping the 4 lossy
 // translations) and returns the native response untouched, ONLY when the runtime
-// flag is on, the inbound protocol matches the target wire protocol, the chain is
-// homogeneous, and the provider client implements nativePassthrough. The branch is a
-// body+response substitution INSIDE the existing per-candidate try/catch — so
+// flag is on, the inbound protocol matches THIS target wire protocol, and the
+// provider client implements nativePassthrough. The branch is a body+response
+// substitution INSIDE the existing per-candidate try/catch — so heterogeneous later
+// fallback candidates remain free to translate if this candidate fails before output.
 // breaker / abort / free-429 / chain-advance semantics are identical.
 describe("createExecute — native protocol passthrough (#217)", () => {
   // model is the ROUTING ALIAS a client sends (e.g. `anthropic/claude-x`), NOT a
@@ -1732,7 +1733,7 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(okRow?.passthrough_disable_reason).toBe("feature_flag_disabled");
   });
 
-  it("cross-protocol fallback chain [anthropic, openai], flag ON → head attempt disabled (fallback_may_change_provider_protocol) and translates", async () => {
+  it("cross-protocol fallback chain [anthropic, openai], flag ON → head attempt still uses same-protocol passthrough", async () => {
     const provider = anthropicProvider(NATIVE_RESP);
     const execute = createExecute({
       defaultProvider: provider,
@@ -1758,13 +1759,62 @@ describe("createExecute — native protocol passthrough (#217)", () => {
 
     const out = await execute(plan(["a", "b"]), anthropicReq());
     expect(out.final.status).toBe("ok");
-    // The HEAD candidate (anthropic) is served, but via translate — a later candidate
-    // resolves to a DIFFERENT provider protocol, so passthrough is disabled.
-    expect(provider.nativePassthrough).not.toHaveBeenCalled();
-    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
+    // The HEAD candidate is same-protocol, so it passthroughs even though a later
+    // fallback candidate would need translation.
+    expect(provider.nativePassthrough).toHaveBeenCalledTimes(1);
+    expect(provider.chatCompletion).not.toHaveBeenCalled();
     const okRow = out.attempts[0];
-    expect(okRow?.passthrough_used).toBe(false);
-    expect(okRow?.passthrough_disable_reason).toBe("fallback_may_change_provider_protocol");
+    expect(okRow?.passthrough_used).toBe(true);
+    expect(okRow?.passthrough_disable_reason).toBeNull();
+  });
+
+  it("cross-protocol fallback chain: failed Anthropic passthrough advances to translated OpenAI attempt", async () => {
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockRejectedValue(new UpstreamError("upstream_error", "boom")),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const tail = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "translated-tail" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient & { chatCompletion: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["anthro", head],
+        ["openai", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "openai",
+          providerModel: "gpt-x",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(plan(["a", "b"]), anthropicReq());
+    expect(head.nativePassthrough).toHaveBeenCalledTimes(1);
+    expect(tail.chatCompletion).toHaveBeenCalledTimes(1);
+    expect(tail.chatCompletion.mock.calls[0]?.[0]).toMatchObject({ model: "gpt-x" });
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-x" });
+    expect(out.body).toEqual({ id: "translated-tail" });
+    expect(out.attempts[0]?.status).toBe("error");
+    expect(out.attempts[0]?.passthrough_used).toBe(true);
+    expect(out.attempts[1]?.status).toBe("ok");
+    expect(out.attempts[1]?.target_provider_protocol).toBe("openai_chat");
+    expect(out.attempts[1]?.passthrough_used).toBe(false);
+    expect(out.attempts[1]?.passthrough_disable_reason).toBe("protocol_mismatch");
   });
 
   it("an UpstreamError from nativePassthrough records a breaker failure and advances the chain", async () => {
@@ -2408,6 +2458,57 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.final.status).toBe("ok");
     expect(out.stream).not.toBeNull();
     expect(out.nativePassthrough).toBe(true);
+  });
+
+  it("stream cross-protocol fallback: failed Anthropic passthrough advances to translated OpenAI stream", async () => {
+    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
+    async function* diesBeforeFirst(): AsyncGenerator<string> {
+      throw new UpstreamError("upstream_error", "connect failed");
+    }
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(diesBeforeFirst()),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const tail = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn().mockReturnValue(gen(["data: {}\n\n"])),
+    } as unknown as ProviderClient & { chatCompletionStream: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["anthro", head],
+        ["openai", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "openai",
+          providerModel: "gpt-x",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(plan(["a", "b"]), anthropicStreamReq());
+
+    expect(head.nativePassthroughStream).toHaveBeenCalledTimes(1);
+    expect(tail.chatCompletionStream).toHaveBeenCalledTimes(1);
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-x" });
+    expect(out.stream).not.toBeNull();
+    expect(out.attempts[0]?.passthrough_used).toBe(true);
+    expect(out.attempts[1]?.target_provider_protocol).toBe("openai_chat");
+    expect(out.attempts[1]?.passthrough_used).toBe(false);
+    expect(out.attempts[1]?.passthrough_disable_reason).toBe("protocol_mismatch");
   });
 
   it("a client abort during the stream peek records client_abort without a breaker failure", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -309,44 +309,20 @@ function resolveAttemptTarget(input: {
 // build the body-free telemetry trail. The guard (core protocol.ts) is the pure
 // decision; here we only assemble its inputs: the runtime flag, whether a verbatim
 // native body rode the request, whether the resolved client implements
-// nativePassthrough, and a LOOKAHEAD over later candidates — if any resolves to a
-// DIFFERENT provider protocol the chain is heterogeneous, so passthrough must stay off
-// (the response must be IR-normalizable to feed any fallback translator).
+// nativePassthrough. This is intentionally PER-ATTEMPT: a same-protocol Anthropic
+// head can passthrough, while a later OpenAI/Responses fallback translates if reached.
 function decideNativePassthroughForAttempt(input: {
   req: InternalRequest;
-  plan: ExecutionPlan;
-  candidateIndex: number;
   target: ResolvedAttemptTarget;
-  defaultProvider: ProviderClient;
-  providers?: Map<string, ProviderClient>;
-  registry: ProviderRegistry;
-  knownOAuthPrefixes?: ReadonlySet<string>;
-  oauthAliases?: () => ReadonlySet<string>;
-  oauthProviderProtocols?: ReadonlyMap<string, ProviderProtocolMetadata>;
   enabled: boolean;
 }): PassthroughTelemetry {
-  const { req, plan, candidateIndex, target } = input;
-  const fallbackMayUseDifferentProviderProtocol = plan.candidate_chain
-    .slice(candidateIndex + 1)
-    .some((fallbackAlias) => {
-      const fallback = resolveAttemptTarget({
-        alias: fallbackAlias,
-        defaultProvider: input.defaultProvider,
-        providers: input.providers,
-        registry: input.registry,
-        knownOAuthPrefixes: input.knownOAuthPrefixes,
-        oauthAliases: input.oauthAliases,
-        oauthProviderProtocols: input.oauthProviderProtocols,
-      });
-      return fallback.targetProviderProtocol !== target.targetProviderProtocol;
-    });
+  const { req, target } = input;
 
   const decision = canUseNativePassthrough({
     enabled: input.enabled,
     hasNativeRequest: req.native_request !== undefined,
     request: req,
     targetProviderProtocol: target.targetProviderProtocol,
-    fallbackMayUseDifferentProviderProtocol,
     providerRequiresCompatibilityRewrite: target.providerRequiresCompatibilityRewrite,
     // Stream-aware feature detection: a stream request needs the streaming sibling
     // (nativePassthroughStream); a non-stream request needs nativePassthrough. A
@@ -601,7 +577,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
     const needsCachedContent =
       typeof req.cached_content === "string" && req.cached_content.length > 0;
 
-    for (const [candidateIndex, alias] of plan.candidate_chain.entries()) {
+    for (const alias of plan.candidate_chain) {
       const startedAt = now();
       const elapsed = () => Math.max(0, now() - startedAt);
 
@@ -683,15 +659,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       // breaker / abort / free-429 / chain-advance below are identical either way.
       const passthrough = decideNativePassthroughForAttempt({
         req,
-        plan,
-        candidateIndex,
         target,
-        defaultProvider,
-        providers,
-        registry,
-        knownOAuthPrefixes,
-        oauthAliases,
-        oauthProviderProtocols,
         enabled: nativeProtocolPassthroughEnabled?.() === true,
       });
 

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -1032,7 +1032,17 @@ export function createMessagesPipeline(
                       model:
                         typeof ir.model === "string" && ir.model.length > 0 ? ir.model : "auto",
                     })
-                  : convertOpenAIStreamToAnthropic(source as AsyncIterable<never>);
+                  : convertOpenAIStreamToAnthropic(source as AsyncIterable<never>, {
+                      id: result.decision.request_id,
+                      model:
+                        result.decision.final?.status === "ok"
+                          ? (result.decision.final.provider_model ??
+                            result.decision.final.model_alias ??
+                            (typeof ir.model === "string" ? ir.model : undefined))
+                          : typeof ir.model === "string"
+                            ? ir.model
+                            : undefined,
+                    });
               for await (const ev of events) {
                 yield ev as (AnthropicSSEEvent | ResponsesSSEEvent) & { type: string };
               }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-14 · 原生直通按 attempt 判断 + Anthropic SSE 元数据修复（docs/02/05；原则 5/7/8）
+
+- **背景**：线上 tuned `claude-opus -> premium` 链被 `fallback_may_change_provider_protocol` 整链否决，导致首个 Anthropic→Anthropic attempt 也被迫走翻译；这会放大 Anthropic SSE 翻译瑕疵并拖慢 Claude Code。用户明确要求保持 lanes 不变，只修代码。
+- **核心改动**：① native passthrough guard 删除“后续 fallback 可能跨协议”的输入与禁用原因，改为只判断**当前 attempt**：source protocol == target provider protocol、runtime flag on、native carrier 存在、provider 支持且无需兼容性 rewrite 即直通；② `execute` 不再 lookahead 解析后续候选，Anthropic head 可以直通，若首包前失败再让后续 `openai_chat` / `openai_responses` fallback 走翻译；③ `convertOpenAIStreamToAnthropic` 的 `message_start` 不再发空 `id/model`，优先取首个 upstream chunk，缺失时用 pipeline 传入的 `request_id/final.provider_model` 兜底并规范成 `msg_*` id。
+- **治理与取舍**：治理路径不变，auth/routing/budget/capture/memory/telemetry 仍先于 execute；`provider_attempts[]` 逐 attempt 记录 `passthrough_used` / `protocol_mismatch`，`final.provider_model` 仍记录实际落点。流式 fallback 只发生在首包前，首包后仍不能换模型，这是既有 contract。
+- **验证**：补回归测试覆盖 heterogeneous chain 的 head Anthropic passthrough、Anthropic passthrough 首包前失败后 fallback 到 translated OpenAI、stream 同场景，以及 translated Anthropic `message_start.id/model` 非空。focused `pnpm exec vitest run packages/core/src/provider/protocol.test.ts apps/gateway/src/routes/execute.test.ts packages/core/src/protocol/anthropic/stream.test.ts` 绿（96 tests）。
+
 ## 2026-06-14 · LiteLLM 协议互译首批 P1 修复（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）
 
 - **背景**：基于本地 LiteLLM 对照和 wiki/spec，本轮先落地最小高风险修复：Responses 非原生流式 prelude 重复、Anthropic-only provider_raw 泄露到 OpenAI-compatible target、Anthropic native 空文本块导致上游 400、OpenAI target 收到 Anthropic `cache_control`。
@@ -25,21 +32,13 @@
 - **TODO**：未提交/未部署（用户要求时再 commit/push）；e2e（Playwright）真账号手验待做；reasoning delta 展示 + 模型严格校验为可选增强。
 
 
-## 2026-06-14 · 原生直通保真实施 + 可执行验收（docs/native-passthrough-fidelity-spec；原则 7/8）
-
-- **背景**：用户要求 Anthropic Messages 和 OpenAI Responses 的 native passthrough 尽量保持客户端原协议与原请求内容，同时保留 Helm 自身治理、优化和 memory 注入，并参考 `claude-relay-service` 的账号安全策略（尤其防封号策略）。本次按 TDD 先补可执行验收，再收敛实现。
-- **核心改动**：① 新增 typed `NativePassthroughCarrier`（`protocol/body/raw_body/headers/mutations`）和共享 helper，route 在 `/v1/messages`、`/v1/responses` 盖戳 raw body + client headers；② provider native 请求统一走 `prepareNativePassthroughRequest`，drop auth/hop-by-hop/`x-helm-*`/cookie/secret-like client headers，替换 provider auth，默认保留安全 identity/session headers（UA、accept、session_id、x-client-request-id、originator 等），合并 Anthropic/OpenAI beta，并在 body 未变时转发 raw JSON text；③ streaming native path 改为 route 可写 raw SSE frame，comments/keepalives/no-data frames 与 CRLF 边界不再被 splitter 丢弃，Responses native stream 不再合成 prelude、不改写 upstream id；④ Responses/Codex profile 对 `store:true` 强制 `store:false` 并记录 `body_shims_applied:["store_forced_false"]` + `provider_profile_applied:"codex_official_safe"`；Anthropic dynamic-auth stream 的 `accept-encoding: identity` 仅在 official-safe profile 触发并记录；⑤ OAuth pool 增加 native sticky session（session_id/x-session-id/x-client-request-id/prompt_cache_key/conversation_id/metadata），同一 session 在 TTL 内绑定同一账号。
-- **治理与可观测性**：native path 仍经过 auth、rate limit、concurrency、budget、route/fallback guard、payload capture、memory inject/observe 和 telemetry；每次 attempt 的 `passthrough_*` 字段与 mutation ledger 进 `DecisionRecord.provider_attempts[]`，ledger 只记录修改类型，不写 secrets 或完整 body。memory 注入保持尾部 `<system-reminder>` 追加；修改 body 时自动清掉 raw body，避免伪装 byte-identical。
-- **验收体系**：新增 `scripts/passthrough/*` 和 package scripts：`test:passthrough:unit`（helper/provider/route/pipeline focused tests）、`test:passthrough:e2e`（fake upstream + route/execute deterministic golden cases）、`test:passthrough:live:*`（真实 Claude CLI / Codex CLI + telemetry proof）和 `test:passthrough:final`。live 脚本 fail-closed：必须看到 CLI sentinel、真实 CLI exit 0、admin telemetry 中 `passthrough_used:true`、协议一致、ledger 不含 Helm API key；live report 的 stdout/stderr 只写长度/行数/hash/sentinel/secret-redaction 摘要，不写完整 prompt 或输出正文。
-- **验证**：`ast-grep` 已用于 native carrier / route glue / mutation ledger 检查；`pnpm lint` 绿；`pnpm typecheck` 绿；`pnpm build` 绿；`pnpm test:passthrough` 绿（323 focused unit + 11 deterministic e2e）；`pnpm test` 绿（255 files / 3578 tests）；`pnpm test:passthrough:final` 绿。live final 使用本地 Helm 测试实例代理真实 upstream，Claude Code `2.1.175` 与 Codex CLI `0.139.0` 均返回 `HELM_LIVE_OK`，并从本地 admin telemetry 证明 `anthropic_messages` / `openai_responses` native passthrough。live 报告只作验收产物，不提交。
-- **取舍 / TODO**：provider profile 目前以代码路径记录（`codex_official_safe` / `anthropic_official_safe`），尚未做成完整 YAML 配置面；admin request detail 已有原始 attempt 字段，但 SPA 专门展示 passthrough ledger 可作为后续 UX 增强；Responses live CLI 本身未必发送 `store:true`，因此 `store_forced_false` 的强断言放在 deterministic fake-upstream case。
-
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-14 · 原生直通保真实施 + 可执行验收（docs/native-passthrough-fidelity-spec；原则 7/8）：建立 native carrier、provider safe profile、raw SSE byte relay、Responses/Codex passthrough、OAuth sticky session 与 live/fake 验收脚本；证明 native path 保持治理/telemetry/memory/预算，mutation ledger 只记修改类型不泄露正文；focused/unit/e2e/live final 当时全绿，TODO 为 provider profile YAML 化与 admin ledger UX。
 
 ### 2026-06-14 · 协议层 review 修复：4 协议保真 + memory 注释纠偏（多 spec；原则 1/7/8）：修 Anthropic stream cache_creation 计费、Gemini 媒体/tool_result、Responses input_audio、Anthropic tool_choice、远端 audio document 模态误判，并把 memory/native passthrough 过期注释改成实际尾部 system-reminder/default ON 模型；focused protocol/gateway suites + typecheck/lint 绿。
 

--- a/packages/core/src/protocol/anthropic/stream.test.ts
+++ b/packages/core/src/protocol/anthropic/stream.test.ts
@@ -81,6 +81,31 @@ describe("convertOpenAIStreamToAnthropic — text event sequence", () => {
       expect(md.delta.stop_reason).toBe("end_turn");
     }
   });
+
+  it("fills message_start id/model from the first upstream chunk", async () => {
+    const events = await collect(convertOpenAIStreamToAnthropic(feed([textChunk("x")])));
+    const start = nth(events, 0);
+    expect(start.type).toBe("message_start");
+    if (start.type === "message_start") {
+      expect(start.message.id).toBe("msg_chatcmpl-x");
+      expect(start.message.model).toBe("gpt-x");
+    }
+  });
+
+  it("uses supplied fallback id/model when the first upstream chunk omits them", async () => {
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(
+        feed([{ choices: [{ index: 0, delta: { content: "x" }, finish_reason: null }] }]),
+        { id: "req-123", model: "gpt-5.5" },
+      ),
+    );
+    const start = nth(events, 0);
+    expect(start.type).toBe("message_start");
+    if (start.type === "message_start") {
+      expect(start.message.id).toBe("msg_req-123");
+      expect(start.message.model).toBe("gpt-5.5");
+    }
+  });
 });
 
 // —— 2. parallel tool-call streaming ——————————————————————————————————————————

--- a/packages/core/src/protocol/anthropic/stream.ts
+++ b/packages/core/src/protocol/anthropic/stream.ts
@@ -120,6 +120,13 @@ export const OpenAIChunkSchema = z
   .passthrough();
 export type OpenAIChunk = z.infer<typeof OpenAIChunkSchema>;
 
+export interface OpenAIToAnthropicStreamOptions {
+  /** Fallback id used when the upstream stream does not expose one before message_start. */
+  id?: string;
+  /** Fallback served model used when the upstream stream does not expose one. */
+  model?: string;
+}
+
 // —— Anthropic SSE event schemas (the output alphabet of the state machine). ————
 // One discriminated union on `type`, mirroring the Anthropic Messages streaming
 // wire events. Deltas are themselves a discriminated union (text vs tool args).
@@ -292,15 +299,25 @@ function tempId(blockIndex: number): string {
 
 // —— Event constructors ————————————————————————————————————————————————————————
 
-function messageStartEvent(): AnthropicSSEEvent {
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function toAnthropicMessageId(value: string | undefined): string {
+  const raw = value ?? "helm_stream";
+  const safe = raw.replace(/[^A-Za-z0-9_-]/g, "_");
+  return safe.startsWith("msg_") ? safe : `msg_${safe}`;
+}
+
+function messageStartEvent(meta: { id?: string; model?: string }): AnthropicSSEEvent {
   // The skeleton usage carries zeros; the real input/output land on message_delta.
   return {
     type: "message_start",
     message: {
-      id: "",
+      id: toAnthropicMessageId(meta.id),
       type: "message",
       role: "assistant",
-      model: "",
+      model: meta.model ?? "unknown",
       content: [],
       stop_reason: null,
       stop_sequence: null,
@@ -364,6 +381,7 @@ function messageDeltaEvent(state: StreamState): AnthropicSSEEvent {
  */
 export async function* convertOpenAIStreamToAnthropic(
   chunks: AsyncIterable<OpenAIChunk>,
+  options: OpenAIToAnthropicStreamOptions = {},
 ): AsyncIterable<AnthropicSSEEvent> {
   const state = createState();
 
@@ -372,7 +390,10 @@ export async function* convertOpenAIStreamToAnthropic(
 
     if (!state.messageStarted) {
       state.messageStarted = true;
-      yield messageStartEvent();
+      yield messageStartEvent({
+        id: nonEmptyString(chunk.id) ?? nonEmptyString(options.id),
+        model: nonEmptyString(chunk.model) ?? nonEmptyString(options.model),
+      });
     }
 
     const choice = chunk.choices?.[0];

--- a/packages/core/src/provider/protocol.test.ts
+++ b/packages/core/src/provider/protocol.test.ts
@@ -45,7 +45,6 @@ function input(
     hasNativeRequest: true,
     request: request(),
     targetProviderProtocol: "anthropic_messages",
-    fallbackMayUseDifferentProviderProtocol: false,
     providerRequiresCompatibilityRewrite: false,
     providerSupportsPassthrough: true,
     ...overrides,
@@ -117,20 +116,18 @@ describe("canUseNativePassthrough", () => {
     ).toEqual({ ok: true });
   });
 
-  it("7) disables when a heterogeneous fallback chain may pick a different provider protocol", () => {
-    expect(
-      canUseNativePassthrough(input({ fallbackMayUseDifferentProviderProtocol: true })),
-    ).toEqual({ ok: false, reason: "fallback_may_change_provider_protocol" });
+  it("does not inspect later fallback candidates; passthrough is per-attempt", () => {
+    expect(canUseNativePassthrough(input())).toEqual({ ok: true });
   });
 
-  it("8) disables when the provider requires a compatibility rewrite (developer-role / schema remap)", () => {
+  it("7) disables when the provider requires a compatibility rewrite (developer-role / schema remap)", () => {
     expect(canUseNativePassthrough(input({ providerRequiresCompatibilityRewrite: true }))).toEqual({
       ok: false,
       reason: "provider_requires_compatibility_rewrite",
     });
   });
 
-  it("9) disables when the resolved provider client has no nativePassthrough method", () => {
+  it("8) disables when the resolved provider client has no nativePassthrough method", () => {
     expect(canUseNativePassthrough(input({ providerSupportsPassthrough: false }))).toEqual({
       ok: false,
       reason: "provider_lacks_passthrough",
@@ -146,7 +143,6 @@ describe("canUseNativePassthrough", () => {
           hasNativeRequest: false,
           request: request({ protocol: "openai_chat", stream: true }),
           targetProviderProtocol: "anthropic_messages",
-          fallbackMayUseDifferentProviderProtocol: true,
           providerRequiresCompatibilityRewrite: true,
           providerSupportsPassthrough: false,
         }),
@@ -162,7 +158,6 @@ describe("canUseNativePassthrough", () => {
     // memory, fallback and breaker must already have run before execute asks this.
     expect(Object.keys(input()).sort()).toEqual([
       "enabled",
-      "fallbackMayUseDifferentProviderProtocol",
       "hasNativeRequest",
       "providerRequiresCompatibilityRewrite",
       "providerSupportsPassthrough",

--- a/packages/core/src/provider/protocol.ts
+++ b/packages/core/src/provider/protocol.ts
@@ -3,10 +3,9 @@ import type { InternalRequest, TargetProviderProtocol } from "@helm/shared";
 // Native protocol passthrough guard (issue #217, Phase 1). Decides whether the
 // executor may forward the client's VERBATIM native request body to the upstream
 // and return the upstream's native response untranslated — skipping the 4 lossy
-// translations (`Anthropic-native → IR → OpenAI-Chat → Anthropic wire` and back)
-// that only exist to normalize a heterogeneous chain. When the inbound protocol
-// already equals the upstream's native protocol, those translations are pure
-// waste and pure risk, so passthrough sends the body as-is.
+// translations (`Anthropic-native → IR → OpenAI-Chat → Anthropic wire` and back).
+// When the inbound protocol already equals THIS attempt's upstream native protocol,
+// those translations are pure waste and pure risk, so passthrough sends the body as-is.
 //
 // This generalizes the #218 same-protocol-serialization guard: the previous guard
 // hard-coded `openai_chat` (which was a no-op — openai_chat IS the lingua franca,
@@ -20,7 +19,6 @@ export type NativePassthroughDisableReason =
   | "missing_native_request"
   | "source_protocol_is_lingua_franca"
   | "protocol_mismatch"
-  | "fallback_may_change_provider_protocol"
   | "provider_requires_compatibility_rewrite"
   | "provider_lacks_passthrough";
 
@@ -36,10 +34,6 @@ export interface NativePassthroughDecisionInput {
   request: InternalRequest;
   /** The resolved candidate's upstream wire protocol. */
   targetProviderProtocol: TargetProviderProtocol;
-  /** True when a LATER candidate in the fallback chain resolves to a different
-   *  provider protocol (a heterogeneous chain) — passthrough must stay off so the
-   *  response can be normalized to IR for any fallback translator. */
-  fallbackMayUseDifferentProviderProtocol: boolean;
   /** The provider needs a compatibility rewrite (e.g. developer-role / tool /
    *  schema remap) — the body cannot be forwarded byte-for-byte. */
   providerRequiresCompatibilityRewrite: boolean;
@@ -83,9 +77,6 @@ export function canUseNativePassthrough(
   // cached prefix (tools → system → history) survives and the native_request stays
   // self-consistent. Passthrough can therefore fire WITH memory — there is no longer a
   // request rewrite for the guard to defend against.
-  if (input.fallbackMayUseDifferentProviderProtocol) {
-    return { ok: false, reason: "fallback_may_change_provider_protocol" };
-  }
   if (input.providerRequiresCompatibilityRewrite) {
     return { ok: false, reason: "provider_requires_compatibility_rewrite" };
   }

--- a/packages/shared/src/config/runtime-settings.schema.ts
+++ b/packages/shared/src/config/runtime-settings.schema.ts
@@ -29,10 +29,9 @@ export const RuntimeSettingsSchema = z.object({
   // bypassing the lossy IR translation round-trip. Default ON: when the inbound
   // protocol already equals the upstream wire protocol (e.g. Anthropic
   // /v1/messages → an Anthropic backend) the verbatim forward is higher-fidelity
-  // and cache-friendlier than translating. The guard still falls back to
-  // translation for openai_chat (lingua franca), cross-protocol routes, and
-  // heterogeneous fallback chains, so turning this ON is safe; flip it OFF here to
-  // force every request back through the IR round-trip.
+  // and cache-friendlier than translating. The guard is per-attempt: it still falls
+  // back to translation for openai_chat (lingua franca) and cross-protocol attempts,
+  // so a later heterogeneous fallback can translate if reached.
   native_protocol_passthrough: z.boolean().default(true),
   // Auto-prune captured payloads older than this many days. Bounds the storage
   // footprint and the plaintext-exposure window. Capped at 10 years.


### PR DESCRIPTION
## 背景

线上 tuned `claude-opus -> premium` fallback 链会被 `fallback_may_change_provider_protocol` 整链否决，导致第一个 `Anthropic -> Anthropic` attempt 也不能走 native passthrough，只能走协议翻译路径。这样既慢，也会放大 Anthropic SSE 翻译路径里的兼容性问题。

这次不修改 `lanes.yaml`，只修代码逻辑：fallback 路线保持不变，但每个 attempt 自己判断是否可以直通。

## 修改内容

- 删除 native passthrough guard 里的“后续 fallback 可能跨协议”整链否决。
- `execute` 不再 lookahead 扫描后续候选协议，只基于当前 resolved target 判断直通。
- 当前 attempt 如果是 `anthropic_messages -> anthropic_messages`，就允许 native passthrough。
- 如果首个 Anthropic passthrough 在首包前失败，后续 fallback 到 OpenAI / Responses provider 时正常走翻译，并在 telemetry 中记录 `protocol_mismatch`。
- 修复 Anthropic 翻译流 `message_start` 的空 `id/model`：优先使用上游 chunk，缺失时使用 pipeline 传入的 `request_id` 和最终服务模型。
- 更新 runtime setting 注释和 implementation notes，明确 passthrough 是 per-attempt 决策。

## 预期行为

```text
请求: claude-opus / anthropic_messages

attempt 1: anthropic/claude-opus-4-8
=> 同协议，passthrough_used: true

如果 attempt 1 首包前失败:

attempt 2: openai-codex/gpt-5.5 或其他 premium 候选
=> 跨协议，passthrough_used: false, passthrough_disable_reason: protocol_mismatch
```

治理记录仍保持原有结构：`requested_model` 保留用户请求，`provider_attempts[]` 记录每次 attempt，`final.provider_model` 记录实际最终服务模型。

## 验证

- `pnpm exec vitest run packages/core/src/provider/protocol.test.ts apps/gateway/src/routes/execute.test.ts packages/core/src/protocol/anthropic/stream.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
