### PR TITLE
fix(classifier): eval prompt skips injected memory; widen eval timeout (v0.21.26)

### DIFF
--- a/apps/gateway/e2e/fixtures/mock-upstream.ts
+++ b/apps/gateway/e2e/fixtures/mock-upstream.ts
@@ -150,9 +150,12 @@ export const TOOL_CALL_STREAM_CHUNKS = [
 // discriminate eval calls without coupling to the model id.
 export const EVAL_PROMPT_MARKER = "Classify the request.";
 export const EVAL_SLOW_SENTINEL = "__HELM_EVAL_SLOW__";
-// Delay (ms) the slow judge sleeps before answering — comfortably past the e2e
-// eval timeout_ms / outer_timeout_ms so the fail-open path is deterministic.
-const EVAL_SLOW_DELAY_MS = 2_000;
+// Delay (ms) the slow judge sleeps before answering — comfortably past BOTH e2e
+// eval timeouts (inner timeout_ms 3000 / outer outer_timeout_ms 4000) so the
+// fail-open path is deterministic regardless of which timeout fires. The eval
+// returns at the inner timeout (~3000ms); this delay only keeps the mock from
+// answering first, so raising it does NOT slow the test wall-clock.
+const EVAL_SLOW_DELAY_MS = 5_000;
 // Strict EvalOutput the NORMAL judge returns → complexity:reasoning → premium.
 const EVAL_OUTPUT_JSON = JSON.stringify({
   complexity: "reasoning",

--- a/apps/gateway/src/routes/classify.test.ts
+++ b/apps/gateway/src/routes/classify.test.ts
@@ -198,4 +198,54 @@ describe("classify adapter — admin classifier hot-apply", () => {
     expect(body.temperature).toBe(0);
     expect(body.stream).toBe(false);
   });
+
+  it("classifies the REAL user turn, skipping the appended memory <system-reminder>", async () => {
+    const cfg = baseClassifier();
+    cfg.eval.enabled = true;
+    cfg.rules.confidence_threshold = 1; // always cascade to eval
+
+    let captured: Record<string, unknown> | null = null;
+    const provider: ProviderForEval = {
+      chatCompletion: async (body) => {
+        captured = body;
+        return {
+          choices: [
+            { message: { content: '{"complexity":"simple","task_type":"chat","confidence":0.9}' } },
+          ],
+        };
+      },
+    };
+
+    const classify = buildClassifyAdapter({
+      getClassifierConfig: () => cfg,
+      lanes: LANES,
+      provider,
+      now: () => Date.now(),
+      log: () => {},
+    });
+
+    // inject-bridge appends the memory block as a trailing role:"user" turn.
+    const reqWithMemory = {
+      messages: [
+        { role: "user", content: "what is 2+2?" },
+        {
+          role: "user",
+          content:
+            "<system-reminder>\n# Persistent memory\nfavorite number is 42\n</system-reminder>",
+        },
+      ],
+      tools: null,
+      response_format: null,
+      attachments: null,
+      metadata: { conversation_id: null },
+    } as unknown as InternalRequest;
+
+    await classify(reqWithMemory);
+
+    const messages = (captured as unknown as { messages: Array<{ role: string; content: string }> })
+      .messages;
+    const userTurn = messages.find((m) => m.role === "user");
+    expect(userTurn?.content).toBe("what is 2+2?");
+    expect(userTurn?.content).not.toContain("system-reminder");
+  });
 });

--- a/apps/gateway/src/routes/classify.ts
+++ b/apps/gateway/src/routes/classify.ts
@@ -9,6 +9,7 @@ import {
   type EvalModelRequest,
   type EvalModelResponse,
   type LanesConfig,
+  lastUserMessageText,
   type MomentumStore,
   resolveCostUsd,
   resolveLane as resolveLaneCore,
@@ -96,18 +97,15 @@ function toClassifierInput(req: InternalRequest): ClassifierInput {
 }
 
 // The Layer-2 eval prompt: a single deterministic instruction asking the small
-// model to judge complexity/task_type/confidence as strict JSON. The user's last
-// message is the only content; no system payload is logged (principle 7).
+// model to judge complexity/task_type/confidence as strict JSON. The REAL last
+// user message is the only content; no system payload is logged (principle 7).
+// MUST use the shared `lastUserMessageText` so it SKIPS the trailing memory
+// `<system-reminder>` turn the inject bridge appends — otherwise the model
+// classifies the injected memory block, not the user's actual question (and the
+// prompt drifts from the eval cache key, which already skips it via the same
+// helper). See classifier/message-text.ts.
 function buildEvalPrompt(req: InternalRequest): EvalModelRequest["messages"] {
-  let lastUser = "";
-  for (let i = req.messages.length - 1; i >= 0; i -= 1) {
-    const m = req.messages[i];
-    if (m && m.role === "user") {
-      const content = (m as { content?: unknown }).content;
-      if (typeof content === "string") lastUser = content;
-      break;
-    }
-  }
+  const lastUser = lastUserMessageText(req.messages);
   return [
     {
       role: "system",

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -232,11 +232,11 @@ classifier:
     # max_tokens always win over extra_body; see classify.ts invokeModel.)
     extra_body:
       thinking: { type: disabled }
-    timeout_ms: 1500               # inner (runner) timeout — covers a real cross-region eval
-                                    # round-trip (~1s with reasoning disabled) with margin.
-                                    # 250ms lost every race in production → eval_timeout on
-                                    # every cache-miss prompt; balanced was the only outcome.
-    outer_timeout_ms: 2000         # outer (consumer) timeout — strictly-later backstop (> inner)
+    timeout_ms: 3000               # inner (runner) timeout — covers a real cross-region eval
+                                    # round-trip with margin, incl. subscription models
+                                    # (codex/zenmux) that queue. Was 1500ms → eval_timeout
+                                    # whenever the small model queued; fail-open to balanced.
+    outer_timeout_ms: 4000         # outer (consumer) timeout — strictly-later backstop (> inner)
     on_failure: balanced
     cache:
       enabled: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.25",
+  "version": "0.21.26",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/config/classifier-samples.test.ts
+++ b/packages/core/src/config/classifier-samples.test.ts
@@ -31,11 +31,12 @@ describe("checked-in classifier.yaml sample", () => {
     expect(cfg.classifier.eval.max_tokens).toBe(256);
     // eval-fast-probe (2026-06-07): the eval timeouts were tightened from 250/350
     // to 1500/2000 once `extra_body.thinking:disabled` removed the eval model's
-    // reasoning round-trip (~2-3s → ~1s). The tight timeout is now SAFE because the
-    // call is fast, not loose to tolerate a slow one. Pin the new values + the
-    // passthrough so a drift back to 250 (which always timed out in prod) fails CI.
-    expect(cfg.classifier.eval.timeout_ms).toBe(1500);
-    expect(cfg.classifier.eval.outer_timeout_ms).toBe(2000);
+    // reasoning round-trip (~2-3s → ~1s). Widened again to 3000/4000 (2026-06-25)
+    // to tolerate a slow small-model round-trip (e.g. a throttled subscription
+    // endpoint) without an over-eager fail-open; still a hot-path safety net.
+    // Pin the values so a drift back to 250 (which always timed out in prod) fails CI.
+    expect(cfg.classifier.eval.timeout_ms).toBe(3000);
+    expect(cfg.classifier.eval.outer_timeout_ms).toBe(4000);
     expect(cfg.classifier.eval.extra_body).toEqual({ thinking: { type: "disabled" } });
     expect(cfg.classifier.eval.on_failure).toBe("balanced");
     expect(cfg.classifier.eval.cache.ttl_sec).toBe(300);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,7 @@ export {
   type EvalModelResponse,
   runEval,
 } from "./classifier/eval/client.js";
+export { lastUserMessageText } from "./classifier/message-text.js";
 export {
   applyMomentum,
   type MomentumDeps,


### PR DESCRIPTION
## What

Investigated request `0ba10463` on la.atmy.work (an `internal-llm` eval loopback): the Layer-2 eval was classifying the **injected memory `<system-reminder>` block** instead of the user's real question, and timing out at 1.5s.

### Two fixes

1. **eval prompt skips the injected memory reminder.** `buildEvalPrompt` used a hand-rolled last-user-message scan that grabbed the trailing `<system-reminder>` turn the inject bridge appends. The shared `lastUserMessageText` helper already skips those turns (and the eval **cache key** already uses it) — so the sent prompt had drifted from the cache key. Reuse the helper as the single source of truth. Export it from `@helm/core`.

2. **widen eval timeout** `timeout_ms` 1500→3000, `outer_timeout_ms` 2000→4000. Hot-path safety net; still fails open to `balanced`. The oversized-prompt cause of the slowness is fixed by (1); this just stops aggressive fail-opens when the small model round-trip is genuinely slow.

Version bump 0.21.25 → 0.21.26.

## Test

- New unit test pins: eval classifies the REAL user turn, skipping the appended memory `<system-reminder>`.
- `pnpm typecheck` (core+gateway), biome lint, classify suite (4) all green.

## Note (not in this PR)

The box points `classifier.eval.model` at the `economy` lane → first candidate is the `openai-codex/gpt-5.4-mini` **subscription** endpoint, which is throttle/queue-prone on the upstream side (helm has no internal queue for `internal-llm`; `concurrency_limit=null` already bypasses). The durable fix is to point eval at a fast direct-API small model — left as an operator decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)