### PR TITLE
fix(ci): initialize publish Docker config in step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,11 +40,12 @@ jobs:
     permissions:
       contents: write   # create the tag + GitHub Release on a version bump
       packages: write
-    env:
-      # Never leave the package-write credential in a persistent runner account's
-      # normal Docker config; the final always() step removes this run-scoped file.
-      DOCKER_CONFIG: ${{ runner.temp }}/helm-publish-docker-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
+      - name: Configure run-scoped registry credentials
+        # `runner` is unavailable in job-level env expressions. The runner exports
+        # RUNNER_TEMP before steps begin; GITHUB_ENV carries this path to every
+        # later step, and the final always() cleanup removes it.
+        run: echo "DOCKER_CONFIG=${RUNNER_TEMP}/helm-publish-docker-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "${GITHUB_ENV}"
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0   # need full tag list to detect "already released"

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -149,10 +149,24 @@ describe("release workflow policy", () => {
 
   it("keeps the package-write Docker credential run-scoped on the persistent runner", () => {
     const publishJob = jobBlock(publishRaw, "publish");
-    expect(publishJob).toContain("DOCKER_CONFIG: ${{ runner.temp }}");
+    const jobHeader = publishJob.slice(0, publishJob.indexOf("\n    steps:"));
+    expect(jobHeader).not.toMatch(/\$\{\{\s*runner\./);
+
+    const setupStep = stepBlock(publishRaw, "Configure run-scoped registry credentials");
+    expect(setupStep).toContain("DOCKER_CONFIG=${RUNNER_TEMP}/helm-publish-docker-");
+    expect(setupStep).toContain("${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}");
+    expect(setupStep).toContain('>> "${GITHUB_ENV}"');
+
     const cleanupStep = stepBlock(publishRaw, "Remove run-scoped registry credentials");
     expect(cleanupStep).toContain("if: always()");
     expect(cleanupStep).toContain('rm -rf -- "${DOCKER_CONFIG}"');
+
+    const setupIndex = publishJob.indexOf("- name: Configure run-scoped registry credentials");
+    const loginIndex = publishJob.indexOf("- name: Log in to GHCR");
+    const cleanupIndex = publishJob.indexOf("- name: Remove run-scoped registry credentials");
+    expect(setupIndex).toBeGreaterThanOrEqual(0);
+    expect(setupIndex).toBeLessThan(loginIndex);
+    expect(cleanupIndex).toBeGreaterThan(publishJob.lastIndexOf("docker "));
   });
 
   it("publishes only after the CI workflow succeeds for a main push", () => {


### PR DESCRIPTION
## Summary

- move the run-scoped `DOCKER_CONFIG` initialization from job-level expressions into the first publish step using `RUNNER_TEMP` and `GITHUB_ENV`
- preserve the final `always()` cleanup on the persistent runner
- strengthen regression coverage for forbidden job-level `runner.*`, run/attempt isolation, and setup/cleanup ordering

## Validation

- `CI=true pnpm exec vitest run packages/shared/src/ci-workflow.test.ts --maxWorkers=1` (23/23)
- workflow YAML parse and all shell blocks validated
- `git diff --check`
- targeted Biome check completed with no errors