### PR TITLE
fix(admin): eliminate cold-read stalls

### DIFF
--- a/apps/admin/src/app-template.test.ts
+++ b/apps/admin/src/app-template.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('admin app template', () => {
+  it('preloads route code on hover but waits for a tap before loading route data', () => {
+    const template = readFileSync(resolve(process.cwd(), 'apps/admin/src/app.html'), 'utf8');
+
+    expect(template).toContain('data-sveltekit-preload-code="hover"');
+    expect(template).toContain('data-sveltekit-preload-data="tap"');
+    expect(template).not.toContain('data-sveltekit-preload-data="hover"');
+  });
+});

--- a/apps/admin/src/app.html
+++ b/apps/admin/src/app.html
@@ -7,7 +7,7 @@
     <title>Helm Admin</title>
     %sveltekit.head%
   </head>
-  <body data-sveltekit-preload-data="hover">
+  <body data-sveltekit-preload-code="hover" data-sveltekit-preload-data="tap">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/apps/admin/src/lib/components/RefreshControl.svelte
+++ b/apps/admin/src/lib/components/RefreshControl.svelte
@@ -110,6 +110,10 @@
     stopTimer();
     if (seconds > 0) {
       timer = setInterval(() => {
+        // Background tabs must not multiply expensive dashboard/list queries. Skip
+        // hidden ticks rather than queueing a catch-up burst; the next visible tick
+        // resumes the normal cadence.
+        if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
         void runRefresh(onAutoRefresh ?? onRefresh);
       }, seconds * 1000);
     }

--- a/apps/admin/src/lib/components/RefreshControl.test.ts
+++ b/apps/admin/src/lib/components/RefreshControl.test.ts
@@ -59,6 +59,23 @@ describe('RefreshControl', () => {
     expect(onRefresh).toHaveBeenCalledTimes(2);
   });
 
+  it('pauses auto-refresh while the document is hidden', async () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    const onRefresh = vi.fn();
+    render(RefreshControl, { onRefresh });
+    await fireEvent.click(screen.getByTestId('refresh-toggle'));
+    await fireEvent.click(screen.getByTestId('refresh-interval-5'));
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    visibility.mockReturnValue('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onRefresh).toHaveBeenCalledOnce();
+    visibility.mockRestore();
+  });
+
   it('can keep manual refresh separate from cache-only auto refresh', async () => {
     const onRefresh = vi.fn();
     const onAutoRefresh = vi.fn();

--- a/apps/admin/src/routes/+page.ts
+++ b/apps/admin/src/routes/+page.ts
@@ -49,22 +49,43 @@ export const load: PageLoad = async ({ url }) => {
   // (not 00:00 UTC) — the fix for the "8am boundary" on UTC+8 dashboards.
   const tzOffsetMinutes = clientTzOffsetMinutes();
 
-  // The aggregate (cards + charts). Fail-soft to an empty aggregate.
-  let agg: DashboardStats = EMPTY_STATS;
-  try {
-    agg = await getStats({ ...statsWindow, bucket, tzOffsetMinutes });
-  } catch {
-    agg = EMPTY_STATS;
-  }
+  // These reads are independent. Start them together so navigation latency is the
+  // slowest read, not the sum of three reads. Each promise owns its fail-soft value
+  // so one admin-API hiccup still cannot sink the rest of the dashboard.
+  const aggPromise = (async (): Promise<DashboardStats> => {
+    try {
+      return await getStats({ ...statsWindow, bucket, tzOffsetMinutes });
+    } catch {
+      return EMPTY_STATS;
+    }
+  })();
+  const itemsPromise = (async (): Promise<RequestListItem[]> => {
+    try {
+      return (await listRequests({ start, end, pageSize: 10 })).items;
+    } catch {
+      return [];
+    }
+  })();
+  const comparisonTotalsPromise =
+    !custom && (range === 'today' || range === 'yesterday')
+      ? (async (): Promise<DashboardStats['totals'] | null> => {
+          try {
+            const cmp =
+              range === 'today'
+                ? resolveTodayComparisonWindow(now)
+                : resolveYesterdayComparisonWindow(now);
+            return (await getStats({ ...cmp, bucket, tzOffsetMinutes })).totals;
+          } catch {
+            return null;
+          }
+        })()
+      : Promise.resolve(null);
 
-  // The recent-requests table preview (first 10 rows shown). Fail-soft to [].
-  let items: RequestListItem[] = [];
-  try {
-    const res = await listRequests({ start, end, pageSize: 10 });
-    items = res.items;
-  } catch {
-    items = [];
-  }
+  const [agg, items, comparisonTotals] = await Promise.all([
+    aggPromise,
+    itemsPromise,
+    comparisonTotalsPromise,
+  ]);
 
   // Derive the headline card numbers from the SQL aggregate (the real totals over
   // the whole window, not a sample). Token totals: Input = prompt, Output =
@@ -87,36 +108,26 @@ export const load: PageLoad = async ({ url }) => {
   // little traffic. Fail-soft: a hiccup → no deltas, cards just omit them.
   const MIN_COMPARISON_BASELINE_REQUESTS = 10;
   let compare: Record<string, { pct: number | null; base: number }> | null = null;
-  if (!custom && (range === 'today' || range === 'yesterday')) {
-    try {
-      const cmp =
-        range === 'today'
-          ? resolveTodayComparisonWindow(now)
-          : resolveYesterdayComparisonWindow(now);
-      const y = (await getStats({ ...cmp, bucket, tzOffsetMinutes })).totals;
-      if (y.requests >= MIN_COMPARISON_BASELINE_REQUESTS) {
-        const yTotalTokens = y.promptTokens + y.completionTokens;
-        compare = {
-          requests: { pct: pctDelta(t.requests, y.requests), base: y.requests },
-          totalTokens: {
-            pct: pctDelta(t.promptTokens + t.completionTokens, yTotalTokens),
-            base: yTotalTokens,
-          },
-          inputTokens: { pct: pctDelta(t.promptTokens, y.promptTokens), base: y.promptTokens },
-          outputTokens: {
-            pct: pctDelta(t.completionTokens, y.completionTokens),
-            base: y.completionTokens,
-          },
-          cachedTokens: { pct: pctDelta(t.cachedTokens, y.cachedTokens), base: y.cachedTokens },
-          totalCost: {
-            pct: pctDelta(t.totalCostUsd ?? 0, y.totalCostUsd ?? 0),
-            base: y.totalCostUsd ?? 0,
-          },
-        };
-      }
-    } catch {
-      compare = null;
-    }
+  if (comparisonTotals && comparisonTotals.requests >= MIN_COMPARISON_BASELINE_REQUESTS) {
+    const y = comparisonTotals;
+    const yTotalTokens = y.promptTokens + y.completionTokens;
+    compare = {
+      requests: { pct: pctDelta(t.requests, y.requests), base: y.requests },
+      totalTokens: {
+        pct: pctDelta(t.promptTokens + t.completionTokens, yTotalTokens),
+        base: yTotalTokens,
+      },
+      inputTokens: { pct: pctDelta(t.promptTokens, y.promptTokens), base: y.promptTokens },
+      outputTokens: {
+        pct: pctDelta(t.completionTokens, y.completionTokens),
+        base: y.completionTokens,
+      },
+      cachedTokens: { pct: pctDelta(t.cachedTokens, y.cachedTokens), base: y.cachedTokens },
+      totalCost: {
+        pct: pctDelta(t.totalCostUsd ?? 0, y.totalCostUsd ?? 0),
+        base: y.totalCostUsd ?? 0,
+      },
+    };
   }
 
   return {

--- a/apps/admin/src/routes/home.test.ts
+++ b/apps/admin/src/routes/home.test.ts
@@ -66,6 +66,14 @@ type HomePageData = {
   compare: Record<string, { pct: number | null; base: number }> | null;
 };
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 function pageData(overrides: Partial<HomePageData> = {}): HomePageData {
   return {
     items: [],
@@ -152,6 +160,30 @@ describe('home dashboard loader', () => {
   function statsWith(totals: Partial<DashboardStats['totals']>): DashboardStats {
     return { ...EMPTY_STATS, totals: { ...EMPTY_STATS.totals, ...totals } };
   }
+
+  it('starts current stats, recent requests, and comparison stats concurrently', async () => {
+    const current = deferred<DashboardStats>();
+    const recent = deferred<{ items: RequestListItem[] }>();
+    const comparison = deferred<DashboardStats>();
+    mocks.getStats
+      .mockReset()
+      .mockReturnValueOnce(current.promise)
+      .mockReturnValueOnce(comparison.promise);
+    mocks.listRequests.mockReset().mockReturnValueOnce(recent.promise);
+
+    const loading = load({ url: new URL('https://admin.test/') } as never);
+    const callsBeforeAnyReadSettles = {
+      stats: mocks.getStats.mock.calls.length,
+      requests: mocks.listRequests.mock.calls.length,
+    };
+
+    current.resolve(statsWith({ requests: 20 }));
+    recent.resolve({ items: [] });
+    comparison.resolve(statsWith({ requests: 10 }));
+    await loading;
+
+    expect(callsBeforeAnyReadSettles).toEqual({ stats: 2, requests: 1 });
+  });
 
   it('computes vs-yesterday deltas (pct + baseline) on the today view', async () => {
     const now = Date.UTC(2026, 5, 17, 12);

--- a/apps/admin/src/routes/keys/[keyId]/+page.ts
+++ b/apps/admin/src/routes/keys/[keyId]/+page.ts
@@ -34,35 +34,35 @@ export const load: PageLoad = async ({ params, url }) => {
   const bucket = bucketForWindow(start, end);
   const tzOffsetMinutes = clientTzOffsetMinutes();
 
-  // Stats scoped to THIS key (cards + charts). Fail-soft to an empty aggregate.
-  let agg: DashboardStats = EMPTY_STATS;
-  try {
-    agg = await getStats({ key_id: keyId, start, end, bucket, tzOffsetMinutes });
-  } catch {
-    agg = EMPTY_STATS;
-  }
-
-  // The key's own request list — only the most-recent page (no in-page pager; the
-  // "view all" link hands the full history off to the global requests list). Total
-  // is still the full filtered count, so the page knows whether there's more.
-  // Fail-soft to an empty page.
-  let requests = {
-    items: [] as RequestListItem[],
-    total: 0,
-    page: 1,
-    pageSize: DETAIL_PAGE_SIZE,
-  };
-  try {
-    requests = await listRequests({
-      keyId,
-      start,
-      end,
-      page: 1,
-      pageSize: DETAIL_PAGE_SIZE,
-    });
-  } catch {
-    // keep the empty page
-  }
+  // Stats and recent requests are independent once the key is known. Start both
+  // together so the page waits for the slower query rather than both in sequence;
+  // each read still fails soft to the same renderable empty state as before.
+  const aggPromise = (async (): Promise<DashboardStats> => {
+    try {
+      return await getStats({ key_id: keyId, start, end, bucket, tzOffsetMinutes });
+    } catch {
+      return EMPTY_STATS;
+    }
+  })();
+  const requestsPromise = (async () => {
+    try {
+      return await listRequests({
+        keyId,
+        start,
+        end,
+        page: 1,
+        pageSize: DETAIL_PAGE_SIZE,
+      });
+    } catch {
+      return {
+        items: [] as RequestListItem[],
+        total: 0,
+        page: 1,
+        pageSize: DETAIL_PAGE_SIZE,
+      };
+    }
+  })();
+  const [agg, requests] = await Promise.all([aggPromise, requestsPromise]);
 
   // Headline cards from the SQL aggregate (real totals over the window, not a
   // sample) — same derivation as the dashboard so the numbers read identically.

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -74,6 +74,14 @@ function keyView(overrides: Partial<ApiKeyView> = {}): ApiKeyView {
   };
 }
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe('key detail loader', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -104,6 +112,26 @@ describe('key detail loader', () => {
       end: now,
     });
     expect((result as { filters: KeyDetailFilters }).filters.range).toBe('today');
+  });
+
+  it('starts stats and recent requests concurrently after the key resolves', async () => {
+    const stats = deferred<DashboardStats>();
+    const requests = deferred<RequestsPage>();
+    mocks.getStats.mockReset().mockReturnValueOnce(stats.promise);
+    mocks.listRequests.mockReset().mockReturnValueOnce(requests.promise);
+
+    const loading = load({
+      params: { keyId: 'k1' },
+      url: new URL('https://admin.test/keys/k1'),
+    } as never);
+    await vi.waitFor(() => expect(mocks.getStats).toHaveBeenCalledOnce());
+    const requestCallsBeforeStatsSettles = mocks.listRequests.mock.calls.length;
+
+    stats.resolve(mocks.emptyStats);
+    requests.resolve({ items: [], total: 0, page: 1, pageSize: 25 });
+    await loading;
+
+    expect(requestCallsBeforeStatsSettles).toBe(1);
   });
 
   it('resolves a custom date range to [midnight(start), midnight(end)+1day)', async () => {

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1084,6 +1084,29 @@ describe("admin.api keys", () => {
       const res = await app.request("/admin/api/keys/usage?tzOffsetMinutes=480");
       expect(res.status).toBe(200);
       expect(windows[0]).toEqual({ start: todayStartUtc, end: now });
+      expect(
+        (await app.request("/admin/api/keys/usage?tzOffsetMinutes=480")).headers.get(
+          "x-helm-cache",
+        ),
+      ).toBe("fresh");
+      expect(windows).toHaveLength(1);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("caches the live per-key usage window instead of regrouping telemetry on every read", async () => {
+    const now = Date.UTC(2026, 5, 1, 20, 0, 0);
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    const usageByKey = vi.fn(async () => []);
+    const telemetry: TelemetryStore = { ...makeTelemetry(), usageByKey };
+    try {
+      const app = buildApp(buildDeps({ telemetry }));
+      const first = await app.request("/admin/api/keys/usage?start=1000");
+      const second = await app.request("/admin/api/keys/usage?start=1000");
+      expect(first.headers.get("x-helm-cache")).toBe("miss");
+      expect(second.headers.get("x-helm-cache")).toBe("fresh");
+      expect(usageByKey).toHaveBeenCalledTimes(1);
     } finally {
       nowSpy.mockRestore();
     }
@@ -1295,6 +1318,24 @@ describe("admin.api stats (dashboard token accounting)", () => {
     expect(await res.json()).toEqual(AGG);
     // The route parsed the explicit window + bucket and passed them through (tz → 0).
     expect(calls).toEqual([{ start: 1000, end: 5000, bucket: "hour", tz: 0 }]);
+  });
+
+  it("caches a live stats window instead of repeating three SQLite aggregates", async () => {
+    const now = Date.UTC(2026, 5, 1, 20, 0, 0);
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    const calls: Array<{ start: number; end: number; bucket: string; tz: number; keyId?: string }> =
+      [];
+    try {
+      const app = buildApp(buildDeps({ telemetry: statsTelemetry(calls) }));
+      const url = `/admin/api/stats?start=1000&end=${now}&bucket=hour`;
+      const first = await app.request(url);
+      const second = await app.request(url);
+      expect(first.headers.get("x-helm-cache")).toBe("miss");
+      expect(second.headers.get("x-helm-cache")).toBe("fresh");
+      expect(calls).toHaveLength(1);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("forwards the client tz offset and fails open to 0 on junk", async () => {

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -3,6 +3,7 @@ import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import { INTERNAL_API_KEY_ID } from "../../internal-key.js";
 import type { AdminApiDeps, KeySummary, KeyUsageSummary } from "./deps.js";
+import { adminWindowCacheKey, createAdminReadCache } from "./read-cache.js";
 
 // Default usage window for the list column when start is omitted: today in the
 // viewer's local day. The SPA sends an explicit local-midnight start; this fallback
@@ -74,6 +75,7 @@ function toSummary(rec: {
 }
 
 export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
+  const usageCache = createAdminReadCache<KeyUsageSummary[]>();
   // GET /keys -> KeySummary[] (no plaintext, no hash full-text).
   app.get("/admin/api/keys", async (c) => {
     const rows = await deps.keyStore.list();
@@ -88,11 +90,22 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
   // mean the viewer's local "today" instead of a rolling 24h window.
   app.get("/admin/api/keys/usage", async (c) => {
     const q = StatsQuerySchema.parse(c.req.query());
-    const end = q.end ?? Date.now();
+    const now = Date.now();
+    const end = q.end ?? now;
     const start = q.start ?? localDayStartMs(end, q.tzOffsetMinutes);
-    const usage = await deps.telemetry.usageByKey(start, end);
-    return c.json(
-      usage.map(
+    const key = adminWindowCacheKey({
+      start,
+      end,
+      now,
+      // The route's fallback is local calendar midnight, not a rolling duration;
+      // keep that absolute start in the key so repeated default reads can hit.
+      startWasDefault: false,
+      endWasDefault: q.end === undefined,
+      dimensions: [q.tzOffsetMinutes],
+    });
+    const result = await usageCache.get(key, async () => {
+      const usage = await deps.telemetry.usageByKey(start, end);
+      return usage.map(
         (u): KeyUsageSummary => ({
           key_id: u.apiKeyId,
           requests: u.requests,
@@ -100,8 +113,10 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
           cost_usd: u.totalCostUsd,
           total_tokens: u.totalTokens,
         }),
-      ),
-    );
+      );
+    });
+    c.header("X-Helm-Cache", result.status);
+    return c.json(result.value);
   });
 
   // GET /keys/:id/secret -> reveal the full key when this row has encrypted

--- a/apps/gateway/src/routes/admin/read-cache.test.ts
+++ b/apps/gateway/src/routes/admin/read-cache.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { adminWindowCacheKey, createAdminReadCache } from "./read-cache.js";
+
+describe("createAdminReadCache", () => {
+  it("coalesces concurrent misses and serves a fresh value without loading again", async () => {
+    let now = 1_000;
+    let resolve!: (value: string) => void;
+    const load = vi.fn(
+      () =>
+        new Promise<string>((done) => {
+          resolve = done;
+        }),
+    );
+    const cache = createAdminReadCache<string>({ now: () => now });
+
+    const first = cache.get("stats", load);
+    const second = cache.get("stats", load);
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(1));
+    resolve("snapshot");
+
+    await expect(first).resolves.toEqual({ value: "snapshot", status: "miss" });
+    await expect(second).resolves.toEqual({ value: "snapshot", status: "coalesced" });
+    now += 5_000;
+    await expect(cache.get("stats", load)).resolves.toEqual({
+      value: "snapshot",
+      status: "fresh",
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns stale data immediately and schedules one background refresh", async () => {
+    let now = 1_000;
+    const scheduled: Array<() => void> = [];
+    const load = vi.fn().mockResolvedValueOnce("old").mockResolvedValueOnce("new");
+    const cache = createAdminReadCache<string>({
+      freshTtlMs: 10_000,
+      staleTtlMs: 300_000,
+      now: () => now,
+      schedule: (run) => scheduled.push(run),
+    });
+
+    await expect(cache.get("stats", load)).resolves.toEqual({ value: "old", status: "miss" });
+    now += 10_001;
+    await expect(cache.get("stats", load)).resolves.toEqual({ value: "old", status: "stale" });
+    await expect(cache.get("stats", load)).resolves.toEqual({ value: "old", status: "stale" });
+    expect(scheduled).toHaveLength(1);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    scheduled[0]?.();
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    await vi.waitFor(async () =>
+      expect(await cache.get("stats", load)).toEqual({ value: "new", status: "fresh" }),
+    );
+  });
+
+  it("does not retain a failed cold load", async () => {
+    const load = vi.fn().mockRejectedValueOnce(new Error("db busy")).mockResolvedValueOnce("ok");
+    const cache = createAdminReadCache<string>();
+
+    await expect(cache.get("stats", load)).rejects.toThrow("db busy");
+    await expect(cache.get("stats", load)).resolves.toEqual({ value: "ok", status: "miss" });
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a stable key for live rolling presets but keeps completed windows exact", () => {
+    const common = { dimensions: ["hour", 480] as const, startWasDefault: false };
+    const first = adminWindowCacheKey({
+      ...common,
+      start: 10_000,
+      end: 10_000 + 3_600_000,
+      now: 10_000 + 3_600_000,
+      endWasDefault: true,
+    });
+    const later = adminWindowCacheKey({
+      ...common,
+      start: 20_000,
+      end: 20_000 + 3_600_000,
+      now: 20_000 + 3_600_000,
+      endWasDefault: true,
+    });
+    expect(later).toBe(first);
+
+    const completed = adminWindowCacheKey({
+      ...common,
+      start: 10_000,
+      end: 20_000,
+      now: 9_999_999,
+      endWasDefault: false,
+    });
+    expect(completed).not.toBe(first);
+  });
+});

--- a/apps/gateway/src/routes/admin/read-cache.ts
+++ b/apps/gateway/src/routes/admin/read-cache.ts
@@ -1,0 +1,137 @@
+export type AdminReadCacheStatus = "miss" | "coalesced" | "fresh" | "stale";
+
+export interface AdminReadCacheResult<T> {
+  value: T;
+  status: AdminReadCacheStatus;
+}
+
+export interface AdminReadCacheOptions {
+  freshTtlMs?: number;
+  staleTtlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+  schedule?: (run: () => void) => void;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  freshUntil: number;
+  staleUntil: number;
+}
+
+const DEFAULT_FRESH_TTL_MS = 10_000;
+const DEFAULT_STALE_TTL_MS = 5 * 60_000;
+const DEFAULT_MAX_ENTRIES = 256;
+
+function defer(run: () => void): void {
+  const timer = setTimeout(run, 0);
+  if (typeof timer.unref === "function") timer.unref();
+}
+
+// Small stale-while-revalidate cache for expensive, read-only Admin aggregates.
+// A cold miss is still authoritative and awaited. Once a last-known-good snapshot
+// exists, an expired read returns it immediately and schedules one coalesced refresh.
+// The deferred refresh matters for better-sqlite3: calling an async wrapper directly
+// would still enter its synchronous SQL work before the stale response can leave.
+export function createAdminReadCache<T>(options: AdminReadCacheOptions = {}) {
+  const freshTtlMs = options.freshTtlMs ?? DEFAULT_FRESH_TTL_MS;
+  const staleTtlMs = Math.max(options.staleTtlMs ?? DEFAULT_STALE_TTL_MS, freshTtlMs);
+  const maxEntries = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const now = options.now ?? Date.now;
+  const schedule = options.schedule ?? defer;
+  const entries = new Map<string, CacheEntry<T>>();
+  const inFlight = new Map<string, Promise<T>>();
+  const scheduled = new Set<string>();
+
+  const store = (key: string, value: T): T => {
+    const at = now();
+    entries.delete(key);
+    entries.set(key, {
+      value,
+      freshUntil: at + freshTtlMs,
+      staleUntil: at + staleTtlMs,
+    });
+    while (entries.size > maxEntries) {
+      const oldest = entries.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      entries.delete(oldest);
+    }
+    return value;
+  };
+
+  const loadOnce = (
+    key: string,
+    load: () => Promise<T>,
+  ): { promise: Promise<T>; shared: boolean } => {
+    const current = inFlight.get(key);
+    if (current !== undefined) return { promise: current, shared: true };
+    // Defer invocation to a microtask so the in-flight marker exists before a
+    // synchronous adapter begins work; concurrent callers then share one scan.
+    const promise = Promise.resolve()
+      .then(load)
+      .then((value) => store(key, value))
+      .finally(() => inFlight.delete(key));
+    inFlight.set(key, promise);
+    return { promise, shared: false };
+  };
+
+  const scheduleRefresh = (key: string, load: () => Promise<T>): void => {
+    if (scheduled.has(key) || inFlight.has(key)) return;
+    scheduled.add(key);
+    schedule(() => {
+      scheduled.delete(key);
+      void loadOnce(key, load).promise.catch(() => {
+        // Keep the last-known-good stale snapshot. The next read may retry; an
+        // auxiliary Admin refresh failure must not become an unhandled rejection.
+      });
+    });
+  };
+
+  return {
+    async get(key: string, load: () => Promise<T>): Promise<AdminReadCacheResult<T>> {
+      const at = now();
+      const hit = entries.get(key);
+      if (hit !== undefined && hit.freshUntil > at) {
+        entries.delete(key);
+        entries.set(key, hit);
+        return { value: hit.value, status: "fresh" };
+      }
+      if (hit !== undefined && hit.staleUntil > at) {
+        scheduleRefresh(key, load);
+        return { value: hit.value, status: "stale" };
+      }
+      if (hit !== undefined) entries.delete(key);
+
+      const pending = loadOnce(key, load);
+      return {
+        value: await pending.promise,
+        status: pending.shared ? "coalesced" : "miss",
+      };
+    },
+  };
+}
+
+export function adminWindowCacheKey(input: {
+  start: number;
+  end: number;
+  now: number;
+  startWasDefault: boolean;
+  endWasDefault: boolean;
+  dimensions: readonly (string | number | undefined)[];
+}): string {
+  const live = input.endWasDefault || Math.abs(input.end - input.now) <= 60_000;
+  const duration = input.end - input.start;
+  const rollingPresetMs = [
+    3_600_000,
+    6 * 3_600_000,
+    86_400_000,
+    7 * 86_400_000,
+    30 * 86_400_000,
+  ].find((candidate) => Math.abs(duration - candidate) <= 1_000);
+  const start =
+    live && (input.startWasDefault || rollingPresetMs !== undefined)
+      ? `rolling:${rollingPresetMs ?? duration}`
+      : input.start;
+  const end = live ? "live" : input.end;
+  return JSON.stringify([start, end, ...input.dimensions]);
+}

--- a/apps/gateway/src/routes/admin/stats.ts
+++ b/apps/gateway/src/routes/admin/stats.ts
@@ -2,6 +2,7 @@ import { StatsQuerySchema } from "@helm/shared";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
 import type { AdminApiDeps } from "./deps.js";
+import { adminWindowCacheKey, createAdminReadCache } from "./read-cache.js";
 
 // /admin/api/stats — dashboard token-accounting aggregate (TelemetryStore,
 // READ-ONLY). Feeds the homepage token cards + the trend / by-model charts in ONE
@@ -13,6 +14,7 @@ import type { AdminApiDeps } from "./deps.js";
 const DAY_MS = 86_400_000;
 
 export function registerStatsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
+  const cache = createAdminReadCache<Awaited<ReturnType<typeof deps.telemetry.aggregate>>>();
   // GET /stats?start&end&bucket&tzOffsetMinutes -> TelemetryAggregate. The window
   // defaults to the last 24h when start/end are omitted (a live dashboard cares
   // about recent traffic); bucket defaults to "day". `tzOffsetMinutes` (the admin
@@ -20,11 +22,23 @@ export function registerStatsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   // to 0 (UTC) when absent. The store does the SUM/GROUP BY in SQL.
   app.get("/admin/api/stats", async (c) => {
     const q = StatsQuerySchema.parse(c.req.query());
-    const end = q.end ?? Date.now();
+    const now = Date.now();
+    const end = q.end ?? now;
     const start = q.start ?? end - DAY_MS;
     // `key_id`, when present, scopes the whole aggregate to one key (the detail
     // page); omitted = the global dashboard view.
-    const agg = await deps.telemetry.aggregate(start, end, q.bucket, q.tzOffsetMinutes, q.key_id);
-    return c.json(agg);
+    const key = adminWindowCacheKey({
+      start,
+      end,
+      now,
+      startWasDefault: q.start === undefined,
+      endWasDefault: q.end === undefined,
+      dimensions: [q.bucket, q.tzOffsetMinutes, q.key_id],
+    });
+    const result = await cache.get(key, () =>
+      deps.telemetry.aggregate(start, end, q.bucket, q.tzOffsetMinutes, q.key_id),
+    );
+    c.header("X-Helm-Cache", result.status);
+    return c.json(result.value);
   });
 }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-16 · Admin 首次点击卡顿改为非投机加载与汇总读（Admin / Store performance，docs/08/11，原则 1/3/7）
+
+- **生产根因**：`la.atmy.work` 的 `/admin/api/memory/stats` 冷读实测最高约 10.2 秒；同步 `better-sqlite3` 在 Node 事件循环上对约 139 万 `memory_messages`、11.9k observations 及其他 memory 表执行 `COUNT/MAX`，扫描期间连 health completion 都暂停。Admin 又在 `app.html` 全局启用 `data-sveltekit-preload-data="hover"`，鼠标经过侧栏即可投机触发这些数据库查询；第一次点击因此等待冷扫描，第二次点击命中 10 秒应用缓存或 OS page cache，形成“再点一下马上出来”的假象。同期没有 VACUUM、cleanup、OOM、`SQLITE_BUSY` 或 payload capture 事件，不能把本次页面卡顿归因于这些路径。
+- **稳定读模型**：SQLite v39 / Postgres v38 在 `memory_threads` 增加 `message_count`、`last_message_at`、`observation_count`、`last_observation_at`，迁移以每个子表一次 set-based `GROUP BY` 原子回填；单条/批量消息写入、dedup conflict、observation 写入与消息清理在同一事务维护汇总。Postgres prune 先按固定顺序锁定受影响的 thread 父行，避免并发 append 的增量被旧快照覆盖；既有 `memory:dedup` SQLite/Postgres 运维路径也在 wipe/prune 后原子重建四个汇总字段，重复运行保持幂等。Admin stats 之后只聚合较小的 thread 父表，不再扫描正文子表。首次升级仍会执行一次有界全量回填，生产发布必须预留启动迁移窗口并观察 WAL/磁盘；它不是每次页面读取的成本。
+- **缓存与前端边界**：SQLite page cache 从 16 MiB 提升到保守的 64 MiB；`/admin/api/stats` 与 `/admin/api/keys/usage` 使用 10 秒 fresh、5 分钟 last-known-good stale 的进程级 single-flight / stale-while-revalidate 缓存，并用 `X-Helm-Cache` 暴露 `miss/coalesced/fresh/stale`。动态 live window 使用稳定 cache key，历史闭合窗口仍按精确边界隔离。Admin 保留 hover code preload，但 data preload 改为 tap；dashboard 与 key detail 的独立读并行，隐藏 tab 不再执行自动刷新。当前生产库约 58.8 GB 且只有约 15 GB 可用、freelist 约 22.8 GiB，继续禁止在线 VACUUM；本次也不擅自开启 memory retention 或修改生产数据。
+
 ## 2026-07-15 · Codex 已重置冷却在 Admin 投影为成功（Admin providers UI，docs/11，原则 3/5/7）
 
 - **UI 边界**：Gateway 与 reset-credit guard 保持不变；Admin 客户端仅把本地 `429 + reset_credit_cooldown_active` 解释为“该账号最近已经完成重置”，复用既有 `alreadyRedeemed` 成功路径并显示“重置已成功完成”。该投影不会重试、不会产生第二次 fetch，也不会再次请求 OpenAI。
@@ -64,15 +70,9 @@
 - **统一投影与存储**：通道目录继续保持 network-free（读取时不发上游请求），Anthropic、Copilot、xAI 自动模式依次使用共享进程缓存、现有加密账号设置中的 durable last-known-good 目录、curated fallback；Admin 刷新与 runtime pool synthesis 只持久化仍被当前 cache generation 接受的非空发现。同名账号重连先失效旧 generation、严格清理旧身份 snapshot，成功后才替换 credential；手动模式仍只使用持久 allowlist，Codex 仍使用独立的持久 ModelInfo catalog，不改变 entitlement 边界，也无需数据库迁移。
 - **失败语义与验证**：空目录或发现错误绝不覆盖 durable last-known-good；缓存和持久快照都不存在时才使用既有 curated fail-open fallback。后台 snapshot 写失败只告警、不阻断路由；但加密设置读取/解密/JSON shape 失败时严格拒绝任何 mutation，不能用空 map 覆盖 proxy、priority、allowlist 等既有状态。TDD 覆盖三种非 Codex provider、进程缓存丢失后的持久恢复、Manual 隔离、旧 credential 并发发现、重连清理顺序、损坏设置防覆盖与写失败 fail-open；定向 5 files / 153 tests 全绿。
 
-## 2026-07-14 · 丢弃 Codex 空 secondary 配额占位窗口（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）
-
-- **生产根因**：Codex 部分账号的响应头会同时返回真实 `primary + windowMinutes:10080` 周窗口，以及 `secondary + usedPercent:0 + 无 duration + reset-after:0`。后者只是空占位，但 header parser 将其作为配额写入；latest-wins snapshot 随后覆盖完整 PULL 数据，Admin 又把未知时长的 positional key 翻译成“次窗口”，造成看似存在第二个额度且 7 天用量消失。
-- **三层防御**：header parser 在入库前丢弃“0% + 无时长 + 截止采集时已重置”的窗口；Admin cache-only API 与 Providers 页面用 snapshot 自己的 `capturedAt` 过滤旧版本已写入的同类脏数据，部署后无需等待新请求或人工清库即可恢复展示。未来重置、非零用量或带真实 duration 的窗口继续保留，避免误删刚开始的新周期与 legacy 数据。
-- **周额度权威**：周窗口改为集合级选择：账号级 `windowMinutes >= 10080` 的明确时长窗口优先；只有整组没有明确周窗口时，才兼容使用非零的未知时长 `secondary`。model-scoped 窗口仍排除。Admin、自动重置和 reset-credit 幂等 guard 共用该选择，空 positional 数据不能再覆盖真实周用量或 reset marker。
-- **验证**：TDD 定向覆盖 live header 形态、durable cache 旧快照、Providers 标签、明确周窗口优先、legacy fallback 与 reset-credit guard；6 files / 219 tests 全绿。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-14 · 丢弃 Codex 空 secondary 配额占位窗口（OAuth quota / Admin providers / reset credits，docs/04/11，原则 3/5/7）**：写入、cache-only API 与 UI 三层过滤 0%/无时长/已重置的空 positional 窗口；明确 `windowMinutes >= 10080` 的账号周窗口优先，避免脏 secondary 覆盖真实周额度与 reset marker。
 - **2026-07-14 · Subscription Providers 改为缓存优先与全局串行刷新（OAuth Admin / provider observability，docs/04/11，原则 1/3/6/7）**：Providers 首屏与兼容读 API 严格 cache-only；显式刷新由进程级单 worker 串行账号、合并并发点击并保留 last-known-good 数据。
 - **2026-07-14 · Avoid Waste 在 provider 池内限制 reset-credit 偏置（OAuth provider selection，docs/04/11，原则 3/5/6）**：reset credits 只作为同一 provider 池内的弱恢复容量信号，不能压过明显更多的真实即将过期额度；套餐标签不参与分池或评分。
 - **2026-07-13 · Responses 工具结果的 multipart 文本使用 input_text（Protocol translation / provider execution，docs/05/07，原则 3/5/8）**：provider 与共享 transformer 统一把请求侧 multipart 工具结果文本编码为 `input_text`，保留字符串、图片、文件与助手输出的既有 wire shape。

--- a/packages/core/src/store/cleanup-stores.test.ts
+++ b/packages/core/src/store/cleanup-stores.test.ts
@@ -97,6 +97,14 @@ describe.each(drivers)("Cleanup store contract — $name", ({ open }) => {
     expect(await q.pruneMessagesOlderThan(2000)).toBe(1);
     // The recent row (t=3000) survives.
     expect(await q.countMessagesOlderThan(9999)).toBe(1);
+    if (!q.getMemoryAdminStats) throw new Error("missing getMemoryAdminStats");
+    const stats = await q.getMemoryAdminStats({
+      accountId: "a",
+      threadId: "t",
+      now: new Date(4000),
+    });
+    expect(stats.storage.messages).toBe(1);
+    expect(stats.activity.lastMessageAt?.getTime()).toBe(3000);
   });
 
   it("memory_messages: keyset paging covers every eligible row exactly once", async () => {

--- a/packages/core/src/store/postgres/dedup-memory-messages.test.ts
+++ b/packages/core/src/store/postgres/dedup-memory-messages.test.ts
@@ -15,7 +15,15 @@ async function seed(): Promise<PGlite> {
   const db = new PGlite();
   clients.push(db);
   await db.exec(`
-    CREATE TABLE memory_threads (id TEXT PRIMARY KEY, created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL);
+    CREATE TABLE memory_threads (
+      id TEXT PRIMARY KEY,
+      message_count INTEGER NOT NULL DEFAULT 0,
+      last_message_at BIGINT,
+      observation_count INTEGER NOT NULL DEFAULT 0,
+      last_observation_at BIGINT,
+      created_at BIGINT NOT NULL,
+      updated_at BIGINT NOT NULL
+    );
     CREATE TABLE memory_messages (
       id TEXT PRIMARY KEY,
       thread_id TEXT NOT NULL,
@@ -83,5 +91,28 @@ describe("dedupMemoryPg ops helper", () => {
     expect(obs.rows[0]?.c).toBe(0);
     const jobs = await db.query<{ id: string }>("SELECT id FROM memory_jobs ORDER BY id");
     expect(jobs.rows.map((r) => r.id)).toEqual(["j-pending"]);
+
+    const summary = await db.query<{
+      message_count: number;
+      last_message_at: number | null;
+      observation_count: number;
+      last_observation_at: number | null;
+    }>(
+      "SELECT message_count, last_message_at, observation_count, last_observation_at FROM memory_threads WHERE id='t1'",
+    );
+    expect(summary.rows[0]).toEqual({
+      message_count: 2,
+      last_message_at: 3,
+      observation_count: 0,
+      last_observation_at: null,
+    });
+
+    const second = await dedupMemoryPg(db, {});
+    expect(second.deletedDuplicates).toBe(0);
+    expect(second.wipedObservations).toBe(0);
+    const summaryAfterSecondRun = await db.query(
+      "SELECT message_count, last_message_at, observation_count, last_observation_at FROM memory_threads WHERE id='t1'",
+    );
+    expect(summaryAfterSecondRun.rows[0]).toEqual(summary.rows[0]);
   });
 });

--- a/packages/core/src/store/postgres/dedup-memory-messages.ts
+++ b/packages/core/src/store/postgres/dedup-memory-messages.ts
@@ -141,13 +141,39 @@ export async function dedupMemoryPg(
     }
   }
 
-  const wiped = await rows<{ id: string }>(db, "DELETE FROM memory_observations RETURNING id");
-  summary.wipedObservations = wiped.length;
-  const pruned = await rows<{ id: string }>(
+  // Wipe the invalid observations, prune terminal jobs, and repair the v38
+  // parent summaries in ONE statement. Besides being atomic, one statement is
+  // safe for the postgres-js CLI client without relying on connection affinity
+  // across separate BEGIN/COMMIT calls.
+  const finalized = await rows<{
+    wiped_observations: number | string;
+    pruned_jobs: number | string;
+  }>(
     db,
-    "DELETE FROM memory_jobs WHERE status IN ('done','failed') RETURNING id",
+    `WITH wiped AS (
+       DELETE FROM memory_observations RETURNING 1
+     ),
+     pruned AS (
+       DELETE FROM memory_jobs WHERE status IN ('done','failed') RETURNING 1
+     ),
+     repaired AS (
+       UPDATE memory_threads AS t
+          SET message_count = (
+                SELECT COUNT(*)::integer FROM memory_messages m WHERE m.thread_id = t.id
+              ),
+              last_message_at = (
+                SELECT MAX(m.created_at)::bigint FROM memory_messages m WHERE m.thread_id = t.id
+              ),
+              observation_count = 0,
+              last_observation_at = NULL
+        RETURNING 1
+     )
+     SELECT (SELECT COUNT(*) FROM wiped) AS wiped_observations,
+            (SELECT COUNT(*) FROM pruned) AS pruned_jobs,
+            (SELECT COUNT(*) FROM repaired) AS repaired_threads`,
   );
-  summary.prunedJobs = pruned.length;
+  summary.wipedObservations = firstNumber(finalized, "wiped_observations");
+  summary.prunedJobs = firstNumber(finalized, "pruned_jobs");
   log(
     `backfilled ${summary.backfilled} messages, deleted ${summary.deletedDuplicates} collision duplicates`,
   );

--- a/packages/core/src/store/postgres/memory-prune-concurrency.test.ts
+++ b/packages/core/src/store/postgres/memory-prune-concurrency.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { PgMemoryStore } from "./memory-store.js";
+import { createPgliteDb } from "./migrate.js";
+
+interface TraceablePgliteDb {
+  session: {
+    options: {
+      logger?: { logQuery(query: string, params: unknown[]): void };
+    };
+  };
+}
+
+// PGlite is an embedded, single-session PostgreSQL engine, so it cannot recreate
+// a two-connection READ COMMITTED snapshot race. The strongest deterministic
+// regression here executes the real prune transaction and records Drizzle's SQL:
+// the affected parent rows must be locked before either DELETE or summary repair.
+describe("PgMemoryStore prune summary serialization", () => {
+  it("locks affected parent rows before deleting and recomputing message summaries", async () => {
+    const db = await createPgliteDb();
+    try {
+      let seq = 0;
+      const store = new PgMemoryStore(
+        db,
+        () => `id-${++seq}`,
+        () => new Date(1_000),
+      );
+      await store.ensureThread({ id: "t", ownerId: "a" });
+      await store.appendMessage({
+        threadId: "t",
+        role: "user",
+        content: "old",
+        tokenEstimate: 1,
+      });
+
+      const statements: string[] = [];
+      const traceable = db as unknown as TraceablePgliteDb;
+      traceable.session.options.logger = {
+        logQuery(query) {
+          statements.push(query.replace(/\s+/g, " ").trim().toLowerCase());
+        },
+      };
+
+      expect(await store.pruneMessagesOlderThan(2_000)).toBe(1);
+
+      const lockAt = statements.findIndex(
+        (query) =>
+          query.includes("from memory_threads t") &&
+          query.includes("join _helm_pruned_message_threads") &&
+          query.includes("order by t.id") &&
+          query.includes("for update"),
+      );
+      const deleteAt = statements.findIndex((query) =>
+        query.includes("delete from memory_messages"),
+      );
+      const repairAt = statements.findIndex(
+        (query) => query.includes("update memory_threads as t") && query.includes("message_count"),
+      );
+
+      expect(lockAt).toBeGreaterThanOrEqual(0);
+      expect(deleteAt).toBeGreaterThan(lockAt);
+      expect(repairAt).toBeGreaterThan(deleteAt);
+    } finally {
+      await db.$close();
+    }
+  });
+});

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -324,29 +324,47 @@ export class PgMemoryStore implements MemoryStore {
 
   async appendMessage(input: MemoryMessageInput): Promise<string> {
     const id = this.genId();
+    const createdAt = this.now().getTime();
     // Idempotent ingest (pg v20 mirror of sqlite v21): a re-sent
     // (thread_id, message_index, role, content) collapses to a no-op via the
     // UNIQUE index while repeated text at a new transcript position persists.
-    await this.db
-      .insert(memoryMessages)
-      .values({
-        id,
-        threadId: input.threadId,
-        messageIndex: input.messageIndex ?? 0,
-        role: input.role,
-        content: input.content,
-        tokenEstimate: input.tokenEstimate,
-        createdAt: this.now().getTime(),
-        contentHash: sha256Hex(input.content),
-      })
-      .onConflictDoNothing({
-        target: [
-          memoryMessages.threadId,
-          memoryMessages.messageIndex,
-          memoryMessages.role,
-          memoryMessages.contentHash,
-        ],
-      });
+    await this.db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(memoryMessages)
+        .values({
+          id,
+          threadId: input.threadId,
+          messageIndex: input.messageIndex ?? 0,
+          role: input.role,
+          content: input.content,
+          tokenEstimate: input.tokenEstimate,
+          createdAt,
+          contentHash: sha256Hex(input.content),
+        })
+        .onConflictDoNothing({
+          target: [
+            memoryMessages.threadId,
+            memoryMessages.messageIndex,
+            memoryMessages.role,
+            memoryMessages.contentHash,
+          ],
+        })
+        .returning();
+      // RETURNING is empty on the dedup conflict, so the summary remains exact.
+      if (inserted.length > 0) {
+        await tx
+          .update(memoryThreads)
+          .set({
+            messageCount: sql`${memoryThreads.messageCount} + 1`,
+            lastMessageAt: sql`CASE
+              WHEN ${memoryThreads.lastMessageAt} IS NULL OR ${memoryThreads.lastMessageAt} < ${createdAt}
+                THEN ${createdAt}
+              ELSE ${memoryThreads.lastMessageAt}
+            END`,
+          })
+          .where(eq(memoryThreads.id, input.threadId));
+      }
+    });
     return id;
   }
 
@@ -401,17 +419,41 @@ export class PgMemoryStore implements MemoryStore {
     // but guarding the insert keeps it robust if the dedup ever changes to drop the
     // first row too. Cheaper than making every future editor re-prove the invariant.
     if (rows.length === 0) return ids;
-    await this.db
-      .insert(memoryMessages)
-      .values(rows)
-      .onConflictDoNothing({
-        target: [
-          memoryMessages.threadId,
-          memoryMessages.messageIndex,
-          memoryMessages.role,
-          memoryMessages.contentHash,
-        ],
-      });
+    await this.db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(memoryMessages)
+        .values(rows)
+        .onConflictDoNothing({
+          target: [
+            memoryMessages.threadId,
+            memoryMessages.messageIndex,
+            memoryMessages.role,
+            memoryMessages.contentHash,
+          ],
+        })
+        .returning();
+      const activity = new Map<string, { count: number; lastAt: number }>();
+      for (const row of inserted) {
+        const current = activity.get(row.threadId);
+        activity.set(row.threadId, {
+          count: (current?.count ?? 0) + 1,
+          lastAt: Math.max(current?.lastAt ?? row.createdAt, row.createdAt),
+        });
+      }
+      for (const [threadId, summary] of activity) {
+        await tx
+          .update(memoryThreads)
+          .set({
+            messageCount: sql`${memoryThreads.messageCount} + ${summary.count}`,
+            lastMessageAt: sql`CASE
+              WHEN ${memoryThreads.lastMessageAt} IS NULL OR ${memoryThreads.lastMessageAt} < ${summary.lastAt}
+                THEN ${summary.lastAt}
+              ELSE ${memoryThreads.lastMessageAt}
+            END`,
+          })
+          .where(eq(memoryThreads.id, threadId));
+      }
+    });
     return ids;
   }
 
@@ -443,18 +485,32 @@ export class PgMemoryStore implements MemoryStore {
 
   async appendObservation(input: MemoryObservationInput): Promise<string> {
     const id = this.genId();
-    await this.db.insert(memoryObservations).values({
-      id,
-      threadId: input.threadId,
-      sourceMessageRange: input.sourceMessageRange,
-      observationText: input.observationText,
-      observedAt: input.observedAt.getTime(),
-      referencedAt: null,
-      // docs/12 (P5) — persist the Observer-resolved salience; absent ⇒ column
-      // default 0.5 (pg mirror of the sqlite adapter).
-      ...(input.importance !== undefined ? { importance: input.importance } : {}),
-      priority: input.priority ?? null,
-      tags: input.tags ?? null,
+    const observedAt = input.observedAt.getTime();
+    await this.db.transaction(async (tx) => {
+      await tx.insert(memoryObservations).values({
+        id,
+        threadId: input.threadId,
+        sourceMessageRange: input.sourceMessageRange,
+        observationText: input.observationText,
+        observedAt,
+        referencedAt: null,
+        // docs/12 (P5) — persist the Observer-resolved salience; absent ⇒ column
+        // default 0.5 (pg mirror of the sqlite adapter).
+        ...(input.importance !== undefined ? { importance: input.importance } : {}),
+        priority: input.priority ?? null,
+        tags: input.tags ?? null,
+      });
+      await tx
+        .update(memoryThreads)
+        .set({
+          observationCount: sql`${memoryThreads.observationCount} + 1`,
+          lastObservationAt: sql`CASE
+            WHEN ${memoryThreads.lastObservationAt} IS NULL OR ${memoryThreads.lastObservationAt} < ${observedAt}
+              THEN ${observedAt}
+            ELSE ${memoryThreads.lastObservationAt}
+          END`,
+        })
+        .where(eq(memoryThreads.id, input.threadId));
     });
     return id;
   }
@@ -1217,48 +1273,37 @@ export class PgMemoryStore implements MemoryStore {
     const noScopeFilter =
       accountId === null && projectId === null && resourceId === null && threadId === null;
     const jobScopeClauses = pgMemoryJobScopeClauses(input);
-    const threads = pgRows<{ n: number | string }>(
+    // Aggregate the denormalized parent-row activity. This avoids scanning the
+    // body-heavy memory_messages/memory_observations tables on an admin read.
+    const threadActivity = pgRows<{
+      n: number | string;
+      messages: number | string;
+      observations: number | string;
+      lastMessageAt: number | string | null;
+      lastObservationAt: number | string | null;
+    }>(
       await this.db.execute(
         noScopeFilter
-          ? sql`SELECT COUNT(*)::bigint AS n FROM memory_threads`
+          ? sql`
+              SELECT COUNT(*)::bigint AS n,
+                     COALESCE(SUM(message_count), 0)::bigint AS messages,
+                     COALESCE(SUM(observation_count), 0)::bigint AS observations,
+                     MAX(last_message_at)::bigint AS "lastMessageAt",
+                     MAX(last_observation_at)::bigint AS "lastObservationAt"
+                FROM memory_threads
+            `
           : sql`
-              SELECT COUNT(*)::bigint AS n
+              SELECT COUNT(*)::bigint AS n,
+                     COALESCE(SUM(t.message_count), 0)::bigint AS messages,
+                     COALESCE(SUM(t.observation_count), 0)::bigint AS observations,
+                     MAX(t.last_message_at)::bigint AS "lastMessageAt",
+                     MAX(t.last_observation_at)::bigint AS "lastObservationAt"
                 FROM memory_threads t
                WHERE (${accountId}::text IS NULL OR t.owner_id = ${accountId})
                  AND (${projectId}::text IS NULL OR t.project_id = ${projectId})
                  AND (${resourceId}::text IS NULL OR t.resource_id = ${resourceId})
                  AND (${threadId}::text IS NULL OR t.id = ${threadId})
-            `,
-      ),
-    )[0];
-    const messages = pgRows<{ n: number | string; lastAt: number | string | null }>(
-      await this.db.execute(
-        noScopeFilter
-          ? sql`SELECT COUNT(*)::bigint AS n, MAX(created_at)::bigint AS "lastAt" FROM memory_messages`
-          : sql`
-              SELECT COUNT(*)::bigint AS n, MAX(m.created_at)::bigint AS "lastAt"
-                FROM memory_messages m
-                JOIN memory_threads t ON t.id = m.thread_id
-               WHERE (${accountId}::text IS NULL OR t.owner_id = ${accountId})
-                 AND (${projectId}::text IS NULL OR t.project_id = ${projectId})
-                 AND (${resourceId}::text IS NULL OR t.resource_id = ${resourceId})
-                 AND (${threadId}::text IS NULL OR t.id = ${threadId})
-            `,
-      ),
-    )[0];
-    const observations = pgRows<{ n: number | string; lastAt: number | string | null }>(
-      await this.db.execute(
-        noScopeFilter
-          ? sql`SELECT COUNT(*)::bigint AS n, MAX(observed_at)::bigint AS "lastAt" FROM memory_observations`
-          : sql`
-              SELECT COUNT(*)::bigint AS n, MAX(o.observed_at)::bigint AS "lastAt"
-                FROM memory_observations o
-                JOIN memory_threads t ON t.id = o.thread_id
-               WHERE (${accountId}::text IS NULL OR t.owner_id = ${accountId})
-                 AND (${projectId}::text IS NULL OR t.project_id = ${projectId})
-                 AND (${resourceId}::text IS NULL OR t.resource_id = ${resourceId})
-                 AND (${threadId}::text IS NULL OR t.id = ${threadId})
-            `,
+          `,
       ),
     )[0];
     const facts = pgRows<{
@@ -1371,9 +1416,9 @@ export class PgMemoryStore implements MemoryStore {
         ...(input.threadId !== undefined ? { threadId: input.threadId } : {}),
       },
       storage: {
-        threads: numberOf(threads?.n),
-        messages: numberOf(messages?.n),
-        observations: numberOf(observations?.n),
+        threads: numberOf(threadActivity?.n),
+        messages: numberOf(threadActivity?.messages),
+        observations: numberOf(threadActivity?.observations),
         facts: numberOf(facts?.n),
         activeFacts: numberOf(facts?.active),
         reflections: numberOf(reflections?.n),
@@ -1390,8 +1435,8 @@ export class PgMemoryStore implements MemoryStore {
         byType,
       },
       activity: {
-        lastMessageAt: dateOrNull(messages?.lastAt),
-        lastObservationAt: dateOrNull(observations?.lastAt),
+        lastMessageAt: dateOrNull(threadActivity?.lastMessageAt),
+        lastObservationAt: dateOrNull(threadActivity?.lastObservationAt),
         lastFactUpdatedAt: dateOrNull(facts?.lastAt),
         lastReflectionUpdatedAt: dateOrNull(reflections?.lastAt),
       },
@@ -1685,11 +1730,56 @@ export class PgMemoryStore implements MemoryStore {
   }
 
   async pruneMessagesOlderThan(olderThanMs: number): Promise<number> {
-    const rows = await this.db
-      .delete(memoryMessages)
-      .where(lt(memoryMessages.createdAt, olderThanMs))
-      .returning();
-    return rows.length;
+    return this.db.transaction(async (tx) => {
+      // A session-local key table keeps the repair set bounded to affected threads
+      // without returning every deleted body row through the JS driver.
+      await tx.execute(sql`
+        CREATE TEMP TABLE IF NOT EXISTS _helm_pruned_message_threads (
+          thread_id TEXT PRIMARY KEY
+        ) ON COMMIT DELETE ROWS
+      `);
+      await tx.execute(sql`DELETE FROM _helm_pruned_message_threads`);
+      await tx.execute(sql`
+        INSERT INTO _helm_pruned_message_threads (thread_id)
+        SELECT DISTINCT thread_id FROM memory_messages WHERE created_at < ${olderThanMs}
+        ON CONFLICT (thread_id) DO NOTHING
+      `);
+      // Serialize summary maintenance with appendMessage/appendMessages, whose
+      // counter increments lock the same parent rows. The deterministic order
+      // also keeps concurrent multi-thread cleanup passes from lock-order drift.
+      // This lock MUST precede DELETE: a blocked locker gets a fresh snapshot for
+      // the later delete/recompute statements after the appender commits.
+      await tx.execute(sql`
+        SELECT t.id
+          FROM memory_threads t
+          JOIN _helm_pruned_message_threads a ON a.thread_id = t.id
+         ORDER BY t.id
+           FOR UPDATE
+      `);
+      const deleted = pgRows<{ n: number | string }>(
+        await tx.execute(sql`
+          WITH deleted AS (
+            DELETE FROM memory_messages
+             WHERE created_at < ${olderThanMs}
+             RETURNING 1
+          )
+          SELECT COUNT(*)::bigint AS n FROM deleted
+        `),
+      )[0];
+      await tx.execute(sql`
+        UPDATE memory_threads AS t
+           SET message_count = (
+                 SELECT COUNT(*)::integer FROM memory_messages m WHERE m.thread_id = t.id
+               ),
+               last_message_at = (
+                 SELECT MAX(m.created_at)::bigint FROM memory_messages m WHERE m.thread_id = t.id
+               )
+         WHERE EXISTS (
+           SELECT 1 FROM _helm_pruned_message_threads a WHERE a.thread_id = t.id
+         )
+      `);
+      return numberOf(deleted?.n);
+    });
   }
 
   async pruneFinishedJobsOlderThan(olderThanMs: number): Promise<number> {

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -239,6 +239,103 @@ describe("runPgMigrations — per-migration atomicity", () => {
     await db.$close();
   });
 
+  it("v38 adds and backfills per-thread admin activity summaries", async () => {
+    const client = new PGlite();
+    const db = Object.assign(drizzlePglite(client), { $close: () => client.close() });
+    await db.execute(
+      sql.raw("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at BIGINT NOT NULL)"),
+    );
+    await db.execute(
+      sql.raw(`
+      CREATE TABLE memory_threads (
+        id TEXT PRIMARY KEY,
+        project_id TEXT,
+        resource_id TEXT,
+        owner_id TEXT,
+        last_served_model TEXT,
+        created_at BIGINT NOT NULL,
+        updated_at BIGINT NOT NULL
+      )
+    `),
+    );
+    await db.execute(
+      sql.raw(`
+      CREATE TABLE memory_messages (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
+        token_estimate INTEGER NOT NULL,
+        created_at BIGINT NOT NULL,
+        message_index INTEGER,
+        content_hash TEXT
+      )
+    `),
+    );
+    await db.execute(
+      sql.raw(`
+      CREATE TABLE memory_observations (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL,
+        source_message_range JSONB NOT NULL,
+        observation_text TEXT NOT NULL,
+        observed_at BIGINT NOT NULL
+      )
+    `),
+    );
+    await db.execute(
+      sql.raw(`
+      INSERT INTO memory_threads (id, owner_id, created_at, updated_at)
+      VALUES ('t1', 'a', 100, 100), ('empty', 'a', 100, 100)
+    `),
+    );
+    await db.execute(
+      sql.raw(`
+      INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at)
+      VALUES ('m1', 't1', 'user', 'one', 1, 1000),
+             ('m2', 't1', 'assistant', 'two', 1, 2000)
+    `),
+    );
+    await db.execute(
+      sql.raw(`
+      INSERT INTO memory_observations
+        (id, thread_id, source_message_range, observation_text, observed_at)
+      VALUES ('o1', 't1', '["m1","m2"]'::jsonb, 'summary', 3000)
+    `),
+    );
+    for (let version = 1; version <= 37; version++) {
+      await db.execute(
+        sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
+      );
+    }
+
+    await expect(runPgMigrations(db)).resolves.toBeUndefined();
+
+    const result = (await db.execute(
+      sql.raw(`
+      SELECT id, message_count, last_message_at, observation_count, last_observation_at
+      FROM memory_threads ORDER BY id
+    `),
+    )) as { rows: Array<Record<string, unknown>> };
+    expect(result.rows).toEqual([
+      {
+        id: "empty",
+        message_count: 0,
+        last_message_at: null,
+        observation_count: 0,
+        last_observation_at: null,
+      },
+      {
+        id: "t1",
+        message_count: 2,
+        last_message_at: 2000,
+        observation_count: 1,
+        last_observation_at: 3000,
+      },
+    ]);
+    await db.$close();
+  });
+
   it("creates memory job admin-stats indexes", async () => {
     const db = await createPgliteDb();
     const indexes = (await db.execute(

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -790,6 +790,63 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // pg mirror of SQLite v39: keep the admin memory activity aggregates on the
+    // scoped parent row. The GROUP BY backfills are one-time ordered index scans;
+    // future insert/prune paths maintain the columns transactionally.
+    version: 38,
+    run: async (db) => {
+      // Several narrow migration tests intentionally seed only one legacy table.
+      // A missing memory subsystem is out of scope for this additive migration.
+      if (!(await pgTableHasColumns(db, "memory_threads", ["id"]))) return;
+      await db.execute(
+        sql.raw(
+          "ALTER TABLE memory_threads ADD COLUMN IF NOT EXISTS message_count INTEGER NOT NULL DEFAULT 0",
+        ),
+      );
+      await db.execute(
+        sql.raw("ALTER TABLE memory_threads ADD COLUMN IF NOT EXISTS last_message_at BIGINT"),
+      );
+      await db.execute(
+        sql.raw(
+          "ALTER TABLE memory_threads ADD COLUMN IF NOT EXISTS observation_count INTEGER NOT NULL DEFAULT 0",
+        ),
+      );
+      await db.execute(
+        sql.raw("ALTER TABLE memory_threads ADD COLUMN IF NOT EXISTS last_observation_at BIGINT"),
+      );
+      if (await pgTableHasColumns(db, "memory_messages", ["thread_id", "created_at"])) {
+        await db.execute(
+          sql.raw(`
+            UPDATE memory_threads AS t
+               SET message_count = activity.n,
+                   last_message_at = activity.last_at
+              FROM (
+                SELECT thread_id, COUNT(*)::integer AS n, MAX(created_at)::bigint AS last_at
+                  FROM memory_messages
+                 GROUP BY thread_id
+              ) AS activity
+             WHERE t.id = activity.thread_id
+          `),
+        );
+      }
+      if (await pgTableHasColumns(db, "memory_observations", ["thread_id", "observed_at"])) {
+        await db.execute(
+          sql.raw(`
+            UPDATE memory_threads AS t
+               SET observation_count = activity.n,
+                   last_observation_at = activity.last_at
+              FROM (
+                SELECT thread_id, COUNT(*)::integer AS n, MAX(observed_at)::bigint AS last_at
+                  FROM memory_observations
+                 GROUP BY thread_id
+              ) AS activity
+             WHERE t.id = activity.thread_id
+          `),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {
@@ -800,7 +857,13 @@ function resultRows<T>(result: unknown): T[] {
 
 async function pgTableHasColumns(
   db: RawExecutor,
-  table: "api_keys" | "memory_threads" | "memory_messages" | "memory_jobs" | "oauth_quota",
+  table:
+    | "api_keys"
+    | "memory_threads"
+    | "memory_messages"
+    | "memory_observations"
+    | "memory_jobs"
+    | "oauth_quota",
   requiredColumns: readonly string[],
 ): Promise<boolean> {
   const rows = resultRows<{ column_name: string }>(

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -154,6 +154,12 @@ export const memoryThreads = pgTable("memory_threads", {
   // best-effort by observeOutbound; read by the background observer to price
   // the auto-compaction ledger. NULL = never stamped.
   lastServedModel: text("last_served_model"),
+  // Denormalized admin activity (pg v38, SQLite v39 mirror). Admin stats aggregate
+  // these narrow parent-row fields instead of scanning body-heavy child tables.
+  messageCount: integer("message_count").notNull().default(0),
+  lastMessageAt: bigint("last_message_at", { mode: "number" }),
+  observationCount: integer("observation_count").notNull().default(0),
+  lastObservationAt: bigint("last_observation_at", { mode: "number" }),
   createdAt: bigint("created_at", { mode: "number" }).notNull(),
   updatedAt: bigint("updated_at", { mode: "number" }).notNull(),
 });

--- a/packages/core/src/store/sqlite/dedup-memory-messages.test.ts
+++ b/packages/core/src/store/sqlite/dedup-memory-messages.test.ts
@@ -92,7 +92,39 @@ describe("dedupMemory ops script", () => {
       expect(out.prunedJobs).toBe(1);
       const jobs = s.prepare("SELECT id FROM memory_jobs").all() as Array<{ id: string }>;
       expect(jobs.map((j) => j.id)).toEqual(["j-pending"]);
+      expect(
+        s
+          .prepare(
+            `SELECT message_count, last_message_at, observation_count, last_observation_at
+               FROM memory_threads WHERE id = 't1'`,
+          )
+          .get(),
+      ).toEqual({
+        message_count: 2,
+        last_message_at: 3,
+        observation_count: 0,
+        last_observation_at: null,
+      });
       expect(out.vacuumed).toBe(true);
+
+      // Re-running maintenance must preserve the repaired summaries without
+      // relying on the already-recorded schema migration to backfill again.
+      const second = dedupMemory(s, {});
+      expect(second.deletedDuplicates).toBe(0);
+      expect(second.wipedObservations).toBe(0);
+      expect(
+        s
+          .prepare(
+            `SELECT message_count, last_message_at, observation_count, last_observation_at
+               FROM memory_threads WHERE id = 't1'`,
+          )
+          .get(),
+      ).toEqual({
+        message_count: 2,
+        last_message_at: 3,
+        observation_count: 0,
+        last_observation_at: null,
+      });
     } finally {
       s.close();
     }

--- a/packages/core/src/store/sqlite/dedup-memory-messages.ts
+++ b/packages/core/src/store/sqlite/dedup-memory-messages.ts
@@ -120,14 +120,28 @@ export function dedupMemory(db: Database.Database, opts: DedupOptions = {}): Ded
     `backfilled ${summary.backfilled} messages, deleted ${summary.deletedDuplicates} collision duplicates`,
   );
 
-  // 3. Observations were built from duplicate-laden data — let the observer rebuild.
-  summary.wipedObservations = db.prepare("DELETE FROM memory_observations").run().changes;
+  // 3+4. Observations were built from duplicate-laden data, terminal jobs are
+  // pure history, and v39's parent summaries must describe the post-maintenance
+  // child rows. Keep all three changes atomic so an already-recorded migration
+  // never leaves the Admin stats permanently stale after this command runs.
+  db.transaction(() => {
+    summary.wipedObservations = db.prepare("DELETE FROM memory_observations").run().changes;
+    summary.prunedJobs = db
+      .prepare("DELETE FROM memory_jobs WHERE status IN ('done','failed')")
+      .run().changes;
+    db.exec(`
+      UPDATE memory_threads AS t
+         SET message_count = (
+               SELECT COUNT(*) FROM memory_messages m WHERE m.thread_id = t.id
+             ),
+             last_message_at = (
+               SELECT MAX(m.created_at) FROM memory_messages m WHERE m.thread_id = t.id
+             ),
+             observation_count = 0,
+             last_observation_at = NULL;
+    `);
+  })();
   log(`wiped ${summary.wipedObservations} observations (observer will rebuild)`);
-
-  // 4. Terminal jobs are pure history; drop them.
-  summary.prunedJobs = db
-    .prepare("DELETE FROM memory_jobs WHERE status IN ('done','failed')")
-    .run().changes;
   log(`pruned ${summary.prunedJobs} terminal jobs`);
 
   // 5. Reclaim space. VACUUM cannot run inside a transaction; it takes an

--- a/packages/core/src/store/sqlite/memory-admin.test.ts
+++ b/packages/core/src/store/sqlite/memory-admin.test.ts
@@ -217,6 +217,87 @@ describe("SqliteMemoryStore.getMemoryAdminStats (docs/13)", () => {
     expect(stats.activity.lastMessageAt).toBeInstanceOf(Date);
     expect(stats.activity.lastObservationAt).toBeInstanceOf(Date);
   });
+
+  it("maintains denormalized thread activity across inserts and dedup conflicts", async () => {
+    let nowMs = 1_000;
+    const db = createSqliteDb(":memory:");
+    let seq = 0;
+    const store = new SqliteMemoryStore(
+      db,
+      () => `activity-${++seq}`,
+      () => new Date(nowMs),
+    );
+    await store.ensureThread({ id: "t1", ownerId: "a", projectId: "p1" });
+    await store.appendMessage({
+      threadId: "t1",
+      messageIndex: 0,
+      role: "user",
+      content: "same",
+      tokenEstimate: 1,
+    });
+    nowMs = 2_000;
+    await store.appendMessage({
+      threadId: "t1",
+      messageIndex: 0,
+      role: "user",
+      content: "same",
+      tokenEstimate: 1,
+    });
+    nowMs = 3_000;
+    await store.appendMessages([
+      { threadId: "t1", messageIndex: 0, role: "user", content: "same", tokenEstimate: 1 },
+      { threadId: "t1", messageIndex: 1, role: "assistant", content: "new", tokenEstimate: 1 },
+    ]);
+    await store.appendObservation({
+      threadId: "t1",
+      sourceMessageRange: ["activity-1", "activity-4"],
+      observationText: "summary",
+      observedAt: new Date(4_000),
+    });
+
+    const thread = db.$sqlite
+      .prepare(
+        `SELECT message_count, last_message_at, observation_count, last_observation_at
+           FROM memory_threads WHERE id = ?`,
+      )
+      .get("t1") as {
+      message_count: number;
+      last_message_at: number | null;
+      observation_count: number;
+      last_observation_at: number | null;
+    };
+    expect(thread).toEqual({
+      message_count: 2,
+      last_message_at: 3_001,
+      observation_count: 1,
+      last_observation_at: 4_000,
+    });
+    const stats = await store.getMemoryAdminStats({ accountId: "a", projectId: "p1", now: NOW });
+    expect(stats.storage).toMatchObject({ messages: 2, observations: 1 });
+    expect(stats.activity.lastMessageAt?.getTime()).toBe(3_001);
+    expect(stats.activity.lastObservationAt?.getTime()).toBe(4_000);
+    db.$sqlite.close();
+  });
+
+  it("uses only memory_threads for raw activity counts", () => {
+    const { db } = newStore(NOW);
+    const plan = db.$sqlite
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT COUNT(*) AS n,
+                COALESCE(SUM(message_count), 0) AS messages,
+                COALESCE(SUM(observation_count), 0) AS observations,
+                MAX(last_message_at) AS lastMessageAt,
+                MAX(last_observation_at) AS lastObservationAt
+           FROM memory_threads`,
+      )
+      .all() as Array<{ detail: string }>;
+    const detail = plan.map((row) => row.detail).join("\n");
+    expect(detail).toContain("memory_threads");
+    expect(detail).not.toContain("memory_messages");
+    expect(detail).not.toContain("memory_observations");
+    db.$sqlite.close();
+  });
 });
 
 describe("SqliteMemoryStore fact reads (docs/13)", () => {

--- a/packages/core/src/store/sqlite/memory-schema.ts
+++ b/packages/core/src/store/sqlite/memory-schema.ts
@@ -17,6 +17,15 @@ export const memoryThreads = sqliteTable("memory_threads", {
   // best-effort by observeOutbound AFTER execution; the background observer
   // reads it to price the auto-compaction ledger. NULL = never stamped.
   lastServedModel: text("last_served_model"),
+  // Denormalized admin activity (v39). getMemoryAdminStats used to COUNT/MAX the
+  // raw message and observation tables on every cold page load. Those tables can
+  // hold millions of body rows, and better-sqlite3 blocks Node while scanning.
+  // Keep the small per-thread summary on the parent row instead; insert/prune
+  // paths update it transactionally and the migration backfills existing data.
+  messageCount: integer("message_count").notNull().default(0),
+  lastMessageAt: integer("last_message_at", { mode: "timestamp_ms" }),
+  observationCount: integer("observation_count").notNull().default(0),
+  lastObservationAt: integer("last_observation_at", { mode: "timestamp_ms" }),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
 });

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -336,32 +336,53 @@ export class SqliteMemoryStore implements MemoryStore {
       .run();
   }
 
+  private bumpThreadMessageActivity(threadId: string, count: number, lastAt: number): void {
+    this.db.$sqlite
+      .prepare(
+        `UPDATE memory_threads
+            SET message_count = message_count + ?,
+                last_message_at = CASE
+                  WHEN last_message_at IS NULL OR last_message_at < ? THEN ?
+                  ELSE last_message_at
+                END
+          WHERE id = ?`,
+      )
+      .run(count, lastAt, lastAt, threadId);
+  }
+
   async appendMessage(input: MemoryMessageInput): Promise<string> {
     const id = this.genId();
+    const createdAt = this.now();
     // Idempotent ingest: a re-sent (thread_id, role, content) collapses to a
     // no-op via the v21 UNIQUE index (re-ingestion fix). Returned id is still
     // generated per call; on conflict it is inert (the row was left untouched).
-    this.db
-      .insert(memoryMessages)
-      .values({
-        id,
-        threadId: input.threadId,
-        messageIndex: input.messageIndex ?? 0,
-        role: input.role,
-        content: input.content,
-        tokenEstimate: input.tokenEstimate,
-        createdAt: this.now(),
-        contentHash: sha256Hex(input.content),
-      })
-      .onConflictDoNothing({
-        target: [
-          memoryMessages.threadId,
-          memoryMessages.messageIndex,
-          memoryMessages.role,
-          memoryMessages.contentHash,
-        ],
-      })
-      .run();
+    this.db.$sqlite.transaction(() => {
+      const inserted = this.db
+        .insert(memoryMessages)
+        .values({
+          id,
+          threadId: input.threadId,
+          messageIndex: input.messageIndex ?? 0,
+          role: input.role,
+          content: input.content,
+          tokenEstimate: input.tokenEstimate,
+          createdAt,
+          contentHash: sha256Hex(input.content),
+        })
+        .onConflictDoNothing({
+          target: [
+            memoryMessages.threadId,
+            memoryMessages.messageIndex,
+            memoryMessages.role,
+            memoryMessages.contentHash,
+          ],
+        })
+        .run();
+      // A dedup conflict has changes=0 and must not inflate the summary.
+      if (inserted.changes > 0) {
+        this.bumpThreadMessageActivity(input.threadId, 1, createdAt.getTime());
+      }
+    })();
     return id;
   }
 
@@ -375,10 +396,11 @@ export class SqliteMemoryStore implements MemoryStore {
     const base = this.now().getTime();
     const ids: string[] = [];
     const run = this.db.$sqlite.transaction(() => {
+      const activity = new Map<string, { count: number; lastAt: number }>();
       inputs.forEach((input, i) => {
         const id = this.genId();
         ids.push(id);
-        this.db
+        const inserted = this.db
           .insert(memoryMessages)
           .values({
             id,
@@ -399,7 +421,19 @@ export class SqliteMemoryStore implements MemoryStore {
             ],
           })
           .run();
+        if (inserted.changes > 0) {
+          const createdAt = base + i;
+          const current = activity.get(input.threadId);
+          activity.set(input.threadId, {
+            count: (current?.count ?? 0) + 1,
+            lastAt: Math.max(current?.lastAt ?? createdAt, createdAt),
+          });
+        }
       });
+      // One parent update per touched thread, not one per message in the turn.
+      for (const [threadId, summary] of activity) {
+        this.bumpThreadMessageActivity(threadId, summary.count, summary.lastAt);
+      }
     });
     run();
     return ids;
@@ -439,22 +473,35 @@ export class SqliteMemoryStore implements MemoryStore {
   // here so core/ports stay DB-agnostic.
   async appendObservation(input: MemoryObservationInput): Promise<string> {
     const id = this.genId();
-    this.db
-      .insert(memoryObservations)
-      .values({
-        id,
-        threadId: input.threadId,
-        sourceMessageRange: JSON.stringify(input.sourceMessageRange),
-        observationText: input.observationText,
-        observedAt: input.observedAt,
-        referencedAt: null,
-        // docs/12 (P5) — persist the Observer-resolved salience; absent ⇒ 0.5 so
-        // the column default and an explicit default agree (legacy/no-salience path).
-        ...(input.importance !== undefined ? { importance: input.importance } : {}),
-        priority: input.priority ?? null,
-        tags: input.tags !== undefined ? JSON.stringify(input.tags) : null,
-      })
-      .run();
+    this.db.$sqlite.transaction(() => {
+      this.db
+        .insert(memoryObservations)
+        .values({
+          id,
+          threadId: input.threadId,
+          sourceMessageRange: JSON.stringify(input.sourceMessageRange),
+          observationText: input.observationText,
+          observedAt: input.observedAt,
+          referencedAt: null,
+          // docs/12 (P5) — persist the Observer-resolved salience; absent ⇒ 0.5 so
+          // the column default and an explicit default agree (legacy/no-salience path).
+          ...(input.importance !== undefined ? { importance: input.importance } : {}),
+          priority: input.priority ?? null,
+          tags: input.tags !== undefined ? JSON.stringify(input.tags) : null,
+        })
+        .run();
+      this.db.$sqlite
+        .prepare(
+          `UPDATE memory_threads
+              SET observation_count = observation_count + 1,
+                  last_observation_at = CASE
+                    WHEN last_observation_at IS NULL OR last_observation_at < ? THEN ?
+                    ELSE last_observation_at
+                  END
+            WHERE id = ?`,
+        )
+        .run(input.observedAt.getTime(), input.observedAt.getTime(), input.threadId);
+    })();
     return id;
   }
 
@@ -1190,43 +1237,41 @@ export class SqliteMemoryStore implements MemoryStore {
       AND (? IS NULL OR thread_id = ?)
     `;
     const jobScope = sqliteMemoryJobScope(input);
-    const threads = (
-      noScopeFilter
-        ? this.db.$sqlite.prepare("SELECT COUNT(*) AS n FROM memory_threads").get()
-        : this.db.$sqlite
-            .prepare(`SELECT COUNT(*) AS n FROM memory_threads t WHERE ${threadWhere}`)
-            .get(...threadArgs)
-    ) as { n: number } | undefined;
-    const messages = (
+    // Raw message/observation bodies live in child tables that grow into millions
+    // of rows. Their count/latest activity is maintained on memory_threads, so this
+    // one narrow parent aggregation replaces the former three synchronous scans.
+    const threadActivity = (
       noScopeFilter
         ? this.db.$sqlite
-            .prepare("SELECT COUNT(*) AS n, MAX(created_at) AS lastAt FROM memory_messages")
+            .prepare(
+              `SELECT COUNT(*) AS n,
+                      COALESCE(SUM(message_count), 0) AS messages,
+                      COALESCE(SUM(observation_count), 0) AS observations,
+                      MAX(last_message_at) AS lastMessageAt,
+                      MAX(last_observation_at) AS lastObservationAt
+                 FROM memory_threads`,
+            )
             .get()
         : this.db.$sqlite
             .prepare(
-              `SELECT COUNT(*) AS n, MAX(m.created_at) AS lastAt
-          FROM memory_messages m
-           JOIN memory_threads t ON t.id = m.thread_id
-          WHERE ${threadWhere}
-        `,
+              `SELECT COUNT(*) AS n,
+                      COALESCE(SUM(t.message_count), 0) AS messages,
+                      COALESCE(SUM(t.observation_count), 0) AS observations,
+                      MAX(t.last_message_at) AS lastMessageAt,
+                      MAX(t.last_observation_at) AS lastObservationAt
+                 FROM memory_threads t
+                WHERE ${threadWhere}`,
             )
             .get(...threadArgs)
-    ) as { n: number; lastAt: number | null } | undefined;
-    const observations = (
-      noScopeFilter
-        ? this.db.$sqlite
-            .prepare("SELECT COUNT(*) AS n, MAX(observed_at) AS lastAt FROM memory_observations")
-            .get()
-        : this.db.$sqlite
-            .prepare(
-              `SELECT COUNT(*) AS n, MAX(o.observed_at) AS lastAt
-          FROM memory_observations o
-           JOIN memory_threads t ON t.id = o.thread_id
-          WHERE ${threadWhere}
-        `,
-            )
-            .get(...threadArgs)
-    ) as { n: number; lastAt: number | null } | undefined;
+    ) as
+      | {
+          n: number;
+          messages: number;
+          observations: number;
+          lastMessageAt: number | null;
+          lastObservationAt: number | null;
+        }
+      | undefined;
     const facts = (
       noScopeFilter
         ? this.db.$sqlite
@@ -1328,9 +1373,9 @@ export class SqliteMemoryStore implements MemoryStore {
         ...(input.threadId !== undefined ? { threadId: input.threadId } : {}),
       },
       storage: {
-        threads: countOf(threads),
-        messages: countOf(messages),
-        observations: countOf(observations),
+        threads: countOf(threadActivity),
+        messages: threadActivity?.messages ?? 0,
+        observations: threadActivity?.observations ?? 0,
         facts: countOf(facts),
         activeFacts: facts?.active ?? 0,
         reflections: countOf(reflections),
@@ -1347,8 +1392,8 @@ export class SqliteMemoryStore implements MemoryStore {
         byType,
       },
       activity: {
-        lastMessageAt: dateOrNull(messages?.lastAt),
-        lastObservationAt: dateOrNull(observations?.lastAt),
+        lastMessageAt: dateOrNull(threadActivity?.lastMessageAt),
+        lastObservationAt: dateOrNull(threadActivity?.lastObservationAt),
         lastFactUpdatedAt: dateOrNull(facts?.lastAt),
         lastReflectionUpdatedAt: dateOrNull(reflections?.lastAt),
       },
@@ -1919,11 +1964,39 @@ export class SqliteMemoryStore implements MemoryStore {
   }
 
   async pruneMessagesOlderThan(olderThanMs: number): Promise<number> {
-    const res = this.db
-      .delete(memoryMessages)
-      .where(lt(memoryMessages.createdAt, new Date(olderThanMs)))
-      .run();
-    return res.changes;
+    // Keep the summary exact in the SAME transaction. A TEMP key table avoids
+    // returning every deleted body row to JS and lets one set-based UPDATE repair
+    // only affected threads after the delete (including the new MAX timestamp).
+    return this.db.$sqlite.transaction(() => {
+      this.db.$sqlite.exec(`
+        CREATE TEMP TABLE IF NOT EXISTS _helm_pruned_message_threads (
+          thread_id TEXT PRIMARY KEY
+        ) WITHOUT ROWID;
+        DELETE FROM _helm_pruned_message_threads;
+      `);
+      this.db.$sqlite
+        .prepare(
+          `INSERT OR IGNORE INTO _helm_pruned_message_threads (thread_id)
+           SELECT thread_id FROM memory_messages WHERE created_at < ?`,
+        )
+        .run(olderThanMs);
+      const res = this.db
+        .delete(memoryMessages)
+        .where(lt(memoryMessages.createdAt, new Date(olderThanMs)))
+        .run();
+      this.db.$sqlite.exec(`
+        UPDATE memory_threads AS t
+           SET message_count = (
+                 SELECT COUNT(*) FROM memory_messages m WHERE m.thread_id = t.id
+               ),
+               last_message_at = (
+                 SELECT MAX(m.created_at) FROM memory_messages m WHERE m.thread_id = t.id
+               )
+         WHERE t.id IN (SELECT thread_id FROM _helm_pruned_message_threads);
+        DELETE FROM _helm_pruned_message_threads;
+      `);
+      return res.changes;
+    })();
   }
 
   async pruneFinishedJobsOlderThan(olderThanMs: number): Promise<number> {

--- a/packages/core/src/store/sqlite/migrate.pragmas.test.ts
+++ b/packages/core/src/store/sqlite/migrate.pragmas.test.ts
@@ -20,8 +20,9 @@ describe("sqlite connection pragmas", () => {
       expect(raw.pragma("busy_timeout", { simple: true })).toBe(5000);
       // temp_store: 0=DEFAULT, 1=FILE, 2=MEMORY. We want MEMORY.
       expect(raw.pragma("temp_store", { simple: true })).toBe(2);
-      // cache_size negative => KiB. ~16MB headroom for the hot tables.
-      expect(raw.pragma("cache_size", { simple: true })).toBe(-16000);
+      // cache_size negative => KiB. 64 MiB keeps the hot admin indexes resident
+      // without putting meaningful pressure on a small self-hosted machine.
+      expect(raw.pragma("cache_size", { simple: true })).toBe(-65536);
     } finally {
       db.$sqlite.close();
     }

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -891,6 +891,68 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Admin memory-stats hot path. Counting/MAXing memory_messages (1M+ rows in
+    // production) synchronously blocked the Node event loop for seconds. Promote
+    // those four aggregate inputs to memory_threads, which is both much smaller
+    // and already carries the exact account/project/resource/thread scope.
+    //
+    // Backfill each child table with ONE ordered covering-index scan and update
+    // only threads that actually have children. SQLite ADD COLUMN with a constant
+    // default is metadata-only, so empty threads cost no rewrite. The migration is
+    // one-time and atomic; steady-state inserts/prunes maintain the fields.
+    version: 39,
+    run: (db) => {
+      if (!sqliteTableHasColumns(db, "memory_threads", ["id"])) return;
+      const columns = new Set(
+        (db.prepare("PRAGMA table_info(memory_threads)").all() as Array<{ name: string }>).map(
+          (column) => column.name,
+        ),
+      );
+      if (!columns.has("message_count")) {
+        db.exec("ALTER TABLE memory_threads ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0");
+      }
+      if (!columns.has("last_message_at")) {
+        db.exec("ALTER TABLE memory_threads ADD COLUMN last_message_at INTEGER");
+      }
+      if (!columns.has("observation_count")) {
+        db.exec(
+          "ALTER TABLE memory_threads ADD COLUMN observation_count INTEGER NOT NULL DEFAULT 0",
+        );
+      }
+      if (!columns.has("last_observation_at")) {
+        db.exec("ALTER TABLE memory_threads ADD COLUMN last_observation_at INTEGER");
+      }
+      if (sqliteTableHasColumns(db, "memory_messages", ["thread_id", "created_at"])) {
+        db.exec(`
+          WITH activity AS (
+            SELECT thread_id, COUNT(*) AS n, MAX(created_at) AS last_at
+              FROM memory_messages
+             GROUP BY thread_id
+          )
+          UPDATE memory_threads AS t
+             SET message_count = activity.n,
+                 last_message_at = activity.last_at
+            FROM activity
+           WHERE t.id = activity.thread_id;
+        `);
+      }
+      if (sqliteTableHasColumns(db, "memory_observations", ["thread_id", "observed_at"])) {
+        db.exec(`
+          WITH activity AS (
+            SELECT thread_id, COUNT(*) AS n, MAX(observed_at) AS last_at
+              FROM memory_observations
+             GROUP BY thread_id
+          )
+          UPDATE memory_threads AS t
+             SET observation_count = activity.n,
+                 last_observation_at = activity.last_at
+            FROM activity
+           WHERE t.id = activity.thread_id;
+        `);
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(
@@ -944,13 +1006,15 @@ function applyMigrations(db: Database.Database): void {
 //                        instantly (defensive: migrations + the runtime handle can
 //                        briefly contend the same file).
 //   - temp_store=MEMORY  keep transient B-trees/sorts in RAM, off the disk path.
-//   - cache_size=-16000  ~16MB page cache (negative => KiB) for the hot tables.
+//   - cache_size=-65536  64MiB page cache (negative => KiB) for hot indexes. This
+//                        remains conservative on the supported small self-hosted
+//                        machines while avoiding needless cold-page churn.
 function applyPragmas(sqlite: Database.Database): void {
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("synchronous = NORMAL");
   sqlite.pragma("busy_timeout = 5000");
   sqlite.pragma("temp_store = MEMORY");
-  sqlite.pragma("cache_size = -16000");
+  sqlite.pragma("cache_size = -65536");
 }
 
 // docs/14 — load the sqlite-vec extension on a connection so the vec0 virtual table

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -183,6 +183,87 @@ describe("sqlite schema + migrations", () => {
     raw.close();
   });
 
+  it("v39 adds and backfills per-thread admin activity summaries", () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v39-memory-activity-"));
+    const path = join(dir, "helm.db");
+    try {
+      const seed = new Database(path);
+      seed.exec(
+        "CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);",
+      );
+      seed.exec(`
+        CREATE TABLE memory_threads (
+          id TEXT PRIMARY KEY,
+          project_id TEXT,
+          resource_id TEXT,
+          owner_id TEXT,
+          last_served_model TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        CREATE TABLE memory_messages (
+          id TEXT PRIMARY KEY,
+          thread_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          content TEXT NOT NULL,
+          token_estimate INTEGER NOT NULL,
+          created_at INTEGER NOT NULL,
+          message_index INTEGER,
+          content_hash TEXT
+        );
+        CREATE INDEX idx_memory_messages_thread ON memory_messages (thread_id, created_at);
+        CREATE TABLE memory_observations (
+          id TEXT PRIMARY KEY,
+          thread_id TEXT NOT NULL,
+          source_message_range TEXT NOT NULL,
+          observation_text TEXT NOT NULL,
+          observed_at INTEGER NOT NULL
+        );
+        CREATE INDEX idx_memory_observations_thread ON memory_observations (thread_id, observed_at);
+        INSERT INTO memory_threads (id, owner_id, created_at, updated_at)
+          VALUES ('t1', 'a', 100, 100), ('empty', 'a', 100, 100);
+        INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at)
+          VALUES ('m1', 't1', 'user', 'one', 1, 1000),
+                 ('m2', 't1', 'assistant', 'two', 1, 2000);
+        INSERT INTO memory_observations
+          (id, thread_id, source_message_range, observation_text, observed_at)
+          VALUES ('o1', 't1', '["m1","m2"]', 'summary', 3000);
+      `);
+      const rec = seed.prepare("INSERT INTO _migrations (version, applied_at) VALUES (?, ?)");
+      for (let version = 1; version <= 38; version++) rec.run(version, 1000);
+      seed.close();
+
+      runMigrations(path);
+
+      const after = new Database(path);
+      const rows = after
+        .prepare(
+          `SELECT id, message_count, last_message_at, observation_count, last_observation_at
+             FROM memory_threads ORDER BY id`,
+        )
+        .all();
+      expect(rows).toEqual([
+        {
+          id: "empty",
+          message_count: 0,
+          last_message_at: null,
+          observation_count: 0,
+          last_observation_at: null,
+        },
+        {
+          id: "t1",
+          message_count: 2,
+          last_message_at: 2000,
+          observation_count: 1,
+          last_observation_at: 3000,
+        },
+      ]);
+      after.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("v32 backfills telemetry latency and creates admin aggregate indexes", () => {
     const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v32-"));
     const path = join(dir, "helm.db");


### PR DESCRIPTION
## Summary
- stop hover-only navigation from issuing speculative Admin API data reads
- parallelize independent dashboard and key-detail requests and pause hidden-tab refreshes
- denormalize memory activity onto thread rows for SQLite and Postgres
- add single-flight stale-while-revalidate caches for stats and per-key usage
- increase the SQLite page cache from 16 MiB to 64 MiB
- keep prune and memory dedup maintenance summaries transactionally consistent

## Production evidence
- cold memory stats reproduced at 10.2 seconds on la.atmy.work
- production currently has about 1.39 million memory messages and a 58.8 GB SQLite database
- frontend hover preloading amplified the cold synchronous SQLite scans

## Verification
- CI=true focused Vitest: 14 files, 185 tests
- Core build passed
- Admin svelte-check passed with 0 errors and 0 warnings
- Gateway typecheck passed
- Biome, Prettier, and git diff checks passed

## Deployment note
SQLite v39 and Postgres v38 perform a one-time atomic set-based backfill. The production rollout should monitor startup, WAL, free disk, and watchdog bad_s. Do not run VACUUM or a full database copy during deployment.