### PR TITLE
Fix Anthropic empty stream fallback

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -3867,7 +3867,15 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
   // Anthropic SSE frames the upstream byte-relays back, verbatim.
   const SSE = [
     'event: message_start\ndata: {"type":"message_start"}\n\n',
-    'event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n',
+    'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n',
+    'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+  ];
+
+  const EMPTY_ANTHROPIC_SSE = [
+    'event: message_start\ndata: {"type":"message_start"}\n\n',
+    'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+    'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+    'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":0}}\n\n',
     'event: message_stop\ndata: {"type":"message_stop"}\n\n',
   ];
 
@@ -4096,6 +4104,59 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.attempts[0]?.status).toBe("error");
     expect(out.attempts[0]?.error_class).toBe("upstream_error");
     // The chain advanced and the second anthropic candidate streamed via passthrough.
+    expect(tail.nativePassthroughStream).toHaveBeenCalledTimes(1);
+    expect(out.final.status).toBe("ok");
+    expect(out.stream).not.toBeNull();
+    expect(out.nativePassthrough).toBe(true);
+  });
+
+  it("an Anthropic passthrough stream that ends with no real output records a failure and advances the chain", async () => {
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(gen(EMPTY_ANTHROPIC_SSE)),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const tail = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(gen(SSE)),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: tail,
+      providers: new Map([
+        ["anthro-a", head],
+        ["anthro-b", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "anthro-a",
+          providerModel: "claude-a",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        b: {
+          providerName: "anthro-b",
+          providerModel: "claude-b",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(plan(["a", "b"]), anthropicStreamReq());
+    expect(head.nativePassthroughStream).toHaveBeenCalledTimes(1);
+    expect(recordFailure).toHaveBeenCalledTimes(1);
+    expect(recordFailure).toHaveBeenCalledWith("a");
+    expect(out.attempts[0]?.status).toBe("error");
+    expect(out.attempts[0]?.error_class).toBe("upstream_error");
+    expect(out.attempts[0]?.error_detail?.message).toBe(
+      "upstream stream ended before producing any output",
+    );
     expect(tail.nativePassthroughStream).toHaveBeenCalledTimes(1);
     expect(out.final.status).toBe("ok");
     expect(out.stream).not.toBeNull();

--- a/packages/core/src/provider/failover-guard.test.ts
+++ b/packages/core/src/provider/failover-guard.test.ts
@@ -102,7 +102,39 @@ describe("guardPreOutputFailure — anthropic_messages", () => {
   it("message_start then content_block_delta → commits byte-for-byte", async () => {
     const chunks = [
       'event: message_start\ndata: {"type":"message_start"}\n\n',
-      'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"Hi"}}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}\n\n',
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), anthropic));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("empty text block then terminal stop → throws so the executor can fall back", async () => {
+    const src = fromChunks([
+      'event: message_start\ndata: {"type":"message_start"}\n\n',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+      'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":0}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ]);
+    await expect(collect(guardPreOutputFailure(src, anthropic))).rejects.toThrow(UpstreamError);
+  });
+
+  it("a valid tool_use block start counts as output even before input_json_delta", async () => {
+    const chunks = [
+      'event: message_start\ndata: {"type":"message_start"}\n\n',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_123","name":"Bash","input":{}}}\n\n',
+      'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":1}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ];
+    const out = await collect(guardPreOutputFailure(fromChunks(chunks), anthropic));
+    expect(out.join("")).toBe(chunks.join(""));
+  });
+
+  it("tool argument deltas count as output", async () => {
+    const chunks = [
+      'event: message_start\ndata: {"type":"message_start"}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"cmd\\":"}}\n\n',
     ];
     const out = await collect(guardPreOutputFailure(fromChunks(chunks), anthropic));
     expect(out.join("")).toBe(chunks.join(""));

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -61,6 +61,14 @@ function tryParse(data: string): Record<string, unknown> | null {
   }
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function nonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.length > 0;
+}
+
 // ── OpenAI Responses ─────────────────────────────────────────────────────────
 // Preamble: response.created / response.in_progress (emitted unconditionally before
 // any model work). Error: error / response.failed. Everything else (deltas,
@@ -86,8 +94,10 @@ const responsesClassifier: PreOutputClassifier = {
 };
 
 // ── Anthropic Messages ───────────────────────────────────────────────────────
-// Preamble: message_start (no content yet) / ping (keep-alive). Error: error.
-// content_block_*, message_delta, message_stop are committing output.
+// Preamble: message_start / ping / empty block lifecycle events. Error: error.
+// Output: real content only — text/thinking deltas, tool_use starts, tool input
+// deltas, or redacted/signature content. Terminal message_delta/message_stop alone
+// must not commit; otherwise an upstream can "succeed" with no client-visible output.
 const anthropicClassifier: PreOutputClassifier = {
   classify(data) {
     if (data === "[DONE]") return "output";
@@ -96,6 +106,42 @@ const anthropicClassifier: PreOutputClassifier = {
     const t = obj.type;
     if (t === "message_start" || t === "ping") return "preamble";
     if (t === "error") return "error";
+    if (t === "content_block_start") {
+      const block = asRecord(obj.content_block);
+      if (!block) return "preamble";
+      switch (block.type) {
+        case "tool_use":
+          return nonEmptyString(block.id) && nonEmptyString(block.name) ? "output" : "preamble";
+        case "text":
+          return nonEmptyString(block.text) ? "output" : "preamble";
+        case "thinking":
+          return nonEmptyString(block.thinking) ? "output" : "preamble";
+        case "redacted_thinking":
+          return nonEmptyString(block.data) ? "output" : "preamble";
+        default:
+          return "output";
+      }
+    }
+    if (t === "content_block_delta") {
+      const delta = asRecord(obj.delta);
+      if (!delta) return "preamble";
+      if (nonEmptyString(delta.text)) return "output";
+      if (nonEmptyString(delta.partial_json)) return "output";
+      if (nonEmptyString(delta.thinking)) return "output";
+      if (nonEmptyString(delta.signature)) return "output";
+      switch (delta.type) {
+        case "text_delta":
+        case "input_json_delta":
+        case "thinking_delta":
+        case "signature_delta":
+          return "preamble";
+        default:
+          return "output";
+      }
+    }
+    if (t === "content_block_stop" || t === "message_delta" || t === "message_stop") {
+      return "preamble";
+    }
     return "output";
   },
   errorMessage(data) {


### PR DESCRIPTION
## Summary
- Tighten the Anthropic pre-output streaming guard so empty lifecycle frames do not commit a provider attempt.
- Treat empty Anthropic streams as upstream failure before first visible output, allowing execution fallback to continue to the next candidate.
- Add core guard and gateway executor regression coverage for the Fable empty-stream case.

## Tests
- pnpm vitest run packages/core/src/provider/failover-guard.test.ts apps/gateway/src/routes/execute.test.ts
- pnpm typecheck
- pnpm lint (passes; reports an existing info-level Biome note in packages/core/src/memory/forgetting/facts.test.ts:64)
- pnpm test (blocked locally by better-sqlite3 NODE_MODULE_VERSION mismatch: built for 137, current Node requires 141)