### PR TITLE
fix(protocol): recover leaked Anthropic tool XML

### DIFF
--- a/apps/admin/src/lib/api/settings.test.ts
+++ b/apps/admin/src/lib/api/settings.test.ts
@@ -9,6 +9,7 @@ const FULL: RuntimeSettings = {
   capture_payloads: false,
   payload_retention_days: 7,
   native_protocol_passthrough: true,
+  tool_call_xml_recovery: false,
   visual_context_compression: 'observe',
   rate_limit_enabled: true,
   rate_limit_default_rpm: 60,
@@ -66,6 +67,7 @@ describe('settings api client', () => {
       capture_payloads: true,
       payload_retention_days: 30,
       native_protocol_passthrough: true,
+      tool_call_xml_recovery: true,
       visual_context_compression: 'off',
       rate_limit_enabled: false,
       rate_limit_default_rpm: 0,
@@ -127,6 +129,7 @@ describe('settings api client', () => {
     expect(JSON.parse(init.body as string)).toMatchObject({
       log_level: 'warn',
       native_protocol_passthrough: true,
+      tool_call_xml_recovery: false,
       visual_context_compression: 'observe',
     });
   });

--- a/apps/admin/src/lib/api/settings.ts
+++ b/apps/admin/src/lib/api/settings.ts
@@ -19,6 +19,9 @@ export interface RuntimeSettings {
   // The admin toggle was removed in #236, but the field stays in the model so it
   // round-trips through Save unchanged (never reset to false — the #225 lesson).
   native_protocol_passthrough: boolean;
+  // Defensive recovery for upstream models that leak tool calls as literal
+  // Anthropic <invoke> XML. Kept in every save even if the UI surface changes.
+  tool_call_xml_recovery: boolean;
   // Lossy visual context compression for bulky Anthropic-native requests. Default
   // OFF; observe records would-apply telemetry while sending original text.
   visual_context_compression: VisualContextCompressionMode;
@@ -99,6 +102,7 @@ function normalize(raw: Record<string, unknown>): RuntimeSettings {
     // across an admin save. normalize() drops any key it doesn't name, so omitting
     // this would silently reset the flag on every save (the #225 lesson).
     native_protocol_passthrough: raw.native_protocol_passthrough !== false,
+    tool_call_xml_recovery: raw.tool_call_xml_recovery !== false,
     visual_context_compression: (
       VISUAL_CONTEXT_COMPRESSION_OPTIONS as readonly string[]
     ).includes(raw.visual_context_compression as string)

--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -35,6 +35,7 @@
     // a toggle (UI removed in #236) — kept in the working copy so it round-trips
     // through Save unchanged and is never reset to false (the #225 lesson).
     native_protocol_passthrough: true,
+    tool_call_xml_recovery: true,
     visual_context_compression: 'off',
     rate_limit_enabled: false,
     rate_limit_default_rpm: 0,

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -3481,6 +3481,7 @@ describe("createExecute — native protocol passthrough (#217)", () => {
       now: clock(),
       signal: new AbortController().signal,
       nativeProtocolPassthroughEnabled: () => true,
+      toolCallXmlRecoveryEnabled: () => false,
     });
 
     const out = await execute(plan(["a"]), anthropicReq());
@@ -3490,6 +3491,9 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     // The native body is forwarded with `model` patched to the RESOLVED upstream id
     // (the client's routing alias would 404 upstream); everything else is verbatim.
     expect(provider.nativePassthrough.mock.calls[0]?.[0]).toEqual({ ...NATIVE, model: "claude-x" });
+    expect(provider.nativePassthrough.mock.calls[0]?.[1]).toMatchObject({
+      toolCallXmlRecovery: false,
+    });
     expect(out.body).toBe(NATIVE_RESP);
     expect(out.nativePassthrough).toBe(true);
     const okRow = out.attempts[0];
@@ -5231,6 +5235,7 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
       now: clock(),
       signal: new AbortController().signal,
       nativeProtocolPassthroughEnabled: () => true,
+      toolCallXmlRecoveryEnabled: () => false,
     });
 
     const out = await execute(plan(["a"]), anthropicStreamReq());
@@ -5240,6 +5245,9 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(provider.nativePassthroughStream.mock.calls[0]?.[0]).toEqual({
       ...NATIVE_STREAM,
       model: "claude-x",
+    });
+    expect(provider.nativePassthroughStream.mock.calls[0]?.[1]).toMatchObject({
+      toolCallXmlRecovery: false,
     });
     expect(provider.chatCompletionStream).not.toHaveBeenCalled();
     // recordSuccess fired on the first peeked chunk (breaker contract unchanged).

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -154,6 +154,10 @@ export interface ExecuteAdapterDeps {
    *  This dep is OPTIONAL: when absent (a caller that never wires it) the executor treats
    *  passthrough as OFF — a defensive fallback, independent of the setting's own default. */
   nativeProtocolPassthroughEnabled?: () => boolean;
+  /** Runtime feature flag `tool_call_xml_recovery` (default ON). Read per native
+   * Anthropic attempt and forwarded request-scoped to the provider so operators can
+   * disable recovery live without rebuilding clients or restarting the gateway. */
+  toolCallXmlRecoveryEnabled?: () => boolean;
   /** Runtime feature flag for lossy visual context compression. Default OFF. */
   visualContextCompressionMode?: () => VisualContextCompressionMode;
   /** Test seam / alternate implementation for visual context compression. */
@@ -1273,6 +1277,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
     signal,
     log,
     nativeProtocolPassthroughEnabled,
+    toolCallXmlRecoveryEnabled,
     visualContextCompressionMode,
     visualContextCompressor = optimizeVisualContext,
   } = deps;
@@ -1734,6 +1739,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                     signal: attemptSignal,
                     captureUpstream,
                     onResponseMeta,
+                    toolCallXmlRecovery:
+                      target.targetProviderProtocol === "anthropic_messages" &&
+                      (toolCallXmlRecoveryEnabled?.() ?? true),
                   });
                   return passthroughClassifier
                     ? guardPreOutputFailure(raw, passthroughClassifier)
@@ -1855,6 +1863,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               signal: attemptSignal,
               captureUpstream,
               onResponseMeta,
+              toolCallXmlRecovery:
+                target.targetProviderProtocol === "anthropic_messages" &&
+                (toolCallXmlRecoveryEnabled?.() ?? true),
             }),
           );
           breaker.recordSuccess(alias);

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -112,6 +112,17 @@ function sseTextStream(): AsyncIterable<string> {
   })();
 }
 
+function sseXmlToolStream(xml: string): AsyncIterable<string> {
+  const frames = [
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: xml } }] })}\n\n`,
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  return (async function* () {
+    for (const frame of frames) yield frame;
+  })();
+}
+
 function streamOkResult(stream: AsyncIterable<string>): ExecutionResult {
   return {
     decision: { lane: { selected_lane: "balanced" } } as unknown as ExecutionResult["decision"],
@@ -194,6 +205,144 @@ describe("createMessagesPipeline — streamIR protocol branch", () => {
       | undefined;
     expect(delta?.delta).toBe("hi");
     expect(events.at(-1)?.type).toBe("response.completed");
+  });
+
+  it("recovers whitelisted XML in the Anthropic translation stream when the live flag is true", async () => {
+    const xml = '<invoke name="Bash"><parameter name="command">git status</parameter></invoke>';
+    const route: RouteFn = async () => streamOkResult(sseXmlToolStream(xml));
+    let recoveryEnabled = false;
+    const pipeline = createMessagesPipeline(
+      route,
+      "anthropic_messages",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { toolCallXmlRecoveryEnabled: () => recoveryEnabled },
+    );
+    const run = await pipeline.run(
+      irOf({
+        stream: true,
+        tools: [
+          { type: "custom", function: { name: "NotAFunctionTool" } },
+          { type: "function", function: { name: 123 } },
+          { type: "function", function: { name: "Bash" } },
+        ],
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+
+    // The getter is live: changing it after run() but before stream consumption
+    // must affect this request without rebuilding the pipeline.
+    recoveryEnabled = true;
+    const events: Array<Record<string, unknown>> = [];
+    for await (const event of run.streamIR()) events.push(event);
+
+    const toolStart = events.find(
+      (event) =>
+        event.type === "content_block_start" &&
+        (event.content_block as { type?: unknown } | undefined)?.type === "tool_use",
+    );
+    expect(toolStart?.content_block).toMatchObject({ type: "tool_use", name: "Bash", input: {} });
+    const args = events.find(
+      (event) =>
+        event.type === "content_block_delta" &&
+        (event.delta as { type?: unknown } | undefined)?.type === "input_json_delta",
+    );
+    expect((args?.delta as { partial_json?: unknown } | undefined)?.partial_json).toBe(
+      JSON.stringify({ command: "git status" }),
+    );
+    expect(
+      events
+        .filter(
+          (event) =>
+            event.type === "content_block_delta" &&
+            (event.delta as { type?: unknown } | undefined)?.type === "text_delta",
+        )
+        .map((event) => (event.delta as { text?: unknown }).text)
+        .join(""),
+    ).not.toContain("<invoke");
+  });
+
+  it("keeps XML text unchanged in the Anthropic translation stream when the live flag is false", async () => {
+    const xml = '<invoke name="Bash"><parameter name="command">pwd</parameter></invoke>';
+    const route: RouteFn = async () => streamOkResult(sseXmlToolStream(xml));
+    const pipeline = createMessagesPipeline(
+      route,
+      "anthropic_messages",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { toolCallXmlRecoveryEnabled: () => false },
+    );
+    const run = await pipeline.run(
+      irOf({
+        stream: true,
+        tools: [{ type: "function", function: { name: "Bash" } }],
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+    const events: Array<Record<string, unknown>> = [];
+    for await (const event of run.streamIR()) events.push(event);
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === "content_block_start" &&
+          (event.content_block as { type?: unknown } | undefined)?.type === "tool_use",
+      ),
+    ).toBe(false);
+    expect(
+      events
+        .filter(
+          (event) =>
+            event.type === "content_block_delta" &&
+            (event.delta as { type?: unknown } | undefined)?.type === "text_delta",
+        )
+        .map((event) => (event.delta as { text?: unknown }).text)
+        .join(""),
+    ).toBe(xml);
+  });
+
+  it("defaults XML recovery to true but never whitelists non-function tool lookalikes", async () => {
+    const skipped = '<invoke name="Bash"><parameter name="command">pwd</parameter></invoke>';
+    const xml = `${skipped}<invoke name="Read"><parameter name="path">README.md</parameter></invoke>`;
+    const route: RouteFn = async () => streamOkResult(sseXmlToolStream(xml));
+    const pipeline = createMessagesPipeline(route);
+    const run = await pipeline.run(
+      irOf({
+        stream: true,
+        tools: [
+          { type: "custom", function: { name: "Bash" } },
+          { type: "function", function: { name: "Read" } },
+        ],
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+    const events: Array<Record<string, unknown>> = [];
+    for await (const event of run.streamIR()) events.push(event);
+
+    const toolStarts = events.filter(
+      (event) =>
+        event.type === "content_block_start" &&
+        (event.content_block as { type?: unknown } | undefined)?.type === "tool_use",
+    );
+    expect(toolStarts).toHaveLength(1);
+    expect(toolStarts[0]?.content_block).toMatchObject({ name: "Read" });
+    expect(
+      events
+        .filter(
+          (event) =>
+            event.type === "content_block_delta" &&
+            (event.delta as { type?: unknown } | undefined)?.type === "text_delta",
+        )
+        .map((event) => (event.delta as { text?: unknown }).text)
+        .join(""),
+    ).toBe(skipped);
   });
 });
 

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -88,6 +88,28 @@ interface PipelineIR {
   [k: string]: unknown;
 }
 
+// Tool XML recovery is request-path behavior, but its operator kill switch is
+// runtime mutable. Keep the getter live so an admin change applies to the next
+// translated Anthropic stream without rebuilding the shared pipeline closure.
+export interface PipelineRuntimeOptions {
+  toolCallXmlRecoveryEnabled?: () => boolean;
+}
+
+function irFunctionToolNames(tools: unknown): readonly string[] {
+  if (!Array.isArray(tools)) return [];
+  const names = new Set<string>();
+  for (const tool of tools) {
+    if (tool === null || typeof tool !== "object" || Array.isArray(tool)) continue;
+    const record = tool as Record<string, unknown>;
+    if (record.type !== "function") continue;
+    const fn = record.function;
+    if (fn === null || typeof fn !== "object" || Array.isArray(fn)) continue;
+    const name = (fn as Record<string, unknown>).name;
+    if (typeof name === "string" && name.length > 0) names.add(name);
+  }
+  return [...names];
+}
+
 // Gateway-side inject wiring (docs/08 Phase 2). Bundles the core InjectDeps with
 // the per-deployment token budget (D9). Optional so existing pipeline tests that
 // pass only `{ observe }` are unaffected (inject absent → inject is a no-op).
@@ -626,6 +648,9 @@ export function createMessagesPipeline(
   // observe writes are enqueued (FIFO, so inbound still settles before outbound) to
   // run AFTER the response. The budget settle is NEVER deferred (quota correctness).
   writes?: WriteQueue,
+  // Live runtime behavior switches. Optional for compatibility with existing callers;
+  // XML recovery defaults ON when the getter is absent, matching the settings schema.
+  runtime?: PipelineRuntimeOptions,
 ): {
   run(ir: PipelineIR, identity: MessagesIdentity, signal: AbortSignal): Promise<PipelineRunResult>;
 } {
@@ -1219,6 +1244,8 @@ export function createMessagesPipeline(
                           : typeof ir.model === "string"
                             ? ir.model
                             : undefined,
+                      toolNames: irFunctionToolNames(ir.tools),
+                      toolCallXmlRecoveryEnabled: runtime?.toolCallXmlRecoveryEnabled?.() ?? true,
                     });
               for await (const ev of events) {
                 genTimer.mark();

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -58,6 +58,7 @@ interface Harness {
   pipelineSawIR: Record<string, unknown> | null;
   pipelineSawAbort: boolean;
   classifyThrew: boolean;
+  responseOptions: unknown;
 }
 
 function makeDeps(
@@ -78,6 +79,7 @@ function makeDeps(
     // nativePassthrough so the route must return collect()'s body UNTOUCHED (skip
     // transformResponseOut). collect() should be set to return the verbatim native body.
     nativePassthrough?: boolean;
+    toolCallXmlRecoveryEnabled?: () => boolean;
   } = {},
 ): { deps: MessagesRouteDeps; harness: Harness } {
   const harness: Harness = {
@@ -85,6 +87,7 @@ function makeDeps(
     pipelineSawIR: null,
     pipelineSawAbort: false,
     classifyThrew: false,
+    responseOptions: undefined,
   };
 
   const deps: MessagesRouteDeps = {
@@ -92,6 +95,7 @@ function makeDeps(
     concurrencyGate: over.concurrencyGate,
     countTokens: over.countTokens,
     record: over.record,
+    toolCallXmlRecoveryEnabled: over.toolCallXmlRecoveryEnabled,
     auth: {
       resolve: async (_key: string | null) => {
         harness.order.push("auth");
@@ -111,8 +115,9 @@ function makeDeps(
           (ir as { __native?: unknown }).__native = native;
           return ir;
         },
-        transformResponseOut: (ir: unknown) => {
+        transformResponseOut: (ir: unknown, options?: unknown) => {
           harness.order.push("translate-back");
+          harness.responseOptions = options;
           return { ...ANTHROPIC_RESPONSE, __ir: ir };
         },
         transformStreamOut: (ev: { type: string }) => ({
@@ -345,6 +350,33 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expect(body.content).toEqual([{ type: "text", text: "hello" }]);
     // The wiring order is a hard contract (docs/02 pipeline): auth FIRST.
     expect(harness.order).toEqual(["auth", "translate-out", "route", "translate-back"]);
+  });
+
+  it("threads the live XML-recovery flag and declared tool names into non-stream translation", async () => {
+    const { deps, harness } = makeDeps({
+      toolCallXmlRecoveryEnabled: () => false,
+      transformRequestOut: () => ({
+        ...fakeIR(false),
+        tools: [
+          { type: "function", function: { name: "Bash", parameters: {} } },
+          { type: "function", function: { name: 42, parameters: {} } },
+          { type: "other", name: "ignored" },
+        ],
+      }),
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(harness.responseOptions).toEqual({
+      toolNames: ["Bash"],
+      toolCallXmlRecoveryEnabled: false,
+    });
   });
 
   it("rejects a missing/invalid key with a 401 Anthropic error and never routes", async () => {

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -157,7 +157,10 @@ export interface MessagesRouteDeps {
       /** Native Anthropic request → IR (inbound Protocol Adapter). */
       transformRequestOut(native: unknown): IRLike | Promise<IRLike>;
       /** IR response → native Anthropic response (outbound Protocol Adapter). */
-      transformResponseOut(ir: unknown): unknown | Promise<unknown>;
+      transformResponseOut(
+        ir: unknown,
+        options?: { toolNames: readonly string[]; toolCallXmlRecoveryEnabled: boolean },
+      ): unknown | Promise<unknown>;
       /** ONE IR stream event → ONE Anthropic SSE frame (state-machine mapped). */
       transformStreamOut(event: Record<string, unknown>): AnthropicSSEFrame;
       /** Structured internal error → Anthropic error envelope + status. */
@@ -173,6 +176,8 @@ export interface MessagesRouteDeps {
   /** SSE keep-alive cadence (ms) for streaming responses; read fresh per request from
    *  runtime.sse_heartbeat_ms. Optional — absent/0 = no heartbeat. Inter-chunk only. */
   sseHeartbeatMs?: () => number;
+  /** Live rollback switch for literal <invoke> recovery. Defaults ON when omitted. */
+  toolCallXmlRecoveryEnabled?: () => boolean;
 }
 
 // The route treats the IR as an opaque bag with the two fields it must read
@@ -181,6 +186,21 @@ interface IRLike {
   stream?: boolean;
   metadata?: Record<string, unknown>;
   [k: string]: unknown;
+}
+
+function declaredToolNames(ir: IRLike): string[] {
+  if (!Array.isArray(ir.tools)) return [];
+  const names: string[] = [];
+  for (const tool of ir.tools) {
+    if (tool === null || typeof tool !== "object" || Array.isArray(tool)) continue;
+    const record = tool as Record<string, unknown>;
+    if (record.type !== "function") continue;
+    const fn = record.function;
+    if (fn === null || typeof fn !== "object" || Array.isArray(fn)) continue;
+    const name = (fn as Record<string, unknown>).name;
+    if (typeof name === "string" && name.length > 0) names.push(name);
+  }
+  return names;
 }
 
 // Extract the plaintext credential from x-api-key (Anthropic SDK default) or the
@@ -636,7 +656,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       body =
         result.nativePassthrough === true
           ? collected
-          : await anthropic.transformResponseOut(collected);
+          : await anthropic.transformResponseOut(collected, {
+              toolNames: declaredToolNames(ir),
+              toolCallXmlRecoveryEnabled: deps.toolCallXmlRecoveryEnabled?.() ?? true,
+            });
     } catch (err) {
       // Record the FAILED served request before surfacing the error (mirrors
       // chat.ts) so an all-providers-failed request still appears in

--- a/apps/gateway/src/server.test.ts
+++ b/apps/gateway/src/server.test.ts
@@ -69,6 +69,13 @@ describe("native_protocol_passthrough runtime flag", () => {
   });
 });
 
+describe("tool_call_xml_recovery runtime flag", () => {
+  it("defaults ON so malformed upstream tool XML is recovered defensively", () => {
+    const parsed = RuntimeSettingsSchema.parse({});
+    expect(parsed.tool_call_xml_recovery).toBe(true);
+  });
+});
+
 describe("buildInternalLlmKeyInput", () => {
   it("mints an internal key that cannot self-observe or inherit user rate limits", () => {
     const input = buildInternalLlmKeyInput({

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -3054,6 +3054,7 @@ export async function buildServer(
             // route is the SAME `route` closure as chat.ts, so this one wiring edit
             // covers BOTH the OpenAI chat and Anthropic /v1/messages surfaces.
             nativeProtocolPassthroughEnabled: () => settings.native_protocol_passthrough,
+            toolCallXmlRecoveryEnabled: () => settings.tool_call_xml_recovery,
             visualContextCompressionMode: () => settings.visual_context_compression,
             // Auto-park: a genuine 429 on a subscription alias parks the served account
             // so the pool routes around it (account read from the serving-account ALS).
@@ -3373,6 +3374,7 @@ export async function buildServer(
     pipelineBudget,
     recordOAuthUsage,
     writeQueue,
+    { toolCallXmlRecoveryEnabled: () => settings.tool_call_xml_recovery },
   );
   const anthropicCountClient = (): ProviderClient | null => {
     for (const client of providerClients.values()) {
@@ -3461,7 +3463,8 @@ export async function buildServer(
         transformRequestOut: (native) => anthropicTransformer.transformRequestOut(native),
         // `collect()` contractually returns an IRResponse; the route hands it back
         // as `unknown`, so narrow at this single boundary.
-        transformResponseOut: (ir) => anthropicTransformer.transformResponseOut(ir as IRResponse),
+        transformResponseOut: (ir, options) =>
+          anthropicTransformer.transformResponseOut(ir as IRResponse, options),
         // The pipeline already produced Anthropic SSE events; here we only
         // serialize ONE event into its wire event/data pair.
         transformStreamOut: (event) => {
@@ -3487,6 +3490,7 @@ export async function buildServer(
     },
     pipeline: messagesPipeline,
     sseHeartbeatMs: () => config.runtime.sse_heartbeat_ms,
+    toolCallXmlRecoveryEnabled: () => settings.tool_call_xml_recovery,
     // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
     // chat route uses, so /v1/messages records served requests like /v1/chat does.
     record: {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-17 · Anthropic XML 工具调用恢复边界（Protocol streaming / provider execution，docs/05/07，原则 3/5/8）
+
+- **恢复信号与实际出口**：只在上游终止原因已经明确为 `tool_use`、XML `<invoke>` 完整闭合、工具名精确命中本次请求声明的 function tools，且响应中不存在既有 structured `tool_use/tool_calls` 时恢复，避免把示例文本或真实结构化调用旁边的 XML 再执行一次。规格所称“三条路径”漏掉了默认 native passthrough 的非流式直返；实现因此覆盖四个实际出口：Anthropic native stream、native JSON、OpenAI→Anthropic translation stream、translation JSON。共享 parser 保持大小写精确、非白名单/未闭合内容逐字保留、JSON-looking 参数按规格转换，并用 null-prototype 字典隔离 `__proto__`。
+- **流式时序与资源边界**：Anthropic 的 message-level `stop_reason` 位于 `content_block_stop` 之后的 `message_delta`，无法按规格字面在 block stop 当场决策。实现只在发现候选起始标记后暂存尾部，等晚到终态再改写；任何非 `tool_use`、解析拒绝、已有 structured call、异常或超限都先按原顺序冲刷文本/原始 SSE。translation 与 native candidate 均设 1 MiB UTF-8 上限，超限后本流永久旁路恢复，防止未闭合 XML 造成无界内存；native 旁路仍以最多 64K 字符的未完成 SSE 尾部有界探测 `message_stop`，避免完整终态因 HTTP body 延迟关闭而误触 idle timeout。实际网络读取继续由 `readAnthropicSSERaw` 负责，其他 idle/stall timeout 语义不变。改写时使用确定性 `toolu_synthetic_*` id，并单调重映射后续 block index。
+- **运行时回滚与保真**：新增 `tool_call_xml_recovery` runtime setting，默认 `true`；Gateway route、pipeline、executor 与 provider 都按请求读取 live 值，Admin 保存模型显式 round-trip 该字段，运维可通过现有 settings API 立即关闭。无工具、无候选或 flag off 的普通路径不解析正文；native 无候选流继续逐 network chunk 原样转发，translated 无候选流保持既有事件机。TDD 覆盖 parser、四个出口、跨 network/delta 分片、晚到 stop reason、周边文本、多 invoke、白名单、structured-call 去重、flag off、缓冲上限、异常冲刷与 index/id 顺序；最终定向结果以本次交付报告为准。
+
 ## 2026-07-16 · 历史费用回填放宽 WAL 与磁盘恢复门槛（Catalog / telemetry repair operations，docs/07/08，原则 2/3/7）
 
 - **生产事实与新门槛**：常驻 supervisor 已在 `2026-07-08` UTC 窗口的 `22,100 / 31,400` 连续等待约 7 小时；CPU、内存、health、restart/OOM、Gateway/SQLite 信号均健康，唯一持续原因是磁盘低于 14 GiB，随后 WAL 增至约 583 MiB。主机当时仍有约 13.9 GiB 可用空间，全部历史回填目录约 1.55 GiB，当前窗口 221 个微型备份约 106 MiB，且 Docker 已无可回收镜像。为避免恢复门槛永久饿死任务，preflight 改为 WAL `<640 MiB`、磁盘 `>13 GiB`；runtime hard stop 改为 WAL `<768 MiB`，磁盘硬底线继续保持 `12 GiB`。这样当前状态可恢复，同时仍保留约 0.9 GiB 磁盘余量、约 185 MiB WAL 运行余量和独立硬上限。
@@ -62,14 +68,9 @@
 - **兼容边界**：计费边界只把空字符串和已确认的 `not_available` 规范化为“地域缺失”，使用既有全球基础卡；仍将真实但未配置的地域（如 `moon`）保持 unknown，避免猜价。原始哨兵继续保存在 telemetry 作为 provenance，不改写 provider 事实；实时响应与历史重算共用同一规范化函数，防止两套语义漂移。
 - **验证与修复边界**：TDD 以生产请求的 Opus 4.8 token/cache 数复现 `$0.24682125`，覆盖未知地域严格拒绝、Anthropic SSE 哨兵保真，以及历史重算仅在 `best-evidence` 下把该哨兵作为全球假设。生产历史数据修复仍须使用既有 manifest、逐批微型恢复库、health/WAL/disk 门禁和 OAuth delta 一致性保护。
 
-## 2026-07-15 · 终端事件缺失的 Responses 流使用部分估算计费（Protocol streaming / telemetry accounting，docs/05/07，原则 3/5/7/8）
-
-- **终态语义**：provider 已产出首包仍保留成功 attempt，但 Responses 流只有收到 `response.completed` / `response.incomplete` / `response.failed` 才算有上游终态；无终态的自然 EOF 记为 `stream_outcome=truncated`、下游 abort 记为 `client_aborted`，request `final.status` 改为 error，分别使用 `upstream_error` / `client_abort`，不再把部分消费伪装成完整成功。`response.incomplete` 保留其独立终态；provider 明确报告的 usage（包括全 0）永远优先。
-- **估算边界**：只在原生 Responses 流缺少 usage 时，对去除 transport 字段与内嵌 binary/base64 的语义 upstream request，以及实际收到的 output/reasoning/tool-call semantic delta 做 `estimated_partial` 估算。16 KiB 内使用 o200k-harmony，超过后改用既有 UTF-8 bytes/4 确定性估算，避免大上下文在 stream finally 阻塞事件循环；sequence number 去重，同一 semantic channel 的碎片先拼接，done snapshot 与 encrypted/base64 数据不参与。cache、cache creation 与隐藏 reasoning 不猜测，保持 null。估算费用沿现有 catalog `costOf` 计算，并以 `cost_basis=catalog_api_equivalent_estimate` 标记，不能解释为 provider 实际账单。
-- **一致性边界**：同一份部分 usage/cost 同时写入 telemetry usage、成功 provider attempt、key budget 与实际 serving account 的 OAuth usage；每项只结算一次。stream generation window 与 usage 解耦，即使 usage 解析失败也保留 `generation_ms`。registry 使用同一 `stream_outcome`，不再把缺失终态默认成 completed。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-15 · 终端事件缺失的 Responses 流使用部分估算计费（Protocol streaming / telemetry accounting，docs/05/07，原则 3/5/7/8）**：原生 Responses 流缺终态时按 truncated/client_aborted 记失败，仅对已收 semantic delta 做有界 partial usage/cost 估算，并让 telemetry、attempt、budget 与 OAuth 账号结算一致；完整原文通过 git history 回溯。
 - **2026-07-15 · 历史费用回填改由常驻 supervisor 持续推进（Catalog / telemetry repair operations，docs/07/08，原则 2/3/5/7）**：systemd 常驻 supervisor 以单实例、100 行原子批次、checkpoint、slice verification、微型恢复库、资源门禁和 5,000 行冷却推进固定截止点前的历史修复；完整原文通过 git history 回溯。
 - **2026-07-15 · 历史重算兼容旧版 completion-only 顶层费用（Catalog / telemetry repair，docs/07/08，原则 2/5/7）**：仅在顶层、attempt 与 breakdown 同时精确证明旧版只保存 completion cost 时接受回填，任何其他漂移仍 fail-closed；完整原文通过 git history 回溯。
 - **2026-07-14 · 官方模型费率与多模态计费校准（Catalog / telemetry / protocol usage，docs/04/05/07/08，原则 1/2/3/5/7/8）**：以官方价格和响应中可证明的 tier、地域、缓存与 modality 证据计费；未知分价、动态 alias 与已丢失的历史证据保持 unknown，历史修复只经 manifest、微型恢复库和资源门禁渐进执行。

--- a/packages/core/src/protocol/anthropic/index.ts
+++ b/packages/core/src/protocol/anthropic/index.ts
@@ -1,11 +1,17 @@
 import type { IRChunk } from "../gemini/gemini-types.js";
+import type { IRResponse } from "../ir.js";
 import type { Transformer } from "../transformer.js";
 import {
   type AnthropicOutboundRequest,
   transformRequestIn,
   transformRequestOut,
 } from "./request.js";
-import { transformNativeResponseToIR, transformResponseIn } from "./response.js";
+import {
+  type AnthropicMessagesResponse,
+  type AnthropicResponseRenderOptions,
+  transformNativeResponseToIR,
+  transformResponseIn,
+} from "./response.js";
 import { type AnthropicSSEEvent, convertAnthropicStreamToIR } from "./stream.js";
 
 // Anthropic Messages protocol barrel (docs/05). Re-exports the pure inbound/
@@ -39,6 +45,7 @@ export {
 export {
   type AnthropicMessagesResponse,
   AnthropicMessagesResponseSchema,
+  type AnthropicResponseRenderOptions,
   type AnthropicStopReason,
   AnthropicStopReasonSchema,
   type AnthropicToolNameMap,
@@ -69,16 +76,22 @@ export {
 //   • transformStreamIn:   native Anthropic SSE events -> IR chunks (provider-inbound)
 // transformResponseOut reuses the IR->native renderer (`transformResponseIn` in
 // response.ts is the IR->Anthropic direction, kept under its historical name).
-export const anthropicTransformer: Transformer & {
+export interface AnthropicTransformer extends Omit<Transformer, "transformResponseOut"> {
+  transformResponseOut: (
+    ir: IRResponse,
+    options?: AnthropicResponseRenderOptions,
+  ) => AnthropicMessagesResponse;
   transformStreamIn: (src: AsyncIterable<AnthropicSSEEvent>) => AsyncIterable<IRChunk>;
-} = {
+}
+
+export const anthropicTransformer: AnthropicTransformer = {
   name: "anthropic",
   endPoint: "/v1/messages",
   transformRequestOut(req) {
     return transformRequestOut(req);
   },
-  transformResponseOut(ir) {
-    return transformResponseIn(ir);
+  transformResponseOut(ir, options) {
+    return transformResponseIn(ir, options);
   },
   transformRequestIn(ir): AnthropicOutboundRequest {
     return transformRequestIn(ir);

--- a/packages/core/src/protocol/anthropic/response.test.ts
+++ b/packages/core/src/protocol/anthropic/response.test.ts
@@ -181,6 +181,97 @@ describe("transformResponseIn", () => {
     expect(out.stop_reason).toBe("tool_use");
   });
 
+  it("recovers a closed whitelisted XML invoke from a tool-use response", () => {
+    const xml =
+      '<invoke name="Bash">\n<parameter name="command">git status</parameter>\n' +
+      '<parameter name="timeout">600000</parameter>\n</invoke>';
+    const out = transformResponseIn(
+      makeIR({
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: `Before\n${xml}\nAfter` },
+            finish_reason: "tool_calls",
+          },
+        ],
+      }),
+      { toolNames: ["Bash"], toolCallXmlRecoveryEnabled: true },
+    );
+
+    expect(out.content).toEqual([
+      { type: "text", text: "Before\n" },
+      {
+        type: "tool_use",
+        id: "toolu_synthetic_1",
+        name: "Bash",
+        input: { command: "git status", timeout: 600000 },
+      },
+      { type: "text", text: "\nAfter" },
+    ]);
+    expect(out.stop_reason).toBe("tool_use");
+  });
+
+  it.each([
+    {
+      title: "finish reason is not tool_use",
+      finishReason: "stop",
+      tools: ["Bash"],
+      enabled: true,
+    },
+    { title: "tool is not declared", finishReason: "tool_calls", tools: ["Read"], enabled: true },
+    {
+      title: "feature flag is disabled",
+      finishReason: "tool_calls",
+      tools: ["Bash"],
+      enabled: false,
+    },
+  ])("keeps XML text untouched when $title", ({ finishReason, tools, enabled }) => {
+    const xml = '<invoke name="Bash"><parameter name="command">git status</parameter></invoke>';
+    const out = transformResponseIn(
+      makeIR({
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: xml },
+            finish_reason: finishReason,
+          },
+        ],
+      }),
+      { toolNames: tools, toolCallXmlRecoveryEnabled: enabled },
+    );
+
+    expect(out.content).toEqual([{ type: "text", text: xml }]);
+  });
+
+  it("does not recover XML when a structured tool call already exists", () => {
+    const xml = '<invoke name="Bash"><parameter name="command">echo prose</parameter></invoke>';
+    const out = transformResponseIn(
+      makeIR({
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: xml,
+              tool_calls: [
+                {
+                  id: "toolu_real",
+                  type: "function",
+                  function: { name: "Bash", arguments: '{"command":"pwd"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      }),
+      { toolNames: ["Bash"], toolCallXmlRecoveryEnabled: true },
+    );
+
+    expect(out.content).toContainEqual({ type: "text", text: xml });
+    expect(out.content.filter((block) => block.type === "tool_use")).toHaveLength(1);
+  });
+
   it("tolerates malformed tool_call arguments without failing the whole response", () => {
     const out = transformResponseIn(
       makeIR({

--- a/packages/core/src/protocol/anthropic/response.ts
+++ b/packages/core/src/protocol/anthropic/response.ts
@@ -8,6 +8,7 @@ import {
   type IRUsage,
 } from "../ir.js";
 import { liftReasoningToFlat, resolveReasoning } from "../reasoning.js";
+import { recoverToolCallsFromText } from "./tool-xml-recovery.js";
 
 // IR -> Anthropic Messages native response (docs/05, task protocol.anthropic-resp).
 // The outbound half of "nativeIn -> IR -> nativeOut, never N×N direct". Two
@@ -105,6 +106,13 @@ const AnthropicContentBlockSchema = z.discriminatedUnion("type", [
   AnthropicImageBlockSchema,
 ]);
 type AnthropicContentBlock = z.infer<typeof AnthropicContentBlockSchema>;
+
+export interface AnthropicResponseRenderOptions {
+  /** Request-scoped whitelist. Recovery is impossible without declared tool names. */
+  toolNames?: readonly string[];
+  /** Runtime rollback flag; true by default at the schema and direct-call boundaries. */
+  toolCallXmlRecoveryEnabled?: boolean;
+}
 
 export interface AnthropicToolNameMap {
   toAnthropic(name: string): string;
@@ -318,6 +326,7 @@ function repairJson(s: string): string | undefined {
 function toContentBlocks(
   message: IRResponse["choices"][number]["message"],
   toolNameMap: AnthropicToolNameMap,
+  recovery: { enabled: boolean; declaredTools: ReadonlySet<string> },
 ): AnthropicContentBlock[] {
   const blocks: AnthropicContentBlock[] = [];
   const { content } = message;
@@ -361,12 +370,35 @@ function toContentBlocks(
     }
   }
 
+  const pushText = (text: string): void => {
+    if (text === "") return;
+    const segments = recovery.enabled
+      ? recoverToolCallsFromText(text, recovery.declaredTools)
+      : null;
+    if (segments === null) {
+      blocks.push({ type: "text", text });
+      return;
+    }
+    for (const segment of segments) {
+      if (segment.type === "text") {
+        blocks.push(segment);
+      } else {
+        blocks.push({
+          type: "tool_use",
+          id: `toolu_synthetic_${blocks.length}`,
+          name: toolNameMap.toAnthropic(segment.call.name),
+          input: segment.call.input,
+        });
+      }
+    }
+  };
+
   if (typeof content === "string") {
-    if (content !== "") blocks.push({ type: "text", text: content });
+    pushText(content);
   } else if (Array.isArray(content)) {
     for (const part of content) {
       if (part.type === "text") {
-        blocks.push({ type: "text", text: part.text });
+        pushText(part.text);
       }
       // thinking parts were already emitted via resolveReasoning above.
     }
@@ -412,7 +444,10 @@ function toToolUseBlock(
  * stop_reason and a well-formed usage. Internal raw values remain available on the
  * IR/telemetry path; the public Anthropic response body never exposes provider_raw.
  */
-export function transformResponseIn(ir: IRResponse): AnthropicMessagesResponse {
+export function transformResponseIn(
+  ir: IRResponse,
+  options: AnthropicResponseRenderOptions = {},
+): AnthropicMessagesResponse {
   const choice = ir.choices[0];
   const message = choice?.message ?? { role: "assistant" as const, content: null };
   const { stop_reason } = mapStopReason(choice?.finish_reason ?? "");
@@ -422,16 +457,26 @@ export function transformResponseIn(ir: IRResponse): AnthropicMessagesResponse {
     ...mapUsage(ir.usage ?? {}),
     ...(anthropicSpeed !== undefined ? { speed: anthropicSpeed } : {}),
   };
-  const toolNameMap = createAnthropicToolNameMap(
-    (message.tool_calls ?? []).map((call) => call.function.name),
-  );
+  const toolNameMap = createAnthropicToolNameMap([
+    ...(message.tool_calls ?? []).map((call) => call.function.name),
+    ...(options.toolNames ?? []),
+  ]);
+  // A real structured call already explains stop_reason=tool_use. Recovering XML in
+  // that mixed response would create a second executable call from what may be prose.
+  const xmlRecoveryEnabled =
+    options.toolCallXmlRecoveryEnabled !== false &&
+    stop_reason === "tool_use" &&
+    (message.tool_calls?.length ?? 0) === 0;
 
   const out: AnthropicMessagesResponse = {
     id: ir.id,
     type: "message",
     role: "assistant",
     model: ir.model,
-    content: toContentBlocks(message, toolNameMap),
+    content: toContentBlocks(message, toolNameMap, {
+      enabled: xmlRecoveryEnabled,
+      declaredTools: new Set(options.toolNames ?? []),
+    }),
     stop_reason,
     stop_sequence: null,
     usage,

--- a/packages/core/src/protocol/anthropic/stream.test.ts
+++ b/packages/core/src/protocol/anthropic/stream.test.ts
@@ -123,6 +123,267 @@ describe("convertOpenAIStreamToAnthropic — text event sequence", () => {
   });
 });
 
+describe("convertOpenAIStreamToAnthropic — leaked tool XML recovery", () => {
+  const invoke =
+    '<invoke name="Bash">\n<parameter name="command">git status</parameter>\n</invoke>';
+
+  function textDeltas(events: readonly AnthropicSSEEvent[]): string[] {
+    return events.flatMap((event) =>
+      event.type === "content_block_delta" && event.delta.type === "text_delta"
+        ? [event.delta.text]
+        : [],
+    );
+  }
+
+  it("recovers a whitelisted invoke split across deltas and preserves surrounding text order", async () => {
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(
+        feed([
+          textChunk("before <inv"),
+          textChunk('oke name="Bash">\n<para'),
+          textChunk('meter name="command">git status</parameter>\n</invoke> after'),
+          textChunk("", "tool_calls"),
+        ]),
+        { toolNames: ["Bash"] },
+      ),
+    );
+
+    const starts = events.filter(
+      (event): event is Extract<AnthropicSSEEvent, { type: "content_block_start" }> =>
+        event.type === "content_block_start",
+    );
+    expect(starts.map((event) => [event.index, event.content_block.type])).toEqual([
+      [0, "text"],
+      [1, "tool_use"],
+      [2, "text"],
+    ]);
+    expect(textDeltas(events)).toEqual(["before ", " after"]);
+
+    const toolStart = starts[1];
+    expect(toolStart?.content_block).toMatchObject({
+      type: "tool_use",
+      id: "toolu_synthetic_1",
+      name: "Bash",
+      input: {},
+    });
+    const toolArgs = events
+      .filter(
+        (event): event is Extract<AnthropicSSEEvent, { type: "content_block_delta" }> =>
+          event.type === "content_block_delta" &&
+          event.index === 1 &&
+          event.delta.type === "input_json_delta",
+      )
+      .map((event) => (event.delta.type === "input_json_delta" ? event.delta.partial_json : ""))
+      .join("");
+    expect(JSON.parse(toolArgs)).toEqual({ command: "git status" });
+    expect(JSON.stringify(events)).not.toContain("<invoke");
+
+    const terminal = events.find((event) => event.type === "message_delta");
+    expect(terminal?.type).toBe("message_delta");
+    if (terminal?.type === "message_delta") {
+      expect(terminal.delta.stop_reason).toBe("tool_use");
+    }
+
+    const open = new Set<number>();
+    for (const event of events) {
+      if (event.type === "content_block_start") {
+        expect(open.has(event.index)).toBe(false);
+        open.add(event.index);
+      } else if (event.type === "content_block_delta") {
+        expect(open.has(event.index)).toBe(true);
+      } else if (event.type === "content_block_stop") {
+        expect(open.delete(event.index)).toBe(true);
+      }
+    }
+    expect(open.size).toBe(0);
+  });
+
+  it("flushes candidate XML verbatim when finish_reason does not map to tool_use", async () => {
+    const chunks = [
+      textChunk(`before ${invoke.slice(0, 17)}`),
+      textChunk(invoke.slice(17)),
+      textChunk("", "stop"),
+    ];
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(feed(chunks), { toolNames: ["Bash"] }),
+    );
+
+    expect(textDeltas(events).join("")).toBe(`before ${invoke}`);
+    expect(
+      events.some(
+        (event) => event.type === "content_block_start" && event.content_block.type === "tool_use",
+      ),
+    ).toBe(false);
+    const terminal = events.find((event) => event.type === "message_delta");
+    if (terminal?.type === "message_delta") {
+      expect(terminal.delta.stop_reason).toBe("end_turn");
+    }
+  });
+
+  it.each([
+    ["an undeclared tool", invoke, ["Read"]],
+    [
+      "an unclosed invoke",
+      '<invoke name="Bash"><parameter name="command">git status</parameter>',
+      ["Bash"],
+    ],
+  ])("flushes %s verbatim", async (_label, text, toolNames) => {
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(
+        feed([
+          textChunk(text.slice(0, 11)),
+          textChunk(text.slice(11)),
+          textChunk("", "tool_calls"),
+        ]),
+        { toolNames },
+      ),
+    );
+
+    expect(textDeltas(events).join("")).toBe(text);
+    expect(
+      events.some(
+        (event) => event.type === "content_block_start" && event.content_block.type === "tool_use",
+      ),
+    ).toBe(false);
+  });
+
+  it("flushes candidate XML verbatim when recovery is disabled", async () => {
+    const chunks = [
+      textChunk(invoke.slice(0, 8)),
+      textChunk(invoke.slice(8)),
+      textChunk("", "tool_calls"),
+    ];
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(feed(chunks), {
+        toolNames: ["Bash"],
+        toolCallXmlRecoveryEnabled: false,
+      }),
+    );
+
+    expect(textDeltas(events)).toEqual([invoke.slice(0, 8), invoke.slice(8)]);
+    expect(
+      events.some(
+        (event) => event.type === "content_block_start" && event.content_block.type === "tool_use",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps an ordinary stream event-for-event identical when recovery is eligible", async () => {
+    const chunks = [textChunk("Hel"), textChunk("lo"), textChunk("", "stop")];
+    const baseline = await collect(convertOpenAIStreamToAnthropic(feed(chunks)));
+    const eligible = await collect(
+      convertOpenAIStreamToAnthropic(feed(chunks), { toolNames: ["Bash"] }),
+    );
+    expect(eligible).toEqual(baseline);
+  });
+
+  it("flushes cached XML before a structured tool call and never recovers both", async () => {
+    const structured: OpenAIChunk = {
+      id: "chatcmpl-x",
+      model: "gpt-x",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: "call_real",
+                type: "function",
+                function: { name: "Bash", arguments: '{"command":"pwd"}' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(
+        feed([
+          textChunk(invoke.slice(0, 13)),
+          textChunk(invoke.slice(13)),
+          structured,
+          textChunk("", "tool_calls"),
+        ]),
+        { toolNames: ["Bash"] },
+      ),
+    );
+
+    expect(textDeltas(events).join("")).toBe(invoke);
+    const toolStarts = events.filter(
+      (event): event is Extract<AnthropicSSEEvent, { type: "content_block_start" }> =>
+        event.type === "content_block_start" && event.content_block.type === "tool_use",
+    );
+    expect(toolStarts).toHaveLength(1);
+    expect(toolStarts[0]?.content_block).toMatchObject({
+      type: "tool_use",
+      id: "call_real",
+      name: "Bash",
+    });
+    const xmlTextIndex = events.findIndex(
+      (event) => event.type === "content_block_delta" && event.delta.type === "text_delta",
+    );
+    const structuredStartIndex = events.findIndex(
+      (event) =>
+        event.type === "content_block_start" &&
+        event.content_block.type === "tool_use" &&
+        event.content_block.id === "call_real",
+    );
+    expect(xmlTextIndex).toBeGreaterThanOrEqual(0);
+    expect(xmlTextIndex).toBeLessThan(structuredStartIndex);
+  });
+
+  it("caps an XML candidate at 1 MiB and disables recovery for the rest of the stream", async () => {
+    const opener = '<invoke name="Bash">';
+    const atLimit = opener + "x".repeat(1024 * 1024 - opener.length);
+    const laterInvoke =
+      '<invoke name="Bash"><parameter name="command">echo later</parameter></invoke>';
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(
+        feed([
+          textChunk(atLimit),
+          textChunk("!"),
+          textChunk(laterInvoke),
+          textChunk("", "tool_calls"),
+        ]),
+        { toolNames: ["Bash"] },
+      ),
+    );
+
+    expect(textDeltas(events).join("") === `${atLimit}!${laterInvoke}`).toBe(true);
+    expect(
+      events.some(
+        (event) => event.type === "content_block_start" && event.content_block.type === "tool_use",
+      ),
+    ).toBe(false);
+  });
+
+  it("flushes a buffered XML candidate before rethrowing a source error", async () => {
+    const boom = new Error("translated stream broke");
+    async function* broken(): AsyncIterable<OpenAIChunk> {
+      yield textChunk(invoke);
+      throw boom;
+    }
+
+    const iterator = convertOpenAIStreamToAnthropic(broken(), {
+      toolNames: ["Bash"],
+    })[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value?.type).toBe("message_start");
+    const start = await iterator.next();
+    expect(start.value).toMatchObject({
+      type: "content_block_start",
+      content_block: { type: "text", text: "" },
+    });
+    expect((await iterator.next()).value).toMatchObject({
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: invoke },
+    });
+    await expect(iterator.next()).rejects.toBe(boom);
+  });
+});
+
 // —— 2. parallel tool-call streaming ——————————————————————————————————————————
 
 describe("convertOpenAIStreamToAnthropic — parallel tool calls", () => {

--- a/packages/core/src/protocol/anthropic/stream.ts
+++ b/packages/core/src/protocol/anthropic/stream.ts
@@ -15,6 +15,11 @@ import {
   mapStopReason,
   mapUsage,
 } from "./response.js";
+import {
+  invokeStartIndex,
+  invokeStartPrefixSuffixLength,
+  recoverToolCallsFromText,
+} from "./tool-xml-recovery.js";
 
 // OpenAI chunk → Anthropic SSE event stream: the EXPLICIT state machine that is
 // protocol translation's #1 risk (CLAUDE.md principle 8, docs/05). Streaming is
@@ -126,6 +131,10 @@ export interface OpenAIToAnthropicStreamOptions {
   id?: string;
   /** Fallback served model used when the upstream stream does not expose one. */
   model?: string;
+  /** Client-declared tool names. XML recovery is fail-closed when this whitelist is empty. */
+  toolNames?: readonly string[];
+  /** Runtime kill switch for leaked tool-call XML recovery. Default ON. */
+  toolCallXmlRecoveryEnabled?: boolean;
 }
 
 // —— Anthropic SSE event schemas (the output alphabet of the state machine). ————
@@ -350,6 +359,88 @@ function inputJSONDeltaEvent(index: number, partial: string): AnthropicSSEEvent 
   };
 }
 
+const MAX_XML_CANDIDATE_BYTES = 1024 * 1024;
+
+function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    if (code <= 0x7f) {
+      bytes += 1;
+    } else if (code <= 0x7ff) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index += 1;
+      } else {
+        bytes += 3;
+      }
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function* emitText(state: StreamState, text: string): Generator<AnthropicSSEEvent> {
+  if (text === "") return;
+  if (state.textBlockIndex === null) {
+    const index = allocBlock(state);
+    state.textBlockIndex = index;
+    yield {
+      type: "content_block_start",
+      index,
+      content_block: { type: "text", text: "" },
+    };
+  }
+  yield textDeltaEvent(state.textBlockIndex, text);
+}
+
+function* closeText(state: StreamState): Generator<AnthropicSSEEvent> {
+  const index = state.textBlockIndex;
+  if (index === null) return;
+  if (state.openBlocks.delete(index)) yield { type: "content_block_stop", index };
+  state.textBlockIndex = null;
+}
+
+function* emitRecoveredToolXML(
+  state: StreamState,
+  text: string,
+  declaredTools: ReadonlySet<string>,
+): Generator<AnthropicSSEEvent, boolean> {
+  const segments = recoverToolCallsFromText(text, declaredTools);
+  if (segments === null) return false;
+
+  for (const segment of segments) {
+    if (segment.type === "text") {
+      yield* emitText(state, segment.text);
+      continue;
+    }
+
+    // Anthropic content blocks are ordered. End any surrounding text block before
+    // lifting the invoke, then allocate a fresh monotonic index for the tool block.
+    yield* closeText(state);
+    const blockIndex = allocBlock(state);
+    yield {
+      type: "content_block_start",
+      index: blockIndex,
+      content_block: {
+        type: "tool_use",
+        id: clientToolUseId({ id: tempId(blockIndex), blockIndex }),
+        name: segment.call.name,
+        input: {},
+      },
+    };
+    yield inputJSONDeltaEvent(blockIndex, JSON.stringify(segment.call.input));
+    if (state.openBlocks.delete(blockIndex)) {
+      yield { type: "content_block_stop", index: blockIndex };
+    }
+  }
+  return true;
+}
+
 function thinkingDeltaEvent(index: number, thinking: string): AnthropicSSEEvent {
   return { type: "content_block_delta", index, delta: { type: "thinking_delta", thinking } };
 }
@@ -396,129 +487,195 @@ export async function* convertOpenAIStreamToAnthropic(
   options: OpenAIToAnthropicStreamOptions = {},
 ): AsyncIterable<AnthropicSSEEvent> {
   const state = createState();
+  const declaredTools = new Set(options.toolNames ?? []);
+  let recoveryEnabled = options.toolCallXmlRecoveryEnabled !== false && declaredTools.size > 0;
+  let xmlCandidate: string | null = null;
+  let xmlCandidateBytes = 0;
+  let invokeProbeSuffix = "";
 
-  for await (const raw of chunks) {
-    const chunk = OpenAIChunkSchema.parse(raw);
+  try {
+    for await (const raw of chunks) {
+      const chunk = OpenAIChunkSchema.parse(raw);
 
-    if (!state.messageStarted) {
-      state.messageStarted = true;
-      yield messageStartEvent({
-        id: nonEmptyString(chunk.id) ?? nonEmptyString(options.id),
-        model: nonEmptyString(chunk.model) ?? nonEmptyString(options.model),
-      });
-    }
-
-    const choice = chunk.choices?.[0];
-    const delta = choice?.delta;
-
-    // —— reasoning: lazily open a thinking block (BEFORE the text block, since
-    // reasoning streams ahead of the answer), then stream thinking_delta. ——
-    if (delta?.reasoning_content) {
-      if (state.thinkingBlockIndex === null) {
-        const i = allocBlock(state);
-        state.thinkingBlockIndex = i;
-        yield {
-          type: "content_block_start",
-          index: i,
-          content_block: { type: "thinking", thinking: "" },
-        };
-      }
-      yield thinkingDeltaEvent(state.thinkingBlockIndex, delta.reasoning_content);
-    }
-
-    // —— redacted thinking: opaque block start/stop, no deltas. Used by synthesized
-    // Anthropic streams so native redacted history survives cache hits/non-stream relays.
-    for (const block of delta?.thinking_blocks ?? []) {
-      if (block.type !== "redacted_thinking" || typeof block.data !== "string") continue;
-      const i = allocBlock(state);
-      yield {
-        type: "content_block_start",
-        index: i,
-        content_block: { type: "redacted_thinking", data: block.data },
-      };
-    }
-
-    // —— text: lazily open the text block, then stream text_delta. ——
-    if (delta?.content) {
-      if (state.textBlockIndex === null) {
-        const i = allocBlock(state);
-        state.textBlockIndex = i;
-        yield {
-          type: "content_block_start",
-          index: i,
-          content_block: { type: "text", text: "" },
-        };
-      }
-      yield textDeltaEvent(state.textBlockIndex, delta.content);
-    }
-
-    // —— tool calls: integer index → stable block; temp id → real id upgrade. ——
-    for (const tc of delta?.tool_calls ?? []) {
-      let slot = state.toolIndexToBlock.get(tc.index);
-      if (slot === undefined) {
-        const blockIndex = allocBlock(state);
-        slot = {
-          blockIndex,
-          started: false,
-          id: tc.id ?? tempId(blockIndex),
-          name:
-            tc.function?.name !== undefined ? state.toolNameMap.toAnthropic(tc.function.name) : "",
-          argBuffer: "",
-        };
-        state.toolIndexToBlock.set(tc.index, slot);
-      } else {
-        // Upgrade a temp id to the real one and backfill a late-arriving name.
-        if (tc.id !== undefined && tc.id !== "") slot.id = tc.id;
-        if (tc.function?.name !== undefined && tc.function.name !== "")
-          slot.name = state.toolNameMap.toAnthropic(tc.function.name);
+      if (!state.messageStarted) {
+        state.messageStarted = true;
+        yield messageStartEvent({
+          id: nonEmptyString(chunk.id) ?? nonEmptyString(options.id),
+          model: nonEmptyString(chunk.model) ?? nonEmptyString(options.model),
+        });
       }
 
-      const args = tc.function?.arguments;
-      if (args !== undefined && args !== "") {
-        // First argument fragment: settle id/name and emit START before any delta
-        // (block start ALWAYS precedes its deltas — no orphan delta, pit #4).
-        if (!slot.started) {
-          slot.started = true;
+      const choice = chunk.choices?.[0];
+      const delta = choice?.delta;
+
+      // —— reasoning: lazily open a thinking block (BEFORE the text block, since
+      // reasoning streams ahead of the answer), then stream thinking_delta. ——
+      if (delta?.reasoning_content) {
+        if (state.thinkingBlockIndex === null) {
+          const i = allocBlock(state);
+          state.thinkingBlockIndex = i;
           yield {
             type: "content_block_start",
-            index: slot.blockIndex,
-            content_block: {
-              type: "tool_use",
-              id: clientToolUseId(slot),
-              name: slot.name,
-              input: {},
-            },
+            index: i,
+            content_block: { type: "thinking", thinking: "" },
           };
         }
-        slot.argBuffer += args;
-        yield inputJSONDeltaEvent(slot.blockIndex, args);
+        yield thinkingDeltaEvent(state.thinkingBlockIndex, delta.reasoning_content);
       }
-    }
 
-    // Buffer usage; never billed mid-stream (pit #2). Raw upstream `prompt_tokens` is
-    // the FULL prompt (cached + fresh + cache creation), but mapUsage() expects IR
-    // usage where prompt has ALREADY had cache read/write subtracted (the non-stream
-    // openai.ts path does the same). Read cache details from flat fields OR the real
-    // OpenAI prompt_tokens_details nesting.
-    if (chunk.usage) {
-      const u = chunk.usage;
-      const cached = u.cached_tokens ?? u.prompt_tokens_details?.cached_tokens ?? 0;
-      const cacheCreation =
-        u.cache_creation_tokens ??
-        tokenCount(u.prompt_tokens_details?.cache_creation_tokens) ??
-        tokenCount(u.prompt_tokens_details?.cache_creation_input_tokens) ??
-        tokenCount(u.prompt_tokens_details?.cache_write_tokens) ??
-        0;
-      state.usage = {
-        ...(u.prompt_tokens !== undefined
-          ? { prompt_tokens: Math.max(0, u.prompt_tokens - cached - cacheCreation) }
-          : {}),
-        ...(u.completion_tokens !== undefined ? { completion_tokens: u.completion_tokens } : {}),
-        ...(cached > 0 ? { cached_tokens: cached } : {}),
-        ...(cacheCreation > 0 ? { cache_creation_tokens: cacheCreation } : {}),
-      };
+      // —— redacted thinking: opaque block start/stop, no deltas. Used by synthesized
+      // Anthropic streams so native redacted history survives cache hits/non-stream relays.
+      for (const block of delta?.thinking_blocks ?? []) {
+        if (block.type !== "redacted_thinking" || typeof block.data !== "string") continue;
+        const i = allocBlock(state);
+        yield {
+          type: "content_block_start",
+          index: i,
+          content_block: { type: "redacted_thinking", data: block.data },
+        };
+      }
+
+      // —— text: lazily open the text block, then stream text_delta. A potential
+      // leaked invoke is buffered until the terminal finish_reason supplies the
+      // third safety signal (it must map to Anthropic tool_use). ——
+      if (delta?.content) {
+        if (!recoveryEnabled) {
+          yield* emitText(state, delta.content);
+        } else if (xmlCandidate !== null) {
+          const deltaBytes = utf8ByteLength(delta.content);
+          if (xmlCandidateBytes + deltaBytes > MAX_XML_CANDIDATE_BYTES) {
+            // A malformed/unclosed invoke must not turn the streaming adapter into an
+            // unbounded response buffer. Flush in source order and permanently disable
+            // recovery for this stream; later XML remains ordinary text.
+            yield* emitText(state, xmlCandidate);
+            yield* emitText(state, delta.content);
+            xmlCandidate = null;
+            xmlCandidateBytes = 0;
+            recoveryEnabled = false;
+          } else {
+            xmlCandidate += delta.content;
+            xmlCandidateBytes += deltaBytes;
+          }
+        } else {
+          const probe = invokeProbeSuffix + delta.content;
+          invokeProbeSuffix = "";
+          const invokeStart = invokeStartIndex(probe);
+          if (invokeStart >= 0) {
+            yield* emitText(state, probe.slice(0, invokeStart));
+            const candidate = probe.slice(invokeStart);
+            const candidateBytes = utf8ByteLength(candidate);
+            if (candidateBytes > MAX_XML_CANDIDATE_BYTES) {
+              yield* emitText(state, candidate);
+              recoveryEnabled = false;
+            } else {
+              xmlCandidate = candidate;
+              xmlCandidateBytes = candidateBytes;
+            }
+          } else {
+            const suffixLength = invokeStartPrefixSuffixLength(probe);
+            const emitLength = probe.length - suffixLength;
+            yield* emitText(state, probe.slice(0, emitLength));
+            invokeProbeSuffix = probe.slice(emitLength);
+          }
+        }
+      }
+
+      // A real structured tool call is authoritative. Replaying both it and recovered
+      // XML could execute the same action twice, so flush any candidate BEFORE handling
+      // the structured delta and suppress XML recovery for the rest of this stream.
+      if ((delta?.tool_calls?.length ?? 0) > 0) {
+        if (xmlCandidate !== null) {
+          yield* emitText(state, xmlCandidate);
+          xmlCandidate = null;
+          xmlCandidateBytes = 0;
+        }
+        if (invokeProbeSuffix !== "") {
+          yield* emitText(state, invokeProbeSuffix);
+          invokeProbeSuffix = "";
+        }
+        recoveryEnabled = false;
+      }
+
+      // —— tool calls: integer index → stable block; temp id → real id upgrade. ——
+      for (const tc of delta?.tool_calls ?? []) {
+        let slot = state.toolIndexToBlock.get(tc.index);
+        if (slot === undefined) {
+          const blockIndex = allocBlock(state);
+          slot = {
+            blockIndex,
+            started: false,
+            id: tc.id ?? tempId(blockIndex),
+            name:
+              tc.function?.name !== undefined
+                ? state.toolNameMap.toAnthropic(tc.function.name)
+                : "",
+            argBuffer: "",
+          };
+          state.toolIndexToBlock.set(tc.index, slot);
+        } else {
+          // Upgrade a temp id to the real one and backfill a late-arriving name.
+          if (tc.id !== undefined && tc.id !== "") slot.id = tc.id;
+          if (tc.function?.name !== undefined && tc.function.name !== "")
+            slot.name = state.toolNameMap.toAnthropic(tc.function.name);
+        }
+
+        const args = tc.function?.arguments;
+        if (args !== undefined && args !== "") {
+          // First argument fragment: settle id/name and emit START before any delta
+          // (block start ALWAYS precedes its deltas — no orphan delta, pit #4).
+          if (!slot.started) {
+            slot.started = true;
+            yield {
+              type: "content_block_start",
+              index: slot.blockIndex,
+              content_block: {
+                type: "tool_use",
+                id: clientToolUseId(slot),
+                name: slot.name,
+                input: {},
+              },
+            };
+          }
+          slot.argBuffer += args;
+          yield inputJSONDeltaEvent(slot.blockIndex, args);
+        }
+      }
+
+      // Buffer usage; never billed mid-stream (pit #2). Raw upstream `prompt_tokens` is
+      // the FULL prompt (cached + fresh + cache creation), but mapUsage() expects IR
+      // usage where prompt has ALREADY had cache read/write subtracted (the non-stream
+      // openai.ts path does the same). Read cache details from flat fields OR the real
+      // OpenAI prompt_tokens_details nesting.
+      if (chunk.usage) {
+        const u = chunk.usage;
+        const cached = u.cached_tokens ?? u.prompt_tokens_details?.cached_tokens ?? 0;
+        const cacheCreation =
+          u.cache_creation_tokens ??
+          tokenCount(u.prompt_tokens_details?.cache_creation_tokens) ??
+          tokenCount(u.prompt_tokens_details?.cache_creation_input_tokens) ??
+          tokenCount(u.prompt_tokens_details?.cache_write_tokens) ??
+          0;
+        state.usage = {
+          ...(u.prompt_tokens !== undefined
+            ? { prompt_tokens: Math.max(0, u.prompt_tokens - cached - cacheCreation) }
+            : {}),
+          ...(u.completion_tokens !== undefined ? { completion_tokens: u.completion_tokens } : {}),
+          ...(cached > 0 ? { cached_tokens: cached } : {}),
+          ...(cacheCreation > 0 ? { cache_creation_tokens: cacheCreation } : {}),
+        };
+      }
+      if (choice?.finish_reason != null) state.finishReason = choice.finish_reason;
     }
-    if (choice?.finish_reason != null) state.finishReason = choice.finish_reason;
+  } catch (error) {
+    // Recovery may hold a candidate while waiting for the terminal finish reason.
+    // Never let an upstream failure swallow bytes already received: replay the
+    // candidate/probe as ordinary text before surfacing the same stream error.
+    if (xmlCandidate !== null) {
+      yield* emitText(state, xmlCandidate);
+    } else if (invokeProbeSuffix !== "") {
+      yield* emitText(state, invokeProbeSuffix);
+    }
+    throw error;
   }
 
   // Empty upstream stream (zero chunks): message_start is emitted lazily on the
@@ -532,6 +689,20 @@ export async function* convertOpenAIStreamToAnthropic(
       id: nonEmptyString(options.id),
       model: nonEmptyString(options.model),
     });
+  }
+
+  // Finish-reason is deliberately checked only after the whole OpenAI stream has
+  // drained: providers announce it after the content deltas. If it does not map to
+  // Anthropic tool_use, or parsing/whitelisting rejects the candidate, replay every
+  // buffered byte as text. Partial invoke-prefix probes are never swallowed either.
+  if (xmlCandidate !== null) {
+    const stopIsToolUse = mapStopReason(state.finishReason ?? "").stop_reason === "tool_use";
+    const recovered = stopIsToolUse
+      ? yield* emitRecoveredToolXML(state, xmlCandidate, declaredTools)
+      : false;
+    if (!recovered) yield* emitText(state, xmlCandidate);
+  } else if (invokeProbeSuffix !== "") {
+    yield* emitText(state, invokeProbeSuffix);
   }
 
   // —— Stream end: flush any tool block that never saw an argument fragment, close

--- a/packages/core/src/protocol/anthropic/tool-xml-recovery.test.ts
+++ b/packages/core/src/protocol/anthropic/tool-xml-recovery.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasInvokeStart,
+  invokeStartIndex,
+  invokeStartPrefixSuffixLength,
+  recoverToolCallsFromText,
+} from "./tool-xml-recovery.js";
+
+const tools = (...names: string[]): ReadonlySet<string> => new Set(names);
+
+describe("hasInvokeStart", () => {
+  it("recognizes bare and antml-prefixed invoke starts case-sensitively", () => {
+    expect(hasInvokeStart('<invoke name="Bash">')).toBe(true);
+    expect(hasInvokeStart('<antml:invoke name="Bash">')).toBe(true);
+    expect(hasInvokeStart('<Invoke name="Bash">')).toBe(false);
+    expect(hasInvokeStart("ordinary text")).toBe(false);
+  });
+
+  it("finds complete starts and retains only a still-possible trailing prefix", () => {
+    expect(invokeStartIndex('text <invoke name="Bash">')).toBe(5);
+    expect(invokeStartIndex('text <antml:invoke name="Bash">')).toBe(5);
+    expect(invokeStartPrefixSuffixLength("if (a < b)")).toBe(0);
+    expect(invokeStartPrefixSuffixLength("text <inv")).toBe(4);
+  });
+});
+
+describe("recoverToolCallsFromText", () => {
+  it("recovers one closed, declared invoke", () => {
+    expect(
+      recoverToolCallsFromText(
+        '<invoke name="Bash"><parameter name="command">git status</parameter></invoke>',
+        tools("Bash"),
+      ),
+    ).toEqual([
+      {
+        type: "tool_use",
+        call: { name: "Bash", input: { command: "git status" } },
+      },
+    ]);
+  });
+
+  it("coerces JSON-looking values and preserves other raw strings", () => {
+    const text =
+      '<invoke name="Tool">' +
+      '<parameter name="enabled"> true </parameter>' +
+      '<parameter name="count">-12.5</parameter>' +
+      '<parameter name="missing">null</parameter>' +
+      '<parameter name="items">[1,"two"]</parameter>' +
+      '<parameter name="config">{"nested":true}</parameter>' +
+      '<parameter name="quoted">"Paris"</parameter>' +
+      '<parameter name="word"> Paris </parameter>' +
+      '<parameter name="invalid"> 12oops </parameter>' +
+      "</invoke>";
+
+    const segments = recoverToolCallsFromText(text, tools("Tool"));
+    expect(segments).toEqual([
+      {
+        type: "tool_use",
+        call: {
+          name: "Tool",
+          input: {
+            enabled: true,
+            count: -12.5,
+            missing: null,
+            items: [1, "two"],
+            config: { nested: true },
+            quoted: "Paris",
+            word: " Paris ",
+            invalid: " 12oops ",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("keeps non-finite and unsafe JSON numbers as strings", () => {
+    const text =
+      '<invoke name="Tool">' +
+      '<parameter name="infinite">1e309</parameter>' +
+      '<parameter name="unsafe">9007199254740993</parameter>' +
+      '<parameter name="safe">9007199254740991</parameter>' +
+      "</invoke>";
+
+    expect(recoverToolCallsFromText(text, tools("Tool"))).toEqual([
+      {
+        type: "tool_use",
+        call: {
+          name: "Tool",
+          input: {
+            infinite: "1e309",
+            unsafe: "9007199254740993",
+            safe: 9007199254740991,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("preserves surrounding text in order", () => {
+    expect(
+      recoverToolCallsFromText(
+        'before <invoke name="Bash"><parameter name="command">pwd</parameter></invoke> after',
+        tools("Bash"),
+      ),
+    ).toEqual([
+      { type: "text", text: "before " },
+      { type: "tool_use", call: { name: "Bash", input: { command: "pwd" } } },
+      { type: "text", text: " after" },
+    ]);
+  });
+
+  it("recovers multiple invokes without merging their lazy bodies", () => {
+    const text =
+      '<invoke name="Read"><parameter name="path">a</parameter></invoke>' +
+      '<invoke name="Read"><parameter name="path">b</parameter></invoke>';
+
+    expect(recoverToolCallsFromText(text, tools("Read"))).toEqual([
+      { type: "tool_use", call: { name: "Read", input: { path: "a" } } },
+      { type: "tool_use", call: { name: "Read", input: { path: "b" } } },
+    ]);
+  });
+
+  it("returns null when the only invoke is not whitelisted", () => {
+    const text = '<invoke name="Bash"><parameter name="command">pwd</parameter></invoke>';
+    expect(recoverToolCallsFromText(text, tools("Read"))).toBeNull();
+  });
+
+  it("keeps a non-whitelisted invoke verbatim between recovered invokes", () => {
+    const skipped = '<invoke name="Write"><parameter name="path">x</parameter></invoke>';
+    const text =
+      '<invoke name="Read"><parameter name="path">a</parameter></invoke>' +
+      skipped +
+      '<invoke name="Read"><parameter name="path">b</parameter></invoke>';
+
+    expect(recoverToolCallsFromText(text, tools("Read"))).toEqual([
+      { type: "tool_use", call: { name: "Read", input: { path: "a" } } },
+      { type: "text", text: skipped },
+      { type: "tool_use", call: { name: "Read", input: { path: "b" } } },
+    ]);
+  });
+
+  it("returns null for an unclosed invoke", () => {
+    expect(
+      recoverToolCallsFromText(
+        '<invoke name="Bash"><parameter name="command">pwd</parameter>',
+        tools("Bash"),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for ordinary text and for an empty declared-tool set", () => {
+    expect(recoverToolCallsFromText("ordinary text", tools("Bash"))).toBeNull();
+    expect(recoverToolCallsFromText('<invoke name="Bash"></invoke>', new Set<string>())).toBeNull();
+  });
+
+  it("recovers the antml-prefixed variant", () => {
+    const ns = "antml:";
+    const text =
+      `<${ns}invoke name="Bash">` +
+      `<${ns}parameter name="command">pwd</${ns}parameter>` +
+      `</${ns}invoke>`;
+
+    expect(recoverToolCallsFromText(text, tools("Bash"))).toEqual([
+      { type: "tool_use", call: { name: "Bash", input: { command: "pwd" } } },
+    ]);
+  });
+
+  it("matches declared tool names case-sensitively", () => {
+    const text = '<invoke name="bash"><parameter name="command">pwd</parameter></invoke>';
+    expect(recoverToolCallsFromText(text, tools("Bash"))).toBeNull();
+  });
+
+  it("uses the last duplicate parameter and cannot pollute Object.prototype", () => {
+    const text =
+      '<invoke name="Tool">' +
+      '<parameter name="value">1</parameter>' +
+      '<parameter name="value">2</parameter>' +
+      '<parameter name="__proto__">{"polluted":true}</parameter>' +
+      "</invoke>";
+
+    const segments = recoverToolCallsFromText(text, tools("Tool"));
+    expect(segments).not.toBeNull();
+    const call = segments?.find((segment) => segment.type === "tool_use");
+    expect(call?.type).toBe("tool_use");
+    if (call?.type !== "tool_use") throw new Error("expected recovered tool_use");
+
+    expect(call.call.input.value).toBe(2);
+    expect(Object.hasOwn(call.call.input, "__proto__")).toBe(true);
+    expect(call.call.input.__proto__).toEqual({ polluted: true });
+    expect(Object.getPrototypeOf(call.call.input)).toBeNull();
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+});

--- a/packages/core/src/protocol/anthropic/tool-xml-recovery.ts
+++ b/packages/core/src/protocol/anthropic/tool-xml-recovery.ts
@@ -1,0 +1,150 @@
+export interface RecoveredToolCall {
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export type RecoverySegment =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; call: RecoveredToolCall };
+
+const BARE_INVOKE_START = '<invoke name="';
+const ANTML_INVOKE_START = '<antml:invoke name="';
+const INVOKE_STARTS = [BARE_INVOKE_START, ANTML_INVOKE_START] as const;
+
+// The model-emitted grammar is deliberately narrow: exact lowercase tag names,
+// double-quoted name attributes, and either a consistently bare or antml-prefixed
+// open/close pair. Narrow matching is the whitelist's first false-positive guard.
+function invokePattern(): RegExp {
+  return /<(antml:)?invoke name="([^"]+)">([\s\S]*?)<\/\1invoke>/g;
+}
+
+function parameterPattern(): RegExp {
+  return /<(antml:)?parameter name="([^"]+)">([\s\S]*?)<\/\1parameter>/g;
+}
+
+/** Cheap, case-sensitive gate for the overwhelmingly common no-leak path. */
+export function hasInvokeStart(text: string): boolean {
+  return invokeStartIndex(text) >= 0;
+}
+
+/** First complete opener, or -1. Shared by both streaming recovery paths. */
+export function invokeStartIndex(text: string): number {
+  let first = -1;
+  for (const marker of INVOKE_STARTS) {
+    const index = text.indexOf(marker);
+    if (index >= 0 && (first < 0 || index < first)) first = index;
+  }
+  return first;
+}
+
+/**
+ * Length of the trailing text that could still become a complete opener after
+ * the next delta. Zero means a streaming probe can be released immediately.
+ */
+export function invokeStartPrefixSuffixLength(text: string): number {
+  const max = Math.min(text.length, Math.max(...INVOKE_STARTS.map((marker) => marker.length)) - 1);
+  for (let length = max; length > 0; length -= 1) {
+    const suffix = text.slice(-length);
+    if (INVOKE_STARTS.some((marker) => marker.startsWith(suffix))) return length;
+  }
+  return 0;
+}
+
+function coerceParameterValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  const first = trimmed[0];
+  const looksLikeJson =
+    trimmed === "true" ||
+    trimmed === "false" ||
+    trimmed === "null" ||
+    first === "-" ||
+    first === "{" ||
+    first === "[" ||
+    first === '"' ||
+    (first !== undefined && first >= "0" && first <= "9");
+
+  if (!looksLikeJson) return raw;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    // JSON itself has no Infinity representation, and an unsafe integer would be
+    // rounded before the tool sees it. Preserve those spellings as strings rather
+    // than silently turning an argument into null or a different integer downstream.
+    if (
+      typeof parsed === "number" &&
+      (!Number.isFinite(parsed) || (Number.isInteger(parsed) && !Number.isSafeInteger(parsed)))
+    ) {
+      return raw;
+    }
+    return parsed;
+  } catch {
+    // Invalid JSON-looking text is still a legitimate raw tool argument. Recovery
+    // must never normalize or discard it merely because coercion was unsuccessful.
+    return raw;
+  }
+}
+
+function parseParameters(body: string): Record<string, unknown> {
+  // A null-prototype dictionary makes even the magic `__proto__` spelling a plain
+  // own data key. Duplicate names intentionally assign in source order, so the last
+  // parameter wins without exposing Object.prototype to model-controlled mutation.
+  const input = Object.create(null) as Record<string, unknown>;
+  for (const match of body.matchAll(parameterPattern())) {
+    const name = match[2];
+    const value = match[3];
+    if (name === undefined || value === undefined) continue;
+    input[name] = coerceParameterValue(value);
+  }
+  return input;
+}
+
+function appendText(segments: RecoverySegment[], text: string): void {
+  if (text === "") return;
+  const previous = segments[segments.length - 1];
+  if (previous?.type === "text") {
+    previous.text += text;
+    return;
+  }
+  segments.push({ type: "text", text });
+}
+
+/**
+ * Lift each complete, declared XML invoke into an ordered tool-use segment.
+ * Anything not recovered remains verbatim; null tells callers to retain the
+ * original text object and avoid changing the normal response path at all.
+ */
+export function recoverToolCallsFromText(
+  text: string,
+  declaredTools: ReadonlySet<string>,
+): RecoverySegment[] | null {
+  if (declaredTools.size === 0 || !hasInvokeStart(text)) return null;
+
+  const segments: RecoverySegment[] = [];
+  let cursor = 0;
+  let recovered = 0;
+
+  for (const match of text.matchAll(invokePattern())) {
+    const raw = match[0];
+    const name = match[2];
+    const body = match[3];
+    const index = match.index;
+    if (raw === undefined || name === undefined || body === undefined || index === undefined) {
+      continue;
+    }
+
+    appendText(segments, text.slice(cursor, index));
+    if (declaredTools.has(name)) {
+      segments.push({
+        type: "tool_use",
+        call: { name, input: parseParameters(body) },
+      });
+      recovered += 1;
+    } else {
+      appendText(segments, raw);
+    }
+    cursor = index + raw.length;
+  }
+
+  if (recovered === 0) return null;
+  appendText(segments, text.slice(cursor));
+  return segments;
+}

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -2296,6 +2296,127 @@ describe("createAnthropicClient — nativePassthrough", () => {
     };
   }
 
+  it("recovers a whitelisted XML tool call in a native JSON response when explicitly enabled", async () => {
+    const invoke = [
+      '<invoke name="Bash">',
+      '<parameter name="command">git status</parameter>',
+      '<parameter name="timeout">600000</parameter>',
+      "</invoke>",
+    ].join("\n");
+    const upstream = {
+      id: "msg_xml",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: invoke }],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => jsonResponse(upstream)) as unknown as typeof fetch,
+    });
+
+    const out = await client.nativePassthrough?.(
+      {
+        ...nativeBody(),
+        tools: [{ name: "Bash", input_schema: { type: "object" } }],
+      },
+      { toolCallXmlRecovery: true },
+    );
+
+    expect(out).toMatchObject({
+      stop_reason: "tool_use",
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu_synthetic_0",
+          name: "Bash",
+          input: { command: "git status", timeout: 600000 },
+        },
+      ],
+    });
+  });
+
+  it("does not recover XML when the native JSON already has a structured tool_use", async () => {
+    const upstream = {
+      id: "msg_mixed_tools",
+      type: "message",
+      role: "assistant",
+      content: [
+        { type: "tool_use", id: "toolu_real", name: "Read", input: { file_path: "/tmp/a" } },
+        {
+          type: "text",
+          text: '<invoke name="Bash"><parameter name="command">rm -rf /tmp/a</parameter></invoke>',
+        },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => jsonResponse(upstream)) as unknown as typeof fetch,
+    });
+
+    const out = await client.nativePassthrough?.(
+      {
+        ...nativeBody(),
+        tools: [
+          { name: "Read", input_schema: { type: "object" } },
+          { name: "Bash", input_schema: { type: "object" } },
+        ],
+      },
+      { toolCallXmlRecovery: true },
+    );
+
+    expect(out).toEqual(upstream);
+  });
+
+  it.each([
+    {
+      label: "the request-scoped flag is off",
+      stopReason: "tool_use",
+      toolName: "Bash",
+      flag: false,
+    },
+    {
+      label: "the stop reason is not tool_use",
+      stopReason: "end_turn",
+      toolName: "Bash",
+      flag: true,
+    },
+    {
+      label: "the leaked name is not declared",
+      stopReason: "tool_use",
+      toolName: "Read",
+      flag: true,
+    },
+  ])("leaves native XML JSON untouched when $label", async ({ stopReason, toolName, flag }) => {
+    const invoke = [
+      '<invoke name="Bash">',
+      '<parameter name="command">git status</parameter>',
+      "</invoke>",
+    ].join("\n");
+    const upstream = {
+      id: "msg_xml_guard",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: invoke }],
+      stop_reason: stopReason,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => jsonResponse(upstream)) as unknown as typeof fetch,
+    });
+
+    const out = await client.nativePassthrough?.(
+      { ...nativeBody(), tools: [{ name: toolName, input_schema: { type: "object" } }] },
+      { toolCallXmlRecovery: flag },
+    );
+
+    expect(out).toEqual(upstream);
+  });
+
   it("forwards the native body VERBATIM (no spoof injection, no openai->anthropic mangling)", async () => {
     const body = nativeBody();
     let sentBody: unknown;
@@ -2658,6 +2779,624 @@ describe("createAnthropicClient — nativePassthroughStream", () => {
     });
     return new Response(stream, { status: 200 });
   }
+
+  function sseEvent(type: string, event: Record<string, unknown>): string {
+    return `event: ${type}\ndata: ${JSON.stringify(event)}\n\n`;
+  }
+
+  function parsedSSEEvents(raw: string): Array<Record<string, unknown>> {
+    return raw
+      .split("\n\n")
+      .map((frame) =>
+        frame
+          .split("\n")
+          .find((line) => line.startsWith("data: "))
+          ?.slice(6),
+      )
+      .filter((data): data is string => data !== undefined)
+      .map((data) => JSON.parse(data) as Record<string, unknown>);
+  }
+
+  function mixedEndingSseEvent(type: string, event: Record<string, unknown>): string {
+    // Legal mixed SSE line endings: CRLF closes `event`, LF closes `data`, then
+    // CRLF is the blank-line terminator. The parser must treat all combinations.
+    return `event: ${type}\r\ndata: ${JSON.stringify(event)}\n\r\n`;
+  }
+
+  it("does not buffer ordinary less-than text as an XML candidate", async () => {
+    vi.useFakeTimers();
+    try {
+      const ordinary = sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "if (a < b) return a" },
+      });
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(ordinary));
+          // Deliberately keep the transport open: a false candidate would wait for
+          // the idle timeout instead of releasing this complete ordinary frame.
+        },
+      });
+      const client = createAnthropicClient({
+        config: {
+          baseUrl: "https://api.anthropic.com",
+          apiKey: "sk-static",
+          timeoutMs: 500,
+        },
+        fetch: (async () => new Response(stream, { status: 200 })) as unknown as typeof fetch,
+      });
+      const iterable = client.nativePassthroughStream?.(
+        {
+          ...nativeStreamBody(),
+          tools: [{ name: "Bash", input_schema: { type: "object" } }],
+        },
+        { toolCallXmlRecovery: true },
+      );
+      if (iterable === undefined) throw new Error("native passthrough stream unavailable");
+      const iterator = iterable[Symbol.asyncIterator]();
+      const first = iterator.next();
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(await first).toEqual({ done: false, value: ordinary });
+      await iterator.return?.();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recovers XML split across text deltas and network chunks after the late tool_use stop reason", async () => {
+    const wire = [
+      sseEvent("message_start", {
+        type: "message_start",
+        message: {
+          id: "msg_xml_stream",
+          type: "message",
+          role: "assistant",
+          model: "claude-opus-4-8",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 1 },
+        },
+      }),
+      sseEvent("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "before <in" },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "text_delta",
+          text: 'voke name="Bash"><parameter name="command">git status</parameter></invoke> after',
+        },
+      }),
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+      sseEvent("content_block_start", {
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "text", text: "" },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "text_delta", text: "later block" },
+      }),
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 1 }),
+      sseEvent("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 20 },
+      }),
+      sseEvent("message_stop", { type: "message_stop" }),
+    ].join("");
+    // Split in the middle of both the SSE JSON and the literal XML start token.
+    const cut1 = wire.indexOf("<in") + 2;
+    const cut2 = wire.indexOf("voke name") + 4;
+    const writes = [wire.slice(0, cut1), wire.slice(cut1, cut2), wire.slice(cut2)];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [{ name: "Bash", input_schema: { type: "object" } }],
+      },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    const raw = chunks.join("");
+    expect(raw).not.toContain("<invoke");
+    const events = parsedSSEEvents(raw);
+    const starts = events.filter((event) => event.type === "content_block_start");
+    expect(starts).toEqual([
+      expect.objectContaining({ index: 0, content_block: { type: "text", text: "" } }),
+      expect.objectContaining({
+        index: 1,
+        content_block: expect.objectContaining({
+          type: "tool_use",
+          id: "toolu_synthetic_1",
+          name: "Bash",
+          input: {},
+        }),
+      }),
+      expect.objectContaining({ index: 2, content_block: { type: "text", text: "" } }),
+      expect.objectContaining({ index: 3, content_block: { type: "text", text: "" } }),
+    ]);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "before " },
+        }),
+        expect.objectContaining({
+          type: "content_block_delta",
+          index: 1,
+          delta: { type: "input_json_delta", partial_json: '{"command":"git status"}' },
+        }),
+        expect.objectContaining({
+          type: "content_block_delta",
+          index: 2,
+          delta: { type: "text_delta", text: " after" },
+        }),
+        expect.objectContaining({
+          type: "content_block_delta",
+          index: 3,
+          delta: { type: "text_delta", text: "later block" },
+        }),
+      ]),
+    );
+    const stopIndexes = events
+      .filter((event) => event.type === "content_block_stop")
+      .map((event) => event.index);
+    expect(stopIndexes).toEqual([0, 1, 2, 3]);
+    expect(events.at(-2)).toMatchObject({
+      type: "message_delta",
+      delta: { stop_reason: "tool_use" },
+    });
+    expect(events.at(-1)).toEqual({ type: "message_stop" });
+  });
+
+  it("does not recover XML when the native stream already emitted structured tool_use", async () => {
+    const writes = [
+      sseEvent("message_start", {
+        type: "message_start",
+        message: { id: "m", stop_reason: null, usage: { input_tokens: 1, output_tokens: 1 } },
+      }),
+      sseEvent("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "toolu_real", name: "Read", input: {} },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"file_path":"/tmp/a"}' },
+      }),
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+      sseEvent("content_block_start", {
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "text", text: "" },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 1,
+        delta: {
+          type: "text_delta",
+          text: '<invoke name="Bash"><parameter name="command">rm /tmp/a</parameter></invoke>',
+        },
+      }),
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 1 }),
+      sseEvent("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 2 },
+      }),
+      sseEvent("message_stop", { type: "message_stop" }),
+    ];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [
+          { name: "Read", input_schema: { type: "object" } },
+          { name: "Bash", input_schema: { type: "object" } },
+        ],
+      },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(writes);
+  });
+
+  it("does not recover XML when message_start already carries structured tool_use content", async () => {
+    const writes = [
+      sseEvent("message_start", {
+        type: "message_start",
+        message: {
+          id: "m",
+          content: [{ type: "tool_use", id: "toolu_real", name: "Read", input: {} }],
+          stop_reason: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 1,
+        delta: {
+          type: "text_delta",
+          text: '<invoke name="Bash"><parameter name="command">rm /tmp/a</parameter></invoke>',
+        },
+      }),
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 1 }),
+      sseEvent("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 2 },
+      }),
+      sseEvent("message_stop", { type: "message_stop" }),
+    ];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [
+          { name: "Read", input_schema: { type: "object" } },
+          { name: "Bash", input_schema: { type: "object" } },
+        ],
+      },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(writes);
+  });
+
+  it.each([
+    {
+      label: "message_stop is missing",
+      expectedChunks: 3,
+      terminal: [
+        sseEvent("message_delta", {
+          type: "message_delta",
+          delta: { stop_reason: "tool_use", stop_sequence: null },
+          usage: { output_tokens: 2 },
+        }),
+      ],
+    },
+    {
+      label: "the authorizing delta arrives after message_stop",
+      expectedChunks: 3,
+      terminal: [
+        sseEvent("message_stop", { type: "message_stop" }),
+        sseEvent("message_delta", {
+          type: "message_delta",
+          delta: { stop_reason: "tool_use", stop_sequence: null },
+          usage: { output_tokens: 2 },
+        }),
+      ],
+    },
+  ])("keeps XML raw when $label", async ({ terminal, expectedChunks }) => {
+    const writes = [
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "text_delta",
+          text: '<invoke name="Bash"><parameter name="command">pwd</parameter></invoke>',
+        },
+      }),
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+      ...terminal,
+    ];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [{ name: "Bash", input_schema: { type: "object" } }],
+      },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(writes.slice(0, expectedChunks));
+  });
+
+  it("recovers a valid XML tool call across mixed SSE line endings", async () => {
+    const writes = [
+      mixedEndingSseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "text_delta",
+          text: '<invoke name="Bash"><parameter name="command">pwd</parameter></invoke>',
+        },
+      }),
+      mixedEndingSseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+      mixedEndingSseEvent("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 2 },
+      }),
+      mixedEndingSseEvent("message_stop", { type: "message_stop" }),
+    ];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [{ name: "Bash", input_schema: { type: "object" } }],
+      },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.join("")).not.toContain("<invoke");
+    expect(chunks.join("")).toContain('"type":"tool_use"');
+  });
+
+  it("finalizes recovery at message_stop without waiting for transport EOF", async () => {
+    vi.useFakeTimers();
+    try {
+      const events = [
+        sseEvent("content_block_delta", {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "text_delta",
+            text: '<invoke name="Bash"><parameter name="command">pwd</parameter></invoke>',
+          },
+        }),
+        sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+        sseEvent("message_delta", {
+          type: "message_delta",
+          delta: { stop_reason: "tool_use", stop_sequence: null },
+          usage: { output_tokens: 2 },
+        }),
+        sseEvent("message_stop", { type: "message_stop" }),
+      ];
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const event of events) controller.enqueue(new TextEncoder().encode(event));
+          // Deliberately hold the body open after the protocol terminal event.
+        },
+      });
+      const client = createAnthropicClient({
+        config: {
+          baseUrl: "https://api.anthropic.com",
+          apiKey: "sk-static",
+          timeoutMs: 500,
+        },
+        fetch: (async () => new Response(stream, { status: 200 })) as unknown as typeof fetch,
+      });
+      const chunks: string[] = [];
+      const run = (async () => {
+        for await (const chunk of client.nativePassthroughStream?.(
+          {
+            ...nativeStreamBody(),
+            tools: [{ name: "Bash", input_schema: { type: "object" } }],
+          },
+          { toolCallXmlRecovery: true },
+        ) ?? []) {
+          chunks.push(chunk);
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(500);
+      await run;
+      expect(chunks.join("")).not.toContain("<invoke");
+      expect(chunks.join("")).toContain('"type":"tool_use"');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes candidate chunks unchanged and permanently bypasses after the 1 MiB UTF-8 cap", async () => {
+    const candidate = sseEvent("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: '<invoke name="Bash">' },
+    });
+    // Non-ASCII text proves the guard counts UTF-8 bytes, not UTF-16 code units.
+    const overflow = "界".repeat(350_000);
+    expect(Buffer.byteLength(candidate + overflow, "utf8")).toBeGreaterThan(1024 * 1024);
+    const terminal =
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "text_delta",
+          text: '<parameter name="command">echo safe</parameter></invoke>',
+        },
+      }) +
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }) +
+      sseEvent("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 2 },
+      });
+    const writes = [candidate, overflow, terminal];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [{ name: "Bash", input_schema: { type: "object" } }],
+      },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(writes);
+  });
+
+  it("still finalizes at message_stop after the 1 MiB recovery bypass", async () => {
+    vi.useFakeTimers();
+    try {
+      const candidate = sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: '<invoke name="Bash">' },
+      });
+      const overflow = "界".repeat(350_000);
+      expect(Buffer.byteLength(candidate + overflow, "utf8")).toBeGreaterThan(1024 * 1024);
+      const messageStop = sseEvent("message_stop", { type: "message_stop" });
+      const splitAt = Math.floor(messageStop.length / 2);
+      const writes = [
+        candidate,
+        overflow,
+        messageStop.slice(0, splitAt),
+        messageStop.slice(splitAt),
+      ];
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const write of writes) controller.enqueue(new TextEncoder().encode(write));
+          // Deliberately keep the HTTP body open after the protocol terminal event.
+        },
+      });
+      const client = createAnthropicClient({
+        config: {
+          baseUrl: "https://api.anthropic.com",
+          apiKey: "sk-static",
+          timeoutMs: 500,
+        },
+        fetch: (async () => new Response(stream, { status: 200 })) as unknown as typeof fetch,
+      });
+      const chunks: string[] = [];
+      const run = (async () => {
+        for await (const chunk of client.nativePassthroughStream?.(
+          {
+            ...nativeStreamBody(),
+            tools: [{ name: "Bash", input_schema: { type: "object" } }],
+          },
+          { toolCallXmlRecovery: true },
+        ) ?? []) {
+          chunks.push(chunk);
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(500);
+      await run;
+      expect(chunks).toEqual(writes);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes pending candidate chunks before rethrowing a source error", async () => {
+    const candidate = sseEvent("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: '<invoke name="Bash">' },
+    });
+    const boom = new Error("native stream broke");
+    let reads = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (reads++ === 0) {
+          controller.enqueue(new TextEncoder().encode(candidate));
+        } else {
+          controller.error(boom);
+        }
+      },
+    });
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => new Response(stream, { status: 200 })) as unknown as typeof fetch,
+    });
+    const iterable = client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [{ name: "Bash", input_schema: { type: "object" } }],
+      },
+      { toolCallXmlRecovery: true },
+    );
+    if (iterable === undefined) throw new Error("native passthrough stream unavailable");
+    const iterator = iterable[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toEqual({ done: false, value: candidate });
+    await expect(iterator.next()).rejects.toBe(boom);
+  });
+
+  it("keeps every raw SSE network chunk unchanged when enabled but no XML is present", async () => {
+    const writes = [
+      sseEvent("message_start", {
+        type: "message_start",
+        message: { id: "m", stop_reason: null, usage: { input_tokens: 1, output_tokens: 1 } },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "ordinary text" },
+      }) +
+        sseEvent("message_delta", {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn", stop_sequence: null },
+          usage: { output_tokens: 2 },
+        }),
+      sseEvent("message_stop", { type: "message_stop" }),
+    ];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      {
+        ...nativeStreamBody(),
+        tools: [{ name: "Bash", input_schema: { type: "object" } }],
+      },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(writes);
+  });
 
   it("forwards the native body VERBATIM and yields upstream SSE chunks unchanged", async () => {
     const body = nativeStreamBody();

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -27,6 +27,13 @@ import {
   createAnthropicToolNameMap,
 } from "../protocol/anthropic/response.js";
 import {
+  hasInvokeStart,
+  invokeStartIndex,
+  invokeStartPrefixSuffixLength,
+  type RecoverySegment,
+  recoverToolCallsFromText,
+} from "../protocol/anthropic/tool-xml-recovery.js";
+import {
   applyForcedAnthropicThinking,
   reasoningEffortToAnthropicThinking,
 } from "../protocol/reasoning-effort.js";
@@ -1742,6 +1749,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     // beta/user-agent/auth from the native body's own system[0]/context_management/speed,
     // so the same closure works unchanged on a native body.
     async nativePassthrough(body, opts) {
+      const declaredTools = declaredNativeToolNames(body);
       const { res } = await requestWithRetry(
         body,
         opts?.signal,
@@ -1751,7 +1759,10 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         false,
       );
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      const nativeResponse = (await res.json()) as Record<string, unknown>;
+      return opts?.toolCallXmlRecovery === true
+        ? recoverNativeAnthropicJSON(nativeResponse, declaredTools)
+        : nativeResponse;
     },
 
     async countTokens(req, opts) {
@@ -1769,6 +1780,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     // chatCompletionStream), then the upstream SSE is BYTE-RELAYED unchanged via
     // readAnthropicSSERaw — no SSE re-mapping state machine to mis-translate (principle 8).
     async *nativePassthroughStream(body, opts) {
+      const declaredTools = declaredNativeToolNames(body);
       const { res } = await requestWithRetry(
         body,
         opts?.signal,
@@ -1778,7 +1790,12 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         false,
       );
       if (!res.ok) throw await errorFromResponse(res);
-      yield* readAnthropicSSERaw(res, timeoutMs);
+      const raw = readAnthropicSSERaw(res, timeoutMs);
+      if (opts?.toolCallXmlRecovery !== true || declaredTools.size === 0) {
+        yield* raw;
+        return;
+      }
+      yield* recoverNativeAnthropicSSE(raw, declaredTools);
     },
   };
 }
@@ -1818,6 +1835,541 @@ export async function* readAnthropicSSERaw(
   } finally {
     reader.releaseLock();
   }
+}
+
+function declaredNativeToolNames(input: NativePassthroughInput): ReadonlySet<string> {
+  const tools = nativePassthroughBody(input).tools;
+  if (!Array.isArray(tools)) return new Set();
+  return new Set(
+    tools.flatMap((tool) => {
+      if (tool === null || typeof tool !== "object" || Array.isArray(tool)) return [];
+      const name = (tool as { name?: unknown }).name;
+      return typeof name === "string" && name.length > 0 ? [name] : [];
+    }),
+  );
+}
+
+function recoveredToolUseBlock(
+  segment: Extract<RecoverySegment, { type: "tool_use" }>,
+  ordinal: number,
+) {
+  return {
+    type: "tool_use" as const,
+    // Stable under replay/cache hits and aligned with stream.ts's existing
+    // `toolu_synthetic_<blockIndex>` convention.
+    id: `toolu_synthetic_${ordinal}`,
+    name: segment.call.name,
+    input: segment.call.input,
+  };
+}
+
+/**
+ * Recover the non-streaming sibling of native passthrough without weakening the
+ * byte-faithful common path. The caller has already proved the request-scoped flag;
+ * this helper additionally requires Anthropic's own tool_use terminal signal and a
+ * declared request tool before replacing any text block.
+ */
+function recoverNativeAnthropicJSON(
+  response: Record<string, unknown>,
+  declaredTools: ReadonlySet<string>,
+): Record<string, unknown> {
+  if (response.stop_reason !== "tool_use" || declaredTools.size === 0) return response;
+  const content = response.content;
+  if (!Array.isArray(content)) return response;
+  // `stop_reason` is message-scoped. If Anthropic already emitted a real tool_use,
+  // that block may be the reason for the terminal signal; converting XML-looking
+  // prose as a second call would create duplicate execution.
+  if (
+    content.some(
+      (block) =>
+        block !== null &&
+        typeof block === "object" &&
+        !Array.isArray(block) &&
+        (block as { type?: unknown }).type === "tool_use",
+    )
+  ) {
+    return response;
+  }
+
+  let recovered = false;
+  const nextContent: unknown[] = [];
+  for (const rawBlock of content) {
+    if (rawBlock === null || typeof rawBlock !== "object" || Array.isArray(rawBlock)) {
+      nextContent.push(rawBlock);
+      continue;
+    }
+    const block = rawBlock as Record<string, unknown>;
+    if (block.type !== "text" || typeof block.text !== "string") {
+      nextContent.push(rawBlock);
+      continue;
+    }
+    const segments = recoverToolCallsFromText(block.text, declaredTools);
+    if (segments === null) {
+      nextContent.push(rawBlock);
+      continue;
+    }
+    recovered = true;
+    for (const segment of segments) {
+      if (segment.type === "text") nextContent.push({ ...block, text: segment.text });
+      else nextContent.push(recoveredToolUseBlock(segment, nextContent.length));
+    }
+  }
+  return recovered ? { ...response, content: nextContent } : response;
+}
+
+interface ParsedRawSSEFrame {
+  raw: string;
+  start: number;
+  end: number;
+  event: Record<string, unknown> | null;
+}
+
+function nextSSEFrameEnd(raw: string, from: number): number {
+  const lineEndingLength = (index: number): number => {
+    if (raw[index] === "\r") return raw[index + 1] === "\n" ? 2 : 1;
+    return raw[index] === "\n" ? 1 : 0;
+  };
+  for (let i = from; i < raw.length; i++) {
+    const first = lineEndingLength(i);
+    if (first === 0) continue;
+    const second = lineEndingLength(i + first);
+    if (second > 0) return i + first + second;
+    i += first - 1;
+  }
+  return -1;
+}
+
+function eventFromRawSSEFrame(raw: string): Record<string, unknown> | null {
+  const dataLines: string[] = [];
+  for (const line of raw.replace(/(?:\r\n|\r|\n){2}$/, "").split(/\r\n|\r|\n/)) {
+    if (!line.startsWith("data:")) continue;
+    dataLines.push(line.slice(5).replace(/^ /, ""));
+  }
+  if (dataLines.length === 0) return null;
+  for (const candidate of [dataLines.join("\n"), dataLines.join("")]) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Try the legal compatibility concatenation before treating this as opaque SSE.
+    }
+  }
+  return null;
+}
+
+function completeRawSSEFrames(raw: string): { frames: ParsedRawSSEFrame[]; end: number } {
+  const frames: ParsedRawSSEFrame[] = [];
+  let start = 0;
+  while (start < raw.length) {
+    const end = nextSSEFrameEnd(raw, start);
+    if (end === -1) break;
+    const frameRaw = raw.slice(start, end);
+    frames.push({ raw: frameRaw, start, end, event: eventFromRawSSEFrame(frameRaw) });
+    start = end;
+  }
+  return { frames, end: start };
+}
+
+function textDeltaOf(event: Record<string, unknown> | null): string | null {
+  if (event?.type !== "content_block_delta") return null;
+  const delta = event.delta;
+  if (delta === null || typeof delta !== "object" || Array.isArray(delta)) return null;
+  const typed = delta as { type?: unknown; text?: unknown };
+  return typed.type === "text_delta" && typeof typed.text === "string" ? typed.text : null;
+}
+
+function containsStructuredToolUse(event: Record<string, unknown> | null): boolean {
+  if (event?.type === "content_block_start") {
+    const block = event.content_block;
+    return (
+      block !== null &&
+      typeof block === "object" &&
+      !Array.isArray(block) &&
+      (block as { type?: unknown }).type === "tool_use"
+    );
+  }
+  if (event?.type !== "message_start") return false;
+  const message = event.message;
+  if (message === null || typeof message !== "object" || Array.isArray(message)) return false;
+  const content = (message as { content?: unknown }).content;
+  return (
+    Array.isArray(content) &&
+    content.some(
+      (block) =>
+        block !== null &&
+        typeof block === "object" &&
+        !Array.isArray(block) &&
+        (block as { type?: unknown }).type === "tool_use",
+    )
+  );
+}
+
+type InvokeSignal =
+  | { kind: "none" }
+  | { kind: "probe"; start: number }
+  | { kind: "candidate"; start: number };
+
+// Scan complete text-delta frames for either a full invoke opener or only the
+// shortest trailing prefix that can still become one in the next delta. Ordinary
+// `<` text is not a signal and therefore remains on the immediate raw-chunk path.
+function invokeSignal(frames: readonly ParsedRawSSEFrame[]): InvokeSignal {
+  let suffix = "";
+  let probeStart = -1;
+  for (const frame of frames) {
+    const text = textDeltaOf(frame.event);
+    if (text === null) continue;
+    const combined = suffix + text;
+    const startIndex = invokeStartIndex(combined);
+    if (startIndex >= 0) {
+      return {
+        kind: "candidate",
+        start: probeStart >= 0 && startIndex < suffix.length ? probeStart : frame.start,
+      };
+    }
+    const suffixLength = invokeStartPrefixSuffixLength(combined);
+    if (suffixLength === 0) {
+      suffix = "";
+      probeStart = -1;
+      continue;
+    }
+    if (probeStart < 0 || suffixLength <= text.length) probeStart = frame.start;
+    suffix = combined.slice(-suffixLength);
+  }
+  return probeStart >= 0 ? { kind: "probe", start: probeStart } : { kind: "none" };
+}
+
+function flushableChunkCount(chunks: readonly string[], safeEnd: number): number {
+  let total = 0;
+  let count = 0;
+  for (const chunk of chunks) {
+    if (total + chunk.length > safeEnd) break;
+    total += chunk.length;
+    count += 1;
+  }
+  return count;
+}
+
+function chunkPrefixLength(chunks: readonly string[], count: number): number {
+  let total = 0;
+  for (let i = 0; i < count; i++) total += chunks[i]?.length ?? 0;
+  return total;
+}
+
+const BYPASS_TERMINAL_PROBE_MAX_CHARS = 64 * 1024;
+
+function boundedIncompleteSSETail(raw: string): string {
+  const parsed = completeRawSSEFrames(raw);
+  const incomplete = raw.slice(parsed.end);
+  // Recovery has already been disabled, so this buffer exists only to recognize a
+  // later protocol terminal frame. Keep enough trailing source for a split frame,
+  // but never let a malformed frame recreate the unbounded-buffer problem.
+  return incomplete.length > BYPASS_TERMINAL_PROBE_MAX_CHARS
+    ? incomplete.slice(-BYPASS_TERMINAL_PROBE_MAX_CHARS)
+    : incomplete;
+}
+
+function advanceBypassTerminalProbe(
+  incompleteTail: string,
+  chunk: string,
+): { incompleteTail: string; messageStopSeen: boolean } {
+  const raw = incompleteTail + chunk;
+  const parsed = completeRawSSEFrames(raw);
+  return {
+    incompleteTail: boundedIncompleteSSETail(raw),
+    messageStopSeen: parsed.frames.some((frame) => frame.event?.type === "message_stop"),
+  };
+}
+
+function numericEventIndex(event: Record<string, unknown>): number | null {
+  return typeof event.index === "number" && Number.isInteger(event.index) && event.index >= 0
+    ? event.index
+    : null;
+}
+
+function withEventIndex(event: Record<string, unknown>, index: number): Record<string, unknown> {
+  return { ...event, index };
+}
+
+function encodedSSEEvent(event: Record<string, unknown>): string {
+  const type = typeof event.type === "string" ? event.type : "message";
+  return `event: ${type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+function generatedTextDelta(index: number, text: string): string {
+  return encodedSSEEvent({
+    type: "content_block_delta",
+    index,
+    delta: { type: "text_delta", text },
+  });
+}
+
+function generatedBlockStop(index: number): string {
+  return encodedSSEEvent({ type: "content_block_stop", index });
+}
+
+function emitRecoveredSegments(
+  originalIndex: number,
+  segments: readonly RecoverySegment[],
+): { raw: string; extraBlocks: number } {
+  let raw = "";
+  let afterFirstTool = false;
+  let nextIndex = originalIndex + 1;
+
+  for (const segment of segments) {
+    if (segment.type === "text") {
+      if (!afterFirstTool) {
+        raw += generatedTextDelta(originalIndex, segment.text);
+      } else {
+        const index = nextIndex++;
+        raw += encodedSSEEvent({
+          type: "content_block_start",
+          index,
+          content_block: { type: "text", text: "" },
+        });
+        raw += generatedTextDelta(index, segment.text);
+        raw += generatedBlockStop(index);
+      }
+      continue;
+    }
+
+    if (!afterFirstTool) {
+      raw += generatedBlockStop(originalIndex);
+      afterFirstTool = true;
+    }
+    const index = nextIndex++;
+    const block = recoveredToolUseBlock(segment, index);
+    raw += encodedSSEEvent({
+      type: "content_block_start",
+      index,
+      content_block: { ...block, input: {} },
+    });
+    raw += encodedSSEEvent({
+      type: "content_block_delta",
+      index,
+      delta: { type: "input_json_delta", partial_json: JSON.stringify(block.input) },
+    });
+    raw += generatedBlockStop(index);
+  }
+
+  return { raw, extraBlocks: nextIndex - (originalIndex + 1) };
+}
+
+/** Return null unless the buffered tail proves every hard recovery signal. */
+function rewriteNativeAnthropicSSETail(
+  raw: string,
+  declaredTools: ReadonlySet<string>,
+  structuredToolUseAlreadySeen: boolean,
+): string | null {
+  const parsed = completeRawSSEFrames(raw);
+  // A partial/malformed transport tail is never a reason to alter bytes.
+  if (parsed.end !== raw.length) return null;
+  if (
+    structuredToolUseAlreadySeen ||
+    parsed.frames.some((frame) => containsStructuredToolUse(frame.event))
+  ) {
+    return null;
+  }
+
+  const messageStopIndex = parsed.frames.findIndex((frame) => frame.event?.type === "message_stop");
+  if (messageStopIndex < 0) return null;
+  // The first message_stop terminates this response. A later semantic frame must
+  // never authorize or be index-shifted as part of the earlier message.
+  if (
+    parsed.frames
+      .slice(messageStopIndex + 1)
+      .some((frame) => frame.event !== null && frame.event.type !== "ping")
+  ) {
+    return null;
+  }
+
+  let terminalToolUseDeltaIndex = -1;
+  for (let index = 0; index < messageStopIndex; index += 1) {
+    const event = parsed.frames[index]?.event;
+    if (event?.type !== "message_delta") continue;
+    const delta = event.delta;
+    if (
+      delta !== null &&
+      typeof delta === "object" &&
+      !Array.isArray(delta) &&
+      (delta as { stop_reason?: unknown }).stop_reason === "tool_use"
+    ) {
+      terminalToolUseDeltaIndex = index;
+    }
+  }
+  if (terminalToolUseDeltaIndex < 0) return null;
+  // Only ping/comment/opaque frames may sit between the terminal delta and stop.
+  if (
+    parsed.frames
+      .slice(terminalToolUseDeltaIndex + 1, messageStopIndex)
+      .some((frame) => frame.event !== null && frame.event.type !== "ping")
+  ) {
+    return null;
+  }
+  const lastBlockStopIndex = parsed.frames.findLastIndex(
+    (frame, index) =>
+      index < terminalToolUseDeltaIndex && frame.event?.type === "content_block_stop",
+  );
+  if (lastBlockStopIndex < 0) return null;
+
+  const textByIndex = new Map<number, string>();
+  const stoppedIndexes = new Set<number>();
+  for (const frame of parsed.frames) {
+    if (frame.event === null) continue;
+    const index = numericEventIndex(frame.event);
+    if (index === null) continue;
+    const text = textDeltaOf(frame.event);
+    if (text !== null) textByIndex.set(index, (textByIndex.get(index) ?? "") + text);
+    if (frame.event.type === "content_block_stop") stoppedIndexes.add(index);
+  }
+
+  const recoveredByIndex = new Map<number, RecoverySegment[]>();
+  for (const [index, text] of textByIndex) {
+    if (!stoppedIndexes.has(index) || (!hasInvokeStart(text) && !text.includes("<"))) continue;
+    const segments = recoverToolCallsFromText(text, declaredTools);
+    if (segments !== null) recoveredByIndex.set(index, segments);
+  }
+  if (recoveredByIndex.size === 0) return null;
+
+  let out = "";
+  let indexOffset = 0;
+  for (const frame of parsed.frames) {
+    const event = frame.event;
+    if (event === null) {
+      out += frame.raw;
+      continue;
+    }
+    const sourceIndex = numericEventIndex(event);
+    const recovered = sourceIndex === null ? undefined : recoveredByIndex.get(sourceIndex);
+    if (
+      recovered !== undefined &&
+      event.type === "content_block_delta" &&
+      textDeltaOf(event) !== null
+    ) {
+      continue;
+    }
+    if (sourceIndex !== null && recovered !== undefined && event.type === "content_block_stop") {
+      const emitted = emitRecoveredSegments(sourceIndex + indexOffset, recovered);
+      out += emitted.raw;
+      indexOffset += emitted.extraBlocks;
+      continue;
+    }
+    if (sourceIndex !== null && indexOffset > 0) {
+      out += encodedSSEEvent(withEventIndex(event, sourceIndex + indexOffset));
+    } else {
+      out += frame.raw;
+    }
+  }
+  return out;
+}
+
+/**
+ * Candidate-gated Anthropic SSE recovery. Complete safe frames are released in the
+ * exact original network chunks. Once a possible XML start appears, only that tail
+ * is held until Anthropic's later message_delta proves `stop_reason:tool_use`; a miss
+ * flushes the original chunks unchanged. The source remains readAnthropicSSERaw, so
+ * its upstream idle/stall deadline continues to guard every network read.
+ */
+async function* recoverNativeAnthropicSSE(
+  source: AsyncIterable<string>,
+  declaredTools: ReadonlySet<string>,
+): AsyncGenerator<string> {
+  const candidateBufferLimitBytes = 1024 * 1024;
+  let pendingChunks: string[] = [];
+  let pendingRaw = "";
+  let candidate = false;
+  let permanentlyBypassed = false;
+  let bypassTerminalProbe = "";
+  let structuredToolUseSeen = false;
+
+  try {
+    for await (const chunk of source) {
+      if (permanentlyBypassed) {
+        yield chunk;
+        const terminal = advanceBypassTerminalProbe(bypassTerminalProbe, chunk);
+        bypassTerminalProbe = terminal.incompleteTail;
+        if (terminal.messageStopSeen) return;
+        continue;
+      }
+
+      pendingChunks.push(chunk);
+      pendingRaw += chunk;
+      let messageStopSeen = false;
+      if (!candidate) {
+        const parsed = completeRawSSEFrames(pendingRaw);
+        if (parsed.frames.some((frame) => containsStructuredToolUse(frame.event))) {
+          structuredToolUseSeen = true;
+        }
+        messageStopSeen = parsed.frames.some((frame) => frame.event?.type === "message_stop");
+        const signal = invokeSignal(parsed.frames);
+        const safeEnd = signal.kind === "none" ? parsed.end : signal.start;
+        const flushCount = flushableChunkCount(pendingChunks, safeEnd);
+        if (flushCount > 0) {
+          const flushed = pendingChunks.slice(0, flushCount);
+          const consumed = chunkPrefixLength(pendingChunks, flushCount);
+          pendingChunks = pendingChunks.slice(flushCount);
+          pendingRaw = pendingRaw.slice(consumed);
+          for (const original of flushed) yield original;
+        }
+        if (signal.kind === "candidate") candidate = true;
+      } else {
+        messageStopSeen = completeRawSSEFrames(pendingRaw).frames.some(
+          (frame) => frame.event?.type === "message_stop",
+        );
+      }
+
+      if (Buffer.byteLength(pendingRaw, "utf8") > candidateBufferLimitBytes) {
+        // The response is provider-controlled but may still be adversarially induced.
+        // Bound both the partial-frame probe and a confirmed candidate; once exceeded,
+        // never attempt recovery again because retained bytes are forwarded verbatim.
+        bypassTerminalProbe = boundedIncompleteSSETail(pendingRaw);
+        for (const original of pendingChunks) yield original;
+        pendingChunks = [];
+        pendingRaw = "";
+        candidate = false;
+        permanentlyBypassed = true;
+        if (messageStopSeen) return;
+        continue;
+      }
+
+      // message_stop, not transport EOF, is Anthropic's terminal boundary. Finalize
+      // immediately so a provider that delays closing the HTTP body cannot turn a
+      // completed response into an idle timeout (same invariant as translateAnthropicSSE).
+      if (messageStopSeen) {
+        const rewritten = candidate
+          ? rewriteNativeAnthropicSSETail(pendingRaw, declaredTools, structuredToolUseSeen)
+          : null;
+        if (rewritten !== null) {
+          yield rewritten;
+        } else {
+          for (const original of pendingChunks) yield original;
+        }
+        return;
+      }
+    }
+  } catch (error) {
+    // The filter may have delayed complete network chunks while waiting for the
+    // terminal signal. Preserve byte delivery order before surfacing the same source
+    // failure; otherwise enabling recovery would silently eat already-received bytes.
+    for (const original of pendingChunks) yield original;
+    pendingChunks = [];
+    pendingRaw = "";
+    throw error;
+  }
+
+  if (candidate) {
+    const rewritten = rewriteNativeAnthropicSSETail(
+      pendingRaw,
+      declaredTools,
+      structuredToolUseSeen,
+    );
+    if (rewritten !== null) {
+      yield rewritten;
+      return;
+    }
+  }
+  for (const original of pendingChunks) yield original;
 }
 
 // ── streaming translation: Anthropic SSE -> OpenAI-Chat SSE strings ──────────

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -71,6 +71,11 @@ export type NativeProtocolProfile =
 export interface ProviderCallOptions {
   signal?: AbortSignal;
   captureUpstream?: (wireBody: string) => void;
+  /** Request-scoped Anthropic defensive recovery switch. The gateway owns the live
+   * runtime setting and passes its current value per attempt; provider clients keep
+   * the default OFF when the option is absent so unrelated callers never opt in by
+   * accident. */
+  toolCallXmlRecovery?: boolean;
   // Per-call response metadata channel. Codex Responses uses this for request-scoped
   // headers such as x-codex-turn-state and x-request-id; provider-level observers may
   // still subscribe separately. Hooks are fail-open and must not affect the response.

--- a/packages/core/src/settings/runtime-settings.test.ts
+++ b/packages/core/src/settings/runtime-settings.test.ts
@@ -34,6 +34,7 @@ describe("defaultSettingsFromConfig", () => {
     expect(defaultSettingsFromConfig(cfg(true))).toEqual({
       capture_payloads: true,
       native_protocol_passthrough: true,
+      tool_call_xml_recovery: true,
       visual_context_compression: "off",
       payload_retention_days: 30,
       rate_limit_enabled: true,

--- a/packages/shared/src/config/runtime-settings.schema.test.ts
+++ b/packages/shared/src/config/runtime-settings.schema.test.ts
@@ -11,6 +11,7 @@ describe("RuntimeSettingsSchema", () => {
     const parsed = RuntimeSettingsSchema.parse({});
     expect(parsed.capture_payloads).toBe(true);
     expect(parsed.native_protocol_passthrough).toBe(true);
+    expect(parsed.tool_call_xml_recovery).toBe(true);
     expect(parsed.visual_context_compression).toBe("off");
     expect(parsed.payload_retention_days).toBe(30);
     expect(parsed.rate_limit_enabled).toBe(false);
@@ -23,6 +24,7 @@ describe("RuntimeSettingsSchema", () => {
     const parsed = RuntimeSettingsSchema.parse({
       capture_payloads: false,
       native_protocol_passthrough: false,
+      tool_call_xml_recovery: false,
       visual_context_compression: "observe",
       payload_retention_days: 7,
       rate_limit_enabled: true,
@@ -33,6 +35,7 @@ describe("RuntimeSettingsSchema", () => {
     expect(parsed).toEqual({
       capture_payloads: false,
       native_protocol_passthrough: false,
+      tool_call_xml_recovery: false,
       visual_context_compression: "observe",
       payload_retention_days: 7,
       rate_limit_enabled: true,

--- a/packages/shared/src/config/runtime-settings.schema.ts
+++ b/packages/shared/src/config/runtime-settings.schema.ts
@@ -34,6 +34,10 @@ export const RuntimeSettingsSchema = z.object({
   // back to translation for openai_chat (lingua franca) and cross-protocol attempts,
   // so a later heterogeneous fallback can translate if reached.
   native_protocol_passthrough: z.boolean().default(true),
+  // Recover malformed upstream tool calls leaked as literal Anthropic <invoke>
+  // XML. Default ON because the recovery is guarded by the upstream tool-use stop
+  // signal, a closed block, and the request's declared-tool whitelist.
+  tool_call_xml_recovery: z.boolean().default(true),
   // Visual context compression renders bulky Anthropic-native context into image
   // blocks before an upstream call. Default OFF because the technique is lossy:
   // dense images are useful for gist/context, not exact byte recall. `observe`


### PR DESCRIPTION
## Summary
- recover malformed Anthropic tool-call XML into structured tool-use blocks across native SSE/JSON and translated SSE/JSON responses
- require the tool-use terminal signal, complete markup, request-declared tool names, and no existing structured tool call
- add bounded streaming buffers, deterministic synthetic IDs, safe bypass behavior, and the default-on `tool_call_xml_recovery` runtime rollback setting

## Validation
- `CI=true pnpm exec vitest run` on 11 targeted files: 541 passed
- `pnpm typecheck`
- `pnpm --filter @helm/admin check`
- `pnpm lint` (existing ci-workflow warnings only)
- `pnpm build`
- `git diff --check`

## Release assessment
Backward-compatible correctness fix with no migration or dependency changes. Recommend a patch release after merge.