### PR TITLE
fix(anthropic): skip forced thinking for forced tool choice

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -2493,6 +2493,58 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(upstreamBodies[0]).toEqual(nativeBody);
   });
 
+  it("skips lane-forced Anthropic thinking when native tool_choice forces a tool", async () => {
+    const provider = anthropicProvider(NATIVE_RESP);
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["anthro", provider]]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-sonnet-4-6",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "anthropic_messages" as const,
+      body: {
+        model: "claude-sonnet-4-6",
+        max_tokens: 32000,
+        temperature: 1,
+        thinking: { type: "disabled" },
+        output_config: { effort: "high" },
+        tool_choice: { type: "tool", name: "web_search" },
+        tools: [{ name: "web_search", input_schema: { type: "object" } }],
+        messages: [{ role: "user", content: [{ type: "text", text: "search" }] }],
+      },
+      headers: { "x-api-key": "client" },
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["a"]),
+      anthropicReq({
+        native_request: carrier,
+        reasoning_effort: "medium",
+        reasoning_effort_forced: true,
+      }),
+    );
+
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body.thinking).toBeUndefined();
+    expect(forwarded.body.tool_choice).toEqual({ type: "tool", name: "web_search" });
+    expect(forwarded.mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_skipped_for_forced_tool_choice"],
+    });
+    expect(out.attempts[0]?.passthrough_mutations).toMatchObject(forwarded.mutations);
+  });
+
   it("strips empty Anthropic text blocks before native passthrough dispatch", async () => {
     const provider = anthropicProvider(NATIVE_RESP);
     const execute = createExecute({

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -616,8 +616,13 @@ function prepareNativeRequestForUpstream(
     if (rewritten.mutated) {
       body = rewritten.body;
       bodyChanged = true;
-      if (mutations)
-        appendMutationList(mutations, "body_shims_applied", ["reasoning_effort_forced"]);
+    }
+    if (mutations) {
+      appendMutationList(mutations, "body_shims_applied", [
+        rewritten.skippedReason === "forced_tool_choice"
+          ? "reasoning_effort_skipped_for_forced_tool_choice"
+          : "reasoning_effort_forced",
+      ]);
     }
   }
 

--- a/packages/core/src/protocol/reasoning-effort.test.ts
+++ b/packages/core/src/protocol/reasoning-effort.test.ts
@@ -102,6 +102,24 @@ describe("applyForcedReasoningToNativeBody — per protocol", () => {
     expect(body.temperature).toBe(1);
   });
 
+  it("anthropic_messages: skips forced thinking when tool_choice forces tool use", () => {
+    const { body, mutated, skippedReason } = applyForcedReasoningToNativeBody(
+      {
+        messages: [],
+        thinking: { type: "disabled" },
+        context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+        tool_choice: { type: "tool", name: "web_search" },
+      },
+      "anthropic_messages",
+      "high",
+    );
+    expect(mutated).toBe(true);
+    expect(skippedReason).toBe("forced_tool_choice");
+    expect(body.thinking).toBeUndefined();
+    expect(body.context_management).toBeUndefined();
+    expect(body.tool_choice).toEqual({ type: "tool", name: "web_search" });
+  });
+
   it("openai_chat: no-op (lingua franca never passes through)", () => {
     const { mutated } = applyForcedReasoningToNativeBody({ messages: [] }, "openai_chat", "high");
     expect(mutated).toBe(false);

--- a/packages/core/src/protocol/reasoning-effort.ts
+++ b/packages/core/src/protocol/reasoning-effort.ts
@@ -33,6 +33,37 @@ export interface AnthropicThinking {
   budget_tokens: number;
 }
 
+export type ForcedReasoningSkipReason = "forced_tool_choice";
+
+export interface ApplyForcedReasoningResult {
+  body: Record<string, unknown>;
+  mutated: boolean;
+  skippedReason?: ForcedReasoningSkipReason;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function anthropicToolChoiceForcesUse(body: Record<string, unknown>): boolean {
+  const toolChoice = body.tool_choice;
+  return (
+    toolChoice === "any" ||
+    (isRecord(toolChoice) && (toolChoice.type === "any" || toolChoice.type === "tool"))
+  );
+}
+
+function stripAnthropicThinkingForForcedToolChoice(body: Record<string, unknown>): {
+  body: Record<string, unknown>;
+  mutated: boolean;
+} {
+  if (body.thinking === undefined) return { body, mutated: false };
+  const next = { ...body };
+  delete next.thinking;
+  delete next.context_management;
+  return { body: next, mutated: true };
+}
+
 /** effort → Anthropic thinking block; `none`/unrecognized → undefined (disabled). */
 export function reasoningEffortToAnthropicThinking(effort: string): AnthropicThinking | undefined {
   const budget = ANTHROPIC_THINKING_BUDGET[effort];
@@ -78,7 +109,7 @@ export function applyForcedReasoningToNativeBody(
   body: Record<string, unknown>,
   protocol: TargetProviderProtocol,
   effort: string,
-): { body: Record<string, unknown>; mutated: boolean } {
+): ApplyForcedReasoningResult {
   switch (protocol) {
     case "gemini": {
       const tc = reasoningEffortToThinkingConfig(effort as IRReasoningEffort);
@@ -100,8 +131,13 @@ export function applyForcedReasoningToNativeBody(
       else next.reasoning = { effort };
       return { body: next, mutated: true };
     }
-    case "anthropic_messages":
+    case "anthropic_messages": {
+      if (effort !== "none" && anthropicToolChoiceForcesUse(body)) {
+        const stripped = stripAnthropicThinkingForForcedToolChoice(body);
+        return { ...stripped, skippedReason: "forced_tool_choice" };
+      }
       return { body: applyForcedAnthropicThinking(body, effort), mutated: true };
+    }
     default:
       return { body, mutated: false }; // openai_chat: never passes through.
   }


### PR DESCRIPTION
## Summary
- Prevent lane-forced Anthropic reasoning from injecting extended thinking when native passthrough `tool_choice` forces tool use.
- Preserve the forced tool call request shape and record `reasoning_effort_skipped_for_forced_tool_choice` in the mutation ledger.
- Add regression coverage for the production failure shape from request `39de84a5-b1b2-40b5-b958-77efec8e0338`.

## Root cause
Anthropic rejects extended thinking when `tool_choice` forces tool use. Helm's native passthrough path was applying lane-forced reasoning after the client had disabled thinking, creating an invalid upstream body.

## Tests
- `pnpm vitest run packages/core/src/protocol/reasoning-effort.test.ts`
- `pnpm vitest run apps/gateway/src/routes/execute.test.ts`
- `pnpm typecheck`
- `pnpm lint` (exit 0; existing non-blocking Biome suggestions remain outside this change)
- `git diff --check`