### PR TITLE
chore(release): v0.27.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.22",
+  "version": "0.27.23",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from `0.27.22` to `0.27.23`
- release the request-list reasoning-effort visibility improvement from PR #596

## Scope
Version-only patch release. No database migration or configuration change.