### PR TITLE
chore(release): v0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.1 — patch.

Includes the single unreleased commit on top of v0.21.0:
- #321 feat(admin): keys Details button, request-detail summary, key→memory link, memory i18n

Admin-only (UI + admin requests API + i18n); no core/provider/protocol/config-schema changes. publish.yml auto-cuts tag v0.21.1 + GitHub Release + GHCR `:0.21.1`/`:latest` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)