### PR TITLE
feat(config): ZenMux Gemini image-generation models + sync box routing config (v0.22.14)

### DIFF
--- a/apps/gateway/e2e/routing.spec.ts
+++ b/apps/gateway/e2e/routing.spec.ts
@@ -32,11 +32,13 @@ const ECONOMY_HEAD = "deepseek/deepseek-v4-flash"; // economy static primary ser
 // so premium serves its first static fallback, deepseek/deepseek-v4-pro.
 const PREMIUM_HEAD = "deepseek/deepseek-v4-pro";
 const BALANCED_HEAD = "deepseek/deepseek-v4-pro"; // balanced static primary serves
-// economy chain = [deepseek/deepseek-v4-flash, openai-codex/gpt-5.4, balanced...].
-// On fault injection (scenario 4) the economy head 5xxs, the next candidate
-// openai-codex/gpt-5.4 is SKIPPED (no subscription), so the in-chain model that
-// actually serves is balanced's primary, deepseek/deepseek-v4-pro.
-const ECONOMY_NEXT = "deepseek/deepseek-v4-pro";
+// economy chain = [openai-codex/gpt-5.4-mini, anthropic/claude-haiku, deepseek/
+// deepseek-v4-flash, openrouter/deepseek-v4-flash, openrouter/auto, zenmux/auto].
+// On fault injection (scenario 4) the economy head 5xxs and the codex/anthropic
+// candidates before it are skipped, so the next in-chain model that serves is
+// openrouter/deepseek-v4-flash (wire id deepseek/deepseek-v4-flash != the failed
+// bare deepseek-v4-flash, so the mock serves it).
+const ECONOMY_NEXT = "openrouter/deepseek-v4-flash";
 
 // The upstream WIRE model ids the gateway sends (config/providers.yaml
 // `provider_model`), echoed back by the mock as `model`. All served candidates
@@ -44,7 +46,7 @@ const ECONOMY_NEXT = "deepseek/deepseek-v4-pro";
 // The routing ALIAS is surfaced separately via `x-helm-final-model`.
 const ECONOMY_HEAD_WIRE = "deepseek-v4-flash";
 const PREMIUM_HEAD_WIRE = "deepseek-v4-pro";
-const ECONOMY_NEXT_WIRE = "deepseek-v4-pro";
+const ECONOMY_NEXT_WIRE = "deepseek/deepseek-v4-flash";
 
 function chat(content: string, extra: Record<string, unknown> = {}) {
   return {
@@ -121,9 +123,9 @@ test.describe("routing e2e", () => {
 
   // ── Scenario 4: primary provider error → EXECUTION fallback serves ──────────
   // Mock injects a one-shot 5xx for the economy head (`deepseek/deepseek-v4-flash`);
-  // the next candidate `openai-codex/gpt-5.4` is skipped (no subscription), so the
-  // first STATIC in-chain candidate that serves is `deepseek/deepseek-v4-pro`. Lane
-  // stays `economy` (execution fallback ≠ classification fallback, principle 5).
+  // the skipped codex/anthropic candidates never serve, so the first in-chain
+  // candidate that serves is `openrouter/deepseek-v4-flash`. Lane stays `economy`
+  // (execution fallback ≠ classification fallback, principle 5).
   test("primary provider error -> fallback model serves (execution fallback)", async ({
     request,
   }) => {

--- a/apps/gateway/playwright.config.ts
+++ b/apps/gateway/playwright.config.ts
@@ -23,6 +23,10 @@ const e2eEnv = {
   // without it. A dummy value is enough: HELM_PROVIDER_BASE_URL points every
   // provider at the offline mock, so no real key is ever used.
   DEEPSEEK_API_KEY: "sk-upstream-mock-key",
+  // OpenRouter is a real production fallback provider (the economy/balanced tails
+  // route through it). Keyed so its mock-backed candidates serve — without it the
+  // economy execution-fallback (scenario 4) has no serving candidate after the head.
+  OPENROUTER_API_KEY: "sk-upstream-mock-key",
   HELM_PROVIDER_BASE_URL: `http://127.0.0.1:${MOCK_PORT}`,
   // e2e-only: lets the `x-helm-eval` request header toggle Layer-2 eval per
   // request so e2e.eval can black-box the cascade without a config reload.

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -162,6 +162,27 @@ zenmux-vertex/gemini-3.1-pro:
   modalities: [audio, video, document]
   maxContextTokens: 1048576
   maxOutputTokens: 65536
+# IMAGE GENERATION models. Manual-only (not in the LiteLLM catalog), so the FULL
+# field set is listed — an omitted maxContextTokens would default to 0 and the
+# capability filter would prune every request (context_too_small). jsonOutput:none
+# (no structured output) so a strict-JSON request prunes them; supportsVision:true
+# (they accept image INPUT for editing). Prompts are tiny, so 32k context never prunes.
+zenmux-vertex/gemini-3.1-flash-image:
+  supportsTools: false
+  jsonOutput: none
+  supportsVision: true
+  supportsStreaming: true
+  supportsCachedContent: false
+  maxContextTokens: 32768
+  maxOutputTokens: 32768
+zenmux-vertex/gemini-3-pro-image:
+  supportsTools: false
+  jsonOutput: none
+  supportsVision: true
+  supportsStreaming: true
+  supportsCachedContent: false
+  maxContextTokens: 32768
+  maxOutputTokens: 32768
 zenmux-anthropic/claude-opus-4.8:
   supportsTools: true
   jsonOutput: schema

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -23,17 +23,18 @@
 # —— quality/cost lanes ——
 economy:
   purpose: Cheap and fast for simple tasks
-  reasoning_effort: high
+  reasoning_effort: medium
   primary: openai-codex/gpt-5.4-mini
   fallback:
     - anthropic/claude-haiku-4-5-20251001
     - deepseek/deepseek-v4-flash
     - openrouter/deepseek-v4-flash
-    - balanced
+    - openrouter/auto
+    - zenmux/auto
 
 balanced:
   purpose: Default quality/cost tradeoff (classification fallback terminal)
-  reasoning_effort: high
+  reasoning_effort: medium
   primary: openai-codex/gpt-5.5
   fallback:
     - anthropic/claude-sonnet-4-6
@@ -45,7 +46,7 @@ balanced:
 
 premium:
   purpose: Strong reasoning and high quality
-  reasoning_effort: xhigh
+  reasoning_effort: high
   primary: openai-codex/gpt-5.5
   fallback:
     - anthropic/claude-opus-4-8
@@ -59,7 +60,7 @@ coding:
   purpose: Coding-capable models for code generation / editing
   # gpt-5.5 is the strongest model the Codex subscription actually exposes; the
   # legacy `*-codex` slugs 400 on the ChatGPT-account backend, so they are NOT used.
-  reasoning_effort: xhigh
+  reasoning_effort: high
   primary: openai-codex/gpt-5.5
   fallback:
     - premium
@@ -116,9 +117,7 @@ claude-opus:
   purpose: Anthropic Claude Opus tier — strongest Claude
   primary: anthropic/claude-opus-4-8
   fallback:
-    # When the native OAuth pool is parked/absent, stay on the NATIVE Anthropic wire
-    # (ZenMux, issue #217) before degrading into the GPT-led premium chain.
-    - zenmux-anthropic/claude-opus-4.8
+    # When the native OAuth pool is parked/absent, degrade into the GPT-led premium chain.
     - premium
 
 # Claude Fable 5 — the Mythos-class Claude (autonomous knowledge work + coding),
@@ -136,17 +135,15 @@ claude-sonnet:
   purpose: Anthropic Claude Sonnet tier — balanced Claude
   primary: anthropic/claude-sonnet-4-6
   fallback:
-    # NATIVE Anthropic wire (ZenMux, issue #217) before the generic balanced lane.
-    - zenmux-anthropic/claude-sonnet-4.6
+    # Native Anthropic OAuth pool, degrading to the generic balanced lane when parked.
     - balanced
 
-# ZenMux serves Claude Haiku over its native Anthropic endpoint, so this cheap/fast
-# tier keeps a NATIVE Haiku fallback before degrading to `economy` (deepseek-flash).
+# Native Anthropic Haiku via the OAuth pool; degrades straight to `economy`
+# (deepseek-flash) when the subscription is parked.
 claude-haiku:
   purpose: Anthropic Claude Haiku tier — cheap/fast
   primary: anthropic/claude-haiku-4-5-20251001
   fallback:
-    - zenmux-anthropic/claude-haiku-4.5
     - economy
 
 # Stays on GPT-5.5 ACROSS providers (Codex subscription -> static ZenMux key) before
@@ -199,3 +196,21 @@ gemini-flash:
   primary: zenmux-vertex/gemini-3.5-flash
   fallback:
     - balanced
+
+# —— image-generation lanes ——
+# Native-Gemini image models (responseModalities:[TEXT,IMAGE]). These lanes are
+# image-ONLY — the fallback is the OTHER image model, NEVER a text lane / `*/auto`
+# tail (a text model can't draw, so degrading there would return no image). Reached
+# by pinning a `gemini-*-image` id on an allow_custom_model key (the model-aliases
+# glob rewrites it onto the lane); a Gemini-CLI request passes through verbatim.
+gemini-flash-image:
+  purpose: Google Gemini Flash image generation (Nano Banana)
+  primary: zenmux-vertex/gemini-3.1-flash-image
+  fallback:
+    - zenmux-vertex/gemini-3-pro-image
+
+gemini-pro-image:
+  purpose: Google Gemini Pro image generation (Nano Banana Pro)
+  primary: zenmux-vertex/gemini-3-pro-image
+  fallback:
+    - zenmux-vertex/gemini-3.1-flash-image

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -64,6 +64,11 @@
 # `gemini-*` catch-all (7) — declaration order is irrelevant. The middle `*` absorbs the
 # version, so a future 3.2/4 flash-lite needs no edit; the trailing `*` absorbs any
 # `-preview` / `-latest` / date suffix (gemini-3.1-flash-lite, gemini-3.5-flash, …).
+# Image-generation ids route to the dedicated image lanes. Longest-literal wins, so
+# `gemini-*flash-image*` (18) beats the text `gemini-*flash*` (12) and `gemini-*pro-image*`
+# (16) beats `gemini-*pro*` (10) — a `*-image` id is never swallowed by a text lane.
+"gemini-*flash-image*": gemini-flash-image
+"gemini-*pro-image*": gemini-pro-image
 "gemini-*flash-lite*": economy
 "gemini-*flash*": gemini-flash
 "gemini-*pro*": gemini-pro

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -59,6 +59,18 @@ zenmux-vertex/gemini-3.1-flash-lite:
 zenmux-vertex/gemini-3.1-pro:
   inputPerMTokUsd: 2.0
   outputPerMTokUsd: 12.0
+# IMAGE models: Gemini bills the generated image as OUTPUT TOKENS (candidatesTokenCount,
+# modality IMAGE) at a per-Mtok IMAGE rate, and helm sets completion_tokens =
+# candidatesTokenCount — so outputPerMTokUsd = the ZenMux image rate yields the EXACT
+# per-image cost (a 1K–2K image = 1120 tokens → flash $0.067, pro $0.134). Rates verified
+# live on the ZenMux model pages 2026-06-28. outputPerMTokUsd is the IMAGE-output rate
+# (these are image models; the marginal text-output rate — flash $3, pro $12 — is unused).
+zenmux-vertex/gemini-3.1-flash-image:
+  inputPerMTokUsd: 0.5
+  outputPerMTokUsd: 60.0
+zenmux-vertex/gemini-3-pro-image:
+  inputPerMTokUsd: 2.0
+  outputPerMTokUsd: 120.0
 zenmux-anthropic/claude-opus-4.8:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 25.0

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -127,6 +127,14 @@ providers:
         provider_model: gemini-3.1-flash-lite
       - alias: zenmux-vertex/gemini-3.1-pro
         provider_model: gemini-3.1-pro-preview
+      # Native-Gemini IMAGE GENERATION models (responseModalities:[TEXT,IMAGE] →
+      # inlineData PNG parts; helm's gemini transformer maps these to IRMessage.images,
+      # and Gemini→Gemini native passthrough forwards them verbatim). Verified live
+      # 2026-06-28 against the ZenMux vertex-ai endpoint.
+      - alias: zenmux-vertex/gemini-3.1-flash-image
+        provider_model: gemini-3.1-flash-image
+      - alias: zenmux-vertex/gemini-3-pro-image
+        provider_model: gemini-3-pro-image
 
   # ZenMux Anthropic-Messages compatible endpoint (Claude native wire). `type:
   # anthropic` → executor appends `/v1/messages`, so the base_url ENDS at

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-28 · ZenMux Gemini 图片生成模型 + box→repo 路由配置合并（config；docs/02/04，原则 2/6）
+
+- **背景（Lukin）**：接入 `zenmux-vertex/gemini-3.1-flash-image`（Nano Banana 2）+ `gemini-3-pro-image`（Nano Banana Pro）做图片生成，要**准确计费**；并把 box 上 admin 改过的路由 config 拉回 repo 一起 PR。
+- **纯 config（无新代码）**：图片 I/O 早已铺好——IR 有 `IRMessage.images`，gemini-transformer 映射 `responseModalities:[TEXT,IMAGE]` ↔ `inlineData` part，Gemini→Gemini native passthrough 逐字转发。四文件：`providers.yaml`（两个 zenmux-vertex 别名，provider_model 用裸 `gemini-3.1-flash-image`/`gemini-3-pro-image`，live 验证）、`capabilities.yaml`（**manual-only 必列全字段**否则 maxContextTokens 默认 0 被剪；`jsonOutput:none`/`supportsVision:true`/32768）、`lanes.yaml`（`gemini-flash-image`/`gemini-pro-image` 两条**纯图片** lane，互为 fallback 不接文本/auto 尾）、`model-aliases.yaml`（`gemini-*flash-image*`(18 字面)胜文本 `*flash*`(12)）。
+- **准确计费（关键）**：Gemini 把生成图按 **OUTPUT TOKEN** 计（`candidatesTokenCount`，modality IMAGE，1K–2K 图=1120 token），而 helm `completion_tokens = candidatesTokenCount`——故 `outputPerMTokUsd =` ZenMux 图片费率即**精确每图成本**。ZenMux 页面实测：flash `$0.5 in / $60 image-out`、pro `$2 in / $120 image-out` per M。e2e 实测记录 `total_usd=0.0672055` = 1120×$60/M + 11×$0.5/M，**分毫不差**。text-out 费率（flash $3/pro $12）不用（图片模型）。
+- **路由 config 合并（box→repo，Lukin 选「路由+图片」不含部署开关）**：语义对比（parse YAML 比 primary/fallback/reasoning_effort，**忽略 admin 写回的 cosmetic `constraints:{all false}` 物化**）后并入 box 真实路由改动：economy `…balanced`→`…openrouter/auto,zenmux/auto`（Lukin 修的降级尾）、economy/balanced reasoning_effort high→medium、premium/coding xhigh→high、claude-opus/sonnet/haiku 去掉 `zenmux-anthropic/*` 原生兜底（同步改 stale #217 注释）。**不并** classifier `eval.enabled:true`/memory `llm/forgetting/mcp.oauth issuer=helm.easymeta.au`（部署专属、含 box 域名，保持 repo 开源默认 OFF）。capabilities/pricing 的 box 差异纯属 reorder+注释 strip，无值变更。
+- **验证**：`samples.test` 加图片 lane 路由断言（最长字面量胜、不被文本 lane 吞）；**全量 4757 单测绿**、typecheck/biome 干净；本地 docker 构建 0.22.14 跑 Gemini 原生请求→`gemini-flash-image` lane→native passthrough→**真 PNG 1408×768（视觉确认香蕉/苹果）**、决策记录 final=`zenmux-vertex/gemini-3.1-flash-image`。**约束**：图片生成需 allow_custom_model key（pin 模型）；OpenAI-chat 出图会被丢（协议无图片字段），走 Gemini-native/Anthropic。分支 `feat/gemini-image-generation`。
+
 ## 2026-06-28 · 客户端点名的模型若在候选链内则提到链首（路由；docs/04，原则 5/6）
 
 - **背景（Lukin，box 实查 req `1a4adea9`）**：Claude Code 请求 `claude-sonnet-4-6`（key **非 allow_custom_model**）→ 分类落 `coding` lane，链首 `openai-codex/gpt-5.5`，实际服务 gpt-5.5；而点名的 sonnet-4-6 本就在链第 5 位（`anthropic/claude-sonnet-4-6`，OAuth 订阅别名）且更便宜。诉求：只要分类后的链里含客户点名的模型就用它（提到链首），失败再回退——**不管 key 是否 allow_custom_model**。
@@ -26,18 +34,13 @@
 - **两处 UI**（均 Codex-only）：管理弹窗 Schedule tab 加 `auto-reset-toggle` checkbox；重置确认弹层加 `reset-auto-reset-toggle`（预填账号当前值，确认时**解耦**先 best-effort 存设置再 consume——重置失败设置也留住）。新 testid 不动旧的（e2e 安全，见 [[e2e-admin-specs-live-in-gateway]]）。
 - **验证**：`auto-reset.test`(7) + account-settings/admin-oauth/oauth-route 各补 autoReset 例；gateway admin+oauth 180 测、admin i18n 17 测、四包 typecheck、svelte-check 934/0/0、biome、**build 全绿**。i18n 走 extract+update 后手填 zh-hans/zh-hant/ja/ko 全四非英语 locale（Codex review P3：`i18n:update` 用英文占位会漏译，须手填，[[i18n-sync-incremental-empty-only]]）。分支 `feat-codex-auto-reset`，**未部署**。
 
-## 2026-06-26 · admin 导航骨架屏 + 详情页 payload 独立 fail-open（admin UI；docs/07，框架体感）
-
-- **背景（Lukin，线上体感）**：la.atmy.work admin 点请求列表/详情，进度条走完却不出内容、再点一次才出——「不像正常 HTML 页面」。调研定性：**非 SvelteKit bug**，是 SPA 阻塞式 `load` + 冷查询慢叠加，外加详情页静默吞错。后端冷查询已修（v0.21.35 indexed admin filters），剩前端体感 + 一个真 bug。
-- **决定（不走 SSR / 不逐页 await）**：SSR 违反原则 1（网关与 UI 解耦、admin headless 静态托管）且后端已快收益微；逐页 `{#await}` 要改 11 个 load + 9 个组件 churn 大。选 **全局延迟骨架**：`+layout.svelte` 监听 `$navigating`，仅「不同路由」且超 `SKELETON_DELAY_MS=150ms` 才显示 `PageSkeleton`（dashboard/detail/list 三形态、按 `route.id` 选）——热查询直接秒换不闪、同路由换筛选/翻页保留旧数据。一处改动覆盖所有页。
-- **详情页 fail-open（真 bug）**：`[traceId]/+page.ts` 原 `Promise.all([getRequest, getRequestPayload])` 注释说 payload「fails open」但代码里 payload 一失败**连累整页** → 改 payload 独立 `.catch(()=>{captured:false})`，只有 detail 本身失败才进错误态；错误态加 **Retry 按钮**（`invalidateAll`）。
-- **验证**：新 `PageSkeleton.svelte`（无文案、`aria-hidden`、零 i18n）；`requests.test` +2（payload 失败仍出 detail / detail 失败才报错，`PageLoad` 返回类型须 `Exclude<…,void>` 收窄）。admin **504 单测全绿**、svelte-check 934/0/0、build 通过。保留所有 testid（e2e 安全）。分支 `fix-admin-nav-skeleton`。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+- **2026-06-26 · admin 导航骨架屏 + 详情页 payload 独立 fail-open（admin UI；docs/07）**：admin 点列表/详情进度条走完却不出内容、再点才出——非 SvelteKit bug，是 SPA 阻塞 `load`+冷查询慢+详情页静默吞错。不走 SSR（违原则 1）/不逐页 await（churn 大），选**全局延迟骨架**：`+layout.svelte` 监听 `$navigating`，仅「不同路由」且超 `SKELETON_DELAY_MS=150ms` 才显 `PageSkeleton`（dashboard/detail/list 三态按 `route.id` 选），热查询秒换不闪、同路由换筛选保留旧数据。真 bug：详情页 `Promise.all([getRequest,getRequestPayload])` 里 payload 失败连累整页 → 改 payload 独立 `.catch` + 错误态加 Retry。`requests.test` +2，admin 504 绿、svelte-check 934/0/0。分支 `fix-admin-nav-skeleton`。
 
 - **2026-06-26 · 记忆事实 subject_key 上限 + base64/图片 blob 不入库（gateway 记忆；docs/12 P6）**：box `memory_facts` 现 1920 字符 subject_key（jpeg base64 data-URL），根因图片合法 user 内容经确定性兜底 `extractFactsDeterministic` 取前 6 词、base64 无空格=巨型词。两道防线（`forgetting/facts.ts` 叶子）：① subject_key ≤80 字符截断；② `buildReconciledFactBatch` 过滤 `isBlobText`（>200 字符且全无空白）blob 候选——真事实有空格、base64 无断点。未在 `serializeContent` 入库层剥图片 part（动 content_hash dedup 指纹+docs/08 审计存储 blast 大）。facts.test +cap/blob 例，core memory 353 绿。box 删该 1 条（备份 `memory-backup-20260626-213811.sql`）。分支 `fix-memory-subject-key-cap`。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.13",
+  "version": "0.22.14",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -133,6 +133,29 @@ describe("checked-in config samples", () => {
     expect(resolveModelAlias("gemini-embedding-001", aliases)).toBe("balanced");
   });
 
+  it("routes Gemini image ids onto dedicated image-generation lanes (flash-image vs pro-image)", () => {
+    const cfg = loadConfig({ configDir, env: {} });
+    const lanes = cfg.lanes;
+    const aliases = cfg.model_aliases;
+    if (lanes === undefined) throw new Error("config/lanes.yaml must load into config.lanes");
+    if (aliases === undefined) throw new Error("config/model-aliases.yaml must load");
+    // Image-generation lanes are image-ONLY (no text/auto tail): if one image model
+    // fails, fall back to the OTHER image model — never to a text lane that can't draw.
+    expect(lanes["gemini-flash-image"]?.primary).toBe("zenmux-vertex/gemini-3.1-flash-image");
+    expect(lanes["gemini-flash-image"]?.fallback).toEqual(["zenmux-vertex/gemini-3-pro-image"]);
+    expect(lanes["gemini-pro-image"]?.primary).toBe("zenmux-vertex/gemini-3-pro-image");
+    expect(lanes["gemini-pro-image"]?.fallback).toEqual(["zenmux-vertex/gemini-3.1-flash-image"]);
+    // Longest-literal wins: `*flash-image*` (18) beats the text `*flash*` (12), so an
+    // image id is NEVER swallowed by the text flash lane; `*pro-image*` (16) beats `*pro*`.
+    expect(resolveModelAlias("gemini-3.1-flash-image", aliases)).toBe("gemini-flash-image");
+    expect(resolveModelAlias("gemini-3-pro-image", aliases)).toBe("gemini-pro-image");
+    // The text flash/pro ids are unaffected by the new image globs.
+    expect(resolveModelAlias("gemini-3.5-flash", aliases)).toBe("gemini-flash");
+    expect(resolveModelAlias("gemini-2.5-pro", aliases)).toBe("gemini-pro");
+    // No drift: the new aliases still validate against the shipped lanes.
+    expect(validateModelAliasTargets(aliases, Object.keys(lanes))).toEqual([]);
+  });
+
   it("loads the shipped claude-fable vendor-family lane (native anthropic primary, premium fallback)", () => {
     const cfg = loadConfig({ configDir, env: {} });
     const lanes = cfg.lanes;


### PR DESCRIPTION
## Image generation

Adds two native-Gemini image-generation models on ZenMux Vertex:
- `zenmux-vertex/gemini-3.1-flash-image` (Nano Banana 2)
- `zenmux-vertex/gemini-3-pro-image` (Nano Banana Pro)

**Config-only** — image I/O is already plumbed: the IR carries `IRMessage.images`, the Gemini transformer maps `responseModalities:[TEXT,IMAGE]` ↔ `inlineData` parts, and Gemini→Gemini native passthrough forwards them verbatim. No new code.

- `providers.yaml`: two `zenmux-vertex` aliases (bare `gemini-3.1-flash-image` / `gemini-3-pro-image`, verified live)
- `capabilities.yaml`: full manual entries (`jsonOutput:none`, `supportsVision:true`, `maxContextTokens:32768`)
- `lanes.yaml`: `gemini-flash-image` / `gemini-pro-image` — **image-only** lanes (fall back only to the other image model; a text lane can't draw)
- `model-aliases.yaml`: `gemini-*flash-image*` / `gemini-*pro-image*` globs (longest-literal beats the text `*flash*` / `*pro*` lanes)

## Accurate billing

Gemini bills the generated image as **output tokens** (`candidatesTokenCount`, modality IMAGE; a 1K–2K image = 1120 tokens), and helm sets `completion_tokens = candidatesTokenCount` — so `outputPerMTokUsd` = the ZenMux image rate gives the **exact per-image cost**. Rates verified live on the ZenMux model pages:

| model | input /M | image-output /M | per image (1120 tok) |
|---|---|---|---|
| flash-image | \$0.5 | \$60 | \$0.067 |
| pro-image | \$2 | \$120 | \$0.134 |

End-to-end through the gateway, a flash image recorded `total_usd = 0.0672055` (1120 × \$60/M + 11 × \$0.5/M) — exact.

## Routing config sync (box → repo)

Reconciles the shipped lane config with what's live on the box (**routing only** — deployment toggles left as repo defaults):
- `economy` fallback now ends in the `*/auto` tail (not `balanced`)
- `economy`/`balanced` `reasoning_effort` high→medium; `premium`/`coding` xhigh→high
- `claude-opus`/`claude-sonnet`/`claude-haiku` drop their `zenmux-anthropic/*` native-wire fallback

Deliberately **not** synced: `classifier.eval.enabled`, `memory.llm/forgetting/mcp.oauth` — those are operator-owned/deployment-specific (the box's `mcp.oauth.issuer` carries the production domain), so they stay off in the repo defaults.

## Verification
- `samples.test` image-lane routing assertions (longest-literal wins; image ids not swallowed by text lanes)
- Full suite **4757 green**, typecheck + biome clean
- Local docker build (0.22.14): Gemini-native request → `gemini-flash-image` lane → native passthrough → real PNG 1408×768; decision record `final = zenmux-vertex/gemini-3.1-flash-image`

**Constraint:** image generation needs an `allow_custom_model` key (pin the model id); OpenAI-chat clients won't get images (the chat protocol has no image-output field) — use Gemini-native or Anthropic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)