### PR TITLE
fix(admin): correct dashboard all-time chart axis

### DIFF
--- a/apps/admin/src/lib/dashboard-chart.test.ts
+++ b/apps/admin/src/lib/dashboard-chart.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatTrendTick,
+  resolveStatsWindow,
+  trendAxisTicks,
+  trendBucketForRange,
+} from './dashboard-chart.js';
+
+const DAY = 86_400_000;
+const HOUR = 3_600_000;
+
+const point = (ms: number) => ({ date: new Date(ms), input: 1, output: 0, cached: 0 });
+
+describe('dashboard chart helpers', () => {
+  it('uses daily aggregation for the all-time dashboard range', () => {
+    expect(trendBucketForRange('all')).toBe('day');
+  });
+
+  it('sends an explicit full-history stats window for all-time instead of triggering the API default', () => {
+    const now = Date.UTC(2026, 5, 17, 12);
+
+    expect(resolveStatsWindow('all', now)).toEqual({ start: 0, end: now });
+  });
+
+  it('pins the x-axis to actual daily aggregate buckets instead of auto intra-day ticks', () => {
+    const ticks = trendAxisTicks([point(Date.UTC(2026, 5, 16)), point(Date.UTC(2026, 5, 17))]);
+
+    expect(ticks.map((d) => d.toISOString())).toEqual([
+      '2026-06-16T00:00:00.000Z',
+      '2026-06-17T00:00:00.000Z',
+    ]);
+  });
+
+  it('thins long bucket lists while keeping the first and last bucket visible', () => {
+    const ticks = trendAxisTicks(
+      Array.from({ length: 31 }, (_, i) => point(Date.UTC(2026, 4, 1) + i * DAY)),
+      7,
+    );
+
+    expect(ticks).toHaveLength(7);
+    expect(ticks[0]?.toISOString()).toBe('2026-05-01T00:00:00.000Z');
+    expect(ticks.at(-1)?.toISOString()).toBe('2026-05-31T00:00:00.000Z');
+  });
+
+  it('formats daily ticks as dates and hourly ticks as times', () => {
+    const date = new Date(Date.UTC(2026, 5, 16, 13));
+
+    expect(formatTrendTick(date, 'day', 'en-US', 'UTC')).toBe('6/16');
+    expect(formatTrendTick(date, 'hour', 'en-US', 'UTC')).toBe('1:00 PM');
+  });
+
+  it('keeps hourly dashboard ranges hourly', () => {
+    expect(trendBucketForRange('1h')).toBe('hour');
+    expect(trendBucketForRange('6h')).toBe('hour');
+    expect(trendBucketForRange('24h')).toBe('hour');
+    expect(trendBucketForRange('today')).toBe('hour');
+    expect(trendAxisTicks([point(0), point(HOUR)]).map((d) => d.getTime())).toEqual([0, HOUR]);
+  });
+});

--- a/apps/admin/src/lib/dashboard-chart.ts
+++ b/apps/admin/src/lib/dashboard-chart.ts
@@ -1,0 +1,52 @@
+import { resolveWindow, type RangeKey } from './requests-filters.js';
+
+export type TrendBucket = 'hour' | 'day';
+export type TrendPointLike = { date: Date };
+
+// Stats endpoint semantics differ from the request list: omitted bounds mean
+// "last 24h" there, so the all-time dashboard must send an explicit lower bound.
+export function resolveStatsWindow(
+  range: RangeKey,
+  nowMs: number,
+): { start?: number; end?: number } {
+  return range === 'all' ? { start: 0, end: nowMs } : resolveWindow(range, nowMs);
+}
+
+// Short windows want hourly shape; longer/all-time windows should be summarized by
+// day so the x-axis answers "which date did this aggregate come from?"
+export function trendBucketForRange(range: RangeKey): TrendBucket {
+  return range === '1h' || range === '6h' || range === '24h' || range === 'today'
+    ? 'hour'
+    : 'day';
+}
+
+export function trendAxisTicks<T extends TrendPointLike>(
+  points: readonly T[],
+  maxTicks = 7,
+): Date[] {
+  const ticks = points.map((p) => p.date).filter((d) => !Number.isNaN(d.getTime()));
+  if (ticks.length <= maxTicks) return ticks;
+
+  const last = ticks.length - 1;
+  const step = Math.ceil(last / (maxTicks - 1));
+  const thinned = ticks.filter((_, i) => i % step === 0);
+  const tail = ticks[last];
+  if (tail && thinned.at(-1)?.getTime() !== tail.getTime()) thinned.push(tail);
+  return thinned;
+}
+
+export function formatTrendTick(
+  date: Date,
+  bucket: TrendBucket,
+  locale?: string | string[],
+  timeZone?: string,
+): string {
+  const options: Intl.DateTimeFormatOptions =
+    bucket === 'day'
+      ? { month: 'numeric', day: 'numeric' }
+      : { hour: 'numeric', minute: '2-digit' };
+  if (timeZone) options.timeZone = timeZone;
+  return bucket === 'day'
+    ? date.toLocaleDateString(locale, options)
+    : date.toLocaleTimeString(locale, options);
+}

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   import type { DashboardStats } from '$lib/api/stats.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
   import TokensCell from '$lib/components/TokensCell.svelte';
+  import { formatTrendTick, trendAxisTicks, type TrendBucket } from '$lib/dashboard-chart.js';
   import { formatCount, formatTimestamp, formatTokens, formatTps, formatUsd } from '$lib/format.js';
   import { DEFAULT_PAGE_SIZE, filtersToSearch, type RangeKey } from '$lib/requests-filters.js';
   import { t } from '$lib/i18n';
@@ -26,8 +27,15 @@
 
   let {
     data,
-  }: { data: { items: RequestListItem[]; range: RangeKey; stats: Stats; agg: DashboardStats } } =
-    $props();
+  }: {
+    data: {
+      items: RequestListItem[];
+      range: RangeKey;
+      bucket: TrendBucket;
+      stats: Stats;
+      agg: DashboardStats;
+    };
+  } = $props();
 
   const stats = $derived(data.stats);
   const recent = $derived(data.items.slice(0, 10));
@@ -49,6 +57,7 @@
       cached: b.cachedTokens,
     })),
   );
+  const trendTicks = $derived(trendAxisTicks(trend));
   const TREND_SERIES = $derived([
     {
       key: 'input',
@@ -127,6 +136,11 @@
   // '—' for a legacy row that carried none.
   function formatTs(ts: string): string {
     return formatTimestamp(ts) || '—';
+  }
+
+  function formatTrendAxisValue(value: unknown): string {
+    const date = value instanceof Date ? value : new Date(value as string | number);
+    return Number.isNaN(date.getTime()) ? String(value ?? '') : formatTrendTick(date, data.bucket);
   }
 
   function decidedByClass(d: RequestListItem['decided_by']): string {
@@ -285,6 +299,7 @@
             series={TREND_SERIES}
             legend
             props={{
+              xAxis: { ticks: trendTicks, format: formatTrendAxisValue },
               yAxis: { format: formatTokens },
               tooltip: { item: { format: formatTokens } },
             }}

--- a/apps/admin/src/routes/+page.ts
+++ b/apps/admin/src/routes/+page.ts
@@ -1,5 +1,6 @@
 import { listRequests, type RequestListItem } from '$lib/api/requests.js';
 import { type DashboardStats, EMPTY_STATS, getStats } from '$lib/api/stats.js';
+import { resolveStatsWindow, trendBucketForRange } from '$lib/dashboard-chart.js';
 import {
   clientTzOffsetMinutes,
   parseRange,
@@ -21,19 +22,12 @@ import type { PageLoad } from './$types.js';
 // API hiccup) shows a zeroed dashboard rather than an error page. Re-runs on every
 // navigation (range change / back-button) since it depends on `url`.
 
-// Short windows want an hourly trend (you can see the shape of a day); long
-// windows want a daily trend (a month of hourly points is noise). The boundary is
-// the sub-day presets.
-function bucketFor(range: RangeKey): 'hour' | 'day' {
-  return range === '1h' || range === '6h' || range === '24h' || range === 'today'
-    ? 'hour'
-    : 'day';
-}
-
 export const load: PageLoad = async ({ url }) => {
   const range = parseRange(url.searchParams.get('range'), '24h');
-  const { start, end } = resolveWindow(range, Date.now());
-  const bucket = bucketFor(range);
+  const now = Date.now();
+  const { start, end } = resolveWindow(range, now);
+  const statsWindow = resolveStatsWindow(range, now);
+  const bucket = trendBucketForRange(range);
   // Send the viewer's UTC offset so the SQL series buckets break at local midnight
   // (not 00:00 UTC) — the fix for the "8am boundary" on UTC+8 dashboards.
   const tzOffsetMinutes = clientTzOffsetMinutes();
@@ -41,7 +35,7 @@ export const load: PageLoad = async ({ url }) => {
   // The aggregate (cards + charts). Fail-soft to an empty aggregate.
   let agg: DashboardStats = EMPTY_STATS;
   try {
-    agg = await getStats({ start, end, bucket, tzOffsetMinutes });
+    agg = await getStats({ ...statsWindow, bucket, tzOffsetMinutes });
   } catch {
     agg = EMPTY_STATS;
   }
@@ -63,6 +57,7 @@ export const load: PageLoad = async ({ url }) => {
 
   return {
     range,
+    bucket,
     agg,
     items,
     stats: {

--- a/apps/admin/src/routes/home.test.ts
+++ b/apps/admin/src/routes/home.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardStats } from '$lib/api/stats.js';
+import { load } from './+page.js';
+
+const mocks = vi.hoisted(() => {
+  const emptyStats: DashboardStats = {
+    totals: {
+      requests: 0,
+      okCount: 0,
+      errorCount: 0,
+      totalCostUsd: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      cachedTokens: 0,
+      cacheCreationTokens: 0,
+      avgLatencyMs: null,
+      avgTps: null,
+    },
+    series: [],
+    byModel: [],
+  };
+  return {
+    emptyStats,
+    getStats: vi.fn(),
+    listRequests: vi.fn(),
+  };
+});
+
+const EMPTY_STATS = mocks.emptyStats;
+
+vi.mock('$lib/api/stats.js', () => ({
+  EMPTY_STATS: mocks.emptyStats,
+  getStats: (...args: unknown[]) => mocks.getStats(...args),
+}));
+
+vi.mock('$lib/api/requests.js', () => ({
+  listRequests: (...args: unknown[]) => mocks.listRequests(...args),
+}));
+
+describe('home dashboard loader', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.getStats.mockReset().mockResolvedValue(EMPTY_STATS);
+    mocks.listRequests.mockReset().mockResolvedValue({ items: [] });
+  });
+
+  it('loads all-time stats with an explicit full-history window', async () => {
+    const now = Date.UTC(2026, 5, 17, 12);
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const result = (await load({ url: new URL('https://admin.test/?range=all') } as never)) as {
+      range: string;
+      bucket: string;
+    };
+
+    expect(result.range).toBe('all');
+    expect(result.bucket).toBe('day');
+    expect(mocks.getStats).toHaveBeenCalledTimes(1);
+    expect(mocks.getStats.mock.calls[0]?.[0]).toMatchObject({
+      start: 0,
+      end: now,
+      bucket: 'day',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix the dashboard all-time stats request so it sends an explicit full-history window instead of triggering the stats API last-24h default
- derive the token trend x-axis ticks from aggregate bucket dates so daily/all-time charts do not show repeated auto-generated same-day labels
- add helper and loader regression tests for the all-time chart behavior

## Tests
- pnpm exec vitest run src/lib/dashboard-chart.test.ts src/routes/home.test.ts
- pnpm typecheck
- pnpm --filter @helm/admin check
- pnpm lint
- pnpm build
- pnpm test