### PR TITLE
feat(store): content-address payload images + gzip; byte-aware write-queue; indexed admin filters (v0.21.34)

### DIFF
--- a/apps/gateway/src/runtime/write-queue.test.ts
+++ b/apps/gateway/src/runtime/write-queue.test.ts
@@ -60,6 +60,17 @@ function tele(id: string): InsertTelemetryInput {
 function payload(id: string): InsertPayloadInput {
   return { requestId: id, requestJson: "{}", responseJson: null, createdAt: new Date(0) };
 }
+// A payload whose serialized JSON fields sum to roughly `bytes` (cheap length
+// approximation the queue uses for its byte budget). The id stays distinct so we
+// can tell which rows survive a shed.
+function bigPayload(id: string, bytes: number): InsertPayloadInput {
+  return {
+    requestId: id,
+    requestJson: "x".repeat(bytes),
+    responseJson: null,
+    createdAt: new Date(0),
+  };
+}
 
 describe("createWriteQueue", () => {
   it("defers telemetry until flush, then writes them in ONE batch", async () => {
@@ -241,6 +252,136 @@ describe("createWriteQueue", () => {
     expect(sink.inserts).toHaveLength(0);
     expect(sink.payloadCalls).toHaveLength(0);
     expect(logs.filter((l) => l.includes("overflow"))).toHaveLength(2);
+  });
+
+  it("sheds on the BYTE budget even when row depth is nowhere near maxDepth", async () => {
+    // Production payloads are 6-7MB each. A handful of them blows the heap long
+    // before the 10k-row maxDepth. The byte budget must trip on size, not count.
+    const sink = fakeSink();
+    const logs: string[] = [];
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: (m) => logs.push(m),
+      flushIntervalMs: 10_000,
+      maxDepth: 10_000, // far out of reach
+      maxBytes: 1_000, // ~1KB budget: two 600B payloads must not both fit
+      flushBytes: 10_000_000, // park eager byte-flush so we observe shedding, not flushing
+    });
+
+    q.enqueuePayload(bigPayload("p1", 600));
+    q.enqueuePayload(bigPayload("p2", 600)); // total would be 1200B > 1000 → shed oldest
+
+    await q.flush();
+    // Only the newest fits under budget; the older one was shed (not a row-count drop).
+    expect(sink.payloadCalls.map((p) => p.requestId)).toEqual(["p2"]);
+    expect(logs.some((l) => l.includes("overflow"))).toBe(true);
+  });
+
+  it("on byte overflow, sheds PAYLOAD (debug) first and keeps TELEMETRY (audit)", async () => {
+    const sink = fakeSink();
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxDepth: 10_000,
+      maxBytes: 1_000,
+      flushBytes: 10_000_000,
+    });
+
+    q.enqueueTelemetry(tele("audit")); // cheap, must survive
+    q.enqueuePayload(bigPayload("debug-1", 600));
+    q.enqueuePayload(bigPayload("debug-2", 600)); // overflow → drop a payload, not the telemetry
+
+    await q.flush();
+    // Telemetry (audit) is preserved; a payload (debug料) was the one shed.
+    expect(sink.inserts.map((i) => (i.decision as { request_id: string }).request_id)).toEqual([
+      "audit",
+    ]);
+    expect(sink.payloadCalls.map((p) => p.requestId)).toEqual(["debug-2"]);
+  });
+
+  it("keeps the byte count accurate across push/shed: a stream of big payloads stays bounded", async () => {
+    // If the byte accounting under-counted on shed, the buffer would creep up and
+    // eventually exceed the budget without ever flushing — the OOM we're fixing.
+    const sink = fakeSink();
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxDepth: 10_000,
+      maxBytes: 1_000,
+      flushBytes: 10_000_000, // never byte-flush; force the budget to hold via shedding alone
+    });
+
+    // 50 payloads of ~600B each: only ~one fits at a time under a 1KB budget.
+    for (let i = 0; i < 50; i++) q.enqueuePayload(bigPayload(`p${i}`, 600));
+
+    // depth never ran away (a single 600B row + headroom; certainly not 50).
+    expect(q.depth).toBeLessThanOrEqual(2);
+  });
+
+  it("byte threshold (flushBytes) flushes early before a few rows balloon into a huge txn", async () => {
+    // maxBatch=256 rows × 7MB ≈ 1.8GB single commit. flushBytes caps the txn size:
+    // a couple of big payloads must flush long before the row threshold.
+    const sink = fakeSink();
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxBatch: 256, // row threshold out of reach
+      maxBytes: 100_000_000, // budget out of reach
+      flushBytes: 1_000, // ~1KB → flush after the first big payload
+    });
+
+    q.enqueuePayload(bigPayload("p1", 1_500)); // exceeds flushBytes alone → eager flush
+    // Drain the in-flight threshold flush.
+    await q.flush();
+    expect(sink.payloadsManyCalls).toBeGreaterThanOrEqual(1);
+    expect(sink.payloadCalls.map((p) => p.requestId)).toContain("p1");
+  });
+
+  it("counts IN-FLIGHT batches toward the byte budget so a stalled writer can't pile up unbounded memory", async () => {
+    // The OOM scenario this whole change exists to fix: the DB writer is blocked (4am
+    // VACUUM holds the write lock). doFlush hands batches to the write chain, but they
+    // still occupy the heap until the commit lands. Counting only the live buffer would
+    // let repeated flushBytes triggers queue unbounded 6-7MB batches behind the first
+    // blocked write. In-flight bytes must count toward maxBytes so admit() rejects once
+    // the cap is reached — otherwise the byte budget doesn't actually bound the heap.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const received: string[] = [];
+    const stalled: WriteQueueTelemetry = {
+      insert: async () => ({ id: "x" }),
+      insertMany: async () => {},
+      insertPayload: async (i) => {
+        received.push(i.requestId);
+      },
+      insertPayloads: async (xs) => {
+        received.push(...xs.map((x) => x.requestId));
+        await gate; // writer is stalled until released
+      },
+    };
+    const logs: string[] = [];
+    const q = createWriteQueue({
+      telemetry: stalled,
+      log: (m) => logs.push(m),
+      flushIntervalMs: 10_000,
+      maxDepth: 10_000, // row backstop far out of reach — only bytes can gate
+      maxBytes: 2_000,
+      flushBytes: 500, // eager-flush each big payload into the (stalled) chain
+    });
+
+    // 100 × 600B payloads at a stalled writer. With in-flight accounting the budget
+    // trips and most are rejected; without it every one would flush and the heap balloon.
+    for (let i = 0; i < 100; i++) q.enqueuePayload(bigPayload(`p${i}`, 600));
+    expect(logs.filter((l) => l.includes("overflow")).length).toBeGreaterThan(0);
+
+    release();
+    await q.flush();
+    // Only a bounded prefix (~maxBytes worth) ever reached the writer — not all 100.
+    expect(received.length).toBeLessThanOrEqual(5);
   });
 
   it("stop() flushes pending writes and stops the timer", async () => {

--- a/apps/gateway/src/runtime/write-queue.ts
+++ b/apps/gateway/src/runtime/write-queue.ts
@@ -19,6 +19,18 @@ export interface WriteQueueDeps {
   // the oldest buffered write is dropped (logged) so a write stall can never grow
   // the heap without bound. Default 10_000.
   maxDepth?: number;
+  // Hard cap on the in-memory BYTE footprint of the buffered inserts. The real OOM
+  // risk isn't row count — a single payload is 6-7MB, so 10_000 rows × 7MB ≈ 70GB.
+  // Past this budget the queue sheds buffered writes (payload first — see
+  // shedBufferedWrite) so a downstream stall (e.g. the 4am VACUUM holding the write
+  // lock) can never balloon the heap. maxDepth stays as a row-count backstop; EITHER
+  // limit tripping triggers a shed/reject. Default 256MiB.
+  maxBytes?: number;
+  // Flush a buffer eagerly once its accumulated bytes reach this, so a few giant
+  // payloads can't coalesce into a multi-hundred-MB single transaction (maxBatch=256
+  // rows × 7MB). Independent of maxBatch (the row-count eager-flush). Default
+  // maxBytes/4.
+  flushBytes?: number;
   // Optional hook fired AFTER each enqueued task settles (success or failure). The
   // composition root wires this to memoryWorker.wake() so a memory observe landing
   // here schedules the debounced drain — request-driven memory formation without
@@ -60,9 +72,26 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   const flushIntervalMs = deps.flushIntervalMs ?? 25;
   const maxBatch = deps.maxBatch ?? 256;
   const maxDepth = deps.maxDepth ?? 10_000;
+  const maxBytes = deps.maxBytes ?? 256 * 1024 * 1024;
+  const flushBytes = deps.flushBytes ?? Math.floor(maxBytes / 4);
 
   let telemetryBuf: InsertTelemetryInput[] = [];
   let payloadBuf: InsertPayloadInput[] = [];
+  // Parallel byte-cost arrays kept in lock-step with the buffers above (same index =
+  // same row). We never re-stringify a buffered entry to weigh it: the cost is
+  // computed ONCE at enqueue (a cheap .length sum of the already-serialized JSON
+  // fields) and the running total is adjusted by +cost on push / -cost on
+  // shed|flush. That keeps backpressure O(1) amortized instead of turning the admit
+  // check into an O(buffer) CPU hotspot.
+  let telemetryBytes: number[] = [];
+  let payloadBytes: number[] = [];
+  let bufferedBytes = 0;
+  // Bytes that have been flushed into the write chain but whose commit hasn't landed
+  // yet — they still occupy the heap (the batch closures retain them). Counted toward
+  // the byte budget so a STALLED writer (the 4am VACUUM holding the write lock) can't
+  // let repeated flushes pile up unbounded batches behind the first blocked write.
+  // Incremented at flush, released when each commit settles.
+  let inFlightBytes = 0;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
   // All DB writes (batch flushes) run on this serial chain so two flushes can never
@@ -73,6 +102,27 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   let pendingTasks = 0;
 
   const depth = (): number => telemetryBuf.length + payloadBuf.length + pendingTasks;
+
+  // Cheap, allocation-free byte estimate of a payload row: the serialized fields are
+  // already strings, so summing their .length is O(1)-per-row and dominates the
+  // footprint (the payload IS the request/response/upstream JSON). UTF-16 .length
+  // slightly under-counts multi-byte chars, but we only need a consistent proxy to
+  // bound the heap, not an exact byte tally.
+  const payloadCost = (input: InsertPayloadInput): number =>
+    input.requestJson.length +
+    (input.responseJson?.length ?? 0) +
+    (input.upstreamRequestJson?.length ?? 0);
+
+  // Telemetry rows are tiny vs payloads, but a redacted decision can still be a few KB.
+  // Approximate it once at enqueue with a single stringify of the decision (the bulk
+  // of the row) — never recomputed afterward; the cached cost rides the byte arrays.
+  const telemetryCost = (input: InsertTelemetryInput): number => {
+    try {
+      return JSON.stringify(input.decision).length;
+    } catch {
+      return 0; // a non-serializable decision can't bloat the heap as a string anyway
+    }
+  };
 
   const clearTimer = (): void => {
     if (timer !== null) {
@@ -146,26 +196,65 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
     const pBatch = payloadBuf;
     telemetryBuf = [];
     payloadBuf = [];
-    writeChain = writeChain.then(async () => {
-      await writeTelemetry(tBatch);
-      await writePayloads(pBatch);
-    });
+    telemetryBytes = [];
+    payloadBytes = [];
+    // The bytes don't leave memory at flush — they move into the batch closures the
+    // write chain retains until the commit lands. Move them from buffered → in-flight
+    // (NOT zeroed) so admit() keeps counting them against maxBytes while the writer is
+    // stalled; released when this batch's commit settles (success or failure).
+    const flushedBytes = bufferedBytes;
+    bufferedBytes = 0;
+    inFlightBytes += flushedBytes;
+    writeChain = writeChain
+      .then(async () => {
+        await writeTelemetry(tBatch);
+        await writePayloads(pBatch);
+      })
+      .finally(() => {
+        inFlightBytes -= flushedBytes;
+      });
     return writeChain;
   };
 
-  // Drop the oldest buffered insert to stay under maxDepth. Tasks are never dropped
-  // mid-chain (they're already scheduled); only buffered inserts are shed.
+  // Would admitting a row costing `incomingBytes` breach either limit? The row budget
+  // is checked LAGGING (depth already at the cap) to preserve the original row-shed
+  // behaviour; the byte budget is checked LOOKING-AHEAD over buffered + IN-FLIGHT +
+  // incoming, so a single oversized payload is shed against BEFORE it lands AND a
+  // stalled writer's queued-but-uncommitted batches still count — one 7MB row must not
+  // overshoot the budget, and a write stall must not pile up batches past the cap.
+  const overBudget = (incomingBytes: number): boolean =>
+    depth() >= maxDepth || bufferedBytes + inFlightBytes + incomingBytes > maxBytes;
+
+  // Drop the oldest buffered insert to relieve a depth/byte overflow. Tasks are never
+  // dropped mid-chain (they're already scheduled); only buffered inserts are shed.
+  // Priority: shed PAYLOAD (debug capture) before TELEMETRY (audit-critical). When a
+  // stall forces a choice we keep the decision record and sacrifice the verbatim body
+  // — and payloads are also where the bytes are (6-7MB each), so dropping them first
+  // reclaims the most heap per shed. Byte counts are decremented in lock-step so the
+  // running total never drifts.
   const shedBufferedWrite = (): boolean => {
-    if (telemetryBuf.length >= payloadBuf.length && telemetryBuf.length > 0) telemetryBuf.shift();
-    else if (payloadBuf.length > 0) payloadBuf.shift();
-    else return false;
+    if (payloadBuf.length > 0) {
+      payloadBuf.shift();
+      bufferedBytes -= payloadBytes.shift() ?? 0;
+    } else if (telemetryBuf.length > 0) {
+      telemetryBuf.shift();
+      bufferedBytes -= telemetryBytes.shift() ?? 0;
+    } else {
+      return false;
+    }
     log("writequeue.overflow");
     return true;
   };
 
-  const admitBufferedWrite = (): boolean => {
-    if (depth() < maxDepth) return true;
-    if (shedBufferedWrite() && depth() < maxDepth) return true;
+  const admitBufferedWrite = (incomingBytes: number): boolean => {
+    if (!overBudget(incomingBytes)) return true;
+    // Keep shedding until BOTH limits clear (a single 7MB payload can blow the byte
+    // budget while many tiny rows blow the row budget). Stop if nothing is left to drop
+    // (the incoming write alone is larger than the whole budget).
+    while (overBudget(incomingBytes) && shedBufferedWrite()) {
+      /* shed until under budget or empty */
+    }
+    if (!overBudget(incomingBytes)) return true;
     log("writequeue.overflow");
     return false;
   };
@@ -173,17 +262,25 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   return {
     enqueueTelemetry(input: InsertTelemetryInput): void {
       if (stopped) return;
-      if (!admitBufferedWrite()) return;
+      const cost = telemetryCost(input);
+      if (!admitBufferedWrite(cost)) return;
       telemetryBuf.push(input);
-      if (telemetryBuf.length >= maxBatch) void doFlush();
+      telemetryBytes.push(cost);
+      bufferedBytes += cost;
+      // Eager flush on EITHER the row threshold or the byte threshold, so neither a
+      // burst of rows nor a few giant rows can grow an oversized single transaction.
+      if (telemetryBuf.length >= maxBatch || bufferedBytes >= flushBytes) void doFlush();
       else scheduleTimer();
     },
 
     enqueuePayload(input: InsertPayloadInput): void {
       if (stopped) return;
-      if (!admitBufferedWrite()) return;
+      const cost = payloadCost(input);
+      if (!admitBufferedWrite(cost)) return;
       payloadBuf.push(input);
-      if (payloadBuf.length >= maxBatch) void doFlush();
+      payloadBytes.push(cost);
+      bufferedBytes += cost;
+      if (payloadBuf.length >= maxBatch || bufferedBytes >= flushBytes) void doFlush();
       else scheduleTimer();
     },
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -14,7 +14,19 @@
 - **UX**：**不动共享 `RangeFilter` 组件**（零 e2e testid 风险）——自定义 From/To 用原生 `<input type="date">` 摆控件旁（仿 key 详情），有效区间时预设 `opacity-50` 变灰并被覆盖。窗口走 URL `?start=YYYY-MM-DD&end=YYYY-MM-DD`，**custom 胜过 preset**；半填/反序/非法日期 fail-soft 回落预设。`end` = endDate 次日 0 点（含尾日，DST 用 `setDate`）。
 - **关键点**：① 自定义模式无同比 delta（门 `!custom && today|yesterday`）、bucket 按实际跨度 `bucketForWindow`（≤2 天 hour 否则 day）。② **后端零改动**（getStats/listRequests 早收任意 epoch ms）。③ **i18n 零成本**（From/To/Apply/Clear 五语已被 key 详情用过）。④「查看全部」用 `filtersToSearch` 串 start/end 忠实带窗口跳转。
 - **TDD+验证**：`requests-filters.test` +18 例（4 个新原语 + parse/serialize round-trip + custom 胜出 + 半填回落）；`key-detail-filters.test` 8 例重构后不变绿。**admin 481 单测全绿、svelte-check 929/0/0、prettier 干净**。全在 `apps/admin`（原则 1）。分支 `worktree-dashboard-date-range`，**未提交未部署**。
+## 2026-06-26 · payload 体积治理：图片内容寻址外置 + gzip + 写队列字节背压 + 分页生成列（存储层性能；原则 7，docs/02）
 
+- **背景（Lukin）**：线上 helm.db **14GB**，实测 `freelist=0`（全 live 数据，非死页膨胀）、`request_payloads` 8090 行 ≈ 13.8GB、大量行 **6–7MB**——根因是 native passthrough 把 Claude Code 每轮重发的完整正文（base64 图 + 大 transcript）逐字落库，`insertPayload` 无上限/压缩/去重。三专家（SRE/DB/交付）评估：先写队列防 OOM(B) + 图片瘦身(A)；分页(P2)最低优先（telemetry 仅 3 万行、不在热路径）。
+- **图片 CAS（治本核心）**：新增 `store/payload-blobs.ts` 纯变换 `externalizeImages`/`rehydrateImages`——按 **sha256(解码字节)** 把 base64 图外置到新表 `payload_blobs`，正文留 `helm-blob:sha256:…` sentinel。识别 Anthropic `image.source` / OpenAI `image_url` data-URL / Gemini `inlineData` 三种 shape，>4KB 才剥。**CC 每轮重发同图 → INSERT OR IGNORE 按 sha 去重只存一份**（跨 request+upstream 列、跨行、跨轮全合一），是 10–30× 的来源。
+- **Lukin 硬约束：查看 + 重试不能坏** → `getPayload` 读时 rehydrate 还原原图。实测 admin 详情（`requests.ts:98`）与重放（`replay.ts` 用前端从 getPayload 拿到再 POST 回的体）**都走 getPayload**，故还原放在 getPayload 一处即同时满足两者，**UI/replay 零改动**。
+- **blob 保留（无引用计数表）**：写入时 sha 命中则 `ON CONFLICT DO UPDATE created_at`（在用图每轮"续命"）；prune 用与 payload **同一 cutoff** 删 blob。不变式：blob.created_at ≥ 每个引用它的 payload.created_at → 存活 payload 永不指向已删 blob（payload-cas.test 覆盖续命存活 + 孤儿回收两面）。
+- **gzip（P1-a，仅 SQLite）**：图外置后剩余文本 gzip 存 BLOB，`payload-codec.ts` 按 gzip 魔数/值类型判编码——**老明文 TEXT 行照读，新 gzip BLOB 行 gunzip**，零迁移向后兼容。**Postgres 不 gzip**（TOAST 自动压缩大 text，手动 gzip 反抵消）——有意的适配器差异。payload 列存 gzip Buffer 走原始 better-sqlite3 prepared 语句（绕开 Drizzle text 列对二进制的强转）。
+- **写队列字节背压（B，防 OOM）**：`write-queue.ts` 背压从按行（`maxDepth=10000` 行）改按字节（`maxBytes=256MB`，行数保留兜底），O(1) 维护（入队算一次字节、shed/flush 增减，不重算）；溢出**优先丢 payload 保 telemetry**；`flushBytes` 字节阈值也触发提前 flush 防 256×7MB 巨事务。根治"VACUUM 写停摆 → 行背压对 7MB 行失效 → 70GB 堆 OOM"。
+- **分页生成列（P2）**：telemetry 加 `lane`/`decided_by` 生成列 + 索引（SQLite **VIRTUAL** 无存储写放大、PG **STORED**），`pageWhere` 改用列消除 json_extract 全扫；**`model` 留 json_extract**（LIKE-contains 无法走索引，加索引无益）。**坑**：加 telemetry 列的迁移会让"部分建表"迁移 fixture（无 telemetry 表）的 ALTER 失败 → 在 `sqlite/schema.test.ts`(2 处) + `postgres/migrate.test.ts`(2 处) 的 applied-version 数组预标记新版本号（既有同模式）。
+- **迁移**：SQLite **v29**(payload_blobs)+**v30**(生成列)；Postgres **v28**(payload_blobs，bytea via customType)+**v29**(生成列)。Store 端口/类型不变；core 共享纯模块（payload-blobs/codec），两适配器各自持久化。
+- **TDD+验证**：新增 payload-blobs(12)/payload-codec(5)/sqlite payload-cas(4)/postgres payload-cas(5)/write-queue(+5) 测试；contract 既有 lane/decided_by 过滤用例双适配器覆盖生成列。**305 文件/4670 单测全绿**，typecheck+lint 干净。分支 `worktree-payload-cas-gzip-perf`。
+- **Codex review 三处修复**：① **写队列 in-flight 字节漏算**(P1，致命)——`doFlush` 把批次交给 writeChain 后 `bufferedBytes` 清零,写入卡住时反复 flush 会把无界批次堆在闭包里、字节上限测不到 → 加 `inFlightBytes`(flush 时计入、commit settle 时释放),`overBudget` 计 buffered+in-flight+incoming,**stalled writer 现在会触发 shed/拒绝**(原本根本没防住 OOM)。② **OpenAI Responses `input_image` 漏剥**(P2)——`image_url` 是字符串(非嵌套 `{url}`),externalize 只认 Chat 的嵌套形 → codex 的图没外置;改为同时认 `image_url`/`input_image` × 字符串/对象两种形,按原形回填。③ **rehydrate 不 fail-open**(P2)——正文是裸 SSE 又含 `helm-blob:` 字面量时 `JSON.parse` 抛 → 拖垮 getPayload;加 try/catch 原样返回。
+- **运维 TODO（Lukin）**：① `vacuum_enabled` 今晚已手动关（止血，已做）；② 部署后 **3 天保留期自动清空旧胖行**，再手动点一次「Compact database」(VACUUM) 收回 14GB，然后开回 auto-vacuum（届时库已 GB 级，VACUUM 秒级安全）；③ 要立刻收回不等 3 天才需流式回填脚本（**未做**，碰 14GB 文件风险高，能等就别做）。
 ## 2026-06-26 · 仪表板「昨天」视图加同比（昨天 vs 前天，整天对整天；admin UI，对应 docs/04 遥测展示）
 
 - **背景（Lukin）**：今天视图的「对比昨日」因今天未过完意义不大；「昨天」是完整一天，**昨天 vs 前天（整天对整天）才有意义**，要求给昨天视图也加同比。
@@ -22,20 +34,13 @@
 - **labels**：badge 与 tooltip 基准按 `data.range` 分流——昨天视图用 `vs day before yesterday`(对比前天)/`Day before yesterday: {value}`(前天：…)，否则沿用 `vs yesterday`/`Yesterday: {value}`。五语补两键，纳入 `dashboard-locales.test` 守卫。
 - **TDD+验证**：`dashboard-chart.test` 加前天窗口断言、`home.test` 加昨天视图 compare（整日对整日，2 次 getStats）；红→绿。**admin svelte-check 0/0、30 相关单测绿**。改动全在 `apps/admin`（原则 1）。随 **v0.21.33** 发布并部署 la.atmy.work。
 
-## 2026-06-26 · key 详情图表对齐 dashboard + 缓存命中率卡片（admin UI；对应 docs/04 遥测展示）
-
-- **背景（Lukin）**：① dashboard「缓存 Token」卡片要显缓存命中率；② key 详情页 `keys/[id]` 的两张图表要和 dashboard 一致（数据已按 key 维度，只差浮层）。
-- **诊断**：两页图表早已同构（都是 LayerChart AreaChart 趋势 + PieChart 模型环），唯一差异是 **tooltip**——dashboard 用自定义 `slot="tooltip"` 富浮层（趋势显逐桶「总花费」、环显逐模型「花费」），key 页只用 props 简易浮层（仅 token）。数据层 `aggregate(...keyId)` 本就返回 `costUsd`，key 页只是没画出来。
-- **决定**：① **缓存命中率 = cached ÷ prompt**（cached ⊆ prompt，截图 677M/740M≈91.5% 可印证），在两个 loader 里随 `successRate` 同款算，`promptTokens===0→null`；UI 作为「缓存 Token」卡片下的 subline（仿 Success rate 的 Errors 子行），**null 则整行隐藏**，不显 `—%`。② 命中率**同时上 dashboard 与 key 页**——用户只点名 dashboard，但既然要两页对齐，命中率也一并加（trivial，保持一致）。③ 把 dashboard 的富浮层**逐字搬到 key 页**（趋势补「总花费」、环补「花费」），`TrendPoint`/`ModelSlice` 补 `cost`，import `Tooltip`。
-- **i18n**：仅新增 `Hit rate: {rate}` 一个 key（图表用的 `Total cost`/`Cost` 五语已存在），五语补全（命中率/命中率/ヒット率/적중률，对齐各 locale 既有 `hit` 译法），纳入 `dashboard-locales.test` 守卫防 `i18n:sync` 漂移。
-- **验证**：`key-detail.test` fixture 补 `cacheHitRate`（Stats 新增必填字段 → 6 处 render 同源一改即修）；**admin svelte-check 0/0、103 路由单测 + 17 i18n locale 单测全绿**。改动全在 `apps/admin`（不碰 core/gateway，符合原则 1 网关与 UI 解耦）。发布 **v0.21.32** 并部署 la.atmy.work。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
+- **2026-06-26 · key 详情图表对齐 dashboard + 缓存命中率卡片（admin UI；docs/04）**：dashboard「缓存 Token」卡片加命中率 subline + key 详情 `keys/[id]` 两图对齐 dashboard。命中率 = cached÷prompt（`promptTokens===0→null` 整行隐藏），两 loader 同算；key 详情富 tooltip（趋势「总花费」/环「花费」）逐字搬自 dashboard，`TrendPoint`/`ModelSlice` 补 `cost`。i18n 加 `Hit rate`。全在 `apps/admin`（原则 1）。发 v0.21.32。
 - **2026-06-25 · 池内重试补洞：前导帧不再误提交，in-band 失败也能换账号（provider 执行；docs/04+05，原则 5/8）**：codex gpt-5.5 过载是 HTTP 200 开流后 in-band 失败（先 `response.created` 前导帧再 `response.failed`），`streamWithRetry` 在首个**原始** chunk(前导帧)就提交账号，而识别错误的 `guardPreOutputFailure` 在执行器层(高一层)→池已提交只能换 alias(被跨协议挡)。修：把 guard **下沉进池**（`OAuthPoolDeps` 注入 native/chat preamble 分类器，gemini→null），`open()` 外包 guard→首 yield 必代表真实输出，pre-output 错误帧变首 chunk 前 `UpstreamError(upstreamStatus:null)`→命中 `isRetryableTransientError`→池自动换号；空流同理。双层 guard 幂等无害，保留执行器层作纵深。pool.test +4 例，core+gateway 228 文件 3856 单测绿。并入 v0.21.31。分支 `fix-pool-preoutput-inpool-failover`。
 
 - **2026-06-25 · OAuth 池内换账号重试瞬时故障（provider 执行；docs/04 执行兜底，原则 5）**：带 Responses 原生工具(web_search/apply_patch/tool_search)的 Codex 请求，链头账号过载(`upstreamStatus:null`)后 9 个 fallback 全被 `responses_native_tools_cross_protocol_blocked` 正确跳过 → `all_providers_failed`，因 `OAuthPoolClient.select()` 每请求只挑 1 个账号、失败即交回执行器（→全跨协议挡），从不在请求内试同订阅其它账号。修：`pool.ts` 加请求内换账号重试，`isRetryableTransientError` 仅 timeout/`upstreamStatus===null`/5xx 可重试（排除 429 留执行器 park + 其它 4xx），`select(stickyKey, exclude)` 跳已试账号（单调收敛）；流式仅 pre-first-chunk 可重试（yield 过 chunk 即提交，对齐原则 8），非流式直接循环；耗尽抛最后 upstream 错让执行器走链。pool.test +7 例，core+gateway 228 文件 3852 单测绿。并入 v0.21.29。分支 `feat-oauth-pool-inretry-transient`。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.34",
+  "version": "0.21.35",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/payload-blobs.test.ts
+++ b/packages/core/src/store/payload-blobs.test.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { externalizeImages, type PayloadBlob, rehydrateImages } from "./payload-blobs.js";
+
+// A >MIN_DATA_CHARS base64 string of deterministic bytes (so dedup/sha is stable).
+function bigB64(seed: number, bytes = 6000): string {
+  const buf = Buffer.alloc(bytes);
+  for (let i = 0; i < bytes; i++) buf[i] = (i * 31 + seed) & 0xff;
+  return buf.toString("base64");
+}
+const sha = (b64: string) => createHash("sha256").update(Buffer.from(b64, "base64")).digest("hex");
+
+// fetchBlob backed by the externalize output — the round-trip's "store".
+function store(blobs: PayloadBlob[]): (s: string) => Uint8Array | null {
+  const m = new Map(blobs.map((b) => [b.sha256, b.bytes]));
+  return (s) => m.get(s) ?? null;
+}
+
+describe("externalizeImages / rehydrateImages", () => {
+  it("Anthropic image: round-trips byte-exact, externalizes the data", () => {
+    const data = bigB64(1);
+    const original = JSON.stringify({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "look" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data } },
+          ],
+        },
+      ],
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(json).not.toContain(data); // the big blob is gone from the row
+    expect(json).toContain("helm-blob:sha256:");
+    expect(blobs).toHaveLength(1);
+    expect(blobs[0]?.sha256).toBe(sha(data));
+    const restored = rehydrateImages(json, store(blobs));
+    expect(JSON.parse(restored)).toEqual(JSON.parse(original)); // semantic identity
+  });
+
+  it("OpenAI image_url data URL: round-trips and keeps the mime", () => {
+    const data = bigB64(2);
+    const original = JSON.stringify({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image_url", image_url: { url: `data:image/jpeg;base64,${data}` } }],
+        },
+      ],
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(json).not.toContain(data);
+    expect(blobs).toHaveLength(1);
+    const restored = rehydrateImages(json, store(blobs));
+    expect(JSON.parse(restored)).toEqual(JSON.parse(original));
+  });
+
+  it("Gemini inlineData: round-trips", () => {
+    const data = bigB64(3);
+    const original = JSON.stringify({
+      contents: [{ parts: [{ inlineData: { mimeType: "image/webp", data } }] }],
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(json).not.toContain(data);
+    expect(blobs).toHaveLength(1);
+    expect(JSON.parse(rehydrateImages(json, store(blobs)))).toEqual(JSON.parse(original));
+  });
+
+  it("dedups identical images across turns into ONE blob", () => {
+    const data = bigB64(4);
+    const img = { type: "image", source: { type: "base64", media_type: "image/png", data } };
+    const original = JSON.stringify({
+      messages: [
+        { role: "user", content: [img] },
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+        { role: "user", content: [img] }, // SAME image re-sent (CC behaviour)
+      ],
+    });
+    const { blobs } = externalizeImages(original);
+    expect(blobs).toHaveLength(1); // collapsed
+  });
+
+  it("leaves small data and non-image base64 alone", () => {
+    const small = Buffer.from("tiny").toString("base64");
+    const original = JSON.stringify({
+      a: { type: "image", source: { type: "base64", media_type: "image/png", data: small } },
+      note: "some short text that happens to look=like base64==",
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(blobs).toHaveLength(0);
+    expect(json).toBe(original); // untouched, byte-exact
+  });
+
+  it("no images → returns the original bytes verbatim", () => {
+    const original = JSON.stringify({ messages: [{ role: "user", content: "hi" }] });
+    const { json, blobs } = externalizeImages(original);
+    expect(blobs).toHaveLength(0);
+    expect(json).toBe(original);
+  });
+
+  it("idempotent: externalizing an already-stripped body adds no new blobs", () => {
+    const data = bigB64(5);
+    const original = JSON.stringify({
+      m: { type: "image", source: { type: "base64", media_type: "image/png", data } },
+    });
+    const first = externalizeImages(original);
+    const second = externalizeImages(first.json);
+    expect(second.blobs).toHaveLength(0);
+    expect(second.json).toBe(first.json);
+  });
+
+  it("rehydrate is fail-open when a blob is missing (sentinel kept, no throw)", () => {
+    const data = bigB64(6);
+    const original = JSON.stringify({
+      m: { type: "image", source: { type: "base64", media_type: "image/png", data } },
+    });
+    const { json } = externalizeImages(original);
+    const restored = rehydrateImages(json, () => null); // blob store empty
+    expect(restored).toContain("helm-blob:sha256:"); // left as-is, didn't crash
+  });
+
+  it("non-JSON body is stored verbatim", () => {
+    const { json, blobs } = externalizeImages("not json at all");
+    expect(json).toBe("not json at all");
+    expect(blobs).toHaveLength(0);
+  });
+
+  it("OpenAI Responses input_image (string image_url): round-trips and externalizes", () => {
+    const data = bigB64(7);
+    const original = JSON.stringify({
+      input: [
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: "what is this" },
+            { type: "input_image", image_url: `data:image/png;base64,${data}` },
+          ],
+        },
+      ],
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(json).not.toContain(data);
+    expect(blobs).toHaveLength(1);
+    expect(JSON.parse(rehydrateImages(json, store(blobs)))).toEqual(JSON.parse(original));
+  });
+
+  it("chat image_url given as a bare string: round-trips and externalizes", () => {
+    const data = bigB64(8);
+    const original = JSON.stringify({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image_url", image_url: `data:image/webp;base64,${data}` }],
+        },
+      ],
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(json).not.toContain(data);
+    expect(blobs).toHaveLength(1);
+    expect(JSON.parse(rehydrateImages(json, store(blobs)))).toEqual(JSON.parse(original));
+  });
+
+  it("rehydrate fails open on non-JSON text containing the sentinel literal", () => {
+    // Raw SSE (not a JSON document) whose model text happens to include the literal.
+    const sse = 'event: delta\ndata: {"t":"helm-blob:sha256:dead"}\n\n';
+    expect(() => rehydrateImages(sse, () => null)).not.toThrow();
+    expect(rehydrateImages(sse, () => null)).toBe(sse); // returned untouched
+  });
+});

--- a/packages/core/src/store/payload-blobs.ts
+++ b/packages/core/src/store/payload-blobs.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+
+// Content-addressed externalization of inline base64 images in a captured body.
+//
+// WHY: Claude Code (and any chat client) re-sends the ENTIRE conversation —
+// including every image as base64 — on EVERY turn. A 1 MB image in a 10-turn
+// thread is therefore stored ~10x verbatim, across many request_payloads rows
+// (and twice within one row: client request_json AND upstream_request_json). On
+// the production box this made the payload table 6-7 MB/row and the DB 14 GB.
+//
+// FIX: pull each base64 image out into a content-addressed blob (sha256 of the
+// DECODED bytes), replacing the inline data with a sentinel. Identical images
+// collapse to ONE stored blob regardless of how many turns/rows reference them.
+// rehydrateImages() restores the exact original body, so the admin payload view
+// and the request replay path (both read through getPayload) keep full fidelity.
+//
+// Pure + framework-free (core may not import Hono/SvelteKit). Recognizes the
+// three wire shapes Helm ingests: Anthropic image source, OpenAI image_url
+// `data:` URL, Gemini inlineData.
+
+export interface PayloadBlob {
+  sha256: string; // hex digest of the decoded bytes — the content address
+  bytes: Uint8Array; // DECODED binary (base64's 1.33x overhead is shed here)
+  mime: string | null; // media type, for the admin blob viewer / debugging
+}
+
+export interface ExternalizeResult {
+  json: string; // body with image data replaced by sentinels (or verbatim if none)
+  blobs: PayloadBlob[]; // de-duplicated by sha256
+}
+
+const SENTINEL_PREFIX = "helm-blob:sha256:";
+// Only externalize base64 data above this many chars. A blob row + a read-time
+// join isn't worth it for a 1 KB favicon; the 14 GB problem is all MB-scale.
+const MIN_DATA_CHARS = 4096;
+
+// OpenAI data URL with our sentinel swapped in for the base64 tail.
+const DATA_URL_SENTINEL = /^(data:.*?;base64,)helm-blob:sha256:([0-9a-f]{64})$/;
+
+function sha256hex(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+// Decode + record a base64 blob; return its sentinel, or null to leave the value
+// untouched (already a sentinel, too small, or empty).
+function stash(data: string, mime: string | null, blobs: Map<string, PayloadBlob>): string | null {
+  if (data.startsWith(SENTINEL_PREFIX) || data.length < MIN_DATA_CHARS) return null;
+  const bytes = Buffer.from(data, "base64");
+  if (bytes.length === 0) return null;
+  const sha = sha256hex(bytes);
+  if (!blobs.has(sha)) blobs.set(sha, { sha256: sha, bytes, mime });
+  return SENTINEL_PREFIX + sha;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function walkExternalize(node: unknown, blobs: Map<string, PayloadBlob>): unknown {
+  if (Array.isArray(node)) return node.map((n) => walkExternalize(n, blobs));
+  if (!isRecord(node)) return node;
+
+  // Anthropic: { type:"image", source:{ type:"base64", media_type, data } }
+  if (node.type === "image" && isRecord(node.source) && node.source.type === "base64") {
+    const src = node.source;
+    if (typeof src.data === "string") {
+      const ref = stash(src.data, (src.media_type as string | undefined) ?? null, blobs);
+      if (ref) return { ...node, source: { ...src, data: ref } };
+    }
+  }
+
+  // OpenAI Chat:      { type:"image_url",   image_url:{ url:"data:<mime>;base64,<data>" } }
+  // OpenAI Responses: { type:"input_image", image_url:"data:<mime>;base64,<data>" }  ← STRING
+  // Also tolerate a bare-string image_url on a chat part. Pull the data: URL from
+  // whichever shape, externalize it, and put the slimmed URL back in the SAME shape.
+  if (node.type === "image_url" || node.type === "input_image") {
+    const iu = node.image_url;
+    const url =
+      typeof iu === "string" ? iu : isRecord(iu) && typeof iu.url === "string" ? iu.url : null;
+    if (url !== null) {
+      const marker = ";base64,";
+      const idx = url.indexOf(marker);
+      if (idx >= 0) {
+        const head = url.slice(0, idx + marker.length); // "data:<mime>;base64,"
+        const data = url.slice(idx + marker.length);
+        const mime = url.slice("data:".length, idx) || null;
+        const ref = stash(data, mime, blobs);
+        if (ref) {
+          const newUrl = head + ref;
+          // In the non-string branch `iu` is a record (url came from iu.url via isRecord).
+          return typeof iu === "string"
+            ? { ...node, image_url: newUrl }
+            : { ...node, image_url: { ...(iu as Record<string, unknown>), url: newUrl } };
+        }
+      }
+    }
+  }
+
+  // Gemini: { inlineData:{ mimeType, data } } (camel or snake)
+  for (const key of ["inlineData", "inline_data"] as const) {
+    const inl = node[key];
+    if (isRecord(inl) && typeof inl.data === "string") {
+      const mime = (inl.mimeType ?? inl.mime_type ?? null) as string | null;
+      const ref = stash(inl.data, mime, blobs);
+      if (ref) return { ...node, [key]: { ...inl, data: ref } };
+    }
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(node)) out[k] = walkExternalize(v, blobs);
+  return out;
+}
+
+export function externalizeImages(json: string): ExternalizeResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return { json, blobs: [] }; // non-JSON (or already-broken) body → store verbatim
+  }
+  const blobs = new Map<string, PayloadBlob>();
+  const walked = walkExternalize(parsed, blobs);
+  // Nothing externalized → return the ORIGINAL bytes verbatim (preserve fidelity
+  // for bodies we didn't touch; avoids a needless re-serialization).
+  if (blobs.size === 0) return { json, blobs: [] };
+  return { json: JSON.stringify(walked), blobs: [...blobs.values()] };
+}
+
+function restoreString(s: string, fetchBlob: (sha: string) => Uint8Array | null): string {
+  if (s.startsWith(SENTINEL_PREFIX)) {
+    const bytes = fetchBlob(s.slice(SENTINEL_PREFIX.length));
+    return bytes ? Buffer.from(bytes).toString("base64") : s; // fail-open: keep sentinel
+  }
+  const m = DATA_URL_SENTINEL.exec(s);
+  if (m) {
+    const bytes = fetchBlob(m[2] as string);
+    return bytes ? `${m[1]}${Buffer.from(bytes).toString("base64")}` : s;
+  }
+  return s;
+}
+
+function walkRehydrate(node: unknown, fetchBlob: (sha: string) => Uint8Array | null): unknown {
+  if (typeof node === "string") return restoreString(node, fetchBlob);
+  if (Array.isArray(node)) return node.map((n) => walkRehydrate(n, fetchBlob));
+  if (!isRecord(node)) return node;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(node)) out[k] = walkRehydrate(v, fetchBlob);
+  return out;
+}
+
+export function rehydrateImages(
+  json: string,
+  fetchBlob: (sha: string) => Uint8Array | null,
+): string {
+  if (!json.includes(SENTINEL_PREFIX)) return json; // fast path: nothing externalized
+  // Only strings WE produced are guaranteed JSON. A captured response can be raw SSE
+  // (not a JSON document) that merely contains the literal "helm-blob:sha256:" in model
+  // text — parsing that throws. Fail open: return the original text untouched rather
+  // than break getPayload / archive reads for that request.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return json;
+  }
+  return JSON.stringify(walkRehydrate(parsed, fetchBlob));
+}

--- a/packages/core/src/store/payload-codec.test.ts
+++ b/packages/core/src/store/payload-codec.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { decodePayloadValue, encodePayloadText } from "./payload-codec.js";
+
+describe("payload-codec", () => {
+  it("gzip round-trips arbitrary unicode text", () => {
+    const text = JSON.stringify({ msg: "héllo 世界 🌍", arr: [1, 2, 3] });
+    expect(decodePayloadValue(encodePayloadText(text))).toBe(text);
+  });
+
+  it("actually shrinks repetitive transcript text", () => {
+    const text = "the quick brown fox ".repeat(2000);
+    expect(encodePayloadText(text).length).toBeLessThan(text.length / 5);
+  });
+
+  it("reads legacy TEXT rows verbatim (no gzip)", () => {
+    const legacy = '{"verbatim":"old row"}';
+    expect(decodePayloadValue(legacy)).toBe(legacy);
+  });
+
+  it("null/undefined → null", () => {
+    expect(decodePayloadValue(null)).toBeNull();
+    expect(decodePayloadValue(undefined)).toBeNull();
+  });
+
+  it("non-gzip buffer is read as utf8 (defensive)", () => {
+    expect(decodePayloadValue(Buffer.from("raw", "utf8"))).toBe("raw");
+  });
+});

--- a/packages/core/src/store/payload-codec.ts
+++ b/packages/core/src/store/payload-codec.ts
@@ -1,0 +1,30 @@
+import { gunzipSync, gzipSync } from "node:zlib";
+
+// On-disk encoding for captured payload columns. After images are externalized
+// (payload-blobs.ts) the remainder is conversation TEXT — Claude Code re-sends the
+// whole transcript every turn, so it's large and highly compressible (~5-10x).
+// We gzip it and store the bytes as a BLOB in the (text-affinity) payload column.
+//
+// Backward compatibility is by VALUE TYPE / MAGIC BYTES, not a schema column:
+//   - legacy rows: the column holds a TEXT string  → returned as-is
+//   - new rows:    the column holds gzip BLOB bytes → gunzipped
+// so old uncompressed rows keep reading correctly with zero migration.
+
+const GZIP_MAGIC_0 = 0x1f;
+const GZIP_MAGIC_1 = 0x8b;
+
+export function encodePayloadText(text: string): Buffer {
+  return gzipSync(Buffer.from(text, "utf8"));
+}
+
+// Decode a raw DB column value (better-sqlite3 returns string for TEXT, Buffer for
+// BLOB; pg returns Buffer for bytea). Null-safe.
+export function decodePayloadValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value; // legacy uncompressed row
+  const buf = Buffer.isBuffer(value) ? value : Buffer.from(value as Uint8Array);
+  if (buf.length >= 2 && buf[0] === GZIP_MAGIC_0 && buf[1] === GZIP_MAGIC_1) {
+    return gunzipSync(buf).toString("utf8");
+  }
+  return buf.toString("utf8"); // defensive: raw bytes stored without gzip
+}

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -160,8 +160,10 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // oauth_quota → pre-mark applied (out of scope).
     // v27 (pgvector + tsvector over memory_facts): this fixture never creates
     // memory_facts (+ no pgvector here) → pre-mark applied, out of scope.
+    // v29 (telemetry lane/decided_by generated columns): no telemetry table here →
+    // pre-mark applied; v28 (payload_blobs CREATE) pre-marked too (out of scope).
     // biome-ignore format: keep the version ledger on one readable line
-    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27]) {
+    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 28, 29]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
       );
@@ -259,8 +261,10 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // v26 (idx_memory_jobs_claim): no memory_jobs table in this messages fixture → pre-mark.
     // v27 (pgvector + tsvector over memory_facts): this messages fixture never creates
     // memory_facts (+ no pgvector here) → pre-mark applied, out of scope.
+    // v28 (payload_blobs) + v29 (telemetry generated columns): out of scope here too.
     for (const version of [
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27,
+      28, 29,
     ]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -544,6 +544,44 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX IF NOT EXISTS idx_memory_facts_fts ON memory_facts USING gin (to_tsvector('simple', fact_text));
     `,
   },
+  {
+    // Content-addressed image blob store (store/payload-blobs.ts) — pg mirror of
+    // the sqlite v29 migration (different ledger, same logical change). The base64
+    // images Claude Code re-sends every turn were the bulk of the prod DB; they now
+    // live ONCE here keyed by sha256 of the decoded bytes, and the request_payloads
+    // text columns hold only sentinels. bytes is BYTEA; the slimmed text is NOT
+    // gzipped here (unlike sqlite) — pg's TOAST auto-compresses large text values.
+    // The created_at index drives the same-cutoff retention prune as the payloads.
+    version: 28,
+    sql: `
+      CREATE TABLE IF NOT EXISTS payload_blobs (
+        sha256 TEXT PRIMARY KEY,
+        bytes BYTEA NOT NULL,
+        mime TEXT,
+        size INTEGER NOT NULL,
+        created_at BIGINT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_payload_blobs_created_at ON payload_blobs (created_at);
+    `,
+  },
+  {
+    // Mirror of sqlite v30: index the admin /requests lane + decided_by filters so
+    // they're an index seek, not a jsonb scan. Postgres generated columns are STORED
+    // only (no VIRTUAL), but the expression is a cheap immutable jsonb extract and
+    // telemetry rows are tiny, so the per-insert cost is negligible. `model` stays a
+    // jsonb ILIKE-contains (no index can serve it).
+    version: 29,
+    sql: `
+      ALTER TABLE telemetry ADD COLUMN IF NOT EXISTS lane TEXT
+        GENERATED ALWAYS AS (decision_json -> 'lane' ->> 'selected_lane') STORED;
+      ALTER TABLE telemetry ADD COLUMN IF NOT EXISTS decided_by TEXT
+        GENERATED ALWAYS AS (decision_json -> 'classifier' ->> 'decided_by') STORED;
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_lane ON telemetry (lane);
+      CREATE INDEX IF NOT EXISTS idx_telemetry_decided_by ON telemetry (decided_by);
+    `,
+  },
 ];
 
 // Anything that can run a raw SQL string against the Postgres connection. Both

--- a/packages/core/src/store/postgres/payload-cas.test.ts
+++ b/packages/core/src/store/postgres/payload-cas.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createPgliteDb, type PgDb } from "./migrate.js";
+import { PgTelemetryStore } from "./telemetry.js";
+
+// A >4 KB base64 blob so externalization kicks in (deterministic bytes → stable sha).
+function bigImageB64(seed = 7, bytes = 8000): string {
+  const buf = Buffer.alloc(bytes);
+  for (let i = 0; i < bytes; i++) buf[i] = (i * 17 + seed) & 0xff;
+  return buf.toString("base64");
+}
+
+function anthropicBody(data: string): string {
+  return JSON.stringify({
+    model: "claude",
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data } },
+        ],
+      },
+    ],
+  });
+}
+
+const dbs: PgDb[] = [];
+
+afterEach(async () => {
+  for (const db of dbs.splice(0)) await db.$close();
+});
+
+async function setup() {
+  const db = await createPgliteDb();
+  dbs.push(db);
+  const store = new PgTelemetryStore(db);
+  const blobCount = async () => {
+    const r = (await db.execute(
+      // biome-ignore lint/suspicious/noExplicitAny: raw count row shape
+      "SELECT COUNT(*) AS c FROM payload_blobs" as any,
+    )) as { rows?: Array<{ c: number | string }> } | Array<{ c: number | string }>;
+    const rows = Array.isArray(r) ? r : (r.rows ?? []);
+    return Number(rows[0]?.c ?? 0);
+  };
+  const rawRequestJson = async (id: string) => {
+    const r = (await db.execute(
+      // biome-ignore lint/suspicious/noExplicitAny: raw select row shape
+      `SELECT request_json AS v FROM request_payloads WHERE request_id = '${id}'` as any,
+    )) as { rows?: Array<{ v: string }> } | Array<{ v: string }>;
+    const rows = Array.isArray(r) ? r : (r.rows ?? []);
+    return rows[0]?.v ?? "";
+  };
+  return { db, store, blobCount, rawRequestJson };
+}
+
+describe("PgTelemetryStore — image CAS (Postgres, no manual gzip)", () => {
+  it("externalizes the image off-row but getPayload rehydrates it byte-exact", async () => {
+    const { store, blobCount, rawRequestJson } = await setup();
+    const data = bigImageB64();
+    const body = anthropicBody(data);
+    await store.insertPayload({
+      requestId: "r1",
+      requestJson: body,
+      responseJson: '{"ok":true}',
+      createdAt: new Date(1000),
+    });
+
+    // The fat base64 is NOT stored in the payload row (it's externalized to a blob).
+    // Postgres keeps the slimmed JSON as plain TEXT (TOAST auto-compresses) — no gzip.
+    const raw = await rawRequestJson("r1");
+    expect(raw.includes(data)).toBe(false);
+    expect(raw).toContain("helm-blob:sha256:");
+    expect(await blobCount()).toBe(1);
+
+    // getPayload restores the verbatim original body (admin view + replay fidelity).
+    const got = await store.getPayload("r1");
+    expect(JSON.parse(got?.requestJson ?? "")).toEqual(JSON.parse(body));
+    expect(got?.responseJson).toBe('{"ok":true}');
+  });
+
+  it("dedups the SAME image across request + upstream into ONE blob", async () => {
+    const { store, blobCount } = await setup();
+    const data = bigImageB64();
+    const body = anthropicBody(data);
+    await store.insertPayload({
+      requestId: "r2",
+      requestJson: body,
+      responseJson: null,
+      upstreamRequestJson: body, // same image re-appears in the upstream body
+      createdAt: new Date(1000),
+    });
+    expect(await blobCount()).toBe(1); // collapsed across both columns
+
+    // Round-trips both columns back to the verbatim originals.
+    const got = await store.getPayload("r2");
+    expect(JSON.parse(got?.requestJson ?? "")).toEqual(JSON.parse(body));
+    expect(JSON.parse(got?.upstreamRequestJson ?? "")).toEqual(JSON.parse(body));
+  });
+
+  it("prune keeps a blob still referenced by a newer payload (created_at touched)", async () => {
+    const { store, blobCount } = await setup();
+    const data = bigImageB64();
+    await store.insertPayload({
+      requestId: "old",
+      requestJson: anthropicBody(data),
+      responseJson: null,
+      createdAt: new Date(1000),
+    });
+    await store.insertPayload({
+      requestId: "new",
+      requestJson: anthropicBody(data), // SAME image, later turn → touches blob.created_at
+      responseJson: null,
+      createdAt: new Date(5000),
+    });
+    expect(await blobCount()).toBe(1);
+
+    await store.prunePayloads(3000); // drops "old", keeps "new"
+    expect(await store.getPayload("old")).toBeNull();
+    expect(await blobCount()).toBe(1); // blob survived (touched to 5000)
+    const got = await store.getPayload("new");
+    expect(JSON.parse(got?.requestJson ?? "")).toEqual(JSON.parse(anthropicBody(data)));
+  });
+
+  it("prune drops a blob whose only payload aged out", async () => {
+    const { store, blobCount } = await setup();
+    await store.insertPayload({
+      requestId: "lonely",
+      requestJson: anthropicBody(bigImageB64()),
+      responseJson: null,
+      createdAt: new Date(1000),
+    });
+    expect(await blobCount()).toBe(1);
+    await store.prunePayloads(3000);
+    expect(await blobCount()).toBe(0); // no surviving reference → reclaimed
+  });
+
+  it("selectPayloadsOlderThan rehydrates the externalized image for the archive scan", async () => {
+    const { store } = await setup();
+    const data = bigImageB64();
+    const body = anthropicBody(data);
+    await store.insertPayload({
+      requestId: "arch",
+      requestJson: body,
+      responseJson: null,
+      upstreamRequestJson: body,
+      createdAt: new Date(1000),
+    });
+    const rows = await store.selectPayloadsOlderThan(5000, 10);
+    expect(rows).toHaveLength(1);
+    expect(JSON.parse(rows[0]?.requestJson ?? "")).toEqual(JSON.parse(body));
+    expect(JSON.parse(rows[0]?.upstreamRequestJson ?? "")).toEqual(JSON.parse(body));
+  });
+});

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -1,6 +1,7 @@
 import {
   bigint,
   boolean,
+  customType,
   doublePrecision,
   integer,
   jsonb,
@@ -9,6 +10,15 @@ import {
   text,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
+
+// Postgres BYTEA — drizzle 0.45 has no built-in `bytea`, so define it once here.
+// Maps to the JS Buffer the pg/pglite driver returns for a bytea column; the
+// adapter writes Buffer.from(bytes) and reads a Buffer straight back.
+const bytea = customType<{ data: Buffer; driverData: Buffer }>({
+  dataType() {
+    return "bytea";
+  },
+});
 
 // Postgres (Drizzle pg-core) table definitions for the supabase Store adapter.
 // Same LOGICAL schema as the sqlite adapter (packages/core/src/store/sqlite/
@@ -266,6 +276,23 @@ export const requestPayloads = pgTable("request_payloads", {
   createdAt: bigint("created_at", { mode: "number" }).notNull(),
 });
 
+// Content-addressed store for base64 images pulled OUT of request_payloads
+// (store/payload-blobs.ts) — pg mirror of the sqlite payload_blobs table. Claude
+// Code re-sends every image on every turn, so the same bytes recur across many
+// rows (and twice within one row: client + upstream); keying by sha256 of the
+// DECODED bytes stores each image ONCE. bytes is BYTEA (the only binary column in
+// the pg schema). created_at is TOUCHED on every re-reference, so a still-in-use
+// image is never pruned out from under a live payload row (prune uses the same
+// retention cutoff as the payloads). Unlike sqlite, the slimmed request_payloads
+// text is NOT gzipped — pg's TOAST auto-compresses large text values.
+export const payloadBlobs = pgTable("payload_blobs", {
+  sha256: text("sha256").primaryKey(),
+  bytes: bytea("bytes").notNull(), // decoded binary (NOT base64)
+  mime: text("mime"),
+  size: integer("size").notNull(),
+  createdAt: bigint("created_at", { mode: "number" }).notNull(), // epoch ms
+});
+
 // Persisted OAuth subscription credentials (issue #38) — the pg mirror of the
 // sqlite oauth_tokens table. access_enc/refresh_enc are AES-256-GCM CIPHERTEXT
 // (TEXT, not jsonb — opaque bytes), the only reversibly-stored secrets in Helm.
@@ -340,4 +367,5 @@ export type MemoryFactsTable = typeof memoryFacts;
 export type MemoryJobsTable = typeof memoryJobs;
 export type ConfigKvTable = typeof configKv;
 export type RequestPayloadsTable = typeof requestPayloads;
+export type PayloadBlobsTable = typeof payloadBlobs;
 export type OAuthTokensTable = typeof oauthTokens;

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { type DecisionRecord, DecisionRecordSchema } from "@helm/shared";
-import { and, asc, count, desc, eq, gt, gte, lt, type SQL, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, gte, inArray, lt, type SQL, sql } from "drizzle-orm";
 import { shapeTelemetryAggregate, shapeTelemetryKeyUsage } from "../aggregate-shape.js";
+import { externalizeImages, type PayloadBlob, rehydrateImages } from "../payload-blobs.js";
 import type {
   InsertPayloadInput,
   InsertTelemetryInput,
@@ -17,7 +18,18 @@ import type {
 } from "../ports.js";
 import { likeContains } from "../sql-like.js";
 import type { PgDb } from "./migrate.js";
-import { requestPayloads, telemetry } from "./schema.js";
+import { payloadBlobs, requestPayloads, telemetry } from "./schema.js";
+
+// Sentinel left in the slimmed text by externalizeImages; we scan for these to
+// know which blobs a stored payload references, so we can pre-fetch them before
+// the SYNCHRONOUS rehydrateImages walk (pg reads are async — rehydrate is not).
+const BLOB_SHA_RE = /helm-blob:sha256:([0-9a-f]{64})/g;
+
+// The write surface shared by the top-level PgDb handle and a transaction handle:
+// both expose `insert(...)`. Typing writePayloadTx against this (not PgDb) lets it
+// accept the `tx` drizzle hands the transaction callback (a PgTransaction, which
+// lacks the PgDb `$close` lifecycle hook) without an unsound cast.
+type PgWriter = Pick<PgDb, "insert">;
 
 type TelemetryRow = typeof telemetry.$inferSelect;
 
@@ -119,14 +131,10 @@ export class PgTelemetryStore implements TelemetryStore {
     if (query.endMs !== undefined) conds.push(lt(telemetry.createdAt, query.endMs));
     if (query.status !== undefined) conds.push(eq(telemetry.finalStatus, query.status));
     if (query.apiKeyId !== undefined) conds.push(eq(telemetry.apiKeyId, query.apiKeyId));
-    if (query.decidedBy !== undefined) {
-      conds.push(
-        sql`${telemetry.decisionJson} -> 'classifier' ->> 'decided_by' = ${query.decidedBy}`,
-      );
-    }
-    if (query.lane !== undefined) {
-      conds.push(sql`${telemetry.decisionJson} -> 'lane' ->> 'selected_lane' = ${query.lane}`);
-    }
+    // lane + decided_by hit the migration-v29 STORED generated columns (indexed)
+    // instead of a jsonb extract — an index seek, no per-row jsonb scan.
+    if (query.decidedBy !== undefined) conds.push(sql`decided_by = ${query.decidedBy}`);
+    if (query.lane !== undefined) conds.push(sql`lane = ${query.lane}`);
     if (query.model !== undefined) {
       const pat = likeContains(query.model);
       conds.push(
@@ -282,27 +290,71 @@ export class PgTelemetryStore implements TelemetryStore {
     return shapeTelemetryKeyUsage(rows);
   }
 
-  // Full-payload capture. Upsert by request_id; verbatim bytes (TEXT), no
-  // redaction. createdAt stored as epoch-ms bigint to match the sqlite adapter.
-  async insertPayload(input: InsertPayloadInput): Promise<void> {
-    await this.db
+  // ── Full-payload capture (verbatim client request + assembled response) ──────
+  //
+  // The base64 images Claude Code re-sends every turn were the bulk of the prod DB.
+  // externalizeImages pulls each one into a content-addressed payload_blobs row
+  // (deduped by sha256, deduped AGAIN across the three columns of a single row),
+  // leaving only a sentinel in the stored text. getPayload reverses it, so the
+  // admin view and the replay path (both read through getPayload) see the exact
+  // original body. UNLIKE the sqlite adapter we do NOT gzip the slimmed text — pg's
+  // TOAST auto-compresses large text values, so a manual gzip would be redundant
+  // (and would defeat TOAST's own compression). The payload row + its blobs commit
+  // atomically (a half-written row would fail to rehydrate). createdAt is epoch-ms
+  // bigint to match the sqlite value space.
+
+  // Externalize images out of one column, accumulating blobs (deduped across all
+  // three columns of the row). NULL stays NULL. Returns the slimmed text.
+  private externalizeColumn(s: string | null, blobs: Map<string, PayloadBlob>): string | null {
+    if (s === null) return null;
+    const ext = externalizeImages(s);
+    for (const b of ext.blobs) if (!blobs.has(b.sha256)) blobs.set(b.sha256, b);
+    return ext.json;
+  }
+
+  // Write one payload row + its blobs inside the given transaction handle. blobs
+  // upsert by sha256, TOUCHING created_at on every reference so an in-use image
+  // always outlives the same-cutoff prune that drops its referencing payload rows.
+  private async writePayloadTx(tx: PgWriter, input: InsertPayloadInput): Promise<void> {
+    const blobs = new Map<string, PayloadBlob>();
+    const req = this.externalizeColumn(input.requestJson, blobs) ?? input.requestJson;
+    const resp = this.externalizeColumn(input.responseJson, blobs);
+    const up = this.externalizeColumn(input.upstreamRequestJson ?? null, blobs);
+    const ts = input.createdAt.getTime();
+    await tx
       .insert(requestPayloads)
       .values({
         requestId: input.requestId,
-        requestJson: input.requestJson,
-        responseJson: input.responseJson,
-        upstreamRequestJson: input.upstreamRequestJson ?? null,
-        createdAt: input.createdAt.getTime(),
+        requestJson: req,
+        responseJson: resp,
+        upstreamRequestJson: up,
+        createdAt: ts,
       })
       .onConflictDoUpdate({
         target: requestPayloads.requestId,
         set: {
-          requestJson: input.requestJson,
-          responseJson: input.responseJson,
-          upstreamRequestJson: input.upstreamRequestJson ?? null,
-          createdAt: input.createdAt.getTime(),
+          requestJson: req,
+          responseJson: resp,
+          upstreamRequestJson: up,
+          createdAt: ts,
         },
       });
+    for (const b of blobs.values()) {
+      await tx
+        .insert(payloadBlobs)
+        .values({
+          sha256: b.sha256,
+          bytes: Buffer.from(b.bytes),
+          mime: b.mime,
+          size: b.bytes.length,
+          createdAt: ts,
+        })
+        .onConflictDoUpdate({ target: payloadBlobs.sha256, set: { createdAt: ts } });
+    }
+  }
+
+  async insertPayload(input: InsertPayloadInput): Promise<void> {
+    await this.db.transaction(async (tx) => this.writePayloadTx(tx, input));
   }
 
   // Batch payload upsert (perf): all rows in ONE transaction. Per-row upsert keeps
@@ -310,27 +362,33 @@ export class PgTelemetryStore implements TelemetryStore {
   async insertPayloads(inputs: InsertPayloadInput[]): Promise<void> {
     if (inputs.length === 0) return;
     await this.db.transaction(async (tx) => {
-      for (const input of inputs) {
-        await tx
-          .insert(requestPayloads)
-          .values({
-            requestId: input.requestId,
-            requestJson: input.requestJson,
-            responseJson: input.responseJson,
-            upstreamRequestJson: input.upstreamRequestJson ?? null,
-            createdAt: input.createdAt.getTime(),
-          })
-          .onConflictDoUpdate({
-            target: requestPayloads.requestId,
-            set: {
-              requestJson: input.requestJson,
-              responseJson: input.responseJson,
-              upstreamRequestJson: input.upstreamRequestJson ?? null,
-              createdAt: input.createdAt.getTime(),
-            },
-          });
-      }
+      for (const input of inputs) await this.writePayloadTx(tx, input);
     });
+  }
+
+  // Restore the externalized images: scan the stored columns for blob sentinels,
+  // pre-fetch the referenced bytes (one async query), then run the SYNCHRONOUS
+  // rehydrate walk against that in-memory map. fail-open: a missing blob leaves the
+  // sentinel in place (rehydrateImages keeps it) rather than throwing.
+  private async rehydrateColumns(
+    cols: Array<string | null>,
+  ): Promise<(text: string | null) => string | null> {
+    const shas = new Set<string>();
+    for (const c of cols) {
+      if (c === null) continue;
+      for (const m of c.matchAll(BLOB_SHA_RE)) shas.add(m[1] as string);
+    }
+    const byteMap = new Map<string, Uint8Array>();
+    if (shas.size > 0) {
+      const rows = await this.db
+        .select({ sha256: payloadBlobs.sha256, bytes: payloadBlobs.bytes })
+        .from(payloadBlobs)
+        .where(inArray(payloadBlobs.sha256, [...shas]));
+      // pg/pglite return BYTEA as a Buffer (already a Uint8Array).
+      for (const r of rows) byteMap.set(r.sha256, r.bytes);
+    }
+    const fetchBlob = (sha: string): Uint8Array | null => byteMap.get(sha) ?? null;
+    return (text) => (text === null ? null : rehydrateImages(text, fetchBlob));
   }
 
   async getPayload(requestId: string): Promise<RequestPayload | null> {
@@ -341,18 +399,27 @@ export class PgTelemetryStore implements TelemetryStore {
       .limit(1);
     const row = rows[0];
     if (!row) return null;
+    const decode = await this.rehydrateColumns([
+      row.requestJson,
+      row.responseJson,
+      row.upstreamRequestJson,
+    ]);
     return {
       requestId: row.requestId,
-      requestJson: row.requestJson,
-      responseJson: row.responseJson,
-      upstreamRequestJson: row.upstreamRequestJson ?? null,
+      requestJson: decode(row.requestJson) ?? "",
+      responseJson: decode(row.responseJson),
+      upstreamRequestJson: decode(row.upstreamRequestJson) ?? null,
       createdAt: new Date(row.createdAt), // epoch-ms bigint → Date
     };
   }
 
-  // Retention auto-prune: drop rows strictly older than the cutoff (epoch ms).
+  // Retention auto-prune: drop rows strictly older than the cutoff (epoch ms), then
+  // the same-cutoff blob prune. Safe because an in-use image's created_at is touched
+  // on every referencing write, so blob.created_at >= every surviving payload's
+  // created_at → a kept payload never references a pruned blob.
   async prunePayloads(olderThanMs: number): Promise<void> {
     await this.db.delete(requestPayloads).where(lt(requestPayloads.createdAt, olderThanMs));
+    await this.db.delete(payloadBlobs).where(lt(payloadBlobs.createdAt, olderThanMs));
   }
 
   // Telemetry retention prune — the decision table's equivalent of prunePayloads
@@ -419,14 +486,25 @@ export class PgTelemetryStore implements TelemetryStore {
       .where(and(...conds))
       .orderBy(asc(requestPayloads.requestId))
       .limit(limit);
-    return rows.map((r) => ({
-      id: r.requestId,
-      requestId: r.requestId,
-      requestJson: r.requestJson,
-      responseJson: r.responseJson,
-      upstreamRequestJson: r.upstreamRequestJson ?? null,
-      createdAt: r.createdAt,
-    }));
+    // Columns hold sentinels for externalized images — rehydrate each row back to
+    // the verbatim original body for the archive (same as getPayload).
+    const out: RequestPayloadArchiveRow[] = [];
+    for (const r of rows) {
+      const decode = await this.rehydrateColumns([
+        r.requestJson,
+        r.responseJson,
+        r.upstreamRequestJson,
+      ]);
+      out.push({
+        id: r.requestId,
+        requestId: r.requestId,
+        requestJson: decode(r.requestJson) ?? "",
+        responseJson: decode(r.responseJson),
+        upstreamRequestJson: decode(r.upstreamRequestJson) ?? null,
+        createdAt: r.createdAt,
+      });
+    }
+    return out;
   }
 
   // Row -> DecisionRecord. Re-validates through the shared schema so a corrupted

--- a/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
+++ b/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
@@ -47,6 +47,9 @@ function seedPreV21(): string {
   // v28 alters memory_facts (+ FTS); this memory_messages-only fixture never creates
   // memory_facts → pre-mark applied (out of scope for the v21 dedup test).
   ins.run(28);
+  // v30 alters telemetry (absent here) → pre-mark; v29 (payload_blobs) out of scope too.
+  ins.run(29);
+  ins.run(30);
   raw.exec(`
     CREATE TABLE memory_messages (
       id TEXT PRIMARY KEY,

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -365,6 +365,9 @@ describe("sqlite v18 forgetting schema deltas", () => {
       rec.run(26, Date.now());
       // v27 indexes memory_jobs; this memory-only fixture never creates it → pre-mark.
       rec.run(27, Date.now());
+      // v30 alters telemetry (absent here) → pre-mark; v29 (payload_blobs) out of scope too.
+      rec.run(29, Date.now());
+      rec.run(30, Date.now());
       seed.close();
 
       expect(() => runMigrations(path)).not.toThrow();

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -642,6 +642,44 @@ const MIGRATIONS: readonly Migration[] = [
       END;
     `,
   },
+  {
+    // Content-addressed image blob store (store/payload-blobs.ts). The base64
+    // images Claude Code re-sends every turn were the entire 14 GB of the prod DB;
+    // they now live ONCE here keyed by sha256 of the decoded bytes, and the
+    // request_payloads columns hold only sentinels (+ gzipped remaining text). The
+    // created_at index drives the same-cutoff retention prune as the payloads.
+    version: 29,
+    sql: `
+      CREATE TABLE IF NOT EXISTS payload_blobs (
+        sha256 TEXT PRIMARY KEY,
+        bytes BLOB NOT NULL,
+        mime TEXT,
+        size INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_payload_blobs_created_at ON payload_blobs (created_at);
+    `,
+  },
+  {
+    // Admin /requests list filters (docs/06): lane + decided_by were filtered via
+    // json_extract(decision_json, …) — a full scan + per-row JSON parse. Promote
+    // them to VIRTUAL generated columns + indexes so the filter is an index seek.
+    // VIRTUAL (not STORED) adds NO per-row storage write-amplification — only the
+    // index is materialized; the column is computed on read/index-build. `model`
+    // stays json_extract on purpose: it's a LIKE-contains match, which no B-tree
+    // index can serve anyway.
+    version: 30,
+    sql: `
+      ALTER TABLE telemetry ADD COLUMN lane TEXT
+        GENERATED ALWAYS AS (json_extract(decision_json, '$.lane.selected_lane')) VIRTUAL;
+      ALTER TABLE telemetry ADD COLUMN decided_by TEXT
+        GENERATED ALWAYS AS (json_extract(decision_json, '$.classifier.decided_by')) VIRTUAL;
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_lane ON telemetry (lane);
+      CREATE INDEX IF NOT EXISTS idx_telemetry_decided_by ON telemetry (decided_by);
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database): void {

--- a/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
@@ -32,6 +32,9 @@ function seedPreV26(): string {
   ins.run(27);
   // v28 alters memory_facts (+ FTS), absent from this oauth_quota-only fixture → pre-mark.
   ins.run(28);
+  // v30 alters telemetry (absent here) → pre-mark; v29 (payload_blobs) out of scope too.
+  ins.run(29);
+  ins.run(30);
   raw.exec(`
     CREATE TABLE oauth_quota (
       provider_id TEXT NOT NULL,

--- a/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
@@ -43,6 +43,9 @@ function seedPreV23(): string {
   ins.run(27);
   // v28 alters memory_facts (+ FTS), absent from this oauth_usage-only fixture → pre-mark.
   ins.run(28);
+  // v30 alters telemetry (absent here) → pre-mark; v29 (payload_blobs) out of scope too.
+  ins.run(29);
+  ins.run(30);
   raw.exec(`
     CREATE TABLE oauth_usage (
       provider_id TEXT NOT NULL,

--- a/packages/core/src/store/sqlite/payload-cas.test.ts
+++ b/packages/core/src/store/sqlite/payload-cas.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { createSqliteDb } from "./migrate.js";
+import { SqliteTelemetryStore } from "./telemetry.js";
+
+// A >4 KB base64 blob so externalization kicks in (deterministic bytes → stable sha).
+function bigImageB64(seed = 7, bytes = 8000): string {
+  const buf = Buffer.alloc(bytes);
+  for (let i = 0; i < bytes; i++) buf[i] = (i * 17 + seed) & 0xff;
+  return buf.toString("base64");
+}
+
+function anthropicBody(data: string): string {
+  return JSON.stringify({
+    model: "claude",
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data } },
+        ],
+      },
+    ],
+  });
+}
+
+function setup() {
+  const db = createSqliteDb(":memory:");
+  const store = new SqliteTelemetryStore(db);
+  const blobCount = () =>
+    (db.$sqlite.prepare("SELECT COUNT(*) AS c FROM payload_blobs").get() as { c: number }).c;
+  const rawRequestJson = (id: string) =>
+    (
+      db.$sqlite
+        .prepare("SELECT request_json AS v FROM request_payloads WHERE request_id = ?")
+        .get(id) as { v: unknown }
+    ).v;
+  return { db, store, blobCount, rawRequestJson };
+}
+
+describe("SqliteTelemetryStore — image CAS + gzip", () => {
+  it("externalizes the image off-row but getPayload rehydrates it byte-exact", async () => {
+    const { store, blobCount, rawRequestJson } = setup();
+    const data = bigImageB64();
+    const body = anthropicBody(data);
+    await store.insertPayload({
+      requestId: "r1",
+      requestJson: body,
+      responseJson: '{"ok":true}',
+      createdAt: new Date(1000),
+    });
+
+    // The fat base64 is NOT stored in the payload row (it's gzipped + externalized).
+    const raw = rawRequestJson("r1");
+    expect(Buffer.isBuffer(raw)).toBe(true); // gzip BLOB, not TEXT
+    expect((raw as Buffer).includes(Buffer.from(data))).toBe(false);
+    expect(blobCount()).toBe(1);
+
+    // getPayload restores the verbatim original body (admin view + replay fidelity).
+    const got = await store.getPayload("r1");
+    expect(JSON.parse(got?.requestJson ?? "")).toEqual(JSON.parse(body));
+    expect(got?.responseJson).toBe('{"ok":true}');
+  });
+
+  it("dedups the SAME image across request + upstream into ONE blob", async () => {
+    const { store, blobCount } = setup();
+    const data = bigImageB64();
+    const body = anthropicBody(data);
+    await store.insertPayload({
+      requestId: "r2",
+      requestJson: body,
+      responseJson: null,
+      upstreamRequestJson: body, // same image re-appears in the upstream body
+      createdAt: new Date(1000),
+    });
+    expect(blobCount()).toBe(1); // collapsed across both columns
+  });
+
+  it("prune keeps a blob still referenced by a newer payload (created_at touched)", async () => {
+    const { store, blobCount } = setup();
+    const data = bigImageB64();
+    await store.insertPayload({
+      requestId: "old",
+      requestJson: anthropicBody(data),
+      responseJson: null,
+      createdAt: new Date(1000),
+    });
+    await store.insertPayload({
+      requestId: "new",
+      requestJson: anthropicBody(data), // SAME image, later turn → touches blob.created_at
+      responseJson: null,
+      createdAt: new Date(5000),
+    });
+    expect(blobCount()).toBe(1);
+
+    await store.prunePayloads(3000); // drops "old", keeps "new"
+    expect(await store.getPayload("old")).toBeNull();
+    expect(blobCount()).toBe(1); // blob survived (touched to 5000)
+    const got = await store.getPayload("new");
+    expect(JSON.parse(got?.requestJson ?? "")).toEqual(JSON.parse(anthropicBody(data)));
+  });
+
+  it("prune drops a blob whose only payload aged out", async () => {
+    const { store, blobCount } = setup();
+    await store.insertPayload({
+      requestId: "lonely",
+      requestJson: anthropicBody(bigImageB64()),
+      responseJson: null,
+      createdAt: new Date(1000),
+    });
+    expect(blobCount()).toBe(1);
+    await store.prunePayloads(3000);
+    expect(blobCount()).toBe(0); // no surviving reference → reclaimed
+  });
+});

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -66,8 +66,10 @@ describe("sqlite schema + migrations", () => {
       // pre-mark applied, out of scope.
       // v28 alters memory_facts (+ FTS); this memory_jobs-only fixture never creates
       // memory_facts → pre-mark applied (out of scope for this v14–v16 test).
+      // v30 alters telemetry (absent from this memory_jobs-only fixture) → pre-mark
+      // applied; v29 (payload_blobs CREATE) has no dependency but pre-marked too.
       // biome-ignore format: keep the version ledger on one readable line
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28])
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28, 29, 30])
         rec.run(v, Date.now());
       const insert = seed.prepare(
         "INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -275,7 +277,8 @@ describe("sqlite schema + migrations", () => {
       // api_keys-only fixture) → pre-mark applied.
       // v25 (telemetry.generation_ms): no telemetry table here → pre-mark applied.
       // v28 alters memory_facts (absent from this api_keys-only fixture) → pre-mark.
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22, 24, 25, 28])
+      // v30 alters telemetry (absent here) → pre-mark; v29 (payload_blobs) pre-marked too.
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22, 24, 25, 28, 29, 30])
         rec.run(v, Date.now());
       seed
         .prepare(

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -1,4 +1,4 @@
-import { integer, primaryKey, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { blob, integer, primaryKey, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 // SQLite (Drizzle) table definitions for the sqlite Store adapter. Columns align
 // with docs/06 (api_keys) and docs/02 (telemetry / decision record). Dialect
@@ -151,6 +151,20 @@ export const requestPayloads = sqliteTable("request_payloads", {
   // EXACT body forwarded upstream (post memory-inject + protocol-translation). NULL
   // when capture off / no provider served / pre-feature row. NO plaintext key.
   upstreamRequestJson: text("upstream_request_json"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+});
+
+// Content-addressed store for base64 images pulled OUT of request_payloads
+// (store/payload-blobs.ts). Claude Code re-sends every image on every turn, so the
+// same bytes recur across many rows (and twice within one row: client + upstream);
+// keying by sha256 of the DECODED bytes stores each image ONCE. created_at is
+// TOUCHED on every re-reference, so a still-in-use image is never pruned out from
+// under a live payload row (prune uses the same retention cutoff as the payloads).
+export const payloadBlobs = sqliteTable("payload_blobs", {
+  sha256: text("sha256").primaryKey(),
+  bytes: blob("bytes").notNull(), // decoded binary (NOT base64)
+  mime: text("mime"),
+  size: integer("size").notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
 });
 

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 import { type DecisionRecord, DecisionRecordSchema } from "@helm/shared";
 import { and, asc, count, desc, eq, gt, gte, lt, type SQL, sql } from "drizzle-orm";
 import { shapeTelemetryAggregate, shapeTelemetryKeyUsage } from "../aggregate-shape.js";
+import { externalizeImages, type PayloadBlob, rehydrateImages } from "../payload-blobs.js";
+import { decodePayloadValue, encodePayloadText } from "../payload-codec.js";
 import type {
   InsertPayloadInput,
   InsertTelemetryInput,
@@ -17,7 +19,7 @@ import type {
 } from "../ports.js";
 import { likeContains } from "../sql-like.js";
 import type { SqliteDb } from "./migrate.js";
-import { requestPayloads, telemetry } from "./schema.js";
+import { payloadBlobs, requestPayloads, telemetry } from "./schema.js";
 
 type TelemetryRow = typeof telemetry.$inferSelect;
 
@@ -116,16 +118,10 @@ export class SqliteTelemetryStore implements TelemetryStore {
     if (query.endMs !== undefined) conds.push(lt(telemetry.createdAt, new Date(query.endMs)));
     if (query.status !== undefined) conds.push(eq(telemetry.finalStatus, query.status));
     if (query.apiKeyId !== undefined) conds.push(eq(telemetry.apiKeyId, query.apiKeyId));
-    if (query.decidedBy !== undefined) {
-      conds.push(
-        sql`json_extract(${telemetry.decisionJson}, '$.classifier.decided_by') = ${query.decidedBy}`,
-      );
-    }
-    if (query.lane !== undefined) {
-      conds.push(
-        sql`json_extract(${telemetry.decisionJson}, '$.lane.selected_lane') = ${query.lane}`,
-      );
-    }
+    // lane + decided_by hit the migration-v30 generated columns (indexed) instead
+    // of json_extract — an index seek, no per-row JSON parse.
+    if (query.decidedBy !== undefined) conds.push(sql`decided_by = ${query.decidedBy}`);
+    if (query.lane !== undefined) conds.push(sql`lane = ${query.lane}`);
     if (query.model !== undefined) {
       const pat = likeContains(query.model);
       conds.push(
@@ -286,59 +282,114 @@ export class SqliteTelemetryStore implements TelemetryStore {
     return shapeTelemetryKeyUsage(rows);
   }
 
-  // Full-payload capture. Upsert by request_id so the stream path can write the
-  // request first then backfill the assembled response. Verbatim bytes — no
-  // redaction (the table holds no plaintext key; see schema/ports comments).
-  // Upsert one payload row (request first, then response backfill — same key).
-  private upsertPayload(input: InsertPayloadInput): void {
-    this.db
-      .insert(requestPayloads)
-      .values({
-        requestId: input.requestId,
-        requestJson: input.requestJson,
-        responseJson: input.responseJson,
-        upstreamRequestJson: input.upstreamRequestJson ?? null,
-        createdAt: input.createdAt,
-      })
-      .onConflictDoUpdate({
-        target: requestPayloads.requestId,
-        set: {
-          requestJson: input.requestJson,
-          responseJson: input.responseJson,
-          upstreamRequestJson: input.upstreamRequestJson ?? null,
-          createdAt: input.createdAt,
-        },
-      })
-      .run();
+  // ── Full-payload capture (verbatim client request + assembled response) ──────
+  //
+  // Two transforms keep what was 6-7 MB/row (the prod 14 GB) small WITHOUT losing
+  // any fidelity — getPayload reverses both, so the admin view and the replay path
+  // (which both read through getPayload) see the exact original body:
+  //   1. externalizeImages → base64 images become content-addressed payload_blobs
+  //      rows, deduped by sha256 (Claude Code re-sends the same image every turn).
+  //      Each blob's created_at is TOUCHED on every write so an in-use image always
+  //      outlives the same-cutoff prune that drops its referencing payload rows.
+  //   2. encodePayloadText → gzip the remaining (image-stripped) JSON text.
+  // Stored via raw SQL because the gzip bytes are a BLOB in a TEXT-affinity column
+  // (legacy rows stay TEXT and read back verbatim — see payload-codec.ts). Upsert
+  // by request_id: the stream path writes the request first, then backfills.
+  private preparedStmts: ReturnType<SqliteTelemetryStore["buildPayloadStmts"]> | undefined;
+  private buildPayloadStmts() {
+    const db = this.db.$sqlite;
+    return {
+      put: db.prepare(
+        `INSERT INTO request_payloads (request_id, request_json, response_json, upstream_request_json, created_at)
+         VALUES (@id, @req, @resp, @up, @ts)
+         ON CONFLICT(request_id) DO UPDATE SET
+           request_json = excluded.request_json,
+           response_json = excluded.response_json,
+           upstream_request_json = excluded.upstream_request_json,
+           created_at = excluded.created_at`,
+      ),
+      putBlob: db.prepare(
+        `INSERT INTO payload_blobs (sha256, bytes, mime, size, created_at)
+         VALUES (@sha, @bytes, @mime, @size, @ts)
+         ON CONFLICT(sha256) DO UPDATE SET created_at = excluded.created_at`,
+      ),
+      get: db.prepare(
+        `SELECT request_json AS req, response_json AS resp, upstream_request_json AS up, created_at AS ts
+         FROM request_payloads WHERE request_id = ?`,
+      ),
+      getBlob: db.prepare("SELECT bytes FROM payload_blobs WHERE sha256 = ?"),
+    };
+  }
+  private stmts() {
+    if (!this.preparedStmts) this.preparedStmts = this.buildPayloadStmts();
+    return this.preparedStmts;
+  }
+
+  // Externalize images out of one column, accumulating blobs (deduped across all
+  // three columns of the row), then gzip the slimmed text. NULL stays NULL.
+  private encodeColumn(s: string | null, blobs: Map<string, PayloadBlob>): Buffer | null {
+    if (s === null) return null;
+    const ext = externalizeImages(s);
+    for (const b of ext.blobs) if (!blobs.has(b.sha256)) blobs.set(b.sha256, b);
+    return encodePayloadText(ext.json);
+  }
+
+  // gunzip (if gzipped) then restore externalized images. Reused by getPayload and
+  // the archive scan so both yield the verbatim original body.
+  private decodeColumn = (v: unknown): string | null => {
+    const text = decodePayloadValue(v);
+    return text === null ? null : rehydrateImages(text, this.fetchBlob);
+  };
+
+  private fetchBlob = (sha: string): Uint8Array | null => {
+    const r = this.stmts().getBlob.get(sha) as { bytes: Buffer } | undefined;
+    return r?.bytes ?? null;
+  };
+
+  private writePayloadRaw(input: InsertPayloadInput): void {
+    const blobs = new Map<string, PayloadBlob>();
+    const req = this.encodeColumn(input.requestJson, blobs);
+    const resp = this.encodeColumn(input.responseJson, blobs);
+    const up = this.encodeColumn(input.upstreamRequestJson ?? null, blobs);
+    const ts = input.createdAt.getTime();
+    this.stmts().put.run({ id: input.requestId, req, resp, up, ts });
+    for (const b of blobs.values()) {
+      this.stmts().putBlob.run({
+        sha: b.sha256,
+        bytes: Buffer.from(b.bytes),
+        mime: b.mime,
+        size: b.bytes.length,
+        ts,
+      });
+    }
   }
 
   async insertPayload(input: InsertPayloadInput): Promise<void> {
-    this.upsertPayload(input);
+    // Payload row + its blobs commit atomically (a half-written row would fail to
+    // rehydrate). better-sqlite3 nests via savepoints, so this is safe inside the
+    // batch transaction below too.
+    this.db.$sqlite.transaction(() => this.writePayloadRaw(input))();
   }
 
-  // Batch payload upsert (perf): all rows in ONE transaction = ONE commit. Reuses
-  // the single-row upsert so the per-row conflict semantics are identical.
+  // Batch payload upsert (perf): all rows in ONE transaction = ONE commit.
   async insertPayloads(inputs: InsertPayloadInput[]): Promise<void> {
     if (inputs.length === 0) return;
-    const run = this.db.$sqlite.transaction(() => {
-      for (const input of inputs) this.upsertPayload(input);
-    });
-    run();
+    this.db.$sqlite.transaction(() => {
+      for (const input of inputs) this.writePayloadRaw(input);
+    })();
   }
 
   async getPayload(requestId: string): Promise<RequestPayload | null> {
-    const row = this.db
-      .select()
-      .from(requestPayloads)
-      .where(eq(requestPayloads.requestId, requestId))
-      .get();
+    const row = this.stmts().get.get(requestId) as
+      | { req: unknown; resp: unknown; up: unknown; ts: number }
+      | undefined;
     if (!row) return null;
     return {
-      requestId: row.requestId,
-      requestJson: row.requestJson,
-      responseJson: row.responseJson,
-      upstreamRequestJson: row.upstreamRequestJson ?? null,
-      createdAt: row.createdAt, // timestamp_ms mode → Date
+      requestId,
+      requestJson: this.decodeColumn(row.req) ?? "",
+      responseJson: this.decodeColumn(row.resp),
+      upstreamRequestJson: this.decodeColumn(row.up),
+      createdAt: new Date(row.ts),
     };
   }
 
@@ -348,6 +399,13 @@ export class SqliteTelemetryStore implements TelemetryStore {
     this.db
       .delete(requestPayloads)
       .where(lt(requestPayloads.createdAt, new Date(olderThanMs)))
+      .run();
+    // Same-cutoff blob prune. Safe because an in-use image's created_at is touched
+    // on every referencing write, so blob.created_at >= every surviving payload's
+    // created_at → a kept payload never references a pruned blob.
+    this.db
+      .delete(payloadBlobs)
+      .where(lt(payloadBlobs.createdAt, new Date(olderThanMs)))
       .run();
   }
 
@@ -423,9 +481,11 @@ export class SqliteTelemetryStore implements TelemetryStore {
       .map((r) => ({
         id: r.requestId,
         requestId: r.requestId,
-        requestJson: r.requestJson,
-        responseJson: r.responseJson,
-        upstreamRequestJson: r.upstreamRequestJson ?? null,
+        // Columns may be gzip BLOBs with externalized images (new rows) or verbatim
+        // TEXT (legacy) — decode both back to the original body for the archive.
+        requestJson: this.decodeColumn(r.requestJson) ?? "",
+        responseJson: this.decodeColumn(r.responseJson),
+        upstreamRequestJson: this.decodeColumn(r.upstreamRequestJson ?? null),
         createdAt: r.createdAt.getTime(),
       }));
   }


### PR DESCRIPTION
## Why

Production SQLite (`la.atmy.work`) hit **14 GB**. Empirically: `freelist=0` (all live data, not dead-page bloat), `request_payloads` ≈ 13.8 GB across only ~8k rows — many rows **6–7 MB** because native passthrough stored Claude Code's full request/response bodies (base64 images + giant transcripts, re-sent every turn) verbatim. `insertPayload` had no size cap, no compression, no dedup.

Three independent expert reviews (SRE / DB / delivery) converged: stop the OOM path + shrink payloads first; pagination last.

## What

- **Image content-addressing (the root-cause fix)** — `store/payload-blobs.ts`: base64 images are externalized to a new `payload_blobs` table keyed by `sha256(decoded bytes)` and **deduped** (the same image, re-sent every turn and duplicated across the client + upstream columns, is now stored once). A sentinel is left inline. `getPayload` rehydrates the original body, so **the admin payload view and the request replay path keep full fidelity with zero UI/replay changes** (both already read through `getPayload`). Recognizes Anthropic `image.source`, OpenAI Chat `image_url`, OpenAI Responses `input_image`, and Gemini `inlineData`.
- **gzip remaining text** — `store/payload-codec.ts` (SQLite only; Postgres relies on TOAST). Backward-compatible reads: legacy TEXT rows read verbatim, new gzip BLOB rows are gunzipped (magic-byte detection, no data migration).
- **Write-queue byte backpressure** — `runtime/write-queue.ts`: row-count cap → byte budget (256 MB) counting **buffered + in-flight** batches, sheds payload-before-telemetry. Closes the "4am VACUUM holds the write lock → unbounded queued 7 MB batches → OOM" path the old row-count cap couldn't see.
- **Indexed admin filters** — `lane` / `decided_by` generated columns + indexes (SQLite `VIRTUAL`, Postgres `STORED`); `pageWhere` uses them instead of `json_extract` full scans. `model` stays `LIKE` (a contains-match no index can serve).
- **Migrations**: SQLite v29 (`payload_blobs`) + v30 (generated columns); Postgres v28 + v29.

## Retention / ops (no code, after deploy)

The DB is the *designed* 14 GB given 3-day retention × multi-MB rows — it shrinks once new writes are thin. `vacuum_enabled` is already off (stop-gap). Post-deploy: wait out the 3-day retention so old fat rows age out, click **Compact database** (VACUUM) once to reclaim, then re-enable auto-vacuum (DB is now GB-scale → VACUUM is seconds). No historical backfill script — touching the 14 GB file is riskier than waiting 3 days.

## Tests

- New: `payload-blobs` (12), `payload-codec` (5), sqlite/pg `payload-cas` (4/5), write-queue (+5, incl. the stalled-writer in-flight-byte bound).
- Store contract exercises `lane`/`decided_by` filters on **both** adapters.
- Telemetry-ALTER migrations required pre-marking v29/v30 in 6 partial-DB migration fixtures.
- **305 files / 4670 unit tests green; `typecheck` + `lint` clean.** Codex review run; its 3 findings (in-flight byte accounting, Responses `input_image`, rehydrate fail-open) are fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
