### PR TITLE
refactor(admin): unify request lists into one shared RequestsTable (v0.22.3)

### DIFF
--- a/apps/admin/src/lib/components/RequestsTable.svelte
+++ b/apps/admin/src/lib/components/RequestsTable.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import type { RequestListItem } from '$lib/api/requests.js';
+  import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
+  import { formatTimestamp, formatTps, formatUsd } from '$lib/format.js';
+  import { t } from '$lib/i18n';
+  import TokensCell from './TokensCell.svelte';
+
+  // Shared request-list table (docs/07 columns). Renders the FULL decision trail so
+  // the dashboard preview and the per-key list match the canonical /requests view —
+  // one place to add a column, not three (the drift that lost Task/Complexity/
+  // Fallbacks/TPS/Error on the other two). Read-only projection: every cell is a
+  // field the backend recorded, nothing recomputed (Principle 1); the key shows by
+  // prefix only (Principle 7); `decided_by` (classification) stays distinct from
+  // `fallback_count` (execution) (Principle 5).
+  //
+  // Per-caller knobs: `detailHref` builds the row link (the `from`/Back target
+  // differs per page). The Key cell filters by key two ways: `onKeyFilter` makes it
+  // an in-page filter <button> (the /requests list updates its own querystring),
+  // `keyHref` makes it an <a> linking to the filtered list (the dashboard, which has
+  // no in-page filter) — pass one or the other. The Key column is dropped on a page
+  // already scoped to a single key (`showKey={false}`).
+  let {
+    items,
+    detailHref,
+    onKeyFilter,
+    keyHref,
+    showKey = true,
+  }: {
+    items: RequestListItem[];
+    detailHref: (traceId: string) => string;
+    onKeyFilter?: (keyId: string) => void;
+    keyHref?: (keyId: string) => string;
+    showKey?: boolean;
+  } = $props();
+
+  // Navigate when the row is clicked, EXCEPT when the click originates on an inner
+  // control (the request-id <a> and the key-filter <button> handle their own click).
+  function onRowClick(event: MouseEvent, traceId: string): void {
+    if ((event.target as HTMLElement).closest('a, button')) return;
+    void goto(detailHref(traceId));
+  }
+
+  function formatTs(ts: string): string {
+    return formatTimestamp(ts) || '—';
+  }
+
+  // Distinct label styling per classification-stage decision layer (Principle 5).
+  function decidedByClass(d: RequestListItem['decided_by']): string {
+    switch (d) {
+      case 'rules':
+        return 'badge-rules';
+      case 'eval':
+        return 'badge-eval';
+      case 'fallback':
+        return 'badge-fallback';
+      default: // default
+        return 'badge-neutral';
+    }
+  }
+</script>
+
+<!-- Key cell contents (name + prefix subtitle, or bare prefix). Shared between the
+     clickable filter button and the non-clickable label. -->
+{#snippet keyLabel(r: RequestListItem)}
+  {#if r.key_name}
+    <span class="text-ink-strong" title={r.key_prefix}>{r.key_name}</span>
+    <code class="block font-mono text-xs text-ink-muted">{r.key_prefix}</code>
+  {:else}
+    <code class="font-mono text-ink-strong">{r.key_prefix}</code>
+  {/if}
+{/snippet}
+
+<div class="table-wrap">
+  <table class="table-base">
+    <thead class="table-head">
+      <tr>
+        <th class="px-3 py-2" title={$t('The unique trace ID recorded for this request.')}
+          >{$t('Request ID')}</th
+        >
+        <th class="px-3 py-2" title={$t('When the gateway received the request.')}>{$t('Time')}</th>
+        {#if showKey}
+          <th
+            class="px-3 py-2"
+            title={$t('The API key that authenticated the client, shown by prefix only.')}
+            >{$t('Key')}</th
+          >
+        {/if}
+        <th class="px-3 py-2" title={$t('The model the client asked for in its request.')}
+          >{$t('Requested model')}</th
+        >
+        <th
+          class="px-3 py-2"
+          title={$t('Task type the classifier detected (e.g. coding, json, vision).')}
+          >{$t('Task')}</th
+        >
+        <th
+          class="px-3 py-2"
+          title={$t('Estimated request difficulty used to pick a quality tier.')}
+          >{$t('Complexity')}</th
+        >
+        <th class="px-3 py-2" title={$t('Which classification layer chose the lane.')}
+          >{$t('Decided by')}</th
+        >
+        <th class="px-3 py-2" title={$t('The quality/cost tier the request was routed to.')}
+          >{$t('Lane')}</th
+        >
+        <th class="px-3 py-2" title={$t('The model that actually handled the request.')}
+          >{$t('Served model')}</th
+        >
+        <th
+          class="px-3 py-2"
+          title={$t('How many fallback models were tried before one succeeded.')}
+          >{$t('Fallbacks')}</th
+        >
+        <th class="px-3 py-2" title={$t('Whether the request succeeded or returned an error.')}
+          >{$t('Status')}</th
+        >
+        <th class="px-3 py-2" title={$t('End-to-end response time in milliseconds.')}
+          >{$t('Latency')}</th
+        >
+        <th
+          class="px-3 py-2"
+          title={$t(
+            'Generation throughput: output tokens per second. Only measured for streamed responses.',
+          )}>{$t('TPS')}</th
+        >
+        <th class="px-3 py-2" title={$t('Token usage: input / output, with cached input tokens.')}
+          >{$t('Tokens')}</th
+        >
+        <th class="px-3 py-2" title={$t('Estimated cost of the request in US dollars.')}
+          >{$t('Cost')}</th
+        >
+        <th class="px-3 py-2" title={$t('The error class, if the request failed.')}
+          >{$t('Error')}</th
+        >
+      </tr>
+    </thead>
+    <tbody>
+      {#each items as r (r.trace_id)}
+        <!-- The whole row links to the detail page; the request-id cell keeps a real
+             <a> for keyboard / open-in-new-tab. -->
+        <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+        <tr
+          data-testid="request-row"
+          class="table-row cursor-pointer"
+          onclick={(e) => onRowClick(e, r.trace_id)}
+        >
+          <td class="px-3 py-2">
+            <a
+              class="link-inline block max-w-[7rem] truncate font-mono text-ink-strong lg:max-w-none"
+              href={detailHref(r.trace_id)}
+              title={r.trace_id}>{r.trace_id}</a
+            >
+          </td>
+          <td class="px-3 py-2 text-ink-body">{formatTs(r.ts)}</td>
+          {#if showKey}
+            <td class="px-3 py-2">
+              {#if r.key_id && onKeyFilter}
+                <!-- In-page filter (the /requests list): a <button> updates the
+                     querystring; onRowClick lets it handle the click, not the row. -->
+                <button
+                  type="button"
+                  data-testid="key-filter"
+                  class="block text-left hover:underline"
+                  title={$t('Filter by this key')}
+                  onclick={() => onKeyFilter(r.key_id!)}
+                >
+                  {@render keyLabel(r)}
+                </button>
+              {:else if r.key_id && keyHref}
+                <!-- Cross-page: link to the full requests list filtered by this key
+                     (the dashboard has no in-page filter). A real <a> → open-in-new-tab. -->
+                <a
+                  data-testid="key-filter"
+                  class="block text-left hover:underline"
+                  title={$t('Filter by this key')}
+                  href={keyHref(r.key_id)}
+                >
+                  {@render keyLabel(r)}
+                </a>
+              {:else}
+                {@render keyLabel(r)}
+              {/if}
+            </td>
+          {/if}
+          <td class="px-3 py-2 text-ink-body">{r.requested_model ?? '—'}</td>
+          <td class="px-3 py-2 text-ink-body">{r.task_type || '—'}</td>
+          <td class="px-3 py-2 text-ink-body">{r.complexity || '—'}</td>
+          <td class="px-3 py-2">
+            <span data-testid="decided-by" class={decidedByClass(r.decided_by)}>{r.decided_by}</span
+            >
+          </td>
+          <td class="px-3 py-2 text-ink-body">{r.lane || '—'}</td>
+          <td class="px-3 py-2 text-ink-body">{r.final_model ?? '—'}</td>
+          <td class="px-3 py-2 text-ink-body">{r.fallback_count}</td>
+          <td class="px-3 py-2">
+            {#if r.status === 'error'}
+              <span class="badge-error">{$t('error')}</span>
+            {:else}
+              <span class="badge-ok">{$t('ok')}</span>
+            {/if}
+          </td>
+          <td class="px-3 py-2 font-mono text-ink-body">{r.latency_ms}ms</td>
+          <td data-testid="cell-tps" class="px-3 py-2 font-mono text-ink-body"
+            >{formatTps(r.tps)}</td
+          >
+          <td class="px-3 py-2"><TokensCell usage={r.usage} /></td>
+          <td class="px-3 py-2 font-mono text-ink-body">{formatUsd(r.cost_usd)}</td>
+          <td
+            class="px-3 py-2 {r.error_class ? 'text-red-600' : 'text-ink-muted'}"
+            title={r.error_class ?? undefined}
+            >{r.error_class ? $t(attemptCodeLabel(r.error_class)) : '—'}</td
+          >
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/apps/admin/src/lib/components/RequestsTable.test.ts
+++ b/apps/admin/src/lib/components/RequestsTable.test.ts
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { RequestListItem } from '$lib/api/requests.js';
+import RequestsTable from './RequestsTable.svelte';
+
+// The shared request-list table renders the full decision trail (docs/07) for all
+// three callers. These cover the per-caller Key-cell branches; the /requests page's
+// in-page filter behavior is covered end-to-end in routes/requests/requests.test.ts.
+
+function item(overrides: Partial<RequestListItem> = {}): RequestListItem {
+  return {
+    trace_id: 'tr_1',
+    ts: '2026-05-31T10:00:00Z',
+    key_id: 'k_42',
+    key_prefix: 'helm_live_ab12',
+    key_name: 'Prod',
+    requested_model: 'gpt-4o',
+    task_type: 'coding',
+    complexity: 'high',
+    decided_by: 'rules',
+    lane: 'premium',
+    final_model: 'claude-x',
+    fallback_count: 1,
+    status: 'ok',
+    latency_ms: 460,
+    cost_usd: 0.0123,
+    usage: { input: 1200, output: 340, cached: 800, cacheCreation: 64, nonCached: 400, total: 1540 },
+    tps: 200,
+    ...overrides,
+  };
+}
+
+const detailHref = (id: string) => `/requests/${id}`;
+
+describe('RequestsTable key cell', () => {
+  it('renders the key as a filter LINK when given keyHref (the dashboard)', () => {
+    render(RequestsTable, {
+      items: [item()],
+      detailHref,
+      keyHref: (keyId: string) => `/requests?key_id=${keyId}&range=all`,
+    });
+    const cell = screen.getByTestId('key-filter');
+    expect(cell.tagName).toBe('A');
+    expect(cell).toHaveAttribute('href', '/requests?key_id=k_42&range=all');
+  });
+
+  it('renders the key as a filter BUTTON when given onKeyFilter (the /requests list)', async () => {
+    const onKeyFilter = vi.fn();
+    render(RequestsTable, { items: [item()], detailHref, onKeyFilter });
+    const cell = screen.getByTestId('key-filter');
+    expect(cell.tagName).toBe('BUTTON');
+    await fireEvent.click(cell);
+    expect(onKeyFilter).toHaveBeenCalledWith('k_42');
+  });
+
+  it('drops the Key column entirely when showKey is false (the key-detail page)', () => {
+    render(RequestsTable, {
+      items: [item()],
+      detailHref,
+      keyHref: (keyId: string) => `/x?${keyId}`,
+      showKey: false,
+    });
+    expect(screen.queryByTestId('key-filter')).toBeNull();
+    expect(screen.queryByText('Key')).toBeNull();
+  });
+});

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -6,9 +6,9 @@
   import type { RequestListItem } from '$lib/api/requests.js';
   import type { DashboardStats } from '$lib/api/stats.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
-  import TokensCell from '$lib/components/TokensCell.svelte';
+  import RequestsTable from '$lib/components/RequestsTable.svelte';
   import { formatTrendTick, trendAxisTicks, type TrendBucket } from '$lib/dashboard-chart.js';
-  import { formatCount, formatTimestamp, formatTokens, formatTps, formatUsd } from '$lib/format.js';
+  import { formatCount, formatTokens, formatTps, formatUsd } from '$lib/format.js';
   import {
     DEFAULT_PAGE_SIZE,
     filtersToSearch,
@@ -192,33 +192,24 @@
     return `${base}/requests/${traceId}`;
   }
 
-  function onRowClick(event: MouseEvent, traceId: string): void {
-    if ((event.target as HTMLElement).closest('a')) return;
-    void goto(detailHref(traceId));
-  }
-
-  // Format the recorded ISO timestamp in the viewer's local zone (shared helper);
-  // '—' for a legacy row that carried none.
-  function formatTs(ts: string): string {
-    return formatTimestamp(ts) || '—';
+  // The dashboard has no in-page filter, so a row's Key cell links to the full
+  // requests list pre-filtered to that key, carrying the current window so it opens
+  // on the same range the dashboard is showing.
+  function keyFilterHref(keyId: string): string {
+    const qs = filtersToSearch({
+      range: data.range,
+      startDate: data.startDate,
+      endDate: data.endDate,
+      keyId,
+      page: 1,
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
+    return `${base}/requests${qs ? `?${qs}` : ''}`;
   }
 
   function formatTrendAxisValue(value: unknown): string {
     const date = value instanceof Date ? value : new Date(value as string | number);
     return Number.isNaN(date.getTime()) ? String(value ?? '') : formatTrendTick(date, data.bucket);
-  }
-
-  function decidedByClass(d: RequestListItem['decided_by']): string {
-    switch (d) {
-      case 'rules':
-        return 'badge-rules';
-      case 'eval':
-        return 'badge-eval';
-      case 'fallback':
-        return 'badge-fallback';
-      default:
-        return 'badge-neutral';
-    }
   }
 
   const cards = [
@@ -553,70 +544,7 @@
         )}
       </div>
     {:else}
-      <div class="table-wrap">
-        <table class="table-base">
-          <thead class="table-head">
-            <tr>
-              <th class="px-3 py-2 font-medium">{$t('Request ID')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Time')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Requested model')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Decided by')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Lane')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Served model')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Status')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Latency')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Tokens')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Cost')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each recent as r (r.trace_id)}
-              <!-- The whole row links to the detail page; the request-id cell keeps a
-                   real <a> for keyboard / open-in-new-tab. (Mirrors /requests.) -->
-              <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-              <tr
-                data-testid="request-row"
-                class="table-row cursor-pointer"
-                onclick={(e) => onRowClick(e, r.trace_id)}
-              >
-                <td class="px-3 py-2">
-                  <a
-                    class="link-inline block max-w-[7rem] truncate font-mono text-ink-strong lg:max-w-none"
-                    href={detailHref(r.trace_id)}
-                    title={r.trace_id}>{r.trace_id}</a
-                  >
-                </td>
-                <td class="px-3 py-2 text-ink-body">{formatTs(r.ts)}</td>
-                <td class="px-3 py-2 text-ink-body">{r.requested_model ?? '—'}</td>
-                <td class="px-3 py-2">
-                  <span
-                    class={decidedByClass(r.decided_by)}
-                    title={r.decided_by === 'rules'
-                      ? $t('Chosen by deterministic Layer-1 rules.')
-                      : r.decided_by === 'eval'
-                        ? $t('Chosen by the Layer-2 small-model evaluator.')
-                        : r.decided_by === 'fallback'
-                          ? $t('No rule matched, so it defaulted to the balanced lane.')
-                          : ''}>{r.decided_by}</span
-                  >
-                </td>
-                <td class="px-3 py-2 text-ink-body">{r.lane || '—'}</td>
-                <td class="px-3 py-2 font-mono text-xs text-ink-body">{r.final_model ?? '—'}</td>
-                <td class="px-3 py-2">
-                  {#if r.status === 'error'}
-                    <span class="badge-error">{$t('error')}</span>
-                  {:else}
-                    <span class="badge-ok">{$t('ok')}</span>
-                  {/if}
-                </td>
-                <td class="px-3 py-2 font-mono text-ink-body">{r.latency_ms}ms</td>
-                <td class="px-3 py-2"><TokensCell usage={r.usage} /></td>
-                <td class="px-3 py-2 font-mono text-ink-body">{formatUsd(r.cost_usd)}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
-      </div>
+      <RequestsTable items={recent} {detailHref} keyHref={keyFilterHref} />
     {/if}
   </section>
 

--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -4,19 +4,12 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import type { ApiKeyView } from '$lib/api/keys.js';
-  import type { RequestListItem, RequestsPage } from '$lib/api/requests.js';
+  import type { RequestsPage } from '$lib/api/requests.js';
   import type { DashboardStats } from '$lib/api/stats.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
-  import TokensCell from '$lib/components/TokensCell.svelte';
+  import RequestsTable from '$lib/components/RequestsTable.svelte';
   import { formatTrendTick, trendAxisTicks, type TrendBucket } from '$lib/dashboard-chart.js';
-  import {
-    durationParts,
-    formatCount,
-    formatTimestamp,
-    formatTokens,
-    formatTps,
-    formatUsd,
-  } from '$lib/format.js';
+  import { durationParts, formatCount, formatTokens, formatTps, formatUsd } from '$lib/format.js';
   import {
     KEY_DETAIL_DEFAULT_RANGE,
     type KeyDetailFilters,
@@ -171,26 +164,6 @@
     const from = `${base}/keys/${encodeURIComponent(data.keyId)}${qs ? `?${qs}` : ''}`;
     return `${base}/requests/${encodeURIComponent(traceId)}?from=${encodeURIComponent(from)}`;
   }
-  function onRowClick(event: MouseEvent, traceId: string): void {
-    if ((event.target as HTMLElement).closest('a')) return;
-    void goto(detailHref(traceId));
-  }
-  function formatTs(ts: string): string {
-    return formatTimestamp(ts) || '—';
-  }
-  function decidedByClass(d: RequestListItem['decided_by']): string {
-    switch (d) {
-      case 'rules':
-        return 'badge-rules';
-      case 'eval':
-        return 'badge-eval';
-      case 'fallback':
-        return 'badge-fallback';
-      default:
-        return 'badge-neutral';
-    }
-  }
-
   // ── Config card helpers (mirror the list view's labels) ──────────────────────
   function limitLabel(v: number | null): string {
     if (v === null) return $t('Default');
@@ -519,59 +492,7 @@
     {#if data.requests.items.length === 0}
       <div class="empty-state">{$t('No requests for this key in the selected window.')}</div>
     {:else}
-      <div class="table-wrap">
-        <table class="table-base">
-          <thead class="table-head">
-            <tr>
-              <th class="px-3 py-2 font-medium">{$t('Request ID')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Time')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Requested model')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Decided by')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Lane')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Served model')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Status')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Latency')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Tokens')}</th>
-              <th class="px-3 py-2 font-medium">{$t('Cost')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each data.requests.items as r (r.trace_id)}
-              <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-              <tr
-                data-testid="request-row"
-                class="table-row cursor-pointer"
-                onclick={(e) => onRowClick(e, r.trace_id)}
-              >
-                <td class="px-3 py-2">
-                  <a
-                    class="link-inline block max-w-[7rem] truncate font-mono text-ink-strong lg:max-w-none"
-                    href={detailHref(r.trace_id)}
-                    title={r.trace_id}>{r.trace_id}</a
-                  >
-                </td>
-                <td class="px-3 py-2 text-ink-body">{formatTs(r.ts)}</td>
-                <td class="px-3 py-2 text-ink-body">{r.requested_model ?? '—'}</td>
-                <td class="px-3 py-2">
-                  <span class={decidedByClass(r.decided_by)}>{r.decided_by}</span>
-                </td>
-                <td class="px-3 py-2 text-ink-body">{r.lane || '—'}</td>
-                <td class="px-3 py-2 font-mono text-xs text-ink-body">{r.final_model ?? '—'}</td>
-                <td class="px-3 py-2">
-                  {#if r.status === 'error'}
-                    <span class="badge-error">{$t('error')}</span>
-                  {:else}
-                    <span class="badge-ok">{$t('ok')}</span>
-                  {/if}
-                </td>
-                <td class="px-3 py-2 font-mono text-ink-body">{r.latency_ms}ms</td>
-                <td class="px-3 py-2"><TokensCell usage={r.usage} /></td>
-                <td class="px-3 py-2 font-mono text-ink-body">{formatUsd(r.cost_usd)}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
-      </div>
+      <RequestsTable items={data.requests.items} {detailHref} showKey={false} />
 
       {#if hasMore}
         <!-- Only the most-recent page is shown here. The full history lives in the

--- a/apps/admin/src/routes/requests/+page.svelte
+++ b/apps/admin/src/routes/requests/+page.svelte
@@ -3,11 +3,9 @@
   import { goto, invalidateAll } from '$app/navigation';
   import { base } from '$app/paths';
   import type { RequestListItem } from '$lib/api/requests.js';
-  import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
   import RefreshControl from '$lib/components/RefreshControl.svelte';
-  import TokensCell from '$lib/components/TokensCell.svelte';
-  import { formatTimestamp, formatTps, formatUsd } from '$lib/format.js';
+  import RequestsTable from '$lib/components/RequestsTable.svelte';
   import { paginationItems } from '$lib/pagination.js';
   import {
     DEFAULT_FILTERS,
@@ -165,34 +163,6 @@
     const search = filtersToSearch(data.filters);
     const from = `${base}/requests${search ? `?${search}` : ''}`;
     return `${base}/requests/${traceId}?from=${encodeURIComponent(from)}`;
-  }
-
-  // Navigate when the row is clicked, EXCEPT when the click originates on an
-  // inner control (the request-id link handles its own navigation; the key cell
-  // is a filter button) — closest('a, button') lets those handle the click.
-  function onRowClick(event: MouseEvent, traceId: string): void {
-    if ((event.target as HTMLElement).closest('a, button')) return;
-    void goto(detailHref(traceId));
-  }
-
-  // Recorded time for the "timestamp" column: format the ISO ts in the viewer's
-  // local zone (shared helper); '—' when the record carried none (legacy row).
-  function formatTs(ts: string): string {
-    return formatTimestamp(ts) || '—';
-  }
-
-  // Distinct label styling per classification-stage decision layer (Principle 5).
-  function decidedByClass(d: RequestListItem['decided_by']): string {
-    switch (d) {
-      case 'rules':
-        return 'badge-rules';
-      case 'eval':
-        return 'badge-eval';
-      case 'fallback':
-        return 'badge-fallback';
-      default: // default
-        return 'badge-neutral';
-    }
   }
 </script>
 
@@ -358,17 +328,6 @@
     </span>
   </div>
 
-  <!-- Key cell contents (name + prefix subtitle, or bare prefix). Shared between
-       the clickable filter button and the non-clickable legacy fallback. -->
-  {#snippet keyLabel(r: RequestListItem)}
-    {#if r.key_name}
-      <span class="text-ink-strong" title={r.key_prefix}>{r.key_name}</span>
-      <code class="block font-mono text-xs text-ink-muted">{r.key_prefix}</code>
-    {:else}
-      <code class="font-mono text-ink-strong">{r.key_prefix}</code>
-    {/if}
-  {/snippet}
-
   {#if data.items.length === 0}
     <div data-testid="requests-empty" class="empty-state">
       <p class="font-medium text-ink-body">{$t('No requests match these filters.')}</p>
@@ -377,143 +336,7 @@
       </p>
     </div>
   {:else}
-    <div class="table-wrap">
-      <table class="table-base">
-        <thead class="table-head">
-          <tr>
-            <th class="px-3 py-2" title={$t('The unique trace ID recorded for this request.')}
-              >{$t('Request ID')}</th
-            >
-            <th class="px-3 py-2" title={$t('When the gateway received the request.')}
-              >{$t('Time')}</th
-            >
-            <th
-              class="px-3 py-2"
-              title={$t('The API key that authenticated the client, shown by prefix only.')}
-              >{$t('Key')}</th
-            >
-            <th class="px-3 py-2" title={$t('The model the client asked for in its request.')}
-              >{$t('Requested model')}</th
-            >
-            <th
-              class="px-3 py-2"
-              title={$t('Task type the classifier detected (e.g. coding, json, vision).')}
-              >{$t('Task')}</th
-            >
-            <th
-              class="px-3 py-2"
-              title={$t('Estimated request difficulty used to pick a quality tier.')}
-              >{$t('Complexity')}</th
-            >
-            <th class="px-3 py-2" title={$t('Which classification layer chose the lane.')}
-              >{$t('Decided by')}</th
-            >
-            <th class="px-3 py-2" title={$t('The quality/cost tier the request was routed to.')}
-              >{$t('Lane')}</th
-            >
-            <th class="px-3 py-2" title={$t('The model that actually handled the request.')}
-              >{$t('Served model')}</th
-            >
-            <th
-              class="px-3 py-2"
-              title={$t('How many fallback models were tried before one succeeded.')}
-              >{$t('Fallbacks')}</th
-            >
-            <th class="px-3 py-2" title={$t('Whether the request succeeded or returned an error.')}
-              >{$t('Status')}</th
-            >
-            <th class="px-3 py-2" title={$t('End-to-end response time in milliseconds.')}
-              >{$t('Latency')}</th
-            >
-            <th
-              class="px-3 py-2"
-              title={$t(
-                'Generation throughput: output tokens per second. Only measured for streamed responses.',
-              )}>{$t('TPS')}</th
-            >
-            <th
-              class="px-3 py-2"
-              title={$t('Token usage: input / output, with cached input tokens.')}
-              >{$t('Tokens')}</th
-            >
-            <th class="px-3 py-2" title={$t('Estimated cost of the request in US dollars.')}
-              >{$t('Cost')}</th
-            >
-            <th class="px-3 py-2" title={$t('The error class, if the request failed.')}
-              >{$t('Error')}</th
-            >
-          </tr>
-        </thead>
-        <tbody>
-          {#each data.items as r (r.trace_id)}
-            <!-- The whole row links to the detail page; the request-id cell keeps a
-                 real <a> for keyboard / open-in-new-tab. -->
-            <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-            <tr
-              data-testid="request-row"
-              class="table-row cursor-pointer"
-              onclick={(e) => onRowClick(e, r.trace_id)}
-            >
-              <td class="px-3 py-2">
-                <a
-                  class="link-inline block max-w-[7rem] truncate font-mono text-ink-strong lg:max-w-none"
-                  href={detailHref(r.trace_id)}
-                  title={r.trace_id}>{r.trace_id}</a
-                >
-              </td>
-              <td class="px-3 py-2 text-ink-body">{formatTs(r.ts)}</td>
-              <td class="px-3 py-2">
-                {#if r.key_id}
-                  <!-- Click the key to scope the list to it (sets the ?key_id
-                       filter). A <button>, so onRowClick lets it handle the click
-                       instead of opening the detail page. -->
-                  <button
-                    type="button"
-                    data-testid="key-filter"
-                    class="block text-left hover:underline"
-                    title={$t('Filter by this key')}
-                    onclick={() => go({ keyId: r.key_id })}
-                  >
-                    {@render keyLabel(r)}
-                  </button>
-                {:else}
-                  {@render keyLabel(r)}
-                {/if}
-              </td>
-              <td class="px-3 py-2 text-ink-body">{r.requested_model ?? '—'}</td>
-              <td class="px-3 py-2 text-ink-body">{r.task_type || '—'}</td>
-              <td class="px-3 py-2 text-ink-body">{r.complexity || '—'}</td>
-              <td class="px-3 py-2">
-                <span data-testid="decided-by" class={decidedByClass(r.decided_by)}
-                  >{r.decided_by}</span
-                >
-              </td>
-              <td class="px-3 py-2 text-ink-body">{r.lane || '—'}</td>
-              <td class="px-3 py-2 text-ink-body">{r.final_model ?? '—'}</td>
-              <td class="px-3 py-2 text-ink-body">{r.fallback_count}</td>
-              <td class="px-3 py-2">
-                {#if r.status === 'error'}
-                  <span class="badge-error">{$t('error')}</span>
-                {:else}
-                  <span class="badge-ok">{$t('ok')}</span>
-                {/if}
-              </td>
-              <td class="px-3 py-2 font-mono text-ink-body">{r.latency_ms}ms</td>
-              <td data-testid="cell-tps" class="px-3 py-2 font-mono text-ink-body"
-                >{formatTps(r.tps)}</td
-              >
-              <td class="px-3 py-2"><TokensCell usage={r.usage} /></td>
-              <td class="px-3 py-2 font-mono text-ink-body">{formatUsd(r.cost_usd)}</td>
-              <td
-                class="px-3 py-2 {r.error_class ? 'text-red-600' : 'text-ink-muted'}"
-                title={r.error_class ?? undefined}
-                >{r.error_class ? $t(attemptCodeLabel(r.error_class)) : '—'}</td
-              >
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    </div>
+    <RequestsTable items={data.items} {detailHref} onKeyFilter={(keyId) => go({ keyId })} />
 
     <!-- Pagination footer: rows-per-page on the left, numbered pages + Prev/Next on
          the right. `total` reflects the active filters so the counts stay consistent

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-26 · 三处请求列表统一为共享 RequestsTable 组件（admin UI；docs/07）
+
+- **背景（Lukin）**：dashboard「最近请求」与 key 详情的请求列表字段太少（各 **10 列**），要参考 `/admin/requests`（最全 **16 列**）补齐。
+- **根因**：三页各自**内联**一份 `<table>`（零组件复用，仅共用 `TokensCell`），故 dashboard/key 详情漏了 **Key/Task/Complexity/Fallbacks/TPS/Error** 六列；且任何「加列」只改 /requests 必再次漂移（这次需求本身就是漂移的症状）。
+- **决定**：抽共享 `lib/components/RequestsTable.svelte`（= 参考页完整列），三页复用，删两份重复表格（~140 行内联标记 + 各页 `onRowClick`/`formatTs`/`decidedByClass` 副本）。Per-caller 旋钮：`detailHref`（行链接，各页 from/返回目标不同）、`showKey`（key 详情传 `false`：每行同一 key、列冗余 → 整列隐藏）；key 单元格**两种筛选机制二选一**——`onKeyFilter?`（仅 /requests 传 → 页内筛选 `<button>`，更新自身 querystring）vs `keyHref?`（dashboard 传 → `<a>` 跳到按 key 预筛的列表，因 dashboard 无页内筛选），两者皆挂 `data-testid=key-filter`。
+- **取舍**：① dashboard 的 key 单元格是**链接**（Lukin 要求）：`keyHref` 渲染真 `<a>`（可中键新开标签页），跳 `/requests?key_id=<id>&<当前窗口>`（带 dashboard 当前 range/custom，落到同窗口）。**不复用 /requests 的 button 机制**——那是页内 `go()` 更新 querystring、被 `requests.test` 的 click→goto 契约锁死，改 `<a>` 既破测试又丢「保留其它 filter + chip」语义；故新增独立 `keyHref` 旁路，参考页零改动。② key 详情**隐藏 Key 列**（非 100% 照搬参考页），因每行都是该 key。③ **零新增 i18n 串**——组件全用 /requests 既有 superset（含各列 `title` 长句），无需 i18n:sync。④ decided-by 单元格统一为参考页纯 badge（dashboard 旧逐层 title tooltip 去掉，但其表上方本就有图例，信息不丢）。
+- **验证**：关键 testid（`request-row`/`decided-by`/`cell-tps`/`key-filter`/`key-filter-chip`）原样保留；新增 `RequestsTable.test`（key 单元格三分支：keyHref→`<a>`+href / onKeyFilter→`<button>`+回调 / `showKey=false`→无列）。**admin 493 单测全绿**（含 `requests.test`/`key-detail.test`/`home.test`）；**svelte-check 931/0/0**；prettier 干净。全在 `apps/admin`（原则 1）。
+
 ## 2026-06-26 · 记忆按 API key 隔离：用时回落 project_id ??= key_id（存储层；docs/08 + 原则 1/7）
 
 - **背景（Lukin）**：admin「记忆 · 按密钥」选某 key 仍列出全部事实。实为**记忆作用域是 account+project,不是单 key**:`account_id` 恒为常量 `"default"`(单租户),真正区分靠 `project_id`,缺省则 thread-locked(换会话即丢,见 [[memory-cross-session-needs-project-scope]])。需求:**默认按 API key 隔离**——key A 的记忆永不进 key B,同 key 跨会话仍记得。
@@ -26,19 +34,13 @@
 - **坑**：行 id 链现带 `?from=`，gateway e2e `admin.spec.ts` 的 `a[href$="/requests/<id>"]`（ends-with）失配 → 改 `href*=`（contains）。请求列表 pager（含 e2e :144 的 `pager-status`/`pager-next`）原样保留、不受影响。
 - **TDD+验证**：`requests-filters`（+keyId round-trip）、`requests.test`（chip/点击筛选/detailHref 带 from/back link/`safeBackTo` 开放重定向守卫）、`key-detail.test`（view-all 链接替换旧多页 pager 断言）、gateway `admin.test`（行 `key_id`）。**admin 488 单测 + 6 admin e2e + gateway admin 69 测全绿；typecheck/lint/svelte-check 0**。i18n 三键五语（translate relay 离线→手填 zh-hans/zh-hant/ja/ko）。改动全在 `apps/admin` + 1 处 gateway route（原则 1）。分支 `worktree-feat+requests-key-filter-and-back-nav`，**未提交未部署**。
 
-## 2026-06-26 · 仪表板 + 请求列表加自定义日期范围（admin UI；对应 docs/04 遥测展示）
-
-- **背景（Lukin）**：仪表板「今天/昨天/7d/30d/全部」预设不够灵活，要能选任意日期范围。
-- **决定（范围）**：Lukin 选「**仪表板 + 请求列表都加**」。`keys/[id]` 早有「预设 或 自定义日期」实现 → 把其通用窗口原语**下沉到共享 `requests-filters.ts`**（`localMidnightMs`/`isValidDateParam`/`resolveCustomDayWindow`/`bucketForWindow`），`key-detail-filters` 改为消费它（删私有副本、重导出 `bucketForWindow` 使其 import 与测试**完全不动**），三页同源。
-- **UX**：**不动共享 `RangeFilter` 组件**（零 e2e testid 风险）——自定义 From/To 用原生 `<input type="date">` 摆控件旁（仿 key 详情），有效区间时预设 `opacity-50` 变灰并被覆盖。窗口走 URL `?start=YYYY-MM-DD&end=YYYY-MM-DD`，**custom 胜过 preset**；半填/反序/非法日期 fail-soft 回落预设。`end` = endDate 次日 0 点（含尾日，DST 用 `setDate`）。
-- **关键点**：① 自定义模式无同比 delta（门 `!custom && today|yesterday`）、bucket 按实际跨度 `bucketForWindow`（≤2 天 hour 否则 day）。② **后端零改动**（getStats/listRequests 早收任意 epoch ms）。③ **i18n 零成本**（From/To/Apply/Clear 五语已被 key 详情用过）。④「查看全部」用 `filtersToSearch` 串 start/end 忠实带窗口跳转。
-- **TDD+验证**：`requests-filters.test` +18 例（4 个新原语 + parse/serialize round-trip + custom 胜出 + 半填回落）；`key-detail-filters.test` 8 例重构后不变绿。**admin 481 单测全绿、svelte-check 929/0/0、prettier 干净**。全在 `apps/admin`（原则 1）。分支 `worktree-dashboard-date-range`，**未提交未部署**。
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
 
+- **2026-06-26 · 仪表板+请求列表加自定义日期范围（admin UI；docs/04）**：把 key 详情早有的「预设 或 自定义日期」窗口原语下沉到共享 `requests-filters.ts`（localMidnightMs/isValidDateParam/resolveCustomDayWindow/bucketForWindow），三页同源（key-detail-filters 改消费它、重导出 bucketForWindow 保 import/测试不变）。不动共享 `RangeFilter`（零 e2e testid 风险），自定义 From/To 用原生 `<input type=date>`，窗口走 URL `?start=&end=` **custom 胜 preset**、半填/反序/非法 fail-soft 回落；自定义模式无同比 delta；后端零改动、i18n 零成本。requests-filters.test +18 例，admin 481 测绿、svelte-check 929/0/0。分支 `worktree-dashboard-date-range`，**未部署**。
 - **2026-06-26 · payload 体积治理：图片 CAS 外置 + gzip + 写队列字节背压 + 分页生成列（存储层；原则 7，docs/02）**：线上 helm.db 14GB 根因=native passthrough 把 CC 每轮重发的 base64 图+大 transcript 逐字落 `request_payloads`。治理:① 图片 CAS——`payload-blobs.ts` 按 sha256(字节) 外置到 `payload_blobs`、正文留 `helm-blob:` sentinel、INSERT OR IGNORE 跨轮去重(10–30×),`getPayload` 读时 rehydrate(UI/replay 零改动);blob 续命=`ON CONFLICT DO UPDATE created_at`、prune 同 cutoff(不变式 blob.created_at≥payload)。② gzip 仅 SQLite(PG 靠 TOAST)。③ 写队列背压改按字节 maxBytes=256MB+inFlightBytes 防 stalled-writer OOM、溢出优先丢 payload 保 telemetry。④ telemetry lane/decided_by 生成列(SQLite VIRTUAL/PG STORED)+索引。迁移 SQLite v29/v30、PG v28/v29。Codex 修 3 处(in-flight 字节漏算致命/Responses input_image 漏剥/rehydrate fail-open)。4670 单测绿。分支 `worktree-payload-cas-gzip-perf`。**运维 TODO**：部署后等 3 天保留期清旧胖行→手动「Compact database」VACUUM 收回 14GB→开回 auto-vacuum。
 - **2026-06-26 · 仪表板「昨天」视图加同比（admin UI；docs/04）**：复用 today-delta 机制，基准窗按视图分流——`dashboard-chart.ts` 加 `resolveYesterdayComparisonWindow`（前天整日 `[前天0点,昨天0点)`），compare 门 `today`→放宽 `today|yesterday`；昨天视图用 `vs day before yesterday`/`Day before yesterday:{value}` 五语两键纳入 `dashboard-locales` 守卫，`MIN_COMPARISON_BASELINE_REQUESTS=10` 不变。发 v0.21.33 并部署。
 - **2026-06-26 · key 详情图表对齐 dashboard + 缓存命中率卡片（admin UI；docs/04）**：dashboard「缓存 Token」卡片加命中率 subline + key 详情 `keys/[id]` 两图对齐 dashboard。命中率 = cached÷prompt（`promptTokens===0→null` 整行隐藏），两 loader 同算；key 详情富 tooltip（趋势「总花费」/环「花费」）逐字搬自 dashboard，`TrendPoint`/`ModelSlice` 补 `cost`。i18n 加 `Hit rate`。全在 `apps/admin`（原则 1）。发 v0.21.32。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What

The dashboard "Recent requests" preview and the per-key request list each inlined **their own** request table showing only **10 columns**, so they had drifted from the canonical `/admin/requests` view (**16 columns**) — missing **Key, Task, Complexity, Fallbacks, TPS, Error**.

This extracts the reference table into a shared `lib/components/RequestsTable.svelte` and reuses it on all three pages.

| Page | Before | After |
|---|---|---|
| `/admin/requests` (reference) | 16 cols | uses component (unchanged) |
| Dashboard · Recent requests | 10 cols | **full columns** |
| Key detail · Requests | 10 cols | **full columns** (Key column hidden) |

Net **−360 lines** of duplicated table markup + per-page `onRowClick`/`formatTs`/`decidedByClass` copies.

## Per-page knobs

- `detailHref` — row link / Back target (differs per page).
- `showKey={false}` — dropped on the key-detail page (every row is the same key).
- Key-cell filter, two mutually-exclusive modes:
  - `onKeyFilter` → in-page filter `<button>` (the `/requests` list updates its own querystring) — **reference page unchanged**.
  - `keyHref` → real `<a>` linking to the filtered requests list (the **dashboard**, which has no in-page filter; carries the current window, supports open-in-new-tab).

## Notes / judgment calls

- Reference `/requests` page untouched — its `key-filter` button → `goto` contract and chip semantics are preserved (couldn't collapse it to a plain `<a>` without breaking that).
- Key detail hides the Key column (not a 1:1 copy of the reference) since the page is already scoped to one key.
- **Zero new i18n strings** — the component reuses the `/requests` superset (including column `title` tooltips).

## Tests

- New `RequestsTable.test.ts` covers the three key-cell branches (keyHref→`<a>`, onKeyFilter→`<button>`+callback, `showKey=false`→no column).
- All testids preserved (`request-row`/`decided-by`/`cell-tps`/`key-filter`/`key-filter-chip`).
- **admin 493 unit tests green**, svelte-check 931/0/0, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)