### PR TITLE
feat(memory): default facts_retrieval on (FTS+score hybrid recall)

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -40,6 +40,12 @@
 # fail-closed validated (snake_case, unknown keys refuse startup).
 forgetting:
   enabled: true
+  # docs/14 — hybrid fact retrieval for the memory_recall MCP tool: FTS5 (trigram,
+  # CJK-capable) + forgetting-score fused via RRF. ON by default — keyword + recency
+  # recall, NO embedding required. Set memory.llm.embedding_model to additionally
+  # light up the cross-lingual vector leg. enabled:false reverts to substring LIKE.
+  facts_retrieval:
+    enabled: true
   score:
     half_life_s: 86400
     importance_floor: 0.1

--- a/docs/12-memory-forgetting-and-tiering.md
+++ b/docs/12-memory-forgetting-and-tiering.md
@@ -343,8 +343,10 @@ retrieval over `memory_facts`, aligned with where the field has converged
 - **Same invariants**: account-scoped reads (`owner_id = :accountId AND
   expired_at IS NULL`), fail-open (empty or failed recall → request proceeds with
   the v1 prefix), and retrieval results get the same reinforcement bump.
-- Gated behind its own flag (`forgetting.facts_retrieval.enabled`, default off);
-  schema impact is one nullable `embedding` column on `memory_facts`.
+- Gated behind its own flag (`forgetting.facts_retrieval.enabled`, **default on** —
+  FTS+score needs no embedding; the vector leg lights up only when
+  `memory.llm.embedding_model` is set). Schema impact is one nullable `embedding`
+  column on `memory_facts`. The flag gates ONLY the `memory_recall` MCP tool (fail-open).
 
 ## Schema deltas
 

--- a/docs/14-memory-deep-recall.md
+++ b/docs/14-memory-deep-recall.md
@@ -184,7 +184,7 @@ Reuse `docs/12`'s gate name; add the embedding fields to the existing `llm` bloc
 ```ts
 // memory.forgetting.facts_retrieval (docs/12 P8) — master gate for hybrid recall.
 facts_retrieval: z.object({
-  enabled: z.boolean().default(false),          // off ⇒ memory_recall degrades to LIKE
+  enabled: z.boolean().default(true),           // ON: FTS+score; false ⇒ memory_recall = LIKE
   top_k: z.number().int().positive().default(10),
 }).strict().prefault({}),
 
@@ -193,9 +193,11 @@ embedding_model: z.string().min(1).optional(),        // absent ⇒ vector leg o
 embedding_dimensions: z.number().int().positive().optional(),
 ```
 
-- `facts_retrieval.enabled` independent of embeddings: with it on but no `embedding_model`, recall runs
-  **FTS+score** (no vector leg) — a usable, cross-lingual-blind mode. Configuring `embedding_model`
-  lights up the vector leg → full hybrid. This is the staged on-ramp inside one flag.
+- `facts_retrieval.enabled` is **ON by default** (FTS+score, no embedding required) — keyword + recency
+  recall, CJK-capable via trigram. Its blast radius is tiny: it ONLY gates the `memory_recall` MCP tool
+  (the inject path is untouched) and the tool is fully fail-open, so on-by-default is safe. Configuring
+  `embedding_model` additionally lights up the vector leg → full cross-lingual hybrid. Set `enabled:false`
+  to force the legacy substring-LIKE behaviour.
 - No exposed RRF `k`, no per-signal weights, no tokenizer knob — code constants (no lying knobs).
 - `.strict()` ⇒ a typo'd key refuses startup; add the unknown-key tests per `memory-schema.test.ts`.
 

--- a/packages/shared/src/config/memory-schema.test.ts
+++ b/packages/shared/src/config/memory-schema.test.ts
@@ -31,8 +31,8 @@ describe("ForgettingSchema", () => {
     expect(f.sweep.max_iterations).toBe(200);
     expect(f.sweep.max_wallclock_s).toBe(900);
     expect(f.sweep.max_consecutive_errors).toBe(5);
-    // docs/14 / P8 — hybrid fact retrieval gate: off by default, top_k prior 10.
-    expect(f.facts_retrieval.enabled).toBe(false);
+    // docs/14 / P8 — hybrid fact retrieval gate: ON by default (FTS+score), top_k prior 10.
+    expect(f.facts_retrieval.enabled).toBe(true);
     expect(f.facts_retrieval.top_k).toBe(10);
   });
 

--- a/packages/shared/src/config/memory-schema.ts
+++ b/packages/shared/src/config/memory-schema.ts
@@ -118,16 +118,17 @@ export const ForgettingSchema = z
       })
       .strict()
       .prefault({}),
-    // docs/14 / P8 — hybrid fact retrieval (the `memory_recall` engine). enabled:false
-    // ⇒ memory_recall degrades to substring LIKE (today's behaviour). enabled:true runs
-    // query-driven recall over memory_facts fusing FTS5(trigram)+forgetting-score via
-    // RRF; the VECTOR leg additionally lights up only when memory.llm.embedding_model is
-    // set — so this flag alone is a usable, cross-lingual-blind on-ramp. top_k caps the
-    // fused result set. The RRF k and per-signal weights are code constants (no lying
-    // knobs); the only operational levers are the gate and the result cap.
+    // docs/14 / P8 — hybrid fact retrieval (the `memory_recall` engine). DEFAULT ON:
+    // memory_recall runs query-driven recall over memory_facts fusing FTS5(trigram) +
+    // forgetting-score via RRF — keyword + recency, CJK-capable, NO embedding required.
+    // The VECTOR leg additionally lights up only when memory.llm.embedding_model is set
+    // (cross-lingual). Blast radius is tiny: this flag ONLY affects the memory_recall
+    // MCP tool (the inject path is untouched), and the tool is fully fail-open — set
+    // enabled:false to force the legacy substring-LIKE behaviour. top_k caps the fused
+    // result set. RRF k + per-signal weights are code constants (no lying knobs).
     facts_retrieval: z
       .object({
-        enabled: z.boolean().default(false),
+        enabled: z.boolean().default(true),
         top_k: z.number().int().positive().default(10),
       })
       .strict()


### PR DESCRIPTION
## What

Flip `memory.forgetting.facts_retrieval.enabled` default **false → true**, so `memory_recall` does FTS5(trigram)+forgetting-score **hybrid recall out of the box** — keyword + recency, CJK-capable, **no embedding required**. The cross-lingual **vector leg** still lights up only when `memory.llm.embedding_model` is set.

## Why it's safe as a default

- `facts_retrieval` gates **only** the `memory_recall` MCP tool — the inject path is untouched, and `memory_recall` only exists when `memory.mcp.enabled`. So for the common deployment (MCP off) this is a **no-op**.
- The tool is **fully fail-open**: a missing FTS table / absent `searchFacts` / any search error → degrades to substring `LIKE`. So even a store that hasn't migrated can't break.
- `enabled: false` still forces the legacy LIKE behaviour.

## Changes

- schema default `false → true` (+ comment); the default-asserting test now expects `true`
- `config/memory.yaml` ships a documented `facts_retrieval` block
- docs/12 P8 + docs/14 updated to "default on"

## Validation

- memory-schema (27) + config samples (12) + mcp (17) tests green
- `typecheck -r` green; lint exit 0 (only the pre-existing `oauth.ts:312` warning)

> la.atmy.work already has `facts_retrieval.enabled:true` set explicitly, so its behaviour is unchanged; this makes it the default for new/other deployments. No version bump here — a separate `chore(release)` cuts the next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)