### PR TITLE
chore(release): v0.27.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump Helm API from 0.27.1 to 0.27.2
- includes the Auto-discovered provider model catalog persistence fix from PR #548

Version-only release change.