### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Minor release cutting a GitHub Release + GHCR `:0.16.0` for three feature PRs merged after **v0.15.6** (so far only refreshed `:latest`):

- **#289** feat(telemetry): capture true generation TPS + surface it in admin
- **#291** feat: auto-park OAuth accounts on usage limit + one-click reset
- **#290** feat(oauth): Codex rate-limit reset-credit ("reset usage limit") admin action

**Why minor:** additive DB migrations (sqlite + postgres) for OAuth usage/quota + telemetry columns, plus new `decision/schema.ts` and `oauth/usage-schema.ts` fields and a `route-request.ts` change — new gateway surface, same precedent as v0.12.0.

**Fail-close gate:** `git diff v0.15.6..main -- packages/shared/src/config packages/core/src/config config/ docker-compose* Dockerfile*` is **empty** → no config-schema change → existing box config stays valid on boot.

Only `package.json` version is changed in this PR; `publish.yml` auto-cuts tag `v0.16.0` + Release + GHCR `:0.16.0`/`:latest` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)