### PR TITLE
feat(pricing): add resident historical reprice supervisor

### DIFF
--- a/deploy/systemd/helm-historical-reprice.service
+++ b/deploy/systemd/helm-historical-reprice.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Helm historical pricing reprice supervisor
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/helm-api
+Environment=HELM_REPRICE_CUTOFF=2026-07-15T13:28:46+08:00
+ExecStart=/usr/bin/flock -n /opt/helm-api/data/pricing-reprice-v0.27.5/supervisor.lock /usr/bin/node /opt/helm-api/bin/historical-reprice-supervisor.mjs
+Restart=on-failure
+RestartSec=30
+TimeoutStopSec=120
+KillSignal=SIGTERM
+Nice=10
+IOSchedulingClass=idle
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-15 · 历史费用回填改由常驻 supervisor 持续推进（Catalog / telemetry repair operations，docs/07/08，原则 2/3/5/7）
+
+- **执行边界**：一次性 Codex automation 改为 host systemd 常驻 supervisor；它通过非阻塞 `flock` 保证唯一执行者，并把大阶段拆成每次最多 100 行的独立 CLI 进程。每批提交并落盘 checkpoint 后才进入下一批，因此 SIGTERM、容器短暂不可用或 supervisor 重启都只会从原子 checkpoint 恢复，不需要大事务、整库备份或 `kill -9`。
+- **资源控制**：启动前必须连续取得 3 个有余量样本；运行中持续检查 host load/MemAvailable、Helm CPU/内存、health 延迟、WAL、磁盘、restart/OOM 与结构化 5xx/timeout/`SQLITE_BUSY`。硬阈值触发后 supervisor 留在 `waiting_safety` 并自动重试，不把辅助回填失败扩散为网关故障；每 5,000 行强制至少冷却 5 分钟。固定截止点为 `2026-07-15T13:28:46+08:00`，不追逐持续增长的新流量。
+- **验证与可观测性**：`pricing:reprice` 新增只读 manifest slice verifier，逐批验证 telemetry 顶层总价、attempt completion、breakdown、alias/status/timestamp 全部已成为 manifest new state；窗口完成后再全量验证。supervisor 原子写入 `supervisor.status.json`，记录 phase、窗口/checkpoint、最近指标、费用 delta、错误与备份聚合哈希；Codex 定时任务部署后只读该状态并汇报，不再直接写生产数据库。manifest 仍按 UTC 日窗、`best-evidence`、固定 pricing/plan hash 依次生成，歧义行保持不变。
+
 ## 2026-07-15 · 历史重算兼容旧版 completion-only 顶层费用（Catalog / telemetry repair，docs/07/08，原则 2/5/7）
 
 - **生产根因**：渐进回填在 June 29 manifest 的第 1,580 行 fail-closed；该 legacy telemetry 的 `provider_attempt.cost_usd` 与 `cost_breakdown.completion_usd` 都是 `$0.118735`，`cost_breakdown.total_usd` 是包含输入费用的 `$0.1193894`，但旧版顶层 `telemetry.cost_usd` 仍只保存 completion cost。planner 正确选择 breakdown total 作为 canonical old total，apply guard 却只接受顶层值已等于该 total 的新格式，导致合法旧格式无法应用；剩余 25,269 行只发现 3 行属于此精确形态，且没有其他 unmatched 状态。
@@ -69,18 +75,9 @@
 - **账号边界**：规则完全 plan-agnostic，覆盖 Codex Plus/Pro/Team/Business/Enterprise/Edu 等实际窗口形态，不按套餐名维护分支。Claude 继续使用其 5h/7d keys；Copilot、SuperGrok 与普通 API-key provider 没有可验证的同类 Codex reset-credit 周窗口，不套用本规则或伪造数据。
 - **验证**：共享 predicate、Admin 单周窗口、reset-credit UI、自动重置与持久 guard 均增加 `primary + 10080m` 回归；同时覆盖 `secondary + 300m` 不误判、缺 duration 的 legacy fallback，以及 model-scoped 周窗口隔离。
 
-## 2026-07-12 · Grok premium fallback 与 Composer 评估边界（Routing / provider evaluation，docs/04/07，原则 2/3/5/6/7）
-
-- **移除 official OpenAI 付费 lane 候选**：所有 `openai/gpt-*` 从 shipped lanes 删除，只保留 provider、能力与价格定义供显式 custom-model 使用；GPT vendor lanes 在 Codex subscription 不可用时进入通用订阅/静态 fallback，不再自动触发 official OpenAI 账单。`gpt-image` 改由 ZenMux relay 的 `gpt-image-2` 领衔，official Images API 同样不再被 lane 自动选择。
-- **Vision 订阅限定**：`vision` 改为 Codex Terra → Grok 4.5 → Claude Sonnet 5 → Claude Opus 4.8，全部为订阅 provider；`zenmux-vertex/gemini-3.5-flash` 从该 lane 移除，但 dedicated `gemini-flash` vendor lane 与底层 provider/catalog 保留供显式 Gemini 请求。链使用 concrete aliases，不再隐式展开 `premium`。
-- **路由调整**：`premium` 在 Claude Opus 前加入 `xai/grok-4.5`，使已连接且健康的 SuperGrok 账号吸收原本进入 Opus 的 fallback 流量；未连接、park 或 provider failure 继续 fail-open。Haiku 改为 Anthropic OAuth → economy，不再自动使用 ZenMux Haiku；GPT-5.5 改为 Codex GPT-5.5 → premium，不再自动使用 `zenmux/gpt-5.5`；GPT-5.4 继续由真实 Codex GPT-5.4 领衔。`zenmux-anthropic/claude-opus-4.8` 同样只从 lanes 移除，所有被移除的 provider/catalog 定义仍保留供显式调用。
-- **Composer 边界**：真实 A/B 暴露 200 + stop + 空正文与质量不足后，不进入 economy，也不再保留独立 canary lane；底层 OAuth 模型发现与 transport 兼容仍保留，避免把一次路由决策扩大成 provider 协议删除。
-- **真实 A/B**：本地 Docker 使用同一账号、总并发 2，Composer 与 Grok 4.5 各执行 30 个相同任务，覆盖 exact/factual/coding/long-context/speed/tool。Composer HTTP/模型命中 30/30、SSE `[DONE]` 30/30、工具参数 4/4、长上下文 6/6、长输出 TPS 中位数约 197，但事实仅 2/5、编码仅 1/4，6 次出现 200 + stop + 空正文，总质量 24/30（80%），可见 TTFT p95 约 1.59s；未达到 economy 晋升门槛。Grok 4.5 模型命中 29/30、质量 28/30、工具 4/4、长上下文 6/6、长输出 TPS 中位数约 138，但出现一次 504，成功率 96.7%、可见 TTFT p95 约 22.9s；速度达标但可靠性未达到 99%，因此只保留 premium fallback，不进入 balanced 或 primary。
-- **Docker 证据**：授权恢复后账号 `healthy:true` 且同时发现 `grok-4.5` / `grok-composer-2.5-fast`，真实 quota PULL 返回 `7d` 周窗口；三条预检分别真实命中 Composer、direct Grok 和 premium→Grok。授权前 premium 的 Grok 候选以 `provider_unavailable` 跳过并继续由 ZenMux Opus 成功，证明未连接边界 fail-open。测试 key 已全部禁用；容器限制 2 CPU / 2 GiB，结束时 healthy、restartCount 0。
-- **Lanes 模型选择器修复**：xAI 自动模式虽然能通过账号发现参与真实路由，但网络无关的 `/admin/api/models` 投影缺少 xAI picker fallback，导致选择器无 `xai/*` 建议。现将已验证的 `grok-4.5` 与 `grok-composer-2.5-fast` 加入仅供已绑定账号使用的 Admin 投影 fallback；它刻意不进入 core `CURATED_OAUTH_MODELS`，所以真实路由在 xAI `/models` entitlement 发现失败时仍 fail-closed。手动模式可按账号缩窄 allowlist，未连接账号不会凭空出现。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-12 · Grok premium fallback 与 Composer 评估边界（Routing / provider evaluation，docs/04/07，原则 2/3/5/6/7）**：移除 official OpenAI/ZenMux 自动付费候选，premium 以已验证的 SuperGrok Grok 4.5 作为订阅 fallback；Composer 因真实 A/B 的空响应与质量不足不进 lane，底层 transport/发现保留，xAI Admin 选择器补 curated 展示但运行时 entitlement 继续 fail-closed。
 - **2026-07-12 · SuperGrok 周配额使用现有 OAuth 读取私有 gRPC-Web credits（OAuth subscription / Admin providers，docs/04/09/11，原则 3/6/7）**：复用现有 xAI OAuth bearer 严格读取 weekly gRPC-Web credits，按账号持久化 quota/cooldown 并以 cache epoch 隔离重连竞态；不保存 Cookie、不混用月度/public billing。
 - **2026-07-12 · SuperGrok/X Premium OAuth 实验性订阅 Provider（OAuth subscription / Responses / Admin providers，docs/04/09/10/11，原则 2/3/6/7/8）**：通过受限 device-code OAuth、加密 token、generic Responses executor 与严格 host/redirect/body-size 边界接入实验性 SuperGrok；动态 entitlement、SSE 聚合、Admin 状态及真实协议矩阵完成验证，Composer 保持 unpriced，Grok 4.5 后续按公开 API 等价费率计 telemetry。
 - **2026-07-11 · 上下文链耗尽恢复 Claude CLI 自动压缩信号（Provider execution / protocol errors，docs/04/05/07，原则 3/5/7/8）**：候选级 context overflow 继续 fail-open fallback；仅上下文/能力 skip 的整链耗尽统一返回 Claude CLI 可识别的 `invalid_request / 400` 与精确 token 上限消息，混合真实 provider failure 保留原分类。

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "pnpm --filter @helm/admin dev",
     "dev:admin": "pnpm --filter @helm/admin dev",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm -r typecheck && pnpm typecheck:ops",
+    "typecheck:ops": "tsc --noEmit -p scripts/ops/tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "pnpm --filter @helm/gateway test:e2e",
@@ -19,7 +20,8 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "lint:fix": "biome check --write .",
-    "build": "pnpm -r build",
+    "build": "pnpm -r build && pnpm build:ops",
+    "build:ops": "esbuild scripts/ops/historical-reprice-supervisor.ts --bundle --platform=node --target=node22 --format=esm --outfile=dist/ops/historical-reprice-supervisor.mjs",
     "i18n:extract": "pnpm --filter @helm/admin i18n:extract",
     "i18n:update": "pnpm --filter @helm/admin i18n:update",
     "i18n:translate": "pnpm --filter @helm/admin i18n:translate",
@@ -44,6 +46,7 @@
     "@types/node": "^22.10.0",
     "@vitest/coverage-v8": "^3.2.4",
     "c8": "^11.0.0",
+    "esbuild": "^0.27.7",
     "tsx": "^4.22.3",
     "typescript": "^5.7.0",
     "vitest": "^3.2.4"

--- a/packages/core/src/store/sqlite/historical-cost-reprice.test.ts
+++ b/packages/core/src/store/sqlite/historical-cost-reprice.test.ts
@@ -8,6 +8,7 @@ import {
   applyHistoricalCostReprice,
   applyHistoricalCostRepriceManifest,
   planHistoricalCostReprice,
+  verifyHistoricalCostRepriceManifest,
 } from "./historical-cost-reprice.js";
 
 const dirs: string[] = [];
@@ -457,6 +458,65 @@ describe("historical cost repricing", () => {
           backup.close();
         }
       }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("verifies only the requested applied manifest slice without mutating telemetry", () => {
+    const db = openFixture();
+    const dir = mkdtempSync(join(tmpdir(), "helm-cost-reprice-verify-"));
+    dirs.push(dir);
+    try {
+      const alias = "anthropic/claude-sonnet-5";
+      for (let index = 0; index < 3; index += 1) {
+        insertTelemetry(db, { requestId: `verify-${index}`, alias });
+      }
+      const manifest = planHistoricalCostReprice(
+        db,
+        new Map([
+          [
+            alias,
+            catalogEntry(alias, {
+              inputPerMTokUsd: 2,
+              outputPerMTokUsd: 10,
+              cacheReadPerMTokUsd: 0.2,
+              cacheWritePerMTokUsd: 2.5,
+              cacheWrite1hPerMTokUsd: 4,
+            }),
+          ],
+        ]),
+        "pricing-sha",
+        { fromMs: 0, toMs: 10_000_000 },
+      );
+
+      expect(() =>
+        verifyHistoricalCostRepriceManifest(db, manifest, {
+          startRowIndex: 0,
+          endRowIndex: 1,
+        }),
+      ).toThrow("manifest row is not applied");
+
+      applyHistoricalCostRepriceManifest(db, manifest, {
+        checkpointPath: join(dir, "progress.json"),
+        backupDir: join(dir, "backups"),
+        batchSize: 2,
+        maxBatches: 1,
+        batchDelayMs: 0,
+      });
+
+      expect(
+        verifyHistoricalCostRepriceManifest(db, manifest, {
+          startRowIndex: 0,
+          endRowIndex: 2,
+        }),
+      ).toEqual({ verifiedRows: 2, totalUsd: expect.any(Number) });
+      expect(() =>
+        verifyHistoricalCostRepriceManifest(db, manifest, {
+          startRowIndex: 0,
+          endRowIndex: 3,
+        }),
+      ).toThrow("manifest row is not applied");
     } finally {
       db.close();
     }

--- a/packages/core/src/store/sqlite/historical-cost-reprice.ts
+++ b/packages/core/src/store/sqlite/historical-cost-reprice.ts
@@ -138,6 +138,11 @@ export interface HistoricalCostRepriceManifest {
   planSha256: string;
 }
 
+export interface HistoricalCostRepriceVerification {
+  verifiedRows: number;
+  totalUsd: number;
+}
+
 interface DecisionAttempt extends Record<string, unknown> {
   alias?: unknown;
   skipped?: unknown;
@@ -993,6 +998,41 @@ function sleep(milliseconds: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
+export function verifyHistoricalCostRepriceManifest(
+  db: Database.Database,
+  manifest: HistoricalCostRepriceManifest,
+  options: { startRowIndex?: number; endRowIndex?: number } = {},
+): HistoricalCostRepriceVerification {
+  validateManifest(manifest);
+  const startRowIndex = positiveInteger(options.startRowIndex ?? 0, "startRowIndex", true);
+  const endRowIndex = positiveInteger(
+    options.endRowIndex ?? manifest.rows.length,
+    "endRowIndex",
+    true,
+  );
+  if (endRowIndex < startRowIndex || endRowIndex > manifest.rows.length) {
+    throw new Error(
+      `invalid verification range: ${startRowIndex}..${endRowIndex} of ${manifest.rows.length}`,
+    );
+  }
+
+  const readTelemetry = db.prepare(
+    "SELECT decision_json, cost_usd, created_at FROM telemetry WHERE request_id = ?",
+  );
+  let totalUsd = 0;
+  for (let index = startRowIndex; index < endRowIndex; index += 1) {
+    const row = manifest.rows[index];
+    if (row === undefined) throw new Error(`manifest row disappeared at index ${index}`);
+    const current = readTelemetry.get(row.requestId) as CurrentTelemetryRow | undefined;
+    if (current === undefined) throw new Error(`telemetry row disappeared: ${row.requestId}`);
+    if (plannedRowState(current, row) !== "new") {
+      throw new Error(`manifest row is not applied: ${row.requestId}`);
+    }
+    totalUsd += current.cost_usd ?? 0;
+  }
+  return { verifiedRows: endRowIndex - startRowIndex, totalUsd };
+}
+
 export function applyHistoricalCostRepriceManifest(
   db: Database.Database,
   manifest: HistoricalCostRepriceManifest,
@@ -1125,7 +1165,10 @@ interface CliArgs {
   toMs?: number;
   mode: HistoricalCostRepriceMode;
   applyManifest?: string;
+  verifyManifest?: string;
   expectedPlanSha256?: string;
+  startRowIndex?: number;
+  endRowIndex?: number;
   manifest?: string;
   checkpoint?: string;
   backupDir?: string;
@@ -1147,7 +1190,10 @@ function parseCliArgs(argv: string[]): CliArgs {
     "--to-ms",
     "--mode",
     "--apply-manifest",
+    "--verify-manifest",
     "--expected-plan-sha256",
+    "--start-row-index",
+    "--end-row-index",
     "--manifest",
     "--checkpoint",
     "--backup-dir",
@@ -1185,8 +1231,15 @@ function parseCliArgs(argv: string[]): CliArgs {
     throw new Error("one-shot --apply is disabled; use --apply-manifest with bounded batches");
   }
   const applyManifest = values.get("--apply-manifest");
+  const verifyManifest = values.get("--verify-manifest");
+  if (applyManifest !== undefined && verifyManifest !== undefined) {
+    throw new Error("--apply-manifest and --verify-manifest are mutually exclusive");
+  }
   if (applyManifest !== undefined && (flags.has("--apply") || flags.has("--dry-run"))) {
     throw new Error("--apply-manifest cannot be combined with --apply or --dry-run");
+  }
+  if (verifyManifest !== undefined && (flags.has("--apply") || flags.has("--dry-run"))) {
+    throw new Error("--verify-manifest cannot be combined with --apply or --dry-run");
   }
   if (
     applyManifest !== undefined &&
@@ -1198,9 +1251,16 @@ function parseCliArgs(argv: string[]): CliArgs {
   if (applyManifest !== undefined && values.get("--expected-plan-sha256") === undefined) {
     throw new Error("--apply-manifest requires --expected-plan-sha256");
   }
+  if (verifyManifest !== undefined && values.get("--expected-plan-sha256") === undefined) {
+    throw new Error("--verify-manifest requires --expected-plan-sha256");
+  }
   const fromMs = values.get("--from-ms");
   const toMs = values.get("--to-ms");
-  if (applyManifest === undefined && (fromMs === undefined || toMs === undefined)) {
+  if (
+    applyManifest === undefined &&
+    verifyManifest === undefined &&
+    (fromMs === undefined || toMs === undefined)
+  ) {
     throw new Error("dry-run and one-shot apply require --from-ms and --to-ms");
   }
   return {
@@ -1210,8 +1270,15 @@ function parseCliArgs(argv: string[]): CliArgs {
     ...(toMs !== undefined ? { toMs: Number(toMs) } : {}),
     mode,
     ...(applyManifest !== undefined ? { applyManifest: resolve(applyManifest) } : {}),
+    ...(verifyManifest !== undefined ? { verifyManifest: resolve(verifyManifest) } : {}),
     ...(values.get("--expected-plan-sha256") !== undefined
       ? { expectedPlanSha256: values.get("--expected-plan-sha256") }
+      : {}),
+    ...(values.get("--start-row-index") !== undefined
+      ? { startRowIndex: Number(values.get("--start-row-index")) }
+      : {}),
+    ...(values.get("--end-row-index") !== undefined
+      ? { endRowIndex: Number(values.get("--end-row-index")) }
       : {}),
     ...(values.get("--manifest") !== undefined
       ? { manifest: resolve(values.get("--manifest") ?? "") }
@@ -1286,6 +1353,32 @@ if (!response.ok) throw new Error(\`health endpoint returned \${response.status}
         ...(healthCheck !== undefined ? { healthCheck } : {}),
       });
       process.stdout.write(`${JSON.stringify(checkpoint, null, 2)}\n`);
+      return;
+    }
+
+    if (args.verifyManifest !== undefined) {
+      if (args.manifest !== undefined) {
+        throw new Error("--manifest is only an output path for dry-run planning");
+      }
+      const manifest = JSON.parse(
+        readFileSync(args.verifyManifest, "utf8"),
+      ) as HistoricalCostRepriceManifest;
+      validateManifest(manifest);
+      if (manifest.planSha256 !== args.expectedPlanSha256) {
+        throw new Error(
+          `plan hash mismatch: expected ${args.expectedPlanSha256 ?? ""}, got ${manifest.planSha256}`,
+        );
+      }
+      if (manifest.pricingSha256 !== pricingSha256) {
+        throw new Error(
+          `pricing hash mismatch: manifest ${manifest.pricingSha256}, current ${pricingSha256}`,
+        );
+      }
+      const verification = verifyHistoricalCostRepriceManifest(db, manifest, {
+        ...(args.startRowIndex !== undefined ? { startRowIndex: args.startRowIndex } : {}),
+        ...(args.endRowIndex !== undefined ? { endRowIndex: args.endRowIndex } : {}),
+      });
+      process.stdout.write(`${JSON.stringify(verification, null, 2)}\n`);
       return;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       c8:
         specifier: ^11.0.0
         version: 11.0.0
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
       tsx:
         specifier: ^4.22.3
         version: 4.22.3
@@ -38,118 +41,6 @@ importers:
       '@helm/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-    devDependencies:
-      '@mylukin/easy-i18n-js':
-        specifier: ^0.1.2
-        version: 0.1.2(svelte@5.56.0)
-      '@sveltejs/adapter-static':
-        specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.0)(typescript@5.9.3)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)))
-      '@sveltejs/kit':
-        specifier: ^2.61.1
-        version: 2.61.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.0)(typescript@5.9.3)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
-      '@sveltejs/vite-plugin-svelte':
-        specifier: ^6.2.4
-        version: 6.2.4(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
-      '@tailwindcss/vite':
-        specifier: ^4.3.0
-        version: 4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
-      '@testing-library/jest-dom':
-        specifier: ^6.9.1
-        version: 6.9.1
-      '@testing-library/svelte':
-        specifier: ^5.3.1
-        version: 5.3.1(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@3.2.4(@types/node@22.19.19)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
-      '@testing-library/user-event':
-        specifier: ^14.6.1
-        version: 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/coverage-v8':
-        specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.19)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
-      jsdom:
-        specifier: ^25.0.1
-        version: 25.0.1
-      layerchart:
-        specifier: ^1.0.13
-        version: 1.0.13(svelte@5.56.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
-      postcss:
-        specifier: ^8.5.15
-        version: 8.5.15
-      prettier:
-        specifier: ^3.4.0
-        version: 3.8.3
-      prettier-plugin-svelte:
-        specifier: ^3.4.0
-        version: 3.5.2(prettier@3.8.3)(svelte@5.56.0)
-      svelte:
-        specifier: ^5.56.0
-        version: 5.56.0
-      svelte-check:
-        specifier: ^4.4.8
-        version: 4.4.8(picomatch@4.0.4)(svelte@5.56.0)(typescript@5.9.3)
-      tailwindcss:
-        specifier: ^4.3.0
-        version: 4.3.0
-      tslib:
-        specifier: ^2.8.0
-        version: 2.8.1
-      typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
-      vite:
-        specifier: ^7.3.3
-        version: 7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.19)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
-
-  apps/gateway:
-    dependencies:
-      '@helm/core':
-        specifier: workspace:*
-        version: link:../../packages/core
-      '@helm/shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
-      '@hono/node-server':
-        specifier: ^2.0.4
-        version: 2.0.4(hono@4.12.23)
-      '@hono/swagger-ui':
-        specifier: ^0.6.1
-        version: 0.6.1(hono@4.12.23)
-      hono:
-        specifier: ^4.12.23
-        version: 4.12.23
-      https-proxy-agent:
-        specifier: ^9.1.0
-        version: 9.1.0
-      socks-proxy-agent:
-        specifier: ^10.1.0
-        version: 10.1.0
-      undici:
-        specifier: ^8.3.0
-        version: 8.3.0
-      ws:
-        specifier: ^8.21.0
-        version: 8.21.0
-      yaml:
-        specifier: ^2.9.0
-        version: 2.9.0
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
-    devDependencies:
-      '@playwright/test':
-        specifier: ^1.60.0
-        version: 1.60.0
-      '@types/ws':
-        specifier: ^8.18.1
-        version: 8.18.1
-      tsx:
-        specifier: ^4.22.3
-        version: 4.22.3
-
-  apps/portal:
     devDependencies:
       '@mylukin/easy-i18n-js':
         specifier: ^0.1.2
@@ -214,6 +105,118 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.19)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+
+  apps/gateway:
+    dependencies:
+      '@helm/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@helm/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@hono/node-server':
+        specifier: ^2.0.4
+        version: 2.0.4(hono@4.12.23)
+      '@hono/swagger-ui':
+        specifier: ^0.6.1
+        version: 0.6.1(hono@4.12.23)
+      hono:
+        specifier: ^4.12.23
+        version: 4.12.23
+      https-proxy-agent:
+        specifier: ^9.1.0
+        version: 9.1.0
+      socks-proxy-agent:
+        specifier: ^10.1.0
+        version: 10.1.0
+      undici:
+        specifier: ^8.3.0
+        version: 8.3.0
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
+
+  apps/portal:
+    devDependencies:
+      '@mylukin/easy-i18n-js':
+        specifier: ^0.1.2
+        version: 0.1.2(svelte@5.56.0)
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.10
+        version: 3.0.10(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.0)(typescript@5.9.3)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)))
+      '@sveltejs/kit':
+        specifier: ^2.61.1
+        version: 2.61.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.0)(typescript@5.9.3)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^6.2.4
+        version: 6.2.4(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.56.0)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@3.2.4(@types/node@22.19.19)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.19)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      layerchart:
+        specifier: ^1.0.13
+        version: 1.0.13(svelte@5.56.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
+      postcss:
+        specifier: ^8.5.15
+        version: 8.5.15
+      prettier:
+        specifier: ^3.4.0
+        version: 3.8.3
+      prettier-plugin-svelte:
+        specifier: ^3.4.0
+        version: 3.5.2(prettier@3.8.3)(svelte@5.56.0)
+      svelte:
+        specifier: ^5.56.0
+        version: 5.56.0
+      svelte-check:
+        specifier: ^4.4.8
+        version: 4.4.8(picomatch@4.0.4)(svelte@5.56.0)(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      tslib:
+        specifier: ^2.8.0
+        version: 2.8.1
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.3
+        version: 7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.19)(jiti@1.21.7)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/core:
     dependencies:

--- a/scripts/ops/historical-reprice-supervisor.test.ts
+++ b/scripts/ops/historical-reprice-supervisor.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SUPERVISOR_THRESHOLDS,
+  buildUtcWindows,
+  evaluatePreflight,
+  evaluateRuntimeSafety,
+  parseStructuredLogSignals,
+  type SupervisorSample,
+} from "./historical-reprice-supervisor.js";
+
+function healthySample(overrides: Partial<SupervisorSample> = {}): SupervisorSample {
+  return {
+    capturedAt: "2026-07-15T00:00:00.000Z",
+    load1: 0.4,
+    memAvailableBytes: 900 * 1024 ** 2,
+    helmCpuPercent: 20,
+    helmMemoryPercent: 40,
+    healthStatus: 200,
+    healthLatencyMs: 40,
+    walBytes: 100 * 1024 ** 2,
+    diskFreeBytes: 20 * 1024 ** 3,
+    restarts: 0,
+    oomKilled: false,
+    fiveXx: 0,
+    timeouts: 0,
+    sqliteBusy: 0,
+    ...overrides,
+  };
+}
+
+describe("historical reprice supervisor", () => {
+  it("builds chronological UTC windows and clamps the final partial day", () => {
+    const windows = buildUtcWindows(
+      Date.parse("2026-06-30T00:00:00Z"),
+      Date.parse("2026-07-02T05:28:46Z"),
+    );
+
+    expect(windows).toEqual([
+      {
+        name: "2026-06-30",
+        fromMs: Date.parse("2026-06-30T00:00:00Z"),
+        toMs: Date.parse("2026-07-01T00:00:00Z"),
+      },
+      {
+        name: "2026-07-01",
+        fromMs: Date.parse("2026-07-01T00:00:00Z"),
+        toMs: Date.parse("2026-07-02T00:00:00Z"),
+      },
+      {
+        name: "2026-07-02",
+        fromMs: Date.parse("2026-07-02T00:00:00Z"),
+        toMs: Date.parse("2026-07-02T05:28:46Z"),
+      },
+    ]);
+  });
+
+  it("requires three clean headroom samples before starting", () => {
+    expect(evaluatePreflight([healthySample(), healthySample()])).toEqual({
+      safe: false,
+      reasons: ["need 3 preflight samples, got 2"],
+    });
+
+    expect(evaluatePreflight([healthySample(), healthySample(), healthySample()])).toEqual({
+      safe: true,
+      reasons: [],
+    });
+
+    const lowMemory = healthySample({ memAvailableBytes: 767 * 1024 ** 2 });
+    const result = evaluatePreflight([healthySample(), lowMemory, healthySample()]);
+    expect(result.safe).toBe(false);
+    expect(result.reasons).toContain("sample 2: available memory below 768 MiB");
+  });
+
+  it("stops immediately on hard limits and only on sustained CPU or health latency", () => {
+    const initial = { highCpuSamples: 0, slowHealthSamples: 0, baselineRestarts: 0 };
+    const firstCpu = evaluateRuntimeSafety(healthySample({ helmCpuPercent: 65 }), initial);
+    expect(firstCpu.stop).toBe(false);
+    expect(firstCpu.state.highCpuSamples).toBe(1);
+
+    const secondCpu = evaluateRuntimeSafety(
+      healthySample({ helmCpuPercent: 61 }),
+      firstCpu.state,
+    );
+    expect(secondCpu.stop).toBe(true);
+    expect(secondCpu.reasons).toContain("Helm CPU sustained at or above 60%");
+
+    const firstSlow = evaluateRuntimeSafety(healthySample({ healthLatencyMs: 700 }), initial);
+    expect(firstSlow.stop).toBe(false);
+    const secondSlow = evaluateRuntimeSafety(
+      healthySample({ healthLatencyMs: 550 }),
+      firstSlow.state,
+    );
+    expect(secondSlow.reasons).toContain("health latency consecutively above 500 ms");
+
+    const lowMemory = evaluateRuntimeSafety(
+      healthySample({ memAvailableBytes: 639 * 1024 ** 2 }),
+      initial,
+    );
+    expect(lowMemory.stop).toBe(true);
+    expect(lowMemory.reasons).toContain("available memory below 640 MiB");
+  });
+
+  it("parses structured failures without mistaking trace identifiers for status codes", () => {
+    const signals = parseStructuredLogSignals(
+      [
+        JSON.stringify({ status: 200, trace_id: "trace-502-timeout" }),
+        JSON.stringify({ http_status: 502, message: "request.error" }),
+        JSON.stringify({ status: 503, message: "request.completed" }),
+        JSON.stringify({ message: "stream.truncated", error_class: "timeout" }),
+        JSON.stringify({ message: "write failed", error_class: "SQLITE_BUSY" }),
+        "not-json",
+      ].join("\n"),
+    );
+
+    expect(signals).toEqual({ fiveXx: 2, timeouts: 1, sqliteBusy: 1 });
+  });
+
+  it("keeps production stop thresholds stricter than CLI hard limits", () => {
+    expect(DEFAULT_SUPERVISOR_THRESHOLDS.preflightWalBytes).toBeLessThan(
+      DEFAULT_SUPERVISOR_THRESHOLDS.stopWalBytes,
+    );
+    expect(DEFAULT_SUPERVISOR_THRESHOLDS.preflightDiskBytes).toBeGreaterThan(
+      DEFAULT_SUPERVISOR_THRESHOLDS.stopDiskBytes,
+    );
+  });
+});

--- a/scripts/ops/historical-reprice-supervisor.ts
+++ b/scripts/ops/historical-reprice-supervisor.ts
@@ -1,0 +1,930 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statfsSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIB = 1024 ** 2;
+const GIB = 1024 ** 3;
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+export interface SupervisorSample {
+  capturedAt: string;
+  load1: number;
+  memAvailableBytes: number;
+  helmCpuPercent: number;
+  helmMemoryPercent: number;
+  healthStatus: number;
+  healthLatencyMs: number;
+  walBytes: number;
+  diskFreeBytes: number;
+  restarts: number;
+  oomKilled: boolean;
+  fiveXx: number;
+  timeouts: number;
+  sqliteBusy: number;
+}
+
+export interface SupervisorThresholds {
+  preflightLoad1: number;
+  preflightMemBytes: number;
+  preflightCpuPercent: number;
+  preflightHelmMemoryPercent: number;
+  preflightHealthMs: number;
+  preflightWalBytes: number;
+  preflightDiskBytes: number;
+  stopLoad1: number;
+  stopMemBytes: number;
+  stopCpuPercent: number;
+  stopHelmMemoryPercent: number;
+  stopHealthMs: number;
+  stopWalBytes: number;
+  stopDiskBytes: number;
+}
+
+export const DEFAULT_SUPERVISOR_THRESHOLDS: SupervisorThresholds = {
+  preflightLoad1: 1.2,
+  preflightMemBytes: 768 * MIB,
+  preflightCpuPercent: 50,
+  preflightHelmMemoryPercent: 55,
+  preflightHealthMs: 300,
+  preflightWalBytes: 384 * MIB,
+  preflightDiskBytes: 14 * GIB,
+  stopLoad1: 1.5,
+  stopMemBytes: 640 * MIB,
+  stopCpuPercent: 60,
+  stopHelmMemoryPercent: 60,
+  stopHealthMs: 500,
+  stopWalBytes: 512 * MIB,
+  stopDiskBytes: 12 * GIB,
+};
+
+export interface RuntimeSafetyState {
+  highCpuSamples: number;
+  slowHealthSamples: number;
+  baselineRestarts: number;
+}
+
+export interface HistoricalWindow {
+  name: string;
+  fromMs: number;
+  toMs: number;
+}
+
+interface ManifestRow {
+  oldTotalUsd: number | null;
+  newTotalUsd: number;
+}
+
+interface RepriceManifest {
+  version: 1;
+  mode: "best-evidence" | "exact";
+  fromMs: number;
+  toMs: number;
+  pricingSha256: string;
+  eligible: number;
+  unchanged: number;
+  skipped: number;
+  totals: {
+    oldTotalUsd: number;
+    newTotalUsd: number;
+  };
+  rows: ManifestRow[];
+  planSha256: string;
+}
+
+interface RepriceCheckpoint {
+  version: 1;
+  planSha256: string;
+  pricingSha256: string;
+  totalRows: number;
+  nextRowIndex: number;
+  appliedRows: number;
+  alreadyAppliedRows: number;
+  batchesApplied: number;
+  completed: boolean;
+  lastBatch: {
+    startRowIndex: number;
+    endRowIndex: number;
+    mutatedRows: number;
+    alreadyAppliedRows: number;
+    oauthBucketsUpdated: number;
+    backupPath: string | null;
+  } | null;
+}
+
+interface SupervisorConfig {
+  container: string;
+  hostDatabasePath: string;
+  containerDatabasePath: string;
+  containerPricingPath: string;
+  hostStateDir: string;
+  containerStateDir: string;
+  statusPath: string;
+  startMs: number;
+  cutoffMs: number;
+  sampleIntervalMs: number;
+  unsafePollMs: number;
+  batchDelayMs: number;
+  cooldownMs: number;
+  maxStageBatches: number;
+  thresholds: SupervisorThresholds;
+}
+
+interface SupervisorStatus {
+  version: 1;
+  phase: "starting" | "waiting_safety" | "planning" | "applying" | "cooling" | "complete";
+  updatedAt: string;
+  startedAt: string;
+  activeWindow: string | null;
+  checkpoint: { nextRowIndex: number; totalRows: number; completed: boolean } | null;
+  stageBatches: number;
+  completedWindows: number;
+  totalWindows: number;
+  sample: SupervisorSample | null;
+  reasons: string[];
+  lastError: string | null;
+  totals: {
+    appliedOldUsd: number;
+    appliedNewUsd: number;
+    appliedDeltaUsd: number;
+  } | null;
+  backupAggregateSha256: string | null;
+}
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+function finiteNumber(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number`);
+  }
+  return value;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function percent(value: string, name: string): number {
+  const parsed = Number(value.trim().replace(/%$/, ""));
+  if (!Number.isFinite(parsed)) throw new Error(`invalid ${name}: ${value}`);
+  return parsed;
+}
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.length === 0) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) throw new Error(`invalid ${name}: ${raw}`);
+  return parsed;
+}
+
+function parseTimestamp(value: string, name: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(`invalid ${name}: ${value}`);
+  return parsed;
+}
+
+export function buildUtcWindows(startMs: number, cutoffMs: number): HistoricalWindow[] {
+  if (!Number.isSafeInteger(startMs) || !Number.isSafeInteger(cutoffMs) || cutoffMs <= startMs) {
+    throw new Error(`invalid historical window range: ${startMs}..${cutoffMs}`);
+  }
+  const windows: HistoricalWindow[] = [];
+  for (let fromMs = startMs; fromMs < cutoffMs; fromMs += DAY_MS) {
+    const midnight = new Date(fromMs);
+    if (
+      midnight.getUTCHours() !== 0 ||
+      midnight.getUTCMinutes() !== 0 ||
+      midnight.getUTCSeconds() !== 0 ||
+      midnight.getUTCMilliseconds() !== 0
+    ) {
+      throw new Error("historical window start must be UTC midnight");
+    }
+    windows.push({
+      name: midnight.toISOString().slice(0, 10),
+      fromMs,
+      toMs: Math.min(fromMs + DAY_MS, cutoffMs),
+    });
+  }
+  return windows;
+}
+
+export function evaluatePreflight(
+  samples: readonly SupervisorSample[],
+  thresholds = DEFAULT_SUPERVISOR_THRESHOLDS,
+): { safe: boolean; reasons: string[] } {
+  if (samples.length !== 3) {
+    return { safe: false, reasons: [`need 3 preflight samples, got ${samples.length}`] };
+  }
+  const reasons: string[] = [];
+  const baselineRestarts = samples[0]?.restarts ?? 0;
+  for (const [index, sample] of samples.entries()) {
+    const prefix = `sample ${index + 1}: `;
+    if (sample.load1 >= thresholds.preflightLoad1) {
+      reasons.push(`${prefix}load1 at or above ${thresholds.preflightLoad1}`);
+    }
+    if (sample.memAvailableBytes < thresholds.preflightMemBytes) {
+      reasons.push(`${prefix}available memory below 768 MiB`);
+    }
+    if (sample.helmCpuPercent >= thresholds.preflightCpuPercent) {
+      reasons.push(`${prefix}Helm CPU at or above 50%`);
+    }
+    if (sample.helmMemoryPercent >= thresholds.preflightHelmMemoryPercent) {
+      reasons.push(`${prefix}Helm memory at or above 55%`);
+    }
+    if (sample.healthStatus !== 200 || sample.healthLatencyMs >= thresholds.preflightHealthMs) {
+      reasons.push(`${prefix}health is not 200 below 300 ms`);
+    }
+    if (sample.walBytes >= thresholds.preflightWalBytes) {
+      reasons.push(`${prefix}WAL at or above 384 MiB`);
+    }
+    if (sample.diskFreeBytes <= thresholds.preflightDiskBytes) {
+      reasons.push(`${prefix}disk free at or below 14 GiB`);
+    }
+    if (sample.restarts !== baselineRestarts) reasons.push(`${prefix}restart count changed`);
+    if (sample.oomKilled) reasons.push(`${prefix}OOM flag is set`);
+    if (sample.fiveXx > 0) reasons.push(`${prefix}new 5xx detected`);
+    if (sample.timeouts > 0) reasons.push(`${prefix}new timeout detected`);
+    if (sample.sqliteBusy > 0) reasons.push(`${prefix}new SQLITE_BUSY detected`);
+  }
+  return { safe: reasons.length === 0, reasons };
+}
+
+export function evaluateRuntimeSafety(
+  sample: SupervisorSample,
+  previous: RuntimeSafetyState,
+  thresholds = DEFAULT_SUPERVISOR_THRESHOLDS,
+): { stop: boolean; reasons: string[]; state: RuntimeSafetyState } {
+  const state = {
+    highCpuSamples:
+      sample.helmCpuPercent >= thresholds.stopCpuPercent ? previous.highCpuSamples + 1 : 0,
+    slowHealthSamples:
+      sample.healthLatencyMs > thresholds.stopHealthMs ? previous.slowHealthSamples + 1 : 0,
+    baselineRestarts: previous.baselineRestarts,
+  };
+  const reasons: string[] = [];
+  if (sample.load1 >= thresholds.stopLoad1) reasons.push("load1 at or above 1.5");
+  if (sample.memAvailableBytes < thresholds.stopMemBytes) {
+    reasons.push("available memory below 640 MiB");
+  }
+  if (sample.helmMemoryPercent >= thresholds.stopHelmMemoryPercent) {
+    reasons.push("Helm memory at or above 60%");
+  }
+  if (state.highCpuSamples >= 2) reasons.push("Helm CPU sustained at or above 60%");
+  if (sample.healthStatus !== 200) reasons.push("health returned non-200");
+  if (state.slowHealthSamples >= 2) {
+    reasons.push("health latency consecutively above 500 ms");
+  }
+  if (sample.walBytes >= thresholds.stopWalBytes) reasons.push("WAL at or above 512 MiB");
+  if (sample.diskFreeBytes < thresholds.stopDiskBytes) reasons.push("disk free below 12 GiB");
+  if (sample.restarts !== previous.baselineRestarts) reasons.push("restart count changed");
+  if (sample.oomKilled) reasons.push("OOM flag is set");
+  if (sample.fiveXx > 0) reasons.push("new 5xx detected");
+  if (sample.timeouts > 0) reasons.push("new timeout detected");
+  if (sample.sqliteBusy > 0) reasons.push("new SQLITE_BUSY detected");
+  return { stop: reasons.length > 0, reasons, state };
+}
+
+export function parseStructuredLogSignals(text: string): {
+  fiveXx: number;
+  timeouts: number;
+  sqliteBusy: number;
+} {
+  let fiveXx = 0;
+  let timeouts = 0;
+  let sqliteBusy = 0;
+  for (const line of text.split("\n")) {
+    if (line.trim().length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const body = record(parsed);
+    if (body === null) continue;
+    const rawStatus = body.status ?? body.http_status ?? body.status_code;
+    const status = typeof rawStatus === "number" ? rawStatus : Number(rawStatus);
+    if (Number.isFinite(status) && status >= 500 && status < 600) fiveXx += 1;
+    const selectedText = [body.message, body.error_class, body.error]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ")
+      .toLowerCase();
+    if (/timeout|timed out/.test(selectedText)) timeouts += 1;
+    if (/sqlite_busy|database is locked/.test(selectedText)) sqliteBusy += 1;
+  }
+  return { fiveXx, timeouts, sqliteBusy };
+}
+
+function runCommand(
+  file: string,
+  args: readonly string[],
+  options: { timeoutMs?: number; maxBuffer?: number } = {},
+): Promise<CommandResult> {
+  return new Promise((resolvePromise, reject) => {
+    execFile(
+      file,
+      [...args],
+      {
+        encoding: "utf8",
+        timeout: options.timeoutMs ?? 60_000,
+        maxBuffer: options.maxBuffer ?? 32 * MIB,
+      },
+      (error, stdout, stderr) => {
+        if (error !== null) {
+          reject(
+            new Error(
+              `${file} ${args.join(" ")} failed: ${stderr.trim() || error.message}`,
+              { cause: error },
+            ),
+          );
+          return;
+        }
+        resolvePromise({ stdout, stderr });
+      },
+    );
+  });
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+}
+
+function atomicWriteJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.tmp-${process.pid}`;
+  writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { flag: "w" });
+  renameSync(temporaryPath, path);
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function parseManifest(path: string, window: HistoricalWindow): RepriceManifest {
+  const body = record(readJson(path));
+  if (body === null || body.version !== 1 || !Array.isArray(body.rows)) {
+    throw new Error(`invalid reprice manifest: ${path}`);
+  }
+  const manifest = body as unknown as RepriceManifest;
+  if (
+    manifest.fromMs !== window.fromMs ||
+    manifest.toMs !== window.toMs ||
+    manifest.mode !== "best-evidence" ||
+    manifest.eligible !== manifest.rows.length ||
+    typeof manifest.planSha256 !== "string" ||
+    typeof manifest.pricingSha256 !== "string"
+  ) {
+    throw new Error(`manifest metadata does not match ${window.name}`);
+  }
+  return manifest;
+}
+
+function parseCheckpoint(path: string, manifest: RepriceManifest): RepriceCheckpoint {
+  if (!existsSync(path)) {
+    return {
+      version: 1,
+      planSha256: manifest.planSha256,
+      pricingSha256: manifest.pricingSha256,
+      totalRows: manifest.rows.length,
+      nextRowIndex: 0,
+      appliedRows: 0,
+      alreadyAppliedRows: 0,
+      batchesApplied: 0,
+      completed: manifest.rows.length === 0,
+      lastBatch: null,
+    };
+  }
+  const body = record(readJson(path));
+  if (body === null || body.version !== 1) throw new Error(`invalid checkpoint: ${path}`);
+  const checkpoint = body as unknown as RepriceCheckpoint;
+  if (
+    checkpoint.planSha256 !== manifest.planSha256 ||
+    checkpoint.pricingSha256 !== manifest.pricingSha256 ||
+    checkpoint.totalRows !== manifest.rows.length ||
+    !Number.isSafeInteger(checkpoint.nextRowIndex) ||
+    checkpoint.nextRowIndex < 0 ||
+    checkpoint.nextRowIndex > checkpoint.totalRows
+  ) {
+    throw new Error(`checkpoint does not match manifest: ${path}`);
+  }
+  return checkpoint;
+}
+
+function appliedTotals(manifest: RepriceManifest, nextRowIndex: number): SupervisorStatus["totals"] {
+  let appliedOldUsd = 0;
+  let appliedNewUsd = 0;
+  for (const row of manifest.rows.slice(0, nextRowIndex)) {
+    appliedOldUsd += row.oldTotalUsd ?? 0;
+    appliedNewUsd += row.newTotalUsd;
+  }
+  return {
+    appliedOldUsd,
+    appliedNewUsd,
+    appliedDeltaUsd: appliedNewUsd - appliedOldUsd,
+  };
+}
+
+function backupAggregateSha256(directory: string): string | null {
+  if (!existsSync(directory)) return null;
+  const names = readdirSync(directory)
+    .filter((name) => /^batch-.*\.sqlite$/.test(name))
+    .sort();
+  if (names.length === 0) return null;
+  const aggregate = createHash("sha256");
+  for (const name of names) {
+    const digest = createHash("sha256").update(readFileSync(join(directory, name))).digest("hex");
+    aggregate.update(`${digest}  ${name}\n`);
+  }
+  return aggregate.digest("hex");
+}
+
+function loadConfig(): SupervisorConfig {
+  const hostStateDir = process.env.HELM_REPRICE_STATE_DIR ??
+    "/opt/helm-api/data/pricing-reprice-v0.27.5";
+  return {
+    container: process.env.HELM_CONTAINER ?? "helm",
+    hostDatabasePath: process.env.HELM_REPRICE_DB ?? "/opt/helm-api/data/helm.db",
+    containerDatabasePath: process.env.HELM_REPRICE_CONTAINER_DB ?? "/app/data/helm.db",
+    containerPricingPath: process.env.HELM_REPRICE_PRICING ?? "/app/config/pricing.yaml",
+    hostStateDir,
+    containerStateDir:
+      process.env.HELM_REPRICE_CONTAINER_STATE_DIR ?? "/app/data/pricing-reprice-v0.27.5",
+    statusPath:
+      process.env.HELM_REPRICE_STATUS_PATH ?? join(hostStateDir, "supervisor.status.json"),
+    startMs: parseTimestamp(
+      process.env.HELM_REPRICE_START ?? "2026-06-30T00:00:00Z",
+      "HELM_REPRICE_START",
+    ),
+    cutoffMs: parseTimestamp(
+      process.env.HELM_REPRICE_CUTOFF ?? "2026-07-15T13:28:46+08:00",
+      "HELM_REPRICE_CUTOFF",
+    ),
+    sampleIntervalMs: envNumber("HELM_REPRICE_SAMPLE_INTERVAL_MS", 10_000),
+    unsafePollMs: envNumber("HELM_REPRICE_UNSAFE_POLL_MS", 30_000),
+    batchDelayMs: envNumber("HELM_REPRICE_BATCH_DELAY_MS", 10_000),
+    cooldownMs: envNumber("HELM_REPRICE_COOLDOWN_MS", 300_000),
+    maxStageBatches: envNumber("HELM_REPRICE_MAX_STAGE_BATCHES", 50),
+    thresholds: DEFAULT_SUPERVISOR_THRESHOLDS,
+  };
+}
+
+class DockerHostOperations {
+  private toolPath: string | null = null;
+
+  constructor(private readonly config: SupervisorConfig) {}
+
+  private async docker(args: readonly string[], timeoutMs = 60_000): Promise<CommandResult> {
+    return runCommand("docker", args, { timeoutMs });
+  }
+
+  async discoverTool(): Promise<string> {
+    if (this.toolPath !== null) return this.toolPath;
+    const result = await this.docker([
+      "exec",
+      this.config.container,
+      "find",
+      "/app",
+      "-path",
+      "*historical-cost-reprice.js",
+      "-type",
+      "f",
+      "-print",
+      "-quit",
+    ]);
+    const path = result.stdout.trim();
+    if (path.length === 0) throw new Error("historical repricer tool not found in container");
+    this.toolPath = path;
+    return path;
+  }
+
+  async collectSample(logSince: string): Promise<SupervisorSample> {
+    const capturedAt = new Date().toISOString();
+    const [stats, inspect, health, logs] = await Promise.all([
+      this.docker([
+        "stats",
+        "--no-stream",
+        "--format",
+        "{{.CPUPerc}}\t{{.MemPerc}}",
+        this.config.container,
+      ]),
+      this.docker([
+        "inspect",
+        "--format",
+        "{{.RestartCount}}\t{{.State.OOMKilled}}\t{{.State.Health.Status}}",
+        this.config.container,
+      ]),
+      this.docker([
+        "exec",
+        this.config.container,
+        "node",
+        "--input-type=module",
+        "--eval",
+        'const started=performance.now();const response=await fetch("http://127.0.0.1:8080/healthz",{signal:AbortSignal.timeout(5000)});console.log(JSON.stringify({status:response.status,latencyMs:performance.now()-started}));',
+      ]),
+      this.docker(["logs", "--since", logSince, this.config.container], 30_000),
+    ]);
+    const [cpuText = "", memoryText = ""] = stats.stdout.trim().split("\t");
+    const [restartsText = "", oomText = "", containerHealth = ""] = inspect.stdout
+      .trim()
+      .split("\t");
+    if (containerHealth !== "healthy") throw new Error(`container health is ${containerHealth}`);
+    const healthBody = record(JSON.parse(health.stdout));
+    if (healthBody === null) throw new Error("invalid health probe output");
+    const memInfo = readFileSync("/proc/meminfo", "utf8");
+    const memMatch = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(memInfo);
+    if (memMatch?.[1] === undefined) throw new Error("MemAvailable missing from /proc/meminfo");
+    const load1 = Number(readFileSync("/proc/loadavg", "utf8").trim().split(/\s+/)[0]);
+    const walPath = `${this.config.hostDatabasePath}-wal`;
+    const fs = statfsSync(dirname(this.config.hostDatabasePath));
+    const signals = parseStructuredLogSignals(`${logs.stdout}\n${logs.stderr}`);
+    return {
+      capturedAt,
+      load1: finiteNumber(load1, "load1"),
+      memAvailableBytes: Number(memMatch[1]) * 1024,
+      helmCpuPercent: percent(cpuText, "Helm CPU"),
+      helmMemoryPercent: percent(memoryText, "Helm memory"),
+      healthStatus: finiteNumber(healthBody.status, "health status"),
+      healthLatencyMs: finiteNumber(healthBody.latencyMs, "health latency"),
+      walBytes: existsSync(walPath) ? statSync(walPath).size : 0,
+      diskFreeBytes: fs.bavail * fs.bsize,
+      restarts: finiteNumber(Number(restartsText), "restart count"),
+      oomKilled: oomText === "true",
+      ...signals,
+    };
+  }
+
+  async planWindow(window: HistoricalWindow): Promise<void> {
+    const tool = await this.discoverTool();
+    await this.docker(
+      [
+        "exec",
+        this.config.container,
+        "node",
+        tool,
+        "--db",
+        this.config.containerDatabasePath,
+        "--pricing",
+        this.config.containerPricingPath,
+        "--from-ms",
+        String(window.fromMs),
+        "--to-ms",
+        String(window.toMs),
+        "--mode",
+        "best-evidence",
+        "--manifest",
+        `${this.config.containerStateDir}/${window.name}.json`,
+      ],
+      10 * 60_000,
+    );
+  }
+
+  async applyBatch(window: HistoricalWindow, manifest: RepriceManifest): Promise<RepriceCheckpoint> {
+    const tool = await this.discoverTool();
+    const result = await this.docker(
+      [
+        "exec",
+        this.config.container,
+        "node",
+        tool,
+        "--db",
+        this.config.containerDatabasePath,
+        "--pricing",
+        this.config.containerPricingPath,
+        "--apply-manifest",
+        `${this.config.containerStateDir}/${window.name}.json`,
+        "--expected-plan-sha256",
+        manifest.planSha256,
+        "--checkpoint",
+        `${this.config.containerStateDir}/${window.name}.progress.json`,
+        "--backup-dir",
+        `${this.config.containerStateDir}/${window.name}.backups`,
+        "--batch-size",
+        "100",
+        "--max-batches",
+        "1",
+        "--batch-delay-ms",
+        "0",
+        "--max-wal-bytes",
+        String(this.config.thresholds.stopWalBytes),
+        "--min-free-bytes",
+        String(this.config.thresholds.stopDiskBytes),
+        "--health-url",
+        "http://127.0.0.1:8080/healthz",
+      ],
+      90_000,
+    );
+    return JSON.parse(result.stdout) as RepriceCheckpoint;
+  }
+
+  async verifyRows(
+    window: HistoricalWindow,
+    manifest: RepriceManifest,
+    startRowIndex: number,
+    endRowIndex: number,
+  ): Promise<void> {
+    const tool = await this.discoverTool();
+    await this.docker(
+      [
+        "exec",
+        this.config.container,
+        "node",
+        tool,
+        "--db",
+        this.config.containerDatabasePath,
+        "--pricing",
+        this.config.containerPricingPath,
+        "--verify-manifest",
+        `${this.config.containerStateDir}/${window.name}.json`,
+        "--expected-plan-sha256",
+        manifest.planSha256,
+        "--start-row-index",
+        String(startRowIndex),
+        "--end-row-index",
+        String(endRowIndex),
+      ],
+      10 * 60_000,
+    );
+  }
+}
+
+function windowPaths(config: SupervisorConfig, window: HistoricalWindow): {
+  manifest: string;
+  checkpoint: string;
+  backups: string;
+} {
+  return {
+    manifest: join(config.hostStateDir, `${window.name}.json`),
+    checkpoint: join(config.hostStateDir, `${window.name}.progress.json`),
+    backups: join(config.hostStateDir, `${window.name}.backups`),
+  };
+}
+
+function findActiveWindow(
+  config: SupervisorConfig,
+  windows: readonly HistoricalWindow[],
+): { window: HistoricalWindow; manifest: RepriceManifest | null; checkpoint: RepriceCheckpoint | null } | null {
+  for (const window of windows) {
+    const paths = windowPaths(config, window);
+    if (!existsSync(paths.manifest)) return { window, manifest: null, checkpoint: null };
+    const manifest = parseManifest(paths.manifest, window);
+    const checkpoint = parseCheckpoint(paths.checkpoint, manifest);
+    if (!checkpoint.completed) return { window, manifest, checkpoint };
+  }
+  return null;
+}
+
+function completedWindowCount(config: SupervisorConfig, windows: readonly HistoricalWindow[]): number {
+  let count = 0;
+  for (const window of windows) {
+    const paths = windowPaths(config, window);
+    if (!existsSync(paths.manifest)) break;
+    const manifest = parseManifest(paths.manifest, window);
+    if (!parseCheckpoint(paths.checkpoint, manifest).completed) break;
+    count += 1;
+  }
+  return count;
+}
+
+export async function runSupervisor(config = loadConfig()): Promise<void> {
+  const windows = buildUtcWindows(config.startMs, config.cutoffMs);
+  const operations = new DockerHostOperations(config);
+  const startedAt = new Date().toISOString();
+  let stopping = false;
+  let stageBatches = 0;
+  let stageStartRowIndex = 0;
+  let runtimeState: RuntimeSafetyState = {
+    highCpuSamples: 0,
+    slowHealthSamples: 0,
+    baselineRestarts: 0,
+  };
+  let status: SupervisorStatus = {
+    version: 1,
+    phase: "starting",
+    updatedAt: startedAt,
+    startedAt,
+    activeWindow: null,
+    checkpoint: null,
+    stageBatches: 0,
+    completedWindows: completedWindowCount(config, windows),
+    totalWindows: windows.length,
+    sample: null,
+    reasons: [],
+    lastError: null,
+    totals: null,
+    backupAggregateSha256: null,
+  };
+  const writeStatus = (updates: Partial<SupervisorStatus>): void => {
+    status = { ...status, ...updates, updatedAt: new Date().toISOString() };
+    atomicWriteJson(config.statusPath, status);
+  };
+  process.once("SIGTERM", () => {
+    stopping = true;
+  });
+  process.once("SIGINT", () => {
+    stopping = true;
+  });
+  writeStatus({});
+
+  let active = findActiveWindow(config, windows);
+  if (active === null) {
+    writeStatus({ phase: "complete", completedWindows: windows.length });
+    return;
+  }
+  runtimeState.baselineRestarts = (await operations.collectSample(new Date().toISOString())).restarts;
+
+  while (!stopping) {
+    try {
+      active = findActiveWindow(config, windows);
+      if (active === null) {
+        writeStatus({
+          phase: "complete",
+          activeWindow: null,
+          checkpoint: null,
+          completedWindows: windows.length,
+          reasons: [],
+          lastError: null,
+        });
+        return;
+      }
+
+      const preflightSamples: SupervisorSample[] = [];
+      while (!stopping) {
+        const since = new Date(Date.now() - 10 * 60_000).toISOString();
+        const sample = await operations.collectSample(since);
+        preflightSamples.push(sample);
+        if (preflightSamples.length > 3) preflightSamples.shift();
+        const preflight = evaluatePreflight(preflightSamples, config.thresholds);
+        writeStatus({
+          phase: "waiting_safety",
+          activeWindow: active.window.name,
+          sample,
+          reasons: preflight.reasons,
+          lastError: null,
+        });
+        if (preflight.safe) {
+          runtimeState = {
+            highCpuSamples: 0,
+            slowHealthSamples: 0,
+            baselineRestarts: sample.restarts,
+          };
+          break;
+        }
+        await sleep(preflightSamples.length < 3 ? config.sampleIntervalMs : config.unsafePollMs);
+      }
+      if (stopping) break;
+
+      if (active.manifest === null) {
+        writeStatus({ phase: "planning", activeWindow: active.window.name, reasons: [] });
+        await operations.planWindow(active.window);
+        active = findActiveWindow(config, windows);
+        if (active === null || active.manifest === null || active.window.name !== status.activeWindow) {
+          continue;
+        }
+      }
+
+      const manifest = active.manifest;
+      let checkpoint = active.checkpoint ??
+        parseCheckpoint(windowPaths(config, active.window).checkpoint, manifest);
+      if (stageBatches === 0) stageStartRowIndex = checkpoint.nextRowIndex;
+      const sample = await operations.collectSample(new Date(Date.now() - 15_000).toISOString());
+      const safety = evaluateRuntimeSafety(sample, runtimeState, config.thresholds);
+      runtimeState = safety.state;
+      if (safety.stop) {
+        stageBatches = 0;
+        writeStatus({
+          phase: "waiting_safety",
+          sample,
+          reasons: safety.reasons,
+          checkpoint: {
+            nextRowIndex: checkpoint.nextRowIndex,
+            totalRows: checkpoint.totalRows,
+            completed: checkpoint.completed,
+          },
+        });
+        await sleep(config.unsafePollMs);
+        continue;
+      }
+
+      const beforeRowIndex = checkpoint.nextRowIndex;
+      writeStatus({
+        phase: "applying",
+        activeWindow: active.window.name,
+        sample,
+        reasons: [],
+        stageBatches,
+        checkpoint: {
+          nextRowIndex: checkpoint.nextRowIndex,
+          totalRows: checkpoint.totalRows,
+          completed: checkpoint.completed,
+        },
+        totals: appliedTotals(manifest, checkpoint.nextRowIndex),
+      });
+      checkpoint = await operations.applyBatch(active.window, manifest);
+      await operations.verifyRows(
+        active.window,
+        manifest,
+        beforeRowIndex,
+        checkpoint.nextRowIndex,
+      );
+      stageBatches += 1;
+      writeStatus({
+        phase: checkpoint.completed ? "cooling" : "applying",
+        checkpoint: {
+          nextRowIndex: checkpoint.nextRowIndex,
+          totalRows: checkpoint.totalRows,
+          completed: checkpoint.completed,
+        },
+        stageBatches,
+        completedWindows: completedWindowCount(config, windows),
+        totals: appliedTotals(manifest, checkpoint.nextRowIndex),
+        lastError: null,
+      });
+
+      if (checkpoint.completed) {
+        await operations.verifyRows(active.window, manifest, 0, checkpoint.totalRows);
+        writeStatus({
+          phase: "cooling",
+          completedWindows: completedWindowCount(config, windows),
+          backupAggregateSha256: backupAggregateSha256(windowPaths(config, active.window).backups),
+        });
+        const cooldownEnd = Date.now() + config.cooldownMs;
+        while (!stopping && Date.now() < cooldownEnd) {
+          const cooldownSample = await operations.collectSample(
+            new Date(Date.now() - 60_000).toISOString(),
+          );
+          writeStatus({ phase: "cooling", sample: cooldownSample });
+          await sleep(Math.min(config.unsafePollMs, Math.max(0, cooldownEnd - Date.now())));
+        }
+        stageBatches = 0;
+        continue;
+      }
+
+      if (stageBatches >= config.maxStageBatches) {
+        await operations.verifyRows(
+          active.window,
+          manifest,
+          stageStartRowIndex,
+          checkpoint.nextRowIndex,
+        );
+        writeStatus({
+          phase: "cooling",
+          backupAggregateSha256: backupAggregateSha256(windowPaths(config, active.window).backups),
+        });
+        const cooldownEnd = Date.now() + config.cooldownMs;
+        while (!stopping && Date.now() < cooldownEnd) {
+          const cooldownSample = await operations.collectSample(
+            new Date(Date.now() - 60_000).toISOString(),
+          );
+          writeStatus({ phase: "cooling", sample: cooldownSample });
+          await sleep(Math.min(config.unsafePollMs, Math.max(0, cooldownEnd - Date.now())));
+        }
+        stageBatches = 0;
+        continue;
+      }
+      await sleep(config.batchDelayMs);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeStatus({ phase: "waiting_safety", lastError: message, reasons: [message] });
+      await sleep(config.unsafePollMs);
+    }
+  }
+}
+
+const entrypoint = process.argv[1] === undefined ? "" : resolve(process.argv[1]);
+if (entrypoint === fileURLToPath(import.meta.url)) {
+  if (process.argv.includes("--check-config")) {
+    const config = loadConfig();
+    const windows = buildUtcWindows(config.startMs, config.cutoffMs);
+    process.stdout.write(
+      `${JSON.stringify({
+        statusPath: config.statusPath,
+        windows: windows.length,
+        firstWindow: windows[0]?.name ?? null,
+        lastWindow: windows.at(-1)?.name ?? null,
+        cutoff: new Date(config.cutoffMs).toISOString(),
+        batchSize: 100,
+        maxStageRows: config.maxStageBatches * 100,
+      })}\n`,
+    );
+  } else {
+    runSupervisor().catch((error: unknown) => {
+      process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    });
+  }
+}

--- a/scripts/ops/tsconfig.json
+++ b/scripts/ops/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../.."
+  },
+  "include": ["./historical-reprice-supervisor.ts", "./historical-reprice-supervisor.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add a systemd-managed, single-writer historical repricing supervisor with continuous safety monitoring and atomic status reporting
- add read-only manifest slice verification to validate each committed batch before continuing
- add UTC window progression through the fixed July 15 cutoff, bounded 100-row batches, stage cooldowns, and structured failure detection

## Validation
- `CI=true corepack pnpm vitest run scripts/ops/historical-reprice-supervisor.test.ts packages/core/src/store/sqlite/historical-cost-reprice.test.ts` (19 tests)
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm build`
- remote Node 22 `--check-config` and `systemd-analyze verify` on `la.atmy.work`

## Production rollout
- deploy the release image first so the new read-only verifier CLI is available
- install the bundled supervisor and systemd unit on the host
- disable the existing write-capable Codex automation before enabling the service
- convert the automation to read-only periodic status reporting