### PR TITLE
feat: add GPT-5.6 support

### DIFF
--- a/apps/gateway/e2e/eval.spec.ts
+++ b/apps/gateway/e2e/eval.spec.ts
@@ -44,16 +44,12 @@ const AUTH = {
 // deliberately omits this and runs at the shipped default threshold.
 const UNCERTAIN = { ...AUTH, "x-helm-rules-threshold": "0.99" };
 
-// Shipped config/lanes.yaml candidate heads (alias-namespace alignment,
-// 2026-05-31). Keep in lockstep with config/lanes.yaml `balanced`/`premium`
-// primaries.
-// These e2e run with NO subscription connected, so a lane's nominal `openai-codex/*`
-// primary is SKIPPED (provider_unavailable) and the lane serves its first STATIC
-// fallback. balanced serves deepseek/deepseek-v4-pro; premium's first mock-backed
-// candidate is zenmux/gpt-5.5 (ZenMux is keyed in the e2e — it carries gpt-image-2),
-// so the two lanes serve DIFFERENT models (also told apart by the x-helm-lane header).
-const BALANCED_HEAD = "deepseek/deepseek-v4-pro";
-const PREMIUM_HEAD = "zenmux/gpt-5.5";
+// Shipped config/lanes.yaml candidate heads. These e2e run with no Codex
+// subscription connected, so `openai-codex/*` is skipped. The official OpenAI
+// provider is keyed with a dummy key and redirected to the mock, so the GPT-5.6
+// official fallbacks serve first.
+const BALANCED_HEAD = "openai/gpt-5.6-terra";
+const PREMIUM_HEAD = "openai/gpt-5.6-sol";
 
 // An intentionally ambiguous prompt: no strong Layer-1 keyword signal. Paired
 // with the UNCERTAIN header (rules threshold 0.99) the cascade is guaranteed to

--- a/apps/gateway/e2e/fixtures/mock-upstream.ts
+++ b/apps/gateway/e2e/fixtures/mock-upstream.ts
@@ -42,14 +42,11 @@ export function echoResponse(model: string) {
 // gateway to fall forward to the next in-chain candidate. Exported so the spec
 // and the mock stay in lockstep.
 //
-// The economy lane head is the alias `deepseek/deepseek-v4-flash`, whose RESOLVED
-// provider_model is the BARE upstream id `deepseek-v4-flash` (alias != provider_
-// model — the upstream accepts the bare id). The gateway forwards that resolved
-// provider_model upstream as `model`, so the mock must match on the BARE id. Keep
-// in lockstep with config/providers.yaml's `provider_model` for config/lanes.yaml
-// `economy.primary`.
+// The e2e economy serving head is the official OpenAI GPT-5.6 Luna fallback
+// (`openai-codex/*` is skipped without a subscription). The gateway forwards the
+// resolved provider_model upstream as `model`, so the mock matches the bare wire id.
 export const FAIL_PRIMARY_SENTINEL = "__HELM_FAIL_PRIMARY__";
-export const FAIL_PRIMARY_MODEL = "deepseek-v4-flash";
+export const FAIL_PRIMARY_MODEL = "gpt-5.6-luna";
 
 // Image-lane fallback steering: a sentinel in the image prompt fails ONLY the
 // `gemini-image` lane's PRIMARY (gemini-3.1-flash-image) on the generateContent

--- a/apps/gateway/e2e/protocol.spec.ts
+++ b/apps/gateway/e2e/protocol.spec.ts
@@ -160,7 +160,7 @@ test.describe("OpenAI client → upstream", () => {
     });
     expect(engineRes.ok()).toBeTruthy();
     const upstream = await lastUpstreamRequest(request);
-    expect(upstream.body.model).toBe("deepseek-v4-flash");
+    expect(upstream.body.model).toBe("gpt-5.6-luna");
   });
 
   test("stream: first chunk carries role, last carries finish_reason, ends [DONE]", async ({

--- a/apps/gateway/e2e/routing.spec.ts
+++ b/apps/gateway/e2e/routing.spec.ts
@@ -19,37 +19,23 @@ import { FAIL_PRIMARY_SENTINEL } from "./fixtures/mock-upstream.js";
 const TEST_KEY = "helm_live_e2e_testkey";
 const AUTH = { Authorization: `Bearer ${TEST_KEY}`, "Content-Type": "application/json" };
 
-// NO-SUBSCRIPTION FAIL-OPEN (the CI reality). These e2e run with NO subscription
-// connected, so the `openai-codex/*` lane heads (premium/coding/tool_use primaries
-// in config/lanes.yaml) are NOT routable: the executor SKIPS them with
-// skip_reason=provider_unavailable (never forwarding a prefixed id to the primary)
-// and the lane falls open to its first STATIC fallback. So the model that actually
-// SERVES each lane below is the deepseek/* (or zenmux/openrouter) static candidate,
-// not the nominal openai-codex primary. With a subscription connected, the codex
-// head would serve instead.
-const ECONOMY_HEAD = "deepseek/deepseek-v4-flash"; // economy static primary serves
-// premium's nominal primary is openai-codex/gpt-5.5 — skipped w/o a subscription;
-// the next candidates (anthropic opus, native zenmux-anthropic opus) are also
-// skipped/unserved, so premium's first MOCK-BACKED candidate is the OpenAI-compat
-// zenmux/gpt-5.5 (wire openai/gpt-5.5) — ZenMux IS keyed in the e2e (it carries the
-// gpt-image-2 image model), matching production where the zenmux fallback serves.
-const PREMIUM_HEAD = "zenmux/gpt-5.5";
-const BALANCED_HEAD = "deepseek/deepseek-v4-pro"; // balanced static primary serves
-// economy chain = [openai-codex/gpt-5.4-mini, anthropic/claude-haiku, deepseek/
-// deepseek-v4-flash, openrouter/deepseek-v4-flash, openrouter/auto, zenmux/auto].
-// On fault injection (scenario 4) the economy head 5xxs and the codex/anthropic
-// candidates before it are skipped, so the next in-chain model that serves is
-// openrouter/deepseek-v4-flash (wire id deepseek/deepseek-v4-flash != the failed
-// bare deepseek-v4-flash, so the mock serves it).
-const ECONOMY_NEXT = "openrouter/deepseek-v4-flash";
+// NO-SUBSCRIPTION FAIL-OPEN (the CI reality). These e2e run with NO Codex
+// subscription connected, so the `openai-codex/*` lane heads are skipped with
+// provider_unavailable. The official OpenAI provider is keyed with a dummy key and
+// redirected to the local mock, so the GPT-5.6 official API fallback serves first.
+const ECONOMY_HEAD = "openai/gpt-5.6-luna";
+const PREMIUM_HEAD = "openai/gpt-5.6-sol";
+const BALANCED_HEAD = "openai/gpt-5.6-terra";
+// economy chain after a failed official Luna call skips Codex/Anthropic
+// subscription aliases and falls forward to the DeepSeek flash static fallback.
+const ECONOMY_NEXT = "deepseek/deepseek-v4-flash";
 
 // The upstream WIRE model ids the gateway sends (config/providers.yaml
-// `provider_model`), echoed back by the mock as `model`. All served candidates
-// here are EXPLICIT deepseek/* entries, so the wire id is the bare provider_model.
+// `provider_model`), echoed back by the mock as `model`.
 // The routing ALIAS is surfaced separately via `x-helm-final-model`.
-const ECONOMY_HEAD_WIRE = "deepseek-v4-flash";
-const PREMIUM_HEAD_WIRE = "openai/gpt-5.5"; // zenmux/gpt-5.5 → provider_model openai/gpt-5.5
-const ECONOMY_NEXT_WIRE = "deepseek/deepseek-v4-flash";
+const ECONOMY_HEAD_WIRE = "gpt-5.6-luna";
+const PREMIUM_HEAD_WIRE = "gpt-5.6-sol";
+const ECONOMY_NEXT_WIRE = "deepseek-v4-flash";
 
 function chat(content: string, extra: Record<string, unknown> = {}) {
   return {
@@ -62,7 +48,7 @@ function chat(content: string, extra: Record<string, unknown> = {}) {
 
 test.describe("routing e2e", () => {
   // ── Scenario 1: simple prompt → economy lane ────────────────────────────────
-  // The economy head (deepseek/deepseek-v4-flash) is json + non-stream capable, so
+  // The economy head (openai/gpt-5.6-luna) is json + non-stream capable, so
   // a plain non-stream request serves it directly. Routing is asserted via the
   // debug headers; the resolved bare wire id is surfaced as x-helm-provider-model.
   test("simple prompt -> economy lane", async ({ request }) => {
@@ -80,11 +66,9 @@ test.describe("routing e2e", () => {
   });
 
   // ── Scenario 2: complex prompt → premium lane ───────────────────────────────
-  // Premium's nominal primary (openai-codex/gpt-5.5) is the subscription channel;
-  // with no subscription connected it is SKIPPED (provider_unavailable) and premium
-  // fails open to its first static fallback, deepseek/deepseek-v4-pro. The lane is
-  // still `premium` (asserted via the header) — only the served model is the
-  // fallback.
+  // Premium's nominal primary (openai-codex/gpt-5.6-sol) is the subscription
+  // channel; with no subscription connected it is skipped and premium serves the
+  // official OpenAI GPT-5.6 Sol fallback.
   test("complex prompt -> premium lane", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
       data: chat(
@@ -125,9 +109,9 @@ test.describe("routing e2e", () => {
   });
 
   // ── Scenario 4: primary provider error → EXECUTION fallback serves ──────────
-  // Mock injects a one-shot 5xx for the economy head (`deepseek/deepseek-v4-flash`);
+  // Mock injects a one-shot 5xx for the economy head (`openai/gpt-5.6-luna`);
   // the skipped codex/anthropic candidates never serve, so the first in-chain
-  // candidate that serves is `openrouter/deepseek-v4-flash`. Lane stays `economy`
+  // candidate that serves is `deepseek/deepseek-v4-flash`. Lane stays `economy`
   // (execution fallback ≠ classification fallback, principle 5).
   test("primary provider error -> fallback model serves (execution fallback)", async ({
     request,

--- a/apps/gateway/src/oauth/effective-models.test.ts
+++ b/apps/gateway/src/oauth/effective-models.test.ts
@@ -93,7 +93,7 @@ describe("effectiveOAuthAliases", () => {
     const { tokens, config } = makeStores();
     await bind(tokens, "openai-codex", "default");
     await setAccountSettings(config, KEY, "openai-codex", "default", {
-      enabledModels: ["gpt-5.5"],
+      enabledModels: ["gpt-5.6-sol"],
     });
     // Codex bound but not routable yet → no aliases.
     const aliases = await effectiveOAuthAliases(
@@ -104,7 +104,7 @@ describe("effectiveOAuthAliases", () => {
     expect(aliases).toEqual([]);
     // Once routable, it appears.
     const withCodex = await effectiveOAuthAliases({ store: tokens, encKey: KEY }, config, ROUTABLE);
-    expect(withCodex).toEqual(["openai-codex/gpt-5.5"]);
+    expect(withCodex).toEqual(["openai-codex/gpt-5.6-sol"]);
   });
 
   it("reflects a curation edit on the NEXT read (no caching/snapshot)", async () => {
@@ -127,14 +127,14 @@ describe("effectiveOAuthAliases", () => {
 describe("effectiveOAuthModelOptions", () => {
   it("groups the exposing account(s) under each alias (sorted, deduped)", async () => {
     const { tokens, config } = makeStores();
-    // Two Codex accounts: both expose gpt-5.5; only `default` exposes gpt-5.4.
+    // Two Codex accounts: both expose Sol; only `default` exposes Luna.
     await bind(tokens, "openai-codex", "default");
     await bind(tokens, "openai-codex", "mylukin");
     await setAccountSettings(config, KEY, "openai-codex", "default", {
-      enabledModels: ["gpt-5.5", "gpt-5.4"],
+      enabledModels: ["gpt-5.6-sol", "gpt-5.6-luna"],
     });
     await setAccountSettings(config, KEY, "openai-codex", "mylukin", {
-      enabledModels: ["gpt-5.5"],
+      enabledModels: ["gpt-5.6-sol"],
     });
     const options = await effectiveOAuthModelOptions(
       { store: tokens, encKey: KEY },
@@ -142,8 +142,8 @@ describe("effectiveOAuthModelOptions", () => {
       ROUTABLE,
     );
     expect(options).toEqual([
-      { alias: "openai-codex/gpt-5.4", accounts: ["default"] },
-      { alias: "openai-codex/gpt-5.5", accounts: ["default", "mylukin"] },
+      { alias: "openai-codex/gpt-5.6-luna", accounts: ["default"] },
+      { alias: "openai-codex/gpt-5.6-sol", accounts: ["default", "mylukin"] },
     ]);
   });
 });

--- a/apps/gateway/src/routes/models.test.ts
+++ b/apps/gateway/src/routes/models.test.ts
@@ -130,20 +130,20 @@ describe("GET /v1/models", () => {
     // contain a hyphen (ROUTABLE_OAUTH keys, e.g. `openai-codex`). owned_by must be
     // the FULL prefix before the first slash, not a truncation.
     const res = await buildApp(record({ allow_custom_model: true }), () => [
-      "openai-codex/gpt-5.4",
+      "openai-codex/gpt-5.6-sol",
       "deepseek/pro", // overlaps a configured alias -> deduped, listed once
     ]).request("/v1/models", { headers: AUTH });
     const body = (await res.json()) as ModelsList;
     const ids = body.data.map((m) => m.id);
-    expect(ids).toContain("openai-codex/gpt-5.4");
+    expect(ids).toContain("openai-codex/gpt-5.6-sol");
     expect(ids.filter((id) => id === "deepseek/pro")).toHaveLength(1);
-    const codex = body.data.find((m) => m.id === "openai-codex/gpt-5.4");
+    const codex = body.data.find((m) => m.id === "openai-codex/gpt-5.6-sol");
     expect(codex?.type).toBe("model");
     expect(codex?.owned_by).toBe("openai-codex");
   });
 
   it("normal key: subscription aliases stay hidden (lane abstraction)", async () => {
-    const res = await buildApp(record(), () => ["openai-codex/gpt-5.4"]).request("/v1/models", {
+    const res = await buildApp(record(), () => ["openai-codex/gpt-5.6-sol"]).request("/v1/models", {
       headers: AUTH,
     });
     const body = (await res.json()) as ModelsList;

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -464,7 +464,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       updatedAt: 1,
     });
     await setAccountSettings(config, ENC_KEY, "openai-codex", "default", {
-      enabledModels: ["gpt-5.5", "gpt-5.4"],
+      enabledModels: ["gpt-5.6-sol", "gpt-5.6-luna"],
     });
     const { providers, poolClients } = await synthesizeOAuthProviders(
       [],
@@ -481,7 +481,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect(providers[0]?.type).toBe("openai-responses");
     expect(poolClients.has("openai-codex")).toBe(true);
     const aliases = (providers[0]?.models ?? []).map((m) => m.alias).sort();
-    expect(aliases).toEqual(["openai-codex/gpt-5.4", "openai-codex/gpt-5.5"]);
+    expect(aliases).toEqual(["openai-codex/gpt-5.6-luna", "openai-codex/gpt-5.6-sol"]);
   });
 
   it("threads per-account Fast mode into the synthesized Codex pool client", async () => {

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -49,19 +49,61 @@
 # stream-only relay), so no `requiresStreaming` constraint applies. `deepseek/*`
 # are the official DeepSeek API models (providers[0]).
 #
-# These three are EXACTLY the curated Codex set the subscription exposes
-# (packages/core/src/provider/oauth/models.ts — the ChatGPT-account Codex backend
-# 400s on legacy `*-codex`/`*-pro` slugs, verified live), so every exposed alias
-# an operator can pick has a capability + pricing entry here.
+# Every curated Codex model (packages/core/src/provider/oauth/models.ts) needs a
+# manual capability entry here because the subscription aliases are synthesized at
+# runtime and do not exist in LiteLLM's generated catalog.
 #
-# CONTEXT WINDOW = 272000 for ALL THREE. The ChatGPT/Codex SUBSCRIPTION caps the
-# effective window at 272K regardless of the underlying model's API window (the
-# API `gpt-5.5` is 1.05M — see zenmux/gpt-5.5 below — but the subscription is NOT).
-# Empirically the codex backend 400s `context_length_exceeded` above ~272K: on
-# la.atmy.work the max input it ever served was 271,529 over 5,919 calls, and every
-# request ≳272K (e.g. a 597K Claude Code passthrough) was rejected. The wrong 1.05M
-# value let the capability filter route oversized requests here, burning a guaranteed
-# upstream 400 before failing over (the whole point of the context_too_small gate).
+# CONTEXT WINDOW = 272000 for `openai-codex/*`. The ChatGPT/Codex SUBSCRIPTION
+# caps the effective window at 272K regardless of the underlying model's API window
+# (official GPT-5.6/GPT-5.5 are 1.05M, but the subscription is not). Empirically
+# the codex backend 400s `context_length_exceeded` above ~272K: on la.atmy.work the
+# max input it ever served was 271,529 over 5,919 calls, and every request ≳272K
+# (e.g. a 597K Claude Code passthrough) was rejected. The wrong 1.05M value would
+# route oversized requests here and burn a guaranteed upstream 400 before failover.
+openai-codex/gpt-5.6:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 272000
+  maxOutputTokens: 128000
+openai-codex/gpt-5.6-sol:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 272000
+  maxOutputTokens: 128000
+openai-codex/gpt-5.6-terra:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 272000
+  maxOutputTokens: 128000
+openai-codex/gpt-5.6-luna:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 272000
+  maxOutputTokens: 128000
 openai-codex/gpt-5.5:
   supportsTools: true
   jsonOutput: schema
@@ -133,6 +175,50 @@ openrouter/deepseek-v4-flash:
   maxOutputTokens: 65536 # OpenRouter /v1/models: deepseek-v4-flash max_completion_tokens=65536
 # Claude capabilities now live under the native `zenmux-anthropic/claude-*` aliases
 # below (issue #217); the OpenAI-compat `zenmux/claude-*` entries were removed.
+openai/gpt-5.6:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 1050000
+  maxOutputTokens: 128000
+openai/gpt-5.6-sol:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 1050000
+  maxOutputTokens: 128000
+openai/gpt-5.6-terra:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 1050000
+  maxOutputTokens: 128000
+openai/gpt-5.6-luna:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [none, low, medium, high, xhigh, max]
+  maxContextTokens: 1050000
+  maxOutputTokens: 128000
 zenmux/gpt-5.5:
   supportsTools: true
   jsonOutput: schema

--- a/config/classifier.yaml
+++ b/config/classifier.yaml
@@ -190,7 +190,7 @@ classifier:
       # scoped to the LAST user turn and excludes code-changing / JSON / vision
       # requests, so explicit heavy-model or edit/debug work is not down-routed.
       cheap_model_low_risk:
-        requested_model_markers: ["economy", "gpt-5.4-mini", "gpt-5.4-mini-*", "spark", "*deepseek-v4-flash", "claude-haiku", "*claude-haiku-*", "claude-3-5-haiku", "*claude-3-5-haiku-*"]
+        requested_model_markers: ["economy", "gpt-5.6-luna", "gpt-5.6-luna-*", "gpt-5.4-mini", "gpt-5.4-mini-*", "spark", "*deepseek-v4-flash", "claude-haiku", "*claude-haiku-*", "claude-3-5-haiku", "*claude-3-5-haiku-*"]
         current_turn_max_chars: 300
         low_risk_markers: ["check", "inspect", "status", "health", "read", "list", "show", "summarize", "report", "monitor", "look at", "see if", "查看", "检查", "状态", "健康", "读取", "列出", "展示", "总结", "报告", "监控"]
         blocked_markers: ["debug", "fix", "implement", "refactor", "modify", "edit", "patch", "write", "create", "generate", "delete", "deploy", "release", "security", "vulnerability", "exploit", "prove", "derive", "calculate", "solve", "调试", "修复", "实现", "重构", "修改", "编辑", "补丁", "编写", "创建", "生成", "删除", "部署", "发布", "安全", "漏洞", "利用", "证明", "推导", "计算", "求解"]

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -9,23 +9,24 @@
 # gateway refuses to boot (fail-closed, principle 2). `balanced` is REQUIRED: it
 # is the terminal of the classification fallback.
 #
-# PROVIDER MIX (2026-06-03, task drop-openai-crs-relay): the cheap/default lanes
-# anchor on the ALWAYS-AVAILABLE official `deepseek` primary (static key — works in
-# dev, e2e, and a fresh install with NO subscription). premium / coding / tool_use
-# lead with the `openai-codex` SUBSCRIPTION channel (connect it in admin →
-# Providers), each backed by a static fallback so the lane degrades gracefully when
-# no subscription is bound: an unconnected `openai-codex/*` candidate fails OPEN
-# (Phase-0 back-fill / skip to the next fallback), never a 5xx. Each lane still ends
-# in a `*/auto` tail fallback; those auto aliases are deliberately JSON-INCAPABLE
-# (catalog jsonOutput:none), so a strict-JSON request prunes them and
+# PROVIDER MIX (2026-07-10, GPT-5.6): quality lanes lead with the `openai-codex`
+# SUBSCRIPTION channel (connect it in admin → Providers) and fall back to official
+# OpenAI GPT-5.6 API aliases when OPENAI_API_KEY is configured. DeepSeek/OpenRouter/
+# ZenMux remain static lower fallbacks so the lane degrades gracefully when Codex
+# or OpenAI API is unavailable. An unconnected `openai-codex/*` candidate fails
+# OPEN (Phase-0 back-fill / skip to the next fallback), never a 5xx. Each lane still
+# ends in a `*/auto` tail fallback; those auto aliases are deliberately
+# JSON-INCAPABLE (catalog jsonOutput:none), so a strict-JSON request prunes them and
 # lands on a deterministic json-capable model (docs/02: `*/auto` only at the tail).
 
 # —— quality/cost lanes ——
 economy:
   purpose: Cheap and fast for simple tasks
   reasoning_effort: medium
-  primary: openai-codex/gpt-5.4-mini
+  primary: openai-codex/gpt-5.6-luna
   fallback:
+    - openai/gpt-5.6-luna
+    - openai-codex/gpt-5.4-mini
     - anthropic/claude-haiku-4-5-20251001
     - deepseek/deepseek-v4-flash
     - openrouter/deepseek-v4-flash
@@ -35,8 +36,9 @@ economy:
 balanced:
   purpose: Default quality/cost tradeoff (classification fallback terminal)
   reasoning_effort: medium
-  primary: openai-codex/gpt-5.5
+  primary: openai-codex/gpt-5.6-terra
   fallback:
+    - openai/gpt-5.6-terra
     - anthropic/claude-sonnet-4-6
     - deepseek/deepseek-v4-pro
     - openrouter/deepseek-v4-pro
@@ -47,8 +49,9 @@ balanced:
 premium:
   purpose: Strong reasoning and high quality
   reasoning_effort: high
-  primary: openai-codex/gpt-5.5
+  primary: openai-codex/gpt-5.6-sol
   fallback:
+    - openai/gpt-5.6-sol
     - anthropic/claude-opus-4-8
     - zenmux-anthropic/claude-opus-4.8
     - zenmux/gpt-5.5
@@ -58,10 +61,10 @@ premium:
 #    classified task_type onto a same-named lane — docs/04) ——
 coding:
   purpose: Coding-capable models for code generation / editing
-  # gpt-5.5 is the strongest model the Codex subscription actually exposes; the
-  # legacy `*-codex` slugs 400 on the ChatGPT-account backend, so they are NOT used.
+  # GPT-5.6 Sol is the flagship coding/reasoning model. The legacy `*-codex` slugs
+  # are not used here because the ChatGPT-account backend historically rejected them.
   reasoning_effort: high
-  primary: openai-codex/gpt-5.5
+  primary: openai-codex/gpt-5.6-sol
   fallback:
     - premium
     - balanced
@@ -92,7 +95,7 @@ vision:
 tool_use:
   purpose: Reliable function / tool calling
   reasoning_effort: high
-  primary: openai-codex/gpt-5.5
+  primary: openai-codex/gpt-5.6-sol
   fallback:
     - premium
   constraints:
@@ -144,6 +147,39 @@ claude-haiku:
   purpose: Anthropic Claude Haiku tier — cheap/fast
   primary: anthropic/claude-haiku-4-5-20251001
   fallback:
+    - economy
+
+# GPT-5.6 family. The unsuffixed `gpt-5.6` alias routes to Sol upstream; Helm keeps
+# an explicit lane so pinned clients get a GPT-5.6-led chain before generic premium.
+"gpt-5.6":
+  purpose: OpenAI GPT-5.6 alias — routes to Sol upstream
+  primary: openai-codex/gpt-5.6
+  fallback:
+    - openai/gpt-5.6
+    - gpt-5.6-sol
+
+"gpt-5.6-sol":
+  purpose: OpenAI GPT-5.6 Sol tier — flagship reasoning/coding
+  reasoning_effort: high
+  primary: openai-codex/gpt-5.6-sol
+  fallback:
+    - openai/gpt-5.6-sol
+    - premium
+
+"gpt-5.6-terra":
+  purpose: OpenAI GPT-5.6 Terra tier — balanced intelligence/cost
+  reasoning_effort: medium
+  primary: openai-codex/gpt-5.6-terra
+  fallback:
+    - openai/gpt-5.6-terra
+    - balanced
+
+"gpt-5.6-luna":
+  purpose: OpenAI GPT-5.6 Luna tier — efficient/high-volume
+  reasoning_effort: medium
+  primary: openai-codex/gpt-5.6-luna
+  fallback:
+    - openai/gpt-5.6-luna
     - economy
 
 # Stays on GPT-5.5 ACROSS providers (Codex subscription -> static ZenMux key) before

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -46,6 +46,14 @@
 # (it is more literal than `gpt-5*`, so longest-literal-wins routes it to the cheap
 # lane, NOT the expensive `premium` catch-all). Comment these out if you don't front
 # any GPT clients.
+"gpt-5.6": gpt-5.6
+"gpt-5.6-sol": gpt-5.6-sol
+"gpt-5.6-sol-*": gpt-5.6-sol
+"gpt-5.6-terra": gpt-5.6-terra
+"gpt-5.6-terra-*": gpt-5.6-terra
+"gpt-5.6-luna": gpt-5.6-luna
+"gpt-5.6-luna-*": gpt-5.6-luna
+"gpt-5.6-*": gpt-5.6
 "gpt-5.5": gpt-5.5
 "gpt-5.4-mini": gpt-5.4-mini
 "gpt-5.4-mini-*": gpt-5.4-mini

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -17,6 +17,26 @@
 # this manual layer, not the generated catalog (see capabilities.yaml header).
 # Cost telemetry only — never drives selection. (deepseek numbers carried over
 # from the prior relay entries; verify against official DeepSeek pricing.)
+openai-codex/gpt-5.6:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 30.0
+  cacheReadPerMTokUsd: 0.5
+  cacheWritePerMTokUsd: 6.25
+openai-codex/gpt-5.6-sol:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 30.0
+  cacheReadPerMTokUsd: 0.5
+  cacheWritePerMTokUsd: 6.25
+openai-codex/gpt-5.6-terra:
+  inputPerMTokUsd: 2.5
+  outputPerMTokUsd: 15.0
+  cacheReadPerMTokUsd: 0.25
+  cacheWritePerMTokUsd: 3.125
+openai-codex/gpt-5.6-luna:
+  inputPerMTokUsd: 1.0
+  outputPerMTokUsd: 6.0
+  cacheReadPerMTokUsd: 0.1
+  cacheWritePerMTokUsd: 1.25
 openai-codex/gpt-5.5:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 30.0
@@ -43,6 +63,26 @@ openrouter/deepseek-v4-flash:
   outputPerMTokUsd: 0.18
 # Claude pricing now lives under the native `zenmux-anthropic/claude-*` aliases
 # (issue #217); the OpenAI-compat `zenmux/claude-*` entries were removed.
+openai/gpt-5.6:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 30.0
+  cacheReadPerMTokUsd: 0.5
+  cacheWritePerMTokUsd: 6.25
+openai/gpt-5.6-sol:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 30.0
+  cacheReadPerMTokUsd: 0.5
+  cacheWritePerMTokUsd: 6.25
+openai/gpt-5.6-terra:
+  inputPerMTokUsd: 2.5
+  outputPerMTokUsd: 15.0
+  cacheReadPerMTokUsd: 0.25
+  cacheWritePerMTokUsd: 3.125
+openai/gpt-5.6-luna:
+  inputPerMTokUsd: 1.0
+  outputPerMTokUsd: 6.0
+  cacheReadPerMTokUsd: 0.1
+  cacheWritePerMTokUsd: 1.25
 zenmux/gpt-5.5:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 30.0

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -34,16 +34,17 @@
 # HELM_PROVIDER_BASE_URL so the mock upstream serves all of them.
 #
 # ─────────────────────────────────────────────────────────────────────────────
-# PRIMARY = official DeepSeek; premium/coding lanes route through the openai-codex
-# SUBSCRIPTION channel (2026-06-03, task drop-openai-crs-relay). The former
-# self-built `openai-crs` relay (la.atmy.work) was deleted: it WAS just a proxy in
-# front of a ChatGPT/Codex subscription, which Helm now connects natively via the
-# built-in `openai-codex` OAuth preset (admin → Providers → Connect). That preset
-# is SYNTHESIZED at runtime — it exposes its models as `openai-codex/<model>`
-# aliases keyed by the OAuth provider id — so it must NOT be declared as a static
-# provider here, or the duplicate alias would fail-closed. Lanes may reference
-# `openai-codex/*` even before a subscription is connected: an unconnected alias
-# fails OPEN (Phase-0 back-fill / skip to the next fallback), never a 5xx.
+# PRIMARY STATIC FALLBACK = official DeepSeek. The quality lanes now lead with the
+# synthesized `openai-codex/*` subscription aliases and then the static official
+# OpenAI GPT-5.6 API aliases below. The former self-built `openai-crs` relay
+# (la.atmy.work) was deleted: it WAS just a proxy in front of a ChatGPT/Codex
+# subscription, which Helm now connects natively via the built-in `openai-codex`
+# OAuth preset (admin → Providers → Connect). That preset is SYNTHESIZED at
+# runtime — it exposes its models as `openai-codex/<model>` aliases keyed by the
+# OAuth provider id — so it must NOT be declared as a static provider here, or the
+# duplicate alias would fail-closed. Lanes may reference `openai-codex/*` even
+# before a subscription is connected: an unconnected alias fails OPEN (Phase-0
+# back-fill / skip to the next fallback), never a 5xx.
 providers:
   # PRIMARY provider (providers[0]). Backs the default path, the Layer-2 eval
   # call, and the Phase-0 passthrough; its credential (DEEPSEEK_API_KEY) is
@@ -83,8 +84,8 @@ providers:
       # `zenmux-anthropic` provider below (issue #217). The former OpenAI-compat
       # `zenmux/claude-*` aliases were removed: same upstream, but the native wire
       # preserves prompt-cache / tool-use and skips the lossy IR translation.
-      # openai/gpt-5.5 — premium fallback when no Codex subscription is connected
-      # (zenmux real id).
+      # openai/gpt-5.5 — legacy premium fallback when no Codex subscription or
+      # official OpenAI key is connected (zenmux real id).
       - alias: zenmux/gpt-5.5
         provider_model: openai/gpt-5.5
       # OpenAI IMAGE GENERATION (Images API). A bare alias so OpenAI clients can pin
@@ -185,12 +186,22 @@ providers:
   # (set OPENAI_API_KEY / GEMINI_API_KEY in the environment); an unset key just makes
   # that provider unavailable (the chain skips it), never a boot failure.
 
-  # OpenAI OFFICIAL — direct Images API for gpt-image-2.
+  # OpenAI OFFICIAL — direct Responses/Chat models for GPT-5.6, plus Images API
+  # for gpt-image-2. If OPENAI_API_KEY is unset, these aliases are simply
+  # unavailable and the lane chain skips to the next fallback.
   - name: openai
     type: openai
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
     models:
+      - alias: openai/gpt-5.6
+        provider_model: gpt-5.6
+      - alias: openai/gpt-5.6-sol
+        provider_model: gpt-5.6-sol
+      - alias: openai/gpt-5.6-terra
+        provider_model: gpt-5.6-terra
+      - alias: openai/gpt-5.6-luna
+        provider_model: gpt-5.6-luna
       - alias: openai/gpt-image-2
         provider_model: gpt-image-2
 
@@ -296,11 +307,11 @@ providers:
   #       provider_model: gpt-4o
   #
   # ChatGPT Plus/Pro — Codex (browser login + paste redirect URL).
-  # This is the default lane channel for premium/coding/tool_use (config/lanes.yaml
-  # references openai-codex/gpt-5.5, openai-codex/gpt-5.4, openai-codex/gpt-5.4-mini
-  # — the models the Codex subscription actually exposes). Just connect it in the
-  # admin UI (Providers → Connect) — the pool is SYNTHESIZED and its models become
-  # `openai-codex/<model>` aliases automatically; NO YAML needed.
+  # This is the default lane channel for the GPT-5.6-led quality/task lanes
+  # (config/lanes.yaml references openai-codex/gpt-5.6*, plus older GPT fallbacks).
+  # Just connect it in the admin UI (Providers → Connect) — the pool is
+  # SYNTHESIZED and its models become `openai-codex/<model>` aliases automatically;
+  # NO YAML needed.
   # Declare a static block ONLY to pin a custom alias to a specific upstream id:
   # - name: chatgpt-codex
   #   type: openai

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-10 · GPT-5.6 family support in Helm defaults（Routing / provider catalog / cost telemetry，docs/03/04/07，原则 3/4/5/6）
+
+- **官方来源**：OpenAI latest-model docs 确认 `gpt-5.6` alias routes to `gpt-5.6-sol`，并给出 `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` 三档；OpenAI Models/Pricing docs 确认 1,050,000 context、128,000 max output、Responses/Chat/Batch 支持，以及标准价 input/cache-read/cache-write/output。
+- **路由决策**：quality lanes 升级为 Sol/Terra/Luna：`premium/coding/tool_use` 走 Sol，`balanced` 走 Terra，`economy` 走 Luna；同时新增 `gpt-5.6*` vendor-family lanes，让显式模型请求先走同家族再降级到既有质量 lane。
+- **供应链边界**：`openai/*` official API aliases 使用官方 1.05M context；`openai-codex/*` subscription aliases 继续保守使用 272K context cap，因为线上 Codex 订阅后端已有 `context_length_exceeded` 证据。这里优先避免 oversized 请求先打到必失败的订阅后端。
+- **价格决策**：telemetry pricing 使用官方标准 tier，不使用 priority tier；cache write 按 1.25x input 记录，cache read 使用折扣价。成本数据只用于观测，不参与路由选择。
+- **兼容性**：Codex OAuth 仍是 curated-only（无 live list endpoint），新 curated list 以 GPT-5.6 family 开头并保留 GPT-5.5/GPT-5.4/GPT-5.4-mini，管理员保存的 enabledModels 仍然是权威覆盖。
+
 ## 2026-07-09 · 个人门户（Self-Service Portal）完整实现 + 补齐 + 多语言（docs/12，原则 1/6/7）→ v0.26.0
 
 - **v0.26.0 发布范围**：整个 self-service portal（apps/portal 新 SvelteKit SPA）+ 6 个 bearer-scoped 端点 + 白名单脱敏 + Docker 集成 + admin/portal 7 语言 i18n。

--- a/packages/core/src/classifier/golden-routing.test.ts
+++ b/packages/core/src/classifier/golden-routing.test.ts
@@ -676,6 +676,7 @@ describe("GOLDEN: cheap-model low-risk current turns stay cheap", () => {
 
   it.each([
     "economy",
+    "gpt-5.6-luna",
     "deepseek-v4-flash",
     "claude-haiku",
   ])("short low-risk %s request with long history -> economy", async (requestedModel) => {

--- a/packages/core/src/classifier/overrides.test.ts
+++ b/packages/core/src/classifier/overrides.test.ts
@@ -148,7 +148,10 @@ describe("evaluateOverrides — cheap model low-risk current turn (set → simpl
   const cheapModelLowRisk = {
     requested_model_markers: [
       "economy",
+      "gpt-5.6-luna",
+      "gpt-5.6-luna-*",
       "gpt-5.4-mini",
+      "gpt-5.4-mini-*",
       "spark",
       "*deepseek-v4-flash",
       "claude-haiku",
@@ -190,6 +193,10 @@ describe("evaluateOverrides — cheap model low-risk current turn (set → simpl
 
   it.each([
     "economy",
+    "gpt-5.6-luna",
+    "gpt-5.6-luna-20260710",
+    "gpt-5.4-mini",
+    "gpt-5.4-mini-20260101",
     "deepseek-v4-flash",
     "deepseek/deepseek-v4-flash",
     "openrouter/deepseek-v4-flash",

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -60,6 +60,9 @@ describe("checked-in config samples", () => {
     expect(lanes.economy).toBeDefined();
     expect(lanes.balanced).toBeDefined();
     expect(lanes.premium).toBeDefined();
+    expect(lanes.economy?.primary).toBe("openai-codex/gpt-5.6-luna");
+    expect(lanes.balanced?.primary).toBe("openai-codex/gpt-5.6-terra");
+    expect(lanes.premium?.primary).toBe("openai-codex/gpt-5.6-sol");
     // task lanes
     expect(lanes.coding?.fallback).toEqual(["premium", "balanced"]);
     expect(lanes.json?.constraints.require_json).toBe(true);
@@ -87,6 +90,13 @@ describe("checked-in config samples", () => {
     // GPT families route to their dedicated vendor-family lanes. The cheap mini must
     // NOT be swallowed by the broad `gpt-5*` -> premium catch-all (longest-literal
     // wins): a dated mini id still lands on the cheap gpt-5.4-mini lane.
+    expect(resolveModelAlias("gpt-5.6", aliases)).toBe("gpt-5.6");
+    expect(resolveModelAlias("gpt-5.6-sol", aliases)).toBe("gpt-5.6-sol");
+    expect(resolveModelAlias("gpt-5.6-sol-20260710", aliases)).toBe("gpt-5.6-sol");
+    expect(resolveModelAlias("gpt-5.6-terra", aliases)).toBe("gpt-5.6-terra");
+    expect(resolveModelAlias("gpt-5.6-terra-20260710", aliases)).toBe("gpt-5.6-terra");
+    expect(resolveModelAlias("gpt-5.6-luna", aliases)).toBe("gpt-5.6-luna");
+    expect(resolveModelAlias("gpt-5.6-luna-20260710", aliases)).toBe("gpt-5.6-luna");
     expect(resolveModelAlias("gpt-5.4", aliases)).toBe("gpt-5.4");
     expect(resolveModelAlias("gpt-5.4-mini", aliases)).toBe("gpt-5.4-mini");
     expect(resolveModelAlias("gpt-5.4-mini-2026-01-01", aliases)).toBe("gpt-5.4-mini");
@@ -95,10 +105,18 @@ describe("checked-in config samples", () => {
     expect(validateModelAliasTargets(aliases, laneNames)).toEqual([]);
   });
 
-  it("loads the shipped gpt-5.4 vendor-family lanes leading with the real codex models", () => {
+  it("loads the shipped GPT vendor-family lanes leading with the real Codex models", () => {
     const cfg = loadConfig({ configDir, env: {} });
     const lanes = cfg.lanes;
     if (lanes === undefined) throw new Error("config/lanes.yaml must load into config.lanes");
+    expect(lanes["gpt-5.6"]?.primary).toBe("openai-codex/gpt-5.6");
+    expect(lanes["gpt-5.6"]?.fallback).toEqual(["openai/gpt-5.6", "gpt-5.6-sol"]);
+    expect(lanes["gpt-5.6-sol"]?.primary).toBe("openai-codex/gpt-5.6-sol");
+    expect(lanes["gpt-5.6-sol"]?.fallback).toEqual(["openai/gpt-5.6-sol", "premium"]);
+    expect(lanes["gpt-5.6-terra"]?.primary).toBe("openai-codex/gpt-5.6-terra");
+    expect(lanes["gpt-5.6-terra"]?.fallback).toEqual(["openai/gpt-5.6-terra", "balanced"]);
+    expect(lanes["gpt-5.6-luna"]?.primary).toBe("openai-codex/gpt-5.6-luna");
+    expect(lanes["gpt-5.6-luna"]?.fallback).toEqual(["openai/gpt-5.6-luna", "economy"]);
     expect(lanes["gpt-5.4"]?.primary).toBe("openai-codex/gpt-5.4");
     expect(lanes["gpt-5.4"]?.fallback).toEqual(["premium"]);
     expect(lanes["gpt-5.4-mini"]?.primary).toBe("openai-codex/gpt-5.4-mini");

--- a/packages/core/src/provider/oauth/models.test.ts
+++ b/packages/core/src/provider/oauth/models.test.ts
@@ -20,6 +20,18 @@ describe("discoverOAuthModels", () => {
     );
   });
 
+  it("keeps the Codex curated fallback on the GPT-5.6 family first", () => {
+    expect(CURATED_OAUTH_MODELS["openai-codex"]).toEqual([
+      "gpt-5.6",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+    ]);
+  });
+
   it("discovers Anthropic models LIVE from /v1/models when a token is present", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -20,13 +20,19 @@ import { listGitHubCopilotModels } from "./github-copilot.js";
 // override via an explicit providers.yaml entry.
 export const CURATED_OAUTH_MODELS: Record<string, string[]> = {
   anthropic: ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
-  // ChatGPT Codex set. VERIFIED LIVE (2026-06-03) against a real ChatGPT-account
-  // token on /backend-api/codex/responses: this backend accepts ONLY the current GA
-  // chat models — every legacy `*-codex` / `*-pro` / `*-nano` slug returns
-  // 400 "model is not supported when using Codex with a ChatGPT account". So the
-  // curated default is exactly the models that serve; operators can add more via the
-  // Manage dialog (their saved list is authoritative) or a providers.yaml override.
-  "openai-codex": ["gpt-5.4", "gpt-5.4-mini", "gpt-5.5"],
+  // ChatGPT Codex set. Starts with the current GPT-5.6 family, then keeps the
+  // previous GA models as fallback choices operators can still select. Operators
+  // can add/remove models via the Manage dialog (their saved list is authoritative)
+  // or a providers.yaml override.
+  "openai-codex": [
+    "gpt-5.6",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+  ],
 };
 
 // Live-list Anthropic (Claude Pro/Max) models via GET /v1/models with the OAuth

--- a/packages/core/src/routing/model-alias.test.ts
+++ b/packages/core/src/routing/model-alias.test.ts
@@ -53,6 +53,16 @@ describe("resolveModelAlias", () => {
     expect(resolveModelAlias("gpt-5x5", { "gpt-5.5": "premium" })).toBeNull();
   });
 
+  it("prefers GPT-5.6 tier-specific aliases over the broad GPT catch-all", () => {
+    const map = {
+      "gpt-5*": "premium",
+      "gpt-5.6-*": "gpt-5.6",
+      "gpt-5.6-luna-*": "gpt-5.6-luna",
+    };
+    expect(resolveModelAlias("gpt-5.6-luna-20260710", map)).toBe("gpt-5.6-luna");
+    expect(resolveModelAlias("gpt-5.6-preview", map)).toBe("gpt-5.6");
+  });
+
   it("a keyword-wrapped glob with more literals wins (flash-lite beats flash), order-independent", () => {
     // `gemini-*flash-lite*` (17 literals) is more specific than `gemini-*flash*` (12),
     // so a flash-lite id routes to the cheap tier while full-flash falls to the flash lane.

--- a/packages/shared/src/config/classifier-schema.test.ts
+++ b/packages/shared/src/config/classifier-schema.test.ts
@@ -29,7 +29,10 @@ function fullClassifier() {
         cheap_model_low_risk: {
           requested_model_markers: [
             "economy",
+            "gpt-5.6-luna",
+            "gpt-5.6-luna-*",
             "gpt-5.4-mini",
+            "gpt-5.4-mini-*",
             "spark",
             "*deepseek-v4-flash",
             "claude-haiku",


### PR DESCRIPTION
## Summary
- add GPT-5.6 Sol/Terra/Luna and unsuffixed GPT-5.6 aliases across lanes, providers, capabilities, pricing, aliases, and classifier cheap-model hints
- update Codex OAuth curated models to expose GPT-5.6 first while preserving GPT-5.5/GPT-5.4 fallbacks
- update unit and e2e expectations for the new GPT-5.6-led default chains

## Verification
- corepack pnpm build
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm --filter @helm/gateway test:e2e