### PR TITLE
chore(release): v0.22.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.24",
+  "version": "0.22.25",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump root package version to `0.22.25` so the publish workflow creates release `v0.22.25`
- includes the merged OAuth quota recovery-window fix from #418

## Release behavior
When this lands on `main`, `.github/workflows/publish.yml` should push:
- `ghcr.io/easymetaau/helm-api:latest`
- `ghcr.io/easymetaau/helm-api:sha-<short>`
- `ghcr.io/easymetaau/helm-api:0.22.25`

and create GitHub Release `v0.22.25`.

## Validation
- `git diff --check`