### PR TITLE
v0.21.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.21",
+  "version": "0.21.22",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release the two PRs merged after the v0.21.21 tag (they only refreshed `:latest` until this bump):

- #370 fix(gateway): surface upstream 4xx invalid_request instead of falling back
- #369 docs: admin UI screenshots + request-trail debug features

Once merged, `publish.yml` cuts tag `v0.21.22` + GitHub Release and pushes `ghcr.io/easymetaau/helm-api:0.21.22` + `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)