### PR TITLE
fix(portal): strengthen Memory help control

### DIFF
--- a/apps/portal/src/app.css
+++ b/apps/portal/src/app.css
@@ -130,6 +130,13 @@
   .btn-icon {
     @apply inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-slate-500 md:h-7 md:w-7;
   }
+  /* Contextual help is intentionally visible at rest and stateful when open. */
+  .btn-help {
+    @apply inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border border-slate-200 bg-slate-100 font-semibold text-slate-600 transition-colors hover:border-slate-300 hover:bg-slate-200 hover:text-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 md:h-7 md:w-7;
+  }
+  .btn-help-open {
+    @apply border-slate-300 bg-slate-200 text-slate-800;
+  }
 
   /* — Form controls — */
   .input {

--- a/apps/portal/src/lib/memory-help-control.test.ts
+++ b/apps/portal/src/lib/memory-help-control.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const page = readFileSync(
+  new URL("../routes/memory/+page.svelte", import.meta.url),
+  "utf8",
+);
+const css = readFileSync(new URL("../app.css", import.meta.url), "utf8");
+
+function cssRule(selector: string): string {
+  return (
+    css.match(new RegExp(`\\.${selector}\\s*\\{([\\s\\S]*?)\\}`))?.[1] ?? ""
+  );
+}
+
+describe("Memory contextual-help control", () => {
+  it("exposes its expanded state and applies a persistent open style", () => {
+    expect(page).toContain('class="btn-help"');
+    expect(page).toContain("aria-expanded={showInfo}");
+    expect(page).toContain("class:btn-help-open={showInfo}");
+  });
+
+  it("has a dedicated circular resting treatment instead of the transparent generic icon", () => {
+    const resting = cssRule("btn-help");
+    const open = cssRule("btn-help-open");
+
+    expect(resting).toContain("rounded-full");
+    expect(resting).toContain("border-slate-200");
+    expect(resting).toContain("bg-slate-100");
+    expect(resting).toContain("font-semibold");
+    expect(resting).toContain("focus-visible:ring-2");
+    expect(open).toContain("bg-slate-200");
+    expect(open).toContain("text-slate-800");
+  });
+});

--- a/apps/portal/src/routes/memory/+page.svelte
+++ b/apps/portal/src/routes/memory/+page.svelte
@@ -188,8 +188,10 @@
       <h1 class="page-title">{$t("Memory")}</h1>
       <button
         type="button"
-        class="btn-icon"
+        class="btn-help"
+        class:btn-help-open={showInfo}
         aria-label={$t("What is memory?")}
+        aria-expanded={showInfo}
         title={$t("What is memory?")}
         onclick={() => (showInfo = !showInfo)}
       >


### PR DESCRIPTION
## Summary
- give the Memory contextual-help control a visible neutral resting treatment
- expose and style its expanded state
- add a focused regression test for the control contract

## Verification
- `pnpm exec vitest run apps/portal/src`
- `pnpm --filter @helm/portal check`
- `pnpm build`
- Prettier check and `git diff --check`
- desktop/mobile visual verification for resting, hover, focus, and open states