### PR TITLE
fix: preserve reasoning effort across Opus/GPT fallback

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1,7 +1,9 @@
 import type { CircuitBreaker, ExecutionPlan, ProviderClient, ProviderRegistry } from "@helm/core";
 import {
+  createAnthropicClient,
   createCircuitBreaker,
   createGeminiClient,
+  createGenericOpenAIResponsesClient,
   TokenRefreshError,
   UpstreamError,
 } from "@helm/core";
@@ -2781,6 +2783,138 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(out.attempts[1]?.passthrough_disable_reason).toBe("protocol_mismatch");
   });
 
+  it("cross-protocol fallback carries Anthropic output_config.effort to OpenAI Responses reasoning.effort", async () => {
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockRejectedValue(new UpstreamError("upstream_error", "boom")),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const upstreamBodies: Array<Record<string, unknown>> = [];
+    const tail = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: vi.fn(async (_url, init) => {
+        upstreamBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(
+          JSON.stringify({
+            id: "resp_1",
+            object: "response",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: "ok" }],
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["anthro", head],
+        ["openai", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "openai",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      anthropicReq({
+        reasoning_effort: "xhigh",
+        provider_raw: { output_config: { effort: "xhigh" } },
+        native_request: createNativePassthroughCarrier({
+          protocol: "anthropic_messages",
+          body: { ...NATIVE, output_config: { effort: "xhigh" } },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(head.nativePassthrough).toHaveBeenCalledTimes(1);
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-5.5" });
+    expect(upstreamBodies[0]?.reasoning).toEqual({ effort: "xhigh" });
+    expect(JSON.parse(out.upstreamRequest ?? "{}").reasoning).toEqual({ effort: "xhigh" });
+    expect(out.attempts[1]?.target_provider_protocol).toBe("openai_responses");
+  });
+
+  it("cross-protocol fallback carries OpenAI reasoning_effort to Anthropic output_config.effort", async () => {
+    const head = {
+      chatCompletion: vi.fn().mockRejectedValue(new UpstreamError("upstream_error", "boom")),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient & { chatCompletion: ReturnType<typeof vi.fn> };
+    const upstreamBodies: Array<Record<string, unknown>> = [];
+    const tail = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.test", apiKey: "sk-test" },
+      fetch: vi.fn(async (_url, init) => {
+        upstreamBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(
+          JSON.stringify({
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "text", text: "ok" }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["openai", head],
+        ["anthro", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "openai",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+        b: {
+          providerName: "anthro",
+          providerModel: "claude-opus-4-8",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(plan(["a", "b"]), req({ reasoning_effort: "xhigh" }));
+
+    expect(head.chatCompletion).toHaveBeenCalledTimes(1);
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "claude-opus-4-8" });
+    expect(upstreamBodies[0]?.output_config).toEqual({ effort: "xhigh" });
+    expect((upstreamBodies[0]?.thinking as { type?: string } | undefined)?.type).toBe("enabled");
+    expect(JSON.parse(out.upstreamRequest ?? "{}").output_config).toEqual({ effort: "xhigh" });
+    expect(out.attempts[1]?.target_provider_protocol).toBe("anthropic_messages");
+  });
+
   it("an UpstreamError from nativePassthrough records a breaker failure and advances the chain", async () => {
     const head = {
       chatCompletion: vi.fn(),
@@ -3481,7 +3615,11 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
   function protocolRegistry(
     map: Record<
       string,
-      { providerName: string; providerModel: string; targetProviderProtocol: string }
+      {
+        providerName: string;
+        providerModel: string;
+        targetProviderProtocol: TargetProviderProtocol;
+      }
     >,
   ): ProviderRegistry {
     return {
@@ -3496,9 +3634,7 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
             providerModel: hit.providerModel,
             baseUrl: "http://x",
             apiKeyEnv: "X",
-            targetProviderProtocol: hit.targetProviderProtocol as
-              | "openai_chat"
-              | "anthropic_messages",
+            targetProviderProtocol: hit.targetProviderProtocol,
             providerRequiresCompatibilityRewrite: false,
           },
         };
@@ -3805,6 +3941,139 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.attempts[1]?.target_provider_protocol).toBe("openai_chat");
     expect(out.attempts[1]?.passthrough_used).toBe(false);
     expect(out.attempts[1]?.passthrough_disable_reason).toBe("protocol_mismatch");
+  });
+
+  it("stream cross-protocol fallback carries Anthropic output_config.effort to OpenAI Responses reasoning.effort", async () => {
+    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
+    async function* diesBeforeFirst(): AsyncGenerator<string> {
+      throw new UpstreamError("upstream_error", "connect failed");
+    }
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(diesBeforeFirst()),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const upstreamBodies: Array<Record<string, unknown>> = [];
+    const tail = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: vi.fn(async (_url, init) => {
+        upstreamBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(
+          [
+            `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "ok" })}\n\n`,
+            `data: ${JSON.stringify({ type: "response.completed", response: { status: "completed" } })}\n\n`,
+          ].join(""),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["anthro", head],
+        ["openai", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro",
+          providerModel: "claude-x",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "openai",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      anthropicStreamReq({
+        reasoning_effort: "high",
+        provider_raw: { output_config: { effort: "high" } },
+        native_request: createNativePassthroughCarrier({
+          protocol: "anthropic_messages",
+          body: { ...NATIVE_STREAM, output_config: { effort: "high" } },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(head.nativePassthroughStream).toHaveBeenCalledTimes(1);
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "gpt-5.5" });
+    expect(out.stream).not.toBeNull();
+    expect(upstreamBodies[0]?.reasoning).toEqual({ effort: "high" });
+    expect(upstreamBodies[0]?.stream).toBe(true);
+    expect(JSON.parse(out.upstreamRequest ?? "{}").reasoning).toEqual({ effort: "high" });
+    expect(out.attempts[1]?.target_provider_protocol).toBe("openai_responses");
+  });
+
+  it("stream cross-protocol fallback carries OpenAI reasoning_effort to Anthropic output_config.effort", async () => {
+    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
+    async function* diesBeforeFirst(): AsyncGenerator<string> {
+      throw new UpstreamError("upstream_error", "connect failed");
+    }
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn().mockReturnValue(diesBeforeFirst()),
+    } as unknown as ProviderClient & { chatCompletionStream: ReturnType<typeof vi.fn> };
+    const upstreamBodies: Array<Record<string, unknown>> = [];
+    const tail = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.test", apiKey: "sk-test" },
+      fetch: vi.fn(async (_url, init) => {
+        upstreamBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(
+          [
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":1}}}\n\n',
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n',
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+          ].join(""),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map<string, ProviderClient>([
+        ["openai", head],
+        ["anthro", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "openai",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+        b: {
+          providerName: "anthro",
+          providerModel: "claude-opus-4-8",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(plan(["a", "b"]), req({ stream: true, reasoning_effort: "high" }));
+
+    expect(head.chatCompletionStream).toHaveBeenCalledTimes(1);
+    expect(out.final).toEqual({ status: "ok", alias: "b", providerModel: "claude-opus-4-8" });
+    expect(out.stream).not.toBeNull();
+    expect(upstreamBodies[0]?.output_config).toEqual({ effort: "high" });
+    expect(upstreamBodies[0]?.stream).toBe(true);
+    expect((upstreamBodies[0]?.thinking as { type?: string } | undefined)?.type).toBe("enabled");
+    expect(JSON.parse(out.upstreamRequest ?? "{}").output_config).toEqual({ effort: "high" });
+    expect(out.attempts[1]?.target_provider_protocol).toBe("anthropic_messages");
   });
 
   it("a client abort during the stream peek records client_abort without a breaker failure", async () => {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-06-30 · Anthropic `output_config.effort` 与 OpenAI `reasoning_effort` 双向保真（协议转换/执行 fallback，docs/05/04，原则 5/8）
+
+- **背景（Lukin）**：生产请求 `fb2fd618-edd6-4da3-8d9f-419e59c2dcb4` 显示 Anthropic 入站体带 `output_config:{"effort":"xhigh"}`，首个 Opus attempt 失败后 fallback 到 `openai-codex/gpt-5.5` 成功；但最终上游 GPT 请求没有 `reasoning` / `reasoning_effort`，只在 attempt mutation 里看到 `provider_raw_stripped_for_target:["context_management","output_config"]`。
+- **根因**：Anthropic adapter 只把 `output_config` 保存在 `provider_raw`，跨到 OpenAI/Responses 目标时该 provider-native 字段会被正确剥离；但剥离前没有把其中的 `effort` 提升到 IR 的跨协议字段 `reasoning_effort`，所以 GPT fallback 没有任何可映射的推理等级。
+- **修复决策**：`transformRequestOut` 保留 `provider_raw.output_config` 以维持 Anthropic round-trip，同时把 `output_config.effort` 通过 `IRReasoningEffortSchema` 规范化为 `IR.reasoning_effort`。这样 Anthropic/Opus → OpenAI Chat 目标继续发 `reasoning_effort`，Anthropic/Opus → OpenAI Responses/Codex 目标继续由 provider client 映射为 `reasoning.effort`。
+- **反向补齐**：GPT/OpenAI → Anthropic/Opus fallback 不能只发 `thinking.budget_tokens`；`transformRequestIn` 与订阅执行器 `openaiToAnthropicRequest` 在没有显式 `output_config` 时，会由 `reasoning_effort` 合成 `output_config:{effort}`。显式 Anthropic `output_config` 仍优先，避免覆盖客户端原生设置。
+- **范围限制**：只映射明确的“等级”字段 `output_config.effort`；不从 Anthropic `thinking.budget_tokens` 反推 effort，避免把预算数值猜成错误等级。`reasoning_effort:"none"` 不合成未知的 `output_config.effort=none`，仍通过不注入 thinking 保持禁用语义。缺省请求不注入任何 reasoning 字段，保持现有默认行为。
+- **验证**：新增 Anthropic adapter/provider 单测（有/无 effort、显式 output_config 优先）、executor 非流式与流式双向跨协议 fallback 测试，分别断言最终 GPT/Responses 上游 JSON 携带 `reasoning.effort`，最终 Anthropic/Opus 上游 JSON 携带 `output_config.effort`；`pnpm vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/provider/anthropic.test.ts apps/gateway/src/routes/execute.test.ts` 绿，发布前跑全量校验。
+
 ## 2026-06-30 · Fast mode 账号强制覆盖 + API key 透传限制（OAuth subscription provider / key governance，docs/04/11，原则 2/5）
 
 - **背景（Lukin）**：ChatGPT/Codex 与 Claude 订阅账号都支持更快服务档位，但 Helm 不能做成全局 provider 开关；同一订阅池里每个账号的权益/成本/限额可能不同，必须让 operator 按账号单独启用。
@@ -24,19 +33,13 @@
 - **取舍/坑**：不会因为单纯看到 98% 就提前 park 正常账号；near-full 仅用于「已有 cooldown」的恢复推断。若未来上游出现多个同时 active 的窗口，本实现按产品预期取最近 reset，最坏情况是过早重试一次后由 429 再次 park。
 - **验证**：新增 core 纯函数测试（98% 5h、最近 reset、94% 忽略）、gateway `/oauth/quota` 延长 active cooldown 测试、admin providers 页截图形态回归测试（不再显示 0m），并覆盖 98% 但未 park 的健康账号不误报。发布前 `pnpm test` 317 文件/4844 测绿，`typecheck`/`svelte-check`/`biome`/`build` 绿；版本 bump 到 v0.22.27。
 
-## 2026-06-29 · OAuth 配额冷却 extend-only + refresh-429 归账号级（Codex review 跟进；provider 执行/池）
-
-- **背景**：v0.22.23 上线后让 Codex 复审，捞出两条 real-bug（均**非本次回归**，是更早就有的写入交互坑）。
-- **#1 配额冷却被 60s 覆盖**：Codex Responses 抛 429 前先经 `captureCodexQuota` 把**精确长 reset**（如周限）写进 `oauth_quota`+pool 成员；同一 429 随后命中 pool `parkRateLimitedAccount` 写 `now()+DEFAULT_429_COOLDOWN_MS`(60s)，`setUsageLimit` 无条件覆盖 → 账号本该停到远期却 60s 后重入、再 429、循环猛敲。**修复 = park 改 extend-only**：`parkRateLimitedAccount`（直接写成员处）与 server `applyUsageLimit`（三条 park 路径的汇聚点，新加 `OAuthPoolClient.getUsageLimit`）都取 `max(现存未来冷却, 候选)`；`null`（admin/auto reset 清除）仍直通。无论 captureCodexQuota / pool hook / executor 侧 channel 谁后写，长 reset 不被缩短。比较用**内存成员的权威值**（同步），无 store 读竞态。
-- **#2 refresh-429 漏判**：`TokenRefreshError(429)`（refresh 端点被限流）既不在 pool `isCredentialAccountFailure(400/401/403)` 也不在 `isRateLimitAccountFailure(UpstreamError 429)` → 不 park、冒泡后 `isAccountScopedFault` 也漏 → 一个账号的 refresh-429 仍能记 alias breaker。**修复**：pool `isRateLimitAccountFailure` 与 executor `isAccountScopedFault` 都纳入 `TokenRefreshError(429)`（两层仍对称）。
-- **Codex 同时确认无误**：无条件 `canAttempt/recordSuccess/recordAbort` 正确；`recordAbort` 只释放 half-open 不清计数；abort/queue-timeout 在 recordFailure 前已排除；null-status overload 计入 breaker 是对的（pool 先 sibling 重试，冒泡=全池救不了）。
-- **验证**：pool 新增 refresh-429 转 sibling、extend-only（精确长 reset 不被 60s 缩短、hook 透传 kept 值）；executor 新增 `isAccountScopedFault` 分类矩阵（含 `TokenRefreshError(429)`/null-status overload/abort/null）。trio 160 绿、四包 typecheck、biome、build 绿。凭据 401/403 仍永久 park 到 rebuild（本次未改）。发 v0.22.24。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+- **2026-06-29 · OAuth 配额冷却 extend-only + refresh-429 归账号级（Codex review 跟进；provider 执行/池）**：修复 Codex quota 精确长 reset 被 generic 60s 429 覆盖的问题（park/applyUsageLimit 改 extend-only，清除仍直通）；同时把 `TokenRefreshError(429)` 纳入 pool 与 executor 的账号级 rate-limit 分类，避免 refresh 限流污染 alias breaker。验证 pool/executor 矩阵、typecheck、biome、build 绿，发 v0.22.24。
 
 - **2026-06-29 · OAuth 单账号故障不再污染 alias 级熔断（provider 执行；docs/04，原则 5）**：OAuth pool 内部拦截账号级 `TokenRefreshError(400/401/403)`、上游 `401/403` 与 `429`，按账号 park/冷却并请求内 sibling 重试；executor 只对账号级故障跳过 alias breaker，整池 5xx/transport 故障仍记 breaker。验证 pool/executor/server OAuth 回归绿。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.28",
+  "version": "0.22.29",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/protocol/anthropic/request.test.ts
+++ b/packages/core/src/protocol/anthropic/request.test.ts
@@ -610,6 +610,30 @@ describe("anthropic transformRequestOut", () => {
     expect(ir.provider_raw?.output_config).toEqual({ effort: "medium" });
   });
 
+  it("maps Anthropic output_config.effort onto cross-provider reasoning_effort", () => {
+    const ir = transformRequestOut({
+      model: "claude-opus-4-8",
+      max_tokens: 64,
+      output_config: { effort: "xhigh" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(ir.reasoning_effort).toBe("xhigh");
+    expect(ir.provider_raw?.output_config).toEqual({ effort: "xhigh" });
+  });
+
+  it("leaves reasoning_effort absent when Anthropic output_config has no effort", () => {
+    const ir = transformRequestOut({
+      model: "claude-opus-4-8",
+      max_tokens: 64,
+      output_config: { verbosity: "normal" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(ir.reasoning_effort).toBeUndefined();
+    expect(ir.provider_raw?.output_config).toEqual({ verbosity: "normal" });
+  });
+
   it("preserves top-level cache_control for automatic prompt caching", () => {
     const ir = transformRequestOut({
       model: "claude-3-5-sonnet",
@@ -763,6 +787,25 @@ describe("anthropic transformRequestIn — P4 params", () => {
     });
     expect(out.thinking).toMatchObject({ type: "enabled" });
     expect((out.thinking as { budget_tokens?: number }).budget_tokens).toBeGreaterThan(0);
+  });
+
+  it("maps IR reasoning_effort onto Anthropic output_config.effort when no raw output_config exists", () => {
+    const out = transformRequestIn({
+      model: "claude-opus-4-8",
+      messages: [{ role: "user", content: "hi" }],
+      reasoning_effort: "xhigh",
+    });
+    expect(out.output_config).toEqual({ effort: "xhigh" });
+  });
+
+  it("keeps explicit Anthropic output_config over synthesized reasoning_effort", () => {
+    const out = transformRequestIn({
+      model: "claude-opus-4-8",
+      messages: [{ role: "user", content: "hi" }],
+      reasoning_effort: "high",
+      provider_raw: { output_config: { effort: "xhigh", verbosity: "normal" } },
+    });
+    expect(out.output_config).toEqual({ effort: "xhigh", verbosity: "normal" });
   });
 
   // order 9: budget must match litellm exactly (billing impact). Previously bloated

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   type IRContentPart,
   type IRMessage,
+  IRReasoningEffortSchema,
   type IRRequest,
   IRRequestSchema,
   type IRToolCall,
@@ -455,6 +456,22 @@ function anthropicToolChoiceToIR(toolChoice: unknown): {
   return { tool_choice: toolChoice }; // unknown shape: keep verbatim
 }
 
+function outputConfigReasoningEffort(outputConfig: unknown): IRRequest["reasoning_effort"] {
+  if (outputConfig === null || typeof outputConfig !== "object" || Array.isArray(outputConfig)) {
+    return undefined;
+  }
+  const effort = (outputConfig as Record<string, unknown>).effort;
+  const parsed = IRReasoningEffortSchema.safeParse(effort);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function outputConfigFromReasoningEffort(
+  effort: IRRequest["reasoning_effort"],
+): { effort: NonNullable<IRRequest["reasoning_effort"]> } | undefined {
+  if (effort === undefined || effort === "none") return undefined;
+  return { effort };
+}
+
 export function transformRequestOut(req: unknown): IRRequest {
   // fail-closed: a structurally invalid request never enters the pipeline.
   const parsed = AnthropicMessagesRequestSchema.parse(req);
@@ -594,6 +611,7 @@ export function transformRequestOut(req: unknown): IRRequest {
   if (parsed.output_config !== undefined) providerRaw.output_config = parsed.output_config;
 
   const toolChoiceIR = anthropicToolChoiceToIR(parsed.tool_choice);
+  const reasoningEffort = outputConfigReasoningEffort(parsed.output_config);
 
   const ir: IRRequest = {
     model: parsed.model,
@@ -617,6 +635,7 @@ export function transformRequestOut(req: unknown): IRRequest {
     ...(parsed.thinking !== undefined ? { thinking: parsed.thinking } : {}),
     ...(parsed.service_tier !== undefined ? { service_tier: parsed.service_tier } : {}),
     ...(parsed.cache_control !== undefined ? { cache_control: parsed.cache_control } : {}),
+    ...(reasoningEffort !== undefined ? { reasoning_effort: reasoningEffort } : {}),
     ...(Object.keys(providerRaw).length > 0 ? { provider_raw: providerRaw } : {}),
   };
 
@@ -1090,6 +1109,8 @@ export function transformRequestIn(ir: IRRequest): AnthropicOutboundRequest {
   // the outbound output_format drops Anthropic-unsupported constraint keywords.
   const outputFormat = responseFormatToOutputFormat(parsed.response_format);
   const thinking = thinkingFromIR(parsed);
+  const outputConfig =
+    parsed.provider_raw?.output_config ?? outputConfigFromReasoningEffort(parsed.reasoning_effort);
   const stopSequences = stopSequencesFromIR(parsed.stop);
 
   // NB: the tool-name reverse map is NOT emitted onto the outbound request wire (an
@@ -1137,9 +1158,7 @@ export function transformRequestIn(ir: IRRequest): AnthropicOutboundRequest {
       ? { container: parsed.provider_raw.container }
       : {}),
     ...(parsed.provider_raw?.speed !== undefined ? { speed: parsed.provider_raw.speed } : {}),
-    ...(parsed.provider_raw?.output_config !== undefined
-      ? { output_config: parsed.provider_raw.output_config }
-      : {}),
+    ...(outputConfig !== undefined ? { output_config: outputConfig } : {}),
   };
   return out;
 }

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -62,6 +62,27 @@ describe("openaiToAnthropicRequest", () => {
     expect(body.top_k).toBeUndefined();
   });
 
+  it("derives Anthropic output_config.effort from OpenAI reasoning_effort", () => {
+    const body = openaiToAnthropicRequest({
+      model: "claude-opus-4-8",
+      messages: [{ role: "user", content: "solve" }],
+      reasoning_effort: "xhigh",
+    } as unknown as Parameters<typeof openaiToAnthropicRequest>[0]);
+
+    expect(body.output_config).toEqual({ effort: "xhigh" });
+  });
+
+  it("keeps explicit Anthropic output_config over reasoning_effort-derived output_config", () => {
+    const body = openaiToAnthropicRequest({
+      model: "claude-opus-4-8",
+      messages: [{ role: "user", content: "solve" }],
+      reasoning_effort: "high",
+      output_config: { effort: "xhigh", verbosity: "normal" },
+    } as unknown as Parameters<typeof openaiToAnthropicRequest>[0]);
+
+    expect(body.output_config).toEqual({ effort: "xhigh", verbosity: "normal" });
+  });
+
   it("keeps an explicit client thinking block over a reasoning_effort-derived one", () => {
     const clientThinking = { type: "enabled", budget_tokens: 5000 };
     const body = openaiToAnthropicRequest({

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -1173,6 +1173,12 @@ function claudeSessionIdFromBody(body: Record<string, unknown>): string | null {
   }
 }
 
+function outputConfigFromReasoningEffort(effort: unknown): { effort: string } | undefined {
+  return typeof effort === "string" && effort.length > 0 && effort !== "none"
+    ? { effort }
+    : undefined;
+}
+
 function toAnthropicMessages(messages: Array<Record<string, unknown>>): AnthropicMessage[] {
   const out: AnthropicMessage[] = [];
   const push = (message: AnthropicMessage): void => {
@@ -1290,7 +1296,8 @@ export function openaiToAnthropicRequest(
   if (r.mcp_servers !== undefined) body.mcp_servers = r.mcp_servers;
   if (r.container !== undefined) body.container = r.container;
   if (r.speed !== undefined) body.speed = r.speed;
-  if (r.output_config !== undefined) body.output_config = r.output_config;
+  const outputConfig = r.output_config ?? outputConfigFromReasoningEffort(r.reasoning_effort);
+  if (outputConfig !== undefined) body.output_config = outputConfig;
   if (r.stream === true) body.stream = true;
   if (typeof r.stop === "string") body.stop_sequences = [r.stop];
   else if (Array.isArray(r.stop)) body.stop_sequences = r.stop;


### PR DESCRIPTION
## Summary
- Map Anthropic `output_config.effort` into IR `reasoning_effort` so Opus -> GPT fallback preserves the reasoning level.
- Map OpenAI `reasoning_effort` back to Anthropic `output_config.effort` for GPT -> Opus fallback, while keeping explicit Anthropic `output_config` authoritative.
- Bump release version to `0.22.29`.

## Production evidence
- Live DB: `la.atmy.work:/opt/helm-api/data/helm.db`
- Request: `fb2fd618-edd6-4da3-8d9f-419e59c2dcb4`
- Incoming body: `model=claude-opus-4-8`, `stream=true`, `output_config.effort=xhigh`
- Attempts: `anthropic/claude-opus-4-8` failed, fallback to `openai-codex/gpt-5.5` succeeded
- Stored final GPT upstream body had no `reasoning`, `reasoning_effort`, or `output_config` before this fix.

## Tests
- `pnpm vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/provider/anthropic.test.ts apps/gateway/src/routes/execute.test.ts`
- `pnpm typecheck`
- `pnpm lint` (exits 0; existing unrelated Biome info in `packages/core/src/memory/forgetting/facts.test.ts`)
- `pnpm build`
- `pnpm test`

Fixes #422