### PR TITLE
chore: release v0.26.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.11",
+  "version": "0.26.12",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump Helm API version to `0.26.12` for the GPT-5.6 Chat tools reasoning fix.

## Included fix
- #510 strips `reasoning_effort` for GPT-5.6 OpenAI Chat attempts whenever tools/functions are present.

## Validation
- Release PR CI will run docker, e2e, and verify gates.