### PR TITLE
fix(oauth): persist auto-discovered model catalogs

### DIFF
--- a/apps/gateway/src/oauth/account-settings.test.ts
+++ b/apps/gateway/src/oauth/account-settings.test.ts
@@ -1,4 +1,4 @@
-import { type ConfigStore, createSqliteDb, SqliteConfigStore } from "@helm/core";
+import { type ConfigStore, createSqliteDb, encryptSecret, SqliteConfigStore } from "@helm/core";
 import { describe, expect, it } from "vitest";
 import {
   clearAccountCredentialFailure,
@@ -7,6 +7,7 @@ import {
   loadGlobalOAuthSettings,
   markAccountCredentialFailure,
   resolveAccountModelsMode,
+  saveAccountDiscoveredModels,
   setAccountSettings,
   setGlobalOAuthSettings,
 } from "./account-settings.js";
@@ -46,6 +47,38 @@ describe("account-settings", () => {
     const config = makeConfig();
     expect(await loadAccountSettings(config, KEY)).toEqual({});
     expect(getAccountSettings({}, "anthropic", "default")).toEqual({});
+  });
+
+  it("fails open when an automatic discovery snapshot cannot be persisted", async () => {
+    const config: ConfigStore = {
+      get: async () => null,
+      set: async () => {
+        throw new Error("database unavailable");
+      },
+    };
+
+    await expect(
+      saveAccountDiscoveredModels(config, KEY, "anthropic", "default", ["claude-fable-5"]),
+    ).resolves.toBe(false);
+  });
+
+  it.each([
+    ["the settings read throws", async () => Promise.reject(new Error("database unavailable"))],
+    ["the ciphertext is invalid", async () => "not-encrypted"],
+    ["the decrypted JSON has the wrong shape", async () => encryptSecret("[]", KEY)],
+  ])("does not overwrite account settings when %s", async (_label, get) => {
+    let writes = 0;
+    const config: ConfigStore = {
+      get,
+      set: async () => {
+        writes += 1;
+      },
+    };
+
+    await expect(
+      saveAccountDiscoveredModels(config, KEY, "anthropic", "default", ["claude-fable-5"]),
+    ).resolves.toBe(false);
+    expect(writes).toBe(0);
   });
 
   it("preserves a legacy Codex enabledModels allowlist as manual mode", () => {

--- a/apps/gateway/src/oauth/account-settings.ts
+++ b/apps/gateway/src/oauth/account-settings.ts
@@ -43,6 +43,10 @@ export interface AccountSettings {
   modelsMode?: "auto" | "manual";
   // Subset of discovered models the operator exposes to Lanes. Unset = expose all.
   enabledModels?: string[];
+  // Last non-empty remote catalog successfully discovered for this account.
+  // Auto mode uses it after a restart or transient discovery failure; live cache
+  // data still wins. Stored inside the existing encrypted settings blob.
+  discoveredModels?: string[];
   // Lower = preferred; round-robin within an equal priority. Scheduler default 50.
   priority?: number;
   // When false the account is skipped by the scheduler (kept connected, parked).
@@ -109,19 +113,34 @@ function serializeSettingsMutation<T>(config: ConfigStore, work: () => Promise<T
   return run;
 }
 
-// Load + decrypt the full settings map. FAIL-OPEN to {} on a missing/corrupt blob
-// so a bad write can never wedge routing or the providers page.
+function parseAccountSettings(blob: string, encKey: Buffer): AccountSettingsMap {
+  const parsed: unknown = JSON.parse(decryptSecret(blob, encKey));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("invalid OAuth account settings");
+  }
+  return parsed as AccountSettingsMap;
+}
+
+async function loadAccountSettingsForMutation(
+  config: ConfigStore,
+  encKey: Buffer,
+): Promise<AccountSettingsMap> {
+  const blob = await config.get(SETTINGS_KEY);
+  if (blob === null) return {};
+  return parseAccountSettings(blob, encKey);
+}
+
+// Read paths FAIL-OPEN to {} on a missing/corrupt blob so a bad write can never
+// wedge routing or the providers page. Mutation paths use the strict loader above:
+// corrupt/unreadable settings must never be replaced with a partial empty map.
 export async function loadAccountSettings(
   config: ConfigStore,
   encKey: Buffer,
 ): Promise<AccountSettingsMap> {
   try {
     const blob = await config.get(SETTINGS_KEY);
-    if (!blob) return {};
-    const json = decryptSecret(blob, encKey);
-    const parsed: unknown = JSON.parse(json);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    return parsed as AccountSettingsMap;
+    if (blob === null) return {};
+    return parseAccountSettings(blob, encKey);
   } catch {
     return {};
   }
@@ -190,11 +209,69 @@ export async function setAccountSettings(
   patch: AccountSettings,
 ): Promise<void> {
   await serializeSettingsMutation(config, async () => {
-    const map = await loadAccountSettings(config, encKey);
+    const map = await loadAccountSettingsForMutation(config, encKey);
     const key = composite(providerId, account);
     map[key] = { ...map[key], ...patch };
     await saveAccountSettings(config, encKey, map);
   });
+}
+
+// Persist one account's non-empty, last-known-good remote catalog. Empty/error
+// discovery must never erase a prior snapshot. Avoid rewriting the encrypted blob
+// when the normalized catalog is unchanged (refresh runs can be frequent).
+export async function saveAccountDiscoveredModels(
+  config: ConfigStore,
+  encKey: Buffer,
+  providerId: string,
+  account: string,
+  models: readonly string[],
+): Promise<boolean> {
+  const normalized = [...new Set(models.map((model) => model.trim()).filter(Boolean))];
+  if (normalized.length === 0) return true;
+  try {
+    await serializeSettingsMutation(config, async () => {
+      const map = await loadAccountSettingsForMutation(config, encKey);
+      const key = composite(providerId, account);
+      const current = map[key] ?? {};
+      if (
+        current.discoveredModels?.length === normalized.length &&
+        current.discoveredModels.every((model, index) => model === normalized[index])
+      ) {
+        return;
+      }
+      map[key] = { ...current, discoveredModels: normalized };
+      await saveAccountSettings(config, encKey, map);
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Credential replacement must remove the old identity's durable catalog BEFORE
+// the token row changes. Unlike background snapshot writes, a failed clear is a
+// hard stop for reconnect; callers use the boolean to keep the old credential.
+export async function clearAccountDiscoveredModels(
+  config: ConfigStore,
+  encKey: Buffer,
+  providerId: string,
+  account: string,
+): Promise<boolean> {
+  try {
+    await serializeSettingsMutation(config, async () => {
+      const map = await loadAccountSettingsForMutation(config, encKey);
+      const key = composite(providerId, account);
+      const current = map[key];
+      if (!current || current.discoveredModels === undefined) return;
+      const next = { ...current };
+      delete next.discoveredModels;
+      map[key] = next;
+      await saveAccountSettings(config, encKey, map);
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function markAccountCredentialFailure(
@@ -205,7 +282,7 @@ export async function markAccountCredentialFailure(
   failure: { at: number; reason: string },
 ): Promise<void> {
   await serializeSettingsMutation(config, async () => {
-    const map = await loadAccountSettings(config, encKey);
+    const map = await loadAccountSettingsForMutation(config, encKey);
     const key = composite(providerId, account);
     const current = map[key] ?? {};
     const wasOperatorParked =
@@ -228,7 +305,7 @@ export async function clearAccountCredentialFailure(
   account: string,
 ): Promise<void> {
   await serializeSettingsMutation(config, async () => {
-    const map = await loadAccountSettings(config, encKey);
+    const map = await loadAccountSettingsForMutation(config, encKey);
     const key = composite(providerId, account);
     const current = map[key];
     if (!current) return;
@@ -268,7 +345,7 @@ export async function clearAccountSettings(
   account: string,
 ): Promise<void> {
   await serializeSettingsMutation(config, async () => {
-    const map = await loadAccountSettings(config, encKey);
+    const map = await loadAccountSettingsForMutation(config, encKey);
     delete map[composite(providerId, account)];
     await saveAccountSettings(config, encKey, map);
   });

--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -1,5 +1,6 @@
 import {
   buildXaiGrokCreditsRequest,
+  type ConfigStore,
   createSqliteDb,
   decryptSecret,
   encryptSecret,
@@ -12,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getAccountSettings, loadAccountSettings, setAccountSettings } from "./account-settings.js";
 import { createOAuthAdmin } from "./admin-oauth.js";
 import type { CodexModelCatalog } from "./codex-model-catalog.js";
+import { createOAuthModelDiscoveryCache } from "./model-discovery-cache.js";
 
 const KEY = Buffer.alloc(32, 4);
 
@@ -758,6 +760,10 @@ describe("createOAuthAdmin", () => {
       ?.accounts.find((candidate) => candidate.account === "default");
 
     expect(account?.models).toEqual(["claude-fable-5", "claude-sonnet-4-7"]);
+    expect(
+      getAccountSettings(await loadAccountSettings(config, KEY), "anthropic", "default")
+        .discoveredModels,
+    ).toEqual(["claude-fable-5", "claude-sonnet-4-7"]);
     await expect(
       admin.listModels({ providerId: "anthropic", account: "default" }),
     ).resolves.toMatchObject({
@@ -790,6 +796,95 @@ describe("createOAuthAdmin", () => {
       ?.accounts.find((candidate) => candidate.account === "default");
 
     expect(account?.models).toEqual([]);
+  });
+
+  it("does not persist an old discovery result after its credential cache generation is invalidated", async () => {
+    const { tokens, config } = makeStores();
+    await tokens.upsert({
+      providerId: "anthropic",
+      account: "default",
+      accessEnc: encryptSecret("AT", KEY),
+      refreshEnc: encryptSecret("RT", KEY),
+      expiresAt: Date.now() + 3_600_000,
+      meta: null,
+      updatedAt: 1,
+    });
+    let resolveModels!: (response: Response) => void;
+    const pendingModels = new Promise<Response>((resolve) => {
+      resolveModels = resolve;
+    });
+    const fetchMock = vi.fn(async () => pendingModels);
+    vi.stubGlobal("fetch", fetchMock);
+    const modelDiscoveryCache = createOAuthModelDiscoveryCache();
+    const admin = createOAuthAdmin({
+      store: tokens,
+      encKey: KEY,
+      config,
+      modelDiscoveryCache,
+    });
+
+    const pending = admin.listModels({ providerId: "anthropic", account: "default" });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    modelDiscoveryCache.invalidate({ providerId: "anthropic", account: "default" });
+    resolveModels(json({ data: [{ id: "claude-old-identity" }] }));
+    await expect(pending).resolves.toMatchObject({ available: ["claude-old-identity"] });
+
+    expect(
+      getAccountSettings(await loadAccountSettings(config, KEY), "anthropic", "default")
+        .discoveredModels,
+    ).toBeUndefined();
+  });
+
+  it("keeps the old credential when its identity-bound model snapshot cannot be cleared", async () => {
+    const db = createSqliteDb(":memory:");
+    const tokens = new SqliteOAuthTokenStore(db);
+    const storedConfig = new SqliteConfigStore(db);
+    await tokens.upsert({
+      providerId: "anthropic",
+      account: "default",
+      accessEnc: encryptSecret("OLD", KEY),
+      refreshEnc: encryptSecret("OLD-RT", KEY),
+      expiresAt: Date.now() + 3_600_000,
+      meta: null,
+      updatedAt: 1,
+    });
+    await setAccountSettings(storedConfig, KEY, "anthropic", "default", {
+      discoveredModels: ["claude-old-identity"],
+    });
+    const failingConfig: ConfigStore = {
+      get: (key) => storedConfig.get(key),
+      set: async () => {
+        throw new Error("database unavailable");
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      routeFetch([
+        [
+          /oauth\/token/,
+          () => json({ access_token: "NEW", refresh_token: "NEW-RT", expires_in: 3600 }),
+        ],
+      ]),
+    );
+    const admin = createOAuthAdmin({
+      store: tokens,
+      encKey: KEY,
+      config: failingConfig,
+      genSessionId: () => "replace",
+    });
+    const { authorizeUrl } = await admin.startManualPaste({ providerId: "anthropic" });
+    const state = new URL(authorizeUrl).searchParams.get("state");
+
+    await expect(
+      admin.completeManualPaste({
+        sessionId: "replace",
+        redirectInput: `https://x/cb?code=C&state=${state}`,
+        account: "default",
+      }),
+    ).rejects.toThrow();
+    expect(decryptSecret((await tokens.get("anthropic", "default"))?.accessEnc ?? "", KEY)).toBe(
+      "OLD",
+    );
   });
 
   it("setEnabledModels persists a subset; listModels then returns it as `enabled`", async () => {

--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -56,12 +56,14 @@ import type {
 import {
   type AccountSettings,
   clearAccountCredentialFailure,
+  clearAccountDiscoveredModels,
   clearAccountSettings,
   getAccountSettings,
   loadAccountSettings,
   loadGlobalOAuthSettings,
   markAccountCredentialFailure,
   resolveAccountModelsMode,
+  saveAccountDiscoveredModels,
   setAccountSettings,
   setGlobalOAuthSettings,
 } from "./account-settings.js";
@@ -527,8 +529,9 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     const provider = getOAuthProvider(providerId);
     if (!provider) return { available: [], entitled: [] };
     if (providerId !== CODEX) {
+      const discoveryKey = { providerId, account };
       const available = await modelDiscoveryCache.load(
-        { providerId, account },
+        discoveryKey,
         async () => {
           const accountFetch = makeFetch(settings.proxy as ProxyConfig | undefined);
           const tm = createTokenManager({
@@ -546,6 +549,20 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
         },
         { force: forceRefresh },
       );
+      const accepted = modelDiscoveryCache.snapshot(discoveryKey);
+      if (
+        accepted &&
+        accepted.length > 0 &&
+        !(await saveAccountDiscoveredModels(
+          deps.config,
+          deps.encKey,
+          providerId,
+          account,
+          accepted,
+        ))
+      ) {
+        log("warn", "oauth.models.snapshot_write_failed", { providerId, account });
+      }
       return { available, entitled: available };
     }
     try {
@@ -631,6 +648,14 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     account: string,
     creds: OAuthCredentials,
   ): Promise<void> {
+    if (providerId !== CODEX) {
+      // Invalidate first so an old in-flight discovery cannot become the current
+      // cache generation, then strictly clear its durable identity-bound snapshot.
+      modelDiscoveryCache.invalidate({ providerId, account });
+      if (!(await clearAccountDiscoveredModels(deps.config, deps.encKey, providerId, account))) {
+        throw new Error("failed to clear the previous account model snapshot");
+      }
+    }
     await deps.store.upsert({
       providerId,
       account,
@@ -644,7 +669,6 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
     // upstream identity. Never let that new credential inherit the old identity's
     // positive OR negative quota cache entry.
     invalidateQuotaCache(providerId, account);
-    modelDiscoveryCache.invalidate({ providerId, account });
   }
 
   // Ensure a stored account's access token is fresh — the SAME lazy refresh the

--- a/apps/gateway/src/oauth/effective-models.test.ts
+++ b/apps/gateway/src/oauth/effective-models.test.ts
@@ -12,6 +12,7 @@ import {
   effectiveOAuthAliases,
   effectiveOAuthModelOptions,
 } from "./effective-models.js";
+import { createOAuthModelDiscoveryCache } from "./model-discovery-cache.js";
 
 const KEY = Buffer.alloc(32, 7);
 const ROUTABLE = new Set(["anthropic", "github-copilot", "openai-codex", "xai"]);
@@ -81,6 +82,15 @@ describe("effectiveAccountModels", () => {
       "claude-sonnet-5",
       "claude-haiku-4-5",
     ]);
+  });
+
+  it("uses the durable auto-discovery snapshot after the process cache is lost", () => {
+    expect(
+      effectiveAccountModels(
+        { modelsMode: "auto", discoveredModels: ["claude-fable-5", "claude-sonnet-4-7"] },
+        "anthropic",
+      ),
+    ).toEqual(["claude-fable-5", "claude-sonnet-4-7"]);
   });
 
   it("offers the verified xAI catalog when a bound account stays in auto mode", () => {
@@ -190,6 +200,42 @@ describe("effectiveOAuthAliases", () => {
 });
 
 describe("effectiveOAuthModelOptions", () => {
+  it.each([
+    ["anthropic", "claude-fable-5"],
+    ["github-copilot", "gpt-5.99-copilot"],
+    ["xai", "grok-next-preview"],
+  ])("uses the discovered %s auto catalog instead of hard-coded picker fallbacks", async (providerId, remoteModel) => {
+    const { tokens, config } = makeStores();
+    await bind(tokens, providerId, "default");
+    const modelDiscoveryCache = createOAuthModelDiscoveryCache();
+    await modelDiscoveryCache.load({ providerId, account: "default" }, async () => [remoteModel]);
+
+    await expect(
+      effectiveOAuthModelOptions({ store: tokens, encKey: KEY }, config, ROUTABLE, {
+        modelDiscoveryCache,
+      }),
+    ).resolves.toEqual([{ alias: `${providerId}/${remoteModel}`, accounts: ["default"] }]);
+  });
+
+  it("does not let an auto-discovery cache snapshot widen a manual allowlist", async () => {
+    const { tokens, config } = makeStores();
+    await bind(tokens, "anthropic", "default");
+    await setAccountSettings(config, KEY, "anthropic", "default", {
+      modelsMode: "manual",
+      enabledModels: ["claude-opus-4-6"],
+    });
+    const modelDiscoveryCache = createOAuthModelDiscoveryCache();
+    await modelDiscoveryCache.load({ providerId: "anthropic", account: "default" }, async () => [
+      "claude-fable-5",
+    ]);
+
+    await expect(
+      effectiveOAuthModelOptions({ store: tokens, encKey: KEY }, config, ROUTABLE, {
+        modelDiscoveryCache,
+      }),
+    ).resolves.toEqual([{ alias: "anthropic/claude-opus-4-6", accounts: ["default"] }]);
+  });
+
   it("does not mutate the original Codex catalog snapshot model order", async () => {
     const { tokens, config } = makeStores();
     await bind(tokens, "openai-codex", "default", { accountId: "acc-default" });

--- a/apps/gateway/src/oauth/effective-models.ts
+++ b/apps/gateway/src/oauth/effective-models.ts
@@ -16,6 +16,7 @@ import {
 } from "./account-settings.js";
 import type { CodexModelCacheKey } from "./codex-model-cache.js";
 import type { CodexModelCatalog } from "./codex-model-catalog.js";
+import type { OAuthModelDiscoveryCache } from "./model-discovery-cache.js";
 
 // THE single source of truth for "which subscription models are routable right
 // now" (issue #38 follow-up). One function, computed LIVE and NETWORK-FREE, so the
@@ -46,16 +47,19 @@ const ACCOUNT_MODEL_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
   xai: ["grok-4.5", "grok-composer-2.5-fast"],
 };
 
-// The effective enabled models for ONE account (no network): the saved
-// `enabledModels` verbatim, else the provider's curated fallback (else []).
+// The effective enabled models for ONE account (no network): Manual uses the
+// saved `enabledModels` verbatim; Auto uses the durable discovery snapshot when
+// available, then the provider's curated fallback (else []).
 export function effectiveAccountModels(
-  settings: Pick<AccountSettings, "modelsMode" | "enabledModels">,
+  settings: Pick<AccountSettings, "modelsMode" | "enabledModels" | "discoveredModels">,
   providerId: string,
 ): string[] {
   if (providerId === "openai-codex") return [];
   return resolveAccountModelsMode(providerId, settings) === "manual"
     ? (settings.enabledModels ?? [])
-    : [...(ACCOUNT_MODEL_FALLBACKS[providerId] ?? [])];
+    : settings.discoveredModels && settings.discoveredModels.length > 0
+      ? [...settings.discoveredModels]
+      : [...(ACCOUNT_MODEL_FALLBACKS[providerId] ?? [])];
 }
 
 // Every routable `${providerId}/${model}` alias across all bound accounts, deduped
@@ -74,6 +78,10 @@ export interface ModelOption {
 export interface EffectiveOAuthModelOptions {
   codexCatalog?: CodexModelCatalog;
   codexClientVersion?: string;
+  // Shared account-scoped discovery cache populated by Admin refreshes and
+  // runtime pool synthesis. The Lanes picker reads its last-known-good snapshot
+  // without performing upstream I/O of its own.
+  modelDiscoveryCache?: OAuthModelDiscoveryCache;
 }
 
 function identityString(value: unknown): string | undefined {
@@ -157,7 +165,21 @@ export async function effectiveOAuthModelOptions(
         models = entitled;
       }
     } else {
-      models = effectiveAccountModels(accountSettings, row.providerId);
+      const modelsMode = resolveAccountModelsMode(row.providerId, accountSettings);
+      const discovered =
+        modelsMode === "auto"
+          ? options.modelDiscoveryCache?.snapshot({
+              providerId: row.providerId,
+              account: row.account,
+            })
+          : undefined;
+      // Auto follows the exact account catalog when a successful discovery has
+      // populated the shared cache. A missing/negative snapshot keeps the existing
+      // curated fail-open projection; Manual remains the operator's saved list.
+      models =
+        discovered && discovered.length > 0
+          ? discovered
+          : effectiveAccountModels(accountSettings, row.providerId);
     }
     for (const m of models) {
       const alias = `${row.providerId}/${m}`;

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -160,6 +160,7 @@ import {
   loadGlobalOAuthSettings,
   markAccountCredentialFailure,
   resolveAccountModelsMode,
+  saveAccountDiscoveredModels,
 } from "./oauth/account-settings.js";
 import { createOAuthAdmin } from "./oauth/admin-oauth.js";
 import { runResetCreditAttempt, weeklySaturated } from "./oauth/auto-reset.js";
@@ -962,6 +963,22 @@ export async function synthesizeOAuthProviders(
         const exact = modelDiscoveryCache
           ? await modelDiscoveryCache.load({ providerId, account }, discoverExact)
           : await discoverExact();
+        const accepted = modelDiscoveryCache
+          ? modelDiscoveryCache.snapshot({ providerId, account })
+          : exact;
+        if (
+          accepted &&
+          accepted.length > 0 &&
+          !(await saveAccountDiscoveredModels(
+            config,
+            oauthCtx.encKey,
+            providerId,
+            account,
+            accepted,
+          ))
+        ) {
+          log("warn", "oauth.models.snapshot_write_failed", { providerId, account });
+        }
         discovered = exact.length > 0 ? exact : (CURATED_OAUTH_MODELS[providerId] ?? []);
       }
       // Auto follows the authenticated account catalog. Manual is an explicit
@@ -2997,6 +3014,7 @@ export async function buildServer(
         ? await effectiveOAuthModelOptions(oauthCtx, store.config, ROUTABLE_OAUTH_IDS, {
             codexCatalog: codexModelCatalog,
             codexClientVersion,
+            modelDiscoveryCache: oauthModelDiscoveryCache,
           })
         : [];
       const byAlias = new Map<string, ModelOption>();

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-14 · 通道模型选择器复用自动发现缓存（OAuth subscription / Admin lanes，docs/04/11，原则 1/3/6）
+
+- **生产根因**：账号管理弹窗与运行时 provider pool 已把非 Codex 自动模式的远程模型目录写入同一个账号级进程缓存，但 `/admin/api/models` 的通道选择器投影没有读取该缓存，也没有跨进程保存成功目录；Anthropic/xAI 因而只显示代码内静态 fallback，Copilot 在没有静态 fallback 时甚至不显示任何自动发现模型。
+- **统一投影与存储**：通道目录继续保持 network-free（读取时不发上游请求），Anthropic、Copilot、xAI 自动模式依次使用共享进程缓存、现有加密账号设置中的 durable last-known-good 目录、curated fallback；Admin 刷新与 runtime pool synthesis 只持久化仍被当前 cache generation 接受的非空发现。同名账号重连先失效旧 generation、严格清理旧身份 snapshot，成功后才替换 credential；手动模式仍只使用持久 allowlist，Codex 仍使用独立的持久 ModelInfo catalog，不改变 entitlement 边界，也无需数据库迁移。
+- **失败语义与验证**：空目录或发现错误绝不覆盖 durable last-known-good；缓存和持久快照都不存在时才使用既有 curated fail-open fallback。后台 snapshot 写失败只告警、不阻断路由；但加密设置读取/解密/JSON shape 失败时严格拒绝任何 mutation，不能用空 map 覆盖 proxy、priority、allowlist 等既有状态。TDD 覆盖三种非 Codex provider、进程缓存丢失后的持久恢复、Manual 隔离、旧 credential 并发发现、重连清理顺序、损坏设置防覆盖与写失败 fail-open；定向 5 files / 153 tests 全绿。
+
 ## 2026-07-14 · 丢弃 Codex 空 secondary 配额占位窗口（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）
 
 - **生产根因**：Codex 部分账号的响应头会同时返回真实 `primary + windowMinutes:10080` 周窗口，以及 `secondary + usedPercent:0 + 无 duration + reset-after:0`。后者只是空占位，但 header parser 将其作为配额写入；latest-wins snapshot 随后覆盖完整 PULL 数据，Admin 又把未知时长的 positional key 翻译成“次窗口”，造成看似存在第二个额度且 7 天用量消失。
@@ -77,18 +83,9 @@
 - **精确消息**：具备 Anthropic native `count_tokens` 时，catalog 的廉价输入估算不再提前 context-skip，而是保留其他能力门控并让精确计数裁决；已有 `inputTokens` 与 `exactContextLimit` 时，终态输出 `prompt is too long: <actual> tokens > <limit> maximum`。不具备精确计数的候选用现有估算生成同形消息。Anthropic 非流式响应为 HTTP 400 `invalid_request_error`；流式响应保持 HTTP SSE 语义并发送同类型 terminal error frame。
 - **验证**：执行层覆盖预检链耗尽、上游链耗尽、原始 detail 保留、精确消息优先、混合真实 provider failure，以及溢出后成功 fallback；Messages 路由覆盖非流式 400 与流式 terminal error frame。
 
-## 2026-07-11 · Subscription Provider 自动模型展示使用账号级发现与共享缓存（OAuth subscription / Admin providers，docs/04/11，原则 1/3/6）
-
-- **根因**：Providers 表格读取 `listStatus().account.models`，但非 Codex 自动模式过去直接调用 `effectiveAccountModels()`，把 `CURATED_OAUTH_MODELS` 静态 fallback 当成该账号实时可用模型；因此多个 Claude 账号会重复显示同一组写死模型，和 Manage 弹窗、账号 token 的实际发现结果不一致。
-- **展示边界**：手动模式继续原样显示持久化的 `enabledModels`；自动模式改为使用该账号的刷新后 token、账号代理和 provider discovery。Anthropic/Copilot 取各自 live models，Codex 保留 account identity、entitlement、visibility 与 alias 扩展规则。
-- **请求边界**：非 Codex 手动模式的 allowlist 已是运行时权威值，pool synthesis 不再先调用 `/models` 再覆盖结果；只有自动模式使用 live discovery。Codex 手动模式仍读取账号 catalog 后与 allowlist 取交集，不能绕过订阅 entitlement。
-- **失败语义**：管理投影使用严格发现，网络/凭证/上游失败时返回空列表，不把 curated fallback 冒充账号返回。路由合成继续保留既有 curated fail-open 默认值，本次不扩大为全局路由策略变更；已持久化 credential failure 的账号也不会为页面展示再次刷新。
-- **复用**：`listStatus` 与 Manage 的 `listModels` 共用账号发现 helper，避免两套 token refresh、proxy 和 Codex catalog 逻辑漂移。core discovery 增加可选 `fallbackToCurated:false`，默认值保持现有运行时兼容。
-- **缓存边界**：非 Codex live discovery 使用 Gateway 进程级账号缓存，按 `providerId + account` 隔离；正缓存 5 分钟、失败冷却 1 分钟、最多 128 个账号，并发刷新 singleflight。空结果/异常保留 last-known-good，重新绑定、断开账号或修改代理时精确失效。Admin 与 runtime synthesis 共用同一实例，避免页面读取和 pool rebuild 各请求一次；curated fallback 只在 runtime cache 之外应用，不能污染 Admin 的“账号实际返回”投影。Codex 继续使用其独立的持久 ModelInfo catalog cache。
-- **验证**：TDD 覆盖自动模式实时模型、发现失败不展示静态默认、手动模式保存值与跳过 discovery、Codex entitlement/alias、core fallback 开关，以及缓存 TTL、singleflight、last-known-good、精确失效和 Admin/runtime 共享复用；workspace typecheck/lint/build 全通过，完整 Vitest 为 352 files / 5631 tests 全绿。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-11 · Subscription Provider 自动模型展示使用账号级发现与共享缓存（OAuth subscription / Admin providers，docs/04/11，原则 1/3/6）**：Providers 表格与 Manage 弹窗改用账号实时发现；非 Codex 使用共享进程缓存与 last-known-good，手动 allowlist、Codex entitlement 和运行时 curated fail-open 边界保持不变。
 - **2026-07-11 · Claude Sonnet 5 订阅流量 API 等价成本与能力目录（Provider catalog / cost telemetry，docs/04/07/11，原则 2/5/7）**：默认 Anthropic 订阅路由升级到 Sonnet 5，并按官方介绍期 API 等价费率记录 telemetry；补齐 1M context、128K output、tools/vision/stream/structured outputs/document 与 adaptive-thinking 能力，2026-09-01 需更新标准费率。
 - **2026-07-11 · 退休 GPT-5.3-Codex-Spark 及其订阅配额投影（OAuth subscription / model catalog / Admin providers，docs/04/11，原则 3/5/6/7）**：从 live/bundled/cached catalog 与手工设置过滤退休模型，并从 WHAM/header/durable/Admin quota 投影移除其 model-scoped 限额，保留最小历史识别以阻止旧缓存复活。
 - **2026-07-11 · Portal 请求详情对齐 Admin 查看器但保持供应链边界（Self-Service Portal / Requests，docs/12，原则 1/6/7/8）**：复用 Admin viewer 并按 metadata-first 懒加载请求/响应与图片，同时保持 ownership 和 `upstream_request` 隔离边界。


### PR DESCRIPTION
## Summary
- feed the Lane model picker from the shared account discovery cache instead of hard-coded provider fallbacks
- persist non-Codex Auto catalogs as encrypted last-known-good account snapshots across restarts
- reject stale credential generations and corrupt settings mutations without weakening Manual or Codex entitlement boundaries

## Verification
- CI=true corepack pnpm exec vitest run apps/gateway/src/oauth/effective-models.test.ts apps/gateway/src/oauth/admin-oauth.test.ts apps/gateway/src/oauth/account-settings.test.ts apps/gateway/src/oauth/model-discovery-cache.test.ts apps/gateway/src/server.oauth.test.ts (153 passed)
- CI=true corepack pnpm typecheck
- CI=true corepack pnpm lint
- CI=true corepack pnpm build
- CI=true corepack pnpm --filter @helm/admin check

No database migration required.