### PR TITLE
chore(release): v0.27.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump root package version from 0.27.3 to 0.27.4
- release the backward-compatible admin duration-formatting improvement merged in #553

This is intentionally a version-only patch release PR.