### PR TITLE
chore(release): bump version to 0.28.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.28.3` to `0.28.4` after merging PR #621.

## Included fix

- runtime-sized memory admission before JSON parsing
- bounded HTTP, SSE, WebSocket, provider response, Session, and write-queue retention
- safe serialized SQLite cleanup/VACUUM lifecycle
- configurable Docker shutdown grace for in-flight maintenance

Payload/Session capture, nightly maintenance, and unrestricted per-key concurrency remain enabled.

## Validation

- PR #621 required CI passed: typecheck, lint, build, full unit tests, Playwright e2e, and Docker smoke
- this PR changes only the root package version

