### PR TITLE
feat(routing): route gemini flash-lite (any version) to the economy lane

### DIFF
--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -56,12 +56,15 @@
 "gpt-*": balanced
 
 # ── Google Gemini (Gemini CLI, AI Studio / Vertex SDKs, …) ───────────────────
-# Bare Gemini ids → vendor-family lanes (config/lanes.yaml). Any `*pro*` id leads
-# with the Gemini Pro tier; any `*flash*` (incl. flash-lite) with the cheaper
-# Flash tier; the bare `gemini-*` catch-all degrades to balanced. Longest-literal
-# wins, so `gemini-*flash*` (12 literal chars) and `gemini-*pro*` (10) both beat
-# the `gemini-*` catch-all (7). The middle `*` absorbs the version + any `-preview`
-# / `-latest` / date suffix (gemini-3.1-pro-preview, gemini-3.5-flash, gemini-2.5-pro…).
+# Bare Gemini ids → vendor-family lanes (config/lanes.yaml). The cheap `*flash-lite*`
+# tier routes straight to the `economy` lane (no dedicated model); any other `*flash*`
+# leads with the Gemini Flash tier; any `*pro*` with the Gemini Pro tier; the bare
+# `gemini-*` catch-all degrades to balanced. Longest-literal wins, so `gemini-*flash-lite*`
+# (17 literal chars) beats `gemini-*flash*` (12) beats `gemini-*pro*` (10) beats the
+# `gemini-*` catch-all (7) — declaration order is irrelevant. The middle `*` absorbs the
+# version, so a future 3.2/4 flash-lite needs no edit; the trailing `*` absorbs any
+# `-preview` / `-latest` / date suffix (gemini-3.1-flash-lite, gemini-3.5-flash, …).
+"gemini-*flash-lite*": economy
 "gemini-*flash*": gemini-flash
 "gemini-*pro*": gemini-pro
 "gemini-*": balanced

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -114,12 +114,16 @@ describe("checked-in config samples", () => {
     expect(lanes["gemini-pro"]?.fallback).toEqual(["premium"]);
     expect(lanes["gemini-flash"]?.primary).toBe("zenmux-vertex/gemini-3.5-flash");
     expect(lanes["gemini-flash"]?.fallback).toEqual(["balanced"]);
-    // Longest-literal wins: `*pro*` / `*flash*` beat the `gemini-*` catch-all, and
-    // the middle `*` absorbs the version + any -preview/-latest suffix.
+    // Longest-literal wins: `*flash-lite*` (cheap lite tier -> economy) beats `*flash*`,
+    // which beats the `gemini-*` catch-all; the middle `*` absorbs the version + any
+    // -preview/-latest suffix.
     expect(resolveModelAlias("gemini-3.1-pro-preview", aliases)).toBe("gemini-pro");
     expect(resolveModelAlias("gemini-2.5-pro", aliases)).toBe("gemini-pro");
     expect(resolveModelAlias("gemini-3.5-flash", aliases)).toBe("gemini-flash");
-    expect(resolveModelAlias("gemini-3.1-flash-lite", aliases)).toBe("gemini-flash");
+    // flash-lite is the cheap tier: any version routes straight to `economy`, NOT the
+    // full-flash lane — version-resilient, so a future 3.2/4 id needs no config edit.
+    expect(resolveModelAlias("gemini-3.1-flash-lite", aliases)).toBe("economy");
+    expect(resolveModelAlias("gemini-4-flash-lite", aliases)).toBe("economy");
     // An id matching neither tier falls through the catch-all to balanced.
     expect(resolveModelAlias("gemini-embedding-001", aliases)).toBe("balanced");
   });

--- a/packages/core/src/routing/model-alias.test.ts
+++ b/packages/core/src/routing/model-alias.test.ts
@@ -52,6 +52,19 @@ describe("resolveModelAlias", () => {
     expect(resolveModelAlias("gpt-5.5", { "gpt-5.5": "premium" })).toBe("premium");
     expect(resolveModelAlias("gpt-5x5", { "gpt-5.5": "premium" })).toBeNull();
   });
+
+  it("a keyword-wrapped glob with more literals wins (flash-lite beats flash), order-independent", () => {
+    // `gemini-*flash-lite*` (17 literals) is more specific than `gemini-*flash*` (12),
+    // so a flash-lite id routes to the cheap tier while full-flash falls to the flash lane.
+    const map = { "gemini-*flash-lite*": "economy", "gemini-*flash*": "gemini-flash" };
+    const reversed = { "gemini-*flash*": "gemini-flash", "gemini-*flash-lite*": "economy" };
+    expect(resolveModelAlias("gemini-3.1-flash-lite", map)).toBe("economy");
+    expect(resolveModelAlias("gemini-3.1-flash-lite", reversed)).toBe("economy");
+    // A future version id matches the same wildcard with no config change.
+    expect(resolveModelAlias("gemini-4-flash-lite-preview", map)).toBe("economy");
+    // Full flash (no "lite") is not captured by the flash-lite glob.
+    expect(resolveModelAlias("gemini-3.5-flash", map)).toBe("gemini-flash");
+  });
 });
 
 describe("validateModelAliasTargets", () => {


### PR DESCRIPTION
## Why

A `gemini-*-flash-lite` request currently matches the generic `gemini-*flash*` wildcard → `gemini-flash` lane → served by the **full** `gemini-3.5-flash`. The cheaper flash-lite provider entry (`zenmux-vertex/gemini-3.1-flash-lite`) was **orphaned**: defined in `capabilities.yaml`/`pricing.yaml`/`providers.yaml` but no lane or alias routed to it.

Per product decision, flash-lite is a *cheap* tier and should route **straight to the existing `economy` lane** — no dedicated lane, no new model — and must be **version-resilient** (future 3.2/4 ids route with no config edit).

## What

- **`config/model-aliases.yaml`**: add `"gemini-*flash-lite*": economy` above `"gemini-*flash*"`. It has 17 literal chars vs `gemini-*flash*`'s 12, so longest-literal-wins routes flash-lite ids to `economy` regardless of declaration order. The mid `*` absorbs the version; the trailing `*` absorbs `-preview`/`-latest`/date suffixes. Full-flash ids (no "lite") still fall to the flash lane.
- **No new lane/model** — `lanes.yaml` / `capabilities.yaml` / `pricing.yaml` / `providers.yaml` untouched. The pre-existing orphaned entry stays as-is (harmless).

`economy` = primary `openai-codex/gpt-5.4-mini`, fallback `claude-haiku-4-5 → deepseek-v4-flash → openrouter/deepseek-v4-flash → balanced`.

## Tests (TDD)

- `samples.test.ts`: flip the pinned `gemini-3.1-flash-lite` assertion `gemini-flash` → `economy`; add a `gemini-4-flash-lite` future-version case. Full-flash assertion unchanged.
- `model-alias.test.ts`: add an order-independent precedence case (flash-lite beats flash).

## Verification

- `pnpm vitest run` (both files): 25 passed
- `pnpm typecheck`: clean (shared/core/gateway)
- `pnpm lint`: clean (475 files)

## Note / limitation

The wildcard covers the **inbound client id** only. A flash-lite request now lands on `economy` (cross-vendor "cheapest available"), so no upstream gemini model id is involved — nothing to version-bump. gpt-5.4 was the original ask but is already fully wired on `main`; no change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)