### PR TITLE
chore(release): v0.27.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.16",
+  "version": "0.27.17",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump root package version from 0.27.16 to 0.27.17
- publish the xAI OAuth grok-build parity fixes merged in PR #580

## Scope
- version-only change
- no runtime or configuration edits in this PR

## Release gate
- merge only after all required CI checks pass
- wait for the exact release merge SHA Publish image workflow before remote deployment
