### PR TITLE
Release v0.26.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.9",
+  "version": "0.26.10",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API version to `0.26.10` for the Codex Responses passthrough reasoning context fix

## Validation
- `node -e "const p=require('./package.json'); if (p.version !== '0.26.10') process.exit(1); console.log(p.version)"`
- `git diff --check`