### PR TITLE
fix(admin): match key detail pager to the requests list

### DIFF
--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -89,6 +89,14 @@
   function gotoPage(page: number): void {
     applyFilters({ ...data.filters, page });
   }
+  // Real href for a page-number link (keeps the active window/range in the URL):
+  // rendering numbers as <a> gives a native pointer cursor + middle-click /
+  // open-in-new-tab; SvelteKit still navigates client-side and
+  // data-sveltekit-noscroll preserves scroll, like the requests list pager.
+  function pageHref(page: number): string {
+    const qs = keyDetailFiltersToSearch({ ...data.filters, page });
+    return qs ? `?${qs}` : '?';
+  }
 
   const customActive = $derived(Boolean(data.filters.startDate && data.filters.endDate));
 
@@ -476,32 +484,57 @@
       </div>
 
       {#if totalPages > 1}
-        <nav class="mt-4 flex items-center justify-center gap-1" aria-label={$t('Pagination')}>
-          <button
-            type="button"
-            class="btn-secondary"
-            disabled={data.filters.page <= 1}
-            onclick={() => gotoPage(data.filters.page - 1)}>{$t('Prev')}</button
-          >
-          {#each pages as p, i (i)}
-            {#if p === 'ellipsis'}
-              <span class="px-2 text-slate-400">…</span>
-            {:else}
-              <button
-                type="button"
-                class={p === data.filters.page ? 'btn-primary' : 'btn-secondary'}
-                aria-current={p === data.filters.page ? 'page' : undefined}
-                onclick={() => gotoPage(p)}>{p}</button
-              >
-            {/if}
-          {/each}
-          <button
-            type="button"
-            class="btn-secondary"
-            disabled={data.filters.page >= totalPages}
-            onclick={() => gotoPage(data.filters.page + 1)}>{$t('Next')}</button
-          >
-        </nav>
+        <!-- Pagination footer — mirrors the requests list pager (numbered <a>
+             links + Prev/Next + "Page X of Y · N requests" status) so the two
+             views read identically. No rows-per-page selector here: the scoped
+             list uses a fixed page size (DETAIL_PAGE_SIZE). Page numbers are real
+             links (native pointer / open-in-new-tab); Prev/Next stay buttons for
+             their disabled states. -->
+        <div
+          class="mt-4 flex flex-col gap-3 text-sm text-ink-muted sm:flex-row sm:items-center sm:justify-between"
+        >
+          <span data-testid="pager-status">
+            {$t('Page {page} of {pages}', { page: data.filters.page, pages: totalPages })} ·
+            {$t('{total} requests', { total: data.requests.total })}
+          </span>
+
+          <nav class="flex items-center gap-1" aria-label={$t('Pagination')}>
+            <button
+              type="button"
+              data-testid="pager-prev"
+              class="btn-secondary"
+              disabled={data.filters.page <= 1}
+              onclick={() => gotoPage(data.filters.page - 1)}>{$t('Previous')}</button
+            >
+            {#each pages as item, i (item === 'ellipsis' ? `e${i}` : item)}
+              {#if item === 'ellipsis'}
+                <span class="px-2 text-ink-muted" aria-hidden="true">…</span>
+              {:else if item === data.filters.page}
+                <span
+                  data-testid="pager-page-current"
+                  aria-current="page"
+                  class="inline-flex h-9 min-w-9 items-center justify-center rounded border border-slate-800 bg-slate-800 px-2 text-sm font-medium text-white"
+                  >{item}</span
+                >
+              {:else}
+                <a
+                  data-testid="pager-page"
+                  data-sveltekit-noscroll
+                  href={pageHref(item)}
+                  class="inline-flex h-9 min-w-9 cursor-pointer items-center justify-center rounded border border-slate-300 px-2 text-sm text-ink-body transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+                  >{item}</a
+                >
+              {/if}
+            {/each}
+            <button
+              type="button"
+              data-testid="pager-next"
+              class="btn-secondary"
+              disabled={data.filters.page >= totalPages}
+              onclick={() => gotoPage(data.filters.page + 1)}>{$t('Next')}</button
+            >
+          </nav>
+        </div>
       {/if}
     {/if}
   </section>

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -219,13 +219,38 @@ describe('key detail page', () => {
     expect(screen.queryByRole('link', { name: /manage memory/i })).not.toBeInTheDocument();
   });
 
-  it('shows a pager when the total exceeds one page', () => {
+  it('renders a requests-style pager (numbered links + status) across pages', () => {
     render(KeyDetailPage, {
       data: pageData({
         requests: { items: [requestItem('tr_1')], total: 60, page: 1, pageSize: 25 },
       }),
     });
-    // 60 / 25 → 3 pages: Next button is present.
-    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    // 60 / 25 → 3 pages. Status line mirrors the requests list: "Page X of Y · N requests".
+    const status = screen.getByTestId('pager-status');
+    expect(status.textContent).toMatch(/Page\s*1\s*of\s*3/);
+    expect(status.textContent).toMatch(/60/);
+
+    // Page numbers are real <a> links carrying the page in the querystring (native
+    // pointer / open-in-new-tab), not plain buttons like the old pager.
+    const page2 = screen.getByRole('link', { name: '2' });
+    expect(page2).toHaveAttribute('href', '?page=2');
+
+    // The current page is a marked, non-link cell.
+    const current = screen.getByTestId('pager-page-current');
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(current.textContent?.trim()).toBe('1');
+
+    // Prev is disabled on page 1; Next stays available — matching the requests pager.
+    expect(screen.getByTestId('pager-prev')).toBeDisabled();
+    expect(screen.getByTestId('pager-next')).not.toBeDisabled();
+  });
+
+  it('hides the pager when everything fits on one page', () => {
+    render(KeyDetailPage, {
+      data: pageData({
+        requests: { items: [requestItem('tr_1')], total: 1, page: 1, pageSize: 25 },
+      }),
+    });
+    expect(screen.queryByTestId('pager-status')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

The API key detail page (`/keys/[keyId]`) used a plain `Prev / 1 2 3 / Next` button row, visually and behaviourally inconsistent with the **requests list** pager. This rebuilds it to mirror that pager so the two views read identically:

- **Numbered pages are real `<a>` links** (`pageHref`) — native pointer cursor, middle-click / open-in-new-tab, and the active window/range is preserved in the URL. `data-sveltekit-noscroll` keeps scroll position.
- **Current page** is a marked, non-link cell (`aria-current="page"`); `…` for gaps.
- **Previous / Next** buttons (was `Prev`/`Next`) with proper disabled states.
- **`Page X of Y · N requests`** status line.
- Reuses the shared `paginationItems` helper and the requests pager's `data-testid`s (`pager-status`, `pager-prev`, `pager-next`, `pager-page`, `pager-page-current`) so both views test the same way.

## Scope decision

No **Rows per page** selector on this page: the scoped list uses a fixed page size (`DETAIL_PAGE_SIZE = 25`, no `pageSize` in the URL), so adding one would require filter-schema + loader + API plumbing — out of scope for a visual-parity fix.

> Note: a "link to the memory page" was also requested, but `main` already ships that (`Manage memory →` → `/memory?key=<keyId>`, PR #321), verified by the existing test. Nothing to add here.

## Tests / verification

- Extended `key-detail.test.ts` (TDD red→green): asserts numbered-link hrefs, the status line, `aria-current`, and Prev/Next disabled states. **9/9 admin tests pass.**
- `pnpm typecheck` ✅ · `biome check` ✅ · `svelte-check` ✅ (0 errors / 0 warnings) · `pnpm build` ✅
- Pager i18n keys present in all 5 locales — no `i18n:sync` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)