### PR TITLE
Fix Codex passthrough reasoning context

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -4147,6 +4147,68 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     });
   });
 
+  it("native Codex Responses passthrough keeps reasoning.context when lane forces effort", async () => {
+    const responsesBody = {
+      id: "resp_codex",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const provider = {
+      nativeProtocolProfile: "codex_responses",
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthrough: vi.fn().mockResolvedValue(responsesBody),
+    } as unknown as ProviderClient & { nativePassthrough: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["codex", provider]]),
+      registry: protocolRegistry({
+        r: {
+          providerName: "codex",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const carrier = {
+      protocol: "openai_responses" as const,
+      body: {
+        model: "gpt-5.6-sol",
+        instructions: "Use the Codex native shape.",
+        input: [{ type: "message", role: "user", content: "hi" }],
+        store: false,
+        include: ["reasoning.encrypted_content"],
+        reasoning: { effort: "low", context: "all_turns" },
+      },
+      headers: {},
+      mutations: {},
+    };
+
+    const out = await execute(
+      plan(["r"]),
+      req({
+        protocol: "openai_responses",
+        native_request: carrier,
+        reasoning_effort: "high",
+        reasoning_effort_forced: true,
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const forwarded = provider.nativePassthrough.mock.calls[0]?.[0] as typeof carrier;
+    expect(forwarded.body.reasoning).toEqual({ effort: "high", context: "all_turns" });
+    expect(forwarded.mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_forced"],
+    });
+  });
+
   it("hoists a developer system item into Codex `instructions` on passthrough (pi-ai shape)", async () => {
     const responsesBody = {
       id: "resp_hoist",

--- a/packages/core/src/protocol/reasoning-effort.test.ts
+++ b/packages/core/src/protocol/reasoning-effort.test.ts
@@ -80,15 +80,28 @@ describe("applyForcedReasoningToNativeBody — per protocol", () => {
     expect(tc.thinkingBudget).toBe(0);
   });
 
-  it("openai_responses: sets reasoning.effort, and `none` removes reasoning", () => {
-    const set = applyForcedReasoningToNativeBody({ input: [] }, "openai_responses", "high");
-    expect(set.body.reasoning).toEqual({ effort: "high" });
+  it("openai_responses: sets reasoning.effort without dropping native reasoning fields", () => {
+    const set = applyForcedReasoningToNativeBody(
+      { input: [], reasoning: { effort: "low", context: "all_turns" } },
+      "openai_responses",
+      "high",
+    );
+    expect(set.body.reasoning).toEqual({ effort: "high", context: "all_turns" });
+  });
+
+  it("openai_responses: `none` removes only effort and drops an empty reasoning object", () => {
     const none = applyForcedReasoningToNativeBody(
+      { input: [], reasoning: { effort: "low", context: "all_turns" } },
+      "openai_responses",
+      "none",
+    );
+    expect(none.body.reasoning).toEqual({ context: "all_turns" });
+    const empty = applyForcedReasoningToNativeBody(
       { input: [], reasoning: { effort: "low" } },
       "openai_responses",
       "none",
     );
-    expect(none.body.reasoning).toBeUndefined();
+    expect(empty.body.reasoning).toBeUndefined();
   });
 
   it("anthropic_messages: derives a thinking block with constraint fix-ups", () => {

--- a/packages/core/src/protocol/reasoning-effort.ts
+++ b/packages/core/src/protocol/reasoning-effort.ts
@@ -126,9 +126,13 @@ export function applyForcedReasoningToNativeBody(
       };
     }
     case "openai_responses": {
+      const prev = isRecord(body.reasoning) ? body.reasoning : {};
+      const reasoning = { ...prev };
+      if (effort === "none") delete reasoning.effort;
+      else reasoning.effort = effort;
       const next = { ...body };
-      if (effort === "none") delete next.reasoning;
-      else next.reasoning = { effort };
+      if (Object.keys(reasoning).length > 0) next.reasoning = reasoning;
+      else delete next.reasoning;
       return { body: next, mutated: true };
     }
     case "anthropic_messages": {


### PR DESCRIPTION
## Summary
- preserve non-effort fields in native OpenAI Responses `reasoning` when a lane forces `reasoning_effort`
- keep Codex App `reasoning.context: all_turns` while still allowing Helm to override `reasoning.effort`
- add execute-level regression for Codex Responses native passthrough

## Production evidence
- request `236a628f-72f9-44a6-a8d1-f9985bd15cf4` had `passthrough_used=true` but `body_shims_applied=[instructions_hoisted_from_input, reasoning_effort_forced]`
- original request carried `reasoning: { effort: low, context: all_turns }`
- lane-forced reasoning replaced the whole object, causing upstream `400`: `reasoning.context` must be `all_turns`

## Validation
- `corepack pnpm exec vitest run packages/core/src/protocol/reasoning-effort.test.ts apps/gateway/src/routes/execute.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`