### PR TITLE
chore(release): v0.27.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## 发布内容

- 将 Helm API 版本提升至 `0.27.3`
- 包含 PR #551：精确配置 lane / 已知模型优先于兼容通配别名，修复 `claude-opus` 被错误路由到 `balanced`

## 变更范围

- 仅修改根目录 `package.json` 版本号
- 合并后由 `Publish image` 自动创建 `v0.27.3` GitHub Release 与 GHCR 镜像标签