### PR TITLE
feat(memory): deep recall — hybrid fact retrieval + memory_recall MCP tool

### DIFF
--- a/apps/gateway/src/memory-embedder.test.ts
+++ b/apps/gateway/src/memory-embedder.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMemoryEmbedder } from "./memory-embedder.js";
+
+const PROVIDERS = [
+  { name: "openai", base_url: "https://api.example.com/v1", api_key_env: "EMB_KEY" },
+  { name: "other", base_url: "https://other.example.com/v1" },
+];
+
+function okFetch(vectors: number[][]) {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ data: vectors.map((embedding) => ({ embedding })) }),
+  })) as unknown as typeof fetch;
+}
+
+describe("createMemoryEmbedder (docs/14)", () => {
+  it("returns undefined when no embedding_model is configured (vector leg off)", () => {
+    expect(
+      createMemoryEmbedder({ embeddingModel: undefined, providers: PROVIDERS }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the provider has no base_url", () => {
+    expect(
+      createMemoryEmbedder({
+        embeddingModel: "missing/model",
+        providers: [{ name: "missing" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("a PREFIXED model whose provider is absent returns undefined (no fallback to providers[0])", () => {
+    // 'typo' is not a configured provider — must NOT silently embed against providers[0]
+    // ('openai') with the wrong creds. The vector leg is disabled instead.
+    expect(
+      createMemoryEmbedder({ embeddingModel: "typo/bge-m3", providers: PROVIDERS }),
+    ).toBeUndefined();
+  });
+
+  it("a BARE model (no prefix) uses the first provider", () => {
+    const embedder = createMemoryEmbedder({ embeddingModel: "bge-m3", providers: PROVIDERS });
+    expect(embedder).toBeDefined();
+  });
+
+  it("POSTs {base_url}/embeddings with the provider's api key and parses vectors in order", async () => {
+    const fetchImpl = okFetch([
+      [1, 0, 0],
+      [0, 1, 0],
+    ]);
+    const embedder = createMemoryEmbedder({
+      embeddingModel: "openai/bge-m3",
+      providers: PROVIDERS,
+      env: { EMB_KEY: "secret-key" },
+      fetchImpl,
+    });
+    expect(embedder).toBeDefined();
+    const out = await embedder?.embed(["hello", "world"]);
+    expect(out?.map((v) => [...v])).toEqual([
+      [1, 0, 0],
+      [0, 1, 0],
+    ]);
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("https://api.example.com/v1/embeddings");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer secret-key");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      model: "bge-m3",
+      input: ["hello", "world"],
+    });
+  });
+
+  it("empty input ⇒ empty output (no request)", async () => {
+    const fetchImpl = okFetch([]);
+    const embedder = createMemoryEmbedder({
+      embeddingModel: "openai/bge-m3",
+      providers: PROVIDERS,
+      env: {},
+      fetchImpl,
+    });
+    expect(await embedder?.embed([])).toEqual([]);
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("rejects on a non-OK response (callers fail-open)", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 503 })) as unknown as typeof fetch;
+    const embedder = createMemoryEmbedder({
+      embeddingModel: "openai/bge-m3",
+      providers: PROVIDERS,
+      env: {},
+      fetchImpl,
+    });
+    await expect(embedder?.embed(["x"])).rejects.toThrow();
+  });
+});

--- a/apps/gateway/src/memory-embedder.ts
+++ b/apps/gateway/src/memory-embedder.ts
@@ -1,0 +1,75 @@
+import type { Embedder } from "@helm/core";
+
+// docs/14 — the embedding port impl for hybrid recall's vector leg. helm has no
+// /v1/embeddings route and ProviderClient has no embeddings method, so this is a thin
+// OpenAI-compatible client that POSTs `{base_url}/embeddings` directly against the
+// provider that owns `memory.llm.embedding_model` ("provider/model"). Self-hosted TEI,
+// OpenAI, Cohere-compat, etc. all expose this shape. The vector leg is OPTIONAL: with
+// no embedding_model (or no resolvable provider/base_url) this returns undefined and
+// recall runs FTS+score. Keys come from the provider's api_key_env (never plaintext in
+// config), matching the rest of helm's credential handling.
+
+interface EmbedderProvider {
+  readonly name: string;
+  readonly base_url?: string;
+  readonly api_key_env?: string;
+}
+
+interface OpenAiEmbeddingsResponse {
+  data: Array<{ embedding: number[] }>;
+}
+
+const DEFAULT_EMBED_TIMEOUT_MS = 30_000;
+
+export function createMemoryEmbedder(deps: {
+  embeddingModel: string | undefined;
+  providers: readonly EmbedderProvider[];
+  env?: Record<string, string | undefined>;
+  fetchImpl?: typeof fetch;
+  // Bounds every embeddings request so a stalled endpoint can't hang memory_recall
+  // (it fails open to FTS+score) or wedge an embedding worker. Defaults to 30s.
+  timeoutMs?: number;
+}): Embedder | undefined {
+  const model = deps.embeddingModel;
+  if (model === undefined) return undefined;
+
+  // "provider/model" → provider name + upstream model id. A PREFIXED model resolves
+  // STRICTLY to that provider: a typo'd or removed prefix must NOT fall back to
+  // providers[0] (that would send private memory text to the wrong upstream with the
+  // wrong model/creds — Codex review). A BARE model (no slash) uses the first provider,
+  // mirroring the memory-LLM convention.
+  const slash = model.indexOf("/");
+  const hasPrefix = slash > 0;
+  const providerModel = hasPrefix ? model.slice(slash + 1) : model;
+  const provider = hasPrefix
+    ? deps.providers.find((p) => p.name === model.slice(0, slash))
+    : deps.providers[0];
+  if (provider?.base_url === undefined) return undefined; // unresolvable → vector leg off
+
+  const baseUrl = provider.base_url.replace(/\/+$/, "");
+  const env = deps.env ?? process.env;
+  const apiKey = provider.api_key_env !== undefined ? env[provider.api_key_env] : undefined;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_EMBED_TIMEOUT_MS;
+
+  return {
+    async embed(texts: string[]): Promise<Float32Array[]> {
+      if (texts.length === 0) return [];
+      const res = await fetchImpl(`${baseUrl}/embeddings`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(apiKey !== undefined ? { authorization: `Bearer ${apiKey}` } : {}),
+        },
+        body: JSON.stringify({ model: providerModel, input: texts }),
+        // A bounded timeout so the OPTIONAL vector leg can never block a tool call or
+        // stick an embedding worker on one job (callers fail open on reject).
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!res.ok) throw new Error(`embeddings request failed: ${res.status}`);
+      const json = (await res.json()) as OpenAiEmbeddingsResponse;
+      // Preserve input order (OpenAI returns data in request order); be defensive.
+      return json.data.map((d) => Float32Array.from(d.embedding));
+    },
+  };
+}

--- a/apps/gateway/src/routes/mcp/deps.ts
+++ b/apps/gateway/src/routes/mcp/deps.ts
@@ -1,4 +1,4 @@
-import type { MemoryStore } from "@helm/core";
+import type { Embedder, MemoryStore, ScoreConfig } from "@helm/core";
 
 // docs/13 — dependencies for the Memory MCP server (mirrors the admin/route DI
 // pattern). The composition root (server.ts) wires store.memory + the same
@@ -11,4 +11,9 @@ export interface McpDeps {
   // Server version reported in the MCP `initialize` handshake (serverInfo.version).
   serverVersion?: string;
   log?: (line: string) => void;
+  // docs/14 — hybrid recall (memory_recall). embedder OPTIONAL (absent ⇒ FTS+score).
+  // scoreConfig = memory.forgetting.score; recall = memory.forgetting.facts_retrieval.
+  embedder?: Embedder;
+  scoreConfig: ScoreConfig;
+  recall: { enabled: boolean; topK: number };
 }

--- a/apps/gateway/src/routes/mcp/index.ts
+++ b/apps/gateway/src/routes/mcp/index.ts
@@ -106,6 +106,9 @@ export function registerMcpServer(app: Hono<AppEnv>, deps: McpDeps): void {
       store,
       now: deps.now,
       estimateTokens: deps.estimateTokens,
+      scoreConfig: deps.scoreConfig,
+      recall: deps.recall,
+      ...(deps.embedder !== undefined ? { embedder: deps.embedder } : {}),
     };
 
     let body: unknown;

--- a/apps/gateway/src/routes/mcp/mcp.test.ts
+++ b/apps/gateway/src/routes/mcp/mcp.test.ts
@@ -54,12 +54,21 @@ function harness() {
   const ctxFor = (
     accountId: string,
     defaultProjectId: string | null = null,
+    extra: Partial<MemoryToolContext> = {},
   ): MemoryToolContext => ({
     accountId,
     defaultProjectId,
     store,
     now: () => NOW,
     estimateTokens: (t) => Math.ceil(t.length / 4),
+    scoreConfig: {
+      half_life_s: 86400,
+      importance_floor: 0.1,
+      importance_ceil: 1.0,
+      access_weight: 0.15,
+    },
+    recall: { enabled: true, topK: 10 },
+    ...extra,
   });
   return { store, ctxFor };
 }
@@ -69,13 +78,14 @@ function parse(result: { content: Array<{ text: string }>; isError?: boolean }) 
 }
 
 describe("memory MCP tools (docs/13)", () => {
-  it("lists the six CRUD tools with input schemas", () => {
+  it("lists the seven tools with input schemas", () => {
     const tools = listMemoryTools();
     expect(tools.map((t) => t.name).sort()).toEqual([
       "memory_add",
       "memory_delete",
       "memory_get",
       "memory_list",
+      "memory_recall",
       "memory_search",
       "memory_update",
     ]);
@@ -106,6 +116,78 @@ describe("memory MCP tools (docs/13)", () => {
       await callMemoryTool("memory_search", { type: "fact", query: "typescript" }, ctx),
     );
     expect((found.facts as unknown[]).length).toBe(1);
+  });
+
+  it("memory_recall hybrid-recalls a fact (CJK trigram), account-scoped", async () => {
+    const { ctxFor } = harness();
+    const ctxA = ctxFor("acct-a");
+    await callMemoryTool(
+      "memory_add",
+      { type: "fact", text: "用户最喜欢的编程语言是 TypeScript", subject: "lang" },
+      ctxA,
+    );
+    await callMemoryTool(
+      "memory_add",
+      { type: "fact", text: "项目部署在 la.atmy.work", subject: "deploy" },
+      ctxA,
+    );
+    // another account's matching fact must NOT surface for acct-a
+    await callMemoryTool(
+      "memory_add",
+      { type: "fact", text: "编程语言机密信息", subject: "x" },
+      ctxFor("acct-b"),
+    );
+    const res = parse(await callMemoryTool("memory_recall", { query: "编程语言" }, ctxA));
+    const texts = (res.facts as Array<{ text: string }>).map((f) => f.text);
+    expect(texts).toContain("用户最喜欢的编程语言是 TypeScript");
+    expect(texts).not.toContain("编程语言机密信息");
+  });
+
+  it("memory_recall degrades to substring LIKE when facts_retrieval is disabled", async () => {
+    const { ctxFor } = harness();
+    const ctx = ctxFor("a", null, { recall: { enabled: false, topK: 10 } });
+    await callMemoryTool(
+      "memory_add",
+      { type: "fact", text: "loves TypeScript", subject: "lang" },
+      ctx,
+    );
+    const res = parse(await callMemoryTool("memory_recall", { query: "TypeScript" }, ctx));
+    expect(res.degraded).toBe(true);
+    expect((res.facts as unknown[]).length).toBe(1);
+  });
+
+  it("memory_recall is fail-open: an embedder error still returns FTS+score results", async () => {
+    const { ctxFor } = harness();
+    const throwingEmbedder = { embed: vi.fn().mockRejectedValue(new Error("embed down")) };
+    const ctx = ctxFor("a", null, { embedder: throwingEmbedder });
+    await callMemoryTool(
+      "memory_add",
+      { type: "fact", text: "deploy target is la.atmy.work", subject: "deploy" },
+      ctx,
+    );
+    const result = await callMemoryTool("memory_recall", { query: "deploy target" }, ctx);
+    expect(result.isError).toBeFalsy();
+    const res = parse(result);
+    expect((res.facts as Array<{ text: string }>).map((f) => f.text)).toContain(
+      "deploy target is la.atmy.work",
+    );
+  });
+
+  it("memory_recall reinforces recalled facts (reference bump)", async () => {
+    const { ctxFor, store } = harness();
+    const ctx = ctxFor("a");
+    const added = parse(
+      await callMemoryTool(
+        "memory_add",
+        { type: "fact", text: "prefers dark mode theme", subject: "ui" },
+        ctx,
+      ),
+    );
+    const id = (added.added as string[])[0] as string;
+    await callMemoryTool("memory_recall", { query: "dark mode" }, ctx);
+    // better-sqlite3 is synchronous, so the fire-and-forget bump has already run.
+    const got = await store.getFactById?.({ accountId: "a", id });
+    expect(got?.referenceCount).toBe(1);
   });
 
   it("memory_add(reflection) returns id + version", async () => {
@@ -229,6 +311,13 @@ function mcpApp(rec: ApiKeyRecord | null) {
     memoryStore: store,
     now: () => NOW,
     estimateTokens: (t) => Math.ceil(t.length / 4),
+    scoreConfig: {
+      half_life_s: 86400,
+      importance_floor: 0.1,
+      importance_ceil: 1.0,
+      access_weight: 0.15,
+    },
+    recall: { enabled: true, topK: 10 },
   });
   return app;
 }
@@ -280,7 +369,7 @@ describe("POST /mcp JSON-RPC route (docs/13)", () => {
     const list = (await (await app.request("/mcp", rpc("tools/list"))).json()) as {
       result: { tools: Array<{ name: string }> };
     };
-    expect(list.result.tools).toHaveLength(6);
+    expect(list.result.tools).toHaveLength(7);
 
     const add = (await (
       await app.request(

--- a/apps/gateway/src/routes/mcp/tools.ts
+++ b/apps/gateway/src/routes/mcp/tools.ts
@@ -1,7 +1,9 @@
 import {
   buildReconciledFactBatch,
+  type Embedder,
   MemoryFactContentHashConflictError,
   type MemoryStore,
+  type ScoreConfig,
 } from "@helm/core";
 import type { Fact, Reflection } from "@helm/shared";
 import { z } from "zod";
@@ -67,6 +69,12 @@ export interface MemoryToolContext {
   store: MemoryAdminStore;
   now: () => Date;
   estimateTokens: (text: string) => number;
+  // docs/14 — hybrid recall (memory_recall). embedder is OPTIONAL: absent ⇒ the vector
+  // leg is skipped (FTS+score). scoreConfig is the forgetting curve for the score
+  // signal. recall carries the gate + top-K (memory.forgetting.facts_retrieval).
+  embedder?: Embedder;
+  scoreConfig: ScoreConfig;
+  recall: { enabled: boolean; topK: number };
 }
 
 // MCP tool result envelope (the subset we emit). isError marks a tool-level
@@ -260,6 +268,82 @@ async function handleSearch(
   return ok(out);
 }
 
+const recallSchema = z.object({
+  query: z.string().min(1),
+  limit: z.number().int().min(1).max(50).optional(),
+  ...scopeFields,
+});
+
+// docs/14 — DEEP RECALL. Hybrid relevance search over facts (vector + FTS5 trigram +
+// forgetting score, RRF-fused), distinct from memory_search's substring LIKE. Gated by
+// memory.forgetting.facts_retrieval.enabled; FAIL-OPEN — a disabled gate, an absent
+// searchFacts adapter, OR a search/embed error all degrade to the LIKE path so the tool
+// never errors. Recalled facts get a fire-and-forget reinforcement bump.
+async function handleRecall(
+  args: z.infer<typeof recallSchema>,
+  ctx: MemoryToolContext,
+): Promise<McpToolResult> {
+  const scope = scopeInput(ctx, args);
+  const limit = args.limit ?? ctx.recall.topK;
+  const searchFacts = ctx.store.searchFacts?.bind(ctx.store);
+
+  const degradeToLike = async (): Promise<McpToolResult> => {
+    const { rows } = await ctx.store.listFacts({
+      accountId: ctx.accountId,
+      ...scope,
+      status: "active",
+      search: args.query,
+      limit,
+      offset: 0,
+    });
+    return ok({ facts: rows.map(factView), degraded: true });
+  };
+
+  if (!ctx.recall.enabled || searchFacts === undefined) return degradeToLike();
+
+  // Embed the query for the vector leg; fail-open drops the leg (FTS+score still run).
+  let queryEmbedding: Float32Array | undefined;
+  if (ctx.embedder !== undefined) {
+    try {
+      const [vec] = await ctx.embedder.embed([args.query]);
+      queryEmbedding = vec;
+    } catch {
+      queryEmbedding = undefined;
+    }
+  }
+
+  let facts: Fact[];
+  try {
+    facts = await searchFacts({
+      accountId: ctx.accountId,
+      ...scope,
+      queryText: args.query,
+      ...(queryEmbedding !== undefined ? { queryEmbedding } : {}),
+      limit,
+      now: ctx.now(),
+      scoreConfig: ctx.scoreConfig,
+    });
+  } catch {
+    return degradeToLike();
+  }
+
+  // Reinforcement bump — recalled facts are "used". Fire-and-forget: never awaited,
+  // never blocks or throws the tool response.
+  if (facts.length > 0 && ctx.store.bumpReferences !== undefined) {
+    void ctx.store
+      .bumpReferences({
+        accountId: ctx.accountId,
+        observationIds: [],
+        reflectionIds: [],
+        factIds: facts.map((f) => f.id),
+        now: ctx.now(),
+      })
+      .catch(() => {});
+  }
+
+  return ok({ facts: facts.map(factView) });
+}
+
 async function handleList(
   args: z.infer<typeof listSchema>,
   ctx: MemoryToolContext,
@@ -379,6 +463,11 @@ const TOOLS: Record<string, ToolDef> = {
     "Search memories by text. Omit `type` to search both facts and reflections. Returns active memories unless includeInactive=true.",
     searchSchema,
     handleSearch,
+  ),
+  memory_recall: defineTool(
+    "Deep relevance search over remembered facts — recall what was discussed or decided about a topic, across sessions. Ranks by meaning (cross-lingual when embeddings are configured) + keywords + recency. Use this for recall; memory_search is exact substring; memory_list browses.",
+    recallSchema,
+    handleRecall,
   ),
   memory_list: defineTool(
     "List memories of a `type` (paginated). Returns active memories unless includeInactive=true.",

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_LANES,
   type DecayDeps,
   discoverOAuthModels,
+  type EmbeddingJob,
   type GeminiGenerateContentResponse,
   type GeneratedKey,
   geminiTransformer,
@@ -79,6 +80,7 @@ import {
   routeRequest,
   runCleanupPass,
   runDecayJob,
+  runEmbeddingJob,
   runObserverJob,
   runReflectorJob,
   type StoreSet,
@@ -106,6 +108,7 @@ import { createApp } from "./app.js";
 import { readBuildInfo } from "./build-info.js";
 import { INTERNAL_API_KEY_ID } from "./internal-key.js";
 import { createJsonLogger, type Logger } from "./logging.js";
+import { createMemoryEmbedder } from "./memory-embedder.js";
 import { createMemoryLlmRuntime, type MemoryModelResolution } from "./memory-llm.js";
 import { createSelfHttpClient } from "./memory-self-http.js";
 import { authMiddleware } from "./middleware/auth.js";
@@ -1582,6 +1585,16 @@ export async function buildServer(
     estimateTokens: estimateMemoryTokens,
     log: memoryLog,
   });
+  // docs/14 — embedder for hybrid recall's vector leg, built from
+  // memory.llm.embedding_model (absent ⇒ undefined ⇒ FTS+score). Used by memory_recall
+  // (query embedding) and the background embedding job (fact embedding).
+  const memoryEmbedder = createMemoryEmbedder({
+    embeddingModel: config.memory.llm.embedding_model,
+    providers: config.providers,
+    timeoutMs: config.memory.llm.timeout_ms,
+  });
+  const embeddingModel = config.memory.llm.embedding_model;
+  const embeddingDim = config.memory.llm.embedding_dimensions;
 
   // Observer/Reflector deps (docs/08 Phase 2). The LLM path is opt-in via
   // config.memory.llm and runs ONLY in these background jobs; disabled or failed
@@ -1740,6 +1753,14 @@ export async function buildServer(
         now: () => new Date(),
         estimateTokens: estimateMemoryTokens,
         log: (line) => logger.log("warn", "mcp", { line }),
+        // docs/14 — hybrid recall config for memory_recall. The embedder (vector leg)
+        // is wired just below from memory.llm.embedding_model; absent ⇒ FTS+score only.
+        scoreConfig: config.memory.forgetting.score,
+        recall: {
+          enabled: config.memory.forgetting.facts_retrieval.enabled,
+          topK: config.memory.forgetting.facts_retrieval.top_k,
+        },
+        ...(memoryEmbedder !== undefined ? { embedder: memoryEmbedder } : {}),
       });
     } else {
       logger.log("warn", "mcp", {
@@ -2511,6 +2532,23 @@ export async function buildServer(
       // forgetting.enabled is false, so with the flag off no decay job is ever enqueued
       // and the worker behaves byte-identically to today.
       runDecay: (job) => runDecayJob(job, decayDeps),
+      // docs/14 — dispatch embedding rows to fill the vector index. Wired ONLY when an
+      // embedder + dimension are configured (memory.llm.embedding_model/_dimensions);
+      // absent ⇒ no embedding rows are enqueued and the vector leg stays empty (recall
+      // = FTS+score). Fail-open like every memory job.
+      ...(memoryEmbedder !== undefined && embeddingModel !== undefined && embeddingDim !== undefined
+        ? {
+            runEmbedding: (job: EmbeddingJob) =>
+              runEmbeddingJob(job, {
+                memoryStore: store.memory,
+                embedder: memoryEmbedder,
+                model: embeddingModel,
+                dim: embeddingDim,
+                batchSize: 64,
+                log: memoryLog,
+              }),
+          }
+        : {}),
       onTick: async () => {
         await maybeEnqueueDecayJobs({
           memoryStore: store.memory,

--- a/docs/14-memory-deep-recall.md
+++ b/docs/14-memory-deep-recall.md
@@ -1,0 +1,232 @@
+# 14 — Memory Deep Recall (Hybrid Fact Retrieval + `memory_recall` MCP tool)
+
+> Status: proposed → in implementation.
+> Builds on [08 — memory middleware](08-memory-middleware.md),
+> [12 — memory forgetting & tiering](12-memory-forgetting-and-tiering.md) (this **implements its deferred P8**),
+> [13 — memory admin & MCP](13-memory-admin-and-mcp.md) (this **adds a 7th MCP tool**).
+
+## Problem
+
+`docs/13` shipped six MCP CRUD tools over the long tier (`memory_facts` + `memory_reflections`).
+Its `memory_search` is a **substring `LIKE` over `fact_text`** (plus an O(n) JS `includes()` scan of
+reflections). That is the *wrong* retrieval for an external agent asking **"what did we discuss /
+decide about X"**:
+
+- `LIKE '%成本%'` can never match a fact stored as "cost" — **no cross-lingual recall** (helm usage is
+  bilingual zh+en).
+- substring match has **no relevance ranking** — every hit is equal; a decayed/superseded fact ranks
+  the same as a fresh, central one.
+- it ignores the rich ranking signals the fact store already carries (`importance`, `referenceCount`,
+  `referencedAt`, bi-temporal `validFrom/invalidAt/expiredAt`).
+
+An MCP consumer now needs **deep history recall**: query-driven, relevance-ranked retrieval over the
+distilled memory the small model (`memory.llm` → Observer/Reflector) already produces.
+
+## Solution — implement P8 (hybrid fact retrieval) and expose it as `memory_recall`
+
+`docs/12` already specified the engine and **deferred it** ("needs embedding infra"). This doc builds
+exactly that engine and wires one new MCP tool over it. **Nothing about the architecture is new — we
+are building helm's own deferred P8.**
+
+- **Retrieval unit = `memory_facts`** (the distilled, cross-session, bi-temporal long tier). Facts carry
+  `owner_id` + full scope, so retrieval needs no thread join. Reflections (one rolled-up blob per scope)
+  and the raw/observation tiers stay **out of scope** for search, consistent with `docs/13` — they are
+  not retrieval units. Complete drill-down to raw history is reachable later via a fact's
+  `sourceObservationRange` → observation `sourceMessageRange` chain; it is **not** the primary search
+  surface.
+- **Three deterministic signals**, each a ranked list per query, fused by **RRF (k=60)**:
+  1. **vector** similarity — `sqlite-vec` (SQLite) / `pgvector` (Postgres), dialect sealed in the adapter;
+  2. **full-text** — `FTS5` with the **`trigram` tokenizer** (SQLite) / `tsvector` (Postgres);
+  3. **forgetting score** — the existing `recency × importance + access_bonus` (so a decayed fact ranks
+     low in retrieval too; retrieval and forgetting share one notion of "alive").
+- **Bilingual story**: the **multilingual embedding** bridges meaning across zh↔en (the thing keyword
+  cannot do); the **trigram FTS** catches literals/identifiers in both scripts (the thing vectors blur —
+  `unicode61` does **not** segment CJK, so a whole Chinese run collapses to one token; trigram indexes
+  3-char windows and works for CJK + Latin without a segmenter); RRF fuses so neither failure mode
+  dominates.
+- **Same invariants as P8**: account-scoped reads (`owner_id = :accountId AND expired_at IS NULL`),
+  **fail-open** (empty/failed recall → caller still gets a result; a degraded leg never 5xxs), and
+  **retrieval results get the reinforcement bump** (recalled facts are "used" → `referenceCount += 1`,
+  `referencedAt = now`).
+
+### Why RRF and not weighted-sum
+
+RRF is **rank-based, scale-free, no tuned weights**, order-stable and trivially unit-testable on a
+fixture — deliberately *not* a learned/hidden fusion (Mem0). BM25 (unbounded, negative) and cosine
+(0–1) live on incompatible scales; RRF consumes ranks, so no normalization is needed.
+
+```
+RRF(fact) = Σ_signal  1 / (k + rank_signal(fact)),   k = 60
+```
+
+A fact present in only one signal's list contributes one term and is naturally penalized vs a
+consensus hit. `k` is a code constant, not config.
+
+## Embedding pipeline
+
+The small model that distills is already wired (`apps/gateway/src/memory-llm.ts` → `chatCompletion`
+on a loopback self-HTTP client). Embeddings are the one **net-new** call.
+
+- **Core stays framework-agnostic**: core defines an injected `Embedder` port
+  (`embed(texts: string[]): Promise<Float32Array[]>`); the gateway composition root provides the impl
+  (an OpenAI-compatible `POST /v1/embeddings` call against the configured model). Tests inject a
+  deterministic fake embedder.
+- **Off the hot path**: facts are embedded in the **background**. `insertFactsReconciled` already returns
+  `{ insertedIds, supersededIds, resurrectedIds }` — exactly the rows needing (or losing) an embedding.
+  Embedding runs via a new `"embedding"` memory job (`MemoryJobTypeSchema`), drained by the existing
+  worker, so it survives restarts and batches. The request path is never blocked; the only synchronous
+  embed is **one query embedding** inside a `memory_recall` call (fail-open to FTS+score if it errors).
+- **Config** (`memory.llm`, strict): `embedding_model` (OpenAI-compatible model id / lane; optional —
+  **absent ⇒ vector leg disabled**, recall degrades to FTS+score), `embedding_dimensions` (must match
+  the model; pins the column width). Default multilingual pick: **bge-m3 (1024-d)** self-hosted via an
+  OpenAI-compatible server (e.g. HF TEI); fallback Qwen3-Embedding-0.6B or a managed API. The model is a
+  config value, never hardcoded.
+- **Versioning**: store `embedding_model` + `embedding_dim` alongside the vector. On a model/dim change,
+  re-embed lazily in the background (`WHERE embedding_model != :current`). Never mix vectors from two
+  models in one index — cosine across models is meaningless.
+
+## `MemoryStore` port — new method
+
+Optional `?` (additive; existing fakes stay valid). **NOT** added to `REQUIRED_METHODS` /
+`MemoryAdminStore` (that gate is shared by the admin route and would fail-close the whole `/mcp` mount
+for any adapter lacking it); the `memory_recall` handler **null-checks** `ctx.store.searchFacts` and
+degrades to today's `listFacts({ search })` LIKE when absent.
+
+```ts
+// Hybrid relevance retrieval over memory_facts (docs/14 / P8). Account-guarded,
+// active-only. Vector leg used only when queryEmbedding is provided AND the adapter
+// has an embedding column populated; otherwise FTS+score. Order is the contract;
+// per-engine scores (bm25 vs ts_rank) are NOT comparable across dialects and are
+// internal. FAIL-OPEN at the call site.
+searchFacts?(input: {
+  accountId: string;
+  projectId?: string;
+  resourceId?: string;
+  threadId?: string;
+  queryText: string;                 // raw user keywords (adapter sanitizes to FTS dialect)
+  queryEmbedding?: Float32Array;      // absent ⇒ skip the vector leg
+  limit: number;                      // top_k after fusion
+  now: Date;                          // for the forgetting-score signal
+  scoreConfig: ScoreConfig;           // reuse memory.forgetting.score curve
+}): Promise<Fact[]>;                  // RRF-ranked, best first
+```
+
+`bumpReferences` gains optional `factIds` (back-compat — existing callers pass `[]`) so recalled facts
+get the reinforcement bump alongside observations/reflections.
+
+## Schema & migrations
+
+Dialect differences stay inside the adapters; core calls only the port.
+
+### SQLite — migration **v28** (`packages/core/src/store/sqlite/migrate.ts`; current max = 27)
+
+1. `ALTER TABLE memory_facts ADD COLUMN embedding BLOB` (nullable) + `embedding_model TEXT`
+   + `embedding_dim INTEGER`.
+2. **FTS5 trigram** external-content table over `fact_text` (index only, no text copy) + AI/AD/AU sync
+   triggers, `'rebuild'` to backfill existing rows:
+   ```sql
+   CREATE VIRTUAL TABLE memory_facts_fts USING fts5(
+     fact_text, content='memory_facts', content_rowid='rowid', tokenize='trigram');
+   INSERT INTO memory_facts_fts(memory_facts_fts) VALUES('rebuild');
+   -- + AFTER INSERT/DELETE/UPDATE triggers keeping the index in sync
+   ```
+3. **sqlite-vec** `vec0` virtual table keyed by `memory_facts.rowid` (only created/queried when the
+   extension loads — see load hook below):
+   ```sql
+   CREATE VIRTUAL TABLE memory_facts_vec USING vec0(
+     fact_rowid INTEGER PRIMARY KEY, embedding FLOAT[<dim>]);
+   ```
+4. `PRAGMA auto_vacuum = INCREMENTAL` discipline (the repo had a free-page bloat incident; deletes from
+   the fact tier + vec churn must not leak pages).
+
+`db.exec(m.sql)` runs the whole block at once (multi-statement OK). **`loadExtension` is not called
+anywhere today** — add a sqlite-vec load hook adjacent to `applyPragmas`, on **both** connection
+openers (`runMigrations` and `createSqliteDb`). If the extension fails to load (missing binary), log and
+**continue without the vector leg** (FTS+score still works) — never crash boot.
+
+### Postgres — migration **v27** (`packages/core/src/store/postgres/migrate.ts`; current max = 26)
+
+1. `CREATE EXTENSION IF NOT EXISTS vector;`
+2. `ALTER TABLE memory_facts ADD COLUMN embedding vector(<dim>)` (or `halfvec` for half the index) +
+   `embedding_model TEXT` + `embedding_dim INTEGER`.
+3. `CREATE INDEX ... USING hnsw (embedding vector_cosine_ops)` and
+   `CREATE INDEX ... USING gin (to_tsvector('simple', fact_text))` — `'simple'` config so CJK isn't
+   English-stemmed; query via `websearch_to_tsquery` (tolerates arbitrary input).
+
+> **Landmine:** the pg migration runner `splitStatements()` splits on every `;`. Keep all DDL
+> semicolon-terminated only (no `;` inside string literals / `WITH (...)`). One statement per `;`.
+> PGlite 0.4.6 (tests) bundles pgvector via `@electric-sql/pglite/vector` — thread the `vector`
+> extension into the PGlite constructor so the contract tests cover the pg vector path in-process.
+
+## MCP tool — `memory_recall`
+
+Added to the `TOOLS` table in `apps/gateway/src/routes/mcp/tools.ts`.
+
+```
+memory_recall(query, projectId?, resourceId?, threadId?, limit?)
+```
+
+- `query`: `z.string().min(1)`; `limit`: `1..50`, default 10; scope via the existing `scopeFields` +
+  `scopeInput` (project defaults to the key's `defaultProjectId`; **account always from
+  `ctx.accountId`, never args**).
+- Handler: embed the query (via injected embedder; on failure → `queryEmbedding` omitted), call
+  `ctx.store.searchFacts?.(...)`; if the method is absent, **degrade** to `listFacts({ search: query })`.
+  Fire the reinforcement bump (fire-and-forget) for the returned fact ids. Return `factView(...)` rows +
+  rank order via `ok(...)`.
+- Description (drives tool selection): *"Deep relevance search over remembered facts — what was
+  discussed/decided about a topic, across sessions. Ranks by meaning (cross-lingual) + keywords +
+  recency. Use this for recall; use memory_search for exact substring lookup, memory_list to browse."*
+
+## Config surface (fail-closed, fewest knobs)
+
+Reuse `docs/12`'s gate name; add the embedding fields to the existing `llm` block. All `.strict()`.
+
+```ts
+// memory.forgetting.facts_retrieval (docs/12 P8) — master gate for hybrid recall.
+facts_retrieval: z.object({
+  enabled: z.boolean().default(false),          // off ⇒ memory_recall degrades to LIKE
+  top_k: z.number().int().positive().default(10),
+}).strict().prefault({}),
+
+// memory.llm additions
+embedding_model: z.string().min(1).optional(),        // absent ⇒ vector leg off (FTS+score only)
+embedding_dimensions: z.number().int().positive().optional(),
+```
+
+- `facts_retrieval.enabled` independent of embeddings: with it on but no `embedding_model`, recall runs
+  **FTS+score** (no vector leg) — a usable, cross-lingual-blind mode. Configuring `embedding_model`
+  lights up the vector leg → full hybrid. This is the staged on-ramp inside one flag.
+- No exposed RRF `k`, no per-signal weights, no tokenizer knob — code constants (no lying knobs).
+- `.strict()` ⇒ a typo'd key refuses startup; add the unknown-key tests per `memory-schema.test.ts`.
+
+## Fail-open (the hard rule)
+
+- Query embed fails → omit `queryEmbedding` → FTS+score recall.
+- Vector leg errors (extension absent / dim mismatch) → adapter returns FTS+score results.
+- Whole `searchFacts` throws → handler catches → degrade to `listFacts({ search })` LIKE.
+- Background embedding job fails → logged, fact simply has no vector yet (FTS+score still finds it);
+  retried by the worker. **No path 5xxs the request or the tool call.**
+
+## TDD plan (red → green)
+
+| # | File | Red assertion |
+|---|---|---|
+| 1 | `packages/shared/src/config/memory-schema.test.ts` | `facts_retrieval` defaults backfill; unknown key throws; `embedding_model`/`embedding_dimensions` parse; absent ⇒ undefined. |
+| 2 | `packages/shared/src/memory/jobs.test.ts` | `MemoryJobTypeSchema` accepts `"embedding"`; unknown type throws. |
+| 3 | `packages/core/src/store/sqlite/memory-search.test.ts` | `searchFacts` over `:memory:`: FTS-only path returns matching facts ranked; **CJK** query `编程语言` matches a fact via trigram; `owner_id` isolation (cross-tenant id → empty); superseded/expired fact never returned. |
+| 4 | same | vector leg with a **fake embedding** (deterministic): a semantically-near fact outranks a keyword-only hit; RRF order stable on a fixture. |
+| 5 | `packages/core/src/store/store-contract.test.ts` | parity: `searchFacts` on sqlite + PGlite (pgvector + tsvector) return the same match set / relative order on a fixed corpus. |
+| 6 | `packages/core/src/store/sqlite/memory-schema.test.ts` | migration v28: `memory_facts_fts` exists + stays in sync on insert/update/delete; backfill via `'rebuild'`; `embedding` column present. |
+| 7 | `packages/core/src/store/postgres/migrate.test.ts` | migration v27: GIN + HNSW indexes created; `splitStatements` doesn't choke; idempotent re-run. |
+| 8 | `apps/gateway/src/routes/mcp/mcp.test.ts` | `memory_recall`: account from identity not args; scope defaults to key project; **fail-open** (throwing `searchFacts` → degrades to LIKE, no isError 500); reinforcement bump fired; `facts_retrieval.enabled:false` ⇒ degrades. |
+| 9 | `packages/core/src/memory/embedding.test.ts` | the background embedding job embeds `insertedIds`, writes `embedding`+`embedding_model`+`embedding_dim`; re-embeds on model change; fail-open on embedder error. |
+
+Write #3 (CJK) and #8 (fail-open) first — the two highest-risk decisions (tokenizer choice,
+degradation path).
+
+## Out of scope (deferred, noted so they're not silently dropped)
+
+- Searching **observations / reflections** (only `memory_facts` indexed in this pass).
+- **Cross-encoder reranker** (`bge-reranker-v2-m3`) — gated config, default off, future.
+- **Raw-history drill-down** tool (resolve `sourceObservationRange` → raw turns).
+- A temporal **knowledge graph** (docs/12 "ceiling"; not built).

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,23 @@
 
 ---
 
+## 2026-06-23 · 记忆深度召回 = 混合检索（落地 docs/12 P8）+ `memory_recall` MCP 工具（docs/14；原则 1/3/4）
+
+- **背景/范围**：用户要 MCP 上「深度历史召回」（"我们讨论过什么"）。现 `memory_search` 是对蒸馏 `fact_text` 的 `LIKE`——无相关性排序、**无跨语言**（`成本`≠`cost`）。决定**落地 docs/12 已 spec 但 deferred 的 P8**，并新增第 7 个 MCP 工具 `memory_recall` 暴露之。**检索单元 = `memory_facts`**（有 owner_id+scope，跨会话；对齐 docs/12 P8 与 docs/13「raw/observation 不入管理面」）；observations/reflections **不入索引**（完整原始历史靠 fact 的 `sourceObservationRange` 溯源链，非主搜索面，留作后续）。
+- **架构**：三确定性信号各出一个 ranked list，**RRF(k=60) 融合**：① 向量（sqlite-vec / pgvector，方言封在适配器）② 全文（FTS5 **trigram** / tsvector）③ forgetting-score（衰减的 fact 检索也排后）。**双语**：多语言 embedding 跨 zh↔en，trigram 抓 CJK+拉丁字面（unicode61 不切中文），RRF 融合两者短板。不变量同 P8：account-scoped + `expired_at IS NULL`、**fail-open**（embed/向量失败→退 FTS+score；全失败→空结果不 5xx）、召回结果走 reinforcement bump。
+- **embedding 接入**：core 框架无关 → 注入 `Embedder` 端口；gateway 实现调 OpenAI 兼容 `/v1/embeddings`；**后台**（新 `embedding` job，复用 worker；`insertFactsReconciled` 返回的 `insertedIds` 即待嵌入行）；唯一同步嵌入是 `memory_recall` 的一次 query 向量。config `memory.llm.embedding_model`+`embedding_dimensions`（**缺省→向量腿关、退 FTS+score**）；默认多语言选型 bge-m3(1024d) 自托管。
+- **配置**：`memory.forgetting.facts_retrieval{ enabled(默认 false), top_k(10) }`（沿用 docs/12 命名）；RRF k、各信号权重、tokenizer 皆**代码常量**（无撒谎旋钮）。`.strict()` fail-closed。
+- **关键坑（sqlite-vec 已实证可用：v0.1.9 darwin-arm64 prebuilt；本机 Node 25.8.2 / better-sqlite3 12.10.0 / SQLite 3.53.1）**：
+  1. **vec0 主键须 BigInt 绑定**——better-sqlite3 把 JS `number` 当 float 传给 vec0 → `Only integers are allowed for primary key`。存 `fact_rowid` 用 `BigInt`。
+  2. **KNN 语法** `WHERE emb MATCH ? AND k = N ORDER BY distance`；向量绑定 `new Uint8Array(Float32Array.buffer)`。
+  3. **`loadExtension` 今天全仓未调用**——需在 `runMigrations` + `createSqliteDb` **两处**连接开启时加 sqlite-vec 加载 hook；加载失败 **fail-open**（FTS+score 仍工作）绝不崩启动。`sqlite-vec` 已加进 `packages/core` deps（预编译二进制，无需进 root `onlyBuiltDependencies`）。
+  4. FTS5 **external-content** 表（`content='memory_facts'`）只存倒排不复制文本 + AI/AD/AU 触发器同步 + `'rebuild'` 回填。
+  5. **pg `splitStatements` 按 `;` 切**——DDL 仅终止符用 `;`；pgvector 需 `CREATE EXTENSION vector`，PGlite 0.4.6 自带（`@electric-sql/pglite/vector`，测试可覆盖 pg 向量路径）。
+- **迁移版本**：sqlite 当前 max=27 → 新 **v28**；postgres 当前 max=26 → 新 **v27**（pg ledger 比 sqlite 偏移 1）。
+- **`searchFacts?` 挂载**：端口加**可选** `?` 方法；**不**进 `REQUIRED_METHODS`/`MemoryAdminStore`（该 gate 被 admin 路由共用，会 fail-close 整个 `/mcp` 挂载）——`memory_recall` handler **null-check** 降级到 `listFacts({search})`。`bumpReferences` 加可选 `factIds`（向后兼容）。
+- **T6/T7 关键坑（实现中实证）**：① **PGlite vector 扩展须 `PGlite.create({extensions:{vector}})`，不能 `new PGlite()`**（后者不注册 extension bundle → `CREATE EXTENSION vector` 报 `vector.control` not found）；② postgres 向量列用**无维度 `vector`**（顺序 `<=>` 扫描，免运行时 dim），但 v27 `CREATE EXTENSION vector` **要求部署装了 pgvector**（supabase 默认有；自建 PG 无则 boot 失败——诚实信号去装）；③ gateway **无 `/v1/embeddings` 路由、`ProviderClient` 无 embeddings 方法** → embedder（`apps/gateway/src/memory-embedder.ts`）直连 `{provider.base_url}/embeddings`（OpenAI 兼容），按 `embedding_model` 的 provider 前缀从 `config.providers` 解析 base_url + api_key_env；④ 迁移 fixture 测试须预标记新版本（sqlite **v28** / pg **v27**）——不含 memory_facts 的最小 fixture 否则 ALTER 失败（sqlite 3 处、pg 2 处已补）。
+- **进度：全部完成（阶段2 端到端）**。docs/14；config（`facts_retrieval`/`embedding_*`/`embedding` job）；RRF 核心；sqlite 适配器（v28：FTS5-trigram + sqlite-vec vec0 + `searchFacts`/`setFactEmbeddings`/`listFactsNeedingEmbedding` + `bumpReferences.factIds`）；postgres 适配器（v27：tsvector GIN + pgvector + 同方法）；embedder + embedding job + scheduler dispatch/enqueue；`memory_recall` MCP 工具 + 接线 + fail-open。**验证**：`typecheck -r` 全绿；core **2568** 测试绿（含 sqlite/pg searchFacts CJK+向量+RRF、embedding-job、mcp fail-open/bump、迁移 fixture）；gateway mcp 17 + embedder 5 绿；lint 我方文件绿（`oauth.ts:312` pre-existing）。分支 `helm-memory-deep-recall`，**未提交**（待用户）。运行时：`memory.forgetting.facts_retrieval.enabled:true` 开 FTS+score；再配 `memory.llm.embedding_model`+`embedding_dimensions` 点亮向量腿。
+
 ## 2026-06-23 · MCP OAuth 2.1 shim（ChatGPT 连接器接入；docs/13；原则 1/2/7）
 
 - **目标**：ChatGPT 自定义连接器（Apps SDK）**不接受裸 API key**，只走 OAuth 2.1 authorize-code + PKCE（RFC 9728 发现）。现 `/mcp` 仅 API-key 中间件 → 无法被 ChatGPT 接入。
@@ -24,19 +41,13 @@
 - **取舍/限制**：是**折算价非实付**（订阅月度统付，与 `openai-codex/*` 既有语义一致），未在 UI 区分名义/实付；仅 4 个 lane alias 被定价，自定义 key 发来的其它/带日期 `anthropic/<id>` 仍 `null`（fail-open 照样尝试，只是不计价，需要时运维补一行）。纯配置无代码改动。
 - **验证**：`samples.test.ts`（Claude lane 路由不回归）、`catalog/{index,load,models-list}.test.ts`（4 条新条目的计数/快照）、`capability/filter.test.ts` 均绿；typecheck+lint 绿。
 
-## 2026-06-22 · Codex 原生 Responses 直通兼容清洗 + fallback reasoning 泄漏修复（docs/05/07；原则 3/7/8）
-
-- **线上实证**：`la.atmy.work` 请求 `e3ead05d-3433-4464-aca2-47d7640ee97f` 的第一候选 `openai-codex/gpt-5.5` 295ms 返回 HTTP 400：`Unsupported parameter: max_output_tokens`；入站是 `/v1/responses` 原生直通，客户端带 `max_output_tokens:512`。请求 `39f175e4-2ff8-4ede-849c-d8dc9542adb0` 第一候选 `openai-codex/gpt-5.4-mini` 404：`Item with id ... not found. Items are not persisted when store is set to false`；同一 fallback 链随后 Anthropic/DeepSeek 因 Responses reasoning history 被当作 provider `thinking` 配置而 400，OpenRouter 最终成功。
-- **决定 1（Codex 直通）**：仅对 ChatGPT-account Codex Responses profile 增加 native body 清洗：移除 `max_output_tokens` / `temperature`；`store:false` 时删除 input item 的 `id/status/phase` 引用元数据，并丢弃空 reasoning item（保留有 `encrypted_content`/summary/content 的 reasoning）。generic OpenAI Responses passthrough 保持原样，避免破坏标准 API 语义。
-- **决定 2（跨协议 fallback）**：`InternalRequest.thinking` 若是 Responses reasoning history 数组，不再作为 provider `thinking` 请求配置转发到 OpenAI-compatible / Anthropic target；attempt 记录 `thinking_history_stripped_for_target`。provider_raw.reasoning 继续按目标协议 allowlist 剥离并记录。
-- **验证**：TDD 红→绿；`openai-responses.test.ts` 覆盖 Codex native 清洗；`execute.test.ts` 覆盖 Codex 直通清洗与 fallback `thinking` 剥离；focused 237 测、core/gateway typecheck、Biome touched-file check 均绿。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
+- **2026-06-22 · Codex 原生 Responses 直通清洗 + fallback reasoning 泄漏修复**：仅对 ChatGPT-account Codex Responses profile 清洗 native body（移除 `max_output_tokens`/`temperature`；`store:false` 删 input item `id/status/phase` + 丢空 reasoning item，保留有 encrypted_content/summary 的）；跨协议 fallback 时 `InternalRequest.thinking` 若为 Responses reasoning history 数组不再作为 provider `thinking` 转发（记 `thinking_history_stripped_for_target`）。`openai-responses.test.ts`/`execute.test.ts` 覆盖。
 - **2026-06-22 · Opus 1M 上下文溢出预检 + 流式失败落库**：Anthropic native 在 invoke 前加 exact `count_tokens` 预检（opus/sonnet/haiku 硬上限 1e6 与 catalog 取较小者，count 失败 fail-open），超限记 `context_too_small` 进 fallback **不记 breaker**；上游 400 的 prompt-too-long/effort 形状错记 `invalid_request` 不污染 breaker；sonnet 仅允 low|medium|high|max effort（xhigh 执行前 skip 不 clamp，更可观测）；`/v1/messages` 已写 error 帧则同步改 `DecisionRecord.final.status=error`，Codex Responses 故障帧带 `providerRaw`。TODO：all-failed chain 的 per-attempt upstream body capture 未补。
 - **2026-06-21 · Codex Chat→Responses 兼容层移除 `temperature`**：economy+temperature:0 非流式 Chat 经 `openaiToResponsesRequest` 互译到 ChatGPT-account Codex Responses 后端 400 `Unsupported parameter: temperature`；改为 Codex Responses 用 openclaw 最小 body（`store:false`/`stream:true`/`include:[reasoning.encrypted_content]`/`text.verbosity:low`，不发 `max_output_tokens`/`temperature`），generic Responses 不变。
 - **2026-06-21 · 全仓评审修复 Tiers 1–5**：按 review C1/C2、C3/H3、H1/H2、H9/H10/H11、breaker+memory 分批修复；关键取舍包括删除未被网关调用且漂移的 `executor/fallback.ts`、不从 `prompt_tokens` 预减 cached、`cleanup_archive_enabled` 默认关并加 2× 安全线、`require_api_key:false` fail-closed、Anthropic mid-conv system 折叠保持现行为、OPEN 态 `recordFailure` no-op；M6/C4 延后单做。

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9",
     "socks": "^2.8.9",
+    "sqlite-vec": "^0.1.9",
     "undici": "^8.3.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -285,6 +285,16 @@ export {
   type ObserverResult,
   runObserverJob,
 } from "./memory/observer.js";
+// docs/14 — hybrid fact retrieval: the embedding port (gateway injects the impl) +
+// the RRF fusion used inside the adapters and re-exported for tests + the background
+// embedding job that fills the vector index.
+export type { Embedder } from "./memory/recall/embedder.js";
+export {
+  type EmbeddingJob,
+  type EmbeddingJobDeps,
+  runEmbeddingJob,
+} from "./memory/recall/embedding-job.js";
+export { type FusedRank, RRF_K, reciprocalRankFusion } from "./memory/recall/rrf.js";
 // Memory middleware — background Reflector (docs/08 Phase 2). Periodically merges a
 // scope's observations into a stable, versioned reflection; off the main request
 // path, fail-open. Framework-agnostic; never touches routing/lane state.

--- a/packages/core/src/memory/recall/embedder.ts
+++ b/packages/core/src/memory/recall/embedder.ts
@@ -1,0 +1,14 @@
+// The embedding port (docs/14). CORE stays framework-agnostic: it declares the
+// interface; the background embedding job + memory_recall depend on it, and the
+// gateway composition root injects the concrete impl (an OpenAI-compatible
+// POST /v1/embeddings call against memory.llm.embedding_model). Tests inject a
+// deterministic fake.
+//
+// `embed` takes a batch and returns one Float32Array per input, IN ORDER, each of the
+// model's fixed dimensionality. A failure must REJECT — callers fail-open: a query
+// embed failure drops the vector leg (recall = FTS+score), a background embed failure
+// leaves the fact vector-less (still FTS+score findable) and is retried. Empty input
+// ⇒ empty output (no call).
+export interface Embedder {
+  embed(texts: string[]): Promise<Float32Array[]>;
+}

--- a/packages/core/src/memory/recall/embedding-job.test.ts
+++ b/packages/core/src/memory/recall/embedding-job.test.ts
@@ -1,0 +1,164 @@
+import type { MemoryFactInput } from "@helm/shared";
+import { describe, expect, it } from "vitest";
+import { SqliteMemoryStore } from "../../store/sqlite/memory-store.js";
+import { createSqliteDb } from "../../store/sqlite/migrate.js";
+import { factContentHash } from "../forgetting/facts.js";
+import type { Embedder } from "./embedder.js";
+import { runEmbeddingJob } from "./embedding-job.js";
+
+const NOW = new Date("2026-06-23T00:00:00.000Z");
+
+function makeFact(text: string): MemoryFactInput {
+  return {
+    ownerId: "a",
+    subjectKey: text.slice(0, 24),
+    factText: text,
+    contentHash: factContentHash(text),
+    importance: 0.5,
+    referenceCount: 0,
+    referencedAt: null,
+    validFrom: NOW,
+    invalidAt: null,
+    expiredAt: null,
+    status: "active",
+  };
+}
+
+const fakeEmbedder: Embedder = {
+  embed: async (texts) => texts.map(() => new Float32Array([1, 0, 0, 0])),
+};
+
+function deps(store: SqliteMemoryStore, embedder: Embedder = fakeEmbedder) {
+  return {
+    memoryStore: store,
+    embedder,
+    model: "test-model",
+    dim: 4,
+    batchSize: 64,
+    log: () => {},
+  };
+}
+
+async function claimOne(
+  store: SqliteMemoryStore,
+): Promise<{ jobId: string; scope: { accountId: string } }> {
+  await store.enqueueJob({ type: "embedding", scope: { accountId: "a" } });
+  const [job] = await store.claimPendingJobs(10);
+  if (job === undefined) throw new Error("no job claimed");
+  return { jobId: job.jobId, scope: job.scope };
+}
+
+describe("runEmbeddingJob (docs/14)", () => {
+  it("embeds pending facts so they no longer need embedding (vector leg gets data)", async () => {
+    const store = new SqliteMemoryStore(createSqliteDb(":memory:"));
+    await store.insertFactsReconciled({
+      accountId: "a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("alpha note"), makeFact("beta note")],
+    });
+    await runEmbeddingJob(await claimOne(store), deps(store));
+    const pending = await store.listFactsNeedingEmbedding?.({
+      accountId: "a",
+      model: "test-model",
+      dim: 4,
+      limit: 10,
+    });
+    expect(pending).toHaveLength(0);
+
+    // the vector leg now returns results for a matching query embedding
+    const hits = await store.searchFacts?.({
+      accountId: "a",
+      queryText: "zzz",
+      queryEmbedding: new Float32Array([1, 0, 0, 0]),
+      limit: 5,
+      now: NOW,
+      scoreConfig: {
+        half_life_s: 86400,
+        importance_floor: 0.1,
+        importance_ceil: 1.0,
+        access_weight: 0.15,
+      },
+    });
+    expect((hits ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("no pending facts ⇒ job completes as a noop (never throws)", async () => {
+    const store = new SqliteMemoryStore(createSqliteDb(":memory:"));
+    await expect(runEmbeddingJob(await claimOne(store), deps(store))).resolves.toBeUndefined();
+  });
+
+  it("an embedder error fails the job cleanly (fail-open); facts stay pending for retry", async () => {
+    const store = new SqliteMemoryStore(createSqliteDb(":memory:"));
+    await store.insertFactsReconciled({
+      accountId: "a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("gamma note")],
+    });
+    const throwing: Embedder = {
+      embed: async () => {
+        throw new Error("embedder down");
+      },
+    };
+    await expect(
+      runEmbeddingJob(await claimOne(store), deps(store, throwing)),
+    ).resolves.toBeUndefined();
+    const pending = await store.listFactsNeedingEmbedding?.({
+      accountId: "a",
+      model: "test-model",
+      dim: 4,
+      limit: 10,
+    });
+    expect(pending).toHaveLength(1);
+  });
+
+  it("re-enqueues a follow-up job after a FULL batch so the backlog drains", async () => {
+    const store = new SqliteMemoryStore(createSqliteDb(":memory:"));
+    await store.insertFactsReconciled({
+      accountId: "a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("f1"), makeFact("f2"), makeFact("f3")],
+    });
+    // batchSize 2 with 3 pending → embeds 2, then re-enqueues for the remaining one.
+    await runEmbeddingJob(await claimOne(store), { ...deps(store), batchSize: 2 });
+    const pending = await store.listFactsNeedingEmbedding?.({
+      accountId: "a",
+      model: "test-model",
+      dim: 4,
+      limit: 10,
+    });
+    expect(pending).toHaveLength(1);
+    const next = await store.claimPendingJobs(10);
+    expect(next.some((j) => j.type === "embedding")).toBe(true);
+  });
+
+  it("re-embeds when the configured dim changes (dim mismatch is flagged)", async () => {
+    const store = new SqliteMemoryStore(createSqliteDb(":memory:"));
+    await store.insertFactsReconciled({
+      accountId: "a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("delta")],
+    });
+    await runEmbeddingJob(await claimOne(store), deps(store)); // embeds at dim 4
+    expect(
+      await store.listFactsNeedingEmbedding?.({
+        accountId: "a",
+        model: "test-model",
+        dim: 4,
+        limit: 10,
+      }),
+    ).toHaveLength(0);
+    // a DIFFERENT dim ⇒ the fact needs re-embedding
+    expect(
+      await store.listFactsNeedingEmbedding?.({
+        accountId: "a",
+        model: "test-model",
+        dim: 8,
+        limit: 10,
+      }),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/core/src/memory/recall/embedding-job.ts
+++ b/packages/core/src/memory/recall/embedding-job.ts
@@ -1,0 +1,75 @@
+import type { ReflectionScope } from "@helm/shared";
+import type { MemoryStore } from "../../store/ports.js";
+import type { Embedder } from "./embedder.js";
+
+// docs/14 — the background embedding job: fill memory_facts.embedding (+ the sqlite-vec
+// vec0 index) for facts that lack a vector, so hybrid recall's vector leg has data.
+// Account-scoped, ONE batch per run (re-enqueued by the next observer/reflector fact
+// write while any remain). Mirrors runDecayJob: try/catch + updateJobStatus(done|
+// failed), fully fail-open — a failure leaves facts vector-less (still FTS+score
+// findable) and is retried on the next enqueue.
+
+export interface EmbeddingJob {
+  readonly jobId: string;
+  readonly scope: ReflectionScope; // account-scoped (scope.accountId)
+}
+
+export interface EmbeddingJobDeps {
+  memoryStore: MemoryStore;
+  embedder: Embedder;
+  model: string; // memory.llm.embedding_model (stamped on the row + checked for re-embed)
+  dim: number; // memory.llm.embedding_dimensions (the vec0 width)
+  batchSize: number;
+  log: (line: string, meta?: object) => void;
+}
+
+export async function runEmbeddingJob(job: EmbeddingJob, deps: EmbeddingJobDeps): Promise<void> {
+  const accountId = job.scope.accountId;
+  try {
+    const list = deps.memoryStore.listFactsNeedingEmbedding;
+    const sink = deps.memoryStore.setFactEmbeddings;
+    if (list === undefined || sink === undefined) {
+      await deps.memoryStore.updateJobStatus(job.jobId, "failed", "embedding: store lacks methods");
+      return;
+    }
+    const facts = await list.call(deps.memoryStore, {
+      accountId,
+      model: deps.model,
+      dim: deps.dim,
+      limit: deps.batchSize,
+    });
+    if (facts.length === 0) {
+      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      return;
+    }
+    const vectors = await deps.embedder.embed(facts.map((f) => f.factText));
+    // Pair each fact with its vector, dropping any whose embedding is missing or the
+    // wrong width (defensive: a misconfigured model must never poison the vec0 index).
+    const items = facts
+      .map((f, i) => ({ factId: f.id, embedding: vectors[i], dim: deps.dim, model: deps.model }))
+      .filter(
+        (it): it is { factId: string; embedding: Float32Array; dim: number; model: string } =>
+          it.embedding !== undefined && it.embedding.length === deps.dim,
+      );
+    if (items.length > 0) await sink.call(deps.memoryStore, { accountId, items });
+    await deps.memoryStore.updateJobStatus(job.jobId, "done");
+    deps.log("memory.embedding.done", { account_id: accountId, embedded: items.length });
+    // A FULL batch likely leaves more unembedded facts (common right after enabling
+    // embeddings or changing models on an existing store). Re-enqueue so the worker
+    // keeps draining instead of waiting for an unrelated future fact write. GATED on
+    // items.length > 0 (progress made) so a batch of only un-embeddable rows — e.g. a
+    // dim mismatch the embedder can't satisfy — can't spin forever; the row is now in
+    // a 'done' state so the open-job unique index admits the fresh pending row.
+    if (facts.length >= deps.batchSize && items.length > 0) {
+      try {
+        await deps.memoryStore.enqueueJob({ type: "embedding", scope: { accountId } });
+      } catch {
+        // best-effort — the next fact write re-enqueues.
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
+    deps.log("memory.embedding.failed", { account_id: accountId, error: message });
+  }
+}

--- a/packages/core/src/memory/recall/rrf.test.ts
+++ b/packages/core/src/memory/recall/rrf.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { RRF_K, reciprocalRankFusion } from "./rrf.js";
+
+// docs/14 / docs/12 P8 — Reciprocal Rank Fusion. Rank-based, scale-free, no tuned
+// weights, deterministic. These cases pin the contract the hybrid recall depends on:
+// consensus wins, contributions sum, k is the documented constant, ties are stable.
+describe("reciprocalRankFusion", () => {
+  it("a single ranked list preserves its order", () => {
+    const fused = reciprocalRankFusion([["a", "b", "c"]]);
+    expect(fused.map((r) => r.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("a consensus item (present in multiple lists) outranks a single-list leader", () => {
+    // 'x' is 2nd in BOTH lists; 'a'/'c' lead only one list each. Consensus wins.
+    const fused = reciprocalRankFusion([
+      ["a", "x", "b"],
+      ["c", "x", "d"],
+    ]);
+    expect(fused[0]?.id).toBe("x");
+  });
+
+  it("uses k=60 by default and the documented 1/(k+rank) score", () => {
+    expect(RRF_K).toBe(60);
+    const fused = reciprocalRankFusion([["a"]]);
+    expect(fused[0]?.score).toBeCloseTo(1 / 61, 10);
+  });
+
+  it("sums contributions across lists for the same id", () => {
+    const fused = reciprocalRankFusion([["a"], ["a"]]);
+    expect(fused).toHaveLength(1);
+    expect(fused[0]?.score).toBeCloseTo(2 / 61, 10);
+  });
+
+  it("skips empty lists and dedups ids", () => {
+    const fused = reciprocalRankFusion([[], ["a", "b"], []]);
+    expect(fused.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("breaks score ties deterministically by id ascending (stable across runs)", () => {
+    // 'a' and 'b' each appear once at rank 1 in separate lists → equal score.
+    const fused = reciprocalRankFusion([["b"], ["a"]]);
+    expect(fused.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(fused[0]?.score).toBeCloseTo(fused[1]?.score ?? Number.NaN, 10);
+  });
+
+  it("respects a custom k", () => {
+    const fused = reciprocalRankFusion([["a"]], 9);
+    expect(fused[0]?.score).toBeCloseTo(1 / 10, 10);
+  });
+});

--- a/packages/core/src/memory/recall/rrf.ts
+++ b/packages/core/src/memory/recall/rrf.ts
@@ -1,0 +1,38 @@
+// Reciprocal Rank Fusion (docs/14 / docs/12 P8 — hybrid fact retrieval).
+//
+// Fuses N ranked id lists (each already sorted best-first) into one ranking by
+// summing 1/(k + rank) across the lists. Rank-based ⇒ SCALE-FREE: BM25 (unbounded,
+// negative), cosine similarity (0..1), and the forgetting score (recency × importance
+// + access) live on incompatible scales, so we fuse RANKS, never raw scores — no
+// normalization, no tuned per-signal weights. `k = 60` is the TREC-standard constant
+// (Cormack et al.); it is a CODE constant, NOT config — a per-deploy RRF k would be a
+// lying knob (the field finds k ∈ [40,80] equivalent).
+//
+// Pure + deterministic: identical input ⇒ identical output. A score tie is broken by
+// id ascending so the order is stable across runs and trivially unit-testable on a
+// fixture. An id appearing in multiple lists accumulates all its contributions; an
+// empty list contributes nothing.
+
+export const RRF_K = 60;
+
+export interface FusedRank {
+  readonly id: string;
+  readonly score: number;
+}
+
+export function reciprocalRankFusion(
+  rankedLists: ReadonlyArray<ReadonlyArray<string>>,
+  k: number = RRF_K,
+): FusedRank[] {
+  const scores = new Map<string, number>();
+  for (const list of rankedLists) {
+    let rank = 0;
+    for (const id of list) {
+      rank++; // 1-based rank within this list
+      scores.set(id, (scores.get(id) ?? 0) + 1 / (k + rank));
+    }
+  }
+  return [...scores.entries()]
+    .map(([id, score]) => ({ id, score }))
+    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+}

--- a/packages/core/src/memory/scheduler.ts
+++ b/packages/core/src/memory/scheduler.ts
@@ -1,7 +1,8 @@
-import type { MemoryJobRow } from "@helm/shared";
+import type { MemoryJobRow, ReflectionScope } from "@helm/shared";
 import type { MemoryStore } from "../store/ports.js";
 import type { DecayJob } from "./forgetting/decay.js";
 import type { ObserverJob, ObserverResult } from "./observer.js";
+import type { EmbeddingJob } from "./recall/embedding-job.js";
 import { type ReflectorJob, type ReflectorResult, reflectionTargetScope } from "./reflector.js";
 
 // Background memory worker (docs/08 Phase 2). The OFF-the-request-path drainer for
@@ -41,6 +42,10 @@ export interface MemoryWorkerDeps {
   // fall-through). Keeping it optional also means existing worker fixtures that predate
   // this phase stay valid unmodified (the gating lever applies to the type surface too).
   runDecay?: (job: DecayJob) => Promise<void>;
+  // docs/14 — run one embedding job (fill the vector index for an account's facts).
+  // Wired to runEmbeddingJob when memory.llm.embedding_model is set; absent ⇒ no
+  // 'embedding' rows are enqueued, and a stray one is failed cleanly (like decay).
+  runEmbedding?: (job: EmbeddingJob) => Promise<void>;
   // OPTIONAL per-tick hook run BEFORE claiming jobs (docs/12 P5 trigger). The
   // composition root wires maybeEnqueueDecayJobs here so the buffer-flush gate is
   // evaluated on the worker interval (OFF the request path — decay never triggers per
@@ -64,10 +69,24 @@ export interface MemoryWorkerHandle {
 // fail-open (the runners never throw), but we still guard so a thrown promotion/enqueue
 // can't escape the tick. An UNKNOWN type (a corrupt row, or a future kind this worker
 // build predates) is marked failed rather than run by the wrong worker.
+// docs/14 — best-effort: after a fact-writing job (observer/reflector), enqueue ONE
+// embedding job for the account so newly written facts get vectors. Gated on
+// runEmbedding (no embedder ⇒ no embedding rows enqueued). The open-job unique index
+// coalesces repeats; a failure just defers embedding to the next write (fail-open).
+async function maybeEnqueueEmbedding(scope: ReflectionScope, deps: MemoryWorkerDeps): Promise<void> {
+  if (deps.runEmbedding === undefined) return;
+  try {
+    await deps.memoryStore.enqueueJob({ type: "embedding", scope: { accountId: scope.accountId } });
+  } catch {
+    // best-effort — the next fact write re-enqueues.
+  }
+}
+
 async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<void> {
   if (job.type === "reflector") {
     // reflector: the whole scope drives the merge.
     await deps.runReflector({ jobId: job.jobId, scope: job.scope });
+    await maybeEnqueueEmbedding(job.scope, deps);
     return;
   }
   if (job.type === "decay") {
@@ -85,6 +104,22 @@ async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<vo
       return;
     }
     await deps.runDecay({ jobId: job.jobId, scope: job.scope });
+    return;
+  }
+  if (job.type === "embedding") {
+    // docs/14 — fill the vector index for the account's facts. Like decay: only
+    // enqueued when the embedder is wired (runEmbedding set); a stray row on a worker
+    // without it is failed cleanly, never mis-routed.
+    if (deps.runEmbedding === undefined) {
+      await deps.memoryStore.updateJobStatus(
+        job.jobId,
+        "failed",
+        "embedding job but worker has no runEmbedding",
+      );
+      deps.log("memory.worker.embedding_unsupported", { job_id: job.jobId });
+      return;
+    }
+    await deps.runEmbedding({ jobId: job.jobId, scope: job.scope });
     return;
   }
   if (job.type === "observer") {
@@ -134,6 +169,7 @@ async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<vo
         });
       }
     }
+    await maybeEnqueueEmbedding(job.scope, deps);
     return;
   }
   // Unknown type: a corrupt scope_id row, or a job kind this worker build predates.

--- a/packages/core/src/memory/scheduler.ts
+++ b/packages/core/src/memory/scheduler.ts
@@ -73,7 +73,10 @@ export interface MemoryWorkerHandle {
 // embedding job for the account so newly written facts get vectors. Gated on
 // runEmbedding (no embedder ⇒ no embedding rows enqueued). The open-job unique index
 // coalesces repeats; a failure just defers embedding to the next write (fail-open).
-async function maybeEnqueueEmbedding(scope: ReflectionScope, deps: MemoryWorkerDeps): Promise<void> {
+async function maybeEnqueueEmbedding(
+  scope: ReflectionScope,
+  deps: MemoryWorkerDeps,
+): Promise<void> {
   if (deps.runEmbedding === undefined) return;
   try {
     await deps.memoryStore.enqueueJob({ type: "embedding", scope: { accountId: scope.accountId } });

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -20,7 +20,7 @@ import type {
   ReflectionUpsertInput,
   RoutingSignal,
 } from "@helm/shared";
-
+import type { ScoreConfig } from "../memory/forgetting/score.js";
 import type { BucketState } from "../ratelimit/token-bucket.js";
 
 // Lifecycle status of a background memory job (docs/08 memory_jobs.status).
@@ -600,6 +600,11 @@ export interface MemoryStore {
     accountId: string;
     observationIds: string[];
     reflectionIds: string[];
+    // docs/14 — recalled facts get the SAME reinforcement bump (reference_count += 1,
+    // referenced_at = now) so a fact surfaced by memory_recall counts as "used".
+    // Optional + defaults to none ⇒ existing inject callers stay byte-identical.
+    // memory_facts carry owner_id directly (no thread join needed).
+    factIds?: string[];
     now: Date;
   }): Promise<void>;
   // docs/12 "Eviction, demotion, promotion" (P5 decay sweep, pass 1) — the read half.
@@ -856,6 +861,55 @@ export interface MemoryStore {
     limit: number;
     offset: number;
   }): Promise<{ rows: Fact[]; total: number }>;
+
+  // docs/14 / docs/12 P8 — HYBRID relevance retrieval over memory_facts (the
+  // `memory_recall` engine). Fuses up to three deterministic ranked lists with
+  // RRF(k=60): full-text (FTS5 trigram / tsvector), vector similarity (sqlite-vec /
+  // pgvector — ONLY when queryEmbedding is given AND the row has an embedding), and
+  // the forgetting score. Account-scoped + active-only (owner_id = :accountId AND
+  // status='active' AND expired_at IS NULL — a superseded/archived fact never
+  // surfaces). Returns RRF-ranked facts, best first, capped at `limit`. Order is the
+  // contract; per-engine scores (bm25 vs ts_rank vs cosine) are NOT comparable across
+  // dialects and stay internal. An adapter that can't run the vector leg (extension
+  // absent / no query embedding) returns FTS+score results — never throws for that.
+  //
+  // OPTIONAL (`?`) and DELIBERATELY NOT in MemoryAdminStore/REQUIRED_METHODS: that
+  // gate is shared by the admin route and would fail-close the whole /mcp mount for
+  // any adapter lacking this method. The memory_recall handler null-checks and
+  // degrades to listFacts({ search }) LIKE instead (fail-open).
+  searchFacts?(input: {
+    accountId: string;
+    projectId?: string;
+    resourceId?: string;
+    threadId?: string;
+    queryText: string;
+    queryEmbedding?: Float32Array;
+    limit: number;
+    now: Date;
+    scoreConfig: ScoreConfig;
+  }): Promise<Fact[]>;
+
+  // docs/14 — write embeddings for facts (the background `embedding` job's sink).
+  // Account-guarded: only the caller's own facts are touched (a foreign factId is a
+  // no-op, never a cross-tenant write). Persists the vector + the model id + dim it
+  // was produced with onto memory_facts, and (sqlite) syncs the vec0 KNN index.
+  // Idempotent — re-embedding overwrites. OPTIONAL `?`: additive; the job null-checks.
+  setFactEmbeddings?(input: {
+    accountId: string;
+    items: Array<{ factId: string; embedding: Float32Array; model: string; dim: number }>;
+  }): Promise<void>;
+
+  // docs/14 — the embedding job's READ half: ACTIVE facts that still need a (re-)
+  // embedding for the vector leg — NULL embedding, OR one from a DIFFERENT model, OR
+  // one at a DIFFERENT dim (re-embed on a model/dimension change; never mix vectors
+  // across models/dims). Account-scoped, capped, oldest-first. Returns only
+  // {id, factText} (the embed inputs).
+  listFactsNeedingEmbedding?(input: {
+    accountId: string;
+    model: string;
+    dim: number;
+    limit: number;
+  }): Promise<Array<{ id: string; factText: string }>>;
 
   // Edit a fact in place (partial; docs/13). Editing factText RECOMPUTES
   // content_hash (the pure helper, identical to ingest) but NEVER subjectKey (the

--- a/packages/core/src/store/postgres/memory-search.test.ts
+++ b/packages/core/src/store/postgres/memory-search.test.ts
@@ -1,0 +1,160 @@
+import type { MemoryFactInput } from "@helm/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { factContentHash } from "../../memory/forgetting/facts.js";
+import { PgMemoryStore } from "./memory-store.js";
+import { createPgliteDb } from "./migrate.js";
+
+// docs/14 / docs/12 P8 — hybrid fact retrieval over Postgres (pg mirror of the sqlite
+// suite). FTS via tsvector('simple') + the vector leg via pgvector (<=>), fused by RRF.
+// 'simple' does not segment CJK, so the FTS cases use English (the vector leg carries
+// cross-lingual recall in production); these pin account isolation + the pgvector path.
+
+const SCORE_CONFIG = {
+  half_life_s: 86400,
+  importance_floor: 0.1,
+  importance_ceil: 1.0,
+  access_weight: 0.15,
+};
+const NOW = new Date("2026-06-23T00:00:00.000Z");
+
+function makeFact(
+  ownerId: string,
+  factText: string,
+  over: Partial<MemoryFactInput> = {},
+): MemoryFactInput {
+  return {
+    ownerId,
+    subjectKey: factText.slice(0, 24),
+    factText,
+    contentHash: factContentHash(factText),
+    importance: 0.5,
+    referenceCount: 0,
+    referencedAt: null,
+    validFrom: NOW,
+    invalidAt: null,
+    expiredAt: null,
+    status: "active",
+    ...over,
+  };
+}
+
+describe("PgMemoryStore.searchFacts (hybrid recall, pg mirror)", () => {
+  let closers: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    for (const c of closers) await c();
+    closers = [];
+  });
+  async function freshStore(): Promise<PgMemoryStore> {
+    const db = await createPgliteDb();
+    closers.push(() => db.$close());
+    return new PgMemoryStore(db);
+  }
+
+  it("FTS leg: an English query matches via tsvector('simple'), account-scoped", async () => {
+    const store = await freshStore();
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "user prefers dark mode"), makeFact("acct-a", "timezone is utc8")],
+    });
+    await store.insertFactsReconciled({
+      accountId: "acct-b",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-b", "dark secret mode")],
+    });
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "dark mode",
+      limit: 10,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    const texts = (hits ?? []).map((f) => f.factText);
+    expect(texts).toContain("user prefers dark mode");
+    expect((hits ?? []).every((f) => f.ownerId === "acct-a")).toBe(true);
+    expect(texts).not.toContain("dark secret mode");
+  });
+
+  it("vector leg: an embedding query recalls the nearest fact via pgvector (<=>)", async () => {
+    const store = await freshStore();
+    const res = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "alpha", { importance: 0.9 }), makeFact("acct-a", "beta")],
+    });
+    const [id0, id1] = res.insertedIds;
+    await store.setFactEmbeddings?.({
+      accountId: "acct-a",
+      items: [
+        { factId: id0 as string, embedding: new Float32Array([1, 0, 0, 0]), model: "test", dim: 4 },
+        { factId: id1 as string, embedding: new Float32Array([0, 1, 0, 0]), model: "test", dim: 4 },
+      ],
+    });
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "zzz",
+      queryEmbedding: new Float32Array([0.95, 0.05, 0, 0]),
+      limit: 2,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(hits?.[0]?.id).toBe(id0);
+  });
+
+  it("listFactsNeedingEmbedding lists un-embedded facts, then clears after a write", async () => {
+    const store = await freshStore();
+    const res = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "gamma fact")],
+    });
+    let pending = await store.listFactsNeedingEmbedding?.({
+      accountId: "acct-a",
+      model: "m",
+      dim: 4,
+      limit: 10,
+    });
+    expect(pending).toHaveLength(1);
+    await store.setFactEmbeddings?.({
+      accountId: "acct-a",
+      items: [
+        {
+          factId: res.insertedIds[0] as string,
+          embedding: new Float32Array([1, 0, 0, 0]),
+          model: "m",
+          dim: 4,
+        },
+      ],
+    });
+    pending = await store.listFactsNeedingEmbedding?.({
+      accountId: "acct-a",
+      model: "m",
+      dim: 4,
+      limit: 10,
+    });
+    expect(pending).toHaveLength(0);
+  });
+
+  it("ILIKE fallback: a CJK substring query recalls via fact_text when tsquery can't segment", async () => {
+    const store = await freshStore();
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "本月的成本超出预算"), makeFact("acct-a", "无关记录")],
+    });
+    // '成本' (2 chars, no spaces) won't tokenize under tsvector('simple') → ILIKE leg.
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "成本",
+      limit: 10,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect((hits ?? []).map((f) => f.factText)).toContain("本月的成本超出预算");
+  });
+});

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -18,9 +18,25 @@ import {
   type ReflectionScope,
   type ReflectionUpsertInput,
 } from "@helm/shared";
-import { and, asc, count, desc, eq, gt, ilike, isNull, lt, ne, type SQL, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  ilike,
+  inArray,
+  isNull,
+  lt,
+  ne,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 import { factContentHash } from "../../memory/forgetting/facts.js";
+import { forgettingScore, type ScoreConfig } from "../../memory/forgetting/score.js";
 import { sha256Hex } from "../../memory/message-hash.js";
+import { reciprocalRankFusion } from "../../memory/recall/rrf.js";
 import {
   MemoryFactContentHashConflictError,
   type MemoryJobStatus,
@@ -599,6 +615,7 @@ export class PgMemoryStore implements MemoryStore {
     accountId: string;
     observationIds: string[];
     reflectionIds: string[];
+    factIds?: string[];
     now: Date;
   }): Promise<void> {
     const nowMs = input.now.getTime();
@@ -628,6 +645,174 @@ export class PgMemoryStore implements MemoryStore {
            AND owner_id = ${input.accountId}
       `);
     }
+    // docs/14 — recalled facts get the same reinforcement bump (memory_facts carry
+    // owner_id directly, no thread join).
+    if (input.factIds !== undefined && input.factIds.length > 0) {
+      const ids = sql.join(
+        input.factIds.map((id) => sql`${id}`),
+        sql`, `,
+      );
+      await this.db.execute(sql`
+        UPDATE memory_facts
+           SET reference_count = reference_count + 1, referenced_at = ${nowMs}
+         WHERE id IN (${ids})
+           AND owner_id = ${input.accountId}
+      `);
+    }
+  }
+
+  // docs/14 / docs/12 P8 — HYBRID relevance retrieval over memory_facts (pg mirror of
+  // the sqlite adapter). Three RRF-fused signals: tsvector('simple') full-text +
+  // pgvector cosine (<=>, sequential scan; ONLY when a query embedding is given) + the
+  // forgetting score over the candidate union. Account-scoped + active-only. The vector
+  // leg is wrapped so a missing column/extension degrades to FTS+score (fail-open).
+  async searchFacts(input: {
+    accountId: string;
+    projectId?: string;
+    resourceId?: string;
+    threadId?: string;
+    queryText: string;
+    queryEmbedding?: Float32Array;
+    limit: number;
+    now: Date;
+    scoreConfig: ScoreConfig;
+  }): Promise<Fact[]> {
+    const candidateLimit = Math.max(input.limit * 5, 50);
+    const scope: SQL[] = [
+      eq(memoryFacts.ownerId, input.accountId),
+      eq(memoryFacts.status, "active"),
+      isNull(memoryFacts.expiredAt),
+    ];
+    if (input.projectId !== undefined) scope.push(eq(memoryFacts.projectId, input.projectId));
+    if (input.resourceId !== undefined) scope.push(eq(memoryFacts.resourceId, input.resourceId));
+    if (input.threadId !== undefined) scope.push(eq(memoryFacts.threadId, input.threadId));
+    const scopeWhere = and(...scope) as SQL;
+
+    // ── FTS leg (tsvector simple + websearch_to_tsquery — tolerates arbitrary input) ──
+    const ftsIds: string[] = [];
+    const cleaned = input.queryText.replace(/\s+/g, " ").trim();
+    if (cleaned.length > 0) {
+      const rows = await this.execRows(sql`
+        SELECT id FROM ${memoryFacts}
+         WHERE ${scopeWhere}
+           AND to_tsvector('simple', fact_text) @@ websearch_to_tsquery('simple', ${cleaned})
+         ORDER BY ts_rank(to_tsvector('simple', fact_text), websearch_to_tsquery('simple', ${cleaned})) DESC
+         LIMIT ${candidateLimit}
+      `);
+      for (const r of rows) ftsIds.push(r.id as string);
+    }
+
+    // ── ILIKE fallback ── when the tsquery leg yields NO candidates — CJK that
+    // tsvector('simple') can't segment, or a short literal — a substring scan restores
+    // exact recall (parity with memory_search), so such queries never regress to empty.
+    if (ftsIds.length === 0 && cleaned.length > 0) {
+      const rows = await this.execRows(sql`
+        SELECT id FROM ${memoryFacts}
+         WHERE ${scopeWhere} AND fact_text ILIKE ${`%${cleaned}%`}
+         ORDER BY updated_at DESC
+         LIMIT ${candidateLimit}
+      `);
+      for (const r of rows) ftsIds.push(r.id as string);
+    }
+
+    // ── vector leg (pgvector cosine, sequential scan) ──
+    const vecIds: string[] = [];
+    if (input.queryEmbedding !== undefined) {
+      const vecLiteral = `[${Array.from(input.queryEmbedding).join(",")}]`;
+      try {
+        const rows = await this.execRows(sql`
+          SELECT id FROM ${memoryFacts}
+           WHERE ${scopeWhere} AND embedding IS NOT NULL
+           ORDER BY embedding <=> ${vecLiteral}::vector
+           LIMIT ${candidateLimit}
+        `);
+        for (const r of rows) vecIds.push(r.id as string);
+      } catch {
+        // embedding column / pgvector absent → skip the vector leg (fail-open).
+      }
+    }
+
+    const candidateIds = [...new Set([...ftsIds, ...vecIds])];
+    if (candidateIds.length === 0) return [];
+
+    const factById = new Map<string, Fact>();
+    for (const row of await this.db
+      .select()
+      .from(memoryFacts)
+      .where(inArray(memoryFacts.id, candidateIds))) {
+      factById.set(row.id, pgRowToFact(row));
+    }
+
+    const scoreIds = [...factById.values()]
+      .map((f) => ({
+        id: f.id,
+        score: forgettingScore(
+          {
+            referencedAt: f.referencedAt ?? null,
+            fallbackTs: f.createdAt,
+            referenceCount: f.referenceCount ?? 0,
+            importance: f.importance ?? 0.5,
+          },
+          input.scoreConfig,
+          input.now,
+        ),
+      }))
+      .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+      .map((x) => x.id);
+
+    return reciprocalRankFusion([ftsIds, vecIds, scoreIds])
+      .map((r) => factById.get(r.id))
+      .filter((f): f is Fact => f !== undefined)
+      .slice(0, input.limit);
+  }
+
+  // docs/14 — embedding write sink (pg). Account-guarded; idempotent UPDATE per fact.
+  async setFactEmbeddings(input: {
+    accountId: string;
+    items: Array<{ factId: string; embedding: Float32Array; model: string; dim: number }>;
+  }): Promise<void> {
+    if (input.items.length === 0) return;
+    for (const it of input.items) {
+      const vecLiteral = `[${Array.from(it.embedding).join(",")}]`;
+      await this.db.execute(sql`
+        UPDATE memory_facts
+           SET embedding = ${vecLiteral}::vector, embedding_model = ${it.model}, embedding_dim = ${it.dim}
+         WHERE id = ${it.factId} AND owner_id = ${input.accountId}
+      `);
+    }
+  }
+
+  // docs/14 — embedding job READ half (pg). ACTIVE facts with no embedding, one from a
+  // DIFFERENT model, or a DIFFERENT dim (IS DISTINCT FROM is NULL-safe). Oldest-first.
+  async listFactsNeedingEmbedding(input: {
+    accountId: string;
+    model: string;
+    dim: number;
+    limit: number;
+  }): Promise<Array<{ id: string; factText: string }>> {
+    const rows = await this.execRows(sql`
+      SELECT id, fact_text AS "factText" FROM ${memoryFacts}
+       WHERE owner_id = ${input.accountId}
+         AND status = 'active'
+         AND expired_at IS NULL
+         AND (
+           embedding IS NULL
+           OR embedding_model IS DISTINCT FROM ${input.model}
+           OR embedding_dim IS DISTINCT FROM ${input.dim}
+         )
+       ORDER BY created_at ASC
+       LIMIT ${input.limit}
+    `);
+    return rows.map((r) => ({ id: r.id as string, factText: r.factText as string }));
+  }
+
+  // Normalize a raw drizzle-pg execute() result to plain rows (pglite returns
+  // { rows }, postgres-js returns an array) — mirrors the migration runner.
+  private async execRows(query: SQL): Promise<Array<Record<string, unknown>>> {
+    const res = (await this.db.execute(query)) as
+      | { rows?: Array<Record<string, unknown>> }
+      | Array<Record<string, unknown>>;
+    return Array.isArray(res) ? res : (res.rows ?? []);
   }
 
   // docs/12 P5 decay sweep — READ half (pg mirror of the sqlite adapter). Every
@@ -1063,6 +1248,17 @@ export class PgMemoryStore implements MemoryStore {
       .update(memoryFacts)
       .set(set)
       .where(and(eq(memoryFacts.id, input.id), eq(memoryFacts.ownerId, input.accountId)));
+    // docs/14 — a TEXT edit invalidates the stored vector (pg mirror): clear the
+    // embedding columns so the fact re-embeds on the next embedding job and is NEVER
+    // ranked by a stale vector (Codex review). Columns live outside the Drizzle schema
+    // (raw migration v27). `set.factText` is set only when the text actually changed.
+    if (set.factText !== undefined) {
+      await this.db.execute(sql`
+        UPDATE memory_facts
+           SET embedding = NULL, embedding_model = NULL, embedding_dim = NULL
+         WHERE id = ${input.id} AND owner_id = ${input.accountId}
+      `);
+    }
     return this.getFactById({ accountId: input.accountId, id: input.id });
   }
 

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -158,8 +158,10 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // v24 (telemetry.generation_ms): no telemetry table here → pre-mark applied.
     // v25 adds oauth_quota.usage_limited_until_ms; this fixture never creates
     // oauth_quota → pre-mark applied (out of scope).
+    // v27 (pgvector + tsvector over memory_facts): this fixture never creates
+    // memory_facts (+ no pgvector here) → pre-mark applied, out of scope.
     // biome-ignore format: keep the version ledger on one readable line
-    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]) {
+    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
       );
@@ -255,8 +257,10 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // v24 (telemetry.generation_ms): no telemetry table here → pre-mark applied.
     // v25 adds oauth_quota.usage_limited_until_ms (oauth_quota absent here) → pre-mark.
     // v26 (idx_memory_jobs_claim): no memory_jobs table in this messages fixture → pre-mark.
+    // v27 (pgvector + tsvector over memory_facts): this messages fixture never creates
+    // memory_facts (+ no pgvector here) → pre-mark applied, out of scope.
     for (const version of [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27,
     ]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -525,6 +525,25 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_memory_jobs_claim ON memory_jobs (status, created_at, id);
     `,
   },
+  {
+    // docs/14 / docs/12 P8 — hybrid fact retrieval (pg mirror of sqlite v28). pgvector
+    // for the vector leg + a GIN tsvector('simple') index for full-text. 'simple' (not
+    // 'english') so CJK isn't English-stemmed; queried via websearch_to_tsquery (which
+    // tolerates arbitrary user input). The `vector` column is left UN-dimensioned (a
+    // sequential <=> scan, the pg analogue of sqlite-vec brute force) so the migration
+    // needs no runtime embedding dim. NOTE: requires the pgvector extension — present by
+    // default on Supabase (helm's hosted-pg target); a self-hosted PG without it fails
+    // this migration at boot (CREATE EXTENSION), which is the honest signal to install
+    // it. Each statement is `;`-terminated only (the splitStatements contract).
+    version: 27,
+    sql: `
+      CREATE EXTENSION IF NOT EXISTS vector;
+      ALTER TABLE memory_facts ADD COLUMN embedding vector;
+      ALTER TABLE memory_facts ADD COLUMN embedding_model text;
+      ALTER TABLE memory_facts ADD COLUMN embedding_dim integer;
+      CREATE INDEX IF NOT EXISTS idx_memory_facts_fts ON memory_facts USING gin (to_tsvector('simple', fact_text));
+    `,
+  },
 ];
 
 // Anything that can run a raw SQL string against the Postgres connection. Both
@@ -597,7 +616,15 @@ export async function runPgMigrations(db: RawExecutor): Promise<void> {
 // path WITHOUT a running server. `dataDir` omitted => a fresh in-memory database.
 export async function createPgliteDb(dataDir?: string): Promise<PgDb> {
   const { PGlite } = await import("@electric-sql/pglite");
-  const client = dataDir ? new PGlite(dataDir) : new PGlite();
+  // docs/14 — load the pgvector extension so the v27 migration's `vector` column +
+  // the hybrid-recall vector leg work in-process (the contract tests cover the pg
+  // vector path without a server). Hosted Postgres (supabase) ships pgvector too.
+  // PGlite.create() (NOT `new PGlite`) is required so the extension's bundle is
+  // registered before any query — otherwise CREATE EXTENSION can't find vector.control.
+  const { vector } = await import("@electric-sql/pglite/vector");
+  const client = dataDir
+    ? await PGlite.create(dataDir, { extensions: { vector } })
+    : await PGlite.create({ extensions: { vector } });
   const db = drizzlePglite(client, { schema });
   await runPgMigrations(db);
   return Object.assign(db, { $close: () => client.close() });

--- a/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
+++ b/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
@@ -44,6 +44,9 @@ function seedPreV21(): string {
   ins.run(26);
   // v27 indexes memory_jobs; this memory_messages-only fixture never creates it → pre-mark.
   ins.run(27);
+  // v28 alters memory_facts (+ FTS); this memory_messages-only fixture never creates
+  // memory_facts → pre-mark applied (out of scope for the v21 dedup test).
+  ins.run(28);
   raw.exec(`
     CREATE TABLE memory_messages (
       id TEXT PRIMARY KEY,

--- a/packages/core/src/store/sqlite/memory-search.test.ts
+++ b/packages/core/src/store/sqlite/memory-search.test.ts
@@ -1,0 +1,234 @@
+import type { MemoryFactInput } from "@helm/shared";
+import { describe, expect, it } from "vitest";
+import { factContentHash } from "../../memory/forgetting/facts.js";
+import { SqliteMemoryStore } from "./memory-store.js";
+import { createSqliteDb } from "./migrate.js";
+
+// docs/14 / docs/12 P8 — hybrid fact retrieval over sqlite. These pin the highest-risk
+// decisions: CJK matches via the trigram tokenizer (unicode61 would not), account
+// isolation, superseded facts stay hidden, and the vector leg (sqlite-vec) re-ranks.
+
+const SCORE_CONFIG = {
+  half_life_s: 86400,
+  importance_floor: 0.1,
+  importance_ceil: 1.0,
+  access_weight: 0.15,
+};
+const NOW = new Date("2026-06-23T00:00:00.000Z");
+
+function makeFact(
+  ownerId: string,
+  factText: string,
+  over: Partial<MemoryFactInput> = {},
+): MemoryFactInput {
+  return {
+    ownerId,
+    subjectKey: factText.slice(0, 24),
+    factText,
+    contentHash: factContentHash(factText),
+    importance: 0.5,
+    referenceCount: 0,
+    referencedAt: null,
+    validFrom: NOW,
+    invalidAt: null,
+    expiredAt: null,
+    status: "active",
+    ...over,
+  };
+}
+
+function freshStore(): SqliteMemoryStore {
+  return new SqliteMemoryStore(createSqliteDb(":memory:"));
+}
+
+describe("SqliteMemoryStore.searchFacts (hybrid recall)", () => {
+  it("FTS-only: a CJK query matches via the trigram tokenizer (substring, mid-string)", async () => {
+    const store = freshStore();
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [
+        makeFact("acct-a", "用户最喜欢的编程语言是 TypeScript"),
+        makeFact("acct-a", "项目部署在 la.atmy.work"),
+      ],
+    });
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "编程语言",
+      limit: 10,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(hits?.map((f) => f.factText)).toContain("用户最喜欢的编程语言是 TypeScript");
+  });
+
+  it("is account-scoped: another account's matching fact never surfaces", async () => {
+    const store = freshStore();
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "编程语言是 TypeScript")],
+    });
+    await store.insertFactsReconciled({
+      accountId: "acct-b",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-b", "编程语言机密信息")],
+    });
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "编程语言",
+      limit: 10,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(hits?.every((f) => f.ownerId === "acct-a")).toBe(true);
+    expect(hits?.map((f) => f.factText)).not.toContain("编程语言机密信息");
+  });
+
+  it("matches an English query via trigram too", async () => {
+    const store = freshStore();
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [
+        makeFact("acct-a", "User prefers dark mode"),
+        makeFact("acct-a", "Timezone is UTC+8"),
+      ],
+    });
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "dark mode",
+      limit: 10,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(hits?.map((f) => f.factText)).toContain("User prefers dark mode");
+  });
+
+  it("a soft-deleted (pruned + expired) fact never surfaces", async () => {
+    const store = freshStore();
+    const res = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "临时的编程语言笔记")],
+    });
+    const id = res.insertedIds[0];
+    expect(id).toBeDefined();
+    await store.deleteFact?.({ accountId: "acct-a", id: id as string, now: NOW });
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "编程语言",
+      limit: 10,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(hits?.map((f) => f.factText)).not.toContain("临时的编程语言笔记");
+  });
+
+  it("vector leg: an embedding query recalls the nearest fact and RRF ranks it first", async () => {
+    const store = freshStore();
+    const res = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [
+        makeFact("acct-a", "alpha note about cats", { importance: 0.9 }),
+        makeFact("acct-a", "beta note about dogs", { importance: 0.1 }),
+        makeFact("acct-a", "gamma note about birds", { importance: 0.1 }),
+      ],
+    });
+    const [id0, id1, id2] = res.insertedIds;
+    await store.setFactEmbeddings?.({
+      accountId: "acct-a",
+      items: [
+        { factId: id0 as string, embedding: new Float32Array([1, 0, 0, 0]), model: "test", dim: 4 },
+        { factId: id1 as string, embedding: new Float32Array([0, 1, 0, 0]), model: "test", dim: 4 },
+        { factId: id2 as string, embedding: new Float32Array([0, 0, 1, 0]), model: "test", dim: 4 },
+      ],
+    });
+    // queryText matches no fact (so FTS is empty); the vector points at id0. id0 also
+    // has the top forgetting score (importance 0.9), so RRF puts it first deterministically.
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "zzz",
+      queryEmbedding: new Float32Array([0.95, 0.05, 0, 0]),
+      limit: 3,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(hits?.[0]?.id).toBe(id0);
+    expect(hits?.map((f) => f.id)).toContain(id1);
+  });
+
+  it("sub-trigram fallback: a 2-char CJK query recalls via LIKE (trigram can't index it)", async () => {
+    const store = freshStore();
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "本月的成本超出预算"), makeFact("acct-a", "无关记录")],
+    });
+    // '成本' is 2 chars → toFtsMatch returns null → the LIKE fallback restores recall.
+    const hits = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "成本",
+      limit: 10,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(hits?.map((f) => f.factText)).toContain("本月的成本超出预算");
+  });
+
+  it("editing a fact's text clears its stale vector (not recalled by the old embedding)", async () => {
+    const store = freshStore();
+    const res = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("acct-a", "old text about cats")],
+    });
+    const id = res.insertedIds[0] as string;
+    await store.setFactEmbeddings?.({
+      accountId: "acct-a",
+      items: [{ factId: id, embedding: new Float32Array([1, 0, 0, 0]), model: "test", dim: 4 }],
+    });
+    const before = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "zzz",
+      queryEmbedding: new Float32Array([1, 0, 0, 0]),
+      limit: 5,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(before?.map((f) => f.id)).toContain(id);
+    // editing the text clears embedding + drops the vec0 row → flagged for re-embed
+    await store.updateFact?.({
+      accountId: "acct-a",
+      id,
+      patch: { factText: "new text about dogs" },
+      now: NOW,
+    });
+    expect(
+      await store.listFactsNeedingEmbedding?.({
+        accountId: "acct-a",
+        model: "test",
+        dim: 4,
+        limit: 10,
+      }),
+    ).toHaveLength(1);
+    const after = await store.searchFacts?.({
+      accountId: "acct-a",
+      queryText: "zzz",
+      queryEmbedding: new Float32Array([1, 0, 0, 0]),
+      limit: 5,
+      now: NOW,
+      scoreConfig: SCORE_CONFIG,
+    });
+    expect(after?.map((f) => f.id)).not.toContain(id);
+  });
+});

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -18,9 +18,25 @@ import {
   type ReflectionScope,
   type ReflectionUpsertInput,
 } from "@helm/shared";
-import { and, asc, count, desc, eq, gt, isNull, like, lt, ne, type SQL, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  like,
+  lt,
+  ne,
+  type SQL,
+  sql,
+} from "drizzle-orm";
 import { factContentHash } from "../../memory/forgetting/facts.js";
+import { forgettingScore, type ScoreConfig } from "../../memory/forgetting/score.js";
 import { sha256Hex } from "../../memory/message-hash.js";
+import { reciprocalRankFusion } from "../../memory/recall/rrf.js";
 import {
   MemoryFactContentHashConflictError,
   type MemoryJobStatus,
@@ -178,6 +194,17 @@ function factListClauses(input: {
     clauses.push(like(memoryFacts.factText, `%${input.search}%`));
   }
   return clauses;
+}
+
+// docs/14 — build a safe FTS5 MATCH expression from raw user text for the trigram
+// index. Wrap the whole query as ONE phrase (escaping `"`→`""`) so FTS5 operators in
+// user text (AND/OR/NOT/NEAR/quotes/column filters) can never cause a syntax error or
+// unintended boolean logic. trigram needs ≥3 chars to match anything, so a shorter
+// query returns null ⇒ the FTS leg is skipped (a vector leg, if any, still runs).
+function toFtsMatch(queryText: string): string | null {
+  const cleaned = queryText.replace(/\s+/g, " ").trim();
+  if ([...cleaned].length < 3) return null;
+  return `"${cleaned.replace(/"/g, '""')}"`;
 }
 
 // SQLite adapter for the MemoryStore port (docs/08). POST-MVP persistence floor:
@@ -624,6 +651,7 @@ export class SqliteMemoryStore implements MemoryStore {
     accountId: string;
     observationIds: string[];
     reflectionIds: string[];
+    factIds?: string[];
     now: Date;
   }): Promise<void> {
     const nowMs = input.now.getTime();
@@ -650,6 +678,19 @@ export class SqliteMemoryStore implements MemoryStore {
               AND owner_id = ?`,
         )
         .run(nowMs, ...input.reflectionIds, input.accountId);
+    }
+    // docs/14 — recalled facts get the same reinforcement bump. memory_facts carry
+    // owner_id directly (no thread join), so guard on owner_id like reflections.
+    if (input.factIds !== undefined && input.factIds.length > 0) {
+      const placeholders = input.factIds.map(() => "?").join(", ");
+      this.db.$sqlite
+        .prepare(
+          `UPDATE memory_facts
+              SET reference_count = reference_count + 1, referenced_at = ?
+            WHERE id IN (${placeholders})
+              AND owner_id = ?`,
+        )
+        .run(nowMs, ...input.factIds, input.accountId);
     }
   }
 
@@ -1104,6 +1145,239 @@ export class SqliteMemoryStore implements MemoryStore {
     return { rows: rows.map(sqliteRowToFact), total: totalRow?.n ?? 0 };
   }
 
+  // docs/14 / docs/12 P8 — HYBRID relevance retrieval over memory_facts. Up to three
+  // ranked lists fused with RRF: FTS5(trigram) full-text, sqlite-vec KNN (only when a
+  // query embedding is given AND the extension loaded AND the vec table matches — else
+  // skipped, fail-open), and the forgetting score over the candidate union. Account-
+  // scoped + active-only; a superseded/archived/expired fact never surfaces.
+  async searchFacts(input: {
+    accountId: string;
+    projectId?: string;
+    resourceId?: string;
+    threadId?: string;
+    queryText: string;
+    queryEmbedding?: Float32Array;
+    limit: number;
+    now: Date;
+    scoreConfig: ScoreConfig;
+  }): Promise<Fact[]> {
+    // Over-fetch per signal so RRF has room to find consensus; final cap is input.limit.
+    const candidateLimit = Math.max(input.limit * 5, 50);
+
+    // Account + active + scope guard, shared by both raw legs (mf = memory_facts).
+    const scopeSql = ["mf.owner_id = ?", "mf.status = 'active'", "mf.expired_at IS NULL"];
+    const scopeArgs: unknown[] = [input.accountId];
+    if (input.projectId !== undefined) {
+      scopeSql.push("mf.project_id = ?");
+      scopeArgs.push(input.projectId);
+    }
+    if (input.resourceId !== undefined) {
+      scopeSql.push("mf.resource_id = ?");
+      scopeArgs.push(input.resourceId);
+    }
+    if (input.threadId !== undefined) {
+      scopeSql.push("mf.thread_id = ?");
+      scopeArgs.push(input.threadId);
+    }
+    const scopeWhere = scopeSql.join(" AND ");
+
+    // ── FTS leg (trigram) ──
+    const ftsIds: string[] = [];
+    const match = toFtsMatch(input.queryText);
+    if (match !== null) {
+      const rows = this.db.$sqlite
+        .prepare(
+          `SELECT mf.id AS id
+             FROM memory_facts_fts ff
+             JOIN memory_facts mf ON mf.rowid = ff.rowid
+            WHERE memory_facts_fts MATCH ?
+              AND ${scopeWhere}
+            ORDER BY bm25(memory_facts_fts)
+            LIMIT ?`,
+        )
+        .all(match, ...scopeArgs, candidateLimit) as Array<{ id: string }>;
+      for (const r of rows) ftsIds.push(r.id);
+    }
+
+    // ── LIKE fallback ── when the FTS leg yields NO candidates — a sub-trigram query
+    // (the 2-char CJK "成本" that trigram can't index, so toFtsMatch returned null) or a
+    // genuine FTS miss — a substring scan restores exact short-literal recall (parity
+    // with memory_search), so short queries never regress to empty. Same scope guard.
+    if (ftsIds.length === 0) {
+      const cleaned = input.queryText.replace(/\s+/g, " ").trim();
+      if (cleaned.length > 0) {
+        const rows = this.db.$sqlite
+          .prepare(
+            `SELECT mf.id AS id
+               FROM memory_facts mf
+              WHERE ${scopeWhere}
+                AND mf.fact_text LIKE ?
+              ORDER BY mf.updated_at DESC
+              LIMIT ?`,
+          )
+          .all(...scopeArgs, `%${cleaned}%`, candidateLimit) as Array<{ id: string }>;
+        for (const r of rows) ftsIds.push(r.id);
+      }
+    }
+
+    // ── vector leg (sqlite-vec KNN) ── only with an embedding AND the extension
+    // loaded. The KNN lives in a subquery (pure vec0 form), then joins memory_facts
+    // for the scope/active guard. Wrapped in try/catch: a missing vec table or a dim
+    // mismatch degrades to FTS+score (fail-open), never throws.
+    const vecIds: string[] = [];
+    if (input.queryEmbedding !== undefined && this.db.$vecLoaded) {
+      try {
+        const qbuf = new Uint8Array(
+          input.queryEmbedding.buffer,
+          input.queryEmbedding.byteOffset,
+          input.queryEmbedding.byteLength,
+        );
+        const rows = this.db.$sqlite
+          .prepare(
+            `SELECT mf.id AS id
+               FROM (
+                 SELECT fact_rowid, distance FROM memory_facts_vec
+                  WHERE embedding MATCH ? AND k = ?
+               ) v
+               JOIN memory_facts mf ON mf.rowid = v.fact_rowid
+              WHERE ${scopeWhere}
+              ORDER BY v.distance`,
+          )
+          .all(qbuf, candidateLimit, ...scopeArgs) as Array<{ id: string }>;
+        for (const r of rows) vecIds.push(r.id);
+      } catch {
+        // vec table absent / dim mismatch → skip the vector leg (fail-open).
+      }
+    }
+
+    // Candidate union; nothing matched ⇒ empty (the tool reports "no hits").
+    const candidateIds = [...new Set([...ftsIds, ...vecIds])];
+    if (candidateIds.length === 0) return [];
+
+    // Materialize via Drizzle (camelCase rows → Fact); only candidates, so cheap.
+    const factById = new Map<string, Fact>();
+    for (const row of this.db
+      .select()
+      .from(memoryFacts)
+      .where(inArray(memoryFacts.id, candidateIds))
+      .all()) {
+      factById.set(row.id, sqliteRowToFact(row));
+    }
+
+    // Forgetting-score ranked list over the candidate union (fact-tier fallback_ts =
+    // created_at, docs/12). A decayed fact ranks low in retrieval too.
+    const scoreIds = [...factById.values()]
+      .map((f) => ({
+        id: f.id,
+        score: forgettingScore(
+          {
+            referencedAt: f.referencedAt ?? null,
+            fallbackTs: f.createdAt,
+            referenceCount: f.referenceCount ?? 0,
+            importance: f.importance ?? 0.5,
+          },
+          input.scoreConfig,
+          input.now,
+        ),
+      }))
+      .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+      .map((x) => x.id);
+
+    // RRF-fuse the three ranked lists, take top-K, return full facts in fused order.
+    return reciprocalRankFusion([ftsIds, vecIds, scoreIds])
+      .map((r) => factById.get(r.id))
+      .filter((f): f is Fact => f !== undefined)
+      .slice(0, input.limit);
+  }
+
+  // docs/14 — embedding write sink (the background embedding job). Account-guarded: a
+  // fact not owned by accountId is skipped (never a cross-tenant write). Persists the
+  // vector + model + dim onto memory_facts, and when sqlite-vec is loaded mirrors it
+  // into the vec0 KNN table (lazily created at the right dim). Idempotent.
+  async setFactEmbeddings(input: {
+    accountId: string;
+    items: Array<{ factId: string; embedding: Float32Array; model: string; dim: number }>;
+  }): Promise<void> {
+    if (input.items.length === 0) return;
+    const selectRowid = this.db.$sqlite.prepare(
+      "SELECT rowid AS rowid FROM memory_facts WHERE id = ? AND owner_id = ?",
+    );
+    const updateEmbedding = this.db.$sqlite.prepare(
+      "UPDATE memory_facts SET embedding = ?, embedding_model = ?, embedding_dim = ? WHERE rowid = ?",
+    );
+    const run = this.db.$sqlite.transaction(() => {
+      for (const it of input.items) {
+        const row = selectRowid.get(it.factId, input.accountId) as { rowid: number } | undefined;
+        if (row === undefined) continue;
+        const buf = new Uint8Array(
+          it.embedding.buffer,
+          it.embedding.byteOffset,
+          it.embedding.byteLength,
+        );
+        updateEmbedding.run(buf, it.model, it.dim, row.rowid);
+        if (this.db.$vecLoaded && this.ensureVecTable(it.dim)) {
+          // vec0 sync is BEST-EFFORT: a failure here must not roll back the BLOB write
+          // above (the fact stays FTS+score findable and re-embed retries).
+          try {
+            const rid = BigInt(row.rowid);
+            this.db.$sqlite.prepare("DELETE FROM memory_facts_vec WHERE fact_rowid = ?").run(rid);
+            this.db.$sqlite
+              .prepare("INSERT INTO memory_facts_vec(fact_rowid, embedding) VALUES (?, ?)")
+              .run(rid, buf);
+          } catch {
+            // skip vec sync for this row
+          }
+        }
+      }
+    });
+    run();
+  }
+
+  // docs/14 — the embedding job's read half. ACTIVE facts with no embedding, or one
+  // from a different model OR a different dim (IS NOT is NULL-safe: an unembedded row
+  // has model/dim NULL, which IS NOT <model>/<dim> → included). Oldest-first, capped.
+  async listFactsNeedingEmbedding(input: {
+    accountId: string;
+    model: string;
+    dim: number;
+    limit: number;
+  }): Promise<Array<{ id: string; factText: string }>> {
+    return this.db.$sqlite
+      .prepare(
+        `SELECT id AS id, fact_text AS factText
+           FROM memory_facts
+          WHERE owner_id = ?
+            AND status = 'active'
+            AND expired_at IS NULL
+            AND (embedding IS NULL OR embedding_model IS NOT ? OR embedding_dim IS NOT ?)
+          ORDER BY created_at ASC
+          LIMIT ?`,
+      )
+      .all(input.accountId, input.model, input.dim, input.limit) as Array<{
+      id: string;
+      factText: string;
+    }>;
+  }
+
+  // Lazily create the vec0 KNN table at the embedding dimension (the migration can't —
+  // FLOAT[dim] needs the runtime dim). Returns false when the extension isn't loaded or
+  // dim is invalid. A changed dim (model swap) rebuilds the table; the embedding job
+  // re-embeds the rest. dim is a trusted integer (config-validated); guarded anyway.
+  private vecDim: number | null = null;
+  private ensureVecTable(dim: number): boolean {
+    if (!this.db.$vecLoaded) return false;
+    if (!Number.isInteger(dim) || dim <= 0) return false;
+    if (this.vecDim === dim) return true;
+    if (this.vecDim !== null && this.vecDim !== dim) {
+      this.db.$sqlite.exec("DROP TABLE IF EXISTS memory_facts_vec");
+    }
+    this.db.$sqlite.exec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS memory_facts_vec USING vec0(fact_rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}])`,
+    );
+    this.vecDim = dim;
+    return true;
+  }
+
   // Edit a fact in place (partial). factText edit recomputes content_hash (never
   // subjectKey); a collision with a DIFFERENT row's (owner_id, content_hash)
   // throws MemoryFactContentHashConflictError (route → 409). invalidAt tri-state
@@ -1154,6 +1428,32 @@ export class SqliteMemoryStore implements MemoryStore {
       .set(set)
       .where(and(eq(memoryFacts.id, input.id), eq(memoryFacts.ownerId, input.accountId)))
       .run();
+    // docs/14 — a TEXT edit invalidates the stored vector. Clear the embedding columns
+    // + drop the vec0 row so the fact re-embeds on the next embedding job and is NEVER
+    // ranked by a stale vector (Codex review). The embedding columns live outside the
+    // Drizzle schema (raw migration v28), so this is a raw clear. `set.factText` is set
+    // only when the text actually changed.
+    if (set.factText !== undefined) {
+      const rowidRow = this.db.$sqlite
+        .prepare("SELECT rowid AS rowid FROM memory_facts WHERE id = ? AND owner_id = ?")
+        .get(input.id, input.accountId) as { rowid: number } | undefined;
+      if (rowidRow !== undefined) {
+        this.db.$sqlite
+          .prepare(
+            "UPDATE memory_facts SET embedding = NULL, embedding_model = NULL, embedding_dim = NULL WHERE rowid = ?",
+          )
+          .run(rowidRow.rowid);
+        if (this.db.$vecLoaded) {
+          try {
+            this.db.$sqlite
+              .prepare("DELETE FROM memory_facts_vec WHERE fact_rowid = ?")
+              .run(BigInt(rowidRow.rowid));
+          } catch {
+            // vec table absent → nothing to drop.
+          }
+        }
+      }
+    }
     return this.getFactById({ accountId: input.accountId, id: input.id });
   }
 

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { type BetterSQLite3Database, drizzle } from "drizzle-orm/better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
 import * as schema from "./schema.js";
 
 type Schema = typeof schema;
@@ -9,6 +10,10 @@ type Schema = typeof schema;
 // return type can be referenced across module boundaries (avoids TS4058).
 export type SqliteDb = BetterSQLite3Database<Schema> & {
   readonly $sqlite: Database.Database;
+  // docs/14 — whether the sqlite-vec extension loaded on this connection. The hybrid
+  // recall vector leg (vec0 KNN) is used only when true; on false the store degrades
+  // to FTS+score (fail-open — a missing/unloadable extension never crashes startup).
+  readonly $vecLoaded: boolean;
 };
 
 // Checked-in, ordered migrations. Each runs exactly once per database; the
@@ -593,6 +598,50 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_memory_jobs_claim ON memory_jobs (status, created_at, id);
     `,
   },
+  {
+    // docs/14 / docs/12 P8 — hybrid fact retrieval. Three additions to memory_facts,
+    // none depend on the sqlite-vec extension (so this migration ALWAYS applies, even
+    // where the extension is absent — fail-open):
+    //   1. embedding columns: the vector (BLOB of a Float32Array) + the model id +
+    //      dim it was produced with (for lazy re-embed on a model change; never mix
+    //      vectors from two models in one index).
+    //   2. an FTS5 EXTERNAL-CONTENT table over fact_text with the `trigram` tokenizer
+    //      — trigram indexes 3-char windows so it matches BOTH CJK (unicode61 collapses
+    //      a Chinese run to one token) and Latin substrings without a segmenter.
+    //      external-content stores ONLY the inverted index, not a copy of the text
+    //      (lean — the request_payloads bloat lesson). Triggers keep it in sync;
+    //      'rebuild' backfills existing rows.
+    // The vec0 virtual table is NOT created here (its FLOAT[dim] width needs the
+    // runtime embedding_dimensions); the store creates it lazily once the extension is
+    // loaded and a dimension is known.
+    version: 28,
+    sql: `
+      ALTER TABLE memory_facts ADD COLUMN embedding BLOB;
+      ALTER TABLE memory_facts ADD COLUMN embedding_model TEXT;
+      ALTER TABLE memory_facts ADD COLUMN embedding_dim INTEGER;
+
+      CREATE VIRTUAL TABLE memory_facts_fts USING fts5(
+        fact_text,
+        content='memory_facts',
+        content_rowid='rowid',
+        tokenize='trigram'
+      );
+      INSERT INTO memory_facts_fts(memory_facts_fts) VALUES('rebuild');
+
+      CREATE TRIGGER memory_facts_fts_ai AFTER INSERT ON memory_facts BEGIN
+        INSERT INTO memory_facts_fts(rowid, fact_text) VALUES (new.rowid, new.fact_text);
+      END;
+      CREATE TRIGGER memory_facts_fts_ad AFTER DELETE ON memory_facts BEGIN
+        INSERT INTO memory_facts_fts(memory_facts_fts, rowid, fact_text)
+          VALUES('delete', old.rowid, old.fact_text);
+      END;
+      CREATE TRIGGER memory_facts_fts_au AFTER UPDATE ON memory_facts BEGIN
+        INSERT INTO memory_facts_fts(memory_facts_fts, rowid, fact_text)
+          VALUES('delete', old.rowid, old.fact_text);
+        INSERT INTO memory_facts_fts(rowid, fact_text) VALUES (new.rowid, new.fact_text);
+      END;
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database): void {
@@ -643,6 +692,21 @@ function applyPragmas(sqlite: Database.Database): void {
   sqlite.pragma("cache_size = -16000");
 }
 
+// docs/14 — load the sqlite-vec extension on a connection so the vec0 virtual table
+// (vector KNN) is available for hybrid recall's vector leg. FAIL-OPEN: if the
+// extension can't load (no prebuilt binary for the platform, a sandbox blocking
+// loadExtension), return false and the store runs FTS+score only — an optional
+// accelerator must NEVER crash startup. sqliteVec.load() calls db.loadExtension(),
+// which better-sqlite3 permits by default.
+function loadVecExtension(sqlite: Database.Database): boolean {
+  try {
+    sqliteVec.load(sqlite);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Apply migrations to a fresh or existing sqlite file (or ":memory:"). Idempotent.
 // Throws on failure so the caller can fail-closed at startup.
 export function runMigrations(dbPath: string): void {
@@ -660,7 +724,10 @@ export function runMigrations(dbPath: string): void {
 export function createSqliteDb(dbPath: string): SqliteDb {
   const sqlite = new Database(dbPath);
   applyPragmas(sqlite);
+  // Load sqlite-vec BEFORE migrations (harmless if a later migration ever needs it);
+  // the result is surfaced on the db so the store knows whether the vector leg exists.
+  const vecLoaded = loadVecExtension(sqlite);
   applyMigrations(sqlite);
   const db = drizzle(sqlite, { schema });
-  return Object.assign(db, { $sqlite: sqlite });
+  return Object.assign(db, { $sqlite: sqlite, $vecLoaded: vecLoaded });
 }

--- a/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
@@ -30,6 +30,8 @@ function seedPreV26(): string {
   // v26 is this test's target (runs); v27 indexes memory_jobs, absent from this
   // oauth_quota-only fixture → pre-mark applied so only v26 runs.
   ins.run(27);
+  // v28 alters memory_facts (+ FTS), absent from this oauth_quota-only fixture → pre-mark.
+  ins.run(28);
   raw.exec(`
     CREATE TABLE oauth_quota (
       provider_id TEXT NOT NULL,

--- a/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
@@ -41,6 +41,8 @@ function seedPreV23(): string {
   ins.run(26);
   // v27 indexes memory_jobs; this oauth_usage-only fixture never creates it → pre-mark.
   ins.run(27);
+  // v28 alters memory_facts (+ FTS), absent from this oauth_usage-only fixture → pre-mark.
+  ins.run(28);
   raw.exec(`
     CREATE TABLE oauth_usage (
       provider_id TEXT NOT NULL,

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -64,8 +64,10 @@ describe("sqlite schema + migrations", () => {
       // v25 (telemetry.generation_ms): no telemetry table here → pre-mark applied.
       // v26 alters oauth_quota (created at v12, applied here without the CREATE) →
       // pre-mark applied, out of scope.
+      // v28 alters memory_facts (+ FTS); this memory_jobs-only fixture never creates
+      // memory_facts → pre-mark applied (out of scope for this v14–v16 test).
       // biome-ignore format: keep the version ledger on one readable line
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26])
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28])
         rec.run(v, Date.now());
       const insert = seed.prepare(
         "INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -205,7 +207,8 @@ describe("sqlite schema + migrations", () => {
       // v20 alters memory_threads (absent from this fixture) → pre-mark applied.
       // v21 dedups memory_messages (absent: v2 marked applied without the CREATE)
       // → pre-mark applied.
-      for (const v of [1, 2, 3, 4, 5, 18, 20, 21]) rec.run(v, Date.now());
+      // v28 alters memory_facts (absent from this fixture) → pre-mark applied.
+      for (const v of [1, 2, 3, 4, 5, 18, 20, 21, 28]) rec.run(v, Date.now());
       seed
         .prepare(
           "INSERT INTO telemetry (id, request_id, api_key_id, decision_json, cost_usd, created_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -271,7 +274,9 @@ describe("sqlite schema + migrations", () => {
       // v24 adds request_payloads.upstream_request_json (table absent from this
       // api_keys-only fixture) → pre-mark applied.
       // v25 (telemetry.generation_ms): no telemetry table here → pre-mark applied.
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22, 24, 25]) rec.run(v, Date.now());
+      // v28 alters memory_facts (absent from this api_keys-only fixture) → pre-mark.
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22, 24, 25, 28])
+        rec.run(v, Date.now());
       seed
         .prepare(
           `INSERT INTO api_keys (key_id, hash, prefix, account_id, role, max_lane, allowed_lanes, created_at)

--- a/packages/shared/src/config/memory-schema.test.ts
+++ b/packages/shared/src/config/memory-schema.test.ts
@@ -31,6 +31,9 @@ describe("ForgettingSchema", () => {
     expect(f.sweep.max_iterations).toBe(200);
     expect(f.sweep.max_wallclock_s).toBe(900);
     expect(f.sweep.max_consecutive_errors).toBe(5);
+    // docs/14 / P8 — hybrid fact retrieval gate: off by default, top_k prior 10.
+    expect(f.facts_retrieval.enabled).toBe(false);
+    expect(f.facts_retrieval.top_k).toBe(10);
   });
 
   it("a non-default half_life_s round-trips and takes effect", () => {
@@ -101,6 +104,17 @@ describe("ForgettingSchema", () => {
 
   it("fails closed on a non-positive half_life_s", () => {
     expect(() => ForgettingSchema.parse({ score: { half_life_s: 0 } })).toThrow();
+  });
+
+  // docs/14 / P8 — hybrid fact retrieval gate. Off by default; enabling it (FTS+score)
+  // is independent of embeddings (the vector leg lights up only when memory.llm.
+  // embedding_model is set). Unknown keys / bad ranges fail closed like every block.
+  it("facts_retrieval round-trips and fails closed on unknown keys (.strict())", () => {
+    const f = ForgettingSchema.parse({ facts_retrieval: { enabled: true, top_k: 25 } });
+    expect(f.facts_retrieval.enabled).toBe(true);
+    expect(f.facts_retrieval.top_k).toBe(25);
+    expect(() => ForgettingSchema.parse({ facts_retrieval: { top_k: 0 } })).toThrow();
+    expect(() => ForgettingSchema.parse({ facts_retrieval: { enabledd: true } })).toThrow();
   });
 });
 
@@ -183,6 +197,24 @@ describe("MemoryLlmSchema", () => {
     expect(() => MemoryLlmSchema.parse({ enabled: true, model: "x", temperature: 2 })).toThrow();
     expect(() =>
       MemoryLlmSchema.parse({ enabled: true, model: "x", max_tokens: { observation: 0 } }),
+    ).toThrow();
+  });
+
+  // docs/14 — the embedding model powers the vector leg of hybrid recall. Optional:
+  // absent ⇒ the vector leg is disabled (recall degrades to FTS+score). When set,
+  // embedding_dimensions pins the stored vector width (must match the model).
+  it("accepts an optional embedding_model + embedding_dimensions (absent ⇒ undefined)", () => {
+    const off = MemoryLlmSchema.parse({});
+    expect(off.embedding_model).toBeUndefined();
+    expect(off.embedding_dimensions).toBeUndefined();
+    const on = MemoryLlmSchema.parse({ embedding_model: "bge-m3", embedding_dimensions: 1024 });
+    expect(on.embedding_model).toBe("bge-m3");
+    expect(on.embedding_dimensions).toBe(1024);
+  });
+
+  it("fails closed on a non-positive embedding_dimensions", () => {
+    expect(() =>
+      MemoryLlmSchema.parse({ embedding_model: "bge-m3", embedding_dimensions: 0 }),
     ).toThrow();
   });
 });

--- a/packages/shared/src/config/memory-schema.ts
+++ b/packages/shared/src/config/memory-schema.ts
@@ -118,6 +118,20 @@ export const ForgettingSchema = z
       })
       .strict()
       .prefault({}),
+    // docs/14 / P8 — hybrid fact retrieval (the `memory_recall` engine). enabled:false
+    // ⇒ memory_recall degrades to substring LIKE (today's behaviour). enabled:true runs
+    // query-driven recall over memory_facts fusing FTS5(trigram)+forgetting-score via
+    // RRF; the VECTOR leg additionally lights up only when memory.llm.embedding_model is
+    // set — so this flag alone is a usable, cross-lingual-blind on-ramp. top_k caps the
+    // fused result set. The RRF k and per-signal weights are code constants (no lying
+    // knobs); the only operational levers are the gate and the result cap.
+    facts_retrieval: z
+      .object({
+        enabled: z.boolean().default(false),
+        top_k: z.number().int().positive().default(10),
+      })
+      .strict()
+      .prefault({}),
   })
   .strict();
 
@@ -174,6 +188,13 @@ export const MemoryLlmSchema = z
     observation_model: z.string().min(1).optional(),
     reflection_model: z.string().min(1).optional(),
     facts_model: z.string().min(1).optional(),
+    // docs/14 — embedding model for the VECTOR leg of hybrid recall (an OpenAI-
+    // compatible /v1/embeddings model id or lane). Optional: absent ⇒ the vector leg
+    // is disabled and recall runs FTS+forgetting-score only. embedding_dimensions pins
+    // the stored vector width and MUST match the model's output dim (the migration
+    // sizes the sqlite-vec / pgvector column from it; changing it requires a re-embed).
+    embedding_model: z.string().min(1).optional(),
+    embedding_dimensions: z.number().int().positive().optional(),
     timeout_ms: z.number().int().positive().default(30_000),
     temperature: z.number().min(0).max(1).default(0),
     max_tokens: MemoryLlmMaxTokensSchema.prefault({}),

--- a/packages/shared/src/memory/jobs.test.ts
+++ b/packages/shared/src/memory/jobs.test.ts
@@ -8,6 +8,12 @@ describe("MemoryJobTypeSchema", () => {
     expect(MemoryJobTypeSchema.parse("decay")).toBe("decay");
   });
 
+  // docs/14 — hybrid fact retrieval (P8) needs facts embedded off the hot path; the
+  // 'embedding' job kind backfills `memory_facts.embedding` for newly inserted facts.
+  it("parses 'embedding' (docs/14 fact-embedding job kind)", () => {
+    expect(MemoryJobTypeSchema.parse("embedding")).toBe("embedding");
+  });
+
   it("still parses the pre-existing observer / reflector kinds", () => {
     expect(MemoryJobTypeSchema.parse("observer")).toBe("observer");
     expect(MemoryJobTypeSchema.parse("reflector")).toBe("reflector");

--- a/packages/shared/src/memory/jobs.ts
+++ b/packages/shared/src/memory/jobs.ts
@@ -10,11 +10,13 @@ import { ReflectionScopeSchema } from "./schema.js";
 // The background job kinds. observer = compress a thread's older raw messages into
 // one observation; reflector = merge a scope's observations into a stable, versioned
 // reflection; decay (docs/12 P5) = the OFF-hot-path forgetting SWEEP that soft-
-// archives sub-threshold observations for one account. All three run OFF the request
-// path. Additive: 'decay' is a NEW member, so an old observer/reflector row still
-// parses unchanged — the gating lever (forgetting.enabled:false ⇒ no decay jobs are
-// ever enqueued) keeps the enum widening inert until the flag is on.
-export const MemoryJobTypeSchema = z.enum(["observer", "reflector", "decay"]);
+// archives sub-threshold observations for one account. embedding (docs/14 P8) =
+// backfill `memory_facts.embedding` for newly inserted facts so hybrid recall gets a
+// vector leg. All run OFF the request path. Additive: each new member leaves older
+// rows parsing unchanged — the gating levers (forgetting.enabled / facts_retrieval.
+// enabled / llm.embedding_model off ⇒ those jobs are never enqueued) keep the enum
+// widening inert until the flag is on.
+export const MemoryJobTypeSchema = z.enum(["observer", "reflector", "decay", "embedding"]);
 
 // Input to enqueue a background job. The scope is the full ReflectionScope so a
 // reflector job can land at the highest available level (project/resource/thread);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       socks:
         specifier: ^2.8.9
         version: 2.8.9
+      sqlite-vec:
+        specifier: ^0.1.9
+        version: 0.1.9
       undici:
         specifier: ^8.3.0
         version: 8.3.0
@@ -2407,6 +2410,34 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sqlite-vec-darwin-arm64@0.1.9:
+    resolution: {integrity: sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sqlite-vec-darwin-x64@0.1.9:
+    resolution: {integrity: sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==}
+    cpu: [x64]
+    os: [darwin]
+
+  sqlite-vec-linux-arm64@0.1.9:
+    resolution: {integrity: sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==}
+    cpu: [arm64]
+    os: [linux]
+
+  sqlite-vec-linux-x64@0.1.9:
+    resolution: {integrity: sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==}
+    cpu: [x64]
+    os: [linux]
+
+  sqlite-vec-windows-x64@0.1.9:
+    resolution: {integrity: sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==}
+    cpu: [x64]
+    os: [win32]
+
+  sqlite-vec@0.1.9:
+    resolution: {integrity: sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4718,6 +4749,29 @@ snapshots:
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
+
+  sqlite-vec-darwin-arm64@0.1.9:
+    optional: true
+
+  sqlite-vec-darwin-x64@0.1.9:
+    optional: true
+
+  sqlite-vec-linux-arm64@0.1.9:
+    optional: true
+
+  sqlite-vec-linux-x64@0.1.9:
+    optional: true
+
+  sqlite-vec-windows-x64@0.1.9:
+    optional: true
+
+  sqlite-vec@0.1.9:
+    optionalDependencies:
+      sqlite-vec-darwin-arm64: 0.1.9
+      sqlite-vec-darwin-x64: 0.1.9
+      sqlite-vec-linux-arm64: 0.1.9
+      sqlite-vec-linux-x64: 0.1.9
+      sqlite-vec-windows-x64: 0.1.9
 
   stackback@0.0.2: {}
 


### PR DESCRIPTION
## What

Implements **docs/12 P8** (previously deferred) as **docs/14** — query-driven **hybrid recall** over `memory_facts`, and exposes it as a new **`memory_recall`** MCP tool. Answers "what did we discuss / decide about X" across sessions, beyond `memory_search`'s substring `LIKE`.

Three deterministic signals fused with **RRF (k=60)**:
- **vector** similarity — `sqlite-vec` (sqlite) / `pgvector` (postgres)
- **full-text** — FTS5 **`trigram`** (sqlite, handles CJK) / `tsvector('simple')` (postgres)
- **forgetting score** — decayed facts rank low in retrieval too

## Changes

- **config**: `memory.forgetting.facts_retrieval{enabled,top_k}` + `memory.llm.embedding_model/_dimensions` + an `embedding` job kind. All `.strict()`, off by default.
- **sqlite adapter**: migration **v28** (embedding cols + FTS5 trigram external-content + `sqlite-vec` vec0 + a fail-open load hook) + `searchFacts` / `setFactEmbeddings` / `listFactsNeedingEmbedding` + `bumpReferences.factIds`.
- **postgres adapter**: migration **v27** (`pgvector` + `tsvector('simple')` GIN) + the same methods.
- **gateway**: an OpenAI-compatible `/v1/embeddings` embedder (strict provider resolution + bounded timeout) + a background **embedding job** + scheduler dispatch/enqueue.
- **MCP**: the `memory_recall` tool + wiring. Fail-open throughout (degrades to `LIKE`); recalled facts get the reinforcement bump.

## Enabling

- `memory.forgetting.facts_retrieval.enabled: true` → FTS+score recall (works immediately, cross-lingual-blind).
- also set `memory.llm.embedding_model` (e.g. `openai/bge-m3`) + `embedding_dimensions: 1024` → lights up the vector leg (cross-lingual). Default all-off ⇒ byte-identical to today.

## Codex review

All **5× P2** addressed: strict prefixed-model resolution, bounded embed timeout, full-batch re-enqueue, re-embed on text/dim change, sub-trigram LIKE fallback (short-CJK recall).

## Validation

- `typecheck -r` green (shared + core + gateway)
- core suite **2573** passed; gateway mcp 17 + embedder 7
- `pnpm build` green
- lint: changed files clean (`oauth.ts:312` is a pre-existing main lint, not in this PR)

> Note: postgres vector leg requires the `pgvector` extension (Supabase has it by default; a self-hosted PG without it fails the v27 migration at boot — the honest signal to install it). e2e (Playwright) run locally per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)