### PR TITLE
chore(release): v0.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release.

## Included
- **#271** — cosmetic reorder of `classifier.yaml` negative dimensions (pair each English negative with its `*_intl_kw` sibling).

No behavior change, no schema change, no fail-close risk.

## Release mechanics
On merge, `publish.yml` auto-cuts tag `v0.14.2` + GitHub Release + GHCR `:0.14.2` / `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)