### PR TITLE
fix: strip GPT-5.6 chat reasoning with tools

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -355,6 +355,69 @@ describe("createExecute — gateway execution adapter", () => {
     expect(body).not.toHaveProperty("max_tokens");
   });
 
+  it("strips GPT-5.6 chat reasoning_effort when function tools are present", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        "openai/gpt-5.6-luna": {
+          providerName: "mock",
+          providerModel: "gpt-5.6-luna",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map([
+        [
+          "openai/gpt-5.6-luna",
+          entry("openai/gpt-5.6-luna", {
+            reasoningEffort: {
+              openaiReasoning: {
+                supported: true,
+                levels: ["none", "low", "medium", "high", "xhigh", "max"],
+              },
+            },
+          }),
+        ],
+      ]),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const tool = {
+      type: "function",
+      function: {
+        name: "git_push",
+        description: "Push the current branch",
+        parameters: { type: "object", properties: {} },
+      },
+    };
+    const out = await execute(
+      plan(["openai/gpt-5.6-luna"]),
+      req({
+        protocol: "anthropic_messages",
+        reasoning_effort: "medium",
+        tools: [tool],
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const body = (provider.chatCompletion as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.model).toBe("gpt-5.6-luna");
+    expect(body.tools).toEqual([tool]);
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(out.attempts[0]?.request_mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_stripped_for_chat_tools"],
+    });
+  });
+
   it.each([
     "openai_chat",
     "anthropic_messages",

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -897,6 +897,21 @@ function stripReasoningEffort(body: Record<string, unknown>): Record<string, unk
   return next;
 }
 
+function hasOpenAIChatFunctionTools(body: Record<string, unknown>): boolean {
+  const tools = body.tools;
+  if (Array.isArray(tools)) {
+    for (const tool of tools) {
+      if (!isPlainRecord(tool)) continue;
+      if (tool.type === "function" || isPlainRecord(tool.function)) return true;
+    }
+  }
+  return Array.isArray(body.functions) && body.functions.length > 0;
+}
+
+function isGpt56FamilyModel(model: unknown): boolean {
+  return typeof model === "string" && /^gpt-5\.6(?:$|-)/.test(model);
+}
+
 function openAIReasoningEffort(body: Record<string, unknown>): string | null {
   if (!isPlainRecord(body.reasoning)) return null;
   return nonEmptyString(body.reasoning.effort);
@@ -938,6 +953,25 @@ function applyOpenAIReasoningPolicy(
     return next;
   }
   return body;
+}
+
+function applyOpenAIChatToolReasoningPolicy(
+  body: Record<string, unknown>,
+  mutations: NativePassthroughCarrier["mutations"],
+): Record<string, unknown> {
+  if (!isGpt56FamilyModel(body.model)) return body;
+  if (!hasOpenAIChatFunctionTools(body)) return body;
+  const hasReasoningEffort =
+    body.reasoning_effort !== undefined || openAIReasoningEffort(body) !== null;
+  if (!hasReasoningEffort) return body;
+
+  const withoutTopLevel = stripReasoningEffort(body);
+  const withoutNested =
+    openAIReasoningEffort(withoutTopLevel) !== null
+      ? applyOpenAIReasoningEffort(withoutTopLevel, { kind: "strip", mapped: false })
+      : withoutTopLevel;
+  appendReasoningPolicyShim(mutations, "reasoning_effort_stripped_for_chat_tools");
+  return withoutNested;
 }
 
 const STRIP_REASONING_EFFORT_POLICY: ReasoningEffortWireCapability = { supported: false };
@@ -1038,7 +1072,15 @@ function applyReasoningEffortPolicy(
   const crossProtocol = sourceProtocol !== targetProviderProtocol;
 
   switch (targetProviderProtocol) {
-    case "openai_chat":
+    case "openai_chat": {
+      const next = applyOpenAIReasoningPolicy(
+        body,
+        policy?.openaiReasoning ??
+          (caps !== undefined && crossProtocol ? STRIP_REASONING_EFFORT_POLICY : undefined),
+        mutations,
+      );
+      return applyOpenAIChatToolReasoningPolicy(next, mutations);
+    }
     case "openai_responses":
       return applyOpenAIReasoningPolicy(
         body,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-07-10 · GPT-5.6 Chat tools strip reasoning_effort（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）
+
+- **背景（Lukin）**：生产请求 `fd9fb61e-7ed0-4950-aecc-a7966b1caf33` 从 Anthropic Messages 协议进入 `economy` lane，`openai-codex/gpt-5.6-luna` 404 后 fallback 到 official `openai/gpt-5.6-luna`。该 fallback 使用 `/v1/chat/completions`，请求同时带 function tools 与 lane-forced `reasoning_effort: medium`，OpenAI 返回 400：该组合只支持 `/v1/responses` 或 `reasoning_effort: none`。
+- **修复决策**：不把 GPT-5.6 的 reasoning 能力整体关闭；只在 `targetProviderProtocol === openai_chat`、resolved model 属于 `gpt-5.6*`、且请求带 function tools/functions 时剥离 Chat wire 上的 `reasoning_effort` / `reasoning.effort`。Responses 路径、无工具请求、以及非 GPT-5.6 模型不受影响。
+- **观测**：触发时写入 `request_mutations.body_shims_applied: ["reasoning_effort_stripped_for_chat_tools"]`，区别于“模型完全不支持 reasoning”的 `reasoning_effort_stripped_for_model`，方便 Admin 请求详情定位。
+- **验证**：新增 execute 回归测试复现 Anthropic→OpenAI Chat fallback + GPT-5.6 Luna + tools + reasoning 的组合，断言 tools 保留、reasoning_effort 不再发给上游。
+
 ## 2026-07-10 · GPT-5.6 family support in Helm defaults（Routing / provider catalog / cost telemetry，docs/03/04/07，原则 3/4/5/6）
 
 - **官方来源**：OpenAI latest-model docs 确认 `gpt-5.6` alias routes to `gpt-5.6-sol`，并给出 `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` 三档；OpenAI Models/Pricing docs 确认 1,050,000 context、128,000 max output、Responses/Chat/Batch 支持，以及标准价 input/cache-read/cache-write/output。


### PR DESCRIPTION
## Summary
- strip GPT-5.6 Chat Completions reasoning effort only when function tools/functions are present
- keep tools and other GPT-5.6 reasoning paths intact, including Responses and no-tools requests
- add execute regression coverage for Anthropic -> OpenAI Chat fallback with gpt-5.6-luna tools

## Validation
- corepack pnpm exec vitest run apps/gateway/src/routes/execute.test.ts
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build
- corepack pnpm test