### PR TITLE
fix(pricing): reset reported stage after safety stop

### DIFF
--- a/scripts/ops/historical-reprice-supervisor.test.ts
+++ b/scripts/ops/historical-reprice-supervisor.test.ts
@@ -5,6 +5,7 @@ import {
   evaluatePreflight,
   evaluateRuntimeSafety,
   parseStructuredLogSignals,
+  resetStageAfterSafetyStop,
   type SupervisorSample,
   shouldRunPreflight,
 } from "./historical-reprice-supervisor.js";
@@ -127,5 +128,12 @@ describe("historical reprice supervisor", () => {
     expect(shouldRunPreflight(1, false)).toBe(false);
     expect(shouldRunPreflight(49, false)).toBe(false);
     expect(shouldRunPreflight(12, true)).toBe(true);
+  });
+
+  it("resets both internal and reported stage progress after a safety stop", () => {
+    expect(resetStageAfterSafetyStop()).toEqual({
+      stageBatches: 0,
+      recoveryRequired: true,
+    });
   });
 });

--- a/scripts/ops/historical-reprice-supervisor.ts
+++ b/scripts/ops/historical-reprice-supervisor.ts
@@ -268,6 +268,13 @@ export function shouldRunPreflight(stageBatches: number, recoveryRequired: boole
   return stageBatches === 0 || recoveryRequired;
 }
 
+export function resetStageAfterSafetyStop(): {
+  stageBatches: 0;
+  recoveryRequired: true;
+} {
+  return { stageBatches: 0, recoveryRequired: true };
+}
+
 export function evaluateRuntimeSafety(
   sample: SupervisorSample,
   previous: RuntimeSafetyState,
@@ -800,6 +807,7 @@ export async function runSupervisor(config = loadConfig()): Promise<void> {
             sample,
             reasons: preflight.reasons,
             lastError: null,
+            stageBatches,
           });
           if (preflight.safe) {
             runtimeState = {
@@ -837,12 +845,14 @@ export async function runSupervisor(config = loadConfig()): Promise<void> {
       const safety = evaluateRuntimeSafety(sample, runtimeState, config.thresholds);
       runtimeState = safety.state;
       if (safety.stop) {
-        stageBatches = 0;
-        recoveryRequired = true;
+        const reset = resetStageAfterSafetyStop();
+        stageBatches = reset.stageBatches;
+        recoveryRequired = reset.recoveryRequired;
         writeStatus({
           phase: "waiting_safety",
           sample,
           reasons: safety.reasons,
+          stageBatches,
           checkpoint: {
             nextRowIndex: checkpoint.nextRowIndex,
             totalRows: checkpoint.totalRows,


### PR DESCRIPTION
## Summary
- reset the status JSON stage counter when a hard safety threshold resets the internal stage
- publish the current stage counter during preflight so periodic reports do not show stale progress

## Production evidence
- supervisor correctly paused at load1 1.53 after advancing 17,500 -> 17,700
- checkpoint and database were correct; only the reported stage counter remained stale at 2

## Validation
- 21 targeted tests
- ops typecheck and bundle build
- targeted Biome check