### PR TITLE
fix(routing): 精确模型名优先于兼容通配别名

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ CORE      packages/core · the routing brain (imports no web framework)
              ├─ gate        rate limit (off) · usage budget (off)        · fail-closed
              ├─ memory      inject remembered context (on by default)    · fail-open
              ├─ classify    L1 rules ─uncertain→ L2 eval (off) ─→ balanced · fail-open
-             ├─ resolve     alias shim · explicit model · first-match policy
+             ├─ resolve     exact lane/model · alias shim · first-match policy
              │                  └─▶ lane → caps (+ signals) → fallback chain
              ├─ execute     capability filter → circuit breaker → provider
              │                  └── on failure: advance to next model in the chain

--- a/config/model-aliases.yaml
+++ b/config/model-aliases.yaml
@@ -13,10 +13,12 @@
 # routes EVERYTHING through classification (auto) — the model field is ignored, never
 # a 400. A key's `allowed_lanes` whitelist still clamps the rewritten lane.
 #
-# MATCHING: an exact key wins; otherwise the matching `*`-glob with the most
-# literal characters wins (so `claude-opus-*` beats `claude-*` regardless of
-# order). `*` = any run of chars (incl. empty) — it absorbs the date suffix Claude
-# Code appends (`claude-opus-4-8-20260115`). Case-sensitive.
+# MATCHING: routeRequest first honors an exact configured lane or deployment-known
+# model. Only then does this compatibility map apply: an exact map key wins;
+# otherwise the matching `*`-glob with the most literal characters wins (so
+# `claude-opus-*` beats `claude-*` regardless of order). `*` = any run of chars
+# (incl. empty) — it absorbs the date suffix Claude Code appends
+# (`claude-opus-4-8-20260115`). Case-sensitive.
 #
 # FAIL-CLOSED (principle 2): every target must be a configured lane or "auto", or
 # the gateway refuses to boot. This file is OPTIONAL — delete it for no rewrite.
@@ -40,15 +42,14 @@
 "claude-*": balanced # catch-all for any other / future Claude id
 
 # ── OpenAI-compatible clients (Codex, Cursor, …) ─────────────────────────────
-# Bare GPT ids → lanes (config/lanes.yaml). Each named family maps to its DEDICATED
-# vendor-family lane so the request LEADS with that family's real model; the `-*`
-# globs absorb any dated/suffixed id. GPT-5.6's unsuffixed alias is defined by Codex
-# as Sol, so it maps directly to the Sol lane instead of passing through the generic
-# requested-model promotion step. The cheap `gpt-5.4-mini` needs its OWN mapping
+# Bare GPT ids → lanes (config/lanes.yaml). Exact bare names that are configured
+# lanes remain authoritative; the `-*` globs handle dated/suffixed vendor ids.
+# GPT-5.6's exact lane leads with Sol, while `openai.gpt-5.6` maps to the Sol-specific
+# compatibility lane. The cheap `gpt-5.4-mini` needs its OWN mapping
 # (it is more literal than `gpt-5*`, so longest-literal-wins routes it to the cheap
 # lane, NOT the expensive `premium` catch-all). Comment these out if you don't front
 # any GPT clients.
-"gpt-5.6": gpt-5.6-sol
+"gpt-5.6": gpt-5.6
 "gpt-5.6-sol": gpt-5.6-sol
 "gpt-5.6-sol-*": gpt-5.6-sol
 "gpt-5.6-terra": gpt-5.6-terra

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -10,8 +10,10 @@ its ordered chain. The framework-agnostic orchestrator is `routeRequest`
 
 ```text
 image-output model             # exact image model → image lane, any key; suppressed while over-budget degrading
-model-alias shim               # fixed vendor id → lane / `auto`; cap-bounded; allow_custom_model keys only
-  > explicit model/lane        # concrete model/lane; skips classify + policy; allow_custom_model keys only
+  > exact lane name            # configured lane; full fallback chain; allow_custom_model keys only
+  > exact known model          # deployment-known model; single candidate; allow_custom_model keys only
+  > exact model-alias entry    # fixed vendor id → lane / `auto`; cap-bounded; allow_custom_model keys only
+  > model-alias wildcard       # most-specific matching glob; last-resort compatibility rewrite
   > classifier short-circuit   # decided_by 'default' | 'fallback' → straight to the default fallback lane (classified branch only)
   > server-side policy         # a policy pin (use_lane)
   > task-specific lane         # a lane named after the detected task_type
@@ -24,10 +26,10 @@ The **model-alias compatibility shim** and explicit model/lane passthrough are
 both **gated on `allow_custom_model`** (and suppressed while over-budget
 degrading). A key **without** `allow_custom_model` skips both — its `model` field
 is ignored and **every** request is classified (the `auto` path). For a
-custom-model key the shim runs first (priority 0; see
-[Model-alias compatibility shim](#model-alias-compatibility-shim) below), then
-explicit passthrough — a request naming a concrete model or lane skips
-classification and policy entirely and is executed directly.
+custom-model key, an exact configured lane or deployment-known model is
+authoritative and skips classification/policy. Only otherwise does the shim try
+an exact map entry and then the most-specific wildcard. This prevents a broad
+rule such as `claude-*` from capturing the exact `claude-opus` lane.
 
 Image-output models are the exception to the custom-model gate on the Gemini
 `generateContent` route: when the requested model is known to produce images,
@@ -68,10 +70,10 @@ and it never escapes policy/key caps.
 
 ### Model-alias compatibility shim
 
-For an `allow_custom_model` key, `plan()` runs a **priority-0** model-alias
-resolution step (route-request.ts steps 0 / 0a) ahead of explicit passthrough.
-Clients that pin a **fixed vendor model id** — Claude Code's `claude-opus-4-8`,
-or an SDK locked to `gpt-5.5` — know neither Helm's lanes nor its provider
+For an `allow_custom_model` key, `plan()` runs model-alias compatibility only
+after checking exact configured lanes and deployment-known models. Clients that
+pin a **fixed vendor model id** — Claude Code's `claude-opus-4-8`,
+or an SDK locked to `openai.gpt-5.6` — know neither Helm's lanes nor its provider
 aliases, so left alone they would get a `400 unknown model`. The shim rewrites
 that inbound `model` field onto a lane (or the `auto` sentinel) **before**
 routing, so a fixed-model client routes cleanly while Helm still only exposes the
@@ -80,12 +82,12 @@ key **without** `allow_custom_model` does not use the shim at all: its `model`
 field is ignored and the request is classified like `auto` (still no `400`).
 
 The map is [`config/model-aliases.yaml`](../config/model-aliases.yaml): a flat
-table of vendor model id → a lane name or `auto`. Keys are glob-matchable and
-**case-sensitive** — an exact key wins, otherwise the matching `*`-glob with the
-most literal characters wins (so `claude-opus-*` beats `claude-*` regardless of
-order; `*` absorbs any date/suffix). Targets are boot-validated to a configured
-lane or `auto` (fail-closed, principle 2); the file is optional — delete it for
-no rewrite.
+table of vendor model id → a lane name or `auto`. After exact configured names
+have had priority, map keys are **case-sensitive**: an exact map key wins;
+otherwise the matching `*`-glob with the most literal characters wins (so
+`claude-opus-*` beats `claude-*` regardless of order; `*` absorbs any
+date/suffix). Targets are boot-validated to a configured lane or `auto`
+(fail-closed, principle 2); the file is optional — delete it for no rewrite.
 
 The shim is **operator-authorized** (the operator owns the mapping) but is
 **gated on `allow_custom_model`** — honoring a pinned vendor id is a custom-model
@@ -96,8 +98,8 @@ capability:
    field, even a known vendor id, is **ignored** (never a 400) and the alias map
    is not consulted (see "Explicit client model" below — one rule covers explicit
    models, lanes, and alias-mapped ids).
-2. It runs **before** explicit-passthrough resolution (so a known vendor id maps
-   to a lane instead of 400ing as an unknown model), but it is **cap-bounded**,
+2. It runs only after exact lane/model resolution. An unknown fixed vendor id can
+   still map to a lane instead of 400ing, but the mapped lane is **cap-bounded**,
    not a bypass. Policy `allowed_lanes` and the key's own `allowed_lanes`
    whitelist both still clamp the resolved lane. The clamp is
    **silent** (the same `applyCaps` path classified routing uses), **not** the
@@ -132,7 +134,10 @@ For an `allow_custom_model` key the `model` field resolves in this order:
    registry ∪ live curated OAuth aliases ∪ `provider/`-prefixed aliases whose
    client is registered); an unknown name is rejected with `invalid_request`
    (400) instead of silently falling through to the default provider.
-3. Over-budget `degrade` (docs/06) suppresses BOTH forms of explicit passthrough
+3. **Compatibility map**: when neither exact form exists, an exact
+   `model-aliases.yaml` key is tried first, then the most-specific wildcard.
+   A mapped lane remains policy/key-cap bounded.
+4. Over-budget `degrade` (docs/06) suppresses all explicit and compatibility forms
    — the request is forced onto the degrade lane.
 
 Keys **without** `allow_custom_model` never let the `model` field steer the lane
@@ -255,22 +260,23 @@ quality/cost lanes by complexity (`simple → economy`, `medium → balanced`,
 
 ### Vendor-family lanes
 
-Beyond the 7 generic lanes above, `config/lanes.yaml` ships **9 vendor-family
+Beyond the 7 generic lanes above, `config/lanes.yaml` ships **13 vendor-family
 lanes** — the rewrite targets of the [model-alias compatibility
 shim](#model-alias-compatibility-shim):
 
 ```text
 claude-opus   claude-fable   claude-sonnet   claude-haiku
+gpt-5.6       gpt-5.6-sol    gpt-5.6-terra   gpt-5.6-luna
 gpt-5.5       gpt-5.4        gpt-5.4-mini
 gemini-pro    gemini-flash
 ```
 
-(18 lanes total when the two image-generation lanes below are included.) These
+(22 lanes total when the two image-generation lanes below are included.) These
 exist so a client that pins a fixed vendor id lands on that family's real model
 instead of the GPT-led `premium` lane. Each one
 **leads with the requested vendor's native/subscription alias** — the Claude
 lanes with the `anthropic/*` Claude OAuth pool, the GPT lanes with the
-`openai-codex/*` subscription, the Gemini lanes with the static `zenmux/*` key —
+`openai-codex/*` subscription, the Gemini lanes with native `zenmux-vertex/*` aliases —
 then **degrades into a generic quality lane** (e.g. `claude-opus → premium`,
 `gpt-5.4-mini → economy`). An unconnected subscription alias **fails OPEN** (skip
 to the next fallback), never a 5xx, so an unbound subscription just serves the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,19 +247,25 @@ results, so a transient upstream failure can't be amplified into a 300s outage.
 ## 7. Routing & lane resolution
 
 How a request becomes an ordered chain of concrete model aliases. See
-[04 Routing & Lanes](04-routing-and-lanes.md). The shipped config has **18 lanes**:
+[04 Routing & Lanes](04-routing-and-lanes.md). The shipped config has **22 lanes**:
 3 quality lanes (`economy`/`balanced`/`premium`), 4 task lanes
-(`coding`/`json`/`vision`/`tool_use`), 9 vendor-family lanes that are the
+(`coding`/`json`/`vision`/`tool_use`), 13 vendor-family lanes that are the
 rewrite targets of the model-alias compatibility shim, and 2 image-generation
 lanes (`gpt-image`, `gemini-image`).
 
 ```mermaid
 flowchart TD
-    A["IR.requested_model"] --> B{"model-alias map hit?<br/>(config/model-aliases.yaml)"}
-    B -- "yes → lane" --> C["rewrite to lane · cap-bounded (silent clamp)"]
-    B -- "yes → auto / no hit" --> D{"explicit passthrough?<br/>allow_custom_model · model ≠ auto · not over-budget"}
-    D -- "yes" --> P["use exact model / lane<br/>(HARD reject if outside key caps)"]
+    A["IR.requested_model"] --> I{"exact image-output model?"}
+    I -- "yes" --> IMG["pin exact image model"]
+    I -- "no" --> D{"explicit resolution eligible?<br/>allow_custom_model · model ≠ auto · not over-budget"}
     D -- "no" --> CL["classify (Layer 1/2)"]
+    D -- "yes" --> E{"exact configured lane<br/>or deployment-known model?"}
+    E -- "yes" --> P["use exact lane / model<br/>(HARD reject if outside key caps)"]
+    E -- "no" --> B{"compatibility map hit?<br/>exact key, then most-specific glob"}
+    B -- "lane" --> C["rewrite to lane · cap-bounded (silent clamp)"]
+    B -- "auto" --> CL
+    B -- "no" --> U["strict unknown-model reject<br/>(legacy headless: unchecked model)"]
+    IMG --> CH
     C --> EXP["expandLaneChain"]
     P --> EXP
     CL --> POL["policy engine:<br/>first-match PIN (use_lane)<br/>+ caps accumulate across ALL matches"]
@@ -273,9 +279,9 @@ flowchart TD
     CH --> EX["→ Executor"]
 ```
 
-Key subtleties the diagram encodes: the model-alias shim runs **before** the
-custom-model gate and needs no special permission (it's operator-authored, still
-clamped by the key's `allowed_lanes`); only the lane *pin* is first-match while
+Key subtleties the diagram encodes: exact configured lane/model names are checked
+before compatibility mappings, and both forms require `allow_custom_model`;
+mapped lanes remain clamped by policy/key `allowed_lanes`. Only the lane *pin* is first-match while
 *caps* accumulate across every matching policy; and Agentic Signals can only ever
 **upgrade** a degraded lane, never demote.
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-14 · 确定模型名优先于兼容通配别名（Routing / model alias precedence，docs/04，原则 2/5/6）
+
+- **生产根因**：请求 `6becfc0f-9ce7-43c6-b604-322972f5aa59` 明确指定已配置 lane `claude-opus`，但兼容映射先执行；`claude-opus-*` 因字面连字符不匹配裸名，宽泛 `claude-*` 把请求改写到 `balanced`，最终首候选 `openai-codex/gpt-5.6-terra` 成功。telemetry 的分类 `passthrough` 仅表示跳过分类器；该次原生协议直通实际因 `anthropic_messages -> openai_responses` 不匹配而关闭。
+- **统一优先级**：`allow_custom_model` 且未触发 budget degrade 时，先识别精确配置 lane，再识别部署已知的精确 model alias；只有两者都不存在时才进入 `model-aliases.yaml`，并继续保持“精确映射键优先、最长字面量 glob 次之”。因此所有当前及未来 lane 都不会再被 `claude-*` / `gpt-*` / `gemini-*` 吞掉；固定 vendor id（如 `claude-opus-4-8`）仍通过兼容映射进入族 lane。
+- **行为边界与验证**：精确 lane 恢复 docs/04 既定的完整 fallback 与 `allowed_lanes` 显式 400 语义，精确 model 保持单候选；标准 key、`auto`、blocked models、image pre-pin、budget degrade、alias cap 与 headless legacy 均不变。`gpt-5.6` 的 telemetry lane 从兼容目标 `gpt-5.6-sol` 恢复为精确 `gpt-5.6`，首个实际模型仍为 Sol。路由单测覆盖 Claude/GPT/Gemini 全部碰撞族及精确 model，shipped-config 组合测试遍历全部 lane 防止未来回归；无需 schema 或配置迁移。
+
 ## 2026-07-14 · 通道模型选择器复用自动发现缓存（OAuth subscription / Admin lanes，docs/04/11，原则 1/3/6）
 
 - **生产根因**：账号管理弹窗与运行时 provider pool 已把非 Codex 自动模式的远程模型目录写入同一个账号级进程缓存，但 `/admin/api/models` 的通道选择器投影没有读取该缓存，也没有跨进程保存成功目录；Anthropic/xAI 因而只显示代码内静态 fallback，Copilot 在没有静态 fallback 时甚至不显示任何自动发现模型。
@@ -75,16 +81,9 @@
 
 - **后续能力与成本更新**：上方初始实现中“vision 未验证 / `cost_usd=null`”的边界已被真实协议证据替代。Grok 4.5 原生 `input_image` 已通过四种入口验证并启用 vision；Composer 对同一 wire 返回 400，CLI 表面的看图来自 `grok-build` 先生成文字描述，因此继续关闭。按用户决定，Grok 4.5 使用公开 API 等价费率 input `$2/M`、cache read `$0.50/M`、output `$6/M` 参与 telemetry 与 API-key budget；这不是订阅账单，且当前固定 catalog 对 >200K 的 `$4/$1/$12` 档位会低估 50%。Composer 没有可验证公开费率，继续保持 `cost_usd=null`。
 
-## 2026-07-11 · 上下文链耗尽恢复 Claude CLI 自动压缩信号（Provider execution / protocol errors，docs/04/05/07，原则 3/5/7/8）
-
-- **生产证据**：请求 `204c4380-b573-4556-a8c5-7be2772c2241` 的 Anthropic Messages body 为 11,152,406 bytes；所有可用候选均为 `context_too_small`，但执行层最终返回 `all_providers_failed / 502 api_error`。Claude CLI `2.1.201` 因收不到 `invalid_request_error` 和可识别的 token 上限消息，没有触发 reactive compaction。
-- **根因**：候选级上下文溢出改为继续 fallback 后，链耗尽聚合仍以 `attemptedAny` 判断 provider 故障；上游溢出曾经实际 invoke，因此被误归类为 `all_providers_failed`。精确 `count_tokens` 预检则被误归类为普通 `capability_unsatisfiable / 422`，且丢失实际 token 与上限。
-- **修复语义**：单个候选溢出继续作为 `context_too_small` skip，不计 breaker failure，也不阻止更大上下文模型成功；执行层保留首个上游 detail/provider_raw，并优先选择符合 Claude CLI matcher 的精确消息。只有整条链最终仅由上下文/能力 skip 构成时，才返回 `invalid_request / 400`；若还出现 5xx、429、circuit open 或 provider unavailable，仍保留原有失败分类。
-- **精确消息**：具备 Anthropic native `count_tokens` 时，catalog 的廉价输入估算不再提前 context-skip，而是保留其他能力门控并让精确计数裁决；已有 `inputTokens` 与 `exactContextLimit` 时，终态输出 `prompt is too long: <actual> tokens > <limit> maximum`。不具备精确计数的候选用现有估算生成同形消息。Anthropic 非流式响应为 HTTP 400 `invalid_request_error`；流式响应保持 HTTP SSE 语义并发送同类型 terminal error frame。
-- **验证**：执行层覆盖预检链耗尽、上游链耗尽、原始 detail 保留、精确消息优先、混合真实 provider failure，以及溢出后成功 fallback；Messages 路由覆盖非流式 400 与流式 terminal error frame。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-11 · 上下文链耗尽恢复 Claude CLI 自动压缩信号（Provider execution / protocol errors，docs/04/05/07，原则 3/5/7/8）**：候选级 context overflow 继续 fail-open fallback；仅上下文/能力 skip 的整链耗尽统一返回 Claude CLI 可识别的 `invalid_request / 400` 与精确 token 上限消息，混合真实 provider failure 保留原分类。
 - **2026-07-11 · Subscription Provider 自动模型展示使用账号级发现与共享缓存（OAuth subscription / Admin providers，docs/04/11，原则 1/3/6）**：Providers 表格与 Manage 弹窗改用账号实时发现；非 Codex 使用共享进程缓存与 last-known-good，手动 allowlist、Codex entitlement 和运行时 curated fail-open 边界保持不变。
 - **2026-07-11 · Claude Sonnet 5 订阅流量 API 等价成本与能力目录（Provider catalog / cost telemetry，docs/04/07/11，原则 2/5/7）**：默认 Anthropic 订阅路由升级到 Sonnet 5，并按官方介绍期 API 等价费率记录 telemetry；补齐 1M context、128K output、tools/vision/stream/structured outputs/document 与 adaptive-thinking 能力，2026-09-01 需更新标准费率。
 - **2026-07-11 · 退休 GPT-5.3-Codex-Spark 及其订阅配额投影（OAuth subscription / model catalog / Admin providers，docs/04/11，原则 3/5/6/7）**：从 live/bundled/cached catalog 与手工设置过滤退休模型，并从 WHAM/header/durable/Admin quota 投影移除其 model-scoped 限额，保留最小历史识别以阻止旧缓存复活。

--- a/packages/core/src/config/rules-routing.test.ts
+++ b/packages/core/src/config/rules-routing.test.ts
@@ -123,7 +123,7 @@ describe("shipped config rules drive routing", () => {
     expect(lane).toBe("json");
   });
 
-  it("routes the Codex gpt-5.6 alias directly to the subscription Sol lane", async () => {
+  it("keeps the exact gpt-5.6 lane while leading with the subscription Sol model", async () => {
     const config = loadConfig({ configDir, env: {} });
     if (config.lanes === undefined) throw new Error("config.lanes must be loaded from lanes.yaml");
 
@@ -141,10 +141,35 @@ describe("shipped config rules drive routing", () => {
       { allowCustomModel: true },
     );
 
-    expect(result.decision.lane.selected_lane).toBe("gpt-5.6-sol");
+    expect(result.decision.lane.selected_lane).toBe("gpt-5.6");
     expect(result.decision.lane.candidate_chain[0]).toBe("openai-codex/gpt-5.6-sol");
     expect(result.decision.lane.candidate_chain).not.toContain("openai/gpt-5.6");
     expect(result.decision.requested_model).toBe("gpt-5.6");
+  });
+
+  it("keeps every exact shipped lane ahead of compatibility aliases and wildcards", async () => {
+    const config = loadConfig({ configDir, env: {} });
+    if (config.lanes === undefined) throw new Error("config.lanes must be loaded from lanes.yaml");
+
+    for (const lane of Object.keys(config.lanes)) {
+      const result = await routeRequest(
+        req({ requested_model: lane }),
+        {
+          classify: async () => classification(),
+          policies: config.policies,
+          lanes: config.lanes,
+          modelAliases: config.model_aliases,
+          execute: async (plan) => okExecute(plan),
+          now: () => new Date(0),
+          log: () => {},
+        },
+        { allowCustomModel: true },
+      );
+
+      expect(result.decision.lane.selected_lane, lane).toBe(lane);
+      expect(result.decision.policy.reason, lane).toBe("explicit lane passthrough");
+      expect(result.decision.lane.candidate_chain.length, lane).toBeGreaterThan(0);
+    }
   });
 
   it("expands the shipped premium chain with Grok before Claude Opus", async () => {

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -120,7 +120,7 @@ describe("checked-in config samples", () => {
     // GPT families route to their dedicated vendor-family lanes. The cheap mini must
     // NOT be swallowed by the broad `gpt-5*` -> premium catch-all (longest-literal
     // wins): a dated mini id still lands on the cheap gpt-5.4-mini lane.
-    expect(resolveModelAlias("gpt-5.6", aliases)).toBe("gpt-5.6-sol");
+    expect(resolveModelAlias("gpt-5.6", aliases)).toBe("gpt-5.6");
     expect(resolveModelAlias("gpt-5.6-sol", aliases)).toBe("gpt-5.6-sol");
     expect(resolveModelAlias("gpt-5.6-sol-20260710", aliases)).toBe("gpt-5.6-sol");
     expect(resolveModelAlias("gpt-5.6-terra", aliases)).toBe("gpt-5.6-terra");

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -917,9 +917,78 @@ describe("routeRequest — per-key blocked models", () => {
 });
 
 // Virtual model-alias map (docs/04): a vendor model id (e.g. Claude Code's
-// "claude-opus-4-8") is rewritten onto a lane / "auto" BEFORE the passthrough
-// gate, so a fixed-model client routes without a 400 even on a default key.
+// "claude-opus-4-8") is rewritten onto a lane / "auto" only after exact configured
+// lane/model names have had priority, so broad globs cannot swallow authoritative names.
 describe("routeRequest — virtual model aliases", () => {
+  it.each([
+    ["claude-opus", "opus_model"],
+    ["claude-fable", "fable_model"],
+    ["claude-sonnet", "sonnet_model"],
+    ["claude-haiku", "haiku_model"],
+    ["gpt-5.6", "gpt_5_6_model"],
+    ["gpt-5.6-sol", "sol_model"],
+    ["gpt-5.6-terra", "terra_model"],
+    ["gpt-5.6-luna", "luna_model"],
+    ["gpt-5.5", "gpt_5_5_model"],
+    ["gpt-5.4", "gpt_5_4_model"],
+    ["gpt-5.4-mini", "mini_model"],
+    ["gpt-image", "image_model"],
+    ["gemini-image", "gemini_image_model"],
+    ["gemini-pro", "gemini_pro_model"],
+    ["gemini-flash", "gemini_flash_model"],
+  ])("exact configured lane %s wins before exact and wildcard compatibility aliases", async (lane, primary) => {
+    const laneConfig = {
+      ...LANES,
+      [lane]: { primary, fallback: [], constraints: {} },
+    } as unknown as LanesConfig;
+    const familyGlob = lane.startsWith("claude-")
+      ? "claude-*"
+      : lane.startsWith("gemini-")
+        ? "gemini-*"
+        : "gpt-*";
+    const d = deps({
+      lanes: laneConfig,
+      modelAliases: {
+        [lane]: "balanced",
+        [familyGlob]: "balanced",
+      },
+    });
+
+    const result = await routeRequest(req({ requested_model: lane }), d, {
+      allowCustomModel: true,
+    });
+
+    expect(result.final.status).toBe("ok");
+    expect(d.classify).not.toHaveBeenCalled();
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe(lane);
+    expect(plan.explicit_model).toBeNull();
+    expect(plan.candidate_chain).toEqual([primary]);
+    const rec = (d.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.policy.reason).toBe("explicit lane passthrough");
+  });
+
+  it("an exact known model wins before exact and wildcard compatibility aliases", async () => {
+    const model = "claude-opus-live";
+    const d = deps({
+      isKnownModel: (candidate) => candidate === model,
+      modelAliases: { [model]: "balanced", "claude-*": "balanced" },
+    });
+
+    const result = await routeRequest(req({ requested_model: model }), d, {
+      allowCustomModel: true,
+    });
+
+    expect(result.final.status).toBe("ok");
+    expect(d.classify).not.toHaveBeenCalled();
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan.selected_lane).toBe(model);
+    expect(plan.explicit_model).toBe(model);
+    expect(plan.candidate_chain).toEqual([model]);
+    const rec = (d.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(rec.policy.reason).toBe("explicit model passthrough");
+  });
+
   it("a DEFAULT key (no allow_custom_model) IGNORES a matching alias and routes via auto", async () => {
     // Honoring a pinned vendor id is a CUSTOM-MODEL capability. A key without
     // allow_custom_model routes EVERYTHING through classification — the alias map is

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -20,7 +20,7 @@ import { promoteRequestedModel } from "./promote-requested-model.js";
 // routeRequest — the SINGLE, framework-agnostic orchestrator for one request
 // (CLAUDE.md principle 1: NO web framework import here — Hono/SSE adaptation
 // lives only in apps/gateway). It wires the pipeline of docs/02:
-//   explicit-passthrough? → classify → policy → lane-resolver(+caps) → chain
+//   exact lane/model? → compatibility alias? → classify → policy → lane-resolver(+caps) → chain
 //   expansion → execute(capability filter + circuit breaker + fallback) →
 //   DecisionRecord → log.
 //
@@ -199,11 +199,11 @@ export interface RouteDeps {
    *  from the catalog; absent (headless core / tests) → no image pinning. */
   isImageModel?: (model: string) => boolean;
   /** Operator-configured virtual model-name map (docs/04 compatibility shim).
-   *  Rewrites an inbound VENDOR model id (e.g. Claude Code's "claude-opus-4-8",
-   *  which is neither a lane nor an internal alias) onto a LANE name or "auto"
-   *  BEFORE the allow_custom_model gate — so a fixed-model client routes without a
-   *  400 even on a default key. Targets are validated at boot (the gateway calls
-   *  validateModelAliasTargets) to be a known lane or "auto", fail-closed. Absent
+   *  After exact configured lanes and deployment-known models have had priority,
+   *  rewrites an inbound VENDOR model id (e.g. Claude Code's "claude-opus-4-8")
+   *  onto a LANE name or "auto" for an allow_custom_model key. Targets are validated
+   *  at boot (the gateway calls validateModelAliasTargets) to be a known lane or
+   *  "auto", fail-closed. Absent
    *  (headless core / tests) → no rewrite. See model-alias.resolveModelAlias for
    *  the exact/glob match order. */
   modelAliases?: ModelAliasMap;
@@ -580,6 +580,65 @@ function noPermittedModelsRejection(args: {
   };
 }
 
+function isExplicitRequestEligible(req: InternalRequest, opts: RouteOptions): boolean {
+  return (
+    opts.allowCustomModel === true &&
+    req.requested_model.length > 0 &&
+    req.requested_model !== "auto" &&
+    (opts.keyCaps?.degradeLane === undefined || opts.keyCaps.degradeLane === null)
+  );
+}
+
+function explicitLaneDecision(
+  req: InternalRequest,
+  deps: RouteDeps,
+  opts: RouteOptions,
+): PlanDecision | PlanRejection {
+  const lane = req.requested_model;
+  const allowed = opts.keyCaps?.allowedLanes;
+  if (allowed != null && allowed.length > 0 && !allowed.includes(lane)) {
+    return {
+      reject: makeHelmError({
+        error_class: "invalid_request",
+        message: `lane "${lane}" is not permitted for this key (allowed_lanes)`,
+        trace_id: req.request_id,
+      }),
+      selectedLane: lane,
+    };
+  }
+
+  const policy = { matched_policy_id: null, reason: "explicit lane passthrough" };
+  const chain = filterBlockedModels(expandChain(lane, deps.lanes), opts);
+  if (chain.length === 0) {
+    return noPermittedModelsRejection({
+      req,
+      selectedLane: lane,
+      classifier: passthroughClassifier(),
+      policy,
+      forcedReasoningEffort: null,
+      evalUsd: null,
+    });
+  }
+
+  return {
+    plan: { selected_lane: lane, candidate_chain: chain, explicit_model: null },
+    classifier: passthroughClassifier(),
+    policy,
+    forcedReasoningEffort: null,
+    evalUsd: null,
+  };
+}
+
+function explicitModelDecision(model: string): PlanDecision {
+  return {
+    plan: { selected_lane: model, candidate_chain: [model], explicit_model: model },
+    classifier: passthroughClassifier(),
+    policy: { matched_policy_id: null, reason: "explicit model passthrough" },
+    forcedReasoningEffort: null,
+    evalUsd: null,
+  };
+}
+
 // Compute the execution plan + the classifier/policy decision segments. Explicit
 // passthrough short-circuits classify/policy/resolver entirely (docs/04: highest
 // priority, gated by allow_custom_model).
@@ -631,14 +690,28 @@ async function plan(
     };
   }
 
-  // 0) Virtual model-alias resolution (docs/04 compatibility shim). An operator
-  //    map rewrites an inbound vendor model id (e.g. Claude Code's "claude-opus-4-8")
-  //    onto a LANE name or the "auto" sentinel so a fixed-model client routes
-  //    without a 400. Boot-validated to a lane or "auto".
+  // 0a) Exact configured names are authoritative. A concrete lane or deployment-known
+  //     model must never be swallowed by a broad compatibility glob such as
+  //     `claude-*` or `gpt-*`. Exact lanes keep their full fallback semantics and
+  //     loud allowed_lanes rejection; exact models remain single-candidate passthrough.
+  //     Both are suppressed while over-budget degrading, just like before.
+  const explicitEligible = isExplicitRequestEligible(req, opts);
+  if (explicitEligible && hasLane(deps.lanes, req.requested_model)) {
+    return explicitLaneDecision(req, deps, opts);
+  }
+  const exactModelKnown = explicitEligible ? deps.isKnownModel?.(req.requested_model) : undefined;
+  if (exactModelKnown === true) {
+    return explicitModelDecision(req.requested_model);
+  }
+
+  // 0b) Virtual model-alias resolution (docs/04 compatibility shim). Only after
+  //     exact lanes/models have had priority, an operator map rewrites an inbound
+  //     vendor model id (e.g. Claude Code's "claude-opus-4-8") onto a LANE name
+  //     or the "auto" sentinel. Boot-validated to a lane or "auto".
   const aliasTarget = resolveModelAlias(req.requested_model, deps.modelAliases);
   const aliasToAuto = aliasTarget === "auto";
 
-  // 0a) Alias -> LANE: a CAP-BOUNDED lane selection, GATED on allow_custom_model.
+  // 0c) Alias -> LANE: a CAP-BOUNDED lane selection, GATED on allow_custom_model.
   //     Honoring a pinned vendor id is a custom-model capability: a key WITHOUT
   //     allow_custom_model routes EVERYTHING through classification (auto) — its
   //     model field, even a known vendor id, is ignored (it falls through to Step 2;
@@ -702,9 +775,10 @@ async function plan(
     };
   }
 
-  // 1) Explicit passthrough — bypass the whole routing brain. The model field
-  //    may name a concrete MODEL (chain = [model]) or a LANE (chain = the lane's
-  //    expanded fallback chain, docs/04 "explicit model/lane").
+  // 1) Legacy/unchecked explicit MODEL passthrough. Exact lanes and deployment-known
+  //    models already returned before alias resolution. This remaining branch either
+  //    rejects a deployment-unknown model or preserves headless callers that do not
+  //    provide isKnownModel.
   //    `auto` is the canonical "let the router decide" sentinel and must NEVER be
   //    treated as an explicit model, even for an allow_custom_model key — otherwise
   //    it short-circuits classify/lane-resolve and gets sent upstream as the literal
@@ -716,62 +790,11 @@ async function plan(
   //    downgrade by naming an expensive explicit model OR lane — so suppress
   //    passthrough while degrading and fall through to the forced degrade lane
   //    below (docs/06).
-  if (
-    opts.allowCustomModel === true &&
-    !aliasToAuto &&
-    req.requested_model.length > 0 &&
-    req.requested_model !== "auto" &&
-    (opts.keyCaps?.degradeLane === undefined || opts.keyCaps.degradeLane === null)
-  ) {
+  if (explicitEligible && !aliasToAuto) {
     const model = req.requested_model;
-
-    // 1a) Explicit LANE — lanes shadow same-named model aliases. The lane runs
-    //     with full fallback semantics (expandChain), but must sit inside the
-    //     key's allowed_lanes whitelist: unlike classified routing (where
-    //     applyCaps silently clamps), an EXPLICIT ask for a forbidden lane is a
-    //     client error and is rejected loudly (no silent downgrade). An empty
-    //     allowedLanes array is inactive, mirroring applyCaps' activation rule.
-    if (Object.hasOwn(deps.lanes, model)) {
-      const allowed = opts.keyCaps?.allowedLanes;
-      if (allowed != null && allowed.length > 0 && !allowed.includes(model)) {
-        return {
-          reject: makeHelmError({
-            error_class: "invalid_request",
-            message: `lane "${model}" is not permitted for this key (allowed_lanes)`,
-            trace_id: req.request_id,
-          }),
-          selectedLane: model,
-        };
-      }
-      const policy = { matched_policy_id: null, reason: "explicit lane passthrough" };
-      const chain = filterBlockedModels(expandChain(model, deps.lanes), opts);
-      if (chain.length === 0) {
-        return noPermittedModelsRejection({
-          req,
-          selectedLane: model,
-          classifier: passthroughClassifier(),
-          policy,
-          forcedReasoningEffort: null,
-          evalUsd: null,
-        });
-      }
-      return {
-        plan: {
-          selected_lane: model,
-          candidate_chain: chain,
-          explicit_model: null,
-        },
-        classifier: passthroughClassifier(),
-        policy,
-        forcedReasoningEffort: null,
-        evalUsd: null,
-      };
-    }
-
-    // 1b) Explicit MODEL — strict validation when the deployment wired
-    //     isKnownModel: an unknown name is a client error (invalid_request),
-    //     NEVER a silent Phase-0 fall-through to the default provider.
-    if (deps.isKnownModel !== undefined && !deps.isKnownModel(model)) {
+    // Strict validation when the deployment wired isKnownModel: an unknown name
+    // is a client error (invalid_request), NEVER a silent Phase-0 fall-through.
+    if (deps.isKnownModel !== undefined) {
       return {
         reject: makeHelmError({
           error_class: "invalid_request",
@@ -781,13 +804,7 @@ async function plan(
         selectedLane: model,
       };
     }
-    return {
-      plan: { selected_lane: model, candidate_chain: [model], explicit_model: model },
-      classifier: passthroughClassifier(),
-      policy: { matched_policy_id: null, reason: "explicit model passthrough" },
-      forcedReasoningEffort: null,
-      evalUsd: null,
-    };
+    return explicitModelDecision(model);
   }
 
   // 2) Classify (fail-open) → policy → lane-resolver (+caps).


### PR DESCRIPTION
## 摘要

- 精确配置 lane 与部署已知模型优先于兼容别名匹配
- 仅在没有精确名称时才使用精确兼容映射与最长字面量通配匹配
- 修复 `claude-opus` 被 `claude-*` 吞到 `balanced` 的生产路由问题，并覆盖全部 22 个默认 lane
- 同步默认配置、架构文档与实现笔记

## 验证

- `CI=true corepack pnpm vitest run packages/core/src/routing/route-request.test.ts packages/core/src/routing/model-alias.test.ts packages/core/src/config/rules-routing.test.ts packages/core/src/config/samples.test.ts`
- `CI=true corepack pnpm biome check packages/core/src/routing/route-request.ts packages/core/src/routing/route-request.test.ts packages/core/src/config/rules-routing.test.ts packages/core/src/config/samples.test.ts`
- `CI=true corepack pnpm --filter @helm/core build`
- `CI=true corepack pnpm typecheck`