### PR TITLE
chore(release): v0.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

- bump Helm API from `0.27.0` to `0.27.1`
- includes the Codex empty quota-placeholder fix from PR #546

This PR intentionally contains only the root package version bump.