### PR TITLE
fix(gateway): probe TLS transport over routable providers (incl. synthesized OAuth) + v0.20.2

### DIFF
--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -917,31 +917,6 @@ export async function buildServer(
     ? await loadAccountSettings(store.config, oauthCtx.encKey)
     : {};
 
-  // Chrome-TLS transport startup probe (#306). Any provider on transport_profile
-  // tls_chrome (Anthropic preset OAuth under `auto`, or explicit) executes through
-  // the OPTIONAL wreq-js native transport. If that binary cannot load, the first
-  // Anthropic request would throw TlsTransportUnavailableError — counted as a
-  // provider failure that trips the breaker and silently degrades to the lane
-  // fallback chain. Probe it ONCE here so the gap is loud at deploy time. Non-fatal
-  // (principle 3): the gateway still starts; the operator can set
-  // transport_profile:default to force the proven undici path.
-  const tlsProviders = tlsTransportProviders(config.providers);
-  if (tlsProviders.length > 0) {
-    const probe = await checkTlsTransportAvailable({
-      browser: process.env.HELM_TLS_BROWSER_PROFILE,
-      os: process.env.HELM_TLS_OS_PROFILE,
-    });
-    if (probe.ok) {
-      logger.log("info", "tls_transport.ready", { providers: tlsProviders });
-    } else {
-      logger.log("warn", "tls_transport.unavailable", {
-        providers: tlsProviders,
-        error: probe.error,
-        hint: "Anthropic OAuth execution will fail over to the lane fallback chain; set transport_profile:default on these providers to force undici, or install a wreq-js build for this platform",
-      });
-    }
-  }
-
   // Runtime-mutable settings (admin "System Settings"): persisted overrides for
   // the operator-facing subset that can change WITHOUT a restart (capture_payloads,
   // payload_retention_days, rate_limit_enabled, log_level). Loaded from the
@@ -1208,6 +1183,33 @@ export async function buildServer(
     ...config.providers,
     ...synthesizedOAuth.providers,
   ];
+
+  // Chrome-TLS transport startup probe (#306). Any routable provider on
+  // transport_profile:tls_chrome (Anthropic preset OAuth under the `auto` default,
+  // or explicit) executes through the OPTIONAL wreq-js native transport — and the
+  // ones that matter here are usually the SYNTHESIZED OAuth pool providers, not
+  // config.providers, so probe the full routable set. If the native binary cannot
+  // load, the first Anthropic request throws TlsTransportUnavailableError — counted
+  // as a provider failure that trips the breaker and silently degrades to the lane
+  // fallback chain. Probe ONCE so the gap is loud at deploy time. Non-fatal
+  // (principle 3): the gateway still serves; operators can set
+  // transport_profile:default to force the proven undici path.
+  const tlsProviders = tlsTransportProviders(routableProviders);
+  if (tlsProviders.length > 0) {
+    const probe = await checkTlsTransportAvailable({
+      browser: process.env.HELM_TLS_BROWSER_PROFILE,
+      os: process.env.HELM_TLS_OS_PROFILE,
+    });
+    if (probe.ok) {
+      logger.log("info", "tls_transport.ready", { providers: tlsProviders });
+    } else {
+      logger.log("warn", "tls_transport.unavailable", {
+        providers: tlsProviders,
+        error: probe.error,
+        hint: "Anthropic OAuth execution will fail over to the lane fallback chain; set transport_profile:default on these providers to force undici, or install a wreq-js build for this platform",
+      });
+    }
+  }
 
   // The default/primary client (eval + passthrough + back-fill aliases), dispatched
   // by type (anthropic native vs OpenAI-compatible). When the primary is OAuth this

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Why
v0.20.1 added the Chrome-TLS startup probe but ran it over `config.providers` only. Anthropic preset OAuth providers are usually **synthesized at runtime** (`oauth.autoroute`), not in `config.providers` — so on an autoroute-only install (e.g. la.atmy.work) the probe found zero `tls_chrome` providers and silently skipped, never emitting `tls_transport.ready`. The probe was a no-op on exactly the setups that use the transport.

## Fix
Move the probe after `synthesizeOAuthProviders` and run `tlsTransportProviders` over `routableProviders` (`config.providers` + synthesized). The synthesized Anthropic OAuth pool executes through `buildOAuthAccountClient → createProviderClient → makeProviderFetch → tls_chrome`, so it must be in the probed set.

Verified: full suite green (272 files / 3960 tests), typecheck + lint clean. Patch → v0.20.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)