### PR TITLE
v0.21.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.16",
+  "version": "0.21.17",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.17.

Ships the MCP OAuth 2.1 shim (#358): ChatGPT connectors authenticate against `/mcp` via authorize-code + PKCE, mapped to an existing API key's account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)