### PR TITLE
chore: release v0.26.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.15",
+  "version": "0.26.16",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump the root package version from `0.26.15` to `0.26.16`
- trigger the version-driven image and GitHub Release workflow after merge

## Included
- API-key portal self-service Memory settings from #518