### PR TITLE
chore(release): v0.27.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.18",
+  "version": "0.27.19",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- release Helm API v0.27.19
- includes the historical repricing resource-threshold fix from PR #588

## Verification

- package.json parses successfully
- version is exactly 0.27.19
- git diff --check