### PR TITLE
fix: hide Claude usage reset action

### DIFF
--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -208,9 +208,10 @@ export async function logoutOAuth(provider: string, account = 'default'): Promis
   if (!res.ok && res.status !== 204) await asJson(res);
 }
 
-// POST /oauth/:provider/reset?account= -> clear the auto-park usage-limit cooldown so
-// a rate-limited account rejoins the pool on the next request ("Reset usage"). Leaves
-// the operator's schedulable park untouched.
+// POST /oauth/:provider/reset?account= -> Codex-only local cooldown override. Clears
+// Helm's auto-park usage-limit cooldown so the account rejoins the pool on the next
+// request ("Reset usage"). Leaves the operator's schedulable park untouched. Claude
+// 5h/7d windows are upstream subscription limits and are not resettable here.
 export async function resetUsageLimit(provider: string, account = 'default'): Promise<void> {
   const res = await fetch(`${BASE}/${provider}/reset?account=${encodeURIComponent(account)}`, {
     method: 'POST',

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -55,8 +55,9 @@
   // Accounts whose inline schedule edit is in flight (keyed provider/account) — used
   // to disable the control while saving without blocking the rest of the table.
   let savingSchedule = $state<Record<string, boolean>>({});
-  // Accounts whose "Reset usage" click is in flight (keyed provider/account) — clears
-  // the auto-park cooldown (#291).
+  // Codex accounts whose "Reset usage" click is in flight (keyed provider/account) —
+  // clears Helm's local auto-park cooldown (#291). Claude's 5h/7d windows are upstream
+  // subscription limits and are not operator-resettable.
   let resetting = $state<Record<string, boolean>>({});
   // The Codex account whose "Reset limit" consume is awaiting confirmation. A reset
   // spends a scarce, irreversible credit AND restores the WHOLE upstream ChatGPT
@@ -482,7 +483,8 @@
             {@const quota = quotaByKey.get(k)}
             {@const saving = savingSchedule[k] === true}
             {@const isCodex = row.provider.id === 'openai-codex'}
-            {@const supportsFast = row.provider.id === 'anthropic' || row.provider.id === 'openai-codex'}
+            {@const supportsFast =
+              row.provider.id === 'anthropic' || row.provider.id === 'openai-codex'}
             {@const codexCredits = isCodex ? (quota?.resetCredits ?? null) : null}
             {@const usageLimit = usageLimitStatus(quota)}
             {@const usageLimitRecovery = usageLimit ? autoRecoverIn(usageLimit.untilMs) : ''}
@@ -653,11 +655,7 @@
                     disabled={saving}
                     aria-label={$t('Fast mode')}
                     onchange={(e) =>
-                      toggleFastMode(
-                        row.provider.id,
-                        row.account.account,
-                        e.currentTarget.checked,
-                      )}
+                      toggleFastMode(row.provider.id, row.account.account, e.currentTarget.checked)}
                   />
                 {:else}
                   <span class="text-xs text-ink-muted">—</span>
@@ -693,7 +691,7 @@
                         account: row.account.account,
                       })}>{$t('Manage')}</button
                   >
-                  {#if usageLimit}
+                  {#if usageLimit && isCodex}
                     <button
                       type="button"
                       class="btn-secondary"

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -224,6 +224,34 @@ describe('providers page', () => {
     expect(within(row).queryByText('Rate limited')).not.toBeInTheDocument();
   });
 
+  it('does not render "Reset usage" for a rate-limited Anthropic account', () => {
+    const now = Date.now();
+    renderPage({
+      quota: [
+        {
+          providerId: 'anthropic',
+          account: 'acct-claude',
+          windows: [
+            {
+              key: '5h',
+              usedPercent: 100,
+              resetsAtMs: now + 2 * 60 * 60_000,
+              windowMinutes: null,
+            },
+          ],
+          capturedAt: now,
+          source: 'anthropic',
+          usageLimitedUntilMs: now + 2 * 60 * 60_000,
+        },
+      ],
+    });
+
+    const row = screen.getByTestId('provider-account-row');
+    expect(within(row).getByText('Rate limited')).toBeInTheDocument();
+    expect(within(row).queryByRole('button', { name: /reset usage/i })).not.toBeInTheDocument();
+    expect(resetUsageLimit).not.toHaveBeenCalled();
+  });
+
   it('renders "Direct" and caps the models list with a +N pill', () => {
     renderPage({
       providers: [

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -663,16 +663,18 @@ describe("admin OAuth routes — POST /oauth/:provider/reset (Reset usage)", () 
     expect(applyUsageLimit).toHaveBeenCalledWith("openai-codex", "default", null);
   });
 
-  it("honors an explicit ?account and never touches schedulable (cooldown only)", async () => {
+  it("rejects Anthropic reset because Claude usage windows are not resettable", async () => {
     const applyUsageLimit = vi.fn(async () => {});
     const seam = fullSeam();
     const res = await app({ oauth: seam, applyUsageLimit }).request(
       "/admin/api/oauth/anthropic/reset?account=work",
       { method: "POST" },
     );
-    expect(res.status).toBe(204);
-    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "work", null);
-    // Reset is a cooldown-only operation — it must not re-schedule the account.
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toMatchObject({
+      error: "usage reset is only supported for openai-codex",
+    });
+    expect(applyUsageLimit).not.toHaveBeenCalled();
     expect(
       (seam as unknown as { setAccountSchedule: ReturnType<typeof vi.fn> }).setAccountSchedule,
     ).not.toHaveBeenCalled();

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -617,18 +617,22 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   });
 
   // POST /oauth/:provider/reset?account=... -> 204 ("Reset usage")
-  // Clear the AUTO-park usage-limit cooldown so a rate-limited account rejoins the
-  // pool on the next request. Clears ONLY the cooldown (live member + persisted) —
-  // an operator-parked (schedulable=false) account stays parked. No rebuild needed:
-  // applyUsageLimit flips the live member in place. 503 when OAuth is disabled (no
-  // seam) — same as every other /oauth/* route, so a disabled deployment never mutates
-  // quota state. (buildServer always wires applyUsageLimit, so the seam is the real gate.)
+  // Codex-only local cooldown override: clear Helm's AUTO-park usage-limit cooldown
+  // so the account rejoins the pool on the next request. Clears ONLY the cooldown
+  // (live member + persisted) — an operator-parked (schedulable=false) account stays
+  // parked. Claude's 5h/7d subscription windows are upstream limits, so they are not
+  // exposed here as resettable. No rebuild needed: applyUsageLimit flips the live
+  // member in place. 503 when OAuth is disabled (no seam), matching /oauth/* routes.
   app.post("/admin/api/oauth/:provider/reset", async (c) => {
     const s = seam();
     if (!s || !deps.applyUsageLimit) return c.json({ error: "oauth login not configured" }, 503);
+    const providerId = c.req.param("provider");
+    if (providerId !== "openai-codex") {
+      return c.json({ error: "usage reset is only supported for openai-codex" }, 400);
+    }
     const account = c.req.query("account") || DEFAULT_ACCOUNT;
     try {
-      await deps.applyUsageLimit(c.req.param("provider"), account, null);
+      await deps.applyUsageLimit(providerId, account, null);
       return c.body(null, 204);
     } catch (e) {
       return c.json({ error: errMessage(e) }, 400);


### PR DESCRIPTION
## Summary
- hide the local `Reset usage` action for Claude/Anthropic accounts because their 5h/7d subscription windows are not operator-resettable
- keep the passive rate-limited recovery countdown visible for Claude accounts
- reject non-Codex `/admin/api/oauth/:provider/reset` calls at the gateway boundary
- add UI and route regressions for Anthropic reset behavior

## Verification
- `pnpm exec vitest run apps/gateway/src/routes/admin/oauth.test.ts --project node`
- `pnpm exec vitest run src/routes/providers/providers.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

Note: `pnpm --filter @helm/admin check` still fails on an unrelated existing fixture type issue in `apps/admin/src/routes/memory/memory.test.ts:85` (`allow_fast_mode` may be undefined).
