### PR TITLE
feat(admin): responsive mobile/tablet pass across all admin pages

### DIFF
--- a/apps/admin/src/app.css
+++ b/apps/admin/src/app.css
@@ -103,26 +103,26 @@
 
   /* — Buttons — */
   .btn-primary {
-    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded bg-slate-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50;
+    @apply inline-flex min-h-11 cursor-pointer items-center justify-center gap-1.5 rounded bg-slate-800 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50 md:min-h-0;
   }
   .btn-primary-sm {
     @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50;
   }
   .btn-secondary {
-    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50;
+    @apply inline-flex min-h-11 cursor-pointer items-center justify-center gap-1.5 rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:cursor-not-allowed disabled:opacity-50 md:min-h-0;
   }
   .btn-success {
-    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 disabled:opacity-50;
+    @apply inline-flex min-h-11 cursor-pointer items-center justify-center gap-1.5 rounded bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 disabled:opacity-50 md:min-h-0;
   }
   .btn-danger {
-    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded bg-red-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:opacity-50;
+    @apply inline-flex min-h-11 cursor-pointer items-center justify-center gap-1.5 rounded bg-red-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 disabled:opacity-50 md:min-h-0;
   }
   .btn-danger-outline {
-    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded border border-red-300 px-3 py-1.5 text-sm text-red-700 transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 disabled:cursor-not-allowed disabled:opacity-50;
+    @apply inline-flex min-h-11 cursor-pointer items-center justify-center gap-1.5 rounded border border-red-300 px-3 py-1.5 text-sm text-red-700 transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 disabled:cursor-not-allowed disabled:opacity-50 md:min-h-0;
   }
   /* Compact icon control (reorder/remove rows). Real hit area + disabled state. */
   .btn-icon {
-    @apply inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-slate-500;
+    @apply inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-slate-500 md:h-7 md:w-7;
   }
 
   /* — Form controls — */
@@ -242,6 +242,39 @@
   }
   .table-row {
     @apply border-t border-slate-100 hover:bg-slate-50;
+  }
+
+  /* — Responsive "cards table" (Providers / API Keys) — these wide management
+     tables would otherwise hide columns (and their row actions) off a horizontal
+     scroll on phones. BELOW lg each row reflows into a bordered CARD and each cell
+     into a stacked "label / value" line (the label is injected from the cell's
+     data-label); AT lg+ it is an ordinary table. Crucially there is still ONE <tr>
+     per record (no duplicated markup), so unit tests and screen readers see a
+     single row. Pair with `data-label="…"` on every <td>, drop `.table-row` from
+     the <tr>, and wrap the <table> in a `.cards-table-frame`. */
+  .cards-table {
+    @apply w-full text-left text-sm;
+  }
+  .cards-table thead {
+    @apply hidden lg:table-header-group;
+  }
+  .cards-table tbody {
+    @apply block lg:table-row-group;
+  }
+  .cards-table tr {
+    @apply mb-3 block rounded-lg border border-slate-200 bg-white last:mb-0 lg:mb-0 lg:table-row lg:rounded-none lg:border-0 lg:border-t lg:border-slate-100 lg:bg-transparent lg:last:mb-0 lg:hover:bg-slate-50;
+  }
+  .cards-table td {
+    @apply block px-3 py-1.5 lg:table-cell lg:whitespace-nowrap lg:py-2;
+  }
+  .cards-table td::before {
+    content: attr(data-label);
+    @apply mb-0.5 block text-xs font-medium uppercase tracking-wide text-ink-muted lg:hidden;
+  }
+  /* The cards carry their own border on mobile, so the table only needs a frame
+     (scroll + outline) once it becomes a real table at lg+. */
+  .cards-table-frame {
+    @apply lg:overflow-x-auto lg:rounded-lg lg:border lg:border-slate-200;
   }
 
   /* — Tabs — */

--- a/apps/admin/src/lib/components/FullscreenToggle.svelte
+++ b/apps/admin/src/lib/components/FullscreenToggle.svelte
@@ -22,7 +22,7 @@
   aria-label={label}
   title={label}
   aria-pressed={active}
-  class="rounded border border-border bg-surface px-2 py-1 text-ink-muted hover:bg-canvas"
+  class="inline-flex h-9 w-9 items-center justify-center rounded border border-border bg-surface text-ink-muted hover:bg-canvas md:h-7 md:w-7"
   onclick={() => (active = !active)}
 >
   {#if active}

--- a/apps/admin/src/lib/components/JsonTree.svelte
+++ b/apps/admin/src/lib/components/JsonTree.svelte
@@ -90,7 +90,7 @@
 {#if isBranch}
   <div class="json-node" data-testid="json-node">
     <details bind:open>
-      <summary class="cursor-pointer select-none">
+      <summary class="cursor-pointer select-none py-1 md:py-0">
         {#if name != null}<span class="text-link">{name}: </span>{/if}<span class="text-ink-muted"
           >{kind === 'array' ? `Array(${entries.length})` : `Object(${entries.length})`}</span
         >

--- a/apps/admin/src/lib/components/RangeFilter.svelte
+++ b/apps/admin/src/lib/components/RangeFilter.svelte
@@ -32,7 +32,7 @@
     <button
       type="button"
       data-testid="range-{opt.key}"
-      class={value === opt.key ? 'btn-primary-sm' : 'btn-secondary'}
+      class="{value === opt.key ? 'btn-primary-sm' : 'btn-secondary'} min-h-11 md:min-h-0"
       aria-pressed={value === opt.key}
       onclick={() => onChange(opt.key)}
     >

--- a/apps/admin/src/lib/components/RefreshControl.svelte
+++ b/apps/admin/src/lib/components/RefreshControl.svelte
@@ -165,7 +165,7 @@
   <button
     type="button"
     data-testid="refresh-toggle"
-    class="btn-secondary -ml-px rounded-l-none px-1.5"
+    class="btn-secondary -ml-px min-w-11 rounded-l-none px-1.5 md:min-w-0"
     aria-haspopup="menu"
     aria-expanded={open}
     aria-label={$t('Auto refresh')}

--- a/apps/admin/src/lib/components/StatusCluster.svelte
+++ b/apps/admin/src/lib/components/StatusCluster.svelte
@@ -73,11 +73,11 @@
   <!-- Live gateway health -->
   <span
     class="flex items-center gap-1.5 text-slate-500"
-    title={$t('Gateway status')}
+    title={$t(healthLabel)}
     data-testid="gateway-health"
   >
     <span class="h-2 w-2 shrink-0 rounded-full {dotClass}"></span>
-    <span class="hidden sm:inline">{$t(healthLabel)}</span>
+    <span class="sr-only sm:not-sr-only sm:inline">{$t(healthLabel)}</span>
   </span>
 
   {#if showVersion && version}

--- a/apps/admin/src/routes/+layout.svelte
+++ b/apps/admin/src/routes/+layout.svelte
@@ -158,7 +158,7 @@
       class="flex h-16 shrink-0 items-center gap-3 border-b border-slate-200 bg-white/80 px-4 backdrop-blur md:px-6"
     >
       <button
-        class="-ml-1 rounded-lg p-2 text-slate-500 hover:bg-slate-100 md:hidden"
+        class="-ml-1 flex h-11 w-11 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 md:hidden"
         aria-label={$t('Open navigation')}
         onclick={() => (navOpen = true)}
       >

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -174,7 +174,7 @@
   </div>
 
   <!-- Stat cards -->
-  <div class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
+  <div class="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">{$t('Requests')}</div>
       <div class="mt-1 text-2xl font-semibold text-slate-900">{formatCount(stats.total)}</div>
@@ -206,7 +206,7 @@
 
   <!-- Token stat cards: Total / Input / Output / Cached — the real SQL aggregate
        over the selected window (not a sampled client-side reduce). -->
-  <div class="mt-3 grid grid-cols-2 gap-3 md:mt-4 md:grid-cols-4 md:gap-4">
+  <div class="mt-3 grid grid-cols-2 gap-3 md:mt-4 lg:grid-cols-4 lg:gap-4">
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
         {$t('Total tokens')}
@@ -353,7 +353,7 @@
               >
                 <td class="px-3 py-2">
                   <a
-                    class="link-inline font-mono text-ink-strong"
+                    class="link-inline block max-w-[7rem] truncate font-mono text-ink-strong lg:max-w-none"
                     href={detailHref(r.trace_id)}
                     title={r.trace_id}>{r.trace_id}</a
                   >

--- a/apps/admin/src/routes/classifier/+page.svelte
+++ b/apps/admin/src/routes/classifier/+page.svelte
@@ -85,7 +85,7 @@
       </p>
     </div>
 
-    <label class="flex items-center gap-3">
+    <label class="flex min-h-11 items-center gap-3 py-1.5 md:min-h-0 md:py-0">
       <input type="checkbox" class="checkbox" name="eval_enabled" bind:checked={evalEnabled} />
       <span class="field-label">{$t('Enable Layer-2 eval')}</span>
       <span class="badge-eval">{$t('Layer-2')}</span>
@@ -191,7 +191,7 @@
         <code>classifier.yaml</code>.
       </p>
     </div>
-    <dl data-testid="eval-details" class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+    <dl data-testid="eval-details" class="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-1 text-sm">
       <dt class="text-ink-muted">{$t('Model')}</dt>
       <dd class="font-mono text-ink-strong">{cfg.eval.model}</dd>
       <dt class="text-ink-muted">{$t('Temperature')}</dt>

--- a/apps/admin/src/routes/keys/+page.svelte
+++ b/apps/admin/src/routes/keys/+page.svelte
@@ -147,7 +147,7 @@
 </script>
 
 <section class="flex w-full flex-col gap-4 px-4 py-6 md:px-8">
-  <header class="flex items-start justify-between gap-3">
+  <header class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
     <div class="min-w-0">
       <h1 class="page-title">{$t('API Keys')}</h1>
       <p class="section-desc">
@@ -189,8 +189,8 @@
       <p>{$t('No API keys yet. Create one to let a client authenticate against the gateway.')}</p>
     </div>
   {:else}
-    <div class="table-wrap">
-      <table class="table-base">
+    <div class="cards-table-frame">
+      <table class="cards-table">
         <thead class="table-head">
           <tr>
             <th class="px-3 py-2">{$t('Name')}</th>
@@ -206,18 +206,18 @@
         </thead>
         <tbody>
           {#each keys as key (key.key_id)}
-            <tr data-testid="key-row" class="table-row align-top">
-              <td class="px-3 py-2">
+            <tr data-testid="key-row" class="align-top">
+              <td data-label={$t('Name')} class="px-3 py-2">
                 {#if key.name}
                   <span class="text-ink-strong">{key.name}</span>
                 {:else}
                   <span class="text-ink-muted">{$t('Unnamed')}</span>
                 {/if}
               </td>
-              <td class="px-3 py-2">
+              <td data-label={$t('Key (prefix)')} class="px-3 py-2">
                 <code class="font-mono text-ink-strong">{key.prefix}</code>
               </td>
-              <td class="px-3 py-2">
+              <td data-label={$t('Role')} class="px-3 py-2">
                 <span class="text-ink-body">{key.role}</span>
                 {#if key.role === 'root'}
                   <p
@@ -228,11 +228,11 @@
                   </p>
                 {/if}
               </td>
-              <td class="px-3 py-2 text-ink-muted">
+              <td data-label={$t('Caps')} class="px-3 py-2 text-ink-muted">
                 <div>{$t('Allowed lanes')}: {key.allowed_lanes?.join(', ') || $t('No cap')}</div>
                 <div>{$t('Custom model')}: {key.allow_custom_model ? $t('yes') : $t('no')}</div>
               </td>
-              <td class="px-3 py-2 text-ink-muted">
+              <td data-label={$t('Rate limit')} class="px-3 py-2 text-ink-muted">
                 <div>{$t('RPM')}: {limitLabel(key.rate_limit_rpm)}</div>
                 <div>{$t('TPM')}: {limitLabel(key.rate_limit_tpm)}</div>
                 <!-- Concurrency null = unlimited (NOT inherit), unlike the rate limits above. -->
@@ -240,7 +240,7 @@
                   {$t('Concurrency')}: {key.concurrency_limit ?? $t('Unlimited')}
                 </div>
               </td>
-              <td class="px-3 py-2 text-ink-muted">
+              <td data-label={$t('Budget')} class="px-3 py-2 text-ink-muted">
                 {#if budgetParts(key).length > 0}
                   <div>{budgetParts(key).join(' · ')}</div>
                   <div class="text-xs">
@@ -252,7 +252,7 @@
                   <span>{$t('None')}</span>
                 {/if}
               </td>
-              <td class="px-3 py-2 text-ink-muted">
+              <td data-label={$t('Memory')} class="px-3 py-2 text-ink-muted">
                 {#if key.memory_mode === 'off'}
                   <span>{$t('Off')}</span>
                 {:else}
@@ -267,14 +267,14 @@
                   {/if}
                 {/if}
               </td>
-              <td class="px-3 py-2">
+              <td data-label={$t('Status')} class="px-3 py-2">
                 {#if key.disabled}
                   <span class="badge-neutral">{$t('disabled')}</span>
                 {:else}
                   <span class="badge-ok">{$t('active')}</span>
                 {/if}
               </td>
-              <td class="px-3 py-2 text-right">
+              <td data-label={$t('Actions')} class="px-3 py-2 lg:text-right">
                 {#if !key.disabled}
                   <div class="flex justify-end gap-2">
                     <button type="button" class="btn-secondary" onclick={() => startEdit(key)}

--- a/apps/admin/src/routes/policies/+page.svelte
+++ b/apps/admin/src/routes/policies/+page.svelte
@@ -116,7 +116,9 @@
     {/each}
   </div>
 
-  <div class="flex items-center justify-between gap-3">
+  <div
+    class="sticky bottom-0 -mx-4 flex items-center justify-between gap-3 border-t border-border bg-canvas/95 px-4 py-3 backdrop-blur sm:static sm:m-0 sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none"
+  >
     <button type="button" class="btn-secondary" onclick={addRow}>{$t('Add policy')}</button>
     <div class="flex items-center gap-3">
       {#if saved}

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -305,8 +305,8 @@
       </p>
     </div>
   {:else}
-    <div class="table-wrap">
-      <table class="table-base">
+    <div class="cards-table-frame">
+      <table class="cards-table">
         <thead class="table-head">
           <tr>
             <th class="px-3 py-2">{$t('Provider')}</th>
@@ -327,16 +327,16 @@
             {@const usage = usageByKey.get(k)}
             {@const quota = quotaByKey.get(k)}
             {@const saving = savingSchedule[k] === true}
-            <tr class="table-row align-top" data-testid="provider-account-row">
+            <tr class="align-top" data-testid="provider-account-row">
               <!-- Provider / account + type badge -->
-              <td class="px-3 py-3">
+              <td data-label={$t('Provider')} class="px-3 py-3">
                 <div class="font-medium text-ink-body">{row.provider.name}</div>
                 <code class="font-mono text-xs text-ink-strong">{row.account.account}</code>
                 <div class="mt-1"><span class="badge-neutral">{typeBadge(row.provider)}</span></div>
               </td>
 
               <!-- Status (+ parked pill) -->
-              <td class="px-3 py-3">
+              <td data-label={$t('Status')} class="px-3 py-3">
                 {#if row.account.healthy}
                   <span class="badge-ok">{$t('connected')}</span>
                 {:else}
@@ -348,7 +348,7 @@
               </td>
 
               <!-- Egress proxy (redacted; "Direct" when none) -->
-              <td class="px-3 py-3 text-xs">
+              <td data-label={$t('Proxy')} class="px-3 py-3 text-xs">
                 {#if proxyLabel(row.account.proxy)}
                   <span class="badge-neutral font-mono" title={proxyTitle(row.account.proxy)}
                     >{proxyLabel(row.account.proxy)}</span
@@ -359,7 +359,7 @@
               </td>
 
               <!-- Effective routable models (network-free; pills capped +N) -->
-              <td class="px-3 py-3">
+              <td data-label={$t('Models')} class="px-3 py-3">
                 {#if row.account.models.length > 0}
                   {@const shown = row.account.models.slice(0, MODELS_SHOWN)}
                   {@const extra = row.account.models.length - shown.length}
@@ -377,7 +377,7 @@
               </td>
 
               <!-- Today's usage -->
-              <td class="px-3 py-3 text-xs">
+              <td data-label={$t('Today')} class="px-3 py-3 text-xs">
                 {#if usage && usage.requests > 0}
                   <div class="text-ink-body">
                     {$t('{n} req', { n: formatCount(usage.requests) })}
@@ -391,7 +391,7 @@
               </td>
 
               <!-- Quota / session windows -->
-              <td class="px-3 py-3">
+              <td data-label={$t('Quota')} class="px-3 py-3">
                 {#if quota && quota.windows.length > 0}
                   <div class="flex w-40 flex-col gap-1.5">
                     {#each quota.windows as w (w.key)}
@@ -418,12 +418,12 @@
               </td>
 
               <!-- Priority (inline, lower = served first) -->
-              <td class="px-3 py-3">
+              <td data-label={$t('Priority')} class="px-3 py-3">
                 <input
                   type="number"
                   min="0"
                   step="1"
-                  class="w-16 rounded border border-slate-300 px-2 py-1 text-sm disabled:opacity-50"
+                  class="min-h-11 w-16 rounded border border-slate-300 px-2 py-1 text-sm disabled:opacity-50 md:min-h-0"
                   value={row.account.priority}
                   disabled={saving}
                   aria-label={$t('Priority')}
@@ -433,10 +433,10 @@
               </td>
 
               <!-- Schedulable (inline toggle) -->
-              <td class="px-3 py-3">
+              <td data-label={$t('Schedulable')} class="px-3 py-3">
                 <input
                   type="checkbox"
-                  class="h-4 w-4 disabled:opacity-50"
+                  class="h-5 w-5 disabled:opacity-50 md:h-4 md:w-4"
                   checked={row.account.schedulable}
                   disabled={saving}
                   aria-label={$t('Schedulable')}
@@ -450,11 +450,11 @@
               </td>
 
               <!-- Token expiry -->
-              <td class="px-3 py-3 text-ink-muted">{expiryLabel(row.account)}</td>
+              <td data-label={$t('Expires')} class="px-3 py-3 text-ink-muted">{expiryLabel(row.account)}</td>
 
               <!-- Actions -->
-              <td class="px-3 py-3 text-right">
-                <div class="inline-flex gap-2">
+              <td data-label={$t('Actions')} class="px-3 py-3 lg:text-right">
+                <div class="flex flex-wrap gap-2 lg:inline-flex lg:flex-nowrap">
                   <button
                     type="button"
                     class="btn-secondary"

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -235,7 +235,7 @@
     </div>
   </form>
 
-  <div class="card flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
+  <div class="card flex flex-col gap-2 lg:flex-row lg:items-center lg:gap-6">
     <span class="text-xs font-medium uppercase tracking-wide text-ink-muted"
       >{$t('Decided by')}</span
     >
@@ -334,7 +334,7 @@
             >
               <td class="px-3 py-2">
                 <a
-                  class="link-inline font-mono text-ink-strong"
+                  class="link-inline block max-w-[7rem] truncate font-mono text-ink-strong lg:max-w-none"
                   href={detailHref(r.trace_id)}
                   title={r.trace_id}>{r.trace_id}</a
                 >

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -70,8 +70,9 @@
           {formatTimestamp(d.ts) || $t('time not recorded')}
         </p>
       </div>
-      <div class="flex items-center gap-2">
-        <code class="rounded bg-slate-100 px-2 py-1 font-mono text-xs text-slate-700"
+      <div class="flex flex-wrap items-center gap-2">
+        <code
+          class="basis-full rounded bg-slate-100 px-2 py-1 font-mono text-xs text-slate-700 md:basis-auto"
           >{d.trace_id}</code
         >
         <button type="button" data-testid="copy-trace" class="btn-secondary" onclick={copyTrace}

--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -102,7 +102,7 @@
           min="1"
           max="3650"
           data-testid="retention-days"
-          class="input-sm w-32"
+          class="input-sm w-32 min-h-11 md:min-h-0"
           bind:value={form.payload_retention_days}
         />
         <span class="field-help">{$t('Older bodies are deleted automatically.')}</span>
@@ -136,7 +136,7 @@
             min="0"
             step="1"
             data-testid="rate-limit-default-rpm"
-            class="input-sm w-32"
+            class="input-sm w-32 min-h-11 md:min-h-0"
             bind:value={form.rate_limit_default_rpm}
           />
         </label>
@@ -147,7 +147,7 @@
             min="0"
             step="1"
             data-testid="rate-limit-default-tpm"
-            class="input-sm w-32"
+            class="input-sm w-32 min-h-11 md:min-h-0"
             bind:value={form.rate_limit_default_tpm}
           />
         </label>
@@ -160,7 +160,7 @@
 
       <label class="flex flex-col gap-1">
         <span class="font-medium">{$t('Log level')}</span>
-        <select data-testid="log-level" class="select w-40" bind:value={form.log_level}>
+        <select data-testid="log-level" class="select w-40 min-h-11 md:min-h-0" bind:value={form.log_level}>
           {#each LOG_LEVEL_OPTIONS as level (level)}
             <option value={level}>{level}</option>
           {/each}
@@ -190,7 +190,7 @@
         </span>
       </label>
 
-      <div class="flex flex-col gap-3 border-l-2 border-slate-100 pl-3 sm:flex-row sm:gap-6">
+      <div class="flex flex-col gap-3 border-l-2 border-slate-100 pl-3 lg:flex-row lg:gap-6">
         <label class="flex flex-col gap-1">
           <span class="font-medium">{$t('Minimum queue size')}</span>
           <input
@@ -199,7 +199,7 @@
             max="100"
             step="1"
             data-testid="concurrency-queue-min-size"
-            class="input-sm w-32"
+            class="input-sm w-32 min-h-11 md:min-h-0"
             bind:value={form.concurrency_queue_min_size}
           />
           <span class="field-help">{$t('Fixed lower bound on how many requests may wait.')}</span>
@@ -211,7 +211,7 @@
             min="0"
             step="0.5"
             data-testid="concurrency-queue-multiplier"
-            class="input-sm w-32"
+            class="input-sm w-32 min-h-11 md:min-h-0"
             bind:value={form.concurrency_queue_size_multiplier}
           />
           <span class="field-help"
@@ -228,7 +228,7 @@
             max="300000"
             step="1000"
             data-testid="concurrency-queue-timeout"
-            class="input-sm w-32"
+            class="input-sm w-32 min-h-11 md:min-h-0"
             bind:value={form.concurrency_queue_wait_timeout_ms}
           />
           <span class="field-help">{$t('Waiting longer than this returns 429.')}</span>
@@ -252,7 +252,7 @@
         </span>
       </label>
 
-      <div class="flex flex-col gap-3 border-l-2 border-slate-100 pl-3 sm:flex-row sm:gap-6">
+      <div class="flex flex-col gap-3 border-l-2 border-slate-100 pl-3 lg:flex-row lg:gap-6">
         <label class="flex flex-col gap-1">
           <span class="font-medium">{$t('Gap between requests (ms)')}</span>
           <input
@@ -261,7 +261,7 @@
             max="10000"
             step="50"
             data-testid="user-message-queue-delay"
-            class="input-sm w-32"
+            class="input-sm w-32 min-h-11 md:min-h-0"
             bind:value={form.user_message_queue_delay_ms}
           />
           <span class="field-help"
@@ -276,7 +276,7 @@
             max="300000"
             step="500"
             data-testid="user-message-queue-timeout"
-            class="input-sm w-32"
+            class="input-sm w-32 min-h-11 md:min-h-0"
             bind:value={form.user_message_queue_wait_timeout_ms}
           />
           <span class="field-help">{$t('Waiting longer than this returns 503.')}</span>

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-14 · Admin 管理界面移动端/响应式走查 + 修复（docs/10/11；原则 1）
+
+- **背景**：用户要求对 admin 全部 9 个页面做移动端/PC 走查（Playwright 截图三视口：iPhone 12 Pro 390×844 / iPad mini 768×1024 / 桌面 1920×1080），找出不合理处并修，移动端必须方便触控。流程：先把本地 main 重新构建部署到 Docker（localhost:8080）→ 截 29 张图（含移动 nav drawer、New key 弹层）→ Workflow 扇出 10 个 reviewer（每页读截图+源码）→ 对抗式验证 → 综合，25 处真实问题归并为 12 条（1 blocker / 3 major / 6 minor / 2 polish）。控制台零报错。
+- **核心修复（全在 `apps/admin`，CSS/Tailwind 为主）**：① **宽表→卡片**（Providers 10 列=blocker、API Keys 9 列）：新增 `.cards-table` / `.cards-table-frame` 配方——`<lg` 每行 reflow 成带框卡片、每格变「label/value」(label 由 `data-label` 经 CSS `::before` 注入)，`lg+` 仍是普通表（含横向滚动框）。② Requests/Dashboard 表首列 UUID 加 `block max-w-[7rem] truncate lg:max-w-none`（移动端不再霸屏，整行仍可点进详情）。③ 触控目标：`btn-icon` `h-7→h-10 md:h-7`，`btn-primary/secondary/success/danger/danger-outline` 配方加 `min-h-11 md:min-h-0`，hamburger 44px，RangeFilter/RefreshControl/settings 输入与 select 同补。④ 768px 挤压：dashboard 统计网格、requests 图例、settings 多字段队列行从 `md/sm` 推迟到 `lg`（rate-limit 行留 `sm`）。⑤ a11y：健康点文字 `sr-only sm:not-sr-only`、wrapper title 改 live healthLabel。⑥ 其它：classifier eval-details `grid-cols-2→[max-content_1fr]` + Layer-2 toggle 行 44px、policies 保存条移动端 `sticky bottom-0`、request-detail trace chip `basis-full md:basis-auto`、JsonTree summary / FullscreenToggle 触控。
+- **关键决定（CSS reflow 而非双 DOM 卡片）**：用户选「Providers+Keys 都用卡片」。但 `hidden lg:block`+`lg:hidden` 会让表与卡片**同时**留在 DOM（jsdom 不跑 CSS、testing-library 不看 display），`keys.test.ts`(20) / `providers.test.ts` 大量 `getByTestId('key-row')` 单行断言 + 全局 `getByText(prefix)` 会因重复而全红。故改为**单 `<tr>` 卡片化 reflow**（CSS 改 display + `::before` 注 label，`data-label` 上 `<td>`，`<tr>` 去掉 `.table-row`，外层换 `.cards-table-frame`）：每记录 DOM 仍只一行 → 单元测试 + 屏幕阅读器零改即过，移动端同时呈现真卡片、无横向滚动、操作全可触达。
+- **验证**：admin `pnpm build` 绿、vitest **364 全绿**（含 keys/providers reflow 后）、Biome lint 绿、svelte-check 仅剩既有 `oauth.test.ts` 3 报错（非回归，与 origin/main 逐字相同、admin 不在 `-r typecheck` 门禁）。Docker 从 worktree 源构建 `:latest` 重新部署后用 Playwright 三视口复测对比。分支 `worktree-admin-mobile-ui`（git worktree，已 rebase 到 main）。截图存 `ui-review/{iphone12pro,ipadmini,desktop}/`，PR #255。
+
 ## 2026-06-14 · 协议互译剩余项 PR review 修复（review of fix/protocol-litellm-remaining；原则 2/3/7）
 
 - **背景**：对 #251（LiteLLM 协议互译剩余项）做 review，发现 Gemini native passthrough 引入了治理漏洞，并加固远程媒体抓取。三处真实问题修复 + 两处误报澄清。
@@ -25,18 +32,13 @@
 - **取舍/TODO**：Codex web 流同有 localhost 死链，但 OpenAI 无等价托管码页，本轮**不动 Codex**（已知 follow-up）。redirect_uri 必须是 client_id `9d1c250a-…` 注册的回调——relay 用同一 client_id/scopes/`code=true` 配同值、helm token 端点本就 `platform.claude.com`，高置信被接受；最终需真订阅 admin 手验。
 - **验证**：TDD 红→绿——`web-login.test.ts` 钉死 begin/complete 的 console redirect_uri + `code#state` 粘贴，`anthropic.test.ts` 钉死 CLI 仍用 localhost。core OAuth + gateway OAuth 全绿（202）、typecheck/lint 绿、svelte-check 仅剩既有 `oauth.test.ts` 3 报错（非回归）。分支 `worktree-claude-oauth-copy-code`（git worktree）。
 
-## 2026-06-14 · 评估并否决引入 `@earendil-works/pi-ai` 替换 OAuth 实现（原则 1/6；docs/02/06/11）
-
-- **背景**：用户想直接引入 pi-coding-agent 同源的 `@earendil-works/pi-ai`（npm，v0.79.3）当 SDK，外包「登录各家 AI（OAuth）」的协议代码，并「支持它支持的所有 OAuth provider」。
-- **调研结论（决策依据）**：① pi-ai 内置 OAuth provider 正好 3 个（`anthropic`/`openai-codex`/`github-copilot`，见 `packages/ai/src/utils/oauth/index.ts` 的 `BUILT_IN_OAUTH_PROVIDERS`）——与 helm 现支持的**完全一致**，无 Gemini/Qwen；pi 文档里「很多 Supported Providers」绝大多数是 **API-key** 类（Gemini/DeepSeek/Mistral/Groq/xAI/OpenRouter/Bedrock…），不是 OAuth。② helm 两层都已覆盖：API-key 改 `config/providers.yaml` 加 `api_key_env` 即可（零代码，已接 DeepSeek/ZenMux/OpenRouter）；OAuth 三家已实现（加密 token 存储/多账号池/代理/调度/admin UI 登录）。③ 形态失配：pi-ai 公开 API 只有「阻塞式 `login*()`（内部强制绑本地回调端口 53692/1455，Anthropic 端口占用即 `reject`）+ `refresh*Token()`」，**不导出** `exchangeAuthorizationCode`/`generatePKCE`；helm 专门写了 `web-login.ts` 做无状态 begin/complete，正因 CLI 流程不适合 web 管理界面。④ 二者**同源**（都出自 openclaw 血统，authorize URL/client_id/token URL/PKCE 近乎一字不差），引入不是「换更好代码」而是「换更不顺手形态 + 加一层桥接 + 运行时绑端口」。
-- **决定（用户拍板「那就不动了」）**：**不引入依赖、保持现状**，无代码改动、无 worktree。唯一真实收益（端点/client_id/未来新 provider 维护外包给上游）不足以抵消「写 ~500–900 行桥接 + 删 ~1.5k 行有测试覆盖的同源协议代码」的净风险（净风险为负）。
-- **TODO / 重评触发条件**：若 pi-ai 日后新增**真正的 OAuth**（非 API-key）provider（如 Gemini/Qwen 订阅登录），再评估「仅接管 `refresh*Token`」这一最小边界（不碰 helm 的 web 登录编排）。现有 helm OAuth 协议代码全部保留：`packages/core/src/provider/oauth/*`（web-login/anthropic/openai-codex/github-copilot/runtime）+ 存储/池/admin/UI。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-14 · 评估并否决引入 `@earendil-works/pi-ai` 替换 OAuth 实现（原则 1/6）：pi-ai（v0.79.3）内置 OAuth provider 与 helm 完全一致（anthropic/codex/copilot），其文档「众多 Supported」多为 API-key 类（非 OAuth）；其公开 API 只 `login*()`（强绑本地端口 53692/1455）+`refresh*Token`、不导出 `exchangeAuthorizationCode`/PKCE，与 helm web begin/complete 形态失配；二者同源（openclaw 血统）。用户拍板**不引入、保持现状**，无代码改动。重评触发：pi-ai 新增真 OAuth（Gemini/Qwen 订阅）时仅评估接管 `refresh*Token`，不碰 web 登录编排。
 
 ### 2026-06-14 · LiteLLM 协议互译剩余项完成（docs/protocol-translation-litellm-gap-spec；原则 1/7/8）：Anthropic/Gemini token helper 改 provider-first + 估算兜底；Responses `previous_response_id` 不再入站拒绝（同协议直通、跨协议 fail-closed）；Responses input_tokens / registry-bound retrieve/delete/cancel/input_items / compact 接线；Gemini native provider（generate/stream/countTokens、parametersJsonSchema/responseJsonSchema/google_genai 保真）；OpenAI Chat response_model_policy；Gemini remote media materializer（默认关）。后续 review 两轮修治理/SSRF/翻译路径（见顶部完整条目）。
 


### PR DESCRIPTION
## What

A full responsive/mobile walkthrough of the admin UI and fixes for every issue found. Each of the 9 pages was screenshotted at **iPhone 12 Pro (390×844)**, **iPad mini (768×1024)** and **desktop (1920×1080)**, reviewed (per-page, with adversarial verification), and the **12 prioritized findings** were fixed and re-verified.

## Findings fixed

| Sev | Area | Fix |
|---|---|---|
| 🔴 Blocker | **Providers** | 10-col table hid all actions/Priority/Schedulable off a horizontal scroll on phones & at 768px → reflows into a labeled card below `lg`. |
| 🟠 Major | **API Keys** | Status + Edit/Revoke/Delete hidden off-screen → card layout below `lg`; header stacks so the description no longer squeezes to a sliver. |
| 🟠 Major | **Requests / Dashboard** | Full UUID lead column ate ~65% of width → `truncate max-w-[7rem] lg:max-w-none`; row still links to detail. |
| 🟠 Major | Lanes/Policies/dialogs | `btn-icon` 28→40px on mobile (`h-10 w-10 md:h-7 md:w-7`). |
| 🟡 Minor | Dashboard/Requests/Settings | 768px squeeze: defer stat grid, decided-by legend, queue rows `md/sm`→`lg`. |
| 🟡 Minor | Classifier | eval-details `grid-cols-2`→`[max-content_1fr]`; Layer-2 toggle row ≥44px. |
| 🟡 Minor | App shell | Hamburger 44px; gateway-health label `sr-only sm:not-sr-only` + live `title`. |
| 🟡 Minor | API Keys / Policies | Header stacks on mobile; Policies save bar `sticky bottom-0` below `sm`. |
| ⚪ Polish | Request detail / shared | trace chip wraps; JSON-tree & fullscreen-toggle hit areas; sweep of sub-44px shared recipes (`min-h-11 md:min-h-0` on buttons, range pills, refresh, settings inputs). |

## Key decision — CSS reflow, not duplicated DOM

The natural "card layout" approach (`hidden lg:block` table + `lg:hidden` cards) would render **both** subtrees in the DOM — and since jsdom ignores CSS, `keys.test.ts`/`providers.test.ts` (which assert a single `getByTestId('key-row')` and global `getByText(prefix)`) would break. Instead a new **`.cards-table` recipe** keeps **one `<tr>` per record** and reflows it via CSS (`display` switch + `::before` label from `data-label`) into cards below `lg`, reverting to a normal table at `lg+`. Real mobile cards, **desktop tables unchanged**, suite stays green.

## Validation

- `pnpm --filter @helm/admin build` ✅
- **364/364 admin unit tests** ✅ (keys/providers reflow kept green)
- Biome lint ✅
- `svelte-check` clean apart from the 3 **pre-existing** `oauth.test.ts` tuple errors (unrelated, identical to `main`)
- Rebuilt the Docker image from this branch and re-screenshotted all three viewports: Providers/Keys = cards on phone **and** iPad-768; desktop tables verified unchanged.

Scope: `apps/admin/**` only (15 files) + `implementation-notes.md`; no `core`/`gateway`/`shared` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
