### PR TITLE
fix(ci): fetch pull request merge parents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          fetch-depth: 2
           persist-credentials: false
       - name: Verify PR merge ref matches event head
         if: github.event_name == 'pull_request_target'
@@ -74,6 +75,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          fetch-depth: 2
           persist-credentials: false
       - name: Verify PR merge ref matches event head
         if: github.event_name == 'pull_request_target'
@@ -112,6 +114,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          fetch-depth: 2
           persist-credentials: false
       - name: Verify PR merge ref matches event head
         if: github.event_name == 'pull_request_target'

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -52,4 +52,8 @@ describe("CI workflow", () => {
     const dockerJob = raw.slice(raw.indexOf("\n  docker:"), raw.indexOf("\n  report_pr_checks:"));
     expect(dockerJob).not.toMatch(/needs:/);
   });
+
+  it("fetches both parents before validating a pull-request merge ref", () => {
+    expect(raw.match(/fetch-depth:\s*2/g)).toHaveLength(3);
+  });
 });


### PR DESCRIPTION
## Summary
- fetch depth 2 for each PR checkout
- let the trusted merge-ref validator inspect both parents in a shallow checkout
- add a focused workflow policy regression test

## Verification
- CI=true focused policy test: 6/6
- YAML parse
- git diff --check

The existing pull_request_target run is expected to retain the old false-negative validator until this patch reaches main; the branch-controlled hosted run validates the patch itself.