### PR TITLE
fix(pricing): prevent supervisor safety starvation

### DIFF
--- a/apps/gateway/src/app.test.ts
+++ b/apps/gateway/src/app.test.ts
@@ -73,7 +73,7 @@ describe("createApp: trace_id, logging, error handling", () => {
   });
 
   it("serializes a thrown HelmError to an OpenAI-shaped body", async () => {
-    const { logger } = fakeLogger();
+    const { logger, lines } = fakeLogger();
     const app = createApp({ logger, genTraceId: () => "trace-xyz" });
     app.get("/boom", () => {
       throw new HelmHttpError(
@@ -86,6 +86,9 @@ describe("createApp: trace_id, logging, error handling", () => {
     expect(body.error.code).toBe("timeout");
     expect(body.error.type).toBe("api_error");
     expect(body.error.trace_id).toBe("trace-xyz");
+    expect(lines.find((line) => line.message === "request.error")?.fields.fault_scope).toBe(
+      "request",
+    );
   });
 
   it.each<[ErrorClass, number, string, string]>([
@@ -124,7 +127,10 @@ describe("createApp: trace_id, logging, error handling", () => {
     expect(text).not.toContain("boom-internal-detail");
     const body = JSON.parse(text) as { error: Record<string, string> };
     expect(body.error.code).toBe("upstream_error");
-    expect(lines.some((l) => l.level === "error")).toBe(true);
+    expect(lines.find((line) => line.message === "request.error")).toMatchObject({
+      level: "error",
+      fields: { fault_scope: "gateway_internal" },
+    });
   });
 
   it("marks the request context as timed out while late route work continues", async () => {

--- a/apps/gateway/src/middleware/error-handler.ts
+++ b/apps/gateway/src/middleware/error-handler.ts
@@ -86,6 +86,7 @@ export function handleError(err: unknown, c: Context<AppEnv>): Response {
     trace_id: traceId,
     error_class: errorClass,
     http_status: status,
+    fault_scope: helm === null ? "gateway_internal" : "request",
   });
 
   return c.json(body, status as ContentfulStatusCode);

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -16,7 +16,7 @@
 ## 2026-07-15 · 历史费用回填改由常驻 supervisor 持续推进（Catalog / telemetry repair operations，docs/07/08，原则 2/3/5/7）
 
 - **执行边界**：一次性 Codex automation 改为 host systemd 常驻 supervisor；它通过非阻塞 `flock` 保证唯一执行者，并把大阶段拆成每次最多 100 行的独立 CLI 进程。每批提交并落盘 checkpoint 后才进入下一批，因此 SIGTERM、容器短暂不可用或 supervisor 重启都只会从原子 checkpoint 恢复，不需要大事务、整库备份或 `kill -9`。
-- **资源控制**：启动前必须连续取得 3 个有余量样本；运行中持续检查 host load/MemAvailable、Helm CPU/内存、health 延迟、WAL、磁盘、restart/OOM 与结构化 5xx/timeout/`SQLITE_BUSY`。硬阈值触发后 supervisor 留在 `waiting_safety` 并自动重试，不把辅助回填失败扩散为网关故障；每 5,000 行强制至少冷却 5 分钟。固定截止点为 `2026-07-15T13:28:46+08:00`，不追逐持续增长的新流量。
+- **资源控制**：启动前必须连续取得 3 个有余量样本；运行中持续检查 host load/MemAvailable、Helm CPU/内存、health 延迟、WAL、磁盘、restart/OOM 与结构化 5xx/timeout/`SQLITE_BUSY`。2GiB 主机的 MemAvailable 采用 512MiB preflight / 384MiB runtime stop，保留 128MiB hysteresis，并继续叠加容器内存比例与 health/CPU 保护，避免原 768MiB 固定门槛在约 588MiB 稳态可用内存下永久饿死。Gateway `request.error` 显式记录 `fault_scope`：可预期的结构化请求错误为 `request`，未知 throw 为 `gateway_internal`；5xx/timeout 总数继续写入状态作纯观测，只有 `gateway_internal` 5xx 与 `SQLITE_BUSY` 会触发 supervisor safety stop，因此正常 `all_providers_failed` 的 error/completed 双日志不能阻断回填，而真正内部故障仍 fail-closed。硬阈值触发后 supervisor 留在 `waiting_safety` 并自动重试，不把辅助回填失败扩散为网关故障；每 5,000 行强制至少冷却 5 分钟。固定截止点为 `2026-07-15T13:28:46+08:00`，不追逐持续增长的新流量。
 - **验证与可观测性**：`pricing:reprice` 新增只读 manifest slice verifier，逐批验证 telemetry 顶层总价、attempt completion、breakdown、alias/status/timestamp 全部已成为 manifest new state；窗口完成后再全量验证。supervisor 原子写入 `supervisor.status.json`，记录 phase、窗口/checkpoint、最近指标、费用 delta、错误与备份聚合哈希；Codex 定时任务部署后只读该状态并汇报，不再直接写生产数据库。manifest 仍按 UTC 日窗、`best-evidence`、固定 pricing/plan hash 依次生成，歧义行保持不变。
 
 ## 2026-07-15 · 历史重算兼容旧版 completion-only 顶层费用（Catalog / telemetry repair，docs/07/08，原则 2/5/7）

--- a/scripts/ops/historical-reprice-supervisor.test.ts
+++ b/scripts/ops/historical-reprice-supervisor.test.ts
@@ -25,6 +25,7 @@ function healthySample(overrides: Partial<SupervisorSample> = {}): SupervisorSam
     oomKilled: false,
     fiveXx: 0,
     timeouts: 0,
+    gatewayFaults: 0,
     sqliteBusy: 0,
     ...overrides,
   };
@@ -67,10 +68,16 @@ describe("historical reprice supervisor", () => {
       reasons: [],
     });
 
-    const lowMemory = healthySample({ memAvailableBytes: 767 * 1024 ** 2 });
+    const stableTwoGiBHost = healthySample({ memAvailableBytes: 588 * 1024 ** 2 });
+    expect(evaluatePreflight([healthySample(), stableTwoGiBHost, healthySample()])).toMatchObject({
+      safe: true,
+      reasons: [],
+    });
+
+    const lowMemory = healthySample({ memAvailableBytes: 511 * 1024 ** 2 });
     const result = evaluatePreflight([healthySample(), lowMemory, healthySample()]);
     expect(result.safe).toBe(false);
-    expect(result.reasons).toContain("sample 2: available memory below 768 MiB");
+    expect(result.reasons).toContain("sample 2: available memory below 512 MiB");
   });
 
   it("stops immediately on hard limits and only on sustained CPU or health latency", () => {
@@ -92,26 +99,115 @@ describe("historical reprice supervisor", () => {
     expect(secondSlow.reasons).toContain("health latency consecutively above 500 ms");
 
     const lowMemory = evaluateRuntimeSafety(
-      healthySample({ memAvailableBytes: 639 * 1024 ** 2 }),
+      healthySample({ memAvailableBytes: 383 * 1024 ** 2 }),
       initial,
     );
     expect(lowMemory.stop).toBe(true);
-    expect(lowMemory.reasons).toContain("available memory below 640 MiB");
+    expect(lowMemory.reasons).toContain("available memory below 384 MiB");
   });
 
-  it("parses structured failures without mistaking trace identifiers for status codes", () => {
+  it("observes all 5xx but scopes only explicit gateway-internal faults as blockers", () => {
+    const signals = parseStructuredLogSignals(
+      [
+        JSON.stringify({
+          trace_id: "normal-provider-failure",
+          http_status: 502,
+          message: "request.error",
+          error_class: "all_providers_failed",
+          fault_scope: "request",
+        }),
+        JSON.stringify({
+          trace_id: "normal-provider-failure",
+          status: 502,
+          message: "request.completed",
+          path: "/v1/responses",
+        }),
+        JSON.stringify({
+          trace_id: "internal-reprice-failure",
+          http_status: 500,
+          message: "request.error",
+          error_class: "upstream_error",
+          fault_scope: "gateway_internal",
+        }),
+        JSON.stringify({
+          trace_id: "internal-reprice-failure",
+          status: 500,
+          message: "request.completed",
+          path: "/internal/pricing/reprice",
+        }),
+      ].join("\n"),
+    );
+
+    expect(signals).toEqual({
+      fiveXx: 4,
+      timeouts: 0,
+      gatewayFaults: 1,
+      sqliteBusy: 0,
+    });
+  });
+
+  it("keeps unscoped/provider 5xx and timeouts observational while retaining SQLITE_BUSY", () => {
     const signals = parseStructuredLogSignals(
       [
         JSON.stringify({ status: 200, trace_id: "trace-502-timeout" }),
-        JSON.stringify({ http_status: 502, message: "request.error" }),
-        JSON.stringify({ status: 503, message: "request.completed" }),
+        JSON.stringify({
+          trace_id: "normal-provider-failure",
+          http_status: 502,
+          message: "request.error",
+          error_class: "all_providers_failed",
+        }),
+        JSON.stringify({
+          trace_id: "normal-provider-failure",
+          status: 502,
+          message: "request.completed",
+        }),
         JSON.stringify({ message: "stream.truncated", error_class: "timeout" }),
         JSON.stringify({ message: "write failed", error_class: "SQLITE_BUSY" }),
         "not-json",
       ].join("\n"),
     );
 
-    expect(signals).toEqual({ fiveXx: 2, timeouts: 1, sqliteBusy: 1 });
+    expect(signals).toEqual({ fiveXx: 2, timeouts: 1, gatewayFaults: 0, sqliteBusy: 1 });
+  });
+
+  it("blocks only actionable fault signals, not ordinary 5xx or timeout observations", () => {
+    const initial = { highCpuSamples: 0, slowHealthSamples: 0, baselineRestarts: 0 };
+    const observations = healthySample({ fiveXx: 12, timeouts: 4 });
+    expect(evaluatePreflight([observations, observations, observations])).toMatchObject({
+      safe: true,
+      reasons: [],
+    });
+    expect(evaluateRuntimeSafety(observations, initial)).toMatchObject({
+      stop: false,
+      reasons: [],
+    });
+
+    expect(evaluateRuntimeSafety(healthySample({ gatewayFaults: 1 }), initial).reasons).toContain(
+      "new gateway-internal 5xx detected",
+    );
+    expect(evaluateRuntimeSafety(healthySample({ sqliteBusy: 1 }), initial).reasons).toContain(
+      "new SQLITE_BUSY detected",
+    );
+  });
+
+  it.each<[string, Partial<SupervisorSample>, string]>([
+    ["host load", { load1: 1.5 }, "load1 at or above 1.5"],
+    ["Helm memory", { helmMemoryPercent: 60 }, "Helm memory at or above 60%"],
+    ["non-200 health", { healthStatus: 503 }, "health returned non-200"],
+    ["WAL growth", { walBytes: 512 * 1024 ** 2 }, "WAL at or above 512 MiB"],
+    ["low disk", { diskFreeBytes: 11 * 1024 ** 3 }, "disk free below 12 GiB"],
+    ["container restart", { restarts: 1 }, "restart count changed"],
+    ["OOM", { oomKilled: true }, "OOM flag is set"],
+    ["gateway-internal fault", { gatewayFaults: 1 }, "new gateway-internal 5xx detected"],
+    ["SQLite lock", { sqliteBusy: 1 }, "new SQLITE_BUSY detected"],
+  ])("retains the %s runtime safety guard", (_name, overrides, expectedReason) => {
+    const result = evaluateRuntimeSafety(healthySample(overrides), {
+      highCpuSamples: 0,
+      slowHealthSamples: 0,
+      baselineRestarts: 0,
+    });
+    expect(result.stop).toBe(true);
+    expect(result.reasons).toContain(expectedReason);
   });
 
   it("keeps production stop thresholds stricter than CLI hard limits", () => {

--- a/scripts/ops/historical-reprice-supervisor.ts
+++ b/scripts/ops/historical-reprice-supervisor.ts
@@ -31,6 +31,7 @@ export interface SupervisorSample {
   oomKilled: boolean;
   fiveXx: number;
   timeouts: number;
+  gatewayFaults: number;
   sqliteBusy: number;
 }
 
@@ -53,14 +54,14 @@ export interface SupervisorThresholds {
 
 export const DEFAULT_SUPERVISOR_THRESHOLDS: SupervisorThresholds = {
   preflightLoad1: 1.2,
-  preflightMemBytes: 768 * MIB,
+  preflightMemBytes: 512 * MIB,
   preflightCpuPercent: 50,
   preflightHelmMemoryPercent: 55,
   preflightHealthMs: 300,
   preflightWalBytes: 384 * MIB,
   preflightDiskBytes: 14 * GIB,
   stopLoad1: 1.5,
-  stopMemBytes: 640 * MIB,
+  stopMemBytes: 384 * MIB,
   stopCpuPercent: 60,
   stopHelmMemoryPercent: 60,
   stopHealthMs: 500,
@@ -238,7 +239,7 @@ export function evaluatePreflight(
       reasons.push(`${prefix}load1 at or above ${thresholds.preflightLoad1}`);
     }
     if (sample.memAvailableBytes < thresholds.preflightMemBytes) {
-      reasons.push(`${prefix}available memory below 768 MiB`);
+      reasons.push(`${prefix}available memory below ${thresholds.preflightMemBytes / MIB} MiB`);
     }
     if (sample.helmCpuPercent >= thresholds.preflightCpuPercent) {
       reasons.push(`${prefix}Helm CPU at or above 50%`);
@@ -257,8 +258,7 @@ export function evaluatePreflight(
     }
     if (sample.restarts !== baselineRestarts) reasons.push(`${prefix}restart count changed`);
     if (sample.oomKilled) reasons.push(`${prefix}OOM flag is set`);
-    if (sample.fiveXx > 0) reasons.push(`${prefix}new 5xx detected`);
-    if (sample.timeouts > 0) reasons.push(`${prefix}new timeout detected`);
+    if (sample.gatewayFaults > 0) reasons.push(`${prefix}new gateway-internal 5xx detected`);
     if (sample.sqliteBusy > 0) reasons.push(`${prefix}new SQLITE_BUSY detected`);
   }
   return { safe: reasons.length === 0, reasons };
@@ -290,7 +290,7 @@ export function evaluateRuntimeSafety(
   const reasons: string[] = [];
   if (sample.load1 >= thresholds.stopLoad1) reasons.push("load1 at or above 1.5");
   if (sample.memAvailableBytes < thresholds.stopMemBytes) {
-    reasons.push("available memory below 640 MiB");
+    reasons.push(`available memory below ${thresholds.stopMemBytes / MIB} MiB`);
   }
   if (sample.helmMemoryPercent >= thresholds.stopHelmMemoryPercent) {
     reasons.push("Helm memory at or above 60%");
@@ -304,8 +304,7 @@ export function evaluateRuntimeSafety(
   if (sample.diskFreeBytes < thresholds.stopDiskBytes) reasons.push("disk free below 12 GiB");
   if (sample.restarts !== previous.baselineRestarts) reasons.push("restart count changed");
   if (sample.oomKilled) reasons.push("OOM flag is set");
-  if (sample.fiveXx > 0) reasons.push("new 5xx detected");
-  if (sample.timeouts > 0) reasons.push("new timeout detected");
+  if (sample.gatewayFaults > 0) reasons.push("new gateway-internal 5xx detected");
   if (sample.sqliteBusy > 0) reasons.push("new SQLITE_BUSY detected");
   return { stop: reasons.length > 0, reasons, state };
 }
@@ -313,10 +312,12 @@ export function evaluateRuntimeSafety(
 export function parseStructuredLogSignals(text: string): {
   fiveXx: number;
   timeouts: number;
+  gatewayFaults: number;
   sqliteBusy: number;
 } {
   let fiveXx = 0;
   let timeouts = 0;
+  let gatewayFaults = 0;
   let sqliteBusy = 0;
   for (const line of text.split("\n")) {
     if (line.trim().length === 0) continue;
@@ -330,7 +331,10 @@ export function parseStructuredLogSignals(text: string): {
     if (body === null) continue;
     const rawStatus = body.status ?? body.http_status ?? body.status_code;
     const status = typeof rawStatus === "number" ? rawStatus : Number(rawStatus);
-    if (Number.isFinite(status) && status >= 500 && status < 600) fiveXx += 1;
+    if (Number.isFinite(status) && status >= 500 && status < 600) {
+      fiveXx += 1;
+      if (body.fault_scope === "gateway_internal") gatewayFaults += 1;
+    }
     const selectedText = [body.message, body.error_class, body.error]
       .filter((value): value is string => typeof value === "string")
       .join(" ")
@@ -338,7 +342,7 @@ export function parseStructuredLogSignals(text: string): {
     if (/timeout|timed out/.test(selectedText)) timeouts += 1;
     if (/sqlite_busy|database is locked/.test(selectedText)) sqliteBusy += 1;
   }
-  return { fiveXx, timeouts, sqliteBusy };
+  return { fiveXx, timeouts, gatewayFaults, sqliteBusy };
 }
 
 function runCommand(


### PR DESCRIPTION
## Summary
- classify unknown gateway exceptions with fault_scope=gateway_internal
- keep provider/request 5xx and timeout counts observable without blocking historical repricing
- lower the 2 GiB host memory gates to 512 MiB preflight and 384 MiB runtime stop while preserving CPU, health, WAL, disk, restart, OOM, and SQLite guards
- document the production safety decision

## Validation
- CI=true corepack pnpm vitest run scripts/ops/historical-reprice-supervisor.test.ts apps/gateway/src/app.test.ts
- CI=true corepack pnpm typecheck
- CI=true corepack pnpm lint
- CI=true corepack pnpm build
- git diff --check