### PR TITLE
chore: release v0.26.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.10",
+  "version": "0.26.11",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API to v0.26.11 for the GPT-5.6 Chat tools reasoning fix

## Validation
- release-only version bump; implementation PR #508 passed docker/e2e/verify and local full gates