### PR TITLE
feat(memory): reliable eager fact extraction + internal LLM calls visible in /admin/requests

### DIFF
--- a/apps/gateway/src/memory-self-http.test.ts
+++ b/apps/gateway/src/memory-self-http.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSelfHttpClient } from "./memory-self-http.js";
+
+function fakeResponse(ok: boolean, body: unknown, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe("createSelfHttpClient", () => {
+  it("POSTs to /v1/chat/completions on loopback with the internal key + x-memory-mode:off, body verbatim", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      fakeResponse(true, { choices: [{ message: { content: '{"facts":[]}' } }] }),
+    );
+    const client = createSelfHttpClient({
+      baseUrl: "http://127.0.0.1:8080",
+      apiKey: "helm_live_secret",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const req = {
+      model: "deepseek/deepseek-v4-flash",
+      messages: [{ role: "user", content: "hi" }],
+      stream: false,
+      response_format: { type: "json_object" },
+    };
+
+    const res = await client.chatCompletion(req);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:8080/v1/chat/completions");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer helm_live_secret");
+    expect(headers["x-memory-mode"]).toBe("off");
+    // body is the request VERBATIM (model/messages/response_format preserved)
+    expect(JSON.parse(init.body as string)).toEqual(req);
+    // 2xx response is returned unchanged for callJsonModel to parse
+    expect(res).toEqual({ choices: [{ message: { content: '{"facts":[]}' } }] });
+  });
+
+  it("prefixes a BARE model with providerPrefix (eval), leaves a prefixed model unchanged", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => fakeResponse(true, {}));
+    const client = createSelfHttpClient({
+      baseUrl: "http://127.0.0.1:8080",
+      apiKey: "k",
+      providerPrefix: "deepseek",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    // bare eval model → prefixed routable alias
+    await client.chatCompletion({ model: "deepseek-v4-flash", messages: [] });
+    expect(JSON.parse((fetchImpl.mock.calls[0]?.[1] as RequestInit).body as string).model).toBe(
+      "deepseek/deepseek-v4-flash",
+    );
+    // already-prefixed memory model → untouched
+    await client.chatCompletion({ model: "openrouter/deepseek-v4-pro", messages: [] });
+    expect(JSON.parse((fetchImpl.mock.calls[1]?.[1] as RequestInit).body as string).model).toBe(
+      "openrouter/deepseek-v4-pro",
+    );
+  });
+
+  it("throws on non-2xx so the caller's fail-open fallback fires", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      fakeResponse(false, { error: "boom" }, 500),
+    );
+    const client = createSelfHttpClient({
+      baseUrl: "http://127.0.0.1:8080",
+      apiKey: "k",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(client.chatCompletion({ model: "m", messages: [] })).rejects.toThrow(
+      /self-http 500/,
+    );
+  });
+
+  it("forwards the abort signal", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => fakeResponse(true, {}));
+    const client = createSelfHttpClient({
+      baseUrl: "http://127.0.0.1:8080",
+      apiKey: "k",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const ctrl = new AbortController();
+    await client.chatCompletion({ model: "m", messages: [] }, { signal: ctrl.signal });
+    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+    expect(init.signal).toBe(ctrl.signal);
+  });
+});

--- a/apps/gateway/src/memory-self-http.ts
+++ b/apps/gateway/src/memory-self-http.ts
@@ -1,0 +1,66 @@
+import type { ProviderClient } from "@helm/core";
+
+// Internal self-HTTP client (observability). Internal LLM tasks (memory
+// summarize/merge/extractFacts, Layer-2 eval) normally call a ProviderClient DIRECTLY,
+// which bypasses the gateway's telemetry + request/response payload capture — so they
+// never appear in /admin/requests and the operator cannot see what was sent to the
+// upstream model. This client is a drop-in ProviderClient that instead routes the call
+// BACK THROUGH helm's own POST /v1/chat/completions over loopback, so it is recorded
+// like any real request. It is authenticated with an internal API key and always sends
+// `x-memory-mode: off` so the self-call is NEVER itself observed (no memory-on-memory
+// loop). Only `chatCompletion` is exercised (these tasks are non-streaming); the stream
+// method is a required-by-interface stub.
+
+export interface SelfHttpClientDeps {
+  // Loopback base URL, e.g. http://127.0.0.1:8080 (NOT config.server.host, which may be
+  // 0.0.0.0 and is not a connectable address).
+  baseUrl: string;
+  // Internal API key plaintext (e.g. the auto-minted internal key). Sent as a bearer.
+  apiKey: string;
+  // Optional provider prefix for BARE model ids (no "/"). The /v1 explicit-model
+  // passthrough needs a routable alias; a bare model (e.g. the Layer-2 eval model
+  // "deepseek-v4-flash", which today goes straight to providers[0]) is rewritten to
+  // `${providerPrefix}/${model}` so it routes the same way. A model that already carries
+  // a "provider/" prefix (e.g. memory's "deepseek/deepseek-v4-flash") is left unchanged.
+  providerPrefix?: string;
+  // Injectable fetch for tests; defaults to the global fetch.
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+export function createSelfHttpClient(deps: SelfHttpClientDeps): ProviderClient {
+  const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+  return {
+    async chatCompletion(req, opts) {
+      const rawModel = typeof req.model === "string" ? req.model : "";
+      const model =
+        deps.providerPrefix && rawModel.length > 0 && !rawModel.includes("/")
+          ? `${deps.providerPrefix}/${rawModel}`
+          : rawModel;
+      const body = model === rawModel ? req : { ...req, model };
+      const res = await fetchImpl(`${deps.baseUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${deps.apiKey}`,
+          // The self-call IS the memory machinery — it must never be observed or have
+          // memory injected, else it would recursively form/inject memory about itself.
+          "x-memory-mode": "off",
+        },
+        body: JSON.stringify(body),
+        ...(opts?.signal ? { signal: opts.signal } : {}),
+      });
+      if (!res.ok) {
+        // Non-2xx → throw so the caller's existing fail-open catch (callJsonModel for
+        // memory, the eval invoker for classify) degrades to its deterministic fallback
+        // exactly as a direct provider error would.
+        const body = await res.text().catch(() => "");
+        throw new Error(`self-http ${res.status}: ${body.slice(0, 200)}`);
+      }
+      return (await res.json()) as Record<string, unknown>;
+    },
+    // Required by the ProviderClient interface; internal LLM tasks are non-streaming.
+    async *chatCompletionStream() {
+      // never called for memory/eval
+    },
+  };
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -103,6 +103,7 @@ import { createApp } from "./app.js";
 import { readBuildInfo } from "./build-info.js";
 import { createJsonLogger, type Logger } from "./logging.js";
 import { createMemoryLlmRuntime, type MemoryModelResolution } from "./memory-llm.js";
+import { createSelfHttpClient } from "./memory-self-http.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { basicAuth, resolveAdminAuth, warnIfAdminUnconfigured } from "./middleware/basic-auth.js";
 import { concurrencyMiddleware, createConcurrencyGate } from "./middleware/concurrency.js";
@@ -1094,6 +1095,43 @@ export async function buildServer(
     log: (line) => logger.log("warn", "bootstrap.root_key", { line }),
   });
 
+  // Internal LLM observability (opt-in via HELM_INTERNAL_LLM_THROUGH_GATEWAY=1): route
+  // memory + Layer-2 eval LLM calls BACK THROUGH helm's own /v1 gateway so they appear in
+  // /admin/requests with full request/response payloads (otherwise they call the provider
+  // directly and are invisible). Mint a dedicated internal key (fixed id k_internal, re-
+  // minted each boot since the plaintext is unrecoverable) and hold its plaintext ONLY in-
+  // process. role:user + allow_custom_model is the minimal privilege (explicit-model
+  // passthrough); memory_mode:off prevents the self-call from being observed. Fail-open: a
+  // mint failure leaves routing OFF (direct provider calls, byte-identical to today).
+  const routeInternalThroughGateway = process.env.HELM_INTERNAL_LLM_THROUGH_GATEWAY === "1";
+  let internalApiKey: string | null = null;
+  if (routeInternalThroughGateway) {
+    try {
+      if ((await keyStore.list()).some((k) => k.key_id === "k_internal")) {
+        await keyStore.disable("k_internal");
+        await keyStore.deleteKey("k_internal");
+      }
+      const k = generateKey();
+      await keyStore.createKey({
+        keyId: "k_internal",
+        hash: k.hash,
+        prefix: k.prefix,
+        accountId: "default",
+        role: "user",
+        name: "internal-llm",
+        allowCustomModel: true,
+        memoryMode: "off",
+        memoryThreadSource: "header",
+      });
+      internalApiKey = k.plaintext;
+      logger.log("info", "internal_llm.key_minted", { key_id: "k_internal" });
+    } catch (err) {
+      logger.log("warn", "internal_llm.key_mint_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   // Provider(s): the configured upstreams (providers-multi). The PRIMARY provider
   // (providers[0]) backs the default/eval path and the Phase-0 passthrough; its
   // credential is mandatory (fail-closed). Additional providers each get their own
@@ -1450,13 +1488,28 @@ export async function buildServer(
   // balanced fail-open. The eval small-model is invoked via the same provider
   // (eval alias). Reads the CURRENT classifier config per request via the getter.
   // The catalog is injected so the eval call's usage becomes eval_usd (docs/07).
+  // Self-HTTP client for internal LLM calls (memory + Layer-2 eval) — built only when
+  // routing-through-gateway is on AND the internal key minted. providerPrefix = the
+  // primary provider name so a BARE eval model ("deepseek-v4-flash") becomes a routable
+  // explicit alias ("deepseek/deepseek-v4-flash"); memory's already-prefixed model is
+  // left unchanged. Loopback only (never config.server.host, which may be 0.0.0.0).
+  const selfHttpClient =
+    routeInternalThroughGateway && internalApiKey !== null
+      ? createSelfHttpClient({
+          baseUrl: `http://127.0.0.1:${config.server.port}`,
+          apiKey: internalApiKey,
+          providerPrefix: first.name,
+        })
+      : null;
   const classify = buildClassifyAdapter({
     getClassifierConfig: () => classifierConfig,
     lanes,
     // Live getter so an admin change to the terminal fallback lane keeps the eval
     // cascade's internal lane consistent with the real router (read per resolve).
     defaultLane: () => settings.default_lane,
-    provider,
+    // When routing internal LLM calls through the gateway, the eval model goes via the
+    // self-HTTP client (visible in /admin/requests); else straight to the primary provider.
+    provider: selfHttpClient ?? provider,
     now: () => Date.now(),
     log: (level, msg, fields) => logger.log(level as "info", msg, fields),
     momentum: { store: momentumStore },
@@ -1471,6 +1524,13 @@ export async function buildServer(
     fallbackBaseUrl,
   );
   const resolveMemoryLlmModel = (alias: string): MemoryModelResolution | null => {
+    // Observability: route memory LLM calls (summarize/merge/extractFacts) back through
+    // helm's own /v1 gateway so they appear in /admin/requests. The task's model `alias`
+    // (e.g. "deepseek/deepseek-v4-flash") is forwarded as an EXPLICIT model → the internal
+    // key's allow_custom_model passthrough skips classify/eval, so the self-call never nests.
+    if (selfHttpClient) {
+      return { client: selfHttpClient, providerModel: alias };
+    }
     const slash = alias.indexOf("/");
     const prefix = slash > 0 ? alias.slice(0, slash) : "";
     if (prefix && ROUTABLE_OAUTH_IDS.has(prefix)) {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-20 · 事实抽取可靠性 + 内部 LLM 调用走自有网关（可观测）（docs/06/08/12；原则 3/7）
+
+- **背景/线上实证**：v0.21.7 上用户说「我有一辆特斯拉 Model Y」仍偶发没记下。observer 准时跑、`memory.llm.completed task:facts` 但 0 fact。直接 curl deepseek 实证：`deepseek-v4-flash` 即使 temperature:0 也**非确定性**，对一条明确事实偶发返空（输出形状每次都变：裸数组/对象/中英文都有），且 Mimi 对话里它自己的 `MEMORY.md` 工具/文件噪音淹没了信号——线上那次恰好返空。另：调试时**所有内部 LLM 调用（记忆 + eval）都不在 /admin/requests 可见**（直接打 ProviderClient、绕过遥测/payload），只能手动 curl deepseek 排查。
+- **决定（A 可靠性）**：`maybeEagerExtractFacts` 抽取**只喂 user 消息**（滤掉 assistant/tool/文件噪音）+ **空结果重试一次**（`eager_facts_retry` 日志、至多两次；extractFactsFromMessages fail-open 永不抛，空是唯一失败信号）。reflector 路径不动（从干净 observation 抽，无噪音）。
+- **决定（B 可观测，用户选「自动生成专用内部 key + 记忆和 eval 一起」）**：opt-in `HELM_INTERNAL_LLM_THROUGH_GATEWAY=1`，把内部 LLM 调用改成**自调用** helm 自己的 `/v1/chat/completions`（loopback），自动获得遥测 + payload → 在 /admin/requests 可见。新模块 `memory-self-http.ts` 的 `createSelfHttpClient`（ProviderClient 形：POST /v1 带内部 key + `x-memory-mode:off`，非 2xx 抛→落 callJsonModel/eval 既有 fail-open）。启动后自动 mint 固定 id `k_internal`（role:user + allow_custom_model + memory_mode:off；明文只留进程内、每启动 re-mint）。memory 经 `resolveMemoryLlmModel` 短路返回 self 客户端 + 原 alias；eval 把 classify 的 `provider` 换成 self 客户端。`providerPrefix=first.name` 把**裸** eval 模型 `deepseek-v4-flash`→`deepseek/deepseek-v4-flash` 使其走**显式模型直通**（不再 classify/eval 递归）。`memory-llm.ts` 零改动（seam 在 resolver）。
+- **坑/取舍**：① eval 在请求热路径——self 调用多一跳 loopback + 遥测写（write-queue 异步），但 eval 有缓存故仅 miss 时自调；② 内部 key 继承系统默认限流，量大需单配；③ 启动顺序：loopback 监听在 `serve()` 后、worker 首 tick ≥8s/eval 仅真流量触发→监听已起；race→ECONNREFUSED→fail-open 回退；④ **无 schema 改/无迁移**（env 开关非 config 字段），默认 OFF = 与今天逐字一致。
+- **验证**：TDD 红→绿；observer 3 新例（user-only / 空重试 / 非空不重试）+ self-http 4 新例（loopback URL/header/x-memory-mode / 裸模型前缀 / 非 2xx 抛）+ memory-llm 整合；typecheck（4 项目）+ biome lint 清、memory+classify+self-http **268 测**绿。分支 `feat/internal-llm-through-gateway`，待发 + box 置 `HELM_INTERNAL_LLM_THROUGH_GATEWAY=1`。
+
 ## 2026-06-20 · eager 事实抽取 `insertFactsReconciled` 未绑定 `this`（v0.21.6 暴露的潜伏 bug）（docs/08/12；原则 3）
 
 - **背景/线上实证**：v0.21.6 部署后用户在 Mimi 说「我家猫咪叫可乐，你记下来」仍没记下。线上日志铁证：`memory.observer.eager_facts_failed thread:019ee3dd error:"Cannot read properties of undefined (reading 'db')"`。根因：`observer.ts` 的 `maybeEagerExtractFacts` 把 store 方法解构成变量后**裸调用**——`const insert = deps.memoryStore.insertFactsReconciled; … await insert({…})`——丢了 `this`，于是 sqlite 适配器里的 `this.db.$sqlite` 抛 "reading 'db'"。eager 路径 fail-open，所以表现为**静默不写**。**为何此前没暴露**：上一条裸数组 schema bug 把数组拒了、路径走不到 `insert(...)`；schema 一修通，这个潜伏 bug 立刻顶出来。**为何单测没抓到**：假 store 的 `insertFactsReconciled` 是不依赖 `this` 的 `vi.fn`。
@@ -20,17 +28,13 @@
 - **验证**：TDD 红（裸数组→`[]`）→绿；`memory-llm.test.ts` 2 新例（eager + reflector 裸数组形状）、memory-llm 18 + `packages/core/src/memory` 247 测绿、typecheck（4 项目）/biome lint 清。分支 `worktree-fix-archived-reflection-delete`（与归档删除同分支），未提交/未部署。**部署后**短个人陈述即可 eager 落库为 project fact、下个 session 注入（前提：box 已置 `eager_facts:true` + `memory.llm.enabled:true`，本次已配）。
 - **同 PR 另带两修（同次排查发现）**：① **Gemini 原生直通不注入记忆**——`messages-pipeline.ts` 的 splice 只有 `anthropic_messages`/`openai_responses` 分支，缺 `gemini`，故 Gemini passthrough 算了记忆却丢弃。新增 `appendMemoryToGeminiBody`（尾随 `contents[]` user 轮、`systemInstruction` 逐字）+ gemini 分支；native-memory-inject 3 新例。② **fact 复活不刷新 scope**——`(owner_id,content_hash)` UNIQUE 是账号全局，故跨 project 重述同一 fact 命中旧行后 `reactivate` 只改 status/时间戳、**保留旧 scope**→新 project 的 inject 读不到。sqlite+pg 双适配器 `reactivate` UPDATE 增 `project_id/resource_id/thread_id`（以重述 scope 为准），sqlite+pg 各 1 新例（跨 project 复活后 p2 可见、p1 不可见）。
 
-## 2026-06-20 · 已归档 reflection 无法删除（两段式 soft→hard delete）（docs/13；原则 1）
-
-- **背景/线上实证**：用户在 admin Memory 页删除一条 reflection 后它变 `已归档`（status='archived'；列表用 `status:'all'` 仍显示该行且带「删除」按钮），**再点删除即 `reflection not found` 报错、永远删不掉**。根因：`deleteReflection` 是纯软删——按 id 查出 scope 后 `UPDATE … SET status='archived' WHERE scope AND status='active'`，对已归档行 0 命中→返回 false→route 404 `reflection not found`。docs/13 原设计 reflection 只有软删（无 hard delete），故一旦归档便无任何途径移除=「卡死的归档行」。
-- **决定（两段式删除 soft→hard）**：`deleteReflection` 改为**按解析行的 status 分支**——`active` 行=原软删（归档整 scope 全部 active 版本，行保留可见、停止注入）；**`archived` 行=硬删该 scope 全部 archived 版本**（用户第二次点删除即永久清除）。硬删**仅运营者手动触发**，自动遗忘管线仍永不 hard delete reflection（docs/12 不变，这是对 spec「reflection 永不硬删」的**有意偏离**：只限 admin 显式动作）。硬删整 scope 而非单 id：`upsertReflection` 每版追加独立行 + `listReflections` 走 `latestPerScope` 取最高版，只删可见的最新归档 id 会让更旧归档版**「诈尸」重现列表**。
-- **实现**：sqlite（`.delete().where(scope AND ne(status,'active'))`）+ pg（`.delete().returning()`）双适配器镜像；route 注释 + `MemoryStore` 端口注释更新为两段式语义；admin 删除弹窗文案随行 status 切换（active=软删/归档措辞；archived=「已归档，删除即永久且不可撤销」），1 新 i18n key×5 locale。**无 schema 改/无迁移**（纯逻辑、复用既有列+既有 `.delete()` 用法）→ box 配置仍有效、fail-close gate N/A。MCP `memory_delete` 自动受益（返回 `{deleted}` 不抛，故两段式透明生效）。
-- **验证**：TDD 红→绿，sqlite 2 + pg 2 改/新（两段式 active→archive→purge + 多版本归档全清防诈尸）、admin SPA 2 新（active 软删文案 / archived 永久文案 + 确认调 deleteReflection）；node 项目 **822 测绿**（仅 `admin-static.test.ts` 7 失败 = 本 worktree 未 `pnpm build` admin、缺 `apps/admin/build` 的**环境性**失败，与本改无关，CI 有 build 步骤）、typecheck（4 项目）/ biome lint / svelte-check(0/0) 清。分支 `worktree-fix-archived-reflection-delete`，未提交/未部署。
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-20 · 已归档 reflection 无法删除（两段式 soft→hard delete）（docs/13；原则 1）：admin 删 reflection→`archived`，再删 0 命中 active→404「reflection not found」永远删不掉。修：`deleteReflection` 按解析行 status 分支——active=软删（归档整 scope 全 active 版）、archived=**硬删该 scope 全 archived 版**（运营者手动二次删才永久清，自动遗忘管线仍永不硬删，docs/12 有意偏离）；硬删整 scope 防旧归档版经 `latestPerScope`「诈尸」。sqlite+pg 双适配器、admin 弹窗文案随 status 切换 + 1 i18n×5、MCP 透明受益。822 测绿。PR #331。
 
 ### 2026-06-20 · 记忆形成低延迟：防抖唤醒 memory worker（docs/08 Phase 2；原则 3）：worker 每 60s 轮询排空 `memory_jobs`，请求 inject 阶段立即入队 observer job 但干等下个 tick→最坏 ~55–60s。修：`scheduler.wake()`=trailing-edge 防抖（`coalesceMs` 默认 8s，`HELM_MEMORY_WORKER_COALESCE_MS` 可覆盖），`write-queue.onTaskDrain` 在 observe 落库后唤醒；`enqueueJob` 幂等去重保住合并（pending 期间多回合 dedupe 进同一 job=一次 LLM 调用）；60s timer 留作 backstop。Codex 修 2 P2（唤醒早于 outbound observe→仅 wakeOnSettle 触发；stop 后 wake no-op）。948 测绿。PR #332。
 

--- a/packages/core/src/memory/observer.test.ts
+++ b/packages/core/src/memory/observer.test.ts
@@ -374,6 +374,69 @@ describe("runObserverJob — eager fact extraction", () => {
     });
   });
 
+  it("feeds ONLY user messages to the extractor (assistant/tool noise excluded)", async () => {
+    // deepseek drops the user's stated fact when the wire body is full of agent
+    // tool/file noise (e.g. Mimi reading/writing its own MEMORY.md). Only user turns
+    // carry user-stated facts, so only they should reach the extractor.
+    const mixed: RawMessage[] = [
+      {
+        id: "u1",
+        threadId: "thread-1",
+        role: "user",
+        content: "我有一辆特斯拉 Model Y，你记下来",
+        tokenEstimate: 10,
+        createdAt: new Date(NOW.getTime() - 4000),
+      },
+      {
+        id: "a1",
+        threadId: "thread-1",
+        role: "assistant",
+        content: "记下了。",
+        tokenEstimate: 3,
+        createdAt: new Date(NOW.getTime() - 3000),
+      },
+      {
+        id: "t1",
+        threadId: "thread-1",
+        role: "tool",
+        content: "# Memory\n用户最喜欢的数字是 42。\nSuccessfully replaced 1 block.",
+        tokenEstimate: 30,
+        createdAt: new Date(NOW.getTime() - 2000),
+      },
+    ];
+    const { store } = makeFakeStore(mixed);
+    const extractFactsFromMessages = vi.fn(
+      async (_input: { messages: RawMessage[]; now: Date }) => [eagerFact],
+    );
+    const deps = makeDeps(store, { extractFactsFromMessages, maxFactsPerSubject: 8 });
+
+    await runObserverJob({ ...JOB, projectId: "proj-x" }, deps);
+
+    expect(extractFactsFromMessages).toHaveBeenCalledOnce();
+    const sent = extractFactsFromMessages.mock.calls[0]?.[0]?.messages as RawMessage[];
+    expect(sent.every((m) => m.role === "user")).toBe(true);
+    expect(sent.map((m) => m.id)).toEqual(["u1"]);
+  });
+
+  it("retries the extraction once when the first result is empty, then succeeds", async () => {
+    // deepseek-v4-flash is non-deterministic even at temperature:0 — it sometimes
+    // returns 0 facts for a clear statement. One retry catches the unlucky empty.
+    const { store, factCalls } = makeFakeStore(makeShortThread());
+    const extractFactsFromMessages = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([eagerFact]);
+    const deps = makeDeps(store, { extractFactsFromMessages, maxFactsPerSubject: 8 });
+
+    await runObserverJob({ ...JOB, projectId: "proj-x" }, deps);
+
+    expect(extractFactsFromMessages).toHaveBeenCalledTimes(2);
+    expect(deps.log).toHaveBeenCalledWith("memory.observer.eager_facts_retry", {
+      thread_id: "thread-1",
+    });
+    expect(factCalls).toHaveLength(1);
+  });
+
   it("calls insertFactsReconciled BOUND to the store (regression: unbound `insert(...)` loses `this`)", async () => {
     // Real adapters implement insertFactsReconciled as a CLASS METHOD that uses `this.db`.
     // The eager path extracts it to a var; calling it unbound (`insert(...)`) makes `this`
@@ -496,14 +559,15 @@ describe("runObserverJob — eager fact extraction", () => {
     expect(jobUpdates).toContainEqual({ jobId: "job-1", status: "done" });
   });
 
-  it("skips the insert when the extractor yields no facts", async () => {
+  it("skips the insert when the extractor yields no facts (after one retry)", async () => {
     const { store, factCalls } = makeFakeStore(makeShortThread());
     const extractFactsFromMessages = vi.fn(async () => []);
     const deps = makeDeps(store, { extractFactsFromMessages });
 
     await runObserverJob({ ...JOB, projectId: "proj-x" }, deps);
 
-    expect(extractFactsFromMessages).toHaveBeenCalledOnce();
+    // Empty first result triggers one retry; still empty → give up, no insert.
+    expect(extractFactsFromMessages).toHaveBeenCalledTimes(2);
     expect(factCalls).toHaveLength(0);
   });
 });

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -38,8 +38,22 @@ async function maybeEagerExtractFacts(
     // tool-result / assistant-only batch carries no user-stated fact (the cost lever
     // that keeps eager extraction off agent tool-roundtrip turns).
     if (!uncovered.some((m) => m.role === "user")) return;
+    // Feed ONLY user turns to the extractor. Assistant chatter and tool/file output
+    // (e.g. an agent reading/writing its own MEMORY.md) is noise that makes the cheap,
+    // fast extraction model drop the user's stated fact — the prompt already says
+    // "ignore assistant text", but removing it from the wire is what actually keeps the
+    // signal from being buried.
+    const userMessages = uncovered.filter((m) => m.role === "user");
     const now = deps.now();
-    const extracted = await extract({ messages: uncovered, now });
+    // The extraction model is non-deterministic even at temperature:0 and intermittently
+    // returns 0 facts for a clear statement. Retry ONCE on an empty first result before
+    // giving up (bounded at two calls; extractFactsFromMessages is fail-open and never
+    // throws, so an empty list is the only failure signal).
+    let extracted = await extract({ messages: userMessages, now });
+    if (extracted.length === 0) {
+      deps.log("memory.observer.eager_facts_retry", { thread_id: job.threadId });
+      extracted = await extract({ messages: userMessages, now });
+    }
     if (extracted.length === 0) return;
     // Scope the fact at the broadest cross-thread level the job carries. With NEITHER
     // project nor resource (a valid thread-only job), fall back to the THREAD — never


### PR DESCRIPTION
Two changes from debugging "memory intermittently doesn't record facts" on prod (v0.21.7).

## A — reliable eager fact extraction
`deepseek-v4-flash` is non-deterministic even at `temperature:0` and intermittently returns **0 facts** for a clear statement (e.g. "我有一辆特斯拉 Model Y"), made worse by an agent's own tool/file noise (Mimi reading/writing its `MEMORY.md`). `maybeEagerExtractFacts` now:
1. feeds **only user messages** to the extractor (assistant/tool turns stripped from the wire so the signal isn't buried), and
2. **retries once** on an empty first result before giving up (bounded at two calls; the extractor is fail-open).

Reflector path unchanged (extracts from already-clean observations).

## B — internal LLM calls visible in /admin/requests  (opt-in `HELM_INTERNAL_LLM_THROUGH_GATEWAY=1`)
Memory (`summarize`/`merge`/`extractFacts`) and Layer-2 eval called the provider **directly**, bypassing telemetry + payload capture — so they never appeared in `/admin/requests` (we had to `curl` deepseek by hand to diagnose). New `apps/gateway/src/memory-self-http.ts` `createSelfHttpClient` is a `ProviderClient` that instead POSTs back through helm's own `/v1/chat/completions` over **loopback** with an internal key + `x-memory-mode:off`, so the call is recorded like any real request.

- Internal key **auto-minted** at startup (fixed id `k_internal`, `role:user` + `allow_custom_model` + `memory_mode:off`; plaintext held only in-process, re-minted each boot).
- memory routes via `resolveMemoryLlmModel`; eval via the classify adapter's `provider`.
- `providerPrefix` rewrites the bare eval model `deepseek-v4-flash` → routable `deepseek/deepseek-v4-flash` so it passes **explicit-model passthrough** (no classify/eval recursion); `x-memory-mode:off` prevents a memory-on-memory loop.
- `memory-llm.ts` unchanged. Default **OFF** → byte-identical to today; fail-open if the key mint or self-call fails.

## Tests
observer +3 (user-only / retry-on-empty / no-retry) + the empty test updated to 2 calls; memory-self-http +4 (loopback URL/headers/`x-memory-mode`, bare-model prefix, non-2xx throws). typecheck + biome lint clean; memory+classify+self-http **268** green.

## Deploy note
Enable on the box via `HELM_INTERNAL_LLM_THROUGH_GATEWAY=1` in the operator `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)