### PR TITLE
feat(admin): auto-expand tool-only conversation turns (drop the extra click)

### DIFF
--- a/apps/admin/src/lib/components/Conversation.test.ts
+++ b/apps/admin/src/lib/components/Conversation.test.ts
@@ -104,7 +104,7 @@ describe('Conversation', () => {
     expect(rows[0].getAttribute('data-turn-role')).toBe('assistant');
   });
 
-  it('a tool call and its result render as ONE merged tool block on expand', async () => {
+  it('a tool call and its result render as ONE merged tool block, open by default (no extra click)', () => {
     render(Conversation, {
       request: {
         messages: [
@@ -117,15 +117,16 @@ describe('Conversation', () => {
     // one row (the tool result turn was folded away)
     const rows = screen.getAllByTestId('conversation-turn');
     expect(rows).toHaveLength(1);
-    await fireEvent.click(within(rows[0]).getByTestId('conversation-row-toggle'));
+    // tool-only turn is expanded by default — the block is there without any click
+    expect(rows[0].getAttribute('data-open')).toBe('true');
     const tool = screen.getByTestId('conversation-tool');
     expect(tool).toHaveTextContent('get_weather');
     expect(tool).toHaveTextContent('ok'); // result status glyph label
   });
 
-  it('expanded tool block shows Name(args) inline + an output peek, full viewer only on click', async () => {
-    // Terminal-style: the block shows `Bash(…)` + the first lines of output inline; the
-    // heavy JsonViewer args/result only appear after clicking the tool header/affordance.
+  it('tool-only turn shows Name(args) + output peek inline WITHOUT a click; full viewer on click', async () => {
+    // The whole friction fix: a turn that is just a tool call opens by default, so the
+    // header + inline peek are visible immediately. Only the full JsonViewer is gated.
     render(Conversation, {
       request: {
         messages: [
@@ -136,24 +137,24 @@ describe('Conversation', () => {
       response: null,
     });
     const row = screen.getByTestId('conversation-turn');
-    await fireEvent.click(within(row).getByTestId('conversation-row-toggle'));
+    // NO click — the tool block, header, and peek are present on first render
+    expect(row.getAttribute('data-open')).toBe('true');
     const tool = screen.getByTestId('conversation-tool');
-    // header shows the tool name + inlined args
     expect(tool).toHaveTextContent('Bash(ls -la)');
     // inline peek shows the first lines; 8 lines total, 6 shown → "+2 lines"
     expect(tool).toHaveTextContent('line1');
     expect(tool).toHaveTextContent('+2');
     // full JsonViewer NOT mounted until we ask for it
     expect(within(tool).queryByText('Arguments')).toBeNull();
-    // click the expand affordance → full args + result appear
+    // ONE click on the expand affordance → full args + result appear
     await fireEvent.click(within(tool).getByTestId('conversation-tool-expand'));
     expect(within(tool).getByText('Arguments')).toBeInTheDocument();
     expect(within(tool).getByText('Result')).toBeInTheDocument();
   });
 
-  it('collapsed tool-call row shows the key argument in the parens, not a blind Name()', () => {
-    // Real Anthropic tool_use shape (the box capture): the collapsed summary must
-    // read `Bash(grep …)` so the reader sees WHAT the tool did, not just that it ran.
+  it('tool-only turn shows the key argument in the parens, not a blind Name()', () => {
+    // Real Anthropic tool_use shape (the box capture): the header must read `Bash(grep …)`
+    // so the reader sees WHAT the tool did, not just that it ran.
     render(Conversation, {
       request: {
         messages: [
@@ -166,10 +167,31 @@ describe('Conversation', () => {
       response: null,
     });
     const row = screen.getByTestId('conversation-turn');
-    // still collapsed — the preview line carries the arg detail
-    expect(row.getAttribute('data-open')).toBe('false');
+    // tool-only → open by default; the header carries the arg detail with no click
+    expect(row.getAttribute('data-open')).toBe('true');
     expect(row.textContent).toContain('Bash(grep -rn foo scripts/)');
     expect(row.textContent).not.toContain('Bash()');
+  });
+
+  it('a MIXED turn (text + tool) still starts collapsed', () => {
+    // Only pure tool turns auto-expand; a turn with prose stays one-line to keep long
+    // traces scannable. Here the assistant narrates AND calls a tool in one turn.
+    render(Conversation, {
+      request: {
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Let me check the weather.' },
+              { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'weather' } },
+            ],
+          },
+        ],
+      },
+      response: null,
+    });
+    const row = screen.getByTestId('conversation-turn');
+    expect(row.getAttribute('data-open')).toBe('false');
   });
 
   it('image renders ImagePreview (not base64) once expanded', async () => {

--- a/apps/admin/src/lib/components/ConversationTurn.svelte
+++ b/apps/admin/src/lib/components/ConversationTurn.svelte
@@ -32,7 +32,14 @@
     expandCommand?: { open: boolean; nonce: number } | null;
   } = $props();
 
-  let open = $state(false);
+  // A turn made entirely of tool calls (no prose/image/reasoning) is opened by default:
+  // its whole signal IS the tool exchange, so the extra "expand the row first" click is
+  // pure friction — the inline peek should just be there (Claude-Code style). Mixed and
+  // text/reasoning turns still start collapsed to keep a long trace scannable. Computed
+  // once at mount (turns never mutate in place), so read `turn` inside the initializer.
+  const isToolOnly = (t: ConversationTurn): boolean =>
+    t.parts.length > 0 && t.parts.every((p) => p.kind === 'tool_exchange' || p.kind === 'tool_result' || p.kind === 'tool_call');
+  let open = $state(isToolOnly(turn));
   let sourceOpen = $state(false);
   // Apply a global command whenever its nonce changes (tracked by value, so identical
   // consecutive commands still re-apply). A later per-row toggle just flips `open`.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-06 · 纯工具 turn 默认展开，去掉多一次点击（Admin conversation view，docs/11，原则 1）
+
+- **背景（Lukin）**：终端风格上线后，看一个工具的 output peek 要点**两次**——先点行展开 turn（row-toggle），再点 `… +N lines` 出完整 JSON。第一层折叠对「整条 turn 就是一个工具调用」的行是纯多余摩擦。Lukin 要求参考 Claude Code：peek 直接可见，不用先展开。
+- **确认方向（AskUserQuestion）**：**纯工具 turn 默认展开**（peek 直接显示），文本/混合 turn 仍默认折叠（保持长 trace 可扫）。
+- **实现**：`ConversationTurn.svelte` 加 `isToolOnly(turn)`（parts 非空且全为 `tool_exchange`/`tool_result`/`tool_call`）；`let open = $state(isToolOnly(turn))`。用**具名函数**在 initializer 里读 `turn`（避免 Svelte `state_referenced_locally` 警告——turn 不会原地变，mount 时算一次即可）。展开态 header/peek 逻辑不变；点 `+N lines` 仍出完整 JsonViewer（第二层保留）。`expandCommand`（全部展开/收起）照常覆盖。
+- **测试更新**：3 个旧断言「tool turn 默认 collapsed / 需点击」翻转为默认 `data-open==='true'` + peek 无点击可见；新增「混合（text+tool）turn 仍 collapsed」用例。670 admin 单测绿、`ConversationTurn.svelte` svelte-check 0 warning。
+- **可视验证坑（记）**：本 session 的 worktree 里有自动清理会**反复删掉未追踪的临时文件**（`/tmp/*.json`、`static/*` payload、`harness-data.json` 每次命令后消失），静态 harness 走不通；改用 live box 部署后截图验证（部署产物不被清理）。
+- **发布轨迹**：终端风格 = v0.25.8（PR #474）；本次默认展开为 v0.25.9。**worktree `worktree-tool-turn-auto-expand`**。
+
 ## 2026-07-06 · 对话视图工具执行改为 Claude-Code 终端风格（inline peek，Admin requests / conversation view，docs/11，原则 1）
 
 - **背景（Lukin）**：原展开态工具块是重边框卡片（🔧 Tool ✓ ok + 两个 bordered JsonViewer 面板 Arguments/Result），boxy、不看展开就不知道工具做了什么。Lukin 给了 Claude Code 终端 transcript 截图，要求参考它做得更清晰。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.8",
+  "version": "0.25.9",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

After the terminal-style redesign (#474), seeing a tool's output peek took **two clicks**: expand the turn (row-toggle) → then `+N lines` for the full JSON. For a turn that *is* just a tool call, that first collapse level is pure friction — the inline peek should be there immediately, like Claude Code.

## Fix

Open a turn by **default** when it is **tool-only** (every part is `tool_exchange` / `tool_result` / `tool_call`, no prose/reasoning/image). Text and mixed turns still start collapsed to keep a long trace scannable. The `+N lines` → full JsonViewer step is unchanged.

```
before:  ▸ Bash(ssh … psql …)         (click 1 to expand)
           ● Bash(…) ✓ ok
           │ id | bigint …
           … +21 lines               (click 2 for full JSON)

after:   ▾ ● Bash(ssh … psql …)  ✓ ok   ← peek visible, no click
           │ id | bigint …
           … +21 lines               (one click for full JSON)
```

One-line change: `let open = $state(isToolOnly(turn))`. Named-function initializer avoids the Svelte `state_referenced_locally` warning (a turn never mutates in place, so it's computed once at mount).

## Scope

Admin-UI only — fail-close gate empty. Patch bump `0.25.8 → 0.25.9`.

## Tests

Updated the three render tests that assumed tool turns start collapsed → now assert `data-open="true"` with the peek visible and no click, and one click reveals the full viewer. Added a "mixed (text + tool) turn still starts collapsed" case. 670 admin tests green; `ConversationTurn.svelte` svelte-check 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)