### PR TITLE
fix: skip context window overflow candidates

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -913,6 +913,74 @@ describe("createExecute — gateway execution adapter", () => {
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
+  it("skips a candidate on context_length_exceeded without tripping the breaker", async () => {
+    // Some upstreams report model-window overflow as an in-band stream error without an
+    // HTTP 400 status. That is a candidate capability miss, not provider health.
+    // Helm should try the next model and render the failed candidate as skipped.
+    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
+    async function* contextWindowError(): AsyncGenerator<string> {
+      throw new UpstreamError(
+        "upstream_error",
+        "codex responses stream error",
+        {
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            code: "context_length_exceeded",
+            message:
+              "Your input exceeds the context window of this model. Please adjust your input and try again.",
+            param: "input",
+          },
+          sequence_number: 2,
+        },
+        null,
+      );
+    }
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi
+        .fn()
+        .mockReturnValueOnce(contextWindowError())
+        .mockReturnValueOnce(gen(['data: {"ok":1}\n\n', "data: [DONE]\n\n"])),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        codex: {
+          providerName: "mock",
+          providerModel: "gpt-5.5",
+          targetProviderProtocol: "openai_responses",
+        },
+        opus: {
+          providerName: "mock",
+          providerModel: "claude-opus-4-8",
+          targetProviderProtocol: "anthropic_messages",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["codex", "opus"]), req({ stream: true }));
+
+    expect(out.final).toEqual({ status: "ok", alias: "opus", providerModel: "claude-opus-4-8" });
+    expect(out.attempts[0]).toMatchObject({
+      alias: "codex",
+      skipped: true,
+      skip_reason: "context_too_small",
+      status: "error",
+      error_class: null,
+    });
+    expect(out.attempts[0]?.error_detail).toBeNull();
+    expect(out.attempts[1]?.status).toBe("ok");
+    expect(recordFailure).not.toHaveBeenCalled();
+  });
+
   it("maps Anthropic output_config.effort through the target model policy instead of skipping", async () => {
     const provider = {
       chatCompletion: vi.fn().mockResolvedValue({ id: "sonnet" }),

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1000,6 +1000,17 @@ function upstreamErrorType(raw: unknown): string | null {
   return typeof top === "string" && top !== "error" ? top : null;
 }
 
+function upstreamErrorCode(raw: unknown): string | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const inner = (raw as { error?: unknown }).error;
+  if (inner !== null && typeof inner === "object") {
+    const code = (inner as { code?: unknown }).code;
+    if (typeof code === "string") return code;
+  }
+  const top = (raw as { code?: unknown }).code;
+  return typeof top === "string" ? top : null;
+}
+
 // Human-readable upstream error message (for surfacing to the client verbatim), if
 // the provider nested one under `error.message`.
 function upstreamErrorMessage(raw: unknown): string | null {
@@ -1012,15 +1023,32 @@ function upstreamErrorMessage(raw: unknown): string | null {
   return null;
 }
 
+// A model-specific context-window rejection means THIS candidate cannot serve the
+// request, but a later fallback with a larger window may still succeed. Some streaming
+// providers emit this as an in-band SSE error with no HTTP status, so classify from the
+// provider error body/message rather than relying on status alone.
+export function isContextWindowRejection(err: unknown): boolean {
+  if (!(err instanceof UpstreamError)) return false;
+  if (upstreamErrorCode(err.providerRaw) === "context_length_exceeded") return true;
+  const text = `${err.message} ${upstreamErrorMessage(err.providerRaw) ?? ""} ${rawErrorText(
+    err.providerRaw,
+  )}`.toLowerCase();
+  return (
+    text.includes("context_length_exceeded") ||
+    text.includes("context window") ||
+    text.includes("context length") ||
+    text.includes("maximum context") ||
+    text.includes("prompt is too long")
+  );
+}
+
 // A DETERMINISTIC request-shape rejection from the upstream: the request body is
-// itself invalid (oversized image, prompt too long, bad param). Re-sending the
-// IDENTICAL body to another candidate is futile — every provider rejects it — and
-// the client owns the fix. Claude Code in particular relies on receiving this 4xx
-// to trigger its own context compaction; burying it behind the fallback chain
-// (synthetic all_providers_failed 502) is exactly what stopped compaction from
-// firing through the gateway. So the executor short-circuits and surfaces it
-// verbatim (see the catch block below). 429 is intentionally NOT here: that is
-// genuine rate-limiting, legitimately retryable on another candidate.
+// itself invalid independent of the selected model (oversized image, bad param).
+// Re-sending the IDENTICAL body to another candidate is futile — every provider
+// rejects it — and the client owns the fix. Context-window errors are handled
+// separately by `isContextWindowRejection`: a larger-window fallback may succeed.
+// 429 is intentionally NOT here: that is genuine rate-limiting, legitimately
+// retryable on another candidate.
 export function isUpstreamRequestRejection(err: unknown): boolean {
   if (!(err instanceof UpstreamError)) return false;
   const status = err.upstreamStatus;
@@ -1030,7 +1058,7 @@ export function isUpstreamRequestRejection(err: unknown): boolean {
   // also honor the unambiguous phrasings real upstreams use for shape errors.
   if (status === 413) return true;
   const text = `${err.message} ${rawErrorText(err.providerRaw)}`.toLowerCase();
-  return text.includes("prompt is too long") || text.includes("max allowed size");
+  return text.includes("max allowed size");
 }
 
 // Coerce an already-scrubbed upstream error body into the schema's record|null
@@ -1567,13 +1595,30 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           continue;
         }
 
-        // Deterministic request-shape rejection (oversized image, prompt too long,
-        // bad param): the body is invalid for EVERY candidate, so do NOT advance the
-        // chain and do NOT fault the breaker (the upstream is healthy — the request is
-        // what's wrong). Surface the upstream's structured error VERBATIM as a 400
-        // invalid_request: Claude Code needs this 4xx to drive its own context
-        // compaction, and burying it behind a fallback (all_providers_failed 502) is
-        // what prevented compaction from firing through the gateway.
+        // Model context window overflow: THIS candidate cannot serve the request,
+        // but a later fallback with a larger window can. Treat it like a late-discovered
+        // capability skip, not provider health: no breaker failure, no red provider
+        // error row, and no execution-fallback count.
+        if (isContextWindowRejection(err)) {
+          capabilityPruned = true;
+          attempts.push({
+            alias,
+            skipped: true,
+            skip_reason: "context_too_small",
+            status: "error",
+            error_class: null,
+            latency_ms: elapsed(),
+            cost_usd: null,
+            error_detail: null,
+            ...attemptTelemetry,
+          });
+          continue;
+        }
+
+        // Deterministic request-shape rejection (oversized image, bad param): the
+        // body is invalid for EVERY candidate, so do NOT advance the chain and do NOT
+        // fault the breaker (the upstream is healthy — the request is what's wrong).
+        // Surface the upstream's structured error VERBATIM as a 400 invalid_request.
         if (isUpstreamRequestRejection(err)) {
           const detail = errorDetailOf(err);
           attempts.push({

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-03 · 上下文窗口超限按候选跳过处理（执行 fallback / streaming telemetry，docs/04/07，原则 5/8）
+
+- **背景（Lukin）**：生产请求 `69d5058f-ea6c-4bfc-91d8-0686a7c120f3` 最终由 `anthropic/claude-opus-4-8` 成功服务，但链中 `openai-codex/gpt-5.5` 先返回 Responses stream `context_length_exceeded`，admin 详情把它显示为普通 `upstream_error`。
+- **修复决策**：`context_length_exceeded` / “context window” / “prompt is too long” 属于当前候选模型窗口不足；即使它来自首个有效输出前的 SSE error 且没有 HTTP 400，也记录为 `skipped:true` + `skip_reason:"context_too_small"`，继续执行 fallback。
+- **熔断决策**：该类错误不调用 `breaker.recordFailure()`，不触发 OAuth 账号 auto-park，也不计入 execution fallback count；它和预检能力过滤的 `context_too_small` 语义保持一致。
+- **保留边界**：非上下文类 request-shape 错误（例如图片尺寸超限、非法参数）仍短路为 `invalid_request`，因为换候选模型无法修复请求体本身。
+- **验证**：新增执行器 stream 回归测试，覆盖 Codex Responses `context_length_exceeded` 先失败、后续 Opus 成功、首个 attempt 显示跳过且不记录 breaker failure；目标 `execute.test.ts` 117/117 绿。
+
 ## 2026-07-03 · API key 级 usage stats 给外部自动化读取（Gateway usage API / telemetry，docs/07，原则 7）
 
 - **背景（Lukin）**：Skillstore 公开页需要每天同步 AI audit token / cost 快照；旧办法直接从 Helm SQLite 和 claude-relay Redis 取数，不适合作为长期自动化接口。新的来源应主要走 Helm 系统，并通过 API key 读取统计数据。
@@ -68,12 +76,10 @@
 
 ---
 
-## 历史条目摘要（最近 4 条）
+## 历史条目摘要（最近 2 条）
 
 - **2026-06-30 · admin favicon cache policy（Admin UI 静态资源，docs/11，原则 7）**：favicon 慢不是体积问题，而是 `/admin` 静态资源 no-cache 策略；`/admin/favicon.{svg,png}` 改私有缓存 7 天，SPA shell/deep-link fallback 仍 no-cache，admin shell 只声明 SVG 避免双拉；补 gateway/admin 回归测试。
 - **2026-06-30 · per-model reasoning effort policy（执行 fallback / 协议转换，docs/04/05，原则 2/5/8）**：新增 catalog `reasoningEffort` policy，按模型/协议 wire 字段映射或删除 unsupported effort；Haiku 4.5 保留 manual `thinking` 但删除 `output_config.effort`，Sonnet `xhigh -> max`，translated/native passthrough 回归覆盖。
-- **2026-06-30 · Anthropic `output_config.effort` 与 OpenAI `reasoning_effort` 双向保真（协议转换/执行 fallback，docs/05/04，原则 5/8）**：Anthropic 入站 `output_config.effort` 提升到 IR `reasoning_effort`，OpenAI/Responses fallback 保留推理等级；反向 GPT/OpenAI→Anthropic 在无显式 output_config 时合成 `output_config.effort`；只映射等级字段，不从 `thinking.budget_tokens` 反推。
-- **2026-06-30 · Fast mode 账号强制覆盖 + API key 透传限制（OAuth subscription provider / key governance，docs/04/11，原则 2/5）**：账号级 `fastMode` 统一映射到 Codex `service_tier:"priority"` 与 Anthropic `speed:"fast"` + beta header，并强制覆盖 provider wire request；per-key `allow_fast_mode` 只治理客户端透传，不阻止账号级强制启用；UI 仅对支持 provider 展示。
 
 ## 更早历史总览
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.40",
+  "version": "0.22.41",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- classify upstream context-window overflow as a candidate skip (`context_too_small`) instead of a provider-health failure
- keep non-context request-shape errors as terminal `invalid_request`
- bump root package version to `0.22.41` so merge to `main` cuts the release/image

## Production evidence
- request `69d5058f-ea6c-4bfc-91d8-0686a7c120f3` ended `ok` on `claude-opus-4-8`
- middle attempt `openai-codex/gpt-5.5` returned provider code `context_length_exceeded` and should be skipped, not shown as a normal provider error

## Validation
- `corepack pnpm vitest run apps/gateway/src/routes/execute.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint` (passes with existing style info in `packages/core/src/memory/forgetting/facts.test.ts`)
- `corepack pnpm build`