### PR TITLE
fix(store): deterministic api-key list order (v0.22.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -1,5 +1,5 @@
 import type { ApiKeyRecord } from "@helm/shared";
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import type { CreateKeyInput, KeyPatch, KeyStore } from "../ports.js";
 import type { PgDb } from "./migrate.js";
 import { apiKeys } from "./schema.js";
@@ -62,7 +62,13 @@ export class PgKeyStore implements KeyStore {
   }
 
   async list(): Promise<ApiKeyRecord[]> {
-    const rows = await this.db.select().from(apiKeys);
+    // Deterministic order: creation time, key_id as the unique tiebreaker. Without an
+    // explicit ORDER BY Postgres returns rows in an unspecified order that shifts as
+    // rows are updated/deleted, so the admin list appeared to reshuffle between loads.
+    const rows = await this.db
+      .select()
+      .from(apiKeys)
+      .orderBy(asc(apiKeys.createdAt), asc(apiKeys.keyId));
     return rows.map((r) => this.toRecord(r));
   }
 

--- a/packages/core/src/store/sqlite/keystore.test.ts
+++ b/packages/core/src/store/sqlite/keystore.test.ts
@@ -101,6 +101,30 @@ describe("SqliteKeyStore", () => {
     }
   });
 
+  it("list() orders by createdAt then key_id, regardless of insertion order or updates", async () => {
+    const db = createSqliteDb(":memory:");
+    let t = 0;
+    const store = new SqliteKeyStore(db, () => new Date(t));
+    // Insert OUT of order; two share a createdAt to exercise the key_id tiebreaker.
+    t = 300;
+    await store.createKey({
+      keyId: "zeta",
+      hash: "h0",
+      prefix: "p0",
+      accountId: "a",
+      role: "user",
+    });
+    t = 100;
+    await store.createKey({ keyId: "kb", hash: "h1", prefix: "p1", accountId: "a", role: "user" });
+    t = 100;
+    await store.createKey({ keyId: "ka", hash: "h2", prefix: "p2", accountId: "a", role: "user" });
+    // createdAt asc (ka/kb=100 before zeta=300); key_id asc within the tie (ka before kb).
+    expect((await store.list()).map((k) => k.key_id)).toEqual(["ka", "kb", "zeta"]);
+    // Stable after an unrelated mutation — disabling a row must not reshuffle the list.
+    await store.disable("ka");
+    expect((await store.list()).map((k) => k.key_id)).toEqual(["ka", "kb", "zeta"]);
+  });
+
   it("getByHash returns null on a miss (no throw)", async () => {
     const store = freshStore();
     expect(await store.getByHash("unknown")).toBeNull();

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -1,5 +1,5 @@
 import type { ApiKeyRecord } from "@helm/shared";
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import type { CreateKeyInput, KeyPatch, KeyStore } from "../ports.js";
 import type { SqliteDb } from "./migrate.js";
 import { apiKeys } from "./schema.js";
@@ -60,9 +60,13 @@ export class SqliteKeyStore implements KeyStore {
   }
 
   async list(): Promise<ApiKeyRecord[]> {
+    // Deterministic order: creation time, key_id as the unique tiebreaker. Without an
+    // explicit ORDER BY the engine returns rows in an unspecified order that shifts as
+    // rows are updated/deleted, so the admin list appeared to reshuffle between loads.
     return this.db
       .select()
       .from(apiKeys)
+      .orderBy(asc(apiKeys.createdAt), asc(apiKeys.keyId))
       .all()
       .map((r) => this.toRecord(r));
   }


### PR DESCRIPTION
## 问题
`/admin/keys` 列表顺序「来回变」——一会这个在上、一会那个在上。

## 根因
顺序完全由存储层 `KeyStore.list()` 决定，但 **sqlite 和 postgres 两个实现都没有 `ORDER BY`**（`SELECT * FROM api_keys`）。不带排序时数据库返回的行序是未指定的，会随行的更新/删除而移位（SQLite 大致按 rowid 但不保证；Postgres 更新后更乱）。前端直接按返回数组渲染、不二次排序。

## 修复
两个 `list()` 都加 `ORDER BY created_at ASC, key_id ASC`：
- 按创建时间升序——root key 恒在最上，新建 key 追加到底部；
- `key_id`（主键唯一）作 tiebreaker，**完全确定**，更新/禁用某 key 不再移位；
- 方向与前端 `onCreated` 追加到列表末尾的行为一致，**前端零改动**。

## 验证
- 新增单测：乱序插入 + created_at 打平仍稳定排成 `ka, kb, zeta`，disable 后顺序不变。
- ✅ keystore 单测 20 · store-contract 130（sqlite + postgres/PGlite 双驱动）· core typecheck · biome lint 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)