### PR TITLE
v0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.18.0**.

Since v0.17.0 (one change):
- feat(admin): reasoning_effort dropdown on /admin/lanes (#298) — operators set/clear a lane's forced reasoning effort from the UI. Front-end only; backend already round-trips `reasoning_effort` from v0.17.0.

Bumps root `package.json` 0.17.0 → 0.18.0; merging to main triggers `publish.yml` to build/push the image and cut the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)