### PR TITLE
Route monitor automation to economy

### DIFF
--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -177,6 +177,13 @@ classifier:
     overrides:
       heartbeat_tokens: ["HEARTBEAT_OK"]
       exact_confirmation_tokens: ["yes", "no", "sure", "got it", "ok", "thanks", "是", "否", "可以", "好的", "谢谢", "对", "嗯", "行", "好", "没问题", "收到", "明白", "知道了"]
+      # Low-cost automation guards production monitor/cron probes from being
+      # escalated just because the request exposes many tools or names a
+      # MONITOR.md path. BOTH marker groups must match, and true long-context
+      # fit is left to the capability filter after lane selection.
+      low_cost_automation:
+        intent_markers: ["[cron:", "chief-monitor", "architect-monitor", "MONITOR.md"]
+        no_reply_markers: ["NO_REPLY", "nothing to action", "无事不回复", "没事不回复", "无需回复"]
       formal_logic_keywords: ["⊢", "∴", "modus ponens", "first-order logic", "充分必要", "反证法", "归纳法"]
       tools_floor: standard
       long_context_token_threshold: 64000  # capability signal (NOT a task_type); bumped 50k->64k to match llm-router lanes.yaml long_context anchor

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-03 · cron monitor 自动化请求降到低成本规则（Classifier / routing，docs/03/04，原则 2/4）
+
+- **背景（Lukin）**：生产 `openclaw` key 的 monitor/cron 请求常请求 `gpt-5.4-mini`，但因 key 不允许 custom model，路由走分类器；请求带长历史、36 个左右工具和 `MONITOR.md` 文件路径，Layer-1 把它判成 `coding/medium`，最终第一候选落到 `openai-codex/gpt-5.5`。
+- **根因**：这些工具和文件路径是自动化探针的环境能力，不代表当前用户 turn 是 coding 任务；`tools_floor`、`tool_count`、`detectFilePath()` 叠加后把“检查状态，无事不回复”的低成本请求误升到 coding/balanced 级别。
+- **规则决策**：新增 `classifier.rules.overrides.low_cost_automation`，只有同时命中 `intent_markers`（如 `[cron:`、`MONITOR.md`）和 `no_reply_markers`（如 `NO_REPLY`、`nothing to action`）时，才 set 到 `simple`；普通“解释 NO_REPLY”不会触发。长历史不再让该自动化探针升档，真实窗口适配交给后续 capability filter。
+- **task_type 决策**：低成本自动化模式下，task detector 忽略 ambient tool-prefix 和 file-path 证据，但仍保留显式 coding keyword（如 `debug/refactor/function`）的升级路径，避免真正要修代码的 monitor 任务被错误降级。
+- **验证计划**：新增 openclaw cron monitor golden route 回归、override 单测、taskdetect 单测和 schema 默认值测试；目标是该形态走 `chat/simple/economy`，链首回到 `openai-codex/gpt-5.4-mini`。
+
 ## 2026-07-03 · 上下文窗口超限按候选跳过处理（执行 fallback / streaming telemetry，docs/04/07，原则 5/8）
 
 - **背景（Lukin）**：生产请求 `69d5058f-ea6c-4bfc-91d8-0686a7c120f3` 最终由 `anthropic/claude-opus-4-8` 成功服务，但链中 `openai-codex/gpt-5.5` 先返回 Responses stream `context_length_exceeded`，admin 详情把它显示为普通 `upstream_error`。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.41",
+  "version": "0.22.42",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/classifier/automation-signals.ts
+++ b/packages/core/src/classifier/automation-signals.ts
@@ -1,0 +1,28 @@
+import type { ClassifierRulesConfig } from "@helm/shared";
+
+type LowCostAutomationConfig = ClassifierRulesConfig["overrides"]["low_cost_automation"];
+
+// Production monitor/cron prompts often carry a broad tool surface and a file
+// path, but their intent is "check state, stay silent if nothing changed". Match
+// only when an automation marker AND a no-reply marker are present, so ordinary
+// questions about NO_REPLY do not get down-routed.
+export function isLowCostAutomationPrompt(text: string, cfg: ClassifierRulesConfig): boolean {
+  const markers = cfg.overrides.low_cost_automation ?? {
+    intent_markers: [],
+    no_reply_markers: [],
+  };
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return false;
+  return (
+    containsAny(trimmed, markers.intent_markers) && containsAny(trimmed, markers.no_reply_markers)
+  );
+}
+
+function containsAny(text: string, markers: LowCostAutomationConfig["intent_markers"]): boolean {
+  if (markers.length === 0) return false;
+  const haystack = text.toLocaleLowerCase();
+  return markers.some((marker) => {
+    const needle = marker.trim().toLocaleLowerCase();
+    return needle.length > 0 && haystack.includes(needle);
+  });
+}

--- a/packages/core/src/classifier/golden-routing.test.ts
+++ b/packages/core/src/classifier/golden-routing.test.ts
@@ -615,3 +615,37 @@ describe("GOLDEN: system-prompt-heavy trivial chat routes cheap, not premium", (
     expect(got.selected_lane).not.toBe("coding");
   });
 });
+
+// PROD regression (openclaw key, 2026-07-03): scheduled monitor prompts often
+// carry dozens of available tools, long history, and a file path to MONITOR.md.
+// That request shape is ambient automation context, not evidence of a coding
+// task. It must stay on the cheap lane unless the current user turn contains a
+// real coding/debugging instruction.
+describe("GOLDEN: cron monitor automation stays cheap", () => {
+  it("openclaw cron monitor with many tools and long history -> economy, not coding", async () => {
+    const request = req(
+      "[cron:2026-07-03T01:00:00Z] chief-monitor Read /Users/lukin/AgentData/chief/MONITOR.md and execute it strictly. Return NO_REPLY if nothing to action.",
+      {
+        requested_model: "gpt-5.4-mini",
+        protocol: "openai_responses",
+        messages: [
+          { role: "assistant", content: "prior context ".repeat(22_000) },
+          {
+            role: "user",
+            content:
+              "[cron:2026-07-03T01:00:00Z] chief-monitor Read /Users/lukin/AgentData/chief/MONITOR.md and execute it strictly. Return NO_REPLY if nothing to action.",
+          },
+        ],
+        tools: Array.from({ length: 36 }, (_value, index) => ({
+          type: "function",
+          function: { name: `tool_${index}` },
+        })),
+      },
+    );
+
+    const got = await decide(request);
+    expect(got.task_type).toBe("chat");
+    expect(got.complexity).toBe("simple");
+    expect(got.selected_lane).toBe("economy");
+  });
+});

--- a/packages/core/src/classifier/overrides.test.ts
+++ b/packages/core/src/classifier/overrides.test.ts
@@ -7,14 +7,7 @@ import { applyOverrides, evaluateOverrides } from "./overrides.js";
 // override-relevant block. The dimension/scoring surface is irrelevant here —
 // overrides are a pure, separate signal path that bypasses weighted scoring.
 function makeConfig(
-  overridesBlock: Partial<{
-    heartbeat_tokens: string[];
-    formal_logic_keywords: string[];
-    tools_floor: "simple" | "standard" | "complex" | "reasoning";
-    long_context_token_threshold: number;
-    long_context_floor: "simple" | "standard" | "complex" | "reasoning";
-    short_message_max_chars: number;
-  }> = {},
+  overridesBlock: Partial<ClassifierRulesConfig["overrides"]> = {},
 ): ClassifierRulesConfig {
   return ClassifierRulesConfigSchema.parse({
     dimensions: {},
@@ -80,6 +73,65 @@ describe("evaluateOverrides — formal logic (set → reasoning)", () => {
     );
     expect(hits).toContainEqual({ rule: "formal_logic", kind: "set", complexity: "reasoning" });
     expect(applyOverrides("simple", hits)).toBe("reasoning");
+  });
+});
+
+describe("evaluateOverrides — low-cost automation (set → simple)", () => {
+  const lowCostAutomation = {
+    intent_markers: ["[cron:", "MONITOR.md"],
+    no_reply_markers: ["NO_REPLY", "nothing to action"],
+  };
+
+  it("pins a cron monitor no-reply probe to simple despite tools floor (prod regression)", () => {
+    const cfg = makeConfig({ low_cost_automation: lowCostAutomation });
+    const hits = evaluateOverrides(
+      req({
+        content:
+          "[cron:2026-07-03T01:00:00Z] chief-monitor Read /Users/lukin/AgentData/chief/MONITOR.md and execute it strictly. Return NO_REPLY if nothing to action.",
+        tools: [{ name: "code_read" }],
+      }),
+      cfg,
+      58_000,
+    );
+    expect(hits).toContainEqual({
+      rule: "low_cost_automation",
+      kind: "set",
+      complexity: "simple",
+    });
+    expect(hits).toContainEqual({ rule: "tools_floor", kind: "floor", complexity: "standard" });
+    expect(applyOverrides("complex", hits)).toBe("simple");
+  });
+
+  it("does not fire on a normal NO_REPLY explanation without an automation marker", () => {
+    const cfg = makeConfig({ low_cost_automation: lowCostAutomation });
+    const hits = evaluateOverrides(
+      req({ content: "Explain why this integration sometimes returns NO_REPLY." }),
+      cfg,
+      20,
+    );
+    expect(hits.find((h) => h.rule === "low_cost_automation")).toBeUndefined();
+  });
+
+  it("lets low-cost automation beat long-history floors; capability filter owns window fit", () => {
+    const cfg = makeConfig({
+      low_cost_automation: lowCostAutomation,
+      long_context_token_threshold: 100,
+    });
+    const hits = evaluateOverrides(
+      req({
+        content:
+          "[cron:2026-07-03T01:00:00Z] Read /tmp/MONITOR.md. Return NO_REPLY if nothing to action.",
+      }),
+      cfg,
+      101,
+    );
+    expect(hits).toContainEqual({
+      rule: "low_cost_automation",
+      kind: "set",
+      complexity: "simple",
+    });
+    expect(hits).toContainEqual({ rule: "long_context", kind: "floor", complexity: "complex" });
+    expect(applyOverrides("complex", hits)).toBe("simple");
   });
 });
 

--- a/packages/core/src/classifier/overrides.ts
+++ b/packages/core/src/classifier/overrides.ts
@@ -1,4 +1,5 @@
 import type { ClassifierRulesConfig, InternalRequest } from "@helm/shared";
+import { isLowCostAutomationPrompt } from "./automation-signals.js";
 import { detectCodeBlock, detectStackTrace, keywordMatcher } from "./signals.js";
 import type { Complexity } from "./tiers.js";
 
@@ -15,7 +16,7 @@ import type { Complexity } from "./tiers.js";
 export type OverrideKind = "set" | "floor";
 
 export interface OverrideHit {
-  /** "heartbeat" | "exact_confirmation" | "formal_logic" | "tools_floor" | "long_context" | "short_message" */
+  /** "heartbeat" | "exact_confirmation" | "low_cost_automation" | "formal_logic" | "tools_floor" | "long_context" | "short_message" */
   rule: string;
   kind: OverrideKind;
   complexity: Complexity;
@@ -65,6 +66,13 @@ export function evaluateOverrides(
   // reasoning regardless of how low the weighted score was.
   if (containsAny(fullText, ov.formal_logic_keywords)) {
     hits.push({ rule: "formal_logic", kind: "set", complexity: "reasoning" });
+  }
+
+  // Low-cost automation: scheduled monitor probes with an explicit no-reply
+  // contract should not be raised by ambient tool/file-path or long-history
+  // signals. True window fit is enforced later by the capability filter.
+  if (isLowCostAutomationPrompt(lastUserText, cfg)) {
+    hits.push({ rule: "low_cost_automation", kind: "set", complexity: "simple" });
   }
 
   // Short-message shortcut: a tiny last user message with NO complex structural

--- a/packages/core/src/classifier/taskdetect.test.ts
+++ b/packages/core/src/classifier/taskdetect.test.ts
@@ -17,6 +17,7 @@ function makeConfig(
     task_keywords: Record<string, string[]>;
     tool_prefixes: Record<string, string[]>;
     task_activation: Record<string, number>;
+    classifier_overrides: Partial<ClassifierRulesConfig["overrides"]>;
   }> = {},
 ): ClassifierRulesConfig {
   return ClassifierRulesConfigSchema.parse({
@@ -37,7 +38,7 @@ function makeConfig(
     },
     task_activation: overrides.task_activation ?? { web: 3.0 },
     tier_boundaries: {},
-    overrides: {},
+    overrides: overrides.classifier_overrides ?? {},
     momentum: {},
   });
 }
@@ -201,6 +202,43 @@ describe("detectTask", () => {
       cfg,
     );
     expect(res.task_type).toBe("chat");
+  });
+
+  it("does not let cron monitor paths or ambient tools masquerade as coding", () => {
+    const cfg = makeConfig({
+      classifier_overrides: {
+        low_cost_automation: {
+          intent_markers: ["[cron:", "MONITOR.md"],
+          no_reply_markers: ["NO_REPLY", "nothing to action"],
+        },
+      },
+    });
+    const res = detectTask(
+      makeReq(
+        "[cron:2026-07-03T01:00:00Z] chief-monitor Read /Users/lukin/AgentData/chief/MONITOR.md and execute it strictly. Return NO_REPLY if nothing to action.",
+        { tools: [{ function: { name: "code_read" } }, { function: { name: "shell_run" } }] },
+      ),
+      cfg,
+    );
+    expect(res.task_type).toBe("chat");
+  });
+
+  it("still detects explicit coding intent inside a cron monitor prompt", () => {
+    const cfg = makeConfig({
+      classifier_overrides: {
+        low_cost_automation: {
+          intent_markers: ["[cron:", "MONITOR.md"],
+          no_reply_markers: ["NO_REPLY"],
+        },
+      },
+    });
+    const res = detectTask(
+      makeReq(
+        "[cron:2026-07-03T01:00:00Z] Read /tmp/MONITOR.md, debug the failing function, and return NO_REPLY only if nothing changed.",
+      ),
+      cfg,
+    );
+    expect(res.task_type).toBe("coding");
   });
 
   it("breaks an exact-score tie stably, not by config key order (no silent demote)", () => {

--- a/packages/core/src/classifier/taskdetect.ts
+++ b/packages/core/src/classifier/taskdetect.ts
@@ -1,4 +1,5 @@
 import type { ClassifierRulesConfig, InternalRequest } from "@helm/shared";
+import { isLowCostAutomationPrompt } from "./automation-signals.js";
 import { lastUserMessageText } from "./message-text.js";
 import { detectCodeBlock, detectFilePath, detectStackTrace, detectUrl } from "./signals.js";
 
@@ -22,7 +23,10 @@ import { detectCodeBlock, detectFilePath, detectStackTrace, detectUrl } from "./
 // coding agent (even "thanks") as coding. This mirrors the language guard's
 // "current turn only" rule (engine.ts §5.5: "historical keyword hits … are not
 // evidence that Layer-1 understood this prompt"). Tool names (path 2) stay full —
-// they are a legitimate per-request capability signal, not history.
+// they are a legitimate per-request capability signal, not history. Low-cost
+// monitor/cron probes are the narrow exception: their tool surface and MONITOR.md
+// path are ambient automation context, so explicit current-turn task keywords must
+// carry the classification instead.
 
 export type TaskType =
   | "chat"
@@ -76,6 +80,7 @@ export function detectTask(req: DetectInput, cfg: ClassifierRulesConfig): TaskDe
   // Text evidence is scoped to the CURRENT user turn (see header). Tool names are
   // request-wide (a capability signal, not history) and read from req.tools below.
   const text = lastUserMessageText(req.messages);
+  const lowCostAutomation = isLowCostAutomationPrompt(text, cfg);
   const toolNames = extractToolNames(req.tools);
 
   // Accumulate score + reasons per task. Lazily created on first hit.
@@ -100,13 +105,15 @@ export function detectTask(req: DetectInput, cfg: ClassifierRulesConfig): TaskDe
   }
 
   // ── path 2: tool-name prefixes (DATA) ────────────────────────────────────
-  for (const [task, prefixes] of Object.entries(cfg.tool_prefixes)) {
-    if (!isTaskType(task)) continue;
-    for (const prefix of prefixes) {
-      if (prefix.length === 0) continue;
-      for (const name of toolNames) {
-        if (name.startsWith(prefix)) {
-          bump(task, TOOL_PREFIX_WEIGHT, `tool_prefix:${prefix}`);
+  if (!lowCostAutomation) {
+    for (const [task, prefixes] of Object.entries(cfg.tool_prefixes)) {
+      if (!isTaskType(task)) continue;
+      for (const prefix of prefixes) {
+        if (prefix.length === 0) continue;
+        for (const name of toolNames) {
+          if (name.startsWith(prefix)) {
+            bump(task, TOOL_PREFIX_WEIGHT, `tool_prefix:${prefix}`);
+          }
         }
       }
     }
@@ -115,7 +122,9 @@ export function detectTask(req: DetectInput, cfg: ClassifierRulesConfig): TaskDe
   // ── path 3: structural signals (CODE — shared regexes) ───────────────────
   if (detectCodeBlock(text) > 0) bump("coding", STRUCTURAL_WEIGHT, "code_block");
   if (detectStackTrace(text) > 0) bump("coding", STRUCTURAL_WEIGHT, "stack_trace");
-  if (detectFilePath(text) > 0) bump("coding", STRUCTURAL_WEIGHT, "file_path");
+  if (!lowCostAutomation && detectFilePath(text) > 0) {
+    bump("coding", STRUCTURAL_WEIGHT, "file_path");
+  }
   if (detectUrl(text) > 0) bump("web", STRUCTURAL_WEIGHT, "url");
   if (hasImageAttachment(req.attachments)) bump("vision", STRUCTURAL_WEIGHT, "image_attachment");
   if (isJsonResponseFormat(req.response_format)) {

--- a/packages/shared/src/config/classifier-schema.test.ts
+++ b/packages/shared/src/config/classifier-schema.test.ts
@@ -22,6 +22,10 @@ function fullClassifier() {
       task_activation: { web: 3.0 },
       overrides: {
         heartbeat_tokens: ["HEARTBEAT_OK"],
+        low_cost_automation: {
+          intent_markers: ["[cron:", "MONITOR.md"],
+          no_reply_markers: ["NO_REPLY"],
+        },
         formal_logic_keywords: ["⊢"],
         tools_floor: "standard",
         long_context_token_threshold: 64000,
@@ -91,6 +95,10 @@ describe("ClassifierConfigSchema", () => {
     expect(parsed.momentum.max_history_weight).toBe(0.6);
     expect(parsed.overrides.long_context_token_threshold).toBe(64000);
     expect(parsed.overrides.heartbeat_tokens).toEqual(["HEARTBEAT_OK"]);
+    expect(parsed.overrides.low_cost_automation).toEqual({
+      intent_markers: [],
+      no_reply_markers: [],
+    });
     expect(parsed.overrides.tools_floor).toBe("standard");
   });
 

--- a/packages/shared/src/config/classifier-schema.ts
+++ b/packages/shared/src/config/classifier-schema.ts
@@ -46,6 +46,12 @@ export const ClassifierRulesConfigSchema = z.object({
     exact_confirmation_tokens: z
       .array(z.string())
       .default(["yes", "no", "sure", "got it", "ok", "thanks"]),
+    low_cost_automation: z
+      .object({
+        intent_markers: z.array(z.string()).default([]),
+        no_reply_markers: z.array(z.string()).default([]),
+      })
+      .prefault({}),
     formal_logic_keywords: z.array(z.string()).default([]),
     tools_floor: TierSchema.default("standard"),
     long_context_token_threshold: z.number().int().positive().default(64_000),


### PR DESCRIPTION
## Summary
- Add a configurable low-cost automation classifier signal for cron/monitor + no-reply prompts.
- Prevent MONITOR.md paths and ambient tool surfaces from misclassifying these probes as coding.
- Bump package version to 0.22.42 so the main publish workflow cuts the release/image tag.

## Production evidence
- openclaw has allow_custom_model=0, so requested gpt-5.4-mini is classified instead of passed through.
- Recent gpt-5.4-mini requests commonly landed on openai-codex/gpt-5.5 with fallback_count=0 and attempts=1, proving this is lane selection rather than execution fallback.

## Tests
- ./node_modules/.bin/vitest run packages/core/src/classifier/golden-routing.test.ts packages/core/src/classifier/overrides.test.ts packages/core/src/classifier/taskdetect.test.ts packages/shared/src/config/classifier-schema.test.ts
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm typecheck
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm build
- COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm test
