### PR TITLE
chore: release v0.26.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.18",
+  "version": "0.26.19",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump the Helm API patch version to `0.26.19`
- publish the Memory help-control visual and accessibility fix

## Included
- #524