### PR TITLE
chore: release v0.26.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Bump Helm API version to `0.26.13` for the GPT-5.6 Chat tools `reasoning_effort: none` fix.

## Included fix
- #512 forces `reasoning_effort: "none"` for GPT-5.6 OpenAI Chat attempts with tools/functions.

## Validation
- Release PR CI will run docker, e2e, and verify gates.