### PR TITLE
[codex] release v0.27.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.25",
+  "version": "0.27.26",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bumps Helm API from `0.27.25` to `0.27.26`.

This patch releases the smooth first-run setup, `HELM_PORT`/Linux installation fixes, optional provider onboarding, subscription-provider guidance, and the first-party Admin login page merged in #604. It is backward-compatible and has no database migration, dependency, or configuration-schema changes.

## Validation

- #604 required CI: verify, e2e, docker, and PR aggregate checks passed
- merged-main CI run `29804471556`: verify, e2e, and docker passed on `b350cca`
- version-only diff
