### PR TITLE
chore(release): v0.21.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.11",
+  "version": "0.21.12",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Cuts a release for #347 — full-repo code-review findings (Tiers 1–5), including the executor fallback refactor (`attempt-record` extraction).

On merge, `publish.yml` builds + pushes `ghcr.io/easymetaau/helm-api:0.21.12` (and `:latest`) and cuts tag `v0.21.12` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)