### PR TITLE
perf(admin): make provider refresh cache-first

### DIFF
--- a/apps/admin/src/lib/api/oauth.test.ts
+++ b/apps/admin/src/lib/api/oauth.test.ts
@@ -3,12 +3,14 @@ import {
   completeManualPaste,
   consumeCodexResetCredit,
   getAccountModels,
+  getOAuthOverview,
   getOAuthQuota,
   getOAuthUsage,
   listOAuthStatus,
   logoutOAuth,
   OAuthApiError,
   pollDeviceCode,
+  requestOAuthRefresh,
   setAccountModels,
   setAccountSchedule,
   setSelectionStrategy,
@@ -50,7 +52,7 @@ describe('admin oauth api client', () => {
   });
 
   it('treats a 503 status response as OAuth not configured', async () => {
-    const fetchFn = vi.fn(async () =>
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
       resp({ error: 'not_configured' }, { ok: false, status: 503 }),
     );
     vi.stubGlobal('fetch', fetchFn);
@@ -84,7 +86,7 @@ describe('admin oauth api client', () => {
   });
 
   it('parses configured provider status without exposing secrets', async () => {
-    const fetchFn = vi.fn(async () =>
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
       resp({
         selectionStrategy: 'low_risk',
         providers: [
@@ -117,6 +119,80 @@ describe('admin oauth api client', () => {
     expect(status.providers[0]?.accounts[0]?.credentialFailed).toBe(false);
     expect(status.providers[0]?.accounts[0]?.fastMode).toBe(true);
     expect(JSON.stringify(status)).not.toMatch(/access_token|refresh_token|secret/i);
+  });
+
+  it('loads the providers overview in one cache-only request', async () => {
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      resp({
+        configured: true,
+        selectionStrategy: 'balanced',
+        providers: [],
+        usage: [
+          {
+            providerId: 'anthropic',
+            account: 'acct-a',
+            requests: 2,
+            tokens: 12,
+            costUsd: null,
+            rpm: 0.1,
+          },
+        ],
+        quota: [
+          {
+            providerId: 'anthropic',
+            account: 'acct-a',
+            windows: [],
+            capturedAt: 123,
+            source: 'anthropic',
+          },
+        ],
+        refresh: {
+          state: 'idle',
+          jobId: null,
+          requestedAt: null,
+          startedAt: null,
+          finishedAt: null,
+          lastSuccessAt: null,
+          nextAllowedAt: null,
+          error: null,
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchFn);
+
+    await expect(getOAuthOverview()).resolves.toMatchObject({
+      configured: true,
+      usage: [{ providerId: 'anthropic', account: 'acct-a', requests: 2 }],
+      quota: [{ providerId: 'anthropic', account: 'acct-a', capturedAt: 123 }],
+      refresh: { state: 'idle', jobId: null },
+    });
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(String(firstCall(fetchFn.mock.calls)[0])).toContain('/admin/api/oauth/overview?');
+  });
+
+  it('enqueues a provider refresh without waiting for upstream work', async () => {
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      resp(
+        {
+          accepted: true,
+          coalesced: false,
+          retryAfterMs: 0,
+          status: { state: 'queued', jobId: 'refresh-1' },
+        },
+        { status: 202 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchFn);
+
+    await expect(requestOAuthRefresh()).resolves.toMatchObject({
+      accepted: true,
+      coalesced: false,
+      status: { state: 'queued', jobId: 'refresh-1' },
+    });
+    expect(fetchFn).toHaveBeenCalledWith('/admin/api/oauth/refresh', {
+      method: 'POST',
+      headers: { accept: 'application/json' },
+    });
   });
 
   it('saves the global selection strategy', async () => {

--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -134,6 +134,35 @@ export interface OAuthUsageRow {
   rpm: number;
 }
 
+export type OAuthAdminRefreshState = 'idle' | 'queued' | 'running' | 'succeeded' | 'failed';
+
+export interface OAuthAdminRefreshStatus {
+  state: OAuthAdminRefreshState;
+  jobId: string | null;
+  requestedAt: number | null;
+  startedAt: number | null;
+  finishedAt: number | null;
+  lastSuccessAt: number | null;
+  nextAllowedAt: number | null;
+  error: string | null;
+}
+
+export interface OAuthOverview {
+  configured: boolean;
+  selectionStrategy: OAuthSelectionStrategy;
+  providers: OAuthProviderStatus[];
+  usage: OAuthUsageRow[];
+  quota: OAuthQuotaSnapshot[];
+  refresh: OAuthAdminRefreshStatus;
+}
+
+export interface OAuthAdminRefreshEnqueueResult {
+  accepted: boolean;
+  coalesced: boolean;
+  retryAfterMs: number;
+  status: OAuthAdminRefreshStatus;
+}
+
 // Quota wire types come exclusively from @helm/shared's Zod schema. Keep aliases
 // here so existing Admin imports stay stable without duplicating the contract.
 export type OAuthQuotaSnapshot = SharedOAuthQuotaSnapshot;
@@ -144,11 +173,29 @@ export type CodexIndividualLimit = NonNullable<OAuthQuotaSnapshot['individualLim
 export type CodexAdditionalLimit = NonNullable<OAuthQuotaSnapshot['additionalLimits']>[number];
 export type CodexResetCreditDetail = NonNullable<OAuthQuotaSnapshot['resetCreditDetails']>[number];
 
-// Observability reads block the providers-page load (Promise.all), so they carry a
-// hard client-side timeout: a slow/hung gateway (e.g. an Anthropic quota pull behind
-// a stalled proxy) must never keep `/admin/providers` spinning — the AbortSignal
-// trips the catch and the page renders with [] for that section.
+// Cache-only observability reads are expected to be fast, but a DB lock or stalled
+// gateway must still not leave the Providers page spinning forever.
 const OBSERVABILITY_TIMEOUT_MS = 10_000;
+
+// GET /oauth/overview -> one cache-only page snapshot. The gateway guarantees this
+// route never performs provider discovery, token refresh, or quota pulls.
+export async function getOAuthOverview(): Promise<OAuthOverview> {
+  const res = await fetch(`${BASE}/overview?tzOffsetMinutes=${clientTzOffsetMinutes()}`, {
+    headers: { accept: 'application/json' },
+    signal: AbortSignal.timeout(OBSERVABILITY_TIMEOUT_MS),
+  });
+  return asJson(res);
+}
+
+// POST /oauth/refresh -> enqueue one global refresh job. The 202 response is
+// immediate; repeated clicks are coalesced by the gateway coordinator.
+export async function requestOAuthRefresh(): Promise<OAuthAdminRefreshEnqueueResult> {
+  const res = await fetch(`${BASE}/refresh`, {
+    method: 'POST',
+    headers: { accept: 'application/json' },
+  });
+  return asJson(res);
+}
 
 // GET /oauth/usage -> today's per-account usage, bucketed by the VIEWER's local day
 // (send the browser UTC offset so "today" matches the dashboard, not 00:00 UTC).
@@ -167,8 +214,8 @@ export async function getOAuthUsage(): Promise<OAuthUsageRow[]> {
   }
 }
 
-// GET /oauth/quota -> latest rate-limit window snapshot per account. FAIL-OPEN to []
-// (incl. timeout) so a hung Anthropic pull on the server never stalls the page.
+// GET /oauth/quota -> latest cached rate-limit window snapshot per account. FAIL-OPEN
+// to [] (incl. timeout) so an unavailable gateway never stalls the page.
 export async function getOAuthQuota(): Promise<OAuthQuotaSnapshot[]> {
   try {
     const res = await fetch(`${BASE}/quota`, {

--- a/apps/admin/src/lib/components/RefreshControl.svelte
+++ b/apps/admin/src/lib/components/RefreshControl.svelte
@@ -18,9 +18,13 @@
   // cadence is a single admin-wide preference so all pages stay in lockstep.
   let {
     onRefresh,
+    onAutoRefresh,
     storageKey = SHARED_STORAGE_KEY,
   }: {
     onRefresh: () => void | Promise<void>;
+    // Providers uses this to keep timer ticks cache-only while the explicit button
+    // enqueues one upstream refresh. Other pages omit it and retain prior behavior.
+    onAutoRefresh?: () => void | Promise<void>;
     // Mostly for tests/future embedded use. Admin routes should omit this so they
     // all share SHARED_STORAGE_KEY.
     storageKey?: string;
@@ -83,11 +87,11 @@
   }
 
   // Run a refresh, guarding against overlap so a slow load never stacks ticks.
-  async function runRefresh(): Promise<void> {
+  async function runRefresh(callback: () => void | Promise<void> = onRefresh): Promise<void> {
     if (refreshing) return;
     refreshing = true;
     try {
-      await onRefresh();
+      await callback();
     } finally {
       refreshing = false;
     }
@@ -106,7 +110,7 @@
     stopTimer();
     if (seconds > 0) {
       timer = setInterval(() => {
-        void runRefresh();
+        void runRefresh(onAutoRefresh ?? onRefresh);
       }, seconds * 1000);
     }
   }

--- a/apps/admin/src/lib/components/RefreshControl.test.ts
+++ b/apps/admin/src/lib/components/RefreshControl.test.ts
@@ -59,6 +59,23 @@ describe('RefreshControl', () => {
     expect(onRefresh).toHaveBeenCalledTimes(2);
   });
 
+  it('can keep manual refresh separate from cache-only auto refresh', async () => {
+    const onRefresh = vi.fn();
+    const onAutoRefresh = vi.fn();
+    render(RefreshControl, { onRefresh, onAutoRefresh });
+
+    await fireEvent.click(screen.getByTestId('refresh-now'));
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(onAutoRefresh).not.toHaveBeenCalled();
+
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    await fireEvent.click(screen.getByTestId('refresh-interval-5'));
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(onAutoRefresh).toHaveBeenCalledOnce();
+  });
+
   it('surfaces the active cadence and closes the menu after selecting', async () => {
     render(RefreshControl, { onRefresh: vi.fn() });
     await fireEvent.click(screen.getByTestId('refresh-toggle'));

--- a/apps/admin/src/lib/i18n/providers-locales.test.ts
+++ b/apps/admin/src/lib/i18n/providers-locales.test.ts
@@ -11,6 +11,15 @@ import zhHans from '../../locales/zh-hans.json';
 import zhHant from '../../locales/zh-hant.json';
 
 const providerPageKeys = [
+  'Failed to load OAuth providers',
+  'Failed to refresh providers',
+  'Provider refresh queued',
+  'Refreshing provider data…',
+  'Provider refresh failed',
+  'Provider refresh failed: {error}',
+  'Provider data refreshed',
+  'Provider data refreshed at {time}',
+  'refresh available again in {seconds}s',
   'Reset-credit count unavailable',
   'No reset credits available',
   'Weekly quota snapshot unavailable',

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -984,5 +984,14 @@
   "This device code has expired.": "This device code has expired.",
   "Authorization was denied.": "Authorization was denied.",
   "Authorization failed. Start again to retry.": "Authorization failed. Start again to retry.",
-  "Start again": "Start again"
+  "Start again": "Start again",
+  "Failed to load OAuth providers": "Failed to load OAuth providers",
+  "Failed to refresh providers": "Failed to refresh providers",
+  "Provider refresh queued": "Provider refresh queued",
+  "Refreshing provider data…": "Refreshing provider data…",
+  "Provider refresh failed": "Provider refresh failed",
+  "Provider refresh failed: {error}": "Provider refresh failed: {error}",
+  "Provider data refreshed": "Provider data refreshed",
+  "Provider data refreshed at {time}": "Provider data refreshed at {time}",
+  "refresh available again in {seconds}s": "refresh available again in {seconds}s"
 }

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -984,5 +984,14 @@
   "This device code has expired.": "Este código de dispositivo ha caducado.",
   "Authorization was denied.": "Se denegó la autorización.",
   "Authorization failed. Start again to retry.": "La autorización falló. Vuelve a empezar para intentarlo de nuevo.",
-  "Start again": "Volver a empezar"
+  "Start again": "Volver a empezar",
+  "Failed to load OAuth providers": "No se pudieron cargar los proveedores OAuth",
+  "Failed to refresh providers": "No se pudieron actualizar los proveedores",
+  "Provider refresh queued": "Actualización de proveedores en cola",
+  "Refreshing provider data…": "Actualizando datos de proveedores…",
+  "Provider refresh failed": "Error al actualizar los proveedores",
+  "Provider refresh failed: {error}": "Error al actualizar los proveedores: {error}",
+  "Provider data refreshed": "Datos de proveedores actualizados",
+  "Provider data refreshed at {time}": "Datos de proveedores actualizados a las {time}",
+  "refresh available again in {seconds}s": "se podrá actualizar de nuevo en {seconds}s"
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -984,5 +984,14 @@
   "This device code has expired.": "このデバイスコードは期限切れです。",
   "Authorization was denied.": "認証が拒否されました。",
   "Authorization failed. Start again to retry.": "認証に失敗しました。最初からやり直してください。",
-  "Start again": "最初からやり直す"
+  "Start again": "最初からやり直す",
+  "Failed to load OAuth providers": "OAuthプロバイダーの読み込みに失敗しました",
+  "Failed to refresh providers": "プロバイダーの更新に失敗しました",
+  "Provider refresh queued": "プロバイダーの更新をキューに追加しました",
+  "Refreshing provider data…": "プロバイダーデータを更新中…",
+  "Provider refresh failed": "プロバイダーの更新に失敗しました",
+  "Provider refresh failed: {error}": "プロバイダーの更新に失敗しました：{error}",
+  "Provider data refreshed": "プロバイダーデータを更新しました",
+  "Provider data refreshed at {time}": "{time} にプロバイダーデータを更新しました",
+  "refresh available again in {seconds}s": "{seconds}秒後に再度更新できます"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -984,5 +984,14 @@
   "This device code has expired.": "이 장치 코드가 만료되었습니다.",
   "Authorization was denied.": "인증이 거부되었습니다.",
   "Authorization failed. Start again to retry.": "인증에 실패했습니다. 다시 시작하여 재시도하세요.",
-  "Start again": "다시 시작"
+  "Start again": "다시 시작",
+  "Failed to load OAuth providers": "OAuth 공급자를 불러오지 못했습니다",
+  "Failed to refresh providers": "공급자를 새로고침하지 못했습니다",
+  "Provider refresh queued": "공급자 새로고침이 대기열에 추가되었습니다",
+  "Refreshing provider data…": "공급자 데이터 새로고침 중…",
+  "Provider refresh failed": "공급자 새로고침 실패",
+  "Provider refresh failed: {error}": "공급자 새로고침 실패: {error}",
+  "Provider data refreshed": "공급자 데이터를 새로고침했습니다",
+  "Provider data refreshed at {time}": "{time}에 공급자 데이터를 새로고침했습니다",
+  "refresh available again in {seconds}s": "{seconds}초 후 다시 새로고침할 수 있습니다"
 }

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -984,5 +984,14 @@
   "This device code has expired.": "Este código de dispositivo expirou.",
   "Authorization was denied.": "A autorização foi negada.",
   "Authorization failed. Start again to retry.": "A autorização falhou. Comece novamente para tentar outra vez.",
-  "Start again": "Começar novamente"
+  "Start again": "Começar novamente",
+  "Failed to load OAuth providers": "Não foi possível carregar os provedores OAuth",
+  "Failed to refresh providers": "Não foi possível atualizar os provedores",
+  "Provider refresh queued": "Atualização de provedores na fila",
+  "Refreshing provider data…": "Atualizando dados dos provedores…",
+  "Provider refresh failed": "Falha ao atualizar os provedores",
+  "Provider refresh failed: {error}": "Falha ao atualizar os provedores: {error}",
+  "Provider data refreshed": "Dados dos provedores atualizados",
+  "Provider data refreshed at {time}": "Dados dos provedores atualizados às {time}",
+  "refresh available again in {seconds}s": "nova atualização disponível em {seconds}s"
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -984,5 +984,14 @@
   "This device code has expired.": "此设备代码已过期。",
   "Authorization was denied.": "授权已被拒绝。",
   "Authorization failed. Start again to retry.": "授权失败，请重新开始后再试。",
-  "Start again": "重新开始"
+  "Start again": "重新开始",
+  "Failed to load OAuth providers": "加载 OAuth 提供商失败",
+  "Failed to refresh providers": "刷新提供商失败",
+  "Provider refresh queued": "提供商刷新已排队",
+  "Refreshing provider data…": "正在刷新提供商数据…",
+  "Provider refresh failed": "提供商刷新失败",
+  "Provider refresh failed: {error}": "提供商刷新失败：{error}",
+  "Provider data refreshed": "提供商数据已刷新",
+  "Provider data refreshed at {time}": "提供商数据已于 {time} 刷新",
+  "refresh available again in {seconds}s": "{seconds} 秒后可再次刷新"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -984,5 +984,14 @@
   "This device code has expired.": "此裝置代碼已過期。",
   "Authorization was denied.": "授權已被拒絕。",
   "Authorization failed. Start again to retry.": "授權失敗，請重新開始後再試。",
-  "Start again": "重新開始"
+  "Start again": "重新開始",
+  "Failed to load OAuth providers": "載入 OAuth 提供商失敗",
+  "Failed to refresh providers": "重新整理提供商失敗",
+  "Provider refresh queued": "提供商重新整理已排入佇列",
+  "Refreshing provider data…": "正在重新整理提供商資料…",
+  "Provider refresh failed": "提供商重新整理失敗",
+  "Provider refresh failed: {error}": "提供商重新整理失敗：{error}",
+  "Provider data refreshed": "提供商資料已重新整理",
+  "Provider data refreshed at {time}": "提供商資料已於 {time} 重新整理",
+  "refresh available again in {seconds}s": "{seconds} 秒後可再次重新整理"
 }

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import { invalidateAll } from '$app/navigation';
   import { isCodexAccountWeeklyQuotaWindow } from '@helm/shared';
   import {
     consumeCodexResetCredit,
+    getOAuthOverview,
     logoutOAuth,
+    requestOAuthRefresh,
     resetUsageLimit,
     setAccountSchedule,
     setSelectionStrategy,
     type OAuthAccount,
+    type OAuthAdminRefreshStatus,
+    type OAuthOverview,
     type OAuthProviderStatus,
     type OAuthQuotaSnapshot,
     type OAuthQuotaWindow,
@@ -32,16 +36,10 @@
   let {
     data,
   }: {
-    data: {
-      configured: boolean;
-      selectionStrategy: OAuthSelectionStrategy;
-      providers: OAuthProviderStatus[];
-      usage: OAuthUsageRow[];
-      quota: OAuthQuotaSnapshot[];
-      loadError?: string;
-    };
+    data: OAuthOverview & { loadError?: string };
   } = $props();
 
+  let overview = $state<OAuthOverview & { loadError?: string }>(untrack(() => ({ ...data })));
   let error = $state<string | null>(untrack(() => data.loadError ?? null));
   let showConnect = $state<boolean>(false);
   let managing = $state<{ providerId: string; providerName: string; account: string } | null>(null);
@@ -88,6 +86,13 @@
   // the next action. Errors continue to use the shared `error` banner.
   let resetNotice = $state<string | null>(null);
 
+  // Keep mutation-triggered SvelteKit invalidations compatible with the local
+  // cache snapshot used by manual/automatic refreshes.
+  $effect(() => {
+    overview = { ...data };
+    if (data.loadError) error = data.loadError;
+  });
+
   const keyOf = (providerId: string, account: string): string => `${providerId}/${account}`;
   const ACTIVE_LIMIT_RECOVERY_THRESHOLD = 95;
   const CODEX_RESET_MIN_WEEKLY_USED_PERCENT = 90;
@@ -121,14 +126,18 @@
 
   // One table row per connected account, flattened across providers, joined to its
   // usage + quota snapshot (both fail-open: a missing entry renders "—").
-  let usageByKey = $derived(new Map(data.usage.map((u) => [keyOf(u.providerId, u.account), u])));
-  let quotaByKey = $derived(new Map(data.quota.map((q) => [keyOf(q.providerId, q.account), q])));
+  let usageByKey = $derived(
+    new Map(overview.usage.map((u) => [keyOf(u.providerId, u.account), u])),
+  );
+  let quotaByKey = $derived(
+    new Map(overview.quota.map((q) => [keyOf(q.providerId, q.account), q])),
+  );
   let rows = $derived(
-    data.providers.flatMap((p) => p.accounts.map((account) => ({ provider: p, account }))),
+    overview.providers.flatMap((p) => p.accounts.map((account) => ({ provider: p, account }))),
   );
 
   function providerName(id: string): string {
-    return data.providers.find((p) => p.id === id)?.name ?? id;
+    return overview.providers.find((p) => p.id === id)?.name ?? id;
   }
 
   // A short "platform · auth" pill so the supply-chain shape is legible at a glance
@@ -454,15 +463,98 @@
     void invalidateAll();
   }
 
-  // Page refresh: re-run the page load (status + today's usage + quota windows in
-  // parallel). Usage counters are read live; the Anthropic quota PULL stays behind
-  // the gateway's 5-min debounce (the upstream endpoint rate-limits aggressively),
-  // so within that window the bars re-render from the cached snapshot. The load
-  // itself never throws (fail-open) — `loadError` carries the only failure signal.
+  const REFRESH_POLL_MS = 750;
+  const REFRESH_POLL_LIMIT = 160;
+  let destroyed = false;
+  let pollGeneration = 0;
+  onDestroy(() => {
+    destroyed = true;
+    pollGeneration += 1;
+  });
+
+  function refreshActive(status: OAuthAdminRefreshStatus): boolean {
+    return status.state === 'queued' || status.state === 'running';
+  }
+
+  function wait(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function refreshCachedOverview(): Promise<OAuthOverview | null> {
+    try {
+      const next = await getOAuthOverview();
+      if (!destroyed) {
+        overview = next;
+        error = null;
+      }
+      return next;
+    } catch (e) {
+      if (!destroyed) {
+        error = e instanceof Error ? e.message : $t('Failed to load OAuth providers');
+      }
+      return null;
+    }
+  }
+
+  // Poll only the cache-only overview after a job is accepted. One poller per page
+  // is enough; the gateway independently coalesces clicks across tabs/requests.
+  async function pollRefresh(jobId: string | null): Promise<void> {
+    const generation = ++pollGeneration;
+    for (let attempt = 0; attempt < REFRESH_POLL_LIMIT; attempt += 1) {
+      await wait(REFRESH_POLL_MS);
+      if (destroyed || generation !== pollGeneration) return;
+      const next = await refreshCachedOverview();
+      if (!next) return;
+      if (!refreshActive(next.refresh)) return;
+      if (jobId !== null && next.refresh.jobId !== jobId) return;
+    }
+  }
+
+  // Explicit click enqueues upstream work and returns immediately. The latest cache
+  // is rendered at once, then cache-only polling picks up the completed snapshot.
   async function refresh(): Promise<void> {
     error = null;
-    await invalidateAll();
-    error = data.loadError ?? null;
+    try {
+      const queued = await requestOAuthRefresh();
+      overview = { ...overview, refresh: queued.status };
+      const next = await refreshCachedOverview();
+      if (next && refreshActive(next.refresh)) void pollRefresh(next.refresh.jobId);
+    } catch (e) {
+      error = e instanceof Error ? e.message : $t('Failed to refresh providers');
+    }
+  }
+
+  // Timer ticks are intentionally cache-only. They can observe a job started by
+  // another admin tab, but they never create provider traffic themselves.
+  async function autoRefresh(): Promise<void> {
+    await refreshCachedOverview();
+  }
+
+  function refreshStatusLabel(status: OAuthAdminRefreshStatus): string | null {
+    if (status.state === 'queued') return $t('Provider refresh queued');
+    if (status.state === 'running') return $t('Refreshing provider data…');
+    if (status.state === 'failed') {
+      return status.error
+        ? $t('Provider refresh failed: {error}', { error: status.error })
+        : $t('Provider refresh failed');
+    }
+    if (status.state === 'succeeded' || status.lastSuccessAt !== null) {
+      const refreshedAt = status.lastSuccessAt ?? status.finishedAt;
+      const time = refreshedAt === null ? null : new Date(refreshedAt).toLocaleTimeString();
+      const cooldownSeconds =
+        status.nextAllowedAt !== null && status.nextAllowedAt > Date.now()
+          ? Math.max(1, Math.ceil((status.nextAllowedAt - Date.now()) / 1000))
+          : null;
+      const refreshed = time
+        ? $t('Provider data refreshed at {time}', { time })
+        : $t('Provider data refreshed');
+      return cooldownSeconds === null
+        ? refreshed
+        : `${refreshed} · ${$t('refresh available again in {seconds}s', {
+            seconds: cooldownSeconds,
+          })}`;
+    }
+    return null;
   }
 
   function onManaged(): void {
@@ -647,16 +739,28 @@
     </div>
     <div class="flex w-full shrink-0 gap-2 sm:w-auto">
       <div class="flex-1 sm:flex-none">
-        <RefreshControl onRefresh={refresh} />
+        <RefreshControl onRefresh={refresh} onAutoRefresh={autoRefresh} />
       </div>
       <button
         type="button"
         class="btn-primary flex-1 sm:flex-none"
-        disabled={!data.configured}
+        disabled={!overview.configured}
         onclick={() => (showConnect = true)}>{$t('Connect')}</button
       >
     </div>
   </header>
+
+  {#if refreshStatusLabel(overview.refresh)}
+    <p
+      data-testid="provider-refresh-status"
+      class:alert-error={overview.refresh.state === 'failed'}
+      class:field-help={overview.refresh.state !== 'failed'}
+      role="status"
+      aria-live="polite"
+    >
+      {refreshStatusLabel(overview.refresh)}
+    </p>
+  {/if}
 
   {#if error}
     <p class="alert-error" role="alert">{error}</p>
@@ -666,7 +770,7 @@
     <p class="alert-success" role="status">{resetNotice}</p>
   {/if}
 
-  {#if !data.configured}
+  {#if !overview.configured}
     <p class="alert-warn">
       {$t('OAuth login is disabled. Set HELM_OAUTH_ENC_KEY (32 bytes) and restart to enable it.')}
     </p>
@@ -674,7 +778,7 @@
 
   {#if showConnect}
     <ConnectProviderDialog
-      providers={data.providers}
+      providers={overview.providers}
       onconnected={onConnected}
       onclose={() => (showConnect = false)}
     />
@@ -711,7 +815,7 @@
     </div>
   {:else}
     {@const selectedStrategy =
-      strategyOptions.find((option) => option.value === data.selectionStrategy) ??
+      strategyOptions.find((option) => option.value === overview.selectionStrategy) ??
       strategyOptions[0]}
     <div class="card flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div class="min-w-0">
@@ -730,7 +834,7 @@
       <select
         class="select shrink-0 disabled:opacity-50 sm:w-56"
         aria-label={$t('Account usage strategy')}
-        value={data.selectionStrategy}
+        value={overview.selectionStrategy}
         disabled={savingStrategy}
         onchange={(e) => saveSelectionStrategy(e.currentTarget.value as OAuthSelectionStrategy)}
       >

--- a/apps/admin/src/routes/providers/+page.ts
+++ b/apps/admin/src/routes/providers/+page.ts
@@ -1,53 +1,37 @@
 import {
-  getOAuthQuota,
-  getOAuthUsage,
-  listOAuthStatus,
-  type OAuthProviderStatus,
-  type OAuthQuotaSnapshot,
-  type OAuthSelectionStrategy,
-  type OAuthUsageRow,
+  getOAuthOverview,
+  type OAuthAdminRefreshStatus,
+  type OAuthOverview,
 } from '$lib/api/oauth.js';
 import type { PageLoad } from './$types.js';
 
-// SPA load: fetch the OAuth provider catalog + logged-in accounts, plus today's
-// per-account usage and the latest quota window snapshots — all in PARALLEL. Never
-// throws; the status load drives the error state (the page never white-screens),
-// while usage/quota are pure observability and FAIL-OPEN to [] (a slow/down stats
-// endpoint must never block or break the page).
-export const load: PageLoad = async (): Promise<{
-  configured: boolean;
-  selectionStrategy: OAuthSelectionStrategy;
-  providers: OAuthProviderStatus[];
-  usage: OAuthUsageRow[];
-  quota: OAuthQuotaSnapshot[];
-  loadError?: string;
-}> => {
-  const [statusRes, usage, quota] = await Promise.all([
-    listOAuthStatus().then(
-      (r) => ({ ok: true as const, ...r }),
-      (e) => ({ ok: false as const, error: e as unknown }),
-    ),
-    getOAuthUsage(), // already fail-open to []
-    getOAuthQuota(), // already fail-open to []
-  ]);
-  if (!statusRes.ok) {
+const IDLE_REFRESH: OAuthAdminRefreshStatus = {
+  state: 'idle',
+  jobId: null,
+  requestedAt: null,
+  startedAt: null,
+  finishedAt: null,
+  lastSuccessAt: null,
+  nextAllowedAt: null,
+  error: null,
+};
+
+export type ProvidersPageData = OAuthOverview & { loadError?: string };
+
+// The initial render is one cache-only gateway read. Provider discovery, token
+// renewal, and quota pulls only run behind POST /oauth/refresh.
+export const load: PageLoad = async (): Promise<ProvidersPageData> => {
+  try {
+    return await getOAuthOverview();
+  } catch (error) {
     return {
       configured: false,
       selectionStrategy: 'balanced',
       providers: [],
-      usage,
-      quota,
-      loadError:
-        statusRes.error instanceof Error
-          ? statusRes.error.message
-          : 'Failed to load OAuth providers',
+      usage: [],
+      quota: [],
+      refresh: IDLE_REFRESH,
+      loadError: error instanceof Error ? error.message : 'Failed to load OAuth providers',
     };
   }
-  return {
-    configured: statusRes.configured,
-    selectionStrategy: statusRes.selectionStrategy,
-    providers: statusRes.providers,
-    usage,
-    quota,
-  };
 };

--- a/apps/admin/src/routes/providers/page-load.test.ts
+++ b/apps/admin/src/routes/providers/page-load.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getOAuthOverview } from '$lib/api/oauth.js';
+import { load } from './+page.js';
+
+vi.mock('$lib/api/oauth.js', () => ({
+  getOAuthOverview: vi.fn(),
+}));
+
+const getOAuthOverviewMock = vi.mocked(getOAuthOverview);
+
+describe('providers page load', () => {
+  beforeEach(() => {
+    getOAuthOverviewMock.mockReset();
+  });
+
+  it('loads one cache-only overview instead of three blocking requests', async () => {
+    getOAuthOverviewMock.mockResolvedValue({
+      configured: true,
+      selectionStrategy: 'balanced',
+      providers: [],
+      usage: [],
+      quota: [],
+      refresh: {
+        state: 'idle',
+        jobId: null,
+        requestedAt: null,
+        startedAt: null,
+        finishedAt: null,
+        lastSuccessAt: null,
+        nextAllowedAt: null,
+        error: null,
+      },
+    });
+
+    await expect(load({} as Parameters<typeof load>[0])).resolves.toMatchObject({
+      configured: true,
+      refresh: { state: 'idle' },
+    });
+    expect(getOAuthOverviewMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns a renderable cached-page fallback when the overview request fails', async () => {
+    getOAuthOverviewMock.mockRejectedValue(new Error('gateway unavailable'));
+
+    await expect(load({} as Parameters<typeof load>[0])).resolves.toMatchObject({
+      configured: false,
+      providers: [],
+      usage: [],
+      quota: [],
+      refresh: { state: 'idle' },
+      loadError: 'gateway unavailable',
+    });
+  });
+});

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/sve
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { invalidateAll } from '$app/navigation';
 import type {
+  OAuthAdminRefreshStatus,
+  OAuthOverview,
   OAuthProviderStatus,
   OAuthQuotaSnapshot,
   OAuthSelectionStrategy,
@@ -19,15 +21,19 @@ const setAccountSchedule = vi.fn();
 const setSelectionStrategy = vi.fn();
 const streamAccountTest = vi.fn();
 const consumeCodexResetCredit = vi.fn();
+const getOAuthOverview = vi.fn();
+const requestOAuthRefresh = vi.fn();
 vi.mock('$lib/api/oauth.js', () => ({
   completeManualPaste: vi.fn(),
   consumeCodexResetCredit: (...args: unknown[]) => consumeCodexResetCredit(...args),
   getAccountModels: (...args: unknown[]) => getAccountModels(...args),
   getAccountProxy: (...args: unknown[]) => getAccountProxy(...args),
   getAccountSchedule: (...args: unknown[]) => getAccountSchedule(...args),
+  getOAuthOverview: (...args: unknown[]) => getOAuthOverview(...args),
   logoutOAuth: (...args: unknown[]) => logoutOAuth(...args),
   pollDeviceCode: vi.fn(),
   resetUsageLimit: (...args: unknown[]) => resetUsageLimit(...args),
+  requestOAuthRefresh: (...args: unknown[]) => requestOAuthRefresh(...args),
   setAccountModels: (...args: unknown[]) => setAccountModels(...args),
   setAccountProxy: vi.fn(),
   setAccountSchedule: (...args: unknown[]) => setAccountSchedule(...args),
@@ -87,6 +93,17 @@ const quota: OAuthQuotaSnapshot[] = [
   },
 ];
 
+const idleRefresh: OAuthAdminRefreshStatus = {
+  state: 'idle',
+  jobId: null,
+  requestedAt: null,
+  startedAt: null,
+  finishedAt: null,
+  lastSuccessAt: null,
+  nextAllowedAt: null,
+  error: null,
+};
+
 function renderPage(
   overrides: Partial<{
     configured: boolean;
@@ -94,6 +111,7 @@ function renderPage(
     providers: OAuthProviderStatus[];
     usage: OAuthUsageRow[];
     quota: OAuthQuotaSnapshot[];
+    refresh: OAuthAdminRefreshStatus;
     loadError?: string;
   }> = {},
 ) {
@@ -104,6 +122,7 @@ function renderPage(
       providers: [provider()],
       usage,
       quota,
+      refresh: idleRefresh,
       ...overrides,
     },
   });
@@ -120,6 +139,8 @@ describe('providers page', () => {
     setSelectionStrategy.mockReset();
     streamAccountTest.mockReset();
     consumeCodexResetCredit.mockReset();
+    getOAuthOverview.mockReset();
+    requestOAuthRefresh.mockReset();
     invalidateAllMock.mockReset();
     logoutOAuth.mockResolvedValue(undefined);
     getAccountModels.mockResolvedValue({
@@ -138,6 +159,20 @@ describe('providers page', () => {
     setAccountModels.mockResolvedValue(undefined);
     setAccountSchedule.mockResolvedValue(undefined);
     setSelectionStrategy.mockResolvedValue(undefined);
+    getOAuthOverview.mockResolvedValue({
+      configured: true,
+      selectionStrategy: 'balanced',
+      providers: [provider()],
+      usage,
+      quota,
+      refresh: idleRefresh,
+    } satisfies OAuthOverview);
+    requestOAuthRefresh.mockResolvedValue({
+      accepted: true,
+      coalesced: false,
+      retryAfterMs: 0,
+      status: { ...idleRefresh, state: 'queued', jobId: 'refresh-1', requestedAt: Date.now() },
+    });
   });
 
   it('labels the Grok subscription provider as experimental', () => {
@@ -445,11 +480,57 @@ describe('providers page', () => {
     renderPage();
 
     await fireEvent.click(screen.getByTestId('refresh-now'));
-    expect(invalidateAllMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(requestOAuthRefresh).toHaveBeenCalledOnce());
+    await waitFor(() => expect(getOAuthOverview).toHaveBeenCalledOnce());
+    expect(invalidateAllMock).not.toHaveBeenCalled();
 
     await fireEvent.click(screen.getByTestId('refresh-toggle'));
     expect(screen.getByTestId('refresh-menu')).toBeInTheDocument();
     expect(screen.getByTestId('refresh-interval-10')).toHaveTextContent('10s');
+  });
+
+  it('shows the latest cached data after the queued refresh completes', async () => {
+    const refreshedAt = Date.now();
+    getOAuthOverview.mockResolvedValue({
+      configured: true,
+      selectionStrategy: 'balanced',
+      providers: [provider()],
+      usage: [{ ...usage[0]!, requests: 99 }],
+      quota,
+      refresh: {
+        ...idleRefresh,
+        state: 'succeeded',
+        jobId: 'refresh-1',
+        requestedAt: refreshedAt - 100,
+        startedAt: refreshedAt - 80,
+        finishedAt: refreshedAt,
+        lastSuccessAt: refreshedAt,
+        nextAllowedAt: refreshedAt + 60_000,
+      },
+    } satisfies OAuthOverview);
+    renderPage();
+
+    await fireEvent.click(screen.getByTestId('refresh-now'));
+
+    await waitFor(() => expect(screen.getByText('99 req')).toBeInTheDocument());
+    expect(screen.getByTestId('provider-refresh-status')).toHaveTextContent(
+      'Provider data refreshed',
+    );
+  });
+
+  it('keeps timer-driven auto refresh cache-only', async () => {
+    vi.useFakeTimers();
+    try {
+      renderPage();
+      await fireEvent.click(screen.getByTestId('refresh-toggle'));
+      await fireEvent.click(screen.getByTestId('refresh-interval-5'));
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(getOAuthOverview).toHaveBeenCalledOnce();
+      expect(requestOAuthRefresh).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('labels the current Claude scoped weekly Fable quota window', () => {

--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -452,6 +452,46 @@ describe("createOAuthAdmin", () => {
     ).toContain("proxy-ep=proxy.y.com");
   });
 
+  it("listCachedStatus never refreshes an expired credential or discovers models upstream", async () => {
+    const { tokens, config } = makeStores();
+    await tokens.upsert({
+      providerId: "anthropic",
+      account: "cached",
+      accessEnc: encryptSecret("expired-access", KEY),
+      refreshEnc: encryptSecret("durable-refresh", KEY),
+      expiresAt: 1_000,
+      meta: null,
+      updatedAt: 500,
+    });
+    await setAccountSettings(config, KEY, "anthropic", "cached", {
+      modelsMode: "manual",
+      enabledModels: ["claude-opus-4-6"],
+    });
+    const fetchFn = vi.fn(async () => {
+      throw new Error("cached status must not access the network");
+    });
+    const admin = createOAuthAdmin({
+      store: tokens,
+      encKey: KEY,
+      config,
+      now: () => 10_000_000,
+      makeFetch: () => fetchFn as unknown as typeof fetch,
+    });
+
+    const account = (await admin.listCachedStatus()).providers
+      .find((provider) => provider.id === "anthropic")
+      ?.accounts.find((candidate) => candidate.account === "cached");
+
+    expect(account).toMatchObject({
+      account: "cached",
+      expiresAt: 1_000,
+      updatedAt: 500,
+      healthy: true,
+      models: ["claude-opus-4-6"],
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
   it("listStatus marks an account unhealthy when its refresh fails (needs reconnect)", async () => {
     const store = makeStore();
     const config = makeConfig();

--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -476,6 +476,20 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
   // undefined for the Anthropic path (which has no such grant).
   const quotaCache = new Map<string, CodexQuotaCacheValue>();
   const quotaCacheEpoch = new Map<string, number>();
+  const cachedCodexQuota = (account: string): CodexQuotaResult => {
+    const cached = quotaCache.get(`${CODEX} ${account}`);
+    if (!cached || cached.windows === null) return null;
+    return {
+      windows: cached.windows,
+      additionalLimits: cached.additionalLimits ?? [],
+      resetCredits: cached.resetCredits ?? null,
+      resetCreditDetails: cached.resetCreditDetails ?? null,
+      credits: cached.credits ?? null,
+      individualLimit: cached.individualLimit ?? null,
+      planType: cached.planType ?? null,
+      rateLimitReachedType: cached.rateLimitReachedType ?? null,
+    };
+  };
   const invalidateQuotaCache = (providerId: string, account: string): void => {
     const key = `${providerId} ${account}`;
     quotaCache.delete(key);
@@ -508,25 +522,30 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     providerId: string,
     account: string,
     settings: AccountSettings,
+    forceRefresh = false,
   ): Promise<{ available: string[]; entitled: string[] }> {
     const provider = getOAuthProvider(providerId);
     if (!provider) return { available: [], entitled: [] };
     if (providerId !== CODEX) {
-      const available = await modelDiscoveryCache.load({ providerId, account }, async () => {
-        const accountFetch = makeFetch(settings.proxy as ProxyConfig | undefined);
-        const tm = createTokenManager({
-          oauth: { kind: "preset", providerId, account },
-          tokenStore: deps.store,
-          encKey: deps.encKey,
-          oauthProvider: provider,
-          fetch: accountFetch,
-          now,
-        });
-        const accessToken = (await tm.getAuthHeader()).replace(/^Bearer /, "");
-        return discoverOAuthModels(providerId, accessToken, accountFetch, {
-          fallbackToCurated: false,
-        });
-      });
+      const available = await modelDiscoveryCache.load(
+        { providerId, account },
+        async () => {
+          const accountFetch = makeFetch(settings.proxy as ProxyConfig | undefined);
+          const tm = createTokenManager({
+            oauth: { kind: "preset", providerId, account },
+            tokenStore: deps.store,
+            encKey: deps.encKey,
+            oauthProvider: provider,
+            fetch: accountFetch,
+            now,
+          });
+          const accessToken = (await tm.getAuthHeader()).replace(/^Bearer /, "");
+          return discoverOAuthModels(providerId, accessToken, accountFetch, {
+            fallbackToCurated: false,
+          });
+        },
+        { force: forceRefresh },
+      );
       return { available, entitled: available };
     }
     try {
@@ -550,17 +569,21 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
           accountIdentity: openAICodexIdentityFingerprint(identity),
           clientVersion,
         };
-        const snapshot = await deps.codexCatalog.load(key, async () => {
-          const currentAccess = (await tm.getAuthHeader()).replace(/^Bearer /, "");
-          const currentIdentity = mergeCodexIdentity(currentAccess, tm.currentMetadata());
-          return listOpenAICodexModels(currentAccess, {
-            accountId: currentIdentity.accountId,
-            isFedramp: currentIdentity.isFedramp,
-            clientVersion,
-            userAgent,
-            fetchImpl: accountFetch,
-          });
-        });
+        const snapshot = await deps.codexCatalog.load(
+          key,
+          async () => {
+            const currentAccess = (await tm.getAuthHeader()).replace(/^Bearer /, "");
+            const currentIdentity = mergeCodexIdentity(currentAccess, tm.currentMetadata());
+            return listOpenAICodexModels(currentAccess, {
+              accountId: currentIdentity.accountId,
+              isFedramp: currentIdentity.isFedramp,
+              clientVersion,
+              userAgent,
+              fetchImpl: accountFetch,
+            });
+          },
+          { force: forceRefresh },
+        );
         if (!snapshot) return { available: [], entitled: [] };
         const modelSets = codexModelSets(snapshot.models);
         return { available: modelSets.visible, entitled: modelSets.entitled };
@@ -682,99 +705,117 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     };
   }
 
-  return {
-    async listStatus(): Promise<OAuthAdminStatusResponse> {
-      const rows = await deps.store.list();
-      // Load the per-account settings blob ONCE for the whole page (a single decrypt)
-      // so the list carries each account's effective priority + schedulable without an
-      // N+1 per-account GET. Fail-open to {} (defaults applied below).
-      const settings = await loadAccountSettings(deps.config, deps.encKey);
-      const globalSettings = await loadGlobalOAuthSettings(deps.config, deps.encKey);
-      // Ensure-fresh every stored account in parallel so the page reflects live,
-      // auto-renewed expiries (and surfaces a dead credential as unhealthy).
-      const refreshed = await Promise.all(
-        rows.map(async (r) => {
-          // Same defaults as getAccountSchedule (priority 50, schedulable true) so a
-          // never-tuned account always renders a concrete value.
-          const sch = getAccountSettings(settings, r.providerId, r.account);
-          const hasCredentialFailure = typeof sch.credentialFailedAt === "number";
-          const fresh = hasCredentialFailure
-            ? {
-                account: r.account,
-                expiresAt: r.expiresAt,
-                updatedAt: r.updatedAt,
-                healthy: false,
-                credentialFailed: true,
-              }
-            : await ensureFresh(r.providerId, r.account, r, sch.proxy as ProxyConfig | undefined);
-          const { credentialFailed, ...freshView } = fresh;
-          const modelsMode = resolveAccountModelsMode(r.providerId, sch);
-          const discovered =
-            modelsMode === "auto" && fresh.healthy
-              ? await discoverAccountModels(r.providerId, r.account, sch)
-              : r.providerId === CODEX
-                ? {
-                    available: [],
-                    entitled: (await codexCatalogModels(r.account))?.entitled ?? [],
-                  }
-                : { available: [], entitled: [] };
-          const models = enabledAccountModels(r.providerId, sch, discovered);
-          const identity = await statusCodexIdentity(
-            deps.store,
-            deps.encKey,
-            r.providerId,
-            r.account,
-          );
-          return {
-            providerId: r.providerId,
-            ...freshView,
-            credentialFailed,
-            ...(identity.email ? { email: identity.email } : {}),
-            ...(identity.chatgptPlanType ? { chatgptPlanType: identity.chatgptPlanType } : {}),
-            ...(identity.accountId ? { chatgptAccountId: identity.accountId } : {}),
-            ...(typeof identity.isFedramp === "boolean" ? { isFedramp: identity.isFedramp } : {}),
-            priority: sch.priority ?? 50,
-            schedulable: credentialFailed ? false : (sch.schedulable ?? true),
-            autoReset: sch.autoReset ?? false,
-            fastMode: sch.fastMode ?? false,
-            // Manual mode comes from the saved allowlist. Auto mode comes from this
-            // account's discovery result and never substitutes curated fallback ids.
-            proxy: redactProxy(sch.proxy),
-            models,
-          };
-        }),
-      );
-      const accountsFor = (id: string) =>
-        refreshed.filter((x) => x.providerId === id).map(({ providerId: _p, ...rest }) => rest);
+  async function buildStatus(options: {
+    refresh: boolean;
+    forceRefresh: boolean;
+    serial: boolean;
+  }): Promise<OAuthAdminStatusResponse> {
+    const rows = await deps.store.list();
+    const settings = await loadAccountSettings(deps.config, deps.encKey);
+    const globalSettings = await loadGlobalOAuthSettings(deps.config, deps.encKey);
+    const project = async (r: (typeof rows)[number]) => {
+      const sch = getAccountSettings(settings, r.providerId, r.account);
+      const hasCredentialFailure = typeof sch.credentialFailedAt === "number";
+      const fresh =
+        options.refresh && !hasCredentialFailure
+          ? await ensureFresh(r.providerId, r.account, r, sch.proxy as ProxyConfig | undefined)
+          : {
+              account: r.account,
+              expiresAt: r.expiresAt,
+              updatedAt: r.updatedAt,
+              healthy: !hasCredentialFailure,
+              credentialFailed: hasCredentialFailure,
+            };
+      const { credentialFailed, ...freshView } = fresh;
+      const modelsMode = resolveAccountModelsMode(r.providerId, sch);
+      let discovered: { available: string[]; entitled: string[] };
+      if (options.refresh && modelsMode === "auto" && fresh.healthy) {
+        discovered = await discoverAccountModels(
+          r.providerId,
+          r.account,
+          sch,
+          options.forceRefresh,
+        );
+      } else if (r.providerId === CODEX) {
+        const cached = await codexCatalogModels(r.account);
+        discovered = { available: cached?.visible ?? [], entitled: cached?.entitled ?? [] };
+      } else if (modelsMode === "auto") {
+        const cached = modelDiscoveryCache.snapshot({
+          providerId: r.providerId,
+          account: r.account,
+        });
+        discovered = { available: cached ?? [], entitled: cached ?? [] };
+      } else {
+        discovered = { available: [], entitled: [] };
+      }
+      const models = enabledAccountModels(r.providerId, sch, discovered);
+      const identity = await statusCodexIdentity(deps.store, deps.encKey, r.providerId, r.account);
       return {
-        selectionStrategy: globalSettings.selectionStrategy ?? "balanced",
-        providers: [
-          {
-            id: ANTHROPIC,
-            name: "Anthropic (Claude Pro/Max)",
-            flow: "manual_paste",
-            accounts: accountsFor(ANTHROPIC),
-          },
-          {
-            id: CODEX,
-            name: "ChatGPT Plus/Pro (Codex)",
-            flow: "manual_paste",
-            accounts: accountsFor(CODEX),
-          },
-          {
-            id: COPILOT,
-            name: "GitHub Copilot",
-            flow: "device_code",
-            accounts: accountsFor(COPILOT),
-          },
-          {
-            id: XAI,
-            name: "xAI (SuperGrok/X Premium) · Experimental",
-            flow: "device_code",
-            accounts: accountsFor(XAI),
-          },
-        ],
+        providerId: r.providerId,
+        ...freshView,
+        credentialFailed,
+        ...(identity.email ? { email: identity.email } : {}),
+        ...(identity.chatgptPlanType ? { chatgptPlanType: identity.chatgptPlanType } : {}),
+        ...(identity.accountId ? { chatgptAccountId: identity.accountId } : {}),
+        ...(typeof identity.isFedramp === "boolean" ? { isFedramp: identity.isFedramp } : {}),
+        priority: sch.priority ?? 50,
+        schedulable: credentialFailed ? false : (sch.schedulable ?? true),
+        autoReset: sch.autoReset ?? false,
+        fastMode: sch.fastMode ?? false,
+        proxy: redactProxy(sch.proxy),
+        models,
       };
+    };
+    const refreshed: Array<Awaited<ReturnType<typeof project>>> = [];
+    if (options.serial) {
+      for (const row of rows) refreshed.push(await project(row));
+    } else {
+      refreshed.push(...(await Promise.all(rows.map(project))));
+    }
+    const accountsFor = (id: string) =>
+      refreshed.filter((x) => x.providerId === id).map(({ providerId: _p, ...rest }) => rest);
+    return {
+      selectionStrategy: globalSettings.selectionStrategy ?? "balanced",
+      providers: [
+        {
+          id: ANTHROPIC,
+          name: "Anthropic (Claude Pro/Max)",
+          flow: "manual_paste",
+          accounts: accountsFor(ANTHROPIC),
+        },
+        {
+          id: CODEX,
+          name: "ChatGPT Plus/Pro (Codex)",
+          flow: "manual_paste",
+          accounts: accountsFor(CODEX),
+        },
+        {
+          id: COPILOT,
+          name: "GitHub Copilot",
+          flow: "device_code",
+          accounts: accountsFor(COPILOT),
+        },
+        {
+          id: XAI,
+          name: "xAI (SuperGrok/X Premium) · Experimental",
+          flow: "device_code",
+          accounts: accountsFor(XAI),
+        },
+      ],
+    };
+  }
+
+  return {
+    async listCachedStatus(): Promise<OAuthAdminStatusResponse> {
+      return buildStatus({ refresh: false, forceRefresh: false, serial: false });
+    },
+
+    async listStatus(options = {}): Promise<OAuthAdminStatusResponse> {
+      return buildStatus({
+        refresh: true,
+        forceRefresh: options.forceRefresh === true,
+        serial: options.serial === true,
+      });
     },
 
     async startManualPaste({ providerId, proxy }) {
@@ -1043,14 +1084,14 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       await setGlobalOAuthSettings(deps.config, deps.encKey, { selectionStrategy });
     },
 
-    async fetchAnthropicQuota({ account }): Promise<OAuthQuotaWindow[] | null> {
+    async fetchAnthropicQuota({ account, force = false }): Promise<OAuthQuotaWindow[] | null> {
       // Serve from the 5-min cache when warm — INCLUDING a cached failure (null) —
       // so reopening the providers page or saving an account setting never re-hits
       // the upstream usage endpoint, which itself rate-limits aggressively. Refresh
       // is therefore page-open-driven AND debounced to at most once per TTL.
       const key = `${ANTHROPIC}${" "}${account}`;
       const cached = quotaCache.get(key);
-      if (cached && now() - cached.at < QUOTA_TTL_MS) return cached.windows;
+      if (!force && cached && now() - cached.at < QUOTA_TTL_MS) return cached.windows;
       const epoch = quotaCacheEpoch.get(key) ?? 0;
       const provider = getOAuthProvider(ANTHROPIC);
       if (!provider) return null;
@@ -1115,10 +1156,10 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       return windows;
     },
 
-    async fetchXaiQuota({ account }): Promise<OAuthQuotaWindow[] | null> {
+    async fetchXaiQuota({ account, force = false }): Promise<OAuthQuotaWindow[] | null> {
       const key = `${XAI} ${account}`;
       const cached = quotaCache.get(key);
-      if (cached && now() - cached.at < QUOTA_TTL_MS) return cached.windows;
+      if (!force && cached && now() - cached.at < QUOTA_TTL_MS) return cached.windows;
       const epoch = quotaCacheEpoch.get(key) ?? 0;
       const provider = getOAuthProvider(XAI);
       if (!provider) return null;
@@ -1174,7 +1215,11 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       return windows;
     },
 
-    async fetchCodexQuota({ account }): Promise<CodexQuotaResult> {
+    async getCachedCodexQuota({ account }): Promise<CodexQuotaResult> {
+      return cachedCodexQuota(account);
+    },
+
+    async fetchCodexQuota({ account, force = false }): Promise<CodexQuotaResult> {
       // Twin of fetchAnthropicQuota above — same 5-min cache (success AND failure),
       // same bounded timeout, same per-account proxy reuse. Codex-specific bits:
       // the endpoint keys on `chatgpt-account-id` (decoded from the access-token
@@ -1183,20 +1228,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       // one PULL) so the providers page can render quota + enable the reset button.
       const key = `${CODEX} ${account}`;
       const cached = quotaCache.get(key);
-      if (cached && now() - cached.at < QUOTA_TTL_MS) {
-        if (cached.windows === null) return null;
-        const result = {
-          windows: cached.windows,
-          additionalLimits: cached.additionalLimits ?? [],
-          resetCredits: cached.resetCredits ?? null,
-          resetCreditDetails: cached.resetCreditDetails ?? null,
-          credits: cached.credits ?? null,
-          individualLimit: cached.individualLimit ?? null,
-          planType: cached.planType ?? null,
-          rateLimitReachedType: cached.rateLimitReachedType ?? null,
-        };
-        return result;
-      }
+      if (!force && cached && now() - cached.at < QUOTA_TTL_MS) return cachedCodexQuota(account);
       const epoch = quotaCacheEpoch.get(key) ?? 0;
       const provider = getOAuthProvider(CODEX);
       if (!provider) return null;

--- a/apps/gateway/src/oauth/admin-refresh-coordinator.test.ts
+++ b/apps/gateway/src/oauth/admin-refresh-coordinator.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOAuthAdminRefreshCoordinator } from "./admin-refresh-coordinator.js";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("OAuth admin refresh coordinator", () => {
+  it("coalesces concurrent refresh clicks into one running job", async () => {
+    const gate = deferred();
+    const refresh = vi.fn(() => gate.promise);
+    const coordinator = createOAuthAdminRefreshCoordinator({
+      refresh,
+      generateJobId: () => "refresh-1",
+    });
+
+    const first = coordinator.enqueue();
+    const followers = Array.from({ length: 19 }, () => coordinator.enqueue());
+    await vi.waitFor(() => expect(coordinator.status().state).toBe("running"));
+
+    expect(first).toMatchObject({ accepted: true, coalesced: false });
+    expect(followers).toHaveLength(19);
+    expect(followers.every((result) => result.coalesced)).toBe(true);
+    expect(new Set([first, ...followers].map((result) => result.status.jobId))).toEqual(
+      new Set(["refresh-1"]),
+    );
+    expect(refresh).toHaveBeenCalledOnce();
+
+    gate.resolve();
+    await coordinator.waitForIdle();
+    expect(coordinator.status()).toMatchObject({ state: "succeeded", jobId: "refresh-1" });
+  });
+
+  it("rejects a new job during the post-success cooldown", async () => {
+    let now = 1_000;
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const coordinator = createOAuthAdminRefreshCoordinator({
+      refresh,
+      now: () => now,
+      cooldownMs: 60_000,
+      generateJobId: () => "refresh-1",
+    });
+
+    coordinator.enqueue();
+    await coordinator.waitForIdle();
+    now += 30_000;
+    const blocked = coordinator.enqueue();
+
+    expect(blocked).toMatchObject({
+      accepted: false,
+      coalesced: true,
+      retryAfterMs: 30_000,
+      status: { state: "succeeded", jobId: "refresh-1", nextAllowedAt: 61_000 },
+    });
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("starts a new job after the cooldown expires", async () => {
+    let now = 1_000;
+    let sequence = 0;
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const coordinator = createOAuthAdminRefreshCoordinator({
+      refresh,
+      now: () => now,
+      cooldownMs: 60_000,
+      generateJobId: () => `refresh-${++sequence}`,
+    });
+
+    coordinator.enqueue();
+    await coordinator.waitForIdle();
+    now = 61_000;
+    const second = coordinator.enqueue();
+    await coordinator.waitForIdle();
+
+    expect(second).toMatchObject({ accepted: true, coalesced: false });
+    expect(second.status.jobId).toBe("refresh-2");
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("records a failed job and releases the queue", async () => {
+    let now = 1_000;
+    let shouldFail = true;
+    const refresh = vi.fn(async () => {
+      if (shouldFail) throw new Error("upstream timeout");
+    });
+    const coordinator = createOAuthAdminRefreshCoordinator({
+      refresh,
+      now: () => now,
+      cooldownMs: 60_000,
+      generateJobId: () => "refresh-1",
+    });
+
+    coordinator.enqueue();
+    await coordinator.waitForIdle();
+
+    expect(coordinator.status()).toMatchObject({
+      state: "failed",
+      error: "upstream timeout",
+      nextAllowedAt: 61_000,
+    });
+
+    shouldFail = false;
+    now = 61_000;
+    expect(coordinator.enqueue()).toMatchObject({ accepted: true });
+    await coordinator.waitForIdle();
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/gateway/src/oauth/admin-refresh-coordinator.ts
+++ b/apps/gateway/src/oauth/admin-refresh-coordinator.ts
@@ -1,0 +1,129 @@
+export type OAuthAdminRefreshState = "idle" | "queued" | "running" | "succeeded" | "failed";
+
+export interface OAuthAdminRefreshStatus {
+  state: OAuthAdminRefreshState;
+  jobId: string | null;
+  requestedAt: number | null;
+  startedAt: number | null;
+  finishedAt: number | null;
+  lastSuccessAt: number | null;
+  nextAllowedAt: number | null;
+  error: string | null;
+}
+
+export interface OAuthAdminRefreshEnqueueResult {
+  accepted: boolean;
+  coalesced: boolean;
+  retryAfterMs: number;
+  status: OAuthAdminRefreshStatus;
+}
+
+export interface OAuthAdminRefreshCoordinator {
+  enqueue(): OAuthAdminRefreshEnqueueResult;
+  status(): OAuthAdminRefreshStatus;
+  waitForIdle(): Promise<void>;
+}
+
+export interface OAuthAdminRefreshCoordinatorOptions {
+  refresh: () => Promise<void>;
+  cooldownMs?: number;
+  now?: () => number;
+  generateJobId?: () => string;
+}
+
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+function cloneStatus(status: OAuthAdminRefreshStatus): OAuthAdminRefreshStatus {
+  return { ...status };
+}
+
+function safeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "provider refresh failed";
+}
+
+export function createOAuthAdminRefreshCoordinator(
+  options: OAuthAdminRefreshCoordinatorOptions,
+): OAuthAdminRefreshCoordinator {
+  const now = options.now ?? (() => Date.now());
+  const cooldownMs = Math.max(0, options.cooldownMs ?? DEFAULT_COOLDOWN_MS);
+  const generateJobId = options.generateJobId ?? (() => crypto.randomUUID());
+  let active: Promise<void> | null = null;
+  let current: OAuthAdminRefreshStatus = {
+    state: "idle",
+    jobId: null,
+    requestedAt: null,
+    startedAt: null,
+    finishedAt: null,
+    lastSuccessAt: null,
+    nextAllowedAt: null,
+    error: null,
+  };
+
+  function result(accepted: boolean, coalesced: boolean): OAuthAdminRefreshEnqueueResult {
+    const currentTime = now();
+    return {
+      accepted,
+      coalesced,
+      retryAfterMs:
+        current.nextAllowedAt === null ? 0 : Math.max(0, current.nextAllowedAt - currentTime),
+      status: cloneStatus(current),
+    };
+  }
+
+  return {
+    enqueue() {
+      if (active !== null) return result(false, true);
+      const currentTime = now();
+      if (current.nextAllowedAt !== null && current.nextAllowedAt > currentTime) {
+        return result(false, true);
+      }
+
+      current = {
+        state: "queued",
+        jobId: generateJobId(),
+        requestedAt: currentTime,
+        startedAt: null,
+        finishedAt: null,
+        lastSuccessAt: current.lastSuccessAt,
+        nextAllowedAt: null,
+        error: null,
+      };
+      active = Promise.resolve()
+        .then(async () => {
+          current = { ...current, state: "running", startedAt: now() };
+          await options.refresh();
+          const finishedAt = now();
+          current = {
+            ...current,
+            state: "succeeded",
+            finishedAt,
+            lastSuccessAt: finishedAt,
+            nextAllowedAt: finishedAt + cooldownMs,
+            error: null,
+          };
+        })
+        .catch((error: unknown) => {
+          const finishedAt = now();
+          current = {
+            ...current,
+            state: "failed",
+            finishedAt,
+            nextAllowedAt: finishedAt + cooldownMs,
+            error: safeErrorMessage(error),
+          };
+        })
+        .finally(() => {
+          active = null;
+        });
+      return result(true, false);
+    },
+
+    status() {
+      return cloneStatus(current);
+    },
+
+    async waitForIdle() {
+      while (active !== null) await active;
+    },
+  };
+}

--- a/apps/gateway/src/oauth/codex-model-catalog.ts
+++ b/apps/gateway/src/oauth/codex-model-catalog.ts
@@ -26,6 +26,7 @@ export interface CodexModelCatalog {
   load(
     key: CodexModelCacheKey,
     fetchModels: () => Promise<OpenAICodexModelsResult>,
+    options?: { force?: boolean },
   ): Promise<CodexModelCatalogSnapshot | null>;
   snapshot(key: CodexModelCacheKey): CodexModelCatalogSnapshot | undefined;
   resolve(key: CodexModelCacheKey, model: string): CodexModelInfo | undefined;
@@ -207,12 +208,12 @@ export function createCodexModelCatalog(options: CodexModelCatalogOptions): Code
   }
 
   return {
-    async load(key, fetchModels) {
+    async load(key, fetchModels, loadOptions = {}) {
       const normalized = normalizedKey(key);
       if (normalized === null) return null;
       const hit = await options.cache.get(normalized);
       const cachedModels = hit ? parseModels(hit.entry.models) : null;
-      if (hit?.fresh && cachedModels) {
+      if (loadOptions.force !== true && hit?.fresh && cachedModels) {
         const models = applyRemoteModels(normalized, cachedModels);
         if (models.length > 0) {
           return apply(

--- a/apps/gateway/src/oauth/model-discovery-cache.test.ts
+++ b/apps/gateway/src/oauth/model-discovery-cache.test.ts
@@ -4,6 +4,17 @@ import { createOAuthModelDiscoveryCache } from "./model-discovery-cache.js";
 const KEY = { providerId: "anthropic", account: "default" };
 
 describe("createOAuthModelDiscoveryCache", () => {
+  it("exposes the last-known-good snapshot without running discovery", async () => {
+    const discover = vi.fn(async () => ["claude-fable-5"]);
+    const cache = createOAuthModelDiscoveryCache();
+
+    expect(cache.snapshot(KEY)).toBeUndefined();
+    await cache.load(KEY, discover);
+
+    expect(cache.snapshot(KEY)).toEqual(["claude-fable-5"]);
+    expect(discover).toHaveBeenCalledOnce();
+  });
+
   it("serves account discovery from cache until the positive TTL expires", async () => {
     let now = 1_000;
     const discover = vi.fn(async () => ["claude-fable-5"]);
@@ -40,6 +51,29 @@ describe("createOAuthModelDiscoveryCache", () => {
       ["claude-fable-5"],
     ]);
     expect(discover).toHaveBeenCalledTimes(1);
+  });
+
+  it("force refresh bypasses a fresh value while retaining single-flight", async () => {
+    let release: ((models: string[]) => void) | undefined;
+    const pending = new Promise<string[]>((resolve) => {
+      release = resolve;
+    });
+    const discover = vi
+      .fn<() => Promise<string[]>>()
+      .mockResolvedValueOnce(["claude-fable-5"])
+      .mockImplementationOnce(() => pending);
+    const cache = createOAuthModelDiscoveryCache();
+
+    await cache.load(KEY, discover);
+    const first = cache.load(KEY, discover, { force: true });
+    const second = cache.load(KEY, discover, { force: true });
+    release?.(["claude-opus-4-8"]);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      ["claude-opus-4-8"],
+      ["claude-opus-4-8"],
+    ]);
+    expect(discover).toHaveBeenCalledTimes(2);
   });
 
   it("keeps last-known-good models and negative-caches an empty refresh", async () => {

--- a/apps/gateway/src/oauth/model-discovery-cache.ts
+++ b/apps/gateway/src/oauth/model-discovery-cache.ts
@@ -8,7 +8,12 @@ export interface OAuthModelDiscoveryCacheKey {
 }
 
 export interface OAuthModelDiscoveryCache {
-  load(key: OAuthModelDiscoveryCacheKey, discover: () => Promise<string[]>): Promise<string[]>;
+  load(
+    key: OAuthModelDiscoveryCacheKey,
+    discover: () => Promise<string[]>,
+    options?: { force?: boolean },
+  ): Promise<string[]>;
+  snapshot(key: OAuthModelDiscoveryCacheKey): string[] | undefined;
   invalidate(key: OAuthModelDiscoveryCacheKey): void;
 }
 
@@ -68,11 +73,12 @@ export function createOAuthModelDiscoveryCache(
   }
 
   return {
-    async load(key, discover) {
+    async load(key, discover, loadOptions = {}) {
       const id = cacheKey(key);
       const currentTime = now();
       const hit = entries.get(id);
       if (
+        loadOptions.force !== true &&
         hit &&
         ((hit.models.length > 0 && currentTime - hit.fetchedAtMs < ttlMs) ||
           currentTime < hit.retryAtMs)
@@ -119,6 +125,11 @@ export function createOAuthModelDiscoveryCache(
       });
       refreshes.set(id, run);
       return run.then((models) => [...models]);
+    },
+
+    snapshot(key) {
+      const hit = entries.get(cacheKey(key));
+      return hit ? [...hit.models] : undefined;
     },
 
     invalidate(key) {

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1536,6 +1536,256 @@ describe("admin.api request payload", () => {
   });
 });
 
+describe("admin.api oauth cached overview and refresh queue", () => {
+  const account = (name: string) => ({
+    account: name,
+    expiresAt: null,
+    updatedAt: 0,
+    healthy: true,
+    priority: 50,
+    schedulable: true,
+    autoReset: false,
+    fastMode: false,
+    proxy: null,
+    models: [],
+  });
+
+  const status = {
+    selectionStrategy: "balanced" as const,
+    providers: [
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        flow: "manual_paste" as const,
+        accounts: [account("claude-a")],
+      },
+      {
+        id: "openai-codex",
+        name: "Codex",
+        flow: "manual_paste" as const,
+        accounts: [account("codex-a")],
+      },
+    ],
+  };
+  const quotaWindow = {
+    key: "5h",
+    usedPercent: 10,
+    resetsAtMs: Date.now() + 3_600_000,
+    windowMinutes: 300,
+  };
+
+  it("GET /oauth/overview reads cached local state without touching upstream refresh methods", async () => {
+    const listCachedStatus = vi.fn().mockResolvedValue(status);
+    const listStatus = vi.fn(() => Promise.reject(new Error("must not refresh on page open")));
+    const fetchAnthropicQuota = vi.fn(() =>
+      Promise.reject(new Error("must not pull quota on page open")),
+    );
+    const oauth = {
+      listCachedStatus,
+      listStatus,
+      fetchAnthropicQuota,
+      getCachedCodexQuota: async () => null,
+    } as unknown as AdminApiDeps["oauth"];
+    const oauthUsage = {
+      queryRange: async () => [
+        {
+          providerId: "anthropic",
+          account: "claude-a",
+          requests: 2,
+          tokens: 12,
+          costUsd: null,
+          firstSeenMs: Date.now() - 60_000,
+          updatedAt: Date.now(),
+        },
+      ],
+    } as unknown as AdminApiDeps["oauthUsage"];
+    const oauthQuota = {
+      getAll: async () => [
+        {
+          providerId: "anthropic",
+          account: "claude-a",
+          windows: [],
+          capturedAt: 123,
+          source: "anthropic" as const,
+          usageLimitedUntilMs: null,
+          resetCredits: null,
+        },
+      ],
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const app = buildApp(buildDeps({ oauth, oauthUsage, oauthQuota }));
+
+    const res = await app.request("/admin/api/oauth/overview?tzOffsetMinutes=480");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      configured: true,
+      selectionStrategy: "balanced",
+      providers: status.providers,
+      usage: [{ providerId: "anthropic", account: "claude-a", requests: 2 }],
+      quota: [{ providerId: "anthropic", account: "claude-a", capturedAt: 123 }],
+      refresh: { state: "idle", jobId: null },
+    });
+    expect(listCachedStatus).toHaveBeenCalledOnce();
+    expect(listStatus).not.toHaveBeenCalled();
+    expect(fetchAnthropicQuota).not.toHaveBeenCalled();
+  });
+
+  it("POST /oauth/refresh coalesces concurrent clicks into one refresh job", async () => {
+    const gate = deferred();
+    const listStatus = vi.fn(async () => {
+      await gate.promise;
+      return status;
+    });
+    const oauth = {
+      listCachedStatus: async () => status,
+      listStatus,
+      fetchAnthropicQuota: async () => [quotaWindow],
+      fetchCodexQuota: async () => ({
+        windows: [quotaWindow],
+        additionalLimits: [],
+        resetCredits: null,
+        resetCreditDetails: null,
+        credits: null,
+        individualLimit: null,
+        planType: null,
+        rateLimitReachedType: null,
+      }),
+    } as unknown as AdminApiDeps["oauth"];
+    const oauthQuota = {
+      getAll: async () => [],
+      upsert: async () => {},
+      delete: async () => {},
+      get: async () => null,
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const app = buildApp(buildDeps({ oauth, oauthQuota }));
+
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, () => app.request("/admin/api/oauth/refresh", { method: "POST" })),
+    );
+    await vi.waitFor(() => expect(listStatus).toHaveBeenCalledOnce());
+    const bodies = await Promise.all(
+      responses.map(
+        (response) => response.json() as Promise<{ coalesced: boolean; status: { jobId: string } }>,
+      ),
+    );
+
+    expect(responses.every((response) => response.status === 202)).toBe(true);
+    expect(bodies.filter((body) => !body.coalesced)).toHaveLength(1);
+    expect(new Set(bodies.map((body) => body.status.jobId)).size).toBe(1);
+
+    gate.resolve();
+    await vi.waitFor(async () => {
+      const overview = await app.request("/admin/api/oauth/overview");
+      expect(await overview.json()).toMatchObject({ refresh: { state: "succeeded" } });
+    });
+  });
+
+  it("runs account quota refreshes serially with force enabled", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const calls: string[] = [];
+    const run = async (label: string) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      calls.push(label);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      active -= 1;
+      return [];
+    };
+    const serialStatus = {
+      ...status,
+      providers: [
+        { ...status.providers[0], accounts: [account("claude-a"), account("claude-b")] },
+        { ...status.providers[1], accounts: [account("codex-a")] },
+      ],
+    };
+    const oauth = {
+      listCachedStatus: async () => serialStatus,
+      listStatus: async () => serialStatus,
+      fetchAnthropicQuota: async ({
+        account: name,
+        force,
+      }: {
+        account: string;
+        force?: boolean;
+      }) => {
+        expect(force).toBe(true);
+        await run(`anthropic/${name}`);
+        return [quotaWindow];
+      },
+      fetchCodexQuota: async ({ account: name, force }: { account: string; force?: boolean }) => {
+        expect(force).toBe(true);
+        await run(`openai-codex/${name}`);
+        return {
+          windows: [quotaWindow],
+          additionalLimits: [],
+          resetCredits: null,
+          resetCreditDetails: null,
+          credits: null,
+          individualLimit: null,
+          planType: null,
+          rateLimitReachedType: null,
+        };
+      },
+    } as unknown as AdminApiDeps["oauth"];
+    const oauthQuota = {
+      getAll: async () => [],
+      upsert: async () => {},
+      delete: async () => {},
+      get: async () => null,
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const app = buildApp(buildDeps({ oauth, oauthQuota }));
+
+    await app.request("/admin/api/oauth/refresh", { method: "POST" });
+    await vi.waitFor(async () => {
+      const overview = await app.request("/admin/api/oauth/overview");
+      expect(await overview.json()).toMatchObject({ refresh: { state: "succeeded" } });
+    });
+
+    expect(maxActive).toBe(1);
+    expect(calls).toEqual(["anthropic/claude-a", "anthropic/claude-b", "openai-codex/codex-a"]);
+  });
+
+  it("marks a partial upstream refresh failure while preserving stale cached quota", async () => {
+    const stale = {
+      providerId: "anthropic",
+      account: "claude-a",
+      windows: [{ key: "5h", usedPercent: 40, resetsAtMs: 123, windowMinutes: 300 }],
+      capturedAt: 100,
+      source: "anthropic" as const,
+      usageLimitedUntilMs: null,
+      resetCredits: null,
+    };
+    const oauth = {
+      listCachedStatus: async () => status,
+      listStatus: async () => status,
+      fetchAnthropicQuota: async () => {
+        throw new Error("anthropic quota timeout");
+      },
+      fetchCodexQuota: async () => null,
+      getCachedCodexQuota: async () => null,
+    } as unknown as AdminApiDeps["oauth"];
+    const oauthQuota = {
+      getAll: async () => [stale],
+      upsert: async () => {},
+      delete: async () => {},
+      get: async () => stale,
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const app = buildApp(buildDeps({ oauth, oauthQuota }));
+
+    const response = await app.request("/admin/api/oauth/refresh", { method: "POST" });
+    expect(response.status).toBe(202);
+
+    await vi.waitFor(async () => {
+      const overview = await app.request("/admin/api/oauth/overview");
+      expect(await overview.json()).toMatchObject({
+        quota: [{ providerId: "anthropic", account: "claude-a", capturedAt: 100 }],
+        refresh: { state: "failed", error: expect.stringContaining("anthropic quota timeout") },
+      });
+    });
+  });
+});
+
 describe("admin.api oauth usage", () => {
   it("GET /oauth/usage returns today's per-account rows + derived RPM", async () => {
     const oauthUsage = {
@@ -1601,7 +1851,7 @@ describe("admin.api oauth usage", () => {
       schedulable: true,
     });
     const oauth = {
-      listStatus: async () => ({
+      listCachedStatus: async () => ({
         selectionStrategy: "balanced",
         providers: [
           { id: "openai-codex", name: "C", flow: "manual_paste", accounts: [acct("mylukin")] },
@@ -1624,7 +1874,7 @@ describe("admin.api oauth usage", () => {
 });
 
 describe("admin.api oauth quota", () => {
-  it("GET /oauth/quota refreshes Anthropic, returns only BOUND accounts, and prunes orphans", async () => {
+  it("GET /oauth/quota returns only cached BOUND rows without pulling or pruning", async () => {
     const upserts: unknown[] = [];
     const deletes: Array<[string, string]> = [];
     const acct = (account: string) => ({
@@ -1663,7 +1913,7 @@ describe("admin.api oauth quota", () => {
     } as unknown as AdminApiDeps["oauthQuota"];
     // Bound accounts: anthropic/mylukin + openai-codex/mylukin (NOT codex/default).
     const oauth = {
-      listStatus: async () => ({
+      listCachedStatus: async () => ({
         selectionStrategy: "balanced",
         providers: [
           { id: "anthropic", name: "A", flow: "manual_paste", accounts: [acct("mylukin")] },
@@ -1677,21 +1927,15 @@ describe("admin.api oauth quota", () => {
     const app = buildApp(buildDeps({ oauthQuota, oauth }));
     const res = await app.request("/admin/api/oauth/quota");
     expect(res.status).toBe(200);
-    // The Anthropic pull was upserted with source "anthropic".
-    expect(upserts).toHaveLength(1);
-    expect(upserts[0]).toMatchObject({
-      providerId: "anthropic",
-      account: "mylukin",
-      source: "anthropic",
-    });
+    expect(upserts).toHaveLength(0);
     // Only BOUND snapshots are returned; the orphan codex/default is dropped.
     const body = (await res.json()) as { quota: Array<{ providerId: string; account: string }> };
     expect(body.quota.map((q) => `${q.providerId}/${q.account}`)).toEqual(["openai-codex/mylukin"]);
-    // …and the orphan row is pruned from the store.
-    expect(deletes).toEqual([["openai-codex", "default"]]);
+    // Cache reads are side-effect free; orphan cleanup belongs to the refresh job.
+    expect(deletes).toEqual([]);
   });
 
-  it("GET /oauth/quota also refreshes the Codex PULL (source 'codex')", async () => {
+  it("POST /oauth/refresh refreshes the Codex PULL (source 'codex')", async () => {
     const upserts: unknown[] = [];
     const oauthQuota = {
       upsert: async (s: unknown) => {
@@ -1701,27 +1945,29 @@ describe("admin.api oauth quota", () => {
       getAll: async () => [],
       delete: async () => {},
     } as unknown as AdminApiDeps["oauthQuota"];
+    const status = {
+      selectionStrategy: "balanced" as const,
+      providers: [
+        {
+          id: "openai-codex",
+          name: "C",
+          flow: "manual_paste" as const,
+          accounts: [
+            {
+              account: "mylukin",
+              expiresAt: null,
+              updatedAt: 0,
+              healthy: true,
+              priority: 50,
+              schedulable: true,
+            },
+          ],
+        },
+      ],
+    };
     const oauth = {
-      listStatus: async () => ({
-        selectionStrategy: "balanced",
-        providers: [
-          {
-            id: "openai-codex",
-            name: "C",
-            flow: "manual_paste",
-            accounts: [
-              {
-                account: "mylukin",
-                expiresAt: null,
-                updatedAt: 0,
-                healthy: true,
-                priority: 50,
-                schedulable: true,
-              },
-            ],
-          },
-        ],
-      }),
+      listCachedStatus: async () => status,
+      listStatus: async () => status,
       // The PULL twin of the x-codex-* header PUSH: windows + reset-credit count.
       fetchCodexQuota: async () => ({
         windows: [
@@ -1732,8 +1978,9 @@ describe("admin.api oauth quota", () => {
       }),
     } as unknown as AdminApiDeps["oauth"];
     const app = buildApp(buildDeps({ oauthQuota, oauth }));
-    const res = await app.request("/admin/api/oauth/quota");
-    expect(res.status).toBe(200);
+    const res = await app.request("/admin/api/oauth/refresh", { method: "POST" });
+    expect(res.status).toBe(202);
+    await vi.waitFor(() => expect(upserts).toHaveLength(1));
     expect(upserts).toHaveLength(1);
     expect(upserts[0]).toMatchObject({
       providerId: "openai-codex",

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -142,8 +142,15 @@ export interface OAuthAdminStatusResponse {
 }
 
 export interface OAuthAdminAccess {
-  // Built-in providers + which accounts are currently logged in (no secrets).
-  listStatus(): Promise<OAuthAdminStatusResponse>;
+  // Cache-only status is the providers page read path: local token/settings/model
+  // snapshots only, with no token refresh or upstream model discovery.
+  listCachedStatus(): Promise<OAuthAdminStatusResponse>;
+  // Explicit refresh path. `serial` bounds provider-account work to one account at
+  // a time; `forceRefresh` bypasses fresh model-discovery caches.
+  listStatus(options?: {
+    forceRefresh?: boolean;
+    serial?: boolean;
+  }): Promise<OAuthAdminStatusResponse>;
   // Anthropic manual-paste: begin -> { authorizeUrl }; the verifier/state are held
   // server-side keyed by sessionId. complete exchanges the pasted redirect URL.
   // `proxy` (optional, entered in the connect dialog's first step) is validated +
@@ -242,18 +249,24 @@ export interface OAuthAdminAccess {
   // an on-demand PULL behind a short TTL cache. FAIL-OPEN: returns null on any
   // failure (dead token, network, malformed body) so the page renders "—" rather
   // than erroring. Optional so unit-test seams can omit it.
-  fetchAnthropicQuota?(input: { account: string }): Promise<OAuthQuotaWindow[] | null>;
+  fetchAnthropicQuota?(input: {
+    account: string;
+    force?: boolean;
+  }): Promise<OAuthQuotaWindow[] | null>;
   // Pull the consumer Grok subscription's weekly usage window from the same
   // gRPC-Web method used by grok.com. The existing xAI OAuth bearer is sufficient;
   // no browser cookie is persisted. Same proxy/refresh/cache/fail-open contract as
   // the other quota PULLs.
-  fetchXaiQuota?(input: { account: string }): Promise<OAuthQuotaWindow[] | null>;
+  fetchXaiQuota?(input: { account: string; force?: boolean }): Promise<OAuthQuotaWindow[] | null>;
   // Same PULL for Codex (chatgpt.com/backend-api/wham/usage — what the Codex CLI
   // /status reads). Complements the `x-codex-*` header PUSH so quota renders even
   // before an account has served any traffic. Same TTL cache + fail-open contract.
   // Returns the windows AND the available rate-limit-reset-credit count (both off
   // the one PULL); null on any failure. `resetCredits` null = no grant / unknown.
-  fetchCodexQuota?(input: { account: string }): Promise<CodexQuotaResult>;
+  fetchCodexQuota?(input: { account: string; force?: boolean }): Promise<CodexQuotaResult>;
+  // Read the last in-process Codex quota result without refreshing an expired
+  // cache. Rich quota metadata is folded into the cache-only overview when present.
+  getCachedCodexQuota?(input: { account: string }): Promise<CodexQuotaResult>;
   // Consume one Codex rate-limit reset credit for the account (the "reset usage
   // limit" operator action). FAIL-CLOSED, unlike the PULLs: the seam THROWS on any
   // upstream failure so the route returns an error rather than a false success.

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -9,11 +9,15 @@ import { registerOAuthRoutes } from "./oauth.js";
 // routes are thin validating wrappers around this seam, so exercising them with a
 // mock seam covers the route logic (validation, error mapping, afterMutation).
 function fullSeam(over: Partial<OAuthAdminAccess> = {}): OAuthAdminAccess {
-  return {
-    listStatus: vi.fn(async () => ({
-      selectionStrategy: "balanced",
+  const listStatus =
+    over.listStatus ??
+    vi.fn(async () => ({
+      selectionStrategy: "balanced" as const,
       providers: [{ id: "anthropic", name: "Anthropic", accounts: [{ account: "default" }] }],
-    })),
+    }));
+  return {
+    listCachedStatus: over.listCachedStatus ?? listStatus,
+    listStatus,
     startManualPaste: vi.fn(async () => ({ sessionId: "s1", authorizeUrl: "https://auth" })),
     completeManualPaste: vi.fn(async () => {}),
     startDeviceCode: vi.fn(async () => ({
@@ -52,6 +56,19 @@ function app(deps: Partial<AdminApiDeps>) {
   const a = new Hono<AppEnv>();
   registerOAuthRoutes(a, deps as AdminApiDeps);
   return a;
+}
+
+async function enqueueRefresh(
+  api: ReturnType<typeof app>,
+  expectedState: "succeeded" | "failed" = "succeeded",
+): Promise<void> {
+  const accepted = await api.request("/admin/api/oauth/refresh", { method: "POST" });
+  expect(accepted.status).toBe(202);
+  await vi.waitFor(async () => {
+    const overview = await api.request("/admin/api/oauth/overview");
+    const body = (await overview.json()) as { refresh: { state: string } };
+    expect(body.refresh.state).toBe(expectedState);
+  });
 }
 
 const JSONH = { "Content-Type": "application/json" };
@@ -163,7 +180,7 @@ describe("admin OAuth routes — read endpoints", () => {
     expect((start ?? 0) % 86_400_000).toBe(0); // offset 0 → UTC midnight
   });
 
-  it("GET /oauth/quota returns [] with no store and merges PULL windows with one", async () => {
+  it("GET /oauth/quota returns cached rows without pulling upstream", async () => {
     expect(
       (
         (await (await app({ oauth: fullSeam() }).request("/admin/api/oauth/quota")).json()) as {
@@ -181,10 +198,11 @@ describe("admin OAuth routes — read endpoints", () => {
     });
     const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
     expect(res.status).toBe(200);
-    expect(upsert).toHaveBeenCalled(); // the PULL refreshed the store
+    expect(upsert).not.toHaveBeenCalled();
+    expect(seam.fetchAnthropicQuota).not.toHaveBeenCalled();
   });
 
-  it("GET /oauth/quota refreshes xAI, updates the pool snapshot, and syncs cooldown", async () => {
+  it("POST /oauth/refresh refreshes xAI, updates the pool snapshot, and syncs cooldown", async () => {
     const now = Date.now();
     const resetAt = now + 3 * 86_400_000;
     const windows: OAuthQuotaWindow[] = [
@@ -216,15 +234,17 @@ describe("admin OAuth routes — read endpoints", () => {
     const applyQuotaSnapshot = vi.fn();
     const applyUsageLimit = vi.fn(async () => {});
 
-    const res = await app({
+    const api = app({
       oauth: seam,
       oauthQuota,
       applyQuotaSnapshot,
       applyUsageLimit,
-    }).request("/admin/api/oauth/quota");
+    });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
-    expect(fetchXaiQuota).toHaveBeenCalledWith({ account: "subscription" });
+    expect(fetchXaiQuota).toHaveBeenCalledWith({ account: "subscription", force: true });
     expect(oauthQuota?.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         providerId: "xai",
@@ -252,7 +272,7 @@ describe("admin OAuth routes — read endpoints", () => {
     });
   });
 
-  it("GET /oauth/quota fails open when xAI refresh rejects and still filters orphans", async () => {
+  it("POST /oauth/refresh reports xAI failure and still refreshes peers and prunes orphans", async () => {
     const anthropicWindows: OAuthQuotaWindow[] = [
       { key: "5h", usedPercent: 10, resetsAtMs: null, windowMinutes: 300 },
     ];
@@ -302,7 +322,9 @@ describe("admin OAuth routes — read endpoints", () => {
       }),
     });
 
-    const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
+    const api = app({ oauth: seam, oauthQuota });
+    await enqueueRefresh(api, "failed");
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
@@ -317,7 +339,7 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(oauthQuota?.delete).toHaveBeenCalledWith("xai", "orphan");
   });
 
-  it("GET /oauth/quota extends an active cooldown to the saturated window reset", async () => {
+  it("POST /oauth/refresh extends an active cooldown to the saturated window reset", async () => {
     const now = Date.now();
     const shortCooldown = now + 60_000;
     const weeklyReset = now + 8 * 60 * 60_000;
@@ -354,15 +376,15 @@ describe("admin OAuth routes — read endpoints", () => {
       fetchAnthropicQuota: vi.fn(async () => [saturatedWeekly]) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", weeklyReset, "replace");
   });
 
-  it("GET /oauth/quota clears a global cooldown when only scoped model windows are saturated", async () => {
+  it("POST /oauth/refresh clears a global cooldown when only scoped windows are saturated", async () => {
     const now = Date.now();
     const shortCooldown = now + 60_000;
     const windows = [
@@ -408,15 +430,15 @@ describe("admin OAuth routes — read endpoints", () => {
       fetchAnthropicQuota: vi.fn(async () => windows) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", null, "replace");
   });
 
-  it("GET /oauth/quota extends an active cooldown to a near-full 5h recovery reset", async () => {
+  it("POST /oauth/refresh extends an active cooldown to a near-full 5h recovery reset", async () => {
     const now = Date.now();
     const shortCooldown = now + 60_000;
     const fiveHourReset = now + 2 * 60 * 60_000 + 57 * 60_000;
@@ -459,15 +481,15 @@ describe("admin OAuth routes — read endpoints", () => {
       ]) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", fiveHourReset, "replace");
   });
 
-  it("GET /oauth/quota clears an active cooldown when fresh windows show no active limit", async () => {
+  it("POST /oauth/refresh clears an active cooldown when fresh windows show no active limit", async () => {
     const now = Date.now();
     const activeCooldown = now + 4 * 86_400_000;
     const cleanWindows = [
@@ -501,15 +523,15 @@ describe("admin OAuth routes — read endpoints", () => {
       fetchAnthropicQuota: vi.fn(async () => cleanWindows) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", null, "replace");
   });
 
-  it("GET /oauth/quota replaces a stale long cooldown with the active shorter recovery window", async () => {
+  it("POST /oauth/refresh replaces a stale cooldown with the active recovery window", async () => {
     const now = Date.now();
     const staleCooldown = now + 5 * 86_400_000;
     const fiveHourReset = now + 2 * 60 * 60_000;
@@ -544,15 +566,15 @@ describe("admin OAuth routes — read endpoints", () => {
       fetchAnthropicQuota: vi.fn(async () => windows) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).toHaveBeenCalledWith("anthropic", "default", fiveHourReset, "replace");
   });
 
-  it("GET /oauth/quota parks an unparked account from a saturated account-wide PULL snapshot", async () => {
+  it("POST /oauth/refresh parks an unparked account from a saturated account-wide snapshot", async () => {
     const now = Date.now();
     const saturatedWeekly = {
       key: "secondary",
@@ -594,9 +616,9 @@ describe("admin OAuth routes — read endpoints", () => {
       })) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).toHaveBeenCalledWith(
@@ -607,7 +629,7 @@ describe("admin OAuth routes — read endpoints", () => {
     );
   });
 
-  it("GET /oauth/quota does not newly park an unparked account from a near-full PULL snapshot", async () => {
+  it("POST /oauth/refresh does not newly park an account from a near-full snapshot", async () => {
     const now = Date.now();
     const nearFullFiveHour = {
       key: "primary",
@@ -649,15 +671,15 @@ describe("admin OAuth routes — read endpoints", () => {
       })) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota, applyUsageLimit }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).not.toHaveBeenCalled();
   });
 
-  it("GET /oauth/quota folds the complete live Codex subscription metadata onto its snapshot", async () => {
+  it("POST /oauth/refresh makes complete Codex metadata available to cached reads", async () => {
     const sparkWindow = {
       key: "codex_spark-primary",
       usedPercent: 40,
@@ -673,6 +695,31 @@ describe("admin OAuth routes — read endpoints", () => {
       windowMinutes: 300,
       limitId: "codex_luna",
       limitName: "GPT-5.6-Codex-Luna",
+    };
+    const codexQuota = {
+      windows: [sparkWindow, lunaWindow],
+      additionalLimits: [],
+      resetCredits: 3,
+      resetCreditDetails: [
+        {
+          id: "credit-1",
+          resetType: "codexRateLimits",
+          status: "available",
+          grantedAt: 1,
+          expiresAt: 2,
+          title: "Full reset",
+          description: "Ready",
+        },
+      ],
+      credits: { hasCredits: true, unlimited: false, balance: "9.99" },
+      individualLimit: {
+        limit: "25000",
+        used: "8000",
+        remainingPercent: 68,
+        resetsAtMs: 1_735_693_200_000,
+      },
+      planType: "pro",
+      rateLimitReachedType: "rate_limit_reached" as const,
     };
     const oauthQuota = {
       getAll: vi.fn(async () => [
@@ -707,35 +754,13 @@ describe("admin OAuth routes — read endpoints", () => {
           },
         ],
       })) as never,
-      fetchCodexQuota: vi.fn(async () => ({
-        windows: [sparkWindow, lunaWindow],
-        resetCredits: 3,
-        resetCreditDetails: [
-          {
-            id: "credit-1",
-            resetType: "codexRateLimits",
-            status: "available",
-            grantedAt: 1,
-            expiresAt: 2,
-            title: "Full reset",
-            description: "Ready",
-          },
-        ],
-        credits: { hasCredits: true, unlimited: false, balance: "9.99" },
-        individualLimit: {
-          limit: "25000",
-          used: "8000",
-          remainingPercent: 68,
-          resetsAtMs: 1_735_693_200_000,
-        },
-        planType: "pro",
-        rateLimitReachedType: "rate_limit_reached",
-      })) as never,
+      fetchCodexQuota: vi.fn(async () => codexQuota) as never,
+      getCachedCodexQuota: vi.fn(async () => codexQuota) as never,
     });
     const applyQuotaSnapshot = vi.fn();
-    const res = await app({ oauth: seam, oauthQuota, applyQuotaSnapshot }).request(
-      "/admin/api/oauth/quota",
-    );
+    const api = app({ oauth: seam, oauthQuota, applyQuotaSnapshot });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
     const body = (await res.json()) as {
       quota: Array<{
         providerId: string;
@@ -787,8 +812,26 @@ describe("admin OAuth routes — read endpoints", () => {
     );
   });
 
-  it("GET /oauth/quota persists and returns Codex metadata when every quota window is absent", async () => {
+  it("POST /oauth/refresh persists Codex metadata when quota windows are absent", async () => {
     const rows: Array<Record<string, unknown>> = [];
+    const codexQuota = {
+      windows: [],
+      additionalLimits: [
+        { limitId: "codex_spark", limitName: "GPT-5.6-Codex-Spark" },
+        { limitId: "codex_terra", limitName: "GPT-5.6-Codex-Terra" },
+      ],
+      resetCredits: 2,
+      resetCreditDetails: [],
+      credits: { hasCredits: true, unlimited: false, balance: "4.50" },
+      individualLimit: {
+        limit: "25000",
+        used: "8000",
+        remainingPercent: 68,
+        resetsAtMs: null,
+      },
+      planType: "pro",
+      rateLimitReachedType: null,
+    };
     const oauthQuota = {
       getAll: vi.fn(async () => rows),
       upsert: vi.fn(async (snapshot: Record<string, unknown>) => {
@@ -801,27 +844,13 @@ describe("admin OAuth routes — read endpoints", () => {
         selectionStrategy: "balanced",
         providers: [{ id: "openai-codex", name: "Codex", accounts: [{ account: "default" }] }],
       })) as never,
-      fetchCodexQuota: vi.fn(async () => ({
-        windows: [],
-        additionalLimits: [
-          { limitId: "codex_spark", limitName: "GPT-5.6-Codex-Spark" },
-          { limitId: "codex_terra", limitName: "GPT-5.6-Codex-Terra" },
-        ],
-        resetCredits: 2,
-        resetCreditDetails: [],
-        credits: { hasCredits: true, unlimited: false, balance: "4.50" },
-        individualLimit: {
-          limit: "25000",
-          used: "8000",
-          remainingPercent: 68,
-          resetsAtMs: null,
-        },
-        planType: "pro",
-        rateLimitReachedType: null,
-      })) as never,
+      fetchCodexQuota: vi.fn(async () => codexQuota) as never,
+      getCachedCodexQuota: vi.fn(async () => codexQuota) as never,
     });
 
-    const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
+    const api = app({ oauth: seam, oauthQuota });
+    await enqueueRefresh(api);
+    const res = await api.request("/admin/api/oauth/quota");
     const body = (await res.json()) as {
       quota: Array<{
         windows: unknown[];

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -6,6 +6,7 @@ import {
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
+import { createOAuthAdminRefreshCoordinator } from "../../oauth/admin-refresh-coordinator.js";
 import {
   CODEX_RESET_MIN_WEEKLY_USED_PERCENT,
   canConsumeResetCredit,
@@ -19,8 +20,8 @@ import {
 import type {
   AccountProxyInput,
   AdminApiDeps,
-  CodexQuotaResult,
   OAuthAdminAccess,
+  OAuthAdminStatusResponse,
   OAuthSelectionStrategy,
 } from "./deps.js";
 
@@ -182,49 +183,34 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   app.get("/admin/api/oauth", async (c) => {
     const s = seam();
     if (!s) return c.json({ error: "oauth login not configured (set HELM_OAUTH_ENC_KEY)" }, 503);
-    return c.json(await s.listStatus());
+    return c.json(await s.listCachedStatus());
   });
 
-  // GET /oauth/usage?tzOffsetMinutes -> today's per-account served traffic (providers
-  // page Tier 2). FAIL-OPEN: an absent store / read failure yields [] (the page
-  // renders zeros) — an observability read must never break the page. "Today" is the
-  // ADMIN's LOCAL day: the browser sends its UTC offset (east-positive minutes) and
-  // we roll the per-hour buckets up over [local-midnight, +24h) in UTC. A missing /
-  // out-of-range offset fails open to 0 (UTC day). RPM is the daily AVERAGE (requests
-  // / minutes since the day's first served call), derived here so the store stays a
-  // plain counter. No secrets — aggregate counters only (principle 7).
-  app.get("/admin/api/oauth/usage", async (c) => {
+  const acctKey = (providerId: string, account: string) => `${providerId}\u0000${account}`;
+  const boundKeys = (status: OAuthAdminStatusResponse): Set<string> =>
+    new Set(
+      status.providers.flatMap((provider) =>
+        provider.accounts.map((account) => acctKey(provider.id, account.account)),
+      ),
+    );
+
+  // Local-only usage aggregation. Binding metadata comes from cached token/settings
+  // state; this function never refreshes a token or calls a provider.
+  const readUsage = async (rawTz: unknown, status: OAuthAdminStatusResponse | null) => {
     const store = deps.oauthUsage;
-    if (!store) return c.json({ usage: [] });
+    if (!store) return [];
     const now = Date.now();
-    // Fail-open tz offset (east-positive minutes; UTC-12 … UTC+14). Then floor to the
-    // viewer's local midnight and express that boundary back in UTC for the query.
-    const rawTz = Number(c.req.query("tzOffsetMinutes"));
-    const tzOffsetMinutes = Number.isInteger(rawTz) && rawTz >= -720 && rawTz <= 840 ? rawTz : 0;
+    const parsedTz = Number(rawTz);
+    const tzOffsetMinutes =
+      Number.isInteger(parsedTz) && parsedTz >= -720 && parsedTz <= 840 ? parsedTz : 0;
     const offsetMs = tzOffsetMinutes * 60_000;
     const start = now + offsetMs - ((now + offsetMs) % 86_400_000) - offsetMs;
     const end = start + 86_400_000;
-    // Restrict to currently-bound accounts (listStatus = the OAuth tokens) so a
-    // renamed / re-bound account does NOT linger as a phantom usage row — the same
-    // guard the /quota route applies. Fail-open: no seam / a listing failure leaves
-    // `bound` null and every row is returned (never hide data behind the filter).
-    const usageKey = (providerId: string, account: string) => JSON.stringify([providerId, account]);
-    let bound: Set<string> | null = null;
-    const s = seam();
-    if (s) {
-      try {
-        const status = await s.listStatus();
-        bound = new Set(
-          status.providers.flatMap((p) => p.accounts.map((a) => usageKey(p.id, a.account))),
-        );
-      } catch {
-        // fail-open: a listing failure returns all rows rather than hiding data
-      }
-    }
+    const bound = status ? boundKeys(status) : null;
     try {
       const rows = await store.queryRange(start, end);
-      const usage = rows
-        .filter((r) => !bound || bound.has(usageKey(r.providerId, r.account)))
+      return rows
+        .filter((r) => !bound || bound.has(acctKey(r.providerId, r.account)))
         .map((r) => {
           const minutes = Math.max(1, (now - r.firstSeenMs) / 60_000);
           return {
@@ -236,21 +222,16 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
             rpm: Math.round((r.requests / minutes) * 100) / 100,
           };
         });
-      return c.json({ usage });
     } catch {
-      return c.json({ usage: [] });
+      return [];
     }
-  });
+  };
 
-  // GET /oauth/quota -> latest rate-limit window snapshot per account (providers
-  // page Tier 3). Sources merge in the quota store: Codex PUSHes `x-codex-*`
-  // headers on every reply, and BOTH Anthropic and Codex expose PULL usage
-  // endpoints we refresh on read (5-min cached in the seam) before returning.
-  // FAIL-OPEN throughout — a dead token / absent store yields fewer windows or
-  // [], never an error.
-  app.get("/admin/api/oauth/quota", async (c) => {
+  // Explicit refresh job body. All upstream work lives here, behind the refresh
+  // coordinator; cache-only GET routes never call it.
+  const refreshQuota = async (): Promise<void> => {
     const store = deps.oauthQuota;
-    if (!store) return c.json({ quota: [] });
+    if (!store) return;
     const s = seam();
     // listStatus (the bound OAuth tokens) is the source of truth for "which accounts
     // exist". We use it BOTH to refresh the Anthropic PULL and to drop ORPHANED
@@ -258,18 +239,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     // Codex push captured under an old label) that would show as a phantom account.
     const acctKey = (providerId: string, account: string) => `${providerId}\u0000${account}`;
     let bound: Set<string> | null = null;
-    // Codex reset-credit counts from the live usage PULL. They are persisted with the
-    // latest snapshot for quota-aware strategy scoring, then folded onto the response.
-    const codexMetadata = new Map<string, NonNullable<CodexQuotaResult>>();
-    const codexIdentities = new Map<
-      string,
-      {
-        email?: string;
-        chatgptPlanType?: string;
-        chatgptAccountId?: string;
-        isFedramp?: boolean;
-      }
-    >();
+    const failures: string[] = [];
     const syncCooldownFromWindows = async (
       providerId: string,
       account: string,
@@ -296,27 +266,10 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     };
     if (s) {
       try {
-        const status = await s.listStatus();
+        const status = await s.listStatus({ forceRefresh: true, serial: true });
         bound = new Set(
           status.providers.flatMap((p) => p.accounts.map((a) => acctKey(p.id, a.account))),
         );
-        const codexAccounts =
-          status.providers.find((provider) => provider.id === "openai-codex")?.accounts ?? [];
-        for (const account of codexAccounts) {
-          const identity = {
-            ...(account.email === undefined ? {} : { email: account.email }),
-            ...(account.chatgptPlanType === undefined
-              ? {}
-              : { chatgptPlanType: account.chatgptPlanType }),
-            ...(account.chatgptAccountId === undefined
-              ? {}
-              : { chatgptAccountId: account.chatgptAccountId }),
-            ...(account.isFedramp === undefined ? {} : { isFedramp: account.isFedramp }),
-          };
-          if (Object.keys(identity).length > 0) {
-            codexIdentities.set(acctKey("openai-codex", account.account), identity);
-          }
-        }
         // Refresh the usage-endpoint PULL for each connected account (cached in the
         // seam). Anthropic and Codex both expose one; the Codex `x-codex-*` header
         // PUSH still updates the same store on live traffic — the PULL covers
@@ -329,30 +282,30 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         // near-full accounts schedulable while preventing the UI from saying "limited"
         // as the pool continues to route to the same exhausted account.
         const acctsOf = (id: string) => status.providers.find((x) => x.id === id)?.accounts ?? [];
-        const tasks: Array<Promise<void>> = [];
+        const tasks: Array<{ label: string; run: () => Promise<void> }> = [];
         // Anthropic: windows only.
         const fetchAnthropic = s.fetchAnthropicQuota;
         if (fetchAnthropic) {
           for (const a of acctsOf("anthropic")) {
-            tasks.push(
-              (async () => {
-                const windows = await fetchAnthropic({ account: a.account });
-                if (windows && windows.length > 0) {
-                  const capturedAt = Date.now();
-                  await store
-                    .upsert({
-                      providerId: "anthropic",
-                      account: a.account,
-                      windows,
-                      capturedAt,
-                      source: "anthropic",
-                    })
-                    .catch(() => {});
-                  deps.applyQuotaSnapshot?.("anthropic", a.account, windows, capturedAt);
-                  await syncCooldownFromWindows("anthropic", a.account, windows);
+            tasks.push({
+              label: `anthropic/${a.account}`,
+              run: async () => {
+                const windows = await fetchAnthropic({ account: a.account, force: true });
+                if (!windows || windows.length === 0) {
+                  throw new Error("quota refresh returned no windows");
                 }
-              })(),
-            );
+                const capturedAt = Date.now();
+                await store.upsert({
+                  providerId: "anthropic",
+                  account: a.account,
+                  windows,
+                  capturedAt,
+                  source: "anthropic",
+                });
+                deps.applyQuotaSnapshot?.("anthropic", a.account, windows, capturedAt);
+                await syncCooldownFromWindows("anthropic", a.account, windows);
+              },
+            });
           }
         }
         // xAI: the Grok subscription usage endpoint also yields normalized windows
@@ -362,57 +315,50 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         const fetchXai = s.fetchXaiQuota;
         if (fetchXai) {
           for (const a of acctsOf("xai")) {
-            tasks.push(
-              (async () => {
-                try {
-                  const windows = await fetchXai({ account: a.account });
-                  if (windows && windows.length > 0) {
-                    const capturedAt = Date.now();
-                    await store
-                      .upsert({
-                        providerId: "xai",
-                        account: a.account,
-                        windows,
-                        capturedAt,
-                        source: "xai",
-                      })
-                      .catch(() => {});
-                    deps.applyQuotaSnapshot?.("xai", a.account, windows, capturedAt);
-                    await syncCooldownFromWindows("xai", a.account, windows);
-                  }
-                } catch {
-                  // One dead xAI token must not short-circuit refreshes for other
-                  // providers/accounts; the route returns the last stored snapshot.
+            tasks.push({
+              label: `xai/${a.account}`,
+              run: async () => {
+                const windows = await fetchXai({ account: a.account, force: true });
+                if (!windows || windows.length === 0) {
+                  throw new Error("quota refresh returned no windows");
                 }
-              })(),
-            );
+                const capturedAt = Date.now();
+                await store.upsert({
+                  providerId: "xai",
+                  account: a.account,
+                  windows,
+                  capturedAt,
+                  source: "xai",
+                });
+                deps.applyQuotaSnapshot?.("xai", a.account, windows, capturedAt);
+                await syncCooldownFromWindows("xai", a.account, windows);
+              },
+            });
           }
         }
         // Codex: windows (persisted) + reset-credit count (live, attached below).
         const fetchCodex = s.fetchCodexQuota;
         if (fetchCodex) {
           for (const a of acctsOf("openai-codex")) {
-            tasks.push(
-              (async () => {
-                const result = await fetchCodex({ account: a.account });
-                if (!result) return;
+            tasks.push({
+              label: `openai-codex/${a.account}`,
+              run: async () => {
+                const result = await fetchCodex({ account: a.account, force: true });
+                if (!result) throw new Error("quota refresh returned no snapshot");
                 const activeResult = {
                   ...result,
                   windows: filterRetiredOpenAICodexLimits(result.windows),
                   additionalLimits: filterRetiredOpenAICodexLimits(result.additionalLimits),
                 };
-                codexMetadata.set(acctKey("openai-codex", a.account), activeResult);
                 const capturedAt = Date.now();
-                await store
-                  .upsert({
-                    providerId: "openai-codex",
-                    account: a.account,
-                    windows: activeResult.windows,
-                    capturedAt,
-                    source: "codex",
-                    resetCredits: activeResult.resetCredits,
-                  })
-                  .catch(() => {});
+                await store.upsert({
+                  providerId: "openai-codex",
+                  account: a.account,
+                  windows: activeResult.windows,
+                  capturedAt,
+                  source: "codex",
+                  resetCredits: activeResult.resetCredits,
+                });
                 deps.applyQuotaSnapshot?.(
                   "openai-codex",
                   a.account,
@@ -423,66 +369,156 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                 if (activeResult.windows.length > 0) {
                   await syncCooldownFromWindows("openai-codex", a.account, activeResult.windows);
                 }
-              })(),
-            );
+              },
+            });
           }
         }
-        await Promise.all(tasks);
-      } catch {
-        // fail-open: a refresh/listing failure still returns whatever is stored
+        for (const task of tasks) {
+          try {
+            await task.run();
+          } catch (error) {
+            failures.push(`${task.label}: ${errMessage(error)}`);
+          }
+        }
+      } catch (error) {
+        failures.push(`provider status: ${errMessage(error)}`);
       }
     }
-    // Fold the complete live Codex subscription metadata onto its snapshot. Only
-    // resetCredits is persisted for pool scoring; the rest remains live/read-only.
-    const withCodexMetadata = <
-      T extends {
-        providerId: string;
-        account: string;
-        windows: Array<{ limitId?: string; limitName?: string | null }>;
-      },
-    >(
-      q: T,
-    ) => {
-      const key = acctKey(q.providerId, q.account);
-      const metadata = codexMetadata.get(key);
-      const identity = codexIdentities.get(key);
-      const snapshot =
-        q.providerId === "openai-codex"
-          ? { ...q, windows: filterRetiredOpenAICodexLimits(q.windows) }
-          : q;
-      return metadata === undefined && identity === undefined
-        ? snapshot
-        : {
-            ...snapshot,
-            ...(identity === undefined ? {} : { identity }),
-            ...(metadata === undefined
-              ? {}
-              : {
-                  resetCredits: metadata.resetCredits,
-                  resetCreditDetails: metadata.resetCreditDetails,
-                  credits: metadata.credits,
-                  individualLimit: metadata.individualLimit,
-                  additionalLimits: metadata.additionalLimits,
-                  planType: metadata.planType,
-                  rateLimitReachedType: metadata.rateLimitReachedType,
-                }),
-          };
-    };
-    try {
-      const all = await store.getAll();
-      // No binding view (no seam / listStatus failed) → fail-open, return everything.
-      if (!bound) return c.json({ quota: all.map(withCodexMetadata) });
-      const live = all.filter((q) => bound.has(acctKey(q.providerId, q.account)));
-      // Best-effort prune so orphans don't accumulate; never block the read on it.
+    const all = await store.getAll().catch((error: unknown) => {
+      failures.push(`quota cache: ${errMessage(error)}`);
+      return [];
+    });
+    if (bound) {
+      // Best-effort prune so orphans don't accumulate. A delete failure does not
+      // discard fresh rows or hide a successful provider pull.
       await Promise.all(
         all
           .filter((q) => !bound.has(acctKey(q.providerId, q.account)))
           .map((o) => store.delete(o.providerId, o.account).catch(() => {})),
       );
-      return c.json({ quota: live.map(withCodexMetadata) });
-    } catch {
-      return c.json({ quota: [] });
     }
+    if (failures.length > 0) {
+      throw new Error(`provider refresh failed (${failures.join("; ")})`);
+    }
+  };
+
+  // Read the durable quota rows plus any richer in-process Codex metadata. This is
+  // intentionally side-effect free: no upstream PULL, orphan pruning, or cooldown
+  // mutation happens on a page read.
+  const readCachedQuota = async (
+    status: OAuthAdminStatusResponse | null,
+  ): Promise<Array<Record<string, unknown>>> => {
+    const store = deps.oauthQuota;
+    if (!store) return [];
+    const bound = status ? boundKeys(status) : null;
+    const identities = new Map<string, Record<string, unknown>>();
+    for (const provider of status?.providers ?? []) {
+      for (const account of provider.accounts) {
+        const identity = {
+          ...(account.email === undefined ? {} : { email: account.email }),
+          ...(account.chatgptPlanType === undefined
+            ? {}
+            : { chatgptPlanType: account.chatgptPlanType }),
+          ...(account.chatgptAccountId === undefined
+            ? {}
+            : { chatgptAccountId: account.chatgptAccountId }),
+          ...(account.isFedramp === undefined ? {} : { isFedramp: account.isFedramp }),
+        };
+        if (Object.keys(identity).length > 0) {
+          identities.set(acctKey(provider.id, account.account), identity);
+        }
+      }
+    }
+    try {
+      const result: Array<Record<string, unknown>> = [];
+      for (const row of await store.getAll()) {
+        const key = acctKey(row.providerId, row.account);
+        if (bound && !bound.has(key)) continue;
+        const metadata =
+          row.providerId === "openai-codex"
+            ? await seam()?.getCachedCodexQuota?.({ account: row.account })
+            : null;
+        const identity = identities.get(key);
+        result.push({
+          ...row,
+          ...(row.providerId === "openai-codex"
+            ? { windows: filterRetiredOpenAICodexLimits(row.windows) }
+            : {}),
+          ...(identity === undefined ? {} : { identity }),
+          ...(metadata === null || metadata === undefined
+            ? {}
+            : {
+                resetCredits: metadata.resetCredits,
+                resetCreditDetails: metadata.resetCreditDetails,
+                credits: metadata.credits,
+                individualLimit: metadata.individualLimit,
+                additionalLimits: filterRetiredOpenAICodexLimits(metadata.additionalLimits),
+                planType: metadata.planType,
+                rateLimitReachedType: metadata.rateLimitReachedType,
+              }),
+        });
+      }
+      return result;
+    } catch {
+      return [];
+    }
+  };
+
+  const refreshCoordinator = createOAuthAdminRefreshCoordinator({
+    refresh: async () => {
+      await refreshQuota();
+    },
+  });
+
+  app.get("/admin/api/oauth/usage", async (c) => {
+    const status = await seam()
+      ?.listCachedStatus()
+      .catch(() => null);
+    return c.json({ usage: await readUsage(c.req.query("tzOffsetMinutes"), status ?? null) });
+  });
+
+  app.get("/admin/api/oauth/quota", async (c) => {
+    const status = await seam()
+      ?.listCachedStatus()
+      .catch(() => null);
+    return c.json({ quota: await readCachedQuota(status ?? null) });
+  });
+
+  // The providers page uses one cache-only round trip for account, usage, quota,
+  // and refresh-job state. A cold upstream or dead proxy cannot delay this route.
+  app.get("/admin/api/oauth/overview", async (c) => {
+    const s = seam();
+    if (!s) {
+      return c.json({
+        configured: false,
+        selectionStrategy: "balanced",
+        providers: [],
+        usage: [],
+        quota: [],
+        refresh: refreshCoordinator.status(),
+      });
+    }
+    const status = await s.listCachedStatus();
+    const [usage, quota] = await Promise.all([
+      readUsage(c.req.query("tzOffsetMinutes"), status),
+      readCachedQuota(status),
+    ]);
+    return c.json({
+      configured: true,
+      ...status,
+      usage,
+      quota,
+      refresh: refreshCoordinator.status(),
+    });
+  });
+
+  app.post("/admin/api/oauth/refresh", (c) => {
+    if (!seam()) return c.json({ error: "oauth login not configured" }, 503);
+    const result = refreshCoordinator.enqueue();
+    if (result.retryAfterMs > 0) {
+      c.header("Retry-After", String(Math.ceil(result.retryAfterMs / 1000)));
+    }
+    return c.json(result, 202);
   });
 
   // POST /oauth/:provider/reset-credit { account? } -> consume one rate-limit reset

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-14 · Subscription Providers 改为缓存优先与全局串行刷新（OAuth Admin / provider observability，docs/04/11，原则 1/3/6/7）
+
+- **性能根因**：Providers 首屏过去并行请求 status、usage、quota；status 会刷新过期 token 并逐账号发现模型，quota 会逐账号拉取上游额度、写 snapshot、同步 cooldown 并清理 orphan。慢代理、上游限流或账号数增加会把页面打开直接绑定到外部网络，刷新按钮和自动刷新也会重复制造同一批工作。
+- **缓存读边界**：新增单次 `GET /admin/api/oauth/overview`，只读取本地 token/settings、进程内模型/额度 snapshot、durable quota 与当日 usage；不得刷新 token、发现模型、请求 quota、删除 orphan 或修改 cooldown。原 `/oauth`、`/usage`、`/quota` 同样改为 cache-only，保持兼容但不再隐式产生上游流量；无需数据库迁移。
+- **刷新队列**：显式 `POST /admin/api/oauth/refresh` 立即返回 `202`，由 Gateway 进程级 coordinator 保证全局最多一个 active job；并发点击合并到同一 job，成功或失败后冷却 60 秒。job 内按账号串行刷新 token、模型目录与 quota，显式刷新可绕过正/负 TTL 缓存；Anthropic/Codex 模型发现增加 10 秒硬超时，避免死代理长期占住唯一 worker。
+- **失败与旧数据**：任一账号的 quota 超时、空/非法窗口或持久化失败会把 job 标为 `failed` 并记录安全错误摘要，但不会删除 last-known-good snapshot；其余账号仍继续串行刷新。页面展示 queued/running/succeeded/failed、最近成功时间与 cooldown，手动点击只入队一次并 cache-only 轮询，定时自动刷新永远只读缓存。
+- **验证**：TDD 覆盖 cache-only 首屏、20 次并发点击合并、账号刷新最大并发 1、失败保留旧 quota、force cache bypass、模型发现 timeout、前端单请求加载、手动/自动刷新分流与多语言状态文案；workspace 357 files / 5775 tests、typecheck、Biome、build 与 Admin check 全通过。
+
 ## 2026-07-14 · Avoid Waste 在 provider 池内限制 reset-credit 偏置（OAuth provider selection，docs/04/11，原则 3/5/6）
 
 - **生产根因**：`openai-codex` 的四个 Plus/Pro 账号已正确合并进同一 provider pool，套餐名没有参与分池或筛选；但 reset credit 的虚拟周容量乘数为 `10`，单个 credit 的加分远高于自然周窗口。生产中 31% 已用、3 credits 的 Pro 账号因此持续压过 2% 已用、0 credits 的 Plus 账号，形成看似按套餐分组的长期偏置。
@@ -81,16 +89,9 @@
 - **历史边界**：部署后新请求可正常估算成本；已有 `cost_usd = null` 的历史 telemetry 不自动回填。
 - **官方依据**：Anthropic Models overview、Pricing、What's new in Claude Sonnet 5、Effort 与 Structured outputs 文档，均于 2026-07-11 读取。
 
-## 2026-07-11 · 退休 GPT-5.3-Codex-Spark 及其订阅配额投影（OAuth subscription / model catalog / Admin providers，docs/04/11，原则 3/5/6/7）
-
-- **退休边界**：`gpt-5.3-codex-spark` 不再作为可用订阅模型。Codex live discovery、bundled fallback、持久 catalog cache 与手工 enabled-model 展开都会过滤该 slug，避免旧设置或 last-known-good 快照重新暴露已退休模型。
-- **配额边界**：WHAM body、Codex response headers、Gateway 持久 quota snapshot、live metadata 和 Admin 最终展示都会过滤 `codex_spark` / `*-Codex-Spark` model-scoped limits。旧快照不会再显示 Spark，也不会让退休窗口参与账号停车、恢复或 reset-credit 判断；若持久 snapshot 过滤后为空，reset-credit 会回退到本次实时 quota，而不是误报 quota unavailable。账号级窗口和 Luna/Sol/Terra 等有效模型窗口保持原语义。
-- **分类与 UI**：保留 cheap-model classifier 中的 `spark` 语义 marker；它用于识别低成本模型族，不等同于已退休的精确 Codex Spark 模型 ID。撤销仅为 Codex Spark 长标签添加的 9px quota 字号，恢复普通窗口标签字号。订阅 credits 继续只显示两位小数，零余额继续隐藏。
-- **兼容决策**：运行时仍保留最小的 Spark 识别常量，并在专门的防回归 fixture 中保留退休字符串；这是为了丢弃历史缓存和旧上游数据，不代表模型仍可配置或使用。
-- **验证**：覆盖 live/bundled/cached catalog、手工 alias 展开、header/WHAM quota、Gateway 读写投影与 Admin 历史快照；相关定向测试、workspace test/typecheck/lint/build 作为交付门禁。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-11 · 退休 GPT-5.3-Codex-Spark 及其订阅配额投影（OAuth subscription / model catalog / Admin providers，docs/04/11，原则 3/5/6/7）**：从 live/bundled/cached catalog 与手工设置过滤退休模型，并从 WHAM/header/durable/Admin quota 投影移除其 model-scoped 限额，保留最小历史识别以阻止旧缓存复活。
 - **2026-07-11 · Portal 请求详情对齐 Admin 查看器但保持供应链边界（Self-Service Portal / Requests，docs/12，原则 1/6/7/8）**：复用 Admin viewer 并按 metadata-first 懒加载请求/响应与图片，同时保持 ownership 和 `upstream_request` 隔离边界。
 - **2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）**：bearer key 可在 Portal 安全配置 observe/inject、共享项目与线程来源；root 只读，显式请求头仍覆盖默认值。
 - **2026-07-10–11 · Codex CLI GPT-5.6 subscription parity（OAuth subscription / Responses / model catalog，docs/04/05/11，原则 3/5/6/7/8）**：按 Codex 源码补齐 GPT-5.6 模型目录、Responses/WebSocket/compact、usage、订阅 entitlement 与 reset-credit 安全边界，并完成真实 CLI 验证。

--- a/packages/core/src/provider/oauth/models.test.ts
+++ b/packages/core/src/provider/oauth/models.test.ts
@@ -6,6 +6,7 @@ import {
   expandOpenAICodexModelAliases,
   filterRetiredOpenAICodexLimits,
   hasLiveModelDiscovery,
+  listAnthropicModels,
   listOpenAICodexModels,
   OpenAICodexModelsError,
   resolveOpenAICodexClientVersion,
@@ -224,6 +225,15 @@ describe("hasLiveModelDiscovery", () => {
 });
 
 describe("listOpenAICodexModels", () => {
+  it("bounds the upstream request with an AbortSignal", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return jsonResponse({ models: [codexModel("gpt-5.6-sol", 1)] });
+    });
+
+    await listOpenAICodexModels("token", { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
   it("uses the current Codex whole client version and permits an environment override", () => {
     expect(DEFAULT_OPENAI_CODEX_CLIENT_VERSION).toBe("0.145.0");
     expect(resolveOpenAICodexClientVersion({})).toBe("0.145.0");
@@ -336,5 +346,17 @@ describe("listOpenAICodexModels", () => {
         fetchImpl: fetchMock as unknown as typeof globalThis.fetch,
       }),
     ).rejects.toBeInstanceOf(OpenAICodexModelsError);
+  });
+});
+
+describe("listAnthropicModels", () => {
+  it("bounds the upstream request with an AbortSignal", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return jsonResponse({ data: [{ id: "claude-sonnet-4-7" }] });
+    });
+
+    await expect(listAnthropicModels("token", fetchImpl)).resolves.toEqual(["claude-sonnet-4-7"]);
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -76,6 +76,9 @@ export function expandOpenAICodexModelAliases(models: readonly string[]): string
 // codex-rs/models-manager::client_version_to_whole.
 export const DEFAULT_OPENAI_CODEX_CLIENT_VERSION = "0.145.0";
 export const OPENAI_CODEX_CLIENT_VERSION_ENV = "HELM_OPENAI_CODEX_CLIENT_VERSION";
+// Provider-model discovery is an admin observability action. It must never inherit
+// Node fetch's multi-minute default and block the providers page refresh worker.
+export const OAUTH_MODEL_DISCOVERY_TIMEOUT_MS = 10_000;
 
 export interface OpenAICodexModelsOptions {
   accountId?: string;
@@ -83,6 +86,7 @@ export interface OpenAICodexModelsOptions {
   clientVersion?: string;
   userAgent?: string;
   fetchImpl?: typeof globalThis.fetch;
+  timeoutMs?: number;
 }
 
 export interface OpenAICodexModelsResult {
@@ -183,7 +187,14 @@ export async function listOpenAICodexModels(
   if (accountId) headers.set("chatgpt-account-id", accountId);
   if (isFedramp) headers.set("X-OpenAI-Fedramp", "true");
 
-  const response = await (options.fetchImpl ?? fetch)(url.toString(), { headers });
+  const timeoutMs =
+    typeof options.timeoutMs === "number" && Number.isFinite(options.timeoutMs)
+      ? Math.max(1, Math.floor(options.timeoutMs))
+      : OAUTH_MODEL_DISCOVERY_TIMEOUT_MS;
+  const response = await (options.fetchImpl ?? fetch)(url.toString(), {
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
   if (!response.ok) {
     await response.text().catch(() => "");
     throw new OpenAICodexModelsError(response.status);
@@ -215,7 +226,12 @@ export async function listOpenAICodexModels(
 export async function listAnthropicModels(
   accessToken: string,
   fetchImpl: typeof globalThis.fetch = fetch,
+  options: { timeoutMs?: number } = {},
 ): Promise<string[]> {
+  const timeoutMs =
+    typeof options.timeoutMs === "number" && Number.isFinite(options.timeoutMs)
+      ? Math.max(1, Math.floor(options.timeoutMs))
+      : OAUTH_MODEL_DISCOVERY_TIMEOUT_MS;
   const res = await fetchImpl("https://api.anthropic.com/v1/models?limit=1000", {
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -224,6 +240,7 @@ export async function listAnthropicModels(
       "user-agent": "claude-cli/1.0.0",
       "x-app": "cli",
     },
+    signal: AbortSignal.timeout(timeoutMs),
   });
   if (!res.ok) throw new Error(`anthropic /v1/models HTTP ${res.status}`);
   const body = (await res.json()) as { data?: Array<{ id?: unknown }> };


### PR DESCRIPTION
## Summary

- load Subscription Providers through one cache-only overview request with no token refresh, model discovery, quota pull, orphan pruning, or cooldown mutation
- add one process-wide refresh coordinator that coalesces clicks, refreshes accounts serially, bypasses stale discovery/quota caches on demand, and enforces a 60-second cooldown
- preserve last-known-good data on partial failure while exposing queued, running, succeeded, failed, last-refresh, and cooldown state in the Admin UI
- keep timer-driven auto refresh cache-only and add bounded provider-discovery timeouts plus locale coverage

## Verification

- corepack pnpm test — 357 files / 5775 tests passed
- corepack pnpm typecheck
- corepack pnpm --filter @helm/admin check
- corepack pnpm lint
- corepack pnpm build