### PR TITLE
fix(admin): make tool-arg preview whitelist-free (works for every tool)

### DIFF
--- a/apps/admin/src/lib/conversation.test.ts
+++ b/apps/admin/src/lib/conversation.test.ts
@@ -570,60 +570,74 @@ describe('clarity pass', () => {
   });
 });
 
-// formatToolArgs powers the collapsed row's `Name(<detail>)` preview. It picks one
-// meaningful field per known tool, coerces a JSON-string arg to its object, truncates,
-// and NEVER throws (returns '' when there's nothing to show). Tool names are Claude
-// Code's capitalized names; matching is case-insensitive so lowercase OpenAI names work.
+// formatToolArgs powers the collapsed row's `Name(<detail>)` preview. It is GENERIC
+// and whitelist-free: it works off the ARGS shape (surface the most readable field,
+// else the first scalar, else compact JSON), so EVERY tool renders a detail — known,
+// unknown, lowercase, or a custom MCP tool. The tool NAME is not even consulted (a
+// couple of polish touches key on the FIELD, e.g. `command` chains, `content` sizes).
+// PURE + fail-soft: never throws, '' only when there's genuinely nothing to show.
 describe('formatToolArgs', () => {
-  it('shows the Bash command', () => {
+  it('surfaces a preferred field: command / file_path / query …', () => {
     expect(formatToolArgs('Bash', { command: 'ls -la', description: 'list' })).toBe('ls -la');
+    expect(formatToolArgs('Read', { file_path: '/a/b.ts' })).toBe('/a/b.ts');
+    expect(formatToolArgs('Edit', { file_path: '/a/c.ts', old_string: 'x' })).toBe('/a/c.ts');
+    expect(formatToolArgs('Grep', { pattern: 'foo', path: '/x' })).toBe('foo');
+    expect(formatToolArgs('WebSearch', { query: 'helm router' })).toBe('helm router');
   });
 
-  it('chains a multi-stage Bash command with →', () => {
+  it('works for an UNKNOWN / custom tool by picking its first readable field', () => {
+    // No whitelist — a never-seen tool still shows a detail, not a blind `Name()`.
+    expect(formatToolArgs('my_custom_mcp_tool', { url: 'https://x.dev', method: 'GET' })).toBe('https://x.dev');
+    expect(formatToolArgs('totally_unknown', { widget_id: 'w-42', extra: 'z' })).toBe('w-42');
+  });
+
+  it('does NOT depend on tool name (lowercase, weird casing all work)', () => {
+    expect(formatToolArgs('read', { file_path: '/HEARTBEAT.md' })).toBe('/HEARTBEAT.md');
+    expect(formatToolArgs('bash', { command: 'pwd' })).toBe('pwd');
+    expect(formatToolArgs('', { query: 'x' })).toBe('x'); // even an empty name
+  });
+
+  it('chains a multi-stage command on → (field-keyed polish, any tool)', () => {
     expect(formatToolArgs('Bash', { command: 'cd /tmp && ls; echo done' })).toBe('cd /tmp → ls → echo done');
   });
 
-  it('matches tool names case-insensitively (lowercase openai)', () => {
-    expect(formatToolArgs('bash', { command: 'pwd' })).toBe('pwd');
-  });
-
-  it('shows file_path for Read/Edit', () => {
-    expect(formatToolArgs('Read', { file_path: '/a/b.ts' })).toBe('/a/b.ts');
-    expect(formatToolArgs('Edit', { file_path: '/a/c.ts', old_string: 'x' })).toBe('/a/c.ts');
-  });
-
-  it('appends a size suffix for Write', () => {
+  it('appends a size hint when a file_path has sibling content (any tool)', () => {
     expect(formatToolArgs('Write', { file_path: '/tmp/x.md', content: 'y'.repeat(2100) })).toBe('/tmp/x.md · 2.1k');
-    expect(formatToolArgs('Write', { file_path: '/tmp/x.md', content: '' })).toBe('/tmp/x.md');
+    expect(formatToolArgs('Write', { file_path: '/tmp/x.md', content: '' })).toBe('/tmp/x.md'); // empty content, no hint
   });
 
-  it('shows the Agent description, not the long prompt', () => {
-    expect(formatToolArgs('Agent', { description: 'Map supply', prompt: 'x'.repeat(500), subagent_type: 'general' })).toBe('Map supply');
-  });
-
-  it('shows subject for TaskCreate and id→status for TaskUpdate', () => {
-    expect(formatToolArgs('TaskCreate', { subject: 'Widen window', description: 'z' })).toBe('Widen window');
-    expect(formatToolArgs('TaskUpdate', { taskId: '12', status: 'in_progress', owner: 'x' })).toBe('12 → in_progress');
+  it('prefers a human field over a long prompt only via ranking, never gating', () => {
+    // description outranks prompt in the preference list.
+    expect(formatToolArgs('Agent', { description: 'Map supply', prompt: 'x'.repeat(500) })).toBe('Map supply');
+    // but a tool with ONLY prompt still shows it (no whitelist to exclude it).
+    expect(formatToolArgs('SomeAgent', { prompt: 'do the thing' })).toBe('do the thing');
   });
 
   it('coerces a raw JSON-string arg to its object', () => {
     expect(formatToolArgs('Bash', JSON.stringify({ command: 'whoami' }))).toBe('whoami');
   });
 
-  it('falls back to truncated JSON for an unknown tool', () => {
-    expect(formatToolArgs('MysteryTool', { a: 1, b: 'two' })).toBe('{"a":1,"b":"two"}');
+  it('picks the first scalar when NO preferred key matches', () => {
+    expect(formatToolArgs('Weird', { taskId: '12', status: 'in_progress' })).toBe('12');
+    expect(formatToolArgs('Cron', { schedule: '*/5 * * * *', on: true })).toBe('*/5 * * * *');
   });
 
-  it('shows the cron expression for CronCreate', () => {
-    expect(formatToolArgs('CronCreate', { cron: '*/17 * * * *', prompt: 'x', recurring: true })).toBe('*/17 * * * *');
+  it('shows a numeric/boolean scalar field rather than nothing', () => {
+    expect(formatToolArgs('N', { count: 42 })).toBe('42');
+    expect(formatToolArgs('B', { enabled: true })).toBe('true');
+  });
+
+  it('compact JSON only when there is no scalar field at all', () => {
+    expect(formatToolArgs('Nested', { filter: { a: 1 }, items: [1, 2] })).toBe('{"filter":{"a":1},"items":[1,2]}');
+  });
+
+  it('shows a bare string / array arg directly', () => {
+    expect(formatToolArgs('Whatever', 'just text')).toBe('just text');
+    expect(formatToolArgs('Arr', [1, 2, 3])).toBe('[1,2,3]');
   });
 
   it('an empty-object arg shows nothing (bare Name()), not {}', () => {
     expect(formatToolArgs('TaskList', {})).toBe('');
-  });
-
-  it('shows a bare string arg', () => {
-    expect(formatToolArgs('Whatever', 'just text')).toBe('just text');
   });
 
   it('truncates long details with an ellipsis', () => {
@@ -632,9 +646,8 @@ describe('formatToolArgs', () => {
     expect(out.endsWith('…')).toBe(true);
   });
 
-  it('is fail-soft: null/garbage args → empty string', () => {
+  it('is fail-soft: null/undefined args → empty string', () => {
     expect(formatToolArgs('Bash', null)).toBe('');
     expect(formatToolArgs('Bash', undefined)).toBe('');
-    expect(formatToolArgs('Read', { file_path: 123 })).toBe(''); // wrong type → nothing to show
   });
 });

--- a/apps/admin/src/lib/conversation.ts
+++ b/apps/admin/src/lib/conversation.ts
@@ -650,13 +650,39 @@ function cleanTurns(turns: ConversationTurn[]): ConversationTurn[] {
 // ── collapsed tool-call arg preview ──────────────────────────────────────────
 // The collapsed conversation row shows a tool call as `Name(<detail>)`. Without a
 // detail it reads just `Bash()` — the reader sees THAT a tool ran but not WHAT it
-// did. This picks the single most meaningful field per known tool (Claude Code's
-// own capitalized tool names, verified against real captures) and truncates it, so
-// `Bash()` becomes `Bash(grep -rn "172.31…" scripts/)`. Full args still render in
-// the expanded view; this is only the one-line summary. Mirrors AgentCrew's
-// tool-format.ts. PURE + fail-soft: never throws, worst case returns ''.
+// did. This produces a one-line detail for ANY tool, with NO per-tool whitelist:
+// tool names change (casing, custom MCP tools, future built-ins), so gating on a
+// known list leaves everything else blind. Instead it works generically off the
+// ARGS shape — pick the most human-readable field present, else the first primitive,
+// else compact JSON. A tiny key-preference list only RANKS which field reads best;
+// it never GATES (an unranked object still shows its first field). Full args render
+// in the expanded view; this is only the summary. PURE + fail-soft: never throws.
 
 const MAX_TOOL_DETAIL_CHARS = 72;
+
+// Keys that tend to hold the single most meaningful value across tools/APIs, most
+// telling first. Purely a RANKING for which field to surface — not a gate: an object
+// with none of these still falls through to its first primitive field below.
+const PREFERRED_KEYS = [
+  'command',
+  'file_path',
+  'filePath',
+  'pattern', // before `path` — a search pattern is more telling than its dir
+  'query',
+  'url',
+  'path',
+  // short human labels before bulky bodies — `description` reads better than a 2KB `prompt`
+  'description',
+  'subject',
+  'summary',
+  'title',
+  'name',
+  'message',
+  'prompt',
+  'content',
+  'text',
+  'input',
+];
 
 function truncateDetail(s: string): string {
   const t = s.replace(/\s+/g, ' ').trim();
@@ -674,74 +700,64 @@ export function formatBashCommandChain(command: string): string {
   return stages.length <= 1 ? command.trim() : stages.join(' → ');
 }
 
+// Render one scalar arg value compactly (string/number/bool). Objects/arrays aren't
+// scalars — the caller handles those via JSON. Returns null for a non-scalar/empty.
+function scalarText(v: unknown): string | null {
+  if (typeof v === 'string') return v.trim() === '' ? null : v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return null;
+}
+
 /**
- * One-line detail for a tool call's args — the `<detail>` inside `Name(<detail>)`.
- * Returns '' when there's nothing worth showing (caller renders bare `Name()`).
- * `args` may be an object OR a raw JSON string (the fold keeps it verbatim), so we
- * coerce a JSON string back to its object first.
+ * One-line detail for a tool call's args — the `<detail>` inside `Name(<detail>)`,
+ * for ANY tool (no whitelist). Returns '' only when there's genuinely nothing to
+ * show. `args` may be an object OR a raw JSON string (the fold keeps it verbatim),
+ * so we coerce a JSON string back to its object first.
  */
-export function formatToolArgs(name: string, args: unknown): string {
+export function formatToolArgs(_name: string, args: unknown): string {
   try {
     const parsed = typeof args === 'string' ? coerceJson(args) : args;
+    // Non-object arg (a bare string / number / array) — show it directly.
     const a = asRecord(parsed);
-    // A tool arg that isn't an object (a bare string/number) is still worth showing.
     if (!a) {
-      const s = str(parsed);
-      return s ? truncateDetail(s) : '';
+      const s = scalarText(parsed);
+      if (s) return truncateDetail(s);
+      return parsed == null ? '' : truncateDetail(JSON.stringify(parsed));
     }
-    const key = name.toLowerCase();
-    const field = (k: string): string | null => str(a[k]);
+    if (Object.keys(a).length === 0) return ''; // empty object → bare `Name()`
 
-    if (key === 'bash') {
-      const cmd = field('command');
-      return cmd ? truncateDetail(formatBashCommandChain(cmd)) : '';
+    // Pick the field to surface: a preferred key first (ranking, not gate), else the
+    // first scalar field in insertion order. Works for every tool, known or not.
+    let picked: { key: string; value: string } | null = null;
+    for (const k of PREFERRED_KEYS) {
+      const v = scalarText(a[k]);
+      if (v !== null) {
+        picked = { key: k, value: v };
+        break;
+      }
     }
-    if (key === 'read' || key === 'edit' || key === 'multiedit') {
-      const fp = field('file_path');
-      return fp ? truncateDetail(fp) : '';
+    if (!picked) {
+      for (const [k, v] of Object.entries(a)) {
+        const s = scalarText(v);
+        if (s !== null) {
+          picked = { key: k, value: s };
+          break;
+        }
+      }
     }
-    if (key === 'write') {
-      const fp = field('file_path');
-      if (!fp) return '';
-      const content = a.content;
-      const chars = typeof content === 'string' ? content.length : 0;
-      const suffix = chars >= 1000 ? ` · ${Math.round(chars / 100) / 10}k` : chars > 0 ? ` · ${chars}` : '';
-      return `${truncateDetail(fp)}${suffix}`;
+    // No scalar field anywhere (all nested objects/arrays) → compact JSON of the whole.
+    if (!picked) return truncateDetail(JSON.stringify(parsed));
+
+    // Light polish, keyed on the FIELD (not the tool name), so it applies to any tool
+    // carrying that field: a shell command chains on `&&`/`;`; a written file with a
+    // sibling `content` string gets a size hint.
+    if (picked.key === 'command') return truncateDetail(formatBashCommandChain(picked.value));
+    if ((picked.key === 'file_path' || picked.key === 'filePath') && typeof a.content === 'string' && a.content.length > 0) {
+      const chars = a.content.length;
+      const suffix = chars >= 1000 ? ` · ${Math.round(chars / 100) / 10}k` : ` · ${chars}`;
+      return `${truncateDetail(picked.value)}${suffix}`;
     }
-    if (key === 'agent' || key === 'task') {
-      const d = field('description') ?? field('subject');
-      return d ? truncateDetail(d) : '';
-    }
-    if (key === 'taskcreate') {
-      const subj = field('subject');
-      return subj ? truncateDetail(subj) : '';
-    }
-    if (key === 'taskupdate') {
-      const id = field('taskId');
-      const status = field('status');
-      const parts = [id, status].filter(Boolean).join(' → ');
-      return parts ? truncateDetail(parts) : '';
-    }
-    if (key === 'sendmessage') {
-      const summary = field('summary');
-      return summary ? truncateDetail(summary) : '';
-    }
-    if (key === 'glob' || key === 'grep' || key === 'ls') {
-      const inline = field('pattern') ?? field('path');
-      return inline ? truncateDetail(inline) : '';
-    }
-    if (key === 'webfetch' || key === 'websearch') {
-      const inline = field('url') ?? field('query');
-      return inline ? truncateDetail(inline) : '';
-    }
-    if (key === 'croncreate') {
-      const cron = field('cron');
-      return cron ? truncateDetail(cron) : '';
-    }
-    // Unknown tool → truncated raw JSON of the whole object. An empty object shows
-    // nothing (bare `Name()`) rather than a noisy `Name({})`.
-    if (Object.keys(a).length === 0) return '';
-    return truncateDetail(JSON.stringify(parsed));
+    return truncateDetail(picked.value);
   } catch {
     return '';
   }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,14 +7,17 @@
 
 ---
 
-## 2026-07-06 · 折叠会话行显示工具调用参数预览（Admin requests / conversation view，docs/11，原则 1）
+## 2026-07-06 · 折叠会话行显示工具调用参数预览（whitelist-free，Admin requests / conversation view，docs/11，原则 1）
 
-- **背景（Lukin）**：请求详情「对话」视图里，assistant 的工具调用折叠行只显示 `Bash()` / `Read()` / `Write()` / `Agent()` 空括号——能看出调用了工具，却看不出具体参数。展开才有完整参数，折叠摘要是盲的。
-- **实现决策**：`conversation.ts` 新增纯函数 `formatToolArgs(name, args)`，只返回括号内的 detail 字符串（`Name(...)` 外壳由调用方拼）。按 Claude Code 大写工具名逐个挑最有意义的单字段（Bash→command 且 `&&`/`;`/`||` 顶层切分成 `→` 链；Read/Edit/MultiEdit→file_path；Write→file_path+内容字数；Agent/Task→description；TaskCreate→subject；TaskUpdate→taskId→status；SendMessage→summary；Glob/Grep/LS→pattern??path；WebFetch/WebSearch→url??query；CronCreate→cron），未知工具回退截断 JSON，空对象回退空串（裸 `Name()`）。参数可能是对象或原始 JSON 串，先 `coerceJson` 归一。72 字符硬截断带 `…`。参照 AgentCrew `channels/ux/tool-format.ts` 的模式。
-- **纯度/失败软化**：`formatToolArgs` 与整个 `conversation.ts` 一致——纯、永不抛，最坏返回 `''`；折叠行渲染不会因坏参数崩页。工具名大小写不敏感（同时覆盖 OpenAI 小写工具名）。
-- **UI 改动面**：仅 `ConversationTurn.svelte` 的 `preview` derived 一行（`Name()` → `Name(${formatToolArgs(...)})`）+ import。展开视图、badges、size hint、状态字形全部不动。无新 i18n key（参数是逐字数据，不可翻译）。
-- **ponytail 简化**：shell 切分是朴素顶层 split（非引号感知），引号内的 `&&`/`;` 会过度切分——展示预览里无害，真命令可见 mis-split 时再升级为引号感知（代码标 `// ponytail:`）。
-- **验证**：`conversation.test.ts` 加 `formatToolArgs` 用例（Bash 链/Read/Write 字数/Agent/对象-vs-JSON串/未知回退/空对象/截断/null 失败软化/CronCreate）；`Conversation.test.ts` 加一条真实 Anthropic `tool_use` 形状的渲染契约（折叠行断言含 `Bash(grep …)` 不含 `Bash()`），走完整 parser→组件→DOM。657 admin 单测绿、svelte-check 0 error。
+- **背景（Lukin）**：请求详情「对话」视图里，assistant 的工具调用折叠行只显示 `Bash()` / `Read()` / `Write()` / `Agent()` 空括号——能看出调用了工具，却看不出具体参数。
+- **关键修正（Lukin 明确指令「不要写白名单，所有工具都要」）**：第一版按大写工具名逐个 special-case（Bash/Read/Write/Agent/Task…），导致名单外的工具（如小写 `read()`、自定义 MCP 工具）仍然是盲括号——见截图 `read()`。**改为完全无白名单、纯按 args 形状泛化**：`formatToolArgs(_name, args)` **不看工具名**，从对象里挑最可读字段渲染，因此任何工具都有 detail。
+- **选字段算法**：① 非对象参数（字符串/数字/数组）直接展示；② 对象：先按 `PREFERRED_KEYS` 排序挑首个 scalar 字段（顺序是**排序不是门禁**：`command`→`file_path`→`pattern`(先于 path)→`query`→`url`→`path`→短标签 `description`/`subject`/`summary`/`title`/`name`/`message`（**先于**大块 `prompt`/`content`/`text`/`input`）），命名外的对象仍回落到**第一个 scalar 字段**；③ 全是嵌套对象/数组 → 整体 compact JSON；④ 空对象 → 空串（裸 `Name()`）。参数可能是对象或原始 JSON 串，先 `coerceJson` 归一。72 字符硬截断带 `…`。
+- **按字段（非按工具名）的轻润色**：`command` 字段做 `&&`/`;`/`||` 顶层切分成 `→` 链；`file_path`/`filePath` 且有 sibling `content` 字符串时追加字数 hint。因为 key 于字段，对任何携带该字段的工具都生效。
+- **纯度/失败软化**：与整个 `conversation.ts` 一致——纯、永不抛，最坏返回 `''`；折叠行渲染不会因坏参数崩页。工具名完全不参与（连大小写都无关）。
+- **UI 改动面**：仅 `ConversationTurn.svelte` 的 `preview` derived 一行 + import。展开视图、badges、size hint、状态字形全部不动。无新 i18n key。
+- **ponytail 简化**：shell 切分是朴素顶层 split（非引号感知），引号内 `&&`/`;` 会过度切分——展示预览里无害（代码标 `// ponytail:`）。
+- **验证**：`conversation.test.ts` 覆盖泛化契约（preferred 字段/未知工具/自定义 MCP 工具/大小写无关/命令链/字数 hint/排序不门禁/first-scalar 回退/数字布尔 scalar/纯嵌套→JSON/裸串数组/空对象/截断/null 软化）；`Conversation.test.ts` 保留真实 Anthropic `tool_use` 渲染契约。截图 `read(HEARTBEAT.md)`、`some_custom_mcp_tool(/v1/x)`、`weird_tool(3)` 均验证通过。svelte-check 0 error。
+- **发布轨迹**：第一版（带白名单）= v0.25.6（PR #471，已发布并部署 box）。本次无白名单重写为后续版本。
 
 ## 2026-07-06 · 配额 PULL 的 100% 账号级窗口必须同步停车（OAuth provider pool / Admin providers，docs/04/11，原则 3/5/7）
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

The first pass (#471, v0.25.6) special-cased a **fixed list** of capitalized Claude Code tool names (`Bash`/`Read`/`Write`/`Agent`/…). Any tool off that list still collapsed to a blind `Name()` — e.g. a lowercase `read()` from a non-Claude-Code client, or a custom MCP tool:

![blind read()](screenshot showed `read()` with empty parens)

## Fix

Rewrite `formatToolArgs` to be **generic and name-agnostic** — it never consults the tool name, it works off the **args shape**:

1. Non-object arg (string / number / array) → show it directly.
2. Object → surface the most readable field: a small `PREFERRED_KEYS` list only **ranks** which field reads best (`command` → `file_path` → `pattern` → `query` → `url` → `path` → short labels `description`/`subject`/`summary`/… before bulky `prompt`/`content`/`text`). This is a ranking, **not a gate** — an object with none of those falls through to its **first scalar field**.
3. All-nested (no scalar anywhere) → compact JSON of the whole object.
4. Empty object → `''` (bare `Name()`).

The two polish touches — Bash `&&`/`;` chaining and the file-size hint — now key on the **field** (`command`, `file_path`+`content`), not the tool name, so they apply to any tool carrying that field.

Result: **every** tool renders a detail.

```
read(HEARTBEAT.md)                 ← the reported bug
some_custom_mcp_tool(/v1/x)        ← unknown MCP tool
weird_tool(3)                      ← scalar-only args
Bash(ssh root@… "docker exec …")
Agent(Expert review: naming linguist)
Write(/tmp/plan.md · 2.7k)
TaskList()                         ← empty args stay bare
```

## Scope

Admin-UI only. No core / gateway / protocol / schema / config touched — fail-close gate empty. Patch bump `0.25.6 → 0.25.7`.

## Tests

`conversation.test.ts` rewritten to pin the whitelist-free contract: preferred-field surfacing, **unknown/custom tool** coverage, name-agnostic (lowercase/empty name), ranking-not-gating, first-scalar fallback, numeric/boolean scalars, nested→JSON, empty object, truncation, fail-soft. `Conversation.test.ts` render contract retained. svelte-check 0 errors, full admin suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)