### PR TITLE
chore(release): v0.21.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.9",
+  "version": "0.21.10",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.10.

Bumps root `package.json` 0.21.9 → 0.21.10 so `publish.yml` cuts the tag + GitHub Release and pushes `ghcr.io/easymetaau/helm-api:0.21.10`.

### Included since v0.21.9
- #343 fix(memory): re-enqueue observer job for turns that arrive mid-run — fixes the live "我喜欢的数字是42" coalescing race where a fact-bearing user turn arriving during an observer run was silently dropped (Codex review: no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)