### PR TITLE
Optimize admin memory stats queries

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-04 · Memory stats 队列统计避免扫全量历史 job（Admin memory performance，docs/11/13，原则 1/7）
+
+- **背景（Lukin）**：线上逐页排查 admin API timing 后，绝大多数接口在 1–20ms，`/admin/api/oauth*` 稳定约 140–160ms；真正稳定慢的是 `/admin/api/memory/stats`，每次约 8.6–11.2s，导致 Memory 页面打开/刷新时明显卡住。
+- **根因**：生产 `memory_jobs` 已接近 10 万行且全部为历史 `done` job。stats 接口每次刷新都用 `CASE WHEN status = ...` 对整张 job 历史做时间统计，又额外做 `type/status` 汇总；这些读是同步 SQLite 路径，会阻塞 Node 事件循环，放大成后台页面卡顿。
+- **查询决策**：队列时间统计拆成按状态查询：pending 查最早 `created_at`，running 查最早/过期 `updated_at`，done/failed 查最新 `updated_at`。这样没有 open job 时不再为几个空指标扫描全部 done 历史。
+- **索引决策**：SQLite/Postgres 都新增 `memory_jobs(status, updated_at, created_at)` 与 `memory_jobs(type, status)`，分别服务状态时间统计和 jobs-by-type 汇总；迁移对缺少 `memory_jobs` 的老 fixture/部分升级库保持兼容。
+- **保持不变**：返回 JSON 语义不变；仍然是只读 admin observability，不读取 message body、不输出明文 key/payload、不触发 worker。
+- **验证计划**：覆盖 SQLite/Postgres stats 返回语义和迁移索引存在性；部署后用线上 `/admin/api/memory/stats` timing、`/admin/memory` 浏览器点击、`/healthz`/`/version` 验证。
+
 ## 2026-07-04 · OAuth 账号池改为会话亲和调度（OAuth provider pool / routing，docs/04/11，原则 3/5/7）
 
 - **背景（Lukin）**：订阅 provider 有多个账号时，单纯 priority + LRU 轮询会让同一客户端会话在多个账号/多个上游设备身份之间漂移，容易呈现“账号池”特征。目标是同一 session/device 尽量固定到同一账号，只有账号不可用、额度/限流、或账号容量已满时才切换，同时让多个账号在新会话维度尽量均衡使用。
@@ -88,18 +97,10 @@
 - **task_type 决策**：低成本自动化模式下，task detector 忽略 ambient tool-prefix 和 file-path 证据，但仍保留显式 coding keyword（如 `debug/refactor/function`）的升级路径，避免真正要修代码的 monitor 任务被错误降级。
 - **验证计划**：新增 openclaw cron monitor golden route 回归、override 单测、taskdetect 单测和 schema 默认值测试；目标是该形态走 `chat/simple/economy`，链首回到 `openai-codex/gpt-5.4-mini`。
 
-## 2026-07-03 · 上下文窗口超限按候选跳过处理（执行 fallback / streaming telemetry，docs/04/07，原则 5/8）
-
-- **背景（Lukin）**：生产请求 `69d5058f-ea6c-4bfc-91d8-0686a7c120f3` 最终由 `anthropic/claude-opus-4-8` 成功服务，但链中 `openai-codex/gpt-5.5` 先返回 Responses stream `context_length_exceeded`，admin 详情把它显示为普通 `upstream_error`。
-- **修复决策**：`context_length_exceeded` / “context window” / “prompt is too long” 属于当前候选模型窗口不足；即使它来自首个有效输出前的 SSE error 且没有 HTTP 400，也记录为 `skipped:true` + `skip_reason:"context_too_small"`，继续执行 fallback。
-- **熔断决策**：该类错误不调用 `breaker.recordFailure()`，不触发 OAuth 账号 auto-park，也不计入 execution fallback count；它和预检能力过滤的 `context_too_small` 语义保持一致。
-- **保留边界**：非上下文类 request-shape 错误（例如图片尺寸超限、非法参数）仍短路为 `invalid_request`，因为换候选模型无法修复请求体本身。
-- **验证**：新增执行器 stream 回归测试，覆盖 Codex Responses `context_length_exceeded` 先失败、后续 Opus 成功、首个 attempt 显示跳过且不记录 breaker failure；目标 `execute.test.ts` 117/117 绿。
-
 ## 历史条目摘要（最近 2 条）
 
+- **2026-07-03 · 上下文窗口超限按候选跳过处理（执行 fallback / streaming telemetry，docs/04/07，原则 5/8）**：`context_length_exceeded` / prompt-too-long 类错误按候选 `context_too_small` 跳过并继续 fallback，不熔断 provider。
 - **2026-07-03 · API key 级 usage stats 给外部自动化读取（Gateway usage API / telemetry，docs/07，原则 7）**：`GET /v1/usage/stats` 复用 API-key auth，只聚合当前 key 的 request/token/cost 统计，避免外部自动化直接读库。
-- **2026-07-02 · API key 加密恢复与原地轮转（Auth / Admin keys，docs/06/11，原则 7）**：API key reveal/rotate 改用 `secret_enc` 恢复材料，鉴权仍只依赖 sha256，历史 hash-only key 明确不可恢复但可原地轮转。
 
 ## 更早历史总览
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -93,6 +93,27 @@ function pgRows<T>(result: unknown): T[] {
   return Array.isArray(maybe.rows) ? maybe.rows : [];
 }
 
+function pgMemoryJobScopeClauses(input: MemoryAdminStatsScope): SQL[] {
+  const clauses: SQL[] = [];
+  if (input.accountId !== undefined) {
+    clauses.push(sql`scope_id::jsonb ->> 'accountId' = ${input.accountId}`);
+  }
+  if (input.projectId !== undefined) {
+    clauses.push(sql`scope_id::jsonb ->> 'projectId' = ${input.projectId}`);
+  }
+  if (input.resourceId !== undefined) {
+    clauses.push(sql`scope_id::jsonb ->> 'resourceId' = ${input.resourceId}`);
+  }
+  if (input.threadId !== undefined) {
+    clauses.push(sql`scope_id::jsonb ->> 'threadId' = ${input.threadId}`);
+  }
+  return clauses;
+}
+
+function pgWhere(clauses: readonly SQL[]): SQL {
+  return clauses.length > 0 ? sql`WHERE ${sql.join([...clauses], sql` AND `)}` : sql``;
+}
+
 // Observation read scope — pg mirror of the sqlite adapter's observationScopeWhere
 // (same contract, different dialect). Thread scope = the thread's own rows;
 // project/resource scope = aggregated across all the owner's matching threads
@@ -1195,6 +1216,7 @@ export class PgMemoryStore implements MemoryStore {
     const threadId = input.threadId ?? null;
     const noScopeFilter =
       accountId === null && projectId === null && resourceId === null && threadId === null;
+    const jobScopeClauses = pgMemoryJobScopeClauses(input);
     const threads = pgRows<{ n: number | string }>(
       await this.db.execute(
         noScopeFilter
@@ -1291,21 +1313,12 @@ export class PgMemoryStore implements MemoryStore {
     )[0];
     const queueRows = pgRows<{ status: string; n: number | string }>(
       await this.db.execute(
-        noScopeFilter
-          ? sql`
-              SELECT status, COUNT(*)::bigint AS n
-                FROM memory_jobs
-               GROUP BY status
-            `
-          : sql`
-              SELECT status, COUNT(*)::bigint AS n
-                FROM memory_jobs
-               WHERE (${accountId}::text IS NULL OR scope_id::jsonb ->> 'accountId' = ${accountId})
-                 AND (${projectId}::text IS NULL OR scope_id::jsonb ->> 'projectId' = ${projectId})
-                 AND (${resourceId}::text IS NULL OR scope_id::jsonb ->> 'resourceId' = ${resourceId})
-                 AND (${threadId}::text IS NULL OR scope_id::jsonb ->> 'threadId' = ${threadId})
-               GROUP BY status
-            `,
+        sql`
+          SELECT status, COUNT(*)::bigint AS n
+            FROM memory_jobs
+            ${pgWhere(jobScopeClauses)}
+           GROUP BY status
+        `,
       ),
     );
     const queue = { pending: 0, running: 0, done: 0, failed: 0 };
@@ -1315,58 +1328,38 @@ export class PgMemoryStore implements MemoryStore {
       else if (row.status === "done") queue.done = numberOf(row.n);
       else if (row.status === "failed") queue.failed = numberOf(row.n);
     }
-    const queueTimes = pgRows<{
-      oldestPendingAt: number | string | null;
-      oldestRunningAt: number | string | null;
-      newestDoneAt: number | string | null;
-      newestFailedAt: number | string | null;
-      staleRunning: number | string | null;
-    }>(
-      await this.db.execute(
-        noScopeFilter
-          ? sql`
-              SELECT
-                MIN(CASE WHEN status = 'pending' THEN created_at END)::bigint AS "oldestPendingAt",
-                MIN(CASE WHEN status = 'running' THEN updated_at END)::bigint AS "oldestRunningAt",
-                MAX(CASE WHEN status = 'done' THEN updated_at END)::bigint AS "newestDoneAt",
-                MAX(CASE WHEN status = 'failed' THEN updated_at END)::bigint AS "newestFailedAt",
-                SUM(CASE WHEN status = 'running' AND updated_at <= ${input.now.getTime() - RUNNING_LEASE_MS} THEN 1 ELSE 0 END)::bigint AS "staleRunning"
-               FROM memory_jobs
-            `
-          : sql`
-              SELECT
-                MIN(CASE WHEN status = 'pending' THEN created_at END)::bigint AS "oldestPendingAt",
-                MIN(CASE WHEN status = 'running' THEN updated_at END)::bigint AS "oldestRunningAt",
-                MAX(CASE WHEN status = 'done' THEN updated_at END)::bigint AS "newestDoneAt",
-                MAX(CASE WHEN status = 'failed' THEN updated_at END)::bigint AS "newestFailedAt",
-                SUM(CASE WHEN status = 'running' AND updated_at <= ${input.now.getTime() - RUNNING_LEASE_MS} THEN 1 ELSE 0 END)::bigint AS "staleRunning"
-               FROM memory_jobs
-              WHERE (${accountId}::text IS NULL OR scope_id::jsonb ->> 'accountId' = ${accountId})
-                AND (${projectId}::text IS NULL OR scope_id::jsonb ->> 'projectId' = ${projectId})
-                AND (${resourceId}::text IS NULL OR scope_id::jsonb ->> 'resourceId' = ${resourceId})
-                AND (${threadId}::text IS NULL OR scope_id::jsonb ->> 'threadId' = ${threadId})
-            `,
-      ),
-    )[0];
+    const jobScalar = async (
+      expr: SQL,
+      status: MemoryJobStatus,
+      extraClauses: readonly SQL[] = [],
+    ): Promise<number | string | null> => {
+      const rows = pgRows<{ value: number | string | null }>(
+        await this.db.execute(sql`
+          SELECT ${expr} AS value
+            FROM memory_jobs
+            ${pgWhere([sql`status = ${status}`, ...jobScopeClauses, ...extraClauses])}
+        `),
+      );
+      return rows[0]?.value ?? null;
+    };
+    const queueTimes = {
+      oldestPendingAt: await jobScalar(sql`MIN(created_at)::bigint`, "pending"),
+      oldestRunningAt: await jobScalar(sql`MIN(updated_at)::bigint`, "running"),
+      newestDoneAt: await jobScalar(sql`MAX(updated_at)::bigint`, "done"),
+      newestFailedAt: await jobScalar(sql`MAX(updated_at)::bigint`, "failed"),
+      staleRunning: await jobScalar(sql`COUNT(*)::bigint`, "running", [
+        sql`updated_at <= ${input.now.getTime() - RUNNING_LEASE_MS}`,
+      ]),
+    };
     const byType = pgRows<{ type: string; status: string; count: number | string }>(
       await this.db.execute(
-        noScopeFilter
-          ? sql`
-              SELECT type, status, COUNT(*)::bigint AS count
-                FROM memory_jobs
-               GROUP BY type, status
-               ORDER BY type ASC, status ASC
-            `
-          : sql`
-              SELECT type, status, COUNT(*)::bigint AS count
-                FROM memory_jobs
-               WHERE (${accountId}::text IS NULL OR scope_id::jsonb ->> 'accountId' = ${accountId})
-                 AND (${projectId}::text IS NULL OR scope_id::jsonb ->> 'projectId' = ${projectId})
-                 AND (${resourceId}::text IS NULL OR scope_id::jsonb ->> 'resourceId' = ${resourceId})
-                 AND (${threadId}::text IS NULL OR scope_id::jsonb ->> 'threadId' = ${threadId})
-               GROUP BY type, status
-               ORDER BY type ASC, status ASC
-            `,
+        sql`
+          SELECT type, status, COUNT(*)::bigint AS count
+            FROM memory_jobs
+            ${pgWhere(jobScopeClauses)}
+           GROUP BY type, status
+           ORDER BY type ASC, status ASC
+        `,
       ),
     ).map((r) => ({ type: r.type, status: r.status, count: numberOf(r.count) }));
     return {

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -140,6 +140,17 @@ describe("runPgMigrations — per-migration atomicity", () => {
     await db.$close();
   });
 
+  it("creates memory job admin-stats indexes", async () => {
+    const db = await createPgliteDb();
+    const indexes = (await db.execute(
+      sql.raw("SELECT indexname FROM pg_indexes WHERE tablename = 'memory_jobs'"),
+    )) as { rows: Array<{ indexname: string }> };
+    expect(indexes.rows.map((r) => r.indexname)).toEqual(
+      expect.arrayContaining(["idx_memory_jobs_status_updated_at", "idx_memory_jobs_type_status"]),
+    );
+    await db.$close();
+  });
+
   // docs/12 "Schema deltas" (P2) — the forgetting migration (sqlite v18 / pg
   // v17). Additive columns + the new account-scoped memory_facts table, mirrored
   // into the pg dialect per CLAUDE.md (dialect differences sealed in the adapter).

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -719,6 +719,28 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Admin memory stats queue indexes — pg mirror of sqlite v35.
+    version: 34,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "memory_jobs", ["status", "updated_at", "created_at"])) {
+        await db.execute(
+          sql.raw(`
+            CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_updated_at
+              ON memory_jobs (status, updated_at, created_at)
+          `),
+        );
+      }
+      if (await pgTableHasColumns(db, "memory_jobs", ["type", "status"])) {
+        await db.execute(
+          sql.raw(`
+            CREATE INDEX IF NOT EXISTS idx_memory_jobs_type_status
+              ON memory_jobs (type, status)
+          `),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {
@@ -729,7 +751,7 @@ function resultRows<T>(result: unknown): T[] {
 
 async function pgTableHasColumns(
   db: RawExecutor,
-  table: "memory_threads" | "memory_messages",
+  table: "memory_threads" | "memory_messages" | "memory_jobs",
   requiredColumns: readonly string[],
 ): Promise<boolean> {
   const rows = resultRows<{ column_name: string }>(

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -236,6 +236,15 @@ describe("sqlite v18 forgetting schema deltas", () => {
       .map((i) => (i as { name: string }).name);
   }
 
+  it("creates memory job admin-stats indexes", () => {
+    const db = createSqliteDb(":memory:");
+    const raw = db.$sqlite;
+    expect(indexNames(raw, "memory_jobs")).toEqual(
+      expect.arrayContaining(["idx_memory_jobs_status_updated_at", "idx_memory_jobs_type_status"]),
+    );
+    raw.close();
+  });
+
   it("adds the forgetting columns to memory_observations", () => {
     const db = createSqliteDb(":memory:");
     const raw = db.$sqlite;

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -90,6 +90,35 @@ function countOf(row: { n?: number } | undefined): number {
   return row?.n ?? 0;
 }
 
+function sqliteMemoryJobScope(input: MemoryAdminStatsScope): {
+  clauses: string[];
+  args: unknown[];
+} {
+  const clauses: string[] = [];
+  const args: unknown[] = [];
+  if (input.accountId !== undefined) {
+    clauses.push("json_extract(scope_id, '$.accountId') = ?");
+    args.push(input.accountId);
+  }
+  if (input.projectId !== undefined) {
+    clauses.push("json_extract(scope_id, '$.projectId') = ?");
+    args.push(input.projectId);
+  }
+  if (input.resourceId !== undefined) {
+    clauses.push("json_extract(scope_id, '$.resourceId') = ?");
+    args.push(input.resourceId);
+  }
+  if (input.threadId !== undefined) {
+    clauses.push("json_extract(scope_id, '$.threadId') = ?");
+    args.push(input.threadId);
+  }
+  return { clauses, args };
+}
+
+function sqliteWhere(clauses: readonly string[]): string {
+  return clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+}
+
 // Observation read scope. Two shapes (docs/08):
 //  - thread scope (inject + observer): the thread's own rows, owner-checked;
 //  - project/resource scope (the REFLECTOR's target): aggregate across ALL the
@@ -1148,16 +1177,6 @@ export class SqliteMemoryStore implements MemoryStore {
       threadId,
       threadId,
     ];
-    const jobArgs = [
-      accountId,
-      accountId,
-      projectId,
-      projectId,
-      resourceId,
-      resourceId,
-      threadId,
-      threadId,
-    ];
     const threadWhere = `
       (? IS NULL OR t.owner_id = ?)
       AND (? IS NULL OR t.project_id = ?)
@@ -1170,12 +1189,7 @@ export class SqliteMemoryStore implements MemoryStore {
       AND (? IS NULL OR resource_id = ?)
       AND (? IS NULL OR thread_id = ?)
     `;
-    const jobWhere = `
-      (? IS NULL OR json_extract(scope_id, '$.accountId') = ?)
-      AND (? IS NULL OR json_extract(scope_id, '$.projectId') = ?)
-      AND (? IS NULL OR json_extract(scope_id, '$.resourceId') = ?)
-      AND (? IS NULL OR json_extract(scope_id, '$.threadId') = ?)
-    `;
+    const jobScope = sqliteMemoryJobScope(input);
     const threads = (
       noScopeFilter
         ? this.db.$sqlite.prepare("SELECT COUNT(*) AS n FROM memory_threads").get()
@@ -1253,8 +1267,7 @@ export class SqliteMemoryStore implements MemoryStore {
             )
             .get(...itemArgs)
     ) as { n: number; active: number | null; lastAt: number | null } | undefined;
-    const jobWhereSql = noScopeFilter ? "" : `WHERE ${jobWhere}`;
-    const scopedJobArgs = noScopeFilter ? [] : jobArgs;
+    const jobWhereSql = sqliteWhere(jobScope.clauses);
     const queueRows = this.db.$sqlite
       .prepare(
         `SELECT status, COUNT(*) AS n
@@ -1262,7 +1275,7 @@ export class SqliteMemoryStore implements MemoryStore {
           ${jobWhereSql}
           GROUP BY status`,
       )
-      .all(...scopedJobArgs) as Array<{ status: string; n: number }>;
+      .all(...jobScope.args) as Array<{ status: string; n: number }>;
     const queue = { pending: 0, running: 0, done: 0, failed: 0 };
     for (const row of queueRows) {
       if (row.status === "pending") queue.pending = row.n;
@@ -1270,26 +1283,33 @@ export class SqliteMemoryStore implements MemoryStore {
       else if (row.status === "done") queue.done = row.n;
       else if (row.status === "failed") queue.failed = row.n;
     }
-    const queueTimes = this.db.$sqlite
-      .prepare(
-        `SELECT
-            MIN(CASE WHEN status = 'pending' THEN created_at END) AS oldestPendingAt,
-            MIN(CASE WHEN status = 'running' THEN updated_at END) AS oldestRunningAt,
-            MAX(CASE WHEN status = 'done' THEN updated_at END) AS newestDoneAt,
-            MAX(CASE WHEN status = 'failed' THEN updated_at END) AS newestFailedAt,
-           SUM(CASE WHEN status = 'running' AND updated_at <= ? THEN 1 ELSE 0 END) AS staleRunning
-           FROM memory_jobs
-          ${jobWhereSql}`,
-      )
-      .get(input.now.getTime() - RUNNING_LEASE_MS, ...scopedJobArgs) as
-      | {
-          oldestPendingAt: number | null;
-          oldestRunningAt: number | null;
-          newestDoneAt: number | null;
-          newestFailedAt: number | null;
-          staleRunning: number | null;
-        }
-      | undefined;
+    const jobScalar = (
+      expr: string,
+      status: MemoryJobStatus,
+      extraClause?: string,
+      extraArgs: readonly unknown[] = [],
+    ): number | null => {
+      const clauses = ["status = ?", ...jobScope.clauses];
+      const args: unknown[] = [status, ...jobScope.args];
+      if (extraClause !== undefined) {
+        clauses.push(extraClause);
+        args.push(...extraArgs);
+      }
+      const row = this.db.$sqlite
+        .prepare(`SELECT ${expr} AS value FROM memory_jobs ${sqliteWhere(clauses)}`)
+        .get(...args) as { value: number | null } | undefined;
+      return row?.value ?? null;
+    };
+    const queueTimes = {
+      oldestPendingAt: jobScalar("MIN(created_at)", "pending"),
+      oldestRunningAt: jobScalar("MIN(updated_at)", "running"),
+      newestDoneAt: jobScalar("MAX(updated_at)", "done"),
+      newestFailedAt: jobScalar("MAX(updated_at)", "failed"),
+      staleRunning:
+        jobScalar("COUNT(*)", "running", "updated_at <= ?", [
+          input.now.getTime() - RUNNING_LEASE_MS,
+        ]) ?? 0,
+    };
     const byType = this.db.$sqlite
       .prepare(
         `SELECT type, status, COUNT(*) AS count
@@ -1298,7 +1318,7 @@ export class SqliteMemoryStore implements MemoryStore {
           GROUP BY type, status
           ORDER BY type ASC, status ASC`,
       )
-      .all(...scopedJobArgs) as Array<{ type: string; status: string; count: number }>;
+      .all(...jobScope.args) as Array<{ type: string; status: string; count: number }>;
     return {
       generatedAt: input.now,
       scope: {

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -815,6 +815,28 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Admin memory stats queue indexes. /admin/api/memory/stats reads queue depth,
+    // oldest/newest timestamps, stale running jobs, and jobs-by-type on every Memory
+    // page refresh. Production keeps tens of thousands of completed jobs between
+    // cleanup sweeps, so those reads must use narrow status/type indexes instead of
+    // repeatedly scanning the whole memory_jobs history.
+    version: 35,
+    run: (db) => {
+      if (sqliteTableHasColumns(db, "memory_jobs", ["status", "updated_at", "created_at"])) {
+        db.exec(`
+          CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_updated_at
+            ON memory_jobs (status, updated_at, created_at);
+        `);
+      }
+      if (sqliteTableHasColumns(db, "memory_jobs", ["type", "status"])) {
+        db.exec(`
+          CREATE INDEX IF NOT EXISTS idx_memory_jobs_type_status
+            ON memory_jobs (type, status);
+        `);
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(


### PR DESCRIPTION
## Summary
- identify `/admin/api/memory/stats` as the stable slow admin endpoint on production traffic
- split queue timestamp stats into status-scoped indexed reads instead of full-history CASE aggregates
- add SQLite/Postgres indexes for memory job status/time and type/status admin stats
- bump release version to `0.23.3`

## Validation
- `corepack pnpm exec vitest run packages/core/src/store/sqlite/memory-admin.test.ts packages/core/src/store/sqlite/memory-schema.test.ts packages/core/src/store/postgres/memory-admin.test.ts packages/core/src/store/postgres/migrate.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`