### PR TITLE
fix(build): declare admin shared dependency

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -15,6 +15,9 @@
     "i18n:translate": "./tools/translate-all.sh",
     "i18n:sync": "pnpm i18n:extract && pnpm i18n:update && pnpm i18n:translate"
   },
+  "dependencies": {
+    "@helm/shared": "workspace:*"
+  },
   "devDependencies": {
     "@mylukin/easy-i18n-js": "^0.1.2",
     "@sveltejs/adapter-static": "^3.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,10 @@ importers:
         version: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   apps/admin:
+    dependencies:
+      '@helm/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
     devDependencies:
       '@mylukin/easy-i18n-js':
         specifier: ^0.1.2


### PR DESCRIPTION
## Summary

- declare the Admin app's direct `@helm/shared` workspace dependency
- make `pnpm -r build` schedule Shared before Admin on a clean runner
- update the lockfile importer metadata

## Verification

- reproduced the release CI failure on a clean dependency graph
- `CI=true pnpm build` passed with Shared completing before Admin starts
- `git diff --check` passed

This keeps the v0.27.5 release PR version-only.