### PR TITLE
v0.21.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.24",
+  "version": "0.21.25",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.21.25.

Bundles since v0.21.24:
- fix(admin): compare dashboard delta day-over-day, not same-period yesterday (#378)
- feat(admin): show cost in dashboard token trend + by-model tooltips (#377)

Merging bumps the root `package.json`; `publish.yml` auto-cuts the tag + GitHub Release + `:0.21.25` image.