### PR TITLE
feat(admin): drop empty header row on tool turns; cap output peek at 3 lines

### DIFF
--- a/apps/admin/src/lib/components/Conversation.test.ts
+++ b/apps/admin/src/lib/components/Conversation.test.ts
@@ -141,15 +141,31 @@ describe('Conversation', () => {
     expect(row.getAttribute('data-open')).toBe('true');
     const tool = screen.getByTestId('conversation-tool');
     expect(tool).toHaveTextContent('Bash(ls -la)');
-    // inline peek shows the first lines; 8 lines total, 6 shown → "+2 lines"
+    // inline peek is capped at 3 lines; 8 lines total, 3 shown → "+5 lines"
     expect(tool).toHaveTextContent('line1');
-    expect(tool).toHaveTextContent('+2');
+    expect(tool).toHaveTextContent('line3');
+    expect(tool).not.toHaveTextContent('line4'); // 4th line is hidden behind the +N
+    expect(tool).toHaveTextContent('+5');
     // full JsonViewer NOT mounted until we ask for it
     expect(within(tool).queryByText('Arguments')).toBeNull();
     // ONE click on the expand affordance → full args + result appear
     await fireEvent.click(within(tool).getByTestId('conversation-tool-expand'));
     expect(within(tool).getByText('Arguments')).toBeInTheDocument();
     expect(within(tool).getByText('Result')).toBeInTheDocument();
+  });
+
+  it('a tool-only turn drops the header row — no conversation-row-toggle, source toggle on the tool line', () => {
+    render(Conversation, {
+      request: {
+        messages: [{ role: 'assistant', content: [{ type: 'tool_use', id: 'c1', name: 'Bash', input: { command: 'ls' } }] }],
+      },
+      response: null,
+    });
+    const row = screen.getByTestId('conversation-turn');
+    // the separate role-header row (with its toggle) is gone for a tool-only turn
+    expect(within(row).queryByTestId('conversation-row-toggle')).toBeNull();
+    // but the { } view-source affordance still exists (moved onto the tool line)
+    expect(within(row).getByTestId('conversation-source-toggle')).toBeInTheDocument();
   });
 
   it('tool-only turn shows the key argument in the parens, not a blind Name()', () => {

--- a/apps/admin/src/lib/components/ConversationTurn.svelte
+++ b/apps/admin/src/lib/components/ConversationTurn.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { t } from '$lib/i18n';
   import { formatToolArgs, toolOutputPeek, type ConversationTurn, type TurnPart } from '$lib/conversation';
   import ImagePreview from './ImagePreview.svelte';
@@ -39,7 +40,16 @@
   // once at mount (turns never mutate in place), so read `turn` inside the initializer.
   const isToolOnly = (t: ConversationTurn): boolean =>
     t.parts.length > 0 && t.parts.every((p) => p.kind === 'tool_exchange' || p.kind === 'tool_result' || p.kind === 'tool_call');
-  let open = $state(isToolOnly(turn));
+  // A tool-only turn drops the separate role-header row entirely: it would render as an
+  // near-empty `▾ ● { }` line above the tool block (ugly, no content). The tool line IS
+  // the row — it carries the name, args, status, and the hover-revealed source toggle.
+  const toolOnly = $derived(isToolOnly(turn));
+  // Index of the first tool part — the one that carries the turn's single `{ }` source
+  // toggle when the header row is dropped (tool-only turns), so it appears once, not per row.
+  const firstToolPart = $derived(turn.parts.findIndex((p) => p.kind === 'tool_exchange' || p.kind === 'tool_result' || p.kind === 'tool_call'));
+  // Read the initial tool-only-ness once for the default open state (untracked so the
+  // $state initializer doesn't capture `turn` reactively — turns never mutate in place).
+  let open = $state(untrack(() => isToolOnly(turn)));
   let sourceOpen = $state(false);
   // Apply a global command whenever its nonce changes (tracked by value, so identical
   // consecutive commands still re-apply). A later per-row toggle just flips `open`.
@@ -67,6 +77,8 @@
 
   // Expanded tool header gets a wider arg budget than the 72-char collapsed line.
   const EXPANDED_ARG_CHARS = 160;
+  // Inline output peek is a glimpse, not the log — keep it short (full body is one click away).
+  const PEEK_LINES = 3;
 
   // Per-role identity: dot color + spine tint + name color — straight from app tokens
   // (indigo brand = assistant, slate = user, amber = system, sky = tool).
@@ -170,48 +182,52 @@
   data-open={open}
   class={`group border-l-2 pl-3 ${style.spine} ${grouped ? '' : 'mt-3'}`}
 >
-  <!-- Collapsed header line: click anywhere to expand. One dense, scannable row. -->
-  <div class="flex items-center gap-2">
-    <button
-      type="button"
-      data-testid="conversation-row-toggle"
-      class="flex min-w-0 flex-1 items-center gap-2 py-1 text-left"
-      onclick={toggle}
-      aria-expanded={open}
-    >
-      <!-- disclosure caret -->
-      <span class="shrink-0 text-[10px] text-ink-faint">{open ? '▾' : '▸'}</span>
-      <!-- role dot + name (name only on the first row of a same-role run) -->
-      <span class={`h-2 w-2 shrink-0 rounded-full ${style.dot}`}></span>
-      {#if !grouped}
-        <span class={`shrink-0 text-xs font-semibold ${style.name}`}>{roleLabel(turn.role)}</span>
-      {/if}
-      <!-- one-line preview (hidden once expanded — the full content shows below) -->
-      {#if !open}
-        <span class="min-w-0 flex-1 truncate text-xs text-ink-muted">{preview}</span>
-      {:else}
-        <span class="flex-1"></span>
-      {/if}
-      <!-- type badges: only what's present -->
-      <span class="flex shrink-0 items-center gap-1.5 text-[11px] text-ink-faint">
-        {#if counts.reasoning}<span title={$t('Reasoning')}>🧠</span>{/if}
-        {#if counts.tools}<span title={$t('tool call')}>🔧{counts.tools > 1 ? `×${counts.tools}` : ''}</span>{/if}
-        {#if counts.images}<span title={$t('Image')}>🖼{counts.images > 1 ? `×${counts.images}` : ''}</span>{/if}
-        {#if counts.errors}<span class="text-red-500" title={$t('error')}>⚠</span>{/if}
-        {#if sizeHint}<span class="font-mono">{sizeHint}</span>{/if}
-      </span>
-    </button>
-    <!-- hover-revealed raw-source affordance (no 48 always-on links) -->
-    <button
-      type="button"
-      data-testid="conversation-source-toggle"
-      class="shrink-0 rounded px-1 font-mono text-xs text-ink-faint opacity-0 transition-opacity hover:text-link focus:opacity-100 group-hover:opacity-100"
-      title={$t('View source')}
-      onclick={() => (sourceOpen = !sourceOpen)}
-    >
-      {'{ }'}
-    </button>
-  </div>
+  <!-- Collapsed header line: click anywhere to expand. One dense, scannable row.
+       A tool-only turn SKIPS this row — the tool block below is the whole row (it
+       carries name/args/status + its own source toggle), so no empty `▾ ● { }` line. -->
+  {#if !toolOnly}
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        data-testid="conversation-row-toggle"
+        class="flex min-w-0 flex-1 items-center gap-2 py-1 text-left"
+        onclick={toggle}
+        aria-expanded={open}
+      >
+        <!-- disclosure caret -->
+        <span class="shrink-0 text-[10px] text-ink-faint">{open ? '▾' : '▸'}</span>
+        <!-- role dot + name (name only on the first row of a same-role run) -->
+        <span class={`h-2 w-2 shrink-0 rounded-full ${style.dot}`}></span>
+        {#if !grouped}
+          <span class={`shrink-0 text-xs font-semibold ${style.name}`}>{roleLabel(turn.role)}</span>
+        {/if}
+        <!-- one-line preview (hidden once expanded — the full content shows below) -->
+        {#if !open}
+          <span class="min-w-0 flex-1 truncate text-xs text-ink-muted">{preview}</span>
+        {:else}
+          <span class="flex-1"></span>
+        {/if}
+        <!-- type badges: only what's present -->
+        <span class="flex shrink-0 items-center gap-1.5 text-[11px] text-ink-faint">
+          {#if counts.reasoning}<span title={$t('Reasoning')}>🧠</span>{/if}
+          {#if counts.tools}<span title={$t('tool call')}>🔧{counts.tools > 1 ? `×${counts.tools}` : ''}</span>{/if}
+          {#if counts.images}<span title={$t('Image')}>🖼{counts.images > 1 ? `×${counts.images}` : ''}</span>{/if}
+          {#if counts.errors}<span class="text-red-500" title={$t('error')}>⚠</span>{/if}
+          {#if sizeHint}<span class="font-mono">{sizeHint}</span>{/if}
+        </span>
+      </button>
+      <!-- hover-revealed raw-source affordance (no 48 always-on links) -->
+      <button
+        type="button"
+        data-testid="conversation-source-toggle"
+        class="shrink-0 rounded px-1 font-mono text-xs text-ink-faint opacity-0 transition-opacity hover:text-link focus:opacity-100 group-hover:opacity-100"
+        title={$t('View source')}
+        onclick={() => (sourceOpen = !sourceOpen)}
+      >
+        {'{ }'}
+      </button>
+    </div>
+  {/if}
 
   <!-- Expanded body — flat, terminal-style transcript (no boxes; dot+indent spine). -->
   {#if open}
@@ -229,23 +245,37 @@
         {:else if part.kind === 'tool_exchange'}
           {@const st = exchangeStatus(part)}
           {@const detail = formatToolArgs(part.name, part.args, EXPANDED_ARG_CHARS)}
-          {@const peek = part.hasResult ? toolOutputPeek(part.output) : { lines: [], moreLines: 0 }}
+          {@const peek = part.hasResult ? toolOutputPeek(part.output, PEEK_LINES) : { lines: [], moreLines: 0 }}
           {@const full = toolOpen.has(i)}
           <div data-testid="conversation-tool" class="my-1.5">
-            <!-- Header: ● Name(args)  <status> — click toggles the full args+result viewer. -->
-            <button
-              type="button"
-              data-testid="conversation-tool-toggle"
-              class="flex w-full items-baseline gap-2 text-left font-mono text-xs"
-              onclick={() => toggleTool(i)}
-              aria-expanded={full}
-            >
-              <span class="shrink-0 text-sky-500">●</span>
-              <span class="min-w-0 flex-1 break-words">
-                <span class="font-semibold text-ink-strong">{part.name || $t('tool call')}</span><span class="text-ink-muted">({detail})</span>
-              </span>
-              <span class={`shrink-0 font-medium ${st.cls}`}>{st.glyph} {st.label}</span>
-            </button>
+            <!-- Header: ● Name(args)  <status>  { } — click toggles the full args+result
+                 viewer; the hover-revealed { } shows this turn's raw wire object. -->
+            <div class="flex items-baseline gap-2">
+              <button
+                type="button"
+                data-testid="conversation-tool-toggle"
+                class="flex min-w-0 flex-1 items-baseline gap-2 text-left font-mono text-xs"
+                onclick={() => toggleTool(i)}
+                aria-expanded={full}
+              >
+                <span class="shrink-0 text-sky-500">●</span>
+                <span class="min-w-0 flex-1 break-words">
+                  <span class="font-semibold text-ink-strong">{part.name || $t('tool call')}</span><span class="text-ink-muted">({detail})</span>
+                </span>
+                <span class={`shrink-0 font-medium ${st.cls}`}>{st.glyph} {st.label}</span>
+              </button>
+              {#if toolOnly && firstToolPart === i}
+                <button
+                  type="button"
+                  data-testid="conversation-source-toggle"
+                  class="shrink-0 rounded px-1 font-mono text-xs text-ink-faint opacity-0 transition-opacity hover:text-link focus:opacity-100 group-hover:opacity-100"
+                  title={$t('View source')}
+                  onclick={() => (sourceOpen = !sourceOpen)}
+                >
+                  {'{ }'}
+                </button>
+              {/if}
+            </div>
             <!-- Inline output peek (first lines) under a left rule — the CC glimpse. -->
             {#if !full && peek.lines.length}
               <div class="mt-0.5 border-l-2 border-border pl-3 font-mono text-[11px] leading-snug text-ink-muted">
@@ -287,7 +317,7 @@
           </div>
         {:else if part.kind === 'tool_result'}
           <!-- orphan result (no matching call) — kept, never silently lost -->
-          {@const peek = toolOutputPeek(part.output)}
+          {@const peek = toolOutputPeek(part.output, PEEK_LINES)}
           {@const full = toolOpen.has(i)}
           <div data-testid="conversation-tool" class="my-1.5 font-mono text-xs">
             <button

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-06 · 纯工具 turn 去掉空 header 行 + peek 收到 3 行（Admin conversation view，docs/11，原则 1）
+
+- **背景（Lukin）**：默认展开后，纯工具 turn 在工具块上方还多渲染一条近乎空的折叠 header 行（`▾ ● { }`：caret+role dot+空 preview+源码切换），很丑；另外 output peek 6 行太多。
+- **改动 1（删空 header）**：`ConversationTurn.svelte` 把折叠 header 行包在 `{#if !toolOnly}` 里——纯工具 turn 不再渲染它，工具块自己的 `● Name(args) ✓ ok` 行就是整条 row。把 per-turn 的 `{ }` view-source 切换挪到**第一个工具部分**那一行右侧（hover 显现，`toolOnly && firstToolPart === i` 只出现一次，不逐行重复）；非纯工具 turn 仍用原 header 里的 `{ }`（不重复）。`toolOnly`/`firstToolPart` 改 `$derived`，`open` 初值用 `untrack(() => isToolOnly(turn))` 消除 `state_referenced_locally` 警告。
+- **改动 2（peek 3 行）**：加 `PEEK_LINES = 3` 常量，两处 `toolOutputPeek(part.output, PEEK_LINES)` 传入（`toolOutputPeek` 默认仍 6，只在组件里收窄）。
+- **测试**：更新「peek」用例断言 3 行可见、第 4 行隐藏、`+5`（8 行输入）；新增「纯工具 turn 无 `conversation-row-toggle`，但 `conversation-source-toggle` 在工具行上」。97 conversation/render 测试绿、svelte-check 0/0/0。full-run 里 `requests.test.ts` 2 红是并发 PGlite flake（隔离跑 40/40 绿，非本次改动，见 [[pnpm-test-pglite-flake]]）。
+- **共享树坑（记）**：切回 main 时发现工作树带着 sibling session（Codex `codex/admin-perf-lazy-payload`）未提交的 `packages/core/src/store/*telemetry.ts` WIP——**没碰它**，直接开隔离 worktree（干净 checkout，不含 sibling 文件）。参见 [[git-add-explicit-not-all-shared-tree]]。
+- **发布**：v0.25.10。worktree `worktree-tool-row-cleaner`。
+
 ## 2026-07-06 · 纯工具 turn 默认展开，去掉多一次点击（Admin conversation view，docs/11，原则 1）
 
 - **背景（Lukin）**：终端风格上线后，看一个工具的 output peek 要点**两次**——先点行展开 turn（row-toggle），再点 `… +N lines` 出完整 JSON。第一层折叠对「整条 turn 就是一个工具调用」的行是纯多余摩擦。Lukin 要求参考 Claude Code：peek 直接可见，不用先展开。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.9",
+  "version": "0.25.10",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Two visual cleanups to the terminal-style conversation view (follow-ups to #474/#475).

## 1. Delete the empty header row on tool-only turns

Since tool turns auto-expand, they rendered a **separate near-empty header row** above the tool block — `▾ ● { }` (caret + role dot + blank preview + source toggle). Ugly and content-free.

Now a tool-only turn skips that row entirely: the tool line `● Name(args) ✓ ok` *is* the row. The hover-revealed `{ }` view-source affordance moves onto that line (shown once per turn, on the first tool part). Text/mixed turns keep their normal header.

## 2. Cap the inline output peek at 3 lines (was 6)

A glimpse, not the log. The full body is still one click away via `+N lines`.

```
before:  ▾ ● { }                          ← empty ugly row
         ● Bash(…) ✓ ok
           │ id | bigint
           │ build_id | text
           │ … (6 lines)
           … +21 lines

after:   ● Bash(…) ✓ ok            { }     ← one clean line, source toggle on hover
           │ id | bigint
           │ build_id | text
           │ given_name | text
           … +24 lines
```

## Scope

Admin-UI only — fail-close gate empty. Patch bump `0.25.9 → 0.25.10`.

## Tests

Updated the peek test (3 lines shown, 4th hidden, `+5`); added "tool-only turn has no `conversation-row-toggle`, source toggle lives on the tool line". 97 conversation/render tests green; svelte-check 0/0/0. Verified visually in a browser against a real 743-turn capture: 0 tool turns with the empty header, peek = 3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)