### PR TITLE
fix(admin): lazy-load request payloads

### DIFF
--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -716,6 +716,20 @@ export interface RequestPayloadView {
   // is what the client sent). Null/absent when no provider served or pre-feature.
   upstream_request?: unknown;
   created_at?: number;
+  parts?: {
+    request: boolean;
+    response: boolean;
+    upstream_request: boolean;
+  };
+}
+
+export type RequestPayloadPartName = 'request' | 'response' | 'upstream_request';
+
+export interface RequestPayloadPartView {
+  captured: boolean;
+  part?: RequestPayloadPartName;
+  value?: unknown;
+  created_at?: number;
 }
 
 // GET /admin/api/requests/:traceId/payload -> the captured bodies. Resolves to
@@ -728,6 +742,36 @@ export async function getRequestPayload(traceId: string): Promise<RequestPayload
     });
     if (!res.ok) return { captured: false };
     return (await res.json()) as RequestPayloadView;
+  } catch {
+    return { captured: false };
+  }
+}
+
+export async function getRequestPayloadMeta(traceId: string): Promise<RequestPayloadView> {
+  try {
+    const res = await fetch(`${BASE}/${encodeURIComponent(traceId)}/payload?part=meta`, {
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return { captured: false };
+    return (await res.json()) as RequestPayloadView;
+  } catch {
+    return { captured: false };
+  }
+}
+
+export async function getRequestPayloadPart(
+  traceId: string,
+  part: RequestPayloadPartName,
+): Promise<RequestPayloadPartView> {
+  try {
+    const res = await fetch(
+      `${BASE}/${encodeURIComponent(traceId)}/payload?part=${encodeURIComponent(part)}`,
+      {
+        headers: { accept: 'application/json' },
+      },
+    );
+    if (!res.ok) return { captured: false };
+    return (await res.json()) as RequestPayloadPartView;
   } catch {
     return { captured: false };
   }

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import { invalidateAll } from '$app/navigation';
-  import type { RequestDetail, RequestPayloadView } from '$lib/api/requests.js';
+  import {
+    getRequestPayloadPart,
+    type RequestDetail,
+    type RequestPayloadPartName,
+    type RequestPayloadView,
+  } from '$lib/api/requests.js';
   import { deepEqual } from '$lib/deep-equal.js';
   import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
   import { formatTimestamp, formatTps } from '$lib/format.js';
@@ -46,6 +51,82 @@
   // truth). Additive: the raw view and everything below it are unchanged.
   let reqView = $state<'chat' | 'raw'>('chat');
 
+  type PartStatus = 'idle' | 'loading' | 'loaded' | 'error';
+  type PayloadValues = Partial<Record<RequestPayloadPartName, unknown>>;
+  type PayloadStatuses = Record<RequestPayloadPartName, PartStatus>;
+
+  function hasOwn(obj: object, key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(obj, key);
+  }
+
+  function pagePayload(): RequestPayloadView {
+    return data.payload ?? { captured: false };
+  }
+
+  function initialPayloadValues(payload: RequestPayloadView): PayloadValues {
+    return {
+      ...(hasOwn(payload, 'request') ? { request: payload.request } : {}),
+      ...(hasOwn(payload, 'response') ? { response: payload.response } : {}),
+      ...(hasOwn(payload, 'upstream_request') ? { upstream_request: payload.upstream_request } : {}),
+    };
+  }
+
+  function initialPayloadStatuses(payload: RequestPayloadView): PayloadStatuses {
+    return {
+      request: hasOwn(payload, 'request') ? 'loaded' : 'idle',
+      response: hasOwn(payload, 'response') ? 'loaded' : 'idle',
+      upstream_request: hasOwn(payload, 'upstream_request') ? 'loaded' : 'idle',
+    };
+  }
+
+  let payloadValues = $state<PayloadValues>(initialPayloadValues(pagePayload()));
+  let payloadStatus = $state<PayloadStatuses>(initialPayloadStatuses(pagePayload()));
+  let payloadErrors = $state<Partial<Record<RequestPayloadPartName, string>>>({});
+
+  function hasPayloadPart(part: RequestPayloadPartName): boolean {
+    if (data.payload?.captured !== true) return false;
+    if (data.payload.parts) return data.payload.parts[part];
+    return hasOwn(data.payload, part);
+  }
+
+  async function loadPayloadPart(part: RequestPayloadPartName): Promise<unknown> {
+    if (!hasPayloadPart(part)) return null;
+    if (payloadStatus[part] === 'loaded') return payloadValues[part];
+    if (payloadStatus[part] === 'loading') return payloadValues[part];
+    payloadStatus[part] = 'loading';
+    payloadErrors[part] = undefined;
+    const res = await getRequestPayloadPart(data.traceId, part);
+    if (res.captured !== true || res.part !== part) {
+      payloadStatus[part] = 'error';
+      payloadErrors[part] = $t('Payload was not available.');
+      return null;
+    }
+    payloadValues[part] = res.value ?? null;
+    payloadStatus[part] = 'loaded';
+    return payloadValues[part];
+  }
+
+  async function loadConversation(): Promise<void> {
+    await Promise.all([
+      loadPayloadPart('request'),
+      hasPayloadPart('response') ? loadPayloadPart('response') : Promise.resolve(null),
+    ]);
+  }
+
+  async function loadUpstreamRequest(): Promise<void> {
+    await Promise.all([
+      loadPayloadPart('request'),
+      hasPayloadPart('upstream_request')
+        ? loadPayloadPart('upstream_request')
+        : Promise.resolve(null),
+    ]);
+  }
+
+  async function openRetry(): Promise<void> {
+    const body = await loadPayloadPart('request');
+    if (body && typeof body === 'object') showRetry = true;
+  }
+
   async function copyTrace(): Promise<void> {
     try {
       await navigator.clipboard?.writeText(data.traceId);
@@ -62,18 +143,22 @@
   // so the client doesn't enumerate shapes here (that would wrongly disable e.g. a
   // string-`input` Responses body). Disabled only when nothing was captured (capture
   // off, or the payload was pruned).
-  const replayBody = $derived(data.payload?.captured === true ? data.payload.request : undefined);
-  const canRetry = $derived(!!replayBody && typeof replayBody === 'object');
+  const replayBody = $derived(payloadValues.request);
+  const canRetry = $derived(data.payload?.captured === true && hasPayloadPart('request'));
 
   // The forwarded-upstream body is worth a SEPARATE panel only when it actually
   // differs from the inbound client body (memory injection / protocol translation /
   // model patch). When they are structurally identical — e.g. a no-memory request to
   // an OpenAI-shaped provider — a second panel is pure noise, so we collapse to one.
-  const hasUpstream = $derived(
-    data.payload?.captured === true && data.payload?.upstream_request != null,
-  );
+  const hasUpstream = $derived(data.payload?.captured === true && hasPayloadPart('upstream_request'));
+  const requestLoaded = $derived(payloadStatus.request === 'loaded');
+  const responseLoaded = $derived(payloadStatus.response === 'loaded');
+  const upstreamLoaded = $derived(payloadStatus.upstream_request === 'loaded');
   const upstreamDiffers = $derived(
-    hasUpstream && !deepEqual(data.payload.request, data.payload.upstream_request),
+    hasUpstream &&
+      requestLoaded &&
+      upstreamLoaded &&
+      !deepEqual(payloadValues.request, payloadValues.upstream_request),
   );
 
   // Media overview: every image in this call surfaced up front, so an operator sees
@@ -95,15 +180,15 @@
     return out;
   }
   const requestImages = $derived(
-    data.payload?.captured === true
+    data.payload?.captured === true && requestLoaded
       ? dedupeByUrl([
-          ...collectImages(data.payload.request),
-          ...(upstreamDiffers ? collectImages(data.payload.upstream_request) : []),
+          ...collectImages(payloadValues.request),
+          ...(upstreamDiffers ? collectImages(payloadValues.upstream_request) : []),
         ])
       : [],
   );
   const responseImages = $derived(
-    data.payload?.captured === true ? collectImages(data.payload.response) : [],
+    data.payload?.captured === true && responseLoaded ? collectImages(payloadValues.response) : [],
   );
   const mediaGroups = $derived(
     [
@@ -153,14 +238,15 @@
           type="button"
           data-testid="retry-request"
           class="btn-primary"
-          disabled={!canRetry}
+          disabled={!canRetry || payloadStatus.request === 'loading'}
           title={canRetry ? '' : $t('Retry unavailable — no captured request body.')}
-          onclick={() => (showRetry = true)}>{$t('Retry')}</button
+          onclick={openRetry}
+          >{payloadStatus.request === 'loading' ? $t('Loading') : $t('Retry')}</button
         >
       </div>
     </header>
 
-    {#if showRetry && canRetry}
+    {#if showRetry && replayBody && typeof replayBody === 'object'}
       <RetryDialog
         traceId={d.trace_id}
         initialRequest={replayBody}
@@ -283,10 +369,10 @@
             )}
           {:else if hasUpstream}
             {$t(
-              'Full request body recorded for this call. The body forwarded upstream was identical (no memory injection or translation).',
+              'Payload capture is available for this call. Large bodies are loaded only when you open a section.',
             )}
           {:else}
-            {$t('Full request body recorded for this call.')}
+            {$t('Payload capture is available for this call. Large bodies are loaded on demand.')}
           {/if}
         </p>
         <!-- Two lenses over the same captured body: Chat (a readable user⇄agent
@@ -302,17 +388,61 @@
             type="button"
             data-testid="request-view-raw"
             class={`rounded border px-3 py-1 text-sm ${reqView === 'raw' ? 'border-action bg-action text-white' : 'border-border bg-surface text-ink-muted hover:bg-canvas'}`}
-            onclick={() => (reqView = 'raw')}>{$t('Raw')}</button
+          onclick={() => (reqView = 'raw')}>{$t('Raw')}</button
           >
         </div>
         {#if reqView === 'chat'}
-          <Conversation
-            request={data.payload.request}
-            response={data.payload.response}
-            testid="conversation"
-          />
+          {#if !requestLoaded || (hasPayloadPart('response') && !responseLoaded)}
+            <div class="rounded border border-dashed border-border bg-canvas p-3">
+              <p class="field-help mb-2">
+                {$t('Load the captured request and response only when you need the transcript.')}
+              </p>
+              <button
+                type="button"
+                data-testid="load-conversation"
+                class="btn-secondary"
+                disabled={payloadStatus.request === 'loading' || payloadStatus.response === 'loading'}
+                onclick={loadConversation}
+                >{payloadStatus.request === 'loading' || payloadStatus.response === 'loading'
+                  ? $t('Loading')
+                  : $t('Load conversation')}</button
+              >
+              {#if payloadErrors.request || payloadErrors.response}
+                <p class="mt-2 text-sm text-red-600">
+                  {payloadErrors.request ?? payloadErrors.response}
+                </p>
+              {/if}
+            </div>
+          {:else}
+            <Conversation
+              request={payloadValues.request}
+              response={payloadValues.response}
+              testid="conversation"
+            />
+          {/if}
         {:else}
-          <JsonViewer value={data.payload.request} testid="request-body" />
+          {#if !requestLoaded}
+            <div class="rounded border border-dashed border-border bg-canvas p-3">
+              <p class="field-help mb-2">
+                {$t('Load the raw request body only when you need to inspect it.')}
+              </p>
+              <button
+                type="button"
+                data-testid="load-request-body"
+                class="btn-secondary"
+                disabled={payloadStatus.request === 'loading'}
+                onclick={() => loadPayloadPart('request')}
+                >{payloadStatus.request === 'loading'
+                  ? $t('Loading')
+                  : $t('Load request body')}</button
+              >
+              {#if payloadErrors.request}
+                <p class="mt-2 text-sm text-red-600">{payloadErrors.request}</p>
+              {/if}
+            </div>
+          {:else}
+            <JsonViewer value={payloadValues.request} testid="request-body" />
+          {/if}
         {/if}
       {:else}
         <p class="field-help mb-2">
@@ -331,7 +461,7 @@
          memory injection + protocol translation. Shown as a SEPARATE panel only when
          it differs from the inbound body; when identical, the single "Request" panel
          above already covers it (no duplicate). -->
-    {#if upstreamDiffers}
+    {#if hasUpstream}
       <section class="card text-sm">
         <h2 class="section-header">{$t('Forwarded to upstream LLM')}</h2>
         <p class="field-help mb-2">
@@ -339,7 +469,34 @@
             'The exact request sent to the provider — after memory injection and protocol translation. This is what the model actually received.',
           )}
         </p>
-        <JsonViewer value={data.payload.upstream_request} testid="upstream-request-body" />
+        {#if !upstreamLoaded || !requestLoaded}
+          <div class="rounded border border-dashed border-border bg-canvas p-3">
+            <p class="field-help mb-2">
+              {$t('Load this only when you need to compare the client body with the provider body.')}
+            </p>
+            <button
+              type="button"
+              data-testid="load-upstream-request"
+              class="btn-secondary"
+              disabled={payloadStatus.upstream_request === 'loading' || payloadStatus.request === 'loading'}
+              onclick={loadUpstreamRequest}
+              >{payloadStatus.upstream_request === 'loading' || payloadStatus.request === 'loading'
+                ? $t('Loading')
+                : $t('Load upstream request')}</button
+            >
+            {#if payloadErrors.upstream_request || payloadErrors.request}
+              <p class="mt-2 text-sm text-red-600">
+                {payloadErrors.upstream_request ?? payloadErrors.request}
+              </p>
+            {/if}
+          </div>
+        {:else if upstreamDiffers}
+          <JsonViewer value={payloadValues.upstream_request} testid="upstream-request-body" />
+        {:else}
+          <p class="field-help italic">
+            {$t('The forwarded upstream body matched the client request body.')}
+          </p>
+        {/if}
       </section>
     {/if}
 
@@ -411,19 +568,38 @@
             : JSON.stringify(d.error.provider_raw)}
         </div>
       </section>
-    {:else if data.payload?.captured && data.payload?.response != null}
+    {:else if data.payload?.captured && hasPayloadPart('response')}
       <section class="card text-sm">
         <h2 class="section-header">{$t('Response')}</h2>
-        {#if isSseStream(data.payload.response)}
+        {#if !responseLoaded}
+          <div class="rounded border border-dashed border-border bg-canvas p-3">
+            <p class="field-help mb-2">
+              {$t('Load the full response body only when you need to inspect it.')}
+            </p>
+            <button
+              type="button"
+              data-testid="load-response-body"
+              class="btn-secondary"
+              disabled={payloadStatus.response === 'loading'}
+              onclick={() => loadPayloadPart('response')}
+              >{payloadStatus.response === 'loading'
+                ? $t('Loading')
+                : $t('Load response body')}</button
+            >
+            {#if payloadErrors.response}
+              <p class="mt-2 text-sm text-red-600">{payloadErrors.response}</p>
+            {/if}
+          </div>
+        {:else if isSseStream(payloadValues.response)}
           <!-- Streaming call: the stored body is the raw SSE wire text. Render it
                stream-aware (assembled final message / per-chunk table / raw). -->
           <p class="field-help mb-2">
             {$t('Streaming response — assembled from the recorded SSE stream.')}
           </p>
-          <StreamViewer raw={data.payload.response} testid="response-body" />
+          <StreamViewer raw={payloadValues.response as string} testid="response-body" />
         {:else}
           <p class="field-help mb-2">{$t('Full response body recorded for this call.')}</p>
-          <JsonViewer value={data.payload.response} testid="response-body" />
+          <JsonViewer value={payloadValues.response} testid="response-body" />
         {/if}
       </section>
     {:else if d.response_meta}

--- a/apps/admin/src/routes/requests/[traceId]/+page.ts
+++ b/apps/admin/src/routes/requests/[traceId]/+page.ts
@@ -1,7 +1,7 @@
 import { base } from '$app/paths';
 import {
   getRequest,
-  getRequestPayload,
+  getRequestPayloadMeta,
   type RequestDetail,
   type RequestPayloadView,
 } from '$lib/api/requests.js';
@@ -18,11 +18,11 @@ export function safeBackTo(from: string | null, fallback: string): string {
   return from;
 }
 
-// SPA load: fetch the full decision trail + the captured payload for one trace.
+// SPA load: fetch the full decision trail + a lightweight payload summary for one trace.
 // On failure (e.g. the trace does not exist / 404) we resolve to a friendly error
-// state rather than throwing — the page must never white-screen (DoD). The payload
-// fetch fails open to { captured:false } so a capture-off request still renders.
-// READ-ONLY (docs/07).
+// state rather than throwing — the page must never white-screen (DoD). The payload meta
+// fetch fails open to { captured:false }; the heavy request/response bodies are loaded
+// on demand by the page, not during navigation. READ-ONLY (docs/07).
 export const load: PageLoad = async ({
   params,
   url,
@@ -35,12 +35,11 @@ export const load: PageLoad = async ({
 }> => {
   const traceId = params.traceId;
   const backTo = safeBackTo(url.searchParams.get('from'), `${base}/requests`);
-  // Payload fails open INDEPENDENTLY: a slow / failed body capture must not sink the
-  // whole page — its own `.catch` keeps `Promise.all` from rejecting on a payload
-  // error, so the decision trail still renders. Only a failure of the detail itself
-  // is fatal, and even then we surface a friendly, retryable state (never
-  // white-screen, DoD).
-  const payloadP = getRequestPayload(traceId).catch(
+  // Payload metadata fails open INDEPENDENTLY: a slow / failed body lookup must not
+  // sink the whole page — its own `.catch` keeps `Promise.all` from rejecting, so the
+  // decision trail still renders. Only a failure of the detail itself is fatal, and
+  // even then we surface a friendly, retryable state (never white-screen, DoD).
+  const payloadP = getRequestPayloadMeta(traceId).catch(
     (): RequestPayloadView => ({ captured: false }),
   );
   try {

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -16,12 +16,16 @@ import { load as loadList } from './+page.js';
 
 const getRequest = vi.fn();
 const getRequestPayload = vi.fn();
+const getRequestPayloadMeta = vi.fn();
+const getRequestPayloadPart = vi.fn();
 const listRequests = vi.fn();
 const listKeys = vi.fn();
 vi.mock('$lib/api/requests.js', () => ({
   listRequests: (...args: unknown[]) => listRequests(...args),
   getRequest: (...args: unknown[]) => getRequest(...args),
   getRequestPayload: (...args: unknown[]) => getRequestPayload(...args),
+  getRequestPayloadMeta: (...args: unknown[]) => getRequestPayloadMeta(...args),
+  getRequestPayloadPart: (...args: unknown[]) => getRequestPayloadPart(...args),
 }));
 vi.mock('$lib/api/keys.js', () => ({
   listKeys: (...args: unknown[]) => listKeys(...args),
@@ -419,6 +423,9 @@ describe('requests list page', () => {
 describe('requests detail page', () => {
   beforeEach(() => {
     getRequest.mockReset();
+    getRequestPayload.mockReset();
+    getRequestPayloadMeta.mockReset();
+    getRequestPayloadPart.mockReset();
   });
 
   it('Back link returns to the originating page passed via the loader (backTo)', () => {
@@ -528,6 +535,34 @@ describe('requests detail page', () => {
     await fireEvent.click(screen.getByTestId('request-view-raw'));
     expect(screen.getByTestId('request-body')).toHaveTextContent(/"model": "auto"/);
     expect(screen.getByTestId('response-body')).toHaveTextContent(/"ok": true/);
+  });
+
+  it('loads captured bodies lazily from the payload part API', async () => {
+    getRequestPayloadPart.mockResolvedValueOnce({
+      captured: true,
+      part: 'request',
+      value: { model: 'auto' },
+      created_at: 1234,
+    });
+    render(DetailPage, {
+      data: {
+        detail: detail(),
+        payload: {
+          captured: true,
+          parts: { request: true, response: false, upstream_request: false },
+          created_at: 1234,
+        },
+        traceId: 'tr_lazy',
+      },
+    });
+
+    expect(getRequestPayloadPart).not.toHaveBeenCalled();
+    await fireEvent.click(screen.getByTestId('request-view-raw'));
+    expect(screen.queryByTestId('request-body')).not.toBeInTheDocument();
+    await fireEvent.click(screen.getByTestId('load-request-body'));
+
+    expect(await screen.findByTestId('request-body')).toHaveTextContent(/"model": "auto"/);
+    expect(getRequestPayloadPart).toHaveBeenCalledWith('tr_lazy', 'request');
   });
 
   // A 1×1 PNG (bare base64) — the form a generated/input image takes inside a body.
@@ -731,21 +766,24 @@ describe('requests detail loader (payload fails open, detail is fatal)', () => {
   beforeEach(() => {
     getRequest.mockReset();
     getRequestPayload.mockReset();
+    getRequestPayloadMeta.mockReset();
+    getRequestPayloadPart.mockReset();
   });
 
   it('still returns the detail when the payload fetch fails — a body error must not sink the page', async () => {
     getRequest.mockResolvedValue(detail());
-    getRequestPayload.mockRejectedValue(new Error('payload timeout'));
+    getRequestPayloadMeta.mockRejectedValue(new Error('payload timeout'));
     const data = await runLoad('tr_1');
     // The decision trail renders; the payload merely fails open to "not captured".
     expect(data.detail).not.toBeNull();
     expect(data.payload).toEqual({ captured: false });
     expect(data.loadError).toBeUndefined();
+    expect(getRequestPayload).not.toHaveBeenCalled();
   });
 
   it('surfaces a retryable error state only when the detail itself fails', async () => {
     getRequest.mockRejectedValue(new Error('not found'));
-    getRequestPayload.mockResolvedValue({ captured: false });
+    getRequestPayloadMeta.mockResolvedValue({ captured: false });
     const data = await runLoad('missing');
     expect(data.detail).toBeNull();
     expect(data.loadError).toBe('not found');

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1474,6 +1474,55 @@ describe("admin.api request payload", () => {
     expect(res.status).toBe(200);
     expect(((await res.json()) as { upstream_request: unknown }).upstream_request).toBeNull();
   });
+
+  it("returns lightweight payload metadata without reading the full body", async () => {
+    const telemetry = {
+      ...makeTelemetry(),
+      getPayload: async () => {
+        throw new Error("full payload should not be read");
+      },
+      getPayloadMeta: async (id: string) =>
+        id === "req_3"
+          ? {
+              requestId: "req_3",
+              createdAt: new Date(1234),
+              parts: { request: true, response: false, upstreamRequest: true },
+            }
+          : null,
+    } as unknown as TelemetryStore;
+    const app = buildApp(buildDeps({ telemetry }));
+    const res = await app.request("/admin/api/requests/req_3/payload?part=meta");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      captured: true,
+      created_at: 1234,
+      parts: { request: true, response: false, upstream_request: true },
+    });
+  });
+
+  it("returns one requested payload part", async () => {
+    const telemetry = {
+      ...makeTelemetry(),
+      getPayloadPart: async (id: string, part: "request" | "response" | "upstream_request") =>
+        id === "req_4" && part === "upstream_request"
+          ? {
+              requestId: "req_4",
+              part,
+              json: JSON.stringify({ model: "gpt-resolved" }),
+              createdAt: new Date(1234),
+            }
+          : null,
+    } as unknown as TelemetryStore;
+    const app = buildApp(buildDeps({ telemetry }));
+    const res = await app.request("/admin/api/requests/req_4/payload?part=upstream_request");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      captured: true,
+      part: "upstream_request",
+      value: { model: "gpt-resolved" },
+      created_at: 1234,
+    });
+  });
 });
 
 describe("admin.api oauth usage", () => {

--- a/apps/gateway/src/routes/admin/memory.test.ts
+++ b/apps/gateway/src/routes/admin/memory.test.ts
@@ -1,7 +1,7 @@
 import { createSqliteDb, factContentHash, type MemoryStore, SqliteMemoryStore } from "@helm/core";
 import type { ApiKeyRecord, Fact } from "@helm/shared";
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
 import { registerMemoryRoutes } from "./memory.js";
@@ -155,6 +155,25 @@ describe("/admin/api/memory routes (docs/13)", () => {
     expect(body.queue.byType).toContainEqual({ type: "observer", status: "pending", count: 1 });
     expect(body.activity.lastMessageAt).not.toBeNull();
     expect(body.activity.lastObservationAt).not.toBeNull();
+  });
+
+  it("caches operational stats briefly per selected memory scope", async () => {
+    const { store } = seededStore();
+    const statsSpy = vi.spyOn(store, "getMemoryAdminStats");
+    const app = buildApp(store);
+
+    expect((await app.request("/admin/api/memory/stats?accountId=acct&projectId=p1")).status).toBe(
+      200,
+    );
+    expect((await app.request("/admin/api/memory/stats?accountId=acct&projectId=p1")).status).toBe(
+      200,
+    );
+    expect(statsSpy).toHaveBeenCalledTimes(1);
+
+    expect((await app.request("/admin/api/memory/stats?accountId=acct&projectId=p2")).status).toBe(
+      200,
+    );
+    expect(statsSpy).toHaveBeenCalledTimes(2);
   });
 
   it("lists facts with default 'all' status visibility and supports filters", async () => {

--- a/apps/gateway/src/routes/admin/memory.ts
+++ b/apps/gateway/src/routes/admin/memory.ts
@@ -1,4 +1,9 @@
-import { buildReconciledFactBatch, MemoryFactContentHashConflictError } from "@helm/core";
+import {
+  buildReconciledFactBatch,
+  type MemoryAdminStats,
+  type MemoryAdminStatsScope,
+  MemoryFactContentHashConflictError,
+} from "@helm/core";
 import {
   effectiveMemoryProjectId,
   type FactListStatus,
@@ -21,6 +26,7 @@ import type { AdminApiDeps } from "./deps.js";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
+const MEMORY_STATS_CACHE_TTL_MS = 10_000;
 const FACT_STATUSES = new Set(["active", "superseded", "archived", "pruned", "all"]);
 const REFLECTION_STATUSES = new Set(["active", "archived", "all"]);
 
@@ -61,8 +67,31 @@ function scopeFromQuery(c: Context<AppEnv>): {
   return scope;
 }
 
+function statsScopeFromQuery(c: Context<AppEnv>): MemoryAdminStatsScope {
+  const accountId = c.req.query("accountId");
+  return {
+    ...(accountId !== undefined && accountId !== "" ? { accountId } : {}),
+    ...scopeFromQuery(c),
+  };
+}
+
+function memoryStatsCacheKey(scope: MemoryAdminStatsScope): string {
+  return [
+    scope.accountId ?? "",
+    scope.projectId ?? "",
+    scope.resourceId ?? "",
+    scope.threadId ?? "",
+  ].join("\u0000");
+}
+
+function statsJsonBody(stats: MemoryAdminStats): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(stats)) as Record<string, unknown>;
+}
+
 export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
   const estimateTokens = deps.estimateTokens ?? ((text: string) => Math.ceil(text.length / 4));
+  const statsCache = new Map<string, { expiresAt: number; body: Record<string, unknown> }>();
+  const clearStatsCache = () => statsCache.clear();
 
   // GET /memory/scopes — the "By Scope" tab: one row per (account,project,
   // resource,thread) group with fact/reflection counts + last-updated.
@@ -83,13 +112,15 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
     if (store.getMemoryAdminStats === undefined) {
       return c.json({ error: "memory stats unavailable" }, 503);
     }
-    const accountId = c.req.query("accountId");
-    const stats = await store.getMemoryAdminStats({
-      ...(accountId !== undefined && accountId !== "" ? { accountId } : {}),
-      ...scopeFromQuery(c),
-      now: new Date(),
-    });
-    return c.json(stats);
+    const scope = statsScopeFromQuery(c);
+    const key = memoryStatsCacheKey(scope);
+    const nowMs = Date.now();
+    const cached = statsCache.get(key);
+    if (cached !== undefined && cached.expiresAt > nowMs) return c.json(cached.body);
+    const stats = await store.getMemoryAdminStats({ ...scope, now: new Date() });
+    const body = statsJsonBody(stats);
+    statsCache.set(key, { expiresAt: nowMs + MEMORY_STATS_CACHE_TTL_MS, body });
+    return c.json(body);
   });
 
   // GET /memory/by-key/:keyId — resolve a key to its memory scope (account +
@@ -174,6 +205,7 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
     // can show it without a second round-trip; null only on a pure dedup (no new row).
     const createdId = res.insertedIds[0] ?? resurrected[0] ?? null;
     const fact = createdId !== null ? await store.getFactById({ accountId, id: createdId }) : null;
+    clearStatsCache();
     return c.json(
       {
         fact,
@@ -210,6 +242,7 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
         patch: parsed.data,
         now: new Date(),
       });
+      if (updated !== null) clearStatsCache();
       return updated === null ? c.json({ error: "fact not found" }, 404) : c.json(updated);
     } catch (e) {
       if (e instanceof MemoryFactContentHashConflictError) {
@@ -226,6 +259,7 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
     if (store instanceof Response) return store;
     const id = c.req.param("id");
     const deleted = await store.deleteFact({ accountId: accountOf(c, deps), id, now: new Date() });
+    if (deleted) clearStatsCache();
     return deleted ? c.json({ deleted: id }) : c.json({ error: "fact not found" }, 404);
   });
 
@@ -274,6 +308,7 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
       tokenEstimate: estimateTokens(parsed.data.reflectionText),
       now: new Date(),
     });
+    if (updated !== null) clearStatsCache();
     return updated === null ? c.json({ error: "reflection not found" }, 404) : c.json(updated);
   });
 
@@ -285,6 +320,7 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
     if (store instanceof Response) return store;
     const id = c.req.param("id");
     const deleted = await store.deleteReflection({ accountId: accountOf(c, deps), id });
+    if (deleted) clearStatsCache();
     return deleted ? c.json({ deleted: id }) : c.json({ error: "reflection not found" }, 404);
   });
 }

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -1,3 +1,9 @@
+import type {
+  RequestPayload,
+  RequestPayloadMeta,
+  RequestPayloadPart,
+  RequestPayloadPartRecord,
+} from "@helm/core";
 import { RequestsQuerySchema } from "@helm/shared";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
@@ -99,7 +105,34 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
   // parse them back so the SPA renders structured JSON, falling back to the raw
   // string if it was a non-JSON stream (assembled SSE).
   app.get("/admin/api/requests/:traceId/payload", async (c) => {
-    const p = await deps.telemetry.getPayload(c.req.param("traceId"));
+    const traceId = c.req.param("traceId");
+    const part = parsePayloadPart(c.req.query("part"));
+    if (part === "invalid") return c.json({ error: "invalid payload part" }, 400);
+    if (part === "meta") {
+      const meta = await getPayloadMeta(deps, traceId);
+      if (!meta) return c.json({ captured: false });
+      return c.json({
+        captured: true,
+        created_at: meta.createdAt.getTime(),
+        parts: {
+          request: meta.parts.request,
+          response: meta.parts.response,
+          upstream_request: meta.parts.upstreamRequest,
+        },
+      });
+    }
+    if (part !== "full") {
+      const p = await getPayloadPart(deps, traceId, part);
+      if (!p) return c.json({ captured: false });
+      return c.json({
+        captured: true,
+        part,
+        value: p.json === null ? null : parseMaybeJson(p.json),
+        created_at: p.createdAt.getTime(),
+      });
+    }
+
+    const p = await deps.telemetry.getPayload(traceId);
     if (!p) return c.json({ captured: false });
     return c.json({
       captured: true,
@@ -112,6 +145,58 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
       created_at: p.createdAt.getTime(),
     });
   });
+}
+
+type PayloadPartQuery = "full" | "meta" | RequestPayloadPart | "invalid";
+
+function parsePayloadPart(value: string | undefined): PayloadPartQuery {
+  if (value === undefined || value === "" || value === "full") return "full";
+  if (value === "meta") return "meta";
+  if (value === "request" || value === "response" || value === "upstream_request") return value;
+  return "invalid";
+}
+
+async function getPayloadMeta(
+  deps: AdminApiDeps,
+  requestId: string,
+): Promise<RequestPayloadMeta | null> {
+  if (deps.telemetry.getPayloadMeta) return deps.telemetry.getPayloadMeta(requestId);
+  const p = await deps.telemetry.getPayload(requestId);
+  return p ? metaFromPayload(p) : null;
+}
+
+function metaFromPayload(p: RequestPayload): RequestPayloadMeta {
+  return {
+    requestId: p.requestId,
+    createdAt: p.createdAt,
+    parts: {
+      request: p.requestJson !== null,
+      response: p.responseJson !== null,
+      upstreamRequest: p.upstreamRequestJson !== null,
+    },
+  };
+}
+
+async function getPayloadPart(
+  deps: AdminApiDeps,
+  requestId: string,
+  part: RequestPayloadPart,
+): Promise<RequestPayloadPartRecord | null> {
+  if (deps.telemetry.getPayloadPart) return deps.telemetry.getPayloadPart(requestId, part);
+  const p = await deps.telemetry.getPayload(requestId);
+  if (!p) return null;
+  return {
+    requestId: p.requestId,
+    part,
+    json: payloadPartJson(p, part),
+    createdAt: p.createdAt,
+  };
+}
+
+function payloadPartJson(p: RequestPayload, part: RequestPayloadPart): string | null {
+  if (part === "request") return p.requestJson;
+  if (part === "response") return p.responseJson;
+  return p.upstreamRequestJson;
 }
 
 // Parse stored JSON text back to a value; if it isn't valid JSON (e.g. assembled

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,15 @@
 
 ---
 
+## 2026-07-06 · Admin 请求详情 payload 改为分段懒加载（Admin requests performance，docs/07/11，原则 1/7）
+
+- **背景（Lukin）**：线上 `/admin/requests/:traceId` 详情页会在首屏同时拉完整 request/response/upstream payload；部分记录超过 1MB，经公网和未压缩 JSON 传输后容易出现长时间白屏/卡顿。
+- **接口决策**：保留原 `/admin/api/requests/:traceId/payload` 全量兼容；新增 `?part=meta` 只返回捕获状态与三个分段是否存在，`?part=request|response|upstream_request` 只返回单段正文。SQLite/Postgres adapter 实现轻量读取，老 adapter 通过 `getPayload()` fallback。
+- **UI 决策**：详情页 loader 只取 meta；Conversation/Raw/Response/Forwarded upstream/Retry 在用户点击时才按需取对应分段。这样列表到详情的首屏不再被大 payload 阻塞，同时保留完整审计正文查看能力。
+- **memory stats 决策**：`/admin/api/memory/stats` 增加 10 秒按 scope 短缓存；管理员写入/编辑/删除 facts/reflections 后清缓存，避免重复刷新扫统计表。返回语义不变。
+- **保留策略**：`payload_retention_days` 继续保持 **3 天**；本次不把它降到 1 天（Lukin 明确要求）。
+- **验证计划**：覆盖 gateway payload meta/part、SQLite/Postgres store contract、admin loader 懒加载 UI、memory stats cache；发布后用线上 API timing、gzip 响应头和浏览器网络请求确认。
+
 ## 2026-07-06 · 纯工具 turn 去掉空 header 行 + peek 收到 3 行（Admin conversation view，docs/11，原则 1）
 
 - **背景（Lukin）**：默认展开后，纯工具 turn 在工具块上方还多渲染一条近乎空的折叠 header 行（`▾ ● { }`：caret+role dot+空 preview+源码切换），很丑；另外 output peek 6 行太多。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.10",
+  "version": "0.25.11",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -776,6 +776,8 @@ export type {
   InsertPayloadInput,
   InsertTelemetryInput,
   KeyStore,
+  MemoryAdminStats,
+  MemoryAdminStatsScope,
   MemoryJobStatus,
   MemoryStore,
   OAuthQuotaStore,
@@ -785,6 +787,9 @@ export type {
   RateLimitConsumeResult,
   RateLimitStore,
   RequestPayload,
+  RequestPayloadMeta,
+  RequestPayloadPart,
+  RequestPayloadPartRecord,
   SignalStore,
   TelemetryStore,
 } from "./store/ports.js";

--- a/packages/core/src/memory/forgetting/facts.test.ts
+++ b/packages/core/src/memory/forgetting/facts.test.ts
@@ -61,7 +61,7 @@ describe("buildReconciledFactBatch blob guard (no base64/image facts)", () => {
   const base = { ownerId: "acct", scope: {}, cap: 8, fallbackNow: new Date("2026-06-26") };
 
   it("drops a candidate whose text is a long whitespace-free blob", () => {
-    const blob = "data:image/jpeg;base64," + "ABCD".repeat(300); // no spaces, ~1200 chars
+    const blob = `data:image/jpeg;base64,${"ABCD".repeat(300)}`; // no spaces, ~1200 chars
     const facts = buildReconciledFactBatch({
       ...base,
       extracted: [{ subjectText: "img", factText: blob }],

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -290,6 +290,25 @@ export interface RequestPayload {
   createdAt: Date;
 }
 
+export type RequestPayloadPart = "request" | "response" | "upstream_request";
+
+export interface RequestPayloadMeta {
+  requestId: string;
+  createdAt: Date;
+  parts: {
+    request: boolean;
+    response: boolean;
+    upstreamRequest: boolean;
+  };
+}
+
+export interface RequestPayloadPartRecord {
+  requestId: string;
+  part: RequestPayloadPart;
+  json: string | null;
+  createdAt: Date;
+}
+
 // One telemetry row as exported by the archive scan — engine-neutral and
 // JSON-serializable (createdAt is epoch ms, the decision is the parsed record),
 // so both the sqlite and pg adapters yield byte-identical archive lines. `id` is
@@ -501,6 +520,14 @@ export interface TelemetryStore {
   // backfill the assembled response). Stores verbatim bodies — never redacted.
   insertPayload(input: InsertPayloadInput): Promise<void>;
   getPayload(requestId: string): Promise<RequestPayload | null>;
+  // Lightweight admin detail reads. These are optional so older test doubles and
+  // custom adapters can fall back to getPayload(), but real adapters implement them
+  // to avoid rehydrating/transmitting every captured body on initial page load.
+  getPayloadMeta?(requestId: string): Promise<RequestPayloadMeta | null>;
+  getPayloadPart?(
+    requestId: string,
+    part: RequestPayloadPart,
+  ): Promise<RequestPayloadPartRecord | null>;
   // Delete payloads with createdAt strictly older than the cutoff (epoch ms).
   // Drives payload_retention_days auto-prune; safe to call opportunistically.
   prunePayloads(olderThanMs: number): Promise<void>;

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -9,6 +9,9 @@ import type {
   RecentDecisionRecord,
   RequestPayload,
   RequestPayloadArchiveRow,
+  RequestPayloadMeta,
+  RequestPayloadPart,
+  RequestPayloadPartRecord,
   TelemetryAggregate,
   TelemetryArchiveRow,
   TelemetryKeyUsage,
@@ -411,6 +414,61 @@ export class PgTelemetryStore implements TelemetryStore {
       responseJson: decode(row.responseJson),
       upstreamRequestJson: decode(row.upstreamRequestJson) ?? null,
       createdAt: new Date(row.createdAt), // epoch-ms bigint → Date
+    };
+  }
+
+  async getPayloadMeta(requestId: string): Promise<RequestPayloadMeta | null> {
+    const rows = await this.db
+      .select({
+        requestId: requestPayloads.requestId,
+        hasRequest: sql<boolean>`${requestPayloads.requestJson} IS NOT NULL`,
+        hasResponse: sql<boolean>`${requestPayloads.responseJson} IS NOT NULL`,
+        hasUpstream: sql<boolean>`${requestPayloads.upstreamRequestJson} IS NOT NULL`,
+        createdAt: requestPayloads.createdAt,
+      })
+      .from(requestPayloads)
+      .where(eq(requestPayloads.requestId, requestId))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      requestId: row.requestId,
+      createdAt: new Date(row.createdAt),
+      parts: {
+        request: row.hasRequest,
+        response: row.hasResponse,
+        upstreamRequest: row.hasUpstream,
+      },
+    };
+  }
+
+  async getPayloadPart(
+    requestId: string,
+    part: RequestPayloadPart,
+  ): Promise<RequestPayloadPartRecord | null> {
+    const column =
+      part === "request"
+        ? requestPayloads.requestJson
+        : part === "response"
+          ? requestPayloads.responseJson
+          : requestPayloads.upstreamRequestJson;
+    const rows = await this.db
+      .select({
+        requestId: requestPayloads.requestId,
+        value: column,
+        createdAt: requestPayloads.createdAt,
+      })
+      .from(requestPayloads)
+      .where(eq(requestPayloads.requestId, requestId))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    const decode = await this.rehydrateColumns([row.value]);
+    return {
+      requestId: row.requestId,
+      part,
+      json: decode(row.value),
+      createdAt: new Date(row.createdAt),
     };
   }
 

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -10,6 +10,9 @@ import type {
   RecentDecisionRecord,
   RequestPayload,
   RequestPayloadArchiveRow,
+  RequestPayloadMeta,
+  RequestPayloadPart,
+  RequestPayloadPartRecord,
   TelemetryAggregate,
   TelemetryArchiveRow,
   TelemetryKeyUsage,
@@ -318,6 +321,27 @@ export class SqliteTelemetryStore implements TelemetryStore {
         `SELECT request_json AS req, response_json AS resp, upstream_request_json AS up, created_at AS ts
          FROM request_payloads WHERE request_id = ?`,
       ),
+      getMeta: db.prepare(
+        `SELECT
+           request_id AS id,
+           request_json IS NOT NULL AS hasReq,
+           response_json IS NOT NULL AS hasResp,
+           upstream_request_json IS NOT NULL AS hasUp,
+           created_at AS ts
+         FROM request_payloads WHERE request_id = ?`,
+      ),
+      getRequestPart: db.prepare(
+        `SELECT request_id AS id, request_json AS value, created_at AS ts
+         FROM request_payloads WHERE request_id = ?`,
+      ),
+      getResponsePart: db.prepare(
+        `SELECT request_id AS id, response_json AS value, created_at AS ts
+         FROM request_payloads WHERE request_id = ?`,
+      ),
+      getUpstreamPart: db.prepare(
+        `SELECT request_id AS id, upstream_request_json AS value, created_at AS ts
+         FROM request_payloads WHERE request_id = ?`,
+      ),
       getBlob: db.prepare("SELECT bytes FROM payload_blobs WHERE sha256 = ?"),
     };
   }
@@ -390,6 +414,42 @@ export class SqliteTelemetryStore implements TelemetryStore {
       requestJson: this.decodeColumn(row.req) ?? "",
       responseJson: this.decodeColumn(row.resp),
       upstreamRequestJson: this.decodeColumn(row.up),
+      createdAt: new Date(row.ts),
+    };
+  }
+
+  async getPayloadMeta(requestId: string): Promise<RequestPayloadMeta | null> {
+    const row = this.stmts().getMeta.get(requestId) as
+      | { id: string; hasReq: number; hasResp: number; hasUp: number; ts: number }
+      | undefined;
+    if (!row) return null;
+    return {
+      requestId: row.id,
+      createdAt: new Date(row.ts),
+      parts: {
+        request: row.hasReq === 1,
+        response: row.hasResp === 1,
+        upstreamRequest: row.hasUp === 1,
+      },
+    };
+  }
+
+  async getPayloadPart(
+    requestId: string,
+    part: RequestPayloadPart,
+  ): Promise<RequestPayloadPartRecord | null> {
+    const stmt =
+      part === "request"
+        ? this.stmts().getRequestPart
+        : part === "response"
+          ? this.stmts().getResponsePart
+          : this.stmts().getUpstreamPart;
+    const row = stmt.get(requestId) as { id: string; value: unknown; ts: number } | undefined;
+    if (!row) return null;
+    return {
+      requestId: row.id,
+      part,
+      json: this.decodeColumn(row.value),
       createdAt: new Date(row.ts),
     };
   }

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -1227,6 +1227,17 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(got?.responseJson).toBe(responseJson);
       expect(got?.upstreamRequestJson).toBe(upstreamRequestJson);
       expect(got?.createdAt.getTime()).toBe(5000);
+      expect(await ctx.stores.telemetry.getPayloadMeta?.("req_1")).toEqual({
+        requestId: "req_1",
+        createdAt: new Date(5000),
+        parts: { request: true, response: true, upstreamRequest: true },
+      });
+      expect(await ctx.stores.telemetry.getPayloadPart?.("req_1", "response")).toEqual({
+        requestId: "req_1",
+        part: "response",
+        json: responseJson,
+        createdAt: new Date(5000),
+      });
       expect(await ctx.stores.telemetry.getPayload("nope")).toBeNull();
     });
 


### PR DESCRIPTION
## Summary
- add lightweight payload meta/part APIs for request detail pages
- load request/response/upstream payload bodies only on demand in the admin detail UI
- add a short per-scope cache for /admin/api/memory/stats
- keep payload_retention_days at 3 days and bump release version to 0.25.10

## Verification
- pnpm test -- apps/gateway/src/routes/admin/admin.test.ts apps/gateway/src/routes/admin/memory.test.ts apps/admin/src/routes/requests/requests.test.ts packages/core/src/store/store-contract.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build