### PR TITLE
chore(release): v0.26.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.25",
+  "version": "0.26.26",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump Helm API from 0.26.25 to 0.26.26
- includes Codex weekly quota duration fix from #539

## Verification
Feature PR CI: verify, e2e, and docker all passed.