### PR TITLE
fix(gateway): hoist Codex Responses instructions on native passthrough

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -2628,11 +2628,19 @@ describe("createExecute — native protocol passthrough (#217)", () => {
 
     expect(out.final.status).toBe("ok");
     const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
-    expect(forwarded.body).toEqual({ model: "gpt-5-codex", input: "hi", store: false });
+    // The Codex backend mandates non-empty `instructions`; a string-input body with no
+    // system content gets the default injected alongside the store shim.
+    expect(forwarded.body).toEqual({
+      model: "gpt-5-codex",
+      input: "hi",
+      store: false,
+      instructions: "You are a helpful assistant.",
+    });
     expect(forwarded.raw_body).toBeUndefined();
     expect(forwarded.mutations).toMatchObject({
       model_rewritten: { from: "codex/gpt-5-codex", to: "gpt-5-codex" },
-      body_shims_applied: ["store_forced_false"],
+      // appendMutationList sorts the ledger → alphabetical order
+      body_shims_applied: ["instructions_defaulted", "store_forced_false"],
     });
     expect(out.attempts[0]?.passthrough_mutations).toMatchObject(forwarded.mutations);
   });
@@ -2689,6 +2697,124 @@ describe("createExecute — native protocol passthrough (#217)", () => {
       input: "hi",
       store: true,
       background: true,
+    });
+    expect((forwarded.mutations as Record<string, unknown>).body_shims_applied).toBeUndefined();
+  });
+
+  it("hoists a developer system item into Codex `instructions` on passthrough (pi-ai shape)", async () => {
+    const responsesBody = {
+      id: "resp_hoist",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["codex", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "codex",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body: {
+        model: "gpt-5.5",
+        input: [
+          { role: "developer", content: "You are Mimi, an AI employee at AgentCrew." },
+          { role: "user", content: "hi" },
+        ],
+        store: false,
+      },
+      headers: {},
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["r"]),
+      req({ protocol: "openai_responses", native_request: carrier }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body).toEqual({
+      model: "gpt-5.5",
+      instructions: "You are Mimi, an AI employee at AgentCrew.",
+      input: [{ role: "user", content: "hi" }],
+      store: false,
+    });
+    expect((forwarded.mutations as Record<string, unknown>).body_shims_applied).toEqual([
+      "instructions_hoisted_from_input",
+    ]);
+  });
+
+  it("leaves a Codex passthrough body verbatim when `instructions` is already present", async () => {
+    const responsesBody = {
+      id: "resp_verbatim",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["codex", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "codex",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body: {
+        model: "gpt-5.5",
+        instructions: "real codex base prompt",
+        input: [{ role: "user", content: "hi" }],
+        store: false,
+      },
+      headers: {},
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["r"]),
+      req({ protocol: "openai_responses", native_request: carrier }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body).toEqual({
+      model: "gpt-5.5",
+      instructions: "real codex base prompt",
+      input: [{ role: "user", content: "hi" }],
+      store: false,
     });
     expect((forwarded.mutations as Record<string, unknown>).body_shims_applied).toBeUndefined();
   });

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -11,6 +11,7 @@ import {
   applyForcedReasoningToNativeBody,
   canUseNativePassthrough,
   checkCapability,
+  hoistResponsesInstructions,
   type NativePassthroughDisableReason,
   openaiTransformer,
   resolveCostUsd,
@@ -525,6 +526,26 @@ function prepareNativeRequestForUpstream(
     if (mutations) {
       appendMutationList(mutations, "body_shims_applied", ["store_forced_false"]);
       mutations.provider_profile_applied = "codex_official_safe";
+    }
+  }
+
+  // The Codex backend MANDATES a non-empty top-level `instructions`. Standard-OpenAI
+  // Responses clients (pi-ai / pi-coding-agent) carry the system prompt as a leading
+  // developer/system item INSIDE `input` and omit `instructions`, so a verbatim forward
+  // 400s with "Instructions are required". Hoist that content into `instructions` (and
+  // strip it from `input`) so passthrough survives instead of burning a fallback hop.
+  if (needsCodexResponsesShim) {
+    const hoist = hoistResponsesInstructions(body);
+    if (hoist.fix !== "none") {
+      body = hoist.body;
+      bodyChanged = true;
+      if (mutations) {
+        appendMutationList(mutations, "body_shims_applied", [
+          hoist.fix === "hoisted_from_input"
+            ? "instructions_hoisted_from_input"
+            : "instructions_defaulted",
+        ]);
+      }
     }
   }
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-18 · Codex 原生直通缺失 instructions 修复（issue #217；docs/05；原则 1/4/8）
+
+- **背景**：线上请求 `09387e28-...`（pi-coding-agent / AgentCrew，经 `@earendil-works/pi-ai`）由 `/v1/responses` 入站，lane=coding 首选 `openai-codex/gpt-5.5`，`passthrough_used=true` 把正文逐字转发给 ChatGPT 订阅版 Codex 后端 → HTTP 400 `{"detail":"Instructions are required"}`，fail-open 回退 `claude-opus-4-8` 成功。SQLite 实证：入站正文 `input` 为数组、无 `messages`、**无顶层 `instructions`**，系统提示词其实是 `input[0]={role:"developer",content:"You are Mimi..."}`（pi-ai 设计：reasoning 模型用 developer、否则 system，塞进 input，故意不发 instructions——对真·OpenAI Responses 合法，但 Codex 订阅后端强制要 instructions）。
+- **根因**：两路不对称。翻译路 `buildInstructions` 无 system 时回退 `DEFAULT_INSTRUCTIONS`，永不空；**直通路逐字转发，无兜底**。`execute.ts` 的 compat-rewrite guard 只覆盖 `map_developer_role_to_system` 与 Anthropic system-fold，没有 Codex/responses 的 instructions guard。
+- **实现**：core 新增纯函数 `hoistResponsesInstructions(body)`（`openai-responses.ts`，复用 `plainText`/`DEFAULT_INSTRUCTIONS`，从 core index 导出）：已有非空 instructions → 原样返回（verbatim）；否则把 `input` 里 `system`/`developer` 项内容 hoist 进顶层 `instructions` 并从 `input` 摘除（与翻译路 buildInstructions/toResponsesInput 同义）；无 system 内容则注入 `DEFAULT_INSTRUCTIONS`。在 `execute.ts` `prepareNativeRequestForUpstream` 的 `needsCodexResponsesShim` 块（仅 `codex_responses` profile，generic responses 不触发）调用，记 `body_shims_applied` 的 `instructions_hoisted_from_input` / `instructions_defaulted`。**保留 passthrough**（prompt_cache_key / reasoning 加密内容 / SSE 字节转发不丢），优于强制走翻译路方案。
+- **取舍/坑**：选 hoist 而非"注入通用默认"——真实系统提示在 input 里，注入 "You are a helpful assistant." 会冗余/误导；hoist 还原真 Codex CLI 形状（instructions=系统提示、input=纯对话）。`appendMutationList` 对 `body_shims_applied` 会去重+排序，故 ledger 顺序是字母序（`instructions_*` 排在 `store_forced_false` 前）。客户端 pi-ai 是第三方 node_modules、未暴露 instructions 配置，改不动，且 helm 本职就是后端兼容（原则 6），故修在网关侧。
+- **验证**：core 8 个 hoist 单测 + gateway 2 个 execute 直通测试（hoist developer 形状、已有 instructions 保持 verbatim）+ 更新既有 store-shim 测试断言（现含 `instructions_defaulted`）。typecheck（3 项目）/ lint(478) / core+gateway 全量 **3264** 绿。分支 `fix-codex-passthrough-instructions-hoist`，未提交/未部署。
+
 ## 2026-06-18 · Anthropic OAuth TLS/JA3 transport spike（docs/05/10；原则 2/7/8）
 
 - **背景**：Claude CLI strict body/header/tool shape 已由 PR #304/#305 合并；剩余第三点是 OmniRoute 风格的 transport fingerprint（TLS ClientHello / JA3/JA4 / HTTP2 traits），不能靠当前 undici Agent/ProxyAgent 调参完成。
@@ -22,18 +30,13 @@
 - **取舍/坑/TODO**：strict pipeline 只作用于互译出站 Anthropic 请求；`nativePassthrough/nativePassthroughStream` 仍传 `includeClaudeCliRuntimeHeaders=false`，保持逐字直通，不做 body/tool 改写。TLS/JA3/transport fingerprint 属于单独 PR/spike，本次不碰 undici fetch/Agent/ProxyAgent。部署后用上述 request detail 重试同类 payload，看 wire shape 与上游结果是否符合预期。
 - **验证**：新增 golden fixture `packages/core/src/provider/fixtures/claude-cli-strict-tool.ts` 与 TDD 回归（非流式 wire shape + tool name restore、流式 restore、401 retry reverse-map）。`pnpm exec vitest run packages/core/src/provider/anthropic.test.ts -t "preserves the reverse map"` 红→绿；`pnpm exec vitest run packages/core/src/provider/anthropic.test.ts` 94 绿；`pnpm --filter @helm/core typecheck` 绿；`pnpm exec biome check packages/core/src/provider/anthropic.ts packages/core/src/provider/anthropic.test.ts` 绿。
 
-## 2026-06-18 · 请求详情页内部 code 人类可读化（admin i18n；原则 1）
-
-- **背景**：请求详情页的「供应商尝试」链 + 错误类型显示的是内部 snake_case code（`no_response_schema_support` / `circuit_open` / `client_abort` / `upstream_error` …），运维看不懂。
-- **实现**：新增 `apps/admin/src/lib/format/attempt-codes.ts` 的 `ATTEMPT_CODE_LABELS`（code→英文人话，**值即 i18n key**）+ `attemptCodeLabel()`（未知 code 回退裸 code，永不空白）。镜像 core 的 `SkipReason` 联合 + execute 的 error_class（admin 不 import core，原则 1）。渲染处 `DecisionChain.svelte`（outcome badge / error_class / skip_reason）、详情页 error type、列表 error_class 列改 `$t(attemptCodeLabel(code))`，并加 `title={原始code}` 悬浮保留调试用裸码。
-- **i18n**：26 个新 key（3 个如 Error/Success 已存在）加进 5 个 locale（en=自身，zh-hans/hant/ja/ko 手译）；用一次性 additive 合并脚本（保留既有字节、仅追加，避开 i18n:extract 会拉无关串的坑）。
-- **验证**：`attempt-codes.test.ts`（映射 + 回退 + 覆盖全 SkipReason）、`attempt-code-locales.test.ts`（4 非英 locale 每个 label 都翻译、非英文回退，镜像 dashboard-locales 模式）；admin 14 测绿、`svelte-check` 0/0、`biome lint`(475)、`build` 全绿。分支 `feat-readable-attempt-codes`，未提交/未部署。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-18 · 请求详情页内部 code 人类可读化（admin i18n；原则 1）：「供应商尝试」链 + 错误类型显示内部 snake_case code（no_response_schema_support/circuit_open/client_abort/upstream_error…）运维看不懂；新增 admin `attempt-codes.ts` 的 `ATTEMPT_CODE_LABELS`(code→英文人话=i18n key)+`attemptCodeLabel()`（未知回退裸 code），镜像 core SkipReason+error_class（admin 不 import core），渲染处改 `$t(attemptCodeLabel(code))` 并 `title` 留裸码；26 新 key×5 locale 手译、additive 合并；admin 14 测/svelte-check 0/build 绿。分支 feat-readable-attempt-codes，未部署。
 
 ### 2026-06-18 · json_schema 能力分级修复（capability tier；docs/02/04；原则 2/3/4）：把 `supportsJsonMode` 拆成有序 `jsonOutput:none|object|schema`，能力过滤区分 `json_object` 与 strict `json_schema`，json_schema 默认落 openrouter-deepseek；旧 `supportsJsonMode` override fail-closed，部署前需改 operator-owned capabilities。
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -504,7 +504,9 @@ export {
   createCodexResponsesClient,
   createGenericOpenAIResponsesClient,
   type GenericOpenAIResponsesClientDeps,
+  hoistResponsesInstructions,
   openaiToResponsesRequest,
+  type ResponsesInstructionsFix,
   translateResponsesSSE,
 } from "./provider/openai-responses.js";
 export {

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -5,6 +5,7 @@ import {
   codexAccountIdFromToken,
   createCodexResponsesClient,
   createGenericOpenAIResponsesClient,
+  hoistResponsesInstructions,
   openaiToResponsesRequest,
   readResponsesEvents,
   readResponsesSSERaw,
@@ -1877,5 +1878,113 @@ describe("createGenericOpenAIResponsesClient — native passthrough", () => {
         body: { model: "gpt-5.5", input: "count me" },
       },
     ]);
+  });
+});
+
+// hoistResponsesInstructions — the native-passthrough repair for the ChatGPT-account
+// Codex backend, which MANDATES a non-empty top-level `instructions`. Standard-OpenAI
+// Responses clients (e.g. pi-ai / pi-coding-agent) put the system prompt as a leading
+// `developer`/`system` item inside `input` and omit `instructions` — valid for the
+// public API but rejected by the Codex backend ("Instructions are required"). On the
+// verbatim passthrough path this pure shim hoists that content into `instructions` and
+// strips the hoisted items, mirroring the translate path's buildInstructions split.
+describe("hoistResponsesInstructions", () => {
+  it("hoists a leading developer item (pi-ai reasoning shape) into instructions and strips it", () => {
+    const { body, fix } = hoistResponsesInstructions({
+      model: "gpt-5.5",
+      input: [
+        { role: "developer", content: "You are Mimi, an AI employee at AgentCrew." },
+        { role: "user", content: "hi" },
+      ],
+      stream: true,
+    });
+    expect(fix).toBe("hoisted_from_input");
+    expect(body.instructions).toBe("You are Mimi, an AI employee at AgentCrew.");
+    expect(body.input).toEqual([{ role: "user", content: "hi" }]);
+    // top-level siblings preserved
+    expect(body.model).toBe("gpt-5.5");
+    expect(body.stream).toBe(true);
+  });
+
+  it("hoists a leading system item (non-reasoning shape) into instructions", () => {
+    const { body, fix } = hoistResponsesInstructions({
+      input: [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "q" },
+      ],
+    });
+    expect(fix).toBe("hoisted_from_input");
+    expect(body.instructions).toBe("You are helpful.");
+    expect(body.input).toEqual([{ role: "user", content: "q" }]);
+  });
+
+  it("joins multiple system/developer items with a blank line, in order", () => {
+    const { body, fix } = hoistResponsesInstructions({
+      input: [
+        { role: "system", content: "A" },
+        { role: "developer", content: "B" },
+        { role: "user", content: "q" },
+      ],
+    });
+    expect(fix).toBe("hoisted_from_input");
+    expect(body.instructions).toBe("A\n\nB");
+    expect(body.input).toEqual([{ role: "user", content: "q" }]);
+  });
+
+  it("extracts text from array (input_text) content", () => {
+    const { body, fix } = hoistResponsesInstructions({
+      input: [
+        { role: "developer", content: [{ type: "input_text", text: "SYS" }] },
+        { role: "user", content: "q" },
+      ],
+    });
+    expect(fix).toBe("hoisted_from_input");
+    expect(body.instructions).toBe("SYS");
+    expect(body.input).toEqual([{ role: "user", content: "q" }]);
+  });
+
+  it("leaves the body verbatim (same reference) when instructions is already present", () => {
+    const original = {
+      instructions: "real codex base prompt",
+      input: [{ role: "user", content: "hi" }],
+    };
+    const { body, fix } = hoistResponsesInstructions(original);
+    expect(fix).toBe("none");
+    expect(body).toBe(original);
+  });
+
+  it("treats whitespace-only instructions as empty and hoists", () => {
+    const { body, fix } = hoistResponsesInstructions({
+      instructions: "   ",
+      input: [
+        { role: "developer", content: "SYS" },
+        { role: "user", content: "q" },
+      ],
+    });
+    expect(fix).toBe("hoisted_from_input");
+    expect(body.instructions).toBe("SYS");
+  });
+
+  it("falls back to the default when instructions is absent and there is no system content", () => {
+    const { body, fix } = hoistResponsesInstructions({
+      input: [{ role: "user", content: "hi" }],
+    });
+    expect(fix).toBe("defaulted");
+    expect(body.instructions).toBe("You are a helpful assistant.");
+    // input is untouched in the defaulted branch
+    expect(body.input).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("does not mutate the input body (returns a new object on repair)", () => {
+    const original: Record<string, unknown> = {
+      input: [
+        { role: "developer", content: "SYS" },
+        { role: "user", content: "q" },
+      ],
+    };
+    const { body } = hoistResponsesInstructions(original);
+    expect(body).not.toBe(original);
+    expect("instructions" in original).toBe(false);
+    expect(original.input).toHaveLength(2);
   });
 });

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -157,6 +157,65 @@ function buildInstructions(messages: Array<Record<string, unknown>>): string {
   return joined || DEFAULT_INSTRUCTIONS;
 }
 
+export type ResponsesInstructionsFix = "none" | "hoisted_from_input" | "defaulted";
+
+// Native-passthrough repair for the ChatGPT-account Codex backend, which MANDATES a
+// non-empty top-level `instructions` (the real Codex CLI always sends its base prompt
+// there). Standard-OpenAI Responses clients (e.g. pi-ai / pi-coding-agent) are spec-
+// compliant the OTHER way: they omit `instructions` and put the system prompt as a
+// leading `developer`/`system` item INSIDE `input`. The public OpenAI API treats the
+// two as equivalent, but the Codex subscription backend rejects the input-only shape
+// with HTTP 400 `{"detail":"Instructions are required"}`.
+//
+// The TRANSLATE path never hits this (buildInstructions injects a value), but the
+// VERBATIM passthrough path forwards the client body as-is. This pure shim repairs the
+// body WITHOUT abandoning passthrough (so prompt_cache_key / reasoning.encrypted_content
+// / SSE byte-relay all survive): it HOISTS the system/developer item content into
+// `instructions` and STRIPS those items from `input` — the SAME system→instructions
+// split buildInstructions/toResponsesInput already perform on the translate path, so the
+// forwarded body matches the real Codex CLI shape (instructions = system prompt, input =
+// conversation only). When `instructions` is already non-empty the body is returned
+// VERBATIM (same reference). When there is no system content to hoist, DEFAULT_INSTRUCTIONS
+// guarantees the backend never sees an empty value. Pure + deterministic (CLAUDE.md
+// principle 4); never mutates the input body.
+export function hoistResponsesInstructions(body: Record<string, unknown>): {
+  body: Record<string, unknown>;
+  fix: ResponsesInstructionsFix;
+} {
+  // Already carries instructions → forward byte-for-byte (verbatim passthrough).
+  if (typeof body.instructions === "string" && body.instructions.trim().length > 0) {
+    return { body, fix: "none" };
+  }
+  const input = body.input;
+  if (Array.isArray(input)) {
+    const systemParts: string[] = [];
+    const remaining: unknown[] = [];
+    for (const item of input) {
+      const role =
+        item !== null && typeof item === "object" ? (item as { role?: unknown }).role : undefined;
+      if (role === "system" || role === "developer") {
+        const text = plainText((item as { content?: unknown }).content);
+        if (text.length > 0) {
+          // Hoist this item's text into instructions and drop it from input.
+          systemParts.push(text);
+          continue;
+        }
+      }
+      remaining.push(item);
+    }
+    const joined = systemParts.join("\n\n");
+    if (joined.length > 0) {
+      return {
+        body: { ...body, instructions: joined, input: remaining },
+        fix: "hoisted_from_input",
+      };
+    }
+  }
+  // No system content anywhere (and instructions absent/empty): inject the default so
+  // the Codex backend never receives an empty `instructions`.
+  return { body: { ...body, instructions: DEFAULT_INSTRUCTIONS }, fix: "defaulted" };
+}
+
 function toResponsesInput(messages: Array<Record<string, unknown>>): ResponsesItem[] {
   const out: ResponsesItem[] = [];
   for (const m of messages) {


### PR DESCRIPTION
## Problem

A prod request (`09387e28-...`, pi-coding-agent / AgentCrew via `@earendil-works/pi-ai`) hit `/v1/responses`, routed to lane `coding` whose primary is `openai-codex/gpt-5.5`. Native passthrough forwarded the verbatim body to the ChatGPT-account Codex backend, which returned **HTTP 400 `{"detail":"Instructions are required"}`**; fail-open then fell back to `claude-opus-4-8` (success). The Codex attempt was a wasted hop + a red telemetry row.

**SQLite evidence** (`request_payloads`): the inbound body has `input` as an array, no `messages`, and **no top-level `instructions`** — the system prompt is `input[0] = {role:"developer", content:"You are Mimi..."}`. pi-ai deliberately puts the system prompt into `input` (role `developer` for reasoning models, else `system`) and omits `instructions`. That's valid for the **public** OpenAI Responses API, but the ChatGPT-account **Codex** backend mandates a non-empty top-level `instructions` (the real Codex CLI always sends its base prompt there).

## Root cause

Asymmetry between the two paths:
- **Translate path** — `buildInstructions` falls back to `DEFAULT_INSTRUCTIONS`, so `instructions` is never empty.
- **Native passthrough path** — forwards the body verbatim with **no equivalent defense**. The compat-rewrite guard in `execute.ts` only covers `map_developer_role_to_system` and the Anthropic system-fold; there was no Codex/responses `instructions` guard.

## Fix

Add a pure `hoistResponsesInstructions(body)` in core (`openai-responses.ts`, reusing `plainText` / `DEFAULT_INSTRUCTIONS`):
- already-present non-empty `instructions` → returned **verbatim** (`none`);
- otherwise **hoist** the `system`/`developer` `input` items' text into top-level `instructions` and **strip** them from `input` (`hoisted_from_input`) — the same system→instructions split `buildInstructions`/`toResponsesInput` already perform on the translate path, producing the real Codex-CLI shape;
- no system content anywhere → inject `DEFAULT_INSTRUCTIONS` (`defaulted`).

Wired into the `needsCodexResponsesShim` block of `prepareNativeRequestForUpstream` (**codex_responses profile only**; generic OpenAI Responses providers are untouched), recording `body_shims_applied: instructions_hoisted_from_input` / `instructions_defaulted`. This **keeps native passthrough** (prompt_cache_key / reasoning.encrypted_content / SSE byte-relay) instead of downgrading to translation.

### Why hoist over a generic default
The agent's real system prompt is already in `input`; injecting `"You are a helpful assistant."` would be redundant/misleading. Hoisting restores the faithful Codex shape. The client (pi-ai) is a third-party `node_modules` lib with no `instructions` config, so the bridge belongs in the gateway (principle 6).

## Tests
- 8 core unit tests for `hoistResponsesInstructions` (hoist developer/system, join, array content, whitespace, verbatim-when-present, default fallback, no-mutation).
- 2 gateway execute passthrough tests (hoist pi-ai shape; verbatim when `instructions` present) + updated the existing store-shim assertion (now also `instructions_defaulted`; ledger is sorted by `appendMutationList`).

## Verification
- `pnpm typecheck` (3 projects) ✓
- `pnpm lint` (biome, 478 files) ✓
- core + gateway full suite: **3264 passed**, no regressions ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)