### PR TITLE
chore(release): v0.27.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.14",
+  "version": "0.27.15",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- release Helm API v0.27.15
- includes the historical repricing CPU 75% policy from PR #576

## Verification

- package.json parses successfully
- version is exactly 0.27.15
- git diff --check