### PR TITLE
Skip cold idle memory backfill

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -11,6 +11,8 @@
 #                               # uncovered segment reaches this many tokens
 #   idle_flush_s: 3600          # fold a quiet thread's whole uncovered history
 #                               # after this many seconds without a new message
+#   idle_flush_max_age_s: 86400 # optional: skip idle backfill older than this
+#                               # many seconds (unset = process all history)
 #   force_context_ratio: 0.8    # force compaction once the active footprint
 #                               # reaches this fraction of the model's window
 #   min_recent_messages: 4      # keep floor: at least this many recent messages…

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-04 · idle-flush 碎片段优先压缩最大连续段（Memory Observer，docs/08/12，原则 3/7）
+
+- **背景（Lukin）**：线上 `v0.23.0` 后记忆队列仍持续运行，排查发现总候选不是 30 多万 job，而是约 3.07 万个 idle candidate thread；最近完成的 observer 基本不会重新成为候选，未见大面积死循环。
+- **边界问题**：个别超长历史 thread 已被旧 observation 切成很多碎片段。Observer 在 idle 模式下原本选择“第一个可压缩段”，如果最前面只是 1 条 message 的小洞，就会一次 internal LLM 只压缩 1 条，形成有限但很慢的长尾。
+- **调度决策**：idle-flush 下仍然不把稀疏集合写成一个虚假的连续 `source_message_range`；但在多个可压缩连续段之间，优先选择 `compressedTokens` 最大、再按 `compressedCount` 打破平局的段。这样 source range 仍精确，同时优先消掉大尾巴，避免一个超长 thread 反复消耗小段 LLM 调用。
+- **跳过决策**：新增可选 `compaction.idle_flush_max_age_s`，让 idle-flush 只处理最近窗口内变 idle 的 thread；线上可设 `86400` 跳过超过 24 小时的旧 backfill，避免为历史冷数据继续消耗 internal LLM token。未配置时保持旧行为。
+- **保持不变**：非 idle 的 writeback/size/context-pressure 路径仍选最早可压缩段，保持时间顺序和已有 cache/keep 语义；open-job dedupe、worker 并发和 idle candidate SQL 不变。
+- **验证计划**：新增 Observer 回归测试，覆盖 idle 且前方有 tiny gap、大段未覆盖尾部时选择最大段；新增 config/idle-flush/store 回归覆盖 max-age 窗口；再跑目标测试、typecheck、lint、build。
+
 ## 2026-07-04 · memory worker 受控并发追赶（Memory worker / scheduler，docs/08/12，原则 3/7）
 
 - **背景（Lukin）**：线上 `/admin/memory` 显示队列持续运行但追赶很慢；生产采样显示 worker 没有卡死，CPU/内存仍有余量，但 open queue 基本维持在约 500，旧 idle-flush backlog 很难明显下降。
@@ -86,19 +95,10 @@
 - **限制 / TODO**：该接口反映 Helm telemetry 当前保留窗口内的数据；历史上还在 claude-relay 的用量需要 Skillstore 侧保留 legacy baseline 或临时兼容同步，等所有 audit 入口完全切到 Helm 后再移除 relay 补数。
 - **验证计划**：新增 route 测试覆盖缺 key 401、当前 key 聚合、恶意 `key_id` 被忽略；OpenAPI 加入 bearer-secured usage endpoint。
 
-## 2026-07-02 · API key 加密恢复与原地轮转（Auth / Admin keys，docs/06/11，原则 7）
-
-- **背景（Lukin）**：管理后台原本只能创建后一次性显示 API key；如果操作员没有保存完整 key，只能删除或重新创建。现需支持查看已存在 key 的完整值，并支持不丢历史的轮转。
-- **安全决策**：鉴权路径仍只用 `sha256(plaintext)` 查找；数据库不保存明文 key。新增 `api_keys.secret_enc` 只保存 AES-GCM 密文，复用 `HELM_OAUTH_ENC_KEY` 作为 at-rest 加密密钥。未配置该密钥时，新建/轮转仍返回一次性 plaintext，但后续 reveal 不可用。
-- **兼容决策**：已有 hash-only 行无法从 sha256 反推出完整 key，因此管理后台 reveal 会明确返回不可恢复；操作员可对该行执行 rotate，让同一个 `key_id` 获得新的 hash/prefix/secret_enc。
-- **轮转决策**：`KeyStore.rotateKey()` 只替换 `hash`、`prefix`、`secret_enc`，保留 `key_id`、name、role、account、caps、usage 与 telemetry 关联。旧 key 值立即失效，但请求历史仍挂在同一 key 下。
-- **UI 决策**：Keys 页面新增「View full key」和「Rotate」。Reveal/rotated plaintext 只存在短暂 modal state；普通 list/detail 仍只显示 prefix，不返回 hash、plaintext 或 ciphertext。
-- **验证计划**：覆盖 store contract（SQLite/Postgres）、cached keystore、admin routes、admin API client 与 Keys 页面交互；旧 hash-only 行 reveal 失败、新/轮转行可 reveal。
-
 ## 历史条目摘要（最近 2 条）
 
+- **2026-07-02 · API key 加密恢复与原地轮转（Auth / Admin keys，docs/06/11，原则 7）**：API key reveal/rotate 使用 `secret_enc` 保存可恢复密文，认证仍只依赖 sha256，旧 hash-only 行需 rotate 后才可 reveal。
 - **2026-07-02 · Claude Fable 周限额改读 `limits[]`（Admin providers / OAuth quota，docs/11，原则 3/7）**：Anthropic quota parser 优先读取新 `limits[]` weekly scoped payload，并在 providers 页显示 `7d · Fable` 等模型级周限额。
-- **2026-07-02 · OAuth 测试成功与 quota PULL 同步账号可用状态（Admin providers / OAuth cooldown，docs/04/11，原则 3/5/7）**：已 park 账号的成功 quota PULL/Test 会用真实 quota 状态替换或清空旧 cooldown，并刷新 providers 页状态。
 
 ## 更早历史总览
 

--- a/packages/core/src/memory/compaction-policy.test.ts
+++ b/packages/core/src/memory/compaction-policy.test.ts
@@ -250,8 +250,13 @@ describe("resolveCompactionTunables — config overrides over internal priors", 
   });
 
   it("a written override wins per-field; omitted siblings keep their priors", () => {
-    const t = resolveCompactionTunables({ idle_flush_s: 7200, force_context_ratio: 0.9 });
+    const t = resolveCompactionTunables({
+      idle_flush_s: 7200,
+      idle_flush_max_age_s: 86_400,
+      force_context_ratio: 0.9,
+    });
     expect(t.idleFlushS).toBe(7200);
+    expect(t.idleFlushMaxAgeS).toBe(86_400);
     expect(t.forceContextRatio).toBe(0.9);
     expect(t.segmentMinTokens).toBe(AUTO_PRIORS.segmentMinTokens);
     expect(t.minRecentMessages).toBe(AUTO_PRIORS.minRecentMessages);

--- a/packages/core/src/memory/compaction-policy.ts
+++ b/packages/core/src/memory/compaction-policy.ts
@@ -89,6 +89,7 @@ export const AUTO_PRIORS = {
 export interface CompactionTunables {
   segmentMinTokens: number;
   idleFlushS: number;
+  idleFlushMaxAgeS?: number;
   forceContextRatio: number;
   minRecentMessages: number;
   minKeepRatio: number;
@@ -97,6 +98,7 @@ export interface CompactionTunables {
 export function resolveCompactionTunables(overrides?: {
   segment_min_tokens?: number;
   idle_flush_s?: number;
+  idle_flush_max_age_s?: number;
   force_context_ratio?: number;
   min_recent_messages?: number;
   min_keep_ratio?: number;
@@ -104,6 +106,9 @@ export function resolveCompactionTunables(overrides?: {
   return {
     segmentMinTokens: overrides?.segment_min_tokens ?? AUTO_PRIORS.segmentMinTokens,
     idleFlushS: overrides?.idle_flush_s ?? AUTO_PRIORS.idleFlushS,
+    ...(overrides?.idle_flush_max_age_s !== undefined
+      ? { idleFlushMaxAgeS: overrides.idle_flush_max_age_s }
+      : {}),
     forceContextRatio: overrides?.force_context_ratio ?? AUTO_PRIORS.forceContextRatio,
     minRecentMessages: overrides?.min_recent_messages ?? AUTO_PRIORS.minRecentMessages,
     minKeepRatio: overrides?.min_keep_ratio ?? AUTO_PRIORS.minKeepRatio,

--- a/packages/core/src/memory/idle-flush.test.ts
+++ b/packages/core/src/memory/idle-flush.test.ts
@@ -88,6 +88,17 @@ describe("maybeEnqueueIdleObserverJobs", () => {
     });
   });
 
+  it("passes idle_flush_max_age_s as a lower activity bound to skip cold backfill", async () => {
+    const { store } = makeStore([]);
+    const deps = { ...makeDeps(store), compaction: { idle_flush_max_age_s: 86_400 } };
+    await maybeEnqueueIdleObserverJobs(deps);
+    expect(store.listIdleFlushCandidates).toHaveBeenCalledWith({
+      idleBeforeMs: new Date("2026-06-05T00:00:00.000Z").getTime() - AUTO_PRIORS.idleFlushS * 1000,
+      idleAfterMs: new Date("2026-06-05T00:00:00.000Z").getTime() - 86_400 * 1000,
+      limit: 100,
+    });
+  });
+
   it("is a no-op when no thread is idle", async () => {
     const { store, enqueued } = makeStore([]);
     await maybeEnqueueIdleObserverJobs(makeDeps(store));

--- a/packages/core/src/memory/idle-flush.ts
+++ b/packages/core/src/memory/idle-flush.ts
@@ -47,12 +47,16 @@ export async function maybeEnqueueIdleObserverJobs(deps: IdleFlushDeps): Promise
   }
 
   try {
-    const idleBeforeMs =
-      deps.now().getTime() - resolveCompactionTunables(deps.compaction).idleFlushS * 1000;
-    const candidates = await listCandidates.call(deps.memoryStore, {
-      idleBeforeMs,
+    const nowMs = deps.now().getTime();
+    const tunables = resolveCompactionTunables(deps.compaction);
+    const input: { idleBeforeMs: number; idleAfterMs?: number; limit: number } = {
+      idleBeforeMs: nowMs - tunables.idleFlushS * 1000,
       limit: deps.batchSize,
-    });
+    };
+    if (tunables.idleFlushMaxAgeS !== undefined) {
+      input.idleAfterMs = nowMs - tunables.idleFlushMaxAgeS * 1000;
+    }
+    const candidates = await listCandidates.call(deps.memoryStore, input);
     for (const { accountId, threadId, projectId, resourceId } of candidates) {
       // Per-thread guard: one thread's enqueue failure must not skip the rest.
       try {

--- a/packages/core/src/memory/observer.test.ts
+++ b/packages/core/src/memory/observer.test.ts
@@ -303,6 +303,22 @@ describe("runObserverJob", () => {
     expect(jobUpdates).toContainEqual({ jobId: "job-1", status: "done" });
   });
 
+  it("prefers the largest idle uncovered segment over a tiny leading gap", async () => {
+    const messages = makeMessages(10, 10);
+    const { store, observations } = makeFakeStore(messages, [
+      ["m2", "m3"],
+      ["m5", "m5"],
+    ]);
+    const deps = makeDeps(store, { now: () => new Date(NOW.getTime() + 2 * 3_600_000) });
+
+    const out = await runObserverJob(JOB, deps);
+
+    expect(observations).toHaveLength(1);
+    expect(observations[0]?.sourceMessageRange).toEqual(["m6", "m10"]);
+    expect(observations[0]?.observationText).toContain("Observed 5 msgs");
+    expect(out.sourceMessageRange).toEqual(["m6", "m10"]);
+  });
+
   it("resolves pricing from the thread's stamped model via getThreadMeta", async () => {
     const messages = makeMessages(8);
     const { store } = makeFakeStore(messages);

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -429,7 +429,23 @@ export async function runObserverJob(
       segment,
       decision: chooseAutoCompaction(segment, inputs),
     }));
-    const selected = decisions.find(({ decision }) => decision.shouldCompact);
+    // In idle-flush catch-up, a historical thread can be fragmented by older
+    // observations: tiny one-message gaps before a large uncovered tail. Pick the
+    // largest compactable segment first so one quiet thread cannot burn one LLM
+    // call per tiny gap while still keeping every source range exact.
+    const selected = idle
+      ? decisions.reduce<(typeof decisions)[number] | undefined>(
+          (best, item) =>
+            item.decision.shouldCompact &&
+            (best === undefined ||
+              item.decision.compressedTokens > best.decision.compressedTokens ||
+              (item.decision.compressedTokens === best.decision.compressedTokens &&
+                item.decision.compressedCount > best.decision.compressedCount))
+              ? item
+              : best,
+          undefined,
+        )
+      : decisions.find(({ decision }) => decision.shouldCompact);
     if (selected === undefined) {
       // No compaction this run → mine the uncovered turns for durable facts.
       await maybeEagerExtractFacts(job, all, covered, deps);

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -877,6 +877,7 @@ export interface MemoryStore {
   // additive — pre-phase fixtures stay valid; the sweep null-checks.
   listIdleFlushCandidates?(input: {
     idleBeforeMs: number;
+    idleAfterMs?: number;
     limit: number;
   }): Promise<
     Array<{ accountId: string; threadId: string; projectId?: string; resourceId?: string }>

--- a/packages/core/src/store/postgres/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/postgres/memory-auto-compaction.test.ts
@@ -106,6 +106,13 @@ describe("PgMemoryStore — idle-flush candidates", () => {
       limit: 10,
     });
     expect(candidates).toEqual([{ accountId: "acct-a", threadId: "tA" }]);
+    expect(
+      await store.listIdleFlushCandidates({
+        idleBeforeMs: clock() + 1000,
+        idleAfterMs: clock() + 1000,
+        limit: 10,
+      }),
+    ).toEqual([]);
     await db.$close();
   });
 

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -1754,10 +1754,12 @@ export class PgMemoryStore implements MemoryStore {
   // monopolize the worker's small per-tick page.
   async listIdleFlushCandidates(input: {
     idleBeforeMs: number;
+    idleAfterMs?: number;
     limit: number;
   }): Promise<
     Array<{ accountId: string; threadId: string; projectId?: string; resourceId?: string }>
   > {
+    const idleAfterMs = input.idleAfterMs ?? null;
     const result = (await this.db.execute(sql`
       WITH candidates AS (
         SELECT t.owner_id AS owner_id, t.id AS thread_id,
@@ -1768,6 +1770,9 @@ export class PgMemoryStore implements MemoryStore {
          WHERE t.owner_id IS NOT NULL
            AND (SELECT MAX(m.created_at) FROM memory_messages m WHERE m.thread_id = t.id)
                  <= ${input.idleBeforeMs}
+           AND (${idleAfterMs}::bigint IS NULL OR
+                (SELECT MAX(m.created_at) FROM memory_messages m WHERE m.thread_id = t.id)
+                  >= ${idleAfterMs})
            AND EXISTS (
              -- A message NOT covered by ANY observation's [first,last] range,
              -- using the SAME order as listMessages/Observer.

--- a/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
@@ -88,6 +88,14 @@ describe("SqliteMemoryStore — idle-flush candidates", () => {
     expect(await store.listIdleFlushCandidates({ idleBeforeMs: afterActivity, limit: 10 })).toEqual(
       [{ accountId: "acct-a", threadId: "t1" }],
     );
+    // Too old for the configured backfill window → skipped.
+    expect(
+      await store.listIdleFlushCandidates({
+        idleBeforeMs: afterActivity,
+        idleAfterMs: afterActivity,
+        limit: 10,
+      }),
+    ).toEqual([]);
   });
 
   it("a fully-covered thread leaves the candidate set (sweep terminates)", async () => {

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -1966,6 +1966,7 @@ export class SqliteMemoryStore implements MemoryStore {
   // backlog cannot monopolize the worker's small per-tick page.
   async listIdleFlushCandidates(input: {
     idleBeforeMs: number;
+    idleAfterMs?: number;
     limit: number;
   }): Promise<
     Array<{ accountId: string; threadId: string; projectId?: string; resourceId?: string }>
@@ -1981,6 +1982,7 @@ export class SqliteMemoryStore implements MemoryStore {
             WHERE t.owner_id IS NOT NULL
               AND last_activity IS NOT NULL
               AND last_activity <= ?
+              AND (? IS NULL OR last_activity >= ?)
               AND EXISTS (
                 -- A message NOT covered by ANY observation's [first,last] range,
                 -- using the SAME order as listMessages/Observer. Interval
@@ -2056,7 +2058,12 @@ export class SqliteMemoryStore implements MemoryStore {
            ORDER BY scope_rank ASC, last_activity ASC, thread_id ASC
            LIMIT ?`,
       )
-      .all(input.idleBeforeMs, input.limit) as Array<{
+      .all(
+        input.idleBeforeMs,
+        input.idleAfterMs ?? null,
+        input.idleAfterMs ?? null,
+        input.limit,
+      ) as Array<{
       owner_id: string;
       thread_id: string;
       project_id: string | null;

--- a/packages/shared/src/config/memory-schema.test.ts
+++ b/packages/shared/src/config/memory-schema.test.ts
@@ -124,12 +124,16 @@ describe("CompactionOverridesSchema (via MemoryConfigSchema.compaction)", () => 
     expect(m.compaction).toEqual({});
     expect(m.compaction.segment_min_tokens).toBeUndefined();
     expect(m.compaction.idle_flush_s).toBeUndefined();
+    expect(m.compaction.idle_flush_max_age_s).toBeUndefined();
     expect(m.compaction.force_context_ratio).toBeUndefined();
   });
 
   it("a written override round-trips; omitted siblings are NOT materialized", () => {
-    const m = MemoryConfigSchema.parse({ compaction: { idle_flush_s: 7200 } });
+    const m = MemoryConfigSchema.parse({
+      compaction: { idle_flush_s: 7200, idle_flush_max_age_s: 86_400 },
+    });
     expect(m.compaction.idle_flush_s).toBe(7200);
+    expect(m.compaction.idle_flush_max_age_s).toBe(86_400);
     // No .default() materialization — the merge/no-lying-knob contract.
     expect("segment_min_tokens" in m.compaction).toBe(false);
     expect("force_context_ratio" in m.compaction).toBe(false);
@@ -142,6 +146,7 @@ describe("CompactionOverridesSchema (via MemoryConfigSchema.compaction)", () => 
     expect(() => MemoryConfigSchema.parse({ compaction: { force_context_ratio: 1.2 } })).toThrow();
     expect(() => MemoryConfigSchema.parse({ compaction: { segment_min_tokens: -1 } })).toThrow();
     expect(() => MemoryConfigSchema.parse({ compaction: { idle_flush_s: 0 } })).toThrow();
+    expect(() => MemoryConfigSchema.parse({ compaction: { idle_flush_max_age_s: 0 } })).toThrow();
     expect(() => MemoryConfigSchema.parse({ compaction: { min_keep_ratio: 1.5 } })).toThrow();
   });
 });

--- a/packages/shared/src/config/memory-schema.ts
+++ b/packages/shared/src/config/memory-schema.ts
@@ -154,6 +154,10 @@ export const CompactionOverridesSchema = z
     // Idle flush: fold a quiet thread's whole uncovered history after this many
     // seconds without a new message (internal default 3600).
     idle_flush_s: z.number().int().positive().optional(),
+    // Optional backfill window: when set, idle-flush only considers threads whose
+    // last activity is newer than now - idle_flush_max_age_s. This lets operators
+    // skip very old cold history instead of spending background LLM tokens on it.
+    idle_flush_max_age_s: z.number().int().positive().optional(),
     // Context-pressure safety valve: force compaction once the active footprint
     // reaches this fraction of the served model's context window (default 0.8).
     force_context_ratio: z.number().gt(0).max(1).optional(),


### PR DESCRIPTION
## Summary
- Add `compaction.idle_flush_max_age_s` so idle-flush can skip very old cold history instead of enqueueing it forever as backfill.
- Pass the max-age window through idle-flush into SQLite/Postgres candidate queries.
- In idle catch-up, prefer the largest uncovered contiguous segment before tiny gaps so one fragmented long thread does not burn one internal LLM call per tiny range.

## Production note
The live worker was temporarily paused with `HELM_MEMORY_WORKER_DISABLED=1` to stop immediate internal LLM token burn. After this lands and deploys, set `compaction.idle_flush_max_age_s: 86400`, mark old open idle-backfill observer jobs done/skipped, then restore the worker.

## Verification
- corepack pnpm vitest packages/shared/src/config/memory-schema.test.ts packages/core/src/memory/compaction-policy.test.ts packages/core/src/memory/idle-flush.test.ts packages/core/src/memory/observer.test.ts packages/core/src/store/sqlite/memory-auto-compaction.test.ts --run
- corepack pnpm vitest packages/core/src/store/postgres/memory-auto-compaction.test.ts --run
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build
- git diff --check