### PR TITLE
Fix Anthropic cache optimization on compatibility path

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -133,6 +133,7 @@ function protocolRegistry(
       providerName: string;
       providerModel: string;
       targetProviderProtocol: TargetProviderProtocol;
+      providerRequiresCompatibilityRewrite?: boolean;
     }
   >,
 ): ProviderRegistry {
@@ -149,7 +150,7 @@ function protocolRegistry(
           baseUrl: "http://x",
           apiKeyEnv: "X",
           targetProviderProtocol: hit.targetProviderProtocol,
-          providerRequiresCompatibilityRewrite: false,
+          providerRequiresCompatibilityRewrite: hit.providerRequiresCompatibilityRewrite === true,
         },
       };
     },
@@ -2187,6 +2188,91 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.final.status).toBe("ok");
     expect(out.attempts[0]).toMatchObject({ alias: "fable", skipped: false, status: "ok" });
     expect(provider.nativePassthrough).toHaveBeenCalledOnce();
+  });
+
+  it("applies visual context compression on Anthropic compatibility rewrite attempts", async () => {
+    const provider = {
+      chatCompletion: vi.fn(async (_body: Record<string, unknown>, opts) => {
+        const upstreamBody = await opts?.optimizeAnthropicBody?.({
+          model: "claude-fable-5",
+          system: [{ type: "text", text: "stable prefix", cache_control: { type: "ephemeral" } }],
+          messages: [{ role: "user", content: [{ type: "text", text: "large visual context" }] }],
+          max_tokens: 64,
+        });
+        expect(upstreamBody).toMatchObject({ compressed: true });
+        return {
+          id: "ok",
+          usage: { input_tokens: 10, output_tokens: 1 },
+        };
+      }),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        fable: {
+          providerName: "mock",
+          providerModel: "claude-fable-5",
+          targetProviderProtocol: "anthropic_messages",
+          providerRequiresCompatibilityRewrite: true,
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map([["fable", entry("fable")]]),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+      visualContextCompressionMode: () => "enabled",
+      visualContextCompressor: async ({ body }) => ({
+        body: { ...body, compressed: true },
+        mutation: {
+          mode: "enabled",
+          applied: true,
+          would_apply: true,
+          reason: "applied",
+          orig_chars: 50_000,
+          compressed_chars: 42_000,
+          image_count: 1,
+          image_bytes: 12_000,
+          owns_cache_control: true,
+          marker_count: 1,
+        },
+      }),
+    });
+
+    const out = await execute(
+      plan(["fable"]),
+      req({
+        protocol: "anthropic_messages",
+        requested_model: "claude-fable-5",
+        native_request: createNativePassthroughCarrier({
+          protocol: "anthropic_messages",
+          body: {
+            model: "anthropic/claude-fable-5",
+            system: [{ type: "text", text: "stable prefix", cache_control: { type: "ephemeral" } }],
+            messages: [{ role: "user", content: "large visual context" }],
+            max_tokens: 64,
+          },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    expect(provider.chatCompletion).toHaveBeenCalledOnce();
+    expect(provider.nativePassthrough).not.toHaveBeenCalled();
+    expect(out.attempts[0]?.passthrough_used).toBe(false);
+    expect(out.attempts[0]?.passthrough_disable_reason).toBe(
+      "provider_requires_compatibility_rewrite",
+    );
+    expect(out.attempts[0]?.request_mutations?.visual_context_compression).toMatchObject({
+      mode: "enabled",
+      applied: true,
+      would_apply: true,
+      reason: "applied",
+    });
   });
 
   // ── capability-wire: the real catalog feeds the capability filter ──────────

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1361,30 +1361,36 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       });
       let visualCompressionMutation: VisualContextCompressionMutation | undefined;
       let optimizedNativeBody: Record<string, unknown> | null = null;
+      const optimizeAnthropicBodyForAttempt = async (
+        body: Record<string, unknown>,
+      ): Promise<Record<string, unknown>> => {
+        if (target.targetProviderProtocol !== "anthropic_messages") return body;
+        try {
+          const optimized = await visualContextCompressor({
+            mode: visualContextCompressionMode?.() ?? "off",
+            targetProviderProtocol: target.targetProviderProtocol,
+            model: providerModel,
+            body,
+            capabilities: caps,
+            requestId: req.request_id,
+          });
+          visualCompressionMutation = optimized.mutation;
+          return optimized.body;
+        } catch (err) {
+          log?.("warn", "visual_context_compression.failed_open", {
+            alias,
+            error_class: errorClassOf(err),
+          });
+          return body;
+        }
+      };
       const optimizeNativeBodyForAttempt = async (
         input: NativePassthroughCarrier | Record<string, unknown>,
       ): Promise<NativePassthroughCarrier | Record<string, unknown>> => {
         if (!passthrough.passthrough_used) return input;
         const body = nativePassthroughBody(input);
         if (optimizedNativeBody === null) {
-          try {
-            const optimized = await visualContextCompressor({
-              mode: visualContextCompressionMode?.() ?? "off",
-              targetProviderProtocol: target.targetProviderProtocol,
-              model: providerModel,
-              body,
-              capabilities: caps,
-              requestId: req.request_id,
-            });
-            optimizedNativeBody = optimized.body;
-            visualCompressionMutation = optimized.mutation;
-          } catch (err) {
-            log?.("warn", "visual_context_compression.failed_open", {
-              alias,
-              error_class: errorClassOf(err),
-            });
-            optimizedNativeBody = body;
-          }
+          optimizedNativeBody = await optimizeAnthropicBodyForAttempt(body);
         }
         return isNativePassthroughCarrier(input)
           ? cloneCarrierWithBody(input, optimizedNativeBody)
@@ -1532,13 +1538,6 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           // forward. peekStream opens chatCompletionStream(stripInternal); the row
           // carries the (used:false) passthrough telemetry. No nativePassthrough marker.
           const rendered = stripInternal(req, providerModel, target.targetProviderProtocol, caps);
-          attemptTelemetry = withRequestMutations(
-            passthrough,
-            mergeRequestMutations(
-              rendered.request_mutations,
-              provider.streamReframed === true ? { stream_reframed: true } : undefined,
-            ),
-          );
           // Pre-output failover guard (principle 5 + 8): the translate generators
           // ALREADY throw on a terminal error frame, but they yield an empty role
           // preamble chunk first, so peekStream would commit success before the throw.
@@ -1556,6 +1555,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                   const raw = provider.chatCompletionStream(rendered.body, {
                     signal: attemptSignal,
                     captureUpstream,
+                    optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
                   });
                   return translateClassifier
                     ? guardPreOutputFailure(raw, translateClassifier)
@@ -1567,6 +1567,14 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               ),
           );
           breaker.recordSuccess(alias);
+          attemptTelemetry = withRequestMutations(
+            passthrough,
+            mergeRequestMutations(
+              rendered.request_mutations,
+              provider.streamReframed === true ? { stream_reframed: true } : undefined,
+              visualCompressionMutationLedger(visualCompressionMutation),
+            ),
+          );
           // Streamed usage is not known at peek time → cost null (not measured).
           attempts.push(okRow(alias, elapsed(), null, attemptTelemetry));
           return {
@@ -1638,9 +1646,19 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           };
         }
         const bodyReq = stripInternal(req, providerModel, target.targetProviderProtocol, caps);
-        attemptTelemetry = withRequestMutations(passthrough, bodyReq.request_mutations);
         const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
-          provider.chatCompletion(bodyReq.body, { signal: attemptSignal, captureUpstream }),
+          provider.chatCompletion(bodyReq.body, {
+            signal: attemptSignal,
+            captureUpstream,
+            optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
+          }),
+        );
+        attemptTelemetry = withRequestMutations(
+          passthrough,
+          mergeRequestMutations(
+            bodyReq.request_mutations,
+            visualCompressionMutationLedger(visualCompressionMutation),
+          ),
         );
         breaker.recordSuccess(alias);
         attempts.push(okRow(alias, elapsed(), costOf(alias, body), attemptTelemetry));

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-07 · Anthropic 兼容改写路径稳定 CCH 并接入视觉压缩（Provider execution / cost control，docs/04/05，原则 3/5/7/8）
+
+- **背景（Lukin）**：生产 Luke key 的 `claude-fable-5` 请求在 v0.25.17 后仍只有约三成 cache-read share。复查发现 `cch` 不是被删除：客户端原始 billing header 无 `cch`，上游 body 有 Helm 重建的 `cch`；但 OAuth strict fingerprint 会再按完整 body 签 CCH，messages/max_tokens 等非缓存前缀变化仍会让 `system[0]` 变化。另一半问题是这批请求大多因 `provider_requires_compatibility_rewrite` 走普通 `chatCompletion` 翻译路径，而 `visual_context_compression` 只挂在 native passthrough body 上，无法处理真正贵的兼容改写请求。
+- **执行决策**：strict Claude CLI shape 仍保留 header 顺序、tool cloak、runtime headers，但 CCH 改为只从 cache-prefix 材料（model/system/tools，排除 messages 和采样参数）计算，避免第一块 system 自己烧掉 prompt cache。再给 `ProviderCallOptions` 增加 Anthropic-only `optimizeAnthropicBody` 钩子；Anthropic provider 先按既有逻辑生成最终 Anthropic Messages body，再在 capture/POST 前调用该钩子。这样不绕过 provider 的 OAuth、签名、重试和响应转换，也不会影响 OpenAI/Gemini providers。
+- **Telemetry 决策**：execute 在 stream/non-stream 翻译路径都传入同一个 per-attempt optimizer，并把 `visual_context_compression` mutation 与既有 `request_mutations` 合并；provider 忽略/未调用时 mutation 为空，避免把没有实际压缩的请求误报成省钱。
+- **风险边界**：该钩子只优化 Anthropic-native wire body；`mode=off` 仍为 no-op，压缩器异常 fail-open 发原 body。实际节省依赖 pxpipe 对该请求形态是否 `applied:true`，上线后必须用 mutation + usage 验证，而不是只看功能开关。
+- **验证路径**：新增 execute 测试覆盖 `provider_requires_compatibility_rewrite` 仍调用 visual compression 并记录 mutation；新增 Anthropic provider 测试确认 translated body 在 capture/POST 前被优化。
+
 ## 2026-07-06 · 请求总超时必须驱动下游 abort 与失败 telemetry（Gateway runtime / telemetry，docs/02/07，原则 3/5/7）
 
 - **背景（Lukin）**：生产 `gpt-5.5` 长请求超过 Helm `request_timeout_ms` 后，客户端收到 504，但上游 provider 后续完成，Telemetry 仍把 `final_status` 记成 `ok`，导致日志和 Admin requests 不能反映客户端真实结果。

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -1351,6 +1351,40 @@ describe("createAnthropicClient", () => {
     expect(Array.isArray(parsed.messages)).toBe(true);
   });
 
+  it("lets the gateway optimize the translated Anthropic body before POST and capture", async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const parsed = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      expect(parsed).toMatchObject({ visual_context_compressed: true });
+      return jsonResponse({
+        id: "msg",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    let captured: string | null = null;
+
+    await client.chatCompletion(
+      { model: "claude-x", messages: [{ role: "user", content: "hi" }], max_tokens: 64 },
+      {
+        captureUpstream: (body) => {
+          captured = body;
+        },
+        optimizeAnthropicBody: async (body) => ({
+          ...body,
+          visual_context_compressed: true,
+        }),
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(JSON.parse(captured ?? "null")).toMatchObject({ visual_context_compressed: true });
+  });
+
   it("sends Bearer + Claude-Code identity headers + system spoof; 401-retries once", async () => {
     let calls = 0;
     const seenAuth: string[] = [];
@@ -1506,7 +1540,7 @@ describe("createAnthropicClient", () => {
     expect(seenRequestIds[0]).not.toBe(seenRequestIds[1]);
   });
 
-  it("defaults OAuth subscription traffic to strict Claude CLI body signing and header/body order", async () => {
+  it("defaults OAuth subscription traffic to strict Claude CLI shape with cache-stable CCH", async () => {
     const uid = '{"device_id":"D","account_uuid":"","session_id":"S"}';
     const seenBodies: string[] = [];
     const seenHeaderOrders: string[][] = [];
@@ -1545,6 +1579,14 @@ describe("createAnthropicClient", () => {
       ],
       max_tokens: 65,
     });
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "changed system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 65,
+    });
 
     const first = JSON.parse(seenBodies[0] ?? "{}") as {
       system: Array<{ text: string }>;
@@ -1552,13 +1594,18 @@ describe("createAnthropicClient", () => {
     const second = JSON.parse(seenBodies[1] ?? "{}") as {
       system: Array<{ text: string }>;
     };
+    const third = JSON.parse(seenBodies[2] ?? "{}") as {
+      system: Array<{ text: string }>;
+    };
     const firstCch = first.system[0]?.text.match(/\bcch=([0-9a-f]{5});/)?.[1];
     const secondCch = second.system[0]?.text.match(/\bcch=([0-9a-f]{5});/)?.[1];
+    const thirdCch = third.system[0]?.text.match(/\bcch=([0-9a-f]{5});/)?.[1];
     expect(firstCch).toMatch(/^[0-9a-f]{5}$/);
     expect(firstCch).not.toBe("00000");
-    // Strict mode signs the final serialized body, so a non-system body mutation
-    // changes cch. The pure translator keeps its cache-stable conservative hash.
-    expect(secondCch).not.toBe(firstCch);
+    // Strict mode keeps Claude-like shape/order, but CCH must remain cache-prefix
+    // stable so changing non-prefix request fields does not burn prompt cache.
+    expect(secondCch).toBe(firstCch);
+    expect(thirdCch).not.toBe(firstCch);
     expect(Object.keys(first)).toEqual(["model", "messages", "system", "metadata", "max_tokens"]);
     expect(seenHeaderOrders[0]?.slice(0, 14)).toEqual([
       "Accept",
@@ -1655,7 +1702,7 @@ describe("createAnthropicClient", () => {
     expect(seenCch[1]).toBe(seenCch[0]);
   });
 
-  it("defaults non-official Anthropic-compatible relays to strict Claude CLI signing", async () => {
+  it("defaults non-official Anthropic-compatible relays to strict shape with cache-stable CCH", async () => {
     const seenCch: string[] = [];
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as { system: Array<{ text: string }> };
@@ -1688,11 +1735,20 @@ describe("createAnthropicClient", () => {
       ],
       max_tokens: 65,
     });
+    await client.chatCompletion({
+      model: "m",
+      messages: [
+        { role: "system", content: "changed system" },
+        { role: "user", content: "hi" },
+      ],
+      max_tokens: 65,
+    });
 
-    expect(seenCch).toHaveLength(2);
+    expect(seenCch).toHaveLength(3);
     expect(seenCch[0]).toMatch(/^[0-9a-f]{5}$/);
     expect(seenCch[0]).not.toBe("00000");
-    expect(seenCch[1]).not.toBe(seenCch[0]);
+    expect(seenCch[1]).toBe(seenCch[0]);
+    expect(seenCch[2]).not.toBe(seenCch[0]);
   });
 
   it("strict Claude CLI tool pipeline matches the golden fixture and restores tool names", async () => {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -808,9 +808,19 @@ function serializeAnthropicBody(
   const orderedPlaceholder = orderTopLevelFields(placeholderBody, CLAUDE_CLI_BODY_FIELD_ORDER);
   const bodyTextWithPlaceholder = JSON.stringify(orderedPlaceholder);
   if (!hasSystemBillingCchPlaceholder(orderedPlaceholder)) return bodyTextWithPlaceholder;
+  // CCH lives in system[0], so deriving it from changing messages would invalidate
+  // Anthropic's strict prefix cache before the real prompt content is even compared.
+  const stablePrefixWithPlaceholder = orderTopLevelFields(
+    {
+      model: placeholderBody.model ?? null,
+      system: placeholderBody.system ?? null,
+      tools: placeholderBody.tools ?? null,
+    },
+    CLAUDE_CLI_BODY_FIELD_ORDER,
+  );
   const signedBody = withSignedSystemBillingCch(
     placeholderBody,
-    computeClaudeCliCch(bodyTextWithPlaceholder),
+    computeClaudeCliCch(JSON.stringify(stablePrefixWithPlaceholder)),
   );
   return JSON.stringify(orderTopLevelFields(signedBody, CLAUDE_CLI_BODY_FIELD_ORDER));
 }
@@ -1663,8 +1673,12 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
 
     async chatCompletion(req, opts) {
       const model = String((req as Record<string, unknown>).model ?? "");
+      const translatedBody = openaiToAnthropicRequest(req, { metadataUserId: cfg.metadataUserId });
+      const body = opts?.optimizeAnthropicBody
+        ? await opts.optimizeAnthropicBody(translatedBody)
+        : translatedBody;
       const { res, toolNameMap } = await requestWithRetry(
-        openaiToAnthropicRequest(req, { metadataUserId: cfg.metadataUserId }),
+        body,
         opts?.signal,
         url,
         [],
@@ -1679,10 +1693,13 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
 
     async *chatCompletionStream(req, opts) {
       const model = String((req as Record<string, unknown>).model ?? "");
-      const body = {
+      const translatedBody = {
         ...openaiToAnthropicRequest(req, { metadataUserId: cfg.metadataUserId }),
         stream: true,
       };
+      const body = opts?.optimizeAnthropicBody
+        ? await opts.optimizeAnthropicBody(translatedBody)
+        : translatedBody;
       const { res, toolNameMap } = await requestWithRetry(
         body,
         opts?.signal,

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -71,6 +71,12 @@ export type NativeProtocolProfile =
 export interface ProviderCallOptions {
   signal?: AbortSignal;
   captureUpstream?: (wireBody: string) => void;
+  /** Anthropic-only post-translation optimizer. Called after an OpenAI/IR-shaped
+   * request is rendered into Anthropic Messages wire format, just before the POST
+   * body is captured/sent. Other providers ignore it. */
+  optimizeAnthropicBody?: (
+    body: Record<string, unknown>,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
   // PER-CANDIDATE timeout hint (ms) for an internal LOOPBACK call. Consumed ONLY by the
   // self-HTTP client (memory-self-http.ts), which forwards it to the nested gateway as
   // `x-helm-attempt-timeout-ms` so that request's executor bounds each candidate (a slow


### PR DESCRIPTION
## Summary
- keep Anthropic/Claude CCH present but make strict-mode CCH cache-prefix stable instead of full-body rotating
- run visual context compression after Anthropic compatibility translation, before capture/POST, for stream and non-stream calls
- record visual compression mutations only when the provider path actually invokes the optimizer

## Production evidence
- Luke Fable traffic still had ~34.7% cache-read share: 151 requests, 14.217M fresh input tokens, 8.591M cache-read tokens, $76.51 cost
- 143/151 requests and $76.44/$76.51 cost were on `provider_requires_compatibility_rewrite`
- linked request `c089c52a-c94e-47f3-8b22-b581c38f6753` had upstream CCH present, but no visual compression mutation
- existing production rows showed visual compression missing on expensive compatibility-rewrite rows

## Verification
- `pnpm vitest run apps/gateway/src/routes/execute.test.ts packages/core/src/provider/anthropic.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`