### PR TITLE
chore(release): v0.21.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.12",
+  "version": "0.21.13",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.13.

Includes the unreleased commit on main past v0.21.12:
- #349 Fix review hardening issues

Version-bump only; publish.yml will build `:0.21.13` + `:latest` and cut the `v0.21.13` tag + GitHub Release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)