### PR TITLE
chore(release): v0.21.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.18",
+  "version": "0.21.19",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v0.21.19** — ships **memory deep recall** (#361).

Hybrid fact retrieval over `memory_facts` (vector via sqlite-vec/pgvector + FTS5-trigram/tsvector + forgetting-score, RRF-fused) exposed as the new `memory_recall` MCP tool, plus a background embedding job.

**Off by default** (`memory.forgetting.facts_retrieval.enabled:false`) → dormant until enabled, so this release is behaviorally identical to v0.21.18 out of the box. Config change is additive-only (new optional `memory.forgetting.facts_retrieval` + `memory.llm.embedding_model/_dimensions`), so existing operator config still validates.

Migration v28 (sqlite) / v27 (postgres) are additive; the sqlite-vec load is fail-open (no extension ⇒ FTS+score, never a boot crash).

On merge, `publish.yml` cuts tag `v0.21.19` + GitHub Release + pushes `ghcr.io/easymetaau/helm-api:0.21.19` & `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)