### PR TITLE
chore(release): v0.27.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.19",
+  "version": "0.27.20",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from `0.27.19` to `0.27.20`
- publish the backward-compatible Anthropic tool-call XML recovery fix merged in PR #590

## Release assessment
Patch release: protocol correctness and operational rollback controls only; no database migration, dependency, schema-breaking, or configuration-file changes.

## Validation
- feature PR #590 passed required verify, e2e, and docker checks
- this PR is intentionally version-only; protected CI must pass before merge