### PR TITLE
Add per-key model blacklist

### DIFF
--- a/apps/admin/src/lib/api/keys.test.ts
+++ b/apps/admin/src/lib/api/keys.test.ts
@@ -29,6 +29,7 @@ function summaryRow(
     role: 'user',
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,
@@ -119,6 +120,7 @@ describe('keys api client', () => {
       role: 'user',
       allowed_lanes: ['economy', 'balanced'],
       allow_custom_model: false,
+      blocked_models: ['gpt-4o'],
       allow_fast_mode: true,
     });
 
@@ -129,6 +131,7 @@ describe('keys api client', () => {
     expect(body.role).toBe('user');
     expect(body.allowed_lanes).toEqual(['economy', 'balanced']);
     expect(body.allow_custom_model).toBe(false);
+    expect(body.blocked_models).toEqual(['gpt-4o']);
     expect(body.allow_fast_mode).toBe(true);
     expect(result.key_id).toBe('key_1');
     expect(result.plaintext).toBe('helm_live_SECRET_ONCE');
@@ -150,7 +153,18 @@ describe('keys api client', () => {
     const body = JSON.parse(init.body as string);
     expect(body).not.toHaveProperty('max_lane');
     expect(body).not.toHaveProperty('allowed_lanes');
+    expect(body).not.toHaveProperty('blocked_models');
     expect(body.role).toBe('user');
+  });
+
+  it('listKeys surfaces blocked model ids as null-or-array', async () => {
+    const rows = [summaryRow('k1'), summaryRow('k2', { blocked_models: ['gpt-4o'] })];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(rows), { status: 200 }),
+    );
+    const keys = await listKeys();
+    expect(keys[0].blocked_models).toBeNull();
+    expect(keys[1].blocked_models).toEqual(['gpt-4o']);
   });
 
   it('listKeys surfaces per-key rate limits (null = inherit, number = override)', async () => {
@@ -267,6 +281,7 @@ describe('keys api client', () => {
     await updateKey('key_1', {
       allowed_lanes: ['economy', 'balanced'],
       allow_custom_model: true,
+      blocked_models: ['gpt-4o'],
       allow_fast_mode: true,
       rate_limit_rpm: null,
       rate_limit_tpm: 100,
@@ -277,6 +292,7 @@ describe('keys api client', () => {
     const body = JSON.parse(init.body as string);
     expect(body.allowed_lanes).toEqual(['economy', 'balanced']);
     expect(body.allow_custom_model).toBe(true);
+    expect(body.blocked_models).toEqual(['gpt-4o']);
     expect(body.allow_fast_mode).toBe(true);
     expect(body.rate_limit_rpm).toBeNull(); // explicit null = clear
     expect(body.rate_limit_tpm).toBe(100);
@@ -290,6 +306,16 @@ describe('keys api client', () => {
     const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     const body = JSON.parse(init.body as string);
     expect(body.allowed_lanes).toBeNull();
+  });
+
+  it('updateKey forwards null to clear the blocked-model blacklist', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ key_id: 'key_1' }), { status: 200 }),
+    );
+    await updateKey('key_1', { blocked_models: null });
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.blocked_models).toBeNull();
   });
 
   it('updateKey rejects on a non-2xx response (404)', async () => {

--- a/apps/admin/src/lib/api/keys.ts
+++ b/apps/admin/src/lib/api/keys.ts
@@ -17,6 +17,7 @@ export interface ApiKeyView {
   name: string | null; // human-readable label; null = unnamed (cosmetic only)
   allowed_lanes: string[] | null; // lane whitelist (empty/null = any lane)
   allow_custom_model: boolean; // explicit client-model passthrough
+  blocked_models: string[] | null; // exact model ids denied across direct and lane routes
   allow_fast_mode: boolean; // explicit client-requested Fast mode passthrough
   disabled: boolean; // revoked state (soft)
   rate_limit_rpm: number | null; // per-key RPM override; null = inherit system default
@@ -49,6 +50,7 @@ export interface CreateKeyInput {
   name?: string;
   allowed_lanes?: string[];
   allow_custom_model?: boolean;
+  blocked_models?: string[];
   allow_fast_mode?: boolean;
   // Optional per-key rate limits at mint time. Omitted => inherit the system
   // default. 0 => explicitly unlimited for that dimension.
@@ -81,6 +83,7 @@ export interface UpdateKeyInput {
   name?: string | null;
   allowed_lanes?: string[] | null;
   allow_custom_model?: boolean;
+  blocked_models?: string[] | null;
   allow_fast_mode?: boolean;
   rate_limit_rpm?: number | null;
   rate_limit_tpm?: number | null;
@@ -177,6 +180,7 @@ async function asJson<T>(res: Response): Promise<T> {
 // leak a secret even if the server response ever changed shape (defence in depth).
 function normalizeView(raw: Record<string, unknown>): ApiKeyView {
   const allowed = raw.allowed_lanes;
+  const blocked = raw.blocked_models;
   return {
     key_id: String(raw.key_id ?? ''),
     prefix: String(raw.prefix ?? ''),
@@ -186,6 +190,7 @@ function normalizeView(raw: Record<string, unknown>): ApiKeyView {
     name: typeof raw.name === 'string' && raw.name.trim().length > 0 ? raw.name.trim() : null,
     allowed_lanes: Array.isArray(allowed) ? allowed.map(String) : null,
     allow_custom_model: raw.allow_custom_model === true,
+    blocked_models: Array.isArray(blocked) ? blocked.map(String) : null,
     allow_fast_mode: raw.allow_fast_mode === true,
     disabled: raw.disabled === true,
     // null/absent = inherit system default; a finite number (incl. 0) = override.
@@ -218,6 +223,9 @@ function toServerBody(input: CreateKeyInput): Record<string, unknown> {
   }
   if (input.allow_custom_model !== undefined) {
     out.allow_custom_model = input.allow_custom_model;
+  }
+  if (input.blocked_models && input.blocked_models.length > 0) {
+    out.blocked_models = input.blocked_models;
   }
   if (input.allow_fast_mode !== undefined) {
     out.allow_fast_mode = input.allow_fast_mode;

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -59,6 +59,7 @@
     const trimmedName = name.trim();
     if (trimmedName.length > 0) input.name = trimmedName;
     if (form.allowedLanes.length > 0) input.allowed_lanes = [...form.allowedLanes];
+    if (form.blockedModels.length > 0) input.blocked_models = [...form.blockedModels];
     // Send a rate limit only when the operator set one; blank => inherit default.
     // `!= null` also catches the `undefined` Svelte 5 gives an emptied number input.
     if (form.rpm != null) input.rate_limit_rpm = form.rpm;
@@ -113,6 +114,7 @@
         name: name.trim().length > 0 ? name.trim() : null,
         allowed_lanes: form.allowedLanes.length > 0 ? [...form.allowedLanes] : null,
         allow_custom_model: form.allowCustomModel,
+        blocked_models: form.blockedModels.length > 0 ? [...form.blockedModels] : null,
         allow_fast_mode: form.allowFastMode,
         disabled: false,
         rate_limit_rpm: form.rpm ?? null,

--- a/apps/admin/src/lib/components/CreateKeyDialog.test.ts
+++ b/apps/admin/src/lib/components/CreateKeyDialog.test.ts
@@ -41,6 +41,9 @@ describe('CreateKeyDialog', () => {
     // Tick a subset of lanes; the whitelist is the only lane cap (no max-lane field).
     await fireEvent.click(screen.getByLabelText('economy'));
     await fireEvent.click(screen.getByLabelText('balanced'));
+    await fireEvent.input(screen.getByLabelText('Blocked models'), {
+      target: { value: 'gpt-4o\nanthropic/claude-sonnet-4-6' },
+    });
     await fireEvent.click(screen.getByLabelText('allow client-requested Fast mode'));
     // allow_custom_model defaults to false; leave that checkbox unchecked.
     await fireEvent.click(screen.getByRole('button', { name: /create key/i }));
@@ -48,6 +51,7 @@ describe('CreateKeyDialog', () => {
     await waitFor(() => expect(createKey).toHaveBeenCalledTimes(1));
     const input = createKey.mock.calls[0][0];
     expect(input.allowed_lanes).toEqual(['economy', 'balanced']);
+    expect(input.blocked_models).toEqual(['gpt-4o', 'anthropic/claude-sonnet-4-6']);
     expect(input.allow_custom_model).toBe(false);
     expect(input.allow_fast_mode).toBe(true);
   });

--- a/apps/admin/src/lib/components/EditKeyDialog.svelte
+++ b/apps/admin/src/lib/components/EditKeyDialog.svelte
@@ -46,6 +46,7 @@
       name: name.trim().length > 0 ? name.trim() : null,
       allowed_lanes: form.allowedLanes.length > 0 ? [...form.allowedLanes] : null,
       allow_custom_model: form.allowCustomModel,
+      blocked_models: form.blockedModels.length > 0 ? [...form.blockedModels] : null,
       allow_fast_mode: form.allowFastMode,
       rate_limit_rpm: form.rpm ?? null,
       rate_limit_tpm: form.tpm ?? null,
@@ -68,6 +69,7 @@
         name: patch.name ?? null,
         allowed_lanes: patch.allowed_lanes ?? null,
         allow_custom_model: form.allowCustomModel,
+        blocked_models: patch.blocked_models ?? null,
         allow_fast_mode: form.allowFastMode,
         rate_limit_rpm: patch.rate_limit_rpm ?? null,
         rate_limit_tpm: patch.rate_limit_tpm ?? null,
@@ -128,7 +130,9 @@
         bind:value={name}
       />
       <span class="field-help"
-        >{$t('A label to help you recognize this key later — e.g. the project it belongs to.')}</span
+        >{$t(
+          'A label to help you recognize this key later — e.g. the project it belongs to.',
+        )}</span
       >
     </label>
 

--- a/apps/admin/src/lib/components/KeyCapsForm.svelte
+++ b/apps/admin/src/lib/components/KeyCapsForm.svelte
@@ -7,6 +7,7 @@
   export type KeyCaps = {
     allowedLanes: string[];
     allowCustomModel: boolean;
+    blockedModels: string[];
     allowFastMode: boolean;
     rpm: number | null;
     tpm: number | null;
@@ -27,6 +28,7 @@
     return {
       allowedLanes: [],
       allowCustomModel: false,
+      blockedModels: [],
       allowFastMode: false,
       rpm: null,
       tpm: null,
@@ -50,6 +52,7 @@
     return {
       allowedLanes: [...(key.allowed_lanes ?? [])],
       allowCustomModel: key.allow_custom_model,
+      blockedModels: [...(key.blocked_models ?? [])],
       allowFastMode: key.allow_fast_mode,
       rpm: key.rate_limit_rpm,
       tpm: key.rate_limit_tpm,
@@ -64,6 +67,18 @@
       memoryProject: key.memory_project_id ?? '',
       memoryThreadSource: key.memory_thread_source,
     };
+  }
+
+  export function parseBlockedModels(value: string): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of value.split(/[\n,;]+/)) {
+      const model = raw.trim();
+      if (model.length === 0 || seen.has(model)) continue;
+      seen.add(model);
+      out.push(model);
+    }
+    return out;
   }
 </script>
 
@@ -111,6 +126,10 @@
     form.allowedLanes = checked
       ? [...form.allowedLanes, lane]
       : form.allowedLanes.filter((l) => l !== lane);
+  }
+
+  function updateBlockedModels(value: string): void {
+    form.blockedModels = parseBlockedModels(value);
   }
 
   // One-line state recaps shown on the closed section headers.
@@ -199,6 +218,23 @@
     )}</span
   >
 </div>
+
+<label class="flex flex-col gap-1 text-sm">
+  <span class="field-label">{$t('Blocked models')}</span>
+  <textarea
+    rows="3"
+    aria-label={$t('Blocked models')}
+    placeholder={$t('One model id per line')}
+    class="input min-h-20 resize-y"
+    value={form.blockedModels.join('\n')}
+    oninput={(e) => updateBlockedModels(e.currentTarget.value)}
+  ></textarea>
+  <span class="field-help"
+    >{$t(
+      'Blocks exact model ids for this key across direct model requests and all lane/fallback routes.',
+    )}</span
+  >
+</label>
 
 <div class="flex flex-col gap-1">
   <label class="checkbox-field">

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -55,6 +55,7 @@ function keyView(overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     name: 'Prod backend',
     allowed_lanes: ['balanced'],
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -30,6 +30,7 @@ function key(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,
@@ -365,6 +366,9 @@ describe('keys page', () => {
     await fireEvent.input(within(dialog).getByLabelText(/requests per minute/i), {
       target: { value: '120' },
     });
+    await fireEvent.input(within(dialog).getByLabelText('Blocked models'), {
+      target: { value: 'gpt-4o' },
+    });
     await fireEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
     await waitFor(() =>
       expect(updateKey).toHaveBeenCalledWith('k1', {
@@ -372,6 +376,7 @@ describe('keys page', () => {
         name: null,
         allowed_lanes: ['economy'],
         allow_custom_model: false,
+        blocked_models: ['gpt-4o'],
         allow_fast_mode: false,
         rate_limit_rpm: 120,
         rate_limit_tpm: null, // untouched → still inherit (null), not undefined

--- a/apps/admin/src/routes/memory/memory.test.ts
+++ b/apps/admin/src/routes/memory/memory.test.ts
@@ -91,6 +91,7 @@ function key(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -92,6 +92,7 @@ function apiKey(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView 
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/middleware/auth.test.ts
+++ b/apps/gateway/src/middleware/auth.test.ts
@@ -15,6 +15,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: ["economy", "balanced"],
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/middleware/auth.ts
+++ b/apps/gateway/src/middleware/auth.ts
@@ -17,6 +17,7 @@ export interface AuthIdentity {
   caps: {
     allowedLanes: string[] | null;
     allowCustomModel: boolean;
+    blockedModels: string[] | null;
     /** Per-key cap for client-requested Fast mode passthrough. Account-level Fast
      *  mode can still be forced by subscription account settings. */
     allowFastMode: boolean;
@@ -105,6 +106,7 @@ export function authMiddleware(deps: AuthDeps): MiddlewareHandler {
       caps: {
         allowedLanes: record.allowed_lanes,
         allowCustomModel: record.allow_custom_model,
+        blockedModels: record.blocked_models,
         allowFastMode: record.allow_fast_mode,
         rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
         concurrencyLimit: record.concurrency_limit,

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -88,6 +88,7 @@ function makeKeyStore(): KeyStore & { rows: TestKeyRecord[] } {
         name: input.name ?? null,
         allowed_lanes: input.allowedLanes ?? null,
         allow_custom_model: input.allowCustomModel ?? false,
+        blocked_models: input.blockedModels ?? null,
         allow_fast_mode: input.allowFastMode ?? false,
         disabled: false,
         rate_limit_rpm: input.rateLimitRpm ?? null,
@@ -131,6 +132,7 @@ function makeKeyStore(): KeyStore & { rows: TestKeyRecord[] } {
       if (patch.name !== undefined) row.name = patch.name;
       if (patch.allowedLanes !== undefined) row.allowed_lanes = patch.allowedLanes;
       if (patch.allowCustomModel !== undefined) row.allow_custom_model = patch.allowCustomModel;
+      if (patch.blockedModels !== undefined) row.blocked_models = patch.blockedModels;
       if (patch.allowFastMode !== undefined) row.allow_fast_mode = patch.allowFastMode;
       if (patch.rateLimitRpm !== undefined) row.rate_limit_rpm = patch.rateLimitRpm;
       if (patch.rateLimitTpm !== undefined) row.rate_limit_tpm = patch.rateLimitTpm;
@@ -610,7 +612,11 @@ describe("admin.api keys", () => {
     const created = await app.request("/admin/api/keys", {
       method: "POST",
       headers: JSON_HEADERS,
-      body: JSON.stringify({ role: "user", allowed_lanes: ["balanced"] }),
+      body: JSON.stringify({
+        role: "user",
+        allowed_lanes: ["balanced"],
+        blocked_models: ["gpt-4o"],
+      }),
     });
     expect(created.status).toBe(201);
     const body = (await created.json()) as { key_id: string; plaintext: string; prefix: string };
@@ -622,6 +628,7 @@ describe("admin.api keys", () => {
     // Stored as hash + prefix plus encrypted recovery material — never plaintext.
     expect(keyStore.rows[0]?.hash).toBe("hash_of_plaintext_full");
     expect(keyStore.rows[0]?.secret_enc).toMatch(/^enc:/);
+    expect(keyStore.rows[0]?.blocked_models).toEqual(["gpt-4o"]);
     expect(JSON.stringify(keyStore.rows[0])).not.toContain("PLAINTEXT_SECRET");
     expect(keyStore.rows[0]?.memory_mode).toBe("off");
     expect(keyStore.rows[0]?.memory_thread_source).toBe("auto");
@@ -633,6 +640,7 @@ describe("admin.api keys", () => {
     expect(raw).not.toContain("PLAINTEXT_SECRET");
     expect(raw).not.toContain("hash_of_plaintext_full"); // no hash full-text
     expect(list[0]?.prefix).toBe("helm_live_PLAI");
+    expect(list[0]?.blocked_models).toEqual(["gpt-4o"]);
     expect(list[0]).not.toHaveProperty("hash");
     expect(list[0]).not.toHaveProperty("plaintext");
     expect(list[0]).not.toHaveProperty("secret_enc");
@@ -852,7 +860,7 @@ describe("admin.api keys", () => {
     expect(keyStore.rows[0]?.rate_limit_tpm).toBe(5000);
   });
 
-  it("PATCH edits a key's caps (allowed_lanes, allow_custom_model, allow_fast_mode; null clears)", async () => {
+  it("PATCH edits a key's caps (allowed_lanes, blocked_models, allow_custom_model, allow_fast_mode; null clears)", async () => {
     const deps = buildDeps();
     const app = buildApp(deps);
     await app.request("/admin/api/keys", {
@@ -866,12 +874,14 @@ describe("admin.api keys", () => {
       body: JSON.stringify({
         allowed_lanes: ["economy", "balanced"],
         allow_custom_model: true,
+        blocked_models: ["gpt-4o"],
         allow_fast_mode: true,
       }),
     });
     expect(set.status).toBe(200);
     expect(keyStore.rows[0]?.allowed_lanes).toEqual(["economy", "balanced"]);
     expect(keyStore.rows[0]?.allow_custom_model).toBe(true);
+    expect(keyStore.rows[0]?.blocked_models).toEqual(["gpt-4o"]);
     expect(keyStore.rows[0]?.allow_fast_mode).toBe(true);
     expect(keyStore.rows[0]?.rate_limit_rpm).toBe(7); // unrelated field untouched
     expect(keyStore.rows[0]?.role).toBe("user"); // role never rewritten
@@ -879,10 +889,11 @@ describe("admin.api keys", () => {
     const clear = await app.request("/admin/api/keys/key_1", {
       method: "PATCH",
       headers: JSON_HEADERS,
-      body: JSON.stringify({ allowed_lanes: null }),
+      body: JSON.stringify({ allowed_lanes: null, blocked_models: null }),
     });
     expect(clear.status).toBe(200);
     expect(keyStore.rows[0]?.allowed_lanes).toBeNull();
+    expect(keyStore.rows[0]?.blocked_models).toBeNull();
     expect(keyStore.rows[0]?.allow_custom_model).toBe(true); // omitted → untouched
     expect(keyStore.rows[0]?.allow_fast_mode).toBe(true); // omitted → untouched
   });

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -469,6 +469,7 @@ export interface KeySummary {
   name: string | null;
   allowed_lanes: string[] | null;
   allow_custom_model: boolean;
+  blocked_models: string[] | null;
   allow_fast_mode: boolean;
   disabled: boolean;
   // Per-key rate-limit override (docs/06). null = inherit the system default; a

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -32,6 +32,7 @@ function toSummary(rec: {
   name: string | null;
   allowed_lanes: string[] | null;
   allow_custom_model: boolean;
+  blocked_models: string[] | null;
   allow_fast_mode: boolean;
   disabled: boolean;
   rate_limit_rpm: number | null;
@@ -54,6 +55,7 @@ function toSummary(rec: {
     name: rec.name,
     allowed_lanes: rec.allowed_lanes,
     allow_custom_model: rec.allow_custom_model,
+    blocked_models: rec.blocked_models,
     allow_fast_mode: rec.allow_fast_mode,
     disabled: rec.disabled,
     rate_limit_rpm: rec.rate_limit_rpm,
@@ -193,6 +195,7 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       name: parsed.data.name,
       allowedLanes: parsed.data.allowed_lanes,
       allowCustomModel: parsed.data.allow_custom_model ?? false,
+      blockedModels: parsed.data.blocked_models,
       allowFastMode: parsed.data.allow_fast_mode ?? false,
       rateLimitRpm: parsed.data.rate_limit_rpm,
       rateLimitTpm: parsed.data.rate_limit_tpm,
@@ -244,6 +247,7 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       name?: string | null;
       allowedLanes?: string[] | null;
       allowCustomModel?: boolean;
+      blockedModels?: string[] | null;
       allowFastMode?: boolean;
       rateLimitRpm?: number | null;
       rateLimitTpm?: number | null;
@@ -261,6 +265,7 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
     if (d.name !== undefined) patch.name = d.name;
     if (d.allowed_lanes !== undefined) patch.allowedLanes = d.allowed_lanes;
     if (d.allow_custom_model !== undefined) patch.allowCustomModel = d.allow_custom_model;
+    if (d.blocked_models !== undefined) patch.blockedModels = d.blocked_models;
     if (d.allow_fast_mode !== undefined) patch.allowFastMode = d.allow_fast_mode;
     if (d.rate_limit_rpm !== undefined) patch.rateLimitRpm = d.rate_limit_rpm;
     if (d.rate_limit_tpm !== undefined) patch.rateLimitTpm = d.rate_limit_tpm;

--- a/apps/gateway/src/routes/admin/replay.test.ts
+++ b/apps/gateway/src/routes/admin/replay.test.ts
@@ -18,6 +18,7 @@ function fakeKey(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,
@@ -222,7 +223,7 @@ describe("runReplay", () => {
     expect(call?.opts).toEqual({
       allowCustomModel: false,
       keyPrefix: "helm_live_ab12",
-      keyCaps: { allowedLanes: null, degradeLane: null },
+      keyCaps: { allowedLanes: null, degradeLane: null, blockedModels: null },
     });
   });
 
@@ -329,7 +330,7 @@ describe("runReplay", () => {
     expect(rec.routeCalls[0]?.opts).toEqual({
       allowCustomModel: true,
       keyPrefix: "helm_live_root",
-      keyCaps: { allowedLanes: null, degradeLane: null },
+      keyCaps: { allowedLanes: null, degradeLane: null, blockedModels: null },
     });
     expect(rec.routeCalls[0]?.req.api_key_id).toBe("k_root");
     // Telemetry attributes the replay to the key ACTUALLY used.

--- a/apps/gateway/src/routes/admin/replay.ts
+++ b/apps/gateway/src/routes/admin/replay.ts
@@ -213,7 +213,11 @@ async function replayOpenAIChat(
     {
       allowCustomModel: key.allow_custom_model,
       keyPrefix: key.prefix,
-      keyCaps: { allowedLanes: key.allowed_lanes, degradeLane: null },
+      keyCaps: {
+        allowedLanes: key.allowed_lanes,
+        degradeLane: null,
+        blockedModels: key.blocked_models,
+      },
     },
     args.signal,
   );
@@ -348,6 +352,7 @@ async function replayViaPipeline(
       allowCustomModel: key.allow_custom_model,
       allowFastMode: key.allow_fast_mode,
       allowedLanes: key.allowed_lanes,
+      blockedModels: key.blocked_models,
     },
   };
 

--- a/apps/gateway/src/routes/chat.errors.test.ts
+++ b/apps/gateway/src/routes/chat.errors.test.ts
@@ -34,6 +34,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/routes/chat.inject.test.ts
+++ b/apps/gateway/src/routes/chat.inject.test.ts
@@ -31,6 +31,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/routes/chat.memory.test.ts
+++ b/apps/gateway/src/routes/chat.memory.test.ts
@@ -30,6 +30,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -26,6 +26,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/routes/chat.session-key.test.ts
+++ b/apps/gateway/src/routes/chat.session-key.test.ts
@@ -33,6 +33,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -225,6 +225,7 @@ interface ChatIdentity {
     allowCustomModel: boolean;
     allowFastMode?: boolean;
     allowedLanes?: string[] | null;
+    blockedModels?: string[] | null;
     budget?: BudgetCaps;
     /** Per-key memory defaults (issue #97); absent = memory off unless headers say otherwise. */
     memory?: MemoryKeyDefaults;
@@ -716,6 +717,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
           // Forced degrade lane: set only when the key is over budget AND its
           // behavior is "degrade" (docs/06). null = no degrade for this request.
           degradeLane,
+          blockedModels: identity.caps?.blockedModels ?? null,
         },
       },
       c.req.raw.signal,

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -138,6 +138,90 @@ describe("registerImagesRoute", () => {
     expect(res.status).toBe(401);
   });
 
+  it("rejects a direct image model that is blocked for the key", async () => {
+    const { app, imageGeneration, enqueueTelemetry } = setup({
+      auth: {
+        resolve: async (cred) =>
+          cred === "k"
+            ? ({
+                keyId: "key1",
+                accountId: "acct",
+                keyPrefix: "helm_live_xy",
+                caps: { budget: BUDGET_CAPS, blockedModels: ["gpt-image-2"] },
+              } as MessagesIdentity)
+            : null,
+      },
+    });
+
+    const res = await post(app, { model: "gpt-image-2", prompt: "x" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string; code: string } };
+    expect(body.error.message).toContain("blocked for this key");
+    expect(body.error.code).toBe("model_blocked");
+    expect(imageGeneration).not.toHaveBeenCalled();
+    expect(enqueueTelemetry).not.toHaveBeenCalled();
+  });
+
+  it("removes blocked image candidates from an image lane before fallback execution", async () => {
+    const blockedImageGeneration = vi.fn().mockResolvedValue(UPSTREAM);
+    const allowedImageGeneration = vi.fn().mockResolvedValue(UPSTREAM);
+    const blockedClient = { imageGeneration: blockedImageGeneration } as unknown as ProviderClient;
+    const allowedClient = { imageGeneration: allowedImageGeneration } as unknown as ProviderClient;
+    const { app, enqueueTelemetry } = setup({
+      auth: {
+        resolve: async (cred) =>
+          cred === "k"
+            ? ({
+                keyId: "key1",
+                accountId: "acct",
+                keyPrefix: "helm_live_xy",
+                caps: { budget: BUDGET_CAPS, blockedModels: ["gpt-image-primary"] },
+              } as MessagesIdentity)
+            : null,
+      },
+      resolveImageChain: (model) =>
+        model === "image-lane"
+          ? {
+              ok: true,
+              laneName: "image-lane",
+              candidateChain: ["gpt-image-primary", "gpt-image-fallback"],
+              targets: [
+                {
+                  client: blockedClient,
+                  providerModel: "openai/gpt-image-primary",
+                  alias: "gpt-image-primary",
+                  kind: "openai",
+                },
+                {
+                  client: allowedClient,
+                  providerModel: "openai/gpt-image-fallback",
+                  alias: "gpt-image-fallback",
+                  kind: "openai",
+                },
+              ],
+            }
+          : { ok: false, status: 404 },
+      costOf: (alias) => (alias === "gpt-image-fallback" ? 0.007 : null),
+    });
+
+    const res = await post(app, { model: "image-lane", prompt: "x" });
+
+    expect(res.status).toBe(200);
+    expect(blockedImageGeneration).not.toHaveBeenCalled();
+    expect(allowedImageGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "openai/gpt-image-fallback", prompt: "x" }),
+      expect.anything(),
+    );
+    expect(res.headers.get("x-helm-final-model")).toBe("gpt-image-fallback");
+
+    const decision = enqueueTelemetry.mock.calls[0]?.[0].decision;
+    expect(decision.lane.candidate_chain).toEqual(["gpt-image-fallback"]);
+    expect(decision.provider_attempts.map((a: { alias: string }) => a.alias)).toEqual([
+      "gpt-image-fallback",
+    ]);
+  });
+
   it("returns 404 for a model that is not a configured image model", async () => {
     const { app } = setup();
     const res = await post(app, { model: "not-an-image-model", prompt: "x" });

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -200,6 +200,32 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
             "provider_unavailable",
           );
     }
+    const blockedModels = new Set(identity.caps?.blockedModels ?? []);
+    const permittedTargets =
+      blockedModels.size === 0
+        ? chain.targets
+        : chain.targets.filter((target) => !blockedModels.has(target.alias));
+    const permittedCandidateChain =
+      blockedModels.size === 0
+        ? chain.candidateChain
+        : chain.candidateChain.filter((alias) => !blockedModels.has(alias));
+    if (permittedTargets.length === 0) {
+      const directBlocked = blockedModels.has(parsed.data.model);
+      return errorJson(
+        c,
+        400,
+        "invalid_request_error",
+        directBlocked
+          ? `model '${parsed.data.model}' is blocked for this key`
+          : `all image candidate models for '${parsed.data.model}' are blocked for this key`,
+        "model_blocked",
+      );
+    }
+    const permittedChain = {
+      ...chain,
+      candidateChain: permittedCandidateChain,
+      targets: permittedTargets,
+    };
 
     // 5b) Per-key usage-budget gate (docs/06), mirroring the chat face — ONCE, before
     //     the chain runs (a fallback within one request is still one billable image).
@@ -247,7 +273,12 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
       };
     };
 
-    const outcome = await runImageChain(chain.targets, deps.breaker, attempt, c.req.raw.signal);
+    const outcome = await runImageChain(
+      permittedChain.targets,
+      deps.breaker,
+      attempt,
+      c.req.raw.signal,
+    );
 
     // 6b) Terminal failure. A client abort is a NON-provider fault → no record, no 5xx.
     if (!outcome.ok) {
@@ -257,8 +288,8 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
           traceId,
           keyPrefix,
           requested: parsed.data.model,
-          selectedLane: chain.laneName,
-          candidateChain: chain.candidateChain,
+          selectedLane: permittedChain.laneName,
+          candidateChain: permittedChain.candidateChain,
           attempts: outcome.attempts,
           served: null,
           finalErrorClass: outcome.errorClass,
@@ -292,8 +323,8 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         traceId,
         keyPrefix,
         requested: parsed.data.model,
-        selectedLane: chain.laneName,
-        candidateChain: chain.candidateChain,
+        selectedLane: permittedChain.laneName,
+        candidateChain: permittedChain.candidateChain,
         attempts: outcome.attempts,
         served: { alias: served.alias, providerModel: served.providerModel },
         finalErrorClass: null,
@@ -337,7 +368,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
     }
 
     // 8) Observability headers + the VERBATIM upstream body (full image) to the client.
-    c.header("x-helm-lane", chain.laneName);
+    c.header("x-helm-lane", permittedChain.laneName);
     c.header("x-helm-final-model", served.alias);
     c.header("x-helm-provider-model", served.providerModel);
     return c.json(result.clientBody);

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -219,6 +219,94 @@ describe("registerInteractionsRoute", () => {
     expect(res.status).toBe(401);
   });
 
+  it("rejects a direct Gemini image model that is blocked for the key", async () => {
+    const { app, nativePassthrough, enqueueTelemetry } = setup({
+      auth: {
+        resolve: async (cred) =>
+          cred === "k"
+            ? ({
+                keyId: "key1",
+                accountId: "acct",
+                keyPrefix: "helm_live_xy",
+                caps: { budget: BUDGET_CAPS, blockedModels: ["gemini-3.1-flash-image"] },
+              } as MessagesIdentity)
+            : null,
+      },
+    });
+
+    const res = await post(app, { model: "gemini-3.1-flash-image", input: "x" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string; status: string } };
+    expect(body.error.message).toContain("blocked for this key");
+    expect(body.error.status).toBe("INVALID_ARGUMENT");
+    expect(nativePassthrough).not.toHaveBeenCalled();
+    expect(enqueueTelemetry).not.toHaveBeenCalled();
+  });
+
+  it("removes blocked Gemini image candidates from a lane before fallback execution", async () => {
+    const blockedNativePassthrough = vi.fn().mockResolvedValue(NATIVE);
+    const allowedNativePassthrough = vi.fn().mockResolvedValue(NATIVE);
+    const blockedClient = {
+      nativePassthrough: blockedNativePassthrough,
+    } as unknown as ProviderClient;
+    const allowedClient = {
+      nativePassthrough: allowedNativePassthrough,
+    } as unknown as ProviderClient;
+    const { app, enqueueTelemetry } = setup({
+      auth: {
+        resolve: async (cred) =>
+          cred === "k"
+            ? ({
+                keyId: "key1",
+                accountId: "acct",
+                keyPrefix: "helm_live_xy",
+                caps: { budget: BUDGET_CAPS, blockedModels: ["gemini-image-primary"] },
+              } as MessagesIdentity)
+            : null,
+      },
+      resolveImageChain: (model) =>
+        model === "image-lane"
+          ? {
+              ok: true,
+              laneName: "image-lane",
+              candidateChain: ["gemini-image-primary", "gemini-image-fallback"],
+              targets: [
+                {
+                  client: blockedClient,
+                  providerModel: "gemini-image-primary",
+                  alias: "gemini-image-primary",
+                  kind: "gemini",
+                },
+                {
+                  client: allowedClient,
+                  providerModel: "gemini-image-fallback",
+                  alias: "gemini-image-fallback",
+                  kind: "gemini",
+                },
+              ],
+            }
+          : { ok: false, status: 404 },
+      costOf: (alias) => (alias === "gemini-image-fallback" ? 0.07 : null),
+    });
+
+    const res = await post(app, { model: "image-lane", input: "x" });
+
+    expect(res.status).toBe(200);
+    expect(blockedNativePassthrough).not.toHaveBeenCalled();
+    expect(allowedNativePassthrough).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "gemini-image-fallback" }),
+      expect.anything(),
+    );
+    expect(res.headers.get("x-helm-final-model")).toBe("gemini-image-fallback");
+
+    const decision = enqueueTelemetry.mock.calls[0]?.[0].decision;
+    expect(decision.lane.candidate_chain).toEqual(["gemini-image-fallback"]);
+    expect(decision.provider_attempts.map((a: { alias: string }) => a.alias)).toEqual([
+      "gemini-image-fallback",
+    ]);
+  });
+
   it("returns 404 for a model that is not a configured image model", async () => {
     const { app } = setup();
     const res = await post(app, { model: "not-an-image-model", input: "x" });

--- a/apps/gateway/src/routes/interactions.ts
+++ b/apps/gateway/src/routes/interactions.ts
@@ -273,7 +273,32 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
             "UNAVAILABLE",
           );
     }
-    const geminiTargets = chain.targets.filter((t) => t.kind === "gemini");
+    const blockedModels = new Set(identity.caps?.blockedModels ?? []);
+    const permittedTargets =
+      blockedModels.size === 0
+        ? chain.targets
+        : chain.targets.filter((target) => !blockedModels.has(target.alias));
+    const permittedCandidateChain =
+      blockedModels.size === 0
+        ? chain.candidateChain
+        : chain.candidateChain.filter((alias) => !blockedModels.has(alias));
+    if (permittedTargets.length === 0) {
+      const directBlocked = blockedModels.has(parsed.data.model);
+      return errorJson(
+        c,
+        400,
+        directBlocked
+          ? `model '${parsed.data.model}' is blocked for this key`
+          : `all image candidate models for '${parsed.data.model}' are blocked for this key`,
+        "INVALID_ARGUMENT",
+      );
+    }
+    const permittedChain = {
+      ...chain,
+      candidateChain: permittedCandidateChain,
+      targets: permittedTargets,
+    };
+    const geminiTargets = permittedChain.targets.filter((t) => t.kind === "gemini");
     if (geminiTargets.length === 0) {
       return errorJson(
         c,
@@ -333,8 +358,8 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
           traceId,
           keyPrefix,
           requested: parsed.data.model,
-          selectedLane: chain.laneName,
-          candidateChain: chain.candidateChain,
+          selectedLane: permittedChain.laneName,
+          candidateChain: permittedChain.candidateChain,
           attempts: outcome.attempts,
           served: null,
           finalErrorClass: outcome.errorClass,
@@ -368,8 +393,8 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
         traceId,
         keyPrefix,
         requested: parsed.data.model,
-        selectedLane: chain.laneName,
-        candidateChain: chain.candidateChain,
+        selectedLane: permittedChain.laneName,
+        candidateChain: permittedChain.candidateChain,
         attempts: outcome.attempts,
         served: { alias: served.alias, providerModel: served.providerModel },
         finalErrorClass: null,
@@ -411,7 +436,7 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
     }
 
     // 8) Observability headers + the interactions JSON (full image) to the client.
-    c.header("x-helm-lane", chain.laneName);
+    c.header("x-helm-lane", permittedChain.laneName);
     c.header("x-helm-final-model", served.alias);
     c.header("x-helm-provider-model", served.providerModel);
     return c.json(result.clientBody);

--- a/apps/gateway/src/routes/mcp/mcp.test.ts
+++ b/apps/gateway/src/routes/mcp/mcp.test.ts
@@ -23,6 +23,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: ["economy", "balanced"],
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/routes/mcp/oauth.test.ts
+++ b/apps/gateway/src/routes/mcp/oauth.test.ts
@@ -19,6 +19,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/routes/mcp/oauth.ts
+++ b/apps/gateway/src/routes/mcp/oauth.ts
@@ -194,6 +194,7 @@ function identityFromClaims(claims: Record<string, unknown>): AuthIdentity {
     caps: {
       allowedLanes: null,
       allowCustomModel: false,
+      blockedModels: null,
       allowFastMode: false,
       rateLimit: { rpm: null, tpm: null },
       concurrencyLimit: null,

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -256,6 +256,7 @@ describe("createMessagesPipeline — failure surfaces", () => {
     expect((sawOpts as RouteOptions | null)?.keyCaps).toEqual({
       allowedLanes: ["economy"],
       degradeLane: null,
+      blockedModels: null,
     });
   });
 
@@ -270,6 +271,7 @@ describe("createMessagesPipeline — failure surfaces", () => {
     expect((sawOpts as RouteOptions | null)?.keyCaps).toEqual({
       allowedLanes: null,
       degradeLane: null,
+      blockedModels: null,
     });
   });
 

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -768,7 +768,12 @@ export function createMessagesPipeline(
       }
 
       const caps = identity.caps as
-        | { allowCustomModel?: unknown; allowedLanes?: unknown; budget?: BudgetCaps }
+        | {
+            allowCustomModel?: unknown;
+            allowedLanes?: unknown;
+            blockedModels?: unknown;
+            budget?: BudgetCaps;
+          }
         | undefined;
       const allowCustomModel = caps?.allowCustomModel === true;
 
@@ -804,6 +809,7 @@ export function createMessagesPipeline(
         allowedLanes: Array.isArray(caps?.allowedLanes) ? (caps.allowedLanes as string[]) : null,
         // Forced degrade lane for this request (docs/06); null = no degrade.
         degradeLane,
+        blockedModels: Array.isArray(caps?.blockedModels) ? (caps.blockedModels as string[]) : null,
       };
 
       const result = await route(internal, { allowCustomModel, keyPrefix, keyCaps }, signal);

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -47,6 +47,8 @@ export interface MessagesIdentity {
     rateLimit?: { rpm: number | null; tpm: number | null };
     /** Per-key max in-flight requests (issue #93). null/absent = unlimited. */
     concurrencyLimit?: number | null;
+    /** Exact model ids denied across direct model requests and lane/fallback routes. */
+    blockedModels?: string[] | null;
     /** Per-key cap for client-requested Fast mode passthrough. Account-level Fast
      *  mode can still be forced by subscription account settings. */
     allowFastMode?: boolean;

--- a/apps/gateway/src/routes/models.test.ts
+++ b/apps/gateway/src/routes/models.test.ts
@@ -46,6 +46,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,
@@ -104,6 +105,20 @@ describe("GET /v1/models", () => {
     expect(pro?.type).toBe("model");
     expect(pro?.pricing?.inputPerMTokUsd).toBe(0.5);
     expect(pro?.lanes?.sort()).toEqual(["balanced", "economy"]);
+  });
+
+  it("allow_custom_model key: hides blocked aliases from model discovery", async () => {
+    const res = await buildApp(
+      record({ allow_custom_model: true, blocked_models: ["deepseek/pro"] }),
+    ).request("/v1/models", {
+      headers: AUTH,
+    });
+    const body = (await res.json()) as ModelsList;
+    const ids = body.data.map((m) => m.id);
+    expect(ids).toContain("economy");
+    expect(ids).not.toContain("balanced");
+    expect(ids).toContain("deepseek/flash");
+    expect(ids).not.toContain("deepseek/pro");
   });
 
   it("allow_custom_model key: includes live subscription (OAuth) aliases", async () => {

--- a/apps/gateway/src/routes/models.ts
+++ b/apps/gateway/src/routes/models.ts
@@ -38,6 +38,7 @@ export function registerModelsRoute(app: Hono<AppEnv>, deps: ModelsRouteDeps): v
       providerAliases: oauth.length ? [...deps.providerAliases, ...oauth] : deps.providerAliases,
       allowCustomModel: identity.caps.allowCustomModel,
       allowedLanes: identity.caps.allowedLanes,
+      blockedModels: identity.caps.blockedModels,
     });
   };
 

--- a/apps/gateway/src/routes/usage.test.ts
+++ b/apps/gateway/src/routes/usage.test.ts
@@ -16,6 +16,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     name: null,
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     allow_fast_mode: false,
     disabled: false,
     rate_limit_rpm: null,

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -2520,6 +2520,7 @@ export async function buildServer(
           caps: {
             allowedLanes: record.allowed_lanes,
             allowCustomModel: record.allow_custom_model,
+            blockedModels: record.blocked_models,
             allowFastMode: record.allow_fast_mode,
             // Per-key rate-limit override (docs/06): carried so the self-auth
             // /v1/messages + /v1/responses paths enforce per-key limits too, not
@@ -2691,6 +2692,7 @@ export async function buildServer(
           caps: {
             allowedLanes: record.allowed_lanes,
             allowCustomModel: record.allow_custom_model,
+            blockedModels: record.blocked_models,
             allowFastMode: record.allow_fast_mode,
             // Per-key rate-limit override (docs/06): carried so the self-auth
             // /v1/messages + /v1/responses paths enforce per-key limits too, not
@@ -2786,6 +2788,7 @@ export async function buildServer(
       caps: {
         allowedLanes: record.allowed_lanes,
         allowCustomModel: record.allow_custom_model,
+        blockedModels: record.blocked_models,
         allowFastMode: record.allow_fast_mode,
         rateLimit: { rpm: record.rate_limit_rpm, tpm: record.rate_limit_tpm },
         // Per-key max in-flight (issue #93): read by the concurrency gate.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,16 @@
 
 ---
 
+## 2026-07-06 · API key 绝对模型黑名单（Key governance / routing / Admin keys，docs/04/06/11，原则 5/6/7）
+
+- **背景（Lukin）**：每个 API key 需要能禁止若干具体模型，语义是“这个用户无论通过 direct model、显式 lane、auto/classified lane、alias-to-lane 还是 execution fallback，都不能实际用到这些模型”。
+- **产品边界**：`blocked_models` 是具体模型 denylist，不是 lane denylist。请求若直接点名被禁的具体模型，立即返回结构化 `invalid_request`；请求若点名 lane 或走自动路由，则在执行前从 expanded candidate chain 中剥离被禁模型，fallback 会自然跳过它们。Chat/Messages/Responses/Gemini 走 `routeRequest`，Images/Interactions 入口在各自 image chain 执行前应用同一过滤。
+- **空链处理**：如果某个 lane 的所有候选都被当前 key 的 `blocked_models` 剥空，路由阶段直接返回 `invalid_request`，不进入 provider executor，也不把它伪装成 provider failure。Routing signal feedback 也会跳过被黑名单剥空的提升目标，避免把本来可用的 lane 误提升成拒绝。
+- **匹配语义**：只做 `trim` 后的精确模型 ID 匹配，不 lowercase、不 glob、不按 provider 前缀扩展；`auto`、空模型、lane 名本身不会作为模型命中，lane 内的具体模型会被过滤。
+- **数据与迁移**：API key schema 增加 nullable `blocked_models`；create/update 支持设置与清空。SQLite v38 用 JSON text，Postgres v37 用 JSONB；两个 store adapter 都做 round-trip，并保持旧 row 默认 `null`。
+- **可见性与 UI**：`/v1/models` 会按当前 key 隐藏被 block 的 concrete alias；若某 lane 过滤后没有任何可用候选，该 lane 也不展示。Admin keys 的共享 caps form 增加多行 `Blocked models` 输入，支持换行、逗号、分号分隔并去重。
+- **验证路径**：覆盖 shared schema、direct reject、classified/explicit/alias lane chain filtering、routing signal 提升过滤、空链拒绝、models list 过滤、SQLite/Postgres store contract、gateway auth/admin/chat/messages/replay/models threading，以及 admin create/edit/list 表单映射。
+
 ## 2026-07-06 · Anthropic native passthrough 稳定 Claude Code billing cch（Provider execution / prompt cache，docs/04/05，原则 3/5/7/8）
 
 - **背景（Lukin）**：线上 `claude-fable-5` 请求大多是 Anthropic native passthrough，理论上应保留 Claude Code 原始 body；但 production SQLite 样本显示同一会话里 `system[0]` 的 `x-anthropic-billing-header` 只有 `cch` 每轮变化（`cc_version`/`cc_entrypoint` 稳定），导致 Anthropic prompt cache 的严格前缀匹配被第一块内容打断，缓存读取只覆盖小前缀，成本显著偏高。
@@ -88,125 +98,14 @@
 - **操作边界**：Providers 页会显式返回 `credentialFailed` 并禁用 schedulable 开关；后端同样拒绝把 credential-failed 账号直接设回 schedulable。状态页若首次发现永久凭证失败，会触发 live pool rebuild，避免“后台已禁用但当前 pool 仍在用”。
 - **测试路径**：覆盖 core pool credential-failure hook、admin test 401 标记、account-settings mark/clear、synthesizeOAuthProviders 跳过 failed account、providers UI 失败后刷新；再跑 targeted Vitest、typecheck、lint、diff check。
 
-## 2026-07-05 · 避免浪费策略纳入周额度与 Codex reset credits（OAuth provider pool / quota，docs/04/11，原则 3/5/7）
-
-- **背景（Lukin）**：`use_expiring` 不能只看单个快重置窗口；用户实际关心的是 5 小时额度、周额度，以及 Codex 账号还剩多少次 reset credit。周额度快到 reset 且还有大量剩余额度时应被优先使用；有 reset credits 的账号也具备额外恢复能力，应进入评分。
-- **评分决策**：`use_expiring` 从“取最佳单窗口”改为“汇总适用窗口分数”：每个窗口按 `(100 - usedPercent) / hoursUntilReset` 计分，周额度窗口（Codex `secondary` / Anthropic `7d*` / 7 天窗口）加权更高；Codex reset credits 作为折扣后的虚拟周窗口加分，影响账号选择但不触发消费。
-- **安全边界**：选择策略只把 reset credits 当软评分信号，不会自动花掉 credit。真正消费仍走手动 Reset limit / auto-reset 的硬门禁（weekly snapshot、阈值、guard、审计）。
-- **实时性修正**：providers 页 `/oauth/quota` PULL 成功后不只写入 `oauth_quota`，还会刷新当前 live OAuth pool 的 soft quota snapshot；Anthropic/Codex 的新鲜 quota 不再必须等待下一次 rebuild 才影响策略。
-- **验证计划**：覆盖 `use_expiring` 汇总短窗口+周窗口、reset credits 参与评分、SQLite/Postgres reset_credits round-trip 且 header PUSH 不清空、admin quota PULL 写库并刷新 live pool；再跑 targeted Vitest、typecheck、lint、build。
-
-## 2026-07-05 · Codex reset-credit 消费改为硬门禁（OAuth quota / Admin providers，docs/04/11，原则 3/5/7）
-
-- **背景（Lukin）**：Codex rate-limit reset credit 是稀缺上游额度，不能因为 providers 页刷新、容器重启、持续 saturated header 或误开 auto-reset 而快速消耗。既要保留手动/自动恢复能力，也要默认 fail-closed 保护 reset credits。
-- **消费门槛**：手动和自动 reset-credit consume 都必须看到 Codex weekly `secondary` window，且 `usedPercent >= 90`；5h `primary` window 自恢复，永远不能作为花费 reset credit 的理由。缺少 quota snapshot 时手动接口返回 409，不直接 PULL 上游再消费。
-- **自动 reset 边界**：auto-reset 仍只在 weekly `secondary >= 100` 时尝试；手动和自动消费都共享同一持久 guard：同一 shared ChatGPT account 一小时内只能 reserve 一次，同一 weekly window 只能 reserve 一次。guard 写在 `config_kv`，key 只含 shared account 的 sha256，不保存 ChatGPT id 明文。
-- **并发/重启决策**：进程内 shared-key in-flight 折叠同进程 sibling burst；真正的一小时 reservation 用 `ConfigStore.setIfMissingOrNumericLte` 在 SQLite/Postgres 单条 SQL 原子抢占，防多实例同时 read-then-write 双消费；持久 `window` guard 防同一 weekly window 在冷却过后继续消费。guard/store 出错或缺少原子 reservation 能力时 fail-closed，宁可不 reset，也不能快速烧额度。
-- **审计决策**：`consumeCodexResetCredit` 生成并记录 `redeem_request_id`；auto-reset 在上游 consume 成功后立刻打 `oauth.auto_reset.consumed`，本地 unpark 失败单独记 `oauth.auto_reset.unpark_failed`，避免“credit 已花但日志看起来像 consume 失败”。
-- **UI 决策**：providers 页 `Reset limit` 按 weekly >=90、resetCredits >0、quota snapshot 存在才可点；确认弹窗里的 auto-reset 勾选只在 consume 成功后保存，失败不会悄悄开启未来自动消费。
-- **验证计划**：覆盖纯 eligibility、持久 cooldown、跨 guard 实例原子抢占、同 weekly window 手动/自动去重、admin route fail-closed、redeem id 审计、providers 按钮禁用和失败不保存 autoReset；再跑 targeted Vitest、store contract、gateway typecheck、admin svelte-check、Biome/Prettier。
-
-## 2026-07-05 · OAuth 账号池支持可选额度使用策略（OAuth provider pool / routing / Admin providers，docs/04/11，原则 3/5/7）
-
-- **背景（Lukin）**：订阅 provider 的多账号池不只有一种合理用法。有的用户希望低风险、少 429、尽量均摊；有的用户希望避免额度浪费，把快重置且还剩较多额度的账号优先用掉；有的用户希望完全按自己设置的 priority 操作。
-- **产品决策**：策略是全局账号池级别，而不是 account 级别，也不是每个 provider 单独配置。用户选择的是“整个系统如何使用订阅账号额度”；该策略在每个订阅 provider 的账号池内统一生效。跨 provider/model 的选择仍由 lanes/policies/fallback 负责，不被这个账号策略替代。
-- **策略集合**：`balanced` 保持现有 sticky/hash/LRU 均衡；`manual_priority` 按 priority + LRU 分配新会话，已有会话继续 sticky；`low_risk` 在最低 priority 层里优先选择 quota pressure 更低的账号，降低打到上限/429 的概率；`use_expiring` 优先使用“剩余额度多且离 reset 更近”的窗口，目标是减少快重置前未用完的额度。
-- **额度语义**：quota windows 只作为软评分输入，缺失或超过 freshness 窗口时自动回退到 balanced 行为；`usageLimitedUntilMs` 仍是硬调度门禁。Codex reset credits 只在 `use_expiring` 中作为折扣后的软评分信号，不会自动触发消费；真正消费仍只在手动/auto-reset 流程里发生。
-- **会话边界**：`previous_response_id` 是强亲和，必须回到产生该 response 的账号，即使 quota 策略觉得另一个账号更优；普通 sticky 会话在 quota 策略下只允许在软阈值内保持，以避免长期卡在高压账号。
-- **Scoped quota 边界**：Anthropic `7d-*` scoped windows 只在当前模型匹配对应 slug 时参与评分，不扩大成全账号压力或全账号 cooldown。
-- **实现路径**：core OAuth pool 统一负责策略选择；gateway 从 encrypted global OAuth settings 读取策略，启动/热重建时注入所有订阅账号池，并把 quota snapshots seed 到 pool member；Codex header PUSH 捕获后即时刷新 live pool member 的软 quota snapshot。Admin Providers 页面提供一个系统级下拉选择，保存后热重建生效。
-- **验证计划**：覆盖 core 策略、provider settings round-trip、admin API、Providers UI、Svelte check、typecheck、lint；SQLite-backed 测试依赖本地 `better-sqlite3` ABI，若本机 Node ABI 不匹配需先重建 native addon。
-
-## 2026-07-04 · internal LLM prompt 输入用 XML 数据边界隔离（Memory / classifier eval，docs/03/08/12，原则 3/4/7）
-
-- **背景（Lukin）**：生产 request `4fa73a51-56d3-4f40-a34d-7ce1e9d1194b` 显示 `internal-llm` key 的一次普通 chat self-call 把任务规则、runtime context、群聊历史和输出契约拼在同一个 user message 里；最后一条群消息包含“可以合并”等业务动作词，容易让小模型把 untrusted chat content 当成可执行指令或错误语境。
-- **Helm 边界**：这条具体 Feishu reply-gate prompt 是调用方发给 Helm 的普通 `/v1/chat/completions` 请求，Helm 不能自动知道哪段是可信规则、哪段是聊天记录；调用方仍需把业务 prompt 改成 XML 分区。Helm 本次修复的是自己创建的 internal LLM prompt：Layer-2 classifier eval 与 memory observation/reflection/fact extraction。
-- **实现决策**：新增 `prompt-boundary` helper，对 XML text 做 `&/< />` escaping；eval 把最后真实 user turn 包进 `<user_request>`；memory 把 schema/时间放进 `<trusted_task_json>`，把 raw messages / observations 放进 `<untrusted_messages_json>` 或 `<untrusted_observations_json>`。
-- **安全语义**：system prompt 明确要求模型把 untrusted XML section 当数据而不是指令；用户内容里伪造的闭合标签会被转义，不能提前关闭数据区。现有 JSON output schema、temperature、timeout、fail-open fallback、日志不记录 prompt 的约束保持不变。
-- **排查结论**：除 memory LLM 与 classifier eval 外，`memory-self-http` 只是把已构造请求走 loopback 以便观测，`memory-embedder` 是 embedding 输入，不是指令型 prompt；未发现第三个 Helm 自己拼自然语言 prompt 的 internal key 调用面。
-- **验证计划**：新增 eval 与 memory prompt-boundary 回归，先证明旧实现裸放数据会失败，再验证 XML section 和 tag-breakout escaping；跑 focused Vitest、typecheck、lint。
-
-## 2026-07-04 · 请求记录最终订阅账号并重排请求列表字段（Telemetry / Admin requests，docs/04/07/11，原则 1/5/7）
-
-- **背景（Lukin）**：请求 telemetry 只能看到最终 model/provider alias，无法确认使用订阅 provider 时最后落到哪个具体订阅账号；排查成本、额度、限流和账号池调度时缺少每次请求的账号级事实。
-- **记录决策**：`DecisionRecord` 新增 `serving_account: { provider_id, account } | null`。OAuth pool 仍只在执行深处通过 ALS 标记候选账号；真正落库前由 gateway 在最终结果已知后 stamp，避免 core/provider 合同依赖 Hono 或 admin。
-- **防误记边界**：只有最终 `final.model_alias` 仍属于被标记账号的 provider 前缀时才记录账号；如果订阅账号候选失败后 fallback 到其它 provider，写入 `null`，避免把 stale selection 错记成实际服务账号。
-- **尝试元数据决策**：`provider_attempts` 保留 `provider_name`、`provider_model`、passthrough/protocol mutation 等执行层已有元数据。Admin 只展示已记录字段，不从 alias 重新推断业务事实。
-- **UI 决策**：请求列表字段按排障优先级重排为：Time、Status、Key、Provider、Subscription account、Served model、Requested model、Lane、Fallbacks、Latency、TPS、Tokens、Cost、Task、Complexity、Decided by、Error、Request ID。Trace ID 仍可点击但降到末尾；详情摘要同步露出 Provider / Subscription account，执行链路每个 attempt 显示 provider、账号、alias 与上游 wire model。
-- **安全/隐私**：只记录 provider id 与订阅账号显示名，不记录 OAuth token、明文 API key 或正文；key 仍只显示 prefix。旧记录和非订阅 provider 统一显示 `—`/`null`。
-- **验证计划**：覆盖 shared schema round-trip、telemetry builder 元数据保留、gateway stamp guard、admin mapper、请求列表/详情/执行链路渲染；再跑目标 Vitest、typecheck、lint、build。
-
-## 2026-07-04 · cheap-model 短低风险当前轮不被长历史抬价（Classifier / routing，docs/03/04，原则 2/4/5）
-
-- **背景（Lukin）**：生产 `openclaw` 24h 数据显示，部分请求显式请求 `gpt-5.4-mini` / cheap alias，最后一条 user 只有约 200 字且是 read/check/status 类低风险动作，但因为完整 transcript 很大、tools 很多，被 Layer-1 长上下文/工具信号抬到 `balanced/coding`，最终使用 `gpt-5.5`。
-- **规则决策**：新增配置化 override `cheap_model_low_risk`。只有 `requested_model` 命中配置 cheap markers、最后一条 user 在 `current_turn_max_chars` 内、命中低风险 marker、且没有 blocked marker 时，才把 complexity 设为 `simple`。判断只看当前 user turn，不用历史正文。
-- **安全边界**：显式 `gpt-5.5` 请求不受影响；JSON response_format、vision attachment、代码变更/调试/部署/安全/数学等 blocked marker 均不触发。真正的窗口 fit 和 provider 能力仍交给后续 capability filter / fallback。
-- **配置取舍**：默认 markers 包含 `economy`、`gpt-5.4-mini` / `gpt-5.4-mini-*` / `spark`，并用 `*deepseek-v4-flash` / `*claude-haiku-*` / `*claude-3-5-haiku-*` 覆盖 bare、provider-prefixed 与 dated 形态；但没有把 `gpt54` 当成 economy hint，避免把用户想要的中档模型继续压到 mini。
-- **验证计划**：新增 override 单测和 golden routing 回归，覆盖 cheap-model 短低风险长历史降到 economy、重模型请求不降级、code-changing/JSON/vision 不触发；再跑 targeted Vitest、typecheck、build。
-
-## 2026-07-04 · 视觉上下文压缩以 observe/off 为默认接入（Request optimizer / native Anthropic，docs/04/05/07/11，原则 1/3/5/7/8）
-
-- **背景（Lukin）**：pxpipe 证明“密集文本渲成图片”在特定模型/价格结构下可能降低输入 token 成本，但该方法不是无损压缩；模型视觉路径会丢失精确字符串、数字、路径、hash、ID 等细节。
-- **产品决策**：运行时设置新增 `visual_context_compression: off|observe|enabled`，默认 `off`。`observe` 会在副本上跑压缩并记录 would-apply telemetry，但实际仍发送原始文本；`enabled` 才会发送压缩后的 body。
-- **执行边界**：MVP 只接 Anthropic native passthrough。它在当前候选 provider 调用前工作，不改变 lane、candidate chain、provider selection、fallback_count 或 breaker 语义。压缩失败 fail-open 回原 body，只记安全日志，不算 provider fault。
-- **上下文窗口决策**：Anthropic `count_tokens` 预检前先尝试压缩，因此“原文超窗口但压缩后可进入窗口”的候选不会被过早 `context_too_small` 跳过。非 passthrough/非 Anthropic/非 vision-capable 目标保持原行为。
-- **安全决策**：core 包装器内置 `keepSharp`，命中 UUID/hash/长数字/URL/path/line-ref/secret-like/request-id 等精确字段时保留文本，避免把必须逐字可靠的内容压进图片。DecisionRecord 只存计数、reason、image_count/image_bytes 等无正文摘要，不存 PNG 或 imaged source text。
-- **实现取舍**：不把几 MB 字体 atlas 复制进 Helm；直接依赖 pxpipe 的公开 `transformAnthropicMessages` 渲染器和 gate。这样保持 Helm core 的 headless 约束，也让后续 pxpipe 修复可通过依赖升级吸收。
-- **验证计划**：新增 shared runtime schema、core optimizer、gateway execute、admin settings API 回归；再跑目标 Vitest、Svelte check、typecheck、lint、build。
-
-## 2026-07-04 · Memory stats 队列统计避免扫全量历史 job（Admin memory performance，docs/11/13，原则 1/7）
-
-- **背景（Lukin）**：线上逐页排查 admin API timing 后，绝大多数接口在 1–20ms，`/admin/api/oauth*` 稳定约 140–160ms；真正稳定慢的是 `/admin/api/memory/stats`，每次约 8.6–11.2s，导致 Memory 页面打开/刷新时明显卡住。
-- **根因**：生产 `memory_jobs` 已接近 10 万行且全部为历史 `done` job。stats 接口每次刷新都用 `CASE WHEN status = ...` 对整张 job 历史做时间统计，又额外做 `type/status` 汇总；这些读是同步 SQLite 路径，会阻塞 Node 事件循环，放大成后台页面卡顿。
-- **查询决策**：队列时间统计拆成按状态查询：pending 查最早 `created_at`，running 查最早/过期 `updated_at`，done/failed 查最新 `updated_at`。这样没有 open job 时不再为几个空指标扫描全部 done 历史。
-- **索引决策**：SQLite/Postgres 都新增 `memory_jobs(status, updated_at, created_at)` 与 `memory_jobs(type, status)`，分别服务状态时间统计和 jobs-by-type 汇总；迁移对缺少 `memory_jobs` 的老 fixture/部分升级库保持兼容。
-- **保持不变**：返回 JSON 语义不变；仍然是只读 admin observability，不读取 message body、不输出明文 key/payload、不触发 worker。
-- **验证计划**：覆盖 SQLite/Postgres stats 返回语义和迁移索引存在性；部署后用线上 `/admin/api/memory/stats` timing、`/admin/memory` 浏览器点击、`/healthz`/`/version` 验证。
-
-## 2026-07-04 · OAuth 账号池改为会话亲和调度（OAuth provider pool / routing，docs/04/11，原则 3/5/7）
-
-- **背景（Lukin）**：订阅 provider 有多个账号时，单纯 priority + LRU 轮询会让同一客户端会话在多个账号/多个上游设备身份之间漂移，容易呈现“账号池”特征。目标是同一 session/device 尽量固定到同一账号，只有账号不可用、额度/限流、或账号容量已满时才切换，同时让多个账号在新会话维度尽量均衡使用。
-- **调度决策**：OAuth pool 优先从显式 `device_id` / `metadata.device_id` / `metadata.user_id` JSON envelope 里的 `device_id` 生成 affinity key；没有 device 信号时再使用 `prompt_cache_key`、`session_id`、`conversation_id`、`metadata.session_id/conversation_id/thread_id/user_id` 等稳定会话信号。有 key 时在最低 priority 的可用账号集合里用 rendezvous hashing 选择账号，保证新会话均衡分布且进程重启后仍尽量落到同一账号。无 key 的请求保留原 LRU 行为。
-- **Responses 连续性决策**：`previous_response_id` 不再作为 hashable affinity key，因为它会随轮次变化；只有 pool 已经从成功的非流式响应 `id` / `response.id` 记录过“这个 response 由哪个账号产生”时，后续同 id 才作为 sticky hit 回到原账号。未知 `previous_response_id` 回到 LRU，不制造假粘性。
-- **容量决策**：per-account user-message queue 新增 `wouldQueue()` 探针。账号被锁住、已有等待者、或仍在请求间隔窗口内时，pool 会优先选择同池其它可用账号；若所有账号都会排队，则回到 deterministic target 并让队列等待，避免无账号可用时误报 provider down。用户 turn 判定同时覆盖 Chat `messages[]` 和 Responses `input`，避免 Codex native `/v1/responses` 绕过队列。
-- **切换边界**：401/403、429/usage cooldown、pre-output transient fault、以及账号队列 timeout 都作为账号级切换原因处理；确定性 4xx 仍不切 sibling。账号级限流仍会 forget 当前 sticky，避免后续会话继续命中不可用账号。
-- **观测决策**：`oauth.pool.select` 日志只记录非敏感选择元信息（`selection_reason`、`affinity_key_source`、`capacity_avoided`、`busy_eligible_accounts`、`retry_attempt`），不记录具体 device/session key 值，便于生产验收“切换只因故障/额度/容量压力”。
-- **验证计划**：新增 OAuth pool affinity/capacity 单测、serial gate `wouldQueue()` 单测、gateway `synthesizeOAuthProviders` 集成测试；再跑相关执行器回归、全量 Vitest、typecheck、lint、build 和 Playwright e2e。
-
-## 2026-07-04 · idle-flush 碎片段优先压缩最大连续段（Memory Observer，docs/08/12，原则 3/7）
-
-- **背景（Lukin）**：线上 `v0.23.0` 后记忆队列仍持续运行，排查发现总候选不是 30 多万 job，而是约 3.07 万个 idle candidate thread；最近完成的 observer 基本不会重新成为候选，未见大面积死循环。
-- **边界问题**：个别超长历史 thread 已被旧 observation 切成很多碎片段。Observer 在 idle 模式下原本选择“第一个可压缩段”，如果最前面只是 1 条 message 的小洞，就会一次 internal LLM 只压缩 1 条，形成有限但很慢的长尾。
-- **调度决策**：idle-flush 下仍然不把稀疏集合写成一个虚假的连续 `source_message_range`；但在多个可压缩连续段之间，优先选择 `compressedTokens` 最大、再按 `compressedCount` 打破平局的段。这样 source range 仍精确，同时优先消掉大尾巴，避免一个超长 thread 反复消耗小段 LLM 调用。
-- **跳过决策**：新增可选 `compaction.idle_flush_max_age_s`，让 idle-flush 只处理最近窗口内变 idle 的 thread；线上可设 `86400` 跳过超过 24 小时的旧 backfill，避免为历史冷数据继续消耗 internal LLM token。未配置时保持旧行为。
-- **保持不变**：非 idle 的 writeback/size/context-pressure 路径仍选最早可压缩段，保持时间顺序和已有 cache/keep 语义；open-job dedupe、worker 并发和 idle candidate SQL 不变。
-- **验证计划**：新增 Observer 回归测试，覆盖 idle 且前方有 tiny gap、大段未覆盖尾部时选择最大段；新增 config/idle-flush/store 回归覆盖 max-age 窗口；再跑目标测试、typecheck、lint、build。
-
-## 2026-07-04 · memory worker 受控并发追赶（Memory worker / scheduler，docs/08/12，原则 3/7）
-
-- **背景（Lukin）**：线上 `/admin/memory` 显示队列持续运行但追赶很慢；生产采样显示 worker 没有卡死，CPU/内存仍有余量，但 open queue 基本维持在约 500，旧 idle-flush backlog 很难明显下降。
-- **根因**：上一版已经把 `batchSize` / `maxBatchesPerDrain` 做大，但 worker 在一个 batch 内仍逐条 `await` LLM 任务。单纯继续调大 batch 只会让更多 job 长时间停在 `running`，不一定提升吞吐，还会让一次 drain 持续更久。
-- **调度决策**：`MemoryWorkerDeps` 新增 `concurrency`，默认 1 以保持 core 旧调用行为；gateway 默认 `HELM_MEMORY_WORKER_CONCURRENCY=3`，同一 claimed batch 内最多并发 3 个 job，让 LLM-bound observer/reflector 任务并行等待上游返回。
-- **安全决策**：gateway 对 `HELM_MEMORY_WORKER_CONCURRENCY` 硬封顶 8；仍保留 `batchSize`、`maxBatchesPerDrain`、`maxDrainMs`、批次间 yield 与 wake debounce，避免在 1GB 自托管容器上产生无上限后台 LLM fan-out。
-- **运维建议**：生产先用默认 3 观察；若 CPU/内存仍低且 `done_1m - enqueued_1m` 不够，可逐步调到 4/5；不要直接把 batch 调到几百来追赶，因为那会增加 running lease 和单轮 drain 风险。
-- **验证计划**：新增 scheduler 并发上限回归，覆盖同 batch 只启动 N 个任务、前一个完成后才启动下一个；再跑 memory scheduler、admin memory 页面、typecheck、lint、build。
-
-## 2026-07-04 · 记忆页只读运行状态面板（Admin memory observability，docs/08/11/13，原则 1/7）
-
-- **背景（Lukin）**：`/admin/memory` 只能看到已经形成的 facts/reflections，看不到 raw message 是否还在进入、后台 job 是否在跑、队列是否滞后或是否有 running lease 卡住；排障需要直接查日志/SQLite。
-- **接口决策**：新增 `GET /admin/api/memory/stats`，复用记忆页现有 scope/key 过滤语义，返回线程、消息、观察、事实、反思、job 状态分布、最早 pending/running、最近 activity 与生成时间。
-- **安全/性能决策**：接口只读、无请求正文、无明文 key/payload 输出；统计用 count/max/min 聚合，不触发 worker、不创建 job、不读取正文内容。全局视图直接聚合原表，只有选中 scope/key 时才 join scope 过滤，避免打开页面就反复扫全量 join。缺少 stats 能力的 store 返回 503，不影响现有记忆管理和网关请求路径。
-- **UI 决策**：记忆页顶部增加状态面板，15 秒轻量刷新一次；按当前选中的 scope/key 同步切换，能直接看到 queued/running/stale、滞后时间、raw input、learned output 和 jobs by type。
-- **验证计划**：覆盖 SQLite/Postgres store 聚合、admin route、admin 页面加载/筛选联动与 locale 文案；再跑目标 Vitest、typecheck、lint/build。
-
 ## 历史条目摘要（最近 5 条）
 
-- **2026-07-04 · Claude scoped weekly quota 不触发账号级限流（Admin providers / OAuth quota，docs/04/11，原则 3/5/7）**：只有账号级窗口能 park 整个 OAuth 账号，`7d-*` scoped model cap 只影响对应模型，不触发全账号限流。
-- **2026-07-04 · 跨协议 reasoning 历史不兼容按候选跳过（执行 fallback / 协议转换，docs/04/05/07，原则 3/5/8）**：跨协议转 OpenAI-compatible 时剥离不兼容 thinking/reasoning 控制，并把 DeepSeek 类 reasoning-history 400 作为候选跳过而非全局失败。
-- **2026-07-04 · memory idle-flush 防饥饿与受控追赶（Memory worker / store，docs/08/12，原则 3/7）**：idle-flush 候选判断改用 observer-order tuple，按 scope rank 交错输出，并支持受控多批 drain，避免旧 backlog 饿死新项目。
-- **2026-07-03 · 策略级 reasoning_effort 覆盖 Lane 默认值（Routing policies / Admin policies，docs/04/11，原则 2/5/6）**：Policy action 可强制 reasoning_effort，优先级为 policy > selected lane > client request，复用现有执行改写链路。
-- **2026-07-03 · cron monitor 自动化请求降到低成本规则（Classifier / routing，docs/03/04，原则 2/4）**：monitor/cron + no-reply 标记命中时降到 `simple/economy`，但保留显式 coding keyword 升级路径，避免自动化探针误打高价模型。
+- **2026-07-05 · 避免浪费策略纳入周额度与 Codex reset credits（OAuth provider pool / quota，docs/04/11，原则 3/5/7）**：`use_expiring` 汇总短窗口、周额度与 reset credits 软评分，quota PULL 会刷新 live pool snapshot 但不自动消费 credit。
+- **2026-07-05 · Codex reset-credit 消费改为硬门禁（OAuth quota / Admin providers，docs/04/11，原则 3/5/7）**：手动/自动 reset credit 必须命中 weekly secondary 阈值与持久 guard，缺少 snapshot 时 fail-closed，避免烧稀缺额度。
+- **2026-07-05 · OAuth 账号池支持可选额度使用策略（OAuth provider pool / routing / Admin providers，docs/04/11，原则 3/5/7）**：新增 balanced/manual_priority/low_risk/use_expiring 全局账号池策略，保持 previous_response_id 强亲和和 scoped quota 边界。
+- **2026-07-04 · internal LLM prompt 输入用 XML 数据边界隔离（Memory / classifier eval，docs/03/08/12，原则 3/4/7）**：classifier eval 与 memory LLM 把可信任务和不可信消息放进 XML/JSON 数据区并 escape，防止用户内容突破数据边界。
+- **2026-07-04 · 请求记录最终订阅账号并重排请求列表字段（Telemetry / Admin requests，docs/04/07/11，原则 1/5/7）**：`DecisionRecord.serving_account` 记录最终服务订阅账号，admin 请求列表/详情按排障优先级展示 provider、account、served/requested model。
 
 ## 更早历史总览
 
-2026-06-30 及以前的工作主要围绕 Helm API 的协议面、路由执行、admin 可观测性与自托管部署逐步成型：补齐 Gemini/OpenAI/Anthropic/Responses 双向转换、SSE 流式正确性、tool-call/JSON schema/思考参数保真、per-model reasoning effort、模型别名与能力/成本目录、provider fallback 与熔断语义、OAuth subscription providers、多账户池与 quota 处理、memory observe/inject/forgetting/admin/MCP、请求 payload 捕获与 request detail UI、API key 治理、admin 表格/过滤/分页/i18n、Docker/CI/release/deploy 验证，以及早期 Phase 0 的 Hono + SvelteKit static admin + Store 端口 + SQLite/Supabase 架构决策。更早细节不再逐条保留在本文件；需要精确背景时回查 git history。
+2026-07-04 更早条目还包括 cheap-model 当前轮低风险降级、视觉上下文压缩 observe/off 接入、Memory stats 队列索引优化、OAuth 会话亲和调度、idle-flush 碎片段优先压缩最大连续段、memory worker 受控并发追赶、记忆页只读运行状态面板、Claude scoped weekly quota 只影响对应模型、跨协议 reasoning-history 候选级跳过、memory idle-flush 防饥饿、策略级 reasoning_effort 覆盖 lane 默认值、cron monitor 低成本规则等。2026-06-30 及以前的工作主要围绕 Helm API 的协议面、路由执行、admin 可观测性与自托管部署逐步成型：补齐 Gemini/OpenAI/Anthropic/Responses 双向转换、SSE 流式正确性、tool-call/JSON schema/思考参数保真、per-model reasoning effort、模型别名与能力/成本目录、provider fallback 与熔断语义、OAuth subscription providers、多账户池与 quota 处理、memory observe/inject/forgetting/admin/MCP、请求 payload 捕获与 request detail UI、API key 治理、admin 表格/过滤/分页/i18n、Docker/CI/release/deploy 验证，以及早期 Phase 0 的 Hono + SvelteKit static admin + Store 端口 + SQLite/Supabase 架构决策。更早细节不再逐条保留在本文件；需要精确背景时回查 git history。

--- a/packages/core/src/catalog/models-list.test.ts
+++ b/packages/core/src/catalog/models-list.test.ts
@@ -100,6 +100,41 @@ describe("buildModelsList", () => {
     expect(flash?.lanes).toEqual(["economy"]);
   });
 
+  it("allow_custom_model key: omits blocked concrete aliases", () => {
+    const list = buildModelsList({
+      lanes,
+      catalog,
+      providerAliases,
+      allowCustomModel: true,
+      blockedModels: ["deepseek/pro"],
+    });
+
+    const ids = list.data.map((m) => m.id);
+    expect(ids).toContain("economy");
+    expect(ids).not.toContain("balanced");
+    expect(ids).toContain("premium");
+    expect(ids).toContain("auto");
+    expect(ids).toContain("deepseek/flash");
+    expect(ids).toContain("openai/o");
+    expect(ids).not.toContain("deepseek/pro");
+  });
+
+  it("normal key: hides a lane when blocked_models removes its whole chain", () => {
+    const list = buildModelsList({
+      lanes,
+      catalog,
+      providerAliases,
+      allowCustomModel: false,
+      blockedModels: ["deepseek/pro"],
+    });
+
+    const ids = list.data.map((m) => m.id);
+    expect(ids).toContain("economy");
+    expect(ids).not.toContain("balanced");
+    expect(ids).toContain("premium");
+    expect(ids).toContain("auto");
+  });
+
   it("nested lane references expand to leaf aliases for membership", () => {
     const list = buildModelsList({
       lanes,

--- a/packages/core/src/catalog/models-list.ts
+++ b/packages/core/src/catalog/models-list.ts
@@ -34,6 +34,8 @@ export interface BuildModelsListInput {
   allowCustomModel: boolean;
   /** The key's allowed_lanes cap; null/undefined = unconstrained. */
   allowedLanes?: string[] | null;
+  /** Exact concrete aliases hidden from and unavailable to this key. */
+  blockedModels?: string[] | null;
 }
 
 // Provider name an alias is owned by: the prefix before the first "/" (e.g.
@@ -46,10 +48,16 @@ function ownerOf(alias: string): string {
 export function buildModelsList(input: BuildModelsListInput): ModelsList {
   const { lanes, catalog, providerAliases, allowCustomModel } = input;
 
-  // Visible lanes: config (insertion) order, narrowed by the key's allowed_lanes.
+  const blocked = new Set(input.blockedModels ?? []);
+  const laneHasVisibleCandidate = (name: string): boolean =>
+    expandLaneChain(name, lanes).some((alias) => !blocked.has(alias));
+
+  // Visible lanes: config (insertion) order, narrowed by the key's allowed_lanes
+  // and by the key's blocked_models. A lane whose entire expanded chain is
+  // blocked is not actually usable by this key, so do not advertise it.
   const allowed = input.allowedLanes ?? null;
   const visibleLanes = Object.keys(lanes).filter(
-    (name) => allowed === null || allowed.includes(name),
+    (name) => (allowed === null || allowed.includes(name)) && laneHasVisibleCandidate(name),
   );
 
   const data: ModelObject[] = [];
@@ -89,7 +97,9 @@ export function buildModelsList(input: BuildModelsListInput): ModelsList {
       }
     }
 
-    const uniqueAliases = [...new Set(providerAliases)].sort((a, b) => a.localeCompare(b));
+    const uniqueAliases = [...new Set(providerAliases)]
+      .filter((alias) => !blocked.has(alias))
+      .sort((a, b) => a.localeCompare(b));
     for (const alias of uniqueAliases) {
       const meta = catalog.get(alias);
       data.push({

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -580,6 +580,39 @@ describe("routeRequest — orchestration", () => {
     expect(plan.selected_lane).toBe("balanced");
   });
 
+  it("signal feedback skips a promoted lane when blocked_models removes its whole chain", async () => {
+    const lanes: LanesConfig = {
+      economy: { primary: "cheap_model", fallback: [], constraints: {} },
+      balanced: { primary: "default_good_model", fallback: [], constraints: {} },
+      premium: { primary: "best_reasoning_model", fallback: [], constraints: {} },
+    } as unknown as LanesConfig;
+    const d = deps({
+      classify: vi.fn(async () =>
+        classification({ task_type: "general", complexity: "medium", constraints: {} }),
+      ),
+      policies: { policies: [] },
+      lanes,
+      signalFeedback: {
+        enabled: true,
+        minSamples: 20,
+        getSignal: vi.fn(async (_taskType, lane) =>
+          lane === "balanced"
+            ? routingSignal({ lane, successRate: 0.4, fallbackRate: 0.8, errorRate: 0.6 })
+            : routingSignal({ lane, successRate: 0.99, fallbackRate: 0, errorRate: 0 }),
+        ),
+      },
+    });
+
+    const result = await routeRequest(req(), d, {
+      keyCaps: { allowedLanes: null, blockedModels: ["best_reasoning_model"] },
+    });
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(result.final.status).toBe("ok");
+    expect(plan.selected_lane).toBe("balanced");
+    expect(plan.candidate_chain).toEqual(["default_good_model"]);
+  });
+
   it("signal feedback does not override policy pins, explicit passthrough, or over-budget degradation", async () => {
     const getSignal = vi.fn(async (_taskType: string, lane: string) =>
       routingSignal({ lane, successRate: lane === "premium" ? 0.99 : 0.2, errorRate: 0.8 }),
@@ -794,6 +827,95 @@ describe("routeRequest — orchestration", () => {
   });
 });
 
+describe("routeRequest — per-key blocked models", () => {
+  it("rejects an explicit model passthrough when the key blocks that model", async () => {
+    const d = deps({ isKnownModel: () => true });
+    const result = await routeRequest(req({ requested_model: "gpt-4o" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: null, blockedModels: ["gpt-4o"] },
+    });
+
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(result.error?.message).toContain('model "gpt-4o" is blocked for this key');
+    expect(d.execute).not.toHaveBeenCalled();
+    expect(d.classify).not.toHaveBeenCalled();
+  });
+
+  it("rejects a direct blocked model even when the key cannot use explicit passthrough", async () => {
+    const d = deps({ isKnownModel: () => true });
+    const result = await routeRequest(req({ requested_model: "gpt-4o" }), d, {
+      allowCustomModel: false,
+      keyCaps: { allowedLanes: null, blockedModels: ["gpt-4o"] },
+    });
+
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(result.error?.message).toContain('model "gpt-4o" is blocked for this key');
+    expect(d.execute).not.toHaveBeenCalled();
+    expect(d.classify).not.toHaveBeenCalled();
+  });
+
+  it("removes blocked models from a classified lane chain before execution", async () => {
+    const d = deps();
+    const result = await routeRequest(req(), d, {
+      keyCaps: { allowedLanes: null, blockedModels: ["coder_a", "best_reasoning_model"] },
+    });
+
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("coding");
+    expect(plan.candidate_chain).toEqual(["coder_b", "default_good_model"]);
+    expect(plan.candidate_chain).not.toContain("coder_a");
+    expect(plan.candidate_chain).not.toContain("best_reasoning_model");
+  });
+
+  it("removes blocked models from an explicit lane fallback chain", async () => {
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "premium" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: ["premium"], blockedModels: ["best_reasoning_model"] },
+    });
+
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+    expect(plan.candidate_chain).toEqual(["default_good_model"]);
+  });
+
+  it("does not treat a blocked_models string as a lane blacklist", async () => {
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "premium" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: null, blockedModels: ["premium"] },
+    });
+
+    expect(result.final.status).toBe("ok");
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe("premium");
+    expect(plan.explicit_model).toBeNull();
+  });
+
+  it("rejects a lane when blocked_models removes every candidate in its chain", async () => {
+    const d = deps();
+    const result = await routeRequest(req({ requested_model: "premium" }), d, {
+      allowCustomModel: true,
+      keyCaps: {
+        allowedLanes: ["premium"],
+        blockedModels: ["best_reasoning_model", "default_good_model"],
+      },
+    });
+
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(result.error?.message).toContain('all candidate models for lane "premium"');
+    expect(d.execute).not.toHaveBeenCalled();
+    const rec = (d.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.lane.selected_lane).toBe("premium");
+    expect(rec.lane.candidate_chain).toEqual([]);
+  });
+});
+
 // Virtual model-alias map (docs/04): a vendor model id (e.g. Claude Code's
 // "claude-opus-4-8") is rewritten onto a lane / "auto" BEFORE the passthrough
 // gate, so a fixed-model client routes without a 400 even on a default key.
@@ -838,6 +960,19 @@ describe("routeRequest — virtual model aliases", () => {
     expect(rec.requested_model).toBe("claude-opus-4-8");
     expect(rec.lane.selected_lane).toBe("premium");
     expect(rec.policy.reason).toContain("alias");
+  });
+
+  it("rejects an alias-mapped model when the requested model is blocked for this key", async () => {
+    const d = deps({ modelAliases: { "claude-opus-4-8": "premium" } });
+    const result = await routeRequest(req({ requested_model: "claude-opus-4-8" }), d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: null, blockedModels: ["claude-opus-4-8"] },
+    });
+
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(result.error?.message).toContain("blocked for this key");
+    expect(d.execute).not.toHaveBeenCalled();
   });
 
   it("resolves the alias BEFORE the unknown-model 400 on an allow_custom_model key", async () => {

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -229,7 +229,12 @@ export interface RouteOptions {
    *  target lane (ranked OR a task lane) and cannot be bypassed by explicit-model
    *  passthrough (passthrough is suppressed while degrading). The forced lane is
    *  still clamped to `allowedLanes` (the harder security bound). */
-  keyCaps?: { allowedLanes: string[] | null; degradeLane?: string | null };
+  keyCaps?: {
+    allowedLanes: string[] | null;
+    degradeLane?: string | null;
+    /** Exact model ids this key may never use, including lane/fallback chains. */
+    blockedModels?: string[] | null;
+  };
 }
 
 export interface RoutingSignalFeedbackDeps {
@@ -344,13 +349,17 @@ interface PlanDecision {
   evalUsd: number | null;
 }
 
-// An explicit passthrough rejected BEFORE execution (unknown model / lane not in
-// the key's allowed_lanes — docs/04 strict validation). Carries everything the
-// orchestrator needs to log a complete error DecisionRecord without executing:
-// `selectedLane` is the requested name (chain stays empty — nothing was planned).
+// A routing decision rejected BEFORE execution (unknown explicit model, lane not
+// in the key's allowed_lanes, or blocked_models removing every candidate). Carries
+// everything needed to log a complete error DecisionRecord without executing.
 interface PlanRejection {
   reject: HelmError;
   selectedLane: string;
+  candidateChain?: string[];
+  classifier?: DecisionRecord["classifier"];
+  policy?: DecisionRecord["policy"];
+  forcedReasoningEffort?: ReasoningEffort | null;
+  evalUsd?: number | null;
 }
 
 function isRejection(p: PlanDecision | PlanRejection): p is PlanRejection {
@@ -383,6 +392,22 @@ function signalSummary(signal: RoutingSignal): Record<string, unknown> {
   };
 }
 
+function blockedModelSetForCaps(keyCaps: RouteOptions["keyCaps"]): Set<string> | null {
+  const blocked = keyCaps?.blockedModels;
+  if (!Array.isArray(blocked) || blocked.length === 0) return null;
+  return new Set(blocked);
+}
+
+function laneHasPermittedModel(
+  lane: string,
+  lanes: LanesConfig,
+  keyCaps: RouteOptions["keyCaps"],
+): boolean {
+  const blocked = blockedModelSetForCaps(keyCaps);
+  if (blocked === null) return true;
+  return expandChain(lane, lanes).some((alias) => !blocked.has(alias));
+}
+
 function isDegradedSignal(signal: RoutingSignal, thresholds: SignalFeedbackThresholds): boolean {
   if (signal.samples < thresholds.minSamples) return false;
   return (
@@ -412,6 +437,7 @@ function strongerRankedLanes(selectedLane: string, lanes: LanesConfig): string[]
 
 function candidateAllowedByCaps(
   candidateLane: string,
+  lanes: LanesConfig,
   policyOutcome: ReturnType<typeof evaluatePolicies>,
   keyCaps: RouteOptions["keyCaps"],
 ): boolean {
@@ -424,7 +450,8 @@ function candidateAllowedByCaps(
     reasoning_effort: null,
     reason: "key caps",
   });
-  return capped === candidateLane;
+  if (capped !== candidateLane) return false;
+  return laneHasPermittedModel(candidateLane, lanes, keyCaps);
 }
 
 async function maybeApplySignalFeedback(args: {
@@ -447,7 +474,7 @@ async function maybeApplySignalFeedback(args: {
 
   const thresholds = signalThresholds(feedback);
   const candidates = strongerRankedLanes(selectedLane, lanes).filter((candidate) =>
-    candidateAllowedByCaps(candidate, policyOutcome, keyCaps),
+    candidateAllowedByCaps(candidate, lanes, policyOutcome, keyCaps),
   );
   if (candidates.length === 0) return null;
 
@@ -509,6 +536,47 @@ function passthroughClassifier(): DecisionRecord["classifier"] {
   };
 }
 
+function blockedModelSet(opts: RouteOptions): Set<string> | null {
+  return blockedModelSetForCaps(opts.keyCaps);
+}
+
+function filterBlockedModels(chain: string[], opts: RouteOptions): string[] {
+  const blocked = blockedModelSet(opts);
+  if (blocked === null) return chain;
+  const filtered = chain.filter((alias) => !blocked.has(alias));
+  return filtered.length === chain.length ? chain : filtered;
+}
+
+function isDirectBlockedModel(req: InternalRequest, deps: RouteDeps, opts: RouteOptions): boolean {
+  const model = req.requested_model;
+  if (model.length === 0 || model === "auto") return false;
+  if (Object.hasOwn(deps.lanes, model)) return false;
+  return blockedModelSet(opts)?.has(model) === true;
+}
+
+function noPermittedModelsRejection(args: {
+  req: InternalRequest;
+  selectedLane: string;
+  classifier: DecisionRecord["classifier"];
+  policy: DecisionRecord["policy"];
+  forcedReasoningEffort: ReasoningEffort | null;
+  evalUsd: number | null;
+}): PlanRejection {
+  return {
+    reject: makeHelmError({
+      error_class: "invalid_request",
+      message: `all candidate models for lane "${args.selectedLane}" are blocked for this key`,
+      trace_id: args.req.request_id,
+    }),
+    selectedLane: args.selectedLane,
+    candidateChain: [],
+    classifier: args.classifier,
+    policy: args.policy,
+    forcedReasoningEffort: args.forcedReasoningEffort,
+    evalUsd: args.evalUsd,
+  };
+}
+
 // Compute the execution plan + the classifier/policy decision segments. Explicit
 // passthrough short-circuits classify/policy/resolver entirely (docs/04: highest
 // priority, gated by allow_custom_model).
@@ -517,6 +585,22 @@ async function plan(
   deps: RouteDeps,
   opts: RouteOptions,
 ): Promise<PlanDecision | PlanRejection> {
+  if (isDirectBlockedModel(req, deps, opts)) {
+    return {
+      reject: makeHelmError({
+        error_class: "invalid_request",
+        message: `model "${req.requested_model}" is blocked for this key`,
+        trace_id: req.request_id,
+      }),
+      selectedLane: req.requested_model,
+      candidateChain: [],
+      classifier: passthroughClassifier(),
+      policy: { matched_policy_id: null, reason: "blocked model rejected" },
+      forcedReasoningEffort: null,
+      evalUsd: null,
+    };
+  }
+
   // 0pre) IMAGE-GENERATION models are ALWAYS model-pinned to their exact alias —
   //    for ANY key, regardless of allow_custom_model, and AHEAD of the alias-glob
   //    shim (§0a) and classification (§2). An image model has no "auto"/classify
@@ -582,19 +666,34 @@ async function plan(
       });
     }
     const clamped = lane !== aliasTarget;
+    const chain = filterBlockedModels(
+      promoteRequestedModel(expandChain(lane, deps.lanes), req.requested_model),
+      opts,
+    );
+    const policy = {
+      matched_policy_id: outcome.matched_policy_id,
+      reason: clamped
+        ? `model alias "${req.requested_model}" -> lane "${aliasTarget}" (capped to "${lane}")`
+        : `model alias "${req.requested_model}" -> lane "${aliasTarget}"`,
+    };
+    if (chain.length === 0) {
+      return noPermittedModelsRejection({
+        req,
+        selectedLane: lane,
+        classifier: passthroughClassifier(),
+        policy,
+        forcedReasoningEffort: outcome.reasoning_effort,
+        evalUsd: null,
+      });
+    }
     return {
       plan: {
         selected_lane: lane,
-        candidate_chain: promoteRequestedModel(expandChain(lane, deps.lanes), req.requested_model),
+        candidate_chain: chain,
         explicit_model: null,
       },
       classifier: passthroughClassifier(),
-      policy: {
-        matched_policy_id: outcome.matched_policy_id,
-        reason: clamped
-          ? `model alias "${req.requested_model}" -> lane "${aliasTarget}" (capped to "${lane}")`
-          : `model alias "${req.requested_model}" -> lane "${aliasTarget}"`,
-      },
+      policy,
       forcedReasoningEffort: outcome.reasoning_effort,
       evalUsd: null,
     };
@@ -641,14 +740,26 @@ async function plan(
           selectedLane: model,
         };
       }
+      const policy = { matched_policy_id: null, reason: "explicit lane passthrough" };
+      const chain = filterBlockedModels(expandChain(model, deps.lanes), opts);
+      if (chain.length === 0) {
+        return noPermittedModelsRejection({
+          req,
+          selectedLane: model,
+          classifier: passthroughClassifier(),
+          policy,
+          forcedReasoningEffort: null,
+          evalUsd: null,
+        });
+      }
       return {
         plan: {
           selected_lane: model,
-          candidate_chain: expandChain(model, deps.lanes),
+          candidate_chain: chain,
           explicit_model: null,
         },
         classifier: passthroughClassifier(),
-        policy: { matched_policy_id: null, reason: "explicit lane passthrough" },
+        policy,
         forcedReasoningEffort: null,
         evalUsd: null,
       };
@@ -731,34 +842,51 @@ async function plan(
   // suppression in steps 0a/1). In those cases the request behaves as auto, so
   // pass no requested model and keep the degrade/classified lane's declared order.
   const honorRequestedModel = !aliasToAuto && opts.keyCaps?.degradeLane == null;
-  const chain = promoteRequestedModel(
-    expandChain(cappedLane, deps.lanes),
-    honorRequestedModel ? req.requested_model : "",
+  const chain = filterBlockedModels(
+    promoteRequestedModel(
+      expandChain(cappedLane, deps.lanes),
+      honorRequestedModel ? req.requested_model : "",
+    ),
+    opts,
   );
   const explanation =
     signalAdjustment === null
       ? cls.explanation
       : [...cls.explanation, signalAdjustment.explanation];
 
+  const classifier: DecisionRecord["classifier"] = {
+    task_type: cls.task_type,
+    complexity: cls.complexity,
+    confidence: cls.confidence,
+    decided_by: cls.decided_by,
+    // Thread Layer-2 eval observability straight from the classify adapter
+    // (cascade). null/undefined collapse to null so the record never carries
+    // an ambiguous undefined (principle 5: classification fields only).
+    rules_confidence: cls.rules_confidence ?? null,
+    eval_cache_hit: cls.eval_cache_hit ?? null,
+    eval_model: cls.eval_model ?? null,
+    eval_latency_ms: cls.eval_latency_ms ?? null,
+    fallback_reason: cls.fallback_reason ?? null,
+    constraints: cls.constraints as Record<string, unknown>,
+    explanation,
+  };
+  const policy = { matched_policy_id: outcome.matched_policy_id, reason: outcome.reason };
+
+  if (chain.length === 0) {
+    return noPermittedModelsRejection({
+      req,
+      selectedLane: cappedLane,
+      classifier,
+      policy,
+      forcedReasoningEffort: outcome.reasoning_effort,
+      evalUsd: cls.eval_usd ?? null,
+    });
+  }
+
   return {
     plan: { selected_lane: cappedLane, candidate_chain: chain, explicit_model: null },
-    classifier: {
-      task_type: cls.task_type,
-      complexity: cls.complexity,
-      confidence: cls.confidence,
-      decided_by: cls.decided_by,
-      // Thread Layer-2 eval observability straight from the classify adapter
-      // (cascade). null/undefined collapse to null so the record never carries
-      // an ambiguous undefined (principle 5: classification fields only).
-      rules_confidence: cls.rules_confidence ?? null,
-      eval_cache_hit: cls.eval_cache_hit ?? null,
-      eval_model: cls.eval_model ?? null,
-      eval_latency_ms: cls.eval_latency_ms ?? null,
-      fallback_reason: cls.fallback_reason ?? null,
-      constraints: cls.constraints as Record<string, unknown>,
-      explanation,
-    },
-    policy: { matched_policy_id: outcome.matched_policy_id, reason: outcome.reason },
+    classifier,
+    policy,
     forcedReasoningEffort: outcome.reasoning_effort,
     evalUsd: cls.eval_usd ?? null,
   };
@@ -771,10 +899,10 @@ export async function routeRequest(
 ): Promise<ExecutionResult> {
   const planned = await plan(req, deps, opts);
 
-  // Explicit passthrough rejected before execution (unknown model / lane not
-  // permitted): no provider was attempted, but the rejection is still a routing
-  // decision — log a complete error record (empty chain, no attempts, costs
-  // unknown) so it shows up in the Debug UI like any other terminal error.
+  // Rejected before execution (unknown model, lane not permitted, or every
+  // candidate blocked for this key): no provider was attempted, but the rejection
+  // is still a routing decision — log a complete error record so it shows up in
+  // the Debug UI like any other terminal error.
   if (isRejection(planned)) {
     const decision: DecisionRecord = {
       request_id: req.request_id,
@@ -782,9 +910,12 @@ export async function routeRequest(
       requested_model: req.requested_model,
       protocol: req.protocol,
       key_prefix: opts.keyPrefix ?? null,
-      classifier: passthroughClassifier(),
-      policy: { matched_policy_id: null, reason: "explicit passthrough rejected" },
-      lane: { selected_lane: planned.selectedLane, candidate_chain: [] },
+      classifier: planned.classifier ?? passthroughClassifier(),
+      policy: planned.policy ?? {
+        matched_policy_id: null,
+        reason: "explicit passthrough rejected",
+      },
+      lane: { selected_lane: planned.selectedLane, candidate_chain: planned.candidateChain ?? [] },
       provider_attempts: [],
       final: {
         model_alias: null,
@@ -794,7 +925,11 @@ export async function routeRequest(
       },
       latency_total_ms: 0,
       fallback_count: 0,
-      cost_breakdown: { eval_usd: null, completion_usd: null, total_usd: null },
+      cost_breakdown: {
+        eval_usd: planned.evalUsd ?? null,
+        completion_usd: null,
+        total_usd: planned.evalUsd ?? null,
+      },
       // Stamped by the GATEWAY after inject ran (memory is a middleware) — the
       // routing core always emits null.
       memory: null,

--- a/packages/core/src/store/cached-keystore.test.ts
+++ b/packages/core/src/store/cached-keystore.test.ts
@@ -12,6 +12,7 @@ function rec(keyId: string, hash: string): ApiKeyRecord {
     role: "user",
     allowed_lanes: null,
     allow_custom_model: false,
+    blocked_models: null,
     disabled: false,
     rate_limit_rpm: null,
     rate_limit_tpm: null,

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -33,6 +33,7 @@ class InMemoryKeyStore implements KeyStore {
       name: input.name ?? null,
       allowed_lanes: input.allowedLanes ?? null,
       allow_custom_model: input.allowCustomModel ?? false,
+      blocked_models: input.blockedModels ?? null,
       allow_fast_mode: input.allowFastMode ?? false,
       disabled: false,
       rate_limit_rpm: input.rateLimitRpm ?? null,
@@ -73,6 +74,7 @@ class InMemoryKeyStore implements KeyStore {
     const next = { ...r };
     if (patch.allowedLanes !== undefined) next.allowed_lanes = patch.allowedLanes;
     if (patch.allowCustomModel !== undefined) next.allow_custom_model = patch.allowCustomModel;
+    if (patch.blockedModels !== undefined) next.blocked_models = patch.blockedModels;
     if (patch.allowFastMode !== undefined) next.allow_fast_mode = patch.allowFastMode;
     if (patch.rateLimitRpm !== undefined) next.rate_limit_rpm = patch.rateLimitRpm;
     if (patch.rateLimitTpm !== undefined) next.rate_limit_tpm = patch.rateLimitTpm;
@@ -389,6 +391,7 @@ describe("port type contracts", () => {
       | "name"
       | "allowedLanes"
       | "allowCustomModel"
+      | "blockedModels"
       | "allowFastMode"
       | "rateLimitRpm"
       | "rateLimitTpm"

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -158,6 +158,9 @@ export interface CreateKeyInput {
   name?: string;
   allowedLanes?: string[];
   allowCustomModel?: boolean;
+  // Exact client-facing model ids this key may not request when explicit model
+  // passthrough is enabled. Omitted => NULL => no blacklist.
+  blockedModels?: string[];
   // Per-key cap for CLIENT-requested Fast mode passthrough. Server/account-level
   // forced Fast mode is controlled separately by account settings.
   allowFastMode?: boolean;
@@ -229,6 +232,8 @@ export interface KeyPatch {
   name?: string | null;
   allowedLanes?: string[] | null;
   allowCustomModel?: boolean;
+  // null clears the blacklist; omitted leaves it untouched.
+  blockedModels?: string[] | null;
   allowFastMode?: boolean;
   rateLimitRpm?: number | null;
   rateLimitTpm?: number | null;

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -30,6 +30,7 @@ export class PgKeyStore implements KeyStore {
       name: input.name ?? null,
       allowedLanes: input.allowedLanes ?? null,
       allowCustomModel: input.allowCustomModel ?? false,
+      blockedModels: input.blockedModels ?? null,
       allowFastMode: input.allowFastMode ?? false,
       disabled: false,
       // Per-key rate-limit override: undefined input => NULL => inherit system default.
@@ -105,6 +106,7 @@ export class PgKeyStore implements KeyStore {
         | "name"
         | "allowedLanes"
         | "allowCustomModel"
+        | "blockedModels"
         | "allowFastMode"
         | "rateLimitRpm"
         | "rateLimitTpm"
@@ -125,6 +127,7 @@ export class PgKeyStore implements KeyStore {
     // Native jsonb: assign the array (or null = no cap) directly, no stringify.
     if (patch.allowedLanes !== undefined) set.allowedLanes = patch.allowedLanes;
     if (patch.allowCustomModel !== undefined) set.allowCustomModel = patch.allowCustomModel;
+    if (patch.blockedModels !== undefined) set.blockedModels = patch.blockedModels;
     if (patch.allowFastMode !== undefined) set.allowFastMode = patch.allowFastMode;
     if (patch.rateLimitRpm !== undefined) set.rateLimitRpm = patch.rateLimitRpm;
     if (patch.rateLimitTpm !== undefined) set.rateLimitTpm = patch.rateLimitTpm;
@@ -191,6 +194,7 @@ export class PgKeyStore implements KeyStore {
       name: row.name ?? null,
       allowed_lanes: row.allowedLanes ?? null,
       allow_custom_model: row.allowCustomModel,
+      blocked_models: row.blockedModels ?? null,
       allow_fast_mode: row.allowFastMode,
       disabled: row.disabled,
       rate_limit_rpm: row.rateLimitRpm ?? null,

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -205,6 +205,40 @@ describe("runPgMigrations — per-migration atomicity", () => {
     await db.$close();
   });
 
+  it("v37 adds blocked_models for per-key model blacklists", async () => {
+    const client = new PGlite();
+    const db = Object.assign(drizzlePglite(client), { $close: () => client.close() });
+    await db.execute(
+      sql.raw("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at BIGINT NOT NULL)"),
+    );
+    await db.execute(sql.raw("CREATE TABLE api_keys (key_id TEXT PRIMARY KEY)"));
+    for (let version = 1; version <= 36; version++) {
+      await db.execute(
+        sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
+      );
+    }
+
+    await expect(runPgMigrations(db)).resolves.toBeUndefined();
+
+    const columns = (await db.execute(
+      sql.raw(`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'api_keys'
+      `),
+    )) as { rows: Array<{ column_name: string }> };
+    expect(columns.rows.map((r) => r.column_name)).toContain("blocked_models");
+    await db.execute(
+      sql.raw("INSERT INTO api_keys (key_id, blocked_models) VALUES ('k1', '[\"gpt-4o\"]'::jsonb)"),
+    );
+    const row = (await db.execute(
+      sql.raw("SELECT blocked_models FROM api_keys WHERE key_id = 'k1'"),
+    )) as { rows: Array<{ blocked_models: string[] }> };
+    expect(row.rows[0]?.blocked_models).toEqual(["gpt-4o"]);
+    await db.$close();
+  });
+
   it("creates memory job admin-stats indexes", async () => {
     const db = await createPgliteDb();
     const indexes = (await db.execute(

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -778,6 +778,18 @@ const MIGRATIONS: readonly Migration[] = [
         ON telemetry (api_key_id, created_at, model_search);
     `,
   },
+  {
+    // Per-key model blacklist. Nullable jsonb array; removes exact models from
+    // direct requests and all lane/fallback chains.
+    version: 37,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "api_keys", ["key_id"])) {
+        await db.execute(
+          sql.raw("ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS blocked_models JSONB"),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {
@@ -788,7 +800,7 @@ function resultRows<T>(result: unknown): T[] {
 
 async function pgTableHasColumns(
   db: RawExecutor,
-  table: "memory_threads" | "memory_messages" | "memory_jobs" | "oauth_quota",
+  table: "api_keys" | "memory_threads" | "memory_messages" | "memory_jobs" | "oauth_quota",
   requiredColumns: readonly string[],
 ): Promise<boolean> {
   const rows = resultRows<{ column_name: string }>(

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -41,6 +41,7 @@ export const apiKeys = pgTable("api_keys", {
   name: text("name"), // human-readable label; NULL = unnamed (cosmetic only)
   allowedLanes: jsonb("allowed_lanes").$type<string[]>(), // native jsonb array
   allowCustomModel: boolean("allow_custom_model").notNull().default(false),
+  blockedModels: jsonb("blocked_models").$type<string[]>(), // exact model id blacklist
   allowFastMode: boolean("allow_fast_mode").notNull().default(false),
   disabled: boolean("disabled").notNull().default(false),
   // Per-key rate-limit override (docs/06). Nullable: NULL = inherit the system

--- a/packages/core/src/store/sqlite/keystore.test.ts
+++ b/packages/core/src/store/sqlite/keystore.test.ts
@@ -18,6 +18,7 @@ describe("SqliteKeyStore", () => {
       role: "user",
       allowedLanes: ["economy", "balanced"],
       allowCustomModel: true,
+      blockedModels: ["gpt-4o"],
       allowFastMode: true,
     });
     const got = await store.getByHash("sha256_h1");
@@ -30,6 +31,7 @@ describe("SqliteKeyStore", () => {
       role: "user",
       allowed_lanes: ["economy", "balanced"],
       allow_custom_model: true,
+      blocked_models: ["gpt-4o"],
       allow_fast_mode: true,
       disabled: false,
     });
@@ -223,21 +225,24 @@ describe("SqliteKeyStore", () => {
     await store.updateKey("k1", {
       allowedLanes: ["economy", "balanced"],
       allowCustomModel: true,
+      blockedModels: ["gpt-4o", "anthropic/claude-sonnet-4-6"],
       allowFastMode: true,
     });
     let got = await store.getByHash("h1");
     expect(got?.allowed_lanes).toEqual(["economy", "balanced"]);
     expect(got?.allow_custom_model).toBe(true);
+    expect(got?.blocked_models).toEqual(["gpt-4o", "anthropic/claude-sonnet-4-6"]);
     expect(got?.allow_fast_mode).toBe(true);
     // an unrelated column (rate limit) is left untouched
     expect(got?.rate_limit_rpm).toBe(7);
     // role is never written by updateKey
     expect(got?.role).toBe("user");
     // null clears the whitelist back to "no cap"
-    await store.updateKey("k1", { allowedLanes: null });
+    await store.updateKey("k1", { allowedLanes: null, blockedModels: null });
     got = await store.getByHash("h1");
     expect(got?.allowed_lanes).toBeNull();
     expect(got?.allow_custom_model).toBe(true);
+    expect(got?.blocked_models).toBeNull();
     expect(got?.allow_fast_mode).toBe(true);
   });
 

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -29,6 +29,7 @@ export class SqliteKeyStore implements KeyStore {
       name: input.name ?? null,
       allowedLanes: input.allowedLanes ? JSON.stringify(input.allowedLanes) : null,
       allowCustomModel: input.allowCustomModel ?? false,
+      blockedModels: input.blockedModels ? JSON.stringify(input.blockedModels) : null,
       allowFastMode: input.allowFastMode ?? false,
       disabled: false,
       // Per-key rate-limit override: undefined input => NULL => inherit system default.
@@ -104,6 +105,7 @@ export class SqliteKeyStore implements KeyStore {
         | "name"
         | "allowedLanes"
         | "allowCustomModel"
+        | "blockedModels"
         | "allowFastMode"
         | "rateLimitRpm"
         | "rateLimitTpm"
@@ -126,6 +128,9 @@ export class SqliteKeyStore implements KeyStore {
       set.allowedLanes = patch.allowedLanes === null ? null : JSON.stringify(patch.allowedLanes);
     }
     if (patch.allowCustomModel !== undefined) set.allowCustomModel = patch.allowCustomModel;
+    if (patch.blockedModels !== undefined) {
+      set.blockedModels = patch.blockedModels === null ? null : JSON.stringify(patch.blockedModels);
+    }
     if (patch.allowFastMode !== undefined) set.allowFastMode = patch.allowFastMode;
     if (patch.rateLimitRpm !== undefined) set.rateLimitRpm = patch.rateLimitRpm;
     if (patch.rateLimitTpm !== undefined) set.rateLimitTpm = patch.rateLimitTpm;
@@ -190,6 +195,7 @@ export class SqliteKeyStore implements KeyStore {
       name: row.name ?? null,
       allowed_lanes: row.allowedLanes ? (JSON.parse(row.allowedLanes) as string[]) : null,
       allow_custom_model: row.allowCustomModel,
+      blocked_models: row.blockedModels ? (JSON.parse(row.blockedModels) as string[]) : null,
       allow_fast_mode: row.allowFastMode,
       disabled: row.disabled,
       rate_limit_rpm: row.rateLimitRpm ?? null,

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -878,6 +878,19 @@ const MIGRATIONS: readonly Migration[] = [
         ON telemetry (api_key_id, created_at, model_search);
     `,
   },
+  {
+    // Per-key model blacklist. Nullable JSON text array; removes exact models
+    // from direct requests and all lane/fallback chains.
+    version: 38,
+    run: (db) => {
+      if (
+        sqliteTableHasColumns(db, "api_keys", ["key_id"]) &&
+        !sqliteTableHasColumns(db, "api_keys", ["blocked_models"])
+      ) {
+        db.exec("ALTER TABLE api_keys ADD COLUMN blocked_models TEXT;");
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -143,6 +143,7 @@ describe("sqlite schema + migrations", () => {
       "role",
       "allowed_lanes",
       "allow_custom_model",
+      "blocked_models",
       "allow_fast_mode",
       "disabled",
       "created_at",

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -19,6 +19,7 @@ export const apiKeys = sqliteTable("api_keys", {
   allowCustomModel: integer("allow_custom_model", { mode: "boolean" }) // SQLite has no native boolean
     .notNull()
     .default(false),
+  blockedModels: text("blocked_models"), // JSON text array of exact model ids; NULL = no blacklist
   allowFastMode: integer("allow_fast_mode", { mode: "boolean" }).notNull().default(false),
   disabled: integer("disabled", { mode: "boolean" }).notNull().default(false),
   // Per-key rate-limit override (docs/06). Nullable: NULL = inherit the system

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -434,18 +434,21 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       await ctx.stores.keys.updateKey("k1", {
         allowedLanes: ["economy", "balanced"],
         allowCustomModel: true,
+        blockedModels: ["gpt-4o"],
         allowFastMode: true,
       });
       let got = await ctx.stores.keys.getByHash("h1");
       expect(got?.allowed_lanes).toEqual(["economy", "balanced"]);
       expect(got?.allow_custom_model).toBe(true);
+      expect(got?.blocked_models).toEqual(["gpt-4o"]);
       expect(got?.allow_fast_mode).toBe(true);
       expect(got?.role).toBe("user"); // never rewritten by updateKey
       // null clears the whitelist back to "no cap"; an omitted field is left untouched.
-      await ctx.stores.keys.updateKey("k1", { allowedLanes: null });
+      await ctx.stores.keys.updateKey("k1", { allowedLanes: null, blockedModels: null });
       got = await ctx.stores.keys.getByHash("h1");
       expect(got?.allowed_lanes).toBeNull();
       expect(got?.allow_custom_model).toBe(true);
+      expect(got?.blocked_models).toBeNull();
       expect(got?.allow_fast_mode).toBe(true);
     });
 

--- a/packages/shared/src/key/schema.test.ts
+++ b/packages/shared/src/key/schema.test.ts
@@ -32,6 +32,24 @@ describe("ApiKeyRecordSchema", () => {
     expect(ApiKeyRecordSchema.safeParse(withCaps).success).toBe(true);
   });
 
+  it("accepts per-key blocked model ids and defaults legacy rows to no blacklist", () => {
+    const legacy = ApiKeyRecordSchema.parse(fullKey());
+    expect(legacy.blocked_models).toBeNull();
+
+    const parsed = ApiKeyRecordSchema.parse({
+      ...fullKey(),
+      blocked_models: ["gpt-4o", "anthropic/claude-sonnet-4-6"],
+    });
+    expect(parsed.blocked_models).toEqual(["gpt-4o", "anthropic/claude-sonnet-4-6"]);
+  });
+
+  it("rejects blank blocked model ids on create/update payloads", () => {
+    expect(CreateKeyRequestSchema.safeParse({ blocked_models: ["gpt-4o", "  "] }).success).toBe(
+      false,
+    );
+    expect(UpdateKeyRequestSchema.safeParse({ blocked_models: [""] }).success).toBe(false);
+  });
+
   it("enforces the role enum", () => {
     for (const r of ["root", "user"] as const) {
       expect(ApiKeyRecordSchema.safeParse({ ...fullKey(), role: r }).success).toBe(true);

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -28,6 +28,10 @@ export const MemoryThreadSourceSchema = z.enum(["header", "auto"]);
 // update schemas so the three can never drift apart.
 const KeyNameSchema = z.string().trim().min(1).max(100);
 
+// Exact client-facing model ids blocked for this API key across direct requests
+// and lane/fallback chains. Trim only; do not lowercase provider/model ids.
+const BlockedModelsSchema = z.array(z.string().trim().min(1)).nullable();
+
 export const ApiKeyRecordSchema = z.object({
   key_id: z.string().min(1),
   hash: z.string().min(1), // sha256(plaintext) hex; never the plaintext
@@ -42,6 +46,9 @@ export const ApiKeyRecordSchema = z.object({
   // Per-key caps (docs/06): present-but-nullable so the storage shape is explicit.
   allowed_lanes: z.array(z.string()).nullable(),
   allow_custom_model: z.boolean(),
+  // Per-key model blacklist. It removes exact models from every route this key
+  // can take; legacy rows default to null = no blacklist.
+  blocked_models: BlockedModelsSchema.default(null),
   // Per-key Fast-mode passthrough cap. false = client-requested Fast is downgraded
   // unless the serving subscription account itself has Fast mode forced on.
   allow_fast_mode: z.boolean().default(false),
@@ -118,6 +125,7 @@ export const CreateKeyRequestSchema = z
     name: KeyNameSchema.optional(),
     allowed_lanes: z.array(z.string().min(1)).optional(),
     allow_custom_model: z.boolean().optional(),
+    blocked_models: z.array(z.string().trim().min(1)).optional(),
     allow_fast_mode: z.boolean().optional(),
     // Optional per-key rate limits at mint time. Omitted => inherit the system
     // default. 0 => explicitly unlimited for that dimension (Principle 2 fail-closed on
@@ -164,6 +172,7 @@ export const UpdateKeyRequestSchema = z
     name: KeyNameSchema.nullable().optional(),
     allowed_lanes: z.array(z.string().min(1)).nullable().optional(),
     allow_custom_model: z.boolean().optional(),
+    blocked_models: BlockedModelsSchema.optional(),
     allow_fast_mode: z.boolean().optional(),
     rate_limit_rpm: z.number().int().nonnegative().nullable().optional(),
     rate_limit_tpm: z.number().int().nonnegative().nullable().optional(),


### PR DESCRIPTION
## Summary
- add `blocked_models` to API key schema, stores, migrations, and admin key forms
- enforce blocked concrete models before direct execution and strip them from lane/alias/fallback chains
- hide blocked aliases and empty lanes from `/v1/models`, and cover chat/messages/images/interactions/replay paths

## Validation
- pnpm exec vitest run packages/core/src/routing/route-request.test.ts apps/gateway/src/routes/messages-pipeline.test.ts apps/gateway/src/routes/admin/replay.test.ts
- pnpm exec vitest run packages/core/src/store/postgres/migrate.test.ts
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm build
- git diff --check

Co-Authored-By: Codex <noreply@openai.com>