### PR TITLE
fix: five bugs from the architecture review (routing, Anthropic stream, client_abort)

### DIFF
--- a/apps/admin/src/lib/api/policies.test.ts
+++ b/apps/admin/src/lib/api/policies.test.ts
@@ -65,7 +65,7 @@ describe('policies api client', () => {
 
   it('savePolicies PUTs /admin/api/policies with the ordered list as the body', async () => {
     const list: Policy[] = [
-      { match: { user_id: 'u1' }, use_lane: 'premium' },
+      { match: { task_type: 'coding' }, use_lane: 'premium' },
       { match: { needs_json: true }, max_lane: 'balanced' },
     ];
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
@@ -81,7 +81,7 @@ describe('policies api client', () => {
     expect(Array.isArray(body)).toBe(true);
     expect(body).toHaveLength(2);
     // order preserved (= priority)
-    expect(body[0].match.user_id).toBe('u1');
+    expect(body[0].match.task_type).toBe('coding');
     expect(body[1].match.needs_json).toBe(true);
   });
 

--- a/apps/admin/src/lib/api/policies.ts
+++ b/apps/admin/src/lib/api/policies.ts
@@ -11,8 +11,8 @@ export interface PolicyMatch {
   task_type?: string; // enum: docs/03 task_type set (TASK_TYPE_OPTIONS)
   complexity?: string; // enum: server PolicyMatchSchema set (COMPLEXITY_OPTIONS)
   needs_json?: boolean;
-  user_id?: string;
-  org_id?: string;
+  // NOTE: no org_id / user_id — routing has no org/user scope (per-key limits live
+  // on the API key, not in policies). The server PolicyMatchSchema rejects them.
 }
 
 export interface Policy {
@@ -66,8 +66,6 @@ function normalizeMatch(raw: Record<string, unknown> | undefined): PolicyMatch {
   if (typeof m.task_type === 'string') out.task_type = m.task_type;
   if (typeof m.complexity === 'string') out.complexity = m.complexity;
   if (typeof m.needs_json === 'boolean') out.needs_json = m.needs_json;
-  if (typeof m.user_id === 'string') out.user_id = m.user_id;
-  if (typeof m.org_id === 'string') out.org_id = m.org_id;
   return out;
 }
 
@@ -89,8 +87,6 @@ function toServerBody(p: Policy): Record<string, unknown> {
   if (p.match.task_type) match.task_type = p.match.task_type;
   if (p.match.complexity) match.complexity = p.match.complexity;
   if (p.match.needs_json === true) match.needs_json = true;
-  if (p.match.user_id) match.user_id = p.match.user_id;
-  if (p.match.org_id) match.org_id = p.match.org_id;
 
   const out: Record<string, unknown> = { match };
   if (p.id) out.id = p.id;

--- a/apps/admin/src/lib/components/PolicyRow.svelte
+++ b/apps/admin/src/lib/components/PolicyRow.svelte
@@ -155,26 +155,6 @@
           {/each}
         </select>
       </label>
-
-      <label class="field">
-        <span class="field-label">{$t('User ID')}</span>
-        <input
-          class="input"
-          value={match.user_id ?? ''}
-          oninput={(e) => emitMatch({ user_id: e.currentTarget.value })}
-        />
-        <span class="field-help">{$t('Match a single end-user by their ID.')}</span>
-      </label>
-
-      <label class="field">
-        <span class="field-label">{$t('Organization ID')}</span>
-        <input
-          class="input"
-          value={match.org_id ?? ''}
-          oninput={(e) => emitMatch({ org_id: e.currentTarget.value })}
-        />
-        <span class="field-help">{$t('Match every request from one organization.')}</span>
-      </label>
     </div>
 
     <label class="checkbox-field items-start">

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -404,7 +404,7 @@ describe("admin.api policies", () => {
     const app = buildApp(deps);
     const policies = [
       { match: { task_type: "coding" }, use_lane: "premium" },
-      { match: { org_id: "acme" }, max_lane: "balanced" },
+      { match: { complexity: "complex" }, max_lane: "balanced" },
     ];
     const put = await app.request("/admin/api/policies", {
       method: "PUT",

--- a/config/policies.yaml
+++ b/config/policies.yaml
@@ -85,9 +85,8 @@ policies:
       complexity: complex
     use_lane: premium
 
-  # Example cost cap: a budget org is never routed above `balanced` (caps-only;
-  # the lane is still chosen by classification, just clamped). Illustrative.
-  - id: budget_org_cap
-    match:
-      org_id: budget_org
-    max_lane: balanced
+  # NOTE on usage / cost limits: there is no org/user policy dimension. Per-key
+  # limits (RPM/TPM, usage budget, allowed_lanes, max-concurrency) live on the API
+  # KEY itself (docs/06), not in policies. A caps-only policy here can still clamp
+  # ALL traffic by lane — e.g. an unconstrained `max_lane: balanced` (empty match)
+  # caps everything — but it cannot target an org or user.

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -21,7 +21,7 @@ The unified internal error (`HelmError`, single source of truth in
 {
   error_class: "auth_error" | "invalid_request" | "lane_unavailable"
              | "all_providers_failed" | "capability_unsatisfiable"
-             | "upstream_error" | "timeout" | "rate_limited",
+             | "upstream_error" | "timeout" | "rate_limited" | "client_abort",
   http_status: number,                          // mapped from error_class (see below)
   message: string,                              // redacted, human-readable
   trace_id: string,                             // links the decision record; restorable in the Debug UI
@@ -43,6 +43,7 @@ callers cannot supply a mismatched status:
 | `upstream_error` | 502 | An upstream provider returned an error |
 | `timeout` | 504 | Timed out |
 | `rate_limited` | 429 | Rate limit tripped |
+| `client_abort` | 499 | Client disconnected mid-request (not a provider fault); the executor stops the chain and records this instead of `upstream_error` |
 
 Per **Principle 7**, `message` and `provider_raw` must already be redacted by the
 producer. The Protocol Adapter's response-out stage translates this unified error

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,17 @@
 
 ---
 
+## 2026-06-15 · 双人 code review 修复：org/user 策略拆除 + Anthropic 空流 + applyCaps + client_abort（docs/02/04/05/07；原则 3/5/7/8）
+
+- **背景**：文档审计后用户要求对架构做真实 bug review（我 + Codex 各一遍，对抗式合并）。覆盖互补：我审路由/执行/鉴权，Codex 审协议/流式（其 run 未出最终报告，关键发现从执行日志捞出并复核）。确认 2 bug + 1 设计问题 + 2 小问题，用户拍板全修。
+- **#1〔major〕org/user 维度策略形同虚设——拆除（非接通）**：`auth.ts` 把 `orgId/userId` 写死 null（`ApiKeyRecord` 无该列可填），IR 的 `org_id/user_id` 取自此身份恒 null → 任何 `match:{org_id|user_id}` 策略**永不命中**，出厂示例 `budget_org_cap` 是死代码。用户「只按 API key 限用量，不需要 org/user 路由」→ 从 `PolicyMatchSchema`/`PolicyContext`/`MATCH_FIELDS`/两 context builder 删 org_id/user_id（schema `.strict()` 使遗留策略 fail-closed 拒启动而非静默不匹配），删 policies.yaml 示例，admin 策略编辑器（`PolicyRow.svelte` + `policies.ts` 类型/序列化）同步删 User/Org ID 输入。`project_id` 保留（已文档化的未接通占位）。IR 的 org_id/user_id 字段暂留（大量测试 fixture 在用，无害死字段，可后续清）。
+- **#2〔major，Codex 发现〕Anthropic 出站空流缺 message_start**：`convertOpenAIStreamToAnthropic` 的 message_start 在 for-await 内懒发，**零 chunk 流**跳过循环 → 收尾无条件发 message_delta/message_stop，客户端收到无 message_start 的非法 Anthropic 序列。修：收尾前加 `if(!messageStarted) yield messageStartEvent(...)` 守卫。
+- **#3〔medium〕applyCaps 把不可排序候选顶到最贵 allowed lane**：task/厂商家族 lane（rank=+∞）不在 allowed_lanes 时挑「最高 ≤ +∞」=最强（premium）。用户拍板回退 balanced：候选 rank 缺省改 `UNRANKED_CANDIDATE_RANK = LANE_RANK.balanced`，向 balanced 降级而非升 premium。
+- **#4〔minor〕client abort 被标 upstream_error**：fallback 终止链时 final.error_class=`upstream_error`，污染上游故障指标。新增 `client_abort`(499) ErrorClass（enum + 状态映射 anthropic `api_error`/gemini `CANCELLED`/openai `api_error` + docs/07 表 + 测试 EXPECTED），fallback.ts abort 路改用之。
+- **#5〔edge〕aliasPolicyContext 写死 complexity:"medium"**：会被 `complexity:medium` 单字段策略误命中（别名请求未分类）。`PolicyContext.complexity` 改 `…|null`，别名 context 设 null（不匹配任何 complexity 策略）。
+- **取舍/坑/TODO**：① #1 选「拆除」而非「接通 org/user」（用户明确不需要）；IR 字段暂留以不动 IR schema 的大量 fixture。② client_abort 用非标 499（gateway onError 早已用）；客户端已断时 body 多半送不达，价值在 telemetry 准确。③ 审过干净（无改）：熔断器状态机/单探针、fallback 顺序/abort/`:free`-429/空链 vs 耗尽链、expand-chain 防环去重、连接重试 abort-safe、鉴权拒禁用 key、（Codex）流式 usage 末尾缓冲与 tool-index 映射。
+- **验证**：TDD 新增回归（空流→`[message_start,message_delta,message_stop]`、不可排序候选→balanced、abort→client_abort/499、org_id/user_id 策略 fail-closed）+ 改写受影响 fixture（policy-engine/policy-matrix/route-request/admin.test/admin policies/两处 policy-schema）。`pnpm typecheck`（shared/core/gateway）+ `pnpm lint` + 全量 **3737 测试** + admin `svelte-check` 0 错 全绿。分支 `fix/review-routing-stream-errors`。
+
 ## 2026-06-15 · 订阅 OAuth 轮换 refresh token 跨实例竞争修复 + 刷新状态码透传（docs/06；原则 1/3/7）
 
 - **背景**：la.atmy.work 上 anthropic 订阅请求报 `oauth refresh failed (anthropic)`（155ms→上游快速 4xx，几乎确定 invalid_grant），fail-open 已正确回退 gpt-5.5。用户疑「token 没提前刷新」。排查：刷新其实**已 ~6min 提前**（parseTokenCredentials `REFRESH_SKEW_MS` 5min + token-manager skew 60s），失败的是**刷新调用本身被拒**。真因：同一 (provider, account) 被建了 **5+ 个独立 TokenManager**（executor / 模型发现 / providers 页 `ensureFresh` 并发刷新 / Anthropic 配额 / 连通性测试），各自内存缓存但共用 store 里**同一个单次性轮换 refresh token**，无跨实例协调 → 两个并发刷新→第二个重放已消费 token→Anthropic invalid_grant 并常**作废整个 token 家族** → 永久失效需重登（in-process single-flight 看不到兄弟实例）。
@@ -22,18 +33,13 @@
 - **取舍/坑/TODO**：① 慢首包（首 token 耗时 > 代理 read-timeout，如推理模型）**未在 helm 侧覆盖**——若复现优先核对 nginx/haproxy/CF 超时，或后续再评估 early-commit（会把流式错误从干净 502/504 变成 in-band `event:error` 帧）。② 心跳默认 15s 远低于 nginx 60s/CF ~100s；运营者按前置代理调 `HELM_SSE_HEARTBEAT_MS`。③ schema 改了须重建 `@helm/shared`。
 - **验证**：TDD 红→绿——`retry.test.ts`(25) + `heartbeat.test.ts`(7, 含边界/disabled/error/early-return) + 三 client wiring + chat 路由 `:\n\n` 端到端集成（断言数据帧逐字 + 心跳非 data 事件）。provider 208 / 路由+schema 全绿，`pnpm typecheck`、`pnpm lint`、`pnpm build` 绿。分支 `fix/upstream-transient-retry-sse-heartbeat`。
 
-## 2026-06-14 · Admin 管理界面移动端/响应式走查 + 修复（docs/10/11；原则 1）
-
-- **背景**：用户要求对 admin 全部 9 个页面做移动端/PC 走查（Playwright 截图三视口：iPhone 12 Pro 390×844 / iPad mini 768×1024 / 桌面 1920×1080），找出不合理处并修，移动端必须方便触控。流程：先把本地 main 重新构建部署到 Docker（localhost:8080）→ 截 29 张图（含移动 nav drawer、New key 弹层）→ Workflow 扇出 10 个 reviewer（每页读截图+源码）→ 对抗式验证 → 综合，25 处真实问题归并为 12 条（1 blocker / 3 major / 6 minor / 2 polish）。控制台零报错。
-- **核心修复（全在 `apps/admin`，CSS/Tailwind 为主）**：① **宽表→卡片**（Providers 10 列=blocker、API Keys 9 列）：新增 `.cards-table` / `.cards-table-frame` 配方——`<lg` 每行 reflow 成带框卡片、每格变「label/value」(label 由 `data-label` 经 CSS `::before` 注入)，`lg+` 仍是普通表（含横向滚动框）。② Requests/Dashboard 表首列 UUID 加 `block max-w-[7rem] truncate lg:max-w-none`（移动端不再霸屏，整行仍可点进详情）。③ 触控目标：`btn-icon` `h-7→h-10 md:h-7`，`btn-primary/secondary/success/danger/danger-outline` 配方加 `min-h-11 md:min-h-0`，hamburger 44px，RangeFilter/RefreshControl/settings 输入与 select 同补。④ 768px 挤压：dashboard 统计网格、requests 图例、settings 多字段队列行从 `md/sm` 推迟到 `lg`（rate-limit 行留 `sm`）。⑤ a11y：健康点文字 `sr-only sm:not-sr-only`、wrapper title 改 live healthLabel。⑥ 其它：classifier eval-details `grid-cols-2→[max-content_1fr]` + Layer-2 toggle 行 44px、policies 保存条移动端 `sticky bottom-0`、request-detail trace chip `basis-full md:basis-auto`、JsonTree summary / FullscreenToggle 触控。
-- **关键决定（CSS reflow 而非双 DOM 卡片）**：用户选「Providers+Keys 都用卡片」。但 `hidden lg:block`+`lg:hidden` 会让表与卡片**同时**留在 DOM（jsdom 不跑 CSS、testing-library 不看 display），`keys.test.ts`(20) / `providers.test.ts` 大量 `getByTestId('key-row')` 单行断言 + 全局 `getByText(prefix)` 会因重复而全红。故改为**单 `<tr>` 卡片化 reflow**（CSS 改 display + `::before` 注 label，`data-label` 上 `<td>`，`<tr>` 去掉 `.table-row`，外层换 `.cards-table-frame`）：每记录 DOM 仍只一行 → 单元测试 + 屏幕阅读器零改即过，移动端同时呈现真卡片、无横向滚动、操作全可触达。
-- **验证**：admin `pnpm build` 绿、vitest **364 全绿**（含 keys/providers reflow 后）、Biome lint 绿、svelte-check 仅剩既有 `oauth.test.ts` 3 报错（非回归，与 origin/main 逐字相同、admin 不在 `-r typecheck` 门禁）。Docker 从 worktree 源构建 `:latest` 重新部署后用 Playwright 三视口复测对比。分支 `worktree-admin-mobile-ui`（git worktree，已 rebase 到 main）。截图存 `ui-review/{iphone12pro,ipadmini,desktop}/`，PR #255。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-14 · Admin 移动端/响应式走查 + 修复（docs/10/11；原则 1）：Playwright 三视口截 29 图 + Workflow 扇出 10 reviewer，25 处归并 12 修复。核心：宽表（Providers 10 列/Keys 9 列）→ CSS reflow 单 `<tr>` 卡片化（`.cards-table` + `::before` 注 `data-label`，避免双 DOM 让 vitest 单行断言全红）、UUID 首列 truncate、触控 44px（btn-* `min-h-11 md:min-h-0`/hamburger）、768px 网格推迟 lg、a11y 健康点 sr-only。admin build/vitest 364/lint 绿、svelte-check 仅既有 oauth.test.ts 3 报错（非回归）。分支 worktree-admin-mobile-ui，PR #255。
 
 ### 2026-06-14 · 协议互译剩余项 PR review 修复（review of fix/protocol-litellm-remaining；原则 2/3/7）：修 Gemini native passthrough 计费/记忆漏洞（usage 改三路协议分支 + observeOutbound，默认 config 无 gemini provider 故不触发）、远程媒体 SSRF 加固（`assertPublicHttpsTarget` 拒私有/保留/元数据 IP + DNS pin 防 rebinding、独立 `mediaFetch` 钉死已校验地址）、Generic Responses→Chat 桥补 `tool_calls`；Codex review round2 再修 Gemini 翻译路径（transformer 组合双向译，不再恒 throw）、静态 key 脱敏、媒体边读边限、401 重建头、registry 有界 LRU。TDD changed-area 全绿。
 

--- a/packages/core/src/executor/fallback.test.ts
+++ b/packages/core/src/executor/fallback.test.ts
@@ -250,9 +250,11 @@ describe("runFallback", () => {
     expect(breaker.recordFailure).not.toHaveBeenCalled();
     // abort terminates the chain: fallback is NOT attempted.
     expect(invoke).toHaveBeenCalledTimes(1);
-    // not all_providers_failed — abort is not a provider fault.
+    // not all_providers_failed — abort is its own client_abort class (499), so
+    // telemetry never miscounts a disconnect as an upstream fault (review fix #4).
     if (out.final.status === "error") {
-      expect(out.final.error.error_class).not.toBe("all_providers_failed");
+      expect(out.final.error.error_class).toBe("client_abort");
+      expect(out.final.error.http_status).toBe(499);
     }
   });
 

--- a/packages/core/src/executor/fallback.ts
+++ b/packages/core/src/executor/fallback.ts
@@ -276,7 +276,9 @@ export async function runFallback(
           final: {
             status: "error",
             error: makeHelmError({
-              error_class: "upstream_error",
+              // Client disconnect — a dedicated class (499) so telemetry never
+              // counts it as an upstream provider fault (docs/02, docs/07).
+              error_class: "client_abort",
               message: "client aborted request",
               trace_id: req.request_id,
             }),

--- a/packages/core/src/protocol/anthropic/error.ts
+++ b/packages/core/src/protocol/anthropic/error.ts
@@ -24,6 +24,7 @@ const ANTHROPIC_ERROR_TYPE: Record<ErrorClass, string> = {
   upstream_error: "api_error",
   timeout: "api_error",
   rate_limited: "rate_limit_error",
+  client_abort: "api_error", // client disconnected; body is rarely delivered
 };
 
 export interface AnthropicErrorEnvelope {

--- a/packages/core/src/protocol/anthropic/stream.test.ts
+++ b/packages/core/src/protocol/anthropic/stream.test.ts
@@ -106,6 +106,21 @@ describe("convertOpenAIStreamToAnthropic — text event sequence", () => {
       expect(start.message.model).toBe("gpt-5.5");
     }
   });
+
+  it("empty upstream stream still leads with message_start (no orphan message_delta)", async () => {
+    // A zero-chunk stream never enters the per-chunk loop, so message_start (lazy)
+    // would be skipped — the finalize-time guard emits it so the client never sees
+    // a message_delta / message_stop without a message_start (review fix #2).
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(feed([]), { id: "req-9", model: "gpt-5.5" }),
+    );
+    expect(events.map((e) => e.type)).toEqual(["message_start", "message_delta", "message_stop"]);
+    const start = nth(events, 0);
+    if (start.type === "message_start") {
+      expect(start.message.id).toBe("msg_req-9");
+      expect(start.message.model).toBe("gpt-5.5");
+    }
+  });
 });
 
 // —— 2. parallel tool-call streaming ——————————————————————————————————————————

--- a/packages/core/src/protocol/anthropic/stream.ts
+++ b/packages/core/src/protocol/anthropic/stream.ts
@@ -504,6 +504,19 @@ export async function* convertOpenAIStreamToAnthropic(
     if (choice?.finish_reason != null) state.finishReason = choice.finish_reason;
   }
 
+  // Empty upstream stream (zero chunks): message_start is emitted lazily on the
+  // first chunk, so it was never sent. The Anthropic SSE contract requires it
+  // before any message_delta / message_stop — emit a skeleton start now so an
+  // empty completion still yields a valid event sequence (never an orphan
+  // message_delta a client would reject).
+  if (!state.messageStarted) {
+    state.messageStarted = true;
+    yield messageStartEvent({
+      id: nonEmptyString(options.id),
+      model: nonEmptyString(options.model),
+    });
+  }
+
   // —— Stream end: flush any tool block that never saw an argument fragment, close
   // every open block exactly once, then the terminal events. ——
   for (const slot of state.toolIndexToBlock.values()) {

--- a/packages/core/src/protocol/gemini/error.ts
+++ b/packages/core/src/protocol/gemini/error.ts
@@ -25,6 +25,7 @@ const GEMINI_ERROR_STATUS: Record<ErrorClass, string> = {
   upstream_error: "INTERNAL",
   timeout: "DEADLINE_EXCEEDED",
   rate_limited: "RESOURCE_EXHAUSTED",
+  client_abort: "CANCELLED", // google.rpc.Code for a caller-cancelled operation
 };
 
 export interface GeminiErrorEnvelope {

--- a/packages/core/src/protocol/openai-error.ts
+++ b/packages/core/src/protocol/openai-error.ts
@@ -33,6 +33,7 @@ export const OPENAI_ERROR_SHAPE: Record<ErrorClass, { type: string; code: string
   upstream_error: { type: "api_error", code: "upstream_error" },
   timeout: { type: "api_error", code: "timeout" },
   rate_limited: { type: "rate_limit_error", code: "rate_limited" },
+  client_abort: { type: "api_error", code: "client_abort" },
 };
 
 export interface OpenAIErrorEnvelope {

--- a/packages/core/src/routing/policy-engine.test.ts
+++ b/packages/core/src/routing/policy-engine.test.ts
@@ -8,8 +8,6 @@ const baseCtx: PolicyContext = {
   needs_json: false,
   needs_tools: false,
   needs_vision: false,
-  user_id: null,
-  org_id: null,
   project_id: null,
 };
 
@@ -29,14 +27,14 @@ describe("evaluatePolicies — first-match", () => {
   });
 
   it("PINs the first use_lane but ACCUMULATES caps from later matching policies", () => {
-    // First-match wins the PIN (use_lane), but a later matching cap policy
-    // (e.g. the shipped budget_org_cap, placed last) must NOT be discarded.
+    // First-match wins the PIN (use_lane), but a later matching cap-only policy
+    // (e.g. a global max_lane placed last) must NOT be discarded.
     const c = cfg([
-      { id: "chat_complex_to_premium", match: { task_type: "coding" }, use_lane: "premium" },
-      { id: "budget_org_cap", match: { complexity: "complex" }, max_lane: "balanced" },
+      { id: "coding_to_premium", match: { task_type: "coding" }, use_lane: "premium" },
+      { id: "complex_cap", match: { complexity: "complex" }, max_lane: "balanced" },
     ]);
     const out = evaluatePolicies(baseCtx, c);
-    expect(out.matched_policy_id).toBe("chat_complex_to_premium");
+    expect(out.matched_policy_id).toBe("coding_to_premium");
     expect(out.use_lane).toBe("premium");
     // the later cap policy's max_lane is accumulated.
     expect(out.max_lane).toBe("balanced");
@@ -111,22 +109,6 @@ describe("evaluatePolicies — AND semantics", () => {
   });
 });
 
-describe("evaluatePolicies — identity dimensions", () => {
-  it("matches on user_id and surfaces use_lane", () => {
-    const ctx: PolicyContext = { ...baseCtx, user_id: "vip_user" };
-    const c = cfg([{ id: "vip", match: { user_id: "vip_user" }, use_lane: "premium" }]);
-    const out = evaluatePolicies(ctx, c);
-    expect(out.matched_policy_id).toBe("vip");
-    expect(out.use_lane).toBe("premium");
-  });
-
-  it("does not match a different user_id", () => {
-    const ctx: PolicyContext = { ...baseCtx, user_id: "other" };
-    const c = cfg([{ id: "vip", match: { user_id: "vip_user" }, use_lane: "premium" }]);
-    expect(evaluatePolicies(ctx, c).matched_policy_id).toBeNull();
-  });
-});
-
 describe("evaluatePolicies — telemetry / determinism", () => {
   it("synthesizes a policy id from index when id omitted", () => {
     const c = cfg([{ match: { task_type: "coding" }, use_lane: "coding" }]);
@@ -134,11 +116,10 @@ describe("evaluatePolicies — telemetry / determinism", () => {
   });
 
   it("reason mentions the matched id and a triggering field", () => {
-    const c = cfg([{ id: "vip", match: { user_id: "x" }, use_lane: "premium" }]);
-    const ctx: PolicyContext = { ...baseCtx, user_id: "x" };
-    const out = evaluatePolicies(ctx, c);
+    const c = cfg([{ id: "vip", match: { task_type: "coding" }, use_lane: "premium" }]);
+    const out = evaluatePolicies(baseCtx, c);
     expect(out.reason).toContain("vip");
-    expect(out.reason).toContain("user_id");
+    expect(out.reason).toContain("task_type");
   });
 
   it("is deterministic across repeated calls", () => {
@@ -204,6 +185,21 @@ describe("applyCaps — allowed_lanes", () => {
     };
     // candidate economy is below all allowed -> lowest allowed = balanced
     expect(applyCaps("economy", out)).toBe("balanced");
+  });
+
+  it("clamps an unrankable (task/vendor) candidate toward balanced, not the strongest allowed", () => {
+    // review fix #3: a task lane like `coding` (or a vendor-family lane like
+    // `claude-opus`) has no cost rank, so it must degrade to balanced — never
+    // escalate to `premium` just because premium happens to be whitelisted.
+    const out = {
+      matched_policy_id: "p",
+      use_lane: null,
+      max_lane: null,
+      allowed_lanes: ["economy", "balanced", "premium"],
+      reason: "",
+    };
+    expect(applyCaps("coding", out)).toBe("balanced");
+    expect(applyCaps("claude-opus", out)).toBe("balanced");
   });
 });
 

--- a/packages/core/src/routing/policy-engine.ts
+++ b/packages/core/src/routing/policy-engine.ts
@@ -7,16 +7,20 @@ import type { PoliciesConfig, Policy, PolicyMatch } from "./policy-schema.js";
 // consumes `PolicyOutcome`. Explicit and inspectable — no hidden magic scoring
 // (docs/04); telemetry records the single matched policy (docs/02).
 
-// Matching context: classifier result + auth identity (Auth Resolver / internal
-// request shape). All fields present; identity dims are `string | null`.
+// Matching context: classifier result + request shape. All fields present.
+// Routing is matched on task/complexity/capability only — there is intentionally
+// no org/user dimension (per-key caps live on the API key, not in policies).
 export interface PolicyContext {
   task_type: string;
-  complexity: "simple" | "medium" | "complex";
+  // null for an unclassified request (the model-alias passthrough path) so it
+  // matches no complexity-constrained policy.
+  complexity: "simple" | "medium" | "complex" | null;
   needs_json: boolean;
   needs_tools: boolean;
   needs_vision: boolean;
-  user_id: string | null;
-  org_id: string | null;
+  // Memory-scope field (client-controlled via x-project-id), NOT a trusted routing
+  // attribute — always null here (see route-request policyContext) so a caller can
+  // never spoof a project_id policy to change lane/cost.
   project_id: string | null;
 }
 
@@ -39,6 +43,11 @@ export const LANE_RANK: Record<string, number> = {
   premium: 2,
 };
 
+// Cost rank an UNRANKABLE candidate (task / vendor-family lane) is treated as when
+// clamped to an allowed_lanes whitelist — the default `balanced` tier, so it
+// degrades toward balanced instead of escalating to the strongest allowed lane.
+const UNRANKED_CANDIDATE_RANK = LANE_RANK.balanced ?? 1;
+
 const EMPTY_OUTCOME: PolicyOutcome = {
   matched_policy_id: null,
   use_lane: null,
@@ -58,8 +67,6 @@ const MATCH_FIELDS: ReadonlyArray<{
   { key: "needs_json", get: (c) => c.needs_json },
   { key: "needs_tools", get: (c) => c.needs_tools },
   { key: "needs_vision", get: (c) => c.needs_vision },
-  { key: "user_id", get: (c) => c.user_id },
-  { key: "org_id", get: (c) => c.org_id },
   { key: "project_id", get: (c) => c.project_id },
 ];
 
@@ -164,6 +171,10 @@ function lowestRankedLane(lanes: string[]): string {
 //  - allowed_lanes: if the candidate is in the whitelist, keep it; else pick the
 //    highest-ranked allowed lane that is <= the candidate's rank, otherwise the
 //    lowest-ranked allowed lane (never upgrade past what the candidate wanted).
+//    An UNRANKABLE candidate (a task lane like `coding`/`json`, or a vendor-family
+//    lane like `claude-opus`) has no cost rank, so it is clamped as if it asked for
+//    the DEFAULT tier (`balanced`) — degrading toward balanced, never escalating to
+//    the most expensive allowed lane (e.g. `premium`).
 //  - max_lane: if LANE_RANK[lane] > LANE_RANK[max_lane], drop to max_lane. An
 //    unrankable candidate is incomparable => conservatively cap to max_lane.
 export function applyCaps(lane: string, outcome: PolicyOutcome): string {
@@ -173,7 +184,9 @@ export function applyCaps(lane: string, outcome: PolicyOutcome): string {
   if (outcome.allowed_lanes != null && outcome.allowed_lanes.length > 0) {
     const allowed = outcome.allowed_lanes;
     if (!allowed.includes(result)) {
-      const candidateRank = LANE_RANK[result] ?? Number.POSITIVE_INFINITY;
+      // Unrankable (task / vendor-family) candidate => treat as the `balanced`
+      // tier so the clamp degrades toward balanced, not the strongest allowed.
+      const candidateRank = LANE_RANK[result] ?? UNRANKED_CANDIDATE_RANK;
       // Highest-ranked allowed lane whose rank is <= candidate's rank.
       let pick: string | null = null;
       let pickRank = Number.NEGATIVE_INFINITY;

--- a/packages/core/src/routing/policy-matrix.test.ts
+++ b/packages/core/src/routing/policy-matrix.test.ts
@@ -63,8 +63,6 @@ function ctx(over: Partial<PolicyContext> = {}): PolicyContext {
     needs_json: false,
     needs_tools: false,
     needs_vision: false,
-    user_id: null,
-    org_id: null,
     project_id: null,
     ...over,
   };
@@ -81,7 +79,7 @@ function decide(c: PolicyContext): {
   const laneDecision = resolveLane({
     classification: {
       task_type: c.task_type,
-      complexity: c.complexity,
+      complexity: c.complexity ?? "medium",
       decided_by: "rules",
       constraints: {
         needs_json: c.needs_json,

--- a/packages/core/src/routing/policy-schema.test.ts
+++ b/packages/core/src/routing/policy-schema.test.ts
@@ -54,12 +54,24 @@ describe("policy-schema", () => {
   it("accepts caps-only policy (max_lane / allowed_lanes without use_lane)", () => {
     const cfg = parsePoliciesConfig({
       policies: [
-        { match: { org_id: "low_cost_org" }, max_lane: "balanced" },
-        { match: { org_id: "white_list_org" }, allowed_lanes: ["economy", "balanced"] },
+        { match: { task_type: "coding" }, max_lane: "balanced" },
+        { match: { complexity: "complex" }, allowed_lanes: ["economy", "balanced"] },
       ],
     });
     expect(cfg.policies[0]?.max_lane).toBe("balanced");
     expect(cfg.policies[1]?.allowed_lanes).toEqual(["economy", "balanced"]);
+  });
+
+  it("fail-closed: org_id / user_id are not match dimensions (.strict)", () => {
+    // Routing has no org/user scope — per-key limits live on the API KEY, not in
+    // policies. A leftover org_id/user_id policy must fail boot, never silently
+    // match-nothing (review fix #1).
+    expect(() =>
+      parsePoliciesConfig({ policies: [{ match: { org_id: "acme" }, max_lane: "balanced" }] }),
+    ).toThrow();
+    expect(() =>
+      parsePoliciesConfig({ policies: [{ match: { user_id: "vip" }, use_lane: "premium" }] }),
+    ).toThrow();
   });
 
   it("exposes inferred PoliciesConfig type via schema (compile-time)", () => {

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -801,26 +801,27 @@ describe("routeRequest — virtual model aliases", () => {
   });
 
   it("an alias-mapped lane is bounded by a POLICY cap — no cap bypass (review P1)", async () => {
-    // An identity-scoped policy caps org 'acme' to balanced. A standard key must
-    // NOT be able to use the operator alias to escape that cap up to premium.
-    const orgCap: PoliciesConfig = {
-      policies: [{ id: "org-cap", match: { org_id: "acme" }, max_lane: "balanced" }],
+    // A global cap policy (empty match) clamps everything to balanced. A standard
+    // key must NOT be able to use the operator alias to escape that cap up to premium.
+    const globalCap: PoliciesConfig = {
+      policies: [{ id: "global-cap", match: {}, max_lane: "balanced" }],
     };
-    const capped = deps({ modelAliases: { "claude-opus-4-8": "premium" }, policies: orgCap });
-    const result = await routeRequest(
-      req({ requested_model: "claude-opus-4-8", org_id: "acme" }),
-      capped,
-      { allowCustomModel: false },
-    );
+    const capped = deps({ modelAliases: { "claude-opus-4-8": "premium" }, policies: globalCap });
+    const result = await routeRequest(req({ requested_model: "claude-opus-4-8" }), capped, {
+      allowCustomModel: false,
+    });
     expect(result.final.status).toBe("ok");
     const plan = (capped.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
-    expect(plan.selected_lane).toBe("balanced"); // premium clamped down by the org cap
+    expect(plan.selected_lane).toBe("balanced"); // premium clamped down by the global cap
     const rec = (capped.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     expect(rec.policy.reason).toContain("capped");
 
-    // Control: a DIFFERENT org is not bound by that cap → the alias keeps premium.
-    const free = deps({ modelAliases: { "claude-opus-4-8": "premium" }, policies: orgCap });
-    await routeRequest(req({ requested_model: "claude-opus-4-8", org_id: "other" }), free, {
+    // Control: with NO cap policy, the alias keeps premium.
+    const free = deps({
+      modelAliases: { "claude-opus-4-8": "premium" },
+      policies: { policies: [] },
+    });
+    await routeRequest(req({ requested_model: "claude-opus-4-8" }), free, {
       allowCustomModel: false,
     });
     const plan2 = (free.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -267,40 +267,33 @@ async function classifySafe(
 const expandChain = expandLaneChain;
 
 // Build the PolicyContext the engine matches on, from the classification.
-function policyContext(req: InternalRequest, cls: Classification): PolicyContext {
+function policyContext(cls: Classification): PolicyContext {
   return {
     task_type: cls.task_type,
     complexity: cls.complexity,
     needs_json: cls.constraints.needs_json === true,
     needs_tools: cls.constraints.needs_tools === true,
     needs_vision: cls.constraints.needs_vision === true,
-    user_id: req.user_id,
-    org_id: req.org_id,
     // project_id is a MEMORY-scope field (client-controlled via the x-project-id
-    // header, docs/08), NOT a trusted routing attribute. Sourcing the client value
-    // here would let any caller spoof a project_id policy to change lane/cost/caps
-    // — memory must never rewrite routing (docs/08). user_id/org_id come from the
-    // trusted auth identity; project-scoped routing needs an equivalent trusted
-    // source (auth/account), which does not exist yet, so it is null.
+    // header, docs/08), NOT a trusted routing attribute — sourcing the client value
+    // here would let any caller spoof a project_id policy to change lane/cost. It is
+    // always null until a trusted (auth/account) project source exists.
     project_id: null,
   };
 }
 
 // PolicyContext for an alias-mapped lane (step 0a). An alias request is NOT
-// classified, so task/complexity/needs_* are neutral (`task_type:"passthrough"`
-// matches no shipped task policy) — only IDENTITY-scoped policies (org_id/user_id,
-// e.g. the shipped budget_org_cap) match, and their caps still clamp the lane.
-// This is what keeps an operator alias from becoming a policy-cap bypass.
-function aliasPolicyContext(req: InternalRequest): PolicyContext {
+// classified, so every classifier dimension is neutral: `task_type:"passthrough"`
+// (matches no shipped task policy) and `complexity:null` (matches no complexity
+// policy). Only an unconstrained / global-cap policy can bind here; the key's own
+// `allowed_lanes` whitelist is still applied separately by the caller.
+function aliasPolicyContext(): PolicyContext {
   return {
     task_type: "passthrough",
-    complexity: "medium",
+    complexity: null,
     needs_json: false,
     needs_tools: false,
     needs_vision: false,
-    user_id: req.user_id,
-    org_id: req.org_id,
-    // project_id stays a non-routing memory field (mirrors policyContext above).
     project_id: null,
   };
 }
@@ -521,7 +514,7 @@ async function plan(
     Object.hasOwn(deps.lanes, aliasTarget) &&
     (opts.keyCaps?.degradeLane === undefined || opts.keyCaps.degradeLane === null)
   ) {
-    const outcome = evaluatePolicies(aliasPolicyContext(req), deps.policies);
+    const outcome = evaluatePolicies(aliasPolicyContext(), deps.policies);
     let lane = applyCaps(aliasTarget, outcome);
     if (opts.keyCaps !== undefined) {
       lane = applyCaps(lane, {
@@ -626,7 +619,7 @@ async function plan(
 
   // 2) Classify (fail-open) → policy → lane-resolver (+caps).
   const cls = await classifySafe(req, deps.classify);
-  const outcome = evaluatePolicies(policyContext(req, cls), deps.policies);
+  const outcome = evaluatePolicies(policyContext(cls), deps.policies);
   const laneDecision = resolveLane({
     classification: forResolver(cls),
     policy: {

--- a/packages/shared/src/config/policy-schema.test.ts
+++ b/packages/shared/src/config/policy-schema.test.ts
@@ -54,12 +54,22 @@ describe("policy-schema", () => {
   it("accepts caps-only policy (max_lane / allowed_lanes without use_lane)", () => {
     const cfg = parsePoliciesConfig({
       policies: [
-        { match: { org_id: "low_cost_org" }, max_lane: "balanced" },
-        { match: { org_id: "white_list_org" }, allowed_lanes: ["economy", "balanced"] },
+        { match: { task_type: "coding" }, max_lane: "balanced" },
+        { match: { complexity: "complex" }, allowed_lanes: ["economy", "balanced"] },
       ],
     });
     expect(cfg.policies[0]?.max_lane).toBe("balanced");
     expect(cfg.policies[1]?.allowed_lanes).toEqual(["economy", "balanced"]);
+  });
+
+  it("fail-closed: org_id / user_id are not match dimensions (.strict)", () => {
+    // No org/user routing scope — per-key limits live on the API key, not policies.
+    expect(() =>
+      parsePoliciesConfig({ policies: [{ match: { org_id: "acme" }, max_lane: "balanced" }] }),
+    ).toThrow();
+    expect(() =>
+      parsePoliciesConfig({ policies: [{ match: { user_id: "vip" }, use_lane: "premium" }] }),
+    ).toThrow();
   });
 
   it("exposes inferred PoliciesConfig type via schema (compile-time)", () => {

--- a/packages/shared/src/config/policy-schema.ts
+++ b/packages/shared/src/config/policy-schema.ts
@@ -25,8 +25,12 @@ export const PolicyMatchSchema = z
     needs_json: z.boolean().optional(),
     needs_tools: z.boolean().optional(),
     needs_vision: z.boolean().optional(),
-    user_id: z.string().optional(),
-    org_id: z.string().optional(),
+    // NOTE: there is intentionally no org_id / user_id match dimension — usage and
+    // routing limits are scoped to the API key, not to an org/user identity. (The
+    // schema is `.strict()`, so a leftover org_id/user_id policy now fails closed at
+    // boot rather than silently never matching.) `project_id` is reserved but the
+    // runtime always supplies null (see PolicyContext), so it currently matches
+    // nothing — kept for forward-compat with a future trusted project source.
     project_id: z.string().optional(),
   })
   .strict();

--- a/packages/shared/src/error/schema.test.ts
+++ b/packages/shared/src/error/schema.test.ts
@@ -15,6 +15,7 @@ const EXPECTED: ReadonlyArray<readonly [string, number]> = [
   ["upstream_error", 502],
   ["timeout", 504],
   ["rate_limited", 429],
+  ["client_abort", 499],
 ];
 
 describe("error_class -> HTTP status map", () => {

--- a/packages/shared/src/error/schema.ts
+++ b/packages/shared/src/error/schema.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 // truth (no magic numbers scattered in the gateway). Per CLAUDE.md principle 7,
 // message/provider_raw must already be redacted by the producer.
 
-// The 8 error classes from docs/07, in document order.
+// The error classes from docs/07, in document order.
 export const ErrorClassSchema = z.enum([
   "auth_error",
   "invalid_request",
@@ -16,6 +16,10 @@ export const ErrorClassSchema = z.enum([
   "upstream_error",
   "timeout",
   "rate_limited",
+  // Client-initiated disconnect during execution — NOT a provider fault. Carries
+  // the non-standard 499 the gateway already uses for client aborts, so telemetry
+  // never miscounts a disconnect as an `upstream_error` (docs/02, docs/07).
+  "client_abort",
 ]);
 
 export type ErrorClass = z.infer<typeof ErrorClassSchema>;
@@ -42,6 +46,7 @@ export const ERROR_CLASS_HTTP_STATUS: Record<ErrorClass, number> = {
   upstream_error: 502,
   timeout: 504,
   rate_limited: 429,
+  client_abort: 499,
 };
 
 // Factory: guarantees http_status matches the map; callers cannot supply a


### PR DESCRIPTION
A dual code review (Claude + Codex) of the routing / execution / protocol-translation paths surfaced five real issues. This PR fixes all of them with regression tests.

## Fixes

**#1 · Remove the inert org/user policy dimension (major).** `auth.ts` hardcodes `orgId`/`userId` to `null` (there are no such columns on `ApiKeyRecord`), so `req.org_id`/`req.user_id` are always null and **any policy matching on `org_id`/`user_id` never fired** — the shipped `budget_org_cap` example was dead code. Per-key limits live on the API key, not in policies, so the org/user match dimension is removed entirely: `PolicyMatchSchema` is `.strict()`, so a leftover such config now **fails closed at boot** instead of silently never-matching. The `budget_org_cap` example and the admin policy-editor's User/Org ID inputs are removed too. (`project_id` stays as a documented, not-yet-wired placeholder.)

**#2 · Anthropic outbound stream omits `message_start` on an empty stream (major, found by Codex).** `convertOpenAIStreamToAnthropic` emits `message_start` lazily inside the chunk loop, so a **zero-chunk** upstream stream produced `message_delta`/`message_stop` with no `message_start` — an invalid Anthropic SSE sequence that breaks SDK/Claude-Code clients. A finalize-time guard now emits a skeleton `message_start`.

**#3 · `applyCaps` no longer escalates unrankable candidates to the strongest lane (medium).** A task lane (`coding`/`json`/…) or vendor-family lane (`claude-opus`, …) outside a key's `allowed_lanes` was clamped to the **highest** allowed lane (e.g. `premium`). It now degrades toward `balanced`.

**#4 · Client disconnects get a dedicated `client_abort` (499) error class (minor).** Previously a client abort returned `final.error_class = "upstream_error"`, inflating upstream-fault metrics. New `client_abort` class with the three protocol error mappings (Anthropic `api_error`, Gemini `CANCELLED`, OpenAI `api_error`) and docs/07 table row.

**#5 · `aliasPolicyContext` no longer hardcodes `complexity: "medium"` (edge).** An unclassified alias request could spuriously match a `complexity`-only policy; it now uses `null` (`PolicyContext.complexity` is nullable).

## Verification

- `pnpm typecheck` (shared/core/gateway) ✅
- `pnpm lint` (Biome) ✅
- **3737 unit tests** ✅ — new regression tests for the empty stream, unrankable→balanced, client_abort/499, and org/user fail-closed
- admin `svelte-check` 0 errors ✅

Independent of the docs PR (#260) — code-only branch off `main` (plus `docs/07` and `implementation-notes.md`, which #260 doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)