### PR TITLE
fix(routing): honest jsonOutput capability tier (json_schema routing) + v0.19.0

### DIFF
--- a/apps/gateway/src/routes/classify.cost.test.ts
+++ b/apps/gateway/src/routes/classify.cost.test.ts
@@ -64,7 +64,7 @@ function priced(modelKey: string, pricing: CatalogEntry["pricing"]): CatalogEntr
     modelKey,
     capabilities: {
       supportsTools: false,
-      supportsJsonMode: false,
+      jsonOutput: "none",
       supportsVision: false,
       supportsStreaming: false,
       maxContextTokens: 0,

--- a/apps/gateway/src/routes/execute.default-config.test.ts
+++ b/apps/gateway/src/routes/execute.default-config.test.ts
@@ -170,9 +170,10 @@ describe("default config activates capability filter + cost (alias-namespace ali
   it("sanity: the shipped catalog is keyed by the SAME provider/model aliases the lanes use", () => {
     // Pre-alignment these were absent (lane aliases like `cheap_model` had no
     // catalog entry). Now every lane candidate alias resolves in the catalog.
-    expect(catalog.get("deepseek/deepseek-v4-flash")?.capabilities.supportsJsonMode).toBe(true);
-    expect(catalog.get("zenmux/auto")?.capabilities.supportsJsonMode).toBe(false);
-    expect(catalog.get("openrouter/auto")?.capabilities.supportsJsonMode).toBe(false);
+    expect(catalog.get("deepseek/deepseek-v4-flash")?.capabilities.jsonOutput).toBe("object");
+    expect(catalog.get("openrouter/deepseek-v4-flash")?.capabilities.jsonOutput).toBe("schema");
+    expect(catalog.get("zenmux/auto")?.capabilities.jsonOutput).toBe("none");
+    expect(catalog.get("openrouter/auto")?.capabilities.jsonOutput).toBe("none");
     expect(catalog.get("zenmux-vertex/gemini-3.5-flash")?.capabilities.supportsCachedContent).toBe(
       true,
     );
@@ -208,6 +209,70 @@ describe("default config activates capability filter + cost (alias-namespace ali
     // The pruned auto must NEVER have been invoked upstream. The upstream `model`
     // is the RESOLVED bare provider_model (`deepseek-v4-pro`), not the alias.
     expect(calls).toEqual(["deepseek-v4-pro"]);
+  });
+
+  // Regression for the prod incident (Codex json_schema → official DeepSeek 400 →
+  // fallback). A strict json_schema request must PRUNE the json_object-only official
+  // deepseek (jsonOutput:object → no_response_schema_support) and land on the cheap,
+  // natively schema-capable openrouter mirror — never burning the 400 attempt.
+  it("json_schema prunes json_object-only official deepseek and lands on the cheap openrouter mirror", async () => {
+    const { client, calls } = stubProvider();
+    const registry = buildRegistry();
+    const execute = createExecute({
+      defaultProvider: client,
+      providers: providerClients(client),
+      registry,
+      breaker: breaker(),
+      catalog,
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    // The json lane's first two candidates (config/lanes.yaml).
+    const chain = ["deepseek/deepseek-v4-flash", "openrouter/deepseek-v4-flash"];
+    const out = await execute(
+      plan(chain),
+      req({
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "x", schema: { type: "object" }, strict: true },
+        },
+      }),
+    );
+
+    expect(out.attempts[0]?.alias).toBe("deepseek/deepseek-v4-flash");
+    expect(out.attempts[0]?.skipped).toBe(true);
+    expect(out.attempts[0]?.skip_reason).toBe("no_response_schema_support");
+    expect(out.final.status).toBe("ok");
+    if (out.final.status === "ok") expect(out.final.alias).toBe("openrouter/deepseek-v4-flash");
+    // Official deepseek (bare `deepseek-v4-flash`) was NEVER invoked; only the openrouter
+    // mirror ran (its provider_model is `deepseek/deepseek-v4-flash`).
+    expect(calls).toEqual(["deepseek/deepseek-v4-flash"]);
+  });
+
+  // The other side of the tier: a plain json_object request stays on the cheapest
+  // candidate (official deepseek serves json_object natively). No regression.
+  it("json_object still lands cheaply on official deepseek (openrouter mirror not reached)", async () => {
+    const { client, calls } = stubProvider();
+    const registry = buildRegistry();
+    const execute = createExecute({
+      defaultProvider: client,
+      providers: providerClients(client),
+      registry,
+      breaker: breaker(),
+      catalog,
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const chain = ["deepseek/deepseek-v4-flash", "openrouter/deepseek-v4-flash"];
+    const out = await execute(plan(chain), req({ response_format: { type: "json_object" } }));
+
+    expect(out.attempts[0]?.alias).toBe("deepseek/deepseek-v4-flash");
+    expect(out.attempts[0]?.skipped).toBe(false);
+    expect(out.final.status).toBe("ok");
+    if (out.final.status === "ok") expect(out.final.alias).toBe("deepseek/deepseek-v4-flash");
+    expect(calls).toEqual(["deepseek-v4-flash"]);
   });
 
   it("threads a captureUpstream sink to the served provider and surfaces it as outcome.upstreamRequest", async () => {

--- a/apps/gateway/src/routes/execute.errors.test.ts
+++ b/apps/gateway/src/routes/execute.errors.test.ts
@@ -80,7 +80,7 @@ function noToolsEntry(modelKey: string): CatalogEntry {
     modelKey,
     capabilities: {
       supportsTools: false,
-      supportsJsonMode: true,
+      jsonOutput: "schema",
       supportsVision: true,
       supportsStreaming: true,
       maxContextTokens: 100000,

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -850,7 +850,7 @@ describe("createExecute — gateway execution adapter", () => {
       modelKey: "a",
       capabilities: {
         supportsTools: false,
-        supportsJsonMode: true,
+        jsonOutput: "schema",
         supportsVision: true,
         supportsStreaming: true,
         maxContextTokens: 100000,
@@ -1335,7 +1335,7 @@ describe("createExecute — gateway execution adapter", () => {
       modelKey,
       capabilities: {
         supportsTools: true,
-        supportsJsonMode: true,
+        jsonOutput: "schema",
         supportsVision: true,
         supportsStreaming: true,
         maxContextTokens: 200000,
@@ -1365,8 +1365,8 @@ describe("createExecute — gateway execution adapter", () => {
       // Catalog is keyed by the candidate ALIAS (the modelKey), not the resolved
       // upstream model id (fix-upstream-model-id 2026-05-31).
       catalog: new Map([
-        ["a", entry("a", { supportsJsonMode: false })],
-        ["b", entry("b", { supportsJsonMode: true })],
+        ["a", entry("a", { jsonOutput: "none" })],
+        ["b", entry("b", { jsonOutput: "schema" })],
       ]),
       now: clock(),
       signal: new AbortController().signal,
@@ -1569,8 +1569,8 @@ describe("createExecute — gateway execution adapter", () => {
       registry: registry({ a: "m-a", b: "m-b" }),
       breaker: breaker(),
       catalog: new Map([
-        ["a", entry("a", { supportsJsonMode: false })],
-        ["b", entry("b", { supportsJsonMode: false })],
+        ["a", entry("a", { jsonOutput: "none" })],
+        ["b", entry("b", { jsonOutput: "none" })],
       ]),
       now: clock(),
       signal: new AbortController().signal,
@@ -1600,7 +1600,7 @@ describe("createExecute — gateway execution adapter", () => {
       providers: new Map([["mock", provider]]),
       registry: registry({ a: "m-a", u: "m-unknown" }),
       breaker: breaker(),
-      catalog: new Map([["a", entry("a", { supportsJsonMode: false })]]),
+      catalog: new Map([["a", entry("a", { jsonOutput: "none" })]]),
       now: clock(),
       signal: new AbortController().signal,
     });
@@ -1647,7 +1647,7 @@ describe("createExecute — gateway execution adapter", () => {
       modelKey,
       capabilities: {
         supportsTools: true,
-        supportsJsonMode: true,
+        jsonOutput: "schema",
         supportsVision: true,
         supportsStreaming: true,
         maxContextTokens: 200000,
@@ -2480,7 +2480,7 @@ describe("createExecute — native protocol passthrough (#217)", () => {
             modelKey: "a",
             capabilities: {
               supportsTools: true,
-              supportsJsonMode: true,
+              jsonOutput: "schema",
               supportsVision: true,
               supportsStreaming: true,
               maxContextTokens: 200000,
@@ -2544,7 +2544,7 @@ describe("createExecute — native protocol passthrough (#217)", () => {
             modelKey: "r",
             capabilities: {
               supportsTools: true,
-              supportsJsonMode: true,
+              jsonOutput: "schema",
               supportsVision: true,
               supportsStreaming: true,
               maxContextTokens: 200000,

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -769,6 +769,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         const verdict = checkCapability(caps, {
           needsTools: Array.isArray(req.tools) && req.tools.length > 0,
           needsJson: isJson(req.response_format),
+          needsResponseSchema: isJsonSchema(req.response_format),
           needsVision:
             (Array.isArray(req.attachments) && req.attachments.length > 0) || reqModalities.image,
           needsStreaming: req.stream,
@@ -1328,6 +1329,14 @@ function isJson(rf: InternalRequest["response_format"]): boolean {
   if (!rf || typeof rf !== "object") return false;
   const t = (rf as { type?: unknown }).type;
   return t === "json_object" || t === "json_schema";
+}
+
+// Strict structured output specifically (json_schema, not bare json_object). Gates the
+// `no_response_schema_support` capability filter so a json_schema request prunes
+// json_object-only backends (official DeepSeek) instead of burning an attempt on a 400.
+function isJsonSchema(rf: InternalRequest["response_format"]): boolean {
+  if (!rf || typeof rf !== "object") return false;
+  return (rf as { type?: unknown }).type === "json_schema";
 }
 
 // Inert passthrough telemetry (issue #217): considered:false — for attempt rows that

--- a/apps/gateway/src/routes/models.test.ts
+++ b/apps/gateway/src/routes/models.test.ts
@@ -17,7 +17,7 @@ const catalog = new Map<string, CatalogEntry>([
       modelKey: "deepseek/pro",
       capabilities: {
         supportsTools: true,
-        supportsJsonMode: true,
+        jsonOutput: "schema",
         supportsVision: false,
         supportsStreaming: true,
         maxContextTokens: 128_000,

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -11,11 +11,17 @@
 
 # "local/llama-3.1-70b":
 #   supportsTools: true
-#   supportsJsonMode: false
+#   jsonOutput: object
 #   supportsVision: false
 #   supportsStreaming: true
 #   maxContextTokens: 131072
 #   maxOutputTokens: 4096
+#
+# `jsonOutput` is an ORDERED tier (none < object < schema): `none` = no JSON mode
+# (pruned for any JSON request); `object` = `response_format:{type:"json_object"}`
+# only (official DeepSeek — json_schema 400s); `schema` = native strict structured
+# output (`response_format:{type:"json_schema"}` / Anthropic output_format / Gemini
+# responseSchema). A json_schema request prunes every candidate below `schema`.
 #
 # `modalities` (optional) lists the EXTRA input modalities a backend accepts beyond
 # text + image (image is gated by supportsVision). Allowed values: audio, video,
@@ -49,52 +55,57 @@
 # an operator can pick has a capability + pricing entry here.
 openai-codex/gpt-5.5:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   maxContextTokens: 1050000
   maxOutputTokens: 128000
 openai-codex/gpt-5.4:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   maxContextTokens: 400000
   maxOutputTokens: 128000
 openai-codex/gpt-5.4-mini:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   maxContextTokens: 400000
   maxOutputTokens: 65536
+# Official DeepSeek API: json_object YES, json_schema NO (response_format json_schema
+# 400s "This response_format type is unavailable now"). Hence `object`, not `schema` —
+# a strict json_schema request prunes these and lands on a schema-capable backend
+# (e.g. the openrouter mirrors below), while a json_object request still serves cheaply.
 deepseek/deepseek-v4-pro:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: object
   supportsVision: false
   supportsStreaming: true
   maxContextTokens: 1048576
   maxOutputTokens: 384000
 deepseek/deepseek-v4-flash:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: object
   supportsVision: false
   supportsStreaming: true
   maxContextTokens: 1048576
   maxOutputTokens: 16384
 # OpenRouter-hosted DeepSeek mirrors (lanes fallback f0d0cc6; data from
 # https://openrouter.ai/api/v1/models, 2026-06-04 — tools + structured_outputs
-# supported, text-only input).
+# supported, text-only input). structured_outputs ⇒ jsonOutput: schema, so a strict
+# json_schema request lands here (cheap + native) rather than on official DeepSeek.
 openrouter/deepseek-v4-pro:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: false
   supportsStreaming: true
   maxContextTokens: 1048576
   maxOutputTokens: 384000
 openrouter/deepseek-v4-flash:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: false
   supportsStreaming: true
   maxContextTokens: 1048576
@@ -103,7 +114,7 @@ openrouter/deepseek-v4-flash:
 # below (issue #217); the OpenAI-compat `zenmux/claude-*` entries were removed.
 zenmux/gpt-5.5:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   # OpenRouter lists `file` input for gpt-5.5 (text+image+file->text).
@@ -112,12 +123,12 @@ zenmux/gpt-5.5:
   maxOutputTokens: 128000
 # NATIVE-protocol passthrough aliases (issue #217). Gemini/Claude are served via
 # ZenMux's native Gemini/Anthropic endpoints (the OpenAI-compat `zenmux/gemini-*` /
-# `zenmux/claude-*` aliases were removed). supportsJsonMode is load-bearing here: a
-# missing entry defaults to false, and a strict-JSON request would skip the
-# candidate (the issue-#217 failure mode).
+# `zenmux/claude-*` aliases were removed). jsonOutput is load-bearing here: a missing
+# entry defaults to `none`, and a strict-JSON request would skip the candidate (the
+# issue-#217 failure mode).
 zenmux-vertex/gemini-3.5-flash:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   supportsCachedContent: true
@@ -126,7 +137,7 @@ zenmux-vertex/gemini-3.5-flash:
   maxOutputTokens: 65536
 zenmux-vertex/gemini-3.1-flash-lite:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   supportsCachedContent: true
@@ -135,7 +146,7 @@ zenmux-vertex/gemini-3.1-flash-lite:
   maxOutputTokens: 65536
 zenmux-vertex/gemini-3.1-pro:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   supportsCachedContent: true
@@ -144,7 +155,7 @@ zenmux-vertex/gemini-3.1-pro:
   maxOutputTokens: 65536
 zenmux-anthropic/claude-opus-4.8:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   modalities: [document]
@@ -152,7 +163,7 @@ zenmux-anthropic/claude-opus-4.8:
   maxOutputTokens: 128000
 zenmux-anthropic/claude-sonnet-4.6:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   modalities: [document]
@@ -160,24 +171,24 @@ zenmux-anthropic/claude-sonnet-4.6:
   maxOutputTokens: 128000
 zenmux-anthropic/claude-haiku-4.5:
   supportsTools: true
-  supportsJsonMode: true
+  jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000
-# */auto aggregators: JSON-INCAPABLE on purpose — the capability filter prunes
-# them for strict-JSON requests so a json lane lands on a deterministic model.
+# */auto aggregators: JSON-INCAPABLE on purpose (jsonOutput: none) — the capability
+# filter prunes them for any JSON request so a json lane lands on a deterministic model.
 zenmux/auto:
   supportsTools: true
-  supportsJsonMode: false
+  jsonOutput: none
   supportsVision: true
   supportsStreaming: true
   maxContextTokens: 200000
   maxOutputTokens: 8192
 openrouter/auto:
   supportsTools: true
-  supportsJsonMode: false
+  jsonOutput: none
   supportsVision: true
   supportsStreaming: true
   maxContextTokens: 200000

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -17,7 +17,7 @@
 # no subscription is bound: an unconnected `openai-codex/*` candidate fails OPEN
 # (Phase-0 back-fill / skip to the next fallback), never a 5xx. Each lane still ends
 # in a `*/auto` tail fallback; those auto aliases are deliberately JSON-INCAPABLE
-# (catalog supports_json_schema:false), so a strict-JSON request prunes them and
+# (catalog jsonOutput:none), so a strict-JSON request prunes them and
 # lands on a deterministic json-capable model (docs/02: `*/auto` only at the tail).
 
 # —— quality/cost lanes ——
@@ -67,12 +67,15 @@ coding:
 
 json:
   purpose: Strict structured-output (JSON) responses
-  # Primary is json-capable (catalog supports_json_schema:true) so a strict-JSON
-  # request lands deterministically. The chain then drops through balanced, whose
-  # tail `*/auto` aliases are json-INCAPABLE and get PRUNED by the capability
-  # filter — proving the filter fires on the default config.
+  # The capability filter discriminates by request shape against each candidate's
+  # `jsonOutput` tier (none<object<schema): a json_OBJECT request is served cheaply by
+  # the official-DeepSeek primary (jsonOutput:object); a strict json_SCHEMA request
+  # PRUNES that primary (no_response_schema_support) and lands on the cheap, natively
+  # schema-capable openrouter mirror (jsonOutput:schema), only then dropping through
+  # balanced whose `*/auto` tail (jsonOutput:none) is pruned for any JSON request.
   primary: deepseek/deepseek-v4-flash
   fallback:
+    - openrouter/deepseek-v4-flash
     - balanced
   constraints:
     require_json: true

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -233,10 +233,14 @@ backed by a static fallback so the lane **degrades gracefully**: an unconnected
 The `*/auto` aliases (`zenmux/auto`, `openrouter/auto`) sit only at the **tail of
 the `balanced` chain** — every other lane reaches them by falling through to
 `balanced`, not by carrying its own auto tail. Those auto aliases are
-deliberately JSON-incapable in the catalog (`supportsJsonMode: false`), so a
+deliberately JSON-incapable in the catalog (`jsonOutput: none`), so a
 strict-JSON request prunes them via the Capability Filter and lands on a
 deterministic JSON-capable model — proving the filter fires on the default
-config.
+config. The same filter discriminates the two JSON tiers: a strict `json_schema`
+request additionally prunes `object`-only backends (official DeepSeek →
+`no_response_schema_support`) and lands on a `schema`-capable one (e.g. the cheap
+`openrouter/deepseek-v4-flash` mirror), while a bare `json_object` request still
+serves on the `object` tier.
 
 ### Chain expansion
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-18 · json_schema 能力分级修复（capability tier；docs/02/04；原则 2/3/4）
+
+- **背景（线上事故）**：`helm_live_KOGN` 的 Codex 请求（Responses API，`text.format={type:json_schema,strict:true}`，rollout 压缩）落 `json` lane 主候选官方 `deepseek/deepseek-v4-flash`，上游 400 `"This response_format type is unavailable now"`（809ms + 一次熔断失败记账），再兜底 gpt-5.5 成功。SSH box `sqlite3 helm.db` 取 `telemetry.decision_json`+`request_payloads` 实证。
+- **根因**：单布尔 `supportsJsonMode` 把两个不同上游能力压成一个——基础 JSON 模式（`json_object`）与严格结构化输出（`json_schema`）。官方 DeepSeek 支持前者不支持后者（严格 schema 仅走 beta 的 strict tool calling），布尔无法表达"会 object 不会 schema"→ 能力过滤放行 → 必 400。`sync-catalog` 还把 LiteLLM 的 `supports_response_schema`（其实是 schema 标志）填进这个布尔，语义全程错位；`economy`/`balanced` 里的官方 deepseek 同坑。
+- **方案抉择**：用户要求根治并问"能否合并/互译"。研究确认（DeepSeek docs + LiteLLM）`json_schema⊋json_object` 是**有序档位**非二元，且 `openrouter/deepseek-v4-flash` **原生支持 structured outputs 且便宜**。故**不做 json_schema→tool 互译**（触 principle 8 流式头号风险、需 beta 端点、且请求带真实 tools 时与强制输出 tool 冲突，无论如何仍需能力路由兜底），改为：诚实建模 + 能力过滤把 json_schema 确定性落到便宜的原生 schema 后端。
+- **实现**：① `supportsJsonMode: boolean` → `jsonOutput: z.enum(["none","object","schema"])`（有序，必填；override 仍 `.partial()`）。② filter 拆两门：`needsJson && jsonOutput==="none"`→`no_json_support`；`needsResponseSchema && jsonOutput!=="schema"`→新 skip reason `no_response_schema_support`。③ `execute.ts` 新 `isJsonSchema()` 喂 `needsResponseSchema`（`needsJson` 不变）。④ `sync-catalog`：`supports_response_schema ? "schema" : "none"`（重生成 catalog.json，diff 仅字段名）。⑤ `capabilities.yaml`：官方 deepseek=object、openrouter-deepseek/gpt/gemini/claude=schema、`*/auto`=none。⑥ `json` lane 在 balanced 前插 `openrouter/deepseek-v4-flash`（json_schema 落点）；policy/classifier **不改**（filter 已逐请求区分，`skip_reason` 即观测面）。
+- **取舍/坑/TODO**：① 必填枚举让 typecheck 把每个漏改 fixture 标红（完整性网，~15 处）；② `none` 默认与旧"非 schema 即不可 JSON"行为等价 → 零回归；③ **明确弃做**：json_schema→forced-tool 互译；`anthropic/*` OAuth alias 仍无 catalog 条目（fail-open，json_schema 下安全因 Anthropic 原生 output_format）；classifier `needs_response_schema`。**TODO（部署验证）**：带 `OPENROUTER_API_KEY` 发真实 strict json_schema，确认落 openrouter-deepseek 且上游真 enforce schema（若被子 provider 忽略 → 注入 `provider:{require_parameters:true}`）。
+- **Codex review P2 修复（fail-closed override）**：`CapabilitiesOverrideEntrySchema` 由 `.partial()` 改 `.partial().strict()`（对齐已 strict 的 PricingOverrideEntrySchema）。否则 operator 的 `capabilities.yaml` 里残留的旧 `supportsJsonMode` key 会被 Zod 静默剥掉 → 手动配 JSON-capable 的纯 override alias 退化成 `jsonOutput:"none"`，请求静默跳过该模型。**不做自动翻译**（旧布尔 object/schema 语义本就模糊，正是本次修的 bug）→ 强制 fail-closed，operator 改 key。**⚠️ 部署连带**：box 的 `capabilities.yaml`（operator-owned）目前仍是 `supportsJsonMode`，新镜像上线会**拒绝启动**直到把 ~15 个条目改成 `jsonOutput`（见 [[config-schema-strict-removal-failclose]]）；canary loadConfig 会先抓到。
+- **验证**：TDD 红→绿。filter 判别矩阵（json_schema 对 object 层→`no_response_schema_support`，即线上 bug 回归）、`execute.default-config`（真实配置：json_schema 落 openrouter-deepseek、json_object 留官方 deepseek）、`samples` 锁 json lane 链、`sync-catalog` jsonOutput 断言、`load.test` 旧 `supportsJsonMode` key fail-closed。`pnpm typecheck`/`lint`(475)/`build`(admin+core+gateway) 绿；全量 core+gateway **3233 绿**。分支 `fix-json-schema-capability-tier`，未发版/未部署。
+
 ## 2026-06-17 · /admin/lanes 加 reasoning_effort 下拉（admin UI；原则 1）
 
 - **背景**：lane 级强制 reasoning_effort 此前只能改 YAML；用户要在 `/admin/lanes` 页面用下拉选。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/capability/filter.test.ts
+++ b/packages/core/src/capability/filter.test.ts
@@ -9,7 +9,7 @@ type Caps = CatalogEntry["capabilities"];
 function caps(overrides: Partial<Caps> = {}): Caps {
   return {
     supportsTools: true,
-    supportsJsonMode: true,
+    jsonOutput: "schema",
     supportsVision: true,
     supportsStreaming: true,
     maxContextTokens: 100_000,
@@ -24,6 +24,7 @@ function req(overrides: Partial<CapabilityRequest> = {}): CapabilityRequest {
   return {
     needsTools: false,
     needsJson: false,
+    needsResponseSchema: false,
     needsVision: false,
     needsStreaming: false,
     estimatedPromptTokens: 0,
@@ -43,13 +44,44 @@ describe("checkCapability", () => {
     expect(result).toEqual({ ok: true, skipReason: null });
   });
 
-  it("skips with no_json_support when strict JSON is required but unsupported", () => {
-    const result = checkCapability(caps({ supportsJsonMode: false }), req({ needsJson: true }));
+  it("skips with no_json_support when JSON is required but the tier is none", () => {
+    const result = checkCapability(caps({ jsonOutput: "none" }), req({ needsJson: true }));
     expect(result).toEqual({ ok: false, skipReason: "no_json_support" });
   });
 
-  it("passes the json gate when the candidate supports JSON mode", () => {
-    const result = checkCapability(caps({ supportsJsonMode: true }), req({ needsJson: true }));
+  it("passes the json gate for a json_object request on the object tier", () => {
+    const result = checkCapability(caps({ jsonOutput: "object" }), req({ needsJson: true }));
+    expect(result).toEqual({ ok: true, skipReason: null });
+  });
+
+  it("passes the json gate for a json_object request on the schema tier", () => {
+    const result = checkCapability(caps({ jsonOutput: "schema" }), req({ needsJson: true }));
+    expect(result).toEqual({ ok: true, skipReason: null });
+  });
+
+  // The prod-bug regression: a strict json_schema request must PRUNE a json_object-only
+  // backend (official DeepSeek) with the SPECIFIC reason, not burn an attempt on a 400.
+  it("prunes an object-tier candidate for a json_schema request (no_response_schema_support)", () => {
+    const result = checkCapability(
+      caps({ jsonOutput: "object" }),
+      req({ needsJson: true, needsResponseSchema: true }),
+    );
+    expect(result).toEqual({ ok: false, skipReason: "no_response_schema_support" });
+  });
+
+  it("prunes a none-tier candidate for a json_schema request with no_json_support (gate ordering)", () => {
+    const result = checkCapability(
+      caps({ jsonOutput: "none" }),
+      req({ needsJson: true, needsResponseSchema: true }),
+    );
+    expect(result).toEqual({ ok: false, skipReason: "no_json_support" });
+  });
+
+  it("passes a schema-tier candidate for a json_schema request", () => {
+    const result = checkCapability(
+      caps({ jsonOutput: "schema" }),
+      req({ needsJson: true, needsResponseSchema: true }),
+    );
     expect(result).toEqual({ ok: true, skipReason: null });
   });
 
@@ -60,7 +92,7 @@ describe("checkCapability", () => {
 
   it("returns no_vision_support for json+vision when json passes but vision fails", () => {
     const result = checkCapability(
-      caps({ supportsJsonMode: true, supportsVision: false }),
+      caps({ jsonOutput: "schema", supportsVision: false }),
       req({ needsJson: true, needsVision: true }),
     );
     expect(result).toEqual({ ok: false, skipReason: "no_vision_support" });
@@ -68,7 +100,7 @@ describe("checkCapability", () => {
 
   it("passes when both json and vision are supported and required", () => {
     const result = checkCapability(
-      caps({ supportsJsonMode: true, supportsVision: true }),
+      caps({ jsonOutput: "schema", supportsVision: true }),
       req({ needsJson: true, needsVision: true }),
     );
     expect(result).toEqual({ ok: true, skipReason: null });
@@ -216,7 +248,7 @@ describe("checkCapability", () => {
 
   it("short-circuits on the first failing gate (tools before json)", () => {
     const result = checkCapability(
-      caps({ supportsTools: false, supportsJsonMode: false }),
+      caps({ supportsTools: false, jsonOutput: "none" }),
       req({ needsTools: true, needsJson: true }),
     );
     expect(result).toEqual({ ok: false, skipReason: "no_tool_support" });

--- a/packages/core/src/capability/filter.ts
+++ b/packages/core/src/capability/filter.ts
@@ -19,7 +19,8 @@ import type { CatalogEntry } from "@helm/shared";
 // reason means updating this enum AND the UI; never slip in a free-form string.
 export type SkipReason =
   | "no_tool_support" // request carries tools, candidate has no tool-call
-  | "no_json_support" // request needs strict JSON, candidate has no JSON mode
+  | "no_json_support" // request needs JSON output, candidate has no JSON mode (jsonOutput:none)
+  | "no_response_schema_support" // request needs strict json_schema, candidate only does json_object (jsonOutput:object)
   | "no_vision_support" // request has images/attachments, candidate is text-only
   | "no_audio_support" // request carries audio input, candidate advertises no audio modality
   | "no_video_support" // request carries video input, candidate advertises no video modality
@@ -31,7 +32,8 @@ export type SkipReason =
 
 export interface CapabilityRequest {
   needsTools: boolean;
-  needsJson: boolean; // response_format = JSON / lane.require_json
+  needsJson: boolean; // response_format is json_object OR json_schema
+  needsResponseSchema: boolean; // response_format.type === "json_schema" (strict structured output)
   needsVision: boolean; // has attachments / images
   needsStreaming: boolean; // request.stream === true
   needsCachedContent?: boolean; // Gemini/LiteLLM cachedContent reference is hard context
@@ -66,9 +68,16 @@ export function checkCapability(
   if (req.needsTools && !caps.supportsTools) {
     return skip("no_tool_support");
   }
-  // 2. strict JSON
-  if (req.needsJson && !caps.supportsJsonMode) {
+  // 2. JSON output. The tier is ordered none < object < schema:
+  //   2a. any JSON request needs at least json_object — a `none` candidate is pruned.
+  //   2b. a strict json_schema request additionally needs the `schema` tier — an
+  //       `object`-only candidate (official DeepSeek) is pruned with the SPECIFIC reason
+  //       so it never burns an attempt on a guaranteed upstream 400.
+  if (req.needsJson && caps.jsonOutput === "none") {
     return skip("no_json_support");
+  }
+  if (req.needsResponseSchema && caps.jsonOutput !== "schema") {
+    return skip("no_response_schema_support");
   }
   // 3. vision
   if (req.needsVision && !caps.supportsVision) {

--- a/packages/core/src/catalog/cost.test.ts
+++ b/packages/core/src/catalog/cost.test.ts
@@ -280,7 +280,7 @@ describe("resolveCompactionPricing — compaction inputs from the catalog", () =
     modelKey: "anthropic/claude-3-5-sonnet",
     capabilities: {
       supportsTools: true,
-      supportsJsonMode: false,
+      jsonOutput: "none",
       supportsVision: true,
       supportsStreaming: true,
       maxContextTokens: 200_000,

--- a/packages/core/src/catalog/generated/catalog.json
+++ b/packages/core/src/catalog/generated/catalog.json
@@ -1,12 +1,12 @@
 {
-  "generatedAt": "2026-06-07T09:06:08.020Z",
+  "generatedAt": "2026-06-18T02:22:42.562Z",
   "source": "litellm:model_prices_and_context_window.json",
   "models": [
     {
       "modelKey": "claude-3-5-haiku-20241022",
       "capabilities": {
         "supportsTools": true,
-        "supportsJsonMode": false,
+        "jsonOutput": "none",
         "supportsVision": false,
         "supportsStreaming": true,
         "maxContextTokens": 200000,
@@ -23,7 +23,7 @@
       "modelKey": "claude-3-5-sonnet-20241022",
       "capabilities": {
         "supportsTools": true,
-        "supportsJsonMode": false,
+        "jsonOutput": "none",
         "supportsVision": true,
         "supportsStreaming": true,
         "maxContextTokens": 200000,
@@ -40,7 +40,7 @@
       "modelKey": "gemini-1.5-pro",
       "capabilities": {
         "supportsTools": true,
-        "supportsJsonMode": false,
+        "jsonOutput": "none",
         "supportsVision": true,
         "supportsStreaming": true,
         "maxContextTokens": 2097152,
@@ -57,7 +57,7 @@
       "modelKey": "gpt-4o",
       "capabilities": {
         "supportsTools": true,
-        "supportsJsonMode": true,
+        "jsonOutput": "schema",
         "supportsVision": true,
         "supportsStreaming": true,
         "maxContextTokens": 128000,
@@ -74,7 +74,7 @@
       "modelKey": "gpt-4o-mini",
       "capabilities": {
         "supportsTools": true,
-        "supportsJsonMode": true,
+        "jsonOutput": "schema",
         "supportsVision": true,
         "supportsStreaming": true,
         "maxContextTokens": 128000,

--- a/packages/core/src/catalog/index.test.ts
+++ b/packages/core/src/catalog/index.test.ts
@@ -12,7 +12,7 @@ const generated: GeneratedCatalog = {
       modelKey: "openai/gpt-4o",
       capabilities: {
         supportsTools: true,
-        supportsJsonMode: true,
+        jsonOutput: "schema",
         supportsVision: false,
         supportsStreaming: true,
         maxContextTokens: 128_000,

--- a/packages/core/src/catalog/index.ts
+++ b/packages/core/src/catalog/index.ts
@@ -14,7 +14,7 @@ import type { z } from "zod";
 // 3 (pricing) can't drift apart and leave a required field undefined.
 const EMPTY_CAPABILITIES: Capabilities = {
   supportsTools: false,
-  supportsJsonMode: false,
+  jsonOutput: "none",
   supportsVision: false,
   supportsStreaming: false,
   maxContextTokens: 0,

--- a/packages/core/src/catalog/load.test.ts
+++ b/packages/core/src/catalog/load.test.ts
@@ -67,7 +67,7 @@ describe("loadRuntimeCatalog", () => {
           return [
             '"local/llama-3.1-70b":',
             "  supportsTools: true",
-            "  supportsJsonMode: false",
+            "  jsonOutput: none",
             "  supportsVision: false",
             "  supportsStreaming: true",
             "  maxContextTokens: 131072",
@@ -103,6 +103,24 @@ describe("loadRuntimeCatalog", () => {
           if (p.endsWith("capabilities.yaml")) {
             // supportsTools must be a boolean → schema rejects.
             return '"x/y":\n  supportsTools: "yes"\n';
+          }
+          enoent();
+        }),
+      }),
+    ).toThrow(CatalogError);
+  });
+
+  it("fails CLOSED on a stale `supportsJsonMode` override key (jsonOutput migration)", () => {
+    // The capability boolean was replaced by the `jsonOutput` tier. A `.strict()`
+    // override schema must REJECT a leftover `supportsJsonMode` rather than silently
+    // strip it (which would degrade a manually-JSON-capable alias to jsonOutput:"none"
+    // and skip it for JSON requests). Fail-closed → operator migrates the key.
+    expect(() =>
+      loadRuntimeCatalog({
+        configDir: "/cfg",
+        readFile: reader((p) => {
+          if (p.endsWith("capabilities.yaml")) {
+            return '"deepseek/deepseek-v4-flash":\n  supportsJsonMode: true\n';
           }
           enoent();
         }),

--- a/packages/core/src/catalog/models-list.test.ts
+++ b/packages/core/src/catalog/models-list.test.ts
@@ -16,7 +16,7 @@ function entry(modelKey: string, over: Partial<CatalogEntry["capabilities"]> = {
     modelKey,
     capabilities: {
       supportsTools: true,
-      supportsJsonMode: true,
+      jsonOutput: "schema",
       supportsVision: false,
       supportsStreaming: true,
       maxContextTokens: 128_000,

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -63,6 +63,11 @@ describe("checked-in config samples", () => {
     // task lanes
     expect(lanes.coding?.fallback).toEqual(["premium", "balanced"]);
     expect(lanes.json?.constraints.require_json).toBe(true);
+    // json lane: official deepseek (cheap json_object) → cheap native-schema openrouter
+    // mirror (where a strict json_schema request lands after the filter prunes official
+    // deepseek) → balanced. Locks the json_schema routing fix into the shipped config.
+    expect(lanes.json?.primary).toBe("deepseek/deepseek-v4-flash");
+    expect(lanes.json?.fallback).toEqual(["openrouter/deepseek-v4-flash", "balanced"]);
     expect(lanes.vision?.constraints.require_vision).toBe(true);
     expect(lanes.tool_use?.constraints.require_tools).toBe(true);
   });

--- a/packages/shared/src/catalog/schema.ts
+++ b/packages/shared/src/catalog/schema.ts
@@ -18,7 +18,17 @@ export type InputModality = z.infer<typeof InputModalitySchema>;
 
 export const CapabilitiesSchema = z.object({
   supportsTools: z.boolean(),
-  supportsJsonMode: z.boolean(),
+  // JSON-output capability as an ORDERED tier (none < object < schema), NOT a boolean:
+  //   none   — no JSON mode at all (e.g. `*/auto` aggregators; pruned for any JSON request).
+  //   object — `response_format:{type:"json_object"}` only (official DeepSeek: json_object
+  //            yes, json_schema 400s "This response_format type is unavailable now").
+  //   schema — native strict structured output (`response_format:{type:"json_schema"}` /
+  //            Anthropic output_format / Gemini responseSchema). Implies `object`.
+  // A boolean cannot express "object but not schema"; that conflation routed a strict
+  // json_schema request onto json_object-only DeepSeek → guaranteed upstream 400. Synced
+  // from LiteLLM's `supports_response_schema` (schema|none); the `object` tier is set via
+  // manual capabilities.yaml overrides.
+  jsonOutput: z.enum(["none", "object", "schema"]),
   supportsVision: z.boolean(),
   supportsStreaming: z.boolean(),
   // Extra input modalities (besides text+image) the backend accepts. See above.
@@ -75,7 +85,15 @@ export const GeneratedCatalogSchema = z.object({
 // Override files (capabilities.yaml / pricing.yaml). Both are maps keyed by
 // modelKey. Every field is optional so a manual entry can override a single
 // field (e.g. just supportsVision) without restating the whole record.
-export const CapabilitiesOverrideEntrySchema = CapabilitiesSchema.partial();
+// `.strict()` (matching PricingOverrideEntrySchema below) makes an UNKNOWN key
+// FAIL-CLOSED (principle 2) instead of being silently stripped. Critical for the
+// `supportsJsonMode` → `jsonOutput` tier migration: a stale `supportsJsonMode`
+// left in an operator's capabilities.yaml would otherwise be dropped by `.partial()`,
+// degrading a manually-JSON-capable alias to `jsonOutput:"none"` so its requests
+// silently skip the model. Refuse to boot instead — the operator migrates the key
+// to `jsonOutput: none|object|schema` (no safe auto-translation: the old boolean
+// conflated object vs schema, which is exactly the bug this migration fixes).
+export const CapabilitiesOverrideEntrySchema = CapabilitiesSchema.partial().strict();
 // NOT `PricingSchema.partial()`: the cache fields carry `.default(null)`, and
 // `.partial()` over a defaulted field still MATERIALIZES the omitted key as null
 // on parse — so an operator overriding only `inputPerMTokUsd` would silently wipe

--- a/scripts/sync-catalog.test.ts
+++ b/scripts/sync-catalog.test.ts
@@ -73,6 +73,9 @@ describe("syncCatalog", () => {
     expect(gpt?.capabilities.maxOutputTokens).toBe(16384);
     expect(gpt?.capabilities.supportsTools).toBe(true);
     expect(gpt?.capabilities.supportsVision).toBe(true);
+    // supports_response_schema:true → schema tier; absent → none (the json_object-only
+    // tier is set only via manual capabilities.yaml overrides, never from upstream).
+    expect(gpt?.capabilities.jsonOutput).toBe("schema");
     // per-token → per-MTok USD
     expect(gpt?.pricing.inputPerMTokUsd).toBeCloseTo(2.5, 6);
     expect(gpt?.pricing.outputPerMTokUsd).toBeCloseTo(10, 6);
@@ -89,6 +92,8 @@ describe("syncCatalog", () => {
     const deepseek = byKey.get("deepseek-chat");
     expect(deepseek?.pricing.cacheReadPerMTokUsd).toBeCloseTo(0.07, 6);
     expect(deepseek?.pricing.cacheWritePerMTokUsd).toBeNull();
+    // No supports_response_schema flag upstream → none (not silently json-capable).
+    expect(deepseek?.capabilities.jsonOutput).toBe("none");
   });
 
   it("emits models in stable sorted key order (deterministic artifact)", async () => {

--- a/scripts/sync-catalog.ts
+++ b/scripts/sync-catalog.ts
@@ -54,7 +54,10 @@ function normalizeEntry(
     modelKey,
     capabilities: {
       supportsTools: info.supports_function_calling === true,
-      supportsJsonMode: info.supports_response_schema === true,
+      // LiteLLM's `supports_response_schema` IS the strict json_schema flag — map it to
+      // the `schema` tier; absence means no JSON mode at all (`none`). LiteLLM exposes no
+      // json_object-only signal, so the `object` tier comes only from manual overrides.
+      jsonOutput: info.supports_response_schema === true ? "schema" : "none",
       supportsVision: info.supports_vision === true,
       // Chat/completion modes stream; embeddings etc. do not.
       supportsStreaming: info.mode === undefined || info.mode === "chat",


### PR DESCRIPTION
## Problem (prod incident)

A Codex request (Responses API, `text.format = {type:"json_schema", strict:true}`, rollout compaction) hit the `json` lane's primary `deepseek/deepseek-v4-flash`. Official DeepSeek supports `response_format: json_object` but **not** `json_schema`, so it returned HTTP 400 `"This response_format type is unavailable now"` — wasting ~809ms + a circuit-breaker failure before falling back to gpt-5.5. Confirmed via prod telemetry (`telemetry.decision_json` + `request_payloads`).

**Root cause:** the single `supportsJsonMode` boolean conflated two distinct upstream capabilities — basic JSON mode (`json_object`) and strict structured output (`json_schema`). It was even sourced from LiteLLM's `supports_response_schema` (the json_schema flag) yet used for both, so a json_object-only backend could not be expressed and was never pruned. `economy`/`balanced` carry the same trap.

## Fix (root, no json_schema→tool translation)

Model JSON output as an **ordered tier** `jsonOutput: none | object | schema` (replaces the boolean):

- **filter** splits the JSON gate: `needsJson && jsonOutput==="none"` → `no_json_support`; new `needsResponseSchema && jsonOutput!=="schema"` → new skip reason `no_response_schema_support`. A strict json_schema request now prunes object-only DeepSeek deterministically.
- **lane**: `json` lane gains `openrouter/deepseek-v4-flash` (cheap, native structured outputs) before `balanced`, so json_schema lands cheaply; json_object still serves on official DeepSeek.
- **catalog**: `sync-catalog` maps `supports_response_schema → schema|none`; `capabilities.yaml` sets official deepseek=`object`, openrouter-deepseek/gpt/gemini/claude=`schema`, `*/auto`=`none`.
- **fail-closed override** (Codex review P2): `CapabilitiesOverrideEntrySchema` is now `.strict()` (matching the pricing override) so a stale `supportsJsonMode` key refuses to boot instead of silently degrading a model to `jsonOutput:none`.

No json_schema→forced-tool translation (declined: touches the streaming #1-risk area, needs DeepSeek beta endpoint, conflicts when the request also carries real tools — and a cheap native-schema backend already exists).

## ⚠️ Operator-breaking config change

`supportsJsonMode` → `jsonOutput` is a breaking rename for `capabilities.yaml`. Deployments must migrate their override file to `jsonOutput: none|object|schema` or the new image **fails closed at boot** (by design — see the `.strict()` change). The shipped `config/capabilities.yaml` is already migrated.

## Tests / verification

- `filter.test.ts` discrimination matrix incl. the prod-bug regression (json_schema on object-tier → `no_response_schema_support`).
- `execute.default-config.test.ts` (real shipped config): json_schema → `openrouter/deepseek-v4-flash`; json_object → official deepseek.
- `samples.test.ts` locks the json lane chain; `sync-catalog.test.ts` asserts the tier mapping; `load.test.ts` asserts a stale `supportsJsonMode` key fails closed.
- `pnpm typecheck` / `lint` / `build` green; full core+gateway **3233 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)