### PR TITLE
fix(admin): show completed Codex reset cooldown

### DIFF
--- a/apps/admin/src/lib/api/oauth.test.ts
+++ b/apps/admin/src/lib/api/oauth.test.ts
@@ -435,6 +435,46 @@ describe('admin oauth api client', () => {
     });
   });
 
+  it('shows a completed reset for the local cooldown response without retrying', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      resp(
+        {
+          error: 'reset credit blocked: a reset credit was already consumed within the last hour',
+          code: 'reset_credit_cooldown_active',
+          retryAfterMs: 358_411,
+        },
+        { ok: false, status: 429 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchFn);
+
+    await expect(consumeCodexResetCredit('openai-codex', 'acct-codex')).resolves.toEqual({
+      code: 'already_redeemed',
+      outcome: 'alreadyRedeemed',
+      windowsReset: 0,
+    });
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it('keeps unrelated reset-credit 429 responses as errors without retrying', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      resp(
+        {
+          error: 'another reset-credit attempt is still in progress',
+          code: 'reset_credit_reservation_active',
+          retryAfterMs: 30_000,
+        },
+        { ok: false, status: 429 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchFn);
+
+    await expect(consumeCodexResetCredit('openai-codex', 'acct-codex')).rejects.toThrow(
+      'reset_credit_reservation_active',
+    );
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
   it('rejects a malformed reset-credit success body instead of casting it', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -61,7 +61,8 @@ const BASE = '/admin/api/oauth';
 export type OAuthApiErrorCode =
   | 'device_authorization_denied'
   | 'device_code_expired'
-  | 'device_poll_failed';
+  | 'device_poll_failed'
+  | 'reset_credit_cooldown_active';
 
 export class OAuthApiError extends Error {
   readonly status: number;
@@ -87,7 +88,8 @@ async function asJson<T>(res: Response): Promise<T> {
         if (
           value === 'device_authorization_denied' ||
           value === 'device_code_expired' ||
-          value === 'device_poll_failed'
+          value === 'device_poll_failed' ||
+          value === 'reset_credit_cooldown_active'
         ) {
           code = value;
         }
@@ -350,7 +352,8 @@ export type CodexResetCreditResult = ReturnType<typeof CodexResetCreditResponseS
 
 // POST /oauth/:provider/reset-credit -> consume one rate-limit reset credit for the
 // account. Codex-only on the server; FAIL-CLOSED (the gateway 502s on any upstream
-// failure), so a rejected promise here means the reset did NOT happen — surface it.
+// failure). A local cooldown means the account was already reset recently, so project
+// that one idempotent state as success without issuing another request.
 export async function consumeCodexResetCredit(
   provider: string,
   account = 'default',
@@ -361,7 +364,22 @@ export async function consumeCodexResetCredit(
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ account, ...options }),
   });
-  return CodexResetCreditResponseSchema.parse(await asJson<unknown>(res));
+  try {
+    return CodexResetCreditResponseSchema.parse(await asJson<unknown>(res));
+  } catch (error) {
+    if (
+      error instanceof OAuthApiError &&
+      error.status === 429 &&
+      error.code === 'reset_credit_cooldown_active'
+    ) {
+      return CodexResetCreditResponseSchema.parse({
+        code: 'already_redeemed',
+        outcome: 'alreadyRedeemed',
+        windowsReset: 0,
+      });
+    }
+    throw error;
+  }
 }
 
 // ── per-account connectivity test (providers page "Test" button) ─────────────

--- a/apps/admin/src/lib/i18n/providers-locales.test.ts
+++ b/apps/admin/src/lib/i18n/providers-locales.test.ts
@@ -31,7 +31,7 @@ const providerPageKeys = [
   'Workspace usage limit reached',
   'No rate-limit window needed resetting',
   'Unexpected reset-credit outcome',
-  'Reset credit was already redeemed',
+  'Reset completed successfully',
   'Primary',
   'Secondary',
   'ChatGPT account ID',

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -969,7 +969,7 @@
   "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.": "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.",
   "Plan: {plan}": "Plan: {plan}",
   "Rate limit reached": "Rate limit reached",
-  "Reset credit was already redeemed": "Reset credit was already redeemed",
+  "Reset completed successfully": "Reset completed successfully",
   "This limit cannot be restored with a Codex reset credit": "This limit cannot be restored with a Codex reset credit",
   "Unexpected reset-credit outcome": "Unexpected reset-credit outcome",
   "Use an explicit model list. New remote models are not added until you choose them.": "Use an explicit model list. New remote models are not added until you choose them.",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -969,7 +969,7 @@
   "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.": "Solo estos modelos se exponen a Lanes. Puedes añadir, editar o eliminar identificadores, o incorporar a la lista el catálogo remoto más reciente.",
   "Plan: {plan}": "Plan contratado: {plan}",
   "Rate limit reached": "Se alcanzó el límite de solicitudes",
-  "Reset credit was already redeemed": "El crédito de restablecimiento ya se había canjeado",
+  "Reset completed successfully": "El restablecimiento se completó correctamente",
   "This limit cannot be restored with a Codex reset credit": "Este límite no se puede restaurar con un crédito de restablecimiento de Codex",
   "Unexpected reset-credit outcome": "Resultado inesperado al usar el crédito de restablecimiento",
   "Use an explicit model list. New remote models are not added until you choose them.": "Usa una lista explícita de modelos. Los modelos remotos nuevos no se añaden hasta que los selecciones.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -969,7 +969,7 @@
   "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.": "これらのモデルだけを Lanes に公開します。ID の追加、編集、削除、または最新のリモートカタログの一覧への取り込みができます。",
   "Plan: {plan}": "プラン: {plan}",
   "Rate limit reached": "レート制限に達しました",
-  "Reset credit was already redeemed": "リセットクレジットはすでに使用済みです",
+  "Reset completed successfully": "リセットが正常に完了しました",
   "This limit cannot be restored with a Codex reset credit": "この制限は Codex リセットクレジットでは復元できません",
   "Unexpected reset-credit outcome": "リセットクレジットから予期しない結果が返されました",
   "Use an explicit model list. New remote models are not added until you choose them.": "明示的なモデル一覧を使用します。新しいリモートモデルは選択するまで追加されません。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -969,7 +969,7 @@
   "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.": "이 모델만 Lanes에 노출합니다. ID를 추가, 편집 또는 제거하거나 최신 원격 카탈로그를 목록으로 가져올 수 있습니다.",
   "Plan: {plan}": "요금제: {plan}",
   "Rate limit reached": "속도 제한에 도달함",
-  "Reset credit was already redeemed": "재설정 크레딧이 이미 사용되었습니다",
+  "Reset completed successfully": "재설정이 완료되었습니다",
   "This limit cannot be restored with a Codex reset credit": "이 제한은 Codex 재설정 크레딧으로 복원할 수 없습니다",
   "Unexpected reset-credit outcome": "재설정 크레딧 결과가 예상과 다릅니다",
   "Use an explicit model list. New remote models are not added until you choose them.": "명시적 모델 목록을 사용합니다. 새 원격 모델은 선택할 때까지 추가되지 않습니다.",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -969,7 +969,7 @@
   "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.": "Somente estes modelos são expostos às Lanes. Adicione, edite ou remova IDs, ou importe o catálogo remoto mais recente para a lista.",
   "Plan: {plan}": "Plano: {plan}",
   "Rate limit reached": "Limite de requisições atingido",
-  "Reset credit was already redeemed": "O crédito de redefinição já havia sido resgatado",
+  "Reset completed successfully": "A redefinição foi concluída com sucesso",
   "This limit cannot be restored with a Codex reset credit": "Este limite não pode ser restaurado com um crédito de redefinição do Codex",
   "Unexpected reset-credit outcome": "Resultado inesperado ao usar o crédito de redefinição",
   "Use an explicit model list. New remote models are not added until you choose them.": "Use uma lista explícita de modelos. Novos modelos remotos só são adicionados depois que você os selecionar.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -969,7 +969,7 @@
   "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.": "仅向 Lanes 暴露这些模型。可添加、编辑或移除 ID，也可将最新远程目录拉取到列表中。",
   "Plan: {plan}": "套餐：{plan}",
   "Rate limit reached": "已达到速率限制",
-  "Reset credit was already redeemed": "重置额度已兑换",
+  "Reset completed successfully": "重置已成功完成",
   "This limit cannot be restored with a Codex reset credit": "此限制无法通过 Codex 重置额度恢复",
   "Unexpected reset-credit outcome": "重置额度返回了意外结果",
   "Use an explicit model list. New remote models are not added until you choose them.": "使用明确的模型列表。新远程模型只有在你选择后才会添加。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -969,7 +969,7 @@
   "Only these models are exposed to Lanes. Add, edit, or remove ids, or pull the latest remote catalog into the list.": "僅向 Lanes 公開這些模型。可新增、編輯或移除 ID，也可將最新遠端目錄拉取到清單中。",
   "Plan: {plan}": "方案：{plan}",
   "Rate limit reached": "已達速率限制",
-  "Reset credit was already redeemed": "重設額度已兌換",
+  "Reset completed successfully": "重設已成功完成",
   "This limit cannot be restored with a Codex reset credit": "此限制無法透過 Codex 重設額度恢復",
   "Unexpected reset-credit outcome": "重設額度傳回非預期結果",
   "Use an explicit model list. New remote models are not added until you choose them.": "使用明確的模型清單。新的遠端模型只有在你選取後才會加入。",

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -707,7 +707,7 @@
       await invalidateAll();
       resetNotice =
         result.outcome === 'alreadyRedeemed'
-          ? $t('Reset credit was already redeemed')
+          ? $t('Reset completed successfully')
           : result.windowsReset != null
             ? $t('Reset {n} window(s)', { n: result.windowsReset })
             : $t('Reset limit consumed');

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -1199,7 +1199,7 @@ describe('providers page', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('shows an idempotent notice and saves auto-reset for alreadyRedeemed', async () => {
+  it('shows reset success and saves auto-reset for alreadyRedeemed', async () => {
     consumeCodexResetCredit.mockResolvedValue({
       code: 'already_redeemed',
       outcome: 'alreadyRedeemed',
@@ -1220,7 +1220,8 @@ describe('providers page', () => {
       }),
     );
     expect(invalidateAllMock).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole('status')).toHaveTextContent('Reset credit was already redeemed');
+    expect(screen.getByRole('status')).toHaveTextContent('Reset completed successfully');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-07-15 · Codex 已重置冷却在 Admin 投影为成功（Admin providers UI，docs/11，原则 3/5/7）
+
+- **UI 边界**：Gateway 与 reset-credit guard 保持不变；Admin 客户端仅把本地 `429 + reset_credit_cooldown_active` 解释为“该账号最近已经完成重置”，复用既有 `alreadyRedeemed` 成功路径并显示“重置已成功完成”。该投影不会重试、不会产生第二次 fetch，也不会再次请求 OpenAI。
+- **错误边界**：进行中的 `reset_credit_reservation_active`、配额/资格问题、其他 429、guard 故障与真实上游失败继续作为错误显示，不能因本次 UI 修正被吞掉。定向测试同时断言 cooldown 只调用一次 fetch、相邻 429 仍拒绝，以及 Providers 成功状态不出现 error alert。
+
 ## 2026-07-15 · Codex 配额 PULL 饱和后触发自动重置（OAuth quota / reset credits，docs/04/11，原则 3/5/7）
 
 - **生产根因**：账号已启用 `autoReset`、仍有 reset credit，显式刷新也从 Codex PULL 得到账号级周窗口 100%；但刷新链只持久化 snapshot、同步 live pool 并停车，自动重置仅由后续响应头 PUSH 触发。账号一旦因 PULL 饱和而停车，可能不再获得下一次响应头，形成“缓存页面持续显示 100%，自动重置没有入口”的延迟触发；生产实例最终在约 5 分钟后的新响应头到达时才成功消耗 credit，证明设置与 guard 本身正常。
@@ -66,16 +71,9 @@
 - **周额度权威**：周窗口改为集合级选择：账号级 `windowMinutes >= 10080` 的明确时长窗口优先；只有整组没有明确周窗口时，才兼容使用非零的未知时长 `secondary`。model-scoped 窗口仍排除。Admin、自动重置和 reset-credit 幂等 guard 共用该选择，空 positional 数据不能再覆盖真实周用量或 reset marker。
 - **验证**：TDD 定向覆盖 live header 形态、durable cache 旧快照、Providers 标签、明确周窗口优先、legacy fallback 与 reset-credit guard；6 files / 219 tests 全绿。
 
-## 2026-07-14 · Subscription Providers 改为缓存优先与全局串行刷新（OAuth Admin / provider observability，docs/04/11，原则 1/3/6/7）
-
-- **性能根因**：Providers 首屏过去并行请求 status、usage、quota；status 会刷新过期 token 并逐账号发现模型，quota 会逐账号拉取上游额度、写 snapshot、同步 cooldown 并清理 orphan。慢代理、上游限流或账号数增加会把页面打开直接绑定到外部网络，刷新按钮和自动刷新也会重复制造同一批工作。
-- **缓存读边界**：新增单次 `GET /admin/api/oauth/overview`，只读取本地 token/settings、进程内模型/额度 snapshot、durable quota 与当日 usage；不得刷新 token、发现模型、请求 quota、删除 orphan 或修改 cooldown。原 `/oauth`、`/usage`、`/quota` 同样改为 cache-only，保持兼容但不再隐式产生上游流量；无需数据库迁移。
-- **刷新队列**：显式 `POST /admin/api/oauth/refresh` 立即返回 `202`，由 Gateway 进程级 coordinator 保证全局最多一个 active job；并发点击合并到同一 job，成功或失败后冷却 60 秒。job 内按账号串行刷新 token、模型目录与 quota，显式刷新可绕过正/负 TTL 缓存；Anthropic/Codex 模型发现增加 10 秒硬超时，避免死代理长期占住唯一 worker。
-- **失败与旧数据**：任一账号的 quota 超时、空/非法窗口或持久化失败会把 job 标为 `failed` 并记录安全错误摘要，但不会删除 last-known-good snapshot；其余账号仍继续串行刷新。页面展示 queued/running/succeeded/failed、最近成功时间与 cooldown，手动点击只入队一次并 cache-only 轮询，定时自动刷新永远只读缓存。
-- **验证**：TDD 覆盖 cache-only 首屏、20 次并发点击合并、账号刷新最大并发 1、失败保留旧 quota、force cache bypass、模型发现 timeout、前端单请求加载、手动/自动刷新分流与多语言状态文案；workspace 357 files / 5775 tests、typecheck、Biome、build 与 Admin check 全通过。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-14 · Subscription Providers 改为缓存优先与全局串行刷新（OAuth Admin / provider observability，docs/04/11，原则 1/3/6/7）**：Providers 首屏与兼容读 API 严格 cache-only；显式刷新由进程级单 worker 串行账号、合并并发点击并保留 last-known-good 数据。
 - **2026-07-14 · Avoid Waste 在 provider 池内限制 reset-credit 偏置（OAuth provider selection，docs/04/11，原则 3/5/6）**：reset credits 只作为同一 provider 池内的弱恢复容量信号，不能压过明显更多的真实即将过期额度；套餐标签不参与分池或评分。
 - **2026-07-13 · Responses 工具结果的 multipart 文本使用 input_text（Protocol translation / provider execution，docs/05/07，原则 3/5/8）**：provider 与共享 transformer 统一把请求侧 multipart 工具结果文本编码为 `input_text`，保留字符串、图片、文件与助手输出的既有 wire shape。
 - **2026-07-13 · Codex 周配额按真实窗口时长识别（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）**：账号级 Codex 周窗口以 provider 报告的 `windowMinutes >= 10080` 为权威，旧快照仅在缺 duration 且有真实用量时回退 secondary；Admin、reset-credit 与 model-scoped 隔离共用同一规则。


### PR DESCRIPTION
## Summary
- treat the exact local Codex reset-credit cooldown response as an already-completed reset in the Admin client
- show a normal success notice instead of the raw OAuth 429 JSON
- keep unrelated 429 and reset failures as errors, with no retry or second request
- update all Admin locales and implementation notes

## Verification
- `CI=true corepack pnpm exec vitest run apps/admin/src/lib/api/oauth.test.ts apps/admin/src/routes/providers/providers.test.ts apps/admin/src/lib/i18n/providers-locales.test.ts` (80 passed)
- `corepack pnpm --filter @helm/admin check` (0 errors, 0 warnings)
- targeted Prettier check
- `git diff --check origin/main...HEAD`