### PR TITLE
chore(release): v0.21.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.10",
+  "version": "0.21.11",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.11. Bumps root `package.json` 0.21.10 → 0.21.11 so `publish.yml` cuts the tag + Release and pushes `ghcr.io/easymetaau/helm-api:0.21.11`.

### Included since v0.21.10
- #345 feat(memory,classify): internal LLM lane support + always route through gateway, default economy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)