### PR TITLE
Release v0.27.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.26",
+  "version": "0.27.27",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- Bump the root package version from `0.27.26` to `0.27.27`.

## Why

- Publish the merged request-body-limit removal from PR #606.
- Ensure Remote runs the image that removes Helm API request-body buffering and leaves request-size enforcement to Nginx.

## Impact

- Patch release; no database migration.
- Helm API no longer enforces or buffers a duplicate application-layer body-size limit.

## Validation

- PR #606 CI passed: verify, e2e, and docker.
- Release diff is version-only.
- `git diff --check` passed.