### PR TITLE
chore(release): v0.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.26.27",
+  "version": "0.27.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump Helm API from 0.26.27 to 0.27.0
- release the cache-first Subscription Providers overview and serialized refresh queue merged in PR #544

## Version rationale

This is a minor release because it adds new admin API endpoints and refresh-job state, introduces a serialized refresh mechanism, and changes provider observability GETs from implicit upstream refreshes to cache-only reads. The change is backward-compatible for supported clients but materially expands behavior beyond a patch-only bug fix.

## Scope

Version-only change in the root package.json.