### PR TITLE
chore(release): v0.21.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.6.

Bundles the memory-correctness fixes merged in #335:
- facts never persisted when deepseek returns a bare-array fact response (tolerant schema coercion)
- Gemini native passthrough now injects memory
- resurrected facts re-scope to the re-ingest scope

Version bump only; publish.yml cuts the tag + GitHub Release + `:0.21.6` / `:latest` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)