### PR TITLE
feat(config): cross-provider image lanes — OpenAI + Google official providers (v0.22.19)

### DIFF
--- a/apps/gateway/e2e/images.spec.ts
+++ b/apps/gateway/e2e/images.spec.ts
@@ -50,18 +50,20 @@ test.describe("images e2e", () => {
   test("an image LANE serves its primary, and fails over to the fallback provider when the primary is down", async ({
     request,
   }) => {
-    // `gemini-image` is a lane (primary gemini-3.1-flash-image → fallback
-    // gemini-3-pro-image). A normal request serves the primary…
+    // `gemini-image` is a cross-provider lane (Google official
+    // google/gemini-3.1-flash-image → ZenMux gemini-3.1-flash-image →
+    // gemini-3-pro-image). A normal request serves the official primary…
     const ok = await request.post("/v1/images/generations", {
       headers: AUTH,
       data: { model: "gemini-image", prompt: "a kite" },
     });
     expect(ok.status()).toBe(200);
     expect(ok.headers()["x-helm-lane"]).toBe("gemini-image");
-    expect(ok.headers()["x-helm-final-model"]).toBe("gemini-3.1-flash-image");
+    expect(ok.headers()["x-helm-final-model"]).toBe("google/gemini-3.1-flash-image");
 
-    // …and when the primary is failing (mock steered by the sentinel prompt), the
-    // chain falls over to the fallback provider/model — still a 200 with an image.
+    // …and when the flash model is failing on BOTH providers (the sentinel fails
+    // provider_model gemini-3.1-flash-image, i.e. the Google primary AND the ZenMux
+    // flash leg), the chain falls over to the pro fallback — still a 200 with an image.
     const failover = await request.post("/v1/images/generations", {
       headers: AUTH,
       data: { model: "gemini-image", prompt: "__HELM_FAIL_IMAGE_PRIMARY__ a kite" },

--- a/apps/gateway/playwright.config.ts
+++ b/apps/gateway/playwright.config.ts
@@ -30,6 +30,13 @@ const e2eEnv = {
   // ZenMux carries the image models (gpt-image-2 via /v1/images/generations). Keyed
   // so its provider client is built — without it resolveImageTarget returns null (503).
   ZENMUX_API_KEY: "sk-upstream-mock-key",
+  // Official image providers (openai / google) lead the gpt-image / gemini-image
+  // cross-provider lanes. Keyed (dummy) so their clients are built and the lane
+  // serves its OFFICIAL primary — without these the chain would skip them as
+  // unavailable and the failover test would non-hermetically pass/fail on whether
+  // the runner happens to have the real keys in its environment.
+  OPENAI_API_KEY: "sk-upstream-mock-key",
+  GEMINI_API_KEY: "sk-upstream-mock-key",
   HELM_PROVIDER_BASE_URL: `http://127.0.0.1:${MOCK_PORT}`,
   // e2e-only: lets the `x-helm-eval` request header toggle Layer-2 eval per
   // request so e2e.eval can black-box the cascade without a config reload.

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -197,6 +197,34 @@ gpt-image-2:
   outputImage: true
   maxContextTokens: 32768
   maxOutputTokens: 32768
+# ─── OFFICIAL image providers (cross-provider failover; mirror the relay entries) ───
+openai/gpt-image-2:
+  supportsTools: false
+  jsonOutput: none
+  supportsVision: true
+  supportsStreaming: false
+  supportsCachedContent: false
+  outputImage: true
+  maxContextTokens: 32768
+  maxOutputTokens: 32768
+google/gemini-3.1-flash-image:
+  supportsTools: false
+  jsonOutput: none
+  supportsVision: true
+  supportsStreaming: true
+  supportsCachedContent: false
+  outputImage: true
+  maxContextTokens: 32768
+  maxOutputTokens: 32768
+google/gemini-3-pro-image:
+  supportsTools: false
+  jsonOutput: none
+  supportsVision: true
+  supportsStreaming: true
+  supportsCachedContent: false
+  outputImage: true
+  maxContextTokens: 32768
+  maxOutputTokens: 32768
 zenmux-anthropic/claude-opus-4.8:
   supportsTools: true
   jsonOutput: schema

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -197,7 +197,7 @@ gemini-flash:
   fallback:
     - balanced
 
-# —— image-generation lane (failover across image providers) ——
+# —— image-generation lanes (failover across image providers) ——
 # Image gen (POST /v1/images/generations, POST /v1beta/interactions, and Gemini
 # :generateContent on image models) is model-pinned per provider; group those
 # per-provider aliases into a LANE and the dedicated image endpoints fail over across
@@ -207,12 +207,19 @@ gemini-flash:
 # the verbatim request params are uniform across providers (a 4xx param-shape error is
 # terminal and would mask a healthy fallback). Request the LANE NAME as `model`.
 #
-# This default only wires one image provider (zenmux-vertex), so the example below
-# fails over flash→pro on that provider. For true multi-provider failover, add the
-# same image model under more providers (e.g. an `openrouter/gpt-image-2` alias) and
-# list them here. See docs/05 (image generation) + README.
-gemini-image:
-  purpose: Gemini image generation — flash primary, pro fallback
-  primary: gemini-3.1-flash-image
+# Each lane LEADS with the DIRECT official upstream (providers.yaml: openai / google,
+# needing OPENAI_API_KEY / GEMINI_API_KEY) and falls over to the ZenMux relay. With
+# no official key set, the official primary is unavailable and the lane serves from
+# the relay leg. See docs/05 (image generation) + README.
+gpt-image:
+  purpose: OpenAI gpt-image-2 — official primary, ZenMux fallback
+  primary: openai/gpt-image-2
   fallback:
+    - gpt-image-2
+
+gemini-image:
+  purpose: Gemini image — Google official → ZenMux Vertex flash → ZenMux pro
+  primary: google/gemini-3.1-flash-image
+  fallback:
+    - gemini-3.1-flash-image
     - gemini-3-pro-image

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -78,6 +78,17 @@ gemini-3-pro-image:
 gpt-image-2:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 30.0
+# OFFICIAL image providers (cross-provider failover). Same model = same rates as the
+# relay entries; OpenAI-direct gpt-image-2 verified live 196 out tok ≈ $0.006.
+openai/gpt-image-2:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 30.0
+google/gemini-3.1-flash-image:
+  inputPerMTokUsd: 0.5
+  outputPerMTokUsd: 60.0
+google/gemini-3-pro-image:
+  inputPerMTokUsd: 2.0
+  outputPerMTokUsd: 120.0
 zenmux-anthropic/claude-opus-4.8:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 25.0

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -178,6 +178,34 @@ providers:
       - alias: openrouter/auto
         provider_model: openrouter/auto
 
+  # ─── OFFICIAL image-generation providers (cross-provider failover) ───
+  # The gpt-image-2 / gemini-*-image models are reachable via the ZenMux relays
+  # above AND via these DIRECT official upstreams, so an image LANE (lanes.yaml:
+  # gpt-image / gemini-image) fails over across providers. Keys are env-var NAMES
+  # (set OPENAI_API_KEY / GEMINI_API_KEY in the environment); an unset key just makes
+  # that provider unavailable (the chain skips it), never a boot failure.
+
+  # OpenAI OFFICIAL — direct Images API for gpt-image-2.
+  - name: openai
+    type: openai
+    base_url: https://api.openai.com/v1
+    api_key_env: OPENAI_API_KEY
+    models:
+      - alias: openai/gpt-image-2
+        provider_model: gpt-image-2
+
+  # Google OFFICIAL — Generative Language API (gemini-*-image native wire,
+  # x-goog-api-key). `type: gemini` appends /models/{model}:{op} to base_url.
+  - name: google
+    type: gemini
+    base_url: https://generativelanguage.googleapis.com/v1beta
+    api_key_env: GEMINI_API_KEY
+    models:
+      - alias: google/gemini-3.1-flash-image
+        provider_model: gemini-3.1-flash-image
+      - alias: google/gemini-3-pro-image
+        provider_model: gemini-3-pro-image
+
   # ─────────────────────────────────────────────────────────────────────────────
   # OAUTH SUBSCRIPTION PROVIDER (issue #38) — EXAMPLE, COMMENTED OUT.
   # For subscription / SSO upstreams that issue SHORT-LIVED OAuth access tokens

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.18",
+  "version": "0.22.19",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What & why

Mirror the box's multi-provider image setup in the **shipped default config** so image generation fails over across providers (not just the single ZenMux relay). Follows #410 (the image-lane fallback engine).

## Changes (config only + 1 e2e assertion)
- **providers.yaml**: `openai` (api.openai.com) + `google` (generativelanguage.googleapis.com) official providers, keyed by env-var NAMES (`OPENAI_API_KEY` / `GEMINI_API_KEY`). An unset key → provider unavailable (chain skips it), never a boot failure.
- **capabilities.yaml / pricing.yaml**: `outputImage` + rate entries for `openai/gpt-image-2`, `google/gemini-3.1-flash-image`, `google/gemini-3-pro-image`.
- **lanes.yaml**:
  - `gpt-image`: `openai/gpt-image-2` → `gpt-image-2`
  - `gemini-image`: `google/gemini-3.1-flash-image` → `gemini-3.1-flash-image` → `gemini-3-pro-image`
  - Each leads with the DIRECT official upstream, falls over to the ZenMux relay.
- **e2e**: gemini-image is now cross-provider; primary-serve asserts `google/gemini-3.1-flash-image` (failover assertion unchanged — the sentinel fails both flash legs, the pro fallback serves).

## Verified
- 4815 unit + 77 e2e green; typecheck + biome clean.
- Live on the box (la.atmy.work): both lanes serve via the official providers, and a forced bad-key failover correctly fell over to the ZenMux relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)