### PR TITLE
[codex] Unify lane editing workflow

### DIFF
--- a/apps/admin/src/lib/api/lanes.test.ts
+++ b/apps/admin/src/lib/api/lanes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Lane } from './lanes.js';
-import { listLanes, saveLane } from './lanes.js';
+import { listLanes, saveLane, saveLanes } from './lanes.js';
 
 // The admin UI talks to the gateway ONLY over /admin/api/* HTTP (DoD: no core
 // import). These tests pin the client contract against a mocked fetch.
@@ -58,6 +58,26 @@ describe('lanes api client', () => {
     expect(body.primary).toBe('best_code_model');
     expect(body.name).toBeUndefined(); // strictObject on the server: name must NOT be sent
     expect(body.fallback).toEqual(['premium']);
+  });
+
+  it('saveLanes PUTs the complete lane map in one request', async () => {
+    const lanes = [
+      laneRow('balanced'),
+      laneRow('coding', { fallback: ['balanced'] }),
+    ] as unknown as Lane[];
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lanes), { status: 200 }),
+    );
+
+    await saveLanes(lanes);
+
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/admin/api/lanes');
+    expect(init.method).toBe('PUT');
+    const body = JSON.parse(init.body as string);
+    expect(Object.keys(body)).toEqual(['balanced', 'coding']);
+    expect(body.coding.name).toBeUndefined();
+    expect(body.coding.fallback).toEqual(['balanced']);
   });
 
   it('saveLane rejects when the server returns a non-2xx (fail-closed)', async () => {

--- a/apps/admin/src/lib/api/lanes.ts
+++ b/apps/admin/src/lib/api/lanes.ts
@@ -20,14 +20,7 @@ export interface LaneConstraints {
 // admin deliberately re-types shapes rather than importing core/shared). When set
 // on a lane, the gateway overrides the client's reasoning effort for every request
 // on that lane; omitted = unforced (the request-driven default).
-export type ReasoningEffort =
-  | 'none'
-  | 'minimal'
-  | 'low'
-  | 'medium'
-  | 'high'
-  | 'xhigh'
-  | 'max';
+export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 export const REASONING_EFFORTS: ReasoningEffort[] = [
   'none',
   'minimal',
@@ -109,6 +102,18 @@ export async function listLanes(): Promise<Lane[]> {
   const res = await fetch(BASE, { headers: { accept: 'application/json' } });
   const rows = await asJson<Record<string, unknown>[]>(res);
   return rows.map(normalizeLane);
+}
+
+// PUT /admin/api/lanes <- complete lane map (one validated, atomic write).
+export async function saveLanes(list: Lane[]): Promise<Lane[]> {
+  const body = Object.fromEntries(list.map((lane) => [lane.name, toServerBody(lane)]));
+  const res = await fetch(BASE, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const saved = await asJson<Record<string, unknown>[]>(res);
+  return saved.map(normalizeLane);
 }
 
 // PUT /admin/api/lanes/:name <- Lane (sans `name`; server fail-closed on extras).

--- a/apps/admin/src/lib/components/LaneEditor.svelte
+++ b/apps/admin/src/lib/components/LaneEditor.svelte
@@ -6,8 +6,7 @@
 
   // Single-lane editor. Pure form: it owns NO routing/classification logic
   // (that lives in headless core) — only client-side form validation:
-  // non-empty primary, numeric latency, and the `balanced` guard from docs/04
-  // (the classification-fallback terminal must always have a primary).
+  // non-empty primary and numeric latency.
   // `models` is the routable-alias catalog (config.providers[].models[].alias),
   // offered as combobox suggestions on the primary + fallback inputs so the
   // operator picks a real alias instead of hand-typing one (a typo would silently
@@ -23,17 +22,21 @@
     lane,
     models = [],
     laneNames = [],
-    onsave,
+    canDelete = true,
+    onchange,
+    ondelete = () => {},
   }: {
     lane: Lane;
     models?: ModelOption[];
     laneNames?: string[];
-    onsave: (name: string, body: Lane) => void | Promise<void>;
+    canDelete?: boolean;
+    onchange: (lane: Lane) => void;
+    ondelete?: (name: string) => void;
   } = $props();
 
-  // Local editable copy so a failed save never dirties the parent's data. We
-  // intentionally seed from the prop's INITIAL value only (untrack) — the editor
-  // then owns its own state; the parent re-keys on save to feed fresh props.
+  // Local editable copy seeded from the prop's initial value. Each edit emits a
+  // complete lane into the page-level working set; a failed save leaves those
+  // unsaved values visible so the operator can correct or retry them.
   const initial = untrack(() => lane);
   let primary = $state(initial.primary);
   let fallback = $state<string[]>([...initial.fallback]);
@@ -43,11 +46,10 @@
   // Lane-forced reasoning effort; '' = unforced (the request-driven default).
   let reasoningEffort = $state<ReasoningEffort | ''>(initial.reasoning_effort ?? '');
   let newFallback = $state('');
-  // Per-card success flag: set when the parent's save resolves without throwing.
-  // It is the visible "success notice" the operator (and the e2e) waits for.
-  let saved = $state(false);
+  let draggingIndex = $state<number | null>(null);
+  let stopPointerDrag: (() => void) | null = null;
+  let fallbackList: HTMLUListElement | undefined;
 
-  const isBalanced = initial.name === 'balanced';
   // Per-card <datalist> id (each lane renders its own editor). Drives the
   // combobox on both the primary and fallback-add inputs.
   const modelsListId = `lane-models-${initial.name}`;
@@ -64,41 +66,12 @@
     return slash > 0 ? alias.slice(0, slash) : undefined;
   }
 
-  // Validation. `balanced` must keep a primary (docs/04 hard line); other lanes also
-  // need a non-empty primary to be coherent. The hint text differs so ops sees
-  // *why* balanced is special.
+  // Every lane needs a non-empty primary to be coherent; no lane name is special.
   const trimmedPrimary = $derived(primary.trim());
   const primaryEmpty = $derived(trimmedPrimary.length === 0);
-  const valid = $derived(!primaryEmpty);
 
-  function addFallback(): void {
-    const v = newFallback.trim();
-    if (v.length === 0) return;
-    fallback = [...fallback, v];
-    newFallback = '';
-  }
-
-  function removeFallback(i: number): void {
-    fallback = fallback.filter((_, idx) => idx !== i);
-  }
-
-  function moveUp(i: number): void {
-    if (i <= 0) return;
-    const next = [...fallback];
-    [next[i - 1], next[i]] = [next[i], next[i - 1]];
-    fallback = next;
-  }
-
-  function moveDown(i: number): void {
-    if (i >= fallback.length - 1) return;
-    const next = [...fallback];
-    [next[i], next[i + 1]] = [next[i + 1], next[i]];
-    fallback = next;
-  }
-
-  async function handleSave(): Promise<void> {
-    if (!valid) return;
-    const body: Lane = {
+  function emit(): void {
+    const next: Lane = {
       ...initial,
       primary: trimmedPrimary,
       fallback: [...fallback],
@@ -109,42 +82,130 @@
         max_latency_ms: maxLatency,
       },
     };
-    // Forced reasoning effort: set when chosen, OMIT when '' so the server (and the
-    // YAML write-back) treat it as unforced and prune the key (a strictObject would
-    // also reject an explicit invalid value).
-    if (reasoningEffort) body.reasoning_effort = reasoningEffort;
-    else delete body.reasoning_effort;
-    saved = false;
-    // The parent owns user-facing error handling (page-level alert). It re-throws
-    // on failure so the per-card success flag is flipped ONLY on a real success;
-    // a rejected save leaves `saved` false (fail-closed UX).
-    try {
-      await onsave(initial.name, body);
-      saved = true;
-    } catch {
-      saved = false;
+    if (reasoningEffort) next.reasoning_effort = reasoningEffort;
+    else delete next.reasoning_effort;
+    onchange(next);
+  }
+
+  function addFallback(): void {
+    const v = newFallback.trim();
+    if (v.length === 0) return;
+    fallback = [...fallback, v];
+    newFallback = '';
+    emit();
+  }
+
+  function removeFallback(i: number): void {
+    fallback = fallback.filter((_, idx) => idx !== i);
+    emit();
+  }
+
+  function moveFallback(from: number, to: number): void {
+    if (from === to || from < 0 || from >= fallback.length || to < 0 || to >= fallback.length) {
+      return;
+    }
+    const next = [...fallback];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    fallback = next;
+    emit();
+  }
+
+  function handleDragStart(index: number, event: DragEvent): void {
+    draggingIndex = index;
+    event.dataTransfer?.setData('text/plain', String(index));
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
+  }
+
+  function finishDrag(): void {
+    stopPointerDrag?.();
+    stopPointerDrag = null;
+    draggingIndex = null;
+  }
+
+  function handleDrop(index: number, event: DragEvent): void {
+    event.preventDefault();
+    const from = draggingIndex ?? Number(event.dataTransfer?.getData('text/plain'));
+    if (Number.isInteger(from)) moveFallback(from, index);
+    finishDrag();
+  }
+
+  function targetIndex(clientY: number): number {
+    const items = Array.from(fallbackList?.children ?? []);
+    for (let i = 0; i < items.length; i += 1) {
+      const rect = items[i].getBoundingClientRect();
+      if (clientY < rect.top + rect.height / 2) return i;
+    }
+    return items.length - 1;
+  }
+
+  function handlePointerStart(index: number, event: PointerEvent): void {
+    if (event.button !== 0 || fallback.length < 2) return;
+    finishDrag();
+    event.preventDefault();
+    draggingIndex = index;
+    const pointerId = event.pointerId;
+    const onMove = (next: PointerEvent) => {
+      if (next.pointerId !== pointerId || draggingIndex === null) return;
+      next.preventDefault();
+      const to = targetIndex(next.clientY);
+      if (to >= 0 && to !== draggingIndex) {
+        moveFallback(draggingIndex, to);
+        draggingIndex = to;
+      }
+    };
+    const onUp = (next: PointerEvent) => {
+      if (next.pointerId === pointerId) finishDrag();
+    };
+    window.addEventListener('pointermove', onMove, { passive: false });
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    stopPointerDrag = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }
+
+  function handleDragKeydown(index: number, event: KeyboardEvent): void {
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveFallback(index, index - 1);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveFallback(index, index + 1);
     }
   }
 </script>
 
-<form
-  class="card flex flex-col gap-3"
-  data-testid="lane-card"
-  onsubmit={(e) => {
-    e.preventDefault();
-    handleSave();
-  }}
->
-  <header class="flex items-baseline justify-between">
+<section class="card flex flex-col gap-3" data-testid="lane-card">
+  <header class="flex items-center justify-between gap-3">
     <h2 class="section-header">{lane.name}</h2>
-    {#if lane.purpose}
-      <span class="badge-neutral">{lane.purpose}</span>
-    {/if}
+    <div class="flex items-center gap-2">
+      {#if lane.purpose}
+        <span class="badge-neutral">{lane.purpose}</span>
+      {/if}
+      <button
+        type="button"
+        class="btn-danger-outline"
+        disabled={!canDelete}
+        onclick={() => ondelete(initial.name)}>{$t('Delete')}</button
+      >
+    </div>
   </header>
 
   <label class="flex flex-col gap-1">
     <span class="field-label">{$t('Primary')}</span>
-    <input name="primary" class="input" list={modelsListId} bind:value={primary} />
+    <input
+      name="primary"
+      class="input"
+      list={modelsListId}
+      value={primary}
+      oninput={(event) => {
+        primary = event.currentTarget.value;
+        emit();
+      }}
+    />
     <span class="field-help">
       {$t('The model this lane uses first. Tried before any fallback.')}
     </span>
@@ -170,28 +231,34 @@
     <span class="field-help">
       {$t('Tried top to bottom when the primary fails. Order is the try order.')}
     </span>
-    <ul class="flex flex-col gap-1">
+    <ul class="flex flex-col gap-1" bind:this={fallbackList}>
       {#each fallback as f, i (i + ':' + f)}
         <li
-          class="flex items-center gap-2 rounded bg-slate-50 px-2 py-1 text-sm"
+          class={`flex items-center gap-2 rounded bg-slate-50 px-2 py-1 text-sm ${draggingIndex === i ? 'opacity-60 ring-2 ring-slate-300' : ''}`}
           data-testid="fallback-item"
+          ondragover={(event) => event.preventDefault()}
+          ondrop={(event) => handleDrop(i, event)}
         >
+          <button
+            type="button"
+            class="btn-icon shrink-0 cursor-grab text-slate-400 hover:text-slate-700 active:cursor-grabbing"
+            aria-label={$t('drag to reorder fallback')}
+            title={$t('drag to reorder fallback')}
+            disabled={fallback.length < 2}
+            draggable={fallback.length > 1}
+            ondragstart={(event) => handleDragStart(i, event)}
+            ondragend={finishDrag}
+            onpointerdown={(event) => handlePointerStart(i, event)}
+            onkeydown={(event) => handleDragKeydown(i, event)}
+          >
+            <svg viewBox="0 0 20 20" class="h-4 w-4" fill="currentColor" aria-hidden="true">
+              <path
+                d="M7 5.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm0 4.75a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Zm-1.25 6a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm9.75-10.75a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0ZM14.25 11.25a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Zm1.25 3.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z"
+              />
+            </svg>
+          </button>
           <span class="badge-fallback">{i + 1}</span>
           <span class="flex-1">{f}</span>
-          <button
-            type="button"
-            class="btn-icon"
-            aria-label={`move ${f} up`}
-            onclick={() => moveUp(i)}
-            disabled={i === 0}>↑</button
-          >
-          <button
-            type="button"
-            class="btn-icon"
-            aria-label={`move ${f} down`}
-            onclick={() => moveDown(i)}
-            disabled={i === fallback.length - 1}>↓</button
-          >
           <button
             type="button"
             class="btn-icon"
@@ -226,11 +293,27 @@
     </span>
     <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
       <label class="checkbox-field">
-        <input type="checkbox" class="checkbox" bind:checked={requireTools} />
+        <input
+          type="checkbox"
+          class="checkbox"
+          checked={requireTools}
+          onchange={(event) => {
+            requireTools = event.currentTarget.checked;
+            emit();
+          }}
+        />
         <span>{$t('Require tools')}</span>
       </label>
       <label class="checkbox-field">
-        <input type="checkbox" class="checkbox" bind:checked={requireJson} />
+        <input
+          type="checkbox"
+          class="checkbox"
+          checked={requireJson}
+          onchange={(event) => {
+            requireJson = event.currentTarget.checked;
+            emit();
+          }}
+        />
         <span>{$t('Require JSON')}</span>
       </label>
     </div>
@@ -244,6 +327,7 @@
         oninput={(e) => {
           const v = (e.currentTarget as HTMLInputElement).value;
           maxLatency = v === '' ? null : Number(v);
+          emit();
         }}
       />
     </label>
@@ -251,7 +335,15 @@
 
   <label class="field flex flex-col gap-1">
     <span class="field-label">{$t('Forced reasoning effort')}</span>
-    <select class="input-sm w-44" data-testid="reasoning-effort" bind:value={reasoningEffort}>
+    <select
+      class="input-sm w-44"
+      data-testid="reasoning-effort"
+      value={reasoningEffort}
+      onchange={(event) => {
+        reasoningEffort = event.currentTarget.value as ReasoningEffort | '';
+        emit();
+      }}
+    >
       <option value="">{$t('Unset (client decides)')}</option>
       {#each REASONING_EFFORTS as eff (eff)}
         <option value={eff}>{eff}</option>
@@ -264,22 +356,7 @@
 
   {#if primaryEmpty}
     <p class="alert-error" role="alert">
-      {#if isBalanced}
-        {$t('The')}
-        <strong>balanced</strong>
-        {$t(
-          'lane is the classification fallback terminal — its primary is required and cannot be empty.',
-        )}
-      {:else}
-        {$t('Primary is required and cannot be empty.')}
-      {/if}
+      {$t('Primary is required and cannot be empty.')}
     </p>
   {/if}
-
-  <div class="card-actions">
-    {#if saved}
-      <span data-testid="lane-saved" role="status" class="badge-ok">{$t('Saved')}</span>
-    {/if}
-    <button type="submit" class="btn-primary" disabled={!valid}>{$t('Save')}</button>
-  </div>
-</form>
+</section>

--- a/apps/admin/src/lib/components/LaneEditor.test.ts
+++ b/apps/admin/src/lib/components/LaneEditor.test.ts
@@ -16,7 +16,7 @@ function makeLane(overrides: Partial<Lane> = {}): Lane {
 
 describe('LaneEditor', () => {
   it('renders name (read-only), primary and ordered fallback', () => {
-    render(LaneEditor, { lane: makeLane(), onsave: vi.fn() });
+    render(LaneEditor, { lane: makeLane(), onchange: vi.fn() });
 
     expect(screen.getByText('coding')).toBeInTheDocument();
     const primary = screen.getByLabelText(/primary/i) as HTMLInputElement;
@@ -32,23 +32,20 @@ describe('LaneEditor', () => {
     expect(idxPremium).toBeLessThan(idxBalanced);
   });
 
-  it('edits primary and calls onsave with the new value', async () => {
-    const onsave = vi.fn();
-    render(LaneEditor, { lane: makeLane(), onsave });
+  it('emits the complete lane when primary changes', async () => {
+    const onchange = vi.fn();
+    render(LaneEditor, { lane: makeLane(), onchange });
 
     const primary = screen.getByLabelText(/primary/i) as HTMLInputElement;
     await fireEvent.input(primary, { target: { value: 'new_code_model' } });
-    await fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(onsave).toHaveBeenCalledTimes(1);
-    const [name, body] = onsave.mock.calls[0];
-    expect(name).toBe('coding');
-    expect(body.primary).toBe('new_code_model');
+    expect(onchange).toHaveBeenCalledTimes(1);
+    expect(onchange.mock.calls[0][0].primary).toBe('new_code_model');
   });
 
-  it('adds and removes a fallback entry, preserving order in the saved body', async () => {
-    const onsave = vi.fn();
-    render(LaneEditor, { lane: makeLane({ fallback: ['premium'] }), onsave });
+  it('adds and removes a fallback entry, preserving order in emitted state', async () => {
+    const onchange = vi.fn();
+    render(LaneEditor, { lane: makeLane({ fallback: ['premium'] }), onchange });
 
     await fireEvent.input(screen.getByTestId('fallback-add-input'), {
       target: { value: 'economy' },
@@ -56,32 +53,50 @@ describe('LaneEditor', () => {
     await fireEvent.click(screen.getByRole('button', { name: /add fallback/i }));
     expect(screen.getAllByTestId('fallback-item')).toHaveLength(2);
 
-    await fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(onsave.mock.calls[0][1].fallback).toEqual(['premium', 'economy']);
+    expect(onchange.mock.lastCall?.[0].fallback).toEqual(['premium', 'economy']);
 
     // remove the first
-    onsave.mockClear();
+    onchange.mockClear();
     const firstItem = screen.getAllByTestId('fallback-item')[0];
     await fireEvent.click(within(firstItem).getByRole('button', { name: /remove/i }));
     expect(screen.getAllByTestId('fallback-item')).toHaveLength(1);
-    await fireEvent.click(screen.getByRole('button', { name: /save/i }));
-    expect(onsave.mock.calls[0][1].fallback).toEqual(['economy']);
+    expect(onchange.mock.lastCall?.[0].fallback).toEqual(['economy']);
   });
 
-  it('toggles require_json into the saved constraints', async () => {
-    const onsave = vi.fn();
-    render(LaneEditor, { lane: makeLane(), onsave });
+  it('toggles require_json into the emitted constraints', async () => {
+    const onchange = vi.fn();
+    render(LaneEditor, { lane: makeLane(), onchange });
 
     await fireEvent.click(screen.getByLabelText(/require json/i));
-    await fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(onsave.mock.calls[0][1].constraints.require_json).toBe(true);
+    expect(onchange.mock.lastCall?.[0].constraints.require_json).toBe(true);
+  });
+
+  it('reorders fallback by dragging its handle and supports keyboard fallback', async () => {
+    const onchange = vi.fn();
+    render(LaneEditor, { lane: makeLane({ fallback: ['premium', 'balanced'] }), onchange });
+    const items = screen.getAllByTestId('fallback-item');
+    const secondHandle = within(items[1]).getByRole('button', {
+      name: /drag to reorder fallback/i,
+    });
+
+    await fireEvent.dragStart(secondHandle);
+    await fireEvent.dragOver(items[0]);
+    await fireEvent.drop(items[0]);
+    expect(onchange.mock.lastCall?.[0].fallback).toEqual(['balanced', 'premium']);
+
+    onchange.mockClear();
+    const firstHandle = within(screen.getAllByTestId('fallback-item')[0]).getByRole('button', {
+      name: /drag to reorder fallback/i,
+    });
+    await fireEvent.keyDown(firstHandle, { key: 'ArrowDown' });
+    expect(onchange.mock.lastCall?.[0].fallback).toEqual(['premium', 'balanced']);
   });
 
   it('offers the model catalog as combobox suggestions on primary + fallback inputs', () => {
     const aliases = ['deepseek/deepseek-v4-flash', 'openai-codex/gpt-5.5', 'zenmux/auto'];
     const models = aliases.map((alias) => ({ alias, accounts: [] }));
-    const { container } = render(LaneEditor, { lane: makeLane(), models, onsave: vi.fn() });
+    const { container } = render(LaneEditor, { lane: makeLane(), models, onchange: vi.fn() });
 
     // A <datalist> with one <option> per alias is rendered…
     const datalist = container.querySelector('datalist');
@@ -106,7 +121,7 @@ describe('LaneEditor', () => {
       lane: makeLane({ name: 'coding' }),
       models,
       laneNames,
-      onsave: vi.fn(),
+      onchange: vi.fn(),
     });
 
     const options = Array.from(
@@ -134,7 +149,7 @@ describe('LaneEditor', () => {
       { alias: 'openai-codex/gpt-5.5', accounts: ['default', 'mylukin'] },
       { alias: 'deepseek/deepseek-v4-flash', accounts: [] }, // configured → provider as label
     ];
-    const { container } = render(LaneEditor, { lane: makeLane(), models, onsave: vi.fn() });
+    const { container } = render(LaneEditor, { lane: makeLane(), models, onchange: vi.fn() });
     const options = Array.from(
       container.querySelectorAll('datalist option'),
     ) as HTMLOptionElement[];
@@ -145,7 +160,7 @@ describe('LaneEditor', () => {
   });
 
   it('still works as a plain text input when no models are provided (graceful default)', () => {
-    const { container } = render(LaneEditor, { lane: makeLane(), onsave: vi.fn() });
+    const { container } = render(LaneEditor, { lane: makeLane(), onchange: vi.fn() });
     const datalist = container.querySelector('datalist');
     // datalist exists but is empty; the input is still typeable (combobox falls back to text).
     expect(datalist?.querySelectorAll('option')).toHaveLength(0);
@@ -153,23 +168,38 @@ describe('LaneEditor', () => {
     expect(primary.value).toBe('best_code_model');
   });
 
-  it('balanced guard: clearing primary disables save and shows a validation hint', async () => {
-    const onsave = vi.fn();
+  it('clearing primary emits invalid state and shows a validation hint', async () => {
+    const onchange = vi.fn();
     render(LaneEditor, {
       lane: makeLane({ name: 'balanced', primary: 'default_good_model' }),
-      onsave,
+      onchange,
     });
 
     const primary = screen.getByLabelText(/primary/i) as HTMLInputElement;
     await fireEvent.input(primary, { target: { value: '' } });
 
-    const save = screen.getByRole('button', { name: /save/i });
-    expect(save).toBeDisabled();
     const alert = screen.getByRole('alert');
-    expect(alert).toHaveTextContent(/balanced/i);
     expect(alert).toHaveTextContent(/cannot be empty|required/i);
+    expect(onchange.mock.lastCall?.[0].primary).toBe('');
+  });
 
-    await fireEvent.click(save);
-    expect(onsave).not.toHaveBeenCalled();
+  it('can delete optional lanes and protects only the configured default lane', async () => {
+    const ondelete = vi.fn();
+    const { unmount } = render(LaneEditor, {
+      lane: makeLane({ name: 'coding' }),
+      onchange: vi.fn(),
+      ondelete,
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(ondelete).toHaveBeenCalledWith('coding');
+
+    unmount();
+    render(LaneEditor, {
+      lane: makeLane({ name: 'premium' }),
+      onchange: vi.fn(),
+      ondelete,
+      canDelete: false,
+    });
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeDisabled();
   });
 });

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -256,6 +256,7 @@
   "Done in {duration}": "Done in {duration}",
   "down": "down",
   "drag to reorder policy": "drag to reorder policy",
+  "drag to reorder fallback": "drag to reorder fallback",
   "e.g. favorite number": "e.g. favorite number",
   "e.g. premium": "e.g. premium",
   "e.g. The user's favorite number is 42.": "e.g. The user's favorite number is 42.",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -256,6 +256,7 @@
   "Done in {duration}": "Listo en {duration}",
   "down": "caído",
   "drag to reorder policy": "arrastra para reordenar la política",
+  "drag to reorder fallback": "arrastra para reordenar la reserva",
   "e.g. favorite number": "p. ej. número favorito",
   "e.g. premium": "p. ej. premium",
   "e.g. The user's favorite number is 42.": "p. ej. El número favorito del usuario es 42.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -256,6 +256,7 @@
   "Done in {duration}": "{duration} で完了",
   "down": "下り",
   "drag to reorder policy": "ドラッグしてポリシーの順序を変更",
+  "drag to reorder fallback": "ドラッグしてフォールバックの順序を変更",
   "e.g. favorite number": "例：好きな数字",
   "e.g. premium": "例: premium",
   "e.g. The user's favorite number is 42.": "例：ユーザーの好きな数字は 42 です。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -256,6 +256,7 @@
   "Done in {duration}": "{duration} 소요",
   "down": "아래",
   "drag to reorder policy": "드래그하여 정책 순서 변경",
+  "drag to reorder fallback": "드래그하여 대체 순서 변경",
   "e.g. favorite number": "예: 좋아하는 숫자",
   "e.g. premium": "예: premium",
   "e.g. The user's favorite number is 42.": "예: 사용자가 좋아하는 숫자는 42입니다.",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -256,6 +256,7 @@
   "Done in {duration}": "Concluído em {duration}",
   "down": "fora do ar",
   "drag to reorder policy": "arraste para reordenar a política",
+  "drag to reorder fallback": "arraste para reordenar o fallback",
   "e.g. favorite number": "ex.: número favorito",
   "e.g. premium": "ex.: premium",
   "e.g. The user's favorite number is 42.": "ex.: O número favorito do usuário é 42.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -256,6 +256,7 @@
   "Done in {duration}": "耗时 {duration}",
   "down": "下行",
   "drag to reorder policy": "拖动以调整策略顺序",
+  "drag to reorder fallback": "拖动以调整回退顺序",
   "e.g. favorite number": "例如：喜欢的数字",
   "e.g. premium": "例如 premium",
   "e.g. The user's favorite number is 42.": "例如：用户喜欢的数字是 42。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -256,6 +256,7 @@
   "Done in {duration}": "耗時 {duration}",
   "down": "下行",
   "drag to reorder policy": "拖動以調整策略順序",
+  "drag to reorder fallback": "拖動以調整回退順序",
   "e.g. favorite number": "例如：喜歡的數字",
   "e.g. premium": "例如 premium",
   "e.g. The user's favorite number is 42.": "例如：使用者喜歡的數字是 42。",

--- a/apps/admin/src/routes/lanes/+page.svelte
+++ b/apps/admin/src/routes/lanes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { untrack } from 'svelte';
-  import { saveLane, type Lane } from '$lib/api/lanes.js';
+  import { saveLanes, type Lane } from '$lib/api/lanes.js';
   import type { ModelOption } from '$lib/api/models.js';
   import LaneEditor from '$lib/components/LaneEditor.svelte';
   import { t } from '$lib/i18n';
@@ -8,8 +8,10 @@
   // Data comes from `+page.ts`'s load (mocked via the `data` prop in tests).
   // `models` is the routable-model catalog (alias + exposing accounts) the editor
   // offers as combobox suggestions; it defaults to [] so older callers/tests work.
-  let { data }: { data: { lanes: Lane[]; models?: ModelOption[] } } = $props();
+  let { data }: { data: { lanes: Lane[]; models?: ModelOption[]; defaultLane?: string } } =
+    $props();
   const models = $derived(data.models ?? []);
+  const defaultLane = untrack(() => data.defaultLane ?? 'balanced');
 
   // Seed the working list from the loaded data once; thereafter the page owns it.
   let lanes = $state<Lane[]>(untrack(() => data.lanes));
@@ -17,27 +19,37 @@
   // element may reference another lane, not just a model). Names are immutable in
   // this editor (saves map by name), so this stays stable across edits.
   const laneNames = $derived(lanes.map((l) => l.name));
+  const valid = $derived(
+    lanes.some((lane) => lane.name === defaultLane) &&
+      lanes.every((lane) => lane.primary.trim().length > 0),
+  );
   let error = $state<string | null>(null);
-  let savingName = $state<string | null>(null);
+  let saving = $state(false);
+  let saved = $state(false);
 
-  // Whole-lane PUT (avoids concurrent-patch field loss). On failure: fail-closed
-  // — surface the error and leave the displayed lane data unchanged.
-  async function handleSave(name: string, body: Lane): Promise<void> {
+  function handleChange(next: Lane): void {
+    lanes = lanes.map((lane) => (lane.name === next.name ? next : lane));
+    saved = false;
+  }
+
+  function handleDelete(name: string): void {
+    lanes = lanes.filter((lane) => lane.name !== name);
+    saved = false;
+  }
+
+  // Whole-set PUT: edits, fallback order, and removals commit together.
+  async function handleSave(): Promise<void> {
+    if (!valid) return;
     error = null;
-    savingName = name;
+    saved = false;
+    saving = true;
     try {
-      const saved = await saveLane(name, body);
-      // Server echoes the persisted lane; fall back to the submitted body so the
-      // list stays consistent even if the response is empty.
-      const next = saved ?? body;
-      lanes = lanes.map((l) => (l.name === name ? next : l));
+      lanes = await saveLanes(lanes);
+      saved = true;
     } catch (e) {
-      // Surface a page-level alert AND re-throw so the editor leaves its per-card
-      // "Saved" flag off (fail-closed: no false success on a rejected write).
       error = e instanceof Error ? e.message : $t('Failed to save lane');
-      throw e;
     } finally {
-      savingName = null;
+      saving = false;
     }
   }
 </script>
@@ -65,8 +77,26 @@
   {:else}
     <div class="flex flex-col gap-4">
       {#each lanes as lane (lane.name)}
-        <LaneEditor {lane} {models} {laneNames} onsave={handleSave} />
+        <LaneEditor
+          {lane}
+          {models}
+          {laneNames}
+          canDelete={lane.name !== defaultLane}
+          onchange={handleChange}
+          ondelete={handleDelete}
+        />
       {/each}
     </div>
   {/if}
+
+  <div
+    class="sticky bottom-0 -mx-4 flex items-center justify-end gap-3 border-t border-border bg-canvas/95 px-4 py-3 backdrop-blur sm:static sm:m-0 sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none"
+  >
+    {#if saved}
+      <span class="badge-ok" data-testid="lanes-saved" role="status">{$t('Saved')}</span>
+    {/if}
+    <button type="button" class="btn-primary" onclick={handleSave} disabled={saving || !valid}
+      >{$t('Save')}</button
+    >
+  </div>
 </section>

--- a/apps/admin/src/routes/lanes/+page.ts
+++ b/apps/admin/src/routes/lanes/+page.ts
@@ -1,11 +1,12 @@
 import { listLanes } from '$lib/api/lanes.js';
 import { listModels } from '$lib/api/models.js';
+import { getSettings } from '$lib/api/settings.js';
 import type { PageLoad } from './$types.js';
 
 // SPA load: fetch the lane list AND the routable-alias catalog (for the combobox
 // suggestions) from the gateway admin API on the client, in parallel. `listModels`
 // never throws (degrades to []), so a missing catalog never blocks the page.
 export const load: PageLoad = async () => {
-  const [lanes, models] = await Promise.all([listLanes(), listModels()]);
-  return { lanes, models };
+  const [lanes, models, settings] = await Promise.all([listLanes(), listModels(), getSettings()]);
+  return { lanes, models, defaultLane: settings.default_lane };
 };

--- a/apps/admin/src/routes/lanes/lanes.test.ts
+++ b/apps/admin/src/routes/lanes/lanes.test.ts
@@ -5,10 +5,10 @@ import type { ModelOption } from '$lib/api/models.js';
 import LanesPage from './+page.svelte';
 
 // The page consumes data from `load` (mocked via the `data` prop) and writes
-// through the `saveLane` API client, which we mock here.
-const saveLane = vi.fn();
+// through the whole-set `saveLanes` API client, which we mock here.
+const saveLanes = vi.fn();
 vi.mock('$lib/api/lanes.js', () => ({
-  saveLane: (...args: unknown[]) => saveLane(...args),
+  saveLanes: (...args: unknown[]) => saveLanes(...args),
   // LaneEditor imports this value from the same module; the mock must expose it.
   REASONING_EFFORTS: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
 }));
@@ -24,15 +24,14 @@ function lane(name: string, overrides: Partial<Lane> = {}): Lane {
   };
 }
 
-function renderPage(lanes: Lane[], models: ModelOption[] = []) {
-  return render(LanesPage, { data: { lanes, models } });
+function renderPage(lanes: Lane[], models: ModelOption[] = [], defaultLane = 'balanced') {
+  return render(LanesPage, { data: { lanes, models, defaultLane } });
 }
 
 describe('lanes page', () => {
   beforeEach(() => {
-    saveLane.mockReset();
-    // Mirror the real client: echo the persisted lane back.
-    saveLane.mockImplementation((name: string, body: Lane) => Promise.resolve(body));
+    saveLanes.mockReset();
+    saveLanes.mockImplementation((lanes: Lane[]) => Promise.resolve(lanes));
   });
 
   it('renders one card per lane with primary + fallback', () => {
@@ -81,51 +80,67 @@ describe('lanes page', () => {
     expect(idxPremium).toBeLessThan(idxEconomy);
   });
 
-  it('editing a lane primary and saving calls saveLane with the new value', async () => {
-    renderPage([lane('coding', { primary: 'old_model' })]);
-    const card = screen.getByTestId('lane-card');
-    const primary = card.querySelector("input[name='primary']") as HTMLInputElement;
-    await fireEvent.input(primary, { target: { value: 'new_model' } });
-    await fireEvent.click(within(card).getByRole('button', { name: /save/i }));
+  it('saves edits from multiple cards in one request', async () => {
+    renderPage([lane('balanced', { primary: 'old-balanced' }), lane('coding')]);
+    const cards = screen.getAllByTestId('lane-card');
+    await fireEvent.input(cards[0].querySelector("input[name='primary']") as HTMLInputElement, {
+      target: { value: 'new-balanced' },
+    });
+    await fireEvent.change(within(cards[1]).getByTestId('reasoning-effort'), {
+      target: { value: 'medium' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
-    await waitFor(() => expect(saveLane).toHaveBeenCalledTimes(1));
-    expect(saveLane.mock.calls[0][0]).toBe('coding');
-    expect(saveLane.mock.calls[0][1].primary).toBe('new_model');
+    await waitFor(() => expect(saveLanes).toHaveBeenCalledTimes(1));
+    expect(saveLanes.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ name: 'balanced', primary: 'new-balanced' }),
+      expect.objectContaining({ name: 'coding', reasoning_effort: 'medium' }),
+    ]);
   });
 
   it('on save failure shows an error and keeps the original value (fail-closed)', async () => {
-    saveLane.mockRejectedValue(new Error('400 invalid lane'));
-    renderPage([lane('coding', { primary: 'old_model' })]);
+    saveLanes.mockRejectedValue(new Error('400 invalid lanes'));
+    renderPage([lane('balanced', { primary: 'old_model' })]);
     const card = screen.getByTestId('lane-card');
     const primary = card.querySelector("input[name='primary']") as HTMLInputElement;
     await fireEvent.input(primary, { target: { value: 'broken_model' } });
-    await fireEvent.click(within(card).getByRole('button', { name: /save/i }));
+    await fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     // The other lanes' data is untouched; the page did not crash.
-    expect(screen.getByText('coding')).toBeInTheDocument();
-  });
-
-  it('selecting a forced reasoning effort and saving sends it to saveLane', async () => {
-    renderPage([lane('coding')]);
-    const card = screen.getByTestId('lane-card');
-    const select = within(card).getByTestId('reasoning-effort') as HTMLSelectElement;
-    await fireEvent.change(select, { target: { value: 'medium' } });
-    await fireEvent.click(within(card).getByRole('button', { name: /save/i }));
-
-    await waitFor(() => expect(saveLane).toHaveBeenCalledTimes(1));
-    expect(saveLane.mock.calls[0][1].reasoning_effort).toBe('medium');
+    expect(screen.getByText('balanced')).toBeInTheDocument();
   });
 
   it('seeds the dropdown from the lane and omits the field when set back to Unset', async () => {
-    renderPage([lane('coding', { reasoning_effort: 'high' })]);
+    renderPage([lane('balanced', { reasoning_effort: 'high' })]);
     const card = screen.getByTestId('lane-card');
     const select = within(card).getByTestId('reasoning-effort') as HTMLSelectElement;
     expect(select.value).toBe('high'); // seeded from the lane's forced value
     await fireEvent.change(select, { target: { value: '' } }); // Unset
-    await fireEvent.click(within(card).getByRole('button', { name: /save/i }));
+    await fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
-    await waitFor(() => expect(saveLane).toHaveBeenCalledTimes(1));
-    expect(saveLane.mock.calls[0][1].reasoning_effort).toBeUndefined();
+    await waitFor(() => expect(saveLanes).toHaveBeenCalledTimes(1));
+    expect(saveLanes.mock.calls[0][0][0].reasoning_effort).toBeUndefined();
+  });
+
+  it('removes a lane from the working set and persists the deletion with Save lanes', async () => {
+    renderPage([lane('balanced'), lane('economy')]);
+    const cards = screen.getAllByTestId('lane-card');
+    await fireEvent.click(within(cards[1]).getByRole('button', { name: /^delete$/i }));
+
+    expect(screen.getAllByTestId('lane-card')).toHaveLength(1);
+    expect(within(cards[0]).getByRole('button', { name: /^delete$/i })).toBeDisabled();
+    await fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(saveLanes).toHaveBeenCalledWith([expect.objectContaining({ name: 'balanced' })]),
+    );
+  });
+
+  it('protects the configured default lane instead of hard-coding balanced', () => {
+    renderPage([lane('balanced'), lane('premium')], [], 'premium');
+    const cards = screen.getAllByTestId('lane-card');
+    expect(within(cards[0]).getByRole('button', { name: /^delete$/i })).toBeEnabled();
+    expect(within(cards[1]).getByRole('button', { name: /^delete$/i })).toBeDisabled();
   });
 });

--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -74,11 +74,11 @@
   let saving = $state(false);
   let saved = $state(false);
 
-  // Lane options for the default-lane dropdown: the loaded lanes, always including
-  // `balanced` (the guaranteed floor) and the current value (so a still-set lane
-  // that no longer loads doesn't vanish from the picker).
+  // Lane options for the default-lane dropdown: only configured lanes plus the
+  // current value (so a stale manually-edited value remains visible and can be
+  // corrected). No lane name is special-cased here.
   const laneOptions = $derived(
-    Array.from(new Set([...(data.lanes ?? []), 'balanced', form.default_lane])),
+    Array.from(new Set([...(data.lanes ?? []), form.default_lane])),
   );
 
   async function handleSave(): Promise<void> {

--- a/apps/admin/src/routes/settings/settings.test.ts
+++ b/apps/admin/src/routes/settings/settings.test.ts
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { RuntimeSettings } from '$lib/api/settings.js';
+import SettingsPage from './+page.svelte';
+
+vi.mock('$lib/api/cleanup.js', () => ({
+  archiveDownloadUrl: vi.fn(),
+  getCleanupStatus: vi.fn(() => Promise.resolve({ lastRun: null, archives: [] })),
+  runCleanupNow: vi.fn(),
+  vacuumDatabase: vi.fn(),
+}));
+
+vi.mock('$lib/api/settings.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/api/settings.js')>();
+  return { ...actual, saveSettings: vi.fn() };
+});
+
+describe('settings default lane options', () => {
+  it('offers only configured lanes without hard-coding balanced', () => {
+    render(SettingsPage, {
+      data: {
+        settings: { default_lane: 'premium' } as RuntimeSettings,
+        lanes: ['economy', 'premium'],
+      },
+    });
+
+    const select = screen.getByTestId('default-lane') as HTMLSelectElement;
+    expect(Array.from(select.options, (option) => option.value)).toEqual(['economy', 'premium']);
+    expect(select.value).toBe('premium');
+  });
+});

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -87,10 +87,10 @@ test.describe("admin lane editing", () => {
 
     const primary = card.locator("input[name='primary']");
     await primary.fill(newPrimary);
-    await card.getByRole("button", { name: /save/i }).click();
+    await page.getByRole("button", { name: /^save$/i }).click();
 
-    // A per-card success indicator must appear after the write-back succeeds.
-    await expect(card.getByTestId("lane-saved")).toBeVisible();
+    // The one page-level success indicator appears after the atomic write-back.
+    await expect(page.getByTestId("lanes-saved")).toBeVisible();
 
     // Reload from the gateway: the runtime config kept the edit (docs/04).
     await page.reload();

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -390,6 +390,43 @@ describe("admin.api lanes", () => {
     expect(names).toContain("balanced");
   });
 
+  it("PUT /lanes replaces the complete lane set atomically", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    const current = await rules.getLanes();
+    const body = {
+      balanced: { ...current.balanced, primary: "new-balanced" },
+      coding: { ...current.coding, primary: "new-coding" },
+    };
+
+    const res = await app.request("/admin/api/lanes", {
+      method: "PUT",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(200);
+    const saved = await rules.getLanes();
+    expect(Object.keys(saved)).toEqual(["balanced", "coding"]);
+    expect(saved.balanced?.primary).toBe("new-balanced");
+    expect(saved.coding?.primary).toBe("new-coding");
+  });
+
+  it("PUT /lanes rejects a complete set without runtime.default_lane and writes nothing", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    const before = structuredClone(await rules.getLanes());
+
+    const res = await app.request("/admin/api/lanes", {
+      method: "PUT",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ economy: before.economy }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await rules.getLanes()).toEqual(before);
+  });
+
   it("rejects an invalid lane body with 400 and does not write", async () => {
     const deps = buildDeps();
     const app = buildApp(deps);
@@ -456,10 +493,7 @@ describe("admin.api lanes", () => {
     expect((await rules.getLanes()).economy).toBeUndefined();
   });
 
-  it("refuses to DELETE the `balanced` fallback terminal (409) and writes nothing", async () => {
-    // Principle 5: `balanced` is the classification-fallback terminal; deleting it would
-    // leave LanesConfigSchema unsatisfiable. The whole-map re-validation must catch
-    // this and leave config untouched (fail-closed).
+  it("refuses to DELETE the configured default lane (409) and writes nothing", async () => {
     const deps = buildDeps();
     const app = buildApp(deps);
     const before = await rules.getLanes();
@@ -467,6 +501,18 @@ describe("admin.api lanes", () => {
     expect(res.status).toBe(409);
     expect(await rules.getLanes()).toEqual(before); // nothing written
     expect((await rules.getLanes()).balanced).toBeDefined();
+  });
+
+  it("allows deleting balanced after another lane becomes runtime.default_lane", async () => {
+    const deps = buildDeps();
+    await deps.settings.save({ ...deps.settings.get(), default_lane: "premium" });
+    const app = buildApp(deps);
+
+    const res = await app.request("/admin/api/lanes/balanced", { method: "DELETE" });
+
+    expect(res.status).toBe(200);
+    expect((await deps.rules.getLanes()).balanced).toBeUndefined();
+    expect((await deps.rules.getLanes()).premium).toBeDefined();
   });
 });
 

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -39,8 +39,7 @@ export type UsageLimitWriteMode = "extend" | "replace";
 // A typed read/write seam for the rule configs. Each accessor returns/accepts an
 // already-validated config object — the routes Zod-validate the inbound body
 // BEFORE calling `set*` so an invalid config is rejected (400) and never written
-// (fail-closed, Principle 2). `lanes` is a name->Lane map matching LanesConfig minus the
-// `balanced`-required refinement concern (the route enforces shape via LaneSchema).
+// (fail-closed, Principle 2). `lanes` is a name->Lane map matching LanesConfig.
 export interface RuleStore {
   getLanes(): Promise<Record<string, Lane>>;
   setLanes(lanes: Record<string, Lane>): Promise<void>;

--- a/apps/gateway/src/routes/admin/lanes.ts
+++ b/apps/gateway/src/routes/admin/lanes.ts
@@ -27,6 +27,24 @@ export function registerLanesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     return c.json(list);
   });
 
+  // PUT /lanes <- complete lane map (validated as one atomic config write).
+  app.put("/admin/api/lanes", async (c) => {
+    const parsed = LanesConfigSchema.safeParse(await c.req.json().catch(() => null));
+    if (!parsed.success) {
+      return c.json({ error: "invalid lanes config", issues: parsed.error.issues }, 400);
+    }
+    const defaultLane = deps.settings.get().default_lane;
+    if (!(defaultLane in parsed.data)) {
+      return c.json({ error: `cannot remove the default lane '${defaultLane}'` }, 409);
+    }
+    try {
+      await deps.rules.setLanes(parsed.data);
+    } catch (err) {
+      return rulePersistErrorResponse(c, err);
+    }
+    return c.json(Object.entries(parsed.data).map(([name, lane]) => ({ name, ...lane })));
+  });
+
   // GET /lanes/:name -> Lane | 404
   app.get("/admin/api/lanes/:name", async (c) => {
     const lanes = await deps.rules.getLanes();
@@ -45,10 +63,8 @@ export function registerLanesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     try {
       await deps.rules.updateLanes((current) => {
         const lanes = { ...current, [name]: parsed.data };
-        // Re-validate the WHOLE map before writing: a single-lane edit can still break
-        // the map-level invariant (LanesConfigSchema requires `balanced`, the
-        // classification-fallback terminal — Principle 5). Fail-closed: nothing written on a
-        // violation (Principle 2).
+        // Re-validate the WHOLE map before writing. Fail-closed: nothing is written
+        // when any lane makes the complete config invalid.
         const map = LanesConfigSchema.safeParse(lanes);
         if (!map.success) {
           throw new LaneMutationHttpError(400, {
@@ -69,14 +85,17 @@ export function registerLanesRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   // DELETE /lanes/:name
   app.delete("/admin/api/lanes/:name", async (c) => {
     const name = c.req.param("name");
+    const defaultLane = deps.settings.get().default_lane;
+    if (name === defaultLane) {
+      return c.json({ error: `cannot delete the default lane '${defaultLane}'` }, 409);
+    }
     try {
       await deps.rules.updateLanes((current) => {
         const lanes = { ...current };
         if (!(name in lanes)) throw new LaneMutationHttpError(404, { error: "lane not found" });
         delete lanes[name];
-        // Re-validate the mutated map BEFORE writing. Deleting `balanced` (or any edit
-        // that breaks the map-level invariant) must be rejected with nothing written —
-        // it is the classification-fallback terminal (Principle 5, fail-closed Principle 2).
+        // Re-validate the mutated map BEFORE writing. The configured default lane
+        // is protected above; the schema still requires at least one valid lane.
         const map = LanesConfigSchema.safeParse(lanes);
         if (!map.success) {
           throw new LaneMutationHttpError(409, {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -2643,6 +2643,11 @@ export async function buildServer(
   // an invalid lanes.yaml already failed the load above). policies default to []
   // via the schema, so an absent policies.yaml is a no-op.
   let lanes: LanesConfig = config.lanes ?? parseLanesConfig(DEFAULT_LANES);
+  if (!(settings.default_lane in lanes)) {
+    throw new Error(
+      `invalid runtime.default_lane '${settings.default_lane}': no matching lane is configured`,
+    );
+  }
   let policies: PoliciesConfig = config.policies;
   // Virtual model aliases (docs/04 compatibility shim): a fixed-model client
   // (Claude CLI, an SDK pinned to a vendor id like "claude-opus-4-8") has its

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -38,7 +38,7 @@ economy:
     - zenmux/auto
 
 balanced:
-  purpose: Default quality/cost tradeoff (classification fallback terminal)
+  purpose: Default quality/cost tradeoff
   reasoning_effort: medium
   primary: openai-codex/gpt-5.6-terra
   fallback:

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -250,8 +250,8 @@ Helm exposes configured **lanes** (the abstraction clients steer toward; provide
 aliases stay internal). The checked-in file currently has 22: three ranked
 quality/cost lanes (`economy`, `balanced`, `premium`), four task lanes (`coding`,
 `json`, `vision`, `tool_use`), 13 vendor-family compatibility lanes, and two
-image lanes. `balanced` is schema-mandatory as the last-resort floor, although
-the live terminal fallback can be changed to another existing lane. Not every
+image lanes. The lane map must contain at least one lane, and the live terminal
+fallback must name one of them (`balanced` is only the shipped default). Not every
 task/image lane transitively includes `balanced`; the exact chains live in
 `config/lanes.yaml`. See
 [04 · Routing & Lanes](04-routing-and-lanes.md).

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -55,15 +55,17 @@ The terminal fallback lane is operator-configurable via the admin **System
 Settings** (`runtime.default_lane`, hot-applied, default `balanced`). It is used at
 **both** fail-open terminals — the classifier short-circuit above and the final
 "nothing resolved" sink — **but only if the named lane exists**; otherwise the
-resolver falls back to the literal `balanced`. It does **not** change the
+resolver defensively prefers `balanced` when present, then the first configured
+lane. It does **not** change the
 complexity-fallback tiers (`simple→economy / medium→balanced / complex→premium`),
 which keep their fixed targets. An unknown lane is rejected (400) at the settings
-write boundary, so a stale value can only arise if a lane is deleted afterwards —
-in which case the `balanced` floor takes over.
+write boundary, and the current default lane cannot be deleted through the Admin
+API. The resolver fallback only protects direct callers or manually inconsistent
+configuration; Gateway composition rejects that inconsistency at startup.
 
 Default lanes are deliberately few and easy to reason about. Any selected lane
-name that does not exist is skipped (fail-open); the terminal `balanced` is
-guaranteed to exist.
+name that does not exist is skipped (fail-open); the configured terminal must be
+one of the lanes in the set.
 
 When `runtime.signal_feedback.enabled` is true, the router performs one
 fail-open read of aggregated Agentic Signals after policy/key caps are applied
@@ -210,7 +212,7 @@ economy:
     - zenmux/auto
 
 balanced:
-  purpose: Default quality/cost tradeoff (classification fallback terminal)
+  purpose: Default quality/cost tradeoff
   reasoning_effort: medium
   primary: openai-codex/gpt-5.6-terra
   fallback:
@@ -230,9 +232,9 @@ premium:
     - balanced
 ```
 
-`balanced` is schema-required as the last-resort floor. It is also the shipped
-`runtime.default_lane`; an operator may choose another existing terminal lane at
-runtime, but a missing/stale choice still falls back to `balanced`.
+The lane map must contain at least one lane. `balanced` is the shipped
+`runtime.default_lane`, not a schema-mandatory name; an operator may choose another
+existing terminal lane and then delete `balanced`.
 
 The shipped task lanes (the lane resolver maps a classified `task_type` onto a
 same-named lane). These are **unranked** — incomparable to the quality/cost

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-22 · Lanes 批量保存、拖拽回退与可配置默认通道删除边界（Routing / Admin lanes，docs/03/04/11，原则 2/3/5/6）
+
+- **整组写入**：Lanes 页面不再由每张卡分别 PUT；所有编辑、fallback 顺序和待删除 lane 由一个底部保存按钮通过 `PUT /admin/api/lanes` 一次提交，Gateway 用共享 `LanesConfigSchema` 校验完整 map 后原子写回 `lanes.yaml` 并热更新，失败时整组不落盘。单 lane API 保留兼容，不新增依赖。
+- **排序与删除**：fallback 的上下按钮改为复用 Policies 页交互语义的拖拽手柄，并保留方向键排序；每张 lane 卡提供删除按钮，删除先进入页面工作集，统一保存时才持久化。页面从 runtime settings 读取当前 `default_lane`，只保护当前默认 lane，不把 `balanced` 写死。
+- **配置边界修正**：`LanesConfigSchema` 改为要求至少一个有效 lane；`runtime.default_lane` 与 lane 集合的交叉约束在 Gateway 边界及启动组合层 fail-closed 校验。因而用户先把默认通道改成其他 lane 后可删除 `balanced`；Settings 选项与默认配置说明也不再把 `balanced` 当作强制终点。若手工配置令默认通道不存在，Gateway 拒绝启动；Resolver 仍对异常调用防御性地回退到存在的 `balanced` 或第一个 lane。
+
 ## 2026-07-21 · 首次安装改为令牌保护的浏览器向导并允许订阅-only 启动（Deployment / bootstrap / Admin，docs/10/11，原则 2/3/7）
 
 - **Admin 登录体验**：浏览器不再依赖 `WWW-Authenticate` 触发原生 Basic 弹窗；未登录页面跳转到 Gateway 自带的 `/admin/login`，成功后使用仅含过期时间与 HMAC 的 12 小时 `HttpOnly`、`SameSite=Strict`、`Path=/admin` Cookie，HTTPS 时加 `Secure`。签名密钥只由进程内现有 Admin 用户名/密码派生，凭据轮换自动让旧会话失效，不新增 session 表、JWT 依赖或独立 secret。Admin SPA 与静态资产仍在会话/Basic 双重认证之后，只有无脚本登录 HTML 公开；脚本可继续主动发送 HTTP Basic，失败响应不再带 challenge，避免浏览器弹窗。登录 POST 校验同源、常量时间比较并限制本地 `next`，顶栏提供退出入口。
@@ -60,14 +66,9 @@
 - **CI 维护边界**：GitHub Actions 升级到经过签名验证并固定完整 SHA 的 checkout v7、setup-node v7 与 pnpm/action-setup v6，消除 Node 20 runtime 弃用；setup-node v7 正式支持 `package-manager-cache:false`。checkout v7 对 fork PR 的显式 opt-in 只存在于 `pull_request_target` 的三个代码执行 job，它们仍固定在一次性 GitHub-hosted runner、只读 token、无 secrets 且 `persist-credentials:false`；特权 Publish 不允许该选项。
 - **验证**：TDD 先复现空集放行、双重 clamp 越权、规则/缓存开关无效和旧 Action pin，再覆盖 core、Gateway、Admin 与 workflow policy；本地只运行 `CI=true` 定向 Vitest 且单 worker，最终结果和 hosted CI 另行记录在 PR。
 
-## 2026-07-16 · xAI 订阅协议跟随官方 grok-build 并收紧动态目录边界（OAuth subscription / model catalog / Responses / Admin providers，docs/04/05/06/11，原则 2/3/5/6/7/8）
-
-- **官方事实边界**：以 `xai-org/grok-build@c68e39f`、本机 Grok CLI `0.2.101` 和当前账号真实 wire 为准；OAuth issuer/client、Device Code 与 `/v1/responses` 主链保留，scope 补齐官方 personal conversation scopes，推理请求补充 headless/client identifier/user identity 并强制请求 `reasoning.encrypted_content`。当前 entitlement 仍只有 `grok-4.5` 与 `grok-composer-2.5-fast`，两者的真实 `/models` backend 均为 `responses`，目录分别报告 500k 与 200k context；官方静态 fallback 中的 `grok-build` 不是账号授权证据，不能自动加入 Helm。
-- **目录与能力边界**：`/models` 不再压缩成字符串；目录 `id` 与实际 wire `model` 分开保存，并保留官方 backend、context、max output/retry、reasoning、visibility 与 streamed-tool metadata。重复 id 与官方一致采用 last-wins，数值和 reasoning fallback 也按官方边界解析。结构化账号目录加密持久化为 last-known-good：上游失败复用，成功空目录则权威清空；换凭证会先清旧身份目录。Lane picker 只读取当前 synthesized pool 接受的 xAI alias/account，不能把被 metadata/wire conflict 剔除的账号继续显示为可路由。Helm 识别 `responses` / `chat_completions` / `messages`，但只路由当前已实现的 Responses transport；hidden 条目排除，`supportedInApi:false` 仍可用于 session auth。已验证 wire model 复用手工 capability/pricing，并以下游目录报告的 context/output 上限做更小值钳制；目录若将来提供 `maxCompletionTokens` / `streamToolCalls`，请求只在客户端未显式设置时应用。未知 Responses 模型只获得保守的纯文本/streaming 能力，tools/vision/JSON/media/cache 与价格保持关闭或 unknown。多账号同 alias 若目录 metadata 或 wire slug 冲突则拒绝冲突账号，不采用跨账号 last-write-wins。
-- **故障与配额边界**：按照官方明确语义，只有 xAI inference 401 才证明凭证失效；403 作为已认证的 policy/content/ZDR denial 进入正常执行 fallback，不停车、不持久化 credential failure。Device Code 完成后 pool rebuild 未应用必须返回 `503 not_applied`。SuperGrok quota 运行时迁移到官方 `GET https://cli-chat-proxy.grok.com/v1/billing?format=credits`，使用 bearer、账号 identity、client version、headless mode 与同账号 proxy；有界 JSON 只投影当前 weekly period，忽略 prepaid/on-demand/monthly/history。真实响应证明 0% 时 proto3 JSON 会省略 `creditUsagePercent`，因此仅“缺失”解释为 0，显式 null/string 仍拒绝。
-- **延后项**：当前真实目录没有发布 `maxRetries`、`maxCompletionTokens` 或 `streamToolCalls`。后两项已具备未来兼容；`maxRetries` 暂不接入，因为 Helm 的账号 pool 与 lane fallback 已各自拥有重试边界，直接照搬会造成 `lane × account × retries` 放大，必须以后以 pool 为唯一共享预算再实现。通用 grok-build 客户端具备 JSON schema、额外 reasoning/retry、backend search 与其他工具扩展，不等于当前两个 SuperGrok entitlement 已验证这些 API 能力；Composer vision、订阅 JSON、额外媒体和未公开价格继续 fail-closed。后续若要开启，必须先做隔离真实请求与协议 fixture，不能仅凭通用 Rust 类型推断。
 ## 历史条目摘要（最新要点）
 
+- **2026-07-16 · xAI 订阅协议跟随官方 grok-build 并收紧动态目录边界（OAuth subscription / model catalog / Responses / Admin providers，原则 2/3/5/6/7/8）**：按官方源码、真实 wire 与 entitlement 校准 xAI OAuth、动态目录、Responses、能力和 weekly credits；401/403、账号冲突、last-known-good 与未知能力继续 fail-closed，完整原文通过 git history 回溯。
 - **2026-07-16 · 收紧发布信任链、请求归属与 Memory 项目隔离（CI / observability / Memory，原则 1/3/7）**：PR 信任链固定到受核验 merge ref 与只读权限，发布绑定已验证 main SHA；内部 `request_id` 与客户端 trace 分离，Memory thread/project 迁移保持租户隔离与事务原子性；完整原文通过 git history 回溯。
 - **2026-07-16 · 文档以当前源码为准完成全量运行时事实校准（docs/01–14 / README / operations，原则 1–8）**：以当前路由、schema、Store、配置与测试校准全部当前文档和中英文 README，明确 Portal、部署、安全、Memory 与协议实现/缺口边界；完整原文通过 git history 回溯。
 - **2026-07-16 · Admin 首次点击卡顿改为非投机加载与汇总读（Admin / Store performance，docs/08/11，原则 1/3/7）**：以 `memory_threads` 的事务维护汇总替代正文表冷扫描，Admin 改为非投机 data preload，并以有界 stale-while-revalidate 缓存保护统计读取；在线 VACUUM 继续禁止。

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -223,15 +223,14 @@ describe("loadConfig", () => {
     expect(cfg.policies.policies).toEqual([]);
   });
 
-  it("fail-closed: a lanes.yaml missing the balanced terminal throws ConfigError", () => {
-    const badLanes = "economy:\n  primary: cheap_model\n  fallback: [premium]\n";
-    expect(() =>
-      loadConfig({
-        configDir: "config",
-        env: {},
-        readFile: fakeReadFile({ ...VALID_YAML, "config/lanes.yaml": badLanes }),
-      }),
-    ).toThrow(ConfigError);
+  it("accepts lanes.yaml without balanced; runtime.default_lane is validated at composition", () => {
+    const lanes = "economy:\n  primary: cheap_model\n  fallback: [premium]\n";
+    const cfg = loadConfig({
+      configDir: "config",
+      env: {},
+      readFile: fakeReadFile({ ...VALID_YAML, "config/lanes.yaml": lanes }),
+    });
+    expect(cfg.lanes?.economy?.primary).toBe("cheap_model");
   });
 
   it("fail-closed: a policy with no action field throws ConfigError", () => {

--- a/packages/core/src/lanes/schema.test.ts
+++ b/packages/core/src/lanes/schema.test.ts
@@ -28,12 +28,16 @@ describe("parseLanesConfig", () => {
     expect(balanced.fallback).toEqual(["premium", "economy"]);
   });
 
-  it("fails closed when balanced is missing", () => {
+  it("allows balanced to be absent when runtime.default_lane points elsewhere", () => {
     const raw = {
       economy: { primary: "cheap_model", fallback: ["premium"] },
       premium: { primary: "best_reasoning_model", fallback: [] },
     };
-    expect(() => parseLanesConfig(raw)).toThrow(/balanced/);
+    expect(Object.keys(parseLanesConfig(raw))).toEqual(["economy", "premium"]);
+  });
+
+  it("fails closed when no lanes are configured", () => {
+    expect(() => parseLanesConfig({})).toThrow();
   });
 
   it("fills defaults: missing constraints -> {} with false flags; missing fallback -> []", () => {

--- a/packages/core/src/routing/lane-resolver.test.ts
+++ b/packages/core/src/routing/lane-resolver.test.ts
@@ -158,7 +158,7 @@ describe("resolveLane — configurable terminal (defaultLane)", () => {
   it("classifier fail-open lands on the configured defaultLane when it exists", () => {
     const out = resolveLane(
       input({
-        lanes: lanes(["economy", "premium"]),
+        lanes: { economy: lane(), premium: lane() },
         defaultLane: "economy",
         classification: classification({ decided_by: "default" }),
       }),
@@ -166,6 +166,17 @@ describe("resolveLane — configurable terminal (defaultLane)", () => {
     expect(out.selected_lane).toBe("economy");
     expect(out.decided_by).toBe("complexity_fallback");
     expect(out.reason.toLowerCase()).toContain("economy");
+  });
+
+  it("uses the first configured lane defensively when both defaultLane and balanced are absent", () => {
+    const out = resolveLane(
+      input({
+        lanes: { premium: lane() },
+        defaultLane: "removed",
+        classification: classification({ decided_by: "fallback" }),
+      }),
+    );
+    expect(out.selected_lane).toBe("premium");
   });
 
   it("final unresolved lands on the configured defaultLane when it exists", () => {

--- a/packages/core/src/routing/lane-resolver.ts
+++ b/packages/core/src/routing/lane-resolver.ts
@@ -1,9 +1,8 @@
 import type { LanesConfig } from "../lanes/schema.js";
 
 // Lane Resolver — collapses the classifier + policy outcome into exactly ONE
-// lane name, defaulting to `balanced`. Pure, deterministic, zero-network
-// (CLAUDE.md principle 4); `balanced` is the terminal of the *classification*
-// fallback (principle 5) and is guaranteed to exist by `lanes.schema`. It does
+// lane name, defaulting to the configured runtime terminal. Pure, deterministic,
+// zero-network (CLAUDE.md principle 4). It does
 // NOT expand primary->fallback chains, trip circuit breakers, or call providers
 // — that EXECUTION fallback belongs to `executor.fallback`, a separate
 // mechanism with separate log fields (principle 5). See
@@ -45,8 +44,8 @@ export interface ResolveLaneInput {
   // Operator-chosen terminal fallback lane (admin "System Settings"). Used ONLY at
   // the fail-open terminal (classifier `default`/`fallback`, or fully-unresolved) —
   // NOT for the complexity tiers. Honoured only if the lane EXISTS; otherwise the
-  // resolver uses the literal `balanced` floor (guaranteed by lanes.schema), so a
-  // stale/removed lane can never strand routing. Omitted ⇒ `balanced` (back-compat).
+  // resolver prefers `balanced`, then the first configured lane, so a stale setting
+  // can never strand routing. Omitted ⇒ `balanced` when present (back-compat).
   defaultLane?: string;
 }
 
@@ -76,16 +75,20 @@ function has(lanes: LanesConfig, name: string): boolean {
 //   3. complexity fallback lane (if it exists)                     -> complexity_fallback
 //   4. otherwise / classifier self-fallback / missing lane         -> balanced
 // Any selected name that is absent from `lanes` is skipped (fail-open,
-// principle 3); the terminal `balanced` is guaranteed present by lanes.schema.
+// principle 3); the terminal is always chosen from the configured lane set.
 export function resolveLane(input: ResolveLaneInput): LaneDecision {
   const { classification, policy, lanes } = input;
 
   // Terminal fallback lane: the operator-chosen `defaultLane` if it names an
-  // existing lane, else the literal `balanced` floor (guaranteed by lanes.schema).
+  // existing lane, else balanced for back-compat, else the first configured lane.
   // This affects ONLY the two fail-open terminals below — never the complexity
   // tiers (COMPLEXITY_FALLBACK), which keep their fixed economy/balanced/premium.
   const terminal =
-    input.defaultLane && has(lanes, input.defaultLane) ? input.defaultLane : BALANCED;
+    input.defaultLane && has(lanes, input.defaultLane)
+      ? input.defaultLane
+      : has(lanes, BALANCED)
+        ? BALANCED
+        : (Object.keys(lanes)[0] ?? BALANCED);
 
   // The classifier already fell back to its terminal (hard fail-open `default`,
   // or Layer-3 cascade `fallback`) — do not re-derive a lane from

--- a/packages/shared/src/config/lanes-schema.test.ts
+++ b/packages/shared/src/config/lanes-schema.test.ts
@@ -28,12 +28,16 @@ describe("parseLanesConfig", () => {
     expect(balanced.fallback).toEqual(["premium", "economy"]);
   });
 
-  it("fails closed when balanced is missing", () => {
+  it("allows balanced to be absent when runtime.default_lane points elsewhere", () => {
     const raw = {
       economy: { primary: "cheap_model", fallback: ["premium"] },
       premium: { primary: "best_reasoning_model", fallback: [] },
     };
-    expect(() => parseLanesConfig(raw)).toThrow(/balanced/);
+    expect(Object.keys(parseLanesConfig(raw))).toEqual(["economy", "premium"]);
+  });
+
+  it("fails closed when no lanes are configured", () => {
+    expect(() => parseLanesConfig({})).toThrow();
   });
 
   it("fills defaults: missing constraints -> {} with false flags; missing fallback -> []", () => {

--- a/packages/shared/src/config/lanes-schema.ts
+++ b/packages/shared/src/config/lanes-schema.ts
@@ -72,13 +72,12 @@ export const LaneSchema = z.strictObject({
 });
 export type Lane = z.infer<typeof LaneSchema>;
 
-// lanes.yaml top level: lane name -> Lane, with `balanced` enforced present —
-// it is the terminal of the classification fallback (docs/04, principle 5).
+// lanes.yaml top level: lane name -> Lane. At least one lane must exist; the
+// runtime.default_lane cross-reference is validated where both values are available.
 export const LanesConfigSchema = z
   .record(z.string().min(1), LaneSchema)
-  .refine((m) => "balanced" in m, {
-    message: "lanes.yaml must define a `balanced` lane (classification fallback terminal)",
-    path: ["balanced"],
+  .refine((m) => Object.keys(m).length > 0, {
+    message: "lanes.yaml must define at least one lane",
   });
 export type LanesConfig = z.infer<typeof LanesConfigSchema>;
 

--- a/packages/shared/src/config/runtime-settings.schema.ts
+++ b/packages/shared/src/config/runtime-settings.schema.ts
@@ -63,9 +63,9 @@ export const RuntimeSettingsSchema = z.object({
   log_level: LogLevelSchema.default("info"),
   // Terminal fallback lane — where a request lands when the classifier fails open
   // (decided_by "default"/"fallback") or nothing else resolves. Default "balanced"
-  // (the schema-guaranteed floor, so behaviour is unchanged when unset). The lane
-  // resolver only honours this if the named lane EXISTS, otherwise it falls back to
-  // "balanced" — so a stale/removed lane can never strand routing (no fail-close).
+  // for backward compatibility. The lane resolver only honours this if the named
+  // lane exists; otherwise it prefers "balanced" when present, then the first lane,
+  // so a stale/manual inconsistency cannot strand direct resolver callers.
   // Lane-existence is validated fail-closed at the admin PUT route. Only the
   // terminal sink is affected; the complexity tiers (simple→economy / medium→
   // balanced / complex→premium) are intentionally NOT changed by this setting.

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -303,7 +303,7 @@ export const HelmConfigSchema = z.object({
   // Lanes (config/lanes.yaml). OPTIONAL at the config level: when lanes.yaml is
   // absent the gateway falls back to core's DEFAULT_LANES (principle 6, the lane
   // abstraction is always present). When PRESENT, it must be a valid LanesConfig
-  // (with a `balanced` terminal) or the loader fails closed (principle 2). Not
+  // (with at least one lane) or the loader fails closed (principle 2). Not
   // defaulted here so the server can distinguish "config provided none" (use
   // DEFAULT_LANES) from "config provided lanes".
   lanes: LanesConfigSchema.optional(),


### PR DESCRIPTION
## What changed

- replace per-lane saves with one atomic full-config save
- replace fallback move buttons with mouse, touch, and keyboard drag reordering
- allow whole lanes to be removed from the working set and persisted by Save
- protect the configured `runtime.default_lane` instead of hard-coding `balanced`
- validate the default-lane cross-reference at Admin write and Gateway startup boundaries
- align Settings options, shipped config descriptions, routing docs, and implementation notes

## Why

The Lanes page required repetitive saves and awkward ordering controls. Deletion also treated `balanced` as permanently special even though the terminal fallback lane is runtime-configurable.

## Validation

- `CI=true pnpm exec vitest run ...` — 196 focused tests passed
- `CI=true pnpm --filter @helm/admin check` — 0 errors, 0 warnings
- `CI=true pnpm typecheck`
- `CI=true pnpm lint` — pass with 37 existing workflow-string warnings
- `CI=true pnpm build`
- Browser QA at desktop and 390x844 mobile: multi-lane edit, drag, delete, one-save persistence, dynamic default-lane protection, no console warnings/errors
