### PR TITLE
chore: release v0.26.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.19",
+  "version": "0.26.20",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.26.19` to `0.26.20`.

## Included

- Admin Providers quota-label sizing for long Codex Spark model names
- two-decimal finite Codex credit balances
- zero credit-balance suppression while preserving Unlimited display

## Verification

The feature PR passed `verify`, `e2e`, and `docker` CI checks before merge.
