### PR TITLE
fix: speed up admin telemetry aggregates

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-01 · admin telemetry 聚合改为列化延迟 + 覆盖索引（Admin observability / store，docs/07/11，原则 7）
+
+- **背景（Lukin）**：生产 SQLite 数据库约 22GB，`/admin/api/stats` 在 7d/30d 窗口可跑到 100s+；由于 SQLite 适配器使用同步 `better-sqlite3`，这类长统计会阻塞 Node event loop，让其它管理端 API 看起来也一起卡住。
+- **根因**：`TelemetryStore.aggregate()` 的 totals 查询仍从 `decision_json` 里 `json_extract('$.latency_total_ms')` 计算平均延迟；在大窗口下这会强制逐行读 telemetry 大 JSON 并解析。series / byModel / usage 也依赖同一时间窗扫描，缺少覆盖索引时会回表读取更多页面。
+- **修复决策**：新增 `telemetry.latency_total_ms` 普通列，写入时从 `DecisionRecord.latency_total_ms` 列化；SQLite v32 / Postgres v31 对历史行从 JSON 回填该列，并把 aggregate 的 `AVG` 改为读普通列。
+- **索引决策**：新增两条管理端聚合覆盖索引：全局窗口以 `created_at` 开头，key 详情窗口以 `(api_key_id, created_at)` 开头，并覆盖 status/cost/tokens/cache/generation/model/key 字段。目标是让 dashboard 三个聚合 shape 尽量扫描窄索引页，减少 JSON 解析和回表。
+- **范围限制**：本次不改 admin 路由返回形状，也不引入物化日报表；先消除确认过的同步慢查询放大器。若未来 telemetry 增长到百万级以上，再考虑后台 rollup 表或异步 worker。
+- **验证**：新增 SQLite/PG 迁移回填测试、SQLite “篡改 decision_json 后 aggregate 仍读列化延迟”测试、跨适配器 aggregate 延迟契约；全量 `pnpm test` 4887/4887 绿，`pnpm typecheck`、`pnpm build` 绿。
+
 ## 2026-06-30 · admin favicon cache policy（Admin UI 静态资源，docs/11，原则 7）
 
 - **背景（Lukin）**：`/admin/favicon.svg` 与 `/admin/favicon.png` 在浏览器网络面板里表现很慢，但文件本身很小（SVG 664B、PNG 约 19KB）。实测问题不是图片体积，而是 admin 静态资源缓存策略把它们当作 SPA shell 处理。
@@ -23,20 +32,13 @@
 - **当前配置**：Codex/OpenAI entries 声明 `openaiReasoning` levels；Gemini entries 声明 `geminiThinkingConfig`；Anthropic Opus/Fable 使用 `anthropicOutputConfig` 并禁用 manual thinking；Sonnet 4.6 将 `xhigh -> max`；Haiku 4.5 删除 `output_config.effort`，但保留/合成 manual `thinking`。
 - **验证**：新增 translated + native passthrough regression：Sonnet `xhigh` 映射为 `output_config.effort=max` 且不 skip；Haiku `reasoning_effort=medium` 仍使用 Haiku，上游 body 无 `output_config` 且有 `thinking`；native passthrough 同样删除 unsupported `output_config.effort`。
 
-## 2026-06-30 · Anthropic `output_config.effort` 与 OpenAI `reasoning_effort` 双向保真（协议转换/执行 fallback，docs/05/04，原则 5/8）
-
-- **背景（Lukin）**：生产请求 `fb2fd618-edd6-4da3-8d9f-419e59c2dcb4` 显示 Anthropic 入站体带 `output_config:{"effort":"xhigh"}`，首个 Opus attempt 失败后 fallback 到 `openai-codex/gpt-5.5` 成功；但最终上游 GPT 请求没有 `reasoning` / `reasoning_effort`，只在 attempt mutation 里看到 `provider_raw_stripped_for_target:["context_management","output_config"]`。
-- **根因**：Anthropic adapter 只把 `output_config` 保存在 `provider_raw`，跨到 OpenAI/Responses 目标时该 provider-native 字段会被正确剥离；但剥离前没有把其中的 `effort` 提升到 IR 的跨协议字段 `reasoning_effort`，所以 GPT fallback 没有任何可映射的推理等级。
-- **修复决策**：`transformRequestOut` 保留 `provider_raw.output_config` 以维持 Anthropic round-trip，同时把 `output_config.effort` 通过 `IRReasoningEffortSchema` 规范化为 `IR.reasoning_effort`。这样 Anthropic/Opus → OpenAI Chat 目标继续发 `reasoning_effort`，Anthropic/Opus → OpenAI Responses/Codex 目标继续由 provider client 映射为 `reasoning.effort`。
-- **反向补齐**：GPT/OpenAI → Anthropic/Opus fallback 不能只发 `thinking.budget_tokens`；`transformRequestIn` 与订阅执行器 `openaiToAnthropicRequest` 在没有显式 `output_config` 时，会由 `reasoning_effort` 合成 `output_config:{effort}`。显式 Anthropic `output_config` 仍优先，避免覆盖客户端原生设置。
-- **范围限制**：只映射明确的“等级”字段 `output_config.effort`；不从 Anthropic `thinking.budget_tokens` 反推 effort，避免把预算数值猜成错误等级。`reasoning_effort:"none"` 不合成未知的 `output_config.effort=none`，仍通过不注入 thinking 保持禁用语义。缺省请求不注入任何 reasoning 字段，保持现有默认行为。
-- **验证**：新增 Anthropic adapter/provider 单测（有/无 effort、显式 output_config 优先）、executor 非流式与流式双向跨协议 fallback 测试，分别断言最终 GPT/Responses 上游 JSON 携带 `reasoning.effort`，最终 Anthropic/Opus 上游 JSON 携带 `output_config.effort`；`pnpm vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/provider/anthropic.test.ts apps/gateway/src/routes/execute.test.ts` 绿，发布前跑全量校验。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+- **2026-06-30 · Anthropic `output_config.effort` 与 OpenAI `reasoning_effort` 双向保真（协议转换/执行 fallback，docs/05/04，原则 5/8）**：Anthropic 入站 `output_config.effort` 提升到 IR `reasoning_effort`，OpenAI/Responses fallback 保留推理等级；反向 GPT/OpenAI→Anthropic 在无显式 output_config 时合成 `output_config.effort`；只映射等级字段，不从 `thinking.budget_tokens` 反推。
 
 - **2026-06-30 · Fast mode 账号强制覆盖 + API key 透传限制（OAuth subscription provider / key governance，docs/04/11，原则 2/5）**：账号级 `fastMode` 统一映射到 Codex `service_tier:"priority"` 与 Anthropic `speed:"fast"` + beta header，并强制覆盖 provider wire request；per-key `allow_fast_mode` 只治理客户端透传，不阻止账号级强制启用；UI 仅对支持 provider 展示。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.32",
+  "version": "0.22.33",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -79,6 +79,67 @@ describe("runPgMigrations — per-migration atomicity", () => {
     await db.$close();
   });
 
+  it("v31 backfills telemetry latency and creates admin aggregate indexes", async () => {
+    const client = new PGlite();
+    const db = Object.assign(drizzlePglite(client), { $close: () => client.close() });
+    await db.execute(
+      sql.raw("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at BIGINT NOT NULL)"),
+    );
+    await db.execute(
+      sql.raw(`
+        CREATE TABLE telemetry (
+          id TEXT PRIMARY KEY,
+          request_id TEXT NOT NULL UNIQUE,
+          api_key_id TEXT NOT NULL,
+          decision_json JSONB NOT NULL,
+          final_status TEXT,
+          cost_usd DOUBLE PRECISION,
+          prompt_tokens INTEGER,
+          completion_tokens INTEGER,
+          cached_tokens INTEGER,
+          cache_creation_tokens INTEGER,
+          served_model TEXT,
+          generation_ms INTEGER,
+          created_at BIGINT NOT NULL
+        )
+      `),
+    );
+    for (let version = 1; version <= 30; version++) {
+      await db.execute(
+        sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
+      );
+    }
+    await db.execute(
+      sql.raw(`
+        INSERT INTO telemetry (
+          id, request_id, api_key_id, decision_json, final_status, cost_usd,
+          prompt_tokens, completion_tokens, cached_tokens, cache_creation_tokens,
+          served_model, generation_ms, created_at
+        ) VALUES (
+          't1', 'req_1', 'k1', '{"latency_total_ms":1234}'::jsonb, 'ok', 0.01,
+          10, 2, 1, 0, 'gpt-4o', 500, 1000
+        )
+      `),
+    );
+
+    await expect(runPgMigrations(db)).resolves.toBeUndefined();
+
+    const row = (await db.execute(
+      sql.raw("SELECT latency_total_ms FROM telemetry WHERE request_id = 'req_1'"),
+    )) as { rows: Array<{ latency_total_ms: number }> };
+    expect(row.rows[0]?.latency_total_ms).toBe(1234);
+    const indexes = (await db.execute(
+      sql.raw("SELECT indexname FROM pg_indexes WHERE tablename = 'telemetry'"),
+    )) as { rows: Array<{ indexname: string }> };
+    expect(indexes.rows.map((r) => r.indexname)).toEqual(
+      expect.arrayContaining([
+        "idx_telemetry_admin_window_cover",
+        "idx_telemetry_admin_key_window_cover",
+      ]),
+    );
+    await db.$close();
+  });
+
   // docs/12 "Schema deltas" (P2) — the forgetting migration (sqlite v18 / pg
   // v17). Additive columns + the new account-scoped memory_facts table, mirrored
   // into the pg dialect per CLAUDE.md (dialect differences sealed in the adapter).
@@ -160,11 +221,10 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // oauth_quota → pre-mark applied (out of scope).
     // v27 (pgvector + tsvector over memory_facts): this fixture never creates
     // memory_facts (+ no pgvector here) → pre-mark applied, out of scope.
-    // v29 (telemetry lane/decided_by generated columns): no telemetry table here →
-    // pre-mark applied; v30 alters api_keys (absent here). v28 (payload_blobs CREATE)
-    // is pre-marked too (out of scope).
+    // v29/v31 alter telemetry (absent here) → pre-mark applied; v30 alters api_keys
+    // (absent here). v28 (payload_blobs CREATE) is pre-marked too (out of scope).
     // biome-ignore format: keep the version ledger on one readable line
-    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 28, 29, 30]) {
+    for (const version of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 28, 29, 30, 31]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
       );
@@ -262,11 +322,11 @@ describe("runPgMigrations — per-migration atomicity", () => {
     // v26 (idx_memory_jobs_claim): no memory_jobs table in this messages fixture → pre-mark.
     // v27 (pgvector + tsvector over memory_facts): this messages fixture never creates
     // memory_facts (+ no pgvector here) → pre-mark applied, out of scope.
-    // v28 (payload_blobs), v29 (telemetry generated columns), and v30 (api_keys
-    // allow_fast_mode) are out of scope here too.
+    // v28 (payload_blobs), v29/v31 (telemetry generated/aggregate columns), and
+    // v30 (api_keys allow_fast_mode) are out of scope here too.
     for (const version of [
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 27,
-      28, 29, 30,
+      28, 29, 30, 31,
     ]) {
       await db.execute(
         sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -590,6 +590,50 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS allow_fast_mode BOOLEAN NOT NULL DEFAULT FALSE;
     `,
   },
+  {
+    // Admin dashboard aggregate hot path — pg mirror of sqlite v32. Store
+    // latency_total_ms as a real column so dashboard aggregates do not parse the
+    // decision_json blob/jsonb on every request, and add covering indexes for
+    // global and per-key aggregate windows.
+    version: 31,
+    sql: `
+      ALTER TABLE telemetry ADD COLUMN IF NOT EXISTS latency_total_ms INTEGER;
+
+      UPDATE telemetry
+      SET latency_total_ms = ((decision_json ->> 'latency_total_ms')::DOUBLE PRECISION)::INTEGER
+      WHERE latency_total_ms IS NULL
+        AND jsonb_typeof(decision_json -> 'latency_total_ms') = 'number';
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_admin_window_cover
+        ON telemetry (created_at)
+        INCLUDE (
+          final_status,
+          cost_usd,
+          prompt_tokens,
+          completion_tokens,
+          cached_tokens,
+          cache_creation_tokens,
+          latency_total_ms,
+          generation_ms,
+          served_model,
+          api_key_id
+        );
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_admin_key_window_cover
+        ON telemetry (api_key_id, created_at)
+        INCLUDE (
+          final_status,
+          cost_usd,
+          prompt_tokens,
+          completion_tokens,
+          cached_tokens,
+          cache_creation_tokens,
+          latency_total_ms,
+          generation_ms,
+          served_model
+        );
+    `,
+  },
 ];
 
 // Anything that can run a raw SQL string against the Postgres connection. Both

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -71,10 +71,10 @@ export const telemetry = pgTable("telemetry", {
   decisionJson: jsonb("decision_json").notNull(), // redacted DecisionRecord (native jsonb)
   finalStatus: text("final_status"),
   costUsd: doublePrecision("cost_usd"), // nullable; summed attempt cost
-  // Dashboard token accounting (pg migration v21) — mirror of the sqlite v22
-  // columns. Nullable integers; NULL = pre-feature row / usage not measured
-  // (forward-only). Counts come from DecisionRecord.usage; servedModel mirrors
-  // final.provider_model for a plain GROUP BY.
+  // Dashboard accounting: denormalized latency (pg migration v31), token counts
+  // (pg migration v21) + served model for cheap SQL aggregation. Nullable
+  // integers; NULL = pre-feature row / usage not measured.
+  latencyTotalMs: integer("latency_total_ms"),
   promptTokens: integer("prompt_tokens"),
   completionTokens: integer("completion_tokens"),
   cachedTokens: integer("cached_tokens"),

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -59,8 +59,9 @@ export class PgTelemetryStore implements TelemetryStore {
       decisionJson: input.decision,
       finalStatus: input.decision.final.status,
       costUsd: finalCost,
-      // Denormalized token counts + served model (pg migration v21) for cheap
-      // aggregation. NULL when the gateway never stamped usage (forward-only).
+      // Denormalized dashboard fields for cheap aggregation. NULL when the
+      // gateway never stamped a field (forward-only / legacy rows).
+      latencyTotalMs: input.decision.latency_total_ms,
       promptTokens: usage?.prompt_tokens ?? null,
       completionTokens: usage?.completion_tokens ?? null,
       cachedTokens: usage?.cached_tokens ?? null,
@@ -229,9 +230,7 @@ export class PgTelemetryStore implements TelemetryStore {
         completionTokens: sql<number>`COALESCE(SUM(${telemetry.completionTokens}), 0)`,
         cachedTokens: sql<number>`COALESCE(SUM(${telemetry.cachedTokens}), 0)`,
         cacheCreationTokens: sql<number>`COALESCE(SUM(${telemetry.cacheCreationTokens}), 0)`,
-        avgLatencyMs: sql<
-          number | null
-        >`AVG((${telemetry.decisionJson} ->> 'latency_total_ms')::double precision)`,
+        avgLatencyMs: sql<number | null>`AVG(${telemetry.latencyTotalMs})`,
         // True-TPS aggregate ratio inputs (mirror of the sqlite adapter). The CASE
         // restricts BOTH sums to streaming rows with a measured window so the rate is
         // never diluted by a non-streaming completion; the shaper divides them.

--- a/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
+++ b/packages/core/src/store/sqlite/memory-dedup-migrate.test.ts
@@ -47,11 +47,12 @@ function seedPreV21(): string {
   // v28 alters memory_facts (+ FTS); this memory_messages-only fixture never creates
   // memory_facts → pre-mark applied (out of scope for the v21 dedup test).
   ins.run(28);
-  // v30 alters telemetry and v31 alters api_keys; both are absent here → pre-mark.
+  // v30/v32 alter telemetry and v31 alters api_keys; both are absent here → pre-mark.
   // v29 (payload_blobs) is out of scope too.
   ins.run(29);
   ins.run(30);
   ins.run(31);
+  ins.run(32);
   raw.exec(`
     CREATE TABLE memory_messages (
       id TEXT PRIMARY KEY,

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -365,11 +365,12 @@ describe("sqlite v18 forgetting schema deltas", () => {
       rec.run(26, Date.now());
       // v27 indexes memory_jobs; this memory-only fixture never creates it → pre-mark.
       rec.run(27, Date.now());
-      // v30 alters telemetry and v31 alters api_keys; both are absent here → pre-mark.
+      // v30/v32 alter telemetry and v31 alters api_keys; both are absent here → pre-mark.
       // v29 (payload_blobs) is out of scope too.
       rec.run(29, Date.now());
       rec.run(30, Date.now());
       rec.run(31, Date.now());
+      rec.run(32, Date.now());
       seed.close();
 
       expect(() => runMigrations(path)).not.toThrow();

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -689,6 +689,53 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE api_keys ADD COLUMN allow_fast_mode INTEGER NOT NULL DEFAULT 0;
     `,
   },
+  {
+    // Admin dashboard aggregate hot path: /admin/api/stats was averaging
+    // json_extract(decision_json, '$.latency_total_ms') across the whole telemetry
+    // window. On production SQLite that forced table reads + JSON parsing for
+    // every dashboard load and blocked Node's synchronous better-sqlite3 thread.
+    // Denormalize the total latency and add covering indexes for the global and
+    // per-key aggregate windows so SUM/COUNT/GROUP BY can scan narrow index pages.
+    version: 32,
+    sql: `
+      ALTER TABLE telemetry ADD COLUMN latency_total_ms INTEGER;
+
+      UPDATE telemetry
+      SET latency_total_ms = CAST(json_extract(decision_json, '$.latency_total_ms') AS INTEGER)
+      WHERE latency_total_ms IS NULL
+        AND json_extract(decision_json, '$.latency_total_ms') IS NOT NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_admin_window_cover
+        ON telemetry (
+          created_at,
+          final_status,
+          cost_usd,
+          prompt_tokens,
+          completion_tokens,
+          cached_tokens,
+          cache_creation_tokens,
+          latency_total_ms,
+          generation_ms,
+          served_model,
+          api_key_id
+        );
+
+      CREATE INDEX IF NOT EXISTS idx_telemetry_admin_key_window_cover
+        ON telemetry (
+          api_key_id,
+          created_at,
+          final_status,
+          cost_usd,
+          prompt_tokens,
+          completion_tokens,
+          cached_tokens,
+          cache_creation_tokens,
+          latency_total_ms,
+          generation_ms,
+          served_model
+        );
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database): void {

--- a/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
@@ -32,11 +32,12 @@ function seedPreV26(): string {
   ins.run(27);
   // v28 alters memory_facts (+ FTS), absent from this oauth_quota-only fixture → pre-mark.
   ins.run(28);
-  // v30 alters telemetry and v31 alters api_keys; both are absent here → pre-mark.
+  // v30/v32 alter telemetry and v31 alters api_keys; both are absent here → pre-mark.
   // v29 (payload_blobs) is out of scope too.
   ins.run(29);
   ins.run(30);
   ins.run(31);
+  ins.run(32);
   raw.exec(`
     CREATE TABLE oauth_quota (
       provider_id TEXT NOT NULL,

--- a/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-usage-migrate.test.ts
@@ -43,11 +43,12 @@ function seedPreV23(): string {
   ins.run(27);
   // v28 alters memory_facts (+ FTS), absent from this oauth_usage-only fixture → pre-mark.
   ins.run(28);
-  // v30 alters telemetry and v31 alters api_keys; both are absent here → pre-mark.
+  // v30/v32 alter telemetry and v31 alters api_keys; both are absent here → pre-mark.
   // v29 (payload_blobs) is out of scope too.
   ins.run(29);
   ins.run(30);
   ins.run(31);
+  ins.run(32);
   raw.exec(`
     CREATE TABLE oauth_usage (
       provider_id TEXT NOT NULL,

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -66,11 +66,11 @@ describe("sqlite schema + migrations", () => {
       // pre-mark applied, out of scope.
       // v28 alters memory_facts (+ FTS); this memory_jobs-only fixture never creates
       // memory_facts → pre-mark applied (out of scope for this v14–v16 test).
-      // v30 alters telemetry and v31 alters api_keys; both tables are absent from
+      // v30/v32 alter telemetry and v31 alters api_keys; both tables are absent from
       // this memory_jobs-only fixture → pre-mark applied. v29 (payload_blobs CREATE)
       // has no dependency but is pre-marked too.
       // biome-ignore format: keep the version ledger on one readable line
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28, 29, 30, 31])
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 28, 29, 30, 31, 32])
         rec.run(v, Date.now());
       const insert = seed.prepare(
         "INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
@@ -158,11 +158,95 @@ describe("sqlite schema + migrations", () => {
       "decision_json",
       "final_status",
       "cost_usd",
+      "latency_total_ms",
+      "prompt_tokens",
+      "completion_tokens",
+      "cached_tokens",
+      "cache_creation_tokens",
+      "served_model",
+      "generation_ms",
       "created_at",
     ]) {
       expect(telCols).toContain(c);
     }
+    const telemetryIndexes = raw
+      .prepare("PRAGMA index_list(telemetry)")
+      .all()
+      .map((idx) => (idx as { name: string }).name);
+    expect(telemetryIndexes).toContain("idx_telemetry_admin_window_cover");
+    expect(telemetryIndexes).toContain("idx_telemetry_admin_key_window_cover");
     raw.close();
+  });
+
+  it("v32 backfills telemetry latency and creates admin aggregate indexes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v32-"));
+    const path = join(dir, "helm.db");
+    try {
+      const seed = new Database(path);
+      seed.exec(
+        "CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);",
+      );
+      seed.exec(`
+        CREATE TABLE telemetry (
+          id TEXT PRIMARY KEY,
+          request_id TEXT NOT NULL UNIQUE,
+          api_key_id TEXT NOT NULL,
+          decision_json TEXT NOT NULL,
+          final_status TEXT,
+          cost_usd REAL,
+          prompt_tokens INTEGER,
+          completion_tokens INTEGER,
+          cached_tokens INTEGER,
+          cache_creation_tokens INTEGER,
+          served_model TEXT,
+          generation_ms INTEGER,
+          created_at INTEGER NOT NULL
+        );
+      `);
+      const rec = seed.prepare("INSERT INTO _migrations (version, applied_at) VALUES (?, ?)");
+      for (let v = 1; v <= 31; v++) rec.run(v, Date.now());
+      seed
+        .prepare(
+          `INSERT INTO telemetry (
+            id, request_id, api_key_id, decision_json, final_status, cost_usd,
+            prompt_tokens, completion_tokens, cached_tokens, cache_creation_tokens,
+            served_model, generation_ms, created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "t1",
+          "req_1",
+          "k1",
+          JSON.stringify({ latency_total_ms: 1234 }),
+          "ok",
+          0.01,
+          10,
+          2,
+          1,
+          0,
+          "gpt-4o",
+          500,
+          1000,
+        );
+      seed.close();
+
+      runMigrations(path);
+
+      const after = new Database(path);
+      const row = after
+        .prepare("SELECT latency_total_ms FROM telemetry WHERE request_id = ?")
+        .get("req_1") as { latency_total_ms: number };
+      expect(row.latency_total_ms).toBe(1234);
+      const telemetryIndexes = after
+        .prepare("PRAGMA index_list(telemetry)")
+        .all()
+        .map((idx) => (idx as { name: string }).name);
+      expect(telemetryIndexes).toContain("idx_telemetry_admin_window_cover");
+      expect(telemetryIndexes).toContain("idx_telemetry_admin_key_window_cover");
+      after.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("v6 rebuild relaxes cost_usd to REAL and preserves existing rows", () => {
@@ -279,8 +363,8 @@ describe("sqlite schema + migrations", () => {
       // api_keys-only fixture) → pre-mark applied.
       // v25 (telemetry.generation_ms): no telemetry table here → pre-mark applied.
       // v28 alters memory_facts (absent from this api_keys-only fixture) → pre-mark.
-      // v30 alters telemetry (absent here) → pre-mark; v29 (payload_blobs) pre-marked too.
-      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22, 24, 25, 28, 29, 30])
+      // v30/v32 alter telemetry (absent here) → pre-mark; v29 (payload_blobs) pre-marked too.
+      for (const v of [1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 20, 21, 22, 24, 25, 28, 29, 30, 32])
         rec.run(v, Date.now());
       seed
         .prepare(

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -51,12 +51,10 @@ export const telemetry = sqliteTable("telemetry", {
   decisionJson: text("decision_json").notNull(), // JSON.stringify(DecisionRecord), redacted
   finalStatus: text("final_status"), // denormalized final.status for querying
   costUsd: real("cost_usd"), // nullable; REAL mirrors pg doublePrecision (no truncation)
-  // Dashboard token accounting (migration v22): denormalized served-completion
-  // token counts + served model for cheap SQL aggregation (SUM / GROUP BY) on the
-  // admin homepage. Nullable — NULL = pre-feature row / usage not measured
-  // (forward-only, no backfill). Counts come from DecisionRecord.usage (the
-  // gateway's post-served stamp); servedModel mirrors final.provider_model so the
-  // by-model breakdown is a plain GROUP BY without json_extract.
+  // Dashboard accounting: denormalized latency (migration v32), token counts
+  // (migration v22) + served model for cheap SQL aggregation on the admin
+  // homepage. Nullable — NULL = pre-feature row / usage not measured.
+  latencyTotalMs: integer("latency_total_ms"),
   promptTokens: integer("prompt_tokens"),
   completionTokens: integer("completion_tokens"),
   cachedTokens: integer("cached_tokens"),

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -62,6 +62,26 @@ function freshStore() {
 }
 
 describe("SqliteTelemetryStore", () => {
+  it("denormalizes latency for dashboard aggregates instead of reading decision_json", async () => {
+    const db = createSqliteDb(":memory:");
+    const store = new SqliteTelemetryStore(db);
+    await store.insert({
+      decision: decision("req_1", { latency_total_ms: 1200 }),
+      apiKeyId: "k1",
+      createdAt: new Date(1000),
+    });
+
+    db.$sqlite
+      .prepare(
+        "UPDATE telemetry SET decision_json = json_set(decision_json, '$.latency_total_ms', 999999) WHERE request_id = ?",
+      )
+      .run("req_1");
+
+    const agg = await store.aggregate(0, 2000, "hour");
+    expect(agg.totals.avgLatencyMs).toBe(1200);
+    db.$sqlite.close();
+  });
+
   it("round-trips insert -> queryRecent without losing nested structure", async () => {
     const store = freshStore();
     const at = new Date(1717155600000);

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -49,8 +49,9 @@ export class SqliteTelemetryStore implements TelemetryStore {
       decisionJson: JSON.stringify(input.decision),
       finalStatus: input.decision.final.status,
       costUsd: finalCost,
-      // Denormalized token counts + served model (migration v22) for cheap
-      // aggregation. NULL when the gateway never stamped usage (forward-only).
+      // Denormalized dashboard fields for cheap aggregation. NULL when the
+      // gateway never stamped a field (forward-only / legacy rows).
+      latencyTotalMs: input.decision.latency_total_ms,
       promptTokens: usage?.prompt_tokens ?? null,
       completionTokens: usage?.completion_tokens ?? null,
       cachedTokens: usage?.cached_tokens ?? null,
@@ -214,9 +215,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
         completionTokens: sql<number>`COALESCE(SUM(${telemetry.completionTokens}), 0)`,
         cachedTokens: sql<number>`COALESCE(SUM(${telemetry.cachedTokens}), 0)`,
         cacheCreationTokens: sql<number>`COALESCE(SUM(${telemetry.cacheCreationTokens}), 0)`,
-        avgLatencyMs: sql<
-          number | null
-        >`AVG(json_extract(${telemetry.decisionJson}, '$.latency_total_ms'))`,
+        avgLatencyMs: sql<number | null>`AVG(${telemetry.latencyTotalMs})`,
         // True-TPS aggregate ratio inputs. The CASE keeps numerator + denominator on
         // the SAME rows (streaming rows with a measured window, generation_ms > 0), so
         // a non-streaming completion never inflates the rate. The shaper divides them.

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -668,6 +668,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(agg.totals.completionTokens).toBe(75); // 20+10+40+5
       expect(agg.totals.cachedTokens).toBe(80);
       expect(agg.totals.cacheCreationTokens).toBe(16);
+      expect(agg.totals.avgLatencyMs).toBe(1200);
 
       // Series: two day buckets, chronological, summed per day.
       expect(agg.series).toHaveLength(2);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "apps/*"
   - "packages/*"
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true


### PR DESCRIPTION
## Summary
- Denormalize telemetry `latency_total_ms` for SQLite and Postgres so admin stats no longer parse `decision_json` for average latency.
- Add admin aggregate covering indexes for global and per-key telemetry windows.
- Backfill the new latency column in migrations and add SQLite/Postgres migration + aggregate contract coverage.
- Add pnpm 11 native build allowlist for `better-sqlite3`/`esbuild` so local/CI installs can build required native deps.

## Production finding
- On the live admin, long-range `/admin/api/stats` calls were the severe hotspot. Prior live sweeps showed 7d/30d stats calls taking 100s+.
- Because the SQLite adapter uses synchronous `better-sqlite3`, one long stats query blocks the Node event loop and makes unrelated admin APIs wait behind it.
- Browser sampling after login confirmed the home page issues two stats calls plus requests; light windows are subsecond, but the long-window stats path is the dangerous amplifier.

## Validation
- `pnpm exec vitest run packages/core/src/store/sqlite/telemetry.test.ts packages/core/src/store/sqlite/schema.test.ts packages/core/src/store/postgres/migrate.test.ts packages/core/src/store/store-contract.test.ts`
- `pnpm test` (319 files, 4887 tests)
- `pnpm typecheck`
- `pnpm lint` (exit 0; existing non-blocking style info in `packages/core/src/memory/forgetting/facts.test.ts`)
- `pnpm build`