### PR TITLE
fix(gateway): probe Chrome-TLS transport at startup + v0.20.1

### DIFF
--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -16,6 +16,7 @@ import {
   type OAuthRuntimeCtx,
   resolveProviderTransportProfile,
   synthesizeOAuthProviders,
+  tlsTransportProviders,
 } from "./server.js";
 
 // Compose a validated shared ProviderConfig (so tests exercise the real schema
@@ -258,6 +259,29 @@ describe("buildProviderClients (issue #38 OAuth wiring)", () => {
     });
 
     expect(() => makeProviderFetch(unsupported)).toThrow(/Anthropic preset OAuth/);
+  });
+
+  it("tlsTransportProviders lists only the providers that resolve to tls_chrome", () => {
+    const anthropicAuto = provider({
+      name: "anthropic",
+      type: "anthropic",
+      base_url: "https://api.anthropic.com",
+      oauth: { provider: "anthropic", account: "default" },
+      models: [{ alias: "anthropic/opus", provider_model: "claude-opus" }],
+    });
+    const anthropicOptedOut = provider({
+      name: "anthropic-undici",
+      type: "anthropic",
+      base_url: "https://api.anthropic.com",
+      oauth: { provider: "anthropic", account: "default" },
+      transport_profile: "default",
+      models: [{ alias: "anthropic-undici/opus", provider_model: "claude-opus" }],
+    });
+
+    expect(
+      tlsTransportProviders([anthropicAuto, anthropicOptedOut, KEY_PROVIDER, OAUTH_PROVIDER]),
+    ).toEqual(["anthropic"]);
+    expect(tlsTransportProviders([KEY_PROVIDER, OAUTH_PROVIDER])).toEqual([]);
   });
 });
 

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -7,6 +7,7 @@ import {
   bootstrapRootKey,
   COPILOT_HEADERS,
   type ConfigStore,
+  checkTlsTransportAvailable,
   createAnthropicClient,
   createBudgetGate,
   createCachedKeyStore,
@@ -591,6 +592,15 @@ export function resolveProviderTransportProfile(p: ProviderConfigShared): Transp
   return isAnthropicPresetOAuth(p) ? "tls_chrome" : "default";
 }
 
+// Names of every provider that resolves to the Chrome-TLS transport (Anthropic
+// preset OAuth under transport_profile:auto, or an explicit tls_chrome). Used at
+// startup to probe the optional wreq-js native transport ONCE and warn loudly if
+// it cannot load — so the gap surfaces at deploy time, not silently on the first
+// Anthropic OAuth request (see checkTlsTransportAvailable / buildServer).
+export function tlsTransportProviders(cfgs: readonly ProviderConfigShared[]): string[] {
+  return cfgs.filter((p) => resolveProviderTransportProfile(p) === "tls_chrome").map((p) => p.name);
+}
+
 function optionalPositiveInt(raw: string | undefined): number | undefined {
   if (raw === undefined || raw.trim() === "") return undefined;
   const n = Number(raw);
@@ -906,6 +916,31 @@ export async function buildServer(
   const accountSettings: AccountSettingsMap = oauthCtx
     ? await loadAccountSettings(store.config, oauthCtx.encKey)
     : {};
+
+  // Chrome-TLS transport startup probe (#306). Any provider on transport_profile
+  // tls_chrome (Anthropic preset OAuth under `auto`, or explicit) executes through
+  // the OPTIONAL wreq-js native transport. If that binary cannot load, the first
+  // Anthropic request would throw TlsTransportUnavailableError — counted as a
+  // provider failure that trips the breaker and silently degrades to the lane
+  // fallback chain. Probe it ONCE here so the gap is loud at deploy time. Non-fatal
+  // (principle 3): the gateway still starts; the operator can set
+  // transport_profile:default to force the proven undici path.
+  const tlsProviders = tlsTransportProviders(config.providers);
+  if (tlsProviders.length > 0) {
+    const probe = await checkTlsTransportAvailable({
+      browser: process.env.HELM_TLS_BROWSER_PROFILE,
+      os: process.env.HELM_TLS_OS_PROFILE,
+    });
+    if (probe.ok) {
+      logger.log("info", "tls_transport.ready", { providers: tlsProviders });
+    } else {
+      logger.log("warn", "tls_transport.unavailable", {
+        providers: tlsProviders,
+        error: probe.error,
+        hint: "Anthropic OAuth execution will fail over to the lane fallback chain; set transport_profile:default on these providers to force undici, or install a wreq-js build for this platform",
+      });
+    }
+  }
 
   // Runtime-mutable settings (admin "System Settings"): persisted overrides for
   // the operator-facing subset that can change WITHOUT a restart (capture_payloads,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -533,9 +533,11 @@ export {
 } from "./provider/registry.js";
 export {
   __setWreqModuleForTesting,
+  checkTlsTransportAvailable,
   makeTlsImpersonationFetch,
   proxyConfigToUrl,
   type TlsImpersonationFetchOptions,
+  type TlsTransportProbeResult,
   TlsTransportUnavailableError,
   type TransportProfile,
 } from "./provider/tls-transport.js";

--- a/packages/core/src/provider/tls-transport.test.ts
+++ b/packages/core/src/provider/tls-transport.test.ts
@@ -3,6 +3,7 @@ import type { ProxyConfig } from "./proxy.js";
 import { isTransientConnectionError } from "./retry.js";
 import {
   __setWreqModuleForTesting,
+  checkTlsTransportAvailable,
   makeTlsImpersonationFetch,
   proxyConfigToUrl,
   TlsTransportUnavailableError,
@@ -187,5 +188,45 @@ describe("makeTlsImpersonationFetch", () => {
     await expect(tlsFetch("https://api.anthropic.com/v1/messages")).rejects.toBeInstanceOf(
       TlsTransportUnavailableError,
     );
+  });
+});
+
+describe("checkTlsTransportAvailable", () => {
+  it("reports ok when wreq-js loads and a transport can be created + closed", async () => {
+    const close = vi.fn(async () => {});
+    const createTransport = vi.fn(async () => ({ close }));
+    __setWreqModuleForTesting({
+      createTransport,
+      fetch: async () => new Response("ok"),
+    });
+
+    const result = await checkTlsTransportAvailable({ browser: "chrome_142", os: "linux" });
+
+    expect(result).toEqual({ ok: true });
+    expect(createTransport).toHaveBeenCalledWith({ browser: "chrome_142", os: "linux" });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("reports not-ok when the optional native package is absent", async () => {
+    __setWreqModuleForTesting(null);
+
+    const result = await checkTlsTransportAvailable();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/wreq-js/);
+  });
+
+  it("reports not-ok with the failure reason when createTransport throws", async () => {
+    __setWreqModuleForTesting({
+      createTransport: async () => {
+        throw new Error("native binary load failed");
+      },
+      fetch: async () => new Response("ok"),
+    });
+
+    const result = await checkTlsTransportAvailable();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("native binary load failed");
   });
 });

--- a/packages/core/src/provider/tls-transport.ts
+++ b/packages/core/src/provider/tls-transport.ts
@@ -179,3 +179,38 @@ export function makeTlsImpersonationFetch(
     }
   }) as typeof globalThis.fetch;
 }
+
+export interface TlsTransportProbeResult {
+  /** True when wreq-js loaded AND a throwaway transport could be created + closed. */
+  ok: boolean;
+  /** Human-readable reason when `ok` is false (module missing, native load failure, …). */
+  error?: string;
+}
+
+/**
+ * Startup probe for the optional Chrome-TLS transport. Loads wreq-js and creates
+ * (then closes) a throwaway transport so a missing/incompatible native binary
+ * surfaces at BOOT — not silently on the first Anthropic OAuth request, where the
+ * thrown {@link TlsTransportUnavailableError} would count as a provider failure,
+ * trip the circuit breaker, and degrade the request to the lane fallback chain.
+ * The impersonated `browser`/`os` do not select the native binary (that is picked
+ * from the runtime platform), so any value exercises the same load path.
+ */
+export async function checkTlsTransportAvailable(
+  options: Pick<TlsImpersonationFetchOptions, "browser" | "os"> = {},
+): Promise<TlsTransportProbeResult> {
+  const mod = await loadWreqModule();
+  if (!mod) {
+    return { ok: false, error: "wreq-js native transport is not loadable on this platform" };
+  }
+  try {
+    const transport = await mod.createTransport({
+      browser: options.browser ?? "chrome_142",
+      os: options.os ?? "macos",
+    });
+    await transport.close();
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}


### PR DESCRIPTION
## Why
`transport_profile: auto` (the default for Anthropic preset OAuth, shipped in v0.20.0/#306) routes execution through the **optional** `wreq-js` Chrome-TLS transport. If that native binary can't load on the host, the first Anthropic OAuth request throws `TlsTransportUnavailableError` → counted as a provider failure → circuit breaker opens → request silently degrades to the lane fallback chain. The failure was invisible until request time.

## What
- **core** `checkTlsTransportAvailable()` — loads `wreq-js` + creates/closes a throwaway transport, returns `{ok, error?}`.
- **gateway** `tlsTransportProviders()` + a one-shot startup probe in `buildServer`: logs `tls_transport.ready` on success, or a loud `tls_transport.unavailable` warning (providers + error + remediation hint) on failure.
- **Non-fatal** (principle 3): gateway still serves; operators can set `transport_profile: default` to force undici.

## Tests
- `checkTlsTransportAvailable`: ok / module-absent / createTransport-throws.
- `tlsTransportProviders`: lists only `tls_chrome` providers.
- Full suite green (272 files / 3960 tests), typecheck + lint clean.

Patch release → v0.20.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)