### PR TITLE
feat(payloads): generated images viewable in admin detail page (v0.22.20)

### DIFF
--- a/apps/gateway/src/routes/image-chain.test.ts
+++ b/apps/gateway/src/routes/image-chain.test.ts
@@ -26,7 +26,6 @@ function target(alias: string, kind: "openai" | "gemini" = "openai"): ImageChain
 function okResult(cost: number | null = 0.01) {
   return {
     clientBody: { data: [{ b64_json: "IMG" }] },
-    captureBody: { data: [{ b64_json: "[image omitted]" }] },
     usage: { input_tokens: 1, output_tokens: 2 },
     cost,
     upstreamRequestJson: "{}",

--- a/apps/gateway/src/routes/image-chain.ts
+++ b/apps/gateway/src/routes/image-chain.ts
@@ -28,8 +28,11 @@ export interface ImageChainTarget {
 // response to the client body, price it); runImageChain only sequences attempts and
 // gates them on the breaker.
 export interface ImageAttemptResult {
-  clientBody: Record<string, unknown>; // returned verbatim to the client (full image)
-  captureBody: Record<string, unknown>; // image-stripped clone for payload capture
+  // Returned verbatim to the client AND captured for telemetry. The base64 image is
+  // NOT stripped here: the store's externalizeImages (payload-blobs.ts) content-
+  // addresses it into payload_blobs (deduped, retention-pruned) and rehydrates it for
+  // the admin detail view — so request_payloads stays lean AND the image is viewable.
+  clientBody: Record<string, unknown>;
   usage: Record<string, unknown> | null; // for budget-settle tokens + decision usage
   cost: number | null; // costOf(servedAlias, body)
   upstreamRequestJson: string | null; // exact bytes forwarded upstream (capture)

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -119,13 +119,16 @@ describe("registerImagesRoute", () => {
     expect(decision.usage.prompt_tokens).toBe(15);
   });
 
-  it("strips the base64 image from the captured payload (DB-bloat guard)", async () => {
+  it("captures the FULL image verbatim (the store externalizes it to payload_blobs)", async () => {
+    // The route no longer strips: it captures the full body. The DB-bloat guard moved
+    // to the store layer (externalizeImages → content-addressed payload_blobs), which
+    // ALSO makes the image rehydratable + viewable in the admin detail page.
     const { app, enqueuePayload } = setup();
     await post(app, { model: "gpt-image-2", prompt: "a cat" });
 
     const payload = enqueuePayload.mock.calls[0]?.[0];
     const stored = JSON.parse(payload.responseJson) as typeof UPSTREAM;
-    expect(stored.data[0]?.b64_json).toBe("[image omitted]"); // megabyte never persisted
+    expect(stored.data[0]?.b64_json).toBe("REALIMAGEBYTES"); // full image handed to capture
     expect(stored.usage.output_tokens).toBe(196); // metadata/usage preserved
   });
 

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -67,27 +67,6 @@ function extractBearer(auth: string | undefined): string | null {
   return m?.[1] ?? null;
 }
 
-// Capture-only clone with the ~1MB base64 image stripped — the request/response are
-// captured for audit, but the megabyte payload must never hit request_payloads
-// (operator DB-bloat guard). The CLIENT still receives the full image.
-function stripImageData(body: Record<string, unknown>): Record<string, unknown> {
-  const data = body.data;
-  if (!Array.isArray(data)) return body;
-  return {
-    ...body,
-    data: data.map((d) => {
-      if (
-        d !== null &&
-        typeof d === "object" &&
-        typeof (d as Record<string, unknown>).b64_json === "string"
-      ) {
-        return { ...(d as Record<string, unknown>), b64_json: "[image omitted]" };
-      }
-      return d;
-    }),
-  };
-}
-
 // Map a Gemini generateContent native response → the OpenAI Images shape, so the
 // rest of the route (cost, telemetry, client response) is provider-uniform. Image
 // parts (inlineData) become data[].b64_json; usageMetadata (candidatesTokenCount =
@@ -262,7 +241,6 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
       const usage = (upstream as { usage?: Record<string, unknown> }).usage ?? null;
       return {
         clientBody: upstream,
-        captureBody: stripImageData(upstream),
         usage,
         cost: deps.costOf(target.alias, upstream),
         upstreamRequestJson,
@@ -321,7 +299,11 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         finalErrorClass: null,
         usage: result.usage,
       });
-      const responseJson = captureEnabled(deps.record) ? JSON.stringify(result.captureBody) : null;
+      // Capture the FULL body — the store's externalizeImages (payload-blobs.ts)
+      // content-addresses the base64 image into payload_blobs (deduped + retention-
+      // pruned) and rehydrates it for the admin detail view. request_payloads keeps
+      // only a sentinel, so it stays lean while the image stays viewable.
+      const responseJson = captureEnabled(deps.record) ? JSON.stringify(result.clientBody) : null;
       await recordServed(
         deps.record,
         {

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -200,7 +200,9 @@ describe("registerInteractionsRoute", () => {
     });
   });
 
-  it("strips the base64 image from the captured payload (DB-bloat guard)", async () => {
+  it("captures the FULL image verbatim (the store externalizes it to payload_blobs)", async () => {
+    // No route-level strip: the store's externalizeImages content-addresses the image
+    // into payload_blobs (lean request_payloads) AND makes it viewable in the admin.
     const { app, enqueuePayload } = setup();
     await post(app, { model: "gemini-3.1-flash-image", input: "a cat" });
     const payload = enqueuePayload.mock.calls[0]?.[0];
@@ -208,7 +210,7 @@ describe("registerInteractionsRoute", () => {
       steps: Array<{ content: Array<{ type: string; data?: string }> }>;
     };
     const img = stored.steps[0]?.content.find((b) => b.type === "image");
-    expect(img?.data).toBe("[image omitted]");
+    expect(img?.data).toBe("GEMIMG"); // full image handed to capture
   });
 
   it("returns 401 without a valid key", async () => {

--- a/apps/gateway/src/routes/interactions.ts
+++ b/apps/gateway/src/routes/interactions.ts
@@ -177,29 +177,6 @@ function usageBodyFromNative(native: Record<string, unknown>): { usage: Record<s
   };
 }
 
-// Capture-only clone with the base64 image stripped — the megabyte payload must never
-// hit request_payloads (DB-bloat guard). The CLIENT still gets the full image.
-function stripInteractionData(body: Record<string, unknown>): Record<string, unknown> {
-  const steps = body.steps;
-  if (!Array.isArray(steps)) return body;
-  return {
-    ...body,
-    steps: steps.map((s) => {
-      const step = s as { content?: unknown };
-      if (!Array.isArray(step.content)) return s;
-      return {
-        ...step,
-        content: step.content.map((blk) => {
-          const b = blk as Record<string, unknown>;
-          return b.type === "image" && typeof b.data === "string"
-            ? { ...b, data: "[image omitted]" }
-            : blk;
-        }),
-      };
-    }),
-  };
-}
-
 export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsRouteDeps): void {
   app.use("/v1beta/interactions", concurrencyReleaseGuard());
 
@@ -340,7 +317,6 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
       const usageBody = usageBodyFromNative(native);
       return {
         clientBody: interactionsBody,
-        captureBody: stripInteractionData(interactionsBody),
         usage: usageBody.usage,
         cost: deps.costOf(target.alias, usageBody),
         upstreamRequestJson,
@@ -399,7 +375,10 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
         finalErrorClass: null,
         usage: result.usage,
       });
-      const responseJson = captureEnabled(deps.record) ? JSON.stringify(result.captureBody) : null;
+      // Capture the FULL body — the store's externalizeImages content-addresses the
+      // base64 image into payload_blobs (deduped + retention-pruned) and rehydrates it
+      // for the admin detail view; request_payloads keeps only a sentinel.
+      const responseJson = captureEnabled(deps.record) ? JSON.stringify(result.clientBody) : null;
       await recordServed(
         deps.record,
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.19",
+  "version": "0.22.20",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/payload-blobs.test.ts
+++ b/packages/core/src/store/payload-blobs.test.ts
@@ -161,6 +161,42 @@ describe("externalizeImages / rehydrateImages", () => {
     expect(JSON.parse(rehydrateImages(json, store(blobs)))).toEqual(JSON.parse(original));
   });
 
+  it("OpenAI Images output (data[].b64_json): externalizes + round-trips byte-exact", () => {
+    const data = bigB64(20);
+    const original = JSON.stringify({
+      created: 0,
+      data: [{ b64_json: data }],
+      usage: { output_tokens: 196 },
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(json).not.toContain(data); // the megabyte image is out of the payload text
+    expect(json).toContain("helm-blob:sha256:");
+    expect(blobs).toHaveLength(1);
+    expect(JSON.parse(rehydrateImages(json, store(blobs)))).toEqual(JSON.parse(original));
+  });
+
+  it("Gemini Interactions image block ({type:image,data}): externalizes + round-trips", () => {
+    const data = bigB64(21);
+    const original = JSON.stringify({
+      id: "int_1",
+      steps: [
+        {
+          type: "model_output",
+          status: "done",
+          content: [
+            { type: "text", text: "here you go" },
+            { type: "image", mime_type: "image/png", data },
+          ],
+        },
+      ],
+    });
+    const { json, blobs } = externalizeImages(original);
+    expect(json).not.toContain(data);
+    expect(blobs).toHaveLength(1);
+    expect(blobs[0]?.mime).toBe("image/png");
+    expect(JSON.parse(rehydrateImages(json, store(blobs)))).toEqual(JSON.parse(original));
+  });
+
   it("rehydrate fails open on non-JSON text containing the sentinel literal", () => {
     // Raw SSE (not a JSON document) whose model text happens to include the literal.
     const sse = 'event: delta\ndata: {"t":"helm-blob:sha256:dead"}\n\n';

--- a/packages/core/src/store/payload-blobs.ts
+++ b/packages/core/src/store/payload-blobs.ts
@@ -106,6 +106,21 @@ function walkExternalize(node: unknown, blobs: Map<string, PayloadBlob>): unknow
     }
   }
 
+  // OpenAI Images output: { b64_json:"<base64>" } (the /v1/images/generations data[]
+  // items — also the IR image shape). A bare base64 string, no `data:` wrapper.
+  if (typeof node.b64_json === "string") {
+    const ref = stash(node.b64_json, null, blobs);
+    if (ref) return { ...node, b64_json: ref };
+  }
+
+  // Gemini Interactions output block: { type:"image", mime_type, data:"<base64>" }
+  // (POST /v1beta/interactions steps[].content[]). Distinct from the Anthropic
+  // `type:"image"` block above, which carries the base64 under `source.data`.
+  if (node.type === "image" && typeof node.data === "string") {
+    const ref = stash(node.data, (node.mime_type as string | undefined) ?? null, blobs);
+    if (ref) return { ...node, data: ref };
+  }
+
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(node)) out[k] = walkExternalize(v, blobs);
   return out;

--- a/packages/core/src/store/sqlite/payload-cas.test.ts
+++ b/packages/core/src/store/sqlite/payload-cas.test.ts
@@ -62,6 +62,29 @@ describe("SqliteTelemetryStore — image CAS + gzip", () => {
     expect(got?.responseJson).toBe('{"ok":true}');
   });
 
+  it("externalizes an image-GEN RESPONSE (data[].b64_json) off-row + rehydrates it for the admin view", async () => {
+    const { store, blobCount } = setup();
+    const data = bigImageB64(9);
+    // The /v1/images/generations response shape — the generated image as b64_json.
+    const responseJson = JSON.stringify({
+      created: 0,
+      data: [{ b64_json: data }],
+      usage: { output_tokens: 196 },
+    });
+    await store.insertPayload({
+      requestId: "img1",
+      requestJson: '{"model":"gpt-image","prompt":"a cat"}',
+      responseJson,
+      createdAt: new Date(2000),
+    });
+
+    expect(blobCount()).toBe(1); // the megabyte image is off-row in payload_blobs
+    // getPayload rehydrates the full image so collectImages() can render it in the admin.
+    const got = await store.getPayload("img1");
+    const resp = JSON.parse(got?.responseJson ?? "") as { data: Array<{ b64_json: string }> };
+    expect(resp.data[0]?.b64_json).toBe(data); // byte-exact image restored
+  });
+
   it("dedups the SAME image across request + upstream into ONE blob", async () => {
     const { store, blobCount } = setup();
     const data = bigImageB64();


### PR DESCRIPTION
## What & why

Generated images couldn't be viewed in the admin request-detail page — the response was stripped to `"[image omitted]"` before capture (the DB-bloat guard), so the media overview had nothing to render.

## How (reuses the existing content-addressed image store)

Main already content-addresses chat images off-row into `payload_blobs` (deduped, gzipped, retention-pruned) via `externalizeImages`/`rehydrateImages` (`store/payload-blobs.ts`), rehydrating them byte-exact for the admin view. Generated images just weren't covered:

- **`payload-blobs.ts`**: `walkExternalize` now also recognizes the **OpenAI Images** output (`{b64_json}`) and the **Gemini Interactions** image block (`{type:"image",data}`).
- **`images.ts` / `interactions.ts`**: drop the route-level `"[image omitted]"` strip (and the `captureBody` clone) — capture the **full** body. The store externalizes the image, so `request_payloads` stays lean **and** `getPayload` rehydrates it for the detail page.

Net: `request_payloads` keeps only a sentinel (lean, perf unchanged); the image lives once in `payload_blobs` (deduped, pruned on `payload_retention_days`); the admin detail page rehydrates + renders it via the existing `collectImages`/`ImagePreview`. **No migration, no new table, no admin-UI change.**

## Tests
- `payload-blobs.test`: `b64_json` + interactions externalize/rehydrate round-trip.
- `sqlite/payload-cas.test`: image-gen response externalized off-row + rehydrated by `getPayload` (the admin path).
- `images`/`interactions` route tests: capture is now the full body.
- 4818 unit + 77 e2e green; typecheck + biome clean.

> Note: depends on no migration; merge order vs #411 (config, v0.22.19) — merge #411 first so versions stay monotonic (0.22.19 → 0.22.20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)