### PR TITLE
chore: release v0.26.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.13",
+  "version": "0.26.14",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- Bump Helm API version to 0.26.14.
- Includes PR #514: pre-skip direct DeepSeek OpenAI Chat candidates when OpenAI Responses reasoning history cannot be represented as required reasoning_content history.

## Verification
- PR #514 CI passed: verify, e2e, docker.
- Local full suite passed: 335 files, 5282 tests.
- Local typecheck, lint, and build passed.