### PR TITLE
fix: sync OAuth account availability after successful checks

### DIFF
--- a/apps/admin/src/lib/components/TestAccountDialog.svelte
+++ b/apps/admin/src/lib/components/TestAccountDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { untrack } from 'svelte';
+  import { invalidateAll } from '$app/navigation';
   import { streamAccountTest } from '$lib/api/oauth.js';
   import Modal from '$lib/components/Modal.svelte';
   import { t } from '$lib/i18n';
@@ -62,7 +63,10 @@
         } else if (ev.type === 'done') {
           durationMs = ev.durationMs ?? Math.round(performance.now() - startedAt);
           // A `done` that arrives after an `error` keeps the failed status.
-          if (status === 'running') status = 'success';
+          if (status === 'running') {
+            status = 'success';
+            void invalidateAll();
+          }
         }
       }
       // Stream ended without a terminal event (e.g. an abort) — settle to idle.

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -22,6 +22,8 @@ import type { ModelOption } from "../../oauth/effective-models.js";
 import type { PayloadCaptureDeps } from "../payload-capture.js";
 import type { OAuthTester } from "./oauth-test.js";
 
+export type UsageLimitWriteMode = "extend" | "replace";
+
 // Injected dependency contracts for the admin API. Per CLAUDE.md principle 1 the
 // route files are PURE HTTP glue — they own no business logic and never touch the
 // filesystem or DB directly. The two persistence targets are deliberately separate
@@ -346,8 +348,11 @@ export interface AdminApiDeps {
   // Per-account connectivity tester (Subscription Providers "Test" button). Streams
   // a single short completion through a FRESH, isolated per-account client — its own
   // token + proxy + executor type, and its OWN no-op breaker — so a test records NO
-  // telemetry / request_payloads and never perturbs the live routing pool. Optional:
-  // the /oauth/:provider/test route 503s when absent (present iff OAuth is wired).
+  // telemetry / request_payloads and never perturbs the live routing pool. A
+  // SUCCESSFUL test still records OAuth account usage and clears stale auto-park
+  // cooldowns because it consumes real upstream quota and proves the account is
+  // available. Optional: the /oauth/:provider/test route 503s when absent (present
+  // iff OAuth is wired).
   oauthTester?: OAuthTester;
   // The catalog of routable model options the Lanes admin UI offers as combobox
   // suggestions (so an operator picks a real alias instead of hand-typing one — a
@@ -390,7 +395,12 @@ export interface AdminApiDeps {
   // the /quota PULL passes a saturated window's reset. Touches ONLY the cooldown,
   // never `schedulable` (operator park stays independent). Optional — absent in unit
   // tests / when no OAuth pool is wired; the reset route 503s, the PULL park is skipped.
-  applyUsageLimit?: (providerId: string, account: string, untilMs: number | null) => Promise<void>;
+  applyUsageLimit?: (
+    providerId: string,
+    account: string,
+    untilMs: number | null,
+    mode?: UsageLimitWriteMode,
+  ) => Promise<void>;
 }
 
 // Re-exported for route signatures.

--- a/apps/gateway/src/routes/admin/oauth-test-route.test.ts
+++ b/apps/gateway/src/routes/admin/oauth-test-route.test.ts
@@ -94,6 +94,39 @@ describe("POST /admin/api/oauth/:provider/test", () => {
     );
   });
 
+  it("records successful test usage and clears any stale account cooldown", async () => {
+    const tester = testerOf([
+      { type: "content", text: "OK" },
+      { type: "usage", promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+      { type: "finish", reason: "stop" },
+    ]);
+    const oauthUsage = {
+      record: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthUsage"];
+    const applyUsageLimit = vi.fn(async () => {});
+
+    const res = await app({ oauthTester: tester, oauthUsage, applyUsageLimit }).request(
+      "/admin/api/oauth/anthropic/test",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ account: "default", model: "claude-x" }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(sseEvents(await res.text()).at(-1)).toMatchObject({ type: "done" });
+    expect(oauthUsage?.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "anthropic",
+        account: "default",
+        tokens: 12,
+        costUsd: null,
+      }),
+    );
+    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", null, "replace");
+  });
+
   it("emits an in-band error event (HTTP 200, not 5xx) when the tester throws mid-stream", async () => {
     const tester = testerOf(() =>
       (async function* () {

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -212,7 +212,7 @@ describe("admin OAuth routes — read endpoints", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", weeklyReset);
+    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", weeklyReset, "replace");
   });
 
   it("GET /oauth/quota extends an active cooldown to a near-full 5h recovery reset", async () => {
@@ -263,7 +263,92 @@ describe("admin OAuth routes — read endpoints", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", fiveHourReset);
+    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", fiveHourReset, "replace");
+  });
+
+  it("GET /oauth/quota clears an active cooldown when fresh windows show no active limit", async () => {
+    const now = Date.now();
+    const activeCooldown = now + 4 * 86_400_000;
+    const cleanWindows = [
+      { key: "5h", usedPercent: 0, resetsAtMs: null, windowMinutes: null },
+      { key: "7d", usedPercent: 0, resetsAtMs: null, windowMinutes: null },
+    ];
+    const applyUsageLimit = vi.fn(async () => {});
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "anthropic",
+        account: "default",
+        windows: [],
+        capturedAt: now,
+        source: "anthropic",
+        usageLimitedUntilMs: activeCooldown,
+      })),
+      getAll: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "default",
+          windows: cleanWindows,
+          capturedAt: now,
+          source: "anthropic",
+          usageLimitedUntilMs: activeCooldown,
+        },
+      ]),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      fetchAnthropicQuota: vi.fn(async () => cleanWindows) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
+      "/admin/api/oauth/quota",
+    );
+
+    expect(res.status).toBe(200);
+    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", null, "replace");
+  });
+
+  it("GET /oauth/quota replaces a stale long cooldown with the active shorter recovery window", async () => {
+    const now = Date.now();
+    const staleCooldown = now + 5 * 86_400_000;
+    const fiveHourReset = now + 2 * 60 * 60_000;
+    const windows = [
+      { key: "5h", usedPercent: 98, resetsAtMs: fiveHourReset, windowMinutes: null },
+      { key: "7d", usedPercent: 40, resetsAtMs: staleCooldown, windowMinutes: null },
+    ];
+    const applyUsageLimit = vi.fn(async () => {});
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "anthropic",
+        account: "default",
+        windows: [],
+        capturedAt: now,
+        source: "anthropic",
+        usageLimitedUntilMs: staleCooldown,
+      })),
+      getAll: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "default",
+          windows,
+          capturedAt: now,
+          source: "anthropic",
+          usageLimitedUntilMs: staleCooldown,
+        },
+      ]),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      fetchAnthropicQuota: vi.fn(async () => windows) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
+      "/admin/api/oauth/quota",
+    );
+
+    expect(res.status).toBe(200);
+    expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", fiveHourReset, "replace");
   });
 
   it("GET /oauth/quota does not newly park an unparked account from a PULL snapshot", async () => {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -31,6 +31,25 @@ function isAbort(e: unknown, signal: AbortSignal): boolean {
   return e instanceof Error && (e.name === "AbortError" || /abort/i.test(e.message));
 }
 
+function testUsageTokens(ev: {
+  type: string;
+  promptTokens?: unknown;
+  completionTokens?: unknown;
+  totalTokens?: unknown;
+}): number | null {
+  if (ev.type !== "usage") return null;
+  if (typeof ev.totalTokens === "number" && Number.isFinite(ev.totalTokens)) {
+    return Math.max(0, Math.trunc(ev.totalTokens));
+  }
+  const prompt =
+    typeof ev.promptTokens === "number" && Number.isFinite(ev.promptTokens) ? ev.promptTokens : 0;
+  const completion =
+    typeof ev.completionTokens === "number" && Number.isFinite(ev.completionTokens)
+      ? ev.completionTokens
+      : 0;
+  return Math.max(0, Math.trunc(prompt + completion));
+}
+
 // A malformed proxy body — thrown by parseProxyInput, caught at the route to map to
 // a 400. Distinct type so a genuine seam error isn't masked as a parse error.
 class ProxyParseError extends Error {}
@@ -168,19 +187,23 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     // instant a credit is consumed, so a stored snapshot would lie). Keyed by acctKey;
     // attached onto the matching codex snapshot in the response below.
     const resetCredits = new Map<string, number | null>();
-    const extendActiveCooldownFromWindows = async (
+    const syncActiveCooldownFromWindows = async (
       providerId: string,
       account: string,
       windows: Parameters<typeof windowsToActiveUsageRecovery>[0],
     ): Promise<void> => {
       if (!deps.applyUsageLimit) return;
       const nowMs = Date.now();
-      const quotaUntil = windowsToActiveUsageRecovery(windows, nowMs);
-      if (quotaUntil === null) return;
       const current = await store.get(providerId, account).catch(() => null);
       const currentUntil = current?.usageLimitedUntilMs ?? null;
-      if (currentUntil === null || currentUntil <= nowMs || currentUntil >= quotaUntil) return;
-      await deps.applyUsageLimit(providerId, account, quotaUntil).catch(() => {});
+      if (currentUntil === null || currentUntil <= nowMs) return;
+      const quotaUntil = windowsToActiveUsageRecovery(windows, nowMs);
+      if (quotaUntil === null) {
+        await deps.applyUsageLimit(providerId, account, null, "replace").catch(() => {});
+        return;
+      }
+      if (currentUntil === quotaUntil) return;
+      await deps.applyUsageLimit(providerId, account, quotaUntil, "replace").catch(() => {});
     };
     if (s) {
       try {
@@ -196,7 +219,9 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         // (generic 429 fallback), a near-full quota window may EXTEND that cooldown to
         // the likely reset time. That keeps "Reset usage" effective: clearing the
         // cooldown then reloading this page does not immediately re-park the account
-        // before it can serve a single request.
+        // before it can serve a single request. For an ALREADY parked account, a
+        // successful PULL is also trusted to clear or shorten stale cooldowns: clean
+        // windows mean the account is available again.
         const acctsOf = (id: string) => status.find((x) => x.id === id)?.accounts ?? [];
         const tasks: Array<Promise<void>> = [];
         // Anthropic: windows only.
@@ -216,7 +241,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                       source: "anthropic",
                     })
                     .catch(() => {});
-                  await extendActiveCooldownFromWindows("anthropic", a.account, windows);
+                  await syncActiveCooldownFromWindows("anthropic", a.account, windows);
                 }
               })(),
             );
@@ -241,7 +266,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                       source: "codex",
                     })
                     .catch(() => {});
-                  await extendActiveCooldownFromWindows("openai-codex", a.account, result.windows);
+                  await syncActiveCooldownFromWindows("openai-codex", a.account, result.windows);
                 }
               })(),
             );
@@ -574,8 +599,10 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   // bare "ok". Fail-open (Principle 3): a missing tester 503s before streaming;
   // missing account/model 400s; any upstream failure is surfaced as an in-band
   // `error` event (HTTP 200, never a 5xx) so the dialog can show what went wrong. A
-  // client/modal abort is silent (not a provider fault). No telemetry is recorded —
-  // the fresh client carries its own no-op breaker (see oauth-test.ts).
+  // client/modal abort is silent (not a provider fault). No request telemetry is
+  // recorded — the fresh client carries its own no-op breaker (see oauth-test.ts).
+  // A SUCCESSFUL test still consumes real upstream quota, so record OAuth account
+  // usage and clear any stale auto-park cooldown.
   app.post("/admin/api/oauth/:provider/test", async (c) => {
     const tester = deps.oauthTester;
     if (!tester) return c.json({ error: "oauth login not configured" }, 503);
@@ -589,11 +616,26 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     const signal = c.req.raw.signal;
     return streamSSE(c, async (sse) => {
       const startedAt = Date.now();
+      let tokens = 0;
       await sse.writeSSE({ data: JSON.stringify({ type: "start", model }) });
       try {
         for await (const ev of tester.test({ providerId, account, model, prompt, signal })) {
+          const usageTokens = testUsageTokens(ev);
+          if (usageTokens !== null) tokens = usageTokens;
           await sse.writeSSE({ data: JSON.stringify(ev) });
         }
+        const nowMs = Date.now();
+        await deps.oauthUsage
+          ?.record({
+            providerId,
+            account,
+            bucketMs: nowMs - (nowMs % 3_600_000),
+            tokens,
+            costUsd: null,
+            nowMs,
+          })
+          .catch(() => {});
+        await deps.applyUsageLimit?.(providerId, account, null, "replace").catch(() => {});
         await sse.writeSSE({
           data: JSON.stringify({ type: "done", durationMs: Date.now() - startedAt }),
         });

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1279,6 +1279,7 @@ export async function buildServer(
     providerId: string,
     account: string,
     untilMs: number | null,
+    mode: "extend" | "replace" = "extend",
   ): Promise<void> => {
     const pool = oauthPoolClients.get(providerId);
     // A park (non-null) is EXTEND-ONLY: a precise quota reset (e.g. a Codex weekly limit,
@@ -1286,7 +1287,7 @@ export async function buildServer(
     // 429 fallback, whichever park fires last. null = clear (admin "Reset usage" / weekly
     // auto-reset) always wins. The live member holds the authoritative cooldown — max it.
     let effective = untilMs;
-    if (untilMs !== null) {
+    if (untilMs !== null && mode === "extend") {
       const current = pool?.getUsageLimit(account) ?? null;
       if (current !== null && current > untilMs) effective = current;
     }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-02 · OAuth 测试成功与 quota PULL 同步账号可用状态（Admin providers / OAuth cooldown，docs/04/11，原则 3/5/7）
+
+- **背景（Lukin）**：生产中 `riverathomas6094@outlook.com` 已能通过单账号 Test 成功返回，但 providers 页仍因旧 `usage_limited_until_ms` 显示“已限流 / 3 天后恢复”，正常路由池也继续跳过该账号。
+- **修复决策**：`GET /admin/api/oauth/quota` 对“已 park 账号”把成功 quota PULL 视作可信状态同步：窗口 near-full 时用真实恢复窗口 `replace` 旧 cooldown；窗口干净时清空 cooldown；未 park 账号仍不会因 PULL 预先 park。
+- **测试路径决策**：Providers 页 Test 仍使用独立 per-account client，不写 request telemetry / payload，也不扰动主路由 breaker；但测试成功会写入 `oauth_usage` 并清空旧 auto-park cooldown，因为它消耗真实上游额度且证明账号当前可用。
+- **UI 决策**：Test 成功后自动 `invalidateAll()`，让状态 pill、Today 用量和 quota/cooldown 立即重新读取，而不是要求操作员手动刷新。
+- **验证**：新增 admin OAuth route 回归覆盖干净窗口清 cooldown、旧 7d cooldown 替换为 active 5h、Test 成功记录用量并清 cooldown；目标 Vitest 53/53 绿，typecheck / build 绿。本机全量 SQLite 测试受 `better-sqlite3` Node ABI 不匹配阻塞，非业务断言失败。
+
 ## 2026-07-01 · Claude Code 日期指纹扩展到全部 prompt 文本面（Anthropic protocol / anti-fingerprint，docs/05/07，原则 7/8）
 
 - **背景（Lukin）**：阅读 X 复盘后确认风险不应只按 `system` 推断；Claude Code 当前实现虽把 `currentDate` 放入系统上下文，但从防检测角度，任意会被发往 Anthropic 的 prompt 文本块只要出现同一句隐写模板，都应还原为普通字符串。
@@ -42,7 +50,6 @@
 - **2026-06-30 · Fast mode 账号强制覆盖 + API key 透传限制（OAuth subscription provider / key governance，docs/04/11，原则 2/5）**：账号级 `fastMode` 统一映射到 Codex `service_tier:"priority"` 与 Anthropic `speed:"fast"` + beta header，并强制覆盖 provider wire request；per-key `allow_fast_mode` 只治理客户端透传，不阻止账号级强制启用；UI 仅对支持 provider 展示。
 - **2026-06-30 · OAuth 5h 限额恢复时间不再落回 60s（admin/gateway，docs/04，原则 5）**：已 park 账号的 generic 60s 429 fallback 改用 near-full (`>=95%`) 窗口推断真实恢复时间，避免 Anthropic 5h 98–99% 限额显示 `0m`；健康账号仍不因 98% 预先 park。验证 core/gateway/admin 相关测试、全量 test/typecheck/svelte-check/biome/build 绿，发 v0.22.27。
 - **2026-06-29 · OAuth 配额冷却 extend-only + refresh-429 归账号级（Codex review 跟进；provider 执行/池）**：修复 Codex quota 精确长 reset 被 generic 60s 429 覆盖的问题（park/applyUsageLimit 改 extend-only，清除仍直通）；同时把 `TokenRefreshError(429)` 纳入 pool 与 executor 的账号级 rate-limit 分类，避免 refresh 限流污染 alias breaker。验证 pool/executor 矩阵、typecheck、biome、build 绿，发 v0.22.24。
-- **2026-06-29 · OAuth 单账号故障不再污染 alias 级熔断（provider 执行；docs/04，原则 5）**：OAuth pool 内部拦截账号级 `TokenRefreshError(400/401/403)`、上游 `401/403` 与 `429`，按账号 park/冷却并请求内 sibling 重试；executor 只对账号级故障跳过 alias breaker，整池 5xx/transport 故障仍记 breaker。验证 pool/executor/server OAuth 回归绿。
 
 ## 更早历史总览
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.35",
+  "version": "0.22.36",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Sync parked OAuth account cooldowns from successful quota PULL snapshots, clearing stale cooldowns when official quota windows are clean.
- Record successful single-account Test usage and clear stale auto-park cooldowns because the test consumes real upstream quota.
- Refresh the admin providers page after a successful Test so status and Today usage update immediately.
- Bump package version to 0.22.36 for release.

## Verification
- pnpm exec vitest run apps/gateway/src/routes/admin/oauth.test.ts apps/gateway/src/routes/admin/oauth-test-route.test.ts
- pnpm typecheck
- pnpm build
- pnpm exec biome check apps/gateway/src/routes/admin/deps.ts apps/gateway/src/routes/admin/oauth-test-route.test.ts apps/gateway/src/routes/admin/oauth.test.ts apps/gateway/src/routes/admin/oauth.ts apps/gateway/src/server.ts
- pnpm --filter @helm/admin exec prettier --check src/lib/components/TestAccountDialog.svelte --plugin prettier-plugin-svelte
- git diff --check