### PR TITLE
fix: preserve Anthropic reasoning effort across fallback

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1,7 +1,9 @@
 import type { CircuitBreaker, ExecutionPlan, ProviderClient, ProviderRegistry } from "@helm/core";
 import {
+  anthropicTransformRequestOut,
   createCircuitBreaker,
   createGeminiClient,
+  createGenericOpenAIResponsesClient,
   TokenRefreshError,
   UpstreamError,
 } from "@helm/core";
@@ -168,6 +170,21 @@ async function* gen(chunks: string[]): AsyncGenerator<string> {
 function clock() {
   let t = 0;
   return () => (t += 10);
+}
+
+function responseJson(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+    ...init,
+  });
+}
+
+function responseSse(events: object[]): Response {
+  return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
 }
 
 describe("createExecute — gateway execution adapter", () => {
@@ -2195,6 +2212,23 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     });
   }
 
+  function anthropicReqFromNative(
+    nativeBody: Record<string, unknown>,
+    over: Partial<InternalRequest> = {},
+  ): InternalRequest {
+    const ir = anthropicTransformRequestOut(nativeBody);
+    return anthropicReq({
+      messages: ir.messages as InternalRequest["messages"],
+      max_tokens: typeof ir.max_tokens === "number" ? ir.max_tokens : null,
+      stream: ir.stream === true,
+      thinking: ir.thinking,
+      reasoning_effort: ir.reasoning_effort,
+      provider_raw: ir.provider_raw as InternalRequest["provider_raw"],
+      native_request: nativeBody,
+      ...over,
+    });
+  }
+
   const NATIVE_RESP = {
     id: "msg_1",
     type: "message",
@@ -2739,7 +2773,10 @@ describe("createExecute — native protocol passthrough (#217)", () => {
       nativePassthrough: vi.fn().mockRejectedValue(new UpstreamError("upstream_error", "boom")),
     } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
     const tail = {
-      chatCompletion: vi.fn().mockResolvedValue({ id: "translated-tail" }),
+      chatCompletion: vi.fn((body, options) => {
+        options?.captureUpstream?.(JSON.stringify(body));
+        return Promise.resolve({ id: "translated-tail" });
+      }),
       chatCompletionStream: vi.fn(),
     } as unknown as ProviderClient & { chatCompletion: ReturnType<typeof vi.fn> };
     const execute = createExecute({
@@ -2767,10 +2804,21 @@ describe("createExecute — native protocol passthrough (#217)", () => {
       nativeProtocolPassthroughEnabled: () => true,
     });
 
-    const out = await execute(plan(["a", "b"]), anthropicReq());
+    const out = await execute(
+      plan(["a", "b"]),
+      anthropicReqFromNative({
+        ...NATIVE,
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: { effort: "high" },
+      }),
+    );
     expect(head.nativePassthrough).toHaveBeenCalledTimes(1);
     expect(tail.chatCompletion).toHaveBeenCalledTimes(1);
-    expect(tail.chatCompletion.mock.calls[0]?.[0]).toMatchObject({ model: "gpt-x" });
+    const fallbackBody = tail.chatCompletion.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(fallbackBody).toMatchObject({ model: "gpt-x", reasoning_effort: "high" });
+    expect(fallbackBody.thinking).toBeUndefined();
+    expect(fallbackBody.output_config).toBeUndefined();
+    expect(out.upstreamRequest).toBe(JSON.stringify(fallbackBody));
     expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-x" });
     expect(out.body).toEqual({ id: "translated-tail" });
     expect(out.attempts[0]?.status).toBe("error");
@@ -2779,6 +2827,128 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(out.attempts[1]?.target_provider_protocol).toBe("openai_chat");
     expect(out.attempts[1]?.passthrough_used).toBe(false);
     expect(out.attempts[1]?.passthrough_disable_reason).toBe("protocol_mismatch");
+  });
+
+  it("cross-protocol fallback to OpenAI Responses sends captured upstream reasoning.effort without Anthropic-only fields", async () => {
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockRejectedValue(new UpstreamError("upstream_error", "boom")),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const tail = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: vi.fn(async () =>
+        responseJson({
+          id: "resp_1",
+          object: "response",
+          status: "completed",
+          output: [
+            { type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] },
+          ],
+        }),
+      ) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["anthro", head],
+        ["responses", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "responses",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      anthropicReqFromNative({
+        ...NATIVE,
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: { effort: "high" },
+      }),
+    );
+
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-5.5" });
+    const upstreamBody = JSON.parse(out.upstreamRequest ?? "{}");
+    expect(upstreamBody.reasoning).toEqual({ effort: "high" });
+    expect(upstreamBody.reasoning_effort).toBeUndefined();
+    expect(upstreamBody.thinking).toBeUndefined();
+    expect(upstreamBody.output_config).toBeUndefined();
+    expect(out.attempts[1]?.target_provider_protocol).toBe("openai_responses");
+  });
+
+  it("cross-protocol fallback to Gemini maps Anthropic reasoning into thinkingConfig without Anthropic-only fields", async () => {
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockRejectedValue(new UpstreamError("upstream_error", "boom")),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const tail = createGeminiClient({
+      config: { baseUrl: "https://generativelanguage.googleapis.com/v1beta", apiKey: "g" },
+      fetch: vi.fn(async () =>
+        responseJson({
+          candidates: [
+            { content: { role: "model", parts: [{ text: "ok" }] }, finishReason: "STOP" },
+          ],
+          usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+        }),
+      ) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["anthro", head],
+        ["google", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "google",
+          providerModel: "gemini-2.5-pro",
+          targetProviderProtocol: "gemini",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      anthropicReqFromNative({
+        ...NATIVE,
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: { effort: "high" },
+      }),
+    );
+
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gemini-2.5-pro" });
+    const upstreamBody = JSON.parse(out.upstreamRequest ?? "{}");
+    expect(upstreamBody.generationConfig?.thinkingConfig).toMatchObject({ includeThoughts: true });
+    expect(upstreamBody.reasoning_effort).toBeUndefined();
+    expect(upstreamBody.thinking).toBeUndefined();
+    expect(upstreamBody.output_config).toBeUndefined();
+    expect(out.attempts[1]?.target_provider_protocol).toBe("gemini");
   });
 
   it("an UpstreamError from nativePassthrough records a breaker failure and advances the chain", async () => {
@@ -3518,6 +3688,23 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     });
   }
 
+  function anthropicStreamReqFromNative(
+    nativeBody: Record<string, unknown>,
+    over: Partial<InternalRequest> = {},
+  ): InternalRequest {
+    const ir = anthropicTransformRequestOut(nativeBody);
+    return anthropicStreamReq({
+      messages: ir.messages as InternalRequest["messages"],
+      max_tokens: typeof ir.max_tokens === "number" ? ir.max_tokens : null,
+      stream: true,
+      thinking: ir.thinking,
+      reasoning_effort: ir.reasoning_effort,
+      provider_raw: ir.provider_raw as InternalRequest["provider_raw"],
+      native_request: nativeBody,
+      ...over,
+    });
+  }
+
   // Anthropic SSE frames the upstream byte-relays back, verbatim.
   const SSE = [
     'event: message_start\ndata: {"type":"message_start"}\n\n',
@@ -3795,16 +3982,93 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
       nativeProtocolPassthroughEnabled: () => true,
     });
 
-    const out = await execute(plan(["a", "b"]), anthropicStreamReq());
+    const out = await execute(
+      plan(["a", "b"]),
+      anthropicStreamReqFromNative({
+        ...NATIVE_STREAM,
+        thinking: { type: "enabled", budget_tokens: 8192 },
+        output_config: { effort: "xhigh" },
+      }),
+    );
 
     expect(head.nativePassthroughStream).toHaveBeenCalledTimes(1);
     expect(tail.chatCompletionStream).toHaveBeenCalledTimes(1);
+    const fallbackBody = tail.chatCompletionStream.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(fallbackBody).toMatchObject({ model: "gpt-x", reasoning_effort: "xhigh" });
+    expect(fallbackBody.thinking).toBeUndefined();
+    expect(fallbackBody.output_config).toBeUndefined();
     expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-x" });
     expect(out.stream).not.toBeNull();
     expect(out.attempts[0]?.passthrough_used).toBe(true);
     expect(out.attempts[1]?.target_provider_protocol).toBe("openai_chat");
     expect(out.attempts[1]?.passthrough_used).toBe(false);
     expect(out.attempts[1]?.passthrough_disable_reason).toBe("protocol_mismatch");
+  });
+
+  it("stream cross-protocol fallback to OpenAI Responses captures reasoning.effort without Anthropic-only fields", async () => {
+    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
+    async function* diesBeforeFirst(): AsyncGenerator<string> {
+      throw new UpstreamError("upstream_error", "connect failed");
+    }
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(diesBeforeFirst()),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const tail = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: vi.fn(async () =>
+        responseSse([
+          { type: "response.created", response: { id: "r1", status: "in_progress" } },
+          { type: "response.output_item.added", item: { type: "message", content: [] } },
+          { type: "response.output_text.delta", delta: "ok", output_index: 0, content_index: 0 },
+          { type: "response.output_text.done", text: "ok", output_index: 0, content_index: 0 },
+          { type: "response.completed", response: { id: "r1", status: "completed" } },
+        ]),
+      ) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["anthro", head],
+        ["responses", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "responses",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      anthropicStreamReqFromNative({
+        ...NATIVE_STREAM,
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        output_config: { effort: "high" },
+      }),
+    );
+
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-5.5" });
+    const upstreamBody = JSON.parse(out.upstreamRequest ?? "{}");
+    expect(upstreamBody.reasoning).toEqual({ effort: "high" });
+    expect(upstreamBody.reasoning_effort).toBeUndefined();
+    expect(upstreamBody.thinking).toBeUndefined();
+    expect(upstreamBody.output_config).toBeUndefined();
+    expect(out.stream).not.toBeNull();
+    expect(out.attempts[1]?.target_provider_protocol).toBe("openai_responses");
   });
 
   it("a client abort during the stream peek records client_abort without a breaker failure", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1652,9 +1652,19 @@ function stripInternal(
   if (req.max_tokens !== null) body.max_tokens = req.max_tokens;
   for (const key of FORWARDED_REQUEST_PARAM_KEYS) {
     const value = req[key];
-    if (key === "thinking" && Array.isArray(value)) {
-      requestMutations.thinking_history_stripped_for_target = true;
-      continue;
+    if (key === "thinking") {
+      if (Array.isArray(value)) {
+        requestMutations.thinking_history_stripped_for_target = true;
+        continue;
+      }
+      if (
+        targetProviderProtocol !== "anthropic_messages" &&
+        value !== undefined &&
+        value !== null
+      ) {
+        requestMutations.thinking_history_stripped_for_target = true;
+        continue;
+      }
     }
     if (value !== undefined && value !== null) body[key] = value;
   }

--- a/packages/core/src/protocol/anthropic/request.test.ts
+++ b/packages/core/src/protocol/anthropic/request.test.ts
@@ -576,6 +576,36 @@ describe("anthropic transformRequestOut", () => {
     expect(ir.thinking).toEqual({ type: "enabled", budget_tokens: 2048 });
   });
 
+  it("also normalizes Anthropic thinking budget into IR reasoning_effort", () => {
+    const ir = transformRequestOut({
+      model: "claude-3-7-sonnet",
+      max_tokens: 64,
+      thinking: { type: "enabled", budget_tokens: 4096 },
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(ir.reasoning_effort).toBe("high");
+  });
+
+  it("prefers Anthropic output_config.effort as the cross-protocol reasoning effort", () => {
+    const ir = transformRequestOut({
+      model: "claude-3-7-sonnet",
+      max_tokens: 64,
+      thinking: { type: "enabled", budget_tokens: 2048 },
+      output_config: { effort: "xhigh" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(ir.reasoning_effort).toBe("xhigh");
+  });
+
+  it("does not inject reasoning_effort when Anthropic reasoning is absent", () => {
+    const ir = transformRequestOut({
+      model: "claude-3-7-sonnet",
+      max_tokens: 64,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(ir.reasoning_effort).toBeUndefined();
+  });
+
   it("passes service_tier through to the IR", () => {
     const ir = transformRequestOut({
       model: "claude-3-5-sonnet",

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import {
   type IRContentPart,
   type IRMessage,
+  type IRReasoningEffort,
+  IRReasoningEffortSchema,
   type IRRequest,
   IRRequestSchema,
   type IRToolCall,
@@ -595,6 +597,8 @@ export function transformRequestOut(req: unknown): IRRequest {
 
   const toolChoiceIR = anthropicToolChoiceToIR(parsed.tool_choice);
 
+  const reasoningEffort = reasoningEffortFromAnthropicRequest(parsed);
+
   const ir: IRRequest = {
     model: parsed.model,
     messages: merged,
@@ -615,6 +619,7 @@ export function transformRequestOut(req: unknown): IRRequest {
     // The extended-thinking config rides IR.thinking (the provider-shaped reasoning
     // bag), distinct from the per-message `thinking` block extension built above.
     ...(parsed.thinking !== undefined ? { thinking: parsed.thinking } : {}),
+    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
     ...(parsed.service_tier !== undefined ? { service_tier: parsed.service_tier } : {}),
     ...(parsed.cache_control !== undefined ? { cache_control: parsed.cache_control } : {}),
     ...(Object.keys(providerRaw).length > 0 ? { provider_raw: providerRaw } : {}),
@@ -792,6 +797,47 @@ function thinkingFromIR(ir: IRRequest): AnthropicThinkingConfigOut | undefined {
 function stopSequencesFromIR(stop: IRRequest["stop"]): string[] | undefined {
   if (stop === undefined) return undefined;
   return typeof stop === "string" ? [stop] : stop;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseReasoningEffort(value: unknown): IRReasoningEffort | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = IRReasoningEffortSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function reasoningEffortFromAnthropicBudget(budget: number): IRReasoningEffort {
+  if (budget <= 0) return "none";
+  if (budget <= 1024) return "low";
+  if (budget <= 2048) return "medium";
+  if (budget <= 4096) return "high";
+  if (budget <= 8192) return "xhigh";
+  return "max";
+}
+
+function reasoningEffortFromAnthropicThinking(thinking: unknown): IRReasoningEffort | undefined {
+  if (!isRecord(thinking)) return undefined;
+  if (thinking.type === "disabled") return "none";
+  if (thinking.type !== "enabled") return undefined;
+  return typeof thinking.budget_tokens === "number"
+    ? reasoningEffortFromAnthropicBudget(thinking.budget_tokens)
+    : undefined;
+}
+
+function reasoningEffortFromOutputConfig(outputConfig: unknown): IRReasoningEffort | undefined {
+  return isRecord(outputConfig) ? parseReasoningEffort(outputConfig.effort) : undefined;
+}
+
+function reasoningEffortFromAnthropicRequest(
+  parsed: AnthropicMessagesRequest,
+): IRReasoningEffort | undefined {
+  return (
+    reasoningEffortFromOutputConfig(parsed.output_config) ??
+    reasoningEffortFromAnthropicThinking(parsed.thinking)
+  );
 }
 
 function normalizeAnthropicContextManagement(value: unknown): unknown {


### PR DESCRIPTION
## 做了什么

- 在 Anthropic Messages inbound 归一化阶段，把 `thinking` / `output_config.effort` 转成 IR 一等字段 `reasoning_effort`。
- 保留 `IR.thinking` 与 `provider_raw.output_config`，保证 Anthropic -> Anthropic same-protocol round-trip 不丢原始字段。
- 在 fallback translated request builder 中，继续阻止 Anthropic-only `thinking` 泄漏到 OpenAI / Responses / Gemini 目标协议。
- 补充 streaming 与 non-streaming cross-protocol fallback 测试，直接断言 provider mock body / captured upstream body。

## 为什么改

issue #422 的根因不是 fallback executor 本身，而是 Anthropic 源协议进入 IR 时没有把“推理等级”标准化成跨协议字段。导致 Opus / Anthropic 首选失败后 fallback 到 GPT / OpenAI 时，目标请求只能看到 Anthropic-only `thinking` / `output_config`，最终被剥离，`reasoning_effort` 丢失。

## Acceptance Criteria

- [x] Opus / Anthropic -> GPT / OpenAI Chat fallback 继承原请求推理等级。
- [x] OpenAI Responses / Codex 协议 fallback body 携带 `reasoning.effort`。
- [x] streaming 与 non-streaming fallback 路径均覆盖。
- [x] Anthropic `output_config.effort` / `thinking.budget_tokens` 映射为 IR `reasoning_effort`，不靠 `provider_raw` 顺路带。
- [x] Anthropic-only `output_config` / `thinking` 不泄漏到 GPT / OpenAI wire。
- [x] 缺省推理等级不注入 `reasoning_effort`，保持现有默认行为。
- [x] Anthropic -> Anthropic same-protocol 仍保留原始 `thinking` / `output_config` round-trip 行为。

## 验证证据

- `pnpm exec vitest run packages/core/src/protocol/anthropic/request.test.ts apps/gateway/src/routes/execute.test.ts`：195 passed。
- `pnpm typecheck`：shared/core/gateway typecheck 全部通过。
- `pnpm exec biome check packages/core/src/protocol/anthropic/request.ts packages/core/src/protocol/anthropic/request.test.ts apps/gateway/src/routes/execute.ts apps/gateway/src/routes/execute.test.ts`：No fixes applied。
- captured/provider body 断言：`cross-protocol fallback chain: failed Anthropic passthrough advances to translated OpenAI attempt` 断言 OpenAI Chat fallback body 包含 `reasoning_effort: "high"`，且 `thinking` / `output_config` 为 `undefined`。
- captured upstream body 断言：`cross-protocol fallback to OpenAI Responses sends captured upstream reasoning.effort without Anthropic-only fields` 断言 Responses body 包含 `reasoning: { effort: "high" }`，且无 `reasoning_effort` / `thinking` / `output_config`。
- captured upstream body 断言：`stream cross-protocol fallback to OpenAI Responses captures reasoning.effort without Anthropic-only fields` 覆盖 streaming Responses fallback，同样断言 `reasoning.effort` 与 Anthropic-only 字段不泄漏。
- Gemini 目标断言：`cross-protocol fallback to Gemini maps Anthropic reasoning into thinkingConfig without Anthropic-only fields` 断言 Gemini body 生成 `generationConfig.thinkingConfig`，且不带 Anthropic-only 字段。
- 额外说明：误跑了一次全量 `pnpm test -- ...`，新增相关测试通过；全量因本地缺少 `apps/admin/build` 导致 `apps/gateway/src/routes/admin-static.test.ts` 404/ENOENT 失败，和本 PR 无关。

## 风险点

- `thinking.budget_tokens` 到 `reasoning_effort` 是按现有 Anthropic outbound budget 阶梯做逆向归一化；`output_config.effort` 存在时优先使用它。
- `thinking: { type: "disabled" }` 会归一化为 `reasoning_effort: "none"`，符合 IR 已支持的显式 no-reasoning 语义。

## 人类 review 关注点

- 请重点看 Anthropic inbound 的归一化优先级：`output_config.effort` 是否应优先于 `thinking.budget_tokens`。
- 请确认 `stripInternal` 对非 Anthropic target 剥离 provider-shaped `thinking` 的范围符合协议隔离预期。
- 请确认 captured upstream body 断言是否足够覆盖 #422 线上 trace / request log 预期。

## 合并策略

- 小 PR，可 squash merge。
- 不自合并，等 Trent review + CI 通过后由人类合并。

Closes #422
