### PR TITLE
chore(release): v0.21.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.7 — ships the eager-fact `this`-binding fix from #337.

Fixes the production "Cannot read properties of undefined (reading 'db')" that silently dropped eager-extracted facts (e.g. "记住我家猫咪叫可乐"). Version bump only; publish.yml cuts the tag + Release + `:0.21.7`/`:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)