### PR TITLE
chore: release v0.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- Bump the root package version from `0.28.1` to `0.28.2`.

## Why

- Publish the merged copy and localization improvements from PR #615 as a separate patch release.

## Impact

- Enables the release workflow to build and publish the immutable v0.28.2 image and GitHub Release.
- No runtime behavior or configuration changes are included in this version-only PR.

## Validation

- PR #615 merged to `main` at `8093602fd2dbd56d47360c37177cdd3a72951363`.
- Main CI run 29931887812 passed Docker smoke, typecheck, lint, build, unit tests, and E2E.
- This branch changes only root `package.json`; `git diff --check` passes.