### PR TITLE
chore(release): v0.27.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.10",
+  "version": "0.27.11",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API to v0.27.11
- include the historical repricing supervisor starvation fix from PR #568

## Validation
- PR #568 passed verify, Docker, and e2e
- package version validated locally
- git diff --check