### PR TITLE
[codex] release v0.27.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.24",
+  "version": "0.27.25",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bumps Helm API from `0.27.24` to `0.27.25`.

This patch releases the terminal `<invoke>` XML recovery merged in #601. It is backward-compatible and has no migration, dependency, or configuration-schema changes.

## Validation

- #601 required CI: verify, e2e, docker, and PR aggregate checks passed
- `CI=true pnpm exec vitest run packages/shared/src/ci-workflow.test.ts` — 25 passed
- version-only diff