### PR TITLE
chore(release): v0.21.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.20",
+  "version": "0.21.21",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release the two PRs merged after the v0.21.20 tag (they only refreshed `:latest` until this bump):

- **#367** feat(cleanup): scheduled auto-VACUUM + fix orphan archive dirs — headline. Adds additive optional RuntimeSettings `vacuum_enabled` (default OFF) + `vacuum_hour` (0–23, default 4am server-local); opt-in DB compaction to reclaim free-page bloat that DELETE-only cleanup leaves behind. Orphan archive-dir fix on the local-volume sink.
- **#366** test: raise unit coverage to marginal-zero, drop dead `cache_control` branch, realign memory e2e.

**Patch** classification: no DB migration, no file-config (`loadConfig`) schema change — the only `packages/shared/src/config` diff is the additive optional RuntimeSettings pair (same precedent as `default_lane` in 0.21.x). Fail-close gate `git diff v0.21.20..main -- packages/shared/src/config packages/core/src/config config/ docker-compose* Dockerfile` shows only that additive pair → box config stays valid.

publish.yml auto-cuts tag `v0.21.21` + GitHub Release + GHCR `:0.21.21`/`:latest` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)