### PR TITLE
chore(release): v0.27.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump the root Helm API version from 0.27.4 to 0.27.5
- release the official model-pricing corrections and guarded historical repricing workflow merged in #555

This is intentionally a version-only release PR.