### PR TITLE
fix(telemetry): account for interrupted response streams

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -115,6 +115,7 @@ describe('toListItem', () => {
 
   it('maps the recorded token usage, deriving non-cached = prompt − cached and a prompt+completion total', () => {
     const row = toListItem(rawRecord());
+    expect(row.usage.measurement).toBe('reported');
     expect(row.usage.input).toBe(1200);
     expect(row.usage.output).toBe(340);
     expect(row.usage.cached).toBe(800);
@@ -139,6 +140,29 @@ describe('toListItem', () => {
     expect(u.cacheCreation).toBeNull();
     expect(u.nonCached).toBeNull();
     expect(u.total).toBeNull();
+    expect(u.measurement).toBe('unknown');
+  });
+
+  it('preserves estimated-partial provenance and stream termination separately from final status', () => {
+    const row = toListItem(
+      rawRecord({
+        stream_outcome: 'truncated',
+        final: {
+          model_alias: 'premium',
+          provider_model: 'claude-x',
+          status: 'error',
+          error_reason: 'upstream_error',
+        },
+        usage: {
+          prompt_tokens: 1200,
+          completion_tokens: 21,
+          measurement: 'estimated_partial',
+        },
+      }),
+    );
+    expect(row.status).toBe('error');
+    expect(row.stream_outcome).toBe('truncated');
+    expect(row.usage.measurement).toBe('estimated_partial');
   });
 });
 
@@ -162,7 +186,9 @@ describe('toDetail', () => {
     expect(d.key_name).toBeNull();
     // An error record maps status through (drives the summary badge).
     const errored = toDetail(
-      rawRecord({ final: { model_alias: null, status: 'error', error_reason: 'all_providers_failed' } }),
+      rawRecord({
+        final: { model_alias: null, status: 'error', error_reason: 'all_providers_failed' },
+      }),
     );
     expect(errored.status).toBe('error');
     expect(errored.final_model).toBeNull();
@@ -173,6 +199,43 @@ describe('toDetail', () => {
     expect(d.cost_breakdown.eval_usd).toBeCloseTo(0.0002);
     expect(d.cost_breakdown.completion_usd).toBeCloseTo(0.01);
     expect(d.cost_breakdown.total_usd).toBeCloseTo(0.0102);
+  });
+
+  it('keeps unknown detail costs null instead of turning them into a free $0', () => {
+    const d = toDetail(
+      rawRecord({
+        cost_breakdown: { eval_usd: null, completion_usd: null, total_usd: null },
+        provider_attempts: [
+          {
+            alias: 'premium',
+            status: 'ok',
+            skipped: false,
+            latency_ms: 340,
+            cost_usd: null,
+          },
+        ],
+      }),
+    );
+    expect(d.cost_breakdown.routing_usd).toBe(0);
+    expect(d.cost_breakdown.eval_usd).toBeNull();
+    expect(d.cost_breakdown.completion_usd).toBeNull();
+    expect(d.cost_breakdown.total_usd).toBeNull();
+  });
+
+  it('maps stream outcome onto detail without widening the binary provider result', () => {
+    const d = toDetail(
+      rawRecord({
+        stream_outcome: 'client_aborted',
+        final: {
+          model_alias: 'premium',
+          provider_model: 'claude-x',
+          status: 'error',
+          error_reason: 'client_abort',
+        },
+      }),
+    );
+    expect(d.status).toBe('error');
+    expect(d.stream_outcome).toBe('client_aborted');
   });
 
   it('surfaces the eval model, latency and decision source (decided_by) for an eval-decided request', () => {
@@ -243,13 +306,14 @@ describe('toDetail', () => {
     expect(d.eval_triggered).toBe(false);
   });
 
-  it('defaults cost parts to 0 when the record has no cost_breakdown (legacy record)', () => {
+  it('uses known attempt cost for a legacy record without inventing eval cost', () => {
     const legacy = rawRecord();
     delete legacy.cost_breakdown;
     const d = toDetail(legacy);
-    // completion derived from the summed attempts; eval unknown -> 0 (visible).
+    // Completion derives from the summed attempts; eval remains unknown.
     expect(d.cost_breakdown.completion_usd).toBeCloseTo(0.01);
-    expect(d.cost_breakdown.eval_usd).toBe(0);
+    expect(d.cost_breakdown.eval_usd).toBeNull();
+    expect(d.cost_breakdown.total_usd).toBeCloseTo(0.01);
   });
 
   it('surfaces a failed attempt error_detail (status + message + raw body); null elsewhere', () => {
@@ -376,7 +440,12 @@ describe('listRequests', () => {
   });
 
   it('maps the envelope rows and passes the totals through', async () => {
-    stubFetch({ items: [rawRecord({ created_at: 1717155600000 })], total: 7, page: 3, pageSize: 2 });
+    stubFetch({
+      items: [rawRecord({ created_at: 1717155600000 })],
+      total: 7,
+      page: 3,
+      pageSize: 2,
+    });
     const res = await listRequests({ page: 3, pageSize: 2 });
     expect(res.total).toBe(7);
     expect(res.page).toBe(3);

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -51,6 +51,9 @@ export interface RequestListItem {
   final_model: string | null;
   fallback_count: number; // execution fallback count (provider attempts - 1)
   status: 'ok' | 'error';
+  // Delivery outcome is separate from the provider attempt result. A provider can
+  // successfully emit bytes while the request later ends as a partial stream.
+  stream_outcome: StreamOutcome;
   latency_ms: number;
   // null = NOT measured (no pricing / usage unknown — e.g. an unpriced model),
   // rendered as '—'. A number is a real cost. Crucially distinct from 0 so an
@@ -72,6 +75,7 @@ export interface RequestListItem {
 // view; the gateway is the single source of the raw counts (Principle 1 — we only
 // render, never recompute the upstream figures).
 export interface TokenUsageView {
+  measurement: UsageMeasurement;
   input: number | null; // prompt_tokens (TOTAL input, includes cached)
   output: number | null; // completion_tokens
   cached: number | null; // cache-READ prompt tokens (served from cache)
@@ -81,6 +85,15 @@ export interface TokenUsageView {
   nonCached: number | null;
   total: number | null; // input + output when present; null when neither is measured
 }
+
+export type UsageMeasurement = 'reported' | 'estimated_partial' | 'unknown';
+export type StreamOutcome =
+  | 'completed'
+  | 'incomplete'
+  | 'failed'
+  | 'client_aborted'
+  | 'truncated'
+  | null;
 
 export interface ServingAccountView {
   provider_id: string;
@@ -125,6 +138,7 @@ export interface RequestDetail {
   final_model: string | null; // the served model alias (null = no provider served)
   lane: string; // selected lane ('' on a legacy record)
   status: 'ok' | 'error';
+  stream_outcome: StreamOutcome;
   // Total wall-clock latency (Σ attempt latency, ms); null on a legacy record.
   latency_ms: number | null;
   request_meta: Record<string, unknown>;
@@ -165,9 +179,9 @@ export interface RequestDetail {
   } | null;
   cost_breakdown: {
     routing_usd: number;
-    eval_usd: number;
-    completion_usd: number;
-    total_usd: number;
+    eval_usd: number | null;
+    completion_usd: number | null;
+    total_usd: number | null;
   };
   // Served-completion token accounting (see TokenUsageView). Every leaf is null on
   // a legacy/un-stamped record → the card renders '—'.
@@ -235,11 +249,13 @@ interface RawDecisionRecord {
   // tail is parsed (TokenUsageSchema). Each leaf is null when not reported; the
   // whole block is null/absent on a legacy (pre-feature) record.
   usage?: {
+    measurement?: string;
     prompt_tokens?: number | null;
     completion_tokens?: number | null;
     cached_tokens?: number | null;
     cache_creation_tokens?: number | null;
   } | null;
+  stream_outcome?: string | null;
   // Served-stream generation window (ms): first→last forwarded chunk, gateway-timed.
   // null/absent for non-streaming responses and legacy records. The true-TPS
   // denominator — paired with usage.completion_tokens to derive tokens/sec.
@@ -399,7 +415,27 @@ export function toUsage(raw: RawDecisionRecord): TokenUsageView {
   const nonCached = input !== null && cached !== null ? Math.max(0, input - cached) : null;
   // Sum the parts that ARE measured; all-unmeasured stays null (never a fake 0).
   const total = input !== null || output !== null ? (input ?? 0) + (output ?? 0) : null;
-  return { input, output, cached, cacheCreation, nonCached, total };
+  const measurement: UsageMeasurement =
+    u === undefined
+      ? 'unknown'
+      : u.measurement === 'estimated_partial'
+        ? 'estimated_partial'
+        : 'reported';
+  return { measurement, input, output, cached, cacheCreation, nonCached, total };
+}
+
+const STREAM_OUTCOMES = new Set<Exclude<StreamOutcome, null>>([
+  'completed',
+  'incomplete',
+  'failed',
+  'client_aborted',
+  'truncated',
+]);
+
+function normalizeStreamOutcome(value: unknown): StreamOutcome {
+  return STREAM_OUTCOMES.has(value as Exclude<StreamOutcome, null>)
+    ? (value as Exclude<StreamOutcome, null>)
+    : null;
 }
 
 // True generation TPS for one request: output tokens ÷ the served-stream generation
@@ -465,6 +501,7 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     fallback_count:
       typeof raw.fallback_count === 'number' ? raw.fallback_count : fallbackCount(attempts),
     status,
+    stream_outcome: normalizeStreamOutcome(raw.stream_outcome),
     latency_ms:
       typeof raw.latency_total_ms === 'number' ? raw.latency_total_ms : sumLatency(attempts),
     cost_usd: listCost(raw, attempts),
@@ -512,20 +549,34 @@ function buildRequestMeta(raw: RawDecisionRecord): Record<string, unknown> {
 // the recorded cost_breakdown.
 function buildCostBreakdown(
   raw: RawDecisionRecord,
-  completionFallback: number,
+  completionFallback: number | null,
 ): RequestDetail['cost_breakdown'] {
   const cb = raw.cost_breakdown;
-  const completion =
-    typeof cb?.completion_usd === 'number' ? cb.completion_usd : completionFallback;
-  const evalUsd = typeof cb?.eval_usd === 'number' ? cb.eval_usd : 0;
-  const total = typeof cb?.total_usd === 'number' ? cb.total_usd : evalUsd + completion;
+  // An explicit null is authoritative "unknown", not a free zero and not an
+  // invitation to recompute. Only truly legacy records without the block use the
+  // attempt-cost fallback.
+  if (cb !== undefined) {
+    return {
+      routing_usd: 0,
+      eval_usd: num(cb.eval_usd),
+      completion_usd: num(cb.completion_usd),
+      total_usd: num(cb.total_usd),
+    };
+  }
   // The backend does not bill a separate routing self-cost in the MVP.
-  return { routing_usd: 0, eval_usd: evalUsd, completion_usd: completion, total_usd: total };
+  return {
+    routing_usd: 0,
+    eval_usd: null,
+    completion_usd: completionFallback,
+    total_usd: completionFallback,
+  };
 }
 
 export function toDetail(raw: RawDecisionRecord): RequestDetail {
   const attempts = Array.isArray(raw.provider_attempts) ? raw.provider_attempts : [];
-  const completion = sumCost(attempts);
+  const completion = attempts.some((a) => typeof a.cost_usd === 'number')
+    ? sumCost(attempts)
+    : null;
   const status = raw.final?.status === 'error' ? 'error' : 'ok';
   const evalCacheHit = raw.classifier?.eval_cache_hit ?? null;
   const account = normalizeServingAccount(raw);
@@ -547,6 +598,7 @@ export function toDetail(raw: RawDecisionRecord): RequestDetail {
     final_model: raw.final?.model_alias ?? null,
     lane: raw.lane?.selected_lane ?? '',
     status,
+    stream_outcome: normalizeStreamOutcome(raw.stream_outcome),
     latency_ms: typeof raw.latency_total_ms === 'number' ? raw.latency_total_ms : null,
     request_meta: buildRequestMeta(raw),
     // The backend does not persist a payload; we render a redaction placeholder so
@@ -566,8 +618,7 @@ export function toDetail(raw: RawDecisionRecord): RequestDetail {
     },
     eval_triggered: raw.classifier?.decided_by === 'eval' || evalCacheHit !== null,
     eval_cache_hit: evalCacheHit,
-    eval_model:
-      typeof raw.classifier?.eval_model === 'string' ? raw.classifier.eval_model : null,
+    eval_model: typeof raw.classifier?.eval_model === 'string' ? raw.classifier.eval_model : null,
     eval_latency_ms:
       typeof raw.classifier?.eval_latency_ms === 'number' ? raw.classifier.eval_latency_ms : null,
     eval_fallback_reason:

--- a/apps/admin/src/lib/components/CostBreakdown.svelte
+++ b/apps/admin/src/lib/components/CostBreakdown.svelte
@@ -5,12 +5,33 @@
 
   // Cost breakdown for one request (docs/07 "cost breakdown, including eval's own cost").
   // Read-only: renders exactly the figures the backend recorded — no re-computation.
-  let { cost }: { cost: RequestDetail['cost_breakdown'] } = $props();
+  let {
+    cost,
+    measurement = 'reported',
+    apiEquivalent = false,
+  }: {
+    cost: RequestDetail['cost_breakdown'];
+    measurement?: RequestDetail['usage']['measurement'];
+    apiEquivalent?: boolean;
+  } = $props();
 
   // Adaptive precision so sub-cent relay costs (~$0.0000244) stay visible instead
   // of collapsing to $0.0000; null components render as "—" (not measured).
   const usd = formatUsd;
+
+  function completionUsd(value: number | null): string {
+    const rendered = usd(value);
+    return value !== null && measurement === 'estimated_partial' ? `≈${rendered}` : rendered;
+  }
 </script>
+
+{#if measurement === 'estimated_partial'}
+  <p data-testid="cost-measurement" class="mb-2 text-xs text-ink-muted">
+    {apiEquivalent
+      ? $t('API-equivalent estimate; subscription has no per-request charge')
+      : $t('Estimated from a partial stream.')}
+  </p>
+{/if}
 
 <dl data-testid="cost-breakdown" class="grid grid-cols-2 gap-x-6 gap-y-1 text-sm">
   <dt class="text-ink-muted">{$t('Routing')}</dt>
@@ -23,11 +44,11 @@
 
   <dt class="text-ink-muted">{$t('Completion')}</dt>
   <dd data-testid="cost-completion" class="text-right font-mono text-ink-strong">
-    {usd(cost.completion_usd)}
+    {completionUsd(cost.completion_usd)}
   </dd>
 
   <dt class="font-medium text-ink-body">{$t('Total')}</dt>
   <dd data-testid="cost-total" class="text-right font-mono font-semibold text-ink-strong">
-    {usd(cost.total_usd)}
+    {completionUsd(cost.total_usd)}
   </dd>
 </dl>

--- a/apps/admin/src/lib/components/DecisionChain.test.ts
+++ b/apps/admin/src/lib/components/DecisionChain.test.ts
@@ -24,6 +24,7 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
     final_model: 'claude-x',
     lane: 'premium',
     status: 'ok',
+    stream_outcome: 'completed',
     latency_ms: 460,
     request_meta: {},
     payload_summary: 'payload withheld (redacted)',
@@ -82,6 +83,7 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
     error: null,
     cost_breakdown: { routing_usd: 0, eval_usd: 0, completion_usd: 0.01, total_usd: 0.01 },
     usage: {
+      measurement: 'reported',
       input: 1200,
       output: 340,
       cached: 800,

--- a/apps/admin/src/lib/components/RequestsTable.svelte
+++ b/apps/admin/src/lib/components/RequestsTable.svelte
@@ -76,13 +76,35 @@
   }
 
   function servedModel(r: RequestListItem): string {
-    if (r.status === 'error') return $t('not served');
+    if (r.status === 'error' && !isPartial(r)) return $t('not served');
     return r.final_model ?? '—';
   }
 
   function servingProvider(r: RequestListItem): string {
     if (r.status === 'error' && !r.served_provider) return $t('not served');
     return r.served_provider ?? '—';
+  }
+
+  function isPartial(r: RequestListItem): boolean {
+    return (
+      r.stream_outcome === 'incomplete' ||
+      r.stream_outcome === 'client_aborted' ||
+      r.stream_outcome === 'truncated'
+    );
+  }
+
+  function outcomeLabel(r: RequestListItem): string {
+    if (r.stream_outcome === 'client_aborted') return $t('client aborted');
+    if (r.stream_outcome === 'truncated') return $t('truncated');
+    if (r.stream_outcome === 'incomplete') return $t('incomplete');
+    return '';
+  }
+
+  function requestCost(r: RequestListItem): string {
+    const rendered = formatUsd(r.cost_usd);
+    return r.cost_usd !== null && r.usage.measurement === 'estimated_partial'
+      ? `≈${rendered}`
+      : rendered;
   }
 </script>
 
@@ -115,7 +137,10 @@
 
 {#snippet resultCell(r: RequestListItem)}
   <div data-testid="cell-result" class="leading-tight">
-    {#if r.status === 'error'}
+    {#if isPartial(r)}
+      <span class="badge-neutral">{$t('partial')}</span>
+      <div class="mt-1 text-xs text-amber-700">{outcomeLabel(r)}</div>
+    {:else if r.status === 'error'}
       <span class="badge-error">{$t('error')}</span>
       {#if r.error_class}
         <div class="mt-1 max-w-[12rem] truncate text-xs text-red-600" title={r.error_class}>
@@ -301,8 +326,18 @@
           <td data-label={$t('Serving')} class="px-3 py-2">
             {@render servingCell(r)}
           </td>
-          <td data-label={$t('Cost')} class="px-3 py-2 font-mono text-ink-body">
-            {formatUsd(r.cost_usd)}
+          <td
+            data-testid="cell-cost"
+            data-label={$t('Cost')}
+            class="px-3 py-2 font-mono text-ink-body"
+            title={r.usage.measurement === 'estimated_partial' && r.serving_account
+              ? $t('API-equivalent estimate; subscription has no per-request charge')
+              : undefined}
+          >
+            {requestCost(r)}
+            {#if r.usage.measurement === 'estimated_partial' && r.serving_account}
+              <div class="text-[10px] text-ink-muted">{$t('API-equivalent')}</div>
+            {/if}
           </td>
           <td data-label={$t('Tokens')} class="px-3 py-2"><TokensCell usage={r.usage} /></td>
           <td data-label={$t('Performance')} class="px-3 py-2">

--- a/apps/admin/src/lib/components/RequestsTable.test.ts
+++ b/apps/admin/src/lib/components/RequestsTable.test.ts
@@ -24,9 +24,11 @@ function item(overrides: Partial<RequestListItem> = {}): RequestListItem {
     final_model: 'claude-x',
     fallback_count: 1,
     status: 'ok',
+    stream_outcome: 'completed',
     latency_ms: 460,
     cost_usd: 0.0123,
     usage: {
+      measurement: 'reported',
       input: 1200,
       output: 340,
       cached: 800,
@@ -100,6 +102,41 @@ describe('RequestsTable variants', () => {
     expect(screen.getByTestId('cell-performance')).toHaveTextContent('1.5min');
   });
 
+  it('shows a partial result and approximate cost for an estimated truncated stream', () => {
+    render(RequestsTable, {
+      items: [
+        item({
+          status: 'error',
+          stream_outcome: 'truncated',
+          usage: { ...item().usage, measurement: 'estimated_partial' },
+        }),
+      ],
+      detailHref,
+    });
+
+    expect(screen.getByTestId('cell-result')).toHaveTextContent(/partial/i);
+    expect(screen.getByTestId('cell-cost')).toHaveTextContent('≈$0.0123');
+    expect(screen.getByTestId('usage-measurement')).toHaveTextContent(/estimated/i);
+  });
+
+  it('keeps an unpriced estimated partial stream unknown instead of showing approximate zero', () => {
+    render(RequestsTable, {
+      items: [
+        item({
+          status: 'error',
+          stream_outcome: 'client_aborted',
+          cost_usd: null,
+          usage: { ...item().usage, measurement: 'estimated_partial' },
+        }),
+      ],
+      detailHref,
+    });
+
+    expect(screen.getByTestId('tokens-cell')).toHaveTextContent('1.2K');
+    expect(screen.getByTestId('cell-cost')).toHaveTextContent('—');
+    expect(screen.getByTestId('cell-cost')).not.toHaveTextContent('≈$0');
+  });
+
   it('keeps the request-list metric columns and hides only Request ID in the dashboard recent variant', () => {
     render(RequestsTable, { items: [item()], detailHref, variant: 'recent' });
 
@@ -139,6 +176,7 @@ describe('RequestsTable variants', () => {
       items: [
         item({
           usage: {
+            measurement: 'unknown',
             input: null,
             output: null,
             cached: null,

--- a/apps/admin/src/lib/components/TokenUsage.svelte
+++ b/apps/admin/src/lib/components/TokenUsage.svelte
@@ -11,9 +11,19 @@
   const fmt = formatTokens;
 </script>
 
+{#if usage.measurement !== 'unknown'}
+  <p data-testid="usage-measurement" class="mb-2 text-xs text-ink-muted">
+    {usage.measurement === 'estimated_partial'
+      ? `≈ ${$t('Estimated from a partial stream.')}`
+      : $t('Provider-reported usage')}
+  </p>
+{/if}
+
 <dl data-testid="token-usage" class="grid grid-cols-2 gap-x-6 gap-y-1 text-sm">
   <dt class="text-ink-muted">{$t('Input tokens')}</dt>
-  <dd data-testid="tokens-input" class="text-right font-mono text-ink-strong">{fmt(usage.input)}</dd>
+  <dd data-testid="tokens-input" class="text-right font-mono text-ink-strong">
+    {fmt(usage.input)}
+  </dd>
 
   <dt class="text-ink-muted">{$t('Output tokens')}</dt>
   <dd data-testid="tokens-output" class="text-right font-mono text-ink-strong">

--- a/apps/admin/src/lib/components/TokenUsage.test.ts
+++ b/apps/admin/src/lib/components/TokenUsage.test.ts
@@ -10,6 +10,7 @@ import TokenUsage from './TokenUsage.svelte';
 
 function usage(overrides: Partial<TokenUsageView> = {}): TokenUsageView {
   return {
+    measurement: 'reported',
     input: 1200,
     output: 340,
     cached: 800,
@@ -35,5 +36,11 @@ describe('TokenUsage', () => {
     render(TokenUsage, { usage: usage({ cached: null, output: 0 }) });
     expect(screen.getByTestId('tokens-cached')).toHaveTextContent('—');
     expect(screen.getByTestId('tokens-output')).toHaveTextContent('0');
+  });
+
+  it('labels estimated partial-stream usage clearly', () => {
+    render(TokenUsage, { usage: usage({ measurement: 'estimated_partial' }) });
+    expect(screen.getByTestId('usage-measurement')).toHaveTextContent(/estimated/i);
+    expect(screen.getByTestId('usage-measurement')).toHaveTextContent(/partial/i);
   });
 });

--- a/apps/admin/src/lib/components/TokensCell.svelte
+++ b/apps/admin/src/lib/components/TokensCell.svelte
@@ -21,12 +21,12 @@
 
   // The full breakdown, surfaced on hover so the headline cell stays compact.
   const tip = $derived(
-    $t('input {input} · output {output} · cached {cached} · non-cached {nonCached}', {
+    `${$t('input {input} · output {output} · cached {cached} · non-cached {nonCached}', {
       input: formatTokens(usage.input),
       output: formatTokens(usage.output),
       cached: formatTokens(usage.cached),
       nonCached: formatTokens(usage.nonCached),
-    }),
+    })}${usage.measurement === 'estimated_partial' ? ` · ${$t('Estimated from a partial stream.')}` : ''}`,
   );
 </script>
 
@@ -40,6 +40,11 @@
       {$t('cached')}
       {formatTokens(usage.cached)}
     </div>
+    {#if usage.measurement === 'estimated_partial'}
+      <div data-testid="usage-measurement" class="text-amber-700">
+        ≈ {$t('estimated · partial stream')}
+      </div>
+    {/if}
   </div>
 {:else}
   <span data-testid="tokens-cell" class="text-ink-muted">—</span>

--- a/apps/admin/src/lib/components/TokensCell.test.ts
+++ b/apps/admin/src/lib/components/TokensCell.test.ts
@@ -11,6 +11,7 @@ import TokensCell from './TokensCell.svelte';
 
 function usage(overrides: Partial<TokenUsageView> = {}): TokenUsageView {
   return {
+    measurement: 'reported',
     input: 1200,
     output: 340,
     cached: 800,
@@ -56,5 +57,14 @@ describe('TokensCell', () => {
   it('renders a measured 0 as "0" (distinct from the unmeasured —)', () => {
     render(TokensCell, { usage: usage({ output: 0 }) });
     expect(screen.getByTestId('tokens-output')).toHaveTextContent('↓ 0');
+  });
+
+  it('marks estimated counts from a partial stream instead of presenting them as exact', () => {
+    render(TokensCell, { usage: usage({ measurement: 'estimated_partial' }) });
+    expect(screen.getByTestId('usage-measurement')).toHaveTextContent(/estimated/i);
+    expect(screen.getByTestId('tokens-cell')).toHaveAttribute(
+      'title',
+      expect.stringMatching(/partial stream/i),
+    );
   });
 });

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -993,5 +993,14 @@
   "Provider refresh failed: {error}": "Provider refresh failed: {error}",
   "Provider data refreshed": "Provider data refreshed",
   "Provider data refreshed at {time}": "Provider data refreshed at {time}",
-  "refresh available again in {duration}": "refresh available again in {duration}"
+  "refresh available again in {duration}": "refresh available again in {duration}",
+  "API-equivalent": "API-equivalent",
+  "API-equivalent estimate; subscription has no per-request charge": "API-equivalent estimate; subscription has no per-request charge",
+  "Estimated from a partial stream.": "Estimated from a partial stream.",
+  "Provider-reported usage": "Provider-reported usage",
+  "estimated · partial stream": "estimated · partial stream",
+  "partial": "partial",
+  "client aborted": "client aborted",
+  "truncated": "truncated",
+  "incomplete": "incomplete"
 }

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -993,5 +993,14 @@
   "Provider refresh failed: {error}": "Error al actualizar los proveedores: {error}",
   "Provider data refreshed": "Datos de proveedores actualizados",
   "Provider data refreshed at {time}": "Datos de proveedores actualizados a las {time}",
-  "refresh available again in {duration}": "se podrá actualizar de nuevo en {duration}"
+  "refresh available again in {duration}": "se podrá actualizar de nuevo en {duration}",
+  "API-equivalent": "equivalente de API",
+  "API-equivalent estimate; subscription has no per-request charge": "Estimación equivalente de API; la suscripción no cobra por solicitud",
+  "Estimated from a partial stream.": "Estimado a partir de un flujo parcial.",
+  "Provider-reported usage": "Uso informado por el proveedor",
+  "estimated · partial stream": "estimado · flujo parcial",
+  "partial": "parcial",
+  "client aborted": "abortado por el cliente",
+  "truncated": "truncado",
+  "incomplete": "incompleto"
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -993,5 +993,14 @@
   "Provider refresh failed: {error}": "プロバイダーの更新に失敗しました：{error}",
   "Provider data refreshed": "プロバイダーデータを更新しました",
   "Provider data refreshed at {time}": "{time} にプロバイダーデータを更新しました",
-  "refresh available again in {duration}": "{duration}後に再度更新できます"
+  "refresh available again in {duration}": "{duration}後に再度更新できます",
+  "API-equivalent": "API 相当",
+  "API-equivalent estimate; subscription has no per-request charge": "API 相当の推定値。サブスクリプションにはリクエスト単位の課金はありません",
+  "Estimated from a partial stream.": "部分的なストリームからの推定値です。",
+  "Provider-reported usage": "プロバイダー報告の使用量",
+  "estimated · partial stream": "推定 · 部分ストリーム",
+  "partial": "部分完了",
+  "client aborted": "クライアントが中止",
+  "truncated": "途中で終了",
+  "incomplete": "未完了"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -993,5 +993,14 @@
   "Provider refresh failed: {error}": "공급자 새로고침 실패: {error}",
   "Provider data refreshed": "공급자 데이터를 새로고침했습니다",
   "Provider data refreshed at {time}": "{time}에 공급자 데이터를 새로고침했습니다",
-  "refresh available again in {duration}": "{duration} 후 다시 새로고침할 수 있습니다"
+  "refresh available again in {duration}": "{duration} 후 다시 새로고침할 수 있습니다",
+  "API-equivalent": "API 환산",
+  "API-equivalent estimate; subscription has no per-request charge": "API 환산 추정치; 구독은 요청별 비용이 없습니다",
+  "Estimated from a partial stream.": "부분 스트림에서 추정한 값입니다.",
+  "Provider-reported usage": "제공자가 보고한 사용량",
+  "estimated · partial stream": "추정 · 부분 스트림",
+  "partial": "부분 완료",
+  "client aborted": "클라이언트 중단",
+  "truncated": "중간 종료",
+  "incomplete": "미완료"
 }

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -993,5 +993,14 @@
   "Provider refresh failed: {error}": "Falha ao atualizar os provedores: {error}",
   "Provider data refreshed": "Dados dos provedores atualizados",
   "Provider data refreshed at {time}": "Dados dos provedores atualizados às {time}",
-  "refresh available again in {duration}": "nova atualização disponível em {duration}"
+  "refresh available again in {duration}": "nova atualização disponível em {duration}",
+  "API-equivalent": "equivalente de API",
+  "API-equivalent estimate; subscription has no per-request charge": "Estimativa equivalente de API; a assinatura não cobra por solicitação",
+  "Estimated from a partial stream.": "Estimado a partir de um fluxo parcial.",
+  "Provider-reported usage": "Uso informado pelo provedor",
+  "estimated · partial stream": "estimado · fluxo parcial",
+  "partial": "parcial",
+  "client aborted": "abortado pelo cliente",
+  "truncated": "truncado",
+  "incomplete": "incompleto"
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -993,5 +993,14 @@
   "Provider refresh failed: {error}": "提供商刷新失败：{error}",
   "Provider data refreshed": "提供商数据已刷新",
   "Provider data refreshed at {time}": "提供商数据已于 {time} 刷新",
-  "refresh available again in {duration}": "{duration} 后可再次刷新"
+  "refresh available again in {duration}": "{duration} 后可再次刷新",
+  "API-equivalent": "API 等值",
+  "API-equivalent estimate; subscription has no per-request charge": "API 等值估算；订阅没有单次请求费用",
+  "Estimated from a partial stream.": "根据部分流估算。",
+  "Provider-reported usage": "提供商报告的用量",
+  "estimated · partial stream": "估算 · 部分流",
+  "partial": "部分完成",
+  "client aborted": "客户端已中止",
+  "truncated": "已截断",
+  "incomplete": "未完成"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -993,5 +993,14 @@
   "Provider refresh failed: {error}": "提供商重新整理失敗：{error}",
   "Provider data refreshed": "提供商資料已重新整理",
   "Provider data refreshed at {time}": "提供商資料已於 {time} 重新整理",
-  "refresh available again in {duration}": "{duration} 後可再次重新整理"
+  "refresh available again in {duration}": "{duration} 後可再次重新整理",
+  "API-equivalent": "API 等值",
+  "API-equivalent estimate; subscription has no per-request charge": "API 等值估算；訂閱沒有單次請求費用",
+  "Estimated from a partial stream.": "根據部分串流估算。",
+  "Provider-reported usage": "供應商回報的用量",
+  "estimated · partial stream": "估算 · 部分串流",
+  "partial": "部分完成",
+  "client aborted": "用戶端已中止",
+  "truncated": "已截斷",
+  "incomplete": "未完成"
 }

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -159,9 +159,18 @@ function requestItem(traceId: string): RequestListItem {
     final_model: 'gpt-4o',
     fallback_count: 0,
     status: 'ok',
+    stream_outcome: 'completed',
     latency_ms: 1200,
     cost_usd: 0.004,
-    usage: { input: 100, output: 20, cached: 0, cacheCreation: 0, nonCached: 100, total: 120 },
+    usage: {
+      measurement: 'reported',
+      input: 100,
+      output: 20,
+      cached: 0,
+      cacheCreation: 0,
+      nonCached: 100,
+      total: 120,
+    },
     tps: 30,
   };
 }

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -283,7 +283,16 @@
         <div>
           <dt class="text-xs uppercase tracking-wide text-slate-400">{$t('Status')}</dt>
           <dd class="mt-0.5">
-            {#if d.status === 'error'}
+            {#if d.stream_outcome === 'incomplete' || d.stream_outcome === 'client_aborted' || d.stream_outcome === 'truncated'}
+              <span class="badge-neutral">{$t('partial')}</span>
+              <span class="ml-1 text-xs text-ink-muted">
+                {d.stream_outcome === 'client_aborted'
+                  ? $t('client aborted')
+                  : d.stream_outcome === 'truncated'
+                    ? $t('truncated')
+                    : $t('incomplete')}
+              </span>
+            {:else if d.status === 'error'}
               <span class="badge-error">{$t('error')}</span>
             {:else}
               <span class="badge-ok">{$t('ok')}</span>
@@ -515,7 +524,11 @@
       <p class="field-help mb-2">
         {$t('What this single request cost, split across routing, optional eval, and completion.')}
       </p>
-      <CostBreakdown cost={d.cost_breakdown} />
+      <CostBreakdown
+        cost={d.cost_breakdown}
+        measurement={d.usage.measurement}
+        apiEquivalent={d.serving_account !== null}
+      />
     </section>
 
     <!-- Token usage: input / output / cached / non-cached split for this request -->

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -47,9 +47,11 @@ function item(traceId: string, overrides: Partial<RequestListItem> = {}): Reques
     final_model: 'claude-x',
     fallback_count: 1,
     status: 'ok',
+    stream_outcome: 'completed',
     latency_ms: 460,
     cost_usd: 0.0123,
     usage: {
+      measurement: 'reported',
       input: 1200,
       output: 340,
       cached: 800,
@@ -123,6 +125,7 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
     final_model: 'claude-x',
     lane: 'premium',
     status: 'ok',
+    stream_outcome: 'completed',
     latency_ms: 460,
     request_meta: { requested_model: 'gpt-4o' },
     payload_summary: 'payload withheld (redacted — only routing metadata is stored)',
@@ -162,6 +165,7 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
       total_usd: 0.0103,
     },
     usage: {
+      measurement: 'reported',
       input: 1200,
       output: 340,
       cached: 800,
@@ -490,6 +494,24 @@ describe('requests detail page', () => {
     expect(summary).toHaveTextContent('claude-x'); // served model
     expect(summary).toHaveTextContent('premium'); // lane
     expect(summary).toHaveTextContent('6.9s'); // total latency
+  });
+
+  it('shows a partial stream status and approximate cost/usage provenance on detail', () => {
+    render(DetailPage, {
+      data: {
+        detail: detail({
+          status: 'error',
+          stream_outcome: 'client_aborted',
+          usage: { ...detail().usage, measurement: 'estimated_partial' },
+        }),
+        payload: { captured: false },
+        traceId: 'tr_partial',
+      },
+    });
+
+    expect(screen.getByTestId('request-summary')).toHaveTextContent(/partial/i);
+    expect(screen.getByTestId('cost-completion')).toHaveTextContent('≈$0.01');
+    expect(screen.getAllByTestId('usage-measurement').at(-1)).toHaveTextContent(/estimated/i);
   });
 
   it('falls back to the prefix (and "—") in the summary for an unnamed/legacy record', () => {

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -15,6 +15,7 @@
     "@hono/node-server": "^2.0.4",
     "@hono/swagger-ui": "^0.6.1",
     "hono": "^4.12.23",
+    "gpt-tokenizer": "^3.4.0",
     "https-proxy-agent": "^9.1.0",
     "socks-proxy-agent": "^10.1.0",
     "undici": "^8.3.0",

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -297,6 +297,7 @@ function decision(traceId: string, lane: string): DecisionRecord {
     cost_breakdown: { eval_usd: null, completion_usd: 0.002, total_usd: 0.002 },
     memory: null,
     usage: null,
+    stream_outcome: null,
     generation_ms: null,
     serving_account: null,
   };

--- a/apps/gateway/src/routes/admin/replay.test.ts
+++ b/apps/gateway/src/routes/admin/replay.test.ts
@@ -695,6 +695,8 @@ describe("runReplay (anthropic_messages / openai_responses / gemini)", () => {
     expect(rec.payloads[0]?.responseJson).toContain("event: response.");
     expect(rec.inserts).toHaveLength(1);
     expect(rec.inserts[0]?.decision.usage).toEqual({
+      measurement: "reported",
+      cost_basis: null,
       prompt_tokens: 3,
       completion_tokens: 1,
       cached_tokens: null,

--- a/apps/gateway/src/routes/image-telemetry.ts
+++ b/apps/gateway/src/routes/image-telemetry.ts
@@ -87,6 +87,7 @@ export function buildImageDecision(p: {
         : { eval_usd: null, completion_usd: null, total_usd: null },
     memory: null,
     usage: hasUsageEvidence ? usage : null,
+    stream_outcome: null,
     generation_ms: null,
     serving_account: null,
   };

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -824,6 +824,88 @@ describe("createMessagesPipeline — openai_responses native passthrough streamI
       prompt_tokens: 12,
       completion_tokens: 9,
       cached_tokens: 4,
+      measurement: "reported",
+    });
+    expect(decisionRef.stream_outcome).toBe("completed");
+  });
+
+  it("estimates and prices a terminal-less partial stream consistently", async () => {
+    const partialFrames = [
+      'event: response.created\ndata: {"type":"response.created","response":{"status":"in_progress"}}\n\n',
+      'event: response.reasoning_summary_text.delta\ndata: {"type":"response.reasoning_summary_text.delta","delta":"Inspecting usage"}\n\n',
+      'event: response.custom_tool_call_input.delta\ndata: {"type":"response.custom_tool_call_input.delta","delta":"{\\"path\\":\\"/tmp/report.json\\"}"}\n\n',
+    ];
+    const stream = (async function* (): AsyncIterable<string> {
+      for (const frame of partialFrames) yield frame;
+    })();
+    const upstreamRequest = JSON.stringify({
+      model: "gpt-5.6-sol",
+      input: [{ role: "user", content: "Inspect this request." }],
+      stream: true,
+    });
+    const decisionRef = passthroughResponsesStreamResult(stream).decision;
+    Object.assign(decisionRef, {
+      final: { status: "ok", model_alias: "openai-codex/gpt-5.6-sol" },
+      cost_breakdown: { total_usd: null, completion_usd: null, eval_usd: null },
+      provider_attempts: [
+        {
+          alias: "openai-codex/gpt-5.6-sol",
+          skipped: false,
+          skip_reason: null,
+          status: "ok",
+          error_class: null,
+          latency_ms: 10,
+          cost_usd: null,
+        },
+      ],
+    });
+    const costOf = vi.fn().mockReturnValue(0.0042);
+    let now = 0;
+    const budget: PipelineBudgetDeps = {
+      gate: { check: async () => ({ overBudget: false }) as never },
+      settle: async () => {},
+      now: () => (now += 5),
+      costOf,
+    };
+    const recordOAuthUsage = vi.fn();
+    const pipeline = createMessagesPipeline(
+      () =>
+        Promise.resolve({
+          ...passthroughResponsesStreamResult(stream),
+          decision: decisionRef,
+          upstreamRequest,
+        }),
+      "openai_responses",
+      undefined,
+      budget,
+      recordOAuthUsage,
+    );
+
+    const run = await pipeline.run(irOf({ stream: true }), IDENTITY, new AbortController().signal);
+    for await (const _ of run.streamIR()) {
+      // drain the clean-but-terminal-less upstream EOF
+    }
+
+    expect(decisionRef.stream_outcome).toBe("truncated");
+    expect(decisionRef.final).toMatchObject({
+      status: "error",
+      error_reason: "upstream_error",
+    });
+    expect(decisionRef.usage).toMatchObject({
+      measurement: "estimated_partial",
+      prompt_tokens: expect.any(Number),
+      completion_tokens: expect.any(Number),
+    });
+    expect(decisionRef.generation_ms).toBeGreaterThan(0);
+    expect(costOf).toHaveBeenCalledWith(
+      "openai-codex/gpt-5.6-sol",
+      expect.objectContaining({ measurement: "estimated_partial" }),
+    );
+    expect(decisionRef.cost_breakdown.completion_usd).toBe(0.0042);
+    expect(decisionRef.provider_attempts[0]?.cost_usd).toBe(0.0042);
+    expect(recordOAuthUsage).toHaveBeenCalledWith(null, "openai-codex/gpt-5.6-sol", {
+      tokens: (decisionRef.usage?.prompt_tokens ?? 0) + (decisionRef.usage?.completion_tokens ?? 0),
+      costUsd: 0.0042,
     });
   });
 

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -41,7 +41,9 @@ import {
 } from "./native-memory-inject.js";
 import {
   backfillCompletionCost,
+  createResponsesDeltaAccumulator,
   createStreamGenerationTimer,
+  estimateInterruptedResponsesUsage,
   type StreamUsage,
   tokensFromUsage,
   usageFromAnthropicResponse,
@@ -1012,7 +1014,9 @@ export function createMessagesPipeline(
             // every frame (the last frame wins).
             const isUsageCarrierFrame = (data: string): boolean =>
               protocol === "openai_responses"
-                ? data.includes("response.completed") || data.includes("response.incomplete")
+                ? data.includes("response.completed") ||
+                  data.includes("response.incomplete") ||
+                  data.includes("response.failed")
                 : protocol === "gemini"
                   ? data.includes("usageMetadata")
                   : data.includes("message_start") || data.includes("message_delta");
@@ -1024,6 +1028,10 @@ export function createMessagesPipeline(
             // never retained, only its running concatenation in `assistant.text` which
             // observeOutbound consumes once.
             let usageBuffer = "";
+            // Only semantic token-bearing DELTAS are retained. Done snapshots and
+            // encrypted/base64 payloads are ignored, while fragments are joined
+            // before tokenization so network chunking cannot change the estimate.
+            const responsesDeltas = createResponsesDeltaAccumulator();
             const passthroughAssistant = { text: "" };
             try {
               for await (const frame of splitSSEFrames(passthroughStream)) {
@@ -1036,6 +1044,9 @@ export function createMessagesPipeline(
                   // (stays bounded). Anthropic/Responses need their distinct carriers
                   // appended (input on message_start, output on message_delta / terminal).
                   usageBuffer = protocol === "gemini" ? frame.raw : usageBuffer + frame.raw;
+                }
+                if (protocol === "openai_responses") {
+                  responsesDeltas.observe(frame.data);
                 }
                 if (memory !== undefined) {
                   if (protocol === "openai_responses") {
@@ -1061,14 +1072,38 @@ export function createMessagesPipeline(
               // budget settle, and per-account OAuth usage. All fail-open. The usage
               // extractor matches the inbound protocol (Responses totals on the terminal
               // event; Anthropic split across message_start/message_delta).
-              const nativeUsage =
+              const reportedUsage =
                 protocol === "openai_responses"
                   ? usageFromResponsesSSE(usageBuffer)
                   : protocol === "gemini"
                     ? usageFromGeminiSSE(usageBuffer)
                     : usageFromAnthropicSSE(usageBuffer);
+              // A provider terminal usage block, including explicit zeros, always
+              // wins. Any Responses stream without reported usage falls back to a
+              // partial estimate, including failed/incomplete terminals that omit it.
+              const nativeUsage =
+                reportedUsage ??
+                (protocol === "openai_responses"
+                  ? estimateInterruptedResponsesUsage(
+                      result.upstreamRequest,
+                      responsesDeltas.channels(),
+                      responsesDeltas.overflowBytes(),
+                    )
+                  : null);
               const finalAlias =
                 result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
+              if (protocol === "openai_responses") {
+                const outcome =
+                  responsesDeltas.outcome() ?? (signal.aborted ? "client_aborted" : "truncated");
+                result.decision.stream_outcome = outcome;
+                if (outcome === "client_aborted" || outcome === "truncated") {
+                  result.decision.final = {
+                    ...result.decision.final,
+                    status: "error",
+                    error_reason: outcome === "client_aborted" ? "client_abort" : "upstream_error",
+                  };
+                }
+              }
               if (memory !== undefined) {
                 const memoryObserve = memory.observe;
                 const responseMessages: IRMessage[] =
@@ -1088,20 +1123,22 @@ export function createMessagesPipeline(
                   ),
                 );
               }
-              if (nativeUsage) {
-                try {
-                  const cost =
-                    finalAlias && budget?.costOf ? budget.costOf(finalAlias, nativeUsage) : null;
-                  backfillCompletionCost(
-                    result.decision,
-                    finalAlias,
-                    cost,
-                    nativeUsage,
-                    genTimer.generationMs(),
-                  );
-                } catch {
-                  /* fail-open: leave cost/usage null on any mapping miss */
-                }
+              try {
+                const cost =
+                  nativeUsage && finalAlias && budget?.costOf
+                    ? budget.costOf(finalAlias, nativeUsage)
+                    : null;
+                // Generation time is independent of usage availability: even a
+                // malformed terminal frame must not erase the measured stream span.
+                backfillCompletionCost(
+                  result.decision,
+                  finalAlias,
+                  cost,
+                  nativeUsage,
+                  genTimer.generationMs(),
+                );
+              } catch {
+                /* fail-open: leave cost/usage null on any mapping miss */
               }
               await settleBudget(tokensFromUsage(nativeUsage));
               recordOAuthUsage?.(servingAccount, result.decision.final.model_alias, {
@@ -1207,20 +1244,20 @@ export function createMessagesPipeline(
             // wired costOf. Budget settlement remains gated inside settleBudget().
             const finalAlias =
               result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
-            if (lastUsage) {
-              try {
-                const cost =
-                  finalAlias && budget?.costOf ? budget.costOf(finalAlias, lastUsage) : null;
-                backfillCompletionCost(
-                  result.decision,
-                  finalAlias,
-                  cost,
-                  lastUsage,
-                  genTimer.generationMs(),
-                );
-              } catch {
-                /* fail-open: leave cost/usage null on any mapping miss */
-              }
+            try {
+              const cost =
+                lastUsage && finalAlias && budget?.costOf
+                  ? budget.costOf(finalAlias, lastUsage)
+                  : null;
+              backfillCompletionCost(
+                result.decision,
+                finalAlias,
+                cost,
+                lastUsage,
+                genTimer.generationMs(),
+              );
+            } catch {
+              /* fail-open: leave cost/usage null on any mapping miss */
             }
             await settleBudget(tokensFromUsage(lastUsage));
             // Per-account OAuth usage (providers page Tier 2) — recorded for every

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createWriteQueue } from "../runtime/write-queue.js";
 import {
   backfillCompletionCost,
+  createResponsesDeltaAccumulator,
   createSseCapture,
   createStreamGenerationTimer,
+  estimateInterruptedResponsesUsage,
   type PayloadCaptureDeps,
   persistPayload,
   type RecordServedDeps,
@@ -18,6 +20,134 @@ import {
   usageFromResponsesSSE,
   usageFromSSE,
 } from "./payload-capture.js";
+
+describe("estimateInterruptedResponsesUsage", () => {
+  it("aggregates fragmented channels once, dedupes sequence numbers, and ignores done snapshots", () => {
+    const accumulator = createResponsesDeltaAccumulator();
+    accumulator.observe(
+      JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        sequence_number: 7,
+        item_id: "call_1",
+        delta: '{"pa',
+      }),
+    );
+    accumulator.observe(
+      JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        sequence_number: 7,
+        item_id: "call_1",
+        delta: '{"pa',
+      }),
+    );
+    accumulator.observe(
+      JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        sequence_number: 8,
+        item_id: "call_1",
+        delta: 'th":"/tmp"}',
+      }),
+    );
+    accumulator.observe(
+      JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        sequence_number: 6,
+        item_id: "call_1",
+        delta: "replayed-old-event",
+      }),
+    );
+    accumulator.observe(
+      JSON.stringify({
+        type: "response.function_call_arguments.done",
+        sequence_number: 9,
+        item_id: "call_1",
+        arguments: '{"path":"/tmp"}',
+      }),
+    );
+
+    expect(accumulator.channels()).toEqual(['{"path":"/tmp"}']);
+    expect(accumulator.outcome()).toBeNull();
+  });
+
+  it("bounds retained deltas and accounts for overflow without retaining it", () => {
+    const accumulator = createResponsesDeltaAccumulator();
+    accumulator.observe(
+      JSON.stringify({
+        type: "response.output_text.delta",
+        sequence_number: 1,
+        item_id: "msg_1",
+        delta: "x".repeat(70_000),
+      }),
+    );
+
+    expect(accumulator.channels().join("").length).toBe(65_536);
+    expect(accumulator.overflowBytes()).toBe(4_464);
+    const usage = estimateInterruptedResponsesUsage(
+      null,
+      accumulator.channels(),
+      accumulator.overflowBytes(),
+    );
+    expect(usage?.completion_tokens).toBeGreaterThan(16_384);
+  });
+
+  it("estimates the semantic upstream request and observed Responses deltas", () => {
+    const upstreamRequest = JSON.stringify({
+      model: "gpt-5.6-sol",
+      input: [{ role: "user", content: "Explain the billing gap precisely." }],
+      stream: true,
+    });
+
+    const usage = estimateInterruptedResponsesUsage(upstreamRequest, [
+      "I inspected the stream.",
+      '{"path":"/tmp/report.json"}',
+    ]);
+
+    expect(usage).toMatchObject({
+      measurement: "estimated_partial",
+      cost_basis: "catalog_api_equivalent_estimate",
+      prompt_tokens: expect.any(Number),
+      completion_tokens: expect.any(Number),
+    });
+    expect(usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(usage?.completion_tokens).toBeGreaterThan(0);
+    expect(usage?.total_tokens).toBe((usage?.prompt_tokens ?? 0) + (usage?.completion_tokens ?? 0));
+  });
+
+  it("does not tokenize embedded base64 bytes as prompt text", () => {
+    const usage = estimateInterruptedResponsesUsage(
+      JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: [
+          {
+            role: "user",
+            content: [
+              { type: "input_text", text: "Describe this image." },
+              { type: "input_image", image_url: `data:image/png;base64,${"A".repeat(20_000)}` },
+            ],
+          },
+        ],
+        stream: true,
+      }),
+      [],
+    );
+
+    expect(usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(usage?.prompt_tokens).toBeLessThan(100);
+  });
+
+  it("uses the bounded fallback for a very large semantic prompt", () => {
+    const usage = estimateInterruptedResponsesUsage(
+      JSON.stringify({ input: [{ role: "user", content: "x".repeat(100_000) }] }),
+      [],
+    );
+
+    expect(usage?.prompt_tokens).toBeGreaterThan(20_000);
+  });
+
+  it("returns null when neither a request nor an observed delta exists", () => {
+    expect(estimateInterruptedResponsesUsage(null, [])).toBeNull();
+  });
+});
 
 describe("usageFromSSE", () => {
   it("extracts the final usage chunk emitted with include_usage", () => {
@@ -397,7 +527,8 @@ describe("usageFromResponsesResponse", () => {
 
 // Native-protocol-passthrough STREAMING cost for openai_responses (#217 Phase 3
 // Stage 1): the upstream Codex Responses SSE carries the totals on the terminal
-// `response.completed` (or `response.incomplete`) event's `response.usage`. Byte-
+// `response.completed`, `response.incomplete`, or `response.failed` event's
+// `response.usage`. Byte-
 // faithful passthrough forwards these frames VERBATIM, so cost extraction scans the
 // accumulated SSE for that event. usageFromResponsesSSE returns the same OpenAI-shaped
 // StreamUsage as the non-stream extractor, mirroring aggregateResponsesStream.
@@ -437,6 +568,23 @@ describe("usageFromResponsesSSE", () => {
       prompt_tokens: 40,
       completion_tokens: 3,
       total_tokens: 43,
+    });
+  });
+
+  it("keeps explicit zero usage from response.failed as reported evidence", () => {
+    const sse =
+      'event: response.failed\ndata: {"type":"response.failed","response":{"status":"failed","usage":{"input_tokens":0,"output_tokens":0}}}\n\n';
+    const usage = usageFromResponsesSSE(sse);
+    expect(usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+    const d = decision();
+    backfillCompletionCost(d, "openai/gpt", null, usage);
+    expect(d.usage).toMatchObject({
+      measurement: "reported",
+      cost_basis: null,
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      cached_tokens: null,
+      cache_creation_tokens: null,
     });
   });
 
@@ -764,6 +912,8 @@ describe("backfillCompletionCost", () => {
       prompt_tokens_details: { cached_tokens: 80 },
     });
     expect(d.usage).toEqual({
+      measurement: "reported",
+      cost_basis: null,
       prompt_tokens: 120,
       completion_tokens: 34,
       cached_tokens: 80,
@@ -790,6 +940,8 @@ describe("backfillCompletionCost", () => {
     });
     // prompt = input + cache_read + cache_creation (core's Anthropic normalization).
     expect(d.usage).toEqual({
+      measurement: "reported",
+      cost_basis: null,
       prompt_tokens: 90,
       completion_tokens: 20,
       cached_tokens: 30,
@@ -825,6 +977,8 @@ describe("backfillCompletionCost", () => {
     });
 
     expect(d.usage).toEqual({
+      measurement: "reported",
+      cost_basis: null,
       prompt_tokens: 1_000,
       completion_tokens: 1_220,
       cached_tokens: 200,

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -1,6 +1,7 @@
 import type { DecisionRecord, TelemetryStore } from "@helm/core";
 import { billedCostFromBody, usageFromBody as parseUsage } from "@helm/core";
 import type { TokenUsageBreakdown } from "@helm/shared";
+import { countTokens as countO200kHarmonyTokens } from "gpt-tokenizer/encoding/o200k_harmony";
 import type { WriteQueue } from "../runtime/write-queue.js";
 
 // Shared full request/response capture + streamed-cost backfill helpers, used by
@@ -26,6 +27,10 @@ export interface PayloadCaptureDeps {
 }
 
 export interface StreamUsage {
+  /** Helm provenance for locally reconstructed partial-stream usage. Provider
+   * usage objects omit this and therefore remain authoritative `reported`. */
+  measurement?: "reported" | "estimated_partial";
+  cost_basis?: "catalog_api_equivalent_estimate";
   prompt_tokens?: number;
   completion_tokens?: number;
   total_tokens?: number;
@@ -65,6 +70,214 @@ export interface StreamUsage {
    *  uses `cost`; others `cost_usd`. resolveCostUsd prefers these over the estimate. */
   cost?: number;
   cost_usd?: number;
+}
+
+/** Inspect one native Responses event without retaining the whole SSE body. */
+export function inspectResponsesStreamEvent(data: string): {
+  delta: string | null;
+  outcome: "completed" | "incomplete" | "failed" | null;
+  sequenceNumber: number | null;
+  channel: string | null;
+} {
+  let event: {
+    type?: unknown;
+    delta?: unknown;
+    sequence_number?: unknown;
+    item_id?: unknown;
+    output_index?: unknown;
+    content_index?: unknown;
+  };
+  try {
+    event = JSON.parse(data) as { type?: unknown; delta?: unknown };
+  } catch {
+    return { delta: null, outcome: null, sequenceNumber: null, channel: null };
+  }
+  if (!event || typeof event !== "object" || typeof event.type !== "string") {
+    return { delta: null, outcome: null, sequenceNumber: null, channel: null };
+  }
+  const sequenceNumber =
+    typeof event.sequence_number === "number" && Number.isInteger(event.sequence_number)
+      ? event.sequence_number
+      : null;
+  if (event.type === "response.completed") {
+    return { delta: null, outcome: "completed", sequenceNumber, channel: null };
+  }
+  if (event.type === "response.incomplete") {
+    return { delta: null, outcome: "incomplete", sequenceNumber, channel: null };
+  }
+  if (
+    event.type === "response.failed" ||
+    event.type === "response.cancelled" ||
+    event.type === "error"
+  ) {
+    return { delta: null, outcome: "failed", sequenceNumber, channel: null };
+  }
+  const tokenBearingDelta =
+    event.type === "response.output_text.delta" ||
+    event.type === "response.refusal.delta" ||
+    event.type === "response.reasoning_text.delta" ||
+    event.type === "response.reasoning_summary_text.delta" ||
+    event.type === "response.function_call_arguments.delta" ||
+    event.type === "response.custom_tool_call_input.delta" ||
+    event.type === "response.code_interpreter_call_code.delta";
+  const channelIdentity = [
+    typeof event.item_id === "string" ? event.item_id : null,
+    typeof event.output_index === "number" ? `output-${event.output_index}` : null,
+    typeof event.content_index === "number" ? `content-${event.content_index}` : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(":");
+  return {
+    delta: tokenBearingDelta && typeof event.delta === "string" ? event.delta : null,
+    outcome: null,
+    sequenceNumber,
+    channel: tokenBearingDelta ? `${event.type}:${channelIdentity || "default"}` : null,
+  };
+}
+
+export interface ResponsesDeltaAccumulator {
+  observe(data: string): void;
+  channels(): string[];
+  overflowBytes(): number;
+  outcome(): "completed" | "incomplete" | "failed" | null;
+}
+
+/** Collect semantic Responses deltas independently of network fragmentation. */
+export function createResponsesDeltaAccumulator(): ResponsesDeltaAccumulator {
+  const maxRetainedChars = 65_536;
+  const channels = new Map<string, string[]>();
+  let retainedChars = 0;
+  let droppedBytes = 0;
+  let lastSequenceNumber: number | null = null;
+  let terminalOutcome: "completed" | "incomplete" | "failed" | null = null;
+  return {
+    observe(data): void {
+      const inspected = inspectResponsesStreamEvent(data);
+      if (
+        inspected.sequenceNumber !== null &&
+        lastSequenceNumber !== null &&
+        inspected.sequenceNumber <= lastSequenceNumber
+      ) {
+        return;
+      }
+      if (inspected.sequenceNumber !== null) lastSequenceNumber = inspected.sequenceNumber;
+      if (inspected.delta !== null && inspected.channel !== null) {
+        const available = Math.max(0, maxRetainedChars - retainedChars);
+        const retained = inspected.delta.slice(0, available);
+        const dropped = inspected.delta.slice(available);
+        if (retained.length > 0) {
+          const chunks = channels.get(inspected.channel) ?? [];
+          chunks.push(retained);
+          channels.set(inspected.channel, chunks);
+          retainedChars += retained.length;
+        }
+        if (dropped.length > 0) droppedBytes += Buffer.byteLength(dropped, "utf8");
+      }
+      if (inspected.outcome !== null) terminalOutcome = inspected.outcome;
+    },
+    channels(): string[] {
+      return [...channels.values()].map((chunks) => chunks.join(""));
+    },
+    overflowBytes(): number {
+      return droppedBytes;
+    },
+    outcome(): "completed" | "incomplete" | "failed" | null {
+      return terminalOutcome;
+    },
+  };
+}
+
+function semanticResponsesRequestText(raw: string): string {
+  let request: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return raw;
+    request = parsed as Record<string, unknown>;
+  } catch {
+    return raw;
+  }
+
+  const sanitize = (value: unknown, key = ""): unknown => {
+    if (typeof value === "string") {
+      const binaryLikeKey = /(?:image|audio|file|data|base64)/i.test(key);
+      const dataUrl = value.startsWith("data:") && value.includes(";base64,");
+      return binaryLikeKey && (dataUrl || value.length > 4096) ? "[binary content]" : value;
+    }
+    if (Array.isArray(value)) return value.map((item) => sanitize(item, key));
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([childKey, child]) => [
+          childKey,
+          sanitize(child, childKey),
+        ]),
+      );
+    }
+    return value;
+  };
+
+  // Token-bearing request dimensions only. Transport controls are excluded;
+  // opaque previous_response_id history remains unobservable, so this is an estimate.
+  return JSON.stringify({
+    instructions: sanitize(request.instructions, "instructions"),
+    input: sanitize(request.input, "input"),
+    tools: sanitize(request.tools, "tools"),
+    tool_choice: sanitize(request.tool_choice, "tool_choice"),
+    response_format: sanitize(request.response_format, "response_format"),
+  });
+}
+
+/**
+ * Reconstruct partial usage when a native Responses stream ends before a terminal
+ * usage event. Prompt tokens are an o200k-harmony estimate over the serialized
+ * upstream wire request. Completion tokens are estimated from the semantic
+ * text/reasoning/tool deltas Helm actually received. Cache hits, hidden
+ * reasoning and provider-side adjustments remain unknowable, hence
+ * `measurement="estimated_partial"` rather than an exact claim.
+ */
+export function estimateInterruptedResponsesUsage(
+  upstreamRequest: string | null | undefined,
+  observedDeltas: readonly string[],
+  observedOverflowBytes = 0,
+): StreamUsage | null {
+  const requestText = upstreamRequest ? semanticResponsesRequestText(upstreamRequest) : "";
+  if (
+    requestText.length === 0 &&
+    observedOverflowBytes === 0 &&
+    observedDeltas.every((delta) => delta.length === 0)
+  )
+    return null;
+
+  const estimate = (text: string): number => {
+    if (text.length === 0) return 0;
+    const byteEstimate = (): number => Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
+    // gpt-tokenizer becomes disproportionately expensive on very large prompts.
+    // Interrupted streams must never turn accounting into an event-loop stall, so
+    // large semantic payloads use Helm's existing deterministic byte estimate.
+    if (text.length > 16_384) return byteEstimate();
+    try {
+      // Treat marker-looking user text as ordinary content, not tokenizer control
+      // tokens. An empty disallowed set disables special-token recognition.
+      return countO200kHarmonyTokens(text, { disallowedSpecial: new Set() });
+    } catch {
+      // The estimator itself must stay fail-open. UTF-8 bytes/4 is the same
+      // deterministic fallback used by the Responses /input_tokens surface.
+      return byteEstimate();
+    }
+  };
+  const promptTokens = estimate(requestText);
+  // Each entry is one semantic output channel after all of its network fragments
+  // were joined. Sum channels separately so unrelated text/tool/reasoning content
+  // cannot create artificial BPE merges at their boundaries.
+  const completionTokens =
+    observedDeltas.reduce((total, channel) => total + estimate(channel), 0) +
+    Math.ceil(observedOverflowBytes / 4);
+  return {
+    measurement: "estimated_partial",
+    cost_basis: "catalog_api_equivalent_estimate",
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens + completionTokens,
+  };
 }
 
 export function captureEnabled(deps: PayloadCaptureDeps): boolean {
@@ -466,8 +679,8 @@ export function usageFromGeminiSSE(raw: string): StreamUsage | null {
 
 // Native-protocol-passthrough STREAMING cost for openai_responses (#217 Phase 3).
 // Unlike Anthropic (usage split across message_start/message_delta), the Codex
-// Responses SSE carries the totals on the TERMINAL event — `response.completed` or
-// `response.incomplete` (truncation / content filter) — under `response.usage`. The
+// Responses SSE carries the totals on a TERMINAL event — `response.completed`,
+// `response.incomplete`, or `response.failed` — under `response.usage`. The
 // byte-faithful passthrough forwards these frames VERBATIM, so cost extraction scans
 // the accumulated SSE for that event and normalizes its usage the SAME way as the
 // non-stream extractor (mirroring aggregateResponsesStream). Frames are split on the
@@ -494,7 +707,13 @@ export function usageFromResponsesSSE(raw: string): StreamUsage | null {
       continue;
     }
     if (!evt || typeof evt !== "object") continue;
-    if (evt.type !== "response.completed" && evt.type !== "response.incomplete") continue;
+    if (
+      evt.type !== "response.completed" &&
+      evt.type !== "response.incomplete" &&
+      evt.type !== "response.failed"
+    ) {
+      continue;
+    }
     const response = (evt.response ?? {}) as Record<string, unknown>;
     const usage = response.usage;
     if (!usage || typeof usage !== "object") continue;
@@ -690,6 +909,9 @@ export function tokenBreakdownFromUsage(
 ): TokenUsageBreakdown {
   const t = parseUsage({ usage: u });
   return {
+    measurement: u.measurement === "estimated_partial" ? "estimated_partial" : "reported",
+    cost_basis:
+      u.cost_basis === "catalog_api_equivalent_estimate" ? "catalog_api_equivalent_estimate" : null,
     prompt_tokens: t.promptTokens ?? null,
     completion_tokens: t.completionTokens ?? null,
     cached_tokens: t.cachedPromptTokens ?? null,

--- a/apps/gateway/src/routes/portal/index.test.ts
+++ b/apps/gateway/src/routes/portal/index.test.ts
@@ -94,6 +94,8 @@ function decision(overrides: Partial<DecisionRecord> = {}): DecisionRecord {
     cost_breakdown: { eval_usd: null, completion_usd: 0.02, total_usd: 0.02 },
     memory: null,
     usage: {
+      measurement: "reported",
+      cost_basis: null,
       prompt_tokens: 10,
       completion_tokens: 5,
       cached_tokens: 0,
@@ -107,6 +109,7 @@ function decision(overrides: Partial<DecisionRecord> = {}): DecisionRecord {
       image_output_tokens: null,
       billed_cost_usd: null,
     },
+    stream_outcome: "completed",
     generation_ms: 300,
     ...overrides,
   };

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1,11 +1,19 @@
-import { CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER, UpstreamError } from "@helm/core";
+import {
+  CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
+  type DecisionRecord,
+  UpstreamError,
+} from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "../responses-websocket-internal.js";
 import type { MessagesIdentity } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
 import type { RecordServedDeps } from "./payload-capture.js";
-import { type ResponsesRouteDeps, registerResponsesRoute } from "./responses.js";
+import {
+  type ResponsesRouteDeps,
+  registerResponsesRoute,
+  settleResponsesStreamOutcome,
+} from "./responses.js";
 
 // POST /v1/responses contract: auth → translate(out) → route → translate(back),
 // OpenAI error envelope, non-streaming only. All business logic is stubbed; the
@@ -18,6 +26,27 @@ const AUTH = { Authorization: "Bearer helm_live_secret", "Content-Type": "applic
 // `model_alias` marker lets a test assert the redacted decision actually rode the
 // insert call.
 const FAKE_DECISION = { final: { status: "ok", model_alias: "gpt-4o" } } as never;
+
+describe("settleResponsesStreamOutcome", () => {
+  it("gives an overall request timeout precedence over an AbortError", () => {
+    const decision = {
+      final: { status: "ok", model_alias: "gpt-4o", error_reason: null },
+      stream_outcome: null,
+    } as unknown as DecisionRecord;
+
+    const outcome = settleResponsesStreamOutcome({
+      decision,
+      streamStatus: null,
+      caughtAbort: true,
+      caughtErrorReason: null,
+      timedOut: true,
+    });
+
+    expect(outcome).toBe("failed");
+    expect(decision.stream_outcome).toBe("failed");
+    expect(decision.final).toMatchObject({ status: "error", error_reason: "timeout" });
+  });
+});
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
@@ -1577,7 +1606,12 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
 
   it("client abort emits NO error frame (benign non-provider fault)", async () => {
     const ac = new AbortController();
+    const { record, insert } = makeRecord();
+    const decision = {
+      final: { status: "ok", model_alias: "gpt-4o", error_reason: null },
+    } as never;
     const { deps } = makeDeps({
+      record,
       transformRequestOut: () => ({
         stream: true,
         model: "auto",
@@ -1589,6 +1623,15 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
         ac.abort();
         throw new Error("aborted");
       },
+      run: async () => ({
+        decision,
+        collect: async () => ({}),
+        streamIR: async function* () {
+          yield { type: "response.created", sequence_number: 0 };
+          ac.abort();
+          throw new Error("aborted");
+        },
+      }),
     });
     const app = buildApp(deps);
     const res = await app.request("/v1/responses", {
@@ -1599,6 +1642,17 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
     const frames = parseSSE(await res.text());
     expect(frames.some((f) => f.event === "error")).toBe(false);
+    const recorded = insert.mock.calls[0]?.[0] as {
+      decision: {
+        final: { status: string; error_reason: string | null };
+        stream_outcome: string;
+      };
+    };
+    expect(recorded.decision.final).toMatchObject({
+      status: "error",
+      error_reason: "client_abort",
+    });
+    expect(recorded.decision.stream_outcome).toBe("client_aborted");
   });
 
   it("maps a structurally invalid Responses body (transformer throws) to 400", async () => {
@@ -1755,6 +1809,57 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(insert).toHaveBeenCalledOnce();
     const arg = insert.mock.calls[0]?.[0] as { apiKeyId: string };
     expect(arg.apiKeyId).toBe("k1");
+  });
+
+  it("records a clean terminal-less stream as truncated instead of ok", async () => {
+    const { record, insert } = makeRecord();
+    const put = vi.fn();
+    const decision = {
+      final: { status: "ok", model_alias: "gpt-4o", error_reason: null },
+      provider_attempts: [],
+    } as never;
+    const { deps } = makeDeps({
+      record,
+      registry: { put, get: vi.fn() },
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      run: async () => ({
+        decision,
+        collect: async () => ({}),
+        streamIR: async function* () {
+          yield { type: "response.created", sequence_number: 0 };
+          yield {
+            type: "response.output_text.delta",
+            sequence_number: 1,
+            delta: "partial",
+          };
+        },
+      }),
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    await res.text();
+
+    const recorded = insert.mock.calls[0]?.[0] as {
+      decision: {
+        final: { status: string; error_reason: string | null };
+        stream_outcome: string;
+      };
+    };
+    expect(recorded.decision.final).toMatchObject({
+      status: "error",
+      error_reason: "upstream_error",
+    });
+    expect(recorded.decision.stream_outcome).toBe("truncated");
   });
 
   it("does not record when no record dep is wired (existing tests stay green)", async () => {
@@ -2208,7 +2313,7 @@ describe("streamStatusFromEventName — incomplete / failed / cancelled cases (l
     );
   });
 
-  it("records status='cancelled' when the stream emits a response.cancelled event", async () => {
+  it("normalizes response.cancelled to the failed stream outcome", async () => {
     const put = vi.fn();
     const cancelledData = JSON.stringify({
       type: "response.cancelled",
@@ -2231,7 +2336,7 @@ describe("streamStatusFromEventName — incomplete / failed / cancelled cases (l
     });
     await res.text();
     expect(put).toHaveBeenCalledWith(
-      expect.objectContaining({ responseId: "resp_cancel_1", status: "cancelled" }),
+      expect.objectContaining({ responseId: "resp_cancel_1", status: "failed" }),
     );
   });
 });

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -392,6 +392,43 @@ function streamStatusFromEventName(eventName: string): string | null {
   }
 }
 
+type ResponsesStreamOutcome = NonNullable<DecisionRecord["stream_outcome"]>;
+
+export function settleResponsesStreamOutcome(args: {
+  decision: DecisionRecord;
+  streamStatus: string | null;
+  caughtAbort: boolean;
+  caughtErrorReason: string | null;
+  timedOut: boolean;
+}): ResponsesStreamOutcome {
+  const outcome: ResponsesStreamOutcome = args.timedOut
+    ? "failed"
+    : args.caughtAbort
+      ? "client_aborted"
+      : args.caughtErrorReason !== null
+        ? "failed"
+        : args.streamStatus === "completed"
+          ? "completed"
+          : args.streamStatus === "incomplete"
+            ? "incomplete"
+            : args.streamStatus === "failed" || args.streamStatus === "cancelled"
+              ? "failed"
+              : "truncated";
+  args.decision.stream_outcome = outcome;
+  if (outcome === "client_aborted" || outcome === "truncated" || outcome === "failed") {
+    args.decision.final = {
+      ...args.decision.final,
+      status: "error",
+      error_reason: args.timedOut
+        ? "timeout"
+        : outcome === "client_aborted"
+          ? "client_abort"
+          : (args.caughtErrorReason ?? "upstream_error"),
+    };
+  }
+  return outcome;
+}
+
 function responseSnapshotFromStreamFrame(
   eventName: string,
   data: string,
@@ -654,6 +691,7 @@ function compactDecision(args: {
     },
     memory: null,
     usage: usage === null ? null : tokenBreakdownFromUsage(usage),
+    stream_outcome: null,
     generation_ms: null,
   };
 }
@@ -1063,6 +1101,8 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         let lastWrite: string | null = null;
         let streamResponseId: string | null = null;
         let streamStatus: string | null = null;
+        let caughtAbort = false;
+        let caughtErrorReason: string | null = null;
         try {
           if (initialError !== null) throw initialError;
           if (result === null) throw new Error("Responses pipeline did not return a result");
@@ -1105,7 +1145,15 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           // before the stream started — writes a SINGLE terminal Responses-shaped
           // error event DIRECTLY into the stream. We CANNOT throw here (the stream
           // has already started; onError would never see it).
-          if (!isAbort(err, c.req.raw.signal)) {
+          if (isAbort(err, c.req.raw.signal)) {
+            caughtAbort = true;
+          } else {
+            caughtErrorReason =
+              err instanceof PipelineError
+                ? err.error_class
+                : isUpstreamTimeout(err)
+                  ? "timeout"
+                  : "upstream_error";
             const body =
               err instanceof PipelineError
                 ? responsesStreamError({
@@ -1127,6 +1175,16 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           }
         } finally {
           releaseConcurrency?.();
+          const streamOutcome =
+            result === null
+              ? null
+              : settleResponsesStreamOutcome({
+                  decision: result.decision,
+                  streamStatus,
+                  caughtAbort,
+                  caughtErrorReason,
+                  timedOut: requestTimedOut(c),
+                });
           // Record AFTER releaseConcurrency so the bookkeeping never extends the
           // concurrency hold, and AFTER the for-await loop ended so the pipeline's
           // own streamIR finally (cost backfill) already mutated result.decision.
@@ -1168,7 +1226,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                   : null,
               createdAt: Date.now(),
               expiresAt: Date.now() + 86_400_000,
-              status: streamStatus ?? "completed",
+              status: streamOutcome ?? "truncated",
             });
           }
         }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-15 · 终端事件缺失的 Responses 流使用部分估算计费（Protocol streaming / telemetry accounting，docs/05/07，原则 3/5/7/8）
+
+- **终态语义**：provider 已产出首包仍保留成功 attempt，但 Responses 流只有收到 `response.completed` / `response.incomplete` / `response.failed` 才算有上游终态；无终态的自然 EOF 记为 `stream_outcome=truncated`、下游 abort 记为 `client_aborted`，request `final.status` 改为 error，分别使用 `upstream_error` / `client_abort`，不再把部分消费伪装成完整成功。`response.incomplete` 保留其独立终态；provider 明确报告的 usage（包括全 0）永远优先。
+- **估算边界**：只在原生 Responses 流缺少 usage 时，对去除 transport 字段与内嵌 binary/base64 的语义 upstream request，以及实际收到的 output/reasoning/tool-call semantic delta 做 `estimated_partial` 估算。16 KiB 内使用 o200k-harmony，超过后改用既有 UTF-8 bytes/4 确定性估算，避免大上下文在 stream finally 阻塞事件循环；sequence number 去重，同一 semantic channel 的碎片先拼接，done snapshot 与 encrypted/base64 数据不参与。cache、cache creation 与隐藏 reasoning 不猜测，保持 null。估算费用沿现有 catalog `costOf` 计算，并以 `cost_basis=catalog_api_equivalent_estimate` 标记，不能解释为 provider 实际账单。
+- **一致性边界**：同一份部分 usage/cost 同时写入 telemetry usage、成功 provider attempt、key budget 与实际 serving account 的 OAuth usage；每项只结算一次。stream generation window 与 usage 解耦，即使 usage 解析失败也保留 `generation_ms`。registry 使用同一 `stream_outcome`，不再把缺失终态默认成 completed。
+
 ## 2026-07-15 · 历史费用回填改由常驻 supervisor 持续推进（Catalog / telemetry repair operations，docs/07/08，原则 2/3/5/7）
 
 - **执行边界**：一次性 Codex automation 改为 host systemd 常驻 supervisor；它通过非阻塞 `flock` 保证唯一执行者，并把大阶段拆成每次最多 100 行的独立 CLI 进程。每批提交并落盘 checkpoint 后才进入下一批，因此 SIGTERM、容器短暂不可用或 supervisor 重启都只会从原子 checkpoint 恢复，不需要大事务、整库备份或 `kill -9`。
@@ -68,15 +74,9 @@
 - **修复边界**：provider 专用 Chat→Responses 与共享 IR→Responses 两条路径统一把 multipart 工具结果文本编码为 `input_text`；字符串工具结果仍保持字符串，`input_image` 与 `input_file` 保持原 wire shape。助手消息正文继续使用 `output_text`，不扩大成全局 content-part 改写，也不改变 `invalid_request` fallback 语义。
 - **验证**：TDD 红灯同时覆盖 provider、共享 transformer 与真实 Anthropic `tool_result`→Codex Responses 链路；定向 Vitest 绿灯为 2 files / 274 tests。
 
-## 2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）
-
-- **生产证据与根因**：生产 `oauth_quota` 中四个 Codex 账号都出现 `primary + windowMinutes:10080`，截图中的唯一窗口虽显示 `5h`，重置倒计时却是 `6d 22h`。上游不同套餐不再保证 `primary=5h / secondary=7d`，Admin 的位置硬编码因此把真实周配额错标为 5h；同一假设还会让手动/自动 reset-credit 误报周快照不可用。
-- **统一判定**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威；只有旧 header 快照缺少 duration 且窗口有真实用量时才兼容回退到 `secondary`。带非默认 `limitId` 的 model-scoped 窗口绝不当作账号周配额。Admin 标签同样时长优先（300m→5h、10080m→Weekly）；有意义的缺时长窗口显示中性的 Primary/Secondary，空的已过期占位窗口则直接过滤。
-- **账号边界**：规则完全 plan-agnostic，覆盖 Codex Plus/Pro/Team/Business/Enterprise/Edu 等实际窗口形态，不按套餐名维护分支。Claude 继续使用其 5h/7d keys；Copilot、SuperGrok 与普通 API-key provider 没有可验证的同类 Codex reset-credit 周窗口，不套用本规则或伪造数据。
-- **验证**：共享 predicate、Admin 单周窗口、reset-credit UI、自动重置与持久 guard 均增加 `primary + 10080m` 回归；同时覆盖 `secondary + 300m` 不误判、缺 duration 的 legacy fallback，以及 model-scoped 周窗口隔离。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威，旧快照仅在缺 duration 且有真实用量时回退 secondary；Admin、reset-credit 与 model-scoped 隔离共用同一规则。
 - **2026-07-12 · Grok premium fallback 与 Composer 评估边界（Routing / provider evaluation，docs/04/07，原则 2/3/5/6/7）**：移除 official OpenAI/ZenMux 自动付费候选，premium 以已验证的 SuperGrok Grok 4.5 作为订阅 fallback；Composer 因真实 A/B 的空响应与质量不足不进 lane，底层 transport/发现保留，xAI Admin 选择器补 curated 展示但运行时 entitlement 继续 fail-closed。
 - **2026-07-12 · SuperGrok 周配额使用现有 OAuth 读取私有 gRPC-Web credits（OAuth subscription / Admin providers，docs/04/09/11，原则 3/6/7）**：复用现有 xAI OAuth bearer 严格读取 weekly gRPC-Web credits，按账号持久化 quota/cooldown 并以 cache epoch 隔离重连竞态；不保存 Cookie、不混用月度/public billing。
 - **2026-07-12 · SuperGrok/X Premium OAuth 实验性订阅 Provider（OAuth subscription / Responses / Admin providers，docs/04/09/10/11，原则 2/3/6/7/8）**：通过受限 device-code OAuth、加密 token、generic Responses executor 与严格 host/redirect/body-size 边界接入实验性 SuperGrok；动态 entitlement、SSE 聚合、Admin 状态及真实协议矩阵完成验证，Composer 保持 unpriced，Grok 4.5 后续按公开 API 等价费率计 telemetry。

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -955,6 +955,7 @@ export async function routeRequest(
       memory: null,
       // Token counts come from the served usage tail (gateway-stamped) — null here.
       usage: null,
+      stream_outcome: null,
       // Served-stream generation window is gateway-timed/stamped — null here.
       generation_ms: null,
       // Concrete subscription account is gateway-stamped after execution.
@@ -1039,6 +1040,7 @@ export async function routeRequest(
     memory: null,
     // Token counts come from the served usage tail (gateway-stamped) — null here.
     usage: null,
+    stream_outcome: null,
     // Served-stream generation window is gateway-timed/stamped — null here.
     generation_ms: null,
     // Concrete subscription account is gateway-stamped after execution.

--- a/packages/core/src/signals/aggregate.test.ts
+++ b/packages/core/src/signals/aggregate.test.ts
@@ -53,6 +53,7 @@ function makeRecord(over: {
     cost_breakdown: { eval_usd: null, completion_usd: null, total_usd: null },
     memory: null,
     usage: null,
+    stream_outcome: null,
     generation_ms: null,
     serving_account: null,
   };

--- a/packages/core/src/signals/collector.test.ts
+++ b/packages/core/src/signals/collector.test.ts
@@ -42,6 +42,7 @@ function makeRecord(taskType: string, lane: string): DecisionRecord {
     cost_breakdown: { eval_usd: null, completion_usd: 0.001, total_usd: 0.001 },
     memory: null,
     usage: null,
+    stream_outcome: null,
     generation_ms: null,
     serving_account: null,
   };

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -363,6 +363,7 @@ describe("Store ports are implementable contracts", () => {
       cost_breakdown: { eval_usd: null, completion_usd: null, total_usd: null },
       memory: null,
       usage: null,
+      stream_outcome: null,
       generation_ms: null,
       serving_account: null,
     } satisfies DecisionRecord;

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -52,6 +52,7 @@ function decision(requestId: string, overrides: Partial<DecisionRecord> = {}): D
     cost_breakdown: { eval_usd: null, completion_usd: 0.004, total_usd: 0.004 },
     memory: null,
     usage: null,
+    stream_outcome: null,
     generation_ms: null,
     serving_account: null,
     ...overrides,

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -83,6 +83,8 @@ const drivers: Driver[] = [
 ];
 
 const unreportedUsageDimensions = {
+  measurement: "reported",
+  cost_basis: null,
   prompt_tokens: null,
   completion_tokens: null,
   cached_tokens: null,
@@ -151,6 +153,7 @@ function decision(requestId: string, overrides: DecisionOverrides = {}): Decisio
     cost_breakdown: { eval_usd: null, completion_usd: 0.004, total_usd: 0.004 },
     memory: null,
     usage: null,
+    stream_outcome: null,
     generation_ms: null,
     serving_account: null,
     ...rest,

--- a/packages/core/src/telemetry/decision.ts
+++ b/packages/core/src/telemetry/decision.ts
@@ -209,6 +209,7 @@ export function buildDecisionRecord(parts: DecisionParts): DecisionRecord {
     // core (like streamed completion cost) — the gateway stamps them post-served
     // via backfillCompletionCost. The builder always emits null.
     usage: null,
+    stream_outcome: null,
     // Served-stream generation window is timed in the GATEWAY (first→last
     // forwarded chunk) and stamped post-stream alongside usage; the routing core
     // is headless about it, so the builder always emits null.

--- a/packages/shared/src/decision/portal-view.test.ts
+++ b/packages/shared/src/decision/portal-view.test.ts
@@ -58,6 +58,8 @@ function poisonedRecord(): DecisionRecord {
     cost_breakdown: { eval_usd: 0.0001, completion_usd: 0.01, total_usd: 0.0101 },
     memory: null,
     usage: {
+      measurement: "reported",
+      cost_basis: null,
       prompt_tokens: 100,
       completion_tokens: 50,
       cached_tokens: 0,
@@ -71,6 +73,7 @@ function poisonedRecord(): DecisionRecord {
       image_output_tokens: 0,
       billed_cost_usd: 0.01,
     },
+    stream_outcome: "completed",
     generation_ms: 800,
   };
 }

--- a/packages/shared/src/decision/schema.test.ts
+++ b/packages/shared/src/decision/schema.test.ts
@@ -96,6 +96,31 @@ describe("DecisionRecordSchema", () => {
     expect(DecisionRecordSchema.safeParse(fullRecord()).success).toBe(true);
   });
 
+  it("defaults measured usage to reported and legacy stream outcome to null", () => {
+    const parsed = DecisionRecordSchema.parse({
+      ...fullRecord(),
+      usage: { prompt_tokens: 12, completion_tokens: 4 },
+    });
+
+    expect(parsed.usage?.measurement).toBe("reported");
+    expect(parsed.stream_outcome).toBeNull();
+  });
+
+  it("accepts partial-estimate provenance and a truncated stream outcome", () => {
+    const parsed = DecisionRecordSchema.parse({
+      ...fullRecord(),
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 4,
+        measurement: "estimated_partial",
+      },
+      stream_outcome: "truncated",
+    });
+
+    expect(parsed.usage?.measurement).toBe("estimated_partial");
+    expect(parsed.stream_outcome).toBe("truncated");
+  });
+
   it("accepts a Phase 0 passthrough-shaped record", () => {
     const parsed = DecisionRecordSchema.parse(passthroughRecord());
     expect(parsed.classifier.decided_by).toBe("default");

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -154,6 +154,13 @@ export const CostBreakdownSchema = z.object({
 // rename this block to anything containing "token" or the whole object is lost to
 // {redacted:true,kind:"object"}. Pinned by redaction.test.ts.
 export const TokenUsageSchema = z.object({
+  // Where the counts came from. A provider terminal usage block is authoritative;
+  // terminal-less Responses streams use an o200k estimate over the semantic upstream
+  // request and the deltas Helm actually received. It is intentionally called
+  // `estimated_partial` because provider-side cache/reasoning accounting is unavailable.
+  // Legacy non-null usage blocks predate this field and were provider-reported.
+  measurement: z.enum(["reported", "estimated_partial"]).default("reported"),
+  cost_basis: z.enum(["catalog_api_equivalent_estimate"]).nullable().default(null),
   prompt_tokens: z.number().int().nonnegative().nullable().default(null),
   completion_tokens: z.number().int().nonnegative().nullable().default(null),
   cached_tokens: z.number().int().nonnegative().nullable().default(null),
@@ -256,6 +263,14 @@ export const DecisionRecordSchema = z.object({
   // `.nullable().default(null)` keeps the core builders and all pre-existing
   // records valid without it.
   usage: TokenUsageSchema.nullable().default(null),
+  // Outcome of the streamed response lifecycle, kept orthogonal to the provider
+  // attempt's binary status. A provider may have successfully produced first-byte
+  // output (`provider_attempts[].status="ok"`) while the request stream later ends
+  // at a client abort or a terminal-less upstream EOF. null for non-stream/legacy.
+  stream_outcome: z
+    .enum(["completed", "incomplete", "failed", "client_aborted", "truncated"])
+    .nullable()
+    .default(null),
   // Wall-clock generation window of the SERVED stream (ms): the span from the
   // first to the last forwarded chunk. Stamped by the GATEWAY post-stream (same
   // place as `usage`, via backfillCompletionCost) — the routing core stays

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       hono:
         specifier: ^4.12.23
         version: 4.12.23
+      gpt-tokenizer:
+        specifier: ^3.4.0
+        version: 3.4.0
       https-proxy-agent:
         specifier: ^9.1.0
         version: 9.1.0


### PR DESCRIPTION
## Summary
- record client-aborted and truncated Responses streams as partial/error outcomes instead of successful zero-usage requests
- estimate missing usage with bounded semantic accounting and apply the same catalog-equivalent cost to telemetry, budgets, provider attempts, and OAuth usage
- preserve unknown costs in Admin, label partial estimates clearly, and show subscription values as API-equivalent rather than billed spend

## Verification
- `CI=true pnpm vitest run --maxWorkers=1 apps/gateway/src/routes/payload-capture.test.ts apps/gateway/src/routes/messages-pipeline.test.ts apps/gateway/src/routes/responses.test.ts packages/shared/src/decision/schema.test.ts` (250 tests)
- `CI=true pnpm vitest run --maxWorkers=1` on 7 changed Admin test files (115 tests)
- shared + gateway typecheck
- Admin svelte-check (0 errors / 0 warnings)
- gateway, shared, and Admin builds
- Biome + Prettier + `git diff --check`