### PR TITLE
chore(release): v0.24.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump root package version from 0.24.2 to 0.24.3
- release #451 cheap-model low-risk classifier routing changes

## Version choice
- patch bump: classifier/config routing optimization, no breaking API or feature-surface expansion requiring a minor bump
- v0.24.2 already exists for the previous settings-width release, so this uses the next patch version

## Verification
- `node -p "require('./package.json').version"` -> 0.24.3
- `corepack pnpm exec vitest run packages/shared/src/smoke.test.ts packages/shared/src/ci-workflow.test.ts packages/shared/src/dockerfile.test.ts packages/shared/src/compose.test.ts`