### PR TITLE
feat(admin): Claude-Code terminal style for conversation tool executions

### DIFF
--- a/apps/admin/src/lib/components/Conversation.test.ts
+++ b/apps/admin/src/lib/components/Conversation.test.ts
@@ -123,6 +123,34 @@ describe('Conversation', () => {
     expect(tool).toHaveTextContent('ok'); // result status glyph label
   });
 
+  it('expanded tool block shows Name(args) inline + an output peek, full viewer only on click', async () => {
+    // Terminal-style: the block shows `Bash(…)` + the first lines of output inline; the
+    // heavy JsonViewer args/result only appear after clicking the tool header/affordance.
+    render(Conversation, {
+      request: {
+        messages: [
+          { role: 'assistant', content: [{ type: 'tool_use', id: 'c1', name: 'Bash', input: { command: 'ls -la' } }] },
+          { role: 'tool', content: [{ type: 'tool_result', tool_use_id: 'c1', content: 'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8' }] },
+        ],
+      },
+      response: null,
+    });
+    const row = screen.getByTestId('conversation-turn');
+    await fireEvent.click(within(row).getByTestId('conversation-row-toggle'));
+    const tool = screen.getByTestId('conversation-tool');
+    // header shows the tool name + inlined args
+    expect(tool).toHaveTextContent('Bash(ls -la)');
+    // inline peek shows the first lines; 8 lines total, 6 shown → "+2 lines"
+    expect(tool).toHaveTextContent('line1');
+    expect(tool).toHaveTextContent('+2');
+    // full JsonViewer NOT mounted until we ask for it
+    expect(within(tool).queryByText('Arguments')).toBeNull();
+    // click the expand affordance → full args + result appear
+    await fireEvent.click(within(tool).getByTestId('conversation-tool-expand'));
+    expect(within(tool).getByText('Arguments')).toBeInTheDocument();
+    expect(within(tool).getByText('Result')).toBeInTheDocument();
+  });
+
   it('collapsed tool-call row shows the key argument in the parens, not a blind Name()', () => {
     // Real Anthropic tool_use shape (the box capture): the collapsed summary must
     // read `Bash(grep …)` so the reader sees WHAT the tool did, not just that it ran.

--- a/apps/admin/src/lib/components/ConversationTurn.svelte
+++ b/apps/admin/src/lib/components/ConversationTurn.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { t } from '$lib/i18n';
-  import { formatToolArgs, type ConversationTurn, type TurnPart } from '$lib/conversation';
+  import { formatToolArgs, toolOutputPeek, type ConversationTurn, type TurnPart } from '$lib/conversation';
   import ImagePreview from './ImagePreview.svelte';
   import JsonViewer from './JsonViewer.svelte';
 
@@ -46,6 +46,20 @@
   function toggle() {
     open = !open;
   }
+
+  // Which tool parts have their FULL JsonViewer revealed (keyed by part index). The
+  // terminal-style block shows an inline peek by default; clicking "+N lines" or the
+  // header lifts the full args+result viewer. A Set keeps each tool row independent.
+  let toolOpen = $state<Set<number>>(new Set());
+  function toggleTool(i: number) {
+    const next = new Set(toolOpen);
+    if (next.has(i)) next.delete(i);
+    else next.add(i);
+    toolOpen = next;
+  }
+
+  // Expanded tool header gets a wider arg budget than the 72-char collapsed line.
+  const EXPANDED_ARG_CHARS = 160;
 
   // Per-role identity: dot color + spine tint + name color — straight from app tokens
   // (indigo brand = assistant, slate = user, amber = system, sky = tool).
@@ -192,60 +206,126 @@
     </button>
   </div>
 
-  <!-- Expanded body -->
+  <!-- Expanded body — flat, terminal-style transcript (no boxes; dot+indent spine). -->
   {#if open}
     <div class="pb-2 pl-4 text-sm text-ink-body">
       {#each turn.parts as part, i (partKey(i))}
         {#if part.kind === 'text'}
           <p class="my-1 whitespace-pre-wrap break-words leading-relaxed">{part.text}</p>
         {:else if part.kind === 'reasoning'}
-          <details data-testid="conversation-reasoning" class="my-1 rounded-lg border border-violet-200 bg-violet-50/60 p-2" open={showReasoning}>
-            <summary class="cursor-pointer text-xs font-medium text-violet-700">🧠 {$t('Reasoning')}</summary>
-            <p class="mt-1 whitespace-pre-wrap break-words text-xs text-ink-muted">{part.text}</p>
+          <details data-testid="conversation-reasoning" class="my-1" open={showReasoning}>
+            <summary class="cursor-pointer text-xs font-medium text-violet-600">🧠 {$t('Reasoning')}</summary>
+            <p class="mt-1 whitespace-pre-wrap break-words border-l-2 border-violet-200 pl-3 text-xs text-ink-muted">{part.text}</p>
           </details>
         {:else if part.kind === 'image'}
           <div class="my-1"><ImagePreview src={part.url} label={$t('Image')} variant="thumb" /></div>
         {:else if part.kind === 'tool_exchange'}
           {@const st = exchangeStatus(part)}
-          <details data-testid="conversation-tool" class="my-1 rounded-lg border border-sky-200 bg-sky-50/50">
-            <summary class="flex cursor-pointer items-center gap-2 px-2 py-1.5 text-xs">
-              <span>🔧</span>
-              <span class="font-mono font-medium text-ink-strong">{part.name || $t('tool call')}</span>
-              <span class="flex-1"></span>
-              <span class={`font-medium ${st.cls}`}>{st.glyph} {st.label}</span>
-            </summary>
-            <div class="space-y-2 border-t border-sky-100 p-2">
-              <div>
-                <div class="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-ink-faint">{$t('Arguments')}</div>
-                <JsonViewer value={part.args} />
+          {@const detail = formatToolArgs(part.name, part.args, EXPANDED_ARG_CHARS)}
+          {@const peek = part.hasResult ? toolOutputPeek(part.output) : { lines: [], moreLines: 0 }}
+          {@const full = toolOpen.has(i)}
+          <div data-testid="conversation-tool" class="my-1.5">
+            <!-- Header: ● Name(args)  <status> — click toggles the full args+result viewer. -->
+            <button
+              type="button"
+              data-testid="conversation-tool-toggle"
+              class="flex w-full items-baseline gap-2 text-left font-mono text-xs"
+              onclick={() => toggleTool(i)}
+              aria-expanded={full}
+            >
+              <span class="shrink-0 text-sky-500">●</span>
+              <span class="min-w-0 flex-1 break-words">
+                <span class="font-semibold text-ink-strong">{part.name || $t('tool call')}</span><span class="text-ink-muted">({detail})</span>
+              </span>
+              <span class={`shrink-0 font-medium ${st.cls}`}>{st.glyph} {st.label}</span>
+            </button>
+            <!-- Inline output peek (first lines) under a left rule — the CC glimpse. -->
+            {#if !full && peek.lines.length}
+              <div class="mt-0.5 border-l-2 border-border pl-3 font-mono text-[11px] leading-snug text-ink-muted">
+                {#each peek.lines as line, li (li)}
+                  <div class="truncate whitespace-pre">{line || ' '}</div>
+                {/each}
               </div>
-              {#if part.hasResult}
+            {/if}
+            <!-- Affordance: reveal the full args + result JsonViewer inline. -->
+            {#if !full}
+              <button
+                type="button"
+                data-testid="conversation-tool-expand"
+                class="mt-0.5 pl-3 font-mono text-[11px] text-link hover:underline"
+                onclick={() => toggleTool(i)}
+              >
+                {peek.moreLines > 0 ? `… +${peek.moreLines} ${$t('lines')} (${$t('click to expand')})` : `⋯ ${$t('view details')}`}
+              </button>
+            {:else}
+              <div class="mt-1 space-y-2 border-l-2 border-sky-200 pl-3">
                 <div>
-                  <div class="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-ink-faint">{$t('Result')}</div>
-                  <JsonViewer value={part.output} />
+                  <div class="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-ink-faint">{$t('Arguments')}</div>
+                  <JsonViewer value={part.args} />
                 </div>
-              {/if}
-            </div>
-          </details>
+                {#if part.hasResult}
+                  <div>
+                    <div class="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-ink-faint">{$t('Result')}</div>
+                    <JsonViewer value={part.output} />
+                  </div>
+                {/if}
+                <button
+                  type="button"
+                  data-testid="conversation-tool-collapse"
+                  class="font-mono text-[11px] text-link hover:underline"
+                  onclick={() => toggleTool(i)}>▾ {$t('Collapse')}</button
+                >
+              </div>
+            {/if}
+          </div>
         {:else if part.kind === 'tool_result'}
           <!-- orphan result (no matching call) — kept, never silently lost -->
-          <details data-testid="conversation-tool" class="my-1 rounded-lg border border-border bg-canvas p-2">
-            <summary class="flex cursor-pointer items-center gap-1.5 text-xs">
-              <span class="badge-neutral">{$t('tool result')}</span>
-              {#if part.name}<span class="font-mono font-medium text-ink-strong">{part.name}</span>{/if}
-            </summary>
-            <div class="mt-1.5"><JsonViewer value={part.output} /></div>
-          </details>
+          {@const peek = toolOutputPeek(part.output)}
+          {@const full = toolOpen.has(i)}
+          <div data-testid="conversation-tool" class="my-1.5 font-mono text-xs">
+            <button
+              type="button"
+              data-testid="conversation-tool-toggle"
+              class="flex w-full items-baseline gap-2 text-left"
+              onclick={() => toggleTool(i)}
+              aria-expanded={full}
+            >
+              <span class="shrink-0 text-ink-faint">●</span>
+              <span class="text-ink-muted">{$t('tool result')}{#if part.name} <span class="font-semibold text-ink-strong">{part.name}</span>{/if}</span>
+            </button>
+            {#if !full && peek.lines.length}
+              <div class="mt-0.5 border-l-2 border-border pl-3 text-[11px] leading-snug text-ink-muted">
+                {#each peek.lines as line, li (li)}<div class="truncate whitespace-pre">{line || ' '}</div>{/each}
+              </div>
+            {/if}
+            {#if full}
+              <div class="mt-1 border-l-2 border-border pl-3"><JsonViewer value={part.output} /></div>
+            {/if}
+          </div>
         {:else if part.kind === 'tool_call'}
           <!-- defensive: a bare call the pairing pass didn't convert -->
-          <details data-testid="conversation-tool" class="my-1 rounded-lg border border-sky-200 bg-sky-50/50 p-2">
-            <summary class="cursor-pointer text-xs"><span class="badge-rules">{$t('tool call')}</span> <span class="font-mono">{part.name}</span></summary>
-            <div class="mt-1.5"><JsonViewer value={part.args} /></div>
-          </details>
+          {@const full = toolOpen.has(i)}
+          <div data-testid="conversation-tool" class="my-1.5 font-mono text-xs">
+            <button
+              type="button"
+              data-testid="conversation-tool-toggle"
+              class="flex w-full items-baseline gap-2 text-left"
+              onclick={() => toggleTool(i)}
+              aria-expanded={full}
+            >
+              <span class="shrink-0 text-sky-500">●</span>
+              <span class="min-w-0 flex-1 break-words"
+                ><span class="font-semibold text-ink-strong">{part.name || $t('tool call')}</span><span class="text-ink-muted"
+                  >({formatToolArgs(part.name, part.args, EXPANDED_ARG_CHARS)})</span
+                ></span
+              >
+            </button>
+            {#if full}<div class="mt-1 border-l-2 border-sky-200 pl-3"><JsonViewer value={part.args} /></div>{/if}
+          </div>
         {:else}
-          <details data-testid="conversation-tool" class="my-1 rounded-lg border border-border bg-canvas p-2">
-            <summary class="cursor-pointer text-xs text-ink-muted">{$t('Other content')}</summary>
-            <div class="mt-1.5"><JsonViewer value={part.value} /></div>
+          <details data-testid="conversation-tool" class="my-1">
+            <summary class="cursor-pointer font-mono text-xs text-ink-muted">● {$t('Other content')}</summary>
+            <div class="mt-1 border-l-2 border-border pl-3"><JsonViewer value={part.value} /></div>
           </details>
         {/if}
       {/each}

--- a/apps/admin/src/lib/conversation.test.ts
+++ b/apps/admin/src/lib/conversation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { detectProtocol, extractConversation, formatToolArgs, type ConversationTurn } from './conversation.js';
+import { detectProtocol, extractConversation, formatToolArgs, toolOutputPeek, type ConversationTurn } from './conversation.js';
 
 // The normalizer folds a captured request body (one of four native wire protocols)
 // plus its response (parsed JSON, or a raw SSE string for streamed calls) into an
@@ -649,5 +649,60 @@ describe('formatToolArgs', () => {
   it('is fail-soft: null/undefined args → empty string', () => {
     expect(formatToolArgs('Bash', null)).toBe('');
     expect(formatToolArgs('Bash', undefined)).toBe('');
+  });
+});
+
+// toolOutputPeek gives the CC-style inline glimpse of a tool result: the first N
+// lines of text + how many more are hidden. Coerces object/array output to pretty
+// JSON, trims trailing blanks, never throws.
+describe('toolOutputPeek', () => {
+  it('returns all lines and moreLines:0 when at/under the cap', () => {
+    expect(toolOutputPeek('a\nb\nc')).toEqual({ lines: ['a', 'b', 'c'], moreLines: 0 });
+  });
+
+  it('caps to maxLines and reports the remainder', () => {
+    const out = ['l1', 'l2', 'l3', 'l4', 'l5', 'l6', 'l7', 'l8'].join('\n');
+    expect(toolOutputPeek(out, 6)).toEqual({ lines: ['l1', 'l2', 'l3', 'l4', 'l5', 'l6'], moreLines: 2 });
+  });
+
+  it('defaults to 6 lines', () => {
+    const out = Array.from({ length: 10 }, (_, i) => `x${i}`).join('\n');
+    const peek = toolOutputPeek(out);
+    expect(peek.lines).toHaveLength(6);
+    expect(peek.moreLines).toBe(4);
+  });
+
+  it('pretty-prints an object result and counts its lines', () => {
+    const peek = toolOutputPeek({ ok: true, n: 2 });
+    expect(peek.lines[0]).toBe('{');
+    expect(peek.lines.join('\n')).toContain('"ok": true');
+    expect(peek.moreLines).toBe(0); // 4-line pretty JSON < 6
+  });
+
+  it('coerces a JSON-string result to pretty JSON', () => {
+    const peek = toolOutputPeek('{"a":1,"b":2}');
+    expect(peek.lines).toEqual(['{', '  "a": 1,', '  "b": 2', '}']);
+  });
+
+  it('trims trailing blank lines (no phantom +N)', () => {
+    expect(toolOutputPeek('one\ntwo\n\n\n')).toEqual({ lines: ['one', 'two'], moreLines: 0 });
+  });
+
+  it('empty / nullish output → nothing to peek', () => {
+    expect(toolOutputPeek('')).toEqual({ lines: [], moreLines: 0 });
+    expect(toolOutputPeek(null)).toEqual({ lines: [], moreLines: 0 });
+    expect(toolOutputPeek(undefined)).toEqual({ lines: [], moreLines: 0 });
+  });
+});
+
+// The expanded tool header can afford a wider arg preview than the collapsed row.
+describe('formatToolArgs maxChars', () => {
+  it('honors a wider cap when passed', () => {
+    const long = 'echo ' + 'x'.repeat(200);
+    const wide = formatToolArgs('Bash', { command: long }, 160);
+    const narrow = formatToolArgs('Bash', { command: long });
+    expect(wide.length).toBeLessThanOrEqual(160);
+    expect(wide.length).toBeGreaterThan(narrow.length); // wider cap shows more
+    expect(narrow.length).toBeLessThanOrEqual(72);
   });
 });

--- a/apps/admin/src/lib/conversation.ts
+++ b/apps/admin/src/lib/conversation.ts
@@ -684,9 +684,9 @@ const PREFERRED_KEYS = [
   'input',
 ];
 
-function truncateDetail(s: string): string {
+function truncateDetail(s: string, max = MAX_TOOL_DETAIL_CHARS): string {
   const t = s.replace(/\s+/g, ' ').trim();
-  return t.length <= MAX_TOOL_DETAIL_CHARS ? t : `${t.slice(0, MAX_TOOL_DETAIL_CHARS - 1)}…`;
+  return t.length <= max ? t : `${t.slice(0, max - 1)}…`;
 }
 
 // ponytail: naive top-level split (not quote-aware) — a `&&`/`;`/`||` inside a quoted
@@ -714,15 +714,15 @@ function scalarText(v: unknown): string | null {
  * show. `args` may be an object OR a raw JSON string (the fold keeps it verbatim),
  * so we coerce a JSON string back to its object first.
  */
-export function formatToolArgs(_name: string, args: unknown): string {
+export function formatToolArgs(_name: string, args: unknown, maxChars = MAX_TOOL_DETAIL_CHARS): string {
   try {
     const parsed = typeof args === 'string' ? coerceJson(args) : args;
     // Non-object arg (a bare string / number / array) — show it directly.
     const a = asRecord(parsed);
     if (!a) {
       const s = scalarText(parsed);
-      if (s) return truncateDetail(s);
-      return parsed == null ? '' : truncateDetail(JSON.stringify(parsed));
+      if (s) return truncateDetail(s, maxChars);
+      return parsed == null ? '' : truncateDetail(JSON.stringify(parsed), maxChars);
     }
     if (Object.keys(a).length === 0) return ''; // empty object → bare `Name()`
 
@@ -746,19 +746,56 @@ export function formatToolArgs(_name: string, args: unknown): string {
       }
     }
     // No scalar field anywhere (all nested objects/arrays) → compact JSON of the whole.
-    if (!picked) return truncateDetail(JSON.stringify(parsed));
+    if (!picked) return truncateDetail(JSON.stringify(parsed), maxChars);
 
     // Light polish, keyed on the FIELD (not the tool name), so it applies to any tool
     // carrying that field: a shell command chains on `&&`/`;`; a written file with a
     // sibling `content` string gets a size hint.
-    if (picked.key === 'command') return truncateDetail(formatBashCommandChain(picked.value));
+    if (picked.key === 'command') return truncateDetail(formatBashCommandChain(picked.value), maxChars);
     if ((picked.key === 'file_path' || picked.key === 'filePath') && typeof a.content === 'string' && a.content.length > 0) {
       const chars = a.content.length;
       const suffix = chars >= 1000 ? ` · ${Math.round(chars / 100) / 10}k` : ` · ${chars}`;
-      return `${truncateDetail(picked.value)}${suffix}`;
+      return `${truncateDetail(picked.value, maxChars - suffix.length)}${suffix}`;
     }
-    return truncateDetail(picked.value);
+    return truncateDetail(picked.value, maxChars);
   } catch {
     return '';
+  }
+}
+
+// ── tool output peek (Claude-Code-style inline glimpse) ──────────────────────
+// The expanded tool row shows the FIRST few lines of a result inline (under a `│`
+// rule) plus a `+N lines` affordance — a glimpse before the full JsonViewer. Coerce
+// any output shape to text (string as-is; object/array → pretty JSON, matching
+// JsonViewer's posture), split on newlines, trim trailing blanks, cap to maxLines.
+// PURE + fail-soft: never throws → { lines: [], moreLines: 0 }.
+function outputToText(output: unknown): string {
+  if (typeof output === 'string') {
+    const parsed = coerceJson(output);
+    // A JSON string → pretty-print (like JsonViewer); a plain string → verbatim.
+    return parsed !== output && parsed != null && typeof parsed === 'object' ? safeStringify(parsed) : output;
+  }
+  if (output == null) return '';
+  return safeStringify(output);
+}
+function safeStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v, null, 2) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export function toolOutputPeek(output: unknown, maxLines = 6): { lines: string[]; moreLines: number } {
+  try {
+    const text = outputToText(output);
+    if (text.trim() === '') return { lines: [], moreLines: 0 };
+    // drop trailing blank lines so they don't inflate the +N count
+    const all = text.split('\n');
+    while (all.length && all[all.length - 1].trim() === '') all.pop();
+    const lines = all.slice(0, maxLines);
+    return { lines, moreLines: Math.max(0, all.length - lines.length) };
+  } catch {
+    return { lines: [], moreLines: 0 };
   }
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -928,6 +928,9 @@
   "First reply": "First reply",
   "Arguments": "Arguments",
   "no result": "no result",
+  "lines": "lines",
+  "click to expand": "click to expand",
+  "view details": "view details",
   "empty": "empty",
   "{count} system prompt hidden — show": "{count} system prompt hidden — show"
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -928,6 +928,9 @@
   "First reply": "最初の返信",
   "Arguments": "引数",
   "no result": "結果なし",
+  "lines": "行",
+  "click to expand": "クリックで展開",
+  "view details": "詳細を表示",
   "empty": "空",
   "{count} system prompt hidden — show": "{count} 件のシステムプロンプトを非表示 — 表示"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -928,6 +928,9 @@
   "First reply": "첫 응답",
   "Arguments": "인수",
   "no result": "결과 없음",
+  "lines": "줄",
+  "click to expand": "클릭하여 펼치기",
+  "view details": "상세 보기",
   "empty": "비어 있음",
   "{count} system prompt hidden — show": "시스템 프롬프트 {count}개 숨김 — 표시"
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -928,6 +928,9 @@
   "First reply": "首个回复",
   "Arguments": "参数",
   "no result": "无结果",
+  "lines": "行",
+  "click to expand": "点击展开",
+  "view details": "查看详情",
   "empty": "空",
   "{count} system prompt hidden — show": "已隐藏 {count} 条系统提示 —— 点击显示"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -928,6 +928,9 @@
   "First reply": "首個回覆",
   "Arguments": "參數",
   "no result": "無結果",
+  "lines": "行",
+  "click to expand": "點擊展開",
+  "view details": "查看詳情",
   "empty": "空",
   "{count} system prompt hidden — show": "已隱藏 {count} 條系統提示 —— 點擊顯示"
 }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,17 @@
 
 ---
 
+## 2026-07-06 · 对话视图工具执行改为 Claude-Code 终端风格（inline peek，Admin requests / conversation view，docs/11，原则 1）
+
+- **背景（Lukin）**：原展开态工具块是重边框卡片（🔧 Tool ✓ ok + 两个 bordered JsonViewer 面板 Arguments/Result），boxy、不看展开就不知道工具做了什么。Lukin 给了 Claude Code 终端 transcript 截图，要求参考它做得更清晰。
+- **确认方向**：展开态 tool block 采用 CC 的 inline peek；**整个 timeline** 转成 borderless dot+indent 终端观感。折叠行 arg 预览（v0.25.7）保持不动。
+- **新纯函数**：`conversation.ts` 加 `toolOutputPeek(output, maxLines=6) → {lines, moreLines}`：output 归一成文本（字符串原样；JSON 串/对象/数组 → pretty JSON，与 JsonViewer 一致），split `\n`，剔尾部空行（防虚增 +N），截前 N 行报剩余数；纯、永不抛。`formatToolArgs` 加可选 `maxChars`（默认 72；展开态 header 传 160，`truncateDetail` 也接受 max）。
+- **组件重构**（`ConversationTurn.svelte` 为主）：展开体去掉 `rounded-lg border bg-*-50` 卡片；每个 turn 用 role dot（`●`）+ 单条淡 spine。tool_exchange = 行1 `●` + mono 粗体 `Name`(`formatToolArgs(...,160)` args) + 复用 `exchangeStatus` 状态字形；行下 `toolOutputPeek` 前几行挂在 `│` 左规则里；footer `… +N lines (click to expand)`（无更多行时 `⋯ view details`）——点开才 inline 挂**完整** JsonViewer（args+result，逃生舱不丢）+ `▾ Collapse`。reasoning 去紫盒改 `🧠` + muted 左规则文本。per-tool 展开用 `toolOpen: Set<number>`，各行独立。
+- **testid 保留**（e2e 硬断言，见 [[e2e-admin-specs-live-in-gateway]]）：`conversation-turn/-tool/-reasoning/-row-toggle/-source-toggle/-source`、`data-open`、`data-turn-role` 全留；新增 `conversation-tool-toggle/-expand/-collapse`。只改样式+内部结构。
+- **i18n**：新增 3 key `lines`/`click to expand`/`view details`，5 语手填（意译：点击展开/查看详情等），插在 `no result` 后（[[i18n-sync-incremental-empty-only]] / [[admin-test-i18n-gotchas]]）。
+- **ponytail**：无新库无新组件，restyle + 1 纯 helper；peek 是 `split('\n').slice()`，非语法高亮（标 `// ponytail:`）；peek 行数 6 硬编码（配置化是投机，跳过）。
+- **验证**：`toolOutputPeek`/`maxChars` 单测 + `Conversation.test.ts` 渲染契约（header `Bash(ls -la)` + peek `line1` + `+2` + 点开才出 Arguments/Result）；668 admin 单测绿、svelte-check 0 error。**真实数据可视验证**：临时 harness route 加载 box trace `2fb017ae` 全 743 turn 真 payload，Playwright 截图确认 `● Bash(ssh…) ✓ ok` + SQL 结果行 inline peek + `… +21 lines (click to expand)`，点开出完整 Tree/Formatted/Raw JsonViewer——与 CC 截图一致；harness 用后即删。**在 git worktree `worktree-cc-terminal-conversation` 开发（Lukin 要求不在 main 搞）。**
+
 ## 2026-07-06 · 折叠会话行显示工具调用参数预览（whitelist-free，Admin requests / conversation view，docs/11，原则 1）
 
 - **背景（Lukin）**：请求详情「对话」视图里，assistant 的工具调用折叠行只显示 `Bash()` / `Read()` / `Write()` / `Agent()` 空括号——能看出调用了工具，却看不出具体参数。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.7",
+  "version": "0.25.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

The expanded conversation view rendered each tool call as a heavy bordered card (`🔧 Tool  ✓ ok` + two boxed *Arguments* / *Result* `JsonViewer` panels). It's boxy and chrome-heavy — you can't see what a tool *did* without opening a JSON tree.

## Fix

Rework it to the **Claude Code terminal transcript** style (per the reference screenshot):

- Flat **dot + indent** timeline, no boxes. Each turn led by a role dot (`●`).
- A tool row reads `● Name(args) ✓ ok` — args inlined on the header — then an inline **output peek**: the first ~6 lines of the result under a left rule `│`, then `… +N lines (click to expand)`.
- Clicking the affordance (or header) lifts the **full** args + result `JsonViewer` inline — the escape hatch is preserved — with a `▾ Collapse`.
- Reasoning drops its violet box for a muted left-rule.

### Before → after (real box capture, trace `2fb017ae…`)

```
before:  ▸ 🔧 Bash                                    ✓ ok
           [ Arguments ▸ ]  [ Result ▸ ]   (boxed JsonViewers)

after:   ● Bash(ssh root@172.31.59.54 "docker exec -i supabase-db psql …")   ✓ ok
           │ id | bigint
           │ build_id | text
           │ given_name | text
           … +21 lines (click to expand)
```

## Implementation

- New pure `toolOutputPeek(output, maxLines=6)` in `conversation.ts` — coerce any output shape to text, trim trailing blanks, cap, report remainder; never throws.
- Optional `maxChars` on `formatToolArgs` (expanded header gets 160 vs the collapsed 72).
- Redesign lives in `ConversationTurn.svelte` (styling + internal structure). **All existing testids preserved** (admin e2e hard-asserts them); adds `conversation-tool-toggle` / `-expand` / `-collapse`.
- i18n: +3 keys (`lines`, `click to expand`, `view details`) hand-filled across all 5 locales.

## Scope

Admin-UI only — no core/gateway/protocol/schema/config touched (fail-close gate empty). Patch bump `0.25.7 → 0.25.8`.

## Verification

- 668 admin unit tests green; svelte-check 0 errors.
- New `toolOutputPeek` + `formatToolArgs maxChars` unit cases; `Conversation.test.ts` render contract (header `Bash(ls -la)` + peek `line1` + `+2`, full JsonViewer only after clicking).
- **Visual:** rendered a real 743-turn box capture through a throwaway harness in a browser — tool rows show `● Name(args)` + inline result peek + `… +N lines`, and expanding reveals the full Tree/Formatted/Raw viewer. Matches the reference. Harness removed before commit.

Developed in a dedicated git worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)