### PR TITLE
feat(portal): align request detail viewers with admin

### DIFF
--- a/apps/gateway/src/routes/portal/index.test.ts
+++ b/apps/gateway/src/routes/portal/index.test.ts
@@ -101,7 +101,13 @@ function decision(overrides: Partial<DecisionRecord> = {}): DecisionRecord {
 
 type PortalTelemetry = Pick<
   TelemetryStore,
-  "aggregate" | "queryPage" | "getByRequestId" | "getApiKeyId" | "getPayload" | "getPayloadPart"
+  | "aggregate"
+  | "queryPage"
+  | "getByRequestId"
+  | "getApiKeyId"
+  | "getPayload"
+  | "getPayloadMeta"
+  | "getPayloadPart"
 >;
 
 function telemetry(over: Partial<PortalTelemetry> = {}): PortalTelemetry {
@@ -163,6 +169,13 @@ function telemetry(over: Partial<PortalTelemetry> = {}): PortalTelemetry {
         requestJson: '{"body":"of request"}',
         responseJson: '{"body":"of response"}',
         upstreamRequestJson: '{"body":"of upstream_request"}',
+        createdAt: new Date(1000),
+      };
+    },
+    async getPayloadMeta() {
+      return {
+        requestId: "trace_1",
+        parts: { request: true, response: true, upstreamRequest: true },
         createdAt: new Date(1000),
       };
     },
@@ -574,6 +587,51 @@ describe("portal API", () => {
         expect(res.status, part).toBe(200);
         expect(await res.text()).toContain(`of ${part}`);
       }
+    });
+
+    it("serves customer-safe payload metadata without revealing upstream availability", async () => {
+      const res = await buildApp(record()).request(
+        "/portal/api/requests/trace_1/payload?part=meta",
+        { headers: AUTH },
+      );
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({
+        captured: true,
+        created_at: 1000,
+        parts: { request: true, response: true },
+      });
+    });
+
+    it("keeps the metadata whitelist when an adapter falls back to the full payload read", async () => {
+      const tel = telemetry({ getPayloadMeta: undefined });
+      const res = await buildApp(record(), tel).request(
+        "/portal/api/requests/trace_1/payload?part=meta",
+        { headers: AUTH },
+      );
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(JSON.parse(body).parts).toEqual({ request: true, response: true });
+      expect(body).not.toContain("upstream");
+    });
+
+    it("checks ownership before reading payload metadata", async () => {
+      const reads: string[] = [];
+      const tel = telemetry({
+        async getApiKeyId() {
+          reads.push("owner");
+          return "someone_else";
+        },
+        async getPayloadMeta() {
+          reads.push("meta");
+          return null;
+        },
+      });
+      const res = await buildApp(record(), tel).request(
+        "/portal/api/requests/trace_1/payload?part=meta",
+        { headers: AUTH },
+      );
+      expect(res.status).toBe(404);
+      expect(reads).toEqual(["owner"]);
     });
 
     it("REJECTS the upstream_request part — supply chain, admin-only (R7)", async () => {

--- a/apps/gateway/src/routes/portal/index.ts
+++ b/apps/gateway/src/routes/portal/index.ts
@@ -1,6 +1,7 @@
 import type {
   KeyStore,
   RequestPayload,
+  RequestPayloadMeta,
   RequestPayloadPartRecord,
   TelemetryStore,
 } from "@helm/core";
@@ -24,7 +25,13 @@ export interface PortalApiDeps {
   keyStore: Pick<KeyStore, "updateKey">;
   telemetry: Pick<
     TelemetryStore,
-    "aggregate" | "queryPage" | "getByRequestId" | "getApiKeyId" | "getPayload" | "getPayloadPart"
+    | "aggregate"
+    | "queryPage"
+    | "getByRequestId"
+    | "getApiKeyId"
+    | "getPayload"
+    | "getPayloadMeta"
+    | "getPayloadPart"
   >;
   now?: () => number;
   // Map a stored served-model value (which is the internal wire `provider_model`,
@@ -199,19 +206,32 @@ export function registerPortalApi(app: Hono<AppEnv>, deps: PortalApiDeps): void 
     return c.json(toPortalDecisionView(rec));
   });
 
-  // GET /portal/api/requests/:traceId/payload?part=request|response — the caller's
-  // own request/response bodies. upstream_request is REJECTED (supply-chain, §4.3 R7).
+  // GET /portal/api/requests/:traceId/payload?part=meta|request|response — the caller's
+  // own request/response bodies. Metadata enables lazy loading without exposing the
+  // presence of upstream_request; that part stays rejected (supply-chain, §4.3 R7).
   app.get("/portal/api/requests/:traceId/payload", async (c) => {
     const identity = c.get("identity");
     const traceId = c.req.param("traceId");
     const part = c.req.query("part");
-    // Whitelist the two portal-visible parts. Reject BEFORE touching the store so
-    // upstream is never even read for a portal caller.
-    if (part !== "request" && part !== "response") {
-      return c.json({ error: "part must be 'request' or 'response'" }, 400);
+    // Whitelist metadata plus the two portal-visible parts. Reject BEFORE touching
+    // the store so upstream is never even read for a portal caller.
+    if (part !== "meta" && part !== "request" && part !== "response") {
+      return c.json({ error: "part must be 'meta', 'request', or 'response'" }, 400);
     }
     if ((await assertOwnsTrace(deps.telemetry, identity.keyId, traceId)) !== "ok") {
       return c.json({ error: "request not found" }, 404);
+    }
+    if (part === "meta") {
+      const meta = await getPortalPayloadMeta(deps, traceId);
+      if (!meta) return c.json({ captured: false });
+      return c.json({
+        captured: true,
+        created_at: meta.createdAt.getTime(),
+        parts: {
+          request: meta.parts.request,
+          response: meta.parts.response,
+        },
+      });
     }
     const p = await getPayloadPart(deps, traceId, part);
     if (!p) return c.json({ captured: false });
@@ -222,6 +242,24 @@ export function registerPortalApi(app: Hono<AppEnv>, deps: PortalApiDeps): void 
       created_at: p.createdAt.getTime(),
     });
   });
+}
+
+async function getPortalPayloadMeta(
+  deps: PortalApiDeps,
+  requestId: string,
+): Promise<RequestPayloadMeta | null> {
+  if (deps.telemetry.getPayloadMeta) return deps.telemetry.getPayloadMeta(requestId);
+  const payload = await deps.telemetry.getPayload(requestId);
+  if (!payload) return null;
+  return {
+    requestId: payload.requestId,
+    createdAt: payload.createdAt,
+    parts: {
+      request: payload.requestJson !== null,
+      response: payload.responseJson !== null,
+      upstreamRequest: false,
+    },
+  };
 }
 
 // Resolve each usage row to a public label and merge rows sharing it, so the

--- a/apps/portal/src/lib/api/portal.ts
+++ b/apps/portal/src/lib/api/portal.ts
@@ -95,6 +95,15 @@ export interface PayloadPart {
   created_at?: number;
 }
 
+export interface PayloadMeta {
+  captured: boolean;
+  created_at?: number;
+  parts?: {
+    request: boolean;
+    response: boolean;
+  };
+}
+
 export function getMe(): Promise<Me> {
   return apiGet<Me>("/me");
 }
@@ -159,5 +168,11 @@ export function getPayloadPart(
 ): Promise<PayloadPart> {
   return apiGet<PayloadPart>(
     `/requests/${encodeURIComponent(traceId)}/payload?part=${part}`,
+  );
+}
+
+export function getPayloadMeta(traceId: string): Promise<PayloadMeta> {
+  return apiGet<PayloadMeta>(
+    `/requests/${encodeURIComponent(traceId)}/payload?part=meta`,
   );
 }

--- a/apps/portal/src/lib/components/StreamViewer.svelte
+++ b/apps/portal/src/lib/components/StreamViewer.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import { t } from "$lib/i18n";
+  import { parseSseStream, type SseEventKind } from "$lib/sse";
+  import FullscreenToggle from "./FullscreenToggle.svelte";
+  import JsonTree from "./JsonTree.svelte";
+  import { VIEWER_FS_CONTAINER, viewerSizing } from "./viewerChrome";
+
+  type Tab = "assembled" | "chunks" | "raw";
+  const TABS: Tab[] = ["assembled", "chunks", "raw"];
+
+  let { raw, testid }: { raw: string; testid?: string } = $props();
+  let tab = $state<Tab>("assembled");
+  let fullscreen = $state(false);
+
+  const parsed = $derived(parseSseStream(raw));
+  const assembled = $derived(parsed.assembled);
+
+  function tabLabel(id: Tab): string {
+    return id === "assembled"
+      ? $t("Assembled")
+      : id === "chunks"
+        ? $t("Chunks")
+        : $t("Raw");
+  }
+
+  const KIND_BADGE: Record<SseEventKind, string> = {
+    reasoning: "badge-eval",
+    content: "badge-ok",
+    tool_call: "badge-rules",
+    finish: "badge-fallback",
+    meta: "badge-neutral",
+    done: "badge-neutral",
+    other: "badge-error",
+  };
+
+  function prettyArgs(args: string): string {
+    try {
+      return JSON.stringify(JSON.parse(args), null, 2);
+    } catch {
+      return args;
+    }
+  }
+
+  const tabActive = "border-action bg-action text-white";
+  const tabInactive = "border-border bg-surface text-ink-muted hover:bg-canvas";
+  const panelCls = $derived(
+    `${viewerSizing(fullscreen)} overflow-auto rounded bg-canvas p-2 font-mono text-xs text-ink-body`,
+  );
+</script>
+
+<div data-testid={testid} class={fullscreen ? VIEWER_FS_CONTAINER : ""}>
+  <div class="mb-2 flex flex-wrap items-center gap-2">
+    {#each TABS as id (id)}
+      <button
+        type="button"
+        class={`rounded border px-3 py-1 text-sm ${tab === id ? tabActive : tabInactive}`}
+        onclick={() => (tab = id)}>{tabLabel(id)}</button
+      >
+    {/each}
+    <div class="ml-auto">
+      <FullscreenToggle
+        bind:active={fullscreen}
+        testid="streamviewer-fullscreen"
+      />
+    </div>
+  </div>
+
+  <div
+    data-testid="streamviewer-assembled"
+    hidden={tab !== "assembled"}
+    class={`${viewerSizing(fullscreen)} overflow-auto`}
+  >
+    <div class="mb-2 flex flex-wrap items-center gap-2 text-xs">
+      {#if assembled.model}
+        <span class="badge-neutral font-mono">{assembled.model}</span>
+      {/if}
+      {#if assembled.finishReason}
+        <span class="badge-fallback"
+          >{$t("finish")}: {assembled.finishReason}</span
+        >
+      {/if}
+      <span class="text-ink-muted"
+        >{$t("{count} chunks", { count: parsed.events.length })}</span
+      >
+    </div>
+
+    {#if assembled.reasoning}
+      <details
+        data-testid="stream-reasoning"
+        class="mb-2 rounded bg-canvas p-2"
+      >
+        <summary class="cursor-pointer text-xs font-medium text-ink-muted">
+          {$t("Reasoning")} · {$t("{count} chars", {
+            count: assembled.reasoning.length,
+          })}
+        </summary>
+        <p class="mt-2 whitespace-pre-wrap text-xs text-ink-muted">
+          {assembled.reasoning}
+        </p>
+      </details>
+    {/if}
+
+    {#if assembled.content}
+      <div
+        data-testid="stream-final-content"
+        class="rounded bg-canvas p-3 text-sm leading-relaxed whitespace-pre-wrap text-ink-body"
+      >
+        {assembled.content}
+      </div>
+    {:else if assembled.toolCalls.length === 0}
+      <p class="text-sm italic text-ink-muted">
+        {$t("No visible output (stream carried no text content).")}
+      </p>
+    {/if}
+
+    {#if assembled.toolCalls.length > 0}
+      <div data-testid="stream-tool-calls" class="mt-2 flex flex-col gap-2">
+        {#each assembled.toolCalls as call, i (i)}
+          <div class="rounded bg-canvas p-2">
+            <div class="text-xs">
+              <span class="badge-rules">{$t("tool call")}</span>
+              <span class="ml-1 font-mono font-medium">{call.name}</span>
+              {#if call.id}<span class="ml-1 font-mono text-ink-muted"
+                  >{call.id}</span
+                >{/if}
+            </div>
+            <pre
+              class="mt-1 overflow-auto font-mono text-xs text-ink-body">{prettyArgs(
+                call.arguments,
+              )}</pre>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if assembled.usage}
+      <details class="mt-2 rounded bg-canvas p-2">
+        <summary class="cursor-pointer text-xs font-medium text-ink-muted">
+          {$t("Usage")}
+        </summary>
+        <pre
+          class="mt-1 overflow-auto font-mono text-xs text-ink-body">{JSON.stringify(
+            assembled.usage,
+            null,
+            2,
+          )}</pre>
+      </details>
+    {/if}
+  </div>
+
+  <div
+    data-testid="streamviewer-chunks"
+    hidden={tab !== "chunks"}
+    class={`${viewerSizing(fullscreen)} overflow-auto rounded bg-canvas`}
+  >
+    <ul class="divide-y divide-border/60">
+      {#each parsed.events as ev (ev.index)}
+        <li data-testid="stream-chunk-row">
+          <details>
+            <summary
+              class="flex cursor-pointer items-baseline gap-2 px-2 py-1 text-xs hover:bg-surface"
+            >
+              <span class="w-8 shrink-0 text-right font-mono text-ink-muted"
+                >{ev.index}</span
+              >
+              <span class={`${KIND_BADGE[ev.kind]} shrink-0`}>{ev.kind}</span>
+              <span class="min-w-0 flex-1 truncate font-mono text-ink-body"
+                >{ev.text || (ev.event ?? "")}</span
+              >
+            </summary>
+            <div class="bg-surface px-2 py-1 pl-12 font-mono text-xs">
+              {#if ev.data !== null}
+                <JsonTree value={ev.data} />
+              {:else}
+                <span class="text-ink-muted">{ev.raw}</span>
+              {/if}
+            </div>
+          </details>
+        </li>
+      {/each}
+    </ul>
+  </div>
+
+  <pre
+    data-testid="streamviewer-raw"
+    hidden={tab !== "raw"}
+    class={panelCls}>{raw}</pre>
+</div>

--- a/apps/portal/src/lib/components/imageData.test.ts
+++ b/apps/portal/src/lib/components/imageData.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { collectImages, imageDataUrl } from "./imageData";
+
+const PNG_1PX =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+describe("imageDataUrl", () => {
+  it("wraps raw image base64 and passes through image data URLs", () => {
+    const jpeg = `/9j/4AAQSkZJRgABAQ${"A".repeat(40)}`;
+    const gif = `R0lGODlhAQABAIAAAA${"A".repeat(40)}`;
+    const webp = `data:image/webp;base64,${"UklGRiQAAABXRUJQ".padEnd(48, "A")}`;
+    expect(imageDataUrl(PNG_1PX)).toBe(`data:image/png;base64,${PNG_1PX}`);
+    expect(imageDataUrl(jpeg)).toBe(`data:image/jpeg;base64,${jpeg}`);
+    expect(imageDataUrl(gif)).toBe(`data:image/gif;base64,${gif}`);
+    expect(imageDataUrl(webp)).toBe(webp);
+  });
+
+  it("rejects ordinary text, short strings, and non-strings", () => {
+    expect(imageDataUrl("hello world, this is a normal sentence.")).toBeNull();
+    expect(imageDataUrl("iVBORw0")).toBeNull();
+    expect(imageDataUrl(42)).toBeNull();
+    expect(imageDataUrl(null)).toBeNull();
+    expect(imageDataUrl({ data: PNG_1PX })).toBeNull();
+  });
+});
+
+describe("collectImages", () => {
+  const GIF = `R0lGODlhAQABAIAAAA${"A".repeat(40)}`;
+
+  it("finds a generated image nested in a Gemini response", () => {
+    const response = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ inlineData: { mimeType: "image/png", data: PNG_1PX } }],
+          },
+        },
+      ],
+    };
+    expect(collectImages(response)).toEqual([
+      {
+        url: `data:image/png;base64,${PNG_1PX}`,
+        path: "candidates.0.content.parts.0.inlineData.data",
+      },
+    ]);
+  });
+
+  it("preserves order, de-duplicates images, and caps the gallery", () => {
+    expect(
+      collectImages({ a: PNG_1PX, b: [GIF, GIF] }).map((image) => image.url),
+    ).toEqual([
+      `data:image/png;base64,${PNG_1PX}`,
+      `data:image/gif;base64,${GIF}`,
+    ]);
+
+    const many: Record<string, string> = {};
+    for (let i = 0; i < 50; i++) {
+      many[`k${i}`] = `data:image/png;base64,AAAA${i}${"B".repeat(40)}`;
+    }
+    expect(collectImages(many)).toHaveLength(24);
+  });
+
+  it("returns an empty list when the payload has no images", () => {
+    expect(collectImages({ hello: "world", nested: [1, 2] })).toEqual([]);
+    expect(collectImages("plain string")).toEqual([]);
+    expect(collectImages(null)).toEqual([]);
+  });
+});

--- a/apps/portal/src/lib/request-detail-media.test.ts
+++ b/apps/portal/src/lib/request-detail-media.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildMediaGroups } from "./request-detail-media";
+
+const PNG = `iVBORw0KGgo${"A".repeat(40)}`;
+const GIF = `R0lGODlhAQ${"B".repeat(40)}`;
+
+describe("buildMediaGroups", () => {
+  it("groups request images before response images", () => {
+    expect(buildMediaGroups({ image: PNG }, { image: GIF })).toEqual([
+      {
+        kind: "request",
+        images: [{ url: `data:image/png;base64,${PNG}`, path: "image" }],
+      },
+      {
+        kind: "response",
+        images: [{ url: `data:image/gif;base64,${GIF}`, path: "image" }],
+      },
+    ]);
+  });
+
+  it("omits empty groups and de-duplicates repeated images", () => {
+    expect(buildMediaGroups(null, { first: PNG, again: PNG })).toEqual([
+      {
+        kind: "response",
+        images: [{ url: `data:image/png;base64,${PNG}`, path: "first" }],
+      },
+    ]);
+    expect(buildMediaGroups(null, null)).toEqual([]);
+  });
+});

--- a/apps/portal/src/lib/request-detail-media.ts
+++ b/apps/portal/src/lib/request-detail-media.ts
@@ -1,0 +1,17 @@
+import { collectImages, type CollectedImage } from "./components/imageData";
+
+export interface RequestDetailMediaGroup {
+  kind: "request" | "response";
+  images: CollectedImage[];
+}
+
+export function buildMediaGroups(
+  request: unknown,
+  response: unknown,
+): RequestDetailMediaGroup[] {
+  const groups: RequestDetailMediaGroup[] = [
+    { kind: "request", images: collectImages(request) },
+    { kind: "response", images: collectImages(response) },
+  ];
+  return groups.filter((group) => group.images.length > 0);
+}

--- a/apps/portal/src/lib/request-detail-parity.test.ts
+++ b/apps/portal/src/lib/request-detail-parity.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const page = readFileSync(
+  new URL("../routes/requests/[traceId]/+page.svelte", import.meta.url),
+  "utf8",
+);
+const api = readFileSync(new URL("./api/portal.ts", import.meta.url), "utf8");
+
+describe("Portal request-detail parity", () => {
+  it("loads payload metadata first and heavy bodies only on demand", () => {
+    expect(api).toContain("getPayloadMeta");
+    expect(api).toContain("part=meta");
+    expect(page).toContain("getPayloadMeta");
+    expect(page).toContain('data-testid="load-conversation"');
+    expect(page).toContain('data-testid="load-request-body"');
+    expect(page).toContain('data-testid="load-response-body"');
+    expect(page.match(/if \(traceId !== id\) return/g)).toHaveLength(4);
+  });
+
+  it("uses the Admin-grade image gallery and stream-aware response viewer", () => {
+    expect(page).toContain("buildMediaGroups");
+    expect(page).toContain("ImagePreview");
+    expect(page).toContain('data-testid="media-overview"');
+    expect(page).toContain('data-testid="media-group"');
+    expect(page).toContain('variant="thumb"');
+    expect(page).toContain("isSseStream");
+    expect(page).toContain("StreamViewer");
+  });
+
+  it("keeps provider-forwarded payloads outside the Portal boundary", () => {
+    expect(page).not.toContain("upstream_request");
+    expect(api).not.toContain('part: "upstream_request"');
+  });
+});

--- a/apps/portal/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/portal/src/routes/requests/[traceId]/+page.svelte
@@ -1,60 +1,127 @@
 <script lang="ts">
   import { base } from "$app/paths";
   import { page } from "$app/stores";
-  import { t } from "$lib/i18n";
-  import { formatUsd, formatTokens } from "$lib/format";
-  import Conversation from "$lib/components/Conversation.svelte";
-  import JsonViewer from "$lib/components/JsonViewer.svelte";
-  import TokenUsage from "$lib/components/TokenUsage.svelte";
-  import CostBreakdown from "$lib/components/CostBreakdown.svelte";
-  import { toTokenUsageView } from "$lib/api/requests";
   import {
-    getRequestDetail,
+    getPayloadMeta,
     getPayloadPart,
+    getRequestDetail,
+    type PayloadMeta,
     type PortalRequestDetail,
   } from "$lib/api/portal";
+  import { toTokenUsageView } from "$lib/api/requests";
+  import Conversation from "$lib/components/Conversation.svelte";
+  import CostBreakdown from "$lib/components/CostBreakdown.svelte";
+  import ImagePreview from "$lib/components/ImagePreview.svelte";
+  import JsonViewer from "$lib/components/JsonViewer.svelte";
+  import StreamViewer from "$lib/components/StreamViewer.svelte";
+  import TokenUsage from "$lib/components/TokenUsage.svelte";
+  import { t } from "$lib/i18n";
+  import { buildMediaGroups } from "$lib/request-detail-media";
+  import { isSseStream } from "$lib/sse";
+
+  type PayloadPartName = "request" | "response";
+  type PartStatus = "idle" | "loading" | "loaded" | "error";
 
   const traceId = $derived($page.params.traceId);
 
   let detail = $state<PortalRequestDetail | null>(null);
-  let requestBody = $state<unknown>(null);
-  let responseBody = $state<unknown>(null);
+  let payloadMeta = $state<PayloadMeta>({ captured: false });
+  let payloadValues = $state<Partial<Record<PayloadPartName, unknown>>>({});
+  let payloadStatus = $state<Record<PayloadPartName, PartStatus>>({
+    request: "idle",
+    response: "idle",
+  });
+  let payloadErrors = $state<Partial<Record<PayloadPartName, string>>>({});
   let loading = $state(true);
   let notFound = $state(false);
   let error = $state("");
-
-  // Two lenses over the captured body: Conversation (a readable user⇄agent
-  // transcript folding request + response, default) and Raw (the JSON tree —
-  // source of truth). Mirrors the admin detail page. The response panel is
-  // raw-only, since the transcript already includes the reply.
   let reqView = $state<"chat" | "raw">("chat");
 
-  async function load(id: string) {
+  function resetPayloadState(): void {
+    payloadMeta = { captured: false };
+    payloadValues = {};
+    payloadStatus = { request: "idle", response: "idle" };
+    payloadErrors = {};
+  }
+
+  async function load(id: string): Promise<void> {
     loading = true;
     notFound = false;
     error = "";
+    detail = null;
+    resetPayloadState();
     try {
-      detail = await getRequestDetail(id);
-      // Payload is best-effort — capture may be off, or pruned.
-      const [req, resp] = await Promise.all([
-        getPayloadPart(id, "request").catch(() => null),
-        getPayloadPart(id, "response").catch(() => null),
+      const [nextDetail, nextMeta] = await Promise.all([
+        getRequestDetail(id),
+        getPayloadMeta(id).catch((): PayloadMeta => ({ captured: false })),
       ]);
-      requestBody = req?.value ?? null;
-      responseBody = resp?.value ?? null;
+      if (traceId !== id) return;
+      detail = nextDetail;
+      payloadMeta = nextMeta;
     } catch (e) {
+      if (traceId !== id) return;
       if (e instanceof Error && e.message.includes("404")) notFound = true;
       else error = e instanceof Error ? e.message : "load failed";
     } finally {
-      loading = false;
+      if (traceId === id) loading = false;
     }
   }
+
   $effect(() => {
     if (traceId) void load(traceId);
   });
 
-  // Portal shows only the user's total cost — eval/routing self-cost stays null
-  // (supply-chain economics, §4.3).
+  function hasPayloadPart(part: PayloadPartName): boolean {
+    return payloadMeta.captured === true && payloadMeta.parts?.[part] === true;
+  }
+
+  async function loadPayloadPart(part: PayloadPartName): Promise<unknown> {
+    const id = traceId;
+    if (!id) return null;
+    if (!hasPayloadPart(part)) return null;
+    if (payloadStatus[part] === "loaded") return payloadValues[part];
+    if (payloadStatus[part] === "loading") return null;
+
+    payloadStatus[part] = "loading";
+    payloadErrors[part] = undefined;
+    try {
+      const result = await getPayloadPart(id, part);
+      if (traceId !== id) return null;
+      if (result.captured !== true || result.part !== part) {
+        payloadStatus[part] = "error";
+        payloadErrors[part] = $t("Payload was not available.");
+        return null;
+      }
+      payloadValues[part] = result.value ?? null;
+      payloadStatus[part] = "loaded";
+      return payloadValues[part];
+    } catch (e) {
+      if (traceId !== id) return null;
+      payloadStatus[part] = "error";
+      payloadErrors[part] =
+        e instanceof Error ? e.message : $t("Payload was not available.");
+      return null;
+    }
+  }
+
+  async function loadConversation(): Promise<void> {
+    await Promise.all([
+      loadPayloadPart("request"),
+      hasPayloadPart("response")
+        ? loadPayloadPart("response")
+        : Promise.resolve(null),
+    ]);
+  }
+
+  const requestLoaded = $derived(payloadStatus.request === "loaded");
+  const responseLoaded = $derived(payloadStatus.response === "loaded");
+  const mediaGroups = $derived(
+    buildMediaGroups(
+      requestLoaded ? payloadValues.request : null,
+      responseLoaded ? payloadValues.response : null,
+    ),
+  );
+
   const costView = $derived(
     detail
       ? {
@@ -81,7 +148,6 @@
   <h1 class="page-title mb-1 mt-2">{$t("Request")}</h1>
   <p class="section-desc mb-4 font-mono text-xs">{detail.request_id}</p>
 
-  <!-- Result summary (lane/result view only — no supply chain, §4.3) -->
   <div class="card mb-4 grid grid-cols-2 gap-3 md:grid-cols-4">
     <div>
       <div class="section-desc">{$t("Model")}</div>
@@ -121,52 +187,160 @@
     {/if}
   </div>
 
-  <!-- The user's own request/response bodies (their data; §4.3). Each panel
-       toggles between the Conversation transcript and the Raw JSON viewer. -->
-  {#snippet viewToggle(
-    current: "chat" | "raw",
-    set: (v: "chat" | "raw") => void,
-    idPrefix: string,
-  )}
-    <div class="mb-3 flex flex-wrap items-center gap-2">
-      <button
-        type="button"
-        data-testid={`${idPrefix}-view-chat`}
-        class={`rounded border px-3 py-1 text-sm ${current === "chat" ? "border-action bg-action text-white" : "border-border bg-surface text-ink-muted hover:bg-canvas"}`}
-        onclick={() => set("chat")}>{$t("Conversation")}</button
-      >
-      <button
-        type="button"
-        data-testid={`${idPrefix}-view-raw`}
-        class={`rounded border px-3 py-1 text-sm ${current === "raw" ? "border-action bg-action text-white" : "border-border bg-surface text-ink-muted hover:bg-canvas"}`}
-        onclick={() => set("raw")}>{$t("Raw")}</button
-      >
-    </div>
-  {/snippet}
+  {#if mediaGroups.length > 0}
+    <section data-testid="media-overview" class="card mt-4 text-sm">
+      <h2 class="section-header">{$t("Images")}</h2>
+      <p class="field-help mb-3">
+        {$t(
+          "All images sent in the request and returned in the response — click any to view full size.",
+        )}
+      </p>
+      <div class="flex flex-col gap-4">
+        {#each mediaGroups as group (group.kind)}
+          <div data-testid="media-group">
+            <p
+              class="mb-2 text-xs font-medium uppercase tracking-wide text-ink-muted"
+            >
+              {group.kind === "request" ? $t("Request") : $t("Response")}
+            </p>
+            <div class="flex flex-wrap gap-3">
+              {#each group.images as image (image.url)}
+                <ImagePreview
+                  src={image.url}
+                  label={`${group.kind === "request" ? $t("Request") : $t("Response")} · ${image.path}`}
+                  variant="thumb"
+                />
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
 
-  {#if requestBody !== null || responseBody !== null}
-    <!-- Request: Conversation (chat) ⇄ Raw JSON. Chat lens folds the whole
-         transcript (request + reply), matching admin. -->
-    <section class="card mt-4">
-      <h2 class="section-header mb-3">{$t("Request")}</h2>
-      {@render viewToggle(reqView, (v) => (reqView = v), "request")}
+  <section class="card mt-4 text-sm">
+    <h2 class="section-header">{$t("Request")}</h2>
+    {#if payloadMeta.captured && hasPayloadPart("request")}
+      <p class="field-help mb-2">
+        {$t(
+          "Payload capture is available for this call. Large bodies are loaded on demand.",
+        )}
+      </p>
+      <div class="mb-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          data-testid="request-view-chat"
+          class={`rounded border px-3 py-1 text-sm ${reqView === "chat" ? "border-action bg-action text-white" : "border-border bg-surface text-ink-muted hover:bg-canvas"}`}
+          onclick={() => (reqView = "chat")}>{$t("Conversation")}</button
+        >
+        <button
+          type="button"
+          data-testid="request-view-raw"
+          class={`rounded border px-3 py-1 text-sm ${reqView === "raw" ? "border-action bg-action text-white" : "border-border bg-surface text-ink-muted hover:bg-canvas"}`}
+          onclick={() => (reqView = "raw")}>{$t("Raw")}</button
+        >
+      </div>
+
       {#if reqView === "chat"}
-        <Conversation request={requestBody} response={responseBody} />
+        {#if !requestLoaded || (hasPayloadPart("response") && !responseLoaded)}
+          <div class="rounded border border-dashed border-border bg-canvas p-3">
+            <p class="field-help mb-2">
+              {$t(
+                "Load the captured request and response only when you need the transcript.",
+              )}
+            </p>
+            <button
+              type="button"
+              data-testid="load-conversation"
+              class="btn-secondary"
+              disabled={payloadStatus.request === "loading" ||
+                payloadStatus.response === "loading"}
+              onclick={loadConversation}
+              >{payloadStatus.request === "loading" ||
+              payloadStatus.response === "loading"
+                ? $t("Loading")
+                : $t("Load conversation")}</button
+            >
+            {#if payloadErrors.request || payloadErrors.response}
+              <p class="mt-2 text-sm text-red-600">
+                {payloadErrors.request ?? payloadErrors.response}
+              </p>
+            {/if}
+          </div>
+        {:else}
+          <Conversation
+            request={payloadValues.request}
+            response={payloadValues.response}
+            testid="conversation"
+          />
+        {/if}
+      {:else if !requestLoaded}
+        <div class="rounded border border-dashed border-border bg-canvas p-3">
+          <p class="field-help mb-2">
+            {$t("Load the raw request body only when you need to inspect it.")}
+          </p>
+          <button
+            type="button"
+            data-testid="load-request-body"
+            class="btn-secondary"
+            disabled={payloadStatus.request === "loading"}
+            onclick={() => loadPayloadPart("request")}
+            >{payloadStatus.request === "loading"
+              ? $t("Loading")
+              : $t("Load request body")}</button
+          >
+          {#if payloadErrors.request}
+            <p class="mt-2 text-sm text-red-600">{payloadErrors.request}</p>
+          {/if}
+        </div>
       {:else}
-        <JsonViewer value={requestBody} testid="request-body" />
+        <JsonViewer value={payloadValues.request} testid="request-body" />
+      {/if}
+    {:else}
+      <div class="empty-state">
+        {$t("No request body was captured for this request.")}
+      </div>
+    {/if}
+  </section>
+
+  {#if payloadMeta.captured && hasPayloadPart("response")}
+    <section class="card mt-4 text-sm">
+      <h2 class="section-header">{$t("Response")}</h2>
+      {#if !responseLoaded}
+        <div class="rounded border border-dashed border-border bg-canvas p-3">
+          <p class="field-help mb-2">
+            {$t(
+              "Load the full response body only when you need to inspect it.",
+            )}
+          </p>
+          <button
+            type="button"
+            data-testid="load-response-body"
+            class="btn-secondary"
+            disabled={payloadStatus.response === "loading"}
+            onclick={() => loadPayloadPart("response")}
+            >{payloadStatus.response === "loading"
+              ? $t("Loading")
+              : $t("Load response body")}</button
+          >
+          {#if payloadErrors.response}
+            <p class="mt-2 text-sm text-red-600">{payloadErrors.response}</p>
+          {/if}
+        </div>
+      {:else if isSseStream(payloadValues.response)}
+        <p class="field-help mb-2">
+          {$t("Streaming response — assembled from the recorded SSE stream.")}
+        </p>
+        <StreamViewer
+          raw={payloadValues.response as string}
+          testid="response-body"
+        />
+      {:else}
+        <p class="field-help mb-2">
+          {$t("Full response body recorded for this call.")}
+        </p>
+        <JsonViewer value={payloadValues.response} testid="response-body" />
       {/if}
     </section>
-
-    <!-- Response: raw payload only (the reply is already in the chat lens above). -->
-    {#if responseBody !== null}
-      <section class="card mt-4">
-        <h2 class="section-header mb-3">{$t("Response")}</h2>
-        <JsonViewer value={responseBody} testid="response-body" />
-      </section>
-    {/if}
-  {:else}
-    <div class="card empty-state mt-4">
-      {$t("No request body was captured for this request.")}
-    </div>
   {/if}
 {/if}

--- a/docs/12-self-service-portal.md
+++ b/docs/12-self-service-portal.md
@@ -107,7 +107,7 @@
 | 2 | `GET /portal/api/usage/stats` | `aggregate(..., identity.keyId)`，**透出 series+byModel+budget**（复用/alias 现有 `/v1/usage/stats`，补透被丢弃的字段） | `TelemetryStore.aggregate` + `identity.caps.budget` | MVP |
 | 3 | `GET /portal/api/requests` | `queryPage({...filters, apiKeyId: identity.keyId})`，apiKeyId 写死 | `TelemetryStore.queryPage` | 迭代 2 |
 | 4 | `GET /portal/api/requests/:traceId` | **先 ownership 校验**（§4.4）→ `getByRequestId` → **白名单脱敏投影**（§4.3） | `getApiKeyId` + `getByRequestId` | 迭代 2 |
-| 5 | `GET /portal/api/requests/:traceId/payload` | **先 ownership 校验** → 取正文，**白名单 `part ∈ {request,response}`，拒 upstream** | `getApiKeyId` + `getPayloadMeta/getPayloadPart` | 迭代 2 |
+| 5 | `GET /portal/api/requests/:traceId/payload` | **先 ownership 校验** → `part=meta` 只回显 request/response 可用性，正文白名单 `part ∈ {request,response}`，**拒 upstream** | `getApiKeyId` + `getPayloadMeta/getPayloadPart` | 迭代 2 |
 | 6 | memory CRUD | **优先前端直接打 `POST /mcp`（零新后端）**；若必须 REST，则 `accountId: identity.accountId` + `projectId: identity.caps.memory.projectId` 全写死，逐字复用 MCP 隔离不变量，**绝不照搬 `/admin/api/memory/*`**（query 参数寻址 = 破隔离） | MCP tools / `MemoryStore` | 迭代 3 |
 | 7 | `PATCH /portal/api/memory-settings` | 严格只收 `memory_mode` / `memory_project_id` / `memory_thread_source`；更新目标写死 `identity.keyId`；root key 拒绝 | `KeyStore.updateKey` | 迭代 4 |
 
@@ -127,7 +127,7 @@ memory REST（仅当 MCP 未启用/需 REST 语义时）：`GET /portal/api/memo
 | Retry/replay | ❌ 砍 | 特权写操作 |
 
 - 折中：可给一行**脱敏「路由结果」**——「已路由至 `<served model>`（lane: balanced），耗时 1.2s」（served model 用户本就能从响应看到）。**不复用整个 `DecisionChain.svelte`**，只复用正文/token/cost 查看器。
-- **payload 端点**：默认只暴露 `request`+`response` 两段，**过滤 `upstream` 段**（供应链细节，admin 才看）。
+- **payload 端点**：只暴露 `request`+`response` 两段；`part=meta` 仅返回这两段的 availability flags，**不返回或暗示 `upstream` 段是否存在**（供应链细节，admin 才看）。
 
 **用量成本**：**显示 `$` 花费**（自托管场景成本透明是信任基石，是给自己人看真实消耗）。**不显示** provider 成本明细/内部计价/markup（principle 6）。额度用**进度条 + 剩余量 + 超支行为 + 重置时间**呈现；无预算上限显示「无限制」。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-11 · Portal 请求详情对齐 Admin 查看器但保持供应链边界（Self-Service Portal / Requests，docs/12，原则 1/6/7/8）
+
+- **对齐范围**：Portal 请求详情复用本地已有的 Conversation / JsonViewer / ImagePreview，并移植 Admin 的 StreamViewer。请求/响应正文按 Admin 模式改为 metadata-first、用户打开时才分段加载；SSE 响应提供 Assembled / Chunks / Raw 三种视图，普通 JSON 继续提供 Tree / Formatted / Raw 与全屏。
+- **图片总览**：只扫描 bearer key 已获授权的 request/response 正文，按 Request、Response 分组显示缩略图；点击沿用 ImagePreview 的放大、缩放、1:1、适配与新标签页能力。图片遍历保持深度 24、总数 24、URL 去重上限，避免大正文生成无界 DOM/解码工作。
+- **性能与失败语义**：新增 `part=meta`，只返回 `{request,response}` availability flags；ownership 必须在 metadata/store read 前验证。单段加载失败只影响对应 viewer，不让详情摘要白屏；trace 切换时丢弃旧异步结果，避免跨详情串数据。
+- **安全边界**：没有照搬 Admin 的原始 `upstream_request`。该正文包含协议翻译结果、wire model 与注入后的 Memory 上下文，继续由 R7 在 store read 前拒绝。Portal metadata 也不得返回或暗示 upstream 是否存在；若未来要展示“模型实际看到的内容”，必须新增服务端白名单规范化投影，不能放开原始 part。
+- **验证**：TDD 增加 Portal payload meta ownership/whitelist/fallback 测试、图片 sniff/遍历/去重/上限测试、media-group 纯函数和页面组合 contract；再运行 Portal/Gateway tests、svelte-check、typecheck、lint/build 与真实浏览器交互检查。
+
 ## 2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）
 
 - **授权边界**：新增 `PATCH /portal/api/memory-settings`，只接受严格的 `memory_mode`、`memory_project_id` 与 `memory_thread_source`；目标 key 始终取 bearer identity 的 `keyId`，不能提交 `key_id/account_id`，也不能借此修改 lane、预算或限流。管理面 root key 继续强制只读、保持 memory inert。`memory_thread_source` 在服务端 schema 保持 optional，仅用于兼容仍打开着的 v0.26.16/17 旧 SPA；新 UI 始终显式发送。
@@ -105,24 +113,13 @@
 - **覆盖面**：OpenAI Chat 的自有 persist 路径和 `recordServed` 共享路径都覆盖；Messages / Responses / Gemini / Images / Interactions 都传入 request timeout state，防止协议面漂移。
 - **验证路径**：新增 timeout context 与 late-success telemetry 测试；覆盖 app/limits/chat/messages/responses/gemini/images/interactions/payload-capture targeted tests，并跑 gateway typecheck。
 
-## 2026-07-06 · API key 绝对模型黑名单（Key governance / routing / Admin keys，docs/04/06/11，原则 5/6/7）
-
-- **背景（Lukin）**：每个 API key 需要能禁止若干具体模型，语义是“这个用户无论通过 direct model、显式 lane、auto/classified lane、alias-to-lane 还是 execution fallback，都不能实际用到这些模型”。
-- **产品边界**：`blocked_models` 是具体模型 denylist，不是 lane denylist。请求若直接点名被禁的具体模型，立即返回结构化 `invalid_request`；请求若点名 lane 或走自动路由，则在执行前从 expanded candidate chain 中剥离被禁模型，fallback 会自然跳过它们。Chat/Messages/Responses/Gemini 走 `routeRequest`，Images/Interactions 入口在各自 image chain 执行前应用同一过滤。
-- **空链处理**：如果某个 lane 的所有候选都被当前 key 的 `blocked_models` 剥空，路由阶段直接返回 `invalid_request`，不进入 provider executor，也不把它伪装成 provider failure。Routing signal feedback 也会跳过被黑名单剥空的提升目标，避免把本来可用的 lane 误提升成拒绝。
-- **匹配语义**：`blocked_models` 每项先 `trim`，匹配时大小写不敏感；普通文本是精确模型 ID，包含 `*` 或 `?` 时按 glob 处理（`*` 任意长度，`?` 单个字符，正则特殊字符按字面量）。不按 provider 前缀隐式扩展；`auto`、空模型、lane 名本身不会作为模型命中，lane 内的具体模型 alias 会被过滤。
-- **数据与迁移**：API key schema 增加 nullable `blocked_models`；create/update 支持设置与清空。SQLite v38 用 JSON text，Postgres v37 用 JSONB；两个 store adapter 都做 round-trip，并保持旧 row 默认 `null`。
-- **可见性与 UI**：`/v1/models` 会按当前 key 隐藏被 block 的 concrete alias；若某 lane 过滤后没有任何可用候选，该 lane 也不展示。Admin keys 的共享 caps form 始终展示多行 `Blocked models` 输入，独立于 `allow_custom_model`，支持换行、逗号、分号分隔并去重。
-- **验证路径**：覆盖 shared schema、direct reject、classified/explicit/alias lane chain filtering、routing signal 提升过滤、空链拒绝、models list 过滤、SQLite/Postgres store contract、gateway auth/admin/chat/messages/replay/models threading，以及 admin create/edit/list 表单映射。
-
 ## 历史条目摘要（最近 5 条）
 
+- **2026-07-06 · API key 绝对模型黑名单（Key governance / routing / Admin keys，docs/04/06/11，原则 5/6/7）**：每把 key 的 exact/glob `blocked_models` 同时约束 direct、lane expansion、fallback、model list 与各协议入口，空链 fail-closed，SQLite/Postgres 与 Admin 表单保持一致。
 - **2026-07-06 · 折叠会话行显示工具调用参数预览（Admin requests / conversation view，docs/11，原则 1）**：工具参数预览改为 whitelist-free，按 args 形状泛化提取 readable scalar，覆盖自定义/大小写不同工具并保留展开详情。
 - **2026-07-06 · 配额 PULL 的 100% 账号级窗口必须同步停车（OAuth provider pool / Admin providers，docs/04/11，原则 3/5/7）**：quota PULL 看到账号级 100% 窗口时立即写入 cooldown 并同步 live pool，scoped model 窗口不扩大成全账号停车。
 - **2026-07-05 · OAuth 凭证失效持久化为 needs reconnect（OAuth provider pool / Admin providers，docs/04/11，原则 3/5/7）**：refresh/持久 upstream 400/401/403 标记 credential failure、写入账号设置并摘出调度，reconnect 成功后按手动/自动停车边界恢复。
 - **2026-07-05 · 避免浪费策略纳入周额度与 Codex reset credits（OAuth provider pool / quota，docs/04/11，原则 3/5/7）**：`use_expiring` 汇总短窗口、周额度与 reset credits 软评分，quota PULL 会刷新 live pool snapshot 但不自动消费 credit。
-- **2026-07-05 · Codex reset-credit 消费改为硬门禁（OAuth quota / Admin providers，docs/04/11，原则 3/5/7）**：手动/自动 reset credit 必须命中 weekly secondary 阈值与持久 guard，缺少 snapshot 时 fail-closed，避免烧稀缺额度。
-
 ## 更早历史总览
 
 2026-07-06 压缩条目还包括 Anthropic native passthrough 稳定 Claude Code billing `cch`、Admin 模型搜索预计算列、payload 分段懒加载、纯工具 turn 去空 header/默认展开，以及 Claude Code 风格 inline tool peek。2026-07-04 更早条目还包括 cheap-model 当前轮低风险降级、视觉上下文压缩 observe/off 接入、Memory stats 队列索引优化、OAuth 会话亲和调度、idle-flush 碎片段优先压缩最大连续段、memory worker 受控并发追赶、记忆页只读运行状态面板、Claude scoped weekly quota 只影响对应模型、跨协议 reasoning-history 候选级跳过、memory idle-flush 防饥饿、策略级 reasoning_effort 覆盖 lane 默认值、cron monitor 低成本规则等。2026-06-30 及以前的工作主要围绕 Helm API 的协议面、路由执行、admin 可观测性与自托管部署逐步成型：补齐 Gemini/OpenAI/Anthropic/Responses 双向转换、SSE 流式正确性、tool-call/JSON schema/思考参数保真、per-model reasoning effort、模型别名与能力/成本目录、provider fallback 与熔断语义、OAuth subscription providers、多账户池与 quota 处理、memory observe/inject/forgetting/admin/MCP、请求 payload 捕获与 request detail UI、API key 治理、admin 表格/过滤/分页/i18n、Docker/CI/release/deploy 验证，以及早期 Phase 0 的 Hono + SvelteKit static admin + Store 端口 + SQLite/Supabase 架构决策。更早细节不再逐条保留在本文件；需要精确背景时回查 git history。


### PR DESCRIPTION
## Summary
- add lazy Portal request/response payload loading with customer-safe metadata
- port Admin conversation, SSE stream, fullscreen, and image-browser experiences
- preserve Portal ownership and R7 supply-chain boundaries

## Verification
- focused Portal/Gateway tests: 32 passed
- portal svelte-check: 0 errors, 0 warnings
- workspace typecheck
- lint and production build
- interactive browser verification for image zoom/fit, stream tabs, fullscreen/Escape, and console errors