### PR TITLE
Complete LiteLLM protocol parity backlog

### DIFF
--- a/apps/gateway/e2e/gemini.spec.ts
+++ b/apps/gateway/e2e/gemini.spec.ts
@@ -168,16 +168,37 @@ test.describe("Gemini auth + error envelopes", () => {
     expect(body.error.code).toBe(401);
   });
 
-  test("a non-generateContent operation returns 404 (Gemini NOT_FOUND envelope)", async ({
-    request,
-  }) => {
+  test("countTokens returns a deterministic local estimate", async ({ request }) => {
     const res = await request.post("/v1beta/models/gemini-2.0-flash:countTokens", {
       headers: GEMINI_AUTH,
       data: { contents: [{ role: "user", parts: [{ text: "hi" }] }] },
     });
-    expect(res.status()).toBe(404);
+    expect(res.status()).toBe(200);
     const body = await res.json();
-    expect(body.error.status).toBe("NOT_FOUND");
+    expect(body).toEqual({ totalTokens: 14, estimated: true });
+  });
+
+  test("countTokens accepts publisher model paths", async ({ request }) => {
+    const res = await request.post(
+      "/models/publishers/google/models/gemini-2.0-flash:countTokens",
+      {
+        headers: GEMINI_AUTH,
+        data: { contents: [{ role: "user", parts: [{ text: "hi" }] }] },
+      },
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ totalTokens: 14, estimated: true });
+  });
+
+  test("malformed countTokens body returns 400 INVALID_ARGUMENT", async ({ request }) => {
+    const res = await request.post("/v1beta/models/gemini-2.0-flash:countTokens", {
+      headers: GEMINI_AUTH,
+      data: {},
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
   });
 
   test("a structurally invalid body returns 400 INVALID_ARGUMENT", async ({ request }) => {

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -247,6 +247,98 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
     expect(settleBudget).toHaveBeenCalledOnce();
   });
 
+  it("preserves the provider response model by default", async () => {
+    const { deps: d, harness } = deps();
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({
+        id: "c",
+        model: "provider-model",
+        choices: [{ message: { content: "ok" } }],
+      }),
+    );
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...NONSTREAM_BODY, model: "client-alias" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { model: string }).model).toBe("provider-model");
+  });
+
+  it("can restamp the OpenAI Chat response model to the requested alias", async () => {
+    const { deps: d, harness } = deps({ responseModelPolicy: "requested_alias" });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({
+        id: "c",
+        model: "provider-model",
+        choices: [{ message: { content: "ok" } }],
+      }),
+    );
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...NONSTREAM_BODY, model: "client-alias" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { model: string }).model).toBe("client-alias");
+    expect(res.headers.get("x-helm-provider-model")).toBe("gpt-x");
+  });
+
+  it("can expose both requested and provider model identities in headers", async () => {
+    const { deps: d, harness } = deps({ responseModelPolicy: "both" });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({
+        id: "c",
+        model: "provider-model",
+        choices: [{ message: { content: "ok" } }],
+      }),
+    );
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...NONSTREAM_BODY, model: "client-alias" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { model: string }).model).toBe("provider-model");
+    expect(res.headers.get("x-helm-requested-model")).toBe("client-alias");
+    expect(res.headers.get("x-helm-provider-model")).toBe("gpt-x");
+  });
+
+  it("can restamp streamed OpenAI Chat chunk models to the requested alias", async () => {
+    const chunks = [
+      'data: {"id":"c","object":"chat.completion.chunk","model":"provider-model","choices":[{"delta":{"content":"hi"}}]}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const { deps: d, harness } = deps({ responseModelPolicy: "requested_alias" });
+    harness.execute.mockResolvedValue({
+      ...nonStreamOutcome(null),
+      body: null,
+      stream: sse(chunks),
+    });
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...STREAM_BODY, model: "client-alias" }),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('"model":"client-alias"');
+    expect(text).not.toContain('"model":"provider-model"');
+    expect(text.trimEnd().endsWith("[DONE]")).toBe(true);
+  });
+
   it("honors the e2e x-helm-eval / x-helm-rules-threshold overrides when evalHeaderOverride is on", async () => {
     const { deps: d, harness } = deps({ evalHeaderOverride: true });
     harness.execute.mockResolvedValue(
@@ -455,6 +547,49 @@ describe("POST /v1/chat/completions (routing pipeline)", () => {
       prompt_version: "v7",
     });
     expect(internal.web_search_options).toEqual({ search_context_size: "low" });
+  });
+
+  it("normalizes OpenAI Chat multimodal content before the execution pipeline", async () => {
+    const { deps: d, harness } = deps();
+    harness.execute.mockResolvedValue(nonStreamOutcome({ ok: true }));
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({
+        model: "auto",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "inspect" },
+              { type: "image_url", image_url: "https://example.test/cat.png" },
+              {
+                type: "file",
+                file: { file_data: "data:application/pdf;base64,JVBERi0=" },
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const internal = harness.execute.mock.calls[0]?.[1] as InternalRequest;
+    const content = internal.messages[0]?.content;
+    expect(Array.isArray(content)).toBe(true);
+    const parts = content as Array<Record<string, unknown>>;
+    expect(parts[1]).toMatchObject({
+      type: "image",
+      url: "https://example.test/cat.png",
+    });
+    expect(parts[2]).toMatchObject({
+      type: "document",
+      data: "JVBERi0=",
+      mediaType: "application/pdf",
+      filename: "document.pdf",
+    });
   });
 
   it("takes the explicit-model passthrough when the key allows custom models", async () => {

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -229,6 +229,10 @@ function toInternalRequest(
   memoryScope: MemoryScope,
 ): InternalRequest {
   const model = typeof body.model === "string" && body.model.length > 0 ? body.model : "auto";
+  // messages is already schema-validated as a non-empty array at the route boundary
+  // (OpenAIChatRequestSchema.safeParse → 400 fail-closed). P1-CHAT-01: reuse the
+  // OpenAI transformer's content normalization so the route and transformer share ONE
+  // source of truth (bare-string image_url → {url}, default filenames, …).
   let messages: InternalRequest["messages"];
   try {
     const normalized = openaiTransformer.transformRequestOut({ ...(body as object), model });

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -19,6 +19,7 @@ import {
   injectIntoIR,
   observeInbound,
   observeOutbound,
+  openaiTransformer,
   ownerScopedThreadId,
 } from "@helm/core";
 import {
@@ -98,6 +99,10 @@ export interface ChatRouteDeps {
    *  Gated by HELM_E2E in the composition root; production never sets this so
    *  classification stays config-driven (fail-closed). */
   evalHeaderOverride?: boolean;
+  /** OpenAI Chat compatibility policy for the response body's `model` field.
+   *  Default preserves the provider's real model identity; requested_alias is a
+   *  compatibility shim for clients that expect their requested model echoed. */
+  responseModelPolicy?: "provider" | "requested_alias" | "both";
   /** Memory observe-phase wiring (docs/08 Phase 1). Optional — absent = no-op
    *  (existing tests run unchanged). When present, observeInbound persists the
    *  request before routing and observeOutbound persists the assistant turn
@@ -118,6 +123,71 @@ export interface ChatRouteDeps {
     usage: { requests: number; tokens: number; costUsd: number | null },
     nowMs: number,
   ) => Promise<void>;
+}
+
+function applyResponseModelPolicy(
+  body: Record<string, unknown>,
+  requestedModel: string,
+  policy: "provider" | "requested_alias" | "both",
+): Record<string, unknown> {
+  if (policy !== "requested_alias") return body;
+  return { ...body, model: requestedModel };
+}
+
+function restampOpenAIStreamEventModel(event: string, requestedModel: string): string {
+  return event
+    .split("\n")
+    .map((line) => {
+      const match = /^data:(\s?)(.*)$/.exec(line);
+      if (match === null) return line;
+      const [, spacing = "", data = ""] = match;
+      const payload = data.trim();
+      if (payload === "" || payload === "[DONE]") return line;
+      try {
+        const parsed = JSON.parse(payload) as unknown;
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return line;
+        if (typeof (parsed as { model?: unknown }).model !== "string") return line;
+        return `data:${spacing}${JSON.stringify({ ...(parsed as Record<string, unknown>), model: requestedModel })}`;
+      } catch {
+        return line;
+      }
+    })
+    .join("\n");
+}
+
+function createOpenAIStreamModelRestamper(requestedModel: string): {
+  push(chunk: string): string;
+  flush(): string;
+} {
+  let pending = "";
+  const nextSeparator = (value: string): { index: number; separator: string } | null => {
+    const lf = value.indexOf("\n\n");
+    const crlf = value.indexOf("\r\n\r\n");
+    if (lf === -1 && crlf === -1) return null;
+    if (crlf !== -1 && (lf === -1 || crlf <= lf)) return { index: crlf, separator: "\r\n\r\n" };
+    return { index: lf, separator: "\n\n" };
+  };
+  return {
+    push(chunk: string): string {
+      let buffer = pending + chunk;
+      let out = "";
+      while (true) {
+        const sep = nextSeparator(buffer);
+        if (sep === null) break;
+        const event = buffer.slice(0, sep.index);
+        out += restampOpenAIStreamEventModel(event, requestedModel) + sep.separator;
+        buffer = buffer.slice(sep.index + sep.separator.length);
+      }
+      pending = buffer;
+      return out;
+    },
+    flush(): string {
+      if (pending === "") return "";
+      const out = restampOpenAIStreamEventModel(pending, requestedModel);
+      pending = "";
+      return out;
+    },
+  };
 }
 
 // Gateway-side inject wiring (docs/08 Phase 2). Bundles the core InjectDeps with
@@ -158,10 +228,18 @@ function toInternalRequest(
   sessionKey: string | null,
   memoryScope: MemoryScope,
 ): InternalRequest {
-  const messages = Array.isArray(body.messages)
-    ? (body.messages as InternalRequest["messages"])
-    : [{ role: "user", content: "" }];
   const model = typeof body.model === "string" && body.model.length > 0 ? body.model : "auto";
+  let messages: InternalRequest["messages"];
+  try {
+    const normalized = openaiTransformer.transformRequestOut({ ...(body as object), model });
+    if (normalized && typeof (normalized as Promise<unknown>).then === "function") {
+      throw new Error("OpenAI request normalizer unexpectedly returned a Promise");
+    }
+    messages = (normalized as { messages: InternalRequest["messages"] }).messages;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : "invalid OpenAI chat request";
+    throw invalidRequest(detail, traceId);
+  }
 
   // Session momentum keys off metadata.conversation_id (classifier engine). An
   // explicit conversation_id in the body wins; otherwise the `x-session-key`
@@ -617,6 +695,9 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       const fin = result.decision.final;
       if (fin.model_alias !== null) c.header("x-helm-final-model", fin.model_alias);
       if (fin.provider_model !== null) c.header("x-helm-provider-model", fin.provider_model);
+      if (deps.responseModelPolicy === "both") {
+        c.header("x-helm-requested-model", internal.requested_model);
+      }
     }
 
     // Classification-decision headers (e2e.eval): expose the cascade's decision
@@ -651,6 +732,10 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       // not the whole response, capping per-stream memory under high concurrency.
       const captureOn = captureEnabled(deps);
       const captured = createSseCapture(captureOn);
+      const streamModelRestamper =
+        (deps.responseModelPolicy ?? "provider") === "requested_alias"
+          ? createOpenAIStreamModelRestamper(internal.requested_model)
+          : null;
       // Concurrency slot handoff (issue #93, feature A): streamSSE returns its
       // Response BEFORE the stream body finishes, so claim the lease from the
       // middleware and release it in the stream's OWN finally — the slot stays
@@ -659,9 +744,17 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       return streamSSE(c, async (sse) => {
         try {
           for await (const chunk of stream) {
-            captured.push(chunk);
-            await sse.write(chunk);
-            if (deps.memory !== undefined) accumulateOpenAIChunk(assistant, chunk);
+            const outboundChunk = streamModelRestamper?.push(chunk) ?? chunk;
+            if (outboundChunk === "") continue;
+            captured.push(outboundChunk);
+            await sse.write(outboundChunk);
+            if (deps.memory !== undefined) accumulateOpenAIChunk(assistant, outboundChunk);
+          }
+          const tail = streamModelRestamper?.flush() ?? "";
+          if (tail !== "") {
+            captured.push(tail);
+            await sse.write(tail);
+            if (deps.memory !== undefined) accumulateOpenAIChunk(assistant, tail);
           }
         } catch (err) {
           // A client disconnect / abort is NOT a provider fault: do not 5xx, do
@@ -778,7 +871,13 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     // Usage-budget settle (non-stream, success): cost is already on the decision;
     // tokens from the body's usage. Fail-open.
     await settle(result.decision, tokensFromUsage(usageFromBody(result.body)));
-    return c.json(result.body as Record<string, unknown>);
+    return c.json(
+      applyResponseModelPolicy(
+        result.body as Record<string, unknown>,
+        internal.requested_model,
+        deps.responseModelPolicy ?? "provider",
+      ),
+    );
   };
 
   app.post("/v1/chat/completions", (c) => handleChat(c));

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1,5 +1,5 @@
 import type { CircuitBreaker, ExecutionPlan, ProviderClient, ProviderRegistry } from "@helm/core";
-import { createCircuitBreaker, UpstreamError } from "@helm/core";
+import { createCircuitBreaker, createGeminiClient, UpstreamError } from "@helm/core";
 import type { CatalogEntry, InternalRequest, TargetProviderProtocol } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import { createExecute, detectRequestModalities } from "./execute.js";
@@ -104,6 +104,37 @@ function registryWithProviders(
           baseUrl: "http://x",
           apiKeyEnv: "X",
           targetProviderProtocol: "openai_chat",
+          providerRequiresCompatibilityRewrite: false,
+        },
+      };
+    },
+    list: () => Object.keys(map),
+  };
+}
+
+function protocolRegistry(
+  map: Record<
+    string,
+    {
+      providerName: string;
+      providerModel: string;
+      targetProviderProtocol: TargetProviderProtocol;
+    }
+  >,
+): ProviderRegistry {
+  return {
+    resolve(alias: string) {
+      const hit = map[alias];
+      if (hit === undefined) return { ok: false, error: { kind: "unknown_alias", alias } };
+      return {
+        ok: true,
+        value: {
+          alias,
+          providerName: hit.providerName,
+          providerModel: hit.providerModel,
+          baseUrl: "http://x",
+          apiKeyEnv: "X",
+          targetProviderProtocol: hit.targetProviderProtocol,
           providerRequiresCompatibilityRewrite: false,
         },
       };
@@ -289,7 +320,7 @@ describe("createExecute — gateway execution adapter", () => {
       signal: new AbortController().signal,
     });
 
-    await execute(
+    const out = await execute(
       plan(["default_good_model"]),
       req({
         protocol: "anthropic_messages",
@@ -316,6 +347,15 @@ describe("createExecute — gateway execution adapter", () => {
     expect(body.container).toBeUndefined();
     expect(body.speed).toBeUndefined();
     expect(body.output_config).toBeUndefined();
+    expect(out.attempts[0]?.request_mutations).toMatchObject({
+      provider_raw_stripped_for_openai: [
+        "context_management",
+        "mcp_servers",
+        "container",
+        "speed",
+        "output_config",
+      ],
+    });
   });
 
   it("strips Anthropic cache_control markers before OpenAI-compatible upstream calls", async () => {
@@ -333,7 +373,7 @@ describe("createExecute — gateway execution adapter", () => {
       signal: new AbortController().signal,
     });
 
-    await execute(
+    const out = await execute(
       plan(["default_good_model"]),
       req({
         cache_control: { type: "ephemeral" },
@@ -373,6 +413,198 @@ describe("createExecute — gateway execution adapter", () => {
       unknown
     >;
     expect(JSON.stringify(body)).not.toContain("cache_control");
+    expect(out.attempts[0]?.request_mutations).toMatchObject({
+      cache_control_stripped_for_openai: 4,
+    });
+  });
+
+  it("renders normalized IR multimodal parts back to OpenAI-native content for OpenAI targets", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ default_good_model: "gpt-x" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    await execute(
+      plan(["default_good_model"]),
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", url: "https://example.test/cat.png", detail: "low" },
+              {
+                type: "document",
+                data: "JVBERi0=",
+                mediaType: "application/pdf",
+                filename: "document.pdf",
+              },
+            ],
+          },
+        ] as unknown as InternalRequest["messages"],
+      }),
+    );
+
+    const body = (provider.chatCompletion as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      messages?: Array<{ content?: Array<Record<string, unknown>> }>;
+    };
+    const parts = body.messages?.[0]?.content ?? [];
+    expect(parts[1]).toEqual({
+      type: "image_url",
+      image_url: { url: "https://example.test/cat.png", detail: "low" },
+    });
+    expect(parts[2]).toEqual({
+      type: "file",
+      file: {
+        file_data: "data:application/pdf;base64,JVBERi0=",
+        filename: "document.pdf",
+        format: "application/pdf",
+      },
+    });
+  });
+
+  it("records a Gemini remote-media warning when translated media is not materialized", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok", choices: [], usage: {} }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["gemini", provider]]),
+      registry: protocolRegistry({
+        g: {
+          providerName: "gemini",
+          providerModel: "gemini-2.0-flash",
+          targetProviderProtocol: "gemini",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["g"]),
+      req({
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "describe" },
+              { type: "image", url: "https://example.test/cat.png", mediaType: "image/png" },
+            ],
+          },
+        ] as InternalRequest["messages"],
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    expect(out.attempts[0]?.request_mutations).toMatchObject({
+      remote_media_not_materialized: 1,
+    });
+  });
+
+  it("blocks Responses previous_response_id tool-output continuations on non-Responses targets", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "should-not-call" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ default_good_model: "gpt-x" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["default_good_model"]),
+      req({
+        protocol: "openai_responses",
+        messages: [{ role: "tool", content: "done", tool_call_id: "call_1" }],
+        provider_raw: { previous_response_id: "resp_prev" },
+      }),
+    );
+
+    expect(provider.chatCompletion).not.toHaveBeenCalled();
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected error result");
+    expect(out.final.error.error_class).toBe("capability_unsatisfiable");
+    expect(out.attempts[0]?.skip_reason).toBe(
+      "responses_previous_response_id_cross_protocol_blocked",
+    );
+  });
+
+  it.each([
+    ["mcp", { type: "mcp", server_label: "local" }],
+    ["file_search", { type: "file_search", vector_store_ids: ["vs_1"] }],
+  ])("blocks Responses native %s tools on non-Responses targets", async (_label, nativeTool) => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "should-not-call" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ default_good_model: "gpt-x" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["default_good_model"]),
+      req({
+        protocol: "openai_responses",
+        provider_raw: { responses_native_tools: [nativeTool] },
+      }),
+    );
+
+    expect(provider.chatCompletion).not.toHaveBeenCalled();
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected error result");
+    expect(out.final.error.error_class).toBe("capability_unsatisfiable");
+    expect(out.attempts[0]?.skip_reason).toBe("responses_native_tools_cross_protocol_blocked");
+  });
+
+  it("blocks Responses background mode on non-Responses targets", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "should-not-call" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ default_good_model: "gpt-x" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["default_good_model"]),
+      req({ protocol: "openai_responses", provider_raw: { background: true } }),
+    );
+
+    expect(provider.chatCompletion).not.toHaveBeenCalled();
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected error result");
+    expect(out.final.error.error_class).toBe("capability_unsatisfiable");
+    expect(out.attempts[0]?.skip_reason).toBe("responses_background_cross_protocol_blocked");
   });
 
   it("does not forward top-level cache_control to non-Anthropic target protocols", async () => {
@@ -670,6 +902,28 @@ describe("createExecute — gateway execution adapter", () => {
     const seen: string[] = [];
     for await (const ch of out.stream as AsyncIterable<string>) seen.push(ch);
     expect(seen).toEqual(chunks);
+  });
+
+  it("records stream_reframed when an OpenAI-compatible provider applies a stream shim", async () => {
+    const provider = {
+      streamReframed: true,
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn().mockReturnValue(gen(["data: {}\n\n"])),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ a: "m-a" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["a"]), req({ stream: true }));
+
+    expect(out.final.status).toBe("ok");
+    expect(out.attempts[0]?.request_mutations).toMatchObject({ stream_reframed: true });
   });
 
   it("logs a structured truncated-stream event when the relay throws AFTER the first chunk", async () => {
@@ -1581,6 +1835,62 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(okRow?.provider_model).toBe("claude-x");
   });
 
+  it("Gemini target + native_request sends GenerateContent body to the Gemini client, not OpenAI Chat", async () => {
+    const upstreamBodies: unknown[] = [];
+    let upstreamUrl = "";
+    const provider = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn(async (url, init) => {
+        upstreamUrl = String(url);
+        upstreamBodies.push(JSON.parse(String(init?.body)));
+        return new Response(
+          JSON.stringify({
+            candidates: [{ content: { role: "model", parts: [{ text: "native" }] } }],
+            usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    });
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["google", provider]]),
+      registry: protocolRegistry({
+        g: {
+          providerName: "google",
+          providerModel: "gemini-2.0-flash",
+          targetProviderProtocol: "gemini",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const nativeBody = {
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      generationConfig: { temperature: 0 },
+    };
+
+    const out = await execute(
+      plan(["g"]),
+      req({
+        protocol: "gemini",
+        requested_model: "gemini-2.0-flash",
+        messages: [{ role: "user", content: "hi" }],
+        native_request: nativeBody,
+      }),
+    );
+
+    expect(out.nativePassthrough).toBe(true);
+    expect(upstreamUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+    );
+    expect(upstreamBodies).toEqual([nativeBody]);
+    expect(JSON.stringify(upstreamBodies[0])).not.toContain('"messages"');
+  });
+
   it("strips empty Anthropic text blocks before native passthrough dispatch", async () => {
     const provider = anthropicProvider(NATIVE_RESP);
     const execute = createExecute({
@@ -2132,6 +2442,120 @@ describe("createExecute — native protocol passthrough (#217)", () => {
       body_shims_applied: ["store_forced_false"],
     });
     expect(out.attempts[0]?.passthrough_mutations).toMatchObject(forwarded.mutations);
+  });
+
+  it("does not apply Codex store:false shim to generic OpenAI Responses providers", async () => {
+    const responsesBody = {
+      id: "resp_generic",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const provider = {
+      nativeProtocolProfile: "generic_openai_responses",
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["openai", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "openai",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body: { model: "gpt-5.5", input: "hi", store: true, background: true },
+      headers: {},
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["r"]),
+      req({
+        protocol: "openai_responses",
+        native_request: carrier,
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body).toEqual({
+      model: "gpt-5.5",
+      input: "hi",
+      store: true,
+      background: true,
+    });
+    expect((forwarded.mutations as Record<string, unknown>).body_shims_applied).toBeUndefined();
+  });
+
+  it("records native passthrough telemetry for Responses previous_response_id continuations", async () => {
+    const responsesBody = {
+      id: "resp_next",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const provider = {
+      nativeProtocolProfile: "generic_openai_responses",
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["openai", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "openai",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body: {
+        model: "gpt-5.5",
+        previous_response_id: "resp_prev",
+        input: [{ type: "function_call_output", call_id: "call_1", output: "done" }],
+      },
+      headers: {},
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["r"]),
+      req({
+        protocol: "openai_responses",
+        messages: [{ role: "tool", content: "done", tool_call_id: "call_1" }],
+        provider_raw: { previous_response_id: "resp_prev" },
+        native_request: carrier,
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    expect(provider.nativePassthrough).toHaveBeenCalledOnce();
+    expect(out.attempts[0]?.passthrough_mutations).toMatchObject({
+      responses_previous_response_id_native_passthrough: true,
+    });
   });
 
   it("flag ON but provider has NO nativePassthrough → translates, reason provider_lacks_passthrough", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -30,7 +30,11 @@ import {
   nativePassthroughBody,
   nativePassthroughMutations,
 } from "@helm/shared";
-import { usageFromAnthropicResponse, usageFromResponsesResponse } from "./payload-capture.js";
+import {
+  usageFromAnthropicResponse,
+  usageFromGeminiResponse,
+  usageFromResponsesResponse,
+} from "./payload-capture.js";
 
 // Gateway execution adapter — the `execute` injected into routeRequest. It walks
 // the resolved candidate chain (ExecutionPlan.candidate_chain) honoring the
@@ -875,7 +879,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           const usage =
             req.protocol === "openai_responses"
               ? usageFromResponsesResponse(body)
-              : usageFromAnthropicResponse(body);
+              : req.protocol === "gemini"
+                ? usageFromGeminiResponse(body)
+                : usageFromAnthropicResponse(body);
           const pricedBody = usage ? { ...body, usage } : body;
           attempts.push(okRow(alias, elapsed(), costOf(alias, pricedBody), passthrough));
           return {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -10,6 +10,7 @@ import {
   canUseNativePassthrough,
   checkCapability,
   type NativePassthroughDisableReason,
+  openaiTransformer,
   resolveCostUsd,
   UpstreamError,
 } from "@helm/core";
@@ -128,6 +129,7 @@ interface PassthroughTelemetry {
   provider_name: string | null;
   provider_model: string | null;
   passthrough_mutations?: NativePassthroughCarrier["mutations"];
+  request_mutations?: NativePassthroughCarrier["mutations"];
 }
 
 function approxPromptTokens(req: InternalRequest): number {
@@ -347,15 +349,69 @@ function decideNativePassthroughForAttempt(input: {
   };
 }
 
-function stripCacheControlDeep(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map((item) => stripCacheControlDeep(item));
-  if (value === null || typeof value !== "object") return value;
-  const out: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
-    if (key === "cache_control") continue;
-    out[key] = stripCacheControlDeep(child);
+function stripCacheControlDeep(value: unknown): { value: unknown; stripped: number } {
+  if (Array.isArray(value)) {
+    let stripped = 0;
+    const next = value.map((item) => {
+      const child = stripCacheControlDeep(item);
+      stripped += child.stripped;
+      return child.value;
+    });
+    return { value: next, stripped };
   }
-  return out;
+  if (value === null || typeof value !== "object") return { value, stripped: 0 };
+  const out: Record<string, unknown> = {};
+  let stripped = 0;
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "cache_control") {
+      stripped += 1;
+      continue;
+    }
+    const next = stripCacheControlDeep(child);
+    stripped += next.stripped;
+    out[key] = next.value;
+  }
+  return { value: out, stripped };
+}
+
+function remoteUrlFromPart(part: Record<string, unknown>): string | null {
+  if (typeof part.url === "string") return part.url;
+  if (typeof part.file_id === "string") return part.file_id;
+  const imageUrl = part.image_url;
+  if (typeof imageUrl === "string") return imageUrl;
+  if (imageUrl !== null && typeof imageUrl === "object" && !Array.isArray(imageUrl)) {
+    const url = (imageUrl as Record<string, unknown>).url;
+    if (typeof url === "string") return url;
+  }
+  const file = part.file;
+  if (file !== null && typeof file === "object" && !Array.isArray(file)) {
+    const fileId = (file as Record<string, unknown>).file_id;
+    if (typeof fileId === "string") return fileId;
+  }
+  return null;
+}
+
+function isRemoteMediaPart(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const part = value as Record<string, unknown>;
+  const type = typeof part.type === "string" ? part.type : "";
+  if (!["image", "image_url", "audio", "video", "document", "file"].includes(type)) {
+    return false;
+  }
+  const url = remoteUrlFromPart(part);
+  return typeof url === "string" && /^https?:\/\//i.test(url);
+}
+
+function countRemoteMediaParts(messages: InternalRequest["messages"]): number {
+  let count = 0;
+  for (const message of messages) {
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const part of content) {
+      if (isRemoteMediaPart(part)) count += 1;
+    }
+  }
+  return count;
 }
 
 function isEmptyAnthropicTextBlock(value: unknown): boolean {
@@ -411,6 +467,7 @@ function prepareNativeRequestForUpstream(
   providerModel: string,
   protocol: Protocol,
   streamReframed: boolean,
+  nativeProtocolProfile: ProviderClient["nativeProtocolProfile"] | undefined,
 ): NativePassthroughCarrier | Record<string, unknown> {
   if (nativeRequest === undefined) {
     throw new Error("native passthrough invoked without a native request");
@@ -432,7 +489,9 @@ function prepareNativeRequestForUpstream(
     }
   }
 
-  if (protocol === "openai_responses" && body.store !== false) {
+  const needsCodexResponsesShim =
+    protocol === "openai_responses" && nativeProtocolProfile !== "generic_openai_responses";
+  if (needsCodexResponsesShim && body.store !== false) {
     body = { ...body, store: false };
     bodyChanged = true;
     if (mutations) {
@@ -461,6 +520,33 @@ function prepareNativeRequestForUpstream(
   return bodyChanged
     ? cloneCarrierWithBody(carrier, body)
     : cloneCarrierWithBody(carrier, body, { preserveRawBody: true });
+}
+
+function hasResponsesHistoryGap(req: InternalRequest): boolean {
+  if (req.protocol !== "openai_responses") return false;
+  if (typeof req.provider_raw?.previous_response_id !== "string") return false;
+  let hasToolOutput = false;
+  let hasLocalToolCall = false;
+  for (const message of req.messages) {
+    if (message.role === "tool") hasToolOutput = true;
+    if (Array.isArray((message as { tool_calls?: unknown }).tool_calls)) hasLocalToolCall = true;
+  }
+  return hasToolOutput && !hasLocalToolCall;
+}
+
+function protocolGuardSkipReason(
+  req: InternalRequest,
+  targetProviderProtocol: TargetProviderProtocol,
+): string | null {
+  if (req.protocol !== "openai_responses" || targetProviderProtocol === "openai_responses") {
+    return null;
+  }
+  if (hasResponsesHistoryGap(req)) return "responses_previous_response_id_cross_protocol_blocked";
+  if (Array.isArray(req.provider_raw?.responses_native_tools)) {
+    return "responses_native_tools_cross_protocol_blocked";
+  }
+  if (req.provider_raw?.background === true) return "responses_background_cross_protocol_blocked";
+  return null;
 }
 
 function upstreamStatusOf(err: unknown): number | null {
@@ -648,6 +734,13 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           continue;
         }
       }
+
+      const protocolSkip = protocolGuardSkipReason(req, target.targetProviderProtocol);
+      if (protocolSkip !== null) {
+        capabilityPruned = true;
+        attempts.push(skipRow(alias, protocolSkip, elapsed()));
+        continue;
+      }
       // Past the gates → this candidate is attempted against the upstream. A
       // failure from here on is a PROVIDER fault, not a capability gap.
       attemptedAny = true;
@@ -662,6 +755,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         target,
         enabled: nativeProtocolPassthroughEnabled?.() === true,
       });
+      let attemptTelemetry: PassthroughTelemetry = passthrough;
 
       // 3) Invoke the provider (stream or non-stream). We send the RESOLVED
       //    provider model (not the originally-requested alias) — the gateway
@@ -694,7 +788,12 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             providerModel,
             req.protocol,
             true,
+            provider.nativeProtocolProfile,
           );
+          if (hasResponsesHistoryGap(req)) {
+            const mutations = nativePassthroughMutations(passthroughBody);
+            if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
+          }
           passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
           const stream = await peekStream(
             () => passthroughStream(passthroughBody, { signal }),
@@ -717,19 +816,23 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // Translate stream path (passthrough disabled): the existing byte-for-byte
           // forward. peekStream opens chatCompletionStream(stripInternal); the row
           // carries the (used:false) passthrough telemetry. No nativePassthrough marker.
+          const rendered = stripInternal(req, providerModel, target.targetProviderProtocol);
+          attemptTelemetry = withRequestMutations(
+            passthrough,
+            mergeRequestMutations(
+              rendered.request_mutations,
+              provider.streamReframed === true ? { stream_reframed: true } : undefined,
+            ),
+          );
           const stream = await peekStream(
-            () =>
-              provider.chatCompletionStream(
-                stripInternal(req, providerModel, target.targetProviderProtocol),
-                { signal },
-              ),
+            () => provider.chatCompletionStream(rendered.body, { signal }),
             signal,
             alias,
             log,
           );
           breaker.recordSuccess(alias);
           // Streamed usage is not known at peek time → cost null (not measured).
-          attempts.push(okRow(alias, elapsed(), null, passthrough));
+          attempts.push(okRow(alias, elapsed(), null, attemptTelemetry));
           return {
             attempts,
             final: { status: "ok", alias, providerModel },
@@ -760,7 +863,12 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             providerModel,
             req.protocol,
             false,
+            provider.nativeProtocolProfile,
           );
+          if (hasResponsesHistoryGap(req)) {
+            const mutations = nativePassthroughMutations(passthroughBody);
+            if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
+          }
           passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
           const body = await passthroughInvoke(passthroughBody, { signal });
           breaker.recordSuccess(alias);
@@ -779,9 +887,10 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           };
         }
         const bodyReq = stripInternal(req, providerModel, target.targetProviderProtocol);
-        const body = await provider.chatCompletion(bodyReq, { signal });
+        attemptTelemetry = withRequestMutations(passthrough, bodyReq.request_mutations);
+        const body = await provider.chatCompletion(bodyReq.body, { signal });
         breaker.recordSuccess(alias);
-        attempts.push(okRow(alias, elapsed(), costOf(alias, body), passthrough));
+        attempts.push(okRow(alias, elapsed(), costOf(alias, body), attemptTelemetry));
         return {
           attempts,
           final: { status: "ok", alias, providerModel },
@@ -884,7 +993,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           latency_ms: elapsed(),
           cost_usd: null,
           error_detail: errorDetailOf(err),
-          ...passthrough,
+          ...attemptTelemetry,
         });
       }
     }
@@ -1013,30 +1122,97 @@ const PROVIDER_RAW_FORWARD_KEYS_BY_PROTOCOL = {
 function renderProviderRawForTarget(
   providerRaw: Record<string, unknown> | undefined,
   targetProviderProtocol: TargetProviderProtocol,
-): Record<string, unknown> {
-  if (providerRaw === undefined) return {};
+): { body: Record<string, unknown>; strippedKeys: string[] } {
+  if (providerRaw === undefined) return { body: {}, strippedKeys: [] };
   const out: Record<string, unknown> = {};
+  const allowed = new Set<string>(PROVIDER_RAW_FORWARD_KEYS_BY_PROTOCOL[targetProviderProtocol]);
   for (const key of PROVIDER_RAW_FORWARD_KEYS_BY_PROTOCOL[targetProviderProtocol]) {
     const value = providerRaw[key];
     if (value !== undefined && value !== null) out[key] = value;
   }
-  return out;
+  const strippedKeys = Object.keys(providerRaw).filter((key) => {
+    const value = providerRaw[key];
+    return value !== undefined && value !== null && !allowed.has(key);
+  });
+  return { body: out, strippedKeys };
+}
+
+function renderOpenAINativeBody(body: Record<string, unknown>): Record<string, unknown> {
+  const normalized = openaiTransformer.transformRequestOut({
+    model: typeof body.model === "string" ? body.model : "model",
+    messages: Array.isArray(body.messages) ? body.messages : [],
+    ...body,
+  });
+  if (normalized && typeof (normalized as Promise<unknown>).then === "function") {
+    throw new Error("OpenAI request normalizer unexpectedly returned a Promise");
+  }
+  const rendered = openaiTransformer.transformRequestIn(normalized as never);
+  if (rendered && typeof (rendered as Promise<unknown>).then === "function") {
+    throw new Error("OpenAI request renderer unexpectedly returned a Promise");
+  }
+  const renderedMessages = (rendered as { messages?: unknown }).messages;
+  return Array.isArray(renderedMessages) ? { ...body, messages: renderedMessages } : body;
+}
+
+function withRequestMutations(
+  passthrough: PassthroughTelemetry,
+  requestMutations: NativePassthroughCarrier["mutations"] | undefined,
+): PassthroughTelemetry {
+  if (requestMutations === undefined || Object.keys(requestMutations).length === 0) {
+    return passthrough;
+  }
+  return { ...passthrough, request_mutations: requestMutations };
+}
+
+function mergeRequestMutations(
+  ...mutations: Array<NativePassthroughCarrier["mutations"] | undefined>
+): NativePassthroughCarrier["mutations"] | undefined {
+  const out: NativePassthroughCarrier["mutations"] = {};
+  for (const mutation of mutations) {
+    if (mutation === undefined) continue;
+    Object.assign(out, mutation);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function stripInternal(
   req: InternalRequest,
   providerModel: string,
   targetProviderProtocol: TargetProviderProtocol,
-): Record<string, unknown> {
+): { body: Record<string, unknown>; request_mutations?: NativePassthroughCarrier["mutations"] } {
+  const requestMutations: NativePassthroughCarrier["mutations"] = {};
+  const openAICompatibleWire =
+    targetProviderProtocol === "openai_chat" || targetProviderProtocol === "openai_responses";
+  const messages = openAICompatibleWire
+    ? stripCacheControlDeep(req.messages)
+    : { value: req.messages, stripped: 0 };
   const body: Record<string, unknown> = {
     model: providerModel,
-    messages:
-      targetProviderProtocol === "openai_chat" ? stripCacheControlDeep(req.messages) : req.messages,
+    messages: messages.value,
     stream: req.stream,
   };
-  if (req.tools)
-    body.tools =
-      targetProviderProtocol === "openai_chat" ? stripCacheControlDeep(req.tools) : req.tools;
+  if (targetProviderProtocol === "gemini") {
+    const remoteMediaCount = countRemoteMediaParts(req.messages);
+    if (remoteMediaCount > 0) {
+      requestMutations.remote_media_not_materialized = remoteMediaCount;
+      appendMutationList(requestMutations, "body_shims_applied", ["remote_media_not_materialized"]);
+    }
+  }
+  if (messages.stripped > 0) {
+    requestMutations.cache_control_stripped_for_openai = messages.stripped;
+  }
+  if (req.tools) {
+    const tools = openAICompatibleWire
+      ? stripCacheControlDeep(req.tools)
+      : { value: req.tools, stripped: 0 };
+    body.tools = tools.value;
+    if (tools.stripped > 0) {
+      requestMutations.cache_control_stripped_for_openai =
+        (typeof requestMutations.cache_control_stripped_for_openai === "number"
+          ? requestMutations.cache_control_stripped_for_openai
+          : 0) + tools.stripped;
+    }
+  }
   if (req.response_format) body.response_format = req.response_format;
   if (req.max_tokens !== null) body.max_tokens = req.max_tokens;
   for (const key of FORWARDED_REQUEST_PARAM_KEYS) {
@@ -1046,9 +1222,13 @@ function stripInternal(
   if (targetProviderProtocol === "anthropic_messages" && req.cache_control !== undefined) {
     body.cache_control = req.cache_control;
   }
-  for (const [key, value] of Object.entries(
-    renderProviderRawForTarget(req.provider_raw, targetProviderProtocol),
-  )) {
+  const renderedRaw = renderProviderRawForTarget(req.provider_raw, targetProviderProtocol);
+  if (targetProviderProtocol === "openai_chat" && renderedRaw.strippedKeys.length > 0) {
+    requestMutations.provider_raw_stripped_for_openai = renderedRaw.strippedKeys;
+  } else if (renderedRaw.strippedKeys.length > 0) {
+    requestMutations.provider_raw_stripped_for_target = renderedRaw.strippedKeys;
+  }
+  for (const [key, value] of Object.entries(renderedRaw.body)) {
     body[key] = value;
   }
   // Streamed usage (cost #6): OpenAI-compatible upstreams only emit a trailing
@@ -1060,7 +1240,14 @@ function stripInternal(
       req.stream_options && typeof req.stream_options === "object" ? req.stream_options : {};
     body.stream_options = { ...streamOptions, include_usage: true };
   }
-  return body;
+  const renderedBody =
+    targetProviderProtocol === "openai_chat" || targetProviderProtocol === "openai_responses"
+      ? renderOpenAINativeBody(body)
+      : body;
+  return {
+    body: renderedBody,
+    ...(Object.keys(requestMutations).length > 0 ? { request_mutations: requestMutations } : {}),
+  };
 }
 
 function isJson(rf: InternalRequest["response_format"]): boolean {

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -40,10 +40,12 @@ function makeDeps(
     streamEvents?: () => AsyncIterable<Record<string, unknown>>;
     authed?: boolean;
     abort?: boolean;
+    nativePassthrough?: boolean;
     transformRequestOut?: (native: unknown) => unknown;
     identity?: MessagesIdentity;
     rateLimiter?: GeminiRouteDeps["rateLimiter"];
     concurrencyGate?: GeminiRouteDeps["concurrencyGate"];
+    countTokens?: GeminiRouteDeps["countTokens"];
     record?: RecordServedDeps;
   } = {},
 ): { deps: GeminiRouteDeps; harness: Harness } {
@@ -52,6 +54,7 @@ function makeDeps(
   const deps: GeminiRouteDeps = {
     rateLimiter: over.rateLimiter,
     concurrencyGate: over.concurrencyGate,
+    countTokens: over.countTokens,
     record: over.record,
     auth: {
       resolve: async (cred) => {
@@ -110,6 +113,7 @@ function makeDeps(
             async function* () {
               yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
             },
+          ...(over.nativePassthrough === true ? { nativePassthrough: true } : {}),
         };
       },
     },
@@ -141,6 +145,19 @@ function makeRecord(over: { capturePayloads?: boolean } = {}): {
     capturePayloads: () => over.capturePayloads ?? true,
   };
   return { record, insert, insertPayload, redact };
+}
+
+function expectGeminiCarrier(value: unknown, body: unknown, rawBody?: string): void {
+  expect(value).toMatchObject({
+    protocol: "gemini",
+    body,
+    headers: expect.objectContaining({
+      "content-type": expect.stringContaining("application/json"),
+    }),
+  });
+  if (rawBody !== undefined) {
+    expect((value as { raw_body?: string }).raw_body).toBe(rawBody);
+  }
 }
 
 describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
@@ -224,7 +241,7 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     expect(harness.order).not.toContain("route");
   });
 
-  it("returns 404 for a non-generateContent path (parseGeminiPath null)", async () => {
+  it("serves countTokens after auth without translating or routing", async () => {
     const { deps, harness } = makeDeps();
     const app = buildApp(deps);
     const res = await app.request("/v1beta/models/gemini-2.0-flash:countTokens", {
@@ -232,8 +249,114 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       headers: GEMINI_AUTH,
       body: JSON.stringify(REQ_BODY),
     });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ totalTokens: 14, estimated: true });
+    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+    expect(harness.pipelineSawIR).toBeNull();
+  });
+
+  it("uses provider-backed countTokens when available", async () => {
+    const countTokens = vi.fn().mockResolvedValue({ totalTokens: 99 });
+    const { deps, harness } = makeDeps({ countTokens });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:countTokens", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ totalTokens: 99 });
+    expect(countTokens).toHaveBeenCalledWith(
+      { ...REQ_BODY, model: "gemini-2.0-flash" },
+      IDENTITY,
+      expect.any(AbortSignal),
+    );
+    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+    expect(harness.pipelineSawIR).toBeNull();
+  });
+
+  it("falls back to an estimated countTokens result if provider counting fails", async () => {
+    const countTokens = vi.fn().mockRejectedValue(new Error("provider unavailable"));
+    const { deps, harness } = makeDeps({ countTokens });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:countTokens", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ totalTokens: 14, estimated: true });
+    expect(countTokens).toHaveBeenCalledOnce();
+    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+  });
+
+  it("serves countTokens on the publisher model path alias", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/models/publishers/google/models/gemini-2.0-flash:countTokens", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ totalTokens: 14, estimated: true });
     expect(harness.order).not.toContain("route");
+  });
+
+  it("rejects malformed countTokens JSON as INVALID_ARGUMENT before routing", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:countTokens", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: '{"contents":',
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { status: string } };
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+    expect(harness.pipelineSawIR).toBeNull();
+  });
+
+  it("stamps the verbatim Gemini request body as a native passthrough carrier", async () => {
+    const { deps, harness } = makeDeps();
+    const app = buildApp(deps);
+    const rawRequest = JSON.stringify(REQ_BODY);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: rawRequest,
+    });
+
+    expect(res.status).toBe(200);
+    const meta = (harness.pipelineSawIR?.metadata ?? {}) as { native_request?: unknown };
+    expectGeminiCarrier(meta.native_request, REQ_BODY, rawRequest);
+  });
+
+  it("non-stream native passthrough returns the native Gemini body without translate-back", async () => {
+    const nativeBody = {
+      candidates: [{ content: { role: "model", parts: [{ text: "passthrough" }] } }],
+    };
+    const { deps, harness } = makeDeps({
+      nativePassthrough: true,
+      collect: async () => nativeBody,
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(nativeBody);
+    expect(harness.order).toEqual(["auth:helm_live_secret", "translate-out", "route"]);
   });
 
   it("rate-limits after auth with a 429 Gemini envelope and limit headers, without translating or routing", async () => {
@@ -478,6 +601,40 @@ describe("POST /v1beta/models/{model}:streamGenerateContent?alt=sse (Gemini stre
     expect(text).not.toContain("[DONE]");
     // Each frame is a full snapshot; the final carries finishReason.
     expect(text).toContain("STOP");
+  });
+
+  it("stream passthrough writes verbatim Gemini nameless SSE frames without wrapping them", async () => {
+    const rawFrames = [
+      'data: {"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP"}]}\n\n',
+    ];
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield {
+        event: "",
+        data: '{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}',
+        raw: rawFrames[0],
+      };
+      yield {
+        event: "",
+        data: '{"candidates":[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP"}]}',
+        raw: rawFrames[1],
+      };
+    }
+    const { deps } = makeDeps({ nativePassthrough: true, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toBe(rawFrames.join(""));
+    expect(text).not.toContain("event:");
+    expect(text).not.toContain("[DONE]");
+    expect(text).not.toContain('"raw"');
   });
 
   it("treats streamGenerateContent without alt=sse as streaming", async () => {

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -12,6 +12,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult, RouteError } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
+import { nativeCarrierFromParsedBody } from "./native-carrier.js";
 import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
 
@@ -61,6 +62,11 @@ export interface GeminiRouteDeps {
   /** Per-key concurrency overflow queue (issue #93) — the SAME process-wide gate
    *  as the chat middleware. Optional — omitted = no gating. */
   concurrencyGate?: ConcurrencyGatePort;
+  countTokens?(
+    body: Record<string, unknown>,
+    identity: MessagesIdentity,
+    signal: AbortSignal,
+  ): Promise<unknown>;
   /** Telemetry + payload recorder (the /admin/requests fix). Optional so existing
    *  tests that omit it record nothing; when wired, every served request (success
    *  OR failure, stream OR non-stream) writes a telemetry row. */
@@ -84,6 +90,24 @@ export interface GeminiRouteDeps {
       signal: AbortSignal,
     ): Promise<PipelineRunResult>;
   };
+}
+
+function hasCountTokensContent(native: unknown): boolean {
+  if (typeof native !== "object" || native === null || Array.isArray(native)) return false;
+  const body = native as {
+    contents?: unknown;
+    generateContentRequest?: { contents?: unknown };
+  };
+  return (
+    Array.isArray(body.contents) ||
+    (typeof body.generateContentRequest === "object" &&
+      body.generateContentRequest !== null &&
+      Array.isArray(body.generateContentRequest.contents))
+  );
+}
+
+function estimateGeminiCountTokens(requestJson: string): number {
+  return Math.max(1, Math.ceil(requestJson.length / 4));
 }
 
 // Extract the plaintext credential from x-goog-api-key (Gemini SDK default) or the
@@ -211,7 +235,47 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       c.set("concurrencyRelease", acquired.release);
     }
 
-    // 2) Parse + translate inbound. A malformed JSON body OR a structurally invalid
+    // 2) countTokens is a local deterministic estimate. It shares auth / rate /
+    //    concurrency with generation, but it must never enter the generation
+    //    transformer or provider pipeline.
+    if (route.operation === "countTokens") {
+      let requestJson = "";
+      let native: unknown;
+      try {
+        requestJson = await c.req.text();
+        native = JSON.parse(requestJson);
+      } catch {
+        return sendError(c, {
+          error_class: "invalid_request",
+          message: "malformed JSON request body",
+          trace_id: traceId,
+        });
+      }
+      if (!hasCountTokensContent(native)) {
+        return sendError(c, {
+          error_class: "invalid_request",
+          message: "invalid Gemini countTokens request body",
+          trace_id: traceId,
+        });
+      }
+      if (deps.countTokens !== undefined) {
+        try {
+          const counted = await deps.countTokens(
+            { ...(native as Record<string, unknown>), model: route.model },
+            identity,
+            c.req.raw.signal,
+          );
+          return c.json(counted as Record<string, unknown>);
+        } catch {
+          // Token helpers are SDK compatibility helpers. A provider counter
+          // outage must not turn the route into a 5xx when deterministic local
+          // estimation is available.
+        }
+      }
+      return c.json({ totalTokens: estimateGeminiCountTokens(requestJson), estimated: true });
+    }
+
+    // 3) Parse + translate inbound. A malformed JSON body OR a structurally invalid
     //    Gemini request (the transformer's Zod parse throws) is a CLIENT error →
     //    400 INVALID_ARGUMENT, before routing (docs/07, principle 2 fail-closed).
     let requestJson = "";
@@ -256,6 +320,16 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     ir.metadata.memory_mode = memoryScope.mode;
     ir.metadata.memory_thread_source = memoryScope.threadSource;
 
+    const nativeCarrier = nativeCarrierFromParsedBody({
+      protocol: "gemini",
+      native,
+      rawBody: requestJson,
+      headers: c.req.raw.headers,
+    });
+    if (nativeCarrier !== null) {
+      ir.metadata.native_request = nativeCarrier;
+    }
+
     // 3) Route through the shared core. The per-request abort signal rides along so
     //    a client disconnect is a non-provider fault (docs/02). run() throws a
     //    PipelineError(invalid_request) for an empty request.
@@ -293,9 +367,21 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
         const captured: string[] = [];
         try {
           for await (const snapshot of result.streamIR()) {
-            const data = JSON.stringify(snapshot);
-            if (captureBodies) captured.push(`data: ${data}\n\n`);
-            await sse.writeSSE({ data });
+            if (result.nativePassthrough === true) {
+              const frame = snapshot as { data?: unknown; raw?: unknown };
+              if (typeof frame.raw === "string") {
+                if (captureBodies) captured.push(frame.raw);
+                await sse.write(frame.raw);
+              } else {
+                const data = typeof frame.data === "string" ? frame.data : JSON.stringify(snapshot);
+                if (captureBodies) captured.push(`data: ${data}\n\n`);
+                await sse.writeSSE({ data });
+              }
+            } else {
+              const data = JSON.stringify(snapshot);
+              if (captureBodies) captured.push(`data: ${data}\n\n`);
+              await sse.writeSSE({ data });
+            }
           }
         } catch (err) {
           // A client disconnect / abort is a benign non-provider fault (docs/02):
@@ -343,7 +429,9 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     // providers failed) — surface it as the Gemini envelope, never an empty 200.
     let body: unknown;
     try {
-      body = transformer.transformResponseOut(await result.collect());
+      const collected = await result.collect();
+      body =
+        result.nativePassthrough === true ? collected : transformer.transformResponseOut(collected);
     } catch (err) {
       // Record the FAILED served request before surfacing the error (mirrors
       // chat.ts) so an all-providers-failed request still appears in

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -846,6 +846,215 @@ describe("createMessagesPipeline — openai_responses native passthrough collect
   });
 });
 
+// A VERBATIM Gemini GenerateContent NON-stream body — what provider.nativePassthrough
+// returns and the pipeline must hand back UNTOUCHED on the passthrough path. Carries
+// the native `candidates[].content.parts[]` (NOT OpenAI choices) + a Gemini
+// usageMetadata block (cache counted INSIDE promptTokenCount, like Responses).
+const NATIVE_GEMINI_BODY = {
+  candidates: [
+    {
+      content: { role: "model", parts: [{ text: "Hello from Gemini" }, { text: " passthrough" }] },
+      finishReason: "STOP",
+    },
+  ],
+  usageMetadata: {
+    promptTokenCount: 12,
+    candidatesTokenCount: 9,
+    cachedContentTokenCount: 4,
+    totalTokenCount: 21,
+  },
+};
+
+function passthroughGeminiOkResult(body: unknown = NATIVE_GEMINI_BODY): ExecutionResult {
+  return {
+    decision: {
+      lane: { selected_lane: "balanced" },
+      final: { status: "ok", model_alias: "gemini/gemini-2.0-flash" },
+      cost_breakdown: { total_usd: 0.02, completion_usd: 0.01, eval_usd: null },
+      provider_attempts: [],
+    } as unknown as ExecutionResult["decision"],
+    final: { status: "ok", alias: "gemini/gemini-2.0-flash" },
+    body,
+    stream: null,
+    error: null,
+    nativePassthrough: true,
+  };
+}
+
+// A canned Gemini streamGenerateContent SSE byte stream. Nameless `data:` frames carry
+// CUMULATIVE usageMetadata (final frame holds the complete count) with DELIBERATELY
+// non-canonical spacing so a test can prove byte-verbatim forwarding (no JSON
+// round-trip). Output text rides candidates[].content.parts[].text.
+const NATIVE_GEMINI_SSE_FRAMES = [
+  'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]}}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":2}}\n\n',
+  'data: {"candidates":[{"content":{"parts":[{"text":" Gemini"}]},"finishReason":"STOP"}],"usageMetadata":{ "promptTokenCount":12 ,"candidatesTokenCount":9,"cachedContentTokenCount":4}}\n\n',
+];
+
+function nativeGeminiSseTextStream(): AsyncIterable<string> {
+  const joined = NATIVE_GEMINI_SSE_FRAMES.join("");
+  const pieces: string[] = [];
+  for (let i = 0; i < joined.length; i += 19) pieces.push(joined.slice(i, i + 19));
+  return (async function* () {
+    for (const p of pieces) yield p;
+  })();
+}
+
+function passthroughGeminiStreamResult(
+  stream: AsyncIterable<string> = nativeGeminiSseTextStream(),
+): ExecutionResult {
+  return {
+    decision: {
+      lane: { selected_lane: "balanced" },
+      final: { status: "ok", model_alias: "gemini/gemini-2.0-flash" },
+      cost_breakdown: { total_usd: 0, completion_usd: null, eval_usd: null },
+      provider_attempts: [],
+    } as unknown as ExecutionResult["decision"],
+    final: { status: "ok", alias: "gemini/gemini-2.0-flash" },
+    body: null,
+    stream,
+    error: null,
+    nativePassthrough: true,
+  };
+}
+
+describe("createMessagesPipeline — gemini native passthrough collect()", () => {
+  it("returns the native Gemini body UNTOUCHED (no openAIBodyToIR projection)", async () => {
+    const pipeline = createMessagesPipeline(
+      () => Promise.resolve(passthroughGeminiOkResult()),
+      "gemini",
+    );
+    const run = await pipeline.run(irOf(), IDENTITY, new AbortController().signal);
+    const body = (await run.collect()) as Record<string, unknown>;
+    expect(body).toBe(NATIVE_GEMINI_BODY);
+    expect(body.candidates).toEqual(NATIVE_GEMINI_BODY.candidates);
+    expect(body.choices).toBeUndefined();
+  });
+
+  it("settles the budget + stamps tokens from the Gemini usageMetadata (cache inside prompt)", async () => {
+    let settledTokens: number | null = null;
+    const budget: PipelineBudgetDeps = {
+      gate: { check: async () => ({ overBudget: false }) as never },
+      settle: async (_keyId, _caps, usage) => {
+        settledTokens = usage.tokens;
+      },
+      now: () => 0,
+    };
+    const identity: MessagesIdentity = {
+      keyId: "k1",
+      accountId: "acct",
+      caps: { budget: { spend_usd: { day: 1 } } as never },
+    };
+    const decisionRef = passthroughGeminiOkResult().decision;
+    const pipeline = createMessagesPipeline(
+      () => Promise.resolve({ ...passthroughGeminiOkResult(), decision: decisionRef }),
+      "gemini",
+      undefined,
+      budget,
+    );
+    const run = await pipeline.run(irOf(), identity, new AbortController().signal);
+    await run.collect();
+    // Gemini: prompt = promptTokenCount(12), completion = candidates(9) → 21 served
+    // tokens (cache already counted inside promptTokenCount, NOT re-added). REGRESSION
+    // GUARD: before the fix this fell into the Anthropic branch → usage null → 0 tokens.
+    expect(settledTokens).toBe(21);
+    expect(decisionRef.usage).toMatchObject({
+      prompt_tokens: 12,
+      completion_tokens: 9,
+      cached_tokens: 4,
+    });
+  });
+
+  it("observe-outbound records the assistant text from candidates[].content.parts[].text", async () => {
+    const { observe, persisted } = makeObserveSpy();
+    const pipeline = createMessagesPipeline(
+      () => Promise.resolve(passthroughGeminiOkResult()),
+      "gemini",
+      { observe },
+    );
+    const run = await pipeline.run(
+      irOf({ metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" } }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+    await run.collect();
+    const assistant = persisted.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    expect(assistant?.content).toBe("Hello from Gemini passthrough");
+  });
+});
+
+describe("createMessagesPipeline — gemini native passthrough streamIR()", () => {
+  it("byte-relays the upstream Gemini SSE: yields the VERBATIM nameless data frames", async () => {
+    const pipeline = createMessagesPipeline(
+      () => Promise.resolve(passthroughGeminiStreamResult()),
+      "gemini",
+    );
+    const run = await pipeline.run(irOf({ stream: true }), IDENTITY, new AbortController().signal);
+    const frames: Array<{ event: string; data: string }> = [];
+    for await (const ev of run.streamIR()) frames.push(ev as { event: string; data: string });
+    // Gemini frames are nameless (no `event:` line) → event "".
+    expect(frames.map((f) => f.event)).toEqual(["", ""]);
+    // The terminal frame's data is forwarded BYTE-FOR-BYTE — the deliberately non-
+    // canonical spacing ("promptTokenCount":12 ,) survives, proving no JSON round-trip.
+    expect(frames.at(-1)?.data).toBe(
+      '{"candidates":[{"content":{"parts":[{"text":" Gemini"}]},"finishReason":"STOP"}],"usageMetadata":{ "promptTokenCount":12 ,"candidatesTokenCount":9,"cachedContentTokenCount":4}}',
+    );
+  });
+
+  it("settles the per-key budget using the cumulative Gemini usageMetadata", async () => {
+    let settledTokens: number | null = null;
+    const budget: PipelineBudgetDeps = {
+      gate: { check: async () => ({ overBudget: false }) as never },
+      settle: async (_keyId, _caps, usage) => {
+        settledTokens = usage.tokens;
+      },
+      now: () => 0,
+    };
+    const identity: MessagesIdentity = {
+      keyId: "k1",
+      accountId: "acct",
+      caps: { budget: { spend_usd: { day: 1 } } as never },
+    };
+    const pipeline = createMessagesPipeline(
+      () => Promise.resolve(passthroughGeminiStreamResult()),
+      "gemini",
+      undefined,
+      budget,
+    );
+    const run = await pipeline.run(irOf({ stream: true }), identity, new AbortController().signal);
+    for await (const _ of run.streamIR()) {
+      // drain
+    }
+    // Final cumulative usageMetadata: prompt(12) + candidates(9) = 21 served tokens.
+    // REGRESSION GUARD: before the fix, the Anthropic carrier filter never matched a
+    // Gemini frame → 0 tokens settled.
+    expect(settledTokens).toBe(21);
+  });
+
+  it("observe-outbound records the assistant text from streamed parts[].text", async () => {
+    const { observe, persisted } = makeObserveSpy();
+    const pipeline = createMessagesPipeline(
+      () => Promise.resolve(passthroughGeminiStreamResult()),
+      "gemini",
+      { observe },
+    );
+    const run = await pipeline.run(
+      irOf({
+        stream: true,
+        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+    for await (const _ of run.streamIR()) {
+      // drain
+    }
+    const assistant = persisted.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    expect(assistant?.content).toBe("Hello Gemini");
+  });
+});
+
 describe("createMessagesPipeline — production IR params", () => {
   it.each<Protocol>([
     "anthropic_messages",

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -44,6 +44,8 @@ import {
   usageFromAnthropicResponse,
   usageFromAnthropicSSE,
   usageFromBody,
+  usageFromGeminiResponse,
+  usageFromGeminiSSE,
   usageFromResponsesResponse,
   usageFromResponsesSSE,
 } from "./payload-capture.js";
@@ -314,6 +316,27 @@ function assistantTurnFromNativeResponses(body: unknown): IRMessage[] {
   return text.length > 0 ? [{ role: "assistant", content: text }] : [];
 }
 
+// Reconstruct a minimal assistant turn from a VERBATIM Gemini GenerateContent
+// non-stream response for observeOutbound on the native-passthrough path (P2-GEM-01
+// governance). The native body was NOT projected into an IR, so this reads the Gemini
+// `candidates[].content.parts[]` directly, concatenating each part's `text`. Fail-open:
+// a missing/degraded body yields an empty turn (observeOutbound persists nothing but
+// still stamps the served model). NEVER throws.
+function assistantTurnFromNativeGemini(body: unknown): IRMessage[] {
+  const candidates = (body as { candidates?: unknown } | null)?.candidates;
+  if (!Array.isArray(candidates)) return [];
+  let text = "";
+  for (const candidate of candidates) {
+    const parts = (candidate as { content?: { parts?: unknown } } | null)?.content?.parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      const p = part as { text?: unknown } | null;
+      if (typeof p?.text === "string") text += p.text;
+    }
+  }
+  return text.length > 0 ? [{ role: "assistant", content: text }] : [];
+}
+
 // —— OpenAI chat.completion body → IRResponse. The upstream is OpenAI-compatible
 // and the IR takes the OpenAI shape as its skeleton, so this is a near-identity
 // projection: content/tool_calls/finish_reason/usage map 1:1. Tolerant of a
@@ -495,6 +518,30 @@ function accumulateResponsesAssistantText(buffer: { text: string }, dataPayload:
   }
   if (evt?.type !== "response.output_text.delta") return;
   if (typeof evt.delta === "string") buffer.text += evt.delta;
+}
+
+// Accumulate assistant text from a VERBATIM Gemini streamGenerateContent SSE data
+// payload for observeOutbound on the native-passthrough stream (P2-GEM-01 governance).
+// Gemini frames are nameless `data:` GenerateContent deltas carrying
+// `candidates[].content.parts[].text` (no `type` discriminator). Fail-open: a non-JSON
+// frame contributes nothing. NEVER throws.
+function accumulateGeminiAssistantText(buffer: { text: string }, dataPayload: string): void {
+  if (dataPayload === "" || dataPayload === "[DONE]") return;
+  let evt: { candidates?: unknown };
+  try {
+    evt = JSON.parse(dataPayload) as { candidates?: unknown };
+  } catch {
+    return;
+  }
+  if (!Array.isArray(evt?.candidates)) return;
+  for (const candidate of evt.candidates) {
+    const parts = (candidate as { content?: { parts?: unknown } } | null)?.content?.parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      const p = part as { text?: unknown } | null;
+      if (typeof p?.text === "string") buffer.text += p.text;
+    }
+  }
 }
 
 function nonNegativeToken(value: unknown): number | undefined {
@@ -790,18 +837,21 @@ export function createMessagesPipeline(
           // and observe-outbound persists the assistant turn reconstructed from the
           // native content. The decision record stays body-free (principle 7).
           if (result.nativePassthrough === true) {
-            const isResponses = protocol === "openai_responses";
             // Memory observe (outbound): reconstruct the assistant turn from the
             // native response (the body was never projected into an IR). Protocol-
             // aware: Anthropic reads content[].text, Responses reads output[].content[]
-            // .output_text. Fail-open — an empty/degraded body persists nothing.
+            // .output_text, Gemini reads candidates[].content.parts[].text. Fail-open —
+            // an empty/degraded body persists nothing.
             if (memory !== undefined) {
               const finalAlias =
                 result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
               const memoryObserve = memory.observe;
-              const responseMessages = isResponses
-                ? assistantTurnFromNativeResponses(result.body)
-                : assistantTurnFromNativeAnthropic(result.body);
+              const responseMessages =
+                protocol === "openai_responses"
+                  ? assistantTurnFromNativeResponses(result.body)
+                  : protocol === "gemini"
+                    ? assistantTurnFromNativeGemini(result.body)
+                    : assistantTurnFromNativeAnthropic(result.body);
               await runObserve(() =>
                 observeOutbound(
                   memoryObserve,
@@ -817,11 +867,14 @@ export function createMessagesPipeline(
             }
             // Cost/budget settle: normalize the native usage block into the OpenAI-
             // shaped StreamUsage the helpers understand (cost was already settled on the
-            // decision by execute()). Protocol-aware: Responses counts cache INSIDE
-            // input_tokens, Anthropic reports it separately.
-            const servedUsage = isResponses
-              ? usageFromResponsesResponse(result.body)
-              : usageFromAnthropicResponse(result.body);
+            // decision by execute()). Protocol-aware: Responses + Gemini count cache
+            // INSIDE the prompt count, Anthropic reports it separately.
+            const servedUsage =
+              protocol === "openai_responses"
+                ? usageFromResponsesResponse(result.body)
+                : protocol === "gemini"
+                  ? usageFromGeminiResponse(result.body)
+                  : usageFromAnthropicResponse(result.body);
             try {
               backfillCompletionCost(result.decision, null, null, servedUsage);
             } catch {
@@ -898,7 +951,16 @@ export function createMessagesPipeline(
           // stamped `protocol`. The byte-faithful forward itself is identical.
           if (result.nativePassthrough === true) {
             const passthroughStream = result.stream;
-            const isResponses = protocol === "openai_responses";
+            // Per-protocol usage extraction: Anthropic splits usage across
+            // message_start/message_delta; Responses carries totals on the terminal
+            // response.completed/incomplete; Gemini emits CUMULATIVE usageMetadata on
+            // every frame (the last frame wins).
+            const isUsageCarrierFrame = (data: string): boolean =>
+              protocol === "openai_responses"
+                ? data.includes("response.completed") || data.includes("response.incomplete")
+                : protocol === "gemini"
+                  ? data.includes("usageMetadata")
+                  : data.includes("message_start") || data.includes("message_delta");
             // Bounded usage buffer: keep ONLY the usage-bearing frames. Anthropic
             // carries usage on message_start (input/cache) + the trailing message_delta
             // (output); Responses carries the totals on the terminal response.completed/
@@ -914,17 +976,17 @@ export function createMessagesPipeline(
                 // frame's text delta feeds the assistant-turn reconstruction. Neither
                 // touches the bytes yielded downstream (byte-faithful forward). The
                 // usage-frame filter is generalized to catch BOTH protocols' carriers.
-                if (
-                  isResponses
-                    ? frame.data.includes("response.completed") ||
-                      frame.data.includes("response.incomplete")
-                    : frame.data.includes("message_start") || frame.data.includes("message_delta")
-                ) {
-                  usageBuffer += frame.raw;
+                if (isUsageCarrierFrame(frame.data)) {
+                  // Gemini's usageMetadata is CUMULATIVE per frame → keep ONLY the latest
+                  // (stays bounded). Anthropic/Responses need their distinct carriers
+                  // appended (input on message_start, output on message_delta / terminal).
+                  usageBuffer = protocol === "gemini" ? frame.raw : usageBuffer + frame.raw;
                 }
                 if (memory !== undefined) {
-                  if (isResponses) {
+                  if (protocol === "openai_responses") {
                     accumulateResponsesAssistantText(passthroughAssistant, frame.data);
+                  } else if (protocol === "gemini") {
+                    accumulateGeminiAssistantText(passthroughAssistant, frame.data);
                   } else {
                     accumulateAnthropicAssistantText(passthroughAssistant, frame.data);
                   }
@@ -943,9 +1005,12 @@ export function createMessagesPipeline(
               // budget settle, and per-account OAuth usage. All fail-open. The usage
               // extractor matches the inbound protocol (Responses totals on the terminal
               // event; Anthropic split across message_start/message_delta).
-              const nativeUsage = isResponses
-                ? usageFromResponsesSSE(usageBuffer)
-                : usageFromAnthropicSSE(usageBuffer);
+              const nativeUsage =
+                protocol === "openai_responses"
+                  ? usageFromResponsesSSE(usageBuffer)
+                  : protocol === "gemini"
+                    ? usageFromGeminiSSE(usageBuffer)
+                    : usageFromAnthropicSSE(usageBuffer);
               const finalAlias =
                 result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
               if (memory !== undefined) {

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -60,6 +60,7 @@ function makeDeps(
     abort?: boolean;
     authed?: boolean;
     transformRequestOut?: (native: unknown) => unknown;
+    countTokens?: MessagesRouteDeps["countTokens"];
     rateLimiter?: MessagesRouteDeps["rateLimiter"];
     concurrencyGate?: MessagesRouteDeps["concurrencyGate"];
     identity?: MessagesIdentity;
@@ -80,6 +81,7 @@ function makeDeps(
   const deps: MessagesRouteDeps = {
     rateLimiter: over.rateLimiter,
     concurrencyGate: over.concurrencyGate,
+    countTokens: over.countTokens,
     record: over.record,
     auth: {
       resolve: async (_key: string | null) => {
@@ -246,7 +248,25 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expect(harness.order).toEqual(["auth"]);
   });
 
-  it("returns an authenticated Anthropic count_tokens estimate without routing", async () => {
+  it("uses provider-backed Anthropic count_tokens when available", async () => {
+    const countTokens = vi.fn().mockResolvedValue({ input_tokens: 42 });
+    const { deps, harness } = makeDeps({ countTokens });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages/count_tokens", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ input_tokens: 42 });
+    expect(countTokens).toHaveBeenCalledWith(REQ_BODY, IDENTITY, expect.any(AbortSignal));
+    expect(harness.order).toEqual(["auth"]);
+    expect(harness.order).not.toContain("route");
+  });
+
+  it("returns an authenticated Anthropic count_tokens estimate without routing when no provider is available", async () => {
     const { deps, harness } = makeDeps();
     const app = buildApp(deps);
 
@@ -257,10 +277,30 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { input_tokens: number };
+    const body = (await res.json()) as { input_tokens: number; estimated: boolean };
     expect(body.input_tokens).toBeGreaterThan(0);
+    expect(body.estimated).toBe(true);
     expect(harness.order).toEqual(["auth"]);
     expect(harness.order).not.toContain("route");
+  });
+
+  it("falls back to an estimated Anthropic count_tokens result if provider counting fails", async () => {
+    const countTokens = vi.fn().mockRejectedValue(new Error("provider unavailable"));
+    const { deps, harness } = makeDeps({ countTokens });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages/count_tokens", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { input_tokens: number; estimated: boolean };
+    expect(body.input_tokens).toBeGreaterThan(0);
+    expect(body.estimated).toBe(true);
+    expect(countTokens).toHaveBeenCalledOnce();
+    expect(harness.order).toEqual(["auth"]);
   });
 
   it("validates count_tokens requests before returning an estimate", async () => {

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -116,6 +116,14 @@ export interface MessagesRouteDeps {
    *  tests that omit it record nothing; when wired, every served request (success
    *  OR failure, stream OR non-stream) writes a telemetry row. */
   record?: RecordServedDeps;
+  /** Optional provider-backed Anthropic token counter. Missing/failing counter
+   *  falls back to a deterministic local estimate, so helper failures never
+   *  affect normal generation. */
+  countTokens?(
+    body: Record<string, unknown>,
+    identity: MessagesIdentity,
+    signal: AbortSignal,
+  ): Promise<Record<string, unknown>>;
   auth: {
     /** Resolve the request credential to an identity, or null when invalid.
      *  Mandatory auth: a null result short-circuits to a 401 (no anonymous
@@ -258,7 +266,15 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         trace_id: traceId,
       });
     }
-    return c.json({ input_tokens: estimateAnthropicInputTokens(native) });
+    if (deps.countTokens !== undefined) {
+      try {
+        return c.json(await deps.countTokens(obj, identity, c.req.raw.signal));
+      } catch {
+        // Token helpers are compatibility helpers, not generation. Fall back to a
+        // deterministic estimate instead of making /v1/messages/count_tokens flaky.
+      }
+    }
+    return c.json({ input_tokens: estimateAnthropicInputTokens(native), estimated: true });
   });
 
   app.post("/v1/messages", async (c) => {

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -11,6 +11,8 @@ import {
   tokensFromUsage,
   usageFromAnthropicResponse,
   usageFromAnthropicSSE,
+  usageFromGeminiResponse,
+  usageFromGeminiSSE,
   usageFromResponsesResponse,
   usageFromResponsesSSE,
   usageFromSSE,
@@ -317,6 +319,101 @@ describe("usageFromResponsesSSE", () => {
     ].join("");
     expect(usageFromResponsesSSE(sse)).toBeNull();
     expect(usageFromResponsesSSE("")).toBeNull();
+  });
+});
+
+// Native-protocol-passthrough cost for Gemini (P2-GEM-01 governance): a VERBATIM
+// Gemini GenerateContent response carries usage under `usageMetadata`. Like
+// Responses (and UNLIKE Anthropic), Gemini's promptTokenCount already INCLUDES the
+// cached slice, so prompt_tokens = promptTokenCount and cached rides
+// prompt_tokens_details. thoughtsTokenCount (reasoning) is billed as output, so it
+// folds into completion_tokens alongside candidatesTokenCount.
+describe("usageFromGeminiResponse", () => {
+  it("maps Gemini usageMetadata to OpenAI-shaped StreamUsage (cache inside prompt)", () => {
+    const body = {
+      candidates: [{ content: { role: "model", parts: [{ text: "hi" }] } }],
+      usageMetadata: {
+        promptTokenCount: 1000,
+        candidatesTokenCount: 500,
+        cachedContentTokenCount: 200,
+        totalTokenCount: 1500,
+      },
+    };
+    expect(usageFromGeminiResponse(body)).toEqual({
+      prompt_tokens: 1000, // cache already counted inside promptTokenCount
+      completion_tokens: 500,
+      total_tokens: 1500,
+      prompt_tokens_details: { cached_tokens: 200 },
+    });
+    expect(tokensFromUsage(usageFromGeminiResponse(body))).toBe(1500);
+  });
+
+  it("folds thoughtsTokenCount (reasoning) into completion tokens", () => {
+    const body = {
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 7, thoughtsTokenCount: 4 },
+    };
+    expect(usageFromGeminiResponse(body)).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 11, // candidates(7) + thoughts(4)
+      total_tokens: 21,
+    });
+  });
+
+  it("omits prompt_tokens_details when there are no cached tokens", () => {
+    const body = { usageMetadata: { promptTokenCount: 12, candidatesTokenCount: 3 } };
+    expect(usageFromGeminiResponse(body)).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 3,
+      total_tokens: 15,
+    });
+  });
+
+  it("returns null when the body has no usageMetadata object", () => {
+    expect(usageFromGeminiResponse({ candidates: [] })).toBeNull();
+    expect(usageFromGeminiResponse(null)).toBeNull();
+    expect(usageFromGeminiResponse(undefined)).toBeNull();
+    expect(usageFromGeminiResponse({ usageMetadata: "nope" })).toBeNull();
+  });
+});
+
+// Native-protocol-passthrough STREAMING cost for Gemini: the streamGenerateContent
+// SSE emits cumulative `usageMetadata` on its frames (the final frame carries the
+// complete count). Byte-faithful passthrough forwards these nameless `data:` frames
+// VERBATIM, so cost extraction scans the accumulated SSE and keeps the LAST seen
+// usageMetadata.
+describe("usageFromGeminiSSE", () => {
+  it("extracts the final cumulative usageMetadata frame", () => {
+    const sse = [
+      'data: {"candidates":[{"content":{"parts":[{"text":"Hel"}]}}],"usageMetadata":{"promptTokenCount":1000,"candidatesTokenCount":1}}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1000,"candidatesTokenCount":500,"cachedContentTokenCount":200}}\n\n',
+    ].join("");
+    expect(usageFromGeminiSSE(sse)).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 500,
+      total_tokens: 1500,
+      prompt_tokens_details: { cached_tokens: 200 },
+    });
+    expect(tokensFromUsage(usageFromGeminiSSE(sse))).toBe(1500);
+  });
+
+  it("skips keepalive / [DONE] / non-JSON frames without throwing", () => {
+    const sse = [
+      ": keepalive comment\n\n",
+      "data: not json at all\n\n",
+      'data: {"candidates":[{"content":{"parts":[{"text":"x"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":2}}\n\n',
+      "data: [DONE]\n\n",
+    ].join("");
+    expect(usageFromGeminiSSE(sse)).toEqual({
+      prompt_tokens: 8,
+      completion_tokens: 2,
+      total_tokens: 10,
+    });
+  });
+
+  it("returns null when no usageMetadata frame is present", () => {
+    const sse = 'data: {"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}\n\n';
+    expect(usageFromGeminiSSE(sse)).toBeNull();
+    expect(usageFromGeminiSSE("")).toBeNull();
   });
 });
 

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -271,6 +271,73 @@ function normalizeResponsesUsage(u: Record<string, unknown>): StreamUsage {
   return normalized;
 }
 
+// Native-protocol-passthrough cost for Gemini (P2-GEM-01 governance): normalize a
+// VERBATIM Gemini GenerateContent NON-stream response's `usageMetadata` into the
+// OpenAI-shaped StreamUsage the gateway's costOf/resolveCostUsd already understand.
+// Token math MIRRORS core's gemini transformResponseIn: Gemini's promptTokenCount
+// ALREADY INCLUDES the cached slice (like Responses, unlike Anthropic), so
+// prompt_tokens = promptTokenCount and the cache rides prompt_tokens_details;
+// thoughtsTokenCount (reasoning) is billed as output, so it folds into
+// completion_tokens. Tolerant of missing fields (each absent → 0); null when the
+// body carries no usageMetadata object at all.
+export function usageFromGeminiResponse(body: unknown): StreamUsage | null {
+  const um = (body as { usageMetadata?: unknown } | null)?.usageMetadata;
+  if (!um || typeof um !== "object") return null;
+  return normalizeGeminiUsage(um as Record<string, unknown>);
+}
+
+// Shared Gemini-usage normalization for the non-stream body and the streamed
+// cumulative usageMetadata (identical shape). Cache is already included in
+// promptTokenCount, so the budget total is simply prompt + completion.
+function normalizeGeminiUsage(um: Record<string, unknown>): StreamUsage {
+  const prompt = typeof um.promptTokenCount === "number" ? um.promptTokenCount : 0;
+  const candidates = typeof um.candidatesTokenCount === "number" ? um.candidatesTokenCount : 0;
+  const thoughts = typeof um.thoughtsTokenCount === "number" ? um.thoughtsTokenCount : 0;
+  const cached = typeof um.cachedContentTokenCount === "number" ? um.cachedContentTokenCount : 0;
+  const completion = candidates + thoughts;
+  const normalized: StreamUsage = {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+  };
+  if (cached > 0) {
+    normalized.prompt_tokens_details = { cached_tokens: cached };
+  }
+  return normalized;
+}
+
+// Native-protocol-passthrough STREAMING cost for Gemini. The streamGenerateContent
+// SSE emits nameless `data:` frames carrying CUMULATIVE `usageMetadata` (the final
+// frame holds the complete count), so cost extraction scans the accumulated SSE and
+// keeps the LAST usageMetadata seen. Frames split on the SSE record separator (\n\n);
+// the `data:` line is read with a tolerant JSON.parse so keepalive / `[DONE]` / non-
+// JSON lines are skipped. null when no usageMetadata frame is present.
+export function usageFromGeminiSSE(raw: string): StreamUsage | null {
+  let last: StreamUsage | null = null;
+  for (const frame of raw.split("\n\n")) {
+    let payload: string | null = null;
+    for (const line of frame.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("data:")) {
+        payload = trimmed.slice("data:".length).trim();
+        break;
+      }
+    }
+    if (payload === null || payload === "" || payload === "[DONE]") continue;
+    let evt: { usageMetadata?: unknown };
+    try {
+      evt = JSON.parse(payload);
+    } catch {
+      // ping / keepalive / non-JSON line — ignore
+      continue;
+    }
+    if (!evt || typeof evt !== "object") continue;
+    const um = evt.usageMetadata;
+    if (um && typeof um === "object") last = normalizeGeminiUsage(um as Record<string, unknown>);
+  }
+  return last;
+}
+
 // Native-protocol-passthrough STREAMING cost for openai_responses (#217 Phase 3).
 // Unlike Anthropic (usage split across message_start/message_delta), the Codex
 // Responses SSE carries the totals on the TERMINAL event — `response.completed` or

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -41,6 +41,8 @@ function makeDeps(
     concurrencyGate?: ResponsesRouteDeps["concurrencyGate"];
     identity?: MessagesIdentity;
     record?: RecordServedDeps;
+    lifecycle?: ResponsesRouteDeps["lifecycle"];
+    registry?: ResponsesRouteDeps["registry"];
   } = {},
 ): { deps: ResponsesRouteDeps; order: string[]; harness: { pipelineSawIR: unknown } } {
   const order: string[] = [];
@@ -49,6 +51,8 @@ function makeDeps(
     rateLimiter: over.rateLimiter,
     concurrencyGate: over.concurrencyGate,
     record: over.record,
+    lifecycle: over.lifecycle,
+    registry: over.registry,
     auth: {
       resolve: async (cred) => {
         order.push("auth");
@@ -191,7 +195,15 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     }
   });
 
-  it("returns OpenAI-shaped errors for unsupported Responses lifecycle endpoints", async () => {
+  it("authenticates Responses lifecycle endpoints before provider dispatch or local fallback", async () => {
+    const lifecycle: ResponsesRouteDeps["lifecycle"] = {
+      retrieve: vi.fn(),
+      delete: vi.fn(),
+      cancel: vi.fn(),
+      inputItems: vi.fn(),
+      compact: vi.fn(),
+      inputTokens: vi.fn(),
+    };
     const cases: Array<[string, string]> = [
       ["GET", "/v1/responses/resp_123"],
       ["DELETE", "/v1/responses/resp_123"],
@@ -199,6 +211,297 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       ["GET", "/v1/responses/resp_123/input_items"],
       ["POST", "/v1/responses/compact"],
       ["POST", "/v1/responses/input_tokens"],
+    ];
+
+    for (const [method, path] of cases) {
+      const { deps, order } = makeDeps({ authed: false, lifecycle });
+      const app = buildApp(deps);
+      const res = await app.request(path, {
+        method,
+        headers: method === "POST" ? AUTH : { Authorization: AUTH.Authorization },
+        body: method === "POST" ? JSON.stringify(REQ) : undefined,
+      });
+      expect(res.status, `${method} ${path}`).toBe(401);
+      const body = (await res.json()) as { error: Record<string, string> };
+      expect(body.error.code).toBe("invalid_api_key");
+      expect(order).toEqual(["auth"]);
+    }
+    expect(lifecycle.retrieve).not.toHaveBeenCalled();
+    expect(lifecycle.delete).not.toHaveBeenCalled();
+    expect(lifecycle.cancel).not.toHaveBeenCalled();
+    expect(lifecycle.inputItems).not.toHaveBeenCalled();
+    expect(lifecycle.compact).not.toHaveBeenCalled();
+    expect(lifecycle.inputTokens).not.toHaveBeenCalled();
+  });
+
+  it("/input_tokens calls the provider lifecycle method when it is available", async () => {
+    const inputTokens = vi.fn().mockResolvedValue({ input_tokens: 123, estimated: false });
+    const { deps, order } = makeDeps({ lifecycle: { inputTokens } });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses/input_tokens", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ input_tokens: 123, estimated: false });
+    expect(inputTokens).toHaveBeenCalledWith(
+      REQ,
+      { keyId: "k1", accountId: "acct" },
+      expect.any(AbortSignal),
+    );
+    expect(order).toEqual(["auth"]);
+  });
+
+  it("/input_tokens falls back to a deterministic local estimate when no provider method exists", async () => {
+    const { deps, order } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses/input_tokens", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ model: "auto", input: "hello world", instructions: "be brief" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { input_tokens: number; estimated: boolean };
+    expect(body.input_tokens).toBeGreaterThan(1);
+    expect(body.estimated).toBe(true);
+    expect(order).toEqual(["auth"]);
+  });
+
+  it("/compact falls back to normal Responses routing when no provider lifecycle method exists", async () => {
+    const { deps, order } = makeDeps();
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses/compact", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { object: string; status: string };
+    expect(body.object).toBe("response");
+    expect(body.status).toBe("completed");
+    expect(order).toEqual(["auth", "translate-out", "route", "translate-back"]);
+  });
+
+  it("calls provider-supported Responses lifecycle endpoints", async () => {
+    const lifecycle: ResponsesRouteDeps["lifecycle"] = {
+      retrieve: vi
+        .fn()
+        .mockResolvedValue({ id: "resp_123", object: "response", status: "completed" }),
+      delete: vi
+        .fn()
+        .mockResolvedValue({ id: "resp_123", object: "response.deleted", deleted: true }),
+      cancel: vi
+        .fn()
+        .mockResolvedValue({ id: "resp_123", object: "response", status: "cancelled" }),
+      inputItems: vi.fn().mockResolvedValue({ object: "list", data: [], has_more: false }),
+      compact: vi
+        .fn()
+        .mockResolvedValue({ id: "resp_compact", object: "response", status: "completed" }),
+    };
+    const { deps } = makeDeps({ lifecycle });
+    const app = buildApp(deps);
+
+    const cases: Array<[string, string, unknown]> = [
+      [
+        "GET",
+        "/v1/responses/resp_123",
+        { id: "resp_123", object: "response", status: "completed" },
+      ],
+      [
+        "DELETE",
+        "/v1/responses/resp_123",
+        { id: "resp_123", object: "response.deleted", deleted: true },
+      ],
+      [
+        "POST",
+        "/v1/responses/resp_123/cancel",
+        { id: "resp_123", object: "response", status: "cancelled" },
+      ],
+      ["GET", "/v1/responses/resp_123/input_items", { object: "list", data: [], has_more: false }],
+      [
+        "POST",
+        "/v1/responses/compact",
+        { id: "resp_compact", object: "response", status: "completed" },
+      ],
+    ];
+
+    for (const [method, path, expected] of cases) {
+      const res = await app.request(path, {
+        method,
+        headers: method === "POST" ? AUTH : { Authorization: AUTH.Authorization },
+        body: method === "POST" ? JSON.stringify(REQ) : undefined,
+      });
+      expect(res.status, `${method} ${path}`).toBe(200);
+      expect(await res.json()).toEqual(expected);
+    }
+    expect(lifecycle.retrieve).toHaveBeenCalledWith(
+      "resp_123",
+      { keyId: "k1", accountId: "acct" },
+      expect.any(AbortSignal),
+    );
+    expect(lifecycle.delete).toHaveBeenCalledWith(
+      "resp_123",
+      { keyId: "k1", accountId: "acct" },
+      expect.any(AbortSignal),
+    );
+    expect(lifecycle.cancel).toHaveBeenCalledWith(
+      "resp_123",
+      { keyId: "k1", accountId: "acct" },
+      expect.any(AbortSignal),
+    );
+    expect(lifecycle.inputItems).toHaveBeenCalledWith(
+      "resp_123",
+      { keyId: "k1", accountId: "acct" },
+      expect.any(AbortSignal),
+    );
+    expect(lifecycle.compact).toHaveBeenCalledWith(
+      REQ,
+      { keyId: "k1", accountId: "acct" },
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("records persistent Responses ids in the lifecycle registry after create", async () => {
+    const put = vi.fn();
+    const decision = {
+      final: { status: "ok", model_alias: "responses/gpt-5.5", provider_model: "gpt-5.5" },
+      provider_attempts: [
+        {
+          alias: "responses/gpt-5.5",
+          status: "ok",
+          skipped: false,
+          provider_name: "openai",
+          provider_model: "gpt-5.5",
+          target_provider_protocol: "openai_responses",
+        },
+      ],
+    } as never;
+    const { deps } = makeDeps({
+      collect: async () => ({ id: "resp_persisted", object: "response", status: "completed" }),
+      run: async () => ({
+        decision,
+        nativePassthrough: true,
+        collect: async () => ({ id: "resp_persisted", object: "response", status: "completed" }),
+        streamIR: async function* () {},
+      }),
+      registry: { put, get: vi.fn() },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, store: true }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseId: "resp_persisted",
+        accountId: "acct",
+        keyId: "k1",
+        providerAlias: "responses/gpt-5.5",
+        providerName: "openai",
+        providerModel: "gpt-5.5",
+        providerProtocol: "openai_responses",
+        status: "completed",
+      }),
+    );
+  });
+
+  it("returns an OpenAI-shaped 404 for unknown registry response ids without provider dispatch", async () => {
+    const retrieve = vi.fn();
+    const registry = { put: vi.fn(), get: vi.fn().mockResolvedValue(null) };
+    const { deps } = makeDeps({ lifecycle: { retrieve }, registry });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses/resp_missing", {
+      headers: { Authorization: AUTH.Authorization },
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: Record<string, string> };
+    expect(body.error.code).toBe("response_not_found");
+    expect(body.error.trace_id).toBeTruthy();
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for expired registry response ids without provider dispatch", async () => {
+    const retrieve = vi.fn();
+    const registryRecord = {
+      responseId: "resp_expired",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "responses/gpt-5.5",
+      providerName: "openai",
+      providerModel: "gpt-5.5",
+      providerProtocol: "openai_responses" as const,
+      createdAt: 1,
+      expiresAt: 1,
+      status: "completed",
+    };
+    const { deps } = makeDeps({
+      lifecycle: { retrieve },
+      registry: { put: vi.fn(), get: vi.fn().mockResolvedValue(registryRecord) },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses/resp_expired", {
+      headers: { Authorization: AUTH.Authorization },
+    });
+
+    expect(res.status).toBe(404);
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
+  it("passes registry records to lifecycle methods for provider-bound dispatch", async () => {
+    const registryRecord = {
+      responseId: "resp_123",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "responses/gpt-5.5",
+      providerName: "openai",
+      providerModel: "gpt-5.5",
+      providerProtocol: "openai_responses" as const,
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      status: "completed",
+    };
+    const retrieve = vi
+      .fn()
+      .mockResolvedValue({ id: "resp_123", object: "response", status: "completed" });
+    const { deps } = makeDeps({
+      lifecycle: { retrieve },
+      registry: { put: vi.fn(), get: vi.fn().mockResolvedValue(registryRecord) },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses/resp_123", {
+      headers: { Authorization: AUTH.Authorization },
+    });
+
+    expect(res.status).toBe(200);
+    expect(retrieve).toHaveBeenCalledWith(
+      "resp_123",
+      { keyId: "k1", accountId: "acct" },
+      expect.any(AbortSignal),
+      registryRecord,
+    );
+  });
+
+  it("returns capability-shaped errors for provider-unsupported lifecycle endpoints", async () => {
+    const cases: Array<[string, string]> = [
+      ["GET", "/v1/responses/resp_123"],
+      ["DELETE", "/v1/responses/resp_123"],
+      ["POST", "/v1/responses/resp_123/cancel"],
+      ["GET", "/v1/responses/resp_123/input_items"],
       ["GET", "/responses/resp_123"],
       ["DELETE", "/openai/v1/responses/resp_123"],
     ];
@@ -206,24 +509,18 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     for (const [method, path] of cases) {
       const { deps, order } = makeDeps();
       const app = buildApp(deps);
-      const res = await app.request(path, { method, headers: AUTH });
-      expect(res.status, `${method} ${path}`).toBe(400);
+      const res = await app.request(path, {
+        method,
+        headers: method === "POST" ? AUTH : { Authorization: AUTH.Authorization },
+        body: method === "POST" ? JSON.stringify(REQ) : undefined,
+      });
+      expect(res.status, `${method} ${path}`).toBe(422);
       const body = (await res.json()) as { error: Record<string, string> };
       expect(body.error.type).toBe("invalid_request_error");
-      expect(body.error.code).toBe("invalid_request");
-      expect(body.error.message).toContain("not implemented");
+      expect(body.error.code).toBe("capability_unsatisfiable");
+      expect(body.error.message).toContain("not supported");
       expect(order).toEqual(["auth"]);
     }
-  });
-
-  it("authenticates unsupported Responses lifecycle endpoints before returning unsupported", async () => {
-    const { deps, order } = makeDeps({ authed: false });
-    const app = buildApp(deps);
-    const res = await app.request("/v1/responses/resp_123", { method: "GET" });
-    expect(res.status).toBe(401);
-    const body = (await res.json()) as { error: Record<string, string> };
-    expect(body.error.code).toBe("invalid_api_key");
-    expect(order).toEqual(["auth"]);
   });
 
   it("rejects a missing key with 401 (OpenAI error envelope) and never routes", async () => {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -44,6 +44,56 @@ export interface ResponsesRateLimiterPort {
   check(probe: RateLimitProbe): Promise<RateLimitResult>;
 }
 
+export interface ResponsesLifecyclePort {
+  retrieve?(
+    responseId: string,
+    identity: MessagesIdentity,
+    signal: AbortSignal,
+    record?: ResponsesRegistryRecord,
+  ): Promise<unknown>;
+  delete?(
+    responseId: string,
+    identity: MessagesIdentity,
+    signal: AbortSignal,
+    record?: ResponsesRegistryRecord,
+  ): Promise<unknown>;
+  cancel?(
+    responseId: string,
+    identity: MessagesIdentity,
+    signal: AbortSignal,
+    record?: ResponsesRegistryRecord,
+  ): Promise<unknown>;
+  inputItems?(
+    responseId: string,
+    identity: MessagesIdentity,
+    signal: AbortSignal,
+    record?: ResponsesRegistryRecord,
+  ): Promise<unknown>;
+  compact?(body: unknown, identity: MessagesIdentity, signal: AbortSignal): Promise<unknown>;
+  inputTokens?(body: unknown, identity: MessagesIdentity, signal: AbortSignal): Promise<unknown>;
+}
+
+export interface ResponsesRegistryRecord {
+  responseId: string;
+  accountId: string;
+  keyId: string;
+  providerAlias: string | null;
+  providerName: string | null;
+  providerModel: string | null;
+  providerProtocol: "openai_chat" | "anthropic_messages" | "openai_responses" | "gemini" | null;
+  createdAt: number;
+  expiresAt: number;
+  status: string;
+}
+
+export interface ResponsesRegistryPort {
+  put(record: ResponsesRegistryRecord): void | Promise<void>;
+  get(
+    responseId: string,
+    identity: MessagesIdentity,
+  ): ResponsesRegistryRecord | null | Promise<ResponsesRegistryRecord | null>;
+}
+
 export interface ResponsesRouteDeps {
   rateLimiter?: ResponsesRateLimiterPort;
   /** Per-key concurrency overflow queue (issue #93) — the SAME process-wide gate
@@ -53,6 +103,13 @@ export interface ResponsesRouteDeps {
    *  tests that omit it record nothing; when wired, every served request (success
    *  OR failure, stream OR non-stream) writes a telemetry row. */
   record?: RecordServedDeps;
+  /** Optional provider-backed Responses lifecycle facade. Missing methods mean
+   *  unsupported capability, except input_tokens which can be locally estimated. */
+  lifecycle?: ResponsesLifecyclePort;
+  /** Optional response object registry. When present, lifecycle methods first
+   *  prove the response id belongs to the calling key/account and can dispatch to
+   *  the provider that created it instead of the first global capable provider. */
+  registry?: ResponsesRegistryPort;
   auth: { resolve(credential: string | null): Promise<MessagesIdentity | null> };
   transformer: {
     /** native Responses request → IR (throws on a structurally invalid body). */
@@ -91,11 +148,44 @@ function extractCredential(auth: string | undefined): string | null {
 }
 
 function helmError(
-  error_class: "auth_error" | "invalid_request",
+  error_class: "auth_error" | "invalid_request" | "capability_unsatisfiable",
   message: string,
   traceId: string,
 ) {
   return new HelmHttpError(makeHelmError({ error_class, message, trace_id: traceId }));
+}
+
+function responseNotFound(c: Context<AppEnv>, responseId: string, traceId: string): Response {
+  return c.json(
+    {
+      error: {
+        message: `Responses response '${responseId}' was not found`,
+        type: "invalid_request_error",
+        code: "response_not_found",
+        trace_id: traceId,
+      },
+    },
+    404,
+  );
+}
+
+function successfulAttempt(decision: unknown): Record<string, unknown> | null {
+  const attempts =
+    decision !== null &&
+    typeof decision === "object" &&
+    Array.isArray((decision as { provider_attempts?: unknown }).provider_attempts)
+      ? (decision as { provider_attempts: Array<Record<string, unknown>> }).provider_attempts
+      : [];
+  return attempts.find((attempt) => attempt.status === "ok" && attempt.skipped !== true) ?? null;
+}
+
+function statusFromResponseBody(body: Record<string, unknown>): string {
+  return typeof body.status === "string" && body.status.length > 0 ? body.status : "completed";
+}
+
+function isUsableRegistryRecord(record: ResponsesRegistryRecord): boolean {
+  if (record.expiresAt <= Date.now()) return false;
+  return record.status !== "deleted";
 }
 
 // Validate a PipelineError's free-form `error_class` against the known ErrorClass
@@ -142,6 +232,30 @@ function pipelineToHelm(err: PipelineError, traceId: string): HelmHttpError {
   );
 }
 
+function estimateResponsesInputTokens(value: unknown): number {
+  const seen = new WeakSet<object>();
+  const collect = (v: unknown): string => {
+    if (typeof v === "string") return v;
+    if (typeof v === "number" || typeof v === "boolean") return String(v);
+    if (v === null || v === undefined) return "";
+    if (Array.isArray(v)) return v.map(collect).join("\n");
+    if (typeof v === "object") {
+      if (seen.has(v)) return "";
+      seen.add(v);
+      return Object.values(v as Record<string, unknown>)
+        .map(collect)
+        .join("\n");
+    }
+    return "";
+  };
+  const obj = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  const text = [obj.instructions, obj.input, obj.tools, obj.tool_choice, obj.response_format]
+    .map(collect)
+    .filter((s) => s.length > 0)
+    .join("\n");
+  return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
+}
+
 export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDeps): void {
   // Frees an unclaimed concurrency lease on every exit path — incl. a throw into
   // onError (the handler below acquires AFTER its self-auth).
@@ -157,18 +271,88 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     return identity;
   };
 
-  const unsupportedLifecycle = (operation: string) => async (c: Context<AppEnv>) => {
-    const traceId = c.get("trace_id");
-
-    // Match OpenAI/LiteLLM route coverage while failing closed for lifecycle
-    // state Helm does not persist yet. Auth still runs first so unsupported
-    // operations do not become unauthenticated route probes.
-    await authenticateResponsesRequest(c);
-    throw helmError(
-      "invalid_request",
-      `Responses ${operation} is not implemented by this Helm API deployment`,
+  const lifecycleUnsupported = (operation: string, traceId: string): HelmHttpError =>
+    helmError(
+      "capability_unsatisfiable",
+      `Responses ${operation} is not supported by the selected provider or this Helm API deployment`,
       traceId,
     );
+
+  const parseJsonBody = async (c: Context<AppEnv>, traceId: string): Promise<unknown> => {
+    try {
+      return JSON.parse(await c.req.text());
+    } catch {
+      throw helmError("invalid_request", "malformed JSON request body", traceId);
+    }
+  };
+
+  const handleProviderLifecycle =
+    (operation: "retrieve" | "delete" | "cancel" | "inputItems") => async (c: Context<AppEnv>) => {
+      const traceId = c.get("trace_id");
+      const identity = await authenticateResponsesRequest(c);
+      const method = deps.lifecycle?.[operation];
+      if (method === undefined) throw lifecycleUnsupported(operation, traceId);
+      const responseId = c.req.param("response_id");
+      if (responseId === undefined) {
+        throw helmError("invalid_request", "missing response_id", traceId);
+      }
+      const registryRecord =
+        deps.registry !== undefined ? await deps.registry.get(responseId, identity) : null;
+      if (deps.registry !== undefined && registryRecord === null) {
+        return responseNotFound(c, responseId, traceId);
+      }
+      if (
+        registryRecord !== null &&
+        registryRecord !== undefined &&
+        !isUsableRegistryRecord(registryRecord)
+      ) {
+        return responseNotFound(c, responseId, traceId);
+      }
+      const body =
+        deps.registry !== undefined
+          ? await method(responseId, identity, c.req.raw.signal, registryRecord ?? undefined)
+          : await method(responseId, identity, c.req.raw.signal);
+      return c.json(body as Record<string, unknown>);
+    };
+
+  const handleCompact = async (c: Context<AppEnv>) => {
+    const traceId = c.get("trace_id");
+    const identity = await authenticateResponsesRequest(c);
+    const native = await parseJsonBody(c, traceId);
+    const method = deps.lifecycle?.compact;
+    if (method === undefined) {
+      let ir: ResponsesIRLike;
+      try {
+        ir = deps.transformer.transformRequestOut(native);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : "invalid Responses compact request";
+        throw helmError("invalid_request", detail, traceId);
+      }
+      ir.metadata = { ...(ir.metadata ?? {}), trace_id: traceId };
+      let result: PipelineRunResult;
+      try {
+        result = await deps.pipeline.run(ir, identity, c.req.raw.signal);
+        const collected = await result.collect();
+        return c.json(deps.transformer.transformResponseOut(collected) as Record<string, unknown>);
+      } catch (err) {
+        if (err instanceof PipelineError) throw pipelineToHelm(err, traceId);
+        throw err;
+      }
+    }
+    const body = await method(native, identity, c.req.raw.signal);
+    return c.json(body as Record<string, unknown>);
+  };
+
+  const handleInputTokens = async (c: Context<AppEnv>) => {
+    const traceId = c.get("trace_id");
+    const identity = await authenticateResponsesRequest(c);
+    const native = await parseJsonBody(c, traceId);
+    const providerMethod = deps.lifecycle?.inputTokens;
+    if (providerMethod !== undefined) {
+      const body = await providerMethod(native, identity, c.req.raw.signal);
+      return c.json(body as Record<string, unknown>);
+    }
+    return c.json({ input_tokens: estimateResponsesInputTokens(native), estimated: true });
   };
 
   const handleResponses = async (c: Context<AppEnv>) => {
@@ -457,6 +641,27 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       if (err instanceof PipelineError) throw pipelineToHelm(err, traceId);
       throw err;
     }
+    if (deps.registry !== undefined && typeof body.id === "string" && body.id.length > 0) {
+      const attempt = successfulAttempt(result.decision);
+      await deps.registry.put({
+        responseId: body.id,
+        accountId: identity.accountId,
+        keyId: identity.keyId,
+        providerAlias: typeof attempt?.alias === "string" ? attempt.alias : null,
+        providerName: typeof attempt?.provider_name === "string" ? attempt.provider_name : null,
+        providerModel: typeof attempt?.provider_model === "string" ? attempt.provider_model : null,
+        providerProtocol:
+          attempt?.target_provider_protocol === "openai_chat" ||
+          attempt?.target_provider_protocol === "anthropic_messages" ||
+          attempt?.target_provider_protocol === "openai_responses" ||
+          attempt?.target_provider_protocol === "gemini"
+            ? attempt.target_provider_protocol
+            : null,
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 86_400_000,
+        status: statusFromResponseBody(body),
+      });
+    }
     // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
     // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
     if (deps.record) {
@@ -476,12 +681,12 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
   };
 
   for (const prefix of ["/v1/responses", "/responses", "/openai/v1/responses"]) {
-    app.post(`${prefix}/compact`, unsupportedLifecycle("compact"));
-    app.post(`${prefix}/input_tokens`, unsupportedLifecycle("input_tokens"));
-    app.get(`${prefix}/:response_id/input_items`, unsupportedLifecycle("input_items"));
-    app.post(`${prefix}/:response_id/cancel`, unsupportedLifecycle("cancel"));
-    app.get(`${prefix}/:response_id`, unsupportedLifecycle("retrieve"));
-    app.delete(`${prefix}/:response_id`, unsupportedLifecycle("delete"));
+    app.post(`${prefix}/compact`, handleCompact);
+    app.post(`${prefix}/input_tokens`, handleInputTokens);
+    app.get(`${prefix}/:response_id/input_items`, handleProviderLifecycle("inputItems"));
+    app.post(`${prefix}/:response_id/cancel`, handleProviderLifecycle("cancel"));
+    app.get(`${prefix}/:response_id`, handleProviderLifecycle("retrieve"));
+    app.delete(`${prefix}/:response_id`, handleProviderLifecycle("delete"));
     app.post(prefix, handleResponses);
   }
 }

--- a/apps/gateway/src/server.test.ts
+++ b/apps/gateway/src/server.test.ts
@@ -5,7 +5,7 @@ import { RuntimeSettingsSchema } from "@helm/shared";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import { createExecute } from "./routes/execute.js";
-import { buildRegistry, estimateRequestTokens } from "./server.js";
+import { buildProviderClients, buildRegistry, estimateRequestTokens } from "./server.js";
 
 // A minimal Hono context whose request carries the given content-length header.
 // We never read the body here — the estimator must derive its estimate WITHOUT
@@ -61,6 +61,74 @@ describe("native_protocol_passthrough runtime flag", () => {
     // and openai_chat traffic still falls back to translation inside the guard.
     const parsed = RuntimeSettingsSchema.parse({});
     expect(parsed.native_protocol_passthrough).toBe(true);
+  });
+});
+
+describe("buildProviderClients provider dispatch", () => {
+  it("creates an Anthropic-native client with provider-backed count_tokens", () => {
+    const previous = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = "anthropic-secret";
+    try {
+      const clients = buildProviderClients(
+        [
+          {
+            name: "anthropic",
+            alias: "anthropic",
+            type: "anthropic",
+            base_url: "https://api.anthropic.com",
+            api_key_env: "ANTHROPIC_API_KEY",
+            models: [{ alias: "claude/sonnet", provider_model: "claude-sonnet" }],
+            targetProviderProtocol: "anthropic_messages",
+            map_developer_role_to_system: false,
+            normalize_reasoning_delta_alias: false,
+            response_model_policy: "provider",
+          },
+        ],
+        "https://fallback.invalid",
+        1_000,
+      );
+
+      const client = clients.get("anthropic");
+      expect(client?.nativeProtocolProfile).toBe("anthropic_messages");
+      expect(typeof client?.countTokens).toBe("function");
+    } finally {
+      if (previous === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = previous;
+    }
+  });
+
+  it("creates a Gemini-native client for provider type gemini", () => {
+    const previous = process.env.GEMINI_API_KEY;
+    process.env.GEMINI_API_KEY = "gemini-secret";
+    try {
+      const clients = buildProviderClients(
+        [
+          {
+            name: "google",
+            alias: "google",
+            type: "gemini",
+            base_url: "https://generativelanguage.googleapis.com/v1beta",
+            api_key_env: "GEMINI_API_KEY",
+            models: [{ alias: "gemini/flash", provider_model: "gemini-2.0-flash" }],
+            targetProviderProtocol: "gemini",
+            map_developer_role_to_system: false,
+            normalize_reasoning_delta_alias: false,
+            response_model_policy: "provider",
+          },
+        ],
+        "https://fallback.invalid",
+        1_000,
+      );
+
+      const client = clients.get("google");
+      expect(client?.nativeProtocolProfile).toBe("gemini");
+      expect(typeof client?.nativePassthrough).toBe("function");
+      expect(typeof client?.nativePassthroughStream).toBe("function");
+      expect(typeof client?.countTokens).toBe("function");
+    } finally {
+      if (previous === undefined) delete process.env.GEMINI_API_KEY;
+      else process.env.GEMINI_API_KEY = previous;
+    }
   });
 });
 
@@ -138,6 +206,8 @@ describe("buildRegistry backfill metadata through execute", () => {
           models: [],
           targetProviderProtocol: "anthropic_messages",
           map_developer_role_to_system: false,
+          normalize_reasoning_delta_alias: false,
+          response_model_policy: "provider",
         },
       ],
       "anthropic",
@@ -200,6 +270,8 @@ describe("buildRegistry backfill metadata through execute", () => {
           // The compatibility shim disables verbatim passthrough — even though the
           // provider implements nativePassthrough and the protocols match.
           map_developer_role_to_system: true,
+          normalize_reasoning_delta_alias: false,
+          response_model_policy: "provider",
         },
       ],
       "anthropic",

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1847,9 +1847,39 @@ export async function buildServer(
     return null;
   };
   const responsesRegistryStore = new Map<string, ResponsesRegistryRecord>();
+  // Bound the process-local registry: expired/deleted entries are swept periodically
+  // (not only on a same-id get), and a hard cap evicts the oldest insertions so a
+  // long-running gateway that creates many never-retrieved response ids cannot grow
+  // without limit. (Best-effort, single-process; a Store-backed registry would persist.)
+  const REGISTRY_MAX_ENTRIES = 10_000;
+  const REGISTRY_PRUNE_EVERY = 256;
+  let registryPutsSincePrune = 0;
+  const pruneResponsesRegistry = (now: number): void => {
+    for (const [id, record] of responsesRegistryStore) {
+      if (record.expiresAt <= now || record.status === "deleted") {
+        responsesRegistryStore.delete(id);
+      }
+    }
+    if (responsesRegistryStore.size > REGISTRY_MAX_ENTRIES) {
+      let excess = responsesRegistryStore.size - REGISTRY_MAX_ENTRIES;
+      for (const id of responsesRegistryStore.keys()) {
+        if (excess <= 0) break;
+        responsesRegistryStore.delete(id); // Map preserves insertion order → drop oldest
+        excess -= 1;
+      }
+    }
+  };
   const responsesRegistry: ResponsesRouteDeps["registry"] = {
     put(record) {
       responsesRegistryStore.set(record.responseId, record);
+      registryPutsSincePrune += 1;
+      if (
+        registryPutsSincePrune >= REGISTRY_PRUNE_EVERY ||
+        responsesRegistryStore.size > REGISTRY_MAX_ENTRIES
+      ) {
+        registryPutsSincePrune = 0;
+        pruneResponsesRegistry(Date.now());
+      }
     },
     get(responseId, identity) {
       const record = responsesRegistryStore.get(responseId);

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -12,6 +12,8 @@ import {
   createCachedKeyStore,
   createCircuitBreaker,
   createCodexResponsesClient,
+  createGeminiClient,
+  createGenericOpenAIResponsesClient,
   createKeyedSemaphore,
   createKeyedSerialGate,
   createMemoryMomentumStore,
@@ -86,7 +88,7 @@ import type {
   RuntimeSettings,
   TargetProviderProtocol,
 } from "@helm/shared";
-import { ErrorClassSchema, isOAuthPreset } from "@helm/shared";
+import { ErrorClassSchema, isOAuthPreset, makeHelmError } from "@helm/shared";
 import { createApp } from "./app.js";
 import { readBuildInfo } from "./build-info.js";
 import { createJsonLogger, type Logger } from "./logging.js";
@@ -94,6 +96,7 @@ import { createMemoryLlmRuntime, type MemoryModelResolution } from "./memory-llm
 import { authMiddleware } from "./middleware/auth.js";
 import { basicAuth, resolveAdminAuth, warnIfAdminUnconfigured } from "./middleware/basic-auth.js";
 import { concurrencyMiddleware, createConcurrencyGate } from "./middleware/concurrency.js";
+import { HelmHttpError } from "./middleware/error-handler.js";
 import { estimateRequestTokens } from "./middleware/estimate-tokens.js";
 import { type RateLimiterPort, rateLimitMiddleware } from "./middleware/rate-limit.js";
 import {
@@ -117,7 +120,11 @@ import type { MessagesIdentity, RouteError } from "./routes/messages.js";
 import { registerMessagesRoute } from "./routes/messages.js";
 import { createMessagesPipeline } from "./routes/messages-pipeline.js";
 import { registerModelsRoute } from "./routes/models.js";
-import { registerResponsesRoute } from "./routes/responses.js";
+import {
+  type ResponsesRegistryRecord,
+  type ResponsesRouteDeps,
+  registerResponsesRoute,
+} from "./routes/responses.js";
 import {
   markServingAccount,
   type ServingAccount,
@@ -688,6 +695,35 @@ function createProviderClient(
       fetch: proxyFetch,
     });
   }
+  if (
+    p.type === "openai-responses" ||
+    p.type === "openai-responses-generic" ||
+    p.type === "openai_responses_generic"
+  ) {
+    return createGenericOpenAIResponsesClient({
+      config: { ...base, ...cred },
+      fetch: proxyFetch,
+    });
+  }
+  if (p.type === "gemini") {
+    return createGeminiClient({
+      config: {
+        ...base,
+        ...cred,
+        remoteMediaFetch:
+          p.remote_media_fetch !== undefined
+            ? {
+                enabled: p.remote_media_fetch.enabled,
+                maxBytes: p.remote_media_fetch.max_bytes,
+                timeoutMs: p.remote_media_fetch.timeout_ms,
+                maxRedirects: p.remote_media_fetch.max_redirects,
+                allowedMimeTypes: p.remote_media_fetch.allowed_mime_types,
+              }
+            : undefined,
+      },
+      fetch: proxyFetch,
+    });
+  }
   // GitHub Copilot is OpenAI-compatible, BUT: (1) it requires editor identity
   // headers on every call, and (2) its API host comes from the current token's
   // `proxy-ep` (the short-lived Copilot token rotates, so the host can change).
@@ -707,6 +743,7 @@ function createProviderClient(
         ...cred,
         extraHeaders: () => ({ ...COPILOT_HEADERS }),
         mapDeveloperRoleToSystem: p.map_developer_role_to_system,
+        normalizeReasoningDeltaAlias: p.normalize_reasoning_delta_alias,
         resolveBaseUrl: async () =>
           getGitHubCopilotBaseUrl((await getAuth()).replace(/^Bearer /, "")),
       },
@@ -714,7 +751,12 @@ function createProviderClient(
     });
   }
   return createOpenAIClient({
-    config: { ...base, ...cred, mapDeveloperRoleToSystem: p.map_developer_role_to_system },
+    config: {
+      ...base,
+      ...cred,
+      mapDeveloperRoleToSystem: p.map_developer_role_to_system,
+      normalizeReasoningDeltaAlias: p.normalize_reasoning_delta_alias,
+    },
     fetch: proxyFetch,
   });
 }
@@ -1470,6 +1512,7 @@ export async function buildServer(
     // post-served settle, threaded from the composition root.
     budgetGate,
     settleBudget: settleKeyBudget,
+    responseModelPolicy: first.response_model_policy,
     // e2e-only: allow the `x-helm-eval` header to toggle Layer-2 eval per request
     // so the eval cascade can be black-boxed without a config reload. Production
     // leaves HELM_E2E unset → eval stays config-driven (fail-closed, principle 2).
@@ -1652,6 +1695,18 @@ export async function buildServer(
     recordOAuthUsage,
     writeQueue,
   );
+  const anthropicCountClient = (): ProviderClient | null => {
+    for (const client of providerClients.values()) {
+      if (
+        client.nativeProtocolProfile === "anthropic_messages" &&
+        typeof client.countTokens === "function"
+      ) {
+        return client;
+      }
+    }
+    return null;
+  };
+  const anthropicCountProvider = anthropicCountClient();
   // Inject the SAME per-key limiter instance the chat surface uses so the
   // Anthropic /v1/messages handler can meter per-key AFTER its self-auth (closes
   // the rate-limit bypass on /v1/messages + /v1/responses). The Wave2 handlers
@@ -1667,6 +1722,15 @@ export async function buildServer(
     // SAME process-wide gate as the chat middleware (issue #93): a key's
     // in-flight count spans every surface.
     concurrencyGate,
+    ...(anthropicCountProvider?.countTokens
+      ? {
+          countTokens: async (body, _identity, signal) => {
+            const client = anthropicCountClient();
+            if (!client?.countTokens) throw new Error("Anthropic countTokens provider unavailable");
+            return await client.countTokens(body, { signal });
+          },
+        }
+      : {}),
     auth: {
       resolve: async (credential): Promise<MessagesIdentity | null> => {
         if (credential === null) return null;
@@ -1763,6 +1827,88 @@ export async function buildServer(
     recordOAuthUsage,
     writeQueue,
   );
+  const responsesClientWith = (
+    method:
+      | "responsesRetrieve"
+      | "responsesDelete"
+      | "responsesCancel"
+      | "responsesInputItems"
+      | "responsesCompact"
+      | "responsesInputTokens",
+    providerName?: string | null,
+  ): ProviderClient | null => {
+    if (providerName !== undefined && providerName !== null) {
+      const client = providerClients.get(providerName);
+      return client !== undefined && typeof client[method] === "function" ? client : null;
+    }
+    for (const client of providerClients.values()) {
+      if (typeof client[method] === "function") return client;
+    }
+    return null;
+  };
+  const responsesRegistryStore = new Map<string, ResponsesRegistryRecord>();
+  const responsesRegistry: ResponsesRouteDeps["registry"] = {
+    put(record) {
+      responsesRegistryStore.set(record.responseId, record);
+    },
+    get(responseId, identity) {
+      const record = responsesRegistryStore.get(responseId);
+      if (record === undefined) return null;
+      if (record.accountId !== identity.accountId || record.keyId !== identity.keyId) return null;
+      if (record.expiresAt <= Date.now() || record.status === "deleted") {
+        responsesRegistryStore.delete(responseId);
+        return null;
+      }
+      return record;
+    },
+  };
+  const responsesLifecycleUnsupported = (operation: string): HelmHttpError =>
+    new HelmHttpError(
+      makeHelmError({
+        error_class: "capability_unsatisfiable",
+        message: `Responses ${operation} is not supported by the selected provider`,
+        trace_id: "responses_lifecycle",
+      }),
+    );
+  const responsesLifecycle: ResponsesRouteDeps["lifecycle"] = {};
+  responsesLifecycle.retrieve = async (responseId, _identity, signal, record) => {
+    const client = responsesClientWith("responsesRetrieve", record?.providerName);
+    if (!client?.responsesRetrieve) throw responsesLifecycleUnsupported("retrieve");
+    return await client.responsesRetrieve(responseId, { signal });
+  };
+  responsesLifecycle.delete = async (responseId, _identity, signal, record) => {
+    const client = responsesClientWith("responsesDelete", record?.providerName);
+    if (!client?.responsesDelete) throw responsesLifecycleUnsupported("delete");
+    return await client.responsesDelete(responseId, { signal });
+  };
+  responsesLifecycle.cancel = async (responseId, _identity, signal, record) => {
+    const client = responsesClientWith("responsesCancel", record?.providerName);
+    if (!client?.responsesCancel) throw responsesLifecycleUnsupported("cancel");
+    return await client.responsesCancel(responseId, { signal });
+  };
+  responsesLifecycle.inputItems = async (responseId, _identity, signal, record) => {
+    const client = responsesClientWith("responsesInputItems", record?.providerName);
+    if (!client?.responsesInputItems) {
+      throw responsesLifecycleUnsupported("input_items");
+    }
+    return await client.responsesInputItems(responseId, { signal });
+  };
+  if (responsesClientWith("responsesCompact")?.responsesCompact) {
+    responsesLifecycle.compact = async (body, _identity, signal) => {
+      const client = responsesClientWith("responsesCompact");
+      if (!client?.responsesCompact) throw new Error("Responses compact provider unavailable");
+      return await client.responsesCompact(body as Record<string, unknown>, { signal });
+    };
+  }
+  if (responsesClientWith("responsesInputTokens")?.responsesInputTokens) {
+    responsesLifecycle.inputTokens = async (body, _identity, signal) => {
+      const client = responsesClientWith("responsesInputTokens");
+      if (!client?.responsesInputTokens) {
+        throw new Error("Responses input_tokens provider unavailable");
+      }
+      return await client.responsesInputTokens(body as Record<string, unknown>, { signal });
+    };
+  }
   registerResponsesRoute(app, {
     // Same per-key limiter, same cast rationale as the messages route above —
     // closes the rate-limit bypass on /v1/responses.
@@ -1822,6 +1968,8 @@ export async function buildServer(
       },
     },
     pipeline: responsesPipeline,
+    lifecycle: responsesLifecycle,
+    registry: responsesRegistry,
     // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
     // chat route uses, so /v1/responses records served requests like /v1/chat does.
     record: {
@@ -1848,9 +1996,27 @@ export async function buildServer(
     recordOAuthUsage,
     writeQueue,
   );
+  const geminiCountClient = (): ProviderClient | null => {
+    for (const client of providerClients.values()) {
+      if (client.nativeProtocolProfile === "gemini" && typeof client.countTokens === "function") {
+        return client;
+      }
+    }
+    return null;
+  };
+  const geminiCountProvider = geminiCountClient();
   registerGeminiRoute(app, {
     rateLimiter,
     concurrencyGate,
+    ...(geminiCountProvider?.countTokens
+      ? {
+          countTokens: async (body, _identity, signal) => {
+            const client = geminiCountClient();
+            if (!client?.countTokens) throw new Error("Gemini countTokens provider unavailable");
+            return await client.countTokens(body, { signal });
+          },
+        }
+      : {}),
     auth: {
       resolve: async (credential): Promise<MessagesIdentity | null> => {
         if (credential === null) return null;

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -14,27 +14,33 @@
 - **澄清（非 bug，未改行为）**：chat route 对缺失/空 `messages` 的 400 是 `OpenAIChatRequestSchema.safeParse` 在 route 边界先于 `toInternalRequest` 拦下（main commit b2d3076 既有，schema 要求非空 messages），并非本 PR 收紧——曾试加宽松 fallback，确认是 dead code 后回退、仅留澄清注释。
 - **已知限制（保留，非本轮修）**：Responses registry 仅在非流式响应路径写入（流式 response id 在 SSE 帧内，未提取）；registry 仍是进程内 Map，重启不留、多实例不共享——后续若需，提升为 Store 端口。
 - **验证**：TDD 红→绿（payload-capture +9、messages-pipeline +6 Gemini passthrough 预算/记忆回归、gemini provider +4 SSRF、openai-responses +2 tool_calls）；新增 ast gate（5-arg materializer 签名 + `assertPublicHttpsTarget`）；`typecheck`/`lint`/`test:protocol-compat:ast` 绿，changed-area 512 tests 绿。
+- **Codex review round 2（同 PR 6 项再修，原则 2/3/7）**：① **P1 Gemini 翻译路径**——Gemini client 的 `chatCompletion`/`chatCompletionStream` 原本恒 throw，导致非 Gemini 客户端路由到 Gemini provider（混合 lane）或关闭 passthrough 时整条 attempt 失败；改为经 transformer 组合翻译 OpenAI-Chat ⇄ Gemini（`openaiTransformer.transformRequestOut`→`geminiTransformer.transformRequestIn`→fetch→`transformResponseIn`→`openaiTransformer.transformResponseOut`；流式 Gemini SSE→`transformStreamIn`→OpenAI chunk+`[DONE]`），返回 OpenAI 形态供 pipeline 消费。② **P1 DNS 钉死（rebinding）**——guard 解析校验后 `fetch` 会二次解析；新增独立 `mediaFetch`（默认 `node:https`，`lookup` 钉死到已校验地址、SNI 仍按真实 hostname 验证），`assertPublicHttpsTarget` 返回 pinned 地址逐 hop 钉死（无 undici 依赖）。③ **P1 静态 key 脱敏**——generic Responses `scrub()` 补 `cfg.apiKey` 进脱敏集，防上游 error body 回显泄露。④ **P2 媒体边读边限**——`readBodyWithLimit` 用 `readChunkWithIdle` 流式读 + 超限即 abort（不再先 `arrayBuffer()` 全量分配）。⑤ **P2 401 重建头**——generic Responses 401 重试前 `providerHeaders()` 重取刷新后 token。⑥ **P2 registry 有界**——周期清理过期项 + 1 万条硬上限 LRU 淘汰。验证：TDD 新增 gemini +4 / openai-responses +2；`typecheck`/`lint`/ast 绿，changed-area 474 tests 绿。
 
-## 2026-06-14 · LiteLLM 协议互译剩余项完成（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）
+## 2026-06-14 · Claude OAuth web 登录改用 console callback「copy code」流（docs/06；原则 1/7）
 
-- **背景**：继续完成 LiteLLM 对照 spec 剩余 P1/P2 项，目标是 native/same-protocol 尽量保真，跨协议不可表达能力必须有 guard/warning，不再靠隐式 404、假成功或提前丢字段。
-- **核心改动**：Anthropic 与 Gemini token helper 改 provider-first + estimated fallback；Responses `previous_response_id` 入站不再提前拒绝，同协议 native passthrough 记录正向 mutation，跨协议 continuation/native tools/background fail-closed；Responses `input_tokens`、registry-bound retrieve/delete/cancel/input_items、`compact` provider 或正常 routing fallback 已接线；Gemini native provider 支持 generate/stream/countTokens，`parametersJsonSchema`/`responseJsonSchema`/Google GenAI raw params 保真；OpenAI Chat `response_model_policy` 覆盖非流式与流式 chunk；Gemini remote media fetch 新增 provider 层 materializer（默认关闭，https-only，大小/mime/timeout/redirect 限制），关闭时记录 `remote_media_not_materialized`。
-- **取舍 / 坑**：Responses object registry 目前是进程内 Map，并检查 account/key、`expiresAt`、`status`；这满足单进程生命周期 dispatch 与防串号，但重启不保留，后续若要多实例/重启后 retrieve，应把 registry 提升为 Store 端口 + SQLite/Postgres migration。Gemini remote media materializer 在 provider 层实现，core transformer 继续纯函数、无 fetch/http import。
-- **验证**：TDD 红→绿；新增/收紧 `pnpm test:protocol-compat:ast` gates，覆盖 previous_response_id、lifecycle stub、Gemini countTokens/profile、Anthropic token-counting beta、response_model_policy、remote media materializer、file_search guard 与 core transformer 无网络 I/O。focused suites、`lint`、`typecheck`、`build`、`test` 均已通过；`test:e2e` 仅剩 memory inject 2 个既有失败，protocol/gemini e2e slice 23/23 绿。
+- **背景**：admin web UI 连接 Claude 订阅时，authorize URL 的 `redirect_uri` 写死 `http://localhost:53692/callback`；批准后浏览器跳到该 localhost 死链（web 环境无回调服务器），运营者要从地址栏抠出报错 URL 粘回——困惑。参考用户指定的 `claude-relay-service`：它用 Anthropic 托管的 console callback，批准后页面**直接显示授权码**（`<code>#<state>`）供复制，干净的 "copy code" 流。
+- **核心改动（外科手术式，仅 Anthropic）**：`provider/oauth/anthropic.ts` 新增 `CONSOLE_REDIRECT_URI="https://platform.claude.com/oauth/code/callback"`，`exchangeAuthorizationCode` 参数化 `redirectUri`；**web 路**（`beginAnthropicLogin` 授权 URL + `completeAnthropicLogin` 交换）改用 console callback，**CLI 路**（`loginAnthropic`）保留 localhost 回调服务器（自动捕获是最佳 CLI UX、且非用户抱怨点）。两路 redirect_uri 现刻意分叉——授权 URL 与 token 交换必须用同一值否则 grant 被拒。admin 编排（`admin-oauth.ts` `MANUAL_FLOWS`）零改（begin/complete 签名不变）。
+- **关键发现（少改两处）**：① `parseOAuthAuthorizationInput`（runtime.ts）**早已**支持 `code#state` 格式（console 页展示形态），无需改 parser；② helm 授权 URL **早已**带 `code=true`（请求 Anthropic 渲染码页），唯一坏的就是 redirect_uri，所以是单点修复。
+- **UI**：`ConnectProviderDialog.svelte` 加 `isAnthropic` 派生，manual 步骤对 Anthropic 改文案「复制页面上显示的授权码」+ 占位符，Codex 仍是「复制重定向 URL」；新增 3 条 i18n 串补 en/zh-hans/zh-hant/ja/ko。
+- **取舍/TODO**：Codex web 流同有 localhost 死链，但 OpenAI 无等价托管码页，本轮**不动 Codex**（已知 follow-up）。redirect_uri 必须是 client_id `9d1c250a-…` 注册的回调——relay 用同一 client_id/scopes/`code=true` 配同值、helm token 端点本就 `platform.claude.com`，高置信被接受；最终需真订阅 admin 手验。
+- **验证**：TDD 红→绿——`web-login.test.ts` 钉死 begin/complete 的 console redirect_uri + `code#state` 粘贴，`anthropic.test.ts` 钉死 CLI 仍用 localhost。core OAuth + gateway OAuth 全绿（202）、typecheck/lint 绿、svelte-check 仅剩既有 `oauth.test.ts` 3 报错（非回归）。分支 `worktree-claude-oauth-copy-code`（git worktree）。
 
-## 2026-06-14 · 移除「协议直通」设置 UI，保持运行时默认 ON（issue #236；原则 1/2）
+## 2026-06-14 · 评估并否决引入 `@earendil-works/pi-ai` 替换 OAuth 实现（原则 1/6；docs/02/06/11）
 
-- **背景**：Admin → System Settings 的「Protocol passthrough / 协议直通」开关（`data-testid=native-protocol-passthrough`，默认勾选）让用户手动开关 `native_protocol_passthrough`；用户拍板**只删 UI**，不改 gateway runtime 行为、不把默认改成 false（schema `z.boolean().default(true)` 不动）。
-- **核心改动（纯前端，5 文件）**：① `routes/settings/+page.svelte` 删整块「Protocol passthrough」section（checkbox + 两段说明），并改 DEFAULTS 注释；② `lib/api/settings.ts` **保留** `native_protocol_passthrough` 字段、type 与 `normalize()` 的 `!== false` 默认（仅补注释说明 UI 已删但字段留作 round-trip）；③ 删 en/zh-hans/zh-hant 三处各 4 条 i18n 串（ja/ko 本就没有这些串、运行时回退英文 key）。
-- **关键决定（为何保留字段而非一并删）**：删 UI 但字段留在数据模型——form 从 GET 载入该值、Save 时原样 PUT 回去，保证 GET→form→PUT round-trip 不变、**绝不在保存其它设置时被静默重置为 false**（#225 教训，`settings.test.ts` 的 "preserves native protocol passthrough when saving an unrelated field" 用例钉死）。若改为删字段靠后端 `.default(true)` 兜底，会在每次 PUT 把运营者显式设的 false 强制翻 true（覆盖 overlay），语义更糟。
-- **验证**：admin vitest `settings.test.ts`(5) + `dashboard-locales.test.ts`(4) 全绿；`prettier --check` 改动文件绿；admin `pnpm build` 绿。svelte-check 仅剩 `oauth.test.ts` 3 处**既有**报错（vi.fn mock.calls 元组类型，来自 v0.12.11 连通性测试特性，与本改动无关、与 origin/main 逐字相同，且 admin 不在 `-r typecheck` CI 门禁）。分支 `worktree-issue-236-remove-passthrough-ui`（git worktree）。
-- **TODO**：未 commit/push（用户要求时再做）；若后续要彻底下线 passthrough，再单独决定是否从 schema/数据模型移除该字段。
+- **背景**：用户想直接引入 pi-coding-agent 同源的 `@earendil-works/pi-ai`（npm，v0.79.3）当 SDK，外包「登录各家 AI（OAuth）」的协议代码，并「支持它支持的所有 OAuth provider」。
+- **调研结论（决策依据）**：① pi-ai 内置 OAuth provider 正好 3 个（`anthropic`/`openai-codex`/`github-copilot`，见 `packages/ai/src/utils/oauth/index.ts` 的 `BUILT_IN_OAUTH_PROVIDERS`）——与 helm 现支持的**完全一致**，无 Gemini/Qwen；pi 文档里「很多 Supported Providers」绝大多数是 **API-key** 类（Gemini/DeepSeek/Mistral/Groq/xAI/OpenRouter/Bedrock…），不是 OAuth。② helm 两层都已覆盖：API-key 改 `config/providers.yaml` 加 `api_key_env` 即可（零代码，已接 DeepSeek/ZenMux/OpenRouter）；OAuth 三家已实现（加密 token 存储/多账号池/代理/调度/admin UI 登录）。③ 形态失配：pi-ai 公开 API 只有「阻塞式 `login*()`（内部强制绑本地回调端口 53692/1455，Anthropic 端口占用即 `reject`）+ `refresh*Token()`」，**不导出** `exchangeAuthorizationCode`/`generatePKCE`；helm 专门写了 `web-login.ts` 做无状态 begin/complete，正因 CLI 流程不适合 web 管理界面。④ 二者**同源**（都出自 openclaw 血统，authorize URL/client_id/token URL/PKCE 近乎一字不差），引入不是「换更好代码」而是「换更不顺手形态 + 加一层桥接 + 运行时绑端口」。
+- **决定（用户拍板「那就不动了」）**：**不引入依赖、保持现状**，无代码改动、无 worktree。唯一真实收益（端点/client_id/未来新 provider 维护外包给上游）不足以抵消「写 ~500–900 行桥接 + 删 ~1.5k 行有测试覆盖的同源协议代码」的净风险（净风险为负）。
+- **TODO / 重评触发条件**：若 pi-ai 日后新增**真正的 OAuth**（非 API-key）provider（如 Gemini/Qwen 订阅登录），再评估「仅接管 `refresh*Token`」这一最小边界（不碰 helm 的 web 登录编排）。现有 helm OAuth 协议代码全部保留：`packages/core/src/provider/oauth/*`（web-login/anthropic/openai-codex/github-copilot/runtime）+ 存储/池/admin/UI。
 
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-14 · LiteLLM 协议互译剩余项完成（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）：Anthropic/Gemini token helper 改 provider-first + 估算兜底；Responses `previous_response_id` 不再入站拒绝（同协议直通、跨协议 fail-closed）；Responses input_tokens / registry-bound retrieve/delete/cancel/input_items / compact 接线；Gemini native provider（generate/stream/countTokens、parametersJsonSchema/responseJsonSchema/google_genai 保真）；OpenAI Chat response_model_policy；Gemini remote media materializer（默认关）。后续 review 两轮修治理/SSRF/翻译路径（见顶部完整条目）。
+
+### 2026-06-14 · 移除「协议直通」设置 UI，保持运行时默认 ON（issue #236；原则 1/2）：删 admin System Settings 的 `native_protocol_passthrough` 开关 UI（纯前端 5 文件），schema/字段/runtime 默认 `true` 不动（保字段防 PUT round-trip 静默重置为 false，#225 教训）；i18n 删 en/zh-hans/zh-hant 各 4 串。
 
 ### 2026-06-14 · 原生直通按 attempt 判断 + Anthropic SSE 元数据修复（docs/02/05；原则 5/7/8）：native passthrough guard 改为只判当前 attempt（删除 lookahead 后续 fallback 协议的整链否决），Anthropic head 可直通、首包前失败再翻译 fallback；`convertOpenAIStreamToAnthropic` 的 `message_start` 不再发空 id/model（取首 chunk，缺失用 request_id/provider_model 兜底成 `msg_*`）。focused 96 tests 绿。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,21 +7,12 @@
 
 ---
 
-## 2026-06-14 · Claude OAuth web 登录改用 console callback「copy code」流（docs/06；原则 1/7）
+## 2026-06-14 · LiteLLM 协议互译剩余项完成（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）
 
-- **背景**：admin web UI 连接 Claude 订阅时，authorize URL 的 `redirect_uri` 写死 `http://localhost:53692/callback`；批准后浏览器跳到该 localhost 死链（web 环境无回调服务器），运营者要从地址栏抠出报错 URL 粘回——困惑。参考用户指定的 `claude-relay-service`：它用 Anthropic 托管的 console callback，批准后页面**直接显示授权码**（`<code>#<state>`）供复制，干净的 "copy code" 流。
-- **核心改动（外科手术式，仅 Anthropic）**：`provider/oauth/anthropic.ts` 新增 `CONSOLE_REDIRECT_URI="https://platform.claude.com/oauth/code/callback"`，`exchangeAuthorizationCode` 参数化 `redirectUri`；**web 路**（`beginAnthropicLogin` 授权 URL + `completeAnthropicLogin` 交换）改用 console callback，**CLI 路**（`loginAnthropic`）保留 localhost 回调服务器（自动捕获是最佳 CLI UX、且非用户抱怨点）。两路 redirect_uri 现刻意分叉——授权 URL 与 token 交换必须用同一值否则 grant 被拒。admin 编排（`admin-oauth.ts` `MANUAL_FLOWS`）零改（begin/complete 签名不变）。
-- **关键发现（少改两处）**：① `parseOAuthAuthorizationInput`（runtime.ts）**早已**支持 `code#state` 格式（console 页展示形态），无需改 parser；② helm 授权 URL **早已**带 `code=true`（请求 Anthropic 渲染码页），唯一坏的就是 redirect_uri，所以是单点修复。
-- **UI**：`ConnectProviderDialog.svelte` 加 `isAnthropic` 派生，manual 步骤对 Anthropic 改文案「复制页面上显示的授权码」+ 占位符，Codex 仍是「复制重定向 URL」；新增 3 条 i18n 串补 en/zh-hans/zh-hant/ja/ko。
-- **取舍/TODO**：Codex web 流同有 localhost 死链，但 OpenAI 无等价托管码页，本轮**不动 Codex**（已知 follow-up）。redirect_uri 必须是 client_id `9d1c250a-…` 注册的回调——relay 用同一 client_id/scopes/`code=true` 配同值、helm token 端点本就 `platform.claude.com`，高置信被接受；最终需真订阅 admin 手验。
-- **验证**：TDD 红→绿——`web-login.test.ts` 钉死 begin/complete 的 console redirect_uri + `code#state` 粘贴，`anthropic.test.ts` 钉死 CLI 仍用 localhost。core OAuth + gateway OAuth 全绿（202）、typecheck/lint 绿、svelte-check 仅剩既有 `oauth.test.ts` 3 报错（非回归）。分支 `worktree-claude-oauth-copy-code`（git worktree）。
-
-## 2026-06-14 · 评估并否决引入 `@earendil-works/pi-ai` 替换 OAuth 实现（原则 1/6；docs/02/06/11）
-
-- **背景**：用户想直接引入 pi-coding-agent 同源的 `@earendil-works/pi-ai`（npm，v0.79.3）当 SDK，外包「登录各家 AI（OAuth）」的协议代码，并「支持它支持的所有 OAuth provider」。
-- **调研结论（决策依据）**：① pi-ai 内置 OAuth provider 正好 3 个（`anthropic`/`openai-codex`/`github-copilot`，见 `packages/ai/src/utils/oauth/index.ts` 的 `BUILT_IN_OAUTH_PROVIDERS`）——与 helm 现支持的**完全一致**，无 Gemini/Qwen；pi 文档里「很多 Supported Providers」绝大多数是 **API-key** 类（Gemini/DeepSeek/Mistral/Groq/xAI/OpenRouter/Bedrock…），不是 OAuth。② helm 两层都已覆盖：API-key 改 `config/providers.yaml` 加 `api_key_env` 即可（零代码，已接 DeepSeek/ZenMux/OpenRouter）；OAuth 三家已实现（加密 token 存储/多账号池/代理/调度/admin UI 登录）。③ 形态失配：pi-ai 公开 API 只有「阻塞式 `login*()`（内部强制绑本地回调端口 53692/1455，Anthropic 端口占用即 `reject`）+ `refresh*Token()`」，**不导出** `exchangeAuthorizationCode`/`generatePKCE`；helm 专门写了 `web-login.ts` 做无状态 begin/complete，正因 CLI 流程不适合 web 管理界面。④ 二者**同源**（都出自 openclaw 血统，authorize URL/client_id/token URL/PKCE 近乎一字不差），引入不是「换更好代码」而是「换更不顺手形态 + 加一层桥接 + 运行时绑端口」。
-- **决定（用户拍板「那就不动了」）**：**不引入依赖、保持现状**，无代码改动、无 worktree。唯一真实收益（端点/client_id/未来新 provider 维护外包给上游）不足以抵消「写 ~500–900 行桥接 + 删 ~1.5k 行有测试覆盖的同源协议代码」的净风险（净风险为负）。
-- **TODO / 重评触发条件**：若 pi-ai 日后新增**真正的 OAuth**（非 API-key）provider（如 Gemini/Qwen 订阅登录），再评估「仅接管 `refresh*Token`」这一最小边界（不碰 helm 的 web 登录编排）。现有 helm OAuth 协议代码全部保留：`packages/core/src/provider/oauth/*`（web-login/anthropic/openai-codex/github-copilot/runtime）+ 存储/池/admin/UI。
+- **背景**：继续完成 LiteLLM 对照 spec 剩余 P1/P2 项，目标是 native/same-protocol 尽量保真，跨协议不可表达能力必须有 guard/warning，不再靠隐式 404、假成功或提前丢字段。
+- **核心改动**：Anthropic 与 Gemini token helper 改 provider-first + estimated fallback；Responses `previous_response_id` 入站不再提前拒绝，同协议 native passthrough 记录正向 mutation，跨协议 continuation/native tools/background fail-closed；Responses `input_tokens`、registry-bound retrieve/delete/cancel/input_items、`compact` provider 或正常 routing fallback 已接线；Gemini native provider 支持 generate/stream/countTokens，`parametersJsonSchema`/`responseJsonSchema`/Google GenAI raw params 保真；OpenAI Chat `response_model_policy` 覆盖非流式与流式 chunk；Gemini remote media fetch 新增 provider 层 materializer（默认关闭，https-only，大小/mime/timeout/redirect 限制），关闭时记录 `remote_media_not_materialized`。
+- **取舍 / 坑**：Responses object registry 目前是进程内 Map，并检查 account/key、`expiresAt`、`status`；这满足单进程生命周期 dispatch 与防串号，但重启不保留，后续若要多实例/重启后 retrieve，应把 registry 提升为 Store 端口 + SQLite/Postgres migration。Gemini remote media materializer 在 provider 层实现，core transformer 继续纯函数、无 fetch/http import。
+- **验证**：TDD 红→绿；新增/收紧 `pnpm test:protocol-compat:ast` gates，覆盖 previous_response_id、lifecycle stub、Gemini countTokens/profile、Anthropic token-counting beta、response_model_policy、remote media materializer、file_search guard 与 core transformer 无网络 I/O。focused suites、`lint`、`typecheck`、`build`、`test` 均已通过；`test:e2e` 仅剩 memory inject 2 个既有失败，protocol/gemini e2e slice 23/23 绿。
 
 ## 2026-06-14 · 移除「协议直通」设置 UI，保持运行时默认 ON（issue #236；原则 1/2）
 
@@ -31,15 +22,22 @@
 - **验证**：admin vitest `settings.test.ts`(5) + `dashboard-locales.test.ts`(4) 全绿；`prettier --check` 改动文件绿；admin `pnpm build` 绿。svelte-check 仅剩 `oauth.test.ts` 3 处**既有**报错（vi.fn mock.calls 元组类型，来自 v0.12.11 连通性测试特性，与本改动无关、与 origin/main 逐字相同，且 admin 不在 `-r typecheck` CI 门禁）。分支 `worktree-issue-236-remove-passthrough-ui`（git worktree）。
 - **TODO**：未 commit/push（用户要求时再做）；若后续要彻底下线 passthrough，再单独决定是否从 schema/数据模型移除该字段。
 
+## 2026-06-14 · 原生直通按 attempt 判断 + Anthropic SSE 元数据修复（docs/02/05；原则 5/7/8）
+
+- **背景**：线上 tuned `claude-opus -> premium` 链被 `fallback_may_change_provider_protocol` 整链否决，导致首个 Anthropic→Anthropic attempt 也被迫走翻译；这会放大 Anthropic SSE 翻译瑕疵并拖慢 Claude Code。用户明确要求保持 lanes 不变，只修代码。
+- **核心改动**：① native passthrough guard 删除“后续 fallback 可能跨协议”的输入与禁用原因，改为只判断**当前 attempt**：source protocol == target provider protocol、runtime flag on、native carrier 存在、provider 支持且无需兼容性 rewrite 即直通；② `execute` 不再 lookahead 解析后续候选，Anthropic head 可以直通，若首包前失败再让后续 `openai_chat` / `openai_responses` fallback 走翻译；③ `convertOpenAIStreamToAnthropic` 的 `message_start` 不再发空 `id/model`，优先取首个 upstream chunk，缺失时用 pipeline 传入的 `request_id/final.provider_model` 兜底并规范成 `msg_*` id。
+- **治理与取舍**：治理路径不变，auth/routing/budget/capture/memory/telemetry 仍先于 execute；`provider_attempts[]` 逐 attempt 记录 `passthrough_used` / `protocol_mismatch`，`final.provider_model` 仍记录实际落点。流式 fallback 只发生在首包前，首包后仍不能换模型，这是既有 contract。
+- **验证**：补回归测试覆盖 heterogeneous chain 的 head Anthropic passthrough、Anthropic passthrough 首包前失败后 fallback 到 translated OpenAI、stream 同场景，以及 translated Anthropic `message_start.id/model` 非空。focused `pnpm exec vitest run packages/core/src/provider/protocol.test.ts apps/gateway/src/routes/execute.test.ts packages/core/src/protocol/anthropic/stream.test.ts` 绿（96 tests）。
+
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
-### 2026-06-14 · 原生直通按 attempt 判断 + Anthropic SSE 元数据修复（docs/02/05；原则 5/7/8）：native passthrough guard 删「后续 fallback 可能跨协议」输入，改为只判**当前 attempt**（source==target protocol + runtime flag on + native carrier 存在 + 无需兼容 rewrite 即直通）；`execute` 不再 lookahead，Anthropic head 可直通、首包前失败再 fallback 到 translated `openai_chat`/`openai_responses`；`convertOpenAIStreamToAnthropic` 的 `message_start` 不再发空 id/model（优先首个 upstream chunk，缺失用 pipeline `request_id`/`final.provider_model` 兜底成 `msg_*`）。治理路径不变、流式 fallback 仅首包前。focused protocol/execute/anthropic-stream 96 绿。
+### 2026-06-14 · OpenAI-compatible reasoning alias opt-in（docs/protocol-translation-litellm-gap-spec P2-CHAT-03/04；原则 7/8）：新增 provider 配置 `normalize_reasoning_delta_alias`，只在显式 opt-in 时把 streaming `choices[].delta.reasoning` 归一为 `reasoning_content`，默认保持 byte-forwarding；后续剩余项已补 `response_model_policy`。
 
-### 2026-06-14 · LiteLLM 协议互译首批 P1 修复（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）：最小高风险修复——`/v1/responses` route 不再重复合成 `response.created`/`in_progress`（只序列化 pipeline 已产 SSE）、`execute.stripInternal` 改 target-protocol-aware（OpenAI target 只转发 OpenAI-compatible provider_raw 并递归删 messages/tools/`cache_control`）、Anthropic native passthrough 发送前 strip 空/非字符串 text block（保 tool_use/media/非空文本，只剩空块的 message 整条省略，ledger 记 `empty_anthropic_text_blocks_stripped`）。取舍：provider_raw/cache_control 过滤暂未接统一 warning ledger（translated path 缺 mutation channel）。TDD 红→绿，focused responses/execute 90 绿、protocol-compat:ast/passthrough:final 绿（真 Claude/Codex CLI trace 证明 native passthrough）；全量 e2e 仍有既存 memory inject 2 红（与协议无关）；标准 test 偶卡 PGlite 5s timeout。
+### 2026-06-14 · LiteLLM 协议互译首批 P1 修复（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）：修 Responses duplicate prelude、target-aware `provider_raw`、Anthropic empty text sanitizer、OpenAI target `cache_control` 清理；focused tests、ast gates、passthrough deterministic/live 当时通过，memory e2e 既有红另记。
 
 ### 2026-06-14 · Subscription Providers 账号「测试」按钮 + 流式连通性检查（docs/06/11；原则 1/3/7）：OAuth『Subscription Providers』页按账号加「Test」按钮（helm 无截图里的 API-key provider 列表，用户拍板按账号测），弹层发单条 user turn 流式**真返回**。后端 TDD 三件：`routes/admin/oauth-test.ts`（`createOpenAiStreamParser` 跨非帧对齐字节重组归一 content/finish/usage、fail-open + `createOAuthAccountTester` 注入 buildClient）、`POST /admin/api/oauth/:provider/test`（streamSSE，无 tester→503/缺参→400/上游失败→**带内 error 事件不 5xx**/断连静默）、`server.ts` 抽 `buildOAuthAccountClient` 与 synthesis 共用且每次测试重载 account proxy。隔离防封号：走全新一次性 client（raw client 本无熔断），**不写 telemetry/不扰生产 pool**，anti-ban 头由 provider client 自动注入故裸 user 请求被 Claude Max/Codex 接受、parked 账号也可测。前端 `streamAccountTest`(永不抛) + `TestAccountDialog.svelte` + i18n 13 串补 en/zh-hans/zh-hant/ja/ko。坑：测试是真实上游调用（真计费、不入 Requests 日志）、只 surface content delta。gateway 732 绿 / admin 358 绿，typecheck/lint/build 绿；oauth.test.ts 3 处 svelte-check 报错为既有非回归。分支 feat/oauth-account-test-button。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-14 · 协议互译剩余项 PR review 修复（review of fix/protocol-litellm-remaining；原则 2/3/7）
+
+- **背景**：对 #251（LiteLLM 协议互译剩余项）做 review，发现 Gemini native passthrough 引入了治理漏洞，并加固远程媒体抓取。三处真实问题修复 + 两处误报澄清。
+- **核心修复**：① **Gemini native passthrough 计费/记忆漏洞**——pipeline `collect()`/`streamIR()` 与 `execute()` 的 usage/记忆提取只分 `openai_responses` vs Anthropic，Gemini 落入 Anthropic 分支 → 把 `usageMetadata` 解析为 0 tokens、且不 observeOutbound（预算/遥测/记忆被绕过，违反原则 2；仅在配置了 `type: gemini` provider 时触发，默认 config 无此 provider）。新增 `usageFromGeminiResponse`/`usageFromGeminiSSE`（promptTokenCount 已含 cache，thoughtsTokenCount 计入 completion）+ `assistantTurnFromNativeGemini`/`accumulateGeminiAssistantText`，三处提取点改 3-way 协议分支（Gemini SSE 的 usageMetadata 累积型，stream tee 只保最后一帧以维持有界内存）。② **远程媒体 SSRF 加固**——`fetchRemoteMediaInlineData` 之前只校验 https，新增 `assertPublicHttpsTarget`：拒绝私有/保留/loopback/link-local/ULA（含 169.254.169.254 元数据端点）IP 字面量 + DNS 解析校验（防 rebinding）+ localhost 主机名，每个 redirect hop 重查；`dnsLookup` 可注入以便 hermetic 测试。③ **Generic Responses→Chat 桥丢工具调用**——`responsesJsonToChatResponse` 之前只取文本、`finish_reason` 恒为 `stop`，现把 `function_call` output 项映射为 chat `tool_calls`、纯工具回合 `content=null`、`finish_reason=tool_calls`。
+- **澄清（非 bug，未改行为）**：chat route 对缺失/空 `messages` 的 400 是 `OpenAIChatRequestSchema.safeParse` 在 route 边界先于 `toInternalRequest` 拦下（main commit b2d3076 既有，schema 要求非空 messages），并非本 PR 收紧——曾试加宽松 fallback，确认是 dead code 后回退、仅留澄清注释。
+- **已知限制（保留，非本轮修）**：Responses registry 仅在非流式响应路径写入（流式 response id 在 SSE 帧内，未提取）；registry 仍是进程内 Map，重启不留、多实例不共享——后续若需，提升为 Store 端口。
+- **验证**：TDD 红→绿（payload-capture +9、messages-pipeline +6 Gemini passthrough 预算/记忆回归、gemini provider +4 SSRF、openai-responses +2 tool_calls）；新增 ast gate（5-arg materializer 签名 + `assertPublicHttpsTarget`）；`typecheck`/`lint`/`test:protocol-compat:ast` 绿，changed-area 512 tests 绿。
+
 ## 2026-06-14 · LiteLLM 协议互译剩余项完成（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）
 
 - **背景**：继续完成 LiteLLM 对照 spec 剩余 P1/P2 项，目标是 native/same-protocol 尽量保真，跨协议不可表达能力必须有 guard/warning，不再靠隐式 404、假成功或提前丢字段。
@@ -22,18 +30,13 @@
 - **验证**：admin vitest `settings.test.ts`(5) + `dashboard-locales.test.ts`(4) 全绿；`prettier --check` 改动文件绿；admin `pnpm build` 绿。svelte-check 仅剩 `oauth.test.ts` 3 处**既有**报错（vi.fn mock.calls 元组类型，来自 v0.12.11 连通性测试特性，与本改动无关、与 origin/main 逐字相同，且 admin 不在 `-r typecheck` CI 门禁）。分支 `worktree-issue-236-remove-passthrough-ui`（git worktree）。
 - **TODO**：未 commit/push（用户要求时再做）；若后续要彻底下线 passthrough，再单独决定是否从 schema/数据模型移除该字段。
 
-## 2026-06-14 · 原生直通按 attempt 判断 + Anthropic SSE 元数据修复（docs/02/05；原则 5/7/8）
-
-- **背景**：线上 tuned `claude-opus -> premium` 链被 `fallback_may_change_provider_protocol` 整链否决，导致首个 Anthropic→Anthropic attempt 也被迫走翻译；这会放大 Anthropic SSE 翻译瑕疵并拖慢 Claude Code。用户明确要求保持 lanes 不变，只修代码。
-- **核心改动**：① native passthrough guard 删除“后续 fallback 可能跨协议”的输入与禁用原因，改为只判断**当前 attempt**：source protocol == target provider protocol、runtime flag on、native carrier 存在、provider 支持且无需兼容性 rewrite 即直通；② `execute` 不再 lookahead 解析后续候选，Anthropic head 可以直通，若首包前失败再让后续 `openai_chat` / `openai_responses` fallback 走翻译；③ `convertOpenAIStreamToAnthropic` 的 `message_start` 不再发空 `id/model`，优先取首个 upstream chunk，缺失时用 pipeline 传入的 `request_id/final.provider_model` 兜底并规范成 `msg_*` id。
-- **治理与取舍**：治理路径不变，auth/routing/budget/capture/memory/telemetry 仍先于 execute；`provider_attempts[]` 逐 attempt 记录 `passthrough_used` / `protocol_mismatch`，`final.provider_model` 仍记录实际落点。流式 fallback 只发生在首包前，首包后仍不能换模型，这是既有 contract。
-- **验证**：补回归测试覆盖 heterogeneous chain 的 head Anthropic passthrough、Anthropic passthrough 首包前失败后 fallback 到 translated OpenAI、stream 同场景，以及 translated Anthropic `message_start.id/model` 非空。focused `pnpm exec vitest run packages/core/src/provider/protocol.test.ts apps/gateway/src/routes/execute.test.ts packages/core/src/protocol/anthropic/stream.test.ts` 绿（96 tests）。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-14 · 原生直通按 attempt 判断 + Anthropic SSE 元数据修复（docs/02/05；原则 5/7/8）：native passthrough guard 改为只判当前 attempt（删除 lookahead 后续 fallback 协议的整链否决），Anthropic head 可直通、首包前失败再翻译 fallback；`convertOpenAIStreamToAnthropic` 的 `message_start` 不再发空 id/model（取首 chunk，缺失用 request_id/provider_model 兜底成 `msg_*`）。focused 96 tests 绿。
 
 ### 2026-06-14 · OpenAI-compatible reasoning alias opt-in（docs/protocol-translation-litellm-gap-spec P2-CHAT-03/04；原则 7/8）：新增 provider 配置 `normalize_reasoning_delta_alias`，只在显式 opt-in 时把 streaming `choices[].delta.reasoning` 归一为 `reasoning_content`，默认保持 byte-forwarding；后续剩余项已补 `response_model_policy`。
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -422,6 +422,11 @@ export {
   openaiToAnthropicRequest,
   translateAnthropicSSE,
 } from "./provider/anthropic.js";
+export {
+  createGeminiClient,
+  type GeminiClientConfig,
+  type GeminiClientDeps,
+} from "./provider/gemini.js";
 // Interactive OAuth subscription-provider kit (issue #38): authorization-code +
 // PKCE / device-code login flows, built-in provider registry (anthropic,
 // github-copilot), and the flow primitives. Ported from openclaw (MIT).
@@ -483,6 +488,8 @@ export {
   type CodexResponsesClientDeps,
   codexAccountIdFromToken,
   createCodexResponsesClient,
+  createGenericOpenAIResponsesClient,
+  type GenericOpenAIResponsesClientDeps,
   openaiToResponsesRequest,
   translateResponsesSSE,
 } from "./provider/openai-responses.js";

--- a/packages/core/src/protocol/anthropic/footguns.test.ts
+++ b/packages/core/src/protocol/anthropic/footguns.test.ts
@@ -70,9 +70,9 @@ describe("footgun #1 — finish/stop enum mismatch never produces an illegal enu
     expect(raw).toBe("totally_made_up_reason");
   });
 
-  it("transformResponseIn lands on a legal stop_reason and stashes the raw in provider_raw", () => {
+  it("transformResponseIn lands on a legal stop_reason without leaking provider_raw", () => {
     // content_filter has no perfect Anthropic equivalent: it must map to a legal enum,
-    // and the raw "content_filter" must survive in provider_raw.stop_reason.
+    // and no Helm-internal raw metadata may leak into the public body.
     const ir: IRResponse = {
       id: "resp_cf",
       model: "gpt-x",
@@ -87,7 +87,7 @@ describe("footgun #1 — finish/stop enum mismatch never produces an illegal enu
     };
     const out = transformResponseIn(ir);
     expect(LEGAL_STOP_REASONS).toContain(out.stop_reason);
-    expect(out.provider_raw?.stop_reason).toBe("content_filter");
+    expect("provider_raw" in out).toBe(false);
   });
 
   it("never produces an illegal enum for a null/empty finish_reason (bottoms out at end_turn)", () => {
@@ -101,8 +101,7 @@ describe("footgun #1 — finish/stop enum mismatch never produces an illegal enu
     const out = transformResponseIn(ir);
     expect(out.stop_reason).toBe("end_turn");
     expect(LEGAL_STOP_REASONS).toContain(out.stop_reason);
-    // raw of a null/absent finish_reason is recorded as "" (the original absence).
-    expect(out.provider_raw?.stop_reason).toBe("");
+    expect("provider_raw" in out).toBe(false);
   });
 });
 

--- a/packages/core/src/protocol/anthropic/response.test.ts
+++ b/packages/core/src/protocol/anthropic/response.test.ts
@@ -13,8 +13,8 @@ import {
 // protocol.anthropic-resp). Two high-risk mismatches are pinned here:
 //   1. finish_reason (OpenAI) <-> stop_reason (Anthropic) enum mapping — an illegal
 //      enum makes the OpenAI SDK drop the whole response; collapsing everything to
-//      `end_turn` makes agents silently misjudge. We map to a LEGAL enum AND stash
-//      the raw value in provider_raw.stop_reason.
+//      `end_turn` makes agents silently misjudge. We map to a LEGAL enum without
+//      leaking Helm-internal provider_raw into the public response body.
 //   2. usage / cached billing — input = prompt - cached (never double-bill cache).
 // Pure function: no network, no framework.
 
@@ -94,7 +94,7 @@ describe("transformResponseIn", () => {
     expect(out.role).toBe("assistant");
   });
 
-  it("maps finish_reason -> stop_reason AND stashes the raw value in provider_raw", () => {
+  it("maps finish_reason -> stop_reason without leaking provider_raw", () => {
     const out = transformResponseIn(
       makeIR({
         choices: [
@@ -103,10 +103,10 @@ describe("transformResponseIn", () => {
       }),
     );
     expect(out.stop_reason).toBe("max_tokens");
-    expect(out.provider_raw?.stop_reason).toBe("length");
+    expect("provider_raw" in out).toBe(false);
   });
 
-  it("stashes the raw stop_reason even for an unknown finish_reason", () => {
+  it("maps an unknown finish_reason to a legal stop_reason without leaking provider_raw", () => {
     const out = transformResponseIn(
       makeIR({
         choices: [
@@ -115,7 +115,7 @@ describe("transformResponseIn", () => {
       }),
     );
     expect(out.stop_reason).toBe("end_turn");
-    expect(out.provider_raw?.stop_reason).toBe("weird_one");
+    expect("provider_raw" in out).toBe(false);
   });
 
   it("usage: input = prompt - cached, cache_read split out (pit #2)", () => {
@@ -142,10 +142,10 @@ describe("transformResponseIn", () => {
     expect(out.usage.input_tokens).toBeGreaterThanOrEqual(0);
   });
 
-  it("preserves the raw upstream usage verbatim in provider_raw.usage", () => {
+  it("does not expose raw upstream usage in the public response body", () => {
     const rawUsage = { prompt_tokens: 200, cached_tokens: 800, completion_tokens: 50 };
     const out = transformResponseIn(makeIR({ usage: rawUsage }));
-    expect(out.provider_raw?.usage).toEqual(rawUsage);
+    expect("provider_raw" in out).toBe(false);
   });
 
   it("back-translates tool_calls -> tool_use block with id/name/parsed input", () => {
@@ -262,10 +262,7 @@ describe("transformResponseIn", () => {
     const secondName = toolUses[1]?.name;
     expect(secondName).toEqual(expect.stringMatching(/^search_web_[a-z0-9]{8}$/));
     expect(toolUses.map((b) => b.name)).toEqual(["search_web", secondName]);
-    expect(out.provider_raw?.anthropic_tool_name_map).toEqual({
-      search_web: "search-web",
-      [secondName as string]: "search web",
-    });
+    expect("provider_raw" in out).toBe(false);
   });
 
   it("back-translates thinking parts -> thinking block preserving signature", () => {

--- a/packages/core/src/protocol/anthropic/response.ts
+++ b/packages/core/src/protocol/anthropic/response.ts
@@ -104,12 +104,6 @@ const AnthropicContentBlockSchema = z.discriminatedUnion("type", [
 ]);
 type AnthropicContentBlock = z.infer<typeof AnthropicContentBlockSchema>;
 
-// —— provider_raw passthrough bag carried on the response (raw upstream
-// stop_reason / usage, for cross-protocol reconstruction + billing). —————————————
-const ProviderRawSchema = z
-  .object({ stop_reason: z.unknown().optional(), usage: z.unknown().optional() })
-  .catchall(z.unknown());
-
 export interface AnthropicToolNameMap {
   toAnthropic(name: string): string;
   toOriginal(name: string): string | undefined;
@@ -188,7 +182,6 @@ export const AnthropicMessagesResponseSchema = z.object({
   stop_reason: AnthropicStopReasonSchema,
   stop_sequence: z.string().nullable(),
   usage: AnthropicUsageSchema,
-  provider_raw: ProviderRawSchema.optional(),
 });
 export type AnthropicMessagesResponse = z.infer<typeof AnthropicMessagesResponseSchema>;
 
@@ -413,18 +406,17 @@ function toToolUseBlock(
 
 /**
  * IR response -> native Anthropic Messages response. Pure. Always lands on a legal
- * stop_reason and a well-formed usage; the raw upstream stop_reason/usage ride
- * along in provider_raw so a client (or billing) can reconstruct the original.
+ * stop_reason and a well-formed usage. Internal raw values remain available on the
+ * IR/telemetry path; the public Anthropic response body never exposes provider_raw.
  */
 export function transformResponseIn(ir: IRResponse): AnthropicMessagesResponse {
   const choice = ir.choices[0];
   const message = choice?.message ?? { role: "assistant" as const, content: null };
-  const { stop_reason, raw } = mapStopReason(choice?.finish_reason ?? "");
+  const { stop_reason } = mapStopReason(choice?.finish_reason ?? "");
   const usage = mapUsage(ir.usage ?? {});
   const toolNameMap = createAnthropicToolNameMap(
     (message.tool_calls ?? []).map((call) => call.function.name),
   );
-  const reverseMap = toolNameMap.reverse;
 
   const out: AnthropicMessagesResponse = {
     id: ir.id,
@@ -435,11 +427,6 @@ export function transformResponseIn(ir: IRResponse): AnthropicMessagesResponse {
     stop_reason,
     stop_sequence: null,
     usage,
-    provider_raw: {
-      stop_reason: raw,
-      ...(ir.usage !== undefined ? { usage: ir.usage } : {}),
-      ...(Object.keys(reverseMap).length > 0 ? { anthropic_tool_name_map: reverseMap } : {}),
-    },
   };
 
   // Final structural validation: the response handed to the client is well-formed.

--- a/packages/core/src/protocol/gemini/gemini-transformer.test.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.test.ts
@@ -1259,7 +1259,11 @@ describe("endPoint routing (/v1beta/...)", () => {
 
   it("parses LiteLLM-compatible /models paths and path-style model names", () => {
     const parsed = parseGeminiPath("/models/google/gemini-2.5-pro:generateContent", "");
-    expect(parsed).toEqual({ model: "google/gemini-2.5-pro", stream: false });
+    expect(parsed).toEqual({
+      model: "google/gemini-2.5-pro",
+      operation: "generateContent",
+      stream: false,
+    });
   });
 
   it("parses streamGenerateContent?alt=sse path: streaming true", () => {
@@ -1273,7 +1277,11 @@ describe("endPoint routing (/v1beta/...)", () => {
 
   it("treats streamGenerateContent as streaming even without alt=sse", () => {
     const parsed = parseGeminiPath("/v1beta/models/gemini-1.5-pro:streamGenerateContent", "");
-    expect(parsed).toEqual({ model: "gemini-1.5-pro", stream: true });
+    expect(parsed).toEqual({
+      model: "gemini-1.5-pro",
+      operation: "streamGenerateContent",
+      stream: true,
+    });
   });
 
   it("returns null for a non-Gemini path", () => {
@@ -1645,6 +1653,30 @@ describe("Gemini transformRequestOut — tools + response_format", () => {
     ]);
   });
 
+  it("maps Google GenAI parametersJsonSchema into IR tool parameters", () => {
+    const native: GeminiGenerateContentRequest = {
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "lookup",
+              parametersJsonSchema: { type: "object", properties: { q: { type: "string" } } },
+            },
+          ],
+        },
+      ],
+    };
+    const ir = geminiTransformer.transformRequestOut(native) as IRRequest;
+    expect(ir.tools?.[0]).toEqual({
+      type: "function",
+      function: {
+        name: "lookup",
+        parameters: { type: "object", properties: { q: { type: "string" } } },
+      },
+    });
+  });
+
   it("maps responseMimeType application/json + responseSchema to a json_schema response_format", () => {
     const native: GeminiGenerateContentRequest = {
       contents: [{ role: "user", parts: [{ text: "hi" }] }],
@@ -1660,6 +1692,24 @@ describe("Gemini transformRequestOut — tools + response_format", () => {
     });
   });
 
+  it.each([
+    "responseJsonSchema",
+    "response_json_schema",
+  ] as const)("maps responseMimeType application/json + %s to a json_schema response_format", (field) => {
+    const native = {
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      generationConfig: {
+        responseMimeType: "application/json",
+        [field]: { type: "object", properties: { ok: { type: "boolean" } } },
+      },
+    } as unknown as GeminiGenerateContentRequest;
+    const ir = geminiTransformer.transformRequestOut(native) as IRRequest;
+    expect(ir.response_format).toEqual({
+      type: "json_schema",
+      json_schema: { type: "object", properties: { ok: { type: "boolean" } } },
+    });
+  });
+
   it("maps responseMimeType application/json with NO schema to a bare json_object", () => {
     const native: GeminiGenerateContentRequest = {
       contents: [{ role: "user", parts: [{ text: "hi" }] }],
@@ -1667,6 +1717,80 @@ describe("Gemini transformRequestOut — tools + response_format", () => {
     };
     const ir = geminiTransformer.transformRequestOut(native) as IRRequest;
     expect(ir.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("emits Google GenAI parametersJsonSchema and responseJsonSchema when requested", () => {
+    const ir: IRRequest = {
+      model: "gemini-2.0-flash",
+      messages: [{ role: "user", content: "hi" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "lookup",
+            parameters: { type: "object", properties: { q: { type: "string" } } },
+          },
+        },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: { type: "object", properties: { ok: { type: "boolean" } } },
+      },
+      provider_raw: { gemini_schema_style: "google_genai" },
+    };
+    const native = geminiTransformer.transformRequestIn(ir) as GeminiGenerateContentRequest;
+    const decl = native.tools?.[0]?.functionDeclarations?.[0] as {
+      parameters?: unknown;
+      parametersJsonSchema?: unknown;
+    };
+    expect(decl.parameters).toBeUndefined();
+    expect(decl.parametersJsonSchema).toEqual({
+      type: "object",
+      properties: { q: { type: "string" } },
+    });
+    expect(native.generationConfig?.responseSchema).toBeUndefined();
+    expect(native.generationConfig?.responseJsonSchema).toEqual({
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+    });
+  });
+
+  it("preserves Google GenAI advanced optional params in provider_raw and native replay", () => {
+    const native = {
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      routing_config: { manual: true },
+      model_selection_config: { featureSelectionPreference: "PRIORITIZE_QUALITY" },
+      labels: { env: "test" },
+      media_resolution: "MEDIA_RESOLUTION_MEDIUM",
+      speech_config: { voiceConfig: { prebuiltVoiceConfig: { voiceName: "Aoede" } } },
+      audio_timestamp: true,
+      automatic_function_calling: { disable: true },
+      image_config: { aspectRatio: "1:1" },
+    } as unknown as GeminiGenerateContentRequest;
+
+    const ir = geminiTransformer.transformRequestOut(native) as IRRequest;
+    expect(ir.provider_raw?.google_genai).toEqual({
+      routing_config: { manual: true },
+      model_selection_config: { featureSelectionPreference: "PRIORITIZE_QUALITY" },
+      labels: { env: "test" },
+      media_resolution: "MEDIA_RESOLUTION_MEDIUM",
+      speech_config: { voiceConfig: { prebuiltVoiceConfig: { voiceName: "Aoede" } } },
+      audio_timestamp: true,
+      automatic_function_calling: { disable: true },
+      image_config: { aspectRatio: "1:1" },
+    });
+
+    const replay = geminiTransformer.transformRequestIn(ir) as Record<string, unknown>;
+    expect(replay).toMatchObject({
+      routing_config: { manual: true },
+      model_selection_config: { featureSelectionPreference: "PRIORITIZE_QUALITY" },
+      labels: { env: "test" },
+      media_resolution: "MEDIA_RESOLUTION_MEDIUM",
+      speech_config: { voiceConfig: { prebuiltVoiceConfig: { voiceName: "Aoede" } } },
+      audio_timestamp: true,
+      automatic_function_calling: { disable: true },
+      image_config: { aspectRatio: "1:1" },
+    });
   });
 });
 

--- a/packages/core/src/protocol/gemini/gemini-transformer.ts
+++ b/packages/core/src/protocol/gemini/gemini-transformer.ts
@@ -56,6 +56,7 @@ export const GEMINI_API_KEY_HEADER = "x-goog-api-key" as const;
 export interface GeminiRoute {
   /** model parsed out of the `{model}` path segment, fed into IR.model. */
   model: string;
+  operation: "generateContent" | "streamGenerateContent" | "countTokens";
   /** true for :streamGenerateContent; alt=sse is not required for compatibility. */
   stream: boolean;
 }
@@ -67,18 +68,19 @@ export interface GeminiRoute {
  * framework request onto this (core never reads a framework object).
  */
 export function parseGeminiPath(pathname: string, query: string): GeminiRoute | null {
-  const m = /^\/(?:v1beta\/models|models)\/(.+):(generateContent|streamGenerateContent)$/.exec(
-    pathname,
-  );
+  const m =
+    /^\/(?:v1beta\/models|models)\/(.+):(generateContent|streamGenerateContent|countTokens)$/.exec(
+      pathname,
+    );
   if (m === null || m[1] === undefined || m[2] === undefined) return null;
   const model = decodeURIComponent(m[1]);
-  const op = m[2];
+  const op = m[2] as GeminiRoute["operation"];
   // LiteLLM's Gemini stream route forces stream=true from the operation name. The
   // `alt=sse` query affects the Google wire format, but silently downgrading a
   // `streamGenerateContent` request to non-stream corrupts client expectations.
   void query;
   const stream = op === "streamGenerateContent";
-  return { model, stream };
+  return { model, operation: op, stream };
 }
 
 // —— finishReason mapping (docs/05 pit #1). Gemini -> legal IR/OpenAI finish_reason;
@@ -438,16 +440,19 @@ function transformRequestOut(native: unknown): IRRequest {
       function: {
         name: d.name,
         ...(d.description !== undefined ? { description: d.description } : {}),
-        ...(d.parameters !== undefined ? { parameters: d.parameters } : {}),
+        ...(d.parametersJsonSchema !== undefined || d.parameters !== undefined
+          ? { parameters: d.parametersJsonSchema ?? d.parameters }
+          : {}),
       },
     })),
   );
 
   const gc = req.generationConfig;
+  const responseSchema = gc?.responseJsonSchema ?? gc?.response_json_schema ?? gc?.responseSchema;
   const responseFormat =
     gc?.responseMimeType === "application/json"
-      ? gc.responseSchema !== undefined
-        ? { type: "json_schema", json_schema: gc.responseSchema }
+      ? responseSchema !== undefined
+        ? { type: "json_schema", json_schema: responseSchema }
         : { type: "json_object" }
       : undefined;
 
@@ -482,9 +487,34 @@ function transformRequestOut(native: unknown): IRRequest {
     ...(geminiToolConfigToToolChoice(req.toolConfig) !== undefined
       ? { tool_choice: geminiToolConfigToToolChoice(req.toolConfig) }
       : {}),
-    ...(req.safetySettings !== undefined
-      ? { provider_raw: { safety_settings: req.safetySettings } }
-      : {}),
+    ...((): Partial<Pick<IRRequest, "provider_raw">> => {
+      const providerRaw: Record<string, unknown> = {};
+      if (req.safetySettings !== undefined) providerRaw.safety_settings = req.safetySettings;
+      const googleGenAIKeys = [
+        "routing_config",
+        "routingConfig",
+        "model_selection_config",
+        "modelSelectionConfig",
+        "labels",
+        "media_resolution",
+        "mediaResolution",
+        "speech_config",
+        "speechConfig",
+        "audio_timestamp",
+        "audioTimestamp",
+        "automatic_function_calling",
+        "automaticFunctionCalling",
+        "image_config",
+        "imageConfig",
+      ];
+      const googleGenAI: Record<string, unknown> = {};
+      const rawReq = req as Record<string, unknown>;
+      for (const key of googleGenAIKeys) {
+        if (rawReq[key] !== undefined) googleGenAI[key] = rawReq[key];
+      }
+      if (Object.keys(googleGenAI).length > 0) providerRaw.google_genai = googleGenAI;
+      return Object.keys(providerRaw).length > 0 ? { provider_raw: providerRaw } : {};
+    })(),
   };
 
   return IRRequestSchema.parse(ir);
@@ -493,16 +523,21 @@ function transformRequestOut(native: unknown): IRRequest {
 // —— Outbound: IR request -> native Gemini request. Drops synthesized tool ids;
 // sanitizes functionDeclarations parameters (format pit). ——————————————————————————
 
-function irToolToFunctionDeclaration(tool: unknown) {
+function irToolToFunctionDeclaration(tool: unknown, schemaStyle: "rest" | "google_genai" = "rest") {
   // IR tools are OpenAI-shaped: { type:"function", function:{ name, description?, parameters? } }
   const t = tool as {
     function?: { name?: string; description?: string; parameters?: unknown };
   };
   const fn = t.function ?? {};
+  const parameters = fn.parameters !== undefined ? sanitizeSchema(fn.parameters) : undefined;
   return {
     name: fn.name ?? "",
     ...(fn.description !== undefined ? { description: fn.description } : {}),
-    ...(fn.parameters !== undefined ? { parameters: sanitizeSchema(fn.parameters) } : {}),
+    ...(parameters !== undefined
+      ? schemaStyle === "google_genai"
+        ? { parametersJsonSchema: parameters }
+        : { parameters }
+      : {}),
   };
 }
 
@@ -708,6 +743,7 @@ function irToolChoiceToGeminiToolConfig(toolChoice: unknown): unknown {
 
 function responseFormatToGenerationConfig(
   responseFormat: unknown,
+  schemaStyle: "rest" | "google_genai" = "rest",
 ): Record<string, unknown> | undefined {
   if (typeof responseFormat !== "object" || responseFormat === null) return undefined;
   const rf = responseFormat as { type?: unknown; json_schema?: unknown };
@@ -721,7 +757,11 @@ function responseFormatToGenerationConfig(
       : rawSchema;
   return {
     responseMimeType: "application/json",
-    ...(schema !== undefined ? { responseSchema: sanitizeSchema(schema) } : {}),
+    ...(schema !== undefined
+      ? schemaStyle === "google_genai"
+        ? { responseJsonSchema: sanitizeSchema(schema) }
+        : { responseSchema: sanitizeSchema(schema) }
+      : {}),
   };
 }
 
@@ -745,6 +785,11 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
   const systemInstruction: GeminiContent | undefined =
     systemText !== "" ? { parts: [{ text: systemText }] } : undefined;
   const toolNameById = new Map<string, string>();
+  const schemaStyle =
+    parsed.provider_raw?.gemini_schema_style === "google_genai" ||
+    parsed.provider_raw?.google_genai_schema_style === "google_genai"
+      ? "google_genai"
+      : "rest";
 
   for (const message of parsed.messages) {
     for (const call of message.tool_calls ?? []) {
@@ -789,7 +834,13 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
 
   const tools =
     parsed.tools !== undefined && parsed.tools.length > 0
-      ? [{ functionDeclarations: parsed.tools.map(irToolToFunctionDeclaration) }]
+      ? [
+          {
+            functionDeclarations: parsed.tools.map((tool) =>
+              irToolToFunctionDeclaration(tool, schemaStyle),
+            ),
+          },
+        ]
       : undefined;
 
   // —— Map the flat IR sampling/control knobs onto Gemini's camelCase generationConfig
@@ -827,12 +878,18 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
 
   const generationConfig = mergeGenerationConfig(
     Object.keys(samplingConfig).length > 0 ? samplingConfig : undefined,
-    responseFormatToGenerationConfig(parsed.response_format),
+    responseFormatToGenerationConfig(parsed.response_format, schemaStyle),
   );
   const toolConfig = irToolChoiceToGeminiToolConfig(parsed.tool_choice);
   const safetySettings = Array.isArray(parsed.provider_raw?.safety_settings)
     ? parsed.provider_raw.safety_settings
     : undefined;
+  const googleGenAI =
+    parsed.provider_raw?.google_genai !== null &&
+    typeof parsed.provider_raw?.google_genai === "object" &&
+    !Array.isArray(parsed.provider_raw.google_genai)
+      ? (parsed.provider_raw.google_genai as Record<string, unknown>)
+      : undefined;
 
   return {
     contents,
@@ -842,6 +899,7 @@ function transformRequestIn(ir: IRRequest): GeminiGenerateContentRequest {
     ...(generationConfig !== undefined ? { generationConfig } : {}),
     ...(parsed.cached_content !== undefined ? { cachedContent: parsed.cached_content } : {}),
     ...(safetySettings !== undefined ? { safetySettings } : {}),
+    ...(googleGenAI !== undefined ? googleGenAI : {}),
   };
 }
 

--- a/packages/core/src/protocol/gemini/gemini-types.ts
+++ b/packages/core/src/protocol/gemini/gemini-types.ts
@@ -86,6 +86,7 @@ export const GeminiFunctionDeclarationSchema = z
     name: z.string(),
     description: z.string().optional(),
     parameters: z.unknown().optional(),
+    parametersJsonSchema: z.unknown().optional(),
   })
   .passthrough();
 
@@ -104,6 +105,8 @@ export const GeminiGenerationConfigSchema = z
     temperature: z.number().optional(),
     responseMimeType: z.string().optional(),
     responseSchema: z.unknown().optional(),
+    responseJsonSchema: z.unknown().optional(),
+    response_json_schema: z.unknown().optional(),
     // —— litellm-parity sampling/control knobs (camelCase Gemini wire names). All
     // optional; the transformer maps the IR's flat OpenAI-shaped params onto these.
     topP: z.number().optional(),

--- a/packages/core/src/protocol/openai.ts
+++ b/packages/core/src/protocol/openai.ts
@@ -87,6 +87,13 @@ const OpenAIChatRequestSchema = z.object({
   safety_identifier: z.string().optional(),
 });
 
+function defaultFilenameForMediaType(mediaType: string | undefined): string {
+  if (mediaType === "application/pdf") return "document.pdf";
+  if (mediaType?.startsWith("image/")) return `image.${mediaType.slice("image/".length) || "bin"}`;
+  if (mediaType?.startsWith("audio/")) return `audio.${mediaType.slice("audio/".length) || "bin"}`;
+  return "document.bin";
+}
+
 // —— OpenAI usage shape. `prompt_tokens` is the FULL prompt (cached + fresh);
 // `prompt_tokens_details.cached_tokens` is the cached slice (pit #2).
 // `completion_tokens_details` carries the litellm-parity reasoning/audio breakdown
@@ -241,7 +248,7 @@ function nativePartToIR(part: unknown): IRContentPart {
           type: "document",
           data: parsed.data,
           mediaType: parsed.mediaType,
-          ...(filename !== undefined ? { filename } : {}),
+          filename: filename ?? defaultFilenameForMediaType(parsed.mediaType),
         };
       }
       // An uploaded-file handle is preserved as fileId (NOT url) so it round-trips

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -959,7 +959,7 @@ describe("responsesTransformer — request sampling/control params (litellm pari
     expect(ir.web_search_options).toEqual({ search_context_size: "low" });
   });
 
-  it("stashes Responses-only params (store/previous_response_id/metadata/logit_bias/context_management) in provider_raw", async () => {
+  it("stashes Responses-only params (store/previous_response_id/metadata/logit_bias/context_management/include/background) in provider_raw", async () => {
     const ir = await responsesTransformer.transformRequestOut({
       model: "gpt-4o",
       input: "hi",
@@ -968,12 +968,16 @@ describe("responsesTransformer — request sampling/control params (litellm pari
       metadata: { trace: "abc" },
       logit_bias: { "123": -100 },
       context_management: { truncation: "auto" },
+      include: ["reasoning.encrypted_content"],
+      background: true,
     });
     expect(ir.provider_raw?.store).toBe(true);
     expect(ir.provider_raw?.previous_response_id).toBe("resp_prev");
     expect(ir.provider_raw?.metadata).toEqual({ trace: "abc" });
     expect(ir.provider_raw?.logit_bias).toEqual({ "123": -100 });
     expect(ir.provider_raw?.context_management).toEqual({ truncation: "auto" });
+    expect(ir.provider_raw?.include).toEqual(["reasoning.encrypted_content"]);
+    expect(ir.provider_raw?.background).toBe(true);
   });
 
   it("round-trips IR-backed params back onto the native Responses request (transformRequestIn)", async () => {
@@ -991,7 +995,11 @@ describe("responsesTransformer — request sampling/control params (litellm pari
       prompt_cache_key: "thread-123",
       prompt_cache_retention: "24h",
       web_search_options: { search_context_size: "low" },
-      provider_raw: { context_management: { truncation: "auto" } },
+      provider_raw: {
+        context_management: { truncation: "auto" },
+        include: ["reasoning.encrypted_content"],
+        background: true,
+      },
     })) as {
       top_p?: number;
       frequency_penalty?: number;
@@ -1005,6 +1013,8 @@ describe("responsesTransformer — request sampling/control params (litellm pari
       prompt_cache_retention?: string;
       web_search_options?: unknown;
       context_management?: unknown;
+      include?: unknown;
+      background?: unknown;
     };
     expect(native.top_p).toBe(0.8);
     expect(native.frequency_penalty).toBe(0.1);
@@ -1018,6 +1028,8 @@ describe("responsesTransformer — request sampling/control params (litellm pari
     expect(native.prompt_cache_retention).toBe("24h");
     expect(native.web_search_options).toEqual({ search_context_size: "low" });
     expect(native.context_management).toEqual({ truncation: "auto" });
+    expect(native.include).toEqual(["reasoning.encrypted_content"]);
+    expect(native.background).toBe(true);
   });
 
   it("normalizes Responses tool_choice into OpenAI Chat format on inbound conversion", async () => {
@@ -1040,14 +1052,33 @@ describe("responsesTransformer — request sampling/control params (litellm pari
     expect(native.tool_choice).toEqual({ type: "function", name: "get_weather" });
   });
 
-  it("rejects stateful tool-output continuation when previous_response_id history is unavailable", async () => {
-    expect(() =>
-      responsesTransformer.transformRequestOut({
-        model: "gpt-4o",
-        previous_response_id: "resp_prev",
-        input: [{ type: "function_call_output", call_id: "call_1", output: "done" }],
-      }),
-    ).toThrow(/previous_response_id continuation is not supported/);
+  it("preserves stateful previous_response_id tool-output continuations for native passthrough guards", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      previous_response_id: "resp_prev",
+      input: [{ type: "function_call_output", call_id: "call_1", output: "done" }],
+    });
+    expect(ir.provider_raw?.previous_response_id).toBe("resp_prev");
+    expect(ir.messages).toEqual([{ role: "tool", content: "done", tool_call_id: "call_1" }]);
+  });
+
+  it("keeps native-only Responses tools out of IR tools and preserves them in provider_raw", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-4o",
+      input: "hi",
+      tools: [
+        { type: "mcp", server_label: "local" },
+        { type: "file_search", vector_store_ids: ["vs_1"] },
+        { type: "function", name: "lookup", parameters: { type: "object" } },
+      ],
+    });
+    expect(ir.tools).toEqual([
+      { type: "function", function: { name: "lookup", parameters: { type: "object" } } },
+    ]);
+    expect(ir.provider_raw?.responses_native_tools).toEqual([
+      { type: "mcp", server_label: "local" },
+      { type: "file_search", vector_store_ids: ["vs_1"] },
+    ]);
   });
 });
 

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -194,6 +194,8 @@ const ResponsesRequestSchema = z
     prompt_cache_retention: z.string().optional(),
     web_search_options: z.unknown().optional(),
     context_management: z.unknown().optional(),
+    include: z.array(z.string()).optional(),
+    background: z.boolean().optional(),
     store: z.boolean().optional(),
     previous_response_id: z.string().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
@@ -291,38 +293,30 @@ function chatToolChoiceToResponses(toolChoice: unknown): unknown {
   return { type: "function", name: toolChoice.function.name };
 }
 
-function rejectUnsupportedPreviousResponseContinuation(
-  parsed: z.infer<typeof ResponsesRequestSchema>,
-): void {
-  if (parsed.previous_response_id === undefined || typeof parsed.input === "string") return;
-
-  const localFunctionCalls = new Set<string>();
-  for (const item of parsed.input) {
-    if (item.type === "function_call") {
-      const call = item as z.infer<typeof ResponsesFunctionCallItemSchema>;
-      const id = call.call_id ?? call.id;
-      if (id !== undefined) localFunctionCalls.add(id);
-      continue;
-    }
-    if (item.type !== "function_call_output") continue;
-
-    const output = item as z.infer<typeof ResponsesFunctionCallOutputItemSchema>;
-    if (output.call_id === undefined || !localFunctionCalls.has(output.call_id)) {
-      throw new Error(
-        "previous_response_id continuation is not supported without local function_call history",
-      );
-    }
-  }
-}
-
 function normalizeResponsesTools(tools: unknown[] | undefined): {
   tools?: unknown[];
   rawTools?: unknown[];
+  nativeTools?: unknown[];
 } {
   if (tools === undefined) return {};
-  const normalized = tools.map(responsesToolToChatTool);
-  const changed = normalized.some((tool, index) => tool !== tools[index]);
-  return { tools: normalized, ...(changed ? { rawTools: tools } : {}) };
+  const normalized: unknown[] = [];
+  const nativeTools: unknown[] = [];
+  let changed = false;
+  for (const tool of tools) {
+    if (isRecord(tool) && tool.type !== "function") {
+      nativeTools.push(tool);
+      changed = true;
+      continue;
+    }
+    const next = responsesToolToChatTool(tool);
+    normalized.push(next);
+    if (next !== tool) changed = true;
+  }
+  return {
+    ...(normalized.length > 0 ? { tools: normalized } : {}),
+    ...(changed ? { rawTools: tools } : {}),
+    ...(nativeTools.length > 0 ? { nativeTools } : {}),
+  };
 }
 
 // —— content-part folding: Responses parts -> IR parts. Unknown parts degrade to a
@@ -379,7 +373,6 @@ function foldMessageContent(
 function toIRRequest(req: NativeRequest): IRRequest {
   // fail-closed: a structurally invalid request never enters the pipeline.
   const parsed = ResponsesRequestSchema.parse(req);
-  rejectUnsupportedPreviousResponseContinuation(parsed);
   const normalizedTools = normalizeResponsesTools(parsed.tools);
 
   const messages: IRMessage[] = [];
@@ -470,8 +463,12 @@ function toIRRequest(req: NativeRequest): IRRequest {
   if (parsed.logit_bias !== undefined) providerRaw.logit_bias = parsed.logit_bias;
   if (parsed.context_management !== undefined)
     providerRaw.context_management = parsed.context_management;
+  if (parsed.include !== undefined) providerRaw.include = parsed.include;
+  if (parsed.background !== undefined) providerRaw.background = parsed.background;
   if (normalizedTools.rawTools !== undefined)
     providerRaw.responses_tools = normalizedTools.rawTools;
+  if (normalizedTools.nativeTools !== undefined)
+    providerRaw.responses_native_tools = normalizedTools.nativeTools;
   // Reasoning config + truncation have no IR field of their own; preserve verbatim.
   // NB: a distinct key — provider_raw.reasoning already holds inbound reasoning ITEMS.
   if (parsed.reasoning !== undefined) providerRaw.reasoning_config = parsed.reasoning;
@@ -638,6 +635,8 @@ function toResponsesRequest(ir: IRRequest): NativeRequest {
     ...(raw?.context_management !== undefined
       ? { context_management: raw.context_management }
       : {}),
+    ...(raw?.include !== undefined ? { include: raw.include } : {}),
+    ...(raw?.background !== undefined ? { background: raw.background } : {}),
     // Reasoning config: prefer the preserved native object, else synthesize from the
     // cross-protocol IR.reasoning_effort so o-series reasoning survives chat->responses.
     ...(raw?.reasoning_config !== undefined

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -1107,6 +1107,15 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe("createAnthropicClient", () => {
+  it("marks the client as the Anthropic Messages native protocol profile", () => {
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+
+    expect(client.nativeProtocolProfile).toBe("anthropic_messages");
+  });
+
   it("sends Bearer + Claude-Code identity headers + system spoof; 401-retries once", async () => {
     let calls = 0;
     const seenAuth: string[] = [];
@@ -1242,6 +1251,67 @@ describe("createAnthropicClient", () => {
     const beta = (seen as unknown as Headers).get("anthropic-beta") ?? "";
     expect(beta).toContain("context-management-2025-06-27");
     expect(beta).toContain("fast-mode-2026-02-01");
+  });
+
+  it("adds feature beta headers for structured output, advisor, and tool search", async () => {
+    let seen: Headers | null = null;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      seen = new Headers(init?.headers);
+      return jsonResponse({
+        id: "m",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.nativePassthrough?.({
+      model: "claude-x",
+      max_tokens: 64,
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      output_config: { type: "json_schema", schema: { type: "object" } },
+      tools: [
+        { type: "advisor_20260301", name: "advisor" },
+        { type: "tool_search_tool_bm25_20251119", name: "search" },
+      ],
+    });
+
+    const beta = (seen as unknown as Headers).get("anthropic-beta") ?? "";
+    expect(beta).toContain("structured-outputs-2025-11-13");
+    expect(beta).toContain("advisor-tool-2026-03-01");
+    expect(beta).toContain("advanced-tool-use-2025-11-20");
+  });
+
+  it("calls the Anthropic count_tokens endpoint with token-counting beta", async () => {
+    let seenUrl = "";
+    let seen: Headers | null = null;
+    let sentBody: unknown;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      seenUrl = url;
+      seen = new Headers(init?.headers);
+      sentBody = JSON.parse(String(init?.body));
+      return jsonResponse({ input_tokens: 123 });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const body = {
+      model: "claude-x",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    };
+    const out = await client.countTokens?.(body);
+
+    expect(out).toEqual({ input_tokens: 123 });
+    expect(seenUrl).toBe("https://api.anthropic.com/v1/messages/count_tokens");
+    expect(sentBody).toEqual(body);
+    const beta = (seen as unknown as Headers).get("anthropic-beta") ?? "";
+    expect(beta).toContain("token-counting-2024-11-01");
   });
 
   it("throws UpstreamError on a persistent non-401 error", async () => {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -65,6 +65,10 @@ const OAUTH_BETA = "claude-code-20250219,oauth-2025-04-20";
 const CONTEXT_MANAGEMENT_BETA = "context-management-2025-06-27";
 const COMPACT_BETA = "compact-2026-01-12";
 const FAST_MODE_BETA = "fast-mode-2026-02-01";
+const STRUCTURED_OUTPUT_BETA = "structured-outputs-2025-11-13";
+const ADVISOR_TOOL_BETA = "advisor-tool-2026-03-01";
+const ADVANCED_TOOL_USE_BETA = "advanced-tool-use-2025-11-20";
+const TOKEN_COUNTING_BETA = "token-counting-2024-11-01";
 const SYSTEM_SPOOF = "You are Claude Code, Anthropic's official CLI for Claude.";
 
 // ── request translation: OpenAI-Chat IR -> Anthropic Messages ────────────────
@@ -169,7 +173,22 @@ function contextManagementEdits(value: unknown): unknown[] {
   return [];
 }
 
-function betaHeaderForBody(body: Record<string, unknown>): string {
+function toolTypeMatches(
+  body: Record<string, unknown>,
+  predicate: (type: string) => boolean,
+): boolean {
+  if (!Array.isArray(body.tools)) return false;
+  return body.tools.some((tool) => {
+    if (tool === null || typeof tool !== "object" || Array.isArray(tool)) return false;
+    const type = (tool as Record<string, unknown>).type;
+    return typeof type === "string" && predicate(type);
+  });
+}
+
+function betaHeaderForBody(
+  body: Record<string, unknown>,
+  extraBetas: readonly string[] = [],
+): string {
   const betas = new Set(OAUTH_BETA.split(","));
   if (body.context_management !== undefined) {
     betas.add(CONTEXT_MANAGEMENT_BETA);
@@ -181,6 +200,16 @@ function betaHeaderForBody(body: Record<string, unknown>): string {
     }
   }
   if (body.speed === "fast") betas.add(FAST_MODE_BETA);
+  if (body.output_format !== undefined || body.output_config !== undefined) {
+    betas.add(STRUCTURED_OUTPUT_BETA);
+  }
+  if (toolTypeMatches(body, (type) => type === "advisor_20260301")) {
+    betas.add(ADVISOR_TOOL_BETA);
+  }
+  if (toolTypeMatches(body, (type) => type.startsWith("tool_search_tool_"))) {
+    betas.add(ADVANCED_TOOL_USE_BETA);
+  }
+  for (const beta of extraBetas) betas.add(beta);
   return [...betas].join(",");
 }
 
@@ -568,6 +597,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
   const cfg = deps.config;
   const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const url = `${cfg.baseUrl}/v1/messages`;
+  const countTokensUrl = `${cfg.baseUrl}/v1/messages/count_tokens`;
 
   const hasStatic = cfg.apiKey !== undefined;
   const hasDynamic = cfg.getAuthHeader !== undefined;
@@ -575,7 +605,10 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     throw new Error("anthropic client requires exactly one of `apiKey` or `getAuthHeader`");
   }
 
-  async function headers(body: Record<string, unknown>): Promise<Record<string, string>> {
+  async function headers(
+    body: Record<string, unknown>,
+    extraBetas: readonly string[] = [],
+  ): Promise<Record<string, string>> {
     const h: Record<string, string> = {
       "Content-Type": "application/json",
       // Header parity with openclaw's OAuth recipe — both are load-bearing for the
@@ -583,7 +616,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
       accept: "application/json",
       "anthropic-dangerous-direct-browser-access": "true",
       "anthropic-version": ANTHROPIC_VERSION,
-      "anthropic-beta": betaHeaderForBody(body),
+      "anthropic-beta": betaHeaderForBody(body, extraBetas),
       // Keep the user-agent coherent with the billing block at system[0]: derive its
       // version + entrypoint from the SAME identity emitted there (the client's real
       // one when present, else the fallback) so the two never disagree.
@@ -617,9 +650,14 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     return changed ? JSON.parse(value) : raw;
   }
 
-  async function request(input: NativePassthroughInput, external?: AbortSignal): Promise<Response> {
+  async function request(
+    input: NativePassthroughInput,
+    external?: AbortSignal,
+    endpointUrl = url,
+    extraBetas: readonly string[] = [],
+  ): Promise<Response> {
     const body = nativePassthroughBody(input);
-    const prepared = prepareNativePassthroughRequest(input, await headers(body), {
+    const prepared = prepareNativePassthroughRequest(input, await headers(body, extraBetas), {
       mergeHeaders: ["anthropic-beta"],
       forceAcceptEncodingIdentity: cfg.getAuthHeader !== undefined && body.stream === true,
       ...(cfg.getAuthHeader !== undefined && body.stream === true
@@ -628,7 +666,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     });
     const t = withTimeout(timeoutMs, external);
     try {
-      return await doFetch(url, {
+      return await doFetch(endpointUrl, {
         method: "POST",
         headers: prepared.headers,
         body: prepared.bodyText,
@@ -647,12 +685,14 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
   async function requestWithRetry(
     body: NativePassthroughInput,
     external?: AbortSignal,
+    endpointUrl = url,
+    extraBetas: readonly string[] = [],
   ): Promise<Response> {
-    const res = await request(body, external);
+    const res = await request(body, external, endpointUrl, extraBetas);
     if (res.status === 401 && cfg.onUnauthorized !== undefined) {
       await res.body?.cancel().catch(() => {});
       cfg.onUnauthorized();
-      return await request(body, external);
+      return await request(body, external, endpointUrl, extraBetas);
     }
     return res;
   }
@@ -671,6 +711,8 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
   }
 
   return {
+    nativeProtocolProfile: "anthropic_messages",
+
     async chatCompletion(req, opts) {
       const model = String((req as Record<string, unknown>).model ?? "");
       const res = await requestWithRetry(
@@ -703,6 +745,12 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     // so the same closure works unchanged on a native body.
     async nativePassthrough(body, opts) {
       const res = await requestWithRetry(body, opts?.signal);
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async countTokens(req, opts) {
+      const res = await requestWithRetry(req, opts?.signal, countTokensUrl, [TOKEN_COUNTING_BETA]);
       if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as Record<string, unknown>;
     },

--- a/packages/core/src/provider/gemini.test.ts
+++ b/packages/core/src/provider/gemini.test.ts
@@ -139,6 +139,8 @@ describe("createGeminiClient — native passthrough", () => {
           allowedMimeTypes: ["image/*"],
         },
       },
+      // Hermetic DNS: example.test resolves to a public address (no real lookup).
+      dnsLookup: async () => ["93.184.216.34"],
       fetch: vi.fn(async (url, init) => {
         calls.push({ url: String(url), init: init ?? {} });
         if (String(url) === "https://example.test/cat.png") {
@@ -220,5 +222,98 @@ describe("createGeminiClient — native passthrough", () => {
         },
       ],
     });
+  });
+
+  // SSRF guard (P2-GEM-02 security): remote media fetch is opt-in, but once enabled a
+  // client-supplied URL must NOT be able to reach internal/link-local/loopback targets
+  // (e.g. the cloud metadata endpoint 169.254.169.254). The guard runs BEFORE the
+  // fetch, so a blocked target is never contacted at all.
+  function fetchSpyOk() {
+    return vi.fn(async () =>
+      jsonResponse({ candidates: [{ content: { role: "model", parts: [{ text: "native" }] } }] }),
+    );
+  }
+
+  function fileUriRequest(fileUri: string) {
+    return {
+      model: "gemini-2.0-flash",
+      contents: [{ role: "user", parts: [{ fileData: { fileUri, mimeType: "image/png" } }] }],
+    };
+  }
+
+  it("blocks a remote media fetch to a private/reserved IP literal without contacting it", async () => {
+    const fetch = fetchSpyOk();
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "g",
+        remoteMediaFetch: { enabled: true },
+      },
+      fetch,
+    });
+    await expect(
+      client.nativePassthrough?.(fileUriRequest("https://169.254.169.254/latest/meta-data/")),
+    ).rejects.toThrow(/private or reserved/);
+    // Fail-closed: neither the metadata endpoint NOR the upstream generateContent was hit.
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks a remote media fetch to a loopback hostname", async () => {
+    const fetch = fetchSpyOk();
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "g",
+        remoteMediaFetch: { enabled: true },
+      },
+      fetch,
+    });
+    await expect(
+      client.nativePassthrough?.(fileUriRequest("https://localhost/secret.png")),
+    ).rejects.toThrow(/local hostname/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks a hostname that DNS-resolves to a private address (rebinding guard)", async () => {
+    const fetch = fetchSpyOk();
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "g",
+        remoteMediaFetch: { enabled: true },
+      },
+      dnsLookup: async () => ["10.0.0.5"],
+      fetch,
+    });
+    await expect(
+      client.nativePassthrough?.(fileUriRequest("https://internal.evil.example/x.png")),
+    ).rejects.toThrow(/resolved to a private/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks a redirect that lands on a private address", async () => {
+    const fetch = vi.fn(async (url: unknown) => {
+      if (String(url) === "https://cdn.example.test/img.png") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://169.254.169.254/x" },
+        });
+      }
+      return jsonResponse({ candidates: [{ content: { role: "model", parts: [{ text: "x" }] } }] });
+    });
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "g",
+        remoteMediaFetch: { enabled: true },
+      },
+      dnsLookup: async () => ["93.184.216.34"],
+      fetch,
+    });
+    await expect(
+      client.nativePassthrough?.(fileUriRequest("https://cdn.example.test/img.png")),
+    ).rejects.toThrow(/private or reserved/);
+    // The first (public) hop was contacted; the upstream generateContent never ran.
+    expect(fetch.mock.calls.map((c) => String(c[0]))).toEqual(["https://cdn.example.test/img.png"]);
   });
 });

--- a/packages/core/src/provider/gemini.test.ts
+++ b/packages/core/src/provider/gemini.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+import { createGeminiClient } from "./gemini.js";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+    ...init,
+  });
+}
+
+function streamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "text/event-stream" } },
+  );
+}
+
+describe("createGeminiClient — native passthrough", () => {
+  it("marks the client as the Gemini native protocol profile", () => {
+    const client = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn() as unknown as typeof fetch,
+    });
+
+    expect(client.nativeProtocolProfile).toBe("gemini");
+  });
+
+  it("posts a native GenerateContent body to the Gemini model path, not OpenAI Chat shape", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "gemini-secret",
+      },
+      fetch: vi.fn(async (url, init) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        return jsonResponse({
+          candidates: [{ content: { role: "model", parts: [{ text: "native" }] } }],
+        });
+      }),
+    });
+
+    const out = await client.nativePassthrough?.({
+      model: "gemini-2.0-flash",
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      generationConfig: { temperature: 0 },
+    });
+
+    expect(out).toMatchObject({
+      candidates: [{ content: { parts: [{ text: "native" }] } }],
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+    );
+    const headers = new Headers(calls[0]?.init.headers);
+    expect(headers.get("x-goog-api-key")).toBe("gemini-secret");
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      generationConfig: { temperature: 0 },
+    });
+    expect(String(calls[0]?.init.body)).not.toContain('"messages"');
+  });
+
+  it("byte-relays Gemini SSE from streamGenerateContent?alt=sse without adding [DONE]", async () => {
+    const chunks = [
+      'data: {"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP"}]}\n\n',
+    ];
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn(async (url, init) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        return streamResponse(chunks);
+      }),
+    });
+
+    const seen: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.({
+      model: "publishers/google/models/gemini-2.0-flash",
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+    }) ?? []) {
+      seen.push(chunk);
+    }
+
+    expect(calls[0]?.url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/publishers/google/models/gemini-2.0-flash:streamGenerateContent?alt=sse",
+    );
+    expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+    });
+    expect(seen.join("")).toBe(chunks.join(""));
+    expect(seen.join("")).not.toContain("[DONE]");
+  });
+
+  it("optionally forwards countTokens to the Gemini countTokens endpoint", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn(async (url, init) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        return jsonResponse({ totalTokens: 7 });
+      }),
+    });
+
+    const out = await client.countTokens?.({
+      model: "gemini-2.0-flash",
+      contents: [{ role: "user", parts: [{ text: "count me" }] }],
+    });
+
+    expect(out).toEqual({ totalTokens: 7 });
+    expect(calls[0]?.url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:countTokens",
+    );
+    expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+      contents: [{ role: "user", parts: [{ text: "count me" }] }],
+    });
+  });
+
+  it("materializes translated HTTPS image placeholders when remote media fetch is enabled", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "g",
+        remoteMediaFetch: {
+          enabled: true,
+          maxBytes: 1024,
+          timeoutMs: 1_000,
+          allowedMimeTypes: ["image/*"],
+        },
+      },
+      fetch: vi.fn(async (url, init) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        if (String(url) === "https://example.test/cat.png") {
+          return new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { "content-type": "image/png", "content-length": "3" },
+          });
+        }
+        return jsonResponse({
+          candidates: [{ content: { role: "model", parts: [{ text: "native" }] } }],
+        });
+      }),
+    });
+
+    await client.nativePassthrough?.({
+      model: "gemini-2.0-flash",
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: "[remote image unsupported by Gemini nativeOut: https://example.test/cat.png]",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(calls.map((c) => c.url)).toEqual([
+      "https://example.test/cat.png",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+    ]);
+    expect(JSON.parse(String(calls[1]?.init.body))).toEqual({
+      contents: [
+        {
+          role: "user",
+          parts: [{ inlineData: { mimeType: "image/png", data: "AQID" } }],
+        },
+      ],
+    });
+  });
+
+  it("leaves remote media placeholders untouched when remote media fetch is disabled", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn(async (url, init) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        return jsonResponse({
+          candidates: [{ content: { role: "model", parts: [{ text: "native" }] } }],
+        });
+      }),
+    });
+
+    await client.nativePassthrough?.({
+      model: "gemini-2.0-flash",
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: "[remote image unsupported by Gemini nativeOut: https://example.test/cat.png]",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: "[remote image unsupported by Gemini nativeOut: https://example.test/cat.png]",
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/src/provider/gemini.test.ts
+++ b/packages/core/src/provider/gemini.test.ts
@@ -127,7 +127,8 @@ describe("createGeminiClient — native passthrough", () => {
   });
 
   it("materializes translated HTTPS image placeholders when remote media fetch is enabled", async () => {
-    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const calls: string[] = [];
+    let apiBody: unknown;
     const client = createGeminiClient({
       config: {
         baseUrl: "https://generativelanguage.googleapis.com/v1beta",
@@ -141,14 +142,17 @@ describe("createGeminiClient — native passthrough", () => {
       },
       // Hermetic DNS: example.test resolves to a public address (no real lookup).
       dnsLookup: async () => ["93.184.216.34"],
+      // Media goes through the dedicated (pinned) media fetcher, NOT the API fetch.
+      mediaFetch: vi.fn(async (url) => {
+        calls.push(String(url));
+        return new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/png", "content-length": "3" },
+        });
+      }),
       fetch: vi.fn(async (url, init) => {
-        calls.push({ url: String(url), init: init ?? {} });
-        if (String(url) === "https://example.test/cat.png") {
-          return new Response(new Uint8Array([1, 2, 3]), {
-            status: 200,
-            headers: { "content-type": "image/png", "content-length": "3" },
-          });
-        }
+        calls.push(String(url));
+        apiBody = JSON.parse(String(init?.body));
         return jsonResponse({
           candidates: [{ content: { role: "model", parts: [{ text: "native" }] } }],
         });
@@ -169,11 +173,11 @@ describe("createGeminiClient — native passthrough", () => {
       ],
     });
 
-    expect(calls.map((c) => c.url)).toEqual([
+    expect(calls).toEqual([
       "https://example.test/cat.png",
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
     ]);
-    expect(JSON.parse(String(calls[1]?.init.body))).toEqual({
+    expect(apiBody).toEqual({
       contents: [
         {
           role: "user",
@@ -181,6 +185,31 @@ describe("createGeminiClient — native passthrough", () => {
         },
       ],
     });
+  });
+
+  it("pins the remote media connection to the validated resolved address (rebinding-proof)", async () => {
+    let pinnedAddress: string | undefined;
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "g",
+        remoteMediaFetch: { enabled: true },
+      },
+      dnsLookup: async () => ["93.184.216.34"],
+      mediaFetch: vi.fn(async (_url, init) => {
+        pinnedAddress = init.pinnedAddress;
+        return new Response(new Uint8Array([1]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        });
+      }),
+      fetch: vi.fn(async () => jsonResponse({ candidates: [] })),
+    });
+
+    await client.nativePassthrough?.(fileUriRequest("https://cdn.example.test/a.png"));
+    // The media fetch is pinned to the exact IP the guard validated — the connection
+    // cannot re-resolve to a private host (no rebinding window).
+    expect(pinnedAddress).toBe("93.184.216.34");
   });
 
   it("leaves remote media placeholders untouched when remote media fetch is disabled", async () => {
@@ -228,7 +257,7 @@ describe("createGeminiClient — native passthrough", () => {
   // client-supplied URL must NOT be able to reach internal/link-local/loopback targets
   // (e.g. the cloud metadata endpoint 169.254.169.254). The guard runs BEFORE the
   // fetch, so a blocked target is never contacted at all.
-  function fetchSpyOk() {
+  function apiFetchSpy() {
     return vi.fn(async () =>
       jsonResponse({ candidates: [{ content: { role: "model", parts: [{ text: "native" }] } }] }),
     );
@@ -242,7 +271,8 @@ describe("createGeminiClient — native passthrough", () => {
   }
 
   it("blocks a remote media fetch to a private/reserved IP literal without contacting it", async () => {
-    const fetch = fetchSpyOk();
+    const fetch = apiFetchSpy();
+    const mediaFetch = vi.fn(async () => new Response(new Uint8Array([1]), { status: 200 }));
     const client = createGeminiClient({
       config: {
         baseUrl: "https://generativelanguage.googleapis.com/v1beta",
@@ -250,16 +280,19 @@ describe("createGeminiClient — native passthrough", () => {
         remoteMediaFetch: { enabled: true },
       },
       fetch,
+      mediaFetch,
     });
     await expect(
       client.nativePassthrough?.(fileUriRequest("https://169.254.169.254/latest/meta-data/")),
     ).rejects.toThrow(/private or reserved/);
     // Fail-closed: neither the metadata endpoint NOR the upstream generateContent was hit.
+    expect(mediaFetch).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it("blocks a remote media fetch to a loopback hostname", async () => {
-    const fetch = fetchSpyOk();
+    const fetch = apiFetchSpy();
+    const mediaFetch = vi.fn(async () => new Response(new Uint8Array([1]), { status: 200 }));
     const client = createGeminiClient({
       config: {
         baseUrl: "https://generativelanguage.googleapis.com/v1beta",
@@ -267,15 +300,18 @@ describe("createGeminiClient — native passthrough", () => {
         remoteMediaFetch: { enabled: true },
       },
       fetch,
+      mediaFetch,
     });
     await expect(
       client.nativePassthrough?.(fileUriRequest("https://localhost/secret.png")),
     ).rejects.toThrow(/local hostname/);
+    expect(mediaFetch).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it("blocks a hostname that DNS-resolves to a private address (rebinding guard)", async () => {
-    const fetch = fetchSpyOk();
+    const fetch = apiFetchSpy();
+    const mediaFetch = vi.fn(async () => new Response(new Uint8Array([1]), { status: 200 }));
     const client = createGeminiClient({
       config: {
         baseUrl: "https://generativelanguage.googleapis.com/v1beta",
@@ -284,22 +320,25 @@ describe("createGeminiClient — native passthrough", () => {
       },
       dnsLookup: async () => ["10.0.0.5"],
       fetch,
+      mediaFetch,
     });
     await expect(
       client.nativePassthrough?.(fileUriRequest("https://internal.evil.example/x.png")),
     ).rejects.toThrow(/resolved to a private/);
+    expect(mediaFetch).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it("blocks a redirect that lands on a private address", async () => {
-    const fetch = vi.fn(async (url: unknown) => {
+    const fetch = apiFetchSpy();
+    const mediaFetch = vi.fn(async (url: URL) => {
       if (String(url) === "https://cdn.example.test/img.png") {
         return new Response(null, {
           status: 302,
           headers: { location: "https://169.254.169.254/x" },
         });
       }
-      return jsonResponse({ candidates: [{ content: { role: "model", parts: [{ text: "x" }] } }] });
+      return new Response(new Uint8Array([1]), { status: 200 });
     });
     const client = createGeminiClient({
       config: {
@@ -309,11 +348,103 @@ describe("createGeminiClient — native passthrough", () => {
       },
       dnsLookup: async () => ["93.184.216.34"],
       fetch,
+      mediaFetch,
     });
     await expect(
       client.nativePassthrough?.(fileUriRequest("https://cdn.example.test/img.png")),
     ).rejects.toThrow(/private or reserved/);
-    // The first (public) hop was contacted; the upstream generateContent never ran.
-    expect(fetch.mock.calls.map((c) => String(c[0]))).toEqual(["https://cdn.example.test/img.png"]);
+    // The first (public) hop was contacted; the redirect target was blocked BEFORE a
+    // second connection, and the upstream generateContent never ran.
+    expect(mediaFetch.mock.calls.map((c) => String(c[0]))).toEqual([
+      "https://cdn.example.test/img.png",
+    ]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+// Translated path (#251 review P1): when a non-Gemini client routes to a Gemini
+// provider (cross-protocol lane) — or native passthrough is disabled — the executor
+// calls chatCompletion/chatCompletionStream. These must translate OpenAI-Chat ⇄ Gemini
+// via the transformers (return OpenAI-shaped output), NOT throw.
+describe("createGeminiClient — translated OpenAI<->Gemini path", () => {
+  it("chatCompletion translates an OpenAI chat request to Gemini native and back to OpenAI", async () => {
+    let sentUrl = "";
+    let sentBody: Record<string, unknown> = {};
+    const client = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn(async (url, init) => {
+        sentUrl = String(url);
+        sentBody = JSON.parse(String(init?.body));
+        return jsonResponse({
+          candidates: [
+            { content: { role: "model", parts: [{ text: "hi there" }] }, finishReason: "STOP" },
+          ],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+        });
+      }),
+    });
+
+    const out = (await client.chatCompletion(
+      { model: "gemini-2.0-flash", messages: [{ role: "user", content: "hello" }] },
+      {},
+    )) as {
+      object: string;
+      choices: Array<{ message: { content: unknown } }>;
+    };
+
+    // Upstream got a NATIVE Gemini body (contents/parts), never OpenAI `messages`.
+    expect(sentUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+    );
+    expect(sentBody.contents).toEqual([{ role: "user", parts: [{ text: "hello" }] }]);
+    expect(sentBody).not.toHaveProperty("messages");
+    // Client got an OpenAI chat.completion back (content may be a string or text parts,
+    // per the IR→OpenAI transformer — both carry the assistant text).
+    expect(out.object).toBe("chat.completion");
+    const content = out.choices[0]?.message.content;
+    const text =
+      typeof content === "string"
+        ? content
+        : Array.isArray(content)
+          ? content.map((part) => (part as { text?: string }).text ?? "").join("")
+          : "";
+    expect(text).toBe("hi there");
+  });
+
+  it("chatCompletionStream translates Gemini SSE into OpenAI chunks terminated by [DONE]", async () => {
+    const client = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn(async () =>
+        streamResponse([
+          'data: {"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\n\n',
+          'data: {"candidates":[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP"}]}\n\n',
+        ]),
+      ),
+    });
+
+    const seen: string[] = [];
+    for await (const chunk of client.chatCompletionStream(
+      { model: "gemini-2.0-flash", messages: [{ role: "user", content: "hi" }] },
+      {},
+    )) {
+      seen.push(chunk);
+    }
+
+    const joined = seen.join("");
+    // OpenAI SSE framing with a [DONE] terminator (Gemini native has none).
+    expect(joined.endsWith("data: [DONE]\n\n")).toBe(true);
+    // Reconstruct the assistant text from the OpenAI-shaped delta chunks.
+    const text = seen
+      .filter((s) => s.startsWith("data: ") && !s.includes("[DONE]"))
+      .map(
+        (s) =>
+          JSON.parse(s.slice("data: ".length)) as {
+            choices?: Array<{ delta?: { content?: string } }>;
+          },
+      )
+      .flatMap((c) => c.choices ?? [])
+      .map((ch) => ch.delta?.content ?? "")
+      .join("");
+    expect(text).toBe("Hello");
   });
 });

--- a/packages/core/src/provider/gemini.ts
+++ b/packages/core/src/provider/gemini.ts
@@ -1,5 +1,10 @@
 import { lookup as nodeDnsLookup } from "node:dns/promises";
+import https from "node:https";
+import { Readable } from "node:stream";
 import { type NativePassthroughInput, nativePassthroughBody } from "@helm/shared";
+import { geminiTransformer } from "../protocol/gemini/gemini-transformer.js";
+import type { GeminiSSEEvent } from "../protocol/gemini/gemini-types.js";
+import { openaiTransformer } from "../protocol/openai.js";
 import {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
@@ -16,6 +21,121 @@ const defaultDnsLookup: HostnameLookup = async (hostname) => {
   const results = await nodeDnsLookup(hostname, { all: true });
   return results.map((r) => r.address);
 };
+
+// Remote-media fetcher. SEPARATE from the API `fetch` (which may route through the LLM
+// proxy): media must connect to the EXACT address the SSRF guard validated, so the
+// default implementation pins the connection to `pinnedAddress` (closes the DNS-
+// rebinding window between validation and connection). Injectable for hermetic tests.
+export type GeminiMediaFetch = (
+  url: URL,
+  init: { signal?: AbortSignal; pinnedAddress?: string },
+) => Promise<Response>;
+
+// Default media fetcher: node:https GET pinned to the pre-validated address via a
+// custom `lookup`, with SNI/cert validation still bound to the real hostname. Does NOT
+// follow redirects (the caller validates each hop). Global `fetch` cannot pin the
+// connection IP without re-resolving, which is exactly the rebinding hole.
+const pinnedHttpsMediaFetch: GeminiMediaFetch = (url, init) =>
+  new Promise<Response>((resolve, reject) => {
+    const pinned = init.pinnedAddress;
+    const request = https.request(
+      url,
+      {
+        method: "GET",
+        servername: url.hostname,
+        ...(init.signal !== undefined ? { signal: init.signal } : {}),
+        ...(pinned !== undefined
+          ? {
+              lookup: (
+                _hostname: string,
+                _options: unknown,
+                callback: (err: Error | null, address: string, family: number) => void,
+              ) => callback(null, pinned, pinned.includes(":") ? 6 : 4),
+            }
+          : {}),
+      },
+      (res) => {
+        const status = res.statusCode ?? 502;
+        const headers = new Headers();
+        for (const [key, value] of Object.entries(res.headers)) {
+          if (typeof value === "string") headers.set(key, value);
+          else if (Array.isArray(value)) headers.set(key, value.join(", "));
+        }
+        const hasBody = status !== 204 && status !== 304;
+        const body = hasBody
+          ? (Readable.toWeb(res) as unknown as ReadableStream<Uint8Array>)
+          : null;
+        resolve(new Response(body, { status, headers }));
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+
+// The protocol transformers declare `T | Promise<T>`; openai + gemini are synchronous.
+// Assert that here so the translated path stays a simple sequence (mirrors execute.ts).
+function expectSync<T>(value: T | Promise<T>, label: string): T {
+  if (value !== null && typeof (value as Promise<T>).then === "function") {
+    throw new UpstreamError("upstream_error", `${label} unexpectedly returned a Promise`);
+  }
+  return value as T;
+}
+
+// Translated path (cross-protocol, or passthrough disabled): an OpenAI-Chat IR request
+// must reach a Gemini upstream and come back OpenAI-shaped. Compose the two
+// transformers through the IR: OpenAI → IR → Gemini native (request), Gemini native →
+// IR → OpenAI (response). Gemini carries the model in the URL, so it rides separately.
+function openAIChatToGeminiBody(req: ChatCompletionRequest): {
+  model: string;
+  body: Record<string, unknown>;
+} {
+  const ir = expectSync(openaiTransformer.transformRequestOut(req), "OpenAI->IR");
+  const native = expectSync(geminiTransformer.transformRequestIn(ir), "IR->Gemini") as Record<
+    string,
+    unknown
+  >;
+  return { model: String((req as Record<string, unknown>).model ?? ""), body: native };
+}
+
+function geminiResponseToOpenAIChat(json: unknown): ChatCompletionResponse {
+  const ir = expectSync(geminiTransformer.transformResponseIn(json), "Gemini->IR");
+  return expectSync(
+    openaiTransformer.transformResponseOut(ir),
+    "IR->OpenAI",
+  ) as ChatCompletionResponse;
+}
+
+// Re-frame raw Gemini SSE bytes into parsed GenerateContent frames for transformStreamIn
+// (which re-validates each via Zod). Buffers across non-frame-aligned chunks.
+async function* parseGeminiStreamEvents(raw: AsyncIterable<string>): AsyncIterable<GeminiSSEEvent> {
+  let buffer = "";
+  const flushFrame = (frame: string): GeminiSSEEvent | null => {
+    for (const line of frame.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice("data:".length).trim();
+      if (payload === "" || payload === "[DONE]") return null;
+      try {
+        return JSON.parse(payload) as GeminiSSEEvent;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  };
+  for await (const chunk of raw) {
+    buffer += chunk;
+    let idx = buffer.indexOf("\n\n");
+    while (idx !== -1) {
+      const event = flushFrame(buffer.slice(0, idx));
+      buffer = buffer.slice(idx + 2);
+      if (event !== null) yield event;
+      idx = buffer.indexOf("\n\n");
+    }
+  }
+  const tail = flushFrame(buffer);
+  if (tail !== null) yield tail;
+}
 
 export interface GeminiClientConfig {
   baseUrl: string;
@@ -40,6 +160,9 @@ export interface GeminiClientDeps {
   fetch?: typeof globalThis.fetch;
   /** Override hostname resolution for the remote-media SSRF guard (tests). */
   dnsLookup?: HostnameLookup;
+  /** Override the remote-media fetcher (tests). Production uses the pinned node:https
+   *  fetcher so the connection cannot re-resolve to a private host. */
+  mediaFetch?: GeminiMediaFetch;
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -165,7 +288,15 @@ function isBlockedHostname(host: string): boolean {
   return h === "localhost" || h.endsWith(".localhost");
 }
 
-async function assertPublicHttpsTarget(target: URL, lookup: HostnameLookup): Promise<void> {
+// Validates the target and returns the PINNED address the connection must use. For an
+// IP literal that is the literal itself; for a DNS name it is the first validated
+// resolved address (so the media fetch connects to exactly what we vetted — no second
+// resolution that a rebinding response could redirect to a private host). Returns
+// undefined only when the host is unresolvable (the fetch then fails naturally).
+async function assertPublicHttpsTarget(
+  target: URL,
+  lookup: HostnameLookup,
+): Promise<string | undefined> {
   if (target.protocol !== "https:") {
     throw new UpstreamError("upstream_error", "Gemini remote media fetch only allows https URLs");
   }
@@ -177,7 +308,7 @@ async function assertPublicHttpsTarget(target: URL, lookup: HostnameLookup): Pro
         "Gemini remote media fetch blocked a private or reserved address",
       );
     }
-    return;
+    return host;
   }
   if (isBlockedHostname(host)) {
     throw new UpstreamError("upstream_error", "Gemini remote media fetch blocked a local hostname");
@@ -187,7 +318,7 @@ async function assertPublicHttpsTarget(target: URL, lookup: HostnameLookup): Pro
     addresses = await lookup(host);
   } catch {
     // Unresolvable host → the fetch itself cannot reach anything; let it fail naturally.
-    return;
+    return undefined;
   }
   for (const address of addresses) {
     if (isBlockedIp(address)) {
@@ -197,13 +328,53 @@ async function assertPublicHttpsTarget(target: URL, lookup: HostnameLookup): Pro
       );
     }
   }
+  return addresses[0];
+}
+
+// Read a response body with a HARD byte cap enforced WHILE streaming (abort once the
+// limit is crossed — never allocate an unbounded buffer) and a per-chunk idle timeout,
+// so a missing/lying Content-Length or a slow/endless body cannot exhaust memory or hang.
+async function readBodyWithLimit(
+  res: Response,
+  maxBytes: number,
+  idleTimeoutMs: number,
+): Promise<Buffer> {
+  const reader = res.body?.getReader();
+  if (reader === undefined) return Buffer.alloc(0);
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      let read: { done: boolean; value?: Uint8Array };
+      try {
+        read = await readChunkWithIdle(reader, idleTimeoutMs);
+      } catch (err) {
+        if (err instanceof StreamStalledError) {
+          throw new UpstreamError("timeout", "Gemini remote media fetch stalled");
+        }
+        throw err;
+      }
+      if (read.done) break;
+      if (read.value !== undefined) {
+        total += read.value.byteLength;
+        if (total > maxBytes) {
+          await reader.cancel().catch(() => {});
+          throw new UpstreamError("upstream_error", "remote media exceeds configured max_bytes");
+        }
+        chunks.push(Buffer.from(read.value));
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks);
 }
 
 async function fetchRemoteMediaInlineData(
   url: string,
   mimeHint: string | undefined,
   config: GeminiRemoteMediaFetchConfig,
-  doFetch: typeof globalThis.fetch,
+  mediaFetch: GeminiMediaFetch,
   lookup: HostnameLookup,
   external?: AbortSignal,
 ): Promise<{ mimeType: string; data: string }> {
@@ -213,12 +384,13 @@ async function fetchRemoteMediaInlineData(
   let current = new URL(url);
   for (let redirect = 0; redirect <= maxRedirects; redirect += 1) {
     // SSRF guard: validate https + reject private/reserved targets on EVERY hop,
-    // before any bytes are sent — the original URL and each redirect destination.
-    await assertPublicHttpsTarget(current, lookup);
+    // before any bytes are sent — the original URL and each redirect destination —
+    // and pin the connection to the exact validated address.
+    const pinnedAddress = await assertPublicHttpsTarget(current, lookup);
     const t = remoteMediaSignal(timeoutMs, external);
     let res: Response;
     try {
-      res = await doFetch(current, { method: "GET", redirect: "manual", signal: t.signal });
+      res = await mediaFetch(current, { signal: t.signal, pinnedAddress });
     } catch (err) {
       if (t.signal.aborted && external?.aborted !== true) {
         throw new UpstreamError("timeout", "Gemini remote media fetch timed out");
@@ -256,10 +428,7 @@ async function fetchRemoteMediaInlineData(
         `remote media mime type is not allowed: ${mimeType}`,
       );
     }
-    const bytes = Buffer.from(await res.arrayBuffer());
-    if (bytes.byteLength > maxBytes) {
-      throw new UpstreamError("upstream_error", "remote media exceeds configured max_bytes");
-    }
+    const bytes = await readBodyWithLimit(res, maxBytes, timeoutMs);
     return { mimeType, data: bytes.toString("base64") };
   }
   throw new UpstreamError("upstream_error", "remote media exceeded redirect limit");
@@ -268,7 +437,7 @@ async function fetchRemoteMediaInlineData(
 async function materializeGeminiPart(
   part: unknown,
   config: GeminiRemoteMediaFetchConfig,
-  doFetch: typeof globalThis.fetch,
+  mediaFetch: GeminiMediaFetch,
   lookup: HostnameLookup,
   signal?: AbortSignal,
 ): Promise<{ part: unknown; changed: boolean }> {
@@ -281,7 +450,7 @@ async function materializeGeminiPart(
         fileUri,
         typeof fileData.mimeType === "string" ? fileData.mimeType : undefined,
         config,
-        doFetch,
+        mediaFetch,
         lookup,
         signal,
       );
@@ -295,7 +464,7 @@ async function materializeGeminiPart(
         match[1],
         "image/png",
         config,
-        doFetch,
+        mediaFetch,
         lookup,
         signal,
       );
@@ -308,7 +477,7 @@ async function materializeGeminiPart(
 export async function materializeGeminiRemoteMediaBody(
   body: Record<string, unknown>,
   config: GeminiRemoteMediaFetchConfig | undefined,
-  doFetch: typeof globalThis.fetch,
+  mediaFetch: GeminiMediaFetch,
   signal?: AbortSignal,
   lookup: HostnameLookup = defaultDnsLookup,
 ): Promise<Record<string, unknown>> {
@@ -319,7 +488,7 @@ export async function materializeGeminiRemoteMediaBody(
       if (!isRecord(content) || !Array.isArray(content.parts)) return content;
       const parts = await Promise.all(
         content.parts.map(async (part) => {
-          const out = await materializeGeminiPart(part, config, doFetch, lookup, signal);
+          const out = await materializeGeminiPart(part, config, mediaFetch, lookup, signal);
           if (out.changed) changed = true;
           return out.part;
         }),
@@ -333,6 +502,7 @@ export async function materializeGeminiRemoteMediaBody(
 export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
   const doFetch = deps.fetch ?? globalThis.fetch;
   const dnsLookup = deps.dnsLookup ?? defaultDnsLookup;
+  const mediaFetch = deps.mediaFetch ?? pinnedHttpsMediaFetch;
   const cfg = deps.config;
   const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
@@ -382,7 +552,7 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
       const materializedBody = await materializeGeminiRemoteMediaBody(
         body,
         cfg.remoteMediaFetch,
-        doFetch,
+        mediaFetch,
         t.signal,
         dnsLookup,
       );
@@ -461,12 +631,32 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
   return {
     nativeProtocolProfile: "gemini",
 
-    async chatCompletion(): Promise<ChatCompletionResponse> {
-      throw new UpstreamError("upstream_error", "gemini client requires native passthrough");
+    // Translated path (#251 review P1): a non-Gemini client routed here, or native
+    // passthrough disabled. Translate OpenAI-Chat → Gemini → OpenAI via the
+    // transformers instead of failing — mirrors the anthropic client's translated path.
+    async chatCompletion(req, opts) {
+      const { model, body } = openAIChatToGeminiBody(req);
+      const res = await requestWithAuthRetry("generateContent", { ...body, model }, opts?.signal);
+      if (!res.ok) throw await errorFromResponse(res);
+      return geminiResponseToOpenAIChat(await res.json());
     },
 
-    chatCompletionStream(): AsyncIterable<string> {
-      throw new UpstreamError("upstream_error", "gemini client requires native passthrough");
+    async *chatCompletionStream(req, opts) {
+      const { model, body } = openAIChatToGeminiBody(req);
+      const res = await requestWithAuthRetry(
+        "streamGenerateContent",
+        { ...body, model },
+        opts?.signal,
+      );
+      if (!res.ok) throw await errorFromResponse(res);
+      // Gemini native SSE → IR chunks → OpenAI SSE strings. IRChunk IS the OpenAI
+      // chat.completion.chunk, so the pipeline's parseOpenAISSE consumes these directly.
+      for await (const chunk of geminiTransformer.transformStreamIn(
+        parseGeminiStreamEvents(readRawSSE(res)),
+      )) {
+        yield `data: ${JSON.stringify(chunk)}\n\n`;
+      }
+      yield "data: [DONE]\n\n";
     },
 
     async nativePassthrough(input, opts) {

--- a/packages/core/src/provider/gemini.ts
+++ b/packages/core/src/provider/gemini.ts
@@ -1,3 +1,4 @@
+import { lookup as nodeDnsLookup } from "node:dns/promises";
 import { type NativePassthroughInput, nativePassthroughBody } from "@helm/shared";
 import {
   type ChatCompletionRequest,
@@ -6,6 +7,15 @@ import {
   UpstreamError,
 } from "./openai.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
+
+// Resolve a hostname to its candidate addresses. Injectable so the SSRF guard can be
+// tested hermetically (no real DNS) — production uses node:dns lookup(all).
+export type HostnameLookup = (hostname: string) => Promise<string[]>;
+
+const defaultDnsLookup: HostnameLookup = async (hostname) => {
+  const results = await nodeDnsLookup(hostname, { all: true });
+  return results.map((r) => r.address);
+};
 
 export interface GeminiClientConfig {
   baseUrl: string;
@@ -28,6 +38,8 @@ export interface GeminiRemoteMediaFetchConfig {
 export interface GeminiClientDeps {
   config: GeminiClientConfig;
   fetch?: typeof globalThis.fetch;
+  /** Override hostname resolution for the remote-media SSRF guard (tests). */
+  dnsLookup?: HostnameLookup;
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -98,21 +110,111 @@ function remoteMediaSignal(timeoutMs: number, external?: AbortSignal) {
   };
 }
 
+// —— SSRF guard for remote media fetch (P2-GEM-02). Remote fetch is opt-in, but once
+// enabled a client-supplied URL must not be able to reach internal infrastructure
+// (cloud metadata at 169.254.169.254, loopback, RFC1918, ULA/link-local v6, …). We
+// reject literal private/reserved IPs AND resolve DNS names to catch a public name
+// that points at a private address (rebinding). Re-checked on every redirect hop.
+
+function parseIpv4Octets(host: string): [number, number, number, number] | null {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (m === null) return null;
+  const octets = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])] as const;
+  if (octets.some((o) => o > 255)) return null;
+  return [octets[0], octets[1], octets[2], octets[3]];
+}
+
+function isBlockedIpv4([a, b]: [number, number, number, number]): boolean {
+  if (a === 0) return true; // 0.0.0.0/8 "this network"
+  if (a === 10) return true; // RFC1918
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local (incl. 169.254.169.254 metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+  if (a === 192 && b === 168) return true; // RFC1918
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT (RFC6598)
+  if (a === 192 && b === 0) return true; // 192.0.0/24 IETF + 192.0.2/24 TEST-NET-1
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast (224/4), reserved (240/4), broadcast
+  return false;
+}
+
+function isBlockedIpv6(host: string): boolean {
+  const lower = host.toLowerCase();
+  if (lower === "::1" || lower === "::") return true; // loopback / unspecified
+  if (/^f[cd]/.test(lower)) return true; // fc00::/7 unique-local
+  if (/^fe[89ab]/.test(lower)) return true; // fe80::/10 link-local
+  // IPv4-mapped (::ffff:a.b.c.d) — validate the embedded v4 address.
+  const mapped = /(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/.exec(lower);
+  const v4 = mapped?.[1] !== undefined ? parseIpv4Octets(mapped[1]) : null;
+  return v4 !== null && isBlockedIpv4(v4);
+}
+
+function isIpLiteral(host: string): boolean {
+  return parseIpv4Octets(host) !== null || host.includes(":");
+}
+
+function isBlockedIp(host: string): boolean {
+  const v4 = parseIpv4Octets(host);
+  if (v4 !== null) return isBlockedIpv4(v4);
+  if (host.includes(":")) return isBlockedIpv6(host);
+  return false; // not an IP literal
+}
+
+function isBlockedHostname(host: string): boolean {
+  const h = host.toLowerCase().replace(/\.$/, "");
+  return h === "localhost" || h.endsWith(".localhost");
+}
+
+async function assertPublicHttpsTarget(target: URL, lookup: HostnameLookup): Promise<void> {
+  if (target.protocol !== "https:") {
+    throw new UpstreamError("upstream_error", "Gemini remote media fetch only allows https URLs");
+  }
+  const host = target.hostname.replace(/^\[|\]$/g, ""); // URL keeps IPv6 in brackets
+  if (isIpLiteral(host)) {
+    if (isBlockedIp(host)) {
+      throw new UpstreamError(
+        "upstream_error",
+        "Gemini remote media fetch blocked a private or reserved address",
+      );
+    }
+    return;
+  }
+  if (isBlockedHostname(host)) {
+    throw new UpstreamError("upstream_error", "Gemini remote media fetch blocked a local hostname");
+  }
+  let addresses: string[];
+  try {
+    addresses = await lookup(host);
+  } catch {
+    // Unresolvable host → the fetch itself cannot reach anything; let it fail naturally.
+    return;
+  }
+  for (const address of addresses) {
+    if (isBlockedIp(address)) {
+      throw new UpstreamError(
+        "upstream_error",
+        "Gemini remote media host resolved to a private or reserved address",
+      );
+    }
+  }
+}
+
 async function fetchRemoteMediaInlineData(
   url: string,
   mimeHint: string | undefined,
   config: GeminiRemoteMediaFetchConfig,
   doFetch: typeof globalThis.fetch,
+  lookup: HostnameLookup,
   external?: AbortSignal,
 ): Promise<{ mimeType: string; data: string }> {
-  if (!url.startsWith("https://")) {
-    throw new UpstreamError("upstream_error", "Gemini remote media fetch only allows https URLs");
-  }
   const maxBytes = config.maxBytes ?? DEFAULT_REMOTE_MEDIA_MAX_BYTES;
   const timeoutMs = config.timeoutMs ?? DEFAULT_REMOTE_MEDIA_TIMEOUT_MS;
   const maxRedirects = config.maxRedirects ?? DEFAULT_REMOTE_MEDIA_MAX_REDIRECTS;
   let current = new URL(url);
   for (let redirect = 0; redirect <= maxRedirects; redirect += 1) {
+    // SSRF guard: validate https + reject private/reserved targets on EVERY hop,
+    // before any bytes are sent — the original URL and each redirect destination.
+    await assertPublicHttpsTarget(current, lookup);
     const t = remoteMediaSignal(timeoutMs, external);
     let res: Response;
     try {
@@ -167,6 +269,7 @@ async function materializeGeminiPart(
   part: unknown,
   config: GeminiRemoteMediaFetchConfig,
   doFetch: typeof globalThis.fetch,
+  lookup: HostnameLookup,
   signal?: AbortSignal,
 ): Promise<{ part: unknown; changed: boolean }> {
   if (!isRecord(part)) return { part, changed: false };
@@ -179,6 +282,7 @@ async function materializeGeminiPart(
         typeof fileData.mimeType === "string" ? fileData.mimeType : undefined,
         config,
         doFetch,
+        lookup,
         signal,
       );
       return { part: { ...part, fileData: undefined, inlineData }, changed: true };
@@ -192,6 +296,7 @@ async function materializeGeminiPart(
         "image/png",
         config,
         doFetch,
+        lookup,
         signal,
       );
       return { part: { inlineData }, changed: true };
@@ -205,6 +310,7 @@ export async function materializeGeminiRemoteMediaBody(
   config: GeminiRemoteMediaFetchConfig | undefined,
   doFetch: typeof globalThis.fetch,
   signal?: AbortSignal,
+  lookup: HostnameLookup = defaultDnsLookup,
 ): Promise<Record<string, unknown>> {
   if (config?.enabled !== true || !Array.isArray(body.contents)) return body;
   let changed = false;
@@ -213,7 +319,7 @@ export async function materializeGeminiRemoteMediaBody(
       if (!isRecord(content) || !Array.isArray(content.parts)) return content;
       const parts = await Promise.all(
         content.parts.map(async (part) => {
-          const out = await materializeGeminiPart(part, config, doFetch, signal);
+          const out = await materializeGeminiPart(part, config, doFetch, lookup, signal);
           if (out.changed) changed = true;
           return out.part;
         }),
@@ -226,6 +332,7 @@ export async function materializeGeminiRemoteMediaBody(
 
 export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
   const doFetch = deps.fetch ?? globalThis.fetch;
+  const dnsLookup = deps.dnsLookup ?? defaultDnsLookup;
   const cfg = deps.config;
   const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
@@ -277,6 +384,7 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
         cfg.remoteMediaFetch,
         doFetch,
         t.signal,
+        dnsLookup,
       );
       return await doFetch(endpoint(cfg.baseUrl, model, operation), {
         method: "POST",

--- a/packages/core/src/provider/gemini.ts
+++ b/packages/core/src/provider/gemini.ts
@@ -1,0 +1,382 @@
+import { type NativePassthroughInput, nativePassthroughBody } from "@helm/shared";
+import {
+  type ChatCompletionRequest,
+  type ChatCompletionResponse,
+  type ProviderClient,
+  UpstreamError,
+} from "./openai.js";
+import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
+
+export interface GeminiClientConfig {
+  baseUrl: string;
+  apiKey?: string;
+  getAuthHeader?: () => Promise<string>;
+  onUnauthorized?: () => void;
+  currentSecrets?: () => string[];
+  timeoutMs?: number;
+  remoteMediaFetch?: GeminiRemoteMediaFetchConfig;
+}
+
+export interface GeminiRemoteMediaFetchConfig {
+  enabled: boolean;
+  maxBytes?: number;
+  timeoutMs?: number;
+  maxRedirects?: number;
+  allowedMimeTypes?: string[];
+}
+
+export interface GeminiClientDeps {
+  config: GeminiClientConfig;
+  fetch?: typeof globalThis.fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_REMOTE_MEDIA_MAX_BYTES = 5_000_000;
+const DEFAULT_REMOTE_MEDIA_TIMEOUT_MS = 5_000;
+const DEFAULT_REMOTE_MEDIA_MAX_REDIRECTS = 2;
+const REMOTE_IMAGE_PLACEHOLDER =
+  /^\[remote image unsupported by Gemini nativeOut: (https:\/\/[^\]]+)\]$/;
+
+function withTimeout(timeoutMs: number, external?: AbortSignal) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  const signal = AbortSignal.any(external ? [ctrl.signal, external] : [ctrl.signal]);
+  return {
+    signal,
+    isTimeout: () => ctrl.signal.aborted,
+    isExternalAbort: () => external?.aborted ?? false,
+    cleanup: () => clearTimeout(timer),
+  };
+}
+
+function endpoint(baseUrl: string, model: string, operation: string): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  const modelRoot = base.endsWith("/models") ? base : `${base}/models`;
+  const modelPath = model
+    .replace(/^\/+/, "")
+    .replace(/^models\//, "")
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  const query = operation === "streamGenerateContent" ? "?alt=sse" : "";
+  return `${modelRoot}/${modelPath}:${operation}${query}`;
+}
+
+function bodyAndModel(input: NativePassthroughInput): {
+  model: string;
+  body: Record<string, unknown>;
+} {
+  const body = { ...nativePassthroughBody(input) };
+  const model = body.model;
+  if (typeof model !== "string" || model.length === 0) {
+    throw new UpstreamError("upstream_error", "gemini native request requires model");
+  }
+  delete body.model;
+  // `stream` is the gateway's InternalRequest switch; Gemini selects streaming by path.
+  delete body.stream;
+  return { model, body };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function mimeAllowed(mimeType: string, allowed: readonly string[] | undefined): boolean {
+  if (allowed === undefined || allowed.length === 0) return true;
+  return allowed.some((entry) => {
+    if (entry.endsWith("/*")) return mimeType.startsWith(`${entry.slice(0, -2)}/`);
+    return mimeType === entry;
+  });
+}
+
+function remoteMediaSignal(timeoutMs: number, external?: AbortSignal) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  return {
+    signal: AbortSignal.any(external ? [ctrl.signal, external] : [ctrl.signal]),
+    cleanup: () => clearTimeout(timer),
+  };
+}
+
+async function fetchRemoteMediaInlineData(
+  url: string,
+  mimeHint: string | undefined,
+  config: GeminiRemoteMediaFetchConfig,
+  doFetch: typeof globalThis.fetch,
+  external?: AbortSignal,
+): Promise<{ mimeType: string; data: string }> {
+  if (!url.startsWith("https://")) {
+    throw new UpstreamError("upstream_error", "Gemini remote media fetch only allows https URLs");
+  }
+  const maxBytes = config.maxBytes ?? DEFAULT_REMOTE_MEDIA_MAX_BYTES;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_REMOTE_MEDIA_TIMEOUT_MS;
+  const maxRedirects = config.maxRedirects ?? DEFAULT_REMOTE_MEDIA_MAX_REDIRECTS;
+  let current = new URL(url);
+  for (let redirect = 0; redirect <= maxRedirects; redirect += 1) {
+    const t = remoteMediaSignal(timeoutMs, external);
+    let res: Response;
+    try {
+      res = await doFetch(current, { method: "GET", redirect: "manual", signal: t.signal });
+    } catch (err) {
+      if (t.signal.aborted && external?.aborted !== true) {
+        throw new UpstreamError("timeout", "Gemini remote media fetch timed out");
+      }
+      throw err;
+    } finally {
+      t.cleanup();
+    }
+    if (res.status >= 300 && res.status < 400 && res.headers.get("location") !== null) {
+      await res.body?.cancel().catch(() => {});
+      const next = new URL(res.headers.get("location") as string, current);
+      if (next.protocol !== "https:") {
+        throw new UpstreamError("upstream_error", "Gemini remote media redirect must stay https");
+      }
+      current = next;
+      continue;
+    }
+    if (!res.ok) {
+      throw new UpstreamError("upstream_error", `remote media fetch returned ${res.status}`);
+    }
+    const contentLength = res.headers.get("content-length");
+    if (contentLength !== null && Number(contentLength) > maxBytes) {
+      await res.body?.cancel().catch(() => {});
+      throw new UpstreamError("upstream_error", "remote media exceeds configured max_bytes");
+    }
+    const mimeType =
+      (res.headers.get("content-type") ?? mimeHint ?? "application/octet-stream")
+        .split(";")[0]
+        ?.trim()
+        .toLowerCase() ?? "application/octet-stream";
+    if (!mimeAllowed(mimeType, config.allowedMimeTypes)) {
+      await res.body?.cancel().catch(() => {});
+      throw new UpstreamError(
+        "upstream_error",
+        `remote media mime type is not allowed: ${mimeType}`,
+      );
+    }
+    const bytes = Buffer.from(await res.arrayBuffer());
+    if (bytes.byteLength > maxBytes) {
+      throw new UpstreamError("upstream_error", "remote media exceeds configured max_bytes");
+    }
+    return { mimeType, data: bytes.toString("base64") };
+  }
+  throw new UpstreamError("upstream_error", "remote media exceeded redirect limit");
+}
+
+async function materializeGeminiPart(
+  part: unknown,
+  config: GeminiRemoteMediaFetchConfig,
+  doFetch: typeof globalThis.fetch,
+  signal?: AbortSignal,
+): Promise<{ part: unknown; changed: boolean }> {
+  if (!isRecord(part)) return { part, changed: false };
+  if (isRecord(part.fileData) && typeof part.fileData.fileUri === "string") {
+    const fileData = part.fileData as Record<string, unknown>;
+    const fileUri = part.fileData.fileUri;
+    if (fileUri.startsWith("https://")) {
+      const inlineData = await fetchRemoteMediaInlineData(
+        fileUri,
+        typeof fileData.mimeType === "string" ? fileData.mimeType : undefined,
+        config,
+        doFetch,
+        signal,
+      );
+      return { part: { ...part, fileData: undefined, inlineData }, changed: true };
+    }
+  }
+  if (typeof part.text === "string") {
+    const match = REMOTE_IMAGE_PLACEHOLDER.exec(part.text);
+    if (match?.[1] !== undefined) {
+      const inlineData = await fetchRemoteMediaInlineData(
+        match[1],
+        "image/png",
+        config,
+        doFetch,
+        signal,
+      );
+      return { part: { inlineData }, changed: true };
+    }
+  }
+  return { part, changed: false };
+}
+
+export async function materializeGeminiRemoteMediaBody(
+  body: Record<string, unknown>,
+  config: GeminiRemoteMediaFetchConfig | undefined,
+  doFetch: typeof globalThis.fetch,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+  if (config?.enabled !== true || !Array.isArray(body.contents)) return body;
+  let changed = false;
+  const contents = await Promise.all(
+    body.contents.map(async (content) => {
+      if (!isRecord(content) || !Array.isArray(content.parts)) return content;
+      const parts = await Promise.all(
+        content.parts.map(async (part) => {
+          const out = await materializeGeminiPart(part, config, doFetch, signal);
+          if (out.changed) changed = true;
+          return out.part;
+        }),
+      );
+      return parts === content.parts ? content : { ...content, parts };
+    }),
+  );
+  return changed ? { ...body, contents } : body;
+}
+
+export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const cfg = deps.config;
+  const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const hasStatic = cfg.apiKey !== undefined;
+  const hasDynamic = cfg.getAuthHeader !== undefined;
+  if (hasStatic === hasDynamic) {
+    throw new Error("gemini client requires exactly one of `apiKey` or `getAuthHeader`");
+  }
+
+  async function headers(): Promise<Record<string, string>> {
+    const h: Record<string, string> = { "Content-Type": "application/json" };
+    if (cfg.getAuthHeader !== undefined) h.Authorization = await cfg.getAuthHeader();
+    else h["x-goog-api-key"] = cfg.apiKey as string;
+    return h;
+  }
+
+  function scrub(raw: unknown): unknown {
+    if (raw === null) return raw;
+    const secrets = cfg.currentSecrets ? cfg.currentSecrets() : [];
+    if (cfg.apiKey !== undefined) secrets.push(cfg.apiKey);
+    const replace = (value: string): { value: string; changed: boolean } => {
+      let v = value;
+      let changed = false;
+      for (const secret of secrets) {
+        if (secret.length < 4) continue;
+        if (v.includes(secret)) {
+          v = v.split(secret).join("[redacted]");
+          changed = true;
+        }
+      }
+      return { value: v, changed };
+    };
+    if (typeof raw === "string") return replace(raw).value;
+    if (typeof raw !== "object") return raw;
+    const { value, changed } = replace(JSON.stringify(raw));
+    return changed ? JSON.parse(value) : raw;
+  }
+
+  async function request(
+    operation: "generateContent" | "streamGenerateContent" | "countTokens",
+    input: NativePassthroughInput,
+    external?: AbortSignal,
+  ): Promise<Response> {
+    const { model, body } = bodyAndModel(input);
+    const t = withTimeout(timeoutMs, external);
+    try {
+      const materializedBody = await materializeGeminiRemoteMediaBody(
+        body,
+        cfg.remoteMediaFetch,
+        doFetch,
+        t.signal,
+      );
+      return await doFetch(endpoint(cfg.baseUrl, model, operation), {
+        method: "POST",
+        headers: await headers(),
+        body: JSON.stringify(materializedBody),
+        signal: t.signal,
+      });
+    } catch (err) {
+      if (t.isTimeout() && !t.isExternalAbort()) {
+        throw new UpstreamError("timeout", "upstream request timed out");
+      }
+      throw err;
+    } finally {
+      t.cleanup();
+    }
+  }
+
+  async function requestWithAuthRetry(
+    operation: "generateContent" | "streamGenerateContent" | "countTokens",
+    input: NativePassthroughInput,
+    external?: AbortSignal,
+  ): Promise<Response> {
+    const res = await request(operation, input, external);
+    if (res.status === 401 && cfg.onUnauthorized !== undefined) {
+      await res.body?.cancel().catch(() => {});
+      cfg.onUnauthorized();
+      return await request(operation, input, external);
+    }
+    return res;
+  }
+
+  async function errorFromResponse(res: Response): Promise<UpstreamError> {
+    const providerRaw = await res
+      .text()
+      .then((text) => {
+        try {
+          return JSON.parse(text) as unknown;
+        } catch {
+          return text;
+        }
+      })
+      .catch(() => null)
+      .then(scrub);
+    return new UpstreamError(
+      "upstream_error",
+      `upstream returned ${res.status}`,
+      providerRaw,
+      res.status,
+    );
+  }
+
+  async function* readRawSSE(res: Response): AsyncGenerator<string> {
+    const body = res.body;
+    if (!body) return;
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    try {
+      while (true) {
+        let read: { done: boolean; value?: Uint8Array };
+        try {
+          read = await readChunkWithIdle(reader, timeoutMs);
+        } catch (err) {
+          if (err instanceof StreamStalledError) throw new UpstreamError("timeout", err.message);
+          throw err;
+        }
+        if (read.done) break;
+        if (read.value) yield decoder.decode(read.value, { stream: true });
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  return {
+    nativeProtocolProfile: "gemini",
+
+    async chatCompletion(): Promise<ChatCompletionResponse> {
+      throw new UpstreamError("upstream_error", "gemini client requires native passthrough");
+    },
+
+    chatCompletionStream(): AsyncIterable<string> {
+      throw new UpstreamError("upstream_error", "gemini client requires native passthrough");
+    },
+
+    async nativePassthrough(input, opts) {
+      const res = await requestWithAuthRetry("generateContent", input, opts?.signal);
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async *nativePassthroughStream(input, opts) {
+      const res = await requestWithAuthRetry("streamGenerateContent", input, opts?.signal);
+      if (!res.ok) throw await errorFromResponse(res);
+      yield* readRawSSE(res);
+    },
+
+    async countTokens(req: ChatCompletionRequest, opts) {
+      const res = await requestWithAuthRetry("countTokens", req, opts?.signal);
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+  };
+}

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateResponsesStream,
   codexAccountIdFromToken,
   createCodexResponsesClient,
+  createGenericOpenAIResponsesClient,
   openaiToResponsesRequest,
   readResponsesEvents,
   readResponsesSSERaw,
@@ -1674,5 +1675,82 @@ describe("createCodexResponsesClient — passthrough methods are defined (pool f
     });
     expect(typeof client.nativePassthrough).toBe("function");
     expect(typeof client.nativePassthroughStream).toBe("function");
+  });
+});
+
+describe("createGenericOpenAIResponsesClient — native passthrough", () => {
+  it("forwards generic Responses bodies without Codex-only defaults or headers", async () => {
+    const body = {
+      model: "gpt-5.5",
+      input: "hi",
+      include: ["file_search_call.results"],
+      background: true,
+      max_output_tokens: 128,
+      store: true,
+    };
+    let seenUrl = "";
+    let seenHeaders = new Headers();
+    let seenBody: unknown;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      seenUrl = String(url);
+      seenHeaders = new Headers(init?.headers);
+      seenBody = JSON.parse(String(init?.body));
+      return jsonResponse({ id: "resp_generic", object: "response", status: "completed" });
+    });
+
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const out = await client.nativePassthrough?.(body);
+
+    expect(client.nativeProtocolProfile).toBe("generic_openai_responses");
+    expect(seenUrl).toBe("https://api.openai.test/v1/responses");
+    expect(seenHeaders.get("Authorization")).toBe("Bearer sk-test");
+    expect(seenHeaders.get("OpenAI-Beta")).toBeNull();
+    expect(seenHeaders.get("chatgpt-account-id")).toBeNull();
+    expect(seenBody).toEqual(body);
+    expect(out).toEqual({ id: "resp_generic", object: "response", status: "completed" });
+  });
+
+  it("calls generic lifecycle endpoints with OpenAI-shaped auth only", async () => {
+    const calls: Array<{ url: string; method: string; body?: unknown }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({
+        url: String(url),
+        method: String(init?.method ?? "GET"),
+        ...(init?.body ? { body: JSON.parse(String(init.body)) } : {}),
+      });
+      return jsonResponse({ ok: true });
+    });
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.responsesRetrieve?.("resp_1");
+    await client.responsesDelete?.("resp_1");
+    await client.responsesCancel?.("resp_1");
+    await client.responsesInputItems?.("resp_1");
+    await client.responsesCompact?.({ model: "gpt-5.5", input: "compact me" });
+    await client.responsesInputTokens?.({ model: "gpt-5.5", input: "count me" });
+
+    expect(calls).toEqual([
+      { url: "https://api.openai.test/v1/responses/resp_1", method: "GET" },
+      { url: "https://api.openai.test/v1/responses/resp_1", method: "DELETE" },
+      { url: "https://api.openai.test/v1/responses/resp_1/cancel", method: "POST" },
+      { url: "https://api.openai.test/v1/responses/resp_1/input_items", method: "GET" },
+      {
+        url: "https://api.openai.test/v1/responses/compact",
+        method: "POST",
+        body: { model: "gpt-5.5", input: "compact me" },
+      },
+      {
+        url: "https://api.openai.test/v1/responses/input_tokens",
+        method: "POST",
+        body: { model: "gpt-5.5", input: "count me" },
+      },
+    ]);
   });
 });

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1786,6 +1786,54 @@ describe("createGenericOpenAIResponsesClient — native passthrough", () => {
     expect((out.choices[0]?.message.tool_calls as unknown[]).length).toBe(1);
   });
 
+  it("redacts a static apiKey echoed in a generic Responses upstream error body", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ error: { message: "invalid key sk-secret-1234 supplied" } }, 500),
+    );
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-secret-1234" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(client.nativePassthrough?.({ model: "gpt-5.5", input: "hi" })).rejects.toThrow();
+    try {
+      await client.nativePassthrough?.({ model: "gpt-5.5", input: "hi" });
+      throw new Error("expected throw");
+    } catch (err) {
+      const raw = JSON.stringify((err as UpstreamError).providerRaw);
+      expect(raw).not.toContain("sk-secret-1234");
+      expect(raw).toContain("[redacted]");
+    }
+  });
+
+  it("rebuilds the Authorization header after a 401 so the OAuth retry uses the refreshed token", async () => {
+    let token = "old-token";
+    const seen: string[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const auth = new Headers(init?.headers).get("Authorization") ?? "";
+      seen.push(auth);
+      if (auth === "Bearer old-token") return jsonResponse({ error: "unauthorized" }, 401);
+      return jsonResponse({ id: "resp_ok", object: "response", status: "completed" });
+    });
+    const client = createGenericOpenAIResponsesClient({
+      config: {
+        baseUrl: "https://api.openai.test/v1",
+        getAuthHeader: async () => `Bearer ${token}`,
+        onUnauthorized: () => {
+          token = "new-token";
+        },
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const out = (await client.nativePassthrough?.({ model: "gpt-5.5", input: "hi" })) as {
+      id: string;
+    };
+    // Retry carried the REFRESHED token, not the stale one.
+    expect(seen).toEqual(["Bearer old-token", "Bearer new-token"]);
+    expect(out.id).toBe("resp_ok");
+  });
+
   it("calls generic lifecycle endpoints with OpenAI-shaped auth only", async () => {
     const calls: Array<{ url: string; method: string; body?: unknown }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1714,6 +1714,78 @@ describe("createGenericOpenAIResponsesClient — native passthrough", () => {
     expect(out).toEqual({ id: "resp_generic", object: "response", status: "completed" });
   });
 
+  it("chatCompletion maps Responses function_call output items to chat tool_calls", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        id: "resp_fc",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "calling a tool" }],
+          },
+          {
+            type: "function_call",
+            call_id: "call_1",
+            name: "get_weather",
+            arguments: '{"city":"SF"}',
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 3 },
+      }),
+    );
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const out = (await client.chatCompletion({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "weather?" }],
+    })) as {
+      choices: Array<{
+        message: { content: unknown; tool_calls?: unknown };
+        finish_reason: string;
+      }>;
+    };
+    const choice = out.choices[0];
+    expect(choice?.message.content).toBe("calling a tool");
+    expect(choice?.message.tool_calls).toEqual([
+      {
+        id: "call_1",
+        type: "function",
+        function: { name: "get_weather", arguments: '{"city":"SF"}' },
+      },
+    ]);
+    expect(choice?.finish_reason).toBe("tool_calls");
+  });
+
+  it("chatCompletion returns null content + finish_reason tool_calls for a pure function_call response", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        id: "resp_fc2",
+        output: [{ type: "function_call", id: "c2", name: "noop", arguments: "{}" }],
+        usage: {},
+      }),
+    );
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    const out = (await client.chatCompletion({ model: "gpt-5.5", messages: [] })) as {
+      choices: Array<{
+        message: { content: unknown; tool_calls?: unknown };
+        finish_reason: string;
+      }>;
+    };
+    expect(out.choices[0]?.message.content).toBeNull();
+    expect(out.choices[0]?.finish_reason).toBe("tool_calls");
+    expect((out.choices[0]?.message.tool_calls as unknown[]).length).toBe(1);
+  });
+
   it("calls generic lifecycle endpoints with OpenAI-shaped auth only", async () => {
     const calls: Array<{ url: string; method: string; body?: unknown }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -23,6 +23,7 @@ import {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   type ProviderClient,
+  type ProviderConfig,
   UpstreamError,
 } from "./openai.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
@@ -52,6 +53,11 @@ export interface CodexResponsesClientConfig {
 
 export interface CodexResponsesClientDeps {
   config: CodexResponsesClientConfig;
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface GenericOpenAIResponsesClientDeps {
+  config: ProviderConfig;
   fetch?: typeof globalThis.fetch;
 }
 
@@ -255,6 +261,86 @@ export function openaiToResponsesRequest(
   return body;
 }
 
+export function openaiToGenericResponsesRequest(
+  req: ChatCompletionRequest,
+): Record<string, unknown> {
+  const r = req as Record<string, unknown>;
+  const messages = Array.isArray(r.messages) ? (r.messages as Array<Record<string, unknown>>) : [];
+  const body: Record<string, unknown> = {
+    model: r.model,
+    instructions: buildInstructions(messages),
+    input: toResponsesInput(messages),
+  };
+  if (r.stream === true) body.stream = true;
+  const maxOutput = r.max_output_tokens ?? r.max_completion_tokens ?? r.max_tokens;
+  if (typeof maxOutput === "number") body.max_output_tokens = maxOutput;
+  if (typeof r.temperature === "number") body.temperature = r.temperature;
+  if (typeof r.top_p === "number") body.top_p = r.top_p;
+  if (typeof r.reasoning_effort === "string" && r.reasoning_effort.length > 0) {
+    body.reasoning = { effort: r.reasoning_effort };
+  }
+  if (r.tool_choice !== undefined) body.tool_choice = chatToolChoiceToResponses(r.tool_choice);
+  if (Array.isArray(r.tools)) {
+    const tools = (r.tools as Array<Record<string, unknown>>).flatMap((t) => {
+      const fn = (t.function ?? {}) as Record<string, unknown>;
+      if (!fn.name) return [];
+      return [
+        {
+          type: "function",
+          name: fn.name,
+          description: fn.description ?? "",
+          parameters: fn.parameters ?? { type: "object" },
+          strict: false,
+        },
+      ];
+    });
+    if (tools.length) body.tools = tools;
+  }
+  return body;
+}
+
+function responsesJsonToChatResponse(
+  response: Record<string, unknown>,
+  model: string,
+): ChatCompletionResponse {
+  const output = Array.isArray(response.output) ? response.output : [];
+  const text = output
+    .flatMap((item) => {
+      if (item === null || typeof item !== "object") return [];
+      const content = (item as { content?: unknown }).content;
+      if (!Array.isArray(content)) return [];
+      return content.flatMap((part) =>
+        part !== null &&
+        typeof part === "object" &&
+        typeof (part as { text?: unknown }).text === "string"
+          ? [(part as { text: string }).text]
+          : [],
+      );
+    })
+    .join("");
+  const usage = response.usage && typeof response.usage === "object" ? response.usage : {};
+  const inputTokens =
+    typeof (usage as { input_tokens?: unknown }).input_tokens === "number"
+      ? ((usage as { input_tokens: number }).input_tokens ?? 0)
+      : 0;
+  const outputTokens =
+    typeof (usage as { output_tokens?: unknown }).output_tokens === "number"
+      ? ((usage as { output_tokens: number }).output_tokens ?? 0)
+      : 0;
+  return {
+    id: typeof response.id === "string" ? response.id : `chatcmpl-${Date.now()}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [{ index: 0, message: { role: "assistant", content: text }, finish_reason: "stop" }],
+    usage: {
+      prompt_tokens: inputTokens,
+      completion_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+    },
+  };
+}
+
 // ── response status -> OpenAI finish_reason ──────────────────────────────────
 
 function finishReason(status: unknown, hadToolCall: boolean): string {
@@ -412,6 +498,8 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   }
 
   return {
+    nativeProtocolProfile: "codex_responses",
+
     async chatCompletion(req, opts) {
       const model = String((req as Record<string, unknown>).model ?? "");
       const res = await requestWithRetry(
@@ -458,6 +546,234 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       const res = await requestWithRetry(body, opts?.signal);
       if (!res.ok) throw await errorFromResponse(res);
       yield* readResponsesSSERaw(res, timeoutMs);
+    },
+  };
+}
+
+export function createGenericOpenAIResponsesClient(
+  deps: GenericOpenAIResponsesClientDeps,
+): ProviderClient {
+  const doFetch = deps.fetch ?? globalThis.fetch;
+  const cfg = deps.config;
+  const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const rootUrl = async (): Promise<string> => {
+    const base = cfg.resolveBaseUrl ? await cfg.resolveBaseUrl() : cfg.baseUrl;
+    const trimmed = base.replace(/\/$/, "");
+    return trimmed.endsWith("/responses") ? trimmed.slice(0, -"/responses".length) : trimmed;
+  };
+
+  const endpoint = async (path: string): Promise<string> => `${await rootUrl()}/${path}`;
+
+  async function providerHeaders(accept = "application/json"): Promise<Record<string, string>> {
+    const authorization =
+      cfg.getAuthHeader !== undefined
+        ? await cfg.getAuthHeader()
+        : cfg.apiKey !== undefined
+          ? `Bearer ${cfg.apiKey}`
+          : "";
+    return {
+      "Content-Type": "application/json",
+      accept,
+      ...(authorization.length > 0 ? { Authorization: authorization } : {}),
+      ...(cfg.extraHeaders ? cfg.extraHeaders() : {}),
+    };
+  }
+
+  function scrub(raw: unknown): unknown {
+    if (raw === null) return raw;
+    const secrets = cfg.currentSecrets ? cfg.currentSecrets() : [];
+    const replace = (value: string): { value: string; changed: boolean } => {
+      let v = value;
+      let changed = false;
+      for (const s of secrets) {
+        if (s.length < 4) continue;
+        if (v.includes(s)) {
+          v = v.split(s).join("[redacted]");
+          changed = true;
+        }
+      }
+      return { value: v, changed };
+    };
+    if (typeof raw === "string") return replace(raw).value;
+    if (typeof raw !== "object") return raw;
+    const { value, changed } = replace(JSON.stringify(raw));
+    return changed ? JSON.parse(value) : raw;
+  }
+
+  async function fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    external?: AbortSignal,
+  ): Promise<Response> {
+    const t = withTimeout(timeoutMs, external);
+    try {
+      return await doFetch(url, { ...init, signal: t.signal });
+    } catch (err) {
+      if (t.isTimeout() && !t.isExternalAbort()) {
+        throw new UpstreamError("timeout", "upstream request timed out");
+      }
+      throw err;
+    } finally {
+      t.cleanup();
+    }
+  }
+
+  async function errorFromResponse(res: Response): Promise<UpstreamError> {
+    const providerRaw = await res
+      .text()
+      .then((t) => {
+        try {
+          return JSON.parse(t);
+        } catch {
+          return t;
+        }
+      })
+      .catch(() => null)
+      .then(scrub);
+    return new UpstreamError(
+      "upstream_error",
+      `upstream returned ${res.status}`,
+      providerRaw,
+      res.status,
+    );
+  }
+
+  async function requestJson(
+    path: string,
+    init: {
+      method: "GET" | "POST" | "DELETE";
+      body?: NativePassthroughInput;
+      accept?: string;
+      signal?: AbortSignal;
+    },
+  ): Promise<Response> {
+    const headers = await providerHeaders(init.accept);
+    let bodyText: string | undefined;
+    let requestHeaders = headers;
+    if (init.body !== undefined) {
+      const prepared = prepareNativePassthroughRequest(init.body, headers);
+      requestHeaders = prepared.headers;
+      bodyText = prepared.bodyText;
+    }
+    const res = await fetchWithTimeout(
+      await endpoint(path),
+      { method: init.method, headers: requestHeaders, ...(bodyText ? { body: bodyText } : {}) },
+      init.signal,
+    );
+    if (res.status === 401 && cfg.onUnauthorized !== undefined) {
+      await res.body?.cancel().catch(() => {});
+      cfg.onUnauthorized();
+      return await fetchWithTimeout(
+        await endpoint(path),
+        { method: init.method, headers: requestHeaders, ...(bodyText ? { body: bodyText } : {}) },
+        init.signal,
+      );
+    }
+    return res;
+  }
+
+  return {
+    nativeProtocolProfile: "generic_openai_responses",
+
+    async chatCompletion(req, opts) {
+      const model = String((req as Record<string, unknown>).model ?? "");
+      const res = await requestJson("responses", {
+        method: "POST",
+        body: openaiToGenericResponsesRequest(req),
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return responsesJsonToChatResponse((await res.json()) as Record<string, unknown>, model);
+    },
+
+    async *chatCompletionStream(req, opts) {
+      const model = String((req as Record<string, unknown>).model ?? "");
+      const res = await requestJson("responses", {
+        method: "POST",
+        body: { ...openaiToGenericResponsesRequest(req), stream: true },
+        accept: "text/event-stream",
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      yield* translateResponsesSSE(res, model, timeoutMs);
+    },
+
+    async nativePassthrough(body, opts) {
+      const res = await requestJson("responses", {
+        method: "POST",
+        body,
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async *nativePassthroughStream(body, opts) {
+      const res = await requestJson("responses", {
+        method: "POST",
+        body,
+        accept: "text/event-stream",
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      yield* readResponsesSSERaw(res, timeoutMs);
+    },
+
+    async responsesRetrieve(responseId, opts) {
+      const res = await requestJson(`responses/${encodeURIComponent(responseId)}`, {
+        method: "GET",
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async responsesDelete(responseId, opts) {
+      const res = await requestJson(`responses/${encodeURIComponent(responseId)}`, {
+        method: "DELETE",
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async responsesCancel(responseId, opts) {
+      const res = await requestJson(`responses/${encodeURIComponent(responseId)}/cancel`, {
+        method: "POST",
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async responsesInputItems(responseId, opts) {
+      const res = await requestJson(`responses/${encodeURIComponent(responseId)}/input_items`, {
+        method: "GET",
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async responsesCompact(req, opts) {
+      const res = await requestJson("responses/compact", {
+        method: "POST",
+        body: req,
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async responsesInputTokens(req, opts) {
+      const res = await requestJson("responses/input_tokens", {
+        method: "POST",
+        body: req,
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
     },
   };
 }

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -604,6 +604,10 @@ export function createGenericOpenAIResponsesClient(
   function scrub(raw: unknown): unknown {
     if (raw === null) return raw;
     const secrets = cfg.currentSecrets ? cfg.currentSecrets() : [];
+    // Mirror the openai/anthropic/gemini clients: a static apiKey must also be
+    // redacted from upstream error bodies (else it can leak into error_detail/
+    // telemetry if the upstream echoes the Authorization value).
+    if (cfg.apiKey !== undefined) secrets.push(cfg.apiKey);
     const replace = (value: string): { value: string; changed: boolean } => {
       let v = value;
       let changed = false;
@@ -685,9 +689,24 @@ export function createGenericOpenAIResponsesClient(
     if (res.status === 401 && cfg.onUnauthorized !== undefined) {
       await res.body?.cancel().catch(() => {});
       cfg.onUnauthorized();
+      // Rebuild headers AFTER onUnauthorized so an OAuth provider's retry carries the
+      // refreshed token — reusing the original headers would resend the expired one
+      // and the refresh would never recover the request.
+      const refreshedHeaders = await providerHeaders(init.accept);
+      let retryHeaders = refreshedHeaders;
+      let retryBodyText = bodyText;
+      if (init.body !== undefined) {
+        const prepared = prepareNativePassthroughRequest(init.body, refreshedHeaders);
+        retryHeaders = prepared.headers;
+        retryBodyText = prepared.bodyText;
+      }
       return await fetchWithTimeout(
         await endpoint(path),
-        { method: init.method, headers: requestHeaders, ...(bodyText ? { body: bodyText } : {}) },
+        {
+          method: init.method,
+          headers: retryHeaders,
+          ...(retryBodyText ? { body: retryBodyText } : {}),
+        },
         init.signal,
       );
     }

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -318,6 +318,21 @@ function responsesJsonToChatResponse(
       );
     })
     .join("");
+  // Responses `function_call` output items → OpenAI chat `tool_calls` so a
+  // cross-protocol (chat→generic-responses) caller still sees the tool invocation
+  // instead of silently losing it. Mirrors the streaming aggregator's mapping.
+  const toolCalls = output.flatMap((item) => {
+    if (item === null || typeof item !== "object") return [];
+    const it = item as Record<string, unknown>;
+    if (it.type !== "function_call") return [];
+    const name = typeof it.name === "string" ? it.name : undefined;
+    if (name === undefined) return [];
+    const callId =
+      typeof it.call_id === "string" ? it.call_id : typeof it.id === "string" ? it.id : name;
+    const args =
+      typeof it.arguments === "string" ? it.arguments : JSON.stringify(it.arguments ?? {});
+    return [{ id: callId, type: "function", function: { name, arguments: args } }];
+  });
   const usage = response.usage && typeof response.usage === "object" ? response.usage : {};
   const inputTokens =
     typeof (usage as { input_tokens?: unknown }).input_tokens === "number"
@@ -327,12 +342,18 @@ function responsesJsonToChatResponse(
     typeof (usage as { output_tokens?: unknown }).output_tokens === "number"
       ? ((usage as { output_tokens: number }).output_tokens ?? 0)
       : 0;
+  // OpenAI convention: content is null (not "") when the turn is purely tool calls.
+  const message: Record<string, unknown> = {
+    role: "assistant",
+    content: text.length > 0 ? text : toolCalls.length > 0 ? null : "",
+    ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+  };
   return {
     id: typeof response.id === "string" ? response.id : `chatcmpl-${Date.now()}`,
     object: "chat.completion",
     created: Math.floor(Date.now() / 1000),
     model,
-    choices: [{ index: 0, message: { role: "assistant", content: text }, finish_reason: "stop" }],
+    choices: [{ index: 0, message, finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop" }],
     usage: {
       prompt_tokens: inputTokens,
       completion_tokens: outputTokens,

--- a/packages/core/src/provider/openai.test.ts
+++ b/packages/core/src/provider/openai.test.ts
@@ -83,6 +83,48 @@ describe("createOpenAIClient (Phase 0 passthrough)", () => {
     expect(received.join("")).toBe(chunks.join(""));
   });
 
+  it("keeps OpenAI-compatible reasoning deltas byte-for-byte unless the provider opts in", async () => {
+    const chunks = [
+      'data: {"id":"cmpl-1","choices":[{"index":0,"delta":{"reasoning":"think"}}]}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const fetch = vi.fn().mockResolvedValue(sseResponse(chunks));
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+    const received: string[] = [];
+
+    for await (const c of client.chatCompletionStream({ model: "m", stream: true })) {
+      received.push(c);
+    }
+
+    expect(received.join("")).toBe(chunks.join(""));
+  });
+
+  it("normalizes OpenAI-compatible stream delta.reasoning when the provider opts in", async () => {
+    const chunks = [
+      'data: {"id":"cmpl-1","choices":[{"index":0,"delta":{"reasoning":"think","content":"visible"}}]}\n\n',
+      'data: {"id":"cmpl-1","choices":[{"index":0,"delta":{"content":"answer"}}]}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const fetch = vi.fn().mockResolvedValue(sseResponse(chunks));
+    const client = createOpenAIClient({
+      config: { ...CONFIG, normalizeReasoningDeltaAlias: true },
+      fetch,
+    });
+    const received: string[] = [];
+
+    for await (const c of client.chatCompletionStream({ model: "m", stream: true })) {
+      received.push(c);
+    }
+
+    const body = received.join("");
+    expect(body).toContain('"reasoning_content":"think"');
+    expect(body).not.toContain('"reasoning":"think"');
+    expect(body).toContain(
+      'data: {"id":"cmpl-1","choices":[{"index":0,"delta":{"content":"answer"}}]}\n\n',
+    );
+    expect(body).toContain("data: [DONE]\n\n");
+  });
+
   it("aborts a stream that goes silent past the idle deadline with UpstreamError(timeout)", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -34,6 +34,9 @@ export interface ProviderConfig {
   // Compatibility shim for OpenAI-compatible providers that have not adopted the
   // newer `developer` role. Disabled by default to keep true OpenAI passthrough.
   mapDeveloperRoleToSystem?: boolean;
+  // Compatibility shim for OpenAI-compatible providers that stream reasoning as
+  // choices[].delta.reasoning. Disabled by default to preserve byte forwarding.
+  normalizeReasoningDeltaAlias?: boolean;
 }
 
 export interface OpenAIClientDeps {
@@ -43,8 +46,15 @@ export interface OpenAIClientDeps {
 
 export type ChatCompletionRequest = Record<string, unknown>;
 export type ChatCompletionResponse = Record<string, unknown>;
+export type NativeProtocolProfile =
+  | "anthropic_messages"
+  | "codex_responses"
+  | "generic_openai_responses"
+  | "gemini";
 
 export interface ProviderClient {
+  nativeProtocolProfile?: NativeProtocolProfile;
+  streamReframed?: boolean;
   chatCompletion(
     req: ChatCompletionRequest,
     opts?: { signal?: AbortSignal },
@@ -73,6 +83,34 @@ export interface ProviderClient {
     request: NativePassthroughInput,
     opts?: { signal?: AbortSignal },
   ): AsyncIterable<string>;
+  countTokens?(
+    req: ChatCompletionRequest,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Record<string, unknown>>;
+  responsesInputTokens?(
+    req: ChatCompletionRequest,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Record<string, unknown>>;
+  responsesRetrieve?(
+    responseId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Record<string, unknown>>;
+  responsesDelete?(
+    responseId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Record<string, unknown>>;
+  responsesCancel?(
+    responseId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Record<string, unknown>>;
+  responsesInputItems?(
+    responseId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Record<string, unknown>>;
+  responsesCompact?(
+    req: ChatCompletionRequest,
+    opts?: { signal?: AbortSignal },
+  ): Promise<Record<string, unknown>>;
 }
 
 // Upstream non-2xx / network error / timeout. The gateway maps this to an
@@ -102,6 +140,62 @@ export class UpstreamError extends Error {
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000;
+
+function nextSseFrameBoundary(buffer: string): { index: number; separator: string } | null {
+  const lf = buffer.indexOf("\n\n");
+  const crlf = buffer.indexOf("\r\n\r\n");
+  if (lf === -1 && crlf === -1) return null;
+  if (lf === -1) return { index: crlf, separator: "\r\n\r\n" };
+  if (crlf === -1) return { index: lf, separator: "\n\n" };
+  return crlf < lf ? { index: crlf, separator: "\r\n\r\n" } : { index: lf, separator: "\n\n" };
+}
+
+function normalizeOpenAIReasoningPayload(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const choices = (value as { choices?: unknown }).choices;
+  if (!Array.isArray(choices)) return false;
+
+  let changed = false;
+  for (const choice of choices) {
+    if (choice === null || typeof choice !== "object" || Array.isArray(choice)) continue;
+    const delta = (choice as { delta?: unknown }).delta;
+    if (delta === null || typeof delta !== "object" || Array.isArray(delta)) continue;
+    const record = delta as Record<string, unknown>;
+    if (!Object.hasOwn(record, "reasoning")) continue;
+    if (!Object.hasOwn(record, "reasoning_content")) {
+      record.reasoning_content = record.reasoning;
+    }
+    delete record.reasoning;
+    changed = true;
+  }
+  return changed;
+}
+
+function normalizeReasoningDeltaFrame(frame: string): string {
+  let changed = false;
+  const lines = frame.split("\n").map((line) => {
+    const hasCarriageReturn = line.endsWith("\r");
+    const core = hasCarriageReturn ? line.slice(0, -1) : line;
+    const match = /^data:\s*/.exec(core);
+    if (!match) return line;
+
+    const payload = core.slice(match[0].length);
+    if (payload.trim() === "[DONE]") return line;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      return line;
+    }
+
+    if (!normalizeOpenAIReasoningPayload(parsed)) return line;
+    changed = true;
+    return `${match[0]}${JSON.stringify(parsed)}${hasCarriageReturn ? "\r" : ""}`;
+  });
+
+  return changed ? lines.join("\n") : frame;
+}
 
 // Merge the caller's signal (client disconnect) with a timeout signal. Returns
 // the combined signal plus a marker so the caller can distinguish a timeout
@@ -263,6 +357,8 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
   }
 
   return {
+    ...(cfg.normalizeReasoningDeltaAlias ? { streamReframed: true } : {}),
+
     async chatCompletion(req, opts) {
       const res = await requestWithAuthRetry(req, opts?.signal);
       if (!res.ok) throw await errorFromResponse(res);
@@ -279,6 +375,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       if (!body) return;
       const reader = body.getReader();
       const decoder = new TextDecoder();
+      let pendingFrame = "";
       try {
         while (true) {
           // Inter-chunk liveness: `withTimeout` already cleared once headers
@@ -288,7 +385,23 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
           // normal fallback-eligible failure; after, it terminates the response.
           const { done, value } = await readChunkWithIdle(reader, timeoutMs);
           if (done) break;
-          if (value) yield decoder.decode(value, { stream: true });
+          if (!value) continue;
+          const chunk = decoder.decode(value, { stream: true });
+          if (!cfg.normalizeReasoningDeltaAlias) {
+            yield chunk;
+            continue;
+          }
+          pendingFrame += chunk;
+          while (true) {
+            const boundary = nextSseFrameBoundary(pendingFrame);
+            if (!boundary) break;
+            const frame = pendingFrame.slice(0, boundary.index);
+            pendingFrame = pendingFrame.slice(boundary.index + boundary.separator.length);
+            yield `${normalizeReasoningDeltaFrame(frame)}${boundary.separator}`;
+          }
+        }
+        if (cfg.normalizeReasoningDeltaAlias && pendingFrame.length > 0) {
+          yield normalizeReasoningDeltaFrame(pendingFrame);
         }
       } catch (err) {
         if (err instanceof StreamStalledError) {

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -111,6 +111,8 @@ export interface ProviderAttempt {
   provider_name?: string | null;
   provider_model?: string | null;
   passthrough_mutations?: NativePassthroughMutationLedger;
+  /** Body-free translated-path request shims/warnings (field names + counters only). */
+  request_mutations?: NativePassthroughMutationLedger;
 }
 
 // What execute() returns: the provider_attempts trail, the final landing, and

--- a/packages/shared/src/config/schema.test.ts
+++ b/packages/shared/src/config/schema.test.ts
@@ -88,6 +88,36 @@ describe("ProviderConfigSchema targetProviderProtocol", () => {
   it("intentionally defaults unknown provider type to openai_chat", () => {
     expect(provider({ type: "unknown-provider" }).targetProviderProtocol).toBe("openai_chat");
   });
+
+  it("defaults reasoning alias stream normalization off and accepts opt-in", () => {
+    expect(provider().normalize_reasoning_delta_alias).toBe(false);
+    expect(
+      provider({ normalize_reasoning_delta_alias: true }).normalize_reasoning_delta_alias,
+    ).toBe(true);
+  });
+
+  it("defaults response model policy to provider identity and accepts compatibility modes", () => {
+    expect(provider().response_model_policy).toBe("provider");
+    expect(provider({ response_model_policy: "requested_alias" }).response_model_policy).toBe(
+      "requested_alias",
+    );
+    expect(provider({ response_model_policy: "both" }).response_model_policy).toBe("both");
+  });
+
+  it("accepts Gemini remote media fetch safety limits", () => {
+    expect(
+      provider({
+        type: "gemini",
+        remote_media_fetch: { enabled: true, max_bytes: 1024, allowed_mime_types: ["image/*"] },
+      }).remote_media_fetch,
+    ).toMatchObject({
+      enabled: true,
+      max_bytes: 1024,
+      timeout_ms: 5_000,
+      max_redirects: 2,
+      allowed_mime_types: ["image/*"],
+    });
+  });
 });
 
 describe("HelmConfigSchema", () => {

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -43,6 +43,8 @@ export const ProviderModelSchema = z.object({
 
 function inferTargetProviderProtocol(type: string): z.infer<typeof TargetProviderProtocolSchema> {
   if (type === "openai-responses") return "openai_responses";
+  if (type === "openai-responses-generic" || type === "openai_responses_generic")
+    return "openai_responses";
   if (type === "anthropic") return "anthropic_messages";
   if (type === "gemini") return "gemini";
   return "openai_chat";
@@ -109,6 +111,14 @@ export const OAuthPresetConfigSchema = z
 // first; a preset object (no token_url / *_env) falls through to the preset branch.
 export const OAuthCredentialSchema = z.union([OAuthConfigSchema, OAuthPresetConfigSchema]);
 
+const RemoteMediaFetchConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  max_bytes: z.number().int().positive().default(5_000_000),
+  timeout_ms: z.number().int().positive().default(5_000),
+  max_redirects: z.number().int().nonnegative().default(2),
+  allowed_mime_types: z.array(z.string().min(1)).optional(),
+});
+
 // Discriminate the two oauth modes at the use site (server wiring): a preset block
 // is the one carrying a `provider` field.
 export function isOAuthPreset(
@@ -135,6 +145,8 @@ export function isOAuthPreset(
 //     compatible upstreams that reject OpenAI's newer `developer` role (e.g.
 //     official DeepSeek). Kept provider-scoped so true OpenAI/Codex can preserve
 //     the higher-priority role.
+//   - `normalize_reasoning_delta_alias`: opt-in stream shim for OpenAI-compatible
+//     upstreams that send choices[].delta.reasoning instead of reasoning_content.
 // Credentials are stored as a REFERENCE (env var name) only — never plaintext.
 export const ProviderConfigSchema = z
   .object({
@@ -156,6 +168,9 @@ export const ProviderConfigSchema = z
     // Responses and other provider wires must be distinguishable metadata.
     target_provider_protocol: TargetProviderProtocolSchema.optional(),
     map_developer_role_to_system: z.boolean().default(false),
+    normalize_reasoning_delta_alias: z.boolean().default(false),
+    response_model_policy: z.enum(["provider", "requested_alias", "both"]).default("provider"),
+    remote_media_fetch: RemoteMediaFetchConfigSchema.optional(),
   })
   .refine((p) => p.name !== undefined || p.alias !== undefined, {
     message: "provider requires `name` or `alias`",

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -111,6 +111,9 @@ export const ProviderAttemptSchema = z.object({
   provider_name: z.string().nullable().optional(),
   provider_model: z.string().nullable().optional(),
   passthrough_mutations: NativePassthroughMutationLedgerSchema.optional(),
+  // Target-protocol request shims on translated attempts. Body-free: codes,
+  // counters, and field names only; never payload values.
+  request_mutations: NativePassthroughMutationLedgerSchema.optional(),
 });
 
 export const FinalDecisionSchema = z.object({

--- a/packages/shared/src/native-passthrough.ts
+++ b/packages/shared/src/native-passthrough.ts
@@ -15,7 +15,7 @@ export interface NativePassthroughMutationLedger {
 }
 
 export interface NativePassthroughCarrier {
-  protocol: Extract<Protocol, "anthropic_messages" | "openai_responses">;
+  protocol: Extract<Protocol, "anthropic_messages" | "openai_responses" | "gemini">;
   body: Record<string, unknown>;
   raw_body?: string;
   headers: Record<string, string | string[]>;
@@ -28,7 +28,9 @@ export function isNativePassthroughCarrier(value: unknown): value is NativePasst
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
   return (
-    (record.protocol === "anthropic_messages" || record.protocol === "openai_responses") &&
+    (record.protocol === "anthropic_messages" ||
+      record.protocol === "openai_responses" ||
+      record.protocol === "gemini") &&
     record.body !== null &&
     typeof record.body === "object" &&
     !Array.isArray(record.body) &&

--- a/packages/shared/src/request/schema.ts
+++ b/packages/shared/src/request/schema.ts
@@ -49,7 +49,7 @@ export const NativePassthroughMutationLedgerSchema = z
   .passthrough();
 
 export const NativePassthroughCarrierSchema = z.object({
-  protocol: z.enum(["anthropic_messages", "openai_responses"]),
+  protocol: z.enum(["anthropic_messages", "openai_responses", "gemini"]),
   body: UnknownRecordSchema,
   raw_body: z.string().optional(),
   headers: z.record(z.string(), NativeHeaderValueSchema),

--- a/scripts/protocol-compat/ast-grep-gates.sh
+++ b/scripts/protocol-compat/ast-grep-gates.sh
@@ -107,7 +107,11 @@ require_match \
 
 require_match \
   "Gemini remote media materializer must be implemented outside the pure transformer" \
-  --lang ts -p 'materializeGeminiRemoteMediaBody($BODY, $CONFIG, $FETCH, $SIGNAL)' packages/core/src/provider/gemini.ts
+  --lang ts -p 'materializeGeminiRemoteMediaBody($BODY, $CONFIG, $FETCH, $SIGNAL, $LOOKUP)' packages/core/src/provider/gemini.ts
+
+require_rg \
+  "Gemini remote media fetch must SSRF-guard private/reserved targets" \
+  'assertPublicHttpsTarget' packages/core/src/provider/gemini.ts
 
 if rg -n 'from "node:http"|from "node:https"|fetch\(' packages/core/src/protocol/gemini >/tmp/helm-gemini-core-fetch.txt; then
   echo 'forbidden structure found: Gemini core transformer must stay network-I/O free' >&2

--- a/scripts/protocol-compat/ast-grep-gates.sh
+++ b/scripts/protocol-compat/ast-grep-gates.sh
@@ -27,6 +27,24 @@ require_no_match() {
   rm -f "$tmp"
 }
 
+require_rg() {
+  local label="$1"
+  local pattern="$2"
+  shift 2
+  if ! rg -n "$pattern" "$@" >/dev/null; then
+    echo "missing expected structure: $label" >&2
+    exit 1
+  fi
+}
+
+require_no_match \
+  "Responses transformer must not reject previous_response_id at inbound parse time" \
+  --lang ts -p 'rejectUnsupportedPreviousResponseContinuation($ARG)' packages/core/src/protocol/responses.ts
+
+require_no_match \
+  "Responses lifecycle routes must not use the old unsupportedLifecycle stub" \
+  --lang ts -p '$APP.$METHOD($PATH, unsupportedLifecycle($OP))' apps/gateway/src/routes/responses.ts
+
 require_no_match \
   "Responses route must not synthesize a duplicate stream prelude" \
   --lang ts -p 'responseStreamPrelude($$$)' apps/gateway/src/routes/responses.ts
@@ -54,5 +72,56 @@ rm -f /tmp/helm-cache-control-forward.txt
 require_match \
   "top-level cache_control must be Anthropic-target-only" \
   --lang ts -p 'if ($TARGET === "anthropic_messages" && $REQ.cache_control !== undefined) { $$$ }' apps/gateway/src/routes/execute.ts
+
+require_match \
+  "Responses native previous_response_id passthrough must be positively recorded" \
+  --lang ts -p '$MUTATIONS.responses_previous_response_id_native_passthrough = true' apps/gateway/src/routes/execute.ts
+
+require_rg \
+  "generic OpenAI Responses providers must be distinguished from Codex profile" \
+  'nativeProtocolProfile: "generic_openai_responses"' packages/core/src/provider/openai-responses.ts
+
+require_rg \
+  "Gemini native providers must advertise the Gemini protocol profile" \
+  'nativeProtocolProfile: "gemini"' packages/core/src/provider/gemini.ts
+
+require_match \
+  "Gemini route must branch countTokens before generation pipeline" \
+  --lang ts -p 'if ($ROUTE.operation === "countTokens") { $$$ }' apps/gateway/src/routes/gemini.ts
+
+require_rg \
+  "Gemini provider must implement native countTokens" \
+  'async countTokens' packages/core/src/provider/gemini.ts
+
+require_rg \
+  "Anthropic token counting must send the provider beta header" \
+  'token-counting-2024-11-01' packages/core/src/provider/anthropic.ts
+
+require_rg \
+  "OpenAI Chat response_model_policy must be configurable" \
+  'response_model_policy' packages/shared/src/config/schema.ts
+
+require_match \
+  "OpenAI Chat streaming response model restamping must be implemented" \
+  --lang ts -p 'createOpenAIStreamModelRestamper($REQUESTED_MODEL)' apps/gateway/src/routes/chat.ts
+
+require_match \
+  "Gemini remote media materializer must be implemented outside the pure transformer" \
+  --lang ts -p 'materializeGeminiRemoteMediaBody($BODY, $CONFIG, $FETCH, $SIGNAL)' packages/core/src/provider/gemini.ts
+
+if rg -n 'from "node:http"|from "node:https"|fetch\(' packages/core/src/protocol/gemini >/tmp/helm-gemini-core-fetch.txt; then
+  echo 'forbidden structure found: Gemini core transformer must stay network-I/O free' >&2
+  cat /tmp/helm-gemini-core-fetch.txt >&2
+  rm -f /tmp/helm-gemini-core-fetch.txt
+  exit 1
+fi
+rm -f /tmp/helm-gemini-core-fetch.txt
+
+if ! rg -n 'file_search' apps/gateway/src/routes/execute.test.ts >/tmp/helm-file-search-guard.txt; then
+  echo 'missing expected structure: Responses file_search guard coverage' >&2
+  rm -f /tmp/helm-file-search-guard.txt
+  exit 1
+fi
+rm -f /tmp/helm-file-search-guard.txt
 
 echo "protocol compatibility ast-grep gates passed"


### PR DESCRIPTION
## Summary
- Complete the remaining P1/P2 items in `docs/protocol-translation-litellm-gap-spec.md` across OpenAI Chat, Anthropic Messages, OpenAI Responses, and Gemini.
- Add provider-first helpers and lifecycle wiring for Anthropic/Responses/Gemini, including Responses registry-bound retrieve/delete/cancel/input_items/compact and provider-first token helpers with deterministic estimate fallback.
- Add Gemini native provider support, schema/optional-param preservation, remote media materialization guardrails, OpenAI Chat response model policy, and expanded ast-grep structural gates.

## Validation
- `git fetch origin && git rebase origin/main` ✅ branch already up to date
- `docker build -t helm-api:litellm-remaining-084e0f1 ... .` ✅
- Local Docker deployment ✅ `helm-litellm-live` on `http://127.0.0.1:8091`, using copied local SQLite data with existing Anthropic + OpenAI Codex OAuth accounts
- `pnpm test:protocol-compat:ast` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` ✅ 258 files / 3667 tests
- `pnpm --filter @helm/gateway exec playwright test e2e/protocol.spec.ts e2e/gemini.spec.ts` ✅ 23/23
- `pnpm test:passthrough` ✅ unit 357 tests + deterministic e2e 11 cases
- `pnpm test:passthrough:live` ✅ real Claude CLI + Codex CLI through local Docker Helm:
  - Claude CLI trace: `6af9ef60-21b6-47cb-ae94-d721d196fc53`, provider `anthropic`, model `claude-opus-4-8`, native passthrough `true`
  - Codex CLI trace: `5d89fdbd-5b6b-42e7-9fbe-6208fe3794d4`, provider `openai-codex`, model `gpt-5.5`, native passthrough `true`
- `pnpm test:e2e` ⚠️ 64/66 passed; only the two existing memory-inject expectations fail:
  - `e2e/memory.spec.ts:62` expects the old memory prefix text to reach upstream.
  - `e2e/memory.spec.ts:89` expects the old `turn number` memory behavior.

## Notes
- The first live preflight failed because `HELM_PASSTHROUGH_*` env vars were not present directly in `.env`; the local Docker run derived them from the copied main repo `.env`, admin API, and a temporary test key.
- Codex CLI required `env_key = "OPENAI_API_KEY"` in the temporary Codex provider config; after that, the official live script passed.
- P3 items in the spec remain explicit non-goals unless production evidence requires them.
