### PR TITLE
chore(release): v0.21.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.22",
+  "version": "0.21.23",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **#373** — admin date-range picker redesigned to calendar-day presets (今天 / 昨天 / 近7天 / 近30天 / 全部, default Today) with a "vs yesterday" delta on the dashboard volume cards.

Bumps root `package.json` 0.21.22 → 0.21.23. On merge, `publish.yml` builds `ghcr.io/easymetaau/helm-api:0.21.23` and auto-cuts tag `v0.21.23` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)