### PR TITLE
chore(release): v0.27.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.23",
+  "version": "0.27.24",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump the root package version from 0.27.23 to 0.27.24
- release the requested-vs-routed reasoning-effort list display merged in PR #598

## Validation
- PR #598 passed verify, e2e, docker, and report_pr_checks
- release diff is limited to the root package.json version