### PR TITLE
fix(oauth): recognize Codex weekly quota by duration

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import { invalidateAll } from '$app/navigation';
+  import { isCodexAccountWeeklyQuotaWindow } from '@helm/shared';
   import {
     consumeCodexResetCredit,
     logoutOAuth,
@@ -198,27 +199,41 @@
   }
 
   // Friendly window labels (provider-specific keys → display).
+  function durationWindowLabel(windowMinutes: number | null): string | null {
+    if (windowMinutes == null || !Number.isFinite(windowMinutes) || windowMinutes <= 0) return null;
+    if (windowMinutes === 300) return '5h';
+    if (windowMinutes === 10_080) return $t('Weekly');
+    if (windowMinutes % 1_440 === 0) return `${windowMinutes / 1_440}d`;
+    if (windowMinutes % 60 === 0) return `${windowMinutes / 60}h`;
+    return `${windowMinutes}m`;
+  }
+
   function windowLabel(key: string, windowMinutes: number | null = null): string {
+    // Codex plan shapes are not stable: some accounts now expose their weekly
+    // allowance as `primary` instead of `secondary`. The duration is authoritative;
+    // the primary/secondary key is only a neutral fallback when duration is absent.
+    const durationLabel = durationWindowLabel(windowMinutes);
+    if (
+      durationLabel &&
+      (key === 'primary' ||
+        key === 'secondary' ||
+        key.endsWith('-primary') ||
+        key.endsWith('-secondary'))
+    ) {
+      return durationLabel;
+    }
     const map: Record<string, string> = {
       '5h': '5h',
       '7d': '7d',
       '7d-opus': '7d · Opus',
       '7d-sonnet': '7d · Sonnet',
       '7d-fable': '7d · Fable',
-      // Codex windows: `primary` is the 5-hour rolling window (windowMinutes 300),
-      // `secondary` is the weekly limit (windowMinutes 10080) — matching the Codex UI.
-      primary: '5h',
-      secondary: $t('Weekly'),
+      primary: $t('Primary'),
+      secondary: $t('Secondary'),
     };
     if (map[key]) return map[key];
-    if (key.endsWith('-primary')) return windowMinutes ? `${windowMinutes}m` : $t('Primary');
-    if (key.endsWith('-secondary')) {
-      return windowMinutes === 10_080
-        ? $t('Weekly')
-        : windowMinutes
-          ? `${windowMinutes}m`
-          : $t('Secondary');
-    }
+    if (key.endsWith('-primary')) return $t('Primary');
+    if (key.endsWith('-secondary')) return $t('Secondary');
     if (key.startsWith('7d-')) return `7d · ${titleFromSlug(key.slice(3))}`;
     return key;
   }
@@ -310,7 +325,7 @@
 
   function codexWeeklyUsedPercent(q: OAuthQuotaSnapshot | undefined): number | null {
     const weekly = q?.windows
-      .filter((w) => w.key === 'secondary' && (w.limitId === undefined || w.limitId === 'codex'))
+      .filter(isCodexAccountWeeklyQuotaWindow)
       .map((w) => w.usedPercent)
       .filter((pct) => Number.isFinite(pct));
     return weekly && weekly.length > 0 ? Math.max(...weekly) : null;

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -279,6 +279,65 @@ describe('providers page', () => {
     expect(within(quotaCell).getByText('Plan: Plus')).toBeInTheDocument();
   });
 
+  it('labels Codex quota windows by their real duration across plan shapes', () => {
+    renderPage({
+      providers: [
+        provider({
+          id: 'openai-codex',
+          name: 'Codex',
+          accounts: [
+            {
+              account: 'acct-codex',
+              chatgptPlanType: 'pro',
+              expiresAt: null,
+              updatedAt: Date.now(),
+              healthy: true,
+              priority: 50,
+              schedulable: true,
+              proxy: null,
+              models: ['gpt-5.6-sol'],
+            },
+          ],
+        }),
+      ],
+      usage: [],
+      quota: [
+        {
+          providerId: 'openai-codex',
+          account: 'acct-codex',
+          windows: [
+            {
+              // Some live plans now expose their weekly allowance as `primary`.
+              key: 'primary',
+              usedPercent: 7,
+              resetsAtMs: Date.now() + 6 * 86_400_000,
+              windowMinutes: 10_080,
+            },
+            {
+              // A key without duration must not invent a five-hour window.
+              key: 'secondary',
+              usedPercent: 2,
+              resetsAtMs: Date.now() + 3_600_000,
+              windowMinutes: null,
+            },
+          ],
+          capturedAt: Date.now(),
+          source: 'codex',
+          usageLimitedUntilMs: null,
+          resetCredits: 2,
+          planType: 'pro',
+        },
+      ],
+    });
+
+    const quotaCell = within(screen.getByTestId('provider-account-row')).getByTestId(
+      'provider-quota-cell',
+    );
+    expect(within(quotaCell).getByText('Weekly')).toBeInTheDocument();
+    expect(within(quotaCell).getByText('Secondary')).toBeInTheDocument();
+    expect(within(quotaCell).queryByText('5h')).not.toBeInTheDocument();
+  });
+
   it('does not reserve subscription-detail space when Codex claims are absent', () => {
     renderPage({
       providers: [
@@ -881,6 +940,23 @@ describe('providers page', () => {
     renderCodex(2, true);
     const row = screen.getByTestId('provider-account-row');
     expect(within(row).getByTestId('auto-reset-badge')).toBeInTheDocument();
+  });
+
+  it('recognizes a duration-backed primary window as the Codex weekly allowance', async () => {
+    renderCodexCooldown(
+      [
+        {
+          key: 'primary',
+          usedPercent: 95,
+          resetsAtMs: Date.now() + 3 * 86_400_000,
+          windowMinutes: 10_080,
+        },
+      ],
+      Date.now() + 60_000,
+    );
+
+    const row = screen.getByTestId('provider-account-row');
+    expect(within(row).getByRole('button', { name: /reset limit \(2\)/i })).toBeEnabled();
   });
 
   it('hides the Auto-reset badge when the account has not opted in', async () => {

--- a/apps/gateway/src/oauth/auto-reset.test.ts
+++ b/apps/gateway/src/oauth/auto-reset.test.ts
@@ -22,6 +22,15 @@ describe("codex reset-credit eligibility", () => {
     expect(canConsumeResetCredit([])).toBe(false);
   });
 
+  it("recognizes a primary account window as weekly when its duration is seven days", () => {
+    expect(
+      canConsumeResetCredit([{ key: "primary", usedPercent: 95, windowMinutes: 10_080 }]),
+    ).toBe(true);
+    expect(canConsumeResetCredit([{ key: "primary", usedPercent: 100, windowMinutes: 300 }])).toBe(
+      false,
+    );
+  });
+
   it("does not spend a reset credit for an additional model-specific secondary window", () => {
     expect(
       canConsumeResetCredit([

--- a/apps/gateway/src/oauth/auto-reset.ts
+++ b/apps/gateway/src/oauth/auto-reset.ts
@@ -2,10 +2,13 @@
 // so the (network-bound) wiring in server.ts can be unit-tested at the gate.
 //
 // Auto-reset consumes a SCARCE rate-limit reset credit (only a few per account),
-// so the trigger must be conservative: only the WEEKLY window (Codex `secondary`)
-// counts — the 5h window (`primary`) self-recovers and must never burn a credit —
+// so the trigger must be conservative: only the account-wide WEEKLY window counts.
+// Its primary/secondary position varies by plan, so duration is authoritative; the
+// 5h window self-recovers and must never burn a credit —
 // and at most ONE consume per account per hour (cooldown), so a burst of concurrent
 // saturated replies can't drain the grant.
+
+import { isCodexAccountWeeklyQuotaWindow } from "@helm/shared";
 
 // At least one hour between reset-credit consumes for the same shared ChatGPT
 // account. The runtime also persists this guard so a container restart cannot
@@ -58,17 +61,33 @@ export async function runResetCreditAttempt<
 }
 
 export function codexWeeklyUsedPercent(
-  windows: ReadonlyArray<{ key: string; limitId?: string; usedPercent: number }>,
+  windows: ReadonlyArray<{
+    key: string;
+    limitId?: string;
+    usedPercent: number;
+    windowMinutes?: number | null;
+  }>,
 ): number | null {
   const weekly = windows
-    .filter((w) => w.key === "secondary" && (w.limitId === undefined || w.limitId === "codex"))
+    .filter((w) =>
+      isCodexAccountWeeklyQuotaWindow({
+        key: w.key,
+        limitId: w.limitId,
+        windowMinutes: w.windowMinutes ?? null,
+      }),
+    )
     .map((w) => w.usedPercent)
     .filter((pct) => Number.isFinite(pct));
   return weekly.length === 0 ? null : Math.max(...weekly);
 }
 
 export function canConsumeResetCredit(
-  windows: ReadonlyArray<{ key: string; limitId?: string; usedPercent: number }>,
+  windows: ReadonlyArray<{
+    key: string;
+    limitId?: string;
+    usedPercent: number;
+    windowMinutes?: number | null;
+  }>,
   rateLimitReachedType?: CodexRateLimitReachedType | null,
 ): boolean {
   if (
@@ -81,10 +100,15 @@ export function canConsumeResetCredit(
   return (codexWeeklyUsedPercent(windows) ?? -1) >= CODEX_RESET_MIN_WEEKLY_USED_PERCENT;
 }
 
-// True when the WEEKLY window is fully used. Codex keys the 7d window "secondary";
-// the 5h window ("primary") is deliberately ignored (it recovers on its own).
+// True when the account-wide WEEKLY window is fully used. The reported duration
+// distinguishes it from the self-recovering 5h window across plan shapes.
 export function weeklySaturated(
-  windows: ReadonlyArray<{ key: string; limitId?: string; usedPercent: number }>,
+  windows: ReadonlyArray<{
+    key: string;
+    limitId?: string;
+    usedPercent: number;
+    windowMinutes?: number | null;
+  }>,
 ): boolean {
   return (codexWeeklyUsedPercent(windows) ?? -1) >= 100;
 }

--- a/apps/gateway/src/oauth/reset-credit-guard.test.ts
+++ b/apps/gateway/src/oauth/reset-credit-guard.test.ts
@@ -333,6 +333,31 @@ describe("createResetCreditGuard", () => {
     });
   });
 
+  it("reserves a duration-backed primary weekly window", async () => {
+    const config = new MemoryConfig();
+    const guard = createResetCreditGuard({
+      config,
+      resolveSharedKey: vi.fn(async () => "codex:shared-account"),
+    });
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work",
+        windows: [
+          {
+            key: "primary",
+            usedPercent: 100,
+            resetsAtMs: 86_400_000,
+            windowMinutes: 10_080,
+          },
+        ],
+        mode: "manual",
+        nowMs: 1_000,
+      }),
+    ).resolves.toMatchObject({ ok: true, windowId: "secondary:86400000" });
+  });
+
   it("allows another reserve after the full cooldown has elapsed", async () => {
     const config = new MemoryConfig();
     const resolveSharedKey = vi.fn(async () => "codex:shared-account");

--- a/apps/gateway/src/oauth/reset-credit-guard.ts
+++ b/apps/gateway/src/oauth/reset-credit-guard.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { ConfigStore } from "@helm/core";
-import type { OAuthQuotaWindow } from "@helm/shared";
+import { isCodexAccountWeeklyQuotaWindow, type OAuthQuotaWindow } from "@helm/shared";
 import {
   AUTO_RESET_COOLDOWN_MS,
   CODEX_RESET_MIN_WEEKLY_USED_PERCENT,
@@ -102,11 +102,13 @@ interface RedeemRequestMarker {
 
 function weeklyWindowMarker(windows: readonly OAuthQuotaWindow[]): WeeklyWindowMarker | null {
   const weekly = windows
-    .filter((w) => w.key === "secondary" && (w.limitId === undefined || w.limitId === "codex"))
+    .filter(isCodexAccountWeeklyQuotaWindow)
     .filter((w) => Number.isFinite(w.usedPercent))
     .sort((a, b) => b.usedPercent - a.usedPercent)[0];
   if (weekly?.resetsAtMs == null || !Number.isFinite(weekly.resetsAtMs)) return null;
   return {
+    // Keep the historical marker prefix canonical even when the live plan places
+    // its weekly allowance in `primary`; this preserves stored guard compatibility.
     windowId: `secondary:${weekly.resetsAtMs}`,
     resetAtMs: weekly.resetsAtMs,
   };

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）
+
+- **生产证据与根因**：生产 `oauth_quota` 中四个 Codex 账号都出现 `primary + windowMinutes:10080`，截图中的唯一窗口虽显示 `5h`，重置倒计时却是 `6d 22h`。上游不同套餐不再保证 `primary=5h / secondary=7d`，Admin 的位置硬编码因此把真实周配额错标为 5h；同一假设还会让手动/自动 reset-credit 误报周快照不可用。
+- **统一判定**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威；只有旧 header 快照缺少 duration 时才兼容回退到 `secondary`。带非默认 `limitId` 的 model-scoped 窗口绝不当作账号周配额。Admin 标签同样时长优先（300m→5h、10080m→Weekly），缺时长显示中性的 Primary/Secondary，不再猜测。
+- **账号边界**：规则完全 plan-agnostic，覆盖 Codex Plus/Pro/Team/Business/Enterprise/Edu 等实际窗口形态，不按套餐名维护分支。Claude 继续使用其 5h/7d keys；Copilot、SuperGrok 与普通 API-key provider 没有可验证的同类 Codex reset-credit 周窗口，不套用本规则或伪造数据。
+- **验证**：共享 predicate、Admin 单周窗口、reset-credit UI、自动重置与持久 guard 均增加 `primary + 10080m` 回归；同时覆盖 `secondary + 300m` 不误判、缺 duration 的 legacy fallback，以及 model-scoped 周窗口隔离。
+
 ## 2026-07-12 · Grok premium fallback 与 Composer 评估边界（Routing / provider evaluation，docs/04/07，原则 2/3/5/6/7）
 
 - **移除 official OpenAI 付费 lane 候选**：所有 `openai/gpt-*` 从 shipped lanes 删除，只保留 provider、能力与价格定义供显式 custom-model 使用；GPT vendor lanes 在 Codex subscription 不可用时进入通用订阅/静态 fallback，不再自动触发 official OpenAI 账单。`gpt-image` 改由 ZenMux relay 的 `gpt-image-2` 领衔，official Images API 同样不再被 lane 自动选择。
@@ -86,25 +93,9 @@
 - **API 投影**：`/portal/api/me` 同时返回有效 `project_id`、原始配置 `project_name` 与 `thread_source`，避免把 null→key-id 的私有默认 scope 错画成显式共享项目，并让弹窗准确回填线程策略。未新增 DB 字段或迁移，复用已有 KeyStore partial update。
 - **验证**：先增加 portal route 红测，覆盖 authenticated-key 强制、严格字段拒绝、disable/clear 和 root 拒绝；设置弹窗再以纯函数红测覆盖 off→inject 编辑回退、observe/project 回填和请求 trim/null 映射；运行 gateway/portal tests、typecheck、portal check/build 和 i18n 校验。
 
-## 2026-07-10–11 · Codex CLI GPT-5.6 subscription parity（OAuth subscription / Responses / model catalog，docs/04/05/11，原则 3/5/6/7/8）
-
-- **对齐基线**：实现逐项对照 OpenAI Codex `54c44b9ed4` 源码，而不是只增加三个模型字符串。Helm 现在使用原生 `GET /v1/models?client_version=...` 的 `{models}` envelope、Codex `ModelInfo` 字段、`minimal_client_version` 过滤和 key 权限过滤，并支持 `gpt-5.6-sol` / `terra` / `luna` 与裸 `gpt-5.6 -> gpt-5.6-sol` wire 规范化。
-- **模型目录与缓存**：订阅模型目录按 account identity + Codex client version 持久缓存，支持 fresh/network/stale last-known-good 与上游 ETag 观测。`/v1/models` 返回的是当前 API key 过滤后的稳定 ETag；Responses/compact 不再透传 account-wide 上游 `x-models-etag`，而是覆盖为同一 key 最近取得的目录 ETag，避免 Codex CLI 每轮误判目录变化。
-- **Responses parity**：原生 Responses 请求保留 Codex CLI body/header，补齐 compact、input tokens、response lifecycle、reasoning/tool/turn-state metadata、三种 SSE 终态（completed/failed/incomplete）和无终态 EOF fail-closed。compact 与普通 Responses 共用模型 alias、lane、allowed_lanes、blocked_models 和订阅 entitlement 边界。
-- **compact 结算与热重建**：compact 只走 Codex 原生 lifecycle，缺少订阅 executor 时返回 `capability_unsatisfiable`，绝不降级成普通 Responses。executor 每次请求读取当前 OAuth pool，所以运行中首次连接、重建或替换账号不需要重启。成功响应按真实顶层 `usage` 结算 token/cost/budget；失败仍保留实际 serving account 和已捕获的 upstream request。Responses usage 同时识别 `cache_write_tokens` / `cache_creation_tokens` / `cache_creation_input_tokens`，避免 cache-write 成本低估。
-- **Responses WebSocket parity**：`/v1/responses` 支持真实 `101` upgrade、per-message deflate、`response.create`、`generate:false` 预热、同连接串行复用和 `previous_response_id`。握手先复用 `/v1/models?client_version=...` 做 Helm key 鉴权，并返回 key-scoped `x-models-etag`；`x-reasoning-included` 按 Codex 的“header 存在即 true”语义处理，false-like 值必须省略。明确 `426` 会立即固定切 HTTP；无 HTTP status 的握手故障先按 Codex retry budget 重试，耗尽后固定切 HTTP；`websocket_connection_limit_reached` 会关闭旧连接并重发同一请求，预算耗尽后切 HTTP。`response.failed` / `response.incomplete` / `error`、wrapped HTTP error、非法帧和无终态断连都会销毁连接，只有 `response.completed` 的连接可复用。
-- **reasoning 计数握手**：账号/版本作用域的模型快照持久保存上游 `/codex/models` 是否带 `x-reasoning-included`。只有本次 key 可路由的所有快照都明确为真时，`/v1/models` 和 WebSocket upgrade 才返回该 header；旧缓存、bundled fallback 或混合未知账号均省略，避免 Codex CLI 重复或错误计算历史 reasoning token。
-- **Codex custom tool 续轮**：Responses Lite 增量帧不得重新注入空 `additional_tools`；协议 transformer 现在显式识别 `custom_tool_call` / `custom_tool_call_output`，映射到 IR tool call/tool message，并在 `provider_raw.responses_input_items` 保留原始 item 序列。这样 output-only continuation 不再变成空 messages，也不会在重放时降级成 `function_call_output`。
-- **裸 GPT-5.6 alias**：Codex 模型目录中的 `gpt-5.6` 是 Sol alias，`model-aliases.yaml` 因此直接映射到 `gpt-5.6-sol` lane。不能先进入通用 `gpt-5.6` lane，否则 requested-model promotion 会把未配置的 official `openai/gpt-5.6` 提升到订阅 Sol 前面，产生虚假的 `provider_unavailable` attempt。
-- **`ultra` 边界**：`ultra` 是 Codex CLI 本地模式，不是跨 provider 的 wire/config 能力。Helm 只在 Codex subscription 请求边界把它归一化为 wire `max`；共享 IR、Lane/Policy schema、Admin 配置、Anthropic 与 Gemini 均不暴露或发送 `ultra`，避免把 Codex 的 proactive multi-agent 开关扩散成全局协议字段。
-- **订阅与配额**：ChatGPT identity claims、plan、credits、reset-credit details、`rate_limit_reached_type`、默认与 additional model limits 都从 WHAM usage/headers 解析并贯通 Gateway/Admin。`x-codex-active-limit` 决定 429 只停车当前模型 entitlement 还是整个账号，quota snapshot 保留上游真实 `usedPercent`，不再把 429 人为改写成 100%。
-- **reset-credit 安全边界**：手动和自动 consume 共用 weekly threshold、shared ChatGPT account guard、每小时 cooldown 与 weekly-window 幂等门禁；workspace credits/spend-control 限制不会消耗 rate-limit reset credit。手动操作可选择具体 `credit_id` 并复用 `redeem_request_id`，Admin 明示 plan/balance/reached type 和具体 credit。
-- **reset-credit 身份后备**：shared guard 优先使用 `chatgpt_account_id`；缺失时使用稳定的 ChatGPT user ID，再后备到规范化 email，只有完全没有上游身份时才退回 Helm label。这样同一订阅绑定多个 label 不会重复消耗 credit，同时不同用户不会被合并。
-- **Claude Fable 外部审查**：PR 按 8 个逻辑 diff 交给 Claude CLI `fable` 高强度只读审查，并逐条由 Helm 侧复核。确认并修复 4 个真实问题：upgrade async preflight 前缺少 raw socket error guard、出站 WebSocket close/error 终态不可重放、共享 catalog snapshot 被原地排序、Admin metadata-only quota 同时显示空占位。其余关于 372K Codex context、ETag CRLF、body reader lock、HTTP fallback session 泄漏、`gpt-5.6-*` 未来模型等结论因与上游源码/运行时或当前作用域证据不符而未改动。
-- **live 验证结果**：本地 Docker 数据卷中的真实 Codex 订阅账号可调度，Codex CLI `0.144.1` 通过完整 custom provider（command auth + Responses WebSocket）验证 `gpt-5.6-sol` / `terra` / `luna` / 裸 `gpt-5.6` 的 shell 工具调用、结果续轮、最终文本和 `turn.completed`。模型目录返回 9 项且包含四个 GPT-5.6 名称；裸 alias 的 3 个 Responses 轮次 telemetry 均为单次 `openai-codex/gpt-5.6-sol` attempt，无 skip/fallback/provider 漂移。本次未消费 reset credit。
-
 ## 历史条目摘要（最近 5 条）
 
+- **2026-07-10–11 · Codex CLI GPT-5.6 subscription parity（OAuth subscription / Responses / model catalog，docs/04/05/11，原则 3/5/6/7/8）**：按 Codex 源码补齐 GPT-5.6 模型目录、Responses/WebSocket/compact、usage、订阅 entitlement 与 reset-credit 安全边界，并完成真实 CLI 验证。
 - **2026-07-10 · Direct DeepSeek Responses reasoning history pre-skip（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）**：检测到 Responses reasoning history 时预跳过无法接收回传 `reasoning_content` 的 direct DeepSeek Chat 候选；OpenRouter mirror 保持可尝试，避免确定性 400 而不改变最终 fallback。
 - **2026-07-10 · GPT-5.6 Chat tools force reasoning_effort none（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）**：official GPT-5.6 Chat fallback 带 tools 时强制 wire `reasoning_effort:none`，保留 tools 并记录专用 body shim，避免 Responses-only 组合返回确定性 400。
 - **2026-07-10 · GPT-5.6 family support in Helm defaults（Routing / provider catalog / cost telemetry，docs/03/04/07，原则 3/4/5/6）**：默认 lanes、能力/价格目录与 wire 参数升级到 Sol/Terra/Luna，同时保持 official API 与 Codex subscription 的 entitlement/context 边界。

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -282,6 +282,7 @@ export {
   CodexOAuthUsageSchema,
   type CodexResetResult,
   CodexResetResultSchema,
+  isCodexAccountWeeklyQuotaWindow,
   type OAuthQuotaSnapshot,
   OAuthQuotaSnapshotSchema,
   type OAuthQuotaWindow,

--- a/packages/shared/src/oauth/usage-schema.test.ts
+++ b/packages/shared/src/oauth/usage-schema.test.ts
@@ -2,8 +2,41 @@ import { describe, expect, it } from "vitest";
 import {
   CodexOAuthUsageSchema,
   CodexResetResultSchema,
+  isCodexAccountWeeklyQuotaWindow,
   OAuthQuotaSnapshotSchema,
 } from "./usage-schema.js";
+
+describe("isCodexAccountWeeklyQuotaWindow", () => {
+  it("uses the reported duration before the unstable primary/secondary position", () => {
+    expect(
+      isCodexAccountWeeklyQuotaWindow({
+        key: "primary",
+        windowMinutes: 10_080,
+      }),
+    ).toBe(true);
+    expect(
+      isCodexAccountWeeklyQuotaWindow({
+        key: "secondary",
+        windowMinutes: 300,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the legacy secondary fallback when duration metadata is absent", () => {
+    expect(isCodexAccountWeeklyQuotaWindow({ key: "secondary", windowMinutes: null })).toBe(true);
+    expect(isCodexAccountWeeklyQuotaWindow({ key: "primary", windowMinutes: null })).toBe(false);
+  });
+
+  it("never treats model-scoped limits as the account-wide weekly allowance", () => {
+    expect(
+      isCodexAccountWeeklyQuotaWindow({
+        key: "codex_terra-primary",
+        windowMinutes: 10_080,
+        limitId: "codex_terra",
+      }),
+    ).toBe(false);
+  });
+});
 
 // The auto-park cooldown (`usageLimitedUntilMs`) rides on the quota snapshot. It must
 // be OPTIONAL on the wire: legacy rows + unit fixtures written before the column existed

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -54,6 +54,21 @@ export const OAuthQuotaWindowSchema = z
 
 export type OAuthQuotaWindow = z.infer<typeof OAuthQuotaWindowSchema>;
 
+// Codex account plans do not consistently assign the short and weekly allowances
+// to `primary` / `secondary`. Prefer the reported duration and retain `secondary`
+// only as a compatibility fallback for older header snapshots without duration.
+// Model-scoped limits are deliberately excluded: reset credits target the default
+// account-wide allowance, not a single model family.
+export function isCodexAccountWeeklyQuotaWindow(
+  window: Pick<OAuthQuotaWindow, "key" | "windowMinutes" | "limitId">,
+): boolean {
+  if (window.limitId !== undefined && window.limitId !== "codex") return false;
+  if (window.windowMinutes != null && Number.isFinite(window.windowMinutes)) {
+    return window.windowMinutes >= 7 * 24 * 60;
+  }
+  return window.key === "secondary";
+}
+
 // Codex subscription identity copied from the authenticated ChatGPT account.
 // Optional fields preserve legacy records and claims that some account types omit.
 // This is operator-facing metadata only; no token or secret material is allowed.


### PR DESCRIPTION
## Summary
- label Codex quota windows from their reported duration instead of assuming primary is always 5h
- share account-wide weekly-window detection across Admin, manual reset guards, and auto-reset
- preserve legacy secondary snapshots while excluding model-scoped limits

## Production evidence
The live quota store contains Codex accounts reporting the weekly 10080-minute allowance as primary. The old UI therefore rendered a weekly window as 5h and the reset-credit paths treated the weekly snapshot as unavailable.

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test (355 files, 5753 tests)