### PR TITLE
Cache GET /v1/models per caps to absorb client retry storms

### DIFF
--- a/apps/gateway/src/routes/models.test.ts
+++ b/apps/gateway/src/routes/models.test.ts
@@ -65,13 +65,17 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
   };
 }
 
-function buildApp(rec: ApiKeyRecord | null, oauthAliases?: () => Iterable<string>) {
+function buildApp(
+  rec: ApiKeyRecord | null,
+  oauthAliases?: () => Iterable<string>,
+  lanesThunk: () => typeof lanes = () => lanes,
+) {
   const getByHash = vi.fn().mockResolvedValue(rec);
   const app = createApp({ logger: { log: () => {} } });
   const auth = authMiddleware({ keyStore: { getByHash }, log: () => {} });
   app.use("/v1/models", auth);
   app.use("/v1/models/*", auth);
-  registerModelsRoute(app, { lanes: () => lanes, catalog, providerAliases, oauthAliases });
+  registerModelsRoute(app, { lanes: lanesThunk, catalog, providerAliases, oauthAliases });
   return app;
 }
 
@@ -150,6 +154,18 @@ describe("GET /v1/models", () => {
     const res = await buildApp(record()).request("/v1/models/balanced", { headers: AUTH });
     expect(res.status).toBe(200);
     expect(((await res.json()) as { id: string }).id).toBe("balanced");
+  });
+
+  it("caches the listing per caps within TTL (rebuild skipped on repeat hits)", async () => {
+    // A misbehaving client hammering /v1/models must not re-run buildModelsList each
+    // time. Probe via the lanes thunk: cache hits never touch it.
+    const lanesSpy = vi.fn(() => lanes);
+    const app = buildApp(record(), undefined, lanesSpy);
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/v1/models", { headers: AUTH });
+      expect(res.status).toBe(200);
+    }
+    expect(lanesSpy).toHaveBeenCalledTimes(1);
   });
 
   it("retrieve: unknown/forbidden id -> structured error (OpenAI envelope)", async () => {

--- a/apps/gateway/src/routes/models.ts
+++ b/apps/gateway/src/routes/models.ts
@@ -26,20 +26,42 @@ export interface ModelsRouteDeps {
   oauthAliases?: () => Iterable<string>;
 }
 
+// ponytail: 30s TTL memo, per caps-fingerprint. A misbehaving client (seen in
+// prod: a codex_exec retry loop hammering GET /v1/models ~1/s) otherwise re-runs
+// buildModelsList — lane walk + oauth-alias merge + dedup/sort — on every hit.
+// The listing depends only on slow-moving inputs (key caps, lanes, oauth aliases),
+// so a short TTL absorbs the flood; admin edits to lanes/curation take effect
+// within TTL_MS. Bounded to CAP entries (distinct caps shapes are few); a full
+// bucket just skips caching that request rather than growing unbounded.
+const TTL_MS = 30_000;
+const CACHE_CAP = 256;
+
 export function registerModelsRoute(app: Hono<AppEnv>, deps: ModelsRouteDeps): void {
+  const cache = new Map<string, { at: number; value: ReturnType<typeof buildModelsList> }>();
+
   const build = (c: Context<AppEnv>) => {
     const identity = c.get("identity");
+    const caps = identity.caps;
+    // Fingerprint the only inputs that vary the output: the key's caps. lanes /
+    // oauth aliases are process-wide, so TTL alone (not the key) covers their drift.
+    const fp = `${caps.allowCustomModel ? 1 : 0}|${(caps.allowedLanes ?? []).join(",")}|${[...(caps.blockedModels ?? [])].join(",")}`;
+    const now = Date.now();
+    const hit = cache.get(fp);
+    if (hit && now - hit.at < TTL_MS) return hit.value;
+
     // Merge static config aliases with the LIVE subscription set. buildModelsList
     // dedups + sorts, so an alias that is both configured and OAuth-curated lists once.
     const oauth = deps.oauthAliases ? [...deps.oauthAliases()] : [];
-    return buildModelsList({
+    const value = buildModelsList({
       lanes: deps.lanes(),
       catalog: deps.catalog,
       providerAliases: oauth.length ? [...deps.providerAliases, ...oauth] : deps.providerAliases,
-      allowCustomModel: identity.caps.allowCustomModel,
-      allowedLanes: identity.caps.allowedLanes,
-      blockedModels: identity.caps.blockedModels,
+      allowCustomModel: caps.allowCustomModel,
+      allowedLanes: caps.allowedLanes,
+      blockedModels: caps.blockedModels,
     });
+    if (cache.size < CACHE_CAP || cache.has(fp)) cache.set(fp, { at: now, value });
+    return value;
   };
 
   app.get("/v1/models", (c) => c.json(build(c), 200));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.25.19",
+  "version": "0.25.20",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## 问题

生产环境观察到某客户端（`codex_exec/0.142.4` 的重试循环）以 ~1次/秒 疯狂打 `GET /v1/models`。虽然请求本身很轻（多为秒回 200），但每次都重跑 `buildModelsList`——lane 遍历 + OAuth 别名 merge + dedup/sort——是纯粹的无谓开销。

叠加在 28GB 臃肿 helm.db 的写放大 + 冷启动上，把 2 核机器的 CPU / 磁盘顶了起来。

## 改动

给 `/v1/models` 加 **30s TTL 进程内缓存**（`apps/gateway/src/routes/models.ts`）：

- 缓存按 **key caps 指纹**分桶（`allowCustomModel | allowedLanes | blockedModels`）——输出唯一取决于这些慢变量。
- 命中即秒回，不再跑 `buildModelsList`。空转客户端随便打，几乎零成本吸收。
- lanes / OAuth 别名是进程级慢变量，靠 TTL 覆盖其漂移：admin 改 lanes/curation 最多 30s 后生效。
- 缓存上限 256 桶（不同 caps 组合本就极少）；满了跳过缓存而非无界增长。

不引缓存库、不动 framework-free 的 core（这是 gateway 展示层护栏）。

## 测试

- 新增命中测试：5 次请求，`lanes` thunk 只被调用 1 次 = 缓存生效。
- 全量 gateway 路由测试 930 passed；typecheck + lint 绿。

## 说明

这治的是**空转开销**，让"疯狂打 `/v1/models`"打不挂网关。CPU 尖峰的**根因**（带 key 真实请求写 payload 到 28GB 库的写放大 + DB 臃肿）是另一条线，靠 auto-vacuum 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)