### PR TITLE
chore(release): v0.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.15.5.

Includes since v0.15.4:
- #285 fix(gateway): restore Opus 4.8 mid-system passthrough

Pure gateway code (execute.ts + provider/protocol.ts + tests). No schema/config/infra change (`git diff v0.15.4..main -- packages/shared/src/config packages/core/src/config config/ docker-compose* Dockerfile*` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)