### PR TITLE
fix(portal): merge by_model rows sharing a label — fixes Overview crash (v0.26.2)

### DIFF
--- a/apps/gateway/src/routes/portal/index.test.ts
+++ b/apps/gateway/src/routes/portal/index.test.ts
@@ -250,6 +250,65 @@ describe("portal API", () => {
       const parsed = JSON.parse(body) as { by_model: { model: string }[] };
       expect(parsed.by_model[0]?.model).toBe("gpt-5.5"); // public alias, not the wire id
     });
+
+    it("MERGES by_model rows that resolve to the same label (no duplicate keys → SPA crash)", async () => {
+      // Real production data has MANY distinct wire models that map to 'other'
+      // (unmapped/retired ids). Without merging, the doughnut gets N same-named
+      // slices → the keyed {#each} throws each_key_duplicate. Assert one row/label.
+      const tel = telemetry({
+        async aggregate() {
+          const row = (servedModel: string | null, totalTokens: number, requests: number) => ({
+            servedModel,
+            promptTokens: totalTokens,
+            completionTokens: 0,
+            totalTokens,
+            requests,
+            costUsd: 0.01,
+          });
+          return {
+            totals: {
+              requests: 6,
+              okCount: 6,
+              errorCount: 0,
+              totalCostUsd: 0.06,
+              promptTokens: 60,
+              completionTokens: 0,
+              cachedTokens: 0,
+              cacheCreationTokens: 0,
+              avgLatencyMs: null,
+              avgTps: null,
+            },
+            series: [],
+            byModel: [
+              row("WIRE_A", 30, 3), // → gpt-5.5
+              row("UNMAPPED_1", 10, 1), // → other
+              row("UNMAPPED_2", 15, 1), // → other
+              row(null, 5, 1), // → other (unstamped)
+            ],
+          };
+        },
+      });
+      const getByHash = vi.fn().mockResolvedValue(record());
+      const app = createApp({ logger: { log: () => {} } });
+      app.use("/portal/api/*", authMiddleware({ keyStore: { getByHash }, log: () => {} }));
+      registerPortalApi(app, {
+        telemetry: tel,
+        now: () => 10_000,
+        resolveModelLabel: (wire: string) => (wire === "WIRE_A" ? "gpt-5.5" : null),
+      });
+      const body = (await (await app.request("/portal/api/usage/stats", { headers: AUTH })).json()) as {
+        by_model: { model: string; total_tokens: number; requests: number }[];
+      };
+      const labels = body.by_model.map((m) => m.model);
+      // Exactly one row per label — no duplicates.
+      expect(new Set(labels).size).toBe(labels.length);
+      const other = body.by_model.find((m) => m.model === "other");
+      expect(other?.total_tokens).toBe(30); // 10 + 15 + 5 merged
+      expect(other?.requests).toBe(3); // 1 + 1 + 1 merged
+      // Ordered by total tokens desc: gpt-5.5 (30) ties other (30) — both present, unique.
+      expect(labels).toContain("gpt-5.5");
+      expect(labels).toContain("other");
+    });
   });
 
   describe("GET /portal/api/requests", () => {

--- a/apps/gateway/src/routes/portal/index.test.ts
+++ b/apps/gateway/src/routes/portal/index.test.ts
@@ -296,7 +296,9 @@ describe("portal API", () => {
         now: () => 10_000,
         resolveModelLabel: (wire: string) => (wire === "WIRE_A" ? "gpt-5.5" : null),
       });
-      const body = (await (await app.request("/portal/api/usage/stats", { headers: AUTH })).json()) as {
+      const body = (await (
+        await app.request("/portal/api/usage/stats", { headers: AUTH })
+      ).json()) as {
         by_model: { model: string; total_tokens: number; requests: number }[];
       };
       const labels = body.by_model.map((m) => m.model);

--- a/apps/gateway/src/routes/portal/index.ts
+++ b/apps/gateway/src/routes/portal/index.ts
@@ -94,14 +94,14 @@ export function registerPortalApi(app: Hono<AppEnv>, deps: PortalApiDeps): void 
         completion_tokens: s.completionTokens,
         cost_usd: s.costUsd,
       })),
-      by_model: agg.byModel.map((m) => ({
-        // NEVER emit m.servedModel verbatim — it is the internal wire provider_model
-        // (原则 6 / R7). Resolve to the public alias; unmappable/unstamped → "other".
-        model: m.servedModel ? (deps.resolveModelLabel?.(m.servedModel) ?? "other") : "other",
-        requests: m.requests,
-        total_tokens: m.totalTokens,
-        cost_usd: m.costUsd,
-      })),
+      // Resolve each row's wire provider_model to its PUBLIC alias (NEVER emit the
+      // wire id verbatim — 原则 6 / R7) and MERGE rows that resolve to the same
+      // label: many distinct wire models map to "other" (unmapped/unstamped), and
+      // several wire ids can share one alias — so without merging the doughnut gets
+      // multiple same-named slices (duplicate keys → the SPA's keyed {#each} crashes).
+      by_model: aggregateByLabel(agg.byModel, (m) =>
+        m.servedModel ? (deps.resolveModelLabel?.(m.servedModel) ?? "other") : "other",
+      ),
       budget: {
         requests: b.requests,
         tokens: b.tokens,
@@ -174,6 +174,39 @@ export function registerPortalApi(app: Hono<AppEnv>, deps: PortalApiDeps): void 
       created_at: p.createdAt.getTime(),
     });
   });
+}
+
+// Resolve each usage row to a public label and merge rows sharing it, so the
+// portal's by_model list has EXACTLY ONE entry per label (no duplicate keys, no
+// wire-id leak). Sums tokens/requests; cost is null only when NO row in the group
+// had a measured cost (COALESCE honesty, matches the store). Ordered by total
+// tokens desc so the doughnut renders largest-first, same as the store.
+type ModelUsageRow = Awaited<ReturnType<TelemetryStore["aggregate"]>>["byModel"][number];
+function aggregateByLabel(
+  rows: ModelUsageRow[],
+  labelOf: (m: ModelUsageRow) => string,
+): Array<{ model: string; requests: number; total_tokens: number; cost_usd: number | null }> {
+  const byLabel = new Map<
+    string,
+    { model: string; requests: number; total_tokens: number; cost_usd: number | null }
+  >();
+  for (const m of rows) {
+    const label = labelOf(m);
+    const acc = byLabel.get(label);
+    if (acc) {
+      acc.requests += m.requests;
+      acc.total_tokens += m.totalTokens;
+      if (m.costUsd !== null) acc.cost_usd = (acc.cost_usd ?? 0) + m.costUsd;
+    } else {
+      byLabel.set(label, {
+        model: label,
+        requests: m.requests,
+        total_tokens: m.totalTokens,
+        cost_usd: m.costUsd,
+      });
+    }
+  }
+  return [...byLabel.values()].sort((a, b) => b.total_tokens - a.total_tokens);
 }
 
 // Mirror admin's part reader: prefer the narrow getPayloadPart, fall back to the

--- a/apps/portal/src/routes/+page.svelte
+++ b/apps/portal/src/routes/+page.svelte
@@ -368,7 +368,7 @@
           </PieChart>
         </div>
         <ul class="mt-3 flex flex-wrap justify-center gap-x-4 gap-y-1.5">
-          {#each byModel as slice, i (slice.model)}
+          {#each byModel as slice, i (i)}
             <li class="flex items-start gap-1.5 text-xs text-ink-2">
               <span
                 class="mt-0.5 size-2.5 shrink-0 rounded-full"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Bug
Logging into the live portal crashed the **Overview** to a blank "Loading…". Console: `svelte.dev/e/each_key_duplicate`.

**Root cause:** production usage data has many distinct wire `provider_model`s that resolve to `'other'` (unmapped/retired ids) — the `/portal/api/usage/stats` `by_model` emitted one row per wire model, so the doughnut got **multiple same-named slices**. The SPA's keyed `{#each}` (and the PieChart's `key` accessor) then threw `each_key_duplicate` and the whole page crashed. Seeded test data all mapped cleanly, so it never surfaced until real data.

## Fix
- **Server:** aggregate `by_model` by resolved label so there's **exactly one row per label** (sum tokens/requests, COALESCE cost, order by tokens desc). All the `'other'` rows now collapse into one. Still never leaks the wire id (原则 6/R7).
- **Client:** key the legend `{#each}` by index (defense in depth).
- **+test** reproducing the multi-`'other'` merge.

Patch → **0.26.2**. Verified locally in Docker: Overview loads with **0 console errors**; new unit test + typecheck + lint + svelte-check all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)