### PR TITLE
fix(admin): show xAI models in lane picker

### DIFF
--- a/apps/gateway/src/oauth/effective-models.test.ts
+++ b/apps/gateway/src/oauth/effective-models.test.ts
@@ -14,7 +14,7 @@ import {
 } from "./effective-models.js";
 
 const KEY = Buffer.alloc(32, 7);
-const ROUTABLE = new Set(["anthropic", "github-copilot", "openai-codex"]);
+const ROUTABLE = new Set(["anthropic", "github-copilot", "openai-codex", "xai"]);
 
 function makeStores(): { tokens: SqliteOAuthTokenStore; config: SqliteConfigStore } {
   const db = createSqliteDb(":memory:");
@@ -83,6 +83,10 @@ describe("effectiveAccountModels", () => {
     ]);
   });
 
+  it("offers the verified xAI catalog when a bound account stays in auto mode", () => {
+    expect(effectiveAccountModels({}, "xai")).toEqual(["grok-4.5", "grok-composer-2.5-fast"]);
+  });
+
   it("returns [] for an unknown provider with no curated set + no enabled list", () => {
     expect(effectiveAccountModels({}, "mystery")).toEqual([]);
   });
@@ -99,6 +103,18 @@ describe("effectiveAccountModels", () => {
 });
 
 describe("effectiveOAuthAliases", () => {
+  it("exposes xAI auto-mode aliases to the Lanes model picker", async () => {
+    const { tokens, config } = makeStores();
+    await bind(tokens, "xai", "mylukin");
+
+    await expect(
+      effectiveOAuthModelOptions({ store: tokens, encKey: KEY }, config, ROUTABLE),
+    ).resolves.toEqual([
+      { alias: "xai/grok-4.5", accounts: ["mylukin"] },
+      { alias: "xai/grok-composer-2.5-fast", accounts: ["mylukin"] },
+    ]);
+  });
+
   it("emits provider/model aliases for every bound account's effective set, deduped + sorted", async () => {
     const { tokens, config } = makeStores();
     await bind(tokens, "anthropic", "default");

--- a/apps/gateway/src/oauth/effective-models.ts
+++ b/apps/gateway/src/oauth/effective-models.ts
@@ -36,6 +36,16 @@ export interface OAuthRuntimeCtxLike {
   encKey: Buffer;
 }
 
+// Network-free suggestions for a BOUND subscription account. xAI deliberately
+// stays out of core's CURATED_OAUTH_MODELS: runtime pool synthesis must continue
+// to fail closed when its live `/models` entitlement discovery has no result.
+// The picker fallback only repairs the Admin projection for the two models Helm
+// has already verified through the authenticated Grok CLI catalog.
+const ACCOUNT_MODEL_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
+  ...CURATED_OAUTH_MODELS,
+  xai: ["grok-4.5", "grok-composer-2.5-fast"],
+};
+
 // The effective enabled models for ONE account (no network): the saved
 // `enabledModels` verbatim, else the provider's curated fallback (else []).
 export function effectiveAccountModels(
@@ -45,7 +55,7 @@ export function effectiveAccountModels(
   if (providerId === "openai-codex") return [];
   return resolveAccountModelsMode(providerId, settings) === "manual"
     ? (settings.enabledModels ?? [])
-    : (CURATED_OAUTH_MODELS[providerId] ?? []);
+    : [...(ACCOUNT_MODEL_FALLBACKS[providerId] ?? [])];
 }
 
 // Every routable `${providerId}/${model}` alias across all bound accounts, deduped

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -15,6 +15,7 @@
 - **Composer 边界**：真实 A/B 暴露 200 + stop + 空正文与质量不足后，不进入 economy，也不再保留独立 canary lane；底层 OAuth 模型发现与 transport 兼容仍保留，避免把一次路由决策扩大成 provider 协议删除。
 - **真实 A/B**：本地 Docker 使用同一账号、总并发 2，Composer 与 Grok 4.5 各执行 30 个相同任务，覆盖 exact/factual/coding/long-context/speed/tool。Composer HTTP/模型命中 30/30、SSE `[DONE]` 30/30、工具参数 4/4、长上下文 6/6、长输出 TPS 中位数约 197，但事实仅 2/5、编码仅 1/4，6 次出现 200 + stop + 空正文，总质量 24/30（80%），可见 TTFT p95 约 1.59s；未达到 economy 晋升门槛。Grok 4.5 模型命中 29/30、质量 28/30、工具 4/4、长上下文 6/6、长输出 TPS 中位数约 138，但出现一次 504，成功率 96.7%、可见 TTFT p95 约 22.9s；速度达标但可靠性未达到 99%，因此只保留 premium fallback，不进入 balanced 或 primary。
 - **Docker 证据**：授权恢复后账号 `healthy:true` 且同时发现 `grok-4.5` / `grok-composer-2.5-fast`，真实 quota PULL 返回 `7d` 周窗口；三条预检分别真实命中 Composer、direct Grok 和 premium→Grok。授权前 premium 的 Grok 候选以 `provider_unavailable` 跳过并继续由 ZenMux Opus 成功，证明未连接边界 fail-open。测试 key 已全部禁用；容器限制 2 CPU / 2 GiB，结束时 healthy、restartCount 0。
+- **Lanes 模型选择器修复**：xAI 自动模式虽然能通过账号发现参与真实路由，但网络无关的 `/admin/api/models` 投影缺少 xAI picker fallback，导致选择器无 `xai/*` 建议。现将已验证的 `grok-4.5` 与 `grok-composer-2.5-fast` 加入仅供已绑定账号使用的 Admin 投影 fallback；它刻意不进入 core `CURATED_OAUTH_MODELS`，所以真实路由在 xAI `/models` entitlement 发现失败时仍 fail-closed。手动模式可按账号缩窄 allowlist，未连接账号不会凭空出现。
 
 ## 2026-07-12 · SuperGrok 周配额使用现有 OAuth 读取私有 gRPC-Web credits（OAuth subscription / Admin providers，docs/04/09/11，原则 3/6/7）
 


### PR DESCRIPTION
## Summary
- expose verified xAI subscription aliases in the Lanes model picker for bound auto-mode accounts
- preserve per-account manual allowlist narrowing
- keep runtime xAI entitlement discovery fail-closed by isolating the picker fallback from core routing fallbacks

## Verification
- TDD red: 2 expected failures before implementation
- targeted Vitest: 73 passed
- full Vitest: 355 files / 5,746 tests passed (max 2 workers)
- pnpm typecheck
- pnpm lint
- pnpm build
- local Docker API: both xAI aliases returned with account label
- Lanes datalist DOM visual walkthrough
- Claude Opus max-effort review: CLEAN