### PR TITLE
chore(release): v0.27.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.17",
+  "version": "0.27.18",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release assessment
Patch release for backward-compatible correctness, isolation, routing-control, and CI fixes merged since v0.27.17.

## Change
- bump root package version from 0.27.17 to 0.27.18
- no lockfile or source changes

## Deployment gate
This release includes the SQLite v40/Postgres v39 Memory-scope migration. Remote deployment will wait for the exact release image and use a production backup, graceful shutdown, disk/WAL/migration monitoring, and post-migration reconciliation.

## Validation
The version-only diff parses successfully and passes git diff --check. Full typecheck, lint, build, unit, Playwright, and Docker smoke run in protected CI.