### PR TITLE
fix(oauth): trigger auto-reset from quota refresh

### DIFF
--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -531,6 +531,17 @@ export interface AdminApiDeps {
     capturedAtMs: number,
     resetCredits?: number | null,
   ) => void;
+  // A fresh Codex upstream PULL is authoritative quota truth, just like response
+  // headers. Notify the runtime after cooldown synchronization so an opted-in 100%
+  // account can auto-reset even if it was parked before another request served.
+  // Cache-only GET routes must never invoke this hook.
+  onCodexQuotaSaturated?: (
+    providerId: "openai-codex",
+    account: string,
+    windows: OAuthQuotaWindow[],
+    capturedAtMs: number,
+    rateLimitReachedType: CodexRateLimitReachedType | null,
+  ) => Promise<boolean>;
   // Durable OAuth credential failure. A refresh 400/401/403 or persistent upstream
   // 401/403 means the account needs reconnecting, not just a short cooldown. The
   // gateway persists that state and rebuilds the pool so admin status and routing agree.

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -196,10 +196,14 @@ describe("admin OAuth routes — read endpoints", () => {
     const seam = fullSeam({
       fetchAnthropicQuota: vi.fn(async () => [{ kind: "5h", utilization: 0.1 }]) as never,
     });
-    const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
+    const onCodexQuotaSaturated = vi.fn(async () => false);
+    const api = app({ oauth: seam, oauthQuota, onCodexQuotaSaturated });
+    const res = await api.request("/admin/api/oauth/quota");
     expect(res.status).toBe(200);
     expect(upsert).not.toHaveBeenCalled();
     expect(seam.fetchAnthropicQuota).not.toHaveBeenCalled();
+    expect((await api.request("/admin/api/oauth/overview")).status).toBe(200);
+    expect(onCodexQuotaSaturated).not.toHaveBeenCalled();
   });
 
   it("GET /oauth/quota hides persisted Codex header placeholders", async () => {
@@ -629,12 +633,19 @@ describe("admin OAuth routes — read endpoints", () => {
   it("POST /oauth/refresh parks an unparked account from a saturated account-wide snapshot", async () => {
     const now = Date.now();
     const saturatedWeekly = {
-      key: "secondary",
+      key: "primary",
       usedPercent: 100,
       resetsAtMs: now + 8 * 60 * 60_000,
       windowMinutes: 10_080,
     };
-    const applyUsageLimit = vi.fn(async () => {});
+    const order: string[] = [];
+    const applyUsageLimit = vi.fn(async () => {
+      order.push("park");
+    });
+    const onCodexQuotaSaturated = vi.fn(async () => {
+      order.push("reset");
+      return false;
+    });
     const oauthQuota = {
       get: vi.fn(async () => ({
         providerId: "openai-codex",
@@ -665,10 +676,11 @@ describe("admin OAuth routes — read endpoints", () => {
       fetchCodexQuota: vi.fn(async () => ({
         windows: [saturatedWeekly],
         resetCredits: 0,
+        rateLimitReachedType: "rate_limit_reached",
       })) as never,
     });
 
-    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit, onCodexQuotaSaturated });
     await enqueueRefresh(api);
     const res = await api.request("/admin/api/oauth/quota");
 
@@ -679,17 +691,170 @@ describe("admin OAuth routes — read endpoints", () => {
       saturatedWeekly.resetsAtMs,
       "extend",
     );
+    expect(onCodexQuotaSaturated).toHaveBeenCalledWith(
+      "openai-codex",
+      "default",
+      [saturatedWeekly],
+      expect.any(Number),
+      "rate_limit_reached",
+    );
+    expect(order).toEqual(["park", "reset"]);
   });
 
-  it("POST /oauth/refresh does not newly park an account from a near-full snapshot", async () => {
+  it("re-pulls and publishes fresh quota after auto-reset consumes a credit", async () => {
     const now = Date.now();
-    const nearFullFiveHour = {
+    const saturatedWeekly = {
       key: "primary",
-      usedPercent: 98,
-      resetsAtMs: now + 2 * 60 * 60_000,
-      windowMinutes: 300,
+      usedPercent: 100,
+      resetsAtMs: now + 8 * 60 * 60_000,
+      windowMinutes: 10_080,
+    };
+    const refreshedWeekly = {
+      ...saturatedWeekly,
+      usedPercent: 1,
+      resetsAtMs: now + 7 * 86_400_000,
+    };
+    let row: Record<string, unknown> | null = null;
+    const oauthQuota = {
+      get: vi.fn(async () => row),
+      getAll: vi.fn(async () => (row ? [row] : [])),
+      upsert: vi.fn(async (snapshot: Record<string, unknown>) => {
+        row = { ...snapshot, usageLimitedUntilMs: row?.usageLimitedUntilMs ?? null };
+      }),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const applyUsageLimit = vi.fn(
+      async (_providerId: string, _account: string, until: number | null) => {
+        if (row) row = { ...row, usageLimitedUntilMs: until };
+      },
+    );
+    const applyQuotaSnapshot = vi.fn();
+    const fetchCodexQuota = vi
+      .fn()
+      .mockResolvedValueOnce({
+        windows: [saturatedWeekly],
+        resetCredits: 1,
+        rateLimitReachedType: "rate_limit_reached",
+      })
+      .mockResolvedValueOnce({
+        windows: [refreshedWeekly],
+        resetCredits: 0,
+        rateLimitReachedType: null,
+      });
+    const seam = fullSeam({
+      listStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [{ id: "openai-codex", name: "Codex", accounts: [{ account: "default" }] }],
+      })) as never,
+      fetchCodexQuota: fetchCodexQuota as never,
+    });
+    const onCodexQuotaSaturated = vi.fn(async () => true);
+    const api = app({
+      oauth: seam,
+      oauthQuota,
+      applyUsageLimit: applyUsageLimit as never,
+      applyQuotaSnapshot,
+      onCodexQuotaSaturated: onCodexQuotaSaturated as never,
+    });
+
+    await enqueueRefresh(api);
+    const body = (await (await api.request("/admin/api/oauth/quota")).json()) as {
+      quota: Array<{ windows: OAuthQuotaWindow[]; resetCredits: number | null }>;
+    };
+
+    expect(fetchCodexQuota).toHaveBeenCalledTimes(2);
+    expect(fetchCodexQuota).toHaveBeenNthCalledWith(2, { account: "default", force: true });
+    expect(body.quota[0]).toMatchObject({ windows: [refreshedWeekly], resetCredits: 0 });
+    expect(applyQuotaSnapshot).toHaveBeenLastCalledWith(
+      "openai-codex",
+      "default",
+      [refreshedWeekly],
+      expect.any(Number),
+      0,
+    );
+    expect(applyUsageLimit).toHaveBeenLastCalledWith("openai-codex", "default", null, "replace");
+  });
+
+  it("waits for one shared-account reset before pulling the sibling label", async () => {
+    const now = Date.now();
+    const saturatedWeekly = {
+      key: "primary",
+      usedPercent: 100,
+      resetsAtMs: now + 8 * 60 * 60_000,
+      windowMinutes: 10_080,
+    };
+    let releaseFirstReset!: () => void;
+    const firstReset = new Promise<void>((resolve) => {
+      releaseFirstReset = resolve;
+    });
+    const fetchCodexQuota = vi.fn(async () => ({
+      windows: [saturatedWeekly],
+      resetCredits: 1,
+      rateLimitReachedType: "rate_limit_reached" as const,
+    }));
+    const onCodexQuotaSaturated = vi.fn(async (_providerId: string, account: string) => {
+      if (account === "label-a") await firstReset;
+      return false;
+    });
+    const oauthQuota = {
+      get: vi.fn(async () => null),
+      getAll: vi.fn(async () => []),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      listStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [
+          {
+            id: "openai-codex",
+            name: "Codex",
+            accounts: [{ account: "label-a" }, { account: "label-b" }],
+          },
+        ],
+      })) as never,
+      fetchCodexQuota: fetchCodexQuota as never,
+    });
+    const api = app({
+      oauth: seam,
+      oauthQuota,
+      applyUsageLimit: vi.fn(async () => {}),
+      onCodexQuotaSaturated,
+    });
+
+    expect((await api.request("/admin/api/oauth/refresh", { method: "POST" })).status).toBe(202);
+    await vi.waitFor(() => {
+      expect(onCodexQuotaSaturated).toHaveBeenCalledWith(
+        "openai-codex",
+        "label-a",
+        [saturatedWeekly],
+        expect.any(Number),
+        "rate_limit_reached",
+      );
+    });
+    expect(fetchCodexQuota).toHaveBeenCalledTimes(1);
+    expect(fetchCodexQuota).toHaveBeenLastCalledWith({ account: "label-a", force: true });
+
+    releaseFirstReset();
+    await vi.waitFor(async () => {
+      const overview = await api.request("/admin/api/oauth/overview");
+      const body = (await overview.json()) as { refresh: { state: string } };
+      expect(body.refresh.state).toBe("succeeded");
+    });
+    expect(fetchCodexQuota).toHaveBeenCalledTimes(2);
+    expect(fetchCodexQuota).toHaveBeenLastCalledWith({ account: "label-b", force: true });
+  });
+
+  it("POST /oauth/refresh does not park or auto-reset a 99% weekly snapshot", async () => {
+    const now = Date.now();
+    const nearFullWeekly = {
+      key: "primary",
+      usedPercent: 99,
+      resetsAtMs: now + 2 * 86_400_000,
+      windowMinutes: 10_080,
     };
     const applyUsageLimit = vi.fn(async () => {});
+    const onCodexQuotaSaturated = vi.fn(async () => false);
     const oauthQuota = {
       get: vi.fn(async () => ({
         providerId: "openai-codex",
@@ -703,7 +868,7 @@ describe("admin OAuth routes — read endpoints", () => {
         {
           providerId: "openai-codex",
           account: "default",
-          windows: [nearFullFiveHour],
+          windows: [nearFullWeekly],
           capturedAt: now,
           source: "codex",
           usageLimitedUntilMs: null,
@@ -718,17 +883,18 @@ describe("admin OAuth routes — read endpoints", () => {
         providers: [{ id: "openai-codex", name: "Codex", accounts: [{ account: "default" }] }],
       })) as never,
       fetchCodexQuota: vi.fn(async () => ({
-        windows: [nearFullFiveHour],
+        windows: [nearFullWeekly],
         resetCredits: 0,
       })) as never,
     });
 
-    const api = app({ oauth: seam, oauthQuota, applyUsageLimit });
+    const api = app({ oauth: seam, oauthQuota, applyUsageLimit, onCodexQuotaSaturated });
     await enqueueRefresh(api);
     const res = await api.request("/admin/api/oauth/quota");
 
     expect(res.status).toBe(200);
     expect(applyUsageLimit).not.toHaveBeenCalled();
+    expect(onCodexQuotaSaturated).not.toHaveBeenCalled();
   });
 
   it("POST /oauth/refresh makes complete Codex metadata available to cached reads", async () => {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -13,6 +13,7 @@ import {
   canConsumeResetCredit,
   codexWeeklyUsedPercent,
   runResetCreditAttempt,
+  weeklySaturated,
 } from "../../oauth/auto-reset.js";
 import {
   isPermanentOAuthCredentialFailure,
@@ -21,6 +22,7 @@ import {
 import type {
   AccountProxyInput,
   AdminApiDeps,
+  CodexQuotaResult,
   OAuthAdminAccess,
   OAuthAdminStatusResponse,
   OAuthSelectionStrategy,
@@ -344,31 +346,53 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
             tasks.push({
               label: `openai-codex/${a.account}`,
               run: async () => {
+                const persistCodexQuota = async (fresh: NonNullable<CodexQuotaResult>) => {
+                  const activeResult = {
+                    ...fresh,
+                    windows: filterRetiredOpenAICodexLimits(fresh.windows),
+                    additionalLimits: filterRetiredOpenAICodexLimits(fresh.additionalLimits),
+                  };
+                  const capturedAt = Date.now();
+                  await store.upsert({
+                    providerId: "openai-codex",
+                    account: a.account,
+                    windows: activeResult.windows,
+                    capturedAt,
+                    source: "codex",
+                    resetCredits: activeResult.resetCredits,
+                  });
+                  deps.applyQuotaSnapshot?.(
+                    "openai-codex",
+                    a.account,
+                    activeResult.windows,
+                    capturedAt,
+                    activeResult.resetCredits,
+                  );
+                  if (activeResult.windows.length > 0) {
+                    await syncCooldownFromWindows("openai-codex", a.account, activeResult.windows);
+                  }
+                  return { activeResult, capturedAt };
+                };
+
                 const result = await fetchCodex({ account: a.account, force: true });
                 if (!result) throw new Error("quota refresh returned no snapshot");
-                const activeResult = {
-                  ...result,
-                  windows: filterRetiredOpenAICodexLimits(result.windows),
-                  additionalLimits: filterRetiredOpenAICodexLimits(result.additionalLimits),
-                };
-                const capturedAt = Date.now();
-                await store.upsert({
-                  providerId: "openai-codex",
-                  account: a.account,
-                  windows: activeResult.windows,
-                  capturedAt,
-                  source: "codex",
-                  resetCredits: activeResult.resetCredits,
-                });
-                deps.applyQuotaSnapshot?.(
-                  "openai-codex",
-                  a.account,
-                  activeResult.windows,
-                  capturedAt,
-                  activeResult.resetCredits,
-                );
-                if (activeResult.windows.length > 0) {
-                  await syncCooldownFromWindows("openai-codex", a.account, activeResult.windows);
+                const { activeResult, capturedAt } = await persistCodexQuota(result);
+                if (weeklySaturated(activeResult.windows)) {
+                  const consumed =
+                    (await deps.onCodexQuotaSaturated?.(
+                      "openai-codex",
+                      a.account,
+                      activeResult.windows,
+                      capturedAt,
+                      activeResult.rateLimitReachedType ?? null,
+                    )) ?? false;
+                  if (consumed) {
+                    const refreshed = await fetchCodex({ account: a.account, force: true });
+                    if (!refreshed) {
+                      throw new Error("post-reset quota refresh returned no snapshot");
+                    }
+                    await persistCodexQuota(refreshed);
+                  }
                 }
               },
             });

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1990,18 +1990,6 @@ export async function buildServer(
       }),
     );
   };
-  const applyQuotaSnapshot = (
-    providerId: string,
-    account: string,
-    windows: OAuthQuotaWindow[],
-    capturedAtMs: number,
-    resetCredits?: number | null,
-  ): void => {
-    oauthPoolClients
-      .get(providerId)
-      ?.setQuotaSnapshot(account, windows, capturedAtMs, resetCredits);
-  };
-
   // Executor hook: an account-wide 429 on a subscription alias means the SERVED account
   // hit its limit. Resolve the provider from the alias prefix + the served account from
   // the ALS holder (set by the pool's onSelect for THIS attempt), then park it for a
@@ -2030,7 +2018,7 @@ export async function buildServer(
   // (keyed by the cheap helm label) only collapses a same-label burst before async
   // work, to avoid a token-read stampede. Fire-and-forget + fail-open: any failure
   // leaves parked state.
-  const autoResetInFlight = new Set<string>(); // helm label -> a reset is being evaluated
+  const autoResetInFlight = new Map<string, Promise<boolean>>(); // helm label -> joined evaluation
 
   // Resolve the SHARED reset-credit key for a Codex helm account from the persisted
   // ChatGPT account identity. Metadata is authoritative because token refresh can leave
@@ -2077,20 +2065,20 @@ export async function buildServer(
     windows: OAuthQuotaWindow[],
     rateLimitReachedType: CodexRateLimitReachedType | null,
     nowMs: number,
-  ): void => {
+  ): Promise<boolean> => {
     const consumeCodexResetCredit = oauthAdmin?.consumeCodexResetCredit;
-    if (!consumeCodexResetCredit || !oauthEncKey) return;
+    if (!consumeCodexResetCredit || !oauthEncKey) return Promise.resolve(false);
     const helmKey = `${providerId} ${account}`;
-    if (autoResetInFlight.has(helmKey)) return; // collapse a same-label burst (cheap, sync)
-    autoResetInFlight.add(helmKey);
-    void (async () => {
+    const existing = autoResetInFlight.get(helmKey);
+    if (existing) return existing; // collapse + join a same-label burst (cheap, sync)
+    const task = (async () => {
       try {
         const s = getAccountSettings(
           await loadAccountSettings(store.config, oauthEncKey),
           providerId,
           account,
         );
-        if (!s.autoReset) return; // opted out → never spend a credit
+        if (!s.autoReset) return false; // opted out → never spend a credit
         const reservation = await resetCreditGuard.reserve({
           providerId,
           account,
@@ -2105,7 +2093,7 @@ export async function buildServer(
             code: reservation.code,
             retry_after_ms: reservation.retryAfterMs ?? null,
           });
-          return;
+          return false;
         }
         const sharedKey = reservation.sharedKey;
         const guardHash = resetCreditGuardHash(sharedKey).slice(0, 12);
@@ -2176,6 +2164,7 @@ export async function buildServer(
               windows_reset: attempt.result.windowsReset ?? null,
             });
           }
+          return attempt.consumed;
         } catch (e) {
           if (!consumeFailed) {
             logger.log("error", "oauth.auto_reset.failed", {
@@ -2186,6 +2175,7 @@ export async function buildServer(
               line: e instanceof Error ? e.message : String(e),
             });
           }
+          return false;
         }
       } catch (e) {
         logger.log("error", "oauth.auto_reset.failed", {
@@ -2194,11 +2184,40 @@ export async function buildServer(
           stage: "post_consume",
           line: e instanceof Error ? e.message : String(e),
         });
+        return false;
       } finally {
         autoResetInFlight.delete(helmKey);
       }
     })();
+    autoResetInFlight.set(helmKey, task);
+    return task;
   };
+
+  const applyQuotaSnapshot = (
+    providerId: string,
+    account: string,
+    windows: OAuthQuotaWindow[],
+    capturedAtMs: number,
+    resetCredits?: number | null,
+  ): void => {
+    oauthPoolClients
+      .get(providerId)
+      ?.setQuotaSnapshot(account, windows, capturedAtMs, resetCredits);
+  };
+
+  // Every AUTHORITATIVE fresh Codex snapshot must feed the same auto-reset path.
+  // Header PUSHes and explicit upstream PULL refreshes are both fresh truth;
+  // cache-only admin reads never call this hook. Without the PULL trigger, a 100%
+  // snapshot can park the account before another response header arrives, leaving
+  // an opted-in account unable to trigger its own reset.
+  const onCodexQuotaSaturated = (
+    providerId: "openai-codex",
+    account: string,
+    windows: OAuthQuotaWindow[],
+    capturedAtMs: number,
+    rateLimitReachedType: CodexRateLimitReachedType | null,
+  ): Promise<boolean> =>
+    maybeAutoReset(providerId, account, windows, rateLimitReachedType, capturedAtMs);
 
   // Codex quota-window scrape (providers page Tier 3): parse the `x-codex-*` headers
   // off each Codex reply and snapshot them per account. FAIL-OPEN — a parse/store
@@ -2208,7 +2227,7 @@ export async function buildServer(
     const details = parseCodexQuotaHeaderDetails(headers, nowMs);
     const windows = details.windows;
     if (windows.length === 0) return; // no quota headers on this reply → nothing to store
-    oauthPoolClients.get(providerId)?.setQuotaSnapshot(account, windows, nowMs);
+    applyQuotaSnapshot(providerId, account, windows, nowMs);
     void store.oauthQuota
       .upsert({ providerId, account, windows, capturedAt: nowMs, source: "codex-headers" })
       .catch(() => logger.log("error", "oauth.quota.capture_failed", { provider_id: providerId }));
@@ -2216,10 +2235,14 @@ export async function buildServer(
     // long cooldown the 429 backstop can't know. Fire-and-forget (fail-open).
     const until = windowsToUsageLimit(windows, nowMs);
     if (until !== null) parkAccountOnLimit(providerId, account, until);
-    // Then, if the WEEKLY window is the one that saturated and the account opted in,
-    // auto-consume a reset credit to restore it (guarded by a ≥1h per-account cooldown).
     if (weeklySaturated(windows)) {
-      maybeAutoReset(providerId, account, windows, details.rateLimitReachedType, nowMs);
+      void onCodexQuotaSaturated(
+        "openai-codex",
+        account,
+        windows,
+        nowMs,
+        details.rateLimitReachedType,
+      );
     }
   };
   // Per-account user-message serial queue (issue #93, feature B). ONE long-lived
@@ -3123,6 +3146,7 @@ export async function buildServer(
       // persist, no rebuild. Never touches schedulable.
       applyUsageLimit,
       applyQuotaSnapshot,
+      onCodexQuotaSaturated,
       onOAuthCredentialFailure: markOAuthCredentialFailure,
     });
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-15 · Codex 配额 PULL 饱和后触发自动重置（OAuth quota / reset credits，docs/04/11，原则 3/5/7）
+
+- **生产根因**：账号已启用 `autoReset`、仍有 reset credit，显式刷新也从 Codex PULL 得到账号级周窗口 100%；但刷新链只持久化 snapshot、同步 live pool 并停车，自动重置仅由后续响应头 PUSH 触发。账号一旦因 PULL 饱和而停车，可能不再获得下一次响应头，形成“缓存页面持续显示 100%，自动重置没有入口”的延迟触发；生产实例最终在约 5 分钟后的新响应头到达时才成功消耗 credit，证明设置与 guard 本身正常。
+- **触发边界**：cache-only 的 `/oauth/quota` 与 `/oauth/overview` 继续严格无副作用，绝不因读取旧 snapshot 消耗 credit；只有显式 refresh job 的新鲜上游 PULL 和实际响应头 PUSH 属于权威输入。PULL 在完成 durable/live quota 更新和 cooldown 停车同步后，仅对账号级周窗口 `>=100%` 调用并等待同一 `maybeAutoReset` 入口，避免先解停后又被异步停车覆盖；同一 Helm label 的并发触发复用同一个 in-flight promise。credit 成功消费后立即强制再 PULL 一次并更新 durable snapshot、live pool、剩余 credits 与 cooldown，cache-only 页面不会继续显示重置前的 100%。低于 100%、5h 窗口和 model-scoped 饱和窗口不触发；是否有 credit、共享账号幂等 marker、每小时 cooldown 与 workspace spend-control 拒绝仍由既有 reset guard fail-closed 判定。
+- **验证**：TDD 先证明 fresh Codex PULL 没有传递自动重置信号，再覆盖真实 `primary + 10080m + 100%` PULL 必须按“停车 -> 触发”顺序执行、成功消费后 cache/live state 立即变为新窗口与新 credit 数、共享 ChatGPT 账号的第二个 Helm label 必须等待首个 reset/unpark 完成后才开始 PULL、99% 周窗口与 cache-only GET/overview 不触发。定向 4 files / 196 tests、Gateway typecheck、Biome 与 Gateway build 全绿。
+
 ## 2026-07-15 · Anthropic 不可用地域哨兵按全球基础卡计费（Catalog / telemetry accounting，docs/07/08，原则 2/3/5/7）
 
 - **生产根因**：Anthropic OAuth 原生流会返回 `usage.inference_geo=not_available`，表示未提供推理地域，不是新的计费地域。地域计费上线后把任意非空字符串都当作已确认地域；catalog 只有 `global` / `us`，该哨兵因此被当作未知费率并令已有完整 token usage 的成功请求得到 `cost_usd=null`。模型、能力和价格条目均未缺失。
@@ -68,14 +74,9 @@
 - **失败与旧数据**：任一账号的 quota 超时、空/非法窗口或持久化失败会把 job 标为 `failed` 并记录安全错误摘要，但不会删除 last-known-good snapshot；其余账号仍继续串行刷新。页面展示 queued/running/succeeded/failed、最近成功时间与 cooldown，手动点击只入队一次并 cache-only 轮询，定时自动刷新永远只读缓存。
 - **验证**：TDD 覆盖 cache-only 首屏、20 次并发点击合并、账号刷新最大并发 1、失败保留旧 quota、force cache bypass、模型发现 timeout、前端单请求加载、手动/自动刷新分流与多语言状态文案；workspace 357 files / 5775 tests、typecheck、Biome、build 与 Admin check 全通过。
 
-## 2026-07-14 · Avoid Waste 在 provider 池内限制 reset-credit 偏置（OAuth provider selection，docs/04/11，原则 3/5/6）
-
-- **生产根因**：`openai-codex` 的四个 Plus/Pro 账号已正确合并进同一 provider pool，套餐名没有参与分池或筛选；但 reset credit 的虚拟周容量乘数为 `10`，单个 credit 的加分远高于自然周窗口。生产中 31% 已用、3 credits 的 Pro 账号因此持续压过 2% 已用、0 credits 的 Plus 账号，形成看似按套餐分组的长期偏置。
-- **评分边界**：同一 provider 内继续按账号优先级、模型 entitlement、可调度/限流状态形成候选集；Avoid Waste 的主分数仍来自即将重置的真实 5h/周额度。reset credits 保留为弱的可恢复容量信号，每个 credit 只贡献完整自然周窗口加权分数的 5%，可打破接近分数，但不能压过明显更多的真实即将过期额度。Plus/Pro/Team/Business 等套餐标签仍只用于身份与配额展示，不进入选择逻辑。
-- **验证**：TDD 使用生产比例覆盖同一池内 `2% + 0 credits` 对 `31% + 3 credits`，并保留真实额度相同情况下 credits 参与选择的回归；定向 pool 测试、typecheck、lint 与 build 作为交付门禁。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-14 · Avoid Waste 在 provider 池内限制 reset-credit 偏置（OAuth provider selection，docs/04/11，原则 3/5/6）**：reset credits 只作为同一 provider 池内的弱恢复容量信号，不能压过明显更多的真实即将过期额度；套餐标签不参与分池或评分。
 - **2026-07-13 · Responses 工具结果的 multipart 文本使用 input_text（Protocol translation / provider execution，docs/05/07，原则 3/5/8）**：provider 与共享 transformer 统一把请求侧 multipart 工具结果文本编码为 `input_text`，保留字符串、图片、文件与助手输出的既有 wire shape。
 - **2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威，旧快照仅在缺 duration 且有真实用量时回退 secondary；Admin、reset-credit 与 model-scoped 隔离共用同一规则。
 - **2026-07-12 · Grok premium fallback 与 Composer 评估边界（Routing / provider evaluation，docs/04/07，原则 2/3/5/6/7）**：移除 official OpenAI/ZenMux 自动付费候选，premium 以已验证的 SuperGrok Grok 4.5 作为订阅 fallback；Composer 因真实 A/B 的空响应与质量不足不进 lane，底层 transport/发现保留，xAI Admin 选择器补 curated 展示但运行时 entitlement 继续 fail-closed。


### PR DESCRIPTION
## Summary
- trigger Codex weekly auto-reset from fresh authoritative quota PULLs, not only response headers
- await reset/unpark before refreshing sibling labels that share a ChatGPT account
- force a post-reset quota PULL so durable cache, live pool, cooldown, and reset-credit count immediately reflect the reset
- keep cache-only quota/overview reads strictly side-effect free

## Production evidence
- affected account had auto-reset enabled and available credits
- explicit refresh showed 100%, but reset did not run until a later response header about five minutes later
- that later header successfully consumed one credit, proving configuration and guard logic were valid

## Verification
- `CI=true corepack pnpm exec vitest run apps/gateway/src/routes/admin/oauth.test.ts apps/gateway/src/routes/admin/admin.test.ts apps/gateway/src/oauth/auto-reset.test.ts apps/gateway/src/oauth/reset-credit-guard.test.ts` (196 tests)
- `CI=true corepack pnpm --filter @helm/gateway typecheck`
- focused Biome check
- `CI=true corepack pnpm --filter @helm/gateway build`
- `git diff --check`