### PR TITLE
v0.12.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.12.14.

## Changes since v0.12.13
- fix(oauth): Claude web login shows copy-code page, not dead-localhost redirect (#252)
- docs(notes): record decision to not adopt @earendil-works/pi-ai for OAuth

Merging bumps root \`package.json\` to 0.12.14, which triggers \`publish.yml\` to build + push \`ghcr.io/easymetaau/helm-api:0.12.14\` + \`:latest\` and auto-cut tag \`v0.12.14\` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)