### PR TITLE
feat: support verified GPT-5.6 Codex models

### DIFF
--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -416,7 +416,18 @@ describe("createOAuthAdmin", () => {
       updatedAt: 1,
     });
     const admin = createOAuthAdmin({ store: tokens, encKey: KEY, config });
-    const { canPull } = await admin.listModels({ providerId: "openai-codex", account: "default" });
+    const { available, enabled, canPull } = await admin.listModels({
+      providerId: "openai-codex",
+      account: "default",
+    });
+    expect(available).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+    ]);
+    expect(enabled).toEqual(available);
     // No live list-models API → the UI hides "pull from provider".
     expect(canPull).toBe(false);
   });

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -9,23 +9,26 @@
 # gateway refuses to boot (fail-closed, principle 2). `balanced` is REQUIRED: it
 # is the terminal of the classification fallback.
 #
-# PROVIDER MIX (2026-07-10, GPT-5.6): quality lanes lead with the `openai-codex`
-# SUBSCRIPTION channel (connect it in admin → Providers) and fall back to official
-# OpenAI GPT-5.6 API aliases when OPENAI_API_KEY is configured. DeepSeek/OpenRouter/
-# ZenMux remain static lower fallbacks so the lane degrades gracefully when Codex
-# or OpenAI API is unavailable. An unconnected `openai-codex/*` candidate fails
-# OPEN (Phase-0 back-fill / skip to the next fallback), never a 5xx. Each lane still
-# ends in a `*/auto` tail fallback; those auto aliases are deliberately
-# JSON-INCAPABLE (catalog jsonOutput:none), so a strict-JSON request prunes them and
-# lands on a deterministic json-capable model (docs/02: `*/auto` only at the tail).
+# PROVIDER MIX (2026-07-10, GPT-5.6): quality lanes lead with verified
+# `openai-codex` SUBSCRIPTION slugs where the ChatGPT/Codex backend accepts them
+# (connect it in admin → Providers) and fall back to official OpenAI GPT-5.6 API
+# aliases when OPENAI_API_KEY is configured. The official `gpt-5.6` alias routes
+# to Sol, but the subscription backend rejects the bare alias; Luna is official API
+# surface, but is not yet accepted by the subscription backend on this executor
+# path. DeepSeek/OpenRouter/ZenMux remain static lower fallbacks so lanes degrade
+# gracefully when Codex or OpenAI API is unavailable. An unconnected candidate
+# fails OPEN (Phase-0 back-fill / skip to the next fallback), never a 5xx. Each
+# lane still ends in a `*/auto` tail fallback; those auto aliases are deliberately
+# JSON-INCAPABLE (catalog jsonOutput:none), so a strict-JSON request prunes them
+# and lands on a deterministic json-capable model (docs/02: `*/auto` only at the
+# tail).
 
 # —— quality/cost lanes ——
 economy:
   purpose: Cheap and fast for simple tasks
   reasoning_effort: medium
-  primary: openai-codex/gpt-5.6-luna
+  primary: openai/gpt-5.6-luna
   fallback:
-    - openai/gpt-5.6-luna
     - openai-codex/gpt-5.4-mini
     - anthropic/claude-haiku-4-5-20251001
     - deepseek/deepseek-v4-flash
@@ -153,7 +156,7 @@ claude-haiku:
 # an explicit lane so pinned clients get a GPT-5.6-led chain before generic premium.
 "gpt-5.6":
   purpose: OpenAI GPT-5.6 alias — routes to Sol upstream
-  primary: openai-codex/gpt-5.6
+  primary: openai-codex/gpt-5.6-sol
   fallback:
     - openai/gpt-5.6
     - gpt-5.6-sol
@@ -177,9 +180,8 @@ claude-haiku:
 "gpt-5.6-luna":
   purpose: OpenAI GPT-5.6 Luna tier — efficient/high-volume
   reasoning_effort: medium
-  primary: openai-codex/gpt-5.6-luna
+  primary: openai/gpt-5.6-luna
   fallback:
-    - openai/gpt-5.6-luna
     - economy
 
 # Stays on GPT-5.5 ACROSS providers (Codex subscription -> static ZenMux key) before

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -54,6 +54,14 @@
 "gpt-5.6-luna": gpt-5.6-luna
 "gpt-5.6-luna-*": gpt-5.6-luna
 "gpt-5.6-*": gpt-5.6
+"openai.gpt-5.6": gpt-5.6
+"openai.gpt-5.6-sol": gpt-5.6-sol
+"openai.gpt-5.6-sol-*": gpt-5.6-sol
+"openai.gpt-5.6-terra": gpt-5.6-terra
+"openai.gpt-5.6-terra-*": gpt-5.6-terra
+"openai.gpt-5.6-luna": gpt-5.6-luna
+"openai.gpt-5.6-luna-*": gpt-5.6-luna
+"openai.gpt-5.6-*": gpt-5.6
 "gpt-5.5": gpt-5.5
 "gpt-5.4-mini": gpt-5.4-mini
 "gpt-5.4-mini-*": gpt-5.4-mini

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,10 +10,11 @@
 ## 2026-07-10 · GPT-5.6 family support in Helm defaults（Routing / provider catalog / cost telemetry，docs/03/04/07，原则 3/4/5/6）
 
 - **官方来源**：OpenAI latest-model docs 确认 `gpt-5.6` alias routes to `gpt-5.6-sol`，并给出 `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` 三档；OpenAI Models/Pricing docs 确认 1,050,000 context、128,000 max output、Responses/Chat/Batch 支持，以及标准价 input/cache-read/cache-write/output。
-- **路由决策**：quality lanes 升级为 Sol/Terra/Luna：`premium/coding/tool_use` 走 Sol，`balanced` 走 Terra，`economy` 走 Luna；同时新增 `gpt-5.6*` vendor-family lanes，让显式模型请求先走同家族再降级到既有质量 lane。
-- **供应链边界**：`openai/*` official API aliases 使用官方 1.05M context；`openai-codex/*` subscription aliases 继续保守使用 272K context cap，因为线上 Codex 订阅后端已有 `context_length_exceeded` 证据。这里优先避免 oversized 请求先打到必失败的订阅后端。
+- **路由决策**：quality lanes 升级为 GPT-5.6 family：`premium/coding/tool_use` 走 verified subscription Sol，`balanced` 走 verified subscription Terra，`economy` 先走 official OpenAI Luna（有 `OPENAI_API_KEY` 时）再降级到 subscription `gpt-5.4-mini` 与既有低成本链；同时新增 `gpt-5.6*` vendor-family lanes，让显式模型请求先走同家族再降级到既有质量 lane。
+- **供应链边界**：`gpt-5.6` 是 official API alias（routes to Sol），但 ChatGPT/Codex subscription backend 当前拒绝裸 `gpt-5.6`；`gpt-5.6-luna` 是 official API/Codex App model，但当前 subscription executor path 直测返回 404。Helm 因此只把 `openai-codex/gpt-5.6-sol` / `openai-codex/gpt-5.6-terra` 放入默认 curated subscription list；operator 仍可手工添加实验 slug 并用 account test 验证。
+- **context 边界**：`openai/*` official API aliases 使用官方 1.05M context；`openai-codex/*` subscription aliases 继续保守使用 272K context cap，因为线上 Codex 订阅后端已有 `context_length_exceeded` 证据。这里优先避免 oversized 请求先打到必失败的订阅后端。
 - **价格决策**：telemetry pricing 使用官方标准 tier，不使用 priority tier；cache write 按 1.25x input 记录，cache read 使用折扣价。成本数据只用于观测，不参与路由选择。
-- **兼容性**：Codex OAuth 仍是 curated-only（无 live list endpoint），新 curated list 以 GPT-5.6 family 开头并保留 GPT-5.5/GPT-5.4/GPT-5.4-mini，管理员保存的 enabledModels 仍然是权威覆盖。
+- **兼容性**：Codex OAuth 仍是 curated-only（无 live list endpoint），默认 curated list 以 verified GPT-5.6 Sol/Terra 开头并保留 GPT-5.5/GPT-5.4/GPT-5.4-mini，管理员保存的 enabledModels 仍然是权威覆盖。`model-aliases.yaml` 同时接受 Codex App/CLI 内部 `openai.gpt-5.6-*` 名字；Responses 入口接受 Codex CLI 发出的 `reasoning:null` 并按未设置处理。
 
 ## 2026-07-09 · 个人门户（Self-Service Portal）完整实现 + 补齐 + 多语言（docs/12，原则 1/6/7）→ v0.26.0
 

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -60,7 +60,7 @@ describe("checked-in config samples", () => {
     expect(lanes.economy).toBeDefined();
     expect(lanes.balanced).toBeDefined();
     expect(lanes.premium).toBeDefined();
-    expect(lanes.economy?.primary).toBe("openai-codex/gpt-5.6-luna");
+    expect(lanes.economy?.primary).toBe("openai/gpt-5.6-luna");
     expect(lanes.balanced?.primary).toBe("openai-codex/gpt-5.6-terra");
     expect(lanes.premium?.primary).toBe("openai-codex/gpt-5.6-sol");
     // task lanes
@@ -97,6 +97,11 @@ describe("checked-in config samples", () => {
     expect(resolveModelAlias("gpt-5.6-terra-20260710", aliases)).toBe("gpt-5.6-terra");
     expect(resolveModelAlias("gpt-5.6-luna", aliases)).toBe("gpt-5.6-luna");
     expect(resolveModelAlias("gpt-5.6-luna-20260710", aliases)).toBe("gpt-5.6-luna");
+    expect(resolveModelAlias("openai.gpt-5.6", aliases)).toBe("gpt-5.6");
+    expect(resolveModelAlias("openai.gpt-5.6-sol", aliases)).toBe("gpt-5.6-sol");
+    expect(resolveModelAlias("openai.gpt-5.6-terra", aliases)).toBe("gpt-5.6-terra");
+    expect(resolveModelAlias("openai.gpt-5.6-luna", aliases)).toBe("gpt-5.6-luna");
+    expect(resolveModelAlias("openai.gpt-5.6-20260710", aliases)).toBe("gpt-5.6");
     expect(resolveModelAlias("gpt-5.4", aliases)).toBe("gpt-5.4");
     expect(resolveModelAlias("gpt-5.4-mini", aliases)).toBe("gpt-5.4-mini");
     expect(resolveModelAlias("gpt-5.4-mini-2026-01-01", aliases)).toBe("gpt-5.4-mini");
@@ -109,14 +114,14 @@ describe("checked-in config samples", () => {
     const cfg = loadConfig({ configDir, env: {} });
     const lanes = cfg.lanes;
     if (lanes === undefined) throw new Error("config/lanes.yaml must load into config.lanes");
-    expect(lanes["gpt-5.6"]?.primary).toBe("openai-codex/gpt-5.6");
+    expect(lanes["gpt-5.6"]?.primary).toBe("openai-codex/gpt-5.6-sol");
     expect(lanes["gpt-5.6"]?.fallback).toEqual(["openai/gpt-5.6", "gpt-5.6-sol"]);
     expect(lanes["gpt-5.6-sol"]?.primary).toBe("openai-codex/gpt-5.6-sol");
     expect(lanes["gpt-5.6-sol"]?.fallback).toEqual(["openai/gpt-5.6-sol", "premium"]);
     expect(lanes["gpt-5.6-terra"]?.primary).toBe("openai-codex/gpt-5.6-terra");
     expect(lanes["gpt-5.6-terra"]?.fallback).toEqual(["openai/gpt-5.6-terra", "balanced"]);
-    expect(lanes["gpt-5.6-luna"]?.primary).toBe("openai-codex/gpt-5.6-luna");
-    expect(lanes["gpt-5.6-luna"]?.fallback).toEqual(["openai/gpt-5.6-luna", "economy"]);
+    expect(lanes["gpt-5.6-luna"]?.primary).toBe("openai/gpt-5.6-luna");
+    expect(lanes["gpt-5.6-luna"]?.fallback).toEqual(["economy"]);
     expect(lanes["gpt-5.4"]?.primary).toBe("openai-codex/gpt-5.4");
     expect(lanes["gpt-5.4"]?.fallback).toEqual(["premium"]);
     expect(lanes["gpt-5.4-mini"]?.primary).toBe("openai-codex/gpt-5.4-mini");

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -162,6 +162,16 @@ describe("responsesTransformer — Tier D request/response fidelity (orders 17-2
     expect(ir.provider_raw?.reasoning_config).toEqual({ effort: "medium", summary: "auto" });
   });
 
+  it("accepts Codex CLI reasoning:null and omits the empty config", async () => {
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "o1",
+      input: "hi",
+      reasoning: null,
+    });
+    expect(ir.reasoning_effort).toBeUndefined();
+    expect(ir.provider_raw?.reasoning_config).toBeUndefined();
+  });
+
   it("reconstructs reasoning config on the outbound Responses request (order 17)", async () => {
     const ir = await responsesTransformer.transformRequestOut({
       model: "o1",

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -179,6 +179,7 @@ const ResponsesRequestSchema = z
         summary: z.union([z.boolean(), z.string()]).optional(),
       })
       .passthrough()
+      .nullable()
       .optional(),
     // Context-window truncation control — no IR home, rides provider_raw.
     truncation: z.enum(["auto", "disabled"]).optional(),
@@ -479,7 +480,7 @@ function toIRRequest(req: NativeRequest): IRRequest {
     providerRaw.responses_native_tools = normalizedTools.nativeTools;
   // Reasoning config + truncation have no IR field of their own; preserve verbatim.
   // NB: a distinct key — provider_raw.reasoning already holds inbound reasoning ITEMS.
-  if (parsed.reasoning !== undefined) providerRaw.reasoning_config = parsed.reasoning;
+  if (parsed.reasoning != null) providerRaw.reasoning_config = parsed.reasoning;
   if (parsed.truncation !== undefined) providerRaw.truncation = parsed.truncation;
   // Preserve the raw Responses `text` so a responses->responses round-trip is lossless
   // even after we canonicalize it into IR.response_format for other backends.

--- a/packages/core/src/provider/oauth/models.test.ts
+++ b/packages/core/src/provider/oauth/models.test.ts
@@ -20,12 +20,10 @@ describe("discoverOAuthModels", () => {
     );
   });
 
-  it("keeps the Codex curated fallback on the GPT-5.6 family first", () => {
+  it("keeps the Codex curated fallback on currently verified subscription models", () => {
     expect(CURATED_OAUTH_MODELS["openai-codex"]).toEqual([
-      "gpt-5.6",
       "gpt-5.6-sol",
       "gpt-5.6-terra",
-      "gpt-5.6-luna",
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -20,19 +20,13 @@ import { listGitHubCopilotModels } from "./github-copilot.js";
 // override via an explicit providers.yaml entry.
 export const CURATED_OAUTH_MODELS: Record<string, string[]> = {
   anthropic: ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
-  // ChatGPT Codex set. Starts with the current GPT-5.6 family, then keeps the
-  // previous GA models as fallback choices operators can still select. Operators
-  // can add/remove models via the Manage dialog (their saved list is authoritative)
-  // or a providers.yaml override.
-  "openai-codex": [
-    "gpt-5.6",
-    "gpt-5.6-sol",
-    "gpt-5.6-terra",
-    "gpt-5.6-luna",
-    "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-  ],
+  // ChatGPT Codex set. Keep this to the subscription backend slugs that are known
+  // to execute through the ChatGPT Codex OAuth path. The public API `gpt-5.6`
+  // alias routes to Sol, but the subscription backend currently rejects the bare
+  // alias; Luna is an official GPT-5.6/API model, but is not yet accepted by the
+  // subscription backend on this executor path. Operators can still add/remove
+  // models via the Manage dialog (their saved list is authoritative).
+  "openai-codex": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
 };
 
 // Live-list Anthropic (Claude Pro/Max) models via GET /v1/models with the OAuth


### PR DESCRIPTION
## Summary
- route default premium/balanced GPT-5.6 traffic to verified Codex subscription Sol/Terra models
- keep Luna on the official OpenAI API lane instead of the Codex subscription executor path
- accept Codex App/CLI openai.gpt-5.6-* aliases and tolerate Responses reasoning:null from Codex CLI

## Verification
- corepack pnpm exec vitest run packages/core/src/provider/oauth/models.test.ts packages/core/src/config/samples.test.ts packages/core/src/protocol/responses.test.ts apps/gateway/src/oauth/admin-oauth.test.ts apps/gateway/src/routes/models.test.ts apps/gateway/src/server.oauth.test.ts
- corepack pnpm test
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build