### PR TITLE
Fix OAuth account failure parking

### DIFF
--- a/apps/admin/src/lib/api/oauth.test.ts
+++ b/apps/admin/src/lib/api/oauth.test.ts
@@ -72,6 +72,7 @@ describe('admin oauth api client', () => {
                 expiresAt: null,
                 updatedAt: 1,
                 healthy: true,
+                credentialFailed: false,
                 priority: 20,
                 schedulable: true,
                 fastMode: true,
@@ -87,6 +88,7 @@ describe('admin oauth api client', () => {
     expect(status.configured).toBe(true);
     expect(status.selectionStrategy).toBe('low_risk');
     expect(status.providers[0]?.accounts[0]?.account).toBe('acct-a');
+    expect(status.providers[0]?.accounts[0]?.credentialFailed).toBe(false);
     expect(status.providers[0]?.accounts[0]?.fastMode).toBe(true);
     expect(JSON.stringify(status)).not.toMatch(/access_token|refresh_token|secret/i);
   });

--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -15,6 +15,9 @@ export interface OAuthAccount {
   // True when the account has a working durable credential (the gateway auto-renews
   // the short-lived access token). False = a refresh failed → needs reconnecting.
   healthy: boolean;
+  // True after a durable OAuth credential rejection. Reconnect clears it; the
+  // schedulable toggle alone must not appear to recover the account.
+  credentialFailed?: boolean;
   // Effective pool scheduling (defaults applied by the gateway: 50 / true). LOWER
   // priority = served first; schedulable false parks the account out of rotation.
   priority: number;

--- a/apps/admin/src/lib/components/TestAccountDialog.svelte
+++ b/apps/admin/src/lib/components/TestAccountDialog.svelte
@@ -60,6 +60,7 @@
         } else if (ev.type === 'error') {
           status = 'error';
           errorMsg = ev.error;
+          void invalidateAll();
         } else if (ev.type === 'done') {
           durationMs = ev.durationMs ?? Math.round(performance.now() - startedAt);
           // A `done` that arrives after an `error` keeps the failed status.

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -607,6 +607,7 @@
             {@const canResetCodexLimit = isCodex && canUseCodexResetCredit(quota, codexCredits)}
             {@const usageLimit = usageLimitStatus(quota)}
             {@const usageLimitRecovery = usageLimit ? autoRecoverIn(usageLimit.untilMs) : ''}
+            {@const credentialFailed = row.account.credentialFailed === true}
             <tr class="align-top" data-testid="provider-account-row">
               <!-- Provider / account + type badge -->
               <td data-label={$t('Provider')} class="px-3 py-3">
@@ -753,8 +754,9 @@
                   type="checkbox"
                   class="h-5 w-5 disabled:opacity-50 md:h-4 md:w-4"
                   checked={row.account.schedulable}
-                  disabled={saving}
+                  disabled={saving || credentialFailed}
                   aria-label={$t('Schedulable')}
+                  title={credentialFailed ? $t('needs reconnect') : undefined}
                   onchange={(e) =>
                     toggleSchedulable(
                       row.provider.id,

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -443,6 +443,36 @@ describe('providers page', () => {
     expect(invalidateAllMock).toHaveBeenCalledTimes(1);
   });
 
+  it('disables schedulability for credential-failed accounts', async () => {
+    renderPage({
+      providers: [
+        provider({
+          accounts: [
+            {
+              account: 'acct-claude',
+              expiresAt: null,
+              updatedAt: Date.now(),
+              healthy: false,
+              credentialFailed: true,
+              priority: 10,
+              schedulable: false,
+              fastMode: false,
+              proxy: null,
+              models: ['claude-opus-4-6'],
+            },
+          ],
+        }),
+      ],
+    });
+    const row = screen.getByTestId('provider-account-row');
+    const checkbox = within(row).getByRole('checkbox', { name: /schedulable/i });
+
+    expect(within(row).getByText('needs reconnect')).toBeInTheDocument();
+    expect(checkbox).toBeDisabled();
+
+    expect(setAccountSchedule).not.toHaveBeenCalled();
+  });
+
   it('toggles per-account Fast mode through the scheduling endpoint', async () => {
     renderPage();
     const checkbox = within(screen.getByTestId('provider-account-row')).getByRole('checkbox', {

--- a/apps/gateway/src/oauth/account-settings.test.ts
+++ b/apps/gateway/src/oauth/account-settings.test.ts
@@ -1,9 +1,11 @@
 import { type ConfigStore, createSqliteDb, SqliteConfigStore } from "@helm/core";
 import { describe, expect, it } from "vitest";
 import {
+  clearAccountCredentialFailure,
   getAccountSettings,
   loadAccountSettings,
   loadGlobalOAuthSettings,
+  markAccountCredentialFailure,
   setAccountSettings,
   setGlobalOAuthSettings,
 } from "./account-settings.js";
@@ -127,6 +129,62 @@ describe("account-settings", () => {
         fastMode: false,
       },
     );
+  });
+
+  it("marks a credential failure as unhealthy and auto-parks only when not already manually parked", async () => {
+    const config = makeConfig();
+    await setAccountSettings(config, KEY, "openai-codex", "default", { priority: 7 });
+
+    await markAccountCredentialFailure(config, KEY, "openai-codex", "default", {
+      at: 12_345,
+      reason: "oauth refresh failed (openai-codex, status 401)",
+    });
+
+    expect(
+      getAccountSettings(await loadAccountSettings(config, KEY), "openai-codex", "default"),
+    ).toEqual({
+      priority: 7,
+      schedulable: false,
+      autoDisabledForCredentialFailure: true,
+      credentialFailedAt: 12_345,
+      credentialFailureReason: "oauth refresh failed (openai-codex, status 401)",
+    });
+
+    await setAccountSettings(config, KEY, "openai-codex", "manual", { schedulable: false });
+    await markAccountCredentialFailure(config, KEY, "openai-codex", "manual", {
+      at: 20_000,
+      reason: "upstream returned 401",
+    });
+    expect(
+      getAccountSettings(await loadAccountSettings(config, KEY), "openai-codex", "manual"),
+    ).toMatchObject({
+      schedulable: false,
+      autoDisabledForCredentialFailure: false,
+      credentialFailedAt: 20_000,
+    });
+  });
+
+  it("clears credential failure on reconnect and only re-enables auto-disabled accounts", async () => {
+    const config = makeConfig();
+    await markAccountCredentialFailure(config, KEY, "openai-codex", "auto", {
+      at: 12_345,
+      reason: "oauth refresh failed (openai-codex, status 401)",
+    });
+    await setAccountSettings(config, KEY, "openai-codex", "manual", { schedulable: false });
+    await markAccountCredentialFailure(config, KEY, "openai-codex", "manual", {
+      at: 20_000,
+      reason: "upstream returned 401",
+    });
+
+    await clearAccountCredentialFailure(config, KEY, "openai-codex", "auto");
+    await clearAccountCredentialFailure(config, KEY, "openai-codex", "manual");
+
+    expect(
+      getAccountSettings(await loadAccountSettings(config, KEY), "openai-codex", "auto"),
+    ).toEqual({});
+    expect(
+      getAccountSettings(await loadAccountSettings(config, KEY), "openai-codex", "manual"),
+    ).toEqual({ schedulable: false });
   });
 
   it("round-trips the global account selection strategy independently from account settings", async () => {

--- a/apps/gateway/src/oauth/account-settings.ts
+++ b/apps/gateway/src/oauth/account-settings.ts
@@ -43,6 +43,15 @@ export interface AccountSettings {
   priority?: number;
   // When false the account is skipped by the scheduler (kept connected, parked).
   schedulable?: boolean;
+  // Durable credential failure detected from a refresh 400/401/403 or upstream auth
+  // rejection. While set, the account is treated as unhealthy and not routable until a
+  // successful reconnect clears it.
+  credentialFailedAt?: number;
+  credentialFailureReason?: string;
+  // True when Helm, not the operator, flipped schedulable:false because the credential
+  // failed. A successful reconnect may safely restore default schedulability only for
+  // these auto-disabled accounts; manually parked accounts stay parked.
+  autoDisabledForCredentialFailure?: boolean;
   // Codex only: when true, auto-consume one rate-limit reset credit the moment the
   // weekly window saturates (≥100%). Unset/false = never auto-reset (manual only).
   autoReset?: boolean;
@@ -168,6 +177,53 @@ export async function setAccountSettings(
     const map = await loadAccountSettings(config, encKey);
     const key = composite(providerId, account);
     map[key] = { ...map[key], ...patch };
+    await saveAccountSettings(config, encKey, map);
+  });
+}
+
+export async function markAccountCredentialFailure(
+  config: ConfigStore,
+  encKey: Buffer,
+  providerId: string,
+  account: string,
+  failure: { at: number; reason: string },
+): Promise<void> {
+  await serializeSettingsMutation(config, async () => {
+    const map = await loadAccountSettings(config, encKey);
+    const key = composite(providerId, account);
+    const current = map[key] ?? {};
+    const wasOperatorParked =
+      current.schedulable === false && current.autoDisabledForCredentialFailure !== true;
+    map[key] = {
+      ...current,
+      schedulable: false,
+      credentialFailedAt: failure.at,
+      credentialFailureReason: failure.reason.slice(0, 240),
+      autoDisabledForCredentialFailure: !wasOperatorParked,
+    };
+    await saveAccountSettings(config, encKey, map);
+  });
+}
+
+export async function clearAccountCredentialFailure(
+  config: ConfigStore,
+  encKey: Buffer,
+  providerId: string,
+  account: string,
+): Promise<void> {
+  await serializeSettingsMutation(config, async () => {
+    const map = await loadAccountSettings(config, encKey);
+    const key = composite(providerId, account);
+    const current = map[key];
+    if (!current) return;
+    const next: AccountSettings = { ...current };
+    const shouldRestoreDefaultSchedulable =
+      next.autoDisabledForCredentialFailure === true && next.schedulable === false;
+    delete next.credentialFailedAt;
+    delete next.credentialFailureReason;
+    delete next.autoDisabledForCredentialFailure;
+    if (shouldRestoreDefaultSchedulable) delete next.schedulable;
+    map[key] = next;
     await saveAccountSettings(config, encKey, map);
   });
 }

--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@helm/core";
 import type { OAuthQuotaWindow } from "@helm/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getAccountSettings, loadAccountSettings } from "./account-settings.js";
+import { getAccountSettings, loadAccountSettings, setAccountSettings } from "./account-settings.js";
 import { createOAuthAdmin } from "./admin-oauth.js";
 
 const KEY = Buffer.alloc(32, 4);
@@ -294,6 +294,8 @@ describe("createOAuthAdmin", () => {
 
   it("listStatus marks an account unhealthy when its refresh fails (needs reconnect)", async () => {
     const store = makeStore();
+    const config = makeConfig();
+    const onCredentialFailure = vi.fn(async () => {});
     await store.upsert({
       providerId: "github-copilot",
       account: "dead",
@@ -306,8 +308,9 @@ describe("createOAuthAdmin", () => {
     const admin = createOAuthAdmin({
       store,
       encKey: KEY,
-      config: makeConfig(),
+      config,
       now: () => 10_000_000,
+      onCredentialFailure,
     });
     vi.stubGlobal(
       "fetch",
@@ -316,6 +319,54 @@ describe("createOAuthAdmin", () => {
     const acct = (await admin.listStatus()).providers.find((p) => p.id === "github-copilot")
       ?.accounts[0];
     expect(acct?.healthy).toBe(false);
+    expect(acct?.credentialFailed).toBe(true);
+    expect(onCredentialFailure).toHaveBeenCalledWith(
+      "github-copilot",
+      "dead",
+      "oauth refresh failed (github-copilot, status 401)",
+    );
+    const settings = getAccountSettings(
+      await loadAccountSettings(config, KEY),
+      "github-copilot",
+      "dead",
+    );
+    expect(settings.credentialFailedAt).toBe(10_000_000);
+    expect(settings.schedulable).toBe(false);
+  });
+
+  it("listStatus treats a persisted credential failure as reconnect-only and does not refresh", async () => {
+    const { tokens, config } = makeStores();
+    await tokens.upsert({
+      providerId: "openai-codex",
+      account: "dead",
+      accessEnc: encryptSecret("x", KEY),
+      refreshEnc: encryptSecret("revoked", KEY),
+      expiresAt: 1000,
+      meta: null,
+      updatedAt: 1,
+    });
+    await setAccountSettings(config, KEY, "openai-codex", "dead", {
+      credentialFailedAt: 12_345,
+      credentialFailureReason: "oauth refresh failed (openai-codex, status 401)",
+      schedulable: false,
+    });
+    const fetchFn = vi.fn(async () => {
+      throw new Error("must not refresh a credential-failed account");
+    });
+    const admin = createOAuthAdmin({
+      store: tokens,
+      encKey: KEY,
+      config,
+      makeFetch: () => fetchFn as unknown as typeof fetch,
+    });
+
+    const acct = (await admin.listStatus()).providers.find((p) => p.id === "openai-codex")
+      ?.accounts[0];
+
+    expect(acct?.healthy).toBe(false);
+    expect(acct?.credentialFailed).toBe(true);
+    expect(acct?.schedulable).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
   });
 
   it("rejects the wrong flow for a provider", async () => {
@@ -692,6 +743,41 @@ describe("createOAuthAdmin", () => {
       autoReset: true,
       fastMode: true,
     });
+  });
+
+  it("setAccountSchedule rejects re-enabling a credential-failed account until reconnect", async () => {
+    const { tokens, config } = makeStores();
+    await setAccountSettings(config, KEY, "openai-codex", "dead", {
+      schedulable: false,
+      credentialFailedAt: 12_345,
+      credentialFailureReason: "oauth refresh failed (openai-codex, status 401)",
+      autoDisabledForCredentialFailure: true,
+    });
+    const admin = createOAuthAdmin({ store: tokens, encKey: KEY, config });
+
+    await expect(
+      admin.setAccountSchedule({
+        providerId: "openai-codex",
+        account: "dead",
+        schedulable: true,
+      }),
+    ).rejects.toThrow(/needs reconnect/);
+
+    expect(await admin.getAccountSchedule({ providerId: "openai-codex", account: "dead" })).toEqual(
+      {
+        priority: 50,
+        schedulable: false,
+        autoReset: false,
+        fastMode: false,
+      },
+    );
+    const settings = getAccountSettings(
+      await loadAccountSettings(config, KEY),
+      "openai-codex",
+      "dead",
+    );
+    expect(settings.credentialFailedAt).toBe(12_345);
+    expect(settings.autoDisabledForCredentialFailure).toBe(true);
   });
 
   it("setAccountSchedule leaves an omitted field unchanged + preserves proxy", async () => {

--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -37,13 +37,19 @@ import type {
   OAuthAdminStatusResponse,
 } from "../routes/admin/deps.js";
 import {
+  clearAccountCredentialFailure,
   clearAccountSettings,
   getAccountSettings,
   loadAccountSettings,
   loadGlobalOAuthSettings,
+  markAccountCredentialFailure,
   setAccountSettings,
   setGlobalOAuthSettings,
 } from "./account-settings.js";
+import {
+  isPermanentOAuthCredentialFailure,
+  oauthCredentialFailureReason,
+} from "./credential-failure.js";
 import { effectiveAccountModels } from "./effective-models.js";
 
 // Admin OAuth-login orchestration (issue #38) — the implementation behind the
@@ -162,6 +168,14 @@ export interface OAuthAdminDeps {
     message: string,
     fields?: Record<string, unknown>,
   ) => void;
+  // Called after listStatus discovers and persists a durable credential failure.
+  // server.ts uses this to rebuild the live OAuth pool so admin status and routing
+  // agree immediately. Optional for unit tests and disabled deployments.
+  onCredentialFailure?: (
+    providerId: string,
+    account: string,
+    reason: string,
+  ) => Promise<void> | void;
 }
 
 // Split a credential into store fields. `meta` carries every key beyond the
@@ -287,9 +301,15 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     // The account's egress proxy (from the already-loaded settings) so the lazy
     // refresh tunnels through the SAME hop as execution — never the real IP.
     proxy?: ProxyConfig,
-  ): Promise<{ account: string; expiresAt: number | null; updatedAt: number; healthy: boolean }> {
+  ): Promise<{
+    account: string;
+    expiresAt: number | null;
+    updatedAt: number;
+    healthy: boolean;
+    credentialFailed: boolean;
+  }> {
     const provider = getOAuthProvider(providerId);
-    if (!provider) return { account, ...stored, healthy: true };
+    if (!provider) return { account, ...stored, healthy: true, credentialFailed: false };
     const tm = createTokenManager({
       oauth: { kind: "preset", providerId, account },
       tokenStore: deps.store,
@@ -299,10 +319,22 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       now,
     });
     let healthy = true;
+    let credentialFailed = false;
     try {
       await tm.getAuthHeader(); // refresh-if-expired + write back; no-op when fresh
-    } catch {
+    } catch (e) {
       healthy = false; // refresh-token / durable credential is dead → needs re-login
+      credentialFailed = isPermanentOAuthCredentialFailure(e);
+      if (credentialFailed) {
+        const reason = oauthCredentialFailureReason(e);
+        await markAccountCredentialFailure(deps.config, deps.encKey, providerId, account, {
+          at: now(),
+          reason,
+        });
+        await Promise.resolve(deps.onCredentialFailure?.(providerId, account, reason)).catch(
+          () => {},
+        );
+      }
     }
     const r = await deps.store.get(providerId, account);
     return {
@@ -310,6 +342,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       expiresAt: r?.expiresAt ?? stored.expiresAt,
       updatedAt: r?.updatedAt ?? stored.updatedAt,
       healthy,
+      credentialFailed,
     };
   }
 
@@ -328,16 +361,23 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
           // Same defaults as getAccountSchedule (priority 50, schedulable true) so a
           // never-tuned account always renders a concrete value.
           const sch = getAccountSettings(settings, r.providerId, r.account);
+          const hasCredentialFailure = typeof sch.credentialFailedAt === "number";
+          const fresh = hasCredentialFailure
+            ? {
+                account: r.account,
+                expiresAt: r.expiresAt,
+                updatedAt: r.updatedAt,
+                healthy: false,
+                credentialFailed: true,
+              }
+            : await ensureFresh(r.providerId, r.account, r, sch.proxy as ProxyConfig | undefined);
+          const { credentialFailed, ...freshView } = fresh;
           return {
             providerId: r.providerId,
-            ...(await ensureFresh(
-              r.providerId,
-              r.account,
-              r,
-              sch.proxy as ProxyConfig | undefined,
-            )),
+            ...freshView,
+            credentialFailed,
             priority: sch.priority ?? 50,
-            schedulable: sch.schedulable ?? true,
+            schedulable: credentialFailed ? false : (sch.schedulable ?? true),
             autoReset: sch.autoReset ?? false,
             fastMode: sch.fastMode ?? false,
             // Both folded from the SAME settings blob (zero extra network): the
@@ -417,6 +457,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       // not routable) — harmless, and overwritten by the next successful bind.
       await persistProxy(s.providerId, account, s.proxy);
       await persist(s.providerId, account, creds);
+      await clearAccountCredentialFailure(deps.config, deps.encKey, s.providerId, account);
       sessions.delete(sessionId);
     },
 
@@ -463,6 +504,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       // account is never bound without its proxy, so it can't later route directly.
       await persistProxy(s.providerId, account, s.proxy);
       await persist(s.providerId, account, creds);
+      await clearAccountCredentialFailure(deps.config, deps.encKey, s.providerId, account);
       sessions.delete(sessionId);
       return { status: "done" };
     },
@@ -570,7 +612,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       // (priority 50, schedulable true, autoReset false) even for a never-tuned account.
       return {
         priority: s.priority ?? 50,
-        schedulable: s.schedulable ?? true,
+        schedulable: typeof s.credentialFailedAt === "number" ? false : (s.schedulable ?? true),
         autoReset: s.autoReset ?? false,
         fastMode: s.fastMode ?? false,
       };
@@ -584,6 +626,16 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       autoReset,
       fastMode,
     }): Promise<void> {
+      if (schedulable === true) {
+        const current = getAccountSettings(
+          await loadAccountSettings(deps.config, deps.encKey),
+          providerId,
+          account,
+        );
+        if (typeof current.credentialFailedAt === "number") {
+          throw new Error("account needs reconnect before it can be scheduled");
+        }
+      }
       // Top-level merge (setAccountSettings) preserves curation/proxy. Only patch
       // the fields the caller supplied — an omitted field stays unchanged.
       const patch: {
@@ -591,9 +643,11 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
         schedulable?: boolean;
         autoReset?: boolean;
         fastMode?: boolean;
+        autoDisabledForCredentialFailure?: boolean;
       } = {};
       if (priority !== undefined) patch.priority = priority;
       if (schedulable !== undefined) patch.schedulable = schedulable;
+      if (schedulable !== undefined) patch.autoDisabledForCredentialFailure = false;
       if (autoReset !== undefined) patch.autoReset = autoReset;
       if (fastMode !== undefined) patch.fastMode = fastMode;
       await setAccountSettings(deps.config, deps.encKey, providerId, account, patch);

--- a/apps/gateway/src/oauth/credential-failure.ts
+++ b/apps/gateway/src/oauth/credential-failure.ts
@@ -1,0 +1,15 @@
+import { TokenRefreshError, UpstreamError } from "@helm/core";
+
+export function isPermanentOAuthCredentialFailure(err: unknown): boolean {
+  if (err instanceof TokenRefreshError) {
+    return err.httpStatus === 400 || err.httpStatus === 401 || err.httpStatus === 403;
+  }
+  if (err instanceof UpstreamError) {
+    return err.upstreamStatus === 401 || err.upstreamStatus === 403;
+  }
+  return false;
+}
+
+export function oauthCredentialFailureReason(err: unknown): string {
+  return err instanceof Error ? err.message : "oauth credential failed";
+}

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -101,6 +101,10 @@ export interface OAuthAdminStatus {
     expiresAt: number | null;
     updatedAt: number;
     healthy: boolean;
+    // Durable credential rejection. While true, reconnect is the only recovery path;
+    // priority/fast-mode edits may still be saved, but the schedulable toggle cannot
+    // put the account back into the routing pool.
+    credentialFailed?: boolean;
     // Effective pool scheduling (defaults applied: priority 50, schedulable true),
     // folded into the list so the providers page renders + inline-edits them without
     // an N+1 per-account GET. LOWER priority = served first; schedulable false parks
@@ -443,6 +447,10 @@ export interface AdminApiDeps {
     capturedAtMs: number,
     resetCredits?: number | null,
   ) => void;
+  // Durable OAuth credential failure. A refresh 400/401/403 or persistent upstream
+  // 401/403 means the account needs reconnecting, not just a short cooldown. The
+  // gateway persists that state and rebuilds the pool so admin status and routing agree.
+  onOAuthCredentialFailure?: (providerId: string, account: string, reason: string) => Promise<void>;
 }
 
 // Re-exported for route signatures.

--- a/apps/gateway/src/routes/admin/oauth-test-route.test.ts
+++ b/apps/gateway/src/routes/admin/oauth-test-route.test.ts
@@ -1,3 +1,4 @@
+import { TokenRefreshError } from "@helm/core";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../../app.js";
@@ -145,5 +146,44 @@ describe("POST /admin/api/oauth/:provider/test", () => {
     expect(err?.error).toMatch(/429/);
     // No spurious done event after a failure.
     expect(events.some((e) => e.type === "done")).toBe(false);
+  });
+
+  it("marks the account as credential-failed when the test refresh gets a permanent 401", async () => {
+    const tester: OAuthTester = {
+      test: vi.fn(
+        () =>
+          ({
+            [Symbol.asyncIterator]() {
+              return {
+                async next(): Promise<IteratorResult<TestStreamEvent>> {
+                  throw new TokenRefreshError(
+                    "oauth refresh failed (openai-codex, status 401)",
+                    401,
+                  );
+                },
+              };
+            },
+          }) satisfies AsyncIterable<TestStreamEvent>,
+      ),
+    };
+    const onOAuthCredentialFailure = vi.fn(async () => {});
+
+    const res = await app({ oauthTester: tester, onOAuthCredentialFailure }).request(
+      "/admin/api/oauth/openai-codex/test",
+      {
+        method: "POST",
+        headers: JSONH,
+        body: JSON.stringify({ account: "easymetaau@gmail.com", model: "gpt-5.4-mini" }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const events = sseEvents(await res.text());
+    expect(events.find((e) => e.type === "error")?.error).toContain("status 401");
+    expect(onOAuthCredentialFailure).toHaveBeenCalledWith(
+      "openai-codex",
+      "easymetaau@gmail.com",
+      "oauth refresh failed (openai-codex, status 401)",
+    );
   });
 });

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -410,31 +410,31 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", fiveHourReset, "replace");
   });
 
-  it("GET /oauth/quota does not newly park an unparked account from a PULL snapshot", async () => {
+  it("GET /oauth/quota parks an unparked account from a saturated account-wide PULL snapshot", async () => {
     const now = Date.now();
     const saturatedWeekly = {
-      key: "7d",
+      key: "secondary",
       usedPercent: 100,
       resetsAtMs: now + 8 * 60 * 60_000,
-      windowMinutes: null,
+      windowMinutes: 10_080,
     };
     const applyUsageLimit = vi.fn(async () => {});
     const oauthQuota = {
       get: vi.fn(async () => ({
-        providerId: "anthropic",
+        providerId: "openai-codex",
         account: "default",
         windows: [],
         capturedAt: now,
-        source: "anthropic",
+        source: "codex",
         usageLimitedUntilMs: null,
       })),
       getAll: vi.fn(async () => [
         {
-          providerId: "anthropic",
+          providerId: "openai-codex",
           account: "default",
           windows: [saturatedWeekly],
           capturedAt: now,
-          source: "anthropic",
+          source: "codex",
           usageLimitedUntilMs: null,
         },
       ]),
@@ -442,7 +442,69 @@ describe("admin OAuth routes — read endpoints", () => {
       delete: vi.fn(async () => {}),
     } as unknown as AdminApiDeps["oauthQuota"];
     const seam = fullSeam({
-      fetchAnthropicQuota: vi.fn(async () => [saturatedWeekly]) as never,
+      listStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [{ id: "openai-codex", name: "Codex", accounts: [{ account: "default" }] }],
+      })) as never,
+      fetchCodexQuota: vi.fn(async () => ({
+        windows: [saturatedWeekly],
+        resetCredits: 0,
+      })) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
+      "/admin/api/oauth/quota",
+    );
+
+    expect(res.status).toBe(200);
+    expect(applyUsageLimit).toHaveBeenCalledWith(
+      "openai-codex",
+      "default",
+      saturatedWeekly.resetsAtMs,
+      "extend",
+    );
+  });
+
+  it("GET /oauth/quota does not newly park an unparked account from a near-full PULL snapshot", async () => {
+    const now = Date.now();
+    const nearFullFiveHour = {
+      key: "primary",
+      usedPercent: 98,
+      resetsAtMs: now + 2 * 60 * 60_000,
+      windowMinutes: 300,
+    };
+    const applyUsageLimit = vi.fn(async () => {});
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "openai-codex",
+        account: "default",
+        windows: [],
+        capturedAt: now,
+        source: "codex",
+        usageLimitedUntilMs: null,
+      })),
+      getAll: vi.fn(async () => [
+        {
+          providerId: "openai-codex",
+          account: "default",
+          windows: [nearFullFiveHour],
+          capturedAt: now,
+          source: "codex",
+          usageLimitedUntilMs: null,
+        },
+      ]),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      listStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [{ id: "openai-codex", name: "Codex", accounts: [{ account: "default" }] }],
+      })) as never,
+      fetchCodexQuota: vi.fn(async () => ({
+        windows: [nearFullFiveHour],
+        resetCredits: 0,
+      })) as never,
     });
 
     const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -1,4 +1,4 @@
-import { windowsToActiveUsageRecovery } from "@helm/core";
+import { windowsToActiveUsageRecovery, windowsToUsageLimit } from "@helm/core";
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
@@ -7,6 +7,10 @@ import {
   canConsumeResetCredit,
   codexWeeklyUsedPercent,
 } from "../../oauth/auto-reset.js";
+import {
+  isPermanentOAuthCredentialFailure,
+  oauthCredentialFailureReason,
+} from "../../oauth/credential-failure.js";
 import type {
   AccountProxyInput,
   AdminApiDeps,
@@ -39,6 +43,18 @@ function errMessage(e: unknown): string {
 function isAbort(e: unknown, signal: AbortSignal): boolean {
   if (signal.aborted) return true;
   return e instanceof Error && (e.name === "AbortError" || /abort/i.test(e.message));
+}
+
+async function recordCredentialFailure(
+  deps: AdminApiDeps,
+  providerId: string,
+  account: string,
+  err: unknown,
+): Promise<void> {
+  if (!deps.onOAuthCredentialFailure || !isPermanentOAuthCredentialFailure(err)) return;
+  await deps
+    .onOAuthCredentialFailure(providerId, account, oauthCredentialFailureReason(err))
+    .catch(() => {});
 }
 
 function testUsageTokens(ev: {
@@ -211,7 +227,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     // Codex reset-credit counts from the live usage PULL. They are persisted with the
     // latest snapshot for quota-aware strategy scoring, then folded onto the response.
     const resetCredits = new Map<string, number | null>();
-    const syncActiveCooldownFromWindows = async (
+    const syncCooldownFromWindows = async (
       providerId: string,
       account: string,
       windows: Parameters<typeof windowsToActiveUsageRecovery>[0],
@@ -220,7 +236,13 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       const nowMs = Date.now();
       const current = await store.get(providerId, account).catch(() => null);
       const currentUntil = current?.usageLimitedUntilMs ?? null;
-      if (currentUntil === null || currentUntil <= nowMs) return;
+      if (currentUntil === null || currentUntil <= nowMs) {
+        const quotaUntil = windowsToUsageLimit(windows, nowMs);
+        if (quotaUntil !== null) {
+          await deps.applyUsageLimit(providerId, account, quotaUntil, "extend").catch(() => {});
+        }
+        return;
+      }
       const quotaUntil = windowsToActiveUsageRecovery(windows, nowMs);
       if (quotaUntil === null) {
         await deps.applyUsageLimit(providerId, account, null, "replace").catch(() => {});
@@ -240,14 +262,12 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         // PUSH still updates the same store on live traffic — the PULL covers
         // accounts that have served nothing yet (else they render "—" forever).
         // NB: this observability PULL refreshes the stored window snapshot (and, for
-        // Codex, the live reset-credit count) but does NOT newly auto-park an otherwise
-        // active account. If the account is ALREADY parked by live-traffic evidence
-        // (generic 429 fallback), a near-full quota window may EXTEND that cooldown to
-        // the likely reset time. That keeps "Reset usage" effective: clearing the
-        // cooldown then reloading this page does not immediately re-park the account
-        // before it can serve a single request. For an ALREADY parked account, a
-        // successful PULL is also trusted to clear or shorten stale cooldowns: clean
-        // windows mean the account is available again.
+        // Codex, the live reset-credit count) and parks an otherwise active account
+        // only when an account-wide window is truly saturated (100% with a future
+        // reset). Near-full windows (98-99%) are used only after a real 429 has already
+        // created a cooldown, where they refine the recovery time. That keeps healthy
+        // near-full accounts schedulable while preventing the UI from saying "limited"
+        // as the pool continues to route to the same exhausted account.
         const acctsOf = (id: string) => status.providers.find((x) => x.id === id)?.accounts ?? [];
         const tasks: Array<Promise<void>> = [];
         // Anthropic: windows only.
@@ -269,7 +289,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                     })
                     .catch(() => {});
                   deps.applyQuotaSnapshot?.("anthropic", a.account, windows, capturedAt);
-                  await syncActiveCooldownFromWindows("anthropic", a.account, windows);
+                  await syncCooldownFromWindows("anthropic", a.account, windows);
                 }
               })(),
             );
@@ -303,7 +323,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                     capturedAt,
                     result.resetCredits,
                   );
-                  await syncActiveCooldownFromWindows("openai-codex", a.account, result.windows);
+                  await syncCooldownFromWindows("openai-codex", a.account, result.windows);
                 }
               })(),
             );
@@ -764,6 +784,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       } catch (e) {
         // A client disconnect / modal close is not a provider failure — stay quiet.
         if (isAbort(e, signal)) return;
+        await recordCredentialFailure(deps, providerId, account, e);
         await sse.writeSSE({ data: JSON.stringify({ type: "error", error: errMessage(e) }) });
       }
     });

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -383,6 +383,30 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect(aliases).toEqual(["anthropic/claude-opus-4-6"]);
   });
 
+  it("excludes a credential-failed account from the synthesized pool until reconnect", async () => {
+    const { ctx, config } = oauthStores();
+    await seedAnthropic(ctx, "dead");
+    await setAccountSettings(config, ENC_KEY, "anthropic", "dead", {
+      enabledModels: ["claude-opus-4-6"],
+      credentialFailedAt: 12_345,
+      credentialFailureReason: "oauth refresh failed (anthropic, status 401)",
+      autoDisabledForCredentialFailure: true,
+      schedulable: false,
+    });
+
+    const { providers, poolClients } = await synthesizeOAuthProviders(
+      [],
+      ctx,
+      config,
+      "https://fallback/v1",
+      60_000,
+      noop,
+    );
+
+    expect(providers).toEqual([]);
+    expect(poolClients.size).toBe(0);
+  });
+
   it("returns empty when no OAuth runtime is wired (no enc key)", async () => {
     const { config } = oauthStores();
     const out = await synthesizeOAuthProviders([], undefined, config, "https://f/v1", 60_000, noop);

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -135,6 +135,7 @@ import {
   getAccountSettings,
   loadAccountSettings,
   loadGlobalOAuthSettings,
+  markAccountCredentialFailure,
 } from "./oauth/account-settings.js";
 import { createOAuthAdmin } from "./oauth/admin-oauth.js";
 import { weeklySaturated } from "./oauth/auto-reset.js";
@@ -484,6 +485,9 @@ export async function synthesizeOAuthProviders(
   // from the executor. This hook persists the cooldown the pool already applied in
   // memory, so rebuilds/restarts keep routing around that account.
   onAccountRateLimit?: (providerId: string, account: string, untilMs: number) => void,
+  // Pool-local credential failures are permanent until reconnect. Persist the
+  // auto-disabled state so admin status, rebuilds, and restarts agree with the live pool.
+  onAccountCredentialFailure?: (providerId: string, account: string, error: unknown) => void,
 ): Promise<SynthesizedOAuth> {
   if (!oauthCtx) return { providers: [], poolClients: new Map() };
   const declared = new Set<string>(
@@ -517,6 +521,14 @@ export async function synthesizeOAuthProviders(
     const unionModels = new Set<string>();
     for (const account of accounts) {
       const s = getAccountSettings(accountSettings, providerId, account);
+      if (typeof s.credentialFailedAt === "number") {
+        log("warn", "oauth.autoroute.skip", {
+          providerId,
+          account,
+          reason: "credential failed",
+        });
+        continue;
+      }
       if (s.schedulable === false) {
         log("info", "oauth.autoroute.parked", { providerId, account });
         continue;
@@ -646,6 +658,8 @@ export async function synthesizeOAuthProviders(
       },
       accountRateLimitCooldownMs: DEFAULT_429_COOLDOWN_MS,
       onAccountRateLimit: (account, untilMs) => onAccountRateLimit?.(providerId, account, untilMs),
+      onAccountCredentialFailure: (account, error) =>
+        onAccountCredentialFailure?.(providerId, account, error),
       shouldParkRateLimit: ({ model }) => shouldParkOAuthRateLimit(providerId, model),
       // Let the in-pool retry fail over across accounts on an IN-BAND pre-output failure
       // (200-then-`response.failed`/overloaded after only the preamble): wrap each member's
@@ -1049,6 +1063,19 @@ export async function buildServer(
   const oauthCtx: OAuthRuntimeCtx | undefined = oauthEncKey
     ? { store: store.oauthTokens, encKey: oauthEncKey }
     : undefined;
+  let rebuildOAuthPool: (() => Promise<{ applied: boolean }>) | undefined;
+  const rebuildAfterOAuthCredentialFailure = async (
+    providerId: string,
+    account: string,
+  ): Promise<void> => {
+    const rebuilt = await rebuildOAuthPool?.();
+    if (rebuilt?.applied === false) {
+      logger.log("warn", "oauth.credential_failure.rebuild_not_applied", {
+        provider_id: providerId,
+        account,
+      });
+    }
+  };
 
   // The admin OAuth-login surface, built ONCE here (was inlined into AdminApiDeps
   // below) so the execution-path quota hook can reuse its `consumeCodexResetCredit`
@@ -1059,6 +1086,7 @@ export async function buildServer(
         encKey: oauthCtx.encKey,
         config: store.config,
         log: (lvl, msg, fields) => logger.log(lvl, msg, fields),
+        onCredentialFailure: rebuildAfterOAuthCredentialFailure,
       })
     : undefined;
 
@@ -1365,6 +1393,32 @@ export async function buildServer(
       }),
     );
   };
+  const markOAuthCredentialFailure = async (
+    providerId: string,
+    account: string,
+    reason: string,
+  ): Promise<void> => {
+    if (!oauthCtx) return;
+    await markAccountCredentialFailure(store.config, oauthCtx.encKey, providerId, account, {
+      at: Date.now(),
+      reason,
+    });
+    await rebuildAfterOAuthCredentialFailure(providerId, account);
+  };
+  const markOAuthCredentialFailureLater = (
+    providerId: string,
+    account: string,
+    error: unknown,
+  ): void => {
+    const reason = error instanceof Error ? error.message : "oauth credential failed";
+    void markOAuthCredentialFailure(providerId, account, reason).catch((e) =>
+      logger.log("error", "oauth.credential_failure.persist_failed", {
+        provider_id: providerId,
+        account,
+        line: e instanceof Error ? e.message : String(e),
+      }),
+    );
+  };
   const applyQuotaSnapshot = (
     providerId: string,
     account: string,
@@ -1571,6 +1625,7 @@ export async function buildServer(
     userMessageQueue,
     await readQuotaSeeds(),
     parkAccountOnLimit,
+    markOAuthCredentialFailureLater,
   );
   const routableProviders: ProviderConfigShared[] = [
     ...config.providers,
@@ -1661,7 +1716,7 @@ export async function buildServer(
   // admin route can return an honest "saved but not applied" (503) on failure instead
   // of a false 204 (the persisted change still wins on the next rebuild / restart).
   let rebuildChain: Promise<void> = Promise.resolve();
-  const rebuildOAuthPool = async (): Promise<{ applied: boolean }> => {
+  rebuildOAuthPool = async (): Promise<{ applied: boolean }> => {
     let applied = true;
     rebuildChain = rebuildChain.then(async () => {
       try {
@@ -1676,6 +1731,7 @@ export async function buildServer(
           userMessageQueue, // SAME gate instance — queue state survives rebuilds
           await readQuotaSeeds(), // re-seed cooldowns + quota windows for strategy scoring
           parkAccountOnLimit,
+          markOAuthCredentialFailureLater,
         );
         oauthPoolClients = next.poolClients;
         oauthAliasSet = aliasSetOf(next);
@@ -2381,6 +2437,7 @@ export async function buildServer(
       // persist, no rebuild. Never touches schedulable.
       applyUsageLimit,
       applyQuotaSnapshot,
+      onOAuthCredentialFailure: markOAuthCredentialFailure,
     });
 
     // Admin SPA static hosting (/admin). MUST be mounted AFTER registerAdminApi so

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,21 @@
 
 ---
 
+## 2026-07-06 · 配额 PULL 的 100% 账号级窗口必须同步停车（OAuth provider pool / Admin providers，docs/04/11，原则 3/5/7）
+
+- **背景（Lukin）**：Providers 页可以从 Codex/Anthropic usage PULL 看到账号级窗口已经 100% 并显示“已限流”，但后端只把该 PULL 当观测快照；如果 live traffic 没先触发 429/header PUSH 写入 `usageLimitedUntilMs`，OAuth pool 仍会继续选择这个账号。
+- **调度决策**：`/admin/api/oauth/quota` 成功拉到账号级窗口 `usedPercent >= 100` 且有未来 reset 时，立即写入 `usageLimitedUntilMs` 并同步 live pool member；近满但未满（例如 98/99%）不主动停车，只在账号已经被真实 429 停车后用于修正恢复时间。
+- **恢复边界**：干净窗口会继续清理已存在 cooldown；scoped model 窗口（如 Anthropic `7d-*`）仍不扩大成全账号停车。Codex reset credit 消费成功后通过现有刷新路径恢复窗口并清理 cooldown。
+- **测试路径**：覆盖 `/oauth/quota` 从 Codex saturated PULL 新建 cooldown，以及 near-full PULL 不误停车；再跑 admin OAuth route focused tests、typecheck/lint/build。
+
+## 2026-07-05 · OAuth 凭证失效持久化为 needs reconnect（OAuth provider pool / Admin providers，docs/04/11，原则 3/5/7）
+
+- **背景（Lukin）**：Providers 页连通性测试可能返回 `oauth refresh failed (... status 401)`，但账号仍显示 connected，且未自动从调度中禁用；原实现只在当前 pool 进程内把 401/403 账号摘掉，admin status 与持久配置没有同步。
+- **状态决策**：refresh 400/401/403 或持久 upstream 401/403 视为 durable credential failure，而不是 429 usage cooldown。Helm 会写入 encrypted account settings：`credentialFailedAt` / `credentialFailureReason`，并把账号 `schedulable:false`；status 显示 unhealthy，重新合成 pool 时跳过该账号。
+- **恢复边界**：成功 reconnect 会清除 credential failure。若账号是 Helm 因凭证失败自动禁用，则恢复默认 schedulable；若原本就是用户手动 parked，则 reconnect 后仍保持手动 parked。
+- **操作边界**：Providers 页会显式返回 `credentialFailed` 并禁用 schedulable 开关；后端同样拒绝把 credential-failed 账号直接设回 schedulable。状态页若首次发现永久凭证失败，会触发 live pool rebuild，避免“后台已禁用但当前 pool 仍在用”。
+- **测试路径**：覆盖 core pool credential-failure hook、admin test 401 标记、account-settings mark/clear、synthesizeOAuthProviders 跳过 failed account、providers UI 失败后刷新；再跑 targeted Vitest、typecheck、lint、diff check。
+
 ## 2026-07-05 · 避免浪费策略纳入周额度与 Codex reset credits（OAuth provider pool / quota，docs/04/11，原则 3/5/7）
 
 - **背景（Lukin）**：`use_expiring` 不能只看单个快重置窗口；用户实际关心的是 5 小时额度、周额度，以及 Codex 账号还剩多少次 reset credit。周额度快到 reset 且还有大量剩余额度时应被优先使用；有 reset credits 的账号也具备额外恢复能力，应进入评分。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1284,9 +1284,13 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
   it("parks a credential-failed account and retries a sibling before surfacing to the alias breaker", async () => {
     const served: string[] = [];
     const selected: string[] = [];
+    const credentialFailures: Array<{ account: string; error: unknown }> = [];
     const pool = createOAuthPoolClient({
       members: [faultMember("bad", 10, served, REFRESH_401), faultMember("good", 50, served, null)],
       onSelect: (account) => selected.push(account),
+      onAccountCredentialFailure: (account, error) => {
+        credentialFailures.push({ account, error });
+      },
     });
 
     await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "good" });
@@ -1294,6 +1298,7 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
 
     expect(served).toEqual(["good", "good"]);
     expect(selected).toEqual(["bad", "good", "good"]);
+    expect(credentialFailures).toEqual([{ account: "bad", error: REFRESH_401 }]);
   });
 
   it("parks a persistent upstream auth failure and retries a sibling", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -158,6 +158,11 @@ export interface OAuthPoolDeps {
   // Optional model-aware guard for provider-specific scoped caps. Returning false
   // means "retry a sibling for this request, but do not globally park the account".
   shouldParkRateLimit?: (ctx: OAuthRateLimitParkContext) => boolean;
+  // Fires when a selected account's durable credential is rejected (refresh 400/401/403
+  // or persistent upstream 401/403). The pool already removes that account from this
+  // process; the hook lets the gateway persist the disabled state for admin status,
+  // rebuilds, and restarts.
+  onAccountCredentialFailure?: (account: string, error: unknown) => void;
   // Pre-output failover classifiers for the in-pool retry (issue: a native byte-relay
   // that 200s then fails IN-BAND after only a content-free preamble — e.g. a Responses
   // `response.created` before `response.failed`/server_is_overloaded). WITHOUT this, the
@@ -196,6 +201,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   const quotaFreshMs = deps.quotaFreshMs ?? 10 * 60 * 1000;
   const entries: PoolEntry[] = deps.members.map((member) => ({ member, lastUsedAt: 0 }));
   const stickySessions = new Map<string, { account: string; expiresAt: number }>();
+  const credentialFailureReported = new Set<string>();
   let selectionCounter = 0;
 
   // An account is eligible only when the operator has not parked it (`schedulable`)
@@ -681,9 +687,16 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     }
   }
 
-  function parkCredentialFailedAccount(entry: PoolEntry): void {
+  function parkCredentialFailedAccount(entry: PoolEntry, err: unknown): void {
     entry.member.schedulable = false;
     forgetStickyAccount(entry.member.account);
+    if (credentialFailureReported.has(entry.member.account)) return;
+    credentialFailureReported.add(entry.member.account);
+    try {
+      deps.onAccountCredentialFailure?.(entry.member.account, err);
+    } catch {
+      /* fail-open: persistence hooks must not break in-pool failover */
+    }
   }
 
   function shouldParkRateLimitedAccount(
@@ -747,7 +760,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         return result;
       } catch (err) {
         if (isCredentialAccountFailure(err)) {
-          parkCredentialFailedAccount(entry);
+          parkCredentialFailedAccount(entry, err);
           lastErr = err;
           continue;
         }
@@ -798,7 +811,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       } catch (err) {
         if (iterator) await iterator.return?.().catch(() => {});
         if (isCredentialAccountFailure(err)) {
-          parkCredentialFailedAccount(entry);
+          parkCredentialFailedAccount(entry, err);
           lastErr = err;
         } else if (isRateLimitAccountFailure(err)) {
           parkRateLimitedAccount(entry, err, model);


### PR DESCRIPTION
## Summary
- Persist durable OAuth credential failures and remove failed accounts from routing until reconnect
- Sync saturated account-wide quota snapshots into usage cooldowns so rate-limited accounts stop being selected
- Disable/guard schedulable recovery for credential-failed accounts and rebuild the live pool when status detects failure

## Verification
- pnpm vitest run apps/gateway/src/oauth/admin-oauth.test.ts apps/gateway/src/routes/admin/oauth.test.ts apps/admin/src/lib/api/oauth.test.ts apps/admin/src/routes/providers/providers.test.ts packages/core/src/provider/oauth/pool.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check
- pnpm build
- pnpm test