### PR TITLE
fix(admin): self-review fixes for the key detail pager

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -466,7 +466,6 @@
   "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.",
   "Policies": "Policies",
   "Port": "Port",
-  "Prev": "Prev",
   "Preview": "Preview",
   "Previous": "Previous",
   "Primary": "Primary",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -466,7 +466,6 @@
   "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "ツールの base URL と API キーを Helm に向け、model に “auto”（またはレーン名）を指定するだけ。どのモデルを使うかはゲートウェイが選びます。",
   "Policies": "ポリシー",
   "Port": "ポート",
-  "Prev": "前へ",
   "Preview": "プレビュー",
   "Previous": "前へ",
   "Primary": "プライマリ",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -466,7 +466,6 @@
   "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "도구의 base URL과 API 키를 Helm으로 설정한 뒤 model에 “auto”(또는 레인 이름)를 보내세요. 어떤 모델을 쓸지는 게이트웨이가 고릅니다.",
   "Policies": "정책",
   "Port": "포트",
-  "Prev": "이전",
   "Preview": "미리보기",
   "Previous": "이전",
   "Primary": "기본",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -466,7 +466,6 @@
   "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "把你的工具指向 Helm：填好 base URL 和 API key，再把 model 设为 “auto”（或某个 lane 名称）——具体用哪个模型交给网关来挑。",
   "Policies": "策略",
   "Port": "端口",
-  "Prev": "上一页",
   "Preview": "预览",
   "Previous": "上一页",
   "Primary": "主用",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -466,7 +466,6 @@
   "Point your tool at Helm by setting its base URL and API key, then send model \"auto\" (or a lane name) — the gateway picks the model.": "把你的工具指向 Helm：填好 base URL 和 API key，再把 model 設為 “auto”（或某個 lane 名稱）——具體用哪個模型交給閘道來挑。",
   "Policies": "策略",
   "Port": "連接埠",
-  "Prev": "上一頁",
   "Preview": "預覽",
   "Previous": "上一頁",
   "Primary": "主用",

--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -139,7 +139,7 @@
 
   // ── Request list (scoped to this key) ────────────────────────────────────────
   const totalPages = $derived(
-    Math.max(1, Math.ceil(data.requests.total / data.requests.pageSize)),
+    Math.max(1, Math.ceil(data.requests.total / Math.max(1, data.requests.pageSize))),
   );
   const pages = $derived(paginationItems(data.filters.page, totalPages));
 
@@ -485,17 +485,18 @@
 
       {#if totalPages > 1}
         <!-- Pagination footer — mirrors the requests list pager (numbered <a>
-             links + Prev/Next + "Page X of Y · N requests" status) so the two
-             views read identically. No rows-per-page selector here: the scoped
-             list uses a fixed page size (DETAIL_PAGE_SIZE). Page numbers are real
-             links (native pointer / open-in-new-tab); Prev/Next stay buttons for
-             their disabled states. -->
+             links + Prev/Next + a "Page X of Y" status). The window's request
+             count is already shown once in the section header above, so it isn't
+             repeated here (the header formats it via formatCount — repeating the
+             raw total would contradict it for >=1000). No rows-per-page selector:
+             the scoped list uses a fixed page size (DETAIL_PAGE_SIZE). Page numbers
+             are real links (native pointer / open-in-new-tab); Prev/Next stay
+             buttons for their disabled states. -->
         <div
           class="mt-4 flex flex-col gap-3 text-sm text-ink-muted sm:flex-row sm:items-center sm:justify-between"
         >
           <span data-testid="pager-status">
-            {$t('Page {page} of {pages}', { page: data.filters.page, pages: totalPages })} ·
-            {$t('{total} requests', { total: data.requests.total })}
+            {$t('Page {page} of {pages}', { page: data.filters.page, pages: totalPages })}
           </span>
 
           <nav class="flex items-center gap-1" aria-label={$t('Pagination')}>

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -225,10 +225,9 @@ describe('key detail page', () => {
         requests: { items: [requestItem('tr_1')], total: 60, page: 1, pageSize: 25 },
       }),
     });
-    // 60 / 25 → 3 pages. Status line mirrors the requests list: "Page X of Y · N requests".
+    // 60 / 25 → 3 pages. Status line mirrors the requests list: "Page X of Y".
     const status = screen.getByTestId('pager-status');
     expect(status.textContent).toMatch(/Page\s*1\s*of\s*3/);
-    expect(status.textContent).toMatch(/60/);
 
     // Page numbers are real <a> links carrying the page in the querystring (native
     // pointer / open-in-new-tab), not plain buttons like the old pager.
@@ -252,5 +251,17 @@ describe('key detail page', () => {
       }),
     });
     expect(screen.queryByTestId('pager-status')).not.toBeInTheDocument();
+  });
+
+  it('preserves a non-default range in the page-number links', () => {
+    render(KeyDetailPage, {
+      data: pageData({
+        filters: { range: '7d', page: 1 } as KeyDetailFilters,
+        requests: { items: [requestItem('tr_1')], total: 60, page: 1, pageSize: 25 },
+      }),
+    });
+    // The href must carry the active range so the window survives navigation —
+    // the behaviour unique to this pager vs the requests list pager.
+    expect(screen.getByRole('link', { name: '2' })).toHaveAttribute('href', '?range=7d&page=2');
   });
 });


### PR DESCRIPTION
Follow-up to #324 (squash-merged at the pager commit only — these self-review fixes didn't make it in). Rebased onto current `main`.

## What

- **Count contradiction (real, ≥1000 requests):** the Requests section header shows the window total via `formatCount` (`1.2K`), while the new pager status printed the *raw* total (`1234`) — contradictory and redundant. The pager status now shows **`Page X of Y`** only; the count stays in the header.
- **Divide-by-zero parity (defensive):** `totalPages` now divides by `Math.max(1, pageSize)`, matching the requests-list pager. Not reachable today (the loader pins `DETAIL_PAGE_SIZE = 25`), but keeps the two pagers identical.
- **Dead i18n key:** removed the now-orphaned `Prev` key from all 5 locales (the pager switched to `Previous` in #324; it had no other consumer).
- **Test:** pins that page-number links preserve a non-default range in the URL — the one behaviour unique to this pager vs the requests list.

## Not reachable (a finding I dismissed)

A review pass flagged a stale `?page=99` deep-link rendering "Page 99 of 3" with a lost current-page marker. It can't happen: the pager is nested inside the `items.length === 0` empty-state branch, and an out-of-range page returns empty `items`, so the pager only renders when `page ≤ totalPages`.

## Verification

typecheck/svelte-check ✅ (0 errors / 0 warnings) · biome ✅ · **10/10** admin tests ✅ · all 5 locales valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)