### PR TITLE
fix(admin): translate the user_message_queue_timeout skip reason (v0.21.30)

### DIFF
--- a/apps/admin/src/lib/format/attempt-codes.ts
+++ b/apps/admin/src/lib/format/attempt-codes.ts
@@ -47,6 +47,7 @@ export const ATTEMPT_CODE_LABELS: Record<string, string> = {
   aborted: 'Client disconnected',
   invalid_request: 'Invalid request',
   lane_unavailable: 'Lane unavailable',
+  user_message_queue_timeout: 'User message queue timed out', // skip_reason (per-account serial-queue backpressure)
   auth_error: 'Authentication failed',
   rate_limited: 'Rate limited', // outcome + error_class
   timeout: 'Timed out', // outcome + error_class

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -729,6 +729,7 @@
   "Use a proxy (optional)": "Use a proxy (optional)",
   "use lane": "use lane",
   "User ID": "User ID",
+  "User message queue timed out": "User message queue timed out",
   "user keys authenticate normal client traffic. root keys are for the management plane only.": "user keys authenticate normal client traffic. root keys are for the management plane only.",
   "Username (optional)": "Username (optional)",
   "uses the “keep bodies for” window above · archived": "uses the “keep bodies for” window above · archived",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -729,6 +729,7 @@
   "Use a proxy (optional)": "プロキシを使用（任意）",
   "use lane": "使用レーン",
   "User ID": "ユーザーID",
+  "User message queue timed out": "ユーザーメッセージキューの待機がタイムアウトしました",
   "user keys authenticate normal client traffic. root keys are for the management plane only.": "userキーは通常のクライアントトラフィックを認証します。rootキーは管理プレーン専用です。",
   "Username (optional)": "ユーザー名（任意）",
   "uses the “keep bodies for” window above · archived": "上記の本文保持期間を使用 · アーカイブ済み",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -726,6 +726,7 @@
   "Use a proxy (optional)": "프록시 사용(선택 사항)",
   "use lane": "사용 레인",
   "User ID": "사용자 ID",
+  "User message queue timed out": "사용자 메시지 대기열 시간 초과",
   "user keys authenticate normal client traffic. root keys are for the management plane only.": "user 키는 일반 클라이언트 트래픽을 인증합니다. root 키는 관리 플레인 전용입니다.",
   "Username (optional)": "사용자 이름 (선택 사항)",
   "uses the “keep bodies for” window above · archived": "위의 “본문 보관 기간” 기간 사용 · 보관됨",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -729,6 +729,7 @@
   "Use a proxy (optional)": "使用代理（可选）",
   "use lane": "使用通道",
   "User ID": "用户 ID",
+  "User message queue timed out": "用户消息队列等待超时",
   "user keys authenticate normal client traffic. root keys are for the management plane only.": "user 密钥用于验证普通客户端流量；root 密钥仅用于管理平面。",
   "Username (optional)": "用户名（可选）",
   "uses the “keep bodies for” window above · archived": "使用上方“保留正文时间”窗口 · 已归档",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -726,6 +726,7 @@
   "Use a proxy (optional)": "使用代理（可選）",
   "use lane": "使用通道",
   "User ID": "使用者 ID",
+  "User message queue timed out": "使用者訊息佇列等待逾時",
   "user keys authenticate normal client traffic. root keys are for the management plane only.": "user 金鑰用於驗證一般用戶端流量；root 金鑰僅用於管理平面。",
   "Username (optional)": "使用者名稱（選填）",
   "uses the “keep bodies for” window above · archived": "使用上方「保留本文時間」窗口 · 已封存",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.29",
+  "version": "0.21.30",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

In the Decision UI's provider-attempt chain, the `user_message_queue_timeout` skip reason rendered as the **raw snake_case code** instead of a localized label — while every other skip reason / error class was translated (e.g. `lane_unavailable` → 通道不可用). Spotted on a real request where an Anthropic OAuth subscription hit the per-account user-message serial queue timeout.

## Cause

`user_message_queue_timeout` was simply **missing** from `ATTEMPT_CODE_LABELS` (apps/admin/src/lib/format/attempt-codes.ts). `attemptCodeLabel()` returns the raw code for any unmapped value, so it never got an English label — and therefore no i18n key to translate.

The `attempt-code-locales.test.ts` guard enforces full locale coverage of every label *in the map*, so it couldn't catch a code that wasn't in the map at all.

## Fix

- Add `user_message_queue_timeout: 'User message queue timed out'` to the label map.
- Add the key to all 5 locale files: `en` (source) + `zh-hans` / `zh-hant` / `ja` / `ko` translations.

## Tests

- `attempt-code-locales.test.ts` (the existing guard) now covers the new key — 5/5 green.
- All admin i18n locale tests green (17), JSON valid, Prettier clean.

Pure `apps/admin` change (principle 1 — UI only, no core/gateway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)