### PR TITLE
Improve policy drag auto-scroll

### DIFF
--- a/apps/admin/src/routes/policies/+page.svelte
+++ b/apps/admin/src/routes/policies/+page.svelte
@@ -34,6 +34,11 @@
   let draggingKey = $state<string | null>(null);
   let dropTargetKey = $state<string | null>(null);
   let stopPointerDrag: (() => void) | null = null;
+  let lastDragClientY: number | null = null;
+  let autoScrollFrame: number | null = null;
+
+  const AUTO_SCROLL_EDGE_PX = 72;
+  const AUTO_SCROLL_MAX_STEP_PX = 18;
 
   function updateRow(index: number, next: Policy): void {
     policyRows = policyRows.map((row, i) =>
@@ -62,6 +67,7 @@
   function resetDrag(): void {
     draggingKey = null;
     dropTargetKey = null;
+    cancelAutoScroll();
   }
 
   function finishPointerDrag(): void {
@@ -81,14 +87,73 @@
     return rows.length - 1;
   }
 
-  function handlePointerMove(event: PointerEvent): void {
+  function scrollContainer(): HTMLElement | null {
+    const main = document.querySelector('main');
+    return main instanceof HTMLElement ? main : null;
+  }
+
+  function dragAutoScrollDelta(container: HTMLElement, clientY: number): number {
+    const rect = container.getBoundingClientRect();
+    const topDistance = clientY - rect.top;
+    const bottomDistance = rect.bottom - clientY;
+    if (topDistance < AUTO_SCROLL_EDGE_PX) {
+      return -Math.ceil(
+        ((AUTO_SCROLL_EDGE_PX - Math.max(0, topDistance)) / AUTO_SCROLL_EDGE_PX) *
+          AUTO_SCROLL_MAX_STEP_PX,
+      );
+    }
+    if (bottomDistance < AUTO_SCROLL_EDGE_PX) {
+      return Math.ceil(
+        ((AUTO_SCROLL_EDGE_PX - Math.max(0, bottomDistance)) / AUTO_SCROLL_EDGE_PX) *
+          AUTO_SCROLL_MAX_STEP_PX,
+      );
+    }
+    return 0;
+  }
+
+  function moveDraggingRowToClientY(clientY: number): void {
     if (draggingKey === null) return;
-    event.preventDefault();
     const from = indexOfKey(draggingKey);
-    const to = targetIndexFromClientY(event.clientY);
+    const to = targetIndexFromClientY(clientY);
     if (from === -1 || to === -1) return;
     if (from !== to) moveRow(from, to);
     dropTargetKey = draggingKey;
+  }
+
+  function runAutoScroll(): void {
+    autoScrollFrame = null;
+    if (draggingKey === null || lastDragClientY === null) return;
+
+    const container = scrollContainer();
+    if (!container) return;
+
+    const delta = dragAutoScrollDelta(container, lastDragClientY);
+    if (delta === 0) return;
+
+    container.scrollBy({ top: delta });
+    moveDraggingRowToClientY(lastDragClientY);
+    autoScrollFrame = window.requestAnimationFrame(runAutoScroll);
+  }
+
+  function scheduleAutoScroll(clientY: number): void {
+    lastDragClientY = clientY;
+    if (autoScrollFrame !== null) return;
+    autoScrollFrame = window.requestAnimationFrame(runAutoScroll);
+  }
+
+  function cancelAutoScroll(): void {
+    if (autoScrollFrame !== null) {
+      window.cancelAnimationFrame(autoScrollFrame);
+      autoScrollFrame = null;
+    }
+    lastDragClientY = null;
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (draggingKey === null) return;
+    event.preventDefault();
+    moveDraggingRowToClientY(event.clientY);
+    scheduleAutoScroll(event.clientY);
   }
 
   function handlePointerStart(index: number, event: PointerEvent): void {

--- a/apps/admin/src/routes/policies/policies.test.ts
+++ b/apps/admin/src/routes/policies/policies.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Policy } from '$lib/api/policies.js';
 import PoliciesPage from './+page.svelte';
 
@@ -20,10 +20,25 @@ function renderPage(policies: Policy[]) {
   return render(PoliciesPage, { data: { policies } });
 }
 
+async function firePointer(
+  target: Document | Node | Element | Window,
+  type: string,
+  init: { button?: number; clientY: number; pointerId?: number },
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, { pointerId: 1, ...init });
+  await fireEvent(target, event);
+}
+
 describe('policies page', () => {
   beforeEach(() => {
     savePolicies.mockReset();
     savePolicies.mockImplementation((list: Policy[]) => Promise.resolve(list));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('renders the policies in order with 1-based priority numbers', () => {
@@ -87,6 +102,81 @@ describe('policies page', () => {
     await waitFor(() => expect(savePolicies).toHaveBeenCalledTimes(1));
     const sent = savePolicies.mock.calls[0][0] as Policy[];
     expect(sent.map((p) => p.match.task_type)).toEqual(['math', 'coding']);
+  });
+
+  it('auto-scrolls and continues reordering while pointer dragging near the list edge', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) =>
+      window.setTimeout(() => callback(0), 16),
+    );
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((handle) =>
+      window.clearTimeout(handle),
+    );
+
+    const main = document.createElement('main');
+    let scrollTop = 0;
+    Object.defineProperty(main, 'clientHeight', { configurable: true, value: 300 });
+    Object.defineProperty(main, 'scrollHeight', { configurable: true, value: 900 });
+    Object.defineProperty(main, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
+    main.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 300, height: 300, left: 0, right: 600, width: 600 }) as DOMRect;
+    const scrollBy = vi.fn((optionsOrX?: ScrollToOptions | number, y?: number) => {
+      scrollTop += typeof optionsOrX === 'number' ? Number(y ?? 0) : Number(optionsOrX?.top ?? 0);
+    });
+    main.scrollBy = scrollBy as unknown as typeof main.scrollBy;
+    document.body.append(main);
+
+    render(
+      PoliciesPage,
+      {
+        target: main,
+        props: {
+          data: {
+            policies: [
+              policy({ match: { task_type: 'coding' }, use_lane: 'coding' }),
+              policy({ match: { task_type: 'math' }, use_lane: 'premium' }),
+              policy({ match: { task_type: 'chat' }, use_lane: 'economy' }),
+            ],
+          },
+        },
+      },
+    );
+
+    const rowRect = (row: HTMLElement): DOMRect => {
+      const rows = Array.from(document.querySelectorAll('[data-testid="policy-row"]'));
+      const index = rows.indexOf(row);
+      const top = 80 + index * 100 - scrollTop;
+      return { top, bottom: top + 80, height: 80, left: 0, right: 600, width: 600 } as DOMRect;
+    };
+
+    for (const row of screen.getAllByTestId('policy-row')) {
+      row.getBoundingClientRect = () => rowRect(row);
+    }
+
+    const rows = screen.getAllByTestId('policy-row');
+    const firstHandle = within(rows[0]).getByRole('button', { name: /drag to reorder/i });
+    firstHandle.getBoundingClientRect = () =>
+      ({ top: 96, bottom: 128, height: 32, left: 16, right: 48, width: 32 }) as DOMRect;
+
+    await firePointer(firstHandle, 'pointerdown', { button: 0, clientY: 112 });
+    await firePointer(window, 'pointermove', { clientY: 280 });
+    await vi.advanceTimersByTimeAsync(80);
+    await firePointer(window, 'pointerup', { clientY: 280 });
+
+    expect(scrollBy).toHaveBeenCalled();
+    expect(scrollTop).toBeGreaterThan(0);
+    const nextRows = screen.getAllByTestId('policy-row');
+    expect((within(nextRows[0]).getByLabelText(/task type/i) as HTMLSelectElement).value).toBe(
+      'math',
+    );
+    expect(nextRows.map((row) => within(row).getByTestId('policy-index').textContent?.trim()))
+      .toEqual(['1', '2', '3']);
   });
 
   it('on save failure shows an error and keeps the pre-save list (fail-closed, no dirty write)', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.22.44",
+  "version": "0.22.45",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary\n- keep policy drag-reorder moving while the pointer is held near the scroll container edge\n- cancel the auto-scroll loop cleanly when dragging ends\n- add regression coverage for auto-scroll reordering\n- bump version to v0.22.45\n\n## Verification\n- corepack pnpm vitest run src/routes/policies/policies.test.ts src/lib/components/PolicyRow.test.ts --config vitest.config.ts\n- corepack pnpm --filter @helm/admin check\n- corepack pnpm lint\n- corepack pnpm test\n- corepack pnpm build\n- local Docker helm container rebuilt/replaced in place; Playwright drag matrix passed including long drag auto-scroll