### PR TITLE
fix(config): correct mis-set context windows + pricing (3-source audit)

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -53,26 +53,35 @@
 # (packages/core/src/provider/oauth/models.ts — the ChatGPT-account Codex backend
 # 400s on legacy `*-codex`/`*-pro` slugs, verified live), so every exposed alias
 # an operator can pick has a capability + pricing entry here.
+#
+# CONTEXT WINDOW = 272000 for ALL THREE. The ChatGPT/Codex SUBSCRIPTION caps the
+# effective window at 272K regardless of the underlying model's API window (the
+# API `gpt-5.5` is 1.05M — see zenmux/gpt-5.5 below — but the subscription is NOT).
+# Empirically the codex backend 400s `context_length_exceeded` above ~272K: on
+# la.atmy.work the max input it ever served was 271,529 over 5,919 calls, and every
+# request ≳272K (e.g. a 597K Claude Code passthrough) was rejected. The wrong 1.05M
+# value let the capability filter route oversized requests here, burning a guaranteed
+# upstream 400 before failing over (the whole point of the context_too_small gate).
 openai-codex/gpt-5.5:
   supportsTools: true
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
-  maxContextTokens: 1050000
+  maxContextTokens: 272000
   maxOutputTokens: 128000
 openai-codex/gpt-5.4:
   supportsTools: true
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
-  maxContextTokens: 400000
+  maxContextTokens: 272000
   maxOutputTokens: 128000
 openai-codex/gpt-5.4-mini:
   supportsTools: true
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
-  maxContextTokens: 400000
+  maxContextTokens: 272000
   maxOutputTokens: 65536
 # Official DeepSeek API: json_object YES, json_schema NO (response_format json_schema
 # 400s "This response_format type is unavailable now"). Hence `object`, not `schema` —
@@ -109,7 +118,7 @@ openrouter/deepseek-v4-flash:
   supportsVision: false
   supportsStreaming: true
   maxContextTokens: 1048576
-  maxOutputTokens: 131072
+  maxOutputTokens: 65536 # OpenRouter /v1/models: deepseek-v4-flash max_completion_tokens=65536
 # Claude capabilities now live under the native `zenmux-anthropic/claude-*` aliases
 # below (issue #217); the OpenAI-compat `zenmux/claude-*` entries were removed.
 zenmux/gpt-5.5:
@@ -169,13 +178,17 @@ zenmux-anthropic/claude-sonnet-4.6:
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000
+# Haiku is a 200K-window model — the 1M context beta is Opus/Sonnet ONLY (confirmed
+# by ZenMux /v1/models: claude-haiku-4.5 ctx=200000). Mirrors native anthropic/claude-haiku
+# below. A 1M value here would let the context_too_small gate route >200K requests in and
+# burn a guaranteed upstream 400 (same class as the openai-codex window bug above).
 zenmux-anthropic/claude-haiku-4.5:
   supportsTools: true
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
   modalities: [document]
-  maxContextTokens: 1000000
+  maxContextTokens: 200000
   maxOutputTokens: 128000
 # `anthropic/*` are the NATIVE Claude Pro/Max SUBSCRIPTION models (synthesized at
 # runtime when the Anthropic OAuth pool is connected — alias prefix == the OAuth

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -39,8 +39,8 @@ openrouter/deepseek-v4-pro:
   inputPerMTokUsd: 0.435
   outputPerMTokUsd: 0.87
 openrouter/deepseek-v4-flash:
-  inputPerMTokUsd: 0.0983
-  outputPerMTokUsd: 0.1966
+  inputPerMTokUsd: 0.09 # OpenRouter /v1/models 2026-06-23
+  outputPerMTokUsd: 0.18
 # Claude pricing now lives under the native `zenmux-anthropic/claude-*` aliases
 # (issue #217); the OpenAI-compat `zenmux/claude-*` entries were removed.
 zenmux/gpt-5.5:
@@ -54,8 +54,8 @@ zenmux-vertex/gemini-3.5-flash:
   inputPerMTokUsd: 1.5
   outputPerMTokUsd: 9.0
 zenmux-vertex/gemini-3.1-flash-lite:
-  inputPerMTokUsd: 1.5
-  outputPerMTokUsd: 9.0
+  inputPerMTokUsd: 0.25 # ZenMux /v1/models pricings: flash-lite is ~6x cheaper than flash, NOT equal
+  outputPerMTokUsd: 1.5
 zenmux-vertex/gemini-3.1-pro:
   inputPerMTokUsd: 2.0
   outputPerMTokUsd: 12.0


### PR DESCRIPTION
## What

Audited **all 20 catalog models** against three sources — ZenMux `/v1/models`, OpenRouter `/v1/models`, and live box telemetry (max input/output actually served per model) — after a 597K Claude Code request kept burning a guaranteed upstream 400 on `openai-codex/gpt-5.5` during fail-over.

The `context_too_small` capability gate logic is correct; it was being fed **wrong window data**, so oversized requests fell INTO models that physically can't hold them instead of being skipped.

## Context windows (routing-critical — drives the capability filter)

| alias | before | after | source |
|---|---|---|---|
| `openai-codex/gpt-5.5` / `5.4` / `5.4-mini` | 1.05M / 400K | **272000** | Codex SUBSCRIPTION caps at 272K (API gpt-5.5 is genuinely 1.05M; `zenmux/gpt-5.5` unchanged). Box: max served 271,529 / 5,919 calls, 400s above. |
| `zenmux-anthropic/claude-haiku-4.5` | 1M | **200000** | ZenMux `/v1/models`; Haiku has no 1M beta (Opus/Sonnet only) |

## Pricing (USD/MTok — cost-telemetry only, never routes)

| alias | before | after | source |
|---|---|---|---|
| `zenmux-vertex/gemini-3.1-flash-lite` | 1.5 / 9.0 | **0.25 / 1.5** | ZenMux pricings (was ~6x over; flash-lite ≠ flash) |
| `openrouter/deepseek-v4-flash` | 0.0983 / 0.1966 | **0.09 / 0.18** | current OpenRouter |

## Verified correct (no change)

Native opus served **994,997** tokens → 1M real; zenmux-anthropic opus/sonnet 1M; gemini 1.05M; deepseek-v4 1.05M (OR-flash served 489K). Pricing exact vs ZenMux: gpt-5.5 5/30, claude opus 5/25 + cache 0.5/6.25, sonnet 3/15, haiku 1/5, gemini-3.5-flash 1.5/9, gemini-3.1-pro 2/12, deepseek-pro 0.435/0.87.

`caps.maxOutputTokens` confirmed metadata-only (unused in routing/clamping).

## Tests

`packages/core/src/config` + `src/capability` green (75 passed). Already applied + live on la.atmy.work (validated, backed up).

## Known gap (not in this PR)

`zenmux-anthropic/*` and `zenmux-vertex/*` pricing rows lack `cacheRead`/`cacheWrite`, so cached tokens on those fallback paths bill at full input rate. Native `anthropic/*` have them. Add for parity if fallback dashboard cost accuracy matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)