### PR TITLE
chore: release v0.26.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.21",
+  "version": "0.26.22",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release v0.26.22

This release includes:

- Claude-compatible context-overflow signaling for reactive compaction
- account-level automatic subscription model discovery with bounded shared caching
- retirement of GPT-5.3-Codex-Spark model and quota surfaces while retaining the classifier marker
- complete Claude Sonnet 5 API-equivalent capability and pricing metadata

Feature PR: #530

The publish workflow will create tag v0.26.22, the GitHub Release, and GHCR latest, 0.26.22, and SHA image tags after merge.