### PR TITLE
fix(memory): facts never persisted (bare-array LLM output) + Gemini passthrough inject + resurrect re-scope

### DIFF
--- a/apps/gateway/src/memory-llm.test.ts
+++ b/apps/gateway/src/memory-llm.test.ts
@@ -381,6 +381,36 @@ describe("createMemoryLlmRuntime", () => {
     expect(facts[0]?.factText).toBe("Project Alpha invoices require PO #123.");
   });
 
+  it("accepts a BARE ARRAY fact response (deepseek shape, no {facts:[]} envelope)", async () => {
+    const { runtime } = runtimeArgs({
+      // deepseek-v4-flash returns the facts as a top-level array, NOT {facts:[...]}.
+      response: [
+        {
+          subject_text: "Project Alpha",
+          fact_text: "Project Alpha invoices require PO #123.",
+          valid_from_observation_id: "obs-1",
+        },
+      ],
+      resolveAlias: "openai/facts",
+    });
+    const obsAt = new Date("2026-06-01T00:00:00Z");
+
+    const facts = await runtime.extractFacts({
+      observations: [observation("obs-1", "Project Alpha invoices require PO #123.", obsAt)],
+      previousReflection: null,
+      now: new Date("2026-06-09T00:00:00Z"),
+    });
+
+    expect(facts).toEqual([
+      {
+        subjectText: "Project Alpha",
+        factText: "Project Alpha invoices require PO #123.",
+        validFrom: obsAt,
+        sourceObservationRange: ["obs-1", "obs-1"],
+      },
+    ]);
+  });
+
   // Salient-fact fast path (salient-fact-memory-spec Change A): extract atomic
   // facts from RAW turns, decoupled from compaction. Unlike the observation-based
   // extractor, there is NO deterministic fallback — without an LLM there are no
@@ -441,6 +471,30 @@ describe("createMemoryLlmRuntime", () => {
         messages: Array<{ content: string }>;
       };
       expect(JSON.stringify(body.messages)).toContain("我喜欢的数字是42");
+    });
+
+    it("accepts a BARE ARRAY response (deepseek shape) instead of {facts:[...]}", async () => {
+      const { runtime } = runtimeArgs({
+        // The real failure on prod: deepseek-v4-flash returns a top-level array, so the
+        // {facts:[...]} schema rejected it and the empty fallback silently dropped the fact.
+        response: [
+          { subject_text: "favorite color", fact_text: "The user's favorite color is green." },
+        ],
+        resolveAlias: "openai/facts",
+      });
+
+      const facts = await runtime.extractFactsFromMessages({
+        messages: [rawMessage("m1", "user", "记住：我最喜欢的颜色是绿色")],
+        now: NOW,
+      });
+
+      expect(facts).toEqual([
+        {
+          subjectText: "favorite color",
+          factText: "The user's favorite color is green.",
+          validFrom: NOW,
+        },
+      ]);
     });
 
     it("returns [] (fail-open) on invalid JSON", async () => {

--- a/apps/gateway/src/memory-llm.ts
+++ b/apps/gateway/src/memory-llm.ts
@@ -23,9 +23,21 @@ const FactOutputSchema = z.object({
   valid_from_observation_id: z.string().trim().min(1),
 });
 
-const FactsOutputSchema = z.object({
-  facts: z.array(FactOutputSchema).default([]),
-});
+// Some memory models (observed in prod: deepseek-v4-flash) ignore the {facts:[...]}
+// envelope and return a BARE ARRAY of fact objects. Coerce that into the envelope
+// BEFORE validation so a correct-but-unwrapped response is never silently dropped to
+// the empty fallback — the exact failure mode that made eager facts never persist
+// (the schema rejected the array, callJsonModel fell back to {facts:[]}). Mirrors the
+// project's tolerant-passthrough rule: accept + normalize a valid response, never reject
+// on shape alone.
+function coerceFactsEnvelope(value: unknown): unknown {
+  return Array.isArray(value) ? { facts: value } : value;
+}
+
+const FactsOutputSchema = z.preprocess(
+  coerceFactsEnvelope,
+  z.object({ facts: z.array(FactOutputSchema).default([]) }),
+);
 
 // Salient-fact fast path (Change A): facts extracted from RAW turns have no
 // supporting observation to cite, so the output is just {subject_text, fact_text}.
@@ -33,9 +45,10 @@ const RawFactOutputSchema = z.object({
   subject_text: z.string().trim().min(1),
   fact_text: z.string().trim().min(1),
 });
-const RawFactsOutputSchema = z.object({
-  facts: z.array(RawFactOutputSchema).default([]),
-});
+const RawFactsOutputSchema = z.preprocess(
+  coerceFactsEnvelope,
+  z.object({ facts: z.array(RawFactOutputSchema).default([]) }),
+);
 
 type ObservationOutput = z.infer<typeof ObservationOutputSchema>;
 type ReflectionOutput = z.infer<typeof ReflectionOutputSchema>;
@@ -139,9 +152,19 @@ function parseJsonObject(text: string): unknown {
   try {
     return JSON.parse(candidate);
   } catch (err) {
-    const start = candidate.indexOf("{");
-    const end = candidate.lastIndexOf("}");
-    if (start >= 0 && end > start) return JSON.parse(candidate.slice(start, end + 1));
+    // Salvage the first balanced JSON value out of noisy prose — an object {...} OR a
+    // bare array [...] (some models wrap a top-level array in explanatory text). Prefer
+    // whichever delimiter opens first so "[...] note: {...}" salvages the array.
+    const objStart = candidate.indexOf("{");
+    const objEnd = candidate.lastIndexOf("}");
+    const arrStart = candidate.indexOf("[");
+    const arrEnd = candidate.lastIndexOf("]");
+    const objOk = objStart >= 0 && objEnd > objStart;
+    const arrOk = arrStart >= 0 && arrEnd > arrStart;
+    if (objOk && (!arrOk || objStart < arrStart)) {
+      return JSON.parse(candidate.slice(objStart, objEnd + 1));
+    }
+    if (arrOk) return JSON.parse(candidate.slice(arrStart, arrEnd + 1));
     throw err;
   }
 }

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -35,6 +35,7 @@ import { copyLiteLLMRequestParams, providerRawFromRequest } from "./internal-req
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
 import {
   appendMemoryToAnthropicBody,
+  appendMemoryToGeminiBody,
   appendMemoryToResponsesBody,
 } from "./native-memory-inject.js";
 import {
@@ -737,6 +738,11 @@ export function createMessagesPipeline(
               : body;
           } else if (protocol === "openai_responses") {
             const body = appendMemoryToResponsesBody(nativeBody, injected.memoryBlock);
+            internal.native_request = isNativePassthroughCarrier(internal.native_request)
+              ? cloneCarrierWithBody(internal.native_request, body)
+              : body;
+          } else if (protocol === "gemini") {
+            const body = appendMemoryToGeminiBody(nativeBody, injected.memoryBlock);
             internal.native_request = isNativePassthroughCarrier(internal.native_request)
               ? cloneCarrierWithBody(internal.native_request, body)
               : body;

--- a/apps/gateway/src/routes/native-memory-inject.test.ts
+++ b/apps/gateway/src/routes/native-memory-inject.test.ts
@@ -2,6 +2,7 @@ import { wrapMemoryReminder } from "@helm/core";
 import { describe, expect, it } from "vitest";
 import {
   appendMemoryToAnthropicBody,
+  appendMemoryToGeminiBody,
   appendMemoryToResponsesBody,
 } from "./native-memory-inject.js";
 
@@ -156,5 +157,46 @@ describe("appendMemoryToResponsesBody", () => {
     expect(input[1]).toBe(fnCall);
     expect(input[2]).toBe(fnOut);
     expect(input[3]).toEqual({ role: "user", content: REMINDER });
+  });
+});
+
+describe("appendMemoryToGeminiBody", () => {
+  it("appends a trailing reminder turn on `contents` and keeps `systemInstruction` VERBATIM", () => {
+    const systemInstruction = { parts: [{ text: "be terse" }] };
+    const userTurn = { role: "user", parts: [{ text: "hi" }] };
+    const body = { systemInstruction, contents: [userTurn] };
+    const out = appendMemoryToGeminiBody(body, MEMORY);
+    // systemInstruction (the Gemini system-equivalent) is forwarded UNCHANGED (same ref).
+    expect(out.systemInstruction).toBe(systemInstruction);
+    // Memory rides ONE trailing user turn AFTER the conversation.
+    expect(out.contents).toEqual([
+      { role: "user", parts: [{ text: "hi" }] },
+      { role: "user", parts: [{ text: REMINDER }] },
+    ]);
+    // The existing turn is kept by reference, in order.
+    expect((out.contents as unknown[])[0]).toBe(userTurn);
+    // A NEW body + NEW contents array — the input is never mutated.
+    expect(out).not.toBe(body);
+    expect(out.contents).not.toBe(body.contents);
+    expect(body.contents).toHaveLength(1);
+  });
+
+  it("appends the reminder turn even when `contents` is absent (lone turn)", () => {
+    const body = { systemInstruction: { parts: [{ text: "be terse" }] } };
+    const out = appendMemoryToGeminiBody(body, MEMORY);
+    expect(out.contents).toEqual([{ role: "user", parts: [{ text: REMINDER }] }]);
+    expect(out.systemInstruction).toBe(body.systemInstruction);
+  });
+
+  it("preserves model/function turns VERBATIM (additive trailing turn only)", () => {
+    const modelTurn = {
+      role: "model",
+      parts: [{ functionCall: { name: "search", args: { q: "x" } } }],
+    };
+    const body = { contents: [{ role: "user", parts: [{ text: "hi" }] }, modelTurn] };
+    const out = appendMemoryToGeminiBody(body, MEMORY);
+    const contents = out.contents as unknown[];
+    expect(contents[1]).toBe(modelTurn);
+    expect(contents[2]).toEqual({ role: "user", parts: [{ text: REMINDER }] });
   });
 });

--- a/apps/gateway/src/routes/native-memory-inject.ts
+++ b/apps/gateway/src/routes/native-memory-inject.ts
@@ -51,3 +51,16 @@ export function appendMemoryToResponsesBody(body: Body, memoryBlock: string): Bo
   }
   return { ...body, input: reminderText };
 }
+
+// Gemini: append the memory reminder as a trailing `{ role:"user", parts:[{text}] }`
+// turn on `contents` (the protocol-native conversation field — sibling of the
+// system-equivalent `systemInstruction`, which is kept VERBATIM). Every existing turn
+// rides through by reference; when `contents` is absent the reminder becomes the lone
+// turn. Returns a NEW body — the input is never mutated. Mirrors the Anthropic helper
+// (trailing user turn, system-level field untouched) so memory rides AFTER the cached
+// prefix on the Gemini native-passthrough path too.
+export function appendMemoryToGeminiBody(body: Body, memoryBlock: string): Body {
+  const reminder = { role: "user", parts: [{ text: wrapMemoryReminder(memoryBlock) }] };
+  const contents = Array.isArray(body.contents) ? body.contents : [];
+  return { ...body, contents: [...contents, reminder] };
+}

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-06-20 · eager/reflector 事实抽取被严格 schema 静默吞掉（deepseek 返回裸数组）（docs/salient-fact-memory-spec；docs/08/12；原则 2/3）
+
+- **背景/线上实证**：用户在 Mimi（`/v1/responses`，project `agentcrew-test`）说「记住：我最喜欢的颜色是绿色」后跨 session 召不回。线上探针（手动入队 observer job + tail 日志）抓到 `memory.llm.fallback task:facts error: ZodError: expected object, received array`。根因：`deepseek-v4-flash` 做事实抽取时**输出形状不确定**（temperature:0 仍时而 `{facts:[...]}`、时而**裸数组** `[...]`）；`RawFactsOutputSchema`/`FactsOutputSchema` 只认对象信封 → `callJsonModel` 的 `schema.parse` 抛 → catch **静默回退** `{facts:[]}` → eager（`observer.ts:337`）/reflector（`reflector.ts:206`）拿 0 条、`observer.ts:40/43` 无日志静默退出 → fact **永不落库**。reflection 能工作是因为其回退是非空确定性文本；fact 回退是空数组故全程隐形。直接 curl deepseek 实证：单条消息返 `{facts:[{subject_text,fact_text}]}`（对象、键正确），多消息上下文时返裸数组——故 06-16 偶尔成功、颜色测试偶尔失败。
+- **决定（事实信封容错，tolerant passthrough）**：镜像项目既有原则（codex role/effort 那条「accept+coerce，never reject on shape」）。新增 `coerceFactsEnvelope`：顶层是数组则包成 `{facts:array}` 再校验；`FactsOutputSchema`/`RawFactsOutputSchema` 改 `z.preprocess(coerceFactsEnvelope, z.object{…})`。内层键 `subject_text`/`fact_text` 经 curl 确认匹配，无需键别名。附带 `parseJsonObject` 增**裸数组打捞**（noisy prose 包顶层数组时，择先开的定界符 `{` / `[`）。**无 schema 改/无迁移** → box 配置仍有效。
+- **验证**：TDD 红（裸数组→`[]`）→绿；`memory-llm.test.ts` 2 新例（eager + reflector 裸数组形状）、memory-llm 18 + `packages/core/src/memory` 247 测绿、typecheck（4 项目）/biome lint 清。分支 `worktree-fix-archived-reflection-delete`（与归档删除同分支），未提交/未部署。**部署后**短个人陈述即可 eager 落库为 project fact、下个 session 注入（前提：box 已置 `eager_facts:true` + `memory.llm.enabled:true`，本次已配）。
+- **同 PR 另带两修（同次排查发现）**：① **Gemini 原生直通不注入记忆**——`messages-pipeline.ts` 的 splice 只有 `anthropic_messages`/`openai_responses` 分支，缺 `gemini`，故 Gemini passthrough 算了记忆却丢弃。新增 `appendMemoryToGeminiBody`（尾随 `contents[]` user 轮、`systemInstruction` 逐字）+ gemini 分支；native-memory-inject 3 新例。② **fact 复活不刷新 scope**——`(owner_id,content_hash)` UNIQUE 是账号全局，故跨 project 重述同一 fact 命中旧行后 `reactivate` 只改 status/时间戳、**保留旧 scope**→新 project 的 inject 读不到。sqlite+pg 双适配器 `reactivate` UPDATE 增 `project_id/resource_id/thread_id`（以重述 scope 为准），sqlite+pg 各 1 新例（跨 project 复活后 p2 可见、p1 不可见）。
+
 ## 2026-06-20 · 已归档 reflection 无法删除（两段式 soft→hard delete）（docs/13；原则 1）
 
 - **背景/线上实证**：用户在 admin Memory 页删除一条 reflection 后它变 `已归档`（status='archived'；列表用 `status:'all'` 仍显示该行且带「删除」按钮），**再点删除即 `reflection not found` 报错、永远删不掉**。根因：`deleteReflection` 是纯软删——按 id 查出 scope 后 `UPDATE … SET status='archived' WHERE scope AND status='active'`，对已归档行 0 命中→返回 false→route 404 `reflection not found`。docs/13 原设计 reflection 只有软删（无 hard delete），故一旦归档便无任何途径移除=「卡死的归档行」。
@@ -22,18 +29,13 @@
 - **Codex review 修的 2 个 P2**：①**唤醒早于 outbound observe**：`onTaskDrain` 原对**每个** task 触发——若上游响应 >`coalesceMs`，inbound observe 落库就 wake → drain 把 observer job 按**仅 inbound** 标 done，outbound（助手/工具轮）不再补 job → 该轮要等 60s/idle backstop 才被吸收。改：`enqueueTask(task, {wakeOnSettle})` 仅对**标记**的 task 触发 `onTaskDrain`；`runObserve(task, wake=true)`，**inbound 传 false**（每路由 1 处），outbound 默认 wake → worker 仅在整轮落库后唤醒。②**stop() 后 wake() 仍 arm timer**：优雅关停**先 stop worker 再 drain 写队列**，残留 task 仍回调 onTaskDrain→wake() 可能在 store 关闭后 `claimPendingJobs`。改：scheduler 加 `stopped` 闩，`stop()` 置位、`wake()` 早返回。
 - **验证**：TDD 红→绿，scheduler 8 新测（防抖/突发合并/wake 不跑 onTick/fail-open/stop 取消/interval backstop/**stop 后 wake no-op**）+ write-queue 2 新测（onTaskDrain 仅 wakeOnSettle 触发/抛错不污染链）；memory+gateway runtime+routes **948 测**绿、typecheck（4 项目）/lint(0/0)/build 清。分支 `feat/memory-worker-debounced-wake`，PR #332。
 
-## 2026-06-20 · 删除的 fact 可被重新学习（resurrect-on-re-ingest）（docs/12/13；原则 1/3）
-
-- **背景/线上实证**：用户在 admin Memory 页删除 fact 后发现「再也不会被记录」。根因：`deleteFact` 软删=`status='pruned'`+盖 `expired_at` 但**保留 content_hash**；`insertFactsReconciled` 用 `INSERT OR IGNORE` 撞 `idx_memory_facts_hash = UNIQUE(owner_id, content_hash)`（**无 status 过滤**），故 Reflector `temperature:0` 重抽出**逐字相同**的 fact（同 sha256）→ `changes===0` → 静默跳过、永不复活=**永久压制**。box DB 实证：19 条 pruned 全保留 content_hash、最新一条 254s 前=用户刚删的；更糟——被删的若是 superseded 过旧版的活体，旧版仍盖着 `expired_at`→该 subject 永久空且无法自愈（实证：8 条 active 全 superseded + 19 pruned = 0 真活体）。
-- **决定（用户在 4 选项里选 resurrect-on-re-ingest）**：dedup 命中时查现有行，若 `status IN (pruned, archived)` 则**就地复活**（status=active、清 expired_at/invalid_at、valid_from=新观测时刻、updated_at=now）并跑 supersede（视为该 subject 的新活体）；活体重复（active + expired_at IS NULL）仍是幂等 no-op。保留软删审计（**不**改成 hard delete）。`status='active'+expired_at NOT NULL`（被 supersede）刻意不复活——属正常生命周期非删除。
-- **实现**：`MemoryFactReconcileResult` 加**可选** `resurrectedIds?`（向后兼容旧 fake）；sqlite（`selectByHash`+`reactivate` prepared stmt 走 else 分支）+ pg（`ON CONFLICT DO NOTHING` 后 SELECT/UPDATE）双适配器镜像；reflector 日志加 inserted/resurrected/superseded 计数；MCP `handleAdd` 报 `resurrected` 且复活时 `deduped:false`。**无 schema 改/无迁移**（纯逻辑、复用既有列）→ box 配置仍有效、fail-close gate N/A。
-- **验证**：TDD 红→绿，sqlite 3 + pg 3 + MCP 1 新测（复活/复活再 supersede/活体不复活/MCP 重加复活）；memory+store+mcp+reflector **650 测**绿、typecheck（4 项目）/lint 清。分支 `fix/memory-fact-resurrect-on-reingest`。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-20 · 删除的 fact 可被重新学习（resurrect-on-re-ingest）（docs/12/13；原则 1/3）：`deleteFact` 软删=`status='pruned'`+盖 `expired_at` 但保留 content_hash；`insertFactsReconciled` 的 `INSERT OR IGNORE` 撞 `UNIQUE(owner_id,content_hash)`（无 status 过滤）→ Reflector 重抽逐字相同 fact `changes===0` 静默跳过=永久压制。修：dedup 命中查现有行，`status IN (pruned,archived)` 则就地复活（active、清 expired_at/invalid_at、valid_from=新观测、跑 supersede）；活体重复仍幂等 no-op；保留软删审计。`MemoryFactReconcileResult` 加 optional `resurrectedIds`，sqlite+pg 双适配器，MCP `handleAdd` 报 resurrected。sqlite 3+pg 3+MCP 1 新测、650 绿。PR #329。（本次 2026-06-20 续修在最上方那条：复活时**刷新 scope 列**——账号全局 hash 跨 project 重述会复活旧 scope 行致 inject 读不到。）
 
 ### 2026-06-19 · 设置页清理动作确认弹窗 + 五卡布局重组（admin「System Settings」；原则 1）：上一条「自动数据清理」的 Clean now / Compact database 两按钮单击即执行（删数据/VACUUM 锁库）无确认 → 复用全站 `Modal` 确认模式（confirmingClean/confirmingVacuum $state，触发改置 flag、弹窗确认才真跑、执行中 `dismissible=false`，保留 testid 故 e2e 不破）；并把杂物卡「Operations」拆成**五卡**（Routing/Rate limiting/Request queueing/Logging/Data retention & cleanup，按请求生命周期排序，binding/testid/文案逐字不变）。坑：i18n 7 新 key 经 `i18n:sync` 中继译，`i18n:extract` 首跑赶在落盘前→0 新 key 重跑即正常。svelte-check 0/0、手测 Playwright 五卡顺序+确认流程绿。分支 `worktree-settings-confirm-and-layout`，未部署。
 

--- a/packages/core/src/store/postgres/memory-facts.test.ts
+++ b/packages/core/src/store/postgres/memory-facts.test.ts
@@ -300,6 +300,52 @@ describe("PgMemoryStore.insertFactsReconciled (resurrect deleted fact on re-inge
     expect(active[0]?.validFrom).toEqual(v2);
   });
 
+  it("RE-SCOPES the resurrected row to the re-ingest scope (account-global hash, new project wins)", async () => {
+    const now = new Date("2026-06-05T00:00:00.000Z");
+    const { store } = await newStore(now);
+    const v1 = new Date("2026-05-01T00:00:00.000Z");
+    const v2 = new Date("2026-06-04T00:00:00.000Z");
+
+    const first = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: { projectId: "p1" },
+      now,
+      facts: [
+        fact({
+          ownerId: "acct-a",
+          subjectKey: "fav-color",
+          contentHash: "h1",
+          validFrom: v1,
+          projectId: "p1",
+        }),
+      ],
+    });
+    const id = first.insertedIds[0] as string;
+    await store.deleteFact({ accountId: "acct-a", id, now });
+
+    // Re-stated under a DIFFERENT project p2 — same content_hash dedup-hits the old
+    // (account-global) row; without re-scoping it would revive under p1 and a p2 inject
+    // would never see it.
+    const again = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: { projectId: "p2" },
+      now,
+      facts: [
+        fact({
+          ownerId: "acct-a",
+          subjectKey: "fav-color",
+          contentHash: "h1",
+          validFrom: v2,
+          projectId: "p2",
+        }),
+      ],
+    });
+    expect(again.resurrectedIds).toEqual([id]);
+
+    expect(await store.listActiveFacts({ accountId: "acct-a", projectId: "p2" })).toHaveLength(1);
+    expect(await store.listActiveFacts({ accountId: "acct-a", projectId: "p1" })).toHaveLength(0);
+  });
+
   it("a resurrected fact supersedes an older still-active same-subject sibling", async () => {
     const now = new Date("2026-06-05T00:00:00.000Z");
     const { store } = await newStore(now);

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -840,10 +840,17 @@ export class PgMemoryStore implements MemoryStore {
             existing !== undefined &&
             (existing.status === "pruned" || existing.status === "archived")
           ) {
+            // Re-scope on resurrect (Codex review fix; sqlite mirror): the
+            // (owner_id, content_hash) index is ACCOUNT-GLOBAL, so a fact re-stated under
+            // a different project/resource/thread dedup-hits the old row. Reactivating
+            // without re-scoping would revive it at the STALE scope and the scoped inject
+            // read would never surface it. The re-ingest's scope is authoritative, so
+            // overwrite the scope columns too (same-scope re-statement = no-op rewrite).
             await tx.execute(sql`
             UPDATE memory_facts
                SET status = 'active', expired_at = NULL, invalid_at = NULL,
-                   valid_from = ${validFromMs}, updated_at = ${nowMs}
+                   valid_from = ${validFromMs}, updated_at = ${nowMs},
+                   project_id = ${projectId}, resource_id = ${resourceId}, thread_id = ${threadId}
              WHERE id = ${existing.id}
           `);
             resurrectedIds.push(existing.id);

--- a/packages/core/src/store/sqlite/memory-facts.test.ts
+++ b/packages/core/src/store/sqlite/memory-facts.test.ts
@@ -400,6 +400,54 @@ describe("SqliteMemoryStore.insertFactsReconciled (resurrect deleted fact on re-
     expect(raw?.valid_from).toBe(v2.getTime());
   });
 
+  it("RE-SCOPES the resurrected row to the re-ingest scope (account-global hash, new project wins)", async () => {
+    const now = new Date("2026-06-05T00:00:00.000Z");
+    const { store } = newStore(now);
+    const v1 = new Date("2026-05-01T00:00:00.000Z");
+    const v2 = new Date("2026-06-04T00:00:00.000Z");
+
+    // Stated + stored under project p1.
+    const first = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: { projectId: "p1" },
+      now,
+      facts: [
+        fact({
+          ownerId: "acct-a",
+          subjectKey: "fav-color",
+          contentHash: "h1",
+          validFrom: v1,
+          projectId: "p1",
+        }),
+      ],
+    });
+    const id = first.insertedIds[0] as string;
+    await store.deleteFact({ accountId: "acct-a", id, now });
+
+    // Re-stated under a DIFFERENT project p2 — same content_hash dedup-hits the old
+    // (account-global) row, so it resurrects. Without re-scoping it would revive under
+    // p1 and a p2 inject would never see it.
+    const again = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: { projectId: "p2" },
+      now,
+      facts: [
+        fact({
+          ownerId: "acct-a",
+          subjectKey: "fav-color",
+          contentHash: "h1",
+          validFrom: v2,
+          projectId: "p2",
+        }),
+      ],
+    });
+    expect(again.resurrectedIds).toEqual([id]);
+
+    // The resurrected row now lives under p2 (visible to a p2 read), NOT p1.
+    expect(await store.listActiveFacts({ accountId: "acct-a", projectId: "p2" })).toHaveLength(1);
+    expect(await store.listActiveFacts({ accountId: "acct-a", projectId: "p1" })).toHaveLength(0);
+  });
+
   it("a resurrected fact supersedes an older still-active same-subject sibling", async () => {
     const now = new Date("2026-06-05T00:00:00.000Z");
     const { store } = newStore(now);

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -857,9 +857,17 @@ export class SqliteMemoryStore implements MemoryStore {
     const selectByHash = this.db.$sqlite.prepare(
       `SELECT id, status FROM memory_facts WHERE owner_id = ? AND content_hash = ?`,
     );
+    // Re-scope on resurrect (Codex review fix): the (owner_id, content_hash) unique
+    // index is ACCOUNT-GLOBAL, so a fact re-stated under a DIFFERENT project/resource/
+    // thread dedup-hits the old row. Reactivating without re-scoping would revive it at
+    // the STALE scope, and the inject read (scoped by project/resource/thread) would
+    // never surface it — the fact "comes back" but stays invisible. The re-ingest's
+    // scope is authoritative for where the fact should now live, so overwrite the scope
+    // columns too. Same-scope re-statement (the common case) is a no-op rewrite.
     const reactivate = this.db.$sqlite.prepare(
       `UPDATE memory_facts
-          SET status = 'active', expired_at = NULL, invalid_at = NULL, valid_from = ?, updated_at = ?
+          SET status = 'active', expired_at = NULL, invalid_at = NULL, valid_from = ?, updated_at = ?,
+              project_id = ?, resource_id = ?, thread_id = ?
         WHERE id = ?`,
     );
     // The whole batch is atomic: a partial ingest must not leave a fact inserted
@@ -938,7 +946,14 @@ export class SqliteMemoryStore implements MemoryStore {
             existing !== undefined &&
             (existing.status === "pruned" || existing.status === "archived")
           ) {
-            reactivate.run(f.validFrom.getTime(), nowMs, existing.id);
+            reactivate.run(
+              f.validFrom.getTime(),
+              nowMs,
+              projectId,
+              resourceId,
+              threadId,
+              existing.id,
+            );
             resurrectedIds.push(existing.id);
             // The resurrected row is now the subject's live fact — supersede older
             // same-subject siblings exactly as a fresh insert would (id <> its own).


### PR DESCRIPTION
## Why

Debugging **"Mimi never remembers personal facts"** on prod (`/v1/responses`, project `agentcrew-test`) surfaced the real blocker plus two more memory-correctness bugs. Root cause was captured live: `memory.llm.fallback task:facts error: ZodError: expected object, received array`.

## Fixes (all TDD: red → green)

**1. Facts silently never persisted (THE blocker).** `deepseek-v4-flash` returns the fact-extraction JSON as a top-level **bare array** (non-deterministic at `temperature:0` — confirmed by direct API call: object for one message, array for multi-message context). The strict `{facts:[...]}` schema rejected it → `callJsonModel` fell back to empty `{facts:[]}` → eager + reflector extraction produced 0 facts with no visible error (reflection works only because its fallback is non-empty text). Fix: `coerceFactsEnvelope` via `z.preprocess` on both fact schemas + bare-array salvage in `parseJsonObject`. Tolerant-passthrough principle (accept+coerce model output, never reject on shape).

**2. Gemini native passthrough never injected memory.** The pipeline splice had `anthropic_messages` + `openai_responses` branches but no `gemini` — assembled memory was computed then dropped. Added `appendMemoryToGeminiBody` (trailing `contents[]` user turn, `systemInstruction` verbatim) + the branch.

**3. Resurrected facts kept their stale scope.** `(owner_id, content_hash)` is account-global, so re-stating a deleted fact under a new project dedup-hits the old row; `reactivate` refreshed status/timestamps but not `project_id/resource_id/thread_id` → the fact "came back" but the scoped inject read never saw it. Re-scope on resurrect in sqlite + pg.

## Tests

- `memory-llm.test.ts`: bare-array shape for eager + reflector paths (×2)
- `native-memory-inject.test.ts`: Gemini trailing-turn / verbatim systemInstruction (×3)
- sqlite + pg `memory-facts.test.ts`: resurrect re-scopes to new project (×2)
- typecheck (4 projects) + biome lint clean; affected memory suites green.

## Notes

No schema change / no migration. Rebased onto `main` (the archived-reflection-delete fix is already on main via #331). Box prod config already set this session: `eager_facts:true`, `memory.llm.enabled:true`, `forgetting.score.half_life_s:2592000`. Codex review: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)