### PR TITLE
chore(release): v0.15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release. Cuts a tag + GitHub Release for #287 (`fix: scope claude cli cch signing`), which merged after the v0.15.5 release commit and so far only refreshed `:latest`.

- #287 — scope Claude CLI CCH signing (gateway/provider code + additive optional provider knob `claude_cli_fingerprint_mode`, default `auto`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)