### PR TITLE
0.21.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.15",
+  "version": "0.21.16",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.16. Bumps root `package.json`; merging to `main` triggers `publish.yml` to build `:latest`/`:0.21.16` images and cut the GitHub Release + tag.

Since v0.21.15 (#354):
- #353 — fix Anthropic context overflow handling
- #355 — sanitize Codex responses passthrough
- #356 — impute Claude subscription (OAuth) token cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)