### PR TITLE
Normalize Claude Code date fingerprint markers

### DIFF
--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -828,6 +828,43 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expectNativeCarrier(meta.native_request, "anthropic_messages", REQ_BODY);
   });
 
+  it("normalizes Claude Code date fingerprint markers before native passthrough", async () => {
+    const incoming = {
+      ...REQ_BODY,
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.197.abc; cc_entrypoint=cli; cch=12345;",
+        },
+        { type: "text", text: "Todayʹs date is 2026/07/01." },
+      ],
+    };
+    const { record, insertPayload } = makeRecord({ capturePayloads: true });
+    const { deps, harness } = makeDeps({ record });
+    const app = buildApp(deps);
+
+    await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(incoming),
+    });
+
+    const meta = (harness.pipelineSawIR?.metadata ?? {}) as { native_request?: unknown };
+    const carrier = meta.native_request as {
+      body?: { system?: Array<{ text?: string }> };
+      raw_body?: string;
+      mutations?: { body_shims_applied?: string[] };
+    };
+    expect(carrier.body?.system?.[1]?.text).toBe("Today's date is 2026-07-01.");
+    expect(JSON.parse(carrier.raw_body ?? "{}").system[1].text).toBe("Today's date is 2026-07-01.");
+    expect(carrier.mutations?.body_shims_applied).toContain(
+      "claude_code_date_fingerprint_normalized",
+    );
+
+    const payload = insertPayload.mock.calls[0]?.[0] as { requestJson: string };
+    expect(JSON.parse(payload.requestJson).system[1].text).toBe("Todayʹs date is 2026/07/01.");
+  });
+
   it("stamps native_request on a STREAMING request too (Phase 2 streaming passthrough)", async () => {
     // Phase 2: the carrier now covers streams. The native streaming body already
     // carries stream:true; the guard + executor decide whether to actually forward it.

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -2,9 +2,11 @@ import {
   type BudgetCaps,
   type DecisionRecord,
   extractBillingHeaderIdentity,
+  normalizeClaudeCodeDateFingerprintInAnthropicRequest,
   type RateLimitProbe,
   type RateLimitResult,
 } from "@helm/core";
+import { appendMutationList } from "@helm/shared";
 import type { Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -385,13 +387,18 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         trace_id: traceId,
       });
     }
+    const normalizedNative = normalizeClaudeCodeDateFingerprintInAnthropicRequest(native);
+    const nativeForPipeline = normalizedNative.body;
+    const nativeCarrierRawBody = normalizedNative.normalized
+      ? (JSON.stringify(nativeForPipeline) ?? requestJson)
+      : requestJson;
     // The REAL Anthropic transformer Zod-validates and THROWS on a structurally
     // invalid body (e.g. {messages:[]}). Wrap it so that throw becomes a 400 in the
     // ANTHROPIC envelope here, instead of escaping to onError → an OpenAI-shaped
     // 502 (principle 2 fail-closed; mirrors how responses.ts guards its transform).
     let ir: IRLike;
     try {
-      ir = await anthropic.transformRequestOut(native);
+      ir = await anthropic.transformRequestOut(nativeForPipeline);
     } catch (err) {
       const detail = err instanceof Error ? err.message : "invalid Anthropic request";
       return sendError(c, { error_class: "invalid_request", message: detail, trace_id: traceId });
@@ -405,7 +412,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     // version with a cache-stable cch instead of a pinned spoof (anti-ban). Null/absent
     // for non-CLI traffic → the executor uses its baked fallback version.
     const clientBilling = extractBillingHeaderIdentity(
-      (native as { system?: unknown } | null)?.system,
+      (nativeForPipeline as { system?: unknown } | null)?.system,
     );
     if (clientBilling !== null) ir.metadata.client_billing_header = clientBilling;
 
@@ -428,8 +435,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     // → off + null (default-safe). The ids are opaque (not credentials) and are
     // never logged here.
     const nativeMetaBag =
-      native && typeof native === "object" && (native as Record<string, unknown>).metadata
-        ? ((native as Record<string, unknown>).metadata as Record<string, unknown>)
+      nativeForPipeline &&
+      typeof nativeForPipeline === "object" &&
+      (nativeForPipeline as Record<string, unknown>).metadata
+        ? ((nativeForPipeline as Record<string, unknown>).metadata as Record<string, unknown>)
         : null;
     const sig = (v: unknown): string | null => (typeof v === "string" && v.length > 0 ? v : null);
     const memoryScope = resolveMemoryScope((name) => c.req.header(name), identity.accountId, {
@@ -447,20 +456,25 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     ir.metadata.memory_mode = memoryScope.mode;
     ir.metadata.memory_thread_source = memoryScope.threadSource;
 
-    // Native protocol passthrough carrier (#217). Stamp the VERBATIM parsed inbound
-    // body onto the IR metadata bag (same HTTP→core hand-off as client_billing_header
-    // above); the pipeline reads it into InternalRequest.native_request and the routing
-    // core's guard decides whether to forward it untranslated. NEVER logged. Covers
-    // BOTH stream and non-stream (Phase 2 added streaming passthrough): the native
-    // streaming body already carries stream:true, so the same verbatim body is the
+    // Native protocol passthrough carrier (#217). Stamp the parsed inbound body onto the
+    // IR metadata bag (same HTTP→core hand-off as client_billing_header above). It is
+    // byte-faithful except for pre-provider safety shims such as Claude Code date-marker
+    // normalization; those shims are recorded in the carrier mutation ledger. NEVER
+    // logged. Covers BOTH stream and non-stream (Phase 2 added streaming passthrough):
+    // the native streaming body already carries stream:true, so the same body is the
     // carrier — the guard + executor decide whether to actually forward it.
     const nativeCarrier = nativeCarrierFromParsedBody({
       protocol: "anthropic_messages",
-      native,
-      rawBody: requestJson,
+      native: nativeForPipeline,
+      rawBody: nativeCarrierRawBody,
       headers: c.req.raw.headers,
     });
     if (nativeCarrier !== null) {
+      if (normalizedNative.normalized) {
+        appendMutationList(nativeCarrier.mutations, "body_shims_applied", [
+          "claude_code_date_fingerprint_normalized",
+        ]);
+      }
       ir.metadata.native_request = nativeCarrier;
     }
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-01 · Claude Code 日期指纹入站归一化（Anthropic protocol / native passthrough，docs/05/07，原则 7/8）
+
+- **背景（Lukin）**：升级最新 `claude update` 后当前最新客户端为 `2.1.197`；二进制中确认仍存在 `ANTHROPIC_BASE_URL` + `Asia/Shanghai|Asia/Urumqi` 检测，以及把 `Today's date is YYYY-MM-DD.` 改成不同 apostrophe / slash 日期格式的逻辑。
+- **风险**：Helm 的 `/v1/messages` 会把 Claude Code 原始 Anthropic body 同时转换成 IR，并作为 `native_request` 交给 native passthrough；如果不处理，日期指纹会在互译路径和 byte passthrough 路径继续到达上游。
+- **修复决策**：新增 core 纯函数 `normalizeClaudeCodeDateFingerprintInAnthropicRequest()`，只还原精确日期句式：`Today[',’,ʼ,ʹ]s date is YYYY[-/]MM[-/]DD.` → `Today's date is YYYY-MM-DD.`；默认只处理 top-level `system` 与 `system/developer` message，若检测到 Claude Code billing header，则也处理 message 文本块以覆盖动态 system sections 被移到消息里的形态。
+- **passthrough 决策**：`request_payloads.request_json` 保留客户端原始输入用于审计；`native_request.body/raw_body` 使用归一化后的 body，并在 mutation ledger 记录 `body_shims_applied=["claude_code_date_fingerprint_normalized"]`，避免隐式改写。
+- **验证**：新增 core 纯函数测试与 gateway native carrier 回归；`pnpm vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/protocol/anthropic/date-fingerprint.test.ts apps/gateway/src/routes/messages.test.ts` 122/122 绿，`pnpm typecheck` 绿，触碰文件 Biome 绿，全仓 `pnpm lint` 退出 0（仅既有 style info）。全量 `pnpm test` 4888/4890 绿后被 2 个 PGlite 15s timeout 拦住，两个失败文件单独重跑均绿。
+
 ## 2026-07-01 · admin telemetry 聚合改为列化延迟 + 覆盖索引（Admin observability / store，docs/07/11，原则 7）
 
 - **背景（Lukin）**：生产 SQLite 数据库约 22GB，`/admin/api/stats` 在 7d/30d 窗口可跑到 100s+；由于 SQLite 适配器使用同步 `better-sqlite3`，这类长统计会阻塞 Node event loop，让其它管理端 API 看起来也一起卡住。
@@ -24,19 +32,13 @@
 - **前端决策**：admin shell 只声明 SVG favicon，保留 PNG 文件作为兼容/直接访问资产，但不主动让浏览器同时拉两张图。
 - **验证**：新增 gateway 静态资源缓存回归测试与 admin shell favicon 数量测试；运行时检查确认 favicons 返回私有 7 天缓存，`/admin/` 仍返回 `no-cache`。
 
-## 2026-06-30 · per-model reasoning effort policy（执行 fallback / 协议转换，docs/04/05，原则 2/5/8）
-
-- **背景（Lukin）**：生产请求 `10124906-2d15-4cf6-accf-8ce26227a8ca` 走 `economy`，首个 `openai-codex/gpt-5.4-mini` 3s timeout 后 fallback 到 `anthropic/claude-haiku-4-5-20251001`；Haiku 返回 `400 invalid_request_error: This model does not support the effort parameter.`。客户端原始 payload 没有 `reasoning_effort`，是 `economy.reasoning_effort: medium` 在路由阶段强制注入。
-- **根因**：`reasoning_effort` 是跨协议 IR 字段，但模型真正支持的是具体 wire 字段：OpenAI `reasoning.effort`、Anthropic `output_config.effort`、Anthropic `thinking`、Gemini `thinkingConfig`。Haiku 4.5 支持 manual thinking budget，但不支持 Anthropic adaptive `output_config.effort`；旧代码把 lane effort 同时合成 thinking + output_config，导致下游 400。之前的 executor guard 又把支持信息写死在代码里，并且选择 skip candidate，不能表达“这个模型能用 thinking，但不能用 effort 参数”。
-- **修复决策**：在 catalog capability 增加 `reasoningEffort`，由 `config/capabilities.yaml` 为每个模型声明各 wire 字段是否支持、支持哪些 level、以及 level map。executor 在每个 candidate attempt 上按该 policy 适配 body：支持则按配置映射，不支持则删除该 wire 参数，继续尝试当前模型；不再因为 unsupported effort 直接 skip candidate。
-- **当前配置**：Codex/OpenAI entries 声明 `openaiReasoning` levels；Gemini entries 声明 `geminiThinkingConfig`；Anthropic Opus/Fable 使用 `anthropicOutputConfig` 并禁用 manual thinking；Sonnet 4.6 将 `xhigh -> max`；Haiku 4.5 删除 `output_config.effort`，但保留/合成 manual `thinking`。
-- **验证**：新增 translated + native passthrough regression：Sonnet `xhigh` 映射为 `output_config.effort=max` 且不 skip；Haiku `reasoning_effort=medium` 仍使用 Haiku，上游 body 无 `output_config` 且有 `thinking`；native passthrough 同样删除 unsupported `output_config.effort`。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+- **2026-06-30 · per-model reasoning effort policy（执行 fallback / 协议转换，docs/04/05，原则 2/5/8）**：新增 catalog `reasoningEffort` policy，按模型/协议 wire 字段映射或删除 unsupported effort；Haiku 4.5 保留 manual `thinking` 但删除 `output_config.effort`，Sonnet `xhigh -> max`，translated/native passthrough 回归覆盖。
 
 - **2026-06-30 · Anthropic `output_config.effort` 与 OpenAI `reasoning_effort` 双向保真（协议转换/执行 fallback，docs/05/04，原则 5/8）**：Anthropic 入站 `output_config.effort` 提升到 IR `reasoning_effort`，OpenAI/Responses fallback 保留推理等级；反向 GPT/OpenAI→Anthropic 在无显式 output_config 时合成 `output_config.effort`；只映射等级字段，不从 `thinking.budget_tokens` 反推。
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -352,6 +352,7 @@ export {
   transformRequestOut as anthropicTransformRequestOut,
   transformResponseIn as anthropicTransformResponseIn,
 } from "./protocol/anthropic/index.js";
+export { normalizeClaudeCodeDateFingerprintInAnthropicRequest } from "./protocol/anthropic/request.js";
 // Gemini-native error envelope transformer (docs/05, 07). HelmError -> the Google
 // google.rpc.Status { error: { code, message, status } } shape; status/code from
 // err.http_status.

--- a/packages/core/src/protocol/anthropic/date-fingerprint.test.ts
+++ b/packages/core/src/protocol/anthropic/date-fingerprint.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { normalizeClaudeCodeDateFingerprintInAnthropicRequest } from "./request.js";
+
+describe("normalizeClaudeCodeDateFingerprintInAnthropicRequest", () => {
+  it("restores Claude Code date apostrophe and slash variants in system content", () => {
+    const input = {
+      model: "claude-3-5-sonnet",
+      system: [
+        { type: "text", text: "Today’s date is 2026-07-01." },
+        { type: "text", text: "Todayʼs date is 2026/07/02." },
+        { type: "text", text: "Todayʹs date is 2026/07/03.", cache_control: { type: "ephemeral" } },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    };
+
+    const out = normalizeClaudeCodeDateFingerprintInAnthropicRequest(input);
+
+    expect(out.normalized).toBe(true);
+    expect(out.body).toEqual({
+      ...input,
+      system: [
+        { type: "text", text: "Today's date is 2026-07-01." },
+        { type: "text", text: "Today's date is 2026-07-02." },
+        { type: "text", text: "Today's date is 2026-07-03.", cache_control: { type: "ephemeral" } },
+      ],
+    });
+  });
+
+  it("normalizes system and developer message text without touching ordinary user text", () => {
+    const input = {
+      model: "claude-3-5-sonnet",
+      messages: [
+        { role: "system", content: "Todayʹs date is 2026/07/01." },
+        {
+          role: "developer",
+          content: [{ type: "text", text: "Todayʼs date is 2026/07/02." }],
+        },
+        { role: "user", content: "quote: Todayʼs date is 2026/07/03." },
+      ],
+    };
+
+    const out = normalizeClaudeCodeDateFingerprintInAnthropicRequest(input);
+
+    expect(out.normalized).toBe(true);
+    expect(out.body).toEqual({
+      ...input,
+      messages: [
+        { role: "system", content: "Today's date is 2026-07-01." },
+        {
+          role: "developer",
+          content: [{ type: "text", text: "Today's date is 2026-07-02." }],
+        },
+        { role: "user", content: "quote: Todayʼs date is 2026/07/03." },
+      ],
+    });
+  });
+});

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -246,6 +246,104 @@ function billingHeaderText(system: unknown): string | null {
   return null;
 }
 
+const CLAUDE_CODE_DATE_FINGERPRINT_RE =
+  /Today['\u2019\u02bc\u02b9]s date is ([0-9]{4})[-/]([0-9]{2})[-/]([0-9]{2})\./g;
+
+function normalizeClaudeCodeDateText(text: string): { text: string; normalized: boolean } {
+  const next = text.replace(
+    CLAUDE_CODE_DATE_FINGERPRINT_RE,
+    (_match, year: string, month: string, day: string) =>
+      `Today's date is ${year}-${month}-${day}.`,
+  );
+  return { text: next, normalized: next !== text };
+}
+
+function normalizeTextBlockArray(value: Array<unknown>): {
+  value: Array<unknown>;
+  normalized: boolean;
+} {
+  let normalized = false;
+  const next = value.map((block) => {
+    if (block === null || typeof block !== "object" || Array.isArray(block)) return block;
+    const record = block as Record<string, unknown>;
+    if (record.type !== "text" || typeof record.text !== "string") return block;
+    const text = normalizeClaudeCodeDateText(record.text);
+    if (!text.normalized) return block;
+    normalized = true;
+    return { ...record, text: text.text };
+  });
+  return normalized ? { value: next, normalized } : { value, normalized: false };
+}
+
+function normalizeSystemFingerprint(system: unknown): { value: unknown; normalized: boolean } {
+  if (typeof system === "string") {
+    const text = normalizeClaudeCodeDateText(system);
+    return text.normalized
+      ? { value: text.text, normalized: true }
+      : { value: system, normalized: false };
+  }
+  if (!Array.isArray(system)) return { value: system, normalized: false };
+  return normalizeTextBlockArray(system);
+}
+
+function normalizeMessageContentFingerprint(content: unknown): {
+  value: unknown;
+  normalized: boolean;
+} {
+  if (typeof content === "string") {
+    const text = normalizeClaudeCodeDateText(content);
+    return text.normalized
+      ? { value: text.text, normalized: true }
+      : { value: content, normalized: false };
+  }
+  if (!Array.isArray(content)) return { value: content, normalized: false };
+  return normalizeTextBlockArray(content);
+}
+
+function normalizeMessagesFingerprint(
+  messages: unknown,
+  opts: { normalizeAllTextMessages: boolean },
+): { value: unknown; normalized: boolean } {
+  if (!Array.isArray(messages)) return { value: messages, normalized: false };
+  let normalized = false;
+  const next = messages.map((message) => {
+    if (message === null || typeof message !== "object" || Array.isArray(message)) return message;
+    const record = message as Record<string, unknown>;
+    const role = record.role;
+    if (role !== "system" && role !== "developer" && !opts.normalizeAllTextMessages) {
+      return message;
+    }
+    const content = normalizeMessageContentFingerprint(record.content);
+    if (!content.normalized) return message;
+    normalized = true;
+    return { ...record, content: content.value };
+  });
+  return normalized ? { value: next, normalized } : { value: messages, normalized: false };
+}
+
+export function normalizeClaudeCodeDateFingerprintInAnthropicRequest(body: unknown): {
+  body: unknown;
+  normalized: boolean;
+} {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { body, normalized: false };
+  }
+  const record = body as Record<string, unknown>;
+  const system = normalizeSystemFingerprint(record.system);
+  const messages = normalizeMessagesFingerprint(record.messages, {
+    normalizeAllTextMessages: billingHeaderText(record.system) !== null,
+  });
+  if (!system.normalized && !messages.normalized) return { body, normalized: false };
+  return {
+    body: {
+      ...record,
+      ...(system.normalized ? { system: system.value } : {}),
+      ...(messages.normalized ? { messages: messages.value } : {}),
+    },
+    normalized: true,
+  };
+}
+
 // —— system: string | block[] -> IR message content (string or multipart). ————————
 function normalizeSystem(system: z.infer<typeof AnthropicSystemSchema>): IRMessage["content"] {
   if (typeof system === "string") return system;


### PR DESCRIPTION
## Summary

- Normalize Claude Code date fingerprint variants in Anthropic message requests before Anthropic IR/native passthrough handling.
- Preserve the original client request in `request_payloads.request_json` for audit/debugging.
- Record the native passthrough mutation ledger with `claude_code_date_fingerprint_normalized` when normalization is applied.

## Verification

- `pnpm vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/protocol/anthropic/date-fingerprint.test.ts apps/gateway/src/routes/messages.test.ts`
- `pnpm typecheck`
- `pnpm exec biome check implementation-notes.md apps/gateway/src/routes/messages.ts apps/gateway/src/routes/messages.test.ts packages/core/src/protocol/anthropic/request.ts packages/core/src/protocol/anthropic/date-fingerprint.test.ts packages/core/src/index.ts`
- `pnpm lint`
- `pnpm test` reached 4888/4890 passed; two PGlite/Postgres concurrent-run timeout failures were rerun individually and passed:
  - `pnpm vitest run packages/core/src/store/postgres/payload-cas.test.ts`
  - `pnpm vitest run packages/core/src/store/postgres/memory-admin.test.ts`
