### PR TITLE
feat(landing): link the self-service portal from the homepage (v0.26.1)

### DIFF
--- a/apps/gateway/src/routes/landing.test.ts
+++ b/apps/gateway/src/routes/landing.test.ts
@@ -9,8 +9,8 @@ describe("GET / (landing page)", () => {
     expect(res.headers.get("content-type")).toContain("text/html");
     const html = await res.text();
     expect(html).toContain("Helm API");
-    // Links to the documented public + admin surface.
-    for (const path of ["/docs", "/v1/models", "/healthz", "/admin"]) {
+    // Links to the documented public + portal + admin surface.
+    for (const path of ["/docs", "/v1/models", "/portal", "/healthz", "/admin"]) {
       expect(html).toContain(`href="${path}"`);
     }
     // /version is surfaced (referenced in the dashboard copy + fetched live).

--- a/apps/gateway/src/routes/landing.ts
+++ b/apps/gateway/src/routes/landing.ts
@@ -129,6 +129,11 @@ const PAGE = `<!doctype html>
         <span class="desc">Models your key can route to</span>
         <span class="path mono">/v1/models</span>
       </a>
+      <a href="/portal">
+        <span class="label">Portal</span>
+        <span class="desc">Your usage, requests &amp; memory — sign in with your key</span>
+        <span class="path mono">/portal</span>
+      </a>
       <a href="/admin">
         <span class="label">Dashboard</span>
         <span class="desc">Lanes, keys &amp; request telemetry</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
The self-service portal shipped at `/portal` in v0.26.0, but the landing page (`/`) had no entry for it — so a key holder couldn't discover it without knowing the path.

Adds a **Portal** card to the homepage nav (between Models and the admin Dashboard) and pins it in `landing.test.ts`.

Patch bump → **0.26.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)