### PR TITLE
Fix GPT-5.6 Luna routing support

### DIFF
--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -423,6 +423,7 @@ describe("createOAuthAdmin", () => {
     expect(available).toEqual([
       "gpt-5.6-sol",
       "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -11,10 +11,11 @@
 
 - **官方来源**：OpenAI latest-model docs 确认 `gpt-5.6` alias routes to `gpt-5.6-sol`，并给出 `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` 三档；OpenAI Models/Pricing docs 确认 1,050,000 context、128,000 max output、Responses/Chat/Batch 支持，以及标准价 input/cache-read/cache-write/output。
 - **路由决策**：quality lanes 升级为 GPT-5.6 family：`premium/coding/tool_use` 走 verified subscription Sol，`balanced` 走 verified subscription Terra，`economy` 先走 official OpenAI Luna（有 `OPENAI_API_KEY` 时）再降级到 subscription `gpt-5.4-mini` 与既有低成本链；同时新增 `gpt-5.6*` vendor-family lanes，让显式模型请求先走同家族再降级到既有质量 lane。
-- **供应链边界**：`gpt-5.6` 是 official API alias（routes to Sol），但 ChatGPT/Codex subscription backend 当前拒绝裸 `gpt-5.6`；`gpt-5.6-luna` 是 official API/Codex App model，但当前 subscription executor path 直测返回 404。Helm 因此只把 `openai-codex/gpt-5.6-sol` / `openai-codex/gpt-5.6-terra` 放入默认 curated subscription list；operator 仍可手工添加实验 slug 并用 account test 验证。
+- **供应链边界**：`gpt-5.6` 是 official API alias（routes to Sol），但 ChatGPT/Codex subscription backend 当前拒绝裸 `gpt-5.6`。Helm 默认 curated subscription list 包含 `openai-codex/gpt-5.6-sol` / `openai-codex/gpt-5.6-terra` / `openai-codex/gpt-5.6-luna`；operator 仍可手工增删并用 account test 验证。
 - **context 边界**：`openai/*` official API aliases 使用官方 1.05M context；`openai-codex/*` subscription aliases 继续保守使用 272K context cap，因为线上 Codex 订阅后端已有 `context_length_exceeded` 证据。这里优先避免 oversized 请求先打到必失败的订阅后端。
 - **价格决策**：telemetry pricing 使用官方标准 tier，不使用 priority tier；cache write 按 1.25x input 记录，cache read 使用折扣价。成本数据只用于观测，不参与路由选择。
-- **兼容性**：Codex OAuth 仍是 curated-only（无 live list endpoint），默认 curated list 以 verified GPT-5.6 Sol/Terra 开头并保留 GPT-5.5/GPT-5.4/GPT-5.4-mini，管理员保存的 enabledModels 仍然是权威覆盖。`model-aliases.yaml` 同时接受 Codex App/CLI 内部 `openai.gpt-5.6-*` 名字；Responses 入口接受 Codex CLI 发出的 `reasoning:null` 并按未设置处理。
+- **OpenAI wire 参数**：Responses `max_output_tokens` 经 IR 到 official OpenAI GPT-5.6 Chat wire 时必须渲染为 `max_completion_tokens`，不能沿用旧 `max_tokens`；否则 `openai/gpt-5.6-luna` 等官方 GPT-5.6 模型会返回 `unsupported_parameter`。
+- **兼容性**：Codex OAuth 仍是 curated-only（无 live list endpoint），默认 curated list 以 GPT-5.6 Sol/Terra/Luna 开头并保留 GPT-5.5/GPT-5.4/GPT-5.4-mini，管理员保存的 enabledModels 仍然是权威覆盖。`model-aliases.yaml` 同时接受 Codex App/CLI 内部 `openai.gpt-5.6-*` 名字；Responses 入口接受 Codex CLI 发出的 `reasoning:null` 并按未设置处理。
 
 ## 2026-07-09 · 个人门户（Self-Service Portal）完整实现 + 补齐 + 多语言（docs/12，原则 1/6/7）→ v0.26.0
 

--- a/packages/core/src/protocol/openai.test.ts
+++ b/packages/core/src/protocol/openai.test.ts
@@ -741,6 +741,29 @@ describe("openaiTransformer — max_completion_tokens (o-series, order 4)", () =
     };
     expect(back.max_completion_tokens).toBe(1000);
   });
+
+  it("renders GPT-5.6 output caps as max_completion_tokens, not max_tokens", async () => {
+    const native = (await openaiTransformer.transformRequestIn({
+      model: "gpt-5.6-luna",
+      messages: [{ role: "user", content: "x" }],
+      max_tokens: 32000,
+    })) as { max_tokens?: number; max_completion_tokens?: number };
+
+    expect(native.max_completion_tokens).toBe(32000);
+    expect(native).not.toHaveProperty("max_tokens");
+    expect(native.max_tokens).toBeUndefined();
+  });
+
+  it("leaves max_tokens unchanged for legacy OpenAI-compatible chat models", async () => {
+    const native = (await openaiTransformer.transformRequestIn({
+      model: "deepseek-v4-flash",
+      messages: [{ role: "user", content: "x" }],
+      max_tokens: 256,
+    })) as { max_tokens?: number; max_completion_tokens?: number };
+
+    expect(native.max_tokens).toBe(256);
+    expect(native.max_completion_tokens).toBeUndefined();
+  });
 });
 
 describe("openaiTransformer — service_tier response round-trip (order 2)", () => {

--- a/packages/core/src/protocol/openai.ts
+++ b/packages/core/src/protocol/openai.ts
@@ -346,6 +346,10 @@ function normalizeMessageContentToNative(message: IRMessage): IRMessage {
   };
 }
 
+function requiresMaxCompletionTokens(model: string): boolean {
+  return /^gpt-5\.6(?:$|-)/.test(model);
+}
+
 // —— Request: OpenAI native -> IR. Identity for everything EXCEPT multimodal content
 // parts, which are normalized into the IR's typed parts; fail-closed validated. ——————
 function toIRRequest(req: NativeRequest) {
@@ -362,9 +366,19 @@ function toIRRequest(req: NativeRequest) {
 // we strip only the IR-internal `provider_raw` bag (never a wire field). ————————
 function toOpenAIRequest(ir: z.infer<typeof IRRequestSchema>): NativeRequest {
   const { provider_raw: _provider_raw, ...wire } = IRRequestSchema.parse(ir);
+  const renderWire =
+    requiresMaxCompletionTokens(wire.model) && wire.max_tokens !== undefined
+      ? (({ max_tokens: _max_tokens, ...rest }) => ({
+          ...rest,
+          max_completion_tokens: wire.max_completion_tokens ?? wire.max_tokens,
+        }))(wire)
+      : wire;
   // Re-emit native OpenAI content parts (image_url/input_audio/file) so the wire
   // request a real OpenAI client/upstream expects is reconstructed losslessly (P7).
-  return { ...wire, messages: wire.messages.map(normalizeMessageContentToNative) };
+  return {
+    ...renderWire,
+    messages: renderWire.messages.map(normalizeMessageContentToNative),
+  };
 }
 
 // —— Response: upstream OpenAI -> IR. Stash raw stop_reason/usage in provider_raw

--- a/packages/core/src/protocol/protocol-matrix.test.ts
+++ b/packages/core/src/protocol/protocol-matrix.test.ts
@@ -921,6 +921,27 @@ describe("developer-role cross-path fold (issue #50)", () => {
   });
 });
 
+// Focused cross-path check for OpenAI GPT-5.6 output caps. The live failure was:
+// Responses max_output_tokens -> IR max_tokens -> official OpenAI GPT-5.6 chat wire
+// max_tokens, which upstream rejects; GPT-5.6 needs max_completion_tokens.
+describe("Responses -> OpenAI GPT-5.6 output cap render", () => {
+  it("renders max_output_tokens as max_completion_tokens for GPT-5.6 family models", async () => {
+    const ir = await requestOut.responses({
+      model: "gpt-5.6-luna",
+      input: [{ role: "user", content: "hi" }],
+      max_output_tokens: 32000,
+    });
+    const openai = (await requestIn.openai?.(ir)) as {
+      max_tokens?: number;
+      max_completion_tokens?: number;
+    };
+
+    expect(openai.max_completion_tokens).toBe(32000);
+    expect(openai).not.toHaveProperty("max_tokens");
+    expect(openai.max_tokens).toBeUndefined();
+  });
+});
+
 // Focused cross-path check for reasoning/thinking (P6). Intentionally NOT a new
 // matrix dimension — protocolMatrixDimensions stays untouched so the "every path
 // has every dimension" invariant above still holds. A single reasoning-bearing IR

--- a/packages/core/src/provider/oauth/models.test.ts
+++ b/packages/core/src/provider/oauth/models.test.ts
@@ -24,6 +24,7 @@ describe("discoverOAuthModels", () => {
     expect(CURATED_OAUTH_MODELS["openai-codex"]).toEqual([
       "gpt-5.6-sol",
       "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -5,9 +5,9 @@
 // Strategy (maintainer decision): discover live where an API exists, else fall
 // back to a curated list. GitHub Copilot exposes GET /models and Anthropic exposes
 // GET /v1/models — both are queried LIVE with the account's token. ChatGPT Codex
-// has no convenient list endpoint (and its execution isn't wired), so it uses a
-// curated set. Any list is OVERRIDABLE by declaring the provider with its own
-// models[] in providers.yaml (that wins).
+// has no convenient list endpoint, so it uses a curated set. Any list is
+// OVERRIDABLE by declaring the provider with its own models[] in providers.yaml
+// (that wins).
 
 import { listGitHubCopilotModels } from "./github-copilot.js";
 
@@ -23,10 +23,16 @@ export const CURATED_OAUTH_MODELS: Record<string, string[]> = {
   // ChatGPT Codex set. Keep this to the subscription backend slugs that are known
   // to execute through the ChatGPT Codex OAuth path. The public API `gpt-5.6`
   // alias routes to Sol, but the subscription backend currently rejects the bare
-  // alias; Luna is an official GPT-5.6/API model, but is not yet accepted by the
-  // subscription backend on this executor path. Operators can still add/remove
-  // models via the Manage dialog (their saved list is authoritative).
-  "openai-codex": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
+  // alias. Operators can still add/remove models via the Manage dialog (their
+  // saved list is authoritative).
+  "openai-codex": [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+  ],
 };
 
 // Live-list Anthropic (Claude Pro/Max) models via GET /v1/models with the OAuth


### PR DESCRIPTION
## Summary
- render GPT-5.6 OpenAI chat output caps as max_completion_tokens instead of max_tokens
- add gpt-5.6-luna to the Codex OAuth curated subscription model list
- document the GPT-5.6 wire-parameter and OAuth curated-list decisions

## Verification
- corepack pnpm exec vitest run packages/core/src/protocol/openai.test.ts packages/core/src/protocol/protocol-matrix.test.ts packages/core/src/provider/oauth/models.test.ts apps/gateway/src/oauth/admin-oauth.test.ts apps/gateway/src/oauth/effective-models.test.ts apps/gateway/src/server.oauth.test.ts
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build
- corepack pnpm test (5274 tests passed before the final no-max_tokens-property tightening; affected tests rerun after tightening)
