### PR TITLE
Translate reset-credit disabled tooltips

### DIFF
--- a/apps/admin/src/lib/i18n/providers-locales.test.ts
+++ b/apps/admin/src/lib/i18n/providers-locales.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '../../locales/en.json';
+import ja from '../../locales/ja.json';
+import ko from '../../locales/ko.json';
+import zhHans from '../../locales/zh-hans.json';
+import zhHant from '../../locales/zh-hant.json';
+
+const resetCreditTooltipKeys = [
+  'Reset-credit count unavailable',
+  'No reset credits available',
+  'Weekly quota snapshot unavailable',
+  'Weekly usage must reach 90% before reset credits can be used',
+  'Consume one credit to restore the rate-limit window',
+] as const;
+
+const translatedLocales = {
+  'zh-hans': zhHans,
+  'zh-hant': zhHant,
+  ja,
+  ko,
+} as const;
+
+describe('provider reset-credit locale coverage', () => {
+  it.each(Object.entries(translatedLocales))(
+    '%s translates reset-credit tooltip strings instead of falling back to English',
+    (_locale, dict: Record<string, string>) => {
+      for (const key of resetCreditTooltipKeys) {
+        expect(dict).toHaveProperty(key);
+        expect(dict[key]).toBeTruthy();
+        expect(dict[key]).not.toBe((en as Record<string, string>)[key]);
+      }
+    },
+  );
+});

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -878,6 +878,8 @@
   "Waiting longer than this returns 429.": "Waiting longer than this returns 429.",
   "Waiting longer than this returns 503.": "Waiting longer than this returns 503.",
   "Weekly": "Weekly",
+  "Weekly quota snapshot unavailable": "Weekly quota snapshot unavailable",
+  "Weekly usage must reach 90% before reset credits can be used": "Weekly usage must reach 90% before reset credits can be used",
   "Weight": "Weight",
   "What this single request cost, split across routing, optional eval, and completion.": "What this single request cost, split across routing, optional eval, and completion.",
   "When a provider has several accounts, Helm pools them: a lower priority is served first, with round-robin within an equal priority. Parking an account keeps it connected but out of routing.": "When a provider has several accounts, Helm pools them: a lower priority is served first, with round-robin within an equal priority. Parking an account keeps it connected but out of routing.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -878,6 +878,8 @@
   "Waiting longer than this returns 429.": "これより長く待機すると 429 が返されます。",
   "Waiting longer than this returns 503.": "これより長く待機すると 503 が返されます。",
   "Weekly": "週間",
+  "Weekly quota snapshot unavailable": "週次クォータのスナップショットを取得できません",
+  "Weekly usage must reach 90% before reset credits can be used": "リセットクレジットを使うには、週次使用率が 90% に達している必要があります",
   "Weight": "重み",
   "What this single request cost, split across routing, optional eval, and completion.": "この単一リクエストのコストを、ルーティング、任意の評価、補完に分けて表示します。",
   "When a provider has several accounts, Helm pools them: a lower priority is served first, with round-robin within an equal priority. Parking an account keeps it connected but out of routing.": "プロバイダーに複数のアカウントがある場合、Helmはそれらをプールします。優先度が低いものから先に処理され、同じ優先度内ではラウンドロビンで処理されます。アカウントをパーキングすると、接続は維持されますがルーティングからは除外されます。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -878,6 +878,8 @@
   "Waiting longer than this returns 429.": "이보다 오래 기다리면 429를 반환합니다.",
   "Waiting longer than this returns 503.": "이보다 오래 기다리면 503을 반환합니다.",
   "Weekly": "주간",
+  "Weekly quota snapshot unavailable": "주간 할당량 스냅샷을 사용할 수 없음",
+  "Weekly usage must reach 90% before reset credits can be used": "재설정 크레딧을 사용하려면 주간 사용량이 90%에 도달해야 합니다",
   "Weight": "가중치",
   "What this single request cost, split across routing, optional eval, and completion.": "라우팅, 선택적 평가, 완료로 나누어 이 단일 요청에 든 비용입니다.",
   "When a provider has several accounts, Helm pools them: a lower priority is served first, with round-robin within an equal priority. Parking an account keeps it connected but out of routing.": "제공자에 여러 계정이 있는 경우 Helm은 이를 풀링합니다. 낮은 우선순위가 먼저 처리되며, 동일한 우선순위 내에서는 라운드 로빈 방식으로 처리됩니다. 계정을 파킹하면 연결은 유지되지만 라우팅에서는 제외됩니다.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -878,6 +878,8 @@
   "Waiting longer than this returns 429.": "等待超过该时间将返回 429。",
   "Waiting longer than this returns 503.": "等待超过该时间将返回 503。",
   "Weekly": "周限",
+  "Weekly quota snapshot unavailable": "周限额快照不可用",
+  "Weekly usage must reach 90% before reset credits can be used": "周用量必须达到 90% 后才能使用重置额度",
   "Weight": "权重",
   "What this single request cost, split across routing, optional eval, and completion.": "这一个请求的成本，分摊到路由、可选评估和补全三部分。",
   "When a provider has several accounts, Helm pools them: a lower priority is served first, with round-robin within an equal priority. Parking an account keeps it connected but out of routing.": "当一个提供商有多个账户时，Helm 会将它们汇集：优先级较低的会先被服务，相同优先级内采用轮询。停放账户会保持其连接，但不参与路由。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -878,6 +878,8 @@
   "Waiting longer than this returns 429.": "等待超過該時間將回傳 429。",
   "Waiting longer than this returns 503.": "等待超過該時間將回傳 503。",
   "Weekly": "週限",
+  "Weekly quota snapshot unavailable": "週限額快照不可用",
+  "Weekly usage must reach 90% before reset credits can be used": "週用量必須達到 90% 後才能使用重設額度",
   "Weight": "權重",
   "What this single request cost, split across routing, optional eval, and completion.": "這一個請求的成本，分攤到路由、可選評估和補全三部分。",
   "When a provider has several accounts, Helm pools them: a lower priority is served first, with round-robin within an equal priority. Parking an account keeps it connected but out of routing.": "當一個提供商有多個帳戶時，Helm 會將它們匯集：優先級較低的會先被服務，相同優先級內採用輪詢。停放帳戶會保持其連線，但不參與路由。",


### PR DESCRIPTION
## Summary
- translate the reset-credit disabled tooltip for zh-Hans, zh-Hant, ja, and ko
- add provider reset-credit locale coverage so these tooltip strings cannot fall back to English

## Tests
- pnpm exec vitest apps/admin/src/lib/i18n/providers-locales.test.ts apps/admin/src/routes/providers/providers.test.ts
- pnpm --filter @helm/admin check
- pnpm --filter @helm/admin exec prettier --check src/locales/en.json src/locales/zh-hans.json src/locales/zh-hant.json src/locales/ja.json src/locales/ko.json src/lib/i18n/providers-locales.test.ts
- git diff --check