### PR TITLE
fix(pricing): handle unavailable Anthropic inference geo

### DIFF
--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -487,7 +487,7 @@ describe("createMessagesPipeline — native passthrough collect()", () => {
 // (input + cache) and the trailing message_delta (output). Split across odd byte
 // boundaries (NOT frame-aligned) to exercise the cross-chunk frame buffering.
 const NATIVE_SSE_FRAMES = [
-  'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_x","usage":{ "input_tokens":7 ,"cache_read_input_tokens":3,"cache_creation_input_tokens":2}}}\n\n',
+  'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_x","usage":{ "input_tokens":7 ,"cache_read_input_tokens":3,"cache_creation_input_tokens":2,"inference_geo":"not_available"}}}\n\n',
   'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
   'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n',
   'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" native"}}\n\n',
@@ -550,7 +550,7 @@ describe("createMessagesPipeline — native passthrough streamIR()", () => {
     // JSON.parse→stringify round-trip (which would have canonicalized it).
     const startFrame = frames[0];
     expect(startFrame?.data).toBe(
-      '{"type":"message_start","message":{"id":"msg_x","usage":{ "input_tokens":7 ,"cache_read_input_tokens":3,"cache_creation_input_tokens":2}}}',
+      '{"type":"message_start","message":{"id":"msg_x","usage":{ "input_tokens":7 ,"cache_read_input_tokens":3,"cache_creation_input_tokens":2,"inference_geo":"not_available"}}}',
     );
     // No `type` key — the passthrough path yields {event,data}, NOT the IR event bag.
     expect((frames[0] as unknown as { type?: unknown }).type).toBeUndefined();
@@ -601,6 +601,7 @@ describe("createMessagesPipeline — native passthrough streamIR()", () => {
       completion_tokens: 11,
       cached_tokens: 3,
       cache_creation_tokens: 2,
+      inference_geo: "not_available",
     });
   });
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-15 · Anthropic 不可用地域哨兵按全球基础卡计费（Catalog / telemetry accounting，docs/07/08，原则 2/3/5/7）
+
+- **生产根因**：Anthropic OAuth 原生流会返回 `usage.inference_geo=not_available`，表示未提供推理地域，不是新的计费地域。地域计费上线后把任意非空字符串都当作已确认地域；catalog 只有 `global` / `us`，该哨兵因此被当作未知费率并令已有完整 token usage 的成功请求得到 `cost_usd=null`。模型、能力和价格条目均未缺失。
+- **兼容边界**：计费边界只把空字符串和已确认的 `not_available` 规范化为“地域缺失”，使用既有全球基础卡；仍将真实但未配置的地域（如 `moon`）保持 unknown，避免猜价。原始哨兵继续保存在 telemetry 作为 provenance，不改写 provider 事实；实时响应与历史重算共用同一规范化函数，防止两套语义漂移。
+- **验证与修复边界**：TDD 以生产请求的 Opus 4.8 token/cache 数复现 `$0.24682125`，覆盖未知地域严格拒绝、Anthropic SSE 哨兵保真，以及历史重算仅在 `best-evidence` 下把该哨兵作为全球假设。生产历史数据修复仍须使用既有 manifest、逐批微型恢复库、health/WAL/disk 门禁和 OAuth delta 一致性保护。
+
 ## 2026-07-15 · 终端事件缺失的 Responses 流使用部分估算计费（Protocol streaming / telemetry accounting，docs/05/07，原则 3/5/7/8）
 
 - **终态语义**：provider 已产出首包仍保留成功 attempt，但 Responses 流只有收到 `response.completed` / `response.incomplete` / `response.failed` 才算有上游终态；无终态的自然 EOF 记为 `stream_outcome=truncated`、下游 abort 记为 `client_aborted`，request `final.status` 改为 error，分别使用 `upstream_error` / `client_abort`，不再把部分消费伪装成完整成功。`response.incomplete` 保留其独立终态；provider 明确报告的 usage（包括全 0）永远优先。
@@ -68,14 +74,9 @@
 - **评分边界**：同一 provider 内继续按账号优先级、模型 entitlement、可调度/限流状态形成候选集；Avoid Waste 的主分数仍来自即将重置的真实 5h/周额度。reset credits 保留为弱的可恢复容量信号，每个 credit 只贡献完整自然周窗口加权分数的 5%，可打破接近分数，但不能压过明显更多的真实即将过期额度。Plus/Pro/Team/Business 等套餐标签仍只用于身份与配额展示，不进入选择逻辑。
 - **验证**：TDD 使用生产比例覆盖同一池内 `2% + 0 credits` 对 `31% + 3 credits`，并保留真实额度相同情况下 credits 参与选择的回归；定向 pool 测试、typecheck、lint 与 build 作为交付门禁。
 
-## 2026-07-13 · Responses 工具结果的 multipart 文本使用 input_text（Protocol translation / provider execution，docs/05/07，原则 3/5/8）
-
-- **生产根因**：请求 `7963c4fa-c0ea-436f-aa4d-af0beb41615e` 从 Anthropic fallback 到 Codex Responses 时，数组形式的 `tool_result` 被编码为 `function_call_output.output[].output_text`；该 item 属于 Responses 请求输入，上游只接受 `input_text`，因此返回确定性 400 `invalid_request`。
-- **修复边界**：provider 专用 Chat→Responses 与共享 IR→Responses 两条路径统一把 multipart 工具结果文本编码为 `input_text`；字符串工具结果仍保持字符串，`input_image` 与 `input_file` 保持原 wire shape。助手消息正文继续使用 `output_text`，不扩大成全局 content-part 改写，也不改变 `invalid_request` fallback 语义。
-- **验证**：TDD 红灯同时覆盖 provider、共享 transformer 与真实 Anthropic `tool_result`→Codex Responses 链路；定向 Vitest 绿灯为 2 files / 274 tests。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-13 · Responses 工具结果的 multipart 文本使用 input_text（Protocol translation / provider execution，docs/05/07，原则 3/5/8）**：provider 与共享 transformer 统一把请求侧 multipart 工具结果文本编码为 `input_text`，保留字符串、图片、文件与助手输出的既有 wire shape。
 - **2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威，旧快照仅在缺 duration 且有真实用量时回退 secondary；Admin、reset-credit 与 model-scoped 隔离共用同一规则。
 - **2026-07-12 · Grok premium fallback 与 Composer 评估边界（Routing / provider evaluation，docs/04/07，原则 2/3/5/6/7）**：移除 official OpenAI/ZenMux 自动付费候选，premium 以已验证的 SuperGrok Grok 4.5 作为订阅 fallback；Composer 因真实 A/B 的空响应与质量不足不进 lane，底层 transport/发现保留，xAI Admin 选择器补 curated 展示但运行时 entitlement 继续 fail-closed。
 - **2026-07-12 · SuperGrok 周配额使用现有 OAuth 读取私有 gRPC-Web credits（OAuth subscription / Admin providers，docs/04/09/11，原则 3/6/7）**：复用现有 xAI OAuth bearer 严格读取 weekly gRPC-Web credits，按账号持久化 quota/cooldown 并以 cache epoch 隔离重连竞态；不保存 Cookie、不混用月度/public billing。

--- a/packages/core/src/catalog/cost.test.ts
+++ b/packages/core/src/catalog/cost.test.ts
@@ -248,6 +248,33 @@ describe("computeCostUsd — token usage × catalog pricing", () => {
     ).toBeNull();
   });
 
+  it("uses the global card when Anthropic reports that inference geo is unavailable", () => {
+    const pricing: Pricing = {
+      inputPerMTokUsd: 5,
+      outputPerMTokUsd: 25,
+      cacheReadPerMTokUsd: 0.5,
+      cacheWritePerMTokUsd: 6.25,
+      inferenceGeoMultipliers: { global: 1, us: 1.1 },
+    };
+
+    expect(
+      computeCostUsd(pricing, {
+        promptTokens: 467_556,
+        cachedPromptTokens: 466_435,
+        cacheCreationPromptTokens: 1_119,
+        completionTokens: 264,
+        inferenceGeo: " NOT_AVAILABLE ",
+      }),
+    ).toBeCloseTo(0.24682125, 12);
+    expect(
+      computeCostUsd(pricing, {
+        promptTokens: 100,
+        completionTokens: 10,
+        inferenceGeo: " ",
+      }),
+    ).toBeCloseTo((100 * 5 + 10 * 25) / 1_000_000, 12);
+  });
+
   it("keeps unsupported Gemini image service tiers unpriced", () => {
     const standardOnlyImage: Pricing = {
       inputPerMTokUsd: 0.5,

--- a/packages/core/src/catalog/cost.ts
+++ b/packages/core/src/catalog/cost.ts
@@ -22,6 +22,19 @@ export interface TokenUsage {
   inferenceGeo?: string;
 }
 
+// Anthropic can return this sentinel when it did not expose the serving region.
+// It is absence of geography evidence, not a new price region. Keep the raw value
+// in telemetry for provenance, but normalize it at the pricing boundary so live
+// and historical cost calculations use the normal global card.
+export function normalizeInferenceGeoForPricing(
+  value: string | null | undefined,
+): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === undefined || normalized === "" || normalized === "not_available"
+    ? undefined
+    : normalized;
+}
+
 // Compute the USD cost of one attempt/eval from its token usage and the model's
 // pricing. Returns null when pricing is unavailable (entry absent, or either
 // per-MTok rate is null). Absent token counts are treated as 0 (a measured
@@ -156,7 +169,7 @@ export function computeCostUsd(pricing: Pricing | undefined, usage: TokenUsage):
     (cacheWriteUnclassified * cacheWritePerMTok) / 1_000_000 +
     (regularOutput * outputPerMTokUsd) / 1_000_000 +
     (imageOutput * imageOutputPerMTok) / 1_000_000;
-  const inferenceGeo = usage.inferenceGeo?.trim().toLowerCase();
+  const inferenceGeo = normalizeInferenceGeoForPricing(usage.inferenceGeo);
   if (inferenceGeo === undefined) return baseCost;
   const geoMultiplier = pricing.inferenceGeoMultipliers?.[inferenceGeo];
   // A response-confirmed geo without a configured official multiplier is an

--- a/packages/core/src/store/sqlite/historical-cost-reprice.test.ts
+++ b/packages/core/src/store/sqlite/historical-cost-reprice.test.ts
@@ -289,6 +289,22 @@ describe("historical cost repricing", () => {
       };
       insertTelemetry(db, { requestId: "us", alias, decision: us });
       insertTelemetry(db, { requestId: "missing-geo", alias });
+      const unavailable = decision(alias, 0.02);
+      unavailable.usage = {
+        prompt_tokens: 1_000,
+        completion_tokens: 100,
+        cached_tokens: 200,
+        cache_creation_tokens: 0,
+        service_tier: null,
+        inference_geo: "not_available",
+        cache_creation_5m_tokens: 0,
+        cache_creation_1h_tokens: 0,
+        audio_prompt_tokens: null,
+        cached_audio_prompt_tokens: null,
+        image_output_tokens: null,
+        billed_cost_usd: null,
+      };
+      insertTelemetry(db, { requestId: "unavailable-geo", alias, decision: unavailable });
       const entry = catalogEntry(alias, {
         inputPerMTokUsd: 2,
         outputPerMTokUsd: 10,
@@ -304,7 +320,7 @@ describe("historical cost repricing", () => {
         toMs: 10_000_000,
       });
       expect(exact.eligible).toBe(1);
-      expect(exact.skippedByReason).toEqual({ missing_inference_geo: 1 });
+      expect(exact.skippedByReason).toEqual({ missing_inference_geo: 2 });
       expect(exact.rows[0]?.newCompletionUsd).toBeCloseTo(0.002904, 12);
       expect(exact.rows[0]?.assumedGlobalInferenceGeo).toBe(false);
 
@@ -313,10 +329,14 @@ describe("historical cost repricing", () => {
         toMs: 10_000_000,
         mode: "best-evidence",
       });
-      expect(bestEvidence.eligible).toBe(2);
-      expect(bestEvidence.assumptions.globalInferenceGeo).toBe(1);
+      expect(bestEvidence.eligible).toBe(3);
+      expect(bestEvidence.assumptions.globalInferenceGeo).toBe(2);
       expect(
         bestEvidence.rows.find((row) => row.requestId === "missing-geo")?.assumedGlobalInferenceGeo,
+      ).toBe(true);
+      expect(
+        bestEvidence.rows.find((row) => row.requestId === "unavailable-geo")
+          ?.assumedGlobalInferenceGeo,
       ).toBe(true);
     } finally {
       db.close();

--- a/packages/core/src/store/sqlite/historical-cost-reprice.ts
+++ b/packages/core/src/store/sqlite/historical-cost-reprice.ts
@@ -14,7 +14,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CatalogEntry } from "@helm/shared";
 import Database from "better-sqlite3";
-import { computeCostUsd } from "../../catalog/cost.js";
+import { computeCostUsd, normalizeInferenceGeoForPricing } from "../../catalog/cost.js";
 import { loadRuntimeCatalog } from "../../catalog/load.js";
 
 // Operator-only historical repair tool. Dry-run is the default:
@@ -372,7 +372,7 @@ function classifyPricingAmbiguity(
     pricing.inferenceGeoMultipliers !== undefined &&
     Object.keys(pricing.inferenceGeoMultipliers).length > 0
   ) {
-    const inferenceGeo = usage.inferenceGeo?.trim().toLowerCase();
+    const inferenceGeo = normalizeInferenceGeoForPricing(usage.inferenceGeo);
     if (inferenceGeo !== undefined) {
       if (pricing.inferenceGeoMultipliers[inferenceGeo] === undefined) {
         return answer("unknown_inference_geo");
@@ -510,7 +510,8 @@ export function planHistoricalCostReprice(
       imageOutputTokens: evidence.imageOutputTokens ?? undefined,
       serviceTier: evidence.serviceTier ?? undefined,
       inferenceGeo:
-        evidence.inferenceGeo ?? (ambiguity.assumedGlobalInferenceGeo ? "global" : undefined),
+        normalizeInferenceGeoForPricing(evidence.inferenceGeo) ??
+        (ambiguity.assumedGlobalInferenceGeo ? "global" : undefined),
     };
     const newCompletionUsd = computeCostUsd(entry.pricing, usage);
     if (newCompletionUsd === null) {


### PR DESCRIPTION
## Summary
- treat Anthropic `inference_geo=not_available` and blank geo as unavailable evidence, not a new pricing region
- preserve strict null pricing for genuinely unknown named regions
- share normalization with historical repricing while retaining raw telemetry provenance
- cover the production Opus token shape, historical recovery, and native Anthropic SSE extraction

## Verification
- `CI=true corepack pnpm vitest run packages/core/src/catalog/cost.test.ts packages/core/src/store/sqlite/historical-cost-reprice.test.ts apps/gateway/src/routes/messages-pipeline.test.ts` (134 passed)
- `CI=true corepack pnpm typecheck`
- `CI=true corepack pnpm lint`
- `CI=true corepack pnpm build`

## Production evidence
Request `d48af8e7-373b-427b-bf64-f57ac01c5bdb` used `anthropic/claude-opus-4-8` with complete reported usage and `inference_geo=not_available`, producing `cost_usd=null`. The global API-equivalent estimate is `$0.24682125`; the model and pricing entry are present.