### PR TITLE
feat(portal): widescreen + reflections-first memory + fix Active filter (v0.26.4)

### DIFF
--- a/apps/portal/src/lib/api/fact-status.test.ts
+++ b/apps/portal/src/lib/api/fact-status.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { factMatchesStatus } from "./fact-status";
+
+// The bug: an unguarded `status === filter` fallback let superseded facts
+// (status:"active", superseded:true) pass the Active filter, because their
+// status is still "active". Guard against that regression here.
+const active = { status: "active" as const, superseded: false };
+const superseded = { status: "active" as const, superseded: true };
+const archived = { status: "archived" as const, superseded: false };
+const pruned = { status: "pruned" as const, superseded: false };
+
+describe("factMatchesStatus", () => {
+  it("Active excludes superseded facts", () => {
+    expect(factMatchesStatus(active, "active")).toBe(true);
+    expect(factMatchesStatus(superseded, "active")).toBe(false); // the fix
+    expect(factMatchesStatus(archived, "active")).toBe(false);
+    expect(factMatchesStatus(pruned, "active")).toBe(false);
+  });
+
+  it("Superseded shows only superseded facts", () => {
+    expect(factMatchesStatus(superseded, "superseded")).toBe(true);
+    expect(factMatchesStatus(active, "superseded")).toBe(false);
+    expect(factMatchesStatus(archived, "superseded")).toBe(false);
+  });
+
+  it("archived/pruned match on status alone", () => {
+    expect(factMatchesStatus(archived, "archived")).toBe(true);
+    expect(factMatchesStatus(pruned, "pruned")).toBe(true);
+    expect(factMatchesStatus(active, "archived")).toBe(false);
+    expect(factMatchesStatus(superseded, "pruned")).toBe(false);
+  });
+
+  it("all matches everything", () => {
+    for (const f of [active, superseded, archived, pruned]) {
+      expect(factMatchesStatus(f, "all")).toBe(true);
+    }
+  });
+});

--- a/apps/portal/src/lib/api/fact-status.ts
+++ b/apps/portal/src/lib/api/fact-status.ts
@@ -1,0 +1,18 @@
+import type { MemoryStatus } from "./memory-types";
+
+export type FactStatusFilter = MemoryStatus | "superseded" | "all";
+
+// Does a fact belong in the given status filter? "active"/"superseded" are both
+// stored as status:"active" and split by the superseded flag; "archived"/"pruned"
+// match on status alone; "all" matches everything. Guarding the archived/pruned
+// branch matters — an unguarded `status === filter` also fires for filter:"active"
+// and leaks superseded facts into the Active view.
+export function factMatchesStatus(
+  fact: { status: MemoryStatus; superseded: boolean },
+  filter: FactStatusFilter,
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "active") return fact.status === "active" && !fact.superseded;
+  if (filter === "superseded") return fact.status === "active" && fact.superseded;
+  return fact.status === filter; // archived | pruned
+}

--- a/apps/portal/src/lib/api/memory-types.ts
+++ b/apps/portal/src/lib/api/memory-types.ts
@@ -1,0 +1,1 @@
+export type MemoryStatus = "active" | "archived" | "pruned";

--- a/apps/portal/src/lib/api/memory.ts
+++ b/apps/portal/src/lib/api/memory.ts
@@ -1,9 +1,15 @@
 import { mcpTool } from "./client";
+import type { MemoryStatus } from "./memory-types";
 
 // Portal memory over MCP tools/call (docs/12 §4.2 endpoint 6). accountId/projectId
 // are server-derived from the bearer key — never sent (R3/R4).
-export type MemoryStatus = "active" | "archived" | "pruned";
-export type FactStatusFilter = MemoryStatus | "superseded" | "all";
+// MemoryStatus + the fact-status filter live in alias-free modules so the pure
+// filter predicate is unit-testable without SvelteKit's $app/$lib runtime.
+export type { MemoryStatus } from "./memory-types";
+export {
+  factMatchesStatus,
+  type FactStatusFilter,
+} from "./fact-status";
 
 export interface Fact {
   id: string;

--- a/apps/portal/src/routes/+layout.svelte
+++ b/apps/portal/src/routes/+layout.svelte
@@ -48,7 +48,7 @@
 {:else}
   <div class="min-h-screen bg-canvas text-ink-1">
     <header class="border-b border-border bg-surface">
-      <div class="mx-auto flex h-14 max-w-6xl items-center gap-4 px-4">
+      <div class="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4">
         <a
           href={hrefFor("")}
           class="flex items-center gap-2 font-semibold text-ink-1"
@@ -142,7 +142,7 @@
       {/if}
     </header>
 
-    <main class="mx-auto max-w-6xl px-4 py-6">
+    <main class="mx-auto max-w-7xl px-4 py-6">
       {@render children()}
     </main>
   </div>

--- a/apps/portal/src/routes/memory/+page.svelte
+++ b/apps/portal/src/routes/memory/+page.svelte
@@ -6,6 +6,7 @@
   import {
     deleteFact,
     deleteReflection,
+    factMatchesStatus,
     listAllFacts,
     listAllReflections,
     type Fact,
@@ -44,16 +45,7 @@
   const filteredFacts = $derived.by(() => {
     const query = factSearch.trim().toLowerCase();
     return facts.filter((fact) => {
-      const statusMatch =
-        factStatus === "all" ||
-        (factStatus === "active" &&
-          fact.status === "active" &&
-          !fact.superseded) ||
-        (factStatus === "superseded" &&
-          fact.status === "active" &&
-          fact.superseded) ||
-        fact.status === factStatus;
-      if (!statusMatch) return false;
+      if (!factMatchesStatus(fact, factStatus)) return false;
       if (!query) return true;
       return `${fact.subjectKey} ${fact.factText}`
         .toLowerCase()
@@ -241,6 +233,52 @@
   {/if}
 
   <section class="mb-6 flex flex-col gap-3">
+    <h2 class="section-header">{$t("Reflections")}</h2>
+    {#if reflections.length === 0}
+      <div class="empty-state">{$t("No reflections yet.")}</div>
+    {:else}
+      <div class="flex flex-col gap-3">
+        {#each reflections as reflection (reflection.id)}
+          <div data-testid="reflection-row" class="card flex flex-col gap-2">
+            <div class="flex items-start justify-between gap-3">
+              <div
+                class="flex flex-wrap items-center gap-2 text-xs text-ink-muted"
+              >
+                {#if reflection.status === "active"}
+                  <span class="badge-ok">{$t("active")}</span>
+                {:else}
+                  <span class="badge-neutral">{$t("archived")}</span>
+                {/if}
+                <span>{$t("Version")} {reflection.version}</span>
+                <span aria-hidden="true">·</span>
+                <span>{formatTimestamp(reflection.updatedAt)}</span>
+              </div>
+              <div class="flex shrink-0 gap-2">
+                <button
+                  type="button"
+                  class="btn-secondary"
+                  onclick={() => (editingReflection = reflection)}
+                  >{$t("Edit")}</button
+                >
+                <button
+                  type="button"
+                  class="btn-danger-outline"
+                  onclick={() => (confirmingReflectionDelete = reflection)}
+                >
+                  {$t("Delete")}
+                </button>
+              </div>
+            </div>
+            <p class="whitespace-pre-wrap break-words text-sm text-ink-body">
+              {reflection.reflectionText}
+            </p>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <section class="flex flex-col gap-3">
     <div
       class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between"
     >
@@ -408,52 +446,6 @@
             onclick={() => (factPage += 1)}>{$t("Next")}</button
           >
         </nav>
-      </div>
-    {/if}
-  </section>
-
-  <section class="flex flex-col gap-3">
-    <h2 class="section-header">{$t("Reflections")}</h2>
-    {#if reflections.length === 0}
-      <div class="empty-state">{$t("No reflections yet.")}</div>
-    {:else}
-      <div class="flex flex-col gap-3">
-        {#each reflections as reflection (reflection.id)}
-          <div data-testid="reflection-row" class="card flex flex-col gap-2">
-            <div class="flex items-start justify-between gap-3">
-              <div
-                class="flex flex-wrap items-center gap-2 text-xs text-ink-muted"
-              >
-                {#if reflection.status === "active"}
-                  <span class="badge-ok">{$t("active")}</span>
-                {:else}
-                  <span class="badge-neutral">{$t("archived")}</span>
-                {/if}
-                <span>{$t("Version")} {reflection.version}</span>
-                <span aria-hidden="true">·</span>
-                <span>{formatTimestamp(reflection.updatedAt)}</span>
-              </div>
-              <div class="flex shrink-0 gap-2">
-                <button
-                  type="button"
-                  class="btn-secondary"
-                  onclick={() => (editingReflection = reflection)}
-                  >{$t("Edit")}</button
-                >
-                <button
-                  type="button"
-                  class="btn-danger-outline"
-                  onclick={() => (confirmingReflectionDelete = reflection)}
-                >
-                  {$t("Delete")}
-                </button>
-              </div>
-            </div>
-            <p class="whitespace-pre-wrap break-words text-sm text-ink-body">
-              {reflection.reflectionText}
-            </p>
-          </div>
-        {/each}
       </div>
     {/if}
   </section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
             "packages/**/*.test.ts",
             "apps/gateway/**/*.test.ts",
             "scripts/**/*.test.ts",
+            // Portal has no Svelte test project; its pure-TS helper tests (no
+            // `$lib`/`$app` aliases, no .svelte imports) run in the node project.
+            "apps/portal/src/lib/**/*.test.ts",
           ],
           // The postgres store suite opens an in-process PGlite (WASM Postgres)
           // per test. Under a full parallel run, many WASM cold-starts contend for


### PR DESCRIPTION
Three fixes from Lukin's review of the live portal.

## 1. Widescreen support
The layout capped content at `max-w-6xl` (1152px), leaving large empty margins on wide screens. Bumped the header + main to `max-w-7xl` (1280px) — the standard generous dashboard width. Responsive grids on the pages were already there; they just needed room.

## 2. Memory page: Reflections first
Moved the **Reflections** section above **Facts**, matching the admin memory page's order. Margin swapped so the top section carries the spacing.

## 3. Memory "Active" filter leaked superseded facts
A superseded fact is stored as `status:"active"` with `superseded:true`. The client-side filter had an unguarded `fact.status === factStatus` fallback that also fired for `factStatus:"active"` — so superseded facts showed up under **Active**.

Fix: extracted the predicate into a pure, alias-free `factMatchesStatus()` that guards the archived/pruned branch, with a unit test covering the regression. Wired portal's pure-TS lib tests into the node vitest project so they run in CI (portal had no test project before).

## Verification
- `svelte-check`: 0 errors / 0 warnings
- `biome check`: clean
- `vitest` (CI node project): `factMatchesStatus` 4/4 pass — incl. the "Active excludes superseded" regression
- portal production build: ✓
- Playwright drive at **1920px** against stubbed memory data:
  - Reflections render **above** Facts ✓
  - **Active** filter → only the non-superseded fact ✓
  - **Superseded** filter → the superseded fact (badge shown), nothing lost ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)