### PR TITLE
chore(release): v0.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release. Auto-cuts tag v0.15.3 + GitHub Release + GHCR :0.15.3 / :latest via publish.yml on merge.

Changes since v0.15.2:
- fix: align anthropic cli emulation with claude code (#281)
- fix: dedupe claude code system boilerplate (#280)

No config/schema diff (`git diff v0.15.2..main -- packages/shared/src/config packages/core/src/config config/` empty) → box config stays valid on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)