### PR TITLE
Fix Claude CLI strict CCH signing

### DIFF
--- a/apps/gateway/src/server.test.ts
+++ b/apps/gateway/src/server.test.ts
@@ -80,6 +80,7 @@ describe("buildProviderClients provider dispatch", () => {
             models: [{ alias: "claude/sonnet", provider_model: "claude-sonnet" }],
             targetProviderProtocol: "anthropic_messages",
             map_developer_role_to_system: false,
+            claude_cli_fingerprint_mode: "auto",
             normalize_reasoning_delta_alias: false,
             response_model_policy: "provider",
           },
@@ -112,6 +113,7 @@ describe("buildProviderClients provider dispatch", () => {
             models: [{ alias: "gemini/flash", provider_model: "gemini-2.0-flash" }],
             targetProviderProtocol: "gemini",
             map_developer_role_to_system: false,
+            claude_cli_fingerprint_mode: "auto",
             normalize_reasoning_delta_alias: false,
             response_model_policy: "provider",
           },
@@ -206,6 +208,7 @@ describe("buildRegistry backfill metadata through execute", () => {
           models: [],
           targetProviderProtocol: "anthropic_messages",
           map_developer_role_to_system: false,
+          claude_cli_fingerprint_mode: "auto",
           normalize_reasoning_delta_alias: false,
           response_model_policy: "provider",
         },
@@ -270,6 +273,7 @@ describe("buildRegistry backfill metadata through execute", () => {
           // The compatibility shim disables verbatim passthrough — even though the
           // provider implements nativePassthrough and the protocols match.
           map_developer_role_to_system: true,
+          claude_cli_fingerprint_mode: "auto",
           normalize_reasoning_delta_alias: false,
           response_model_policy: "provider",
         },

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -682,7 +682,12 @@ function createProviderClient(
   const proxyFetch = proxy ? makeProxyFetch(proxy) : undefined;
   if (p.type === "anthropic") {
     return createAnthropicClient({
-      config: { ...base, ...cred, metadataUserId: identity?.metadataUserId },
+      config: {
+        ...base,
+        ...cred,
+        metadataUserId: identity?.metadataUserId,
+        claudeCliFingerprintMode: p.claude_cli_fingerprint_mode,
+      },
       fetch: proxyFetch,
     });
   }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-06-17 · Claude CLI strict fingerprint profile 落地（docs/05/06/07；原则 2/5/7/8）
+
+- **背景**：当前 Helm 已做到保守子集：Anthropic OAuth subscription / Claude subscription 互译或 compatibility rewrite 路径会补 Claude Code billing header、sentinel、agent prompt 与 Claude CLI-like headers；same-protocol native passthrough 不重复注入，尽量保留真实客户端 request。对比 `/Users/lukin/Projects/llm-router-packages/OmniRoute` 与 `la.atmy.work` 线上 request payload 后，决定把更激进的 Claude CLI wire-image profile 放进 provider HTTP 最后一跳，而不是污染协议 transformer。
+- **已实现**：新增 provider 配置 `claude_cli_fingerprint_mode: auto | off | conservative | strict`（Zod fail-closed）。`auto` 规则：Anthropic OAuth subscription / dynamic `getAuthHeader` 默认 `strict`；非官方 `api.anthropic.com` 的 Anthropic-compatible base URL（Claude-Code-compatible relay）默认 `strict`；普通 Anthropic static API key 默认 `conservative`。Gateway wiring 把该字段传入 `createAnthropicClient`，未配置时保持向后兼容。
+- **strict 行为**：只在互译/compat rewrite 发送 Anthropic upstream 时启用；native passthrough 继续传 `includeClaudeCliRuntimeHeaders=false`，不额外注入 runtime header、不重排/重签 raw carrier body。strict 会在最终 POST 前把 `system[0]` billing block 的 `cch` 置为 `00000` 占位，按 top-level body order `model/messages/system/tools/tool_choice/metadata/max_tokens/temperature/thinking/context_management/output_config/stream` 序列化，用 Claude/OmniRoute 对齐的 xxHash64(seed `0x6e52736ac806831e`) 计算 body-level 5-hex CCH，再只替换 `system[0]` 的占位，避免改写 user/tool 文本里看似 `cch=abcde;` 的普通内容；headers 同步按 Claude CLI order/casing 输出，并补 `X-Stainless-Arch/OS/Package-Version`。
+- **取舍/风险**：strict CCH 会随最终 body bytes 变化，牺牲 2026-06-12 “按稳定 system 派生 CCH” 的 prompt-cache 友好性；但只默认作用于 OAuth subscription/CC relay 互译路径，static key 仍默认保守。`off` 是 kill switch，但 subscription endpoint 可能依赖部分 Claude Code identity；关闭前应有 canary。该 fingerprint 只能降低“请求形态不像官方 CLI”的风险，不能保证降低封号风险，也可能触碰上游 ToS。
+- **延后 TODO**：① 建立官方 Claude CLI golden fixtures（只存脱敏结构、header/body order、system skeleton、metadata/session、beta set、CCH 形态）；② TLS/JA3/proxy/HTTP transport fingerprint 仍未做；③ tool name cloak/reverse-map、零参数 schema、thinking/cache_control 约束仍只覆盖现有保守清洗，没有完整 strict tool pipeline；④ admin UI 暂未暴露 per-provider 模式开关，当前靠 YAML；⑤ telemetry 暂未新增 body-free profile/mutation ledger，仍依赖现有 payload capture 与 request metadata。
+- **验证**：TDD 红→绿。新增 provider 回归覆盖 OAuth 默认 strict、body-level CCH 在最终 body mutation 后变化、header/body order、static API key 默认 conservative、用户正文含 `cch=abcde;` 时只签 `system[0]` billing 占位；新增 config loader 回归覆盖合法 mode 与 typo fail-closed。`pnpm exec vitest run packages/core/src/provider/anthropic.test.ts packages/core/src/config/loader.test.ts apps/gateway/src/server.test.ts` 126 绿；额外 focused `protocol/messages/execute/server/samples` 后合计 269 绿；`pnpm typecheck`、`pnpm lint` 绿。
+
 ## 2026-06-17 · Opus 4.8 会话中 system 消息恢复原生直通（issue #217；原则 5/8）
 
 - **背景**：线上请求 `5191ce2b-1d82-4802-a3b7-779f5aa54419`（`helm.easymeta.au` / `la.atmy.work` SQLite 复盘）入站是 Anthropic native 流式请求，`messages=[user, system]`，`tools=63`，模型 `claude-opus-4-8`。记录显示 `passthrough_used=false`，disable reason 是 `provider_requires_compatibility_rewrite`；互译/折叠后的上游请求只返回 `message_start → message_delta(stop_reason=end_turn) → message_stop`，没有 text delta / tool_use，客户端表现为“卡住”。
@@ -24,19 +33,13 @@
 - **取舍/坑/TODO**：① 不照搬 OmniRoute 的 `Claude Agent SDK` sentinel：Helm 目标是模拟官方 Claude Code CLI，真实 sentinel 仍是 `You are Claude Code...`。② 不盲目照搬 OmniRoute 固定版本（其 `2.1.158` 与 Helm 捕获的 `2.1.175` 不一致），避免 billing/user-agent/header 互相矛盾。③ agent prompt 形态完整覆盖真实 Claude Code 的 memory / environment / git-status 段，但其中路径、shell、模型等机器相关值使用 Helm 运行时可得信息；当客户端已带真实 agent prompt 时，优先复用客户端 block。④ 不改用户 message 正文，只清洗 system 与 tool description，降低语义破坏风险。⑤ 这次**不放宽** `anthropicNativeBodyRequiresSystemFold`；是否让更多 `messages[].role=system` 继续走直通，需独立实测订阅端接受矩阵。
 - **验证**：TDD 红→绿。新增 provider 回归：互译 native Anthropic 流量时 sentinel 只出现一次、Claude Code agent prompt 存在且不重复、固定提醒只保留一次、`messages[0]` 仍是真实 user；普通重复 system 内容与不同 interrupt 不会被误删；OmniRoute 指纹清洗不改用户消息；runtime headers 只在互译路径出现，native carrier passthrough 不出现新增模拟头。`pnpm exec vitest run packages/core/src/provider/anthropic.test.ts`、`pnpm --filter @helm/core typecheck`、Biome changed files、全量 `pnpm test`（263 files / 3796 tests）均通过。仅本地修复，尚未部署。
 
-## 2026-06-16 · 修复原生直通对 Claude Code「会话中 system 消息」400（issue #217；原则 3/5/8）
-
-- **背景**：生产请求 `81f3fa9e-...`（`la.atmy.work`，SSH+sqlite3 取 `request_payloads` 正文复盘）：**Claude Code 2.1.175** 的「role-folded transcript」把 MCP server instructions 作为**末尾 `role:"system"` 消息**塞进 `messages[]`（顶层 `system` 仍在），即 `messages=[user, system]`。Anthropic 订阅端 400 `messages.1: role 'system' must precede an 'assistant' message or end the array`，请求 fail-open **回退到 gpt-5.5**（用户问 Claude 却被另一个模型/厂商应答——非仅报错，是错路由+错计费）。见 [[claude-code-billing-header-cache-buster]]。
-- **根因**：`native_protocol_passthrough` schema **默认 `true`**（`runtime-settings.schema.ts:35`，box 无 override 故 ON；`protocol.ts` 注释「default OFF」已陈旧，本次改正），故走**原生直通**（`provider/anthropic.ts nativePassthroughStream`）**逐字转发**客户端 body → `messages[]` 里的 system 消息原样上送被拒。非直通的 IR 翻译路（`openaiToAnthropicRequest`/`transformRequestIn`）本就把 system/developer **折叠进顶层 `system`**（LiteLLM `map_developer_role_to_system` 同款），产出合法请求——所以 bug 只在直通路。
-- **决定（外科式 per-request 关直通，而非全局关）**：新增纯函数 `anthropicNativeBodyRequiresSystemFold(nativeRequest)`（core `protocol.ts`，单测覆盖载体/裸 body/developer/首位 system/缺失各分支），在 `execute.ts decideNativePassthroughForAttempt` 把它（仅 `anthropic_messages` target）**OR 进 `providerRequiresCompatibilityRewrite`**——复用既有 `provider_requires_compatibility_rewrite` 这条 disable reason，让此类请求落回**翻译/折叠路**。否决「全局把默认翻回 false」（会废掉整个直通特性）与「直通内就地折叠 body」（破坏逐字保真且更复杂）。
-- **取舍/坑/TODO**：① 对**带 MCP 的 CC 流量直通保真丢失**（这些请求几乎每条都带 inline system）——但它们当前本就 400→回退，折叠路恰是带正确 Claude-Code 身份头/spoof/相干 billing 的原始 OAuth 路，是**修复**不是退化。② 错误文案「or end the array」具误导性：末位 system（`[user, system]`）按字面应合法，但订阅端实测仍拒——故折叠是稳妥解，不去赌 `mid-conversation-system-2026-04-07` beta（helm 全仓零感知该 beta；即便 merge 透传了客户端 beta，订阅端仍拒）。若日后确认订阅端支持该 beta，可改为「保直通+确保该 beta 上送」。③ 检查刻意宽（任何 system/developer in messages[] 都关直通，含首位 system，Anthropic 同样拒 messages[0] system）——折叠恒合法，宽即安全。
-- **验证**：TDD 红→绿（先临时回退 wiring 证明直通确会对该 body 触发=复现 bug，再恢复）。`protocol.test` **+7**（helper 各分支）、`execute.test` **+1**（inline system → `passthrough_used:false`/reason `provider_requires_compatibility_rewrite`/走 `chatCompletion` 不走 `nativePassthrough`）；focused 4 文件 **231** 绿，`pnpm typecheck`（shared/core/gateway）0、`biome` 0。worktree 分支 `worktree-fix-midconv-system-ordering`，**仅改本地仓库，未发版/未部署**。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-16 · 修复原生直通对 Claude Code「会话中 system 消息」400（issue #217；原则 3/5/8）：生产请求 `81f3fa9e-...` 显示 Claude Code 把 MCP instructions 作为 `messages=[user, system]` 末尾 system 直通上送，被 Anthropic subscription 400 后 fail-open 回退到 gpt-5.5；修为新增 `anthropicNativeBodyRequiresSystemFold(nativeRequest)`，仅对 Anthropic target 且 `messages[].system|developer` 需折叠时关闭 native passthrough，复用 `provider_requires_compatibility_rewrite` 让请求落回合法的翻译/折叠路。取舍：保留全局 native passthrough 默认 ON，不在直通内就地改 body；后续若订阅端支持更多 mid-conversation system，再用实测扩大 allowlist。focused tests/typecheck/biome 绿。
 
 ### 2026-06-16 · classifier 中英文关键词对等 + 修复短消息捷径的 CJK 盲区（docs/03；原则 2/4）：根因是 `overrides.ts` 短消息捷径只看英文 signals 且自带 CJK-broken matcher，短中文 analysis/security 被钉 `simple`→economy；修为 `signals.ts` 共享 CJK-aware `keywordMatcher`，`containsClassifierSignal` 纳入 `*_intl_kw`，补 diagnostic/translation/lookup/chitchat intl 配置与中文确认词。TDD 覆盖短中文不降级、纯问候仍 simple、golden routing 中文样本；focused tests/typecheck/biome 绿。
 

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -51,6 +51,31 @@ describe("loadConfig", () => {
     expect(cfg.providers[0]?.map_developer_role_to_system).toBe(true);
   });
 
+  it("loads the provider Claude CLI fingerprint mode and rejects typos", () => {
+    const cfg = loadConfig({
+      configDir: "config",
+      env: {},
+      readFile: fakeReadFile({
+        ...VALID_YAML,
+        "config/providers.yaml":
+          "providers:\n  - alias: anthropic\n    type: anthropic\n    base_url: https://api.anthropic.com\n    api_key_env: ANTHROPIC_API_KEY\n    claude_cli_fingerprint_mode: strict\n",
+      }),
+    });
+    expect(cfg.providers[0]?.claude_cli_fingerprint_mode).toBe("strict");
+
+    expect(() =>
+      loadConfig({
+        configDir: "config",
+        env: {},
+        readFile: fakeReadFile({
+          ...VALID_YAML,
+          "config/providers.yaml":
+            "providers:\n  - alias: anthropic\n    type: anthropic\n    base_url: https://api.anthropic.com\n    api_key_env: ANTHROPIC_API_KEY\n    claude_cli_fingerprint_mode: aggressive\n",
+        }),
+      }),
+    ).toThrow(ConfigError);
+  });
+
   it("lets env override file values (env wins) with coercion", () => {
     const cfg = loadConfig({
       configDir: "config",

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -1407,6 +1407,195 @@ describe("createAnthropicClient", () => {
     expect(seenRequestIds[0]).not.toBe(seenRequestIds[1]);
   });
 
+  it("defaults OAuth subscription traffic to strict Claude CLI body signing and header/body order", async () => {
+    const uid = '{"device_id":"D","account_uuid":"","session_id":"S"}';
+    const seenBodies: string[] = [];
+    const seenHeaderOrders: string[][] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      seenBodies.push(String(init?.body));
+      seenHeaderOrders.push(Object.keys(init?.headers as Record<string, string>));
+      return jsonResponse({
+        id: "m",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: {
+        baseUrl: "https://api.anthropic.com",
+        getAuthHeader: async () => "Bearer T",
+        metadataUserId: uid,
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "stable system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 64,
+    });
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "stable system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 65,
+    });
+
+    const first = JSON.parse(seenBodies[0] ?? "{}") as {
+      system: Array<{ text: string }>;
+    };
+    const second = JSON.parse(seenBodies[1] ?? "{}") as {
+      system: Array<{ text: string }>;
+    };
+    const firstCch = first.system[0]?.text.match(/\bcch=([0-9a-f]{5});/)?.[1];
+    const secondCch = second.system[0]?.text.match(/\bcch=([0-9a-f]{5});/)?.[1];
+    expect(firstCch).toMatch(/^[0-9a-f]{5}$/);
+    expect(firstCch).not.toBe("00000");
+    // Strict mode signs the final serialized body, so a non-system body mutation
+    // changes cch. The pure translator keeps its cache-stable conservative hash.
+    expect(secondCch).not.toBe(firstCch);
+    expect(Object.keys(first)).toEqual(["model", "messages", "system", "metadata", "max_tokens"]);
+    expect(seenHeaderOrders[0]?.slice(0, 14)).toEqual([
+      "Accept",
+      "Authorization",
+      "Content-Type",
+      "User-Agent",
+      "X-Claude-Code-Session-Id",
+      "X-Stainless-Arch",
+      "X-Stainless-Lang",
+      "X-Stainless-OS",
+      "X-Stainless-Package-Version",
+      "X-Stainless-Retry-Count",
+      "X-Stainless-Runtime",
+      "X-Stainless-Runtime-Version",
+      "X-Stainless-Timeout",
+      "anthropic-beta",
+    ]);
+  });
+
+  it("strict signing only replaces the billing CCH placeholder, never user text", async () => {
+    let sentBody = "";
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      sentBody = String(init?.body);
+      return jsonResponse({
+        id: "m",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", getAuthHeader: async () => "Bearer T" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        {
+          role: "user",
+          content: "Please quote this exactly: x-anthropic-billing-header: cch=abcde;",
+        },
+      ],
+      max_tokens: 64,
+    });
+
+    const parsed = JSON.parse(sentBody) as {
+      messages: Array<{ content: Array<{ text: string }> }>;
+      system: Array<{ text: string }>;
+    };
+    expect(parsed.messages[0]?.content[0]?.text).toContain("cch=abcde;");
+    const billing = parsed.system[0]?.text ?? "";
+    expect(billing).toMatch(/^x-anthropic-billing-header:/);
+    expect(billing).toMatch(/\bcch=[0-9a-f]{5};$/);
+    expect(billing).not.toContain("cch=00000;");
+  });
+
+  it("keeps static-key Anthropic traffic on the conservative cache-stable CCH profile by default", async () => {
+    const seenCch: string[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { system: Array<{ text: string }> };
+      seenCch.push(body.system[0]?.text.match(/\bcch=([0-9a-f]{5});/)?.[1] ?? "");
+      return jsonResponse({
+        id: "m",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "stable system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 64,
+    });
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "stable system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 65,
+    });
+
+    expect(seenCch).toHaveLength(2);
+    expect(seenCch[0]).toMatch(/^[0-9a-f]{5}$/);
+    expect(seenCch[1]).toBe(seenCch[0]);
+  });
+
+  it("defaults non-official Anthropic-compatible relays to strict Claude CLI signing", async () => {
+    const seenCch: string[] = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { system: Array<{ text: string }> };
+      seenCch.push(body.system[0]?.text.match(/\bcch=([0-9a-f]{5});/)?.[1] ?? "");
+      return jsonResponse({
+        id: "m",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://claude-code-relay.example", apiKey: "relay-key" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "stable system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 64,
+    });
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "stable system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 65,
+    });
+
+    expect(seenCch).toHaveLength(2);
+    expect(seenCch[0]).toMatch(/^[0-9a-f]{5}$/);
+    expect(seenCch[0]).not.toBe("00000");
+    expect(seenCch[1]).not.toBe(seenCch[0]);
+  });
+
   it("adds feature beta headers for Anthropic context_management and fast mode", async () => {
     let seen: Headers | null = null;
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -39,6 +39,9 @@ export interface AnthropicClientConfig {
   // the device identity never rotates — the real-client posture Anthropic expects.
   // Undefined → no `metadata` is sent (back-compat; matches openclaw's default).
   metadataUserId?: string;
+  // Wire-image profile for Claude Code emulation. "auto" keeps static API-key
+  // providers conservative while making OAuth subscription traffic strict.
+  claudeCliFingerprintMode?: "auto" | "off" | "conservative" | "strict";
   // Transient-connection retry at the fetch boundary (provider/retry.ts). Optional —
   // omitted falls back to defaults (2 retries, [200,500] ms). Pre-first-byte, so the
   // retry is idempotent. See ProviderConfig for the rationale.
@@ -78,6 +81,9 @@ const ADVANCED_TOOL_USE_BETA = "advanced-tool-use-2025-11-20";
 const TOKEN_COUNTING_BETA = "token-counting-2024-11-01";
 const SYSTEM_SPOOF = "You are Claude Code, Anthropic's official CLI for Claude.";
 const BILLING_HEADER_PREFIX = "x-anthropic-billing-header:";
+const CCH_SEED = 0x6e52736ac806831en;
+const CCH_PATTERN = /\bcch=([0-9a-f]{5});/;
+const CCH_PLACEHOLDER = "cch=00000;";
 const TASK_TOOLS_REMINDER_PREFIX = "The task tools haven't been used recently.";
 const USER_INTERRUPT_PREFIX = "The user sent a new message while you were working:";
 const CLAUDE_CODE_AGENT_PROMPT_PREFIX =
@@ -121,6 +127,49 @@ const THIRD_PARTY_OBFUSCATE_WORDS = [
   "avante",
   "codecompanion",
 ];
+const CLAUDE_CLI_BODY_FIELD_ORDER = [
+  "model",
+  "messages",
+  "system",
+  "tools",
+  "tool_choice",
+  "metadata",
+  "max_tokens",
+  "temperature",
+  "thinking",
+  "context_management",
+  "output_config",
+  "stream",
+] as const;
+const CLAUDE_CLI_HEADER_ORDER = [
+  "Accept",
+  "Authorization",
+  "Content-Type",
+  "User-Agent",
+  "X-Claude-Code-Session-Id",
+  "X-Stainless-Arch",
+  "X-Stainless-Lang",
+  "X-Stainless-OS",
+  "X-Stainless-Package-Version",
+  "X-Stainless-Retry-Count",
+  "X-Stainless-Runtime",
+  "X-Stainless-Runtime-Version",
+  "X-Stainless-Timeout",
+  "anthropic-beta",
+  "anthropic-dangerous-direct-browser-access",
+  "anthropic-version",
+  "x-app",
+  "x-client-request-id",
+  "Connection",
+  "Host",
+  "Accept-Encoding",
+  "Content-Length",
+] as const;
+const CLAUDE_CLI_HEADER_CANONICAL = new Map(
+  CLAUDE_CLI_HEADER_ORDER.map((name) => [name.toLowerCase(), name] as const),
+);
+
+type EffectiveClaudeCliFingerprintMode = "off" | "conservative" | "strict";
 
 // ── request translation: OpenAI-Chat IR -> Anthropic Messages ────────────────
 
@@ -262,6 +311,217 @@ function betaHeaderForBody(
   }
   for (const beta of extraBetas) betas.add(beta);
   return [...betas].join(",");
+}
+
+function effectiveClaudeCliFingerprintMode(
+  configured: AnthropicClientConfig["claudeCliFingerprintMode"],
+  hasDynamicAuth: boolean,
+  baseUrl: string,
+): EffectiveClaudeCliFingerprintMode {
+  const mode = configured ?? "auto";
+  if (mode === "auto") {
+    return hasDynamicAuth || !isOfficialAnthropicBaseUrl(baseUrl) ? "strict" : "conservative";
+  }
+  return mode;
+}
+
+function isOfficialAnthropicBaseUrl(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === "api.anthropic.com";
+  } catch {
+    return false;
+  }
+}
+
+function orderTopLevelFields(
+  body: Record<string, unknown>,
+  fieldOrder: readonly string[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const consumed = new Set<string>();
+  for (const key of fieldOrder) {
+    if (Object.hasOwn(body, key)) {
+      out[key] = body[key];
+      consumed.add(key);
+    }
+  }
+  for (const [key, value] of Object.entries(body)) {
+    if (!consumed.has(key)) out[key] = value;
+  }
+  return out;
+}
+
+function withClaudeCliCchPlaceholder(body: Record<string, unknown>): Record<string, unknown> {
+  const system = body.system;
+  if (!Array.isArray(system)) return body;
+  const first = system[0];
+  if (first === null || typeof first !== "object" || Array.isArray(first)) return body;
+  const text = (first as Record<string, unknown>).text;
+  if (typeof text !== "string" || !CCH_PATTERN.test(text)) return body;
+  return {
+    ...body,
+    system: [
+      { ...(first as Record<string, unknown>), text: text.replace(CCH_PATTERN, CCH_PLACEHOLDER) },
+      ...system.slice(1),
+    ],
+  };
+}
+
+const MASK64 = (1n << 64n) - 1n;
+const PRIME64_1 = 0x9e3779b185ebca87n;
+const PRIME64_2 = 0xc2b2ae3d27d4eb4fn;
+const PRIME64_3 = 0x165667b19e3779f9n;
+const PRIME64_4 = 0x85ebca77c2b2ae63n;
+const PRIME64_5 = 0x27d4eb2f165667c5n;
+
+function u64(value: bigint): bigint {
+  return value & MASK64;
+}
+
+function rotl64(value: bigint, bits: number): bigint {
+  const b = BigInt(bits);
+  return u64((value << b) | (value >> (64n - b)));
+}
+
+function xxh64Round(acc: bigint, input: bigint): bigint {
+  let out = u64(acc + u64(input * PRIME64_2));
+  out = rotl64(out, 31);
+  return u64(out * PRIME64_1);
+}
+
+function xxh64MergeRound(acc: bigint, value: bigint): bigint {
+  let out = acc ^ xxh64Round(0n, value);
+  out = u64(u64(out * PRIME64_1) + PRIME64_4);
+  return out;
+}
+
+function xxh64Avalanche(hash: bigint): bigint {
+  let out = hash ^ (hash >> 33n);
+  out = u64(out * PRIME64_2);
+  out ^= out >> 29n;
+  out = u64(out * PRIME64_3);
+  out ^= out >> 32n;
+  return u64(out);
+}
+
+function xxHash64(bytes: Uint8Array, seed: bigint): bigint {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 0;
+  let hash: bigint;
+  if (bytes.byteLength >= 32) {
+    let v1 = u64(seed + PRIME64_1 + PRIME64_2);
+    let v2 = u64(seed + PRIME64_2);
+    let v3 = u64(seed);
+    let v4 = u64(seed - PRIME64_1);
+    const limit = bytes.byteLength - 32;
+    while (offset <= limit) {
+      v1 = xxh64Round(v1, view.getBigUint64(offset, true));
+      offset += 8;
+      v2 = xxh64Round(v2, view.getBigUint64(offset, true));
+      offset += 8;
+      v3 = xxh64Round(v3, view.getBigUint64(offset, true));
+      offset += 8;
+      v4 = xxh64Round(v4, view.getBigUint64(offset, true));
+      offset += 8;
+    }
+    hash = u64(rotl64(v1, 1) + rotl64(v2, 7) + rotl64(v3, 12) + rotl64(v4, 18));
+    hash = xxh64MergeRound(hash, v1);
+    hash = xxh64MergeRound(hash, v2);
+    hash = xxh64MergeRound(hash, v3);
+    hash = xxh64MergeRound(hash, v4);
+  } else {
+    hash = u64(seed + PRIME64_5);
+  }
+
+  hash = u64(hash + BigInt(bytes.byteLength));
+  while (offset + 8 <= bytes.byteLength) {
+    const k1 = xxh64Round(0n, view.getBigUint64(offset, true));
+    hash ^= k1;
+    hash = u64(u64(rotl64(hash, 27) * PRIME64_1) + PRIME64_4);
+    offset += 8;
+  }
+  if (offset + 4 <= bytes.byteLength) {
+    hash ^= u64(BigInt(view.getUint32(offset, true)) * PRIME64_1);
+    hash = u64(u64(rotl64(hash, 23) * PRIME64_2) + PRIME64_3);
+    offset += 4;
+  }
+  while (offset < bytes.byteLength) {
+    hash ^= u64(BigInt(bytes[offset] ?? 0) * PRIME64_5);
+    hash = u64(rotl64(hash, 11) * PRIME64_1);
+    offset += 1;
+  }
+  return xxh64Avalanche(hash);
+}
+
+function computeClaudeCliCch(bodyTextWithPlaceholder: string): string {
+  const bytes = new TextEncoder().encode(bodyTextWithPlaceholder);
+  const token = xxHash64(bytes, CCH_SEED) & 0xfffffn;
+  return token.toString(16).padStart(5, "0");
+}
+
+function hasSystemBillingCchPlaceholder(body: Record<string, unknown>): boolean {
+  const system = body.system;
+  if (!Array.isArray(system)) return false;
+  const first = system[0];
+  if (first === null || typeof first !== "object" || Array.isArray(first)) return false;
+  const text = (first as Record<string, unknown>).text;
+  return typeof text === "string" && text.includes(CCH_PLACEHOLDER);
+}
+
+function withSignedSystemBillingCch(
+  body: Record<string, unknown>,
+  token: string,
+): Record<string, unknown> {
+  const system = body.system;
+  if (!Array.isArray(system)) return body;
+  const first = system[0];
+  if (first === null || typeof first !== "object" || Array.isArray(first)) return body;
+  const text = (first as Record<string, unknown>).text;
+  if (typeof text !== "string" || !text.includes(CCH_PLACEHOLDER)) return body;
+  return {
+    ...body,
+    system: [
+      {
+        ...(first as Record<string, unknown>),
+        text: text.replace(CCH_PLACEHOLDER, `cch=${token};`),
+      },
+      ...system.slice(1),
+    ],
+  };
+}
+
+function serializeAnthropicBody(
+  body: Record<string, unknown>,
+  options: { strictClaudeCliFingerprint: boolean },
+): string {
+  if (!options.strictClaudeCliFingerprint) return JSON.stringify(body);
+  const placeholderBody = withClaudeCliCchPlaceholder(body);
+  const orderedPlaceholder = orderTopLevelFields(placeholderBody, CLAUDE_CLI_BODY_FIELD_ORDER);
+  const bodyTextWithPlaceholder = JSON.stringify(orderedPlaceholder);
+  if (!hasSystemBillingCchPlaceholder(orderedPlaceholder)) return bodyTextWithPlaceholder;
+  const signedBody = withSignedSystemBillingCch(
+    placeholderBody,
+    computeClaudeCliCch(bodyTextWithPlaceholder),
+  );
+  return JSON.stringify(orderTopLevelFields(signedBody, CLAUDE_CLI_BODY_FIELD_ORDER));
+}
+
+function orderClaudeCliHeaders(headers: Record<string, string>): Record<string, string> {
+  const byLower = new Map<string, { name: string; value: string }>();
+  for (const [key, value] of Object.entries(headers)) {
+    const canonical = CLAUDE_CLI_HEADER_CANONICAL.get(key.toLowerCase()) ?? key;
+    byLower.set(key.toLowerCase(), { name: canonical, value });
+  }
+  const out: Record<string, string> = {};
+  for (const name of CLAUDE_CLI_HEADER_ORDER) {
+    const entry = byLower.get(name.toLowerCase());
+    if (entry === undefined) continue;
+    out[name] = entry.value;
+    byLower.delete(name.toLowerCase());
+  }
+  for (const [_, entry] of byLower) out[entry.name] = entry.value;
+  return out;
 }
 
 function textBlocksFromContent(content: unknown, messageCacheControl?: unknown): AnthropicBlock[] {
@@ -859,28 +1119,40 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
   if (hasStatic === hasDynamic) {
     throw new Error("anthropic client requires exactly one of `apiKey` or `getAuthHeader`");
   }
+  const fingerprintMode = effectiveClaudeCliFingerprintMode(
+    cfg.claudeCliFingerprintMode,
+    hasDynamic,
+    cfg.baseUrl,
+  );
 
   async function headers(
     body: Record<string, unknown>,
     extraBetas: readonly string[] = [],
     options: { includeClaudeCliRuntimeHeaders?: boolean } = {},
   ): Promise<Record<string, string>> {
+    const userAgent = userAgentFromBody(body);
+    const cliVersion = userAgent.match(/^claude-cli\/([^ ]+)/)?.[1] ?? FALLBACK_CLAUDE_CODE_VERSION;
     const h: Record<string, string> = {
       "Content-Type": "application/json",
       // Header parity with openclaw's OAuth recipe — both are load-bearing for the
       // Claude-Code identity the subscription endpoint expects.
-      accept: "application/json",
+      Accept: "application/json",
       "anthropic-dangerous-direct-browser-access": "true",
       "anthropic-version": ANTHROPIC_VERSION,
       "anthropic-beta": betaHeaderForBody(body, extraBetas),
       // Keep the user-agent coherent with the billing block at system[0]: derive its
       // version + entrypoint from the SAME identity emitted there (the client's real
       // one when present, else the fallback) so the two never disagree.
-      "user-agent": userAgentFromBody(body),
+      "User-Agent": userAgent,
       "x-app": "cli",
     };
-    if (options.includeClaudeCliRuntimeHeaders === true) {
+    if (options.includeClaudeCliRuntimeHeaders === true && fingerprintMode !== "off") {
       h["x-client-request-id"] = randomUUID();
+      if (fingerprintMode === "strict") {
+        h["X-Stainless-Arch"] = process.arch;
+        h["X-Stainless-OS"] = process.platform;
+        h["X-Stainless-Package-Version"] = cliVersion;
+      }
       h["X-Stainless-Lang"] = "js";
       h["X-Stainless-Runtime"] = "node";
       h["X-Stainless-Runtime-Version"] = process.version;
@@ -936,10 +1208,18 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
           : {}),
       },
     );
+    const strictClaudeCliFingerprint =
+      fingerprintMode === "strict" && includeClaudeCliRuntimeHeaders === true;
+    const wireBody = strictClaudeCliFingerprint
+      ? serializeAnthropicBody(prepared.body, { strictClaudeCliFingerprint: true })
+      : prepared.bodyText;
+    const wireHeaders = strictClaudeCliFingerprint
+      ? orderClaudeCliHeaders(prepared.headers)
+      : prepared.headers;
     // The exact Anthropic-native bytes POSTed upstream — for the translate path this is
     // the OpenAI→Anthropic re-serialization, for native passthrough the verbatim body
     // (model patched). Surfaced before the first fetch so the gateway captures it.
-    capture?.(prepared.bodyText);
+    capture?.(wireBody);
     // Retry transient connection blips at the fetch boundary (pre-first-byte → idempotent);
     // a timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
     return withConnectionRetry(
@@ -948,8 +1228,8 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         try {
           return await doFetch(endpointUrl, {
             method: "POST",
-            headers: prepared.headers,
-            body: prepared.bodyText,
+            headers: wireHeaders,
+            body: wireBody,
             signal: t.signal,
           });
         } catch (err) {

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -168,6 +168,7 @@ export const ProviderConfigSchema = z
     // Responses and other provider wires must be distinguishable metadata.
     target_provider_protocol: TargetProviderProtocolSchema.optional(),
     map_developer_role_to_system: z.boolean().default(false),
+    claude_cli_fingerprint_mode: z.enum(["auto", "off", "conservative", "strict"]).default("auto"),
     normalize_reasoning_delta_alias: z.boolean().default(false),
     response_model_policy: z.enum(["provider", "requested_alias", "both"]).default("provider"),
     remote_media_fetch: RemoteMediaFetchConfigSchema.optional(),


### PR DESCRIPTION
## Summary
- add provider-level `claude_cli_fingerprint_mode` with strict defaults for Anthropic OAuth subscription and Claude-Code-compatible relays
- implement strict Claude CLI body/header ordering and body-level xxHash64 CCH signing
- scope CCH replacement to `system[0]` billing placeholder so user text like `cch=abcde;` is never rewritten
- record deferred strict-profile work in `implementation-notes.md`

## Validation
- `pnpm exec vitest run packages/core/src/provider/anthropic.test.ts packages/core/src/config/loader.test.ts apps/gateway/src/server.test.ts packages/core/src/provider/protocol.test.ts apps/gateway/src/routes/messages.test.ts apps/gateway/src/routes/execute.test.ts packages/core/src/config/samples.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`