### PR TITLE
feat(admin): memory page "Connect via MCP" dialog + fix nav subtitle i18n

### DIFF
--- a/apps/admin/src/lib/components/ConnectMcpDialog.svelte
+++ b/apps/admin/src/lib/components/ConnectMcpDialog.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { t } from '$lib/i18n';
+  import Modal from './Modal.svelte';
+
+  // "Connect via MCP" guide: a tabbed, copy-paste reference shown on the Memory
+  // page, mirroring the API Keys "Connect a client" dialog. Helm's memory MCP
+  // server (docs/13) speaks the MCP Streamable HTTP transport at POST /mcp on the
+  // BARE origin — NOT /v1 (that path is the OpenAI/Responses chat surface). It is
+  // authed by the SAME API key as /v1, sent as a bearer token, and a tool call is
+  // scoped to that key's account + default project — so the agent reads and writes
+  // the very facts/reflections shown on this page.
+  //
+  // The endpoint is fail-closed: it only exists when memory.mcp.enabled is set on
+  // the gateway, otherwise /mcp returns 404 (server.ts). We say so in the prose.
+  //
+  // Snippet bodies are literal template strings, NOT i18n keys — translating a URL,
+  // a CLI flag, or TOML/JSON punctuation would silently break the config. Only the
+  // prose around them is localized. The key is a copy-and-replace placeholder by
+  // default; a freshly-minted plaintext can be injected (one-time) like the sibling
+  // dialog, but the Memory page opens this without one.
+  let { plaintextKey, onclose }: { plaintextKey?: string; onclose: () => void } = $props();
+
+  type Tab = 'claude' | 'json' | 'codex' | 'curl';
+  let tab = $state<Tab>('claude');
+
+  // Admin is same-origin with the gateway (Hono serves it at /admin), so
+  // window.location.origin IS the public base URL. SSR-safe default; resolved on
+  // mount. Under `pnpm dev` this shows the Vite port — correct only when served by
+  // the gateway.
+  let origin = $state('https://helm.example.com');
+  onMount(() => {
+    origin = window.location.origin;
+  });
+
+  // MCP endpoint = bare origin + /mcp (NOT /v1/mcp).
+  let mcpUrl = $derived(`${origin}/mcp`);
+  let keyShown = $derived(plaintextKey ?? '<your-helm-key>');
+
+  let claudeCmd = $derived(
+    `claude mcp add --transport http helm-memory ${mcpUrl} \\\n  --header "Authorization: Bearer ${keyShown}"`,
+  );
+  let jsonCfg = $derived(
+    `{\n  "mcpServers": {\n    "helm-memory": {\n      "type": "http",\n      "url": "${mcpUrl}",\n      "headers": { "Authorization": "Bearer ${keyShown}" }\n    }\n  }\n}`,
+  );
+  // Codex (and any stdio-only client) reach the HTTP server through the mcp-remote
+  // bridge — no space around the header colon, which trips Codex's arg parsing.
+  let codexToml = $derived(
+    `# ~/.codex/config.toml\n[mcp_servers.helm-memory]\ncommand = "npx"\nargs = ["-y", "mcp-remote", "${mcpUrl}", "--header", "Authorization:Bearer ${keyShown}"]`,
+  );
+  let curlCmd = $derived(
+    `curl -X POST "${mcpUrl}" \\\n  -H "Authorization: Bearer ${keyShown}" \\\n  -H "Content-Type: application/json" \\\n  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`,
+  );
+
+  // Which code block last had its Copy pressed — drives the per-block "Copied" flip
+  // without a sub-component. Clipboard may be unavailable in an insecure context;
+  // degrade silently and never surface the secret in an error.
+  let copiedId = $state<string | null>(null);
+  async function copy(id: string, text: string): Promise<void> {
+    try {
+      await navigator.clipboard?.writeText(text);
+      copiedId = id;
+    } catch {
+      copiedId = null;
+    }
+  }
+</script>
+
+{#snippet codeBlock(id: string, code: string, testid: string)}
+  <div class="overflow-hidden rounded-lg border border-slate-200">
+    <div
+      class="flex items-center justify-between gap-2 border-b border-slate-200 bg-slate-50 px-3 py-1.5"
+    >
+      <span class="font-mono text-xs text-ink-muted">{testid.replace('snippet-', '')}</span>
+      <button type="button" class="btn-primary-sm" onclick={() => copy(id, code)}
+        >{copiedId === id ? $t('Copied') : $t('Copy')}</button
+      >
+    </div>
+    <pre
+      data-testid={testid}
+      class="overflow-auto whitespace-pre-wrap break-words bg-white p-3 font-mono text-xs leading-relaxed text-ink-strong [overflow-wrap:anywhere]">{code}</pre>
+  </div>
+{/snippet}
+
+<Modal label={$t('Connect via MCP')} {onclose} wide>
+  <div class="flex max-h-[80vh] flex-col">
+    <h2 class="section-header">{$t('Connect via MCP')}</h2>
+    <p class="mt-1 text-sm text-ink-muted">
+      {$t(
+        "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.",
+      )}
+    </p>
+    <p class="mt-1 text-sm text-ink-muted">
+      {$t(
+        'The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.',
+      )}
+    </p>
+
+    {#if plaintextKey}
+      <p data-testid="connect-secret-note" class="mt-2 text-sm text-amber-700">
+        {$t(
+          'These snippets include your new key, shown only this once. Copy what you need now — we store only a hash, so it cannot be recovered later.',
+        )}
+      </p>
+    {/if}
+
+    <!-- One tab per client; all hit the same POST /mcp endpoint with a bearer key. -->
+    <div
+      class="mt-4 flex max-w-full gap-4 overflow-x-auto border-b border-slate-200 [scrollbar-width:thin]"
+      role="tablist"
+      aria-label={$t('Connect via MCP')}
+    >
+      <button
+        type="button"
+        role="tab"
+        class="tab-btn shrink-0 whitespace-nowrap"
+        aria-selected={tab === 'claude'}
+        onclick={() => (tab = 'claude')}>{$t('Claude Code')}</button
+      >
+      <button
+        type="button"
+        role="tab"
+        class="tab-btn shrink-0 whitespace-nowrap"
+        aria-selected={tab === 'json'}
+        onclick={() => (tab = 'json')}>{$t('JSON config')}</button
+      >
+      <button
+        type="button"
+        role="tab"
+        class="tab-btn shrink-0 whitespace-nowrap"
+        aria-selected={tab === 'codex'}
+        onclick={() => (tab = 'codex')}>{$t('Codex CLI')}</button
+      >
+      <button
+        type="button"
+        role="tab"
+        class="tab-btn shrink-0 whitespace-nowrap"
+        aria-selected={tab === 'curl'}
+        onclick={() => (tab = 'curl')}>{$t('curl')}</button
+      >
+    </div>
+
+    <div class="mt-4 min-h-0 flex-1 overflow-auto">
+      {#if tab === 'claude'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t(
+            'Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.',
+          )}
+        </p>
+        {@render codeBlock('mcp-claude', claudeCmd, 'snippet-mcp-claude')}
+      {:else if tab === 'json'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t(
+            'Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.',
+          )}
+        </p>
+        {@render codeBlock('mcp-json', jsonCfg, 'snippet-mcp-json')}
+      {:else if tab === 'codex'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t(
+            'Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.',
+          )}
+        </p>
+        {@render codeBlock('mcp-codex', codexToml, 'snippet-mcp-codex')}
+      {:else}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t(
+            'Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.',
+          )}
+        </p>
+        {@render codeBlock('mcp-curl', curlCmd, 'snippet-mcp-curl')}
+      {/if}
+    </div>
+
+    <div class="mt-4 flex justify-end">
+      <button type="button" class="btn-secondary" onclick={onclose}>{$t('Close')}</button>
+    </div>
+  </div>
+</Modal>

--- a/apps/admin/src/lib/components/ConnectMcpDialog.test.ts
+++ b/apps/admin/src/lib/components/ConnectMcpDialog.test.ts
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ConnectMcpDialog from './ConnectMcpDialog.svelte';
+
+// "Connect via MCP" guide on the Memory page — mirrors ConnectClientDialog but for
+// Helm's memory MCP server (docs/13). The server lives at POST /mcp on the BARE
+// origin (the MCP Streamable HTTP transport), authed by the same API key as a
+// bearer token. The footgun guarded here is the inverse of the /v1 one: /mcp must
+// sit on the bare origin, never /v1/mcp (that path is the chat surface).
+//
+// The base URL is read from window.location.origin (admin is same-origin with the
+// gateway). The key is a copy-and-replace placeholder unless a freshly-minted
+// plaintext is injected (one-time), mirroring CLAUDE.md 原则7.
+
+const ORIGIN = 'https://helm.example.test';
+const MCP_URL = `${ORIGIN}/mcp`;
+
+function stubOrigin(value: string): void {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, origin: value, href: `${value}/admin/memory` },
+  });
+}
+
+function setup(props: { plaintextKey?: string } = {}) {
+  const onclose = vi.fn();
+  render(ConnectMcpDialog, { onclose, ...props });
+  return { onclose };
+}
+
+describe('ConnectMcpDialog', () => {
+  beforeEach(() => {
+    stubOrigin(ORIGIN);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders inside a labelled, dismissible modal', async () => {
+    const { onclose } = setup();
+    expect(screen.getByRole('dialog', { name: /connect via mcp/i })).toBeInTheDocument();
+    await fireEvent.click(screen.getByTestId('modal-scrim'));
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to the Claude Code tab and registers /mcp on the BARE origin (no /v1)', () => {
+    setup();
+    const claudeTab = screen.getByRole('tab', { name: /claude code/i });
+    expect(claudeTab).toHaveAttribute('aria-selected', 'true');
+    const snippet = screen.getByTestId('snippet-mcp-claude').textContent ?? '';
+    expect(snippet).toContain(`claude mcp add --transport http helm-memory ${MCP_URL}`);
+    expect(snippet).toContain('--header "Authorization: Bearer <your-helm-key>"');
+    // The endpoint must be the bare origin + /mcp. A /v1/mcp here is the 404 footgun.
+    expect(snippet).not.toContain(`${ORIGIN}/v1`);
+  });
+
+  it('renders the JSON config tab with type "http" and the bearer header', async () => {
+    setup();
+    await fireEvent.click(screen.getByRole('tab', { name: /json config/i }));
+    const snippet = screen.getByTestId('snippet-mcp-json').textContent ?? '';
+    expect(snippet).toContain('"mcpServers"');
+    expect(snippet).toContain('"type": "http"');
+    expect(snippet).toContain(`"url": "${MCP_URL}"`);
+    expect(snippet).toContain('"Authorization": "Bearer <your-helm-key>"');
+    expect(snippet).not.toContain(`${ORIGIN}/v1`);
+  });
+
+  it('renders the Codex tab as an mcp-remote stdio bridge', async () => {
+    setup();
+    await fireEvent.click(screen.getByRole('tab', { name: /codex/i }));
+    const snippet = screen.getByTestId('snippet-mcp-codex').textContent ?? '';
+    expect(snippet).toContain('[mcp_servers.helm-memory]');
+    expect(snippet).toContain('mcp-remote');
+    expect(snippet).toContain(MCP_URL);
+    // No space around the header colon — Codex arg parsing trips on it otherwise.
+    expect(snippet).toContain('"Authorization:Bearer <your-helm-key>"');
+  });
+
+  it('renders the curl tab with a tools/list JSON-RPC probe to /mcp', async () => {
+    setup();
+    await fireEvent.click(screen.getByRole('tab', { name: /^curl$/i }));
+    const snippet = screen.getByTestId('snippet-mcp-curl').textContent ?? '';
+    expect(snippet).toContain(`curl -X POST "${MCP_URL}"`);
+    expect(snippet).toContain('Authorization: Bearer <your-helm-key>');
+    expect(snippet).toContain('"method":"tools/list"');
+  });
+
+  it('shows a placeholder key when no plaintext is supplied (opened from the header)', () => {
+    setup();
+    expect(screen.getByTestId('snippet-mcp-claude').textContent ?? '').toContain('<your-helm-key>');
+    expect(screen.queryByTestId('connect-secret-note')).not.toBeInTheDocument();
+  });
+
+  it('injects the freshly-minted plaintext into every tab when supplied', async () => {
+    const KEY = 'helm_live_FRESH_ONE_TIME';
+    setup({ plaintextKey: KEY });
+    expect(screen.getByTestId('snippet-mcp-claude').textContent ?? '').toContain(KEY);
+    expect(screen.getByTestId('snippet-mcp-claude').textContent ?? '').not.toContain(
+      '<your-helm-key>',
+    );
+    await fireEvent.click(screen.getByRole('tab', { name: /json config/i }));
+    expect(screen.getByTestId('snippet-mcp-json').textContent ?? '').toContain(KEY);
+    expect(screen.getByTestId('connect-secret-note')).toBeInTheDocument();
+  });
+
+  it('copies the active snippet to the clipboard and flips the button to "Copied"', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    setup();
+    const copyBtn = screen.getAllByRole('button', { name: /^copy$/i })[0];
+    await fireEvent.click(copyBtn);
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).toContain(`helm-memory ${MCP_URL}`);
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /copied/i }).length).toBeGreaterThan(0),
+    );
+  });
+
+  it('exposes Claude Code, JSON config, Codex and curl tabs', () => {
+    setup();
+    expect(screen.getByRole('tab', { name: /claude code/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /json config/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /codex/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /^curl$/i })).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/lib/i18n/extraction-anchors.svelte
+++ b/apps/admin/src/lib/i18n/extraction-anchors.svelte
@@ -22,7 +22,7 @@
 {#if false}
   <!-- nav + quick-link labels -->
   {$t('Dashboard')}{$t('Requests')}{$t('Lanes')}{$t('Policies')}{$t('Classifier')}{$t('API Keys')}
-  {$t('Providers')}{$t('Settings')}
+  {$t('Memory')}{$t('Providers')}{$t('Settings')}
   <!-- sidebar nav subtitles -->
   {$t('Traffic and health at a glance')}
   {$t('Every request and the lane it took')}
@@ -30,6 +30,7 @@
   {$t('Rules that override or cap the lane')}
   {$t('How a request is matched to a lane')}
   {$t('Client keys and their lane limits')}
+  {$t('Facts and reflections the gateway remembers')}
   {$t('Connect Codex and Claude subscriptions')}
   {$t('System Settings')}
   <!-- dashboard quick-link descriptions -->

--- a/apps/admin/src/lib/i18n/mcp-locales.test.ts
+++ b/apps/admin/src/lib/i18n/mcp-locales.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '../../locales/en.json';
+import ja from '../../locales/ja.json';
+import ko from '../../locales/ko.json';
+import zhHans from '../../locales/zh-hans.json';
+import zhHant from '../../locales/zh-hant.json';
+
+// ConnectMcpDialog (Memory page) ships localized prose around literal copy-paste
+// snippets. These are static `$t('…')` calls so the extractor sees them — but a
+// missing translation still silently falls back to English (the exact regression
+// the Memory nav subtitle hit). Guard every translatable string. 'curl' is a proper
+// noun (command name), identical across locales by design, so it is NOT asserted to
+// differ from English.
+const mcpKeys = [
+  'Connect via MCP',
+  "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.",
+  'The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.',
+  'Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.',
+  'Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.',
+  'Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.',
+  'Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.',
+  'JSON config',
+] as const;
+
+const translatedLocales = {
+  'zh-hans': zhHans,
+  'zh-hant': zhHant,
+  ja,
+  ko,
+} as const;
+
+describe('ConnectMcpDialog locale coverage', () => {
+  it.each(Object.entries(translatedLocales))(
+    '%s translates every MCP dialog string instead of falling back to English',
+    (_locale, dict: Record<string, string>) => {
+      for (const key of mcpKeys) {
+        expect(dict).toHaveProperty(key);
+        expect(dict[key]).toBeTruthy();
+        expect(dict[key]).not.toBe((en as Record<string, string>)[key]);
+      }
+    },
+  );
+});

--- a/apps/admin/src/lib/i18n/nav-locales.test.ts
+++ b/apps/admin/src/lib/i18n/nav-locales.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '../../locales/en.json';
+import ja from '../../locales/ja.json';
+import ko from '../../locales/ko.json';
+import zhHans from '../../locales/zh-hans.json';
+import zhHant from '../../locales/zh-hant.json';
+
+// The sidebar nav subtitles in routes/+layout.svelte are referenced ONLY via the
+// dynamic `$t(item.desc)`, so the extractor never sees them as static calls —
+// they are kept alive by lib/i18n/extraction-anchors.svelte. If an anchor is
+// missing, `pnpm i18n:sync` prunes the string from every locale and the subtitle
+// silently falls back to raw English. The Memory subtitle regressed exactly that
+// way (its anchor was never added when the Memory nav item shipped). Guard them all.
+const navSubtitleKeys = [
+  'Traffic and health at a glance',
+  'Every request and the lane it took',
+  'Quality tiers and fallback models',
+  'Rules that override or cap the lane',
+  'How a request is matched to a lane',
+  'Client keys and their lane limits',
+  'Facts and reflections the gateway remembers',
+  'Connect Codex and Claude subscriptions',
+  'System Settings',
+] as const;
+
+const translatedLocales = {
+  'zh-hans': zhHans,
+  'zh-hant': zhHant,
+  ja,
+  ko,
+} as const;
+
+describe('sidebar nav subtitle locale coverage', () => {
+  it.each(Object.entries(translatedLocales))(
+    '%s translates every sidebar nav subtitle instead of falling back to English',
+    (_locale, dict: Record<string, string>) => {
+      for (const key of navSubtitleKeys) {
+        expect(dict).toHaveProperty(key);
+        expect(dict[key]).toBeTruthy();
+        expect(dict[key]).not.toBe((en as Record<string, string>)[key]);
+      }
+    },
+  );
+});

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -231,6 +231,7 @@
   "Fact status filter": "Fact status filter",
   "Fact text": "Fact text",
   "Facts": "Facts",
+  "Facts and reflections the gateway remembers": "Facts and reflections the gateway remembers",
   "Failed": "Failed",
   "Failed to clear proxy": "Failed to clear proxy",
   "Failed to create key": "Failed to create key",
@@ -728,5 +729,14 @@
   "yes": "yes",
   "Your new API key": "Your new API key",
   "Zoom in": "Zoom in",
-  "Zoom out": "Zoom out"
+  "Zoom out": "Zoom out",
+  "Connect via MCP": "Connect via MCP",
+  "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.": "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.",
+  "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.",
+  "Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.": "Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.",
+  "Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.": "Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.",
+  "Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.": "Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.",
+  "Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.": "Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.",
+  "JSON config": "JSON config",
+  "curl": "curl"
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -231,6 +231,7 @@
   "Fact status filter": "ファクト状態フィルター",
   "Fact text": "ファクトテキスト",
   "Facts": "ファクト",
+  "Facts and reflections the gateway remembers": "ゲートウェイが記憶するファクトとリフレクション",
   "Failed": "失敗",
   "Failed to clear proxy": "プロキシのクリアに失敗しました",
   "Failed to create key": "キーの作成に失敗しました",
@@ -728,5 +729,14 @@
   "yes": "はい",
   "Your new API key": "新しい API キー",
   "Zoom in": "拡大",
-  "Zoom out": "縮小"
+  "Zoom out": "縮小",
+  "Connect via MCP": "MCP で接続",
+  "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.": "AI エージェントに永続的なメモリを与えます。Helm の MCP サーバーは、このページのファクトとリフレクションをツール（memory_add、memory_search、memory_list…）として公開し、API キーに紐づくアカウントにスコープされます。",
+  "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "サーバーはベースとなるオリジン + /mcp で MCP Streamable HTTP トランスポートを使用し、API キーを Bearer トークンとして認証します。ゲートウェイで memory.mcp.enabled を有効にしてください。それまで /mcp は 404 を返します。",
+  "Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.": "1 つのコマンドでサーバーを登録します。Claude Code は HTTP で接続し、キーを Bearer トークンとして送信します。",
+  "Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.": "または .mcp.json（プロジェクトまたはユーザースコープ）に追加します。同じエントリは他の MCP 対応エディタでも機能します。",
+  "Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.": "Codex やその他の stdio のみのクライアントは、~/.codex/config.toml の mcp-remote ブリッジ経由で HTTP サーバーに接続します。",
+  "Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.": "素の JSON-RPC 呼び出しで接続性と認証を確認します。サーバーが公開するメモリツールの一覧が返ります。",
+  "JSON config": "JSON 設定",
+  "curl": "curl"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -231,6 +231,7 @@
   "Fact status filter": "사실 상태 필터",
   "Fact text": "사실 텍스트",
   "Facts": "사실",
+  "Facts and reflections the gateway remembers": "게이트웨이가 기억하는 사실과 회고",
   "Failed": "실패",
   "Failed to clear proxy": "프록시를 지우지 못했습니다",
   "Failed to create key": "키 생성 실패",
@@ -728,5 +729,14 @@
   "yes": "예",
   "Your new API key": "새 API 키",
   "Zoom in": "확대",
-  "Zoom out": "축소"
+  "Zoom out": "축소",
+  "Connect via MCP": "MCP로 연결",
+  "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.": "AI 에이전트에 영속적인 메모리를 제공합니다. Helm의 MCP 서버는 이 페이지의 사실과 회고를 도구(memory_add, memory_search, memory_list…)로 노출하며, API 키에 연결된 계정으로 범위가 한정됩니다.",
+  "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "서버는 베이스 오리진 + /mcp에서 MCP Streamable HTTP 전송을 사용하며, API 키를 Bearer 토큰으로 인증합니다. 게이트웨이에서 memory.mcp.enabled로 활성화하세요. 그 전까지 /mcp는 404를 반환합니다.",
+  "Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.": "명령 하나로 서버를 등록합니다. Claude Code는 HTTP로 연결하고 키를 Bearer 토큰으로 전송합니다.",
+  "Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.": "또는 .mcp.json(프로젝트 또는 사용자 범위)에 추가하세요. 동일한 항목이 다른 MCP 지원 에디터에서도 작동합니다.",
+  "Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.": "Codex 및 기타 stdio 전용 클라이언트는 ~/.codex/config.toml의 mcp-remote 브리지를 통해 HTTP 서버에 접근합니다.",
+  "Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.": "원시 JSON-RPC 호출로 연결과 인증을 확인합니다. 서버가 노출하는 메모리 도구 목록을 반환합니다.",
+  "JSON config": "JSON 설정",
+  "curl": "curl"
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -231,6 +231,7 @@
   "Fact status filter": "事实状态筛选器",
   "Fact text": "事实文本",
   "Facts": "事实",
+  "Facts and reflections the gateway remembers": "网关记住的事实与反思",
   "Failed": "测试失败",
   "Failed to clear proxy": "清除代理失败",
   "Failed to create key": "创建密钥失败",
@@ -728,5 +729,14 @@
   "yes": "是",
   "Your new API key": "你的新 API 密钥",
   "Zoom in": "放大",
-  "Zoom out": "缩小"
+  "Zoom out": "缩小",
+  "Connect via MCP": "通过 MCP 接入",
+  "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.": "为 AI 智能体提供持久记忆。Helm 的 MCP 服务器将本页的事实与反思作为工具（memory_add、memory_search、memory_list…）暴露出来，范围限定为你的 API 密钥所属的账户。",
+  "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "服务器在裸源地址 + /mcp 上使用 MCP Streamable HTTP 传输，并以 Bearer 令牌形式用你的 API 密钥进行认证。需在网关上通过 memory.mcp.enabled 启用——在此之前 /mcp 返回 404。",
+  "Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.": "用一条命令注册服务器。Claude Code 通过 HTTP 连接，并以 Bearer 令牌形式发送你的密钥。",
+  "Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.": "或将其添加到 .mcp.json（项目或用户范围）。同样的条目也适用于其他支持 MCP 的编辑器。",
+  "Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.": "Codex 及其他仅支持 stdio 的客户端，通过 ~/.codex/config.toml 中的 mcp-remote 桥接来访问 HTTP 服务器。",
+  "Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.": "用一次原始 JSON-RPC 调用检查连通性与认证。它会列出服务器暴露的记忆工具。",
+  "JSON config": "JSON 配置",
+  "curl": "curl"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -231,6 +231,7 @@
   "Fact status filter": "事實狀態篩選器",
   "Fact text": "事實文字",
   "Facts": "事實",
+  "Facts and reflections the gateway remembers": "閘道記住的事實與反思",
   "Failed": "測試失敗",
   "Failed to clear proxy": "清除代理失敗",
   "Failed to create key": "建立金鑰失敗",
@@ -728,5 +729,14 @@
   "yes": "是",
   "Your new API key": "你的新 API 金鑰",
   "Zoom in": "放大",
-  "Zoom out": "縮小"
+  "Zoom out": "縮小",
+  "Connect via MCP": "透過 MCP 接入",
+  "Give an AI agent persistent memory. Helm's MCP server exposes the facts and reflections on this page as tools (memory_add, memory_search, memory_list, …), scoped to the account behind your API key.": "為 AI 代理提供持久記憶。Helm 的 MCP 伺服器會將本頁的事實與反思作為工具（memory_add、memory_search、memory_list…）公開，範圍限定為你的 API 金鑰所屬的帳戶。",
+  "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "伺服器在裸源位址 + /mcp 上使用 MCP Streamable HTTP 傳輸，並以 Bearer 權杖形式用你的 API 金鑰進行認證。需在閘道上透過 memory.mcp.enabled 啟用——在此之前 /mcp 回傳 404。",
+  "Register the server with one command. Claude Code connects over HTTP and sends your key as a bearer token.": "用一條命令註冊伺服器。Claude Code 透過 HTTP 連線，並以 Bearer 權杖形式傳送你的金鑰。",
+  "Or add it to a .mcp.json (project or user scope). The same entry works in other MCP-aware editors.": "或將其加入 .mcp.json（專案或使用者範圍）。同樣的條目也適用於其他支援 MCP 的編輯器。",
+  "Codex and other stdio-only clients reach the HTTP server through the mcp-remote bridge in ~/.codex/config.toml.": "Codex 及其他僅支援 stdio 的用戶端，透過 ~/.codex/config.toml 中的 mcp-remote 橋接來存取 HTTP 伺服器。",
+  "Check connectivity and auth with a raw JSON-RPC call. It lists the memory tools the server exposes.": "用一次原始 JSON-RPC 呼叫檢查連通性與認證。它會列出伺服器公開的記憶工具。",
+  "JSON config": "JSON 設定",
+  "curl": "curl"
 }

--- a/apps/admin/src/routes/memory/+page.svelte
+++ b/apps/admin/src/routes/memory/+page.svelte
@@ -15,6 +15,7 @@
     updateFact,
     updateReflection,
   } from '$lib/api/memory.js';
+  import ConnectMcpDialog from '$lib/components/ConnectMcpDialog.svelte';
   import EditFactDialog from '$lib/components/EditFactDialog.svelte';
   import EditReflectionDialog from '$lib/components/EditReflectionDialog.svelte';
   import Modal from '$lib/components/Modal.svelte';
@@ -71,6 +72,9 @@
   // Edit/delete modal state (one fact / reflection at a time).
   let editingFact = $state<Fact | null>(null);
   let editingReflection = $state<Reflection | null>(null);
+  // "Connect via MCP" guide — opened from the header, no minted key (the snippets
+  // carry a copy-and-replace placeholder). Mirrors the API Keys "Connect a client".
+  let showMcp = $state<boolean>(false);
   let confirmingFactDelete = $state<Fact | null>(null);
   let confirmingReflectionDelete = $state<Reflection | null>(null);
 
@@ -266,13 +270,20 @@
 </script>
 
 <section class="flex w-full flex-col gap-4 px-4 py-6 md:px-8">
-  <header class="min-w-0">
-    <h1 class="page-title">{$t('Memory')}</h1>
-    <p class="section-desc">
-      {$t(
-        'Manage the long-term memory the gateway has learned — the discrete facts it remembers and the per-scope reflections it merges. Browse by scope or by key, then edit or remove what it keeps.',
-      )}
-    </p>
+  <header class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <div class="min-w-0">
+      <h1 class="page-title">{$t('Memory')}</h1>
+      <p class="section-desc">
+        {$t(
+          'Manage the long-term memory the gateway has learned — the discrete facts it remembers and the per-scope reflections it merges. Browse by scope or by key, then edit or remove what it keeps.',
+        )}
+      </p>
+    </div>
+    <div class="flex shrink-0 gap-2">
+      <button type="button" class="btn-secondary" onclick={() => (showMcp = true)}
+        >{$t('Connect via MCP')}</button
+      >
+    </div>
   </header>
 
   {#if error}
@@ -550,6 +561,10 @@
     </div>
   {/if}
 </section>
+
+{#if showMcp}
+  <ConnectMcpDialog onclose={() => (showMcp = false)} />
+{/if}
 
 {#if editingFact}
   <EditFactDialog fact={editingFact} onsaved={onFactSaved} onclose={() => (editingFact = null)} />


### PR DESCRIPTION
## What

Two changes to the **Memory** admin page.

### 1. "Connect via MCP" dialog (new feature)
A tabbed copy-paste setup guide on the Memory page, modeled on the API Keys **Connect a client** dialog (same `Modal` + `codeBlock` pattern). Opened from a new header button.

- **Tabs:** Claude Code (`claude mcp add --transport http`), `.mcp.json` (`type: http`), Codex CLI (via the `mcp-remote` stdio bridge), and `curl` (raw `tools/list` probe).
- Accurate to the server (docs/13): endpoint is **`POST /mcp` on the bare origin** (not `/v1`), authed with the API key as a **Bearer token**, exposing the `memory_*` tools. Prose notes it needs `memory.mcp.enabled` (else `/mcp` 404s).
- Snippet bodies are literal (URLs/flags/punctuation never localized); only prose is i18n'd.

### 2. Fix: Memory nav subtitle fell back to English
The sidebar subtitle `'Facts and reflections the gateway remembers'` is referenced only via the dynamic `$t(item.desc)`, so the extractor never saw it and `pnpm i18n:sync` pruned it from every locale. Fix: anchor it (and the `Memory` label) in `extraction-anchors.svelte` and add translations.

## i18n
All new strings translated across **en / zh-hans / zh-hant / ja / ko**. Reused already-translated keys (`Claude Code`, `Codex CLI`, `Copy`, `Close`).

## Tests
- `ConnectMcpDialog.test.ts` — 9 tests (tabs, snippet correctness incl. no-`/v1` footgun, copy, key placeholder/inject).
- `nav-locales.test.ts` + `mcp-locales.test.ts` — regression guards asserting each string is present + non-English in the 4 translated locales.
- **455 admin tests green**, `svelte-check` 0 errors, Prettier clean.
- Verified live in the browser (EN + 简体中文).

Admin-only (UI + i18n); no core/provider/protocol/config-schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)