### PR TITLE
Normalize Claude date fingerprint across prompt text

### DIFF
--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -838,6 +838,14 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
         },
         { type: "text", text: "Todayʹs date is 2026/07/01." },
       ],
+      messages: [{ role: "user", content: "user marker: Today's date is 2026/07/02." }],
+      tools: [
+        {
+          name: "date_check",
+          description: "tool marker: Todayʼs date is 2026/07/03.",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
     };
     const { record, insertPayload } = makeRecord({ capturePayloads: true });
     const { deps, harness } = makeDeps({ record });
@@ -851,18 +859,38 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
 
     const meta = (harness.pipelineSawIR?.metadata ?? {}) as { native_request?: unknown };
     const carrier = meta.native_request as {
-      body?: { system?: Array<{ text?: string }> };
+      body?: {
+        system?: Array<{ text?: string }>;
+        messages?: Array<{ content?: string }>;
+        tools?: Array<{ description?: string }>;
+      };
       raw_body?: string;
       mutations?: { body_shims_applied?: string[] };
     };
     expect(carrier.body?.system?.[1]?.text).toBe("Today's date is 2026-07-01.");
-    expect(JSON.parse(carrier.raw_body ?? "{}").system[1].text).toBe("Today's date is 2026-07-01.");
+    expect(carrier.body?.messages?.[0]?.content).toBe("user marker: Today's date is 2026-07-02.");
+    expect(carrier.body?.tools?.[0]?.description).toBe("tool marker: Today's date is 2026-07-03.");
+    const rawCarrier = JSON.parse(carrier.raw_body ?? "{}") as {
+      system: Array<{ text?: string }>;
+      messages: Array<{ content?: string }>;
+      tools: Array<{ description?: string }>;
+    };
+    expect(rawCarrier.system[1]?.text).toBe("Today's date is 2026-07-01.");
+    expect(rawCarrier.messages[0]?.content).toBe("user marker: Today's date is 2026-07-02.");
+    expect(rawCarrier.tools[0]?.description).toBe("tool marker: Today's date is 2026-07-03.");
     expect(carrier.mutations?.body_shims_applied).toContain(
       "claude_code_date_fingerprint_normalized",
     );
 
     const payload = insertPayload.mock.calls[0]?.[0] as { requestJson: string };
-    expect(JSON.parse(payload.requestJson).system[1].text).toBe("Todayʹs date is 2026/07/01.");
+    const captured = JSON.parse(payload.requestJson) as {
+      system: Array<{ text?: string }>;
+      messages: Array<{ content?: string }>;
+      tools: Array<{ description?: string }>;
+    };
+    expect(captured.system[1]?.text).toBe("Todayʹs date is 2026/07/01.");
+    expect(captured.messages[0]?.content).toBe("user marker: Today's date is 2026/07/02.");
+    expect(captured.tools[0]?.description).toBe("tool marker: Todayʼs date is 2026/07/03.");
   });
 
   it("stamps native_request on a STREAMING request too (Phase 2 streaming passthrough)", async () => {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-01 · Claude Code 日期指纹扩展到全部 prompt 文本面（Anthropic protocol / anti-fingerprint，docs/05/07，原则 7/8）
+
+- **背景（Lukin）**：阅读 X 复盘后确认风险不应只按 `system` 推断；Claude Code 当前实现虽把 `currentDate` 放入系统上下文，但从防检测角度，任意会被发往 Anthropic 的 prompt 文本块只要出现同一句隐写模板，都应还原为普通字符串。
+- **修复决策**：`normalizeClaudeCodeDateFingerprintInAnthropicRequest()` 不再依赖 billing header，也不再按 message role 限制；所有 `messages[].content` 的 string / `type:"text"` block 都归一化，嵌套 `tool_result.content` 也处理。
+- **工具提示面**：`tools[].description` 也是会进入上游 prompt surface 的自然语言说明，同样归一化；但 `tool_use.input`、`input_schema`、`metadata` 等结构化/数据字段不递归改写，避免把用户数据或 schema 常量改坏。
+- **边界**：仍只匹配精确句式 `Today[',’,ʼ,ʹ]s date is YYYY[-/]MM[-/]DD.`，统一输出 `Today's date is YYYY-MM-DD.`；这覆盖 X 文强调的「普通第三方端点 + 中国时区」即普通 apostrophe + slash 日期。
+- **验证**：新增 core 测试覆盖 user/assistant/tool_result/tools description，gateway native carrier 测试覆盖 message + tools 字段；目标 Vitest 绿。
+
 ## 2026-07-01 · Claude Code 日期指纹入站归一化（Anthropic protocol / native passthrough，docs/05/07，原则 7/8）
 
 - **背景（Lukin）**：升级最新 `claude update` 后当前最新客户端为 `2.1.197`；二进制中确认仍存在 `ANTHROPIC_BASE_URL` + `Asia/Shanghai|Asia/Urumqi` 检测，以及把 `Today's date is YYYY-MM-DD.` 改成不同 apostrophe / slash 日期格式的逻辑。
@@ -24,19 +32,13 @@
 - **范围限制**：本次不改 admin 路由返回形状，也不引入物化日报表；先消除确认过的同步慢查询放大器。若未来 telemetry 增长到百万级以上，再考虑后台 rollup 表或异步 worker。
 - **验证**：新增 SQLite/PG 迁移回填测试、SQLite “篡改 decision_json 后 aggregate 仍读列化延迟”测试、跨适配器 aggregate 延迟契约；全量 `pnpm test` 4887/4887 绿，`pnpm typecheck`、`pnpm build` 绿。
 
-## 2026-06-30 · admin favicon cache policy（Admin UI 静态资源，docs/11，原则 7）
-
-- **背景（Lukin）**：`/admin/favicon.svg` 与 `/admin/favicon.png` 在浏览器网络面板里表现很慢，但文件本身很小（SVG 664B、PNG 约 19KB）。实测问题不是图片体积，而是 admin 静态资源缓存策略把它们当作 SPA shell 处理。
-- **根因**：`admin-static` 对除 `/_app/immutable/` 外的所有 `/admin` 静态资源统一设置 `Cache-Control: no-cache`。这对 `index.html` 是正确的（必须每次 revalidate 才能捡到新 hash chunk），但 favicon 不是 shell；再加上 `app.html` 同时声明 SVG 与 PNG，浏览器可发起重复图标请求。
-- **修复决策**：`/admin/favicon.{svg,png}` 单独设置 `Cache-Control: private, max-age=604800`，只允许浏览器私有缓存一周；`/admin/` 与 SPA deep-link fallback 仍保持 `no-cache`，避免部署后旧 shell 指向旧 chunk。
-- **前端决策**：admin shell 只声明 SVG favicon，保留 PNG 文件作为兼容/直接访问资产，但不主动让浏览器同时拉两张图。
-- **验证**：新增 gateway 静态资源缓存回归测试与 admin shell favicon 数量测试；运行时检查确认 favicons 返回私有 7 天缓存，`/admin/` 仍返回 `no-cache`。
-
 ---
 
 ## 历史条目摘要（压缩归档）
 
 > 以下为更早条目的一行要点（新→旧）。完整原文见 git history（本文件在 2026-06-05 压缩前的版本）。
+
+- **2026-06-30 · admin favicon cache policy（Admin UI 静态资源，docs/11，原则 7）**：favicon 慢不是体积问题，而是 `/admin` 静态资源 no-cache 策略；`/admin/favicon.{svg,png}` 改私有缓存 7 天，SPA shell/deep-link fallback 仍 no-cache，admin shell 只声明 SVG 避免双拉；补 gateway/admin 回归测试。
 
 - **2026-06-30 · per-model reasoning effort policy（执行 fallback / 协议转换，docs/04/05，原则 2/5/8）**：新增 catalog `reasoningEffort` policy，按模型/协议 wire 字段映射或删除 unsupported effort；Haiku 4.5 保留 manual `thinking` 但删除 `output_config.effort`，Sonnet `xhigh -> max`，translated/native passthrough 回归覆盖。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.34",
+  "version": "0.22.35",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/protocol/anthropic/date-fingerprint.test.ts
+++ b/packages/core/src/protocol/anthropic/date-fingerprint.test.ts
@@ -26,7 +26,7 @@ describe("normalizeClaudeCodeDateFingerprintInAnthropicRequest", () => {
     });
   });
 
-  it("normalizes system and developer message text without touching ordinary user text", () => {
+  it("normalizes fingerprint markers in every message text surface", () => {
     const input = {
       model: "claude-3-5-sonnet",
       messages: [
@@ -36,6 +36,20 @@ describe("normalizeClaudeCodeDateFingerprintInAnthropicRequest", () => {
           content: [{ type: "text", text: "Todayʼs date is 2026/07/02." }],
         },
         { role: "user", content: "quote: Todayʼs date is 2026/07/03." },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "assistant saw Today’s date is 2026/07/04." }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool_1",
+              content: [{ type: "text", text: "tool says Today's date is 2026/07/05." }],
+            },
+          ],
+        },
       ],
     };
 
@@ -50,7 +64,65 @@ describe("normalizeClaudeCodeDateFingerprintInAnthropicRequest", () => {
           role: "developer",
           content: [{ type: "text", text: "Today's date is 2026-07-02." }],
         },
-        { role: "user", content: "quote: Todayʼs date is 2026/07/03." },
+        { role: "user", content: "quote: Today's date is 2026-07-03." },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "assistant saw Today's date is 2026-07-04." }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool_1",
+              content: [{ type: "text", text: "tool says Today's date is 2026-07-05." }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("normalizes tool descriptions without touching non-prompt tool input data", () => {
+    const input = {
+      model: "claude-3-5-sonnet",
+      tools: [
+        {
+          name: "date_check",
+          description: "Tool instructions. Todayʹs date is 2026/07/06.",
+          input_schema: {
+            type: "object",
+            properties: {
+              literal: { const: "Todayʹs date is 2026/07/06." },
+            },
+          },
+        },
+      ],
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tool_1",
+              name: "date_check",
+              input: { literal: "Todayʹs date is 2026/07/06." },
+            },
+          ],
+        },
+      ],
+    };
+
+    const out = normalizeClaudeCodeDateFingerprintInAnthropicRequest(input);
+
+    expect(out.normalized).toBe(true);
+    expect(out.body).toEqual({
+      ...input,
+      tools: [
+        {
+          ...input.tools[0],
+          description: "Tool instructions. Today's date is 2026-07-06.",
+        },
       ],
     });
   });

--- a/packages/core/src/protocol/anthropic/request.ts
+++ b/packages/core/src/protocol/anthropic/request.ts
@@ -266,11 +266,19 @@ function normalizeTextBlockArray(value: Array<unknown>): {
   const next = value.map((block) => {
     if (block === null || typeof block !== "object" || Array.isArray(block)) return block;
     const record = block as Record<string, unknown>;
-    if (record.type !== "text" || typeof record.text !== "string") return block;
-    const text = normalizeClaudeCodeDateText(record.text);
-    if (!text.normalized) return block;
-    normalized = true;
-    return { ...record, text: text.text };
+    if (record.type === "text" && typeof record.text === "string") {
+      const text = normalizeClaudeCodeDateText(record.text);
+      if (!text.normalized) return block;
+      normalized = true;
+      return { ...record, text: text.text };
+    }
+    if (record.type === "tool_result" && "content" in record) {
+      const content = normalizeMessageContentFingerprint(record.content);
+      if (!content.normalized) return block;
+      normalized = true;
+      return { ...record, content: content.value };
+    }
+    return block;
   });
   return normalized ? { value: next, normalized } : { value, normalized: false };
 }
@@ -300,25 +308,33 @@ function normalizeMessageContentFingerprint(content: unknown): {
   return normalizeTextBlockArray(content);
 }
 
-function normalizeMessagesFingerprint(
-  messages: unknown,
-  opts: { normalizeAllTextMessages: boolean },
-): { value: unknown; normalized: boolean } {
+function normalizeMessagesFingerprint(messages: unknown): { value: unknown; normalized: boolean } {
   if (!Array.isArray(messages)) return { value: messages, normalized: false };
   let normalized = false;
   const next = messages.map((message) => {
     if (message === null || typeof message !== "object" || Array.isArray(message)) return message;
     const record = message as Record<string, unknown>;
-    const role = record.role;
-    if (role !== "system" && role !== "developer" && !opts.normalizeAllTextMessages) {
-      return message;
-    }
     const content = normalizeMessageContentFingerprint(record.content);
     if (!content.normalized) return message;
     normalized = true;
     return { ...record, content: content.value };
   });
   return normalized ? { value: next, normalized } : { value: messages, normalized: false };
+}
+
+function normalizeToolsFingerprint(tools: unknown): { value: unknown; normalized: boolean } {
+  if (!Array.isArray(tools)) return { value: tools, normalized: false };
+  let normalized = false;
+  const next = tools.map((tool) => {
+    if (tool === null || typeof tool !== "object" || Array.isArray(tool)) return tool;
+    const record = tool as Record<string, unknown>;
+    if (typeof record.description !== "string") return tool;
+    const description = normalizeClaudeCodeDateText(record.description);
+    if (!description.normalized) return tool;
+    normalized = true;
+    return { ...record, description: description.text };
+  });
+  return normalized ? { value: next, normalized } : { value: tools, normalized: false };
 }
 
 export function normalizeClaudeCodeDateFingerprintInAnthropicRequest(body: unknown): {
@@ -330,15 +346,17 @@ export function normalizeClaudeCodeDateFingerprintInAnthropicRequest(body: unkno
   }
   const record = body as Record<string, unknown>;
   const system = normalizeSystemFingerprint(record.system);
-  const messages = normalizeMessagesFingerprint(record.messages, {
-    normalizeAllTextMessages: billingHeaderText(record.system) !== null,
-  });
-  if (!system.normalized && !messages.normalized) return { body, normalized: false };
+  const messages = normalizeMessagesFingerprint(record.messages);
+  const tools = normalizeToolsFingerprint(record.tools);
+  if (!system.normalized && !messages.normalized && !tools.normalized) {
+    return { body, normalized: false };
+  }
   return {
     body: {
       ...record,
       ...(system.normalized ? { system: system.value } : {}),
       ...(messages.normalized ? { messages: messages.value } : {}),
+      ...(tools.normalized ? { tools: tools.value } : {}),
     },
     normalized: true,
   };


### PR DESCRIPTION
## Summary

- Extend Claude Code date fingerprint normalization across all Anthropic prompt text surfaces.
- Normalize `messages[].content` strings, text blocks, nested `tool_result.content`, and `tools[].description`.
- Keep structured data untouched (`tool_use.input`, `input_schema`, `metadata`) to avoid mutating user parameters or schemas.
- Bump root package version to `0.22.35` so the publish workflow cuts a release after merge.

## Verification

- `./node_modules/.bin/vitest run packages/core/src/protocol/anthropic/request.test.ts packages/core/src/protocol/anthropic/date-fingerprint.test.ts apps/gateway/src/routes/messages.test.ts`
- `CI=true pnpm typecheck`
- `./node_modules/.bin/biome check implementation-notes.md apps/gateway/src/routes/messages.test.ts packages/core/src/protocol/anthropic/request.ts packages/core/src/protocol/anthropic/date-fingerprint.test.ts`
- `git diff --check`
