### PR TITLE
chore(release): v0.12.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.12.12**.

Bumps `package.json` `0.12.11 → 0.12.12` so publish.yml cuts the tag + GitHub Release and pushes `ghcr.io/easymetaau/helm-api:0.12.12` / `:latest`.

### Included since v0.12.11
- #247 `feat(admin): remove protocol passthrough settings UI (#236)` — removes the "Protocol passthrough / 协议直通" card from System Settings. UI-only; gateway runtime behavior and the `native_protocol_passthrough` schema default (`true`) are unchanged, and the field still round-trips through Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)