### PR TITLE
chore: release v0.25.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.18",
+  "version": "0.25.19",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump root package version to `0.25.19`.
- Trigger the publish workflow to create `v0.25.19` and publish the semver Docker image.

## Included changes
- PR #489: Improve Anthropic visual cache reuse.
