### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.12.14",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.13.0** — minor bump. Ships three PRs merged since v0.12.14:

- **#251** Complete LiteLLM protocol parity backlog
- **#255** Responsive mobile/tablet pass across all admin pages
- **#254** Provider retry for transient upstream disconnects + SSE keep-alive heartbeat

### Why minor
New gateway surface: dedicated Gemini provider (`provider/gemini.ts`), upstream retry layer, SSE keep-alive heartbeat across 4 streaming surfaces (chat/messages/responses/gemini), plus a new optional knob `runtime.sse_heartbeat_ms` / `HELM_SSE_HEARTBEAT_MS` (default 15000, 0 = off) and additive config/decision/request schema.

### Deploy notes
- No `config/` or Docker/infra diff vs v0.12.14 → deploy stays **pull + up -d only**.
- New knob `HELM_SSE_HEARTBEAT_MS` is code-defaulted (15s < nginx 60s / CF ~100s) — no need to set it; tune in `.env` only if a fronting proxy demands a different cadence.

publish.yml will auto-cut tag `v0.13.0` + GitHub Release + GHCR `:0.13.0`/`:latest` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)