### PR TITLE
Include weekly quota and reset credits in avoid-waste strategy

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -571,7 +571,7 @@
   "Port": "Port",
   "Preview": "Preview",
   "Prefer accounts with lower quota pressure to reduce 429 risk.": "Prefer accounts with lower quota pressure to reduce 429 risk.",
-  "Prefer accounts with quota left that will reset soon.": "Prefer accounts with quota left that will reset soon.",
+  "Prefer accounts with 5h or weekly quota resetting soon, plus Codex reset credits.": "Prefer accounts with 5h or weekly quota resetting soon, plus Codex reset credits.",
   "Previous": "Previous",
   "Primary": "Primary",
   "Primary is required and cannot be empty.": "Primary is required and cannot be empty.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -571,7 +571,7 @@
   "Port": "ポート",
   "Preview": "プレビュー",
   "Prefer accounts with lower quota pressure to reduce 429 risk.": "429 リスクを下げるため、クォータ負荷が低いアカウントを優先します。",
-  "Prefer accounts with quota left that will reset soon.": "まもなくリセットされ、まだクォータが残っているアカウントを優先します。",
+  "Prefer accounts with 5h or weekly quota resetting soon, plus Codex reset credits.": "まもなくリセットされる 5 時間枠または週次クォータと、Codex リセットクレジットを考慮して優先します。",
   "Previous": "前へ",
   "Primary": "プライマリ",
   "Primary is required and cannot be empty.": "プライマリは必須で、空にできません。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -571,7 +571,7 @@
   "Port": "포트",
   "Preview": "미리보기",
   "Prefer accounts with lower quota pressure to reduce 429 risk.": "429 위험을 줄이기 위해 할당량 부담이 낮은 계정을 우선 사용합니다.",
-  "Prefer accounts with quota left that will reset soon.": "곧 초기화되고 남은 할당량이 있는 계정을 우선 사용합니다.",
+  "Prefer accounts with 5h or weekly quota resetting soon, plus Codex reset credits.": "곧 초기화되는 5시간/주간 할당량과 Codex 재설정 크레딧을 함께 고려해 계정을 우선 사용합니다.",
   "Previous": "이전",
   "Primary": "기본",
   "Primary is required and cannot be empty.": "기본은 필수이며 비워둘 수 없습니다.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -571,7 +571,7 @@
   "Port": "端口",
   "Preview": "预览",
   "Prefer accounts with lower quota pressure to reduce 429 risk.": "优先使用额度压力低的账号，降低 429 风险。",
-  "Prefer accounts with quota left that will reset soon.": "优先使用快重置且还剩额度的账号，减少浪费。",
+  "Prefer accounts with 5h or weekly quota resetting soon, plus Codex reset credits.": "优先使用 5 小时或周额度快重置、且结合 Codex 重置次数的账号，减少浪费。",
   "Previous": "上一页",
   "Primary": "主用",
   "Primary is required and cannot be empty.": "主用为必填，不能为空。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -571,7 +571,7 @@
   "Port": "連接埠",
   "Preview": "預覽",
   "Prefer accounts with lower quota pressure to reduce 429 risk.": "優先使用額度壓力低的帳號，降低 429 風險。",
-  "Prefer accounts with quota left that will reset soon.": "優先使用快重置且還剩額度的帳號，減少浪費。",
+  "Prefer accounts with 5h or weekly quota resetting soon, plus Codex reset credits.": "優先使用 5 小時或週額度快重置、且結合 Codex 重設次數的帳號，減少浪費。",
   "Previous": "上一頁",
   "Primary": "主用",
   "Primary is required and cannot be empty.": "主用為必填，不能為空。",

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -110,7 +110,7 @@
     {
       value: 'use_expiring',
       label: 'Avoid waste',
-      description: 'Prefer accounts with quota left that will reset soon.',
+      description: 'Prefer accounts with 5h or weekly quota resetting soon, plus Codex reset credits.',
     },
   ];
 

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1672,6 +1672,7 @@ describe("admin.api oauth quota", () => {
       providerId: "openai-codex",
       account: "mylukin",
       source: "codex",
+      resetCredits: 2,
     });
   });
 

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -433,6 +433,16 @@ export interface AdminApiDeps {
     untilMs: number | null,
     mode?: UsageLimitWriteMode,
   ) => Promise<void>;
+  // Refresh one account's live soft quota snapshot in the current OAuth pool. Used by
+  // the /quota PULL so quota-aware strategies see fresh windows/reset credits without
+  // waiting for a full pool rebuild. Optional in tests/disabled deployments.
+  applyQuotaSnapshot?: (
+    providerId: string,
+    account: string,
+    windows: OAuthQuotaWindow[],
+    capturedAtMs: number,
+    resetCredits?: number | null,
+  ) => void;
 }
 
 // Re-exported for route signatures.

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -468,6 +468,7 @@ describe("admin OAuth routes — read endpoints", () => {
       upsert: vi.fn(async () => {}),
       delete: vi.fn(async () => {}),
     } as unknown as AdminApiDeps["oauthQuota"];
+    const upsert = oauthQuota?.upsert as unknown as ReturnType<typeof vi.fn>;
     const seam = fullSeam({
       listStatus: vi.fn(async () => ({
         selectionStrategy: "balanced",
@@ -475,12 +476,23 @@ describe("admin OAuth routes — read endpoints", () => {
       })) as never,
       fetchCodexQuota: vi.fn(async () => ({ windows: [window], resetCredits: 3 })) as never,
     });
-    const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
+    const applyQuotaSnapshot = vi.fn();
+    const res = await app({ oauth: seam, oauthQuota, applyQuotaSnapshot }).request(
+      "/admin/api/oauth/quota",
+    );
     const body = (await res.json()) as {
       quota: Array<{ providerId: string; resetCredits?: number }>;
     };
     expect(body.quota).toHaveLength(1);
     expect(body.quota[0]?.resetCredits).toBe(3);
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ resetCredits: 3 }));
+    expect(applyQuotaSnapshot).toHaveBeenCalledWith(
+      "openai-codex",
+      "default",
+      [window],
+      expect.any(Number),
+      3,
+    );
   });
 
   it("GET /oauth/:provider/models returns available + enabled", async () => {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -208,9 +208,8 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     // Codex push captured under an old label) that would show as a phantom account.
     const acctKey = (providerId: string, account: string) => `${providerId}\u0000${account}`;
     let bound: Set<string> | null = null;
-    // Codex reset-credit counts, surfaced LIVE (never persisted — the value drops the
-    // instant a credit is consumed, so a stored snapshot would lie). Keyed by acctKey;
-    // attached onto the matching codex snapshot in the response below.
+    // Codex reset-credit counts from the live usage PULL. They are persisted with the
+    // latest snapshot for quota-aware strategy scoring, then folded onto the response.
     const resetCredits = new Map<string, number | null>();
     const syncActiveCooldownFromWindows = async (
       providerId: string,
@@ -259,15 +258,17 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
               (async () => {
                 const windows = await fetchAnthropic({ account: a.account });
                 if (windows && windows.length > 0) {
+                  const capturedAt = Date.now();
                   await store
                     .upsert({
                       providerId: "anthropic",
                       account: a.account,
                       windows,
-                      capturedAt: Date.now(),
+                      capturedAt,
                       source: "anthropic",
                     })
                     .catch(() => {});
+                  deps.applyQuotaSnapshot?.("anthropic", a.account, windows, capturedAt);
                   await syncActiveCooldownFromWindows("anthropic", a.account, windows);
                 }
               })(),
@@ -284,15 +285,24 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                 if (!result) return;
                 resetCredits.set(acctKey("openai-codex", a.account), result.resetCredits);
                 if (result.windows.length > 0) {
+                  const capturedAt = Date.now();
                   await store
                     .upsert({
                       providerId: "openai-codex",
                       account: a.account,
                       windows: result.windows,
-                      capturedAt: Date.now(),
+                      capturedAt,
                       source: "codex",
+                      resetCredits: result.resetCredits,
                     })
                     .catch(() => {});
+                  deps.applyQuotaSnapshot?.(
+                    "openai-codex",
+                    a.account,
+                    result.windows,
+                    capturedAt,
+                    result.resetCredits,
+                  );
                   await syncActiveCooldownFromWindows("openai-codex", a.account, result.windows);
                 }
               })(),

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -392,6 +392,7 @@ export interface OAuthQuotaSeed {
   windows: OAuthQuotaWindow[];
   capturedAt: number;
   usageLimitedUntilMs: number | null;
+  resetCredits?: number | null;
 }
 
 // Build a FRESH, standalone executor client for ONE oauth account: its token manager
@@ -612,6 +613,7 @@ export async function synthesizeOAuthProviders(
         usageLimitedUntilMs: quotaSeed?.usageLimitedUntilMs ?? null,
         quotaWindows: quotaSeed?.windows,
         quotaCapturedAtMs: quotaSeed?.capturedAt,
+        quotaResetCredits: quotaSeed?.resetCredits ?? null,
       });
     }
 
@@ -1323,6 +1325,7 @@ export async function buildServer(
           windows: snap.windows,
           capturedAt: snap.capturedAt,
           usageLimitedUntilMs: snap.usageLimitedUntilMs ?? null,
+          resetCredits: snap.resetCredits ?? null,
         });
       }
     } catch {
@@ -1361,6 +1364,17 @@ export async function buildServer(
         line: e instanceof Error ? e.message : String(e),
       }),
     );
+  };
+  const applyQuotaSnapshot = (
+    providerId: string,
+    account: string,
+    windows: OAuthQuotaWindow[],
+    capturedAtMs: number,
+    resetCredits?: number | null,
+  ): void => {
+    oauthPoolClients
+      .get(providerId)
+      ?.setQuotaSnapshot(account, windows, capturedAtMs, resetCredits);
   };
 
   // Executor hook: an account-wide 429 on a subscription alias means the SERVED account
@@ -2366,6 +2380,7 @@ export async function buildServer(
       // /quota PULL parks a saturated account — both flip the live member in place +
       // persist, no rebuild. Never touches schedulable.
       applyUsageLimit,
+      applyQuotaSnapshot,
     });
 
     // Admin SPA static hosting (/admin). MUST be mounted AFTER registerAdminApi so

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-05 · 避免浪费策略纳入周额度与 Codex reset credits（OAuth provider pool / quota，docs/04/11，原则 3/5/7）
+
+- **背景（Lukin）**：`use_expiring` 不能只看单个快重置窗口；用户实际关心的是 5 小时额度、周额度，以及 Codex 账号还剩多少次 reset credit。周额度快到 reset 且还有大量剩余额度时应被优先使用；有 reset credits 的账号也具备额外恢复能力，应进入评分。
+- **评分决策**：`use_expiring` 从“取最佳单窗口”改为“汇总适用窗口分数”：每个窗口按 `(100 - usedPercent) / hoursUntilReset` 计分，周额度窗口（Codex `secondary` / Anthropic `7d*` / 7 天窗口）加权更高；Codex reset credits 作为折扣后的虚拟周窗口加分，影响账号选择但不触发消费。
+- **安全边界**：选择策略只把 reset credits 当软评分信号，不会自动花掉 credit。真正消费仍走手动 Reset limit / auto-reset 的硬门禁（weekly snapshot、阈值、guard、审计）。
+- **实时性修正**：providers 页 `/oauth/quota` PULL 成功后不只写入 `oauth_quota`，还会刷新当前 live OAuth pool 的 soft quota snapshot；Anthropic/Codex 的新鲜 quota 不再必须等待下一次 rebuild 才影响策略。
+- **验证计划**：覆盖 `use_expiring` 汇总短窗口+周窗口、reset credits 参与评分、SQLite/Postgres reset_credits round-trip 且 header PUSH 不清空、admin quota PULL 写库并刷新 live pool；再跑 targeted Vitest、typecheck、lint、build。
+
 ## 2026-07-05 · Codex reset-credit 消费改为硬门禁（OAuth quota / Admin providers，docs/04/11，原则 3/5/7）
 
 - **背景（Lukin）**：Codex rate-limit reset credit 是稀缺上游额度，不能因为 providers 页刷新、容器重启、持续 saturated header 或误开 auto-reset 而快速消耗。既要保留手动/自动恢复能力，也要默认 fail-closed 保护 reset credits。
@@ -22,7 +30,7 @@
 - **背景（Lukin）**：订阅 provider 的多账号池不只有一种合理用法。有的用户希望低风险、少 429、尽量均摊；有的用户希望避免额度浪费，把快重置且还剩较多额度的账号优先用掉；有的用户希望完全按自己设置的 priority 操作。
 - **产品决策**：策略是全局账号池级别，而不是 account 级别，也不是每个 provider 单独配置。用户选择的是“整个系统如何使用订阅账号额度”；该策略在每个订阅 provider 的账号池内统一生效。跨 provider/model 的选择仍由 lanes/policies/fallback 负责，不被这个账号策略替代。
 - **策略集合**：`balanced` 保持现有 sticky/hash/LRU 均衡；`manual_priority` 按 priority + LRU 分配新会话，已有会话继续 sticky；`low_risk` 在最低 priority 层里优先选择 quota pressure 更低的账号，降低打到上限/429 的概率；`use_expiring` 优先使用“剩余额度多且离 reset 更近”的窗口，目标是减少快重置前未用完的额度。
-- **额度语义**：quota windows 只作为软评分输入，缺失或超过 freshness 窗口时自动回退到 balanced 行为；`usageLimitedUntilMs` 仍是硬调度门禁。Codex reset credits 不当作普通容量参与评分，因为它是稀缺的消耗型恢复能力，仍只在手动/auto-reset 流程里使用。
+- **额度语义**：quota windows 只作为软评分输入，缺失或超过 freshness 窗口时自动回退到 balanced 行为；`usageLimitedUntilMs` 仍是硬调度门禁。Codex reset credits 只在 `use_expiring` 中作为折扣后的软评分信号，不会自动触发消费；真正消费仍只在手动/auto-reset 流程里发生。
 - **会话边界**：`previous_response_id` 是强亲和，必须回到产生该 response 的账号，即使 quota 策略觉得另一个账号更优；普通 sticky 会话在 quota 策略下只允许在软阈值内保持，以避免长期卡在高压账号。
 - **Scoped quota 边界**：Anthropic `7d-*` scoped windows 只在当前模型匹配对应 slug 时参与评分，不扩大成全账号压力或全账号 cooldown。
 - **实现路径**：core OAuth pool 统一负责策略选择；gateway 从 encrypted global OAuth settings 读取策略，启动/热重建时注入所有订阅账号池，并把 quota snapshots seed 到 pool member；Codex header PUSH 捕获后即时刷新 live pool member 的软 quota snapshot。Admin Providers 页面提供一个系统级下拉选择，保存后热重建生效。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -171,6 +171,76 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(calls).toEqual(["soon"]);
   });
 
+  it("use_expiring strategy combines short and weekly windows instead of only taking the best single window", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        {
+          ...member("weekly-left", 50, true, calls),
+          quotaWindows: [
+            { key: "primary", usedPercent: 60, resetsAtMs: 60 * 60 * 1000, windowMinutes: 300 },
+            {
+              key: "secondary",
+              usedPercent: 60,
+              resetsAtMs: 60 * 60 * 1000,
+              windowMinutes: 10_080,
+            },
+          ],
+          quotaCapturedAtMs: 1_000,
+        },
+        {
+          ...member("short-left", 50, true, calls),
+          quotaWindows: [
+            { key: "primary", usedPercent: 10, resetsAtMs: 60 * 60 * 1000, windowMinutes: 300 },
+            {
+              key: "secondary",
+              usedPercent: 100,
+              resetsAtMs: 60 * 60 * 1000,
+              windowMinutes: 10_080,
+            },
+          ],
+          quotaCapturedAtMs: 1_000,
+        },
+      ],
+      selectionStrategy: "use_expiring",
+      now: () => 1_000,
+    });
+
+    await pool.chatCompletion(REQ);
+
+    expect(calls).toEqual(["weekly-left"]);
+  });
+
+  it("use_expiring strategy includes Codex reset credits as recoverable weekly capacity", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        {
+          ...member("no-credits", 50, true, calls),
+          quotaWindows: [
+            { key: "primary", usedPercent: 0, resetsAtMs: 60 * 60 * 1000, windowMinutes: 300 },
+          ],
+          quotaCapturedAtMs: 1_000,
+          quotaResetCredits: 0,
+        },
+        {
+          ...member("has-credits", 50, true, calls),
+          quotaWindows: [
+            { key: "primary", usedPercent: 10, resetsAtMs: 60 * 60 * 1000, windowMinutes: 300 },
+          ],
+          quotaCapturedAtMs: 1_000,
+          quotaResetCredits: 2,
+        },
+      ],
+      selectionStrategy: "use_expiring",
+      now: () => 1_000,
+    });
+
+    await pool.chatCompletion(REQ);
+
+    expect(calls).toEqual(["has-credits"]);
+  });
+
   it("manual_priority keeps new sessions on priority/LRU instead of hash assignment", async () => {
     const calls: string[] = [];
     const pool = createOAuthPoolClient({

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -108,6 +108,9 @@ export interface OAuthPoolMember {
   // signals: stale/missing windows must never make the pool fail closed.
   quotaWindows?: OAuthQuotaWindow[];
   quotaCapturedAtMs?: number | null;
+  // Codex only: available rate-limit reset credits captured with the latest usage
+  // snapshot. Soft signal for quota-aware scoring; never consumed by selection.
+  quotaResetCredits?: number | null;
 }
 
 export type OAuthSelectionStrategy = "balanced" | "manual_priority" | "low_risk" | "use_expiring";
@@ -121,7 +124,12 @@ export interface OAuthPoolClient extends ProviderClient {
   // The account's current auto-park cooldown (epoch ms), or null if eligible now. Lets
   // the gateway make a park EXTEND-ONLY — never shorten a precise quota reset already set.
   getUsageLimit(account: string): number | null;
-  setQuotaSnapshot(account: string, windows: OAuthQuotaWindow[], capturedAtMs: number): void;
+  setQuotaSnapshot(
+    account: string,
+    windows: OAuthQuotaWindow[],
+    capturedAtMs: number,
+    resetCredits?: number | null,
+  ): void;
 }
 
 export interface OAuthRateLimitParkContext {
@@ -413,6 +421,32 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return scoped.length > 0 && model.toLowerCase().includes(scoped);
   }
 
+  function isWeeklyQuotaWindow(window: OAuthQuotaWindow): boolean {
+    return (
+      window.key === "secondary" ||
+      window.key === "7d" ||
+      window.key.startsWith("7d-") ||
+      (window.windowMinutes !== null && window.windowMinutes >= 7 * 24 * 60)
+    );
+  }
+
+  function expiringWindowWeight(window: OAuthQuotaWindow): number {
+    return isWeeklyQuotaWindow(window) ? 2 : 1;
+  }
+
+  function resetCreditValue(entry: PoolEntry, nowMs: number): number {
+    if (!quotaFresh(entry.member, nowMs)) return 0;
+    const credits = entry.member.quotaResetCredits;
+    if (credits == null || credits <= 0) return 0;
+    // A reset credit can restore one set of Codex rate-limit windows, but spending it
+    // is guarded elsewhere. Treat it as discounted virtual weekly capacity: important
+    // enough to break ties and influence Avoid Waste, not enough to beat a natural
+    // window that is about to reset with large unused quota.
+    const cappedCredits = Math.min(Math.trunc(credits), 5);
+    const virtualWeeklyValue = 100 / (7 * 24);
+    return cappedCredits * virtualWeeklyValue * 10;
+  }
+
   function applicableQuotaWindows(
     entry: PoolEntry,
     model: string | null,
@@ -433,16 +467,16 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     model: string | null,
     nowMs: number,
   ): number | null {
-    let best = 0;
+    let total = 0;
     for (const w of applicableQuotaWindows(entry, model, nowMs)) {
       if (w.resetsAtMs === null || w.resetsAtMs <= nowMs) continue;
       const remaining = Math.max(0, 100 - w.usedPercent);
       if (remaining <= 0) continue;
       const hoursUntilReset = Math.max((w.resetsAtMs - nowMs) / 3_600_000, 0.25);
-      const value = remaining / hoursUntilReset;
-      if (value > best) best = value;
+      total += (remaining / hoursUntilReset) * expiringWindowWeight(w);
     }
-    return best > 0 ? best : null;
+    total += resetCreditValue(entry, nowMs);
+    return total > 0 ? total : null;
   }
 
   function chooseByLowRisk(
@@ -810,11 +844,17 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     getUsageLimit(account: string): number | null {
       return entries.find((e) => e.member.account === account)?.member.usageLimitedUntilMs ?? null;
     },
-    setQuotaSnapshot(account: string, windows: OAuthQuotaWindow[], capturedAtMs: number): void {
+    setQuotaSnapshot(
+      account: string,
+      windows: OAuthQuotaWindow[],
+      capturedAtMs: number,
+      resetCredits?: number | null,
+    ): void {
       const entry = entries.find((e) => e.member.account === account);
       if (!entry) return;
       entry.member.quotaWindows = windows;
       entry.member.quotaCapturedAtMs = capturedAtMs;
+      if (resetCredits !== undefined) entry.member.quotaResetCredits = resetCredits;
     },
     async chatCompletion(
       req: ChatCompletionRequest,

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -741,6 +741,18 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Codex reset-credit count for quota-aware account selection — pg mirror of
+    // sqlite v36. Nullable and observability-only; Codex usage PULLs refresh it.
+    version: 35,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "oauth_quota", ["provider_id"])) {
+        await db.execute(
+          sql.raw("ALTER TABLE oauth_quota ADD COLUMN IF NOT EXISTS reset_credits INTEGER"),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {
@@ -751,7 +763,7 @@ function resultRows<T>(result: unknown): T[] {
 
 async function pgTableHasColumns(
   db: RawExecutor,
-  table: "memory_threads" | "memory_messages" | "memory_jobs",
+  table: "memory_threads" | "memory_messages" | "memory_jobs" | "oauth_quota",
   requiredColumns: readonly string[],
 ): Promise<boolean> {
   const rows = resultRows<{ column_name: string }>(

--- a/packages/core/src/store/postgres/oauth-quota.ts
+++ b/packages/core/src/store/postgres/oauth-quota.ts
@@ -13,24 +13,30 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
   constructor(private readonly db: PgDb) {}
 
   async upsert(snapshot: Omit<OAuthQuotaSnapshot, "usageLimitedUntilMs">): Promise<void> {
+    const values = {
+      providerId: snapshot.providerId,
+      account: snapshot.account,
+      windows: snapshot.windows,
+      capturedAt: snapshot.capturedAt,
+      source: snapshot.source,
+      ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
+    };
+    const set = {
+      windows: snapshot.windows,
+      capturedAt: snapshot.capturedAt,
+      source: snapshot.source,
+      ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
+    };
     // usage_limited_until_ms is intentionally absent from BOTH insert values (NULL on
     // a new row) and the conflict SET — a window refresh must not clobber a cooldown.
+    // reset_credits is updated only when the caller has a fresh Codex PULL count;
+    // Codex header PUSHes preserve it.
     await this.db
       .insert(oauthQuota)
-      .values({
-        providerId: snapshot.providerId,
-        account: snapshot.account,
-        windows: snapshot.windows,
-        capturedAt: snapshot.capturedAt,
-        source: snapshot.source,
-      })
+      .values(values)
       .onConflictDoUpdate({
         target: [oauthQuota.providerId, oauthQuota.account],
-        set: {
-          windows: snapshot.windows,
-          capturedAt: snapshot.capturedAt,
-          source: snapshot.source,
-        },
+        set,
       });
   }
 
@@ -46,6 +52,7 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
         capturedAt: 0,
         source: providerId === "anthropic" ? "anthropic" : "codex-headers",
         usageLimitedUntilMs: untilMs,
+        resetCredits: null,
       })
       .onConflictDoUpdate({
         target: [oauthQuota.providerId, oauthQuota.account],
@@ -82,6 +89,7 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
       capturedAt: row.capturedAt,
       source: row.source,
       usageLimitedUntilMs: row.usageLimitedUntilMs ?? null,
+      resetCredits: row.resetCredits ?? null,
     });
   }
 }

--- a/packages/core/src/store/postgres/oauth-usage.test.ts
+++ b/packages/core/src/store/postgres/oauth-usage.test.ts
@@ -122,6 +122,30 @@ describe("PgOAuthQuotaStore (pglite)", () => {
     await db.$close();
   });
 
+  it("round-trips reset credits and preserves them when a header snapshot omits the count", async () => {
+    const db: PgDb = await createPgliteDb();
+    const store = new PgOAuthQuotaStore(db);
+    await store.upsert(
+      snap({
+        providerId: "openai-codex",
+        source: "codex",
+        resetCredits: 2,
+      }),
+    );
+    expect((await store.get("openai-codex", "a"))?.resetCredits).toBe(2);
+
+    await store.upsert(
+      snap({
+        providerId: "openai-codex",
+        source: "codex-headers",
+        capturedAt: 999,
+        resetCredits: undefined,
+      }),
+    );
+    expect((await store.get("openai-codex", "a"))?.resetCredits).toBe(2);
+    await db.$close();
+  });
+
   it("setUsageLimit upserts a synthetic row; a window upsert preserves the cooldown; null clears it", async () => {
     const db: PgDb = await createPgliteDb();
     const store = new PgOAuthQuotaStore(db);

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -351,6 +351,8 @@ export const oauthQuota = pgTable(
     // scheduling pool (null = not limited). Runtime twin of `windows`; the "Reset
     // usage" action sets it back to null.
     usageLimitedUntilMs: bigint("usage_limited_until_ms", { mode: "number" }), // nullable
+    // Codex only: available rate-limit reset credits captured from the usage PULL.
+    resetCredits: integer("reset_credits"), // nullable
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -837,6 +837,20 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Codex reset-credit count for quota-aware account selection. Nullable and
+    // observability-only; header refreshes can leave it unchanged when no count is
+    // present, while Codex usage PULLs refresh it.
+    version: 36,
+    run: (db) => {
+      if (
+        sqliteTableHasColumns(db, "oauth_quota", ["provider_id"]) &&
+        !sqliteTableHasColumns(db, "oauth_quota", ["reset_credits"])
+      ) {
+        db.exec("ALTER TABLE oauth_quota ADD COLUMN reset_credits INTEGER;");
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/oauth-quota.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.test.ts
@@ -48,6 +48,30 @@ describe("SqliteOAuthQuotaStore", () => {
     close();
   });
 
+  it("round-trips reset credits and preserves them when a header snapshot omits the count", async () => {
+    const { store, close } = freshStore();
+    await store.upsert(
+      snap({
+        providerId: "openai-codex",
+        source: "codex",
+        resetCredits: 2,
+      }),
+    );
+    expect((await store.get("openai-codex", "a"))?.resetCredits).toBe(2);
+
+    await store.upsert(
+      snap({
+        providerId: "openai-codex",
+        source: "codex-headers",
+        capturedAt: 999,
+        resetCredits: undefined,
+      }),
+    );
+
+    expect((await store.get("openai-codex", "a"))?.resetCredits).toBe(2);
+    close();
+  });
+
   it("getAll returns every account's latest snapshot; get is null when absent", async () => {
     const { store, close } = freshStore();
     expect(await store.get("anthropic", "missing")).toBeNull();

--- a/packages/core/src/store/sqlite/oauth-quota.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.ts
@@ -21,16 +21,24 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
       windows: JSON.stringify(snapshot.windows),
       capturedAt: snapshot.capturedAt,
       source: snapshot.source,
+      ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
     };
-    // Note: usage_limited_until_ms is intentionally absent from BOTH the insert
-    // values (defaults to NULL on a brand-new row) and the conflict SET — an
-    // observability refresh must never overwrite an active cooldown.
+    const set = {
+      windows: row.windows,
+      capturedAt: row.capturedAt,
+      source: row.source,
+      ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
+    };
+    // Note: usage_limited_until_ms is intentionally absent from BOTH the insert values
+    // (defaults to NULL on a brand-new row) and the conflict SET — an observability
+    // refresh must never overwrite an active cooldown. reset_credits is updated only
+    // when the caller has a fresh Codex PULL count; Codex header PUSHes preserve it.
     this.db
       .insert(oauthQuota)
       .values(row)
       .onConflictDoUpdate({
         target: [oauthQuota.providerId, oauthQuota.account],
-        set: { windows: row.windows, capturedAt: row.capturedAt, source: row.source },
+        set,
       })
       .run();
   }
@@ -48,6 +56,7 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
         capturedAt: 0,
         source: providerId === "anthropic" ? "anthropic" : "codex-headers",
         usageLimitedUntilMs: untilMs,
+        resetCredits: null,
       })
       .onConflictDoUpdate({
         target: [oauthQuota.providerId, oauthQuota.account],
@@ -90,6 +99,7 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
       capturedAt: row.capturedAt,
       source: row.source,
       usageLimitedUntilMs: row.usageLimitedUntilMs ?? null,
+      resetCredits: row.resetCredits ?? null,
     });
   }
 }

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -228,6 +228,8 @@ export const oauthQuota = sqliteTable(
     // scheduling pool (null = not limited). The runtime twin of `windows` — the
     // scheduler gates on it; the "Reset usage" action sets it back to null.
     usageLimitedUntilMs: integer("usage_limited_until_ms"), // nullable
+    // Codex only: available rate-limit reset credits captured from the usage PULL.
+    resetCredits: integer("reset_credits"), // nullable
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );

--- a/packages/shared/src/oauth/usage-schema.test.ts
+++ b/packages/shared/src/oauth/usage-schema.test.ts
@@ -33,6 +33,11 @@ describe("OAuthQuotaSnapshotSchema — usageLimitedUntilMs", () => {
     expect(parsed.usageLimitedUntilMs).toBe(1_700_000);
   });
 
+  it("round-trips an optional Codex reset-credit count", () => {
+    const parsed = OAuthQuotaSnapshotSchema.parse({ ...base, resetCredits: 2 });
+    expect(parsed.resetCredits).toBe(2);
+  });
+
   it("rejects a non-integer cooldown", () => {
     expect(() => OAuthQuotaSnapshotSchema.parse({ ...base, usageLimitedUntilMs: 1.5 })).toThrow();
   });

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -65,6 +65,9 @@ export const OAuthQuotaSnapshotSchema = z
     capturedAt: z.number().int(), // epoch ms the snapshot was taken
     source: z.enum(["anthropic", "codex-headers", "codex"]),
     usageLimitedUntilMs: z.number().int().nullable().default(null),
+    // Codex only: how many rate-limit reset credits are available at capture time.
+    // Optional because Anthropic has no equivalent and older rows predate this field.
+    resetCredits: z.number().int().nonnegative().nullable().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- make the OAuth avoid-waste strategy score both short-window and weekly quota before reset
- include Codex reset credits as discounted recoverable weekly capacity without consuming them during selection
- persist reset_credits in SQLite/Postgres quota snapshots and hot-refresh the live pool after admin quota pulls
- update provider strategy copy so users see that weekly quota and reset credits are considered

## Tests
- pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts packages/shared/src/oauth/usage-schema.test.ts packages/core/src/store/sqlite/oauth-quota.test.ts packages/core/src/store/postgres/oauth-usage.test.ts apps/gateway/src/routes/admin/oauth.test.ts apps/gateway/src/routes/admin/admin.test.ts apps/admin/src/lib/api/oauth.test.ts apps/admin/src/routes/providers/providers.test.ts
- pnpm exec vitest run packages/core/src/store/sqlite/oauth-quota-migrate.test.ts packages/core/src/store/sqlite/schema.test.ts packages/core/src/store/postgres/migrate.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build