### PR TITLE
chore(release): v0.27.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.13",
+  "version": "0.27.14",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump the root Helm version from `0.27.13` to `0.27.14`
- publish the merged Admin reset-cooldown success UI as a backward-compatible patch release

## Release scope
- version-only change in `package.json`
- feature PR: #574
- expected publish flow: GitHub tag/release `v0.27.14` plus GHCR `latest`, `0.27.14`, and SHA tags