### PR TITLE
chore(release): v0.21.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.19",
+  "version": "0.21.20",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Ships two changes that landed on main since v0.21.19:

- **#364** `fix(config)` — corrected mis-set context windows + pricing after a 3-source audit (ZenMux/OpenRouter `/v1/models` + box telemetry). `openai-codex/*` → 272K, `zenmux-anthropic/claude-haiku-4.5` → 200K, `gemini-3.1-flash-lite` price → 0.25/1.5. Stops oversized Claude Code requests from burning guaranteed upstream 400s in the fail-over chain.
- **#363** `feat(memory)` — `facts_retrieval` now defaults ON (FTS5 + forgetting-score hybrid recall).

Merging this to main triggers `publish.yml` → image `:0.21.20` + tag `v0.21.20` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)