### PR TITLE
chore: release v0.25.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.17",
+  "version": "0.25.18",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump root package version to `0.25.18` so the publish workflow cuts the release image/tag after merge

## Verification
- `node -p "require('./package.json').version"` -> `0.25.18`
- `git diff --check`