### PR TITLE
Release v0.24.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API release version to v0.24.6
- includes compact request table density fix from #457

## Verification
- covered by release PR CI