### PR TITLE
Fix key request view range handoff

### DIFF
--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -15,7 +15,12 @@
     type KeyDetailFilters,
     keyDetailFiltersToSearch,
   } from '$lib/key-detail-filters.js';
-  import { type RangeKey, todayLocalDate } from '$lib/requests-filters.js';
+  import {
+    DEFAULT_PAGE_SIZE,
+    type RangeKey,
+    filtersToSearch,
+    todayLocalDate,
+  } from '$lib/requests-filters.js';
   import { t } from '$lib/i18n';
 
   type Stats = {
@@ -153,9 +158,20 @@
 
   // ── Request list (scoped to this key) ────────────────────────────────────────
   // Only the most-recent page is shown here (no in-page pager); a "view all" link
-  // hands the full history off to the global requests list, pre-filtered to this
+  // hands the current window off to the global requests list, pre-filtered to this
   // key. `hasMore` decides whether that link is worth showing.
   const hasMore = $derived(data.requests.total > data.requests.items.length);
+  const viewAllRequestsHref = $derived.by(() => {
+    const qs = filtersToSearch({
+      range: data.filters.range,
+      startDate: data.filters.startDate,
+      endDate: data.filters.endDate,
+      keyId: data.keyId,
+      page: 1,
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
+    return `${base}/requests${qs ? `?${qs}` : ''}`;
+  });
 
   // Carry THIS key page (its window/range filters) as `from`, so the request
   // detail's Back link returns here — not to the global requests list.
@@ -499,15 +515,10 @@
       <RequestsTable items={data.requests.items} {detailHref} showKey={false} />
 
       {#if hasMore}
-        <!-- Only the most-recent page is shown here. The full history lives in the
-             global requests list; "View all" hands off there pre-filtered to this
-             key (range=all so it shows the key's whole history, not just the window
-             selected above). -->
+        <!-- Only the most-recent page is shown here. The full current window lives
+             in the global requests list, still pre-filtered to this key. -->
         <div class="mt-4 text-sm">
-          <a
-            data-testid="view-all-requests"
-            class="link-inline"
-            href={`${base}/requests?key_id=${encodeURIComponent(data.keyId)}&range=all`}
+          <a data-testid="view-all-requests" class="link-inline" href={viewAllRequestsHref}
             >{$t('View all requests for this key')} →</a
           >
         </div>

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -236,7 +236,7 @@ describe('key detail page', () => {
     );
   });
 
-  it('shows a "view all" link to the global requests list (filtered by key) when there is more', () => {
+  it('shows a "view all" link to the global requests list filtered by key and active window', () => {
     render(KeyDetailPage, {
       data: pageData({
         // 60 in the window, only the most-recent 25 shown → there IS more.
@@ -245,10 +245,37 @@ describe('key detail page', () => {
     });
     // No in-page pager any more — the key page only shows the recent slice.
     expect(screen.queryByTestId('pager-status')).not.toBeInTheDocument();
-    // "View all" hands the full history off to the global list, scoped to this key
-    // and range=all (the key's whole history, not just the selected window).
+    // The clean global requests URL defaults to today, so the link only needs key_id.
     const link = screen.getByTestId('view-all-requests');
-    expect(link).toHaveAttribute('href', '/requests?key_id=k1&range=all');
+    expect(link).toHaveAttribute('href', '/requests?key_id=k1');
+  });
+
+  it('carries a non-default key detail preset into the global requests list', () => {
+    render(KeyDetailPage, {
+      data: pageData({
+        filters: { range: '7d', page: 1 },
+        requests: { items: [requestItem('tr_1')], total: 60, page: 1, pageSize: 25 },
+      }),
+    });
+
+    expect(screen.getByTestId('view-all-requests')).toHaveAttribute(
+      'href',
+      '/requests?range=7d&key_id=k1',
+    );
+  });
+
+  it('carries a custom key detail date range into the global requests list', () => {
+    render(KeyDetailPage, {
+      data: pageData({
+        filters: { range: 'today', startDate: '2026-06-01', endDate: '2026-06-03', page: 1 },
+        requests: { items: [requestItem('tr_1')], total: 60, page: 1, pageSize: 25 },
+      }),
+    });
+
+    expect(screen.getByTestId('view-all-requests')).toHaveAttribute(
+      'href',
+      '/requests?start=2026-06-01&end=2026-06-03&key_id=k1',
+    );
   });
 
   it('hides the "view all" link when the window\'s requests all fit on the page', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.29",
+  "version": "0.22.30",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Change the key detail “View all requests for this key” link to carry the active date window into `/admin/requests` instead of forcing `range=all`.
- Reuse the requests-list filter serializer so today stays clean, presets carry `range`, and custom dates carry `start`/`end`.
- Bump root package version to `0.22.30` so merge to main triggers the publish workflow and GitHub Release.

## Validation
- `pnpm vitest run 'src/routes/keys/[keyId]/key-detail.test.ts'`\n- `pnpm exec prettier --check 'src/routes/keys/[keyId]/+page.svelte' 'src/routes/keys/[keyId]/key-detail.test.ts' --plugin prettier-plugin-svelte`\n- `pnpm typecheck`\n- `pnpm lint`\n- `pnpm build`\n- `pnpm test`\n