### PR TITLE
Guard Codex reset credit consumption

### DIFF
--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -227,6 +227,7 @@ export async function resetUsageLimit(provider: string, account = 'default'): Pr
 export interface CodexResetCreditResult {
   code: string | null;
   windowsReset: number | null;
+  redeemRequestId?: string;
 }
 
 // POST /oauth/:provider/reset-credit -> consume one rate-limit reset credit for the

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -80,6 +80,7 @@
 
   const keyOf = (providerId: string, account: string): string => `${providerId}/${account}`;
   const ACTIVE_LIMIT_RECOVERY_THRESHOLD = 95;
+  const CODEX_RESET_MIN_WEEKLY_USED_PERCENT = 90;
 
   // One table row per connected account, flattened across providers, joined to its
   // usage + quota snapshot (both fail-open: a missing entry renders "—").
@@ -146,9 +147,7 @@
       .split('-')
       .filter(Boolean)
       .map((part) =>
-        part.length <= 3
-          ? part.toUpperCase()
-          : `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`,
+        part.length <= 3 ? part.toUpperCase() : `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`,
       )
       .join(' ');
   }
@@ -236,6 +235,36 @@
       return null;
     }
     return untilMs == null ? null : { untilMs, label };
+  }
+
+  function codexWeeklyUsedPercent(q: OAuthQuotaSnapshot | undefined): number | null {
+    const weekly = q?.windows
+      .filter((w) => w.key === 'secondary')
+      .map((w) => w.usedPercent)
+      .filter((pct) => Number.isFinite(pct));
+    return weekly && weekly.length > 0 ? Math.max(...weekly) : null;
+  }
+
+  function canUseCodexResetCredit(
+    q: OAuthQuotaSnapshot | undefined,
+    credits: number | null,
+  ): boolean {
+    return (
+      credits != null &&
+      credits > 0 &&
+      (codexWeeklyUsedPercent(q) ?? -1) >= CODEX_RESET_MIN_WEEKLY_USED_PERCENT
+    );
+  }
+
+  function resetCreditTitle(q: OAuthQuotaSnapshot | undefined, credits: number | null): string {
+    const weekly = codexWeeklyUsedPercent(q);
+    if (credits == null) return $t('Reset-credit count unavailable');
+    if (credits <= 0) return $t('No reset credits available');
+    if (weekly == null) return $t('Weekly quota snapshot unavailable');
+    if (weekly < CODEX_RESET_MIN_WEEKLY_USED_PERCENT) {
+      return $t('Weekly usage must reach 90% before reset credits can be used');
+    }
+    return $t('Consume one credit to restore the rate-limit window');
   }
 
   // Countdown to auto-recovery for the rate-limited pill — same `durationParts`
@@ -361,16 +390,19 @@
     error = null;
     resetNotice = null;
     try {
-      // Persist the auto-reset opt-in first, decoupled from the consume below: even if
-      // the reset fails (no credit / network), the operator's "do this automatically
-      // from now on" choice still sticks. Best-effort — a save failure never blocks the
-      // reset (they can still toggle it in the Manage dialog).
+      const quota = quotaByKey.get(keyOf(providerId, account));
+      if (!canUseCodexResetCredit(quota, confirmingReset.credits)) {
+        error = $t('Reset limit requires weekly usage of at least 90%');
+        return;
+      }
+      const result = await consumeCodexResetCredit(providerId, account);
+      // Persist the auto-reset opt-in only after the scarce reset-credit consume
+      // succeeds. A failed manual reset must not silently enable future auto-spends.
       try {
         await setAccountSchedule(providerId, account, { autoReset });
       } catch {
         /* non-fatal: the manual reset is the primary action */
       }
-      const result = await consumeCodexResetCredit(providerId, account);
       confirmingReset = null;
       await invalidateAll();
       resetNotice =
@@ -501,6 +533,7 @@
             {@const supportsFast =
               row.provider.id === 'anthropic' || row.provider.id === 'openai-codex'}
             {@const codexCredits = isCodex ? (quota?.resetCredits ?? null) : null}
+            {@const canResetCodexLimit = isCodex && canUseCodexResetCredit(quota, codexCredits)}
             {@const usageLimit = usageLimitStatus(quota)}
             {@const usageLimitRecovery = usageLimit ? autoRecoverIn(usageLimit.untilMs) : ''}
             <tr class="align-top" data-testid="provider-account-row">
@@ -719,12 +752,8 @@
                     <button
                       type="button"
                       class="btn-secondary"
-                      disabled={codexCredits == null || codexCredits <= 0}
-                      title={codexCredits == null
-                        ? $t('Reset-credit count unavailable')
-                        : codexCredits <= 0
-                          ? $t('No reset credits available')
-                          : $t('Consume one credit to restore the rate-limit window')}
+                      disabled={!canResetCodexLimit}
+                      title={resetCreditTitle(quota, codexCredits)}
                       onclick={() =>
                         (confirmingReset = {
                           providerId: row.provider.id,

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -485,7 +485,7 @@ describe('providers page', () => {
 
   // ── Codex "Reset limit" (rate-limit reset credit) ──────────────────────────
   // One Codex account + a quota snapshot carrying the live reset-credit count.
-  function renderCodex(resetCredits: number | null, autoReset = false) {
+  function renderCodex(resetCredits: number | null, autoReset = false, weeklyUsedPercent = 95) {
     renderPage({
       providers: [
         provider({
@@ -518,6 +518,12 @@ describe('providers page', () => {
               usedPercent: 80,
               resetsAtMs: Date.now() + 3_600_000,
               windowMinutes: 300,
+            },
+            {
+              key: 'secondary',
+              usedPercent: weeklyUsedPercent,
+              resetsAtMs: Date.now() + 3 * 86_400_000,
+              windowMinutes: 10_080,
             },
           ],
           capturedAt: Date.now(),
@@ -581,10 +587,37 @@ describe('providers page', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
+  it('does not persist auto-reset from the reset dialog when the consume fails', async () => {
+    consumeCodexResetCredit.mockRejectedValue(new Error('no credits'));
+    renderCodex(2);
+    const row = screen.getByTestId('provider-account-row');
+    await fireEvent.click(within(row).getByRole('button', { name: /reset limit \(2\)/i }));
+
+    const dialog = screen.getByRole('dialog');
+    await fireEvent.click(within(dialog).getByTestId('reset-auto-reset-toggle'));
+    await fireEvent.click(within(dialog).getByRole('button', { name: /^reset limit$/i }));
+
+    await waitFor(() => expect(consumeCodexResetCredit).toHaveBeenCalled());
+    expect(setAccountSchedule).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('no credits');
+  });
+
   it('disables "Reset limit" for a Codex account with no reset credits', () => {
     renderCodex(0);
     const row = screen.getByTestId('provider-account-row');
     expect(within(row).getByRole('button', { name: /reset limit/i })).toBeDisabled();
+    expect(consumeCodexResetCredit).not.toHaveBeenCalled();
+  });
+
+  it('disables "Reset limit" until the Codex weekly window reaches 90%', () => {
+    renderCodex(2, false, 89);
+    const row = screen.getByTestId('provider-account-row');
+    const button = within(row).getByRole('button', { name: /reset limit \(2\)/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Weekly usage must reach 90% before reset credits can be used',
+    );
     expect(consumeCodexResetCredit).not.toHaveBeenCalled();
   });
 

--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -1116,12 +1116,12 @@ describe("createOAuthAdmin > codex reset credit", () => {
     expect(result?.resetCredits).toBeNull();
   });
 
-  it("consumeCodexResetCredit POSTs a redeem id with the bearer + account-id headers", async () => {
-    const { admin, consumeCalls } = await connectCodex({
+  it("consumeCodexResetCredit POSTs and audits a redeem id with the bearer + account-id headers", async () => {
+    const { admin, consumeCalls, logs } = await connectCodex({
       onConsume: () => json({ code: "ok", credit: { id: "c_1" }, windows_reset: 2 }),
     });
     const result = await admin.consumeCodexResetCredit?.({ account: "default" });
-    expect(result).toEqual({ code: "ok", windowsReset: 2 });
+    expect(result).toMatchObject({ code: "ok", windowsReset: 2 });
 
     expect(consumeCalls()).toHaveLength(1);
     const init = consumeCalls()[0]?.init;
@@ -1132,6 +1132,18 @@ describe("createOAuthAdmin > codex reset credit", () => {
     expect(headers["content-type"]).toBe("application/json");
     const body = JSON.parse(String(init?.body)) as { redeem_request_id?: unknown };
     expect(typeof body.redeem_request_id).toBe("string");
+    expect(result?.redeemRequestId).toBe(body.redeem_request_id);
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "oauth.reset_credit.consumed",
+        fields: expect.objectContaining({
+          account: "default",
+          redeem_request_id: body.redeem_request_id,
+          windows_reset: 2,
+        }),
+      }),
+    );
   });
 
   it("consumeCodexResetCredit busts the quota cache so the next PULL re-fetches", async () => {
@@ -1181,10 +1193,17 @@ describe("createOAuthAdmin > codex reset credit", () => {
     await expect(admin.consumeCodexResetCredit?.({ account: "default" })).rejects.toThrow(
       /status 402/,
     );
-    expect(logs).toContainEqual({
-      level: "warn",
-      message: "oauth.reset_credit.failed",
-      fields: { provider_id: "openai-codex", account: "default", status: 402 },
-    });
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "oauth.reset_credit.failed",
+        fields: expect.objectContaining({
+          provider_id: "openai-codex",
+          account: "default",
+          status: 402,
+          redeem_request_id: expect.any(String),
+        }),
+      }),
+    );
   });
 });

--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -154,7 +154,11 @@ export interface OAuthAdminDeps {
   // on a stale snapshot for ~a day with zero log evidence. Optional so the many
   // existing unit harnesses stay untouched. Ids/labels/status only — never a body
   // or token (principle 7).
-  log?: (level: "warn" | "error", message: string, fields?: Record<string, unknown>) => void;
+  log?: (
+    level: "info" | "warn" | "error",
+    message: string,
+    fields?: Record<string, unknown>,
+  ) => void;
 }
 
 // Split a credential into store fields. `meta` carries every key beyond the
@@ -755,6 +759,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       });
       const authorization = await tm.getAuthHeader(); // "Bearer <access>"
       const accountId = codexAccountIdFromToken(authorization.replace(/^Bearer\s+/i, ""));
+      const redeemRequestId = randomUUID();
       const res = await doFetch(CODEX_RESET_URL, {
         method: "POST",
         headers: {
@@ -763,7 +768,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
           "content-type": "application/json",
           ...(accountId ? { "chatgpt-account-id": accountId } : {}),
         },
-        body: JSON.stringify({ redeem_request_id: randomUUID() }),
+        body: JSON.stringify({ redeem_request_id: redeemRequestId }),
         signal: AbortSignal.timeout(QUOTA_FETCH_TIMEOUT_MS),
       });
       if (!res.ok) {
@@ -772,11 +777,19 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
           provider_id: CODEX,
           account,
           status: res.status,
+          redeem_request_id: redeemRequestId,
         });
         throw new Error(`codex reset-credit consume failed (status ${res.status})`);
       }
       const body: unknown = await res.json().catch(() => null);
       const result = parseCodexResetResult(body);
+      log("info", "oauth.reset_credit.consumed", {
+        provider_id: CODEX,
+        account,
+        redeem_request_id: redeemRequestId,
+        code: result.code,
+        windows_reset: result.windowsReset,
+      });
       // The consume restored the windows AND decremented the credit count. The grant is
       // keyed by the upstream ChatGPT account (chatgpt_account_id), which can back
       // SEVERAL connected helm accounts — so a single consume resets every sibling that
@@ -788,7 +801,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       for (const key of [...quotaCache.keys()]) {
         if (key.startsWith(`${CODEX} `)) quotaCache.delete(key);
       }
-      return result;
+      return { ...result, redeemRequestId };
     },
   };
 }

--- a/apps/gateway/src/oauth/auto-reset.test.ts
+++ b/apps/gateway/src/oauth/auto-reset.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { AUTO_RESET_COOLDOWN_MS, cooldownPassed, weeklySaturated } from "./auto-reset.js";
+import {
+  AUTO_RESET_COOLDOWN_MS,
+  CODEX_RESET_MIN_WEEKLY_USED_PERCENT,
+  canConsumeResetCredit,
+  codexWeeklyUsedPercent,
+  cooldownPassed,
+  weeklySaturated,
+} from "./auto-reset.js";
+
+describe("codex reset-credit eligibility", () => {
+  it("requires the weekly (secondary) window to be at least 90%", () => {
+    expect(CODEX_RESET_MIN_WEEKLY_USED_PERCENT).toBe(90);
+    expect(canConsumeResetCredit([{ key: "secondary", usedPercent: 90 }])).toBe(true);
+    expect(canConsumeResetCredit([{ key: "secondary", usedPercent: 100 }])).toBe(true);
+  });
+
+  it("blocks reset-credit consumption below 90% or without a weekly window", () => {
+    expect(canConsumeResetCredit([{ key: "secondary", usedPercent: 89.99 }])).toBe(false);
+    expect(canConsumeResetCredit([{ key: "primary", usedPercent: 100 }])).toBe(false);
+    expect(canConsumeResetCredit([])).toBe(false);
+  });
+
+  it("reports the weekly percentage from secondary only", () => {
+    expect(
+      codexWeeklyUsedPercent([
+        { key: "primary", usedPercent: 100 },
+        { key: "secondary", usedPercent: 42 },
+      ]),
+    ).toBe(42);
+    expect(codexWeeklyUsedPercent([{ key: "primary", usedPercent: 100 }])).toBeNull();
+  });
+});
 
 describe("weeklySaturated", () => {
   it("is true only when the weekly (secondary) window is ≥100%", () => {

--- a/apps/gateway/src/oauth/auto-reset.ts
+++ b/apps/gateway/src/oauth/auto-reset.ts
@@ -7,18 +7,38 @@
 // and at most ONE consume per account per hour (cooldown), so a burst of concurrent
 // saturated replies can't drain the grant.
 
-// At least one hour between reset-credit consumes for the same account. A freshly
-// reset weekly window cannot re-saturate within an hour, so this also makes the
-// in-memory cooldown safe across a gateway restart (no second spend is physically
-// possible before it would expire anyway).
+// At least one hour between reset-credit consumes for the same shared ChatGPT
+// account. The runtime also persists this guard so a container restart cannot
+// rapidly drain the scarce reset-credit grant.
 export const AUTO_RESET_COOLDOWN_MS = 60 * 60 * 1000;
+
+// Manual and automatic reset-credit consumes are only allowed once the Codex weekly
+// window is genuinely close to exhausted. The 5h window recovers on its own and
+// must never justify spending a weekly reset credit.
+export const CODEX_RESET_MIN_WEEKLY_USED_PERCENT = 90;
+
+export function codexWeeklyUsedPercent(
+  windows: ReadonlyArray<{ key: string; usedPercent: number }>,
+): number | null {
+  const weekly = windows
+    .filter((w) => w.key === "secondary")
+    .map((w) => w.usedPercent)
+    .filter((pct) => Number.isFinite(pct));
+  return weekly.length === 0 ? null : Math.max(...weekly);
+}
+
+export function canConsumeResetCredit(
+  windows: ReadonlyArray<{ key: string; usedPercent: number }>,
+): boolean {
+  return (codexWeeklyUsedPercent(windows) ?? -1) >= CODEX_RESET_MIN_WEEKLY_USED_PERCENT;
+}
 
 // True when the WEEKLY window is fully used. Codex keys the 7d window "secondary";
 // the 5h window ("primary") is deliberately ignored (it recovers on its own).
 export function weeklySaturated(
   windows: ReadonlyArray<{ key: string; usedPercent: number }>,
 ): boolean {
-  return windows.some((w) => w.key === "secondary" && w.usedPercent >= 100);
+  return (codexWeeklyUsedPercent(windows) ?? -1) >= 100;
 }
 
 // True when enough time has passed since the last auto-reset for this account

--- a/apps/gateway/src/oauth/reset-credit-guard.test.ts
+++ b/apps/gateway/src/oauth/reset-credit-guard.test.ts
@@ -1,0 +1,299 @@
+import type { ConfigStore } from "@helm/core";
+import type { OAuthQuotaWindow } from "@helm/shared";
+import { describe, expect, it, vi } from "vitest";
+import { AUTO_RESET_COOLDOWN_MS } from "./auto-reset.js";
+import {
+  createResetCreditGuard,
+  resetCreditGuardConfigKey,
+  resetCreditGuardWindowConfigKey,
+} from "./reset-credit-guard.js";
+
+class MemoryConfig implements ConfigStore {
+  readonly values = new Map<string, string>();
+  readonly get = vi.fn(async (key: string) => this.values.get(key) ?? null);
+  readonly set = vi.fn(async (key: string, value: string) => {
+    this.values.set(key, value);
+  });
+  readonly setIfMissingOrNumericLte = vi.fn(async (key: string, value: string, lte: number) => {
+    const current = this.values.get(key);
+    if (current === undefined) {
+      this.values.set(key, value);
+      return true;
+    }
+    if (!/^\d+$/.test(current)) return false;
+    if (Number(current) <= lte) {
+      this.values.set(key, value);
+      return true;
+    }
+    return false;
+  });
+}
+
+const weeklyWindow = (
+  usedPercent: number,
+  resetsAtMs = Date.now() + 86_400_000,
+): OAuthQuotaWindow => ({
+  key: "secondary",
+  usedPercent,
+  resetsAtMs,
+  windowMinutes: 10_080,
+});
+
+const weekly = (usedPercent: number): OAuthQuotaWindow[] => [weeklyWindow(usedPercent)];
+
+describe("createResetCreditGuard", () => {
+  it("persists the one-hour cooldown by shared account so a restart cannot spend again", async () => {
+    const config = new MemoryConfig();
+    const resolveSharedKey = vi.fn(async () => "codex:shared-account");
+    const now = 1_000_000;
+    const first = createResetCreditGuard({ config, resolveSharedKey });
+
+    await expect(
+      first.reserve({
+        providerId: "openai-codex",
+        account: "work-a",
+        windows: weekly(100),
+        mode: "auto",
+        nowMs: now,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    const persistedKey = resetCreditGuardConfigKey("codex:shared-account");
+    expect(config.values.get(persistedKey)).toBe(String(now));
+    expect(persistedKey).not.toContain("shared-account");
+
+    const afterRestart = createResetCreditGuard({ config, resolveSharedKey });
+    const blocked = await afterRestart.reserve({
+      providerId: "openai-codex",
+      account: "work-b",
+      windows: weekly(100),
+      mode: "auto",
+      nowMs: now + AUTO_RESET_COOLDOWN_MS / 2,
+    });
+
+    expect(blocked).toMatchObject({
+      ok: false,
+      status: 429,
+      code: "reset_credit_cooldown_active",
+      retryAfterMs: AUTO_RESET_COOLDOWN_MS / 2,
+    });
+  });
+
+  it("does not reserve or resolve the account when weekly usage is below 90%", async () => {
+    const config = new MemoryConfig();
+    const resolveSharedKey = vi.fn(async () => "codex:shared-account");
+    const guard = createResetCreditGuard({ config, resolveSharedKey });
+
+    const result = await guard.reserve({
+      providerId: "openai-codex",
+      account: "work",
+      windows: weekly(89),
+      mode: "manual",
+      nowMs: 1_000,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 409,
+      code: "weekly_usage_below_reset_threshold",
+    });
+    expect(resolveSharedKey).not.toHaveBeenCalled();
+    expect(config.set).not.toHaveBeenCalled();
+    expect(config.setIfMissingOrNumericLte).not.toHaveBeenCalled();
+  });
+
+  it("allows only one reset-credit reservation for the same weekly window", async () => {
+    const config = new MemoryConfig();
+    const resolveSharedKey = vi.fn(async () => "codex:shared-account");
+    const guard = createResetCreditGuard({ config, resolveSharedKey });
+    const now = 4_000_000;
+    const windowReset = now + 3 * 86_400_000;
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work-a",
+        windows: [weeklyWindow(100, windowReset)],
+        mode: "auto",
+        nowMs: now,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(config.values.get(resetCreditGuardWindowConfigKey("codex:shared-account"))).toBe(
+      `secondary:${windowReset}`,
+    );
+
+    const sameWindowAfterCooldown = await guard.reserve({
+      providerId: "openai-codex",
+      account: "work-b",
+      windows: [weeklyWindow(100, windowReset)],
+      mode: "auto",
+      nowMs: now + AUTO_RESET_COOLDOWN_MS,
+    });
+    expect(sameWindowAfterCooldown).toMatchObject({
+      ok: false,
+      status: 409,
+      code: "reset_credit_window_already_reserved",
+    });
+
+    const sameManualWindowAfterCooldown = await guard.reserve({
+      providerId: "openai-codex",
+      account: "work-b",
+      windows: [weeklyWindow(100, windowReset)],
+      mode: "manual",
+      nowMs: now + 2 * AUTO_RESET_COOLDOWN_MS,
+    });
+    expect(sameManualWindowAfterCooldown).toMatchObject({
+      ok: false,
+      status: 409,
+      code: "reset_credit_window_already_reserved",
+    });
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work-b",
+        windows: [weeklyWindow(100, windowReset + 86_400_000)],
+        mode: "auto",
+        nowMs: now + 2 * AUTO_RESET_COOLDOWN_MS,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  it("blocks reset-credit reserve when the weekly window cannot be identified", async () => {
+    const config = new MemoryConfig();
+    const guard = createResetCreditGuard({
+      config,
+      resolveSharedKey: vi.fn(async () => "codex:shared-account"),
+    });
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work",
+        windows: [{ key: "secondary", usedPercent: 100, resetsAtMs: null, windowMinutes: 10_080 }],
+        mode: "auto",
+        nowMs: 1_000,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 409,
+      code: "weekly_window_reset_unavailable",
+    });
+  });
+
+  it("allows another reserve after the full cooldown has elapsed", async () => {
+    const config = new MemoryConfig();
+    const resolveSharedKey = vi.fn(async () => "codex:shared-account");
+    const guard = createResetCreditGuard({ config, resolveSharedKey });
+    const now = 2_000_000;
+    const windowReset = now + 86_400_000;
+
+    await guard.reserve({
+      providerId: "openai-codex",
+      account: "work",
+      windows: [weeklyWindow(100, windowReset)],
+      mode: "manual",
+      nowMs: now,
+    });
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work",
+        windows: [weeklyWindow(100, windowReset + 86_400_000)],
+        mode: "manual",
+        nowMs: now + AUTO_RESET_COOLDOWN_MS,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+  });
+
+  it("atomically allows only one cross-instance cooldown reservation", async () => {
+    const config = new MemoryConfig();
+    const now = 7_000_000;
+    const makeGuard = () =>
+      createResetCreditGuard({
+        config,
+        resolveSharedKey: vi.fn(async () => "codex:shared-account"),
+      });
+
+    const [a, b] = await Promise.all([
+      makeGuard().reserve({
+        providerId: "openai-codex",
+        account: "work-a",
+        windows: [weeklyWindow(100, now + 86_400_000)],
+        mode: "auto",
+        nowMs: now,
+      }),
+      makeGuard().reserve({
+        providerId: "openai-codex",
+        account: "work-b",
+        windows: [weeklyWindow(100, now + 2 * 86_400_000)],
+        mode: "auto",
+        nowMs: now,
+      }),
+    ]);
+
+    const results = [a, b];
+    expect(results.filter((r) => r.ok)).toHaveLength(1);
+    expect(results.filter((r) => !r.ok)).toEqual([
+      expect.objectContaining({ status: 429, code: "reset_credit_cooldown_active" }),
+    ]);
+    expect(config.setIfMissingOrNumericLte).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when the durable store cannot reserve atomically", async () => {
+    const config: ConfigStore = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {
+        throw new Error("unexpected set");
+      }),
+      setIfMissingOrNumericLte: vi.fn(async () => {
+        throw new Error("disk unavailable");
+      }),
+    };
+    const guard = createResetCreditGuard({
+      config,
+      resolveSharedKey: vi.fn(async () => "codex:shared-account"),
+    });
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work",
+        windows: weekly(100),
+        mode: "auto",
+        nowMs: 1_000,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 503,
+      code: "reset_credit_guard_failed",
+    });
+  });
+
+  it("fails closed when the durable store lacks atomic reservation support", async () => {
+    const config: ConfigStore = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => undefined),
+    };
+    const guard = createResetCreditGuard({
+      config,
+      resolveSharedKey: vi.fn(async () => "codex:shared-account"),
+    });
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work",
+        windows: weekly(100),
+        mode: "manual",
+        nowMs: 1_000,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 503,
+      code: "reset_credit_guard_failed",
+    });
+  });
+});

--- a/apps/gateway/src/oauth/reset-credit-guard.ts
+++ b/apps/gateway/src/oauth/reset-credit-guard.ts
@@ -1,0 +1,200 @@
+import { createHash } from "node:crypto";
+import type { ConfigStore } from "@helm/core";
+import type { OAuthQuotaWindow } from "@helm/shared";
+import {
+  AUTO_RESET_COOLDOWN_MS,
+  CODEX_RESET_MIN_WEEKLY_USED_PERCENT,
+  canConsumeResetCredit,
+  codexWeeklyUsedPercent,
+  cooldownPassed,
+} from "./auto-reset.js";
+
+export type ResetCreditSpendMode = "manual" | "auto";
+
+export type ResetCreditGuardResult =
+  | { ok: true; sharedKey: string; windowId: string }
+  | {
+      ok: false;
+      status: 409 | 429 | 503;
+      code: string;
+      error: string;
+      retryAfterMs?: number;
+    };
+
+export interface ResetCreditGuard {
+  reserve(input: {
+    providerId: string;
+    account: string;
+    windows: OAuthQuotaWindow[];
+    mode: ResetCreditSpendMode;
+    nowMs?: number;
+  }): Promise<ResetCreditGuardResult>;
+}
+
+export interface ResetCreditGuardDeps {
+  config: ConfigStore;
+  resolveSharedKey(input: { providerId: string; account: string }): Promise<string>;
+  log?: (
+    level: "debug" | "info" | "warn" | "error",
+    message: string,
+    fields?: Record<string, unknown>,
+  ) => void;
+}
+
+export function resetCreditGuardHash(sharedKey: string): string {
+  return createHash("sha256").update(sharedKey, "utf8").digest("hex");
+}
+
+export function resetCreditGuardConfigKey(sharedKey: string): string {
+  return `oauth.codex_reset_credit.last.v1.${resetCreditGuardHash(sharedKey)}`;
+}
+
+export function resetCreditGuardWindowConfigKey(sharedKey: string): string {
+  return `oauth.codex_reset_credit.window.v1.${resetCreditGuardHash(sharedKey)}`;
+}
+
+export const resetCreditGuardAutoWindowConfigKey = resetCreditGuardWindowConfigKey;
+
+function weeklyWindowId(windows: readonly OAuthQuotaWindow[]): string | null {
+  const weekly = windows
+    .filter((w) => w.key === "secondary")
+    .filter((w) => Number.isFinite(w.usedPercent))
+    .sort((a, b) => b.usedPercent - a.usedPercent)[0];
+  return weekly?.resetsAtMs == null ? null : `secondary:${weekly.resetsAtMs}`;
+}
+
+function cooldownBlocked(
+  lastMs: number,
+  nowMs: number,
+): { ok: false; status: 429; code: string; error: string; retryAfterMs: number } {
+  return {
+    ok: false,
+    status: 429,
+    code: "reset_credit_cooldown_active",
+    error: "reset credit blocked: a reset credit was already reserved within the last hour",
+    retryAfterMs: Math.max(0, lastMs + AUTO_RESET_COOLDOWN_MS - nowMs),
+  };
+}
+
+export function createResetCreditGuard(deps: ResetCreditGuardDeps): ResetCreditGuard {
+  const lastBySharedKey = new Map<string, number>();
+  const inFlightSharedKeys = new Set<string>();
+
+  async function readPersistedLast(sharedKey: string): Promise<number | undefined> {
+    const raw = await deps.config.get(resetCreditGuardConfigKey(sharedKey));
+    if (raw == null) return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  }
+
+  async function readReservedWindow(sharedKey: string): Promise<string | null> {
+    return deps.config.get(resetCreditGuardWindowConfigKey(sharedKey));
+  }
+
+  async function writeReservedWindow(sharedKey: string, windowId: string): Promise<void> {
+    await deps.config.set(resetCreditGuardWindowConfigKey(sharedKey), windowId);
+  }
+
+  async function reserveWindow(sharedKey: string, windows: readonly OAuthQuotaWindow[]) {
+    const windowId = weeklyWindowId(windows);
+    if (windowId == null) {
+      return {
+        ok: false,
+        status: 409,
+        code: "weekly_window_reset_unavailable",
+        error: "reset credit blocked: Codex weekly window reset time is unavailable",
+      } as const;
+    }
+    if ((await readReservedWindow(sharedKey)) === windowId) {
+      return {
+        ok: false,
+        status: 409,
+        code: "reset_credit_window_already_reserved",
+        error: "reset credit blocked: this Codex weekly window already reserved a reset credit",
+      } as const;
+    }
+    return { ok: true, windowId } as const;
+  }
+
+  return {
+    async reserve({ providerId, account, windows, mode, nowMs = Date.now() }) {
+      const weeklyUsedPercent = codexWeeklyUsedPercent(windows);
+      if (providerId !== "openai-codex") {
+        return {
+          ok: false,
+          status: 409,
+          code: "unsupported_provider",
+          error: "reset credit is only supported for openai-codex",
+        };
+      }
+      if (!canConsumeResetCredit(windows)) {
+        return {
+          ok: false,
+          status: 409,
+          code: "weekly_usage_below_reset_threshold",
+          error: `reset credit blocked: Codex weekly usage must be at least ${CODEX_RESET_MIN_WEEKLY_USED_PERCENT}%`,
+        };
+      }
+
+      try {
+        const sharedKey = await deps.resolveSharedKey({ providerId, account });
+        if (inFlightSharedKeys.has(sharedKey)) {
+          return cooldownBlocked(nowMs, nowMs);
+        }
+        inFlightSharedKeys.add(sharedKey);
+        try {
+          const memoryLast = lastBySharedKey.get(sharedKey);
+          if (memoryLast !== undefined && !cooldownPassed(memoryLast, nowMs)) {
+            return cooldownBlocked(memoryLast, nowMs);
+          }
+
+          const window = await reserveWindow(sharedKey, windows);
+          if (!window.ok) return window;
+
+          if (!deps.config.setIfMissingOrNumericLte) {
+            throw new Error("ConfigStore does not support atomic reset-credit reserve");
+          }
+          const cutoffMs = nowMs - AUTO_RESET_COOLDOWN_MS;
+          const claimed = await deps.config.setIfMissingOrNumericLte(
+            resetCreditGuardConfigKey(sharedKey),
+            String(nowMs),
+            cutoffMs,
+          );
+          if (!claimed) {
+            const persistedLast = await readPersistedLast(sharedKey);
+            if (persistedLast === undefined) {
+              throw new Error("reset-credit guard row is not a numeric timestamp");
+            }
+            lastBySharedKey.set(sharedKey, persistedLast);
+            return cooldownBlocked(persistedLast, nowMs);
+          }
+
+          await writeReservedWindow(sharedKey, window.windowId);
+          lastBySharedKey.set(sharedKey, nowMs);
+          deps.log?.("info", "oauth.reset_credit.reserved", {
+            provider_id: providerId,
+            mode,
+            weekly_used_percent: weeklyUsedPercent,
+            guard: resetCreditGuardHash(sharedKey).slice(0, 12),
+            window: window.windowId,
+          });
+          return { ok: true, sharedKey, windowId: window.windowId };
+        } finally {
+          inFlightSharedKeys.delete(sharedKey);
+        }
+      } catch (e) {
+        deps.log?.("error", "oauth.reset_credit.guard_failed", {
+          provider_id: providerId,
+          mode,
+          line: e instanceof Error ? e.message : String(e),
+        });
+        return {
+          ok: false,
+          status: 503,
+          code: "reset_credit_guard_failed",
+          error: "reset credit guard failed closed",
+        };
+      }
+    },
+  };
+}

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -19,6 +19,7 @@ import type {
   RuntimeSettings,
 } from "@helm/shared";
 import type { ModelOption } from "../../oauth/effective-models.js";
+import type { ResetCreditGuard } from "../../oauth/reset-credit-guard.js";
 import type { PayloadCaptureDeps } from "../payload-capture.js";
 import type { OAuthTester } from "./oauth-test.js";
 
@@ -234,6 +235,8 @@ export type CodexQuotaResult = {
 export interface CodexResetCreditResult {
   code: string | null;
   windowsReset: number | null;
+  // Locally generated idempotency/audit id sent to upstream as redeem_request_id.
+  redeemRequestId?: string;
 }
 
 // The effective scheduling for one account: defaults applied (priority 50,
@@ -350,6 +353,10 @@ export interface AdminApiDeps {
   // list when absent (fail-open; never 503 the whole page over observability).
   oauthUsage?: OAuthUsageStore;
   oauthQuota?: OAuthQuotaStore;
+  // Hard safety gate before any Codex reset-credit consume (manual button or
+  // auto-reset). Optional only for tests/disabled deployments; reset-credit routes
+  // fail closed when it is absent.
+  resetCreditGuard?: ResetCreditGuard;
   // Per-account connectivity tester (Subscription Providers "Test" button). Streams
   // a single short completion through a FRESH, isolated per-account client — its own
   // token + proxy + executor type, and its OWN no-op breaker — so a test records NO

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -501,6 +501,33 @@ describe("admin OAuth routes — read endpoints", () => {
 });
 
 describe("admin OAuth routes — reset credit", () => {
+  const codexWindows = (weeklyUsedPercent = 90) => [
+    {
+      key: "secondary",
+      usedPercent: weeklyUsedPercent,
+      resetsAtMs: Date.now() + 86_400_000,
+      windowMinutes: 10_080,
+    },
+  ];
+  const quotaStore = (windows = codexWindows()): AdminApiDeps["oauthQuota"] =>
+    ({
+      get: vi.fn(async (providerId: string, account: string) => ({
+        providerId,
+        account,
+        windows,
+        capturedAt: Date.now(),
+        source: "codex",
+        usageLimitedUntilMs: null,
+      })),
+    }) as unknown as AdminApiDeps["oauthQuota"];
+  const allowResetCredit = () => ({
+    reserve: vi.fn(async () => ({
+      ok: true as const,
+      sharedKey: "codex:shared-account",
+      windowId: "secondary:1",
+    })),
+  });
+
   it("503 when the seam lacks consumeCodexResetCredit", async () => {
     const res = await app({ oauth: fullSeam() }).request(
       "/admin/api/oauth/openai-codex/reset-credit",
@@ -521,37 +548,128 @@ describe("admin OAuth routes — reset credit", () => {
     expect(res.status).toBe(400);
   });
 
-  it("200 consumes a credit and returns { code, windowsReset } (defaults the account)", async () => {
+  it("409 when no Codex quota snapshot is available", async () => {
     const consume = vi.fn(async () => ({ code: "ok", windowsReset: 2 }));
+    const guard = allowResetCredit();
     const seam = fullSeam({ consumeCodexResetCredit: consume as never });
-    const res = await app({ oauth: seam }).request("/admin/api/oauth/openai-codex/reset-credit", {
+    const res = await app({ oauth: seam, resetCreditGuard: guard }).request(
+      "/admin/api/oauth/openai-codex/reset-credit",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: "{}",
+      },
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string }).toMatchObject({ code: "quota_unavailable" });
+    expect(guard.reserve).not.toHaveBeenCalled();
+    expect(consume).not.toHaveBeenCalled();
+  });
+
+  it("409 blocks reset-credit consumption when weekly usage is below 90%", async () => {
+    const consume = vi.fn(async () => ({ code: "ok", windowsReset: 2 }));
+    const guard = allowResetCredit();
+    const seam = fullSeam({ consumeCodexResetCredit: consume as never });
+    const res = await app({
+      oauth: seam,
+      oauthQuota: quotaStore(codexWindows(89)),
+      resetCreditGuard: guard,
+    }).request("/admin/api/oauth/openai-codex/reset-credit", {
+      method: "POST",
+      headers: JSONH,
+      body: "{}",
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { code: string; minWeeklyUsedPercent: number }).toMatchObject({
+      code: "weekly_usage_below_reset_threshold",
+      minWeeklyUsedPercent: 90,
+    });
+    expect(guard.reserve).not.toHaveBeenCalled();
+    expect(consume).not.toHaveBeenCalled();
+  });
+
+  it("429 blocks reset-credit consumption when the one-hour guard is active", async () => {
+    const consume = vi.fn(async () => ({ code: "ok", windowsReset: 2 }));
+    const guard = {
+      reserve: vi.fn(async () => ({
+        ok: false as const,
+        status: 429 as const,
+        code: "reset_credit_cooldown_active",
+        error: "cooldown",
+        retryAfterMs: 60_000,
+      })),
+    };
+    const seam = fullSeam({ consumeCodexResetCredit: consume as never });
+    const res = await app({
+      oauth: seam,
+      oauthQuota: quotaStore(),
+      resetCreditGuard: guard,
+    }).request("/admin/api/oauth/openai-codex/reset-credit", {
+      method: "POST",
+      headers: JSONH,
+      body: "{}",
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(consume).not.toHaveBeenCalled();
+  });
+
+  it("200 consumes a credit only after quota + guard allow it (defaults the account)", async () => {
+    const consume = vi.fn(async () => ({ code: "ok", windowsReset: 2 }));
+    const guard = allowResetCredit();
+    const seam = fullSeam({ consumeCodexResetCredit: consume as never });
+    const res = await app({
+      oauth: seam,
+      oauthQuota: quotaStore(),
+      resetCreditGuard: guard,
+    }).request("/admin/api/oauth/openai-codex/reset-credit", {
       method: "POST",
       headers: JSONH,
       body: "{}",
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ code: "ok", windowsReset: 2 });
+    expect(guard.reserve).toHaveBeenCalledWith({
+      providerId: "openai-codex",
+      account: "default",
+      windows: expect.arrayContaining([
+        expect.objectContaining({ key: "secondary", usedPercent: 90 }),
+      ]),
+      mode: "manual",
+    });
     expect(consume).toHaveBeenCalledWith({ account: "default" });
   });
 
   it("passes an explicit account through to the seam", async () => {
     const consume = vi.fn(async () => ({ code: "ok", windowsReset: 1 }));
+    const guard = allowResetCredit();
     const seam = fullSeam({ consumeCodexResetCredit: consume as never });
-    await app({ oauth: seam }).request("/admin/api/oauth/openai-codex/reset-credit", {
-      method: "POST",
-      headers: JSONH,
-      body: JSON.stringify({ account: "work" }),
-    });
+    await app({ oauth: seam, oauthQuota: quotaStore(), resetCreditGuard: guard }).request(
+      "/admin/api/oauth/openai-codex/reset-credit",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ account: "work" }),
+      },
+    );
+    expect(guard.reserve).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "openai-codex", account: "work", mode: "manual" }),
+    );
     expect(consume).toHaveBeenCalledWith({ account: "work" });
   });
 
   it("502 when the seam throws (fail-closed upstream error)", async () => {
+    const guard = allowResetCredit();
     const seam = fullSeam({
       consumeCodexResetCredit: vi.fn(async () => {
         throw new Error("no credits");
       }) as never,
     });
-    const res = await app({ oauth: seam }).request("/admin/api/oauth/openai-codex/reset-credit", {
+    const res = await app({
+      oauth: seam,
+      oauthQuota: quotaStore(),
+      resetCreditGuard: guard,
+    }).request("/admin/api/oauth/openai-codex/reset-credit", {
       method: "POST",
       headers: JSONH,
       body: "{}",

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -2,6 +2,11 @@ import { windowsToActiveUsageRecovery } from "@helm/core";
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
+import {
+  CODEX_RESET_MIN_WEEKLY_USED_PERCENT,
+  canConsumeResetCredit,
+  codexWeeklyUsedPercent,
+} from "../../oauth/auto-reset.js";
 import type { AccountProxyInput, AdminApiDeps, OAuthAdminAccess } from "./deps.js";
 
 // /admin/api/oauth/* — interactive OAuth subscription login from the admin UI
@@ -315,6 +320,56 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     const body = (await c.req.json().catch(() => ({}))) as { account?: unknown };
     const account =
       typeof body.account === "string" && body.account ? body.account : DEFAULT_ACCOUNT;
+    const snapshot = await deps.oauthQuota?.get(providerId, account).catch(() => null);
+    if (!snapshot) {
+      return c.json(
+        {
+          error: "reset credit blocked: Codex weekly quota snapshot is unavailable",
+          code: "quota_unavailable",
+        },
+        409,
+      );
+    }
+    const weeklyUsedPercent = codexWeeklyUsedPercent(snapshot.windows);
+    if (!canConsumeResetCredit(snapshot.windows)) {
+      return c.json(
+        {
+          error: `reset credit blocked: Codex weekly usage must be at least ${CODEX_RESET_MIN_WEEKLY_USED_PERCENT}%`,
+          code: "weekly_usage_below_reset_threshold",
+          weeklyUsedPercent,
+          minWeeklyUsedPercent: CODEX_RESET_MIN_WEEKLY_USED_PERCENT,
+        },
+        409,
+      );
+    }
+    const guard = deps.resetCreditGuard;
+    if (!guard) {
+      return c.json(
+        { error: "reset credit guard is not configured", code: "reset_credit_guard_unavailable" },
+        503,
+      );
+    }
+    const reservation = await guard.reserve({
+      providerId,
+      account,
+      windows: snapshot.windows,
+      mode: "manual",
+    });
+    if (!reservation.ok) {
+      if (reservation.retryAfterMs !== undefined) {
+        c.header("Retry-After", String(Math.ceil(reservation.retryAfterMs / 1000)));
+      }
+      return c.json(
+        {
+          error: reservation.error,
+          code: reservation.code,
+          ...(reservation.retryAfterMs === undefined
+            ? {}
+            : { retryAfterMs: reservation.retryAfterMs }),
+        },
+        reservation.status,
+      );
+    }
     try {
       const result = await s.consumeCodexResetCredit({ account });
       return c.json(result, 200);

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -105,6 +105,7 @@ import type {
   ClassifierConfig,
   ErrorClass,
   InternalRequest,
+  OAuthQuotaWindow,
   ProviderConfig as ProviderConfigShared,
   RuntimeSettings,
   TargetProviderProtocol,
@@ -134,9 +135,10 @@ import {
   loadAccountSettings,
 } from "./oauth/account-settings.js";
 import { createOAuthAdmin } from "./oauth/admin-oauth.js";
-import { cooldownPassed, weeklySaturated } from "./oauth/auto-reset.js";
+import { weeklySaturated } from "./oauth/auto-reset.js";
 import { anthropicMetadataUserId, stableSessionId } from "./oauth/device-identity.js";
 import { effectiveOAuthModelOptions, type ModelOption } from "./oauth/effective-models.js";
+import { createResetCreditGuard, resetCreditGuardHash } from "./oauth/reset-credit-guard.js";
 import { createResponsesRegistry } from "./responses-registry.js";
 import { createArchiveFsAccess } from "./routes/admin/cleanup-fs.js";
 import { registerAdminApi } from "./routes/admin/index.js";
@@ -1365,17 +1367,11 @@ export async function buildServer(
   // Reset credits are SCARCE and the grant is keyed by the upstream ChatGPT account
   // (chatgpt_account_id), which can back SEVERAL connected helm labels — so the spend
   // guard MUST key on that shared id, not the helm label, or two sibling labels both
-  // saturating would each spend a credit for the one shared window. `autoResetLast`
-  // (the ≥1h cooldown, keyed by the shared id) is the correctness guard: the check +
-  // commit are adjacent and synchronous, so concurrent siblings serialize on it.
-  // `autoResetInFlight` (keyed by the cheap helm label) only collapses a same-label
-  // burst before the async work, to avoid a token-read stampede. Fire-and-forget +
-  // fail-open: any failure (no credit, network, opted-out) leaves the account parked.
-  const autoResetLast = new Map<string, number>(); // sharedKey -> last consume epoch-ms
+  // saturating would each spend a credit for the one shared window. `autoResetInFlight`
+  // (keyed by the cheap helm label) only collapses a same-label burst before async
+  // work, to avoid a token-read stampede. Fire-and-forget + fail-open: any failure
+  // leaves parked state.
   const autoResetInFlight = new Set<string>(); // helm label -> a reset is being evaluated
-  // ponytail: cooldown is process memory — a restart clears it, but a just-reset weekly
-  // window cannot re-saturate within an hour, so a second spend is physically impossible
-  // before the cooldown would have expired anyway. No persistence needed.
 
   // Resolve the SHARED reset-credit key for a Codex helm account: its chatgpt_account_id
   // (`codex:<id>`), decoded from the STORED access token — no network/refresh, and the
@@ -1398,8 +1394,20 @@ export async function buildServer(
     return helmKey;
   };
 
-  const maybeAutoReset = (providerId: string, account: string, nowMs: number): void => {
-    if (!oauthAdmin?.consumeCodexResetCredit || !oauthEncKey) return;
+  const resetCreditGuard = createResetCreditGuard({
+    config: store.config,
+    resolveSharedKey: ({ providerId, account }) => resolveCodexAccountKey(providerId, account),
+    log: (lvl, msg, fields) => logger.log(lvl, msg, fields),
+  });
+
+  const maybeAutoReset = (
+    providerId: string,
+    account: string,
+    windows: OAuthQuotaWindow[],
+    nowMs: number,
+  ): void => {
+    const consumeCodexResetCredit = oauthAdmin?.consumeCodexResetCredit;
+    if (!consumeCodexResetCredit || !oauthEncKey) return;
     const helmKey = `${providerId} ${account}`;
     if (autoResetInFlight.has(helmKey)) return; // collapse a same-label burst (cheap, sync)
     autoResetInFlight.add(helmKey);
@@ -1411,32 +1419,72 @@ export async function buildServer(
           account,
         );
         if (!s.autoReset) return; // opted out → never spend a credit
-        // Guard on the SHARED ChatGPT account: check + commit are adjacent (no await
-        // between), so concurrent sibling labels serialize here and only one spends.
-        const sharedKey = await resolveCodexAccountKey(providerId, account);
-        if (!cooldownPassed(autoResetLast.get(sharedKey), nowMs)) return;
-        autoResetLast.set(sharedKey, nowMs);
-        const r = await oauthAdmin.consumeCodexResetCredit?.({ account });
+        const reservation = await resetCreditGuard.reserve({
+          providerId,
+          account,
+          windows,
+          mode: "auto",
+          nowMs,
+        });
+        if (!reservation.ok) {
+          logger.log(reservation.status === 429 ? "info" : "warn", "oauth.auto_reset.blocked", {
+            provider_id: providerId,
+            code: reservation.code,
+            retry_after_ms: reservation.retryAfterMs ?? null,
+          });
+          return;
+        }
+        const sharedKey = reservation.sharedKey;
+        const guardHash = resetCreditGuardHash(sharedKey).slice(0, 12);
+        let r: Awaited<ReturnType<typeof consumeCodexResetCredit>>;
+        try {
+          r = await consumeCodexResetCredit({ account });
+        } catch (e) {
+          logger.log("error", "oauth.auto_reset.failed", {
+            provider_id: providerId,
+            account,
+            guard: guardHash,
+            stage: "consume",
+            line: e instanceof Error ? e.message : String(e),
+          });
+          return;
+        }
+        logger.log("info", "oauth.auto_reset.consumed", {
+          provider_id: providerId,
+          account,
+          guard: guardHash,
+          redeem_request_id: r.redeemRequestId ?? null,
+          code: r.code ?? null,
+          windows_reset: r.windowsReset ?? null,
+        });
         // The consume restored the shared window for EVERY sibling on this login — unpark
         // them all (the trigger account included), or a sibling parked by its own
         // saturated reply would stay out of rotation until its window's natural reset.
         const codexAccounts = (await store.oauthTokens.list()).filter(
           (t) => t.providerId === providerId,
         );
-        await Promise.all(
+        const unparkResults = await Promise.allSettled(
           codexAccounts.map(async (t) => {
             if ((await resolveCodexAccountKey(t.providerId, t.account)) === sharedKey) {
               await applyUsageLimit(t.providerId, t.account, null);
             }
           }),
         );
-        logger.log("info", "oauth.auto_reset.consumed", {
-          provider_id: providerId,
-          windows_reset: r?.windowsReset ?? null,
-        });
+        const unparkFailed = unparkResults.filter((x) => x.status === "rejected").length;
+        if (unparkFailed > 0) {
+          logger.log("error", "oauth.auto_reset.unpark_failed", {
+            provider_id: providerId,
+            account,
+            guard: guardHash,
+            failed_accounts: unparkFailed,
+            redeem_request_id: r.redeemRequestId ?? null,
+          });
+        }
       } catch (e) {
         logger.log("error", "oauth.auto_reset.failed", {
           provider_id: providerId,
+          account,
+          stage: "post_consume",
           line: e instanceof Error ? e.message : String(e),
         });
       } finally {
@@ -1461,7 +1509,7 @@ export async function buildServer(
     if (until !== null) parkAccountOnLimit(providerId, account, until);
     // Then, if the WEEKLY window is the one that saturated and the account opted in,
     // auto-consume a reset credit to restore it (guarded by a ≥1h per-account cooldown).
-    if (weeklySaturated(windows)) maybeAutoReset(providerId, account, nowMs);
+    if (weeklySaturated(windows)) maybeAutoReset(providerId, account, windows, nowMs);
   };
   // Per-account user-message serial queue (issue #93, feature B). ONE long-lived
   // gate for the whole process: it must survive pool rebuilds so queued requests
@@ -2286,6 +2334,7 @@ export async function buildServer(
       // /oauth/usage + /oauth/quota admin routes (fail-open to empty when absent).
       oauthUsage: store.oauthUsage,
       oauthQuota: store.oauthQuota,
+      resetCreditGuard,
       // Per-account connectivity tester (providers page "Test" button); see above.
       oauthTester,
       // Hot-reload the routable OAuth pool after any admin mutation (proxy /

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-07-05 · Codex reset-credit 消费改为硬门禁（OAuth quota / Admin providers，docs/04/11，原则 3/5/7）
+
+- **背景（Lukin）**：Codex rate-limit reset credit 是稀缺上游额度，不能因为 providers 页刷新、容器重启、持续 saturated header 或误开 auto-reset 而快速消耗。既要保留手动/自动恢复能力，也要默认 fail-closed 保护 reset credits。
+- **消费门槛**：手动和自动 reset-credit consume 都必须看到 Codex weekly `secondary` window，且 `usedPercent >= 90`；5h `primary` window 自恢复，永远不能作为花费 reset credit 的理由。缺少 quota snapshot 时手动接口返回 409，不直接 PULL 上游再消费。
+- **自动 reset 边界**：auto-reset 仍只在 weekly `secondary >= 100` 时尝试；手动和自动消费都共享同一持久 guard：同一 shared ChatGPT account 一小时内只能 reserve 一次，同一 weekly window 只能 reserve 一次。guard 写在 `config_kv`，key 只含 shared account 的 sha256，不保存 ChatGPT id 明文。
+- **并发/重启决策**：进程内 shared-key in-flight 折叠同进程 sibling burst；真正的一小时 reservation 用 `ConfigStore.setIfMissingOrNumericLte` 在 SQLite/Postgres 单条 SQL 原子抢占，防多实例同时 read-then-write 双消费；持久 `window` guard 防同一 weekly window 在冷却过后继续消费。guard/store 出错或缺少原子 reservation 能力时 fail-closed，宁可不 reset，也不能快速烧额度。
+- **审计决策**：`consumeCodexResetCredit` 生成并记录 `redeem_request_id`；auto-reset 在上游 consume 成功后立刻打 `oauth.auto_reset.consumed`，本地 unpark 失败单独记 `oauth.auto_reset.unpark_failed`，避免“credit 已花但日志看起来像 consume 失败”。
+- **UI 决策**：providers 页 `Reset limit` 按 weekly >=90、resetCredits >0、quota snapshot 存在才可点；确认弹窗里的 auto-reset 勾选只在 consume 成功后保存，失败不会悄悄开启未来自动消费。
+- **验证计划**：覆盖纯 eligibility、持久 cooldown、跨 guard 实例原子抢占、同 weekly window 手动/自动去重、admin route fail-closed、redeem id 审计、providers 按钮禁用和失败不保存 autoReset；再跑 targeted Vitest、store contract、gateway typecheck、admin svelte-check、Biome/Prettier。
+
 ## 2026-07-04 · internal LLM prompt 输入用 XML 数据边界隔离（Memory / classifier eval，docs/03/08/12，原则 3/4/7）
 
 - **背景（Lukin）**：生产 request `4fa73a51-56d3-4f40-a34d-7ce1e9d1194b` 显示 `internal-llm` key 的一次普通 chat self-call 把任务规则、runtime context、群聊历史和输出契约拼在同一个 user message 里；最后一条群消息包含“可以合并”等业务动作词，容易让小模型把 untrusted chat content 当成可执行指令或错误语境。
@@ -89,22 +99,13 @@
 - **UI 决策**：记忆页顶部增加状态面板，15 秒轻量刷新一次；按当前选中的 scope/key 同步切换，能直接看到 queued/running/stale、滞后时间、raw input、learned output 和 jobs by type。
 - **验证计划**：覆盖 SQLite/Postgres store 聚合、admin route、admin 页面加载/筛选联动与 locale 文案；再跑目标 Vitest、typecheck、lint/build。
 
-## 2026-07-04 · Claude scoped weekly quota 不触发账号级限流（Admin providers / OAuth quota，docs/04/11，原则 3/5/7）
-
-- **背景（Lukin）**：providers 页出现 `7d · Fable` 100% 后，账号被显示为“已限流”，并且路由池把整个 Anthropic OAuth 账号排除；但账号级 `7d` 全模型额度仍有余量，只有 Fable / Sonnet 这类 scoped model cap 不可用。
-- **根因**：`windowsToUsageLimit()` 与 `windowsToActiveUsageRecovery()` 把所有 100% quota window 都当作账号级 limiter；`7d-fable` / `7d-sonnet` / `7d-opus` 这种 scoped weekly model window 因而被错误写入 `usage_limited_until_ms`，扩大成全账号 cooldown。OAuth pool 的 429 backstop 也没有区分 Anthropic 模型级 429。
-- **语义决策**：只有账号级窗口（`5h`、`7d`、Codex `primary/secondary` 等非 `7d-*` key）能 park 整个账号；`7d-*` 只说明对应 Claude 模型的周限额已满，不能阻止同账号继续服务其它模型。
-- **执行路径决策**：Anthropic `claude-fable-*` / `claude-sonnet-*` / `claude-opus-*` 的 429 不写全局 cooldown；当前请求仍可在池内尝试 sibling account 或交给执行 fallback，但不会把该账号从所有模型的调度池里移除。
-- **UI 决策**：providers 页渲染“已限流”时只用账号级窗口解释恢复时间；如果页面已有账号级窗口且它们未触顶，旧的全局 cooldown 不再显示为 active rate limit。
-- **验证计划**：新增 core quota helper、OAuth pool、admin `/oauth/quota`、providers 页面回归测试，覆盖 Fable/Sonnet scoped window 100% 但 `7d` 仍有余量时不触发账号级限流。
-
 ## 历史条目摘要（最近 5 条）
 
+- **2026-07-04 · Claude scoped weekly quota 不触发账号级限流（Admin providers / OAuth quota，docs/04/11，原则 3/5/7）**：只有账号级窗口能 park 整个 OAuth 账号，`7d-*` scoped model cap 只影响对应模型，不触发全账号限流。
 - **2026-07-04 · 跨协议 reasoning 历史不兼容按候选跳过（执行 fallback / 协议转换，docs/04/05/07，原则 3/5/8）**：跨协议转 OpenAI-compatible 时剥离不兼容 thinking/reasoning 控制，并把 DeepSeek 类 reasoning-history 400 作为候选跳过而非全局失败。
 - **2026-07-04 · memory idle-flush 防饥饿与受控追赶（Memory worker / store，docs/08/12，原则 3/7）**：idle-flush 候选判断改用 observer-order tuple，按 scope rank 交错输出，并支持受控多批 drain，避免旧 backlog 饿死新项目。
 - **2026-07-03 · 策略级 reasoning_effort 覆盖 Lane 默认值（Routing policies / Admin policies，docs/04/11，原则 2/5/6）**：Policy action 可强制 reasoning_effort，优先级为 policy > selected lane > client request，复用现有执行改写链路。
 - **2026-07-03 · cron monitor 自动化请求降到低成本规则（Classifier / routing，docs/03/04，原则 2/4）**：monitor/cron + no-reply 标记命中时降到 `simple/economy`，但保留显式 coding keyword 升级路径，避免自动化探针误打高价模型。
-- **2026-07-03 · 上下文窗口超限按候选跳过处理（执行 fallback / streaming telemetry，docs/04/07，原则 5/8）**：`context_length_exceeded` / prompt-too-long 类错误按候选 `context_too_small` 跳过并继续 fallback，不熔断 provider。
 
 ## 更早历史总览
 

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -1058,6 +1058,10 @@ export class MemoryFactContentHashConflictError extends Error {
 export interface ConfigStore {
   get(key: string): Promise<string | null>;
   set(key: string, value: string): Promise<void>;
+  // Atomic scarce-resource reservation helper. Sets `key=value` only when the row
+  // is missing or the current value is a valid non-negative integer <= `lte`.
+  // Returns true only for the caller that won the reservation.
+  setIfMissingOrNumericLte?(key: string, value: string, lte: number): Promise<boolean>;
 }
 
 // Persisted OAuth subscription credentials (issue #38 follow-up — makes the

--- a/packages/core/src/store/postgres/config-store.ts
+++ b/packages/core/src/store/postgres/config-store.ts
@@ -21,4 +21,17 @@ export class PgConfigStore implements ConfigStore {
       .values({ key, value })
       .onConflictDoUpdate({ target: configKv.key, set: { value: sql`excluded.value` } });
   }
+
+  async setIfMissingOrNumericLte(key: string, value: string, lte: number): Promise<boolean> {
+    const result = (await this.db.execute(sql`
+      INSERT INTO config_kv (key, value)
+      VALUES (${key}, ${value})
+      ON CONFLICT (key) DO UPDATE SET value = excluded.value
+      WHERE config_kv.value ~ '^[0-9]+$'
+        AND config_kv.value::numeric <= ${Math.trunc(lte)}
+      RETURNING key
+    `)) as { rows?: Array<{ key: string }> } | Array<{ key: string }>;
+    const rows = Array.isArray(result) ? result : (result.rows ?? []);
+    return rows[0] !== undefined;
+  }
 }

--- a/packages/core/src/store/sqlite/config-store.ts
+++ b/packages/core/src/store/sqlite/config-store.ts
@@ -22,4 +22,18 @@ export class SqliteConfigStore implements ConfigStore {
       .onConflictDoUpdate({ target: configKv.key, set: { value } })
       .run();
   }
+
+  async setIfMissingOrNumericLte(key: string, value: string, lte: number): Promise<boolean> {
+    const res = this.db.$sqlite
+      .prepare(`
+        INSERT INTO config_kv (key, value)
+        VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        WHERE config_kv.value GLOB '[0-9]*'
+          AND config_kv.value NOT GLOB '*[^0-9]*'
+          AND CAST(config_kv.value AS INTEGER) <= ?
+      `)
+      .run(key, value, Math.trunc(lte));
+    return res.changes > 0;
+  }
 }

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -1932,5 +1932,24 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       await ctx.stores.config.set("k", "v2");
       expect(await ctx.stores.config.get("k")).toBe("v2");
     });
+
+    it("atomically sets a numeric guard only when missing or old enough", async () => {
+      ctx = await make();
+      if (!ctx.stores.config.setIfMissingOrNumericLte) {
+        throw new Error("ConfigStore must support atomic numeric reservations");
+      }
+      const setIf = ctx.stores.config.setIfMissingOrNumericLte.bind(ctx.stores.config);
+
+      await expect(setIf("guard", "100", 50)).resolves.toBe(true);
+      expect(await ctx.stores.config.get("guard")).toBe("100");
+      await expect(setIf("guard", "200", 99)).resolves.toBe(false);
+      expect(await ctx.stores.config.get("guard")).toBe("100");
+      await expect(setIf("guard", "200", 100)).resolves.toBe(true);
+      expect(await ctx.stores.config.get("guard")).toBe("200");
+
+      await ctx.stores.config.set("guard", "not-a-number");
+      await expect(setIf("guard", "300", 1_000)).resolves.toBe(false);
+      expect(await ctx.stores.config.get("guard")).toBe("not-a-number");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add a persistent reset-credit guard so Codex reset credits cannot be consumed repeatedly after restarts or concurrent requests
- use an atomic ConfigStore reservation in SQLite/Postgres so multi-instance read/write races cannot double-spend the same shared ChatGPT account
- require Codex weekly usage to be at least 90% before manual or automatic reset-credit consumption
- block both manual and automatic reset-credit consumption more than once for the same weekly window
- improve audit logging for reset-credit consumes and only persist auto-reset opt-in after a successful manual consume
- update providers UI and tests so the Reset limit action is disabled below the weekly threshold

## Verification
- pnpm --filter @helm/gateway typecheck
- pnpm exec vitest apps/gateway/src/oauth/auto-reset.test.ts apps/gateway/src/oauth/reset-credit-guard.test.ts apps/gateway/src/oauth/admin-oauth.test.ts apps/gateway/src/routes/admin/oauth.test.ts apps/admin/src/routes/providers/providers.test.ts packages/core/src/store/store-contract.test.ts
- pnpm --filter @helm/admin check
- pnpm exec biome check packages/core/src/store/ports.ts packages/core/src/store/sqlite/config-store.ts packages/core/src/store/postgres/config-store.ts packages/core/src/store/store-contract.test.ts apps/gateway/src/oauth/auto-reset.ts apps/gateway/src/oauth/auto-reset.test.ts apps/gateway/src/oauth/reset-credit-guard.ts apps/gateway/src/oauth/reset-credit-guard.test.ts apps/gateway/src/oauth/admin-oauth.ts apps/gateway/src/oauth/admin-oauth.test.ts apps/gateway/src/routes/admin/deps.ts apps/gateway/src/routes/admin/oauth.ts apps/gateway/src/routes/admin/oauth.test.ts apps/gateway/src/server.ts
- pnpm --filter @helm/admin exec prettier --check src/lib/api/oauth.ts src/routes/providers/+page.svelte src/routes/providers/providers.test.ts --plugin prettier-plugin-svelte
- git diff --check
- pnpm build