### PR TITLE
[codex] release v0.28.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.28.5` to `0.28.6`.

This release keeps Session recovery available while live API responses are using the bounded response-work pool. It reserves half the pool for live responses, allows two bounded recoveries to coexist, and fails a third recovery before reading bodies.

No historical payload deletion, VACUUM, or manual checkpoint is included.

## Validation

Feature PR #625 passed verify, e2e, and docker CI, and Claude CLI Opus approved the final change. This version-only PR must pass the same release gates before merge.
