### PR TITLE
chore(release): v0.27.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.21",
+  "version": "0.27.22",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from `0.27.21` to `0.27.22`
- release the backward-compatible reasoning telemetry visibility fix from PR #594

## Scope
Version-only patch release. No database migration or configuration change.