### PR TITLE
Release v0.26.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.7",
+  "version": "0.26.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API version to 0.26.8
- release GPT-5.6 Luna routing/OAuth support from PR #502

## Verification
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build
