### PR TITLE
[codex] compress SQLite session and memory bodies

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -13,6 +13,12 @@
 - **请求、输出与 Session 热路径**：所有 JSON 入口在 `JSON.parse` 前按真实流式字节申请进程级预算，超出单请求容量返回结构化 413，暂时无余量返回 503；`maxPayload` 与上游 Codex connector 同样随运行时容量变化。客户端 WebSocket 另从 cgroup 或 `RSS + availableMemory` 扣除未来 heap 增长和 SQLite 预留，得到 native ingress 池；每连接只预留一个最坏帧、不按 key 或固定连接数限流。WS 每连接只保留一个正在执行的 `response.create`，terminal 后排空内部流再释放 lease；所有上游 Codex WS 会话共用 response-work 池，每条消息从入队、等待、`JSON.parse` 到 frame 被消费全程持有 lease。四种 SSE 出口共用有界正文捕获器，容量耗尽只省略该响应 payload、记录 `payload.capture_limited` 并继续转发与保存 telemetry。Session 热写不再重建完整历史；Admin Session 恢复由 SQLite/Postgres 先查行字节元数据、再按 sequence 分页物化，并占用共享 recovery window。Store 的 64 MiB/10,000 revision 仍是跨实例一致的持久数据完整性上限，不是运行时内存值。
 - **夜间维护**：自动 cleanup、自动 VACUUM 与 Admin 手工维护复用同一 Promise 串行链；VACUUM 前进程级 gate 暂停新工作并依次等待 HTTP/body、Memory/Signal producer、OAuth/MCP/Admin cache 后台任务与正文写队列静止，结束或失败都逆序恢复。维护期间除 `/healthz`、`/version` 外的新请求统一返回带 `Retry-After` 的 503，并按 OpenAI、Anthropic、Gemini 或普通 Admin 路径输出对应错误形状；维护 drain 上限为 `min(request_timeout_ms, 120s)`。自动任务每 10 分钟检查一次，只有整段成功才记录当日完成。SQLite 仅在 freelist 至少占总页数 5% 时执行全库重写；worker 启动前要求 `availableMemory()` 至少为动态 process limit 的 25%，并按数据库与 WAL 实际大小检查磁盘。worker 使用独立连接、`temp_store=FILE` 与机器推导的低维护 cache；Compose 默认给 shutdown 30 分钟 grace。未引入守护进程、Redis、消息队列或新依赖。
 
+## 2026-07-23 · SQLite Session 与 Memory 正文使用兼容 gzip 存储（Store / Memory，docs/07/08，原则 1/3/7）
+
+- **Session 存储**：SQLite 复用既有 payload gzip codec，把 `session_revisions` 的 request delta、request envelope 与 response 保存为 BLOB；读取按 SQLite value type 与 gzip magic 同时兼容旧 TEXT。v42 只增加可空的逻辑字节列，不扫描历史正文；新行写入未压缩大小，旧 TEXT 行读取时由 SQLite `length()` 计算。分页先按逻辑字节执行内存准入，再读取并解压正文；`sessions.stored_bytes` 与 64 MiB 重建安全上限不变。Postgres 保持 TEXT，继续依赖 TOAST；不新增配置、依赖或正文回写迁移。
+- **Memory 存储**：SQLite 仅对不少于 256 UTF-8 字节且 gzip 后确实更小的 `memory_messages.content` 保存 BLOB；短消息和不可压缩正文仍保存 TEXT。去重 hash 始终基于原文，常规读取与归档出口统一解码，Memory 注入、Observer、租户范围和归档格式不变。生产小样本显示该门槛保留约 71.5% 的正文节省，同时避免小消息膨胀。
+- **历史数据边界**：代码不在启动或请求路径回写历史正文，也不在线执行 VACUUM。旧 Session、完整 payload 与关联图片 blob 的删除继续暂停；SQLite 物理文件缩减必须另行安排维护窗口。
+
 ## 2026-07-22 · 全项目文案审查补齐多语言维护闭环（Admin / Portal / Setup，docs/11/12，原则 1/2）
 
 - **审查边界**：Claude CLI Opus 对 Admin、Portal、Gateway 公开页面、README、当前 docs、脚本输出和客户端可见错误做了只读审查；不改协议字段、配置键、模型 ID、命令或历史事实。README 中文版已是自然意译，当前 docs 没有值得用大范围重写换取的明确收益。
@@ -63,14 +69,9 @@
 - **官方契约**：以 `xai-org/grok-build@a881e67` 的 Custom Models 指南为准，Grok Build 设置 `GROK_MODELS_BASE_URL` 后从 `{base_url}/models` 发现模型，以 `XAI_API_KEY` 作为 Bearer key，并默认走 OpenAI Chat Completions。Admin「接入客户端」因此只新增可复制的 `GROK_MODELS_BASE_URL=<origin>/v1`、Helm key 与 `grok -m auto` 引导；`/v1/models` 继续按 key 暴露 `auto` / lanes，推理由既有 `/v1/chat/completions` 路由处理。
 - **最小边界**：不新增 Grok 专用 Gateway 路由、协议适配、依赖或运行时配置，也不要求 `grok login`；只扩展现有 Admin 对话框、七种现有语言文案与一个定向组件测试。
 
-## 2026-07-20 · `end_turn` XML 泄漏只按终态工具调用恢复（Protocol streaming / provider execution，docs/05/07，原则 3/5/8）
-
-- **恢复边界**：本机 2,520 个 Claude session JSONL 的匿名化扫描中，高置信完整泄漏有 85 个 `tool_use` 与 23 个 `end_turn`；后者是当前真实漏项。保留既有 `tool_use` 的宽松周边文本恢复；仅对 `end_turn` 增加收紧路径。共享 parser 只有在所有完整 invoke 都精确命中请求声明的工具、最后一个非空 segment 是已恢复的 tool、文本 segment 不含残留 `<invoke`，且 invoke 不在 Markdown 三反引号 fence 内时才接受；多个调用之间仅允许空白，避免把前置的无围栏 XML 示例一并执行。末尾空白可保留；无名、未闭合、未知尾巴、function-calls wrapper 和带转义引号的文档示例都不扩 grammar、不恢复。
-- **四出口一致性**：native Anthropic JSON/SSE 与 OpenAI→Anthropic translation JSON/SSE 都只在末个 terminal text 上调用该收紧路径，且没有既有 structured call 才可恢复；成功后分别将终态改为 `tool_use` / `tool_calls`。Translation SSE 与 JSON 复用同一份声明工具名映射，保证点号、碰撞等名称规范化一致。SSE 仍在 `message_delta` 证明终态后才改写，普通 `tool_use` 与非候选路径保持既有行为。
-- **验证**：TDD 先在共享 parser 和四个出口加入失败 case，再以 4 个定向 Vitest 文件、257 个用例覆盖完整 end-turn 恢复及拒绝 fence、尾随文本、调用间 prose、未闭合和未知 invoke；`pnpm typecheck`、`pnpm lint`、`pnpm build` 与 `git diff --check` 通过，不新增依赖或运行时配置。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-20 · `end_turn` XML 泄漏只按终态工具调用恢复（Protocol streaming / provider execution，原则 3/5/8）**：仅在终态、完整、白名单且无既有结构化调用时恢复 `end_turn` XML 工具调用，四个出口共用收紧边界；完整原文通过 git history 回溯。
 - **2026-07-18 · 请求推理等级与实际路由等级分开展示（Telemetry / Admin requests，原则 1/7）**：单独保存客户端请求等级与覆盖后的实际执行等级，共享列表分别展示且不从旧记录反推；完整原文通过 git history 回溯。
 - **2026-07-18 · 关闭正文捕获时仍保留推理等级（Telemetry / Admin requests，原则 1/7）**：完整正文关闭时仍把实际生效的 `reasoning_effort` 作为脱敏 DecisionRecord 元数据保存并显示；完整原文通过 git history 回溯。
 - **2026-07-18 · Codex 自动压缩目录与无状态传输故障切换（OAuth subscription / Responses / provider execution，原则 3/5/7/8）**：对齐 Codex 自动压缩阈值，并只允许无状态 transport failure 在兄弟账号间切换；有状态续接与私有 Responses items 保持 fail-closed，完整原文通过 git history 回溯。

--- a/packages/core/src/store/payload-codec.test.ts
+++ b/packages/core/src/store/payload-codec.test.ts
@@ -25,4 +25,8 @@ describe("payload-codec", () => {
   it("non-gzip buffer is read as utf8 (defensive)", () => {
     expect(decodePayloadValue(Buffer.from("raw", "utf8"))).toBe("raw");
   });
+
+  it("treats a truncated gzip BLOB as unavailable instead of throwing", () => {
+    expect(decodePayloadValue(Buffer.from([0x1f, 0x8b, 0x08]))).toBeNull();
+  });
 });

--- a/packages/core/src/store/payload-codec.ts
+++ b/packages/core/src/store/payload-codec.ts
@@ -24,7 +24,11 @@ export function decodePayloadValue(value: unknown): string | null {
   if (typeof value === "string") return value; // legacy uncompressed row
   const buf = Buffer.isBuffer(value) ? value : Buffer.from(value as Uint8Array);
   if (buf.length >= 2 && buf[0] === GZIP_MAGIC_0 && buf[1] === GZIP_MAGIC_1) {
-    return gunzipSync(buf).toString("utf8");
+    try {
+      return gunzipSync(buf).toString("utf8");
+    } catch {
+      return null;
+    }
   }
   return buf.toString("utf8"); // defensive: raw bytes stored without gzip
 }

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -143,6 +143,45 @@ describe("sqlite memory schema + migrations", () => {
     db.$sqlite.close();
   });
 
+  it("stores large messages as gzip BLOBs and reads mixed legacy TEXT", async () => {
+    const db = createSqliteDb(":memory:");
+    const store = new SqliteMemoryStore(
+      db,
+      () => "compressed-message",
+      () => new Date(1_000),
+    );
+    await store.ensureThread({ id: "t1", ownerId: "o1" });
+    const content = "compressible memory content ".repeat(1_000);
+    await store.appendMessage({
+      threadId: "t1",
+      messageIndex: 0,
+      role: "assistant",
+      content,
+      tokenEstimate: 3,
+    });
+
+    expect(
+      db.$sqlite
+        .prepare("SELECT typeof(content) AS type FROM memory_messages WHERE id = ?")
+        .get("compressed-message"),
+    ).toEqual({ type: "blob" });
+    db.$sqlite
+      .prepare(
+        `INSERT INTO memory_messages
+           (id, thread_id, message_index, role, content, token_estimate, created_at, content_hash)
+         VALUES ('legacy-message', 't1', 1, 'user', 'legacy text', 2, 2000, 'legacy-hash')`,
+      )
+      .run();
+
+    expect(
+      (await store.listMessages({ accountId: "o1", threadId: "t1" })).map((m) => m.content),
+    ).toEqual([content, "legacy text"]);
+    expect((await store.selectMessagesOlderThan(3_000, 10)).map((m) => m.content).sort()).toEqual(
+      [content, "legacy text"].sort(),
+    );
+    db.$sqlite.close();
+  });
+
   it("ensureThread is idempotent (re-ensure does not throw or duplicate)", async () => {
     const db = createSqliteDb(":memory:");
     const store = new SqliteMemoryStore(db);

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -38,6 +38,7 @@ import { factContentHash } from "../../memory/forgetting/facts.js";
 import { forgettingScore, type ScoreConfig } from "../../memory/forgetting/score.js";
 import { sha256Hex } from "../../memory/message-hash.js";
 import { reciprocalRankFusion } from "../../memory/recall/rrf.js";
+import { decodePayloadValue, encodePayloadText } from "../payload-codec.js";
 import {
   type MemoryAdminStats,
   type MemoryAdminStatsScope,
@@ -81,6 +82,18 @@ function reflectionScopeWhere(scope: ReflectionScope): SQL {
 // and re-claims it — without this, the enqueue dedupe against running rows would
 // block the scope's queue FOREVER. 5 min is far beyond any real tick's work.
 const RUNNING_LEASE_MS = 5 * 60_000;
+const MEMORY_GZIP_MIN_BYTES = 256;
+
+function encodeMemoryContent(content: string): string | Buffer {
+  const bytes = Buffer.byteLength(content, "utf8");
+  if (bytes < MEMORY_GZIP_MIN_BYTES) return content;
+  const compressed = encodePayloadText(content);
+  return compressed.length < bytes ? compressed : content;
+}
+
+function decodeMemoryContent(content: unknown): string {
+  return decodePayloadValue(content) ?? "";
+}
 
 function dateOrNull(ms: number | null | undefined): Date | null {
   return ms === null || ms === undefined ? null : new Date(ms);
@@ -263,6 +276,21 @@ export class SqliteMemoryStore implements MemoryStore {
     private readonly now: () => Date = () => new Date(),
   ) {}
 
+  private preparedMessageInsert: ReturnType<SqliteMemoryStore["buildMessageInsert"]> | undefined;
+  private buildMessageInsert() {
+    return this.db.$sqlite.prepare(
+      `INSERT INTO memory_messages
+         (id, thread_id, message_index, role, content, token_estimate, created_at, content_hash)
+       VALUES
+         (@id, @threadId, @messageIndex, @role, @content, @tokenEstimate, @createdAt, @contentHash)
+       ON CONFLICT(thread_id, message_index, role, content_hash) DO NOTHING`,
+    );
+  }
+  private messageInsert() {
+    if (!this.preparedMessageInsert) this.preparedMessageInsert = this.buildMessageInsert();
+    return this.preparedMessageInsert;
+  }
+
   async ensureThread(input: MemoryThreadInput): Promise<void> {
     const ts = this.now();
     const tsMs = ts.getTime();
@@ -357,27 +385,16 @@ export class SqliteMemoryStore implements MemoryStore {
     // no-op via the v21 UNIQUE index (re-ingestion fix). Returned id is still
     // generated per call; on conflict it is inert (the row was left untouched).
     this.db.$sqlite.transaction(() => {
-      const inserted = this.db
-        .insert(memoryMessages)
-        .values({
-          id,
-          threadId: input.threadId,
-          messageIndex: input.messageIndex ?? 0,
-          role: input.role,
-          content: input.content,
-          tokenEstimate: input.tokenEstimate,
-          createdAt,
-          contentHash: sha256Hex(input.content),
-        })
-        .onConflictDoNothing({
-          target: [
-            memoryMessages.threadId,
-            memoryMessages.messageIndex,
-            memoryMessages.role,
-            memoryMessages.contentHash,
-          ],
-        })
-        .run();
+      const inserted = this.messageInsert().run({
+        id,
+        threadId: input.threadId,
+        messageIndex: input.messageIndex ?? 0,
+        role: input.role,
+        content: encodeMemoryContent(input.content),
+        tokenEstimate: input.tokenEstimate,
+        createdAt: createdAt.getTime(),
+        contentHash: sha256Hex(input.content),
+      });
       // A dedup conflict has changes=0 and must not inflate the summary.
       if (inserted.changes > 0) {
         this.bumpThreadMessageActivity(input.threadId, 1, createdAt.getTime());
@@ -400,27 +417,16 @@ export class SqliteMemoryStore implements MemoryStore {
       inputs.forEach((input, i) => {
         const id = this.genId();
         ids.push(id);
-        const inserted = this.db
-          .insert(memoryMessages)
-          .values({
-            id,
-            threadId: input.threadId,
-            messageIndex: input.messageIndex ?? i,
-            role: input.role,
-            content: input.content,
-            tokenEstimate: input.tokenEstimate,
-            createdAt: new Date(base + i),
-            contentHash: sha256Hex(input.content),
-          })
-          .onConflictDoNothing({
-            target: [
-              memoryMessages.threadId,
-              memoryMessages.messageIndex,
-              memoryMessages.role,
-              memoryMessages.contentHash,
-            ],
-          })
-          .run();
+        const inserted = this.messageInsert().run({
+          id,
+          threadId: input.threadId,
+          messageIndex: input.messageIndex ?? i,
+          role: input.role,
+          content: encodeMemoryContent(input.content),
+          tokenEstimate: input.tokenEstimate,
+          createdAt: base + i,
+          contentHash: sha256Hex(input.content),
+        });
         if (inserted.changes > 0) {
           const createdAt = base + i;
           const current = activity.get(input.threadId);
@@ -462,7 +468,7 @@ export class SqliteMemoryStore implements MemoryStore {
       threadId: row.threadId,
       // Stored role is the IR-aligned enum; widen back to the shared union.
       role: row.role as RawMessage["role"],
-      content: row.content,
+      content: decodeMemoryContent(row.content),
       tokenEstimate: row.tokenEstimate,
       createdAt: row.createdAt,
     }));
@@ -1955,7 +1961,7 @@ export class SqliteMemoryStore implements MemoryStore {
         id: r.id,
         threadId: r.threadId,
         role: r.role,
-        content: r.content,
+        content: decodeMemoryContent(r.content),
         tokenEstimate: r.tokenEstimate,
         messageIndex: r.messageIndex ?? null,
         contentHash: r.contentHash ?? null,

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1207,6 +1207,15 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // New rows record logical bytes before gzip. NULL marks legacy TEXT so reads can
+    // use SQLite length() without a deployment-time scan of a potentially huge table.
+    version: 42,
+    sql: `
+      ALTER TABLE session_revisions
+        ADD COLUMN body_bytes INTEGER;
+    `,
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -190,6 +190,7 @@ describe("sqlite schema + migrations", () => {
       "retain_count",
       "request_delta_json",
       "request_envelope_json",
+      "body_bytes",
       "response_id",
       "response_json",
       "fidelity",
@@ -217,6 +218,54 @@ describe("sqlite schema + migrations", () => {
     expect(() => insertRevision.run("r-negative", 2, -1)).toThrow();
     expect(() => insertRevision.run("r-fractional", 2, 1.5)).toThrow();
     raw.close();
+  });
+
+  it("v42 adds Session body-byte metadata without scanning old bodies", () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v42-session-bytes-"));
+    const path = join(dir, "helm.db");
+    try {
+      const seed = new Database(path);
+      seed.exec(`
+        CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);
+        CREATE TABLE session_revisions (
+          request_id TEXT PRIMARY KEY,
+          session_ref TEXT NOT NULL,
+          sequence INTEGER NOT NULL,
+          parent_request_id TEXT,
+          retain_count INTEGER NOT NULL,
+          request_delta_json TEXT NOT NULL,
+          request_envelope_json TEXT NOT NULL,
+          response_id TEXT,
+          response_json TEXT,
+          fidelity TEXT NOT NULL,
+          created_at INTEGER NOT NULL
+        );
+        INSERT INTO session_revisions
+          (request_id, session_ref, sequence, retain_count, request_delta_json,
+           request_envelope_json, response_json, fidelity, created_at)
+        VALUES ('r1', 's1', 1, 0, '["\u4f60\u597d"]', '{"model":"x"}', NULL, 'semantic', 1);
+      `);
+      const record = seed.prepare("INSERT INTO _migrations (version, applied_at) VALUES (?, ?)");
+      for (let version = 1; version <= 41; version++) record.run(version, 1);
+      seed.close();
+
+      runMigrations(path);
+
+      const after = new Database(path);
+      expect(after.prepare("SELECT body_bytes AS bodyBytes FROM session_revisions").get()).toEqual({
+        bodyBytes: null,
+      });
+      const schemaSql = (
+        after.prepare("SELECT sql FROM sqlite_master WHERE name = 'session_revisions'").get() as {
+          sql: string;
+        }
+      ).sql;
+      expect(schemaSql).toContain("body_bytes INTEGER");
+      expect(schemaSql).not.toContain("body_bytes INTEGER CHECK");
+      after.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("v39 adds and backfills per-thread admin activity summaries", () => {

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -117,6 +117,7 @@ export const sessionRevisions = sqliteTable(
     retainCount: integer("retain_count").notNull(),
     requestDeltaJson: text("request_delta_json").notNull(),
     requestEnvelopeJson: text("request_envelope_json").notNull(),
+    bodyBytes: integer("body_bytes"),
     responseId: text("response_id"),
     responseJson: text("response_json"),
     fidelity: text("fidelity").notNull(),

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -64,6 +64,142 @@ function freshStore() {
 }
 
 describe("SqliteTelemetryStore", () => {
+  it("stores session bodies as gzip BLOBs and still reads legacy TEXT", async () => {
+    const db = createSqliteDb(":memory:");
+    const store = new SqliteTelemetryStore(db);
+    const requestDeltaJson = JSON.stringify(["event ".repeat(2_000)]);
+    const requestEnvelopeJson = JSON.stringify({ model: "x", instructions: "rule ".repeat(2_000) });
+    const responseJson = JSON.stringify({ output: "answer ".repeat(2_000) });
+
+    const revision = {
+      sessionRef: "s1",
+      accountId: "a1",
+      apiKeyId: "k1",
+      source: "header",
+      externalSessionId: "external-1",
+      requestId: "r1",
+      parentRequestId: null,
+      retainCount: 0,
+      requestDeltaJson,
+      requestEnvelopeJson,
+      responseId: "resp_1",
+      responseJson: null,
+      fidelity: "semantic",
+      createdAt: new Date(1_000),
+    } as const;
+    await store.upsertSessionRevision(revision);
+    await store.upsertSessionRevision({ ...revision, responseJson });
+
+    expect(
+      db.$sqlite
+        .prepare(
+          `SELECT typeof(request_delta_json) AS delta,
+                  typeof(request_envelope_json) AS envelope,
+                  typeof(response_json) AS response
+             FROM session_revisions WHERE request_id = 'r1'`,
+        )
+        .get(),
+    ).toEqual({ delta: "blob", envelope: "blob", response: "blob" });
+    expect(await store.listSessionRevisions("s1")).toEqual([
+      expect.objectContaining({ requestDeltaJson, requestEnvelopeJson, responseJson }),
+    ]);
+    expect(await store.getSessionRevisionByResponseId("s1", "resp_1")).toEqual(
+      expect.objectContaining({ requestDeltaJson, requestEnvelopeJson, responseJson }),
+    );
+    expect((await store.getSessionByRef("s1"))?.storedBytes).toBe(
+      Buffer.byteLength(requestDeltaJson + requestEnvelopeJson + responseJson, "utf8"),
+    );
+    await expect(
+      store.listSessionRevisionsPage("s1", { limit: 10, maxBytes: 1_024 }),
+    ).resolves.toEqual({ revisions: [], nextSequence: null, limited: true });
+    await expect(
+      store.listSessionRevisionsPage("s1", { limit: 10, maxBytes: 100_000 }),
+    ).resolves.toEqual({
+      revisions: [expect.objectContaining({ requestDeltaJson, requestEnvelopeJson, responseJson })],
+      nextSequence: null,
+      limited: false,
+    });
+
+    const legacy = '["legacy text"]';
+    db.$sqlite
+      .prepare("UPDATE session_revisions SET request_delta_json = ? WHERE request_id = 'r1'")
+      .run(legacy);
+    expect((await store.listSessionRevisions("s1"))[0]?.requestDeltaJson).toBe(legacy);
+    db.$sqlite.close();
+  });
+
+  it("pages mixed Session rows by uncompressed bytes and returns decoded text", async () => {
+    const db = createSqliteDb(":memory:");
+    const store = new SqliteTelemetryStore(db);
+    const put = (requestId: string, parentRequestId: string | null, body: string, at: number) =>
+      store.upsertSessionRevision({
+        sessionRef: "s-page",
+        accountId: "a1",
+        apiKeyId: "k1",
+        source: "header",
+        externalSessionId: "external-page",
+        requestId,
+        parentRequestId,
+        retainCount: 0,
+        requestDeltaJson: body,
+        requestEnvelopeJson: "{}",
+        responseId: null,
+        responseJson: null,
+        fidelity: "semantic",
+        createdAt: new Date(at),
+      });
+    const firstBody = JSON.stringify(["first ".repeat(1_000)]);
+    const secondBody = JSON.stringify(["second ".repeat(1_000)]);
+    await put("r1", null, firstBody, 1_000);
+    await put("r2", "r1", secondBody, 2_000);
+    db.$sqlite
+      .prepare(
+        "UPDATE session_revisions SET request_delta_json = ?, body_bytes = NULL WHERE request_id = 'r2'",
+      )
+      .run(secondBody);
+
+    const first = await store.listSessionRevisionsPage("s-page", {
+      limit: 1,
+      maxBytes: Buffer.byteLength(firstBody, "utf8") + 256,
+    });
+    expect(first).toEqual({
+      revisions: [
+        expect.objectContaining({
+          requestId: "r1",
+          requestDeltaJson: firstBody,
+          responseJson: null,
+        }),
+      ],
+      nextSequence: 1,
+      limited: false,
+    });
+    await expect(
+      store.listSessionRevisionsPage("s-page", {
+        afterSequence: first.nextSequence ?? undefined,
+        limit: 1,
+        maxBytes: 1,
+      }),
+    ).resolves.toEqual({ revisions: [], nextSequence: null, limited: true });
+    await expect(
+      store.listSessionRevisionsPage("s-page", {
+        afterSequence: first.nextSequence ?? undefined,
+        limit: 1,
+        maxBytes: Buffer.byteLength(secondBody, "utf8") + 256,
+      }),
+    ).resolves.toEqual({
+      revisions: [
+        expect.objectContaining({
+          requestId: "r2",
+          requestDeltaJson: secondBody,
+          responseJson: null,
+        }),
+      ],
+      nextSequence: null,
+      limited: false,
+    });
+    db.$sqlite.close();
+  });
+
   it("denormalizes latency for dashboard aggregates instead of reading decision_json", async () => {
     const db = createSqliteDb(":memory:");
     const store = new SqliteTelemetryStore(db);

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -32,6 +32,17 @@ import type { SqliteDb } from "./migrate.js";
 import { payloadBlobs, requestPayloads, sessionRevisions, sessions, telemetry } from "./schema.js";
 
 type TelemetryRow = typeof telemetry.$inferSelect;
+type SessionRevisionRow = typeof sessionRevisions.$inferSelect;
+
+function decodeSessionRevisionRow(row: SessionRevisionRow): SessionRevisionRecord {
+  const { bodyBytes: _, ...revision } = row;
+  return {
+    ...revision,
+    requestDeltaJson: decodePayloadValue(row.requestDeltaJson) ?? "",
+    requestEnvelopeJson: decodePayloadValue(row.requestEnvelopeJson) ?? "",
+    responseJson: decodePayloadValue(row.responseJson),
+  };
+}
 
 function boundedSessionPageLimit(options: SessionRevisionPageOptions): number {
   if (!Number.isSafeInteger(options.limit) || options.limit <= 0)
@@ -56,6 +67,41 @@ export class SqliteTelemetryStore implements TelemetryStore {
     private readonly db: SqliteDb,
     private readonly genId: () => string = randomUUID,
   ) {}
+
+  private sessionPreparedStmts:
+    | ReturnType<SqliteTelemetryStore["buildSessionWriteStmts"]>
+    | undefined;
+  private buildSessionWriteStmts() {
+    const db = this.db.$sqlite;
+    return {
+      insert: db.prepare(
+        `INSERT INTO session_revisions
+           (request_id, session_ref, sequence, parent_request_id, retain_count,
+            request_delta_json, request_envelope_json, body_bytes, response_id, response_json,
+            fidelity, created_at)
+         VALUES
+           (@requestId, @sessionRef, @sequence, @parentRequestId, @retainCount,
+            @requestDeltaJson, @requestEnvelopeJson, @bodyBytes, @responseId, @responseJson,
+            @fidelity, @createdAt)`,
+      ),
+      updateResponse: db.prepare(
+        `UPDATE session_revisions
+            SET response_id = @responseId,
+                response_json = @responseJson,
+                body_bytes = coalesce(
+                  body_bytes,
+                  length(CAST(request_delta_json AS BLOB)) +
+                  length(CAST(request_envelope_json AS BLOB))
+                ) + @responseBytes,
+                fidelity = @fidelity
+          WHERE request_id = @requestId`,
+      ),
+    };
+  }
+  private sessionWriteStmts() {
+    if (!this.sessionPreparedStmts) this.sessionPreparedStmts = this.buildSessionWriteStmts();
+    return this.sessionPreparedStmts;
+  }
 
   // Build one telemetry row (fresh id + denormalized status/cost). Shared by the
   // single and batch inserts so they can never drift.
@@ -135,11 +181,12 @@ export class SqliteTelemetryStore implements TelemetryStore {
         .get();
       if (existing) {
         if (existing.sessionRef !== input.sessionRef) throw new Error("request session mismatch");
+        const responseJson = input.responseJson;
         const responseBytes =
-          input.responseJson !== null && existing.responseJson === null
-            ? Buffer.byteLength(input.responseJson, "utf8")
+          responseJson !== null && existing.responseJson === null
+            ? Buffer.byteLength(responseJson, "utf8")
             : 0;
-        if (responseBytes === 0) return;
+        if (responseBytes === 0 || responseJson === null) return;
         const session = this.db
           .select({ storedBytes: sessions.storedBytes })
           .from(sessions)
@@ -156,15 +203,13 @@ export class SqliteTelemetryStore implements TelemetryStore {
           })
           .where(eq(sessions.sessionRef, input.sessionRef))
           .run();
-        this.db
-          .update(sessionRevisions)
-          .set({
-            responseId: input.responseId ?? null,
-            responseJson: input.responseJson,
-            fidelity: input.fidelity,
-          })
-          .where(eq(sessionRevisions.requestId, input.requestId))
-          .run();
+        this.sessionWriteStmts().updateResponse.run({
+          requestId: input.requestId,
+          responseId: input.responseId ?? null,
+          responseJson: encodePayloadText(responseJson),
+          responseBytes,
+          fidelity: input.fidelity,
+        });
         return;
       }
 
@@ -191,22 +236,20 @@ export class SqliteTelemetryStore implements TelemetryStore {
         throw new Error("session capture limit exceeded");
       }
       const sequence = session.revisionCount + 1;
-      this.db
-        .insert(sessionRevisions)
-        .values({
-          requestId: input.requestId,
-          sessionRef: input.sessionRef,
-          sequence,
-          parentRequestId: input.parentRequestId,
-          retainCount: input.retainCount,
-          requestDeltaJson: input.requestDeltaJson,
-          requestEnvelopeJson: input.requestEnvelopeJson,
-          responseId: input.responseId ?? null,
-          responseJson: input.responseJson,
-          fidelity: input.fidelity,
-          createdAt: at,
-        })
-        .run();
+      this.sessionWriteStmts().insert.run({
+        requestId: input.requestId,
+        sessionRef: input.sessionRef,
+        sequence,
+        parentRequestId: input.parentRequestId,
+        retainCount: input.retainCount,
+        requestDeltaJson: encodePayloadText(input.requestDeltaJson),
+        requestEnvelopeJson: encodePayloadText(input.requestEnvelopeJson),
+        bodyBytes: storedBytes,
+        responseId: input.responseId ?? null,
+        responseJson: input.responseJson === null ? null : encodePayloadText(input.responseJson),
+        fidelity: input.fidelity,
+        createdAt: atMs,
+      });
       this.db
         .update(sessions)
         .set({
@@ -255,7 +298,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
       .where(eq(sessionRevisions.sessionRef, sessionRef))
       .orderBy(asc(sessionRevisions.sequence))
       .all()
-      .map((row) => ({ ...row }));
+      .map(decodeSessionRevisionRow);
   }
 
   async listSessionRevisionsPage(
@@ -268,10 +311,13 @@ export class SqliteTelemetryStore implements TelemetryStore {
       length(CAST(${sessionRevisions.sessionRef} AS BLOB)) +
       length(CAST(${sessionRevisions.requestId} AS BLOB)) +
       coalesce(length(CAST(${sessionRevisions.parentRequestId} AS BLOB)), 0) +
-      length(CAST(${sessionRevisions.requestDeltaJson} AS BLOB)) +
-      length(CAST(${sessionRevisions.requestEnvelopeJson} AS BLOB)) +
+      coalesce(
+        ${sessionRevisions.bodyBytes},
+        length(CAST(${sessionRevisions.requestDeltaJson} AS BLOB)) +
+        length(CAST(${sessionRevisions.requestEnvelopeJson} AS BLOB)) +
+        coalesce(length(CAST(${sessionRevisions.responseJson} AS BLOB)), 0)
+      ) +
       coalesce(length(CAST(${sessionRevisions.responseId} AS BLOB)), 0) +
-      coalesce(length(CAST(${sessionRevisions.responseJson} AS BLOB)), 0) +
       length(CAST(${sessionRevisions.fidelity} AS BLOB)) + 64
     `;
     const metadata = this.db
@@ -308,7 +354,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
       )
       .orderBy(asc(sessionRevisions.sequence))
       .all()
-      .map((row) => ({ ...row }));
+      .map(decodeSessionRevisionRow);
     return {
       revisions,
       nextSequence: metadata.length > selected.length ? (selected.at(-1) ?? null) : null,
@@ -330,7 +376,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
         ),
       )
       .get();
-    return row ? { ...row } : null;
+    return row ? decodeSessionRevisionRow(row) : null;
   }
 
   async pruneInactiveSessions(olderThanMs: number): Promise<number> {


### PR DESCRIPTION
## What changed

- gzip new SQLite Session revision request/response bodies while keeping legacy TEXT readable
- gzip compressible SQLite Memory messages of at least 256 bytes while preserving plaintext hashes and mixed-row reads
- add metadata-only migration v42 so Session recovery enforces logical byte budgets before decompression
- fail soft on corrupt gzip data and cover legacy/new mixed storage, pagination, response backfill, and migration behavior

## Why

Per-request and Session content made the production SQLite database grow quickly. This reduces future storage without rewriting historical bodies during startup or changing Postgres behavior.

## Safety

- migration v42 is a nullable `ADD COLUMN` only; no historical scan, rewrite, cleanup, or VACUUM
- Session limits continue to use uncompressed UTF-8 bytes
- complete request payload capture remains separate and off by factory default
- no production data deletion is included

## Validation

- `CI=true pnpm exec vitest run packages/core/src/store/payload-codec.test.ts packages/core/src/store/sqlite/schema.test.ts packages/core/src/store/sqlite/telemetry.test.ts packages/core/src/store/sqlite/memory-schema.test.ts` (59 passed)
- `CI=true pnpm --filter @helm/core typecheck`
- targeted Biome check and `git diff --check`
- Claude CLI Opus review loop: fixed metadata-migration full-scan risk; second pass APPROVE
