### PR TITLE
Release v0.25.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.16",
+  "version": "0.25.17",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump Helm API to v0.25.17 so the publish workflow cuts a release for PR #485.

## Verification
- Version-only release bump; functional checks already passed on #485.