### PR TITLE
chore(release): v0.21.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.23",
+  "version": "0.21.24",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **#375** — the dashboard "vs yesterday" delta is now transparent: relabeled **对比昨日同期** (vs same period yesterday), the card tooltip shows the yesterday baseline, and the whole delta set is suppressed when yesterday's same-period traffic is too thin to compare against. Includes the e2e seed-at-`now` fix so the today-default request list stays robust across the midnight boundary.

Bumps root `package.json` 0.21.23 → 0.21.24. On merge, `publish.yml` builds `ghcr.io/easymetaau/helm-api:0.21.24` and auto-cuts tag `v0.21.24` + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)