### PR TITLE
chore(release): v0.26.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.22",
+  "version": "0.26.23",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- release xAI SuperGrok OAuth subscription provider integration
- bump Helm API version to 0.26.23

## Validation

- feature PR #532 CI: verify, e2e, docker all passed
- release diff is version-only