### PR TITLE
fix(provider): retry a sibling OAuth account on a transient pre-output fault (v0.21.29)

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-06-25 · OAuth 池内换账号重试瞬时故障（provider 执行；docs/04 执行兜底，原则 5）
+
+- **背景（Lukin 报，box req `0348f222`）**：Codex（`protocol:openai_responses` + native tools）请求 `gpt-5.5`，链头 `openai-codex/gpt-5.5` 被某账号返回 `Our servers are currently overloaded`（`upstream_error`，`upstreamStatus:null`，pre-first-chunk），随后**全部 9 个 fallback 被 `responses_native_tools_cross_protocol_blocked` 跳过** → `all_providers_failed`，`fallback_count:0`。**非熔断、非 429**。
+- **诊断（拍证）**：抓 `request_payloads` 证实该请求 14 个工具含 `web_search`(OpenAI 服务端托管)/`tool_search`/`apply_patch`(custom 语法)——这些是 Responses-原生工具，Chat Completions 无等价物，故跨协议跳过**是正确拒绝**（`protocolGuardSkipReason`，execute.ts:642：`type!=="function"` 全进 `nativeTools`）。真正的洞：一个带 Responses 原生工具的 Codex 请求**唯一合法 fallback 就是另一个 Responses-原生 gpt-5.5 端点 = 同订阅的其它账号**。可 `OAuthPoolClient.select()` **每请求只挑 1 个账号**，失败即交回执行器走链（→ 全被跨协议挡），**从不在请求内试其它账号**。4 个 codex 订阅一个忙没帮上。
+- **决定（Lukin 选「池内重试」）**：在 `pool.ts` 加请求内换账号重试。`isRetryableTransientError`：仅 `UpstreamError` 的 **timeout / `upstreamStatus===null`(过载无状态) / 5xx(含 529)** 可重试；**排除 429**（执行器要看见它去 park 该账号 + 配额窗归因，池内吞掉会留它不 park）与**其它 4xx**（确定性请求/鉴权错，换账号同样失败）；非 UpstreamError（client abort）永不重试。`select(stickyKey, exclude)` 加 `exclude` 跳过本请求已试账号（单调收敛，上界=成员数）。
+- **关键权衡（流式的 select 时机）**：现有测试**硬断言流式方法在调用回合同步 `select`**（不 drain 即查 onSelect；缺方法**同步 throw**）。故用**混合**：首个 `select()` 仍同步发生在调用回合（保 rotation+onSelect+fail-closed），只把**重试**放进 async generator——`streamWithRetry(firstEntry,…)`。**仅 pre-first-chunk 可重试**：一旦 yield 过任何 chunk 即提交该账号（字节已上线），mid-stream 故障原样抛出**绝不重试**（对齐 breaker「首个有效 chunk 后记成功」语义 + 原则 8）。非流式 `completeWithRetry` 直接循环。耗尽全部账号时**抛最后一个 upstream 故障**（非内部 "no schedulable account"），让执行器据此 recordFailure+走链。延迟有界：执行器的 per-attempt 超时（见下条）会 abort 整个 alias attempt，天然封顶池内重试总时长。
+- **TDD+验证**：`pool.test.ts` 加 7 例（非流式重试/429 不重试/4xx 不重试/全失败 surface 最后错/流式 pre-first-chunk 重试/mid-stream 不重试/native-passthrough-stream Codex 场景）；红→绿。全量 **core+gateway 228 文件 3852 单测绿**、typecheck+biome 干净。**纯 `packages/core` 改动**（原则 1，不碰框架）。分支 `feat-oauth-pool-inretry-transient`，**未提交/未部署**（待用户）。
+- **关联 TODO**：跨协议跳过本身正确，但「Codex 请求的 fallback 链全废」仍是产品级隐患——可选另一路：若 ZenMux 支持 `/v1/responses`，配 Responses-原生 `zenmux` gpt-5.5 当跨账号兜底（但 web_search 是 OpenAI 托管，ZenMux 未必能代理，**不确定**，本次未做）。
+
 ## 2026-06-25 · per-attempt 超时 → fallback → 熔断（执行器；docs/04 执行兜底，原则 5）
 
 - **背景（Lukin）**：eval 回环到 `openai-codex/gpt-5.4-mini` 反复超时（`d49c6b67` client_abort、fallback_count:0）。查 box telemetry：该"mini"模型 eval 调用 **p50≈5s、p95≈14s，仅 25% 在 3s 内完成**（订阅端点被节流）。Lukin 拍板正解（比"换模型"更通用）：**慢 attempt 应超时→fallback 下一个候选；总超时就熔断跳过**——对所有路由生效。
@@ -26,14 +35,6 @@
 - **逐协议分类器**（按 `req.protocol` 选；翻译路径恒用 chat）：responses 前导=`response.created`/`in_progress`、错误=`error`/`response.failed`；anthropic 前导=`message_start`/`ping`、错误=`error`；**chat 保守**——只有 delta 是"role 公告"(`{role}`/`{role,content:""}`,翻译路径前导)才算前导,裸 `{}`/无 choices/usage-only/finish_reason 一律 commit（非回归默认，避免误杀健康流，对齐既有 `data: {}` mock 契约）；**gemini=null 跳过守卫**（其 SSE 无独立前导，守它有风险无收益，维持 commit-on-first）。SSE 缓冲按 `\n\n` 切完整事件,容忍跨 chunk 拆分/单 chunk 多事件;解析失败默认 output（非回归）。
 - **TDD+验证**：`failover-guard.test.ts` 15 例覆盖三协议×{前导→错误→抛、前导→输出→提交 byte-for-byte、错误打头、跨 chunk 拆分、单 chunk 多事件、输出后错误=提交、前导后净结束=抛、`data:{}` 提交}。execute.test 原两条翻译流测试（`data:{}\n\n` mock）一度变红→坐实"chat 别把无 role 的空帧当前导"→收紧分类器后**自动转绿不必改测试**。全量 **301 文件/4623 单测绿**、**e2e 47 绿**（含真实流式 passthrough）、lint+typecheck 干净。
 - **box 现状关联**：该请求 `requested_model:auto`→balanced 链头 `openai-codex/gpt-5.5`（订阅端点,易被上游过载),正是触发此 bug 的场景;修复后这类 200-then-overloaded 会落到链内下一个 `anthropic/claude-sonnet-4-6`。分支 `fix/...`,**待提交+部署**。
-
-## 2026-06-25 · 仪表板 Token 趋势图/饼图 tooltip 增加花费（admin UI；docs/04 遥测展示）
-
-- **背景**：用户（Lukin）要「Token 用量趋势」浮层与「各模型 Token 用量」饼图除 token 外**显示花费**——趋势浮层加该时间桶**总花费**、饼图悬停显示**该模型花费**；并确认时间轴今天/昨天按小时、其余按日期（`trendBucketForRange`/`formatTrendTick` **早已实现**，本次未改，浮层 header 复用 `formatTrendAxisValue` 随桶切换）。
-- **后端**：`TelemetrySeriesBucket`/`TelemetryModelUsage` 各加 `costUsd: number|null`；sqlite+pg 两适配器 series/byModel 查询加 `SUM(cost_usd)`（别名 `totalCostUsd`），`aggregate-shape` 用 `numOrNull` 映射（**SUM 全 null→null**，区别于实测 0，符合原则 3/7 成本可空语义）。`/admin/api/stats` 路由 `c.json(agg)` 逐字透传，无需改。
-- **决定（「各种花费」的范围）**：telemetry 只存**单列 `cost_usd`（每行=非空 attempt 成本之和）**，故只做**逐桶/逐模型总花费**；**不**按 token 类型（输入/输出/缓存）拆分成本——拆分须运行时按 `pricing.yaml` 重算，未存储，超本次范围（YAGNI）。趋势浮层=三条 token 行 + 分隔线 +「总花费」；饼图=模型名+token+「花费」。
-- **前端**：`+page.svelte` `TrendPoint`/`ModelSlice` 带 `cost`；用 LayerChart 的 `slot="tooltip"`（legacy slot，Svelte 5 互操作，非 snippet）自定义两图浮层，`formatUsd`（null→「—」，自适应精度）渲染；新增 i18n key `Total cost` 五语（`Cost` 早已有）。
-- **TDD+验证**：红→绿，`store-contract.test` 加 series/byModel `costUsd` 断言（两适配器，0.004×N，`toBeCloseTo` 避 FP）；`ports.test` 内存假 store 补 `costUsd:null`（与其 `totalCostUsd:null` 同保真度）。typecheck 三包绿、admin svelte-check 0/0、build 绿、相关单测绿；**Playwright 实测**桩 stats 数据悬停截图确认趋势浮层「总花费 $9.63」、饼图「claude-opus-4-8 / Cost $31.50」。分支 `worktree-dashboard-cost-tooltips`，未提交（待用户）。
 
 ## 2026-06-24 · 仪表板时间筛选改自然日预设 + 「对比昨天」增量（admin UI；对应 docs/04 遥测展示）
 
@@ -66,6 +67,7 @@
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
+- **2026-06-25 · 仪表板 Token 趋势/饼图 tooltip 加花费（admin UI）**：`TelemetrySeriesBucket`/`TelemetryModelUsage` 加 `costUsd:number|null`，sqlite+pg 查询加 `SUM(cost_usd)`（全 null→null，原则 3/7）；趋势浮层显逐桶总花费、饼图显逐模型花费。决定：只做逐桶/逐模型**总**花费，不按 token 类型拆成本（须运行时按 pricing 重算，YAGNI）。LayerChart legacy `slot="tooltip"` 自定义浮层 + `formatUsd`；i18n `Total cost` 五语。store-contract 加 costUsd 断言。分支 `worktree-dashboard-cost-tooltips`，未提交。
 - **2026-06-24 · 定时自动 VACUUM + 归档残留空目录修复（运维；原则 2/3）**：helm.db 反弹 6.4G 真因=`auto_vacuum=0` + cleanup 只 DELETE 不 VACUUM（1.77G 死空间永不还盘）。新增纯函数 `shouldAutoVacuum` + 复用 `startCleanupScheduler` 每小时 tick（`vacuum_enabled` 默认 false opt-in / `vacuum_hour` 默认 4 服务器本地时区；pg 自带 autovacuum 故 `store.vacuum()` no-op）；Bug A `local-volume-sink.ts` 归档失败 catch 里 `rmdir`（非递归）清孤儿空目录。`RuntimeSettings` 加两必填字段涟漪到 admin settings/i18n/全量断言测试。146 测绿，分支 `worktree-vacuum-and-archive-fixes`，**未部署**（box 可用手动「压缩数据库」按钮一次性回收 1.77G）。
 - **2026-06-23 · 记忆深度召回 = 混合检索（docs/12 P8）+ `memory_recall` MCP 工具（docs/14）**：检索单元=`memory_facts`（account-scoped 跨会话）；三信号 **RRF(k=60)** 融合——向量（sqlite-vec/pgvector）+ 全文（FTS5 trigram/tsvector）+ forgetting-score；双语跨 zh↔en；**fail-open**（全失败空结果不 5xx）。迁移 sqlite **v28**/pg **v27**。坑：vec0 主键须 `BigInt`；`loadExtension` 须在 migrations+createDb 两处 hook 且失败 fail-open；PGlite 须 `PGlite.create({extensions:{vector}})`；gateway 无 `/v1/embeddings` 故 embedder 直连 provider base_url。config `memory.forgetting.facts_retrieval.enabled` 开 FTS+score，再配 `memory.llm.embedding_model` 点亮向量腿。core 2568 测试绿；分支 `helm-memory-deep-recall`。**已上线 v0.21.19**（见记忆 deep-recall-shipped）。
 - **2026-06-23 · MCP OAuth 2.1 shim（ChatGPT 连接器接入；docs/13）**：`/mcp` 前加薄 OAuth 授权服务器（`routes/mcp/oauth.ts`）把 OAuth token 映射回既有 API key 的 account——**无状态 JWT、无 token/code 表、无迁移**；授权码=60s 签名 JWT（PKCE S256 绑定），access token 默认 30 天无 refresh，签名密钥从既有 `HELM_OAUTH_ENC_KEY` 派生（`memory.mcp.oauth.enabled` 且无 enc key → fail-closed 拒启动）；`mcpAuth` 接受 JWT 或裸 key。天花板：授权码 60s 窗口可重放、token 到期前不可撤销（轮换 enc key 全失效）。`oauth.test.ts` 16 例绿，未部署。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.28",
+  "version": "0.21.29",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ChatCompletionRequest, ProviderClient } from "../openai.js";
+import { type ChatCompletionRequest, type ProviderClient, UpstreamError } from "../openai.js";
 import { createOAuthPoolClient, type OAuthPoolMember } from "./pool.js";
 
 // A stub account client that records every call it served (so a test can assert
@@ -376,5 +376,155 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     expect(() => pool.nativePassthroughStream?.(NATIVE)).toThrow();
     // The sibling that CAN passthrough-stream was never reached.
     expect(pt).toEqual([]);
+  });
+});
+
+// In-pool retry (the real fix for the Codex `all_providers_failed` on a single OpenAI
+// overload): when the picked account fails with a TRANSIENT, account-agnostic upstream
+// fault BEFORE the first chunk, try the next eligible sibling in the SAME pool before the
+// executor advances to the (cross-protocol-incompatible) next alias. A 429 / 4xx is NOT
+// retried (the executor parks the account / the request is deterministically bad).
+describe("createOAuthPoolClient — in-pool retry on transient upstream fault", () => {
+  // Member whose complete/stream throws a chosen error (or serves) — `served` records
+  // which account actually produced a result, so a test asserts who served vs was skipped.
+  function faultMember(
+    account: string,
+    priority: number,
+    served: string[],
+    fault: UpstreamError | null,
+    opts?: { failMidStream?: boolean },
+  ): OAuthPoolMember {
+    return {
+      account,
+      priority,
+      schedulable: true,
+      client: {
+        async chatCompletion(_req: ChatCompletionRequest) {
+          if (fault) throw fault;
+          served.push(account);
+          return { served_by: account };
+        },
+        chatCompletionStream(_req: ChatCompletionRequest): AsyncIterable<string> {
+          return (async function* () {
+            // Pre-first-chunk fault: throw BEFORE yielding (the breaker/retry boundary).
+            if (fault && !opts?.failMidStream) throw fault;
+            served.push(account);
+            yield `data: ${account}\n\n`;
+            // Mid-stream fault: already committed — must NOT trigger a sibling retry.
+            if (fault && opts?.failMidStream) throw fault;
+          })();
+        },
+      },
+    };
+  }
+
+  const OVERLOAD = new UpstreamError("upstream_error", "overloaded", null, null);
+  const FIVE_XX = new UpstreamError("upstream_error", "bad gateway", null, 502);
+  const RATE = new UpstreamError("upstream_error", "usage limit", null, 429);
+  const BAD = new UpstreamError("upstream_error", "bad request", null, 400);
+
+  it("retries the next account on a transient fault (non-stream)", async () => {
+    const served: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        faultMember("a", 10, served, OVERLOAD), // preferred, but overloaded
+        faultMember("b", 50, served, null),
+      ],
+    });
+    const res = await pool.chatCompletion(REQ);
+    expect(res).toEqual({ served_by: "b" });
+    expect(served).toEqual(["b"]); // a never served; b rescued the request
+  });
+
+  it("does NOT retry on a 429 — left for the executor's per-account park", async () => {
+    const served: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [faultMember("a", 10, served, RATE), faultMember("b", 50, served, null)],
+    });
+    await expect(pool.chatCompletion(REQ)).rejects.toThrow(/usage limit/);
+    expect(served).toEqual([]); // stopped at a's 429; b (healthy) was never tried
+  });
+
+  it("does NOT retry on a deterministic 4xx", async () => {
+    const served: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [faultMember("a", 10, served, BAD), faultMember("b", 50, served, null)],
+    });
+    await expect(pool.chatCompletion(REQ)).rejects.toThrow(/bad request/);
+    expect(served).toEqual([]);
+  });
+
+  it("surfaces the upstream fault (not pool-empty) when every account fails transiently", async () => {
+    const served: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [faultMember("a", 10, served, OVERLOAD), faultMember("b", 50, served, FIVE_XX)],
+    });
+    // The LAST transient error is surfaced — NOT the internal "no schedulable account".
+    await expect(pool.chatCompletion(REQ)).rejects.toThrow(/bad gateway/);
+  });
+
+  it("retries the next account when a stream fails before its first chunk", async () => {
+    const served: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [faultMember("a", 10, served, OVERLOAD), faultMember("b", 50, served, null)],
+    });
+    const chunks: string[] = [];
+    for await (const c of pool.chatCompletionStream(REQ)) chunks.push(c);
+    expect(chunks).toEqual(["data: b\n\n"]);
+    expect(served).toEqual(["b"]); // a threw pre-first-chunk → fell over to b
+  });
+
+  it("does NOT retry once a stream has emitted its first chunk (mid-stream fault)", async () => {
+    const served: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        faultMember("a", 10, served, FIVE_XX, { failMidStream: true }),
+        faultMember("b", 50, served, null),
+      ],
+    });
+    const chunks: string[] = [];
+    await expect(
+      (async () => {
+        for await (const c of pool.chatCompletionStream(REQ)) chunks.push(c);
+      })(),
+    ).rejects.toThrow(/bad gateway/);
+    expect(chunks).toEqual(["data: a\n\n"]); // committed to a after its first chunk
+    expect(served).toEqual(["a"]); // never fell over to b — the bytes were already out
+  });
+
+  it("retries native passthrough streaming across accounts (the Codex case)", async () => {
+    const served: string[] = [];
+    const NATIVE: Record<string, unknown> = { model: "gpt-5.5", stream: true, messages: [] };
+    const mk = (
+      account: string,
+      priority: number,
+      fault: UpstreamError | null,
+    ): OAuthPoolMember => ({
+      account,
+      priority,
+      schedulable: true,
+      client: {
+        async chatCompletion(_req: ChatCompletionRequest) {
+          return { served_by: account };
+        },
+        async *chatCompletionStream(_req: ChatCompletionRequest) {
+          yield `data: ${account}\n\n`;
+        },
+        nativePassthroughStream(_body: Record<string, unknown>): AsyncIterable<string> {
+          return (async function* () {
+            if (fault) throw fault;
+            served.push(account);
+            yield `data: ${account}\n\n`;
+          })();
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [mk("a", 10, OVERLOAD), mk("b", 50, null)],
+    });
+    const chunks: string[] = [];
+    for await (const c of pool.nativePassthroughStream?.(NATIVE) ?? []) chunks.push(c);
+    expect(chunks).toEqual(["data: b\n\n"]);
+    expect(served).toEqual(["b"]);
   });
 });

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -20,7 +20,31 @@ import {
   type NativePassthroughInput,
   nativePassthroughBody,
 } from "@helm/shared";
-import type { ChatCompletionRequest, ChatCompletionResponse, ProviderClient } from "../openai.js";
+import {
+  type ChatCompletionRequest,
+  type ChatCompletionResponse,
+  type ProviderClient,
+  UpstreamError,
+} from "../openai.js";
+
+// Which PRE-FIRST-CHUNK failure justifies trying a SIBLING account in the same pool
+// before the executor advances to the next alias. A Codex (openai_responses + native
+// tools) request has NO valid cross-protocol fallback — every non-Responses alias is
+// skipped — so the only real fallback is another account of the SAME subscription. We
+// retry only TRANSIENT, account-agnostic server faults (a 5xx / overload / connect
+// timeout on one account says nothing about its siblings) and DELIBERATELY exclude:
+//   • 429 — a usage/rate limit is per-account; the executor must SEE it to park that
+//     account (retrying here would hide the 429 and leave it un-parked / mis-attributed);
+//   • other 4xx (400/401/403/413/422) — deterministic request/auth faults a sibling
+//     would hit identically; surface immediately so the executor classifies + advances.
+// Non-UpstreamError (client abort, programmer error) is never retried.
+function isRetryableTransientError(err: unknown): boolean {
+  if (!(err instanceof UpstreamError)) return false;
+  if (err.errorClass === "timeout") return true; // connect/TTFB timeout (pre-first-chunk)
+  const status = err.upstreamStatus;
+  if (status === null) return true; // network / overload with no HTTP status
+  return status >= 500; // 5xx incl. 529 (overloaded); excludes 429 + every other 4xx
+}
 
 // One account in the pool: its scheduling knobs plus the fully-wired client that
 // carries that account's credential + proxy. `lastUsedAt` is MUTABLE soft state
@@ -133,7 +157,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   // robin within equal priority). Bumps the winner's cursor and notifies onSelect.
   // Throws when no member is schedulable (fail-closed — the caller treats it as a
   // provider failure and advances the fallback chain).
-  function select(stickyKey?: string | null): PoolEntry {
+  // `exclude` holds accounts already TRIED-and-transiently-failed this request (in-pool
+  // retry): they are skipped — both as the sticky target and in the LRU scan — so each
+  // retry advances to a fresh sibling and the loop terminates (bounded by member count).
+  function select(stickyKey?: string | null, exclude?: ReadonlySet<string>): PoolEntry {
     const nowMs = now();
     if (stickyKey) {
       const sticky = stickySessions.get(stickyKey);
@@ -142,7 +169,8 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
           (candidate) =>
             candidate.member.account === sticky.account &&
             candidate.member.schedulable &&
-            !usageLimited(candidate.member, nowMs),
+            !usageLimited(candidate.member, nowMs) &&
+            !exclude?.has(candidate.member.account),
         );
         if (entry !== undefined) {
           entry.lastUsedAt = nowMs;
@@ -158,6 +186,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     for (const e of entries) {
       if (!e.member.schedulable) continue; // operator park
       if (usageLimited(e.member, nowMs)) continue; // auto-park cooldown
+      if (exclude?.has(e.member.account)) continue; // already tried this request (retry)
       if (
         !best ||
         e.member.priority < best.member.priority ||
@@ -178,6 +207,80 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return best;
   }
 
+  // Non-stream in-pool retry: try the selected account; on a transient pre-result fault
+  // advance to the next eligible sibling, until one succeeds or none remain. When the
+  // pool is exhausted we surface the LAST upstream fault (the real cause), not the
+  // internal "no schedulable account" — the executor records THAT and advances the chain.
+  async function completeWithRetry<R>(
+    stickyKey: string | null,
+    call: (client: ProviderClient) => Promise<R>,
+  ): Promise<R> {
+    const tried = new Set<string>();
+    let lastErr: unknown;
+    for (;;) {
+      let entry: PoolEntry;
+      try {
+        entry = select(stickyKey, tried);
+      } catch (selErr) {
+        throw lastErr ?? selErr;
+      }
+      tried.add(entry.member.account);
+      try {
+        return await call(entry.member.client);
+      } catch (err) {
+        if (!isRetryableTransientError(err)) throw err;
+        lastErr = err;
+      }
+    }
+  }
+
+  // Streaming in-pool retry. The FIRST account is picked SYNCHRONOUSLY on the call turn
+  // (preserving rotation + onSelect timing — a lazy iterable that deferred select() would
+  // skip rotation until drained); `firstEntry` is that pick. Retry only happens BEFORE the
+  // first chunk: once a chunk is yielded the account is committed (its bytes are already on
+  // the wire), so a mid-stream fault propagates and is NEVER retried.
+  async function* streamWithRetry(
+    firstEntry: PoolEntry,
+    stickyKey: string | null,
+    open: (client: ProviderClient) => AsyncIterable<string>,
+  ): AsyncIterable<string> {
+    const tried = new Set<string>([firstEntry.member.account]);
+    let entry = firstEntry;
+    let lastErr: unknown;
+    for (;;) {
+      let iterator: AsyncIterator<string> | undefined;
+      let first: IteratorResult<string>;
+      try {
+        iterator = open(entry.member.client)[Symbol.asyncIterator]();
+        first = await iterator.next(); // pre-first-chunk fault surfaces HERE
+      } catch (err) {
+        if (iterator) await iterator.return?.().catch(() => {});
+        if (!isRetryableTransientError(err)) throw err;
+        lastErr = err;
+        let next: PoolEntry;
+        try {
+          next = select(stickyKey, tried);
+        } catch {
+          throw lastErr; // no sibling left → surface the real upstream cause
+        }
+        tried.add(next.member.account);
+        entry = next;
+        continue;
+      }
+      // First chunk obtained (or a clean empty stream) → COMMIT to this account.
+      try {
+        if (!first.done) yield first.value;
+        while (true) {
+          const chunk = await iterator.next();
+          if (chunk.done) return;
+          yield chunk.value;
+        }
+      } finally {
+        await iterator.return?.().catch(() => {});
+      }
+    }
+  }
+
   return {
     // Park / un-park ONE account's auto-park cooldown in place. The next select()
     // observes the new value without a pool rebuild; null clears it (the manual
@@ -190,15 +293,16 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       req: ChatCompletionRequest,
       opts?: { signal?: AbortSignal },
     ): Promise<ChatCompletionResponse> {
-      return select().member.client.chatCompletion(req, opts);
+      return completeWithRetry(null, (client) => client.chatCompletion(req, opts));
     },
     chatCompletionStream(
       req: ChatCompletionRequest,
       opts?: { signal?: AbortSignal },
     ): AsyncIterable<string> {
-      // Select SYNCHRONOUSLY (one pick per call) before opening the stream so the
-      // rotation + onSelect fire even though the body is a lazy async iterable.
-      return select().member.client.chatCompletionStream(req, opts);
+      // Pick SYNCHRONOUSLY (one pick per call) before opening the stream so rotation +
+      // onSelect fire on the call turn; streamWithRetry only adds sibling fallbacks.
+      const first = select();
+      return streamWithRetry(first, null, (client) => client.chatCompletionStream(req, opts));
     },
     // Native protocol passthrough (issue #217, Phase 1): forward it like the other
     // methods so the executor's feature-detect (`provider.nativePassthrough`) sees a
@@ -213,13 +317,16 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       body: NativePassthroughInput,
       opts?: { signal?: AbortSignal },
     ): Promise<ChatCompletionResponse> {
-      // select() runs SYNCHRONOUSLY at the top of the async body (before any await),
-      // so rotation + onSelect fire on the call turn, exactly like the other methods.
-      const { client } = select(stickyKeyFromNative(body)).member;
-      if (!client.nativePassthrough) {
-        throw new Error("oauth pool member does not support native passthrough");
-      }
-      return client.nativePassthrough(body, opts);
+      // completeWithRetry's first select() runs SYNCHRONOUSLY before its first await, so
+      // rotation + onSelect fire on the call turn exactly like the other methods. A member
+      // missing the method throws a NON-transient error → surfaced at once (fail-closed,
+      // never silently routed to a translating sibling), not retried.
+      return completeWithRetry(stickyKeyFromNative(body), (client) => {
+        if (!client.nativePassthrough) {
+          throw new Error("oauth pool member does not support native passthrough");
+        }
+        return client.nativePassthrough(body, opts);
+      });
     },
     // Streaming native passthrough (issue #217, Phase 2). A SYNCHRONOUS method (NOT an
     // async fn) so select() — and thus rotation + onSelect — fires on the CALL turn,
@@ -230,11 +337,19 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       body: NativePassthroughInput,
       opts?: { signal?: AbortSignal },
     ): AsyncIterable<string> {
-      const { client } = select(stickyKeyFromNative(body)).member;
-      if (!client.nativePassthroughStream) {
+      const stickyKey = stickyKeyFromNative(body);
+      // Pick + fail-closed check SYNCHRONOUSLY on the call turn (rotation + onSelect, and a
+      // synchronous throw if the picked member can't passthrough-stream), exactly as before.
+      const first = select(stickyKey);
+      if (!first.member.client.nativePassthroughStream) {
         throw new Error("oauth pool member does not support native passthrough streaming");
       }
-      return client.nativePassthroughStream(body, opts);
+      return streamWithRetry(first, stickyKey, (client) => {
+        if (!client.nativePassthroughStream) {
+          throw new Error("oauth pool member does not support native passthrough streaming");
+        }
+        return client.nativePassthroughStream(body, opts);
+      });
     },
   };
 }


### PR DESCRIPTION
## Problem (box req `0348f222`)

A Codex request (`protocol: openai_responses` + native tools) for `gpt-5.5` hit `openai-codex/gpt-5.5`, one pooled account returned **`Our servers are currently overloaded`** (`upstream_error`, `upstreamStatus: null`, pre-first-chunk), and then **all 9 fallbacks were skipped** with `responses_native_tools_cross_protocol_blocked` → `all_providers_failed`, `fallback_count: 0`. Not a breaker trip, not a 429.

### Why the chain was useless (and the skips are *correct*)

The captured request carries `web_search` (OpenAI server-hosted), `tool_search`, and `apply_patch` (custom-grammar) tools. These are Responses-API-native — Chat Completions has no equivalent — so routing to `zenmux/gpt-5.5` (openai_chat) or `deepseek/*` would silently strip Codex's ability to search and patch files. The cross-protocol guard refusing them is the **right** call.

The real gap: a Codex request with native tools has exactly **one** kind of valid fallback — *another Responses-native `gpt-5.5` endpoint = another account of the same subscription*. But `OAuthPoolClient.select()` picked one account per request and, on failure, handed control back to the executor, which walked the (100%-skipped) alias chain. The other 3 codex accounts were never tried.

## Fix

In-pool, in-request retry across sibling accounts:

- **`isRetryableTransientError`** — retry only `UpstreamError` that is `timeout` / `upstreamStatus === null` (overload, no status) / `5xx` (incl. 529). **Excludes 429** (the executor must see it to park that account + attribute the quota window) and **other 4xx** (deterministic — a sibling fails identically). Non-`UpstreamError` (client abort) is never retried.
- **`select(stickyKey, exclude)`** — skip accounts already tried this request (monotonic; bounded by member count).
- **Streaming retries only before the first chunk.** Once a byte is yielded the account is committed (bytes are on the wire) and a mid-stream fault propagates — never retried. Aligns with the breaker's "success only after first valid chunk" contract (principle 8). The first `select()` still fires synchronously on the call turn (rotation + onSelect + fail-closed), so existing streaming contracts hold.
- Exhausting all accounts surfaces the **last upstream fault** (not the internal "no schedulable account"), so the executor records it and advances the chain as before.

## Effect

`openai-codex/gpt-5.5` overloaded on one account → now immediately tries your other codex accounts (all Responses-native, can run web_search / apply_patch) instead of crashing to `all_providers_failed`.

## Tests

- `pool.test.ts`: +7 cases (TDD red→green) — non-stream retry, 429 not retried, 4xx not retried, exhausted-surfaces-last-fault, stream pre-first-chunk retry, mid-stream NOT retried, native-passthrough-stream (the Codex case).
- Full **core + gateway: 228 files / 3852 unit tests green**; typecheck + biome clean.
- Pure `packages/core` change (principle 1 — no framework imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)