### PR TITLE
chore(release): v0.21.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.13",
+  "version": "0.21.14",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.14.

Includes the unreleased commit on main past v0.21.13:
- #351 fix: omit temperature for codex responses

Version-bump only; publish.yml will build `:0.21.14` + `:latest` and cut the `v0.21.14` tag + GitHub Release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)