### PR TITLE
fix(cleanup): await stream close so a failed archive never orphans a run dir

### DIFF
--- a/packages/core/src/cleanup/archive/local-volume-sink.test.ts
+++ b/packages/core/src/cleanup/archive/local-volume-sink.test.ts
@@ -69,6 +69,26 @@ describe("LocalVolumeSink", () => {
     expect(entries).toEqual([]);
   });
 
+  it("never orphans a run dir across repeated mid-stream failures (close-before-rm race guard)", async () => {
+    // The cleanup destroys the write stream then rm's the temp file + rmdir's the run
+    // dir. If destroy() isn't awaited, an in-flight open() can recreate the .tmp after
+    // the rm, so rmdir finds a non-empty dir → orphan folder (flaky under load). Run
+    // many failed archives; with the fix EVERY one cleans up after itself.
+    base = join(tmpdir(), `helm-archive-${randomUUID()}`);
+    const sink = new LocalVolumeSink(base);
+    async function* boom(): AsyncIterable<unknown> {
+      yield { id: "a" };
+      throw new Error("stream blew up");
+    }
+    for (let i = 0; i < 30; i++) {
+      await expect(sink.archiveTable(`run${i}`, "telemetry", boom())).rejects.toThrow(
+        "stream blew up",
+      );
+    }
+    const entries = await readdir(base).catch(() => []);
+    expect(entries).toEqual([]); // no orphan run dirs from any iteration
+  });
+
   it("removes the run dir when the pre-flight space check fails (no orphan folder)", async () => {
     base = join(tmpdir(), `helm-archive-${randomUUID()}`);
     const sink = new LocalVolumeSink(base, { minFreeBytes: Number.MAX_SAFE_INTEGER });

--- a/packages/core/src/cleanup/archive/local-volume-sink.ts
+++ b/packages/core/src/cleanup/archive/local-volume-sink.ts
@@ -3,13 +3,29 @@ import { once } from "node:events";
 import { createWriteStream } from "node:fs";
 import { mkdir, open, rename, rm, rmdir, stat, statfs, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import type { Writable } from "node:stream";
 import { createGzip } from "node:zlib";
+
 import {
   ArchiveDiskFullError,
   type ArchivedTableResult,
   type ArchiveManifest,
   type ArchiveSink,
 } from "./types.js";
+
+// Destroy a stream and AWAIT its 'close' so the underlying file handle is released
+// before we touch the filesystem. destroy() is async — without awaiting close, a
+// still-in-flight createWriteStream open() can land AFTER we rm the temp file,
+// recreating it, so the non-recursive rmdir then finds a non-empty dir and orphans
+// an empty <runId>/ folder (the flaky-under-load failure). Idempotent: a stream
+// already destroyed resolves immediately.
+async function closeStream(s: Writable | undefined): Promise<void> {
+  if (!s || s.destroyed) return;
+  await new Promise<void>((resolve) => {
+    s.once("close", () => resolve());
+    s.destroy();
+  });
+}
 
 export interface LocalVolumeSinkOptions {
   // Refuse to start a table archive when the volume's free space is below this many
@@ -77,13 +93,15 @@ export class LocalVolumeSink implements ArchiveSink {
       }
       await rename(tmpPath, finalPath);
     } catch (err) {
-      // Leave NO residue: drop the temp file, AND remove the run dir if THIS failure
-      // left it empty — a non-recursive rmdir only deletes an empty dir, so a sibling
-      // table's already-archived .gz keeps it. Without this, every failed/aborted
-      // archive (the gzip-choke incident) orphaned an empty <runId>/ folder. Re-throw
-      // so the runner skips the delete for this table (rows survive).
-      gz?.destroy();
-      out?.destroy();
+      // Leave NO residue. FIRST fully close the streams (await — destroy() is async;
+      // an in-flight open/write can otherwise recreate the .tmp after we delete it).
+      // THEN drop the temp file, AND remove the run dir if THIS failure left it empty
+      // — a non-recursive rmdir only deletes an empty dir, so a sibling table's
+      // already-archived .gz keeps it. Without the await, the open raced the rm and
+      // orphaned an empty <runId>/ folder under load. Re-throw so the runner skips the
+      // delete for this table (rows survive).
+      await closeStream(gz);
+      await closeStream(out);
       await rm(tmpPath, { force: true }).catch(() => {});
       await rmdir(dir).catch(() => {});
       throw err;


### PR DESCRIPTION
Fixes the flaky `local-volume-sink.test.ts` failure seen in CI under parallel load.

**Root cause:** on a mid-stream archive failure the cleanup did `gz.destroy(); out.destroy()` (fire-and-forget) then `rm(tmp)` + non-recursive `rmdir(dir)`. `destroy()` is async, so an in-flight `createWriteStream` open could recreate the `.tmp` *after* the `rm` — `rmdir` then saw a non-empty dir and left an orphan `<runId>/` folder.

**Fix:** await each stream's `close` before touching the filesystem. Adds a 30-iteration race-guard test. Not in the deployed runtime path (archive is opt-in, off on prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)