### PR TITLE
fix: force GPT-5.6 chat tool reasoning none

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -355,7 +355,7 @@ describe("createExecute — gateway execution adapter", () => {
     expect(body).not.toHaveProperty("max_tokens");
   });
 
-  it("strips GPT-5.6 chat reasoning_effort when function tools are present", async () => {
+  it("sets GPT-5.6 chat reasoning_effort none when function tools are present", async () => {
     const provider = {
       chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
       chatCompletionStream: vi.fn(),
@@ -412,13 +412,13 @@ describe("createExecute — gateway execution adapter", () => {
     >;
     expect(body.model).toBe("gpt-5.6-luna");
     expect(body.tools).toEqual([tool]);
-    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning_effort).toBe("none");
     expect(out.attempts[0]?.request_mutations).toMatchObject({
-      body_shims_applied: ["reasoning_effort_stripped_for_chat_tools"],
+      body_shims_applied: ["reasoning_effort_none_for_chat_tools"],
     });
   });
 
-  it("strips GPT-5.6 chat reasoning_effort for Anthropic-shaped tools without catalog data", async () => {
+  it("sets GPT-5.6 chat reasoning_effort none for Anthropic-shaped tools without catalog data", async () => {
     const provider = {
       chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
       chatCompletionStream: vi.fn(),
@@ -460,10 +460,54 @@ describe("createExecute — gateway execution adapter", () => {
     >;
     expect(body.model).toBe("gpt-5.6-luna");
     expect(body.tools).toEqual([tool]);
-    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning_effort).toBe("none");
     expect(out.attempts[0]?.request_mutations).toMatchObject({
-      body_shims_applied: ["reasoning_effort_stripped_for_chat_tools"],
+      body_shims_applied: ["reasoning_effort_none_for_chat_tools"],
     });
+  });
+
+  it("sets GPT-5.6 chat reasoning_effort none for tools even when the client omits reasoning", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        "openai/gpt-5.6-luna": {
+          providerName: "mock",
+          providerModel: "gpt-5.6-luna",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    await execute(
+      plan(["openai/gpt-5.6-luna"]),
+      req({
+        protocol: "anthropic_messages",
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "noop_tool",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+      }),
+    );
+
+    const body = (provider.chatCompletion as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(body.reasoning_effort).toBe("none");
   });
 
   it.each([

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -956,16 +956,14 @@ function applyOpenAIChatToolReasoningPolicy(
 ): Record<string, unknown> {
   if (!isGpt56FamilyModel(body.model)) return body;
   if (!hasOpenAIChatTools(body)) return body;
-  const hasReasoningEffort =
-    body.reasoning_effort !== undefined || openAIReasoningEffort(body) !== null;
-  if (!hasReasoningEffort) return body;
 
-  const withoutTopLevel = stripReasoningEffort(body);
+  const withoutTopLevel =
+    body.reasoning_effort === "none" ? body : { ...body, reasoning_effort: "none" };
   const withoutNested =
     openAIReasoningEffort(withoutTopLevel) !== null
       ? applyOpenAIReasoningEffort(withoutTopLevel, { kind: "strip", mapped: false })
       : withoutTopLevel;
-  appendReasoningPolicyShim(mutations, "reasoning_effort_stripped_for_chat_tools");
+  appendReasoningPolicyShim(mutations, "reasoning_effort_none_for_chat_tools");
   return withoutNested;
 }
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,12 +7,12 @@
 
 ---
 
-## 2026-07-10 · GPT-5.6 Chat tools strip reasoning_effort（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）
+## 2026-07-10 · GPT-5.6 Chat tools force reasoning_effort none（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）
 
 - **背景（Lukin）**：生产请求 `fd9fb61e-7ed0-4950-aecc-a7966b1caf33` 从 Anthropic Messages 协议进入 `economy` lane，`openai-codex/gpt-5.6-luna` 404 后 fallback 到 official `openai/gpt-5.6-luna`。该 fallback 使用 `/v1/chat/completions`，请求同时带 function tools 与 lane-forced `reasoning_effort: medium`，OpenAI 返回 400：该组合只支持 `/v1/responses` 或 `reasoning_effort: none`。
-- **修复决策**：不把 GPT-5.6 的 reasoning 能力整体关闭；只在 `targetProviderProtocol === openai_chat`、resolved model 属于 `gpt-5.6*`、且请求带 function tools/functions 时剥离 Chat wire 上的 `reasoning_effort` / `reasoning.effort`。Responses 路径、无工具请求、以及非 GPT-5.6 模型不受影响。
-- **观测**：触发时写入 `request_mutations.body_shims_applied: ["reasoning_effort_stripped_for_chat_tools"]`，区别于“模型完全不支持 reasoning”的 `reasoning_effort_stripped_for_model`，方便 Admin 请求详情定位。
-- **验证**：新增 execute 回归测试复现 Anthropic→OpenAI Chat fallback + GPT-5.6 Luna + tools + reasoning 的组合，断言 tools 保留、reasoning_effort 不再发给上游。
+- **修复决策**：不把 GPT-5.6 的 reasoning 能力整体关闭；只在 `targetProviderProtocol === openai_chat`、resolved model 属于 `gpt-5.6*`、且请求带 tools/functions 时把 Chat wire 显式设为 `reasoning_effort: "none"`，并剥离 nested `reasoning.effort`。单纯删除字段不够，因为 GPT-5.6 Chat+tools 仍会按上游默认 reasoning 触发同一个 400。
+- **观测**：触发时写入 `request_mutations.body_shims_applied: ["reasoning_effort_none_for_chat_tools"]`，区别于“模型完全不支持 reasoning”的 `reasoning_effort_stripped_for_model`，方便 Admin 请求详情定位。
+- **验证**：新增 execute 回归测试复现 Anthropic→OpenAI Chat fallback + GPT-5.6 Luna + tools + reasoning 的组合，并覆盖客户端完全不传 reasoning 的情况；断言 tools 保留、wire body 显式发送 `reasoning_effort: "none"`。
 
 ## 2026-07-10 · GPT-5.6 family support in Helm defaults（Routing / provider catalog / cost telemetry，docs/03/04/07，原则 3/4/5/6）
 


### PR DESCRIPTION
## Summary
- Force `reasoning_effort: "none"` for GPT-5.6 OpenAI Chat attempts whenever tools/functions are present.
- Keep tools intact and strip nested `reasoning.effort`; omitting the field is not enough because upstream still rejects Chat+tools under its default reasoning behavior.
- Update implementation notes and add regression coverage for clients that omit reasoning entirely.

## Validation
- Local wire-body check: Anthropic Messages -> OpenAI Chat direct alias sends `reasoning_effort: "none"` with tools.
- `corepack pnpm exec vitest run apps/gateway/src/routes/execute.test.ts -t "GPT-5.6 chat reasoning_effort"`
- `corepack pnpm exec vitest run apps/gateway/src/routes/execute.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`