### PR TITLE
fix(portal): add Memory thread source setting

### DIFF
--- a/apps/gateway/src/routes/portal/index.test.ts
+++ b/apps/gateway/src/routes/portal/index.test.ts
@@ -14,6 +14,7 @@ const AUTH = { Authorization: "Bearer helm_live_secret" } as const;
 type MemoryPatch = {
   memoryMode?: "off" | "observe" | "inject";
   memoryProjectId?: string | null;
+  memoryThreadSource?: "header" | "auto";
 };
 
 function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
@@ -215,6 +216,7 @@ describe("portal API", () => {
       expect(body.allowed_lanes).toEqual(["balanced", "coding"]);
       expect((body.budget as Record<string, unknown>).spend_usd).toBe(100);
       expect((body.memory as Record<string, unknown>).mode).toBe("inject");
+      expect((body.memory as Record<string, unknown>).thread_source).toBe("header");
       const serialized = JSON.stringify(body);
       expect(serialized).not.toContain(hashKey("helm_live_secret"));
       expect(serialized).not.toContain("helm_live_secret");
@@ -230,7 +232,11 @@ describe("portal API", () => {
         {
           method: "PATCH",
           headers: { ...AUTH, "content-type": "application/json" },
-          body: JSON.stringify({ memory_mode: "observe", memory_project_id: "project-a" }),
+          body: JSON.stringify({
+            memory_mode: "observe",
+            memory_project_id: "project-a",
+            memory_thread_source: "auto",
+          }),
         },
       );
 
@@ -238,9 +244,15 @@ describe("portal API", () => {
       expect(updateKey).toHaveBeenCalledWith("k1", {
         memoryMode: "observe",
         memoryProjectId: "project-a",
+        memoryThreadSource: "auto",
       });
       await expect(res.json()).resolves.toEqual({
-        memory: { mode: "observe", project_id: "project-a", project_name: "project-a" },
+        memory: {
+          mode: "observe",
+          project_id: "project-a",
+          project_name: "project-a",
+          thread_source: "auto",
+        },
       });
     });
 
@@ -250,21 +262,69 @@ describe("portal API", () => {
       const ok = await app.request("/portal/api/memory-settings", {
         method: "PATCH",
         headers: { ...AUTH, "content-type": "application/json" },
-        body: JSON.stringify({ memory_mode: "off", memory_project_id: null }),
+        body: JSON.stringify({
+          memory_mode: "off",
+          memory_project_id: null,
+          memory_thread_source: "header",
+        }),
       });
       expect(ok.status).toBe(200);
       expect(updateKey).toHaveBeenCalledWith("k1", {
         memoryMode: "off",
         memoryProjectId: null,
+        memoryThreadSource: "header",
       });
 
       const invalid = await app.request("/portal/api/memory-settings", {
         method: "PATCH",
         headers: { ...AUTH, "content-type": "application/json" },
-        body: JSON.stringify({ memory_mode: "inject", allowed_lanes: ["premium"] }),
+        body: JSON.stringify({
+          memory_mode: "inject",
+          memory_project_id: null,
+          memory_thread_source: "magic",
+        }),
       });
       expect(invalid.status).toBe(400);
       expect(updateKey).toHaveBeenCalledTimes(1);
+
+      const adminField = await app.request("/portal/api/memory-settings", {
+        method: "PATCH",
+        headers: { ...AUTH, "content-type": "application/json" },
+        body: JSON.stringify({
+          memory_mode: "inject",
+          memory_project_id: null,
+          memory_thread_source: "auto",
+          allowed_lanes: ["premium"],
+        }),
+      });
+      expect(adminField.status).toBe(400);
+      expect(updateKey).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves the current thread source for an older portal request that omits it", async () => {
+      const updateKey = vi.fn(async () => {});
+      const res = await buildApp(
+        record({ memory_thread_source: "header" }),
+        telemetry(),
+        updateKey,
+      ).request("/portal/api/memory-settings", {
+        method: "PATCH",
+        headers: { ...AUTH, "content-type": "application/json" },
+        body: JSON.stringify({ memory_mode: "observe", memory_project_id: null }),
+      });
+      expect(res.status).toBe(200);
+      expect(updateKey).toHaveBeenCalledWith("k1", {
+        memoryMode: "observe",
+        memoryProjectId: null,
+      });
+      expect(await res.json()).toEqual({
+        memory: {
+          mode: "observe",
+          project_id: "k1",
+          project_name: null,
+          thread_source: "header",
+        },
+      });
     });
 
     it("keeps the management-plane root key memory-inert", async () => {
@@ -276,7 +336,11 @@ describe("portal API", () => {
       ).request("/portal/api/memory-settings", {
         method: "PATCH",
         headers: { ...AUTH, "content-type": "application/json" },
-        body: JSON.stringify({ memory_mode: "inject", memory_project_id: "root-project" }),
+        body: JSON.stringify({
+          memory_mode: "inject",
+          memory_project_id: "root-project",
+          memory_thread_source: "auto",
+        }),
       });
       expect(res.status).toBe(403);
       expect(updateKey).not.toHaveBeenCalled();

--- a/apps/gateway/src/routes/portal/index.ts
+++ b/apps/gateway/src/routes/portal/index.ts
@@ -59,6 +59,7 @@ export function registerPortalApi(app: Hono<AppEnv>, deps: PortalApiDeps): void 
         mode: identity.caps.memory.mode,
         project_id: identity.caps.memory.projectId,
         project_name: identity.caps.memory.projectName ?? null,
+        thread_source: identity.caps.memory.threadSource,
       },
     });
   });
@@ -77,15 +78,20 @@ export function registerPortalApi(app: Hono<AppEnv>, deps: PortalApiDeps): void 
     if (!parsed.success) {
       return c.json({ error: "invalid memory settings", issues: parsed.error.issues }, 400);
     }
-    await deps.keyStore.updateKey(identity.keyId, {
+    const patch: Parameters<PortalApiDeps["keyStore"]["updateKey"]>[1] = {
       memoryMode: parsed.data.memory_mode,
       memoryProjectId: parsed.data.memory_project_id,
-    });
+    };
+    if (parsed.data.memory_thread_source !== undefined) {
+      patch.memoryThreadSource = parsed.data.memory_thread_source;
+    }
+    await deps.keyStore.updateKey(identity.keyId, patch);
     return c.json({
       memory: {
         mode: parsed.data.memory_mode,
         project_id: parsed.data.memory_project_id ?? identity.keyId,
         project_name: parsed.data.memory_project_id,
+        thread_source: parsed.data.memory_thread_source ?? identity.caps.memory.threadSource,
       },
     });
   });

--- a/apps/portal/src/lib/api/memory-settings.test.ts
+++ b/apps/portal/src/lib/api/memory-settings.test.ts
@@ -6,20 +6,32 @@ import {
 
 describe("Memory settings dialog mapping", () => {
   it("restores inject as the active mode when Memory is currently off", () => {
-    expect(toMemorySettingsForm({ mode: "off", project_name: null })).toEqual({
+    expect(
+      toMemorySettingsForm({
+        mode: "off",
+        project_name: null,
+        thread_source: "header",
+      }),
+    ).toEqual({
       enabled: false,
       activeMode: "inject",
       projectName: "",
+      threadSource: "header",
     });
   });
 
   it("preserves observe mode and the configured project", () => {
     expect(
-      toMemorySettingsForm({ mode: "observe", project_name: "project-a" }),
+      toMemorySettingsForm({
+        mode: "observe",
+        project_name: "project-a",
+        thread_source: "auto",
+      }),
     ).toEqual({
       enabled: true,
       activeMode: "observe",
       projectName: "project-a",
+      threadSource: "auto",
     });
   });
 
@@ -29,14 +41,24 @@ describe("Memory settings dialog mapping", () => {
         enabled: true,
         activeMode: "inject",
         projectName: "  project-a  ",
+        threadSource: "auto",
       }),
-    ).toEqual({ memory_mode: "inject", memory_project_id: "project-a" });
+    ).toEqual({
+      memory_mode: "inject",
+      memory_project_id: "project-a",
+      memory_thread_source: "auto",
+    });
     expect(
       toMemorySettingsRequest({
         enabled: false,
         activeMode: "observe",
         projectName: "   ",
+        threadSource: "header",
       }),
-    ).toEqual({ memory_mode: "off", memory_project_id: null });
+    ).toEqual({
+      memory_mode: "off",
+      memory_project_id: null,
+      memory_thread_source: "header",
+    });
   });
 });

--- a/apps/portal/src/lib/api/memory-settings.ts
+++ b/apps/portal/src/lib/api/memory-settings.ts
@@ -6,24 +6,28 @@ export interface MemorySettingsForm {
   enabled: boolean;
   activeMode: ActiveMemoryMode;
   projectName: string;
+  threadSource: "header" | "auto";
 }
 
 export function toMemorySettingsForm(
-  memory: Pick<Me["memory"], "mode" | "project_name">,
+  memory: Pick<Me["memory"], "mode" | "project_name" | "thread_source">,
 ): MemorySettingsForm {
   return {
     enabled: memory.mode !== "off",
     activeMode: memory.mode === "observe" ? "observe" : "inject",
     projectName: memory.project_name ?? "",
+    threadSource: memory.thread_source,
   };
 }
 
 export function toMemorySettingsRequest(form: MemorySettingsForm): {
   memory_mode: "off" | ActiveMemoryMode;
   memory_project_id: string | null;
+  memory_thread_source: "header" | "auto";
 } {
   return {
     memory_mode: form.enabled ? form.activeMode : "off",
     memory_project_id: form.projectName.trim() || null,
+    memory_thread_source: form.threadSource,
   };
 }

--- a/apps/portal/src/lib/api/portal.ts
+++ b/apps/portal/src/lib/api/portal.ts
@@ -19,6 +19,7 @@ export interface Me {
     mode: "off" | "observe" | "inject";
     project_id: string | null;
     project_name: string | null;
+    thread_source: "header" | "auto";
   };
 }
 
@@ -101,6 +102,7 @@ export function getMe(): Promise<Me> {
 export function updateMemorySettings(input: {
   memory_mode: "off" | "observe" | "inject";
   memory_project_id: string | null;
+  memory_thread_source: "header" | "auto";
 }): Promise<{ memory: Me["memory"] }> {
   return apiPatch<{ memory: Me["memory"] }>("/memory-settings", input);
 }

--- a/apps/portal/src/lib/components/MemorySettingsDialog.svelte
+++ b/apps/portal/src/lib/components/MemorySettingsDialog.svelte
@@ -21,6 +21,7 @@
   let enabled = $state(false);
   let activeMode = $state<ActiveMemoryMode>("inject");
   let projectName = $state("");
+  let threadSource = $state<"header" | "auto">("auto");
   let saving = $state(false);
   let error = $state("");
 
@@ -29,6 +30,7 @@
     enabled = form.enabled;
     activeMode = form.activeMode;
     projectName = form.projectName;
+    threadSource = form.threadSource;
   });
 
   async function save(): Promise<void> {
@@ -37,7 +39,12 @@
     error = "";
     try {
       const result = await updateMemorySettings(
-        toMemorySettingsRequest({ enabled, activeMode, projectName }),
+        toMemorySettingsRequest({
+          enabled,
+          activeMode,
+          projectName,
+          threadSource,
+        }),
       );
       onsaved(result.memory);
     } catch (e) {
@@ -92,6 +99,18 @@
       >
         <option value="observe">{$t("Observe (record only)")}</option>
         <option value="inject">{$t("Inject (record + hydrate)")}</option>
+      </select>
+    </label>
+
+    <label class="flex flex-col gap-1 text-sm">
+      <span class="field-label">{$t("Thread source")}</span>
+      <select
+        class="select"
+        bind:value={threadSource}
+        disabled={me.role === "root"}
+      >
+        <option value="auto">{$t("Auto (derive from client signals)")}</option>
+        <option value="header">{$t("Header only (x-thread-id)")}</option>
       </select>
     </label>
 

--- a/apps/portal/src/routes/account/+page.svelte
+++ b/apps/portal/src/routes/account/+page.svelte
@@ -75,5 +75,13 @@
         >{me.memory.project_name ?? $t("Private to this key")}</span
       >
     </div>
+    <div class="flex justify-between">
+      <span class="section-desc">{$t("Thread source")}</span>
+      <span>
+        {me.memory.thread_source === "auto"
+          ? $t("Auto (derive from client signals)")
+          : $t("Header only (x-thread-id)")}
+      </span>
+    </div>
   </div>
 {/if}

--- a/docs/12-self-service-portal.md
+++ b/docs/12-self-service-portal.md
@@ -74,8 +74,8 @@
 | **概览 Overview** | `/portal`（首页） | **MVP** | 4 张 stat 卡（请求数/成功率/总token/花费，含环比 delta）+「我的额度」进度条区块（admin 无）+ LayerChart 双图（用量趋势 area + by-model donut）+ 最近请求（`RequestsTable` `showKey=false`）。**去掉一切管理动作**（编辑/轮换/吊销）。**智能空状态**：零请求时整页替换成接入引导卡（客户端快捷入口 → 直达接入页对应 tab）。 |
 | **接入 Connect** | `/portal/connect` | **MVP（门户灵魂）** | 左侧客户端选择器 + 右侧分步指引 + 一键复制。见 §5。 |
 | **请求 Requests** | `/portal/requests` `/portal/requests/:traceId` | 迭代 2 | 列表（`RequestsTable` full 变体，去 key/lane/decided-by 列）+ **脱敏详情**（§4.3）。 |
-| **记忆 Memory** | `/portal/memory` | 迭代 3 + settings | facts + reflections 浏览/增删改；标题区 `Settings` 打开弹窗，编辑本 key 的 Memory 开关、模式和项目。加「什么是记忆?」说明气泡 + 隐私文案。空状态引导。 |
-| **账户 Account** | `/portal/account` | MVP | key prefix、只读 caps（lanes/预算/速率）与只读 Memory mode/project 摘要。退出、语言仍在账户菜单。 |
+| **记忆 Memory** | `/portal/memory` | 迭代 3 + settings | facts + reflections 浏览/增删改；标题区 `Settings` 打开弹窗，编辑本 key 的 Memory 开关、模式、项目和线程来源。加「什么是记忆?」说明气泡 + 隐私文案。空状态引导。 |
+| **账户 Account** | `/portal/account` | MVP | key prefix、只读 caps（lanes/预算/速率）与只读 Memory mode/project/thread source 摘要。退出、语言仍在账户菜单。 |
 
 **IA 决策**：接入指南放导航第一/二位，不塞进设置角落。新用户第一眼看到「怎么接」，老用户日常看「概览」——这两个是门户双核心。
 
@@ -109,7 +109,7 @@
 | 4 | `GET /portal/api/requests/:traceId` | **先 ownership 校验**（§4.4）→ `getByRequestId` → **白名单脱敏投影**（§4.3） | `getApiKeyId` + `getByRequestId` | 迭代 2 |
 | 5 | `GET /portal/api/requests/:traceId/payload` | **先 ownership 校验** → 取正文，**白名单 `part ∈ {request,response}`，拒 upstream** | `getApiKeyId` + `getPayloadMeta/getPayloadPart` | 迭代 2 |
 | 6 | memory CRUD | **优先前端直接打 `POST /mcp`（零新后端）**；若必须 REST，则 `accountId: identity.accountId` + `projectId: identity.caps.memory.projectId` 全写死，逐字复用 MCP 隔离不变量，**绝不照搬 `/admin/api/memory/*`**（query 参数寻址 = 破隔离） | MCP tools / `MemoryStore` | 迭代 3 |
-| 7 | `PATCH /portal/api/memory-settings` | 严格只收 `memory_mode` / `memory_project_id`；更新目标写死 `identity.keyId`；root key 拒绝 | `KeyStore.updateKey` | 迭代 4 |
+| 7 | `PATCH /portal/api/memory-settings` | 严格只收 `memory_mode` / `memory_project_id` / `memory_thread_source`；更新目标写死 `identity.keyId`；root key 拒绝 | `KeyStore.updateKey` | 迭代 4 |
 
 memory REST（仅当 MCP 未启用/需 REST 语义时）：`GET /portal/api/memory/facts`、`GET/PATCH/DELETE .../facts/:id`、reflections 同构。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -9,10 +9,10 @@
 
 ## 2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）
 
-- **授权边界**：新增 `PATCH /portal/api/memory-settings`，只接受严格的 `memory_mode` 与 `memory_project_id`；目标 key 始终取 bearer identity 的 `keyId`，不能提交 `key_id/account_id`，也不能借此修改 lane、预算或限流。管理面 root key 继续强制只读、保持 memory inert。
-- **交互**：Memory 页标题区提供 `Settings` 入口，弹窗内编辑 Memory 开关、`observe`（仅记录）/`inject`（记录并注入）模式和最多 100 字符的项目名；Account 页只保留只读摘要，避免两个可编辑入口。保存项目后立即重载 facts/reflections，不能继续显示旧池数据。显式 `x-memory-*` 请求头仍覆盖这些服务端默认值。
+- **授权边界**：新增 `PATCH /portal/api/memory-settings`，只接受严格的 `memory_mode`、`memory_project_id` 与 `memory_thread_source`；目标 key 始终取 bearer identity 的 `keyId`，不能提交 `key_id/account_id`，也不能借此修改 lane、预算或限流。管理面 root key 继续强制只读、保持 memory inert。`memory_thread_source` 在服务端 schema 保持 optional，仅用于兼容仍打开着的 v0.26.16/17 旧 SPA；新 UI 始终显式发送。
+- **交互**：Memory 页标题区提供 `Settings` 入口，弹窗内编辑 Memory 开关、`observe`（仅记录）/`inject`（记录并注入）模式、最多 100 字符的项目名，以及线程来源 `auto` / `header`；Account 页只保留只读摘要，避免两个可编辑入口。保存项目后立即重载 facts/reflections，不能继续显示旧池数据。显式 `x-memory-*` 请求头仍覆盖这些服务端默认值。
 - **scope 语义**：`memory_project_id` 是共享池选择器，不是纯展示标签；空值仍回落到 key 自身的私有 scope。更改项目只切换默认池，不迁移旧 Memory；同一 account 下采用相同显式项目名的 keys 会共享该池，UI 明示这一点。
-- **API 投影**：`/portal/api/me` 同时返回有效 `project_id` 与原始配置 `project_name`，避免把 null→key-id 的私有默认 scope 错画成显式共享项目。未新增 DB 字段或迁移，复用已有 KeyStore partial update。
+- **API 投影**：`/portal/api/me` 同时返回有效 `project_id`、原始配置 `project_name` 与 `thread_source`，避免把 null→key-id 的私有默认 scope 错画成显式共享项目，并让弹窗准确回填线程策略。未新增 DB 字段或迁移，复用已有 KeyStore partial update。
 - **验证**：先增加 portal route 红测，覆盖 authenticated-key 强制、严格字段拒绝、disable/clear 和 root 拒绝；设置弹窗再以纯函数红测覆盖 off→inject 编辑回退、observe/project 回填和请求 trim/null 映射；运行 gateway/portal tests、typecheck、portal check/build 和 i18n 校验。
 
 ## 2026-07-10–11 · Codex CLI GPT-5.6 subscription parity（OAuth subscription / Responses / model catalog，docs/04/05/11，原则 3/5/6/7/8）

--- a/packages/shared/src/key/schema.test.ts
+++ b/packages/shared/src/key/schema.test.ts
@@ -417,12 +417,18 @@ describe("PortalMemorySettingsRequestSchema", () => {
       PortalMemorySettingsRequestSchema.parse({
         memory_mode: "observe",
         memory_project_id: "  project-a  ",
+        memory_thread_source: "auto",
       }),
-    ).toEqual({ memory_mode: "observe", memory_project_id: "project-a" });
+    ).toEqual({
+      memory_mode: "observe",
+      memory_project_id: "project-a",
+      memory_thread_source: "auto",
+    });
     expect(
       PortalMemorySettingsRequestSchema.safeParse({
         memory_mode: "inject",
         memory_project_id: null,
+        memory_thread_source: "header",
         budget_tokens: 1,
       }).success,
     ).toBe(false);
@@ -431,8 +437,9 @@ describe("PortalMemorySettingsRequestSchema", () => {
   it("rejects invalid modes and blank or oversized project names", () => {
     for (const input of [
       { memory_mode: "on", memory_project_id: null },
-      { memory_mode: "off", memory_project_id: "   " },
-      { memory_mode: "off", memory_project_id: "x".repeat(101) },
+      { memory_mode: "off", memory_project_id: "   ", memory_thread_source: "auto" },
+      { memory_mode: "off", memory_project_id: "x".repeat(101), memory_thread_source: "auto" },
+      { memory_mode: "off", memory_project_id: null, memory_thread_source: "magic" },
     ]) {
       expect(PortalMemorySettingsRequestSchema.safeParse(input).success).toBe(false);
     }

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -205,6 +205,9 @@ export const PortalMemorySettingsRequestSchema = z
   .object({
     memory_mode: MemoryModeSchema,
     memory_project_id: z.string().trim().min(1).max(100).nullable(),
+    // Optional for backward compatibility with the first portal-settings SPA.
+    // New clients always send it; omitted means keep the current per-key value.
+    memory_thread_source: MemoryThreadSourceSchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- expose `memory_thread_source` in the safe portal `/me` projection
- allow authenticated API-key owners to update `auto` versus `header` through the strict Memory-only endpoint
- add the Thread source control to the Memory settings dialog and Account summary
- preserve existing values for requests from older cached portal builds
- retain root-key and admin-field authorization boundaries

## Verification
- focused portal/shared/auth suite: 98 tests
- portal check: 0 errors, 0 warnings
- gateway typecheck
- full workspace build
- locale key parity, formatting, and diff checks