### PR TITLE
feat(admin): distinguish requested and routed reasoning effort

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -12,6 +12,7 @@ function rawRecord(overrides: Record<string, unknown> = {}): Record<string, unkn
     request_id: 'tr_1',
     trace_id: 'tr_1',
     requested_model: 'gpt-4o',
+    requested_reasoning_effort: 'low',
     reasoning_effort: 'high',
     key_prefix: 'helm_live_ab12',
     classifier: {
@@ -106,6 +107,7 @@ describe('toListItem', () => {
     expect(row.fallback_count).toBe(1);
     expect(row.cost_usd).toBeCloseTo(0.01);
     expect(row.decided_by).toBe('eval');
+    expect(row.requested_reasoning_effort).toBe('low');
     expect(row.reasoning_effort).toBe('high');
   });
 

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -46,6 +46,7 @@ export interface RequestListItem {
   user_id?: string;
   org_id?: string;
   requested_model: string | null;
+  requested_reasoning_effort: string | null;
   reasoning_effort: string | null;
   task_type: string;
   complexity: string;
@@ -233,6 +234,7 @@ interface RawDecisionRecord {
   // row by GET /admin/api/requests). Absent on legacy records → ts stays ''.
   created_at?: number;
   requested_model?: string;
+  requested_reasoning_effort?: string | null;
   reasoning_effort?: string | null;
   // Display prefix only (helm_live_ab12) — the record NEVER carries the plaintext
   // key (Principle 7). Null/absent on legacy (pre-enrichment) records.
@@ -506,6 +508,7 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     // back to the prefix (so an unnamed/deleted key still renders something).
     key_name: typeof raw.key_name === 'string' && raw.key_name.length > 0 ? raw.key_name : null,
     requested_model: raw.requested_model ?? null,
+    requested_reasoning_effort: nonEmptyString(raw.requested_reasoning_effort),
     reasoning_effort: nonEmptyString(raw.reasoning_effort),
     task_type: raw.classifier?.task_type ?? '',
     complexity: raw.classifier?.complexity ?? '',

--- a/apps/admin/src/lib/components/RequestsTable.svelte
+++ b/apps/admin/src/lib/components/RequestsTable.svelte
@@ -168,6 +168,9 @@
       >
         {$t('requested:')}
         {r.requested_model}
+        {#if r.requested_reasoning_effort}
+          {r.requested_reasoning_effort}
+        {/if}
       </div>
     {/if}
   </div>
@@ -190,9 +193,12 @@
         · {r.complexity}{/if}
     </div>
     {#if r.reasoning_effort}
-      <div data-testid="reasoning-effort" class="mt-1 text-xs text-ink-muted">
-        {$t('Reasoning effort')}:
-        <span class="font-mono text-ink-body">{r.reasoning_effort}</span>
+      <div
+        data-testid="reasoning-effort"
+        class="mt-1 font-mono text-xs text-ink-body"
+        title={$t('Reasoning effort')}
+      >
+        {r.reasoning_effort}
       </div>
     {/if}
   </div>

--- a/apps/admin/src/lib/components/RequestsTable.test.ts
+++ b/apps/admin/src/lib/components/RequestsTable.test.ts
@@ -16,6 +16,7 @@ function item(overrides: Partial<RequestListItem> = {}): RequestListItem {
     key_prefix: 'helm_live_ab12',
     key_name: 'Prod',
     requested_model: 'gpt-4o',
+    requested_reasoning_effort: null,
     reasoning_effort: null,
     task_type: 'coding',
     complexity: 'high',
@@ -97,7 +98,13 @@ describe('RequestsTable variants', () => {
 
   it('renders the full request-audit columns as grouped cells', () => {
     render(RequestsTable, {
-      items: [item({ latency_ms: 6911, reasoning_effort: 'xhigh' })],
+      items: [
+        item({
+          latency_ms: 6911,
+          requested_reasoning_effort: 'low',
+          reasoning_effort: 'xhigh',
+        }),
+      ],
       detailHref,
       variant: 'full',
     });
@@ -105,12 +112,11 @@ describe('RequestsTable variants', () => {
     const row = screen.getByTestId('request-row');
     expect(within(row).getByTestId('cell-result')).toHaveTextContent('ok');
     expect(within(row).getByTestId('cell-model')).toHaveTextContent('claude-x');
-    expect(within(row).getByTestId('cell-model')).toHaveTextContent('requested: gpt-4o');
+    expect(within(row).getByTestId('cell-model')).toHaveTextContent('requested: gpt-4o low');
     expect(within(row).getByTestId('cell-routing')).toHaveTextContent('premium');
     expect(within(row).getByTestId('cell-routing')).toHaveTextContent('coding');
-    expect(within(row).getByTestId('reasoning-effort')).toHaveTextContent(
-      'Reasoning effort: xhigh',
-    );
+    expect(within(row).getByTestId('reasoning-effort')).toHaveTextContent('xhigh');
+    expect(within(row).getByTestId('reasoning-effort')).not.toHaveTextContent('Reasoning effort');
     expect(within(row).getByTestId('cell-serving')).toHaveTextContent('anthropic');
     expect(within(row).getByTestId('cell-serving')).toHaveTextContent('exec +1');
     expect(within(row).getByTestId('cell-performance')).toHaveTextContent('6.9s');
@@ -124,7 +130,10 @@ describe('RequestsTable variants', () => {
   });
 
   it('keeps legacy rows compact when reasoning effort was not recorded', () => {
-    render(RequestsTable, { items: [item({ reasoning_effort: null })], detailHref });
+    render(RequestsTable, {
+      items: [item({ requested_reasoning_effort: null, reasoning_effort: null })],
+      detailHref,
+    });
 
     expect(screen.queryByTestId('reasoning-effort')).toBeNull();
   });

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -179,6 +179,7 @@ function requestItem(traceId: string): RequestListItem {
     key_prefix: 'helm_live_ab12',
     key_name: 'Prod backend',
     requested_model: 'gpt-4o',
+    requested_reasoning_effort: null,
     reasoning_effort: null,
     task_type: 'coding',
     complexity: 'complex',

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -41,6 +41,7 @@ function item(traceId: string, overrides: Partial<RequestListItem> = {}): Reques
     key_prefix: 'helm_live_ab12',
     key_name: null,
     requested_model: 'gpt-4o',
+    requested_reasoning_effort: 'low',
     reasoning_effort: 'xhigh',
     task_type: 'coding',
     complexity: 'high',

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -627,6 +627,7 @@ function compactDecision(args: {
     request_id: args.requestId,
     trace_id: args.traceId,
     requested_model: args.requestedModel,
+    requested_reasoning_effort: args.reasoningEffort,
     reasoning_effort: args.reasoningEffort,
     protocol: "openai_responses",
     key_prefix: args.keyPrefix,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-07-18 · 请求推理等级与实际路由等级分开展示（Telemetry / Admin requests，docs/07/11，原则 1/7）
+
+- **事实边界**：`requested_reasoning_effort` 在进入路由、策略或 lane 覆盖前从客户端请求单独截取；既有 `reasoning_effort` 继续表示覆盖后的有效执行等级。两者都是不含正文与密钥的可选 `DecisionRecord` 元数据，因此关闭 `capture_payloads` 后仍可读取，旧记录缺少请求等级时保持空白，不用有效等级反推客户端意图。
+- **列表展示**：共享 `RequestsTable` 在“请求”模型后直接追加客户端等级（例如 `请求: gpt-5.6-sol high`），Routing 单元格只显示实际有效等级值，不再重复“推理等级”标签。Dashboard、主 Requests 与 key-scoped 列表共用该行为；请求详情现有的有效等级展示不变。
+
 ## 2026-07-18 · 关闭正文捕获时仍保留推理等级（Telemetry / Admin requests，docs/07/11，原则 1/7）
 
 - **存储边界**：`capture_payloads:false` 仍只禁止 `request_payloads` 中的完整请求、上游请求与响应正文；请求实际生效的 `reasoning_effort` 作为不含正文和密钥的独立字段写入既有 `DecisionRecord`，随 `decision_json` 持久化。策略或 lane 强制覆盖时记录覆盖后的有效值；请求未指定时记录 `null`，旧记录缺字段继续兼容，不新增 SQLite/Postgres 列或迁移。
@@ -62,11 +67,6 @@
 - **生产根因**：`la.atmy.work` 的 `/admin/api/memory/stats` 冷读实测最高约 10.2 秒；同步 `better-sqlite3` 在 Node 事件循环上对约 139 万 `memory_messages`、11.9k observations 及其他 memory 表执行 `COUNT/MAX`，扫描期间连 health completion 都暂停。Admin 又在 `app.html` 全局启用 `data-sveltekit-preload-data="hover"`，鼠标经过侧栏即可投机触发这些数据库查询；第一次点击因此等待冷扫描，第二次点击命中 10 秒应用缓存或 OS page cache，形成“再点一下马上出来”的假象。同期没有 VACUUM、cleanup、OOM、`SQLITE_BUSY` 或 payload capture 事件，不能把本次页面卡顿归因于这些路径。
 - **稳定读模型**：SQLite v39 / Postgres v38 在 `memory_threads` 增加 `message_count`、`last_message_at`、`observation_count`、`last_observation_at`，迁移以每个子表一次 set-based `GROUP BY` 原子回填；单条/批量消息写入、dedup conflict、observation 写入与消息清理在同一事务维护汇总。Postgres prune 先按固定顺序锁定受影响的 thread 父行，避免并发 append 的增量被旧快照覆盖；既有 `memory:dedup` SQLite/Postgres 运维路径也在 wipe/prune 后原子重建四个汇总字段，重复运行保持幂等。Admin stats 之后只聚合较小的 thread 父表，不再扫描正文子表。首次升级仍会执行一次有界全量回填，生产发布必须预留启动迁移窗口并观察 WAL/磁盘；它不是每次页面读取的成本。
 - **缓存与前端边界**：SQLite page cache 从 16 MiB 提升到保守的 64 MiB；`/admin/api/stats` 与 `/admin/api/keys/usage` 使用 10 秒 fresh、5 分钟 last-known-good stale 的进程级 single-flight / stale-while-revalidate 缓存，并用 `X-Helm-Cache` 暴露 `miss/coalesced/fresh/stale`。动态 live window 使用稳定 cache key，历史闭合窗口仍按精确边界隔离。Admin 保留 hover code preload，但 data preload 改为 tap；dashboard 与 key detail 的独立读并行，隐藏 tab 不再执行自动刷新。当前生产库约 58.8 GB 且只有约 15 GB 可用、freelist 约 22.8 GiB，继续禁止在线 VACUUM；本次也不擅自开启 memory retention 或修改生产数据。
-
-## 2026-07-15 · Codex 已重置冷却在 Admin 投影为成功（Admin providers UI，docs/11，原则 3/5/7）
-
-- **UI 边界**：Gateway 与 reset-credit guard 保持不变；Admin 客户端仅把本地 `429 + reset_credit_cooldown_active` 解释为“该账号最近已经完成重置”，复用既有 `alreadyRedeemed` 成功路径并显示“重置已成功完成”。该投影不会重试、不会产生第二次 fetch，也不会再次请求 OpenAI。
-- **错误边界**：进行中的 `reset_credit_reservation_active`、配额/资格问题、其他 429、guard 故障与真实上游失败继续作为错误显示，不能因本次 UI 修正被吞掉。定向测试同时断言 cooldown 只调用一次 fetch、相邻 429 仍拒绝，以及 Providers 成功状态不出现 error alert。
 
 ## 历史条目摘要（最新要点）
 

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -1284,6 +1284,7 @@ describe("routeRequest — lane-forced reasoning_effort", () => {
     const passed = reqPassedToExecute(d);
     expect(passed.reasoning_effort).toBe("high");
     expect(passed.reasoning_effort_forced).toBe(true);
+    expect(result.decision.requested_reasoning_effort).toBe("low");
     expect(result.decision.reasoning_effort).toBe("high");
   });
 

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -973,6 +973,10 @@ export async function routeRequest(
   deps: RouteDeps,
   opts: RouteOptions = {},
 ): Promise<ExecutionResult> {
+  // Capture client intent before policy/lane routing can overwrite the mutable
+  // InternalRequest. This metadata is body-free and remains available when full
+  // payload capture is disabled.
+  const requestedReasoningEffort = req.reasoning_effort ?? null;
   const planned = await plan(req, deps, opts);
 
   // Rejected before execution (unknown model, lane not permitted, or every
@@ -984,6 +988,7 @@ export async function routeRequest(
       request_id: req.request_id,
       trace_id: correlationTraceId(req),
       requested_model: req.requested_model,
+      requested_reasoning_effort: requestedReasoningEffort,
       reasoning_effort: req.reasoning_effort ?? null,
       protocol: req.protocol,
       key_prefix: opts.keyPrefix ?? null,
@@ -1078,6 +1083,7 @@ export async function routeRequest(
     request_id: req.request_id,
     trace_id: correlationTraceId(req),
     requested_model: req.requested_model,
+    requested_reasoning_effort: requestedReasoningEffort,
     reasoning_effort: req.reasoning_effort ?? null,
     protocol: req.protocol,
     key_prefix: opts.keyPrefix ?? null,

--- a/packages/core/src/telemetry/decision.ts
+++ b/packages/core/src/telemetry/decision.ts
@@ -169,6 +169,8 @@ export function buildDecisionRecord(parts: DecisionParts): DecisionRecord {
     request_id: request.request_id,
     trace_id: correlationTraceId(request),
     requested_model: request.requested_model,
+    requested_reasoning_effort: request.reasoning_effort ?? null,
+    reasoning_effort: request.reasoning_effort ?? null,
     protocol: request.protocol,
     key_prefix: keyPrefix,
     classifier: {

--- a/packages/shared/src/decision/schema.test.ts
+++ b/packages/shared/src/decision/schema.test.ts
@@ -95,9 +95,11 @@ describe("DecisionRecordSchema", () => {
   it("preserves body-free reasoning effort metadata", () => {
     const parsed = DecisionRecordSchema.parse({
       ...fullRecord(),
+      requested_reasoning_effort: "low",
       reasoning_effort: "high",
     });
 
+    expect(parsed.requested_reasoning_effort).toBe("low");
     expect(parsed.reasoning_effort).toBe("high");
   });
 

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -219,6 +219,10 @@ export const DecisionRecordSchema = z.object({
   // server-generated request_id and must never be used as a storage/ownership key.
   trace_id: z.string().min(1),
   requested_model: z.string(),
+  // Reasoning level supplied by the client before any policy/lane override.
+  // Body-free metadata, kept separately from the effective value below so the
+  // Admin list can compare request intent with the routed execution decision.
+  requested_reasoning_effort: z.string().min(1).nullable().optional(),
   // Effective request reasoning level after policy/lane overrides. This is
   // deliberately body-free routing metadata so operators can inspect it even
   // when full request/response capture is disabled. Optional for stored legacy


### PR DESCRIPTION
## Summary
- persist the client-requested reasoning level separately from the effective routed level
- append the requested level directly after the requested model in shared request lists
- show only the effective routed level in the Routing cell
- preserve truthful legacy behavior when the requested level was not recorded

## Validation
- CI=true pnpm exec vitest run packages/shared/src/decision/schema.test.ts packages/core/src/routing/route-request.test.ts packages/core/src/telemetry/decision.test.ts apps/gateway/src/routes/responses.test.ts apps/admin/src/lib/api/requests.test.ts apps/admin/src/lib/components/RequestsTable.test.ts apps/admin/src/routes/requests/requests.test.ts apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
- pnpm typecheck
- pnpm --filter @helm/admin check
- Biome / Prettier / git diff --check

Tests: 316 passed; svelte-check: 0 errors and 0 warnings.