### PR TITLE
fix(portal): hourly x-axis + raw request/response viewers (v0.26.3)

### DIFF
--- a/apps/portal/src/routes/+page.svelte
+++ b/apps/portal/src/routes/+page.svelte
@@ -139,7 +139,7 @@
   function formatTrendAxisValue(value: unknown): string {
     const date =
       value instanceof Date ? value : new Date(value as string | number);
-    return formatTrendTick(date, "day");
+    return formatTrendTick(date, bucket);
   }
 
   // Budget: percent used against the cap when there is one (docs/12 §4.3).

--- a/apps/portal/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/portal/src/routes/requests/[traceId]/+page.svelte
@@ -4,6 +4,7 @@
   import { t } from "$lib/i18n";
   import { formatUsd, formatTokens } from "$lib/format";
   import Conversation from "$lib/components/Conversation.svelte";
+  import JsonViewer from "$lib/components/JsonViewer.svelte";
   import TokenUsage from "$lib/components/TokenUsage.svelte";
   import CostBreakdown from "$lib/components/CostBreakdown.svelte";
   import { toTokenUsageView } from "$lib/api/requests";
@@ -21,6 +22,12 @@
   let loading = $state(true);
   let notFound = $state(false);
   let error = $state("");
+
+  // Two lenses over the captured body: Conversation (a readable user⇄agent
+  // transcript folding request + response, default) and Raw (the JSON tree —
+  // source of truth). Mirrors the admin detail page. The response panel is
+  // raw-only, since the transcript already includes the reply.
+  let reqView = $state<"chat" | "raw">("chat");
 
   async function load(id: string) {
     loading = true;
@@ -114,12 +121,49 @@
     {/if}
   </div>
 
-  <!-- The user's own request/response bodies (their data; §4.3) -->
+  <!-- The user's own request/response bodies (their data; §4.3). Each panel
+       toggles between the Conversation transcript and the Raw JSON viewer. -->
+  {#snippet viewToggle(
+    current: "chat" | "raw",
+    set: (v: "chat" | "raw") => void,
+    idPrefix: string,
+  )}
+    <div class="mb-3 flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        data-testid={`${idPrefix}-view-chat`}
+        class={`rounded border px-3 py-1 text-sm ${current === "chat" ? "border-action bg-action text-white" : "border-border bg-surface text-ink-muted hover:bg-canvas"}`}
+        onclick={() => set("chat")}>{$t("Conversation")}</button
+      >
+      <button
+        type="button"
+        data-testid={`${idPrefix}-view-raw`}
+        class={`rounded border px-3 py-1 text-sm ${current === "raw" ? "border-action bg-action text-white" : "border-border bg-surface text-ink-muted hover:bg-canvas"}`}
+        onclick={() => set("raw")}>{$t("Raw")}</button
+      >
+    </div>
+  {/snippet}
+
   {#if requestBody !== null || responseBody !== null}
+    <!-- Request: Conversation (chat) ⇄ Raw JSON. Chat lens folds the whole
+         transcript (request + reply), matching admin. -->
     <section class="card mt-4">
-      <h2 class="section-header mb-3">{$t("Conversation")}</h2>
-      <Conversation request={requestBody} response={responseBody} />
+      <h2 class="section-header mb-3">{$t("Request")}</h2>
+      {@render viewToggle(reqView, (v) => (reqView = v), "request")}
+      {#if reqView === "chat"}
+        <Conversation request={requestBody} response={responseBody} />
+      {:else}
+        <JsonViewer value={requestBody} testid="request-body" />
+      {/if}
     </section>
+
+    <!-- Response: raw payload only (the reply is already in the chat lens above). -->
+    {#if responseBody !== null}
+      <section class="card mt-4">
+        <h2 class="section-header mb-3">{$t("Response")}</h2>
+        <JsonViewer value={responseBody} testid="response-body" />
+      </section>
+    {/if}
   {:else}
     <div class="card empty-state mt-4">
       {$t("No request body was captured for this request.")}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Two portal fixes from Lukin's review of the live Overview + request-detail pages.

## 1. Chart: hourly x-axis for Today/Yesterday
The Token Usage Trend chart already fetched hour-bucketed data for the `today`/`yesterday` ranges, but `formatTrendAxisValue` hardcoded the `"day"` bucket — so every hourly tick (and the tooltip header) rendered as the same `M/D` date instead of a time. Pass the reactive `bucket`, matching admin's `dashboard-chart` behavior. Hour buckets now format as `HH:MM`.

## 2. Request detail: raw request/response viewers
The detail page already loaded the full raw request & response bodies but only surfaced them through the chat-style Conversation view. Brought to parity with the admin detail page:

- **Request panel** — `Conversation ⇄ Raw` toggle. Chat lens folds the full transcript; Raw lens shows the request JSON in the existing `JsonViewer` (Tree/Formatted/Raw tabs, expand/collapse, fullscreen).
- **Response panel** — raw response payload in a `JsonViewer`.

Frontend-only: reuses portal's existing `JsonViewer` and the payload the page already fetches. No backend/API change; `upstream_request` stays off-limits per §4.3.

## Verification
- `svelte-check`: 0 errors / 0 warnings
- `biome check`: clean (572 files)
- portal production build: ✓
- Playwright drive of the built SPA against a stubbed captured trace: confirmed the request Conversation⇄Raw toggle and the raw response JSON tree both render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)