### PR TITLE
feat(admin): show reasoning effort in request lists

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -106,6 +106,7 @@ describe('toListItem', () => {
     expect(row.fallback_count).toBe(1);
     expect(row.cost_usd).toBeCloseTo(0.01);
     expect(row.decided_by).toBe('eval');
+    expect(row.reasoning_effort).toBe('high');
   });
 
   it('surfaces the served provider and final subscription account on list rows', () => {

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -46,6 +46,7 @@ export interface RequestListItem {
   user_id?: string;
   org_id?: string;
   requested_model: string | null;
+  reasoning_effort: string | null;
   task_type: string;
   complexity: string;
   decided_by: 'rules' | 'eval' | 'default' | 'fallback'; // decision layer (classification stage)
@@ -505,6 +506,7 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     // back to the prefix (so an unnamed/deleted key still renders something).
     key_name: typeof raw.key_name === 'string' && raw.key_name.length > 0 ? raw.key_name : null,
     requested_model: raw.requested_model ?? null,
+    reasoning_effort: nonEmptyString(raw.reasoning_effort),
     task_type: raw.classifier?.task_type ?? '',
     complexity: raw.classifier?.complexity ?? '',
     decided_by: normalizeDecidedBy(raw.classifier?.decided_by),

--- a/apps/admin/src/lib/components/RequestsTable.svelte
+++ b/apps/admin/src/lib/components/RequestsTable.svelte
@@ -189,6 +189,12 @@
       {r.task_type || '—'}{#if r.complexity}
         · {r.complexity}{/if}
     </div>
+    {#if r.reasoning_effort}
+      <div data-testid="reasoning-effort" class="mt-1 text-xs text-ink-muted">
+        {$t('Reasoning effort')}:
+        <span class="font-mono text-ink-body">{r.reasoning_effort}</span>
+      </div>
+    {/if}
   </div>
 {/snippet}
 
@@ -249,8 +255,9 @@
         >
         <th
           class="px-3 py-2"
-          title={$t('Classification result: lane, decision source, task, and complexity.')}
-          >{$t('Routing')}</th
+          title={$t(
+            'Classification result: lane, decision source, task, complexity, and reasoning effort.',
+          )}>{$t('Routing')}</th
         >
         <th class="px-3 py-2" title={$t('Provider, account, and execution fallback count.')}
           >{$t('Serving')}</th

--- a/apps/admin/src/lib/components/RequestsTable.test.ts
+++ b/apps/admin/src/lib/components/RequestsTable.test.ts
@@ -16,6 +16,7 @@ function item(overrides: Partial<RequestListItem> = {}): RequestListItem {
     key_prefix: 'helm_live_ab12',
     key_name: 'Prod',
     requested_model: 'gpt-4o',
+    reasoning_effort: null,
     task_type: 'coding',
     complexity: 'high',
     decided_by: 'rules',
@@ -96,7 +97,7 @@ describe('RequestsTable variants', () => {
 
   it('renders the full request-audit columns as grouped cells', () => {
     render(RequestsTable, {
-      items: [item({ latency_ms: 6911 })],
+      items: [item({ latency_ms: 6911, reasoning_effort: 'xhigh' })],
       detailHref,
       variant: 'full',
     });
@@ -107,6 +108,9 @@ describe('RequestsTable variants', () => {
     expect(within(row).getByTestId('cell-model')).toHaveTextContent('requested: gpt-4o');
     expect(within(row).getByTestId('cell-routing')).toHaveTextContent('premium');
     expect(within(row).getByTestId('cell-routing')).toHaveTextContent('coding');
+    expect(within(row).getByTestId('reasoning-effort')).toHaveTextContent(
+      'Reasoning effort: xhigh',
+    );
     expect(within(row).getByTestId('cell-serving')).toHaveTextContent('anthropic');
     expect(within(row).getByTestId('cell-serving')).toHaveTextContent('exec +1');
     expect(within(row).getByTestId('cell-performance')).toHaveTextContent('6.9s');
@@ -117,6 +121,12 @@ describe('RequestsTable variants', () => {
     render(RequestsTable, { items: [item({ latency_ms: 90_000 })], detailHref });
 
     expect(screen.getByTestId('cell-performance')).toHaveTextContent('1.5min');
+  });
+
+  it('keeps legacy rows compact when reasoning effort was not recorded', () => {
+    render(RequestsTable, { items: [item({ reasoning_effort: null })], detailHref });
+
+    expect(screen.queryByTestId('reasoning-effort')).toBeNull();
   });
 
   it('shows a partial result and approximate cost for an estimated truncated stream', () => {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -136,7 +136,7 @@
   "circuit open": "circuit open",
   "Circuit open": "Circuit open",
   "Classification failed safely and fell back to balanced.": "Classification failed safely and fell back to balanced.",
-  "Classification result: lane, decision source, task, and complexity.": "Classification result: lane, decision source, task, and complexity.",
+  "Classification result: lane, decision source, task, complexity, and reasoning effort.": "Classification result: lane, decision source, task, complexity, and reasoning effort.",
   "Classification-stage decision source": "Classification-stage decision source",
   "Classifier": "Classifier",
   "Classifier (classification stage)": "Classifier (classification stage)",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -136,7 +136,7 @@
   "circuit open": "circuito abierto",
   "Circuit open": "Circuito abierto",
   "Classification failed safely and fell back to balanced.": "La clasificación falló de forma segura y volvió a balanced.",
-  "Classification result: lane, decision source, task, and complexity.": "Resultado de clasificación: lane, origen de decisión, tarea y complejidad.",
+  "Classification result: lane, decision source, task, complexity, and reasoning effort.": "Resultado de clasificación: lane, origen de decisión, tarea, complejidad y esfuerzo de razonamiento.",
   "Classification-stage decision source": "Origen de decisión de la etapa de clasificación",
   "Classifier": "Clasificador",
   "Classifier (classification stage)": "Clasificador (etapa de clasificación)",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -136,7 +136,7 @@
   "circuit open": "サーキットオープン",
   "Circuit open": "サーキットオープン",
   "Classification failed safely and fell back to balanced.": "分類は安全に失敗し、バランスにフォールバックしました。",
-  "Classification result: lane, decision source, task, and complexity.": "分類結果: レーン、決定元、タスク、複雑度。",
+  "Classification result: lane, decision source, task, complexity, and reasoning effort.": "分類結果: レーン、決定元、タスク、複雑度、推論レベル。",
   "Classification-stage decision source": "分類段階の決定元",
   "Classifier": "分類器",
   "Classifier (classification stage)": "分類器（分類ステージ）",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -136,7 +136,7 @@
   "circuit open": "서킷 오픈",
   "Circuit open": "서킷 오픈",
   "Classification failed safely and fell back to balanced.": "분류가 안전하게 실패하여 균형 레인으로 대체되었습니다.",
-  "Classification result: lane, decision source, task, and complexity.": "분류 결과: 레인, 결정 출처, 작업, 복잡도.",
+  "Classification result: lane, decision source, task, complexity, and reasoning effort.": "분류 결과: 레인, 결정 출처, 작업, 복잡도, 추론 수준.",
   "Classification-stage decision source": "분류 단계 결정 출처",
   "Classifier": "분류기",
   "Classifier (classification stage)": "분류기 (분류 단계)",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -136,7 +136,7 @@
   "circuit open": "circuito aberto",
   "Circuit open": "Circuito aberto",
   "Classification failed safely and fell back to balanced.": "A classificação falhou com segurança e voltou para balanced.",
-  "Classification result: lane, decision source, task, and complexity.": "Resultado da classificação: lane, origem da decisão, tarefa e complexidade.",
+  "Classification result: lane, decision source, task, complexity, and reasoning effort.": "Resultado da classificação: lane, origem da decisão, tarefa, complexidade e esforço de raciocínio.",
   "Classification-stage decision source": "Origem da decisão da etapa de classificação",
   "Classifier": "Classificador",
   "Classifier (classification stage)": "Classificador (etapa de classificação)",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -136,7 +136,7 @@
   "circuit open": "熔断开启",
   "Circuit open": "熔断开启",
   "Classification failed safely and fell back to balanced.": "分类安全失败，已兜底到 balanced 通道。",
-  "Classification result: lane, decision source, task, and complexity.": "分类结果：lane、决策来源、任务和复杂度。",
+  "Classification result: lane, decision source, task, complexity, and reasoning effort.": "分类结果：lane、决策来源、任务、复杂度和推理等级。",
   "Classification-stage decision source": "分类阶段决策来源",
   "Classifier": "分类器",
   "Classifier (classification stage)": "分类器（分类阶段）",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -136,7 +136,7 @@
   "circuit open": "熔斷開啟",
   "Circuit open": "熔斷開啟",
   "Classification failed safely and fell back to balanced.": "分類安全失敗，已備援到 balanced 通道。",
-  "Classification result: lane, decision source, task, and complexity.": "分類結果：lane、決策來源、任務和複雜度。",
+  "Classification result: lane, decision source, task, complexity, and reasoning effort.": "分類結果：lane、決策來源、任務、複雜度和推理等級。",
   "Classification-stage decision source": "分類階段決策來源",
   "Classifier": "分類器",
   "Classifier (classification stage)": "分類器（分類階段）",

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -179,6 +179,7 @@ function requestItem(traceId: string): RequestListItem {
     key_prefix: 'helm_live_ab12',
     key_name: 'Prod backend',
     requested_model: 'gpt-4o',
+    reasoning_effort: null,
     task_type: 'coding',
     complexity: 'complex',
     decided_by: 'rules',

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -41,6 +41,7 @@ function item(traceId: string, overrides: Partial<RequestListItem> = {}): Reques
     key_prefix: 'helm_live_ab12',
     key_name: null,
     requested_model: 'gpt-4o',
+    reasoning_effort: 'xhigh',
     task_type: 'coding',
     complexity: 'high',
     decided_by: 'rules',
@@ -205,6 +206,7 @@ describe('requests list page', () => {
     expect(first).toHaveTextContent('coding'); // task_type
     expect(first).toHaveTextContent('high'); // complexity
     expect(first).toHaveTextContent('rules'); // decided_by
+    expect(within(first).getByTestId('reasoning-effort')).toHaveTextContent('xhigh');
     expect(first).toHaveTextContent('premium'); // lane
     expect(within(first).getByTestId('cell-serving')).toHaveTextContent('anthropic'); // provider
     expect(within(first).getByTestId('cell-serving')).toHaveTextContent('claude-team-a'); // subscription account

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -11,6 +11,7 @@
 
 - **存储边界**：`capture_payloads:false` 仍只禁止 `request_payloads` 中的完整请求、上游请求与响应正文；请求实际生效的 `reasoning_effort` 作为不含正文和密钥的独立字段写入既有 `DecisionRecord`，随 `decision_json` 持久化。策略或 lane 强制覆盖时记录覆盖后的有效值；请求未指定时记录 `null`，旧记录缺字段继续兼容，不新增 SQLite/Postgres 列或迁移。
 - **展示边界**：Admin 请求详情在正文未捕获时，通过既有脱敏 request metadata 面板展示 `reasoning_effort`；完整正文开启时仍以原始 payload 为事实来源。OpenAI Chat、Anthropic、Responses、Gemini 的共享路由链自动覆盖，`/v1/responses/compact` 的独立遥测构造也显式投影 `reasoning.effort`。
+- **列表投影**：共享 `RequestsTable` 的 Routing 单元格同步展示已记录的有效推理等级，因此主 Requests 列表、Dashboard recent 与 key-scoped 列表保持一致；旧记录缺字段时不渲染占位行。
 
 ## 2026-07-18 · Codex 自动压缩目录与无状态传输故障切换（OAuth subscription / Responses / provider execution，docs/04/05/07，原则 3/5/7/8）
 


### PR DESCRIPTION
## Summary
- project recorded `reasoning_effort` into request list rows
- show the effective reasoning level in the shared Routing cell
- keep legacy rows compact when the field is absent
- update all Admin locales and implementation notes

## Release assessment
Backward-compatible Admin observability improvement with no database migration. Release as the next patch after merge.

## Validation
- 102 focused Admin tests passed
- Admin `svelte-check`: 0 errors, 0 warnings
- Prettier and `git diff --check` passed