### PR TITLE
feat(admin): redesign date-range picker to calendar-day presets

### DIFF
--- a/apps/admin/src/lib/components/RangeFilter.svelte
+++ b/apps/admin/src/lib/components/RangeFilter.svelte
@@ -16,11 +16,12 @@
     label?: string;
   } = $props();
 
-  // The numeric labels are language-neutral literals; only "All" is translated.
+  // Calendar-day presets: aggregate by natural day, not a rolling now−N window.
+  // The numeric spans (7d/30d) stay language-neutral literals; the word labels
+  // (Today/Yesterday/All) are translated via their English key.
   const OPTIONS: { key: RangeKey; label: string }[] = [
-    { key: '1h', label: '1h' },
-    { key: '6h', label: '6h' },
-    { key: '24h', label: '24h' },
+    { key: 'today', label: 'Today' },
+    { key: 'yesterday', label: 'Yesterday' },
     { key: '7d', label: '7d' },
     { key: '30d', label: '30d' },
     { key: 'all', label: 'All' },
@@ -36,7 +37,7 @@
       aria-pressed={value === opt.key}
       onclick={() => onChange(opt.key)}
     >
-      {opt.key === 'all' ? $t('All') : opt.label}
+      {opt.key === '7d' || opt.key === '30d' ? opt.label : $t(opt.label)}
     </button>
   {/each}
 </div>

--- a/apps/admin/src/lib/components/RangeFilter.test.ts
+++ b/apps/admin/src/lib/components/RangeFilter.test.ts
@@ -2,29 +2,30 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import RangeFilter from './RangeFilter.svelte';
 
-// Presentational + stateless: it renders the preset row, marks the active one, and
-// reports clicks via onChange. i18n is untouched (the `t` store returns the English
-// key when no dict is loaded, so 'All' renders as "All").
+// Presentational + stateless: it renders the calendar-day preset row, marks the
+// active one, and reports clicks via onChange. i18n is untouched (the `t` store
+// returns the English key when no dict is loaded, so 'Today'/'All' render as-is).
 
 describe('RangeFilter', () => {
-  it('renders all six presets in order', () => {
-    render(RangeFilter, { props: { value: '24h', onChange: vi.fn() } });
-    for (const key of ['1h', '6h', '24h', '7d', '30d', 'all']) {
+  it('renders the calendar-day presets in order', () => {
+    render(RangeFilter, { props: { value: 'today', onChange: vi.fn() } });
+    for (const key of ['today', 'yesterday', '7d', '30d', 'all']) {
       expect(screen.getByTestId(`range-${key}`)).toBeInTheDocument();
     }
+    expect(screen.getByTestId('range-today')).toHaveTextContent('Today');
     expect(screen.getByTestId('range-all')).toHaveTextContent('All');
   });
 
   it('marks only the active preset as pressed', () => {
     render(RangeFilter, { props: { value: '7d', onChange: vi.fn() } });
     expect(screen.getByTestId('range-7d').getAttribute('aria-pressed')).toBe('true');
-    expect(screen.getByTestId('range-24h').getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByTestId('range-today').getAttribute('aria-pressed')).toBe('false');
   });
 
   it('calls onChange with the clicked preset key', async () => {
     const onChange = vi.fn();
     render(RangeFilter, { props: { value: 'all', onChange } });
-    await fireEvent.click(screen.getByTestId('range-6h'));
-    expect(onChange).toHaveBeenCalledExactlyOnceWith('6h');
+    await fireEvent.click(screen.getByTestId('range-yesterday'));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('yesterday');
   });
 });

--- a/apps/admin/src/lib/dashboard-chart.test.ts
+++ b/apps/admin/src/lib/dashboard-chart.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   formatTrendTick,
+  pctDelta,
   resolveStatsWindow,
+  resolveTodayComparisonWindow,
   trendAxisTicks,
   trendBucketForRange,
 } from './dashboard-chart.js';
@@ -54,6 +56,27 @@ describe('dashboard chart helpers', () => {
     expect(trendBucketForRange('6h')).toBe('hour');
     expect(trendBucketForRange('24h')).toBe('hour');
     expect(trendBucketForRange('today')).toBe('hour');
+    expect(trendBucketForRange('yesterday')).toBe('hour');
     expect(trendAxisTicks([point(0), point(HOUR)]).map((d) => d.getTime())).toEqual([0, HOUR]);
+  });
+});
+
+describe('today vs yesterday comparison', () => {
+  it('baselines against yesterday up to the same elapsed time (not the full day)', () => {
+    const now = new Date('2026-06-01T15:30:00').getTime();
+    const yMidnight = new Date('2026-05-31T00:00:00').getTime();
+    // Today is 15h30m old; the baseline window is yesterday over the same span.
+    const elapsed = now - new Date('2026-06-01T00:00:00').getTime();
+    expect(resolveTodayComparisonWindow(now)).toEqual({
+      start: yMidnight,
+      end: yMidnight + elapsed,
+    });
+  });
+
+  it('pctDelta rounds the percentage change; null when there is no baseline', () => {
+    expect(pctDelta(120, 100)).toBe(20);
+    expect(pctDelta(80, 100)).toBe(-20);
+    expect(pctDelta(5, 0)).toBeNull(); // no traffic yesterday → no honest delta
+    expect(pctDelta(0, 0)).toBeNull();
   });
 });

--- a/apps/admin/src/lib/dashboard-chart.ts
+++ b/apps/admin/src/lib/dashboard-chart.ts
@@ -13,11 +13,37 @@ export function resolveStatsWindow(
 }
 
 // Short windows want hourly shape; longer/all-time windows should be summarized by
-// day so the x-axis answers "which date did this aggregate come from?"
+// day so the x-axis answers "which date did this aggregate come from?" A single
+// calendar day (today/yesterday) reads best hour-bucketed.
 export function trendBucketForRange(range: RangeKey): TrendBucket {
-  return range === '1h' || range === '6h' || range === '24h' || range === 'today'
+  return range === '1h' ||
+    range === '6h' ||
+    range === '24h' ||
+    range === 'today' ||
+    range === 'yesterday'
     ? 'hour'
     : 'day';
+}
+
+// Same-time-yesterday baseline for the "today" delta: yesterday from local
+// midnight up to the SAME elapsed offset as today-so-far. Comparing a partial day
+// against a full one would always read as a drop, so we cut yesterday at the same
+// point in the day. DST: yesterday midnight via setDate; the elapsed offset is
+// added as flat ms (a DST jump shifts the cutoff by ≤1h — fine for a glance).
+export function resolveTodayComparisonWindow(nowMs: number): { start: number; end: number } {
+  const d = new Date(nowMs);
+  d.setHours(0, 0, 0, 0);
+  const elapsed = nowMs - d.getTime();
+  d.setDate(d.getDate() - 1);
+  const start = d.getTime();
+  return { start, end: start + elapsed };
+}
+
+// Percentage change current-vs-baseline, rounded. null when there is no baseline
+// (yesterday had zero) — an honest "no comparison" instead of a fake +∞/+100%.
+export function pctDelta(current: number, baseline: number): number | null {
+  if (!(baseline > 0)) return null;
+  return Math.round(((current - baseline) / baseline) * 100);
 }
 
 export function trendAxisTicks<T extends TrendPointLike>(

--- a/apps/admin/src/lib/i18n/dashboard-locales.test.ts
+++ b/apps/admin/src/lib/i18n/dashboard-locales.test.ts
@@ -22,6 +22,10 @@ const dashboardTokenKeys = [
   'Cache write tokens',
   'cached',
   'input {input} · output {output} · cached {cached} · non-cached {nonCached}',
+  // Calendar-day range picker + the "vs yesterday" card delta: every locale must
+  // translate these instead of falling back to the English source.
+  'Yesterday',
+  'vs yesterday',
 ] as const;
 
 const translatedLocales = {

--- a/apps/admin/src/lib/key-detail-filters.test.ts
+++ b/apps/admin/src/lib/key-detail-filters.test.ts
@@ -11,7 +11,7 @@ import {
 const sp = (q: string) => new URLSearchParams(q);
 
 describe('key-detail-filters', () => {
-  it('defaults to the 24h preset, page 1, no custom dates', () => {
+  it('defaults to the today preset, page 1, no custom dates', () => {
     const f = parseKeyDetailFilters(sp(''));
     expect(f.range).toBe(KEY_DETAIL_DEFAULT_RANGE);
     expect(f.page).toBe(1);
@@ -34,12 +34,14 @@ describe('key-detail-filters', () => {
   });
 
   it('treats an inverted / half-filled custom range as not-custom', () => {
-    expect(hasCustomRange(parseKeyDetailFilters(sp('start=2026-06-10&end=2026-06-01')))).toBe(false);
+    expect(hasCustomRange(parseKeyDetailFilters(sp('start=2026-06-10&end=2026-06-01')))).toBe(
+      false,
+    );
     expect(hasCustomRange(parseKeyDetailFilters(sp('start=2026-06-01')))).toBe(false);
   });
 
   it('serializes clean URLs: custom dates win over the preset; defaults omitted', () => {
-    expect(keyDetailFiltersToSearch({ range: '24h', page: 1 })).toBe('');
+    expect(keyDetailFiltersToSearch({ range: 'today', page: 1 })).toBe('');
     expect(keyDetailFiltersToSearch({ range: '7d', page: 2 })).toBe('range=7d&page=2');
     // Custom range present → preset dropped, dates serialized.
     expect(
@@ -70,6 +72,13 @@ describe('key-detail-filters', () => {
       end: now,
     });
     expect(resolveKeyDetailWindow({ range: 'all', page: 1 }, now)).toEqual({ start: 0, end: now });
+  });
+
+  it('honors a closed preset end so yesterday does not bleed into today', () => {
+    const now = new Date('2026-06-01T15:30:00').getTime();
+    const start = new Date('2026-05-31T00:00:00').getTime();
+    const end = new Date('2026-06-01T00:00:00').getTime();
+    expect(resolveKeyDetailWindow({ range: 'yesterday', page: 1 }, now)).toEqual({ start, end });
   });
 
   it('buckets short windows hourly, long windows daily', () => {

--- a/apps/admin/src/lib/key-detail-filters.ts
+++ b/apps/admin/src/lib/key-detail-filters.ts
@@ -9,7 +9,7 @@
 
 import { RANGE_KEYS, type RangeKey, resolveWindow } from './requests-filters.js';
 
-export const KEY_DETAIL_DEFAULT_RANGE: RangeKey = '24h';
+export const KEY_DETAIL_DEFAULT_RANGE: RangeKey = 'today';
 
 const DAY_MS = 86_400_000;
 // A 2-day window or shorter reads better hour-bucketed; longer → day buckets.
@@ -101,7 +101,9 @@ export function resolveKeyDetailWindow(
   }
   if (f.range === 'all') return { start: 0, end: nowMs };
   const w = resolveWindow(f.range, nowMs);
-  return { start: w.start ?? 0, end: nowMs };
+  // Honor a CLOSED preset end (yesterday) so it doesn't bleed into today; the
+  // rolling/today presets leave end open → now.
+  return { start: w.start ?? 0, end: w.end ?? nowMs };
 }
 
 // Trend bucket granularity for a resolved window: hourly for short spans, daily

--- a/apps/admin/src/lib/requests-filters.test.ts
+++ b/apps/admin/src/lib/requests-filters.test.ts
@@ -34,8 +34,8 @@ describe('parseFilters', () => {
     expect(parseFilters(new URLSearchParams('page=-4')).page).toBe(1);
   });
 
-  it('defaults the range to 24h (not all) for a clean URL', () => {
-    expect(parseFilters(new URLSearchParams()).range).toBe('24h');
+  it('defaults the range to today (not all) for a clean URL', () => {
+    expect(parseFilters(new URLSearchParams()).range).toBe('today');
     // 'all' is only reached when asked for explicitly.
     expect(parseFilters(new URLSearchParams('range=all')).range).toBe('all');
   });
@@ -54,15 +54,16 @@ describe('parseFilters', () => {
 describe('filtersToSearch', () => {
   it('omits defaults so clean URLs stay clean', () => {
     expect(filtersToSearch(DEFAULT_FILTERS)).toBe('');
-    expect(filtersToSearch({ range: '24h', page: 1, pageSize: 50, lane: '   ' })).toBe('');
+    expect(filtersToSearch({ range: 'today', page: 1, pageSize: 50, lane: '   ' })).toBe('');
   });
 
-  it('writes range=all explicitly since 24h is now the default', () => {
+  it('writes a non-default range explicitly since today is now the default', () => {
     expect(filtersToSearch({ range: 'all', page: 1, pageSize: 50 })).toBe('range=all');
+    expect(filtersToSearch({ range: 'yesterday', page: 1, pageSize: 50 })).toBe('range=yesterday');
   });
 
   it('writes a non-default page size', () => {
-    expect(filtersToSearch({ range: '24h', page: 1, pageSize: 100 })).toBe('pageSize=100');
+    expect(filtersToSearch({ range: 'today', page: 1, pageSize: 100 })).toBe('pageSize=100');
   });
 
   it('round-trips through parseFilters', () => {
@@ -89,6 +90,12 @@ describe('resolveWindow', () => {
   it('today → since local midnight, open end', () => {
     const midnight = new Date('2026-06-01T00:00:00').getTime();
     expect(resolveWindow('today', now)).toEqual({ start: midnight });
+  });
+
+  it('yesterday → the full previous local day, closed end', () => {
+    const start = new Date('2026-05-31T00:00:00').getTime();
+    const end = new Date('2026-06-01T00:00:00').getTime();
+    expect(resolveWindow('yesterday', now)).toEqual({ start, end });
   });
 
   it('rolling windows are now − N days', () => {

--- a/apps/admin/src/lib/requests-filters.ts
+++ b/apps/admin/src/lib/requests-filters.ts
@@ -6,9 +6,11 @@
 
 import type { RequestListItem } from '$lib/api/requests.js';
 
-// Date-range presets exposed in the UI. The window is resolved to absolute epoch
-// ms in the loader (client-local time) so the gateway stays timezone-agnostic.
-export const RANGE_KEYS = ['all', 'today', '1h', '6h', '24h', '7d', '30d'] as const;
+// Date-range presets. The window is resolved to absolute epoch ms in the loader
+// (client-local time) so the gateway stays timezone-agnostic. The UI offers only
+// the calendar-day presets (today/yesterday/7d/30d/all — see RangeFilter.svelte);
+// the rolling 1h/6h/24h keys are retained so old bookmarks still resolve.
+export const RANGE_KEYS = ['all', 'today', 'yesterday', '7d', '30d', '1h', '6h', '24h'] as const;
 export type RangeKey = (typeof RANGE_KEYS)[number];
 
 // Rows-per-page choices offered by the list pager. The backend clamps to [1, 200]
@@ -26,10 +28,10 @@ export interface RequestsFilters {
   pageSize: number;
 }
 
-// The list defaults to the last 24 hours (a live ops view cares about recent
-// traffic) — NOT 'all'. So '24h' is the "clean URL" range (omitted from the query),
-// and 'all' must be requested explicitly (?range=all).
-export const DEFAULT_RANGE: RangeKey = '24h';
+// The list defaults to TODAY (since local midnight) — the calendar-day view the
+// dashboard is built around, NOT 'all'. So 'today' is the "clean URL" range
+// (omitted from the query), and anything else (incl. 'all') is written explicitly.
+export const DEFAULT_RANGE: RangeKey = 'today';
 
 export const DEFAULT_FILTERS: RequestsFilters = {
   range: DEFAULT_RANGE,
@@ -110,6 +112,16 @@ export function resolveWindow(range: RangeKey, nowMs: number): { start?: number;
       const d = new Date(nowMs);
       d.setHours(0, 0, 0, 0);
       return { start: d.getTime() };
+    }
+    case 'yesterday': {
+      // The full previous local day: [yesterday midnight, today midnight). The
+      // only preset with a CLOSED end — it must not bleed into today. setDate
+      // steps the day (DST-correct), not a flat −DAY_MS.
+      const d = new Date(nowMs);
+      d.setHours(0, 0, 0, 0);
+      const end = d.getTime();
+      d.setDate(d.getDate() - 1);
+      return { start: d.getTime(), end };
     }
     case '1h':
       return { start: nowMs - HOUR_MS };

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -693,6 +693,8 @@
   "Timeout (ms)": "Timeout (ms)",
   "To": "To",
   "Today": "Today",
+  "Yesterday": "Yesterday",
+  "vs yesterday": "vs yesterday",
   "tok": "tok",
   "Token usage": "Token usage",
   "Token usage over time": "Token usage over time",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -693,6 +693,8 @@
   "Timeout (ms)": "タイムアウト（ミリ秒）",
   "To": "終了",
   "Today": "今日",
+  "Yesterday": "昨日",
+  "vs yesterday": "前日比",
   "tok": "トークン",
   "Token usage": "トークン使用量",
   "Token usage over time": "トークン使用量の推移",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -690,6 +690,8 @@
   "Timeout (ms)": "타임아웃 (ms)",
   "To": "종료",
   "Today": "오늘",
+  "Yesterday": "어제",
+  "vs yesterday": "어제 대비",
   "tok": "토큰",
   "Token usage": "토큰 사용량",
   "Token usage over time": "토큰 사용량 추이",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -693,6 +693,8 @@
   "Timeout (ms)": "超时（毫秒）",
   "To": "结束",
   "Today": "今天",
+  "Yesterday": "昨天",
+  "vs yesterday": "对比昨天",
   "tok": "词元",
   "Token usage": "Token 用量",
   "Token usage over time": "Token 用量趋势",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -690,6 +690,8 @@
   "Timeout (ms)": "逾時（毫秒）",
   "To": "結束",
   "Today": "今天",
+  "Yesterday": "昨天",
+  "vs yesterday": "對比昨天",
   "tok": "詞元",
   "Token usage": "權杖用量",
   "Token usage over time": "權杖用量趨勢",

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -34,6 +34,9 @@
       bucket: TrendBucket;
       stats: Stats;
       agg: DashboardStats;
+      // "vs yesterday" % deltas, keyed by card; null entry = no baseline. Whole
+      // object null unless the TODAY view is active (set by the loader).
+      compare: Record<string, number | null> | null;
     };
   } = $props();
 
@@ -101,10 +104,10 @@
   ];
 
   // The dashboard window lives in the URL (?range=…) so the loader re-fetches and
-  // the view is shareable / back-button friendly — '24h' is the default, written
+  // the view is shareable / back-button friendly — 'today' is the default, written
   // as a clean URL (no query) to match the loader's fallback. The button row is the
   // shared RangeFilter (same control as the request-list filter bar).
-  const HOME_DEFAULT_RANGE: RangeKey = '24h';
+  const HOME_DEFAULT_RANGE: RangeKey = 'today';
 
   function selectRange(next: RangeKey): void {
     const search = next === HOME_DEFAULT_RANGE ? '' : `range=${next}`;
@@ -201,11 +204,22 @@
     <RangeFilter value={data.range} onChange={selectRange} />
   </div>
 
+  <!-- "vs yesterday" delta, shown under a volume card on the TODAY view. null pct
+       (no baseline) or no comparison loaded → renders nothing. -->
+  {#snippet deltaBadge(pct: number | null)}
+    {#if pct !== null}
+      <div class="mt-0.5 text-xs text-slate-400">
+        {pct >= 0 ? '↑' : '↓'}{Math.abs(pct)}% {$t('vs yesterday')}
+      </div>
+    {/if}
+  {/snippet}
+
   <!-- Stat cards -->
   <div class="grid grid-cols-2 gap-3 lg:grid-cols-5 lg:gap-4">
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">{$t('Requests')}</div>
       <div class="mt-1 text-2xl font-semibold text-slate-900">{formatCount(stats.total)}</div>
+      {@render deltaBadge(data.compare?.requests ?? null)}
     </div>
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
@@ -242,6 +256,7 @@
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">{$t('Spend')}</div>
       <div class="mt-1 text-2xl font-semibold text-slate-900">{formatUsd(stats.totalCost)}</div>
+      {@render deltaBadge(data.compare?.totalCost ?? null)}
     </div>
   </div>
 
@@ -255,6 +270,7 @@
       <div class="mt-1 text-2xl font-semibold text-slate-900">
         {formatTokens(stats.totalTokens)}
       </div>
+      {@render deltaBadge(data.compare?.totalTokens ?? null)}
     </div>
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
@@ -263,6 +279,7 @@
       <div class="mt-1 text-2xl font-semibold text-slate-900">
         {formatTokens(stats.inputTokens)}
       </div>
+      {@render deltaBadge(data.compare?.inputTokens ?? null)}
     </div>
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
@@ -271,6 +288,7 @@
       <div class="mt-1 text-2xl font-semibold text-slate-900">
         {formatTokens(stats.outputTokens)}
       </div>
+      {@render deltaBadge(data.compare?.outputTokens ?? null)}
     </div>
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
@@ -279,6 +297,7 @@
       <div class="mt-1 text-2xl font-semibold text-slate-900">
         {formatTokens(stats.cachedTokens)}
       </div>
+      {@render deltaBadge(data.compare?.cachedTokens ?? null)}
     </div>
   </div>
 

--- a/apps/admin/src/routes/+page.ts
+++ b/apps/admin/src/routes/+page.ts
@@ -1,12 +1,12 @@
 import { listRequests, type RequestListItem } from '$lib/api/requests.js';
 import { type DashboardStats, EMPTY_STATS, getStats } from '$lib/api/stats.js';
-import { resolveStatsWindow, trendBucketForRange } from '$lib/dashboard-chart.js';
 import {
-  clientTzOffsetMinutes,
-  parseRange,
-  type RangeKey,
-  resolveWindow,
-} from '$lib/requests-filters.js';
+  pctDelta,
+  resolveStatsWindow,
+  resolveTodayComparisonWindow,
+  trendBucketForRange,
+} from '$lib/dashboard-chart.js';
+import { clientTzOffsetMinutes, parseRange, resolveWindow } from '$lib/requests-filters.js';
 import type { PageLoad } from './$types.js';
 
 // Dashboard load (SPA, client-side): read the date-range preset from the URL
@@ -23,7 +23,7 @@ import type { PageLoad } from './$types.js';
 // navigation (range change / back-button) since it depends on `url`.
 
 export const load: PageLoad = async ({ url }) => {
-  const range = parseRange(url.searchParams.get('range'), '24h');
+  const range = parseRange(url.searchParams.get('range'), 'today');
   const now = Date.now();
   const { start, end } = resolveWindow(range, now);
   const statsWindow = resolveStatsWindow(range, now);
@@ -55,11 +55,36 @@ export const load: PageLoad = async ({ url }) => {
   const t = agg.totals;
   const successRate = t.requests === 0 ? null : Math.round((t.okCount / t.requests) * 100);
 
+  // "vs yesterday" deltas — only for the TODAY view, baselined against yesterday up
+  // to the same time of day (resolveTodayComparisonWindow) so it's pace-vs-pace,
+  // not partial-vs-full. Fail-soft: a hiccup → no deltas, cards just omit them.
+  let compare: Record<string, number | null> | null = null;
+  if (range === 'today') {
+    try {
+      const cmp = resolveTodayComparisonWindow(now);
+      const y = (await getStats({ ...cmp, bucket, tzOffsetMinutes })).totals;
+      compare = {
+        requests: pctDelta(t.requests, y.requests),
+        totalTokens: pctDelta(
+          t.promptTokens + t.completionTokens,
+          y.promptTokens + y.completionTokens,
+        ),
+        inputTokens: pctDelta(t.promptTokens, y.promptTokens),
+        outputTokens: pctDelta(t.completionTokens, y.completionTokens),
+        cachedTokens: pctDelta(t.cachedTokens, y.cachedTokens),
+        totalCost: pctDelta(t.totalCostUsd ?? 0, y.totalCostUsd ?? 0),
+      };
+    } catch {
+      compare = null;
+    }
+  }
+
   return {
     range,
     bucket,
     agg,
     items,
+    compare,
     stats: {
       total: t.requests,
       ok: t.okCount,

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -82,7 +82,7 @@ describe('key detail loader', () => {
       .mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 25 });
   });
 
-  it('scopes getStats + listRequests to the key id and the resolved 24h window', async () => {
+  it('scopes getStats + listRequests to the key id and the resolved today window', async () => {
     const now = Date.UTC(2026, 5, 17, 12);
     vi.spyOn(Date, 'now').mockReturnValue(now);
 
@@ -94,12 +94,14 @@ describe('key detail loader', () => {
     // Both reads are scoped to the key.
     expect(mocks.getStats.mock.calls[0]?.[0]).toMatchObject({ key_id: 'k1' });
     expect(mocks.listRequests.mock.calls[0]?.[0]).toMatchObject({ keyId: 'k1', page: 1 });
-    // Default 24h window: start = now - 24h, end = now.
+    // Default 'today' window: start = local midnight (TZ-independent recompute), end = now.
+    const midnight = new Date(now);
+    midnight.setHours(0, 0, 0, 0);
     expect(mocks.getStats.mock.calls[0]?.[0]).toMatchObject({
-      start: now - 86_400_000,
+      start: midnight.getTime(),
       end: now,
     });
-    expect((result as { filters: KeyDetailFilters }).filters.range).toBe('24h');
+    expect((result as { filters: KeyDetailFilters }).filters.range).toBe('today');
   });
 
   it('resolves a custom date range to [midnight(start), midnight(end)+1day)', async () => {
@@ -160,15 +162,17 @@ function requestItem(traceId: string): RequestListItem {
   };
 }
 
-function pageData(over: {
-  key?: ApiKeyView;
-  requests?: RequestsPage;
-  filters?: KeyDetailFilters;
-} = {}) {
+function pageData(
+  over: {
+    key?: ApiKeyView;
+    requests?: RequestsPage;
+    filters?: KeyDetailFilters;
+  } = {},
+) {
   return {
     key: over.key ?? keyView(),
     keyId: 'k1',
-    filters: over.filters ?? ({ range: '24h', page: 1 } as KeyDetailFilters),
+    filters: over.filters ?? ({ range: 'today', page: 1 } as KeyDetailFilters),
     bucket: 'hour' as const,
     // Empty aggregate → charts render their empty-state, LayerChart never mounts.
     agg: mocks.emptyStats,

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -136,9 +136,10 @@ test.describe("admin request list filtering + pagination", () => {
     await expect(seededRow).toBeVisible();
 
     // Filter controls + numbered pager are present. The date range is the shared
-    // RangeFilter preset-button row (testid range-<key>), not a select.
+    // RangeFilter calendar-day preset row (testid range-<key>), not a select;
+    // 'today' is the default-active preset.
     await expect(page.getByTestId("filter-status")).toBeVisible();
-    await expect(page.getByTestId("range-24h")).toBeVisible();
+    await expect(page.getByTestId("range-today")).toBeVisible();
     // Only the one seeded row exists → single page, Next disabled.
     await expect(page.getByTestId("pager-status")).toContainText("1 requests");
     await expect(page.getByTestId("pager-next")).toBeDisabled();

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-06-24 · 仪表板时间筛选改自然日预设 + 「对比昨天」增量（admin UI；对应 docs/04 遥测展示）
+
+- **背景**：用户（Lukin）要把共享 `RangeFilter` 从滚动窗口（1h/6h/24h/7d/30d/全部）改成**自然日语义**——今天 / 昨天 / 近7天 / 近30天 / 全部，默认今天。1h/6h 对其无意义，核心诉求是**逐日汇总与逐日对比**。三处共用此组件：dashboard 概览、requests 列表筛选栏、key-detail 用量。
+- **决定**：① UI 砍掉 1h/6h/24h 三个滚动按钮，但 `RANGE_KEYS` 仍保留它们（旧书签 `?range=24h` 仍能解析，只是不再渲染成按钮——零破坏迁移）；② 默认值三页统一 `24h`→`today`（`DEFAULT_RANGE`/`KEY_DETAIL_DEFAULT_RANGE`/dashboard `parseRange` 兜底/`HOME_DEFAULT_RANGE`）；③ **逐日对比复用既有按天趋势图**（`trendBucketForRange` 对 7d/30d/all 已 day-bucket，每天一个点即对比），**不另造对比面板**（YAGNI）。
+- **`yesterday` 是首个「闭合窗口」预设**（`[昨天0点, 今天0点)`，不能漏进今天）。由此抓出 key-detail 的潜伏 bug：`resolveKeyDetailWindow` 预设分支**硬把 end 覆盖成 now**，会让"昨天"含进今天数据 → 改 `end: w.end ?? nowMs`（滚动/today 仍开口到 now，仅 yesterday 守闭口）。
+- **「对比昨天」delta**：仅 `range=today` 显示，基准用**诚实的"昨天同一时刻"窗**（`resolveTodayComparisonWindow`：昨天午夜 + 今天已过时长）——今天半天 vs 昨天整天必然显示为暴跌，故把昨天截到同一时点做 pace-vs-pace。`pctDelta` 基准为 0 → 返回 `null`（不显假 +100%）。dashboard 在 Requests/Spend/Total/Input/Output/Cached **六张量级卡片**下挂 `↑/↓N%` **中性灰**标（**不对成本上涨着红色**，避免道德化歧义）；loader 多拉一次 `getStats(昨天窗)`，**fail-soft**（出错则无 delta，卡片照常）。
+- **i18n**：`Today`/`All`/`Date range` 五语早已有；仅补 `Yesterday`（昨天/昨日/어제）+ `vs yesterday`（对比昨天/前日比/어제 대비）五语，并纳入 `dashboard-locales.test` 守卫（非英语 locale 必须 ≠ 英文源）。
+- **TDD + 验证**：红→绿；改/加 `requests-filters`/`key-detail-filters`/`dashboard-chart`/`RangeFilter` 四组单测 + key-detail loader/page 默认值。**admin 466 单测全绿、svelte-check 0/0、prettier 已格式化**。改动全在 `apps/admin`（不碰 core/gateway，符合原则 1 网关与 UI 解耦）。工作树未提交（待用户）。
+
 ## 2026-06-24 · 测试覆盖率补强至「边际收益 0」+ 诚实化单测指标（CLAUDE.md 开发流程「覆盖率到边际效应为止」）
 
 - **背景**：`main`(v0.21.20) 实测单测覆盖率**低于仓库自配阈值**（stmts/lines 89.11% < 90、branches 84.35% < 85、functions 93.01% < 93）——CI「单测」门禁未带 `--coverage` 故长期带债。4520 未覆盖行里 ~50% 是 **e2e 已覆盖的启动胶水 + admin UI 路由**，逐行单测边际收益≈0。
@@ -31,29 +40,13 @@
 - **类型涟漪**：`RuntimeSettings` 加必填字段 → admin 客户端 `settings.ts`（与 schema **有意分叉**，如 archive 默认 true）+ svelte `DEFAULTS` + 三语言 i18n（en/zh-hans/ja）+ 两处全量等值断言测试（core `runtime-settings.test`、admin `settings.test`）同步加 `vacuum_enabled/vacuum_hour`。
 - **验证**：typecheck（shared/core/gateway）+ lint（仅 pre-existing `oauth.ts` warning）+ 单测（schema/auto-vacuum/local-volume-sink/settings/cleanup/gateway 共 146 例绿）+ `pnpm build`（admin 静态含 settings 页 + 三语言 chunk）全绿。分支 `worktree-vacuum-and-archive-fixes`，**未提交**（待用户）。**该功能未部署**——box 仍可用既有手动「压缩数据库」按钮一次性回收那 1.77GB（部署新版后才有定时 VACUUM）。
 
-## 2026-06-23 · 记忆深度召回 = 混合检索（落地 docs/12 P8）+ `memory_recall` MCP 工具（docs/14；原则 1/3/4）
-
-- **背景/范围**：用户要 MCP 上「深度历史召回」（"我们讨论过什么"）。现 `memory_search` 是对蒸馏 `fact_text` 的 `LIKE`——无相关性排序、**无跨语言**（`成本`≠`cost`）。决定**落地 docs/12 已 spec 但 deferred 的 P8**，并新增第 7 个 MCP 工具 `memory_recall` 暴露之。**检索单元 = `memory_facts`**（有 owner_id+scope，跨会话；对齐 docs/12 P8 与 docs/13「raw/observation 不入管理面」）；observations/reflections **不入索引**（完整原始历史靠 fact 的 `sourceObservationRange` 溯源链，非主搜索面，留作后续）。
-- **架构**：三确定性信号各出一个 ranked list，**RRF(k=60) 融合**：① 向量（sqlite-vec / pgvector，方言封在适配器）② 全文（FTS5 **trigram** / tsvector）③ forgetting-score（衰减的 fact 检索也排后）。**双语**：多语言 embedding 跨 zh↔en，trigram 抓 CJK+拉丁字面（unicode61 不切中文），RRF 融合两者短板。不变量同 P8：account-scoped + `expired_at IS NULL`、**fail-open**（embed/向量失败→退 FTS+score；全失败→空结果不 5xx）、召回结果走 reinforcement bump。
-- **embedding 接入**：core 框架无关 → 注入 `Embedder` 端口；gateway 实现调 OpenAI 兼容 `/v1/embeddings`；**后台**（新 `embedding` job，复用 worker；`insertFactsReconciled` 返回的 `insertedIds` 即待嵌入行）；唯一同步嵌入是 `memory_recall` 的一次 query 向量。config `memory.llm.embedding_model`+`embedding_dimensions`（**缺省→向量腿关、退 FTS+score**）；默认多语言选型 bge-m3(1024d) 自托管。
-- **配置**：`memory.forgetting.facts_retrieval{ enabled(默认 false), top_k(10) }`（沿用 docs/12 命名）；RRF k、各信号权重、tokenizer 皆**代码常量**（无撒谎旋钮）。`.strict()` fail-closed。
-- **关键坑（sqlite-vec 已实证可用：v0.1.9 darwin-arm64 prebuilt；本机 Node 25.8.2 / better-sqlite3 12.10.0 / SQLite 3.53.1）**：
-  1. **vec0 主键须 BigInt 绑定**——better-sqlite3 把 JS `number` 当 float 传给 vec0 → `Only integers are allowed for primary key`。存 `fact_rowid` 用 `BigInt`。
-  2. **KNN 语法** `WHERE emb MATCH ? AND k = N ORDER BY distance`；向量绑定 `new Uint8Array(Float32Array.buffer)`。
-  3. **`loadExtension` 今天全仓未调用**——需在 `runMigrations` + `createSqliteDb` **两处**连接开启时加 sqlite-vec 加载 hook；加载失败 **fail-open**（FTS+score 仍工作）绝不崩启动。`sqlite-vec` 已加进 `packages/core` deps（预编译二进制，无需进 root `onlyBuiltDependencies`）。
-  4. FTS5 **external-content** 表（`content='memory_facts'`）只存倒排不复制文本 + AI/AD/AU 触发器同步 + `'rebuild'` 回填。
-  5. **pg `splitStatements` 按 `;` 切**——DDL 仅终止符用 `;`；pgvector 需 `CREATE EXTENSION vector`，PGlite 0.4.6 自带（`@electric-sql/pglite/vector`，测试可覆盖 pg 向量路径）。
-- **迁移版本**：sqlite 当前 max=27 → 新 **v28**；postgres 当前 max=26 → 新 **v27**（pg ledger 比 sqlite 偏移 1）。
-- **`searchFacts?` 挂载**：端口加**可选** `?` 方法；**不**进 `REQUIRED_METHODS`/`MemoryAdminStore`（该 gate 被 admin 路由共用，会 fail-close 整个 `/mcp` 挂载）——`memory_recall` handler **null-check** 降级到 `listFacts({search})`。`bumpReferences` 加可选 `factIds`（向后兼容）。
-- **T6/T7 关键坑（实现中实证）**：① **PGlite vector 扩展须 `PGlite.create({extensions:{vector}})`，不能 `new PGlite()`**（后者不注册 extension bundle → `CREATE EXTENSION vector` 报 `vector.control` not found）；② postgres 向量列用**无维度 `vector`**（顺序 `<=>` 扫描，免运行时 dim），但 v27 `CREATE EXTENSION vector` **要求部署装了 pgvector**（supabase 默认有；自建 PG 无则 boot 失败——诚实信号去装）；③ gateway **无 `/v1/embeddings` 路由、`ProviderClient` 无 embeddings 方法** → embedder（`apps/gateway/src/memory-embedder.ts`）直连 `{provider.base_url}/embeddings`（OpenAI 兼容），按 `embedding_model` 的 provider 前缀从 `config.providers` 解析 base_url + api_key_env；④ 迁移 fixture 测试须预标记新版本（sqlite **v28** / pg **v27**）——不含 memory_facts 的最小 fixture 否则 ALTER 失败（sqlite 3 处、pg 2 处已补）。
-- **进度：全部完成（阶段2 端到端）**。docs/14；config（`facts_retrieval`/`embedding_*`/`embedding` job）；RRF 核心；sqlite 适配器（v28：FTS5-trigram + sqlite-vec vec0 + `searchFacts`/`setFactEmbeddings`/`listFactsNeedingEmbedding` + `bumpReferences.factIds`）；postgres 适配器（v27：tsvector GIN + pgvector + 同方法）；embedder + embedding job + scheduler dispatch/enqueue；`memory_recall` MCP 工具 + 接线 + fail-open。**验证**：`typecheck -r` 全绿；core **2568** 测试绿（含 sqlite/pg searchFacts CJK+向量+RRF、embedding-job、mcp fail-open/bump、迁移 fixture）；gateway mcp 17 + embedder 5 绿；lint 我方文件绿（`oauth.ts:312` pre-existing）。分支 `helm-memory-deep-recall`，**未提交**（待用户）。运行时：`memory.forgetting.facts_retrieval.enabled:true` 开 FTS+score；再配 `memory.llm.embedding_model`+`embedding_dimensions` 点亮向量腿。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
+- **2026-06-23 · 记忆深度召回 = 混合检索（docs/12 P8）+ `memory_recall` MCP 工具（docs/14）**：检索单元=`memory_facts`（account-scoped 跨会话）；三信号 **RRF(k=60)** 融合——向量（sqlite-vec/pgvector）+ 全文（FTS5 trigram/tsvector）+ forgetting-score；双语跨 zh↔en；**fail-open**（全失败空结果不 5xx）。迁移 sqlite **v28**/pg **v27**。坑：vec0 主键须 `BigInt`；`loadExtension` 须在 migrations+createDb 两处 hook 且失败 fail-open；PGlite 须 `PGlite.create({extensions:{vector}})`；gateway 无 `/v1/embeddings` 故 embedder 直连 provider base_url。config `memory.forgetting.facts_retrieval.enabled` 开 FTS+score，再配 `memory.llm.embedding_model` 点亮向量腿。core 2568 测试绿；分支 `helm-memory-deep-recall`。**已上线 v0.21.19**（见记忆 deep-recall-shipped）。
 - **2026-06-23 · MCP OAuth 2.1 shim（ChatGPT 连接器接入；docs/13）**：`/mcp` 前加薄 OAuth 授权服务器（`routes/mcp/oauth.ts`）把 OAuth token 映射回既有 API key 的 account——**无状态 JWT、无 token/code 表、无迁移**；授权码=60s 签名 JWT（PKCE S256 绑定），access token 默认 30 天无 refresh，签名密钥从既有 `HELM_OAUTH_ENC_KEY` 派生（`memory.mcp.oauth.enabled` 且无 enc key → fail-closed 拒启动）；`mcpAuth` 接受 JWT 或裸 key。天花板：授权码 60s 窗口可重放、token 到期前不可撤销（轮换 enc key 全失效）。`oauth.test.ts` 16 例绿，未部署。
 - **2026-06-22 · Claude 订阅（OAuth）token 成本折算**：admin 对 `anthropic/*` OAuth 池只显 token 数、花费恒 null，因 `pricing.yaml` 无 `anthropic/*` 行（`costOf` 查 catalog 落空→`resolveCostUsd` null）。坑：必须**同时**改 `capabilities.yaml`，否则 `loadCatalog` 用 `EMPTY_CAPABILITIES` 造条目→`context_too_small` 剪掉每个 Claude 请求。用官方 Anthropic 价**含 cache 读写价**；4 个 lane alias 折算价非实付，纯配置无代码改动。
 - **2026-06-22 · Codex 原生 Responses 直通清洗 + fallback reasoning 泄漏修复**：仅对 ChatGPT-account Codex Responses profile 清洗 native body（移除 `max_output_tokens`/`temperature`；`store:false` 删 input item `id/status/phase` + 丢空 reasoning item，保留有 encrypted_content/summary 的）；跨协议 fallback 时 `InternalRequest.thinking` 若为 Responses reasoning history 数组不再作为 provider `thinking` 转发（记 `thinking_history_stripped_for_target`）。`openai-responses.test.ts`/`execute.test.ts` 覆盖。


### PR DESCRIPTION
## What

Redesign the shared `RangeFilter` from rolling windows (`1h/6h/24h/7d/30d/全部`) to **calendar-day** semantics — **今天 / 昨天 / 近7天 / 近30天 / 全部**, defaulting to **Today**. Used in three places: dashboard overview, request list filter bar, key-detail usage.

Motivation: rolling 1h/6h windows aren't meaningful for the user; the real need is **summarize and compare by natural day**.

## Changes

- **Calendar-day presets.** Drop `1h/6h/24h` from the button row, but keep them in `RANGE_KEYS` so old bookmarks (`?range=24h`) still resolve — zero-breakage migration. Default range goes `24h → today` across all three pages.
- **`yesterday` = first closed-window preset** `[昨天 00:00, 今天 00:00)`. This surfaced a latent bug: `resolveKeyDetailWindow` forced the preset `end` to `now`, bleeding *yesterday* into *today*'s data → now honors a closed end (`end: w.end ?? nowMs`).
- **"vs yesterday" delta** on the dashboard volume cards (requests, spend, total/input/output/cached tokens), shown only on the **Today** view. Baseline is yesterday **up to the same time of day** (`resolveTodayComparisonWindow`) so a partial day isn't compared against a full one; `pctDelta` returns `null` when there's no baseline (no fake `+100%`). The extra aggregate fetch fails soft.
- **Day-over-day comparison reuses the existing day-bucketed trend chart** (7d/30d/all already bucket by day) — no separate comparison panel (YAGNI).
- **i18n**: add `Yesterday` / `vs yesterday` to all five locales, guarded by `dashboard-locales.test`.

## Testing

- TDD (red → green): updated/added unit tests for `requests-filters`, `key-detail-filters`, `dashboard-chart`, `RangeFilter`, and the key-detail loader/page defaults.
- **466 admin unit tests green**, `svelte-check` 0/0, prettier formatted.
- Changes confined to `apps/admin` — core/gateway untouched (UI/gateway decoupling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)