### PR TITLE
fix: strip GPT-5.6 chat reasoning for all tools

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -418,6 +418,54 @@ describe("createExecute — gateway execution adapter", () => {
     });
   });
 
+  it("strips GPT-5.6 chat reasoning_effort for Anthropic-shaped tools without catalog data", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        "openai/gpt-5.6-luna": {
+          providerName: "mock",
+          providerModel: "gpt-5.6-luna",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const tool = {
+      name: "noop_tool",
+      description: "No-op test tool",
+      input_schema: { type: "object", properties: {} },
+    };
+    const out = await execute(
+      plan(["openai/gpt-5.6-luna"]),
+      req({
+        protocol: "anthropic_messages",
+        reasoning_effort: "medium",
+        tools: [tool],
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    const body = (provider.chatCompletion as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.model).toBe("gpt-5.6-luna");
+    expect(body.tools).toEqual([tool]);
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(out.attempts[0]?.request_mutations).toMatchObject({
+      body_shims_applied: ["reasoning_effort_stripped_for_chat_tools"],
+    });
+  });
+
   it.each([
     "openai_chat",
     "anthropic_messages",

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -897,14 +897,9 @@ function stripReasoningEffort(body: Record<string, unknown>): Record<string, unk
   return next;
 }
 
-function hasOpenAIChatFunctionTools(body: Record<string, unknown>): boolean {
+function hasOpenAIChatTools(body: Record<string, unknown>): boolean {
   const tools = body.tools;
-  if (Array.isArray(tools)) {
-    for (const tool of tools) {
-      if (!isPlainRecord(tool)) continue;
-      if (tool.type === "function" || isPlainRecord(tool.function)) return true;
-    }
-  }
+  if (Array.isArray(tools) && tools.length > 0) return true;
   return Array.isArray(body.functions) && body.functions.length > 0;
 }
 
@@ -960,7 +955,7 @@ function applyOpenAIChatToolReasoningPolicy(
   mutations: NativePassthroughCarrier["mutations"],
 ): Record<string, unknown> {
   if (!isGpt56FamilyModel(body.model)) return body;
-  if (!hasOpenAIChatFunctionTools(body)) return body;
+  if (!hasOpenAIChatTools(body)) return body;
   const hasReasoningEffort =
     body.reasoning_effort !== undefined || openAIReasoningEffort(body) !== null;
   if (!hasReasoningEffort) return body;


### PR DESCRIPTION
## Summary
- Strip `reasoning_effort` for GPT-5.6 OpenAI Chat attempts whenever tools/functions are present, not only when tools already match the OpenAI function-tool shape.
- Add a regression covering Anthropic-shaped tools without catalog data so direct aliases and translated requests do not forward the unsupported combination.

## Validation
- `corepack pnpm exec vitest run apps/gateway/src/routes/execute.test.ts -t "GPT-5.6 chat reasoning_effort"`
- `corepack pnpm exec vitest run apps/gateway/src/routes/execute.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`