### PR TITLE
fix(admin): show "Manage memory" link on key detail even when memory is off

### DIFF
--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -255,13 +255,17 @@
             {#if key.memory_project_id}
               · {key.memory_project_id}
             {/if}
-            <!-- Jump to this key's memory (its account + default project scope) so an
-                 operator can browse/curate the facts & reflections it has learned. -->
-            <a
-              class="link-inline ml-1"
-              href={`${base}/memory?key=${encodeURIComponent(data.keyId)}`}>{$t('Manage memory')} →</a
-            >
           {/if}
+          <!-- Jump to this key's memory (its account + default project scope) so an
+               operator can browse/curate the facts & reflections it has learned. Shown
+               even when memory is OFF: switching observe off doesn't erase what the key
+               already learned, and the memory page resolves the scope from the key's
+               config (account + memory_project_id) regardless of mode — without this a
+               switched-off key has no path to its accumulated memory. -->
+          <a
+            class="link-inline ml-1"
+            href={`${base}/memory?key=${encodeURIComponent(data.keyId)}`}>{$t('Manage memory')} →</a
+          >
         </dd>
       </div>
     </dl>

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -205,7 +205,7 @@ describe('key detail page', () => {
     expect(link.getAttribute('href')).toBe('/requests/tr_1');
   });
 
-  it('links the Memory config to the scoped memory view when memory is on; omits it when off', () => {
+  it('always links the Memory config to the scoped memory view — even when memory is off', () => {
     const { unmount } = render(KeyDetailPage, {
       data: pageData({ key: keyView({ memory_mode: 'inject', memory_project_id: 'proj-a' }) }),
     });
@@ -214,9 +214,17 @@ describe('key detail page', () => {
     expect(link.getAttribute('href')).toBe('/memory?key=k1');
     unmount();
 
-    // Memory off → nothing to manage → no link.
-    render(KeyDetailPage, { data: pageData({ key: keyView({ memory_mode: 'off' }) }) });
-    expect(screen.queryByRole('link', { name: /manage memory/i })).not.toBeInTheDocument();
+    // Memory off does NOT mean "nothing to manage": switching observe off doesn't
+    // erase what the key already learned, and the memory page resolves the scope
+    // from the key's config (account + memory_project_id) regardless of mode. So
+    // the link MUST stay — otherwise a switched-off key with prior memory has no
+    // path to it. This is the fix.
+    render(KeyDetailPage, {
+      data: pageData({ key: keyView({ memory_mode: 'off', memory_project_id: 'lukin-personal' }) }),
+    });
+    expect(screen.getByRole('link', { name: /manage memory/i }).getAttribute('href')).toBe(
+      '/memory?key=k1',
+    );
   });
 
   it('renders a requests-style pager (numbered links + status) across pages', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

On the key detail page (`/admin/keys/{id}`), the **Manage memory →** link was rendered only inside `{#if key.memory_mode !== 'off'}`. A key with `memory_mode: off` showed no link at all — even when it still has accumulated facts/reflections under its `memory_project_id`.

This is exactly the case for a real key (`helm_live_KOGN`: `memory_mode: off`, `memory_project_id: lukin-personal`): memory was switched off but the project scope still holds learned facts/reflections, and there was **no way to reach them from the key page**. Reported repeatedly; prior passes kept the gate (and a test even codified `"off → no link"`).

## Fix

Move the link out of the conditional so it **always** renders. This is correct because:

- Turning observe off doesn't erase what the key already learned.
- The memory page resolves a key's scope from its **config** — `GET /admin/api/memory/by-key/:keyId` returns `account_id` + `memory_project_id` with **no `memory_mode` check** — so `/memory?key=<id>` lands on the right scope regardless of mode.

Flipped the `key-detail.test.ts` assertion that had cemented the wrong behavior.

## Verification

- `key-detail.test.ts` red → green
- Full admin suite: 460/460
- Biome (`pnpm lint`) + svelte-check: clean
- i18n key `Manage memory` already present in all 5 locales (no English fallback)

Bundles the `chore(release): v0.21.5` bump so the merge cuts the release. **No deploy in this PR** — running instances stay on 0.21.4 until a separate deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)