### PR TITLE
chore(release): v0.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release.

## Included
- #264 — feat: configurable default fallback lane (admin System Settings `default_lane`). The terminal fail-open lane is now operator-selectable; default `"balanced"` → fully backward-compatible. Additive runtime setting + routing-terminal change; **no new endpoint/provider**, **no config-file change**, **no schema fail-close risk** (the new field has a default).

## Release mechanics
On merge, `publish.yml` auto-cuts tag `v0.13.6` + GitHub Release + GHCR `:0.13.6`/`:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)