### PR TITLE
fix(admin): halve body viewer height cap (80vh → 40vh)

### DIFF
--- a/apps/admin/src/lib/components/viewerChrome.ts
+++ b/apps/admin/src/lib/components/viewerChrome.ts
@@ -6,7 +6,7 @@
 
 /**
  * Sizing classes for a viewer panel.
- * - default: content-fit height capped at 80vh, draggable taller/shorter via the
+ * - default: content-fit height capped at 40vh, draggable taller/shorter via the
  *   browser's native `resize-y` handle (needs `overflow != visible`, which every
  *   panel already sets). `resize` is clamped to `max-h`, so fullscreen covers the
  *   "show everything" case.
@@ -15,7 +15,7 @@
 export function viewerSizing(fullscreen: boolean): string {
   return fullscreen
     ? 'flex-1 min-h-0 max-h-none resize-none'
-    : 'min-h-32 max-h-[80vh] resize-y';
+    : 'min-h-32 max-h-[40vh] resize-y';
 }
 
 /** Root-container classes that turn a viewer into a full-viewport overlay. */


### PR DESCRIPTION
## What

The request/response body viewers were too tall. Halve the height cap of the shared `viewerSizing` helper: `max-h-[80vh]` → `max-h-[40vh]`.

## Why here, not in `JsonViewer.svelte`

The height isn't set in the component — it comes from the shared `viewerSizing` helper in `apps/admin/src/lib/components/viewerChrome.ts`, used by **both** `JsonViewer` and `StreamViewer`. The file's design note says the two viewers must behave identically, so changing the helper halves both and keeps them consistent.

## What's preserved

- `min-h-32` floor for small payloads — unchanged.
- Native `resize-y` drag handle and fullscreen mode — unchanged.

## Tests

`JsonViewer.test.ts` + `StreamViewer.test.ts` → **29/29 passed**. No test pins the `80vh` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)