### PR TITLE
fix(admin): refine Codex quota display

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -372,6 +372,13 @@
     return Number.isFinite(number) ? new Intl.NumberFormat().format(number) : value;
   }
 
+  function formatCreditBalance(value: string | null): string | null {
+    if (value == null) return '—';
+    const number = Number(value);
+    if (!Number.isFinite(number)) return value;
+    return number === 0 ? null : number.toFixed(2);
+  }
+
   function additionalLimitNames(q: OAuthQuotaSnapshot | undefined): string[] {
     if (!q?.additionalLimits?.length) return [];
     const representedIds = new Set(q.windows.map((window) => window.limitId).filter(Boolean));
@@ -724,6 +731,10 @@
             {@const usageLimitRecovery = usageLimit ? autoRecoverIn(usageLimit.untilMs) : ''}
             {@const credentialFailed = row.account.credentialFailed === true}
             {@const additionalLimits = isCodex ? additionalLimitNames(quota) : []}
+            {@const codexCreditBalance =
+              isCodex && quota?.credits && !quota.credits.unlimited
+                ? formatCreditBalance(quota.credits.balance)
+                : null}
             {@const hasCodexQuotaMetadata =
               isCodex &&
               Boolean(
@@ -863,9 +874,9 @@
                   <div class="flex w-full flex-col gap-1.5 lg:w-40">
                     {#each quota.windows as w (w.key)}
                       <div>
-                        <div class="flex items-center justify-between text-xs text-ink-muted">
-                          <span>{quotaWindowLabel(w)}</span>
-                          <span>{Math.round(w.usedPercent)}%</span>
+                        <div class="flex items-center justify-between gap-1 text-xs text-ink-muted">
+                          <span class="text-[9px]">{quotaWindowLabel(w)}</span>
+                          <span class="shrink-0">{Math.round(w.usedPercent)}%</span>
                         </div>
                         <div class="progress-track">
                           <div
@@ -935,12 +946,16 @@
                     {$t('Plan: {plan}', { plan: planLabel(quota.planType) })}
                   </div>
                 {/if}
-                {#if isCodex && quota?.credits}
+                {#if isCodex && quota?.credits?.unlimited}
                   <div class="text-[10px] text-ink-muted">
                     {$t('Credits: {balance}', {
-                      balance: quota.credits.unlimited
-                        ? $t('Unlimited')
-                        : (quota.credits.balance ?? '—'),
+                      balance: $t('Unlimited'),
+                    })}
+                  </div>
+                {:else if codexCreditBalance}
+                  <div class="text-[10px] text-ink-muted">
+                    {$t('Credits: {balance}', {
+                      balance: codexCreditBalance,
                     })}
                   </div>
                 {/if}

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -1027,7 +1027,7 @@ describe('providers page', () => {
               resetsAtMs: Date.now() + 3_600_000,
               windowMinutes: 30,
               limitId: 'codex_spark',
-              limitName: 'GPT-5.6-Codex-Spark',
+              limitName: 'GPT-5.3-Codex-Spark',
             },
           ],
           capturedAt: Date.now(),
@@ -1045,7 +1045,7 @@ describe('providers page', () => {
     });
 
     const row = screen.getByTestId('provider-account-row');
-    expect(within(row).getByText('GPT-5.6-Codex-Spark · 30m')).toBeInTheDocument();
+    expect(within(row).getByText('GPT-5.3-Codex-Spark · 30m')).toHaveClass('text-[9px]');
     const individualLimit = within(row).getByTestId('codex-individual-limit');
     expect(within(individualLimit).getByText('Monthly credit limit')).toBeInTheDocument();
     expect(within(individualLimit).getByText('8,000 of 25,000 credits used')).toBeInTheDocument();
@@ -1136,7 +1136,7 @@ describe('providers page', () => {
           usageLimitedUntilMs: null,
           resetCredits: null,
           planType: 'pro',
-          credits: { hasCredits: true, unlimited: false, balance: '9.99' },
+          credits: { hasCredits: true, unlimited: false, balance: '24524.0366637500' },
           rateLimitReachedType: 'rate_limit_reached',
         },
       ],
@@ -1146,9 +1146,54 @@ describe('providers page', () => {
       'provider-quota-cell',
     );
     expect(within(quotaCell).getByText('Plan: Pro')).toBeInTheDocument();
-    expect(within(quotaCell).getByText('Credits: 9.99')).toBeInTheDocument();
+    expect(within(quotaCell).getByText('Credits: 24524.04')).toBeInTheDocument();
     expect(within(quotaCell).getByText('Rate limit reached')).toBeInTheDocument();
     expect(within(quotaCell).queryByText('—')).not.toBeInTheDocument();
+  });
+
+  it('hides a zero Codex credit balance', () => {
+    renderPage({
+      providers: [
+        provider({
+          id: 'openai-codex',
+          name: 'Codex',
+          accounts: [
+            {
+              account: 'acct-codex',
+              expiresAt: null,
+              updatedAt: Date.now(),
+              healthy: true,
+              priority: 50,
+              schedulable: true,
+              autoReset: false,
+              fastMode: false,
+              proxy: null,
+              models: ['gpt-5.6-sol'],
+            },
+          ],
+        }),
+      ],
+      usage: [],
+      quota: [
+        {
+          providerId: 'openai-codex',
+          account: 'acct-codex',
+          windows: [],
+          capturedAt: Date.now(),
+          source: 'codex',
+          usageLimitedUntilMs: null,
+          resetCredits: null,
+          planType: 'pro',
+          credits: { hasCredits: false, unlimited: false, balance: '0.0000000000' },
+        },
+      ],
+    });
+
+    const quotaCell = within(screen.getByTestId('provider-account-row')).getByTestId(
+      'provider-quota-cell',
+    );
+    expect(within(quotaCell).getByText('Plan: Pro')).toBeInTheDocument();
+    expect(within(quotaCell).queryByText(/^Credits:/)).not.toBeInTheDocument();
   });
 
   it('does NOT consume when the reset confirmation is cancelled', async () => {


### PR DESCRIPTION
## Summary

- reduce Codex quota-window labels to 9px so long Spark model names fit without colliding with percentages
- format finite Codex credit balances to two decimal places and hide zero balances
- preserve the existing Unlimited credit display
- add regression coverage for the long Spark label, decimal formatting, and zero suppression

## Verification

- `pnpm build`
- `pnpm test` (348 files, 5,609 tests)
- `pnpm typecheck`
- `pnpm lint`
- Admin Providers tests: 40/40
- local Docker UI smoke at `http://127.0.0.1:8100/admin/providers`: label computed at 9px, percentage spacing preserved, and `24524.0366637500` rendered as `24524.04`
