### PR TITLE
feat(mcp): OAuth 2.1 shim so ChatGPT connectors can authenticate

### DIFF
--- a/apps/gateway/src/routes/mcp/oauth.test.ts
+++ b/apps/gateway/src/routes/mcp/oauth.test.ts
@@ -1,0 +1,348 @@
+import { createHash } from "node:crypto";
+import { type ApiKeyRecord, hashKey } from "@helm/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../../app.js";
+import { deriveMcpSigningKey, type McpOAuthDeps, mcpAuth, registerMcpOAuth } from "./oauth.js";
+
+const KEY = "helm_live_secret";
+const REDIRECT = "https://chatgpt.com/connector/oauth/abc123";
+const ENC_KEY = Buffer.alloc(32, 7);
+
+function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
+  return {
+    key_id: "k1",
+    hash: hashKey(KEY),
+    prefix: "helm_live_ab",
+    account_id: "acct-42",
+    role: "user",
+    name: null,
+    allowed_lanes: null,
+    allow_custom_model: false,
+    disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: "degrade",
+    degrade_lane: null,
+    concurrency_limit: null,
+    memory_mode: "inject",
+    memory_project_id: "proj-9",
+    memory_thread_source: "header",
+    ...overrides,
+  };
+}
+
+// PKCE S256 challenge for a given verifier (mirrors the client side).
+function challengeFor(verifier: string): string {
+  return createHash("sha256")
+    .update(verifier)
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function build(rec: ApiKeyRecord | null, overrides: Partial<McpOAuthDeps> = {}) {
+  let nowMs = 1_000_000_000_000;
+  const deps: McpOAuthDeps = {
+    // Hash-faithful: only the real key resolves (a real store returns null for
+    // anything else), so a tampered bearer that falls through to API-key auth 401s.
+    keyStore: { getByHash: vi.fn(async (h: string) => (rec && h === hashKey(KEY) ? rec : null)) },
+    signingKey: deriveMcpSigningKey(ENC_KEY),
+    accessTtlSeconds: 3600,
+    allowedRedirectPrefixes: ["https://chatgpt.com/connector/oauth/"],
+    now: () => nowMs,
+    ...overrides,
+  };
+  const app = new Hono<AppEnv>();
+  registerMcpOAuth(app, deps);
+  app.use("/mcp", mcpAuth(deps));
+  // Probe route: echoes the resolved identity so we can assert auth wiring.
+  app.post("/mcp", (c) => {
+    const id = c.get("identity");
+    return c.json({ accountId: id.accountId, projectId: id.caps.memory.projectId });
+  });
+  return { app, deps, setNow: (ms: number) => (nowMs = ms) };
+}
+
+// Run the GET→POST authorize → POST token flow, returning the access token.
+async function fullFlow(app: Hono<AppEnv>, verifier = "verifier-0123456789-abcdefghij") {
+  const challenge = challengeFor(verifier);
+  const authzQs = new URLSearchParams({
+    response_type: "code",
+    client_id: "chatgpt",
+    redirect_uri: REDIRECT,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state: "xyz",
+    resource: "https://helm.example/mcp",
+  }).toString();
+
+  const authzRes = await app.request(`/authorize?${authzQs}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: `${authzQs}&api_key=${encodeURIComponent(KEY)}`,
+  });
+  if (authzRes.status !== 302) return { authzRes, token: null as string | null };
+  const loc = new URL(authzRes.headers.get("location") as string);
+  const code = loc.searchParams.get("code") as string;
+
+  const tokenRes = await app.request("/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      redirect_uri: REDIRECT,
+    }).toString(),
+  });
+  return { authzRes, tokenRes, state: loc.searchParams.get("state") };
+}
+
+describe("deriveMcpSigningKey", () => {
+  it("is deterministic and distinct from the input key", () => {
+    const a = deriveMcpSigningKey(ENC_KEY);
+    const b = deriveMcpSigningKey(ENC_KEY);
+    expect(a.equals(b)).toBe(true);
+    expect(a.equals(ENC_KEY)).toBe(false);
+    expect(a.length).toBe(32);
+  });
+});
+
+describe("discovery metadata", () => {
+  it("advertises the resource + AS derived from forwarded headers", async () => {
+    const { app } = build(record());
+    const res = await app.request("/.well-known/oauth-protected-resource", {
+      headers: { "x-forwarded-proto": "https", "x-forwarded-host": "helm.example" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string; authorization_servers: string[] };
+    expect(body.resource).toBe("https://helm.example/mcp");
+    expect(body.authorization_servers).toEqual(["https://helm.example"]);
+  });
+
+  it("the path-suffixed protected-resource form also resolves", async () => {
+    const { app } = build(record());
+    const res = await app.request("/.well-known/oauth-protected-resource/mcp", {
+      headers: { "x-forwarded-proto": "https", "x-forwarded-host": "helm.example" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("the AS metadata requires S256 PKCE", async () => {
+    const { app } = build(record());
+    const res = await app.request("/.well-known/oauth-authorization-server", {
+      headers: { "x-forwarded-proto": "https", "x-forwarded-host": "helm.example" },
+    });
+    const body = (await res.json()) as {
+      authorization_endpoint: string;
+      token_endpoint: string;
+      code_challenge_methods_supported: string[];
+    };
+    expect(body.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(body.authorization_endpoint).toBe("https://helm.example/authorize");
+    expect(body.token_endpoint).toBe("https://helm.example/token");
+  });
+});
+
+describe("GET /authorize", () => {
+  it("renders the login form for a valid request", async () => {
+    const { app } = build(record());
+    const qs = new URLSearchParams({
+      response_type: "code",
+      redirect_uri: REDIRECT,
+      code_challenge: "cc",
+      code_challenge_method: "S256",
+      state: "st",
+    }).toString();
+    const res = await app.request(`/authorize?${qs}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('name="api_key"');
+    expect(html).toContain('name="code_challenge" value="cc"');
+    expect(html).toContain('name="state" value="st"');
+  });
+
+  it("rejects a redirect_uri outside the allowlist", async () => {
+    const { app } = build(record());
+    const qs = new URLSearchParams({
+      redirect_uri: "https://evil.example/cb",
+      code_challenge: "cc",
+    }).toString();
+    const res = await app.request(`/authorize?${qs}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("requires PKCE (missing code_challenge → 400)", async () => {
+    const { app } = build(record());
+    const res = await app.request(`/authorize?redirect_uri=${encodeURIComponent(REDIRECT)}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("escapes reflected params (no XSS)", async () => {
+    const { app } = build(record());
+    const qs = new URLSearchParams({
+      redirect_uri: REDIRECT,
+      code_challenge: "cc",
+      state: '"><script>x</script>',
+    }).toString();
+    const res = await app.request(`/authorize?${qs}`);
+    const html = await res.text();
+    expect(html).not.toContain("<script>x</script>");
+    expect(html).toContain("&quot;&gt;&lt;script&gt;");
+  });
+});
+
+describe("POST /authorize", () => {
+  it("rejects an invalid API key with the form re-rendered", async () => {
+    const { app } = build(null); // getByHash → null
+    const qs = new URLSearchParams({
+      redirect_uri: REDIRECT,
+      code_challenge: "cc",
+      code_challenge_method: "S256",
+    }).toString();
+    const res = await app.request("/authorize", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: `${qs}&api_key=wrong`,
+    });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid or disabled API key");
+  });
+
+  it("rejects a disabled key", async () => {
+    const { app } = build(record({ disabled: true }));
+    const qs = new URLSearchParams({ redirect_uri: REDIRECT, code_challenge: "cc" }).toString();
+    const res = await app.request("/authorize", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: `${qs}&api_key=${encodeURIComponent(KEY)}`,
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("end-to-end authorize → token → /mcp", () => {
+  it("issues an access token that resolves to the key's account + project", async () => {
+    const { app } = build(record());
+    const { authzRes, tokenRes, state } = await fullFlow(app);
+    expect(authzRes.status).toBe(302);
+    expect(state).toBe("xyz");
+    expect(tokenRes?.status).toBe(200);
+    const tok = (await tokenRes?.json()) as { access_token: string; token_type: string };
+    expect(tok.token_type).toBe("Bearer");
+
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tok.access_token}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accountId: "acct-42", projectId: "proj-9" });
+  });
+
+  it("rejects a token exchange with the wrong PKCE verifier", async () => {
+    const { app } = build(record());
+    const challenge = challengeFor("the-real-verifier-aaaaaaaaaa");
+    const qs = new URLSearchParams({
+      response_type: "code",
+      redirect_uri: REDIRECT,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString();
+    const authzRes = await app.request("/authorize", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: `${qs}&api_key=${encodeURIComponent(KEY)}`,
+    });
+    const code = new URL(authzRes.headers.get("location") as string).searchParams.get(
+      "code",
+    ) as string;
+
+    const tokenRes = await app.request("/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        code_verifier: "WRONG-verifier-bbbbbbbbbbbb",
+        redirect_uri: REDIRECT,
+      }).toString(),
+    });
+    expect(tokenRes.status).toBe(400);
+    expect((await tokenRes.json()) as { error: string }).toMatchObject({ error: "invalid_grant" });
+  });
+
+  it("rejects an expired authorization code", async () => {
+    const { app, setNow } = build(record());
+    const verifier = "verifier-cccccccccc-dddddddddd";
+    const challenge = challengeFor(verifier);
+    const qs = new URLSearchParams({
+      redirect_uri: REDIRECT,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString();
+    const authzRes = await app.request("/authorize", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: `${qs}&api_key=${encodeURIComponent(KEY)}`,
+    });
+    const code = new URL(authzRes.headers.get("location") as string).searchParams.get(
+      "code",
+    ) as string;
+
+    setNow(1_000_000_000_000 + 120_000); // +120s, past the 60s code TTL
+    const tokenRes = await app.request("/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        code_verifier: verifier,
+        redirect_uri: REDIRECT,
+      }).toString(),
+    });
+    expect(tokenRes.status).toBe(400);
+  });
+});
+
+describe("mcpAuth fallback", () => {
+  it("still accepts a raw API key (back-compat)", async () => {
+    const { app } = build(record());
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${KEY}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accountId: "acct-42", projectId: "proj-9" });
+  });
+
+  it("rejects a request with no credentials", async () => {
+    const { app } = build(record());
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a forged access token (bad signature)", async () => {
+    const { app } = build(record());
+    const { tokenRes } = await fullFlow(app);
+    const tok = (await tokenRes?.json()) as { access_token: string };
+    const tampered = `${tok.access_token.slice(0, -3)}xxx`;
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tampered}`, "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/gateway/src/routes/mcp/oauth.ts
+++ b/apps/gateway/src/routes/mcp/oauth.ts
@@ -1,0 +1,375 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { hashKey, type KeyStore } from "@helm/core";
+import type { Context, Hono, MiddlewareHandler } from "hono";
+import type { AppEnv } from "../../app.js";
+import { type AuthIdentity, authMiddleware } from "../../middleware/auth.js";
+
+// docs/13 — OAuth 2.1 shim so ChatGPT's MCP connector can authenticate against
+// /mcp. ChatGPT cannot present a raw API key; it runs an authorize-code + PKCE
+// flow (RFC 9728 discovery → /authorize → /token). This module is a *thin*
+// authorization server: the human pastes a helm API key on the /authorize login
+// page, and the issued access token is a stateless HS256 JWT carrying that key's
+// account. /mcp then accepts EITHER the JWT or a raw API key (back-compat).
+//
+// ponytail: stateless JWTs, no token/code store, no migration. The authorization
+// code is itself a 60s-lived signed JWT (PKCE-bound). Ceiling: codes are
+// replayable within their 60s window and access tokens are non-revocable until
+// expiry — for a single-resource self-hosted gateway with TLS + PKCE that's an
+// accepted trade. Upgrade path if it ever matters: a one-time-code store + a
+// token denylist (then this whole file gains a store dep).
+
+export interface McpOAuthDeps {
+  keyStore: Pick<KeyStore, "getByHash">;
+  /** HS256 key for signing codes + access tokens (deriveMcpSigningKey). */
+  signingKey: Buffer;
+  /** Access-token lifetime in seconds. */
+  accessTtlSeconds: number;
+  /** Public base URL override; else derived from forwarded headers. No trailing slash. */
+  issuer?: string;
+  /** Allowlisted redirect_uri prefixes (https). */
+  allowedRedirectPrefixes: string[];
+  now: () => number; // ms epoch (injectable for tests)
+  log?: (line: string) => void;
+}
+
+// Domain-separated derivation from the at-rest OAuth key so we add NO new secret
+// to the deployment: HELM_OAUTH_ENC_KEY already exists wherever subscription
+// OAuth runs. Distinct label => unrelated to the AES key material.
+export function deriveMcpSigningKey(encKey: Buffer): Buffer {
+  return createHmac("sha256", encKey).update("helm-mcp-oauth/v1").digest();
+}
+
+// --- minimal HS256 JWT (no dep; we both issue and verify, so format is ours) ---
+
+function b64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function b64urlJson(obj: unknown): string {
+  return b64url(Buffer.from(JSON.stringify(obj)));
+}
+function signJwt(payload: Record<string, unknown>, key: Buffer): string {
+  const head = b64urlJson({ alg: "HS256", typ: "JWT" });
+  const body = b64urlJson(payload);
+  const data = `${head}.${body}`;
+  const sig = b64url(createHmac("sha256", key).update(data).digest());
+  return `${data}.${sig}`;
+}
+function verifyJwt(token: string, key: Buffer, nowSec: number): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [head, body, sig] = parts as [string, string, string];
+  const expected = b64url(createHmac("sha256", key).update(`${head}.${body}`).digest());
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(Buffer.from(body, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof payload.exp === "number" && payload.exp < nowSec) return null;
+  return payload;
+}
+
+// PKCE S256: base64url(sha256(verifier)) === challenge (constant-time).
+function pkceMatches(verifier: string, challenge: string): boolean {
+  const computed = b64url(createHash("sha256").update(verifier).digest());
+  const a = Buffer.from(computed);
+  const b = Buffer.from(challenge);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+// --- request helpers ---
+
+function baseUrl(
+  c: { req: { url: string; header: (n: string) => string | undefined } },
+  deps: McpOAuthDeps,
+): string {
+  if (deps.issuer) return deps.issuer.replace(/\/$/, "");
+  const fwdProto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim();
+  const fwdHost = c.req.header("x-forwarded-host")?.split(",")[0]?.trim();
+  const u = new URL(c.req.url);
+  const proto = fwdProto ?? u.protocol.replace(":", "");
+  const host = fwdHost ?? c.req.header("host") ?? u.host;
+  return `${proto}://${host}`;
+}
+
+const AUTHZ_PARAMS = [
+  "response_type",
+  "client_id",
+  "redirect_uri",
+  "code_challenge",
+  "code_challenge_method",
+  "state",
+  "scope",
+  "resource",
+] as const;
+
+type AuthzParams = Partial<Record<(typeof AUTHZ_PARAMS)[number], string>>;
+
+function pickParams(src: Record<string, unknown>): AuthzParams {
+  const out: AuthzParams = {};
+  for (const k of AUTHZ_PARAMS) {
+    const v = src[k];
+    if (typeof v === "string" && v !== "") out[k] = v;
+  }
+  return out;
+}
+
+function validateAuthz(
+  q: AuthzParams,
+  prefixes: string[],
+): { ok: true } | { ok: false; error: string } {
+  if (q.response_type && q.response_type !== "code")
+    return { ok: false, error: "unsupported response_type (only 'code')" };
+  const ru = q.redirect_uri;
+  if (!ru) return { ok: false, error: "missing redirect_uri" };
+  let u: URL;
+  try {
+    u = new URL(ru);
+  } catch {
+    return { ok: false, error: "invalid redirect_uri" };
+  }
+  if (u.protocol !== "https:") return { ok: false, error: "redirect_uri must be https" };
+  if (!prefixes.some((p) => ru.startsWith(p)))
+    return { ok: false, error: "redirect_uri not in allowlist" };
+  if (!q.code_challenge) return { ok: false, error: "missing code_challenge (PKCE required)" };
+  if (q.code_challenge_method && q.code_challenge_method !== "S256")
+    return { ok: false, error: "code_challenge_method must be S256" };
+  return { ok: true };
+}
+
+// Escape for HTML attribute context — authorize params are attacker-controllable
+// and reflected into hidden inputs, so this is the XSS boundary (not optional).
+function escAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function loginForm(q: AuthzParams, base: string, error?: string): string {
+  const hidden = AUTHZ_PARAMS.filter((k) => q[k] !== undefined)
+    .map((k) => `<input type="hidden" name="${k}" value="${escAttr(q[k] as string)}">`)
+    .join("\n      ");
+  const err = error ? `<p class="err">${escAttr(error)}</p>` : "";
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Connect to Helm memory</title>
+<style>
+  body{font:15px/1.5 system-ui,sans-serif;max-width:26rem;margin:4rem auto;padding:0 1rem;color:#111}
+  h1{font-size:1.25rem} label{display:block;margin:.75rem 0 .25rem;font-weight:600}
+  input[type=password]{width:100%;padding:.6rem;border:1px solid #bbb;border-radius:.4rem;box-sizing:border-box}
+  button{margin-top:1rem;width:100%;padding:.6rem;border:0;border-radius:.4rem;background:#111;color:#fff;font-size:1rem;cursor:pointer}
+  .err{color:#b00020;font-weight:600} .hint{color:#666;font-size:.85rem}
+</style></head>
+<body>
+  <h1>Connect to Helm memory</h1>
+  <p class="hint">Paste a Helm API key to authorize this app. The key grants access to that key's memory only.</p>
+  ${err}
+  <form method="post" action="${escAttr(base)}/authorize">
+      ${hidden}
+    <label for="api_key">Helm API key</label>
+    <input id="api_key" name="api_key" type="password" autocomplete="off" autofocus placeholder="helm_live_...">
+    <button type="submit">Authorize</button>
+  </form>
+</body></html>`;
+}
+
+function identityFromClaims(claims: Record<string, unknown>): AuthIdentity {
+  const str = (v: unknown, d = ""): string => (typeof v === "string" ? v : d);
+  const mode = claims.mode === "observe" || claims.mode === "inject" ? claims.mode : "off";
+  return {
+    keyId: str(claims.kid),
+    keyPrefix: str(claims.pfx),
+    accountId: str(claims.sub),
+    orgId: null,
+    userId: null,
+    role: claims.role === "root" ? "root" : "user",
+    caps: {
+      allowedLanes: null,
+      allowCustomModel: false,
+      rateLimit: { rpm: null, tpm: null },
+      concurrencyLimit: null,
+      budget: {
+        requests: null,
+        tokens: null,
+        spendUsd: null,
+        windowSeconds: null,
+        behavior: "degrade",
+        degradeLane: null,
+      },
+      // The only caps /mcp actually reads — keep memory scope faithful to the key.
+      memory: {
+        mode,
+        projectId: typeof claims.pid === "string" ? claims.pid : null,
+        threadSource: "header",
+      },
+    },
+  };
+}
+
+const NO_STORE = { "Cache-Control": "no-store" } as const;
+
+// Register the OAuth endpoints (all UNAUTHENTICATED — they ARE the auth surface).
+export function registerMcpOAuth(app: Hono<AppEnv>, deps: McpOAuthDeps): void {
+  // RFC 9728 protected-resource metadata (bare + path-suffixed form some clients use).
+  const protectedResource = (c: Context<AppEnv>) => {
+    const base = baseUrl(c, deps);
+    return c.json({
+      resource: `${base}/mcp`,
+      authorization_servers: [base],
+      bearer_methods_supported: ["header"],
+      scopes_supported: [],
+    });
+  };
+  app.get("/.well-known/oauth-protected-resource", protectedResource);
+  app.get("/.well-known/oauth-protected-resource/mcp", protectedResource);
+
+  // RFC 8414 authorization-server metadata (bare + path-suffixed form).
+  const authServerMeta = (c: Context<AppEnv>) => {
+    const base = baseUrl(c, deps);
+    return c.json({
+      issuer: base,
+      authorization_endpoint: `${base}/authorize`,
+      token_endpoint: `${base}/token`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+      scopes_supported: [],
+    });
+  };
+  app.get("/.well-known/oauth-authorization-server", authServerMeta);
+  app.get("/.well-known/oauth-authorization-server/mcp", authServerMeta);
+
+  // GET /authorize — show the login form (after validating the request shape).
+  app.get("/authorize", (c) => {
+    const q = pickParams(c.req.query());
+    const v = validateAuthz(q, deps.allowedRedirectPrefixes);
+    if (!v.ok) return c.text(v.error, 400);
+    return c.html(loginForm(q, baseUrl(c, deps)));
+  });
+
+  // POST /authorize — validate the pasted key, mint a code, redirect to the client.
+  app.post("/authorize", async (c) => {
+    const form = await c.req.parseBody();
+    const q = pickParams(form as Record<string, unknown>);
+    const v = validateAuthz(q, deps.allowedRedirectPrefixes);
+    if (!v.ok) return c.text(v.error, 400);
+
+    const apiKey = typeof form.api_key === "string" ? form.api_key : "";
+    const base = baseUrl(c, deps);
+    if (!apiKey) return c.html(loginForm(q, base, "Please paste your API key."), 400);
+
+    const rec = await deps.keyStore.getByHash(hashKey(apiKey));
+    if (rec === null || rec.disabled) {
+      deps.log?.("authorize: invalid or disabled API key");
+      return c.html(loginForm(q, base, "Invalid or disabled API key."), 401);
+    }
+
+    const nowSec = Math.floor(deps.now() / 1000);
+    const code = signJwt(
+      {
+        typ: "mcp_code",
+        sub: rec.account_id,
+        kid: rec.key_id,
+        pfx: rec.prefix,
+        role: rec.role,
+        pid: rec.memory_project_id,
+        mode: rec.memory_mode,
+        cc: q.code_challenge,
+        ru: q.redirect_uri,
+        aud: q.resource ?? `${base}/mcp`,
+        exp: nowSec + 60,
+      },
+      deps.signingKey,
+    );
+    // q.redirect_uri is allowlisted + parseable (validateAuthz).
+    const url = new URL(q.redirect_uri as string);
+    url.searchParams.set("code", code);
+    if (q.state) url.searchParams.set("state", q.state);
+    return c.redirect(url.toString(), 302);
+  });
+
+  // POST /token — exchange code (+ PKCE verifier) for an access token.
+  app.post("/token", async (c) => {
+    const form = (await c.req.parseBody()) as Record<string, unknown>;
+    const grant = typeof form.grant_type === "string" ? form.grant_type : "";
+    if (grant !== "authorization_code")
+      return c.json({ error: "unsupported_grant_type" }, 400, NO_STORE);
+
+    const code = typeof form.code === "string" ? form.code : "";
+    const verifier = typeof form.code_verifier === "string" ? form.code_verifier : "";
+    const redirectUri = typeof form.redirect_uri === "string" ? form.redirect_uri : "";
+    const nowSec = Math.floor(deps.now() / 1000);
+
+    const claims = verifyJwt(code, deps.signingKey, nowSec);
+    if (!claims || claims.typ !== "mcp_code")
+      return c.json(
+        { error: "invalid_grant", error_description: "bad or expired authorization code" },
+        400,
+        NO_STORE,
+      );
+    if (!verifier || !pkceMatches(verifier, String(claims.cc)))
+      return c.json(
+        { error: "invalid_grant", error_description: "PKCE verification failed" },
+        400,
+        NO_STORE,
+      );
+    if (redirectUri && redirectUri !== claims.ru)
+      return c.json(
+        { error: "invalid_grant", error_description: "redirect_uri mismatch" },
+        400,
+        NO_STORE,
+      );
+
+    const access = signJwt(
+      {
+        typ: "mcp_access",
+        sub: claims.sub,
+        kid: claims.kid,
+        pfx: claims.pfx,
+        role: claims.role,
+        pid: claims.pid,
+        mode: claims.mode,
+        aud: claims.aud,
+        exp: nowSec + deps.accessTtlSeconds,
+      },
+      deps.signingKey,
+    );
+    return c.json(
+      {
+        access_token: access,
+        token_type: "Bearer",
+        expires_in: deps.accessTtlSeconds,
+        scope: typeof form.scope === "string" ? form.scope : "",
+      },
+      200,
+      NO_STORE,
+    );
+  });
+}
+
+// /mcp auth that accepts EITHER an issued access JWT or a raw API key. A bearer
+// that is not a valid mcp_access token falls through to the existing API-key
+// middleware (an API key IS a bearer), so both ChatGPT and direct clients work.
+export function mcpAuth(deps: McpOAuthDeps): MiddlewareHandler {
+  const apiKeyMw = authMiddleware({ keyStore: deps.keyStore, log: deps.log ?? (() => {}) });
+  return async (c, next) => {
+    const auth = c.req.header("Authorization");
+    const m = auth ? /^Bearer\s+(.+)$/.exec(auth) : null;
+    if (m?.[1]) {
+      const claims = verifyJwt(m[1], deps.signingKey, Math.floor(deps.now() / 1000));
+      if (claims && claims.typ === "mcp_access") {
+        c.set("identity", identityFromClaims(claims));
+        return next();
+      }
+    }
+    return apiKeyMw(c, next);
+  };
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -134,6 +134,7 @@ import { buildClassifyAdapter } from "./routes/classify.js";
 import { createExecute } from "./routes/execute.js";
 import { registerGeminiRoute } from "./routes/gemini.js";
 import { registerMcpServer } from "./routes/mcp/index.js";
+import { deriveMcpSigningKey, mcpAuth, registerMcpOAuth } from "./routes/mcp/oauth.js";
 import { supportsMemoryAdmin } from "./routes/mcp/tools.js";
 import type { MessagesIdentity, RouteError } from "./routes/messages.js";
 import { registerMessagesRoute } from "./routes/messages.js";
@@ -1705,10 +1706,35 @@ export async function buildServer(
   // resolved (mirrors /v1/models).
   if (config.memory.mcp.enabled) {
     if (supportsMemoryAdmin(store.memory)) {
-      app.use(
-        "/mcp",
-        authMiddleware({ keyStore, log: (l) => logger.log("warn", "auth", { line: l }) }),
-      );
+      const mcpOAuth = config.memory.mcp.oauth;
+      if (mcpOAuth.enabled) {
+        // ChatGPT-style connectors can't send a raw key — front /mcp with an
+        // OAuth 2.1 shim (authorize/token + RFC 9728 discovery). Tokens are
+        // signed HS256 JWTs keyed off the existing at-rest OAuth secret, so the
+        // feature adds NO new secret but REQUIRES one to exist (fail-closed).
+        if (!oauthEncKey) {
+          throw new Error(
+            "memory.mcp.oauth.enabled requires HELM_OAUTH_ENC_KEY (used to sign MCP OAuth tokens): set a 32-byte key (base64 or 64 hex chars)",
+          );
+        }
+        const oauthDeps = {
+          keyStore,
+          signingKey: deriveMcpSigningKey(oauthEncKey),
+          accessTtlSeconds: mcpOAuth.access_token_ttl_seconds,
+          issuer: mcpOAuth.issuer,
+          allowedRedirectPrefixes: mcpOAuth.allowed_redirect_prefixes,
+          now: () => Date.now(),
+          log: (line: string) => logger.log("warn", "mcp.oauth", { line }),
+        };
+        registerMcpOAuth(app, oauthDeps);
+        // Accepts EITHER an issued access token OR a raw API key (back-compat).
+        app.use("/mcp", mcpAuth(oauthDeps));
+      } else {
+        app.use(
+          "/mcp",
+          authMiddleware({ keyStore, log: (l) => logger.log("warn", "auth", { line: l }) }),
+        );
+      }
       registerMcpServer(app, {
         memoryStore: store.memory,
         now: () => new Date(),

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-06-23 · MCP OAuth 2.1 shim（ChatGPT 连接器接入；docs/13；原则 1/2/7）
+
+- **目标**：ChatGPT 自定义连接器（Apps SDK）**不接受裸 API key**，只走 OAuth 2.1 authorize-code + PKCE（RFC 9728 发现）。现 `/mcp` 仅 API-key 中间件 → 无法被 ChatGPT 接入。
+- **决定**：在 `/mcp` 前加**薄 OAuth 授权服务器**（`apps/gateway/src/routes/mcp/oauth.ts`），把 OAuth token 映射回既有 API key 的 account——不引入新身份系统。端点：`/.well-known/oauth-protected-resource`(+`/mcp` 后缀)、`/.well-known/oauth-authorization-server`(+后缀)、`GET/POST /authorize`（登录页粘贴 helm key→`keyStore.getByHash` 校验）、`POST /token`（PKCE S256→发 access token）。`mcpAuth` 中间件接受 **JWT 或裸 API key**（向后兼容直连客户端）。
+- **ponytail 取舍**：**无状态 JWT，无 token/code 表、无迁移**。授权码本身是 60s 签名 JWT（PKCE 绑定）；access token 默认 30 天、**无 refresh**（到期重新登录）。签名密钥从既有 `HELM_OAUTH_ENC_KEY` 派生（HMAC 域分隔 `helm-mcp-oauth/v1`）——**不新增任何密钥**，但要求其存在（`memory.mcp.oauth.enabled` 且无 enc key → **fail-closed 拒启动**）。
+- **天花板（已在代码注释）**：授权码在 60s 窗口内可重放；access token 到期前不可撤销（撤销手段=轮换 enc key，会一次性失效全部 token）。升级路径：一次性码存储 + token 黑名单（届时本文件需加 store 依赖）。redirect_uri 前缀白名单（仅 https，默认 ChatGPT 连接器回调）防开放重定向；登录页 hidden 字段做 HTML 属性转义防反射 XSS（authorize 参数全可控）。
+- **配置**：`memory.mcp.oauth { enabled(默认 false), issuer?(缺省从 X-Forwarded-Proto/Host 推导), access_token_ttl_seconds(默认 2592000), allowed_redirect_prefixes }`。token 写入 audience（RFC 8707），但 `/mcp` 端只验签名+exp，aud 当 best-effort（单资源网关，aud 仅纵深防御）。
+- **验证**：TDD 红→绿；`oauth.test.ts` 16 例（密钥派生/JWT 篡改、PKCE 正误、过期码、发现元数据、authorize 校验+XSS 转义、e2e authorize→token→/mcp、裸 key 兼容、无凭据 401）；typecheck + lint + config samples 均绿。**未部署**；启用需 box 配置 `memory.mcp.oauth.enabled:true`（box 已有 `HELM_OAUTH_ENC_KEY`，因用了 Anthropic 订阅 OAuth）。
+
 ## 2026-06-22 · Claude 订阅（OAuth）token 成本折算（docs/04/07；约定「能力与定价数据源」；原则 6）
 
 - **问题**：admin 对 Claude Pro/Max 订阅（`anthropic/*` OAuth 池）流量只显示 token **数量**，花费恒为 `—`（null）。token 计数链路（解析→落库→聚合→渲染）对所有 provider 早已就绪，唯一缺口是 `config/pricing.yaml` 无 `anthropic/*` 行；`costOf(alias)` 以路由 alias 查 catalog 落空 → `resolveCostUsd` 返回 `null`（fail-open「未计量」）。`openai-codex/*` 早有定价故 ChatGPT 订阅花费一直能显示——Claude 是唯一漏配的订阅渠道；`github-copilot/*` 无 lane 引用，不在范围。
@@ -22,22 +31,13 @@
 - **决定 2（跨协议 fallback）**：`InternalRequest.thinking` 若是 Responses reasoning history 数组，不再作为 provider `thinking` 请求配置转发到 OpenAI-compatible / Anthropic target；attempt 记录 `thinking_history_stripped_for_target`。provider_raw.reasoning 继续按目标协议 allowlist 剥离并记录。
 - **验证**：TDD 红→绿；`openai-responses.test.ts` 覆盖 Codex native 清洗；`execute.test.ts` 覆盖 Codex 直通清洗与 fallback `thinking` 剥离；focused 237 测、core/gateway typecheck、Biome touched-file check 均绿。
 
-## 2026-06-22 · Opus 1M 上下文溢出预检 + 流式失败落库修正（docs/04/05/07；原则 3/5/7/8）
-
-- **线上实证**：`la.atmy.work` SQLite 显示 `claude-opus-4-8` 原生 Anthropic 请求在 `2026-06-22 01:28:23–01:33:50 UTC` 连续失败，核心错误为 `prompt is too long: 1001854 tokens > 1000000 maximum`；稍后同模型 `prompt_tokens=924300` 成功，说明客户端压缩/清理尚未把活动上下文降到硬上限以下。`decision_json.memory` 为空，Helm memory middleware 未参与。
-- **决定 1（上下文）**：对 Anthropic native target 在真正 provider invoke 前增加 exact `count_tokens` 预检；`claude-opus-4-8` / `claude-sonnet-4-6` / `claude-haiku-4-5` 采用保守硬上限 `1_000_000`，并与 catalog 值取较小者。`count_tokens` 失败时 fail-open 继续原尝试（避免 token helper 自身成为 5xx），但一旦精确 `input_tokens` 超限，记录 `skip_reason:"context_too_small"` 并进入 fallback，**不记 breaker failure**。
-- **决定 2（请求形状 400）**：上游 400 中的 `prompt is too long`、`does not support effort level`、`output_config.effort` 等判为请求形状错误，attempt 记 `invalid_request`，但不污染 circuit breaker。`:free` 429、OAuth 429 auto-park 等 provider-health 路径保持原语义。
-- **决定 3（effort）**：`claude-sonnet-4-6` 只允许 `low|medium|high|max` 的 `output_config.effort`；`xhigh` 等不兼容值在执行前以 `unsupported_reasoning_effort` 跳过该候选，而不是发给上游再 400。没有把 `xhigh` 自动 clamp 到 `max`，因为 clamp 会悄悄改变用户请求语义；fallback skip 更可观测。
-- **决定 4（流式可观测）**：`/v1/messages` 已写出 Anthropic `event:error` 时，同步把 `DecisionRecord.final.status` 改为 `error` 并写入 `error_reason`，避免 admin 显示 ok 但 payload 里是错误帧。Codex Responses `response.failed` / `error` 抛出的 `UpstreamError` 现在带原始 SSE event 到 `providerRaw`，让 `error_detail.provider_raw` 能保留故障字段（仍经 telemetry redaction）。
-- **仍未做**：all-failed chain 的 per-attempt upstream body capture 还没补；当前只继续保存 served attempt 的 `upstream_request_json`。这需要扩展 payload 表或决策 attempt 附属表，单独做更稳。
-- **验证**：TDD 红→绿；`execute.test.ts` 覆盖 exact count_tokens skip、Sonnet effort skip、request-shape 400 不触发 breaker；`messages.test.ts` 覆盖 stream error 落库；`openai-responses.test.ts` 覆盖 `response.failed.providerRaw`。focused 212 测、typecheck、Biome lint 均绿。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
+- **2026-06-22 · Opus 1M 上下文溢出预检 + 流式失败落库**：Anthropic native 在 invoke 前加 exact `count_tokens` 预检（opus/sonnet/haiku 硬上限 1e6 与 catalog 取较小者，count 失败 fail-open），超限记 `context_too_small` 进 fallback **不记 breaker**；上游 400 的 prompt-too-long/effort 形状错记 `invalid_request` 不污染 breaker；sonnet 仅允 low|medium|high|max effort（xhigh 执行前 skip 不 clamp，更可观测）；`/v1/messages` 已写 error 帧则同步改 `DecisionRecord.final.status=error`，Codex Responses 故障帧带 `providerRaw`。TODO：all-failed chain 的 per-attempt upstream body capture 未补。
 - **2026-06-21 · Codex Chat→Responses 兼容层移除 `temperature`**：economy+temperature:0 非流式 Chat 经 `openaiToResponsesRequest` 互译到 ChatGPT-account Codex Responses 后端 400 `Unsupported parameter: temperature`；改为 Codex Responses 用 openclaw 最小 body（`store:false`/`stream:true`/`include:[reasoning.encrypted_content]`/`text.verbosity:low`，不发 `max_output_tokens`/`temperature`），generic Responses 不变。
 - **2026-06-21 · 全仓评审修复 Tiers 1–5**：按 review C1/C2、C3/H3、H1/H2、H9/H10/H11、breaker+memory 分批修复；关键取舍包括删除未被网关调用且漂移的 `executor/fallback.ts`、不从 `prompt_tokens` 预减 cached、`cleanup_archive_enabled` 默认关并加 2× 安全线、`require_api_key:false` fail-closed、Anthropic mid-conv system 折叠保持现行为、OPEN 态 `recordFailure` no-op；M6/C4 延后单做。
 

--- a/packages/shared/src/config/memory-schema.ts
+++ b/packages/shared/src/config/memory-schema.ts
@@ -200,9 +200,38 @@ export const MemoryLlmSchema = z
 // fact/reflection CRUD to external agents, authed by the SAME API key as /v1.
 // Default OFF (fail-closed): an operator opts in. `.strict()` rejects unknown
 // keys so a typo'd toggle refuses startup rather than silently leaving it off.
+// OAuth 2.1 shim for the MCP endpoint (docs/13). ChatGPT connectors cannot send
+// a raw API key — they require an OAuth authorize/token handshake — so this block
+// turns on a thin authorization server in front of /mcp that maps an OAuth token
+// back to an existing API key's account. Default OFF: it adds a public
+// authorize/token surface, so an operator opts in. The access token is a stateless
+// HS256 JWT signed with a key derived from HELM_OAUTH_ENC_KEY (startup fails if
+// enabled without it). `.strict()` rejects typos.
+export const McpOAuthSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    // Override the public base URL advertised in discovery metadata + token
+    // audience. Leave unset to derive it from X-Forwarded-Proto/Host (or Host).
+    issuer: z.url().optional(),
+    // Access-token lifetime. No refresh grant: ChatGPT re-runs the login when it
+    // expires. Default 30 days. Revocation before expiry = rotate HELM_OAUTH_ENC_KEY.
+    access_token_ttl_seconds: z.number().int().positive().default(2_592_000),
+    // redirect_uri allowlist (prefix match, https only) — guards against the
+    // authorize endpoint being abused as an open redirector. Defaults cover the
+    // ChatGPT connector callback; add localhost for MCP Inspector testing.
+    allowed_redirect_prefixes: z
+      .array(z.url())
+      .default([
+        "https://chatgpt.com/connector/oauth/",
+        "https://chat.openai.com/connector/oauth/",
+      ]),
+  })
+  .strict();
+
 export const MemoryMcpSchema = z
   .object({
     enabled: z.boolean().default(false),
+    oauth: McpOAuthSchema.prefault({}),
   })
   .strict();
 


### PR DESCRIPTION
## Why

ChatGPT's MCP connector (Apps SDK) **cannot present a raw API key** — it requires an OAuth 2.1 authorize-code + PKCE flow (RFC 9728 discovery). Today `/mcp` only has API-key middleware, so it can't be added to ChatGPT.

## What

A **thin OAuth 2.1 authorization server** in front of `/mcp` that maps an OAuth token back to an existing API key's account — no new identity system.

- `routes/mcp/oauth.ts`: discovery (`/.well-known/oauth-protected-resource` + `/.well-known/oauth-authorization-server`, both with `/mcp`-suffixed variants), `GET/POST /authorize` (login page → paste a helm key → validated via `keyStore.getByHash`), `POST /token` (PKCE S256 → issues an HS256 JWT).
- `mcpAuth` middleware accepts **either** the issued JWT **or** a raw API key — direct/existing clients keep working unchanged.
- Config: `memory.mcp.oauth { enabled, issuer?, access_token_ttl_seconds, allowed_redirect_prefixes }`, default **off**.

## Design (ponytail)

- **Stateless**: the authorization code is a 60s signed JWT (PKCE-bound); the access token is a 30d signed JWT. **No token/code store, no migration.**
- **No new secret**: the signing key is derived (HMAC, domain-separated) from the existing `HELM_OAUTH_ENC_KEY`. Enabling oauth without it is **fail-closed** (refuses startup).
- **Security boundaries kept**: redirect_uri prefix allowlist (open-redirect guard, https-only) + HTML attribute escaping on reflected authorize params (reflected-XSS guard).

### Ceiling (documented in-code)

Codes are replayable within their 60s window; access tokens are non-revocable until expiry (revoke = rotate `HELM_OAUTH_ENC_KEY`). Upgrade path if it ever matters: a one-time-code store + token denylist. No refresh grant — ChatGPT re-runs the login on expiry.

## Tests

`oauth.test.ts` (16): key derivation + JWT tamper, PKCE pass/fail, expired code, discovery metadata, authorize validation + XSS escaping, e2e authorize→token→/mcp, raw-key back-compat, no-creds 401. `pnpm typecheck` + `pnpm lint` + config-samples green.

## Enabling

```yaml
memory:
  mcp:
    enabled: true
    oauth:
      enabled: true   # requires HELM_OAUTH_ENC_KEY (box already has it)
```

ChatGPT dialog: server URL `https://…/mcp`, predefined OAuth client (any client_id, no secret, token-endpoint-auth `none`), endpoints auto-discovered. On connect, ChatGPT opens the login page → paste a helm key → bound to that key's account/memory.

> One follow-up to verify after connecting: `/mcp` is POST-only JSON; if ChatGPT's client probes a GET/SSE session we may need to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)