### PR TITLE
fix(admin): reconcile Codex plan labels

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -744,6 +744,10 @@
             {@const usage = usageByKey.get(k)}
             {@const isCodex = row.provider.id === 'openai-codex'}
             {@const quota = isCodex ? activeCodexQuota(quotaByKey.get(k)) : quotaByKey.get(k)}
+            <!-- The live WHAM quota plan can change before the OAuth identity claim refreshes. -->
+            {@const codexPlanType = isCodex
+              ? (quota?.planType ?? row.account.chatgptPlanType)
+              : undefined}
             {@const saving = savingSchedule[k] === true}
             {@const supportsFast =
               row.provider.id === 'anthropic' || row.provider.id === 'openai-codex'}
@@ -768,7 +772,7 @@
               isCodex &&
               Boolean(
                 row.account.email ||
-                row.account.chatgptPlanType ||
+                codexPlanType ||
                 row.account.chatgptAccountId ||
                 row.account.isFedramp,
               )}
@@ -785,11 +789,10 @@
                     {#if row.account.email}
                       <span class="break-all text-ink-body">{row.account.email}</span>
                     {/if}
-                    {#if row.account.chatgptPlanType || row.account.isFedramp}
+                    {#if codexPlanType || row.account.isFedramp}
                       <div class="flex flex-wrap gap-1">
-                        {#if row.account.chatgptPlanType}
-                          <span class="badge-neutral">{planLabel(row.account.chatgptPlanType)}</span
-                          >
+                        {#if codexPlanType}
+                          <span class="badge-neutral">{planLabel(codexPlanType)}</span>
                         {/if}
                         {#if row.account.isFedramp}
                           <span class="badge-neutral">{$t('FedRAMP')}</span>

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -207,6 +207,50 @@ describe('providers page', () => {
     expect(within(details).getByText('FedRAMP')).toBeInTheDocument();
   });
 
+  it('prefers the live Codex quota plan over a stale identity plan', () => {
+    renderPage({
+      providers: [
+        provider({
+          id: 'openai-codex',
+          name: 'ChatGPT Plus/Pro (Codex)',
+          accounts: [
+            {
+              account: 'acct-codex',
+              chatgptPlanType: 'pro',
+              expiresAt: null,
+              updatedAt: Date.now(),
+              healthy: true,
+              priority: 50,
+              schedulable: true,
+              proxy: null,
+              models: ['gpt-5.6-sol'],
+            },
+          ],
+        }),
+      ],
+      usage: [],
+      quota: [
+        {
+          providerId: 'openai-codex',
+          account: 'acct-codex',
+          windows: [],
+          capturedAt: Date.now(),
+          source: 'codex',
+          usageLimitedUntilMs: null,
+          resetCredits: null,
+          planType: 'plus',
+        },
+      ],
+    });
+
+    const row = screen.getByTestId('provider-account-row');
+    const details = within(row).getByTestId('codex-subscription-details');
+    const quotaCell = within(row).getByTestId('provider-quota-cell');
+    expect(within(details).getByText('Plus')).toBeInTheDocument();
+    expect(within(details).queryByText('Pro')).not.toBeInTheDocument();
+    expect(within(quotaCell).getByText('Plan: Plus')).toBeInTheDocument();
+  });
+
   it('does not reserve subscription-detail space when Codex claims are absent', () => {
     renderPage({
       providers: [


### PR DESCRIPTION
## Summary

- prefer the live Codex quota plan when it disagrees with the cached OAuth identity claim
- retain the identity claim as a fail-open fallback when quota metadata is unavailable
- add a regression test for the exact `Pro` badge / `Plan: Plus` mismatch

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm --filter @helm/admin check`
- focused provider-page suite: 41/41 tests passed