### PR TITLE
fix(admin): SSE viewer captures custom-tool/refusal/code bodies + correct routing (v0.22.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,18 @@ on:
     branches: [main]
 
 jobs:
+  # NOTE: actions/checkout + actions/setup-node are pinned to @v4 (node20 runtime).
+  # Some self-hosted runners (e.g. machine 199-4, runner v2.321.0) are too old to
+  # run v5's node24 runtime — they fail at "Set up job" with "'using: node24' is
+  # not supported". Bump back to @v5 once every runner in the pool is updated.
   verify:
     # Self-hosted runners (EasyMetaAu org, docker-runner-*); GitHub-hosted minutes
     # are not used. All 9 runners carry these labels.
     runs-on: [self-hosted, Linux, X64, docker]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           # The self-hosted Docker runners keep /home/runner/_work on a host
@@ -41,9 +45,9 @@ jobs:
   e2e:
     runs-on: [self-hosted, Linux, X64, docker]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           package-manager-cache: false
@@ -64,7 +68,7 @@ jobs:
   docker:
     runs-on: [self-hosted, Linux, X64, docker]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: Build gateway image
         # Inject build info (docs/10) so GET /version reports real values instead
         # of "unknown": app version from package.json, the commit, and a UTC stamp.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write   # create the tag + GitHub Release on a version bump
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # need full tag list to detect "already released"
       - name: Resolve tags + build info

--- a/apps/admin/src/lib/sse.test.ts
+++ b/apps/admin/src/lib/sse.test.ts
@@ -155,6 +155,44 @@ const RESPONSES_STREAM = [
   })}\n\n`,
 ].join('');
 
+// Codex apply_patch: a short preamble message, then a *custom* (freeform) tool
+// call whose body streams as raw text via `custom_tool_call_input.delta` — NOT
+// `function_call_arguments`. The 16K document lives in those deltas.
+const RESPONSES_CUSTOM_TOOL_STREAM = [
+  `event: response.output_text.delta\ndata: ${JSON.stringify({
+    type: 'response.output_text.delta',
+    output_index: 0,
+    delta: 'Writing the doc now.',
+  })}\n\n`,
+  `event: response.output_item.added\ndata: ${JSON.stringify({
+    type: 'response.output_item.added',
+    output_index: 1,
+    item: { type: 'custom_tool_call', id: 'ctc_1', call_id: 'call_1', name: 'apply_patch', input: '' },
+  })}\n\n`,
+  `event: response.custom_tool_call_input.delta\ndata: ${JSON.stringify({
+    type: 'response.custom_tool_call_input.delta',
+    item_id: 'ctc_1',
+    output_index: 1,
+    delta: '*** Begin Patch\n',
+  })}\n\n`,
+  `event: response.custom_tool_call_input.delta\ndata: ${JSON.stringify({
+    type: 'response.custom_tool_call_input.delta',
+    item_id: 'ctc_1',
+    output_index: 1,
+    delta: '+the whole document\n',
+  })}\n\n`,
+  `event: response.custom_tool_call_input.done\ndata: ${JSON.stringify({
+    type: 'response.custom_tool_call_input.done',
+    item_id: 'ctc_1',
+    output_index: 1,
+    input: '*** Begin Patch\n+the whole document\n',
+  })}\n\n`,
+  `event: response.completed\ndata: ${JSON.stringify({
+    type: 'response.completed',
+    response: { id: 'resp_2', model: 'gpt-5.5', status: 'completed' },
+  })}\n\n`,
+].join('');
+
 // Gemini native streaming: bare `data:` lines (no `event:`, no top-level `type`)
 // whose payload carries `candidates[].content.parts[]`. Reasoning parts are
 // flagged `thought: true`; tool calls are `functionCall` with an *object* `args`;
@@ -265,6 +303,37 @@ describe('parseSseStream — OpenAI chat.completion.chunk', () => {
     expect(tools.assembled.finishReason).toBe('tool_calls');
     expect(tools.events[0]?.kind).toBe('tool_call');
   });
+
+  it('assembles a streamed refusal as visible content', () => {
+    const stream = [
+      `data: ${JSON.stringify({
+        choices: [{ index: 0, delta: { refusal: 'I cannot ' } }],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        choices: [{ index: 0, delta: { refusal: 'do that.' }, finish_reason: 'stop' }],
+      })}\n\n`,
+      'data: [DONE]\n\n',
+    ].join('');
+    const parsed = parseSseStream(stream);
+    expect(parsed.assembled.content).toBe('I cannot do that.');
+    expect(parsed.assembled.finishReason).toBe('stop'); // finish on the refusal chunk is kept
+    expect(parsed.events.map((e) => e.kind)).toEqual(['content', 'content', 'done']);
+  });
+
+  it('keeps finish_reason when it rides the same chunk as the final content token', () => {
+    const stream = [
+      `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: 'Hi' } }] })}\n\n`,
+      `data: ${JSON.stringify({
+        choices: [{ index: 0, delta: { content: '!' }, finish_reason: 'stop' }],
+      })}\n\n`,
+      'data: [DONE]\n\n',
+    ].join('');
+    const parsed = parseSseStream(stream);
+    expect(parsed.assembled.content).toBe('Hi!');
+    expect(parsed.assembled.finishReason).toBe('stop');
+    // The combined chunk still reports as content (content-first), not finish.
+    expect(parsed.events.map((e) => e.kind)).toEqual(['content', 'content', 'done']);
+  });
 });
 
 describe('parseSseStream — Anthropic events', () => {
@@ -287,6 +356,25 @@ describe('parseSseStream — Anthropic events', () => {
     expect(kinds).toContain('content');
     expect(kinds[kinds.length - 2]).toBe('finish'); // message_delta w/ stop_reason
   });
+
+  it('opens a tool call for server_tool_use blocks so input_json_delta is kept', () => {
+    const stream = [
+      `event: content_block_start\ndata: ${JSON.stringify({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'server_tool_use', id: 'srvtoolu_1', name: 'web_search' },
+      })}\n\n`,
+      `event: content_block_delta\ndata: ${JSON.stringify({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"query":"helm"}' },
+      })}\n\n`,
+    ].join('');
+    const parsed2 = parseSseStream(stream);
+    expect(parsed2.assembled.toolCalls).toEqual([
+      { id: 'srvtoolu_1', name: 'web_search', arguments: '{"query":"helm"}' },
+    ]);
+  });
 });
 
 describe('parseSseStream — OpenAI Responses API events', () => {
@@ -308,6 +396,113 @@ describe('parseSseStream — OpenAI Responses API events', () => {
       'content',
       'content',
       'finish',
+    ]);
+  });
+});
+
+describe('parseSseStream — OpenAI Responses custom tool (apply_patch)', () => {
+  const parsed = parseSseStream(RESPONSES_CUSTOM_TOOL_STREAM);
+
+  it('keeps the preamble as content and captures the full custom-tool body', () => {
+    expect(parsed.assembled.content).toBe('Writing the doc now.');
+    expect(parsed.assembled.toolCalls).toEqual([
+      {
+        id: 'call_1',
+        name: 'apply_patch',
+        arguments: '*** Begin Patch\n+the whole document\n',
+      },
+    ]);
+    expect(parsed.assembled.finishReason).toBe('completed');
+  });
+
+  it('classifies the input deltas as tool_call, not meta', () => {
+    expect(parsed.events.map((e) => e.kind)).toEqual([
+      'content', // preamble
+      'tool_call', // output_item.added(custom_tool_call)
+      'tool_call', // input.delta
+      'tool_call', // input.delta
+      'tool_call', // input.done
+      'finish',
+    ]);
+  });
+});
+
+describe('parseSseStream — OpenAI Responses refusal + mcp/code tools', () => {
+  it('assembles a streamed refusal as visible content (not "No visible output")', () => {
+    const stream = [
+      `event: response.refusal.delta\ndata: ${JSON.stringify({
+        type: 'response.refusal.delta',
+        delta: "I can't help ",
+      })}\n\n`,
+      `event: response.refusal.delta\ndata: ${JSON.stringify({
+        type: 'response.refusal.delta',
+        delta: 'with that.',
+      })}\n\n`,
+      `event: response.refusal.done\ndata: ${JSON.stringify({
+        type: 'response.refusal.done',
+        refusal: "I can't help with that.",
+      })}\n\n`,
+    ].join('');
+    const parsed = parseSseStream(stream);
+    expect(parsed.assembled.content).toBe("I can't help with that.");
+    expect(parsed.events.map((e) => e.kind)).toEqual(['content', 'content', 'content']);
+  });
+
+  it('captures mcp_call and code_interpreter tool bodies', () => {
+    const stream = [
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        type: 'response.output_item.added',
+        item: { type: 'mcp_call', id: 'mcp_1', name: 'search', server_label: 'docs' },
+      })}\n\n`,
+      `event: response.mcp_call_arguments.delta\ndata: ${JSON.stringify({
+        type: 'response.mcp_call_arguments.delta',
+        item_id: 'mcp_1',
+        delta: '{"q":"helm"}',
+      })}\n\n`,
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        type: 'response.output_item.added',
+        item: { type: 'code_interpreter_call', id: 'ci_1' },
+      })}\n\n`,
+      `event: response.code_interpreter_call_code.delta\ndata: ${JSON.stringify({
+        type: 'response.code_interpreter_call_code.delta',
+        item_id: 'ci_1',
+        delta: 'print(1)',
+      })}\n\n`,
+    ].join('');
+    const parsed = parseSseStream(stream);
+    expect(parsed.assembled.toolCalls).toEqual([
+      { id: 'mcp_1', name: 'search', arguments: '{"q":"helm"}' },
+      { id: 'ci_1', name: 'code_interpreter', arguments: 'print(1)' },
+    ]);
+  });
+
+  it('routes interleaved tool-arg deltas to the right call by item_id', () => {
+    // Two function_call items opened back-to-back, THEN their deltas interleave —
+    // "append to the last call" would corrupt call A with call B's args.
+    const stream = [
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        type: 'response.output_item.added',
+        item: { type: 'function_call', id: 'fc_a', call_id: 'call_a', name: 'a' },
+      })}\n\n`,
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        type: 'response.output_item.added',
+        item: { type: 'function_call', id: 'fc_b', call_id: 'call_b', name: 'b' },
+      })}\n\n`,
+      `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({
+        type: 'response.function_call_arguments.delta',
+        item_id: 'fc_a',
+        delta: '{"x":1}',
+      })}\n\n`,
+      `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({
+        type: 'response.function_call_arguments.delta',
+        item_id: 'fc_b',
+        delta: '{"y":2}',
+      })}\n\n`,
+    ].join('');
+    const parsed = parseSseStream(stream);
+    expect(parsed.assembled.toolCalls).toEqual([
+      { id: 'call_a', name: 'a', arguments: '{"x":1}' },
+      { id: 'call_b', name: 'b', arguments: '{"y":2}' },
     ]);
   });
 });
@@ -342,6 +537,34 @@ describe('parseSseStream — Gemini native events', () => {
     ]);
     expect(tools.assembled.finishReason).toBe('STOP');
     expect(tools.events.map((e) => e.kind)).toEqual(['reasoning', 'tool_call']);
+  });
+
+  it('captures executableCode and codeExecutionResult parts as content', () => {
+    const stream = [
+      `data: ${JSON.stringify({
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ executableCode: { language: 'PYTHON', code: 'print(2+2)' } }],
+            },
+            index: 0,
+          },
+        ],
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        candidates: [
+          {
+            content: { role: 'model', parts: [{ codeExecutionResult: { outcome: 'OUTCOME_OK', output: '4' } }] },
+            finishReason: 'STOP',
+            index: 0,
+          },
+        ],
+      })}\n\n`,
+    ].join('');
+    const parsed = parseSseStream(stream);
+    expect(parsed.assembled.content).toBe('print(2+2)4');
+    expect(parsed.events.map((e) => e.kind)).toEqual(['content', 'content']);
   });
 });
 

--- a/apps/admin/src/lib/sse.ts
+++ b/apps/admin/src/lib/sse.ts
@@ -113,8 +113,23 @@ function str(value: unknown): string | null {
 
 interface Accumulator {
   assembled: AssembledStream;
-  // OpenAI tool_calls arrive fragmented and keyed by index.
+  // OpenAI chat.completion tool_calls arrive fragmented and keyed by index.
   toolsByIndex: Map<number, AssembledToolCall>;
+  // OpenAI Responses tool items are keyed by their `item_id`: a stream can open
+  // several tool calls, and their *.delta events interleave — routing by item_id
+  // (not "the last opened call") keeps each body with its own call.
+  responseToolsById: Map<string, AssembledToolCall>;
+}
+
+/** The Responses tool call a `*.delta`/`*.done` event belongs to: by `item_id`
+ * when present, else the last-opened call (handles captures lacking item_id). */
+function responseTool(
+  acc: Accumulator,
+  payload: Record<string, unknown>,
+): AssembledToolCall | undefined {
+  const id = str(payload.item_id);
+  const byId = id ? acc.responseToolsById.get(id) : undefined;
+  return byId ?? acc.assembled.toolCalls[acc.assembled.toolCalls.length - 1];
 }
 
 function mergeUsage(acc: Accumulator, usage: unknown): void {
@@ -162,7 +177,13 @@ function consumeOpenAiChunk(
   const finish = str(choice?.finish_reason);
   const reasoning = str(delta.reasoning_content) ?? str(delta.reasoning);
   const content = str(delta.content);
+  const refusal = str(delta.refusal);
   const toolCalls = Array.isArray(delta.tool_calls) ? delta.tool_calls : null;
+
+  // Some providers attach finish_reason to the SAME chunk that carries the final
+  // content/refusal/tool token (not a trailing empty chunk). Record it up front so
+  // the content-first early returns below never drop the terminal status.
+  if (finish) acc.assembled.finishReason = finish;
 
   if (toolCalls) {
     let label = '';
@@ -191,6 +212,11 @@ function consumeOpenAiChunk(
   if (content) {
     acc.assembled.content += content;
     return { kind: 'content', text: content };
+  }
+  if (refusal) {
+    // Safety refusal — visible output in place of an answer (mirrors content).
+    acc.assembled.content += refusal;
+    return { kind: 'content', text: refusal };
   }
   if (finish) {
     acc.assembled.finishReason = finish;
@@ -235,27 +261,65 @@ function consumeOpenAiResponseEvent(
       if (text && !acc.assembled.reasoning) acc.assembled.reasoning = text;
       return { kind: 'reasoning', text };
     }
-    case 'response.function_call_arguments.delta': {
+    // Refusals are visible output shown in place of an answer — without these a
+    // safety-refused turn assembles empty and renders "No visible output".
+    case 'response.refusal.delta': {
       const delta = str(payload.delta) ?? '';
-      const last = acc.assembled.toolCalls[acc.assembled.toolCalls.length - 1];
-      if (last) last.arguments += delta;
+      acc.assembled.content += delta;
+      return { kind: 'content', text: delta };
+    }
+    case 'response.refusal.done': {
+      const text = str(payload.refusal) ?? '';
+      if (text && !acc.assembled.content) acc.assembled.content = text;
+      return { kind: 'content', text };
+    }
+    // Tool-input deltas across ALL Responses tool flavors stream the same way:
+    // append the delta to the open tool call. function_call = JSON args;
+    // custom_tool_call (Codex apply_patch) = freeform text; mcp_call = JSON args;
+    // code_interpreter = generated code. Miss any flavor and a 16K tool body is
+    // lost as `meta` (the apply_patch bug). output_item.added opened the call.
+    case 'response.function_call_arguments.delta':
+    case 'response.custom_tool_call_input.delta':
+    case 'response.mcp_call_arguments.delta':
+    case 'response.code_interpreter_call_code.delta': {
+      const delta = str(payload.delta) ?? '';
+      const call = responseTool(acc, payload);
+      if (call) call.arguments += delta;
       return { kind: 'tool_call', text: delta };
     }
-    case 'response.function_call_arguments.done': {
-      const args = str(payload.arguments) ?? '';
-      const last = acc.assembled.toolCalls[acc.assembled.toolCalls.length - 1];
-      if (last && args && !last.arguments) last.arguments = args;
-      return { kind: 'tool_call', text: args };
+    // Authoritative full-body snapshot — the field name varies per tool flavor.
+    case 'response.function_call_arguments.done':
+    case 'response.custom_tool_call_input.done':
+    case 'response.mcp_call_arguments.done':
+    case 'response.code_interpreter_call_code.done': {
+      const full = str(payload.arguments) ?? str(payload.input) ?? str(payload.code) ?? '';
+      const call = responseTool(acc, payload);
+      if (call && full && !call.arguments) call.arguments = full;
+      return { kind: 'tool_call', text: full };
     }
     case 'response.output_item.added': {
       const item = asRecord(payload.item);
-      if (str(item?.type) === 'function_call') {
-        acc.assembled.toolCalls.push({
+      const itemType = str(item?.type);
+      // Every tool-call item type opens a tool call; its body arrives via the
+      // *.delta events above. code_interpreter_call carries no `name` → label it.
+      if (
+        itemType === 'function_call' ||
+        itemType === 'custom_tool_call' ||
+        itemType === 'mcp_call' ||
+        itemType === 'code_interpreter_call'
+      ) {
+        const call: AssembledToolCall = {
           id: str(item?.call_id) ?? str(item?.id),
-          name: str(item?.name) ?? '',
-          arguments: str(item?.arguments) ?? '',
-        });
-        return { kind: 'tool_call', text: str(item?.name) ?? '' };
+          name: str(item?.name) ?? (itemType === 'code_interpreter_call' ? 'code_interpreter' : ''),
+          // function_call → `arguments`; custom_tool_call → `input`;
+          // code_interpreter_call → `code` (usually empty here, filled by deltas).
+          arguments: str(item?.arguments) ?? str(item?.input) ?? str(item?.code) ?? '',
+        };
+        acc.assembled.toolCalls.push(call);
+        // Key by item_id so interleaved *.delta events route to the right call.
+        const itemId = str(item?.id);
+        if (itemId) acc.responseToolsById.set(itemId, call);
+        return { kind: 'tool_call', text: str(item?.name) ?? itemType };
       }
       return { kind: 'meta', text: type };
     }
@@ -317,7 +381,12 @@ function consumeAnthropicEvent(
     }
     case 'content_block_start': {
       const block = asRecord(payload.content_block);
-      if (str(block?.type) === 'tool_use') {
+      const blockType = str(block?.type);
+      // `tool_use` = client tool; `server_tool_use` = Anthropic-run tool (native
+      // web_search/code-execution). Both stream args via input_json_delta below,
+      // which appends to the last tool call — so both must open one here or the
+      // args vanish.
+      if (blockType === 'tool_use' || blockType === 'server_tool_use') {
         acc.assembled.toolCalls.push({
           id: str(block?.id),
           name: str(block?.name) ?? '',
@@ -373,6 +442,10 @@ function consumeGeminiEvent(
     const part = asRecord(rawPart);
     if (!part) continue;
     const fnCall = asRecord(part.functionCall);
+    // Gemini code execution: the model-written code and its run output ride as
+    // dedicated parts (not `text`) — without these a code-exec turn loses them.
+    const execCode = asRecord(part.executableCode);
+    const execResult = asRecord(part.codeExecutionResult);
     const text = str(part.text);
     if (fnCall) {
       const args = fnCall.args;
@@ -384,6 +457,11 @@ function consumeGeminiEvent(
       acc.assembled.toolCalls.push(call);
       kind = 'tool_call';
       label = call.name;
+    } else if (execCode || execResult) {
+      const code = str(execCode?.code) ?? str(execResult?.output) ?? '';
+      acc.assembled.content += code;
+      if (kind === null) kind = 'content';
+      if (kind === 'content') label = code;
     } else if (part.thought === true && text !== null) {
       acc.assembled.reasoning += text;
       if (kind !== 'tool_call') kind = 'reasoning';
@@ -417,6 +495,7 @@ export function parseSseStream(raw: string): ParsedSseStream {
       model: null,
     },
     toolsByIndex: new Map(),
+    responseToolsById: new Map(),
   };
 
   const events: SseEvent[] = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

The request-detail **响应** viewer reconstructs the streamed answer from the captured SSE. For a `gpt-5.5` (Codex) turn that wrote a ~16K document via **apply_patch**, the merged view showed only the one-line preamble — the entire document was lost. Root cause: apply_patch streams as a Responses **custom (freeform) tool** (`response.custom_tool_call_input.delta`), which the parser didn't recognise, so all 15k+ deltas fell through to `meta`.

## Audit + fixes

Swept all four protocol parsers in `apps/admin/src/lib/sse.ts` for the same "output-bearing event silently dropped" class:

| Protocol | Fix |
|---|---|
| Responses | `refusal`, `custom_tool_call` (apply_patch), `mcp_call`, `code_interpreter_call_code` now captured; tool-arg deltas routed **by `item_id`** (not "last opened call") so interleaved multi-tool streams don't cross-contaminate |
| chat.completion | `delta.refusal` captured; `finish_reason` recorded even when it rides the same chunk as the final content token |
| Anthropic | `server_tool_use` blocks open a tool call so `input_json_delta` isn't lost |
| Gemini | `executableCode` / `codeExecutionResult` parts captured |

Deliberately left as `meta` (no text to lose): status-only events (`*_call.in_progress/...`), binary (image/audio, Gemini `inlineData`), metadata (annotations/citations).

## Notes

- Pure **admin view-layer** change — storage keeps the raw stream verbatim (Principle 7). Applies **retroactively** to already-captured streams; no re-capture needed.
- Reviewed by Codex; both findings (item_id routing P2, finish_reason on refusal P3) addressed.
- 30 unit tests in `sse.test.ts`, `svelte-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)