### PR TITLE
chore(release): v0.12.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release bundling changes since v0.12.10.

## Included
- **#245** fix(protocol): allow per-attempt native passthrough — the passthrough guard is now evaluated per attempt, so a heterogeneous fallback can fall back to translation if reached. The `native_protocol_passthrough` setting and its default (ON) are unchanged; only guard logic + a doc comment.

## Release mechanics
On squash-merge, `publish.yml` auto-cuts tag `v0.12.11` + GitHub Release + GHCR `:0.12.11` and `:latest`. No manual tag/release.

No new config knobs; zero config/infra diff since the last deploy — la.atmy.work deploy is a clean `pull + up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
