### PR TITLE
Improve memory refresh control and worker catch-up

### DIFF
--- a/apps/admin/src/routes/memory/+page.svelte
+++ b/apps/admin/src/routes/memory/+page.svelte
@@ -21,6 +21,7 @@
   import EditFactDialog from '$lib/components/EditFactDialog.svelte';
   import EditReflectionDialog from '$lib/components/EditReflectionDialog.svelte';
   import Modal from '$lib/components/Modal.svelte';
+  import RefreshControl from '$lib/components/RefreshControl.svelte';
   import { formatTimestamp } from '$lib/format.js';
   import { paginationItems } from '$lib/pagination.js';
   import { t } from '$lib/i18n';
@@ -72,7 +73,6 @@
   // whenever an error is raised or a new selection is made.
   let notice = $state<string | null>(null);
   let stats = $state<MemoryStats | null>(initialStats);
-  let loadingStats = $state<boolean>(initialStats === null);
 
   // Facts table state. The list is paginated + searchable client-side (facts load on
   // selection, not via the loader), so page/search live here and drive loadFacts.
@@ -163,14 +163,11 @@
   const statusBadge = $derived(statsBadge(stats));
 
   async function loadStats(scope: SelectedScope | null = selected): Promise<void> {
-    loadingStats = true;
     statsError = null;
     try {
       stats = await getMemoryStats(scope === null ? {} : scopeQuery(scope));
     } catch (e) {
       statsError = e instanceof Error ? e.message : $t('Failed to load memory status');
-    } finally {
-      loadingStats = false;
     }
   }
 
@@ -377,10 +374,6 @@
     } else if (initialStats === null) {
       void loadStats(null);
     }
-    const timer = window.setInterval(() => {
-      void loadStats();
-    }, 15_000);
-    return () => window.clearInterval(timer);
   });
 </script>
 
@@ -422,12 +415,10 @@
         </div>
         <p class="section-desc font-mono">{statsScopeLabel}</p>
       </div>
-      <button
-        type="button"
-        class="btn-secondary"
-        disabled={loadingStats}
-        onclick={() => loadStats()}>{loadingStats ? $t('Refreshing…') : $t('Refresh')}</button
-      >
+      <RefreshControl
+        storageKey="helm_admin_memory_refresh_interval"
+        onRefresh={() => loadStats()}
+      />
     </div>
     {#if statsError}
       <p class="alert-error" role="alert">{statsError}</p>

--- a/apps/admin/src/routes/memory/memory.test.ts
+++ b/apps/admin/src/routes/memory/memory.test.ts
@@ -154,6 +154,7 @@ function renderPage(scopes: MemoryScope[], keys: ApiKeyView[] = [key('k1')]) {
 
 describe('memory page', () => {
   beforeEach(() => {
+    localStorage.clear();
     listFacts.mockReset();
     listReflections.mockReset();
     getMemoryStats.mockReset();
@@ -180,6 +181,18 @@ describe('memory page', () => {
     expect(screen.getAllByTestId('scope-row')).toHaveLength(2);
     expect(screen.getByText('proj-a')).toBeInTheDocument();
     expect(screen.getByText('proj-b')).toBeInTheDocument();
+  });
+
+  it('uses the shared refresh control for memory status reloads and cadence selection', async () => {
+    renderPage([scope()]);
+
+    expect(screen.getByTestId('refresh-control')).toBeInTheDocument();
+    await fireEvent.click(screen.getByTestId('refresh-now'));
+    await waitFor(() => expect(getMemoryStats).toHaveBeenCalledWith({}));
+
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    expect(screen.getByTestId('refresh-menu')).toBeInTheDocument();
+    expect(screen.getByTestId('refresh-interval-30')).toBeInTheDocument();
   });
 
   it('selecting a scope loads and renders the facts and reflections tables', async () => {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -2829,6 +2829,11 @@ export async function buildServer(
     const maxDrainRaw = Number(process.env.HELM_MEMORY_WORKER_MAX_DRAIN_MS ?? 30_000);
     const memoryWorkerMaxDrainMs =
       Number.isFinite(maxDrainRaw) && maxDrainRaw > 0 ? Math.floor(maxDrainRaw) : 30_000;
+    const concurrencyRaw = Number(process.env.HELM_MEMORY_WORKER_CONCURRENCY ?? 3);
+    const memoryWorkerConcurrency =
+      Number.isFinite(concurrencyRaw) && concurrencyRaw > 0
+        ? Math.min(8, Math.floor(concurrencyRaw))
+        : 3;
     // Debounce window for the request-driven wake() (see scheduler MemoryWorkerDeps).
     // Default 8s: a paused user's fact forms in ~8s while a burst of turns still
     // coalesces into one observer run. Clamped below the interval (the backstop must
@@ -2841,6 +2846,7 @@ export async function buildServer(
     memoryWorker = startMemoryWorker({
       memoryStore: store.memory,
       batchSize: memoryWorkerBatchSize,
+      concurrency: memoryWorkerConcurrency,
       intervalMs,
       coalesceMs,
       maxBatchesPerDrain: memoryWorkerMaxBatches,

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -226,7 +226,12 @@ The `MemoryWorker` is started process-wide by default. It claims pending
 ```text
 HELM_MEMORY_WORKER_DISABLED      set to "1" to disable the worker entirely
 HELM_MEMORY_WORKER_INTERVAL_MS   tick interval (default 60000)
-batchSize                        jobs claimed per tick (10)
+HELM_MEMORY_WORKER_BATCH_SIZE    jobs claimed per batch (default 50)
+HELM_MEMORY_WORKER_CONCURRENCY   simultaneous jobs per claimed batch (default 3, capped at 8)
+HELM_MEMORY_WORKER_MAX_BATCHES_PER_DRAIN
+                                  consecutive batches per drain (default 10)
+HELM_MEMORY_WORKER_MAX_DRAIN_MS  wall-clock guard between batches (default 30000)
+HELM_MEMORY_WORKER_COALESCE_MS   request-driven wake debounce (default 8000)
 ```
 
 `decay` jobs are only ever enqueued when `forgetting.enabled`, so a build with

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -95,7 +95,11 @@ Configuration comes from **files** and **environment variables**, and env vars
   - Background-worker toggles: `HELM_SIGNALS_DISABLED=1` stops the signal
     scheduler and `HELM_MEMORY_WORKER_DISABLED=1` stops the memory worker (both
     run by default); `HELM_MEMORY_WORKER_INTERVAL_MS` tunes the memory worker
-    tick (default `60000`).
+    tick (default `60000`). Memory catch-up can be tuned with
+    `HELM_MEMORY_WORKER_BATCH_SIZE`, `HELM_MEMORY_WORKER_MAX_BATCHES_PER_DRAIN`,
+    `HELM_MEMORY_WORKER_MAX_DRAIN_MS`, `HELM_MEMORY_WORKER_COALESCE_MS`, and
+    `HELM_MEMORY_WORKER_CONCURRENCY` (default `3`, capped at `8` to avoid a
+    background LLM fan-out spike on small self-hosted machines).
   - Anthropic preset OAuth execution uses `transport_profile: auto` by default,
     which routes final provider execution through the optional Chrome-like
     TLS/JA3 transport (`wreq-js`) instead of undici. Set

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-04 · memory worker 受控并发追赶（Memory worker / scheduler，docs/08/12，原则 3/7）
+
+- **背景（Lukin）**：线上 `/admin/memory` 显示队列持续运行但追赶很慢；生产采样显示 worker 没有卡死，CPU/内存仍有余量，但 open queue 基本维持在约 500，旧 idle-flush backlog 很难明显下降。
+- **根因**：上一版已经把 `batchSize` / `maxBatchesPerDrain` 做大，但 worker 在一个 batch 内仍逐条 `await` LLM 任务。单纯继续调大 batch 只会让更多 job 长时间停在 `running`，不一定提升吞吐，还会让一次 drain 持续更久。
+- **调度决策**：`MemoryWorkerDeps` 新增 `concurrency`，默认 1 以保持 core 旧调用行为；gateway 默认 `HELM_MEMORY_WORKER_CONCURRENCY=3`，同一 claimed batch 内最多并发 3 个 job，让 LLM-bound observer/reflector 任务并行等待上游返回。
+- **安全决策**：gateway 对 `HELM_MEMORY_WORKER_CONCURRENCY` 硬封顶 8；仍保留 `batchSize`、`maxBatchesPerDrain`、`maxDrainMs`、批次间 yield 与 wake debounce，避免在 1GB 自托管容器上产生无上限后台 LLM fan-out。
+- **运维建议**：生产先用默认 3 观察；若 CPU/内存仍低且 `done_1m - enqueued_1m` 不够，可逐步调到 4/5；不要直接把 batch 调到几百来追赶，因为那会增加 running lease 和单轮 drain 风险。
+- **验证计划**：新增 scheduler 并发上限回归，覆盖同 batch 只启动 N 个任务、前一个完成后才启动下一个；再跑 memory scheduler、admin memory 页面、typecheck、lint、build。
+
 ## 2026-07-04 · 记忆页只读运行状态面板（Admin memory observability，docs/08/11/13，原则 1/7）
 
 - **背景（Lukin）**：`/admin/memory` 只能看到已经形成的 facts/reflections，看不到 raw message 是否还在进入、后台 job 是否在跑、队列是否滞后或是否有 running lease 卡住；排障需要直接查日志/SQLite。
@@ -86,18 +95,10 @@
 - **UI 决策**：Keys 页面新增「View full key」和「Rotate」。Reveal/rotated plaintext 只存在短暂 modal state；普通 list/detail 仍只显示 prefix，不返回 hash、plaintext 或 ciphertext。
 - **验证计划**：覆盖 store contract（SQLite/Postgres）、cached keystore、admin routes、admin API client 与 Keys 页面交互；旧 hash-only 行 reveal 失败、新/轮转行可 reveal。
 
-## 2026-07-02 · Claude Fable 周限额改读 `limits[]`（Admin providers / OAuth quota，docs/11，原则 3/7）
-
-- **背景（Lukin）**：Claude Code 的 Plan usage limits 已把 scoped weekly model 用量显示为 `Fable`，不再是旧的 Sonnet 专项行；本机真实 `GET https://api.anthropic.com/api/oauth/usage` 返回中，`seven_day_sonnet` 为 `null`，而 `limits[]` 包含 `kind:"weekly_scoped"` + `scope.model.display_name:"Fable"`。
-- **修复决策**：Anthropic quota parser 优先读取新的 `limits[]`：`session -> 5h`、`weekly_all -> 7d`、`weekly_scoped -> 7d-{model-slug}`，例如 Fable 变成 `7d-fable`；旧 top-level `five_hour/seven_day/seven_day_opus/seven_day_sonnet` 只作为 fallback，保证老 payload 继续可读。
-- **UI 决策**：providers 页 quota label 增加 `7d · Fable`，并为未来 `7d-*` scoped key 提供通用标题化 fallback；避免下一次 Claude 增加 scoped model 时页面又退回原始 key 或显示旧 Sonnet。
-- **价格决策**：`anthropic/claude-fable-5` 已按官方 Anthropic 价格配置为 input `$10/M`、output `$50/M`、cache hit `$1/M`、5-minute cache write `$12.50/M`；官方还有 1-hour cache write `$20/M`，但当前 Helm pricing schema 只有一个 `cacheWritePerMTokUsd`，所以仍记录 5-minute rate，避免在本次小修里扩大 telemetry schema。
-- **验证**：真实上游 usage payload 与 `/v1/models` 已本机核验；新增 parser、gateway quota pull、providers 页面回归测试。目标 parser/admin 页面测试与 typecheck 绿；gateway SQLite 相关测试仍被本机 `better-sqlite3` Node ABI 不匹配阻塞。
-
 ## 历史条目摘要（最近 2 条）
 
+- **2026-07-02 · Claude Fable 周限额改读 `limits[]`（Admin providers / OAuth quota，docs/11，原则 3/7）**：Anthropic quota parser 优先读取新 `limits[]` weekly scoped payload，并在 providers 页显示 `7d · Fable` 等模型级周限额。
 - **2026-07-02 · OAuth 测试成功与 quota PULL 同步账号可用状态（Admin providers / OAuth cooldown，docs/04/11，原则 3/5/7）**：已 park 账号的成功 quota PULL/Test 会用真实 quota 状态替换或清空旧 cooldown，并刷新 providers 页状态。
-- **2026-07-01 · Claude Code 日期指纹入站归一化（Anthropic protocol / native passthrough，docs/05/07，原则 7/8）**：Helm 在 Anthropic native passthrough 与互译路径中归一化 Claude Code 日期指纹，并用 mutation ledger 记录改写；新增 core/gateway 回归覆盖。
 
 ## 更早历史总览
 

--- a/packages/core/src/memory/scheduler.test.ts
+++ b/packages/core/src/memory/scheduler.test.ts
@@ -107,6 +107,38 @@ describe("startMemoryWorker", () => {
     expect(claimSpy).toHaveBeenCalledTimes(3);
   });
 
+  it("processes one claimed batch with bounded concurrency", async () => {
+    const { store } = makeStore([
+      { jobId: "j1", type: "observer", scope: { accountId: "acct-a", threadId: "t1" } },
+      { jobId: "j2", type: "observer", scope: { accountId: "acct-a", threadId: "t2" } },
+      { jobId: "j3", type: "observer", scope: { accountId: "acct-a", threadId: "t3" } },
+    ]);
+    const releases: Array<() => void> = [];
+    const started: string[] = [];
+    const runObserver = vi.fn(
+      (job): Promise<ObserverResult> =>
+        new Promise((resolve) => {
+          started.push(job.jobId);
+          releases.push(() => resolve(OBS_NOOP));
+        }),
+    );
+    const handle = startMemoryWorker(makeDeps(store, { concurrency: 2, runObserver }));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(started).toEqual(["j1", "j2"]);
+
+    releases.shift()?.();
+    await vi.runOnlyPendingTimersAsync();
+    expect(started).toEqual(["j1", "j2", "j3"]);
+
+    releases.shift()?.();
+    releases.shift()?.();
+    await vi.runOnlyPendingTimersAsync();
+    handle.stop();
+
+    expect(runObserver).toHaveBeenCalledTimes(3);
+  });
+
   it("stops catch-up after the drain time cap between batches", async () => {
     let now = 0;
     const { store } = makeStore([]);

--- a/packages/core/src/memory/scheduler.ts
+++ b/packages/core/src/memory/scheduler.ts
@@ -19,6 +19,10 @@ export interface MemoryWorkerDeps {
   memoryStore: MemoryStore;
   // How many jobs to claim per tick.
   batchSize: number;
+  // How many claimed jobs may run at the same time. Defaults to 1 for old
+  // callers/tests; the gateway can raise it modestly to drain LLM-bound backlog
+  // without claiming a huge batch that sits `running` for minutes.
+  concurrency?: number;
   intervalMs: number;
   // Catch-up mode: one interval/wake drain can claim multiple batches back-to-back
   // instead of waiting for the next timer. Defaults to 1 for old callers/tests; the
@@ -204,35 +208,54 @@ async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<vo
 export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
   // Claim + dispatch one batch. The latency-critical path — NO onTick housekeeping
   // (that is the interval's job). Shared by the interval tick and the wake drain.
-  const drainJobs = async (): Promise<number> => {
-    const jobs = await deps.memoryStore.claimPendingJobs(deps.batchSize);
-    for (const job of jobs) {
-      // Per-job guard: a single failing job must not abort the rest of the batch
-      // nor stop the timer (principle 3). The runners record their own outcome on
-      // the row; this catch is the belt-and-braces around everything else.
+  const workerConcurrency = Math.max(1, Math.floor(deps.concurrency ?? 1));
+
+  const runOneJob = async (job: MemoryJobRow): Promise<void> => {
+    // Per-job guard: a single failing job must not abort the rest of the batch
+    // nor stop the timer (principle 3). The runners record their own outcome on
+    // the row; this catch is the belt-and-braces around everything else.
+    try {
+      await processJob(job, deps);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.log("memory.worker.job_failed", {
+        job_id: job.jobId,
+        type: job.type,
+        error: message,
+      });
+      // claimPendingJobs already flipped this row to `running`, and enqueueJob
+      // dedupes against pending AND running rows — swallowing the throw without
+      // closing the row would block this scope's queue FOREVER. Best-effort:
+      // even the failure bookkeeping must never escape the tick.
       try {
-        await processJob(job, deps);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        deps.log("memory.worker.job_failed", {
+        await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
+      } catch (updateErr) {
+        deps.log("memory.worker.job_update_failed", {
           job_id: job.jobId,
-          type: job.type,
-          error: message,
+          error: updateErr instanceof Error ? updateErr.message : String(updateErr),
         });
-        // claimPendingJobs already flipped this row to `running`, and enqueueJob
-        // dedupes against pending AND running rows — swallowing the throw without
-        // closing the row would block this scope's queue FOREVER. Best-effort:
-        // even the failure bookkeeping must never escape the tick.
-        try {
-          await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
-        } catch (updateErr) {
-          deps.log("memory.worker.job_update_failed", {
-            job_id: job.jobId,
-            error: updateErr instanceof Error ? updateErr.message : String(updateErr),
-          });
-        }
       }
     }
+  };
+
+  const processClaimedJobs = async (jobs: MemoryJobRow[]): Promise<void> => {
+    if (jobs.length === 0) return;
+    let next = 0;
+    const runLane = async (): Promise<void> => {
+      while (next < jobs.length) {
+        const job = jobs[next];
+        next += 1;
+        if (job !== undefined) await runOneJob(job);
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(workerConcurrency, jobs.length) }, () => runLane()),
+    );
+  };
+
+  const drainJobs = async (): Promise<number> => {
+    const jobs = await deps.memoryStore.claimPendingJobs(deps.batchSize);
+    await processClaimedJobs(jobs);
     return jobs.length;
   };
 


### PR DESCRIPTION
## Summary
- Replace the memory page fixed refresh button/timer with the shared RefreshControl and persisted cadence menu.
- Add bounded memory worker concurrency via HELM_MEMORY_WORKER_CONCURRENCY, defaulting to 3 and capped at 8.
- Document the memory worker tuning knobs and record the operational decision in implementation notes.

## Why
Production was not stuck, but the queue was barely catching up: the worker had already claimed 50 jobs, yet processed each batch serially. Raising batch size further would mostly create more long-lived running jobs. Bounded concurrency increases LLM-bound throughput while keeping a hard fan-out cap for the 1GB self-hosted container.

## Verification
- corepack pnpm vitest packages/core/src/memory/scheduler.test.ts apps/admin/src/routes/memory/memory.test.ts --run
- corepack pnpm typecheck
- corepack pnpm --filter @helm/admin check
- corepack pnpm lint
- corepack pnpm build
- git diff --check