### PR TITLE
Handle Claude Fable usage limits and pricing

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -141,6 +141,18 @@
     return $t('in {m}m', { m: p.m });
   }
 
+  function titleFromSlug(slug: string): string {
+    return slug
+      .split('-')
+      .filter(Boolean)
+      .map((part) =>
+        part.length <= 3
+          ? part.toUpperCase()
+          : `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`,
+      )
+      .join(' ');
+  }
+
   // Friendly window labels (provider-specific keys → display).
   function windowLabel(key: string): string {
     const map: Record<string, string> = {
@@ -148,12 +160,15 @@
       '7d': '7d',
       '7d-opus': '7d · Opus',
       '7d-sonnet': '7d · Sonnet',
+      '7d-fable': '7d · Fable',
       // Codex windows: `primary` is the 5-hour rolling window (windowMinutes 300),
       // `secondary` is the weekly limit (windowMinutes 10080) — matching the Codex UI.
       primary: '5h',
       secondary: $t('Weekly'),
     };
-    return map[key] ?? key;
+    if (map[key]) return map[key];
+    if (key.startsWith('7d-')) return `7d · ${titleFromSlug(key.slice(3))}`;
+    return key;
   }
 
   // Color ramp mirrors claude-relay: calm under 75%, warning to 90%, danger beyond.

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -129,6 +129,39 @@ describe('providers page', () => {
     expect(within(row).getByText('claude-haiku-4-5')).toBeInTheDocument();
   });
 
+  it('labels the current Claude scoped weekly Fable quota window', () => {
+    renderPage({
+      quota: [
+        {
+          providerId: 'anthropic',
+          account: 'acct-claude',
+          windows: [
+            { key: '5h', usedPercent: 11, resetsAtMs: Date.now() + 3_600_000, windowMinutes: null },
+            {
+              key: '7d',
+              usedPercent: 7,
+              resetsAtMs: Date.now() + 86_400_000,
+              windowMinutes: null,
+            },
+            {
+              key: '7d-fable',
+              usedPercent: 5,
+              resetsAtMs: Date.now() + 86_400_000,
+              windowMinutes: null,
+            },
+          ],
+          capturedAt: Date.now(),
+          source: 'anthropic',
+          usageLimitedUntilMs: null,
+        },
+      ],
+    });
+
+    const row = screen.getByTestId('provider-account-row');
+    expect(within(row).getByText('7d · Fable')).toBeInTheDocument();
+    expect(within(row).getByText('5%')).toBeInTheDocument();
+  });
+
   it('uses the saturated quota window as the rate-limit recovery source', () => {
     const now = Date.now();
     renderPage({

--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -993,16 +993,35 @@ describe("createOAuthAdmin > fetchAnthropicQuota", () => {
       json({
         five_hour: { utilization: 3, resets_at: "2026-06-04T12:00:00.000Z" },
         seven_day: { utilization: 17, resets_at: "2026-06-08T12:00:00.000Z" },
-        seven_day_sonnet: { utilization: 0, resets_at: "2026-06-08T12:00:00.000Z" },
+        seven_day_sonnet: null,
+        limits: [
+          {
+            kind: "session",
+            group: "session",
+            percent: 3,
+            resets_at: "2026-06-04T12:00:00.000Z",
+            scope: null,
+          },
+          {
+            kind: "weekly_all",
+            group: "weekly",
+            percent: 17,
+            resets_at: "2026-06-08T12:00:00.000Z",
+            scope: null,
+          },
+          {
+            kind: "weekly_scoped",
+            group: "weekly",
+            percent: 5,
+            resets_at: "2026-06-08T12:00:00.000Z",
+            scope: { model: { id: null, display_name: "Fable" }, surface: null },
+          },
+        ],
       }),
     );
     const first = await fetchQuota({ account: "default" });
     const second = await fetchQuota({ account: "default" });
-    expect(first?.map((w) => `${w.key}:${w.usedPercent}`)).toEqual([
-      "5h:3",
-      "7d:17",
-      "7d-sonnet:0",
-    ]);
+    expect(first?.map((w) => `${w.key}:${w.usedPercent}`)).toEqual(["5h:3", "7d:17", "7d-fable:5"]);
     expect(second).toEqual(first); // served from the warm cache
     expect(usageHits()).toBe(1);
   });

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -104,8 +104,10 @@ zenmux-anthropic/claude-haiku-4.5:
 # selection) so subscription traffic shows real $ in the dashboard instead of "—".
 # Generated catalog has no entry for these models (only old claude-3-5-*), so per the
 # "API price first, else official" rule these use OFFICIAL Anthropic list prices.
-# cache_read = 0.1x input, cache_write (5-min) = 1.25x input — load-bearing: Claude
-# Code caches heavily, and without these computeCostUsd bills cached tokens at full
+# cache_read = 0.1x input, cache_write (5-min) = 1.25x input — verified against the
+# official Anthropic pricing page on 2026-07-02 (Fable 5: $10/M input, $50/M
+# output, $1/M cache hit, $12.50/M 5-min cache write). Load-bearing: Claude Code
+# caches heavily, and without these computeCostUsd bills cached tokens at full
 # input rate (large over-estimate). MUST stay in sync with the capabilities.yaml caps.
 anthropic/claude-opus-4-8:
   inputPerMTokUsd: 5.0

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-02 · Claude Fable 周限额改读 `limits[]`（Admin providers / OAuth quota，docs/11，原则 3/7）
+
+- **背景（Lukin）**：Claude Code 的 Plan usage limits 已把 scoped weekly model 用量显示为 `Fable`，不再是旧的 Sonnet 专项行；本机真实 `GET https://api.anthropic.com/api/oauth/usage` 返回中，`seven_day_sonnet` 为 `null`，而 `limits[]` 包含 `kind:"weekly_scoped"` + `scope.model.display_name:"Fable"`。
+- **修复决策**：Anthropic quota parser 优先读取新的 `limits[]`：`session -> 5h`、`weekly_all -> 7d`、`weekly_scoped -> 7d-{model-slug}`，例如 Fable 变成 `7d-fable`；旧 top-level `five_hour/seven_day/seven_day_opus/seven_day_sonnet` 只作为 fallback，保证老 payload 继续可读。
+- **UI 决策**：providers 页 quota label 增加 `7d · Fable`，并为未来 `7d-*` scoped key 提供通用标题化 fallback；避免下一次 Claude 增加 scoped model 时页面又退回原始 key 或显示旧 Sonnet。
+- **价格决策**：`anthropic/claude-fable-5` 已按官方 Anthropic 价格配置为 input `$10/M`、output `$50/M`、cache hit `$1/M`、5-minute cache write `$12.50/M`；官方还有 1-hour cache write `$20/M`，但当前 Helm pricing schema 只有一个 `cacheWritePerMTokUsd`，所以仍记录 5-minute rate，避免在本次小修里扩大 telemetry schema。
+- **验证**：真实上游 usage payload 与 `/v1/models` 已本机核验；新增 parser、gateway quota pull、providers 页面回归测试。目标 parser/admin 页面测试与 typecheck 绿；gateway SQLite 相关测试仍被本机 `better-sqlite3` Node ABI 不匹配阻塞。
+
 ## 2026-07-02 · OAuth 测试成功与 quota PULL 同步账号可用状态（Admin providers / OAuth cooldown，docs/04/11，原则 3/5/7）
 
 - **背景（Lukin）**：生产中 `riverathomas6094@outlook.com` 已能通过单账号 Test 成功返回，但 providers 页仍因旧 `usage_limited_until_ms` 显示“已限流 / 3 天后恢复”，正常路由池也继续跳过该账号。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.36",
+  "version": "0.22.37",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/catalog/load.test.ts
+++ b/packages/core/src/catalog/load.test.ts
@@ -95,6 +95,21 @@ describe("loadRuntimeCatalog", () => {
     expect(gpt4o?.capabilities.supportsVision).toBe(true);
   });
 
+  it("loads the native Claude Fable pricing and capabilities from real config", () => {
+    const catalog = loadRuntimeCatalog({ configDir: "config" });
+    const fable = catalog.get("anthropic/claude-fable-5");
+
+    expect(fable?.source).toBe("override");
+    expect(fable?.pricing).toMatchObject({
+      inputPerMTokUsd: 10,
+      outputPerMTokUsd: 50,
+      cacheReadPerMTokUsd: 1,
+      cacheWritePerMTokUsd: 12.5,
+    });
+    expect(fable?.capabilities.maxContextTokens).toBe(1_000_000);
+    expect(fable?.capabilities.supportsStreaming).toBe(true);
+  });
+
   it("fails closed on an invalid override yaml (principle 2)", () => {
     expect(() =>
       loadRuntimeCatalog({

--- a/packages/core/src/provider/oauth/anthropic-quota.test.ts
+++ b/packages/core/src/provider/oauth/anthropic-quota.test.ts
@@ -6,6 +6,73 @@ const RESET = "2026-06-03T12:00:00.000Z";
 const RESET_MS = Date.parse(RESET);
 
 describe("parseAnthropicUsageBody", () => {
+  it("uses the current limits[] shape so scoped Fable usage is not dropped", () => {
+    const out = parseAnthropicUsageBody(
+      {
+        five_hour: { utilization: 11, resets_at: RESET },
+        seven_day: { utilization: 7, resets_at: RESET },
+        seven_day_opus: null,
+        seven_day_sonnet: null,
+        limits: [
+          {
+            kind: "session",
+            group: "session",
+            percent: 11,
+            resets_at: RESET,
+            scope: null,
+            is_active: true,
+          },
+          {
+            kind: "weekly_all",
+            group: "weekly",
+            percent: 7,
+            resets_at: RESET,
+            scope: null,
+            is_active: false,
+          },
+          {
+            kind: "weekly_scoped",
+            group: "weekly",
+            percent: 5,
+            resets_at: RESET,
+            scope: { model: { id: null, display_name: "Fable" }, surface: null },
+            is_active: false,
+          },
+        ],
+      },
+      NOW,
+    );
+    expect(out).toEqual([
+      { key: "5h", usedPercent: 11, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d", usedPercent: 7, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d-fable", usedPercent: 5, resetsAtMs: RESET_MS, windowMinutes: null },
+    ]);
+  });
+
+  it("fills missing session/all windows from legacy fields when limits[] is partial", () => {
+    const out = parseAnthropicUsageBody(
+      {
+        five_hour: { utilization: 11, resets_at: RESET },
+        seven_day: { utilization: 7, resets_at: RESET },
+        limits: [
+          {
+            kind: "weekly_scoped",
+            group: "weekly",
+            percent: 5,
+            resets_at: RESET,
+            scope: { model: { id: null, display_name: "Fable" }, surface: null },
+          },
+        ],
+      },
+      NOW,
+    );
+    expect(out).toEqual([
+      { key: "7d-fable", usedPercent: 5, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "5h", usedPercent: 11, resetsAtMs: RESET_MS, windowMinutes: null },
+      { key: "7d", usedPercent: 7, resetsAtMs: RESET_MS, windowMinutes: null },
+    ]);
+  });
+
   it("maps the four windows to 5h / 7d / 7d-opus / 7d-sonnet (utilization is 0–100 percent)", () => {
     const out = parseAnthropicUsageBody(
       {

--- a/packages/core/src/provider/oauth/anthropic-quota.ts
+++ b/packages/core/src/provider/oauth/anthropic-quota.ts
@@ -5,35 +5,93 @@ import {
 } from "@helm/shared";
 
 // Map Anthropic's OAuth usage-endpoint payload (GET /api/oauth/usage) to the
-// providers-page quota windows (Tier 3). Anthropic reports `utilization` as a
-// 0–100 PERCENT (e.g. 33.0), NOT a 0–1 fraction — surfaced as-is (clamped), never
-// re-scaled. Each window maps 1:1 to our keys: five_hour → 5h, seven_day → 7d,
-// seven_day_opus → 7d-opus, seven_day_sonnet → 7d-sonnet (matching the official
-// Claude /usage display). PURE + FAIL-OPEN: an absent window or unparseable reset
-// timestamp is skipped/nulled, never thrown.
-const WINDOWS = [
+// providers-page quota windows (Tier 3). Anthropic reports percentages as 0-100
+// (e.g. 33.0), NOT 0-1 fractions — surfaced as-is (clamped), never re-scaled.
+// Prefer the current generic `limits[]` shape because scoped model caps now appear
+// there (Fable) while old fixed fields may be null. Fall back to legacy top-level
+// windows for older payloads. PURE + FAIL-OPEN: an absent window or unparseable
+// reset timestamp is skipped/nulled, never thrown.
+const LEGACY_WINDOWS = [
   { src: "five_hour", key: "5h" },
   { src: "seven_day", key: "7d" },
   { src: "seven_day_opus", key: "7d-opus" },
   { src: "seven_day_sonnet", key: "7d-sonnet" },
 ] as const;
 
+type AnthropicLimit = NonNullable<AnthropicOAuthUsage["limits"]>[number];
+
+function parseResetMs(raw: unknown): number | null {
+  const resetMs = typeof raw === "string" ? Date.parse(raw) : Number.NaN;
+  return Number.isFinite(resetMs) ? resetMs : null;
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+function modelSlug(limit: AnthropicLimit): string {
+  const displayName = limit.scope?.model?.display_name;
+  const raw = typeof displayName === "string" && displayName.trim() !== "" ? displayName : "scoped";
+  const slug = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "scoped";
+}
+
+function windowFromLimit(limit: AnthropicLimit): OAuthQuotaWindow | null {
+  if (typeof limit.percent !== "number" || !Number.isFinite(limit.percent)) return null;
+
+  let key: string | null = null;
+  if (limit.kind === "session" || limit.group === "session") {
+    key = "5h";
+  } else if (limit.kind === "weekly_all") {
+    key = "7d";
+  } else if (limit.kind === "weekly_scoped") {
+    key = `7d-${modelSlug(limit)}`;
+  }
+  if (key === null) return null;
+
+  return {
+    key,
+    usedPercent: clampPercent(limit.percent),
+    resetsAtMs: parseResetMs(limit.resets_at),
+    windowMinutes: null,
+  };
+}
+
+function windowsFromLimits(usage: AnthropicOAuthUsage): OAuthQuotaWindow[] {
+  const windows = usage.limits?.map(windowFromLimit).filter((w) => w !== null) ?? [];
+  const seen = new Set<string>();
+  return windows.filter((w) => {
+    if (seen.has(w.key)) return false;
+    seen.add(w.key);
+    return true;
+  });
+}
+
 export function anthropicUsageToWindows(
   usage: AnthropicOAuthUsage,
   _nowMs: number,
 ): OAuthQuotaWindow[] {
   const out: OAuthQuotaWindow[] = [];
-  for (const w of WINDOWS) {
+  const seen = new Set<string>();
+  for (const w of windowsFromLimits(usage)) {
+    out.push(w);
+    seen.add(w.key);
+  }
+
+  for (const w of LEGACY_WINDOWS) {
+    if (seen.has(w.key)) continue;
     const win = (usage as Record<string, { utilization?: number; resets_at?: string } | undefined>)[
       w.src
     ];
     if (!win || typeof win.utilization !== "number" || !Number.isFinite(win.utilization)) continue;
-    // resets_at is ISO-8601; Date.parse → NaN on garbage → null (no countdown).
-    const resetMs = typeof win.resets_at === "string" ? Date.parse(win.resets_at) : Number.NaN;
     out.push({
       key: w.key,
-      usedPercent: Math.min(100, Math.max(0, win.utilization)),
-      resetsAtMs: Number.isFinite(resetMs) ? resetMs : null,
+      usedPercent: clampPercent(win.utilization),
+      resetsAtMs: parseResetMs(win.resets_at),
       windowMinutes: null, // Anthropic does not report a window length
     });
   }

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -33,9 +33,10 @@ export type OAuthUsageRow = z.infer<typeof OAuthUsageRowSchema>;
 // ── Quota (Tier 3): latest rate-limit window snapshot per (provider, account) ─
 
 // One rate-limit window. `key` names the window (Claude: 5h / 7d / 7d-opus /
-// 7d-sonnet; Codex: primary / secondary). `usedPercent` is 0–100. `resetsAtMs` is the epoch
-// ms the window resets (null when unknown). `windowMinutes` is the window length
-// when the provider reports it (Codex), else null.
+// 7d-sonnet / 7d-fable; Codex: primary / secondary). `usedPercent` is 0–100.
+// `resetsAtMs` is the epoch ms the window resets (null when unknown).
+// `windowMinutes` is the window length when the provider reports it (Codex), else
+// null.
 export const OAuthQuotaWindowSchema = z
   .object({
     key: z.string(),
@@ -76,17 +77,46 @@ export type OAuthQuotaSnapshot = z.infer<typeof OAuthQuotaSnapshotSchema>;
 // `"seven_day_opus": null` on plans without a separate Opus weekly cap), so each
 // field is `.nullish()` — a strict `.optional()` would REJECT the null and fail the
 // whole parse, leaving the page blank. The SAME applies to the INNER fields: a
-// PRESENT window can still carry `"resets_at": null` (e.g. a weekly Sonnet cap not
+// PRESENT window can still carry `"resets_at": null` (e.g. a weekly scoped cap not
 // yet touched, so no countdown), so both inner fields are `.nullish()` too — an
 // inner `.optional()` would reject that null and drop EVERY window, freezing the
-// providers page on a stale snapshot. `utilization` is already a 0–100 PERCENT
-// (e.g. 33.0), NOT a 0–1 fraction — do not re-scale on ingest. `resets_at` is an
-// ISO-8601 timestamp. Windows: five_hour / seven_day / seven_day_opus /
-// seven_day_sonnet (mirrors the official Claude /usage display).
+// providers page on a stale snapshot. Older payloads expose fixed top-level
+// windows: five_hour / seven_day / seven_day_opus / seven_day_sonnet.
 const AnthropicWindowSchema = z
   .object({
     utilization: z.number().nullish(),
     resets_at: z.string().nullish(),
+  })
+  .loose();
+
+// Current Claude usage payloads also carry a generic `limits[]` list. That list is
+// now the authoritative source for scoped model limits (for example Fable) because
+// old fixed fields such as `seven_day_sonnet` may be null even when a scoped weekly
+// row exists. `percent` is already a 0-100 percentage.
+const AnthropicLimitScopeSchema = z
+  .object({
+    model: z
+      .object({
+        id: z.string().nullable().optional(),
+        display_name: z.string().nullable().optional(),
+      })
+      .loose()
+      .nullable()
+      .optional(),
+    surface: z.unknown().nullable().optional(),
+  })
+  .loose()
+  .nullable()
+  .optional();
+
+const AnthropicLimitSchema = z
+  .object({
+    kind: z.string().optional(),
+    group: z.string().optional(),
+    percent: z.number().nullish(),
+    resets_at: z.string().nullish(),
+    scope: AnthropicLimitScopeSchema,
+    is_active: z.boolean().optional(),
   })
   .loose();
 
@@ -96,6 +126,7 @@ export const AnthropicOAuthUsageSchema = z
     seven_day: AnthropicWindowSchema.nullish(),
     seven_day_opus: AnthropicWindowSchema.nullish(),
     seven_day_sonnet: AnthropicWindowSchema.nullish(),
+    limits: z.array(AnthropicLimitSchema).nullish(),
   })
   .loose();
 


### PR DESCRIPTION
## Summary
- parse Anthropic OAuth usage limits[] so scoped Fable quota is exposed as 7d-fable
- render Fable and other scoped 7-day quotas clearly in the provider admin UI
- document official Fable pricing source and add catalog/pricing regression coverage
- bump package version to 0.22.37 for release

## Validation
- pnpm vitest run packages/core/src/catalog/load.test.ts packages/shared/src/oauth/usage-schema.test.ts packages/core/src/provider/oauth/anthropic-quota.test.ts apps/admin/src/routes/providers/providers.test.ts
- pnpm exec biome check package.json config/pricing.yaml implementation-notes.md packages/core/src/catalog/load.test.ts packages/shared/src/oauth/usage-schema.ts packages/core/src/provider/oauth/anthropic-quota.ts packages/core/src/provider/oauth/anthropic-quota.test.ts apps/gateway/src/oauth/admin-oauth.test.ts apps/admin/src/routes/providers/providers.test.ts
- pnpm typecheck
- pnpm build
- git diff --check

## Note
- The full gateway OAuth test file remains locally blocked by the existing better-sqlite3 Node ABI mismatch under Node v25.8.2; this PR's targeted OAuth quota regression passed.