### PR TITLE
fix(gateway): surface upstream 4xx invalid_request instead of falling back

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -961,15 +961,27 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.attempts[1]?.status).toBe("ok");
   });
 
-  it("does not trip the breaker for Anthropic request-shape 400s", async () => {
+  it("short-circuits the chain on an upstream request-shape 400 and surfaces it verbatim", async () => {
+    // A 400 invalid_request_error (oversized image / prompt too long / bad param) is
+    // DETERMINISTIC: the identical body fails on every candidate, and Claude Code
+    // relies on receiving this 4xx to drive its own context compaction. So the chain
+    // must NOT advance to `codex`, the breaker must NOT fault, and the upstream error
+    // is returned to the client verbatim (not buried as all_providers_failed 502).
     const provider = {
       chatCompletion: vi
         .fn()
         .mockRejectedValueOnce(
           new UpstreamError(
             "upstream_error",
-            "prompt is too long: 1001854 tokens > 1000000 maximum",
-            { error: { message: "prompt is too long" } },
+            "upstream returned 400",
+            {
+              type: "error",
+              error: {
+                type: "invalid_request_error",
+                message:
+                  "messages.7.content.14.image.source.base64.data: At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels",
+              },
+            },
             400,
           ),
         )
@@ -1001,15 +1013,72 @@ describe("createExecute — gateway execution adapter", () => {
 
     const out = await execute(plan(["opus", "codex"]), req());
 
-    expect(out.final.status).toBe("ok");
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error.error_class).toBe("invalid_request");
+    expect(out.final.error.http_status).toBe(400);
+    expect(out.final.error.message).toContain("many-image requests");
+    expect(out.final.error.provider_raw).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+    // Only the head candidate was attempted — no fallback to codex.
+    expect(out.attempts).toHaveLength(1);
     expect(out.attempts[0]).toMatchObject({
       alias: "opus",
       skipped: false,
       status: "error",
       error_class: "invalid_request",
     });
-    expect(out.attempts[1]?.status).toBe("ok");
+    expect(provider.chatCompletion).toHaveBeenCalledOnce();
     expect(recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("still falls back and faults the breaker on a non-request upstream 5xx", async () => {
+    // Control: a 5xx is a provider-HEALTH failure (not a request-shape rejection),
+    // so the chain advances to the next candidate and the breaker records a fault.
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError(
+            "upstream_error",
+            "upstream returned 500",
+            { type: "error", error: { type: "api_error", message: "overloaded" } },
+            500,
+          ),
+        )
+        .mockResolvedValueOnce({ id: "second" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        opus: {
+          providerName: "mock",
+          providerModel: "claude-opus-4-8",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        codex: {
+          providerName: "mock",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "codex"]), req());
+
+    expect(out.final.status).toBe("ok");
+    expect(out.attempts).toHaveLength(2);
+    expect(out.attempts[1]?.status).toBe("ok");
+    expect(recordFailure).toHaveBeenCalledWith("opus");
   });
 
   it("captures error_detail for a non-UpstreamError failure (null status, null raw)", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -712,19 +712,51 @@ function rawErrorText(raw: unknown): string {
   }
 }
 
-function isAnthropicRequestShapeError(err: unknown): boolean {
-  if (!(err instanceof UpstreamError) || err.upstreamStatus !== 400) return false;
-  const text = `${err.message} ${rawErrorText(err.providerRaw)}`.toLowerCase();
-  return (
-    text.includes("prompt is too long") ||
-    text.includes("does not support effort level") ||
-    (text.includes("unsupported") && text.includes("effort")) ||
-    (text.includes("output_config") && text.includes("effort"))
-  );
+// Extract the upstream error discriminator. Anthropic nests it as
+// `{type:"error", error:{type, message}}`; OpenAI as `{error:{type, code, message}}`.
+// The wrapper `type:"error"` is ignored — we want the inner classification.
+function upstreamErrorType(raw: unknown): string | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const inner = (raw as { error?: unknown }).error;
+  if (inner !== null && typeof inner === "object") {
+    const t = (inner as { type?: unknown }).type;
+    if (typeof t === "string") return t;
+  }
+  const top = (raw as { type?: unknown }).type;
+  return typeof top === "string" && top !== "error" ? top : null;
 }
 
-function attemptErrorClassOf(err: unknown): string {
-  return isAnthropicRequestShapeError(err) ? "invalid_request" : errorClassOf(err);
+// Human-readable upstream error message (for surfacing to the client verbatim), if
+// the provider nested one under `error.message`.
+function upstreamErrorMessage(raw: unknown): string | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const inner = (raw as { error?: unknown }).error;
+  if (inner !== null && typeof inner === "object") {
+    const m = (inner as { message?: unknown }).message;
+    if (typeof m === "string" && m.length > 0) return m;
+  }
+  return null;
+}
+
+// A DETERMINISTIC request-shape rejection from the upstream: the request body is
+// itself invalid (oversized image, prompt too long, bad param). Re-sending the
+// IDENTICAL body to another candidate is futile — every provider rejects it — and
+// the client owns the fix. Claude Code in particular relies on receiving this 4xx
+// to trigger its own context compaction; burying it behind the fallback chain
+// (synthetic all_providers_failed 502) is exactly what stopped compaction from
+// firing through the gateway. So the executor short-circuits and surfaces it
+// verbatim (see the catch block below). 429 is intentionally NOT here: that is
+// genuine rate-limiting, legitimately retryable on another candidate.
+function isUpstreamRequestRejection(err: unknown): boolean {
+  if (!(err instanceof UpstreamError)) return false;
+  const status = err.upstreamStatus;
+  if (status !== 400 && status !== 413 && status !== 422) return false;
+  if (upstreamErrorType(err.providerRaw) === "invalid_request_error") return true;
+  // 413 is "payload too large" by definition; some providers omit a typed body, so
+  // also honor the unambiguous phrasings real upstreams use for shape errors.
+  if (status === 413) return true;
+  const text = `${err.message} ${rawErrorText(err.providerRaw)}`.toLowerCase();
+  return text.includes("prompt is too long") || text.includes("max allowed size");
 }
 
 // Coerce an already-scrubbed upstream error body into the schema's record|null
@@ -1215,27 +1247,60 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           continue;
         }
 
-        const requestShapeError = isAnthropicRequestShapeError(err);
-        if (!requestShapeError) {
-          // Genuine pre-first-chunk failure: record on the breaker, try next. This row
-          // carries the REAL passthrough telemetry: a failure during nativePassthrough
-          // (UpstreamError) lands HERE just like a chatCompletion failure — the trail
-          // shows the verbatim-forward was attempted on this candidate before it failed.
-          breaker.recordFailure(alias);
-          // Auto-park a subscription account that hit its rate/usage limit. A genuine
-          // (non-`:free`, handled above) 429 on an OAuth alias means the served account
-          // is throttled — signal the gateway to park it so the pool routes around it.
-          // Pure side-channel: the breaker failure + chain advance below are unchanged.
-          if (upstreamStatusOf(err) === 429 && isOAuthSubscriptionAlias(alias)) {
-            onOAuthSubscription429?.(alias);
-          }
+        // Deterministic request-shape rejection (oversized image, prompt too long,
+        // bad param): the body is invalid for EVERY candidate, so do NOT advance the
+        // chain and do NOT fault the breaker (the upstream is healthy — the request is
+        // what's wrong). Surface the upstream's structured error VERBATIM as a 400
+        // invalid_request: Claude Code needs this 4xx to drive its own context
+        // compaction, and burying it behind a fallback (all_providers_failed 502) is
+        // what prevented compaction from firing through the gateway.
+        if (isUpstreamRequestRejection(err)) {
+          const detail = errorDetailOf(err);
+          attempts.push({
+            alias,
+            skipped: false,
+            skip_reason: null,
+            status: "error",
+            error_class: "invalid_request",
+            latency_ms: elapsed(),
+            cost_usd: null,
+            error_detail: detail,
+            ...attemptTelemetry,
+          });
+          return {
+            attempts,
+            final: {
+              status: "error",
+              error: makeHelmError({
+                error_class: "invalid_request",
+                message: upstreamErrorMessage(detail.provider_raw) ?? detail.message,
+                trace_id: req.request_id,
+                provider_raw: detail.provider_raw,
+              }),
+            },
+            body: null,
+            stream: null,
+          };
+        }
+
+        // Genuine pre-first-chunk failure: record on the breaker, try next. This row
+        // carries the REAL passthrough telemetry: a failure during nativePassthrough
+        // (UpstreamError) lands HERE just like a chatCompletion failure — the trail
+        // shows the verbatim-forward was attempted on this candidate before it failed.
+        breaker.recordFailure(alias);
+        // Auto-park a subscription account that hit its rate/usage limit. A genuine
+        // (non-`:free`, handled above) 429 on an OAuth alias means the served account
+        // is throttled — signal the gateway to park it so the pool routes around it.
+        // Pure side-channel: the breaker failure + chain advance below are unchanged.
+        if (upstreamStatusOf(err) === 429 && isOAuthSubscriptionAlias(alias)) {
+          onOAuthSubscription429?.(alias);
         }
         attempts.push({
           alias,
           skipped: false,
           skip_reason: null,
           status: "error",
-          error_class: attemptErrorClassOf(err),
+          error_class: errorClassOf(err),
           latency_ms: elapsed(),
           cost_usd: null,
           error_detail: errorDetailOf(err),


### PR DESCRIPTION
## Problem

Claude Code's server-side **context compaction** works against the first-party Anthropic API but **errors through the gateway**.

Traced to a real request on `la.atmy.work` (`d44c78e3`): a 366-message turn carried 22 images, one of them a **2304×1316** MCP screenshot (a Playwright/agent-browser tool result, which bypasses Claude Code's own ≤2000px resize). Anthropic's ">20 images ⇒ each ≤2000px" rule rejects it:

```
400 invalid_request_error
messages.7.content.14.image.source.base64.data: At least one of the image
dimensions exceed max allowed size for many-image requests: 2000 pixels
```

The gateway then classified this deterministic 400 as a generic provider failure: it **faulted the circuit breaker** on `anthropic`, **advanced the fallback chain** to `openai-codex/gpt-5.5` (which also failed on the same body), exhausted the chain, and returned a synthetic **`all_providers_failed` (502)** — dropping the upstream's structured error.

The identical body fails on *every* candidate, so the fallback is futile. Worse, it strips the very `4xx` that Claude Code relies on to **trigger its own compaction**. Telemetry showed 12 such failures clustered 09:10–09:31; the same session compacted successfully at 09:59 once it was pointed back at the first-party API.

(The `anthropic-beta` header — incl. `context-management-2025-06-27` — is correctly merged/forwarded, so betas were never the cause.)

## Fix

Treat an upstream **4xx (400/413/422) `invalid_request_error`** as terminal:

- **short-circuit** the chain (no fallback),
- return the upstream error **verbatim** as a `400 invalid_request` (message + `provider_raw` preserved),
- **do not** fault the breaker — the upstream is healthy; the request is what's invalid.

`5xx` / timeouts / `429` still fall back as genuine provider-health failures. Detection is by the upstream `error.type`, replacing the previous fragile substring allowlist (`isAnthropicRequestShapeError`) that only caught "prompt too long" / effort and missed everything else.

## Behavior change

A `prompt is too long` 400 now **short-circuits to the client** instead of falling back to a larger-context candidate. For native passthrough (Claude Code) this is the correct behavior — the client compacts on the 4xx.

## Tests

- `execute.test.ts`: replaced the old "falls back on prompt-too-long" case with a **short-circuit** test (real image-400 body) asserting `error_class: invalid_request` / HTTP 400 / verbatim `provider_raw` / single attempt / no breaker fault; added a **5xx control** proving health failures still fall back + fault the breaker.
- `execute.test.ts` 98/98, gateway routes 164/164, `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)