### PR TITLE
chore(release): v0.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release.

## Changes since v0.15.3
- #283 fix(admin): halve body viewer height cap (80vh → 40vh)

Admin-only. No config/schema/infra changes (`git diff v0.15.3..HEAD -- packages/shared/src/config packages/core/src/config config/ docker-compose* Dockerfile` is empty), so existing operator config remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)