### PR TITLE
fix: route short Chinese analysis/security prompts correctly (CJK short-circuit + intl keyword parity)

### DIFF
--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -93,6 +93,10 @@ classifier:
       # Short diagnostics/security fragments are meaningful despite being tiny;
       # give them enough positive signal to escape the simple/economy shortcut.
       diagnostic_short_kw: { weight: 3.60, keywords: ["no output", "no stack trace", "no auth check", "no command injection"] }
+      # Chinese diagnostic fragments — POSITIVE signal mirrors diagnostic_short_kw so a
+      # short ZH diagnostic ("没有输出") escapes the simple/economy shortcut AND gives the
+      # language guard real grip. Simplified only (engine.test asserts no Traditional).
+      diagnostic_short_intl_kw: { weight: 3.60, keywords: ["没有输出", "无输出", "没有报错", "无报错", "没有堆栈跟踪", "没有权限检查", "没有命令注入"] }
       extraction_kw: { weight: 0.12, keywords: ["extract", "parse", "json from", "fields", "schema", "pull out", "list all", "structured data", "named entities", "scrape"] }
       extraction_intl_kw: { weight: 0.12, keywords: ["提取", "解析", "从 JSON", "字段", "模式", "抽取", "列出所有", "结构化数据", "命名实体", "抓取", "提取字段", "抽取实体"] }
       data_kw: { weight: 0.20, keywords: ["csv", "dataframe", "aggregate", "sql", "pivot", "group by", "spreadsheet", "histogram", "correlation", "query"] }
@@ -115,6 +119,16 @@ classifier:
       lookup_kw: { weight: -1.05, keywords: ["what is", "who is", "define", "meaning of", "when did", "where is", "how many", "capital of", "tell me about", "what are"] }
       chitchat_kw: { weight: -1.15, keywords: ["how are you", "good morning", "lol", "haha", "thank you", "goodbye", "what's up", "good night", "cheers"] }
       simple_kw: { weight: -1.35, keywords: ["hi", "thanks", "ok", "ping", "thx"] }
+      # —— international (Simplified Chinese) negatives —— mirror the English negatives.
+      # NOTE: a NEGATIVE contribution does NOT suppress the language guard (engine.ts
+      # requires a POSITIVE hit), and short ZH prompts are already pinned `simple` by
+      # short_message — so these mainly add grip-DOWN for medium-length ZH prompts that
+      # also carry a positive hit. Politeness preambles (你好/您好/请问/谢谢) are
+      # DELIBERATELY excluded: they routinely prefix real tasks, so penalizing them
+      # would misroute genuine ZH coding/analysis requests toward economy.
+      translation_intl_kw: { weight: -0.78, keywords: ["翻译", "翻译成", "译成", "翻成", "用英文", "用中文", "用法语", "用日语", "本地化", "译为"] }
+      lookup_intl_kw: { weight: -1.05, keywords: ["什么是", "谁是", "是什么", "什么意思", "的意思", "什么时候", "在哪里", "在哪儿", "有多少", "的首都", "多少钱"] }
+      chitchat_intl_kw: { weight: -1.15, keywords: ["最近怎么样", "早上好", "晚上好", "晚安", "哈哈", "呵呵", "再见", "拜拜", "在吗", "在不在", "吃了吗"] }
       # —— structural / context dimensions (keywords empty; code feeds the score) ——
       has_code_block: { weight: 0.34 }
       has_url: { weight: 0.06 }
@@ -162,7 +176,7 @@ classifier:
     task_activation: { web: 3.0, security: 2.0 }
     overrides:
       heartbeat_tokens: ["HEARTBEAT_OK"]
-      exact_confirmation_tokens: ["yes", "no", "sure", "got it", "ok", "thanks", "是", "否", "可以", "好的", "谢谢"]
+      exact_confirmation_tokens: ["yes", "no", "sure", "got it", "ok", "thanks", "是", "否", "可以", "好的", "谢谢", "对", "嗯", "行", "好", "没问题", "收到", "明白", "知道了"]
       formal_logic_keywords: ["⊢", "∴", "modus ponens", "first-order logic", "充分必要", "反证法", "归纳法"]
       tools_floor: standard
       long_context_token_threshold: 64000  # capability signal (NOT a task_type); bumped 50k->64k to match llm-router lanes.yaml long_context anchor

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-16 · classifier 中英文关键词对等 + 修复短消息捷径的 CJK 盲区（docs/03；原则 2/4）
+
+- **背景**：用户审查 `classifier.yaml` 发现部分维度只有英文、缺中文。逐 key 审计后定位到**真正的问题在代码不在配置**：短消息捷径（`overrides.ts isShortAndSimple → containsClassifierSignal`）只检查英文 `analysis_kw/security_kw/diagnostic_short_kw`，且 `overrides.ts` 自带的 `keywordMatcher` **没有 CJK 豁免**（与 `dimensions.ts` 的版本漂移）。后果：一条**短中文**分析/安全请求（"分析这个系统的根因"）被强钉 `simple`→economy，**即使开了 eval 也救不回**（set override 在 Layer-1 即决、不进 eval）。
+- **决定（用户选「配置+代码完整修复」而非仅补关键词）**：① 把 CJK-aware `keywordMatcher` 上提到 `signals.ts`（既有「共享 detector 防止两份正则漂移」之处），`dimensions.ts`/`overrides.ts` **同源导入**，删掉 overrides 那份 CJK-broken 副本（根因就是这次漂移）；② `containsClassifierSignal` 同时检查 `*_intl_kw`（analysis/security/diagnostic）；③ `classifier.yaml` 补 4 个缺失 intl 维度。
+- **改动（config）**：新增 `diagnostic_short_intl_kw`（**正**权重 3.60，镜像英文，同时给语言守卫正向 grip）、`translation_intl_kw`/`lookup_intl_kw`/`chitchat_intl_kw`（负权重镜像英文）；`exact_confirmation_tokens` 补简体确认词（对/嗯/行/好/没问题/收到/明白/知道了）。全简体（`engine.test` 钉死 intl 种子无繁体）。
+- **取舍/坑/TODO**：① **负向 intl 维度不抑制语言守卫**（`engine.ts languageGuardTrips` 只认正向 grip），且短中文早被 `short_message`(≤50 字符)钉 simple → 负向 intl 维度主要对「带正向命中的中等长度中文」起 grip-down 作用，价值有限但补齐对等与可解释性。② **礼貌前缀（你好/您好/请问/谢谢）刻意排除出负向维度**——中文里它们常作真实任务开头，惩罚会误降真实编码/分析请求（已加「你好+复杂分析→premium」golden 守卫证明不误路）。③ web 仍只有 `web_intl_kw` 无英文 `web_kw`（英文 web 走 `task_keywords`，刻意保留不对称）。④ matcher 上提对**英文行为零影响**（Latin 边界逻辑不变）——38 条英文 golden 全绿可证。
+- **验证**：TDD 红→绿。`overrides.test` **+4**（短中文 analysis/security 不再钉 simple、CJK 中段匹配、纯问候仍 simple，先红后绿）；`golden-routing` **+7** 中文行（问候/查词/翻译/简单编码→economy；短分析/安全→premium；礼貌前缀+复杂→premium）。classifier+samples 全量 **254** 绿，`@helm/core typecheck` 0、biome lint 0。注：harness 报的 `token-manager.test.ts` 诊断是切分支后的**陈旧 LSP 噪声**（实际 tsc 绿，见 [[workflow-stale-diagnostics]]）。worktree 分支 `tz-aggregation-review`，**仅改本地仓库，未发版/未部署**（线上 classifier 已在 0.14.0 部署时恢复为 repo 完整版+`eval.enabled:true`，此次新增维度待 Lukin 决定再上线）。
+
 ## 2026-06-16 · 数据汇总按客户端时区分桶（修复「8 点边界」）（docs/02/04/10；原则 1/2/3）
 
 - **背景**：用户报仪表盘日/「今日」数据「8 点前后不一致」。三方只读审查（时间戳记录 / 时间显示 / 数据汇总）确认：**时间戳存储全 UTC epoch-ms、显示全走 `formatTimestamp`→浏览器本地，两者都对**；**唯一 bug 在数据汇总按 UTC 日/小时分桶**——`(createdAt / 86_400_000) * 86_400_000` 是 UTC 午夜地板。UTC+8 下 UTC 午夜=本地 08:00，正是那条断点。根因：网关**从不接收客户端时区**，每个 rollup 都按 UTC 钟分区。
@@ -23,19 +31,13 @@
 - **取舍/坑/TODO**：① 删后**策略只能 force（use_lane）**，restrict 仍由 per-key allowed_lanes 承担（policy 编辑器本就没暴露 allowed_lanes）；想要 policy 级 restrict UI 是后续可选项。② 「全局成本上限」从 `max_lane: balanced` 改用 `allowed_lanes: [economy, balanced]`（catch-all 空 match），docs 例子已更。③ per-key max_lane 的退役迁移/测试（DROP COLUMN、key schema 拒收）**保留不动**——那是另一回事。
 - **验证**：TDD——policy-engine/schema(×2)/route-request/admin PolicyRow+policies/crossref 全改绿；`pnpm typecheck`/`lint`/全量 + admin `svelte-check` 待 CI。分支 `feat/drop-policy-max-lane`，开 PR（BREAKING，不发版/不部署）。
 
-## 2026-06-15 · 可配置的「默认兜底车道」系统设置（docs/04；原则 1/2/3/5）
-
-- **背景**：兜底终点写死 `balanced`（`lane-resolver.ts` 的 `BALANCED` 常量 + lanes schema 强制 `"balanced" in m`），运营者无法改。用户要「不想默认到 balanced 的人可定制」。讨论中**否决两个直觉方案**：① policies 加 catch-all 规则——policy 是 resolver **第 1 优先级（最高）**，底部 catch-all 会**盖过** task/complexity 路由（`use_lane` 钉死全部未匹配请求 / `max_lane` 全局封顶 premium 不可达），正是 shipped policies.yaml 注释当年特意避开的；② 靠 lanes map「最后一条」——lanes 是 `z.record` 无序，靠 key 顺序当兜底脆弱且违反原则 4。用户拍板：**系统设置里加一个可选 lane 的兜底项**，且**只改最终兜底**（不动 complexity 档）。
-- **方案**：`default_lane` 做成**热改 RuntimeSettings 字段**（DB `config_kv`，读 fail-open / 写 fail-closed），默认 `"balanced"` → 100% 向后兼容。resolver 仅在**两个 fail-open 终点**（classifier `default`/`fallback` 短路 + 完全未解析）用它，且**仅当该 lane 存在**否则回落字面 `"balanced"`（lanes schema 仍强制 balanced 存在=终极地板）→ **无新增 fail-close 路径**，不会重演 0.13.4 `org_id` 启动崩溃。**不动 `COMPLEXITY_FALLBACK`**（simple→economy/medium→balanced/complex→premium 保持）。
-- **接线**：schema 加 `default_lane`（runtime-settings.schema.ts）；resolver `ResolveLaneInput.defaultLane?`（缺省=balanced，旧 caller/测试不变，终点用 `defaultLane && has(lanes,…) ? : BALANCED`）；route-request `RouteDeps.defaultLane` + plan() 传入；`apps/gateway/.../classify.ts` eval-cascade 包装器加 live getter；server.ts route 闭包 `settings.default_lane`（每请求读=热生效）+ buildClassifyAdapter `() => settings.default_lane`；admin settings PUT **校验 lane 存在**（不存在 400，resolver 另有运行时守卫=纵深防御）；admin 系统设置加 lane 下拉（`+page.ts` listLanes + `+page.svelte` `<select>` 镜像 log_level）+ 5 语言 i18n（en/zh-hans/zh-hant/ja/ko）。
-- **取舍/坑/TODO**：① 因 balanced 恒存在且 medium→balanced 在终点前命中，`default_lane` 主要影响**分类器 fail-open 路径**（这正是「兜底」语义，用户认可只改这层）；② classify 适配器用 live getter 保持 cascade 内部 lane 与真实路由一致（route-request 才权威）；③ i18n 手工补 5 文件，无强制完整性测试覆盖新键，缺则回退英文。
-- **验证**：TDD——lane-resolver +5（配置终点 / 缺失回落 balanced / medium 不受影响 / 缺省 back-compat）、runtime-settings +1、admin 路由 +2（合法 lane 200 / 未知 lane 400 不持久化）、admin settings client round-trip。`pnpm typecheck`/`lint`/全量测试 + admin `svelte-check` 待 CI。分支 `feat/configurable-default-lane`，开 PR（不发版/不部署）。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-15 · 可配置的「默认兜底车道」系统设置（docs/04；原则 1/2/3/5）：兜底写死 `balanced` 不可改 → 加**热改** RuntimeSettings `default_lane`（DB config_kv，读 fail-open/写 fail-closed，默认 balanced=向后兼容）。否决 policies catch-all（policy 最高优先级会盖过 task/complexity 路由）与 lanes 末条（z.record 无序）两方案。只在 resolver 两个 fail-open 终点用、且仅当该 lane 存在否则回落字面 balanced（**无新 fail-close 路径**，不重演 0.13.4）；不动 COMPLEXITY_FALLBACK。admin 系统设置加 lane 下拉 + 5 语言 i18n + PUT 校验 lane 存在。分支 feat/configurable-default-lane。
 
 ### 2026-06-15 · 双人 code review 修复：org/user 策略拆除 + Anthropic 空流 + applyCaps + client_abort（docs/02/04/05/07；原则 3/5/7/8）：我+Codex 对抗式 review，确认 2 bug+1 设计+2 小问题全修。#1 org/user 维度策略形同虚设（`auth.ts` 写死 null→永不命中、`budget_org_cap` 死代码）→ 从 PolicyMatch/Context/MATCH_FIELDS/两 builder 拆除（`.strict()` 使遗留策略 fail-closed），admin PolicyRow 同步删 User/Org ID；#2〔Codex〕Anthropic 出站零 chunk 流缺 message_start→收尾前补 `messageStartEvent` 守卫；#3 applyCaps 把不可排序候选顶到 premium→`UNRANKED_CANDIDATE_RANK=balanced` 降级；#4 client abort 误标 upstream_error→新增 `client_abort`(499) ErrorClass；#5 aliasPolicyContext 写死 complexity:medium→改 null；#6 非自定义模型 key 全走 auto（route-request Step 0a 加 `allowCustomModel` 门槛）。TDD 全量 **3737** 绿。分支 fix/review-routing-stream-errors。
 

--- a/packages/core/src/classifier/dimensions.ts
+++ b/packages/core/src/classifier/dimensions.ts
@@ -6,6 +6,7 @@ import {
   detectStackTrace,
   detectTable,
   detectUrl,
+  keywordMatcher,
   lengthSignal,
   normalize,
 } from "./signals.js";
@@ -133,42 +134,10 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 // ── keyword signal ────────────────────────────────────────────────────────────
 
-// Case-insensitive, WORD/TOKEN-boundary aware match; signal = normalized hit
-// count over keywords. We do NOT lowercase the original text for storage — the
-// `i` flag folds case locally without mutating the source for any other use.
-//
-// Boundaries are enforced ONLY on a keyword edge that is itself a word char
-// (alnum/underscore). This is what stops a naive `includes` from firing "hi"
-// inside "t·hi·s" or "ok" inside "lo·ok"/"bo·ok" (a real regression: those
-// false hits silently poisoned the rawScore of unrelated prompts). Keywords
-// that contain spaces ("step by step") or END in punctuation ("cve-", meant to
-// match "cve-2021") keep matching, because the non-word edge gets NO boundary.
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-const WORD = /[\p{L}\p{N}_]/u; // unicode letter/number/underscore
-// CJK scripts (Han / Hiragana / Katakana / Hangul) write words WITHOUT spaces, so a
-// CJK edge char would NEVER satisfy the word-boundary lookaround below — "分析" inside
-// "请分析这个" is flanked by other \p{L} chars, so both lookarounds fail and the keyword
-// becomes permanently unmatchable. CJK edges therefore match as plain substrings (their
-// "words" are 1–3 meaningful chars, so the naive-substring false-hit risk that boundaries
-// guard against for Latin does not apply). This is what makes config-level CJK keyword
-// lists possible at all (see implementation-notes: classifier.multilingual-guard).
-const CJK = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
-const needsBoundary = (ch: string): boolean => WORD.test(ch) && !CJK.test(ch);
-const keywordMatcherCache = new Map<string, RegExp>();
-function keywordMatcher(kw: string): RegExp {
-  let re = keywordMatcherCache.get(kw);
-  if (re === undefined) {
-    const left = needsBoundary(kw[0] ?? "") ? "(?<![\\p{L}\\p{N}_])" : "";
-    const right = needsBoundary(kw[kw.length - 1] ?? "") ? "(?![\\p{L}\\p{N}_])" : "";
-    re = new RegExp(left + escapeRegExp(kw) + right, "iu");
-    keywordMatcherCache.set(kw, re);
-  }
-  return re;
-}
-
+// `keywordMatcher` (case-insensitive; Latin word-boundary aware, CJK substring) is
+// the SHARED matcher from signals.ts — the same one the override short-circuit uses,
+// so the two paths can never drift (a divergent CJK-broken copy here once did). The
+// signal SATURATES at min(1, hits/ceil(len/2)), so a longer list dilutes each hit.
 function keywordSignal(text: string, keywords: string[]): number {
   if (text.trim().length === 0) return 0;
   let hits = 0;

--- a/packages/core/src/classifier/golden-routing.test.ts
+++ b/packages/core/src/classifier/golden-routing.test.ts
@@ -506,6 +506,66 @@ const CASES: GoldenCase[] = [
     complexity: "medium",
     selected_lane: "balanced",
   },
+
+  // ── INTERNATIONAL (Simplified Chinese) PARITY (2026-06-16) ──────────────────
+  // ZH rows mirror their English golden rows. The analysis/security rows are the
+  // regression guard for the overrides.ts CJK short-circuit fix: a SHORT ZH
+  // analysis/security prompt must NOT be force-pinned simple→economy because the
+  // English signal lists miss it (and the old override matcher could not match CJK).
+  {
+    name: "zh greeting -> economy",
+    request: req("你好"),
+    task_type: "chat",
+    complexity: "simple",
+    selected_lane: "economy",
+  },
+  {
+    name: "zh lookup what-is -> economy",
+    request: req("什么是单子"),
+    task_type: "chat",
+    complexity: "simple",
+    selected_lane: "economy",
+  },
+  {
+    name: "zh translate -> economy",
+    request: req("把这段话翻译成英文"),
+    task_type: "chat",
+    complexity: "simple",
+    selected_lane: "economy",
+  },
+  {
+    name: "zh trivial coding -> economy",
+    request: req("写一个反转字符串的函数"),
+    task_type: "coding",
+    complexity: "simple",
+    selected_lane: "economy",
+  },
+  {
+    // BUG-FIX guard: this short ZH analysis prompt was mis-pinned simple→economy
+    // before the overrides CJK short-circuit fix; now analysis_intl grip routes it up.
+    name: "zh analysis (short) -> up, NOT economy",
+    request: req("分析这个系统的根因和利弊"),
+    task_type: "chat",
+    complexity: "complex",
+    selected_lane: "premium",
+  },
+  {
+    // BUG-FIX guard: short ZH security audit (>=2 security hits) routes up.
+    name: "zh security (short) -> premium",
+    request: req("检查这个接口的命令注入和越权漏洞"),
+    task_type: "security",
+    complexity: "complex",
+    selected_lane: "premium",
+  },
+  {
+    // POLITENESS-PREAMBLE guard: a 你好 preamble must NOT drag a genuine complex ZH
+    // request down (你好 is deliberately excluded from the negative intl dims).
+    name: "zh polite preamble + complex analysis -> premium",
+    request: req("你好，请分析这个复杂分布式系统的架构权衡、性能瓶颈和根因"),
+    task_type: "chat",
+    complexity: "complex",
+    selected_lane: "premium",
+  },
 ];
 
 describe("GOLDEN classify+route baseline (characterizes current behavior)", () => {

--- a/packages/core/src/classifier/overrides.test.ts
+++ b/packages/core/src/classifier/overrides.test.ts
@@ -203,6 +203,55 @@ describe("evaluateOverrides / applyOverrides — no override", () => {
   });
 });
 
+describe("evaluateOverrides — CJK short-message short-circuit (intl parity)", () => {
+  // A config carrying the shipped *_intl_kw signal dimensions so the short-message
+  // disqualifier (containsClassifierSignal) can see Chinese analysis/security/
+  // diagnostic grip. Regression guard: short Chinese complex prompts must NOT be
+  // force-pinned `simple` just because the English signal lists miss them and the
+  // old override matcher could not match CJK mid-text.
+  function intlConfig(): ClassifierRulesConfig {
+    return ClassifierRulesConfigSchema.parse({
+      dimensions: {
+        analysis_kw: { weight: 0.76, keywords: ["analyze", "root cause"] },
+        analysis_intl_kw: { weight: 0.76, keywords: ["分析", "根因", "利弊", "评估"] },
+        security_intl_kw: { weight: 1.4, keywords: ["缓冲区溢出", "命令注入", "越权"] },
+        diagnostic_short_intl_kw: { weight: 3.6, keywords: ["没有输出", "没有报错"] },
+      },
+      task_keywords: {},
+      tool_prefixes: {},
+      tier_boundaries: {},
+      overrides: {},
+      momentum: {},
+    });
+  }
+
+  it("does NOT short-circuit a short Chinese ANALYSIS prompt to simple (intl grip)", () => {
+    const cfg = intlConfig();
+    const hits = evaluateOverrides(req({ content: "分析这个系统的根因和利弊" }), cfg, 8);
+    expect(hits.find((h) => h.rule === "short_message")).toBeUndefined();
+  });
+
+  it("does NOT short-circuit a short Chinese SECURITY prompt to simple", () => {
+    const cfg = intlConfig();
+    const hits = evaluateOverrides(req({ content: "这个接口有命令注入和越权漏洞吗" }), cfg, 9);
+    expect(hits.find((h) => h.rule === "short_message")).toBeUndefined();
+  });
+
+  it("matches a Chinese signal keyword MID-TEXT (CJK boundary carve-out)", () => {
+    // "分析" is flanked by other CJK chars — the old WORD-boundary override matcher
+    // (no CJK exception) silently failed here, so the prompt was mis-pinned simple.
+    const cfg = intlConfig();
+    const hits = evaluateOverrides(req({ content: "请你帮我分析一下这段" }), cfg, 7);
+    expect(hits.find((h) => h.rule === "short_message")).toBeUndefined();
+  });
+
+  it("still short-circuits a short Chinese greeting (no signal) to simple", () => {
+    const cfg = intlConfig();
+    const hits = evaluateOverrides(req({ content: "你好呀在吗" }), cfg, 5);
+    expect(hits).toContainEqual({ rule: "short_message", kind: "set", complexity: "simple" });
+  });
+});
+
 describe("applyOverrides — multiple floors take the highest", () => {
   it("combines tools + long-context floors to the higher tier (edge)", () => {
     const cfg = makeConfig();

--- a/packages/core/src/classifier/overrides.ts
+++ b/packages/core/src/classifier/overrides.ts
@@ -1,5 +1,5 @@
 import type { ClassifierRulesConfig, InternalRequest } from "@helm/shared";
-import { detectCodeBlock, detectStackTrace } from "./signals.js";
+import { detectCodeBlock, detectStackTrace, keywordMatcher } from "./signals.js";
 import type { Complexity } from "./tiers.js";
 
 // Layer-1 hard overrides & shortcuts — the deterministic signals that BYPASS the
@@ -130,11 +130,20 @@ function isShortAndSimple(text: string, maxChars: number, cfg: ClassifierRulesCo
   return true;
 }
 
+// The short-message disqualifier must see BOTH the English signal dimensions and
+// their international (*_intl_kw) counterparts — otherwise a short Chinese analysis/
+// security/diagnostic prompt ("分析这个系统的根因") is wrongly force-pinned `simple`
+// because the English lists never match it. The shared keywordMatcher matches CJK as
+// a substring, so these now fire mid-text. task_keywords.security carries its own
+// Simplified entries; the *_intl_kw dimensions cover analysis/security/diagnostic.
 function containsClassifierSignal(text: string, cfg: ClassifierRulesConfig): boolean {
   const signalKeywords = [
     ...keywordsForDimension(cfg, "analysis_kw"),
+    ...keywordsForDimension(cfg, "analysis_intl_kw"),
     ...keywordsForDimension(cfg, "security_kw"),
+    ...keywordsForDimension(cfg, "security_intl_kw"),
     ...keywordsForDimension(cfg, "diagnostic_short_kw"),
+    ...keywordsForDimension(cfg, "diagnostic_short_intl_kw"),
     ...(cfg.task_keywords.security ?? []),
   ];
   return matchesAnyKeyword(text, signalKeywords);
@@ -160,23 +169,6 @@ function normalizeUtterance(text: string): string {
     .toLowerCase()
     .replace(/[.!?]+$/u, "")
     .replace(/\s+/gu, " ");
-}
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-const WORD = /[\p{L}\p{N}_]/u;
-const keywordMatcherCache = new Map<string, RegExp>();
-function keywordMatcher(kw: string): RegExp {
-  let re = keywordMatcherCache.get(kw);
-  if (re === undefined) {
-    const left = WORD.test(kw[0] ?? "") ? "(?<![\\p{L}\\p{N}_])" : "";
-    const right = WORD.test(kw[kw.length - 1] ?? "") ? "(?![\\p{L}\\p{N}_])" : "";
-    re = new RegExp(left + escapeRegExp(kw) + right, "iu");
-    keywordMatcherCache.set(kw, re);
-  }
-  return re;
 }
 
 // Text of the LAST user-role message (heartbeat / short-message look at the

--- a/packages/core/src/classifier/signals.ts
+++ b/packages/core/src/classifier/signals.ts
@@ -82,3 +82,38 @@ export function nonLatinRatio(text: string): number {
   }
   return letters === 0 ? 0 : nonLatin / letters;
 }
+
+// ── shared keyword matcher ──────────────────────────────────────────────────
+// The SINGLE keyword-matching regex builder used by BOTH the dimension scorer
+// (dimensions.ts) and the override short-circuit (overrides.ts). It lives here for
+// the same reason the detectors do: a divergent second copy DID drift — overrides.ts
+// once carried its own WORD-boundary-only matcher that silently failed on CJK, so
+// short Chinese analysis/security prompts slipped through the short-message shortcut
+// (classifier.multilingual-guard). One implementation, no drift.
+//
+// Case-insensitive. WORD/TOKEN-boundary is enforced ONLY on a keyword edge that is
+// itself a Latin word char — this stops a naive `includes` firing "hi" inside
+// "t·hi·s" or "ok" inside "lo·ok". CJK scripts (Han/Hiragana/Katakana/Hangul) write
+// words WITHOUT spaces, so a CJK edge char can never satisfy the boundary lookaround
+// (its neighbours are also \p{L}); CJK edges therefore match as plain substrings
+// (their "words" are 1–3 meaningful chars, so the naive-substring false-hit risk that
+// boundaries guard against for Latin does not apply). This is what makes config-level
+// CJK keyword lists work at all. Keywords with spaces ("step by step") or ending in
+// punctuation ("cve-") keep matching — the non-word edge gets no boundary.
+const WORD = /[\p{L}\p{N}_]/u;
+const CJK = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+const needsBoundary = (ch: string): boolean => WORD.test(ch) && !CJK.test(ch);
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+const keywordMatcherCache = new Map<string, RegExp>();
+export function keywordMatcher(kw: string): RegExp {
+  let re = keywordMatcherCache.get(kw);
+  if (re === undefined) {
+    const left = needsBoundary(kw[0] ?? "") ? "(?<![\\p{L}\\p{N}_])" : "";
+    const right = needsBoundary(kw[kw.length - 1] ?? "") ? "(?![\\p{L}\\p{N}_])" : "";
+    re = new RegExp(left + escapeRegExp(kw) + right, "iu");
+    keywordMatcherCache.set(kw, re);
+  }
+  return re;
+}


### PR DESCRIPTION
## Problem

A key-by-key review of `classifier.yaml` started as "some dimensions only have English keywords, not Chinese" — but the real issue was in **code**, not config.

The short-message shortcut (`overrides.ts` → `isShortAndSimple` → `containsClassifierSignal`) only checked the **English** `analysis_kw` / `security_kw` / `diagnostic_short_kw`, and `overrides.ts` carried its **own** `keywordMatcher` with **no CJK carve-out** (a divergent copy of the one in `dimensions.ts`). Consequence: a short Chinese analysis/security request like `"分析这个系统的根因"` was force-pinned `simple → economy` — **even with eval ON**, because a `set` override decides in Layer-1 before eval runs. Adding `*_intl_kw` keywords alone would NOT have fixed this.

## Fix

- **Unify the matcher**: move the CJK-aware `keywordMatcher` into `signals.ts` (the shared-regex home where the structural detectors already live to prevent drift). `dimensions.ts` and `overrides.ts` now import it; the divergent CJK-broken copy in `overrides.ts` is deleted (it was the root cause).
- **Extend the disqualifier**: `containsClassifierSignal` now also checks `analysis_intl_kw` / `security_intl_kw` / `diagnostic_short_intl_kw`.
- **Keyword parity** (`classifier.yaml`): add `diagnostic_short_intl_kw` (positive — also gives the language guard real grip) + `translation_intl_kw` / `lookup_intl_kw` / `chitchat_intl_kw` (negatives); expand `exact_confirmation_tokens` with Simplified terms. All Simplified (the `engine.test` no-Traditional assertion stays green). Politeness preambles (你好/您好/请问/谢谢) are **deliberately excluded** from the negative dims — they routinely prefix real tasks.

## Tests (TDD, red→green)

- `overrides.test.ts` **+4** — short ZH analysis/security no longer pinned `simple`; CJK keyword matches mid-text; pure greeting still `simple`. (Confirmed RED before the fix.)
- `golden-routing.test.ts` **+7** ZH rows — greeting/lookup/translation/trivial-coding → economy; short analysis/security → premium; **你好 + complex analysis → premium** (politeness-preamble guard).
- Full classifier suite + `samples.test` green. **English golden rows unchanged** — the shared matcher is byte-identical on Latin edges, so EN scoring/routing is untouched.
- `@helm/core typecheck` 0, biome lint 0.

## Notes

- No new config knobs; no schema changes; no fail-close risk.
- Behavior change is **scoped to CJK** short prompts (the intended fix) — they now route up instead of to economy, which may shift some Chinese traffic toward balanced/premium (correct, but worth noting for cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)