### PR TITLE
feat(provider): retry transient upstream disconnects + SSE keep-alive heartbeat

### DIFF
--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -453,6 +453,41 @@ describe("POST /v1/chat/completions (routing pipeline)", () => {
     expect(text.trimEnd().endsWith("[DONE]")).toBe(true);
   });
 
+  it("emits an SSE heartbeat comment during an inter-chunk idle gap without corrupting frames", async () => {
+    // A healthy-but-slow stream: a real idle gap between chunks. With a short cadence
+    // the route must interleave `:\n\n` keep-alive comments and still forward the data
+    // frames byte-intact (principle 8). The comment is wire-only — never a data event.
+    async function* slow(): AsyncGenerator<string> {
+      yield 'data: {"a":1}\n\n';
+      await new Promise((r) => setTimeout(r, 60)); // idle gap > heartbeat cadence
+      yield 'data: {"b":2}\n\n';
+      yield "data: [DONE]\n\n";
+    }
+    const { deps: d, harness } = deps({ sseHeartbeatMs: () => 15 });
+    harness.execute.mockResolvedValue({
+      ...nonStreamOutcome(null),
+      body: null,
+      stream: slow(),
+    });
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(STREAM_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain(":\n\n"); // at least one keep-alive comment landed
+    expect(text).toContain('data: {"a":1}'); // data frames intact + uncorrupted
+    expect(text).toContain('data: {"b":2}');
+    expect(text.trimEnd().endsWith("[DONE]")).toBe(true);
+    // The beat is an SSE comment, NOT a data event — no extra `data:` frame appears.
+    const dataLines = text.split("\n").filter((l) => l.startsWith("data: "));
+    expect(dataLines.length).toBe(3); // a, b, [DONE]
+  });
+
   it("preserves the timeout class in the terminal error frame when the stream stalls mid-flight", async () => {
     // The provider idle guard throws UpstreamError("timeout") AFTER the first
     // chunk; the route must surface that as a `timeout` frame, not a generic

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -35,6 +35,7 @@ import type { AppEnv } from "../app.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
 import type { ServingAccount } from "../runtime/serving-account.js";
 import type { WriteQueue } from "../runtime/write-queue.js";
+import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { copyLiteLLMRequestParams, providerRawFromRequest } from "./internal-request-params.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
 import {
@@ -78,6 +79,10 @@ export interface ChatRouteDeps {
   writes?: WriteQueue;
   redact: (payload: unknown) => unknown;
   now: () => number;
+  /** SSE keep-alive cadence (ms) for streaming responses; read fresh per request
+   *  from runtime.sse_heartbeat_ms. Optional — absent/0 = no heartbeat (existing
+   *  tests run unchanged). Covers only the inter-chunk idle gap. */
+  sseHeartbeatMs?: () => number;
   /** Per-account OAuth subscription usage recorder (providers page Tier 2).
    *  Optional — absent in unit tests. Called once per served request from the
    *  settle path with the subscription that served it (null for a configured /
@@ -745,20 +750,35 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       // middleware and release it in the stream's OWN finally — the slot stays
       // held until the bytes are fully drained (or the client disconnects).
       const releaseConcurrency = c.get("concurrencyClaim")?.();
+      // SSE keep-alive: emit a `:` comment during inter-chunk idle so a proxy/client
+      // idle-timeout does not sever a long but healthy stream. The comment is wire-only
+      // (never captured, accumulated, or priced) and is gated on an event boundary so it
+      // can never split a partial SSE frame (principle 8). 0 = disabled (today's behavior).
+      const heartbeatMs = deps.sseHeartbeatMs?.() ?? 0;
+      let lastWrite: string | null = null;
       return streamSSE(c, async (sse) => {
         try {
-          for await (const chunk of stream) {
-            const outboundChunk = streamModelRestamper?.push(chunk) ?? chunk;
+          for await (const item of withHeartbeat(stream, {
+            heartbeatMs,
+            signal: c.req.raw.signal,
+          })) {
+            if (item.type === "beat") {
+              if (atEventBoundary(lastWrite)) await sse.write(HEARTBEAT_COMMENT);
+              continue;
+            }
+            const outboundChunk = streamModelRestamper?.push(item.value) ?? item.value;
             if (outboundChunk === "") continue;
             captured.push(outboundChunk);
             await sse.write(outboundChunk);
             if (deps.memory !== undefined) accumulateOpenAIChunk(assistant, outboundChunk);
+            lastWrite = outboundChunk;
           }
           const tail = streamModelRestamper?.flush() ?? "";
           if (tail !== "") {
             captured.push(tail);
             await sse.write(tail);
             if (deps.memory !== undefined) accumulateOpenAIChunk(assistant, tail);
+            lastWrite = tail;
           }
         } catch (err) {
           // A client disconnect / abort is NOT a provider fault: do not 5xx, do

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -9,6 +9,7 @@ import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
+import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult, RouteError } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
@@ -90,6 +91,9 @@ export interface GeminiRouteDeps {
       signal: AbortSignal,
     ): Promise<PipelineRunResult>;
   };
+  /** SSE keep-alive cadence (ms) for streaming responses; read fresh per request from
+   *  runtime.sse_heartbeat_ms. Optional — absent/0 = no heartbeat. Inter-chunk only. */
+  sseHeartbeatMs?: () => number;
 }
 
 function hasCountTokensContent(native: unknown): boolean {
@@ -365,22 +369,39 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
         // captured (verbatim) alongside the telemetry row in the finally below.
         // Gemini frames are nameless `data:` frames (no `event:` name, no [DONE]).
         const captured: string[] = [];
+        // SSE keep-alive: emit a `:` comment during inter-chunk idle (wire-only, never
+        // captured) so a proxy/client idle-timeout does not sever a long healthy stream.
+        // Gemini frames are whole `data:` frames (writeSSE) → always at a boundary.
+        // 0 = disabled (today's behavior).
+        const heartbeatMs = deps.sseHeartbeatMs?.() ?? 0;
+        let lastWrite: string | null = null;
         try {
-          for await (const snapshot of result.streamIR()) {
+          for await (const item of withHeartbeat(result.streamIR(), {
+            heartbeatMs,
+            signal: c.req.raw.signal,
+          })) {
+            if (item.type === "beat") {
+              if (atEventBoundary(lastWrite)) await sse.write(HEARTBEAT_COMMENT);
+              continue;
+            }
+            const snapshot = item.value;
             if (result.nativePassthrough === true) {
               const frame = snapshot as { data?: unknown; raw?: unknown };
               if (typeof frame.raw === "string") {
                 if (captureBodies) captured.push(frame.raw);
                 await sse.write(frame.raw);
+                lastWrite = frame.raw; // verbatim bytes may end mid-frame
               } else {
                 const data = typeof frame.data === "string" ? frame.data : JSON.stringify(snapshot);
                 if (captureBodies) captured.push(`data: ${data}\n\n`);
                 await sse.writeSSE({ data });
+                lastWrite = "\n\n";
               }
             } else {
               const data = JSON.stringify(snapshot);
               if (captureBodies) captured.push(`data: ${data}\n\n`);
               await sse.writeSSE({ data });
+              lastWrite = "\n\n"; // writeSSE emits a complete frame — always a boundary
             }
           }
         } catch (err) {

--- a/apps/gateway/src/routes/heartbeat.test.ts
+++ b/apps/gateway/src/routes/heartbeat.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  atEventBoundary,
+  type HeartbeatItem,
+  type ScheduleTimer,
+  withHeartbeat,
+} from "./heartbeat.js";
+
+// A manually-fired timer: captures every scheduled callback so a test can release a
+// heartbeat at an exact point, with no real time.
+function manualTimer(): { schedule: ScheduleTimer; fire: () => void; pending: () => number } {
+  let cbs: Array<() => void> = [];
+  return {
+    schedule: (cb) => {
+      cbs.push(cb);
+      return () => {
+        cbs = cbs.filter((c) => c !== cb);
+      };
+    },
+    fire: () => {
+      const batch = cbs;
+      cbs = [];
+      for (const cb of batch) cb();
+    },
+    pending: () => cbs.length,
+  };
+}
+
+// A source whose chunks the test pushes on demand, so idle gaps are explicit.
+function gatedSource<T>(): {
+  source: AsyncIterable<T>;
+  push: (value: T) => void;
+  end: () => void;
+  fail: (err: unknown) => void;
+} {
+  let resolve: ((r: IteratorResult<T>) => void) | null = null;
+  let reject: ((e: unknown) => void) | null = null;
+  const queue: Array<{ ok: true; r: IteratorResult<T> } | { ok: false; e: unknown }> = [];
+  const iterator: AsyncIterator<T> = {
+    next() {
+      const head = queue.shift();
+      if (head) return head.ok ? Promise.resolve(head.r) : Promise.reject(head.e);
+      return new Promise<IteratorResult<T>>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+    },
+    return: () => Promise.resolve({ value: undefined, done: true }),
+  };
+  return {
+    source: { [Symbol.asyncIterator]: () => iterator },
+    push: (value) => {
+      if (resolve) {
+        const r = resolve;
+        resolve = null;
+        reject = null;
+        r({ value, done: false });
+      } else queue.push({ ok: true, r: { value, done: false } });
+    },
+    end: () => {
+      if (resolve) {
+        const r = resolve;
+        resolve = null;
+        reject = null;
+        r({ value: undefined as never, done: true });
+      } else queue.push({ ok: true, r: { value: undefined as never, done: true } });
+    },
+    fail: (err) => {
+      if (reject) {
+        const j = reject;
+        resolve = null;
+        reject = null;
+        j(err);
+      } else queue.push({ ok: false, e: err });
+    },
+  };
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("atEventBoundary", () => {
+  it("is true at the start and after a blank-line terminator", () => {
+    expect(atEventBoundary(null)).toBe(true);
+    expect(atEventBoundary("data: x\n\n")).toBe(true);
+  });
+  it("is false mid-frame", () => {
+    expect(atEventBoundary('data: {"par')).toBe(false);
+    expect(atEventBoundary("event: message\n")).toBe(false);
+  });
+});
+
+describe("withHeartbeat", () => {
+  it("emits a beat when the source idles, then the chunk", async () => {
+    const { source, push, end } = gatedSource<string>();
+    const timer = manualTimer();
+    const gen = withHeartbeat(source, { heartbeatMs: 100, scheduleTimer: timer.schedule });
+
+    const p1 = gen.next();
+    await tick(); // let withHeartbeat register the timer + await the race
+    expect(timer.pending()).toBe(1);
+    timer.fire();
+    expect(await p1).toEqual<IteratorResult<HeartbeatItem<string>>>({
+      done: false,
+      value: { type: "beat" },
+    });
+
+    const p2 = gen.next();
+    push("data: x\n\n");
+    expect(await p2).toEqual({ done: false, value: { type: "chunk", value: "data: x\n\n" } });
+
+    const p3 = gen.next();
+    end();
+    expect((await p3).done).toBe(true);
+  });
+
+  it("does not beat when chunks flow faster than the cadence", async () => {
+    const { source, push, end } = gatedSource<string>();
+    const timer = manualTimer();
+    const out: HeartbeatItem<string>[] = [];
+    push("a");
+    push("b");
+    end();
+    for await (const item of withHeartbeat(source, {
+      heartbeatMs: 100,
+      scheduleTimer: timer.schedule,
+    })) {
+      out.push(item);
+    }
+    expect(out).toEqual([
+      { type: "chunk", value: "a" },
+      { type: "chunk", value: "b" },
+    ]);
+  });
+
+  it("passes chunks straight through when disabled (heartbeatMs=0)", async () => {
+    const { source, push, end } = gatedSource<string>();
+    const schedule = vi.fn<ScheduleTimer>(() => () => {});
+    const out: HeartbeatItem<string>[] = [];
+    push("a");
+    end();
+    for await (const item of withHeartbeat(source, { heartbeatMs: 0, scheduleTimer: schedule })) {
+      out.push(item);
+    }
+    expect(out).toEqual([{ type: "chunk", value: "a" }]);
+    expect(schedule).not.toHaveBeenCalled();
+  });
+
+  it("propagates a source error", async () => {
+    const { source, fail } = gatedSource<string>();
+    const timer = manualTimer();
+    const gen = withHeartbeat(source, { heartbeatMs: 100, scheduleTimer: timer.schedule });
+    const p = gen.next();
+    await tick();
+    fail(new Error("upstream boom"));
+    await expect(p).rejects.toThrow("upstream boom");
+  });
+
+  it("returns the source and leaves no timer pending when the consumer breaks", async () => {
+    const { source, push } = gatedSource<string>();
+    const iterator = source[Symbol.asyncIterator]();
+    const returnSpy = vi.spyOn(iterator, "return");
+    const timer = manualTimer();
+    push("a");
+    for await (const item of withHeartbeat(source, {
+      heartbeatMs: 100,
+      scheduleTimer: timer.schedule,
+    })) {
+      expect(item).toEqual({ type: "chunk", value: "a" });
+      break; // consumer stops after the first chunk (for-await calls return())
+    }
+    expect(returnSpy).toHaveBeenCalled();
+    expect(timer.pending()).toBe(0);
+  });
+});

--- a/apps/gateway/src/routes/heartbeat.ts
+++ b/apps/gateway/src/routes/heartbeat.ts
@@ -1,0 +1,110 @@
+// SSE keep-alive heartbeat for STREAMING responses. While the upstream idles
+// between chunks, a long-but-healthy stream (slow generation, tool pauses) can be
+// severed by a front proxy or client idle-timeout that sees no bytes. We interleave
+// an SSE comment (`:\n\n`) — ignored by every compliant SSE parser (OpenAI/Anthropic
+// SDKs included) — so the connection stays warm.
+//
+// Scope (the low-risk variant, issue: upstream transient retry + SSE heartbeat): this
+// covers ONLY the inter-chunk gap. The first chunk is peeked inside execute() BEFORE
+// the response commits (so pre-first-chunk fallback is preserved); by the time a route
+// reaches this loop the first chunk is already in hand. We never emit a heartbeat before
+// the first chunk, and never after the stream ends.
+//
+// `withHeartbeat` decides chunk-vs-beat purely by TIMING and is element-type agnostic.
+// EVENT-BOUNDARY SAFETY is the caller's job: a raw byte-relay chunk may split an SSE
+// frame across network reads, and injecting `:\n\n` mid-frame would corrupt it — so a
+// route that forwards raw bytes must gate the beat on `atEventBoundary(lastWrite)`.
+// Routes that write whole frames (writeSSE) are always at a boundary.
+
+/** The keep-alive comment frame. A leading `:` marks an SSE comment line (ignored). */
+export const HEARTBEAT_COMMENT = ":\n\n";
+
+export type HeartbeatItem<T> = { type: "chunk"; value: T } | { type: "beat" };
+
+/** Schedule `cb` after `ms`; the returned canceller clears it. Cancels on abort. */
+export type ScheduleTimer = (cb: () => void, ms: number, signal?: AbortSignal) => () => void;
+
+export interface HeartbeatOptions {
+  /** Beat cadence in ms. <= 0 disables (chunks pass straight through). */
+  heartbeatMs: number;
+  /** Client-disconnect signal — when aborted the pending timer is cancelled. */
+  signal?: AbortSignal;
+  /** Injected for tests; defaults to setTimeout. */
+  scheduleTimer?: ScheduleTimer;
+}
+
+const defaultScheduleTimer: ScheduleTimer = (cb, ms, signal) => {
+  if (signal?.aborted) return () => {};
+  const timer = setTimeout(cb, ms);
+  const onAbort = () => clearTimeout(timer);
+  signal?.addEventListener("abort", onAbort, { once: true });
+  return () => {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", onAbort);
+  };
+};
+
+/**
+ * Wrap an async iterable, yielding `{type:"beat"}` whenever it stays silent for
+ * `heartbeatMs`, otherwise `{type:"chunk", value}`. The SAME pending `next()` is
+ * re-raced across successive beats — it is never called twice for one element, so no
+ * upstream chunk is dropped. A source error propagates; on early return the pending
+ * timer is cancelled and the source's `return()` is invoked for cleanup.
+ */
+export async function* withHeartbeat<T>(
+  source: AsyncIterable<T>,
+  opts: HeartbeatOptions,
+): AsyncGenerator<HeartbeatItem<T>> {
+  const { heartbeatMs } = opts;
+  const schedule = opts.scheduleTimer ?? defaultScheduleTimer;
+  const iterator = source[Symbol.asyncIterator]();
+  let cancelTimer: () => void = () => {};
+  try {
+    while (true) {
+      const nextPromise = iterator.next();
+      if (heartbeatMs <= 0) {
+        const r = await nextPromise;
+        if (r.done) return;
+        yield { type: "chunk", value: r.value };
+        continue;
+      }
+      // Re-race the SAME next() against fresh heartbeat timers until it settles.
+      for (;;) {
+        let fireBeat!: () => void;
+        const beat = new Promise<void>((resolve) => {
+          fireBeat = resolve;
+        });
+        cancelTimer = schedule(fireBeat, heartbeatMs, opts.signal);
+        const outcome = await Promise.race([
+          nextPromise.then(
+            (r) => ({ kind: "next" as const, r }),
+            (e) => ({ kind: "error" as const, e }),
+          ),
+          beat.then(() => ({ kind: "beat" as const })),
+        ]);
+        cancelTimer();
+        cancelTimer = () => {};
+        if (outcome.kind === "beat") {
+          yield { type: "beat" };
+          continue;
+        }
+        if (outcome.kind === "error") throw outcome.e;
+        if (outcome.r.done) return;
+        yield { type: "chunk", value: outcome.r.value };
+        break;
+      }
+    }
+  } finally {
+    cancelTimer();
+    await iterator.return?.();
+  }
+}
+
+/**
+ * True when the wire is at an SSE event boundary — safe to inject a heartbeat. The
+ * initial state (nothing written yet) and any chunk ending in a blank line (`\n\n`)
+ * are boundaries; a chunk that ended mid-frame is not.
+ */
+export function atEventBoundary(lastRawWrite: string | null): boolean {
+  return lastRawWrite === null || lastRawWrite.endsWith("\n\n");
+}

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -11,6 +11,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
+import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
 import { PipelineError } from "./messages-pipeline.js";
 import { nativeCarrierFromParsedBody } from "./native-carrier.js";
@@ -148,6 +149,9 @@ export interface MessagesRouteDeps {
      *  fault (does not trip the circuit breaker). */
     run(ir: IRLike, identity: MessagesIdentity, signal: AbortSignal): Promise<PipelineRunResult>;
   };
+  /** SSE keep-alive cadence (ms) for streaming responses; read fresh per request from
+   *  runtime.sse_heartbeat_ms. Optional — absent/0 = no heartbeat. Inter-chunk only. */
+  sseHeartbeatMs?: () => number;
 }
 
 // The route treats the IR as an opaque bag with the two fields it must read
@@ -492,8 +496,23 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         // machine (the #221/#222 bug source) is ELIMINATED on this path, not replaced.
         // Capture stays native on both ends; an upstream error mid-passthrough still
         // surfaces the Anthropic terminal error frame below (catch is unchanged).
+        // SSE keep-alive: emit a `:` comment during inter-chunk idle (wire-only, never
+        // captured) so a proxy/client idle-timeout does not sever a long healthy stream.
+        // Gated on an event boundary so it can never split a verbatim-relayed frame
+        // (writeSSE frames are always whole; raw passthrough chunks may be partial).
+        // 0 = disabled (today's behavior).
+        const heartbeatMs = deps.sseHeartbeatMs?.() ?? 0;
+        let lastWrite: string | null = null;
         try {
-          for await (const event of result.streamIR()) {
+          for await (const item of withHeartbeat(result.streamIR(), {
+            heartbeatMs,
+            signal: c.req.raw.signal,
+          })) {
+            if (item.type === "beat") {
+              if (atEventBoundary(lastWrite)) await sse.write(HEARTBEAT_COMMENT);
+              continue;
+            }
+            const event = item.value;
             const frame =
               result.nativePassthrough === true
                 ? (event as { event: string; data: string; raw?: string })
@@ -503,8 +522,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
               captured.push(raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`);
             if (raw !== undefined) {
               await sse.write(raw);
+              lastWrite = raw;
             } else {
               await sse.writeSSE({ event: frame.event, data: frame.data });
+              lastWrite = "\n\n"; // writeSSE emits a complete frame — always a boundary
             }
           }
         } catch (err) {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -7,6 +7,7 @@ import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
+import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
@@ -130,6 +131,9 @@ export interface ResponsesRouteDeps {
       signal: AbortSignal,
     ): Promise<PipelineRunResult>;
   };
+  /** SSE keep-alive cadence (ms) for streaming responses; read fresh per request from
+   *  runtime.sse_heartbeat_ms. Optional — absent/0 = no heartbeat. Inter-chunk only. */
+  sseHeartbeatMs?: () => number;
 }
 
 // Client disconnect / abort detection — mirrors messages.ts. Used to suppress a
@@ -518,9 +522,23 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         // captured (verbatim) alongside the telemetry row in the finally below.
         const captured: string[] = [];
         let result: PipelineRunResult | null = null;
+        // SSE keep-alive: emit a `:` comment during inter-chunk idle (wire-only, never
+        // captured) so a proxy/client idle-timeout does not sever a long healthy stream.
+        // Gated on an event boundary so it can never split a verbatim-relayed frame.
+        // 0 = disabled (today's behavior).
+        const heartbeatMs = deps.sseHeartbeatMs?.() ?? 0;
+        let lastWrite: string | null = null;
         try {
           result = await deps.pipeline.run(ir, identity, c.req.raw.signal);
-          for await (const event of result.streamIR()) {
+          for await (const item of withHeartbeat(result.streamIR(), {
+            heartbeatMs,
+            signal: c.req.raw.signal,
+          })) {
+            if (item.type === "beat") {
+              if (atEventBoundary(lastWrite)) await sse.write(HEARTBEAT_COMMENT);
+              continue;
+            }
+            const event = item.value;
             if (typeof event.sequence_number === "number")
               nextErrorSequence = event.sequence_number + 1;
             const frame =
@@ -536,8 +554,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
               captured.push(raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`);
             if (raw !== undefined) {
               await sse.write(raw);
+              lastWrite = raw;
             } else {
               await sse.writeSSE({ event: frame.event, data: frame.data });
+              lastWrite = "\n\n"; // writeSSE emits a complete frame — always a boundary
             }
           }
         } catch (err) {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1502,6 +1502,8 @@ export async function buildServer(
     writes: writeQueue,
     redact: (payload) => redact(payload),
     now: () => Date.now(),
+    // SSE keep-alive cadence (runtime.sse_heartbeat_ms / HELM_SSE_HEARTBEAT_MS); 0 = off.
+    sseHeartbeatMs: () => config.runtime.sse_heartbeat_ms,
     recordOAuthUsage,
     // Full request/response capture + streamed-cost backfill. The getters read the
     // LIVE runtime settings so the admin toggle/retention apply without a restart.
@@ -1803,6 +1805,7 @@ export async function buildServer(
       },
     },
     pipeline: messagesPipeline,
+    sseHeartbeatMs: () => config.runtime.sse_heartbeat_ms,
     // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
     // chat route uses, so /v1/messages records served requests like /v1/chat does.
     record: {
@@ -2000,6 +2003,7 @@ export async function buildServer(
     pipeline: responsesPipeline,
     lifecycle: responsesLifecycle,
     registry: responsesRegistry,
+    sseHeartbeatMs: () => config.runtime.sse_heartbeat_ms,
     // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
     // chat route uses, so /v1/responses records served requests like /v1/chat does.
     record: {
@@ -2101,6 +2105,7 @@ export async function buildServer(
         }),
     },
     pipeline: geminiPipeline,
+    sseHeartbeatMs: () => config.runtime.sse_heartbeat_ms,
     // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
     // chat route uses, so the gemini face records served requests like /v1/chat does.
     record: {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-14 · 上游瞬时断连的幂等重试 + SSE 心跳保活（docs/02/05；原则 3/8）
+
+- **背景**：客户端偶发 `The socket connection was closed unexpectedly…`（Bun fetch 文案 → 客户端↔helm 的 TCP 被无干净 HTTP 错误地掐断）。排查：helm 正常错误路径**不产生裸 socket 关闭**（首包前→结构化 JSON 502/504，流中→`event: error` 帧），裸断 ⇒ 代理 idle/read 超时 / 进程重启 / keepalive 复用竞争。helm 旧行为只有「换模型」execution fallback，**无「重试同一上游」**——单候选链遇瞬时抖动即 502。用户拍板做两件且对流式/非流式都健壮：(A) 幂等重试 (B) SSE 心跳；慢首包覆盖（early-commit）走**否决**（保留 peek-before-commit、低风险）。
+- **Change A — 幂等重试（`provider/retry.ts`）**：`isTransientConnectionError` 严格白名单（ECONNRESET/ECONNREFUSED/EPIPE/ETIMEDOUT/UND_ERR_SOCKET + 跨运行时 message 子串含 Bun 文案；递归查 `err.cause`；`name==="AbortError"` 短路 false），`withConnectionRetry(fn,{retries,backoffMs,sleep,signal})` 默认 2×[200,500]ms、abort 期间停。落在三 client（openai/anthropic/openai-responses）的 `request()` **fetch 边界**——stream/non-stream 共用唯一 fetch 入口、首字节前 ⇒ 幂等、**对单候选链也生效**；嵌于 401-retry 之内（401 是成功响应不触发连接重试，二者正交）；timeout→非 transient 不重试（交给跨模型 fallback）。三 client 加可选 `connectRetries`/`connectRetryBackoffMs`（缺省走 helper 默认，亦作测试 seam）。**非目标**：non-stream body-read / stream 首包读取阶段 reset 仍靠跨模型 fallback。
+- **Change B — SSE chunk 间心跳（`routes/heartbeat.ts`）**：`withHeartbeat` 纯时序生成器把**同一**待决 `next()` 与心跳定时器反复赛跑（绝不重复调 next ⇒ 不丢/不重 chunk），产出 `{type:beat|chunk}`；`heartbeatMs=0` 关闭、early-return 取消定时器并 `iterator.return()`。**边界抑制在路由**（元素类型各异，生成器不懂字节）：`atEventBoundary(lastRawWrite)`——`writeSSE` 整帧恒边界、raw 直传按 `\n\n` 收尾判断 ⇒ `:\n\n` 永不插进半帧（principle 8 关键）。心跳帧 wire-only：**不进 capture、不喂 accumulator、不计 cost**。接入**4 个**流式面（chat/messages/responses/**gemini**——超出原计划 3 个，为一致性扩到 Gemini）。配置 `runtime.sse_heartbeat_ms`（默认 15000、`HELM_SSE_HEARTBEAT_MS`、0 关、`nonnegative` 允许 0）经 4 处 register 注入；**仅覆盖 chunk 间 idle**——首包 peek 仍在 `execute()` 内（早于 200 提交），pre-first-chunk fallback 语义不变。
+- **取舍/坑/TODO**：① 慢首包（首 token 耗时 > 代理 read-timeout，如推理模型）**未在 helm 侧覆盖**——若复现优先核对 nginx/haproxy/CF 超时，或后续再评估 early-commit（会把流式错误从干净 502/504 变成 in-band `event:error` 帧）。② 心跳默认 15s 远低于 nginx 60s/CF ~100s；运营者按前置代理调 `HELM_SSE_HEARTBEAT_MS`。③ schema 改了须重建 `@helm/shared`。
+- **验证**：TDD 红→绿——`retry.test.ts`(25) + `heartbeat.test.ts`(7, 含边界/disabled/error/early-return) + 三 client wiring + chat 路由 `:\n\n` 端到端集成（断言数据帧逐字 + 心跳非 data 事件）。provider 208 / 路由+schema 全绿，`pnpm typecheck`、`pnpm lint`、`pnpm build` 绿。分支 `fix/upstream-transient-retry-sse-heartbeat`。
+
 ## 2026-06-14 · Admin 管理界面移动端/响应式走查 + 修复（docs/10/11；原则 1）
 
 - **背景**：用户要求对 admin 全部 9 个页面做移动端/PC 走查（Playwright 截图三视口：iPhone 12 Pro 390×844 / iPad mini 768×1024 / 桌面 1920×1080），找出不合理处并修，移动端必须方便触控。流程：先把本地 main 重新构建部署到 Docker（localhost:8080）→ 截 29 张图（含移动 nav drawer、New key 弹层）→ Workflow 扇出 10 个 reviewer（每页读截图+源码）→ 对抗式验证 → 综合，25 处真实问题归并为 12 条（1 blocker / 3 major / 6 minor / 2 polish）。控制台零报错。
@@ -23,20 +31,13 @@
 - **验证**：TDD 红→绿（payload-capture +9、messages-pipeline +6 Gemini passthrough 预算/记忆回归、gemini provider +4 SSRF、openai-responses +2 tool_calls）；新增 ast gate（5-arg materializer 签名 + `assertPublicHttpsTarget`）；`typecheck`/`lint`/`test:protocol-compat:ast` 绿，changed-area 512 tests 绿。
 - **Codex review round 2（同 PR 6 项再修，原则 2/3/7）**：① **P1 Gemini 翻译路径**——Gemini client 的 `chatCompletion`/`chatCompletionStream` 原本恒 throw，导致非 Gemini 客户端路由到 Gemini provider（混合 lane）或关闭 passthrough 时整条 attempt 失败；改为经 transformer 组合翻译 OpenAI-Chat ⇄ Gemini（`openaiTransformer.transformRequestOut`→`geminiTransformer.transformRequestIn`→fetch→`transformResponseIn`→`openaiTransformer.transformResponseOut`；流式 Gemini SSE→`transformStreamIn`→OpenAI chunk+`[DONE]`），返回 OpenAI 形态供 pipeline 消费。② **P1 DNS 钉死（rebinding）**——guard 解析校验后 `fetch` 会二次解析；新增独立 `mediaFetch`（默认 `node:https`，`lookup` 钉死到已校验地址、SNI 仍按真实 hostname 验证），`assertPublicHttpsTarget` 返回 pinned 地址逐 hop 钉死（无 undici 依赖）。③ **P1 静态 key 脱敏**——generic Responses `scrub()` 补 `cfg.apiKey` 进脱敏集，防上游 error body 回显泄露。④ **P2 媒体边读边限**——`readBodyWithLimit` 用 `readChunkWithIdle` 流式读 + 超限即 abort（不再先 `arrayBuffer()` 全量分配）。⑤ **P2 401 重建头**——generic Responses 401 重试前 `providerHeaders()` 重取刷新后 token。⑥ **P2 registry 有界**——周期清理过期项 + 1 万条硬上限 LRU 淘汰。验证：TDD 新增 gemini +4 / openai-responses +2；`typecheck`/`lint`/ast 绿，changed-area 474 tests 绿。
 
-## 2026-06-14 · Claude OAuth web 登录改用 console callback「copy code」流（docs/06；原则 1/7）
-
-- **背景**：admin web UI 连接 Claude 订阅时，authorize URL 的 `redirect_uri` 写死 `http://localhost:53692/callback`；批准后浏览器跳到该 localhost 死链（web 环境无回调服务器），运营者要从地址栏抠出报错 URL 粘回——困惑。参考用户指定的 `claude-relay-service`：它用 Anthropic 托管的 console callback，批准后页面**直接显示授权码**（`<code>#<state>`）供复制，干净的 "copy code" 流。
-- **核心改动（外科手术式，仅 Anthropic）**：`provider/oauth/anthropic.ts` 新增 `CONSOLE_REDIRECT_URI="https://platform.claude.com/oauth/code/callback"`，`exchangeAuthorizationCode` 参数化 `redirectUri`；**web 路**（`beginAnthropicLogin` 授权 URL + `completeAnthropicLogin` 交换）改用 console callback，**CLI 路**（`loginAnthropic`）保留 localhost 回调服务器（自动捕获是最佳 CLI UX、且非用户抱怨点）。两路 redirect_uri 现刻意分叉——授权 URL 与 token 交换必须用同一值否则 grant 被拒。admin 编排（`admin-oauth.ts` `MANUAL_FLOWS`）零改（begin/complete 签名不变）。
-- **关键发现（少改两处）**：① `parseOAuthAuthorizationInput`（runtime.ts）**早已**支持 `code#state` 格式（console 页展示形态），无需改 parser；② helm 授权 URL **早已**带 `code=true`（请求 Anthropic 渲染码页），唯一坏的就是 redirect_uri，所以是单点修复。
-- **UI**：`ConnectProviderDialog.svelte` 加 `isAnthropic` 派生，manual 步骤对 Anthropic 改文案「复制页面上显示的授权码」+ 占位符，Codex 仍是「复制重定向 URL」；新增 3 条 i18n 串补 en/zh-hans/zh-hant/ja/ko。
-- **取舍/TODO**：Codex web 流同有 localhost 死链，但 OpenAI 无等价托管码页，本轮**不动 Codex**（已知 follow-up）。redirect_uri 必须是 client_id `9d1c250a-…` 注册的回调——relay 用同一 client_id/scopes/`code=true` 配同值、helm token 端点本就 `platform.claude.com`，高置信被接受；最终需真订阅 admin 手验。
-- **验证**：TDD 红→绿——`web-login.test.ts` 钉死 begin/complete 的 console redirect_uri + `code#state` 粘贴，`anthropic.test.ts` 钉死 CLI 仍用 localhost。core OAuth + gateway OAuth 全绿（202）、typecheck/lint 绿、svelte-check 仅剩既有 `oauth.test.ts` 3 报错（非回归）。分支 `worktree-claude-oauth-copy-code`（git worktree）。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-14 · Claude OAuth web 登录改用 console callback「copy code」流（docs/06；原则 1/7）：admin web 连 Claude 订阅时 authorize 的 `redirect_uri` 写死 localhost 死链（web 无回调服务器）；改用 Anthropic 托管 console callback `https://platform.claude.com/oauth/code/callback`（批准后页面直接显示 `code#state` 供复制）。外科式仅改 Anthropic：`provider/oauth/anthropic.ts` 参数化 `exchangeAuthorizationCode(redirectUri)`，**web 路** begin/complete 用 console callback、**CLI 路** `loginAnthropic` 保留 localhost；两路 redirect_uri 刻意分叉（授权 URL 与 token 交换须同值）。`parseOAuthAuthorizationInput` 早已认 `code#state`、授权 URL 早已带 `code=true`，故单点修复。Codex web 同有死链但 OpenAI 无托管码页，未动（follow-up）。TDD web-login/anthropic 绿、core+gateway OAuth 202 绿。
 
 ### 2026-06-14 · 评估并否决引入 `@earendil-works/pi-ai` 替换 OAuth 实现（原则 1/6）：pi-ai（v0.79.3）内置 OAuth provider 与 helm 完全一致（anthropic/codex/copilot），其文档「众多 Supported」多为 API-key 类（非 OAuth）；其公开 API 只 `login*()`（强绑本地端口 53692/1455）+`refresh*Token`、不导出 `exchangeAuthorizationCode`/PKCE，与 helm web begin/complete 形态失配；二者同源（openclaw 血统）。用户拍板**不引入、保持现状**，无代码改动。重评触发：pi-ai 新增真 OAuth（Gemini/Qwen 订阅）时仅评估接管 `refresh*Token`，不碰 web 登录编排。
 

--- a/packages/core/src/config/env-map.ts
+++ b/packages/core/src/config/env-map.ts
@@ -31,6 +31,11 @@ export const ENV_MAPPINGS: readonly EnvMapping[] = [
     kind: "number",
   },
   {
+    env: "HELM_SSE_HEARTBEAT_MS",
+    path: ["runtime", "sse_heartbeat_ms"],
+    kind: "number",
+  },
+  {
     env: "HELM_RATE_LIMIT_ENABLED",
     path: ["runtime", "rate_limit", "enabled"],
     kind: "boolean",

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -1447,19 +1447,27 @@ describe("createAnthropicClient", () => {
     }
   });
 
-  it("re-throws a real network error (not a timeout) unchanged", async () => {
+  it("retries a transient network error then re-throws it unchanged", async () => {
     // The non-timeout catch arm: fetch rejects for a reason OTHER than the internal
-    // abort -> the original error propagates (executor treats it as a provider failure).
+    // abort. ECONNREFUSED is a transient connection error, so it is retried at the
+    // fetch boundary ([0,0] backoff keeps the test instant); once the budget is
+    // exhausted the ORIGINAL error propagates (executor treats it as a provider failure).
     const boom = new Error("ECONNREFUSED");
+    const fetch = vi.fn(async () => {
+      throw boom;
+    });
     const client = createAnthropicClient({
-      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
-      fetch: (async () => {
-        throw boom;
-      }) as unknown as typeof fetch,
+      config: {
+        baseUrl: "https://api.anthropic.com",
+        apiKey: "sk-static",
+        connectRetryBackoffMs: [0, 0],
+      },
+      fetch: fetch as unknown as typeof globalThis.fetch,
     });
     await expect(
       client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] }),
     ).rejects.toBe(boom);
+    expect(fetch).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
   });
 
   it("does NOT convert an external client abort into a timeout (client disconnect is not a provider failure)", async () => {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -22,6 +22,7 @@ import {
   type ProviderClient,
   UpstreamError,
 } from "./openai.js";
+import { withConnectionRetry } from "./retry.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface AnthropicClientConfig {
@@ -37,6 +38,11 @@ export interface AnthropicClientConfig {
   // the device identity never rotates — the real-client posture Anthropic expects.
   // Undefined → no `metadata` is sent (back-compat; matches openclaw's default).
   metadataUserId?: string;
+  // Transient-connection retry at the fetch boundary (provider/retry.ts). Optional —
+  // omitted falls back to defaults (2 retries, [200,500] ms). Pre-first-byte, so the
+  // retry is idempotent. See ProviderConfig for the rationale.
+  connectRetries?: number;
+  connectRetryBackoffMs?: readonly number[];
 }
 
 export interface AnthropicClientDeps {
@@ -664,22 +670,29 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         ? { providerProfileApplied: "anthropic_official_safe" }
         : {}),
     });
-    const t = withTimeout(timeoutMs, external);
-    try {
-      return await doFetch(endpointUrl, {
-        method: "POST",
-        headers: prepared.headers,
-        body: prepared.bodyText,
-        signal: t.signal,
-      });
-    } catch (err) {
-      if (t.isTimeout() && !t.isExternalAbort()) {
-        throw new UpstreamError("timeout", "upstream request timed out");
-      }
-      throw err;
-    } finally {
-      t.cleanup();
-    }
+    // Retry transient connection blips at the fetch boundary (pre-first-byte → idempotent);
+    // a timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
+    return withConnectionRetry(
+      async () => {
+        const t = withTimeout(timeoutMs, external);
+        try {
+          return await doFetch(endpointUrl, {
+            method: "POST",
+            headers: prepared.headers,
+            body: prepared.bodyText,
+            signal: t.signal,
+          });
+        } catch (err) {
+          if (t.isTimeout() && !t.isExternalAbort()) {
+            throw new UpstreamError("timeout", "upstream request timed out");
+          }
+          throw err;
+        } finally {
+          t.cleanup();
+        }
+      },
+      { retries: cfg.connectRetries, backoffMs: cfg.connectRetryBackoffMs, signal: external },
+    );
   }
 
   async function requestWithRetry(

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1126,20 +1126,25 @@ describe("createCodexResponsesClient", () => {
     expect(caught).not.toBeInstanceOf(UpstreamError);
   });
 
-  it("re-throws a real network error (not a timeout) unchanged", async () => {
+  it("retries a transient network error then re-throws it unchanged", async () => {
+    // ECONNREFUSED is transient → retried at the fetch boundary ([0,0] backoff keeps
+    // the test instant); the ORIGINAL error propagates once the budget is exhausted.
     const boom = new Error("ECONNREFUSED");
+    const fetch = vi.fn(async () => {
+      throw boom;
+    });
     const client = createCodexResponsesClient({
       config: {
         baseUrl: "https://chatgpt.com/backend-api/codex",
         getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        connectRetryBackoffMs: [0, 0],
       },
-      fetch: (async () => {
-        throw boom;
-      }) as unknown as typeof fetch,
+      fetch: fetch as unknown as typeof globalThis.fetch,
     });
     await expect(
       client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] }),
     ).rejects.toBe(boom);
+    expect(fetch).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
   });
 
   it("preserves a non-JSON upstream error body as raw text in the UpstreamError", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -26,6 +26,7 @@ import {
   type ProviderConfig,
   UpstreamError,
 } from "./openai.js";
+import { withConnectionRetry } from "./retry.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface CodexResponsesClientConfig {
@@ -49,6 +50,11 @@ export interface CodexResponsesClientConfig {
   // caller wraps its own fail-open); a throw here is swallowed so it never breaks a
   // served request.
   onResponseMeta?: (headers: Headers) => void;
+  // Transient-connection retry at the fetch boundary (provider/retry.ts). Optional —
+  // omitted falls back to defaults (2 retries, [200,500] ms). Pre-first-byte, so the
+  // retry is idempotent. See ProviderConfig for the rationale.
+  connectRetries?: number;
+  connectRetryBackoffMs?: readonly number[];
 }
 
 export interface CodexResponsesClientDeps {
@@ -451,22 +457,29 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     const prepared = prepareNativePassthroughRequest(input, providerHeaders, {
       mergeHeaders: ["openai-beta"],
     });
-    const t = withTimeout(timeoutMs, external);
-    try {
-      return await doFetch(url, {
-        method: "POST",
-        headers: prepared.headers,
-        body: prepared.bodyText,
-        signal: t.signal,
-      });
-    } catch (err) {
-      if (t.isTimeout() && !t.isExternalAbort()) {
-        throw new UpstreamError("timeout", "upstream request timed out");
-      }
-      throw err;
-    } finally {
-      t.cleanup();
-    }
+    // Retry transient connection blips at the fetch boundary (pre-first-byte → idempotent);
+    // a timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
+    return withConnectionRetry(
+      async () => {
+        const t = withTimeout(timeoutMs, external);
+        try {
+          return await doFetch(url, {
+            method: "POST",
+            headers: prepared.headers,
+            body: prepared.bodyText,
+            signal: t.signal,
+          });
+        } catch (err) {
+          if (t.isTimeout() && !t.isExternalAbort()) {
+            throw new UpstreamError("timeout", "upstream request timed out");
+          }
+          throw err;
+        } finally {
+          t.cleanup();
+        }
+      },
+      { retries: cfg.connectRetries, backoffMs: cfg.connectRetryBackoffMs, signal: external },
+    );
   }
 
   // Scrape the upstream rate-limit window headers (providers page Tier 3) the moment

--- a/packages/core/src/provider/openai.test.ts
+++ b/packages/core/src/provider/openai.test.ts
@@ -502,3 +502,66 @@ describe("createOpenAIClient (extraHeaders + resolveBaseUrl — Copilot path, is
     expect(seenUrl).toBe("https://upstream.test/v1/chat/completions");
   });
 });
+
+describe("createOpenAIClient (transient-connection retry)", () => {
+  const econnreset = () => Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+  // [0, 0] backoff keeps the test instant; the retry path itself is unchanged.
+  const RETRY_CONFIG = { ...CONFIG, connectRetryBackoffMs: [0, 0] as const };
+
+  it("retries a transient connection error then succeeds (non-streaming)", async () => {
+    let calls = 0;
+    const fetch = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw econnreset();
+      return jsonResponse({ ok: true });
+    });
+    const client = createOpenAIClient({
+      config: RETRY_CONFIG,
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    });
+    const out = await client.chatCompletion({ model: "m" });
+    expect(out).toEqual({ ok: true });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a transient connection error before the first stream chunk", async () => {
+    let calls = 0;
+    const fetch = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw econnreset();
+      return sseResponse(["data: a\n\n", "data: b\n\n"]);
+    });
+    const client = createOpenAIClient({
+      config: RETRY_CONFIG,
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    });
+    const chunks: string[] = [];
+    for await (const c of client.chatCompletionStream({ model: "m" })) chunks.push(c);
+    expect(chunks.join("")).toBe("data: a\n\ndata: b\n\n");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-transient upstream status", async () => {
+    const fetch = vi.fn(async () => jsonResponse({ error: "bad" }, 400));
+    const client = createOpenAIClient({
+      config: RETRY_CONFIG,
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    });
+    await expect(client.chatCompletion({ model: "m" })).rejects.toBeInstanceOf(UpstreamError);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a client abort", async () => {
+    const ac = new AbortController();
+    const fetch = vi.fn(async () => {
+      ac.abort();
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    });
+    const client = createOpenAIClient({
+      config: RETRY_CONFIG,
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    });
+    await expect(client.chatCompletion({ model: "m" }, { signal: ac.signal })).rejects.toThrow();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -13,6 +13,7 @@ import type { NativePassthroughInput } from "@helm/shared";
 //   - `currentSecrets`: live access + refresh tokens, used by `scrub()` to strip
 //     any echoed credential from an upstream error body (principle 7).
 // Credentials are runtime-only: from env, never persisted/logged.
+import { withConnectionRetry } from "./retry.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface ProviderConfig {
@@ -37,6 +38,13 @@ export interface ProviderConfig {
   // Compatibility shim for OpenAI-compatible providers that stream reasoning as
   // choices[].delta.reasoning. Disabled by default to preserve byte forwarding.
   normalizeReasoningDeltaAlias?: boolean;
+  // Transient-connection retry at the fetch boundary (provider/retry.ts). Both
+  // optional — omitted falls back to withConnectionRetry's defaults (2 retries,
+  // [200,500] ms). Safe here because a retry happens BEFORE any byte reaches the
+  // client (idempotent); it absorbs a keepalive-reuse race / ECONNRESET so a hiccup
+  // does not burn a candidate or 502 a single-candidate chain.
+  connectRetries?: number;
+  connectRetryBackoffMs?: readonly number[];
 }
 
 export interface OpenAIClientDeps {
@@ -305,23 +313,32 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     req: ChatCompletionRequest,
     external: AbortSignal | undefined,
   ): Promise<Response> {
-    const t = withTimeout(timeoutMs, external);
-    try {
-      return await doFetch(await chatUrl(), {
-        method: "POST",
-        headers: await headers(),
-        body: JSON.stringify(prepareRequest(req)),
-        signal: t.signal,
-      });
-    } catch (err) {
-      if (t.isTimeout() && !t.isExternalAbort()) {
-        throw new UpstreamError("timeout", "upstream request timed out");
-      }
-      // Client abort is NOT a provider fault — rethrow as-is for the caller.
-      throw err;
-    } finally {
-      t.cleanup();
-    }
+    // Retry transient connection blips at the fetch boundary (pre-first-byte, so
+    // idempotent). A timeout is rethrown as UpstreamError (non-transient → no retry,
+    // the chain falls back); a client abort rethrows as-is. Each attempt gets a fresh
+    // timeout + freshly resolved url/headers (tracks a rotating token).
+    return withConnectionRetry(
+      async () => {
+        const t = withTimeout(timeoutMs, external);
+        try {
+          return await doFetch(await chatUrl(), {
+            method: "POST",
+            headers: await headers(),
+            body: JSON.stringify(prepareRequest(req)),
+            signal: t.signal,
+          });
+        } catch (err) {
+          if (t.isTimeout() && !t.isExternalAbort()) {
+            throw new UpstreamError("timeout", "upstream request timed out");
+          }
+          // Client abort is NOT a provider fault — rethrow as-is for the caller.
+          throw err;
+        } finally {
+          t.cleanup();
+        }
+      },
+      { retries: cfg.connectRetries, backoffMs: cfg.connectRetryBackoffMs, signal: external },
+    );
   }
 
   // Issue the request, applying the OAuth 401 single-retry (D2): on a 401 with an

--- a/packages/core/src/provider/retry.test.ts
+++ b/packages/core/src/provider/retry.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { isTransientConnectionError, withConnectionRetry } from "./retry.js";
+
+// A transient connection error is one safe to retry BEFORE any bytes reached the
+// client (idempotent: no upstream response consumed). The classifier is a strict
+// allowlist — only raw socket/connection signatures match, so an already-classified
+// UpstreamError (timeout / non-2xx) or a client AbortError falls through to false.
+
+describe("isTransientConnectionError", () => {
+  const transient: Array<[string, unknown]> = [
+    ["ECONNRESET code", Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })],
+    [
+      "ECONNREFUSED code",
+      Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }),
+    ],
+    ["EPIPE code", Object.assign(new Error("write EPIPE"), { code: "EPIPE" })],
+    ["ETIMEDOUT code", Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" })],
+    [
+      "UND_ERR_SOCKET code",
+      Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" }),
+    ],
+    ["undici 'terminated'", new Error("terminated")],
+    ["node 'socket hang up'", new Error("socket hang up")],
+    [
+      "Bun socket-closed text",
+      new Error(
+        "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+      ),
+    ],
+    ["undici 'Premature close'", new Error("Premature close")],
+    [
+      "undici 'fetch failed' wrapping a SocketError cause",
+      Object.assign(new TypeError("fetch failed"), {
+        cause: Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" }),
+      }),
+    ],
+  ];
+  it.each(transient)("treats %s as transient", (_label, err) => {
+    expect(isTransientConnectionError(err)).toBe(true);
+  });
+
+  const nonTransient: Array<[string, unknown]> = [
+    ["AbortError name", Object.assign(new Error("aborted"), { name: "AbortError" })],
+    ["DOMException abort", new DOMException("This operation was aborted", "AbortError")],
+    ["UpstreamError(timeout) message", new Error("upstream request timed out")],
+    ["upstream non-2xx message", new Error("upstream returned 500")],
+    ["unrelated error", new Error("totally unrelated")],
+    ["null", null],
+    ["undefined", undefined],
+    ["string", "boom"],
+  ];
+  it.each(nonTransient)("treats %s as non-transient", (_label, err) => {
+    expect(isTransientConnectionError(err)).toBe(false);
+  });
+
+  it("does not retry an abort even if its message looks transient", () => {
+    // Defense in depth: a client abort that happens to carry a socket-ish message
+    // must still be classified non-transient (name wins).
+    const err = Object.assign(new Error("socket hang up"), { name: "AbortError" });
+    expect(isTransientConnectionError(err)).toBe(false);
+  });
+});
+
+describe("withConnectionRetry", () => {
+  const reset = () => Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+
+  it("retries a transient error then succeeds", async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw reset();
+      return "ok";
+    });
+    const sleep = vi.fn(async () => {});
+    const result = await withConnectionRetry(fn, { retries: 2, sleep });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-transient error", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("upstream returned 400");
+    });
+    await expect(withConnectionRetry(fn, { retries: 2, sleep: async () => {} })).rejects.toThrow(
+      "400",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("exhausts the retry budget then throws the last transient error", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("socket hang up");
+    });
+    await expect(withConnectionRetry(fn, { retries: 2, sleep: async () => {} })).rejects.toThrow(
+      "socket hang up",
+    );
+    expect(fn).toHaveBeenCalledTimes(3); // 1 + 2
+  });
+
+  it("stops immediately when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const fn = vi.fn(async () => {
+      throw reset();
+    });
+    await expect(
+      withConnectionRetry(fn, { retries: 2, sleep: async () => {}, signal: ac.signal }),
+    ).rejects.toThrow("ECONNRESET");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying if the signal aborts during backoff", async () => {
+    const ac = new AbortController();
+    const fn = vi.fn(async () => {
+      throw reset();
+    });
+    // The abort lands while we are sleeping between attempts.
+    const sleep = vi.fn(async () => {
+      ac.abort();
+    });
+    await expect(withConnectionRetry(fn, { retries: 3, sleep, signal: ac.signal })).rejects.toThrow(
+      "ECONNRESET",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to 2 retries with no opts", async () => {
+    const fn = vi.fn(async () => {
+      throw reset();
+    });
+    await expect(withConnectionRetry(fn, { sleep: async () => {} })).rejects.toThrow("ECONNRESET");
+    expect(fn).toHaveBeenCalledTimes(3); // default retries = 2
+  });
+});

--- a/packages/core/src/provider/retry.ts
+++ b/packages/core/src/provider/retry.ts
@@ -1,0 +1,125 @@
+// Idempotent retry for TRANSIENT upstream connection failures, applied at the
+// provider's fetch boundary — BEFORE any response byte has reached the client, so
+// re-issuing the request is safe (no duplicated/half-emitted output, principle 8).
+//
+// This is NOT the execution fallback (executor/fallback.ts swaps to the NEXT model
+// in the chain): this retries the SAME upstream a couple of times to absorb a
+// transient blip — a keepalive connection-reuse race, an ECONNRESET, a peer that
+// closed the socket — which otherwise burns a candidate (or 502s a single-candidate
+// chain) for a hiccup that a 200 ms retry would have survived.
+//
+// The classifier is a STRICT allowlist: only raw socket/connection signatures match.
+// An already-classified UpstreamError("timeout") (slow connect — retrying only adds
+// latency; the chain falls back instead) and a client AbortError both fall through
+// to non-transient and are never retried.
+
+const TRANSIENT_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_SOCKET",
+]);
+
+// Lowercased message substrings of transient connection failures across runtimes:
+// undici ("terminated", "other side closed"), Node ("socket hang up"), Bun ("The
+// socket connection was closed unexpectedly…"), and stream prematurely-closed errors.
+const TRANSIENT_MESSAGE_PATTERNS = [
+  "econnreset",
+  "econnrefused",
+  "epipe",
+  "etimedout",
+  "other side closed",
+  "terminated",
+  "socket hang up",
+  "socket connection was closed",
+  "premature close",
+];
+
+/**
+ * True iff `err` (or a `cause` in its chain) is a transient connection failure
+ * safe to retry pre-first-byte. A client abort (`name === "AbortError"`) is never
+ * transient — the name check wins even over a socket-ish message.
+ */
+export function isTransientConnectionError(err: unknown): boolean {
+  let cur: unknown = err;
+  for (let depth = 0; depth < 5 && cur != null; depth += 1) {
+    if (typeof cur !== "object") break;
+    const e = cur as { name?: unknown; code?: unknown; message?: unknown; cause?: unknown };
+    // Client abort short-circuits: never retry a cancellation.
+    if (e.name === "AbortError") return false;
+    if (typeof e.code === "string" && TRANSIENT_CODES.has(e.code)) return true;
+    if (typeof e.message === "string") {
+      const msg = e.message.toLowerCase();
+      if (TRANSIENT_MESSAGE_PATTERNS.some((p) => msg.includes(p))) return true;
+    }
+    cur = e.cause;
+  }
+  return false;
+}
+
+export interface ConnectionRetryOptions {
+  /** Max additional attempts after the first. Default 2. */
+  retries?: number;
+  /** Backoff (ms) before retry i; the last value repeats if fewer than `retries`. Default [200, 500]. */
+  backoffMs?: readonly number[];
+  /** Injected for tests; default sleeps real time and resolves early on abort. */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /** Client/external signal — when aborted, stop retrying and rethrow. */
+  signal?: AbortSignal;
+  /** Override the retryability predicate (default isTransientConnectionError). */
+  shouldRetry?: (err: unknown) => boolean;
+}
+
+const DEFAULT_RETRIES = 2;
+const DEFAULT_BACKOFF_MS = [200, 500] as const;
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Run `fn`, retrying ONLY on transient connection errors (per `shouldRetry`) up to
+ * `retries` times with `backoffMs` spacing. Stops early — without consuming the next
+ * attempt — when `signal` aborts before or during a backoff. Non-transient errors and
+ * an exhausted budget rethrow the original error unchanged.
+ */
+export async function withConnectionRetry<T>(
+  fn: () => Promise<T>,
+  opts: ConnectionRetryOptions = {},
+): Promise<T> {
+  const retries = opts.retries ?? DEFAULT_RETRIES;
+  const backoff = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const sleep = opts.sleep ?? defaultSleep;
+  const shouldRetry = opts.shouldRetry ?? isTransientConnectionError;
+
+  let attempt = 0;
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= retries || opts.signal?.aborted || !shouldRetry(err)) throw err;
+      const delay = backoff[Math.min(attempt, backoff.length - 1)] ?? 0;
+      await sleep(delay, opts.signal);
+      // A disconnect during the backoff means the client is gone — don't burn
+      // another upstream attempt; surface the original failure.
+      if (opts.signal?.aborted) throw err;
+      attempt += 1;
+    }
+  }
+}

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -248,6 +248,13 @@ export const RoutingSignalFeedbackConfigSchema = z
 export const RuntimeConfigSchema = z.object({
   max_request_bytes: z.number().int().positive().default(20_000_000),
   request_timeout_ms: z.number().int().positive().default(60_000),
+  // SSE keep-alive heartbeat (ms). While a STREAMING response idles between upstream
+  // chunks, emit an SSE comment (`:\n\n` — ignored by every compliant SSE parser) at
+  // this cadence so a front proxy / client idle-timeout does not sever a long but
+  // healthy stream (slow generation, tool pauses). 0 disables. Covers ONLY the
+  // inter-chunk gap: the first chunk is peeked before the response commits, so
+  // pre-first-chunk fallback is unaffected. Overridable via HELM_SSE_HEARTBEAT_MS.
+  sse_heartbeat_ms: z.number().int().nonnegative().default(15_000),
   rate_limit: RateLimitConfigSchema,
   // Store driver selection. Defaulted so an absent runtime.store stays on sqlite
   // (back-compat); overridable via HELM_STORE_DRIVER (see env-map).


### PR DESCRIPTION
## Why

A client hitting the gateway can see a raw `The socket connection was closed unexpectedly` when the TCP connection between it and helm is severed **without a clean HTTP error**. Helm's normal error paths never produce a bare socket close (pre-first-chunk → structured 502/504; mid-stream → `event: error` frame), so a bare cut means the connection was killed by a front proxy idle/read timeout, a process restart, or a keepalive connection-reuse race.

Root cause on the helm side: helm had only **cross-model execution fallback** — never a **retry of the same upstream**. A single-candidate chain 502'd on a transient blip, and a long-but-idle stream could be cut by a proxy idle-timeout.

## What

Two server-side, idempotent additions (both safe because they act **before any byte reaches the client**):

### 1. Transient-connection retry — `packages/core/src/provider/retry.ts`
- `isTransientConnectionError`: strict allowlist (`ECONNRESET / ECONNREFUSED / EPIPE / ETIMEDOUT / UND_ERR_SOCKET` + cross-runtime message substrings incl. the Bun text), walks `err.cause`, `AbortError` short-circuits to false.
- `withConnectionRetry`: retries at each provider's `request()` **fetch boundary**, default `2 × [200,500]ms`, abort-aware. Nested inside the existing 401-retry; **timeouts are not retried** (left to cross-model fallback). **Works for single-candidate chains too.**
- Wired into the `openai` / `anthropic` / `openai-responses` clients (optional `connectRetries` / `connectRetryBackoffMs` config seam).

### 2. SSE inter-chunk heartbeat — `apps/gateway/src/routes/heartbeat.ts`
- `withHeartbeat` re-races the **same** pending `next()` against a timer (never drops/dups a chunk), emitting a `:\n\n` comment during idle gaps — **gated on an event boundary** so it can never split a partial SSE frame (principle 8).
- Wire-only: the heartbeat is **never captured, accumulated, or priced**.
- Wired into all **four** streaming surfaces: chat / messages / responses / gemini.
- Config `runtime.sse_heartbeat_ms` (default `15000`) / `HELM_SSE_HEARTBEAT_MS`; `0` disables. **Inter-chunk only** — the first-chunk peek stays before the response commits, so pre-first-chunk fallback semantics are unchanged.

## Out of scope (deliberate, low-risk)
- **Slow-first-token** (first token > proxy read-timeout, e.g. reasoning models) is *not* covered in helm — keeping the `peek-before-commit` ordering preserves clean fallback. If it recurs, tune the front-proxy read timeout, or revisit early-commit streaming (which would turn streaming errors into in-band `event: error` frames instead of clean 502/504).
- Non-stream body-read / first-chunk-read resets still rely on cross-model fallback.

## Tests / verification
- TDD: `retry.test.ts` (25), `heartbeat.test.ts` (7, incl. boundary / disabled / error / early-return), provider-client wiring tests, and a chat-route **end-to-end** heartbeat integration test (asserts data frames byte-intact + heartbeat is not a data event).
- `pnpm typecheck`, `pnpm lint`, `pnpm build` green. Full `pnpm test` green apart from the known PGlite parallel-load timeouts (confirmed passing in isolation/serial; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)