### PR TITLE
chore: release v0.26.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.5",
+  "version": "0.26.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump root package version to v0.26.6 for the GPT-5.6 support release

## Verification
- node package.json version check
- git diff --check

Feature PR #498 already passed docker/e2e/verify before merge.