### PR TITLE
chore(release): v0.21.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.14",
+  "version": "0.21.15",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.15.

Covers #353 — Fix Anthropic context overflow handling (merged to main after the v0.21.14 release tag, so it only refreshed \`:latest\` until this bump).

Pure gateway + provider bug fix (gateway execute/messages routes + core openai-responses), no config/schema change → patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)