### PR TITLE
chore(release): bump version to 0.28.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from `0.28.2` to `0.28.3`
- release the merged Admin 30-day login session fix from #617

## Scope
- version-only patch release