### PR TITLE
chore(release): v0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.21.35",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Minor version bump to **v0.22.0** to reflect the size of the payload storage-layer feature shipped in #389 (image content-addressing + dedup, gzip, write-queue byte backpressure, indexed admin filters). Code is unchanged from #389 — this is a version-policy bump (minor, not patch) for a feature-level change.

`publish.yml` will auto-cut the `v0.22.0` tag + GitHub Release + Docker image on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)