### PR TITLE
[codex] recover terminal tool XML

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-20 · `end_turn` XML 泄漏只按终态工具调用恢复（Protocol streaming / provider execution，docs/05/07，原则 3/5/8）
+
+- **恢复边界**：本机 2,520 个 Claude session JSONL 的匿名化扫描中，高置信完整泄漏有 85 个 `tool_use` 与 23 个 `end_turn`；后者是当前真实漏项。保留既有 `tool_use` 的宽松周边文本恢复；仅对 `end_turn` 增加收紧路径。共享 parser 只有在所有完整 invoke 都精确命中请求声明的工具、最后一个非空 segment 是已恢复的 tool、文本 segment 不含残留 `<invoke`，且 invoke 不在 Markdown 三反引号 fence 内时才接受；多个调用之间仅允许空白，避免把前置的无围栏 XML 示例一并执行。末尾空白可保留；无名、未闭合、未知尾巴、function-calls wrapper 和带转义引号的文档示例都不扩 grammar、不恢复。
+- **四出口一致性**：native Anthropic JSON/SSE 与 OpenAI→Anthropic translation JSON/SSE 都只在末个 terminal text 上调用该收紧路径，且没有既有 structured call 才可恢复；成功后分别将终态改为 `tool_use` / `tool_calls`。Translation SSE 与 JSON 复用同一份声明工具名映射，保证点号、碰撞等名称规范化一致。SSE 仍在 `message_delta` 证明终态后才改写，普通 `tool_use` 与非候选路径保持既有行为。
+- **验证**：TDD 先在共享 parser 和四个出口加入失败 case，再以 4 个定向 Vitest 文件、257 个用例覆盖完整 end-turn 恢复及拒绝 fence、尾随文本、调用间 prose、未闭合和未知 invoke；`pnpm typecheck`、`pnpm lint`、`pnpm build` 与 `git diff --check` 通过，不新增依赖或运行时配置。
+
 ## 2026-07-18 · 请求推理等级与实际路由等级分开展示（Telemetry / Admin requests，docs/07/11，原则 1/7）
 
 - **事实边界**：`requested_reasoning_effort` 在进入路由、策略或 lane 覆盖前从客户端请求单独截取；既有 `reasoning_effort` 继续表示覆盖后的有效执行等级。两者都是不含正文与密钥的可选 `DecisionRecord` 元数据，因此关闭 `capture_payloads` 后仍可读取，旧记录缺少请求等级时保持空白，不用有效等级反推客户端意图。
@@ -62,14 +68,9 @@
 - **诚实边界**：文档明确列出已解析但未完整生效的 `lane.constraints`、`classifier.rules.enabled`、`eval.cache.enabled`、policy `project_id` 与空/无交集 `allowed_lanes`，以及尚未挂载的 `HELM_BASE_PATH`、进程内多副本协调限制、Memory 观测/embedding 延迟和跨协议保真缺口。协议矩阵与 roadmap 以后必须把 native passthrough、可证明的翻译、结构化降级和未实现行为分开描述，避免把 schema 存在或测试 helper 能力写成已上线功能。
 - **中文文案边界**：`README.zh-CN.md` 保持与当前代码和英文技术事实一致，但作为独立中文文案按中文语序与读者习惯意译；命令、字段、端点、警告与链接不可改义，也不做逐句机械对照。
 
-## 2026-07-16 · Admin 首次点击卡顿改为非投机加载与汇总读（Admin / Store performance，docs/08/11，原则 1/3/7）
-
-- **生产根因**：`la.atmy.work` 的 `/admin/api/memory/stats` 冷读实测最高约 10.2 秒；同步 `better-sqlite3` 在 Node 事件循环上对约 139 万 `memory_messages`、11.9k observations 及其他 memory 表执行 `COUNT/MAX`，扫描期间连 health completion 都暂停。Admin 又在 `app.html` 全局启用 `data-sveltekit-preload-data="hover"`，鼠标经过侧栏即可投机触发这些数据库查询；第一次点击因此等待冷扫描，第二次点击命中 10 秒应用缓存或 OS page cache，形成“再点一下马上出来”的假象。同期没有 VACUUM、cleanup、OOM、`SQLITE_BUSY` 或 payload capture 事件，不能把本次页面卡顿归因于这些路径。
-- **稳定读模型**：SQLite v39 / Postgres v38 在 `memory_threads` 增加 `message_count`、`last_message_at`、`observation_count`、`last_observation_at`，迁移以每个子表一次 set-based `GROUP BY` 原子回填；单条/批量消息写入、dedup conflict、observation 写入与消息清理在同一事务维护汇总。Postgres prune 先按固定顺序锁定受影响的 thread 父行，避免并发 append 的增量被旧快照覆盖；既有 `memory:dedup` SQLite/Postgres 运维路径也在 wipe/prune 后原子重建四个汇总字段，重复运行保持幂等。Admin stats 之后只聚合较小的 thread 父表，不再扫描正文子表。首次升级仍会执行一次有界全量回填，生产发布必须预留启动迁移窗口并观察 WAL/磁盘；它不是每次页面读取的成本。
-- **缓存与前端边界**：SQLite page cache 从 16 MiB 提升到保守的 64 MiB；`/admin/api/stats` 与 `/admin/api/keys/usage` 使用 10 秒 fresh、5 分钟 last-known-good stale 的进程级 single-flight / stale-while-revalidate 缓存，并用 `X-Helm-Cache` 暴露 `miss/coalesced/fresh/stale`。动态 live window 使用稳定 cache key，历史闭合窗口仍按精确边界隔离。Admin 保留 hover code preload，但 data preload 改为 tap；dashboard 与 key detail 的独立读并行，隐藏 tab 不再执行自动刷新。当前生产库约 58.8 GB 且只有约 15 GB 可用、freelist 约 22.8 GiB，继续禁止在线 VACUUM；本次也不擅自开启 memory retention 或修改生产数据。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-16 · Admin 首次点击卡顿改为非投机加载与汇总读（Admin / Store performance，docs/08/11，原则 1/3/7）**：以 `memory_threads` 的事务维护汇总替代正文表冷扫描，Admin 改为非投机 data preload，并以有界 stale-while-revalidate 缓存保护统计读取；在线 VACUUM 继续禁止。
 - **2026-07-15 · Codex 配额 PULL 饱和后触发自动重置（OAuth quota / reset credits，docs/04/11，原则 3/5/7）**：仅新鲜 PULL/PUSH 在账号级周窗口饱和后经共享幂等 guard 触发 reset credit，成功后强制回读并同步 durable/live quota；cache-only 读取始终无副作用。
 - **2026-07-15 · Anthropic 不可用地域哨兵按全球基础卡计费（Catalog / telemetry accounting，docs/07/08，原则 2/3/5/7）**：仅把 `usage.inference_geo=not_available` 解释为地域缺失并使用全球基础卡，真实未知地域继续 unknown；实时与历史重算共用规范化且保留原始 provenance。
 - **2026-07-15 · 终端事件缺失的 Responses 流使用部分估算计费（Protocol streaming / telemetry accounting，docs/05/07，原则 3/5/7/8）**：原生 Responses 流缺终态时按 truncated/client_aborted 记失败，仅对已收 semantic delta 做有界 partial usage/cost 估算，并让 telemetry、attempt、budget 与 OAuth 账号结算一致；完整原文通过 git history 回溯。

--- a/packages/core/src/protocol/anthropic/response.test.ts
+++ b/packages/core/src/protocol/anthropic/response.test.ts
@@ -211,10 +211,37 @@ describe("transformResponseIn", () => {
     expect(out.stop_reason).toBe("tool_use");
   });
 
+  it("recovers a terminal closed whitelisted XML invoke from an end-turn response", () => {
+    const xml = '<invoke name="Bash"><parameter name="command">git status</parameter></invoke>';
+    const out = transformResponseIn(
+      makeIR({
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: xml },
+            finish_reason: "stop",
+          },
+        ],
+      }),
+      { toolNames: ["Bash"], toolCallXmlRecoveryEnabled: true },
+    );
+
+    expect(out.content).toContainEqual(
+      expect.objectContaining({ type: "tool_use", name: "Bash", input: { command: "git status" } }),
+    );
+    expect(out.stop_reason).toBe("tool_use");
+  });
+
   it.each([
     {
-      title: "finish reason is not tool_use",
-      finishReason: "stop",
+      title: "finish reason is not tool_use or end_turn",
+      finishReason: "length",
+      tools: ["Bash"],
+      enabled: true,
+    },
+    {
+      title: "unknown finish reason maps to end_turn but is ineligible",
+      finishReason: "not_a_finish_reason",
       tools: ["Bash"],
       enabled: true,
     },

--- a/packages/core/src/protocol/anthropic/response.ts
+++ b/packages/core/src/protocol/anthropic/response.ts
@@ -8,7 +8,7 @@ import {
   type IRUsage,
 } from "../ir.js";
 import { liftReasoningToFlat, resolveReasoning } from "../reasoning.js";
-import { recoverToolCallsFromText } from "./tool-xml-recovery.js";
+import { recoverTerminalToolCallsFromText, recoverToolCallsFromText } from "./tool-xml-recovery.js";
 
 // IR -> Anthropic Messages native response (docs/05, task protocol.anthropic-resp).
 // The outbound half of "nativeIn -> IR -> nativeOut, never N×N direct". Two
@@ -326,7 +326,7 @@ function repairJson(s: string): string | undefined {
 function toContentBlocks(
   message: IRResponse["choices"][number]["message"],
   toolNameMap: AnthropicToolNameMap,
-  recovery: { enabled: boolean; declaredTools: ReadonlySet<string> },
+  recovery: { enabled: boolean; terminalOnly: boolean; declaredTools: ReadonlySet<string> },
 ): AnthropicContentBlock[] {
   const blocks: AnthropicContentBlock[] = [];
   const { content } = message;
@@ -370,10 +370,14 @@ function toContentBlocks(
     }
   }
 
-  const pushText = (text: string): void => {
+  const pushText = (text: string, terminal: boolean): void => {
     if (text === "") return;
     const segments = recovery.enabled
-      ? recoverToolCallsFromText(text, recovery.declaredTools)
+      ? recovery.terminalOnly
+        ? terminal
+          ? recoverTerminalToolCallsFromText(text, recovery.declaredTools)
+          : null
+        : recoverToolCallsFromText(text, recovery.declaredTools)
       : null;
     if (segments === null) {
       blocks.push({ type: "text", text });
@@ -394,11 +398,13 @@ function toContentBlocks(
   };
 
   if (typeof content === "string") {
-    pushText(content);
+    pushText(content, true);
   } else if (Array.isArray(content)) {
-    for (const part of content) {
+    for (let index = 0; index < content.length; index += 1) {
+      const part = content[index];
+      if (part === undefined) continue;
       if (part.type === "text") {
-        pushText(part.text);
+        pushText(part.text, index === content.length - 1);
       }
       // thinking parts were already emitted via resolveReasoning above.
     }
@@ -450,7 +456,7 @@ export function transformResponseIn(
 ): AnthropicMessagesResponse {
   const choice = ir.choices[0];
   const message = choice?.message ?? { role: "assistant" as const, content: null };
-  const { stop_reason } = mapStopReason(choice?.finish_reason ?? "");
+  const { stop_reason: mappedStopReason } = mapStopReason(choice?.finish_reason ?? "");
   const anthropicSpeed: "fast" | "standard" | undefined =
     ir.service_tier === "fast" ? "fast" : ir.service_tier === "standard" ? "standard" : undefined;
   const usage = {
@@ -461,22 +467,31 @@ export function transformResponseIn(
     ...(message.tool_calls ?? []).map((call) => call.function.name),
     ...(options.toolNames ?? []),
   ]);
+  // Unknown upstream finish reasons map to the legal end_turn output enum, but do
+  // not earn the stricter end-turn recovery fallback.
+  const terminalOnly = choice?.finish_reason === "stop";
   // A real structured call already explains stop_reason=tool_use. Recovering XML in
   // that mixed response would create a second executable call from what may be prose.
   const xmlRecoveryEnabled =
     options.toolCallXmlRecoveryEnabled !== false &&
-    stop_reason === "tool_use" &&
+    (mappedStopReason === "tool_use" || terminalOnly) &&
     (message.tool_calls?.length ?? 0) === 0;
 
+  const content = toContentBlocks(message, toolNameMap, {
+    enabled: xmlRecoveryEnabled,
+    terminalOnly,
+    declaredTools: new Set(options.toolNames ?? []),
+  });
+  const stop_reason =
+    terminalOnly && xmlRecoveryEnabled && content.some((block) => block.type === "tool_use")
+      ? "tool_use"
+      : mappedStopReason;
   const out: AnthropicMessagesResponse = {
     id: ir.id,
     type: "message",
     role: "assistant",
     model: ir.model,
-    content: toContentBlocks(message, toolNameMap, {
-      enabled: xmlRecoveryEnabled,
-      declaredTools: new Set(options.toolNames ?? []),
-    }),
+    content,
     stop_reason,
     stop_sequence: null,
     usage,

--- a/packages/core/src/protocol/anthropic/stream.test.ts
+++ b/packages/core/src/protocol/anthropic/stream.test.ts
@@ -198,11 +198,45 @@ describe("convertOpenAIStreamToAnthropic — leaked tool XML recovery", () => {
     expect(open.size).toBe(0);
   });
 
-  it("flushes candidate XML verbatim when finish_reason does not map to tool_use", async () => {
+  it("recovers a terminal whitelisted invoke from an end-turn stream", async () => {
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(feed([textChunk(invoke), textChunk("", "stop")]), {
+        toolNames: ["Bash"],
+      }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "content_block_start",
+        content_block: expect.objectContaining({ type: "tool_use", name: "Bash" }),
+      }),
+    );
+    const terminal = events.find((event) => event.type === "message_delta");
+    expect(terminal).toMatchObject({ type: "message_delta", delta: { stop_reason: "tool_use" } });
+  });
+
+  it("sanitizes a recovered tool name consistently with non-stream translation", async () => {
+    const dottedInvoke =
+      '<invoke name="fs.read"><parameter name="path">README.md</parameter></invoke>';
+    const events = await collect(
+      convertOpenAIStreamToAnthropic(feed([textChunk(dottedInvoke), textChunk("", "stop")]), {
+        toolNames: ["fs.read"],
+      }),
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "content_block_start",
+        content_block: expect.objectContaining({ type: "tool_use", name: "fs_read" }),
+      }),
+    );
+  });
+
+  it("flushes candidate XML verbatim when finish_reason is not tool_use or literal end_turn", async () => {
     const chunks = [
       textChunk(`before ${invoke.slice(0, 17)}`),
       textChunk(invoke.slice(17)),
-      textChunk("", "stop"),
+      textChunk("", "not_a_finish_reason"),
     ];
     const events = await collect(
       convertOpenAIStreamToAnthropic(feed(chunks), { toolNames: ["Bash"] }),

--- a/packages/core/src/protocol/anthropic/stream.ts
+++ b/packages/core/src/protocol/anthropic/stream.ts
@@ -18,6 +18,7 @@ import {
 import {
   invokeStartIndex,
   invokeStartPrefixSuffixLength,
+  recoverTerminalToolCallsFromText,
   recoverToolCallsFromText,
 } from "./tool-xml-recovery.js";
 
@@ -280,7 +281,7 @@ interface StreamState {
   usage: IRUsage | null; // buffered; flushed on the terminal event
 }
 
-function createState(): StreamState {
+function createState(toolNames: readonly string[] = []): StreamState {
   return {
     messageStarted: false,
     nextBlockIndex: 0,
@@ -288,7 +289,7 @@ function createState(): StreamState {
     thinkingBlockIndex: null,
     textBlockIndex: null,
     toolIndexToBlock: new Map(),
-    toolNameMap: createAnthropicToolNameMap(),
+    toolNameMap: createAnthropicToolNameMap(toolNames),
     finishReason: null,
     usage: null,
   };
@@ -409,8 +410,11 @@ function* emitRecoveredToolXML(
   state: StreamState,
   text: string,
   declaredTools: ReadonlySet<string>,
+  terminalOnly = false,
 ): Generator<AnthropicSSEEvent, boolean> {
-  const segments = recoverToolCallsFromText(text, declaredTools);
+  const segments = terminalOnly
+    ? recoverTerminalToolCallsFromText(text, declaredTools)
+    : recoverToolCallsFromText(text, declaredTools);
   if (segments === null) return false;
 
   for (const segment of segments) {
@@ -429,7 +433,7 @@ function* emitRecoveredToolXML(
       content_block: {
         type: "tool_use",
         id: clientToolUseId({ id: tempId(blockIndex), blockIndex }),
-        name: segment.call.name,
+        name: state.toolNameMap.toAnthropic(segment.call.name),
         input: {},
       },
     };
@@ -486,7 +490,7 @@ export async function* convertOpenAIStreamToAnthropic(
   chunks: AsyncIterable<OpenAIChunk>,
   options: OpenAIToAnthropicStreamOptions = {},
 ): AsyncIterable<AnthropicSSEEvent> {
-  const state = createState();
+  const state = createState(options.toolNames ?? []);
   const declaredTools = new Set(options.toolNames ?? []);
   let recoveryEnabled = options.toolCallXmlRecoveryEnabled !== false && declaredTools.size > 0;
   let xmlCandidate: string | null = null;
@@ -536,8 +540,8 @@ export async function* convertOpenAIStreamToAnthropic(
       }
 
       // —— text: lazily open the text block, then stream text_delta. A potential
-      // leaked invoke is buffered until the terminal finish_reason supplies the
-      // third safety signal (it must map to Anthropic tool_use). ——
+      // leaked invoke is buffered until the terminal finish_reason either confirms
+      // tool_use or permits the stricter terminal-only end_turn fallback. ——
       if (delta?.content) {
         if (!recoveryEnabled) {
           yield* emitText(state, delta.content);
@@ -692,14 +696,17 @@ export async function* convertOpenAIStreamToAnthropic(
   }
 
   // Finish-reason is deliberately checked only after the whole OpenAI stream has
-  // drained: providers announce it after the content deltas. If it does not map to
-  // Anthropic tool_use, or parsing/whitelisting rejects the candidate, replay every
-  // buffered byte as text. Partial invoke-prefix probes are never swallowed either.
+  // drained: providers announce it after the content deltas. If neither tool_use nor
+  // the stricter terminal end_turn fallback applies, replay every buffered byte as
+  // text. Partial invoke-prefix probes are never swallowed either.
   if (xmlCandidate !== null) {
-    const stopIsToolUse = mapStopReason(state.finishReason ?? "").stop_reason === "tool_use";
-    const recovered = stopIsToolUse
-      ? yield* emitRecoveredToolXML(state, xmlCandidate, declaredTools)
-      : false;
+    const stopReason = mapStopReason(state.finishReason ?? "").stop_reason;
+    const terminalOnly = state.finishReason === "stop" && stopReason === "end_turn";
+    const recovered =
+      stopReason === "tool_use" || terminalOnly
+        ? yield* emitRecoveredToolXML(state, xmlCandidate, declaredTools, terminalOnly)
+        : false;
+    if (recovered && terminalOnly) state.finishReason = "tool_calls";
     if (!recovered) yield* emitText(state, xmlCandidate);
   } else if (invokeProbeSuffix !== "") {
     yield* emitText(state, invokeProbeSuffix);

--- a/packages/core/src/protocol/anthropic/tool-xml-recovery.test.ts
+++ b/packages/core/src/protocol/anthropic/tool-xml-recovery.test.ts
@@ -3,6 +3,7 @@ import {
   hasInvokeStart,
   invokeStartIndex,
   invokeStartPrefixSuffixLength,
+  recoverTerminalToolCallsFromText,
   recoverToolCallsFromText,
 } from "./tool-xml-recovery.js";
 
@@ -189,5 +190,30 @@ describe("recoverToolCallsFromText", () => {
     expect(call.call.input.__proto__).toEqual({ polluted: true });
     expect(Object.getPrototypeOf(call.call.input)).toBeNull();
     expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+});
+
+describe("recoverTerminalToolCallsFromText", () => {
+  const invoke = '<invoke name="Bash"><parameter name="command">git status</parameter></invoke>';
+
+  it("recovers a declared complete terminal invoke after leading prose and preserves whitespace", () => {
+    expect(recoverTerminalToolCallsFromText(`analysis\n${invoke}\n`, tools("Bash"))).toEqual([
+      { type: "text", text: "analysis\n" },
+      { type: "tool_use", call: { name: "Bash", input: { command: "git status" } } },
+      { type: "text", text: "\n" },
+    ]);
+  });
+
+  it.each([
+    ["an open code fence", `\`\`\`xml\n${invoke}`],
+    ["surrounding trailing text", `${invoke} done`],
+    ["an unclosed invoke tail", `${invoke}<invoke name="Bash">`],
+    ["an unknown invoke tail", `${invoke}<invoke name="Read"></invoke>`],
+    ["a nameless invoke prefix", `<invoke>${invoke}`],
+    ["a stray closing invoke prefix", `</invoke>${invoke}`],
+    ["an incomplete function_calls wrapper", `<function_calls>${invoke}`],
+    ["prose between multiple invokes", `${invoke}\nexample only\n${invoke}`],
+  ])("rejects $0", (_label, text) => {
+    expect(recoverTerminalToolCallsFromText(text, tools("Bash"))).toBeNull();
   });
 });

--- a/packages/core/src/protocol/anthropic/tool-xml-recovery.ts
+++ b/packages/core/src/protocol/anthropic/tool-xml-recovery.ts
@@ -148,3 +148,51 @@ export function recoverToolCallsFromText(
   appendText(segments, text.slice(cursor));
   return segments;
 }
+
+/**
+ * The end_turn fallback is intentionally narrower than tool_use recovery: every
+ * invoke must be declared and outside a Markdown code fence, and the final
+ * meaningful segment must itself be a recovered tool call.
+ */
+export function recoverTerminalToolCallsFromText(
+  text: string,
+  declaredTools: ReadonlySet<string>,
+): RecoverySegment[] | null {
+  const segments = recoverToolCallsFromText(text, declaredTools);
+  if (segments === null) return null;
+
+  let fence = text.indexOf("```");
+  let fences = 0;
+  for (const match of text.matchAll(invokePattern())) {
+    const index = match.index;
+    if (index === undefined) return null;
+    while (fence >= 0 && fence < index) {
+      fences += 1;
+      fence = text.indexOf("```", fence + 3);
+    }
+    if (fences % 2 === 1) return null;
+  }
+
+  const residualToolXml = /<\/?(?:[A-Za-z_][\w.-]*:)?(?:invoke|function_calls)\b/i;
+  for (const segment of segments) {
+    if (segment.type === "text" && residualToolXml.test(segment.text)) return null;
+  }
+  let recoveredToolSeen = false;
+  for (const segment of segments) {
+    if (segment.type === "tool_use") {
+      recoveredToolSeen = true;
+      continue;
+    }
+    // Leading prose may explain the action, but once execution begins, separate
+    // recovered calls only with whitespace. This prevents an earlier un-fenced
+    // XML example from becoming executable alongside the real terminal call.
+    if (recoveredToolSeen && segment.text.trim() !== "") return null;
+  }
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const segment = segments[index];
+    if (segment === undefined) continue;
+    if (segment.type === "tool_use") return segments;
+    if (segment.text.trim() !== "") return null;
+  }
+  return null;
+}

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -2337,6 +2337,36 @@ describe("createAnthropicClient — nativePassthrough", () => {
     });
   });
 
+  it("recovers a terminal whitelisted XML tool call from a native end-turn JSON response", async () => {
+    const upstream = {
+      id: "msg_xml_end_turn",
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: '<invoke name="Bash"><parameter name="command">git status</parameter></invoke>',
+        },
+      ],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => jsonResponse(upstream)) as unknown as typeof fetch,
+    });
+
+    const out = await client.nativePassthrough?.(
+      { ...nativeBody(), tools: [{ name: "Bash", input_schema: { type: "object" } }] },
+      { toolCallXmlRecovery: true },
+    );
+
+    expect(out).toMatchObject({
+      stop_reason: "tool_use",
+      content: [expect.objectContaining({ type: "tool_use", name: "Bash" })],
+    });
+  });
+
   it("does not recover XML when the native JSON already has a structured tool_use", async () => {
     const upstream = {
       id: "msg_mixed_tools",
@@ -2379,8 +2409,8 @@ describe("createAnthropicClient — nativePassthrough", () => {
       flag: false,
     },
     {
-      label: "the stop reason is not tool_use",
-      stopReason: "end_turn",
+      label: "the stop reason is not tool_use or end_turn",
+      stopReason: "max_tokens",
       toolName: "Bash",
       flag: true,
     },
@@ -2968,6 +2998,64 @@ describe("createAnthropicClient — nativePassthroughStream", () => {
       delta: { stop_reason: "tool_use" },
     });
     expect(events.at(-1)).toEqual({ type: "message_stop" });
+  });
+
+  it("recovers a terminal XML invoke and upgrades an end_turn native SSE terminal", async () => {
+    const writes = [
+      sseEvent("message_start", {
+        type: "message_start",
+        message: {
+          id: "msg_xml_end_turn",
+          content: [],
+          stop_reason: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+      }),
+      sseEvent("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      sseEvent("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "text_delta",
+          text: '<invoke name="Bash"><parameter name="command">git status</parameter></invoke>',
+        },
+      }),
+      sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+      sseEvent("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 2 },
+      }),
+      sseEvent("message_stop", { type: "message_stop" }),
+    ];
+    const client = createAnthropicClient({
+      config: { baseUrl: "https://api.anthropic.com", apiKey: "sk-static" },
+      fetch: (async () => sseStreamResponse(writes)) as unknown as typeof fetch,
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      { ...nativeStreamBody(), tools: [{ name: "Bash", input_schema: { type: "object" } }] },
+      { toolCallXmlRecovery: true },
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    const events = parsedSSEEvents(chunks.join(""));
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "content_block_start",
+        content_block: expect.objectContaining({ type: "tool_use", name: "Bash" }),
+      }),
+    );
+    expect(events.at(-2)).toMatchObject({
+      type: "message_delta",
+      delta: { stop_reason: "tool_use" },
+    });
   });
 
   it("does not recover XML when the native stream already emitted structured tool_use", async () => {

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -31,6 +31,7 @@ import {
   invokeStartIndex,
   invokeStartPrefixSuffixLength,
   type RecoverySegment,
+  recoverTerminalToolCallsFromText,
   recoverToolCallsFromText,
 } from "../protocol/anthropic/tool-xml-recovery.js";
 import {
@@ -1866,14 +1867,16 @@ function recoveredToolUseBlock(
 /**
  * Recover the non-streaming sibling of native passthrough without weakening the
  * byte-faithful common path. The caller has already proved the request-scoped flag;
- * this helper additionally requires Anthropic's own tool_use terminal signal and a
- * declared request tool before replacing any text block.
+ * this helper additionally requires either Anthropic's tool_use signal or the strict
+ * terminal-only end_turn fallback, plus a declared request tool.
  */
 function recoverNativeAnthropicJSON(
   response: Record<string, unknown>,
   declaredTools: ReadonlySet<string>,
 ): Record<string, unknown> {
-  if (response.stop_reason !== "tool_use" || declaredTools.size === 0) return response;
+  const terminalOnly = response.stop_reason === "end_turn";
+  if ((!terminalOnly && response.stop_reason !== "tool_use") || declaredTools.size === 0)
+    return response;
   const content = response.content;
   if (!Array.isArray(content)) return response;
   // `stop_reason` is message-scoped. If Anthropic already emitted a real tool_use,
@@ -1893,7 +1896,8 @@ function recoverNativeAnthropicJSON(
 
   let recovered = false;
   const nextContent: unknown[] = [];
-  for (const rawBlock of content) {
+  for (let index = 0; index < content.length; index += 1) {
+    const rawBlock = content[index];
     if (rawBlock === null || typeof rawBlock !== "object" || Array.isArray(rawBlock)) {
       nextContent.push(rawBlock);
       continue;
@@ -1903,7 +1907,11 @@ function recoverNativeAnthropicJSON(
       nextContent.push(rawBlock);
       continue;
     }
-    const segments = recoverToolCallsFromText(block.text, declaredTools);
+    const segments = terminalOnly
+      ? index === content.length - 1
+        ? recoverTerminalToolCallsFromText(block.text, declaredTools)
+        : null
+      : recoverToolCallsFromText(block.text, declaredTools);
     if (segments === null) {
       nextContent.push(rawBlock);
       continue;
@@ -1914,7 +1922,9 @@ function recoverNativeAnthropicJSON(
       else nextContent.push(recoveredToolUseBlock(segment, nextContent.length));
     }
   }
-  return recovered ? { ...response, content: nextContent } : response;
+  return recovered
+    ? { ...response, content: nextContent, ...(terminalOnly ? { stop_reason: "tool_use" } : {}) }
+    : response;
 }
 
 interface ParsedRawSSEFrame {
@@ -2184,7 +2194,8 @@ function rewriteNativeAnthropicSSETail(
     return null;
   }
 
-  let terminalToolUseDeltaIndex = -1;
+  let terminalDeltaIndex = -1;
+  let terminalOnly = false;
   for (let index = 0; index < messageStopIndex; index += 1) {
     const event = parsed.frames[index]?.event;
     if (event?.type !== "message_delta") continue;
@@ -2193,25 +2204,28 @@ function rewriteNativeAnthropicSSETail(
       delta !== null &&
       typeof delta === "object" &&
       !Array.isArray(delta) &&
-      (delta as { stop_reason?: unknown }).stop_reason === "tool_use"
+      ((delta as { stop_reason?: unknown }).stop_reason === "tool_use" ||
+        (delta as { stop_reason?: unknown }).stop_reason === "end_turn")
     ) {
-      terminalToolUseDeltaIndex = index;
+      terminalDeltaIndex = index;
+      terminalOnly = (delta as { stop_reason?: unknown }).stop_reason === "end_turn";
     }
   }
-  if (terminalToolUseDeltaIndex < 0) return null;
+  if (terminalDeltaIndex < 0) return null;
   // Only ping/comment/opaque frames may sit between the terminal delta and stop.
   if (
     parsed.frames
-      .slice(terminalToolUseDeltaIndex + 1, messageStopIndex)
+      .slice(terminalDeltaIndex + 1, messageStopIndex)
       .some((frame) => frame.event !== null && frame.event.type !== "ping")
   ) {
     return null;
   }
   const lastBlockStopIndex = parsed.frames.findLastIndex(
-    (frame, index) =>
-      index < terminalToolUseDeltaIndex && frame.event?.type === "content_block_stop",
+    (frame, index) => index < terminalDeltaIndex && frame.event?.type === "content_block_stop",
   );
   if (lastBlockStopIndex < 0) return null;
+  const terminalTextIndex = numericEventIndex(parsed.frames[lastBlockStopIndex]?.event ?? {});
+  if (terminalOnly && terminalTextIndex === null) return null;
 
   const textByIndex = new Map<number, string>();
   const stoppedIndexes = new Set<number>();
@@ -2226,8 +2240,11 @@ function rewriteNativeAnthropicSSETail(
 
   const recoveredByIndex = new Map<number, RecoverySegment[]>();
   for (const [index, text] of textByIndex) {
+    if (terminalOnly && index !== terminalTextIndex) continue;
     if (!stoppedIndexes.has(index) || (!hasInvokeStart(text) && !text.includes("<"))) continue;
-    const segments = recoverToolCallsFromText(text, declaredTools);
+    const segments = terminalOnly
+      ? recoverTerminalToolCallsFromText(text, declaredTools)
+      : recoverToolCallsFromText(text, declaredTools);
     if (segments !== null) recoveredByIndex.set(index, segments);
   }
   if (recoveredByIndex.size === 0) return null;
@@ -2242,6 +2259,17 @@ function rewriteNativeAnthropicSSETail(
     }
     const sourceIndex = numericEventIndex(event);
     const recovered = sourceIndex === null ? undefined : recoveredByIndex.get(sourceIndex);
+    if (
+      terminalOnly &&
+      event.type === "message_delta" &&
+      frame === parsed.frames[terminalDeltaIndex]
+    ) {
+      const delta = event.delta;
+      if (delta !== null && typeof delta === "object" && !Array.isArray(delta)) {
+        out += encodedSSEEvent({ ...event, delta: { ...delta, stop_reason: "tool_use" } });
+        continue;
+      }
+    }
     if (
       recovered !== undefined &&
       event.type === "content_block_delta" &&
@@ -2267,9 +2295,10 @@ function rewriteNativeAnthropicSSETail(
 /**
  * Candidate-gated Anthropic SSE recovery. Complete safe frames are released in the
  * exact original network chunks. Once a possible XML start appears, only that tail
- * is held until Anthropic's later message_delta proves `stop_reason:tool_use`; a miss
- * flushes the original chunks unchanged. The source remains readAnthropicSSERaw, so
- * its upstream idle/stall deadline continues to guard every network read.
+ * is held until Anthropic's later message_delta either confirms tool_use or permits
+ * the stricter terminal-only end_turn fallback; a miss flushes the original chunks
+ * unchanged. The source remains readAnthropicSSERaw, so its upstream idle/stall
+ * deadline continues to guard every network read.
  */
 async function* recoverNativeAnthropicSSE(
   source: AsyncIterable<string>,


### PR DESCRIPTION
## What changed

- recover complete, request-declared terminal `<invoke>` calls when an upstream ends with `end_turn` instead of `tool_use`
- apply the same strict fallback to native Anthropic JSON/SSE and OpenAI-to-Anthropic JSON/SSE
- rewrite the terminal reason only after successful recovery and preserve normal `tool_use` behavior
- reject fenced examples, trailing prose, malformed or undeclared invokes, residual wrappers, and mixed structured calls
- keep translated stream tool-name sanitization consistent with non-stream responses

## Root cause

A local-only aggregate scan of 2,520 private Claude session JSONL files found 85 high-confidence complete leaks already covered by the existing `tool_use` path and 23 high-confidence complete terminal invokes emitted with `end_turn`. The latter bypassed recovery and reached clients as literal XML. Private message bodies were not copied into this PR.

## Impact

This is a backward-compatible protocol fix. It has no schema, migration, dependency, or configuration change. Existing `tool_call_xml_recovery` controls the behavior and remains default-on.

## Validation

- `CI=true pnpm exec vitest run packages/core/src/protocol/anthropic/tool-xml-recovery.test.ts packages/core/src/protocol/anthropic/response.test.ts packages/core/src/protocol/anthropic/stream.test.ts packages/core/src/provider/anthropic.test.ts` — 257 passed
- `pnpm typecheck`
- `pnpm lint` — passed with 37 existing unrelated warnings
- `pnpm build`
- `git diff --check`

## Security review

An independent review identified and verified fixes for two boundaries before commit: prose between multiple terminal invokes is rejected, and recovered translated-stream tool names use the shared Anthropic name map.