### PR TITLE
[codex] prevent OOM resets with dynamic memory admission

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,8 @@ GEMINI_API_KEY=
 # —— Optional runtime overrides (env wins over config/*.yaml) ——
 HELM_HOST=0.0.0.0
 HELM_PORT=8080
+# Compose-only graceful shutdown window; increase for very large SQLite files.
+HELM_STOP_GRACE_PERIOD=30m
 # Linux bind-mount ownership. Use the output of `id -u` and `id -g` when they
 # differ; scripts/quickstart.sh fills these automatically.
 HELM_UID=1000

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ never overwritten. For a terminal/automation install instead, run
 restarts. It passes `.env` into the container, so optional provider and runtime
 settings work without editing Compose. `HELM_PORT` controls the host port, the
 gateway bind port, and health checks together.
+Compose waits up to 30 minutes for graceful shutdown by default so queued writes
+and SQLite maintenance are not cut off; override `HELM_STOP_GRACE_PERIOD` in `.env`
+for a larger database.
 
 For manual Docker setup, create `./data`, set `HELM_UID` / `HELM_GID` to
 `id -u` / `id -g` on Linux, and run `docker compose up -d --wait`; `.env` and a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,6 +78,8 @@ Codex 和 SDK 的可复制接入配置；整个过程无需手动重启服务。
 `docker-compose.yml` 会挂载 `./config` 和 `./data`，因此重启容器不会丢失
 配置或数据库；它也会把 `.env` 注入容器，无需再为可选 provider 或运行时
 覆盖修改 Compose。`HELM_PORT` 会统一控制宿主机端口、Gateway 监听端口和健康检查。
+Compose 默认给优雅停止预留 30 分钟，避免队列写入或 SQLite 维护被 Docker 强制中断；
+数据库更大时可在 `.env` 中提高 `HELM_STOP_GRACE_PERIOD`。
 
 手动使用 Compose 时，Linux 用户应先创建 `./data`，并把 `HELM_UID`、
 `HELM_GID` 设为 `id -u`、`id -g` 的输出，再执行

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -10,6 +10,10 @@ import { traceIdMiddleware } from "./middleware/trace-id.js";
 import { type HealthDeps, registerHealthRoutes } from "./routes/health.js";
 import { registerLandingRoute } from "./routes/landing.js";
 import { registerOpenApiRoutes } from "./routes/openapi.js";
+import {
+  type MaintenanceActivityGate,
+  maintenanceActivityMiddleware,
+} from "./runtime/maintenance-gate.js";
 
 export interface AppDeps {
   logger: Logger;
@@ -19,6 +23,7 @@ export interface AppDeps {
   health?: HealthDeps;
   // Request timeout. Optional; omitted = no timeout middleware.
   limits?: LimitsConfig;
+  maintenanceGate?: MaintenanceActivityGate;
 }
 
 // Per-request context variables (typed c.get/c.set).
@@ -62,6 +67,9 @@ export function createApp(deps: AppDeps): Hono<AppEnv> {
   app.use("*", normalizeHeaders());
   if (deps.limits) {
     app.use("*", timeout(deps.limits));
+  }
+  if (deps.maintenanceGate) {
+    app.use("*", maintenanceActivityMiddleware(deps.maintenanceGate));
   }
 
   // Health/version routes (unauthenticated, registered before auth).

--- a/apps/gateway/src/codex-responses-websocket.test.ts
+++ b/apps/gateway/src/codex-responses-websocket.test.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import {
   CodexResponsesWebSocketConnectError,
   type CodexResponsesWebSocketConnector,
+  createResponseWorkAdmission,
 } from "@helm/core";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { SocksProxyAgent } from "socks-proxy-agent";
@@ -54,6 +55,7 @@ describe("createCodexResponsesWebSocketConnector", () => {
     server.on("upgrade", (request, socket, head) => {
       expect(request.headers.authorization).toBe("Bearer subscription-token");
       expect(request.headers["openai-beta"]).toBe("responses_websockets=2026-02-06");
+      expect(request.headers["sec-websocket-extensions"]).toBeUndefined();
       websocketServer.handleUpgrade(request, socket, head, (websocket) => {
         websocketServer.emit("connection", websocket, request);
       });
@@ -143,6 +145,111 @@ describe("createCodexResponsesWebSocketConnector", () => {
     await expect(settlePromptly(connection.receive())).rejects.toThrow(Error);
   });
 
+  it("closes an upstream connection when unread messages exceed the dynamic pending budget", async () => {
+    const server = createServer();
+    const websocketServer = new WebSocketServer({ noServer: true });
+    server.on("upgrade", (request, socket, head) => {
+      websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+        websocketServer.emit("connection", websocket, request);
+      });
+    });
+    websocketServer.on("connection", (socket) => {
+      socket.send("0123456789");
+      socket.send("abcdefghij");
+    });
+    const port = await listen(server);
+    const connector = createCodexResponsesWebSocketConnector({
+      timeoutMs: 2_000,
+      maxPayloadBytes: 100,
+      maxPendingBytes: 15,
+    });
+    const connection = await connector({
+      url: `ws://127.0.0.1:${port}/responses`,
+      headers: {},
+    });
+    connections.push(connection);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    let caught: unknown;
+    try {
+      await connection.receive();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({ queueTimeout: true });
+  });
+
+  it("holds one shared response-work lease through receive and rejects another session when full", async () => {
+    const server = createServer();
+    const websocketServer = new WebSocketServer({ noServer: true });
+    server.on("upgrade", (request, socket, head) => {
+      websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+        websocketServer.emit("connection", websocket, request);
+      });
+    });
+    websocketServer.on("connection", (socket) => socket.send("0123456789"));
+    const port = await listen(server);
+    const responseWorkAdmission = createResponseWorkAdmission({
+      capacityBytes: 15,
+      jsonAmplification: 1,
+      minChargeBytes: 1,
+    });
+    const connector = createCodexResponsesWebSocketConnector({
+      timeoutMs: 2_000,
+      maxPayloadBytes: 100,
+      maxPendingBytes: 100,
+      responseWorkAdmission,
+    });
+    const first = await connector({ url: `ws://127.0.0.1:${port}/responses`, headers: {} });
+    connections.push(first);
+    const firstMessage = await settlePromptly(first.receiveWithWork?.() ?? Promise.resolve(null));
+    expect(firstMessage?.text).toBe("0123456789");
+    expect(responseWorkAdmission.reservedBytes).toBe(10);
+
+    const second = await connector({ url: `ws://127.0.0.1:${port}/responses`, headers: {} });
+    connections.push(second);
+    await expect(settlePromptly(second.receive())).rejects.toMatchObject({ queueTimeout: true });
+    expect(responseWorkAdmission.reservedBytes).toBe(10);
+
+    firstMessage?.release();
+    expect(responseWorkAdmission.reservedBytes).toBe(0);
+  });
+
+  it("releases shared response-work held by unread messages when the connection closes", async () => {
+    const server = createServer();
+    const websocketServer = new WebSocketServer({ noServer: true });
+    server.on("upgrade", (request, socket, head) => {
+      websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+        websocketServer.emit("connection", websocket, request);
+      });
+    });
+    websocketServer.on("connection", (socket) => socket.send("0123456789"));
+    const port = await listen(server);
+    const responseWorkAdmission = createResponseWorkAdmission({
+      capacityBytes: 20,
+      jsonAmplification: 1,
+      minChargeBytes: 1,
+    });
+    const connector = createCodexResponsesWebSocketConnector({
+      timeoutMs: 2_000,
+      maxPayloadBytes: 100,
+      responseWorkAdmission,
+    });
+    const connection = await connector({
+      url: `ws://127.0.0.1:${port}/responses`,
+      headers: {},
+    });
+    connections.push(connection);
+    for (let attempt = 0; attempt < 20 && responseWorkAdmission.reservedBytes === 0; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(responseWorkAdmission.reservedBytes).toBe(10);
+
+    await connection.close();
+
+    expect(responseWorkAdmission.reservedBytes).toBe(0);
+  });
+
   it("captures a non-101 response for account-scoped error mapping", async () => {
     const server = createServer((_request, response) => {
       response.writeHead(429, {
@@ -171,6 +278,70 @@ describe("createCodexResponsesWebSocketConnector", () => {
     expect((caught as CodexResponsesWebSocketConnectError).status).toBe(429);
     expect((caught as CodexResponsesWebSocketConnectError).headers.get("retry-after")).toBe("17");
     expect((caught as CodexResponsesWebSocketConnectError).body).toContain("quota exhausted");
+  });
+
+  it("destroys an unexpected response whose body exceeds the dynamic websocket limit", async () => {
+    let responseClosed = false;
+    const server = createServer((_request, response) => {
+      response.on("close", () => {
+        responseClosed = true;
+      });
+      response.writeHead(429, { "content-type": "application/json" });
+      response.write("12345678");
+      setImmediate(() => {
+        response.write("abcdefgh");
+        response.end();
+      });
+    });
+    const port = await listen(server);
+    const connector = createCodexResponsesWebSocketConnector({
+      timeoutMs: 2_000,
+      maxPayloadBytes: 10,
+    });
+
+    let caught: unknown;
+    try {
+      await connector({ url: `ws://127.0.0.1:${port}/responses`, headers: {} });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(CodexResponsesWebSocketConnectError);
+    expect(caught).toMatchObject({ status: 429 });
+    expect((caught as Error).message).toContain("exceeded");
+    expect(responseClosed).toBe(true);
+  });
+
+  it("destroys an unexpected response whose body does not finish within the handshake timeout", async () => {
+    let responseClosed = false;
+    const server = createServer((_request, response) => {
+      response.on("close", () => {
+        responseClosed = true;
+      });
+      response.writeHead(503, { "content-type": "text/plain" });
+      response.write("still waiting");
+      setTimeout(() => response.end(), 100).unref?.();
+    });
+    const port = await listen(server);
+    const connector = createCodexResponsesWebSocketConnector({
+      timeoutMs: 25,
+      maxPayloadBytes: 100,
+    });
+
+    let caught: unknown;
+    try {
+      await settlePromptly(connector({ url: `ws://127.0.0.1:${port}/responses`, headers: {} }));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(CodexResponsesWebSocketConnectError);
+    expect(caught).toMatchObject({ status: 503 });
+    expect((caught as Error).message).toContain("timed out");
+    for (let attempt = 0; attempt < 20 && !responseClosed; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(responseClosed).toBe(true);
   });
 
   it("builds proxy-aware agents for HTTP, HTTPS, and SOCKS5 accounts", () => {

--- a/apps/gateway/src/codex-responses-websocket.ts
+++ b/apps/gateway/src/codex-responses-websocket.ts
@@ -3,16 +3,23 @@ import {
   CodexResponsesWebSocketConnectError,
   type CodexResponsesWebSocketConnection,
   type CodexResponsesWebSocketConnector,
+  type CodexResponsesWebSocketReceivedMessage,
   type ProxyConfig,
   proxyConfigToUrl,
+  type ResponseWorkAdmission,
+  runtimeMemoryBudget,
+  runtimeResponseWorkAdmission,
 } from "@helm/core";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { SocksProxyAgent } from "socks-proxy-agent";
-import WebSocket from "ws";
+import WebSocket, { type RawData } from "ws";
 
 export interface CodexResponsesWebSocketConnectorOptions {
   proxy?: ProxyConfig;
   timeoutMs?: number;
+  maxPayloadBytes?: number;
+  maxPendingBytes?: number;
+  responseWorkAdmission?: ResponseWorkAdmission;
 }
 
 function responseHeaders(response: IncomingMessage): Headers {
@@ -38,9 +45,10 @@ export function codexWebSocketAgent(proxy: ProxyConfig | undefined): HttpAgent |
 
 class WsCodexConnection implements CodexResponsesWebSocketConnection {
   readonly responseHeaders: Headers;
-  private readonly pending: string[] = [];
+  private readonly pending: Array<CodexResponsesWebSocketReceivedMessage & { bytes: number }> = [];
+  private pendingBytes = 0;
   private readonly waiters: Array<{
-    resolve: (value: string | null) => void;
+    resolve: (value: CodexResponsesWebSocketReceivedMessage | null) => void;
     reject: (error: Error) => void;
   }> = [];
   private terminal: Error | null | undefined;
@@ -48,29 +56,74 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
   constructor(
     private readonly socket: WebSocket,
     headers: Headers,
+    private readonly maxPendingBytes: number,
+    private readonly responseWorkAdmission: ResponseWorkAdmission,
   ) {
     this.responseHeaders = headers;
-    socket.on("message", (data) => this.enqueue(data.toString()));
-    socket.on("close", () => this.enqueue(null));
-    socket.on("error", (error) => this.enqueue(error));
+    socket.on("message", (data) => this.enqueueMessage(data));
+    socket.on("close", () => this.terminate(null));
+    socket.on("error", (error) => this.terminate(error));
   }
 
-  private enqueue(value: string | null | Error): void {
+  private terminate(value: Error | null): void {
     if (this.terminal !== undefined) return;
-    if (value === null || value instanceof Error) {
-      this.terminal = value;
-      for (const waiter of this.waiters.splice(0)) {
-        if (value instanceof Error) waiter.reject(value);
-        else waiter.resolve(value);
-      }
+    this.terminal = value;
+    for (const pending of this.pending.splice(0)) pending.release();
+    this.pendingBytes = 0;
+    for (const waiter of this.waiters.splice(0)) {
+      if (value instanceof Error) waiter.reject(value);
+      else waiter.resolve(value);
+    }
+  }
+
+  private capacityError(): Error {
+    return Object.assign(new Error("Codex websocket pending response capacity exceeded"), {
+      name: "QueueTimeoutError",
+      queueTimeout: true as const,
+    });
+  }
+
+  private failCapacity(currentRelease?: () => void): void {
+    currentRelease?.();
+    const error = this.capacityError();
+    this.terminate(error);
+    this.socket.close(1013, "response capacity exceeded");
+  }
+
+  private enqueueMessage(data: RawData): void {
+    if (this.terminal !== undefined) return;
+    const bytes = Array.isArray(data)
+      ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
+      : data.byteLength;
+    const acquired = this.responseWorkAdmission.acquire(bytes);
+    if (!acquired.ok) {
+      this.failCapacity();
       return;
     }
+    let text: string;
+    try {
+      text = Array.isArray(data)
+        ? Buffer.concat(data, bytes).toString("utf8")
+        : data instanceof ArrayBuffer
+          ? Buffer.from(data).toString("utf8")
+          : data.toString("utf8");
+    } catch (error) {
+      acquired.lease.release();
+      this.terminate(error instanceof Error ? error : new Error("invalid websocket message"));
+      return;
+    }
+    const message = { text, bytes, release: () => acquired.lease.release() };
     const waiter = this.waiters.shift();
     if (waiter) {
-      waiter.resolve(value);
+      waiter.resolve(message);
       return;
     }
-    this.pending.push(value);
+    if (this.pendingBytes + bytes > this.maxPendingBytes) {
+      this.failCapacity(message.release);
+      return;
+    }
+    this.pending.push(message);
+    this.pendingBytes += bytes;
   }
 
   async send(text: string): Promise<void> {
@@ -87,11 +140,24 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
   }
 
   async receive(): Promise<string | null> {
+    const message = await this.receiveWithWork();
+    if (message === null) return null;
+    try {
+      return message.text;
+    } finally {
+      message.release();
+    }
+  }
+
+  async receiveWithWork(): Promise<CodexResponsesWebSocketReceivedMessage | null> {
     const next = this.pending.shift();
-    if (next !== undefined) return next;
+    if (next !== undefined) {
+      this.pendingBytes -= next.bytes;
+      return next;
+    }
     if (this.terminal instanceof Error) throw this.terminal;
     if (this.terminal === null) return null;
-    return await new Promise<string | null>((resolve, reject) => {
+    return await new Promise<CodexResponsesWebSocketReceivedMessage | null>((resolve, reject) => {
       this.waiters.push({ resolve, reject });
     });
   }
@@ -114,30 +180,72 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
   }
 }
 
-async function unexpectedResponseBody(response: IncomingMessage): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of response) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+class UnexpectedResponseBodyError extends Error {
+  constructor(
+    readonly reason: "too_large" | "timeout",
+    message: string,
+  ) {
+    super(message);
+    this.name = "UnexpectedResponseBodyError";
   }
-  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function unexpectedResponseBody(
+  response: IncomingMessage,
+  maxBytes: number,
+  timeoutMs: number,
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  const timeoutError = new UnexpectedResponseBodyError(
+    "timeout",
+    `Codex Responses websocket unexpected response body timed out after ${timeoutMs} ms`,
+  );
+  const timer = setTimeout(() => response.destroy(timeoutError), timeoutMs);
+  timer.unref?.();
+  try {
+    for await (const chunk of response) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bytes += buffer.byteLength;
+      if (bytes > maxBytes) {
+        const error = new UnexpectedResponseBodyError(
+          "too_large",
+          `Codex Responses websocket unexpected response body exceeded ${maxBytes} bytes`,
+        );
+        response.destroy(error);
+        throw error;
+      }
+      chunks.push(buffer);
+    }
+    return Buffer.concat(chunks, bytes).toString("utf8");
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function createCodexResponsesWebSocketConnector(
   options: CodexResponsesWebSocketConnectorOptions = {},
 ): CodexResponsesWebSocketConnector {
   const agent = codexWebSocketAgent(options.proxy);
-  const timeoutMs = options.timeoutMs ?? 60_000;
+  const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? 60_000));
+  const maxPayloadBytes = Math.max(
+    1,
+    Math.floor(options.maxPayloadBytes ?? runtimeMemoryBudget().maxWireBytes),
+  );
+  const maxPendingBytes = Math.max(1, Math.floor(options.maxPendingBytes ?? maxPayloadBytes));
+  const responseWorkAdmission = options.responseWorkAdmission ?? runtimeResponseWorkAdmission();
 
   return async ({ url, headers, signal }) =>
     await new Promise<CodexResponsesWebSocketConnection>((resolve, reject) => {
       let settled = false;
+      let readingUnexpectedResponse = false;
       let upgradeHeaders = new Headers();
       const socket = new WebSocket(url, {
         headers,
         agent,
-        perMessageDeflate: true,
+        perMessageDeflate: false,
         handshakeTimeout: timeoutMs,
-        maxPayload: 64 * 1024 * 1024,
+        maxPayload: maxPayloadBytes,
       });
 
       const fail = (error: unknown): void => {
@@ -171,25 +279,40 @@ export function createCodexResponsesWebSocketConnector(
         if (settled) return;
         settled = true;
         cleanup();
-        resolve(new WsCodexConnection(socket, upgradeHeaders));
+        resolve(
+          new WsCodexConnection(socket, upgradeHeaders, maxPendingBytes, responseWorkAdmission),
+        );
       });
       socket.once("unexpected-response", (_request, response) => {
-        void unexpectedResponseBody(response)
+        readingUnexpectedResponse = true;
+        const status = response.statusCode ?? null;
+        const headers = responseHeaders(response);
+        void unexpectedResponseBody(response, maxPayloadBytes, timeoutMs)
           .then((body) => {
             fail(
               new CodexResponsesWebSocketConnectError(
-                `Codex Responses websocket returned HTTP ${response.statusCode ?? 0}`,
+                `Codex Responses websocket returned HTTP ${status ?? 0}`,
                 {
-                  status: response.statusCode ?? null,
-                  headers: responseHeaders(response),
+                  status,
+                  headers,
                   body,
                 },
               ),
             );
           })
-          .catch((error) => fail(error));
+          .catch((error) => {
+            fail(
+              new CodexResponsesWebSocketConnectError(
+                error instanceof UnexpectedResponseBodyError
+                  ? error.message
+                  : "Codex Responses websocket unexpected response body failed",
+                { status, headers, cause: error },
+              ),
+            );
+          });
       });
       socket.once("error", (error) => {
+        if (readingUnexpectedResponse) return;
         fail(
           new CodexResponsesWebSocketConnectError("Codex Responses websocket connection failed", {
             cause: error,

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -88,6 +88,7 @@ async function main(): Promise<void> {
         fetch: (request) => handle.app.fetch(request),
         closeSession: next.closeResponsesWebSocketSession,
         sessionProof: next.responsesWebSocketSessionProof,
+        memoryAdmission: next.responsesMemoryAdmission,
       });
     };
 

--- a/apps/gateway/src/middleware/error-handler.ts
+++ b/apps/gateway/src/middleware/error-handler.ts
@@ -3,6 +3,7 @@ import { type ErrorClass, type HelmError, HelmErrorSchema } from "@helm/shared";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv } from "../app.js";
+import { RequestAdmissionError } from "../runtime/memory-admission.js";
 
 // The OpenAI error wire shape (type/code/status) lives in ONE place —
 // @helm/core's openai-error transformer (OPENAI_ERROR_SHAPE) — so the gateway's
@@ -61,6 +62,26 @@ function asHelmError(err: unknown): HelmError | null {
 export function handleError(err: unknown, c: Context<AppEnv>): Response {
   const traceId = c.get("trace_id") ?? "unknown";
   const logger = c.get("logger");
+
+  if (err instanceof RequestAdmissionError) {
+    if (err.status === 503) c.header("retry-after", "1");
+    logger.log("warn", "request.memory_rejected", {
+      trace_id: traceId,
+      http_status: err.status,
+      code: err.code,
+    });
+    return c.json(
+      {
+        error: {
+          message: err.message,
+          type: err.status === 413 ? "invalid_request_error" : "server_error",
+          code: err.code,
+          trace_id: traceId,
+        },
+      },
+      err.status as ContentfulStatusCode,
+    );
+  }
 
   if (isClientDisconnect(err)) {
     // Client went away — do not map to 5xx, do not record a provider fault.

--- a/apps/gateway/src/oauth/admin-refresh-coordinator.test.ts
+++ b/apps/gateway/src/oauth/admin-refresh-coordinator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createTrackedBackgroundTasks } from "../runtime/maintenance-gate.js";
 import { createOAuthAdminRefreshCoordinator } from "./admin-refresh-coordinator.js";
 
 function deferred(): {
@@ -16,6 +17,47 @@ function deferred(): {
 }
 
 describe("OAuth admin refresh coordinator", () => {
+  it("registers refresh work so maintenance waits after enqueue returns", async () => {
+    const background = createTrackedBackgroundTasks();
+    const gate = deferred();
+    const runInBackground = vi.fn(background.run);
+    const coordinator = createOAuthAdminRefreshCoordinator({
+      refresh: () => gate.promise,
+      runInBackground,
+    });
+
+    expect(coordinator.enqueue().accepted).toBe(true);
+    expect(runInBackground).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(coordinator.status().state).toBe("running"));
+    let paused = false;
+    const waiting = background.pauseAndWait().then(() => {
+      paused = true;
+    });
+    await Promise.resolve();
+    expect(paused).toBe(false);
+
+    gate.resolve();
+    await waiting;
+    expect(paused).toBe(true);
+  });
+
+  it("fails cleanly when the runtime no longer accepts background work", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const coordinator = createOAuthAdminRefreshCoordinator({
+      refresh,
+      runInBackground: () => false,
+    });
+
+    expect(coordinator.enqueue()).toMatchObject({
+      accepted: false,
+      coalesced: false,
+      status: { state: "failed", error: "refresh queue unavailable" },
+    });
+    await coordinator.waitForIdle();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(coordinator.enqueue()).toMatchObject({ accepted: false, coalesced: false });
+  });
+
   it("coalesces concurrent refresh clicks into one running job", async () => {
     const gate = deferred();
     const refresh = vi.fn(() => gate.promise);

--- a/apps/gateway/src/oauth/admin-refresh-coordinator.ts
+++ b/apps/gateway/src/oauth/admin-refresh-coordinator.ts
@@ -26,6 +26,7 @@ export interface OAuthAdminRefreshCoordinator {
 
 export interface OAuthAdminRefreshCoordinatorOptions {
   refresh: () => Promise<void>;
+  runInBackground?: (task: () => Promise<unknown>, onError?: (error: unknown) => void) => boolean;
   cooldownMs?: number;
   now?: () => number;
   generateJobId?: () => string;
@@ -47,6 +48,12 @@ export function createOAuthAdminRefreshCoordinator(
   const now = options.now ?? (() => Date.now());
   const cooldownMs = Math.max(0, options.cooldownMs ?? DEFAULT_COOLDOWN_MS);
   const generateJobId = options.generateJobId ?? (() => crypto.randomUUID());
+  const runInBackground =
+    options.runInBackground ??
+    ((task: () => Promise<unknown>) => {
+      void Promise.resolve().then(task);
+      return true;
+    });
   let active: Promise<void> | null = null;
   let current: OAuthAdminRefreshStatus = {
     state: "idle",
@@ -88,8 +95,13 @@ export function createOAuthAdminRefreshCoordinator(
         nextAllowedAt: null,
         error: null,
       };
-      active = Promise.resolve()
-        .then(async () => {
+      let settle!: () => void;
+      const pending = new Promise<void>((resolve) => {
+        settle = resolve;
+      });
+      active = pending;
+      const accepted = runInBackground(async () => {
+        try {
           current = { ...current, state: "running", startedAt: now() };
           await options.refresh();
           const finishedAt = now();
@@ -101,8 +113,7 @@ export function createOAuthAdminRefreshCoordinator(
             nextAllowedAt: finishedAt + cooldownMs,
             error: null,
           };
-        })
-        .catch((error: unknown) => {
+        } catch (error: unknown) {
           const finishedAt = now();
           current = {
             ...current,
@@ -111,10 +122,22 @@ export function createOAuthAdminRefreshCoordinator(
             nextAllowedAt: finishedAt + cooldownMs,
             error: safeErrorMessage(error),
           };
-        })
-        .finally(() => {
-          active = null;
-        });
+        } finally {
+          if (active === pending) active = null;
+          settle();
+        }
+      });
+      if (!accepted) {
+        active = null;
+        current = {
+          ...current,
+          state: "failed",
+          finishedAt: now(),
+          error: "refresh queue unavailable",
+        };
+        settle();
+        return result(false, false);
+      }
       return result(true, false);
     },
 

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -8,6 +8,7 @@ import {
   isResponsesWebSocketPath,
   type ResponsesWebSocketUpgradeServer,
 } from "./responses-websocket.js";
+import { createBodyMemoryAdmission } from "./runtime/memory-admission.js";
 
 interface CapturedRequest {
   body: Record<string, unknown>;
@@ -77,6 +78,8 @@ async function startBridge(
     }),
   options: {
     closeSession?: (sessionId: string) => void | Promise<void>;
+    memoryAdmission?: ReturnType<typeof createBodyMemoryAdmission>;
+    ingressAdmission?: ReturnType<typeof createBodyMemoryAdmission>;
   } = {},
 ) {
   const server = createServer((_req, res) => {
@@ -93,6 +96,8 @@ async function startBridge(
       return fetch(request);
     },
     closeSession: options.closeSession,
+    memoryAdmission: options.memoryAdmission,
+    ingressAdmission: options.ingressAdmission,
   });
   openBridges.push(bridge);
   server.listen(0, "127.0.0.1");
@@ -117,6 +122,96 @@ async function connect(url: string, headers: Record<string, string> = {}): Promi
 }
 
 describe("Responses websocket bridge", () => {
+  it("reserves shared ingress capacity before websocket upgrade and releases it on close", async () => {
+    const ingressAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 20,
+      maxWireBytes: 10,
+      jsonAmplification: 1,
+      minRequestChargeBytes: 10,
+    });
+    let resolvePreflight!: (response: Response) => void;
+    let preflightCalls = 0;
+    const preflight = new Promise<Response>((resolve) => {
+      resolvePreflight = resolve;
+    });
+    const baseUrl = await startBridge(
+      () => {
+        throw new Error("response fetch should not run");
+      },
+      () => {
+        preflightCalls += 1;
+        return preflight;
+      },
+      { ingressAdmission },
+    );
+    const first = new WebSocket(`${baseUrl}/v1/responses`);
+    openSockets.push(first);
+    for (let attempt = 0; attempt < 20 && preflightCalls === 0; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(preflightCalls).toBe(1);
+
+    const second = new WebSocket(`${baseUrl}/v1/responses`);
+    openSockets.push(second);
+    for (let attempt = 0; attempt < 20 && preflightCalls < 2; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(preflightCalls).toBe(2);
+    const third = new WebSocket(`${baseUrl}/v1/responses`);
+    openSockets.push(third);
+    const [, rejected] = (await once(third, "unexpected-response")) as [
+      IncomingMessage,
+      IncomingMessage,
+    ];
+    rejected.resume();
+    expect(rejected.statusCode).toBe(503);
+    expect(rejected.headers["retry-after"]).toBe("1");
+    expect(preflightCalls).toBe(2);
+
+    resolvePreflight(
+      new Response(JSON.stringify({ data: [] }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await once(first, "open");
+    await once(second, "open");
+    expect(ingressAdmission.reservedBytes).toBe(20);
+    first.terminate();
+    await once(first, "close");
+    for (let attempt = 0; attempt < 20 && ingressAdmission.reservedBytes !== 10; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(ingressAdmission.reservedBytes).toBe(10);
+    second.terminate();
+    await once(second, "close");
+    for (let attempt = 0; attempt < 20 && ingressAdmission.reservedBytes !== 0; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(ingressAdmission.reservedBytes).toBe(0);
+  });
+
+  it("uses the shared machine-derived limit before parsing a websocket message", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    const baseUrl = await startBridge(
+      () => {
+        throw new Error("fetch should not run");
+      },
+      undefined,
+      { memoryAdmission },
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    const closed = once(socket, "close");
+    socket.send(JSON.stringify({ type: "response.create", input: "too large" }));
+    const [code] = await closed;
+
+    expect(code).toBe(1009);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
   it.each([
     "/v1/responses",
     "/responses",
@@ -250,6 +345,36 @@ describe("Responses websocket bridge", () => {
     expect(captured[0]?.headers.get("accept")).toBe("text/event-stream");
   });
 
+  it("closes a connection that pipelines a second active response without injecting an error", async () => {
+    let started!: () => void;
+    const requestStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const baseUrl = await startBridge((request) => {
+      started();
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            request.signal.addEventListener("abort", () => controller.close(), { once: true });
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    });
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    const messages: string[] = [];
+    socket.on("message", (data) => messages.push(data.toString()));
+    socket.send(JSON.stringify({ type: "response.create", input: [], stream: true }));
+    await requestStarted;
+
+    const closed = once(socket, "close");
+    socket.send(JSON.stringify({ type: "response.create", input: [], stream: true }));
+    const [code] = await closed;
+
+    expect(code).toBe(1008);
+    expect(messages).toEqual([]);
+  });
+
   it("returns the models ETag without inventing reasoning capability on the 101 handshake", async () => {
     const baseUrl = await startBridge(
       () => {
@@ -277,7 +402,7 @@ describe("Responses websocket bridge", () => {
     expect(response.statusCode).toBe(101);
     expect(response.headers["x-models-etag"]).toBe('"models-1"');
     expect(response.headers["x-reasoning-included"]).toBeUndefined();
-    expect(response.headers["sec-websocket-extensions"]).toContain("permessage-deflate");
+    expect(response.headers["sec-websocket-extensions"]).toBeUndefined();
   });
 
   it("prefers the standard version header for the models preflight cache key", async () => {
@@ -375,6 +500,44 @@ describe("Responses websocket bridge", () => {
 
     expect(response.statusCode).toBe(400);
     expect(modelsCalled).toBe(false);
+  });
+
+  it("forwards a protocol-shaped maintenance response from models preflight", async () => {
+    const body = {
+      error: {
+        message: "database maintenance in progress",
+        type: "api_error",
+        code: "database_maintenance",
+        trace_id: "trace-maintenance",
+      },
+    };
+    const baseUrl = await startBridge(
+      () => {
+        throw new Error("response fetch should not run");
+      },
+      () =>
+        new Response(JSON.stringify(body), {
+          status: 503,
+          headers: { "content-type": "application/json", "retry-after": "1" },
+        }),
+    );
+    const socket = new WebSocket(`${baseUrl}/v1/responses`, {
+      headers: { authorization: "Bearer helm-test-key" },
+    });
+    socket.on("error", () => {});
+    openSockets.push(socket);
+
+    const [, response] = (await once(socket, "unexpected-response")) as [
+      IncomingMessage,
+      IncomingMessage,
+    ];
+    let payload = "";
+    response.setEncoding("utf8");
+    for await (const chunk of response) payload += chunk;
+
+    expect(response.statusCode).toBe(503);
+    expect(response.headers["retry-after"]).toBe("1");
+    expect(JSON.parse(payload)).toEqual(body);
   });
 
   it("omits a false x-reasoning-included value because Codex treats presence as true", async () => {
@@ -571,7 +734,7 @@ describe("Responses websocket bridge", () => {
     ]);
   });
 
-  it("stops at the terminal event and cancels the internal HTTP stream", async () => {
+  it("drains the internal HTTP stream after the terminal event without forwarding trailing data", async () => {
     let cancelled = false;
     let trailingTimer: ReturnType<typeof setTimeout> | null = null;
     const encoder = new TextEncoder();
@@ -619,59 +782,13 @@ describe("Responses websocket bridge", () => {
     await once(socket, "message");
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    expect(cancelled).toBe(true);
+    expect(cancelled).toBe(false);
     expect(events).toEqual([
       {
         type: "response.completed",
         response: { id: "resp-terminal", status: "completed" },
       },
     ]);
-  });
-
-  it("does not wait for internal stream cancellation before handling the next turn", async () => {
-    let requestCount = 0;
-    let cancelled = false;
-    const encoder = new TextEncoder();
-    const completedFrame =
-      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-completed","status":"completed"}}\n\n';
-    const baseUrl = await startBridge(() => {
-      requestCount += 1;
-      return new Response(
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(encoder.encode(completedFrame));
-            if (requestCount > 1) controller.close();
-          },
-          cancel() {
-            cancelled = true;
-            return new Promise<void>(() => {});
-          },
-        }),
-        { headers: { "content-type": "text/event-stream" } },
-      );
-    });
-    const socket = await connect(`${baseUrl}/v1/responses`);
-
-    await collectTurn(socket, {
-      type: "response.create",
-      model: "gpt-5.6-sol",
-      input: [],
-      stream: true,
-    });
-    socket.send(
-      JSON.stringify({
-        type: "response.create",
-        model: "gpt-5.6-sol",
-        input: [],
-        stream: true,
-      }),
-    );
-    for (let attempt = 0; attempt < 20 && requestCount < 2; attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    expect(cancelled).toBe(true);
-    expect(requestCount).toBe(2);
   });
 
   it.each([

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { type IncomingMessage, STATUS_CODES } from "node:http";
 import type { Duplex } from "node:stream";
-import { CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER, readSSE } from "@helm/core";
+import { CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER, readSSE, runtimeMemoryBudget } from "@helm/core";
 import WebSocket, { WebSocketServer } from "ws";
 import { normalizeOpenAICodexClientVersion } from "./oauth/codex-client-version.js";
 import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "./responses-websocket-internal.js";
+import {
+  type BodyMemoryAdmission,
+  createBodyMemoryAdmission,
+  RequestAdmissionError,
+} from "./runtime/memory-admission.js";
 
 const RESPONSES_WEBSOCKET_PATHS = new Set(["/v1/responses", "/responses", "/openai/v1/responses"]);
 
@@ -43,6 +48,9 @@ export interface ResponsesWebSocketBridgeOptions {
   fetch: AppFetch;
   closeSession?: (sessionId: string) => void | Promise<void>;
   sessionProof?: string;
+  memoryAdmission?: BodyMemoryAdmission;
+  /** Optional test/embedding override for bytes retained by `ws` before `message`. */
+  ingressAdmission?: BodyMemoryAdmission;
 }
 
 export interface ResponsesWebSocketUpgradeServer {
@@ -221,6 +229,19 @@ async function responseErrorEnvelope(response: Response): Promise<Record<string,
 }
 
 function localErrorEnvelope(error: unknown): Record<string, unknown> {
+  if (error instanceof RequestAdmissionError) {
+    return {
+      type: "error",
+      status: error.status,
+      status_code: error.status,
+      error: {
+        type: error.status === 413 ? "invalid_request_error" : "server_error",
+        code: error.code,
+        message: error.message,
+      },
+      headers: error.status === 503 ? { "retry-after": "1" } : {},
+    };
+  }
   if (error instanceof WebSocketRequestError) {
     return {
       type: "error",
@@ -320,6 +341,7 @@ async function forwardResponse(
 
   let terminalType: unknown;
   for await (const frame of readSSE(body)) {
+    if (terminalType !== undefined) continue;
     const payload = websocketPayload(frame.event, frame.data);
     if (payload === null) continue;
     await sendText(socket, payload);
@@ -336,11 +358,9 @@ async function forwardResponse(
       type === "error"
     ) {
       terminalType = type;
-      break;
     }
   }
   if (terminalType !== undefined) {
-    void body.cancel().catch(() => {});
     return terminalType !== "response.completed";
   }
   if (!signal.aborted) {
@@ -387,11 +407,13 @@ async function rejectUpgrade(socket: Duplex, response: Response): Promise<void> 
   const payload =
     body.length > 0 ? body : JSON.stringify({ error: { message: "upgrade rejected" } });
   const statusText = STATUS_CODES[response.status] ?? "Error";
+  const retryAfter = response.headers.get("retry-after");
   socket.end(
     [
       `HTTP/1.1 ${response.status} ${statusText}`,
       "Connection: close",
       "Content-Type: application/json",
+      ...(retryAfter === null ? [] : [`Retry-After: ${retryAfter}`]),
       `Content-Length: ${Buffer.byteLength(payload)}`,
       "",
       payload,
@@ -404,12 +426,39 @@ export function installResponsesWebSocketBridge({
   fetch,
   closeSession,
   sessionProof,
+  memoryAdmission,
+  ingressAdmission,
 }: ResponsesWebSocketBridgeOptions): ResponsesWebSocketBridge {
+  const memoryBudget = runtimeMemoryBudget();
+  const admission =
+    memoryAdmission ??
+    createBodyMemoryAdmission({
+      activeRequestBytes: memoryBudget.activeRequestBytes,
+      maxWireBytes: memoryBudget.maxWireBytes,
+      jsonAmplification: memoryBudget.jsonAmplification,
+    });
+  const ingress =
+    ingressAdmission ??
+    createBodyMemoryAdmission({
+      activeRequestBytes: memoryBudget.websocketIngressBytes,
+      maxWireBytes: Math.min(admission.maxWireBytes, memoryBudget.websocketMaxPayloadBytes),
+      jsonAmplification: 1,
+      // Reserve one whole permitted frame before `ws` can inflate/materialize it.
+      // A one-byte charge makes true zero-headroom budgets reject every upgrade.
+      minRequestChargeBytes: Math.max(
+        1,
+        Math.min(admission.maxWireBytes, memoryBudget.websocketMaxPayloadBytes),
+      ),
+    });
+  const websocketMaxPayloadBytes = Math.max(
+    1,
+    Math.min(admission.maxWireBytes, ingress.maxWireBytes),
+  );
   const metadataByRequest = new WeakMap<IncomingMessage, UpgradeMetadata>();
   const websocketServer = new WebSocketServer({
     noServer: true,
-    perMessageDeflate: true,
-    maxPayload: 64 * 1024 * 1024,
+    perMessageDeflate: false,
+    maxPayload: websocketMaxPayloadBytes,
   });
   let closed = false;
 
@@ -423,7 +472,7 @@ export function installResponsesWebSocketBridge({
     const controller = new AbortController();
     const sessionId = randomUUID();
     let sessionClosed = false;
-    let pending = Promise.resolve();
+    let processing = false;
     const closeUpstreamSession = async () => {
       await Promise.resolve(closeSession?.(sessionId)).catch(() => {});
     };
@@ -436,8 +485,37 @@ export function installResponsesWebSocketBridge({
     socket.on("close", abort);
     socket.on("error", abort);
     socket.on("message", (data) => {
-      pending = pending
-        .then(async () => {
+      if (processing) {
+        socket.close(1008, "one active response per connection");
+        return;
+      }
+      const bytes = Array.isArray(data)
+        ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
+        : data.byteLength;
+      const acquired = admission.acquire(bytes);
+      if (!acquired.ok) {
+        const error =
+          acquired.reason === "too_large"
+            ? new RequestAdmissionError(
+                413,
+                "request_too_large",
+                `websocket message exceeds the runtime capacity limit of ${admission.maxWireBytes} bytes`,
+              )
+            : new RequestAdmissionError(
+                503,
+                "server_overloaded",
+                "request memory capacity is temporarily exhausted",
+              );
+        void sendEnvelope(socket, localErrorEnvelope(error))
+          .catch(() => {})
+          .finally(() => {
+            if (error.status === 413) socket.close(1009, "message too big");
+          });
+        return;
+      }
+      processing = true;
+      void (async () => {
+        try {
           const invalidatesSession = await forwardResponse(
             socket,
             request,
@@ -448,12 +526,15 @@ export function installResponsesWebSocketBridge({
             sessionProof,
           );
           if (invalidatesSession) await closeUpstreamSession();
-        })
-        .catch(async (error: unknown) => {
+        } catch (error) {
           if (controller.signal.aborted || socket.readyState !== WebSocket.OPEN) return;
-          await sendEnvelope(socket, localErrorEnvelope(error));
+          await sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
           await closeUpstreamSession();
-        });
+        } finally {
+          processing = false;
+          acquired.lease.release();
+        }
+      })();
     });
   });
 
@@ -462,10 +543,35 @@ export function installResponsesWebSocketBridge({
       socket.destroy();
       return;
     }
+    const ingressLease = ingress.acquire(0);
+    if (!ingressLease.ok) {
+      const error = new RequestAdmissionError(
+        503,
+        "server_overloaded",
+        "websocket ingress memory capacity is temporarily exhausted",
+      );
+      const onRejectedSocketError = () => socket.destroy();
+      socket.once("error", onRejectedSocketError);
+      void rejectUpgrade(
+        socket,
+        new Response(JSON.stringify(localErrorEnvelope(error)), {
+          status: error.status,
+          headers: { "content-type": "application/json", "retry-after": "1" },
+        }),
+      )
+        .catch(() => socket.destroy())
+        .finally(() => socket.off("error", onRejectedSocketError));
+      return;
+    }
+    let handedOff = false;
+    const releaseIngress = ingressLease.lease.release;
     const onPreflightSocketError = () => {
+      releaseIngress();
       socket.destroy();
     };
+    const onPreflightSocketClose = () => releaseIngress();
     socket.on("error", onPreflightSocketError);
+    socket.once("close", onPreflightSocketClose);
     void preflightUpgrade(request, fetch)
       .then(async ({ response, metadata }) => {
         if (closed || socket.destroyed) {
@@ -478,6 +584,9 @@ export function installResponsesWebSocketBridge({
         }
         metadataByRequest.set(request, metadata);
         websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+          handedOff = true;
+          websocket.once("close", releaseIngress);
+          websocket.once("error", releaseIngress);
           websocketServer.emit("connection", websocket, request);
         });
       })
@@ -498,6 +607,8 @@ export function installResponsesWebSocketBridge({
       })
       .finally(() => {
         socket.off("error", onPreflightSocketError);
+        socket.off("close", onPreflightSocketClose);
+        if (!handedOff) releaseIngress();
       });
   };
   server.on("upgrade", onUpgrade);

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1,4 +1,11 @@
-import type { CreateKeyInput, KeyStore, Lane, PoliciesConfig, TelemetryStore } from "@helm/core";
+import type {
+  CreateKeyInput,
+  KeyStore,
+  Lane,
+  PoliciesConfig,
+  SessionRevisionRecord,
+  TelemetryStore,
+} from "@helm/core";
 import { DEFAULT_LANES, parseLanesConfig } from "@helm/core";
 import type { ApiKeyRecord, ClassifierConfig, DecisionRecord, RuntimeSettings } from "@helm/shared";
 import { ClassifierConfigSchema, RuntimeSettingsSchema } from "@helm/shared";
@@ -69,6 +76,10 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
     resolve = r;
   });
   return { promise, resolve };
+}
+
+function singleSessionRevisionPage(revisions: SessionRevisionRecord[]) {
+  return async () => ({ revisions, nextSequence: null, limited: false });
 }
 
 type TestKeyRecord = ApiKeyRecord & { secret_enc: string | null };
@@ -1683,19 +1694,25 @@ describe("admin.api request payload", () => {
     const telemetry = {
       ...makeTelemetry([rec]),
       getPayload: async () => null,
-      listSessionRevisions: async () => [
-        {
-          sessionRef: "session-ref",
-          requestId: "req_session",
-          parentRequestId: null,
-          retainCount: 0,
-          requestDeltaJson: '[{"role":"user","content":"hello"}]',
-          requestEnvelopeJson: '{"model":"auto","messages":[]}',
-          responseJson,
-          fidelity: "semantic",
-          createdAt: new Date(1234),
-        },
-      ],
+      listSessionRevisionsPage: async () => ({
+        revisions: [
+          {
+            sessionRef: "session-ref",
+            requestId: "req_session",
+            sequence: 1,
+            parentRequestId: null,
+            retainCount: 0,
+            requestDeltaJson: '[{"role":"user","content":"hello"}]',
+            requestEnvelopeJson: '{"model":"auto","messages":[]}',
+            responseId: null,
+            responseJson,
+            fidelity: "semantic",
+            createdAt: new Date(1234),
+          },
+        ],
+        nextSequence: null,
+        limited: false,
+      }),
     } as unknown as TelemetryStore;
     const app = buildApp(buildDeps({ telemetry }));
     const res = await app.request("/admin/api/requests/req_session/payload");
@@ -1738,6 +1755,155 @@ describe("admin.api request payload", () => {
     });
   });
 
+  it("recovers Session revisions through bounded keyset pages without listing the whole Session", async () => {
+    const rec = {
+      ...decision("req_child", "balanced"),
+      session: { ref: "session-ref", label: "thread-1", source: "x-thread-id" as const },
+    };
+    const pages: Array<{ afterSequence?: number; limit: number; maxBytes: number }> = [];
+    const root = {
+      sessionRef: "session-ref",
+      requestId: "req_root",
+      sequence: 1,
+      parentRequestId: null,
+      retainCount: 0,
+      requestDeltaJson: '[{"role":"user","content":"root"}]',
+      requestEnvelopeJson: '{"model":"auto","messages":[]}',
+      responseId: null,
+      responseJson: null,
+      fidelity: "semantic",
+      createdAt: new Date(1000),
+    };
+    const child = {
+      ...root,
+      requestId: "req_child",
+      sequence: 2,
+      parentRequestId: "req_root",
+      retainCount: 1,
+      requestDeltaJson: '[{"role":"user","content":"child"}]',
+      responseJson: '{"choices":[]}',
+      createdAt: new Date(2000),
+    };
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayload: async () => null,
+      listSessionRevisions: async () => {
+        throw new Error("unbounded Session read must not be used");
+      },
+      listSessionRevisionsPage: async (
+        _sessionRef: string,
+        options: { afterSequence?: number; limit: number; maxBytes: number },
+      ) => {
+        pages.push(options);
+        return options.afterSequence === undefined
+          ? { revisions: [root], nextSequence: 1, limited: false }
+          : { revisions: [child], nextSequence: null, limited: false };
+      },
+    } as unknown as TelemetryStore;
+    const response = await buildApp(buildDeps({ telemetry })).request(
+      "/admin/api/requests/req_child/payload",
+    );
+
+    expect(await response.json()).toMatchObject({
+      captured: true,
+      source: "session",
+      exact: false,
+      request: {
+        model: "auto",
+        messages: [
+          { role: "user", content: "root" },
+          { role: "user", content: "child" },
+        ],
+      },
+    });
+    expect(pages).toHaveLength(2);
+    expect(pages[0]?.limit).toBeGreaterThan(0);
+    expect(pages[0]?.maxBytes).toBeGreaterThan(0);
+    expect(pages[1]?.afterSequence).toBe(1);
+    expect(pages[1]?.maxBytes).toBeLessThan(pages[0]?.maxBytes ?? 0);
+  });
+
+  it("returns an honest limited result when Session recovery exceeds the runtime byte budget", async () => {
+    const rec = {
+      ...decision("req_session", "balanced"),
+      session: { ref: "session-ref", source: "x-thread-id" as const },
+    };
+    let maxBytes = 0;
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayload: async () => null,
+      listSessionRevisionsPage: async (
+        _sessionRef: string,
+        options: { afterSequence?: number; limit: number; maxBytes: number },
+      ) => {
+        maxBytes = options.maxBytes;
+        return { revisions: [], nextSequence: null, limited: true };
+      },
+    } as unknown as TelemetryStore;
+    const response = await buildApp(buildDeps({ telemetry })).request(
+      "/admin/api/requests/req_session/payload",
+    );
+
+    expect(maxBytes).toBeGreaterThan(0);
+    expect(await response.json()).toEqual({
+      captured: false,
+      source: "unavailable",
+      reason: "session_recovery_limited",
+    });
+  });
+
+  it("reserves the shared recovery budget before materializing a Session page", async () => {
+    const rec = {
+      ...decision("req_session", "balanced"),
+      session: { ref: "session-ref", source: "x-thread-id" as const },
+    };
+    const pageEntered = deferred();
+    const releasePage = deferred();
+    let pageReads = 0;
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayload: async () => null,
+      listSessionRevisionsPage: async () => {
+        pageReads++;
+        pageEntered.resolve();
+        await releasePage.promise;
+        return {
+          revisions: [
+            {
+              sessionRef: "session-ref",
+              requestId: "req_session",
+              sequence: 1,
+              parentRequestId: null,
+              retainCount: 0,
+              requestDeltaJson: '[{"role":"user","content":"hello"}]',
+              requestEnvelopeJson: '{"model":"auto","messages":[]}',
+              responseId: null,
+              responseJson: null,
+              fidelity: "semantic",
+              createdAt: new Date(1234),
+            },
+          ],
+          nextSequence: null,
+          limited: false,
+        };
+      },
+    } as unknown as TelemetryStore;
+    const app = buildApp(buildDeps({ telemetry }));
+    const first = app.request("/admin/api/requests/req_session/payload");
+    await pageEntered.promise;
+
+    const competing = await app.request("/admin/api/requests/req_session/payload");
+    expect(await competing.json()).toEqual({
+      captured: false,
+      source: "unavailable",
+      reason: "session_recovery_limited",
+    });
+    expect(pageReads).toBe(1);
+
+    releasePage.resolve();
+    expect(await (await first).json()).toMatchObject({ captured: true, source: "session" });
+  });
+
   it("distinguishes a cleaned session from a corrupt session chain", async () => {
     const rec = {
       ...decision("req_session", "balanced"),
@@ -1746,7 +1912,7 @@ describe("admin.api request payload", () => {
     const unavailable = {
       ...makeTelemetry([rec]),
       getPayload: async () => null,
-      listSessionRevisions: async () => [],
+      listSessionRevisionsPage: singleSessionRevisionPage([]),
     } as unknown as TelemetryStore;
     const unavailableApp = buildApp(buildDeps({ telemetry: unavailable }));
     expect(
@@ -1760,7 +1926,7 @@ describe("admin.api request payload", () => {
     const incomplete = {
       ...makeTelemetry([rec]),
       getPayload: async () => null,
-      listSessionRevisions: async () => [
+      listSessionRevisionsPage: singleSessionRevisionPage([
         {
           sessionRef: "session-ref",
           requestId: "req_session",
@@ -1769,11 +1935,12 @@ describe("admin.api request payload", () => {
           retainCount: 0,
           requestDeltaJson: "[]",
           requestEnvelopeJson: '{"messages":[]}',
+          responseId: null,
           responseJson: null,
           fidelity: "semantic",
           createdAt: new Date(1234),
         },
-      ],
+      ]),
     } as unknown as TelemetryStore;
     const incompleteApp = buildApp(buildDeps({ telemetry: incomplete }));
     expect(
@@ -1787,7 +1954,7 @@ describe("admin.api request payload", () => {
     const unknownContinuation = {
       ...makeTelemetry([rec]),
       getPayload: async () => null,
-      listSessionRevisions: async () => [
+      listSessionRevisionsPage: singleSessionRevisionPage([
         {
           sessionRef: "session-ref",
           requestId: "req_session",
@@ -1801,7 +1968,7 @@ describe("admin.api request payload", () => {
           fidelity: "partial",
           createdAt: new Date(1234),
         },
-      ],
+      ]),
     } as unknown as TelemetryStore;
     const unknownContinuationApp = buildApp(buildDeps({ telemetry: unknownContinuation }));
     expect(

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -438,6 +438,7 @@ export interface AdminApiDeps {
   rules: RuleStore;
   keyStore: KeyStore;
   telemetry: TelemetryStore;
+  runInBackground?: (task: () => Promise<unknown>, onError?: (error: unknown) => void) => boolean;
   // Automatic data cleanup / retention / archival (admin "Data cleanup"). Optional —
   // absent in unit tests; the cleanup routes 503 when not wired.
   cleanup?: CleanupAccess;

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -75,7 +75,9 @@ function toSummary(rec: {
 }
 
 export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
-  const usageCache = createAdminReadCache<KeyUsageSummary[]>();
+  const usageCache = createAdminReadCache<KeyUsageSummary[]>({
+    ...(deps.runInBackground !== undefined ? { runInBackground: deps.runInBackground } : {}),
+  });
   // GET /keys -> KeySummary[] (no plaintext, no hash full-text).
   app.get("/admin/api/keys", async (c) => {
     const rows = await deps.keyStore.list();

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -2,6 +2,7 @@ import type { OAuthQuotaWindow } from "@helm/shared";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../../app.js";
+import { createTrackedBackgroundTasks } from "../../runtime/maintenance-gate.js";
 import type { AdminApiDeps, OAuthAdminAccess } from "./deps.js";
 import { registerOAuthRoutes } from "./oauth.js";
 
@@ -1120,6 +1121,46 @@ describe("admin OAuth routes — read endpoints", () => {
       priority: 50,
       schedulable: true,
     });
+  });
+});
+
+describe("admin OAuth routes — tracked refresh lifecycle", () => {
+  it("returns 202 while maintenance still waits for the refresh database work", async () => {
+    const background = createTrackedBackgroundTasks();
+    let releaseStatus!: () => void;
+    const statusGate = new Promise<void>((resolve) => {
+      releaseStatus = resolve;
+    });
+    const seam = fullSeam({
+      listStatus: vi.fn(async () => {
+        await statusGate;
+        return { selectionStrategy: "balanced", providers: [] };
+      }) as never,
+    });
+    const oauthQuota = {
+      get: vi.fn(async () => null),
+      getAll: vi.fn(async () => []),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const api = app({
+      oauth: seam,
+      oauthQuota,
+      runInBackground: background.run,
+    });
+
+    expect((await api.request("/admin/api/oauth/refresh", { method: "POST" })).status).toBe(202);
+    await vi.waitFor(() => expect(seam.listStatus).toHaveBeenCalledOnce());
+    let paused = false;
+    const waiting = background.pauseAndWait().then(() => {
+      paused = true;
+    });
+    await Promise.resolve();
+    expect(paused).toBe(false);
+
+    releaseStatus();
+    await waiting;
+    expect(paused).toBe(true);
   });
 });
 

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -497,6 +497,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     refresh: async () => {
       await refreshQuota();
     },
+    ...(deps.runInBackground !== undefined ? { runInBackground: deps.runInBackground } : {}),
   });
 
   app.get("/admin/api/oauth/usage", async (c) => {

--- a/apps/gateway/src/routes/admin/read-cache.test.ts
+++ b/apps/gateway/src/routes/admin/read-cache.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createTrackedBackgroundTasks } from "../../runtime/maintenance-gate.js";
 import { adminWindowCacheKey, createAdminReadCache } from "./read-cache.js";
 
 describe("createAdminReadCache", () => {
@@ -51,6 +52,68 @@ describe("createAdminReadCache", () => {
     await vi.waitFor(async () =>
       expect(await cache.get("stats", load)).toEqual({ value: "new", status: "fresh" }),
     );
+  });
+
+  it("registers a stale refresh so maintenance waits for its database read", async () => {
+    let now = 1_000;
+    const scheduled: Array<() => void> = [];
+    const background = createTrackedBackgroundTasks();
+    const runInBackground = vi.fn(background.run);
+    let finishRefresh!: (value: string) => void;
+    const load = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("old")
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            finishRefresh = resolve;
+          }),
+      );
+    const cache = createAdminReadCache<string>({
+      freshTtlMs: 10_000,
+      staleTtlMs: 300_000,
+      now: () => now,
+      schedule: (run) => scheduled.push(run),
+      runInBackground,
+    });
+
+    await cache.get("stats", load);
+    now += 10_001;
+    await expect(cache.get("stats", load)).resolves.toMatchObject({ status: "stale" });
+    scheduled[0]?.();
+    expect(runInBackground).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    let paused = false;
+    const waiting = background.pauseAndWait().then(() => {
+      paused = true;
+    });
+    await Promise.resolve();
+    expect(paused).toBe(false);
+
+    finishRefresh("new");
+    await waiting;
+    expect(paused).toBe(true);
+  });
+
+  it("keeps stale data and retries later when maintenance rejects a refresh", async () => {
+    let now = 1_000;
+    const scheduled: Array<() => void> = [];
+    const load = vi.fn().mockResolvedValue("old");
+    const cache = createAdminReadCache<string>({
+      freshTtlMs: 10_000,
+      staleTtlMs: 300_000,
+      now: () => now,
+      schedule: (run) => scheduled.push(run),
+      runInBackground: () => false,
+    });
+
+    await cache.get("stats", load);
+    now += 10_001;
+    await expect(cache.get("stats", load)).resolves.toEqual({ value: "old", status: "stale" });
+    scheduled.shift()?.();
+    expect(load).toHaveBeenCalledOnce();
+    await expect(cache.get("stats", load)).resolves.toEqual({ value: "old", status: "stale" });
+    expect(scheduled).toHaveLength(1);
   });
 
   it("does not retain a failed cold load", async () => {

--- a/apps/gateway/src/routes/admin/read-cache.ts
+++ b/apps/gateway/src/routes/admin/read-cache.ts
@@ -11,6 +11,7 @@ export interface AdminReadCacheOptions {
   maxEntries?: number;
   now?: () => number;
   schedule?: (run: () => void) => void;
+  runInBackground?: (task: () => Promise<unknown>, onError?: (error: unknown) => void) => boolean;
 }
 
 interface CacheEntry<T> {
@@ -39,6 +40,7 @@ export function createAdminReadCache<T>(options: AdminReadCacheOptions = {}) {
   const maxEntries = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
   const now = options.now ?? Date.now;
   const schedule = options.schedule ?? defer;
+  const runInBackground = options.runInBackground;
   const entries = new Map<string, CacheEntry<T>>();
   const inFlight = new Map<string, Promise<T>>();
   const scheduled = new Set<string>();
@@ -80,7 +82,10 @@ export function createAdminReadCache<T>(options: AdminReadCacheOptions = {}) {
     scheduled.add(key);
     schedule(() => {
       scheduled.delete(key);
-      void loadOnce(key, load).promise.catch(() => {
+      const refresh = () => loadOnce(key, load).promise;
+      if (runInBackground?.(refresh, () => {}) === true) return;
+      if (runInBackground !== undefined) return;
+      void refresh().catch(() => {
         // Keep the last-known-good stale snapshot. The next read may retry; an
         // auxiliary Admin refresh failure must not become an unhandled rejection.
       });

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -3,8 +3,13 @@ import type {
   RequestPayloadMeta,
   RequestPayloadPart,
   RequestPayloadPartRecord,
+  SessionRevisionRecord,
 } from "@helm/core";
-import { restoreSessionRevisionJson } from "@helm/core";
+import {
+  restoreSessionRevisionJson,
+  runtimeMemoryBudget,
+  runtimeResponseWorkAdmission,
+} from "@helm/core";
 import { RequestsQuerySchema } from "@helm/shared";
 import type { Hono } from "hono";
 import type { AppEnv } from "../../app.js";
@@ -138,18 +143,22 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
         const recovered = await getSessionRequest(deps, traceId);
         if (recovered.status === "unavailable")
           return c.json({ captured: false, source: "unavailable", reason: recovered.reason });
-        return c.json({
-          captured: true,
-          source: "session",
-          exact: false,
-          fidelity: recovered.fidelity,
-          created_at: recovered.createdAt.getTime(),
-          parts: {
-            request: true,
-            response: recovered.responseJson !== null,
-            upstream_request: false,
-          },
-        });
+        try {
+          return c.json({
+            captured: true,
+            source: "session",
+            exact: false,
+            fidelity: recovered.fidelity,
+            created_at: recovered.createdAt.getTime(),
+            parts: {
+              request: true,
+              response: recovered.responseJson !== null,
+              upstream_request: false,
+            },
+          });
+        } finally {
+          recovered.release();
+        }
       }
       return c.json({
         captured: true,
@@ -173,18 +182,26 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
           return c.json({ captured: false, source: "unavailable", reason: "no_session" });
         if (recovered.status === "unavailable")
           return c.json({ captured: false, source: "unavailable", reason: recovered.reason });
-        const json = part === "request" ? recovered.requestJson : recovered.responseJson;
-        if (json === null)
-          return c.json({ captured: false, source: "unavailable", reason: "response_unavailable" });
-        return c.json({
-          captured: true,
-          source: "session",
-          exact: false,
-          fidelity: recovered.fidelity,
-          part,
-          value: parseMaybeJson(json),
-          created_at: recovered.createdAt.getTime(),
-        });
+        try {
+          const json = part === "request" ? recovered.requestJson : recovered.responseJson;
+          if (json === null)
+            return c.json({
+              captured: false,
+              source: "unavailable",
+              reason: "response_unavailable",
+            });
+          return c.json({
+            captured: true,
+            source: "session",
+            exact: false,
+            fidelity: recovered.fidelity,
+            part,
+            value: parseMaybeJson(json),
+            created_at: recovered.createdAt.getTime(),
+          });
+        } finally {
+          recovered.release();
+        }
       }
       return c.json({
         captured: true,
@@ -202,16 +219,20 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
       const recovered = await getSessionRequest(deps, traceId);
       if (recovered.status === "unavailable")
         return c.json({ captured: false, source: "unavailable", reason: recovered.reason });
-      return c.json({
-        captured: true,
-        source: "session",
-        exact: false,
-        fidelity: recovered.fidelity,
-        request: parseMaybeJson(recovered.requestJson),
-        response: recovered.responseJson === null ? null : parseMaybeJson(recovered.responseJson),
-        upstream_request: null,
-        created_at: recovered.createdAt.getTime(),
-      });
+      try {
+        return c.json({
+          captured: true,
+          source: "session",
+          exact: false,
+          fidelity: recovered.fidelity,
+          request: parseMaybeJson(recovered.requestJson),
+          response: recovered.responseJson === null ? null : parseMaybeJson(recovered.responseJson),
+          upstream_request: null,
+          created_at: recovered.createdAt.getTime(),
+        });
+      } finally {
+        recovered.release();
+      }
     }
     return c.json({
       captured: true,
@@ -239,31 +260,89 @@ async function getSessionRequest(
       responseJson: string | null;
       fidelity: string;
       createdAt: Date;
+      release: () => void;
     }
   | {
       status: "unavailable";
-      reason: "no_session" | "session_unavailable" | "session_incomplete";
+      reason:
+        | "no_session"
+        | "session_unavailable"
+        | "session_incomplete"
+        | "session_recovery_limited";
     }
 > {
-  const list = deps.telemetry.listSessionRevisions;
+  const listPage = deps.telemetry.listSessionRevisionsPage;
   const decision = await deps.telemetry.getByRequestId(requestId);
   const sessionRef = decision?.session?.ref;
   if (!sessionRef) return { status: "unavailable", reason: "no_session" };
-  if (!list) return { status: "unavailable", reason: "session_unavailable" };
+  if (!listPage) return { status: "unavailable", reason: "session_unavailable" };
+  const budget = runtimeMemoryBudget();
+  // Reserve one whole safe recovery window before the adapter materializes even
+  // the first page. Reserving after listPage() would let concurrent readers each
+  // allocate a large page before either one became visible to the shared budget.
+  const acquired = runtimeResponseWorkAdmission().acquire(budget.maxWireBytes);
+  if (!acquired.ok) return { status: "unavailable", reason: "session_recovery_limited" };
+  const revisions: SessionRevisionRecord[] = [];
+  let afterSequence: number | undefined;
+  let wireBytes = 0;
+  let releaseTransferred = false;
   try {
-    const revisions = await list.call(deps.telemetry, sessionRef);
-    const target = revisions.find((revision) => revision.requestId === requestId);
-    if (!target) return { status: "unavailable", reason: "session_unavailable" };
-    return {
-      status: "recovered",
-      requestJson: restoreSessionRevisionJson(revisions, requestId),
-      responseJson: decision.final.status === "ok" ? target.responseJson : null,
-      fidelity: target.fidelity,
-      createdAt: target.createdAt,
-    };
+    for (;;) {
+      const remainingBytes = budget.maxWireBytes - wireBytes;
+      if (remainingBytes <= 0) return { status: "unavailable", reason: "session_recovery_limited" };
+      const page = await listPage.call(deps.telemetry, sessionRef, {
+        afterSequence,
+        limit: 100,
+        maxBytes: remainingBytes,
+      });
+      if (page.limited) return { status: "unavailable", reason: "session_recovery_limited" };
+      if (page.revisions.length === 0)
+        return { status: "unavailable", reason: "session_unavailable" };
+      for (const revision of page.revisions) wireBytes += sessionRevisionWireBytes(revision);
+      if (wireBytes > budget.maxWireBytes)
+        return { status: "unavailable", reason: "session_recovery_limited" };
+      revisions.push(...page.revisions);
+      const target = page.revisions.find((revision) => revision.requestId === requestId);
+      if (target) {
+        const recovered = {
+          status: "recovered" as const,
+          requestJson: restoreSessionRevisionJson(revisions, requestId),
+          responseJson: decision.final.status === "ok" ? target.responseJson : null,
+          fidelity: target.fidelity,
+          createdAt: target.createdAt,
+          release: acquired.lease.release,
+        };
+        releaseTransferred = true;
+        return recovered;
+      }
+      if (page.nextSequence === null)
+        return { status: "unavailable", reason: "session_unavailable" };
+      if (afterSequence !== undefined && page.nextSequence <= afterSequence)
+        return { status: "unavailable", reason: "session_incomplete" };
+      afterSequence = page.nextSequence;
+    }
   } catch {
     return { status: "unavailable", reason: "session_incomplete" };
+  } finally {
+    if (!releaseTransferred) acquired.lease.release();
   }
+}
+
+function sessionRevisionWireBytes(revision: SessionRevisionRecord): number {
+  const values = [
+    revision.sessionRef,
+    revision.requestId,
+    revision.parentRequestId,
+    revision.requestDeltaJson,
+    revision.requestEnvelopeJson,
+    revision.responseId,
+    revision.responseJson,
+    revision.fidelity,
+  ];
+  return values.reduce(
+    (bytes, value) => bytes + (value === null ? 0 : Buffer.byteLength(value, "utf8")),
+    64,
+  );
 }
 
 type PayloadPartQuery = "full" | "meta" | RequestPayloadPart | "invalid";

--- a/apps/gateway/src/routes/admin/stats.ts
+++ b/apps/gateway/src/routes/admin/stats.ts
@@ -14,7 +14,9 @@ import { adminWindowCacheKey, createAdminReadCache } from "./read-cache.js";
 const DAY_MS = 86_400_000;
 
 export function registerStatsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void {
-  const cache = createAdminReadCache<Awaited<ReturnType<typeof deps.telemetry.aggregate>>>();
+  const cache = createAdminReadCache<Awaited<ReturnType<typeof deps.telemetry.aggregate>>>({
+    ...(deps.runInBackground !== undefined ? { runInBackground: deps.runInBackground } : {}),
+  });
   // GET /stats?start&end&bucket&tzOffsetMinutes -> TelemetryAggregate. The window
   // defaults to the last 24h when start/end are omitted (a live dashboard cares
   // about recent traffic); bucket defaults to "day". `tzOffsetMinutes` (the admin

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -12,6 +12,7 @@ import { type InternalRequest, makeHelmError } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import { authMiddleware } from "../middleware/auth.js";
+import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import { createWriteQueue } from "../runtime/write-queue.js";
 import { type ChatRouteDeps, registerChatRoutes } from "./chat.js";
 
@@ -164,6 +165,51 @@ const BUDGET_RECORD: Partial<ApiKeyRecord> = {
 };
 
 describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overrides", () => {
+  it.each([
+    "/v1/chat/completions",
+    "/chat/completions",
+    "/engines/azure-deployment/chat/completions",
+    "/openai/deployments/azure-deployment/chat/completions",
+  ])("rejects an oversized body before JSON.parse on %s", async (path) => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1024,
+      maxWireBytes: 1,
+      jsonAmplification: 1,
+    });
+    const { deps: d, harness } = deps({ memoryAdmission });
+    const app = buildApp(d);
+
+    const res = await app.request(path, {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+
+    expect(res.status).toBe(413);
+    expect(harness.execute).not.toHaveBeenCalled();
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("returns 503 with Retry-After when the shared body budget is occupied", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1,
+      maxWireBytes: 1024,
+      jsonAmplification: 1,
+    });
+    const { deps: d, harness } = deps({ memoryAdmission });
+    const app = buildApp(d);
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("1");
+    expect(harness.execute).not.toHaveBeenCalled();
+  });
+
   it("rejects an over-budget request with 429 before routing (behavior=reject)", async () => {
     const budgetGate = {
       check: vi.fn(async () => ({

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -35,6 +35,12 @@ import type { AppEnv } from "../app.js";
 import { INTERNAL_API_KEY_ID } from "../internal-key.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
+import {
+  type BodyMemoryAdmission,
+  memoryAdmissionReleaseGuard,
+  RequestAdmissionError,
+  readAdmittedRequestBody,
+} from "../runtime/memory-admission.js";
 import { type ServingAccount, stampServingAccount } from "../runtime/serving-account.js";
 import type { WriteQueue } from "../runtime/write-queue.js";
 import { downgradeClientFastModeIfDisallowed } from "./fast-mode.js";
@@ -54,6 +60,7 @@ import {
   tokensFromUsage,
   usageFromBody,
   usageFromSSE,
+  withSseCaptureRelease,
 } from "./payload-capture.js";
 import { resolveSessionCapture, stampSessionCapture } from "./session-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
@@ -68,6 +75,8 @@ import { isUpstreamTimeout } from "./stream-error.js";
 // use()s auth, so `identity` is present.
 
 export interface ChatRouteDeps {
+  /** Machine-derived request-body budget shared by every AI ingress surface. */
+  memoryAdmission?: BodyMemoryAdmission;
   /** Bound core orchestrator: routeRequest(req, coreDeps) with deps closed over.
    *  `signal` is the per-request client-disconnect signal — the gateway binds
    *  the per-request `execute` (provider invoke) to it. */
@@ -425,6 +434,14 @@ function flushOpenAIChunk(buffer: SSEAccumulator): void {
 }
 
 export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void {
+  const chatPaths = [
+    "/v1/chat/completions",
+    "/chat/completions",
+    "/engines/:model{.+}/chat/completions",
+    "/openai/deployments/:model{.+}/chat/completions",
+  ];
+  for (const path of chatPaths) app.use(path, memoryAdmissionReleaseGuard());
+
   const handleChat = async (c: Context<AppEnv>, pathModel?: string) => {
     const traceId = c.get("trace_id");
     const requestId = c.get("request_id");
@@ -438,9 +455,28 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     let requestJson = "";
     let raw: unknown;
     try {
-      requestJson = await c.req.text();
+      const admitted =
+        deps.memoryAdmission === undefined
+          ? null
+          : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+      requestJson = admitted?.text ?? (await c.req.text());
+      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
       raw = JSON.parse(requestJson);
-    } catch {
+    } catch (error) {
+      if (error instanceof RequestAdmissionError) {
+        if (error.status === 503) c.header("retry-after", "1");
+        return c.json(
+          {
+            error: {
+              message: error.message,
+              type: error.status === 413 ? "invalid_request_error" : "api_error",
+              code: error.code,
+              param: null,
+            },
+          },
+          error.status,
+        );
+      }
       throw invalidRequest("malformed JSON request body", traceId);
     }
     if (pathModel !== undefined && raw !== null && typeof raw === "object") {
@@ -595,13 +631,17 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     // drained until the OUTBOUND turn is persisted (else the assistant turn is dropped
     // from this run). Outbound observes use the default → the worker wakes once the
     // whole turn has landed.
+    // The raw JSON is already retained by the parsed request/observe closure. Pass its
+    // exact wire size to the queue; the queue applies the runtime-derived JSON/V8
+    // amplification instead of a fixed per-task memory limit.
+    const observeRetainedBytes = Buffer.byteLength(requestJson, "utf8");
     const runObserve = async (task: () => Promise<unknown>, wake = true) => {
       if (deps.writes !== undefined) {
         deps.writes.enqueueTask(
           async () => {
             await task();
           },
-          { wakeOnSettle: wake },
+          { wakeOnSettle: wake, retainedBytes: observeRetainedBytes },
         );
         return;
       }
@@ -850,6 +890,8 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       // middleware and release it in the stream's OWN finally — the slot stays
       // held until the bytes are fully drained (or the client disconnects).
       const releaseConcurrency = c.get("concurrencyClaim")?.();
+      const releaseRequestMemory = c.get("requestMemoryRelease");
+      c.set("requestMemoryRelease", undefined);
       // SSE keep-alive: emit a `:` comment during inter-chunk idle so a proxy/client
       // idle-timeout does not sever a long but healthy stream. The comment is wire-only
       // (never captured, accumulated, or priced) and is gated on an event boundary so it
@@ -903,62 +945,71 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
           // Free the concurrency slot FIRST — the bytes are done; the
           // persist/settle bookkeeping below must not extend the hold.
           releaseConcurrency?.();
-          // Streamed completion-cost backfill (#6): parse the trailing usage and
-          // price it at the served alias. Fail-open — leave cost null on any miss.
-          const rawSse = captured.value();
-          const finalAlias =
-            result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
           try {
-            const usage = usageFromSSE(rawSse);
-            if (usage) {
-              // Cost backfill needs the served alias + pricing closure; the TOKEN
-              // stamp does not. Stamp usage whenever the tail has it (dashboard
-              // accounting) and price the cost only when costOf is wired.
-              const cost = finalAlias && deps.costOf ? deps.costOf(finalAlias, usage) : null;
-              backfillCompletionCost(
-                result.decision,
-                finalAlias,
-                cost,
-                usage,
-                genTimer.generationMs(),
-              );
-            }
-          } catch {
-            c.get("logger").log("warn", "cost.stream_backfill_failed", { trace_id: traceId });
-          }
-          await capturePayload(captureOn ? rawSse : null, result.upstreamRequest ?? null);
-          stampServingAccount(result.decision, servingAccount);
-          await persist(result.decision);
-          // Usage-budget settle (streamed): runs HERE — after the usage tail
-          // backfilled the streamed cost — so the spend dimension settles the real
-          // total. Tokens come from the same usage tail. Fail-open. NEVER deferred
-          // (quota correctness): the next request's pre-route gate must see this spend.
-          await settle(result.decision, tokensFromUsage(usageFromSSE(rawSse)));
-          // Memory observe (outbound, streamed): persist the reconstructed
-          // assistant turn AFTER the bytes were forwarded. Fail-open inside core.
-          // Called UNCONDITIONALLY (even with no reconstructed text — e.g. a
-          // tool-call-only turn) so the served-model stamp still lands; the empty
-          // responseMessages just persist nothing while the stamp records the
-          // model auto-compaction prices itself from.
-          if (deps.memory !== undefined) {
-            // Flush the last partial event the \n\n-split loop held back, so a
-            // final frame without a trailing \n\n is not dropped.
-            flushOpenAIChunk(assistant);
-            const memoryObserve = deps.memory.observe;
-            const responseMessages: IRMessage[] =
-              assistant.text.length > 0 ? [{ role: "assistant", content: assistant.text }] : [];
-            await runObserve(() =>
-              observeOutbound(
-                memoryObserve,
-                memoryScope,
-                {
-                  responseMessages,
-                  toolResults: [],
-                  messageIndexOffset: originalMessagesForMemory.length,
-                },
-                finalAlias,
-              ),
-            );
+            await withSseCaptureRelease(captured, async () => {
+              // Streamed completion-cost backfill (#6): parse the trailing usage and
+              // price it at the served alias. Fail-open — leave cost null on any miss.
+              const rawSse = captured.value();
+              if (captured.limited()) {
+                c.get("logger").log("warn", "payload.capture_limited", { trace_id: traceId });
+              }
+              const finalAlias =
+                result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
+              try {
+                const usage = usageFromSSE(rawSse);
+                if (usage) {
+                  // Cost backfill needs the served alias + pricing closure; the TOKEN
+                  // stamp does not. Stamp usage whenever the tail has it (dashboard
+                  // accounting) and price the cost only when costOf is wired.
+                  const cost = finalAlias && deps.costOf ? deps.costOf(finalAlias, usage) : null;
+                  backfillCompletionCost(
+                    result.decision,
+                    finalAlias,
+                    cost,
+                    usage,
+                    genTimer.generationMs(),
+                  );
+                }
+              } catch {
+                c.get("logger").log("warn", "cost.stream_backfill_failed", { trace_id: traceId });
+              }
+              await capturePayload(captured.payloadValue(), result.upstreamRequest ?? null);
+              stampServingAccount(result.decision, servingAccount);
+              await persist(result.decision);
+              // Usage-budget settle (streamed): runs HERE — after the usage tail
+              // backfilled the streamed cost — so the spend dimension settles the real
+              // total. Tokens come from the same usage tail. Fail-open. NEVER deferred
+              // (quota correctness): the next request's pre-route gate must see this spend.
+              await settle(result.decision, tokensFromUsage(usageFromSSE(rawSse)));
+              // Memory observe (outbound, streamed): persist the reconstructed
+              // assistant turn AFTER the bytes were forwarded. Fail-open inside core.
+              // Called UNCONDITIONALLY (even with no reconstructed text — e.g. a
+              // tool-call-only turn) so the served-model stamp still lands; the empty
+              // responseMessages just persist nothing while the stamp records the
+              // model auto-compaction prices itself from.
+              if (deps.memory !== undefined) {
+                // Flush the last partial event the \n\n-split loop held back, so a
+                // final frame without a trailing \n\n is not dropped.
+                flushOpenAIChunk(assistant);
+                const memoryObserve = deps.memory.observe;
+                const responseMessages: IRMessage[] =
+                  assistant.text.length > 0 ? [{ role: "assistant", content: assistant.text }] : [];
+                await runObserve(() =>
+                  observeOutbound(
+                    memoryObserve,
+                    memoryScope,
+                    {
+                      responseMessages,
+                      toolResults: [],
+                      messageIndexOffset: originalMessagesForMemory.length,
+                    },
+                    finalAlias,
+                  ),
+                );
+              }
+            });
+          } finally {
+            releaseRequestMemory?.();
           }
         }
       });

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -1,6 +1,7 @@
 import type { TelemetryStore, UpsertSessionRevisionInput } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
+import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import { type GeminiRouteDeps, registerGeminiRoute } from "./gemini.js";
 import type { MessagesIdentity } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
@@ -48,6 +49,7 @@ function makeDeps(
     concurrencyGate?: GeminiRouteDeps["concurrencyGate"];
     countTokens?: GeminiRouteDeps["countTokens"];
     record?: RecordServedDeps;
+    memoryAdmission?: GeminiRouteDeps["memoryAdmission"];
   } = {},
 ): { deps: GeminiRouteDeps; harness: Harness } {
   const harness: Harness = { order: [], pipelineSawIR: null, pipelineSawAbort: false };
@@ -57,6 +59,7 @@ function makeDeps(
     concurrencyGate: over.concurrencyGate,
     countTokens: over.countTokens,
     record: over.record,
+    memoryAdmission: over.memoryAdmission,
     auth: {
       resolve: async (cred) => {
         harness.order.push(`auth:${cred ?? "null"}`);
@@ -171,6 +174,50 @@ function expectGeminiCarrier(value: unknown, body: unknown, rawBody?: string): v
 }
 
 describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
+  it.each([
+    "generateContent",
+    "streamGenerateContent",
+    "countTokens",
+  ])("rejects oversized %s bodies before JSON.parse", async (operation) => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1024,
+      maxWireBytes: 1,
+      jsonAmplification: 1,
+    });
+    const { deps, harness } = makeDeps({ memoryAdmission });
+    const app = buildApp(deps);
+
+    const res = await app.request(`/v1beta/models/gemini-2.0-flash:${operation}`, {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(413);
+    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("returns 503 with Retry-After when the shared body budget is occupied", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1,
+      maxWireBytes: 1024,
+      jsonAmplification: 1,
+    });
+    const { deps, harness } = makeDeps({ memoryAdmission });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("1");
+    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+  });
+
   it("non-stream: auth → translate-out → route → translate-back, returns Gemini JSON", async () => {
     const { deps, harness } = makeDeps();
     const app = buildApp(deps);

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -10,6 +10,12 @@ import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
+import {
+  type BodyMemoryAdmission,
+  memoryAdmissionReleaseGuard,
+  RequestAdmissionError,
+  readAdmittedRequestBody,
+} from "../runtime/memory-admission.js";
 import { stampServingAccount } from "../runtime/serving-account.js";
 import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { resolveMemoryScope } from "./memory-scope.js";
@@ -18,9 +24,11 @@ import { PipelineError } from "./messages-pipeline.js";
 import { nativeCarrierFromParsedBody } from "./native-carrier.js";
 import {
   captureEnabled,
+  createSseCapture,
   type RecordServedDeps,
   recordServed,
   sessionCaptureEnabled,
+  withSseCaptureRelease,
 } from "./payload-capture.js";
 import { resolveSessionCapture, stampSessionCapture } from "./session-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
@@ -67,6 +75,8 @@ interface GeminiIRLike {
 }
 
 export interface GeminiRouteDeps {
+  /** Machine-derived request-body budget shared by every AI ingress surface. */
+  memoryAdmission?: BodyMemoryAdmission;
   rateLimiter?: GeminiRateLimiterPort;
   /** Per-key concurrency overflow queue (issue #93) — the SAME process-wide gate
    *  as the chat middleware. Optional — omitted = no gating. */
@@ -148,11 +158,26 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     const out = transformer.transformErrorOut(err);
     return c.json(out.body as Record<string, unknown>, out.status as 400 | 401 | 404 | 429 | 502);
   };
+  const sendAdmissionError = (c: Context<AppEnv>, error: RequestAdmissionError): Response => {
+    if (error.status === 503) c.header("retry-after", "1");
+    const out = transformer.transformErrorOut({
+      error_class: error.status === 413 ? "invalid_request" : "lane_unavailable",
+      message: error.message,
+      trace_id: c.get("trace_id"),
+    });
+    const body = out.body as { error?: Record<string, unknown> };
+    return c.json(
+      body.error === undefined ? body : { ...body, error: { ...body.error, code: error.status } },
+      error.status as 413 | 503,
+    );
+  };
 
   // Frees an unclaimed concurrency lease on every exit path (the handler below
   // acquires AFTER its self-auth).
   app.use("/v1beta/models/*", concurrencyReleaseGuard());
   app.use("/models/*", concurrencyReleaseGuard());
+  app.use("/v1beta/models/*", memoryAdmissionReleaseGuard());
+  app.use("/models/*", memoryAdmissionReleaseGuard());
 
   // Hono cannot match the literal ':' in `{model}:generateContent` with a named
   // param, so we mount catch-alls under both Gemini path families and hand the
@@ -255,9 +280,15 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       let requestJson = "";
       let native: unknown;
       try {
-        requestJson = await c.req.text();
+        const admitted =
+          deps.memoryAdmission === undefined
+            ? null
+            : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+        requestJson = admitted?.text ?? (await c.req.text());
+        if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
         native = JSON.parse(requestJson);
-      } catch {
+      } catch (error) {
+        if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
         return sendError(c, {
           error_class: "invalid_request",
           message: "malformed JSON request body",
@@ -294,9 +325,15 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     let requestJson = "";
     let native: unknown;
     try {
-      requestJson = await c.req.text();
+      const admitted =
+        deps.memoryAdmission === undefined
+          ? null
+          : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+      requestJson = admitted?.text ?? (await c.req.text());
+      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
       native = JSON.parse(requestJson);
-    } catch {
+    } catch (error) {
+      if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
       return sendError(c, {
         error_class: "invalid_request",
         message: "malformed JSON request body",
@@ -379,11 +416,13 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       // body fully drains — release in the stream's own finally, not the guard.
       const releaseConcurrency = c.get("concurrencyRelease");
       c.set("concurrencyRelease", undefined);
+      const releaseRequestMemory = c.get("requestMemoryRelease");
+      c.set("requestMemoryRelease", undefined);
       return streamSSE(c, async (sse) => {
         // Accumulate the serialized wire frames so the served response body can be
         // captured (verbatim) alongside the telemetry row in the finally below.
         // Gemini frames are nameless `data:` frames (no `event:` name, no [DONE]).
-        const captured: string[] = [];
+        const captured = captureBodies ? createSseCapture(true) : null;
         // SSE keep-alive: emit a `:` comment during inter-chunk idle (wire-only, never
         // captured) so a proxy/client idle-timeout does not sever a long healthy stream.
         // Gemini frames are whole `data:` frames (writeSSE) → always at a boundary.
@@ -403,18 +442,18 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
             if (result.nativePassthrough === true) {
               const frame = snapshot as { data?: unknown; raw?: unknown };
               if (typeof frame.raw === "string") {
-                if (captureBodies) captured.push(frame.raw);
+                captured?.push(frame.raw);
                 await sse.write(frame.raw);
                 lastWrite = frame.raw; // verbatim bytes may end mid-frame
               } else {
                 const data = typeof frame.data === "string" ? frame.data : JSON.stringify(snapshot);
-                if (captureBodies) captured.push(`data: ${data}\n\n`);
+                captured?.push(`data: ${data}\n\n`);
                 await sse.writeSSE({ data });
                 lastWrite = "\n\n";
               }
             } else {
               const data = JSON.stringify(snapshot);
-              if (captureBodies) captured.push(`data: ${data}\n\n`);
+              captured?.push(`data: ${data}\n\n`);
               await sse.writeSSE({ data });
               lastWrite = "\n\n"; // writeSSE emits a complete frame — always a boundary
             }
@@ -435,31 +474,40 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
                   };
             const out = transformer.transformErrorOut(re);
             const data = JSON.stringify(out.body);
-            if (captureBodies) captured.push(`data: ${data}\n\n`);
+            captured?.push(`data: ${data}\n\n`);
             await sse.writeSSE({ data });
           }
         } finally {
           releaseConcurrency?.();
-          // Record AFTER releaseConcurrency (never extend the hold) and AFTER the
-          // for-await loop ended so the pipeline's own streamIR finally (cost
-          // backfill) already mutated result.decision. result.decision exists even
-          // on a pre-stream failure, so a failed stream still records. Fail-open.
-          if (deps.record) {
-            stampServingAccount(result.decision, result.servingAccount ?? null);
-            await recordServed(
-              deps.record,
-              {
-                requestId,
-                accountId: identity.accountId,
-                apiKeyId: identity.keyId,
-                decision: result.decision,
-                requestJson,
-                responseJson: captureBodies ? captured.join("") : null,
-                timedOut: requestTimedOut(c),
-                upstreamRequestJson: result.upstreamRequest ?? null,
-              },
-              (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
-            );
+          try {
+            await withSseCaptureRelease(captured, async () => {
+              // Record AFTER releaseConcurrency (never extend the hold) and AFTER the
+              // for-await loop ended so the pipeline's own streamIR finally (cost
+              // backfill) already mutated result.decision. result.decision exists even
+              // on a pre-stream failure, so a failed stream still records. Fail-open.
+              if (deps.record) {
+                stampServingAccount(result.decision, result.servingAccount ?? null);
+                if (captured?.limited()) {
+                  c.get("logger").log("warn", "payload.capture_limited", { trace_id: traceId });
+                }
+                await recordServed(
+                  deps.record,
+                  {
+                    requestId,
+                    accountId: identity.accountId,
+                    apiKeyId: identity.keyId,
+                    decision: result.decision,
+                    requestJson,
+                    responseJson: captured?.payloadValue() ?? null,
+                    timedOut: requestTimedOut(c),
+                    upstreamRequestJson: result.upstreamRequest ?? null,
+                  },
+                  (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+                );
+              }
+            });
+          } finally {
+            releaseRequestMemory?.();
           }
         }
       });

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -3,6 +3,7 @@ import { UpstreamError } from "@helm/core";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../app.js";
+import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import { type ImagesRouteDeps, registerImagesRoute } from "./images.js";
 import type { MessagesIdentity } from "./messages.js";
 import type { RecordServedDeps } from "./payload-capture.js";
@@ -136,6 +137,73 @@ describe("registerImagesRoute", () => {
     const { app } = setup();
     const res = await post(app, { model: "gpt-image-2", prompt: "x" }, "Bearer wrong");
     expect(res.status).toBe(401);
+  });
+
+  it("rejects an over-capacity body before JSON parsing and releases its lease", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    const { app, imageGeneration } = setup({ memoryAdmission });
+
+    const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
+
+    expect(res.status).toBe(413);
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { type: "invalid_request_error", code: "request_too_large" },
+    });
+    expect(imageGeneration).not.toHaveBeenCalled();
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("returns an OpenAI 503 with Retry-After when runtime request capacity is busy", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1,
+      maxWireBytes: 1000,
+      jsonAmplification: 1,
+    });
+    const { app, imageGeneration } = setup({ memoryAdmission });
+
+    const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("1");
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { type: "server_error", code: "server_overloaded" },
+    });
+    expect(imageGeneration).not.toHaveBeenCalled();
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("releases its memory lease after a successful image request", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1000,
+      maxWireBytes: 1000,
+      jsonAmplification: 1,
+    });
+    const { app } = setup({ memoryAdmission });
+
+    expect((await post(app, { model: "gpt-image-2", prompt: "a cat" })).status).toBe(200);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("releases its memory lease when image JSON is malformed", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1000,
+      maxWireBytes: 1000,
+      jsonAmplification: 1,
+    });
+    const { app } = setup({ memoryAdmission });
+
+    const res = await app.request("/v1/images/generations", {
+      method: "POST",
+      headers: { Authorization: "Bearer k", "Content-Type": "application/json" },
+      body: "{",
+    });
+
+    expect(res.status).toBe(400);
+    expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("rejects a direct image model that is blocked for the key", async () => {

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -12,6 +12,12 @@ import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
+import {
+  type BodyMemoryAdmission,
+  memoryAdmissionReleaseGuard,
+  RequestAdmissionError,
+  readAdmittedRequestBody,
+} from "../runtime/memory-admission.js";
 import type { GeminiRateLimiterPort } from "./gemini.js";
 import {
   type ImageAttempt,
@@ -35,6 +41,8 @@ import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-c
 export interface ImagesRouteDeps {
   rateLimiter?: GeminiRateLimiterPort;
   concurrencyGate?: ConcurrencyGatePort;
+  /** Machine-derived request-body budget shared by every AI ingress surface. */
+  memoryAdmission?: BodyMemoryAdmission;
   auth: { resolve(credential: string | null): Promise<MessagesIdentity | null> };
   /** Resolve the client id (bare model OR image lane) → the ordered provider chain.
    *  Both upstream KINDS ride through: `openai` → OpenAI Images API
@@ -100,6 +108,7 @@ function mapGeminiToImages(native: Record<string, unknown>): Record<string, unkn
 
 export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): void {
   app.use("/v1/images/generations", concurrencyReleaseGuard());
+  app.use("/v1/images/generations", memoryAdmissionReleaseGuard());
 
   app.post("/v1/images/generations", async (c) => {
     // Production always receives both ids from createApp. The UUID fallback keeps
@@ -170,9 +179,24 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
     let requestJson = "";
     let raw: unknown;
     try {
-      requestJson = await c.req.text();
+      const admitted =
+        deps.memoryAdmission === undefined
+          ? null
+          : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+      requestJson = admitted?.text ?? (await c.req.text());
+      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
       raw = JSON.parse(requestJson);
-    } catch {
+    } catch (error) {
+      if (error instanceof RequestAdmissionError) {
+        if (error.status === 503) c.header("retry-after", "1");
+        return errorJson(
+          c,
+          error.status,
+          error.status === 413 ? "invalid_request_error" : "server_error",
+          error.message,
+          error.code,
+        );
+      }
       return errorJson(c, 400, "invalid_request_error", "malformed JSON request body");
     }
     const parsed = ImageGenerationRequestSchema.safeParse(raw);

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -3,6 +3,7 @@ import { UpstreamError } from "@helm/core";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../app.js";
+import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import { type InteractionsRouteDeps, registerInteractionsRoute } from "./interactions.js";
 import type { MessagesIdentity } from "./messages.js";
 import type { RecordServedDeps } from "./payload-capture.js";
@@ -183,6 +184,75 @@ describe("registerInteractionsRoute", () => {
     expect(res.status).toBe(200);
     expect(json.id).toBe("int_server-request-123");
     expect(json.id).not.toBe("int_client-controlled-trace");
+  });
+
+  it("rejects an over-capacity body before JSON parsing and releases its lease", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    const { app, nativePassthrough } = setup({ memoryAdmission });
+
+    const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
+
+    expect(res.status).toBe(413);
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { status: "INVALID_ARGUMENT" },
+    });
+    expect(nativePassthrough).not.toHaveBeenCalled();
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("returns a Gemini 503 with Retry-After when runtime request capacity is busy", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1,
+      maxWireBytes: 1000,
+      jsonAmplification: 1,
+    });
+    const { app, nativePassthrough } = setup({ memoryAdmission });
+
+    const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("1");
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { status: "UNAVAILABLE" },
+    });
+    expect(nativePassthrough).not.toHaveBeenCalled();
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("releases its memory lease after a successful interactions request", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1000,
+      maxWireBytes: 1000,
+      jsonAmplification: 1,
+    });
+    const { app } = setup({ memoryAdmission });
+
+    expect(
+      (await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" })).status,
+    ).toBe(200);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("releases its memory lease when interactions JSON is malformed", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1000,
+      maxWireBytes: 1000,
+      jsonAmplification: 1,
+    });
+    const { app } = setup({ memoryAdmission });
+
+    const res = await app.request("/v1beta/interactions", {
+      method: "POST",
+      headers: { "x-goog-api-key": "k", "Content-Type": "application/json" },
+      body: "{",
+    });
+
+    expect(res.status).toBe(400);
+    expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("translates an array input with text + image blocks into generateContent parts", async () => {

--- a/apps/gateway/src/routes/interactions.ts
+++ b/apps/gateway/src/routes/interactions.ts
@@ -12,6 +12,12 @@ import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
+import {
+  type BodyMemoryAdmission,
+  memoryAdmissionReleaseGuard,
+  RequestAdmissionError,
+  readAdmittedRequestBody,
+} from "../runtime/memory-admission.js";
 import type { GeminiRateLimiterPort } from "./gemini.js";
 import {
   type ImageAttempt,
@@ -40,6 +46,8 @@ import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-c
 export interface InteractionsRouteDeps {
   rateLimiter?: GeminiRateLimiterPort;
   concurrencyGate?: ConcurrencyGatePort;
+  /** Machine-derived request-body budget shared by every AI ingress surface. */
+  memoryAdmission?: BodyMemoryAdmission;
   auth: { resolve(credential: string | null): Promise<MessagesIdentity | null> };
   /** SAME resolver the /v1/images/generations route uses. Returns the ordered image
    *  chain (both kinds); this route filters to gemini-kind and 400s an openai-only id. */
@@ -176,6 +184,7 @@ function usageBodyFromNative(native: Record<string, unknown>): { usage: Record<s
 
 export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsRouteDeps): void {
   app.use("/v1beta/interactions", concurrencyReleaseGuard());
+  app.use("/v1beta/interactions", memoryAdmissionReleaseGuard());
 
   app.post("/v1beta/interactions", async (c) => {
     // Production always receives both ids from createApp. The UUID fallback keeps
@@ -241,9 +250,23 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
     let requestJson = "";
     let raw: unknown;
     try {
-      requestJson = await c.req.text();
+      const admitted =
+        deps.memoryAdmission === undefined
+          ? null
+          : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+      requestJson = admitted?.text ?? (await c.req.text());
+      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
       raw = JSON.parse(requestJson);
-    } catch {
+    } catch (error) {
+      if (error instanceof RequestAdmissionError) {
+        if (error.status === 503) c.header("retry-after", "1");
+        return errorJson(
+          c,
+          error.status,
+          error.message,
+          error.status === 413 ? "INVALID_ARGUMENT" : "UNAVAILABLE",
+        );
+      }
       return errorJson(c, 400, "malformed JSON request body", "INVALID_ARGUMENT");
     }
     const parsed = InteractionsRequestSchema.safeParse(raw);

--- a/apps/gateway/src/routes/mcp/deps.ts
+++ b/apps/gateway/src/routes/mcp/deps.ts
@@ -8,6 +8,7 @@ export interface McpDeps {
   memoryStore: MemoryStore;
   now: () => Date;
   estimateTokens: (text: string) => number;
+  runInBackground: (task: () => Promise<unknown>, onError?: (error: unknown) => void) => boolean;
   // Server version reported in the MCP `initialize` handshake (serverInfo.version).
   serverVersion?: string;
   log?: (line: string) => void;

--- a/apps/gateway/src/routes/mcp/index.ts
+++ b/apps/gateway/src/routes/mcp/index.ts
@@ -108,6 +108,7 @@ export function registerMcpServer(app: Hono<AppEnv>, deps: McpDeps): void {
       estimateTokens: deps.estimateTokens,
       scoreConfig: deps.scoreConfig,
       recall: deps.recall,
+      runInBackground: deps.runInBackground,
       ...(deps.embedder !== undefined ? { embedder: deps.embedder } : {}),
     };
 

--- a/apps/gateway/src/routes/mcp/mcp.test.ts
+++ b/apps/gateway/src/routes/mcp/mcp.test.ts
@@ -3,6 +3,8 @@ import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../../app.js";
 import { authMiddleware } from "../../middleware/auth.js";
+import { createTrackedBackgroundTasks } from "../../runtime/maintenance-gate.js";
+import type { McpDeps } from "./deps.js";
 import { registerMcpServer } from "./index.js";
 import {
   callMemoryTool,
@@ -192,6 +194,55 @@ describe("memory MCP tools (docs/13)", () => {
     expect(got?.referenceCount).toBe(1);
   });
 
+  it("registers the recall reference bump so maintenance waits for it", async () => {
+    const { ctxFor, store } = harness();
+    const background = createTrackedBackgroundTasks();
+    const runInBackground = vi.fn(background.run);
+    const ctx = ctxFor("a", null, { runInBackground });
+    await callMemoryTool(
+      "memory_add",
+      { type: "fact", text: "maintenance-safe recall", subject: "runtime" },
+      ctx,
+    );
+    let finishBump = () => {};
+    store.bumpReferences = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishBump = resolve;
+        }),
+    );
+
+    await callMemoryTool("memory_recall", { query: "maintenance-safe" }, ctx);
+    expect(runInBackground).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(store.bumpReferences).toHaveBeenCalledOnce());
+    let paused = false;
+    const waiting = background.pauseAndWait().then(() => {
+      paused = true;
+    });
+    await Promise.resolve();
+    expect(paused).toBe(false);
+
+    finishBump();
+    await waiting;
+    expect(paused).toBe(true);
+  });
+
+  it("keeps recall fail-open without writing when maintenance rejects the bump", async () => {
+    const { ctxFor, store } = harness();
+    const ctx = ctxFor("a", null, { runInBackground: () => false });
+    await callMemoryTool(
+      "memory_add",
+      { type: "fact", text: "reject unsafe background write", subject: "runtime" },
+      ctx,
+    );
+    store.bumpReferences = vi.fn(async () => {});
+
+    const result = await callMemoryTool("memory_recall", { query: "unsafe background" }, ctx);
+
+    expect(result.isError).toBeFalsy();
+    expect(store.bumpReferences).not.toHaveBeenCalled();
+  });
+
   it("memory_add(reflection) returns id + version", async () => {
     const { ctxFor } = harness();
     const res = parse(
@@ -296,7 +347,13 @@ describe("memory MCP tools (docs/13)", () => {
 
 // ---- route / JSON-RPC / auth -----------------------------------------------
 
-function mcpApp(rec: ApiKeyRecord | null) {
+function mcpApp(
+  rec: ApiKeyRecord | null,
+  runInBackground: McpDeps["runInBackground"] = (task) => {
+    void task();
+    return true;
+  },
+) {
   const db = createSqliteDb(":memory:");
   let seq = 0;
   const store = new SqliteMemoryStore(
@@ -313,6 +370,7 @@ function mcpApp(rec: ApiKeyRecord | null) {
     memoryStore: store,
     now: () => NOW,
     estimateTokens: (t) => Math.ceil(t.length / 4),
+    runInBackground,
     scoreConfig: {
       half_life_s: 86400,
       importance_floor: 0.1,
@@ -396,6 +454,29 @@ describe("POST /mcp JSON-RPC route (docs/13)", () => {
     ).json()) as { result: { content: Array<{ text: string }> } };
     const facts = JSON.parse(search.result.content[0]?.text ?? "{}") as { facts: unknown[] };
     expect(facts.facts).toHaveLength(1);
+  });
+
+  it("passes the runtime background runner to memory_recall", async () => {
+    const runInBackground = vi.fn((_task: () => Promise<unknown>) => true);
+    const app = mcpApp(record(), runInBackground);
+    await app.request(
+      "/mcp",
+      rpc("tools/call", {
+        name: "memory_add",
+        arguments: { type: "fact", text: "tracked route recall" },
+      }),
+    );
+
+    const response = await app.request(
+      "/mcp",
+      rpc("tools/call", {
+        name: "memory_recall",
+        arguments: { query: "tracked route" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runInBackground).toHaveBeenCalledOnce();
   });
 
   it("returns 202 with no body for a notification", async () => {

--- a/apps/gateway/src/routes/mcp/tools.ts
+++ b/apps/gateway/src/routes/mcp/tools.ts
@@ -71,6 +71,7 @@ export interface MemoryToolContext {
   store: MemoryAdminStore;
   now: () => Date;
   estimateTokens: (text: string) => number;
+  runInBackground?: (task: () => Promise<unknown>, onError?: (error: unknown) => void) => boolean;
   // docs/14 — hybrid recall (memory_recall). embedder is OPTIONAL: absent ⇒ the vector
   // leg is skipped (FTS+score). scoreConfig is the forgetting curve for the score
   // signal. recall carries the gate + top-K (memory.forgetting.facts_retrieval).
@@ -341,18 +342,21 @@ async function handleRecall(
     return degradeToLike();
   }
 
-  // Reinforcement bump — recalled facts are "used". Fire-and-forget: never awaited,
-  // never blocks or throws the tool response.
-  if (facts.length > 0 && ctx.store.bumpReferences !== undefined) {
-    void ctx.store
-      .bumpReferences({
+  // Reinforcement bump — recalled facts are "used". It never blocks or throws the
+  // tool response, but the runtime tracks it so maintenance/shutdown can drain it.
+  const bumpReferences = ctx.store.bumpReferences;
+  if (facts.length > 0 && bumpReferences !== undefined) {
+    const bump = () =>
+      bumpReferences.call(ctx.store, {
         accountId: ctx.accountId,
         observationIds: [],
         reflectionIds: [],
         factIds: facts.map((f) => f.id),
         now: ctx.now(),
-      })
-      .catch(() => {});
+      });
+    if (ctx.runInBackground?.(bump, () => {}) !== true && ctx.runInBackground === undefined) {
+      void bump().catch(() => {});
+    }
   }
 
   return ok({ facts: facts.map(factView) });

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -1,4 +1,10 @@
-import type { ExecutionResult, InjectDeps, ObserveDeps, RouteOptions } from "@helm/core";
+import {
+  createResponseWorkAdmission,
+  type ExecutionResult,
+  type InjectDeps,
+  type ObserveDeps,
+  type RouteOptions,
+} from "@helm/core";
 import {
   createNativePassthroughCarrier,
   type InternalRequest,
@@ -15,6 +21,7 @@ import {
   type PipelineBudgetDeps,
   PipelineError,
   type RouteFn,
+  splitSSEFrames,
 } from "./messages-pipeline.js";
 
 // messages-pipeline — the framework-agnostic bridge injected into both
@@ -677,6 +684,53 @@ function passthroughStreamResult(
 }
 
 describe("createMessagesPipeline — native passthrough streamIR()", () => {
+  it("rejects both terminated and unterminated native frames beyond the dynamic budget", async () => {
+    const frame = `data: ${"x".repeat(17)}`;
+    for (const oversized of [frame, `${frame}\n\n`]) {
+      async function* stream(): AsyncIterable<string> {
+        yield oversized;
+      }
+
+      await expect(
+        (async () => {
+          for await (const _ of splitSSEFrames(stream(), 16)) {
+            // drain
+          }
+        })(),
+      ).rejects.toMatchObject({
+        name: "UpstreamError",
+        errorClass: "upstream_error",
+        upstreamStatus: null,
+      });
+    }
+  });
+
+  it("shares response-work capacity while a native frame is being consumed", async () => {
+    const wire = "data: one\n\n";
+    const admission = createResponseWorkAdmission({
+      capacityBytes: Buffer.byteLength(wire) * 2,
+      jsonAmplification: 2,
+      minChargeBytes: 2,
+    });
+    async function* stream(): AsyncIterable<string> {
+      yield wire;
+    }
+    const first = splitSSEFrames(stream(), 64, admission)[Symbol.asyncIterator]();
+
+    await expect(first.next()).resolves.toMatchObject({ done: false, value: { data: "one" } });
+    expect(admission.reservedBytes).toBe(Buffer.byteLength(wire) * 2);
+    await expect(
+      (async () => {
+        for await (const _ of splitSSEFrames(stream(), 64, admission)) {
+          // drain
+        }
+      })(),
+    ).rejects.toMatchObject({ name: "UpstreamError", errorClass: "upstream_error" });
+
+    await first.return?.();
+    expect(admission.reservedBytes).toBe(0);
+  });
+
   it("byte-relays the upstream SSE: yields {event,data} with the VERBATIM data string", async () => {
     const route: RouteFn = async () => passthroughStreamResult();
     const pipeline = createMessagesPipeline(route);
@@ -2069,9 +2123,14 @@ describe("createMessagesPipeline — recordOAuthUsage (lines 960-963, 917-920)",
 describe("createMessagesPipeline — writes queue (line 635-641)", () => {
   it("enqueues memory tasks onto the write queue instead of inline-awaiting", async () => {
     const tasks: Array<() => Promise<void>> = [];
+    const options: Array<{ wakeOnSettle?: boolean; retainedBytes?: number }> = [];
     const writes = {
-      enqueueTask: (task: () => Promise<void>, _opts?: { wakeOnSettle?: boolean }) => {
+      enqueueTask: (
+        task: () => Promise<void>,
+        opts?: { wakeOnSettle?: boolean; retainedBytes?: number },
+      ) => {
         tasks.push(task);
+        options.push(opts ?? {});
       },
       depth: 0,
     } as never;
@@ -2097,6 +2156,7 @@ describe("createMessagesPipeline — writes queue (line 635-641)", () => {
     await run.collect();
     // With write queue wired, tasks are enqueued (not awaited inline)
     expect(tasks.length).toBeGreaterThan(0);
+    expect(options.every((opts) => (opts.retainedBytes ?? 0) > 0)).toBe(true);
   });
 });
 

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import {
   type AnthropicSSEEvent,
   assembleInjectedContext,
@@ -20,8 +21,12 @@ import {
   observeOutbound,
   projectScopedThreadId,
   type ResponsesSSEEvent,
+  type ResponseWorkAdmission,
   type RouteOptions,
   resolveMemoryMode,
+  runtimeMemoryBudget,
+  runtimeResponseWorkAdmission,
+  UpstreamError,
 } from "@helm/core";
 import type { InternalRequest, MemoryDecision, Protocol } from "@helm/shared";
 import {
@@ -108,6 +113,40 @@ function irFunctionToolNames(tools: unknown): readonly string[] {
     if (typeof name === "string" && name.length > 0) names.add(name);
   }
   return [...names];
+}
+
+// Count strings already held by the normalized request without serializing or
+// copying its complete object graph. Native carriers preserve their exact raw body;
+// translated requests retain message content/tool arguments directly.
+function retainedRequestBytes(request: InternalRequest): number {
+  let bytes = 0;
+  if (isNativePassthroughCarrier(request.native_request)) {
+    bytes += Buffer.byteLength(request.native_request.raw_body ?? "", "utf8");
+  }
+  const add = (value: unknown): void => {
+    if (typeof value === "string") bytes += Buffer.byteLength(value, "utf8");
+  };
+  for (const message of request.messages) {
+    add(message.role);
+    add(message.content);
+    add(message.name);
+    add(message.tool_call_id);
+    add(message.reasoning_content);
+    for (const part of Array.isArray(message.content) ? message.content : []) {
+      for (const value of Object.values(part)) add(value);
+    }
+    for (const call of Array.isArray(message.tool_calls) ? message.tool_calls : []) {
+      if (call === null || typeof call !== "object") continue;
+      const record = call as {
+        id?: unknown;
+        function?: { name?: unknown; arguments?: unknown };
+      };
+      add(record.id);
+      add(record.function?.name);
+      add(record.function?.arguments);
+    }
+  }
+  return bytes;
 }
 
 // Gateway-side inject wiring (docs/08 Phase 2). Bundles the core InjectDeps with
@@ -469,7 +508,7 @@ function parseFrame(event: string): Record<string, unknown> | null {
 // writeSSE (semantically identical). This ELIMINATES the per-protocol SSE re-mapping
 // state machine (the #221/#222 reasoning/tool mangling source) instead of replacing
 // it (principle 8).
-interface RawSSEFrame {
+export interface RawSSEFrame {
   /** The verbatim `event:` line value (empty when the frame carries no event line). */
   event: string;
   /** The verbatim `data:` payload string (the exact upstream JSON), unparsed. */
@@ -505,21 +544,54 @@ function nextSSEBoundary(buffer: string): { index: number; length: number } | nu
   return candidates[0] ?? null;
 }
 
-async function* splitSSEFrames(raw: AsyncIterable<string>): AsyncIterable<RawSSEFrame> {
-  let buffer = "";
-  for await (const piece of raw) {
-    buffer += piece;
-    let sep = nextSSEBoundary(buffer);
-    while (sep !== null) {
-      const rawFrame = buffer.slice(0, sep.index + sep.length);
-      const frame = parseRawSSEFrame(buffer.slice(0, sep.index), rawFrame);
-      buffer = buffer.slice(sep.index + sep.length);
-      if (frame !== null) yield frame;
-      sep = nextSSEBoundary(buffer);
-    }
+function assertNativeSSEFrameFits(frame: string, maxFrameBytes: number): void {
+  if (Buffer.byteLength(frame) <= maxFrameBytes) return;
+  throw new UpstreamError("upstream_error", "upstream SSE frame exceeds the runtime memory budget");
+}
+
+export async function* splitSSEFrames(
+  raw: AsyncIterable<string>,
+  maxFrameBytes = runtimeMemoryBudget().maxWireBytes,
+  workAdmission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
+): AsyncIterable<RawSSEFrame> {
+  const acquired = workAdmission.acquire(0);
+  if (!acquired.ok) {
+    throw new UpstreamError(
+      "upstream_error",
+      "upstream response memory capacity is temporarily exhausted",
+    );
   }
-  const tail = parseRawSSEFrame(buffer, buffer);
-  if (tail !== null) yield tail;
+  const { lease } = acquired;
+  let buffer = "";
+  const resize = (wireBytes: number): void => {
+    if (lease.resize(wireBytes).ok) return;
+    throw new UpstreamError(
+      "upstream_error",
+      "upstream response memory capacity is temporarily exhausted",
+    );
+  };
+  try {
+    for await (const piece of raw) {
+      resize(Buffer.byteLength(buffer) + Buffer.byteLength(piece));
+      buffer += piece;
+      let sep = nextSSEBoundary(buffer);
+      while (sep !== null) {
+        const rawFrame = buffer.slice(0, sep.index + sep.length);
+        assertNativeSSEFrameFits(rawFrame, maxFrameBytes);
+        const frame = parseRawSSEFrame(buffer.slice(0, sep.index), rawFrame);
+        buffer = buffer.slice(sep.index + sep.length);
+        if (frame !== null) yield frame;
+        resize(Buffer.byteLength(buffer));
+        sep = nextSSEBoundary(buffer);
+      }
+      assertNativeSSEFrameFits(buffer, maxFrameBytes);
+    }
+    assertNativeSSEFrameFits(buffer, maxFrameBytes);
+    const tail = parseRawSSEFrame(buffer, buffer);
+    if (tail !== null) yield tail;
+  } finally {
+    lease.release();
+  }
 }
 
 // Accumulate assistant text from a VERBATIM Anthropic content_block_delta data
@@ -658,25 +730,6 @@ export function createMessagesPipeline(
 ): {
   run(ir: PipelineIR, identity: MessagesIdentity, signal: AbortSignal): Promise<PipelineRunResult>;
 } {
-  // Run a fail-open memory observe: deferred (FIFO) when a write queue is wired, else
-  // inline await (today). FIFO ordering keeps inbound before outbound per thread.
-  // `wake` (default true) asks the write queue to nudge the memory worker after this
-  // observe settles. The INBOUND observe passes false: the observer job must not be
-  // drained until the OUTBOUND turn is persisted (else the assistant turn is dropped
-  // from this run). Outbound observes use the default → the worker wakes once the
-  // whole turn has landed.
-  const runObserve = async (task: () => Promise<unknown>, wake = true): Promise<void> => {
-    if (writes !== undefined) {
-      writes.enqueueTask(
-        async () => {
-          await task();
-        },
-        { wakeOnSettle: wake },
-      );
-      return;
-    }
-    await task();
-  };
   return {
     async run(ir, identity, signal) {
       const meta = ir.metadata;
@@ -699,6 +752,22 @@ export function createMessagesPipeline(
         identity.caps?.allowFastMode === true,
       );
       const originalMessagesForMemory = [...(internal.messages as IRMessage[])];
+      const observeRetainedBytes = retainedRequestBytes(internal);
+      // Deferred observe closures retain normalized request strings. Their exact
+      // string-byte estimate is charged by WriteQueue with the runtime-derived JSON
+      // amplification; inline mode remains unchanged.
+      const runObserve = async (task: () => Promise<unknown>, wake = true): Promise<void> => {
+        if (writes !== undefined) {
+          writes.enqueueTask(
+            async () => {
+              await task();
+            },
+            { wakeOnSettle: wake, retainedBytes: observeRetainedBytes },
+          );
+          return;
+        }
+        await task();
+      };
 
       // Memory scope rides ir.metadata, already stamped by the route from the
       // request headers. Inject runs before inbound observe so this turn cannot

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -1,6 +1,7 @@
 import type { TelemetryStore, UpsertSessionRevisionInput } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
+import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import {
   type MessagesIdentity,
   type MessagesRouteDeps,
@@ -76,6 +77,7 @@ function makeDeps(
     concurrencyGate?: MessagesRouteDeps["concurrencyGate"];
     identity?: MessagesIdentity;
     record?: RecordServedDeps;
+    memoryAdmission?: MessagesRouteDeps["memoryAdmission"];
     // Native passthrough (#217 C3): when true the stubbed pipeline run reports
     // nativePassthrough so the route must return collect()'s body UNTOUCHED (skip
     // transformResponseOut). collect() should be set to return the verbatim native body.
@@ -96,6 +98,7 @@ function makeDeps(
     concurrencyGate: over.concurrencyGate,
     countTokens: over.countTokens,
     record: over.record,
+    memoryAdmission: over.memoryAdmission,
     toolCallXmlRecoveryEnabled: over.toolCallXmlRecoveryEnabled,
     auth: {
       resolve: async (_key: string | null) => {
@@ -242,6 +245,47 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/messages (Anthropic inbound)", () => {
+  it("rejects oversized message and count-token bodies before JSON.parse", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1024,
+      maxWireBytes: 1,
+      jsonAmplification: 1,
+    });
+    const { deps, harness } = makeDeps({ memoryAdmission });
+    const app = buildApp(deps);
+
+    for (const path of ["/v1/messages", "/v1/messages/count_tokens"]) {
+      const res = await app.request(path, {
+        method: "POST",
+        headers: AUTH,
+        body: JSON.stringify(REQ_BODY),
+      });
+      expect(res.status).toBe(413);
+    }
+    expect(harness.order).toEqual(["auth", "auth"]);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("returns 503 with Retry-After when the shared body budget is occupied", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1,
+      maxWireBytes: 1024,
+      jsonAmplification: 1,
+    });
+    const { deps, harness } = makeDeps({ memoryAdmission });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("1");
+    expect(harness.order).toEqual(["auth"]);
+  });
+
   it("accepts the Claude Code event logging compatibility endpoint after auth", async () => {
     const { deps, harness } = makeDeps();
     const app = buildApp(deps);

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -14,6 +14,12 @@ import type { AppEnv } from "../app.js";
 import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
+import {
+  type BodyMemoryAdmission,
+  memoryAdmissionReleaseGuard,
+  RequestAdmissionError,
+  readAdmittedRequestBody,
+} from "../runtime/memory-admission.js";
 import { type ServingAccount, stampServingAccount } from "../runtime/serving-account.js";
 import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { type MemoryKeyDefaults, resolveMemoryScope } from "./memory-scope.js";
@@ -21,9 +27,11 @@ import { PipelineError } from "./messages-pipeline.js";
 import { nativeCarrierFromParsedBody } from "./native-carrier.js";
 import {
   captureEnabled,
+  createSseCapture,
   type RecordServedDeps,
   recordServed,
   sessionCaptureEnabled,
+  withSseCaptureRelease,
 } from "./payload-capture.js";
 import { resolveSessionCapture, stampSessionCapture } from "./session-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
@@ -135,6 +143,8 @@ export interface MessagesRateLimiterPort {
 }
 
 export interface MessagesRouteDeps {
+  /** Machine-derived request-body budget shared by every AI ingress surface. */
+  memoryAdmission?: BodyMemoryAdmission;
   rateLimiter?: MessagesRateLimiterPort;
   /** Per-key concurrency overflow queue (issue #93). The SAME process-wide gate
    *  the chat middleware uses, so a key's in-flight count spans every surface.
@@ -267,10 +277,21 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     const out = anthropic.transformErrorOut(err);
     return c.json(out.body as Record<string, unknown>, out.status as ContentfulStatusCode);
   };
+  const sendAdmissionError = (c: Context<AppEnv>, error: RequestAdmissionError): Response => {
+    if (error.status === 503) c.header("retry-after", "1");
+    const out = anthropic.transformErrorOut({
+      error_class: error.status === 413 ? "invalid_request" : "lane_unavailable",
+      message: error.message,
+      trace_id: c.get("trace_id"),
+    });
+    return c.json(out.body as Record<string, unknown>, error.status as ContentfulStatusCode);
+  };
 
   // Frees an unclaimed concurrency lease on every exit path (the handler below
   // acquires AFTER its self-auth, so the slot cannot be taken by middleware).
   app.use("/v1/messages", concurrencyReleaseGuard());
+  app.use("/v1/messages", memoryAdmissionReleaseGuard());
+  app.use("/v1/messages/count_tokens", memoryAdmissionReleaseGuard());
 
   const resolveIdentity = async (c: Context<AppEnv>): Promise<MessagesIdentity | null> => {
     const credential = extractCredential(c.req.header("x-api-key"), c.req.header("Authorization"));
@@ -302,8 +323,15 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     }
     let native: unknown;
     try {
-      native = JSON.parse(await c.req.text());
-    } catch {
+      const admitted =
+        deps.memoryAdmission === undefined
+          ? null
+          : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+      const requestJson = admitted?.text ?? (await c.req.text());
+      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+      native = JSON.parse(requestJson);
+    } catch (error) {
+      if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
       return sendError(c, {
         error_class: "invalid_request",
         message: "malformed JSON request body",
@@ -416,9 +444,15 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     let requestJson = "";
     let native: unknown;
     try {
-      requestJson = await c.req.text();
+      const admitted =
+        deps.memoryAdmission === undefined
+          ? null
+          : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+      requestJson = admitted?.text ?? (await c.req.text());
+      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
       native = JSON.parse(requestJson);
-    } catch {
+    } catch (error) {
+      if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
       return sendError(c, {
         error_class: "invalid_request",
         message: "malformed JSON request body",
@@ -555,10 +589,12 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       // the stream body fully drains — release in the stream's own finally.
       const releaseConcurrency = c.get("concurrencyRelease");
       c.set("concurrencyRelease", undefined);
+      const releaseRequestMemory = c.get("requestMemoryRelease");
+      c.set("requestMemoryRelease", undefined);
       return streamSSE(c, async (sse) => {
         // Accumulate the serialized wire frames so the served response body can be
         // captured (verbatim) alongside the telemetry row in the finally below.
-        const captured: string[] = [];
+        const captured = captureBodies ? createSseCapture(true) : null;
         // Translate path: every IR event is mapped by the transformer's explicit
         // state machine; we NEVER forward a raw upstream chunk through the
         // convertOpenAIStreamToAnthropic machine blind (CLAUDE.md principle 8). The
@@ -592,8 +628,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
                 ? (event as { event: string; data: string; raw?: string })
                 : { ...anthropic.transformStreamOut(event), raw: undefined };
             const raw = frame.raw;
-            if (captureBodies)
-              captured.push(raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`);
+            captured?.push(raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`);
             if (raw !== undefined) {
               await sse.write(raw);
               lastWrite = raw;
@@ -626,31 +661,40 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
             markStreamDecisionError(result.decision, errorClass);
             const out = anthropic.transformErrorOut(re);
             const data = JSON.stringify(out.body);
-            if (captureBodies) captured.push(`event: error\ndata: ${data}\n\n`);
+            captured?.push(`event: error\ndata: ${data}\n\n`);
             await sse.writeSSE({ event: "error", data });
           }
         } finally {
           releaseConcurrency?.();
-          // Record AFTER releaseConcurrency (never extend the hold) and AFTER the
-          // for-await loop ended so the pipeline's own streamIR finally (cost
-          // backfill) already mutated result.decision. result.decision exists even
-          // on a pre-stream failure, so a failed stream still records. Fail-open.
-          if (deps.record) {
-            stampServingAccount(result.decision, result.servingAccount ?? null);
-            await recordServed(
-              deps.record,
-              {
-                requestId,
-                accountId: identity.accountId,
-                apiKeyId: identity.keyId,
-                decision: result.decision,
-                requestJson,
-                responseJson: captureBodies ? captured.join("") : null,
-                timedOut: requestTimedOut(c),
-                upstreamRequestJson: result.upstreamRequest ?? null,
-              },
-              (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
-            );
+          try {
+            await withSseCaptureRelease(captured, async () => {
+              // Record AFTER releaseConcurrency (never extend the hold) and AFTER the
+              // for-await loop ended so the pipeline's own streamIR finally (cost
+              // backfill) already mutated result.decision. result.decision exists even
+              // on a pre-stream failure, so a failed stream still records. Fail-open.
+              if (deps.record) {
+                stampServingAccount(result.decision, result.servingAccount ?? null);
+                if (captured?.limited()) {
+                  c.get("logger").log("warn", "payload.capture_limited", { trace_id: traceId });
+                }
+                await recordServed(
+                  deps.record,
+                  {
+                    requestId,
+                    accountId: identity.accountId,
+                    apiKeyId: identity.keyId,
+                    decision: result.decision,
+                    requestJson,
+                    responseJson: captured?.payloadValue() ?? null,
+                    timedOut: requestTimedOut(c),
+                    upstreamRequestJson: result.upstreamRequest ?? null,
+                  },
+                  (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+                );
+              }
+            });
+          } finally {
+            releaseRequestMemory?.();
           }
         }
       });

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -1,5 +1,6 @@
 import type { DecisionRecord, InsertPayloadInput, UpsertSessionRevisionInput } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
+import type { WriteQueue } from "../runtime/write-queue.js";
 import { createWriteQueue } from "../runtime/write-queue.js";
 import {
   backfillCompletionCost,
@@ -11,6 +12,8 @@ import {
   estimateInterruptedResponsesUsage,
   type PayloadCaptureDeps,
   persistPayload,
+  persistSessionRequest,
+  queueOrPersistSessionRequest,
   type RecordServedDeps,
   recordServed,
   tokensFromUsage,
@@ -21,6 +24,7 @@ import {
   usageFromResponsesResponse,
   usageFromResponsesSSE,
   usageFromSSE,
+  withSseCaptureRelease,
 } from "./payload-capture.js";
 
 describe("session head cache", () => {
@@ -48,6 +52,83 @@ describe("session head cache", () => {
     expect(cache.retainedBytes).toBe(0);
     expect(cache.get("one")).toBeUndefined();
     expect(cache.get("three")).toBeUndefined();
+  });
+});
+
+describe("Session queue admission", () => {
+  it("rejects an oversized retained body before creating the deferred closure", async () => {
+    const enqueueSession = vi.fn();
+    const writes = { enqueueSession } as unknown as WriteQueue;
+    const sessionDecision = {
+      session: { ref: "session-capacity", label: "thread-capacity", source: "x-session-key" },
+    } as unknown as DecisionRecord;
+    const log = vi.fn();
+
+    await queueOrPersistSessionRequest(
+      {
+        telemetry: {} as PayloadCaptureDeps["telemetry"],
+        writes,
+        captureSessions: () => true,
+        captureBodyLimitBytes: 10,
+      },
+      {
+        requestId: "request-capacity",
+        accountId: "account-1",
+        apiKeyId: "key-1",
+        decision: sessionDecision,
+        requestJson: "x".repeat(11),
+        responseId: null,
+        responseJson: null,
+        now: 1,
+      },
+      log,
+    );
+
+    expect(enqueueSession).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith("session.capture_limited");
+  });
+
+  it("bounds saturated Session metadata by the dynamic cache capacity", async () => {
+    const telemetry = {
+      getSessionByRef: vi.fn(async () => ({
+        revisionCount: Number.MAX_SAFE_INTEGER,
+        storedBytes: 0,
+      })),
+      upsertSessionRevision: vi.fn(),
+    } as unknown as PayloadCaptureDeps["telemetry"];
+    const deps = {
+      telemetry,
+      captureSessions: () => true,
+      captureBodyLimitBytes: 1_024,
+      sessionCacheBytes: 2_048,
+    } satisfies PayloadCaptureDeps;
+    const args = (sessionRef: string) => ({
+      requestId: `request-${sessionRef}`,
+      accountId: "account-1",
+      apiKeyId: "key-1",
+      decision: {
+        session: { ref: sessionRef, label: sessionRef, source: "x-session-key" },
+      } as unknown as DecisionRecord,
+      requestJson: '{"input":"hello"}',
+      responseId: null,
+      responseJson: null,
+      now: 1,
+    });
+
+    for (const sessionRef of ["session-one", "session-two", "session-three"]) {
+      await persistSessionRequest(deps, args(sessionRef), vi.fn());
+    }
+
+    const enqueueSession = vi.fn();
+    const queuedDeps = {
+      ...deps,
+      writes: { enqueueSession } as unknown as WriteQueue,
+    };
+    await queueOrPersistSessionRequest(queuedDeps, args("session-one"), vi.fn());
+    await queueOrPersistSessionRequest(queuedDeps, args("session-three"), vi.fn());
+
+    expect(enqueueSession).toHaveBeenCalledTimes(1);
+    expect(enqueueSession).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
   });
 });
 
@@ -850,6 +931,20 @@ describe("createSseCapture", () => {
     ];
     for (const c of chunks) cap.push(c);
     expect(cap.value()).toBe(chunks.join(""));
+    expect(cap.payloadValue()).toBe(chunks.join(""));
+    expect(cap.limited()).toBe(false);
+    cap.release();
+  });
+
+  it("drops an oversized full capture but keeps a bounded tail for accounting", () => {
+    const cap = createSseCapture(true, 32, 16);
+    cap.push("0123456789");
+    cap.push("abcdefghijklmnop");
+
+    expect(cap.limited()).toBe(true);
+    expect(cap.payloadValue()).toBeNull();
+    expect(cap.value()).toContain("abcdefghijklmnop");
+    cap.release();
   });
 
   it("keeps only a bounded tail when NOT capturing, still enough for usageFromSSE", () => {
@@ -865,12 +960,79 @@ describe("createSseCapture", () => {
     expect(tail.length).toBeLessThan(4000);
     // ...yet cost backfill still finds the usage (it scans from the end).
     expect(usageFromSSE(tail)).toEqual({ prompt_tokens: 100, completion_tokens: 50 });
+    expect(cap.payloadValue()).toBeNull();
+    cap.release();
   });
 
-  it("never drops the only/last chunk even if it exceeds the tail budget", () => {
+  it("strictly truncates a single chunk to the dynamic tail budget", () => {
     const cap = createSseCapture(false, 8);
     cap.push(usageFrame); // single chunk larger than the budget
-    expect(usageFromSSE(cap.value())).toEqual({ prompt_tokens: 100, completion_tokens: 50 });
+    expect(cap.value()).toBe(usageFrame.slice(-8));
+    expect(cap.value().length).toBeLessThanOrEqual(8);
+    cap.release();
+  });
+
+  it("copies a large sliced tail into independent storage", () => {
+    const bufferFrom = vi.spyOn(Buffer, "from");
+    const cap = createSseCapture(false, 8);
+    const chunk = `${"x".repeat(1_000_000)}tail-end`;
+
+    try {
+      cap.push(chunk);
+      expect(cap.value()).toBe("tail-end");
+      expect(bufferFrom).toHaveBeenCalledWith("tail-end", "utf16le");
+    } finally {
+      cap.release();
+      bufferFrom.mockRestore();
+    }
+  });
+
+  it("reserves two UTF-8 copies for retained full parts plus their joined value", () => {
+    const first = createSseCapture(true, 0, 4, 8);
+    const blocked = createSseCapture(true, 0, 4, 8);
+    const afterRelease = createSseCapture(true, 0, 4, 8);
+
+    first.push("👋"); // 4 UTF-8 bytes; parts + joined value reserve 8 bytes.
+    expect(first.limited()).toBe(false);
+    expect(first.payloadValue()).toBe("👋");
+
+    blocked.push("x");
+    expect(blocked.limited()).toBe(true);
+    first.release();
+
+    afterRelease.push("👋");
+    expect(afterRelease.limited()).toBe(false);
+    expect(afterRelease.payloadValue()).toBe("👋");
+    blocked.release();
+    afterRelease.release();
+  });
+
+  it("charges tail retention to the global capture budget and releases it", () => {
+    const first = createSseCapture(false, 8, 1, 32);
+    const second = createSseCapture(false, 8, 1, 32);
+
+    first.push("12345678");
+    second.push("abcdefgh");
+    expect(first.value()).toBe("12345678");
+    expect(second.value()).toBe("");
+
+    first.release();
+    second.push("abcdefgh");
+    expect(second.value()).toBe("abcdefgh");
+    second.release();
+  });
+
+  it("releases the capture reservation when post-stream bookkeeping throws", async () => {
+    const release = vi.fn();
+    const failure = new Error("bookkeeping failed");
+
+    await expect(
+      withSseCaptureRelease({ release } as never, async () => {
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+
+    expect(release).toHaveBeenCalledOnce();
   });
 });
 
@@ -1279,7 +1441,7 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     });
   });
 
-  it("keeps the request revision but omits a Session response larger than 16 MiB", async () => {
+  it("keeps the request revision but omits a Session response beyond the runtime limit", async () => {
     const s = sink();
     const revisions: UpsertSessionRevisionInput[] = [];
     const telemetry = {
@@ -1304,13 +1466,14 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
         now: () => 5000,
         capturePayloads: () => false,
         captureSessions: () => true,
+        captureBodyLimitBytes: 1024,
       },
       {
         ...args,
         requestId: "large-response",
         decision: sessionDecision,
         requestJson: '{"model":"auto","messages":[{"role":"user","content":"hi"}]}',
-        responseJson: "x".repeat(16 * 1024 * 1024 + 1),
+        responseJson: "x".repeat(1025),
       },
       log,
     );
@@ -1484,7 +1647,7 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     });
   });
 
-  it("charges retained Responses output to the deferred Session byte budget", async () => {
+  it("charges retained Responses output to the persisted Session byte quota", async () => {
     const upsertSessionRevision = vi.fn(async (_input: UpsertSessionRevisionInput) => {});
     const insert = vi.fn(async () => ({ id: "1" }));
     const telemetry = {

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -1,10 +1,10 @@
 import type { DecisionRecord, TelemetryStore } from "@helm/core";
 import {
   billedCostFromBody,
+  PERSISTED_SESSION_MAX_REVISIONS,
+  PERSISTED_SESSION_MAX_STORED_BYTES,
   usageFromBody as parseUsage,
-  restoreSessionRevisionJson,
-  SESSION_MAX_REVISIONS,
-  SESSION_MAX_STORED_BYTES,
+  runtimeMemoryBudget,
   splitSessionRequestJson,
 } from "@helm/core";
 import type { TokenUsageBreakdown } from "@helm/shared";
@@ -28,6 +28,10 @@ export interface PayloadCaptureDeps {
   capturePayloads?: () => boolean;
   /** Live getter for the incremental per-session request transcript setting. */
   captureSessions?: () => boolean;
+  /** Optional test/embedding override. Production derives this from the V8 heap. */
+  captureBodyLimitBytes?: number;
+  /** Optional test/embedding override. Production derives this from the V8 heap. */
+  sessionCacheBytes?: number;
   /** Resolve the served attempt's USD cost from the trailing usage chunk: an
    *  upstream-BILLED cost in it (`cost_usd` / OpenRouter `cost`) OVERRIDES the
    *  catalog estimate, else tokens × `alias`'s pricing; null when neither is
@@ -347,13 +351,6 @@ export function capturedResponsesResponse(
   return { responseId: null, responseJson: null };
 }
 
-function previousResponseIdFromRequest(requestJson: string): string | null {
-  const value = JSON.parse(requestJson) as unknown;
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const previous = (value as Record<string, unknown>).previous_response_id;
-  return typeof previous === "string" && previous.trim() !== "" ? previous : null;
-}
-
 function hasResponsesOutput(raw: string | null | undefined): boolean {
   if (!raw) return false;
   try {
@@ -369,11 +366,15 @@ function hasResponsesOutput(raw: string | null | undefined): boolean {
   }
 }
 
-const MAX_SESSION_REQUEST_BYTES = 16 * 1024 * 1024;
-// Per revision: prevents one response from consuming the separate 64 MiB whole-Session budget.
-const MAX_SESSION_RESPONSE_BYTES = 16 * 1024 * 1024;
-const MAX_CACHED_SESSION_HEADS = 1_000;
-const MAX_CACHED_SESSION_HEAD_BYTES = 64 * 1024 * 1024;
+const defaultMemoryBudget = runtimeMemoryBudget();
+
+function captureBodyLimitBytes(deps: PayloadCaptureDeps): number {
+  return deps.captureBodyLimitBytes ?? defaultMemoryBudget.maxWireBytes;
+}
+
+function sessionCacheBytes(deps: PayloadCaptureDeps): number {
+  return deps.sessionCacheBytes ?? defaultMemoryBudget.sessionCacheBytes;
+}
 
 export interface SessionHeadCache {
   get(sessionRef: string): { requestId: string; requestJson: string } | undefined;
@@ -383,8 +384,8 @@ export interface SessionHeadCache {
 }
 
 export function createSessionHeadCache(
-  maxEntries = MAX_CACHED_SESSION_HEADS,
-  maxBytes = MAX_CACHED_SESSION_HEAD_BYTES,
+  maxEntries = Math.max(1, Math.floor(defaultMemoryBudget.sessionCacheBytes / 1024)),
+  maxBytes = defaultMemoryBudget.sessionCacheBytes,
 ): SessionHeadCache {
   const entries = new Map<
     string,
@@ -426,11 +427,32 @@ export function createSessionHeadCache(
 }
 
 const sessionHeadCaches = new WeakMap<TelemetryStore, SessionHeadCache>();
+const saturatedSessionRefs = new WeakMap<TelemetryStore, Set<string>>();
 
-function sessionHeadCache(store: TelemetryStore): SessionHeadCache {
+function saturatedSessions(store: TelemetryStore): Set<string> {
+  const existing = saturatedSessionRefs.get(store);
+  if (existing) return existing;
+  const created = new Set<string>();
+  saturatedSessionRefs.set(store, created);
+  return created;
+}
+
+function markSaturatedSession(store: TelemetryStore, sessionRef: string, maxBytes: number): void {
+  const refs = saturatedSessions(store);
+  refs.delete(sessionRef);
+  refs.add(sessionRef);
+  const maxEntries = Math.max(1, Math.floor(maxBytes / 1024));
+  while (refs.size > maxEntries) {
+    const oldest = refs.values().next().value;
+    if (oldest === undefined) break;
+    refs.delete(oldest);
+  }
+}
+
+function sessionHeadCache(store: TelemetryStore, maxBytes: number): SessionHeadCache {
   const existing = sessionHeadCaches.get(store);
   if (existing) return existing;
-  const created = createSessionHeadCache();
+  const created = createSessionHeadCache(Math.max(1, Math.floor(maxBytes / 1024)), maxBytes);
   sessionHeadCaches.set(store, created);
   return created;
 }
@@ -439,8 +461,14 @@ function cacheSessionHead(
   store: TelemetryStore,
   sessionRef: string,
   head: { requestId: string; requestJson: string },
+  maxBytes: number,
 ): void {
-  sessionHeadCache(store).set(sessionRef, head);
+  sessionHeadCache(store, maxBytes).set(sessionRef, head);
+}
+
+export function clearSessionCaptureCache(store: TelemetryStore): void {
+  sessionHeadCaches.delete(store);
+  saturatedSessionRefs.delete(store);
 }
 
 export async function persistSessionRequest(
@@ -459,29 +487,30 @@ export async function persistSessionRequest(
 ): Promise<void> {
   const session = args.decision.session;
   const get = deps.telemetry.getSessionByRef;
-  const list = deps.telemetry.listSessionRevisions;
   const getByResponseId = deps.telemetry.getSessionRevisionByResponseId;
   const upsert = deps.telemetry.upsertSessionRevision;
   if (!sessionCaptureEnabled(deps)) {
-    sessionHeadCaches.delete(deps.telemetry);
+    clearSessionCaptureCache(deps.telemetry);
     return;
   }
-  if (!session?.label || !get || !list || !upsert) return;
+  if (!session?.label || !get || !upsert) return;
   try {
-    if (Buffer.byteLength(args.requestJson, "utf8") > MAX_SESSION_REQUEST_BYTES) {
+    if (Buffer.byteLength(args.requestJson, "utf8") > captureBodyLimitBytes(deps)) {
       log("session.capture_limited");
       return;
     }
     const head = await get.call(deps.telemetry, session.ref);
     if (
       head &&
-      (head.revisionCount >= SESSION_MAX_REVISIONS || head.storedBytes >= SESSION_MAX_STORED_BYTES)
+      (head.revisionCount >= PERSISTED_SESSION_MAX_REVISIONS ||
+        head.storedBytes >= PERSISTED_SESSION_MAX_STORED_BYTES)
     ) {
+      markSaturatedSession(deps.telemetry, session.ref, sessionCacheBytes(deps));
       log("session.capture_limited");
       return;
     }
-    const previousResponseId = previousResponseIdFromRequest(args.requestJson);
     const currentBase = splitSessionRequestJson(args.requestJson);
+    const previousResponseId = currentBase.previousResponseId;
     let parentRequestId: string | null = null;
     let previousEvents: string | undefined;
     let fidelity: "semantic" | "partial" = "semantic";
@@ -493,30 +522,31 @@ export async function persistSessionRequest(
       if (!hasResponsesOutput(parent?.responseJson)) fidelity = "partial";
     } else {
       parentRequestId = head?.headRequestId ?? null;
-      const cached = sessionHeadCache(deps.telemetry).get(session.ref);
+      const cached = sessionHeadCache(deps.telemetry, sessionCacheBytes(deps)).get(session.ref);
       const parentRequest =
         parentRequestId === null
           ? null
           : cached?.requestId === parentRequestId
             ? cached.requestJson
-            : restoreSessionRevisionJson(
-                await list.call(deps.telemetry, session.ref),
-                parentRequestId,
-              );
+            : null;
       const parentDelta = parentRequest ? splitSessionRequestJson(parentRequest) : null;
       previousEvents =
         parentDelta?.eventKey === currentBase.eventKey ? parentDelta.eventsJson : undefined;
     }
-    const delta = splitSessionRequestJson(args.requestJson, previousEvents);
+    const delta =
+      previousEvents === undefined
+        ? currentBase
+        : splitSessionRequestJson(args.requestJson, previousEvents);
     const deltaBytes = Buffer.byteLength(delta.eventsJson + delta.envelopeJson, "utf8");
-    if ((head?.storedBytes ?? 0) + deltaBytes > SESSION_MAX_STORED_BYTES) {
+    if ((head?.storedBytes ?? 0) + deltaBytes > PERSISTED_SESSION_MAX_STORED_BYTES) {
+      markSaturatedSession(deps.telemetry, session.ref, sessionCacheBytes(deps));
       log("session.capture_limited");
       return;
     }
     const responseBytes =
       args.responseJson === null ? 0 : Buffer.byteLength(args.responseJson, "utf8");
     const responseJson =
-      (head?.storedBytes ?? 0) + deltaBytes + responseBytes <= SESSION_MAX_STORED_BYTES
+      (head?.storedBytes ?? 0) + deltaBytes + responseBytes <= PERSISTED_SESSION_MAX_STORED_BYTES
         ? args.responseJson
         : null;
     if (args.responseJson !== null && responseJson === null) log("session.response_limited");
@@ -536,10 +566,22 @@ export async function persistSessionRequest(
       fidelity: fidelity === "partial" ? fidelity : delta.fidelity,
       createdAt: new Date(args.now),
     });
-    cacheSessionHead(deps.telemetry, session.ref, {
-      requestId: args.requestId,
-      requestJson: args.requestJson,
-    });
+    if (
+      (head?.revisionCount ?? 0) + 1 >= PERSISTED_SESSION_MAX_REVISIONS ||
+      (head?.storedBytes ?? 0) + deltaBytes + (responseJson === null ? 0 : responseBytes) >=
+        PERSISTED_SESSION_MAX_STORED_BYTES
+    ) {
+      markSaturatedSession(deps.telemetry, session.ref, sessionCacheBytes(deps));
+    }
+    cacheSessionHead(
+      deps.telemetry,
+      session.ref,
+      {
+        requestId: args.requestId,
+        requestJson: args.requestJson,
+      },
+      sessionCacheBytes(deps),
+    );
   } catch {
     log("session.capture_failed");
   }
@@ -550,9 +592,18 @@ export async function queueOrPersistSessionRequest(
   args: Parameters<typeof persistSessionRequest>[1],
   log: (msg: string) => void,
 ): Promise<void> {
+  if (Buffer.byteLength(args.requestJson, "utf8") > captureBodyLimitBytes(deps)) {
+    log("session.capture_limited");
+    return;
+  }
+  const sessionRef = args.decision.session?.ref;
+  if (sessionRef && saturatedSessions(deps.telemetry).has(sessionRef)) {
+    log("session.capture_limited");
+    return;
+  }
   const responseJson =
     args.responseJson !== null &&
-    Buffer.byteLength(args.responseJson, "utf8") > MAX_SESSION_RESPONSE_BYTES
+    Buffer.byteLength(args.responseJson, "utf8") > captureBodyLimitBytes(deps)
       ? null
       : args.responseJson;
   if (args.responseJson !== null && responseJson === null) log("session.response_limited");
@@ -568,16 +619,28 @@ export async function queueOrPersistSessionRequest(
   await persistSessionRequest(deps, boundedArgs, log);
 }
 
-// Default retained-tail size (chars) when NOT persisting the body. The trailing
-// usage frame (include_usage) is tiny and always last, so a few KB is ample for
-// usageFromSSE; this caps per-stream memory instead of pinning the whole response.
-const SSE_TAIL_CHARS = 16_384;
-
 export interface SseCapture {
   push(chunk: string): void;
   /** The retained text: the FULL body when capturing, else a bounded trailing tail. */
   value(): string;
+  /** Exact payload body, or null when capture is off / exceeded the runtime budget. */
+  payloadValue(): string | null;
+  limited(): boolean;
+  release(): void;
 }
+
+export async function withSseCaptureRelease<T>(
+  capture: SseCapture | null,
+  bookkeeping: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await bookkeeping();
+  } finally {
+    capture?.release();
+  }
+}
+
+let retainedSseCaptureBytes = 0;
 
 // Accumulate forwarded SSE chunks for end-of-stream use (verbatim capture +
 // streamed-cost backfill) WITHOUT pinning the whole response in memory when capture
@@ -586,22 +649,95 @@ export interface SseCapture {
 // END — so a large stream under high concurrency costs O(tail), not O(response). The
 // caller always feeds a COPY after writing the chunk downstream, so this never
 // touches the bytes forwarded to the client (principle 8).
-export function createSseCapture(full: boolean, tailChars: number = SSE_TAIL_CHARS): SseCapture {
+export function createSseCapture(
+  full: boolean,
+  tailChars: number = runtimeMemoryBudget().sseTailChars,
+  maxFullBytes: number = Math.max(1, Math.floor(runtimeMemoryBudget().responseCaptureBytes / 2)),
+  totalCaptureBytes: number = runtimeMemoryBudget().responseCaptureBytes,
+): SseCapture {
   const parts: string[] = [];
-  let size = 0;
+  const tailLimit = Math.max(0, Math.floor(tailChars));
+  const captureLimit = Math.max(0, Math.floor(totalCaptureBytes));
+  let tail = "";
+  let tailReservation = 0;
+  let fullBytes = 0;
+  let fullReservation = 0;
+  let captureLimited = false;
+  let fullValue: string | undefined;
+  let released = false;
+  const releaseFullReservation = () => {
+    retainedSseCaptureBytes -= fullReservation;
+    fullReservation = 0;
+    fullBytes = 0;
+    parts.length = 0;
+    fullValue = undefined;
+  };
+  const releaseTailReservation = () => {
+    retainedSseCaptureBytes -= tailReservation;
+    tailReservation = 0;
+    tail = "";
+  };
+  const joinedFullValue = () => {
+    if (fullValue === undefined) fullValue = parts.join("");
+    return fullValue;
+  };
   return {
     push(chunk: string): void {
-      parts.push(chunk);
-      if (full) return;
-      size += chunk.length;
-      // Drop oldest parts while over budget, but always retain at least the last one.
-      while (size > tailChars && parts.length > 1) {
-        const dropped = parts.shift();
-        if (dropped !== undefined) size -= dropped.length;
+      if (released) return;
+      const slicedTail =
+        tailLimit === 0
+          ? ""
+          : chunk.length >= tailLimit
+            ? chunk.slice(-tailLimit)
+            : `${tail}${chunk}`.slice(-tailLimit);
+      // V8 may represent `slice()` as a SlicedString that keeps the entire source
+      // chunk alive. Round-trip the bounded suffix through an owned Buffer so the
+      // retained JS string has independent backing storage. UTF-16LE preserves exact
+      // JS code units even when the character limit lands between a surrogate pair.
+      const nextTail =
+        slicedTail === "" ? "" : Buffer.from(slicedTail, "utf16le").toString("utf16le");
+      // A JS string can retain two bytes per code unit, and replacing/reading the
+      // tail can briefly keep both old and new strings alive. Reserve that peak.
+      const nextTailReservation = nextTail.length * 4;
+      const tailDelta = nextTailReservation - tailReservation;
+      if (tailDelta <= 0 || retainedSseCaptureBytes + tailDelta <= captureLimit) {
+        retainedSseCaptureBytes += tailDelta;
+        tailReservation = nextTailReservation;
+        tail = nextTail;
       }
+      if (!full || captureLimited) return;
+      const nextBytes = Buffer.byteLength(chunk, "utf8");
+      const nextReservation = nextBytes * 2;
+      if (
+        fullBytes + nextBytes > maxFullBytes ||
+        retainedSseCaptureBytes + nextReservation > captureLimit
+      ) {
+        captureLimited = true;
+        releaseFullReservation();
+        return;
+      }
+      parts.push(chunk);
+      fullBytes += nextBytes;
+      fullReservation += nextReservation;
+      retainedSseCaptureBytes += nextReservation;
+      fullValue = undefined;
     },
     value(): string {
-      return parts.join("");
+      if (full && !captureLimited) return joinedFullValue();
+      return tail;
+    },
+    payloadValue(): string | null {
+      if (!full || captureLimited) return null;
+      return joinedFullValue();
+    },
+    limited(): boolean {
+      return captureLimited;
+    },
+    release(): void {
+      if (released) return;
+      released = true;
+      releaseFullReservation();
+      releaseTailReservation();
     },
   };
 }

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -8,9 +8,10 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "../responses-websocket-internal.js";
+import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import type { MessagesIdentity } from "./messages.js";
 import { PipelineError } from "./messages-pipeline.js";
-import type { RecordServedDeps } from "./payload-capture.js";
+import type { RecordServedDeps, SseCapture } from "./payload-capture.js";
 import {
   type ResponsesRouteDeps,
   registerResponsesRoute,
@@ -81,6 +82,8 @@ function makeDeps(
     registry?: ResponsesRouteDeps["registry"];
     modelsEtag?: string | null;
     modelsEtagForKey?: ResponsesRouteDeps["modelsEtagForKey"];
+    memoryAdmission?: ResponsesRouteDeps["memoryAdmission"];
+    sseCaptureFactory?: ResponsesRouteDeps["sseCaptureFactory"];
   } = {},
 ): { deps: ResponsesRouteDeps; order: string[]; harness: { pipelineSawIR: unknown } } {
   const order: string[] = [];
@@ -93,6 +96,8 @@ function makeDeps(
     budget: over.budget,
     recordOAuthUsage: over.recordOAuthUsage,
     registry: over.registry,
+    memoryAdmission: over.memoryAdmission,
+    sseCaptureFactory: over.sseCaptureFactory,
     ...(over.modelsEtagForKey !== undefined
       ? { modelsEtagForKey: over.modelsEtagForKey }
       : over.modelsEtag === undefined
@@ -215,6 +220,28 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/responses (OpenAI Responses inbound)", () => {
+  it("rejects a body beyond the machine-derived admission limit before translation", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    const { deps, order } = makeDeps({ memoryAdmission });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+
+    expect(res.status).toBe(413);
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { type: "invalid_request_error", code: "request_too_large" },
+    });
+    expect(order).toEqual(["auth"]);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
   it("non-stream: auth → translate-out → route → translate-back, returns Responses JSON", async () => {
     const { deps, order } = makeDeps();
     const app = buildApp(deps);
@@ -2043,6 +2070,70 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
         responseJson: JSON.stringify(terminalResponse),
       }),
     );
+  });
+
+  it("budgets a Session-only terminal frame before parsing and releases a limited capture", async () => {
+    const push = vi.fn();
+    const release = vi.fn();
+    const capture: SseCapture = {
+      push,
+      value: () => "",
+      payloadValue: () => null,
+      limited: () => true,
+      release,
+    };
+    const upsertSessionRevision = vi.fn(async (_input: UpsertSessionRevisionInput) => {});
+    const record: RecordServedDeps = {
+      telemetry: {
+        insert: vi.fn().mockResolvedValue({ id: "1" }),
+        getSessionByRef: vi.fn(async () => null),
+        getSessionRevisionByResponseId: vi.fn(async () => null),
+        upsertSessionRevision,
+      } as unknown as TelemetryStore,
+      redact: (value) => value,
+      now: () => 1000,
+      capturePayloads: () => false,
+      captureSessions: () => true,
+    };
+    const { deps } = makeDeps({
+      record,
+      sseCaptureFactory: () => capture,
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      streamIR: async function* () {
+        yield { type: "response.created", sequence_number: 0 };
+        yield {
+          type: "response.completed",
+          sequence_number: 1,
+          response: { id: "resp_limited", output: [{ type: "message" }] },
+        };
+      },
+    });
+    const log = vi.fn();
+    const app = createApp({ logger: { log } });
+    registerResponsesRoute(app, deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { ...AUTH, "x-thread-id": "thread-limited" },
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    await res.text();
+
+    expect(push).toHaveBeenCalledOnce();
+    expect(push.mock.calls[0]?.[0]).toContain("event: response.completed");
+    expect(log).toHaveBeenCalledWith(
+      "warn",
+      "session.response_limited",
+      expect.objectContaining({ trace_id: expect.any(String) }),
+    );
+    expect(upsertSessionRevision).toHaveBeenCalledWith(
+      expect.objectContaining({ responseId: null, responseJson: null }),
+    );
+    expect(release).toHaveBeenCalledOnce();
   });
 
   // ── Terminal stream error frame must be appended to the captured body (review

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -26,6 +26,11 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import { normalizeOpenAICodexClientVersion } from "../oauth/codex-client-version.js";
 import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "../responses-websocket-internal.js";
+import {
+  type BodyMemoryAdmission,
+  memoryAdmissionReleaseGuard,
+  readAdmittedRequestBody,
+} from "../runtime/memory-admission.js";
 import { stampServingAccount } from "../runtime/serving-account.js";
 import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { resolveMemoryScope } from "./memory-scope.js";
@@ -35,8 +40,10 @@ import { nativeCarrierFromParsedBody } from "./native-carrier.js";
 import {
   capturedResponsesResponse,
   captureEnabled,
+  createSseCapture,
   type RecordServedDeps,
   recordServed,
+  type SseCapture,
   type StreamUsage,
   sessionCaptureEnabled,
   tokenBreakdownFromUsage,
@@ -216,6 +223,9 @@ export interface ResponsesRouteDeps {
   // Without it, a normal HTTP client could spoof x-helm-* session headers and
   // accidentally create a long-lived upstream websocket.
   responsesWebSocketSessionProof?: string;
+  memoryAdmission?: BodyMemoryAdmission;
+  /** Optional test/embedding override; production uses the machine-derived capture budget. */
+  sseCaptureFactory?: (full: boolean) => SseCapture;
 }
 
 // Client disconnect / abort detection — mirrors messages.ts. Used to suppress a
@@ -393,6 +403,14 @@ function streamStatusFromEventName(eventName: string): string | null {
     default:
       return null;
   }
+}
+
+function isResponsesTerminalEvent(eventName: string): boolean {
+  return (
+    eventName === "response.completed" ||
+    eventName === "response.incomplete" ||
+    eventName === "response.failed"
+  );
 }
 
 type ResponsesStreamOutcome = NonNullable<DecisionRecord["stream_outcome"]>;
@@ -719,6 +737,12 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
   app.use("/responses/*", concurrencyReleaseGuard());
   app.use("/openai/v1/responses", concurrencyReleaseGuard());
   app.use("/openai/v1/responses/*", concurrencyReleaseGuard());
+  app.use("/v1/responses", memoryAdmissionReleaseGuard());
+  app.use("/v1/responses/*", memoryAdmissionReleaseGuard());
+  app.use("/responses", memoryAdmissionReleaseGuard());
+  app.use("/responses/*", memoryAdmissionReleaseGuard());
+  app.use("/openai/v1/responses", memoryAdmissionReleaseGuard());
+  app.use("/openai/v1/responses/*", memoryAdmissionReleaseGuard());
 
   const authenticateResponsesRequest = async (c: Context<AppEnv>): Promise<MessagesIdentity> => {
     const traceId = c.get("trace_id");
@@ -794,8 +818,16 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     c: Context<AppEnv>,
     traceId: string,
   ): Promise<{ native: unknown; rawBody: string }> => {
+    const trustedWebSocketSelfCall =
+      deps.responsesWebSocketSessionProof !== undefined &&
+      c.req.header(CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER) === deps.responsesWebSocketSessionProof;
+    const admitted =
+      deps.memoryAdmission === undefined || trustedWebSocketSelfCall
+        ? null
+        : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
+    const rawBody = admitted?.text ?? (await c.req.text());
+    if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
     try {
-      const rawBody = await c.req.text();
       return { native: JSON.parse(rawBody), rawBody };
     } catch {
       throw helmError("invalid_request", "malformed JSON request body", traceId);
@@ -1010,14 +1042,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     // 2) Parse + translate inbound. A malformed JSON body OR a structurally invalid
     //    Responses request (the transformer's Zod parse throws) is a CLIENT error →
     //    400 invalid_request, before routing (docs/07, principle 2 fail-closed).
-    let requestJson = "";
-    let native: unknown;
-    try {
-      requestJson = await c.req.text();
-      native = JSON.parse(requestJson);
-    } catch {
-      throw helmError("invalid_request", "malformed JSON request body", traceId);
-    }
+    const { native, rawBody: requestJson } = await parseJsonBodyWithRaw(c, traceId);
     let ir: ResponsesIRLike;
     try {
       ir = deps.transformer.transformRequestOut(native);
@@ -1110,6 +1135,8 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       // body fully drains — release in the stream's own finally, not the guard.
       const releaseConcurrency = c.get("concurrencyRelease");
       c.set("concurrencyRelease", undefined);
+      const releaseMemory = c.get("requestMemoryRelease");
+      c.set("requestMemoryRelease", undefined);
       let initialResult: PipelineRunResult | null = null;
       let initialError: unknown = null;
       try {
@@ -1140,7 +1167,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         let nextErrorSequence = 0;
         // Accumulate the serialized wire frames so the served response body can be
         // captured (verbatim) alongside the telemetry row in the finally below.
-        const captured: string[] = [];
+        const makeSseCapture = deps.sseCaptureFactory ?? createSseCapture;
+        const captured = captureBodies ? makeSseCapture(true) : null;
+        const sessionTerminalCapture =
+          captureSessionResponse && !captureBodies ? makeSseCapture(true) : null;
         const result = initialResult;
         // SSE keep-alive: emit a `:` comment during inter-chunk idle (wire-only, never
         // captured) so a proxy/client idle-timeout does not sever a long healthy stream.
@@ -1174,16 +1204,22 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     raw: (event as { raw?: string }).raw,
                   }
                 : { ...deps.transformer.transformStreamOut(event), raw: undefined };
+            const raw = frame.raw;
+            const serializedFrame = raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`;
+            captured?.push(serializedFrame);
+            const terminalEvent = isResponsesTerminalEvent(frame.event);
+            if (terminalEvent) sessionTerminalCapture?.push(serializedFrame);
             const snapshot = responseSnapshotFromStreamFrame(frame.event, frame.data);
             if (snapshot.responseId !== null) streamResponseId = snapshot.responseId;
             if (snapshot.status !== null) streamStatus = snapshot.status;
-            if (captureSessionResponse && !captureBodies) {
-              const captured = capturedResponsesResponse("openai_responses", frame.data);
-              if (captured.responseJson !== null) sessionResponseJson = captured.responseJson;
+            if (captureSessionResponse && terminalEvent && !captureBodies) {
+              if (sessionTerminalCapture?.limited()) {
+                c.get("logger").log("warn", "session.response_limited", { trace_id: traceId });
+              } else if (sessionTerminalCapture !== null) {
+                const terminal = capturedResponsesResponse("openai_responses", frame.data);
+                if (terminal.responseJson !== null) sessionResponseJson = terminal.responseJson;
+              }
             }
-            const raw = frame.raw;
-            if (captureBodies)
-              captured.push(raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`);
             if (raw !== undefined) {
               await sse.write(raw);
               lastWrite = raw;
@@ -1223,7 +1259,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     sequenceNumber: nextErrorSequence,
                   });
             const data = JSON.stringify(body);
-            if (captureBodies) captured.push(`event: error\ndata: ${data}\n\n`);
+            captured?.push(`event: error\ndata: ${data}\n\n`);
             await sse.writeSSE({ event: "error", data });
           }
         } finally {
@@ -1243,45 +1279,59 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           // own streamIR finally (cost backfill) already mutated result.decision.
           // result.decision exists even on a pre-stream failure, so a failed stream
           // still records. Fail-open inside recordServed.
-          if (deps.record && result !== null) {
-            stampServingAccount(result.decision, result.servingAccount ?? null);
-            await recordServed(
-              deps.record,
-              {
-                requestId,
-                accountId: identity.accountId,
-                apiKeyId: identity.keyId,
-                decision: result.decision,
-                requestJson,
-                responseJson: captureBodies ? captured.join("") : sessionResponseJson,
-                timedOut: requestTimedOut(c),
-                upstreamRequestJson: result.upstreamRequest ?? null,
-              },
-              (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
-            );
-          }
-          if (deps.registry !== undefined && result !== null && streamResponseId !== null) {
-            const attempt = successfulAttempt(result.decision);
-            await deps.registry.put({
-              responseId: streamResponseId,
-              accountId: identity.accountId,
-              keyId: identity.keyId,
-              providerAlias: typeof attempt?.alias === "string" ? attempt.alias : null,
-              providerName:
-                typeof attempt?.provider_name === "string" ? attempt.provider_name : null,
-              providerModel:
-                typeof attempt?.provider_model === "string" ? attempt.provider_model : null,
-              providerProtocol:
-                attempt?.target_provider_protocol === "openai_chat" ||
-                attempt?.target_provider_protocol === "anthropic_messages" ||
-                attempt?.target_provider_protocol === "openai_responses" ||
-                attempt?.target_provider_protocol === "gemini"
-                  ? attempt.target_provider_protocol
-                  : null,
-              createdAt: Date.now(),
-              expiresAt: Date.now() + 86_400_000,
-              status: streamOutcome ?? "truncated",
-            });
+          try {
+            if (deps.record && result !== null) {
+              stampServingAccount(result.decision, result.servingAccount ?? null);
+              if (captured?.limited()) {
+                c.get("logger").log("warn", "payload.capture_limited", { trace_id: traceId });
+              }
+              await recordServed(
+                deps.record,
+                {
+                  requestId,
+                  accountId: identity.accountId,
+                  apiKeyId: identity.keyId,
+                  decision: result.decision,
+                  requestJson,
+                  responseJson: captureBodies
+                    ? (captured?.payloadValue() ?? null)
+                    : sessionResponseJson,
+                  timedOut: requestTimedOut(c),
+                  upstreamRequestJson: result.upstreamRequest ?? null,
+                },
+                (msg) => c.get("logger").log("warn", msg, { trace_id: traceId }),
+              );
+            }
+          } finally {
+            try {
+              if (deps.registry !== undefined && result !== null && streamResponseId !== null) {
+                const attempt = successfulAttempt(result.decision);
+                await deps.registry.put({
+                  responseId: streamResponseId,
+                  accountId: identity.accountId,
+                  keyId: identity.keyId,
+                  providerAlias: typeof attempt?.alias === "string" ? attempt.alias : null,
+                  providerName:
+                    typeof attempt?.provider_name === "string" ? attempt.provider_name : null,
+                  providerModel:
+                    typeof attempt?.provider_model === "string" ? attempt.provider_model : null,
+                  providerProtocol:
+                    attempt?.target_provider_protocol === "openai_chat" ||
+                    attempt?.target_provider_protocol === "anthropic_messages" ||
+                    attempt?.target_provider_protocol === "openai_responses" ||
+                    attempt?.target_provider_protocol === "gemini"
+                      ? attempt.target_provider_protocol
+                      : null,
+                  createdAt: Date.now(),
+                  expiresAt: Date.now() + 86_400_000,
+                  status: streamOutcome ?? "truncated",
+                });
+              }
+            } finally {
+              captured?.release();
+              sessionTerminalCapture?.release();
+              releaseMemory?.();
+            }
           }
         }
       });

--- a/apps/gateway/src/runtime/maintenance-gate.test.ts
+++ b/apps/gateway/src/runtime/maintenance-gate.test.ts
@@ -1,0 +1,423 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../app.js";
+import {
+  createMaintenanceActivityGate,
+  createSerializedMaintenanceQueue,
+  createTrackedBackgroundTasks,
+  maintenanceActivityMiddleware,
+  maintenanceDrainTimeoutMs,
+  withPausedActivities,
+} from "./maintenance-gate.js";
+
+describe("maintenance drain timeout", () => {
+  it("uses the configured request window up to a bounded maintenance ceiling", () => {
+    expect(maintenanceDrainTimeoutMs(60_000)).toBe(60_000);
+    expect(maintenanceDrainTimeoutMs(900_000)).toBe(120_000);
+  });
+});
+
+describe("serialized maintenance queue", () => {
+  it("keeps scheduled cleanup and vacuum atomic ahead of a manual request", async () => {
+    const queue = createSerializedMaintenanceQueue();
+    const calls: string[] = [];
+    let finishCleanup = () => {};
+    const cleanupWaiting = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const scheduled = queue.run(async () => {
+      calls.push("scheduled:cleanup");
+      await cleanupWaiting;
+      calls.push("scheduled:vacuum");
+    });
+    const manual = queue.run(async () => {
+      calls.push("manual:vacuum");
+    });
+
+    await Promise.resolve();
+    expect(calls).toEqual(["scheduled:cleanup"]);
+    finishCleanup();
+    await Promise.all([scheduled, manual]);
+    expect(calls).toEqual(["scheduled:cleanup", "scheduled:vacuum", "manual:vacuum"]);
+  });
+
+  it("closes after active maintenance and rejects later work", async () => {
+    const queue = createSerializedMaintenanceQueue();
+    let finish = () => {};
+    const waiting = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const active = queue.run(() => waiting);
+    const closing = queue.closeAndWait();
+
+    await expect(queue.run(async () => {})).rejects.toThrow(
+      "database maintenance is shutting down",
+    );
+    finish();
+    await Promise.all([active, closing]);
+  });
+});
+
+describe("maintenance activity gate", () => {
+  it.each([
+    [
+      "OpenAI Responses",
+      "/v1/responses",
+      {
+        error: {
+          message: "database maintenance in progress",
+          type: "api_error",
+          code: "database_maintenance",
+          trace_id: "trace-maintenance",
+        },
+      },
+    ],
+    [
+      "OpenAI Chat",
+      "/v1/chat/completions",
+      {
+        error: {
+          message: "database maintenance in progress",
+          type: "api_error",
+          code: "database_maintenance",
+          trace_id: "trace-maintenance",
+        },
+      },
+    ],
+    [
+      "Responses WebSocket preflight",
+      "/v1/models",
+      {
+        error: {
+          message: "database maintenance in progress",
+          type: "api_error",
+          code: "database_maintenance",
+          trace_id: "trace-maintenance",
+        },
+      },
+    ],
+    [
+      "Anthropic",
+      "/v1/messages",
+      {
+        type: "error",
+        error: { type: "overloaded_error", message: "database maintenance in progress" },
+      },
+    ],
+    [
+      "Gemini",
+      "/v1beta/models/gemini:generateContent",
+      {
+        error: {
+          code: 503,
+          message: "database maintenance in progress",
+          status: "UNAVAILABLE",
+        },
+      },
+    ],
+    [
+      "Gemini interactions",
+      "/v1beta/interactions",
+      {
+        error: {
+          code: 503,
+          message: "database maintenance in progress",
+          status: "UNAVAILABLE",
+        },
+      },
+    ],
+    [
+      "Admin",
+      "/admin/api/stats",
+      {
+        error: {
+          code: "database_maintenance",
+          message: "database maintenance in progress",
+          trace_id: "trace-maintenance",
+        },
+      },
+    ],
+  ])("returns a protocol-shaped maintenance 503 for %s", async (_name, path, expected) => {
+    const gate = createMaintenanceActivityGate();
+    const app = new Hono<AppEnv>();
+    app.use("*", async (c, next) => {
+      c.set("trace_id", "trace-maintenance");
+      await next();
+    });
+    app.use("*", maintenanceActivityMiddleware(gate));
+    app.all("*", (c) => c.text("work"));
+
+    await gate.pauseAndWait();
+    const response = await app.request(path, { method: "POST" });
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(await response.json()).toEqual(expected);
+  });
+
+  it("rejects new work while paused but keeps health and version available", async () => {
+    const gate = createMaintenanceActivityGate();
+    const app = new Hono<AppEnv>();
+    app.use("*", maintenanceActivityMiddleware(gate));
+    app.get("/healthz", (c) => c.text("ok"));
+    app.get("/version", (c) => c.text("v"));
+    app.get("/work", (c) => c.text("work"));
+
+    await gate.pauseAndWait();
+    expect((await app.request("/work")).status).toBe(503);
+    expect((await app.request("/healthz")).status).toBe(200);
+    expect((await app.request("/version")).status).toBe(200);
+    gate.resume();
+    expect((await app.request("/work")).status).toBe(200);
+  });
+
+  it("waits until an active streaming response body is drained", async () => {
+    const gate = createMaintenanceActivityGate();
+    const app = new Hono<AppEnv>();
+    app.use("*", maintenanceActivityMiddleware(gate));
+    let finish = () => {};
+    app.get(
+      "/stream",
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("one"));
+              finish = () => controller.close();
+            },
+          }),
+        ),
+    );
+
+    const response = await app.request("/stream");
+    let paused = false;
+    const waiting = gate.pauseAndWait().then(() => {
+      paused = true;
+    });
+    await Promise.resolve();
+    expect(paused).toBe(false);
+    finish();
+    expect(await response.text()).toBe("one");
+    await waiting;
+    expect(paused).toBe(true);
+  });
+
+  it("does not deadlock the admitted request that starts maintenance", async () => {
+    const gate = createMaintenanceActivityGate();
+    const app = new Hono<AppEnv>();
+    app.use("*", maintenanceActivityMiddleware(gate));
+    let markStarted = () => {};
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let finish = () => {};
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    app.post("/vacuum", async (c) => {
+      gate.releaseCurrent();
+      markStarted();
+      await finished;
+      return c.text("done");
+    });
+
+    const pendingResponse = app.request("/vacuum", { method: "POST" });
+    await started;
+    await gate.pauseAndWait();
+    gate.resume();
+    finish();
+    const response = await pendingResponse;
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("done");
+  });
+
+  it("resumes paused activities in reverse order when maintenance fails", async () => {
+    const calls: string[] = [];
+    const activity = (name: string) => ({
+      async pauseAndWait() {
+        calls.push(`pause:${name}`);
+      },
+      resume() {
+        calls.push(`resume:${name}`);
+      },
+    });
+
+    await expect(
+      withPausedActivities([activity("http"), activity("worker"), activity("writes")], async () => {
+        calls.push("vacuum");
+        throw new Error("failed");
+      }),
+    ).rejects.toThrow("failed");
+    expect(calls).toEqual([
+      "pause:http",
+      "pause:worker",
+      "pause:writes",
+      "vacuum",
+      "resume:writes",
+      "resume:worker",
+      "resume:http",
+    ]);
+  });
+
+  it("abandons maintenance and resumes already-paused activities when draining times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: string[] = [];
+      const waiting = new Promise<void>(() => {});
+      const maintenance = withPausedActivities(
+        [
+          {
+            async pauseAndWait() {
+              calls.push("pause:http");
+            },
+            resume() {
+              calls.push("resume:http");
+            },
+          },
+          {
+            async pauseAndWait() {
+              calls.push("pause:leaked-task");
+              await waiting;
+            },
+            resume() {
+              calls.push("resume:leaked-task");
+            },
+          },
+        ],
+        async () => {
+          calls.push("vacuum");
+        },
+        { pauseTimeoutMs: 60_000 },
+      );
+
+      const rejection = expect(maintenance).rejects.toThrow("maintenance drain timed out");
+      await vi.advanceTimersByTimeAsync(60_000);
+      await rejection;
+      expect(calls).toEqual([
+        "pause:http",
+        "pause:leaked-task",
+        "resume:leaked-task",
+        "resume:http",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for detached store work after the HTTP response has drained", async () => {
+    const http = createMaintenanceActivityGate();
+    const background = createTrackedBackgroundTasks();
+    const app = new Hono<AppEnv>();
+    app.use("*", maintenanceActivityMiddleware(http));
+    let finishWrite = () => {};
+    app.get("/work", (c) => {
+      background.run(
+        () =>
+          new Promise<void>((resolve) => {
+            finishWrite = resolve;
+          }),
+      );
+      return c.text("done");
+    });
+
+    const response = await app.request("/work");
+    expect(await response.text()).toBe("done");
+    let vacuumStarted = false;
+    const maintenance = withPausedActivities([http, background], async () => {
+      vacuumStarted = true;
+    });
+    await Promise.resolve();
+    expect(vacuumStarted).toBe(false);
+    finishWrite();
+    await maintenance;
+    expect(vacuumStarted).toBe(true);
+  });
+
+  it("drains non-HTTP producers before pausing detached work", async () => {
+    const background = createTrackedBackgroundTasks();
+    let finishWrite = () => {};
+    const producer = {
+      async pauseAndWait() {
+        expect(
+          background.run(
+            () =>
+              new Promise<void>((resolve) => {
+                finishWrite = resolve;
+              }),
+          ),
+        ).toBe(true);
+      },
+      resume() {},
+    };
+    let vacuumStarted = false;
+    const maintenance = withPausedActivities([producer, background], async () => {
+      vacuumStarted = true;
+    });
+    await Promise.resolve();
+    expect(vacuumStarted).toBe(false);
+    finishWrite();
+    await maintenance;
+    expect(vacuumStarted).toBe(true);
+  });
+
+  it("closeAndWait waits for active work and rejects later tasks", async () => {
+    const background = createTrackedBackgroundTasks();
+    let finish = () => {};
+    expect(
+      background.run(
+        () =>
+          new Promise<void>((resolve) => {
+            finish = resolve;
+          }),
+      ),
+    ).toBe(true);
+    let closed = false;
+    const closing = background.closeAndWait().then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+    expect(closed).toBe(false);
+    expect(background.run(async () => {})).toBe(false);
+    finish();
+    await closing;
+    expect(closed).toBe(true);
+  });
+
+  it("tracks nested work spawned by an active task after pause begins", async () => {
+    const background = createTrackedBackgroundTasks();
+    let continueParent = () => {};
+    const parentReady = new Promise<void>((resolve) => {
+      continueParent = resolve;
+    });
+    let parentStarted = () => {};
+    const started = new Promise<void>((resolve) => {
+      parentStarted = resolve;
+    });
+    let finishChild = () => {};
+    background.run(async () => {
+      parentStarted();
+      await parentReady;
+      expect(
+        background.run(
+          () =>
+            new Promise<void>((resolve) => {
+              finishChild = resolve;
+            }),
+        ),
+      ).toBe(true);
+    });
+
+    await started;
+    let paused = false;
+    const waiting = background.pauseAndWait().then(() => {
+      paused = true;
+    });
+    continueParent();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(paused).toBe(false);
+    finishChild();
+    await waiting;
+    expect(paused).toBe(true);
+  });
+});

--- a/apps/gateway/src/runtime/maintenance-gate.ts
+++ b/apps/gateway/src/runtime/maintenance-gate.ts
@@ -1,0 +1,263 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  anthropicTransformErrorOut,
+  geminiTransformErrorOut,
+  openaiTransformErrorOut,
+} from "@helm/core";
+import { makeHelmError } from "@helm/shared";
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "../app.js";
+
+type Activity = object;
+
+export function maintenanceDrainTimeoutMs(requestTimeoutMs: number): number {
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new Error("requestTimeoutMs must be positive");
+  }
+  return Math.min(Math.floor(requestTimeoutMs), 120_000);
+}
+
+export function createSerializedMaintenanceQueue() {
+  let tail: Promise<void> = Promise.resolve();
+  let closed = false;
+
+  return {
+    run<T>(work: () => Promise<T>): Promise<T> {
+      if (closed) return Promise.reject(new Error("database maintenance is shutting down"));
+      const result = tail.then(work, work);
+      tail = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
+    async closeAndWait(): Promise<void> {
+      closed = true;
+      await tail;
+    },
+  };
+}
+
+export function createMaintenanceActivityGate() {
+  const current = new AsyncLocalStorage<Activity>();
+  const active = new Set<Activity>();
+  const idleWaiters: Array<() => void> = [];
+  let paused = false;
+
+  const release = (activity: Activity): void => {
+    if (!active.delete(activity) || active.size !== 0) return;
+    for (const resolve of idleWaiters.splice(0)) resolve();
+  };
+  const releaseCurrent = (): void => {
+    const caller = current.getStore();
+    if (caller) release(caller);
+  };
+
+  return {
+    enter(): { ok: true; activity: Activity } | { ok: false } {
+      if (paused) return { ok: false };
+      const activity = {};
+      active.add(activity);
+      return { ok: true, activity };
+    },
+    run<T>(activity: Activity, work: () => T): T {
+      return current.run(activity, work);
+    },
+    release,
+    releaseCurrent,
+    async pauseAndWait(): Promise<void> {
+      paused = true;
+      releaseCurrent();
+      if (active.size === 0) return;
+      await new Promise<void>((resolve) => idleWaiters.push(resolve));
+    },
+    resume(): void {
+      paused = false;
+    },
+  };
+}
+
+export type MaintenanceActivityGate = ReturnType<typeof createMaintenanceActivityGate>;
+
+const MAINTENANCE_MESSAGE = "database maintenance in progress";
+
+function maintenanceErrorBody(path: string, traceId: string) {
+  const error = makeHelmError({
+    error_class: "lane_unavailable",
+    message: MAINTENANCE_MESSAGE,
+    trace_id: traceId,
+  });
+  if (path === "/v1/messages" || path.startsWith("/v1/messages/")) {
+    return anthropicTransformErrorOut(error).body;
+  }
+  if (
+    path.startsWith("/v1beta/models/") ||
+    path.startsWith("/models/") ||
+    path === "/v1beta/interactions"
+  ) {
+    return geminiTransformErrorOut(error).body;
+  }
+  if (
+    path === "/v1/models" ||
+    path.startsWith("/v1/") ||
+    path === "/responses" ||
+    path.startsWith("/responses/") ||
+    path.startsWith("/openai/") ||
+    path === "/chat/completions" ||
+    path.startsWith("/engines/")
+  ) {
+    const body = openaiTransformErrorOut(error).body;
+    return { ...body, error: { ...body.error, code: "database_maintenance" } };
+  }
+  return {
+    error: {
+      code: "database_maintenance",
+      message: MAINTENANCE_MESSAGE,
+      trace_id: traceId,
+    },
+  };
+}
+
+export function createTrackedBackgroundTasks() {
+  type TaskToken = object;
+  const current = new AsyncLocalStorage<TaskToken>();
+  const active = new Map<TaskToken, Promise<void>>();
+  let state: "open" | "paused" | "closed" = "open";
+  const waitForIdle = async (): Promise<void> => {
+    while (active.size > 0) await Promise.all(active.values());
+  };
+
+  return {
+    run(task: () => Promise<unknown>, onError: (error: unknown) => void = () => {}): boolean {
+      const parent = current.getStore();
+      if (state !== "open" && (parent === undefined || !active.has(parent))) return false;
+      const token = {};
+      const promise = Promise.resolve()
+        .then(() => current.run(token, task))
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          try {
+            onError(error);
+          } catch {
+            // Logging is advisory; a detached failure must stay fail-open.
+          }
+        })
+        .finally(() => active.delete(token));
+      active.set(token, promise);
+      return true;
+    },
+    async pauseAndWait(): Promise<void> {
+      if (state === "open") state = "paused";
+      await waitForIdle();
+    },
+    resume(): void {
+      if (state === "paused") state = "open";
+    },
+    async closeAndWait(): Promise<void> {
+      state = "closed";
+      await waitForIdle();
+    },
+  };
+}
+
+export interface PausableActivity {
+  pauseAndWait(): Promise<void>;
+  resume(): void;
+}
+
+export async function withPausedActivities<T>(
+  activities: readonly PausableActivity[],
+  work: () => Promise<T>,
+  options: { pauseTimeoutMs?: number } = {},
+): Promise<T> {
+  const paused: PausableActivity[] = [];
+  const pauseTimeoutMs = options.pauseTimeoutMs;
+  const deadline =
+    pauseTimeoutMs !== undefined && Number.isFinite(pauseTimeoutMs) && pauseTimeoutMs > 0
+      ? Date.now() + pauseTimeoutMs
+      : null;
+  try {
+    for (const activity of activities) {
+      paused.push(activity);
+      const draining = activity.pauseAndWait();
+      if (deadline === null) {
+        await draining;
+        continue;
+      }
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) throw new Error("maintenance drain timed out");
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          draining,
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error("maintenance drain timed out")),
+              remainingMs,
+            );
+          }),
+        ]);
+      } finally {
+        if (timeout !== undefined) clearTimeout(timeout);
+      }
+    }
+    return await work();
+  } finally {
+    for (const activity of paused.reverse()) activity.resume();
+  }
+}
+
+function responseWithRelease(response: Response, release: () => void): Response {
+  if (response.body === null) {
+    release();
+    return response;
+  }
+  const reader = response.body.getReader();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const next = await reader.read();
+          if (next.done) {
+            release();
+            controller.close();
+          } else {
+            controller.enqueue(next.value);
+          }
+        } catch (error) {
+          release();
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader.cancel(reason);
+        } finally {
+          release();
+        }
+      },
+    }),
+    response,
+  );
+}
+
+export function maintenanceActivityMiddleware(
+  gate: MaintenanceActivityGate,
+): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    if (c.req.path === "/healthz" || c.req.path === "/version") return await next();
+    const entered = gate.enter();
+    if (!entered.ok) {
+      c.header("Retry-After", "1");
+      return c.json(maintenanceErrorBody(c.req.path, c.get("trace_id") ?? "unknown"), 503);
+    }
+    let delegated = false;
+    try {
+      await gate.run(entered.activity, next);
+      c.res = responseWithRelease(c.res, () => gate.release(entered.activity));
+      delegated = true;
+    } finally {
+      if (!delegated) gate.release(entered.activity);
+    }
+  };
+}

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { createBodyMemoryAdmission, readAdmittedRequestBody } from "./memory-admission.js";
+
+describe("body memory admission", () => {
+  it("charges a capacity-derived floor for tiny requests", () => {
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      maxWireBytes: 100,
+      jsonAmplification: 2,
+      minRequestChargeBytes: 40,
+    });
+
+    const first = admission.acquire(1);
+    const second = admission.acquire(1);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(admission.reservedBytes).toBe(80);
+    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy" });
+    if (first.ok) first.lease.release();
+    if (second.ok) second.lease.release();
+    expect(admission.reservedBytes).toBe(0);
+  });
+
+  it("pauses new requests and waits for active leases before maintenance", async () => {
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    const active = admission.acquire(5);
+    expect(active.ok).toBe(true);
+    admission.pause();
+    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy" });
+    let idle = false;
+    const waiting = admission.waitForIdle().then(() => {
+      idle = true;
+    });
+    await Promise.resolve();
+    expect(idle).toBe(false);
+    if (active.ok) active.lease.release();
+    await waiting;
+    admission.resume();
+    expect(admission.acquire(1).ok).toBe(true);
+  });
+
+  it("charges parsed JSON amplification and releases the shared budget", () => {
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    const first = admission.acquire(6);
+    expect(first.ok).toBe(true);
+    expect(admission.reservedBytes).toBe(36);
+    expect(admission.acquire(5)).toMatchObject({ ok: false, reason: "busy" });
+    if (first.ok) first.lease.release();
+    expect(admission.reservedBytes).toBe(0);
+  });
+
+  it("bounds a streaming body before JSON parsing and returns its lease", async () => {
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 120,
+      maxWireBytes: 20,
+      jsonAmplification: 6,
+    });
+    const admitted = await readAdmittedRequestBody(
+      new Request("http://helm.test/v1/responses", { method: "POST", body: '{"ok":true}' }),
+      admission,
+    );
+    expect(admitted.text).toBe('{"ok":true}');
+    expect(admission.reservedBytes).toBeGreaterThan(0);
+    admitted.release();
+    expect(admission.reservedBytes).toBe(0);
+
+    await expect(
+      readAdmittedRequestBody(
+        new Request("http://helm.test/v1/responses", { method: "POST", body: "x".repeat(21) }),
+        admission,
+      ),
+    ).rejects.toMatchObject({ status: 413, code: "request_too_large" });
+  });
+
+  it("best-effort cancels the body when Content-Length is rejected before reading", async () => {
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        canceled = true;
+      },
+    });
+    const request = new Request("http://helm.test/v1/responses", {
+      method: "POST",
+      headers: { "content-length": "11" },
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    await expect(readAdmittedRequestBody(request, admission)).rejects.toMatchObject({
+      status: 413,
+      code: "request_too_large",
+    });
+    expect(canceled).toBe(true);
+    expect(admission.reservedBytes).toBe(0);
+  });
+});

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -1,0 +1,162 @@
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "../app.js";
+
+export class RequestAdmissionError extends Error {
+  constructor(
+    readonly status: 413 | 503,
+    readonly code: "request_too_large" | "server_overloaded",
+    message: string,
+  ) {
+    super(message);
+    this.name = "RequestAdmissionError";
+  }
+}
+
+export function createBodyMemoryAdmission(options: {
+  activeRequestBytes: number;
+  maxWireBytes: number;
+  jsonAmplification: number;
+  minRequestChargeBytes?: number;
+}) {
+  let reservedBytes = 0;
+  let paused = false;
+  const idleWaiters: Array<() => void> = [];
+  const resolveIdle = () => {
+    if (reservedBytes !== 0) return;
+    for (const resolve of idleWaiters.splice(0)) resolve();
+  };
+  const minRequestChargeBytes =
+    options.minRequestChargeBytes ?? Math.max(1, Math.floor(options.activeRequestBytes * 0.01));
+  const charge = (wireBytes: number): number =>
+    Math.max(minRequestChargeBytes, Math.ceil(Math.max(0, wireBytes) * options.jsonAmplification));
+  const rejection = (wireBytes: number) =>
+    wireBytes > options.maxWireBytes
+      ? { ok: false as const, reason: "too_large" as const }
+      : { ok: false as const, reason: "busy" as const };
+
+  return {
+    maxWireBytes: options.maxWireBytes,
+    acquire(wireBytes: number) {
+      if (paused) return { ok: false as const, reason: "busy" as const };
+      let held = charge(wireBytes);
+      if (wireBytes > options.maxWireBytes || reservedBytes + held > options.activeRequestBytes) {
+        return rejection(wireBytes);
+      }
+      reservedBytes += held;
+      let released = false;
+      return {
+        ok: true as const,
+        lease: {
+          resize(nextWireBytes: number) {
+            if (released) return { ok: false as const, reason: "busy" as const };
+            const next = charge(nextWireBytes);
+            if (
+              nextWireBytes > options.maxWireBytes ||
+              reservedBytes - held + next > options.activeRequestBytes
+            ) {
+              return rejection(nextWireBytes);
+            }
+            reservedBytes += next - held;
+            held = next;
+            return { ok: true as const };
+          },
+          release() {
+            if (released) return;
+            released = true;
+            reservedBytes -= held;
+            resolveIdle();
+          },
+        },
+      };
+    },
+    pause() {
+      paused = true;
+    },
+    resume() {
+      paused = false;
+    },
+    waitForIdle(): Promise<void> {
+      if (reservedBytes === 0) return Promise.resolve();
+      return new Promise((resolve) => idleWaiters.push(resolve));
+    },
+    get reservedBytes() {
+      return reservedBytes;
+    },
+  };
+}
+
+export type BodyMemoryAdmission = ReturnType<typeof createBodyMemoryAdmission>;
+
+export function memoryAdmissionReleaseGuard(): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    try {
+      await next();
+    } finally {
+      c.get("requestMemoryRelease")?.();
+    }
+  };
+}
+
+declare module "hono" {
+  interface ContextVariableMap {
+    requestMemoryRelease?: (() => void) | undefined;
+  }
+}
+
+function admissionError(reason: "too_large" | "busy", maxWireBytes: number) {
+  return reason === "too_large"
+    ? new RequestAdmissionError(
+        413,
+        "request_too_large",
+        `request body exceeds the runtime capacity limit of ${maxWireBytes} bytes`,
+      )
+    : new RequestAdmissionError(
+        503,
+        "server_overloaded",
+        "request memory capacity is temporarily exhausted",
+      );
+}
+
+export async function readAdmittedRequestBody(
+  request: Request,
+  admission: BodyMemoryAdmission,
+): Promise<{ text: string; release: () => void }> {
+  const declared = Number(request.headers.get("content-length"));
+  const initialBytes =
+    request.headers.has("transfer-encoding") || !Number.isFinite(declared) || declared < 0
+      ? 0
+      : declared;
+  const acquired = admission.acquire(initialBytes);
+  if (!acquired.ok) {
+    await request.body?.cancel().catch(() => {});
+    throw admissionError(acquired.reason, admission.maxWireBytes);
+  }
+  const { lease } = acquired;
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    const reader = request.body?.getReader();
+    if (reader) {
+      for (;;) {
+        const next = await reader.read();
+        if (next.done) break;
+        bytes += next.value.byteLength;
+        const resized = lease.resize(bytes);
+        if (!resized.ok) {
+          await reader.cancel().catch(() => {});
+          throw admissionError(resized.reason, admission.maxWireBytes);
+        }
+        chunks.push(next.value);
+      }
+    }
+    const resized = lease.resize(bytes);
+    if (!resized.ok) throw admissionError(resized.reason, admission.maxWireBytes);
+    return {
+      text: Buffer.concat(chunks).toString("utf8"),
+      release: lease.release,
+    };
+  } catch (error) {
+    lease.release();
+    throw error;
+  }
+}

--- a/apps/gateway/src/runtime/write-queue.test.ts
+++ b/apps/gateway/src/runtime/write-queue.test.ts
@@ -264,7 +264,7 @@ describe("createWriteQueue", () => {
       log: (m) => logs.push(m),
       flushIntervalMs: 10_000,
       maxDepth: 10_000, // far out of reach
-      maxBytes: 1_000, // ~1KB budget: two 600B payloads must not both fit
+      maxBytes: 1_500, // one retained 600-char payload fits; two do not
       flushBytes: 10_000_000, // park eager byte-flush so we observe shedding, not flushing
     });
 
@@ -277,6 +277,30 @@ describe("createWriteQueue", () => {
     expect(logs.some((l) => l.includes("overflow"))).toBe(true);
   });
 
+  it("charges retained strings by worst-case V8 bytes instead of UTF-16 code units", async () => {
+    const sink = fakeSink();
+    const logs: string[] = [];
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: (message) => logs.push(message),
+      flushIntervalMs: 10_000,
+      maxBytes: 10,
+      flushBytes: 10_000,
+    });
+
+    q.enqueuePayload({
+      requestId: "unicode",
+      requestJson: "😀😀😀",
+      responseJson: null,
+      upstreamRequestJson: null,
+      createdAt: new Date(0),
+    });
+    await q.flush();
+
+    expect(sink.payloadCalls).toHaveLength(0);
+    expect(logs).toContain("writequeue.overflow");
+  });
+
   it("on byte overflow, sheds PAYLOAD (debug) first and keeps TELEMETRY (audit)", async () => {
     const sink = fakeSink();
     const q = createWriteQueue({
@@ -284,7 +308,7 @@ describe("createWriteQueue", () => {
       log: () => {},
       flushIntervalMs: 10_000,
       maxDepth: 10_000,
-      maxBytes: 1_000,
+      maxBytes: 1_500,
       flushBytes: 10_000_000,
     });
 
@@ -309,7 +333,7 @@ describe("createWriteQueue", () => {
       log: () => {},
       flushIntervalMs: 10_000,
       maxDepth: 10_000,
-      maxBytes: 1_000,
+      maxBytes: 1_500,
       flushBytes: 10_000_000, // never byte-flush; force the budget to hold via shedding alone
     });
 
@@ -391,7 +415,7 @@ describe("createWriteQueue", () => {
       telemetry: sink,
       log: () => {},
       flushIntervalMs: 10_000,
-      maxBytes: 1_000,
+      maxBytes: 1_500,
     });
     q.enqueueSession(async () => {
       ran.push("session");
@@ -400,6 +424,73 @@ describe("createWriteQueue", () => {
     await q.flush();
     expect(ran).toEqual(["session"]);
     expect(q.depth).toBe(0);
+  });
+
+  it("charges retained task closures until they settle, then releases their dynamic budget", async () => {
+    const sink = fakeSink();
+    const logs: string[] = [];
+    let release!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: (message) => logs.push(message),
+      flushIntervalMs: 10_000,
+      // The explicit budget keeps this test independent of the host memory limit.
+      // 100 wire bytes are charged at the runtime JSON-amplification multiplier.
+      maxBytes: 1_000,
+    });
+    const ran: string[] = [];
+
+    q.enqueueTask(
+      async () => {
+        await blocker;
+        ran.push("first");
+      },
+      { retainedBytes: 100 },
+    );
+    await Promise.resolve(); // let the first task become active
+    q.enqueueTask(
+      async () => {
+        ran.push("rejected");
+      },
+      { retainedBytes: 100 },
+    );
+    expect(logs).toContain("writequeue.task_overflow");
+
+    release();
+    await q.flush();
+    q.enqueueTask(
+      async () => {
+        ran.push("after-release");
+      },
+      { retainedBytes: 100 },
+    );
+    await q.flush();
+    expect(ran).toEqual(["first", "after-release"]);
+  });
+
+  it("sheds payload capture before admitting a retained side-effect task", async () => {
+    const sink = fakeSink();
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxBytes: 1_500,
+      flushBytes: 10_000,
+    });
+    const ran: string[] = [];
+    q.enqueuePayload(bigPayload("payload", 700));
+    q.enqueueTask(
+      async () => {
+        ran.push("observe");
+      },
+      { retainedBytes: 200 },
+    );
+    await q.flush();
+    expect(ran).toEqual(["observe"]);
+    expect(sink.payloadCalls).toHaveLength(0);
   });
 
   it("rejects an oversized session without dropping audit telemetry", async () => {
@@ -428,7 +519,7 @@ describe("createWriteQueue", () => {
       telemetry: sink,
       log: () => {},
       flushIntervalMs: 10_000,
-      maxBytes: 1_000,
+      maxBytes: 1_500,
       flushBytes: 10_000,
     });
     q.enqueueTelemetry(tele("audit"));
@@ -446,6 +537,28 @@ describe("createWriteQueue", () => {
     q.enqueueTask(async () => {});
     await q.stop();
     expect(sink.inserts).toHaveLength(1);
+  });
+
+  it("pauses new writes while maintenance drains the existing queue", async () => {
+    const sink = fakeSink();
+    const logs: string[] = [];
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: (message) => logs.push(message),
+      flushIntervalMs: 10_000,
+    });
+    q.enqueueTelemetry(tele("before"));
+
+    await q.pauseAndFlush();
+    q.enqueueTelemetry(tele("during"));
+    q.resume();
+    q.enqueueTelemetry(tele("after"));
+    await q.flush();
+
+    expect(
+      sink.inserts.map((input) => (input.decision as { request_id: string }).request_id),
+    ).toEqual(["before", "after"]);
+    expect(logs).toContain("writequeue.paused");
   });
 
   it("fires onTaskDrain ONLY for tasks flagged wakeOnSettle (inbound observe must not wake)", async () => {

--- a/apps/gateway/src/runtime/write-queue.ts
+++ b/apps/gateway/src/runtime/write-queue.ts
@@ -1,4 +1,9 @@
-import type { InsertPayloadInput, InsertTelemetryInput, TelemetryStore } from "@helm/core";
+import {
+  type InsertPayloadInput,
+  type InsertTelemetryInput,
+  runtimeMemoryBudget,
+  type TelemetryStore,
+} from "@helm/core";
 
 // The slice of TelemetryStore the queue drives. Batch methods are optional (the
 // queue falls back to per-row writes when an adapter lacks them).
@@ -24,7 +29,7 @@ export interface WriteQueueDeps {
   // Past this budget the queue sheds buffered writes (payload first — see
   // shedBufferedWrite) so a downstream stall (e.g. the 4am VACUUM holding the write
   // lock) can never balloon the heap. maxDepth stays as a row-count backstop; EITHER
-  // limit tripping triggers a shed/reject. Default 256MiB.
+  // limit tripping triggers a shed/reject. Default scales from the V8 heap limit.
   maxBytes?: number;
   // Flush a buffer eagerly once its accumulated bytes reach this, so a few giant
   // payloads can't coalesce into a multi-hundred-MB single transaction (maxBatch=256
@@ -53,9 +58,15 @@ export interface WriteQueue {
   // `wakeOnSettle` fires onTaskDrain after THIS task settles — set it only on the
   // turn's FINAL write (the outbound observe) so the memory worker is woken once the
   // whole turn is persisted, never mid-turn after the inbound-only write.
-  enqueueTask(task: () => Promise<void>, opts?: { wakeOnSettle?: boolean }): void;
+  enqueueTask(
+    task: () => Promise<void>,
+    opts?: { wakeOnSettle?: boolean; retainedBytes?: number },
+  ): void;
   // Drain everything currently buffered/queued and resolve when the DB has it.
   flush(): Promise<void>;
+  // Maintenance barrier: reject new deferred writes, then drain everything admitted.
+  pauseAndFlush(): Promise<void>;
+  resume(): void;
   // Stop the idle timer and flush once. Idempotent. For graceful shutdown.
   stop(): Promise<void>;
   // Current backlog size (for tests / metrics).
@@ -76,8 +87,9 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   const flushIntervalMs = deps.flushIntervalMs ?? 25;
   const maxBatch = deps.maxBatch ?? 256;
   const maxDepth = deps.maxDepth ?? 10_000;
-  const maxBytes = deps.maxBytes ?? 256 * 1024 * 1024;
+  const maxBytes = deps.maxBytes ?? runtimeMemoryBudget().writeQueueBytes;
   const flushBytes = deps.flushBytes ?? Math.floor(maxBytes / 4);
+  const jsonAmplification = runtimeMemoryBudget().jsonAmplification;
 
   let telemetryBuf: InsertTelemetryInput[] = [];
   let payloadBuf: InsertPayloadInput[] = [];
@@ -98,6 +110,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   let inFlightBytes = 0;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
+  let paused = false;
   // All DB writes (batch flushes) run on this serial chain so two flushes can never
   // interleave; flush()/stop() await its tail.
   let writeChain: Promise<void> = Promise.resolve();
@@ -105,29 +118,33 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   let taskChain: Promise<void> = Promise.resolve();
   let pendingTasks = 0;
   let pendingSessionBytes = 0;
+  let pendingTaskBytes = 0;
 
   const depth = (): number => telemetryBuf.length + payloadBuf.length + pendingTasks;
 
-  // Cheap, allocation-free byte estimate of a payload row: the serialized fields are
-  // already strings, so summing their .length is O(1)-per-row and dominates the
-  // footprint (the payload IS the request/response/upstream JSON). UTF-16 .length
-  // slightly under-counts multi-byte chars, but we only need a consistent proxy to
-  // bound the heap, not an exact byte tally.
+  // Cheap, allocation-free worst-case V8 estimate: retained JS strings may occupy
+  // two bytes per UTF-16 code unit. Object/array overhead is small beside the bodies.
   const payloadCost = (input: InsertPayloadInput): number =>
-    input.requestJson.length +
-    (input.responseJson?.length ?? 0) +
-    (input.upstreamRequestJson?.length ?? 0);
+    2 *
+    (input.requestJson.length +
+      (input.responseJson?.length ?? 0) +
+      (input.upstreamRequestJson?.length ?? 0));
 
   // Telemetry rows are tiny vs payloads, but a redacted decision can still be a few KB.
   // Approximate it once at enqueue with a single stringify of the decision (the bulk
   // of the row) — never recomputed afterward; the cached cost rides the byte arrays.
   const telemetryCost = (input: InsertTelemetryInput): number => {
     try {
-      return JSON.stringify(input.decision).length;
+      return JSON.stringify(input.decision).length * 2;
     } catch {
       return 0; // a non-serializable decision can't bloat the heap as a string anyway
     }
   };
+
+  // Deferred closures retain parsed/stringified request data as well as the original
+  // strings. Charge their wire-size estimate using the process-derived multiplier.
+  const retainedTaskCost = (bytes: number): number =>
+    Number.isFinite(bytes) && bytes > 0 ? Math.ceil(bytes * jsonAmplification) : 0;
 
   const clearTimer = (): void => {
     if (timer !== null) {
@@ -229,7 +246,8 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   // overshoot the budget, and a write stall must not pile up batches past the cap.
   const overBudget = (incomingBytes: number): boolean =>
     depth() >= maxDepth ||
-    bufferedBytes + inFlightBytes + pendingSessionBytes + incomingBytes > maxBytes;
+    bufferedBytes + inFlightBytes + pendingSessionBytes + pendingTaskBytes + incomingBytes >
+      maxBytes;
 
   const shedPayload = (): boolean => {
     if (payloadBuf.length === 0) return false;
@@ -274,6 +292,10 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   return {
     enqueueTelemetry(input: InsertTelemetryInput): void {
       if (stopped) return;
+      if (paused) {
+        log("writequeue.paused");
+        return;
+      }
       const cost = telemetryCost(input);
       if (!admitBufferedWrite(cost)) return;
       telemetryBuf.push(input);
@@ -287,6 +309,10 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
 
     enqueuePayload(input: InsertPayloadInput): void {
       if (stopped) return;
+      if (paused) {
+        log("writequeue.paused");
+        return;
+      }
       const cost = payloadCost(input);
       if (!admitBufferedWrite(cost)) return;
       payloadBuf.push(input);
@@ -298,7 +324,11 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
 
     enqueueSession(task: () => Promise<void>, bytes: number): void {
       if (stopped) return;
-      const cost = Math.max(0, bytes);
+      if (paused) {
+        log("writequeue.paused");
+        return;
+      }
+      const cost = retainedTaskCost(bytes);
       while (overBudget(cost) && shedPayload()) {
         /* payload is less valuable than a semantic session transcript */
       }
@@ -320,14 +350,26 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
       });
     },
 
-    enqueueTask(task: () => Promise<void>, opts?: { wakeOnSettle?: boolean }): void {
+    enqueueTask(
+      task: () => Promise<void>,
+      opts?: { wakeOnSettle?: boolean; retainedBytes?: number },
+    ): void {
       if (stopped) return;
-      if (pendingTasks >= maxDepth) {
-        log("writequeue.overflow");
+      if (paused) {
+        log("writequeue.paused");
+        return;
+      }
+      const cost = retainedTaskCost(opts?.retainedBytes ?? 0);
+      while (overBudget(cost) && shedPayload()) {
+        /* payload capture is less valuable than a deferred semantic write */
+      }
+      if (overBudget(cost)) {
+        log("writequeue.task_overflow");
         return;
       }
       const wakeOnSettle = opts?.wakeOnSettle === true;
       pendingTasks++;
+      pendingTaskBytes += cost;
       taskChain = taskChain.then(async () => {
         try {
           await task();
@@ -335,6 +377,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
           log("writequeue.task_failed");
         } finally {
           pendingTasks--;
+          pendingTaskBytes -= cost;
           // Fire the post-task hook (memory-worker wake) ONLY for tasks that opted in
           // — the turn's final/outbound observe. Waking after the inbound-only write
           // could drain the observer job before the assistant turn is persisted.
@@ -356,6 +399,18 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
       await doFlush();
       await writeChain;
       await taskChain;
+    },
+
+    async pauseAndFlush(): Promise<void> {
+      paused = true;
+      clearTimer();
+      await doFlush();
+      await writeChain;
+      await taskChain;
+    },
+
+    resume(): void {
+      if (!stopped) paused = false;
     },
 
     async stop(): Promise<void> {

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -524,6 +524,10 @@ function codexJwt(payload: Record<string, unknown>): string {
 
 describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
   const noop = () => {};
+  const runInBackground = (task: () => Promise<unknown>) => {
+    void task();
+    return true;
+  };
 
   it("routes xAI subscription OAuth through the generic Responses proxy by default", async () => {
     const { ctx, config } = oauthStores();
@@ -1265,7 +1269,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
     // Codex is now routable: one synthetic provider keyed by providerId, executor
     // type `openai-responses`, served by ONE pool client.
@@ -1349,6 +1353,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       {
         catalog,
         clientVersion: DEFAULT_OPENAI_CODEX_CLIENT_VERSION,
+        runInBackground,
         userAgent: "codex_cli_rs/test",
       },
     );
@@ -1528,7 +1533,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
     const client = poolClients.get("openai-codex");
     if (!client?.nativePassthrough) throw new Error("Codex native passthrough is unavailable");
@@ -1668,7 +1673,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
     const client = poolClients.get("openai-codex");
     if (!client) throw new Error("Codex pool is unavailable");
@@ -1728,7 +1733,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
 
     expect(result.providers).toEqual([]);
@@ -1808,7 +1813,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
 
     expect(modelCalls).toBe(2);
@@ -1858,7 +1863,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
 
     expect((result.providers[0]?.models ?? []).map((model) => model.alias)).toEqual([
@@ -1916,7 +1921,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
     await poolClients.get("openai-codex")?.chatCompletion({
       model: "gpt-5.6-luna",
@@ -1990,7 +1995,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
 
     await poolClients.get("openai-codex")?.chatCompletion({
@@ -2065,7 +2070,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
 
     await poolClients.get("openai-codex")?.chatCompletion({
@@ -2153,7 +2158,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       undefined,
       undefined,
       undefined,
-      { catalog },
+      { catalog, runInBackground },
     );
 
     await poolClients.get("openai-codex")?.chatCompletion({

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import {
   type AnthropicSSEEvent,
+  AUTO_VACUUM_CHECK_INTERVAL_MS,
   anthropicTransformer,
   type BudgetCaps,
   bootstrapRootKey,
@@ -15,6 +16,7 @@ import {
   checkTlsTransportAvailable,
   codexActiveLimitIdFromProviderRaw,
   createAnthropicClient,
+  createAutoVacuumRunner,
   createBudgetGate,
   createCachedKeyStore,
   createCircuitBreaker,
@@ -106,10 +108,10 @@ import {
   runEmbeddingJob,
   runObserverJob,
   runReflectorJob,
+  runtimeMemoryBudget,
   type StoreSet,
   saveRuntimeSettings,
   settleBudget,
-  shouldAutoVacuum,
   startCleanupScheduler,
   startMemoryWorker,
   startSignalScheduler,
@@ -209,6 +211,7 @@ import type { MessagesIdentity, RouteError } from "./routes/messages.js";
 import { registerMessagesRoute } from "./routes/messages.js";
 import { createMessagesPipeline } from "./routes/messages-pipeline.js";
 import { registerModelsRoute } from "./routes/models.js";
+import { clearSessionCaptureCache } from "./routes/payload-capture.js";
 import { registerPortalApi } from "./routes/portal/index.js";
 import { mountPortalStatic, PORTAL_BUILD_ROOT } from "./routes/portal-static.js";
 import {
@@ -217,6 +220,15 @@ import {
   registerResponsesRoute,
 } from "./routes/responses.js";
 import { registerUsageStatsRoute } from "./routes/usage.js";
+import {
+  createMaintenanceActivityGate,
+  createSerializedMaintenanceQueue,
+  createTrackedBackgroundTasks,
+  maintenanceDrainTimeoutMs,
+  type PausableActivity,
+  withPausedActivities,
+} from "./runtime/maintenance-gate.js";
+import { type BodyMemoryAdmission, createBodyMemoryAdmission } from "./runtime/memory-admission.js";
 import {
   markServingAccount,
   type ServingAccount,
@@ -232,6 +244,7 @@ export interface ServerHandle {
   host: string;
   closeResponsesWebSocketSession?: (sessionId: string) => Promise<void>;
   responsesWebSocketSessionProof?: string;
+  responsesMemoryAdmission?: BodyMemoryAdmission;
   // Stop background workers (e.g. the Agentic Signals scheduler). Optional and
   // safe to skip — the timers are unref'd so they never block process exit.
   dispose?: () => void | Promise<void>;
@@ -369,6 +382,7 @@ export interface OAuthRuntimeCtx {
 
 export interface CodexOAuthRuntime {
   catalog: CodexModelCatalog;
+  runInBackground: (task: () => Promise<unknown>, onError?: (error: unknown) => void) => boolean;
   clientVersion?: string;
   userAgent?: string;
   onCatalogChanged?: () => void;
@@ -381,6 +395,7 @@ interface CodexAccountRuntime {
   accountIdentity: OpenAICodexIdentity;
   clientVersion: string;
   userAgent: string;
+  runInBackground: CodexOAuthRuntime["runInBackground"];
   onCatalogChanged?: () => void;
 }
 
@@ -435,6 +450,7 @@ async function loadCodexAccountCatalog(input: {
   clientVersion: string;
   catalog: CodexModelCatalog;
   onCatalogChanged?: () => void;
+  runInBackground: CodexOAuthRuntime["runInBackground"];
 }): Promise<LoadedCodexAccountCatalog | null> {
   const clientVersion = normalizeOpenAICodexClientVersion(input.clientVersion);
   if (clientVersion === null) return null;
@@ -481,6 +497,7 @@ async function loadCodexAccountCatalog(input: {
       accountIdentity,
       clientVersion,
       userAgent,
+      runInBackground: input.runInBackground,
       onCatalogChanged: input.onCatalogChanged,
     },
   };
@@ -542,6 +559,7 @@ export async function loadCodexCatalogForClientVersion(input: {
         proxyFetch,
         clientVersion,
         catalog: input.catalog,
+        runInBackground: () => false,
       });
     } catch {
       continue;
@@ -1019,6 +1037,7 @@ export async function synthesizeOAuthProviders(
           proxyFetch,
           clientVersion,
           catalog: codex.catalog,
+          runInBackground: codex.runInBackground,
           onCatalogChanged: codex.onCatalogChanged,
         });
         discovered = loaded
@@ -1501,11 +1520,13 @@ function createProviderClient(
           : undefined,
         onModelsEtag: codexRuntime
           ? (etag) => {
-              void codexRuntime.catalog.observeEtag(
-                codexRuntime.key,
-                etag,
-                codexRuntime.fetchModels,
-                codexRuntime.onCatalogChanged,
+              codexRuntime.runInBackground(() =>
+                codexRuntime.catalog.observeEtag(
+                  codexRuntime.key,
+                  etag,
+                  codexRuntime.fetchModels,
+                  codexRuntime.onCatalogChanged,
+                ),
               );
             }
           : undefined,
@@ -1744,6 +1765,28 @@ export async function buildServer(
 ): Promise<ServerHandle> {
   const logger = opts.logger ?? createJsonLogger();
   const responsesWebSocketSessionProof = randomUUID();
+  const memoryBudget = runtimeMemoryBudget();
+  const maintenanceActivityGate = createMaintenanceActivityGate();
+  const backgroundTasks = createTrackedBackgroundTasks();
+  const requestBodyMemoryAdmission = createBodyMemoryAdmission({
+    activeRequestBytes: memoryBudget.activeRequestBytes,
+    maxWireBytes: memoryBudget.maxWireBytes,
+    jsonAmplification: memoryBudget.jsonAmplification,
+    minRequestChargeBytes: memoryBudget.minRequestChargeBytes,
+  });
+  logger.log("info", "runtime.memory_budget", {
+    heap_limit_bytes: memoryBudget.heapLimitBytes,
+    process_limit_bytes: memoryBudget.processLimitBytes,
+    active_request_bytes: memoryBudget.activeRequestBytes,
+    max_wire_bytes: memoryBudget.maxWireBytes,
+    min_request_charge_bytes: memoryBudget.minRequestChargeBytes,
+    write_queue_bytes: memoryBudget.writeQueueBytes,
+    session_cache_bytes: memoryBudget.sessionCacheBytes,
+    response_capture_bytes: memoryBudget.responseCaptureBytes,
+    sse_tail_chars: memoryBudget.sseTailChars,
+    sqlite_page_cache_bytes: memoryBudget.sqlitePageCacheBytes,
+    sqlite_maintenance_cache_bytes: memoryBudget.sqliteMaintenanceCacheBytes,
+  });
   const config = loadConfig({ configDir: opts.configDir ?? "./config" });
   // Validate the optional Grok proxy protocol override before opening stores or
   // starting background work. Invalid runtime configuration must fail closed at
@@ -1833,13 +1876,18 @@ export async function buildServer(
   const codexRuntime: CodexOAuthRuntime | undefined = codexModelCatalog
     ? {
         catalog: codexModelCatalog,
+        runInBackground: backgroundTasks.run,
         clientVersion: codexClientVersion,
         userAgent: codexUserAgent,
         onCatalogChanged: () => {
-          void rebuildOAuthPool?.().catch((error) =>
-            logger.log("warn", "oauth.codex_catalog.rebuild_failed", {
-              line: error instanceof Error ? error.message : String(error),
-            }),
+          backgroundTasks.run(
+            async () => {
+              await rebuildOAuthPool?.();
+            },
+            (error) =>
+              logger.log("warn", "oauth.codex_catalog.rebuild_failed", {
+                line: error instanceof Error ? error.message : String(error),
+              }),
           );
         },
       }
@@ -1908,6 +1956,8 @@ export async function buildServer(
   };
   let cleanupScheduler: ReturnType<typeof startCleanupScheduler> | null = null;
   let vacuumScheduler: ReturnType<typeof startCleanupScheduler> | null = null;
+  let signalScheduler: ReturnType<typeof startSignalScheduler> | null = null;
+  let memoryWorker: ReturnType<typeof startMemoryWorker> | null = null;
   // Apply a new settings object live: re-bind `settings`, push the log level into
   // the logger, flip the rate-limit master switch, and retune the system-default
   // quota. Cleanup cadence is also rescheduled live so the admin setting is not
@@ -1930,8 +1980,9 @@ export async function buildServer(
   const archiveDir = process.env.HELM_ARCHIVE_DIR ?? `${dataDir}/archive`;
   const archiveSink = new LocalVolumeSink(archiveDir);
   const archiveFs = createArchiveFsAccess(archiveDir);
-  const runCleanupPassNow = (trigger: "scheduled" | "manual") =>
-    runCleanupPass({
+  const maintenanceQueue = createSerializedMaintenanceQueue();
+  const executeCleanupPass = async (trigger: "scheduled" | "manual") => {
+    const report = await runCleanupPass({
       settings,
       telemetry,
       memory: store.memory,
@@ -1943,6 +1994,45 @@ export async function buildServer(
       trigger,
       log: (line, meta) => logger.log("info", line, meta as Record<string, unknown> | undefined),
     });
+    clearSessionCaptureCache(telemetry);
+    return report;
+  };
+  const runCleanupPassNow = (trigger: "scheduled" | "manual") =>
+    maintenanceQueue.run(() => executeCleanupPass(trigger));
+  const executeVacuum = async () => {
+    const activities: PausableActivity[] = [
+      maintenanceActivityGate,
+      {
+        pauseAndWait: async () => {
+          requestBodyMemoryAdmission.pause();
+          await requestBodyMemoryAdmission.waitForIdle();
+        },
+        resume: requestBodyMemoryAdmission.resume,
+      },
+      {
+        pauseAndWait: async () => await memoryWorker?.pauseAndWait(),
+        resume: () => memoryWorker?.resume(),
+      },
+      {
+        pauseAndWait: async () => await signalScheduler?.pauseAndWait(),
+        resume: () => signalScheduler?.resume(),
+      },
+      backgroundTasks,
+      { pauseAndWait: writeQueue.pauseAndFlush, resume: writeQueue.resume },
+    ];
+    await withPausedActivities(
+      activities,
+      async () => {
+        clearSessionCaptureCache(telemetry);
+        await store.vacuum();
+      },
+      { pauseTimeoutMs: maintenanceDrainTimeoutMs(config.runtime.request_timeout_ms) },
+    );
+  };
+  const runVacuumNow = () => {
+    maintenanceActivityGate.releaseCurrent();
+    return maintenanceQueue.run(executeVacuum);
+  };
   // Agentic Signals (docs/02). The collector consumes ALREADY-persisted telemetry
   // and writes aggregated, REDACTED signals in the background. The optional
   // routing feedback consumer below reads only those aggregates and remains
@@ -2171,11 +2261,13 @@ export async function buildServer(
 
   // Fire-and-forget park (detection hot path): never blocks / fails a served request.
   const parkAccountOnLimit = (providerId: string, account: string, untilMs: number): void => {
-    void applyUsageLimit(providerId, account, untilMs).catch((e) =>
-      logger.log("error", "oauth.usage_limit.park_failed", {
-        provider_id: providerId,
-        line: e instanceof Error ? e.message : String(e),
-      }),
+    backgroundTasks.run(
+      () => applyUsageLimit(providerId, account, untilMs),
+      (e) =>
+        logger.log("error", "oauth.usage_limit.park_failed", {
+          provider_id: providerId,
+          line: e instanceof Error ? e.message : String(e),
+        }),
     );
   };
   const markOAuthCredentialFailure = async (
@@ -2196,12 +2288,14 @@ export async function buildServer(
     error: unknown,
   ): void => {
     const reason = error instanceof Error ? error.message : "oauth credential failed";
-    void markOAuthCredentialFailure(providerId, account, reason).catch((e) =>
-      logger.log("error", "oauth.credential_failure.persist_failed", {
-        provider_id: providerId,
-        account,
-        line: e instanceof Error ? e.message : String(e),
-      }),
+    backgroundTasks.run(
+      () => markOAuthCredentialFailure(providerId, account, reason),
+      (e) =>
+        logger.log("error", "oauth.credential_failure.persist_failed", {
+          provider_id: providerId,
+          account,
+          line: e instanceof Error ? e.message : String(e),
+        }),
     );
   };
   // Executor hook: an account-wide 429 on a subscription alias means the SERVED account
@@ -2442,20 +2536,30 @@ export async function buildServer(
     const windows = details.windows;
     if (windows.length === 0) return; // no quota headers on this reply → nothing to store
     applyQuotaSnapshot(providerId, account, windows, nowMs);
-    void store.oauthQuota
-      .upsert({ providerId, account, windows, capturedAt: nowMs, source: "codex-headers" })
-      .catch(() => logger.log("error", "oauth.quota.capture_failed", { provider_id: providerId }));
+    backgroundTasks.run(
+      () =>
+        store.oauthQuota.upsert({
+          providerId,
+          account,
+          windows,
+          capturedAt: nowMs,
+          source: "codex-headers",
+        }),
+      () => logger.log("error", "oauth.quota.capture_failed", { provider_id: providerId }),
+    );
     // Auto-park when a window is saturated (≥100% with a future reset): the precise
     // long cooldown the 429 backstop can't know. Fire-and-forget (fail-open).
     const until = windowsToUsageLimit(windows, nowMs);
     if (until !== null) parkAccountOnLimit(providerId, account, until);
     if (weeklySaturated(windows)) {
-      void onCodexQuotaSaturated(
-        "openai-codex",
-        account,
-        windows,
-        nowMs,
-        details.rateLimitReachedType,
+      backgroundTasks.run(() =>
+        onCodexQuotaSaturated(
+          "openai-codex",
+          account,
+          windows,
+          nowMs,
+          details.rateLimitReachedType,
+        ),
       );
     }
   };
@@ -2862,6 +2966,7 @@ export async function buildServer(
   });
   const app = createApp({
     logger,
+    maintenanceGate: maintenanceActivityGate,
     health: {
       checkReadiness: async () => ({ ready: true, checks: { store: "ok" } }),
       buildInfo: readBuildInfo(),
@@ -3041,6 +3146,7 @@ export async function buildServer(
         memoryStore: store.memory,
         now: () => new Date(),
         estimateTokens: estimateMemoryTokens,
+        runInBackground: backgroundTasks.run,
         log: (line) => logger.log("warn", "mcp", { line }),
         // docs/14 — hybrid recall config for memory_recall. The embedder (vector leg)
         // is wired just below from memory.llm.embedding_model; absent ⇒ FTS+score only.
@@ -3177,23 +3283,25 @@ export async function buildServer(
   ): void => {
     if (!servingAccount || !servedByAccount(servingAccount, servedAlias)) return;
     const nowMs = Date.now();
-    void store.oauthUsage
-      .record({
-        providerId: servingAccount.providerId,
-        account: servingAccount.account,
-        bucketMs: nowMs - (nowMs % 3_600_000),
-        tokens: usage.tokens,
-        costUsd: usage.costUsd,
-        nowMs,
-      })
-      .catch(() =>
+    backgroundTasks.run(
+      () =>
+        store.oauthUsage.record({
+          providerId: servingAccount.providerId,
+          account: servingAccount.account,
+          bucketMs: nowMs - (nowMs % 3_600_000),
+          tokens: usage.tokens,
+          costUsd: usage.costUsd,
+          nowMs,
+        }),
+      () =>
         logger.log("error", "oauth.usage.record_failed", {
           provider_id: servingAccount.providerId,
         }),
-      );
+    );
   };
 
   registerChatRoutes(app, {
+    memoryAdmission: requestBodyMemoryAdmission,
     route,
     telemetry,
     writes: writeQueue,
@@ -3323,11 +3431,12 @@ export async function buildServer(
       rules: ruleStore,
       keyStore,
       telemetry,
+      runInBackground: backgroundTasks.run,
       // Data cleanup / retention / archival surface (admin "Data cleanup").
       cleanup: {
         runNow: () => runCleanupPassNow("manual"),
         lastReport: () => readLastCleanupReport(store.config),
-        vacuum: () => store.vacuum(),
+        vacuum: runVacuumNow,
         listArchives: archiveFs.listArchives,
         resolveArchive: archiveFs.resolveArchive,
       },
@@ -3464,6 +3573,7 @@ export async function buildServer(
   // shape === RateLimiterPort (limiter.check(probe)). Wave2 adds the field to the
   // interfaces and the cast becomes a no-op at the final gate.
   registerMessagesRoute(app, {
+    memoryAdmission: requestBodyMemoryAdmission,
     // See note above: attached via cast until Wave2 adds `rateLimiter` to the deps
     // interface (the cast then becomes a no-op).
     rateLimiter,
@@ -3760,6 +3870,7 @@ export async function buildServer(
     modelsEtagForKey: (keyId, clientVersion) =>
       clientVersion === null ? null : codexModelsEtagTracker.forResponse(keyId, clientVersion),
     responsesWebSocketSessionProof,
+    memoryAdmission: requestBodyMemoryAdmission,
     // Telemetry + payload recorder (the /admin/requests fix): the SAME values the
     // chat route uses, so /v1/responses records served requests like /v1/chat does.
     record: {
@@ -3839,6 +3950,7 @@ export async function buildServer(
   };
 
   registerGeminiRoute(app, {
+    memoryAdmission: requestBodyMemoryAdmission,
     rateLimiter,
     concurrencyGate,
     ...(geminiCountProvider?.countTokens
@@ -3942,6 +4054,7 @@ export async function buildServer(
   };
 
   registerImagesRoute(app, {
+    memoryAdmission: requestBodyMemoryAdmission,
     rateLimiter,
     concurrencyGate,
     auth: { resolve: resolveIdentity },
@@ -3966,6 +4079,7 @@ export async function buildServer(
   // client.interactions.create). Same chain resolver + breaker + budget + telemetry as
   // the images route; translates the interactions request ↔ generateContent.
   registerInteractionsRoute(app, {
+    memoryAdmission: requestBodyMemoryAdmission,
     rateLimiter,
     concurrencyGate,
     auth: { resolve: resolveIdentity },
@@ -3990,7 +4104,6 @@ export async function buildServer(
   // is logged, never thrown). DELIBERATELY started here, OUTSIDE every middleware
   // / route registration, so no request ever touches signal code (zero added
   // latency). Disabled when HELM_SIGNALS_DISABLED is set (e.g. unit/e2e runs).
-  let signalScheduler: { stop: () => void } | null = null;
   if (process.env.HELM_SIGNALS_DISABLED !== "1") {
     const intervalMs = Number(process.env.HELM_SIGNALS_INTERVAL_MS ?? 60_000);
     signalScheduler = startSignalScheduler({
@@ -4008,7 +4121,6 @@ export async function buildServer(
   // outside every route, so no request touches it (zero added latency). Disabled
   // when HELM_MEMORY_WORKER_DISABLED=1 (tests default to OFF); interval is an
   // env tunable (fail-safe default + guard, mirroring the signals scheduler).
-  let memoryWorker: { stop: () => void; wake: () => void } | null = null;
   if (process.env.HELM_MEMORY_WORKER_DISABLED !== "1") {
     const intervalRaw = Number(process.env.HELM_MEMORY_WORKER_INTERVAL_MS ?? 60_000);
     const intervalMs = Number.isFinite(intervalRaw) && intervalRaw > 0 ? intervalRaw : 60_000;
@@ -4130,29 +4242,29 @@ export async function buildServer(
     // is on (default off — VACUUM holds an exclusive lock for the whole rewrite). The
     // live `settings` closure means a toggle/hour change takes effect without a
     // restart. store.vacuum() is a no-op on postgres (autovacuum), so this is inert
-    // there. lastRunDayKey is in-memory: a restart at the vacuum hour may run one
-    // extra VACUUM (harmless — it just reclaims nothing the second time).
-    let lastVacuumDayKey: string | null = null;
+    // there. The last successful day is in-memory: failures remain retryable if a
+    // later tick is still eligible, while a restart may harmlessly run it once more.
+    const autoVacuum = createAutoVacuumRunner();
     vacuumScheduler = startCleanupScheduler({
-      intervalMs: 3_600_000,
+      intervalMs: AUTO_VACUUM_CHECK_INTERVAL_MS,
       runTick: async () => {
         const now = new Date();
         const todayKey = now.toDateString();
-        if (
-          !shouldAutoVacuum({
+        await autoVacuum.run(
+          {
             enabled: settings.vacuum_enabled,
             vacuumHour: settings.vacuum_hour,
             currentHour: now.getHours(),
-            lastRunDayKey: lastVacuumDayKey,
             todayKey,
-          })
-        ) {
-          return;
-        }
-        lastVacuumDayKey = todayKey; // mark BEFORE the slow rewrite so a retry can't double-run
-        logger.log("info", "vacuum.auto_start", { hour: settings.vacuum_hour });
-        await store.vacuum();
-        logger.log("info", "vacuum.auto_done", {});
+          },
+          () =>
+            maintenanceQueue.run(async () => {
+              logger.log("info", "vacuum.auto_start", { hour: settings.vacuum_hour });
+              if (settings.cleanup_enabled) await executeCleanupPass("scheduled");
+              await executeVacuum();
+              logger.log("info", "vacuum.auto_done", {});
+            }),
+        );
       },
       log: (level, msg, fields) => logger.log(level, msg, fields),
     });
@@ -4163,6 +4275,7 @@ export async function buildServer(
     port: config.server.port,
     host: config.server.host,
     responsesWebSocketSessionProof,
+    responsesMemoryAdmission: requestBodyMemoryAdmission,
     closeResponsesWebSocketSession: async (sessionId) => {
       await Promise.all(
         [...providerClients.values()].map(
@@ -4171,10 +4284,13 @@ export async function buildServer(
       );
     },
     dispose: async () => {
-      signalScheduler?.stop();
-      memoryWorker?.stop();
+      const signalStopped = signalScheduler?.stop();
+      const memoryStopped = memoryWorker?.stop();
+      const backgroundStopped = backgroundTasks.closeAndWait();
       cleanupScheduler?.stop();
       vacuumScheduler?.stop();
+      await maintenanceQueue.closeAndWait();
+      await Promise.all([signalStopped, memoryStopped, backgroundStopped]);
       // Drain the deferred write queue BEFORE closing the DB so a graceful shutdown
       // persists every buffered telemetry/payload/observe write (no loss on deploy).
       await writeQueue.stop();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
     #     HELM_GIT_SHA: ${HELM_GIT_SHA:-dev}
     #     HELM_BUILT_AT: ${HELM_BUILT_AT:-dev}
     container_name: helm
+    # Let shutdown drain active streams, detached Store work, and an in-flight
+    # SQLite maintenance pass instead of Docker's short default SIGKILL window.
+    stop_grace_period: ${HELM_STOP_GRACE_PERIOD:-30m}
     env_file:
       - path: .env
         required: false

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -66,6 +66,7 @@ services:
     image: ${HELM_IMAGE:-ghcr.io/easymetaau/helm-api:latest}
     # build: .
     container_name: helm
+    stop_grace_period: ${HELM_STOP_GRACE_PERIOD:-30m}
     env_file:
       - path: .env
         required: false
@@ -89,6 +90,9 @@ so every documented optional provider/runtime setting reaches the container.
 On Linux, `HELM_UID` / `HELM_GID` let the non-root process write `./data` without
 `sudo` or world-writable permissions; the initializer fills the exact current
 values. The `10001:10001` fallback preserves the image user for existing installs.
+Compose also gives graceful shutdown 30 minutes by default so active streams,
+queued Store writes, and an in-flight SQLite maintenance pass can drain before
+Docker sends SIGKILL. Large databases can raise `HELM_STOP_GRACE_PERIOD` in `.env`.
 
 ### Reverse proxy WebSocket forwarding
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-23 · Codex Responses 按运行时容量准入并让夜间 SQLite 维护收缩内存（Gateway / Session / Store，docs/02/05/07/10，原则 2/3/7/8）
+
+- **功能边界不降级**：按 operator 要求保留正文/Session 捕获、自动 cleanup/VACUUM 和不限 key 并发；不再用关闭正文、关闭维护或固定并发作为稳定手段。Node 启动时从 V8 heap limit 与 cgroup/process constrained memory 推导活动请求、response work、单条 wire message、写队列、Session head cache、SQLite page cache 与维护 cache；活动请求和 response work 各占动态可分配容量的 20%，部署值随机器容量自动缩放，不写死 MiB。
+- **请求、输出与 Session 热路径**：所有 JSON 入口在 `JSON.parse` 前按真实流式字节申请进程级预算，超出单请求容量返回结构化 413，暂时无余量返回 503；`maxPayload` 与上游 Codex connector 同样随运行时容量变化。客户端 WebSocket 另从 cgroup 或 `RSS + availableMemory` 扣除未来 heap 增长和 SQLite 预留，得到 native ingress 池；每连接只预留一个最坏帧、不按 key 或固定连接数限流。WS 每连接只保留一个正在执行的 `response.create`，terminal 后排空内部流再释放 lease；所有上游 Codex WS 会话共用 response-work 池，每条消息从入队、等待、`JSON.parse` 到 frame 被消费全程持有 lease。四种 SSE 出口共用有界正文捕获器，容量耗尽只省略该响应 payload、记录 `payload.capture_limited` 并继续转发与保存 telemetry。Session 热写不再重建完整历史；Admin Session 恢复由 SQLite/Postgres 先查行字节元数据、再按 sequence 分页物化，并占用共享 recovery window。Store 的 64 MiB/10,000 revision 仍是跨实例一致的持久数据完整性上限，不是运行时内存值。
+- **夜间维护**：自动 cleanup、自动 VACUUM 与 Admin 手工维护复用同一 Promise 串行链；VACUUM 前进程级 gate 暂停新工作并依次等待 HTTP/body、Memory/Signal producer、OAuth/MCP/Admin cache 后台任务与正文写队列静止，结束或失败都逆序恢复。维护期间除 `/healthz`、`/version` 外的新请求统一返回带 `Retry-After` 的 503，并按 OpenAI、Anthropic、Gemini 或普通 Admin 路径输出对应错误形状；维护 drain 上限为 `min(request_timeout_ms, 120s)`。自动任务每 10 分钟检查一次，只有整段成功才记录当日完成。SQLite 仅在 freelist 至少占总页数 5% 时执行全库重写；worker 启动前要求 `availableMemory()` 至少为动态 process limit 的 25%，并按数据库与 WAL 实际大小检查磁盘。worker 使用独立连接、`temp_store=FILE` 与机器推导的低维护 cache；Compose 默认给 shutdown 30 分钟 grace。未引入守护进程、Redis、消息队列或新依赖。
+
 ## 2026-07-22 · 全项目文案审查补齐多语言维护闭环（Admin / Portal / Setup，docs/11/12，原则 1/2）
 
 - **审查边界**：Claude CLI Opus 对 Admin、Portal、Gateway 公开页面、README、当前 docs、脚本输出和客户端可见错误做了只读审查；不改协议字段、配置键、模型 ID、命令或历史事实。README 中文版已是自然意译，当前 docs 没有值得用大范围重写换取的明确收益。
@@ -63,13 +69,9 @@
 - **四出口一致性**：native Anthropic JSON/SSE 与 OpenAI→Anthropic translation JSON/SSE 都只在末个 terminal text 上调用该收紧路径，且没有既有 structured call 才可恢复；成功后分别将终态改为 `tool_use` / `tool_calls`。Translation SSE 与 JSON 复用同一份声明工具名映射，保证点号、碰撞等名称规范化一致。SSE 仍在 `message_delta` 证明终态后才改写，普通 `tool_use` 与非候选路径保持既有行为。
 - **验证**：TDD 先在共享 parser 和四个出口加入失败 case，再以 4 个定向 Vitest 文件、257 个用例覆盖完整 end-turn 恢复及拒绝 fence、尾随文本、调用间 prose、未闭合和未知 invoke；`pnpm typecheck`、`pnpm lint`、`pnpm build` 与 `git diff --check` 通过，不新增依赖或运行时配置。
 
-## 2026-07-18 · 请求推理等级与实际路由等级分开展示（Telemetry / Admin requests，docs/07/11，原则 1/7）
-
-- **事实边界**：`requested_reasoning_effort` 在进入路由、策略或 lane 覆盖前从客户端请求单独截取；既有 `reasoning_effort` 继续表示覆盖后的有效执行等级。两者都是不含正文与密钥的可选 `DecisionRecord` 元数据，因此关闭 `capture_payloads` 后仍可读取，旧记录缺少请求等级时保持空白，不用有效等级反推客户端意图。
-- **列表展示**：共享 `RequestsTable` 在“请求”模型后直接追加客户端等级（例如 `请求: gpt-5.6-sol high`），Routing 单元格只显示实际有效等级值，不再重复“推理等级”标签。Dashboard、主 Requests 与 key-scoped 列表共用该行为；请求详情现有的有效等级展示不变。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-18 · 请求推理等级与实际路由等级分开展示（Telemetry / Admin requests，原则 1/7）**：单独保存客户端请求等级与覆盖后的实际执行等级，共享列表分别展示且不从旧记录反推；完整原文通过 git history 回溯。
 - **2026-07-18 · 关闭正文捕获时仍保留推理等级（Telemetry / Admin requests，原则 1/7）**：完整正文关闭时仍把实际生效的 `reasoning_effort` 作为脱敏 DecisionRecord 元数据保存并显示；完整原文通过 git history 回溯。
 - **2026-07-18 · Codex 自动压缩目录与无状态传输故障切换（OAuth subscription / Responses / provider execution，原则 3/5/7/8）**：对齐 Codex 自动压缩阈值，并只允许无状态 transport failure 在兄弟账号间切换；有状态续接与私有 Responses items 保持 fail-closed，完整原文通过 git history 回溯。
 - **2026-07-17 · Anthropic XML 工具调用恢复边界（Protocol streaming / provider execution，原则 3/5/8）**：只在终态、完整、白名单且无既有结构化调用时恢复 XML 工具调用；四个实际出口共用边界并以有界缓冲保持流式保真，完整原文通过 git history 回溯。

--- a/packages/core/src/cleanup/auto-vacuum.test.ts
+++ b/packages/core/src/cleanup/auto-vacuum.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldAutoVacuum } from "./auto-vacuum.js";
+import {
+  AUTO_VACUUM_CHECK_INTERVAL_MS,
+  createAutoVacuumRunner,
+  shouldAutoVacuum,
+} from "./auto-vacuum.js";
 
 const base = {
   enabled: true,
@@ -10,6 +14,10 @@ const base = {
 };
 
 describe("shouldAutoVacuum", () => {
+  it("checks more than once during the configured hour so a failed attempt can retry", () => {
+    expect(AUTO_VACUUM_CHECK_INTERVAL_MS).toBeLessThan(60 * 60 * 1_000);
+  });
+
   it("runs at the configured hour when enabled and not yet run today", () => {
     expect(shouldAutoVacuum(base)).toBe(true);
   });
@@ -32,5 +40,40 @@ describe("shouldAutoVacuum", () => {
     expect(
       shouldAutoVacuum({ ...base, lastRunDayKey: "Sun Jun 21 2026", todayKey: "Mon Jun 22 2026" }),
     ).toBe(true);
+  });
+});
+
+describe("createAutoVacuumRunner", () => {
+  const tick = {
+    enabled: true,
+    vacuumHour: 4,
+    currentHour: 4,
+    todayKey: "Mon Jun 22 2026",
+  };
+
+  it("marks the day only after maintenance succeeds", async () => {
+    const runner = createAutoVacuumRunner();
+    let attempts = 0;
+    const run = async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("disk preflight failed");
+    };
+
+    await expect(runner.run(tick, run)).rejects.toThrow("disk preflight failed");
+    await expect(runner.run(tick, run)).resolves.toBe(true);
+    await expect(runner.run(tick, run)).resolves.toBe(false);
+    expect(attempts).toBe(2);
+  });
+
+  it("does not invoke maintenance when the live gate is closed", async () => {
+    const runner = createAutoVacuumRunner();
+    let called = false;
+
+    await expect(
+      runner.run({ ...tick, enabled: false }, async () => {
+        called = true;
+      }),
+    ).resolves.toBe(false);
+    expect(called).toBe(false);
   });
 });

--- a/packages/core/src/cleanup/auto-vacuum.ts
+++ b/packages/core/src/cleanup/auto-vacuum.ts
@@ -1,5 +1,5 @@
-// Pure decision for the off-hours auto-VACUUM scheduler. The gateway runs a plain
-// hourly tick (mirroring the cleanup scheduler); each tick this answers "should I
+// Pure decision for the off-hours auto-VACUUM scheduler. The gateway checks more
+// than once during the selected hour so a failed preflight can retry; each tick asks "should I
 // VACUUM right now?" from the live settings + the wall clock. Kept pure (no Date, no
 // store) so the once-a-day, right-hour, opt-in logic is unit-testable: the tick
 // supplies the clock (currentHour/todayKey) and remembers lastRunDayKey across ticks.
@@ -10,6 +10,8 @@
 //   - not the configured hour → wait (the operator picks a low-traffic local hour);
 //   - already ran today       → skip (at most once per day, even if the hour ticks
 //                               twice from setInterval drift).
+export const AUTO_VACUUM_CHECK_INTERVAL_MS = 10 * 60 * 1_000;
+
 export function shouldAutoVacuum(args: {
   enabled: boolean;
   vacuumHour: number;
@@ -20,4 +22,20 @@ export function shouldAutoVacuum(args: {
   if (!args.enabled) return false;
   if (args.currentHour !== args.vacuumHour) return false;
   return args.lastRunDayKey !== args.todayKey;
+}
+
+export function createAutoVacuumRunner() {
+  let lastSuccessfulDayKey: string | null = null;
+
+  return {
+    async run(
+      args: Omit<Parameters<typeof shouldAutoVacuum>[0], "lastRunDayKey">,
+      maintenance: () => Promise<void>,
+    ): Promise<boolean> {
+      if (!shouldAutoVacuum({ ...args, lastRunDayKey: lastSuccessfulDayKey })) return false;
+      await maintenance();
+      lastSuccessfulDayKey = args.todayKey;
+      return true;
+    },
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -150,7 +150,11 @@ export {
   type ArchiveManifest,
   type ArchiveSink,
 } from "./cleanup/archive/types.js";
-export { shouldAutoVacuum } from "./cleanup/auto-vacuum.js";
+export {
+  AUTO_VACUUM_CHECK_INTERVAL_MS,
+  createAutoVacuumRunner,
+  shouldAutoVacuum,
+} from "./cleanup/auto-vacuum.js";
 export { buildCleanupPlan, type CleanupAction, type CleanupTable } from "./cleanup/cleanup-plan.js";
 export {
   type CleanupReport,
@@ -623,6 +627,7 @@ export {
   type CodexResponsesWebSocketConnectInput,
   type CodexResponsesWebSocketConnection,
   type CodexResponsesWebSocketConnector,
+  type CodexResponsesWebSocketReceivedMessage,
   codexAccountIdFromToken,
   createCodexResponsesClient,
   createGenericOpenAIResponsesClient,
@@ -763,6 +768,19 @@ export {
   type RoutingSignalFeedbackDeps,
   routeRequest,
 } from "./routing/route-request.js";
+export {
+  deriveRuntimeMemoryBudget,
+  type RuntimeMemoryBudget,
+  runtimeMemoryBudget,
+} from "./runtime/memory-budget.js";
+export {
+  acquireResponseWork,
+  createResponseWorkAdmission,
+  type ResponseWorkAdmission,
+  ResponseWorkCapacityError,
+  type ResponseWorkLease,
+  runtimeResponseWorkAdmission,
+} from "./runtime/response-work-admission.js";
 // Runtime-mutable settings (admin "System Settings") — load/seed/persist the
 // operator-facing config subset that can change at runtime without a restart.
 export {
@@ -806,6 +824,8 @@ export {
   createStore,
   InMemoryRateLimitStore,
   InMemorySignalStore,
+  PERSISTED_SESSION_MAX_REVISIONS,
+  PERSISTED_SESSION_MAX_STORED_BYTES,
   PgBudgetStore,
   PgConfigStore,
   type PgDb,
@@ -860,6 +880,8 @@ export type {
   RequestPayloadPart,
   RequestPayloadPartRecord,
   SessionRecord,
+  SessionRevisionPage,
+  SessionRevisionPageOptions,
   SessionRevisionRecord,
   SignalStore,
   TelemetryStore,

--- a/packages/core/src/memory/scheduler.test.ts
+++ b/packages/core/src/memory/scheduler.test.ts
@@ -574,6 +574,65 @@ describe("startMemoryWorker wake()", () => {
   // backstop is verified separately by the describe above).
   const WAKE_DEPS = { coalesceMs: 8000, intervalMs: 60_000 } as const;
 
+  it("stop waits for an active drain before resolving", async () => {
+    let finish = () => {};
+    const { store } = makeStore([
+      { jobId: "j1", type: "observer", scope: { accountId: "a", threadId: "t1" } },
+    ]);
+    const runObserver = vi.fn(
+      () =>
+        new Promise<ObserverResult>((resolve) => {
+          finish = () => resolve(OBS_NOOP);
+        }),
+    );
+    const handle = startMemoryWorker(makeDeps(store, { ...WAKE_DEPS, coalesceMs: 1, runObserver }));
+
+    handle.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    let stopped = false;
+    const stopping = handle.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    finish();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
+
+  it("pauseAndWait cancels pending wakes and waits for the active drain", async () => {
+    let finish = () => {};
+    const { store } = makeStore([
+      { jobId: "j1", type: "observer", scope: { accountId: "a", threadId: "t1" } },
+    ]);
+    const runObserver = vi.fn(
+      () =>
+        new Promise<ObserverResult>((resolve) => {
+          finish = () => resolve(OBS_NOOP);
+        }),
+    );
+    const handle = startMemoryWorker(makeDeps(store, { ...WAKE_DEPS, coalesceMs: 1, runObserver }));
+
+    handle.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    let paused = false;
+    const waiting = handle.pauseAndWait().then(() => {
+      paused = true;
+    });
+    await Promise.resolve();
+    expect(paused).toBe(false);
+    finish();
+    await waiting;
+    handle.wake();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(runObserver).toHaveBeenCalledTimes(1);
+    handle.resume();
+    handle.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(store.claimPendingJobs).toHaveBeenCalledTimes(2);
+    handle.stop();
+  });
+
   it("debounces the drain by coalesceMs (no drain before the window elapses)", async () => {
     const { store } = makeStore([
       { jobId: "j1", type: "observer", scope: { accountId: "a", threadId: "t1" } },

--- a/packages/core/src/memory/scheduler.ts
+++ b/packages/core/src/memory/scheduler.ts
@@ -69,7 +69,9 @@ export interface MemoryWorkerDeps {
 }
 
 export interface MemoryWorkerHandle {
-  stop(): void;
+  stop(): Promise<void>;
+  pauseAndWait(): Promise<void>;
+  resume(): void;
   // Request-path trigger: schedule a drain after coalesceMs of quiet (debounced).
   // Coalesced, non-blocking, fail-open — the caller (a write-queue task settle) is
   // never blocked and a wake can never throw. Does NOT run the onTick housekeeping
@@ -317,10 +319,26 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
     await drainCoalesced();
   };
 
+  let wakeTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let paused = false;
+  let activeRuns = 0;
+  const idleWaiters: Array<() => void> = [];
+  const runWhileActive = async (run: () => Promise<void>): Promise<void> => {
+    if (paused || stopped) return;
+    activeRuns += 1;
+    try {
+      await run();
+    } finally {
+      activeRuns -= 1;
+      if (activeRuns === 0) for (const resolve of idleWaiters.splice(0)) resolve();
+    }
+  };
+
   const timer = setInterval(() => {
     // Fire-and-forget; tick is fail-open, but guard the promise so a rejection can
     // never become an unhandled rejection on the timer.
-    void tick().catch((err: unknown) => {
+    void runWhileActive(tick).catch((err: unknown) => {
       deps.log("memory.worker.tick_failed", {
         error: err instanceof Error ? err.message : String(err),
       });
@@ -332,29 +350,37 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
 
   // Trailing-edge debounce timer for wake(): re-armed on every wake, fires one
   // jobs-only drain after coalesceMs of quiet.
-  let wakeTimer: ReturnType<typeof setTimeout> | null = null;
-  // Latched by stop(): a wake() arriving afterwards (e.g. a write-queue task that
-  // settles while the queue drains on shutdown — stop() runs before that drain) must
-  // not arm a fresh timer that later claims jobs against an already-closed store.
-  let stopped = false;
-
   return {
-    stop() {
+    async stop() {
       stopped = true;
       clearInterval(timer);
       if (wakeTimer !== null) {
         clearTimeout(wakeTimer);
         wakeTimer = null;
       }
+      if (activeRuns === 0) return;
+      await new Promise<void>((resolve) => idleWaiters.push(resolve));
+    },
+    async pauseAndWait() {
+      paused = true;
+      if (wakeTimer !== null) {
+        clearTimeout(wakeTimer);
+        wakeTimer = null;
+      }
+      if (activeRuns === 0) return;
+      await new Promise<void>((resolve) => idleWaiters.push(resolve));
+    },
+    resume() {
+      paused = false;
     },
     wake() {
-      if (stopped) return;
+      if (stopped || paused) return;
       if (wakeTimer !== null) clearTimeout(wakeTimer);
       wakeTimer = setTimeout(() => {
         wakeTimer = null;
         // Jobs-only drain (no onTick). Fail-open: a rejection is logged, never an
         // unhandled rejection on the timer.
-        void drainCoalesced().catch((err: unknown) => {
+        void runWhileActive(drainCoalesced).catch((err: unknown) => {
           deps.log("memory.worker.wake_drain_failed", {
             error: err instanceof Error ? err.message : String(err),
           });

--- a/packages/core/src/protocol/streaming.test.ts
+++ b/packages/core/src/protocol/streaming.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createResponseWorkAdmission } from "../runtime/response-work-admission.js";
 import type { IRResponse } from "./ir.js";
 import {
   type Controller,
@@ -118,6 +119,40 @@ describe("readSSE — generic SSE splitter", () => {
     expect(events).toEqual([{ data: '{"text":"你好👋"}' }]);
     // Round-trips through JSON with no replacement-char corruption.
     expect(JSON.parse(nth(events, 0).data).text).toBe("你好👋");
+  });
+
+  it("rejects both terminated and unterminated frames beyond the dynamic frame budget", async () => {
+    const frame = `data: ${"x".repeat(17)}`;
+    for (const oversized of [frame, `${frame}\n\n`]) {
+      await expect(collect(readSSE(streamOf([enc.encode(oversized)]), 16))).rejects.toMatchObject({
+        name: "UpstreamError",
+        errorClass: "upstream_error",
+        upstreamStatus: null,
+      });
+    }
+  });
+
+  it("holds a shared response-work lease while the consumer parses a yielded frame", async () => {
+    const wire = "data: one\n\n";
+    const admission = createResponseWorkAdmission({
+      capacityBytes: enc.encode(wire).byteLength * 2,
+      jsonAmplification: 2,
+      minChargeBytes: 2,
+    });
+    const first = readSSE(streamOf([enc.encode(wire)]), 64, admission)[Symbol.asyncIterator]();
+
+    await expect(first.next()).resolves.toMatchObject({ done: false, value: { data: "one" } });
+    expect(admission.reservedBytes).toBe(enc.encode(wire).byteLength * 2);
+    await expect(
+      collect(readSSE(streamOf([enc.encode(wire)]), 64, admission)),
+    ).rejects.toMatchObject({ name: "UpstreamError", errorClass: "upstream_error" });
+
+    await first.return?.();
+    expect(admission.reservedBytes).toBe(0);
+    await expect(collect(readSSE(streamOf([enc.encode(wire)]), 64, admission))).resolves.toEqual([
+      { data: "one" },
+    ]);
+    expect(admission.reservedBytes).toBe(0);
   });
 });
 

--- a/packages/core/src/protocol/streaming.ts
+++ b/packages/core/src/protocol/streaming.ts
@@ -1,3 +1,10 @@
+import { Buffer } from "node:buffer";
+import { UpstreamError } from "../provider/openai.js";
+import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
+import {
+  type ResponseWorkAdmission,
+  runtimeResponseWorkAdmission,
+} from "../runtime/response-work-admission.js";
 import type { IRResponse } from "./ir.js";
 
 // Streaming primitives for the protocol layer (docs/05). Streaming correctness is
@@ -31,6 +38,18 @@ export interface SSEFrame {
   data: string;
 }
 
+function assertSSEFrameFits(frame: string, maxFrameBytes: number): void {
+  if (Buffer.byteLength(frame) <= maxFrameBytes) return;
+  throw new UpstreamError("upstream_error", "upstream SSE frame exceeds the runtime memory budget");
+}
+
+function responseWorkError(): UpstreamError {
+  return new UpstreamError(
+    "upstream_error",
+    "upstream response memory capacity is temporarily exhausted",
+  );
+}
+
 // Per the SSE spec a frame ends at a BLANK line. `data:`/`event:` fields may
 // repeat; multiple `data:` lines join with "\n". A leading single space after the
 // colon is stripped. `[DONE]` is just another data payload (the caller decides).
@@ -57,14 +76,29 @@ function parseFrame(block: string): SSEFrame | null {
  * byte (half-lines across chunks), CRLF/LF mixes, and multiple events packed into
  * one chunk. Yields one `SSEFrame` per blank-line-delimited block.
  */
-export async function* readSSE(stream: ReadableStream<Uint8Array>): AsyncIterable<SSEFrame> {
+export async function* readSSE(
+  stream: ReadableStream<Uint8Array>,
+  maxFrameBytes = runtimeMemoryBudget().maxWireBytes,
+  workAdmission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
+): AsyncIterable<SSEFrame> {
   const reader = stream.getReader();
+  const acquired = workAdmission.acquire(0);
+  if (!acquired.ok) {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+    throw responseWorkError();
+  }
+  const { lease } = acquired;
   const decoder = new TextDecoder();
   let buffer = "";
+  const resize = (wireBytes: number): void => {
+    if (!lease.resize(wireBytes).ok) throw responseWorkError();
+  };
   try {
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
+      resize(Buffer.byteLength(buffer) + value.byteLength);
       // `stream: true` keeps multibyte chars split across chunks intact.
       buffer += decoder.decode(value, { stream: true });
       // Normalize CRLF so we can split on a single blank line.
@@ -73,18 +107,29 @@ export async function* readSSE(stream: ReadableStream<Uint8Array>): AsyncIterabl
       while (sep !== -1) {
         const block = buffer.slice(0, sep);
         buffer = buffer.slice(sep + 2);
+        assertSSEFrameFits(block, maxFrameBytes);
         const frame = parseFrame(block);
         if (frame !== null) yield frame;
+        resize(Buffer.byteLength(buffer));
         sep = buffer.indexOf("\n\n");
       }
+      assertSSEFrameFits(buffer, maxFrameBytes);
     }
     // Flush any trailing frame that wasn't terminated by a blank line.
-    buffer += decoder.decode();
-    const tail = parseFrame(buffer.replace(/\r\n/g, "\n"));
+    const decodedTail = decoder.decode();
+    resize(Buffer.byteLength(buffer) + Buffer.byteLength(decodedTail));
+    buffer += decodedTail;
+    buffer = buffer.replace(/\r\n/g, "\n");
+    assertSSEFrameFits(buffer, maxFrameBytes);
+    const tail = parseFrame(buffer);
     if (tail !== null) yield tail;
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    throw error;
   } finally {
     // Abort / client-disconnect cleanup: release the lock without throwing.
     reader.releaseLock();
+    lease.release();
   }
 }
 

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { transformRequestOut as anthropicToIRRequest } from "../protocol/anthropic/request.js";
+import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
 import type { CodexModelInfo } from "./oauth/codex-model-info.js";
 import { UpstreamError } from "./openai.js";
 import {
@@ -2527,6 +2528,178 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     return connection;
   }
 
+  it("holds a websocket response-work lease until the yielded frame is consumed", async () => {
+    let releaseCalls = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {},
+      async receive() {
+        throw new Error("legacy receive should not be used");
+      },
+      async receiveWithWork() {
+        return {
+          text: JSON.stringify({ type: "response.created", response: { id: "resp-held" } }),
+          release() {
+            releaseCalls += 1;
+          },
+        };
+      },
+      async close() {},
+    };
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_work_lease")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+      },
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-work-lease", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    const yielded = await iterator?.next();
+
+    expect(yielded?.value).toContain("response.created");
+    expect(releaseCalls).toBe(0);
+    await iterator?.return?.();
+    expect(releaseCalls).toBe(1);
+  });
+
+  it("releases websocket response-work after malformed JSON", async () => {
+    let releaseCalls = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {},
+      async receive() {
+        throw new Error("legacy receive should not be used");
+      },
+      async receiveWithWork() {
+        return {
+          text: "not-json",
+          release() {
+            releaseCalls += 1;
+          },
+        };
+      },
+      async close() {},
+    };
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_bad_work")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+      },
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-bad-work", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({ name: "UpstreamError" });
+    expect(releaseCalls).toBe(1);
+  });
+
+  it("releases a late websocket response when the receive timeout wins", async () => {
+    let resolveReceive: ((value: { text: string; release(): void } | null) => void) | undefined;
+    let releaseCalls = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {},
+      async receive() {
+        throw new Error("legacy receive should not be used");
+      },
+      async receiveWithWork() {
+        return await new Promise<{ text: string; release(): void } | null>((resolve) => {
+          resolveReceive = resolve;
+        });
+      },
+      async close() {},
+    };
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_late_work")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+        timeoutMs: 5,
+      },
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-late-work", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({
+      name: "UpstreamError",
+      errorClass: "timeout",
+    });
+    resolveReceive?.({
+      text: JSON.stringify({ type: "response.created" }),
+      release() {
+        releaseCalls += 1;
+      },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(releaseCalls).toBe(1);
+  });
+
+  it("rejects an abort that happens during websocket send before receive starts", async () => {
+    const controller = new AbortController();
+    let closeCalls = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {
+        controller.abort(new Error("client aborted during send"));
+      },
+      async receive() {
+        return await new Promise<string | null>(() => {});
+      },
+      async close() {
+        closeCalls += 1;
+      },
+    };
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_abort_send")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+        timeoutMs: 10,
+      },
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-abort-send", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+        { signal: controller.signal },
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toThrow("client aborted during send");
+    expect(closeCalls).toBe(1);
+  });
+
   it("reuses one upstream websocket for prewarm and previous_response_id continuation", async () => {
     const connection = fakeConnection([
       [
@@ -3275,6 +3448,31 @@ describe("createCodexResponsesClient — nativePassthrough", () => {
     expect(out).toEqual(upstream);
   });
 
+  it.each([
+    "nativePassthrough",
+    "responsesCompact",
+  ] as const)("maps an oversized unary %s body into fallback-eligible UpstreamError", async (method) => {
+    const limit = runtimeMemoryBudget().maxWireBytes;
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+      },
+      fetch: (async () =>
+        new Response("{}", { headers: { "content-length": String(limit + 1) } })) as typeof fetch,
+    });
+
+    const run =
+      method === "nativePassthrough"
+        ? client.nativePassthrough?.(nativeBody())
+        : client.responsesCompact?.(nativeBody());
+    await expect(run).rejects.toMatchObject({
+      errorClass: "upstream_error",
+      upstreamStatus: null,
+      providerRaw: { error: { code: "response_body_too_large", limit_bytes: limit } },
+    });
+  });
+
   it("throws UpstreamError with upstreamStatus + scrubbed body on a non-2xx", async () => {
     const token = jwt("acct_secret_value_1234");
     const client = createCodexResponsesClient({
@@ -3582,6 +3780,30 @@ describe("createCodexResponsesClient — passthrough methods are defined (pool f
 });
 
 describe("createGenericOpenAIResponsesClient — native passthrough", () => {
+  it("maps every JSON unary Responses endpoint over the dynamic body budget to UpstreamError", async () => {
+    const limit = runtimeMemoryBudget().maxWireBytes;
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
+      fetch: (async () =>
+        new Response("{}", { headers: { "content-length": String(limit + 1) } })) as typeof fetch,
+    });
+    const expectTooLarge = (run: Promise<unknown> | undefined) =>
+      expect(run).rejects.toMatchObject({
+        errorClass: "upstream_error",
+        upstreamStatus: null,
+        providerRaw: { error: { code: "response_body_too_large", limit_bytes: limit } },
+      });
+
+    await expectTooLarge(client.chatCompletion({ model: "m", messages: [] }));
+    await expectTooLarge(client.nativePassthrough?.({ model: "m", input: [] }));
+    await expectTooLarge(client.responsesRetrieve?.("resp_1"));
+    await expectTooLarge(client.responsesDelete?.("resp_1"));
+    await expectTooLarge(client.responsesCancel?.("resp_1"));
+    await expectTooLarge(client.responsesInputItems?.("resp_1"));
+    await expectTooLarge(client.responsesCompact?.({ model: "m", input: [] }));
+    await expectTooLarge(client.responsesInputTokens?.({ model: "m", input: [] }));
+  });
+
   it("injects default native instructions when the opt-in contract requires them", async () => {
     let seenBody: Record<string, unknown> = {};
     const client = createGenericOpenAIResponsesClient({

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -24,6 +24,12 @@ import {
   type NativePassthroughInput,
 } from "@helm/shared";
 import {
+  consumeResponseTextWithinBudget,
+  ResponseBodyTooLargeError,
+} from "../runtime/bounded-response.js";
+import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
+import { ResponseWorkCapacityError } from "../runtime/response-work-admission.js";
+import {
   type PreparedNativePassthroughRequest,
   prepareNativePassthroughRequest,
 } from "./native-passthrough.js";
@@ -149,10 +155,16 @@ export interface CodexResponsesWebSocketConnectInput {
   signal?: AbortSignal;
 }
 
+export interface CodexResponsesWebSocketReceivedMessage {
+  text: string;
+  release(): void;
+}
+
 export interface CodexResponsesWebSocketConnection {
   responseHeaders: Headers;
   send(text: string): Promise<void>;
   receive(): Promise<string | null>;
+  receiveWithWork?(): Promise<CodexResponsesWebSocketReceivedMessage | null>;
   close(): Promise<void>;
 }
 
@@ -192,6 +204,18 @@ const RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite";
 const CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata";
 const CODEX_TURN_STATE_HEADER = "x-codex-turn-state";
 const MAX_CODEX_TURN_STATES = 128;
+
+function responseBodyTooLargeUpstreamError(error: ResponseBodyTooLargeError): UpstreamError {
+  return new UpstreamError("upstream_error", error.message, {
+    error: { code: "response_body_too_large", limit_bytes: error.limitBytes },
+  });
+}
+
+function responseWorkCapacityUpstreamError(error: ResponseWorkCapacityError): UpstreamError {
+  return new UpstreamError("upstream_error", error.message, {
+    error: { code: "response_work_capacity_exhausted", limit_bytes: error.capacityBytes },
+  });
+}
 
 const RESPONSES_REASONING_DELTA_TYPES = new Set([
   "response.reasoning_summary.delta",
@@ -1371,12 +1395,25 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     }
   }
 
-  async function readUnaryBody(result: CodexHttpResponse): Promise<string> {
+  async function consumeUnaryBody<T>(
+    result: CodexHttpResponse,
+    consume: (text: string) => T | Promise<T>,
+  ): Promise<T> {
     try {
-      return await result.response.text();
+      return await consumeResponseTextWithinBudget(
+        result.response,
+        runtimeMemoryBudget().maxWireBytes,
+        consume,
+      );
     } catch (err) {
       if (result.bodyTimeout?.isTimeout() && !result.bodyTimeout.isExternalAbort()) {
         throw new UpstreamError("timeout", "upstream request timed out");
+      }
+      if (err instanceof ResponseBodyTooLargeError) {
+        throw responseBodyTooLargeUpstreamError(err);
+      }
+      if (err instanceof ResponseWorkCapacityError) {
+        throw responseWorkCapacityUpstreamError(err);
       }
       throw err;
     } finally {
@@ -1387,7 +1424,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   }
 
   async function readUnaryJson(result: CodexHttpResponse): Promise<Record<string, unknown>> {
-    return JSON.parse(await readUnaryBody(result)) as Record<string, unknown>;
+    return await consumeUnaryBody(result, (text) => JSON.parse(text) as Record<string, unknown>);
   }
 
   function fireMetadataHook(
@@ -1485,16 +1522,19 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   async function errorFromResponse(result: CodexHttpResponse): Promise<UpstreamError> {
     let providerRaw: unknown = null;
     try {
-      const text = await readUnaryBody(result);
-      try {
-        providerRaw = JSON.parse(text);
-      } catch {
-        providerRaw = text;
-      }
+      providerRaw = await consumeUnaryBody(result, (text) => {
+        let raw: unknown;
+        try {
+          raw = JSON.parse(text);
+        } catch {
+          raw = text;
+        }
+        return scrub(raw);
+      });
     } catch (err) {
       if (err instanceof UpstreamError && err.errorClass === "timeout") throw err;
     }
-    const scrubbedBody = scrub(providerRaw);
+    const scrubbedBody = providerRaw;
     const selectedHeaders =
       result.response.status === 429 ? codexErrorHeaders(result.response.headers) : {};
     const structuredRaw =
@@ -1866,25 +1906,39 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   async function receiveWebSocketMessage(
     connection: CodexResponsesWebSocketConnection,
     signal: AbortSignal | undefined,
-  ): Promise<string | null> {
+  ): Promise<CodexResponsesWebSocketReceivedMessage | null> {
     const timeout = withTimeout(timeoutMs, signal);
+    const receive =
+      connection.receiveWithWork?.() ??
+      connection.receive().then((text) =>
+        text === null
+          ? null
+          : {
+              text,
+              release() {},
+            },
+      );
     try {
       return await Promise.race([
-        connection.receive(),
+        receive,
         new Promise<never>((_, reject) => {
-          timeout.signal.addEventListener(
-            "abort",
-            () => {
-              if (timeout.isTimeout() && !timeout.isExternalAbort()) {
-                reject(new UpstreamError("timeout", "upstream websocket stream timed out"));
-              } else {
-                reject(signal?.reason ?? new Error("client aborted"));
-              }
-            },
-            { once: true },
-          );
+          const rejectAbort = () => {
+            if (timeout.isTimeout() && !timeout.isExternalAbort()) {
+              reject(new UpstreamError("timeout", "upstream websocket stream timed out"));
+            } else {
+              reject(signal?.reason ?? new Error("client aborted"));
+            }
+          };
+          if (timeout.signal.aborted) rejectAbort();
+          else timeout.signal.addEventListener("abort", rejectAbort, { once: true });
         }),
       ]);
+    } catch (error) {
+      void receive.then(
+        (message) => message?.release(),
+        () => {},
+      );
+      throw error;
     } finally {
       timeout.cleanup();
     }
@@ -2005,40 +2059,44 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
             opts?.captureUpstream?.(requestText);
             await lease.connection.send(requestText);
             while (true) {
-              const message = await receiveWebSocketMessage(lease.connection, opts?.signal);
-              if (message === null) {
+              const received = await receiveWebSocketMessage(lease.connection, opts?.signal);
+              if (received === null) {
                 await closeWebSocketSession(sessionId);
                 throw new UpstreamError(
                   "upstream_error",
                   "upstream websocket closed before a terminal response event",
                 );
               }
-              const event = websocketSseFrame(message);
-              if (event.kind === "rate_limits") {
-                fireResponseMetaHeaders(event.headers, opts?.onResponseMeta);
-                continue;
-              }
-              if (event.kind === "error") {
-                fireResponseMetaHeaders(event.headers, opts?.onResponseMeta);
-                if (isWebsocketConnectionLimitError(event.error)) {
-                  await closeWebSocketSession(sessionId);
-                  if (retries < maxRetries) {
-                    retryConnection = true;
-                  } else {
-                    websocketHttpFallbackSessions.add(sessionId);
-                    fallbackToHttp = true;
-                  }
-                  break;
+              try {
+                const event = websocketSseFrame(received.text);
+                if (event.kind === "rate_limits") {
+                  fireResponseMetaHeaders(event.headers, opts?.onResponseMeta);
+                  continue;
                 }
-                await closeWebSocketSession(sessionId);
-                throw event.error;
-              }
-              if (event.terminal && !event.reusable) {
-                await closeWebSocketSession(sessionId);
-              }
-              yield event.frame;
-              if (event.terminal) {
-                return;
+                if (event.kind === "error") {
+                  fireResponseMetaHeaders(event.headers, opts?.onResponseMeta);
+                  if (isWebsocketConnectionLimitError(event.error)) {
+                    await closeWebSocketSession(sessionId);
+                    if (retries < maxRetries) {
+                      retryConnection = true;
+                    } else {
+                      websocketHttpFallbackSessions.add(sessionId);
+                      fallbackToHttp = true;
+                    }
+                    break;
+                  }
+                  await closeWebSocketSession(sessionId);
+                  throw event.error;
+                }
+                if (event.terminal && !event.reusable) {
+                  await closeWebSocketSession(sessionId);
+                }
+                yield event.frame;
+                if (event.terminal) {
+                  return;
+                }
+              } finally {
+                received.release();
               }
             }
           } catch (error) {
@@ -2250,23 +2308,41 @@ export function createGenericOpenAIResponsesClient(
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await res
-      .text()
-      .then((t) => {
+    const providerRaw = await consumeResponseTextWithinBudget(
+      res,
+      runtimeMemoryBudget().maxWireBytes,
+      (text) => {
         try {
-          return JSON.parse(t);
+          return scrub(JSON.parse(text));
         } catch {
-          return t;
+          return scrub(text);
         }
-      })
-      .catch(() => null)
-      .then(scrub);
+      },
+    ).catch(() => null);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
       providerRaw,
       res.status,
     );
+  }
+
+  async function readUnaryJson(res: Response): Promise<Record<string, unknown>> {
+    try {
+      return await consumeResponseTextWithinBudget(
+        res,
+        runtimeMemoryBudget().maxWireBytes,
+        (text) => JSON.parse(text) as Record<string, unknown>,
+      );
+    } catch (error) {
+      if (error instanceof ResponseBodyTooLargeError) {
+        throw responseBodyTooLargeUpstreamError(error);
+      }
+      if (error instanceof ResponseWorkCapacityError) {
+        throw responseWorkCapacityUpstreamError(error);
+      }
+      throw error;
+    }
   }
 
   async function requestJson(
@@ -2380,7 +2456,7 @@ export function createGenericOpenAIResponsesClient(
       if (requestContract?.forceSse === true) {
         return await aggregateResponsesStream(res, model, timeoutMs, { allowIncomplete: true });
       }
-      return responsesJsonToChatResponse((await res.json()) as Record<string, unknown>, model);
+      return responsesJsonToChatResponse(await readUnaryJson(res), model);
     },
 
     async *chatCompletionStream(req, opts) {
@@ -2412,7 +2488,7 @@ export function createGenericOpenAIResponsesClient(
       if (requestContract?.forceSse === true) {
         return await aggregateNativeResponsesStream(res, timeoutMs);
       }
-      return (await res.json()) as Record<string, unknown>;
+      return await readUnaryJson(res);
     },
 
     async *nativePassthroughStream(body, opts) {
@@ -2434,7 +2510,7 @@ export function createGenericOpenAIResponsesClient(
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUnaryJson(res);
     },
 
     async responsesDelete(responseId, opts) {
@@ -2443,7 +2519,7 @@ export function createGenericOpenAIResponsesClient(
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUnaryJson(res);
     },
 
     async responsesCancel(responseId, opts) {
@@ -2452,7 +2528,7 @@ export function createGenericOpenAIResponsesClient(
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUnaryJson(res);
     },
 
     async responsesInputItems(responseId, opts) {
@@ -2461,7 +2537,7 @@ export function createGenericOpenAIResponsesClient(
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUnaryJson(res);
     },
 
     async responsesCompact(req, opts) {
@@ -2471,7 +2547,7 @@ export function createGenericOpenAIResponsesClient(
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUnaryJson(res);
     },
 
     async responsesInputTokens(req, opts) {
@@ -2481,7 +2557,7 @@ export function createGenericOpenAIResponsesClient(
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUnaryJson(res);
     },
   };
 }

--- a/packages/core/src/runtime/bounded-response.test.ts
+++ b/packages/core/src/runtime/bounded-response.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumeResponseTextWithinBudget,
+  ResponseBodyTooLargeError,
+  readResponseTextWithinBudget,
+} from "./bounded-response.js";
+import {
+  createResponseWorkAdmission,
+  ResponseWorkCapacityError,
+} from "./response-work-admission.js";
+
+describe("readResponseTextWithinBudget", () => {
+  it("rejects an oversized Content-Length before reading or decoding the body", async () => {
+    const response = new Response("unread", {
+      headers: { "content-length": "4" },
+    });
+
+    await expect(readResponseTextWithinBudget(response, 3)).rejects.toMatchObject({
+      name: "ResponseBodyTooLargeError",
+      limitBytes: 3,
+    });
+  });
+
+  it("counts streamed bytes, including when Content-Length is absent", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("ab"));
+          controller.enqueue(new TextEncoder().encode("cd"));
+          controller.close();
+        },
+      }),
+    );
+
+    await expect(readResponseTextWithinBudget(response, 3)).rejects.toBeInstanceOf(
+      ResponseBodyTooLargeError,
+    );
+  });
+
+  it("returns valid UTF-8 up to the supplied dynamic budget", async () => {
+    const body = "你好";
+    expect(
+      await readResponseTextWithinBudget(
+        new Response(body),
+        new TextEncoder().encode(body).byteLength,
+      ),
+    ).toBe(body);
+  });
+
+  it("holds the shared amplified reservation through consumption and releases it", async () => {
+    const admission = createResponseWorkAdmission({
+      capacityBytes: 12,
+      jsonAmplification: 2,
+      minChargeBytes: 2,
+    });
+
+    await expect(
+      consumeResponseTextWithinBudget(
+        new Response("123456"),
+        6,
+        async (text) => {
+          expect(admission.reservedBytes).toBe(12);
+          await expect(
+            readResponseTextWithinBudget(new Response("x"), 1, admission),
+          ).rejects.toBeInstanceOf(ResponseWorkCapacityError);
+          return text;
+        },
+        admission,
+      ),
+    ).resolves.toBe("123456");
+    expect(admission.reservedBytes).toBe(0);
+  });
+
+  it("releases the shared reservation when the consumer throws", async () => {
+    const admission = createResponseWorkAdmission({
+      capacityBytes: 12,
+      jsonAmplification: 2,
+      minChargeBytes: 2,
+    });
+
+    await expect(
+      consumeResponseTextWithinBudget(
+        new Response("123456"),
+        6,
+        () => {
+          throw new Error("parse failed");
+        },
+        admission,
+      ),
+    ).rejects.toThrow("parse failed");
+    expect(admission.reservedBytes).toBe(0);
+  });
+});

--- a/packages/core/src/runtime/bounded-response.ts
+++ b/packages/core/src/runtime/bounded-response.ts
@@ -1,0 +1,99 @@
+import {
+  acquireResponseWork,
+  type ResponseWorkAdmission,
+  ResponseWorkCapacityError,
+  type ResponseWorkLease,
+  runtimeResponseWorkAdmission,
+} from "./response-work-admission.js";
+
+/** A response body exceeded the caller's runtime-derived byte budget. */
+export class ResponseBodyTooLargeError extends Error {
+  readonly limitBytes: number;
+
+  constructor(limitBytes: number) {
+    super("upstream response exceeds the runtime memory budget");
+    this.name = "ResponseBodyTooLargeError";
+    this.limitBytes = limitBytes;
+  }
+}
+
+function exceedsBudget(contentLength: string | null, maxBytes: number): boolean {
+  if (contentLength === null || !/^\d+$/.test(contentLength)) return false;
+  const bytes = Number(contentLength);
+  return !Number.isSafeInteger(bytes) || bytes > maxBytes;
+}
+
+/**
+ * Reads a unary upstream response without letting an untrusted body allocate past
+ * the runtime-derived wire budget. Content-Length is only an early rejection; the
+ * stream is always counted because it may be absent or dishonest.
+ */
+export async function readResponseTextWithinBudget(
+  response: Response,
+  maxBytes: number,
+  admission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
+): Promise<string> {
+  return await consumeResponseTextWithinBudget(response, maxBytes, (text) => text, admission);
+}
+
+export async function consumeResponseTextWithinBudget<T>(
+  response: Response,
+  maxBytes: number,
+  consume: (text: string) => T | Promise<T>,
+  admission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
+): Promise<T> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new Error("maxBytes must be a non-negative safe integer");
+  }
+  if (exceedsBudget(response.headers.get("content-length"), maxBytes)) {
+    await response.body?.cancel().catch(() => {});
+    throw new ResponseBodyTooLargeError(maxBytes);
+  }
+
+  const contentLength = response.headers.get("content-length");
+  const declaredBytes =
+    contentLength !== null && /^\d+$/.test(contentLength) ? Number(contentLength) : 0;
+  let lease: ResponseWorkLease;
+  try {
+    lease = acquireResponseWork(admission, declaredBytes);
+  } catch (error) {
+    await response.body?.cancel().catch(() => {});
+    throw error;
+  }
+
+  try {
+    const reader = response.body?.getReader();
+    if (reader === undefined) return await consume("");
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+          await reader.cancel().catch(() => {});
+          throw new ResponseBodyTooLargeError(maxBytes);
+        }
+        if (!lease.resize(totalBytes).ok) {
+          await reader.cancel().catch(() => {});
+          throw new ResponseWorkCapacityError(admission.capacityBytes);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const bytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return await consume(new TextDecoder().decode(bytes));
+  } finally {
+    lease.release();
+  }
+}

--- a/packages/core/src/runtime/memory-budget.test.ts
+++ b/packages/core/src/runtime/memory-budget.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { deriveRuntimeMemoryBudget } from "./memory-budget.js";
+
+describe("deriveRuntimeMemoryBudget", () => {
+  it("scales every in-memory budget from the detected runtime capacity", () => {
+    const small = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1_000,
+      constrainedMemoryBytes: 2_000,
+      rssBytes: 500,
+      heapTotalBytes: 400,
+    });
+    const large = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 2_000,
+      constrainedMemoryBytes: 4_000,
+      rssBytes: 1_000,
+      heapTotalBytes: 800,
+    });
+
+    expect(large.activeRequestBytes).toBe(small.activeRequestBytes * 2);
+    expect(large.responseWorkBytes).toBe(small.responseWorkBytes * 2);
+    expect(large.maxWireBytes).toBe(small.maxWireBytes * 2);
+    expect(
+      Math.abs(large.minRequestChargeBytes - small.minRequestChargeBytes * 2),
+    ).toBeLessThanOrEqual(1);
+    expect(Math.abs(large.writeQueueBytes - small.writeQueueBytes * 2)).toBeLessThanOrEqual(1);
+    expect(Math.abs(large.sessionCacheBytes - small.sessionCacheBytes * 2)).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(large.responseCaptureBytes - small.responseCaptureBytes * 2),
+    ).toBeLessThanOrEqual(1);
+    expect(Math.abs(large.sseTailChars - small.sseTailChars * 2)).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(large.sqlitePageCacheBytes - small.sqlitePageCacheBytes * 2),
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(large.sqliteMaintenanceCacheBytes - small.sqliteMaintenanceCacheBytes * 2),
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(large.websocketIngressBytes - small.websocketIngressBytes * 2),
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(large.websocketMaxPayloadBytes - small.websocketMaxPayloadBytes * 2),
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it("uses rss plus available memory as the process limit without cgroup constraints", () => {
+    const budget = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1_000,
+      constrainedMemoryBytes: 0,
+      rssBytes: 400,
+      heapTotalBytes: 300,
+      availableMemoryBytes: 1_600,
+    });
+
+    expect(budget.processLimitBytes).toBe(2_000);
+    expect(budget.websocketIngressBytes).toBeGreaterThan(0);
+    expect(budget.websocketMaxPayloadBytes).toBeGreaterThan(0);
+  });
+
+  it("reduces websocket ingress capacity as non-heap RSS grows", () => {
+    const quiet = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1_000,
+      constrainedMemoryBytes: 2_000,
+      rssBytes: 400,
+      heapTotalBytes: 300,
+    });
+    const busy = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1_000,
+      constrainedMemoryBytes: 2_000,
+      rssBytes: 700,
+      heapTotalBytes: 300,
+    });
+
+    expect(busy.websocketIngressBytes).toBeLessThan(quiet.websocketIngressBytes);
+  });
+
+  it("shrinks websocket max payload to native headroom and fails closed only at zero", () => {
+    const narrow = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1_000,
+      constrainedMemoryBytes: 1_050,
+      rssBytes: 200,
+      heapTotalBytes: 200,
+    });
+    const none = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1_000,
+      constrainedMemoryBytes: 1_000,
+      rssBytes: 200,
+      heapTotalBytes: 200,
+    });
+
+    expect(narrow.websocketIngressBytes).toBeGreaterThan(0);
+    expect(narrow.websocketMaxPayloadBytes).toBe(narrow.websocketIngressBytes);
+    expect(narrow.websocketMaxPayloadBytes).toBeLessThan(narrow.maxWireBytes);
+    expect(none.websocketIngressBytes).toBe(0);
+    expect(none.websocketMaxPayloadBytes).toBe(0);
+  });
+
+  it("uses the tighter process capacity for every runtime allocation", () => {
+    const budget = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1024 * 1024 * 1024,
+      constrainedMemoryBytes: 512 * 1024 * 1024,
+    });
+
+    expect(budget.processLimitBytes).toBe(512 * 1024 * 1024);
+    expect(budget.activeRequestBytes).toBe(Math.floor(budget.processLimitBytes * 0.2));
+    expect(budget.responseWorkBytes).toBe(Math.floor(budget.processLimitBytes * 0.2));
+    expect(budget.minRequestChargeBytes).toBe(Math.floor(budget.activeRequestBytes * 0.01));
+    expect(budget.writeQueueBytes).toBe(Math.floor(budget.processLimitBytes * 0.08));
+    expect(budget.sessionCacheBytes).toBe(Math.floor(budget.processLimitBytes * 0.04));
+    expect(budget.responseCaptureBytes).toBe(Math.floor(budget.processLimitBytes * 0.06));
+    expect(budget.sseTailChars).toBe(Math.floor(budget.responseCaptureBytes * 0.0004));
+    expect(budget.sqlitePageCacheBytes).toBe(Math.floor(budget.processLimitBytes * 0.03));
+  });
+
+  it("admits the production-proven request at the observed constrained heap capacity", () => {
+    const budget = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 706_740_224,
+      constrainedMemoryBytes: 706_740_224,
+    });
+
+    expect(budget.maxWireBytes).toBeGreaterThanOrEqual(22_020_096);
+    expect(budget.responseWorkBytes).toBeGreaterThanOrEqual(
+      budget.maxWireBytes * budget.jsonAmplification,
+    );
+    expect(
+      budget.activeRequestBytes +
+        budget.responseWorkBytes +
+        budget.writeQueueBytes +
+        budget.sessionCacheBytes +
+        budget.responseCaptureBytes,
+    ).toBeLessThanOrEqual(Math.floor(budget.processLimitBytes * 0.58));
+  });
+});

--- a/packages/core/src/runtime/memory-budget.test.ts
+++ b/packages/core/src/runtime/memory-budget.test.ts
@@ -56,6 +56,18 @@ describe("deriveRuntimeMemoryBudget", () => {
     expect(budget.websocketMaxPayloadBytes).toBeGreaterThan(0);
   });
 
+  it("ignores the no-limit sentinel returned by process.constrainedMemory", () => {
+    const budget = deriveRuntimeMemoryBudget({
+      heapLimitBytes: 1_000,
+      constrainedMemoryBytes: Number.MAX_SAFE_INTEGER + 1,
+      rssBytes: 400,
+      heapTotalBytes: 300,
+      availableMemoryBytes: 1_600,
+    });
+
+    expect(budget.processLimitBytes).toBe(2_000);
+  });
+
   it("reduces websocket ingress capacity as non-heap RSS grows", () => {
     const quiet = deriveRuntimeMemoryBudget({
       heapLimitBytes: 1_000,

--- a/packages/core/src/runtime/memory-budget.ts
+++ b/packages/core/src/runtime/memory-budget.ts
@@ -1,0 +1,123 @@
+import { getHeapStatistics } from "node:v8";
+
+const JSON_AMPLIFICATION = 6;
+
+export interface RuntimeMemoryBudget {
+  heapLimitBytes: number;
+  processLimitBytes: number;
+  jsonAmplification: number;
+  activeRequestBytes: number;
+  responseWorkBytes: number;
+  maxWireBytes: number;
+  minRequestChargeBytes: number;
+  writeQueueBytes: number;
+  sessionCacheBytes: number;
+  responseCaptureBytes: number;
+  sseTailChars: number;
+  sqlitePageCacheBytes: number;
+  sqliteMaintenanceCacheBytes: number;
+  websocketIngressBytes: number;
+  websocketMaxPayloadBytes: number;
+}
+
+export function deriveRuntimeMemoryBudget(input: {
+  heapLimitBytes: number;
+  constrainedMemoryBytes?: number;
+  rssBytes?: number;
+  heapTotalBytes?: number;
+  availableMemoryBytes?: number;
+}): RuntimeMemoryBudget {
+  if (!Number.isFinite(input.heapLimitBytes) || input.heapLimitBytes <= 0) {
+    throw new Error("heapLimitBytes must be positive");
+  }
+  const constrained = input.constrainedMemoryBytes ?? 0;
+  const hasConstrainedLimit = Number.isFinite(constrained) && constrained > 0;
+  const rssBytes =
+    Number.isFinite(input.rssBytes) && (input.rssBytes ?? -1) >= 0
+      ? Math.floor(input.rssBytes ?? 0)
+      : 0;
+  const availableMemoryBytes = input.availableMemoryBytes ?? 0;
+  const hasAvailableMemory = Number.isFinite(availableMemoryBytes) && availableMemoryBytes > 0;
+  const processLimitBytes = hasConstrainedLimit
+    ? constrained
+    : hasAvailableMemory
+      ? rssBytes + availableMemoryBytes
+      : input.heapLimitBytes;
+  const allocationLimitBytes = Math.min(input.heapLimitBytes, processLimitBytes);
+  const activeRequestBytes = Math.floor(allocationLimitBytes * 0.2);
+  const responseWorkBytes = Math.floor(allocationLimitBytes * 0.2);
+  const writeQueueBytes = Math.floor(allocationLimitBytes * 0.08);
+  const sessionCacheBytes = Math.floor(allocationLimitBytes * 0.04);
+  const responseCaptureBytes = Math.floor(allocationLimitBytes * 0.06);
+  const sqlitePageCacheBytes = Math.floor(processLimitBytes * 0.03);
+  const sqliteMaintenanceCacheBytes = Math.floor(sqlitePageCacheBytes / 4);
+  const maxWireBytes = Math.floor(activeRequestBytes / JSON_AMPLIFICATION);
+  const hasNativeMeasurement = hasConstrainedLimit || hasAvailableMemory;
+  const heapTotalBytes = Math.min(
+    rssBytes,
+    Number.isFinite(input.heapTotalBytes) && (input.heapTotalBytes ?? -1) >= 0
+      ? Math.floor(input.heapTotalBytes ?? 0)
+      : 0,
+  );
+  const managedHeapBytes =
+    activeRequestBytes +
+    responseWorkBytes +
+    writeQueueBytes +
+    sessionCacheBytes +
+    responseCaptureBytes;
+  // A normal unconstrained process can still grow to V8's real heap ceiling. In
+  // a tighter cgroup where V8 reports a larger host-derived ceiling, reserve the
+  // gateway's explicitly managed heap budget instead of falsely consuming the
+  // entire cgroup and reducing native capacity to zero.
+  const heapReservationCeilingBytes =
+    input.heapLimitBytes <= processLimitBytes ? input.heapLimitBytes : managedHeapBytes;
+  const futureHeapGrowthBytes = Math.max(0, heapReservationCeilingBytes - heapTotalBytes);
+  const availableProcessBytes = Math.max(0, processLimitBytes - rssBytes);
+  // Raw websocket frames live outside the JS heap until `ws` emits `message`.
+  // Reserve measured native headroom after current non-heap RSS and the SQLite
+  // caches that may still grow. If the runtime exposes neither a cgroup limit nor
+  // available memory, retain the prior heap-derived capacity instead of treating
+  // an unknown limit as genuine zero headroom.
+  const websocketIngressBytes = hasNativeMeasurement
+    ? Math.max(
+        0,
+        Math.floor(
+          availableProcessBytes -
+            futureHeapGrowthBytes -
+            sqlitePageCacheBytes -
+            sqliteMaintenanceCacheBytes,
+        ),
+      )
+    : activeRequestBytes;
+  return {
+    heapLimitBytes: input.heapLimitBytes,
+    processLimitBytes,
+    jsonAmplification: JSON_AMPLIFICATION,
+    activeRequestBytes,
+    responseWorkBytes,
+    maxWireBytes,
+    minRequestChargeBytes: Math.max(1, Math.floor(activeRequestBytes * 0.01)),
+    writeQueueBytes,
+    sessionCacheBytes,
+    responseCaptureBytes,
+    sseTailChars: Math.max(1, Math.floor(responseCaptureBytes * 0.0004)),
+    sqlitePageCacheBytes,
+    sqliteMaintenanceCacheBytes,
+    websocketIngressBytes,
+    websocketMaxPayloadBytes: Math.min(maxWireBytes, websocketIngressBytes),
+  };
+}
+
+let detected: RuntimeMemoryBudget | undefined;
+
+export function runtimeMemoryBudget(): RuntimeMemoryBudget {
+  const memory = process.memoryUsage();
+  detected ??= deriveRuntimeMemoryBudget({
+    heapLimitBytes: getHeapStatistics().heap_size_limit,
+    constrainedMemoryBytes: process.constrainedMemory(),
+    rssBytes: memory.rss,
+    heapTotalBytes: memory.heapTotal,
+    availableMemoryBytes: process.availableMemory(),
+  });
+  return detected;
+}

--- a/packages/core/src/runtime/memory-budget.ts
+++ b/packages/core/src/runtime/memory-budget.ts
@@ -31,7 +31,7 @@ export function deriveRuntimeMemoryBudget(input: {
     throw new Error("heapLimitBytes must be positive");
   }
   const constrained = input.constrainedMemoryBytes ?? 0;
-  const hasConstrainedLimit = Number.isFinite(constrained) && constrained > 0;
+  const hasConstrainedLimit = Number.isSafeInteger(constrained) && constrained > 0;
   const rssBytes =
     Number.isFinite(input.rssBytes) && (input.rssBytes ?? -1) >= 0
       ? Math.floor(input.rssBytes ?? 0)

--- a/packages/core/src/runtime/response-work-admission.test.ts
+++ b/packages/core/src/runtime/response-work-admission.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createResponseWorkAdmission } from "./response-work-admission.js";
+
+describe("response work admission", () => {
+  it("shares one amplified byte budget and releases resized leases", () => {
+    const admission = createResponseWorkAdmission({
+      capacityBytes: 60,
+      jsonAmplification: 2,
+      minChargeBytes: 6,
+    });
+
+    const first = admission.acquire(5);
+    const second = admission.acquire(10);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(admission.reservedBytes).toBe(30);
+    expect(admission.acquire(16)).toMatchObject({ ok: false, reason: "busy" });
+
+    if (!first.ok || !second.ok) throw new Error("expected response work leases");
+    expect(first.lease.resize(20)).toEqual({ ok: true });
+    expect(admission.reservedBytes).toBe(60);
+    expect(second.lease.resize(11)).toMatchObject({ ok: false, reason: "busy" });
+    first.lease.release();
+    expect(second.lease.resize(11)).toEqual({ ok: true });
+    second.lease.release();
+    second.lease.release();
+    expect(admission.reservedBytes).toBe(0);
+  });
+});

--- a/packages/core/src/runtime/response-work-admission.ts
+++ b/packages/core/src/runtime/response-work-admission.ts
@@ -1,0 +1,92 @@
+import { runtimeMemoryBudget } from "./memory-budget.js";
+
+export class ResponseWorkCapacityError extends Error {
+  constructor(readonly capacityBytes: number) {
+    super("upstream response memory capacity is temporarily exhausted");
+    this.name = "ResponseWorkCapacityError";
+  }
+}
+
+export interface ResponseWorkLease {
+  resize(wireBytes: number): { ok: true } | { ok: false; reason: "busy" };
+  release(): void;
+}
+
+export interface ResponseWorkAdmission {
+  acquire(
+    wireBytes: number,
+  ): { ok: true; lease: ResponseWorkLease } | { ok: false; reason: "busy" };
+  readonly capacityBytes: number;
+  readonly reservedBytes: number;
+}
+
+export function createResponseWorkAdmission(options: {
+  capacityBytes: number;
+  jsonAmplification: number;
+  minChargeBytes: number;
+}): ResponseWorkAdmission {
+  const capacityBytes = Math.max(1, Math.floor(options.capacityBytes));
+  const minChargeBytes = Math.max(1, Math.floor(options.minChargeBytes));
+  let reservedBytes = 0;
+  const charge = (wireBytes: number): number =>
+    Math.max(minChargeBytes, Math.ceil(Math.max(0, wireBytes) * options.jsonAmplification));
+
+  return {
+    acquire(wireBytes) {
+      let held = charge(wireBytes);
+      if (reservedBytes + held > capacityBytes) {
+        return { ok: false as const, reason: "busy" as const };
+      }
+      reservedBytes += held;
+      let released = false;
+      return {
+        ok: true as const,
+        lease: {
+          resize(nextWireBytes) {
+            if (released) return { ok: false as const, reason: "busy" as const };
+            const next = charge(nextWireBytes);
+            if (reservedBytes - held + next > capacityBytes) {
+              return { ok: false as const, reason: "busy" as const };
+            }
+            reservedBytes += next - held;
+            held = next;
+            return { ok: true as const };
+          },
+          release() {
+            if (released) return;
+            released = true;
+            reservedBytes -= held;
+          },
+        },
+      };
+    },
+    get capacityBytes() {
+      return capacityBytes;
+    },
+    get reservedBytes() {
+      return reservedBytes;
+    },
+  };
+}
+
+let detected: ResponseWorkAdmission | undefined;
+
+export function runtimeResponseWorkAdmission(): ResponseWorkAdmission {
+  if (detected !== undefined) return detected;
+  const budget = runtimeMemoryBudget();
+  detected = createResponseWorkAdmission({
+    capacityBytes: budget.responseWorkBytes,
+    jsonAmplification: budget.jsonAmplification,
+    minChargeBytes: budget.minRequestChargeBytes,
+  });
+  return detected;
+}
+
+export function acquireResponseWork(
+  admission: ResponseWorkAdmission,
+  wireBytes: number,
+): ResponseWorkLease {
+  const acquired = admission.acquire(wireBytes);
+  if (!acquired.ok) throw new ResponseWorkCapacityError(admission.capacityBytes);
+  return acquired.lease;
+}

--- a/packages/core/src/signals/scheduler.test.ts
+++ b/packages/core/src/signals/scheduler.test.ts
@@ -14,6 +14,74 @@ function fakeCollector(): SignalCollector & { calls: Array<[number, number]> } {
 }
 
 describe("startSignalScheduler", () => {
+  it("stop waits for an active collection before resolving", async () => {
+    vi.useFakeTimers();
+    try {
+      let finish = () => {};
+      const handle = startSignalScheduler({
+        collector: {
+          collect: () =>
+            new Promise((resolve) => {
+              finish = () => resolve({ written: 0, ok: true });
+            }),
+        },
+        intervalMs: 1_000,
+        now: () => Date.now(),
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      let stopped = false;
+      const stopping = handle.stop().then(() => {
+        stopped = true;
+      });
+      await Promise.resolve();
+      expect(stopped).toBe(false);
+      finish();
+      await stopping;
+      expect(stopped).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("pauseAndWait blocks new ticks and waits for the active collection", async () => {
+    vi.useFakeTimers();
+    try {
+      let finish = () => {};
+      const collect = vi.fn(
+        () =>
+          new Promise<{ written: number; ok: true }>((resolve) => {
+            finish = () => resolve({ written: 0, ok: true });
+          }),
+      );
+      const handle = startSignalScheduler({
+        collector: { collect },
+        intervalMs: 1_000,
+        now: () => Date.now(),
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      let paused = false;
+      const waiting = handle.pauseAndWait().then(() => {
+        paused = true;
+      });
+      await Promise.resolve();
+      expect(paused).toBe(false);
+      finish();
+      await waiting;
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(collect).toHaveBeenCalledTimes(1);
+      handle.resume();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(collect).toHaveBeenCalledTimes(2);
+      finish();
+      await Promise.resolve();
+      handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("runs collect once per interval over the just-elapsed window, and stop() halts it", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/signals/scheduler.ts
+++ b/packages/core/src/signals/scheduler.ts
@@ -21,7 +21,9 @@ export interface SignalSchedulerDeps {
 }
 
 export interface SignalSchedulerHandle {
-  stop(): void;
+  stop(): Promise<void>;
+  pauseAndWait(): Promise<void>;
+  resume(): void;
 }
 
 export function startSignalScheduler(deps: SignalSchedulerDeps): SignalSchedulerHandle {
@@ -29,9 +31,11 @@ export function startSignalScheduler(deps: SignalSchedulerDeps): SignalScheduler
   let prevTick = deps.now();
   let retryWindow: [number, number] | null = null;
   let inFlight = false;
+  let paused = false;
+  const idleWaiters: Array<() => void> = [];
 
   const timer = setInterval(() => {
-    if (inFlight) return;
+    if (paused || inFlight) return;
     const [windowStart, windowEnd] = retryWindow ?? [prevTick, deps.now()];
     inFlight = true;
     // Fire-and-forget; collect() is fail-open in normal operation, but the scheduler
@@ -58,6 +62,7 @@ export function startSignalScheduler(deps: SignalSchedulerDeps): SignalScheduler
       })
       .finally(() => {
         inFlight = false;
+        for (const resolve of idleWaiters.splice(0)) resolve();
       });
   }, deps.intervalMs);
 
@@ -65,8 +70,19 @@ export function startSignalScheduler(deps: SignalSchedulerDeps): SignalScheduler
   (timer as { unref?: () => void }).unref?.();
 
   return {
-    stop() {
+    async stop() {
       clearInterval(timer);
+      paused = true;
+      if (!inFlight) return;
+      await new Promise<void>((resolve) => idleWaiters.push(resolve));
+    },
+    async pauseAndWait() {
+      paused = true;
+      if (!inFlight) return;
+      await new Promise<void>((resolve) => idleWaiters.push(resolve));
+    },
+    resume() {
+      paused = false;
     },
   };
 }

--- a/packages/core/src/store/factory.test.ts
+++ b/packages/core/src/store/factory.test.ts
@@ -2,9 +2,10 @@ import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StoreConfig } from "@helm/shared";
-import { describe, expect, it } from "vitest";
-import { createStore } from "./factory.js";
+import { describe, expect, it, vi } from "vitest";
+import { createStore, vacuumSqlite } from "./factory.js";
 import { SqliteKeyStore } from "./sqlite/keystore.js";
+import { createSqliteDb } from "./sqlite/migrate.js";
 
 // The factory is the single config-driven switch point: core depends only on the
 // Store ports, the factory binds the concrete driver ONCE (CLAUDE.md "DB abstraction layer").
@@ -31,6 +32,27 @@ describe("createStore factory", () => {
     const store = await createStore({ store: { driver: "sqlite" }, dataDir });
     expect(existsSync(join(dataDir, "helm.db"))).toBe(true);
     await store.close();
+  });
+
+  it("runs VACUUM in low-memory mode and restores normal SQLite pragmas", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "helm-factory-vacuum-"));
+    const db = createSqliteDb(join(dataDir, "helm.db"));
+    const before = {
+      cacheSize: db.$sqlite.pragma("cache_size", { simple: true }),
+      tempStore: db.$sqlite.pragma("temp_store", { simple: true }),
+    };
+    db.$sqlite.exec("CREATE TABLE reclaimable (value BLOB)");
+    db.$sqlite.prepare("INSERT INTO reclaimable VALUES (?)").run(Buffer.alloc(4 * 1024 * 1024));
+    db.$sqlite.exec("DROP TABLE reclaimable");
+    const pragma = vi.spyOn(db.$sqlite, "pragma");
+    await vacuumSqlite(db.$sqlite, { maintenanceCacheBytes: 1024 * 1024 });
+    expect(pragma).toHaveBeenCalledWith("shrink_memory");
+    const after = {
+      cacheSize: db.$sqlite.pragma("cache_size", { simple: true }),
+      tempStore: db.$sqlite.pragma("temp_store", { simple: true }),
+    };
+    expect(after).toEqual(before);
+    db.$sqlite.close();
   });
 
   it("fails closed when driver=supabase has no connection string", async () => {

--- a/packages/core/src/store/factory.ts
+++ b/packages/core/src/store/factory.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { StoreConfig } from "@helm/shared";
+import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
 import type {
   BudgetStore,
   ConfigStore,
@@ -35,6 +36,9 @@ import { SqliteOAuthUsageStore } from "./sqlite/oauth-usage.js";
 import { SqliteRateLimitStore } from "./sqlite/rate-limit.js";
 import { SqliteSignalStore } from "./sqlite/signals.js";
 import { SqliteTelemetryStore } from "./sqlite/telemetry.js";
+import { vacuumSqlite } from "./sqlite/vacuum.js";
+
+export { vacuumSqlite } from "./sqlite/vacuum.js";
 
 // The full set of Store-port implementations the gateway needs, plus a `close`
 // lifecycle hook. The driver (sqlite vs supabase) is chosen ONCE here by config;
@@ -54,9 +58,8 @@ export interface StoreSet {
   readonly oauthUsage: OAuthUsageStore;
   readonly oauthQuota: OAuthQuotaStore;
   // Reclaim on-disk space after a cleanup sweep. sqlite runs VACUUM (rewrites the
-  // file under an EXCLUSIVE lock — manual/off-hours only); postgres is a no-op (it
-  // autovacuums). Optional + driver-specific; the admin "Compact database" button
-  // calls it, never the scheduled runner.
+  // file under an EXCLUSIVE lock in the gateway's serialized off-hours maintenance
+  // window); postgres is a no-op because it autovacuums.
   readonly vacuum: () => Promise<void>;
   readonly close: () => Promise<void>;
 }
@@ -95,11 +98,12 @@ export async function createStore(opts: CreateStoreOptions): Promise<StoreSet> {
         oauthTokens: new SqliteOAuthTokenStore(db),
         oauthUsage: new SqliteOAuthUsageStore(db),
         oauthQuota: new SqliteOAuthQuotaStore(db),
-        // VACUUM cannot run inside a transaction; it takes an exclusive lock and
-        // rewrites the whole file. Manual "Compact database" only — never scheduled.
-        vacuum: async () => {
-          db.$sqlite.exec("VACUUM");
-        },
+        // VACUUM cannot run inside a transaction. The helper checkpoints WAL, sheds
+        // SQLite cache memory, uses file-backed temp storage, then restores pragmas.
+        vacuum: () =>
+          vacuumSqlite(db.$sqlite, {
+            maintenanceCacheBytes: runtimeMemoryBudget().sqliteMaintenanceCacheBytes,
+          }),
         close: async () => {
           db.$sqlite.close();
         },

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -19,12 +19,19 @@ export type {
   RateLimitStore,
   RequestPayload,
   SessionRecord,
+  SessionRevisionPage,
+  SessionRevisionPageOptions,
   SessionRevisionRecord,
   SignalStore,
   TelemetryStore,
   UpsertSessionRevisionInput,
 } from "./ports.js";
-export { SESSION_MAX_REVISIONS, SESSION_MAX_STORED_BYTES } from "./ports.js";
+export {
+  PERSISTED_SESSION_MAX_REVISIONS,
+  PERSISTED_SESSION_MAX_STORED_BYTES,
+  SESSION_MAX_REVISIONS,
+  SESSION_MAX_STORED_BYTES,
+} from "./ports.js";
 // Postgres (supabase) adapters + migration helpers. supabase == hosted Postgres,
 // reached via postgres-js; the same adapters run against in-process PGlite in
 // tests (drizzle pg dialect), validating the supabase path without a server.

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -353,8 +353,15 @@ export interface SessionRecord {
   storedBytes: number;
 }
 
-export const SESSION_MAX_REVISIONS = 10_000;
-export const SESSION_MAX_STORED_BYTES = 64 * 1024 * 1024;
+// Persistent per-Session database quotas. These bound retained revision history;
+// they are not runtime heap, request-admission, or cache-memory limits.
+export const PERSISTED_SESSION_MAX_REVISIONS = 10_000;
+export const PERSISTED_SESSION_MAX_STORED_BYTES = 64 * 1024 * 1024;
+
+/** @deprecated Use PERSISTED_SESSION_MAX_REVISIONS. */
+export const SESSION_MAX_REVISIONS = PERSISTED_SESSION_MAX_REVISIONS;
+/** @deprecated Use PERSISTED_SESSION_MAX_STORED_BYTES. */
+export const SESSION_MAX_STORED_BYTES = PERSISTED_SESSION_MAX_STORED_BYTES;
 
 export interface SessionRevisionRecord {
   sessionRef: string;
@@ -368,6 +375,22 @@ export interface SessionRevisionRecord {
   responseJson: string | null;
   fidelity: string;
   createdAt: Date;
+}
+
+export interface SessionRevisionPageOptions {
+  afterSequence?: number;
+  limit: number;
+  // Maximum UTF-8 bytes of revision data the adapter may materialize for this page.
+  maxBytes: number;
+}
+
+export interface SessionRevisionPage {
+  revisions: SessionRevisionRecord[];
+  // Last returned sequence when another page exists; null when this is the final page.
+  nextSequence: number | null;
+  // True when the next row would exceed maxBytes. Callers must not treat a partial
+  // page as a recoverable Session chain.
+  limited: boolean;
 }
 
 // One telemetry row as exported by the archive scan — engine-neutral and
@@ -534,6 +557,10 @@ export interface TelemetryStore {
   getSessionByRef?(sessionRef: string): Promise<SessionRecord | null>;
   listSessionsByRefs?(sessionRefs: readonly string[]): Promise<SessionRecord[]>;
   listSessionRevisions?(sessionRef: string): Promise<SessionRevisionRecord[]>;
+  listSessionRevisionsPage?(
+    sessionRef: string,
+    options: SessionRevisionPageOptions,
+  ): Promise<SessionRevisionPage>;
   getSessionRevisionByResponseId?(
     sessionRef: string,
     responseId: string,

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -13,6 +13,8 @@ import type {
   RequestPayloadPart,
   RequestPayloadPartRecord,
   SessionRecord,
+  SessionRevisionPage,
+  SessionRevisionPageOptions,
   SessionRevisionRecord,
   TelemetryAggregate,
   TelemetryArchiveRow,
@@ -22,7 +24,7 @@ import type {
   TelemetryStore,
   UpsertSessionRevisionInput,
 } from "../ports.js";
-import { SESSION_MAX_REVISIONS, SESSION_MAX_STORED_BYTES } from "../ports.js";
+import { PERSISTED_SESSION_MAX_REVISIONS, PERSISTED_SESSION_MAX_STORED_BYTES } from "../ports.js";
 import { likeContains } from "../sql-like.js";
 import { denormalizedDecisionCost } from "../telemetry-cost.js";
 import type { PgDb } from "./migrate.js";
@@ -40,6 +42,19 @@ const BLOB_SHA_RE = /helm-blob:sha256:([0-9a-f]{64})/g;
 type PgWriter = Pick<PgDb, "insert">;
 
 type TelemetryRow = typeof telemetry.$inferSelect;
+
+function boundedSessionPageLimit(options: SessionRevisionPageOptions): number {
+  if (!Number.isSafeInteger(options.limit) || options.limit <= 0)
+    throw new Error("session revision page limit must be a positive integer");
+  if (!Number.isSafeInteger(options.maxBytes) || options.maxBytes < 0)
+    throw new Error("session revision page maxBytes must be a non-negative integer");
+  if (
+    options.afterSequence !== undefined &&
+    (!Number.isSafeInteger(options.afterSequence) || options.afterSequence < 0)
+  )
+    throw new Error("session revision page cursor must be a non-negative integer");
+  return Math.min(options.limit, 500);
+}
 
 // Postgres adapter for the TelemetryStore port — the supabase implementation.
 // Same contract as SqliteTelemetryStore, but async and storing the redacted
@@ -141,7 +156,7 @@ export class PgTelemetryStore implements TelemetryStore {
             ? Buffer.byteLength(input.responseJson, "utf8")
             : 0;
         if (responseBytes === 0) return;
-        if (lockedSession.storedBytes + responseBytes > SESSION_MAX_STORED_BYTES)
+        if (lockedSession.storedBytes + responseBytes > PERSISTED_SESSION_MAX_STORED_BYTES)
           throw new Error("session capture limit exceeded");
         await tx
           .update(sessions)
@@ -182,8 +197,8 @@ export class PgTelemetryStore implements TelemetryStore {
         .where(
           and(
             eq(sessions.sessionRef, input.sessionRef),
-            lt(sessions.revisionCount, SESSION_MAX_REVISIONS),
-            sql`${sessions.storedBytes} + ${storedBytes} <= ${SESSION_MAX_STORED_BYTES}`,
+            lt(sessions.revisionCount, PERSISTED_SESSION_MAX_REVISIONS),
+            sql`${sessions.storedBytes} + ${storedBytes} <= ${PERSISTED_SESSION_MAX_STORED_BYTES}`,
           ),
         )
         .returning();
@@ -258,6 +273,61 @@ export class PgTelemetryStore implements TelemetryStore {
       ...row,
       createdAt: new Date(row.createdAt),
     }));
+  }
+
+  async listSessionRevisionsPage(
+    sessionRef: string,
+    options: SessionRevisionPageOptions,
+  ): Promise<SessionRevisionPage> {
+    const limit = boundedSessionPageLimit(options);
+    const afterSequence = options.afterSequence ?? 0;
+    const rowBytes = sql<number>`
+      octet_length(${sessionRevisions.sessionRef}) +
+      octet_length(${sessionRevisions.requestId}) +
+      octet_length(coalesce(${sessionRevisions.parentRequestId}, '')) +
+      octet_length(${sessionRevisions.requestDeltaJson}) +
+      octet_length(${sessionRevisions.requestEnvelopeJson}) +
+      octet_length(coalesce(${sessionRevisions.responseId}, '')) +
+      octet_length(coalesce(${sessionRevisions.responseJson}, '')) +
+      octet_length(${sessionRevisions.fidelity}) + 64
+    `;
+    const metadata = await this.db
+      .select({ sequence: sessionRevisions.sequence, bytes: rowBytes })
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          gt(sessionRevisions.sequence, afterSequence),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence))
+      .limit(limit + 1);
+    const selected: number[] = [];
+    let usedBytes = 0;
+    for (const row of metadata.slice(0, limit)) {
+      const bytes = Number(row.bytes);
+      if (!Number.isSafeInteger(bytes) || bytes < 0 || usedBytes + bytes > options.maxBytes) {
+        return { revisions: [], nextSequence: null, limited: true };
+      }
+      selected.push(row.sequence);
+      usedBytes += bytes;
+    }
+    if (selected.length === 0) return { revisions: [], nextSequence: null, limited: false };
+    const rows = await this.db
+      .select()
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          inArray(sessionRevisions.sequence, selected),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence));
+    return {
+      revisions: rows.map((row) => ({ ...row, createdAt: new Date(row.createdAt) })),
+      nextSequence: metadata.length > selected.length ? (selected.at(-1) ?? null) : null,
+      limited: false,
+    };
   }
 
   async getSessionRevisionByResponseId(

--- a/packages/core/src/store/session-delta.ts
+++ b/packages/core/src/store/session-delta.ts
@@ -1,9 +1,12 @@
+import { isDeepStrictEqual } from "node:util";
+
 export interface SessionRequestDelta {
   eventKey: "messages" | "contents" | "input";
   retainCount: number;
   eventsJson: string;
   envelopeJson: string;
   fidelity: "verbatim" | "semantic";
+  previousResponseId: string | null;
 }
 
 const EVENT_KEYS = ["messages", "contents", "input"] as const;
@@ -26,11 +29,7 @@ function array(value: unknown): unknown[] {
 
 function prefixLength(previous: unknown[], current: unknown[]): number {
   let n = 0;
-  while (
-    n < previous.length &&
-    n < current.length &&
-    JSON.stringify(previous[n]) === JSON.stringify(current[n])
-  )
+  while (n < previous.length && n < current.length && isDeepStrictEqual(previous[n], current[n]))
     n++;
   return n;
 }
@@ -46,6 +45,7 @@ export function splitSessionRequestJson(
   const current = array(request[key]);
   const hasPreviousResponse =
     typeof request.previous_response_id === "string" && request.previous_response_id.trim() !== "";
+  const previousResponseId = hasPreviousResponse ? (request.previous_response_id as string) : null;
   const previous = previousEventsJson === undefined ? [] : array(JSON.parse(previousEventsJson));
   const retainCount = hasPreviousResponse ? 0 : prefixLength(previous, current);
   // Keep the carrier with an empty array so recovery can identify its protocol
@@ -57,6 +57,7 @@ export function splitSessionRequestJson(
     eventsJson: JSON.stringify(current.slice(retainCount)),
     envelopeJson: JSON.stringify(envelope),
     fidelity: "semantic",
+    previousResponseId,
   };
 }
 

--- a/packages/core/src/store/sqlite/migrate.pragmas.test.ts
+++ b/packages/core/src/store/sqlite/migrate.pragmas.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { runtimeMemoryBudget } from "../../runtime/memory-budget.js";
 import { createSqliteDb, runMigrations } from "./migrate.js";
 
 // Performance contract (perf-sqlite-fastpath): better-sqlite3 is SYNCHRONOUS, so
@@ -20,9 +21,10 @@ describe("sqlite connection pragmas", () => {
       expect(raw.pragma("busy_timeout", { simple: true })).toBe(5000);
       // temp_store: 0=DEFAULT, 1=FILE, 2=MEMORY. We want MEMORY.
       expect(raw.pragma("temp_store", { simple: true })).toBe(2);
-      // cache_size negative => KiB. 64 MiB keeps the hot admin indexes resident
-      // without putting meaningful pressure on a small self-hosted machine.
-      expect(raw.pragma("cache_size", { simple: true })).toBe(-65536);
+      // cache_size negative => KiB, scaled from the process memory constraint.
+      expect(raw.pragma("cache_size", { simple: true })).toBe(
+        -Math.floor(runtimeMemoryBudget().sqlitePageCacheBytes / 1024),
+      );
     } finally {
       db.$sqlite.close();
     }

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -7,6 +7,7 @@ import {
   quarantinedMalformedJobThreadId,
   quarantinedRawThreadId,
 } from "../../memory/thread-scope.js";
+import { runtimeMemoryBudget } from "../../runtime/memory-budget.js";
 import * as schema from "./schema.js";
 
 type Schema = typeof schema;
@@ -1259,15 +1260,14 @@ function applyMigrations(db: Database.Database): void {
 //                        instantly (defensive: migrations + the runtime handle can
 //                        briefly contend the same file).
 //   - temp_store=MEMORY  keep transient B-trees/sorts in RAM, off the disk path.
-//   - cache_size=-65536  64MiB page cache (negative => KiB) for hot indexes. This
-//                        remains conservative on the supported small self-hosted
-//                        machines while avoiding needless cold-page churn.
+//   - cache_size         page cache scaled from the process memory constraint.
 function applyPragmas(sqlite: Database.Database): void {
+  const cacheKiB = Math.max(1, Math.floor(runtimeMemoryBudget().sqlitePageCacheBytes / 1024));
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("synchronous = NORMAL");
   sqlite.pragma("busy_timeout = 5000");
   sqlite.pragma("temp_store = MEMORY");
-  sqlite.pragma("cache_size = -65536");
+  sqlite.pragma(`cache_size = -${cacheKiB}`);
 }
 
 // docs/14 — load the sqlite-vec extension on a connection so the vec0 virtual table

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -14,6 +14,8 @@ import type {
   RequestPayloadPart,
   RequestPayloadPartRecord,
   SessionRecord,
+  SessionRevisionPage,
+  SessionRevisionPageOptions,
   SessionRevisionRecord,
   TelemetryAggregate,
   TelemetryArchiveRow,
@@ -23,13 +25,26 @@ import type {
   TelemetryStore,
   UpsertSessionRevisionInput,
 } from "../ports.js";
-import { SESSION_MAX_REVISIONS, SESSION_MAX_STORED_BYTES } from "../ports.js";
+import { PERSISTED_SESSION_MAX_REVISIONS, PERSISTED_SESSION_MAX_STORED_BYTES } from "../ports.js";
 import { likeContains } from "../sql-like.js";
 import { denormalizedDecisionCost } from "../telemetry-cost.js";
 import type { SqliteDb } from "./migrate.js";
 import { payloadBlobs, requestPayloads, sessionRevisions, sessions, telemetry } from "./schema.js";
 
 type TelemetryRow = typeof telemetry.$inferSelect;
+
+function boundedSessionPageLimit(options: SessionRevisionPageOptions): number {
+  if (!Number.isSafeInteger(options.limit) || options.limit <= 0)
+    throw new Error("session revision page limit must be a positive integer");
+  if (!Number.isSafeInteger(options.maxBytes) || options.maxBytes < 0)
+    throw new Error("session revision page maxBytes must be a non-negative integer");
+  if (
+    options.afterSequence !== undefined &&
+    (!Number.isSafeInteger(options.afterSequence) || options.afterSequence < 0)
+  )
+    throw new Error("session revision page cursor must be a non-negative integer");
+  return Math.min(options.limit, 500);
+}
 
 // SQLite adapter for the TelemetryStore port. Persists a redacted DecisionRecord
 // as JSON text (SQLite has no native jsonb); denormalizes final_status/cost for
@@ -131,7 +146,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
           .where(eq(sessions.sessionRef, input.sessionRef))
           .get();
         if (!session) throw new Error("session row missing after insert");
-        if (session.storedBytes + responseBytes > SESSION_MAX_STORED_BYTES)
+        if (session.storedBytes + responseBytes > PERSISTED_SESSION_MAX_STORED_BYTES)
           throw new Error("session capture limit exceeded");
         this.db
           .update(sessions)
@@ -170,8 +185,8 @@ export class SqliteTelemetryStore implements TelemetryStore {
         .get();
       if (!session) throw new Error("session row missing after insert");
       if (
-        session.revisionCount >= SESSION_MAX_REVISIONS ||
-        session.storedBytes + storedBytes > SESSION_MAX_STORED_BYTES
+        session.revisionCount >= PERSISTED_SESSION_MAX_REVISIONS ||
+        session.storedBytes + storedBytes > PERSISTED_SESSION_MAX_STORED_BYTES
       ) {
         throw new Error("session capture limit exceeded");
       }
@@ -241,6 +256,64 @@ export class SqliteTelemetryStore implements TelemetryStore {
       .orderBy(asc(sessionRevisions.sequence))
       .all()
       .map((row) => ({ ...row }));
+  }
+
+  async listSessionRevisionsPage(
+    sessionRef: string,
+    options: SessionRevisionPageOptions,
+  ): Promise<SessionRevisionPage> {
+    const limit = boundedSessionPageLimit(options);
+    const afterSequence = options.afterSequence ?? 0;
+    const rowBytes = sql<number>`
+      length(CAST(${sessionRevisions.sessionRef} AS BLOB)) +
+      length(CAST(${sessionRevisions.requestId} AS BLOB)) +
+      coalesce(length(CAST(${sessionRevisions.parentRequestId} AS BLOB)), 0) +
+      length(CAST(${sessionRevisions.requestDeltaJson} AS BLOB)) +
+      length(CAST(${sessionRevisions.requestEnvelopeJson} AS BLOB)) +
+      coalesce(length(CAST(${sessionRevisions.responseId} AS BLOB)), 0) +
+      coalesce(length(CAST(${sessionRevisions.responseJson} AS BLOB)), 0) +
+      length(CAST(${sessionRevisions.fidelity} AS BLOB)) + 64
+    `;
+    const metadata = this.db
+      .select({ sequence: sessionRevisions.sequence, bytes: rowBytes })
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          gt(sessionRevisions.sequence, afterSequence),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence))
+      .limit(limit + 1)
+      .all();
+    const selected: number[] = [];
+    let usedBytes = 0;
+    for (const row of metadata.slice(0, limit)) {
+      const bytes = Number(row.bytes);
+      if (!Number.isSafeInteger(bytes) || bytes < 0 || usedBytes + bytes > options.maxBytes) {
+        return { revisions: [], nextSequence: null, limited: true };
+      }
+      selected.push(row.sequence);
+      usedBytes += bytes;
+    }
+    if (selected.length === 0) return { revisions: [], nextSequence: null, limited: false };
+    const revisions = this.db
+      .select()
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          inArray(sessionRevisions.sequence, selected),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence))
+      .all()
+      .map((row) => ({ ...row }));
+    return {
+      revisions,
+      nextSequence: metadata.length > selected.length ? (selected.at(-1) ?? null) : null,
+      limited: false,
+    };
   }
 
   async getSessionRevisionByResponseId(

--- a/packages/core/src/store/sqlite/vacuum.test.ts
+++ b/packages/core/src/store/sqlite/vacuum.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSqliteDb } from "./migrate.js";
+import {
+  assertVacuumDiskCapacity,
+  assertVacuumMemoryCapacity,
+  shouldRunVacuumForFreelist,
+  vacuumSqlite,
+} from "./vacuum.js";
+
+const cleanup: string[] = [];
+const safeMemory = { processLimitBytes: 1_000_000_000, availableMemoryBytes: 500_000_000 };
+
+function tempDb() {
+  const dir = mkdtempSync(join(tmpdir(), "helm-vacuum-worker-"));
+  cleanup.push(dir);
+  const path = join(dir, "helm.db");
+  const db = createSqliteDb(path);
+  return { db, path };
+}
+
+afterEach(() => {
+  for (const dir of cleanup.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("sqlite VACUUM worker", () => {
+  it("runs off the main event loop and preserves existing data", async () => {
+    const { db } = tempDb();
+    try {
+      db.$sqlite.exec("CREATE TABLE vacuum_probe (id INTEGER PRIMARY KEY, value BLOB)");
+      db.$sqlite
+        .prepare("INSERT INTO vacuum_probe (id, value) VALUES (1, ?), (2, ?)")
+        .run(Buffer.from("keep"), Buffer.alloc(4 * 1024 * 1024));
+      db.$sqlite.prepare("DELETE FROM vacuum_probe WHERE id = 2").run();
+      expect(Number(db.$sqlite.pragma("freelist_count", { simple: true }))).toBeGreaterThan(0);
+
+      let eventLoopTurned = false;
+      const eventLoopTurn = new Promise<void>((resolve) =>
+        setImmediate(() => {
+          eventLoopTurned = true;
+          resolve();
+        }),
+      );
+      const vacuum = vacuumSqlite(db.$sqlite, {
+        maintenanceCacheBytes: 1024 * 1024,
+        ...safeMemory,
+      });
+
+      await eventLoopTurn;
+      expect(eventLoopTurned).toBe(true);
+      await vacuum;
+      expect(db.$sqlite.prepare("SELECT value FROM vacuum_probe WHERE id = 1").get()).toEqual({
+        value: Buffer.from("keep"),
+      });
+      expect(db.$sqlite.pragma("integrity_check", { simple: true })).toBe("ok");
+    } finally {
+      db.$sqlite.close();
+    }
+  });
+
+  it("calculates the fail-closed disk requirement from the database and WAL sizes", () => {
+    expect(() =>
+      assertVacuumDiskCapacity({
+        databaseBytes: 10_000n,
+        walBytes: 2_000n,
+        availableBytes: 23_999n,
+      }),
+    ).toThrow(/insufficient disk space/);
+  });
+
+  it("requires dynamic process memory headroom before starting the worker", () => {
+    expect(() =>
+      assertVacuumMemoryCapacity({
+        processLimitBytes: 1_000_000_000,
+        availableBytes: 249_999_999,
+      }),
+    ).toThrow(/insufficient memory/);
+    expect(() =>
+      assertVacuumMemoryCapacity({
+        processLimitBytes: 1_000_000_000,
+        availableBytes: 250_000_000,
+      }),
+    ).not.toThrow();
+  });
+
+  it("skips a full rewrite when free pages are below the database-relative threshold", () => {
+    expect(shouldRunVacuumForFreelist({ freelistPages: 49, totalPages: 1_000 })).toBe(false);
+    expect(shouldRunVacuumForFreelist({ freelistPages: 50, totalPages: 1_000 })).toBe(true);
+  });
+
+  it("fails closed when WAL checkpoint is busy and leaves data intact", async () => {
+    const { db, path } = tempDb();
+    const reader = new Database(path);
+    try {
+      reader.pragma("journal_mode = WAL");
+      db.$sqlite.exec("CREATE TABLE checkpoint_probe (id INTEGER PRIMARY KEY, value TEXT)");
+      db.$sqlite.prepare("INSERT INTO checkpoint_probe VALUES (1, 'keep')").run();
+      db.$sqlite.pragma("wal_checkpoint(TRUNCATE)");
+      reader.exec("BEGIN");
+      reader.prepare("SELECT * FROM checkpoint_probe").get();
+      db.$sqlite.prepare("INSERT INTO checkpoint_probe VALUES (2, 'after-reader')").run();
+      db.$sqlite.exec("CREATE TABLE free_pages (value BLOB)");
+      db.$sqlite.prepare("INSERT INTO free_pages VALUES (?)").run(Buffer.alloc(1024 * 1024));
+      db.$sqlite.exec("DROP TABLE free_pages");
+
+      await expect(
+        vacuumSqlite(db.$sqlite, { maintenanceCacheBytes: 1024 * 1024, ...safeMemory }),
+      ).rejects.toThrow(/checkpoint is busy/);
+      expect(db.$sqlite.prepare("SELECT value FROM checkpoint_probe ORDER BY id").all()).toEqual([
+        { value: "keep" },
+        { value: "after-reader" },
+      ]);
+    } finally {
+      reader.exec("ROLLBACK");
+      reader.close();
+      db.$sqlite.close();
+    }
+  });
+
+  it("does not rewrite a database with no free pages", async () => {
+    const { db } = tempDb();
+    try {
+      expect(db.$sqlite.pragma("freelist_count", { simple: true })).toBe(0);
+      await expect(
+        vacuumSqlite(db.$sqlite, { maintenanceCacheBytes: 1024 * 1024, ...safeMemory }),
+      ).resolves.toBeUndefined();
+    } finally {
+      db.$sqlite.close();
+    }
+  });
+});

--- a/packages/core/src/store/sqlite/vacuum.ts
+++ b/packages/core/src/store/sqlite/vacuum.ts
@@ -1,0 +1,211 @@
+import { stat, statfs } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { Worker } from "node:worker_threads";
+import type Database from "better-sqlite3";
+import { runtimeMemoryBudget } from "../../runtime/memory-budget.js";
+
+export function shouldRunVacuumForFreelist(args: {
+  freelistPages: number;
+  totalPages: number;
+}): boolean {
+  if (
+    !Number.isSafeInteger(args.freelistPages) ||
+    args.freelistPages < 0 ||
+    !Number.isSafeInteger(args.totalPages) ||
+    args.totalPages <= 0
+  ) {
+    throw new Error("invalid sqlite page counts");
+  }
+  if (args.freelistPages === 0) return false;
+  return args.freelistPages * 20 >= args.totalPages;
+}
+
+export function assertVacuumMemoryCapacity(args: {
+  processLimitBytes: number;
+  availableBytes: number;
+}): void {
+  if (
+    !Number.isFinite(args.processLimitBytes) ||
+    args.processLimitBytes <= 0 ||
+    !Number.isFinite(args.availableBytes) ||
+    args.availableBytes < 0
+  ) {
+    throw new Error("invalid process memory capacity");
+  }
+  const requiredBytes = Math.floor(args.processLimitBytes * 0.25);
+  if (args.availableBytes < requiredBytes) {
+    throw new Error(
+      `insufficient memory for sqlite VACUUM: required=${requiredBytes} available=${Math.floor(args.availableBytes)}`,
+    );
+  }
+}
+
+export function assertVacuumDiskCapacity(args: {
+  databaseBytes: bigint;
+  walBytes: bigint;
+  availableBytes: bigint;
+}): void {
+  const requiredBytes = (args.databaseBytes + args.walBytes) * 2n;
+  if (args.availableBytes < requiredBytes) {
+    throw new Error(
+      `insufficient disk space for sqlite VACUUM: required=${requiredBytes} available=${args.availableBytes}`,
+    );
+  }
+}
+
+async function optionalFileSize(path: string): Promise<bigint> {
+  try {
+    return (await stat(path, { bigint: true })).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0n;
+    throw error;
+  }
+}
+
+async function assertVacuumFileSystemCapacity(databasePath: string): Promise<void> {
+  const [databaseBytes, walBytes, fileSystem] = await Promise.all([
+    stat(databasePath, { bigint: true }).then((value) => value.size),
+    optionalFileSize(`${databasePath}-wal`),
+    statfs(dirname(databasePath), { bigint: true }),
+  ]);
+  assertVacuumDiskCapacity({
+    databaseBytes,
+    walBytes,
+    availableBytes: fileSystem.bavail * fileSystem.bsize,
+  });
+}
+
+const vacuumWorkerSource = `
+const { parentPort, workerData } = require("node:worker_threads");
+const Database = require(workerData.betterSqlite3Path);
+
+const message = (error) => error instanceof Error ? error.message : String(error);
+let result;
+let sqlite;
+try {
+  sqlite = new Database(workerData.databasePath, { fileMustExist: true });
+  sqlite.pragma("busy_timeout = 0");
+  const checkpoint = sqlite.pragma("wal_checkpoint(TRUNCATE)");
+  if (!Array.isArray(checkpoint) || checkpoint.length !== 1 || checkpoint[0].busy !== 0) {
+    throw new Error("sqlite checkpoint is busy");
+  }
+
+  const freelistCount = Number(sqlite.pragma("freelist_count", { simple: true }));
+  if (!Number.isFinite(freelistCount) || freelistCount < 0) {
+    throw new Error("invalid sqlite freelist_count");
+  }
+
+  if (freelistCount === 0) {
+    result = { ok: true, noOp: true };
+  } else {
+    const normalCacheSize = Number(sqlite.pragma("cache_size", { simple: true }));
+    const normalTempStore = Number(sqlite.pragma("temp_store", { simple: true }));
+    let primaryError;
+    const restoreErrors = [];
+    try {
+      sqlite.pragma("busy_timeout = 5000");
+      sqlite.pragma("temp_store = FILE");
+      sqlite.pragma("cache_size = -" + workerData.maintenanceCacheKiB);
+      sqlite.pragma("shrink_memory");
+      sqlite.exec("VACUUM");
+    } catch (error) {
+      primaryError = error;
+    }
+    try {
+      sqlite.pragma("temp_store = " + normalTempStore);
+    } catch (error) {
+      restoreErrors.push("temp_store: " + message(error));
+    }
+    try {
+      sqlite.pragma("cache_size = " + normalCacheSize);
+    } catch (error) {
+      restoreErrors.push("cache_size: " + message(error));
+    }
+    if (primaryError || restoreErrors.length > 0) {
+      const details = restoreErrors.length > 0 ? "; restore failed: " + restoreErrors.join(", ") : "";
+      throw new Error((primaryError ? message(primaryError) : "sqlite pragma restore failed") + details);
+    }
+    result = { ok: true, noOp: false };
+  }
+} catch (error) {
+  result = { ok: false, error: message(error) };
+}
+
+if (sqlite) {
+  try {
+    sqlite.close();
+  } catch (error) {
+    if (result && result.ok) result = { ok: false, error: "sqlite close failed: " + message(error) };
+  }
+}
+parentPort.postMessage(result);
+`;
+
+interface VacuumWorkerResult {
+  ok: boolean;
+  error?: string;
+}
+
+function runVacuumWorker(args: {
+  databasePath: string;
+  maintenanceCacheKiB: number;
+}): Promise<void> {
+  const betterSqlite3Path = createRequire(import.meta.url).resolve("better-sqlite3");
+  return new Promise<void>((resolvePromise, rejectPromise) => {
+    const worker = new Worker(vacuumWorkerSource, {
+      eval: true,
+      workerData: { ...args, betterSqlite3Path },
+    });
+    let settled = false;
+    const rejectOnce = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      rejectPromise(error);
+    };
+    worker.once("message", (value: VacuumWorkerResult) => {
+      if (settled) return;
+      settled = true;
+      if (value?.ok) resolvePromise();
+      else rejectPromise(new Error(value?.error ?? "sqlite VACUUM worker failed"));
+    });
+    worker.once("error", rejectOnce);
+    worker.once("exit", (code) => {
+      if (!settled) rejectOnce(new Error(`sqlite VACUUM worker exited before reporting: ${code}`));
+    });
+  });
+}
+
+export async function vacuumSqlite(
+  sqlite: Database.Database,
+  options: {
+    maintenanceCacheBytes: number;
+    processLimitBytes?: number;
+    availableMemoryBytes?: number;
+  },
+): Promise<void> {
+  if (!Number.isFinite(options.maintenanceCacheBytes) || options.maintenanceCacheBytes <= 0) {
+    throw new Error("maintenanceCacheBytes must be positive");
+  }
+  if (sqlite.name === ":memory:" || sqlite.name === "") {
+    throw new Error("sqlite VACUUM worker requires a file-backed database");
+  }
+  const freelistCount = Number(sqlite.pragma("freelist_count", { simple: true }));
+  if (!Number.isFinite(freelistCount) || freelistCount < 0) {
+    throw new Error("invalid sqlite freelist_count");
+  }
+  const pageCount = Number(sqlite.pragma("page_count", { simple: true }));
+  if (!shouldRunVacuumForFreelist({ freelistPages: freelistCount, totalPages: pageCount })) return;
+
+  const databasePath = resolve(sqlite.name);
+  await assertVacuumFileSystemCapacity(databasePath);
+  sqlite.pragma("shrink_memory");
+  assertVacuumMemoryCapacity({
+    processLimitBytes: options.processLimitBytes ?? runtimeMemoryBudget().processLimitBytes,
+    availableBytes: options.availableMemoryBytes ?? process.availableMemory(),
+  });
+  await runVacuumWorker({
+    databasePath,
+    maintenanceCacheKiB: Math.max(1, Math.floor(options.maintenanceCacheBytes / 1024)),
+  });
+}

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -503,6 +503,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         !t.upsertSessionRevision ||
         !t.getSessionByRef ||
         !t.listSessionRevisions ||
+        !("listSessionRevisionsPage" in t) ||
         !t.getSessionRevisionByResponseId
       )
         throw new Error("session revision methods required");
@@ -632,6 +633,56 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
           createdAt: new Date(3000),
         }),
       ]);
+      const firstPage = await (
+        t as TelemetryStore & {
+          listSessionRevisionsPage(
+            sessionRef: string,
+            options: { afterSequence?: number; limit: number; maxBytes: number },
+          ): Promise<{
+            revisions: Array<{ requestId: string; sequence: number }>;
+            nextSequence: number | null;
+            limited: boolean;
+          }>;
+        }
+      ).listSessionRevisionsPage("s_1", { limit: 1, maxBytes: 1024 });
+      expect(firstPage).toMatchObject({
+        revisions: [{ requestId: "r1", sequence: 1 }],
+        nextSequence: 1,
+        limited: false,
+      });
+      const secondPage = await (
+        t as TelemetryStore & {
+          listSessionRevisionsPage(
+            sessionRef: string,
+            options: { afterSequence?: number; limit: number; maxBytes: number },
+          ): Promise<{
+            revisions: Array<{ requestId: string; sequence: number }>;
+            nextSequence: number | null;
+            limited: boolean;
+          }>;
+        }
+      ).listSessionRevisionsPage("s_1", {
+        afterSequence: firstPage.nextSequence ?? undefined,
+        limit: 2,
+        maxBytes: 1024,
+      });
+      expect(secondPage).toMatchObject({
+        revisions: [
+          { requestId: "r2", sequence: 2 },
+          { requestId: "r3", sequence: 3 },
+        ],
+        nextSequence: null,
+        limited: false,
+      });
+      const limited = await (
+        t as TelemetryStore & {
+          listSessionRevisionsPage(
+            sessionRef: string,
+            options: { afterSequence?: number; limit: number; maxBytes: number },
+          ): Promise<{ revisions: unknown[]; nextSequence: number | null; limited: boolean }>;
+        }
+      ).listSessionRevisionsPage("s_1", { limit: 10, maxBytes: 1 });
+      expect(limited).toEqual({ revisions: [], nextSequence: null, limited: true });
     });
 
     it("prunes an entire inactive session without touching a recent one", async () => {

--- a/packages/shared/src/compose.test.ts
+++ b/packages/shared/src/compose.test.ts
@@ -48,6 +48,11 @@ describe("docker-compose contract", () => {
     expect(compose).toContain("/healthz");
   });
 
+  it("gives graceful shutdown enough time to drain maintenance and queued writes", () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: Docker Compose interpolation is literal.
+    expect(compose).toContain("stop_grace_period: ${HELM_STOP_GRACE_PERIOD:-30m}");
+  });
+
   it("declares a single service (no extra Redis/DB containers in MVP)", () => {
     const serviceCount = (compose.match(/^\s{2}\w[\w-]*:/gm) ?? []).length;
     expect(serviceCount).toBe(1);


### PR DESCRIPTION
## What changed

- admit JSON bodies before `JSON.parse` using a shared runtime budget derived from V8 and process/cgroup memory
- bound HTTP, SSE, WebSocket, provider-response, Session recovery/cache, write-queue, and SQLite memory retention
- serialize cleanup and VACUUM behind a maintenance drain, run VACUUM in a worker, and add memory/disk/checkpoint safety gates
- preserve payload and Session capture, automatic nightly maintenance, and unrestricted per-key concurrency
- give Docker shutdown enough configurable grace time for active maintenance

## Why

Production reconnects were caused by Helm's Node process reaching the V8 heap limit and restarting. HAProxy and Nginx WebSocket timeouts are already one hour, so increasing proxy timeouts would not address the root cause.

This change rejects unsafe work before large JSON allocations, prevents retained queues and Session recovery from growing without a runtime memory budget, and makes SQLite maintenance drain and resume deterministically.

## User impact

Normal HTTP, SSE, and WebSocket requests continue unchanged. When the current machine cannot safely accept more work, clients receive protocol-shaped 413/503 responses instead of random process resets. Nightly cleanup and VACUUM remain enabled; maintenance can briefly return a structured 503 on a single-instance deployment.

## Validation

- 1000/1000 changed-path Vitest cases passed
- 20/20 Playwright smoke/protocol cases passed
- full `pnpm typecheck` passed
- full `pnpm build` passed
- Biome passed for all changed TypeScript/JSON files
- `docker compose config --quiet` passed
- `git diff --check` passed

