### PR TITLE
chore: release v0.26.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.20",
+  "version": "0.26.21",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API package version to 0.26.21
- publish the Portal request-detail parity release

## Included
- PR #528