### PR TITLE
Tighten compact request table layout

### DIFF
--- a/apps/admin/src/lib/components/RequestsTable.svelte
+++ b/apps/admin/src/lib/components/RequestsTable.svelte
@@ -37,10 +37,7 @@
   } = $props();
 
   const visibleKey = $derived(showKey ?? variant !== 'key');
-  const compactMetrics = $derived(variant !== 'full');
   const visibleRequestId = $derived(variant === 'full');
-  const showRoutingDetail = $derived(variant !== 'recent');
-  const showServingAccount = $derived(variant !== 'recent');
 
   // Navigate when the row is clicked, EXCEPT when the click originates on an inner
   // control (the request-id <a> and the key-filter <button> handle their own click).
@@ -163,12 +160,10 @@
         {r.decided_by}
       </span>
     </div>
-    {#if showRoutingDetail}
-      <div class="mt-1 text-xs text-ink-muted">
-        {r.task_type || '—'}{#if r.complexity}
-          · {r.complexity}{/if}
-      </div>
-    {/if}
+    <div class="mt-1 text-xs text-ink-muted">
+      {r.task_type || '—'}{#if r.complexity}
+        · {r.complexity}{/if}
+    </div>
   </div>
 {/snippet}
 
@@ -187,7 +182,7 @@
         </span>
       {/if}
     </div>
-    {#if showServingAccount && r.serving_account}
+    {#if r.serving_account}
       <div
         class="mt-1 max-w-[12rem] truncate font-mono text-xs text-ink-muted"
         title={accountTitle(r.serving_account)}
@@ -202,24 +197,6 @@
   <div data-testid="cell-performance" class="font-mono text-xs leading-tight">
     <div>{r.latency_ms}ms</div>
     <div data-testid="cell-tps" class="text-ink-muted">{formatTps(r.tps)}</div>
-  </div>
-{/snippet}
-
-{#snippet metricsCell(r: RequestListItem)}
-  <div data-testid="cell-metrics" class="font-mono text-xs leading-tight">
-    {#if variant === 'recent'}
-      <div>{r.latency_ms}ms · {formatTps(r.tps)}</div>
-      <div class="text-ink-muted">{formatUsd(r.cost_usd)}</div>
-      <div class="mt-1">
-        <TokensCell usage={r.usage} />
-      </div>
-    {:else}
-      <div>{formatUsd(r.cost_usd)}</div>
-      <div class="mt-1">
-        <TokensCell usage={r.usage} />
-      </div>
-      <div class="text-ink-muted">{r.latency_ms}ms · {formatTps(r.tps)}</div>
-    {/if}
   </div>
 {/snippet}
 
@@ -253,21 +230,15 @@
         <th class="px-3 py-2" title={$t('Provider, account, and execution fallback count.')}
           >{$t('Serving')}</th
         >
-        {#if compactMetrics}
-          <th class="px-3 py-2" title={$t('Cost, token usage, latency, and throughput.')}
-            >{$t('Metrics')}</th
-          >
-        {:else}
-          <th class="px-3 py-2" title={$t('Estimated cost of the request in US dollars.')}
-            >{$t('Cost')}</th
-          >
-          <th class="px-3 py-2" title={$t('Token usage: input / output, with cached input tokens.')}
-            >{$t('Tokens')}</th
-          >
-          <th class="px-3 py-2" title={$t('End-to-end latency and streamed generation throughput.')}
-            >{$t('Performance')}</th
-          >
-        {/if}
+        <th class="px-3 py-2" title={$t('Estimated cost of the request in US dollars.')}
+          >{$t('Cost')}</th
+        >
+        <th class="px-3 py-2" title={$t('Token usage: input / output, with cached input tokens.')}
+          >{$t('Tokens')}</th
+        >
+        <th class="px-3 py-2" title={$t('End-to-end latency and streamed generation throughput.')}
+          >{$t('Performance')}</th
+        >
         {#if visibleRequestId}
           <th class="px-3 py-2" title={$t('The unique trace ID recorded for this request.')}
             >{$t('Request ID')}</th
@@ -330,19 +301,13 @@
           <td data-label={$t('Serving')} class="px-3 py-2">
             {@render servingCell(r)}
           </td>
-          {#if compactMetrics}
-            <td data-label={$t('Metrics')} class="px-3 py-2">
-              {@render metricsCell(r)}
-            </td>
-          {:else}
-            <td data-label={$t('Cost')} class="px-3 py-2 font-mono text-ink-body">
-              {formatUsd(r.cost_usd)}
-            </td>
-            <td data-label={$t('Tokens')} class="px-3 py-2"><TokensCell usage={r.usage} /></td>
-            <td data-label={$t('Performance')} class="px-3 py-2">
-              {@render performanceCell(r)}
-            </td>
-          {/if}
+          <td data-label={$t('Cost')} class="px-3 py-2 font-mono text-ink-body">
+            {formatUsd(r.cost_usd)}
+          </td>
+          <td data-label={$t('Tokens')} class="px-3 py-2"><TokensCell usage={r.usage} /></td>
+          <td data-label={$t('Performance')} class="px-3 py-2">
+            {@render performanceCell(r)}
+          </td>
           {#if visibleRequestId}
             <td data-label={$t('Request ID')} class="px-3 py-2">
               <a

--- a/apps/admin/src/lib/components/RequestsTable.test.ts
+++ b/apps/admin/src/lib/components/RequestsTable.test.ts
@@ -90,15 +90,21 @@ describe('RequestsTable variants', () => {
     expect(screen.getByText('Request ID')).toBeInTheDocument();
   });
 
-  it('uses a compact metrics cell and hides Request ID in the dashboard recent variant', () => {
+  it('keeps the request-list metric columns and hides only Request ID in the dashboard recent variant', () => {
     render(RequestsTable, { items: [item()], detailHref, variant: 'recent' });
 
     const row = screen.getByTestId('request-row');
-    expect(within(row).getByTestId('cell-metrics')).toHaveTextContent('460ms');
-    expect(within(row).getByTestId('cell-metrics')).toHaveTextContent('$0.0123');
-    expect(within(row).getByTestId('cell-metrics')).toHaveTextContent('↑ 1.2K');
-    expect(within(row).getByTestId('cell-metrics')).toHaveTextContent('↓ 340');
-    expect(within(row).getByTestId('cell-metrics')).toHaveTextContent('cached 800');
+    expect(screen.getByText('Cost')).toBeInTheDocument();
+    expect(screen.getByText('Tokens')).toBeInTheDocument();
+    expect(screen.getByText('Performance')).toBeInTheDocument();
+    expect(screen.queryByText('Metrics')).toBeNull();
+    expect(within(row).getByText('$0.0123')).toBeInTheDocument();
+    expect(within(row).getByTestId('tokens-cell')).toHaveTextContent('↑ 1.2K');
+    expect(within(row).getByTestId('tokens-cell')).toHaveTextContent('↓ 340');
+    expect(within(row).getByTestId('tokens-cell')).toHaveTextContent('cached 800');
+    expect(within(row).getByTestId('cell-performance')).toHaveTextContent('460ms');
+    expect(within(row).getByTestId('cell-routing')).toHaveTextContent('coding');
+    expect(within(row).getByTestId('cell-serving')).toHaveTextContent('claude-team-a');
     expect(within(row).getByTestId('request-detail-link')).toHaveAttribute(
       'href',
       '/requests/tr_1',
@@ -112,10 +118,13 @@ describe('RequestsTable variants', () => {
     expect(screen.queryByText('Key')).toBeNull();
     expect(screen.queryByText('Request ID')).toBeNull();
     expect(screen.getByTestId('request-detail-link')).toHaveAttribute('href', '/requests/tr_1');
-    expect(screen.getByTestId('cell-metrics')).toBeInTheDocument();
+    expect(screen.getByText('Cost')).toBeInTheDocument();
+    expect(screen.getByText('Tokens')).toBeInTheDocument();
+    expect(screen.getByText('Performance')).toBeInTheDocument();
+    expect(screen.queryByText('Metrics')).toBeNull();
   });
 
-  it('keeps unknown token usage as unknown in compact metrics', () => {
+  it('keeps unknown token usage as unknown in the shared token column', () => {
     render(RequestsTable, {
       items: [
         item({
@@ -133,10 +142,8 @@ describe('RequestsTable variants', () => {
       variant: 'recent',
     });
 
-    expect(screen.getByTestId('cell-metrics')).not.toHaveTextContent('— tok');
-    expect(within(screen.getByTestId('cell-metrics')).getByTestId('tokens-cell')).toHaveTextContent(
-      '—',
-    );
+    expect(screen.getByTestId('tokens-cell')).not.toHaveTextContent('— tok');
+    expect(screen.getByTestId('tokens-cell')).toHaveTextContent('—');
   });
 
   it('does not repeat normal auto-routing requests as requested-model drift', () => {


### PR DESCRIPTION
## Summary
- keep dashboard and key-scoped request tables aligned with the main request list
- remove the merged Metrics column from compact variants
- keep routing details, serving account, cost, tokens, and performance visible as separate scan-friendly columns

## Verification
- corepack pnpm --filter @helm/admin check
- corepack pnpm vitest run apps/admin/src/lib/components/RequestsTable.test.ts
- corepack pnpm --filter @helm/admin build