### PR TITLE
fix: configure reasoning effort per model

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -11,6 +11,7 @@ import {
   type CatalogEntry,
   createNativePassthroughCarrier,
   type InternalRequest,
+  type NativePassthroughCarrier,
   type TargetProviderProtocol,
 } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
@@ -912,11 +913,11 @@ describe("createExecute — gateway execution adapter", () => {
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
-  it("skips Anthropic candidates whose output_config.effort is unsupported by the target model", async () => {
+  it("maps Anthropic output_config.effort through the target model policy instead of skipping", async () => {
     const provider = {
-      chatCompletion: vi.fn().mockResolvedValue({ id: "second" }),
+      chatCompletion: vi.fn().mockResolvedValue({ id: "sonnet" }),
       chatCompletionStream: vi.fn(),
-    } as unknown as ProviderClient;
+    } as unknown as ProviderClient & { chatCompletion: ReturnType<typeof vi.fn> };
     const execute = createExecute({
       defaultProvider: provider,
       providers: new Map([["mock", provider]]),
@@ -926,46 +927,106 @@ describe("createExecute — gateway execution adapter", () => {
           providerModel: "claude-sonnet-4-6",
           targetProviderProtocol: "anthropic_messages",
         },
-        codex: {
-          providerName: "mock",
-          providerModel: "gpt-5.5",
-          targetProviderProtocol: "openai_responses",
-        },
       }),
       breaker: breaker(),
-      catalog: new Map(),
+      catalog: new Map([
+        [
+          "sonnet",
+          entry("sonnet", {
+            reasoningEffort: {
+              anthropicOutputConfig: {
+                supported: true,
+                levels: ["low", "medium", "high", "max"],
+                map: { xhigh: "max" },
+              },
+              anthropicThinking: {
+                supported: true,
+                levels: ["minimal", "low", "medium", "high", "xhigh", "max"],
+              },
+            },
+          }),
+        ],
+      ]),
       now: clock(),
       signal: new AbortController().signal,
     });
 
-    const out = await execute(
-      plan(["sonnet", "codex"]),
-      req({
-        protocol: "anthropic_messages",
-        requested_model: "claude-sonnet-4-6",
-        provider_raw: { output_config: { effort: "xhigh" } },
-        native_request: createNativePassthroughCarrier({
-          protocol: "anthropic_messages",
-          body: {
-            model: "claude-sonnet-4-6",
-            messages: [{ role: "user", content: "hello" }],
-            output_config: { effort: "xhigh" },
-            max_tokens: 64,
-          },
-          headers: {},
-        }),
-      }),
-    );
+    const out = await execute(plan(["sonnet"]), req({ reasoning_effort: "xhigh" }));
 
     expect(out.final.status).toBe("ok");
     expect(provider.chatCompletion).toHaveBeenCalledOnce();
-    expect(out.attempts[0]).toMatchObject({
-      alias: "sonnet",
-      skipped: true,
-      skip_reason: "unsupported_reasoning_effort",
-      status: "error",
+    const body = provider.chatCompletion.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(body.output_config).toEqual({ effort: "max" });
+    expect(body.reasoning_effort).toBeUndefined();
+    expect((body.thinking as { type?: string } | undefined)?.type).toBe("enabled");
+    expect(out.attempts[0]).toMatchObject({ alias: "sonnet", skipped: false, status: "ok" });
+    expect(out.attempts[0]?.request_mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_mapped_for_model"],
     });
-    expect(out.attempts[1]?.status).toBe("ok");
+  });
+
+  it("uses Anthropic Haiku and strips unsupported output_config.effort for that attempt", async () => {
+    const upstreamBodies: Array<Record<string, unknown>> = [];
+    const provider = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.test", apiKey: "sk-test" },
+      fetch: vi.fn(async (_url, init) => {
+        upstreamBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return new Response(
+          JSON.stringify({
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "text", text: "ok" }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }) as unknown as typeof fetch,
+    });
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["anthro", provider]]),
+      registry: protocolRegistry({
+        haiku: {
+          providerName: "anthro",
+          providerModel: "claude-haiku-4-5-20251001",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map([
+        [
+          "haiku",
+          entry("haiku", {
+            reasoningEffort: {
+              anthropicOutputConfig: { supported: false },
+              anthropicThinking: {
+                supported: true,
+                levels: ["minimal", "low", "medium", "high", "xhigh", "max"],
+              },
+            },
+          }),
+        ],
+      ]),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["haiku"]), req({ reasoning_effort: "medium" }));
+
+    expect(out.final).toEqual({
+      status: "ok",
+      alias: "haiku",
+      providerModel: "claude-haiku-4-5-20251001",
+    });
+    expect(upstreamBodies[0]?.output_config).toBeUndefined();
+    expect(upstreamBodies[0]?.reasoning_effort).toBeUndefined();
+    expect((upstreamBodies[0]?.thinking as { type?: string } | undefined)?.type).toBe("enabled");
+    expect(out.attempts[0]).toMatchObject({ alias: "haiku", skipped: false, status: "ok" });
+    expect(out.attempts[0]?.request_mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_stripped_for_model"],
+    });
   });
 
   it("short-circuits the chain on an upstream request-shape 400 and surfaces it verbatim", async () => {
@@ -2246,6 +2307,80 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect(okRow?.provider_model).toBe("claude-x");
   });
 
+  it("native passthrough strips Anthropic effort when the target model does not support it", async () => {
+    const provider = anthropicProvider(NATIVE_RESP);
+    const haikuEntry: CatalogEntry = {
+      modelKey: "haiku",
+      capabilities: {
+        supportsTools: true,
+        jsonOutput: "schema",
+        supportsVision: true,
+        supportsStreaming: true,
+        reasoningEffort: {
+          anthropicOutputConfig: { supported: false },
+          anthropicThinking: {
+            supported: true,
+            levels: ["minimal", "low", "medium", "high", "xhigh", "max"],
+          },
+        },
+        maxContextTokens: 200000,
+        maxOutputTokens: 65536,
+      },
+      pricing: {
+        inputPerMTokUsd: null,
+        outputPerMTokUsd: null,
+        cacheReadPerMTokUsd: null,
+        cacheWritePerMTokUsd: null,
+      },
+      source: "generated",
+    };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["anthro", provider]]),
+      registry: protocolRegistry({
+        haiku: {
+          providerName: "anthro",
+          providerModel: "claude-haiku-4-5-20251001",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map([["haiku", haikuEntry]]),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["haiku"]),
+      anthropicReq({
+        reasoning_effort: "medium",
+        native_request: createNativePassthroughCarrier({
+          protocol: "anthropic_messages",
+          body: {
+            model: "anthropic/claude-haiku-4-5-20251001",
+            max_tokens: 64,
+            messages: [{ role: "user", content: "hi" }],
+            output_config: { effort: "medium" },
+          },
+          headers: {},
+        }),
+      }),
+    );
+
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as NativePassthroughCarrier;
+    expect(forwarded.body.output_config).toBeUndefined();
+    expect((forwarded.body.thinking as { type?: string } | undefined)?.type).toBe("enabled");
+    expect(forwarded.mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_stripped_for_model"],
+    });
+    expect(out.final).toEqual({
+      status: "ok",
+      alias: "haiku",
+      providerModel: "claude-haiku-4-5-20251001",
+    });
+  });
+
   it("anthropic native body with an inline system turn DISABLES passthrough (folds via chatCompletion)", async () => {
     // Regression for request 81f3fa9e... on older/unknown models: Claude Code 2.1.175
     // emits the MCP-server instructions as a TRAILING system message ([user, system]).
@@ -3297,6 +3432,81 @@ describe("createExecute — native protocol passthrough (#217)", () => {
       background: true,
     });
     expect((forwarded.mutations as Record<string, unknown>).body_shims_applied).toBeUndefined();
+  });
+
+  it("native Responses passthrough strips unsupported reasoning.effort per model policy", async () => {
+    const responsesBody = {
+      id: "resp_generic",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const provider = {
+      nativeProtocolProfile: "generic_openai_responses",
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const entry: CatalogEntry = {
+      modelKey: "r",
+      capabilities: {
+        supportsTools: true,
+        jsonOutput: "schema",
+        supportsVision: true,
+        supportsStreaming: true,
+        reasoningEffort: {
+          openaiReasoning: { supported: true, levels: ["low", "medium", "high", "xhigh"] },
+        },
+        maxContextTokens: 272000,
+        maxOutputTokens: 128000,
+      },
+      pricing: {
+        inputPerMTokUsd: null,
+        outputPerMTokUsd: null,
+        cacheReadPerMTokUsd: null,
+        cacheWritePerMTokUsd: null,
+      },
+      source: "generated",
+    };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["openai", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "openai",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map([["r", entry]]),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body: {
+        model: "gpt-5.5",
+        input: "hi",
+        reasoning: { effort: "max", summary: "auto" },
+      },
+      headers: {},
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["r"]),
+      req({ protocol: "openai_responses", native_request: carrier }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body.reasoning).toEqual({ summary: "auto" });
+    expect(forwarded.mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_stripped_for_model"],
+    });
   });
 
   it("hoists a developer system item into Codex `instructions` on passthrough (pi-ai shape)", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -8,6 +8,7 @@ import type {
 } from "@helm/core";
 import {
   anthropicNativeBodyRequiresSystemFold,
+  applyForcedAnthropicThinking,
   applyForcedReasoningToNativeBody,
   canUseNativePassthrough,
   checkCapability,
@@ -23,10 +24,12 @@ import {
 } from "@helm/core";
 import type {
   AttemptErrorDetail,
+  Capabilities,
   CatalogEntry,
   InternalRequest,
   NativePassthroughCarrier,
   Protocol,
+  ReasoningEffortWireCapability,
   TargetProviderProtocol,
 } from "@helm/shared";
 import {
@@ -535,6 +538,8 @@ function prepareNativeRequestForUpstream(
   // so the override beats the client even on the byte-passthrough path. undefined =>
   // body stays verbatim (default).
   forcedReasoningEffort: string | undefined,
+  caps: Capabilities | undefined,
+  requestReasoningEffort: string | undefined,
 ): NativePassthroughCarrier | Record<string, unknown> {
   if (nativeRequest === undefined) {
     throw new Error("native passthrough invoked without a native request");
@@ -626,6 +631,19 @@ function prepareNativeRequestForUpstream(
     }
   }
 
+  const policyMutations = carrier?.mutations ?? {};
+  const policyBody = applyReasoningEffortPolicy(
+    body,
+    protocol,
+    caps,
+    requestReasoningEffort,
+    policyMutations,
+  );
+  if (policyBody !== body) {
+    body = policyBody;
+    bodyChanged = true;
+  }
+
   if (streamReframed && mutations) mutations.stream_reframed = true;
 
   if (carrier === null) return body;
@@ -704,10 +722,6 @@ const ANTHROPIC_NATIVE_CONTEXT_LIMITS = [
   { pattern: /^claude-haiku-4[-.]5(?:-|$)/, maxContextTokens: 1_000_000 },
 ] as const;
 
-const ANTHROPIC_OUTPUT_EFFORTS = {
-  sonnet_4_6: new Set(["low", "medium", "high", "max"]),
-} as const;
-
 function bareAnthropicModelId(model: string): string {
   const slash = model.lastIndexOf("/");
   return (slash >= 0 ? model.slice(slash + 1) : model).toLowerCase();
@@ -738,23 +752,222 @@ function outputConfigEffort(value: unknown): string | null {
   return typeof effort === "string" && effort.length > 0 ? effort : null;
 }
 
-function anthropicOutputEffortSkipReason(
-  req: InternalRequest,
-  targetProviderProtocol: TargetProviderProtocol,
-  providerModel: string,
-): string | null {
-  if (targetProviderProtocol !== "anthropic_messages") return null;
-  const nativeBody = req.native_request ? nativePassthroughBody(req.native_request) : null;
-  const effort =
-    outputConfigEffort(nativeBody?.output_config) ??
-    outputConfigEffort(req.provider_raw?.output_config);
-  if (effort === null) return null;
+function outputConfigEffortFromReasoningEffort(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 && value !== "none" ? value : null;
+}
 
-  const bare = bareAnthropicModelId(providerModel);
-  if (/^claude-sonnet-4[-.]6(?:-|$)/.test(bare)) {
-    return ANTHROPIC_OUTPUT_EFFORTS.sonnet_4_6.has(effort) ? null : "unsupported_reasoning_effort";
+type ReasoningEffortPolicy = NonNullable<Capabilities["reasoningEffort"]>;
+
+type WireEffortDecision =
+  | { kind: "keep"; effort: string; mapped: boolean }
+  | { kind: "strip"; mapped: false };
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function decideWireEffort(
+  policy: ReasoningEffortWireCapability | undefined,
+  effort: string | null,
+): WireEffortDecision | null {
+  if (effort === null) return null;
+  if (effort === "none") return { kind: "strip", mapped: false };
+  if (policy === undefined) return null;
+  if (!policy.supported) return { kind: "strip", mapped: false };
+
+  const mapped = policy.map?.[effort] ?? effort;
+  if (policy.levels !== undefined && !(policy.levels as readonly string[]).includes(mapped)) {
+    return { kind: "strip", mapped: false };
   }
-  return null;
+  return { kind: "keep", effort: mapped, mapped: mapped !== effort };
+}
+
+function appendReasoningPolicyShim(
+  mutations: NativePassthroughCarrier["mutations"],
+  shim: string,
+): void {
+  appendMutationList(mutations, "body_shims_applied", [shim]);
+}
+
+function setObjectField(
+  body: Record<string, unknown>,
+  key: string,
+  value: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const next = { ...body };
+  if (value === undefined || Object.keys(value).length === 0) delete next[key];
+  else next[key] = value;
+  return next;
+}
+
+function applyOutputConfigEffort(
+  body: Record<string, unknown>,
+  decision: WireEffortDecision,
+): Record<string, unknown> {
+  const current = isPlainRecord(body.output_config) ? body.output_config : {};
+  const outputConfig = { ...current };
+  if (decision.kind === "keep") outputConfig.effort = decision.effort;
+  else delete outputConfig.effort;
+  return setObjectField(body, "output_config", outputConfig);
+}
+
+function stripReasoningEffort(body: Record<string, unknown>): Record<string, unknown> {
+  if (body.reasoning_effort === undefined) return body;
+  const next = { ...body };
+  delete next.reasoning_effort;
+  return next;
+}
+
+function openAIReasoningEffort(body: Record<string, unknown>): string | null {
+  if (!isPlainRecord(body.reasoning)) return null;
+  return nonEmptyString(body.reasoning.effort);
+}
+
+function applyOpenAIReasoningEffort(
+  body: Record<string, unknown>,
+  decision: WireEffortDecision,
+): Record<string, unknown> {
+  const current = isPlainRecord(body.reasoning) ? body.reasoning : {};
+  const reasoning = { ...current };
+  if (decision.kind === "keep") reasoning.effort = decision.effort;
+  else delete reasoning.effort;
+  return setObjectField(body, "reasoning", reasoning);
+}
+
+function applyOpenAIReasoningPolicy(
+  body: Record<string, unknown>,
+  policy: ReasoningEffortWireCapability | undefined,
+  mutations: NativePassthroughCarrier["mutations"],
+): Record<string, unknown> {
+  if (policy === undefined) return body;
+  const explicitReasoningEffort = openAIReasoningEffort(body);
+  const effort = explicitReasoningEffort ?? nonEmptyString(body.reasoning_effort);
+  const decision = decideWireEffort(policy, effort);
+  if (decision === null) return body;
+  if (decision.kind === "strip") {
+    appendReasoningPolicyShim(mutations, "reasoning_effort_stripped_for_model");
+    const next =
+      explicitReasoningEffort !== null ? applyOpenAIReasoningEffort(body, decision) : body;
+    return stripReasoningEffort(next);
+  }
+  if (decision.mapped) {
+    appendReasoningPolicyShim(mutations, "reasoning_effort_mapped_for_model");
+    const next =
+      explicitReasoningEffort !== null
+        ? applyOpenAIReasoningEffort(body, decision)
+        : { ...body, reasoning_effort: decision.effort };
+    return next;
+  }
+  return body;
+}
+
+function applyGeminiThinkingPolicy(
+  body: Record<string, unknown>,
+  policy: ReasoningEffortWireCapability | undefined,
+  mutations: NativePassthroughCarrier["mutations"],
+): Record<string, unknown> {
+  if (policy === undefined) return body;
+  let next = applyOpenAIReasoningPolicy(body, policy, mutations);
+  if (!policy.supported) {
+    const generationConfig = isPlainRecord(next.generationConfig)
+      ? { ...next.generationConfig }
+      : null;
+    if (generationConfig?.thinkingConfig !== undefined) {
+      delete generationConfig.thinkingConfig;
+      next = setObjectField(next, "generationConfig", generationConfig);
+      appendReasoningPolicyShim(mutations, "reasoning_effort_stripped_for_model");
+    }
+  }
+  return next;
+}
+
+function applyAnthropicReasoningPolicy(
+  body: Record<string, unknown>,
+  policy: ReasoningEffortPolicy,
+  fallbackReasoningEffort: string | undefined,
+  mutations: NativePassthroughCarrier["mutations"],
+): Record<string, unknown> {
+  const outputPolicy = policy.anthropicOutputConfig;
+  const thinkingPolicy = policy.anthropicThinking;
+  if (outputPolicy === undefined && thinkingPolicy === undefined) return body;
+
+  let next = body;
+  const bodyReasoningEffort = nonEmptyString(next.reasoning_effort);
+  const explicitOutputEffort = outputConfigEffort(next.output_config);
+  const sourceEffort = bodyReasoningEffort ?? fallbackReasoningEffort ?? explicitOutputEffort;
+
+  if (outputPolicy !== undefined) {
+    const outputDecision = decideWireEffort(
+      outputPolicy,
+      explicitOutputEffort ?? outputConfigEffortFromReasoningEffort(sourceEffort),
+    );
+    if (outputDecision?.kind === "strip") {
+      next = applyOutputConfigEffort(next, outputDecision);
+      appendReasoningPolicyShim(mutations, "reasoning_effort_stripped_for_model");
+    } else if (outputDecision?.kind === "keep") {
+      next = applyOutputConfigEffort(next, outputDecision);
+      if (outputDecision.mapped) {
+        appendReasoningPolicyShim(mutations, "reasoning_effort_mapped_for_model");
+      }
+    }
+  }
+
+  if (thinkingPolicy !== undefined) {
+    const thinkingDecision = decideWireEffort(thinkingPolicy, sourceEffort ?? null);
+    if (!thinkingPolicy.supported) {
+      let stripped = bodyReasoningEffort !== null || fallbackReasoningEffort !== undefined;
+      if (next.thinking !== undefined) {
+        next = { ...next };
+        delete next.thinking;
+        delete next.context_management;
+        stripped = true;
+      }
+      if (stripped) appendReasoningPolicyShim(mutations, "reasoning_effort_stripped_for_model");
+    } else if (thinkingDecision?.kind === "keep") {
+      next = applyForcedAnthropicThinking(next, thinkingDecision.effort);
+      if (thinkingDecision.mapped) {
+        appendReasoningPolicyShim(mutations, "reasoning_effort_mapped_for_model");
+      }
+    } else if (thinkingDecision?.kind === "strip" && next.thinking !== undefined) {
+      next = { ...next };
+      delete next.thinking;
+      delete next.context_management;
+      appendReasoningPolicyShim(mutations, "reasoning_effort_stripped_for_model");
+    }
+  }
+
+  // Once model-specific policy is active, make the requested tier concrete on the
+  // fields above. Leaving `reasoning_effort` would let provider adapters synthesize
+  // another unsupported provider-specific field after this guard.
+  if (bodyReasoningEffort !== null) {
+    next = stripReasoningEffort(next);
+  }
+  return next;
+}
+
+function applyReasoningEffortPolicy(
+  body: Record<string, unknown>,
+  targetProviderProtocol: TargetProviderProtocol,
+  caps: Capabilities | undefined,
+  fallbackReasoningEffort: string | undefined,
+  mutations: NativePassthroughCarrier["mutations"],
+): Record<string, unknown> {
+  const policy = caps?.reasoningEffort;
+  if (policy === undefined) return body;
+
+  switch (targetProviderProtocol) {
+    case "openai_chat":
+    case "openai_responses":
+      return applyOpenAIReasoningPolicy(body, policy.openaiReasoning, mutations);
+    case "gemini":
+      return applyGeminiThinkingPolicy(body, policy.geminiThinkingConfig, mutations);
+    case "anthropic_messages":
+      return applyAnthropicReasoningPolicy(body, policy, fallbackReasoningEffort, mutations);
+  }
 }
 
 function countTokensInputTokens(raw: unknown): number | null {
@@ -1011,17 +1224,6 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         continue;
       }
 
-      const effortSkip = anthropicOutputEffortSkipReason(
-        req,
-        target.targetProviderProtocol,
-        providerModel,
-      );
-      if (effortSkip !== null) {
-        capabilityPruned = true;
-        attempts.push(skipRow(alias, effortSkip, elapsed()));
-        continue;
-      }
-
       const exactContextLimit = effectiveContextLimit(catalogEntry, providerModel);
       if (
         target.targetProviderProtocol === "anthropic_messages" &&
@@ -1037,6 +1239,8 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             false,
             provider.nativeProtocolProfile,
             req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
+            caps,
+            req.reasoning_effort,
           );
           const countBody = { ...nativePassthroughBody(countInput) };
           delete countBody.stream;
@@ -1112,6 +1316,8 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             true,
             provider.nativeProtocolProfile,
             req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
+            caps,
+            req.reasoning_effort,
           );
           if (hasResponsesHistoryGap(req)) {
             const mutations = nativePassthroughMutations(passthroughBody);
@@ -1161,7 +1367,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // Translate stream path (passthrough disabled): the existing byte-for-byte
           // forward. peekStream opens chatCompletionStream(stripInternal); the row
           // carries the (used:false) passthrough telemetry. No nativePassthrough marker.
-          const rendered = stripInternal(req, providerModel, target.targetProviderProtocol);
+          const rendered = stripInternal(req, providerModel, target.targetProviderProtocol, caps);
           attemptTelemetry = withRequestMutations(
             passthrough,
             mergeRequestMutations(
@@ -1232,6 +1438,8 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             false,
             provider.nativeProtocolProfile,
             req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
+            caps,
+            req.reasoning_effort,
           );
           if (hasResponsesHistoryGap(req)) {
             const mutations = nativePassthroughMutations(passthroughBody);
@@ -1259,7 +1467,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             upstreamRequest: capturedUpstream,
           };
         }
-        const bodyReq = stripInternal(req, providerModel, target.targetProviderProtocol);
+        const bodyReq = stripInternal(req, providerModel, target.targetProviderProtocol, caps);
         attemptTelemetry = withRequestMutations(passthrough, bodyReq.request_mutations);
         const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
           provider.chatCompletion(bodyReq.body, { signal: attemptSignal, captureUpstream }),
@@ -1614,6 +1822,7 @@ function stripInternal(
   req: InternalRequest,
   providerModel: string,
   targetProviderProtocol: TargetProviderProtocol,
+  caps: Capabilities | undefined,
 ): { body: Record<string, unknown>; request_mutations?: NativePassthroughCarrier["mutations"] } {
   const requestMutations: NativePassthroughCarrier["mutations"] = {};
   const openAICompatibleWire =
@@ -1679,10 +1888,17 @@ function stripInternal(
       req.stream_options && typeof req.stream_options === "object" ? req.stream_options : {};
     body.stream_options = { ...streamOptions, include_usage: true };
   }
+  const policyBody = applyReasoningEffortPolicy(
+    body,
+    targetProviderProtocol,
+    caps,
+    req.reasoning_effort,
+    requestMutations,
+  );
   const renderedBody =
     targetProviderProtocol === "openai_chat" || targetProviderProtocol === "openai_responses"
-      ? renderOpenAINativeBody(body)
-      : body;
+      ? renderOpenAINativeBody(policyBody)
+      : policyBody;
   return {
     body: renderedBody,
     ...(Object.keys(requestMutations).length > 0 ? { request_mutations: requestMutations } : {}),

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -67,6 +67,10 @@ openai-codex/gpt-5.5:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [low, medium, high, xhigh]
   maxContextTokens: 272000
   maxOutputTokens: 128000
 openai-codex/gpt-5.4:
@@ -74,6 +78,10 @@ openai-codex/gpt-5.4:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [low, medium, high, xhigh]
   maxContextTokens: 272000
   maxOutputTokens: 128000
 openai-codex/gpt-5.4-mini:
@@ -81,6 +89,10 @@ openai-codex/gpt-5.4-mini:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [low, medium, high, xhigh]
   maxContextTokens: 272000
   maxOutputTokens: 65536
 # Official DeepSeek API: json_object YES, json_schema NO (response_format json_schema
@@ -126,6 +138,10 @@ zenmux/gpt-5.5:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [low, medium, high, xhigh]
   # OpenRouter lists `file` input for gpt-5.5 (text+image+file->text).
   modalities: [document]
   maxContextTokens: 1050000
@@ -141,6 +157,9 @@ zenmux-vertex/gemini-3.5-flash:
   supportsVision: true
   supportsStreaming: true
   supportsCachedContent: true
+  reasoningEffort:
+    geminiThinkingConfig:
+      supported: true
   modalities: [audio, video, document]
   maxContextTokens: 1048576
   maxOutputTokens: 65536
@@ -150,6 +169,9 @@ zenmux-vertex/gemini-3.1-flash-lite:
   supportsVision: true
   supportsStreaming: true
   supportsCachedContent: true
+  reasoningEffort:
+    geminiThinkingConfig:
+      supported: true
   modalities: [audio, video, document]
   maxContextTokens: 1048576
   maxOutputTokens: 65536
@@ -159,6 +181,9 @@ zenmux-vertex/gemini-3.1-pro:
   supportsVision: true
   supportsStreaming: true
   supportsCachedContent: true
+  reasoningEffort:
+    geminiThinkingConfig:
+      supported: true
   modalities: [audio, video, document]
   maxContextTokens: 1048576
   maxOutputTokens: 65536
@@ -230,6 +255,14 @@ zenmux-anthropic/claude-opus-4.8:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: true
+      levels: [low, medium, high, xhigh, max]
+      map:
+        minimal: low
+    anthropicThinking:
+      supported: false
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000
@@ -238,6 +271,16 @@ zenmux-anthropic/claude-sonnet-4.6:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: true
+      levels: [low, medium, high, max]
+      map:
+        minimal: low
+        xhigh: max
+    anthropicThinking:
+      supported: true
+      levels: [minimal, low, medium, high, xhigh, max]
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000
@@ -250,6 +293,12 @@ zenmux-anthropic/claude-haiku-4.5:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: false
+    anthropicThinking:
+      supported: true
+      levels: [minimal, low, medium, high, xhigh, max]
   modalities: [document]
   maxContextTokens: 200000
   maxOutputTokens: 128000
@@ -267,6 +316,14 @@ anthropic/claude-opus-4-8:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: true
+      levels: [low, medium, high, xhigh, max]
+      map:
+        minimal: low
+    anthropicThinking:
+      supported: false
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000
@@ -275,6 +332,16 @@ anthropic/claude-sonnet-4-6:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: true
+      levels: [low, medium, high, max]
+      map:
+        minimal: low
+        xhigh: max
+    anthropicThinking:
+      supported: true
+      levels: [minimal, low, medium, high, xhigh, max]
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000
@@ -283,6 +350,14 @@ anthropic/claude-fable-5:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: true
+      levels: [low, medium, high, xhigh, max]
+      map:
+        minimal: low
+    anthropicThinking:
+      supported: false
   modalities: [document]
   maxContextTokens: 1000000
   maxOutputTokens: 128000
@@ -291,6 +366,12 @@ anthropic/claude-haiku-4-5-20251001:
   jsonOutput: schema
   supportsVision: true
   supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: false
+    anthropicThinking:
+      supported: true
+      levels: [minimal, low, medium, high, xhigh, max]
   modalities: [document]
   maxContextTokens: 200000
   maxOutputTokens: 65536

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-06-30 · per-model reasoning effort policy（执行 fallback / 协议转换，docs/04/05，原则 2/5/8）
+
+- **背景（Lukin）**：生产请求 `10124906-2d15-4cf6-accf-8ce26227a8ca` 走 `economy`，首个 `openai-codex/gpt-5.4-mini` 3s timeout 后 fallback 到 `anthropic/claude-haiku-4-5-20251001`；Haiku 返回 `400 invalid_request_error: This model does not support the effort parameter.`。客户端原始 payload 没有 `reasoning_effort`，是 `economy.reasoning_effort: medium` 在路由阶段强制注入。
+- **根因**：`reasoning_effort` 是跨协议 IR 字段，但模型真正支持的是具体 wire 字段：OpenAI `reasoning.effort`、Anthropic `output_config.effort`、Anthropic `thinking`、Gemini `thinkingConfig`。Haiku 4.5 支持 manual thinking budget，但不支持 Anthropic adaptive `output_config.effort`；旧代码把 lane effort 同时合成 thinking + output_config，导致下游 400。之前的 executor guard 又把支持信息写死在代码里，并且选择 skip candidate，不能表达“这个模型能用 thinking，但不能用 effort 参数”。
+- **修复决策**：在 catalog capability 增加 `reasoningEffort`，由 `config/capabilities.yaml` 为每个模型声明各 wire 字段是否支持、支持哪些 level、以及 level map。executor 在每个 candidate attempt 上按该 policy 适配 body：支持则按配置映射，不支持则删除该 wire 参数，继续尝试当前模型；不再因为 unsupported effort 直接 skip candidate。
+- **当前配置**：Codex/OpenAI entries 声明 `openaiReasoning` levels；Gemini entries 声明 `geminiThinkingConfig`；Anthropic Opus/Fable 使用 `anthropicOutputConfig` 并禁用 manual thinking；Sonnet 4.6 将 `xhigh -> max`；Haiku 4.5 删除 `output_config.effort`，但保留/合成 manual `thinking`。
+- **验证**：新增 translated + native passthrough regression：Sonnet `xhigh` 映射为 `output_config.effort=max` 且不 skip；Haiku `reasoning_effort=medium` 仍使用 Haiku，上游 body 无 `output_config` 且有 `thinking`；native passthrough 同样删除 unsupported `output_config.effort`。
+
 ## 2026-06-30 · Anthropic `output_config.effort` 与 OpenAI `reasoning_effort` 双向保真（协议转换/执行 fallback，docs/05/04，原则 5/8）
 
 - **背景（Lukin）**：生产请求 `fb2fd618-edd6-4da3-8d9f-419e59c2dcb4` 显示 Anthropic 入站体带 `output_config:{"effort":"xhigh"}`，首个 Opus attempt 失败后 fallback 到 `openai-codex/gpt-5.5` 成功；但最终上游 GPT 请求没有 `reasoning` / `reasoning_effort`，只在 attempt mutation 里看到 `provider_raw_stripped_for_target:["context_management","output_config"]`。
@@ -25,19 +33,13 @@
 - **范围限制**：目前 UI 只对 `anthropic` 与 `openai-codex` 显示 Fast 开关；其他 provider 显示不支持。Anthropic 的 `count_tokens` 路径不注入 `speed`，避免把消息生成参数带到 token 统计端点。
 - **验证计划**：provider 单测覆盖翻译请求与 native passthrough 都被强制覆盖；gateway/admin 单测覆盖 `fastMode` / `allow_fast_mode` 的 API 校验、持久化、列表展示、池合成、客户端降级与 UI 切换。
 
-## 2026-06-30 · OAuth 5h 限额恢复时间不再落回 60s（admin/gateway，docs/04，原则 5）
-
-- **背景（Lukin）**：Subscription Providers 页里 Anthropic 账号已经被 429 标为 `Rate limited`，但 quota 快照显示 `5h=98%`、`7d/7d Sonnet` 远未打满；左侧却显示 `0 分钟后自动恢复`，因为只信 `usageLimitedUntilMs=now+60s` 的 generic 429 fallback。
-- **根因**：旧逻辑只把 `usedPercent >= 100` 当作可证明窗口，并且在 UI 中偏向更远的 reset。Anthropic usage PULL 在真实 5h 限额时可能仍报 98–99%（取样/舍入滞后），于是 `/oauth/quota` 没把已 park 账号延长到 5h reset，UI 也找不到窗口 label。
-- **修复决策**：保留 `windowsToUsageLimit` 的严格 100% 语义给「主动 park 健康账号」路径；新增 `windowsToActiveUsageRecovery`：只在账号**已经**因真实 429 处于 cooldown 时，使用 `>=95%` 的 near-full 窗口推断恢复时间，并取最近的未来 reset（5h 与 7d 只显示一个 active limiter）。`/admin/api/oauth/quota` 用它把 60s fallback 延长到真实窗口 reset；providers UI 用同样阈值显示 `5h · auto-recovers in ...`。
-- **取舍/坑**：不会因为单纯看到 98% 就提前 park 正常账号；near-full 仅用于「已有 cooldown」的恢复推断。若未来上游出现多个同时 active 的窗口，本实现按产品预期取最近 reset，最坏情况是过早重试一次后由 429 再次 park。
-- **验证**：新增 core 纯函数测试（98% 5h、最近 reset、94% 忽略）、gateway `/oauth/quota` 延长 active cooldown 测试、admin providers 页截图形态回归测试（不再显示 0m），并覆盖 98% 但未 park 的健康账号不误报。发布前 `pnpm test` 317 文件/4844 测绿，`typecheck`/`svelte-check`/`biome`/`build` 绿；版本 bump 到 v0.22.27。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+- **2026-06-30 · OAuth 5h 限额恢复时间不再落回 60s（admin/gateway，docs/04，原则 5）**：已 park 账号的 generic 60s 429 fallback 改用 near-full (`>=95%`) 窗口推断真实恢复时间，避免 Anthropic 5h 98–99% 限额显示 `0m`；健康账号仍不因 98% 预先 park。验证 core/gateway/admin 相关测试、全量 test/typecheck/svelte-check/biome/build 绿，发 v0.22.27。
 
 - **2026-06-29 · OAuth 配额冷却 extend-only + refresh-429 归账号级（Codex review 跟进；provider 执行/池）**：修复 Codex quota 精确长 reset 被 generic 60s 429 覆盖的问题（park/applyUsageLimit 改 extend-only，清除仍直通）；同时把 `TokenRefreshError(429)` 纳入 pool 与 executor 的账号级 rate-limit 分类，避免 refresh 限流污染 alias breaker。验证 pool/executor 矩阵、typecheck、biome、build 绿，发 v0.22.24。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.30",
+  "version": "0.22.31",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/catalog/index.test.ts
+++ b/packages/core/src/catalog/index.test.ts
@@ -163,6 +163,27 @@ describe("loadCatalog", () => {
     expect(entry?.capabilities.requiresStreaming).toBe(true);
   });
 
+  it("propagates per-model reasoning effort policy into the merged catalog entry", () => {
+    const cat = loadCatalog({
+      generated,
+      capabilitiesOverride: {
+        "anthropic/claude-haiku-4-5-20251001": {
+          reasoningEffort: {
+            anthropicOutputConfig: { supported: false },
+            anthropicThinking: {
+              supported: true,
+              levels: ["minimal", "low", "medium", "high", "xhigh", "max"],
+            },
+          },
+        },
+      },
+      pricingOverride: {},
+    });
+    const effort = cat.get("anthropic/claude-haiku-4-5-20251001")?.capabilities.reasoningEffort;
+    expect(effort?.anthropicOutputConfig?.supported).toBe(false);
+    expect(effort?.anthropicThinking?.levels).toContain("xhigh");
+  });
+
   it("leaves requiresStreaming absent for entries that never set it (back-compat)", () => {
     const cat = loadCatalog({ generated, capabilitiesOverride: {}, pricingOverride: {} });
     expect(cat.get("openai/gpt-4o")?.capabilities.requiresStreaming).toBeUndefined();

--- a/packages/shared/src/catalog/schema.ts
+++ b/packages/shared/src/catalog/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ReasoningEffortSchema } from "../config/lanes-schema.js";
 
 // Catalog metadata = per-model capabilities + pricing. Two layers:
 //   1. generated  — synced from LiteLLM's model_prices_and_context_window.json
@@ -15,6 +16,37 @@ import { z } from "zod";
 // request without them is unaffected; one WITH them gets an explicit skip reason).
 export const InputModalitySchema = z.enum(["audio", "video", "document"]);
 export type InputModality = z.infer<typeof InputModalitySchema>;
+
+// Per-model reasoning/effort wire compatibility. The router's normalized
+// `reasoning_effort` may become different provider fields per attempt
+// (`reasoning.effort`, Anthropic `output_config.effort`, Anthropic `thinking`,
+// Gemini `thinkingConfig`). Some models support only a subset of tiers, or only
+// one of those wire fields. Config declares that explicitly so the executor can
+// map or strip unsupported fields before the upstream call instead of hard-coding
+// model ids or burning avoidable 400s.
+export const ReasoningEffortWireCapabilitySchema = z
+  .strictObject({
+    supported: z.boolean(),
+    // If omitted with supported:true, every known Helm tier is accepted as-is.
+    levels: z.array(ReasoningEffortSchema).nonempty().optional(),
+    // Incoming Helm tier -> upstream-supported tier. Unknown keys are allowed so
+    // operators can bridge newly observed client tiers before Helm adds them.
+    map: z.record(z.string().min(1), ReasoningEffortSchema).optional(),
+  })
+  .strict();
+
+export const ReasoningEffortCapabilitySchema = z
+  .strictObject({
+    // OpenAI Chat `reasoning_effort` / Responses `reasoning.effort`.
+    openaiReasoning: ReasoningEffortWireCapabilitySchema.optional(),
+    // Anthropic adaptive thinking effort: `output_config: { effort }`.
+    anthropicOutputConfig: ReasoningEffortWireCapabilitySchema.optional(),
+    // Anthropic manual extended thinking: `thinking: { type, budget_tokens }`.
+    anthropicThinking: ReasoningEffortWireCapabilitySchema.optional(),
+    // Gemini `generationConfig.thinkingConfig`.
+    geminiThinkingConfig: ReasoningEffortWireCapabilitySchema.optional(),
+  })
+  .strict();
 
 export const CapabilitiesSchema = z.object({
   supportsTools: z.boolean(),
@@ -53,6 +85,7 @@ export const CapabilitiesSchema = z.object({
   // its provider via native passthrough (preserving responseModalities → inlineData)
   // instead of being swallowed by a `gemini-*flash*` glob onto a text lane.
   outputImage: z.boolean().optional(),
+  reasoningEffort: ReasoningEffortCapabilitySchema.optional(),
   maxContextTokens: z.number().int().nonnegative(),
   maxOutputTokens: z.number().int().nonnegative().nullable(),
 });
@@ -123,6 +156,8 @@ export const CapabilitiesOverrideSchema = z.record(
 );
 export const PricingOverrideSchema = z.record(z.string().min(1), PricingOverrideEntrySchema);
 
+export type ReasoningEffortWireCapability = z.infer<typeof ReasoningEffortWireCapabilitySchema>;
+export type ReasoningEffortCapability = z.infer<typeof ReasoningEffortCapabilitySchema>;
 export type Capabilities = z.infer<typeof CapabilitiesSchema>;
 export type Pricing = z.infer<typeof PricingSchema>;
 export type CatalogSource = z.infer<typeof CatalogSourceSchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,6 +22,10 @@ export {
   type PricingOverride,
   PricingOverrideSchema,
   PricingSchema,
+  type ReasoningEffortCapability,
+  ReasoningEffortCapabilitySchema,
+  type ReasoningEffortWireCapability,
+  ReasoningEffortWireCapabilitySchema,
 } from "./catalog/schema.js";
 // Layer-2 eval output model (docs/03 §Task classification) — strict JSON the eval model
 // emits; validated as untrusted external input, fail-open on any failure.


### PR DESCRIPTION
## Summary
- add catalog-driven per-model reasoning effort capability policy
- map or strip unsupported reasoning-effort wire fields per candidate attempt instead of hard-coding model skips
- configure Codex/OpenAI, Gemini, and Anthropic reasoning support, including Haiku output_config stripping and Sonnet xhigh->max mapping

## Tests
- pnpm vitest run apps/gateway/src/routes/execute.test.ts packages/core/src/catalog/index.test.ts packages/core/src/catalog/load.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check
- pnpm build
- pnpm test