### PR TITLE
fix(admin): don't claim "Copied" when the Clipboard API is unavailable

### DIFF
--- a/apps/admin/src/lib/components/ConnectMcpDialog.svelte
+++ b/apps/admin/src/lib/components/ConnectMcpDialog.svelte
@@ -57,8 +57,15 @@
   // degrade silently and never surface the secret in an error.
   let copiedId = $state<string | null>(null);
   async function copy(id: string, text: string): Promise<void> {
+    // No Clipboard API (insecure context / old browser): bail without claiming
+    // success — `clipboard?.writeText(...)` would resolve to undefined, falsely
+    // flipping the button to "Copied" though nothing was written.
+    if (!navigator.clipboard?.writeText) {
+      copiedId = null;
+      return;
+    }
     try {
-      await navigator.clipboard?.writeText(text);
+      await navigator.clipboard.writeText(text);
       copiedId = id;
     } catch {
       copiedId = null;

--- a/apps/admin/src/lib/components/ConnectMcpDialog.test.ts
+++ b/apps/admin/src/lib/components/ConnectMcpDialog.test.ts
@@ -124,4 +124,14 @@ describe('ConnectMcpDialog', () => {
     expect(screen.getByRole('tab', { name: /codex/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /^curl$/i })).toBeInTheDocument();
   });
+
+  it('does not falsely flip to "Copied" when the Clipboard API is unavailable', async () => {
+    // Insecure context (plain HTTP) / old browser: navigator.clipboard is absent.
+    // The button must NOT claim success when nothing was written.
+    Object.assign(navigator, { clipboard: undefined });
+    setup();
+    await fireEvent.click(screen.getAllByRole('button', { name: /^copy$/i })[0]);
+    expect(screen.queryByRole('button', { name: /copied/i })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /^copy$/i }).length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## What
Follow-up to **#323** addressing the Codex review (P3).

`ConnectMcpDialog`'s `copy()` did:
```js
await navigator.clipboard?.writeText(text);
copiedId = id;
```
In an **insecure context (plain HTTP)** or an old browser, `navigator.clipboard?.writeText` is `undefined`, so the optional chain short-circuits to `undefined`, the `await` resolves, and the button flips to **"Copied"** even though nothing was written to the clipboard.

## Fix
Guard for the Clipboard API and bail (no false success) before attempting the write — then only flip to "Copied" once `writeText` actually resolves.

## Test
Adds a regression test asserting the button does **not** show "Copied" when `navigator.clipboard` is unavailable. `ConnectMcpDialog.test.ts` now 10 tests, all green; `svelte-check` clean; Prettier clean.

Note: the sibling `ConnectClientDialog.svelte` (API Keys page, unchanged here) has the same latent pattern — happy to fix it in a separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)