### PR TITLE
Release v0.26.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.8",
+  "version": "0.26.9",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API version to `0.26.9` for the GPT-5.6 Luna OAuth routing and GPT-5.6 OpenAI parameter fix

## Validation
- `node -e "const p=require('./package.json'); if (p.version !== '0.26.9') process.exit(1); console.log(p.version)"`
- `git diff --check`