### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Minor release — bundles #266 (BREAKING) + #267 onto v0.13.6.

## Included
- **#266 — BREAKING: remove the redundant policy-level `max_lane` cap.** A `policies.yaml` still containing `max_lane` now fail-closes at boot; use `allowed_lanes` (whitelist) instead. Verified safe for the production box (`la.atmy.work`): its `policies.yaml` carries no active `max_lane`, and `loadConfig` validates the box config against the new schema.
- **#267 — aggregate dashboard stats + OAuth usage by client timezone.** Adds additive, auto-run SQLite + Postgres migrations.

## Release mechanics
On merge, `publish.yml` auto-cuts tag `v0.14.0` + GitHub Release + GHCR `:0.14.0` / `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)