### PR TITLE
Release v0.24.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump root package version to 0.24.5 so the publish workflow cuts the release and versioned image

## Validation
- node -p "require('./package.json').version"