### PR TITLE
test(e2e): de-flake admin request-list filter (settle nav between reset + re-filter)

### DIFF
--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -23,6 +23,13 @@ const SEED_MODEL_FILTER = "best_reasoning_model";
 async function filterToSeededRequest(page: Page) {
   await page.getByTestId("filter-model").fill(SEED_MODEL_FILTER);
   await page.getByTestId("filter-model").press("Enter");
+  // The model filter applies via a client navigation (?model=…) + loader refetch.
+  // Wait for it to commit so callers assert against the *filtered* list, never one
+  // still settling from a previous filter/reset — that overlap was the flake: a
+  // reset's goto('?') and this goto('?model=…') raced, and whichever loader landed
+  // last won (the `$effect` then re-synced the input from its data), so the filter
+  // silently didn't stick and the seeded row never appeared.
+  await expect(page).toHaveURL(/[?&]model=best_reasoning_model\b/);
   return page
     .getByTestId("request-row")
     .filter({ has: page.locator(`a[href$="/requests/${SEED_TRACE_ID}"]`) });
@@ -144,8 +151,11 @@ test.describe("admin request list filtering + pagination", () => {
     await expect(seededRow).toHaveCount(0);
 
     // Reset clears every filter; re-apply the seed filter so the assertion stays
-    // independent of request rows created by earlier e2e specs.
+    // independent of request rows created by earlier e2e specs. Wait for the reset
+    // navigation to land (status param gone) BEFORE re-filtering, so the two gotos
+    // never overlap.
     await page.getByTestId("filter-reset").click();
+    await expect(page).not.toHaveURL(/status=error/);
     await filterToSeededRequest(page);
     await expect(seededRow).toBeVisible();
 
@@ -153,6 +163,7 @@ test.describe("admin request list filtering + pagination", () => {
     await page.getByTestId("filter-decided-by").selectOption("eval");
     await expect(page.getByTestId("requests-empty")).toBeVisible();
     await page.getByTestId("filter-reset").click();
+    await expect(page).not.toHaveURL(/decided_by=eval/); // reset navigation committed
     await filterToSeededRequest(page);
     await expect(seededRow).toBeVisible();
 

--- a/apps/gateway/playwright.config.ts
+++ b/apps/gateway/playwright.config.ts
@@ -47,6 +47,11 @@ export default defineConfig({
   testDir: "./e2e",
   fullyParallel: false,
   workers: 1,
+  // Default expect timeout (5s) is tight for a real gateway (SQLite + SSR) driven by
+  // a real browser: the admin request-list filter occasionally re-renders in >5s,
+  // flaking `seededRow.toBeVisible()`. 10s covers the slow tail; the happy path is
+  // unaffected (assertions resolve the moment they pass).
+  expect: { timeout: 10_000 },
   use: {
     baseURL: `http://127.0.0.1:${GATEWAY_PORT}`,
   },


### PR DESCRIPTION
## What

Fix the intermittently-failing admin e2e `filters narrow the list and the pager reflects the filtered total`.

## Root cause — a navigation race, **not** a slow render

It still failed after I first bumped the expect timeout to 10s (`element(s) not found`, waited the full 10s). The real cause:

- The requests page applies filters via a client `goto()` + loader refetch; `reset()` clears the model then `goto('?')`.
- The spec clicked `filter-reset` and **immediately** re-applied the model filter → two overlapping `goto`s. Whichever loader landed last won, and the page's `$effect` re-synced the model input from that data — so the filter silently didn't stick and the seeded row never appeared.
- `workers: 1` (serial), and the failure point drifted across runs (line 150 vs 157) → a timing race, confirmed not a regression from #370/#369.

## Fix — let each navigation commit before the next

- `filterToSeededRequest` waits for `?model=…` in the URL after Enter.
- After each `filter-reset`, wait for the prior filter param to clear before re-filtering, so the reset + filter gotos never overlap.
- Raise the global expect timeout 5s → 10s as a backstop for the slow loader tail on CI (real gateway SQLite + SSR).

## Verification

Local `--repeat-each` runs are deterministic: the test 6/6 and the full admin project 18/18 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)