### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.15.0**. Merging to main triggers publish.yml to cut the v0.15.0 tag + GitHub Release and push `ghcr.io/easymetaau/helm-api:0.15.0` + `:latest`.

Ships since v0.14.2:
- feat(observability): capture the real request forwarded to the upstream LLM (#274)
- fix(gateway): fold Claude Code mid-conversation system messages (#273)

🤖 Generated with [Claude Code](https://claude.com/claude-code)