### PR TITLE
chore: release 0.22.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.33",
+  "version": "0.22.34",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- Bump root package version to `0.22.34` to trigger the Helm API publish workflow.
- This release includes the merged Claude Code date fingerprint normalization from #429 and the Claude usage reset visibility fix from #430.

## Verification

- `node -p "require('./package.json').version"` -> `0.22.34`
- `git diff --check`
- `pnpm exec biome check package.json` was not applicable because `package.json` is ignored by the Biome config.
