### PR TITLE
chore(release): v0.20.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.20.3**.

Bumps root `package.json` → `0.20.3`. On merge, `publish.yml` cuts tag `v0.20.3` + GitHub Release and builds `ghcr.io/easymetaau/helm-api:0.20.3` + `:latest`.

### Since v0.20.2
- #310 — fix(gateway): hoist Codex Responses instructions on native passthrough. Repairs HTTP 400 `{"detail":"Instructions are required"}` from the ChatGPT-account Codex backend when a Responses client (pi-ai / pi-coding-agent) omits top-level `instructions` and carries the system prompt as a leading `developer`/`system` item in `input`. The shim hoists that content into `instructions` (codex_responses profile only) while keeping native passthrough intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)