### PR TITLE
fix(i18n): keep tok label untranslated

### DIFF
--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -865,7 +865,7 @@
   "Timeout (ms)": "タイムアウト（ミリ秒）",
   "To": "終了",
   "Today": "今日",
-  "tok": "トークン",
+  "tok": "tok",
   "Token usage": "トークン使用量",
   "Token usage over time": "トークン使用量の推移",
   "Token usage: input / output, with cached input tokens.": "トークン使用量：入力 / 出力、キャッシュされた入力トークンを含む。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -865,7 +865,7 @@
   "Timeout (ms)": "타임아웃 (ms)",
   "To": "종료",
   "Today": "오늘",
-  "tok": "토큰",
+  "tok": "tok",
   "Token usage": "토큰 사용량",
   "Token usage over time": "토큰 사용량 추이",
   "Token usage: input / output, with cached input tokens.": "토큰 사용량: 입력 / 출력, 캐시된 입력 토큰 포함.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -865,7 +865,7 @@
   "Timeout (ms)": "超时（毫秒）",
   "To": "结束",
   "Today": "今天",
-  "tok": "词元",
+  "tok": "tok",
   "Token usage": "Token 用量",
   "Token usage over time": "Token 用量趋势",
   "Token usage: input / output, with cached input tokens.": "Token 用量：输入 / 输出，含缓存的输入 Token。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -865,7 +865,7 @@
   "Timeout (ms)": "逾時（毫秒）",
   "To": "結束",
   "Today": "今天",
-  "tok": "詞元",
+  "tok": "tok",
   "Token usage": "權杖用量",
   "Token usage over time": "權杖用量趨勢",
   "Token usage: input / output, with cached input tokens.": "權杖用量：輸入 / 輸出，含快取的輸入權杖。",

--- a/apps/portal/src/locales/ja.json
+++ b/apps/portal/src/locales/ja.json
@@ -889,7 +889,7 @@
   "Timeout (ms)": "タイムアウト（ミリ秒）",
   "To": "終了",
   "Today": "今日",
-  "tok": "トークン",
+  "tok": "tok",
   "Token budget": "トークン予算",
   "Token usage": "トークン使用量",
   "Token usage over time": "トークン使用量の推移",

--- a/apps/portal/src/locales/ko.json
+++ b/apps/portal/src/locales/ko.json
@@ -889,7 +889,7 @@
   "Timeout (ms)": "타임아웃 (ms)",
   "To": "종료",
   "Today": "오늘",
-  "tok": "토큰",
+  "tok": "tok",
   "Token budget": "토큰 예산",
   "Token usage": "토큰 사용량",
   "Token usage over time": "토큰 사용량 추이",

--- a/apps/portal/src/locales/zh-hans.json
+++ b/apps/portal/src/locales/zh-hans.json
@@ -889,7 +889,7 @@
   "Timeout (ms)": "超时（毫秒）",
   "To": "结束",
   "Today": "今天",
-  "tok": "词元",
+  "tok": "tok",
   "Token budget": "Token 预算",
   "Token usage": "Token 用量",
   "Token usage over time": "Token 用量趋势",

--- a/apps/portal/src/locales/zh-hant.json
+++ b/apps/portal/src/locales/zh-hant.json
@@ -889,7 +889,7 @@
   "Timeout (ms)": "逾時（毫秒）",
   "To": "結束",
   "Today": "今天",
-  "tok": "詞元",
+  "tok": "tok",
   "Token budget": "Token 預算",
   "Token usage": "權杖用量",
   "Token usage over time": "權杖用量趨勢",


### PR DESCRIPTION
## Summary
- render the `tok` abbreviation literally in every Admin locale
- render the `tok` abbreviation literally in every Portal locale
- remove translated variants such as 词元, 詞元, トークン, and 토큰 for this abbreviation only

## Verification
- all 14 locale JSON files parse successfully
- every locale maps the `tok` key to the literal `tok`
- CI=true corepack pnpm lint
- CI=true Admin and Portal svelte-check