### PR TITLE
chore(release): v0.12.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.12.13.

Includes since v0.12.12:
- feat(admin): resizable + fullscreen request/response viewers (#249)

Merging this bump to main triggers `publish.yml` to build & push `ghcr.io/easymetaau/helm-api:0.12.13` + `:latest` and cut GitHub Release `v0.12.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)