### PR TITLE
chore(release): v0.27.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.15",
+  "version": "0.27.16",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release assessment
Patch release for the backward-compatible Admin cold-read performance and correctness fix merged in PR #578.

## Change
- bump root package version from 0.27.15 to 0.27.16
- no other files changed

## Release gate
Wait for verify, e2e, and docker before merge. After merge, deploy only after the Publish image workflow succeeds for the exact release merge SHA.