### PR TITLE
[codex] Release v0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.27.28",
+  "version": "0.28.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the root package version from 0.27.28 to 0.28.0

## Why

- publish incremental Session transcript capture, request-list Session visibility, and payload-first Session recovery
- make Session transcript capture the default for new installations while preserving explicit legacy content-capture choices
- use a minor release because this adds a storage model and changes the new-install default behavior

## Validation

- confirmed the release diff changes only root package.json
- git diff --check
- parsed package.json and verified version 0.28.0
- feature PR #611 passed verify, e2e, docker, and report_pr_checks
- Claude CLI Opus review cycle 2 returned APPROVE
