### PR TITLE
fix: show quota-window recovery for oauth limits

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -173,9 +173,25 @@
     return $t('resets in {m}m', { m: p.m });
   }
 
-  // Is this account auto-parked by a usage limit right now? (cooldown in the future)
-  const isUsageLimited = (q: OAuthQuotaSnapshot | undefined): boolean =>
-    q?.usageLimitedUntilMs != null && q.usageLimitedUntilMs > Date.now();
+  // Is this account auto-parked by a usage limit right now? Prefer a saturated
+  // quota window's reset over the short generic 429 fallback, so the status pill
+  // distinguishes 5h vs 7d limits when the quota snapshot proves the source.
+  function usageLimitStatus(
+    q: OAuthQuotaSnapshot | undefined,
+  ): { untilMs: number; label: string | null } | null {
+    const now = Date.now();
+    let untilMs =
+      q?.usageLimitedUntilMs != null && q.usageLimitedUntilMs > now ? q.usageLimitedUntilMs : null;
+    let label: string | null = null;
+    for (const w of q?.windows ?? []) {
+      if (w.usedPercent < 100 || w.resetsAtMs == null || w.resetsAtMs <= now) continue;
+      if (untilMs == null || w.resetsAtMs >= untilMs) {
+        untilMs = w.resetsAtMs;
+        label = windowLabel(w.key);
+      }
+    }
+    return untilMs == null ? null : { untilMs, label };
+  }
 
   // Countdown to auto-recovery for the rate-limited pill — same `durationParts`
   // coarsening as resetIn so a long cooldown reads "auto-recovers in 4d 16h".
@@ -337,8 +353,11 @@
       </p>
     </div>
     <div class="flex w-full shrink-0 gap-2 sm:w-auto">
-      <button type="button" class="btn-secondary flex-1 sm:flex-none" disabled={refreshing} onclick={refresh}
-        >{refreshing ? $t('Refreshing…') : $t('Refresh')}</button
+      <button
+        type="button"
+        class="btn-secondary flex-1 sm:flex-none"
+        disabled={refreshing}
+        onclick={refresh}>{refreshing ? $t('Refreshing…') : $t('Refresh')}</button
       >
       <button
         type="button"
@@ -424,6 +443,8 @@
             {@const saving = savingSchedule[k] === true}
             {@const isCodex = row.provider.id === 'openai-codex'}
             {@const codexCredits = isCodex ? (quota?.resetCredits ?? null) : null}
+            {@const usageLimit = usageLimitStatus(quota)}
+            {@const usageLimitRecovery = usageLimit ? autoRecoverIn(usageLimit.untilMs) : ''}
             <tr class="align-top" data-testid="provider-account-row">
               <!-- Provider / account + type badge -->
               <td data-label={$t('Provider')} class="px-3 py-3">
@@ -435,8 +456,9 @@
                     <span
                       class="badge-ok"
                       data-testid="auto-reset-badge"
-                      title={$t('Auto-resets the weekly limit once it saturates (at most once per hour)')}
-                      >{$t('Auto-reset')}</span
+                      title={$t(
+                        'Auto-resets the weekly limit once it saturates (at most once per hour)',
+                      )}>{$t('Auto-reset')}</span
                     >
                   {/if}
                 </div>
@@ -452,12 +474,14 @@
                 {#if !row.account.schedulable}
                   <div class="mt-1"><span class="badge-neutral">{$t('parked')}</span></div>
                 {/if}
-                {#if isUsageLimited(quota)}
+                {#if usageLimit}
                   <div class="mt-1">
                     <span class="badge-error">{$t('Rate limited')}</span>
-                    {#if quota && autoRecoverIn(quota.usageLimitedUntilMs)}
+                    {#if usageLimitRecovery}
                       <div class="text-[10px] text-ink-muted">
-                        {autoRecoverIn(quota.usageLimitedUntilMs)}
+                        {usageLimit.label
+                          ? `${usageLimit.label} · ${usageLimitRecovery}`
+                          : usageLimitRecovery}
                       </div>
                     {/if}
                   </div>
@@ -480,7 +504,10 @@
                 {#if row.account.models.length > 0}
                   {@const shown = row.account.models.slice(0, MODELS_SHOWN)}
                   {@const extra = row.account.models.length - shown.length}
-                  <div class="flex max-w-full flex-wrap gap-1 lg:w-48" title={row.account.models.join('\n')}>
+                  <div
+                    class="flex max-w-full flex-wrap gap-1 lg:w-48"
+                    title={row.account.models.join('\n')}
+                  >
                     {#each shown as m (m)}
                       <span class="badge-neutral font-mono text-[10px]">{m}</span>
                     {/each}
@@ -531,7 +558,10 @@
                   </div>
                 {/if}
                 {#if codexCredits != null}
-                  <div class="text-[10px] text-ink-muted" class:mt-1={quota && quota.windows.length > 0}>
+                  <div
+                    class="text-[10px] text-ink-muted"
+                    class:mt-1={quota && quota.windows.length > 0}
+                  >
                     {$t('{n} reset credits', { n: codexCredits })}
                   </div>
                 {/if}
@@ -573,7 +603,9 @@
               </td>
 
               <!-- Token expiry -->
-              <td data-label={$t('Expires')} class="px-3 py-3 text-ink-muted">{expiryLabel(row.account)}</td>
+              <td data-label={$t('Expires')} class="px-3 py-3 text-ink-muted"
+                >{expiryLabel(row.account)}</td
+              >
 
               <!-- Actions -->
               <td data-label={$t('Actions')} class="px-3 py-3 lg:text-right">
@@ -599,7 +631,7 @@
                         account: row.account.account,
                       })}>{$t('Manage')}</button
                   >
-                  {#if isUsageLimited(quota)}
+                  {#if usageLimit}
                     <button
                       type="button"
                       class="btn-secondary"

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -127,6 +127,34 @@ describe('providers page', () => {
     expect(within(row).getByText('claude-haiku-4-5')).toBeInTheDocument();
   });
 
+  it('uses the saturated quota window as the rate-limit recovery source', () => {
+    const now = Date.now();
+    renderPage({
+      quota: [
+        {
+          providerId: 'anthropic',
+          account: 'acct-claude',
+          windows: [
+            { key: '5h', usedPercent: 0, resetsAtMs: now + 30 * 60_000, windowMinutes: null },
+            {
+              key: '7d',
+              usedPercent: 100,
+              resetsAtMs: now + 8 * 60 * 60_000 + 11 * 60_000,
+              windowMinutes: null,
+            },
+          ],
+          capturedAt: now,
+          source: 'anthropic',
+          usageLimitedUntilMs: now + 60_000,
+        },
+      ],
+    });
+
+    const row = screen.getByTestId('provider-account-row');
+    expect(within(row).getByText('Rate limited')).toBeInTheDocument();
+    expect(within(row).getByText(/7d.*auto-recovers in 8h/i)).toBeInTheDocument();
+  });
+
   it('renders "Direct" and caps the models list with a +N pill', () => {
     renderPage({
       providers: [
@@ -286,7 +314,12 @@ describe('providers page', () => {
           providerId: 'openai-codex',
           account: 'acct-codex',
           windows: [
-            { key: 'primary', usedPercent: 80, resetsAtMs: Date.now() + 3_600_000, windowMinutes: 300 },
+            {
+              key: 'primary',
+              usedPercent: 80,
+              resetsAtMs: Date.now() + 3_600_000,
+              windowMinutes: 300,
+            },
           ],
           capturedAt: Date.now(),
           source: 'codex',
@@ -332,9 +365,7 @@ describe('providers page', () => {
     );
     expect(invalidateAllMock).toHaveBeenCalledTimes(1);
     // Success banner reflects how many windows were restored.
-    await waitFor(() =>
-      expect(screen.getByRole('status')).toHaveTextContent('Reset 2 window(s)'),
-    );
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Reset 2 window(s)'));
     // Dialog is dismissed after a successful reset.
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -165,6 +165,94 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(upsert).toHaveBeenCalled(); // the PULL refreshed the store
   });
 
+  it("GET /oauth/quota extends an active cooldown to the saturated window reset", async () => {
+    const now = Date.now();
+    const shortCooldown = now + 60_000;
+    const weeklyReset = now + 8 * 60 * 60_000;
+    const saturatedWeekly = {
+      key: "7d",
+      usedPercent: 100,
+      resetsAtMs: weeklyReset,
+      windowMinutes: null,
+    };
+    const applyUsageLimit = vi.fn(async () => {});
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "anthropic",
+        account: "default",
+        windows: [],
+        capturedAt: now,
+        source: "anthropic",
+        usageLimitedUntilMs: shortCooldown,
+      })),
+      getAll: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "default",
+          windows: [saturatedWeekly],
+          capturedAt: now,
+          source: "anthropic",
+          usageLimitedUntilMs: shortCooldown,
+        },
+      ]),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      fetchAnthropicQuota: vi.fn(async () => [saturatedWeekly]) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
+      "/admin/api/oauth/quota",
+    );
+
+    expect(res.status).toBe(200);
+    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", weeklyReset);
+  });
+
+  it("GET /oauth/quota does not newly park an unparked account from a PULL snapshot", async () => {
+    const now = Date.now();
+    const saturatedWeekly = {
+      key: "7d",
+      usedPercent: 100,
+      resetsAtMs: now + 8 * 60 * 60_000,
+      windowMinutes: null,
+    };
+    const applyUsageLimit = vi.fn(async () => {});
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "anthropic",
+        account: "default",
+        windows: [],
+        capturedAt: now,
+        source: "anthropic",
+        usageLimitedUntilMs: null,
+      })),
+      getAll: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "default",
+          windows: [saturatedWeekly],
+          capturedAt: now,
+          source: "anthropic",
+          usageLimitedUntilMs: null,
+        },
+      ]),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      fetchAnthropicQuota: vi.fn(async () => [saturatedWeekly]) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
+      "/admin/api/oauth/quota",
+    );
+
+    expect(res.status).toBe(200);
+    expect(applyUsageLimit).not.toHaveBeenCalled();
+  });
+
   it("GET /oauth/quota folds the live codex reset-credit count onto its snapshot", async () => {
     const window = { key: "primary", usedPercent: 40, resetsAtMs: null, windowMinutes: 300 };
     const oauthQuota = {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -1,3 +1,4 @@
+import { windowsToUsageLimit } from "@helm/core";
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
@@ -167,6 +168,20 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     // instant a credit is consumed, so a stored snapshot would lie). Keyed by acctKey;
     // attached onto the matching codex snapshot in the response below.
     const resetCredits = new Map<string, number | null>();
+    const extendActiveCooldownFromWindows = async (
+      providerId: string,
+      account: string,
+      windows: Parameters<typeof windowsToUsageLimit>[0],
+    ): Promise<void> => {
+      if (!deps.applyUsageLimit) return;
+      const nowMs = Date.now();
+      const quotaUntil = windowsToUsageLimit(windows, nowMs);
+      if (quotaUntil === null) return;
+      const current = await store.get(providerId, account).catch(() => null);
+      const currentUntil = current?.usageLimitedUntilMs ?? null;
+      if (currentUntil === null || currentUntil <= nowMs || currentUntil >= quotaUntil) return;
+      await deps.applyUsageLimit(providerId, account, quotaUntil).catch(() => {});
+    };
     if (s) {
       try {
         const status = await s.listStatus();
@@ -176,12 +191,12 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         // PUSH still updates the same store on live traffic — the PULL covers
         // accounts that have served nothing yet (else they render "—" forever).
         // NB: this observability PULL refreshes the stored window snapshot (and, for
-        // Codex, the live reset-credit count) but does NOT auto-park. Parking is driven
-        // only by live-traffic evidence (a real 429 in the executor, or a saturated
-        // x-codex header on a real reply) — never by a page-open quota read. That keeps
-        // "Reset usage" effective: clicking it reloads the page (this PULL), which would
-        // otherwise immediately re-derive the same saturated window and re-park the
-        // account before it can serve a single request.
+        // Codex, the live reset-credit count) but does NOT newly auto-park an otherwise
+        // active account. If the account is ALREADY parked by live-traffic evidence
+        // (generic 429 fallback), a saturated quota window may EXTEND that cooldown to
+        // the precise reset time. That keeps "Reset usage" effective: clearing the
+        // cooldown then reloading this page does not immediately re-park the account
+        // before it can serve a single request.
         const acctsOf = (id: string) => status.find((x) => x.id === id)?.accounts ?? [];
         const tasks: Array<Promise<void>> = [];
         // Anthropic: windows only.
@@ -201,6 +216,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                       source: "anthropic",
                     })
                     .catch(() => {});
+                  await extendActiveCooldownFromWindows("anthropic", a.account, windows);
                 }
               })(),
             );
@@ -225,6 +241,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                       source: "codex",
                     })
                     .catch(() => {});
+                  await extendActiveCooldownFromWindows("openai-codex", a.account, result.windows);
                 }
               })(),
             );


### PR DESCRIPTION
## Summary
- extend an already active OAuth usage-limit cooldown from saturated quota windows, without newly parking unparked accounts from quota pulls
- show the saturated quota window label in the providers table recovery text, e.g. `7d · auto-recovers in 8h 11m`
- add backend and providers-page regression coverage

## Validation
- `pnpm exec vitest run apps/gateway/src/routes/admin/oauth.test.ts apps/admin/src/routes/providers/providers.test.ts`
- `pnpm --filter @helm/gateway typecheck`
- `pnpm --filter @helm/admin check`
- `pnpm lint`