### PR TITLE
feat(admin): collapse the upstream-request panel when it matches the client body

### DIFF
--- a/apps/admin/src/lib/deep-equal.test.ts
+++ b/apps/admin/src/lib/deep-equal.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { deepEqual } from './deep-equal.js';
+
+describe('deepEqual', () => {
+  it('treats identical primitives / null as equal', () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual('a', 'a')).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+  });
+
+  it('distinguishes differing primitives and null vs object', () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual('a', 'b')).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual({}, null)).toBe(false);
+  });
+
+  it('compares nested objects structurally, ignoring key order', () => {
+    const inbound = { model: 'auto', messages: [{ role: 'user', content: 'hi' }], stream: false };
+    const same = { stream: false, messages: [{ content: 'hi', role: 'user' }], model: 'auto' };
+    expect(deepEqual(inbound, same)).toBe(true);
+  });
+
+  it('detects an injected memory turn (the real "differs" case)', () => {
+    const inbound = { model: 'auto', messages: [{ role: 'user', content: 'hi' }] };
+    const forwarded = {
+      model: 'claude-x',
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'user', content: '<system-reminder># Persistent memory</system-reminder>' },
+      ],
+    };
+    expect(deepEqual(inbound, forwarded)).toBe(false);
+  });
+
+  it('is array order-sensitive and length-sensitive', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2, 3], [3, 2, 1])).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  it('distinguishes an array from an object', () => {
+    expect(deepEqual([], {})).toBe(false);
+  });
+
+  it('detects extra / missing keys', () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  it('compares raw strings (non-JSON streamed bodies) directly', () => {
+    expect(deepEqual('data: [DONE]', 'data: [DONE]')).toBe(true);
+    expect(deepEqual('a', 'b')).toBe(false);
+  });
+});

--- a/apps/admin/src/lib/deep-equal.ts
+++ b/apps/admin/src/lib/deep-equal.ts
@@ -1,0 +1,34 @@
+// Structural equality for parsed-JSON values (objects / arrays / primitives /
+// strings). Used by the request-detail page to decide whether the body forwarded
+// upstream actually differs from the inbound client body — if they are equal there
+// is nothing to compare, so the UI collapses the two panels into one.
+//
+// Object key order is IGNORED (two objects with the same keys/values in a different
+// order are equal): the upstream body is re-serialized, so an order-only difference
+// is not a meaningful change to surface. Arrays ARE order-sensitive.
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
+    return false;
+  }
+  const aArr = Array.isArray(a);
+  const bArr = Array.isArray(b);
+  if (aArr !== bArr) return false;
+  if (aArr && bArr) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const aKeys = Object.keys(ao);
+  const bKeys = Object.keys(bo);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+    if (!deepEqual(ao[k], bo[k])) return false;
+  }
+  return true;
+}

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import type { RequestDetail, RequestPayloadView } from '$lib/api/requests.js';
+  import { deepEqual } from '$lib/deep-equal.js';
   import { formatTimestamp } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import CostBreakdown from '$lib/components/CostBreakdown.svelte';
@@ -48,6 +49,17 @@
   // off, or the payload was pruned).
   const replayBody = $derived(data.payload?.captured === true ? data.payload.request : undefined);
   const canRetry = $derived(!!replayBody && typeof replayBody === 'object');
+
+  // The forwarded-upstream body is worth a SEPARATE panel only when it actually
+  // differs from the inbound client body (memory injection / protocol translation /
+  // model patch). When they are structurally identical — e.g. a no-memory request to
+  // an OpenAI-shaped provider — a second panel is pure noise, so we collapse to one.
+  const hasUpstream = $derived(
+    data.payload?.captured === true && data.payload?.upstream_request != null,
+  );
+  const upstreamDiffers = $derived(
+    hasUpstream && !deepEqual(data.payload.request, data.payload.upstream_request),
+  );
 </script>
 
 <section class="flex w-full flex-col gap-4 px-4 py-6 md:px-8">
@@ -99,10 +111,20 @@
 
     <!-- Request: full captured body when capture_payloads is on, else metadata. -->
     <section class="card text-sm">
-      <h2 class="section-header">{$t('Request (from client)')}</h2>
+      <h2 class="section-header">
+        {upstreamDiffers ? $t('Request (from client)') : $t('Request')}
+      </h2>
       {#if data.payload?.captured}
         <p class="field-help mb-2">
-          {$t('The request body as received from the client — before memory injection and translation.')}
+          {#if upstreamDiffers}
+            {$t('The request body as received from the client — before memory injection and translation.')}
+          {:else if hasUpstream}
+            {$t(
+              'Full request body recorded for this call. The body forwarded upstream was identical (no memory injection or translation).',
+            )}
+          {:else}
+            {$t('Full request body recorded for this call.')}
+          {/if}
         </p>
         <JsonViewer value={data.payload.request} testid="request-body" />
       {:else}
@@ -119,9 +141,10 @@
     </section>
 
     <!-- Forwarded upstream request: the EXACT body sent to the provider, AFTER
-         memory injection + protocol translation. Only present when a provider
-         served and capture was on. This is what the model actually received. -->
-    {#if data.payload?.captured && data.payload?.upstream_request != null}
+         memory injection + protocol translation. Shown as a SEPARATE panel only when
+         it differs from the inbound body; when identical, the single "Request" panel
+         above already covers it (no duplicate). -->
+    {#if upstreamDiffers}
       <section class="card text-sm">
         <h2 class="section-header">{$t('Forwarded to upstream LLM')}</h2>
         <p class="field-help mb-2">


### PR DESCRIPTION
Follow-up to #274. The request-detail page showed a separate **Forwarded to upstream LLM** panel whenever a forwarded body was captured — even when it was identical to the inbound client body (no-memory request to an OpenAI-shaped provider). That second panel was pure noise.

Now:
- **Differs** (memory injection / translation / model patch) → two panels: `Request (from client)` + `Forwarded to upstream LLM`.
- **Identical** → one neutral `Request` panel + a note that the forwarded body was identical.
- **Not captured** → unchanged.

Adds a small tested `deepEqual` helper (ignores object key order since the upstream body is re-serialized; arrays stay order-sensitive). Admin-only; svelte-check + biome + 8 unit tests + admin build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)