### PR TITLE
[codex] release v0.28.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.28.4` to `0.28.5`.

This release includes SQLite gzip storage for new Session revision and Memory message bodies, legacy TEXT compatibility, logical-byte recovery admission, and metadata-only migration v42.

No historical payload deletion or VACUUM is included.

## Validation

The feature PR #623 passed verify, e2e, and docker CI. This version-only PR must pass the same release gates before merge.
