### PR TITLE
chore(release): v0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.21.0** — bumps root `package.json` so `publish.yml` cuts tag `v0.21.0` + GitHub Release + GHCR `:0.21.0`/`:latest` on merge.

## What's in this release (since v0.20.3)

**Features**
- feat(memory): admin management page + MCP server for facts/reflections (docs/13) (#319)
- feat(admin): per-API-key usage stats — keys list 24h column + detail page (#317)
- feat(cleanup): scheduled data cleanup, retention & archival (#318)
- feat(memory): salient-fact fast path — eager extraction + Known-facts injection (#312)

**Fixes**
- fix(provider): normalize Anthropic outbound tool names on all translate paths (#316)
- fix(classifier): scope complexity-tier scoring to the current user turn (#315)
- fix(classifier): scope Layer-1 task detection to the current user turn (#313)

## Config / migration notes
All new config is **additive with safe defaults** — existing/operator config boots unchanged:
- `memory.mcp.enabled` (default `false`, opt-in MCP endpoint)
- `memory.forgetting.consolidate.eager_facts` (default `false`; cross-gated — `true` requires `memory.llm.enabled` + `memory.forgetting.enabled`)
- runtime cleanup/retention settings (all defaulted; raw-transcript + derived-memory cleanup default **off**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)