### PR TITLE
chore(release): v0.27.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.11",
+  "version": "0.27.12",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- release the Anthropic unavailable inference-geo billing compatibility fix
- ensure complete reported token usage receives the global/base API-equivalent cost when Anthropic returns `inference_geo=not_available`
- keep genuinely unknown named geographies unpriced

## Included
- PR #570