### PR TITLE
fix(admin): format durations by magnitude

### DIFF
--- a/apps/admin/src/lib/components/DecisionChain.svelte
+++ b/apps/admin/src/lib/components/DecisionChain.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
   import type { RequestDetail } from '$lib/api/requests.js';
+  import { formatDurationMs } from '$lib/format.js';
   import { t } from '$lib/i18n';
 
   // Visualises the recorded decision trail in order:
@@ -75,7 +76,9 @@
     }
   }
 
-  function accountTitle(account: RequestDetail['provider_attempts'][number]['serving_account']): string {
+  function accountTitle(
+    account: RequestDetail['provider_attempts'][number]['serving_account'],
+  ): string {
     return account ? `${account.provider_id}/${account.account}` : '';
   }
 </script>
@@ -163,7 +166,9 @@
               : $t('miss')}
         </span>
         {#if detail.eval_latency_ms !== null}
-          <span class="text-ink-muted">{$t('latency:')} {detail.eval_latency_ms}ms</span>
+          <span class="text-ink-muted"
+            >{$t('latency:')} {formatDurationMs(detail.eval_latency_ms)}</span
+          >
         {/if}
       </div>
       {#if cls.decided_by === 'eval'}
@@ -255,7 +260,7 @@
             <span class={outcomeBadge(a.outcome)} title={a.outcome}
               >{$t(attemptCodeLabel(a.outcome))}</span
             >
-            <span class="text-ink-muted">{a.latency_ms}ms</span>
+            <span class="text-ink-muted">{formatDurationMs(a.latency_ms)}</span>
             {#if a.error_class}<span class="text-red-600" title={a.error_class}
                 >{$t(attemptCodeLabel(a.error_class))}</span
               >{/if}

--- a/apps/admin/src/lib/components/DecisionChain.test.ts
+++ b/apps/admin/src/lib/components/DecisionChain.test.ts
@@ -64,7 +64,7 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
         provider_model: 'claude-x',
         serving_account: { provider_id: 'anthropic', account: 'claude-team-a' },
         outcome: 'success',
-        latency_ms: 340,
+        latency_ms: 90_000,
         error_detail: null,
       },
       {
@@ -81,7 +81,14 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
     response_meta: { model_alias: 'claude-x' },
     error: null,
     cost_breakdown: { routing_usd: 0, eval_usd: 0, completion_usd: 0.01, total_usd: 0.01 },
-    usage: { input: 1200, output: 340, cached: 800, cacheCreation: 64, nonCached: 400, total: 1540 },
+    usage: {
+      input: 1200,
+      output: 340,
+      cached: 800,
+      cacheCreation: 64,
+      nonCached: 400,
+      total: 1540,
+    },
     tps: 200,
     generation_ms: 1700,
     ttfb_ms: 460,
@@ -112,7 +119,7 @@ describe('DecisionChain', () => {
     const evalSec = screen.getByTestId('chain-eval');
     // The eval model name + latency answer "which model evaluated, how long".
     expect(within(evalSec).getByText('gpt-4o-mini')).toBeInTheDocument();
-    expect(within(evalSec).getByText(/1234ms/)).toBeInTheDocument();
+    expect(within(evalSec).getByText(/1\.2s/)).toBeInTheDocument();
     // The eval verdict is restated here, attributed, so it is not mistaken for rules.
     const verdict = within(evalSec).getByTestId('eval-verdict');
     expect(verdict).toHaveTextContent('coding');
@@ -246,6 +253,7 @@ describe('DecisionChain', () => {
     expect(rows[0]).toHaveTextContent('120');
     expect(rows[1]).toHaveTextContent(/success/i);
     expect(rows[1]).toHaveTextContent('claude-team-a');
+    expect(rows[1]).toHaveTextContent('1.5min');
     expect(rows[2]).toHaveTextContent(/skipped/i);
     // Codes render as human labels; the raw code is preserved in the title tooltip.
     expect(rows[2]).toHaveTextContent('No compatible model');

--- a/apps/admin/src/lib/components/RequestsTable.svelte
+++ b/apps/admin/src/lib/components/RequestsTable.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import type { RequestListItem } from '$lib/api/requests.js';
   import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
-  import { formatTimestamp, formatTps, formatUsd } from '$lib/format.js';
+  import { formatDurationMs, formatTimestamp, formatTps, formatUsd } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import TokensCell from './TokensCell.svelte';
 
@@ -195,7 +195,7 @@
 
 {#snippet performanceCell(r: RequestListItem)}
   <div data-testid="cell-performance" class="font-mono text-xs leading-tight">
-    <div>{r.latency_ms}ms</div>
+    <div>{formatDurationMs(r.latency_ms)}</div>
     <div data-testid="cell-tps" class="text-ink-muted">{formatTps(r.tps)}</div>
   </div>
 {/snippet}

--- a/apps/admin/src/lib/components/RequestsTable.test.ts
+++ b/apps/admin/src/lib/components/RequestsTable.test.ts
@@ -76,7 +76,11 @@ describe('RequestsTable key cell', () => {
 
 describe('RequestsTable variants', () => {
   it('renders the full request-audit columns as grouped cells', () => {
-    render(RequestsTable, { items: [item()], detailHref, variant: 'full' });
+    render(RequestsTable, {
+      items: [item({ latency_ms: 6911 })],
+      detailHref,
+      variant: 'full',
+    });
 
     const row = screen.getByTestId('request-row');
     expect(within(row).getByTestId('cell-result')).toHaveTextContent('ok');
@@ -86,8 +90,14 @@ describe('RequestsTable variants', () => {
     expect(within(row).getByTestId('cell-routing')).toHaveTextContent('coding');
     expect(within(row).getByTestId('cell-serving')).toHaveTextContent('anthropic');
     expect(within(row).getByTestId('cell-serving')).toHaveTextContent('exec +1');
-    expect(within(row).getByTestId('cell-performance')).toHaveTextContent('460ms');
+    expect(within(row).getByTestId('cell-performance')).toHaveTextContent('6.9s');
     expect(screen.getByText('Request ID')).toBeInTheDocument();
+  });
+
+  it('formats performance latency in minutes from sixty seconds', () => {
+    render(RequestsTable, { items: [item({ latency_ms: 90_000 })], detailHref });
+
+    expect(screen.getByTestId('cell-performance')).toHaveTextContent('1.5min');
   });
 
   it('keeps the request-list metric columns and hides only Request ID in the dashboard recent variant', () => {

--- a/apps/admin/src/lib/components/RetryDialog.svelte
+++ b/apps/admin/src/lib/components/RetryDialog.svelte
@@ -4,6 +4,7 @@
   import { base } from '$app/paths';
   import { replayRequest } from '$lib/api/requests.js';
   import Modal from '$lib/components/Modal.svelte';
+  import { formatDurationMs } from '$lib/format.js';
   import { t } from '$lib/i18n';
 
   // Retry dialog: shows the recorded request body in an EDITABLE textarea (e.g. to
@@ -137,7 +138,10 @@
       data-testid="retry-send"
       class="btn-primary"
       disabled={sending}
-      onclick={handleSend}>{sending ? $t('Sending… {s}s', { s: elapsed }) : $t('Send')}</button
+      onclick={handleSend}
+      >{sending
+        ? $t('Sending… {duration}', { duration: formatDurationMs(elapsed * 1000) })
+        : $t('Send')}</button
     >
   </div>
 </Modal>

--- a/apps/admin/src/lib/components/RetryDialog.test.ts
+++ b/apps/admin/src/lib/components/RetryDialog.test.ts
@@ -67,11 +67,15 @@ describe('RetryDialog sending state', () => {
     const note = screen.getByTestId('retry-progress');
     expect(note).toBeInTheDocument();
 
-    // The counter ticks: 0s -> 3s proves the UI is alive, not frozen.
-    expect(sendButton().textContent).toContain('0s');
+    // The counter ticks: 0ms -> 3s proves the UI is alive, not frozen.
+    expect(sendButton().textContent).toContain('0ms');
     vi.advanceTimersByTime(3000);
     await tick();
     expect(sendButton().textContent).toContain('3s');
+
+    vi.advanceTimersByTime(57_000);
+    await tick();
+    expect(sendButton().textContent).toContain('1min');
   });
 
   it('locks the body editor while sending and unlocks it on failure', async () => {

--- a/apps/admin/src/lib/components/TestAccountDialog.svelte
+++ b/apps/admin/src/lib/components/TestAccountDialog.svelte
@@ -3,6 +3,7 @@
   import { invalidateAll } from '$app/navigation';
   import { streamAccountTest } from '$lib/api/oauth.js';
   import Modal from '$lib/components/Modal.svelte';
+  import { formatDurationMs } from '$lib/format.js';
   import { t } from '$lib/i18n';
 
   // Per-account connectivity test (providers page "Test" button). Streams a single
@@ -146,7 +147,9 @@
             <span class="badge-error">{$t('Failed')}</span>
           {/if}
           {#if durationMs !== null}
-            <span class="text-ink-muted">{$t('Done in {ms} ms', { ms: durationMs })}</span>
+            <span class="text-ink-muted"
+              >{$t('Done in {duration}', { duration: formatDurationMs(durationMs) })}</span
+            >
           {/if}
         </span>
         <span class="text-ink-muted">{$t('{n} chars', { n: response.length })}</span>

--- a/apps/admin/src/lib/format.test.ts
+++ b/apps/admin/src/lib/format.test.ts
@@ -2,11 +2,30 @@ import { describe, expect, it } from 'vitest';
 import {
   durationParts,
   formatCount,
+  formatDurationMs,
   formatTimestamp,
   formatTokens,
   formatTps,
   formatUsd,
 } from './format.js';
+
+describe('formatDurationMs — compact duration', () => {
+  it('keeps sub-second durations in milliseconds', () => {
+    expect(formatDurationMs(0)).toBe('0ms');
+    expect(formatDurationMs(999)).toBe('999ms');
+  });
+
+  it('uses seconds from one second and trims trailing zeroes', () => {
+    expect(formatDurationMs(1000)).toBe('1s');
+    expect(formatDurationMs(6911)).toBe('6.9s');
+    expect(formatDurationMs(59_999)).toBe('60s');
+  });
+
+  it('uses minutes from one minute', () => {
+    expect(formatDurationMs(60_000)).toBe('1min');
+    expect(formatDurationMs(90_000)).toBe('1.5min');
+  });
+});
 
 describe('formatTokens — compact token counts for the dashboard', () => {
   it('renders not-measured (null/undefined/NaN) as an em dash', () => {

--- a/apps/admin/src/lib/format.ts
+++ b/apps/admin/src/lib/format.ts
@@ -74,6 +74,19 @@ export function formatTokens(n: number | null | undefined): string {
 // to touch one signature.
 export const formatCount = formatTokens;
 
+// Compact durations for narrow UI surfaces. Preserve millisecond
+// precision below one second, then use one decimal at larger units so operators
+// can compare values quickly without scanning long raw millisecond numbers.
+export function formatDurationMs(ms: number): string {
+  const value = Math.max(0, ms);
+  if (value < 1000) return `${Math.round(value)}ms`;
+
+  const unit = value < 60_000 ? 's' : 'min';
+  const divisor = value < 60_000 ? 1000 : 60_000;
+  const scaled = (value / divisor).toFixed(1).replace(/\.0$/, '');
+  return `${scaled}${unit}`;
+}
+
 // True generation throughput (tokens/sec) for the dashboard "Avg TPS" card, the
 // request-list TPS column, and the detail card. The SINGLE source of truth for
 // rendering a TPS value — never re-divides tokens by time here, only formats the

--- a/apps/admin/src/lib/i18n/providers-locales.test.ts
+++ b/apps/admin/src/lib/i18n/providers-locales.test.ts
@@ -19,7 +19,7 @@ const providerPageKeys = [
   'Provider refresh failed: {error}',
   'Provider data refreshed',
   'Provider data refreshed at {time}',
-  'refresh available again in {seconds}s',
+  'refresh available again in {duration}',
   'Reset-credit count unavailable',
   'No reset credits available',
   'Weekly quota snapshot unavailable',

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -252,7 +252,7 @@
   "Disconnect": "Disconnect",
   "Disconnecting…": "Disconnecting…",
   "Done": "Done",
-  "Done in {ms} ms": "Done in {ms} ms",
+  "Done in {duration}": "Done in {duration}",
   "down": "down",
   "drag to reorder policy": "drag to reorder policy",
   "e.g. favorite number": "e.g. favorite number",
@@ -760,7 +760,7 @@
   "Select a key…": "Select a key…",
   "Send": "Send",
   "Send a short message through this account and stream the reply.": "Send a short message through this account and stream the reply.",
-  "Sending… {s}s": "Sending… {s}s",
+  "Sending… {duration}": "Sending… {duration}",
   "Serialize user messages per subscription account": "Serialize user messages per subscription account",
   "Served model": "Served model",
   "Server URL: paste the URL above (it must end in /mcp).": "Server URL: paste the URL above (it must end in /mcp).",
@@ -862,7 +862,7 @@
   "Time to first token": "Time to first token",
   "timed out": "timed out",
   "Timed out": "Timed out",
-  "Timeout (ms)": "Timeout (ms)",
+  "Timeout": "Timeout",
   "To": "To",
   "Today": "Today",
   "tok": "tok",
@@ -993,5 +993,5 @@
   "Provider refresh failed: {error}": "Provider refresh failed: {error}",
   "Provider data refreshed": "Provider data refreshed",
   "Provider data refreshed at {time}": "Provider data refreshed at {time}",
-  "refresh available again in {seconds}s": "refresh available again in {seconds}s"
+  "refresh available again in {duration}": "refresh available again in {duration}"
 }

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -252,7 +252,7 @@
   "Disconnect": "Desconectar",
   "Disconnecting…": "Desconectando…",
   "Done": "Listo",
-  "Done in {ms} ms": "Listo en {ms} ms",
+  "Done in {duration}": "Listo en {duration}",
   "down": "caído",
   "drag to reorder policy": "arrastra para reordenar la política",
   "e.g. favorite number": "p. ej. número favorito",
@@ -760,7 +760,7 @@
   "Select a key…": "Selecciona una clave…",
   "Send": "Enviar",
   "Send a short message through this account and stream the reply.": "Envía un mensaje corto a través de esta cuenta y transmite la respuesta en streaming.",
-  "Sending… {s}s": "Enviando… {s}s",
+  "Sending… {duration}": "Enviando… {duration}",
   "Serialize user messages per subscription account": "Serializar mensajes de usuario por cuenta de suscripción",
   "Served model": "Modelo servido",
   "Server URL: paste the URL above (it must end in /mcp).": "URL del servidor: pega la URL anterior (debe terminar en /mcp).",
@@ -862,7 +862,7 @@
   "Time to first token": "Tiempo hasta el primer token",
   "timed out": "agotó el tiempo de espera",
   "Timed out": "Tiempo de espera agotado",
-  "Timeout (ms)": "Tiempo de espera (ms)",
+  "Timeout": "Tiempo de espera",
   "To": "Hasta",
   "Today": "Hoy",
   "tok": "tok",
@@ -993,5 +993,5 @@
   "Provider refresh failed: {error}": "Error al actualizar los proveedores: {error}",
   "Provider data refreshed": "Datos de proveedores actualizados",
   "Provider data refreshed at {time}": "Datos de proveedores actualizados a las {time}",
-  "refresh available again in {seconds}s": "se podrá actualizar de nuevo en {seconds}s"
+  "refresh available again in {duration}": "se podrá actualizar de nuevo en {duration}"
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -252,7 +252,7 @@
   "Disconnect": "切断",
   "Disconnecting…": "切断中…",
   "Done": "完了",
-  "Done in {ms} ms": "{ms} ms で完了",
+  "Done in {duration}": "{duration} で完了",
   "down": "下り",
   "drag to reorder policy": "ドラッグしてポリシーの順序を変更",
   "e.g. favorite number": "例：好きな数字",
@@ -760,7 +760,7 @@
   "Select a key…": "キーを選択…",
   "Send": "送信",
   "Send a short message through this account and stream the reply.": "このアカウント経由で短いメッセージを送信し、応答をストリーミング表示します。",
-  "Sending… {s}s": "送信中… {s}秒",
+  "Sending… {duration}": "送信中… {duration}",
   "Serialize user messages per subscription account": "サブスクリプションアカウントごとにユーザーメッセージを直列化",
   "Served model": "提供モデル",
   "Server URL: paste the URL above (it must end in /mcp).": "サーバーURL: 上記のURLを貼り付けます（/mcpで終わる必要があります）。",
@@ -862,7 +862,7 @@
   "Time to first token": "最初のトークンまでの時間",
   "timed out": "タイムアウト",
   "Timed out": "タイムアウト",
-  "Timeout (ms)": "タイムアウト（ミリ秒）",
+  "Timeout": "タイムアウト",
   "To": "終了",
   "Today": "今日",
   "tok": "tok",
@@ -993,5 +993,5 @@
   "Provider refresh failed: {error}": "プロバイダーの更新に失敗しました：{error}",
   "Provider data refreshed": "プロバイダーデータを更新しました",
   "Provider data refreshed at {time}": "{time} にプロバイダーデータを更新しました",
-  "refresh available again in {seconds}s": "{seconds}秒後に再度更新できます"
+  "refresh available again in {duration}": "{duration}後に再度更新できます"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -252,7 +252,7 @@
   "Disconnect": "연결 해제",
   "Disconnecting…": "연결 해제 중…",
   "Done": "완료",
-  "Done in {ms} ms": "{ms} ms 소요",
+  "Done in {duration}": "{duration} 소요",
   "down": "아래",
   "drag to reorder policy": "드래그하여 정책 순서 변경",
   "e.g. favorite number": "예: 좋아하는 숫자",
@@ -760,7 +760,7 @@
   "Select a key…": "키 선택…",
   "Send": "보내기",
   "Send a short message through this account and stream the reply.": "이 계정으로 짧은 메시지를 보내고 응답을 스트리밍합니다.",
-  "Sending… {s}s": "보내는 중… {s}초",
+  "Sending… {duration}": "보내는 중… {duration}",
   "Serialize user messages per subscription account": "구독 계정별로 사용자 메시지 직렬화",
   "Served model": "제공된 모델",
   "Server URL: paste the URL above (it must end in /mcp).": "서버 URL: 위의 URL을 붙여넣으세요(/mcp로 끝나야 합니다).",
@@ -862,7 +862,7 @@
   "Time to first token": "첫 토큰까지의 시간",
   "timed out": "시간 초과",
   "Timed out": "시간 초과",
-  "Timeout (ms)": "타임아웃 (ms)",
+  "Timeout": "타임아웃",
   "To": "종료",
   "Today": "오늘",
   "tok": "tok",
@@ -993,5 +993,5 @@
   "Provider refresh failed: {error}": "공급자 새로고침 실패: {error}",
   "Provider data refreshed": "공급자 데이터를 새로고침했습니다",
   "Provider data refreshed at {time}": "{time}에 공급자 데이터를 새로고침했습니다",
-  "refresh available again in {seconds}s": "{seconds}초 후 다시 새로고침할 수 있습니다"
+  "refresh available again in {duration}": "{duration} 후 다시 새로고침할 수 있습니다"
 }

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -252,7 +252,7 @@
   "Disconnect": "Desconectar",
   "Disconnecting…": "Desconectando…",
   "Done": "Concluído",
-  "Done in {ms} ms": "Concluído em {ms} ms",
+  "Done in {duration}": "Concluído em {duration}",
   "down": "fora do ar",
   "drag to reorder policy": "arraste para reordenar a política",
   "e.g. favorite number": "ex.: número favorito",
@@ -760,7 +760,7 @@
   "Select a key…": "Selecione uma chave…",
   "Send": "Enviar",
   "Send a short message through this account and stream the reply.": "Envie uma mensagem curta por esta conta e transmita a resposta em streaming.",
-  "Sending… {s}s": "Enviando… {s}s",
+  "Sending… {duration}": "Enviando… {duration}",
   "Serialize user messages per subscription account": "Serializar mensagens de usuário por conta de assinatura",
   "Served model": "Modelo servido",
   "Server URL: paste the URL above (it must end in /mcp).": "URL do servidor: cole a URL acima (ela deve terminar em /mcp).",
@@ -862,7 +862,7 @@
   "Time to first token": "Tempo até o primeiro token",
   "timed out": "tempo esgotado",
   "Timed out": "Tempo esgotado",
-  "Timeout (ms)": "Tempo limite (ms)",
+  "Timeout": "Tempo limite",
   "To": "Até",
   "Today": "Hoje",
   "tok": "tok",
@@ -993,5 +993,5 @@
   "Provider refresh failed: {error}": "Falha ao atualizar os provedores: {error}",
   "Provider data refreshed": "Dados dos provedores atualizados",
   "Provider data refreshed at {time}": "Dados dos provedores atualizados às {time}",
-  "refresh available again in {seconds}s": "nova atualização disponível em {seconds}s"
+  "refresh available again in {duration}": "nova atualização disponível em {duration}"
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -252,7 +252,7 @@
   "Disconnect": "断开连接",
   "Disconnecting…": "正在断开连接…",
   "Done": "完成",
-  "Done in {ms} ms": "耗时 {ms} 毫秒",
+  "Done in {duration}": "耗时 {duration}",
   "down": "下行",
   "drag to reorder policy": "拖动以调整策略顺序",
   "e.g. favorite number": "例如：喜欢的数字",
@@ -760,7 +760,7 @@
   "Select a key…": "选择一个密钥…",
   "Send": "发送",
   "Send a short message through this account and stream the reply.": "通过该账号发送一条简短消息，并流式显示返回结果。",
-  "Sending… {s}s": "发送中… {s} 秒",
+  "Sending… {duration}": "发送中… {duration}",
   "Serialize user messages per subscription account": "按订阅账户串行处理用户消息",
   "Served model": "最终模型",
   "Server URL: paste the URL above (it must end in /mcp).": "服务器 URL：粘贴上面的地址（必须以 /mcp 结尾）。",
@@ -862,7 +862,7 @@
   "Time to first token": "首 Token 延迟",
   "timed out": "超时",
   "Timed out": "请求超时",
-  "Timeout (ms)": "超时（毫秒）",
+  "Timeout": "超时",
   "To": "结束",
   "Today": "今天",
   "tok": "tok",
@@ -993,5 +993,5 @@
   "Provider refresh failed: {error}": "提供商刷新失败：{error}",
   "Provider data refreshed": "提供商数据已刷新",
   "Provider data refreshed at {time}": "提供商数据已于 {time} 刷新",
-  "refresh available again in {seconds}s": "{seconds} 秒后可再次刷新"
+  "refresh available again in {duration}": "{duration} 后可再次刷新"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -252,7 +252,7 @@
   "Disconnect": "中斷連線",
   "Disconnecting…": "正在中斷連線…",
   "Done": "完成",
-  "Done in {ms} ms": "耗時 {ms} 毫秒",
+  "Done in {duration}": "耗時 {duration}",
   "down": "下行",
   "drag to reorder policy": "拖動以調整策略順序",
   "e.g. favorite number": "例如：喜歡的數字",
@@ -760,7 +760,7 @@
   "Select a key…": "選擇一個金鑰…",
   "Send": "發送",
   "Send a short message through this account and stream the reply.": "透過此帳號傳送一則簡短訊息，並串流顯示回應。",
-  "Sending… {s}s": "發送中… {s} 秒",
+  "Sending… {duration}": "發送中… {duration}",
   "Serialize user messages per subscription account": "按訂閱帳戶串行處理使用者訊息",
   "Served model": "最終模型",
   "Server URL: paste the URL above (it must end in /mcp).": "伺服器 URL：貼上上面的位址（必須以 /mcp 結尾）。",
@@ -862,7 +862,7 @@
   "Time to first token": "首 Token 延遲",
   "timed out": "逾時",
   "Timed out": "請求逾時",
-  "Timeout (ms)": "逾時（毫秒）",
+  "Timeout": "逾時",
   "To": "結束",
   "Today": "今天",
   "tok": "tok",
@@ -993,5 +993,5 @@
   "Provider refresh failed: {error}": "提供商重新整理失敗：{error}",
   "Provider data refreshed": "提供商資料已重新整理",
   "Provider data refreshed at {time}": "提供商資料已於 {time} 重新整理",
-  "refresh available again in {seconds}s": "{seconds} 秒後可再次重新整理"
+  "refresh available again in {duration}": "{duration} 後可再次重新整理"
 }

--- a/apps/admin/src/routes/+page.svelte
+++ b/apps/admin/src/routes/+page.svelte
@@ -9,7 +9,13 @@
   import RefreshControl from '$lib/components/RefreshControl.svelte';
   import RequestsTable from '$lib/components/RequestsTable.svelte';
   import { formatTrendTick, trendAxisTicks, type TrendBucket } from '$lib/dashboard-chart.js';
-  import { formatCount, formatTokens, formatTps, formatUsd } from '$lib/format.js';
+  import {
+    formatCount,
+    formatDurationMs,
+    formatTokens,
+    formatTps,
+    formatUsd,
+  } from '$lib/format.js';
   import {
     DEFAULT_PAGE_SIZE,
     filtersToSearch,
@@ -342,7 +348,7 @@
         {$t('Avg latency')}
       </div>
       <div class="mt-1 text-2xl font-semibold text-slate-900">
-        {stats.avgLatency === null ? '—' : `${stats.avgLatency}ms`}
+        {stats.avgLatency === null ? '—' : formatDurationMs(stats.avgLatency)}
       </div>
     </div>
     <div class="card">

--- a/apps/admin/src/routes/classifier/+page.svelte
+++ b/apps/admin/src/routes/classifier/+page.svelte
@@ -2,6 +2,7 @@
   import { untrack } from 'svelte';
   import { saveClassifier, type ClassifierConfig } from '$lib/api/classifier.js';
   import DimensionTable from '$lib/components/DimensionTable.svelte';
+  import { formatDurationMs } from '$lib/format.js';
   import { t } from '$lib/i18n';
 
   // Data comes from `+page.ts`'s load (mocked via the `data` prop in tests). The
@@ -198,13 +199,15 @@
       <dd class="tabular-nums text-ink-strong">{cfg.eval.temperature}</dd>
       <dt class="text-ink-muted">{$t('Max tokens')}</dt>
       <dd class="tabular-nums text-ink-strong">{cfg.eval.max_tokens}</dd>
-      <dt class="text-ink-muted">{$t('Timeout (ms)')}</dt>
-      <dd class="tabular-nums text-ink-strong">{cfg.eval.timeout_ms}</dd>
+      <dt class="text-ink-muted">{$t('Timeout')}</dt>
+      <dd class="tabular-nums text-ink-strong">{formatDurationMs(cfg.eval.timeout_ms)}</dd>
       <dt class="text-ink-muted">{$t('On failure')}</dt>
       <dd class="text-ink-strong">{cfg.eval.on_failure}</dd>
       <dt class="text-ink-muted">{$t('Cache')}</dt>
       <dd class="text-ink-strong">
-        {cfg.eval.cache.enabled ? $t('on') : $t('off')} · ttl {cfg.eval.cache.ttl_sec}s
+        {cfg.eval.cache.enabled ? $t('on') : $t('off')} · ttl {formatDurationMs(
+          cfg.eval.cache.ttl_sec * 1000,
+        )}
       </dd>
     </dl>
   </div>

--- a/apps/admin/src/routes/classifier/classifier.test.ts
+++ b/apps/admin/src/routes/classifier/classifier.test.ts
@@ -28,9 +28,9 @@ function config(overrides: Partial<ClassifierConfig> = {}): ClassifierConfig {
       model: 'deepseek/deepseek-v4-flash',
       temperature: 0,
       max_tokens: 256,
-      timeout_ms: 300,
+      timeout_ms: 6911,
       on_failure: 'balanced',
-      cache: { enabled: true, ttl_sec: 300 },
+      cache: { enabled: true, ttl_sec: 90 },
     },
     ...overrides,
   };
@@ -135,7 +135,8 @@ describe('classifier page', () => {
     const details = screen.getByTestId('eval-details');
     expect(within_text(details, 'deepseek/deepseek-v4-flash')).toBe(true);
     expect(within_text(details, 'balanced')).toBe(true);
-    expect(within_text(details, '300')).toBe(true);
+    expect(within_text(details, '6.9s')).toBe(true);
+    expect(within_text(details, 'ttl 1.5min')).toBe(true);
     // temperature is locked to 0 and surfaced.
     expect(within_text(details, '0')).toBe(true);
     // No editable controls in the read-only eval detail block.

--- a/apps/admin/src/routes/home.test.ts
+++ b/apps/admin/src/routes/home.test.ts
@@ -116,6 +116,15 @@ describe('home dashboard loader', () => {
     expect(invalidateAll).toHaveBeenCalledTimes(1);
   });
 
+  it('formats average latency in seconds', () => {
+    const data = pageData();
+    data.stats.avgLatency = 6911;
+
+    render(HomePage, { data });
+
+    expect(screen.getByText('6.9s')).toBeInTheDocument();
+  });
+
   it('loads all-time stats with an explicit full-history window', async () => {
     const now = Date.UTC(2026, 5, 17, 12);
     vi.spyOn(Date, 'now').mockReturnValue(now);

--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -9,7 +9,14 @@
   import RangeFilter from '$lib/components/RangeFilter.svelte';
   import RequestsTable from '$lib/components/RequestsTable.svelte';
   import { formatTrendTick, trendAxisTicks, type TrendBucket } from '$lib/dashboard-chart.js';
-  import { durationParts, formatCount, formatTokens, formatTps, formatUsd } from '$lib/format.js';
+  import {
+    durationParts,
+    formatCount,
+    formatDurationMs,
+    formatTokens,
+    formatTps,
+    formatUsd,
+  } from '$lib/format.js';
   import {
     KEY_DETAIL_DEFAULT_RANGE,
     type KeyDetailFilters,
@@ -351,7 +358,7 @@
         {$t('Avg latency')}
       </div>
       <div class="mt-1 text-2xl font-semibold text-slate-900">
-        {stats.avgLatency === null ? '—' : `${stats.avgLatency}ms`}
+        {stats.avgLatency === null ? '—' : formatDurationMs(stats.avgLatency)}
       </div>
     </div>
     <div class="card">

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -185,7 +185,7 @@ function pageData(
       ok: 40,
       errors: 2,
       successRate: 95,
-      avgLatency: 800,
+      avgLatency: 90_000,
       avgTps: 30,
       totalCost: 0.5,
       totalTokens: 1500,
@@ -211,6 +211,7 @@ describe('key detail page', () => {
     expect(screen.getByText(/^yes$/i)).toBeInTheDocument();
     // Headline request count from stats.
     expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('1.5min')).toBeInTheDocument();
     // The scoped request row links to the shared request detail page, carrying THIS
     // key page as `from` so the detail's Back link returns here (not the global list).
     const link = screen.getByTestId('request-detail-link');

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -27,7 +27,13 @@
   import Modal from '$lib/components/Modal.svelte';
   import RefreshControl from '$lib/components/RefreshControl.svelte';
   import TestAccountDialog from '$lib/components/TestAccountDialog.svelte';
-  import { durationParts, formatCount, formatTokens, formatUsd } from '$lib/format';
+  import {
+    durationParts,
+    formatCount,
+    formatDurationMs,
+    formatTokens,
+    formatUsd,
+  } from '$lib/format';
   import { t } from '$lib/i18n';
 
   // Subscription OAuth login (issue #38). Pure consumer (Principle 1): the gateway
@@ -545,17 +551,15 @@
     if (status.state === 'succeeded' || status.lastSuccessAt !== null) {
       const refreshedAt = status.lastSuccessAt ?? status.finishedAt;
       const time = refreshedAt === null ? null : new Date(refreshedAt).toLocaleTimeString();
-      const cooldownSeconds =
-        status.nextAllowedAt !== null && status.nextAllowedAt > Date.now()
-          ? Math.max(1, Math.ceil((status.nextAllowedAt - Date.now()) / 1000))
-          : null;
+      const remainingMs = status.nextAllowedAt === null ? 0 : status.nextAllowedAt - Date.now();
+      const cooldownMs = remainingMs > 0 ? remainingMs : null;
       const refreshed = time
         ? $t('Provider data refreshed at {time}', { time })
         : $t('Provider data refreshed');
-      return cooldownSeconds === null
+      return cooldownMs === null
         ? refreshed
-        : `${refreshed} · ${$t('refresh available again in {seconds}s', {
-            seconds: cooldownSeconds,
+        : `${refreshed} · ${$t('refresh available again in {duration}', {
+            duration: formatDurationMs(cooldownMs),
           })}`;
     }
     return null;

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -506,7 +506,7 @@ describe('providers page', () => {
         startedAt: refreshedAt - 80,
         finishedAt: refreshedAt,
         lastSuccessAt: refreshedAt,
-        nextAllowedAt: refreshedAt + 60_000,
+        nextAllowedAt: refreshedAt + 90_000,
       },
     } satisfies OAuthOverview);
     renderPage();
@@ -515,7 +515,7 @@ describe('providers page', () => {
 
     await waitFor(() => expect(screen.getByText('99 req')).toBeInTheDocument());
     expect(screen.getByTestId('provider-refresh-status')).toHaveTextContent(
-      'Provider data refreshed',
+      'refresh available again in 1.5min',
     );
   });
 
@@ -869,7 +869,7 @@ describe('providers page', () => {
     streamAccountTest.mockImplementation(async function* () {
       yield { type: 'content', text: 'Hello' };
       yield { type: 'content', text: ' there' };
-      yield { type: 'done', durationMs: 12 };
+      yield { type: 'done', durationMs: 1200 };
     });
     renderPage();
     await fireEvent.click(
@@ -890,6 +890,7 @@ describe('providers page', () => {
       expect(within(dialog).getByTestId('test-response')).toHaveTextContent('Hello there'),
     );
     expect(within(dialog).getByText('Success')).toBeInTheDocument();
+    expect(within(dialog).getByText('Done in 1.2s')).toBeInTheDocument();
   });
 
   it('confirms and disconnects a stored account credential', async () => {

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -9,7 +9,7 @@
   } from '$lib/api/requests.js';
   import { deepEqual } from '$lib/deep-equal.js';
   import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
-  import { formatTimestamp, formatTps } from '$lib/format.js';
+  import { formatDurationMs, formatTimestamp, formatTps } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import Conversation from '$lib/components/Conversation.svelte';
   import CostBreakdown from '$lib/components/CostBreakdown.svelte';
@@ -67,7 +67,9 @@
     return {
       ...(hasOwn(payload, 'request') ? { request: payload.request } : {}),
       ...(hasOwn(payload, 'response') ? { response: payload.response } : {}),
-      ...(hasOwn(payload, 'upstream_request') ? { upstream_request: payload.upstream_request } : {}),
+      ...(hasOwn(payload, 'upstream_request')
+        ? { upstream_request: payload.upstream_request }
+        : {}),
     };
   }
 
@@ -150,7 +152,9 @@
   // differs from the inbound client body (memory injection / protocol translation /
   // model patch). When they are structurally identical — e.g. a no-memory request to
   // an OpenAI-shaped provider — a second panel is pure noise, so we collapse to one.
-  const hasUpstream = $derived(data.payload?.captured === true && hasPayloadPart('upstream_request'));
+  const hasUpstream = $derived(
+    data.payload?.captured === true && hasPayloadPart('upstream_request'),
+  );
   const requestLoaded = $derived(payloadStatus.request === 'loaded');
   const responseLoaded = $derived(payloadStatus.response === 'loaded');
   const upstreamLoaded = $derived(payloadStatus.upstream_request === 'loaded');
@@ -318,7 +322,7 @@
         <div>
           <dt class="text-xs uppercase tracking-wide text-slate-400">{$t('Latency')}</dt>
           <dd class="mt-0.5 font-mono text-ink-body">
-            {d.latency_ms === null ? '—' : `${d.latency_ms}ms`}
+            {d.latency_ms === null ? '—' : formatDurationMs(d.latency_ms)}
           </dd>
         </div>
       </dl>
@@ -388,7 +392,7 @@
             type="button"
             data-testid="request-view-raw"
             class={`rounded border px-3 py-1 text-sm ${reqView === 'raw' ? 'border-action bg-action text-white' : 'border-border bg-surface text-ink-muted hover:bg-canvas'}`}
-          onclick={() => (reqView = 'raw')}>{$t('Raw')}</button
+            onclick={() => (reqView = 'raw')}>{$t('Raw')}</button
           >
         </div>
         {#if reqView === 'chat'}
@@ -401,7 +405,8 @@
                 type="button"
                 data-testid="load-conversation"
                 class="btn-secondary"
-                disabled={payloadStatus.request === 'loading' || payloadStatus.response === 'loading'}
+                disabled={payloadStatus.request === 'loading' ||
+                  payloadStatus.response === 'loading'}
                 onclick={loadConversation}
                 >{payloadStatus.request === 'loading' || payloadStatus.response === 'loading'
                   ? $t('Loading')
@@ -420,29 +425,27 @@
               testid="conversation"
             />
           {/if}
+        {:else if !requestLoaded}
+          <div class="rounded border border-dashed border-border bg-canvas p-3">
+            <p class="field-help mb-2">
+              {$t('Load the raw request body only when you need to inspect it.')}
+            </p>
+            <button
+              type="button"
+              data-testid="load-request-body"
+              class="btn-secondary"
+              disabled={payloadStatus.request === 'loading'}
+              onclick={() => loadPayloadPart('request')}
+              >{payloadStatus.request === 'loading'
+                ? $t('Loading')
+                : $t('Load request body')}</button
+            >
+            {#if payloadErrors.request}
+              <p class="mt-2 text-sm text-red-600">{payloadErrors.request}</p>
+            {/if}
+          </div>
         {:else}
-          {#if !requestLoaded}
-            <div class="rounded border border-dashed border-border bg-canvas p-3">
-              <p class="field-help mb-2">
-                {$t('Load the raw request body only when you need to inspect it.')}
-              </p>
-              <button
-                type="button"
-                data-testid="load-request-body"
-                class="btn-secondary"
-                disabled={payloadStatus.request === 'loading'}
-                onclick={() => loadPayloadPart('request')}
-                >{payloadStatus.request === 'loading'
-                  ? $t('Loading')
-                  : $t('Load request body')}</button
-              >
-              {#if payloadErrors.request}
-                <p class="mt-2 text-sm text-red-600">{payloadErrors.request}</p>
-              {/if}
-            </div>
-          {:else}
-            <JsonViewer value={payloadValues.request} testid="request-body" />
-          {/if}
+          <JsonViewer value={payloadValues.request} testid="request-body" />
         {/if}
       {:else}
         <p class="field-help mb-2">
@@ -472,13 +475,16 @@
         {#if !upstreamLoaded || !requestLoaded}
           <div class="rounded border border-dashed border-border bg-canvas p-3">
             <p class="field-help mb-2">
-              {$t('Load this only when you need to compare the client body with the provider body.')}
+              {$t(
+                'Load this only when you need to compare the client body with the provider body.',
+              )}
             </p>
             <button
               type="button"
               data-testid="load-upstream-request"
               class="btn-secondary"
-              disabled={payloadStatus.upstream_request === 'loading' || payloadStatus.request === 'loading'}
+              disabled={payloadStatus.upstream_request === 'loading' ||
+                payloadStatus.request === 'loading'}
               onclick={loadUpstreamRequest}
               >{payloadStatus.upstream_request === 'loading' || payloadStatus.request === 'loading'
                 ? $t('Loading')
@@ -537,12 +543,12 @@
 
         <dt class="text-ink-muted">{$t('Time to first token')}</dt>
         <dd data-testid="ttfb" class="text-right font-mono text-ink-strong">
-          {d.ttfb_ms === null ? '—' : `${d.ttfb_ms}ms`}
+          {d.ttfb_ms === null ? '—' : formatDurationMs(d.ttfb_ms)}
         </dd>
 
         <dt class="text-ink-muted">{$t('Generation time')}</dt>
         <dd data-testid="generation-ms" class="text-right font-mono text-ink-strong">
-          {d.generation_ms === null ? '—' : `${d.generation_ms}ms`}
+          {d.generation_ms === null ? '—' : formatDurationMs(d.generation_ms)}
         </dd>
       </dl>
     </section>

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -306,8 +306,12 @@ describe('requests list page', () => {
       }),
     });
     const select = screen.getByTestId('filter-key');
-    expect(within(select).getByRole('option', { name: 'Prod / helm_live_prod' })).toBeInTheDocument();
-    expect(within(select).getByRole('option', { name: /helm_live_old.*revoked/i })).toBeInTheDocument();
+    expect(
+      within(select).getByRole('option', { name: 'Prod / helm_live_prod' }),
+    ).toBeInTheDocument();
+    expect(
+      within(select).getByRole('option', { name: /helm_live_old.*revoked/i }),
+    ).toBeInTheDocument();
 
     await fireEvent.change(select, { target: { value: 'k_42' } });
     expect(goto).toHaveBeenCalledWith('?key_id=k_42', expect.anything());
@@ -471,7 +475,11 @@ describe('requests detail page', () => {
 
   it('renders a Request summary card with key, provider/account, requested+served model, lane, status, latency', () => {
     render(DetailPage, {
-      data: { detail: detail(), payload: { captured: false }, traceId: 'tr_1' },
+      data: {
+        detail: detail({ latency_ms: 6911 }),
+        payload: { captured: false },
+        traceId: 'tr_1',
+      },
     });
     const summary = screen.getByTestId('request-summary');
     expect(summary).toHaveTextContent('Production backend'); // key name
@@ -481,7 +489,7 @@ describe('requests detail page', () => {
     expect(summary).toHaveTextContent('gpt-4o'); // requested model
     expect(summary).toHaveTextContent('claude-x'); // served model
     expect(summary).toHaveTextContent('premium'); // lane
-    expect(summary).toHaveTextContent('460ms'); // total latency
+    expect(summary).toHaveTextContent('6.9s'); // total latency
   });
 
   it('falls back to the prefix (and "—") in the summary for an unnamed/legacy record', () => {
@@ -501,12 +509,16 @@ describe('requests detail page', () => {
 
   it('renders the throughput card: true TPS, time-to-first-token, and the generation window', () => {
     render(DetailPage, {
-      data: { detail: detail(), payload: { captured: false }, traceId: 'tr_1' },
+      data: {
+        detail: detail({ ttfb_ms: 11_626, generation_ms: 90_000 }),
+        payload: { captured: false },
+        traceId: 'tr_1',
+      },
     });
     const tp = screen.getByTestId('throughput');
     expect(within(tp).getByTestId('tps')).toHaveTextContent('200 tok/s');
-    expect(within(tp).getByTestId('ttfb')).toHaveTextContent('460ms');
-    expect(within(tp).getByTestId('generation-ms')).toHaveTextContent('1700ms');
+    expect(within(tp).getByTestId('ttfb')).toHaveTextContent('11.6s');
+    expect(within(tp).getByTestId('generation-ms')).toHaveTextContent('1.5min');
   });
 
   it('renders the throughput card as not-measured for a non-streaming request', () => {


### PR DESCRIPTION
## Summary
- add a shared duration formatter for milliseconds, seconds, and minutes
- apply it to every display-only duration across admin pages and dialogs
- preserve explicit units for editable configuration inputs and update localized labels

## Verification
- CI=true corepack pnpm vitest run (10 focused admin test files; 182 tests passed)
- CI=true corepack pnpm --filter @helm/admin check
- CI=true corepack pnpm --filter @helm/admin build
- Prettier check and git diff --check