### PR TITLE
Improve policy reorder drag handle

### DIFF
--- a/apps/admin/src/lib/components/PolicyRow.svelte
+++ b/apps/admin/src/lib/components/PolicyRow.svelte
@@ -20,17 +20,31 @@
     index,
     total,
     lanes,
+    dragging = false,
+    dropTarget = false,
     onchange,
     onremove,
     onmove,
+    ondragstart = () => {},
+    ondragover = () => {},
+    ondrop = () => {},
+    ondragend = () => {},
+    onpointerstart = () => {},
   }: {
     policy: Policy;
     index: number;
     total: number;
     lanes: string[];
+    dragging?: boolean;
+    dropTarget?: boolean;
     onchange: (next: Policy) => void;
     onremove: (index: number) => void;
     onmove: (from: number, to: number) => void;
+    ondragstart?: (index: number, event: DragEvent) => void;
+    ondragover?: (index: number, event: DragEvent) => void;
+    ondrop?: (index: number, event: DragEvent) => void;
+    ondragend?: () => void;
+    onpointerstart?: (index: number, event: PointerEvent) => void;
   } = $props();
 
   // Own an editable copy seeded from the initial prop. The component accumulates
@@ -71,10 +85,49 @@
     reasoningEffort = value as ReasoningEffort | '';
     emit();
   }
+
+  function handleDragKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      onmove(index, index - 1);
+      return;
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      onmove(index, index + 1);
+    }
+  }
 </script>
 
-<div class="card flex flex-col gap-3" data-testid="policy-row">
+<div
+  class={`card flex flex-col gap-3 transition-shadow ${
+    dragging ? 'opacity-60 ring-2 ring-slate-300' : ''
+  } ${dropTarget ? 'ring-2 ring-slate-400' : ''}`}
+  data-testid="policy-row"
+  role="group"
+  aria-label={`${$t('priority')} ${index + 1}`}
+  ondragover={(event) => ondragover(index, event)}
+  ondrop={(event) => ondrop(index, event)}
+>
   <header class="flex items-center gap-2">
+    <button
+      type="button"
+      class="btn-icon shrink-0 cursor-grab text-slate-400 hover:text-slate-700 active:cursor-grabbing"
+      aria-label={$t('drag to reorder policy')}
+      title={$t('drag to reorder policy')}
+      disabled={total < 2}
+      data-testid="policy-drag-handle"
+      ondragstart={(event) => ondragstart(index, event)}
+      ondragend={ondragend}
+      onpointerdown={(event) => onpointerstart(index, event)}
+      onkeydown={handleDragKeydown}
+    >
+      <svg viewBox="0 0 20 20" class="h-4 w-4" fill="currentColor" aria-hidden="true">
+        <path
+          d="M7 5.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0 4.75a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm-1.25 6a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm9.75-10.75a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0ZM14.25 11.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1.25 3.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z"
+        />
+      </svg>
+    </button>
     <span
       class="flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white"
       data-testid="policy-index"
@@ -84,20 +137,6 @@
       >{$t('first match wins — lower number = higher priority')}</span
     >
     <span class="flex-1"></span>
-    <button
-      type="button"
-      class="btn-icon"
-      aria-label={$t('move up')}
-      onclick={() => onmove(index, index - 1)}
-      disabled={index === 0}>↑</button
-    >
-    <button
-      type="button"
-      class="btn-icon"
-      aria-label={$t('move down')}
-      onclick={() => onmove(index, index + 1)}
-      disabled={index === total - 1}>↓</button
-    >
     <button
       type="button"
       class="btn-icon hover:bg-red-50 hover:text-red-600"

--- a/apps/admin/src/lib/components/PolicyRow.test.ts
+++ b/apps/admin/src/lib/components/PolicyRow.test.ts
@@ -139,7 +139,23 @@ describe('PolicyRow', () => {
     expect(screen.getByTestId('catch-all-warning')).toBeInTheDocument();
   });
 
-  it('remove and move buttons call their callbacks', async () => {
+  it('shows one drag handle for reordering instead of separate up/down buttons', () => {
+    render(PolicyRow, {
+      policy: makePolicy(),
+      index: 1,
+      total: 3,
+      lanes: LANES,
+      onchange: vi.fn(),
+      onremove: vi.fn(),
+      onmove: vi.fn(),
+    });
+    const row = screen.getByTestId('policy-row');
+    expect(within(row).getByRole('button', { name: /drag to reorder/i })).toBeInTheDocument();
+    expect(within(row).queryByRole('button', { name: /move up/i })).toBeNull();
+    expect(within(row).queryByRole('button', { name: /move down/i })).toBeNull();
+  });
+
+  it('drag handle supports keyboard reordering and remove still calls its callback', async () => {
     const onremove = vi.fn();
     const onmove = vi.fn();
     render(PolicyRow, {
@@ -152,7 +168,9 @@ describe('PolicyRow', () => {
       onmove,
     });
     const row = screen.getByTestId('policy-row');
-    await fireEvent.click(within(row).getByRole('button', { name: /move up/i }));
+    await fireEvent.keyDown(within(row).getByRole('button', { name: /drag to reorder/i }), {
+      key: 'ArrowUp',
+    });
     expect(onmove).toHaveBeenCalledWith(1, 0);
     await fireEvent.click(within(row).getByRole('button', { name: /remove/i }));
     expect(onremove).toHaveBeenCalledWith(1);

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -216,6 +216,7 @@
   "disabled": "disabled",
   "Disconnect": "Disconnect",
   "Disconnecting…": "Disconnecting…",
+  "drag to reorder policy": "drag to reorder policy",
   "Done": "Done",
   "Done in {ms} ms": "Done in {ms} ms",
   "down": "down",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -216,6 +216,7 @@
   "disabled": "無効",
   "Disconnect": "切断",
   "Disconnecting…": "切断中…",
+  "drag to reorder policy": "ドラッグしてポリシーの順序を変更",
   "Done": "完了",
   "Done in {ms} ms": "{ms} ms で完了",
   "down": "下り",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -216,6 +216,7 @@
   "disabled": "비활성화됨",
   "Disconnect": "연결 해제",
   "Disconnecting…": "연결 해제 중…",
+  "drag to reorder policy": "드래그하여 정책 순서 변경",
   "Done": "완료",
   "Done in {ms} ms": "{ms} ms 소요",
   "down": "아래",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -216,6 +216,7 @@
   "disabled": "已禁用",
   "Disconnect": "断开连接",
   "Disconnecting…": "正在断开连接…",
+  "drag to reorder policy": "拖动以调整策略顺序",
   "Done": "完成",
   "Done in {ms} ms": "耗时 {ms} 毫秒",
   "down": "下行",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -216,6 +216,7 @@
   "disabled": "已停用",
   "Disconnect": "中斷連線",
   "Disconnecting…": "正在中斷連線…",
+  "drag to reorder policy": "拖動以調整策略順序",
   "Done": "完成",
   "Done in {ms} ms": "耗時 {ms} 毫秒",
   "down": "下行",

--- a/apps/admin/src/routes/policies/+page.svelte
+++ b/apps/admin/src/routes/policies/+page.svelte
@@ -10,7 +10,20 @@
   // edits/reorders the list and writes the whole set back via the API client.
   let { data }: { data: { policies: Policy[]; lanes?: string[] } } = $props();
 
-  let policies = $state<Policy[]>(untrack(() => data.policies.map((p) => ({ ...p }))));
+  type PolicyRowState = { key: string; policy: Policy };
+
+  let nextPolicyRowKey = 0;
+
+  function makePolicyRow(policy: Policy): PolicyRowState {
+    nextPolicyRowKey += 1;
+    return {
+      key: `${policy.id ?? 'policy'}-${nextPolicyRowKey}`,
+      policy: { ...policy, match: { ...policy.match } },
+    };
+  }
+
+  let policyRows = $state<PolicyRowState[]>(untrack(() => data.policies.map(makePolicyRow)));
+  const policies = $derived(policyRows.map((row) => row.policy));
   // Lane names for the action dropdowns. Falls back to the well-known set when
   // the load didn't supply them (the gateway is the source of truth on save).
   const lanes = untrack(() => data.lanes ?? ['economy', 'balanced', 'premium', 'coding']);
@@ -18,28 +31,129 @@
   let error = $state<string | null>(null);
   let saving = $state(false);
   let saved = $state(false);
+  let draggingKey = $state<string | null>(null);
+  let dropTargetKey = $state<string | null>(null);
+  let stopPointerDrag: (() => void) | null = null;
 
   function updateRow(index: number, next: Policy): void {
-    policies = policies.map((p, i) => (i === index ? next : p));
+    policyRows = policyRows.map((row, i) =>
+      i === index ? { ...row, policy: { ...next, match: { ...next.match } } } : row,
+    );
   }
 
   function removeRow(index: number): void {
-    policies = policies.filter((_, i) => i !== index);
+    policyRows = policyRows.filter((_, i) => i !== index);
   }
 
   function moveRow(from: number, to: number): void {
-    if (to < 0 || to >= policies.length) return;
-    const next = [...policies];
+    if (from === to || from < 0 || from >= policyRows.length || to < 0 || to >= policyRows.length) {
+      return;
+    }
+    const next = [...policyRows];
     const [moved] = next.splice(from, 1);
     next.splice(to, 0, moved);
-    policies = next;
+    policyRows = next;
+  }
+
+  function indexOfKey(key: string): number {
+    return policyRows.findIndex((row) => row.key === key);
+  }
+
+  function resetDrag(): void {
+    draggingKey = null;
+    dropTargetKey = null;
+  }
+
+  function finishPointerDrag(): void {
+    stopPointerDrag?.();
+    stopPointerDrag = null;
+    resetDrag();
+  }
+
+  function targetIndexFromClientY(clientY: number): number {
+    const rows = Array.from(document.querySelectorAll('[data-testid="policy-row"]'));
+    if (rows.length === 0) return -1;
+
+    for (let i = 0; i < rows.length; i += 1) {
+      const rect = rows[i].getBoundingClientRect();
+      if (clientY < rect.top + rect.height / 2) return i;
+    }
+    return rows.length - 1;
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (draggingKey === null) return;
+    event.preventDefault();
+    const from = indexOfKey(draggingKey);
+    const to = targetIndexFromClientY(event.clientY);
+    if (from === -1 || to === -1) return;
+    if (from !== to) moveRow(from, to);
+    dropTargetKey = draggingKey;
+  }
+
+  function handlePointerStart(index: number, event: PointerEvent): void {
+    if (event.button !== 0 || policyRows.length < 2) return;
+    const row = policyRows[index];
+    if (!row) return;
+    finishPointerDrag();
+    event.preventDefault();
+    draggingKey = row.key;
+    dropTargetKey = row.key;
+
+    const pointerId = event.pointerId;
+    const onMove = (nextEvent: PointerEvent) => {
+      if (nextEvent.pointerId === pointerId) handlePointerMove(nextEvent);
+    };
+    const onUp = (nextEvent: PointerEvent) => {
+      if (nextEvent.pointerId !== pointerId) return;
+      finishPointerDrag();
+    };
+    window.addEventListener('pointermove', onMove, { passive: false });
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    stopPointerDrag = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }
+
+  function handleDragStart(index: number, event: DragEvent): void {
+    const row = policyRows[index];
+    if (!row) return;
+    draggingKey = row.key;
+    dropTargetKey = null;
+    event.dataTransfer?.setData('text/plain', row.key);
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
+  }
+
+  function handleDragOver(index: number, event: DragEvent): void {
+    if (draggingKey === null) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+    dropTargetKey = policyRows[index]?.key ?? null;
+  }
+
+  function handleDrop(index: number, event: DragEvent): void {
+    event.preventDefault();
+    const key = draggingKey ?? event.dataTransfer?.getData('text/plain');
+    if (!key) {
+      resetDrag();
+      return;
+    }
+    const from = indexOfKey(key);
+    if (from !== -1) moveRow(from, index);
+    resetDrag();
   }
 
   async function addRow(): Promise<void> {
     // New rule defaults to a concrete action so it is never a silent no-op
     // (server requires at least one of use_lane/allowed_lanes). Appended LAST so it
     // gets the lowest priority (first-match order) and can't shadow existing rules.
-    policies = [...policies, { match: { task_type: TASK_TYPE_OPTIONS[0] }, use_lane: lanes[0] }];
+    policyRows = [
+      ...policyRows,
+      makePolicyRow({ match: { task_type: TASK_TYPE_OPTIONS[0] }, use_lane: lanes[0] }),
+    ];
     // The new row appends to the end of a potentially long list, so the click can
     // land below the fold and look like a no-op. Scroll it into view for
     // immediate feedback.
@@ -56,7 +170,7 @@
     saving = true;
     try {
       const result = await savePolicies(policies);
-      policies = result.map((p) => ({ ...p }));
+      policyRows = result.map(makePolicyRow);
       saved = true;
     } catch (e) {
       error = e instanceof Error ? e.message : $t('Failed to save policies');
@@ -91,7 +205,7 @@
     </p>
   {/if}
 
-  {#if policies.length === 0}
+  {#if policyRows.length === 0}
     <div class="empty-state" data-testid="policies-empty">
       <p class="font-medium text-ink-body">{$t('No policies yet')}</p>
       <p class="mt-1 text-sm text-ink-muted">
@@ -103,15 +217,22 @@
   {/if}
 
   <div class="flex flex-col gap-4">
-    {#each policies as policy, i (i)}
+    {#each policyRows as row, i (row.key)}
       <PolicyRow
-        {policy}
+        policy={row.policy}
         index={i}
-        total={policies.length}
+        total={policyRows.length}
         {lanes}
+        dragging={draggingKey === row.key}
+        dropTarget={dropTargetKey === row.key}
         onchange={(next) => updateRow(i, next)}
         onremove={removeRow}
         onmove={moveRow}
+        ondragstart={handleDragStart}
+        ondragover={handleDragOver}
+        ondrop={handleDrop}
+        ondragend={resetDrag}
+        onpointerstart={handlePointerStart}
       />
     {/each}
   </div>

--- a/apps/admin/src/routes/policies/policies.test.ts
+++ b/apps/admin/src/routes/policies/policies.test.ts
@@ -64,14 +64,24 @@ describe('policies page', () => {
     expect(screen.getAllByTestId('policy-row')).toHaveLength(2);
   });
 
-  it('reordering changes the saved array order (order = priority)', async () => {
+  it('dragging a row changes the visible order and saved array order', async () => {
     renderPage([
       policy({ match: { task_type: 'coding' }, use_lane: 'coding' }),
       policy({ match: { task_type: 'math' }, use_lane: 'premium' }),
     ]);
-    const rows = screen.getAllByTestId('policy-row');
-    // move the 2nd row up
-    await fireEvent.click(within(rows[1]).getByRole('button', { name: /move up/i }));
+    let rows = screen.getAllByTestId('policy-row');
+    const dragHandle = within(rows[1]).getByRole('button', { name: /drag to reorder/i });
+
+    await fireEvent.dragStart(dragHandle);
+    await fireEvent.dragOver(rows[0]);
+    await fireEvent.drop(rows[0]);
+
+    rows = screen.getAllByTestId('policy-row');
+    expect((within(rows[0]).getByLabelText(/task type/i) as HTMLSelectElement).value).toBe('math');
+    expect((within(rows[1]).getByLabelText(/task type/i) as HTMLSelectElement).value).toBe(
+      'coding',
+    );
+
     await fireEvent.click(screen.getByRole('button', { name: /save policies/i }));
 
     await waitFor(() => expect(savePolicies).toHaveBeenCalledTimes(1));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.43",
+  "version": "0.22.44",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- replace the policies up/down reorder buttons with a drag handle
- keep keyboard ArrowUp/ArrowDown reorder support on the handle
- use stable row keys so reordered policy rows visually update instead of reusing stale row state
- bump version to 0.22.44 for release

## Verification
- corepack pnpm vitest run src/routes/policies/policies.test.ts src/lib/components/PolicyRow.test.ts --config vitest.config.ts (from apps/admin)
- corepack pnpm --filter @helm/admin check
- corepack pnpm test
- corepack pnpm lint
- corepack pnpm build
- docker build -t helm-api:policy-drag ...
- replaced local helm container on port 8080 with the local image; verified /healthz and /version
- browser-verified /admin/policies: dragging the second row to the first position updates the visible order immediately