### PR TITLE
chore(release): v0.21.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.7",
+  "version": "0.21.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.8 — reliable eager fact extraction (#339) + internal LLM calls observable in /admin/requests (opt-in HELM_INTERNAL_LLM_THROUGH_GATEWAY=1). Version bump; publish.yml cuts tag + Release + `:0.21.8`/`:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)