### PR TITLE
Release v0.24.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.24.7",
+  "version": "0.24.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API release version to 0.24.8
- triggers publish workflow for reset-credit guard fix from #462

## Verification
- node -p "require('./package.json').version" -> 0.24.8
- git diff --check