### PR TITLE
chore(release): v0.13.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release.

## Included
- #262 — fix: non-custom-model keys route everything via auto (gate the model-alias shim on `allow_custom_model`). Keys without `allow_custom_model` now route every request through classification; the `model` field is ignored (never a 400). `model-aliases.yaml` change is comment-only; **no config schema change** (no fail-closed risk for existing deployments).

## Release mechanics
On merge, `publish.yml` auto-cuts tag `v0.13.5` + GitHub Release + GHCR `:0.13.5`/`:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)