### PR TITLE
fix: pre-skip DeepSeek reasoning history fallback

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1530,6 +1530,109 @@ describe("createExecute — gateway execution adapter", () => {
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
+  it("pre-skips direct DeepSeek when Responses reasoning history cannot be represented", async () => {
+    const deepseekProvider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "should-not-call" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const tailProvider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "tail" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: tailProvider,
+      providers: new Map([
+        ["deepseek", deepseekProvider],
+        ["mock", tailProvider],
+      ]),
+      registry: protocolRegistry({
+        deepseek: {
+          providerName: "deepseek",
+          providerModel: "deepseek-v4-flash",
+          targetProviderProtocol: "openai_chat",
+        },
+        tail: {
+          providerName: "mock",
+          providerModel: "gpt-fallback",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["deepseek", "tail"]),
+      req({
+        protocol: "openai_responses",
+        thinking: [{ type: "thinking", text: "hidden reasoning" }],
+        provider_raw: {
+          reasoning: [{ type: "reasoning", id: "rs_1", summary: [] }],
+          reasoning_config: { effort: "medium" },
+        },
+      }),
+    );
+
+    expect(out.final).toEqual({ status: "ok", alias: "tail", providerModel: "gpt-fallback" });
+    expect(deepseekProvider.chatCompletion).not.toHaveBeenCalled();
+    expect(tailProvider.chatCompletion).toHaveBeenCalledOnce();
+    expect(out.attempts[0]).toMatchObject({
+      alias: "deepseek",
+      skipped: true,
+      skip_reason: "reasoning_history_incompatible",
+      status: "error",
+      error_class: null,
+    });
+  });
+
+  it("does not pre-skip OpenRouter-hosted DeepSeek for Responses reasoning history", async () => {
+    const openrouterProvider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "ok" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: openrouterProvider,
+      providers: new Map([["openrouter", openrouterProvider]]),
+      registry: protocolRegistry({
+        openrouter: {
+          providerName: "openrouter",
+          providerModel: "deepseek/deepseek-v4-flash",
+          targetProviderProtocol: "openai_chat",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["openrouter"]),
+      req({
+        protocol: "openai_responses",
+        thinking: [{ type: "thinking", text: "hidden reasoning" }],
+        provider_raw: {
+          reasoning: [{ type: "reasoning", id: "rs_1", summary: [] }],
+          reasoning_config: { effort: "medium" },
+        },
+      }),
+    );
+
+    expect(out.final).toEqual({
+      status: "ok",
+      alias: "openrouter",
+      providerModel: "deepseek/deepseek-v4-flash",
+    });
+    expect(openrouterProvider.chatCompletion).toHaveBeenCalledOnce();
+    expect(out.attempts[0]).toMatchObject({
+      alias: "openrouter",
+      skipped: false,
+      status: "ok",
+    });
+  });
+
   it("still falls back and faults the breaker on a non-request upstream 5xx", async () => {
     // Control: a 5xx is a provider-HEALTH failure (not a request-shape rejection),
     // so the chain advances to the next candidate and the breaker records a fault.

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -739,6 +739,26 @@ function hasResponsesHistoryGap(req: InternalRequest): boolean {
   return hasToolOutput && !hasLocalToolCall;
 }
 
+function hasResponsesReasoningHistory(req: InternalRequest): boolean {
+  if (req.protocol !== "openai_responses") return false;
+  if (Array.isArray(req.thinking) && req.thinking.length > 0) return true;
+  return Array.isArray(req.provider_raw?.reasoning) && req.provider_raw.reasoning.length > 0;
+}
+
+function candidateGuardSkipReason(
+  req: InternalRequest,
+  target: ResolvedAttemptTarget,
+): string | null {
+  if (
+    target.providerName === "deepseek" &&
+    target.targetProviderProtocol === "openai_chat" &&
+    hasResponsesReasoningHistory(req)
+  ) {
+    return "reasoning_history_incompatible";
+  }
+  return null;
+}
+
 function protocolGuardSkipReason(
   req: InternalRequest,
   targetProviderProtocol: TargetProviderProtocol,
@@ -1383,6 +1403,13 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       if (protocolSkip !== null) {
         capabilityPruned = true;
         attempts.push(skipRow(alias, protocolSkip, elapsed()));
+        continue;
+      }
+
+      const candidateSkip = candidateGuardSkipReason(req, target);
+      if (candidateSkip !== null) {
+        capabilityPruned = true;
+        attempts.push(skipRow(alias, candidateSkip, elapsed()));
         continue;
       }
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-07-10 · Direct DeepSeek Responses reasoning history pre-skip（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）
+
+- **背景（Lukin）**：生产请求 `17de8e09-cd94-4aa4-ab67-d2bacf3e4318` 最终由 `openrouter/deepseek-v4-flash` 成功服务，但 direct `deepseek/deepseek-v4-flash` fallback 先返回 400：`The reasoning_content in the thinking mode must be passed back to the API.` 近 3 天统计显示这类 direct DeepSeek reasoning-history 400 共 89 次，均最终 fallback 成功；部署 `v0.26.13` 后新增 3 次，说明 GPT-5.6 Chat tools 修复后剩余红色 400 主要是这个兼容问题。
+- **修复决策**：Responses reasoning items 在 IR 中进入 `thinking` / `provider_raw.reasoning`，跨到 OpenAI Chat target 时会被剥离，无法还原成 direct DeepSeek thinking 模式要求的历史 `reasoning_content`。因此对 `providerName === "deepseek"` 且 `targetProviderProtocol === "openai_chat"` 的候选，在检测到 Responses reasoning history 时发送前直接 skip，使用既有 `reasoning_history_incompatible` skip reason。
+- **边界**：不跳过 OpenRouter 托管的 DeepSeek；线上同一请求证明 OpenRouter target 能接受 Helm 剥离 reasoning history 后的 OpenAI Chat body。该规则只避免 direct DeepSeek 的确定性 400，不改变最终 fallback 选择。
+- **验证**：新增 execute 正/负回归测试：direct DeepSeek 被预跳过且不会调用 provider；OpenRouter-hosted DeepSeek 仍会正常尝试。
+
 ## 2026-07-10 · GPT-5.6 Chat tools force reasoning_effort none（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）
 
 - **背景（Lukin）**：生产请求 `fd9fb61e-7ed0-4950-aecc-a7966b1caf33` 从 Anthropic Messages 协议进入 `economy` lane，`openai-codex/gpt-5.6-luna` 404 后 fallback 到 official `openai/gpt-5.6-luna`。该 fallback 使用 `/v1/chat/completions`，请求同时带 function tools 与 lane-forced `reasoning_effort: medium`，OpenAI 返回 400：该组合只支持 `/v1/responses` 或 `reasoning_effort: none`。


### PR DESCRIPTION
## Summary
- Pre-skip direct DeepSeek OpenAI Chat candidates when an OpenAI Responses request carries reasoning history that cannot be represented as DeepSeek-required reasoning_content history.
- Keep OpenRouter-hosted DeepSeek eligible, matching the live successful fallback path.
- Document the production 400 distribution and compatibility boundary.

## Production evidence
- Request 17de8e09-cd94-4aa4-ab67-d2bacf3e4318 ultimately succeeded via openrouter/deepseek-v4-flash, but direct deepseek/deepseek-v4-flash returned 400: reasoning_content in thinking mode must be passed back.
- Last 3 days: 487 requests contained upstream 400; 368 were old openai/gpt-5.6-luna errors already addressed by v0.26.13; direct DeepSeek reasoning-history 400s were 89 and all fell back successfully.
- Since v0.26.13 deploy, gpt-5.6-luna upstream 400 count is 0; remaining observed new 400s are this direct DeepSeek reasoning-history class.

## Verification
- corepack pnpm exec vitest run apps/gateway/src/routes/execute.test.ts
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm build
- corepack pnpm test