### PR TITLE
Fix GPT-5.6 Luna OAuth routing

### DIFF
--- a/apps/gateway/e2e/routing.spec.ts
+++ b/apps/gateway/e2e/routing.spec.ts
@@ -26,7 +26,7 @@ const AUTH = { Authorization: `Bearer ${TEST_KEY}`, "Content-Type": "application
 const ECONOMY_HEAD = "openai/gpt-5.6-luna";
 const PREMIUM_HEAD = "openai/gpt-5.6-sol";
 const BALANCED_HEAD = "openai/gpt-5.6-terra";
-// economy chain after a failed official Luna call skips Codex/Anthropic
+// economy chain after a failed official Luna fallback skips Codex/Anthropic
 // subscription aliases and falls forward to the DeepSeek flash static fallback.
 const ECONOMY_NEXT = "deepseek/deepseek-v4-flash";
 
@@ -48,9 +48,10 @@ function chat(content: string, extra: Record<string, unknown> = {}) {
 
 test.describe("routing e2e", () => {
   // ── Scenario 1: simple prompt → economy lane ────────────────────────────────
-  // The economy head (openai/gpt-5.6-luna) is json + non-stream capable, so
-  // a plain non-stream request serves it directly. Routing is asserted via the
-  // debug headers; the resolved bare wire id is surfaced as x-helm-provider-model.
+  // The economy primary is openai-codex/gpt-5.6-luna. With no subscription
+  // connected in e2e, it is skipped and the json + non-stream capable official
+  // Luna fallback serves directly. Routing is asserted via the debug headers; the
+  // resolved bare wire id is surfaced as x-helm-provider-model.
   test("simple prompt -> economy lane", async ({ request }) => {
     const res = await request.post("/v1/chat/completions", {
       // Clearly-simple: strong simple-keyword signals (hi/thanks/ok) push the
@@ -60,7 +61,8 @@ test.describe("routing e2e", () => {
     });
     expect(res.status()).toBe(200);
     expect(res.headers()["x-helm-lane"]).toBe("economy");
-    // final model is the economy head; its resolved provider_model is the bare id.
+    // final model is the official economy fallback; its resolved provider_model is
+    // the bare id.
     expect(res.headers()["x-helm-final-model"]).toBe(ECONOMY_HEAD);
     expect(res.headers()["x-helm-provider-model"]).toBe(ECONOMY_HEAD_WIRE);
   });
@@ -109,18 +111,18 @@ test.describe("routing e2e", () => {
   });
 
   // ── Scenario 4: primary provider error → EXECUTION fallback serves ──────────
-  // Mock injects a one-shot 5xx for the economy head (`openai/gpt-5.6-luna`);
-  // the skipped codex/anthropic candidates never serve, so the first in-chain
-  // candidate that serves is `deepseek/deepseek-v4-flash`. Lane stays `economy`
-  // (execution fallback ≠ classification fallback, principle 5).
+  // Mock injects a one-shot 5xx for the official Luna fallback
+  // (`openai/gpt-5.6-luna`); the skipped codex/anthropic candidates never serve,
+  // so the first in-chain candidate that serves is `deepseek/deepseek-v4-flash`.
+  // Lane stays `economy` (execution fallback ≠ classification fallback, principle 5).
   test("primary provider error -> fallback model serves (execution fallback)", async ({
     request,
   }) => {
     // The prompt routes to economy (simple) AND carries the fail sentinel so the
-    // mock 5xxs the economy head. The gateway only forwards model+messages
-    // upstream, so the fault is steered through the prompt. The economy head is
-    // invoked (non-stream) and 5xxs, so the gateway falls forward past the skipped
-    // codex candidate to the next static one — the upstream-error fallback this
+    // mock 5xxs the official Luna fallback. The gateway only forwards model+messages
+    // upstream, so the fault is steered through the prompt. The official Luna fallback
+    // is invoked (non-stream) and 5xxs, so the gateway falls forward past the skipped
+    // codex candidates to the next static one — the upstream-error fallback this
     // scenario is about.
     const res = await request.post("/v1/chat/completions", {
       // Same clearly-simple economy prompt as scenario 1, plus the fail sentinel.

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -320,6 +320,41 @@ describe("createExecute — gateway execution adapter", () => {
     expect(body.store).toBe(false);
   });
 
+  it("renders Responses output caps as max_completion_tokens for GPT-5.6 OpenAI-chat targets", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        "openai/gpt-5.6-luna": {
+          providerName: "mock",
+          providerModel: "gpt-5.6-luna",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["openai/gpt-5.6-luna"]),
+      req({ protocol: "openai_responses", max_tokens: 16 }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const body = (provider.chatCompletion as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.max_completion_tokens).toBe(16);
+    expect(body).not.toHaveProperty("max_tokens");
+  });
+
   it.each([
     "openai_chat",
     "anthropic_messages",

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -2018,8 +2018,10 @@ function renderOpenAINativeBody(body: Record<string, unknown>): Record<string, u
   if (rendered && typeof (rendered as Promise<unknown>).then === "function") {
     throw new Error("OpenAI request renderer unexpectedly returned a Promise");
   }
-  const renderedMessages = (rendered as { messages?: unknown }).messages;
-  return Array.isArray(renderedMessages) ? { ...body, messages: renderedMessages } : body;
+  const renderedBody = rendered as Record<string, unknown>;
+  const out = { ...body, ...renderedBody };
+  if (!Object.hasOwn(renderedBody, "max_tokens")) delete out.max_tokens;
+  return out;
 }
 
 function withRequestMutations(

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -13,10 +13,10 @@
 # `openai-codex` SUBSCRIPTION slugs where the ChatGPT/Codex backend accepts them
 # (connect it in admin → Providers) and fall back to official OpenAI GPT-5.6 API
 # aliases when OPENAI_API_KEY is configured. The official `gpt-5.6` alias routes
-# to Sol, but the subscription backend rejects the bare alias; Luna is official API
-# surface, but is not yet accepted by the subscription backend on this executor
-# path. DeepSeek/OpenRouter/ZenMux remain static lower fallbacks so lanes degrade
-# gracefully when Codex or OpenAI API is unavailable. An unconnected candidate
+# to Sol, but the subscription backend rejects the bare alias, so Helm routes to
+# the concrete Sol/Terra/Luna subscription slugs instead. DeepSeek/OpenRouter/ZenMux
+# remain static lower fallbacks so lanes degrade gracefully when Codex or OpenAI API
+# is unavailable. An unconnected candidate
 # fails OPEN (Phase-0 back-fill / skip to the next fallback), never a 5xx. Each
 # lane still ends in a `*/auto` tail fallback; those auto aliases are deliberately
 # JSON-INCAPABLE (catalog jsonOutput:none), so a strict-JSON request prunes them
@@ -27,8 +27,9 @@
 economy:
   purpose: Cheap and fast for simple tasks
   reasoning_effort: medium
-  primary: openai/gpt-5.6-luna
+  primary: openai-codex/gpt-5.6-luna
   fallback:
+    - openai/gpt-5.6-luna
     - openai-codex/gpt-5.4-mini
     - anthropic/claude-haiku-4-5-20251001
     - deepseek/deepseek-v4-flash
@@ -180,8 +181,9 @@ claude-haiku:
 "gpt-5.6-luna":
   purpose: OpenAI GPT-5.6 Luna tier — efficient/high-volume
   reasoning_effort: medium
-  primary: openai/gpt-5.6-luna
+  primary: openai-codex/gpt-5.6-luna
   fallback:
+    - openai/gpt-5.6-luna
     - economy
 
 # Stays on GPT-5.5 ACROSS providers (Codex subscription -> static ZenMux key) before

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,8 +10,8 @@
 ## 2026-07-10 · GPT-5.6 family support in Helm defaults（Routing / provider catalog / cost telemetry，docs/03/04/07，原则 3/4/5/6）
 
 - **官方来源**：OpenAI latest-model docs 确认 `gpt-5.6` alias routes to `gpt-5.6-sol`，并给出 `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` 三档；OpenAI Models/Pricing docs 确认 1,050,000 context、128,000 max output、Responses/Chat/Batch 支持，以及标准价 input/cache-read/cache-write/output。
-- **路由决策**：quality lanes 升级为 GPT-5.6 family：`premium/coding/tool_use` 走 verified subscription Sol，`balanced` 走 verified subscription Terra，`economy` 先走 official OpenAI Luna（有 `OPENAI_API_KEY` 时）再降级到 subscription `gpt-5.4-mini` 与既有低成本链；同时新增 `gpt-5.6*` vendor-family lanes，让显式模型请求先走同家族再降级到既有质量 lane。
-- **供应链边界**：`gpt-5.6` 是 official API alias（routes to Sol），但 ChatGPT/Codex subscription backend 当前拒绝裸 `gpt-5.6`。Helm 默认 curated subscription list 包含 `openai-codex/gpt-5.6-sol` / `openai-codex/gpt-5.6-terra` / `openai-codex/gpt-5.6-luna`；operator 仍可手工增删并用 account test 验证。
+- **路由决策**：quality lanes 升级为 GPT-5.6 family：`premium/coding/tool_use` 走 verified subscription Sol，`balanced` 走 verified subscription Terra，`economy` 走 verified subscription Luna 并以 official OpenAI Luna（有 `OPENAI_API_KEY` 时）兜底，再降级到 subscription `gpt-5.4-mini` 与既有低成本链；同时新增 `gpt-5.6*` vendor-family lanes，让显式模型请求先走同家族再降级到既有质量 lane。
+- **供应链边界**：`gpt-5.6` 是 official API alias（routes to Sol），但 ChatGPT/Codex subscription backend 当前拒绝裸 `gpt-5.6`。Helm 默认 curated subscription list 包含 `openai-codex/gpt-5.6-sol` / `openai-codex/gpt-5.6-terra` / `openai-codex/gpt-5.6-luna`，显式 `gpt-5.6-luna` 与 `economy` 默认优先使用 Luna 的 OAuth 路径；operator 仍可手工增删并用 account test 验证。
 - **context 边界**：`openai/*` official API aliases 使用官方 1.05M context；`openai-codex/*` subscription aliases 继续保守使用 272K context cap，因为线上 Codex 订阅后端已有 `context_length_exceeded` 证据。这里优先避免 oversized 请求先打到必失败的订阅后端。
 - **价格决策**：telemetry pricing 使用官方标准 tier，不使用 priority tier；cache write 按 1.25x input 记录，cache read 使用折扣价。成本数据只用于观测，不参与路由选择。
 - **OpenAI wire 参数**：Responses `max_output_tokens` 经 IR 到 official OpenAI GPT-5.6 Chat wire 时必须渲染为 `max_completion_tokens`，不能沿用旧 `max_tokens`；否则 `openai/gpt-5.6-luna` 等官方 GPT-5.6 模型会返回 `unsupported_parameter`。

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -60,7 +60,8 @@ describe("checked-in config samples", () => {
     expect(lanes.economy).toBeDefined();
     expect(lanes.balanced).toBeDefined();
     expect(lanes.premium).toBeDefined();
-    expect(lanes.economy?.primary).toBe("openai/gpt-5.6-luna");
+    expect(lanes.economy?.primary).toBe("openai-codex/gpt-5.6-luna");
+    expect(lanes.economy?.fallback[0]).toBe("openai/gpt-5.6-luna");
     expect(lanes.balanced?.primary).toBe("openai-codex/gpt-5.6-terra");
     expect(lanes.premium?.primary).toBe("openai-codex/gpt-5.6-sol");
     // task lanes
@@ -120,8 +121,8 @@ describe("checked-in config samples", () => {
     expect(lanes["gpt-5.6-sol"]?.fallback).toEqual(["openai/gpt-5.6-sol", "premium"]);
     expect(lanes["gpt-5.6-terra"]?.primary).toBe("openai-codex/gpt-5.6-terra");
     expect(lanes["gpt-5.6-terra"]?.fallback).toEqual(["openai/gpt-5.6-terra", "balanced"]);
-    expect(lanes["gpt-5.6-luna"]?.primary).toBe("openai/gpt-5.6-luna");
-    expect(lanes["gpt-5.6-luna"]?.fallback).toEqual(["economy"]);
+    expect(lanes["gpt-5.6-luna"]?.primary).toBe("openai-codex/gpt-5.6-luna");
+    expect(lanes["gpt-5.6-luna"]?.fallback).toEqual(["openai/gpt-5.6-luna", "economy"]);
     expect(lanes["gpt-5.4"]?.primary).toBe("openai-codex/gpt-5.4");
     expect(lanes["gpt-5.4"]?.fallback).toEqual(["premium"]);
     expect(lanes["gpt-5.4-mini"]?.primary).toBe("openai-codex/gpt-5.4-mini");


### PR DESCRIPTION
## Summary
- route `economy` and explicit `gpt-5.6-luna` through `openai-codex/gpt-5.6-luna` first, with official OpenAI Luna as fallback
- preserve the full OpenAI renderer output in gateway execution so GPT-5.6 requests use `max_completion_tokens` instead of leaking `max_tokens`
- update shipped-config tests, e2e routing notes, and implementation notes

## Validation
- `corepack pnpm exec vitest run packages/core/src/provider/oauth/models.test.ts packages/core/src/config/samples.test.ts apps/gateway/src/routes/execute.test.ts packages/core/src/protocol/openai.test.ts packages/core/src/protocol/protocol-matrix.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`
- `corepack pnpm --filter @helm/gateway exec playwright test e2e/routing.spec.ts e2e/protocol.spec.ts --project=gateway`