### PR TITLE
chore(release): v0.27.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.5",
+  "version": "0.27.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump Helm API from 0.27.5 to 0.27.6
- publish the legacy historical-repricing compatibility fix from #558

## Verification

- feature PR #558 CI is fully green
- version resolves to `0.27.6`
- `git diff --check` passed