### PR TITLE
fix(codex): recover native transport failures

### DIFF
--- a/apps/gateway/src/oauth/codex-model-catalog.test.ts
+++ b/apps/gateway/src/oauth/codex-model-catalog.test.ts
@@ -360,7 +360,7 @@ describe("createCodexModelCatalog", () => {
     expect(catalog.listRoutable(["not-entitled"])).toBeNull();
   });
 
-  it("advertises a conservative compact threshold without replacing an upstream value", async () => {
+  it("advertises Codex-compatible derived and clamped compact thresholds", async () => {
     const catalog = createCodexModelCatalog({ cache: fakeCache(null) });
     await catalog.load(
       KEY,
@@ -373,6 +373,16 @@ describe("createCodexModelCatalog", () => {
           max_context_window: 80_000,
           auto_compact_token_limit: null,
         }),
+        model("max-window-only", 5, {
+          context_window: null,
+          max_context_window: 1_000_000,
+          auto_compact_token_limit: null,
+        }),
+        model("oversized-explicit-limit", 6, {
+          context_window: 100_000,
+          max_context_window: 100_000,
+          auto_compact_token_limit: 95_000,
+        }),
       ]),
     );
 
@@ -381,6 +391,8 @@ describe("createCodexModelCatalog", () => {
       "gpt-5.6-terra",
       "gpt-5.6-luna",
       "small-future-model",
+      "max-window-only",
+      "oversized-explicit-limit",
     ]);
 
     expect(
@@ -393,6 +405,8 @@ describe("createCodexModelCatalog", () => {
       { slug: "gpt-5.6-terra", auto_compact_token_limit: 334_800 },
       { slug: "gpt-5.6-luna", auto_compact_token_limit: 250_000 },
       { slug: "small-future-model", auto_compact_token_limit: 72_000 },
+      { slug: "max-window-only", auto_compact_token_limit: 900_000 },
+      { slug: "oversized-explicit-limit", auto_compact_token_limit: 90_000 },
     ]);
   });
 

--- a/apps/gateway/src/oauth/codex-model-catalog.test.ts
+++ b/apps/gateway/src/oauth/codex-model-catalog.test.ts
@@ -360,6 +360,42 @@ describe("createCodexModelCatalog", () => {
     expect(catalog.listRoutable(["not-entitled"])).toBeNull();
   });
 
+  it("advertises a conservative compact threshold without replacing an upstream value", async () => {
+    const catalog = createCodexModelCatalog({ cache: fakeCache(null) });
+    await catalog.load(
+      KEY,
+      remote([
+        model("gpt-5.6-sol", 1, { auto_compact_token_limit: null }),
+        model("gpt-5.6-terra", 2, { auto_compact_token_limit: undefined }),
+        model("gpt-5.6-luna", 3, { auto_compact_token_limit: 250_000 }),
+        model("small-future-model", 4, {
+          context_window: 80_000,
+          max_context_window: 80_000,
+          auto_compact_token_limit: null,
+        }),
+      ]),
+    );
+
+    const result = catalog.listRoutable([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "small-future-model",
+    ]);
+
+    expect(
+      result?.models.map(({ slug, auto_compact_token_limit }) => ({
+        slug,
+        auto_compact_token_limit,
+      })),
+    ).toEqual([
+      { slug: "gpt-5.6-sol", auto_compact_token_limit: 334_800 },
+      { slug: "gpt-5.6-terra", auto_compact_token_limit: 334_800 },
+      { slug: "gpt-5.6-luna", auto_compact_token_limit: 250_000 },
+      { slug: "small-future-model", auto_compact_token_limit: 72_000 },
+    ]);
+  });
+
   it("does not advertise reasoning-inclusive accounting when any routable account is unknown", async () => {
     const catalog = createCodexModelCatalog({ cache: fakeCache(null), bundledModels: [] });
     const secondKey = { ...KEY, account: "team", accountIdentity: "acc_2" };

--- a/apps/gateway/src/oauth/codex-model-catalog.ts
+++ b/apps/gateway/src/oauth/codex-model-catalog.ts
@@ -81,15 +81,19 @@ export function defaultCodexAutoCompactTokenLimit(contextWindow: number): number
 }
 
 function withDefaultAutoCompactTokenLimit(model: CodexModelInfo): CodexModelInfo {
-  if (
-    model.auto_compact_token_limit != null ||
-    !model.context_window ||
-    model.context_window <= 0
-  ) {
-    return model;
-  }
-  const autoCompactTokenLimit = defaultCodexAutoCompactTokenLimit(model.context_window);
+  const resolvedContextWindow =
+    typeof model.context_window === "number" && model.context_window > 0
+      ? model.context_window
+      : model.max_context_window;
+  if (typeof resolvedContextWindow !== "number" || resolvedContextWindow <= 0) return model;
+  const derivedLimit = defaultCodexAutoCompactTokenLimit(resolvedContextWindow);
+  if (derivedLimit === null) return model;
+  const autoCompactTokenLimit =
+    model.auto_compact_token_limit == null
+      ? derivedLimit
+      : Math.min(model.auto_compact_token_limit, derivedLimit);
   if (autoCompactTokenLimit === null) return model;
+  if (autoCompactTokenLimit === model.auto_compact_token_limit) return model;
   return { ...model, auto_compact_token_limit: autoCompactTokenLimit };
 }
 

--- a/apps/gateway/src/oauth/codex-model-catalog.ts
+++ b/apps/gateway/src/oauth/codex-model-catalog.ts
@@ -15,6 +15,11 @@ import type {
 
 export const DEFAULT_CODEX_MODEL_CATALOG_MAX_ENTRIES = 64;
 
+// Codex core derives an omitted auto-compact limit as 90% of the resolved
+// context window. Materialize the same value for clients that consume Helm's
+// filtered catalog without reimplementing that fallback.
+export const DEFAULT_CODEX_AUTO_COMPACT_PERCENT = 90;
+
 export interface CodexModelCatalogSnapshot {
   models: CodexModelInfo[];
   etag: string | null;
@@ -68,6 +73,24 @@ function parseModels(models: readonly unknown[]): CodexModelInfo[] | null {
     parsed.push(result.data);
   }
   return parsed;
+}
+
+export function defaultCodexAutoCompactTokenLimit(contextWindow: number): number | null {
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) return null;
+  return Math.max(1, Math.floor((contextWindow * DEFAULT_CODEX_AUTO_COMPACT_PERCENT) / 100));
+}
+
+function withDefaultAutoCompactTokenLimit(model: CodexModelInfo): CodexModelInfo {
+  if (
+    model.auto_compact_token_limit != null ||
+    !model.context_window ||
+    model.context_window <= 0
+  ) {
+    return model;
+  }
+  const autoCompactTokenLimit = defaultCodexAutoCompactTokenLimit(model.context_window);
+  if (autoCompactTokenLimit === null) return model;
+  return { ...model, auto_compact_token_limit: autoCompactTokenLimit };
 }
 
 function sameCatalog(
@@ -289,9 +312,11 @@ export function createCodexModelCatalog(options: CodexModelCatalogOptions): Code
         if (source === undefined) continue;
         selected.set(slug, slug === source.slug ? source : { ...source, slug });
       }
-      const combined = [...selected.values()].sort(
-        (left, right) => left.priority - right.priority || left.slug.localeCompare(right.slug),
-      );
+      const combined = [...selected.values()]
+        .sort(
+          (left, right) => left.priority - right.priority || left.slug.localeCompare(right.slug),
+        )
+        .map(withDefaultAutoCompactTokenLimit);
       if (combined.length === 0) return null;
       const digest = createHash("sha256").update(JSON.stringify(combined)).digest("hex");
       return {

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -950,6 +950,56 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.attempts[0]?.skip_reason).toBe("responses_native_items_cross_protocol_blocked");
   });
 
+  it("blocks Codex-native Responses items on xAI Responses targets", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "should-not-call" }),
+      chatCompletionStream: vi.fn(),
+      nativeProtocolProfile: "generic_openai_responses",
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["xai", provider]]),
+      registry: {
+        resolve(alias: string) {
+          if (alias !== "xai/grok-4.5") {
+            return { ok: false as const, error: { kind: "unknown_alias" as const, alias } };
+          }
+          return {
+            ok: true as const,
+            value: {
+              alias,
+              providerName: "xai",
+              providerModel: "grok-4.5",
+              baseUrl: "https://example.test",
+              apiKeyEnv: "XAI_API_KEY",
+              targetProviderProtocol: "openai_responses" as const,
+              providerRequiresCompatibilityRewrite: false,
+            },
+          };
+        },
+        list: () => ["xai/grok-4.5"],
+      },
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["xai/grok-4.5"]),
+      req({
+        protocol: "openai_responses",
+        provider_raw: {
+          unknown_items: [{ type: "agent_message", content: [] }],
+        },
+      }),
+    );
+
+    expect(provider.chatCompletion).not.toHaveBeenCalled();
+    expect(out.final.status).toBe("error");
+    expect(out.attempts[0]?.skip_reason).toBe("responses_native_items_provider_incompatible");
+  });
+
   it("does not forward top-level cache_control to non-Anthropic target protocols", async () => {
     const provider = {
       chatCompletion: vi.fn().mockResolvedValue({ id: "ok", usage: {} }),

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -4,6 +4,7 @@ import {
   createCircuitBreaker,
   createGeminiClient,
   createGenericOpenAIResponsesClient,
+  createOAuthPoolClient,
   TokenRefreshError,
   UpstreamError,
 } from "@helm/core";
@@ -951,11 +952,21 @@ describe("createExecute — gateway execution adapter", () => {
   });
 
   it("blocks Codex-native Responses items on xAI Responses targets", async () => {
-    const provider = {
+    const memberClient = {
       chatCompletion: vi.fn().mockResolvedValue({ id: "should-not-call" }),
       chatCompletionStream: vi.fn(),
       nativeProtocolProfile: "generic_openai_responses",
     } as unknown as ProviderClient;
+    const provider = createOAuthPoolClient({
+      members: [
+        {
+          account: "xai-account",
+          priority: 10,
+          schedulable: true,
+          client: memberClient,
+        },
+      ],
+    });
     const execute = createExecute({
       defaultProvider: provider,
       providers: new Map([["xai", provider]]),
@@ -995,7 +1006,7 @@ describe("createExecute — gateway execution adapter", () => {
       }),
     );
 
-    expect(provider.chatCompletion).not.toHaveBeenCalled();
+    expect(memberClient.chatCompletion).not.toHaveBeenCalled();
     expect(out.final.status).toBe("error");
     expect(out.attempts[0]?.skip_reason).toBe("responses_native_items_provider_incompatible");
   });

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -767,6 +767,15 @@ function candidateGuardSkipReason(
   target: ResolvedAttemptTarget,
 ): string | null {
   if (
+    req.protocol === "openai_responses" &&
+    target.targetProviderProtocol === "openai_responses" &&
+    target.provider?.nativeProtocolProfile === "generic_openai_responses" &&
+    (Array.isArray(req.provider_raw?.responses_input_items) ||
+      Array.isArray(req.provider_raw?.unknown_items))
+  ) {
+    return "responses_native_items_provider_incompatible";
+  }
+  if (
     target.providerName === "deepseek" &&
     target.targetProviderProtocol === "openai_chat" &&
     hasResponsesReasoningHistory(req)

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -9,7 +9,7 @@
 
 ## 2026-07-18 · Codex 自动压缩目录与无状态传输故障切换（OAuth subscription / Responses / provider execution，docs/04/05/07，原则 3/5/7/8）
 
-- **压缩职责边界**：Codex 客户端拥有当前会话历史并负责在阈值到达时调用 `/v1/responses/compact`、用摘要更新本地 transcript 后重试；Gateway 不透明改写历史，也不把 auto-compact 触发点误当成模型硬输入上限。当前 Codex core 对缺失 `auto_compact_token_limit` 按 resolved context 的 90% 推导，因此 Helm 的 key-filtered `/v1/models?client_version=...` 只把 null/缺失字段物化成相同默认值（372K → 334,800），上游显式值保持不变。真正超过模型 context 的整链耗尽继续复用既有 compaction-compatible `400 invalid_request`，而不是在 90% 处提前拒绝仍可执行的请求。
+- **压缩职责边界**：Codex 客户端拥有当前会话历史并负责在阈值到达时调用 `/v1/responses/compact`、用摘要更新本地 transcript 后重试；Gateway 不透明改写历史，也不把 auto-compact 触发点误当成模型硬输入上限。当前 Codex core 对缺失 `auto_compact_token_limit` 按 resolved context（`context_window`，缺失时回退 `max_context_window`）的 90% 推导，并把上游显式阈值钳制到该上限，因此 Helm 的 key-filtered `/v1/models?client_version=...` 物化相同的有效值（372K → 334,800）。真正超过模型 context 的整链耗尽继续复用既有 compaction-compatible `400 invalid_request`，而不是在 90% 处提前拒绝仍可执行的请求。
 - **传输故障边界**：Codex fetch 在同账号短连接重试耗尽后，将原始 `TypeError: fetch failed` 归类为无 HTTP status 的 `UpstreamError`，并在脱敏后的 `provider_raw` 保留有界嵌套 `name/code/message`（例如 `UND_ERR_SOCKET`），使 OAuth pool 能对无状态请求尝试兄弟账号。客户端 abort 与显式 provider timeout 保持原分类；带 `previous_response_id` 或已知 `x-codex-turn-state` 的有状态 continuation 仍严格绑定原账号，不能跨账号重放。
 - **fallback 协议边界**：含 native/custom/caller-linked 或未知 Responses input sequence 的请求，只能交给 `codex_responses` profile；`generic_openai_responses` provider 在调用前按能力 profile 跳过，避免把 Codex 私有 items 发给 xAI 等兼容端点后得到确定性 422。判断不依赖 provider 名字，后续新增 generic provider 自动继承相同保护。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-18 · Codex 自动压缩目录与无状态传输故障切换（OAuth subscription / Responses / provider execution，docs/04/05/07，原则 3/5/7/8）
+
+- **压缩职责边界**：Codex 客户端拥有当前会话历史并负责在阈值到达时调用 `/v1/responses/compact`、用摘要更新本地 transcript 后重试；Gateway 不透明改写历史，也不把 auto-compact 触发点误当成模型硬输入上限。当前 Codex core 对缺失 `auto_compact_token_limit` 按 resolved context 的 90% 推导，因此 Helm 的 key-filtered `/v1/models?client_version=...` 只把 null/缺失字段物化成相同默认值（372K → 334,800），上游显式值保持不变。真正超过模型 context 的整链耗尽继续复用既有 compaction-compatible `400 invalid_request`，而不是在 90% 处提前拒绝仍可执行的请求。
+- **传输故障边界**：Codex fetch 在同账号短连接重试耗尽后，将原始 `TypeError: fetch failed` 归类为无 HTTP status 的 `UpstreamError`，并在脱敏后的 `provider_raw` 保留有界嵌套 `name/code/message`（例如 `UND_ERR_SOCKET`），使 OAuth pool 能对无状态请求尝试兄弟账号。客户端 abort 与显式 provider timeout 保持原分类；带 `previous_response_id` 或已知 `x-codex-turn-state` 的有状态 continuation 仍严格绑定原账号，不能跨账号重放。
+- **fallback 协议边界**：含 native/custom/caller-linked 或未知 Responses input sequence 的请求，只能交给 `codex_responses` profile；`generic_openai_responses` provider 在调用前按能力 profile 跳过，避免把 Codex 私有 items 发给 xAI 等兼容端点后得到确定性 422。判断不依赖 provider 名字，后续新增 generic provider 自动继承相同保护。
+
 ## 2026-07-17 · Anthropic XML 工具调用恢复边界（Protocol streaming / provider execution，docs/05/07，原则 3/5/8）
 
 - **恢复信号与实际出口**：只在上游终止原因已经明确为 `tool_use`、XML `<invoke>` 完整闭合、工具名精确命中本次请求声明的 function tools，且响应中不存在既有 structured `tool_use/tool_calls` 时恢复，避免把示例文本或真实结构化调用旁边的 XML 再执行一次。规格所称“三条路径”漏掉了默认 native passthrough 的非流式直返；实现因此覆盖四个实际出口：Anthropic native stream、native JSON、OpenAI→Anthropic translation stream、translation JSON。共享 parser 保持大小写精确、非白名单/未闭合内容逐字保留、JSON-looking 参数按规格转换，并用 null-prototype 字典隔离 `__proto__`。
@@ -62,14 +68,9 @@
 - **触发边界**：cache-only 的 `/oauth/quota` 与 `/oauth/overview` 继续严格无副作用，绝不因读取旧 snapshot 消耗 credit；只有显式 refresh job 的新鲜上游 PULL 和实际响应头 PUSH 属于权威输入。PULL 在完成 durable/live quota 更新和 cooldown 停车同步后，仅对账号级周窗口 `>=100%` 调用并等待同一 `maybeAutoReset` 入口，避免先解停后又被异步停车覆盖；同一 Helm label 的并发触发复用同一个 in-flight promise。credit 成功消费后立即强制再 PULL 一次并更新 durable snapshot、live pool、剩余 credits 与 cooldown，cache-only 页面不会继续显示重置前的 100%。低于 100%、5h 窗口和 model-scoped 饱和窗口不触发；是否有 credit、共享账号幂等 marker、每小时 cooldown 与 workspace spend-control 拒绝仍由既有 reset guard fail-closed 判定。
 - **验证**：TDD 先证明 fresh Codex PULL 没有传递自动重置信号，再覆盖真实 `primary + 10080m + 100%` PULL 必须按“停车 -> 触发”顺序执行、成功消费后 cache/live state 立即变为新窗口与新 credit 数、共享 ChatGPT 账号的第二个 Helm label 必须等待首个 reset/unpark 完成后才开始 PULL、99% 周窗口与 cache-only GET/overview 不触发。定向 4 files / 196 tests、Gateway typecheck、Biome 与 Gateway build 全绿。
 
-## 2026-07-15 · Anthropic 不可用地域哨兵按全球基础卡计费（Catalog / telemetry accounting，docs/07/08，原则 2/3/5/7）
-
-- **生产根因**：Anthropic OAuth 原生流会返回 `usage.inference_geo=not_available`，表示未提供推理地域，不是新的计费地域。地域计费上线后把任意非空字符串都当作已确认地域；catalog 只有 `global` / `us`，该哨兵因此被当作未知费率并令已有完整 token usage 的成功请求得到 `cost_usd=null`。模型、能力和价格条目均未缺失。
-- **兼容边界**：计费边界只把空字符串和已确认的 `not_available` 规范化为“地域缺失”，使用既有全球基础卡；仍将真实但未配置的地域（如 `moon`）保持 unknown，避免猜价。原始哨兵继续保存在 telemetry 作为 provenance，不改写 provider 事实；实时响应与历史重算共用同一规范化函数，防止两套语义漂移。
-- **验证与修复边界**：TDD 以生产请求的 Opus 4.8 token/cache 数复现 `$0.24682125`，覆盖未知地域严格拒绝、Anthropic SSE 哨兵保真，以及历史重算仅在 `best-evidence` 下把该哨兵作为全球假设。生产历史数据修复仍须使用既有 manifest、逐批微型恢复库、health/WAL/disk 门禁和 OAuth delta 一致性保护。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-15 · Anthropic 不可用地域哨兵按全球基础卡计费（Catalog / telemetry accounting，docs/07/08，原则 2/3/5/7）**：仅把 `usage.inference_geo=not_available` 解释为地域缺失并使用全球基础卡，真实未知地域继续 unknown；实时与历史重算共用规范化且保留原始 provenance。
 - **2026-07-15 · 终端事件缺失的 Responses 流使用部分估算计费（Protocol streaming / telemetry accounting，docs/05/07，原则 3/5/7/8）**：原生 Responses 流缺终态时按 truncated/client_aborted 记失败，仅对已收 semantic delta 做有界 partial usage/cost 估算，并让 telemetry、attempt、budget 与 OAuth 账号结算一致；完整原文通过 git history 回溯。
 - **2026-07-15 · 历史费用回填改由常驻 supervisor 持续推进（Catalog / telemetry repair operations，docs/07/08，原则 2/3/5/7）**：systemd 常驻 supervisor 以单实例、100 行原子批次、checkpoint、slice verification、微型恢复库、资源门禁和 5,000 行冷却推进固定截止点前的历史修复；完整原文通过 git history 回溯。
 - **2026-07-15 · 历史重算兼容旧版 completion-only 顶层费用（Catalog / telemetry repair，docs/07/08，原则 2/5/7）**：仅在顶层、attempt 与 breakdown 同时精确证明旧版只保存 completion cost 时接受回填，任何其他漂移仍 fail-closed；完整原文通过 git history 回溯。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { preOutputClassifierFor } from "../failover-guard.js";
 import { type ChatCompletionRequest, type ProviderClient, UpstreamError } from "../openai.js";
+import { createCodexResponsesClient } from "../openai-responses.js";
 import { TokenRefreshError } from "../token-manager.js";
 import { createOAuthPoolClient, type OAuthPoolMember } from "./pool.js";
 
@@ -549,7 +550,7 @@ describe("createOAuthPoolClient — account selection", () => {
             async chatCompletion(req: ChatCompletionRequest) {
               calls.push("a");
               if (req.previous_response_id) {
-                throw Object.assign(new Error("temporary"), { status: 503 });
+                throw new UpstreamError("upstream_error", "temporary", null, null);
               }
               return { id: "resp-a" };
             },
@@ -1314,6 +1315,50 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     expect(firstMeta).toEqual(["req-a"]);
   });
 
+  it("never retries a known x-codex-turn-state on a sibling after a transient fault", async () => {
+    const calls: string[] = [];
+    let firstAccountCalls = 0;
+    const transient = new UpstreamError("upstream_error", "fetch failed", null, null);
+    const responseMember = (account: string, priority: number): OAuthPoolMember => ({
+      account,
+      priority,
+      schedulable: true,
+      client: {
+        async chatCompletion() {
+          return { served_by: account };
+        },
+        async *chatCompletionStream() {
+          yield `data: ${account}\n\n`;
+        },
+        async *nativePassthroughStream(_body, opts) {
+          calls.push(account);
+          if (account === "a" && firstAccountCalls++ > 0) throw transient;
+          opts?.onResponseMeta?.(new Headers({ "x-codex-turn-state": "strict-turn-state" }));
+          yield `event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-${account}"}}\n\n`;
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [responseMember("a", 10), responseMember("b", 50)],
+    });
+    const drain = async (headers: Record<string, string>): Promise<void> => {
+      const stream = pool.nativePassthroughStream?.({
+        protocol: "openai_responses",
+        body: { model: "gpt-5.6-sol", stream: true, input: "continue" },
+        headers,
+        mutations: {},
+      });
+      for await (const _chunk of stream ?? []) {
+        // Drain until the strict continuation either completes or fails.
+      }
+    };
+
+    await drain({ "session-id": "initial-session" });
+    await expect(drain({ "x-codex-turn-state": "strict-turn-state" })).rejects.toBe(transient);
+
+    expect(calls).toEqual(["a", "a"]);
+  });
+
   it("fails a known x-codex-turn-state when its original account is unavailable", async () => {
     const calls: string[] = [];
     const responseMember = (account: string): OAuthPoolMember => ({
@@ -2047,6 +2092,59 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     for await (const c of pool.nativePassthroughStream?.(NATIVE) ?? []) chunks.push(c);
     expect(chunks).toEqual(["data: b\n\n"]);
     expect(served).toEqual(["b"]);
+  });
+
+  it("rotates to a sibling Codex account after an exhausted raw fetch failure", async () => {
+    const selected: string[] = [];
+    const raw = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" }),
+    });
+    const codexMember = (
+      account: string,
+      priority: number,
+      providerFetch: typeof fetch,
+    ): OAuthPoolMember => ({
+      account,
+      priority,
+      schedulable: true,
+      client: createCodexResponsesClient({
+        config: {
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          getAuthHeader: async () => `Bearer token-${account}`,
+          connectRetries: 0,
+        },
+        fetch: providerFetch,
+      }),
+    });
+    const pool = createOAuthPoolClient({
+      members: [
+        codexMember("a", 10, (async () => {
+          throw raw;
+        }) as unknown as typeof fetch),
+        codexMember(
+          "b",
+          50,
+          (async () =>
+            new Response(
+              'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-b","status":"completed"}}\n\n',
+              { status: 200, headers: { "content-type": "text/event-stream" } },
+            )) as unknown as typeof fetch,
+        ),
+      ],
+      onSelect: (account) => selected.push(account),
+    });
+    const request = {
+      protocol: "openai_responses" as const,
+      body: { model: "gpt-5.6-sol", input: "full stateless history", stream: true, store: false },
+      headers: { "session-id": "stateless-session" },
+      mutations: {},
+    };
+
+    const chunks: string[] = [];
+    for await (const chunk of pool.nativePassthroughStream?.(request) ?? []) chunks.push(chunk);
+
+    expect(selected).toEqual(["a", "b"]);
+    expect(chunks.join("")).toContain('"id":"resp-b"');
   });
 
   it("cools a Codex model-scoped 429 on native streaming without parking sibling models", async () => {

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -36,6 +36,22 @@ const USER_REQ: ChatCompletionRequest = {
 };
 
 describe("createOAuthPoolClient — account selection", () => {
+  it("exposes a shared native protocol profile from homogeneous members", () => {
+    const calls: string[] = [];
+    const profileClient = (account: string): ProviderClient => ({
+      ...stubClient(account, calls),
+      nativeProtocolProfile: "generic_openai_responses",
+    });
+    const pool = createOAuthPoolClient({
+      members: [
+        { account: "a", priority: 10, schedulable: true, client: profileClient("a") },
+        { account: "b", priority: 20, schedulable: true, client: profileClient("b") },
+      ],
+    });
+
+    expect(pool.nativeProtocolProfile).toBe("generic_openai_responses");
+  });
+
   it("prefers the lowest priority (lower = preferred)", async () => {
     const calls: string[] = [];
     const selected: string[] = [];

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -226,6 +226,14 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     deps.upstreamCredentialFailureStatuses ?? [401, 403],
   );
   const entries: PoolEntry[] = deps.members.map((member) => ({ member, lastUsedAt: 0 }));
+  const firstNativeProtocolProfile = entries[0]?.member.client.nativeProtocolProfile;
+  const nativeProtocolProfile =
+    firstNativeProtocolProfile !== undefined &&
+    entries.every(
+      (entry) => entry.member.client.nativeProtocolProfile === firstNativeProtocolProfile,
+    )
+      ? firstNativeProtocolProfile
+      : undefined;
   const stickySessions = new Map<string, { account: string; expiresAt: number }>();
   const scopedRateLimits = new Map<
     string,
@@ -1036,6 +1044,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   }
 
   return {
+    ...(nativeProtocolProfile === undefined ? {} : { nativeProtocolProfile }),
     // Park / un-park ONE account's auto-park cooldown in place. The next select()
     // observes the new value without a pool rebuild; null clears it (the manual
     // "Reset usage" path). Unknown account = no-op.

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1663,9 +1663,9 @@ describe("createCodexResponsesClient", () => {
     expect(caught).not.toBeInstanceOf(UpstreamError);
   });
 
-  it("retries a transient network error then re-throws it unchanged", async () => {
+  it("retries a transient network error then wraps it for account-pool failover", async () => {
     // ECONNREFUSED is transient → retried at the fetch boundary ([0,0] backoff keeps
-    // the test instant); the ORIGINAL error propagates once the budget is exhausted.
+    // the test instant); exhaustion is then classified for account-pool failover.
     const boom = new Error("ECONNREFUSED");
     const fetch = vi.fn(async () => {
       throw boom;
@@ -1680,7 +1680,11 @@ describe("createCodexResponsesClient", () => {
     });
     await expect(
       client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] }),
-    ).rejects.toBe(boom);
+    ).rejects.toMatchObject({
+      errorClass: "upstream_error",
+      upstreamStatus: null,
+      providerRaw: { error: { name: "Error", message: "ECONNREFUSED" } },
+    });
     expect(fetch).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
   });
 
@@ -3292,6 +3296,75 @@ describe("createCodexResponsesClient — nativePassthrough", () => {
     expect(err.upstreamStatus).toBe(500);
     expect(JSON.stringify(err.providerRaw)).not.toContain(token);
     expect(JSON.stringify(err.providerRaw)).toContain("[redacted]");
+  });
+
+  it("wraps an exhausted raw fetch failure with scrubbed nested cause details", async () => {
+    const secret = "proxy-secret-1234";
+    const raw = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error(`other side closed ${secret}`), {
+        code: "UND_ERR_SOCKET",
+      }),
+    });
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        currentSecrets: () => [secret],
+        connectRetries: 0,
+      },
+      fetch: (async () => {
+        throw raw;
+      }) as unknown as typeof fetch,
+    });
+
+    let caught: unknown;
+    try {
+      await client.nativePassthrough?.(nativeBody());
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(UpstreamError);
+    expect(caught).toMatchObject({
+      errorClass: "upstream_error",
+      upstreamStatus: null,
+      providerRaw: {
+        error: {
+          name: "TypeError",
+          message: "fetch failed",
+          cause: {
+            name: "Error",
+            code: "UND_ERR_SOCKET",
+            message: "other side closed [redacted]",
+          },
+        },
+      },
+    });
+  });
+
+  it("preserves a client abort instead of wrapping it as an upstream transport failure", async () => {
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        connectRetries: 0,
+      },
+      fetch: (async () => {
+        throw new DOMException("This operation was aborted", "AbortError");
+      }) as unknown as typeof fetch,
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    let caught: unknown;
+    try {
+      await client.nativePassthrough?.(nativeBody(), { signal: controller.signal });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).not.toBeInstanceOf(UpstreamError);
+    expect(caught).toMatchObject({ name: "AbortError" });
   });
 });
 

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -36,7 +36,7 @@ import {
   type ProviderConfig,
   UpstreamError,
 } from "./openai.js";
-import { isTransientConnectionError, withConnectionRetry } from "./retry.js";
+import { isFetchTransportError, isTransientConnectionError, withConnectionRetry } from "./retry.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface CodexResponsesClientConfig {
@@ -1216,6 +1216,45 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     return changed ? JSON.parse(value) : raw;
   }
 
+  function transportErrorNode(
+    error: unknown,
+    depth = 0,
+    seen = new WeakSet<object>(),
+  ): Record<string, unknown> {
+    if (typeof error !== "object" || error === null) return { message: String(error) };
+    if (seen.has(error)) return { message: "[circular cause]" };
+    seen.add(error);
+    const source = error as {
+      name?: unknown;
+      message?: unknown;
+      code?: unknown;
+      cause?: unknown;
+    };
+    const detail: Record<string, unknown> = {};
+    if (typeof source.name === "string" && source.name.length > 0) detail.name = source.name;
+    if (typeof source.code === "string" || typeof source.code === "number") {
+      detail.code = source.code;
+    }
+    if (typeof source.message === "string" && source.message.length > 0) {
+      detail.message = source.message;
+    }
+    if (source.cause !== undefined && depth < 4) {
+      detail.cause = transportErrorNode(source.cause, depth + 1, seen);
+    }
+    return detail;
+  }
+
+  function transportUpstreamError(error: unknown): UpstreamError {
+    const rawMessage = error instanceof Error ? error.message : "upstream fetch failed";
+    const scrubbedMessage = scrub(rawMessage);
+    return new UpstreamError(
+      "upstream_error",
+      typeof scrubbedMessage === "string" ? scrubbedMessage : "upstream fetch failed",
+      scrub({ error: transportErrorNode(error) }),
+      null,
+    );
+  }
+
   type RequestTimeout = ReturnType<typeof withTimeout>;
   interface CodexHttpResponse {
     response: Response;
@@ -1291,37 +1330,45 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     init.capture?.(prepared.bodyText);
     // Retry transient connection blips at the fetch boundary (pre-first-byte → idempotent);
     // a timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
-    return withConnectionRetry(
-      async () => {
-        const t = withTimeout(timeoutMs, init.signal);
-        try {
-          const response = await doFetch(init.endpoint, {
-            method: "POST",
-            headers: prepared.headers,
-            body: prepared.bodyText,
-            signal: t.signal,
-          });
-          if (init.timeoutThroughBody === true) {
-            return { response, bodyTimeout: t, turnKey };
+    try {
+      return await withConnectionRetry(
+        async () => {
+          const t = withTimeout(timeoutMs, init.signal);
+          try {
+            const response = await doFetch(init.endpoint, {
+              method: "POST",
+              headers: prepared.headers,
+              body: prepared.bodyText,
+              signal: t.signal,
+            });
+            if (init.timeoutThroughBody === true) {
+              return { response, bodyTimeout: t, turnKey };
+            }
+            return { response, turnKey };
+          } catch (err) {
+            if (t.isTimeout() && !t.isExternalAbort()) {
+              throw new UpstreamError("timeout", "upstream request timed out");
+            }
+            throw err;
+          } finally {
+            if (init.timeoutThroughBody !== true) {
+              t.cleanup();
+            }
           }
-          return { response, turnKey };
-        } catch (err) {
-          if (t.isTimeout() && !t.isExternalAbort()) {
-            throw new UpstreamError("timeout", "upstream request timed out");
-          }
-          throw err;
-        } finally {
-          if (init.timeoutThroughBody !== true) {
-            t.cleanup();
-          }
-        }
-      },
-      {
-        retries: cfg.connectRetries,
-        backoffMs: cfg.connectRetryBackoffMs,
-        signal: init.signal,
-      },
-    );
+        },
+        {
+          retries: cfg.connectRetries,
+          backoffMs: cfg.connectRetryBackoffMs,
+          signal: init.signal,
+        },
+      );
+    } catch (error) {
+      // An external abort is client-owned even when fetch happens to surface a
+      // transport-shaped TypeError. Explicit provider timeouts are already
+      // UpstreamError("timeout") and therefore fail this raw-transport guard.
+      if (init.signal?.aborted || !isFetchTransportError(error)) throw error;
+      throw transportUpstreamError(error);
+    }
   }
 
   async function readUnaryBody(result: CodexHttpResponse): Promise<string> {

--- a/packages/core/src/provider/retry.test.ts
+++ b/packages/core/src/provider/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { isTransientConnectionError, withConnectionRetry } from "./retry.js";
+import { isFetchTransportError, isTransientConnectionError, withConnectionRetry } from "./retry.js";
 
 // A transient connection error is one safe to retry BEFORE any bytes reached the
 // client (idempotent: no upstream response consumed). The classifier is a strict
@@ -58,6 +58,26 @@ describe("isTransientConnectionError", () => {
     // must still be classified non-transient (name wins).
     const err = Object.assign(new Error("socket hang up"), { name: "AbortError" });
     expect(isTransientConnectionError(err)).toBe(false);
+  });
+});
+
+describe("isFetchTransportError", () => {
+  it("classifies an opaque undici fetch failure even when its cause code is not retry-allowlisted", () => {
+    const err = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("Connect Timeout Error"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      }),
+    });
+
+    expect(isTransientConnectionError(err)).toBe(false);
+    expect(isFetchTransportError(err)).toBe(true);
+  });
+
+  it("does not classify an abort or an already-classified timeout as a raw fetch transport error", () => {
+    expect(
+      isFetchTransportError(new DOMException("This operation was aborted", "AbortError")),
+    ).toBe(false);
+    expect(isFetchTransportError(new Error("upstream request timed out"))).toBe(false);
   });
 });
 

--- a/packages/core/src/provider/retry.ts
+++ b/packages/core/src/provider/retry.ts
@@ -58,6 +58,30 @@ export function isTransientConnectionError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * True when a raw fetch-boundary failure should be surfaced as a status-less
+ * upstream transport error after same-account connection retries are exhausted.
+ *
+ * This is intentionally broader than `isTransientConnectionError`: undici can
+ * report DNS, TLS, connect-timeout, and socket failures as an opaque
+ * `TypeError("fetch failed")` whose nested code is not in the short-retry
+ * allowlist. Those errors should still reach the OAuth pool as transport faults
+ * so a stateless request can try a sibling account. Abort always wins.
+ */
+export function isFetchTransportError(err: unknown): boolean {
+  let cur: unknown = err;
+  for (let depth = 0; depth < 5 && cur != null; depth += 1) {
+    if (typeof cur !== "object") break;
+    const e = cur as { name?: unknown; cause?: unknown };
+    if (e.name === "AbortError") return false;
+    cur = e.cause;
+  }
+  if (isTransientConnectionError(err)) return true;
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { name?: unknown; message?: unknown };
+  return e.name === "TypeError" && e.message === "fetch failed";
+}
+
 export interface ConnectionRetryOptions {
   /** Max additional attempts after the first. Default 2. */
   retries?: number;


### PR DESCRIPTION
## Summary

- materialize Codex auto-compaction metadata with the same resolved-context 90% rule and clamp used by Codex core
- classify exhausted raw fetch failures as scrubbed upstream transport faults so stateless OAuth requests can rotate to a sibling account
- preserve stateful continuation pinning and client abort/timeout semantics
- expose homogeneous OAuth pool protocol metadata and pre-skip Codex-native items on generic Responses providers

## Verification

- `CI=true pnpm exec vitest run apps/gateway/src/oauth/codex-model-catalog.test.ts apps/gateway/src/routes/responses.test.ts apps/gateway/src/routes/execute.test.ts packages/core/src/provider/retry.test.ts packages/core/src/provider/openai-responses.test.ts packages/core/src/provider/oauth/pool.test.ts` (535 passed)
- `pnpm typecheck`
- `pnpm lint` (no errors; 37 pre-existing warnings in CI workflow string fixtures)
- `pnpm build`
- targeted Biome and `git diff --check`