### PR TITLE
chore(release): v0.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.15.2** (patch, admin i18n). Merging triggers publish.yml to cut tag v0.15.2 + Release and push :0.15.2 + :latest.

- chore(i18n): sync locales for the upstream-request payload panels (#278)

🤖 Generated with [Claude Code](https://claude.com/claude-code)