### PR TITLE
Add dashboard home refresh control

### DIFF
--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { AreaChart, PieChart, Tooltip } from 'layerchart';
   import { untrack } from 'svelte';
-  import { goto } from '$app/navigation';
+  import { goto, invalidateAll } from '$app/navigation';
   import { base } from '$app/paths';
   import type { RequestListItem } from '$lib/api/requests.js';
   import type { DashboardStats } from '$lib/api/stats.js';
   import RangeFilter from '$lib/components/RangeFilter.svelte';
+  import RefreshControl from '$lib/components/RefreshControl.svelte';
   import RequestsTable from '$lib/components/RequestsTable.svelte';
   import { formatTrendTick, trendAxisTicks, type TrendBucket } from '$lib/dashboard-chart.js';
   import { formatCount, formatTokens, formatTps, formatUsd } from '$lib/format.js';
@@ -242,13 +243,23 @@
 </script>
 
 <div class="w-full px-4 py-6 md:px-8 md:py-8">
-  <header class="mb-6">
-    <h1 class="page-title">{$t('Overview')}</h1>
-    <p class="section-desc mt-1">
-      {$t(
-        'A live snapshot of how the gateway is routing requests right now, plus shortcuts to manage it.',
-      )}
-    </p>
+  <header class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <div class="min-w-0">
+      <h1 class="page-title">{$t('Overview')}</h1>
+      <p class="section-desc mt-1">
+        {$t(
+          'A live snapshot of how the gateway is routing requests right now, plus shortcuts to manage it.',
+        )}
+      </p>
+    </div>
+    <!-- Refresh now + auto-refresh cadence. Re-runs the dashboard loader, covering
+         stats, comparisons, charts, and the recent-request preview in one pass. -->
+    <div class="shrink-0">
+      <RefreshControl
+        onRefresh={() => invalidateAll()}
+        storageKey="helm_admin_home_refresh_interval"
+      />
+    </div>
   </header>
 
   <!-- Date-range filter: scopes the stat cards + recent-request preview to a window.

--- a/apps/admin/src/routes/home.test.ts
+++ b/apps/admin/src/routes/home.test.ts
@@ -1,5 +1,10 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invalidateAll } from '$app/navigation';
+import type { RequestListItem } from '$lib/api/requests.js';
 import type { DashboardStats } from '$lib/api/stats.js';
+import type { TrendBucket } from '$lib/dashboard-chart.js';
+import type { RangeKey } from '$lib/requests-filters.js';
 import { load } from './+page.js';
 
 const mocks = vi.hoisted(() => {
@@ -28,6 +33,64 @@ const mocks = vi.hoisted(() => {
 
 const EMPTY_STATS = mocks.emptyStats;
 
+// LayerChart touches browser-only APIs and is expensive to import in jsdom. The
+// component test uses an empty aggregate, so charts render empty states and these
+// stubs are never instantiated.
+vi.mock('layerchart', () => ({ AreaChart: () => {}, PieChart: () => {} }));
+
+import HomePage from './+page.svelte';
+
+type HomeStats = {
+  total: number;
+  ok: number;
+  errors: number;
+  successRate: number | null;
+  avgLatency: number | null;
+  avgTps: number | null;
+  totalCost: number | null;
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  cacheHitRate: number | null;
+};
+
+type HomePageData = {
+  items: RequestListItem[];
+  range: RangeKey;
+  startDate?: string;
+  endDate?: string;
+  bucket: TrendBucket;
+  stats: HomeStats;
+  agg: DashboardStats;
+  compare: Record<string, { pct: number | null; base: number }> | null;
+};
+
+function pageData(overrides: Partial<HomePageData> = {}): HomePageData {
+  return {
+    items: [],
+    range: 'today',
+    bucket: 'hour',
+    stats: {
+      total: 0,
+      ok: 0,
+      errors: 0,
+      successRate: null,
+      avgLatency: null,
+      avgTps: null,
+      totalCost: null,
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      cacheHitRate: null,
+    },
+    agg: EMPTY_STATS,
+    compare: null,
+    ...overrides,
+  };
+}
+
 vi.mock('$lib/api/stats.js', () => ({
   EMPTY_STATS: mocks.emptyStats,
   getStats: (...args: unknown[]) => mocks.getStats(...args),
@@ -42,6 +105,15 @@ describe('home dashboard loader', () => {
     vi.restoreAllMocks();
     mocks.getStats.mockReset().mockResolvedValue(EMPTY_STATS);
     mocks.listRequests.mockReset().mockResolvedValue({ items: [] });
+    vi.mocked(invalidateAll).mockClear();
+  });
+
+  it('renders a refresh control that reloads all dashboard data', async () => {
+    render(HomePage, { data: pageData() });
+
+    await fireEvent.click(screen.getByTestId('refresh-now'));
+
+    expect(invalidateAll).toHaveBeenCalledTimes(1);
   });
 
   it('loads all-time stats with an explicit full-history window', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.25",
+  "version": "0.22.26",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- add the shared RefreshControl to the dashboard homepage header
- reload homepage stats, comparisons, charts, and recent requests through invalidateAll()
- bump package version to 0.22.26 so the main-branch publish workflow creates the release after merge

## Validation
- git diff --check
- pnpm exec vitest run src/routes/home.test.ts (from apps/admin)
- pnpm --filter @helm/admin check
- pnpm --filter @helm/admin exec prettier --check src/routes/+page.svelte src/routes/home.test.ts --plugin prettier-plugin-svelte
- pnpm typecheck
- pnpm lint (success; reports existing unrelated Biome suggestions)
- pnpm build
- pnpm test (317 files, 4,838 tests)
