### PR TITLE
Fix OAuth 5h quota recovery

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -9,6 +9,7 @@
     type OAuthAccount,
     type OAuthProviderStatus,
     type OAuthQuotaSnapshot,
+    type OAuthQuotaWindow,
     type OAuthUsageRow,
   } from '$lib/api/oauth.js';
   import ConnectProviderDialog from '$lib/components/ConnectProviderDialog.svelte';
@@ -77,6 +78,7 @@
   let resetNotice = $state<string | null>(null);
 
   const keyOf = (providerId: string, account: string): string => `${providerId}/${account}`;
+  const ACTIVE_LIMIT_RECOVERY_THRESHOLD = 95;
 
   // One table row per connected account, flattened across providers, joined to its
   // usage + quota snapshot (both fail-open: a missing entry renders "—").
@@ -173,9 +175,26 @@
     return $t('resets in {m}m', { m: p.m });
   }
 
-  // Is this account auto-parked by a usage limit right now? Prefer a saturated
-  // quota window's reset over the short generic 429 fallback, so the status pill
-  // distinguishes 5h vs 7d limits when the quota snapshot proves the source.
+  function activeRecoveryWindow(
+    windows: OAuthQuotaWindow[],
+    now: number,
+    threshold: number,
+  ): OAuthQuotaWindow | null {
+    let chosen: OAuthQuotaWindow | null = null;
+    for (const w of windows) {
+      if (w.usedPercent < threshold || w.resetsAtMs == null || w.resetsAtMs <= now) {
+        continue;
+      }
+      if (chosen == null || w.resetsAtMs < (chosen.resetsAtMs ?? Number.POSITIVE_INFINITY)) {
+        chosen = w;
+      }
+    }
+    return chosen;
+  }
+
+  // Is this account auto-parked by a usage limit right now? Prefer the nearest
+  // near-full quota window over the short generic 429 fallback, so an Anthropic 5h
+  // limit reported as 98-99% still shows the real reset instead of "0m".
   function usageLimitStatus(
     q: OAuthQuotaSnapshot | undefined,
   ): { untilMs: number; label: string | null } | null {
@@ -183,12 +202,14 @@
     let untilMs =
       q?.usageLimitedUntilMs != null && q.usageLimitedUntilMs > now ? q.usageLimitedUntilMs : null;
     let label: string | null = null;
-    for (const w of q?.windows ?? []) {
-      if (w.usedPercent < 100 || w.resetsAtMs == null || w.resetsAtMs <= now) continue;
-      if (untilMs == null || w.resetsAtMs >= untilMs) {
-        untilMs = w.resetsAtMs;
-        label = windowLabel(w.key);
-      }
+    const recoveryWindow = activeRecoveryWindow(
+      q?.windows ?? [],
+      now,
+      untilMs == null ? 100 : ACTIVE_LIMIT_RECOVERY_THRESHOLD,
+    );
+    if (recoveryWindow?.resetsAtMs != null) {
+      untilMs = recoveryWindow.resetsAtMs;
+      label = windowLabel(recoveryWindow.key);
     }
     return untilMs == null ? null : { untilMs, label };
   }

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -155,6 +155,73 @@ describe('providers page', () => {
     expect(within(row).getByText(/7d.*auto-recovers in 8h/i)).toBeInTheDocument();
   });
 
+  it('uses a near-full 5h quota window over the generic 429 fallback', () => {
+    const now = Date.now();
+    renderPage({
+      quota: [
+        {
+          providerId: 'anthropic',
+          account: 'acct-claude',
+          windows: [
+            {
+              key: '5h',
+              usedPercent: 98,
+              resetsAtMs: now + 2 * 60 * 60_000 + 57 * 60_000,
+              windowMinutes: null,
+            },
+            {
+              key: '7d',
+              usedPercent: 61,
+              resetsAtMs: now + 5 * 86_400_000 + 10 * 60 * 60_000,
+              windowMinutes: null,
+            },
+            {
+              key: '7d-sonnet',
+              usedPercent: 37,
+              resetsAtMs: now + 5 * 86_400_000 + 10 * 60 * 60_000,
+              windowMinutes: null,
+            },
+          ],
+          capturedAt: now,
+          source: 'anthropic',
+          usageLimitedUntilMs: now + 60_000,
+        },
+      ],
+    });
+
+    const row = screen.getByTestId('provider-account-row');
+    expect(within(row).getByText('Rate limited')).toBeInTheDocument();
+    expect(within(row).getByText(/5h.*auto-recovers in 2h/i)).toBeInTheDocument();
+    expect(within(row).queryByText(/auto-recovers in 0m/i)).not.toBeInTheDocument();
+  });
+
+  it('does not mark a healthy account rate-limited from a near-full window alone', () => {
+    const now = Date.now();
+    renderPage({
+      quota: [
+        {
+          providerId: 'anthropic',
+          account: 'acct-claude',
+          windows: [
+            {
+              key: '5h',
+              usedPercent: 98,
+              resetsAtMs: now + 2 * 60 * 60_000 + 57 * 60_000,
+              windowMinutes: null,
+            },
+          ],
+          capturedAt: now,
+          source: 'anthropic',
+          usageLimitedUntilMs: null,
+        },
+      ],
+    });
+
+    const row = screen.getByTestId('provider-account-row');
+    expect(within(row).getByText('98%')).toBeInTheDocument();
+    expect(within(row).queryByText('Rate limited')).not.toBeInTheDocument();
+  });
+
   it('renders "Direct" and caps the models list with a +N pill', () => {
     renderPage({
       providers: [

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -210,6 +210,57 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", weeklyReset);
   });
 
+  it("GET /oauth/quota extends an active cooldown to a near-full 5h recovery reset", async () => {
+    const now = Date.now();
+    const shortCooldown = now + 60_000;
+    const fiveHourReset = now + 2 * 60 * 60_000 + 57 * 60_000;
+    const likelyFiveHourLimit = {
+      key: "5h",
+      usedPercent: 98,
+      resetsAtMs: fiveHourReset,
+      windowMinutes: null,
+    };
+    const applyUsageLimit = vi.fn(async () => {});
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "anthropic",
+        account: "default",
+        windows: [],
+        capturedAt: now,
+        source: "anthropic",
+        usageLimitedUntilMs: shortCooldown,
+      })),
+      getAll: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "default",
+          windows: [
+            likelyFiveHourLimit,
+            { key: "7d", usedPercent: 61, resetsAtMs: now + 5 * 86_400_000, windowMinutes: null },
+          ],
+          capturedAt: now,
+          source: "anthropic",
+          usageLimitedUntilMs: shortCooldown,
+        },
+      ]),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      fetchAnthropicQuota: vi.fn(async () => [
+        likelyFiveHourLimit,
+        { key: "7d", usedPercent: 61, resetsAtMs: now + 5 * 86_400_000, windowMinutes: null },
+      ]) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
+      "/admin/api/oauth/quota",
+    );
+
+    expect(res.status).toBe(200);
+    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", fiveHourReset);
+  });
+
   it("GET /oauth/quota does not newly park an unparked account from a PULL snapshot", async () => {
     const now = Date.now();
     const saturatedWeekly = {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -1,4 +1,4 @@
-import { windowsToUsageLimit } from "@helm/core";
+import { windowsToActiveUsageRecovery } from "@helm/core";
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
@@ -171,11 +171,11 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     const extendActiveCooldownFromWindows = async (
       providerId: string,
       account: string,
-      windows: Parameters<typeof windowsToUsageLimit>[0],
+      windows: Parameters<typeof windowsToActiveUsageRecovery>[0],
     ): Promise<void> => {
       if (!deps.applyUsageLimit) return;
       const nowMs = Date.now();
-      const quotaUntil = windowsToUsageLimit(windows, nowMs);
+      const quotaUntil = windowsToActiveUsageRecovery(windows, nowMs);
       if (quotaUntil === null) return;
       const current = await store.get(providerId, account).catch(() => null);
       const currentUntil = current?.usageLimitedUntilMs ?? null;
@@ -193,8 +193,8 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         // NB: this observability PULL refreshes the stored window snapshot (and, for
         // Codex, the live reset-credit count) but does NOT newly auto-park an otherwise
         // active account. If the account is ALREADY parked by live-traffic evidence
-        // (generic 429 fallback), a saturated quota window may EXTEND that cooldown to
-        // the precise reset time. That keeps "Reset usage" effective: clearing the
+        // (generic 429 fallback), a near-full quota window may EXTEND that cooldown to
+        // the likely reset time. That keeps "Reset usage" effective: clearing the
         // cooldown then reloading this page does not immediately re-park the account
         // before it can serve a single request.
         const acctsOf = (id: string) => status.find((x) => x.id === id)?.accounts ?? [];

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-30 · OAuth 5h 限额恢复时间不再落回 60s（admin/gateway，docs/04，原则 5）
+
+- **背景（Lukin）**：Subscription Providers 页里 Anthropic 账号已经被 429 标为 `Rate limited`，但 quota 快照显示 `5h=98%`、`7d/7d Sonnet` 远未打满；左侧却显示 `0 分钟后自动恢复`，因为只信 `usageLimitedUntilMs=now+60s` 的 generic 429 fallback。
+- **根因**：旧逻辑只把 `usedPercent >= 100` 当作可证明窗口，并且在 UI 中偏向更远的 reset。Anthropic usage PULL 在真实 5h 限额时可能仍报 98–99%（取样/舍入滞后），于是 `/oauth/quota` 没把已 park 账号延长到 5h reset，UI 也找不到窗口 label。
+- **修复决策**：保留 `windowsToUsageLimit` 的严格 100% 语义给「主动 park 健康账号」路径；新增 `windowsToActiveUsageRecovery`：只在账号**已经**因真实 429 处于 cooldown 时，使用 `>=95%` 的 near-full 窗口推断恢复时间，并取最近的未来 reset（5h 与 7d 只显示一个 active limiter）。`/admin/api/oauth/quota` 用它把 60s fallback 延长到真实窗口 reset；providers UI 用同样阈值显示 `5h · auto-recovers in ...`。
+- **取舍/坑**：不会因为单纯看到 98% 就提前 park 正常账号；near-full 仅用于「已有 cooldown」的恢复推断。若未来上游出现多个同时 active 的窗口，本实现按产品预期取最近 reset，最坏情况是过早重试一次后由 429 再次 park。
+- **验证**：新增 core 纯函数测试（98% 5h、最近 reset、94% 忽略）、gateway `/oauth/quota` 延长 active cooldown 测试、admin providers 页截图形态回归测试（不再显示 0m），并覆盖 98% 但未 park 的健康账号不误报。发布前 `pnpm test` 317 文件/4844 测绿，`typecheck`/`svelte-check`/`biome`/`build` 绿；版本 bump 到 v0.22.27。
+
 ## 2026-06-29 · OAuth 配额冷却 extend-only + refresh-429 归账号级（Codex review 跟进；provider 执行/池）
 
 - **背景**：v0.22.23 上线后让 Codex 复审，捞出两条 real-bug（均**非本次回归**，是更早就有的写入交互坑）。
@@ -24,18 +32,13 @@
 - **取舍/坑**：凭据失败不自动改 operator 的持久 `schedulable` 设置，也不删除 token；这是运行时健康隔离，重连/重建 pool 会重新按当前凭据判断。429 会持久化到 `oauth_quota` 的冷却窗口，重建 pool 后仍会绕开该账号直到窗口过期。`overload`(null-status) 当前算 server fault 计入 breaker——若实测短尖峰误触发，可收窄为仅真 HTTP 5xx 计入。
 - **验证**：OAuth pool 回归（非流式 + native passthrough streaming 的 `TokenRefreshError(401)`/持久 `401`/`429` 都转 sibling、后续不再选坏账号）不变；executor 回归更新为 B' 语义——账号级 `429`/`401`/`TokenRefreshError(401)` **不**记 breaker；**`502` 现在 *会* 记 breaker**；被 5xx 打开的 breaker **会**跳过 subscription alias（back-off）；新增端到端：连续 5 个 502 打开 breaker → 第 6 个请求 `circuit_open` 且不再打上游。`pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts apps/gateway/src/routes/execute.test.ts apps/gateway/src/server.oauth.test.ts` 全绿（execute 106）。
 
-## 2026-06-28 · 文档/README 对齐今日图片特性 + `/openapi.json` 完善（仅文档与 OpenAPI，无运行时改动）
-
-- **背景（Lukin）**：今日 v0.22.13–v0.22.20 一串提交后核对全部文档；其中**三个提交没碰文档**。另诉求 `/openapi.json` 不够完整、要更好用。
-- **文档缺口补全**：① v0.22.13「点名模型在选中 lane 链内则提到链首」——README/zh 的 model 表与备注原说"标准 key model 字段被忽略"已不准确，改写 + `docs/04` 新增权威小节「In-chain model promotion」（reorder-only、归一化匹配、over-budget/alias→auto 抑制）。② v0.22.19 官方 OpenAI/Google image provider 默认内置——README/zh env 表加 `OPENAI_API_KEY`/`GEMINI_API_KEY`、failover 示例改成内置的 `gpt-image`/`gemini-image` lane（官方上游→ZenMux 回退）、`.env.example` 补两 key。③ v0.22.15+v0.22.20 admin 媒体总览（含生成图）——README/zh payload inspector + `docs/11` 各补一句。
-- **OpenAPI（`apps/gateway/src/routes/openapi.ts`）**：补齐缺失的 `POST /v1beta/models/{model}:generateContent` 路径；images/interactions 的请求+响应 body 接现成 Zod schema（单一来源，不再是空 object）；声明 `x-goog-api-key` apiKey 安全方案并挂到两个 Gemini 端点；给 chat/messages/responses/images/interactions/gemini 各加可直接 "Try it out" 的请求示例；顶层加 tags 描述 + externalDocs。**取舍**：Anthropic/Responses/Gemini 是 loose passthrough，**不造假 full schema**——只给 example，诚实且 Swagger 可用。
-- **验证**：`openapi.test` 扩断言（11 path 全覆盖、4 个 image/interactions 组件、googleApiKey 方案）3/3 绿；gateway typecheck 干净、biome 干净；spec JSON round-trip 正常。fail-close 闸：**无 config/schema 改动**。发 v0.22.21。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+- **2026-06-28 · 文档/README 对齐今日图片特性 + `/openapi.json` 完善（仅文档与 OpenAPI，无运行时改动）**：补 README/zh + docs/04/11 中 in-chain model promotion、内置 image provider、admin 媒体总览说明；`openapi.ts` 补 Gemini `:generateContent`、images/interactions schema、Google apiKey security、示例与 tags。验证 `openapi.test` 3/3、gateway typecheck、biome，发 v0.22.21。
 
 - **2026-06-28 · 图片生成 lane fallback（多 provider 故障转移；gateway，docs/05，原则 5/8）**：把"同图片模型在多 provider 的别名"组成普通 lane 复用文本 fallback 抽象（core 零改动）：`execute.ts` 导出 5 个纯分类函数 + 新 `runImageChain` 镜像候选链（breaker/abort/4xx 终止/served-cost/链尽 502、空 503），`server.resolveImageChain` 展链（新导出 `expandLaneChain`）注入两 dedicated 端点；`:generateContent` 零代码（命中 §1a 显式 lane 展链走 execute 跨 provider fallback）。坑：image lane 须单一 kind；generateContent 按名选 lane 仅 allow_custom_model key；shipped `gemini-image` 示例只 wire 一 provider。4815 单测/77 e2e 绿。分支 `feat/image-lane-fallback` **未提交未部署**。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.26",
+  "version": "0.22.27",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -490,6 +490,7 @@ export {
 // PKCE / device-code login flows, built-in provider registry (anthropic,
 // github-copilot), and the flow primitives. Ported from openclaw (MIT).
 export {
+  ACTIVE_LIMIT_RECOVERY_THRESHOLD,
   type AnthropicLoginStart,
   anthropicOAuthProvider,
   anthropicUsageToWindows,
@@ -536,6 +537,7 @@ export {
   refreshGitHubCopilotToken,
   refreshOpenAICodexToken,
   type SerializeClientDeps,
+  windowsToActiveUsageRecovery,
   windowsToUsageLimit,
 } from "./provider/oauth/index.js";
 export {

--- a/packages/core/src/provider/oauth/index.ts
+++ b/packages/core/src/provider/oauth/index.ts
@@ -72,7 +72,9 @@ export type {
   OAuthProviderInterface,
 } from "./types.js";
 export {
+  ACTIVE_LIMIT_RECOVERY_THRESHOLD,
   DEFAULT_429_COOLDOWN_MS,
   LIMIT_THRESHOLD,
+  windowsToActiveUsageRecovery,
   windowsToUsageLimit,
 } from "./usage-limit.js";

--- a/packages/core/src/provider/oauth/usage-limit.test.ts
+++ b/packages/core/src/provider/oauth/usage-limit.test.ts
@@ -1,6 +1,12 @@
 import type { OAuthQuotaWindow } from "@helm/shared";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_429_COOLDOWN_MS, LIMIT_THRESHOLD, windowsToUsageLimit } from "./usage-limit.js";
+import {
+  ACTIVE_LIMIT_RECOVERY_THRESHOLD,
+  DEFAULT_429_COOLDOWN_MS,
+  LIMIT_THRESHOLD,
+  windowsToActiveUsageRecovery,
+  windowsToUsageLimit,
+} from "./usage-limit.js";
 
 const win = (over: Partial<OAuthQuotaWindow> = {}): OAuthQuotaWindow => ({
   key: "primary",
@@ -42,6 +48,40 @@ describe("windowsToUsageLimit", () => {
 
   it("exposes sane constants", () => {
     expect(LIMIT_THRESHOLD).toBe(100);
+    expect(ACTIVE_LIMIT_RECOVERY_THRESHOLD).toBeLessThan(LIMIT_THRESHOLD);
     expect(DEFAULT_429_COOLDOWN_MS).toBeGreaterThan(0);
+  });
+});
+
+describe("windowsToActiveUsageRecovery", () => {
+  it("uses a near-full 5h window once the account is already rate-limited", () => {
+    expect(
+      windowsToActiveUsageRecovery(
+        [
+          win({ key: "5h", usedPercent: 98, resetsAtMs: 8_000 }),
+          win({ key: "7d", usedPercent: 61, resetsAtMs: 90_000 }),
+          win({ key: "7d-sonnet", usedPercent: 37, resetsAtMs: 90_000 }),
+        ],
+        1_000,
+      ),
+    ).toBe(8_000);
+  });
+
+  it("chooses the nearest plausible recovery window", () => {
+    expect(
+      windowsToActiveUsageRecovery(
+        [
+          win({ key: "7d", usedPercent: 100, resetsAtMs: 90_000 }),
+          win({ key: "5h", usedPercent: 98, resetsAtMs: 8_000 }),
+        ],
+        1_000,
+      ),
+    ).toBe(8_000);
+  });
+
+  it("ignores windows that are not close to the limit", () => {
+    expect(windowsToActiveUsageRecovery([win({ usedPercent: 94, resetsAtMs: 8_000 })], 1_000)).toBe(
+      null,
+    );
   });
 });

--- a/packages/core/src/provider/oauth/usage-limit.ts
+++ b/packages/core/src/provider/oauth/usage-limit.ts
@@ -10,6 +10,12 @@ import type { OAuthQuotaWindow } from "@helm/shared";
 // account that is still serving at 99%.
 export const LIMIT_THRESHOLD = 100;
 
+// After a real 429 has already parked an account, use a slightly softer threshold
+// to identify the active provider window. Anthropic's usage endpoint can report the
+// 5h window as 98-99% while the account is already hard-limited, so exact 100% would
+// leave the account on the generic 60s fallback.
+export const ACTIVE_LIMIT_RECOVERY_THRESHOLD = 95;
+
 // Fallback cooldown for a 429 that carries no reset hint: short, so a transient 429
 // self-heals quickly and we re-probe rather than parking for hours on an ambiguous
 // signal. The precise (long) cooldown comes from the quota-window path when present.
@@ -26,6 +32,24 @@ export function windowsToUsageLimit(windows: OAuthQuotaWindow[], nowMs: number):
     if (w.usedPercent < LIMIT_THRESHOLD) continue;
     if (w.resetsAtMs === null || w.resetsAtMs <= nowMs) continue;
     if (until === null || w.resetsAtMs > until) until = w.resetsAtMs;
+  }
+  return until;
+}
+
+// Recovery time for an account that is ALREADY parked by a real upstream 429. This
+// is deliberately softer than windowsToUsageLimit: it must not pre-park a healthy
+// 98% account, but once the account is known limited, the near-full window gives a
+// better cooldown than the generic 60s fallback. Choose the nearest future reset
+// because subscription UIs surface one active limiter at a time.
+export function windowsToActiveUsageRecovery(
+  windows: OAuthQuotaWindow[],
+  nowMs: number,
+): number | null {
+  let until: number | null = null;
+  for (const w of windows) {
+    if (w.usedPercent < ACTIVE_LIMIT_RECOVERY_THRESHOLD) continue;
+    if (w.resetsAtMs === null || w.resetsAtMs <= nowMs) continue;
+    if (until === null || w.resetsAtMs < until) until = w.resetsAtMs;
   }
   return until;
 }


### PR DESCRIPTION
## Summary
- add an active OAuth quota-recovery helper for accounts already parked by a real upstream 429
- use near-full 5h Anthropic windows to replace the generic 60s cooldown in /admin/api/oauth/quota and the providers UI
- keep healthy near-full accounts from showing a rate-limited status, and bump package version to 0.22.27 for release

## Validation
- git diff --check
- pnpm test (317 files, 4,844 tests)
- pnpm typecheck
- pnpm --filter @helm/admin check
- pnpm lint (success; reports existing unrelated Biome suggestions)
- pnpm build
