### PR TITLE
Fix Anthropic context overflow handling

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1,6 +1,11 @@
 import type { CircuitBreaker, ExecutionPlan, ProviderClient, ProviderRegistry } from "@helm/core";
 import { createCircuitBreaker, createGeminiClient, UpstreamError } from "@helm/core";
-import type { CatalogEntry, InternalRequest, TargetProviderProtocol } from "@helm/shared";
+import {
+  type CatalogEntry,
+  createNativePassthroughCarrier,
+  type InternalRequest,
+  type TargetProviderProtocol,
+} from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import { createExecute, detectRequestModalities } from "./execute.js";
 
@@ -794,6 +799,172 @@ describe("createExecute — gateway execution adapter", () => {
     });
     // ok / skipped rows must NOT carry a detail.
     expect(out.attempts[1]?.error_detail ?? null).toBeNull();
+  });
+
+  it("uses exact Anthropic count_tokens to skip an over-context native attempt without tripping the breaker", async () => {
+    const provider = {
+      countTokens: vi.fn().mockResolvedValue({ input_tokens: 1_001_854 }),
+      chatCompletion: vi.fn().mockResolvedValue({ id: "second" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        opus: {
+          providerName: "mock",
+          providerModel: "claude-opus-4-8",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        codex: {
+          providerName: "mock",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["opus", "codex"]),
+      req({
+        protocol: "anthropic_messages",
+        requested_model: "claude-opus-4-8",
+        native_request: createNativePassthroughCarrier({
+          protocol: "anthropic_messages",
+          body: {
+            model: "claude-opus-4-8",
+            messages: [{ role: "user", content: "huge" }],
+            max_tokens: 64,
+          },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    expect(provider.countTokens).toHaveBeenCalledOnce();
+    expect(provider.chatCompletion).toHaveBeenCalledOnce();
+    expect(out.attempts[0]).toMatchObject({
+      alias: "opus",
+      skipped: true,
+      skip_reason: "context_too_small",
+      status: "error",
+    });
+    expect(out.attempts[1]?.status).toBe("ok");
+    expect(recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("skips Anthropic candidates whose output_config.effort is unsupported by the target model", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "second" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        sonnet: {
+          providerName: "mock",
+          providerModel: "claude-sonnet-4-6",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        codex: {
+          providerName: "mock",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["sonnet", "codex"]),
+      req({
+        protocol: "anthropic_messages",
+        requested_model: "claude-sonnet-4-6",
+        provider_raw: { output_config: { effort: "xhigh" } },
+        native_request: createNativePassthroughCarrier({
+          protocol: "anthropic_messages",
+          body: {
+            model: "claude-sonnet-4-6",
+            messages: [{ role: "user", content: "hello" }],
+            output_config: { effort: "xhigh" },
+            max_tokens: 64,
+          },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    expect(provider.chatCompletion).toHaveBeenCalledOnce();
+    expect(out.attempts[0]).toMatchObject({
+      alias: "sonnet",
+      skipped: true,
+      skip_reason: "unsupported_reasoning_effort",
+      status: "error",
+    });
+    expect(out.attempts[1]?.status).toBe("ok");
+  });
+
+  it("does not trip the breaker for Anthropic request-shape 400s", async () => {
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError(
+            "upstream_error",
+            "prompt is too long: 1001854 tokens > 1000000 maximum",
+            { error: { message: "prompt is too long" } },
+            400,
+          ),
+        )
+        .mockResolvedValueOnce({ id: "second" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        opus: {
+          providerName: "mock",
+          providerModel: "claude-opus-4-8",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        codex: {
+          providerName: "mock",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "codex"]), req());
+
+    expect(out.final.status).toBe("ok");
+    expect(out.attempts[0]).toMatchObject({
+      alias: "opus",
+      skipped: false,
+      status: "error",
+      error_class: "invalid_request",
+    });
+    expect(out.attempts[1]?.status).toBe("ok");
+    expect(recordFailure).not.toHaveBeenCalled();
   });
 
   it("captures error_detail for a non-UpstreamError failure (null status, null raw)", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -630,6 +630,96 @@ function errorClassOf(err: unknown): string {
   return "upstream_error";
 }
 
+const ANTHROPIC_NATIVE_CONTEXT_LIMITS = [
+  { pattern: /^claude-opus-4[-.]8(?:-|$)/, maxContextTokens: 1_000_000 },
+  { pattern: /^claude-sonnet-4[-.]6(?:-|$)/, maxContextTokens: 1_000_000 },
+  { pattern: /^claude-haiku-4[-.]5(?:-|$)/, maxContextTokens: 1_000_000 },
+] as const;
+
+const ANTHROPIC_OUTPUT_EFFORTS = {
+  sonnet_4_6: new Set(["low", "medium", "high", "max"]),
+} as const;
+
+function bareAnthropicModelId(model: string): string {
+  const slash = model.lastIndexOf("/");
+  return (slash >= 0 ? model.slice(slash + 1) : model).toLowerCase();
+}
+
+function hardAnthropicContextLimit(providerModel: string): number | null {
+  const bare = bareAnthropicModelId(providerModel);
+  for (const row of ANTHROPIC_NATIVE_CONTEXT_LIMITS) {
+    if (row.pattern.test(bare)) return row.maxContextTokens;
+  }
+  return null;
+}
+
+function effectiveContextLimit(catalogEntry: CatalogEntry | undefined, providerModel: string) {
+  const catalogLimit = catalogEntry?.capabilities.maxContextTokens;
+  const normalizedCatalogLimit =
+    typeof catalogLimit === "number" && catalogLimit > 0 ? catalogLimit : null;
+  const hardLimit = hardAnthropicContextLimit(providerModel);
+  if (normalizedCatalogLimit !== null && hardLimit !== null) {
+    return Math.min(normalizedCatalogLimit, hardLimit);
+  }
+  return normalizedCatalogLimit ?? hardLimit;
+}
+
+function outputConfigEffort(value: unknown): string | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const effort = (value as Record<string, unknown>).effort;
+  return typeof effort === "string" && effort.length > 0 ? effort : null;
+}
+
+function anthropicOutputEffortSkipReason(
+  req: InternalRequest,
+  targetProviderProtocol: TargetProviderProtocol,
+  providerModel: string,
+): string | null {
+  if (targetProviderProtocol !== "anthropic_messages") return null;
+  const nativeBody = req.native_request ? nativePassthroughBody(req.native_request) : null;
+  const effort =
+    outputConfigEffort(nativeBody?.output_config) ??
+    outputConfigEffort(req.provider_raw?.output_config);
+  if (effort === null) return null;
+
+  const bare = bareAnthropicModelId(providerModel);
+  if (/^claude-sonnet-4[-.]6(?:-|$)/.test(bare)) {
+    return ANTHROPIC_OUTPUT_EFFORTS.sonnet_4_6.has(effort) ? null : "unsupported_reasoning_effort";
+  }
+  return null;
+}
+
+function countTokensInputTokens(raw: unknown): number | null {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const inputTokens = (raw as Record<string, unknown>).input_tokens;
+  return typeof inputTokens === "number" && Number.isFinite(inputTokens) ? inputTokens : null;
+}
+
+function rawErrorText(raw: unknown): string {
+  if (raw === null || raw === undefined) return "";
+  if (typeof raw === "string") return raw;
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return "";
+  }
+}
+
+function isAnthropicRequestShapeError(err: unknown): boolean {
+  if (!(err instanceof UpstreamError) || err.upstreamStatus !== 400) return false;
+  const text = `${err.message} ${rawErrorText(err.providerRaw)}`.toLowerCase();
+  return (
+    text.includes("prompt is too long") ||
+    text.includes("does not support effort level") ||
+    (text.includes("unsupported") && text.includes("effort")) ||
+    (text.includes("output_config") && text.includes("effort"))
+  );
+}
+
+function attemptErrorClassOf(err: unknown): string {
+  return isAnthropicRequestShapeError(err) ? "invalid_request" : errorClassOf(err);
+}
+
 // Coerce an already-scrubbed upstream error body into the schema's record|null
 // shape. A plain object passes through; a primitive/array (e.g. an HTML or text
 // error page) is wrapped so the detail is preserved, not silently dropped.
@@ -780,7 +870,8 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       // 2) Capability filter. Missing catalog data remains fail-open for generic
       // requests, but not for cached_content: that field is a required Gemini/LiteLLM
       // cached context handle, not an optional affinity hint.
-      const caps = catalog.get(alias)?.capabilities;
+      const catalogEntry = catalog.get(alias);
+      const caps = catalogEntry?.capabilities;
       if (!caps && needsCachedContent) {
         capabilityPruned = true;
         attempts.push(skipRow(alias, "no_cached_content_support", elapsed()));
@@ -813,6 +904,51 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         capabilityPruned = true;
         attempts.push(skipRow(alias, protocolSkip, elapsed()));
         continue;
+      }
+
+      const effortSkip = anthropicOutputEffortSkipReason(
+        req,
+        target.targetProviderProtocol,
+        providerModel,
+      );
+      if (effortSkip !== null) {
+        capabilityPruned = true;
+        attempts.push(skipRow(alias, effortSkip, elapsed()));
+        continue;
+      }
+
+      const exactContextLimit = effectiveContextLimit(catalogEntry, providerModel);
+      if (
+        target.targetProviderProtocol === "anthropic_messages" &&
+        req.native_request !== undefined &&
+        provider.countTokens !== undefined &&
+        exactContextLimit !== null
+      ) {
+        try {
+          const countInput = prepareNativeRequestForUpstream(
+            { ...nativePassthroughBody(req.native_request) },
+            providerModel,
+            req.protocol,
+            false,
+            provider.nativeProtocolProfile,
+            req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
+          );
+          const countBody = { ...nativePassthroughBody(countInput) };
+          delete countBody.stream;
+          const tokenCount = await provider.countTokens(countBody, { signal });
+          const inputTokens = countTokensInputTokens(tokenCount);
+          if (inputTokens !== null && inputTokens > exactContextLimit) {
+            capabilityPruned = true;
+            attempts.push(skipRow(alias, "context_too_small", elapsed()));
+            continue;
+          }
+        } catch (err) {
+          log?.("warn", "anthropic.count_tokens_preflight_failed", {
+            alias,
+            error_class: errorClassOf(err),
+            upstream_status: upstreamStatusOf(err),
+          });
+        }
       }
       // Past the gates → this candidate is attempted against the upstream. A
       // failure from here on is a PROVIDER fault, not a capability gap.
@@ -1072,24 +1208,27 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           continue;
         }
 
-        // Genuine pre-first-chunk failure: record on the breaker, try next. This row
-        // carries the REAL passthrough telemetry: a failure during nativePassthrough
-        // (UpstreamError) lands HERE just like a chatCompletion failure — the trail
-        // shows the verbatim-forward was attempted on this candidate before it failed.
-        breaker.recordFailure(alias);
-        // Auto-park a subscription account that hit its rate/usage limit. A genuine
-        // (non-`:free`, handled above) 429 on an OAuth alias means the served account
-        // is throttled — signal the gateway to park it so the pool routes around it.
-        // Pure side-channel: the breaker failure + chain advance below are unchanged.
-        if (upstreamStatusOf(err) === 429 && isOAuthSubscriptionAlias(alias)) {
-          onOAuthSubscription429?.(alias);
+        const requestShapeError = isAnthropicRequestShapeError(err);
+        if (!requestShapeError) {
+          // Genuine pre-first-chunk failure: record on the breaker, try next. This row
+          // carries the REAL passthrough telemetry: a failure during nativePassthrough
+          // (UpstreamError) lands HERE just like a chatCompletion failure — the trail
+          // shows the verbatim-forward was attempted on this candidate before it failed.
+          breaker.recordFailure(alias);
+          // Auto-park a subscription account that hit its rate/usage limit. A genuine
+          // (non-`:free`, handled above) 429 on an OAuth alias means the served account
+          // is throttled — signal the gateway to park it so the pool routes around it.
+          // Pure side-channel: the breaker failure + chain advance below are unchanged.
+          if (upstreamStatusOf(err) === 429 && isOAuthSubscriptionAlias(alias)) {
+            onOAuthSubscription429?.(alias);
+          }
         }
         attempts.push({
           alias,
           skipped: false,
           skip_reason: null,
           status: "error",
-          error_class: errorClassOf(err),
+          error_class: attemptErrorClassOf(err),
           latency_ms: elapsed(),
           cost_usd: null,
           error_detail: errorDetailOf(err),

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -19,7 +19,16 @@ const IDENTITY: MessagesIdentity = { keyId: "k1", accountId: "acct" };
 
 // A fake DecisionRecord stand-in the route hands opaquely to recordServed →
 // redact → telemetry.insert (it never inspects fields).
-const FAKE_DECISION = { final: { status: "ok", model_alias: "claude-3-5-sonnet" } } as never;
+function fakeDecision() {
+  return {
+    final: {
+      status: "ok",
+      model_alias: "claude-3-5-sonnet",
+      provider_model: "claude",
+      error_reason: null,
+    },
+  } as never;
+}
 
 // A minimal IR-ish object the stub transformer returns; the route must thread it
 // to the pipeline untouched (save trace_id) and never inspect its internals.
@@ -150,7 +159,7 @@ function makeDeps(
           });
         }
         return {
-          decision: FAKE_DECISION,
+          decision: fakeDecision(),
           collect: over.collect ?? (async () => ({ id: "ir-resp" })),
           streamIR:
             over.streamEvents ??
@@ -949,5 +958,29 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     const arg = insertPayload.mock.calls[0]?.[0] as { responseJson: string };
     expect(arg.responseJson).toContain("event: error");
     expect(arg.responseJson).toContain("error");
+  });
+
+  it("stream error frame marks the persisted decision as error", async () => {
+    async function* events(): AsyncIterable<{ type: string }> {
+      yield { type: "message_start" };
+      throw new Error("upstream blew up mid-stream");
+    }
+    const { record, insert } = makeRecord({ capturePayloads: true });
+    const { deps } = makeDeps({ record, isStream: true, streamEvents: events });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ_BODY, stream: true }),
+    });
+    await res.text();
+
+    expect(insert).toHaveBeenCalledOnce();
+    const arg = insert.mock.calls[0]?.[0] as {
+      decision: { final: { status: string; error_reason: string | null } };
+    };
+    expect(arg.decision.final.status).toBe("error");
+    expect(arg.decision.final.error_reason).toBe("upstream_error");
   });
 });

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -209,6 +209,14 @@ function isAbort(err: unknown, signal: AbortSignal): boolean {
   return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
 }
 
+function markStreamDecisionError(decision: DecisionRecord, errorClass: string): void {
+  decision.final = {
+    ...decision.final,
+    status: "error",
+    error_reason: errorClass,
+  };
+}
+
 export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps): void {
   const { anthropic } = deps.transformers;
 
@@ -539,15 +547,22 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
           // providers failed before the stream started — emits a TERMINAL Anthropic
           // error event so the client never sees a silently truncated stream.
           if (!isAbort(err, c.req.raw.signal)) {
+            const errorClass =
+              err instanceof PipelineError
+                ? err.error_class
+                : isUpstreamTimeout(err)
+                  ? "timeout"
+                  : "upstream_error";
             const re: RouteError =
               err instanceof PipelineError
                 ? { error_class: err.error_class, message: err.message, trace_id: traceId }
                 : {
                     // Preserve a mid-stream idle timeout instead of upstream_error.
-                    error_class: isUpstreamTimeout(err) ? "timeout" : "upstream_error",
+                    error_class: errorClass,
                     message: isUpstreamTimeout(err) ? "upstream timed out" : "upstream error",
                     trace_id: traceId,
                   };
+            markStreamDecisionError(result.decision, errorClass);
             const out = anthropic.transformErrorOut(re);
             const data = JSON.stringify(out.body);
             if (captureBodies) captured.push(`event: error\ndata: ${data}\n\n`);

--- a/docs/incidents/2026-06-22-opus-context-overflow.md
+++ b/docs/incidents/2026-06-22-opus-context-overflow.md
@@ -1,0 +1,121 @@
+# 2026-06-22 Opus Context Overflow Incident
+
+All times below are UTC. Evidence came from production SQLite on `la.atmy.work`
+using `/opt/helm-api/data/helm.db` in read-only mode. No captured prompt text is
+included here.
+
+## Trigger Requests
+
+- `ec1dcf69-0493-4729-b160-4bf1a7d8fca0` at `2026-06-22 01:27:59`
+- `2d698330-d6d5-4b82-979e-a0fc60417e64` at `2026-06-22 01:28:23`
+
+The user-facing failure burst ran from `2026-06-22 01:28:23` to
+`2026-06-22 01:33:50` and contained 10 failed requests after the first trace.
+
+## Confirmed Root Cause
+
+The failing native Anthropic request targeted `claude-opus-4-8` and Anthropic
+returned:
+
+```text
+prompt is too long: 1001854 tokens > 1000000 maximum
+```
+
+The failing request had:
+
+- `request_len`: about 3.21 MB
+- `messages`: 864
+- `tools`: about 127 KB
+- `system`: about 7 KB
+- `thinking.type`: `adaptive`
+- `output_config.effort`: `xhigh`
+- `context_management`: `{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`
+
+A later request, `f5221b67-8323-4eb5-a71e-7d2448e06b6c` at
+`2026-06-22 01:40:11`, succeeded on the same model with the same tools/system,
+same `thinking`, same `output_config`, and same `context_management`, but with
+841 messages and `prompt_tokens=924300`.
+
+This means the burst was sent before enough client-side history cleanup or
+compaction had reduced the active prompt below the hard 1M-token limit. Helm's
+own memory middleware was not active for these traces: `decision_json.memory`
+was empty.
+
+## Secondary Problems Exposed
+
+1. Mid-stream failures can be recorded as `ok`.
+   `ec1dcf69-0493-4729-b160-4bf1a7d8fca0` is stored with `final_status=ok`, but
+   its captured response contains only `message_start` followed by an Anthropic
+   `event: error` with `upstream error`. Docker also logged
+   `stream.truncated` for `openai-codex/gpt-5.5`.
+
+2. `response.failed` details from the Codex Responses stream are too lossy.
+   Eight fallback attempts to `openai-codex/gpt-5.5` only stored the generic
+   message `codex responses stream error`, with no provider raw event body.
+
+3. Request-shape 400s pollute provider health.
+   The executor records `prompt too long` and unsupported effort 400s as provider
+   failures, so repeated retries opened circuits and produced a later request
+   where candidates were skipped as `circuit_open`.
+
+4. Cross-model fallback forwards incompatible Anthropic effort.
+   Fallback to `anthropic/claude-sonnet-4-6` returned:
+
+   ```text
+   This model does not support effort level 'xhigh'. Supported levels: high, low, max, medium.
+   ```
+
+   Helm forwarded the client `output_config.effort=xhigh` to Sonnet instead of
+   applying a model-aware clamp or skip.
+
+5. `upstream_request_json` is null on all-failed requests.
+   The payload table only captures the served attempt's upstream body. For an
+   all-failed chain, the exact upstream body for failed attempts is not persisted,
+   which makes later diagnosis harder.
+
+6. Balance-only failures are present but not primary for this incident.
+   `zenmux/*` attempts returned 402 insufficient credit. Per user instruction,
+   these should be ignored for root-cause prioritization.
+
+## Fixes Applied
+
+- Added an Anthropic native `count_tokens` preflight in the executor. Known Claude
+  4.x native models use the conservative 1,000,000-token hard ceiling, combined
+  with catalog limits by taking the smaller value. Over-limit candidates are
+  skipped with `context_too_small` and do not trip the circuit breaker.
+- Added a model-aware guard for `claude-sonnet-4-6` so unsupported
+  `output_config.effort` values such as `xhigh` skip the candidate with
+  `unsupported_reasoning_effort` instead of burning an upstream 400.
+- Classified Anthropic request-shape 400s such as `prompt is too long` and
+  unsupported effort as `invalid_request` attempt errors that do not count
+  against provider health.
+- Fixed `/v1/messages` stream telemetry so a stream that emits a terminal
+  `event: error` is persisted with `final.status=error`.
+- Preserved Codex Responses `response.failed` / `error` SSE events in
+  `UpstreamError.providerRaw`, so attempt `error_detail.provider_raw` can explain
+  what the backend actually sent.
+
+## Recommended Fix Order
+
+1. Done: add a deterministic preflight for native Anthropic requests near context
+   limits. Use Anthropic token counting when the request is large or the selected
+   lane/model has a hard context ceiling. Skip an over-limit candidate with
+   `context_too_small` before burning the upstream attempt.
+
+2. Done: treat upstream 400 request-shape errors as non-provider-health failures.
+   `prompt too long` and unsupported effort should not open the circuit breaker.
+
+3. Done: make Anthropic `output_config.effort` model-aware.
+   For Sonnet, clamp `xhigh` to a supported level or skip the candidate with a
+   structured reason such as `unsupported_reasoning_effort`.
+
+4. Done: fix stream telemetry. If a stream throws after the first frame and the route
+   emits an error frame, record the final request as a stream error, not `ok`.
+
+5. Done: preserve Codex stream failure detail safely.
+   When `response.failed` or `error` arrives without a simple message, store a
+   scrubbed provider raw event in `error_detail.provider_raw`.
+
+6. Pending: improve failed-attempt payload observability.
+   Capture at least the last attempted upstream body for all-failed chains, or add
+   per-attempt upstream body capture under the existing `capture_payloads` setting.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-22 · Opus 1M 上下文溢出预检 + 流式失败落库修正（docs/04/05/07；原则 3/5/7/8）
+
+- **线上实证**：`la.atmy.work` SQLite 显示 `claude-opus-4-8` 原生 Anthropic 请求在 `2026-06-22 01:28:23–01:33:50 UTC` 连续失败，核心错误为 `prompt is too long: 1001854 tokens > 1000000 maximum`；稍后同模型 `prompt_tokens=924300` 成功，说明客户端压缩/清理尚未把活动上下文降到硬上限以下。`decision_json.memory` 为空，Helm memory middleware 未参与。
+- **决定 1（上下文）**：对 Anthropic native target 在真正 provider invoke 前增加 exact `count_tokens` 预检；`claude-opus-4-8` / `claude-sonnet-4-6` / `claude-haiku-4-5` 采用保守硬上限 `1_000_000`，并与 catalog 值取较小者。`count_tokens` 失败时 fail-open 继续原尝试（避免 token helper 自身成为 5xx），但一旦精确 `input_tokens` 超限，记录 `skip_reason:"context_too_small"` 并进入 fallback，**不记 breaker failure**。
+- **决定 2（请求形状 400）**：上游 400 中的 `prompt is too long`、`does not support effort level`、`output_config.effort` 等判为请求形状错误，attempt 记 `invalid_request`，但不污染 circuit breaker。`:free` 429、OAuth 429 auto-park 等 provider-health 路径保持原语义。
+- **决定 3（effort）**：`claude-sonnet-4-6` 只允许 `low|medium|high|max` 的 `output_config.effort`；`xhigh` 等不兼容值在执行前以 `unsupported_reasoning_effort` 跳过该候选，而不是发给上游再 400。没有把 `xhigh` 自动 clamp 到 `max`，因为 clamp 会悄悄改变用户请求语义；fallback skip 更可观测。
+- **决定 4（流式可观测）**：`/v1/messages` 已写出 Anthropic `event:error` 时，同步把 `DecisionRecord.final.status` 改为 `error` 并写入 `error_reason`，避免 admin 显示 ok 但 payload 里是错误帧。Codex Responses `response.failed` / `error` 抛出的 `UpstreamError` 现在带原始 SSE event 到 `providerRaw`，让 `error_detail.provider_raw` 能保留故障字段（仍经 telemetry redaction）。
+- **仍未做**：all-failed chain 的 per-attempt upstream body capture 还没补；当前只继续保存 served attempt 的 `upstream_request_json`。这需要扩展 payload 表或决策 attempt 附属表，单独做更稳。
+- **验证**：TDD 红→绿；`execute.test.ts` 覆盖 exact count_tokens skip、Sonnet effort skip、request-shape 400 不触发 breaker；`messages.test.ts` 覆盖 stream error 落库；`openai-responses.test.ts` 覆盖 `response.failed.providerRaw`。focused 212 测、typecheck、Biome lint 均绿。
+
 ## 2026-06-21 · Codex Chat→Responses 兼容层移除 `temperature`（docs/05/07；原则 3/7/8）
 
 - **线上实证**：`la.atmy.work` 请求 `49f1eb18-7430-48b2-97d4-b97169d425cf` 的第一候选 `openai-codex/gpt-5.4-mini` 351ms 返回 HTTP 400：`Unsupported parameter: temperature`；执行 fallback 随后命中 `anthropic/claude-haiku-4-5-20251001` 成功，整体 `final_status=ok`、`fallback_count=1`。该请求是 `model:"economy"` + `temperature:0` + 非流式 Chat Completions；因 `source_protocol=openai_chat`、`target_provider_protocol=openai_responses`、`passthrough_disable_reason=missing_native_request`，Helm 走 `openaiToResponsesRequest` 互译路径，而不是原生 Responses 直通。
@@ -24,20 +34,13 @@
 - **Tier 5（breaker + memory，原则 3）**：**H7** OPEN 态 `recordFailure` 改 no-op（原会 `trip()` 重置 openedAt→冷却永刷新）。**M4** `recordAbort` 仅 HALF_OPEN 释放探针锁（防误放他人锁；现状下其他态 lock 已为 false，属防御性）。**H8** `peekStream` 空流（首 next `done`）抛 `UpstreamError` → 记 breaker 失败 + 进链，而非 `recordSuccess` 治愈 breaker 并回空体。**H4 = 误报**：pg `appendMessages` dedup 循环**永远保留首条**输入→`rows` 对非空输入不可能为空→`.values([])` 不可达；保留一行防御性 `if(rows.length===0)return ids`（注释标明"今日不可达"）+ 跨适配器全重复批次 parity 测。**M5** compaction 经济学（`priorCompactionCount`/`measuredRetention`）排除 pruned 墓碑（`[pruned]` 8 字符会污染留存比），用 `activeObservations` 过滤。**M7** 加 `idx_memory_jobs_claim (status, created_at, id)`（sqlite v27 / pg v26；claimPendingJobs 每 tick+wake 跑），4 个 scoped 迁移 fixture 预标 v27 applied。
 - **本批主动延后（记账，未做）**：**M6**（decay 候选查询去重 + 给 `memory_jobs` 加可索引的 accountId 生成列）——是 forgetting 关键查询的**两方言 SQL 重写**，误改即影响"哪些记忆被遗忘"，刚因 H4 误报更应谨慎；值单开 PR 做前后结果对比。**C4**（observer 重入队锚定原始 frontier）——v0.21.10 现机制工作正常（debounce 合并 + user 门控 + ~1h idle-flush 兜底），review 担心的"持续负载下无界"实为"每个 user 轮都观测"=按设计；强行锚定 frontier 有**重新引入漏轮 bug**（即"42 永不持久化"）的风险，故只做风险评估不改码。
 
-## 2026-06-20 · 内部 LLM（memory + eval）支持 lane 名 + 默认 economy（docs/03/04/08；原则 4/6）
-
-- **目标（用户）**：所有内部 LLM 调用（memory 的 observation/reflection/facts + Layer-2 eval）都能把 **lane 名**当模型用（走 lane 的 fallback 链），未配置时**默认 economy**。
-- **现状核实**：网关路由**早已支持 lane-as-model**——`allow_custom_model` 的 key 传 `model:"<lane>"` 会路由到该 lane 的展开链且**跳过 classify+eval**（route-request.ts step 1a，无递归）；内部 key `k_internal`（allow_custom_model + 无 allowed_lanes + memory_mode:off）有资格路由任意 lane。**唯一阻塞**：`createSelfHttpClient`（self-http 模式，box 开着 `HELM_INTERNAL_LLM_THROUGH_GATEWAY=1`）把任何无斜杠 model 一律改写成 `${providerPrefix}/${model}`→裸 lane `economy`→`deepseek/economy`→上游无此模型→fail-open 静默降级。默认模式 resolver 同样把 lane 当裸模型直发主 provider。
-- **专家评估（用户要求 3 角色两轮）**：路由架构/可靠性/成本三角色达成共识。**关键发现（成本角色）**：`economy` 的 primary 是 `openai-codex/gpt-5.4-mini`（$0.75/$4.5），是 nano deepseek-v4-flash 的 7.5–22.5×，链尾兜到 balanced 可达 Sonnet/Opus；专家组原推荐另建廉价 `internal` lane。**用户在知情下仍选 economy**，并明确"不要关心成本，只做技术实现"。
-- **决定（技术实现）**：① **P0**——`createSelfHttpClient` 注入 `isLane()`，已知 lane 名**跳过 provider 前缀、原样透传**（`server.ts` 用 live `(m)=>Object.hasOwn(lanes,m)`，admin 改 lane 即时生效）。因 memory + eval 都经同一 selfHttpClient，**一处修复同时覆盖全部内部 LLM**。② **默认 economy**——`MemoryLlmSchema` 把 `superRefine(必填)` 改为 `transform`：enabled 且 model 未配置→`model="economy"`（per-task 字段继承之）；`ClassifierConfigSchema` 的 eval prefault `deepseek-v4-flash`→`economy`。显式值（lane 名 OR `provider/model`）一律原样honored。③ **删除 `HELM_INTERNAL_LLM_THROUGH_GATEWAY` 开关，内部 LLM 走自有网关改为始终开启**（用户：「没必要默认关闭」）——去掉 env 判断 + `if` 门控，`k_internal` 每次启动必 mint，`selfHttpClient` 仅在 mint 失败时为 null（落回直连 provider，与 self-http 前逐字一致，不阻塞启动）。这同时**消除了"非 self-http 就 fail-open"那条尾巴**——lane 路由现在全局生效。
-- **范围/坑**：lane 路由现走始终开启的 self-http 路径，无模式分叉。memory.llm/eval 默认都 OFF，故默认 economy 只影响主动开启者。**box 当前 pin 了 `deepseek/deepseek-v4-flash`** → 默认改动不影响 box，要用 economy 需删 pin 或显式设 `model: economy`；box 旧 env `HELM_INTERNAL_LLM_THROUGH_GATEWAY=1` 部署后变成无害死变量（可删可留）。本 PR**未做**：启动期 JSON-capability 校验、成本可观测（按用户"只做技术实现"裁掉，列为后续）。
-- **验证**：TDD 红→绿；self-http 1 新例（lane 名不被加前缀、裸模型仍加前缀）+ memory-schema 改 2 例（默认 economy / 非法 knob 仍 fail-closed）；gateway+shared+core memory/config **1486 测**绿、typecheck（4 项目）/biome 清。分支 `feat/internal-llm-lane-support`，待发。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+### 2026-06-20 · 内部 LLM（memory + eval）支持 lane 名 + 默认 economy（docs/03/04/08；原则 4/6）：self-http 内部 LLM 原把裸 lane `economy` 改写成 `deepseek/economy` 导致 lane-as-model 失效；修为 `createSelfHttpClient` 注入 live `isLane()`，已知 lane 原样透传，memory/eval 默认 model 改为 `economy`，并删除 `HELM_INTERNAL_LLM_THROUGH_GATEWAY` 开关使内部调用始终经自有网关（mint `k_internal`，失败才落回直连）。用户知情接受 economy 成本较高；未做启动期 capability 校验/成本可观测。
 
 ### 2026-06-20 · observer 任务合并竞态致"运行期到达的消息"丢失（docs/08 Phase 2；原则 3）：observer job claim 时一次性快照，运行期间新 user 轮被开放任务唯一索引合并进已过读取点的 running job，导致短线程 fact 轮永不被挖；修为 `runObserverJob` 记录 `snapshotMessageIds`，done 后重读并仅对快照外新 user 消息补发 observer job，避免 assistant-only 热循环；无 schema/迁移，SQLite+Postgres 对称，observer 26 + core memory/store 653 绿。
 

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -513,6 +513,10 @@ describe("translateResponsesSSE", () => {
     }
     expect(caught).toBeInstanceOf(UpstreamError);
     expect((caught as UpstreamError).message).toBe("model exploded");
+    expect((caught as UpstreamError).providerRaw).toMatchObject({
+      type: "response.failed",
+      response: { error: { message: "model exploded" } },
+    });
   });
 
   it("falls back to a generic message when response.failed carries no error message", async () => {
@@ -526,6 +530,10 @@ describe("translateResponsesSSE", () => {
       caught = e;
     }
     expect((caught as UpstreamError).message).toBe("codex responses stream error");
+    expect((caught as UpstreamError).providerRaw).toMatchObject({
+      type: "response.failed",
+      response: {},
+    });
   });
 
   it("closes cleanly with finish + [DONE] when the stream ends without response.completed (EOF path)", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1149,7 +1149,7 @@ export async function* translateResponsesSSE(
                 message?: string;
               }
             ).message;
-      throw new UpstreamError("upstream_error", msg || "codex responses stream error");
+      throw new UpstreamError("upstream_error", msg || "codex responses stream error", evt);
     }
   }
   // Stream ended without an explicit response.completed → close cleanly.
@@ -1231,7 +1231,7 @@ export async function aggregateResponsesStream(
                 message?: string;
               }
             ).message;
-      throw new UpstreamError("upstream_error", msg || "codex responses stream error");
+      throw new UpstreamError("upstream_error", msg || "codex responses stream error", evt);
     }
   }
 


### PR DESCRIPTION
## Summary
- add Anthropic native count_tokens preflight for Claude 4.x hard context limits
- skip unsupported Sonnet output_config.effort values and keep request-shape 400s out of circuit breaker health
- persist streamed Anthropic error frames as failed decisions and preserve Codex response.failed raw event details
- document the 2026-06-22 Opus context overflow incident and applied fixes

## Tests
- pnpm vitest run apps/gateway/src/routes/execute.test.ts apps/gateway/src/routes/messages.test.ts packages/core/src/provider/openai-responses.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build