### PR TITLE
fix(admin): cap custom date pickers at today (no future days)

### DIFF
--- a/apps/admin/src/lib/requests-filters.test.ts
+++ b/apps/admin/src/lib/requests-filters.test.ts
@@ -9,6 +9,7 @@ import {
   parseRange,
   resolveCustomDayWindow,
   resolveWindow,
+  todayLocalDate,
 } from './requests-filters.js';
 
 describe('parseFilters', () => {
@@ -145,6 +146,18 @@ describe('localMidnightMs', () => {
     expect(localMidnightMs('2026-06-31')).toBeNull(); // June has 30 days
     expect(localMidnightMs('2026-13-01')).toBeNull();
     expect(localMidnightMs('nope')).toBeNull();
+  });
+});
+
+describe('todayLocalDate', () => {
+  it("formats the viewer's local day as zero-padded YYYY-MM-DD", () => {
+    // Local constructor (not UTC) so the assertion is timezone-independent.
+    expect(todayLocalDate(new Date(2026, 5, 26, 14, 30).getTime())).toBe('2026-06-26');
+    expect(todayLocalDate(new Date(2026, 0, 5, 0, 0).getTime())).toBe('2026-01-05'); // padding
+  });
+
+  it('is round-trippable through localMidnightMs (a real calendar day)', () => {
+    expect(localMidnightMs(todayLocalDate(new Date(2026, 11, 1).getTime()))).not.toBeNull();
   });
 });
 

--- a/apps/admin/src/lib/requests-filters.ts
+++ b/apps/admin/src/lib/requests-filters.ts
@@ -176,6 +176,17 @@ export function isValidDateParam(date: string | undefined): date is string {
   return date !== undefined && localMidnightMs(date) !== null;
 }
 
+// The viewer's local calendar 'today' as 'YYYY-MM-DD' — the latest day a custom range
+// may select, since future days have no data yet (used as the date inputs' `max`).
+// Built from local Y/M/D, NOT toISOString() (which is UTC and would jump a day near
+// midnight for non-UTC viewers).
+export function todayLocalDate(nowMs: number = Date.now()): string {
+  const d = new Date(nowMs);
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+
 // Resolve a custom calendar-day range to a half-open window [start, end) in epoch ms
 // (viewer-local). `end` is midnight of the day AFTER endDate so the end day is
 // INCLUDED. null when either date isn't a real day or start > end — the caller then

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -9,7 +9,12 @@
   import TokensCell from '$lib/components/TokensCell.svelte';
   import { formatTrendTick, trendAxisTicks, type TrendBucket } from '$lib/dashboard-chart.js';
   import { formatCount, formatTimestamp, formatTokens, formatTps, formatUsd } from '$lib/format.js';
-  import { DEFAULT_PAGE_SIZE, filtersToSearch, type RangeKey } from '$lib/requests-filters.js';
+  import {
+    DEFAULT_PAGE_SIZE,
+    filtersToSearch,
+    type RangeKey,
+    todayLocalDate,
+  } from '$lib/requests-filters.js';
   import { t } from '$lib/i18n';
 
   type Stats = {
@@ -150,6 +155,8 @@
     customStart = data.startDate ?? '';
     customEnd = data.endDate ?? '';
   });
+  // Future days have no data → cap both pickers at the viewer's local today.
+  const today = todayLocalDate();
   const customActive = $derived(Boolean(data.startDate && data.endDate));
 
   // Apply the custom day range (only when both ends are set); the loader re-reads
@@ -268,7 +275,7 @@
           type="date"
           class="input mt-0.5"
           bind:value={customStart}
-          max={customEnd || undefined}
+          max={customEnd && customEnd < today ? customEnd : today}
         />
       </label>
       <label class="flex flex-col text-xs text-slate-500">
@@ -278,6 +285,7 @@
           class="input mt-0.5"
           bind:value={customEnd}
           min={customStart || undefined}
+          max={today}
         />
       </label>
       <button

--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -23,7 +23,7 @@
     keyDetailFiltersToSearch,
   } from '$lib/key-detail-filters.js';
   import { paginationItems } from '$lib/pagination.js';
-  import type { RangeKey } from '$lib/requests-filters.js';
+  import { type RangeKey, todayLocalDate } from '$lib/requests-filters.js';
   import { t } from '$lib/i18n';
 
   type Stats = {
@@ -69,6 +69,8 @@
     customStart = data.filters.startDate ?? '';
     customEnd = data.filters.endDate ?? '';
   });
+  // Future days have no data → cap both pickers at the viewer's local today.
+  const today = todayLocalDate();
 
   function applyFilters(next: KeyDetailFilters): void {
     const qs = keyDetailFiltersToSearch(next);
@@ -81,7 +83,12 @@
   // Apply the custom day range (only when both ends are set); resets to page 1.
   function applyCustom(): void {
     if (!customStart || !customEnd) return;
-    applyFilters({ range: data.filters.range, startDate: customStart, endDate: customEnd, page: 1 });
+    applyFilters({
+      range: data.filters.range,
+      startDate: customStart,
+      endDate: customEnd,
+      page: 1,
+    });
   }
   // Drop back to the default preset.
   function clearCustom(): void {
@@ -122,14 +129,33 @@
   );
   const trendTicks = $derived(trendAxisTicks(trend));
   const TREND_SERIES = $derived([
-    { key: 'input', label: $t('Input tokens'), value: (d: TrendPoint) => d.input, color: 'hsl(217 91% 60%)' },
-    { key: 'output', label: $t('Output tokens'), value: (d: TrendPoint) => d.output, color: 'hsl(160 84% 39%)' },
-    { key: 'cached', label: $t('Cached tokens'), value: (d: TrendPoint) => d.cached, color: 'hsl(38 92% 50%)' },
+    {
+      key: 'input',
+      label: $t('Input tokens'),
+      value: (d: TrendPoint) => d.input,
+      color: 'hsl(217 91% 60%)',
+    },
+    {
+      key: 'output',
+      label: $t('Output tokens'),
+      value: (d: TrendPoint) => d.output,
+      color: 'hsl(160 84% 39%)',
+    },
+    {
+      key: 'cached',
+      label: $t('Cached tokens'),
+      value: (d: TrendPoint) => d.cached,
+      color: 'hsl(38 92% 50%)',
+    },
   ]);
   const byModel = $derived<ModelSlice[]>(
     data.agg.byModel
       .filter((m) => m.totalTokens > 0)
-      .map((m) => ({ model: m.servedModel ?? $t('unknown'), tokens: m.totalTokens, cost: m.costUsd })),
+      .map((m) => ({
+        model: m.servedModel ?? $t('unknown'),
+        tokens: m.totalTokens,
+        cost: m.costUsd,
+      })),
   );
   const SLICE_COLORS = [
     'hsl(var(--color-primary))',
@@ -270,9 +296,8 @@
                already learned, and the memory page resolves the scope from the key's
                config (account + memory_project_id) regardless of mode — without this a
                switched-off key has no path to its accumulated memory. -->
-          <a
-            class="link-inline ml-1"
-            href={`${base}/memory?key=${encodeURIComponent(data.keyId)}`}>{$t('Manage memory')} →</a
+          <a class="link-inline ml-1" href={`${base}/memory?key=${encodeURIComponent(data.keyId)}`}
+            >{$t('Manage memory')} →</a
           >
         </dd>
       </div>
@@ -290,11 +315,22 @@
       <div class="flex flex-wrap items-end gap-2">
         <label class="flex flex-col text-xs text-slate-500">
           {$t('From')}
-          <input type="date" class="input mt-0.5" bind:value={customStart} max={customEnd || undefined} />
+          <input
+            type="date"
+            class="input mt-0.5"
+            bind:value={customStart}
+            max={customEnd && customEnd < today ? customEnd : today}
+          />
         </label>
         <label class="flex flex-col text-xs text-slate-500">
           {$t('To')}
-          <input type="date" class="input mt-0.5" bind:value={customEnd} min={customStart || undefined} />
+          <input
+            type="date"
+            class="input mt-0.5"
+            bind:value={customEnd}
+            min={customStart || undefined}
+            max={today}
+          />
         </label>
         <button
           type="button"
@@ -350,13 +386,17 @@
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
         {$t('Total tokens')}
       </div>
-      <div class="mt-1 text-2xl font-semibold text-slate-900">{formatTokens(stats.totalTokens)}</div>
+      <div class="mt-1 text-2xl font-semibold text-slate-900">
+        {formatTokens(stats.totalTokens)}
+      </div>
     </div>
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">
         {$t('Input tokens')}
       </div>
-      <div class="mt-1 text-2xl font-semibold text-slate-900">{formatTokens(stats.inputTokens)}</div>
+      <div class="mt-1 text-2xl font-semibold text-slate-900">
+        {formatTokens(stats.inputTokens)}
+      </div>
     </div>
     <div class="card">
       <div class="text-xs font-medium uppercase tracking-wide text-slate-400">

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -15,6 +15,7 @@
     PAGE_SIZE_OPTIONS,
     type RangeKey,
     type RequestsFilters,
+    todayLocalDate,
   } from '$lib/requests-filters.js';
   import { t } from '$lib/i18n';
 
@@ -51,6 +52,8 @@
   // (?start=&end=) and OVERRIDES the preset; these mirror it, re-synced below.
   let customStart = $state(untrack(() => data.filters.startDate) ?? '');
   let customEnd = $state(untrack(() => data.filters.endDate) ?? '');
+  // Future days have no data → cap both pickers at the viewer's local today.
+  const today = todayLocalDate();
 
   $effect(() => {
     const f = data.filters;
@@ -208,7 +211,7 @@
           type="date"
           class="input mt-0.5"
           bind:value={customStart}
-          max={customEnd || undefined}
+          max={customEnd && customEnd < today ? customEnd : today}
         />
       </label>
       <label class="flex flex-col text-xs text-ink-muted">
@@ -218,6 +221,7 @@
           class="input mt-0.5"
           bind:value={customEnd}
           min={customStart || undefined}
+          max={today}
         />
       </label>
       <button


### PR DESCRIPTION
The custom date-range pickers (dashboard / requests / key detail) let you select **future days, which have no data yet**.

**Fix:** new shared `todayLocalDate()` helper (viewer-local `YYYY-MM-DD`); the date inputs' `max` is now today — start input caps at `min(end, today)`, end input caps at `today` (keeping the existing start ≤ end constraint). Admin-only (template + one helper + test).

Verified: requests-filters test +2, **143 admin route/filter tests green, svelte-check 929/0/0, prettier clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)