### PR TITLE
[codex] release v0.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.28.0` to `0.28.1` after merging PR #613.

## Included fix

- restore Session response snapshots in Admin request details
- persist successful non-stream response snapshots in Session mode
- preserve Responses continuation semantics and bounded storage behavior

## Validation

PR #613 passed verify, E2E, Docker smoke, and two Claude CLI Opus review passes before merge.
