### PR TITLE
chore(release): v0.26.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.26",
+  "version": "0.26.27",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- release the Responses multipart tool-output fix already merged in PR #541
- publish Helm API v0.26.27 for production deployment

## Verification

- version-only diff
- PR #541 CI passed (verify, e2e, docker)

## Production issue

Production is still running v0.26.26 / 1186ff8 and rejects multipart tool results encoded as output_text. After merge, deploy the v0.26.27 image and verify /version, /healthz, and the failing request path.