### PR TITLE
fix(oauth): drop empty Codex quota placeholders

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
   import { invalidateAll } from '$app/navigation';
-  import { isCodexAccountWeeklyQuotaWindow } from '@helm/shared';
+  import {
+    isCodexQuotaWindowPlaceholder,
+    selectCodexAccountWeeklyQuotaWindows,
+  } from '@helm/shared';
   import {
     consumeCodexResetCredit,
     getOAuthOverview,
@@ -333,8 +336,7 @@
   }
 
   function codexWeeklyUsedPercent(q: OAuthQuotaSnapshot | undefined): number | null {
-    const weekly = q?.windows
-      .filter(isCodexAccountWeeklyQuotaWindow)
+    const weekly = selectCodexAccountWeeklyQuotaWindows(q?.windows ?? [])
       .map((w) => w.usedPercent)
       .filter((pct) => Number.isFinite(pct));
     return weekly && weekly.length > 0 ? Math.max(...weekly) : null;
@@ -418,7 +420,9 @@
     return {
       ...quota,
       windows: quota.windows.filter(
-        (window) => !isRetiredCodexLimit(window.limitId, window.limitName),
+        (window) =>
+          !isRetiredCodexLimit(window.limitId, window.limitName) &&
+          !isCodexQuotaWindowPlaceholder(window, quota.capturedAt),
       ),
       additionalLimits: quota.additionalLimits?.filter(
         (limit) => !isRetiredCodexLimit(limit.limitId, limit.limitName),

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -315,6 +315,7 @@ describe('providers page', () => {
   });
 
   it('labels Codex quota windows by their real duration across plan shapes', () => {
+    const capturedAt = Date.now();
     renderPage({
       providers: [
         provider({
@@ -349,15 +350,15 @@ describe('providers page', () => {
               windowMinutes: 10_080,
             },
             {
-              // A key without duration must not invent a five-hour window.
+              // Live headers emit this already-expired zero-usage placeholder.
               key: 'secondary',
-              usedPercent: 2,
-              resetsAtMs: Date.now() + 3_600_000,
+              usedPercent: 0,
+              resetsAtMs: capturedAt,
               windowMinutes: null,
             },
           ],
-          capturedAt: Date.now(),
-          source: 'codex',
+          capturedAt,
+          source: 'codex-headers',
           usageLimitedUntilMs: null,
           resetCredits: 2,
           planType: 'pro',
@@ -369,7 +370,7 @@ describe('providers page', () => {
       'provider-quota-cell',
     );
     expect(within(quotaCell).getByText('Weekly')).toBeInTheDocument();
-    expect(within(quotaCell).getByText('Secondary')).toBeInTheDocument();
+    expect(within(quotaCell).queryByText('Secondary')).not.toBeInTheDocument();
     expect(within(quotaCell).queryByText('5h')).not.toBeInTheDocument();
   });
 

--- a/apps/gateway/src/oauth/auto-reset.test.ts
+++ b/apps/gateway/src/oauth/auto-reset.test.ts
@@ -63,6 +63,16 @@ describe("codex reset-credit eligibility", () => {
     ).toBe(42);
     expect(codexWeeklyUsedPercent([{ key: "primary", usedPercent: 100 }])).toBeNull();
   });
+
+  it("prefers an explicit weekly duration and ignores empty positional placeholders", () => {
+    expect(
+      codexWeeklyUsedPercent([
+        { key: "secondary", usedPercent: 95 },
+        { key: "primary", usedPercent: 37, windowMinutes: 10_080 },
+      ]),
+    ).toBe(37);
+    expect(codexWeeklyUsedPercent([{ key: "secondary", usedPercent: 0 }])).toBeNull();
+  });
 });
 
 describe("weeklySaturated", () => {

--- a/apps/gateway/src/oauth/auto-reset.ts
+++ b/apps/gateway/src/oauth/auto-reset.ts
@@ -8,7 +8,7 @@
 // and at most ONE consume per account per hour (cooldown), so a burst of concurrent
 // saturated replies can't drain the grant.
 
-import { isCodexAccountWeeklyQuotaWindow } from "@helm/shared";
+import { selectCodexAccountWeeklyQuotaWindows } from "@helm/shared";
 
 // At least one hour between reset-credit consumes for the same shared ChatGPT
 // account. The runtime also persists this guard so a container restart cannot
@@ -68,14 +68,7 @@ export function codexWeeklyUsedPercent(
     windowMinutes?: number | null;
   }>,
 ): number | null {
-  const weekly = windows
-    .filter((w) =>
-      isCodexAccountWeeklyQuotaWindow({
-        key: w.key,
-        limitId: w.limitId,
-        windowMinutes: w.windowMinutes ?? null,
-      }),
-    )
+  const weekly = selectCodexAccountWeeklyQuotaWindows(windows)
     .map((w) => w.usedPercent)
     .filter((pct) => Number.isFinite(pct));
   return weekly.length === 0 ? null : Math.max(...weekly);

--- a/apps/gateway/src/oauth/reset-credit-guard.test.ts
+++ b/apps/gateway/src/oauth/reset-credit-guard.test.ts
@@ -358,6 +358,37 @@ describe("createResetCreditGuard", () => {
     ).resolves.toMatchObject({ ok: true, windowId: "secondary:86400000" });
   });
 
+  it("uses the duration-backed weekly window instead of a positional placeholder", async () => {
+    const config = new MemoryConfig();
+    const guard = createResetCreditGuard({
+      config,
+      resolveSharedKey: vi.fn(async () => "codex:shared-account"),
+    });
+
+    await expect(
+      guard.reserve({
+        providerId: "openai-codex",
+        account: "work",
+        windows: [
+          {
+            key: "secondary",
+            usedPercent: 100,
+            resetsAtMs: 1_000,
+            windowMinutes: null,
+          },
+          {
+            key: "primary",
+            usedPercent: 100,
+            resetsAtMs: 86_400_000,
+            windowMinutes: 10_080,
+          },
+        ],
+        mode: "manual",
+        nowMs: 500,
+      }),
+    ).resolves.toMatchObject({ ok: true, windowId: "secondary:86400000" });
+  });
+
   it("allows another reserve after the full cooldown has elapsed", async () => {
     const config = new MemoryConfig();
     const resolveSharedKey = vi.fn(async () => "codex:shared-account");

--- a/apps/gateway/src/oauth/reset-credit-guard.ts
+++ b/apps/gateway/src/oauth/reset-credit-guard.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { ConfigStore } from "@helm/core";
-import { isCodexAccountWeeklyQuotaWindow, type OAuthQuotaWindow } from "@helm/shared";
+import { type OAuthQuotaWindow, selectCodexAccountWeeklyQuotaWindows } from "@helm/shared";
 import {
   AUTO_RESET_COOLDOWN_MS,
   CODEX_RESET_MIN_WEEKLY_USED_PERCENT,
@@ -101,8 +101,7 @@ interface RedeemRequestMarker {
 }
 
 function weeklyWindowMarker(windows: readonly OAuthQuotaWindow[]): WeeklyWindowMarker | null {
-  const weekly = windows
-    .filter(isCodexAccountWeeklyQuotaWindow)
+  const weekly = selectCodexAccountWeeklyQuotaWindows(windows)
     .filter((w) => Number.isFinite(w.usedPercent))
     .sort((a, b) => b.usedPercent - a.usedPercent)[0];
   if (weekly?.resetsAtMs == null || !Number.isFinite(weekly.resetsAtMs)) return null;

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -202,6 +202,58 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(seam.fetchAnthropicQuota).not.toHaveBeenCalled();
   });
 
+  it("GET /oauth/quota hides persisted Codex header placeholders", async () => {
+    const capturedAt = 1_000_000;
+    const oauthQuota = {
+      getAll: vi.fn(async () => [
+        {
+          providerId: "openai-codex",
+          account: "default",
+          windows: [
+            {
+              key: "primary",
+              usedPercent: 37,
+              resetsAtMs: capturedAt + 500_000,
+              windowMinutes: 10_080,
+            },
+            {
+              key: "secondary",
+              usedPercent: 0,
+              resetsAtMs: capturedAt,
+              windowMinutes: null,
+            },
+          ],
+          capturedAt,
+          source: "codex-headers",
+          usageLimitedUntilMs: null,
+        },
+      ]),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      listCachedStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [
+          {
+            id: "openai-codex",
+            name: "Codex",
+            accounts: [{ account: "default" }],
+          },
+        ],
+      })) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
+    const body = (await res.json()) as { quota: Array<{ windows: OAuthQuotaWindow[] }> };
+    expect(body.quota[0]?.windows).toEqual([
+      {
+        key: "primary",
+        usedPercent: 37,
+        resetsAtMs: capturedAt + 500_000,
+        windowMinutes: 10_080,
+      },
+    ]);
+  });
+
   it("POST /oauth/refresh refreshes xAI, updates the pool snapshot, and syncs cooldown", async () => {
     const now = Date.now();
     const resetAt = now + 3 * 86_400_000;

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -3,6 +3,7 @@ import {
   windowsToActiveUsageRecovery,
   windowsToUsageLimit,
 } from "@helm/core";
+import { isCodexQuotaWindowPlaceholder } from "@helm/shared";
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
@@ -442,7 +443,11 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         result.push({
           ...row,
           ...(row.providerId === "openai-codex"
-            ? { windows: filterRetiredOpenAICodexLimits(row.windows) }
+            ? {
+                windows: filterRetiredOpenAICodexLimits(row.windows).filter(
+                  (window) => !isCodexQuotaWindowPlaceholder(window, row.capturedAt),
+                ),
+              }
             : {}),
           ...(identity === undefined ? {} : { identity }),
           ...(metadata === null || metadata === undefined

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-07-14 · 丢弃 Codex 空 secondary 配额占位窗口（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）
+
+- **生产根因**：Codex 部分账号的响应头会同时返回真实 `primary + windowMinutes:10080` 周窗口，以及 `secondary + usedPercent:0 + 无 duration + reset-after:0`。后者只是空占位，但 header parser 将其作为配额写入；latest-wins snapshot 随后覆盖完整 PULL 数据，Admin 又把未知时长的 positional key 翻译成“次窗口”，造成看似存在第二个额度且 7 天用量消失。
+- **三层防御**：header parser 在入库前丢弃“0% + 无时长 + 截止采集时已重置”的窗口；Admin cache-only API 与 Providers 页面用 snapshot 自己的 `capturedAt` 过滤旧版本已写入的同类脏数据，部署后无需等待新请求或人工清库即可恢复展示。未来重置、非零用量或带真实 duration 的窗口继续保留，避免误删刚开始的新周期与 legacy 数据。
+- **周额度权威**：周窗口改为集合级选择：账号级 `windowMinutes >= 10080` 的明确时长窗口优先；只有整组没有明确周窗口时，才兼容使用非零的未知时长 `secondary`。model-scoped 窗口仍排除。Admin、自动重置和 reset-credit 幂等 guard 共用该选择，空 positional 数据不能再覆盖真实周用量或 reset marker。
+- **验证**：TDD 定向覆盖 live header 形态、durable cache 旧快照、Providers 标签、明确周窗口优先、legacy fallback 与 reset-credit guard；6 files / 219 tests 全绿。
+
 ## 2026-07-14 · Subscription Providers 改为缓存优先与全局串行刷新（OAuth Admin / provider observability，docs/04/11，原则 1/3/6/7）
 
 - **性能根因**：Providers 首屏过去并行请求 status、usage、quota；status 会刷新过期 token 并逐账号发现模型，quota 会逐账号拉取上游额度、写 snapshot、同步 cooldown 并清理 orphan。慢代理、上游限流或账号数增加会把页面打开直接绑定到外部网络，刷新按钮和自动刷新也会重复制造同一批工作。
@@ -30,7 +37,7 @@
 ## 2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）
 
 - **生产证据与根因**：生产 `oauth_quota` 中四个 Codex 账号都出现 `primary + windowMinutes:10080`，截图中的唯一窗口虽显示 `5h`，重置倒计时却是 `6d 22h`。上游不同套餐不再保证 `primary=5h / secondary=7d`，Admin 的位置硬编码因此把真实周配额错标为 5h；同一假设还会让手动/自动 reset-credit 误报周快照不可用。
-- **统一判定**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威；只有旧 header 快照缺少 duration 时才兼容回退到 `secondary`。带非默认 `limitId` 的 model-scoped 窗口绝不当作账号周配额。Admin 标签同样时长优先（300m→5h、10080m→Weekly），缺时长显示中性的 Primary/Secondary，不再猜测。
+- **统一判定**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威；只有旧 header 快照缺少 duration 且窗口有真实用量时才兼容回退到 `secondary`。带非默认 `limitId` 的 model-scoped 窗口绝不当作账号周配额。Admin 标签同样时长优先（300m→5h、10080m→Weekly）；有意义的缺时长窗口显示中性的 Primary/Secondary，空的已过期占位窗口则直接过滤。
 - **账号边界**：规则完全 plan-agnostic，覆盖 Codex Plus/Pro/Team/Business/Enterprise/Edu 等实际窗口形态，不按套餐名维护分支。Claude 继续使用其 5h/7d keys；Copilot、SuperGrok 与普通 API-key provider 没有可验证的同类 Codex reset-credit 周窗口，不套用本规则或伪造数据。
 - **验证**：共享 predicate、Admin 单周窗口、reset-credit UI、自动重置与持久 guard 均增加 `primary + 10080m` 回归；同时覆盖 `secondary + 300m` 不误判、缺 duration 的 legacy fallback，以及 model-scoped 周窗口隔离。
 
@@ -80,17 +87,9 @@
 - **缓存边界**：非 Codex live discovery 使用 Gateway 进程级账号缓存，按 `providerId + account` 隔离；正缓存 5 分钟、失败冷却 1 分钟、最多 128 个账号，并发刷新 singleflight。空结果/异常保留 last-known-good，重新绑定、断开账号或修改代理时精确失效。Admin 与 runtime synthesis 共用同一实例，避免页面读取和 pool rebuild 各请求一次；curated fallback 只在 runtime cache 之外应用，不能污染 Admin 的“账号实际返回”投影。Codex 继续使用其独立的持久 ModelInfo catalog cache。
 - **验证**：TDD 覆盖自动模式实时模型、发现失败不展示静态默认、手动模式保存值与跳过 discovery、Codex entitlement/alias、core fallback 开关，以及缓存 TTL、singleflight、last-known-good、精确失效和 Admin/runtime 共享复用；workspace typecheck/lint/build 全通过，完整 Vitest 为 352 files / 5631 tests 全绿。
 
-## 2026-07-11 · Claude Sonnet 5 订阅流量 API 等价成本与能力目录（Provider catalog / cost telemetry，docs/04/07/11，原则 2/5/7）
-
-- **默认路由升级（2026-07-12）**：`balanced` 与 `claude-sonnet` 的 native Anthropic 候选从 Sonnet 4.6 切换到 `anthropic/claude-sonnet-5`，Anthropic live discovery 失败时的 curated fallback 同步改为 Sonnet 5。成本过高的 `zenmux-anthropic/claude-sonnet-4.6` 只从 shipped lanes 删除；provider、能力与价格定义继续保留，供历史 telemetry、显式 custom-model 和兼容性使用。
-- **成本定义**：`anthropic/claude-sonnet-5` 是 Claude Pro/Max OAuth 订阅别名，订阅本身不按请求扣费；Helm 的 `cost_usd` 使用官方 Claude API 等价估算，只用于 telemetry，不参与路由或订阅结算。
-- **当前价格**：按 Anthropic 官方 2026-07-11 价格表使用介绍期价格：input `$2/M`、output `$10/M`、5 分钟 cache write `$2.50/M`、cache read `$0.20/M`。介绍期于 2026-08-31 结束；静态 catalog 不支持生效日期，2026-09-01 必须更新为标准 `$3/$15/$3.75/$0.30`。
-- **能力边界**：与价格同一变更补齐 1M context、128K synchronous output、tools、vision、streaming、structured outputs、document input，以及 `low/medium/high/xhigh/max` adaptive-thinking effort。manual `budget_tokens` thinking 明确不支持，避免价格单独引入 `EMPTY_CAPABILITIES` 后被 `context_too_small` 错误过滤。
-- **历史边界**：部署后新请求可正常估算成本；已有 `cost_usd = null` 的历史 telemetry 不自动回填。
-- **官方依据**：Anthropic Models overview、Pricing、What's new in Claude Sonnet 5、Effort 与 Structured outputs 文档，均于 2026-07-11 读取。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-11 · Claude Sonnet 5 订阅流量 API 等价成本与能力目录（Provider catalog / cost telemetry，docs/04/07/11，原则 2/5/7）**：默认 Anthropic 订阅路由升级到 Sonnet 5，并按官方介绍期 API 等价费率记录 telemetry；补齐 1M context、128K output、tools/vision/stream/structured outputs/document 与 adaptive-thinking 能力，2026-09-01 需更新标准费率。
 - **2026-07-11 · 退休 GPT-5.3-Codex-Spark 及其订阅配额投影（OAuth subscription / model catalog / Admin providers，docs/04/11，原则 3/5/6/7）**：从 live/bundled/cached catalog 与手工设置过滤退休模型，并从 WHAM/header/durable/Admin quota 投影移除其 model-scoped 限额，保留最小历史识别以阻止旧缓存复活。
 - **2026-07-11 · Portal 请求详情对齐 Admin 查看器但保持供应链边界（Self-Service Portal / Requests，docs/12，原则 1/6/7/8）**：复用 Admin viewer 并按 metadata-first 懒加载请求/响应与图片，同时保持 ownership 和 `upstream_request` 隔离边界。
 - **2026-07-11 · API-key 门户自助 Memory 默认设置（Self-Service Portal / Memory，docs/06/08/12，原则 2/7）**：bearer key 可在 Portal 安全配置 observe/inject、共享项目与线程来源；root 只读，显式请求头仍覆盖默认值。

--- a/packages/core/src/provider/oauth/codex-quota.test.ts
+++ b/packages/core/src/provider/oauth/codex-quota.test.ts
@@ -35,6 +35,28 @@ describe("parseCodexQuotaHeaders", () => {
     ]);
   });
 
+  it("drops the live zero-duration secondary header placeholder", () => {
+    expect(
+      parseCodexQuotaHeaders(
+        headers({
+          "x-codex-primary-used-percent": "37",
+          "x-codex-primary-reset-after-seconds": "500000",
+          "x-codex-primary-window-minutes": "10080",
+          "x-codex-secondary-used-percent": "0",
+          "x-codex-secondary-reset-after-seconds": "0",
+        }),
+        NOW,
+      ),
+    ).toEqual([
+      {
+        key: "primary",
+        usedPercent: 37,
+        resetsAtMs: NOW + 500_000_000,
+        windowMinutes: 10_080,
+      },
+    ]);
+  });
+
   it("prefers reset-at epoch seconds over reset-after-seconds", () => {
     const out = parseCodexQuotaHeaders(
       headers({

--- a/packages/core/src/provider/oauth/codex-quota.ts
+++ b/packages/core/src/provider/oauth/codex-quota.ts
@@ -2,6 +2,7 @@ import {
   type CodexOAuthUsage,
   CodexOAuthUsageSchema,
   CodexResetResultSchema,
+  isCodexQuotaWindowPlaceholder,
   type OAuthQuotaWindow,
 } from "@helm/shared";
 import { isRetiredOpenAICodexLimit } from "./models.js";
@@ -136,7 +137,7 @@ export function parseCodexQuotaHeaderDetails(headers: Headers, nowMs: number): C
     const normalizedLimitId = family.limitId.replaceAll("-", "_");
     const limitName = headers.get(`x-${family.limitId}-limit-name`)?.trim() || null;
     if (isRetiredOpenAICodexLimit(normalizedLimitId, limitName)) continue;
-    out.push({
+    const candidate: OAuthQuotaWindow = {
       key: family.key,
       usedPercent: Math.max(0, used),
       resetsAtMs:
@@ -152,7 +153,9 @@ export function parseCodexQuotaHeaderDetails(headers: Headers, nowMs: number): C
             limitId: normalizedLimitId,
             limitName,
           }),
-    });
+    };
+    if (isCodexQuotaWindowPlaceholder(candidate, nowMs)) continue;
+    out.push(candidate);
   }
   const additionalLimits = new Map<string, CodexAdditionalLimitSnapshot>();
   for (const window of out) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -283,12 +283,14 @@ export {
   type CodexResetResult,
   CodexResetResultSchema,
   isCodexAccountWeeklyQuotaWindow,
+  isCodexQuotaWindowPlaceholder,
   type OAuthQuotaSnapshot,
   OAuthQuotaSnapshotSchema,
   type OAuthQuotaWindow,
   OAuthQuotaWindowSchema,
   type OAuthUsageRow,
   OAuthUsageRowSchema,
+  selectCodexAccountWeeklyQuotaWindows,
 } from "./oauth/usage-schema.js";
 export {
   type ImageGenerationRequest,

--- a/packages/shared/src/oauth/usage-schema.test.ts
+++ b/packages/shared/src/oauth/usage-schema.test.ts
@@ -3,8 +3,83 @@ import {
   CodexOAuthUsageSchema,
   CodexResetResultSchema,
   isCodexAccountWeeklyQuotaWindow,
+  isCodexQuotaWindowPlaceholder,
   OAuthQuotaSnapshotSchema,
+  selectCodexAccountWeeklyQuotaWindows,
 } from "./usage-schema.js";
+
+describe("Codex normalized quota-window helpers", () => {
+  const capturedAt = 1_000_000;
+
+  it("recognizes only expired zero-usage windows without a reported duration as placeholders", () => {
+    expect(
+      isCodexQuotaWindowPlaceholder(
+        { key: "secondary", usedPercent: 0, windowMinutes: null, resetsAtMs: capturedAt },
+        capturedAt,
+      ),
+    ).toBe(true);
+    expect(
+      isCodexQuotaWindowPlaceholder(
+        { key: "secondary", usedPercent: 1, windowMinutes: null, resetsAtMs: capturedAt },
+        capturedAt,
+      ),
+    ).toBe(false);
+    expect(
+      isCodexQuotaWindowPlaceholder(
+        { key: "secondary", usedPercent: 0, windowMinutes: 10_080, resetsAtMs: capturedAt },
+        capturedAt,
+      ),
+    ).toBe(false);
+    expect(
+      isCodexQuotaWindowPlaceholder(
+        {
+          key: "secondary",
+          usedPercent: 0,
+          windowMinutes: null,
+          resetsAtMs: capturedAt + 60_000,
+        },
+        capturedAt,
+      ),
+    ).toBe(false);
+  });
+
+  it("prefers duration-backed weekly truth over positional legacy fallbacks", () => {
+    const explicit = {
+      key: "primary",
+      usedPercent: 37,
+      windowMinutes: 10_080,
+      resetsAtMs: capturedAt + 500_000,
+    };
+    expect(
+      selectCodexAccountWeeklyQuotaWindows([
+        { key: "secondary", usedPercent: 99, windowMinutes: null, resetsAtMs: null },
+        explicit,
+      ]),
+    ).toEqual([explicit]);
+  });
+
+  it("uses only meaningful account-wide secondary windows as a legacy fallback", () => {
+    const legacy = {
+      key: "secondary",
+      usedPercent: 42,
+      windowMinutes: null,
+      resetsAtMs: capturedAt + 500_000,
+    };
+    expect(selectCodexAccountWeeklyQuotaWindows([legacy])).toEqual([legacy]);
+    expect(
+      selectCodexAccountWeeklyQuotaWindows([
+        { key: "secondary", usedPercent: 0, windowMinutes: null, resetsAtMs: capturedAt },
+        {
+          key: "codex_terra-secondary",
+          limitId: "codex_terra",
+          usedPercent: 100,
+          windowMinutes: null,
+          resetsAtMs: capturedAt + 500_000,
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
 
 describe("isCodexAccountWeeklyQuotaWindow", () => {
   it("uses the reported duration before the unstable primary/secondary position", () => {

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -54,6 +54,50 @@ export const OAuthQuotaWindowSchema = z
 
 export type OAuthQuotaWindow = z.infer<typeof OAuthQuotaWindowSchema>;
 
+type CodexQuotaWindowCandidate = Pick<OAuthQuotaWindow, "key" | "usedPercent"> &
+  Partial<Pick<OAuthQuotaWindow, "windowMinutes" | "resetsAtMs" | "limitId">>;
+
+// Some Codex response-header families expose an empty positional window even
+// though the account has no second allowance: 0% used, no duration, and a reset
+// deadline that is already expired at capture time. It is transport padding, not
+// quota truth, so callers may discard it both before persistence and on cached
+// reads of snapshots written by older Helm versions.
+export function isCodexQuotaWindowPlaceholder(
+  window: CodexQuotaWindowCandidate,
+  capturedAtMs: number,
+): boolean {
+  return (
+    window.usedPercent === 0 &&
+    window.windowMinutes == null &&
+    (window.resetsAtMs == null || window.resetsAtMs <= capturedAtMs)
+  );
+}
+
+// Weekly selection is collection-level because an unknown-duration `secondary`
+// is only a legacy fallback when the same snapshot has no duration-backed weekly
+// account window. Model-scoped limits never participate in account reset credits.
+export function selectCodexAccountWeeklyQuotaWindows<T extends CodexQuotaWindowCandidate>(
+  windows: readonly T[],
+): T[] {
+  const accountWide = windows.filter(
+    (window) => window.limitId === undefined || window.limitId === "codex",
+  );
+  const explicit = accountWide.filter(
+    (window) =>
+      window.windowMinutes != null &&
+      Number.isFinite(window.windowMinutes) &&
+      window.windowMinutes >= 7 * 24 * 60,
+  );
+  if (explicit.length > 0) return explicit;
+  return accountWide.filter(
+    (window) =>
+      window.key === "secondary" &&
+      window.windowMinutes == null &&
+      Number.isFinite(window.usedPercent) &&
+      window.usedPercent > 0,
+  );
+}
+
 // Codex account plans do not consistently assign the short and weekly allowances
 // to `primary` / `secondary`. Prefer the reported duration and retain `secondary`
 // only as a compatibility fallback for older header snapshots without duration.


### PR DESCRIPTION
## Summary

- discard expired zero-usage Codex header placeholders before persistence
- filter placeholders from cached Admin quota reads and the Providers UI
- prefer duration-backed account weekly windows over legacy positional fallbacks

## Verification

- `CI=true pnpm exec vitest run packages/core/src/provider/oauth/codex-quota.test.ts packages/shared/src/oauth/usage-schema.test.ts apps/gateway/src/oauth/auto-reset.test.ts apps/gateway/src/oauth/reset-credit-guard.test.ts apps/gateway/src/routes/admin/oauth.test.ts apps/admin/src/routes/providers/providers.test.ts` (219 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @helm/admin check`
- `pnpm build`