### PR TITLE
Restore settings page full width

### DIFF
--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -152,7 +152,7 @@
   }
 </script>
 
-<section class="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-6 md:px-8">
+<section class="flex w-full flex-col gap-6 px-4 py-6 md:px-8">
   <header class="flex flex-col gap-2">
     <h1 class="page-title">{$t('System Settings')}</h1>
     <p class="section-desc">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- restore the Settings page top-level container to the same full-width layout used by other admin pages
- keep the reorganized Settings grouping intact
- bump release version to 0.24.2

## Verification
- corepack pnpm --filter @helm/admin check
- corepack pnpm --filter @helm/admin build
- corepack pnpm --filter @helm/gateway exec playwright test --project=admin --grep "renders the settings page"
- browser width check at 1440px: /admin/settings and /admin/requests both measured 1184px content width with matching left/right edges

Note: unrelated local classifier/config changes were present in the working tree and were not included in this PR.