### PR TITLE
fix(responses): encode multipart tool outputs as input

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-13 · Responses 工具结果的 multipart 文本使用 input_text（Protocol translation / provider execution，docs/05/07，原则 3/5/8）
+
+- **生产根因**：请求 `7963c4fa-c0ea-436f-aa4d-af0beb41615e` 从 Anthropic fallback 到 Codex Responses 时，数组形式的 `tool_result` 被编码为 `function_call_output.output[].output_text`；该 item 属于 Responses 请求输入，上游只接受 `input_text`，因此返回确定性 400 `invalid_request`。
+- **修复边界**：provider 专用 Chat→Responses 与共享 IR→Responses 两条路径统一把 multipart 工具结果文本编码为 `input_text`；字符串工具结果仍保持字符串，`input_image` 与 `input_file` 保持原 wire shape。助手消息正文继续使用 `output_text`，不扩大成全局 content-part 改写，也不改变 `invalid_request` fallback 语义。
+- **验证**：TDD 红灯同时覆盖 provider、共享 transformer 与真实 Anthropic `tool_result`→Codex Responses 链路；定向 Vitest 绿灯为 2 files / 274 tests。
+
 ## 2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）
 
 - **生产证据与根因**：生产 `oauth_quota` 中四个 Codex 账号都出现 `primary + windowMinutes:10080`，截图中的唯一窗口虽显示 `5h`，重置倒计时却是 `6d 22h`。上游不同套餐不再保证 `primary=5h / secondary=7d`，Admin 的位置硬编码因此把真实周配额错标为 5h；同一假设还会让手动/自动 reset-credit 误报周快照不可用。
@@ -85,16 +91,9 @@
 - **安全边界**：没有照搬 Admin 的原始 `upstream_request`。该正文包含协议翻译结果、wire model 与注入后的 Memory 上下文，继续由 R7 在 store read 前拒绝。Portal metadata 也不得返回或暗示 upstream 是否存在；若未来要展示“模型实际看到的内容”，必须新增服务端白名单规范化投影，不能放开原始 part。
 - **验证**：TDD 增加 Portal payload meta ownership/whitelist/fallback 测试、图片 sniff/遍历/去重/上限测试、media-group 纯函数和页面组合 contract；再运行 Portal/Gateway tests、svelte-check、typecheck、lint/build 与真实浏览器交互检查。
 
-## 2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）
+## 历史条目摘要（最新要点）
 
-- **授权边界**：新增 `PATCH /portal/api/memory-settings`，只接受严格的 `memory_mode`、`memory_project_id` 与 `memory_thread_source`；目标 key 始终取 bearer identity 的 `keyId`，不能提交 `key_id/account_id`，也不能借此修改 lane、预算或限流。管理面 root key 继续强制只读、保持 memory inert。`memory_thread_source` 在服务端 schema 保持 optional，仅用于兼容仍打开着的 v0.26.16/17 旧 SPA；新 UI 始终显式发送。
-- **交互**：Memory 页标题区提供 `Settings` 入口，弹窗内编辑 Memory 开关、`observe`（仅记录）/`inject`（记录并注入）模式、最多 100 字符的项目名，以及线程来源 `auto` / `header`；Account 页只保留只读摘要，避免两个可编辑入口。保存项目后立即重载 facts/reflections，不能继续显示旧池数据。显式 `x-memory-*` 请求头仍覆盖这些服务端默认值。
-- **scope 语义**：`memory_project_id` 是共享池选择器，不是纯展示标签；空值仍回落到 key 自身的私有 scope。更改项目只切换默认池，不迁移旧 Memory；同一 account 下采用相同显式项目名的 keys 会共享该池，UI 明示这一点。
-- **API 投影**：`/portal/api/me` 同时返回有效 `project_id`、原始配置 `project_name` 与 `thread_source`，避免把 null→key-id 的私有默认 scope 错画成显式共享项目，并让弹窗准确回填线程策略。未新增 DB 字段或迁移，复用已有 KeyStore partial update。
-- **验证**：先增加 portal route 红测，覆盖 authenticated-key 强制、严格字段拒绝、disable/clear 和 root 拒绝；设置弹窗再以纯函数红测覆盖 off→inject 编辑回退、observe/project 回填和请求 trim/null 映射；运行 gateway/portal tests、typecheck、portal check/build 和 i18n 校验。
-
-## 历史条目摘要（最近 5 条）
-
+- **2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）**：bearer key 可在 Portal 安全配置 observe/inject、共享项目与线程来源；root 只读，显式请求头仍覆盖默认值。
 - **2026-07-10–11 · Codex CLI GPT-5.6 subscription parity（OAuth subscription / Responses / model catalog，docs/04/05/11，原则 3/5/6/7/8）**：按 Codex 源码补齐 GPT-5.6 模型目录、Responses/WebSocket/compact、usage、订阅 entitlement 与 reset-credit 安全边界，并完成真实 CLI 验证。
 - **2026-07-10 · Direct DeepSeek Responses reasoning history pre-skip（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）**：检测到 Responses reasoning history 时预跳过无法接收回传 `reasoning_content` 的 direct DeepSeek Chat 候选；OpenRouter mirror 保持可尝试，避免确定性 400 而不改变最终 fallback。
 - **2026-07-10 · GPT-5.6 Chat tools force reasoning_effort none（Provider execution / protocol translation，docs/04/05/07，原则 3/5/8）**：official GPT-5.6 Chat fallback 带 tools 时强制 wire `reasoning_effort:none`，保留 tools 并记录专用 body shim，避免 Responses-only 组合返回确定性 400。

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -700,7 +700,7 @@ describe("responsesTransformer — request input items -> IR (folding)", () => {
           type: "function_call_output",
           call_id: "call_abc",
           output: [
-            { type: "output_text", text: "chart:" },
+            { type: "input_text", text: "chart:" },
             { type: "input_image", image_url: "https://x/chart.png", detail: "low" },
             { type: "input_file", file_url: "https://x/data.csv", filename: "data.csv" },
           ],
@@ -1903,7 +1903,7 @@ describe("responsesTransformer — contentToFunctionCallOutput paths (line 671-6
       ],
     })) as { input: Array<{ type: string; output?: unknown }> };
     const fco = native.input.find((i) => i.type === "function_call_output");
-    expect(Array.isArray(fco?.output)).toBe(true);
+    expect(fco?.output).toEqual([{ type: "input_text", text: "result" }]);
   });
 });
 

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -732,7 +732,7 @@ function contentToFunctionCallOutput(
   content: IRMessage["content"],
 ): string | Array<Record<string, unknown>> {
   if (content === null || typeof content === "string") return contentToText(content);
-  return contentToResponsesParts(content, true);
+  return contentToResponsesParts(content, false);
 }
 
 // IR content -> Responses content parts, PRESERVING multimodality (order 25): text ->

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { transformRequestOut as anthropicToIRRequest } from "../protocol/anthropic/request.js";
 import type { CodexModelInfo } from "./oauth/codex-model-info.js";
 import { UpstreamError } from "./openai.js";
 import {
@@ -4418,7 +4419,7 @@ describe("openaiToGenericResponsesRequest — tools and reasoning_effort", () =>
     ]);
   });
 
-  it("preserves multipart tool results as native Responses output parts", () => {
+  it("preserves multipart tool results as native Responses input parts", () => {
     const body = openaiToGenericResponsesRequest({
       model: "grok",
       messages: [
@@ -4439,7 +4440,7 @@ describe("openaiToGenericResponsesRequest — tools and reasoning_effort", () =>
         type: "function_call_output",
         call_id: "call_1",
         output: [
-          { type: "output_text", text: "chart:" },
+          { type: "input_text", text: "chart:" },
           { type: "input_image", image_url: "https://example.test/chart.png", detail: "high" },
           {
             type: "input_file",
@@ -4449,6 +4450,63 @@ describe("openaiToGenericResponsesRequest — tools and reasoning_effort", () =>
         ],
       },
     ]);
+  });
+
+  it("maps Anthropic multipart tool_result text to Responses input_text", () => {
+    const anthropicRequest = {
+      model: "claude-opus-4-8",
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_1", name: "read_chart", input: {} }],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: [
+                { type: "text", text: "chart:" },
+                {
+                  type: "image",
+                  source: {
+                    type: "url",
+                    url: "https://example.test/chart.png",
+                  },
+                },
+                {
+                  type: "document",
+                  source: {
+                    type: "url",
+                    url: "https://example.test/data.csv",
+                  },
+                  title: "data.csv",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const ir = anthropicToIRRequest(anthropicRequest);
+    const body = openaiToResponsesRequest(ir);
+
+    expect(body.input).toContainEqual({
+      type: "function_call_output",
+      call_id: "toolu_1",
+      output: [
+        { type: "input_text", text: "chart:" },
+        { type: "input_image", image_url: "https://example.test/chart.png" },
+        {
+          type: "input_file",
+          file_url: "https://example.test/data.csv",
+          filename: "data.csv",
+        },
+      ],
+    });
   });
 
   it("maps reasoning_effort to body.reasoning.effort", () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -303,7 +303,7 @@ function plainText(content: unknown): string {
 function responsesToolOutput(content: unknown): string | ResponsesContentPart[] {
   if (typeof content === "string") return content;
   if (Array.isArray(content)) {
-    const parts = inputPartsFromContent(content, "output_text");
+    const parts = inputPartsFromContent(content, "input_text");
     return parts.length > 0 ? parts : "";
   }
   return JSON.stringify(content ?? "");


### PR DESCRIPTION
## Summary

- encode multipart function_call_output text as input_text in both Responses translators
- add an Anthropic tool_result to Codex Responses regression covering text, image, and file parts
- preserve string tool outputs and assistant-side output_text behavior

## Production root cause

Request 7963c4fa-c0ea-436f-aa4d-af0beb41615e fell back from Anthropic to openai-codex/gpt-5.6-sol. Helm emitted output_text at input[16].output[0], which the upstream rejected because function_call_output is a request input item.

## Verification

- TDD red: 4 expected failures across the two targeted suites
- targeted Vitest: 274/274 passed
- full Vitest: 5754/5754 passed
- pnpm typecheck
- pnpm lint
- pnpm build
- git diff --check