### PR TITLE
docs: audit docs against code, rewrite README, add architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Open-source · self-hosted · MIT
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.9.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/github/package-json/v/EasyMetaAu/helm-api)](package.json)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](tsconfig.base.json)
 [![Built with Hono](https://img.shields.io/badge/gateway-Hono-ff5e00.svg)](https://hono.dev)
@@ -63,16 +63,17 @@ docker compose logs helm | grep -i "root API key"
 | :---: | :--- | :--- |
 | 🔀 | **Four client protocols** | OpenAI Chat, Anthropic Messages, OpenAI Responses, Google Gemini — all streaming + non-streaming. One IR in the middle: any client reaches any backend with a consistent output shape, SSE included. |
 | 🧭 | **Three-layer classification** | Deterministic rules (pure, zero-network, unit-tested — always on) → optional small-model eval (`temperature: 0`, cached, off by default — needs a configured eval model) → `balanced` lane as the fail-open sink. |
-| 🛣️ | **Lanes + policies** | Requests route through lanes (`economy` / `balanced` / `premium`, plus task lanes `coding`, `json`, `vision`, `tool_use`), never raw provider names. First-match policies pin or cap the lane. Each lane = a primary model + a fallback chain, all in config. Opt-in Agentic Signals can promote degraded ranked lanes inside those caps. |
+| 🛣️ | **Lanes + policies** | Requests route through lanes (`economy` / `balanced` / `premium`, plus task lanes `coding`, `json`, `vision`, `tool_use`), never raw provider names. First-match policies pin or cap the lane. Each lane = a primary model + a fallback chain, all in config. Opt-in Agentic Signals can promote a degraded lane within those caps. |
+| 🪪 | **Drop-in for fixed-model clients** | A compatibility shim maps a pinned vendor model id (Claude Code's `claude-opus-4-8`, an SDK locked to `gpt-5.5`) onto a lane — so existing clients stop getting *400 unknown model* without giving up lane routing or failover. Operator-authored, works on any key. |
 | 🛡️ | **Resilient execution** | Circuit breaker (OPEN/HALF_OPEN + single probe), capability filter with explicit skip reasons, `:free`-tier 429 skipping, per-key concurrency queueing. Client disconnects are never counted as provider faults. |
 | 🔐 | **OAuth subscriptions** | Route your Claude Pro/Max, ChatGPT Codex, and GitHub Copilot subscriptions as backends — pooled accounts, per-account model curation / egress proxy / scheduling, all hot-reloaded. *(Opt-in; read the [ToS warning](#oauth-subscription-providers-claude-promax-chatgpt-codex-github-copilot).)* |
 | 🔑 | **Keys with teeth** | Mandatory auth; keys stored as SHA-256 hashes only. Per key: lane whitelist, custom-model permission, RPM/TPM limits, usage budgets (degrade or reject), concurrency cap, memory mode. Revoke softly, then delete permanently. |
-| 🧠 | **Memory middleware** | On by default: remembered context is injected before routing; a background worker compresses and consolidates — compaction is **auto-adaptive and zero-config** (prices and context windows resolve from the model catalog; size / idle / context-pressure triggers); a forgetting/tiering layer (decay, reinforcement, retention) keeps it honest. Opt out per key or per request (`x-memory-mode: off`). |
-| 📊 | **Total observability** | A redacted decision record per request — classifier, policy, lane, every provider attempt, latency, fallbacks, cost. Verbatim payload capture to a separate table (on by default, 30-day retention). An editable **Retry** button replays any captured request. |
+| 🧠 | **Memory middleware** | On by default: remembered context is injected before routing as a trailing turn; a background worker compresses and consolidates — compaction is **auto-adaptive and zero-config** (prices and context windows resolve from the model catalog; size / idle / context-pressure triggers). Summarize/merge default to deterministic local logic, with an **opt-in LLM path** (`config.memory.llm`, off by default). A forgetting/tiering layer (decay, reinforcement, retention) keeps it honest. Opt out per key or per request (`x-memory-mode: off`). |
+| 📊 | **Total observability** | A redacted decision record per request — classifier, policy, lane, every provider attempt, latency, fallbacks, cost. Verbatim payload capture to a separate table (on by default, 30-day retention). An editable **Retry** button replays any captured request in its own protocol. |
 | 🖥️ | **Admin dashboard** | SvelteKit SPA at `/admin` behind HTTP Basic: overview, key CRUD, lane/policy/classifier editors, system settings, drill-down request log. Edits **write back to `config/*.yaml`** (comment-preserving, atomic) and rebind live — no restart, and they survive one. Five languages. |
 | 💾 | **Storage** | SQLite by default (one local file). Postgres / Supabase behind the same Store-port abstraction — switch with one env var. |
 
-**Roadmap:** LLM-backed memory summarization (today's observer/reflector summarize step is a deterministic stub). Account/customer billing is intentionally out of scope. See [09 Roadmap](docs/09-roadmap.md).
+**Roadmap:** Account/customer billing is intentionally out of scope. See [09 Roadmap](docs/09-roadmap.md).
 
 ## Two failure disciplines
 
@@ -85,7 +86,7 @@ And two fallbacks that are never conflated: *classification fallback* (undecided
 
 ## Architecture
 
-Four client protocols enter one stable interface; one framework-agnostic core does the work; config drives every stage.
+Four client protocols enter one stable interface; one framework-agnostic core does the work; config drives every stage. (For the same pipeline as sequence, flow, and state diagrams, see **[Architecture & Data Flow](docs/architecture.md)**.)
 
 ```text
 CLIENT ── OpenAI · Anthropic · OpenAI Responses · Google Gemini
@@ -101,7 +102,8 @@ CORE      packages/core · the routing brain (imports no web framework)
              ├─ gate        rate limit (off) · usage budget (off)        · fail-closed
              ├─ memory      inject remembered context (on by default)    · fail-open
              ├─ classify    L1 rules ─uncertain→ L2 eval (off) ─→ balanced · fail-open
-             ├─ resolve     first-match policy → lane → caps → fallback chain
+             ├─ resolve     alias shim · explicit model · first-match policy
+             │                  └─▶ lane → caps (+ signals) → fallback chain
              ├─ execute     capability filter → circuit breaker → provider
              │                  └── on failure: advance to next model in the chain
              └─ translate   provider-native  ⇄  IR  ⇄  client protocol (streaming SSE)
@@ -126,8 +128,8 @@ helm-api/
 ├─ packages/
 │  ├─ core/      # routing, classification, providers, protocol translation, storage ports (no framework)
 │  └─ shared/    # Zod schemas + shared types (single source of truth)
-├─ config/       # default lanes / policies / classifier / providers / … YAML
-├─ docs/         # documentation (read 01 → 12)
+├─ config/       # default lanes / policies / classifier / providers / model-aliases / … YAML
+├─ docs/         # documentation (start at docs/README.md)
 └─ scripts/      # sync:catalog and other build-time tools
 ```
 
@@ -151,16 +153,18 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅ (via `:streamGenerateContent?alt=sse`; auth via `x-goog-api-key`) |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅ (via `:streamGenerateContent`; auth via `x-goog-api-key`) |
 
 **What to put in `model`:**
 
 | Value | What Helm does |
 |---|---|
 | `auto` *(recommended)* | Classifies the request and routes it to the best lane. |
-| a model alias, e.g. `deepseek/deepseek-v4-pro` | Uses exactly that model, skipping routing — only for keys with custom-model permission. |
+| a lane name, e.g. `premium` | Routes straight into that lane (subject to the key's lane whitelist). |
+| a pinned vendor id, e.g. `claude-opus-4-8` | The compatibility shim rewrites it onto a lane (see `config/model-aliases.yaml`) — works on any key. |
+| a concrete model alias, e.g. `deepseek/deepseek-v4-pro` | Uses exactly that model, skipping routing — only for keys with custom-model permission. |
 
-> With a standard key, routing is always automatic — just use `auto`. Lanes are operator config (`lanes.yaml` + dashboard); clients don't pick lanes per call.
+> With a standard key, just use `auto` (or a lane name) and routing is automatic. Lanes are operator config (`lanes.yaml` + dashboard); clients don't define lanes per call.
 
 **Other endpoints** (full interactive docs at `/docs`, raw spec at `/openapi.json`):
 
@@ -168,7 +172,7 @@ curl http://localhost:8080/v1/chat/completions \
 |---|---|---|
 | `GET /` · `GET /healthz` · `GET /version` | — | Landing page · readiness · build info |
 | `GET /v1/models` · `GET /v1/models/{id}` | API key | Models the key can route to (lanes + `auto`; concrete aliases with capabilities & pricing for custom-model keys) |
-| `/admin` · `/admin/api/*` | Basic auth | Dashboard + its JSON backend (mounted only when admin credentials are set) |
+| `/admin` · `/admin/api/*` | Basic auth | Dashboard + its JSON backend (mounted only when admin is enabled) |
 
 ## Configuration
 
@@ -180,10 +184,11 @@ Everything lives in `config/*.yaml`, Zod-validated on load. **Invalid config sto
 | `auth.yaml` | API key requirement + first-run root key | — |
 | `runtime.yaml` | Request limits, rate-limit defaults, storage driver, opt-in signal feedback | partial |
 | `providers.yaml` | Upstream providers + model aliases (credentials by env-var **name** only) | — |
-| `lanes.yaml` | Each lane's primary model + fallback chain | ✅ persists |
+| `lanes.yaml` | Each lane's primary model + fallback chain (quality, task, and vendor-family lanes) | ✅ persists |
 | `policies.yaml` | First-match rules that pick or cap the lane | ✅ persists |
 | `classifier.yaml` | Built-in rules + the optional eval model | ✅ persists |
-| `memory.yaml` | Forgetting/tiering knobs (on in the shipped config) + optional compaction trigger overrides (`compaction:` — size/idle/pressure thresholds; economics stay automatic). A leftover `observer:` block from older configs refuses startup | ✅ |
+| `model-aliases.yaml` | Maps a pinned vendor model id → lane / `auto` (compatibility shim, optional) | — |
+| `memory.yaml` | Forgetting/tiering knobs (on in the shipped config) · optional compaction trigger overrides (`compaction:`) · optional LLM summarizer (`llm:`, off by default). A leftover `observer:` block from older configs refuses startup | ✅ |
 | `capabilities.yaml` / `pricing.yaml` | Manual overrides on the model catalog (incl. prompt-cache read/write prices) | — |
 
 Most-used environment variables (env wins over YAML; full list in [`.env.example`](.env.example)):
@@ -229,8 +234,6 @@ pnpm dev          # admin dashboard dev server (Vite) — see note below
 pnpm test         # Vitest unit tests
 pnpm exec vitest run --coverage # unit coverage with source-only include/exclude + thresholds
 pnpm test:e2e     # Playwright end-to-end tests
-pnpm test:e2e:coverage       # protocol-focused gateway/server E2E coverage
-pnpm test:e2e:coverage:full  # full Playwright suite gateway/server E2E coverage
 pnpm typecheck    # tsc --noEmit across the workspace
 pnpm lint         # Biome
 pnpm build        # build the gateway + dashboard
@@ -247,7 +250,7 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 
 ## Documentation
 
-Start at [`docs/README.md`](docs/README.md) and read in order:
+Start at [`docs/README.md`](docs/README.md). For a visual tour of the pipeline, read **[Architecture & Data Flow](docs/architecture.md)**. The numbered specification, in order:
 
 [01 Overview](docs/01-overview.md) ·
 [02 Architecture](docs/02-architecture.md) ·
@@ -265,7 +268,7 @@ Start at [`docs/README.md`](docs/README.md) and read in order:
 
 ## Status
 
-Helm API is at **0.9.0** — a real, end-to-end implementation, not a scaffold. The full pipeline (config → auth → classify → route → execute with circuit-breaking and fallback → protocol translation → telemetry) is wired and covered by an extensive Vitest suite plus Playwright e2e specs.
+Helm API is a real, end-to-end implementation, not a scaffold. The full pipeline (config → auth → classify → route → execute with circuit-breaking and fallback → protocol translation → telemetry → memory) is wired and covered by an extensive Vitest suite plus Playwright e2e specs. The version badge above tracks the current release.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 开源 · 自托管 · MIT
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.9.0-blue.svg)](package.json)
+[![Version](https://img.shields.io/github/package-json/v/EasyMetaAu/helm-api)](package.json)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-3c873a.svg)](package.json)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)](tsconfig.base.json)
 [![Built with Hono](https://img.shields.io/badge/gateway-Hono-ff5e00.svg)](https://hono.dev)
@@ -63,16 +63,17 @@ docker compose logs helm | grep -i "root API key"
 | :---: | :--- | :--- |
 | 🔀 | **四种客户端协议** | OpenAI Chat、Anthropic Messages、OpenAI Responses、Google Gemini——全部支持流式 + 非流式。中间是同一套 IR：任意客户端触达任意后端，输出格式一致，SSE 也不例外。 |
 | 🧭 | **三层分类** | 确定性规则（纯函数、零网络、有单测——常驻开启）→ 可选的小模型 eval（`temperature: 0`、带缓存、默认关闭——需要先配好 eval 模型）→ `balanced` lane 作为 fail-open 兜底口。 |
-| 🛣️ | **Lane + 策略路由** | 请求走 lane（`economy` / `balanced` / `premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`），从不直接面对供应商名。首条命中的策略可以钉死或封顶 lane。每条 lane = 一个主模型 + 一条兜底链，全在配置里。可选的 Agentic Signals 能在这些上限内把异常的分级 lane 提升到更健康的强档 lane。 |
+| 🛣️ | **Lane + 策略路由** | 请求走 lane（`economy` / `balanced` / `premium`，外加任务 lane `coding`、`json`、`vision`、`tool_use`），从不直接面对供应商名。首条命中的策略可以钉死或封顶 lane。每条 lane = 一个主模型 + 一条兜底链，全在配置里。可选的 Agentic Signals 能在这些上限内，把异常的 lane 提升到更健康的强档 lane。 |
+| 🪪 | **固定模型的客户端也能即插即用** | 一个兼容垫片把客户端写死的厂商模型 id（Claude Code 的 `claude-opus-4-8`、锁定 `gpt-5.5` 的 SDK）映射到某条 lane——老客户端不改一行代码，就不再吃到 *400 unknown model*，还照样享受 lane 路由与失败兜底。由运维方配置，对任何 key 都生效。 |
 | 🛡️ | **稳健的执行层** | 熔断器（OPEN/HALF_OPEN + 单探针）、能力过滤（跳过候选时记下明确原因）、`:free` 档 429 跳过、按 key 并发排队。客户端断连永远不算供应商故障。 |
 | 🔐 | **OAuth 订阅** | 把 Claude Pro/Max、ChatGPT Codex、GitHub Copilot 的**订阅**当后端来路由——多账号组池，逐账号做模型策展 / 出口代理 / 调度，全部热重载。*（可选功能，先读 [ToS 警告](#oauth-订阅类供应商claude-promaxchatgpt-codexgithub-copilot)。）* |
 | 🔑 | **带约束力的 key** | 强制鉴权；key 只存 SHA-256 哈希。每把 key 可设：lane 白名单、自定义模型权限、RPM/TPM 限流、用量预算（降级或拒绝）、并发上限、记忆模式。先软吊销，再永久删除。 |
-| 🧠 | **Memory 中间件** | 默认开启：路由前把记忆注入上下文；后台 worker 负责压缩与归并——压缩**全自动、零配置**（价格与上下文窗口取自模型目录；按体量 / 空闲 / 上下文压力三种时机触发）；遗忘/分层机制（衰减、强化、保留期）防止记忆膨胀。可按 key 或按请求关闭（`x-memory-mode: off`）。 |
-| 📊 | **全程可观测** | 每个请求一条脱敏决策记录——分类、策略、lane、每次供应商尝试、延迟、兜底、成本。正文逐字捕获单独存表（默认开，保留 30 天）。可编辑的 **Retry** 按钮能重放任何已捕获的请求。 |
+| 🧠 | **Memory 中间件** | 默认开启：路由前把记忆作为一轮追加消息注入上下文；后台 worker 负责压缩与归并——压缩**全自动、零配置**（价格与上下文窗口取自模型目录；按体量 / 空闲 / 上下文压力三种时机触发）。摘要与归并默认走确定性的本地逻辑，另有**可选的 LLM 路径**（`config.memory.llm`，默认关闭）；遗忘/分层机制（衰减、强化、保留期）防止记忆膨胀。可按 key 或按请求关闭（`x-memory-mode: off`）。 |
+| 📊 | **全程可观测** | 每个请求一条脱敏决策记录——分类、策略、lane、每次供应商尝试、延迟、兜底、成本。正文逐字捕获单独存表（默认开，保留 30 天）。可编辑的 **Retry** 按钮能按原协议重放任何已捕获的请求。 |
 | 🖥️ | **管理面板** | `/admin` 上的 SvelteKit SPA，HTTP Basic 把守：概览、key 增删改、lane / 策略 / 分类器编辑器、系统设置、可下钻的请求日志。编辑会**写回 `config/*.yaml`**（保留注释、原子写入）并实时重绑——无需重启，重启也不丢。支持 5 种语言。 |
 | 💾 | **存储** | 默认 SQLite（一个本地文件）。Postgres / Supabase 走同一套 Store 端口抽象——改一个环境变量即可切换。 |
 
-**路线图：** 接 LLM 的记忆摘要（observer/reflector 的摘要步骤目前是确定性桩）。账户 / 客户级计费明确不在范围内。详见 [09 路线图](docs/09-roadmap.md)。
+**路线图：** 账户 / 客户级计费明确不在范围内。详见 [09 路线图](docs/09-roadmap.md)。
 
 ## 两套失败纪律
 
@@ -85,7 +86,7 @@ docker compose logs helm | grep -i "root API key"
 
 ## 架构
 
-四种客户端协议进入同一套稳定接口；一个不依赖框架的内核干所有活；配置驱动每一个阶段。
+四种客户端协议进入同一套稳定接口；一个不依赖框架的内核干所有活；配置驱动每一个阶段。（想看同一条流水线的时序图、流程图与状态图，见 **[架构与数据流](docs/architecture.md)**。）
 
 ```text
 CLIENT ── OpenAI · Anthropic · OpenAI Responses · Google Gemini
@@ -101,7 +102,8 @@ CORE      packages/core · 路由大脑（不 import 任何 Web 框架）
              ├─ gate        限流（默认关）· 用量预算（默认关）       · fail-closed
              ├─ memory      把记忆注入上下文（默认开）               · fail-open
              ├─ classify    L1 规则 ─不确定→ L2 eval（默认关）─→ balanced · fail-open
-             ├─ resolve     首条命中策略 → lane → 限额 → 兜底链
+             ├─ resolve     别名垫片 · 显式模型 · 首条命中策略
+             │                  └─▶ lane → 限额（+ 信号）→ 兜底链
              ├─ execute     能力过滤 → 熔断器 → provider
              │                  └── 失败时：切到链内下一个模型
              └─ translate   provider 原生  ⇄  IR  ⇄  客户端协议（流式 SSE）
@@ -126,8 +128,8 @@ helm-api/
 ├─ packages/
 │  ├─ core/      # 路由、分类、provider、协议互译、存储端口（不依赖框架）
 │  └─ shared/    # Zod schema + 共享类型（类型唯一来源）
-├─ config/       # 默认 lanes / policies / classifier / providers / … YAML
-├─ docs/         # 文档（按 01 → 12 顺序读）
+├─ config/       # 默认 lanes / policies / classifier / providers / model-aliases / … YAML
+├─ docs/         # 文档（从 docs/README.md 开始读）
 └─ scripts/      # sync:catalog 等构建期工具
 ```
 
@@ -151,16 +153,18 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅（走 `:streamGenerateContent?alt=sse`；用 `x-goog-api-key` 鉴权） |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅（走 `:streamGenerateContent`；用 `x-goog-api-key` 鉴权） |
 
 **`model` 字段填什么：**
 
 | 取值 | Helm 的行为 |
 |---|---|
 | `auto`（推荐） | 对请求做分类，路由到最合适的 lane。 |
-| 模型别名，如 `deepseek/deepseek-v4-pro` | 精确使用该模型、跳过路由——仅对有「自定义模型」权限的 key 生效。 |
+| lane 名，如 `premium` | 直接进入该 lane（受 key 的 lane 白名单约束）。 |
+| 写死的厂商 id，如 `claude-opus-4-8` | 兼容垫片把它改写到某条 lane（见 `config/model-aliases.yaml`）——对任何 key 都生效。 |
+| 具体模型别名，如 `deepseek/deepseek-v4-pro` | 精确使用该模型、跳过路由——仅对有「自定义模型」权限的 key 生效。 |
 
-> 用普通 key 时，路由永远是自动的——直接填 `auto`。Lane 由运维方配置（`lanes.yaml` + 面板），客户端不在单次调用里挑 lane。
+> 用普通 key 时，直接填 `auto`（或某个 lane 名）即可，路由全自动。Lane 由运维方配置（`lanes.yaml` + 面板），客户端不在单次调用里定义 lane。
 
 **其余端点**（交互式文档在 `/docs`，原始规格在 `/openapi.json`）：
 
@@ -168,7 +172,7 @@ curl http://localhost:8080/v1/chat/completions \
 |---|---|---|
 | `GET /` · `GET /healthz` · `GET /version` | — | 落地页 · 就绪探针 · 构建信息 |
 | `GET /v1/models` · `GET /v1/models/{id}` | API key | 列出该 key 能路由到的模型（lane + `auto`；自定义模型 key 还会看到带能力与定价的具体别名） |
-| `/admin` · `/admin/api/*` | Basic auth | 面板 + 其 JSON 后端（仅在设置了面板凭证时才挂载） |
+| `/admin` · `/admin/api/*` | Basic auth | 面板 + 其 JSON 后端（仅在启用面板时才挂载） |
 
 ## 配置
 
@@ -180,10 +184,11 @@ curl http://localhost:8080/v1/chat/completions \
 | `auth.yaml` | 是否强制 API key + 首次启动的 root key | — |
 | `runtime.yaml` | 请求限额、限流默认值、存储驱动、可选信号反馈 | 部分 |
 | `providers.yaml` | 上游供应商 + 模型别名（凭证只引用环境变量**名**） | — |
-| `lanes.yaml` | 每条 lane 的主模型 + 兜底链 | ✅ 持久化 |
+| `lanes.yaml` | 每条 lane 的主模型 + 兜底链（质量 lane、任务 lane、厂商家族 lane） | ✅ 持久化 |
 | `policies.yaml` | 首条命中、用来挑选或封顶 lane 的规则 | ✅ 持久化 |
 | `classifier.yaml` | 内置规则 + 可选的 eval 模型 | ✅ 持久化 |
-| `memory.yaml` | 遗忘/分层旋钮（出厂配置即开启）+ 可选的压缩触发覆盖（`compaction:`——体量/空闲/压力阈值；经济学部分保持全自动）。旧版遗留的 `observer:` 配置块会导致启动失败 | ✅ |
+| `model-aliases.yaml` | 把写死的厂商模型 id 映射到 lane / `auto`（兼容垫片，可选） | — |
+| `memory.yaml` | 遗忘/分层旋钮（出厂配置即开启）· 可选的压缩触发覆盖（`compaction:`）· 可选的 LLM 摘要器（`llm:`，默认关闭）。旧版遗留的 `observer:` 配置块会导致启动失败 | ✅ |
 | `capabilities.yaml` / `pricing.yaml` | 对模型目录的手动覆盖项（含 prompt 缓存读/写价格） | — |
 
 最常用的环境变量（env 优先于 YAML；完整列表见 [`.env.example`](.env.example)）：
@@ -229,8 +234,6 @@ pnpm dev          # 管理面板开发服务器（Vite）—— 见下方说明
 pnpm test         # Vitest 单元测试
 pnpm exec vitest run --coverage # 单元测试覆盖率（只统计源码，并带阈值）
 pnpm test:e2e     # Playwright 端到端测试
-pnpm test:e2e:coverage       # 协议重点的网关 / 服务端 E2E 覆盖率
-pnpm test:e2e:coverage:full  # 全量 Playwright 套件的网关 / 服务端 E2E 覆盖率
 pnpm typecheck    # 全仓库 tsc --noEmit
 pnpm lint         # Biome
 pnpm build        # 构建网关 + 面板
@@ -239,7 +242,7 @@ pnpm sync:catalog # 刷新生成的模型目录（能力 + 定价）
 
 > `pnpm dev` 只起 admin SPA。网关没有 watch 脚本——构建后运行（`pnpm build` 再 `node apps/gateway/dist/index.js`），或用 Docker。
 >
-> 文档目前仅有英文版。
+> 规格文档目前仅有英文版。
 
 测试先行：core 用 Vitest，完整链路用 Playwright。设计决策记录在 [`implementation-notes.md`](implementation-notes.md)。开 PR 前：
 
@@ -249,7 +252,7 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 
 ## 文档
 
-从 [`docs/README.md`](docs/README.md) 开始，按顺序读：
+从 [`docs/README.md`](docs/README.md) 开始。想先看流水线全貌，读 **[架构与数据流](docs/architecture.md)**。编号规格按顺序读：
 
 [01 概览](docs/01-overview.md) ·
 [02 架构](docs/02-architecture.md) ·
@@ -267,7 +270,7 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm test:e2e
 
 ## 项目状态
 
-Helm API 当前版本 **0.9.0**——一套端到端的真实实现，不是空架子。完整链路（配置 → 鉴权 → 分类 → 路由 → 执行（含熔断与兜底）→ 协议互译 → 遥测）已全部打通，背后是一套相当完整的 Vitest 单测加 Playwright e2e 用例。
+Helm API 是一套端到端的真实实现，不是空架子。完整链路（配置 → 鉴权 → 分类 → 路由 → 执行（含熔断与兜底）→ 协议互译 → 遥测 → 记忆）已全部打通，背后是一套相当完整的 Vitest 单测加 Playwright e2e 用例。上方的版本徽章会跟踪当前发布版本。
 
 ## 许可
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+> See also [Architecture & Data Flow (diagrams)](architecture.md) — the same pipeline as sequence, flow, and state diagrams.
+
 ```text
 Client
   -> API Gateway (Hono)
@@ -43,8 +45,10 @@ Built on Hono. Responsibilities:
   `runtime.request_timeout_ms`).
 - Dispatch to the correct protocol adapter.
 
-It also serves `/healthz` and `/version`, and (when admin credentials are
-configured) mounts the Admin UI and admin API under `/admin`.
+It also serves `/healthz` and `/version`, and mounts the Admin UI and admin
+API under `/admin` when admin is enabled — i.e. when credentials are configured
+(auto-enable) OR `HELM_ADMIN_ENABLED` / `admin.enabled` is set; otherwise
+`/admin` and `/admin/api` return 404.
 
 ### Protocol Adapter
 
@@ -237,6 +241,7 @@ config/
   runtime.yaml         # store driver, rate limit, timeouts, request size, signal feedback
   server.yaml          # host / port
   memory.yaml          # forgetting/decay layer (observer compaction is auto, not configured)
+  model-aliases.yaml   # virtual vendor-model-id → lane | "auto" rewrite map (compatibility shim, optional)
 ```
 
 Capability and pricing data originate from a checked-in **generated catalog**
@@ -262,8 +267,10 @@ console for basic rule management (lanes / policies / classifier / keys) and
 request debugging, plus a "System Settings" page for runtime-mutable settings
 (payload capture, retention, the rate-limit switch, log level) that apply without
 a restart. It is independent of API traffic and authenticated with HTTP Basic
-credentials (file / environment). The admin surface is mounted **only** when
-credentials are configured; otherwise `/admin` and `/admin/api` return 404. See
+credentials (file / environment). The admin surface is mounted when admin is
+enabled — i.e. when credentials are configured (auto-enable) OR
+`HELM_ADMIN_ENABLED` / `admin.enabled` is set; otherwise `/admin` and
+`/admin/api` return 404. See
 [11 · Admin UI](11-admin-ui.md).
 
 Deployment: **open-source, self-hosted, one-command Docker**, config-as-code,

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -9,7 +9,8 @@ its ordered chain. The framework-agnostic orchestrator is `routeRequest`
 ## Lane routing priority
 
 ```text
-explicit model/lane            # client specified a concrete model/lane; skips classify + policy entirely
+model-alias shim               # operator map rewrites a fixed vendor id onto a lane / `auto`; cap-bounded
+  > explicit model/lane        # client specified a concrete model/lane; skips classify + policy entirely
   > classifier short-circuit   # decided_by 'default' | 'fallback' → straight to balanced (classified branch only)
   > server-side policy         # a policy pin (use_lane)
   > task-specific lane         # a lane named after the detected task_type
@@ -18,7 +19,10 @@ explicit model/lane            # client specified a concrete model/lane; skips c
   > balanced                   # final default
 ```
 
-Explicit model/lane passthrough is the **priority-0** short-circuit: a request
+The **model-alias compatibility shim** runs first (priority 0); see
+[Model-alias compatibility shim](#model-alias-compatibility-shim) below.
+
+Explicit model/lane passthrough is the next short-circuit: a request
 that names a concrete model or lane (gated by `allow_custom_model`, and
 suppressed while degrading) skips classification and policy entirely and is
 executed directly, so the classifier never runs for it.
@@ -40,6 +44,44 @@ lane (`economy` or `balanced`) to a stronger ranked lane with healthier aggregat
 success/error/fallback rates. It never runs on explicit passthrough,
 classifier-default/fallback, policy `use_lane` pins, or over-budget degradation,
 and it never escapes policy/key caps.
+
+### Model-alias compatibility shim
+
+Before any passthrough gate, `plan()` runs a **priority-0** model-alias
+resolution step (route-request.ts steps 0 / 0a). Clients that pin a **fixed
+vendor model id** — Claude Code's `claude-opus-4-8`, or an SDK locked to
+`gpt-5.5` — know neither Helm's lanes nor its provider aliases, so left alone
+they would get a `400 unknown model`. The shim rewrites that inbound `model`
+field onto a lane (or the `auto` sentinel) **before** routing, so a fixed-model
+client routes cleanly while Helm still only exposes the lane abstraction
+(principle 6 — the literal vendor id is never sent upstream).
+
+The map is [`config/model-aliases.yaml`](../config/model-aliases.yaml): a flat
+table of vendor model id → a lane name or `auto`. Keys are glob-matchable and
+**case-sensitive** — an exact key wins, otherwise the matching `*`-glob with the
+most literal characters wins (so `claude-opus-*` beats `claude-*` regardless of
+order; `*` absorbs any date/suffix). Targets are boot-validated to a configured
+lane or `auto` (fail-closed, principle 2); the file is optional — delete it for
+no rewrite.
+
+Unlike explicit passthrough, the shim is **operator-authorized**, not
+client-authorized:
+
+1. It runs **before** the `allow_custom_model` gate and does **not** require
+   `allow_custom_model` on the key — a standard key routes through it too,
+   because the operator authorized the rewrite by configuring the map.
+2. It is **cap-bounded**, not a bypass. Identity-scoped policy caps (org/user
+   `max_lane` / `allowed_lanes`) and the key's own `allowed_lanes` whitelist
+   both still clamp the resolved lane. The clamp is **silent** (the same
+   `applyCaps` path classified routing uses), **not** the loud `invalid_request`
+   reject an explicit forbidden-lane ask gets — so a standard key can never use
+   an operator alias to escape a cap it would otherwise be bound by.
+   (Task/complexity-scoped policies do not fire here: an alias request is not
+   classified.)
+3. It is **suppressed while the key is over-budget/degrading** — the request
+   falls through to the forced degrade lane (docs/06), no bypass.
+4. An alias that maps **to `auto`** does not passthrough the literal vendor id;
+   it falls through to classification, letting the router decide per request.
 
 ### Explicit client model
 
@@ -140,6 +182,28 @@ If no task-specific lane is configured, the resolver falls back to the three
 quality/cost lanes by complexity (`simple → economy`, `medium → balanced`,
 `complex → premium`).
 
+### Vendor-family lanes
+
+Beyond the 7 generic lanes above, `config/lanes.yaml` ships **9 vendor-family
+lanes** — the rewrite targets of the [model-alias compatibility
+shim](#model-alias-compatibility-shim):
+
+```text
+claude-opus   claude-fable   claude-sonnet   claude-haiku
+gpt-5.5       gpt-5.4        gpt-5.4-mini
+gemini-pro    gemini-flash
+```
+
+(16 lanes total.) These exist so a client that pins a fixed vendor id lands on
+that family's real model instead of the GPT-led `premium` lane. Each one
+**leads with the requested vendor's native/subscription alias** — the Claude
+lanes with the `anthropic/*` Claude OAuth pool, the GPT lanes with the
+`openai-codex/*` subscription, the Gemini lanes with the static `zenmux/*` key —
+then **degrades into a generic quality lane** (e.g. `claude-opus → premium`,
+`gpt-5.4-mini → economy`). An unconnected subscription alias **fails OPEN** (skip
+to the next fallback), never a 5xx, so an unbound subscription just serves the
+request from the generic-lane backing.
+
 ### Provider mix and the `*/auto` tail
 
 The cheap and default lanes anchor on the **always-available** official
@@ -152,7 +216,7 @@ backed by a static fallback so the lane **degrades gracefully**: an unconnected
 The `*/auto` aliases (`zenmux/auto`, `openrouter/auto`) sit only at the **tail of
 the `balanced` chain** — every other lane reaches them by falling through to
 `balanced`, not by carrying its own auto tail. Those auto aliases are
-deliberately JSON-incapable in the catalog (`supports_json_schema: false`), so a
+deliberately JSON-incapable in the catalog (`supportsJsonMode: false`), so a
 strict-JSON request prunes them via the Capability Filter and lands on a
 deterministic JSON-capable model — proving the filter fires on the default
 config.

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -15,7 +15,7 @@ Four client protocols are wired and routed:
 | `POST /v1/chat/completions` | OpenAI Chat Completions | Yes (SSE) and non-stream |
 | `POST /v1/messages` | Anthropic Messages | Yes (SSE) and non-stream |
 | `POST /v1/responses` | OpenAI Responses | Yes (SSE) and non-stream |
-| `POST /v1beta/models/{model}:generateContent` | Google Gemini | Yes (SSE via `:streamGenerateContent?alt=sse`) and non-stream |
+| `POST /v1beta/models/{model}:generateContent` | Google Gemini | Yes (SSE via `:streamGenerateContent`) and non-stream |
 
 **OpenAI Responses** streaming returns a native Responses SSE stream of
 `response.*` events terminated by a `response.completed` event. There is **no**
@@ -26,11 +26,16 @@ see `apps/gateway/src/routes/responses.ts` for the route.
 
 **Gemini** is mounted as a catch-all `POST /v1beta/models/:rest{.+}` (Hono can't
 match the literal `:` in `{model}:generateContent` with a named param). The core
-`parseGeminiPath` recognizes only `:generateContent` and `:streamGenerateContent`;
-any other op (`:countTokens`, `:embedContent`, …) returns a `404` in the **Gemini
-error shape**, never a generic gateway error. Auth is `x-goog-api-key` (the Gemini
-SDK default), with `Authorization: Bearer` as a fallback. Streaming via
-`:streamGenerateContent?alt=sse` emits nameless `data:` `GenerateContentResponse`
+`parseGeminiPath` recognizes `:generateContent`, `:streamGenerateContent`, and
+`:countTokens`; `:countTokens` is served (200) and returns a Gemini-shaped token
+count — either a provider-native count or a deterministic local estimate
+`{totalTokens, estimated:true}` — without routing through the generation pipeline.
+Any other op (`:embedContent`, …) returns a `404` in the **Gemini error shape**,
+never a generic gateway error. Auth is `x-goog-api-key` (the Gemini SDK default),
+with `Authorization: Bearer` as a fallback. Streaming is selected by the
+`:streamGenerateContent` operation name; `alt=sse` affects the Google wire format
+but is **not required** by the gateway — the query parameter is ignored when
+deciding stream vs. non-stream. Streaming emits nameless `data:` `GenerateContentResponse`
 frames each carrying an **incremental** text delta (matching real Gemini — clients
 accumulate `chunk.text`), with **no** `event:` name and **no** `[DONE]` sentinel;
 the terminal frame carries the completed `functionCall` parts, `finishReason`, and
@@ -84,12 +89,16 @@ correctness reference; the code is a clean reimplementation, not a copy.
   `reasoning_effort` maps to a per-protocol thinking-budget band
   (`anthropic/request.ts` `REASONING_EFFORT_TO_BUDGET` and
   `gemini/gemini-transformer.ts` `REASONING_EFFORT_BUDGET`) — Anthropic
-  `{minimal:1024, low:2048, medium:8192, high:16384}`, Gemini
+  `{none:0, minimal:1024, low:1024, medium:2048, high:4096, xhigh:8192, max:16384}`
+  (litellm parity; the previous low:2048/medium:8192/high:16384 over-budgeted 2–4×
+  and were replaced to avoid billing/latency inflation), Gemini
   `{minimal:128, low:1024, medium:8192, high:24576}`.
 - **Non-mappable knobs degrade observably, never silently**
   (`protocol/protocol-guards.ts`): guards fire **only for the Anthropic target** —
-  `n>1` is capped to 1 (`n_capped`), and `logprobs` / `top_logprobs` / `modalities`
-  are dropped with a `data_loss` warning. The `openai` and `gemini` targets are an
+  `n>1` is capped to 1 (`n_capped`), and `logprobs` / `top_logprobs` / `modalities` /
+  `frequency_penalty` / `presence_penalty` / `seed` are dropped with a `data_loss`
+  warning (Anthropic Messages has no native surface for these sampling knobs). The
+  `openai` and `gemini` targets are an
   intentional no-op: every guarded knob has a native home (Responses passes `n`
   through; Gemini maps `n` → `candidateCount`). Warnings ride
   `provider_raw.warnings` and are stripped before the wire — telemetry sees them,

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -8,10 +8,15 @@
 > (`apps/gateway/src/routes/memory-scope.ts`); mode normalization and
 > owner-scoping live in core (`packages/core/src/memory/observe.ts`).
 >
-> The only genuinely deferred piece is the **real LLM summarize/merge**: the
-> Observer, Reflector, and fact-extraction summarizers are currently
-> **deterministic non-LLM stubs** (concatenate / truncate) behind an injected
-> interface. Swapping in an LLM is a drop-in replacement.
+> **LLM-backed summarize / merge / fact-extraction has also shipped** and is
+> wired into the Observer and Reflector (`createMemoryLlmRuntime` in
+> `apps/gateway/src/memory-llm.ts`), gated behind `config.memory.llm.enabled`
+> (Zod schema default `false`). When enabled, the background jobs call a real
+> model via `client.chatCompletion` with `response_format: json_object` and
+> parse strict JSON. The **deterministic concatenate / truncate path is the
+> default** — and the fail-open fallback whenever the LLM is disabled, the model
+> is unavailable, or a call / parse / timeout fails. See "`config.memory.llm`"
+> below.
 >
 > The forgetting & tiering layer ([12 · Memory: Forgetting & Tiering](12-memory-forgetting-and-tiering.md))
 > has also shipped, gated behind `config.memory.forgetting.enabled`. Although the
@@ -336,7 +341,7 @@ memory_messages
 memory_observations
   id, thread_id, source_message_range, observation_text, observed_at,
   referenced_at, priority, tags,
-  reference_count, importance, status (active | archived), archived_at, expired_at
+  reference_count, importance, status (active | archived | pruned), archived_at, expired_at
 
 memory_reflections
   id, owner_id, project_id, resource_id, thread_id, reflection_text, version,
@@ -354,10 +359,14 @@ memory_jobs
 ```
 
 `source_message_range` is required so compressed memory can be audited against the
-original raw messages. The forgetting-score columns on observations / reflections
-and the `memory_facts` table back the docs/12 layer; with `forgetting.enabled`
-false every row stays `status='active'` / `expired_at=null`, so those columns are
-inert.
+original raw messages. The shared `MemoryStatusSchema` enum — `active | archived |
+pruned` — backs observations, reflections, and facts alike. `pruned` is the
+retention **tombstone**: the row's text is freed (e.g. `observation_text` blanked to
+`[pruned]`) but the row itself **and** its `source_message_range` are kept, so the
+pruned observation still marks its raw messages as covered (audit + window-dedup
+stay intact). The forgetting-score columns on observations / reflections and the
+`memory_facts` table back the docs/12 layer; with `forgetting.enabled` false every
+row stays `status='active'` / `expired_at=null`, so those columns are inert.
 
 ## Routing integration
 
@@ -391,9 +400,44 @@ Observability](07-observability.md)).
 Memory maintenance has its own token/cost buckets so it is visible in cost
 reports and not hidden inside provider execution cost: actor request tokens,
 actor response tokens, memory hydrate tokens, Observer tokens, Reflector tokens.
-The buckets and sinks exist today; the Observer bucket is currently a no-op sink
-(deterministic stub), and full memory-maintenance cost reporting is deferred
-until the LLM summarizer lands.
+The buckets and sinks are real: when the LLM path runs (`config.memory.llm.enabled`)
+the Observer and Reflector buckets bill the measured tokens of the summarize /
+merge / fact-extraction calls. Under the default deterministic-stub path those
+buckets are a no-op sink — the concatenate / truncate work spends no model
+tokens.
+
+## `config.memory.llm`
+
+LLM-backed memory formation is **opt-in**. The `llm:` block (validated by
+`MemoryLlmSchema`, `.strict()` — unknown keys refuse startup) controls **only** the
+background Observer / Reflector summarize / merge / fact-extraction calls; the
+request-path observe / inject stays synchronous and deterministic. With
+`enabled: false` (the default) the deterministic concatenate / truncate stubs run,
+and they also remain the **fail-open fallback** at runtime — an unavailable model,
+invalid JSON, or a timeout degrades that one job to the deterministic output (never
+a 5xx).
+
+```yaml
+# config/memory.yaml
+llm:
+  enabled: false                          # opt-in master switch (default false)
+  model: deepseek/deepseek-v4-flash       # base model for all memory LLM tasks
+                                          #   (required when enabled: true)
+  # Optional per-task overrides (each falls back to `model`):
+  # observation_model: openai/gpt-4.1-mini   # raw messages → observation (Observer)
+  # reflection_model:  openai/gpt-4.1-mini   # observations → reflection (Reflector)
+  # facts_model:       openai/gpt-4.1-nano   # observations → atomic facts
+  timeout_ms: 30000                       # per-call abort budget (default 30000)
+  temperature: 0                          # default 0 (deterministic)
+  max_tokens:                             # per-task output caps
+    observation: 800
+    reflection: 1200
+    facts: 1000
+```
+
+Calls go through `client.chatCompletion` with `response_format: json_object` and
+the result is parsed against a strict Zod schema; anything that does not parse
+falls back to the deterministic path.
 
 ## Phases
 
@@ -413,7 +457,9 @@ until the LLM summarizer lands.
   conversation — works for tool / multimodal / native-passthrough turns, with
   window-aware dedup, and preserves the upstream prompt cache (the cached prefix is
   never touched). See "Inject is additive (trailing-reminder model)" above.
-- The summarize/merge steps are deterministic stubs pending an LLM.
+- The summarize / merge / fact-extraction steps default to deterministic stubs,
+  with an opt-in LLM-backed path behind `config.memory.llm.enabled` (see
+  "`config.memory.llm`").
 
 ### Phase 3 — Project memory · implemented
 

--- a/docs/09-roadmap.md
+++ b/docs/09-roadmap.md
@@ -1,13 +1,13 @@
 # 09 · Roadmap
 
-> Status: **shipped — 0.9.0.** The core gateway (routing, classification, provider
+> Status: **shipped — production.** The core gateway (routing, classification, provider
 > execution, protocol translation, telemetry) runs in production, and several major
 > subsystems have landed since the early releases: a memory middleware (observe +
 > inject + background workers, on by default), per-key budgets / rate limits /
 > concurrency limiting, runtime hot-reload settings with admin YAML write-back,
 > verbatim payload capture, four streaming inbound protocols, full OAuth subscription
 > providers, Agentic Signals feedback into ranked-lane routing, an admin-UI
-> overhaul, observer-economy compaction, and permanent delete of revoked keys. The
+> overhaul, auto-adaptive memory compaction, and permanent delete of revoked keys. The
 > "deferred" list below is what is genuinely still out of scope or not yet wired.
 
 ## Delivered
@@ -61,9 +61,12 @@ default of `off` to opt out (zero DB touch):
 - The `DecisionRecord` carries a redacted `memory` block (counts / ids only, never
   content). See [08 · Memory Middleware](08-memory-middleware.md).
 
-> Note: the observer / reflector / fact-extraction summarizers are currently
-> **deterministic non-LLM stubs** (concatenate + truncate). The real LLM
-> summarize / merge path is the one genuinely deferred piece of this subsystem.
+> Note: the observer / reflector / fact-extraction summarizers default to
+> **deterministic local logic** (concatenate + truncate). An optional LLM-backed
+> path (`config.memory.llm.enabled`, default `false`) calls the configured small
+> model from background jobs and falls back to the deterministic output on
+> failure, invalid JSON, or unavailable model. The `enable_llm_supersede`
+> contradiction-path remains gated and not yet wired.
 
 ### OAuth subscription providers
 
@@ -106,9 +109,6 @@ and OpenAI Codex (ChatGPT):
 
 Verified against the code and `implementation-notes.md`:
 
-- **LLM-backed memory summarization.** The observer / reflector / fact-extraction
-  paths use deterministic stubs today; swapping in a real small-model summarize +
-  merge step is the next memory milestone.
 - **Account-level credit accounting.** Per-key RPM/TPM and budgets have shipped.
   Helm is an internal/self-hosted gateway with no account/customer billing subject,
   so account-level / customer credit accounting is **out of scope** (not merely

--- a/docs/11-admin-ui.md
+++ b/docs/11-admin-ui.md
@@ -142,9 +142,11 @@ never diverge.
   candidate chain, provider attempts, cost, error, and `trace_id`. When
   `capture_payloads` is on, the detail can load the full captured request/response
   bodies (`/admin/api/requests/:traceId/payload`). When the full request body was
-  captured and is an OpenAI-chat request (a `messages` array), the detail page
-  offers an editable **Retry** button that re-sends the (optionally edited) body
-  as an isolated, newly-traced debug re-run via the server replay endpoint.
+  captured, the detail page offers an editable **Retry** button. The server
+  recovers the original protocol (OpenAI chat, Anthropic messages, OpenAI
+  Responses, or Gemini) and re-sends the (optionally edited) body in its native
+  shape as an isolated, newly-traced debug re-run via the server replay endpoint;
+  a body that cannot be replayed returns a precise 400.
 
 ## Boundaries
 

--- a/docs/12-memory-forgetting-and-tiering.md
+++ b/docs/12-memory-forgetting-and-tiering.md
@@ -13,13 +13,23 @@
 > job. This is the single inertness guarantee; the rest of the doc assumes the flag
 > is **on** unless it says otherwise.
 >
-> **Deterministic stubs, not LLM yet.** The fact extractor and the
-> reflection-merge/summarize behind the Observer/Reflector interfaces are
-> **deterministic MVP stubs** (docs/08): one candidate fact per active observation,
-> subject = its first tag (else a 6-word slug of the leading words), assertion = the
-> observation text. They are genuinely live when the flag is on, but the real LLM
-> summarize / merge / atomize path stays the deferred piece — don't read the tier
-> diagram as evidence of LLM-grade extraction quality.
+> **Deterministic by default; optional LLM memory-formation path ships behind
+> `config.memory.llm`.** The fact extractor and the reflection-merge/summarize
+> behind the Observer/Reflector interfaces are **deterministic** by default
+> (docs/08): one candidate fact per active observation, subject = its first tag
+> (else a 6-word slug of the leading words), assertion = the observation text. That
+> deterministic path is the **default** and the **fail-open fallback** — it is
+> genuinely live when the flag is on. On top of it, an **optional LLM-backed
+> summarize / merge / fact-extract path now exists and is fully wired**:
+> `MemoryLlmSchema` (`config.memory.llm`) drives `createMemoryLlmRuntime`
+> (`apps/gateway/src/memory-llm.ts`), whose real `summarize` / `merge` /
+> `extractFacts` are plugged into the Observer/Reflector deps in `server.ts`. It is
+> **off by default** (`enabled: false`) and any disabled-or-failed model call falls
+> back to the deterministic stubs, so it is implemented and configurable, not
+> deferred — don't read the tier diagram as a promise of LLM-grade extraction
+> quality unless that path is enabled. The only memory-formation piece still gated
+> and unimplemented is the `enable_llm_supersede` contradiction path
+> (`z.literal(false)` — setting it `true` refuses startup).
 
 ## Where it lives (spec → code)
 
@@ -29,7 +39,7 @@
 | Sweep job (archive / consolidate / supersede) | `packages/core/src/memory/forgetting/decay.ts` → `runDecayJob` |
 | Buffer-flush "should the sweep run" gate | `packages/core/src/memory/decay-trigger.ts` |
 | Retention (tombstone obs / hard-delete facts) | `packages/core/src/memory/forgetting/retention.ts` → `pruneRetainedMemory` |
-| Deterministic fact-extractor stub | `extractFactsFromObservations` in `apps/gateway/src/server.ts` |
+| Deterministic fact-extractor stub | `extractFactsDeterministic` in `apps/gateway/src/memory-llm.ts` (surfaced via `createMemoryLlmRuntime().extractFacts`, wired into the Reflector in `apps/gateway/src/server.ts`) |
 | Scheduler dispatch (`type='decay'`) + sweep `onTick` | `startMemoryWorker` wiring in `apps/gateway/src/server.ts` |
 | Config schema (snake_case, `.strict()`) | `packages/shared/src/config/memory-schema.ts` (`ForgettingSchema`; re-exported from `config/schema.ts`) |
 | Migration v18 + Zod row deltas | `packages/core/src/store/sqlite/migrate.ts`, `packages/shared/src/memory/schema.ts` |
@@ -548,7 +558,7 @@ shippable and gated.
 | **P3** | Reinforcement hook `bumpReferences({accountId, ids})` (gated) | bumps only when enabled; a throwing `bumpReferences` does not change returned `messages` (fail-open); only rows of the request's `accountId` are bumped. With flag off, `inject.ts` byte-identical. |
 | **P4** | Score-driven inject trim (gated) | under `score`, a high-`reference_count` old observation outlives a never-referenced newer one; comparator throw → oldest-first fallback. Legacy `oldest` path unchanged. |
 | **P5** | Extend `MemoryJobTypeSchema` with `decay` + scheduler dispatch + `runDecayJob` sweep (gated, off hot path) | **`MemoryJobTypeSchema.parse('decay')` succeeds and the scheduler routes it to `runDecayJob`**; `decay` job dedupe/enqueue works; archives only sub-threshold active rows of one account; never `recent_raw`; idempotent re-run; bounded loop (iterations / wallclock / consecutive-errors). |
-| **P6** | Fact extraction + supersede (gated, deterministic stub). Reflector reads **active observations only**; the deterministic `extractFactsFromObservations` extractor is wired in `server.ts` so the pipeline is live when enabled (pg insert+supersede in one transaction) | identical fact within an account → idempotent skip (`UNIQUE(owner_id, content_hash)`); newer same-`(owner_id, subject_key)` fact → old `expired_at` stamped; reads filter `owner_id = :accountId AND expired_at IS NULL`; an **archived/pruned observation is excluded from the merge + extraction**. Reflector versioning tests unchanged. |
+| **P6** | Fact extraction + supersede (gated, deterministic stub). Reflector reads **active observations only**; the deterministic `extractFactsDeterministic` extractor (in `apps/gateway/src/memory-llm.ts`, surfaced via `createMemoryLlmRuntime().extractFacts`) is wired into the Reflector in `server.ts` so the pipeline is live when enabled (pg insert+supersede in one transaction) | identical fact within an account → idempotent skip (`UNIQUE(owner_id, content_hash)`); newer same-`(owner_id, subject_key)` fact → old `expired_at` stamped; reads filter `owner_id = :accountId AND expired_at IS NULL`; an **archived/pruned observation is excluded from the merge + extraction**. Reflector versioning tests unchanged. |
 | **P7** | Retention (rare): observations **tombstoned** (`status='pruned'`, text freed, coverage kept); facts **hard-deleted** | tombstone keeps the row + `sourceMessageRange` visible to coverage reads (raw stays covered after prune); facts are the only `DELETE`; never touches `active` or recently-aged rows. |
 | **P8** | Hybrid fact retrieval (gated, own flag) — sqlite-vec/pgvector + FTS5 + forgetting-score, fused with RRF(k=60) | RRF fusion is order-stable and scale-free on a fixture; a superseded/archived fact never surfaces; empty/failed recall → request proceeds with the v1 prefix (fail-open); retrieved facts get the reinforcement bump. |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,10 +18,15 @@ interface ships with the gateway for basic rule management.
 
 ## Reading order
 
+> **New to the codebase?** [Architecture & Data Flow](architecture.md) draws the
+> whole pipeline as sequence, flow, and state diagrams — the fastest way to see
+> how a request moves through the system.
+
 | # | Document | Contents |
 |---|----------|----------|
 | 01 | [Overview & Positioning](01-overview.md) | What Helm is, the nginx analogy, goals & non-goals, the core product loop. |
 | 02 | [Architecture](02-architecture.md) | Pipeline, component responsibilities, internal request shape, decision record, config layout, security rules. |
+| — | [Architecture & Data Flow](architecture.md) | Visual companion to 02 — Mermaid sequence/flow/state diagrams for the request lifecycle, classification, routing, execution, protocol translation, memory, and OAuth. |
 | 03 | [Classification Cascade](03-classification.md) | The three-layer cascade (rules → optional eval → balanced fallback), task detection, the rule engine, small-model eval. |
 | 04 | [Routing & Lanes](04-routing-and-lanes.md) | Routing priority, default & task lanes, policies, execution and the two fallbacks. |
 | 05 | [Protocol Translation](05-protocol-translation.md) | Protocol Adapter design (OpenAI Chat, Anthropic, OpenAI Responses, Google Gemini), the unified IR, the streaming state machine, the footguns that are handled. |
@@ -61,4 +66,4 @@ These keep Helm more focused than its predecessor `llm-router`:
 | Specification | Implemented (these documents describe the shipping system) |
 | Core gateway (routing, classification, protocol translation, store) | Implemented |
 | Admin UI | Implemented |
-| Release | 0.9.0 |
+| Release | Production — see [`package.json`](../package.json) for the current version |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,518 @@
+# Helm API — Architecture & Data Flow
+
+> Visual companion to [02 Architecture](02-architecture.md). That chapter explains
+> the system in prose; this one draws it — component map, request lifecycle,
+> and a per-stage set of sequence, flow, and state diagrams. Everything here is
+> traced to the shipping code; where a stage has its own chapter, it is linked.
+
+Diagrams use [Mermaid](https://mermaid.js.org). GitHub renders them inline; in a
+plain editor read the fenced source.
+
+---
+
+## 1. The shape of the system
+
+Helm sits between your applications and every upstream LLM. Clients speak one of
+four wire protocols to a single `base_url`; a declarative YAML config decides
+which model actually answers; every decision is recorded.
+
+```mermaid
+flowchart TB
+    subgraph clients["Clients — unchanged SDKs"]
+        C1["OpenAI Chat"]
+        C2["Anthropic Messages"]
+        C3["OpenAI Responses"]
+        C4["Google Gemini"]
+    end
+
+    subgraph gw["apps/gateway — Hono HTTP shell (thin, optional)"]
+        MW["middleware: trace · auth · rate-limit · concurrency · limits"]
+        AD["Protocol Adapter: native wire ⇄ IR"]
+        ADMIN["/admin SPA + /admin/api · /healthz · /version · /docs"]
+    end
+
+    subgraph core["packages/core — the routing brain (no web framework)"]
+        CLS["Classifier (3-layer)"]
+        RT["Router: policies · lanes · caps · signals"]
+        EX["Executor: capability filter · circuit breaker · fallback"]
+        MEM["Memory middleware"]
+        PR["Protocol transformers (IR hub)"]
+    end
+
+    subgraph up["Upstream providers"]
+        SK["Static API keys — DeepSeek · ZenMux · OpenRouter"]
+        OA["OAuth subscriptions — Claude · Codex · Copilot (pooled)"]
+    end
+
+    subgraph data["Storage (Store ports)"]
+        DB["SQLite (default) | Postgres / Supabase"]
+    end
+
+    CFG["config/*.yaml — Zod-validated · invalid config refuses to boot"]
+
+    clients -->|"one base_url + Helm key"| MW
+    MW --> AD --> core
+    CLS --> RT --> EX --> PR
+    EX --> up
+    core --> data
+    CFG -.drives every stage.-> core
+    ADMIN <-->|REST| data
+    admin_user["Operator (browser)"] -->|HTTP Basic| ADMIN
+```
+
+**Reading it:** the gateway is a shell — it normalizes a request into one
+*internal representation* (IR) and hands everything else to `core`. The core
+never imports Hono or SvelteKit; an architecture test (`packages/core/src/arch.test.ts`)
+fails the build if it ever does. That is what makes Helm runnable **headless**.
+
+---
+
+## 2. Module boundaries & the headless-core contract
+
+| Package | Responsibility | Imports a web framework? |
+|---|---|---|
+| `packages/shared` | Zod schemas → the single source of truth for every type (`z.infer`). Defines the IR, `DecisionRecord`, error model, config schemas. | No |
+| `packages/core` | Classification, routing, execution, protocol translation, memory, Store *ports*. Pure logic. | **No (enforced)** |
+| `apps/gateway` | Hono: HTTP surfaces, middleware order, protocol ⇄ IR wiring, Store *adapters*, background workers. | Hono |
+| `apps/admin` | SvelteKit static SPA. Talks only to `/admin/api/*`; imports **zero** core/gateway code. | SvelteKit |
+
+The dependency arrow only ever points **inward**: `gateway → core → shared`.
+The admin SPA depends on neither — it is a pure HTTP client of the admin API.
+
+---
+
+## 3. Request lifecycle — the master path
+
+A single `POST /v1/chat/completions` (or any of the four faces), streaming,
+end to end. Optional stages are marked; the colored notes call out each stage's
+failure discipline.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cl as Client
+    participant GW as Gateway (Hono)
+    participant Mem as Memory
+    participant Rt as Core Router
+    participant Cf as Classifier
+    participant Ex as Executor + Breaker
+    participant Up as Provider
+    participant St as Store (writeQueue)
+
+    Cl->>GW: HTTP request (one of 4 protocols)
+    Note over GW: trace_id · body-limit · timeout
+    GW->>GW: auth (sha256(key) → KeyStore) · rate-limit · concurrency
+    Note right of GW: fail-closed — bad/over-limit key never reaches core
+    GW->>GW: transformRequestOut → IR
+
+    GW->>Mem: observeInbound — persist the turn
+    GW->>Mem: injectIntoIR — assemble memory, append as trailing user turn
+    Note right of Mem: fail-open — any error returns the IR unchanged
+
+    GW->>Rt: routeRequest(IR)
+    Rt->>Cf: classify (L1 rules → L2 eval?)
+    Note right of Cf: fail-open — any throw → balanced lane
+    Cf-->>Rt: task_type · complexity · decided_by
+    Rt->>Rt: policies → resolveLane → caps → signals → candidate_chain
+
+    Rt->>Ex: execute(candidate_chain)
+    loop each candidate until first success
+        Ex->>Ex: canAttempt? · capability filter
+        alt circuit OPEN or capability skip
+            Note over Ex: push skipped attempt, try next
+        else allowed
+            Ex->>Up: invoke (IR → native via transformRequestIn)
+            alt first valid chunk arrives
+                Up-->>Ex: stream/json · recordSuccess
+            else failure before first chunk
+                Up-->>Ex: error · recordFailure → next candidate
+            end
+        end
+    end
+    Ex-->>Rt: result (or all_providers_failed → 502)
+
+    Rt-->>GW: ExecutionResult + DecisionRecord
+    GW->>GW: transformResponseOut / SSE → client's own protocol
+    GW-->>Cl: response (streamed or JSON)
+
+    GW->>Mem: observeOutbound — persist the response
+    GW->>St: DecisionRecord (redacted) + payload (verbatim, opt-in)
+    Note right of St: telemetry + memory writes are batched, never block the reply
+```
+
+The two memory writes and the telemetry write run **after** the client already
+has its answer — they are deferred onto a batched write queue, so observability
+never adds latency to the hot path.
+
+---
+
+## 4. Boot — fail-closed configuration
+
+Helm refuses to run half-configured. The whole config tree is parsed and
+Zod-validated before the server binds a port.
+
+```mermaid
+flowchart TD
+    A["loadConfig(): read config/*.yaml in order<br/>server · auth · providers · runtime · classifier<br/>· lanes · policies · memory · model-aliases"] --> B["applyEnvOverrides() — env wins over YAML"]
+    B --> C{"HelmConfigSchema<br/>valid?"}
+    C -- "no" --> X["throw ConfigError (field paths only,<br/>no secret values) → process.exit(1)"]
+    C -- "yes" --> D{"store driver?"}
+    D -- "sqlite (default)" --> E["open ./data/helm.db · 5 pragmas · run migrations"]
+    D -- "supabase" --> F["open Postgres via HELM_STORE_URL_ENV → DSN"]
+    D -- "unknown" --> X
+    E --> G["loadCatalog(): generated JSON + capabilities.yaml + pricing.yaml<br/>(per-field override · re-validated · fail-closed)"]
+    F --> G
+    G --> H["bootstrap root key (printed once) · build provider clients<br/>· synthesize OAuth presets · circuit breaker · classify adapter"]
+    H --> R(["READY — bind port, start memory worker + signal scheduler"])
+
+    style X fill:#fee,stroke:#c33
+    style R fill:#efe,stroke:#3a3
+```
+
+Optional files (`classifier`, `lanes`, `policies`, `memory`, `model-aliases`)
+may be **absent** (schema defaults apply) but never **invalid** — a present file
+that fails validation still aborts boot. A leftover legacy `observer:` block in
+`memory.yaml` is a hard rejection (the schema is `.strict()`), not a silent drop.
+
+---
+
+## 5. The two failure disciplines
+
+Everything in Helm is one of two kinds of component. This single rule explains
+almost every design choice.
+
+```mermaid
+flowchart LR
+    subgraph fc["FAIL-CLOSED — config & credentials"]
+        direction TB
+        a1["invalid YAML / missing required key"]
+        a2["unknown store driver"]
+        a3["OAuth preset without HELM_OAUTH_ENC_KEY"]
+        a1 & a2 & a3 --> aX["refuse to start<br/>(never run half-configured)"]
+    end
+    subgraph fo["FAIL-OPEN — the request path"]
+        direction TB
+        b1["classification error"]
+        b2["eval timeout"]
+        b3["memory error"]
+        b4["circuit-breaker fault"]
+        b1 & b2 & b3 & b4 --> bX["degrade quietly to balanced / pass through · log it<br/>(client sees 5xx only when EVERY provider is down)"]
+    end
+    style aX fill:#fee,stroke:#c33
+    style bX fill:#fff3cd,stroke:#d39e00
+```
+
+And two *fallbacks* that are deliberately never conflated, with separate
+`DecisionRecord` fields so you can always tell which one fired:
+
+- **Classification fallback** — undecided/eval-off → the `balanced` lane
+  (`decided_by = fallback`).
+- **Execution fallback** — a provider failed → the next model in the chain
+  (`fallback_count`, counting only non-skipped attempts).
+
+---
+
+## 6. Classification cascade
+
+Three layers; see [03 Classification](03-classification.md) for the rule engine.
+Layer 1 is a pure function (zero network, unit-tested, always on). Layer 2 is an
+optional small-model evaluation — `temperature: 0`, cached, **off by default**.
+`balanced` is the fail-open sink.
+
+```mermaid
+flowchart TD
+    A["IR (last user message, tools, turn count, attachments)"] --> B["Layer 1 — deterministic rules<br/>dimensions · momentum · tiers · overrides · task detect"]
+    B --> C{"rules confidence<br/>≥ threshold (0.42)?"}
+    C -- "yes" --> RULES["decided_by = rules"]
+    C -- "no" --> D{"eval.enabled?"}
+    D -- "no (shipped default)" --> FB["decided_by = fallback<br/>reason = eval_disabled"]
+    D -- "yes" --> E["Layer 2 — small-model eval<br/>temp 0 · cache (sha256 of 5 canonical fields) · double timeout"]
+    E --> F{"eval returned<br/>valid JSON verdict?"}
+    F -- "yes" --> EVAL["decided_by = eval"]
+    F -- "no (timeout / error / bad JSON)" --> FB
+    RULES --> RL["resolveLane"]
+    EVAL --> RL
+    FB --> BAL["lane = balanced"]
+
+    style FB fill:#fff3cd,stroke:#d39e00
+    style BAL fill:#fff3cd,stroke:#d39e00
+```
+
+A high-confidence Layer-1 verdict **stops the cascade** — eval is never called,
+even when enabled. The eval cache is per-process and only stores *decided*
+results, so a transient upstream failure can't be amplified into a 300s outage.
+
+---
+
+## 7. Routing & lane resolution
+
+How a request becomes an ordered chain of concrete model aliases. See
+[04 Routing & Lanes](04-routing-and-lanes.md). The shipped config has **16 lanes**:
+3 quality lanes (`economy`/`balanced`/`premium`), 4 task lanes
+(`coding`/`json`/`vision`/`tool_use`), and 9 vendor-family lanes that are the
+rewrite targets of the model-alias compatibility shim.
+
+```mermaid
+flowchart TD
+    A["IR.requested_model"] --> B{"model-alias map hit?<br/>(config/model-aliases.yaml)"}
+    B -- "yes → lane" --> C["rewrite to lane · cap-bounded (silent clamp)"]
+    B -- "yes → auto / no hit" --> D{"explicit passthrough?<br/>allow_custom_model · model ≠ auto · not over-budget"}
+    D -- "yes" --> P["use exact model / lane<br/>(HARD reject if outside key caps)"]
+    D -- "no" --> CL["classify (Layer 1/2)"]
+    C --> EXP["expandLaneChain"]
+    P --> EXP
+    CL --> POL["policy engine:<br/>first-match PIN (use_lane)<br/>+ caps accumulate across ALL matches"]
+    POL --> RES["resolveLane:<br/>default/fallback → balanced<br/>else use_lane → task lane → complexity lane → balanced"]
+    RES --> CAP["applyCaps: policy caps → key caps<br/>(degrade_lane forces the base when over budget)"]
+    CAP --> SIG{"signal feedback on<br/>& lane degraded?"}
+    SIG -- "yes" --> PROMO["promote to stronger healthy lane<br/>(only upgrades · cap-bounded)"]
+    SIG -- "no" --> EXP
+    PROMO --> EXP
+    EXP --> CH["candidate_chain = leaf model aliases<br/>(lanes flattened recursively · dedup · cycle-safe)"]
+    CH --> EX["→ Executor"]
+```
+
+Key subtleties the diagram encodes: the model-alias shim runs **before** the
+custom-model gate and needs no special permission (it's operator-authored, still
+clamped by the key's `allowed_lanes`); only the lane *pin* is first-match while
+*caps* accumulate across every matching policy; and Agentic Signals can only ever
+**upgrade** a degraded lane, never demote.
+
+---
+
+## 8. Execution — fallback chain + circuit breaker
+
+The executor walks the candidate chain, gating each model through the breaker
+and the capability filter. Provider-execution semantics are ported from the
+battle-tested `llm-router` (re-implemented, not imported).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ex as runFallback
+    participant Br as Circuit Breaker
+    participant Cap as Capability Filter
+    participant Up as Provider
+
+    loop for each candidate in chain
+        Ex->>Br: canAttempt(model)
+        alt OPEN
+            Br-->>Ex: SKIP (circuit_open)
+            Note over Ex: record skipped attempt, continue
+        else CLOSED / HALF_OPEN probe
+            Br-->>Ex: ALLOW / PROBE
+            Ex->>Cap: checkCapability(model, req)
+            alt gate fails (tools / json / vision / context …)
+                Cap-->>Ex: skip + typed reason
+                Note over Ex: continue to next candidate
+            else ok
+                Ex->>Up: invoke (connection-retry pre-first-byte · per-chunk idle watchdog)
+                alt first valid chunk
+                    Up-->>Ex: success → Br.recordSuccess → return
+                else ":free" tier 429
+                    Up-->>Ex: SKIP (free_429) — no breaker failure
+                else client abort
+                    Up-->>Ex: stop chain — Br.recordAbort (release probe only), NOT a provider fault
+                else pre-first-chunk error
+                    Up-->>Ex: Br.recordFailure → next candidate
+                end
+            end
+        end
+    end
+    Note over Ex: chain exhausted → all_providers_failed (502)<br/>empty chain → lane_unavailable (503)
+```
+
+The breaker is per-process and in-memory; its state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> CLOSED
+    CLOSED --> OPEN : consecutive failures ≥ threshold (default 5)
+    OPEN --> HALF_OPEN : cooldown elapsed (default 30s)<br/>first caller takes the single probe lock
+    HALF_OPEN --> CLOSED : probe success (first valid chunk)
+    HALF_OPEN --> OPEN : probe failure
+    note right of HALF_OPEN
+        Only ONE probe in flight; all other
+        callers SKIP. An abort releases the
+        probe lock without changing state.
+    end note
+```
+
+Two principles encoded here: **success is recorded at the first valid chunk**
+(so a request that streams then dies mid-way still healed the breaker), and a
+**client disconnect is never a provider fault** — it returns 499, terminates the
+chain, and does not trip the breaker.
+
+---
+
+## 9. Protocol translation & the IR hub
+
+Every protocol meets in the middle. There is no direct A→B path: each side maps
+to/from one internal representation, so any client reaches any backend with a
+consistent output shape — streaming included. See
+[05 Protocol Translation](05-protocol-translation.md).
+
+```mermaid
+flowchart LR
+    subgraph clientside["Client wire (in)"]
+        I1["OpenAI Chat"]
+        I2["Anthropic Messages"]
+        I3["OpenAI Responses"]
+        I4["Google Gemini"]
+    end
+    IR{{"IR — InternalRequest / IRResponse<br/>OpenAI-shaped skeleton · provider_raw passthrough bag<br/>· reasoning carried in two parallel shapes"}}
+    subgraph provside["Provider wire (out)"]
+        O1["OpenAI-compatible"]
+        O2["Anthropic native"]
+        O3["Gemini native"]
+    end
+
+    I1 & I2 & I3 & I4 -->|transformRequestOut| IR
+    IR -->|"transformRequestIn (+ guards: cap n>1, data_loss warnings)"| O1 & O2 & O3
+    O1 & O2 & O3 -->|transformResponseIn| IR
+    IR -->|transformResponseOut| I1 & I2 & I3 & I4
+```
+
+Streaming is **never** raw passthrough: each direction has an explicit per-protocol
+SSE state machine, with `safeEnqueue`/`safeClose` guards and usage buffered until
+the terminal event. A cache hit or a non-streaming upstream is exploded into a
+deterministic SSE byte stream (`synthesizeSSE`) the client can't distinguish from
+a live one. Unknown upstream fields ride along losslessly in `provider_raw` and
+are stripped from the client-facing body.
+
+---
+
+## 10. Memory middleware
+
+On by default; opt out per key or per request (`x-memory-mode: off`). Two halves:
+a synchronous **inject** on the request path, and an asynchronous **background
+worker** that compresses and consolidates. See [08 Memory Middleware](08-memory-middleware.md)
+and [12 Forgetting & Tiering](12-memory-forgetting-and-tiering.md).
+
+**Request path — inject (fail-open throughout):**
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant GW as Gateway
+    participant Ob as observeInbound
+    participant As as assembleInjectedContext
+    participant Br as inject-bridge
+    GW->>Ob: persist user/assistant/tool turns (if mode ≠ off, thread present)
+    GW->>As: load project + resource reflections + thread observations
+    Note over As: window-aware dedup — drop observations whose<br/>covered turns are all still in the live window
+    As->>As: budget-trim (oldest-first, or lowest-score-first if forgetting on)
+    As-->>Br: memory block (or null)
+    Br->>GW: append ONE trailing user turn (a system-reminder block)
+    Note over Br: leading system prompt untouched, prompt cache prefix preserved
+```
+
+**Background worker — formation, consolidation, forgetting:**
+
+```mermaid
+flowchart TD
+    T["worker tick (unref'd interval)"] --> K["claimPendingJobs(batch)"]
+    T --> H["onTick: enqueue idle-observer + decay jobs"]
+    K --> J{"job type"}
+    J -- "observer" --> O["compress uncovered message segments → observation<br/>(auto-adaptive compaction · AUTO_PRIORS from catalog)"]
+    J -- "reflector" --> R["merge observations → reflection (cross-thread)<br/>· optional extractFacts"]
+    J -- "decay" --> D["score active observations · archive sub-threshold<br/>(gated on forgetting.enabled)"]
+    O -->|"wrote new obs & has project/resource scope"| R
+    D --> RB["re-enqueue affected reflections"]
+
+    subgraph llm["summarize / merge / extractFacts"]
+        S1["deterministic stubs (DEFAULT + fail-open fallback)"]
+        S2["optional LLM path — config.memory.llm.enabled (default off)"]
+    end
+    O -.uses.-> llm
+    R -.uses.-> llm
+```
+
+The summarize/merge/fact-extraction steps are injected interfaces. The default
+is a deterministic concatenate/truncate; an **opt-in** LLM path
+(`config.memory.llm`, default off) calls a small model and falls back to the
+deterministic output on any failure. Idle-flush (baseline memory formation) runs
+for everyone; only decay and retention are gated behind `forgetting.enabled`.
+
+---
+
+## 11. OAuth subscription pool
+
+A provider can authenticate with an OAuth **subscription** instead of a static
+key. Helm pools several accounts per provider, refreshes tokens non-interactively,
+and hot-reloads every change. See [06 Auth](06-auth-and-rate-limits.md).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as Operator
+    participant AD as Admin API
+    participant TS as OAuthTokenStore (encrypted)
+    participant Pool as Account Pool
+    participant TM as TokenManager
+    participant Up as Upstream
+
+    Op->>AD: Connect (manual-paste code · or device-code poll)
+    AD->>TS: store rotating refresh token (encrypted at rest)
+    Note over Op,AD: per account: model allow-list · egress proxy · schedule — all hot-reloaded
+
+    rect rgb(238,245,255)
+    Note over Pool,Up: per request
+    Pool->>Pool: select account — priority asc, then round-robin (LRU)
+    Pool->>TM: ensure fresh access token
+    TM->>TS: load token, refresh if expired (serialized across instances)
+    TS-->>TM: access token
+    TM-->>Pool: Bearer
+    Pool->>Up: request via the account's proxy + stable device identity
+    end
+```
+
+Account selection honors `priority` (lower serves first) with round-robin within
+a tier; a "parked" account stays connected but out of rotation. A removed model
+stops routing immediately (the allow-list is live, not a display filter). An
+*unconnected* subscription alias referenced by a lane **fails open** — Helm skips
+to the next fallback rather than erroring.
+
+> ⚠️ Routing a Claude/ChatGPT/Copilot subscription through a third-party gateway
+> may violate the provider's ToS. Opt-in, self-hosted, your responsibility.
+
+---
+
+## 12. Observability & storage
+
+Every request yields a redacted `DecisionRecord`; optionally, the verbatim
+request/response payloads are captured to a **separate** table for debugging and
+the editable Retry button. Storage hides behind Store ports so SQLite and
+Postgres are interchangeable. See [07 Observability](07-observability.md).
+
+```mermaid
+flowchart LR
+    REQ["served request"] --> BD["buildDecisionRecord<br/>classifier · policy · lane · every attempt · cost · latency"]
+    BD --> RD["redact() — keys matching api_key/authorization/secret/token<br/>fingerprinted; numbers pass through"]
+    RD --> WQ["writeQueue (batched, 25ms flush)"]
+    REQ -->|"if capture_payloads (runtime setting, default on)"| PL["request_payloads — VERBATIM, not redacted"]
+    PL --> WQ
+    WQ --> PORTS{{"Store ports:<br/>KeyStore · TelemetryStore · ConfigStore<br/>MemoryStore · OAuth*Store · …"}}
+    PORTS --> SQ["sqlite adapter (Drizzle)"]
+    PORTS --> PG["postgres adapter (Drizzle)"]
+    PL -.->|"payload_retention_days (default 30)"| PRUNE["opportunistic prune"]
+
+    ADM["Admin / requests UI"] -->|paginated query| TELE["TelemetryStore"]
+```
+
+The redacted `DecisionRecord` (no request body) is defense-in-depth: API keys
+are stored only as SHA-256 hashes, and the bearer never appears in telemetry or
+logs. The verbatim payload table is the one place full bodies live — guarded by
+a runtime toggle and an automatic retention sweep.
+
+---
+
+## Where to go next
+
+- Prose architecture & the internal request/decision shapes → [02 Architecture](02-architecture.md)
+- The rule engine and eval cache → [03 Classification](03-classification.md)
+- Lane/policy semantics and the model-alias shim → [04 Routing & Lanes](04-routing-and-lanes.md)
+- SSE event mapping and the IR contract → [05 Protocol Translation](05-protocol-translation.md)
+- Keys, caps, OAuth pooling → [06 Auth & Rate Limits](06-auth-and-rate-limits.md)
+- The memory subsystem → [08](08-memory-middleware.md) · [12](12-memory-forgetting-and-tiering.md)
+- Deploying it → [10 Deployment](10-deployment.md)

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -26,10 +26,13 @@ all four streaming-capable:
 | OpenAI Responses | `POST /v1/responses` | `openai-responses` | `Authorization: Bearer` |
 | Google Gemini | `POST /v1beta/models/{model}:generateContent` (+ `:streamGenerateContent?alt=sse`) | `gemini` | `x-goog-api-key` |
 
-Gemini is mounted as a catch-all `POST /v1beta/models/:rest{.+}`; any operation
-other than `generateContent` / `streamGenerateContent` returns 404 in the native
-Gemini error shape. The Gemini and Responses faces authenticate **inside** the
-handler so they can emit their own native error envelopes.
+Gemini is mounted as catch-alls under both `POST /v1beta/models/:rest{.+}` and
+`POST /models/:rest{.+}`. `generateContent` / `streamGenerateContent` run the
+full pipeline; `countTokens` returns a Gemini-shaped count (provider-native or a
+deterministic local estimate, the latter flagged `estimated: true`); any other
+operation returns 404 in the native Gemini error shape. The Gemini and Responses
+faces authenticate **inside** the handler so they can emit their own native error
+envelopes.
 
 ---
 
@@ -100,9 +103,12 @@ Notes (only what the table can't show):
   targets honor multiple candidates: OpenAI Chat and Responses pass `n` through,
   Gemini maps it to `candidateCount`.
 - **Remote `http(s)` images → Gemini output.** Gemini's request shape wants
-  inline base64 or a `gs://` / Files-API URI; an arbitrary remote image URL
-  degrades to an explicit text placeholder (issue #49 non-goal). Inline base64
-  images round-trip cleanly.
+  inline base64 or a `gs://` / Files-API URI. By default an arbitrary remote
+  image URL degrades to an explicit text placeholder — the pure core transformer
+  does no network I/O. An optional, default-off provider-layer media materializer
+  (`materializeGeminiRemoteMediaBody`, config-gated by `remoteMediaFetch` and
+  SSRF-guarded via `assertPublicHttpsTarget`) can fetch the `https` image into
+  `inlineData` when enabled. Inline base64 images round-trip cleanly.
 - **Responses statefulness → others.** `store` / `previous_response_id` describe
   a server-side conversation that other protocols don't model; they ride
   `provider_raw` so a Responses→Responses round-trip is lossless, but they are
@@ -151,9 +157,13 @@ thinking knob. The band values differ per target:
 | effort | Anthropic (thinking budget) | Gemini (`thinkingConfig`) |
 |---|---|---|
 | minimal | 1024 | 128 |
-| low | 2048 | 1024 |
-| medium | 8192 | 8192 |
-| high | 16384 | 24576 |
+| low | 1024 | 1024 |
+| medium | 2048 | 8192 |
+| high | 4096 | 24576 |
+
+The Anthropic column is exact litellm parity (`minimal`/`low` both floor at 1024,
+`medium` 2048, `high` 4096); the extended tiers `xhigh` → 8192 and `max` → 16384
+continue above the four standard bands.
 
 Anthropic Messages also defaults `max_tokens` to **4096** when the client omits
 it (the field is required upstream but optional on the Helm face).
@@ -213,6 +223,8 @@ provider-execution (OAuth) concern, not protocol-translation `provider_raw`.
 
 Field coverage is asserted path-by-path against the litellm reference in
 `protocol-matrix.test.ts`. The remaining gaps are provider-specific edges —
-litellm's Vertex-only fields, true Responses session continuation, and
-remote-image fetch on the Gemini output path — each a documented non-goal above,
-not a silent loss.
+litellm's Vertex-only fields and true Responses session continuation — each a
+documented non-goal above, not a silent loss. Remote-image fetch on the Gemini
+output path is no longer unconditional: it degrades to a text placeholder by
+default but can be materialized into `inlineData` by the optional, default-off
+provider-layer `remoteMediaFetch` materializer (SSRF-guarded).

--- a/docs/protocol-translation-litellm-gap-spec.md
+++ b/docs/protocol-translation-litellm-gap-spec.md
@@ -10,7 +10,7 @@
 - Google Gemini GenerateContent
 
 
-状态说明：本文是完整缺口 backlog 和验收规格；证据索引中的“现状”来自本轮分析时的快照。首个实施 PR 先覆盖低风险高收益子集：P1-RESP-03、P1-ANT-01、P1-ANT-02，以及 P1-CHAT-02 的 OpenAI-compatible `cache_control` 清理。其他 P1/P2 项仍按本文实施顺序继续推进。
+状态说明：本文是完整缺口 backlog 和验收规格；证据索引和第 3 节各项的“现状”块来自本轮分析时的快照，不一定反映当前代码。截至目前，全部 P1 项（P1-RESP-01/02/03、P1-ANT-01/02、P1-CHAT-02、P1-GEM-01/02/03）以及本文列出的大部分 P2 项（P2-GEM-01/02、P2-RESP-03/04、P2-ANT-01、P2-CHAT-03/04）均已落地，并由 `scripts/protocol-compat/ast-grep-gates.sh`（经 `pnpm test:protocol-compat:ast` 调用）正向门禁强制保证实现存在。真正仍未实现的剩余项是 P3（P3-ANT-02 thinking-signature retry、P3-RESP-06 WebSocket）以及第 4 节明确声明的非目标。
 
 相关实现已经整理到 wiki：
 
@@ -325,11 +325,11 @@ LiteLLM 支持较新的 Google GenAI `response_json_schema` / `responseJsonSchem
 - `response_json_schema` SDK-shape 输入不丢。
 - outbound profile 测试证明字段名可配置。
 
-### P2-ANT-03：Anthropic 响应不能暴露内部 `provider_raw`
+### P2-ANT-03：Anthropic 响应不能暴露内部 `provider_raw`（已解决）
 
 **现状**
 
-Helm 的 Anthropic response schema 允许 `provider_raw`，`transformResponseOut()` 也会把 raw stop reason、usage、tool-name map 放入响应 body。
+已解决：客户端可见的 Anthropic response body 不再暴露 `provider_raw`。`packages/core/src/protocol/anthropic/response.ts:410` 的注释明确说明 the public Anthropic response body never exposes provider_raw；raw stop reason、usage、tool-name map 仅存在于 IR/telemetry 路径，不进入客户端响应 body。下文保留为最初分析快照与验收口径。
 
 **问题**
 


### PR DESCRIPTION
## What & why

A full documentation audit against the **shipping code (v0.13.3)**. Every module was scanned and every doc fact-checked; this PR corrects the drift, rewrites both READMEs to current truth, and adds a diagram-rich architecture document.

## Doc corrections (22 verified discrepancies)

- **Memory LLM path** — summarization is now **opt-in shipped** (`config.memory.llm`, default off, deterministic fallback), not a "deferred stub" as docs 08/09/12 claimed.
- **Anthropic reasoning-budget table** — fixed stale over-budgeted values; now matches the litellm-parity mapping (docs 05 + `protocol-compatibility`).
- **Model-alias → lane compatibility shim** — documented the priority-0 rewrite path and the 9 vendor-family lanes (16 lanes total); corrected `supports_json_schema` → `supportsJsonMode` (docs 04).
- **Gemini** — `:countTokens` is served (not 404), `/models/*` is mounted, `alt=sse` isn't required for streaming (docs 05 + `protocol-compatibility`).
- Plus: admin-mount condition, config-file inventory (`model-aliases.yaml`), Retry-all-protocols, `extractFactsDeterministic` symbol/location, litellm-gap completion status, observation status enum, remote-media materializer, version banner.

## New + rewritten

- **`docs/architecture.md` (new)** — 13 Mermaid sequence/flow/state diagrams: component map, request lifecycle, fail-closed boot, the two failure disciplines, classification cascade, routing + model-alias shim, execution + circuit-breaker state machine, IR translation hub, memory inject + worker, OAuth pool, storage/telemetry.
- **`README.md` / `README.zh-CN.md`** — rewritten to current truth: drift-proof version badge, opt-in memory LLM, the compatibility shim, refreshed text architecture diagram. Chinese is idiomatic (意译).

## Verification

- All 13 Mermaid diagrams **render-validated in a real browser** (Mermaid 11) — the first pass caught 2 genuine parse errors, since fixed; 13/13 pass.
- Grep-confirmed every stale value is removed. Docs/README only — **no code changed**.

## Out of scope (flagged for follow-up)

- `packages/shared/src/version.ts` hardcodes `'0.0.0'`, so `GET /version` is wrong regardless of release.
- `config/providers.yaml` / `lanes.yaml` comments still say `supports_json_schema` (real field: `supportsJsonMode`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)