### PR TITLE
chore: release v0.26.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.14",
+  "version": "0.26.15",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

Release Helm API `v0.26.15` with the Codex CLI GPT-5.6 subscription parity work merged in PR #516.

## Included

- Complete GPT-5.6 Sol, Terra, Luna, and bare alias support for Codex subscriptions.
- Codex-native model discovery, Responses, compact, and WebSocket behavior.
- Subscription identity, quota, spend limit, additional model limit, and reset-credit parity.
- Claude Fable review fixes for WebSocket lifecycle, shared catalog state, and Admin quota rendering.
- Real subscription, Codex CLI WebSocket, compact, Docker, and telemetry verification.

## Change

- Bump root package version from `0.26.14` to `0.26.15`.

Merging this PR triggers the standard `Publish image` workflow, which publishes GHCR tags and creates GitHub Release `v0.26.15`.
