### PR TITLE
feat(portal): add self-service memory settings

### DIFF
--- a/apps/gateway/src/middleware/auth.ts
+++ b/apps/gateway/src/middleware/auth.ts
@@ -37,6 +37,9 @@ export interface AuthIdentity {
     memory: {
       mode: "off" | "observe" | "inject";
       projectId: string | null;
+      /** Raw user-configured project name. null means the effective scope falls
+       *  back to this key's id; kept separate from projectId for portal editing. */
+      projectName?: string | null;
       threadSource: "header" | "auto";
     };
   };
@@ -124,6 +127,7 @@ export function authMiddleware(deps: AuthDeps): MiddlewareHandler {
           // a pool across keys (effectiveMemoryProjectId). Resolved per request so
           // clearing the column reverts to isolated-by-self with no migration.
           projectId: effectiveMemoryProjectId(record),
+          projectName: record.memory_project_id,
           threadSource: record.memory_thread_source,
         },
       },

--- a/apps/gateway/src/routes/portal/index.test.ts
+++ b/apps/gateway/src/routes/portal/index.test.ts
@@ -11,6 +11,10 @@ import { authMiddleware } from "../../middleware/auth.js";
 import { registerPortalApi } from "./index.js";
 
 const AUTH = { Authorization: "Bearer helm_live_secret" } as const;
+type MemoryPatch = {
+  memoryMode?: "off" | "observe" | "inject";
+  memoryProjectId?: string | null;
+};
 
 function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
   return {
@@ -173,11 +177,15 @@ function telemetry(over: Partial<PortalTelemetry> = {}): PortalTelemetry {
   };
 }
 
-function buildApp(rec: ApiKeyRecord | null, tel: PortalTelemetry = telemetry()) {
+function buildApp(
+  rec: ApiKeyRecord | null,
+  tel: PortalTelemetry = telemetry(),
+  updateKey: (keyId: string, patch: MemoryPatch) => Promise<void> = vi.fn(async () => {}),
+) {
   const getByHash = vi.fn().mockResolvedValue(rec);
   const app = createApp({ logger: { log: () => {} } });
   app.use("/portal/api/*", authMiddleware({ keyStore: { getByHash }, log: () => {} }));
-  registerPortalApi(app, { telemetry: tel, now: () => 10_000 });
+  registerPortalApi(app, { telemetry: tel, keyStore: { updateKey }, now: () => 10_000 });
   return app;
 }
 
@@ -186,6 +194,7 @@ describe("portal API", () => {
     const app = buildApp(record());
     for (const path of [
       "/portal/api/me",
+      "/portal/api/memory-settings",
       "/portal/api/usage/stats",
       "/portal/api/requests",
       "/portal/api/requests/trace_1",
@@ -210,6 +219,67 @@ describe("portal API", () => {
       expect(serialized).not.toContain(hashKey("helm_live_secret"));
       expect(serialized).not.toContain("helm_live_secret");
       expect(serialized.toLowerCase()).not.toContain("hash");
+    });
+  });
+
+  describe("PATCH /portal/api/memory-settings", () => {
+    it("updates only the authenticated key's memory defaults", async () => {
+      const updateKey = vi.fn(async () => {});
+      const res = await buildApp(record(), telemetry(), updateKey).request(
+        "/portal/api/memory-settings",
+        {
+          method: "PATCH",
+          headers: { ...AUTH, "content-type": "application/json" },
+          body: JSON.stringify({ memory_mode: "observe", memory_project_id: "project-a" }),
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect(updateKey).toHaveBeenCalledWith("k1", {
+        memoryMode: "observe",
+        memoryProjectId: "project-a",
+      });
+      await expect(res.json()).resolves.toEqual({
+        memory: { mode: "observe", project_id: "project-a", project_name: "project-a" },
+      });
+    });
+
+    it("clears the project and disables memory without accepting admin fields", async () => {
+      const updateKey = vi.fn(async () => {});
+      const app = buildApp(record(), telemetry(), updateKey);
+      const ok = await app.request("/portal/api/memory-settings", {
+        method: "PATCH",
+        headers: { ...AUTH, "content-type": "application/json" },
+        body: JSON.stringify({ memory_mode: "off", memory_project_id: null }),
+      });
+      expect(ok.status).toBe(200);
+      expect(updateKey).toHaveBeenCalledWith("k1", {
+        memoryMode: "off",
+        memoryProjectId: null,
+      });
+
+      const invalid = await app.request("/portal/api/memory-settings", {
+        method: "PATCH",
+        headers: { ...AUTH, "content-type": "application/json" },
+        body: JSON.stringify({ memory_mode: "inject", allowed_lanes: ["premium"] }),
+      });
+      expect(invalid.status).toBe(400);
+      expect(updateKey).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the management-plane root key memory-inert", async () => {
+      const updateKey = vi.fn(async () => {});
+      const res = await buildApp(
+        record({ role: "root", memory_mode: "off" }),
+        telemetry(),
+        updateKey,
+      ).request("/portal/api/memory-settings", {
+        method: "PATCH",
+        headers: { ...AUTH, "content-type": "application/json" },
+        body: JSON.stringify({ memory_mode: "inject", memory_project_id: "root-project" }),
+      });
+      expect(res.status).toBe(403);
+      expect(updateKey).not.toHaveBeenCalled();
     });
   });
 
@@ -241,6 +311,7 @@ describe("portal API", () => {
       const app = createApp({ logger: { log: () => {} } });
       app.use("/portal/api/*", authMiddleware({ keyStore: { getByHash }, log: () => {} }));
       registerPortalApi(app, {
+        keyStore: { updateKey: vi.fn(async () => {}) },
         telemetry: telemetry(),
         now: () => 10_000,
         resolveModelLabel: (wire: string) => (wire === "SECRET_WIRE_MODEL" ? "gpt-5.5" : null),
@@ -292,6 +363,7 @@ describe("portal API", () => {
       const app = createApp({ logger: { log: () => {} } });
       app.use("/portal/api/*", authMiddleware({ keyStore: { getByHash }, log: () => {} }));
       registerPortalApi(app, {
+        keyStore: { updateKey: vi.fn(async () => {}) },
         telemetry: tel,
         now: () => 10_000,
         resolveModelLabel: (wire: string) => (wire === "WIRE_A" ? "gpt-5.5" : null),

--- a/apps/gateway/src/routes/portal/index.ts
+++ b/apps/gateway/src/routes/portal/index.ts
@@ -1,5 +1,15 @@
-import type { RequestPayload, RequestPayloadPartRecord, TelemetryStore } from "@helm/core";
-import { RequestsQuerySchema, StatsQuerySchema, toPortalDecisionView } from "@helm/shared";
+import type {
+  KeyStore,
+  RequestPayload,
+  RequestPayloadPartRecord,
+  TelemetryStore,
+} from "@helm/core";
+import {
+  PortalMemorySettingsRequestSchema,
+  RequestsQuerySchema,
+  StatsQuerySchema,
+  toPortalDecisionView,
+} from "@helm/shared";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import { assertOwnsTrace } from "./ownership.js";
@@ -11,6 +21,7 @@ import { assertOwnsTrace } from "./ownership.js";
 // a scopeless read. Memory CRUD is deliberately absent: the SPA calls the existing
 // POST /mcp JSON-RPC directly (§4.2 endpoint 6 — zero new backend).
 export interface PortalApiDeps {
+  keyStore: Pick<KeyStore, "updateKey">;
   telemetry: Pick<
     TelemetryStore,
     "aggregate" | "queryPage" | "getByRequestId" | "getApiKeyId" | "getPayload" | "getPayloadPart"
@@ -44,7 +55,38 @@ export function registerPortalApi(app: Hono<AppEnv>, deps: PortalApiDeps): void 
         window_seconds: b.windowSeconds,
         behavior: b.behavior,
       },
-      memory: { mode: identity.caps.memory.mode, project_id: identity.caps.memory.projectId },
+      memory: {
+        mode: identity.caps.memory.mode,
+        project_id: identity.caps.memory.projectId,
+        project_name: identity.caps.memory.projectName ?? null,
+      },
+    });
+  });
+
+  // The only customer-writable key settings. Scope is forced from the bearer
+  // identity and the strict schema rejects every administrator-owned field.
+  app.patch("/portal/api/memory-settings", async (c) => {
+    const identity = c.get("identity");
+    // Root is the management-plane key and must remain memory-inert.
+    if (identity.role === "root") {
+      return c.json({ error: "root key memory settings are read-only" }, 403);
+    }
+    const parsed = PortalMemorySettingsRequestSchema.safeParse(
+      await c.req.json().catch(() => null),
+    );
+    if (!parsed.success) {
+      return c.json({ error: "invalid memory settings", issues: parsed.error.issues }, 400);
+    }
+    await deps.keyStore.updateKey(identity.keyId, {
+      memoryMode: parsed.data.memory_mode,
+      memoryProjectId: parsed.data.memory_project_id,
+    });
+    return c.json({
+      memory: {
+        mode: parsed.data.memory_mode,
+        project_id: parsed.data.memory_project_id ?? identity.keyId,
+        project_name: parsed.data.memory_project_id,
+      },
     });
   });
 

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -2674,6 +2674,7 @@ export async function buildServer(
       if (!wireToAlias.has(m.provider_model)) wireToAlias.set(m.provider_model, m.alias);
   }
   registerPortalApi(app, {
+    keyStore,
     telemetry,
     resolveModelLabel: (wire) => wireToAlias.get(wire) ?? null,
   });

--- a/apps/portal/src/lib/api/client.ts
+++ b/apps/portal/src/lib/api/client.ts
@@ -4,7 +4,8 @@ import { getKey, clearKey } from "$lib/auth";
 // The portal's single fetch wrapper. Injects Authorization: Bearer from the
 // sessionStorage key (never a query/body — R6). On 401 it clears the session and
 // bounces to /login (the key was revoked/disabled). Read-only GETs only in the
-// MVP; memory writes go through mcpFetch (POST /mcp), not here.
+// Memory content writes go through MCP; the narrow per-key settings mutation uses
+// the portal API because it updates key metadata, not memory content.
 const API_BASE = `${base}/api`;
 
 export class ApiError extends Error {
@@ -32,6 +33,29 @@ export async function apiGet<T>(path: string): Promise<T> {
   if (!res.ok) {
     throw new ApiError(res.status, `portal api ${res.status}`);
   }
+  return (await res.json()) as T;
+}
+
+export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
+  const key = getKey();
+  if (!key) {
+    clearKey();
+    throw new ApiError(401, "no api key");
+  }
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "PATCH",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 401) {
+    clearKey();
+    throw new ApiError(401, "unauthorized");
+  }
+  if (!res.ok) throw new ApiError(res.status, `portal api ${res.status}`);
   return (await res.json()) as T;
 }
 

--- a/apps/portal/src/lib/api/portal.ts
+++ b/apps/portal/src/lib/api/portal.ts
@@ -1,4 +1,4 @@
-import { apiGet } from "./client";
+import { apiGet, apiPatch } from "./client";
 
 // Portal API response contracts — mirror the /portal/api/* JSON the gateway emits.
 // These are customer-safe whitelist projections.
@@ -15,7 +15,11 @@ export interface Me {
     window_seconds: number | null;
     behavior: string;
   };
-  memory: { mode: "off" | "observe" | "inject"; project_id: string | null };
+  memory: {
+    mode: "off" | "observe" | "inject";
+    project_id: string | null;
+    project_name: string | null;
+  };
 }
 
 export interface UsageStats {
@@ -92,6 +96,13 @@ export interface PayloadPart {
 
 export function getMe(): Promise<Me> {
   return apiGet<Me>("/me");
+}
+
+export function updateMemorySettings(input: {
+  memory_mode: "off" | "observe" | "inject";
+  memory_project_id: string | null;
+}): Promise<{ memory: Me["memory"] }> {
+  return apiPatch<{ memory: Me["memory"] }>("/memory-settings", input);
 }
 
 export function getUsage(

--- a/apps/portal/src/locales/en.json
+++ b/apps/portal/src/locales/en.json
@@ -986,6 +986,8 @@
   "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.": "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.",
   "Your new API key": "Your new API key",
   "Your requests, filtered by time, status, model, or lane.": "Your requests, filtered by time, status, model, or lane.",
+  "Your key, its limits, and Memory defaults.": "Your key, its limits, and Memory defaults.",
+  "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.",
   "Zoom in": "Zoom in",
   "Zoom out": "Zoom out"
 }

--- a/apps/portal/src/locales/es.json
+++ b/apps/portal/src/locales/es.json
@@ -986,6 +986,8 @@
   "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.": "Tu key permanece solo en esta pestaña del navegador y se envía por HTTPS con cada solicitud. Al cerrar la pestaña, se cierra tu sesión.",
   "Your new API key": "Tu nueva API key",
   "Your requests, filtered by time, status, model, or lane.": "Tus solicitudes, filtradas por hora, estado, modelo o lane.",
+  "Your key, its limits, and Memory defaults.": "Tu clave, sus límites y los valores predeterminados de Memoria.",
+  "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "Cambiar el proyecto cambia el grupo de memoria; la memoria existente no se mueve. Las claves de la misma cuenta que usan el mismo proyecto comparten ese grupo.",
   "Zoom in": "Acercar",
   "Zoom out": "Alejar"
 }

--- a/apps/portal/src/locales/ja.json
+++ b/apps/portal/src/locales/ja.json
@@ -986,6 +986,8 @@
   "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.": "あなたのキーはこのブラウザータブ内だけに保存され、各リクエストで HTTPS 経由で送信されます。タブを閉じるとサインアウトします。",
   "Your new API key": "新しい API キー",
   "Your requests, filtered by time, status, model, or lane.": "あなたのリクエストを、時間、ステータス、モデル、レーンで絞り込めます。",
+  "Your key, its limits, and Memory defaults.": "キー、その上限、Memory のデフォルト設定です。",
+  "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "プロジェクトを変更するとメモリプールが切り替わります。既存のメモリは移動されません。同じアカウントで同じプロジェクトを使うキーは、そのプールを共有します。",
   "Zoom in": "拡大",
   "Zoom out": "縮小"
 }

--- a/apps/portal/src/locales/ko.json
+++ b/apps/portal/src/locales/ko.json
@@ -986,6 +986,8 @@
   "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.": "내 키는 이 브라우저 탭에만 저장되며 각 요청마다 HTTPS로 전송됩니다. 탭을 닫으면 로그아웃됩니다.",
   "Your new API key": "새 API 키",
   "Your requests, filtered by time, status, model, or lane.": "내 요청을 시간, 상태, 모델 또는 레인으로 필터링합니다.",
+  "Your key, its limits, and Memory defaults.": "키, 사용 한도 및 Memory 기본값입니다.",
+  "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "프로젝트를 변경하면 메모리 풀이 전환되며 기존 메모리는 이동되지 않습니다. 같은 계정에서 같은 프로젝트를 사용하는 키는 해당 풀을 공유합니다.",
   "Zoom in": "확대",
   "Zoom out": "축소"
 }

--- a/apps/portal/src/locales/pt.json
+++ b/apps/portal/src/locales/pt.json
@@ -986,6 +986,8 @@
   "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.": "Sua key fica apenas nesta aba do navegador e é enviada por HTTPS em cada solicitação. Fechar a aba encerra sua sessão.",
   "Your new API key": "Sua nova API key",
   "Your requests, filtered by time, status, model, or lane.": "Suas solicitações, filtradas por hora, status, modelo ou lane.",
+  "Your key, its limits, and Memory defaults.": "Sua chave, seus limites e os padrões de Memória.",
+  "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "Alterar o projeto troca o conjunto de memória; a memória existente não é movida. Chaves da mesma conta que usam o mesmo projeto compartilham esse conjunto.",
   "Zoom in": "Aproximar zoom",
   "Zoom out": "Afastar zoom"
 }

--- a/apps/portal/src/locales/zh-hans.json
+++ b/apps/portal/src/locales/zh-hans.json
@@ -986,6 +986,8 @@
   "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.": "你的密钥只保存在此浏览器标签页中，并会随每次请求通过 HTTPS 发送。关闭标签页即退出登录。",
   "Your new API key": "你的新 API 密钥",
   "Your requests, filtered by time, status, model, or lane.": "你的请求，可按时间、状态、模型或通道筛选。",
+  "Your key, its limits, and Memory defaults.": "你的密钥、使用限制和 Memory 默认设置。",
+  "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "更改项目会切换 Memory 池，已有记忆不会迁移。同一账户中使用相同项目的密钥会共享该 Memory 池。",
   "Zoom in": "放大",
   "Zoom out": "缩小"
 }

--- a/apps/portal/src/locales/zh-hant.json
+++ b/apps/portal/src/locales/zh-hant.json
@@ -986,6 +986,8 @@
   "Your key stays in this browser tab only and is sent over HTTPS with each request. Closing the tab signs you out.": "你的金鑰只會保存在此瀏覽器分頁中，並隨每次請求透過 HTTPS 傳送。關閉分頁即會登出。",
   "Your new API key": "你的新 API 金鑰",
   "Your requests, filtered by time, status, model, or lane.": "你的請求，可依時間、狀態、模型或通道篩選。",
+  "Your key, its limits, and Memory defaults.": "你的金鑰、使用限制和 Memory 預設設定。",
+  "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "變更專案會切換 Memory 池，既有記憶不會遷移。同一帳戶中使用相同專案的金鑰會共享該 Memory 池。",
   "Zoom in": "放大",
   "Zoom out": "縮小"
 }

--- a/apps/portal/src/routes/account/+page.svelte
+++ b/apps/portal/src/routes/account/+page.svelte
@@ -1,18 +1,27 @@
 <script lang="ts">
   import { t } from "$lib/i18n";
   import { formatUsd, formatTokens } from "$lib/format";
-  import { getMe, type Me } from "$lib/api/portal";
+  import { getMe, type Me, updateMemorySettings } from "$lib/api/portal";
 
   let me = $state<Me | null>(null);
   let loading = $state(true);
-  let error = $state("");
+  let loadError = $state("");
+  let saveError = $state("");
+  let saving = $state(false);
+  let saved = $state(false);
+  let memoryEnabled = $state(false);
+  let activeMode = $state<"observe" | "inject">("inject");
+  let projectName = $state("");
 
   $effect(() => {
     void (async () => {
       try {
         me = await getMe();
+        memoryEnabled = me.memory.mode !== "off";
+        activeMode = me.memory.mode === "observe" ? "observe" : "inject";
+        projectName = me.memory.project_name ?? "";
       } catch (e) {
-        error = e instanceof Error ? e.message : "load failed";
+        loadError = e instanceof Error ? e.message : "load failed";
       } finally {
         loading = false;
       }
@@ -22,19 +31,38 @@
   const rpm = $derived(me?.rate_limit.rpm);
   const spend = $derived(me?.budget.spend_usd ?? null);
   const tokens = $derived(me?.budget.tokens ?? null);
+
+  async function saveMemorySettings(): Promise<void> {
+    if (!me || me.role === "root" || saving) return;
+    saving = true;
+    saved = false;
+    saveError = "";
+    try {
+      const result = await updateMemorySettings({
+        memory_mode: memoryEnabled ? activeMode : "off",
+        memory_project_id: projectName.trim() || null,
+      });
+      me = { ...me, memory: result.memory };
+      projectName = result.memory.project_name ?? "";
+      saved = true;
+    } catch (e) {
+      saveError =
+        e instanceof Error ? e.message : $t("Failed to save settings");
+    } finally {
+      saving = false;
+    }
+  }
 </script>
 
 <h1 class="page-title mb-1">{$t("Account")}</h1>
 <p class="section-desc mb-4">
-  {$t(
-    "Your key and its limits. These are read-only — contact your administrator to change them.",
-  )}
+  {$t("Your key, its limits, and Memory defaults.")}
 </p>
 
 {#if loading}
   <p class="section-desc">{$t("Loading…")}</p>
-{:else if error}
-  <p class="alert-error">{error}</p>
+{:else if loadError}
+  <p class="alert-error">{loadError}</p>
 {:else if me}
   <div class="card space-y-3">
     <div class="flex justify-between">
@@ -65,9 +93,73 @@
       <span class="section-desc">{$t("Token budget")}</span>
       <span>{tokens === null ? $t("unlimited") : formatTokens(tokens)}</span>
     </div>
-    <div class="flex justify-between">
-      <span class="section-desc">{$t("Memory mode")}</span>
-      <span>{me.memory.mode}</span>
-    </div>
   </div>
+
+  <form
+    class="card mt-4 space-y-4"
+    onsubmit={(event) => {
+      event.preventDefault();
+      void saveMemorySettings();
+    }}
+  >
+    <div>
+      <h2 class="text-base font-semibold">{$t("Memory defaults")}</h2>
+      <p class="field-help mt-1">
+        {$t(
+          "Server-side memory defaults for clients that cannot send dynamic headers (Claude Code, Codex). Explicit x-memory-* request headers always override. Auto thread source derives the conversation from signals the client already sends (prompt_cache_key, metadata.user_id, x-session-key).",
+        )}
+      </p>
+    </div>
+
+    <label class="flex items-center justify-between gap-4 text-sm">
+      <span class="field-label">{$t("Memory")}</span>
+      <input
+        type="checkbox"
+        bind:checked={memoryEnabled}
+        disabled={me.role === "root"}
+        aria-label={$t("Memory")}
+        class="h-4 w-4 accent-indigo-600"
+      />
+    </label>
+
+    <label class="flex flex-col gap-1 text-sm">
+      <span class="field-label">{$t("Memory mode")}</span>
+      <select
+        class="select"
+        bind:value={activeMode}
+        disabled={!memoryEnabled || me.role === "root"}
+      >
+        <option value="observe">{$t("Observe (record only)")}</option>
+        <option value="inject">{$t("Inject (record + hydrate)")}</option>
+      </select>
+    </label>
+
+    <label class="flex flex-col gap-1 text-sm">
+      <span class="field-label">{$t("Default project id")}</span>
+      <input
+        class="input"
+        maxlength="100"
+        placeholder={$t("None")}
+        bind:value={projectName}
+        disabled={me.role === "root"}
+      />
+      <span class="field-help">
+        {$t(
+          "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.",
+        )}
+      </span>
+    </label>
+
+    {#if me.role === "root"}
+      <p class="field-help">{me.role}: {$t("Memory mode")} {$t("Off")}</p>
+    {:else}
+      {#if saveError}<p class="alert-error">{saveError}</p>{/if}
+      <div class="flex items-center gap-3">
+        <button class="btn-primary" type="submit" disabled={saving}>
+          {saving ? $t("Saving…") : $t("Save settings")}
+        </button>
+        {#if saved}<span class="text-sm text-success">{$t("Saved")}</span>{/if}
+      </div>
+    {/if}
+  </form>
 {/if}

--- a/docs/12-self-service-portal.md
+++ b/docs/12-self-service-portal.md
@@ -52,7 +52,7 @@
 | **P0** | 「我用了多少、花了多少、还剩多少额度？会不会突然被限流/断供？」 | 自助门户的存在理由。`/v1/usage/stats` 安全模型天然就绪。 |
 | **P1** | 「我这条请求为什么失败/为什么慢/路由去哪了？」 | 高价值但边界最危险，必须重度脱敏（§4.3）。需新建 bearer-scoped 只读端点。 |
 | **P1** | 「Helm 记住了我什么？我能改吗？」 | 差异化能力。已按 key 硬隔离；优先前端直接打 `POST /mcp`，零新后端。 |
-| **P2（砍）** | 「让我在门户里改自己的预算/限流/换模型。」 | **YAGNI，明确砍掉。** 账户治理是管理员职权；自助提额破坏信任模型。门户只**读**配额不**改**。 |
+| **P2（砍）** | 「让我在门户里改自己的预算/限流/换模型。」 | **YAGNI，明确砍掉。** 账户治理是管理员职权；自助提额破坏信任模型。门户只**读**配额不**改**。Memory 的行为默认值属于 key 持有者自己的数据偏好，单独允许自助修改。 |
 
 **同样砍掉**（YAGNI）：自助轮换/吊销自己的 key、团队/多成员视图、自建子 key、Retry/replay。
 
@@ -75,7 +75,7 @@
 | **接入 Connect** | `/portal/connect` | **MVP（门户灵魂）** | 左侧客户端选择器 + 右侧分步指引 + 一键复制。见 §5。 |
 | **请求 Requests** | `/portal/requests` `/portal/requests/:traceId` | 迭代 2 | 列表（`RequestsTable` full 变体，去 key/lane/decided-by 列）+ **脱敏详情**（§4.3）。 |
 | **记忆 Memory** | `/portal/memory` | 迭代 3 | facts + reflections 浏览/增删改，复用 admin By-Key 布局但只显示「我的」、隐藏 scope 选择器。加「什么是记忆?」说明气泡 + 隐私文案。空状态引导。 |
-| 账户菜单 | 下拉（非独立页） | MVP | key prefix、只读 caps（可用 lanes/预算上限/速率/memory 模式，数据来自 `/portal/api/me`）、退出、语言。**不做独立配置页**（用户能改的为零，单列太空）。 |
+| **账户 Account** | `/portal/account` | MVP + Memory settings | key prefix、只读 caps（lanes/预算/速率）以及可编辑的 Memory 开关、模式和项目名。退出、语言仍在账户菜单。 |
 
 **IA 决策**：接入指南放导航第一/二位，不塞进设置角落。新用户第一眼看到「怎么接」，老用户日常看「概览」——这两个是门户双核心。
 
@@ -109,6 +109,7 @@
 | 4 | `GET /portal/api/requests/:traceId` | **先 ownership 校验**（§4.4）→ `getByRequestId` → **白名单脱敏投影**（§4.3） | `getApiKeyId` + `getByRequestId` | 迭代 2 |
 | 5 | `GET /portal/api/requests/:traceId/payload` | **先 ownership 校验** → 取正文，**白名单 `part ∈ {request,response}`，拒 upstream** | `getApiKeyId` + `getPayloadMeta/getPayloadPart` | 迭代 2 |
 | 6 | memory CRUD | **优先前端直接打 `POST /mcp`（零新后端）**；若必须 REST，则 `accountId: identity.accountId` + `projectId: identity.caps.memory.projectId` 全写死，逐字复用 MCP 隔离不变量，**绝不照搬 `/admin/api/memory/*`**（query 参数寻址 = 破隔离） | MCP tools / `MemoryStore` | 迭代 3 |
+| 7 | `PATCH /portal/api/memory-settings` | 严格只收 `memory_mode` / `memory_project_id`；更新目标写死 `identity.keyId`；root key 拒绝 | `KeyStore.updateKey` | 迭代 4 |
 
 memory REST（仅当 MCP 未启用/需 REST 语义时）：`GET /portal/api/memory/facts`、`GET/PATCH/DELETE .../facts/:id`、reflections 同构。
 
@@ -153,6 +154,7 @@ async function assertOwnsTrace(c, telemetry, traceId): Promise<"ok"|"not_found">
 - telemetry 隔离粒度 = **keyId**（key 级）；memory 隔离粒度 = **accountId**（账户级），key 级只是 projectId 软 scope。
 - 若 account 下多 key 且 `memory_project_id` 皆 null → `effectiveMemoryProjectId` 各落 key_id → 天然 key 级隔离，门户始终传 `projectId: identity.caps.memory.projectId` 即可。
 - 若运营方给多 key 设同一显式 `memory_project_id`（共享池）→ 同 project 的 key 互见 memory，**这是配置决定的预期共享，非 bug**，但门户 UI 须诚实标注「此 memory 池为 project xxx，可能与同 project 的其他 key 共享」。
+- 门户自助修改 project 只切换默认池，**不迁移**旧池里的 facts/reflections；UI 必须在输入框旁明示。`/portal/api/me` 同时返回 effective `project_id` 与原始 `project_name`，避免把 null→keyId 的私有回落误标成显式共享。
 
 ### 4.6 fail-open / 错误信封
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）
+
+- **授权边界**：新增 `PATCH /portal/api/memory-settings`，只接受严格的 `memory_mode` 与 `memory_project_id`；目标 key 始终取 bearer identity 的 `keyId`，不能提交 `key_id/account_id`，也不能借此修改 lane、预算或限流。管理面 root key 继续强制只读、保持 memory inert。
+- **交互**：Account 页提供 Memory 开关、`observe`（仅记录）/`inject`（记录并注入）模式和最多 100 字符的项目名；保存后同实例 auth cache 立即失效。显式 `x-memory-*` 请求头仍覆盖这些服务端默认值。
+- **scope 语义**：`memory_project_id` 是共享池选择器，不是纯展示标签；空值仍回落到 key 自身的私有 scope。更改项目只切换默认池，不迁移旧 Memory；同一 account 下采用相同显式项目名的 keys 会共享该池，UI 明示这一点。
+- **API 投影**：`/portal/api/me` 同时返回有效 `project_id` 与原始配置 `project_name`，避免把 null→key-id 的私有默认 scope 错画成显式共享项目。未新增 DB 字段或迁移，复用已有 KeyStore partial update。
+- **验证**：先增加 portal route 红测，覆盖 authenticated-key 强制、严格字段拒绝、disable/clear 和 root 拒绝；再实现后端与 UI，并运行 gateway portal tests、shared/gateway/portal typecheck、portal check/build 和 i18n 校验。
+
 ## 2026-07-10–11 · Codex CLI GPT-5.6 subscription parity（OAuth subscription / Responses / model catalog，docs/04/05/11，原则 3/5/6/7/8）
 
 - **对齐基线**：实现逐项对照 OpenAI Codex `54c44b9ed4` 源码，而不是只增加三个模型字符串。Helm 现在使用原生 `GET /v1/models?client_version=...` 的 `{models}` envelope、Codex `ModelInfo` 字段、`minimal_client_version` 过滤和 key 权限过滤，并支持 `gpt-5.6-sol` / `terra` / `luna` 与裸 `gpt-5.6 -> gpt-5.6-sol` wire 规范化。
@@ -107,14 +115,6 @@
 - **可见性与 UI**：`/v1/models` 会按当前 key 隐藏被 block 的 concrete alias；若某 lane 过滤后没有任何可用候选，该 lane 也不展示。Admin keys 的共享 caps form 始终展示多行 `Blocked models` 输入，独立于 `allow_custom_model`，支持换行、逗号、分号分隔并去重。
 - **验证路径**：覆盖 shared schema、direct reject、classified/explicit/alias lane chain filtering、routing signal 提升过滤、空链拒绝、models list 过滤、SQLite/Postgres store contract、gateway auth/admin/chat/messages/replay/models threading，以及 admin create/edit/list 表单映射。
 
-## 2026-07-06 · Anthropic native passthrough 稳定 Claude Code billing cch（Provider execution / prompt cache，docs/04/05，原则 3/5/7/8）
-
-- **背景（Lukin）**：线上 `claude-fable-5` 请求大多是 Anthropic native passthrough，理论上应保留 Claude Code 原始 body；但 production SQLite 样本显示同一会话里 `system[0]` 的 `x-anthropic-billing-header` 只有 `cch` 每轮变化（`cc_version`/`cc_entrypoint` 稳定），导致 Anthropic prompt cache 的严格前缀匹配被第一块内容打断，缓存读取只覆盖小前缀，成本显著偏高。
-- **问题归属**：这不是 Helm 协议转换 correctness bug；原样转发本身成立。这里是对 Claude Code 官方 billing header 与 Anthropic prompt cache 机制冲突的兼容性 workaround：为了自托管网关的成本边界，允许 native passthrough 做一个可审计的最小 body shim。
-- **修复边界**：只在 `protocol === anthropic_messages` 且 `system[0]` 明确是 `x-anthropic-billing-header`、含 5 位 hex `cch` 时触发；保留 `cc_version`、`cc_entrypoint`、system/messages/tools 正文和 cache_control，仅把 `cch` 替换成由稳定 cache-prefix 材料（resolved model、system、tools，排除 messages）计算出的 5 位值。没有该 header 的 native 请求完全不变。
-- **观测决策**：触发时写入 passthrough mutation `body_shims_applied: ["anthropic_billing_cch_stabilized"]`，并清掉 raw_body 走重序列化，避免 telemetry 显示仍是旧的客户端 raw body。后续线上可按该 mutation 与 `cached_tokens/cache_creation_tokens` 验证成本改善。
-- **风险边界**：如果 Anthropic 将来开始强校验官方 `cch` 与整请求字节一致，这个 shim 可能引发上游拒绝；届时可通过 native passthrough flag 或后续 runtime setting 回滚。当前生产证据显示 `cch` 更像缓存/归因指纹而非认证字段。
-
 ## 历史条目摘要（最近 5 条）
 
 - **2026-07-06 · 折叠会话行显示工具调用参数预览（Admin requests / conversation view，docs/11，原则 1）**：工具参数预览改为 whitelist-free，按 args 形状泛化提取 readable scalar，覆盖自定义/大小写不同工具并保留展开详情。
@@ -125,4 +125,4 @@
 
 ## 更早历史总览
 
-2026-07-06 压缩条目还包括 Admin 模型搜索预计算列、payload 分段懒加载、纯工具 turn 去空 header/默认展开，以及 Claude Code 风格 inline tool peek。2026-07-04 更早条目还包括 cheap-model 当前轮低风险降级、视觉上下文压缩 observe/off 接入、Memory stats 队列索引优化、OAuth 会话亲和调度、idle-flush 碎片段优先压缩最大连续段、memory worker 受控并发追赶、记忆页只读运行状态面板、Claude scoped weekly quota 只影响对应模型、跨协议 reasoning-history 候选级跳过、memory idle-flush 防饥饿、策略级 reasoning_effort 覆盖 lane 默认值、cron monitor 低成本规则等。2026-06-30 及以前的工作主要围绕 Helm API 的协议面、路由执行、admin 可观测性与自托管部署逐步成型：补齐 Gemini/OpenAI/Anthropic/Responses 双向转换、SSE 流式正确性、tool-call/JSON schema/思考参数保真、per-model reasoning effort、模型别名与能力/成本目录、provider fallback 与熔断语义、OAuth subscription providers、多账户池与 quota 处理、memory observe/inject/forgetting/admin/MCP、请求 payload 捕获与 request detail UI、API key 治理、admin 表格/过滤/分页/i18n、Docker/CI/release/deploy 验证，以及早期 Phase 0 的 Hono + SvelteKit static admin + Store 端口 + SQLite/Supabase 架构决策。更早细节不再逐条保留在本文件；需要精确背景时回查 git history。
+2026-07-06 压缩条目还包括 Anthropic native passthrough 稳定 Claude Code billing `cch`、Admin 模型搜索预计算列、payload 分段懒加载、纯工具 turn 去空 header/默认展开，以及 Claude Code 风格 inline tool peek。2026-07-04 更早条目还包括 cheap-model 当前轮低风险降级、视觉上下文压缩 observe/off 接入、Memory stats 队列索引优化、OAuth 会话亲和调度、idle-flush 碎片段优先压缩最大连续段、memory worker 受控并发追赶、记忆页只读运行状态面板、Claude scoped weekly quota 只影响对应模型、跨协议 reasoning-history 候选级跳过、memory idle-flush 防饥饿、策略级 reasoning_effort 覆盖 lane 默认值、cron monitor 低成本规则等。2026-06-30 及以前的工作主要围绕 Helm API 的协议面、路由执行、admin 可观测性与自托管部署逐步成型：补齐 Gemini/OpenAI/Anthropic/Responses 双向转换、SSE 流式正确性、tool-call/JSON schema/思考参数保真、per-model reasoning effort、模型别名与能力/成本目录、provider fallback 与熔断语义、OAuth subscription providers、多账户池与 quota 处理、memory observe/inject/forgetting/admin/MCP、请求 payload 捕获与 request detail UI、API key 治理、admin 表格/过滤/分页/i18n、Docker/CI/release/deploy 验证，以及早期 Phase 0 的 Hono + SvelteKit static admin + Store 端口 + SQLite/Supabase 架构决策。更早细节不再逐条保留在本文件；需要精确背景时回查 git history。

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -198,6 +198,8 @@ export {
   MemoryThreadSourceSchema,
   type OverBudgetBehavior,
   OverBudgetBehaviorSchema,
+  type PortalMemorySettingsRequest,
+  PortalMemorySettingsRequestSchema,
   type UpdateKeyRequest,
   UpdateKeyRequestSchema,
 } from "./key/schema.js";

--- a/packages/shared/src/key/schema.test.ts
+++ b/packages/shared/src/key/schema.test.ts
@@ -4,6 +4,7 @@ import {
   CreateKeyRequestSchema,
   effectiveMemoryProjectId,
   KeyRoleSchema,
+  PortalMemorySettingsRequestSchema,
   UpdateKeyRequestSchema,
 } from "./schema.js";
 
@@ -407,5 +408,33 @@ describe("effectiveMemoryProjectId", () => {
     expect(effectiveMemoryProjectId({ memory_project_id: "team-pool", key_id: "k-abc" })).toBe(
       "team-pool",
     );
+  });
+});
+
+describe("PortalMemorySettingsRequestSchema", () => {
+  it("accepts only the self-service memory subset and normalizes the project", () => {
+    expect(
+      PortalMemorySettingsRequestSchema.parse({
+        memory_mode: "observe",
+        memory_project_id: "  project-a  ",
+      }),
+    ).toEqual({ memory_mode: "observe", memory_project_id: "project-a" });
+    expect(
+      PortalMemorySettingsRequestSchema.safeParse({
+        memory_mode: "inject",
+        memory_project_id: null,
+        budget_tokens: 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects invalid modes and blank or oversized project names", () => {
+    for (const input of [
+      { memory_mode: "on", memory_project_id: null },
+      { memory_mode: "off", memory_project_id: "   " },
+      { memory_mode: "off", memory_project_id: "x".repeat(101) },
+    ]) {
+      expect(PortalMemorySettingsRequestSchema.safeParse(input).success).toBe(false);
+    }
   });
 });

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -197,3 +197,15 @@ export const UpdateKeyRequestSchema = z
   .strict();
 
 export type UpdateKeyRequest = z.infer<typeof UpdateKeyRequestSchema>;
+
+// Customer self-service subset. Deliberately separate from UpdateKeyRequestSchema:
+// a bearer-key holder may tune only this key's Memory behavior and project scope,
+// never lanes, budgets, role, or any other administrator-owned capability.
+export const PortalMemorySettingsRequestSchema = z
+  .object({
+    memory_mode: MemoryModeSchema,
+    memory_project_id: z.string().trim().min(1).max(100).nullable(),
+  })
+  .strict();
+
+export type PortalMemorySettingsRequest = z.infer<typeof PortalMemorySettingsRequestSchema>;


### PR DESCRIPTION
## Summary
- let API-key portal users manage their own Memory enablement, observe/inject mode, and project scope
- keep the update bearer-scoped to the authenticated key with a strict Memory-only schema
- preserve root-key memory inertness and document project-pool sharing/switching semantics
- add the Account UI, seven-locale copy, tests, docs, and implementation notes

## Verification
- `pnpm exec vitest run --project node portal`
- focused gateway/shared/auth suite: 80 tests
- `pnpm --filter @helm/gateway typecheck`
- `pnpm --filter @helm/portal check`
- `pnpm build`
- Biome, Prettier, locale key parity, and `git diff --check`