### PR TITLE
feat: add API-key usage stats endpoint

### DIFF
--- a/apps/gateway/src/routes/openapi.test.ts
+++ b/apps/gateway/src/routes/openapi.test.ts
@@ -22,6 +22,7 @@ describe("OpenAPI docs", () => {
       "/healthz",
       "/version",
       "/v1/models",
+      "/v1/usage/stats",
       "/v1/chat/completions",
       "/v1/messages",
       "/v1/responses",
@@ -56,6 +57,8 @@ describe("OpenAPI docs", () => {
     ]);
     // /v1/models is marked as bearer-secured; / is public.
     expect(doc.paths["/v1/models"]?.get.security).toEqual([{ bearerAuth: [] }]);
+    expect(doc.paths["/v1/usage/stats"]?.get.security).toEqual([{ bearerAuth: [] }]);
+    expect(doc.components.schemas.UsageStats).toBeDefined();
     expect(doc.paths["/"]?.get.security).toEqual([]);
   });
 

--- a/apps/gateway/src/routes/openapi.ts
+++ b/apps/gateway/src/routes/openapi.ts
@@ -84,6 +84,10 @@ export function buildOpenApiDocument(buildInfo?: BuildInfo): JsonSchema {
       { name: "Meta", description: "Landing page, readiness, and build info — no auth." },
       { name: "Models", description: "What the key can route to: lanes, `auto`, and aliases." },
       {
+        name: "Usage",
+        description: "Read-only telemetry aggregates scoped to the authenticated API key.",
+      },
+      {
         name: "Inference",
         description:
           'The four client protocols plus image generation. Send `model: "auto"` to let ' +
@@ -115,6 +119,49 @@ export function buildOpenApiDocument(buildInfo?: BuildInfo): JsonSchema {
         ImageGenerationResponse: component(ImageGenerationResponseSchema),
         InteractionsRequest: component(InteractionsRequestSchema),
         InteractionsResponse: component(InteractionsResponseSchema),
+        UsageStats: {
+          type: "object",
+          properties: {
+            object: { const: "usage_stats" },
+            api_key_id: { type: "string" },
+            range: {
+              type: "object",
+              properties: {
+                start_ms: { type: "integer", minimum: 0 },
+                end_ms: { type: "integer", minimum: 0 },
+                bucket: { enum: ["hour", "day"] },
+                tz_offset_minutes: { type: "integer", minimum: -720, maximum: 840 },
+              },
+              required: ["start_ms", "end_ms", "bucket", "tz_offset_minutes"],
+            },
+            totals: {
+              type: "object",
+              properties: {
+                requests: { type: "integer", minimum: 0 },
+                ok_count: { type: "integer", minimum: 0 },
+                error_count: { type: "integer", minimum: 0 },
+                prompt_tokens: { type: "integer", minimum: 0 },
+                completion_tokens: { type: "integer", minimum: 0 },
+                total_tokens: { type: "integer", minimum: 0 },
+                cached_tokens: { type: "integer", minimum: 0 },
+                cache_creation_tokens: { type: "integer", minimum: 0 },
+                cost_usd: { type: "number", minimum: 0 },
+              },
+              required: [
+                "requests",
+                "ok_count",
+                "error_count",
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+                "cached_tokens",
+                "cache_creation_tokens",
+                "cost_usd",
+              ],
+            },
+          },
+          required: ["object", "api_key_id", "range", "totals"],
+        },
         ErrorEnvelope: ERROR_ENVELOPE,
       },
     },
@@ -189,6 +236,56 @@ export function buildOpenApiDocument(buildInfo?: BuildInfo): JsonSchema {
               },
             },
             "400": errorResponse("Unknown model / not available to this key"),
+            "401": errorResponse("Missing or invalid API key"),
+          },
+        },
+      },
+      "/v1/usage/stats": {
+        get: {
+          tags: ["Usage"],
+          summary: "Get usage stats for the authenticated key",
+          description:
+            "Returns compact token, request, and cost totals scoped to the API key used " +
+            "for authentication. `key_id` query parameters are ignored; callers cannot " +
+            "read another key's usage through this endpoint.",
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            {
+              name: "start",
+              in: "query",
+              required: false,
+              schema: { type: "integer", minimum: 0 },
+              description: "Inclusive epoch-ms lower bound. Defaults to 0 for cumulative usage.",
+            },
+            {
+              name: "end",
+              in: "query",
+              required: false,
+              schema: { type: "integer", minimum: 0 },
+              description: "Exclusive epoch-ms upper bound. Defaults to the current server time.",
+            },
+            {
+              name: "bucket",
+              in: "query",
+              required: false,
+              schema: { enum: ["hour", "day"], default: "day" },
+              description: "Telemetry aggregation bucket. Present for query parity with stats.",
+            },
+            {
+              name: "tzOffsetMinutes",
+              in: "query",
+              required: false,
+              schema: { type: "integer", minimum: -720, maximum: 840, default: 0 },
+              description: "East-positive timezone offset used for bucket flooring.",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Usage totals scoped to the authenticated key",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/UsageStats" } },
+              },
+            },
             "401": errorResponse("Missing or invalid API key"),
           },
         },

--- a/apps/gateway/src/routes/usage.test.ts
+++ b/apps/gateway/src/routes/usage.test.ts
@@ -1,0 +1,127 @@
+import { type ApiKeyRecord, hashKey, type TelemetryStore } from "@helm/core";
+import { describe, expect, it, vi } from "vitest";
+import { createApp } from "../app.js";
+import { authMiddleware } from "../middleware/auth.js";
+import { registerUsageStatsRoute } from "./usage.js";
+
+const AUTH = { Authorization: "Bearer helm_live_secret" } as const;
+
+function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
+  return {
+    key_id: "k1",
+    hash: hashKey("helm_live_secret"),
+    prefix: "helm_live_ab",
+    account_id: "acct",
+    role: "user",
+    name: null,
+    allowed_lanes: null,
+    allow_custom_model: false,
+    allow_fast_mode: false,
+    disabled: false,
+    rate_limit_rpm: null,
+    rate_limit_tpm: null,
+    budget_requests: null,
+    budget_tokens: null,
+    budget_spend_usd: null,
+    budget_window_seconds: null,
+    over_budget_behavior: "degrade",
+    degrade_lane: null,
+    concurrency_limit: null,
+    memory_mode: "off" as const,
+    memory_project_id: null,
+    memory_thread_source: "header" as const,
+    ...overrides,
+  };
+}
+
+type AggregateCall = {
+  start: number;
+  end: number;
+  bucket: "hour" | "day";
+  tzOffsetMinutes: number;
+  keyId?: string;
+};
+
+function statsTelemetry(calls: AggregateCall[]): Pick<TelemetryStore, "aggregate"> {
+  return {
+    async aggregate(start, end, bucket, tzOffsetMinutes = 0, keyId) {
+      calls.push({ start, end, bucket, tzOffsetMinutes, keyId });
+      return {
+        totals: {
+          requests: 3,
+          okCount: 2,
+          errorCount: 1,
+          totalCostUsd: 12.34,
+          promptTokens: 1_000,
+          completionTokens: 250,
+          cachedTokens: 40,
+          cacheCreationTokens: 9,
+          avgLatencyMs: null,
+          avgTps: null,
+        },
+        series: [],
+        byModel: [],
+      };
+    },
+  };
+}
+
+function buildApp(rec: ApiKeyRecord | null, calls: AggregateCall[] = [], now = () => 10_000) {
+  const getByHash = vi.fn().mockResolvedValue(rec);
+  const app = createApp({ logger: { log: () => {} } });
+  app.use("/v1/usage/*", authMiddleware({ keyStore: { getByHash }, log: () => {} }));
+  registerUsageStatsRoute(app, { telemetry: statsTelemetry(calls), now });
+  return app;
+}
+
+describe("GET /v1/usage/stats", () => {
+  it("requires API-key auth", async () => {
+    const res = await buildApp(record()).request("/v1/usage/stats");
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as Record<string, unknown>).error_class).toBe("auth_error");
+  });
+
+  it("returns compact cumulative usage totals for the authenticated key", async () => {
+    const calls: AggregateCall[] = [];
+    const res = await buildApp(record(), calls).request("/v1/usage/stats?end=2000", {
+      headers: AUTH,
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toEqual([
+      { start: 0, end: 2000, bucket: "day", tzOffsetMinutes: 0, keyId: "k1" },
+    ]);
+    expect(await res.json()).toEqual({
+      object: "usage_stats",
+      api_key_id: "k1",
+      range: {
+        start_ms: 0,
+        end_ms: 2000,
+        bucket: "day",
+        tz_offset_minutes: 0,
+      },
+      totals: {
+        requests: 3,
+        ok_count: 2,
+        error_count: 1,
+        prompt_tokens: 1_000,
+        completion_tokens: 250,
+        total_tokens: 1_250,
+        cached_tokens: 40,
+        cache_creation_tokens: 9,
+        cost_usd: 12.34,
+      },
+    });
+  });
+
+  it("ignores caller-supplied key_id and fails open on malformed query params", async () => {
+    const calls: AggregateCall[] = [];
+    const res = await buildApp(record(), calls, () => 12_345).request(
+      "/v1/usage/stats?key_id=other&start=-9&bucket=decade&tzOffsetMinutes=banana",
+      { headers: AUTH },
+    );
+    expect(res.status).toBe(200);
+    expect(calls).toEqual([
+      { start: 0, end: 12_345, bucket: "day", tzOffsetMinutes: 0, keyId: "k1" },
+    ]);
+  });
+});

--- a/apps/gateway/src/routes/usage.ts
+++ b/apps/gateway/src/routes/usage.ts
@@ -1,0 +1,53 @@
+import type { TelemetryStore } from "@helm/core";
+import { StatsQuerySchema } from "@helm/shared";
+import type { Hono } from "hono";
+import type { AppEnv } from "../app.js";
+
+export interface UsageStatsRouteDeps {
+  telemetry: Pick<TelemetryStore, "aggregate">;
+  now?: () => number;
+}
+
+export function registerUsageStatsRoute(app: Hono<AppEnv>, deps: UsageStatsRouteDeps): void {
+  app.get("/v1/usage/stats", async (c) => {
+    const q = StatsQuerySchema.parse(c.req.query());
+    const identity = c.get("identity");
+    const end = q.end ?? deps.now?.() ?? Date.now();
+    const start = q.start ?? 0;
+    const agg = await deps.telemetry.aggregate(
+      start,
+      end,
+      q.bucket,
+      q.tzOffsetMinutes,
+      identity.keyId,
+    );
+    const totals = agg.totals;
+    const promptTokens = totals.promptTokens;
+    const completionTokens = totals.completionTokens;
+
+    return c.json(
+      {
+        object: "usage_stats",
+        api_key_id: identity.keyId,
+        range: {
+          start_ms: start,
+          end_ms: end,
+          bucket: q.bucket,
+          tz_offset_minutes: q.tzOffsetMinutes,
+        },
+        totals: {
+          requests: totals.requests,
+          ok_count: totals.okCount,
+          error_count: totals.errorCount,
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          total_tokens: promptTokens + completionTokens,
+          cached_tokens: totals.cachedTokens,
+          cache_creation_tokens: totals.cacheCreationTokens,
+          cost_usd: totals.totalCostUsd ?? 0,
+        },
+      },
+      200,
+    );
+  });
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -159,6 +159,7 @@ import { registerMessagesRoute } from "./routes/messages.js";
 import { createMessagesPipeline } from "./routes/messages-pipeline.js";
 import { registerModelsRoute } from "./routes/models.js";
 import { type ResponsesRouteDeps, registerResponsesRoute } from "./routes/responses.js";
+import { registerUsageStatsRoute } from "./routes/usage.js";
 import {
   markServingAccount,
   type ServingAccount,
@@ -1873,6 +1874,15 @@ export async function buildServer(
     // routability never disagree.
     oauthAliases: () => oauthAliasSet,
   });
+
+  // Machine-readable usage stats for API-key owners. Read-only and scoped by the
+  // authenticated key id; unlike /admin/api/stats this is not Basic Auth and does
+  // not accept a caller-supplied key_id.
+  app.use(
+    "/v1/usage/*",
+    authMiddleware({ keyStore, log: (l) => logger.log("warn", "auth", { line: l }) }),
+  );
+  registerUsageStatsRoute(app, { telemetry });
 
   // Memory MCP server (docs/13): POST /mcp exposes fact/reflection CRUD to
   // external agents, authed by the SAME API key as /v1 (so a tool call is scoped

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-03 · API key 级 usage stats 给外部自动化读取（Gateway usage API / telemetry，docs/07，原则 7）
+
+- **背景（Lukin）**：Skillstore 公开页需要每天同步 AI audit token / cost 快照；旧办法直接从 Helm SQLite 和 claude-relay Redis 取数，不适合作为长期自动化接口。新的来源应主要走 Helm 系统，并通过 API key 读取统计数据。
+- **接口决策**：新增 `GET /v1/usage/stats`，复用现有 API-key auth，不挂 admin Basic Auth。默认 `start=0`、`end=now`，返回当前 key 的累计 request/token/cost 汇总；仍接受 `start/end/bucket/tzOffsetMinutes` 以便后续做日窗口或趋势同步。
+- **隔离决策**：接口忽略 caller 传入的 `key_id`，只使用 `authMiddleware` 解析出的 `identity.keyId` 调 `TelemetryStore.aggregate(..., keyId)`；这样 Skillstore workflow 只能读它自己的 Helm key，不可能枚举其它 key 的用量。
+- **返回形状**：返回紧凑 snake_case 机器格式：`prompt_tokens`、`completion_tokens`、`total_tokens`、`cost_usd` 等，避免让下游 workflow 依赖 admin dashboard 的 series/byModel 大结构。
+- **限制 / TODO**：该接口反映 Helm telemetry 当前保留窗口内的数据；历史上还在 claude-relay 的用量需要 Skillstore 侧保留 legacy baseline 或临时兼容同步，等所有 audit 入口完全切到 Helm 后再移除 relay 补数。
+- **验证计划**：新增 route 测试覆盖缺 key 401、当前 key 聚合、恶意 `key_id` 被忽略；OpenAPI 加入 bearer-secured usage endpoint。
+
 ## 2026-07-02 · API key 加密恢复与原地轮转（Auth / Admin keys，docs/06/11，原则 7）
 
 - **背景（Lukin）**：管理后台原本只能创建后一次性显示 API key；如果操作员没有保存完整 key，只能删除或重新创建。现需支持查看已存在 key 的完整值，并支持不丢历史的轮转。


### PR DESCRIPTION
## 背景

Skillstore 的公开 audit stats 需要定时读取 Helm 侧的 token / cost 累计值。之前只能通过 SSH 直接读 Helm SQLite，不适合作为长期自动化接口。

## 改动

- 新增 `GET /v1/usage/stats`，复用现有 API key 鉴权。
- 返回当前 API key 的累计 request/token/cost 汇总，默认 `start=0`、`end=now`。
- 忽略 caller 传入的 `key_id`，只按 `identity.keyId` 聚合，避免读取其它 key 的 usage。
- 将 endpoint 加入 OpenAPI，并补 route / OpenAPI 回归测试。
- 更新 `implementation-notes.md` 记录接口口径和限制。

## 验证

- `corepack pnpm exec vitest run apps/gateway/src/routes/usage.test.ts apps/gateway/src/routes/openapi.test.ts`
- `corepack pnpm exec biome check apps/gateway/src/routes/usage.ts apps/gateway/src/routes/usage.test.ts apps/gateway/src/routes/openapi.ts apps/gateway/src/routes/openapi.test.ts apps/gateway/src/server.ts`
- `corepack pnpm --filter @helm/gateway typecheck`