### PR TITLE
[codex] Add Grok Build client setup guide

### DIFF
--- a/apps/admin/src/lib/components/ConnectClientDialog.svelte
+++ b/apps/admin/src/lib/components/ConnectClientDialog.svelte
@@ -17,7 +17,7 @@
   // never persisted or re-fetched here (CLAUDE.md 原则7 / docs/06).
   let { plaintextKey, onclose }: { plaintextKey?: string; onclose: () => void } = $props();
 
-  type Tab = 'claude' | 'codex' | 'gemini' | 'openclaw' | 'sdk';
+  type Tab = 'claude' | 'codex' | 'grok' | 'gemini' | 'openclaw' | 'sdk';
   let tab = $state<Tab>('claude');
 
   // The gateway is same-origin with this SPA (Hono serves the admin at /admin), so
@@ -43,6 +43,9 @@
   );
   let codexToml = $derived(
     `# ~/.codex/config.toml\n[model_providers.helm]\nname = "Helm"\nbase_url = "${baseV1}"\nenv_key = "HELM_API_KEY"\nwire_api = "responses"\n\n# then, in your shell:\nexport HELM_API_KEY="${keyShown}"`,
+  );
+  let grokEnv = $derived(
+    `export GROK_MODELS_BASE_URL="${baseV1}"\nexport XAI_API_KEY="${keyShown}"\n\ngrok -m auto`,
   );
   // Gemini CLI / Google GenAI SDK read GOOGLE_GEMINI_BASE_URL and append the
   // /v1beta/models/{model}:generateContent path themselves — so this is the BARE
@@ -130,6 +133,13 @@
         type="button"
         role="tab"
         class="tab-btn shrink-0 whitespace-nowrap"
+        aria-selected={tab === 'grok'}
+        onclick={() => (tab = 'grok')}>Grok Build</button
+      >
+      <button
+        type="button"
+        role="tab"
+        class="tab-btn shrink-0 whitespace-nowrap"
         aria-selected={tab === 'gemini'}
         onclick={() => (tab = 'gemini')}>{$t('Gemini')}</button
       >
@@ -164,6 +174,13 @@
           )}
         </p>
         {@render codeBlock('codex-toml', codexToml, 'snippet-codex')}
+      {:else if tab === 'grok'}
+        <p class="mb-2 text-sm text-ink-body">
+          {$t(
+            'Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model "auto".',
+          )}
+        </p>
+        {@render codeBlock('grok-env', grokEnv, 'snippet-grok')}
       {:else if tab === 'gemini'}
         <p class="mb-2 text-sm text-ink-body">
           {$t(

--- a/apps/admin/src/lib/components/ConnectClientDialog.test.ts
+++ b/apps/admin/src/lib/components/ConnectClientDialog.test.ts
@@ -63,6 +63,15 @@ describe('ConnectClientDialog', () => {
     expect(snippet).toContain('wire_api = "responses"');
   });
 
+  it('renders the Grok Build tab with Helm model discovery and bearer-key auth', async () => {
+    setup({ plaintextKey: 'helm_live_GROK' });
+    await fireEvent.click(screen.getByRole('tab', { name: /grok build/i }));
+    const snippet = screen.getByTestId('snippet-grok').textContent ?? '';
+    expect(snippet).toContain(`export GROK_MODELS_BASE_URL="${ORIGIN}/v1"`);
+    expect(snippet).toContain('export XAI_API_KEY="helm_live_GROK"');
+    expect(snippet).toContain('grok -m auto');
+  });
+
   it('renders the Gemini tab with the native /v1beta path and x-goog-api-key auth', async () => {
     setup();
     await fireEvent.click(screen.getByRole('tab', { name: /gemini/i }));
@@ -112,13 +121,16 @@ describe('ConnectClientDialog', () => {
     await fireEvent.click(copyBtn);
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     expect(writeText.mock.calls[0][0]).toContain(`ANTHROPIC_BASE_URL="${ORIGIN}"`);
-    await waitFor(() => expect(screen.getAllByRole('button', { name: /copied/i }).length).toBeGreaterThan(0));
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /copied/i }).length).toBeGreaterThan(0),
+    );
   });
 
-  it('exposes Claude Code, Codex, Gemini, OpenClaw and SDK tabs', () => {
+  it('exposes Claude Code, Codex, Grok Build, Gemini, OpenClaw and SDK tabs', () => {
     setup();
     expect(screen.getByRole('tab', { name: /claude code/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /codex/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /grok build/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /gemini/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /openclaw/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /sdk/i })).toBeInTheDocument();

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -771,6 +771,7 @@
   "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.": "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.",
   "Serving": "Serving",
   "Set the primary model and fallback chain for each quality and cost tier.": "Set the primary model and fallback chain for each quality and cost tier.",
+  "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".": "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".",
   "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).",
   "Settings": "Settings",
   "Show all {count} dimensions": "Show all {count} dimensions",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -771,6 +771,7 @@
   "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.": "Reglas de enrutamiento del lado del servidor. Cada una es una condición → acción (forzar una lane). Las políticas anulan las lanes de tarea, pero nunca la cadena de fallback de ejecución.",
   "Serving": "Sirviendo",
   "Set the primary model and fallback chain for each quality and cost tier.": "Define el modelo principal y la cadena de fallback para cada nivel de calidad y coste.",
+  "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".": "Configura estas variables de entorno. La base URL DEBE terminar en /v1 para que Grok Build descubra los modelos de Helm; después inicia con el modelo “auto”.",
   "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "Configura estas variables de entorno. La base URL es el origen sin ruta: NO añadas /v1 (los clientes Anthropic agregan /v1/messages por sí mismos).",
   "Settings": "Ajustes",
   "Show all {count} dimensions": "Mostrar todas las {count} dimensiones",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -771,6 +771,7 @@
   "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.": "サーバーサイドのルーティング規則。各規則は 条件 → アクション（レーンの強制）です。ポリシーはタスクレーンを上書きしますが、実行フォールバック チェーンは上書きしません。",
   "Serving": "提供元",
   "Set the primary model and fallback chain for each quality and cost tier.": "各品質およびコストティアのプライマリモデルとフォールバックチェーンを設定します。",
+  "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".": "次の環境変数を設定します。Grok Build が Helm のモデルを検出できるよう、base URL は /v1 で終わらせ、model “auto” で起動します。",
   "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "次の環境変数を設定します。base URL はオリジンそのままで——/v1 は付けないでください（Anthropic クライアントが自分で /v1/messages を付けます）。",
   "Settings": "設定",
   "Show all {count} dimensions": "全 {count} 件のディメンションを表示",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -771,6 +771,7 @@
   "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.": "서버 측 라우팅 규칙. 각 규칙은 조건 → 동작(레인 강제)입니다. 정책은 작업 레인을 재정의하지만 실행 폴백 체인은 재정의하지 않습니다.",
   "Serving": "제공",
   "Set the primary model and fallback chain for each quality and cost tier.": "각 품질 및 비용 티어에 대한 기본 모델과 대체 체인을 설정하세요.",
+  "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".": "다음 환경 변수를 설정하세요. Grok Build가 Helm 모델을 찾을 수 있도록 base URL은 /v1로 끝나야 하며, model “auto”로 시작하세요.",
   "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "다음 환경 변수를 설정하세요. base URL은 오리진 그대로이며 /v1을 붙이지 마세요(Anthropic 클라이언트가 /v1/messages를 직접 붙입니다).",
   "Settings": "설정",
   "Show all {count} dimensions": "전체 {count}개 차원 보기",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -771,6 +771,7 @@
   "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.": "Regras de roteamento do lado do servidor. Cada uma é uma condição → ação (forçar uma lane). Políticas substituem lanes de tarefa, mas nunca a cadeia de fallback de execução.",
   "Serving": "Servindo",
   "Set the primary model and fallback chain for each quality and cost tier.": "Defina o modelo principal e a cadeia de fallback para cada nível de qualidade e custo.",
+  "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".": "Defina estas variáveis de ambiente. A base URL DEVE terminar em /v1 para que o Grok Build descubra os modelos do Helm; depois inicie com o modelo “auto”.",
   "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "Defina estas variáveis de ambiente. A base URL é a origem sem caminho: NÃO adicione /v1 (clientes Anthropic acrescentam /v1/messages por conta própria).",
   "Settings": "Configurações",
   "Show all {count} dimensions": "Mostrar todas as {count} dimensões",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -771,6 +771,7 @@
   "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.": "服务端路由规则。每条都是 条件 → 动作（强制某条通道）。策略会覆盖任务通道，但绝不覆盖执行回退链。",
   "Serving": "服务",
   "Set the primary model and fallback chain for each quality and cost tier.": "为每个质量和成本层级设置主模型和备用链。",
+  "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".": "设置这些环境变量。base URL 必须以 /v1 结尾，Grok Build 才能发现 Helm 模型；然后用 “auto” 模型启动。",
   "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "设置下面这几个环境变量。base URL 用裸域名即可——千万别加 /v1（Anthropic 客户端会自己补上 /v1/messages）。",
   "Settings": "设置",
   "Show all {count} dimensions": "展开查看全部 {count} 项",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -771,6 +771,7 @@
   "Server-side routing rules. Each is a condition → action (force a lane). Policies override task lanes but never the execution fallback chain.": "伺服器端路由規則。每條都是 條件 → 動作（強制某條通道）。策略會覆蓋任務通道，但絕不覆蓋執行回退鏈。",
   "Serving": "服務",
   "Set the primary model and fallback chain for each quality and cost tier.": "為每個品質和成本層級設定主模型和備用鏈。",
+  "Set these environment variables. The base URL MUST end in /v1 so Grok Build can discover Helm models, then start with model \"auto\".": "設定這些環境變數。base URL 必須以 /v1 結尾，Grok Build 才能發現 Helm 模型；然後使用 “auto” 模型啟動。",
   "Set these environment variables. The base URL is the bare origin — do NOT add /v1 (Anthropic clients append /v1/messages themselves).": "設定下面這幾個環境變數。base URL 用裸網域即可——千萬別加 /v1（Anthropic 用戶端會自己補上 /v1/messages）。",
   "Settings": "設定",
   "Show all {count} dimensions": "展開查看全部 {count} 項",

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-07-21 · Grok Build 复用 OpenAI 模型发现接入 Helm（Admin client setup，docs/05/11，原则 2/5/6）
+
+- **官方契约**：以 `xai-org/grok-build@a881e67` 的 Custom Models 指南为准，Grok Build 设置 `GROK_MODELS_BASE_URL` 后从 `{base_url}/models` 发现模型，以 `XAI_API_KEY` 作为 Bearer key，并默认走 OpenAI Chat Completions。Admin「接入客户端」因此只新增可复制的 `GROK_MODELS_BASE_URL=<origin>/v1`、Helm key 与 `grok -m auto` 引导；`/v1/models` 继续按 key 暴露 `auto` / lanes，推理由既有 `/v1/chat/completions` 路由处理。
+- **最小边界**：不新增 Grok 专用 Gateway 路由、协议适配、依赖或运行时配置，也不要求 `grok login`；只扩展现有 Admin 对话框、七种现有语言文案与一个定向组件测试。
+
 ## 2026-07-20 · `end_turn` XML 泄漏只按终态工具调用恢复（Protocol streaming / provider execution，docs/05/07，原则 3/5/8）
 
 - **恢复边界**：本机 2,520 个 Claude session JSONL 的匿名化扫描中，高置信完整泄漏有 85 个 `tool_use` 与 23 个 `end_turn`；后者是当前真实漏项。保留既有 `tool_use` 的宽松周边文本恢复；仅对 `end_turn` 增加收紧路径。共享 parser 只有在所有完整 invoke 都精确命中请求声明的工具、最后一个非空 segment 是已恢复的 tool、文本 segment 不含残留 `<invoke`，且 invoke 不在 Markdown 三反引号 fence 内时才接受；多个调用之间仅允许空白，避免把前置的无围栏 XML 示例一并执行。末尾空白可保留；无名、未闭合、未知尾巴、function-calls wrapper 和带转义引号的文档示例都不扩 grammar、不恢复。
@@ -61,15 +66,9 @@
 - **请求归属边界**：入站 `X-Request-Id` / `X-Trace-Id` 继续作为可复用的客户端关联信息，不能再充当数据库主键；响应 `X-Trace-Id` 稳定回显该值，Responses 路径的 `X-Request-Id` 则按既有 Codex/OpenAI 兼容契约可能展示上游诊断 ID。Gateway 为每次请求生成不可覆盖的内部 `request_id`，通过 `X-Helm-Request-Id` 返回，并统一用于 telemetry、payload、replay 与 Portal ownership；Admin 列表 row key、详情链接、payload 与 Retry 也只按 `request_id` 寻址，`trace_id` 保留为展示/复制字段，重复 trace 不会再产生重复 keyed row。详情页“复制 Trace ID”读取展示中的客户端关联值，不再误复制 URL 里的内部 ID；Portal 的详情与 payload URL 明确使用 `request_id`，同时在安全投影中保留 `trace_id`，方便 key 持有者对照自己的日志。Interactions 响应体的 `id` 固定为 `int_<request_id>`，可与 `X-Helm-Request-Id` 对照，绝不从客户端可控的 `trace_id` 派生。鉴权失败也复用 middleware 已解析的 context trace，避免 401 错误体、响应头和完成日志各自生成不同 ID。`request.completed` 与 `route.decision` 都同时记录两者，便于从外部关联值定位唯一存储记录。`recordServed` 强制 DecisionRecord 与 payload 共用内部主键，避免攻击者复用 trace 值覆盖或读取其他请求；生产 routeRequest、执行错误与拒绝路径也统一从 metadata 保留客户端关联 ID。
 - **Memory 隔离与迁移**：物理 thread id 改为版本化编码，纳入 account、有效 project（`memory_project_id ?? key_id`）和客户端 thread id；同一账号下默认项目不同的 key 不再意外共享，显式选择同一项目的 key 仍按契约共享。Chat、Messages、Responses、observe/inject、worker、MCP 与 Admin 使用同一投影规则，对客户端和运维界面继续显示原始 thread id；输入始终按 opaque client id 处理，不能凭 `acct:` / `v2:` 外形猜测物理 ID。旧 account-only parent 无法证明归属，SQLite v40 / Postgres v39 因此不做猜测：parent 与子表进入 `v2:q:p:*` 隔离区并清除 project/resource，受影响 owner 的全部历史 fact/reflection（包括没有 thread 的项目级派生数据）进入 `v2:q:r:*`，reflection 归档，fact 同时归档并标记失效；可能继续消费混合历史的待处理或运行中任务一律标记失败，畸形 job scope 也改写成合法的合成隔离作用域，避免统计查询被坏 JSON 拖垮。`owner_id` 缺失、目标 ID 冲突或 FK 异常会让整版迁移回滚并拒绝启动；Postgres 每版迁移在 Drizzle 保留的单一事务连接内取得事务级 advisory lock，不能再用连接池上的分散 `BEGIN/COMMIT` 冒充原子事务。升级前必须停掉所有旧副本并备份数据库，混合版本滚动升级不受支持。
 
-## 2026-07-16 · 文档以当前源码为准完成全量运行时事实校准（docs/01–14 / README / operations，原则 1–8）
-
-- **审计边界**：以当前分支的路由注册、composition root、Zod schema、Store 端口与迁移、默认配置和定向测试为权威，逐章校准 README、`docs/01–14`、协议/Memory 专题、部署说明、Portal、历史复盘与 passthrough 运维文档；本次只修文档与 `.env.example`，不改变任何运行时行为。历史 incident、review、proposal、外部研究和 v0.25.2 Admin 截图保留原始证据，但必须显式标注为历史快照，不能继续充当当前契约。
-- **主要纠偏**：Portal 已完整实现且按 key ownership 隔离 request/payload/memory；新 key 的 Memory 默认值是 `off`；`/healthz` 只是浅层进程 readiness；Gateway 不自动加载 `.env`，Compose 也只转发 `environment:` 中显式列出的变量；root bootstrap 明文 key 只写一次到配置的 `0600` recovery file；OpenAPI 只覆盖主要公共路由；shipping Admin 配置实际上依赖 `HELM_ADMIN_*` 环境变量。
-- **诚实边界**：文档明确列出已解析但未完整生效的 `lane.constraints`、`classifier.rules.enabled`、`eval.cache.enabled`、policy `project_id` 与空/无交集 `allowed_lanes`，以及尚未挂载的 `HELM_BASE_PATH`、进程内多副本协调限制、Memory 观测/embedding 延迟和跨协议保真缺口。协议矩阵与 roadmap 以后必须把 native passthrough、可证明的翻译、结构化降级和未实现行为分开描述，避免把 schema 存在或测试 helper 能力写成已上线功能。
-- **中文文案边界**：`README.zh-CN.md` 保持与当前代码和英文技术事实一致，但作为独立中文文案按中文语序与读者习惯意译；命令、字段、端点、警告与链接不可改义，也不做逐句机械对照。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-16 · 文档以当前源码为准完成全量运行时事实校准（docs/01–14 / README / operations，原则 1–8）**：以当前路由、schema、Store、配置与测试校准全部当前文档和中英文 README，明确 Portal、部署、安全、Memory 与协议实现/缺口边界；完整原文通过 git history 回溯。
 - **2026-07-16 · Admin 首次点击卡顿改为非投机加载与汇总读（Admin / Store performance，docs/08/11，原则 1/3/7）**：以 `memory_threads` 的事务维护汇总替代正文表冷扫描，Admin 改为非投机 data preload，并以有界 stale-while-revalidate 缓存保护统计读取；在线 VACUUM 继续禁止。
 - **2026-07-15 · Codex 配额 PULL 饱和后触发自动重置（OAuth quota / reset credits，docs/04/11，原则 3/5/7）**：仅新鲜 PULL/PUSH 在账号级周窗口饱和后经共享幂等 guard 触发 reset credit，成功后强制回读并同步 durable/live quota；cache-only 读取始终无副作用。
 - **2026-07-15 · Anthropic 不可用地域哨兵按全球基础卡计费（Catalog / telemetry accounting，docs/07/08，原则 2/3/5/7）**：仅把 `usage.inference_geo=not_available` 解释为地域缺失并使用全球基础卡，真实未知地域继续 unknown；实时与历史重算共用规范化且保留原始 provenance。


### PR DESCRIPTION
## Summary

- add a Grok Build tab to the Admin client connection guide
- provide the official `GROK_MODELS_BASE_URL` and `XAI_API_KEY` setup with Helm model `auto`
- localize the guidance across the seven existing Admin locales and record the integration boundary

## Why

Grok Build supports custom OpenAI-compatible endpoints and discovers models from `{base_url}/models`. Helm already exposes authenticated `/v1/models` and `/v1/chat/completions`, so users only need a correct `/v1` base URL and their Helm key. The UI guide prevents the base-URL guesswork without adding a Grok-specific gateway path.

Official reference: https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/11-custom-models.md

## Impact

Admin users can copy a working Grok Build setup directly from the API Keys page. Gateway behavior, routing, dependencies, and runtime configuration are unchanged.

## Validation

- `CI=true pnpm exec vitest run apps/admin/src/lib/components/ConnectClientDialog.test.ts` (10 passed)
- `CI=true pnpm --filter @helm/admin check` (0 errors, 0 warnings)
- Admin Prettier check passed
- locale JSON validation passed
- `git diff --check` passed
