### PR TITLE
chore: release v0.26.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.17",
+  "version": "0.26.18",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump root package version to `0.26.18`
- release the portal Memory Thread source setting from #522