### PR TITLE
feat(portal): full-width layout, no side margins (v0.26.5)

### DIFF
--- a/apps/portal/src/routes/+layout.svelte
+++ b/apps/portal/src/routes/+layout.svelte
@@ -48,7 +48,7 @@
 {:else}
   <div class="min-h-screen bg-canvas text-ink-1">
     <header class="border-b border-border bg-surface">
-      <div class="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4">
+      <div class="flex h-14 items-center gap-4 px-4 sm:px-6 lg:px-8">
         <a
           href={hrefFor("")}
           class="flex items-center gap-2 font-semibold text-ink-1"
@@ -142,7 +142,7 @@
       {/if}
     </header>
 
-    <main class="mx-auto max-w-7xl px-4 py-6">
+    <main class="px-4 py-6 sm:px-6 lg:px-8">
       {@render children()}
     </main>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Lukin wanted the portal truly edge-to-edge — the earlier `max-w-7xl` still left visible margins on wide screens.

## Change
Drop the width cap (`max-w-7xl`) and centering (`mx-auto`) on the layout header + main, so content goes full-width. Keep responsive horizontal padding (`px-4 sm:px-6 lg:px-8`) so it doesn't touch the screen edge.

Two-line diff in `apps/portal/src/routes/+layout.svelte`.

## Verification
- `svelte-check`: 0 errors / 0 warnings
- `biome check`: clean
- Built + served locally with a mock API, driven at **1920px**: Overview (KPI cards, trend + pie chart, recent-requests table) and Memory both fill the full viewport width, no side margins. Confirmed visually with Lukin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)