### PR TITLE
Add OAuth account affinity scheduler

### DIFF
--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1,5 +1,6 @@
 import {
   __setWreqModuleForTesting,
+  createKeyedSerialGate,
   createSqliteDb,
   encryptSecret,
   SqliteConfigStore,
@@ -499,5 +500,136 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       service_tier: "default",
     });
     expect(sentBody).toEqual(expect.objectContaining({ service_tier: "priority" }));
+  });
+
+  it("synthesizes capacity-aware account selection from the shared user-message queue", async () => {
+    const { ctx, config } = oauthStores();
+    for (const account of ["a", "b"]) {
+      await ctx.store.upsert({
+        providerId: "openai-codex",
+        account,
+        accessEnc: encryptSecret(`access-${account}`, ENC_KEY),
+        refreshEnc: encryptSecret(`refresh-${account}`, ENC_KEY),
+        expiresAt: FAR_FUTURE,
+        meta: null,
+        updatedAt: 1,
+      });
+      await setAccountSettings(config, ENC_KEY, "openai-codex", account, {
+        enabledModels: ["gpt-5.5"],
+        priority: 50,
+      });
+    }
+
+    const gate = createKeyedSerialGate();
+    const held = await gate.acquire({
+      key: "openai-codex a",
+      delayMs: 0,
+      timeoutMs: 5_000,
+    });
+    expect(held.ok).toBe(true);
+    const authHeaders: string[] = [];
+    const logs: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      authHeaders.push(new Headers(init?.headers).get("authorization") ?? "");
+      return sseResponse([
+        { type: "response.output_item.added", item: { type: "message", role: "assistant" } },
+        { type: "response.output_text.delta", delta: "ok" },
+        { type: "response.completed", response: { status: "completed", usage: {} } },
+      ]);
+    });
+
+    const { poolClients } = await synthesizeOAuthProviders(
+      [],
+      ctx,
+      config,
+      "https://fallback/v1",
+      60_000,
+      (_lvl, msg, fields) => logs.push({ msg, fields }),
+      undefined,
+      {
+        gate,
+        getConfig: () => ({ enabled: true, delayMs: 0, timeoutMs: 5_000 }),
+      },
+    );
+
+    await poolClients.get("openai-codex")?.chatCompletion({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "hi" }],
+      prompt_cache_key: "stick-a",
+    });
+
+    // stick-a hashes to account "a", but account a is already holding the queue
+    // lease, so the synthesized pool commits this request to account b.
+    expect(authHeaders).toEqual(["Bearer access-b"]);
+    const selectLog = logs.find((l) => l.msg === "oauth.pool.select");
+    expect(selectLog?.fields).toMatchObject({
+      providerId: "openai-codex",
+      account: "b",
+      selection_reason: "hash_assign",
+      affinity_key_source: "prompt_cache_key",
+      capacity_avoided: true,
+      busy_eligible_accounts: 1,
+      retry_attempt: 0,
+    });
+    if (held.ok) held.release();
+  });
+
+  it("does not steer away from the sticky target when the shared queue is disabled", async () => {
+    const { ctx, config } = oauthStores();
+    for (const account of ["a", "b"]) {
+      await ctx.store.upsert({
+        providerId: "openai-codex",
+        account,
+        accessEnc: encryptSecret(`access-${account}`, ENC_KEY),
+        refreshEnc: encryptSecret(`refresh-${account}`, ENC_KEY),
+        expiresAt: FAR_FUTURE,
+        meta: null,
+        updatedAt: 1,
+      });
+      await setAccountSettings(config, ENC_KEY, "openai-codex", account, {
+        enabledModels: ["gpt-5.5"],
+        priority: 50,
+      });
+    }
+
+    const gate = createKeyedSerialGate();
+    const held = await gate.acquire({
+      key: "openai-codex a",
+      delayMs: 0,
+      timeoutMs: 5_000,
+    });
+    expect(held.ok).toBe(true);
+    const authHeaders: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      authHeaders.push(new Headers(init?.headers).get("authorization") ?? "");
+      return sseResponse([
+        { type: "response.output_item.added", item: { type: "message", role: "assistant" } },
+        { type: "response.output_text.delta", delta: "ok" },
+        { type: "response.completed", response: { status: "completed", usage: {} } },
+      ]);
+    });
+
+    const { poolClients } = await synthesizeOAuthProviders(
+      [],
+      ctx,
+      config,
+      "https://fallback/v1",
+      60_000,
+      noop,
+      undefined,
+      {
+        gate,
+        getConfig: () => ({ enabled: false, delayMs: 0, timeoutMs: 5_000 }),
+      },
+    );
+
+    await poolClients.get("openai-codex")?.chatCompletion({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "hi" }],
+      prompt_cache_key: "stick-a",
+    });
+
+    expect(authHeaders).toEqual(["Bearer access-a"]);
+    if (held.ok) held.release();
   });
 });

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -569,11 +569,12 @@ export async function synthesizeOAuthProviders(
       // Serialize user-message requests per account (issue #93, feature B). The
       // wrap sits INSIDE the pool member so the gate key is the concrete account
       // the pool selected; non-user turns and a disabled setting pass through.
+      const queueKey = `${providerId} ${account}`;
       const serialized = userMessageQueue
         ? createSerializingClient({
             inner: client,
             gate: userMessageQueue.gate,
-            key: `${providerId} ${account}`,
+            key: queueKey,
             getConfig: userMessageQueue.getConfig,
             isUserMessage: isUserMessageRequest,
             log: (lvl, msg, fields) => log(lvl, msg, fields),
@@ -584,6 +585,15 @@ export async function synthesizeOAuthProviders(
         priority: s.priority ?? 50,
         schedulable: true,
         client: serialized,
+        isAtCapacity: userMessageQueue
+          ? () => {
+              const qc = userMessageQueue.getConfig();
+              return (
+                qc.enabled &&
+                userMessageQueue.gate.wouldQueue({ key: queueKey, delayMs: qc.delayMs })
+              );
+            }
+          : undefined,
         // Seed the auto-park cooldown from the persisted snapshot (survives restart /
         // rebuild). A past timestamp is harmless — select() treats now>=until as
         // eligible — so stale seeds self-clear.
@@ -600,8 +610,17 @@ export async function synthesizeOAuthProviders(
     const pool = createOAuthPoolClient({
       members,
       now: () => Date.now(),
-      onSelect: (account) => {
-        log("info", "oauth.pool.select", { providerId, account });
+      onSelect: (account, selection) => {
+        log("info", "oauth.pool.select", {
+          providerId,
+          account,
+          selection_reason: selection.reason,
+          affinity_key_source: selection.affinityKeySource,
+          capacity_avoided: selection.capacityAvoided,
+          all_candidates_at_capacity: selection.allCandidatesAtCapacity,
+          busy_eligible_accounts: selection.busyEligibleAccounts,
+          retry_attempt: selection.retryAttempt,
+        });
         // Stamp the per-request holder so the route's settle path can attribute
         // today's usage to THIS subscription (providers page Tier 2). No-op when
         // not inside a capture scope (fail-open; never throws).

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-07-04 · OAuth 账号池改为会话亲和调度（OAuth provider pool / routing，docs/04/11，原则 3/5/7）
+
+- **背景（Lukin）**：订阅 provider 有多个账号时，单纯 priority + LRU 轮询会让同一客户端会话在多个账号/多个上游设备身份之间漂移，容易呈现“账号池”特征。目标是同一 session/device 尽量固定到同一账号，只有账号不可用、额度/限流、或账号容量已满时才切换，同时让多个账号在新会话维度尽量均衡使用。
+- **调度决策**：OAuth pool 优先从显式 `device_id` / `metadata.device_id` / `metadata.user_id` JSON envelope 里的 `device_id` 生成 affinity key；没有 device 信号时再使用 `prompt_cache_key`、`session_id`、`conversation_id`、`metadata.session_id/conversation_id/thread_id/user_id` 等稳定会话信号。有 key 时在最低 priority 的可用账号集合里用 rendezvous hashing 选择账号，保证新会话均衡分布且进程重启后仍尽量落到同一账号。无 key 的请求保留原 LRU 行为。
+- **Responses 连续性决策**：`previous_response_id` 不再作为 hashable affinity key，因为它会随轮次变化；只有 pool 已经从成功的非流式响应 `id` / `response.id` 记录过“这个 response 由哪个账号产生”时，后续同 id 才作为 sticky hit 回到原账号。未知 `previous_response_id` 回到 LRU，不制造假粘性。
+- **容量决策**：per-account user-message queue 新增 `wouldQueue()` 探针。账号被锁住、已有等待者、或仍在请求间隔窗口内时，pool 会优先选择同池其它可用账号；若所有账号都会排队，则回到 deterministic target 并让队列等待，避免无账号可用时误报 provider down。用户 turn 判定同时覆盖 Chat `messages[]` 和 Responses `input`，避免 Codex native `/v1/responses` 绕过队列。
+- **切换边界**：401/403、429/usage cooldown、pre-output transient fault、以及账号队列 timeout 都作为账号级切换原因处理；确定性 4xx 仍不切 sibling。账号级限流仍会 forget 当前 sticky，避免后续会话继续命中不可用账号。
+- **观测决策**：`oauth.pool.select` 日志只记录非敏感选择元信息（`selection_reason`、`affinity_key_source`、`capacity_avoided`、`busy_eligible_accounts`、`retry_attempt`），不记录具体 device/session key 值，便于生产验收“切换只因故障/额度/容量压力”。
+- **验证计划**：新增 OAuth pool affinity/capacity 单测、serial gate `wouldQueue()` 单测、gateway `synthesizeOAuthProviders` 集成测试；再跑相关执行器回归、全量 Vitest、typecheck、lint、build 和 Playwright e2e。
+
 ## 2026-07-04 · idle-flush 碎片段优先压缩最大连续段（Memory Observer，docs/08/12，原则 3/7）
 
 - **背景（Lukin）**：线上 `v0.23.0` 后记忆队列仍持续运行，排查发现总候选不是 30 多万 job，而是约 3.07 万个 idle candidate thread；最近完成的 observer 基本不会重新成为候选，未见大面积死循环。
@@ -86,19 +96,10 @@
 - **保留边界**：非上下文类 request-shape 错误（例如图片尺寸超限、非法参数）仍短路为 `invalid_request`，因为换候选模型无法修复请求体本身。
 - **验证**：新增执行器 stream 回归测试，覆盖 Codex Responses `context_length_exceeded` 先失败、后续 Opus 成功、首个 attempt 显示跳过且不记录 breaker failure；目标 `execute.test.ts` 117/117 绿。
 
-## 2026-07-03 · API key 级 usage stats 给外部自动化读取（Gateway usage API / telemetry，docs/07，原则 7）
-
-- **背景（Lukin）**：Skillstore 公开页需要每天同步 AI audit token / cost 快照；旧办法直接从 Helm SQLite 和 claude-relay Redis 取数，不适合作为长期自动化接口。新的来源应主要走 Helm 系统，并通过 API key 读取统计数据。
-- **接口决策**：新增 `GET /v1/usage/stats`，复用现有 API-key auth，不挂 admin Basic Auth。默认 `start=0`、`end=now`，返回当前 key 的累计 request/token/cost 汇总；仍接受 `start/end/bucket/tzOffsetMinutes` 以便后续做日窗口或趋势同步。
-- **隔离决策**：接口忽略 caller 传入的 `key_id`，只使用 `authMiddleware` 解析出的 `identity.keyId` 调 `TelemetryStore.aggregate(..., keyId)`；这样 Skillstore workflow 只能读它自己的 Helm key，不可能枚举其它 key 的用量。
-- **返回形状**：返回紧凑 snake_case 机器格式：`prompt_tokens`、`completion_tokens`、`total_tokens`、`cost_usd` 等，避免让下游 workflow 依赖 admin dashboard 的 series/byModel 大结构。
-- **限制 / TODO**：该接口反映 Helm telemetry 当前保留窗口内的数据；历史上还在 claude-relay 的用量需要 Skillstore 侧保留 legacy baseline 或临时兼容同步，等所有 audit 入口完全切到 Helm 后再移除 relay 补数。
-- **验证计划**：新增 route 测试覆盖缺 key 401、当前 key 聚合、恶意 `key_id` 被忽略；OpenAPI 加入 bearer-secured usage endpoint。
-
 ## 历史条目摘要（最近 2 条）
 
-- **2026-07-02 · API key 加密恢复与原地轮转（Auth / Admin keys，docs/06/11，原则 7）**：API key reveal/rotate 使用 `secret_enc` 保存可恢复密文，认证仍只依赖 sha256，旧 hash-only 行需 rotate 后才可 reveal。
-- **2026-07-02 · Claude Fable 周限额改读 `limits[]`（Admin providers / OAuth quota，docs/11，原则 3/7）**：Anthropic quota parser 优先读取新 `limits[]` weekly scoped payload，并在 providers 页显示 `7d · Fable` 等模型级周限额。
+- **2026-07-03 · API key 级 usage stats 给外部自动化读取（Gateway usage API / telemetry，docs/07，原则 7）**：`GET /v1/usage/stats` 复用 API-key auth，只聚合当前 key 的 request/token/cost 统计，避免外部自动化直接读库。
+- **2026-07-02 · API key 加密恢复与原地轮转（Auth / Admin keys，docs/06/11，原则 7）**：API key reveal/rotate 改用 `secret_enc` 恢复材料，鉴权仍只依赖 sha256，历史 hash-only key 明确不可恢复但可原地轮转。
 
 ## 更早历史总览
 

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -29,6 +29,10 @@ function member(
 }
 
 const REQ: ChatCompletionRequest = { model: "m", messages: [] };
+const USER_REQ: ChatCompletionRequest = {
+  model: "m",
+  messages: [{ role: "user", content: "hi" }],
+};
 
 describe("createOAuthPoolClient — account selection", () => {
   it("prefers the lowest priority (lower = preferred)", async () => {
@@ -57,6 +61,274 @@ describe("createOAuthPoolClient — account selection", () => {
     await pool.chatCompletion(REQ);
     await pool.chatCompletion(REQ);
     expect(calls).toEqual(["a", "b", "a", "b"]);
+  });
+
+  it("keeps a chat prompt_cache_key on one deterministic account", async () => {
+    const calls: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [member("a", 50, true, calls), member("b", 50, true, calls)],
+      onSelect: (acc) => selected.push(acc),
+    });
+
+    const req = { ...USER_REQ, prompt_cache_key: "thread-a" };
+    await pool.chatCompletion(req);
+    await pool.chatCompletion(req);
+    await pool.chatCompletion(req);
+
+    // thread-a hashes to b; repeated turns do not LRU-rotate across accounts.
+    expect(calls).toEqual(["b", "b", "b"]);
+    expect(selected).toEqual(["b", "b", "b"]);
+  });
+
+  it("uses chat metadata conversation_id as a sticky account key for streams", async () => {
+    const calls: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [member("a", 50, true, calls), member("b", 50, true, calls)],
+      onSelect: (acc) => selected.push(acc),
+    });
+    const req = { ...USER_REQ, metadata: { conversation_id: "conv-b" } };
+
+    for await (const _ of pool.chatCompletionStream(req)) {
+      /* drain first stream */
+    }
+    for await (const _ of pool.chatCompletionStream(req)) {
+      /* drain second stream */
+    }
+
+    // conv-b hashes to a; streaming now follows the same affinity rule as non-stream.
+    expect(calls).toEqual(["a", "a"]);
+    expect(selected).toEqual(["a", "a"]);
+  });
+
+  it("spreads distinct sticky sessions across equal-priority accounts", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [member("a", 50, true, calls), member("b", 50, true, calls)],
+    });
+
+    await pool.chatCompletion({ ...USER_REQ, metadata: { conversation_id: "conv-b" } });
+    await pool.chatCompletion({ ...USER_REQ, prompt_cache_key: "thread-a" });
+
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("keeps new sticky-session distribution reasonably balanced across equal-priority accounts", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        member("a", 50, true, calls),
+        member("b", 50, true, calls),
+        member("c", 50, true, calls),
+      ],
+    });
+
+    for (let i = 0; i < 300; i += 1) {
+      await pool.chatCompletion({ ...USER_REQ, prompt_cache_key: `session-${i}` });
+    }
+
+    const counts = new Map<string, number>();
+    for (const account of calls) counts.set(account, (counts.get(account) ?? 0) + 1);
+    expect(counts.size).toBe(3);
+    for (const count of counts.values()) {
+      expect(count).toBeGreaterThan(70);
+      expect(count).toBeLessThan(130);
+    }
+  });
+
+  it("prefers a stable metadata.user_id device id over changing chat session signals", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [member("a", 50, true, calls), member("b", 50, true, calls)],
+    });
+    const userId = (session: string) =>
+      JSON.stringify({ device_id: "device-stable-1", account_uuid: "", session_id: session });
+
+    await pool.chatCompletion({
+      ...USER_REQ,
+      prompt_cache_key: "thread-a",
+      metadata: { user_id: userId("session-1") },
+    });
+    await pool.chatCompletion({
+      ...USER_REQ,
+      metadata: { conversation_id: "conv-b", user_id: userId("session-2") },
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toBe(calls[0]);
+  });
+
+  it("uses an explicit metadata device_id as chat account affinity", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [member("a", 50, true, calls), member("b", 50, true, calls)],
+    });
+
+    await pool.chatCompletion({
+      ...USER_REQ,
+      prompt_cache_key: "thread-a",
+      metadata: { device_id: "device-explicit-1" },
+    });
+    await pool.chatCompletion({
+      ...USER_REQ,
+      metadata: { conversation_id: "conv-b", device_id: "device-explicit-1" },
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toBe(calls[0]);
+  });
+
+  it("maps a known previous_response_id back to the account that produced it", async () => {
+    const calls: string[] = [];
+    const responseMember = (account: string): OAuthPoolMember => ({
+      account,
+      priority: 50,
+      schedulable: true,
+      client: {
+        async chatCompletion(_req: ChatCompletionRequest) {
+          calls.push(account);
+          return { id: `resp-${account}`, served_by: account };
+        },
+        async *chatCompletionStream(_req: ChatCompletionRequest) {
+          calls.push(account);
+          yield `data: ${account}\n\n`;
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [responseMember("a"), responseMember("b")],
+    });
+
+    await pool.chatCompletion(REQ);
+    await pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-a" });
+
+    expect(calls).toEqual(["a", "a"]);
+  });
+
+  it("does not hash an unknown previous_response_id as a fake stable account key", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [member("a", 50, true, calls), member("b", 50, true, calls)],
+    });
+
+    await pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-1" });
+    await pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-2" });
+
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("does not let previous_response_id override a stable chat user key", async () => {
+    const calls: string[] = [];
+    const responseMember = (account: string): OAuthPoolMember => ({
+      account,
+      priority: 50,
+      schedulable: true,
+      client: {
+        async chatCompletion(_req: ChatCompletionRequest) {
+          calls.push(account);
+          return { id: `resp-${account}`, served_by: account };
+        },
+        async *chatCompletionStream(_req: ChatCompletionRequest) {
+          calls.push(account);
+          yield `data: ${account}\n\n`;
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [responseMember("a"), responseMember("b")],
+    });
+
+    await pool.chatCompletion(REQ);
+    await pool.chatCompletion({
+      ...USER_REQ,
+      user: "stable-user",
+      previous_response_id: "resp-a",
+    });
+
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("keeps sticky hashing inside the lowest-priority eligible tier", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [member("a", 10, true, calls), member("b", 50, true, calls)],
+    });
+
+    await pool.chatCompletion({ ...USER_REQ, prompt_cache_key: "thread-a" });
+
+    // thread-a hashes to b when both accounts are equal priority, but b is a lower
+    // preference tier here. Priority still wins before affinity distribution.
+    expect(calls).toEqual(["a"]);
+  });
+
+  it("uses a lower-priority account when the whole preferred tier is at capacity", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...member("a", 10, true, calls), isAtCapacity: () => true },
+        member("b", 50, true, calls),
+      ],
+    });
+
+    await pool.chatCompletion({ ...USER_REQ, metadata: { conversation_id: "conv-b" } });
+
+    // conv-b normally maps to preferred account a, but a would queue and b is open.
+    expect(calls).toEqual(["b"]);
+  });
+
+  it("prefers another account when the sticky target is at capacity", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...member("a", 50, true, calls), isAtCapacity: () => true },
+        member("b", 50, true, calls),
+      ],
+    });
+
+    await pool.chatCompletion({ ...USER_REQ, metadata: { conversation_id: "conv-b" } });
+
+    // conv-b normally hashes to a, but a would queue, so the request moves to b.
+    expect(calls).toEqual(["b"]);
+  });
+
+  it("prefers another account when a chat stream sticky target is at capacity", async () => {
+    const calls: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...member("a", 50, true, calls), isAtCapacity: () => true },
+        member("b", 50, true, calls),
+      ],
+      onSelect: (acc) => selected.push(acc),
+    });
+
+    const chunks: string[] = [];
+    for await (const c of pool.chatCompletionStream({
+      ...USER_REQ,
+      metadata: { conversation_id: "conv-b" },
+    })) {
+      chunks.push(c);
+    }
+
+    expect(calls).toEqual(["b"]);
+    expect(selected).toEqual(["b"]);
+    expect(chunks).toEqual(["data: b\n\n"]);
+  });
+
+  it("queues on the sticky account when every eligible account is at capacity", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...member("a", 50, true, calls), isAtCapacity: () => true },
+        { ...member("b", 50, true, calls), isAtCapacity: () => true },
+      ],
+    });
+
+    await pool.chatCompletion({ ...USER_REQ, metadata: { conversation_id: "conv-b" } });
+
+    // All accounts are busy, so selection falls back to the deterministic target.
+    expect(calls).toEqual(["a"]);
   });
 
   it("skips an unschedulable account entirely", async () => {
@@ -275,11 +547,13 @@ describe("createOAuthPoolClient — nativePassthrough", () => {
     clock += 10;
     await pool.nativePassthrough?.(secondSession);
 
-    expect(pt).toEqual(["a", "a", "b"]);
-    expect(selected).toEqual(["a", "a", "b"]);
+    expect(pt[1]).toBe(pt[0]);
+    expect(selected[1]).toBe(selected[0]);
+    expect(pt).toHaveLength(3);
+    expect(selected).toHaveLength(3);
   });
 
-  it("expires native sticky sessions and returns to LRU selection", async () => {
+  it("expires native sticky cache entries but recomputes the same deterministic account", async () => {
     const pt: string[] = [];
     let clock = 1_000;
     const pool = createOAuthPoolClient({
@@ -298,7 +572,96 @@ describe("createOAuthPoolClient — nativePassthrough", () => {
     clock += 100;
     await pool.nativePassthrough?.(native);
 
-    expect(pt).toEqual(["a", "b"]);
+    expect(pt).toHaveLength(2);
+    expect(pt[1]).toBe(pt[0]);
+  });
+
+  it("keeps a native metadata.user_id device id on one account even when session ids change", async () => {
+    const pt: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [ptMember("a", 50, pt), ptMember("b", 50, pt)],
+    });
+    const userId = (session: string) =>
+      JSON.stringify({ device_id: "native-device-1", account_uuid: "", session_id: session });
+
+    await pool.nativePassthrough?.({
+      protocol: "anthropic_messages" as const,
+      body: { model: "claude", messages: [], metadata: { user_id: userId("session-1") } },
+      headers: {},
+      mutations: {},
+    });
+    await pool.nativePassthrough?.({
+      protocol: "anthropic_messages" as const,
+      body: { model: "claude", messages: [], metadata: { user_id: userId("session-2") } },
+      headers: {},
+      mutations: {},
+    });
+
+    expect(pt).toHaveLength(2);
+    expect(pt[1]).toBe(pt[0]);
+  });
+
+  it("prefers another account when a native sticky target is at capacity", async () => {
+    const pt: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [{ ...ptMember("a", 50, pt), isAtCapacity: () => true }, ptMember("b", 50, pt)],
+    });
+
+    await pool.nativePassthrough?.({
+      protocol: "anthropic_messages" as const,
+      body: {
+        model: "claude",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: { conversation_id: "conv-b" },
+      },
+      headers: {},
+      mutations: {},
+    });
+
+    expect(pt).toEqual(["b"]);
+  });
+
+  it("serializes native Responses input capacity checks through the same user-turn detector", async () => {
+    const pt: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [{ ...ptMember("a", 50, pt), isAtCapacity: () => true }, ptMember("b", 50, pt)],
+    });
+
+    await pool.nativePassthrough?.({
+      protocol: "openai_responses" as const,
+      body: {
+        model: "gpt-5.5",
+        input: [{ type: "message", role: "user", content: "hi" }],
+        prompt_cache_key: "stick-a",
+      },
+      headers: {},
+      mutations: {},
+    });
+
+    expect(pt).toEqual(["b"]);
+  });
+
+  it("ignores per-request x-client-request-id when a stable native body key exists", async () => {
+    const pt: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [ptMember("a", 50, pt), ptMember("b", 50, pt)],
+    });
+
+    await pool.nativePassthrough?.({
+      protocol: "openai_responses" as const,
+      body: { model: "gpt-5.5", input: "hi", prompt_cache_key: "thread-a" },
+      headers: { "x-client-request-id": "one" },
+      mutations: {},
+    });
+    await pool.nativePassthrough?.({
+      protocol: "openai_responses" as const,
+      body: { model: "gpt-5.5", input: "hi", prompt_cache_key: "thread-a" },
+      headers: { "x-client-request-id": "two" },
+      mutations: {},
+    });
+
+    expect(pt).toHaveLength(2);
+    expect(pt[1]).toBe(pt[0]);
   });
 
   it("throws fail-closed when the selected member lacks nativePassthrough (never falls back to a sibling)", async () => {
@@ -367,6 +730,66 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     expect(chunks).toEqual(["data: a\n\n", "data: b\n\n"]);
   });
 
+  it("prefers another account when a native stream sticky target is at capacity", async () => {
+    const pt: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...ptStreamMember("a", 50, pt), isAtCapacity: () => true },
+        ptStreamMember("b", 50, pt),
+      ],
+      onSelect: (acc) => selected.push(acc),
+    });
+
+    const stream = pool.nativePassthroughStream?.({
+      protocol: "anthropic_messages" as const,
+      body: {
+        model: "claude",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        metadata: { conversation_id: "conv-b" },
+      },
+      headers: {},
+      mutations: {},
+    });
+    const chunks: string[] = [];
+    for await (const c of stream ?? []) chunks.push(c);
+
+    expect(pt).toEqual(["b"]);
+    expect(selected).toEqual(["b"]);
+    expect(chunks).toEqual(["data: b\n\n"]);
+  });
+
+  it("applies capacity checks to native Responses input streams", async () => {
+    const pt: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...ptStreamMember("a", 50, pt), isAtCapacity: () => true },
+        ptStreamMember("b", 50, pt),
+      ],
+      onSelect: (acc) => selected.push(acc),
+    });
+
+    const stream = pool.nativePassthroughStream?.({
+      protocol: "openai_responses" as const,
+      body: {
+        model: "gpt-5.5",
+        stream: true,
+        input: [{ type: "message", role: "user", content: "hi" }],
+        prompt_cache_key: "stick-a",
+      },
+      headers: {},
+      mutations: {},
+    });
+    const chunks: string[] = [];
+    for await (const c of stream ?? []) chunks.push(c);
+
+    expect(pt).toEqual(["b"]);
+    expect(selected).toEqual(["b"]);
+    expect(chunks).toEqual(["data: b\n\n"]);
+  });
+
   it("throws fail-closed when the selected member lacks nativePassthroughStream", async () => {
     const pt: string[] = [];
     const pool = createOAuthPoolClient({
@@ -427,6 +850,9 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
   const BAD = new UpstreamError("upstream_error", "bad request", null, 400);
   const REFRESH_401 = new TokenRefreshError("oauth refresh failed (openai-codex, status 401)", 401);
   const REFRESH_429 = new TokenRefreshError("oauth refresh rate-limited (status 429)", 429);
+  const QUEUE_TIMEOUT = Object.assign(new Error("user message queue wait timed out"), {
+    queueTimeout: true,
+  });
 
   it("retries the next account on a transient fault (non-stream)", async () => {
     const served: string[] = [];
@@ -452,11 +878,48 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
       onAccountRateLimit: (account, untilMs) => limited.push({ account, untilMs }),
       onSelect: (account) => selected.push(account),
     });
+
     await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "b" });
     await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "b" });
     expect(served).toEqual(["b", "b"]);
     expect(selected).toEqual(["a", "b", "b"]);
     expect(limited).toEqual([{ account: "a", untilMs: 1_250 }]);
+  });
+
+  it("treats an account queue timeout as sibling capacity failover", async () => {
+    const served: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        faultMember("busy", 10, served, QUEUE_TIMEOUT),
+        faultMember("open", 50, served, null),
+      ],
+      onSelect: (account) => selected.push(account),
+    });
+
+    await expect(pool.chatCompletion(USER_REQ)).resolves.toEqual({ served_by: "open" });
+
+    expect(served).toEqual(["open"]);
+    expect(selected).toEqual(["busy", "open"]);
+  });
+
+  it("treats a chat stream queue timeout as sibling capacity failover", async () => {
+    const served: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        faultMember("busy", 10, served, QUEUE_TIMEOUT),
+        faultMember("open", 50, served, null),
+      ],
+      onSelect: (account) => selected.push(account),
+    });
+
+    const chunks: string[] = [];
+    for await (const c of pool.chatCompletionStream(USER_REQ)) chunks.push(c);
+
+    expect(chunks).toEqual(["data: open\n\n"]);
+    expect(served).toEqual(["open"]);
+    expect(selected).toEqual(["busy", "open"]);
   });
 
   it("can retry a sibling on a model-scoped 429 without globally parking the account", async () => {
@@ -657,6 +1120,47 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     for await (const c of pool.nativePassthroughStream?.(NATIVE) ?? []) chunks.push(c);
     expect(chunks).toEqual(["data: b\n\n"]);
     expect(served).toEqual(["b"]);
+  });
+
+  it("treats a native stream queue timeout as sibling capacity failover", async () => {
+    const served: string[] = [];
+    const selected: string[] = [];
+    const NATIVE: Record<string, unknown> = {
+      model: "gpt-5.5",
+      stream: true,
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const mk = (account: string, priority: number, fault: Error | null): OAuthPoolMember => ({
+      account,
+      priority,
+      schedulable: true,
+      client: {
+        async chatCompletion(_req: ChatCompletionRequest) {
+          return { served_by: account };
+        },
+        async *chatCompletionStream(_req: ChatCompletionRequest) {
+          yield `data: ${account}\n\n`;
+        },
+        nativePassthroughStream(_body: Record<string, unknown>): AsyncIterable<string> {
+          return (async function* () {
+            if (fault) throw fault;
+            served.push(account);
+            yield `data: ${account}\n\n`;
+          })();
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [mk("busy", 10, QUEUE_TIMEOUT), mk("open", 50, null)],
+      onSelect: (account) => selected.push(account),
+    });
+
+    const chunks: string[] = [];
+    for await (const c of pool.nativePassthroughStream?.(NATIVE) ?? []) chunks.push(c);
+
+    expect(chunks).toEqual(["data: open\n\n"]);
+    expect(served).toEqual(["open"]);
+    expect(selected).toEqual(["busy", "open"]);
   });
 
   it("parks a credential-failed account and retries native passthrough streaming", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -3,23 +3,25 @@
 // with its own token manager + egress proxy + executor type). On every call it
 // SELECTS one account, then delegates the whole request to that account's client.
 //
-// Selection (CRS-reference scheduler): from the SCHEDULABLE members, pick the one
-// with the lowest `priority` (lower = preferred); ties broken by least-recently-
-// used (oldest `lastUsedAt` first), giving round-robin within an equal priority.
-// The chosen member's `lastUsedAt` is bumped (in-memory) so the next call rotates
-// to its sibling. `onSelect(account)` fires with the picked account so the caller
-// can record WHICH subscription served the request (telemetry / structured log).
+// Selection: when the request carries a stable session/device fingerprint, bind it
+// to one account by deterministic rendezvous hashing inside the lowest-priority
+// eligible tier. That makes new sessions spread across equal-priority accounts,
+// while repeated turns stay on the same account unless it is parked, usage-limited,
+// or currently at capacity. Requests with no session signal keep the old LRU
+// round-robin behavior inside the lowest-priority tier.
 //
 // Fail-closed (principle 2): a pool with no schedulable member cannot serve, so
 // the call throws — the executor records the failure and advances the chain, never
 // silently picks a parked account. Streaming and non-streaming share the SAME
 // selection (one pick per call), so a streamed request also rotates the pool.
 
+import { createHash } from "node:crypto";
 import {
   isNativePassthroughCarrier,
   type NativePassthroughInput,
   nativePassthroughBody,
 } from "@helm/shared";
+import { isUserMessageRequest } from "../../queue/user-turn.js";
 import { guardPreOutputFailure, type PreOutputClassifier } from "../failover-guard.js";
 import {
   type ChatCompletionRequest,
@@ -73,6 +75,13 @@ function isRateLimitAccountFailure(err: unknown): boolean {
   return err instanceof UpstreamError && err.upstreamStatus === 429;
 }
 
+// The per-account user-message queue reports backpressure with this structural flag.
+// Treat it as account-scoped capacity pressure: try a sibling account before surfacing
+// a terminal 503. No instanceof check, because the class may cross package boundaries.
+function isAccountBackpressureFailure(err: unknown): boolean {
+  return err instanceof Error && (err as { queueTimeout?: unknown }).queueTimeout === true;
+}
+
 // One account in the pool: its scheduling knobs plus the fully-wired client that
 // carries that account's credential + proxy. `lastUsedAt` is MUTABLE soft state
 // (round-robin cursor); it starts at 0 so an untouched account is always preferred
@@ -82,6 +91,10 @@ export interface OAuthPoolMember {
   priority: number;
   schedulable: boolean;
   client: ProviderClient;
+  // Optional live capacity probe. When true, the pool prefers another eligible account
+  // before committing this request. If every eligible account is busy, selection falls
+  // back to the normal target and lets that member's queue wait.
+  isAtCapacity?: () => boolean;
   // Auto-park cooldown: epoch ms until which this account is removed from selection
   // because it hit its usage/rate limit (null/undefined = eligible). Distinct from
   // `schedulable` (the operator's manual park). MUTABLE soft state — the gateway flips
@@ -118,7 +131,7 @@ export interface OAuthPoolDeps {
   stickyTtlMs?: number;
   // Fires with the selected account on each served call — the seam the gateway
   // uses to record the serving subscription in telemetry / logs (no secrets).
-  onSelect?: (account: string) => void;
+  onSelect?: (account: string, selection: OAuthPoolSelection) => void;
   // Fires when the selected account hits an account-wide upstream 429. The pool already
   // applies the in-memory cooldown before calling this; the hook lets the gateway persist
   // the same cooldown so rebuilds/restarts keep routing around the account.
@@ -147,12 +160,22 @@ interface PoolEntry {
   lastUsedAt: number;
 }
 
+export interface OAuthPoolSelection {
+  reason: "sticky_hit" | "hash_assign" | "lru";
+  affinityKeySource: string | null;
+  capacityAvoided: boolean;
+  allCandidatesAtCapacity: boolean;
+  busyEligibleAccounts: number;
+  retryAttempt: number;
+}
+
 export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   const now = deps.now ?? (() => Date.now());
   const stickyTtlMs = deps.stickyTtlMs ?? 10 * 60 * 1000;
   const accountRateLimitCooldownMs = deps.accountRateLimitCooldownMs ?? DEFAULT_429_COOLDOWN_MS;
   const entries: PoolEntry[] = deps.members.map((member) => ({ member, lastUsedAt: 0 }));
   const stickySessions = new Map<string, { account: string; expiresAt: number }>();
+  let selectionCounter = 0;
 
   // An account is eligible only when the operator has not parked it (`schedulable`)
   // AND its auto-park cooldown has elapsed. Re-evaluated on every select() against the
@@ -177,36 +200,86 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
   }
 
+  function objectRecord(value: unknown): Record<string, unknown> | null {
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  }
+
+  function deviceIdFromMetadataUserId(userId: string): string | null {
+    try {
+      const parsed = objectRecord(JSON.parse(userId) as unknown);
+      if (parsed === null) return null;
+      return bodyString(parsed, "device_id") ?? bodyString(parsed, "deviceId");
+    } catch {
+      return null;
+    }
+  }
+
+  function deviceAffinityKeyFromBody(body: Record<string, unknown>): string | null {
+    const direct = bodyString(body, "device_id") ?? bodyString(body, "deviceId");
+    if (direct !== null) return `device_id:${direct}`;
+    const metadata = objectRecord(body.metadata);
+    if (metadata === null) return null;
+    const metadataDevice = bodyString(metadata, "device_id") ?? bodyString(metadata, "deviceId");
+    if (metadataDevice !== null) return `metadata.device_id:${metadataDevice}`;
+    const userId = bodyString(metadata, "user_id");
+    const parsedDevice = userId === null ? null : deviceIdFromMetadataUserId(userId);
+    return parsedDevice === null ? null : `metadata.user_id.device_id:${parsedDevice}`;
+  }
+
   function stickyKeyFromNative(input: NativePassthroughInput): string | null {
     const body = nativePassthroughBody(input);
+    const bodyDeviceKey = deviceAffinityKeyFromBody(body);
+    if (bodyDeviceKey !== null) return bodyDeviceKey;
     if (isNativePassthroughCarrier(input)) {
-      for (const header of [
-        "session_id",
-        "x-session-id",
-        "x-client-request-id",
-        "prompt_cache_key",
-        "conversation_id",
-      ]) {
+      for (const header of ["device_id", "x-device-id"]) {
+        const value = headerValue(input.headers, header);
+        if (value !== null) return `${header}:${value}`;
+      }
+      for (const header of ["session_id", "x-session-id", "prompt_cache_key", "conversation_id"]) {
         const value = headerValue(input.headers, header);
         if (value !== null) return `${header}:${value}`;
       }
     }
-    for (const key of [
-      "session_id",
-      "prompt_cache_key",
-      "conversation_id",
-      "previous_response_id",
-    ]) {
+    for (const key of ["session_id", "prompt_cache_key", "conversation_id"]) {
       const value = bodyString(body, key);
       if (value !== null) return `${key}:${value}`;
     }
-    const metadata = body.metadata;
-    if (metadata !== null && typeof metadata === "object" && !Array.isArray(metadata)) {
-      for (const key of ["session_id", "conversation_id", "thread_id"]) {
-        const value = bodyString(metadata as Record<string, unknown>, key);
+    const metadata = objectRecord(body.metadata);
+    if (metadata !== null) {
+      for (const key of ["session_id", "conversation_id", "thread_id", "user_id"]) {
+        const value = bodyString(metadata, key);
         if (value !== null) return `metadata.${key}:${value}`;
       }
     }
+    const previousResponseId = bodyString(body, "previous_response_id");
+    if (previousResponseId !== null) return `previous_response_id:${previousResponseId}`;
+    return null;
+  }
+
+  function stickyKeyFromChat(req: ChatCompletionRequest): string | null {
+    const deviceKey = deviceAffinityKeyFromBody(req);
+    if (deviceKey !== null) return deviceKey;
+    for (const key of [
+      "prompt_cache_key",
+      "session_id",
+      "conversation_id",
+      "user",
+      "safety_identifier",
+    ]) {
+      const value = bodyString(req, key);
+      if (value !== null) return `${key}:${value}`;
+    }
+    const metadata = objectRecord(req.metadata);
+    if (metadata !== null) {
+      for (const key of ["session_id", "conversation_id", "thread_id", "user_id"]) {
+        const value = bodyString(metadata, key);
+        if (value !== null) return `metadata.${key}:${value}`;
+      }
+    }
+    const previousResponseId = bodyString(req, "previous_response_id");
+    if (previousResponseId !== null) return `previous_response_id:${previousResponseId}`;
     return null;
   }
 
@@ -220,40 +293,62 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return typeof model === "string" && model.trim().length > 0 ? model.trim() : null;
   }
 
-  // Pick the next account: lowest priority, then oldest lastUsedAt (LRU round-
-  // robin within equal priority). Bumps the winner's cursor and notifies onSelect.
-  // Throws when no member is schedulable (fail-closed — the caller treats it as a
-  // provider failure and advances the fallback chain).
-  // `exclude` holds accounts already TRIED-and-transiently-failed this request (in-pool
-  // retry): they are skipped — both as the sticky target and in the LRU scan — so each
-  // retry advances to a fresh sibling and the loop terminates (bounded by member count).
-  function select(stickyKey?: string | null, exclude?: ReadonlySet<string>): PoolEntry {
-    const nowMs = now();
-    if (stickyKey) {
-      const sticky = stickySessions.get(stickyKey);
-      if (sticky !== undefined && sticky.expiresAt > nowMs) {
-        const entry = entries.find(
-          (candidate) =>
-            candidate.member.account === sticky.account &&
-            candidate.member.schedulable &&
-            !usageLimited(candidate.member, nowMs) &&
-            !exclude?.has(candidate.member.account),
-        );
-        if (entry !== undefined) {
-          entry.lastUsedAt = nowMs;
-          sticky.expiresAt = nowMs + stickyTtlMs;
-          deps.onSelect?.(entry.member.account);
-          return entry;
-        }
-      }
-      stickySessions.delete(stickyKey);
-    }
+  function stickyScore(stickyKey: string, account: string): bigint {
+    return createHash("sha256")
+      .update(stickyKey)
+      .update("\0")
+      .update(account)
+      .digest()
+      .readBigUInt64BE(0);
+  }
 
+  function atCapacity(entry: PoolEntry): boolean {
+    try {
+      return entry.member.isAtCapacity?.() === true;
+    } catch {
+      return false;
+    }
+  }
+
+  function eligibleEntries(nowMs: number, exclude: ReadonlySet<string> | undefined): PoolEntry[] {
+    return entries.filter(
+      (e) =>
+        e.member.schedulable && !usageLimited(e.member, nowMs) && !exclude?.has(e.member.account),
+    );
+  }
+
+  function preferredCapacityTier(
+    eligible: PoolEntry[],
+    avoidBusy: boolean,
+  ): {
+    candidates: PoolEntry[];
+    capacityAvoided: boolean;
+    allCandidatesAtCapacity: boolean;
+    busyEligibleAccounts: number;
+  } {
+    if (!avoidBusy) {
+      return {
+        candidates: eligible,
+        capacityAvoided: false,
+        allCandidatesAtCapacity: false,
+        busyEligibleAccounts: 0,
+      };
+    }
+    const nonBusy = eligible.filter((e) => !atCapacity(e));
+    const busyEligibleAccounts = eligible.length - nonBusy.length;
+    // If every account is busy, do not fail closed. Let the chosen member's queue wait
+    // and preserve the existing retry/timeout behavior.
+    return {
+      candidates: nonBusy.length > 0 ? nonBusy : eligible,
+      capacityAvoided: nonBusy.length > 0 && busyEligibleAccounts > 0,
+      allCandidatesAtCapacity: eligible.length > 0 && nonBusy.length === 0,
+      busyEligibleAccounts,
+    };
+  }
+
+  function chooseByLru(candidates: PoolEntry[]): PoolEntry | undefined {
     let best: PoolEntry | undefined;
-    for (const e of entries) {
-      if (!e.member.schedulable) continue; // operator park
-      if (usageLimited(e.member, nowMs)) continue; // auto-park cooldown
-      if (exclude?.has(e.member.account)) continue; // already tried this request (retry)
+    for (const e of candidates) {
       if (
         !best ||
         e.member.priority < best.member.priority ||
@@ -262,16 +357,116 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         best = e;
       }
     }
-    if (!best) throw new Error("oauth pool has no schedulable account");
-    best.lastUsedAt = nowMs;
+    return best;
+  }
+
+  function chooseByStickyHash(candidates: PoolEntry[], stickyKey: string): PoolEntry | undefined {
+    let tierPriority: number | undefined;
+    for (const e of candidates) {
+      if (tierPriority === undefined || e.member.priority < tierPriority) {
+        tierPriority = e.member.priority;
+      }
+    }
+    let best: { entry: PoolEntry; score: bigint } | undefined;
+    for (const e of candidates) {
+      if (e.member.priority !== tierPriority) continue;
+      const score = stickyScore(stickyKey, e.member.account);
+      if (best === undefined || score > best.score) best = { entry: e, score };
+    }
+    return best?.entry;
+  }
+
+  function responseIdFromResult(result: unknown): string | null {
+    const body = objectRecord(result);
+    if (body === null) return null;
+    const direct = bodyString(body, "id");
+    if (direct !== null) return direct;
+    const response = objectRecord(body.response);
+    return response === null ? null : bodyString(response, "id");
+  }
+
+  function rememberResponseAffinity(result: unknown, entry: PoolEntry): void {
+    const id = responseIdFromResult(result);
+    if (id === null) return;
+    stickySessions.set(`previous_response_id:${id}`, {
+      account: entry.member.account,
+      expiresAt: now() + stickyTtlMs,
+    });
+  }
+
+  function affinityKeySource(stickyKey: string | null): string | null {
+    if (stickyKey === null) return null;
+    const separator = stickyKey.indexOf(":");
+    return separator > 0 ? stickyKey.slice(0, separator) : "unknown";
+  }
+
+  function commitSelection(
+    entry: PoolEntry,
+    stickyKey: string | null,
+    nowMs: number,
+    selection: OAuthPoolSelection,
+  ): PoolEntry {
+    selectionCounter += 1;
+    entry.lastUsedAt = selectionCounter;
     if (stickyKey) {
       stickySessions.set(stickyKey, {
-        account: best.member.account,
+        account: entry.member.account,
         expiresAt: nowMs + stickyTtlMs,
       });
     }
-    deps.onSelect?.(best.member.account);
-    return best;
+    deps.onSelect?.(entry.member.account, selection);
+    return entry;
+  }
+
+  // Pick the next account: lowest priority, then oldest lastUsedAt (LRU round-
+  // robin within equal priority). Bumps the winner's cursor and notifies onSelect.
+  // Throws when no member is schedulable (fail-closed — the caller treats it as a
+  // provider failure and advances the fallback chain).
+  // `exclude` holds accounts already TRIED-and-transiently-failed this request (in-pool
+  // retry): they are skipped — both as the sticky target and in the LRU scan — so each
+  // retry advances to a fresh sibling and the loop terminates (bounded by member count).
+  function select(
+    stickyKey?: string | null,
+    exclude?: ReadonlySet<string>,
+    opts: { avoidBusy?: boolean } = {},
+  ): PoolEntry {
+    const nowMs = now();
+    const eligible = eligibleEntries(nowMs, exclude);
+    const capacityTier = preferredCapacityTier(eligible, opts.avoidBusy === true);
+    const selectionBase = {
+      affinityKeySource: affinityKeySource(stickyKey ?? null),
+      capacityAvoided: capacityTier.capacityAvoided,
+      allCandidatesAtCapacity: capacityTier.allCandidatesAtCapacity,
+      busyEligibleAccounts: capacityTier.busyEligibleAccounts,
+      retryAttempt: exclude?.size ?? 0,
+    };
+    if (stickyKey) {
+      const sticky = stickySessions.get(stickyKey);
+      if (sticky !== undefined && sticky.expiresAt > nowMs) {
+        const entry = capacityTier.candidates.find(
+          (candidate) => candidate.member.account === sticky.account,
+        );
+        if (entry !== undefined) {
+          sticky.expiresAt = nowMs + stickyTtlMs;
+          return commitSelection(entry, stickyKey, nowMs, {
+            ...selectionBase,
+            reason: "sticky_hit",
+          });
+        }
+      }
+      stickySessions.delete(stickyKey);
+    }
+
+    const stickyOnly = stickyKey?.startsWith("previous_response_id:") === true;
+    const best =
+      stickyKey && !stickyOnly && capacityTier.candidates.length > 0
+        ? chooseByStickyHash(capacityTier.candidates, stickyKey)
+        : chooseByLru(capacityTier.candidates);
+    if (!best) throw new Error("oauth pool has no schedulable account");
+    return commitSelection(best, stickyOnly ? null : (stickyKey ?? null), nowMs, {
+      ...selectionBase,
+      reason: stickyKey && !stickyOnly ? "hash_assign" : "lru",
+    });
   }
 
   function forgetStickyAccount(account: string): void {
@@ -327,6 +522,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   async function completeWithRetry<R>(
     stickyKey: string | null,
     model: string | null,
+    avoidBusy: boolean,
     call: (client: ProviderClient) => Promise<R>,
   ): Promise<R> {
     const tried = new Set<string>();
@@ -334,13 +530,15 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     for (;;) {
       let entry: PoolEntry;
       try {
-        entry = select(stickyKey, tried);
+        entry = select(stickyKey, tried, { avoidBusy });
       } catch (selErr) {
         throw lastErr ?? selErr;
       }
       tried.add(entry.member.account);
       try {
-        return await call(entry.member.client);
+        const result = await call(entry.member.client);
+        rememberResponseAffinity(result, entry);
+        return result;
       } catch (err) {
         if (isCredentialAccountFailure(err)) {
           parkCredentialFailedAccount(entry);
@@ -349,6 +547,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         }
         if (isRateLimitAccountFailure(err)) {
           parkRateLimitedAccount(entry, err, model);
+          lastErr = err;
+          continue;
+        }
+        if (isAccountBackpressureFailure(err)) {
           lastErr = err;
           continue;
         }
@@ -367,6 +569,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     firstEntry: PoolEntry,
     stickyKey: string | null,
     model: string | null,
+    avoidBusy: boolean,
     open: (client: ProviderClient) => AsyncIterable<string>,
     // When set, each member's SSE is wrapped so a pre-output error frame (after only a
     // content-free preamble) throws BEFORE the first yielded chunk — turning "commit on
@@ -394,13 +597,15 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         } else if (isRateLimitAccountFailure(err)) {
           parkRateLimitedAccount(entry, err, model);
           lastErr = err;
+        } else if (isAccountBackpressureFailure(err)) {
+          lastErr = err;
         } else {
           if (!isRetryableTransientError(err)) throw err;
           lastErr = err;
         }
         let next: PoolEntry;
         try {
-          next = select(stickyKey, tried);
+          next = select(stickyKey, tried, { avoidBusy });
         } catch {
           throw lastErr; // no sibling left → surface the real upstream cause
         }
@@ -437,8 +642,11 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       req: ChatCompletionRequest,
       opts?: { signal?: AbortSignal },
     ): Promise<ChatCompletionResponse> {
-      return completeWithRetry(null, modelFromChat(req), (client) =>
-        client.chatCompletion(req, opts),
+      return completeWithRetry(
+        stickyKeyFromChat(req),
+        modelFromChat(req),
+        isUserMessageRequest(req),
+        (client) => client.chatCompletion(req, opts),
       );
     },
     chatCompletionStream(
@@ -447,11 +655,14 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     ): AsyncIterable<string> {
       // Pick SYNCHRONOUSLY (one pick per call) before opening the stream so rotation +
       // onSelect fire on the call turn; streamWithRetry only adds sibling fallbacks.
-      const first = select();
+      const stickyKey = stickyKeyFromChat(req);
+      const avoidBusy = isUserMessageRequest(req);
+      const first = select(stickyKey, undefined, { avoidBusy });
       return streamWithRetry(
         first,
-        null,
+        stickyKey,
         modelFromChat(req),
+        avoidBusy,
         (client) => client.chatCompletionStream(req, opts),
         deps.chatStreamPreambleClassifier,
       );
@@ -473,12 +684,17 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       // rotation + onSelect fire on the call turn exactly like the other methods. A member
       // missing the method throws a NON-transient error → surfaced at once (fail-closed,
       // never silently routed to a translating sibling), not retried.
-      return completeWithRetry(stickyKeyFromNative(body), modelFromNative(body), (client) => {
-        if (!client.nativePassthrough) {
-          throw new Error("oauth pool member does not support native passthrough");
-        }
-        return client.nativePassthrough(body, opts);
-      });
+      return completeWithRetry(
+        stickyKeyFromNative(body),
+        modelFromNative(body),
+        isUserMessageRequest(nativePassthroughBody(body)),
+        (client) => {
+          if (!client.nativePassthrough) {
+            throw new Error("oauth pool member does not support native passthrough");
+          }
+          return client.nativePassthrough(body, opts);
+        },
+      );
     },
     // Streaming native passthrough (issue #217, Phase 2). A SYNCHRONOUS method (NOT an
     // async fn) so select() — and thus rotation + onSelect — fires on the CALL turn,
@@ -490,9 +706,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       opts?: { signal?: AbortSignal },
     ): AsyncIterable<string> {
       const stickyKey = stickyKeyFromNative(body);
+      const avoidBusy = isUserMessageRequest(nativePassthroughBody(body));
       // Pick + fail-closed check SYNCHRONOUSLY on the call turn (rotation + onSelect, and a
       // synchronous throw if the picked member can't passthrough-stream), exactly as before.
-      const first = select(stickyKey);
+      const first = select(stickyKey, undefined, { avoidBusy });
       if (!first.member.client.nativePassthroughStream) {
         throw new Error("oauth pool member does not support native passthrough streaming");
       }
@@ -500,6 +717,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         first,
         stickyKey,
         modelFromNative(body),
+        avoidBusy,
         (client) => {
           if (!client.nativePassthroughStream) {
             throw new Error("oauth pool member does not support native passthrough streaming");

--- a/packages/core/src/provider/oauth/serialize-client.test.ts
+++ b/packages/core/src/provider/oauth/serialize-client.test.ts
@@ -267,6 +267,29 @@ describe("createSerializingClient", () => {
     expect(inner.nativeCalls).toBe(2);
   });
 
+  it("serializes native Responses input calls with the configured delay", async () => {
+    const inner = makeNativeInner();
+    const client = makeClient(inner, { enabled: true, delayMs: 200, timeoutMs: 5_000 });
+    const responsesReq = {
+      model: "gpt-5.5",
+      input: [{ type: "message", role: "user", content: "hi" }],
+    };
+    const t0 = Date.now();
+    const first = client.nativePassthrough?.(responsesReq);
+    let secondDoneAt: number | null = null;
+    const second = client.nativePassthrough?.(responsesReq).then((r) => {
+      secondDoneAt = Date.now();
+      return r;
+    });
+
+    await first;
+    await vi.advanceTimersByTimeAsync(200);
+    await second;
+
+    expect((secondDoneAt ?? 0) - t0).toBeGreaterThanOrEqual(200);
+    expect(inner.nativeCalls).toBe(2);
+  });
+
   it("holds the lock across the FULL nativePassthroughStream drain", async () => {
     const inner = makeNativeInner(["c1", "c2", "c3"]);
     const client = makeClient(inner, { enabled: true, delayMs: 0, timeoutMs: 5_000 });
@@ -284,6 +307,32 @@ describe("createSerializingClient", () => {
     await it?.next();
     await it?.next(); // done:true — generator finally releases
     await second;
+    expect(secondGranted).toBe(true);
+    expect(inner.nativeStreamCalls).toBe(1);
+  });
+
+  it("holds the lock across a native Responses input stream", async () => {
+    const inner = makeNativeInner(["c1", "c2", "c3"]);
+    const client = makeClient(inner, { enabled: true, delayMs: 0, timeoutMs: 5_000 });
+    const responsesReq = {
+      model: "gpt-5.5",
+      input: [{ type: "message", role: "user", content: "hi" }],
+    };
+    const it = client.nativePassthroughStream?.(responsesReq)[Symbol.asyncIterator]();
+    await it?.next();
+    let secondGranted = false;
+    const second = client.nativePassthrough?.(responsesReq).then((r) => {
+      secondGranted = true;
+      return r;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(secondGranted).toBe(false);
+    await it?.next();
+    await it?.next();
+    await it?.next();
+    await second;
+
     expect(secondGranted).toBe(true);
     expect(inner.nativeStreamCalls).toBe(1);
   });

--- a/packages/core/src/queue/keyed-serial-gate.test.ts
+++ b/packages/core/src/queue/keyed-serial-gate.test.ts
@@ -173,4 +173,41 @@ describe("createKeyedSerialGate", () => {
     if (a.ok) a.release();
     if (b.ok) b.release();
   });
+
+  it("reports whether a fresh acquire would queue", async () => {
+    const gate = createKeyedSerialGate();
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 200 })).toBe(false);
+
+    const first = await gate.acquire(args());
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 200 })).toBe(true);
+
+    const waiting = gate.acquire(args());
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 200 })).toBe(true);
+
+    if (first.ok) first.release();
+    await vi.advanceTimersByTimeAsync(200);
+    const granted = await waiting;
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 200 })).toBe(true);
+
+    if (granted.ok) granted.release();
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 200 })).toBe(true);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 200 })).toBe(false);
+  });
+
+  it("does not report a released zero-delay key as queued", async () => {
+    const gate = createKeyedSerialGate();
+    const first = await gate.acquire(args({ delayMs: 0 }));
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 0 })).toBe(true);
+    if (first.ok) first.release();
+    expect(gate.wouldQueue({ key: "acct1", delayMs: 0 })).toBe(false);
+  });
+
+  it("wouldQueue is scoped per key", async () => {
+    const gate = createKeyedSerialGate();
+    const first = await gate.acquire(args({ key: "acctA" }));
+    expect(gate.wouldQueue({ key: "acctA", delayMs: 200 })).toBe(true);
+    expect(gate.wouldQueue({ key: "acctB", delayMs: 200 })).toBe(false);
+    if (first.ok) first.release();
+  });
 });

--- a/packages/core/src/queue/keyed-serial-gate.ts
+++ b/packages/core/src/queue/keyed-serial-gate.ts
@@ -23,6 +23,10 @@ export type SerialAcquireResult =
 
 export interface KeyedSerialGate {
   acquire(args: SerialAcquireArgs): Promise<SerialAcquireResult>;
+  // Would a fresh acquire for this key have to wait instead of starting now?
+  // Used by the OAuth account pool to prefer another eligible account before it
+  // commits a session to a busy subscription account.
+  wouldQueue(args: { key: string; delayMs: number }): boolean;
 }
 
 export interface KeyedSerialGateDeps {
@@ -149,6 +153,14 @@ export function createKeyedSerialGate(deps: KeyedSerialGateDeps = {}): KeyedSeri
         entry.waiters.push(waiter);
         pump(args.key);
       });
+    },
+
+    wouldQueue(args: { key: string; delayMs: number }): boolean {
+      const entry = entries.get(args.key);
+      if (!entry) return false;
+      if (entry.locked || entry.waiters.length > 0) return true;
+      if (entry.lastCompletionMs === null || args.delayMs <= 0) return false;
+      return entry.lastCompletionMs + args.delayMs > now();
     },
   };
 }

--- a/packages/core/src/queue/user-turn.test.ts
+++ b/packages/core/src/queue/user-turn.test.ts
@@ -76,4 +76,41 @@ describe("isUserMessageRequest", () => {
     expect(isUserMessageRequest({ messages: "nope" })).toBe(false);
     expect(isUserMessageRequest({ messages: [null] })).toBe(false);
   });
+
+  it("true for Responses input string and last user message items", () => {
+    expect(isUserMessageRequest({ input: "hello" })).toBe(true);
+    expect(
+      isUserMessageRequest({
+        input: [
+          { type: "message", role: "assistant", content: "previous" },
+          { type: "message", role: "user", content: [{ type: "input_text", text: "next" }] },
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      isUserMessageRequest({
+        input: [
+          { role: "assistant", content: "previous" },
+          { role: "user", content: "next" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("false for Responses tool outputs and non-user continuations", () => {
+    expect(
+      isUserMessageRequest({
+        input: [
+          { type: "message", role: "user", content: "question" },
+          { type: "function_call_output", call_id: "call_1", output: "42" },
+        ],
+      }),
+    ).toBe(false);
+    expect(isUserMessageRequest({ input: [{ type: "reasoning", id: "rs_1" }] })).toBe(false);
+    expect(
+      isUserMessageRequest({
+        input: [{ type: "message", role: "assistant", content: "continuing" }],
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/core/src/queue/user-turn.ts
+++ b/packages/core/src/queue/user-turn.ts
@@ -1,8 +1,8 @@
 // Pure detector for the per-account user-message serial queue (issue #93,
-// feature B): only requests whose LAST message is a genuine user turn are
-// serialized — tool-result round-trips and assistant/system continuations flow
-// freely (they are mid-agent-loop and delaying them would only slow the loop
-// without protecting upstream rate limits).
+// feature B): only requests whose LAST Chat message or Responses input item is
+// a genuine user turn are serialized — tool-result round-trips and
+// assistant/system continuations flow freely (they are mid-agent-loop and
+// delaying them would only slow the loop without protecting upstream rate limits).
 //
 // At the provider layer messages are OpenAI-shaped, where tool results carry
 // role "tool" — so the role check alone covers the normal path. The content
@@ -11,23 +11,43 @@
 // insurance against any pass-through shape. Malformed input => false
 // (fail-safe: never serialize what we cannot classify).
 
-export function isUserMessageRequest(req: { messages?: unknown }): boolean {
-  const messages = req.messages;
-  if (!Array.isArray(messages) || messages.length === 0) return false;
-  const last: unknown = messages[messages.length - 1];
-  if (typeof last !== "object" || last === null) return false;
-  const { role, content } = last as { role?: unknown; content?: unknown };
-  if (role !== "user") return false;
-  if (Array.isArray(content)) {
-    for (const part of content) {
-      if (typeof part === "object" && part !== null) {
-        const p = part as { type?: unknown; tool_use_id?: unknown; tool_call_id?: unknown };
-        if (p.type === "tool_result" || p.type === "tool_use_result" || p.type === "tool_use") {
-          return false;
-        }
-        if (p.tool_use_id !== undefined || p.tool_call_id !== undefined) return false;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isToolResultContent(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  for (const part of content) {
+    if (isRecord(part)) {
+      if (
+        part.type === "tool_result" ||
+        part.type === "tool_use_result" ||
+        part.type === "tool_use"
+      ) {
+        return true;
       }
+      if (part.tool_use_id !== undefined || part.tool_call_id !== undefined) return true;
     }
   }
-  return true;
+  return false;
+}
+
+export function isUserMessageRequest(req: { messages?: unknown; input?: unknown }): boolean {
+  const messages = req.messages;
+  if (Array.isArray(messages)) {
+    if (messages.length === 0) return false;
+    const last: unknown = messages[messages.length - 1];
+    if (!isRecord(last)) return false;
+    if (last.role !== "user") return false;
+    return !isToolResultContent(last.content);
+  }
+
+  const input = req.input;
+  if (typeof input === "string") return input.trim().length > 0;
+  if (!Array.isArray(input) || input.length === 0) return false;
+  const last: unknown = input[input.length - 1];
+  if (!isRecord(last)) return false;
+  if (last.type === "function_call_output" || last.type === "reasoning") return false;
+  if (last.role !== "user") return false;
+  return !isToolResultContent(last.content);
 }

--- a/scripts/passthrough/deterministic-e2e.ts
+++ b/scripts/passthrough/deterministic-e2e.ts
@@ -488,7 +488,10 @@ async function testResponsesExecuteStoreForcedFalse(): Promise<void> {
       assert.equal(parsed.model, "gpt-5-codex");
       assert.equal(parsed.store, false);
       assert.deepEqual(parsed.future_field, { preserved: true });
-      assert.deepEqual(carrier.mutations.body_shims_applied, ["store_forced_false"]);
+      assert.deepEqual(carrier.mutations.body_shims_applied, [
+        "instructions_defaulted",
+        "store_forced_false",
+      ]);
       assert.equal(carrier.mutations.model_rewritten?.to, "gpt-5-codex");
       const headers = lowerHeaders(captured[0]?.headers ?? {});
       assert.equal(headers["x-helm-internal"], undefined);


### PR DESCRIPTION
## Summary
- add device/session affinity for OAuth subscription account pools using deterministic rendezvous hashing inside the preferred priority tier
- avoid busy accounts through the shared per-account user-message queue probe, including native Responses input requests
- keep `previous_response_id` safe by using only known response-id-to-account mappings, never random hashing unknown response ids
- add redaction-safe selection observability for account choice reason, key source, capacity avoidance, and retry attempt

## Test plan
- `corepack pnpm exec vitest run packages/core/src/queue/user-turn.test.ts packages/core/src/provider/oauth/serialize-client.test.ts packages/core/src/provider/oauth/pool.test.ts packages/core/src/queue/keyed-serial-gate.test.ts apps/gateway/src/server.oauth.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`
- `corepack pnpm test:e2e`
- `corepack pnpm test:protocol-compat:ast`
- `corepack pnpm test:passthrough`