### PR TITLE
[codex] Enable safe Codex WebSocket continuations

### DIFF
--- a/apps/admin/src/lib/components/ConnectClientDialog.svelte
+++ b/apps/admin/src/lib/components/ConnectClientDialog.svelte
@@ -42,7 +42,7 @@
     `export ANTHROPIC_BASE_URL="${baseBare}"\nexport ANTHROPIC_AUTH_TOKEN="${keyShown}"`,
   );
   let codexToml = $derived(
-    `# ~/.codex/config.toml\n[model_providers.helm]\nname = "Helm"\nbase_url = "${baseV1}"\nenv_key = "HELM_API_KEY"\nwire_api = "responses"\n\n# then, in your shell:\nexport HELM_API_KEY="${keyShown}"`,
+    `# ~/.codex/config.toml\n[model_providers.helm]\nname = "Helm"\nbase_url = "${baseV1}"\nenv_key = "HELM_API_KEY"\nwire_api = "responses"\nsupports_websockets = true\n\n# then, in your shell:\nexport HELM_API_KEY="${keyShown}"`,
   );
   let grokEnv = $derived(
     `export GROK_MODELS_BASE_URL="${baseV1}"\nexport XAI_API_KEY="${keyShown}"\n\ngrok -m auto`,

--- a/apps/admin/src/lib/components/ConnectClientDialog.test.ts
+++ b/apps/admin/src/lib/components/ConnectClientDialog.test.ts
@@ -55,12 +55,13 @@ describe('ConnectClientDialog', () => {
     expect(snippet).toContain('ANTHROPIC_AUTH_TOKEN');
   });
 
-  it('renders the Codex tab with base_url ending in /v1 and wire_api = "responses"', async () => {
+  it('renders the Codex tab with Responses WebSocket support enabled', async () => {
     setup();
     await fireEvent.click(screen.getByRole('tab', { name: /codex/i }));
     const snippet = screen.getByTestId('snippet-codex').textContent ?? '';
     expect(snippet).toContain(`base_url = "${ORIGIN}/v1"`);
     expect(snippet).toContain('wire_api = "responses"');
+    expect(snippet).toContain('supports_websockets = true');
   });
 
   it('renders the Grok Build tab with Helm model discovery and bearer-key auth', async () => {

--- a/apps/admin/src/lib/format/attempt-codes.ts
+++ b/apps/admin/src/lib/format/attempt-codes.ts
@@ -38,6 +38,8 @@ export const ATTEMPT_CODE_LABELS: Record<string, string> = {
   responses_native_tools_cross_protocol_blocked: 'Native tools blocked across protocols',
   responses_previous_response_id_cross_protocol_blocked:
     'Conversation continuation blocked across protocols',
+  responses_previous_response_id_provider_mismatch:
+    'Conversation continuation pinned to its original provider',
 
   // ── error classes / outcomes (also used as attempt outcomes where noted) ──
   upstream_error: 'Provider error',

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -192,6 +192,7 @@
   "Context window too small": "Context window too small",
   "Conversation": "Conversation",
   "Conversation continuation blocked across protocols": "Conversation continuation blocked across protocols",
+  "Conversation continuation pinned to its original provider": "Conversation continuation pinned to its original provider",
   "Copied": "Copied",
   "Copy": "Copy",
   "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.": "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -192,6 +192,7 @@
   "Context window too small": "Ventana de contexto demasiado pequeña",
   "Conversation": "Conversación",
   "Conversation continuation blocked across protocols": "Continuación de conversación bloqueada entre protocolos",
+  "Conversation continuation pinned to its original provider": "Continuación de la conversación fijada al proveedor original",
   "Copied": "Copiado",
   "Copy": "Copiar",
   "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.": "Cópiala ahora: el cifrado de revelación de claves no está configurado, así que no podrá recuperarse después.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -192,6 +192,7 @@
   "Context window too small": "コンテキストウィンドウが不足",
   "Conversation": "会話",
   "Conversation continuation blocked across protocols": "プロトコル跨ぎで会話の継続を遮断",
+  "Conversation continuation pinned to its original provider": "会話の継続を元のプロバイダーに固定",
   "Copied": "コピーしました",
   "Copy": "コピー",
   "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.": "今すぐコピーしてください。キー表示用の暗号化が未設定のため、後から復元できません。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -192,6 +192,7 @@
   "Context window too small": "컨텍스트 윈도우 부족",
   "Conversation": "대화",
   "Conversation continuation blocked across protocols": "프로토콜 간 대화 이어가기 차단",
+  "Conversation continuation pinned to its original provider": "대화 이어가기를 원래 제공업체에 고정",
   "Copied": "복사됨",
   "Copy": "복사",
   "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.": "지금 복사하세요. 키 표시용 암호화가 설정되어 있지 않아 나중에 복구할 수 없습니다.",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -192,6 +192,7 @@
   "Context window too small": "Janela de contexto pequena demais",
   "Conversation": "Conversa",
   "Conversation continuation blocked across protocols": "Continuação de conversa bloqueada entre protocolos",
+  "Conversation continuation pinned to its original provider": "Continuação da conversa fixada ao provedor original",
   "Copied": "Copiado",
   "Copy": "Copiar",
   "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.": "Copie-a agora: a criptografia de revelação de chaves não está configurada, então ela não poderá ser recuperada depois.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -192,6 +192,7 @@
   "Context window too small": "上下文窗口过小",
   "Conversation": "对话",
   "Conversation continuation blocked across protocols": "跨协议下会话续接被阻止",
+  "Conversation continuation pinned to its original provider": "会话续接固定到原始提供商",
   "Copied": "已复制",
   "Copy": "复制",
   "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.": "请立即复制——密钥查看所需的加密未配置，之后无法恢复。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -192,6 +192,7 @@
   "Context window too small": "上下文視窗過小",
   "Conversation": "對話",
   "Conversation continuation blocked across protocols": "跨協定下對話續接遭封鎖",
+  "Conversation continuation pinned to its original provider": "對話續接固定到原始供應商",
   "Copied": "已複製",
   "Copy": "複製",
   "Copy it now — key reveal encryption is not configured, so it cannot be recovered later.": "請立即複製——金鑰查看所需的加密未設定，之後無法恢復。",

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -816,7 +816,7 @@ describe("createExecute — gateway execution adapter", () => {
     });
   });
 
-  it("blocks Responses previous_response_id tool-output continuations on non-Responses targets", async () => {
+  it("blocks every Responses previous_response_id continuation on non-Responses targets", async () => {
     const provider = {
       chatCompletion: vi.fn().mockResolvedValue({ id: "should-not-call" }),
       chatCompletionStream: vi.fn(),
@@ -835,7 +835,7 @@ describe("createExecute — gateway execution adapter", () => {
       plan(["default_good_model"]),
       req({
         protocol: "openai_responses",
-        messages: [{ role: "tool", content: "done", tool_call_id: "call_1" }],
+        messages: [{ role: "user", content: "continue" }],
         provider_raw: { previous_response_id: "resp_prev" },
       }),
     );
@@ -847,6 +847,52 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.attempts[0]?.skip_reason).toBe(
       "responses_previous_response_id_cross_protocol_blocked",
     );
+  });
+
+  it("keeps a previous_response_id continuation on its recorded provider alias", async () => {
+    const first = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "wrong-provider" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const pinned = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "right-provider" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: first,
+      providers: new Map([
+        ["first", first],
+        ["pinned", pinned],
+      ]),
+      registry: protocolRegistry({
+        "first/gpt": {
+          providerName: "first",
+          providerModel: "gpt",
+          targetProviderProtocol: "openai_responses",
+        },
+        "pinned/gpt": {
+          providerName: "pinned",
+          providerModel: "gpt",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+    const request = req({
+      protocol: "openai_responses",
+      provider_raw: { previous_response_id: "resp_prev" },
+    });
+    (request.metadata as Record<string, unknown>).stateful_provider_alias = "pinned/gpt";
+
+    const out = await execute(plan(["first/gpt", "pinned/gpt"]), request);
+
+    expect(out.final).toMatchObject({ status: "ok", alias: "pinned/gpt" });
+    expect(first.chatCompletion).not.toHaveBeenCalled();
+    expect(pinned.chatCompletion).toHaveBeenCalledOnce();
+    expect(out.attempts[0]?.skip_reason).toBe("responses_previous_response_id_provider_mismatch");
   });
 
   it.each([

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -748,16 +748,12 @@ function prepareNativeRequestForUpstream(
     : cloneCarrierWithBody(carrier, body, { preserveRawBody: true });
 }
 
-function hasResponsesHistoryGap(req: InternalRequest): boolean {
-  if (req.protocol !== "openai_responses") return false;
-  if (typeof req.provider_raw?.previous_response_id !== "string") return false;
-  let hasToolOutput = false;
-  let hasLocalToolCall = false;
-  for (const message of req.messages) {
-    if (message.role === "tool") hasToolOutput = true;
-    if (Array.isArray((message as { tool_calls?: unknown }).tool_calls)) hasLocalToolCall = true;
-  }
-  return hasToolOutput && !hasLocalToolCall;
+function hasResponsesContinuation(req: InternalRequest): boolean {
+  return (
+    req.protocol === "openai_responses" &&
+    typeof req.provider_raw?.previous_response_id === "string" &&
+    req.provider_raw.previous_response_id.length > 0
+  );
 }
 
 function hasResponsesReasoningHistory(req: InternalRequest): boolean {
@@ -769,7 +765,15 @@ function hasResponsesReasoningHistory(req: InternalRequest): boolean {
 function candidateGuardSkipReason(
   req: InternalRequest,
   target: ResolvedAttemptTarget,
+  alias: string,
 ): string | null {
+  if (
+    hasResponsesContinuation(req) &&
+    typeof req.metadata.stateful_provider_alias === "string" &&
+    alias !== req.metadata.stateful_provider_alias
+  ) {
+    return "responses_previous_response_id_provider_mismatch";
+  }
   if (
     req.protocol === "openai_responses" &&
     target.targetProviderProtocol === "openai_responses" &&
@@ -796,7 +800,9 @@ function protocolGuardSkipReason(
   if (req.protocol !== "openai_responses" || targetProviderProtocol === "openai_responses") {
     return null;
   }
-  if (hasResponsesHistoryGap(req)) return "responses_previous_response_id_cross_protocol_blocked";
+  if (hasResponsesContinuation(req)) {
+    return "responses_previous_response_id_cross_protocol_blocked";
+  }
   if (Array.isArray(req.provider_raw?.responses_native_tools)) {
     return "responses_native_tools_cross_protocol_blocked";
   }
@@ -1575,7 +1581,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         continue;
       }
 
-      const candidateSkip = candidateGuardSkipReason(req, target);
+      const candidateSkip = candidateGuardSkipReason(req, target, alias);
       if (candidateSkip !== null) {
         capabilityPruned = true;
         attempts.push(skipRow(alias, candidateSkip, elapsed()));
@@ -1725,7 +1731,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               req.reasoning_effort,
             ),
           );
-          if (hasResponsesHistoryGap(req)) {
+          if (hasResponsesContinuation(req)) {
             const mutations = nativePassthroughMutations(passthroughBody);
             if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
           }
@@ -1862,7 +1868,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               req.reasoning_effort,
             ),
           );
-          if (hasResponsesHistoryGap(req)) {
+          if (hasResponsesContinuation(req)) {
             const mutations = nativePassthroughMutations(passthroughBody);
             if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
           }

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -1826,6 +1826,30 @@ describe("createMessagesPipeline — memory inject additive trailing reminder", 
 // ── Additional coverage: uncovered branches / lines ────────────────────────
 
 describe("createMessagesPipeline — toInternalRequest metadata branches", () => {
+  it("threads a trusted stateful Responses provider pin into execution", async () => {
+    let seen: InternalRequest | null = null;
+    const route: RouteFn = async (req) => {
+      seen = req;
+      return okResult({ id: "x" });
+    };
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+
+    await pipeline.run(
+      irOf({
+        metadata: {
+          trace_id: "t1",
+          stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+        },
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+
+    expect((seen as InternalRequest | null)?.metadata.stateful_provider_alias).toBe(
+      "openai-codex/gpt-5.6-sol",
+    );
+  });
+
   it("forwards conversation_id when it is a non-empty string (line 172 truthy branch)", async () => {
     let seen: Record<string, unknown> | null = null;
     const route: RouteFn = async (req) => {

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -245,6 +245,10 @@ function toInternalRequest(
       resource_id: memoryScope.resourceId,
       project_id: memoryScope.projectId,
       memory_mode: memoryScope.mode,
+      ...(typeof ir.metadata?.stateful_provider_alias === "string" &&
+      ir.metadata.stateful_provider_alias.length > 0
+        ? { stateful_provider_alias: ir.metadata.stateful_provider_alias }
+        : {}),
       // The CLI's captured billing identity (anthropic route stamps it; absent on the
       // OpenAI/Gemini surfaces). The native-Anthropic executor reads it to re-emit the
       // client's own version. Length-capped: it is re-emitted into the upstream header.

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1297,6 +1297,57 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     );
   });
 
+  it("pins previous_response_id continuations to the provider that created the response", async () => {
+    const registryRecord = {
+      responseId: "resp_previous",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "openai-codex/gpt-5.6-sol",
+      providerName: "openai-codex",
+      providerModel: "gpt-5.6-sol",
+      providerProtocol: "openai_responses" as const,
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      status: "completed",
+    };
+    const get = vi.fn().mockResolvedValue(registryRecord);
+    const { deps, harness } = makeDeps({ registry: { put: vi.fn(), get } });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, previous_response_id: "resp_previous" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(get).toHaveBeenCalledWith("resp_previous", { keyId: "k1", accountId: "acct" });
+    expect(harness.pipelineSawIR).toMatchObject({
+      metadata: { stateful_provider_alias: "openai-codex/gpt-5.6-sol" },
+    });
+  });
+
+  it("rejects an unknown previous_response_id instead of routing it without history", async () => {
+    const run = vi.fn();
+    const { deps } = makeDeps({
+      run,
+      registry: { put: vi.fn(), get: vi.fn().mockResolvedValue(null) },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, previous_response_id: "resp_unknown" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: Record<string, string> };
+    expect(body.error.code).toBe("invalid_request");
+    expect(body.error.message).toContain("send the full conversation input");
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("returns an OpenAI-shaped 404 for unknown registry response ids without provider dispatch", async () => {
     const retrieve = vi.fn();
     const registry = { put: vi.fn(), get: vi.fn().mockResolvedValue(null) };

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -1054,6 +1054,27 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       memory_thread_source: memoryScope.threadSource,
     };
 
+    const previousResponseId =
+      typeof nativeRec.previous_response_id === "string" &&
+      nativeRec.previous_response_id.length > 0
+        ? nativeRec.previous_response_id
+        : null;
+    if (previousResponseId !== null) {
+      const previous =
+        deps.registry === undefined ? null : await deps.registry.get(previousResponseId, identity);
+      if (previous?.providerAlias === null || previous?.providerProtocol !== "openai_responses") {
+        throw helmError(
+          "invalid_request",
+          `previous_response_id '${previousResponseId}' cannot be continued safely; send the full conversation input instead`,
+          traceId,
+        );
+      }
+      ir.metadata = {
+        ...ir.metadata,
+        stateful_provider_alias: previous.providerAlias,
+      };
+    }
+
     // Native protocol passthrough carrier (#217 Phase 3). Stamp the VERBATIM parsed
     // inbound Responses body onto the IR metadata bag (same HTTP→core hand-off as the
     // /v1/messages route); the pipeline reads it into InternalRequest.native_request and

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -173,10 +173,11 @@ The request transformer folds native Responses input into the IR:
 
 Known function tools translate cross-protocol. Native-only tools (for example
 MCP/file-search-like tool objects), native/unknown input items,
-`background: true`, and some `previous_response_id` histories cannot be
+`background: true`, and every `previous_response_id` continuation cannot be
 safely reconstructed on a non-Responses backend. The executor skips such
 cross-protocol candidates with an explicit reason instead of silently dropping
-the state. Same-protocol passthrough remains eligible.
+the state. A continuation is also pinned to the provider alias recorded for the
+referenced response; same-provider Responses passthrough remains eligible.
 
 Translated non-stream output expands one IR choice into Responses `output[]`
 message, reasoning, and function-call items. It renders citations on

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -90,6 +90,31 @@ On Linux, `HELM_UID` / `HELM_GID` let the non-root process write `./data` withou
 `sudo` or world-writable permissions; the initializer fills the exact current
 values. The `10001:10001` fallback preserves the image user for existing installs.
 
+### Reverse proxy WebSocket forwarding
+
+Codex can reuse the Responses WebSocket transport only when every reverse proxy
+forwards HTTP/1.1 upgrades to Helm. For nginx, keep normal HTTP requests free of
+hop-by-hop headers and forward them only for an actual upgrade:
+
+```nginx
+map $http_upgrade $helm_connection_upgrade {
+    default upgrade;
+    ''      '';
+}
+
+location / {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $helm_connection_upgrade;
+}
+```
+
+If another proxy routes WebSocket traffic before nginx, route the Helm hostname
+to this HTTP backend before any catch-all WebSocket backend. Codex providers
+using Helm can then set `supports_websockets = true`; connection failures still
+fall back to the normal Responses HTTP/SSE path.
+
 ### First-run security and persistence
 
 When Admin credentials are absent, Helm exposes only `/setup`, `/healthz`, and

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -74,7 +74,8 @@ protocol boundary. The attempt is recorded as skipped and fallback can continue:
 
 | Skip reason | Trigger |
 |---|---|
-| `responses_previous_response_id_cross_protocol_blocked` | A Responses request relies on `previous_response_id` plus a tool-output history that cannot be reconstructed locally. |
+| `responses_previous_response_id_cross_protocol_blocked` | A Responses request uses `previous_response_id`, whose hidden history cannot be reconstructed by a non-Responses target. |
+| `responses_previous_response_id_provider_mismatch` | A continuation candidate is not the provider alias recorded for the referenced response. |
 | `responses_native_tools_cross_protocol_blocked` | The Responses request contains non-function/native tools. |
 | `responses_native_items_cross_protocol_blocked` | The request contains native/custom/caller-linked or unknown Responses input items whose sequence cannot be represented safely. |
 | `responses_background_cross_protocol_blocked` | A Responses request sets `background: true` and the target is not Responses. |

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,18 @@
 
 ---
 
+## 2026-07-22 · Responses 状态续接严格绑定原 provider 与账号（Protocol translation / provider execution，docs/04/05/07，原则 2/3/5/8）
+
+- **状态引用边界**：`previous_response_id` 引用的是上游保存、Helm 无法从当前增量请求重建的隐藏历史。Responses create 入口复用既有 lifecycle registry，按同一 account/key 查出产生该 ID 的 provider alias；未知 ID、registry 不可用、或由非 Responses 翻译路径生成的 ID 在路由前返回 `400 invalid_request`，要求客户端发送完整 conversation input，不猜测也不静默丢历史。
+- **路由与协议边界**：可信 provider pin 只作为 Gateway 内部 metadata 进入共享执行器；候选不等于原 alias 时记录 `responses_previous_response_id_provider_mismatch` 并跳过，任何非 Responses 候选统一记录 `responses_previous_response_id_cross_protocol_blocked`。无状态首请求仍保留原有跨协议 fallback，只有有状态 continuation 被收紧。
+- **账号绑定边界**：OAuth pool 同时收到 WebSocket session 与 `previous_response_id` 时以后者优先，复用现有 response-id → account affinity，使续接在原账号不可用或首输出前故障时直接失败，不切换兄弟账号。没有新增存储、配置、依赖或客户端协议。
+
+## 2026-07-22 · Codex 客户端默认启用 Responses WebSocket，并补齐反向代理边界（Deployment / Protocol / Admin client setup，docs/05/10/11，原则 3/5/8）
+
+- **客户端契约**：Admin「接入客户端」现有 Codex TOML 直接增加 `supports_websockets = true`，复用 Helm 已实现的三个 Responses WebSocket 入口及 Codex 自身的 HTTP fallback；不新增 Gateway 路由、媒体服务、客户端 npm shim 或缓存层。该优化只减少同一 Codex turn 内后续模型调用的重复 input，跨 turn 首次请求仍会发送完整历史。
+- **部署边界**：WebSocket 可用性取决于整条反向代理链，不是 Gateway 代码存在即代表现网可用。nginx 只在真实 Upgrade 请求上转发 `Upgrade` / `Connection`，普通 HTTP/SSE 不注入 hop-by-hop header；若前置 HAProxy 另有 catch-all WebSocket backend，必须先按 Helm hostname 路由到 web backend，避免 Upgrade 在到达 nginx 前被截走。
+- **延后项**：Claude Code 没有可依赖的图片 URL / `file_id` 客户端契约，因此暂不建设本地 npm shim；不可变媒体引用留待自有客户端或明确协议需求出现后再做。
+
 ## 2026-07-21 · 首次安装改为令牌保护的浏览器向导并允许订阅-only 启动（Deployment / bootstrap / Admin，docs/10/11，原则 2/3/7）
 
 - **Admin 登录体验**：浏览器不再依赖 `WWW-Authenticate` 触发原生 Basic 弹窗；未登录页面跳转到 Gateway 自带的 `/admin/login`，成功后使用仅含过期时间与 HMAC 的 12 小时 `HttpOnly`、`SameSite=Strict`、`Path=/admin` Cookie，HTTPS 时加 `Secure`。签名密钥只由进程内现有 Admin 用户名/密码派生，凭据轮换自动让旧会话失效，不新增 session 表、JWT 依赖或独立 secret。Admin SPA 与静态资产仍在会话/Basic 双重认证之后，只有无脚本登录 HTML 公开；脚本可继续主动发送 HTTP Basic，失败响应不再带 challenge，避免浏览器弹窗。登录 POST 校验同源、常量时间比较并限制本地 `next`，顶栏提供退出入口。
@@ -53,21 +65,10 @@
 - **生产事实与新门槛**：常驻 supervisor 已在 `2026-07-08` UTC 窗口的 `22,100 / 31,400` 连续等待约 7 小时；CPU、内存、health、restart/OOM、Gateway/SQLite 信号均健康，唯一持续原因是磁盘低于 14 GiB，随后 WAL 增至约 583 MiB。主机当时仍有约 13.9 GiB 可用空间，全部历史回填目录约 1.55 GiB，当前窗口 221 个微型备份约 106 MiB，且 Docker 已无可回收镜像。为避免恢复门槛永久饿死任务，preflight 改为 WAL `<640 MiB`、磁盘 `>13 GiB`；runtime hard stop 改为 WAL `<768 MiB`，磁盘硬底线继续保持 `12 GiB`。这样当前状态可恢复，同时仍保留约 0.9 GiB 磁盘余量、约 185 MiB WAL 运行余量和独立硬上限。
 - **未放宽边界**：CPU `<75%`、load、可用内存、Helm 内存、non-200/5 秒 health probe timeout、restart、OOM、gateway-internal 5xx 与 `SQLITE_BUSY` 继续按原逻辑阻断；每批 100 行、每阶段最多 5,000 行、冷却、checkpoint、slice verification 与微型恢复库均不变。WAL/磁盘原因文案改为从配置阈值动态生成，避免以后阈值调整后状态继续报告旧数字。
 
-## 2026-07-16 · 路由白名单改为真实交集并让分类开关兑现配置语义（Routing / classifier / CI，docs/03/04/06/09，原则 2/3/5/6/7）
-
-- **白名单边界**：Policy 与 API key 的 `allowed_lanes` 不再先后 clamp，而是先求真实交集；`null` 表示无约束，动态交集 `[]` 表示没有任何 lane 可执行并在 provider 前返回结构化 `invalid_request`。新建/更新 key 与静态 policy 拒绝显式空数组，清除 key 限制必须传 `null`；旧库中的 `[]` 继续可读但按 deny-all 解释，编辑其他字段时省略该字段并保留原值，不能顺手扩成无限制。显式 lane、兼容 alias、自动分类、预算 degrade、signal feedback 与 Codex compact 共用同一边界；预算降级只允许保持目标或向可证明更便宜的 ranked lane 收敛，白名单若只剩更贵 lane 就在 provider 前拒绝，绝不把成本保护反向升级。具体 model 仍只受 `allow_custom_model` / `blocked_models` 约束，并由 route、模型目录与 Codex compact 的空白名单用例共同锁定。模型列表在无可用 lane 时不再展示 `auto`，缓存指纹也明确区分 `null` 与 `[]`。
-- **分类开关边界**：`classifier.rules.enabled:false` 现在完全跳过 Layer 1，包括 momentum 读写；eval 开启时直接进入 Layer 2，eval 也关闭时以 `rules_and_eval_disabled` 进入运行时默认 lane，`rules_confidence` 为 `null`，不伪造规则分数。`eval.cache.enabled:false` 在构造 content hash 前直接调用 eval，不读写已有缓存，每次都记录 fresh latency/cost 与 `eval_cache_hit:false`；热更新开关会重建配置指纹，重新开启缓存后首个请求 miss、后续请求才 hit。
-- **CI 维护边界**：GitHub Actions 升级到经过签名验证并固定完整 SHA 的 checkout v7、setup-node v7 与 pnpm/action-setup v6，消除 Node 20 runtime 弃用；setup-node v7 正式支持 `package-manager-cache:false`。checkout v7 对 fork PR 的显式 opt-in 只存在于 `pull_request_target` 的三个代码执行 job，它们仍固定在一次性 GitHub-hosted runner、只读 token、无 secrets 且 `persist-credentials:false`；特权 Publish 不允许该选项。
-- **验证**：TDD 先复现空集放行、双重 clamp 越权、规则/缓存开关无效和旧 Action pin，再覆盖 core、Gateway、Admin 与 workflow policy；本地只运行 `CI=true` 定向 Vitest 且单 worker，最终结果和 hosted CI 另行记录在 PR。
-
-## 2026-07-16 · xAI 订阅协议跟随官方 grok-build 并收紧动态目录边界（OAuth subscription / model catalog / Responses / Admin providers，docs/04/05/06/11，原则 2/3/5/6/7/8）
-
-- **官方事实边界**：以 `xai-org/grok-build@c68e39f`、本机 Grok CLI `0.2.101` 和当前账号真实 wire 为准；OAuth issuer/client、Device Code 与 `/v1/responses` 主链保留，scope 补齐官方 personal conversation scopes，推理请求补充 headless/client identifier/user identity 并强制请求 `reasoning.encrypted_content`。当前 entitlement 仍只有 `grok-4.5` 与 `grok-composer-2.5-fast`，两者的真实 `/models` backend 均为 `responses`，目录分别报告 500k 与 200k context；官方静态 fallback 中的 `grok-build` 不是账号授权证据，不能自动加入 Helm。
-- **目录与能力边界**：`/models` 不再压缩成字符串；目录 `id` 与实际 wire `model` 分开保存，并保留官方 backend、context、max output/retry、reasoning、visibility 与 streamed-tool metadata。重复 id 与官方一致采用 last-wins，数值和 reasoning fallback 也按官方边界解析。结构化账号目录加密持久化为 last-known-good：上游失败复用，成功空目录则权威清空；换凭证会先清旧身份目录。Lane picker 只读取当前 synthesized pool 接受的 xAI alias/account，不能把被 metadata/wire conflict 剔除的账号继续显示为可路由。Helm 识别 `responses` / `chat_completions` / `messages`，但只路由当前已实现的 Responses transport；hidden 条目排除，`supportedInApi:false` 仍可用于 session auth。已验证 wire model 复用手工 capability/pricing，并以下游目录报告的 context/output 上限做更小值钳制；目录若将来提供 `maxCompletionTokens` / `streamToolCalls`，请求只在客户端未显式设置时应用。未知 Responses 模型只获得保守的纯文本/streaming 能力，tools/vision/JSON/media/cache 与价格保持关闭或 unknown。多账号同 alias 若目录 metadata 或 wire slug 冲突则拒绝冲突账号，不采用跨账号 last-write-wins。
-- **故障与配额边界**：按照官方明确语义，只有 xAI inference 401 才证明凭证失效；403 作为已认证的 policy/content/ZDR denial 进入正常执行 fallback，不停车、不持久化 credential failure。Device Code 完成后 pool rebuild 未应用必须返回 `503 not_applied`。SuperGrok quota 运行时迁移到官方 `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`，使用 bearer、账号 identity、client version、headless mode 与同账号 proxy；有界 JSON 只投影当前 weekly period，忽略 prepaid/on-demand/monthly/history。真实响应证明 0% 时 proto3 JSON 会省略 `creditUsagePercent`，因此仅“缺失”解释为 0，显式 null/string 仍拒绝。
-- **延后项**：当前真实目录没有发布 `maxRetries`、`maxCompletionTokens` 或 `streamToolCalls`。后两项已具备未来兼容；`maxRetries` 暂不接入，因为 Helm 的账号 pool 与 lane fallback 已各自拥有重试边界，直接照搬会造成 `lane × account × retries` 放大，必须以后以 pool 为唯一共享预算再实现。通用 grok-build 客户端具备 JSON schema、额外 reasoning/retry、backend search 与其他工具扩展，不等于当前两个 SuperGrok entitlement 已验证这些 API 能力；Composer vision、订阅 JSON、额外媒体和未公开价格继续 fail-closed。后续若要开启，必须先做隔离真实请求与协议 fixture，不能仅凭通用 Rust 类型推断。
 ## 历史条目摘要（最新要点）
 
+- **2026-07-16 · 路由白名单改为真实交集并让分类开关兑现配置语义（Routing / classifier / CI，原则 2/3/5/6/7）**：Policy 与 key 白名单求真实交集并让空集 fail-closed；rules/eval cache 开关兑现配置语义，CI Actions 固定到核验 SHA；完整原文通过 git history 回溯。
+- **2026-07-16 · xAI 订阅协议跟随官方 grok-build 并收紧动态目录边界（OAuth subscription / model catalog / Responses / Admin providers，原则 2/3/6/7/8）**：以真实 wire 和账号 entitlement 分离模型目录 ID、执行 slug、能力与配额，未知能力保持 fail-closed，跨账号冲突拒绝；完整原文通过 git history 回溯。
 - **2026-07-16 · 收紧发布信任链、请求归属与 Memory 项目隔离（CI / observability / Memory，原则 1/3/7）**：PR 信任链固定到受核验 merge ref 与只读权限，发布绑定已验证 main SHA；内部 `request_id` 与客户端 trace 分离，Memory thread/project 迁移保持租户隔离与事务原子性；完整原文通过 git history 回溯。
 - **2026-07-16 · 文档以当前源码为准完成全量运行时事实校准（docs/01–14 / README / operations，原则 1–8）**：以当前路由、schema、Store、配置与测试校准全部当前文档和中英文 README，明确 Portal、部署、安全、Memory 与协议实现/缺口边界；完整原文通过 git history 回溯。
 - **2026-07-16 · Admin 首次点击卡顿改为非投机加载与汇总读（Admin / Store performance，docs/08/11，原则 1/3/7）**：以 `memory_threads` 的事务维护汇总替代正文表冷扫描，Admin 改为非投机 data preload，并以有界 stale-while-revalidate 缓存保护统计读取；在线 VACUUM 继续禁止。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { preOutputClassifierFor } from "../failover-guard.js";
 import { type ChatCompletionRequest, type ProviderClient, UpstreamError } from "../openai.js";
-import { createCodexResponsesClient } from "../openai-responses.js";
+import {
+  CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
+  createCodexResponsesClient,
+} from "../openai-responses.js";
 import { TokenRefreshError } from "../token-manager.js";
 import { createOAuthPoolClient, type OAuthPoolMember } from "./pool.js";
 
@@ -1268,6 +1271,67 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     }
 
     expect(calls).toEqual(["a", "a"]);
+  });
+
+  it("prioritizes previous_response_id affinity over websocket session affinity", async () => {
+    const calls: string[] = [];
+    const responseMember = (account: string): OAuthPoolMember => ({
+      account,
+      priority: 50,
+      schedulable: true,
+      client: {
+        async chatCompletion() {
+          return { served_by: account };
+        },
+        async *chatCompletionStream() {
+          yield `data: ${account}\n\n`;
+        },
+        async *nativePassthroughStream() {
+          calls.push(account);
+          yield `event: response.created\ndata: {"type":"response.created","response":{"id":"resp-${account}"}}\n\n`;
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [responseMember("a"), responseMember("b")],
+      selectionStrategy: "manual_priority",
+      now: () => 1_000,
+    });
+
+    const first = pool.nativePassthroughStream?.({
+      protocol: "openai_responses",
+      body: { model: "gpt-5.6-sol", stream: true, input: "first" },
+      headers: {},
+      mutations: {},
+    });
+    for await (const _chunk of first ?? []) {
+      // Drain so resp-a is bound to account a.
+    }
+    const websocketWarmup = pool.nativePassthroughStream?.({
+      protocol: "openai_responses",
+      body: { model: "gpt-5.6-sol", stream: true, input: "warmup" },
+      headers: { [CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER]: "session-b" },
+      mutations: {},
+    });
+    for await (const _chunk of websocketWarmup ?? []) {
+      // Drain so session-b is bound to account b.
+    }
+    const continuation = pool.nativePassthroughStream?.({
+      protocol: "openai_responses",
+      body: {
+        model: "gpt-5.6-sol",
+        stream: true,
+        input: "continue",
+        previous_response_id: "resp-a",
+      },
+      headers: { [CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER]: "session-b" },
+      mutations: {},
+    });
+    for await (const _chunk of continuation ?? []) {
+      // Drain the continuation.
+    }
+
+    expect(calls).toEqual(["a", "b", "a"]);
   });
 
   it("binds an upstream x-codex-turn-state to the account that produced it", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -316,12 +316,12 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
 
   function stickyKeyFromNative(input: NativePassthroughInput): string | null {
     const body = nativePassthroughBody(input);
+    const previousResponseId = bodyString(body, "previous_response_id");
+    if (previousResponseId !== null) return `previous_response_id:${previousResponseId}`;
     if (isNativePassthroughCarrier(input)) {
       const websocketSession = headerValue(input.headers, CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER);
       if (websocketSession !== null) return `responses_websocket_session:${websocketSession}`;
     }
-    const previousResponseId = bodyString(body, "previous_response_id");
-    if (previousResponseId !== null) return `previous_response_id:${previousResponseId}`;
     if (isNativePassthroughCarrier(input)) {
       const turnState = headerValue(input.headers, "x-codex-turn-state");
       if (turnState !== null) return `x-codex-turn-state:${turnState}`;

--- a/packages/shared/src/request/schema.ts
+++ b/packages/shared/src/request/schema.ts
@@ -91,6 +91,9 @@ export const RequestMetadataSchema = z.object({
   resource_id: z.string().nullable(),
   project_id: z.string().nullable(),
   memory_mode: MemoryModeSchema,
+  // Trusted gateway-only pin resolved from the Responses registry. Stateful
+  // previous_response_id turns may use only the provider alias that created the id.
+  stateful_provider_alias: z.string().min(1).optional(),
   // The inbound client's Claude-Code billing-attribution prefix —
   // "cc_version=<v>.<3hex>; cc_entrypoint=<entry>" with the per-request `cch` dropped
   // — captured at the Anthropic route from the real CLI's system[0] block before it


### PR DESCRIPTION
## What changed

- enable `supports_websockets = true` in the generated Codex client config
- document the required nginx WebSocket upgrade boundary
- pin `previous_response_id` continuations to the Responses provider alias that created the response
- keep stateful continuations on the original OAuth account, even when a WebSocket session is present
- reject unknown or cross-protocol continuations instead of silently losing hidden history

## Why

Codex WebSocket mode can avoid resending large image-heavy history by continuing from `previous_response_id`. That identifier is provider-owned state and cannot be safely translated to Anthropic Messages, OpenAI Chat, Gemini, another Responses provider, or another subscription account.

The previous guard covered only tool-output history gaps, and OAuth account selection prioritized the WebSocket session over the stronger response-id affinity. This could allow a continuation to run without its original hidden context.

## Impact

Stateless requests keep the existing cross-provider fallback behavior. Stateful Responses continuations now fail closed unless Helm can prove and reuse their original provider/account. No new dependency, setting, table, or client shim is introduced.

## Validation

- `CI=true pnpm exec vitest run apps/gateway/src/routes/messages-pipeline.test.ts apps/gateway/src/routes/execute.test.ts apps/gateway/src/routes/responses.test.ts packages/core/src/provider/oauth/pool.test.ts` — 396 passed
- `CI=true pnpm exec vitest run apps/gateway/src/responses-websocket.test.ts apps/admin/src/lib/components/ConnectClientDialog.test.ts` — 35 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
