### PR TITLE
feat(observability): capture the real request forwarded to the upstream LLM

### DIFF
--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -555,6 +555,10 @@ export interface RequestPayloadView {
   captured: boolean;
   request?: unknown;
   response?: unknown;
+  // The EXACT body forwarded upstream — AFTER memory injection + protocol
+  // translation. This is what the model actually received (the inbound `request`
+  // is what the client sent). Null/absent when no provider served or pre-feature.
+  upstream_request?: unknown;
   created_at?: number;
 }
 

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -99,10 +99,10 @@
 
     <!-- Request: full captured body when capture_payloads is on, else metadata. -->
     <section class="card text-sm">
-      <h2 class="section-header">{$t('Request')}</h2>
+      <h2 class="section-header">{$t('Request (from client)')}</h2>
       {#if data.payload?.captured}
         <p class="field-help mb-2">
-          {$t('Full request body recorded for this call.')}
+          {$t('The request body as received from the client — before memory injection and translation.')}
         </p>
         <JsonViewer value={data.payload.request} testid="request-body" />
       {:else}
@@ -117,6 +117,21 @@
         </p>
       {/if}
     </section>
+
+    <!-- Forwarded upstream request: the EXACT body sent to the provider, AFTER
+         memory injection + protocol translation. Only present when a provider
+         served and capture was on. This is what the model actually received. -->
+    {#if data.payload?.captured && data.payload?.upstream_request != null}
+      <section class="card text-sm">
+        <h2 class="section-header">{$t('Forwarded to upstream LLM')}</h2>
+        <p class="field-help mb-2">
+          {$t(
+            'The exact request sent to the provider — after memory injection and protocol translation. This is what the model actually received.',
+          )}
+        </p>
+        <JsonViewer value={data.payload.upstream_request} testid="upstream-request-body" />
+      </section>
+    {/if}
 
     <!-- Decision chain (classification -> eval -> policy -> lanes -> attempts) -->
     <DecisionChain detail={d} />

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1104,6 +1104,7 @@ describe("admin.api request payload", () => {
               requestId: "req_1",
               requestJson: JSON.stringify({ model: "auto" }),
               responseJson: JSON.stringify({ ok: true }),
+              upstreamRequestJson: JSON.stringify({ model: "gpt-resolved", injected: true }),
               createdAt: new Date(1234),
             }
           : null,
@@ -1115,8 +1116,29 @@ describe("admin.api request payload", () => {
       captured: true,
       request: { model: "auto" },
       response: { ok: true },
+      upstream_request: { model: "gpt-resolved", injected: true },
       created_at: 1234,
     });
+  });
+
+  it("returns upstream_request:null when the forwarded body was not captured", async () => {
+    const telemetry = {
+      ...makeTelemetry(),
+      getPayload: async (id: string) =>
+        id === "req_2"
+          ? {
+              requestId: "req_2",
+              requestJson: JSON.stringify({ model: "auto" }),
+              responseJson: null,
+              upstreamRequestJson: null,
+              createdAt: new Date(1234),
+            }
+          : null,
+    } as unknown as TelemetryStore;
+    const app = buildApp(buildDeps({ telemetry }));
+    const res = await app.request("/admin/api/requests/req_2/payload");
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { upstream_request: unknown }).upstream_request).toBeNull();
   });
 });
 

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -84,6 +84,10 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
       captured: true,
       request: parseMaybeJson(p.requestJson),
       response: p.responseJson === null ? null : parseMaybeJson(p.responseJson),
+      // The EXACT body forwarded upstream (post memory-inject + protocol-translation)
+      // — what the model actually received. Null when no provider served / pre-feature.
+      upstream_request:
+        p.upstreamRequestJson === null ? null : parseMaybeJson(p.upstreamRequestJson),
       created_at: p.createdAt.getTime(),
     });
   });

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -813,6 +813,7 @@ describe("POST /v1/chat/completions — payload capture + streamed cost", () => 
       requestId: string;
       requestJson: string;
       responseJson: string | null;
+      upstreamRequestJson: string | null;
     }> = [];
     const telemetry = {
       insert: vi.fn(async (i: { decision: unknown }) => {
@@ -820,11 +821,17 @@ describe("POST /v1/chat/completions — payload capture + streamed cost", () => 
         return { id: "1" };
       }),
       insertPayload: vi.fn(
-        async (p: { requestId: string; requestJson: string; responseJson: string | null }) => {
+        async (p: {
+          requestId: string;
+          requestJson: string;
+          responseJson: string | null;
+          upstreamRequestJson?: string | null;
+        }) => {
           payloads.push({
             requestId: p.requestId,
             requestJson: p.requestJson,
             responseJson: p.responseJson,
+            upstreamRequestJson: p.upstreamRequestJson ?? null,
           });
         },
       ),
@@ -873,6 +880,42 @@ describe("POST /v1/chat/completions — payload capture + streamed cost", () => 
     expect(decision.cost_breakdown.completion_usd).toBeCloseTo(100 * 1e-6 + 50 * 2e-6);
     const okAttempt = decision.provider_attempts.find((a) => a.alias === "default_good_model");
     expect(okAttempt?.cost_usd).toBeCloseTo(100 * 1e-6 + 50 * 2e-6);
+  });
+
+  it("captures the forwarded upstream request (post inject + translation) alongside the inbound body", async () => {
+    const cap = captureTelemetry();
+    const { deps: d, harness } = deps({
+      telemetry: cap.telemetry,
+      capturePayloads: () => true,
+    });
+    // The EXACT serialized wire body the executor captured at the provider boundary —
+    // model patched + memory turn appended. Differs from the inbound body (NONSTREAM_BODY).
+    const upstreamRequest = JSON.stringify({
+      model: "gpt-x",
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "user", content: "<system-reminder># Persistent memory</system-reminder>" },
+      ],
+    });
+    harness.execute.mockResolvedValue({
+      ...nonStreamOutcome({ id: "cmpl-1", choices: [], usage: { completion_tokens: 1 } }),
+      upstreamRequest,
+    });
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(res.status).toBe(200);
+    await res.text();
+
+    expect(cap.payloads).toHaveLength(1);
+    // Inbound body captured verbatim (no memory turn) …
+    expect(cap.payloads[0]?.requestJson).not.toContain("Persistent memory");
+    // … and the forwarded upstream body captured verbatim (the wire bytes) WITH memory.
+    expect(cap.payloads[0]?.upstreamRequestJson).toBe(upstreamRequest);
   });
 
   it("backfills streamed cost even when capture_payloads is OFF (#6 ungated)", async () => {

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -492,13 +492,17 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     // batched when a write queue is wired, else the inline await (today's behavior).
     // Self-gates on capture_payloads exactly like persistPayload. The retention
     // prune rides along as a deferred task so it never blocks the response.
-    const capturePayload = async (responseJson: string | null) => {
+    const capturePayload = async (
+      responseJson: string | null,
+      upstreamRequestJson: string | null,
+    ) => {
       if (deps.writes !== undefined) {
         if (!captureEnabled(deps)) return;
         deps.writes.enqueuePayload({
           requestId: traceId,
           requestJson,
           responseJson,
+          upstreamRequestJson,
           createdAt: new Date(deps.now()),
         });
         const retentionMs = deps.payloadRetentionMs?.();
@@ -510,7 +514,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       }
       await persistPayload(
         deps,
-        { requestId: traceId, requestJson, responseJson, now: deps.now() },
+        { requestId: traceId, requestJson, responseJson, upstreamRequestJson, now: deps.now() },
         (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
       );
     };
@@ -815,7 +819,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
           } catch {
             c.get("logger").log("warn", "cost.stream_backfill_failed", { trace_id: traceId });
           }
-          await capturePayload(captureOn ? rawSse : null);
+          await capturePayload(captureOn ? rawSse : null, result.upstreamRequest ?? null);
           await persist(result.decision);
           // Usage-budget settle (streamed): runs HERE — after the usage tail
           // backfilled the streamed cost — so the spend dimension settles the real
@@ -863,7 +867,10 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         c.get("logger").log("warn", "tokens.backfill_failed", { trace_id: traceId });
       }
     }
-    await capturePayload(result.body !== null ? JSON.stringify(result.body) : null);
+    await capturePayload(
+      result.body !== null ? JSON.stringify(result.body) : null,
+      result.upstreamRequest ?? null,
+    );
     await persist(result.decision);
     if (result.final.status === "error" || result.body === null) {
       const error =

--- a/apps/gateway/src/routes/execute.default-config.test.ts
+++ b/apps/gateway/src/routes/execute.default-config.test.ts
@@ -208,6 +208,45 @@ describe("default config activates capability filter + cost (alias-namespace ali
     expect(calls).toEqual(["deepseek-v4-pro"]);
   });
 
+  it("threads a captureUpstream sink to the served provider and surfaces it as outcome.upstreamRequest", async () => {
+    // A stub that fires captureUpstream with the EXACT body it is about to POST — the
+    // execute layer must collect that string into ExecuteOutcome.upstreamRequest, NOT
+    // the pre-call stripInternal input (Codex P2: capture the real wire body).
+    let fired: string | null = null;
+    const client = {
+      chatCompletion: vi.fn(
+        async (body: Record<string, unknown>, opts?: { captureUpstream?: (b: string) => void }) => {
+          fired = JSON.stringify(body);
+          opts?.captureUpstream?.(fired);
+          return {
+            id: "chatcmpl-stub",
+            choices: [
+              { index: 0, message: { role: "assistant", content: "{}" }, finish_reason: "stop" },
+            ],
+            usage: { prompt_tokens: 1, completion_tokens: 1 },
+          };
+        },
+      ),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: client,
+      providers: providerClients(client),
+      registry: buildRegistry(),
+      breaker: breaker(),
+      catalog,
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+    const out = await execute(plan(["deepseek/deepseek-v4-flash"]), req({}));
+    expect(out.final.status).toBe("ok");
+    expect(fired).not.toBeNull();
+    // outcome carries the EXACT captured wire string …
+    expect(out.upstreamRequest).toBe(fired);
+    // … and it is the RESOLVED bare upstream model (post stripInternal), not the alias.
+    expect(JSON.parse(out.upstreamRequest ?? "null").model).toBe("deepseek-v4-flash");
+  });
+
   it("the shipped `json` lane serves its json-capable primary and never reaches the */auto tail", async () => {
     const { client, calls } = stubProvider();
     const execute = createExecute({

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -765,6 +765,14 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       //    provider model (not the originally-requested alias) — the gateway
       //    picked this model, so the upstream must be told which one to run.
       try {
+        // Capture sink for the EXACT bytes forwarded upstream (AFTER memory injection +
+        // protocol translation). Each provider fires this just before its HTTP POST with
+        // the serialized provider-native body; the value the SERVED attempt captured
+        // becomes ExecuteOutcome.upstreamRequest. Scoped per candidate (reset each loop).
+        let capturedUpstream: string | null = null;
+        const captureUpstream = (wireBody: string): void => {
+          capturedUpstream = wireBody;
+        };
         if (req.stream && passthrough.passthrough_used) {
           // Native STREAMING passthrough (issue #217, Phase 2): forward the client's
           // VERBATIM native body (which ALREADY carries stream:true) to the upstream and
@@ -800,7 +808,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           }
           passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
           const stream = await peekStream(
-            () => passthroughStream(passthroughBody, { signal }),
+            () => passthroughStream(passthroughBody, { signal, captureUpstream }),
             signal,
             alias,
             log,
@@ -814,6 +822,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             body: null,
             stream,
             nativePassthrough: true,
+            upstreamRequest: capturedUpstream,
           };
         }
         if (req.stream) {
@@ -829,7 +838,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             ),
           );
           const stream = await peekStream(
-            () => provider.chatCompletionStream(rendered.body, { signal }),
+            () => provider.chatCompletionStream(rendered.body, { signal, captureUpstream }),
             signal,
             alias,
             log,
@@ -842,6 +851,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             final: { status: "ok", alias, providerModel },
             body: null,
             stream,
+            upstreamRequest: capturedUpstream,
           };
         }
         if (passthrough.passthrough_used) {
@@ -874,7 +884,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
           }
           passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
-          const body = await passthroughInvoke(passthroughBody, { signal });
+          const body = await passthroughInvoke(passthroughBody, { signal, captureUpstream });
           breaker.recordSuccess(alias);
           const usage =
             req.protocol === "openai_responses"
@@ -890,11 +900,12 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             body,
             stream: null,
             nativePassthrough: true,
+            upstreamRequest: capturedUpstream,
           };
         }
         const bodyReq = stripInternal(req, providerModel, target.targetProviderProtocol);
         attemptTelemetry = withRequestMutations(passthrough, bodyReq.request_mutations);
-        const body = await provider.chatCompletion(bodyReq.body, { signal });
+        const body = await provider.chatCompletion(bodyReq.body, { signal, captureUpstream });
         breaker.recordSuccess(alias);
         attempts.push(okRow(alias, elapsed(), costOf(alias, body), attemptTelemetry));
         return {
@@ -902,6 +913,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           final: { status: "ok", alias, providerModel },
           body,
           stream: null,
+          upstreamRequest: capturedUpstream,
         };
       } catch (err) {
         // Client abort: non-provider fault. Terminate the chain WITHOUT marking a

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -438,6 +438,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
                 decision: result.decision,
                 requestJson,
                 responseJson: captureBodies ? captured.join("") : null,
+                upstreamRequestJson: result.upstreamRequest ?? null,
               },
               (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
             );
@@ -467,6 +468,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
             decision: result.decision,
             requestJson,
             responseJson: null,
+            upstreamRequestJson: result.upstreamRequest ?? null,
           },
           (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
         );
@@ -491,6 +493,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
           decision: result.decision,
           requestJson,
           responseJson: captureBodies ? JSON.stringify(body) : null,
+          upstreamRequestJson: result.upstreamRequest ?? null,
         },
         (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
       );

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -826,6 +826,9 @@ export function createMessagesPipeline(
         // response. The route reads this to BYPASS transformResponseOut and hand the
         // native body back byte-for-byte. Absent/false → today's translate path.
         nativePassthrough: result.nativePassthrough === true,
+        // The exact body forwarded upstream for the served attempt (post inject +
+        // translation). Exposed so the three faces capture it into the payload table.
+        upstreamRequest: result.upstreamRequest,
         async collect(): Promise<unknown> {
           if (failure !== null) throw failure;
           // Native passthrough (#217): the upstream's response is already in the

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -90,6 +90,11 @@ export interface PipelineRunResult {
    *  response. The route reads this to BYPASS transformResponseOut and hand the
    *  native body back byte-for-byte. Absent/false → today's translate path. */
   readonly nativePassthrough?: boolean;
+  /** The EXACT serialized wire body forwarded upstream for the served attempt (post
+   *  memory-inject + protocol-translation, captured at the provider's HTTP boundary).
+   *  Each face writes it verbatim into the captured payload so the admin sees what the
+   *  model actually received. Null/absent on a routing failure (no served attempt). */
+  readonly upstreamRequest?: string | null;
   /** Drain the full (non-stream) result into ONE IR response object. */
   collect(): Promise<unknown>;
   /** The outbound-protocol event stream: one object per wire event. For Anthropic
@@ -563,6 +568,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
                 decision: result.decision,
                 requestJson,
                 responseJson: captureBodies ? captured.join("") : null,
+                upstreamRequestJson: result.upstreamRequest ?? null,
               },
               (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
             );
@@ -599,6 +605,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
             decision: result.decision,
             requestJson,
             responseJson: null,
+            upstreamRequestJson: result.upstreamRequest ?? null,
           },
           (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
         );
@@ -623,6 +630,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
           decision: result.decision,
           requestJson,
           responseJson: captureBodies ? JSON.stringify(body) : null,
+          upstreamRequestJson: result.upstreamRequest ?? null,
         },
         (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
       );

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -123,6 +123,9 @@ export async function recordServed(
     decision: DecisionRecord;
     requestJson: string;
     responseJson: string | null;
+    // The exact body forwarded upstream (post inject + translation); null when no
+    // provider served or capture context lacks it.
+    upstreamRequestJson?: string | null;
   },
   log: (msg: string) => void,
 ): Promise<void> {
@@ -136,6 +139,7 @@ export async function recordServed(
         requestId: args.requestId,
         requestJson: args.requestJson,
         responseJson: args.responseJson,
+        upstreamRequestJson: args.upstreamRequestJson ?? null,
         createdAt: new Date(deps.now()),
       });
       const retentionMs = deps.payloadRetentionMs?.();
@@ -159,6 +163,7 @@ export async function recordServed(
       requestId: args.requestId,
       requestJson: args.requestJson,
       responseJson: args.responseJson,
+      upstreamRequestJson: args.upstreamRequestJson ?? null,
       now: deps.now(),
     },
     log,
@@ -381,7 +386,13 @@ export function usageFromResponsesSSE(raw: string): StreamUsage | null {
 // rows. Never throws — logs via the provided sink on failure.
 export async function persistPayload(
   deps: PayloadCaptureDeps,
-  args: { requestId: string; requestJson: string; responseJson: string | null; now: number },
+  args: {
+    requestId: string;
+    requestJson: string;
+    responseJson: string | null;
+    upstreamRequestJson?: string | null;
+    now: number;
+  },
   log: (msg: string) => void,
 ): Promise<void> {
   if (!captureEnabled(deps)) return;
@@ -390,6 +401,7 @@ export async function persistPayload(
       requestId: args.requestId,
       requestJson: args.requestJson,
       responseJson: args.responseJson,
+      upstreamRequestJson: args.upstreamRequestJson ?? null,
       createdAt: new Date(args.now),
     });
     const retentionMs = deps.payloadRetentionMs?.();

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -602,6 +602,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                 decision: result.decision,
                 requestJson,
                 responseJson: captureBodies ? captured.join("") : null,
+                upstreamRequestJson: result.upstreamRequest ?? null,
               },
               (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
             );
@@ -654,6 +655,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
             decision: result.decision,
             requestJson,
             responseJson: null,
+            upstreamRequestJson: result.upstreamRequest ?? null,
           },
           (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
         );
@@ -693,6 +695,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           decision: result.decision,
           requestJson,
           responseJson: captureBodies ? JSON.stringify(body) : null,
+          upstreamRequestJson: result.upstreamRequest ?? null,
         },
         (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
       );

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -1116,6 +1116,44 @@ describe("createAnthropicClient", () => {
     expect(client.nativeProtocolProfile).toBe("anthropic_messages");
   });
 
+  it("captureUpstream receives the EXACT Anthropic-native wire body on the TRANSLATE path (not the OpenAI input)", async () => {
+    let wireBody = "";
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      wireBody = String(init?.body);
+      return jsonResponse({
+        id: "msg",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    let captured: string | null = null;
+    // An OpenAI-Chat request routed to Anthropic → the adapter translates it to
+    // Anthropic-native before POSTing. Codex P2: the capture must be the NATIVE body,
+    // not this OpenAI input.
+    await client.chatCompletion(
+      { model: "claude-x", messages: [{ role: "user", content: "hi" }], max_tokens: 64 },
+      {
+        captureUpstream: (b) => {
+          captured = b;
+        },
+      },
+    );
+    // Captured the EXACT bytes that hit the wire …
+    expect(captured).toBe(wireBody);
+    // … and they are Anthropic-native (max_tokens is a required Anthropic field set by
+    // the OpenAI→Anthropic translation), proving we capture post-translation, not the
+    // pre-translation adapter input.
+    const parsed = JSON.parse(captured ?? "null") as Record<string, unknown>;
+    expect(parsed.model).toBe("claude-x");
+    expect(parsed.max_tokens).toBe(64);
+    expect(Array.isArray(parsed.messages)).toBe(true);
+  });
+
   it("sends Bearer + Claude-Code identity headers + system spoof; 401-retries once", async () => {
     let calls = 0;
     const seenAuth: string[] = [];

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -661,6 +661,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     external?: AbortSignal,
     endpointUrl = url,
     extraBetas: readonly string[] = [],
+    capture?: (wireBody: string) => void,
   ): Promise<Response> {
     const body = nativePassthroughBody(input);
     const prepared = prepareNativePassthroughRequest(input, await headers(body, extraBetas), {
@@ -670,6 +671,10 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         ? { providerProfileApplied: "anthropic_official_safe" }
         : {}),
     });
+    // The exact Anthropic-native bytes POSTed upstream — for the translate path this is
+    // the OpenAI→Anthropic re-serialization, for native passthrough the verbatim body
+    // (model patched). Surfaced before the first fetch so the gateway captures it.
+    capture?.(prepared.bodyText);
     // Retry transient connection blips at the fetch boundary (pre-first-byte → idempotent);
     // a timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
     return withConnectionRetry(
@@ -700,12 +705,13 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     external?: AbortSignal,
     endpointUrl = url,
     extraBetas: readonly string[] = [],
+    capture?: (wireBody: string) => void,
   ): Promise<Response> {
-    const res = await request(body, external, endpointUrl, extraBetas);
+    const res = await request(body, external, endpointUrl, extraBetas, capture);
     if (res.status === 401 && cfg.onUnauthorized !== undefined) {
       await res.body?.cancel().catch(() => {});
       cfg.onUnauthorized();
-      return await request(body, external, endpointUrl, extraBetas);
+      return await request(body, external, endpointUrl, extraBetas, capture);
     }
     return res;
   }
@@ -731,6 +737,9 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
       const res = await requestWithRetry(
         openaiToAnthropicRequest(req, { metadataUserId: cfg.metadataUserId }),
         opts?.signal,
+        url,
+        [],
+        opts?.captureUpstream,
       );
       if (!res.ok) throw await errorFromResponse(res);
       const anthResp = (await res.json()) as Record<string, unknown>;
@@ -743,7 +752,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         ...openaiToAnthropicRequest(req, { metadataUserId: cfg.metadataUserId }),
         stream: true,
       };
-      const res = await requestWithRetry(body, opts?.signal);
+      const res = await requestWithRetry(body, opts?.signal, url, [], opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
       yield* translateAnthropicSSE(res, model, timeoutMs);
     },
@@ -757,7 +766,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     // beta/user-agent/auth from the native body's own system[0]/context_management/speed,
     // so the same closure works unchanged on a native body.
     async nativePassthrough(body, opts) {
-      const res = await requestWithRetry(body, opts?.signal);
+      const res = await requestWithRetry(body, opts?.signal, url, [], opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as Record<string, unknown>;
     },
@@ -775,7 +784,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     // chatCompletionStream), then the upstream SSE is BYTE-RELAYED unchanged via
     // readAnthropicSSERaw — no SSE re-mapping state machine to mis-translate (principle 8).
     async *nativePassthroughStream(body, opts) {
-      const res = await requestWithRetry(body, opts?.signal);
+      const res = await requestWithRetry(body, opts?.signal, url, [], opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
       yield* readAnthropicSSERaw(res, timeoutMs);
     },

--- a/packages/core/src/provider/gemini.ts
+++ b/packages/core/src/provider/gemini.ts
@@ -545,6 +545,7 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
     operation: "generateContent" | "streamGenerateContent" | "countTokens",
     input: NativePassthroughInput,
     external?: AbortSignal,
+    capture?: (wireBody: string) => void,
   ): Promise<Response> {
     const { model, body } = bodyAndModel(input);
     const t = withTimeout(timeoutMs, external);
@@ -556,10 +557,14 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
         t.signal,
         dnsLookup,
       );
+      // The exact Gemini-native bytes POSTed upstream (after remote-media materialization
+      // + OpenAI→Gemini translation on the translate path) — surfaced for capture.
+      const wireBody = JSON.stringify(materializedBody);
+      capture?.(wireBody);
       return await doFetch(endpoint(cfg.baseUrl, model, operation), {
         method: "POST",
         headers: await headers(),
-        body: JSON.stringify(materializedBody),
+        body: wireBody,
         signal: t.signal,
       });
     } catch (err) {
@@ -576,12 +581,13 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
     operation: "generateContent" | "streamGenerateContent" | "countTokens",
     input: NativePassthroughInput,
     external?: AbortSignal,
+    capture?: (wireBody: string) => void,
   ): Promise<Response> {
-    const res = await request(operation, input, external);
+    const res = await request(operation, input, external, capture);
     if (res.status === 401 && cfg.onUnauthorized !== undefined) {
       await res.body?.cancel().catch(() => {});
       cfg.onUnauthorized();
-      return await request(operation, input, external);
+      return await request(operation, input, external, capture);
     }
     return res;
   }
@@ -636,7 +642,12 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
     // transformers instead of failing — mirrors the anthropic client's translated path.
     async chatCompletion(req, opts) {
       const { model, body } = openAIChatToGeminiBody(req);
-      const res = await requestWithAuthRetry("generateContent", { ...body, model }, opts?.signal);
+      const res = await requestWithAuthRetry(
+        "generateContent",
+        { ...body, model },
+        opts?.signal,
+        opts?.captureUpstream,
+      );
       if (!res.ok) throw await errorFromResponse(res);
       return geminiResponseToOpenAIChat(await res.json());
     },
@@ -647,6 +658,7 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
         "streamGenerateContent",
         { ...body, model },
         opts?.signal,
+        opts?.captureUpstream,
       );
       if (!res.ok) throw await errorFromResponse(res);
       // Gemini native SSE → IR chunks → OpenAI SSE strings. IRChunk IS the OpenAI
@@ -660,13 +672,23 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
     },
 
     async nativePassthrough(input, opts) {
-      const res = await requestWithAuthRetry("generateContent", input, opts?.signal);
+      const res = await requestWithAuthRetry(
+        "generateContent",
+        input,
+        opts?.signal,
+        opts?.captureUpstream,
+      );
       if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as Record<string, unknown>;
     },
 
     async *nativePassthroughStream(input, opts) {
-      const res = await requestWithAuthRetry("streamGenerateContent", input, opts?.signal);
+      const res = await requestWithAuthRetry(
+        "streamGenerateContent",
+        input,
+        opts?.signal,
+        opts?.captureUpstream,
+      );
       if (!res.ok) throw await errorFromResponse(res);
       yield* readRawSSE(res);
     },

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -446,7 +446,11 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     return changed ? JSON.parse(value) : raw;
   }
 
-  async function request(input: NativePassthroughInput, external?: AbortSignal): Promise<Response> {
+  async function request(
+    input: NativePassthroughInput,
+    external?: AbortSignal,
+    capture?: (wireBody: string) => void,
+  ): Promise<Response> {
     const providerHeaders = await headers();
     if (isNativePassthroughCarrier(input) && cfg.userAgent === undefined) {
       const hasClientUserAgent = Object.keys(input.headers).some(
@@ -457,6 +461,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     const prepared = prepareNativePassthroughRequest(input, providerHeaders, {
       mergeHeaders: ["openai-beta"],
     });
+    // The exact Responses-native bytes POSTed upstream (translate path: OpenAI→Responses
+    // re-serialization; native passthrough: verbatim, model patched) — surfaced for capture.
+    capture?.(prepared.bodyText);
     // Retry transient connection blips at the fetch boundary (pre-first-byte → idempotent);
     // a timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
     return withConnectionRetry(
@@ -498,12 +505,13 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   async function requestWithRetry(
     body: NativePassthroughInput,
     external?: AbortSignal,
+    capture?: (wireBody: string) => void,
   ): Promise<Response> {
-    const res = await request(body, external);
+    const res = await request(body, external, capture);
     if (res.status === 401 && cfg.onUnauthorized !== undefined) {
       await res.body?.cancel().catch(() => {});
       cfg.onUnauthorized();
-      const retried = await request(body, external);
+      const retried = await request(body, external, capture);
       fireResponseMeta(retried);
       return retried;
     }
@@ -539,6 +547,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       const res = await requestWithRetry(
         openaiToResponsesRequest(req, { sessionId: cfg.sessionId }),
         opts?.signal,
+        opts?.captureUpstream,
       );
       if (!res.ok) throw await errorFromResponse(res);
       // Codex is stream-only → aggregate the SSE into a single Chat response.
@@ -550,6 +559,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       const res = await requestWithRetry(
         openaiToResponsesRequest(req, { sessionId: cfg.sessionId }),
         opts?.signal,
+        opts?.captureUpstream,
       );
       if (!res.ok) throw await errorFromResponse(res);
       yield* translateResponsesSSE(res, model, timeoutMs);
@@ -565,7 +575,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     // identity headers (Bearer + chatgpt-account-id + originator + OpenAI-Beta) are applied
     // by `headers()` inside the shared core, so they ride on the native body unchanged.
     async nativePassthrough(body, opts) {
-      const res = await requestWithRetry(body, opts?.signal);
+      const res = await requestWithRetry(body, opts?.signal, opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as Record<string, unknown>;
     },
@@ -577,7 +587,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     // the upstream Responses SSE is BYTE-RELAYED unchanged via readResponsesSSERaw — no SSE
     // re-mapping state machine to mangle reasoning.encrypted_content / tools (principle 8).
     async *nativePassthroughStream(body, opts) {
-      const res = await requestWithRetry(body, opts?.signal);
+      const res = await requestWithRetry(body, opts?.signal, opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
       yield* readResponsesSSERaw(res, timeoutMs);
     },
@@ -684,6 +694,7 @@ export function createGenericOpenAIResponsesClient(
       body?: NativePassthroughInput;
       accept?: string;
       signal?: AbortSignal;
+      captureUpstream?: (wireBody: string) => void;
     },
   ): Promise<Response> {
     const headers = await providerHeaders(init.accept);
@@ -693,6 +704,9 @@ export function createGenericOpenAIResponsesClient(
       const prepared = prepareNativePassthroughRequest(init.body, headers);
       requestHeaders = prepared.headers;
       bodyText = prepared.bodyText;
+      // Exact Responses-native bytes POSTed upstream (post OpenAI→Responses translation
+      // on the translate path) — surfaced for forwarded-upstream capture.
+      init.captureUpstream?.(bodyText);
     }
     const res = await fetchWithTimeout(
       await endpoint(path),
@@ -712,6 +726,7 @@ export function createGenericOpenAIResponsesClient(
         const prepared = prepareNativePassthroughRequest(init.body, refreshedHeaders);
         retryHeaders = prepared.headers;
         retryBodyText = prepared.bodyText;
+        init.captureUpstream?.(retryBodyText);
       }
       return await fetchWithTimeout(
         await endpoint(path),
@@ -735,6 +750,7 @@ export function createGenericOpenAIResponsesClient(
         method: "POST",
         body: openaiToGenericResponsesRequest(req),
         signal: opts?.signal,
+        captureUpstream: opts?.captureUpstream,
       });
       if (!res.ok) throw await errorFromResponse(res);
       return responsesJsonToChatResponse((await res.json()) as Record<string, unknown>, model);
@@ -747,6 +763,7 @@ export function createGenericOpenAIResponsesClient(
         body: { ...openaiToGenericResponsesRequest(req), stream: true },
         accept: "text/event-stream",
         signal: opts?.signal,
+        captureUpstream: opts?.captureUpstream,
       });
       if (!res.ok) throw await errorFromResponse(res);
       yield* translateResponsesSSE(res, model, timeoutMs);
@@ -757,6 +774,7 @@ export function createGenericOpenAIResponsesClient(
         method: "POST",
         body,
         signal: opts?.signal,
+        captureUpstream: opts?.captureUpstream,
       });
       if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as Record<string, unknown>;
@@ -768,6 +786,7 @@ export function createGenericOpenAIResponsesClient(
         body,
         accept: "text/event-stream",
         signal: opts?.signal,
+        captureUpstream: opts?.captureUpstream,
       });
       if (!res.ok) throw await errorFromResponse(res);
       yield* readResponsesSSERaw(res, timeoutMs);

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -60,16 +60,29 @@ export type NativeProtocolProfile =
   | "generic_openai_responses"
   | "gemini";
 
+// Options for a completion / native-passthrough call. `captureUpstream`, when
+// supplied, is invoked with the EXACT serialized request body bytes the client is
+// about to POST upstream — AFTER any OpenAI→native translation, just before the HTTP
+// request. The gateway uses it to record the forwarded-upstream payload (what the
+// model actually received), which differs from the inbound client body for both the
+// translate path (re-serialized to the provider's native shape) and native passthrough
+// (model patched to the resolved upstream id). Fires once per fetch attempt (idempotent
+// across connection / 401 retries — same body). MUST NOT throw (capture is fail-open).
+export interface ProviderCallOptions {
+  signal?: AbortSignal;
+  captureUpstream?: (wireBody: string) => void;
+}
+
 export interface ProviderClient {
   nativeProtocolProfile?: NativeProtocolProfile;
   streamReframed?: boolean;
   chatCompletion(
     req: ChatCompletionRequest,
-    opts?: { signal?: AbortSignal },
+    opts?: ProviderCallOptions,
   ): Promise<ChatCompletionResponse>;
   chatCompletionStream(
     req: ChatCompletionRequest,
-    opts?: { signal?: AbortSignal },
+    opts?: ProviderCallOptions,
   ): AsyncIterable<string>;
   // Native protocol passthrough (issue #217, Phase 1). OPTIONAL so every existing
   // client and test double stays valid without change; the executor feature-detects
@@ -79,7 +92,7 @@ export interface ProviderClient {
   // implement it; the guard (canUseNativePassthrough) gates when it may be used.
   nativePassthrough?(
     request: NativePassthroughInput,
-    opts?: { signal?: AbortSignal },
+    opts?: ProviderCallOptions,
   ): Promise<Record<string, unknown>>;
   // Streaming native protocol passthrough (issue #217, Phase 2). The streaming sibling
   // of nativePassthrough: forwards the client's VERBATIM native body (which ALREADY
@@ -89,7 +102,7 @@ export interface ProviderClient {
   // clients implement it, gated by the same guard as nativePassthrough.
   nativePassthroughStream?(
     request: NativePassthroughInput,
-    opts?: { signal?: AbortSignal },
+    opts?: ProviderCallOptions,
   ): AsyncIterable<string>;
   countTokens?(
     req: ChatCompletionRequest,
@@ -312,7 +325,12 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
   async function request(
     req: ChatCompletionRequest,
     external: AbortSignal | undefined,
+    capture?: (wireBody: string) => void,
   ): Promise<Response> {
+    // The exact bytes POSTed upstream — deterministic in `req`, so computed once
+    // (outside the retry loop) and surfaced to the capture sink before the first fetch.
+    const bodyText = JSON.stringify(prepareRequest(req));
+    capture?.(bodyText);
     // Retry transient connection blips at the fetch boundary (pre-first-byte, so
     // idempotent). A timeout is rethrown as UpstreamError (non-transient → no retry,
     // the chain falls back); a client abort rethrows as-is. Each attempt gets a fresh
@@ -324,7 +342,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
           return await doFetch(await chatUrl(), {
             method: "POST",
             headers: await headers(),
-            body: JSON.stringify(prepareRequest(req)),
+            body: bodyText,
             signal: t.signal,
           });
         } catch (err) {
@@ -349,13 +367,14 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
   async function requestWithAuthRetry(
     req: ChatCompletionRequest,
     external: AbortSignal | undefined,
+    capture?: (wireBody: string) => void,
   ): Promise<Response> {
-    const res = await request(req, external);
+    const res = await request(req, external, capture);
     if (res.status === 401 && cfg.onUnauthorized !== undefined) {
       // Discard the 401 body (it may echo the credential) before refreshing.
       await res.body?.cancel().catch(() => {});
       cfg.onUnauthorized();
-      return await request(req, external); // exactly one retry with the new token
+      return await request(req, external, capture); // exactly one retry with the new token
     }
     return res;
   }
@@ -377,7 +396,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     ...(cfg.normalizeReasoningDeltaAlias ? { streamReframed: true } : {}),
 
     async chatCompletion(req, opts) {
-      const res = await requestWithAuthRetry(req, opts?.signal);
+      const res = await requestWithAuthRetry(req, opts?.signal, opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as ChatCompletionResponse;
     },
@@ -386,7 +405,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       // 401-retry happens here, BEFORE getReader() / any chunk is yielded, so the
       // SSE stream is replayed cleanly from the start (principle 8 — no duplicated
       // or half-emitted events).
-      const res = await requestWithAuthRetry(req, opts?.signal);
+      const res = await requestWithAuthRetry(req, opts?.signal, opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
       const body = res.body;
       if (!body) return;

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -147,6 +147,18 @@ describe("routeRequest — orchestration", () => {
     expect(rec.final.model_alias).toBe("coder_a");
   });
 
+  it("forwards the executor's upstreamRequest onto the ExecutionResult (ok branch)", async () => {
+    // The EXACT serialized wire body the provider captured (a string), forwarded verbatim.
+    const upstreamRequest = JSON.stringify({
+      model: "coder-a-model",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const d = deps({ execute: vi.fn(async () => ({ ...okExecute(), upstreamRequest })) });
+    const result = await routeRequest(req(), d);
+    expect(result.final.status).toBe("ok");
+    expect(result.upstreamRequest).toBe(upstreamRequest);
+  });
+
   it("ignores a spoofed x-project-id (memory scope) for routing — a project_id policy does NOT match", async () => {
     // A client sets x-project-id to a value a server-side project_id policy targets.
     // The memory header rides metadata.project_id, but routing must NOT trust it

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -130,6 +130,12 @@ export interface ExecuteOutcome {
   // reads this to BYPASS `openAIBodyToIR`/`transformResponseOut` and return the
   // native body to the client untouched. Absent/false → the normal translate path.
   nativePassthrough?: boolean;
+  // The EXACT serialized request body bytes forwarded upstream for the SERVED attempt
+  // — AFTER memory injection + protocol translation (provider-native shape, model
+  // patched to the resolved upstream id). Captured at the provider's HTTP boundary, so
+  // it is the real wire body the model received, NOT the pre-translation adapter input.
+  // null when no provider served. The gateway records it to the payload table; never logged.
+  upstreamRequest?: string | null;
 }
 
 // The orchestrator's return value: the executor outcome enriched with the
@@ -144,6 +150,10 @@ export interface ExecutionResult {
   // is the upstream's verbatim native response, so the gateway skips response
   // translation. Only set on the ok branch.
   nativePassthrough?: boolean;
+  // Forwarded from ExecuteOutcome.upstreamRequest: the EXACT serialized wire body sent
+  // upstream for the served attempt (post inject + translation). The gateway writes it
+  // verbatim to the captured payload. Only set on the ok branch.
+  upstreamRequest?: string | null;
 }
 
 export interface RouteDeps {
@@ -813,6 +823,9 @@ export async function routeRequest(
       // Forward the verbatim-native-response marker so the presentation surface
       // can bypass response translation (issue #217).
       nativePassthrough: outcome.nativePassthrough,
+      // Forward the exact body sent upstream so the gateway can capture it into the
+      // payload table (what the model actually received, post inject + translation).
+      upstreamRequest: outcome.upstreamRequest,
     };
   }
   return {

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -135,7 +135,10 @@ class InMemoryTelemetryStore implements TelemetryStore {
   }
   private readonly payloads = new Map<string, RequestPayload>();
   async insertPayload(input: InsertPayloadInput): Promise<void> {
-    this.payloads.set(input.requestId, { ...input });
+    this.payloads.set(input.requestId, {
+      ...input,
+      upstreamRequestJson: input.upstreamRequestJson ?? null,
+    });
   }
   async getPayload(requestId: string): Promise<RequestPayload | null> {
     return this.payloads.get(requestId) ?? null;

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -207,6 +207,12 @@ export interface InsertPayloadInput {
   requestId: string;
   requestJson: string; // verbatim client request body, serialized
   responseJson: string | null; // assembled full response (null on error / unknown)
+  // The EXACT provider-native body forwarded upstream — AFTER memory injection and
+  // protocol translation (model patched to the resolved upstream id). This is what
+  // the model actually received; the diff vs requestJson is the injected memory +
+  // translation. Null when capture is off, no provider served, or pre-feature rows.
+  // Like requestJson it carries NO plaintext key (the bearer is an HTTP header).
+  upstreamRequestJson?: string | null;
   createdAt: Date;
 }
 
@@ -214,6 +220,7 @@ export interface RequestPayload {
   requestId: string;
   requestJson: string;
   responseJson: string | null;
+  upstreamRequestJson: string | null;
   createdAt: Date;
 }
 

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -128,7 +128,9 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // ALTER would fail — pre-mark applied, out of scope for this jobs upgrade.
     // v22 (oauth_usage day→bucket_ms rename): this fixture never creates oauth_usage,
     // so the RENAME would fail — pre-marked, out of scope.
-    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22]) {
+    // v23 adds request_payloads.upstream_request_json; this memory_jobs fixture
+    // never creates request_payloads → pre-mark applied (out of scope).
+    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
       );
@@ -220,8 +222,9 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // v21 (telemetry token columns) is pre-marked too: no telemetry table here, so
     // its ALTER would fail — keep the test scoped to v20. v22 (oauth_usage rename)
     // likewise: no oauth_usage table here, so its RENAME would fail — pre-marked.
+    // v23 adds request_payloads.upstream_request_json (table absent here) → pre-mark.
     for (const version of [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23,
     ]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -475,6 +475,16 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_oauth_usage_bucket_ms ON oauth_usage (bucket_ms);
     `,
   },
+  {
+    // Forwarded-upstream request capture (mirrors sqlite v24): the EXACT provider-
+    // native body sent upstream (AFTER memory injection + protocol translation).
+    // Additive + nullable (NULL = pre-feature row / capture off / no provider
+    // served); forward-only. TEXT to round-trip exact bytes; NO plaintext key.
+    version: 23,
+    sql: `
+      ALTER TABLE request_payloads ADD COLUMN upstream_request_json TEXT;
+    `,
+  },
 ];
 
 // Anything that can run a raw SQL string against the Postgres connection. Both

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -256,6 +256,9 @@ export const requestPayloads = pgTable("request_payloads", {
   requestId: text("request_id").primaryKey(),
   requestJson: text("request_json").notNull(),
   responseJson: text("response_json"),
+  // EXACT body forwarded upstream (post memory-inject + protocol-translation). NULL
+  // when capture off / no provider served / pre-feature row. NO plaintext key.
+  upstreamRequestJson: text("upstream_request_json"),
   createdAt: bigint("created_at", { mode: "number" }).notNull(),
 });
 

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -250,6 +250,7 @@ export class PgTelemetryStore implements TelemetryStore {
         requestId: input.requestId,
         requestJson: input.requestJson,
         responseJson: input.responseJson,
+        upstreamRequestJson: input.upstreamRequestJson ?? null,
         createdAt: input.createdAt.getTime(),
       })
       .onConflictDoUpdate({
@@ -257,6 +258,7 @@ export class PgTelemetryStore implements TelemetryStore {
         set: {
           requestJson: input.requestJson,
           responseJson: input.responseJson,
+          upstreamRequestJson: input.upstreamRequestJson ?? null,
           createdAt: input.createdAt.getTime(),
         },
       });
@@ -274,6 +276,7 @@ export class PgTelemetryStore implements TelemetryStore {
             requestId: input.requestId,
             requestJson: input.requestJson,
             responseJson: input.responseJson,
+            upstreamRequestJson: input.upstreamRequestJson ?? null,
             createdAt: input.createdAt.getTime(),
           })
           .onConflictDoUpdate({
@@ -281,6 +284,7 @@ export class PgTelemetryStore implements TelemetryStore {
             set: {
               requestJson: input.requestJson,
               responseJson: input.responseJson,
+              upstreamRequestJson: input.upstreamRequestJson ?? null,
               createdAt: input.createdAt.getTime(),
             },
           });
@@ -300,6 +304,7 @@ export class PgTelemetryStore implements TelemetryStore {
       requestId: row.requestId,
       requestJson: row.requestJson,
       responseJson: row.responseJson,
+      upstreamRequestJson: row.upstreamRequestJson ?? null,
       createdAt: new Date(row.createdAt), // epoch-ms bigint → Date
     };
   }

--- a/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
+++ b/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
@@ -34,6 +34,9 @@ function seedPreV21(): string {
   for (let v = 1; v <= 20; v += 1) ins.run(v);
   ins.run(22);
   ins.run(23);
+  // v24 adds request_payloads.upstream_request_json; this fixture never creates
+  // request_payloads (memory_messages only) → pre-mark applied (out of scope).
+  ins.run(24);
   raw.exec(`
     CREATE TABLE memory_messages (
       id TEXT PRIMARY KEY,

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -357,6 +357,8 @@ describe("sqlite v18 forgetting schema deltas", () => {
       rec.run(22, Date.now());
       // v23 renames oauth_usage.day (also absent here) → pre-mark applied.
       rec.run(23, Date.now());
+      // v24 adds request_payloads.upstream_request_json (table absent here) → pre-mark.
+      rec.run(24, Date.now());
       seed.close();
 
       expect(() => runMigrations(path)).not.toThrow();

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -544,6 +544,18 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_oauth_usage_bucket_ms ON oauth_usage (bucket_ms);
     `,
   },
+  {
+    // Forwarded-upstream request capture: the EXACT provider-native body sent
+    // upstream (AFTER memory injection + protocol translation), so the admin
+    // request detail shows what the model actually received — not just the
+    // pre-injection client body. Additive + nullable (NULL = pre-feature row,
+    // capture off, or no provider served); forward-only. Verbatim bytes, no
+    // plaintext key (the bearer is an HTTP header, never the chat body).
+    version: 24,
+    sql: `
+      ALTER TABLE request_payloads ADD COLUMN upstream_request_json TEXT;
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database): void {

--- a/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
@@ -31,6 +31,9 @@ function seedPreV23(): string {
   raw.exec("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);");
   const ins = raw.prepare("INSERT INTO _migrations (version, applied_at) VALUES (?, 1)");
   for (let v = 1; v <= 22; v += 1) ins.run(v);
+  // v24 adds request_payloads.upstream_request_json; this fixture has no
+  // request_payloads table (only oauth_usage) → pre-mark applied (out of scope).
+  ins.run(24);
   raw.exec(`
     CREATE TABLE oauth_usage (
       provider_id TEXT NOT NULL,

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -59,7 +59,9 @@ describe("sqlite schema + migrations", () => {
       // ALTER would fail — pre-mark applied, out of scope for this v14–v16 test.
       // v23 (oauth_usage day→bucket_ms): v12 is applied without the oauth_usage
       // CREATE, so the RENAME would fail — pre-mark applied, out of scope.
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23])
+      // v24 adds request_payloads.upstream_request_json; this memory_jobs fixture
+      // never creates request_payloads → pre-mark applied (out of scope).
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23, 24])
         rec.run(v, Date.now());
       const insert = seed.prepare(
         "INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -262,7 +264,9 @@ describe("sqlite schema + migrations", () => {
       // v20 alters memory_threads (absent from this fixture) → pre-mark applied.
       // v21 dedups memory_messages (absent here) → pre-mark applied.
       // v22 alters telemetry (absent from this api_keys-only fixture) → pre-mark applied.
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22]) rec.run(v, Date.now());
+      // v24 adds request_payloads.upstream_request_json (table absent from this
+      // api_keys-only fixture) → pre-mark applied.
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22, 24]) rec.run(v, Date.now());
       seed
         .prepare(
           `INSERT INTO api_keys (key_id, hash, prefix, account_id, role, max_lane, allowed_lanes, created_at)

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -143,6 +143,9 @@ export const requestPayloads = sqliteTable("request_payloads", {
   requestId: text("request_id").primaryKey(),
   requestJson: text("request_json").notNull(), // verbatim client request body (JSON text)
   responseJson: text("response_json"), // assembled full response (null on error/unknown)
+  // EXACT body forwarded upstream (post memory-inject + protocol-translation). NULL
+  // when capture off / no provider served / pre-feature row. NO plaintext key.
+  upstreamRequestJson: text("upstream_request_json"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
 });
 

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -255,6 +255,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
         requestId: input.requestId,
         requestJson: input.requestJson,
         responseJson: input.responseJson,
+        upstreamRequestJson: input.upstreamRequestJson ?? null,
         createdAt: input.createdAt,
       })
       .onConflictDoUpdate({
@@ -262,6 +263,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
         set: {
           requestJson: input.requestJson,
           responseJson: input.responseJson,
+          upstreamRequestJson: input.upstreamRequestJson ?? null,
           createdAt: input.createdAt,
         },
       })
@@ -293,6 +295,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
       requestId: row.requestId,
       requestJson: row.requestJson,
       responseJson: row.responseJson,
+      upstreamRequestJson: row.upstreamRequestJson ?? null,
       createdAt: row.createdAt, // timestamp_ms mode → Date
     };
   }

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -913,17 +913,38 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         messages: [{ role: "user", content: "hi" }],
       });
       const responseJson = JSON.stringify({ choices: [{ message: { content: "yo" } }] });
+      const upstreamRequestJson = JSON.stringify({
+        model: "gpt-resolved",
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "user", content: "<system-reminder>memory</system-reminder>" },
+        ],
+      });
       await ctx.stores.telemetry.insertPayload({
         requestId: "req_1",
         requestJson,
         responseJson,
+        upstreamRequestJson,
         createdAt: new Date(5000),
       });
       const got = await ctx.stores.telemetry.getPayload("req_1");
       expect(got?.requestJson).toBe(requestJson);
       expect(got?.responseJson).toBe(responseJson);
+      expect(got?.upstreamRequestJson).toBe(upstreamRequestJson);
       expect(got?.createdAt.getTime()).toBe(5000);
       expect(await ctx.stores.telemetry.getPayload("nope")).toBeNull();
+    });
+
+    it("defaults the forwarded upstream request to null when omitted", async () => {
+      ctx = await make();
+      await ctx.stores.telemetry.insertPayload({
+        requestId: "req_no_upstream",
+        requestJson: "{}",
+        responseJson: null,
+        createdAt: new Date(5000),
+      });
+      const got = await ctx.stores.telemetry.getPayload("req_no_upstream");
+      expect(got?.upstreamRequestJson ?? null).toBeNull();
     });
 
     it("upserts a payload by request_id (request first, response backfilled)", async () => {


### PR DESCRIPTION
## What & why

The admin request-detail **payload** view showed only the **inbound client body**, captured *before* memory injection and protocol translation — so an operator could never see **what the model actually received**. Verified in prod: for a memory-injected request, the stored `request_json` did not contain helm's injected `<system-reminder>` block even though telemetry showed `memory_hydrated=true`.

This PR captures and displays the **exact provider-native request forwarded upstream** — post memory-injection + protocol-translation, with `model` patched to the resolved upstream id. The inbound body is kept too; the diff between the two is the injected memory + translation.

## How

Capture happens at the **wire boundary** inside each provider's `request()` (just before `doFetch`, *after* translation), via a `captureUpstream(wireBody)` callback on `ProviderCallOptions`. Because both the translate path and native passthrough funnel through the same `request()`, this records the true bytes for **every** path (OpenAI / Anthropic / Gemini / Responses-Codex / generic-Responses).

- **Store**: new nullable `request_payloads.upstream_request_json` (sqlite **v24** / postgres **v23**, additive `ADD COLUMN`). `InsertPayloadInput` / `RequestPayload` + both adapter upserts/reads.
- **Plumbing**: `execute()` provides a capture sink and surfaces it as `ExecuteOutcome.upstreamRequest` (the wire string), forwarded through `ExecutionResult` + `PipelineRunResult` to all four faces (chat / messages / responses / gemini).
- **Admin**: `/admin/api/requests/:id/payload` returns `upstream_request`; the detail page renders a **"Forwarded to upstream LLM"** panel; the existing panel is relabeled **"Request (from client)"**.
- **Safety**: fail-open, gated by the existing `capture_payloads` setting; `upstream_request_json` is `NULL` when capture is off / no provider served / pre-feature rows. The bearer stays in the Authorization header, never the body (Principle 7).

## Tests

TDD throughout; `pnpm typecheck` + `pnpm lint` + `pnpm build` + **3778 unit tests** all green. New coverage:
- **anthropic provider**: translate path's `captureUpstream` receives the **Anthropic-native** body (`max_tokens` present) equal to the actual wire bytes — proves we capture post-translation, not the OpenAI adapter input.
- **execute**: threads the sink to the served provider and surfaces `outcome.upstreamRequest`.
- **chat route**: full route → capture → store chain carries the forwarded body; inbound body stays verbatim.
- **store contract** (sqlite + pglite): `upstream_request_json` round-trips and defaults to null.
- **admin API**: payload endpoint returns parsed `upstream_request` (and null when absent).

## Deploy note

Additive nullable column — the `ADD COLUMN` is an O(1) metadata op on SQLite (no table rewrite, safe on the large prod DB). Pre-feature rows read `NULL` (no panel shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
