### PR TITLE
chore(release): v0.21.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.9 — protect the internal LLM key (k_internal) from admin revoke/delete + hide its action buttons (#341). Version bump; publish.yml cuts tag + Release + `:0.21.9`/`:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)