### PR TITLE
fix(executor): per-attempt timeout → fallback → breaker (v0.21.28)

### DIFF
--- a/apps/gateway/e2e/eval.spec.ts
+++ b/apps/gateway/e2e/eval.spec.ts
@@ -171,18 +171,23 @@ test.describe("eval cascade e2e", () => {
   });
 
   // ── Scenario 5: eval timeout → balanced (fail-open, HTTP 200) ──────────────
-  test("eval timeout -> request still 200, falls open to balanced", async ({ request }) => {
+  test("eval too slow -> request still 200, falls open to balanced", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
-      // the slow sentinel makes the eval stand-in delay past timeout_ms.
+      // The slow sentinel makes the eval stand-in delay past the PER-CANDIDATE deadline
+      // (eval.timeout_ms). The eval loopback's executor times the candidate out and, with
+      // only one eval candidate in the hermetic e2e, the chain exhausts → the eval call
+      // fails → fail-open to balanced. (In production eval.model is a LANE, so the
+      // per-candidate timeout instead falls back to the next candidate and the eval
+      // SUCCEEDS — see execute.test withAttemptDeadline + classifier-samples.) Either
+      // way the contract guarded here holds: the main path is NEVER dragged to a 5xx.
       data: chat(`${ambiguous("s5")} ${EVAL_SLOW_SENTINEL}`),
       headers: { ...UNCERTAIN, "x-helm-eval": "on" },
     });
-    // fail-open: the main path is NEVER dragged down to a 5xx.
     expect(res.status()).toBe(200);
     expect(res.headers()["x-helm-lane"]).toBe("balanced");
     expect(res.headers()["x-helm-final-model"]).toBe(BALANCED_HEAD);
     expect(res.headers()["x-helm-decided-by"]).toBe("fallback");
-    expect(res.headers()["x-helm-fallback-reason"]).toBe("eval_timeout");
+    expect(res.headers()["x-helm-fallback-reason"]).toBe("eval_provider_error");
   });
 
   // ── Scenario 6: rules high-confidence → hit-stop, eval never consulted ─────
@@ -267,7 +272,7 @@ test.describe("eval cascade e2e", () => {
       headers: { ...UNCERTAIN, "x-helm-eval": "on" },
     });
     expect(first.status()).toBe(200);
-    expect(first.headers()["x-helm-fallback-reason"]).toBe("eval_timeout");
+    expect(first.headers()["x-helm-fallback-reason"]).toBe("eval_provider_error");
     const afterFirst = await evalCalls(request);
     expect(afterFirst).toBeGreaterThanOrEqual(1);
 
@@ -276,7 +281,7 @@ test.describe("eval cascade e2e", () => {
       headers: { ...UNCERTAIN, "x-helm-eval": "on" },
     });
     expect(second.status()).toBe(200);
-    expect(second.headers()["x-helm-fallback-reason"]).toBe("eval_timeout");
+    expect(second.headers()["x-helm-fallback-reason"]).toBe("eval_provider_error");
     // the failed result was NOT cached → the endpoint is hit again (no permanent
     // wedge on a transient blip, CLAUDE.md principle 3).
     expect(await evalCalls(request)).toBeGreaterThan(afterFirst);

--- a/apps/gateway/src/memory-self-http.test.ts
+++ b/apps/gateway/src/memory-self-http.test.ts
@@ -42,6 +42,28 @@ describe("createSelfHttpClient", () => {
     expect(res).toEqual({ choices: [{ message: { content: '{"facts":[]}' } }] });
   });
 
+  it("forwards opts.attemptTimeoutMs as the x-helm-attempt-timeout-ms header (eval per-candidate budget)", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => fakeResponse(true, {}));
+    const client = createSelfHttpClient({
+      baseUrl: "http://127.0.0.1:8080",
+      apiKey: "k",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await client.chatCompletion({ model: "economy", messages: [] }, { attemptTimeoutMs: 3000 });
+    const withTimeout = (fetchImpl.mock.calls[0]?.[1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(withTimeout["x-helm-attempt-timeout-ms"]).toBe("3000");
+    // Absent ⇒ no header (normal memory self-calls are unaffected).
+    await client.chatCompletion({ model: "economy", messages: [] });
+    const noTimeout = (fetchImpl.mock.calls[1]?.[1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(noTimeout["x-helm-attempt-timeout-ms"]).toBeUndefined();
+  });
+
   it("prefixes a BARE model with providerPrefix (eval), leaves a prefixed model unchanged", async () => {
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => fakeResponse(true, {}));
     const client = createSelfHttpClient({

--- a/apps/gateway/src/memory-self-http.ts
+++ b/apps/gateway/src/memory-self-http.ts
@@ -58,6 +58,12 @@ export function createSelfHttpClient(deps: SelfHttpClientDeps): ProviderClient {
           // The self-call IS the memory machinery — it must never be observed or have
           // memory injected, else it would recursively form/inject memory about itself.
           "x-memory-mode": "off",
+          // Forward the caller's PER-CANDIDATE timeout to the nested executor (gated to
+          // the internal key in the chat route): a slow head model times out and the
+          // loopback falls back to the next candidate instead of failing the whole call.
+          ...(opts?.attemptTimeoutMs
+            ? { "x-helm-attempt-timeout-ms": String(opts.attemptTimeoutMs) }
+            : {}),
         },
         body: JSON.stringify(body),
         ...(opts?.signal ? { signal: opts.signal } : {}),

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -32,6 +32,7 @@ import {
 import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../app.js";
+import { INTERNAL_API_KEY_ID } from "../internal-key.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
 import type { ServingAccount } from "../runtime/serving-account.js";
 import type { WriteQueue } from "../runtime/write-queue.js";
@@ -469,6 +470,16 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     });
 
     const internal = toInternalRequest(body, traceId, identity, sessionKey, memoryScope);
+    // Per-candidate attempt timeout: a slow head model times out and the executor falls
+    // back to the next candidate (instead of waiting out the global 90s connect timeout).
+    // Honored ONLY from the trusted INTERNAL key — the classifier eval / memory self-HTTP
+    // loopback set it; an untrusted client could otherwise pick a tiny value to force-fail
+    // attempts and trip the SHARED breaker for other tenants. Absent ⇒ today's behavior.
+    if (identity.keyId === INTERNAL_API_KEY_ID) {
+      const raw = c.req.header("x-helm-attempt-timeout-ms");
+      const ms = raw === undefined ? Number.NaN : Number(raw);
+      if (Number.isFinite(ms) && ms > 0) internal.attempt_timeout_ms = Math.floor(ms);
+    }
     const originalMessagesForMemory = [...(internal.messages as IRMessage[])];
 
     // Persist a (redacted) telemetry record. Fail-open: a telemetry failure must

--- a/apps/gateway/src/routes/classify.ts
+++ b/apps/gateway/src/routes/classify.ts
@@ -122,7 +122,7 @@ function buildEvalPrompt(req: InternalRequest): EvalModelRequest["messages"] {
 export interface ProviderForEval {
   chatCompletion(
     req: Record<string, unknown>,
-    opts?: { signal?: AbortSignal },
+    opts?: { signal?: AbortSignal; attemptTimeoutMs?: number },
   ): Promise<Record<string, unknown>>;
 }
 
@@ -232,6 +232,7 @@ export function buildClassifyAdapter(deps: ClassifyAdapterDeps): ClassifyFn {
   const invokeModel = async (
     modelReq: EvalModelRequest,
     signal: AbortSignal,
+    attemptTimeoutMs: number,
   ): Promise<EvalModelResponse> => {
     const res = await provider.chatCompletion(
       {
@@ -245,7 +246,12 @@ export function buildClassifyAdapter(deps: ClassifyAdapterDeps): ClassifyFn {
         stream: modelReq.stream,
         max_tokens: modelReq.max_tokens,
       },
-      { signal },
+      // attemptTimeoutMs is the eval's PER-CANDIDATE budget: the self-HTTP loopback
+      // forwards it as `x-helm-attempt-timeout-ms` so the executor times out a slow
+      // head model and falls back to the next candidate (instead of the eval aborting
+      // the whole loopback as a client_abort). A direct provider (no self-HTTP) ignores
+      // it and relies on the outer guard, byte-identical to before.
+      { signal, attemptTimeoutMs },
     );
     // Extract the assistant text from an OpenAI-shaped completion (defensive).
     const choices = (res as { choices?: unknown }).choices;

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1372,6 +1372,89 @@ describe("createExecute — gateway execution adapter", () => {
     if (out.final.status === "ok") expect(out.final.providerModel).toBe("model-b");
   });
 
+  it("a candidate that exceeds attempt_timeout_ms is a TIMEOUT fault → breaker failure + advance", async () => {
+    // The head hangs until its signal aborts (a too-slow upstream); the per-attempt
+    // deadline must abort it, classify it as a `timeout` provider fault (NOT a client
+    // abort), record a breaker failure, and fall back to the next candidate.
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const recordAbort = vi.spyOn(cb, "recordAbort");
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockImplementationOnce(
+          (_b: unknown, opts: { signal: AbortSignal }) =>
+            new Promise((_res, rej) => {
+              opts.signal.addEventListener("abort", () =>
+                rej(Object.assign(new Error("aborted"), { name: "AbortError" })),
+              );
+            }),
+        )
+        .mockResolvedValueOnce({ id: "from-fallback" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ slow: "m-slow", fast: "m-fast" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["slow", "fast"]), req({ attempt_timeout_ms: 20 }));
+
+    expect(out.final.status).toBe("ok");
+    expect(out.body).toEqual({ id: "from-fallback" });
+    // Slow head = timeout fault: breaker failure + chain advance, NOT a client abort.
+    expect(recordFailure).toHaveBeenCalledWith("slow");
+    expect(recordAbort).not.toHaveBeenCalled();
+    expect(out.attempts[0]?.status).toBe("error");
+    expect(out.attempts[0]?.error_class).toBe("timeout");
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+  });
+
+  it("a genuine client abort still records client_abort even when attempt_timeout_ms is set", async () => {
+    // The per-attempt deadline must NOT swallow a real client disconnect: a client
+    // abort wins over the (much longer) deadline, stays a non-provider fault
+    // (recordAbort, no breaker failure), and terminates the chain (no advance).
+    const cb = breaker();
+    const recordAbort = vi.spyOn(cb, "recordAbort");
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const ac = new AbortController();
+    const provider = {
+      chatCompletion: vi.fn().mockImplementation(
+        (_b: unknown, opts: { signal: AbortSignal }) =>
+          new Promise((_res, rej) => {
+            opts.signal.addEventListener("abort", () =>
+              rej(Object.assign(new Error("aborted"), { name: "AbortError" })),
+            );
+          }),
+      ),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ slow: "m-slow", fast: "m-fast" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: ac.signal,
+    });
+    // Client disconnects well before the 5s attempt deadline.
+    setTimeout(() => ac.abort(), 10);
+
+    const out = await execute(plan(["slow", "fast"]), req({ attempt_timeout_ms: 5000 }));
+
+    expect(out.final.status).toBe("error");
+    expect(recordAbort).toHaveBeenCalledWith("slow");
+    expect(recordFailure).not.toHaveBeenCalled();
+    // Terminal: did NOT advance to the fallback candidate.
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
+  });
+
   it("structurally routes a provider/model alias the registry never enumerated to that provider's pool client", async () => {
     // Live OAuth curation: the operator added a model AFTER startup, so the live
     // catalog offers `openai-codex/gpt-5.5` but the startup registry has no entry.

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -223,6 +223,40 @@ function isAbort(err: unknown, signal: AbortSignal): boolean {
   return err instanceof Error && err.name === "AbortError";
 }
 
+// Run one candidate's provider call under an optional PER-ATTEMPT deadline
+// (`req.attempt_timeout_ms`). The bounded window is time-to-first-output: for a
+// non-stream call it covers the whole completion; for a stream it covers the peek
+// (first chunk), after which the timer is cleared so long generation stays uncapped.
+//
+// When the deadline fires (and the CLIENT did not disconnect), the thrown error is
+// reclassified as `UpstreamError("timeout")` so the executor's generic failure path
+// records a breaker fault and advances to the next candidate — a too-slow upstream
+// becomes a normal fallback, exactly like a non-2xx. A genuine client abort still
+// wins (clientSignal.aborted) and rethrows verbatim so `isAbort` routes it to
+// `recordAbort` (no breaker fault, terminal). Mirrors the provider clients' own
+// `withTimeout` discriminator (openai.ts). Absent `attemptMs` => the client signal is
+// passed straight through (zero behavior change for normal traffic).
+async function withAttemptDeadline<T>(
+  attemptMs: number | undefined,
+  clientSignal: AbortSignal,
+  op: (attemptSignal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  if (!attemptMs) return op(clientSignal);
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), attemptMs);
+  const merged = AbortSignal.any([clientSignal, ctrl.signal]);
+  try {
+    return await op(merged);
+  } catch (err) {
+    if (ctrl.signal.aborted && !clientSignal.aborted) {
+      throw new UpstreamError("timeout", `attempt exceeded per-attempt timeout (${attemptMs}ms)`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Per-account user-message queue timeout (issue #93, feature B). Detected by the
 // `queueTimeout` flag (not instanceof) so the check survives any package-boundary
 // duplication of the QueueTimeoutError class.
@@ -1062,16 +1096,24 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // throw → peekStream records a breaker failure and advances the chain. null
           // classifier (gemini) → unchanged commit-on-first behavior.
           const passthroughClassifier = preOutputClassifierFor(req.protocol);
-          const stream = await peekStream(
-            () => {
-              const raw = passthroughStream(passthroughBody, { signal, captureUpstream });
-              return passthroughClassifier
-                ? guardPreOutputFailure(raw, passthroughClassifier)
-                : raw;
-            },
+          const stream = await withAttemptDeadline(
+            req.attempt_timeout_ms,
             signal,
-            alias,
-            log,
+            (attemptSignal) =>
+              peekStream(
+                () => {
+                  const raw = passthroughStream(passthroughBody, {
+                    signal: attemptSignal,
+                    captureUpstream,
+                  });
+                  return passthroughClassifier
+                    ? guardPreOutputFailure(raw, passthroughClassifier)
+                    : raw;
+                },
+                attemptSignal,
+                alias,
+                log,
+              ),
           );
           breaker.recordSuccess(alias);
           // Streamed usage is not known at peek time → cost null, backfilled later.
@@ -1105,14 +1147,24 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // frame) stays a pre-first-chunk failure → fallback. Translate output is
           // always OpenAI-Chat framed, so the chat classifier is always correct.
           const translateClassifier = preOutputClassifierFor("openai_chat");
-          const stream = await peekStream(
-            () => {
-              const raw = provider.chatCompletionStream(rendered.body, { signal, captureUpstream });
-              return translateClassifier ? guardPreOutputFailure(raw, translateClassifier) : raw;
-            },
+          const stream = await withAttemptDeadline(
+            req.attempt_timeout_ms,
             signal,
-            alias,
-            log,
+            (attemptSignal) =>
+              peekStream(
+                () => {
+                  const raw = provider.chatCompletionStream(rendered.body, {
+                    signal: attemptSignal,
+                    captureUpstream,
+                  });
+                  return translateClassifier
+                    ? guardPreOutputFailure(raw, translateClassifier)
+                    : raw;
+                },
+                attemptSignal,
+                alias,
+                log,
+              ),
           );
           breaker.recordSuccess(alias);
           // Streamed usage is not known at peek time → cost null (not measured).
@@ -1156,7 +1208,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
           }
           passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
-          const body = await passthroughInvoke(passthroughBody, { signal, captureUpstream });
+          const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
+            passthroughInvoke(passthroughBody, { signal: attemptSignal, captureUpstream }),
+          );
           breaker.recordSuccess(alias);
           const usage =
             req.protocol === "openai_responses"
@@ -1177,7 +1231,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         }
         const bodyReq = stripInternal(req, providerModel, target.targetProviderProtocol);
         attemptTelemetry = withRequestMutations(passthrough, bodyReq.request_mutations);
-        const body = await provider.chatCompletion(bodyReq.body, { signal, captureUpstream });
+        const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
+          provider.chatCompletion(bodyReq.body, { signal: attemptSignal, captureUpstream }),
+        );
         breaker.recordSuccess(alias);
         attempts.push(okRow(alias, elapsed(), costOf(alias, body), attemptTelemetry));
         return {

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -232,11 +232,14 @@ classifier:
     # max_tokens always win over extra_body; see classify.ts invokeModel.)
     extra_body:
       thinking: { type: disabled }
-    timeout_ms: 3000               # inner (runner) timeout — covers a real cross-region eval
-                                    # round-trip with margin, incl. subscription models
-                                    # (codex/zenmux) that queue. Was 1500ms → eval_timeout
-                                    # whenever the small model queued; fail-open to balanced.
-    outer_timeout_ms: 4000         # outer (consumer) timeout — strictly-later backstop (> inner)
+    timeout_ms: 3000               # PER-CANDIDATE deadline (ms): forwarded to the loopback
+                                    # executor so a slow head model (e.g. codex gpt-5.4-mini,
+                                    # p50≈5s) TIMES OUT and FALLS BACK to the next candidate
+                                    # (breaker fault + advance), instead of aborting the whole
+                                    # eval as a client_abort. Repeated timeouts open its breaker.
+    outer_timeout_ms: 8000         # TOTAL eval budget (ms) across fallback hops — strictly > the
+                                    # per-candidate deadline. The final consumer guard: if the
+                                    # chain can't decide within this, abort + fail open to balanced.
     on_failure: balanced
     cache:
       enabled: true

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-06-25 · per-attempt 超时 → fallback → 熔断（执行器；docs/04 执行兜底，原则 5）
+
+- **背景（Lukin）**：eval 回环到 `openai-codex/gpt-5.4-mini` 反复超时（`d49c6b67` client_abort、fallback_count:0）。查 box telemetry：该"mini"模型 eval 调用 **p50≈5s、p95≈14s，仅 25% 在 3s 内完成**（订阅端点被节流）。Lukin 拍板正解（比"换模型"更通用）：**慢 attempt 应超时→fallback 下一个候选；总超时就熔断跳过**——对所有路由生效。
+- **诊断**：超时→fallback→熔断的机器**早已存在**（`execute.ts` 通用失败路径 `recordFailure`+走链；breaker 连续 5 次 OPEN）。两个缺口：① 唯一 per-attempt 截止是 90s connect 超时（太长，5-6s 的慢模型碰不到→当"成功"）；② eval 的外层 `controller.abort()` → 执行器判 **client_abort → recordAbort**（不记熔断、不走链）那条死路。
+- **方案（per-request 作用域，避免全局 tight 超时误杀推理模型）**：新增 `InternalRequest.attempt_timeout_ms`（内部信号）。执行器加 `withAttemptDeadline`：把每个候选的 provider 调用（非流式 + 流式 peek）包进可选 per-attempt 截止；到点 abort **per-attempt controller**（非 client signal）→ 抛 `UpstreamError("timeout")` → 落到既有 recordFailure+走链；客户端真断连仍 `clientSignal.aborted` 胜出→recordAbort（保留 client-abort-beats-timeout 不变式，镜像 provider `withTimeout`）。零 `attemptMs` = 直通 client signal（普通流量零变化）。
+- **接线到 eval 回环**：`ProviderCallOptions.attemptTimeoutMs`（仅 self-HTTP 消费，转成 `x-helm-attempt-timeout-ms` 头）→ chat 路由读该头（**仅 internal key 放行**，防恶意客户端用 1ms 触发共享 breaker 跨租户误熔断）→ `req.attempt_timeout_ms` → 嵌套执行器。eval `runEval` 重构：**去掉 inner abort race**，把 `config.timeout_ms` 作为**每候选预算**传给 invokeModel；`outer_timeout_ms` 保留为**总预算**最终兜底。`config.classifier.eval`：timeout_ms=3000（每候选）/ outer_timeout_ms 4000→**8000**（总，容 ~2 跳）。
+- **效果**：eval 回环 gpt-5.4-mini 超 3s → timeout fault → 走链到 haiku（~1.9s）→ **eval 成功**（原 client_abort→fail-open balanced）；连续 5 次 → breaker OPEN（30s）→ 跳过。**共享 breaker 细节**：90s 默认下真实流量 success 会 reset 计数，但 gpt-5.4-mini 流量 eval 占绝大多数（DB 194 internal vs 5 real/2d），故实际仍会 OPEN（符合意图，note 非 blocker）。
+- **TDD+验证**：execute.test 加 2 例（超 attempt_timeout_ms → recordFailure+走链 error_class:timeout，**非** client_abort；真 client abort 仍 recordAbort 终止）；eval client.test「test 3」从"inner timeout"重构为"forwards timeout_ms as per-candidate deadline"；memory-self-http.test 加头转发例；classifier-samples 改 outer 8000。**e2e eval.spec**:单候选 e2e 下慢 eval 现 fail-open 理由 `eval_timeout`→`eval_provider_error`（per-candidate 超时耗尽单候选链→502→provider_error；prod 多候选 lane 则真 fallback 成功，注释说明）。全量 **4626 单测 + 66 e2e 绿**、typecheck+biome 干净。
+- **box**：仅改 operator config `outer_timeout_ms`→8000（timeout_ms 3000 不变）；`eval.model=economy` **不必改**（fallback 自行处理）。分支 `fix/per-attempt-timeout-fallback`。
+
 ## 2026-06-25 · 流式 pre-output 失败 → fallback（执行器；docs/04 执行兜底 + docs/05 流式正确性，原则 5/8）
 
 - **背景（Lukin 报）**：codex `gpt-5.5` 经 native passthrough 返回 HTTP 200 开了 SSE 流，先发无条件前导帧 `response.created`/`response.in_progress`，**随后** `error`/`response.failed`（`server_is_overloaded`）。helm 却记 `final.status:ok`、`fallback_count:0`，把错误帧原样透传给客户端——既不熔断也不 fallback。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.27",
+  "version": "0.21.28",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/classifier/eval/client.test.ts
+++ b/packages/core/src/classifier/eval/client.test.ts
@@ -11,8 +11,9 @@ import {
 
 // eval.client — `runEval` actually calls the internal small model to judge a
 // request's lane. It MUST: send a non-streaming, temperature:0, max_tokens-capped
-// request; wrap the whole chain in a DOUBLE timeout (inner runner abort + outer
-// consumer guard); and NEVER throw — any timeout / provider error / circuit-open /
+// request; forward config.timeout_ms to invokeModel as the PER-CANDIDATE deadline
+// (executor-enforced fallback) and guard the whole call with the outer_timeout_ms
+// consumer race; and NEVER throw — any timeout / provider error / circuit-open /
 // parse failure collapses to `{ decided:false, reason }` so eval.cascade fails
 // open to balanced (CLAUDE.md principles 3, 4, 7). Logs/telemetry must never carry
 // plaintext prompt, user messages, or raw model output (principle 7).
@@ -145,28 +146,32 @@ describe("runEval", () => {
     expect(req.extra_body).toBeUndefined();
   });
 
-  it("inner timeout fails open and aborts the upstream request (test 3)", async () => {
-    let captured: AbortSignal | undefined;
+  it("forwards config.timeout_ms to invokeModel as the per-candidate attempt deadline (test 3)", async () => {
+    // timeout_ms is no longer a local inner race; it is the PER-CANDIDATE budget the
+    // loopback hands to the executor so a slow head model falls back to the next
+    // candidate (breaker fault + advance) instead of aborting the whole eval.
+    let capturedAttemptMs: number | undefined;
     const deps = makeDeps({
-      config: makeConfig({ timeout_ms: 300, outer_timeout_ms: 10_000 }),
-      // Never resolves; only an abort can stop it.
-      invokeModel: vi.fn((_req: EvalModelRequest, signal: AbortSignal) => {
-        captured = signal;
-        return new Promise<EvalModelResponse>(() => {});
-      }),
+      config: makeConfig({ timeout_ms: 3000, outer_timeout_ms: 10_000 }),
+      invokeModel: vi.fn(
+        async (
+          _req: EvalModelRequest,
+          _signal: AbortSignal,
+          attemptTimeoutMs: number,
+        ): Promise<EvalModelResponse> => {
+          capturedAttemptMs = attemptTimeoutMs;
+          return { text: SECRET_MODEL_TEXT };
+        },
+      ),
     });
-    const p = runEval(INPUT, deps);
-    await vi.advanceTimersByTimeAsync(301);
-    const result = await p;
-    expect(result.decided).toBe(false);
-    if (!result.decided) {
-      expect(result.reason).toBe("timeout");
-    }
-    expect(captured?.aborted).toBe(true);
+    const result = await runEval(INPUT, deps);
+    expect(capturedAttemptMs).toBe(3000);
+    expect(result.decided).toBe(true);
   });
 
-  it("outer timeout fires independently of the inner race (test 4)", async () => {
-    // Inner timeout is set absurdly high so ONLY the outer guard can win.
+  it("outer timeout guards the total budget (test 4)", async () => {
+    // A loopback that never resolves (e.g. every candidate wedged) must still fail open
+    // when the TOTAL outer budget elapses, never hanging the hot path.
     const deps = makeDeps({
       config: makeConfig({ timeout_ms: 10_000, outer_timeout_ms: 250 }),
       invokeModel: vi.fn(() => new Promise<EvalModelResponse>(() => {})),

--- a/packages/core/src/classifier/eval/client.ts
+++ b/packages/core/src/classifier/eval/client.ts
@@ -5,16 +5,20 @@ import { parseEvalOutput } from "./contract.js";
 // to judge a request's lane. It composes: buildPrompt → non-streaming,
 // temperature:0, max_tokens-capped invokeModel (supplied by provider.registry —
 // the internal small-model alias, NOT one of the three public lanes) →
-// parseEvalOutput (eval.contract). The whole chain is wrapped in a DOUBLE timeout
-// per docs/research-notes (llm-router probe hardening):
-//   • inner runner timeout (config.timeout_ms): a Promise.race that, on expiry,
-//     aborts the upstream request so the connection/billing is reclaimed;
-//   • outer consumer timeout (config.outer_timeout_ms): an INDEPENDENT second
-//     Promise.race that protects the main path even if the inner race wedges
-//     (event-loop stalls, an invokeModel that ignores its AbortSignal, etc).
-// Helm's three improvements over the llm-router probe land here: a max_tokens cap
-// (cost bound), the outer timeout is REALLY wired (not dead config), and the
-// output is decisive (parsed → decision), not advisory.
+// parseEvalOutput (eval.contract). Two timeouts, with DISTINCT roles:
+//   • config.timeout_ms = the PER-CANDIDATE deadline. It is NOT a local race here —
+//     it is forwarded to invokeModel, which hands it to the executor as the loopback's
+//     per-attempt budget. A slow head model (e.g. codex gpt-5.4-mini, p50≈5s) then
+//     TIMES OUT and FALLS BACK to the next candidate inside the loopback (breaker
+//     fault + advance), instead of aborting the whole eval as a client_abort;
+//   • config.outer_timeout_ms = the TOTAL consumer guard. A `Promise.race` that, on
+//     expiry, aborts the loopback so a chain that can't decide within the total budget
+//     never hangs the main request path (event-loop stalls, an invokeModel that
+//     ignores its AbortSignal, etc) — it fails open to balanced.
+// Helm's improvements over the llm-router probe land here: a max_tokens cap (cost
+// bound), the outer guard is REALLY wired (not dead config), the per-candidate timeout
+// drives real execution fallback (not a single abort), and the output is decisive
+// (parsed → decision), not advisory.
 //
 // `runEval` NEVER throws (CLAUDE.md principle 3). Every failure path — timeout,
 // provider error, circuit-open, dirty output — collapses to
@@ -79,9 +83,18 @@ export interface EvalLogEvent {
 
 export interface EvalClientDeps<TInput> {
   config: EvalConfig;
-  /** Internal small-model call (provider.registry); non-streaming. Must honor
-   *  the AbortSignal so a timeout reclaims the upstream connection. */
-  invokeModel: (req: EvalModelRequest, signal: AbortSignal) => Promise<EvalModelResponse>;
+  /** Internal small-model call (provider.registry); non-streaming. Must honor the
+   *  AbortSignal so the outer-budget timeout reclaims the upstream connection.
+   *  `attemptTimeoutMs` is the PER-CANDIDATE deadline (config.timeout_ms): the loopback
+   *  forwards it to the executor so a slow head model FALLS BACK to the next candidate
+   *  instead of failing the whole eval (issue: codex gpt-5.4-mini p50≈5s on the eval
+   *  hot path). The executor records a breaker fault + advances on each per-candidate
+   *  timeout; the eval still fails open only if the TOTAL outer budget is exceeded. */
+  invokeModel: (
+    req: EvalModelRequest,
+    signal: AbortSignal,
+    attemptTimeoutMs: number,
+  ) => Promise<EvalModelResponse>;
   /** Pure prompt builder; runEval never inspects TInput itself. */
   buildPrompt: (input: TInput) => EvalModelRequest["messages"];
   /** Injected clock for deterministic latency / timeout assertions. */
@@ -135,17 +148,18 @@ export async function runEval<TInput>(
     ...(config.extra_body ? { extra_body: config.extra_body } : {}),
   };
 
-  // Inner runner: the upstream call raced against its own runner timeout. On
-  // inner timeout we abort so the connection is reclaimed and stops billing.
-  const inner = (async (): Promise<EvalModelResponse | typeof TIMEOUT> => {
-    return Promise.race([invokeModel(request, controller.signal), timeoutAfter(config.timeout_ms)]);
-  })();
-
   let raced: EvalModelResponse | typeof TIMEOUT;
   try {
-    // Outer consumer guard: independent second race so a wedged inner race can
-    // never hold up the main request path.
-    raced = await Promise.race([inner, timeoutAfter(config.outer_timeout_ms)]);
+    // The loopback call races the TOTAL outer budget. config.timeout_ms is NOT an
+    // inner race here — it is forwarded to invokeModel as the PER-CANDIDATE deadline
+    // the executor enforces, so a slow head model (e.g. codex gpt-5.4-mini) falls back
+    // to the next candidate inside the loopback instead of aborting the whole eval.
+    // outer_timeout_ms is the final consumer guard: if the chain can't decide within
+    // the total budget we abort and fail open (balanced), never hanging the hot path.
+    raced = await Promise.race([
+      invokeModel(request, controller.signal, config.timeout_ms),
+      timeoutAfter(config.outer_timeout_ms),
+    ]);
   } catch (err) {
     // The upstream call rejected. Abort (defensive) and classify the failure.
     controller.abort();

--- a/packages/core/src/config/classifier-samples.test.ts
+++ b/packages/core/src/config/classifier-samples.test.ts
@@ -29,14 +29,13 @@ describe("checked-in classifier.yaml sample", () => {
     const cfg = loadConfig({ configDir, env: {} });
     expect(cfg.classifier.eval.enabled).toBe(false);
     expect(cfg.classifier.eval.max_tokens).toBe(256);
-    // eval-fast-probe (2026-06-07): the eval timeouts were tightened from 250/350
-    // to 1500/2000 once `extra_body.thinking:disabled` removed the eval model's
-    // reasoning round-trip (~2-3s → ~1s). Widened again to 3000/4000 (2026-06-25)
-    // to tolerate a slow small-model round-trip (e.g. a throttled subscription
-    // endpoint) without an over-eager fail-open; still a hot-path safety net.
-    // Pin the values so a drift back to 250 (which always timed out in prod) fails CI.
+    // eval-timeout semantics (2026-06-25): timeout_ms is now the PER-CANDIDATE deadline
+    // the loopback hands to the executor (a slow head model times out → falls back to the
+    // next candidate, breaker fault + advance), and outer_timeout_ms is the TOTAL eval
+    // budget across fallback hops (the final fail-open guard). Pin the values so a drift
+    // back to the old 250 (which always timed out in prod) fails CI.
     expect(cfg.classifier.eval.timeout_ms).toBe(3000);
-    expect(cfg.classifier.eval.outer_timeout_ms).toBe(4000);
+    expect(cfg.classifier.eval.outer_timeout_ms).toBe(8000);
     expect(cfg.classifier.eval.extra_body).toEqual({ thinking: { type: "disabled" } });
     expect(cfg.classifier.eval.on_failure).toBe("balanced");
     expect(cfg.classifier.eval.cache.ttl_sec).toBe(300);

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -71,6 +71,13 @@ export type NativeProtocolProfile =
 export interface ProviderCallOptions {
   signal?: AbortSignal;
   captureUpstream?: (wireBody: string) => void;
+  // PER-CANDIDATE timeout hint (ms) for an internal LOOPBACK call. Consumed ONLY by the
+  // self-HTTP client (memory-self-http.ts), which forwards it to the nested gateway as
+  // `x-helm-attempt-timeout-ms` so that request's executor bounds each candidate (a slow
+  // head model then falls back instead of the caller aborting the whole loopback). Real
+  // provider clients IGNORE it — the executor enforces the deadline itself (execute.ts
+  // withAttemptDeadline); this is purely the loopback's way to propagate it inward.
+  attemptTimeoutMs?: number;
 }
 
 export interface ProviderClient {

--- a/packages/shared/src/request/schema.ts
+++ b/packages/shared/src/request/schema.ts
@@ -112,6 +112,14 @@ export const InternalRequestSchema = z.object({
   // body's reasoning field (the translated path already forwards reasoning_effort).
   // Absent => passthrough stays byte-verbatim, as today.
   reasoning_effort_forced: z.boolean().optional(),
+  // Internal signal (NOT a client wire field): a per-CANDIDATE timeout (ms) for the
+  // execution-fallback loop. When set, each candidate's attempt is bounded to this
+  // many ms to first output; exceeding it is treated as a provider `timeout` fault
+  // (breaker failure + advance to the next candidate), NOT a client abort. Set only
+  // by trusted internal callers (the classifier eval loopback, gated to the internal
+  // key in the chat route). Absent => only the global connect/idle timeouts apply, as
+  // today.
+  attempt_timeout_ms: z.number().int().positive().optional(),
   user: z.string().optional(),
   service_tier: z.string().optional(),
   tool_choice: z.unknown().optional(),


### PR DESCRIPTION
## What

Follow-up to the eval/slow-model investigation (request `d49c6b67`). DB evidence: the eval loopback to `openai-codex/gpt-5.4-mini` has **p50≈5s, p95≈14s, only 25% under the 3s eval timeout** — a throttled subscription endpoint, too slow for the hot path.

Lukin's directive (more general than "switch the model"): **a slow attempt should time out → fall back to the next candidate; a model that keeps timing out should be circuit-broken and skipped.**

### Root cause

The timeout→fallback→breaker machinery already exists (`execute.ts` generic failure path: `recordFailure` + advance; breaker opens after 5 consecutive). Two gaps:
1. The only per-attempt deadline was the **90s** connect timeout — a 5–6s model never tripped it (treated as "success, just slow").
2. The eval's own `controller.abort()` made the loopback a **`client_abort` → `recordAbort`** (no breaker fault, no chain advance) — the dead path.

### Fix — per-request attempt deadline

- `InternalRequest.attempt_timeout_ms` (internal signal).
- `execute.ts` **`withAttemptDeadline`** wraps each candidate's call (non-stream + stream peek): on the deadline (a per-attempt controller, **not** the client signal) it throws `UpstreamError("timeout")` → the existing `recordFailure` + chain-advance path. A genuine client abort still wins → `recordAbort`, terminal. Absent ⇒ unchanged (client signal passed straight through, zero change for normal traffic).
- Plumbed to the eval loopback: `ProviderCallOptions.attemptTimeoutMs` → self-HTTP `x-helm-attempt-timeout-ms` header → chat route (**gated to the INTERNAL key**, so an untrusted client can't trip the shared breaker for other tenants) → `req.attempt_timeout_ms`.
- `runEval` drops the inner abort race; `config.timeout_ms` is now the **per-candidate** budget forwarded to the loopback, `outer_timeout_ms` the **total** guard (4000→8000).

### Result

Eval loopback: `gpt-5.4-mini` exceeds 3s → `timeout` fault → falls back to `haiku` (~1.9s) → **eval succeeds** (was `client_abort` → fail-open to balanced). Repeated timeouts → breaker OPEN → skipped. Benefits all routing, not just eval.

## Test

- `execute.test.ts`: a candidate exceeding `attempt_timeout_ms` → `recordFailure` + advance, `error_class:"timeout"` (NOT `client_abort`); a genuine client abort still → `recordAbort`, terminal.
- `eval client.test.ts`: `timeout_ms` forwarded to `invokeModel` as the per-candidate deadline; outer guard still fails open.
- `memory-self-http.test.ts`: header forwarding. `classifier-samples`: outer 8000.
- `e2e/eval.spec.ts`: slow-eval fail-open contract preserved; reason now `eval_provider_error` (single e2e eval candidate exhausts; prod's lane falls back & succeeds — see comment).
- Full suite: **4626 unit + 66 e2e**, typecheck + biome clean.

## Deploy note

Box: bump operator `classifier.eval.outer_timeout_ms` → 8000 (timeout_ms 3000 unchanged); `eval.model = economy` needs **no** change — the fallback now does the right thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)