### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Minor release bundling the work merged to `main` after v0.19.1.

## Included
- **#306** feat: optional Anthropic TLS transport — `transport_profile` provider field (default `auto`) routes Anthropic preset OAuth execution through the Chrome-like `wreq-js` TLS/JA3 transport; adds `HELM_TLS_BROWSER_PROFILE` / `HELM_TLS_OS_PROFILE` / `HELM_TLS_TRANSPORT_TIMEOUT_MS` env knobs. Verified: transport loads + works in the linux/amd64 image (wreq-js ships nested under `@helm/core`).
- **#305** fix: preserve strict tool map across auth retry
- **#304** fix: align strict Claude CLI tool wire shape

## Deploy notes
- Fail-close gate passes: `transport_profile` is additive-optional (`.default("auto")`); box config without the key boots fine.
- `providers.yaml` diff is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)