### PR TITLE
fix(portal): move Memory settings to Memory page

### DIFF
--- a/apps/portal/src/lib/api/memory-settings.test.ts
+++ b/apps/portal/src/lib/api/memory-settings.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  toMemorySettingsForm,
+  toMemorySettingsRequest,
+} from "./memory-settings";
+
+describe("Memory settings dialog mapping", () => {
+  it("restores inject as the active mode when Memory is currently off", () => {
+    expect(toMemorySettingsForm({ mode: "off", project_name: null })).toEqual({
+      enabled: false,
+      activeMode: "inject",
+      projectName: "",
+    });
+  });
+
+  it("preserves observe mode and the configured project", () => {
+    expect(
+      toMemorySettingsForm({ mode: "observe", project_name: "project-a" }),
+    ).toEqual({
+      enabled: true,
+      activeMode: "observe",
+      projectName: "project-a",
+    });
+  });
+
+  it("maps the dialog form to the strict API request and trims the project", () => {
+    expect(
+      toMemorySettingsRequest({
+        enabled: true,
+        activeMode: "inject",
+        projectName: "  project-a  ",
+      }),
+    ).toEqual({ memory_mode: "inject", memory_project_id: "project-a" });
+    expect(
+      toMemorySettingsRequest({
+        enabled: false,
+        activeMode: "observe",
+        projectName: "   ",
+      }),
+    ).toEqual({ memory_mode: "off", memory_project_id: null });
+  });
+});

--- a/apps/portal/src/lib/api/memory-settings.ts
+++ b/apps/portal/src/lib/api/memory-settings.ts
@@ -1,0 +1,29 @@
+import type { Me } from "./portal";
+
+export type ActiveMemoryMode = "observe" | "inject";
+
+export interface MemorySettingsForm {
+  enabled: boolean;
+  activeMode: ActiveMemoryMode;
+  projectName: string;
+}
+
+export function toMemorySettingsForm(
+  memory: Pick<Me["memory"], "mode" | "project_name">,
+): MemorySettingsForm {
+  return {
+    enabled: memory.mode !== "off",
+    activeMode: memory.mode === "observe" ? "observe" : "inject",
+    projectName: memory.project_name ?? "",
+  };
+}
+
+export function toMemorySettingsRequest(form: MemorySettingsForm): {
+  memory_mode: "off" | ActiveMemoryMode;
+  memory_project_id: string | null;
+} {
+  return {
+    memory_mode: form.enabled ? form.activeMode : "off",
+    memory_project_id: form.projectName.trim() || null,
+  };
+}

--- a/apps/portal/src/lib/components/MemorySettingsDialog.svelte
+++ b/apps/portal/src/lib/components/MemorySettingsDialog.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { t } from "$lib/i18n";
+  import { updateMemorySettings, type Me } from "$lib/api/portal";
+  import {
+    toMemorySettingsForm,
+    toMemorySettingsRequest,
+    type ActiveMemoryMode,
+  } from "$lib/api/memory-settings";
+  import Modal from "./Modal.svelte";
+
+  let {
+    me,
+    onsaved,
+    onclose,
+  }: {
+    me: Me;
+    onsaved: (memory: Me["memory"]) => void;
+    onclose: () => void;
+  } = $props();
+
+  let enabled = $state(false);
+  let activeMode = $state<ActiveMemoryMode>("inject");
+  let projectName = $state("");
+  let saving = $state(false);
+  let error = $state("");
+
+  $effect(() => {
+    const form = toMemorySettingsForm(me.memory);
+    enabled = form.enabled;
+    activeMode = form.activeMode;
+    projectName = form.projectName;
+  });
+
+  async function save(): Promise<void> {
+    if (me.role === "root" || saving) return;
+    saving = true;
+    error = "";
+    try {
+      const result = await updateMemorySettings(
+        toMemorySettingsRequest({ enabled, activeMode, projectName }),
+      );
+      onsaved(result.memory);
+    } catch (e) {
+      error = e instanceof Error ? e.message : $t("Failed to save settings");
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<Modal label={$t("Memory settings")} {onclose}>
+  <form
+    class="space-y-4"
+    onsubmit={(event) => {
+      event.preventDefault();
+      void save();
+    }}
+  >
+    <div>
+      <h2 class="section-header">{$t("Memory settings")}</h2>
+      <p class="field-help mt-1">
+        {$t(
+          "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.",
+        )}
+      </p>
+    </div>
+
+    <label
+      class="flex items-center justify-between gap-4 rounded-lg border border-border bg-canvas px-3 py-3 text-sm"
+    >
+      <span>
+        <span class="block field-label">{$t("Memory")}</span>
+        <span class="field-help"
+          >{$t("Record useful context across sessions")}</span
+        >
+      </span>
+      <input
+        type="checkbox"
+        bind:checked={enabled}
+        disabled={me.role === "root"}
+        aria-label={$t("Memory")}
+        class="h-4 w-4 accent-indigo-600"
+      />
+    </label>
+
+    <label class="flex flex-col gap-1 text-sm">
+      <span class="field-label">{$t("Memory mode")}</span>
+      <select
+        class="select"
+        bind:value={activeMode}
+        disabled={!enabled || me.role === "root"}
+      >
+        <option value="observe">{$t("Observe (record only)")}</option>
+        <option value="inject">{$t("Inject (record + hydrate)")}</option>
+      </select>
+    </label>
+
+    <label class="flex flex-col gap-1 text-sm">
+      <span class="field-label">{$t("Project")}</span>
+      <input
+        class="input"
+        maxlength="100"
+        placeholder={$t("Private to this key")}
+        bind:value={projectName}
+        disabled={me.role === "root"}
+      />
+      <span class="field-help">
+        {$t(
+          "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.",
+        )}
+      </span>
+    </label>
+
+    {#if error}<p class="alert-error" role="alert">{error}</p>{/if}
+
+    <div class="flex justify-end gap-2 pt-1">
+      <button type="button" class="btn-secondary" onclick={onclose}>
+        {$t("Cancel")}
+      </button>
+      {#if me.role !== "root"}
+        <button type="submit" class="btn-primary" disabled={saving}>
+          {saving ? $t("Saving…") : $t("Save settings")}
+        </button>
+      {/if}
+    </div>
+  </form>
+</Modal>

--- a/apps/portal/src/locales/en.json
+++ b/apps/portal/src/locales/en.json
@@ -988,6 +988,10 @@
   "Your requests, filtered by time, status, model, or lane.": "Your requests, filtered by time, status, model, or lane.",
   "Your key, its limits, and Memory defaults.": "Your key, its limits, and Memory defaults.",
   "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.",
+  "Memory settings": "Memory settings",
+  "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.": "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.",
+  "Record useful context across sessions": "Record useful context across sessions",
+  "Private to this key": "Private to this key",
   "Zoom in": "Zoom in",
   "Zoom out": "Zoom out"
 }

--- a/apps/portal/src/locales/es.json
+++ b/apps/portal/src/locales/es.json
@@ -988,6 +988,10 @@
   "Your requests, filtered by time, status, model, or lane.": "Tus solicitudes, filtradas por hora, estado, modelo o lane.",
   "Your key, its limits, and Memory defaults.": "Tu clave, sus límites y los valores predeterminados de Memoria.",
   "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "Cambiar el proyecto cambia el grupo de memoria; la memoria existente no se mueve. Las claves de la misma cuenta que usan el mismo proyecto comparten ese grupo.",
+  "Memory settings": "Configuración de Memoria",
+  "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.": "Estos valores predeterminados controlan cómo esta clave API registra y aplica la memoria. Los encabezados explícitos x-memory-* todavía los sustituyen.",
+  "Record useful context across sessions": "Registrar contexto útil entre sesiones",
+  "Private to this key": "Privado para esta clave",
   "Zoom in": "Acercar",
   "Zoom out": "Alejar"
 }

--- a/apps/portal/src/locales/ja.json
+++ b/apps/portal/src/locales/ja.json
@@ -988,6 +988,10 @@
   "Your requests, filtered by time, status, model, or lane.": "あなたのリクエストを、時間、ステータス、モデル、レーンで絞り込めます。",
   "Your key, its limits, and Memory defaults.": "キー、その上限、Memory のデフォルト設定です。",
   "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "プロジェクトを変更するとメモリプールが切り替わります。既存のメモリは移動されません。同じアカウントで同じプロジェクトを使うキーは、そのプールを共有します。",
+  "Memory settings": "Memory 設定",
+  "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.": "これらのデフォルト設定は、この API キーが Memory を記録して適用する方法を制御します。明示的な x-memory-* リクエストヘッダーが引き続き優先されます。",
+  "Record useful context across sessions": "セッションをまたいで有用なコンテキストを記録",
+  "Private to this key": "このキー専用",
   "Zoom in": "拡大",
   "Zoom out": "縮小"
 }

--- a/apps/portal/src/locales/ko.json
+++ b/apps/portal/src/locales/ko.json
@@ -988,6 +988,10 @@
   "Your requests, filtered by time, status, model, or lane.": "내 요청을 시간, 상태, 모델 또는 레인으로 필터링합니다.",
   "Your key, its limits, and Memory defaults.": "키, 사용 한도 및 Memory 기본값입니다.",
   "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "프로젝트를 변경하면 메모리 풀이 전환되며 기존 메모리는 이동되지 않습니다. 같은 계정에서 같은 프로젝트를 사용하는 키는 해당 풀을 공유합니다.",
+  "Memory settings": "Memory 설정",
+  "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.": "이 기본값은 이 API 키가 Memory를 기록하고 적용하는 방식을 제어합니다. 명시적인 x-memory-* 요청 헤더가 계속 우선합니다.",
+  "Record useful context across sessions": "세션 간 유용한 컨텍스트 기록",
+  "Private to this key": "이 키 전용",
   "Zoom in": "확대",
   "Zoom out": "축소"
 }

--- a/apps/portal/src/locales/pt.json
+++ b/apps/portal/src/locales/pt.json
@@ -988,6 +988,10 @@
   "Your requests, filtered by time, status, model, or lane.": "Suas solicitações, filtradas por hora, status, modelo ou lane.",
   "Your key, its limits, and Memory defaults.": "Sua chave, seus limites e os padrões de Memória.",
   "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "Alterar o projeto troca o conjunto de memória; a memória existente não é movida. Chaves da mesma conta que usam o mesmo projeto compartilham esse conjunto.",
+  "Memory settings": "Configurações de Memória",
+  "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.": "Esses padrões controlam como esta chave de API registra e aplica a memória. Cabeçalhos explícitos x-memory-* ainda os substituem.",
+  "Record useful context across sessions": "Registrar contexto útil entre sessões",
+  "Private to this key": "Privado para esta chave",
   "Zoom in": "Aproximar zoom",
   "Zoom out": "Afastar zoom"
 }

--- a/apps/portal/src/locales/zh-hans.json
+++ b/apps/portal/src/locales/zh-hans.json
@@ -988,6 +988,10 @@
   "Your requests, filtered by time, status, model, or lane.": "你的请求，可按时间、状态、模型或通道筛选。",
   "Your key, its limits, and Memory defaults.": "你的密钥、使用限制和 Memory 默认设置。",
   "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "更改项目会切换 Memory 池，已有记忆不会迁移。同一账户中使用相同项目的密钥会共享该 Memory 池。",
+  "Memory settings": "Memory 设置",
+  "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.": "这些默认设置控制此 API 密钥如何记录和应用 Memory。显式的 x-memory-* 请求头仍会覆盖这些设置。",
+  "Record useful context across sessions": "跨会话记录有用的上下文",
+  "Private to this key": "仅此密钥可用",
   "Zoom in": "放大",
   "Zoom out": "缩小"
 }

--- a/apps/portal/src/locales/zh-hant.json
+++ b/apps/portal/src/locales/zh-hant.json
@@ -988,6 +988,10 @@
   "Your requests, filtered by time, status, model, or lane.": "你的請求，可依時間、狀態、模型或通道篩選。",
   "Your key, its limits, and Memory defaults.": "你的金鑰、使用限制和 Memory 預設設定。",
   "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.": "變更專案會切換 Memory 池，既有記憶不會遷移。同一帳戶中使用相同專案的金鑰會共享該 Memory 池。",
+  "Memory settings": "Memory 設定",
+  "These defaults control how this API key records and applies memory. Explicit x-memory-* request headers still override them.": "這些預設設定控制此 API 金鑰如何記錄和套用 Memory。明確的 x-memory-* 請求標頭仍會覆寫這些設定。",
+  "Record useful context across sessions": "跨工作階段記錄有用的內容",
+  "Private to this key": "僅此金鑰可用",
   "Zoom in": "放大",
   "Zoom out": "縮小"
 }

--- a/apps/portal/src/routes/account/+page.svelte
+++ b/apps/portal/src/routes/account/+page.svelte
@@ -1,25 +1,16 @@
 <script lang="ts">
   import { t } from "$lib/i18n";
   import { formatUsd, formatTokens } from "$lib/format";
-  import { getMe, type Me, updateMemorySettings } from "$lib/api/portal";
+  import { getMe, type Me } from "$lib/api/portal";
 
   let me = $state<Me | null>(null);
   let loading = $state(true);
   let loadError = $state("");
-  let saveError = $state("");
-  let saving = $state(false);
-  let saved = $state(false);
-  let memoryEnabled = $state(false);
-  let activeMode = $state<"observe" | "inject">("inject");
-  let projectName = $state("");
 
   $effect(() => {
     void (async () => {
       try {
         me = await getMe();
-        memoryEnabled = me.memory.mode !== "off";
-        activeMode = me.memory.mode === "observe" ? "observe" : "inject";
-        projectName = me.memory.project_name ?? "";
       } catch (e) {
         loadError = e instanceof Error ? e.message : "load failed";
       } finally {
@@ -31,32 +22,13 @@
   const rpm = $derived(me?.rate_limit.rpm);
   const spend = $derived(me?.budget.spend_usd ?? null);
   const tokens = $derived(me?.budget.tokens ?? null);
-
-  async function saveMemorySettings(): Promise<void> {
-    if (!me || me.role === "root" || saving) return;
-    saving = true;
-    saved = false;
-    saveError = "";
-    try {
-      const result = await updateMemorySettings({
-        memory_mode: memoryEnabled ? activeMode : "off",
-        memory_project_id: projectName.trim() || null,
-      });
-      me = { ...me, memory: result.memory };
-      projectName = result.memory.project_name ?? "";
-      saved = true;
-    } catch (e) {
-      saveError =
-        e instanceof Error ? e.message : $t("Failed to save settings");
-    } finally {
-      saving = false;
-    }
-  }
 </script>
 
 <h1 class="page-title mb-1">{$t("Account")}</h1>
 <p class="section-desc mb-4">
-  {$t("Your key, its limits, and Memory defaults.")}
+  {$t(
+    "Your key and its limits. These are read-only — contact your administrator to change them.",
+  )}
 </p>
 
 {#if loading}
@@ -93,73 +65,15 @@
       <span class="section-desc">{$t("Token budget")}</span>
       <span>{tokens === null ? $t("unlimited") : formatTokens(tokens)}</span>
     </div>
-  </div>
-
-  <form
-    class="card mt-4 space-y-4"
-    onsubmit={(event) => {
-      event.preventDefault();
-      void saveMemorySettings();
-    }}
-  >
-    <div>
-      <h2 class="text-base font-semibold">{$t("Memory defaults")}</h2>
-      <p class="field-help mt-1">
-        {$t(
-          "Server-side memory defaults for clients that cannot send dynamic headers (Claude Code, Codex). Explicit x-memory-* request headers always override. Auto thread source derives the conversation from signals the client already sends (prompt_cache_key, metadata.user_id, x-session-key).",
-        )}
-      </p>
+    <div class="flex justify-between">
+      <span class="section-desc">{$t("Memory mode")}</span>
+      <span>{me.memory.mode}</span>
     </div>
-
-    <label class="flex items-center justify-between gap-4 text-sm">
-      <span class="field-label">{$t("Memory")}</span>
-      <input
-        type="checkbox"
-        bind:checked={memoryEnabled}
-        disabled={me.role === "root"}
-        aria-label={$t("Memory")}
-        class="h-4 w-4 accent-indigo-600"
-      />
-    </label>
-
-    <label class="flex flex-col gap-1 text-sm">
-      <span class="field-label">{$t("Memory mode")}</span>
-      <select
-        class="select"
-        bind:value={activeMode}
-        disabled={!memoryEnabled || me.role === "root"}
+    <div class="flex justify-between gap-4">
+      <span class="section-desc">{$t("Project")}</span>
+      <span class="truncate"
+        >{me.memory.project_name ?? $t("Private to this key")}</span
       >
-        <option value="observe">{$t("Observe (record only)")}</option>
-        <option value="inject">{$t("Inject (record + hydrate)")}</option>
-      </select>
-    </label>
-
-    <label class="flex flex-col gap-1 text-sm">
-      <span class="field-label">{$t("Default project id")}</span>
-      <input
-        class="input"
-        maxlength="100"
-        placeholder={$t("None")}
-        bind:value={projectName}
-        disabled={me.role === "root"}
-      />
-      <span class="field-help">
-        {$t(
-          "Changing the project switches memory pools; existing memory is not moved. Keys in the same account using the same project share that pool.",
-        )}
-      </span>
-    </label>
-
-    {#if me.role === "root"}
-      <p class="field-help">{me.role}: {$t("Memory mode")} {$t("Off")}</p>
-    {:else}
-      {#if saveError}<p class="alert-error">{saveError}</p>{/if}
-      <div class="flex items-center gap-3">
-        <button class="btn-primary" type="submit" disabled={saving}>
-          {saving ? $t("Saving…") : $t("Save settings")}
-        </button>
-        {#if saved}<span class="text-sm text-success">{$t("Saved")}</span>{/if}
-      </div>
-    {/if}
-  </form>
+    </div>
+  </div>
 {/if}

--- a/apps/portal/src/routes/memory/+page.svelte
+++ b/apps/portal/src/routes/memory/+page.svelte
@@ -17,6 +17,7 @@
   import AddFactDialog from "$lib/components/AddFactDialog.svelte";
   import EditFactDialog from "$lib/components/EditFactDialog.svelte";
   import EditReflectionDialog from "$lib/components/EditReflectionDialog.svelte";
+  import MemorySettingsDialog from "$lib/components/MemorySettingsDialog.svelte";
   import Modal from "$lib/components/Modal.svelte";
   import RefreshControl from "$lib/components/RefreshControl.svelte";
 
@@ -35,12 +36,13 @@
   let factPage = $state(1);
   let showInfo = $state(false);
   let showAddFact = $state(false);
+  let showSettings = $state(false);
   let editingFact = $state<Fact | null>(null);
   let editingReflection = $state<Reflection | null>(null);
   let confirmingFactDelete = $state<Fact | null>(null);
   let confirmingReflectionDelete = $state<Reflection | null>(null);
 
-  const sharedPool = $derived(me?.memory.project_id ?? null);
+  const sharedPool = $derived(me?.memory.project_name ?? null);
 
   const filteredFacts = $derived.by(() => {
     const query = factSearch.trim().toLowerCase();
@@ -139,6 +141,15 @@
     notice = $t("Reflection updated.");
   }
 
+  function onSettingsSaved(memory: Me["memory"]): void {
+    if (me) me = { ...me, memory };
+    showSettings = false;
+    notice = $t("Saved");
+    // A project change selects a different memory pool. Reload immediately so
+    // the page never keeps showing facts/reflections from the previous pool.
+    void load();
+  }
+
   async function confirmDeleteFact(): Promise<void> {
     const fact = confirmingFactDelete;
     if (!fact) return;
@@ -189,7 +200,15 @@
       {$t("Review and curate what Helm remembers across sessions.")}
     </p>
   </div>
-  <div class="shrink-0">
+  <div class="flex shrink-0 items-center gap-2">
+    <button
+      type="button"
+      class="btn-secondary"
+      disabled={!me}
+      onclick={() => (showSettings = true)}
+    >
+      {$t("Settings")}
+    </button>
     <RefreshControl onRefresh={load} />
   </div>
 </header>
@@ -449,6 +468,14 @@
       </div>
     {/if}
   </section>
+{/if}
+
+{#if showSettings && me}
+  <MemorySettingsDialog
+    {me}
+    onsaved={onSettingsSaved}
+    onclose={() => (showSettings = false)}
+  />
 {/if}
 
 {#if showAddFact}

--- a/docs/12-self-service-portal.md
+++ b/docs/12-self-service-portal.md
@@ -74,8 +74,8 @@
 | **概览 Overview** | `/portal`（首页） | **MVP** | 4 张 stat 卡（请求数/成功率/总token/花费，含环比 delta）+「我的额度」进度条区块（admin 无）+ LayerChart 双图（用量趋势 area + by-model donut）+ 最近请求（`RequestsTable` `showKey=false`）。**去掉一切管理动作**（编辑/轮换/吊销）。**智能空状态**：零请求时整页替换成接入引导卡（客户端快捷入口 → 直达接入页对应 tab）。 |
 | **接入 Connect** | `/portal/connect` | **MVP（门户灵魂）** | 左侧客户端选择器 + 右侧分步指引 + 一键复制。见 §5。 |
 | **请求 Requests** | `/portal/requests` `/portal/requests/:traceId` | 迭代 2 | 列表（`RequestsTable` full 变体，去 key/lane/decided-by 列）+ **脱敏详情**（§4.3）。 |
-| **记忆 Memory** | `/portal/memory` | 迭代 3 | facts + reflections 浏览/增删改，复用 admin By-Key 布局但只显示「我的」、隐藏 scope 选择器。加「什么是记忆?」说明气泡 + 隐私文案。空状态引导。 |
-| **账户 Account** | `/portal/account` | MVP + Memory settings | key prefix、只读 caps（lanes/预算/速率）以及可编辑的 Memory 开关、模式和项目名。退出、语言仍在账户菜单。 |
+| **记忆 Memory** | `/portal/memory` | 迭代 3 + settings | facts + reflections 浏览/增删改；标题区 `Settings` 打开弹窗，编辑本 key 的 Memory 开关、模式和项目。加「什么是记忆?」说明气泡 + 隐私文案。空状态引导。 |
+| **账户 Account** | `/portal/account` | MVP | key prefix、只读 caps（lanes/预算/速率）与只读 Memory mode/project 摘要。退出、语言仍在账户菜单。 |
 
 **IA 决策**：接入指南放导航第一/二位，不塞进设置角落。新用户第一眼看到「怎么接」，老用户日常看「概览」——这两个是门户双核心。
 
@@ -155,6 +155,7 @@ async function assertOwnsTrace(c, telemetry, traceId): Promise<"ok"|"not_found">
 - 若 account 下多 key 且 `memory_project_id` 皆 null → `effectiveMemoryProjectId` 各落 key_id → 天然 key 级隔离，门户始终传 `projectId: identity.caps.memory.projectId` 即可。
 - 若运营方给多 key 设同一显式 `memory_project_id`（共享池）→ 同 project 的 key 互见 memory，**这是配置决定的预期共享，非 bug**，但门户 UI 须诚实标注「此 memory 池为 project xxx，可能与同 project 的其他 key 共享」。
 - 门户自助修改 project 只切换默认池，**不迁移**旧池里的 facts/reflections；UI 必须在输入框旁明示。`/portal/api/me` 同时返回 effective `project_id` 与原始 `project_name`，避免把 null→keyId 的私有回落误标成显式共享。
+- 设置保存后 Memory 页必须重新读取 facts/reflections；只更新 mode/project 标签而保留旧池列表会造成跨 scope 的错误展示。
 
 ### 4.6 fail-open / 错误信封
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,10 +10,10 @@
 ## 2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）
 
 - **授权边界**：新增 `PATCH /portal/api/memory-settings`，只接受严格的 `memory_mode` 与 `memory_project_id`；目标 key 始终取 bearer identity 的 `keyId`，不能提交 `key_id/account_id`，也不能借此修改 lane、预算或限流。管理面 root key 继续强制只读、保持 memory inert。
-- **交互**：Account 页提供 Memory 开关、`observe`（仅记录）/`inject`（记录并注入）模式和最多 100 字符的项目名；保存后同实例 auth cache 立即失效。显式 `x-memory-*` 请求头仍覆盖这些服务端默认值。
+- **交互**：Memory 页标题区提供 `Settings` 入口，弹窗内编辑 Memory 开关、`observe`（仅记录）/`inject`（记录并注入）模式和最多 100 字符的项目名；Account 页只保留只读摘要，避免两个可编辑入口。保存项目后立即重载 facts/reflections，不能继续显示旧池数据。显式 `x-memory-*` 请求头仍覆盖这些服务端默认值。
 - **scope 语义**：`memory_project_id` 是共享池选择器，不是纯展示标签；空值仍回落到 key 自身的私有 scope。更改项目只切换默认池，不迁移旧 Memory；同一 account 下采用相同显式项目名的 keys 会共享该池，UI 明示这一点。
 - **API 投影**：`/portal/api/me` 同时返回有效 `project_id` 与原始配置 `project_name`，避免把 null→key-id 的私有默认 scope 错画成显式共享项目。未新增 DB 字段或迁移，复用已有 KeyStore partial update。
-- **验证**：先增加 portal route 红测，覆盖 authenticated-key 强制、严格字段拒绝、disable/clear 和 root 拒绝；再实现后端与 UI，并运行 gateway portal tests、shared/gateway/portal typecheck、portal check/build 和 i18n 校验。
+- **验证**：先增加 portal route 红测，覆盖 authenticated-key 强制、严格字段拒绝、disable/clear 和 root 拒绝；设置弹窗再以纯函数红测覆盖 off→inject 编辑回退、observe/project 回填和请求 trim/null 映射；运行 gateway/portal tests、typecheck、portal check/build 和 i18n 校验。
 
 ## 2026-07-10–11 · Codex CLI GPT-5.6 subscription parity（OAuth subscription / Responses / model catalog，docs/04/05/11，原则 3/5/6/7/8）
 


### PR DESCRIPTION
## Summary
- add a contextual Settings entry and focused dialog to the portal Memory page
- move Account back to a read-only summary to avoid two editable locations
- reload facts/reflections immediately after a project-pool change
- use the raw configured project name for shared-pool messaging
- add seven-locale copy and pure form-mapping regression tests

## Verification
- `pnpm exec vitest run --project node portal` (35 tests)
- `pnpm --filter @helm/portal check` (0 errors, 0 warnings)
- `pnpm build`
- locale key parity + formatting + `git diff --check`
- local browser interaction: open dialog, save changed project, page reloads new pool, zero console errors