### PR TITLE
feat(admin): reasoning_effort dropdown on /admin/lanes

### DIFF
--- a/apps/admin/src/lib/api/lanes.test.ts
+++ b/apps/admin/src/lib/api/lanes.test.ts
@@ -73,4 +73,40 @@ describe('lanes api client', () => {
 
     await expect(saveLane('balanced', lane)).rejects.toThrow();
   });
+
+  it('reads a valid reasoning_effort from GET and ignores an unknown value', async () => {
+    const rows = [
+      laneRow('balanced', { reasoning_effort: 'high' } as Partial<Lane>),
+      laneRow('economy', { reasoning_effort: 'bogus' } as unknown as Partial<Lane>),
+      laneRow('premium'),
+    ];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(rows), { status: 200 }),
+    );
+    const lanes = await listLanes();
+    expect(lanes[0].reasoning_effort).toBe('high');
+    expect(lanes[1].reasoning_effort).toBeUndefined(); // unknown value dropped
+    expect(lanes[2].reasoning_effort).toBeUndefined(); // absent stays unforced
+  });
+
+  it('saveLane sends reasoning_effort when set and omits it when unforced', async () => {
+    const ok = () => new Response(JSON.stringify({ primary: 'x' }), { status: 200 });
+    const fetchMock = fetch as ReturnType<typeof vi.fn>;
+    const base: Lane = {
+      name: 'coding',
+      primary: 'x',
+      fallback: [],
+      constraints: { require_tools: false, require_json: false, max_latency_ms: null },
+    };
+    // Fresh Response per call (a Response body can only be read once).
+    fetchMock.mockResolvedValueOnce(ok());
+    await saveLane('coding', { ...base, reasoning_effort: 'xhigh' });
+    const forced = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(forced.reasoning_effort).toBe('xhigh');
+
+    fetchMock.mockResolvedValueOnce(ok());
+    await saveLane('coding', base); // no reasoning_effort
+    const unforced = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    expect(unforced.reasoning_effort).toBeUndefined();
+  });
 });

--- a/apps/admin/src/lib/api/lanes.ts
+++ b/apps/admin/src/lib/api/lanes.ts
@@ -16,12 +16,34 @@ export interface LaneConstraints {
   [extra: string]: unknown;
 }
 
+// Lane-FORCED reasoning effort (mirrors @helm/shared ReasoningEffortSchema — the
+// admin deliberately re-types shapes rather than importing core/shared). When set
+// on a lane, the gateway overrides the client's reasoning effort for every request
+// on that lane; omitted = unforced (the request-driven default).
+export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export const REASONING_EFFORTS: ReasoningEffort[] = [
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+];
+
+function isReasoningEffort(v: unknown): v is ReasoningEffort {
+  return typeof v === 'string' && (REASONING_EFFORTS as string[]).includes(v);
+}
+
 export interface Lane {
   name: string; // economy | balanced | premium | coding | ...
   purpose?: string;
   primary: string;
   fallback: string[];
   constraints: LaneConstraints;
+  // Lane-forced reasoning effort; omitted = unforced. Round-trips to the gateway's
+  // optional LaneSchema.reasoning_effort (strict enum, fail-closed) untouched.
+  reasoning_effort?: ReasoningEffort;
 }
 
 const BASE = '/admin/api/lanes';
@@ -57,6 +79,9 @@ function normalizeLane(raw: Record<string, unknown>): Lane {
     primary: String(raw.primary ?? ''),
     fallback: Array.isArray(raw.fallback) ? raw.fallback.map(String) : [],
     constraints: normalizeConstraints(raw.constraints as Record<string, unknown> | undefined),
+    // Carry a valid forced effort; an absent/unknown value stays unforced. The
+    // PUT body (toServerBody) spreads it through, so no extra wiring there.
+    ...(isReasoningEffort(raw.reasoning_effort) ? { reasoning_effort: raw.reasoning_effort } : {}),
   };
 }
 

--- a/apps/admin/src/lib/components/LaneEditor.svelte
+++ b/apps/admin/src/lib/components/LaneEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { untrack } from 'svelte';
-  import type { Lane } from '$lib/api/lanes.js';
+  import { type Lane, REASONING_EFFORTS, type ReasoningEffort } from '$lib/api/lanes.js';
   import type { ModelOption } from '$lib/api/models.js';
   import { t } from '$lib/i18n';
 
@@ -40,6 +40,8 @@
   let requireTools = $state(initial.constraints.require_tools);
   let requireJson = $state(initial.constraints.require_json);
   let maxLatency = $state<number | null>(initial.constraints.max_latency_ms ?? null);
+  // Lane-forced reasoning effort; '' = unforced (the request-driven default).
+  let reasoningEffort = $state<ReasoningEffort | ''>(initial.reasoning_effort ?? '');
   let newFallback = $state('');
   // Per-card success flag: set when the parent's save resolves without throwing.
   // It is the visible "success notice" the operator (and the e2e) waits for.
@@ -107,6 +109,11 @@
         max_latency_ms: maxLatency,
       },
     };
+    // Forced reasoning effort: set when chosen, OMIT when '' so the server (and the
+    // YAML write-back) treat it as unforced and prune the key (a strictObject would
+    // also reject an explicit invalid value).
+    if (reasoningEffort) body.reasoning_effort = reasoningEffort;
+    else delete body.reasoning_effort;
     saved = false;
     // The parent owns user-facing error handling (page-level alert). It re-throws
     // on failure so the per-card success flag is flipped ONLY on a real success;
@@ -241,6 +248,19 @@
       />
     </label>
   </div>
+
+  <label class="field flex flex-col gap-1">
+    <span class="field-label">{$t('Forced reasoning effort')}</span>
+    <select class="input-sm w-44" data-testid="reasoning-effort" bind:value={reasoningEffort}>
+      <option value="">{$t('Unset (client decides)')}</option>
+      {#each REASONING_EFFORTS as eff (eff)}
+        <option value={eff}>{eff}</option>
+      {/each}
+    </select>
+    <span class="field-help">
+      {$t('When set, overrides the client reasoning effort for every request on this lane.')}
+    </span>
+  </label>
 
   {#if primaryEmpty}
     <p class="alert-error" role="alert">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -606,5 +606,8 @@
   "Generation time": "Generation time",
   "Tokens generated per second (output ÷ generation time), averaged over streamed requests.": "Tokens generated per second (output ÷ generation time), averaged over streamed requests.",
   "Generation throughput: output tokens per second. Only measured for streamed responses.": "Generation throughput: output tokens per second. Only measured for streamed responses.",
-  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses."
+  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.",
+  "Forced reasoning effort": "Forced reasoning effort",
+  "Unset (client decides)": "Unset (client decides)",
+  "When set, overrides the client reasoning effort for every request on this lane.": "When set, overrides the client reasoning effort for every request on this lane."
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -606,5 +606,8 @@
   "Generation time": "生成時間",
   "Tokens generated per second (output ÷ generation time), averaged over streamed requests.": "1秒あたりの生成トークン数（出力 ÷ 生成時間）。ストリーミングリクエストの平均。",
   "Generation throughput: output tokens per second. Only measured for streamed responses.": "生成スループット：1秒あたりの出力トークン数。ストリーミング応答でのみ測定されます。",
-  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "応答が生成された速度——1秒あたりの出力トークン数、生成ウィンドウ、最初のトークンまでの時間。ストリーミング応答でのみ測定されます。"
+  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "応答が生成された速度——1秒あたりの出力トークン数、生成ウィンドウ、最初のトークンまでの時間。ストリーミング応答でのみ測定されます。",
+  "Forced reasoning effort": "推論レベルを強制",
+  "Unset (client decides)": "未設定（クライアントが決定）",
+  "When set, overrides the client reasoning effort for every request on this lane.": "設定すると、このレーンのすべてのリクエストでクライアントの推論レベルを上書きします。"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -606,5 +606,8 @@
   "Generation time": "생성 시간",
   "Tokens generated per second (output ÷ generation time), averaged over streamed requests.": "초당 생성 토큰 수(출력 ÷ 생성 시간), 스트리밍 요청 평균.",
   "Generation throughput: output tokens per second. Only measured for streamed responses.": "생성 처리량: 초당 출력 토큰 수. 스트리밍 응답에서만 측정됩니다.",
-  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "응답이 생성된 속도 — 초당 출력 토큰 수, 생성 구간, 첫 토큰까지의 시간. 스트리밍 응답에서만 측정됩니다."
+  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "응답이 생성된 속도 — 초당 출력 토큰 수, 생성 구간, 첫 토큰까지의 시간. 스트리밍 응답에서만 측정됩니다.",
+  "Forced reasoning effort": "추론 수준 강제",
+  "Unset (client decides)": "미설정 (클라이언트가 결정)",
+  "When set, overrides the client reasoning effort for every request on this lane.": "설정하면 이 레인의 모든 요청에서 클라이언트 추론 수준을 덮어씁니다."
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -606,5 +606,8 @@
   "Generation time": "生成耗时",
   "Tokens generated per second (output ÷ generation time), averaged over streamed requests.": "每秒生成的 Token 数（输出 ÷ 生成时间），按流式请求平均。",
   "Generation throughput: output tokens per second. Only measured for streamed responses.": "生成吞吐量：每秒输出 Token 数。仅对流式响应测量。",
-  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "响应生成的速度——每秒输出 Token 数、生成窗口时长，以及首 Token 的延迟。仅对流式响应测量。"
+  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "响应生成的速度——每秒输出 Token 数、生成窗口时长，以及首 Token 的延迟。仅对流式响应测量。",
+  "Forced reasoning effort": "强制推理等级",
+  "Unset (client decides)": "未设置（由客户端决定）",
+  "When set, overrides the client reasoning effort for every request on this lane.": "设置后，将覆盖该通道上每个请求的客户端推理等级。"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -606,5 +606,8 @@
   "Generation time": "生成耗時",
   "Tokens generated per second (output ÷ generation time), averaged over streamed requests.": "每秒生成的 Token 數（輸出 ÷ 生成時間），依串流請求平均。",
   "Generation throughput: output tokens per second. Only measured for streamed responses.": "生成吞吐量：每秒輸出 Token 數。僅對串流回應測量。",
-  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "回應生成的速度——每秒輸出 Token 數、生成視窗時長，以及首 Token 的延遲。僅對串流回應測量。"
+  "How fast the response was generated — output tokens per second, the generation window, and the time to the first token. Measured only for streamed responses.": "回應生成的速度——每秒輸出 Token 數、生成視窗時長，以及首 Token 的延遲。僅對串流回應測量。",
+  "Forced reasoning effort": "強制推理等級",
+  "Unset (client decides)": "未設定（由用戶端決定）",
+  "When set, overrides the client reasoning effort for every request on this lane.": "設定後，將覆寫該通道上每個請求的用戶端推理等級。"
 }

--- a/apps/admin/src/routes/lanes/lanes.test.ts
+++ b/apps/admin/src/routes/lanes/lanes.test.ts
@@ -9,6 +9,8 @@ import LanesPage from './+page.svelte';
 const saveLane = vi.fn();
 vi.mock('$lib/api/lanes.js', () => ({
   saveLane: (...args: unknown[]) => saveLane(...args),
+  // LaneEditor imports this value from the same module; the mock must expose it.
+  REASONING_EFFORTS: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
 }));
 
 function lane(name: string, overrides: Partial<Lane> = {}): Lane {
@@ -102,5 +104,28 @@ describe('lanes page', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     // The other lanes' data is untouched; the page did not crash.
     expect(screen.getByText('coding')).toBeInTheDocument();
+  });
+
+  it('selecting a forced reasoning effort and saving sends it to saveLane', async () => {
+    renderPage([lane('coding')]);
+    const card = screen.getByTestId('lane-card');
+    const select = within(card).getByTestId('reasoning-effort') as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: 'medium' } });
+    await fireEvent.click(within(card).getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(saveLane).toHaveBeenCalledTimes(1));
+    expect(saveLane.mock.calls[0][1].reasoning_effort).toBe('medium');
+  });
+
+  it('seeds the dropdown from the lane and omits the field when set back to Unset', async () => {
+    renderPage([lane('coding', { reasoning_effort: 'high' })]);
+    const card = screen.getByTestId('lane-card');
+    const select = within(card).getByTestId('reasoning-effort') as HTMLSelectElement;
+    expect(select.value).toBe('high'); // seeded from the lane's forced value
+    await fireEvent.change(select, { target: { value: '' } }); // Unset
+    await fireEvent.click(within(card).getByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(saveLane).toHaveBeenCalledTimes(1));
+    expect(saveLane.mock.calls[0][1].reasoning_effort).toBeUndefined();
   });
 });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-17 · /admin/lanes 加 reasoning_effort 下拉（admin UI；原则 1）
+
+- **背景**：lane 级强制 reasoning_effort 此前只能改 YAML；用户要在 `/admin/lanes` 页面用下拉选。
+- **关键发现：纯前端**——v0.17.0 后端**已**整条 round-trip `reasoning_effort`：admin lanes 路由 `LaneSchema.safeParse` 已含该可选字段、YAML write-back `deepAssign` 无字段白名单（写存在的键、prune 缺失的键），**gateway/writeback 零改**。唯一漏处是 admin 客户端 DTO（`apps/admin/src/lib/api/lanes.ts` `normalizeLane`/`Lane`）丢弃该字段。
+- **实现**：`lanes.ts` 加 `ReasoningEffort` 类型 + `REASONING_EFFORTS` + `Lane.reasoning_effort`，`normalizeLane` 携带（非法值丢弃）；`LaneEditor.svelte` 加 `<select>`（"Unset（客户端决定）" + 7 档），seed 自 lane，`handleSave` 选中则写、Unset 则 `delete`（让 strictObject + writeback 把键剪掉）；5 语言各补 3 键（zh-hans/hant/ja/ko 手译）。admin 不 import core/shared（原则 1），故 enum 在 admin 侧手写镜像。
+- **坑**：① page 测试 `vi.mock('$lib/api/lanes.js')` 必须补 `REASONING_EFFORTS` 导出，否则 LaneEditor 导入它时整页 mock 崩。② `pnpm i18n:extract` 会顺手把**别处**未提取的串（TPS/auto-park）一起拉进 locale → 改为手动 append 3 键保 PR 干净（代价：键未按工具字母序，下次 extract 会重排，无害）。③ Response body 只能读一次——api 测试两次 saveLane 要各给 `mockResolvedValueOnce`。
+- **验证**：admin lanes api(5)+page(13 含 select→save / Unset→omit / seed) 绿；`svelte-check` 0 err/0 warn；biome lint + prettier 绿。分支 `feat/admin-lane-reasoning-effort-dropdown`（off main v0.17.0），未发版（admin 由 gateway 托管，需新镜像才到 box）。
+
 ## 2026-06-17 · Lane 级强制 reasoning_effort（gateway 侧覆盖客户端；docs/04；原则 1/2/4）
 
 - **背景**：helm 此前 reasoning 等级纯请求级（客户端发，透传/互译）。用户要 operator 在 **lane** 级**强制** reasoning_effort，客户端不可覆盖（"以前 sub2api 支持的"其实是 sub2api 教用户填 Codex CLI `model_reasoning_effort` 的客户端配置，非网关）。范围拍板：**仅 lane 级 + 强制**；保留原生直通；覆盖全 4 协议（含 Anthropic——这是 helm 唯一缺的 `reasoning_effort→thinking` 映射）。


### PR DESCRIPTION
## Why
Lane-forced `reasoning_effort` (v0.17.0) could only be set by hand-editing `lanes.yaml`. This adds a dropdown to the `/admin/lanes` lane editor so operators set/clear it from the UI.

## Front-end only
The v0.17.0 backend already round-trips the field end-to-end, so **no gateway/writeback change**:
- Admin lanes `PUT` validates with `LaneSchema` → already includes optional `reasoning_effort`.
- YAML write-back `deepAssign` has no field allowlist → writes a present key, prunes an absent one.

The admin client DTO was the only layer dropping it.

## Changes
- **`lib/api/lanes.ts`**: `ReasoningEffort` type + `REASONING_EFFORTS` + `Lane.reasoning_effort`; `normalizeLane` carries a valid value (ignores unknown). `toServerBody` already spreads it through.
- **`LaneEditor.svelte`**: a `<select>` — **Unset (client decides)** + the 7 tiers (`none…max`) — seeded from the lane; `handleSave` sets it when chosen and **omits** it on Unset (server `strictObject` + writeback then prune the key → lane reverts to client-driven).
- **i18n**: 3 strings translated to zh-hans / zh-hant / ja / ko (appended to keep the diff minimal — `i18n:extract` would otherwise pull in unrelated previously-unextracted strings).
- **tests**: +5 — API round-trip + ignore-unknown; page select→save asserts the field; Unset→omit; seed-from-lane.

## Verification
- `svelte-check` 0 errors / 0 warnings; `biome` lint + `prettier` clean.
- Admin lanes suites green: `lib/api/lanes.test.ts` (5) + `routes/lanes/lanes.test.ts` (13).

## Deploy note
The admin SPA is served by the gateway, so this reaches a deployment only via a new image (next release after v0.17.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)