### PR TITLE
fix(executor): fall back when a stream fails before any output (v0.21.27)

### DIFF
--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -11,9 +11,11 @@ import {
   applyForcedReasoningToNativeBody,
   canUseNativePassthrough,
   checkCapability,
+  guardPreOutputFailure,
   hoistResponsesInstructions,
   type NativePassthroughDisableReason,
   openaiTransformer,
+  preOutputClassifierFor,
   resolveCostUsd,
   sanitizeCodexResponsesNativeBody,
   UpstreamError,
@@ -1052,8 +1054,21 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
           }
           passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
+          // Pre-output failover guard (principle 5 + 8): a same-protocol byte-relay
+          // that 200s then fails IN-BAND before any output (e.g. Responses
+          // `response.failed`/server_is_overloaded after only the `response.created`
+          // preamble) must fall back, not stream the error as success. The guard
+          // buffers preamble and turns a pre-output error frame into a pre-first-chunk
+          // throw → peekStream records a breaker failure and advances the chain. null
+          // classifier (gemini) → unchanged commit-on-first behavior.
+          const passthroughClassifier = preOutputClassifierFor(req.protocol);
           const stream = await peekStream(
-            () => passthroughStream(passthroughBody, { signal, captureUpstream }),
+            () => {
+              const raw = passthroughStream(passthroughBody, { signal, captureUpstream });
+              return passthroughClassifier
+                ? guardPreOutputFailure(raw, passthroughClassifier)
+                : raw;
+            },
             signal,
             alias,
             log,
@@ -1082,8 +1097,19 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               provider.streamReframed === true ? { stream_reframed: true } : undefined,
             ),
           );
+          // Pre-output failover guard (principle 5 + 8): the translate generators
+          // ALREADY throw on a terminal error frame, but they yield an empty role
+          // preamble chunk first, so peekStream would commit success before the throw.
+          // The guard buffers that preamble so the commit lands on the first REAL
+          // output; a pre-output error (thrown by the generator, or an in-band error
+          // frame) stays a pre-first-chunk failure → fallback. Translate output is
+          // always OpenAI-Chat framed, so the chat classifier is always correct.
+          const translateClassifier = preOutputClassifierFor("openai_chat");
           const stream = await peekStream(
-            () => provider.chatCompletionStream(rendered.body, { signal, captureUpstream }),
+            () => {
+              const raw = provider.chatCompletionStream(rendered.body, { signal, captureUpstream });
+              return translateClassifier ? guardPreOutputFailure(raw, translateClassifier) : raw;
+            },
             signal,
             alias,
             log,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-25 · 流式 pre-output 失败 → fallback（执行器；docs/04 执行兜底 + docs/05 流式正确性，原则 5/8）
+
+- **背景（Lukin 报）**：codex `gpt-5.5` 经 native passthrough 返回 HTTP 200 开了 SSE 流，先发无条件前导帧 `response.created`/`response.in_progress`，**随后** `error`/`response.failed`（`server_is_overloaded`）。helm 却记 `final.status:ok`、`fallback_count:0`，把错误帧原样透传给客户端——既不熔断也不 fallback。
+- **根因**：`execute.ts:peekStream` 把"**peek 到的第一个 chunk**"当成功提交点（`breaker.recordSuccess` 后不再 fallback）。passthrough 是字节中继，第一个 chunk 是 `response.created` 前导字节（非空）→ 误判 healthy → 提交。翻译路径同病：生成器在看到 `response.failed`(会 throw) 前先 yield 了空 role 前导 chunk，peek 同样在前导上提交，错误退化成 mid-stream truncation（`stream.truncated` 日志），照样不 fallback。**前导帧不是有效输出**，模型一个 token 没吐就被判成功。
+- **决定（Lukin 选「全覆盖」）**：新增 `packages/core/src/provider/failover-guard.ts` —— 协议感知的 pre-output 守卫，夹在 provider 流与 peekStream 之间：**缓冲前导帧不下发**；首个**真实输出**才提交（按序原样补发缓冲字节，byte-for-byte）；输出前遇**终止错误帧**则 `throw UpstreamError` → peek 当 pre-first-chunk failure → 现有熔断+走链 fallback（与非流式 non-2xx 完全对称）。**已提交后零解析**：真实输出之后的错误是 truncation（客户端已拿字节，回退会重发），原样中继不变。
+- **关键不变量**：客户端尚未收到任何真实字节前失败 = 可安全 fallback，retryable 与否不影响安全性 → 守卫不区分错误码，一律回退。
+- **逐协议分类器**（按 `req.protocol` 选；翻译路径恒用 chat）：responses 前导=`response.created`/`in_progress`、错误=`error`/`response.failed`；anthropic 前导=`message_start`/`ping`、错误=`error`；**chat 保守**——只有 delta 是"role 公告"(`{role}`/`{role,content:""}`,翻译路径前导)才算前导,裸 `{}`/无 choices/usage-only/finish_reason 一律 commit（非回归默认，避免误杀健康流，对齐既有 `data: {}` mock 契约）；**gemini=null 跳过守卫**（其 SSE 无独立前导，守它有风险无收益，维持 commit-on-first）。SSE 缓冲按 `\n\n` 切完整事件,容忍跨 chunk 拆分/单 chunk 多事件;解析失败默认 output（非回归）。
+- **TDD+验证**：`failover-guard.test.ts` 15 例覆盖三协议×{前导→错误→抛、前导→输出→提交 byte-for-byte、错误打头、跨 chunk 拆分、单 chunk 多事件、输出后错误=提交、前导后净结束=抛、`data:{}` 提交}。execute.test 原两条翻译流测试（`data:{}\n\n` mock）一度变红→坐实"chat 别把无 role 的空帧当前导"→收紧分类器后**自动转绿不必改测试**。全量 **301 文件/4623 单测绿**、**e2e 47 绿**（含真实流式 passthrough）、lint+typecheck 干净。
+- **box 现状关联**：该请求 `requested_model:auto`→balanced 链头 `openai-codex/gpt-5.5`（订阅端点,易被上游过载),正是触发此 bug 的场景;修复后这类 200-then-overloaded 会落到链内下一个 `anthropic/claude-sonnet-4-6`。分支 `fix/...`,**待提交+部署**。
+
 ## 2026-06-25 · 仪表板 Token 趋势图/饼图 tooltip 增加花费（admin UI；docs/04 遥测展示）
 
 - **背景**：用户（Lukin）要「Token 用量趋势」浮层与「各模型 Token 用量」饼图除 token 外**显示花费**——趋势浮层加该时间桶**总花费**、饼图悬停显示**该模型花费**；并确认时间轴今天/昨天按小时、其余按日期（`trendBucketForRange`/`formatTrendTick` **早已实现**，本次未改，浮层 header 复用 `formatTrendAxisValue` 随桶切换）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.26",
+  "version": "0.21.27",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -472,6 +472,12 @@ export {
   translateAnthropicSSE,
 } from "./provider/anthropic.js";
 export {
+  type ChunkClass,
+  guardPreOutputFailure,
+  type PreOutputClassifier,
+  preOutputClassifierFor,
+} from "./provider/failover-guard.js";
+export {
   createGeminiClient,
   type GeminiClientConfig,
   type GeminiClientDeps,

--- a/packages/core/src/provider/failover-guard.test.ts
+++ b/packages/core/src/provider/failover-guard.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { guardPreOutputFailure, preOutputClassifierFor } from "./failover-guard.js";
+import { UpstreamError } from "./openai.js";
+
+// failover-guard — the pre-output streaming failure detector. A native upstream that
+// returns HTTP 200 then fails IN-BAND (e.g. Responses `response.failed` /
+// `server_is_overloaded` after only the unconditional `response.created` preamble)
+// must count as a FAILED attempt so the executor falls back — not stream the error to
+// the client as a success. The guard buffers preamble, commits on the first REAL
+// output (flushing buffered bytes verbatim), and throws on a terminal error frame seen
+// before any output (→ peekStream surfaces it as a pre-first-chunk failure).
+
+async function* fromChunks(chunks: string[]): AsyncGenerator<string> {
+  for (const c of chunks) yield c;
+}
+
+async function collect(gen: AsyncIterable<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const c of gen) out.push(c);
+  return out;
+}
+
+const responses = preOutputClassifierFor("openai_responses");
+const anthropic = preOutputClassifierFor("anthropic_messages");
+const chat = preOutputClassifierFor("openai_chat");
+if (!responses || !anthropic || !chat) throw new Error("classifier missing");
+
+describe("guardPreOutputFailure — openai_responses", () => {
+  it("preamble then a terminal error frame → throws UpstreamError (no output yielded)", async () => {
+    const src = fromChunks([
+      'event: response.created\ndata: {"type":"response.created"}\n\n',
+      'event: response.in_progress\ndata: {"type":"response.in_progress"}\n\n',
+      'event: error\ndata: {"type":"error","error":{"message":"server_is_overloaded"}}\n\n',
+    ]);
+    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toThrow(
+      /server_is_overloaded/,
+    );
+  });
+
+  it("response.failed (nested error) before output → throws UpstreamError", async () => {
+    const src = fromChunks([
+      'event: response.created\ndata: {"type":"response.created"}\n\n',
+      'event: response.failed\ndata: {"type":"response.failed","response":{"error":{"message":"overloaded"}}}\n\n',
+    ]);
+    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toThrow(UpstreamError);
+  });
+
+  it("preamble then real output → commits, replays every byte in order (preamble kept)", async () => {
+    const chunks = [
+      'event: response.created\ndata: {"type":"response.created"}\n\n',
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+      'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), responses));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("an SSE event split across chunk boundaries still classifies correctly", async () => {
+    const chunks = [
+      "event: response.created\nda",
+      'ta: {"type":"response.created"}\n\nevent: response.output_text.delta\ndata: {"type":"resp',
+      'onse.output_text.delta","delta":"Hi"}\n\n',
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), responses));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("error and preamble batched in ONE chunk (error before any output) → throws", async () => {
+    const src = fromChunks([
+      'event: response.created\ndata: {"type":"response.created"}\n\nevent: response.failed\ndata: {"type":"response.failed","response":{"error":{"message":"overloaded"}}}\n\n',
+    ]);
+    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toThrow(UpstreamError);
+  });
+
+  it("output THEN error in the same chunk → commits (error relayed as bytes, NOT a failure)", async () => {
+    const chunks = [
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hi"}\n\nevent: error\ndata: {"type":"error","error":{"message":"late"}}\n\n',
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), responses));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("preamble-only stream that ends with no output and no error → throws (fallback)", async () => {
+    const src = fromChunks([
+      'event: response.created\ndata: {"type":"response.created"}\n\n',
+      'event: response.in_progress\ndata: {"type":"response.in_progress"}\n\n',
+    ]);
+    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toThrow(UpstreamError);
+  });
+});
+
+describe("guardPreOutputFailure — anthropic_messages", () => {
+  it("message_start + ping then error → throws", async () => {
+    const src = fromChunks([
+      'event: message_start\ndata: {"type":"message_start"}\n\n',
+      'event: ping\ndata: {"type":"ping"}\n\n',
+      'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}\n\n',
+    ]);
+    await expect(collect(guardPreOutputFailure(src, anthropic))).rejects.toThrow(/overloaded/);
+  });
+
+  it("message_start then content_block_delta → commits byte-for-byte", async () => {
+    const chunks = [
+      'event: message_start\ndata: {"type":"message_start"}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"Hi"}}\n\n',
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), anthropic));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+});
+
+describe("guardPreOutputFailure — openai_chat", () => {
+  it("role-only preamble then an in-band error frame → throws", async () => {
+    const src = fromChunks([
+      'data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+      'data: {"error":{"message":"server_is_overloaded"}}\n\n',
+    ]);
+    await expect(collect(guardPreOutputFailure(src, chat))).rejects.toThrow(/server_is_overloaded/);
+  });
+
+  it("role-only preamble then a content delta → commits byte-for-byte", async () => {
+    const chunks = [
+      'data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), chat));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("the translate path's {role,content:''} preamble defers, then content commits", async () => {
+    const chunks = [
+      'data: {"choices":[{"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), chat));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("a bare content-less frame with no role (data: {}) commits immediately (non-regressive)", async () => {
+    const chunks = ["data: {}\n\n"];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), chat));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("a finish_reason-only terminal chunk counts as output (commits, no fallback)", async () => {
+    const chunks = [
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      "data: [DONE]\n\n",
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), chat));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+});
+
+describe("preOutputClassifierFor", () => {
+  it("returns null for gemini (no guard → unchanged commit-on-first behavior)", () => {
+    expect(preOutputClassifierFor("gemini")).toBeNull();
+  });
+});

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -1,0 +1,214 @@
+import type { Protocol } from "@helm/shared";
+import { UpstreamError } from "./openai.js";
+
+// provider.failover-guard — pre-output streaming failure detector (CLAUDE.md
+// principle 5 + 8: streaming correctness is the #1 risk; classification fallback ≠
+// execution fallback). A native upstream that returns HTTP 200 and OPENS an SSE
+// stream, then fails IN-BAND before producing any model output — e.g. OpenAI
+// Responses emits the unconditional `response.created` / `response.in_progress`
+// preamble, then `error` / `response.failed` with `server_is_overloaded` — must
+// count as a FAILED attempt so the executor falls back to the next candidate, not
+// stream the error frame to the client as a 200 success.
+//
+// WHY this is needed: the executor commits an attempt (breaker.recordSuccess, no
+// further fallback) on the FIRST chunk peekStream pulls. For a stream that emits
+// preamble before any output, that first chunk is meaningless preamble — the commit
+// fires too early, and a later terminal error can only surface as a mid-stream
+// truncation (client already "succeeded"). This guard sits BETWEEN the provider
+// stream and peekStream and moves the commit point to the first REAL output:
+//   • preamble events are BUFFERED, not yielded;
+//   • on the first OUTPUT event → commit: flush the buffered bytes VERBATIM (byte-
+//     for-byte, in order) then relay the rest of the stream untouched;
+//   • on a terminal ERROR event seen BEFORE any output → throw UpstreamError, which
+//     peekStream surfaces as a pre-first-chunk failure → the executor records a
+//     breaker failure and advances the chain (exactly like a non-2xx upstream).
+// Once committed it does ZERO parsing: a terminal error AFTER real output is a
+// truncation (the client already holds bytes — falling back would double-send), so
+// it is relayed verbatim, identical to today.
+
+export type ChunkClass = "preamble" | "output" | "error";
+
+export interface PreOutputClassifier {
+  // Classify ONE complete SSE event by its `data:` payload (the JSON string, or the
+  // literal "[DONE]"). Unparseable / unknown payloads default to "output" so a healthy
+  // stream is never falsely failed (non-regressive: today everything commits at once).
+  classify(dataPayload: string): ChunkClass;
+  // Human-readable message for a terminal error event, for the thrown UpstreamError.
+  errorMessage(dataPayload: string): string;
+}
+
+// Pull the `data:` payload out of one SSE event block (everything before a blank
+// line). Joins multiple `data:` lines with "\n" per the SSE spec; returns null for an
+// event with no data line (comments, bare `event:`/`: keep-alive`) so the guard skips
+// it without committing.
+function extractData(event: string): string | null {
+  let data: string | null = null;
+  for (const line of event.split("\n")) {
+    if (line.startsWith("data:")) {
+      const value = line.slice(5).replace(/^ /, "");
+      data = data === null ? value : `${data}\n${value}`;
+    }
+  }
+  return data;
+}
+
+function tryParse(data: string): Record<string, unknown> | null {
+  try {
+    const v = JSON.parse(data);
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── OpenAI Responses ─────────────────────────────────────────────────────────
+// Preamble: response.created / response.in_progress (emitted unconditionally before
+// any model work). Error: error / response.failed. Everything else (deltas,
+// output_item.added, response.completed/incomplete) is committing output.
+const responsesClassifier: PreOutputClassifier = {
+  classify(data) {
+    if (data === "[DONE]") return "output";
+    const obj = tryParse(data);
+    if (!obj) return "output";
+    const t = obj.type;
+    if (t === "response.created" || t === "response.in_progress") return "preamble";
+    if (t === "error" || t === "response.failed") return "error";
+    return "output";
+  },
+  errorMessage(data) {
+    const obj = tryParse(data) ?? {};
+    const top = (obj.error ?? {}) as { message?: string };
+    const nested = (((obj.response ?? {}) as Record<string, unknown>).error ?? {}) as {
+      message?: string;
+    };
+    return top.message || nested.message || "upstream responses stream error";
+  },
+};
+
+// ── Anthropic Messages ───────────────────────────────────────────────────────
+// Preamble: message_start (no content yet) / ping (keep-alive). Error: error.
+// content_block_*, message_delta, message_stop are committing output.
+const anthropicClassifier: PreOutputClassifier = {
+  classify(data) {
+    if (data === "[DONE]") return "output";
+    const obj = tryParse(data);
+    if (!obj) return "output";
+    const t = obj.type;
+    if (t === "message_start" || t === "ping") return "preamble";
+    if (t === "error") return "error";
+    return "output";
+  },
+  errorMessage(data) {
+    const obj = tryParse(data) ?? {};
+    const err = (obj.error ?? {}) as { message?: string };
+    return err.message || "upstream anthropic stream error";
+  },
+};
+
+// ── OpenAI Chat ──────────────────────────────────────────────────────────────
+// Used both for native openai_chat passthrough AND for the translate path (whose
+// generators always emit OpenAI-Chat frames). Preamble: a role-only / empty delta
+// with no finish_reason. Error: a `{"error":{…}}` frame. Output: any real delta
+// (content/tool_calls/function_call/reasoning_content/refusal), a finish_reason, a
+// usage-only terminal frame, or [DONE].
+const chatClassifier: PreOutputClassifier = {
+  classify(data) {
+    if (data === "[DONE]") return "output";
+    const obj = tryParse(data);
+    if (!obj) return "output";
+    if (obj.error) return "error";
+    const choices = Array.isArray(obj.choices) ? obj.choices : [];
+    // No choices at all (a bare frame, or a usage-only terminal frame) → committing
+    // output, never preamble: only a positively-recognized role announcement defers.
+    if (choices.length === 0) return "output";
+    const choice = (choices[0] ?? {}) as {
+      delta?: Record<string, unknown>;
+      finish_reason?: unknown;
+    };
+    if (choice.finish_reason != null) return "output";
+    const delta = (choice.delta ?? {}) as Record<string, unknown>;
+    const hasContent =
+      (typeof delta.content === "string" && delta.content.length > 0) ||
+      delta.tool_calls != null ||
+      delta.function_call != null ||
+      (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) ||
+      delta.refusal != null;
+    if (hasContent) return "output";
+    // Content-less choice: defer ONLY if it is a role announcement — the translate
+    // path's `{role,content:""}` preamble or an OpenAI first role-only chunk. Any other
+    // content-less frame commits (conservative, non-regressive default).
+    return delta.role != null ? "preamble" : "output";
+  },
+  errorMessage(data) {
+    const obj = tryParse(data) ?? {};
+    const err = (obj.error ?? {}) as { message?: string };
+    return err.message || "upstream stream error";
+  },
+};
+
+// Select the classifier for a native wire protocol. Returns null for gemini: its SSE
+// has no separate preamble, so guarding it would add risk with no payoff — the caller
+// skips the wrapper and keeps the unchanged commit-on-first-chunk behavior.
+export function preOutputClassifierFor(protocol: Protocol): PreOutputClassifier | null {
+  switch (protocol) {
+    case "openai_responses":
+      return responsesClassifier;
+    case "anthropic_messages":
+      return anthropicClassifier;
+    case "openai_chat":
+      return chatClassifier;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Wrap a provider SSE string stream so a pre-output upstream failure becomes a
+ * pre-first-chunk throw (→ executor fallback) instead of a relayed "success". See the
+ * module header for the contract. Byte-for-byte on the commit path; ZERO parsing once
+ * committed.
+ */
+export async function* guardPreOutputFailure(
+  source: AsyncIterable<string>,
+  classifier: PreOutputClassifier,
+): AsyncGenerator<string> {
+  const buffered: string[] = [];
+  let sse = "";
+  let committed = false;
+
+  for await (const chunk of source) {
+    if (committed) {
+      yield chunk;
+      continue;
+    }
+    // Hold the raw bytes for verbatim replay; accumulate a parallel text buffer only
+    // to frame complete SSE events (split on the blank-line terminator).
+    buffered.push(chunk);
+    sse += chunk;
+    let sep = sse.indexOf("\n\n");
+    while (sep >= 0) {
+      const data = extractData(sse.slice(0, sep));
+      sse = sse.slice(sep + 2);
+      if (data !== null) {
+        const cls = classifier.classify(data);
+        if (cls === "error") {
+          throw new UpstreamError("upstream_error", classifier.errorMessage(data));
+        }
+        if (cls === "output") {
+          committed = true;
+          for (const b of buffered) yield b;
+          buffered.length = 0;
+          break;
+        }
+      }
+      sep = sse.indexOf("\n\n");
+    }
+  }
+
+  // Source ended having emitted only preamble (no output, no error): an abnormal
+  // close. Throw so the caller records a failure and falls back, rather than serving
+  // an empty body as success.
+  if (!committed) {
+    throw new UpstreamError("upstream_error", "upstream stream ended before producing any output");
+  }
+}


### PR DESCRIPTION
## What

Investigated request `c14abb7d` on la.atmy.work: codex `gpt-5.5` (native passthrough) returned **HTTP 200**, opened the SSE stream, emitted `response.created` + `response.in_progress`, then `error` / `response.failed` with `server_is_overloaded`. helm recorded `final.status: ok`, `fallback_count: 0` and relayed the error to the client — no fallback.

### Root cause

`peekStream` commits the attempt (`breaker.recordSuccess`, no further fallback) on the **first chunk** it pulls. For a stream that emits preamble before any model output, that first chunk is meaningless preamble — so the commit fires too early and a later terminal error can only surface as a mid-stream truncation. The translate path has the same bug (it yields an empty role preamble chunk before its generator throws on the error frame).

### Fix — pre-output failover guard

New `packages/core/src/provider/failover-guard.ts` sits between the provider stream and `peekStream`:

- **buffers preamble** (Responses `response.created`/`in_progress`; Anthropic `message_start`/`ping`; chat role-announcement) without yielding;
- on the first **real output** → commits: flushes the buffered bytes **verbatim, byte-for-byte**, then relays the rest untouched;
- on a terminal **error frame before any output** → throws `UpstreamError` → peekStream surfaces a pre-first-chunk failure → executor records a breaker failure and **falls back** (symmetric with a non-2xx upstream).

Invariant: the client has received **no real bytes** before the failure → safe to fall back regardless of error code. Once real output has streamed, a later error stays a truncation (unchanged — falling back would double-send).

Coverage: native passthrough (classifier by `req.protocol`) + translate path (always OpenAI-Chat framed). Gemini opts out (no separate preamble → unchanged commit-on-first). The chat classifier defers **only** on a role announcement, so a bare content-less frame still commits (non-regressive).

## Test

- `failover-guard.test.ts` — 15 cases across all three protocols: preamble→error→throw; preamble→output→commit byte-for-byte; error-first; SSE split across chunk boundaries; multiple events per chunk; output-then-error→commit; preamble-only→throw; bare `data: {}`→commit.
- Full suite green: **301 files / 4623 unit tests**, **47 e2e** (incl. real streaming passthrough), typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)