### PR TITLE
fix(admin): keep login sessions for 30 days

### DIFF
--- a/apps/gateway/src/routes/admin-login.test.ts
+++ b/apps/gateway/src/routes/admin-login.test.ts
@@ -58,7 +58,7 @@ describe("Admin login page", () => {
     expect(cookie).toContain("HttpOnly");
     expect(cookie).toContain("SameSite=Strict");
     expect(cookie).toContain("Path=/admin");
-    expect(cookie).toContain("Max-Age=43200");
+    expect(cookie).toContain("Max-Age=2592000");
     expect(cookie).not.toContain("Secure");
   });
 
@@ -72,7 +72,8 @@ describe("Admin login page", () => {
 
   it("uses a login-issued session cookie on the protected Admin API", async () => {
     const app = appWithLogin();
-    app.use("/admin/api/*", basicAuth(AUTH, { allowSession: true, now: () => NOW }));
+    let now = NOW + 30 * 24 * 60 * 60 * 1000 - 1;
+    app.use("/admin/api/*", basicAuth(AUTH, { allowSession: true, now: () => now }));
     app.get("/admin/api/ping", (c) => c.json({ ok: true }));
 
     const login = await app.request(
@@ -85,6 +86,10 @@ describe("Admin login page", () => {
     const api = await app.request("/admin/api/ping", { headers: { Cookie: cookie ?? "" } });
     expect(api.status).toBe(200);
     await expect(api.json()).resolves.toEqual({ ok: true });
+
+    now += 1;
+    const expired = await app.request("/admin/api/ping", { headers: { Cookie: cookie ?? "" } });
+    expect(expired.status).toBe(401);
   });
 
   it("shows a generic inline error without echoing credentials", async () => {

--- a/apps/gateway/src/routes/admin-login.ts
+++ b/apps/gateway/src/routes/admin-login.ts
@@ -11,7 +11,7 @@ import {
   verifyAdminSessionToken,
 } from "../middleware/basic-auth.js";
 
-const SESSION_SECONDS = 12 * 60 * 60;
+const SESSION_SECONDS = 30 * 24 * 60 * 60;
 const LoginSchema = z.object({
   username: z.string().max(128),
   password: z.string().max(512),


### PR DESCRIPTION
## Summary
- extend the signed Admin session and cookie Max-Age from 12 hours to 30 days
- keep existing HttpOnly, SameSite=Strict, path, Secure, logout, and password-rotation protections
- verify the session is accepted until the 30-day boundary and rejected at expiry

## Validation
- `git diff --check`
- focused Vitest covered by PR CI (local isolated worktree has no dependencies; machine load prevented an install)