### PR TITLE
feat: 实现 PostgreSQL 分布式并发租约

### DIFF
--- a/apps/gateway/e2e/concurrency-postgres.spec.ts
+++ b/apps/gateway/e2e/concurrency-postgres.spec.ts
@@ -40,6 +40,7 @@ import {
   createConcurrencyGate,
 } from "../src/middleware/concurrency.js";
 import { requestSignal, timeout } from "../src/middleware/limits.js";
+import { CONCURRENCY_LEASE_LOST_REASON } from "../src/request-cancellation.js";
 import { registerChatRoutes } from "../src/routes/chat.js";
 import { createExecute } from "../src/routes/execute.js";
 import { registerGeminiRoute } from "../src/routes/gemini.js";
@@ -370,6 +371,8 @@ interface BreakerObservations {
   cooldowns: number;
 }
 
+type PersistenceRaceStep = "lease_loss" | "timeout" | "persist";
+
 interface ProductionRouteResult {
   wire: string;
   decision: DecisionRecord;
@@ -377,6 +380,7 @@ interface ProductionRouteResult {
   fallbackCalls: number;
   breakerState: ReturnType<CircuitBreaker["getState"]>;
   breaker: BreakerObservations;
+  persistenceOrder: PersistenceRaceStep[];
 }
 
 function trackedBreaker(): {
@@ -474,8 +478,10 @@ async function runProductionRouteLeaseLoss(
   const primaryAlias = `${protocol}-primary`;
   const fallbackAlias = `${protocol}-fallback`;
   const providerWaiting = deferred();
+  const timeoutObserved = deferred();
   const persisted = deferred();
   const persistedDecisions: DecisionRecord[] = [];
+  const persistenceOrder: PersistenceRaceStep[] = [];
   let primaryCalls = 0;
   let fallbackCalls = 0;
   let executionSignal: AbortSignal | null = null;
@@ -498,6 +504,12 @@ async function runProductionRouteLeaseLoss(
     providerWaiting.resolve();
     if (executionSignal === null) throw new Error("production route did not bind its signal");
     await waitForAbort(executionSignal);
+    if (executionSignal.reason !== CONCURRENCY_LEASE_LOST_REASON) {
+      throw new Error(
+        `expected lease loss to win cancellation race, got ${executionSignal.reason}`,
+      );
+    }
+    persistenceOrder.push("lease_loss");
     throw abortError();
   }
 
@@ -567,6 +579,7 @@ async function runProductionRouteLeaseLoss(
 
   const telemetry = {
     insert: async (input: { decision: DecisionRecord }) => {
+      persistenceOrder.push("persist");
       persistedDecisions.push(input.decision);
       persisted.resolve();
       return { id: "route-lease-loss" };
@@ -579,8 +592,23 @@ async function runProductionRouteLeaseLoss(
     capturePayloads: () => false,
     captureSessions: () => false,
   };
+  const releaseAfterTimeoutSemaphore: DistributedKeyedSemaphore = {
+    async acquire(args) {
+      const acquired = await replica.manager.acquire(args);
+      if (!acquired.ok) return acquired;
+      let releasePromise: Promise<void> | null = null;
+      return {
+        ...acquired,
+        release: () => {
+          releasePromise ??= timeoutObserved.promise.then(() => acquired.release());
+          return releasePromise;
+        },
+      };
+    },
+    shutdown: () => replica.manager.shutdown(),
+  };
   const gate = createConcurrencyGate({
-    semaphore: replica.manager,
+    semaphore: releaseAfterTimeoutSemaphore,
     getConfig: () => ({
       enabled: true,
       minSize: 2,
@@ -597,6 +625,21 @@ async function runProductionRouteLeaseLoss(
     logger: {
       log: (level, message, fields) => routeLogs.push({ level, message, fields }),
     },
+    limits: { requestTimeoutMs: 2_000 },
+  });
+  app.use("*", async (c, next) => {
+    const timeoutState = c.get("request_timeout");
+    if (timeoutState === undefined) throw new Error("production route did not install limits");
+    timeoutState.signal.addEventListener(
+      "abort",
+      () => {
+        if (!timeoutState.timedOut) return;
+        persistenceOrder.push("timeout");
+        timeoutObserved.resolve();
+      },
+      { once: true },
+    );
+    await next();
   });
 
   try {
@@ -725,6 +768,7 @@ async function runProductionRouteLeaseLoss(
       fallbackCalls,
       breakerState: breaker.getState(primaryAlias),
       breaker: observations,
+      persistenceOrder,
     };
   } finally {
     await replica.shutdown();
@@ -744,32 +788,33 @@ function assertProductionRouteLeaseLoss(
   expect(result.breakerState).toBe("CLOSED");
   expect(result.breaker.failures).toBe(0);
   expect(result.breaker.cooldowns).toBe(0);
+  expect(result.persistenceOrder).toEqual(["lease_loss", "timeout", "persist"]);
   expect(result.decision.final.status).toBe("error");
   expect(result.decision.stream_outcome).toBe("truncated");
   expect(result.decision.final.error_reason).toBe("concurrency_lease_lost");
 }
 
 test.describe("real PostgreSQL distributed concurrency leases", () => {
-  test("persists Chat started-stream concurrency lease loss through the production route", async () => {
+  test("preserves Chat lease loss when timeout follows lease loss before independent persistence", async () => {
     test.setTimeout(20_000);
     assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("openai_chat"), ["[DONE]"]);
   });
 
-  test("persists Messages started-stream concurrency lease loss through the production route", async () => {
+  test("preserves Messages lease loss when timeout follows lease loss before shared persistence", async () => {
     test.setTimeout(20_000);
     assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("anthropic_messages"), [
       "event: message_stop",
     ]);
   });
 
-  test("persists Responses started-stream concurrency lease loss through the production route", async () => {
+  test("preserves Responses lease loss when timeout follows lease loss before shared persistence", async () => {
     test.setTimeout(20_000);
     assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("openai_responses"), [
       "event: response.completed",
     ]);
   });
 
-  test("persists Gemini started-stream concurrency lease loss through the production route", async () => {
+  test("preserves Gemini lease loss when timeout follows lease loss before shared persistence", async () => {
     test.setTimeout(20_000);
     assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("gemini"), [
       '"finishReason":"STOP"',

--- a/apps/gateway/e2e/concurrency-postgres.spec.ts
+++ b/apps/gateway/e2e/concurrency-postgres.spec.ts
@@ -1,10 +1,16 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import {
+  createCircuitBreaker,
   createDistributedKeyedSemaphore,
   createPgDb,
   type DistributedKeyedSemaphore,
+  type ExecutionPlan,
   PgConcurrencyLeaseStore,
   type PgDb,
+  type ProviderClient,
+  type ProviderRegistry,
 } from "@helm/core";
+import { ERROR_CLASS_HTTP_STATUS, type InternalRequest } from "@helm/shared";
 import { expect, test } from "@playwright/test";
 import type { Hono } from "hono";
 import { type AppEnv, createApp } from "../src/app.js";
@@ -13,7 +19,13 @@ import {
   concurrencyMiddleware,
   createConcurrencyGate,
 } from "../src/middleware/concurrency.js";
-import { requestSignal } from "../src/middleware/limits.js";
+import { requestSignal, timeout } from "../src/middleware/limits.js";
+import { createExecute } from "../src/routes/execute.js";
+import {
+  type ImageAttempt,
+  type ImageChainTarget,
+  runImageChain,
+} from "../src/routes/image-chain.js";
 
 // This is intentionally request-level E2E rather than another PGlite contract test:
 // two independent Hono app dependency graphs and two independent postgres-js pools
@@ -38,6 +50,7 @@ interface Replica {
   manager: DistributedKeyedSemaphore;
   store: PgConcurrencyLeaseStore;
   ownerId: string;
+  deleteCurrentLease: (keyId: string) => Promise<void>;
   closeDb: () => Promise<void>;
   shutdown: () => Promise<void>;
 }
@@ -81,13 +94,17 @@ async function createReplica(options: ReplicaOptions): Promise<Replica> {
   const store = new PgConcurrencyLeaseStore(db);
   const ownerId = `e2e-${options.name}-${crypto.randomUUID()}`;
   let leaseSequence = 0;
+  let currentLeaseId = "";
   const manager = createDistributedKeyedSemaphore({
     store,
     ownerId,
     leaseTtlMs: options.ttlMs ?? 2_000,
     heartbeatIntervalMs: options.heartbeatMs ?? 500,
     random: () => 0,
-    createLeaseId: () => `${ownerId}-lease-${++leaseSequence}`,
+    createLeaseId: () => {
+      currentLeaseId = `${ownerId}-lease-${++leaseSequence}`;
+      return currentLeaseId;
+    },
   });
   const config: ConcurrencyGateConfig = {
     enabled: true,
@@ -130,6 +147,10 @@ async function createReplica(options: ReplicaOptions): Promise<Replica> {
     manager,
     store,
     ownerId,
+    deleteCurrentLease: async (keyId: string) => {
+      if (currentLeaseId === "") throw new Error("replica has no current lease to delete");
+      await store.release({ keyId, leaseId: currentLeaseId, ownerId });
+    },
     closeDb,
     shutdown: async () => {
       await manager.shutdown();
@@ -147,6 +168,124 @@ async function work(replica: Replica, keyId: string, workMs = 2, limit = 1): Pro
       "x-test-work-ms": String(workMs),
     },
   });
+}
+
+function leaseLossRegistry(aliases: string[]): ProviderRegistry {
+  const known = new Set(aliases);
+  return {
+    resolve(alias: string) {
+      if (!known.has(alias)) return { ok: false, error: { kind: "unknown_alias", alias } };
+      return {
+        ok: true,
+        value: {
+          alias,
+          providerName: alias,
+          providerModel: `wire/${alias}`,
+          baseUrl: "http://lease-loss.invalid",
+          apiKeyEnv: "LEASE_LOSS_TEST",
+          targetProviderProtocol: "openai_chat" as const,
+          providerRequiresCompatibilityRewrite: false,
+        },
+      };
+    },
+    list: () => aliases,
+  };
+}
+
+function leaseLossPlan(aliases: string[]): ExecutionPlan {
+  return { selected_lane: "balanced", candidate_chain: aliases, explicit_model: null };
+}
+
+function leaseLossRequest(stream = false): InternalRequest {
+  return {
+    request_id: `lease-loss-${crypto.randomUUID()}`,
+    protocol: "openai_chat",
+    account_id: "acct",
+    api_key_id: "key",
+    user_id: null,
+    org_id: null,
+    requested_model: "auto",
+    messages: [{ role: "user", content: "hello" }],
+    tools: null,
+    response_format: null,
+    attachments: null,
+    max_tokens: null,
+    stream,
+    metadata: {
+      conversation_id: null,
+      thread_id: null,
+      resource_id: null,
+      project_id: null,
+      memory_mode: "off",
+    },
+  };
+}
+
+function abortError(): Error {
+  return Object.assign(new Error("lease lost"), { name: "AbortError" });
+}
+
+async function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) =>
+    signal.addEventListener("abort", () => resolve(), { once: true }),
+  );
+}
+
+async function spawnLeaseHolderChild(
+  keyId: string,
+  ttlMs: number,
+): Promise<ChildProcessWithoutNullStreams> {
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", new URL("./lease-holder-child.ts", import.meta.url).pathname],
+    {
+      env: {
+        ...process.env,
+        PG_TEST_URL: requirePostgresUrl(),
+        LEASE_TEST_KEY_ID: keyId,
+        LEASE_TEST_TTL_MS: String(ttlMs),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  await new Promise<void>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(
+      () => reject(new Error(`child replica readiness timeout: ${stderr}`)),
+      5_000,
+    );
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+      if (stdout.includes('"event":"lease-held"')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      reject(
+        new Error(`child replica exited before ready: code=${code} signal=${signal} ${stderr}`),
+      );
+    });
+  });
+  return child;
+}
+
+async function acquireLease(replica: Replica, keyId: string) {
+  const held = await replica.manager.acquire({
+    key: keyId,
+    limit: 1,
+    maxQueue: 2,
+    timeoutMs: 2_000,
+  });
+  expect(held.ok).toBe(true);
+  if (!held.ok) throw new Error(`failed to acquire test lease: ${held.reason}`);
+  return held;
 }
 
 function streamApp(replica: Replica): {
@@ -244,17 +383,10 @@ test.describe("real PostgreSQL distributed concurrency leases", () => {
     }
   });
 
-  test("recovers capacity after replica crash within TTL plus five seconds", async () => {
+  test("recovers capacity after a child replica holding the lease is SIGKILLed", async () => {
     test.setTimeout(10_000);
     const ttlMs = 250;
     const state = providerState();
-    const replicaA = await createReplica({
-      name: "crash-a",
-      state,
-      ttlMs,
-      heartbeatMs: 1_000,
-      waitTimeoutMs: ttlMs + 5_000,
-    });
     const replicaB = await createReplica({
       name: "crash-b",
       state,
@@ -263,17 +395,17 @@ test.describe("real PostgreSQL distributed concurrency leases", () => {
       waitTimeoutMs: ttlMs + 5_000,
     });
     const keyId = `crash-${crypto.randomUUID()}`;
+    let child: ChildProcessWithoutNullStreams | undefined;
     try {
-      const crashedLease = await replicaA.manager.acquire({
-        key: keyId,
-        limit: 1,
-        maxQueue: 2,
-        timeoutMs: 1_000,
-      });
-      expect(crashedLease.ok).toBe(true);
-
+      child = await spawnLeaseHolderChild(keyId, ttlMs);
       const crashedAt = Date.now();
-      await replicaA.closeDb();
+      expect(child.kill("SIGKILL")).toBe(true);
+      const [exitCode, exitSignal] = await new Promise<[number | null, NodeJS.Signals | null]>(
+        (resolve) => child?.once("exit", (code, signal) => resolve([code, signal])),
+      );
+      expect(exitCode).toBeNull();
+      expect(exitSignal).toBe("SIGKILL");
+
       const recovered = await replicaB.manager.acquire({
         key: keyId,
         limit: 1,
@@ -283,10 +415,11 @@ test.describe("real PostgreSQL distributed concurrency leases", () => {
       const recoveryMs = Date.now() - crashedAt;
       expect(recovered.ok).toBe(true);
       expect(recoveryMs).toBeLessThanOrEqual(ttlMs + 5_000);
-      console.info(`[real-pg] crash_recovery_ms=${recoveryMs} ttl_ms=${ttlMs}`);
+      console.info(`[real-pg] child_sigkill=true crash_recovery_ms=${recoveryMs} ttl_ms=${ttlMs}`);
       if (recovered.ok) await recovered.release();
     } finally {
-      await Promise.all([replicaA.shutdown(), replicaB.shutdown()]);
+      if (child?.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      await replicaB.shutdown();
     }
   });
 
@@ -321,60 +454,302 @@ test.describe("real PostgreSQL distributed concurrency leases", () => {
     }
   });
 
-  test("aborts the unified upstream signal on lease loss without provider cooldown", async () => {
-    test.setTimeout(10_000);
+  test("routes real-PG lease loss through production execute and runImageChain semantics", async () => {
+    test.setTimeout(20_000);
     const state = providerState();
     const replica = await createReplica({
-      name: "lease-loss-a",
+      name: "lease-loss-production",
       state,
       ttlMs: 400,
-      heartbeatMs: 50,
+      heartbeatMs: 40,
     });
-    const tamperDb = await createPgDb(requirePostgresUrl());
-    const tamperStore = new PgConcurrencyLeaseStore(tamperDb);
-    const keyId = `lease-loss-${crypto.randomUUID()}`;
+    try {
+      const textKey = `lease-loss-text-${crypto.randomUUID()}`;
+      const textLease = await acquireLease(replica, textKey);
+      const textEntered = deferred();
+      let primaryCalls = 0;
+      let fallbackCalls = 0;
+      const primary = {
+        chatCompletion: async (_request: unknown, options: { signal: AbortSignal }) => {
+          primaryCalls += 1;
+          textEntered.resolve();
+          await waitForAbort(options.signal);
+          throw abortError();
+        },
+        chatCompletionStream: () => {
+          throw new Error("unexpected stream call");
+        },
+      } as unknown as ProviderClient;
+      const fallback = {
+        chatCompletion: async () => {
+          fallbackCalls += 1;
+          return { id: "unexpected-fallback" };
+        },
+        chatCompletionStream: () => {
+          throw new Error("unexpected fallback stream call");
+        },
+      } as unknown as ProviderClient;
+      const textBreaker = createCircuitBreaker({
+        config: { failureThreshold: 1, cooldownMs: 60_000 },
+        now: Date.now,
+      });
+      const executeText = createExecute({
+        defaultProvider: primary,
+        providers: new Map([
+          ["primary", primary],
+          ["fallback", fallback],
+        ]),
+        registry: leaseLossRegistry(["primary", "fallback"]),
+        breaker: textBreaker,
+        catalog: new Map(),
+        now: Date.now,
+        signal: textLease.signal,
+      });
+      const textOutcomePromise = executeText(
+        leaseLossPlan(["primary", "fallback"]),
+        leaseLossRequest(),
+      );
+      await textEntered.promise;
+      await replica.deleteCurrentLease(textKey);
+      const textOutcome = await textOutcomePromise;
+      expect(textOutcome.final.status).toBe("error");
+      if (textOutcome.final.status !== "error") throw new Error("expected terminal text error");
+      expect(textOutcome.final.error.error_class).toBe("lane_unavailable");
+      expect(ERROR_CLASS_HTTP_STATUS[textOutcome.final.error.error_class]).toBe(503);
+      expect(textOutcome.attempts[0]).toMatchObject({
+        skip_reason: "concurrency_lease_lost",
+        error_class: "lane_unavailable",
+      });
+      expect(primaryCalls).toBe(1);
+      expect(fallbackCalls).toBe(0);
+      expect(textBreaker.getState("primary")).toBe("CLOSED");
+
+      for (const kind of ["openai", "gemini"] as const) {
+        const keyId = `lease-loss-${kind}-${crypto.randomUUID()}`;
+        const held = await acquireLease(replica, keyId);
+        const entered = deferred();
+        let calls = 0;
+        const imageBreaker = createCircuitBreaker({
+          config: { failureThreshold: 1, cooldownMs: 60_000 },
+          now: Date.now,
+        });
+        const targets: ImageChainTarget[] = [
+          {
+            alias: `${kind}-primary`,
+            providerModel: `${kind}-wire-primary`,
+            kind,
+            client: {} as ProviderClient,
+          },
+          {
+            alias: `${kind}-fallback`,
+            providerModel: `${kind}-wire-fallback`,
+            kind,
+            client: {} as ProviderClient,
+          },
+        ];
+        const attempt: ImageAttempt = async () => {
+          calls += 1;
+          entered.resolve();
+          await waitForAbort(held.signal);
+          throw abortError();
+        };
+        const outcomePromise = runImageChain(targets, imageBreaker, attempt, held.signal);
+        await entered.promise;
+        await replica.deleteCurrentLease(keyId);
+        const outcome = await outcomePromise;
+        expect(outcome.ok).toBe(false);
+        if (outcome.ok) throw new Error("expected terminal image error");
+        expect(outcome.aborted).toBe(false);
+        expect(outcome.errorClass).toBe("lane_unavailable");
+        expect(outcome.httpStatus).toBe(503);
+        expect(outcome.attempts[0]).toMatchObject({
+          skip_reason: "concurrency_lease_lost",
+          error_class: "lane_unavailable",
+        });
+        expect(calls).toBe(1);
+        expect(imageBreaker.getState(`${kind}-primary`)).toBe("CLOSED");
+      }
+
+      const streamKey = `lease-loss-stream-${crypto.randomUUID()}`;
+      const streamLease = await acquireLease(replica, streamKey);
+      const streamWaiting = deferred();
+      const streamLogs: Array<{ msg: string; fields: Record<string, unknown> }> = [];
+      async function* productionStream(): AsyncGenerator<string> {
+        yield 'data: {"choices":[{"delta":{"content":"first"}}]}\n\n';
+        streamWaiting.resolve();
+        await waitForAbort(streamLease.signal);
+        throw abortError();
+      }
+      const streamProvider = {
+        chatCompletion: async () => ({ id: "unexpected-non-stream" }),
+        chatCompletionStream: () => productionStream(),
+      } as unknown as ProviderClient;
+      const streamBreaker = createCircuitBreaker({
+        config: { failureThreshold: 1, cooldownMs: 60_000 },
+        now: Date.now,
+      });
+      const executeStream = createExecute({
+        defaultProvider: streamProvider,
+        providers: new Map([["stream-primary", streamProvider]]),
+        registry: leaseLossRegistry(["stream-primary"]),
+        breaker: streamBreaker,
+        catalog: new Map(),
+        now: Date.now,
+        signal: streamLease.signal,
+        log: (_level, msg, fields) => streamLogs.push({ msg, fields }),
+      });
+      const streamOutcome = await executeStream(
+        leaseLossPlan(["stream-primary"]),
+        leaseLossRequest(true),
+      );
+      expect(streamOutcome.final.status).toBe("ok");
+      const chunks: string[] = [];
+      let streamError: unknown;
+      const consume = (async () => {
+        try {
+          for await (const chunk of streamOutcome.stream as AsyncIterable<string>)
+            chunks.push(chunk);
+        } catch (error) {
+          streamError = error;
+        }
+      })();
+      await streamWaiting.promise;
+      await replica.deleteCurrentLease(streamKey);
+      await consume;
+      expect(streamError).toBeInstanceOf(Error);
+      expect(chunks.join("")).not.toContain("[DONE]");
+      expect(streamLogs).toContainEqual({
+        msg: "stream.truncated",
+        fields: {
+          alias: "stream-primary",
+          error_class: "lane_unavailable",
+          reason: "concurrency_lease_lost",
+        },
+      });
+      expect(streamBreaker.getState("stream-primary")).toBe("CLOSED");
+      console.info(
+        "[real-pg] production lease-loss text/image/interaction/stream failure=0 cooldown=0",
+      );
+    } finally {
+      await replica.shutdown();
+    }
+  });
+
+  test("leaves zero real-PG leases after provider error timeout client abort and stream error", async () => {
+    test.setTimeout(15_000);
+    const state = providerState();
+    const replica = await createReplica({
+      name: "exit-matrix",
+      state,
+      ttlMs: 500,
+      heartbeatMs: 100,
+      waitTimeoutMs: 2_000,
+    });
     const gate = createConcurrencyGate({
       semaphore: replica.manager,
       getConfig: () => ({ enabled: true, minSize: 2, multiplier: 0, waitTimeoutMs: 2_000 }),
     });
     const app = createApp({ logger: { log: () => {} } });
-    app.use("/upstream", async (c, next) => {
+    const keyFor = (path: string) => `exit-${path}-${crypto.randomUUID()}`;
+    const keys = new Map<string, string>();
+    app.use("/exit/*", async (c, next) => {
+      const path = c.req.path.split("/").at(-1) ?? "unknown";
+      const keyId = c.req.header("x-test-key") ?? keyFor(path);
+      keys.set(path, keyId);
       // biome-ignore lint/suspicious/noExplicitAny: request-level test identity seam
       (c as any).set("identity", { keyId, caps: { concurrencyLimit: 1 } });
       await next();
     });
-    app.use("/upstream", concurrencyMiddleware(gate));
-    const entered = deferred();
-    app.get("/upstream", async (c) => {
-      state.calls += 1;
-      entered.resolve();
-      const signal = requestSignal(c);
-      await new Promise<void>((resolve) =>
-        signal.addEventListener("abort", () => resolve(), { once: true }),
-      );
-      if (String(signal.reason).includes("lease_lost")) {
-        return c.json({ error: "lease_lost" }, 503);
-      }
-      state.failures += 1;
-      state.cooldowns += 1;
-      return c.json({ error: "provider_failure" }, 502);
+    app.use("/exit/request-timeout", timeout({ requestTimeoutMs: 25 }));
+    app.use("/exit/*", concurrencyMiddleware(gate));
+    app.get("/exit/provider-error", () => {
+      throw new Error("provider failed");
     });
-    try {
-      const responsePromise = app.request("/upstream");
-      await entered.promise;
-      await tamperStore.release({
-        keyId,
-        leaseId: `${replica.ownerId}-lease-1`,
-        ownerId: replica.ownerId,
+    app.get("/exit/request-timeout", async (c) => {
+      await waitForAbort(requestSignal(c));
+      await delay(10);
+      return c.text("late timeout completion");
+    });
+    const clientEntered = deferred();
+    app.get("/exit/client-abort", async (c) => {
+      clientEntered.resolve();
+      await waitForAbort(requestSignal(c));
+      throw Object.assign(new Error("client abort"), { name: "AbortError" });
+    });
+    app.get("/exit/stream-error", (c) => {
+      const release = c.get("concurrencyClaim")?.();
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("first"));
+          setTimeout(() => {
+            void release?.().finally(() => controller.error(new Error("stream failed")));
+          }, 10);
+        },
+        async cancel() {
+          await release?.();
+        },
       });
-      const response = await responsePromise;
-      expect(response.status).toBe(503);
-      expect(state.calls).toBe(1);
-      expect(state.failures).toBe(0);
-      expect(state.cooldowns).toBe(0);
-      console.info("[real-pg] lease_loss provider_failures=0 provider_cooldowns=0");
+      return new Response(body);
+    });
+
+    const assertNoResidual = async (path: string): Promise<void> => {
+      const keyId = keys.get(path);
+      expect(keyId).toBeTruthy();
+      const probe = await replica.manager.acquire({
+        key: keyId as string,
+        limit: 1,
+        maxQueue: 0,
+        timeoutMs: 1_000,
+      });
+      expect(probe.ok).toBe(true);
+      if (probe.ok) await probe.release();
+    };
+
+    try {
+      const providerKey = keyFor("provider-error");
+      expect(
+        (
+          await app.request("/exit/provider-error", {
+            headers: { "x-test-key": providerKey },
+          })
+        ).status,
+      ).toBe(502);
+      await assertNoResidual("provider-error");
+
+      const timeoutKey = keyFor("request-timeout");
+      expect(
+        (
+          await app.request("/exit/request-timeout", {
+            headers: { "x-test-key": timeoutKey },
+          })
+        ).status,
+      ).toBe(504);
+      await delay(20);
+      await assertNoResidual("request-timeout");
+
+      const abortKey = keyFor("client-abort");
+      const controller = new AbortController();
+      const abortedRequest = app
+        .request("/exit/client-abort", {
+          headers: { "x-test-key": abortKey },
+          signal: controller.signal,
+        })
+        .catch(() => null);
+      await clientEntered.promise;
+      controller.abort("client_disconnect");
+      await abortedRequest;
+      await assertNoResidual("client-abort");
+
+      const streamKey = keyFor("stream-error");
+      const streamResponse = await app.request("/exit/stream-error", {
+        headers: { "x-test-key": streamKey },
+      });
+      await expect(streamResponse.text()).rejects.toThrow("stream failed");
+      await assertNoResidual("stream-error");
+      console.info(
+        "[real-pg] exit_matrix provider_error/timeout/client_abort/stream_error residual=0",
+      );
     } finally {
-      await tamperDb.$close();
       await replica.shutdown();
     }
   });

--- a/apps/gateway/e2e/concurrency-postgres.spec.ts
+++ b/apps/gateway/e2e/concurrency-postgres.spec.ts
@@ -1,0 +1,434 @@
+import {
+  createDistributedKeyedSemaphore,
+  createPgDb,
+  type DistributedKeyedSemaphore,
+  PgConcurrencyLeaseStore,
+  type PgDb,
+} from "@helm/core";
+import { expect, test } from "@playwright/test";
+import type { Hono } from "hono";
+import { type AppEnv, createApp } from "../src/app.js";
+import {
+  type ConcurrencyGateConfig,
+  concurrencyMiddleware,
+  createConcurrencyGate,
+} from "../src/middleware/concurrency.js";
+import { requestSignal } from "../src/middleware/limits.js";
+
+// This is intentionally request-level E2E rather than another PGlite contract test:
+// two independent Hono app dependency graphs and two independent postgres-js pools
+// represent two replicas while sharing the exact production lease store/manager.
+// The e2e launcher guarantees a real PostgreSQL 17 + pgvector URL before Playwright
+// starts. Explicit URL precedence is PG_TEST_URL, then HELM_TEST_POSTGRES_URL.
+const postgresUrl = process.env.PG_TEST_URL ?? process.env.HELM_TEST_POSTGRES_URL;
+
+const encoder = new TextEncoder();
+
+interface ProviderState {
+  active: number;
+  maxActive: number;
+  calls: number;
+  failures: number;
+  cooldowns: number;
+}
+
+interface Replica {
+  app: Hono<AppEnv>;
+  db: PgDb;
+  manager: DistributedKeyedSemaphore;
+  store: PgConcurrencyLeaseStore;
+  ownerId: string;
+  closeDb: () => Promise<void>;
+  shutdown: () => Promise<void>;
+}
+
+interface ReplicaOptions {
+  name: string;
+  state: ProviderState;
+  ttlMs?: number;
+  heartbeatMs?: number;
+  waitTimeoutMs?: number;
+  minQueueSize?: number;
+}
+
+function requirePostgresUrl(): string {
+  if (!postgresUrl) {
+    throw new Error(
+      "real PostgreSQL E2E requires PG_TEST_URL or HELM_TEST_POSTGRES_URL; the pnpm test:e2e launcher must provision one",
+    );
+  }
+  return postgresUrl;
+}
+
+function providerState(): ProviderState {
+  return { active: 0, maxActive: 0, calls: 0, failures: 0, cooldowns: 0 };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function createReplica(options: ReplicaOptions): Promise<Replica> {
+  const db = await createPgDb(requirePostgresUrl());
+  const store = new PgConcurrencyLeaseStore(db);
+  const ownerId = `e2e-${options.name}-${crypto.randomUUID()}`;
+  let leaseSequence = 0;
+  const manager = createDistributedKeyedSemaphore({
+    store,
+    ownerId,
+    leaseTtlMs: options.ttlMs ?? 2_000,
+    heartbeatIntervalMs: options.heartbeatMs ?? 500,
+    random: () => 0,
+    createLeaseId: () => `${ownerId}-lease-${++leaseSequence}`,
+  });
+  const config: ConcurrencyGateConfig = {
+    enabled: true,
+    minSize: options.minQueueSize ?? 100,
+    multiplier: 0,
+    waitTimeoutMs: options.waitTimeoutMs ?? 4_000,
+  };
+  const gate = createConcurrencyGate({ semaphore: manager, getConfig: () => config });
+  const app = createApp({ logger: { log: () => {} } });
+
+  app.use("/work", async (c, next) => {
+    const keyId = c.req.header("x-test-key") ?? "real-pg-default";
+    const limit = Number(c.req.header("x-test-limit") ?? "1");
+    // biome-ignore lint/suspicious/noExplicitAny: request-level test identity seam
+    (c as any).set("identity", { keyId, caps: { concurrencyLimit: limit } });
+    await next();
+  });
+  app.use("/work", concurrencyMiddleware(gate));
+  app.post("/work", async (c) => {
+    options.state.calls += 1;
+    options.state.active += 1;
+    options.state.maxActive = Math.max(options.state.maxActive, options.state.active);
+    try {
+      await delay(Number(c.req.header("x-test-work-ms") ?? "2"));
+      return c.json({ ok: true });
+    } finally {
+      options.state.active -= 1;
+    }
+  });
+
+  let dbClosed = false;
+  const closeDb = async (): Promise<void> => {
+    if (dbClosed) return;
+    dbClosed = true;
+    await db.$close();
+  };
+  return {
+    app,
+    db,
+    manager,
+    store,
+    ownerId,
+    closeDb,
+    shutdown: async () => {
+      await manager.shutdown();
+      await closeDb();
+    },
+  };
+}
+
+async function work(replica: Replica, keyId: string, workMs = 2, limit = 1): Promise<Response> {
+  return replica.app.request("/work", {
+    method: "POST",
+    headers: {
+      "x-test-key": keyId,
+      "x-test-limit": String(limit),
+      "x-test-work-ms": String(workMs),
+    },
+  });
+}
+
+function streamApp(replica: Replica): {
+  app: Hono<AppEnv>;
+  ready: Promise<void>;
+  finish: () => void;
+} {
+  const ready = deferred();
+  const finish = deferred();
+  const gate = createConcurrencyGate({
+    semaphore: replica.manager,
+    getConfig: () => ({ enabled: true, minSize: 10, multiplier: 0, waitTimeoutMs: 4_000 }),
+  });
+  const app = createApp({ logger: { log: () => {} } });
+  app.use("/stream", async (c, next) => {
+    // biome-ignore lint/suspicious/noExplicitAny: request-level test identity seam
+    (c as any).set("identity", {
+      keyId: c.req.header("x-test-key") ?? "stream-key",
+      caps: { concurrencyLimit: 1 },
+    });
+    await next();
+  });
+  app.use("/stream", concurrencyMiddleware(gate));
+  app.get("/stream", (c) => {
+    const release = c.get("concurrencyClaim")?.();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("event: chunk\ndata: first\n\n"));
+        ready.resolve();
+        void finish.promise.then(async () => {
+          controller.enqueue(encoder.encode("event: done\ndata: [DONE]\n\n"));
+          controller.close();
+          await release?.();
+        });
+      },
+      async cancel() {
+        await release?.();
+      },
+    });
+    return new Response(body, { headers: { "content-type": "text/event-stream" } });
+  });
+  return { app, ready: ready.promise, finish: finish.resolve };
+}
+
+test.describe("real PostgreSQL distributed concurrency leases", () => {
+  test("enforces one global slot across two replicas and 100 concurrent requests", async () => {
+    test.setTimeout(20_000);
+    const state = providerState();
+    const replicaA = await createReplica({ name: "load-a", state, waitTimeoutMs: 5_000 });
+    const replicaB = await createReplica({ name: "load-b", state, waitTimeoutMs: 5_000 });
+    const keyId = `load-${crypto.randomUUID()}`;
+    try {
+      const responses = await Promise.all(
+        Array.from({ length: 100 }, (_, index) =>
+          work(index % 2 === 0 ? replicaA : replicaB, keyId, 3),
+        ),
+      );
+      expect(responses.map((response) => response.status)).toEqual(Array(100).fill(200));
+      expect(state.calls).toBe(100);
+      expect(state.maxActive).toBe(1);
+      console.info(`[real-pg] requests=100 max_active=${state.maxActive}`);
+    } finally {
+      await Promise.all([replicaA.shutdown(), replicaB.shutdown()]);
+    }
+  });
+
+  test("does not let key A limit=1 block key B", async () => {
+    const state = providerState();
+    const replicaA = await createReplica({ name: "isolation-a", state });
+    const replicaB = await createReplica({ name: "isolation-b", state });
+    const holdA = deferred();
+    const keyA = `isolation-a-${crypto.randomUUID()}`;
+    const keyB = `isolation-b-${crypto.randomUUID()}`;
+    try {
+      const held = replicaA.manager.acquire({
+        key: keyA,
+        limit: 1,
+        maxQueue: 2,
+        timeoutMs: 2_000,
+      });
+      const leaseA = await held;
+      expect(leaseA.ok).toBe(true);
+
+      const responseB = await Promise.race([
+        work(replicaB, keyB, 10),
+        holdA.promise.then(() => {
+          throw new Error("key B waited for unrelated key A");
+        }),
+      ]);
+      expect(responseB.status).toBe(200);
+      if (leaseA.ok) await leaseA.release();
+    } finally {
+      holdA.resolve();
+      await Promise.all([replicaA.shutdown(), replicaB.shutdown()]);
+    }
+  });
+
+  test("recovers capacity after replica crash within TTL plus five seconds", async () => {
+    test.setTimeout(10_000);
+    const ttlMs = 250;
+    const state = providerState();
+    const replicaA = await createReplica({
+      name: "crash-a",
+      state,
+      ttlMs,
+      heartbeatMs: 1_000,
+      waitTimeoutMs: ttlMs + 5_000,
+    });
+    const replicaB = await createReplica({
+      name: "crash-b",
+      state,
+      ttlMs,
+      heartbeatMs: 50,
+      waitTimeoutMs: ttlMs + 5_000,
+    });
+    const keyId = `crash-${crypto.randomUUID()}`;
+    try {
+      const crashedLease = await replicaA.manager.acquire({
+        key: keyId,
+        limit: 1,
+        maxQueue: 2,
+        timeoutMs: 1_000,
+      });
+      expect(crashedLease.ok).toBe(true);
+
+      const crashedAt = Date.now();
+      await replicaA.closeDb();
+      const recovered = await replicaB.manager.acquire({
+        key: keyId,
+        limit: 1,
+        maxQueue: 2,
+        timeoutMs: ttlMs + 5_000,
+      });
+      const recoveryMs = Date.now() - crashedAt;
+      expect(recovered.ok).toBe(true);
+      expect(recoveryMs).toBeLessThanOrEqual(ttlMs + 5_000);
+      console.info(`[real-pg] crash_recovery_ms=${recoveryMs} ttl_ms=${ttlMs}`);
+      if (recovered.ok) await recovered.release();
+    } finally {
+      await Promise.all([replicaA.shutdown(), replicaB.shutdown()]);
+    }
+  });
+
+  test("heartbeats a request beyond two TTLs without oversubscribing", async () => {
+    test.setTimeout(10_000);
+    const ttlMs = 180;
+    const state = providerState();
+    const replicaA = await createReplica({
+      name: "heartbeat-a",
+      state,
+      ttlMs,
+      heartbeatMs: 40,
+      waitTimeoutMs: 4_000,
+    });
+    const replicaB = await createReplica({
+      name: "heartbeat-b",
+      state,
+      ttlMs,
+      heartbeatMs: 40,
+      waitTimeoutMs: 4_000,
+    });
+    const keyId = `heartbeat-${crypto.randomUUID()}`;
+    try {
+      const first = work(replicaA, keyId, ttlMs * 3);
+      await delay(50);
+      const second = work(replicaB, keyId, 10);
+      expect((await first).status).toBe(200);
+      expect((await second).status).toBe(200);
+      expect(state.maxActive).toBe(1);
+    } finally {
+      await Promise.all([replicaA.shutdown(), replicaB.shutdown()]);
+    }
+  });
+
+  test("aborts the unified upstream signal on lease loss without provider cooldown", async () => {
+    test.setTimeout(10_000);
+    const state = providerState();
+    const replica = await createReplica({
+      name: "lease-loss-a",
+      state,
+      ttlMs: 400,
+      heartbeatMs: 50,
+    });
+    const tamperDb = await createPgDb(requirePostgresUrl());
+    const tamperStore = new PgConcurrencyLeaseStore(tamperDb);
+    const keyId = `lease-loss-${crypto.randomUUID()}`;
+    const gate = createConcurrencyGate({
+      semaphore: replica.manager,
+      getConfig: () => ({ enabled: true, minSize: 2, multiplier: 0, waitTimeoutMs: 2_000 }),
+    });
+    const app = createApp({ logger: { log: () => {} } });
+    app.use("/upstream", async (c, next) => {
+      // biome-ignore lint/suspicious/noExplicitAny: request-level test identity seam
+      (c as any).set("identity", { keyId, caps: { concurrencyLimit: 1 } });
+      await next();
+    });
+    app.use("/upstream", concurrencyMiddleware(gate));
+    const entered = deferred();
+    app.get("/upstream", async (c) => {
+      state.calls += 1;
+      entered.resolve();
+      const signal = requestSignal(c);
+      await new Promise<void>((resolve) =>
+        signal.addEventListener("abort", () => resolve(), { once: true }),
+      );
+      if (String(signal.reason).includes("lease_lost")) {
+        return c.json({ error: "lease_lost" }, 503);
+      }
+      state.failures += 1;
+      state.cooldowns += 1;
+      return c.json({ error: "provider_failure" }, 502);
+    });
+    try {
+      const responsePromise = app.request("/upstream");
+      await entered.promise;
+      await tamperStore.release({
+        keyId,
+        leaseId: `${replica.ownerId}-lease-1`,
+        ownerId: replica.ownerId,
+      });
+      const response = await responsePromise;
+      expect(response.status).toBe(503);
+      expect(state.calls).toBe(1);
+      expect(state.failures).toBe(0);
+      expect(state.cooldowns).toBe(0);
+      console.info("[real-pg] lease_loss provider_failures=0 provider_cooldowns=0");
+    } finally {
+      await tamperDb.$close();
+      await replica.shutdown();
+    }
+  });
+
+  test("holds a streaming slot until the final event and reader cancel", async () => {
+    test.setTimeout(10_000);
+    const state = providerState();
+    const replicaA = await createReplica({ name: "stream-a", state, waitTimeoutMs: 4_000 });
+    const replicaB = await createReplica({ name: "stream-b", state, waitTimeoutMs: 4_000 });
+    const keyId = `stream-${crypto.randomUUID()}`;
+    try {
+      const first = streamApp(replicaA);
+      const response = await first.app.request("/stream", { headers: { "x-test-key": keyId } });
+      await first.ready;
+      const competing = work(replicaB, keyId, 5);
+      let competingDone = false;
+      void competing.then(() => {
+        competingDone = true;
+      });
+      await delay(100);
+      expect(competingDone).toBe(false);
+      first.finish();
+      expect(await response.text()).toContain("[DONE]");
+      expect((await competing).status).toBe(200);
+
+      const cancelled = streamApp(replicaA);
+      const cancelResponse = await cancelled.app.request("/stream", {
+        headers: { "x-test-key": keyId },
+      });
+      await cancelled.ready;
+      const reader = cancelResponse.body?.getReader();
+      expect(reader).toBeTruthy();
+      await reader?.read();
+      const blocked = work(replicaB, keyId, 5);
+      await delay(100);
+      await reader?.cancel("client_cancelled");
+      expect((await blocked).status).toBe(200);
+    } finally {
+      await Promise.all([replicaA.shutdown(), replicaB.shutdown()]);
+    }
+  });
+
+  test("fails closed with protocol 503 and zero provider calls when the DB is unavailable", async () => {
+    const state = providerState();
+    const replica = await createReplica({ name: "db-down", state });
+    try {
+      await replica.closeDb();
+      const response = await work(replica, `db-down-${crypto.randomUUID()}`);
+      expect(response.status).toBe(503);
+      expect(state.calls).toBe(0);
+      const body = (await response.json()) as { error: { code: string } };
+      expect(body.error.code).toBe("lane_unavailable");
+    } finally {
+      await replica.shutdown();
+    }
+  });
+});

--- a/apps/gateway/e2e/concurrency-postgres.spec.ts
+++ b/apps/gateway/e2e/concurrency-postgres.spec.ts
@@ -1,31 +1,61 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import {
+  type AnthropicSSEEvent,
+  anthropicTransformer,
+  type CircuitBreaker,
   createCircuitBreaker,
   createDistributedKeyedSemaphore,
   createPgDb,
+  type DecisionRecord,
   type DistributedKeyedSemaphore,
   type ExecutionPlan,
+  geminiTransformer,
+  type IRResponse,
+  makeAnthropicError,
+  makeGeminiError,
   PgConcurrencyLeaseStore,
   type PgDb,
   type ProviderClient,
   type ProviderRegistry,
+  type ResponsesSSEEvent,
+  type RouteDeps,
+  type RouteOptions,
+  responsesTransformer,
+  routeRequest,
+  type TelemetryStore,
 } from "@helm/core";
-import { ERROR_CLASS_HTTP_STATUS, type InternalRequest } from "@helm/shared";
+import {
+  ERROR_CLASS_HTTP_STATUS,
+  ErrorClassSchema,
+  type InternalRequest,
+  type Protocol,
+} from "@helm/shared";
 import { expect, test } from "@playwright/test";
 import type { Hono } from "hono";
 import { type AppEnv, createApp } from "../src/app.js";
+import type { AuthIdentity } from "../src/middleware/auth.js";
 import {
   type ConcurrencyGateConfig,
   concurrencyMiddleware,
   createConcurrencyGate,
 } from "../src/middleware/concurrency.js";
 import { requestSignal, timeout } from "../src/middleware/limits.js";
+import { registerChatRoutes } from "../src/routes/chat.js";
 import { createExecute } from "../src/routes/execute.js";
+import { registerGeminiRoute } from "../src/routes/gemini.js";
 import {
   type ImageAttempt,
   type ImageChainTarget,
   runImageChain,
 } from "../src/routes/image-chain.js";
+import {
+  type MessagesIdentity,
+  type RouteError,
+  registerMessagesRoute,
+} from "../src/routes/messages.js";
+import { createMessagesPipeline } from "../src/routes/messages-pipeline.js";
+import type { RecordServedDeps } from "../src/routes/payload-capture.js";
+import { registerResponsesRoute } from "../src/routes/responses.js";
 
 // This is intentionally request-level E2E rather than another PGlite contract test:
 // two independent Hono app dependency graphs and two independent postgres-js pools
@@ -330,7 +360,423 @@ function streamApp(replica: Replica): {
   return { app, ready: ready.promise, finish: finish.resolve };
 }
 
+type ProductionRouteProtocol = Extract<
+  Protocol,
+  "openai_chat" | "anthropic_messages" | "openai_responses" | "gemini"
+>;
+
+interface BreakerObservations {
+  failures: number;
+  cooldowns: number;
+}
+
+interface ProductionRouteResult {
+  wire: string;
+  decision: DecisionRecord;
+  primaryCalls: number;
+  fallbackCalls: number;
+  breakerState: ReturnType<CircuitBreaker["getState"]>;
+  breaker: BreakerObservations;
+}
+
+function trackedBreaker(): {
+  breaker: CircuitBreaker;
+  observations: BreakerObservations;
+} {
+  const inner = createCircuitBreaker({
+    config: { failureThreshold: 1, cooldownMs: 60_000 },
+    now: Date.now,
+  });
+  const observations: BreakerObservations = { failures: 0, cooldowns: 0 };
+  return {
+    observations,
+    breaker: {
+      canAttempt(model) {
+        const decision = inner.canAttempt(model);
+        if (!decision.allow && decision.reason === "circuit_open") observations.cooldowns += 1;
+        return decision;
+      },
+      recordFailure(model) {
+        observations.failures += 1;
+        inner.recordFailure(model);
+      },
+      recordSuccess: (model) => inner.recordSuccess(model),
+      recordAbort: (model) => inner.recordAbort(model),
+      getState: (model) => inner.getState(model),
+    },
+  };
+}
+
+function routeIdentity(keyId: string): {
+  chat: AuthIdentity;
+  pipeline: MessagesIdentity;
+} {
+  const commonCaps = {
+    allowedLanes: null,
+    allowCustomModel: true,
+    blockedModels: null,
+    allowFastMode: true,
+    rateLimit: { rpm: null, tpm: null },
+    concurrencyLimit: 1,
+    budget: {
+      requests: null,
+      tokens: null,
+      spendUsd: null,
+      windowSeconds: null,
+      behavior: "degrade" as const,
+      degradeLane: null,
+    },
+    memory: {
+      mode: "off" as const,
+      projectId: null,
+      threadSource: "header" as const,
+    },
+  };
+  return {
+    chat: {
+      keyId,
+      keyPrefix: "helm_test_route",
+      accountId: "acct",
+      orgId: null,
+      userId: null,
+      role: "user",
+      caps: commonCaps,
+    },
+    pipeline: {
+      keyId,
+      keyPrefix: "helm_test_route",
+      accountId: "acct",
+      orgId: null,
+      userId: null,
+      role: "user",
+      caps: commonCaps,
+    },
+  };
+}
+
+function errorClass(error: RouteError) {
+  const parsed = ErrorClassSchema.safeParse(error.error_class);
+  return parsed.success ? parsed.data : ("upstream_error" as const);
+}
+
+async function runProductionRouteLeaseLoss(
+  protocol: ProductionRouteProtocol,
+): Promise<ProductionRouteResult> {
+  const state = providerState();
+  const replica = await createReplica({
+    name: `route-${protocol}`,
+    state,
+    ttlMs: 400,
+    heartbeatMs: 40,
+  });
+  const keyId = `route-${protocol}-${crypto.randomUUID()}`;
+  const identity = routeIdentity(keyId);
+  const primaryAlias = `${protocol}-primary`;
+  const fallbackAlias = `${protocol}-fallback`;
+  const providerWaiting = deferred();
+  const persisted = deferred();
+  const persistedDecisions: DecisionRecord[] = [];
+  let primaryCalls = 0;
+  let fallbackCalls = 0;
+  let executionSignal: AbortSignal | null = null;
+  const { breaker, observations } = trackedBreaker();
+
+  async function* primaryStream(): AsyncGenerator<string> {
+    yield `data: ${JSON.stringify({
+      id: "chatcmpl-route-lease-loss",
+      object: "chat.completion.chunk",
+      created: 1,
+      model: "wire/route-primary",
+      choices: [
+        {
+          index: 0,
+          delta: { role: "assistant", content: "first-visible-chunk" },
+          finish_reason: null,
+        },
+      ],
+    })}\n\n`;
+    providerWaiting.resolve();
+    if (executionSignal === null) throw new Error("production route did not bind its signal");
+    await waitForAbort(executionSignal);
+    throw abortError();
+  }
+
+  const primary = {
+    chatCompletion: async () => ({ id: "unexpected-non-stream" }),
+    chatCompletionStream: () => {
+      primaryCalls += 1;
+      return primaryStream();
+    },
+  } as unknown as ProviderClient;
+  const fallback = {
+    chatCompletion: async () => {
+      fallbackCalls += 1;
+      return { id: "unexpected-fallback" };
+    },
+    chatCompletionStream: () => {
+      fallbackCalls += 1;
+      return (async function* () {
+        yield "data: [DONE]\n\n";
+      })();
+    },
+  } as unknown as ProviderClient;
+  const providers = new Map([
+    [primaryAlias, primary],
+    [fallbackAlias, fallback],
+  ]);
+  const registry = leaseLossRegistry([primaryAlias, fallbackAlias]);
+  const routingDeps = {
+    classify: async () => ({
+      task_type: "general",
+      complexity: "medium" as const,
+      confidence: 1,
+      decided_by: "rules" as const,
+      constraints: {},
+      explanation: [],
+    }),
+    policies: { policies: [] },
+    lanes: {
+      balanced: {
+        primary: primaryAlias,
+        fallback: [fallbackAlias],
+        constraints: {},
+      },
+    },
+    now: () => new Date(),
+    log: () => {},
+  } as RouteDeps;
+  const route = (request: InternalRequest, options: RouteOptions, signal: AbortSignal) => {
+    executionSignal = signal;
+    return routeRequest(
+      request,
+      {
+        ...routingDeps,
+        execute: createExecute({
+          defaultProvider: primary,
+          providers,
+          registry,
+          breaker,
+          catalog: new Map(),
+          now: Date.now,
+          signal,
+        }),
+      },
+      options,
+    );
+  };
+
+  const telemetry = {
+    insert: async (input: { decision: DecisionRecord }) => {
+      persistedDecisions.push(input.decision);
+      persisted.resolve();
+      return { id: "route-lease-loss" };
+    },
+  } as unknown as TelemetryStore;
+  const record: RecordServedDeps = {
+    telemetry,
+    redact: (decision) => decision,
+    now: Date.now,
+    capturePayloads: () => false,
+    captureSessions: () => false,
+  };
+  const gate = createConcurrencyGate({
+    semaphore: replica.manager,
+    getConfig: () => ({
+      enabled: true,
+      minSize: 2,
+      multiplier: 0,
+      waitTimeoutMs: 2_000,
+    }),
+  });
+  const routeLogs: Array<{
+    level: string;
+    message: string;
+    fields: Record<string, unknown> | undefined;
+  }> = [];
+  const app = createApp({
+    logger: {
+      log: (level, message, fields) => routeLogs.push({ level, message, fields }),
+    },
+  });
+
+  try {
+    let path: string;
+    let headers: Record<string, string>;
+    let body: Record<string, unknown>;
+    if (protocol === "openai_chat") {
+      path = "/v1/chat/completions";
+      headers = { "content-type": "application/json" };
+      body = {
+        model: "auto",
+        messages: [{ role: "user", content: "hello" }],
+        stream: true,
+      };
+      app.use(path, async (c, next) => {
+        c.set("identity", identity.chat);
+        await next();
+      });
+      app.use(path, concurrencyMiddleware(gate));
+      registerChatRoutes(app, {
+        route,
+        telemetry,
+        redact: (decision) => decision,
+        now: Date.now,
+      });
+    } else if (protocol === "anthropic_messages") {
+      path = "/v1/messages";
+      headers = { "content-type": "application/json", "x-api-key": "route-test-key" };
+      body = {
+        model: "auto",
+        max_tokens: 32,
+        messages: [{ role: "user", content: "hello" }],
+        stream: true,
+      };
+      registerMessagesRoute(app, {
+        concurrencyGate: gate,
+        record,
+        auth: { resolve: async () => identity.pipeline },
+        transformers: {
+          anthropic: {
+            transformRequestOut: (native) => anthropicTransformer.transformRequestOut(native),
+            transformResponseOut: (ir, options) =>
+              anthropicTransformer.transformResponseOut(ir as IRResponse, options),
+            transformStreamOut: (event) => {
+              const typed = event as AnthropicSSEEvent & { type: string };
+              return { event: typed.type, data: JSON.stringify(typed) };
+            },
+            transformErrorOut: (error) =>
+              makeAnthropicError({
+                error_class: errorClass(error),
+                message: error.message,
+                trace_id: error.trace_id,
+              }),
+          },
+        },
+        pipeline: createMessagesPipeline(route, protocol),
+      });
+    } else if (protocol === "openai_responses") {
+      path = "/v1/responses";
+      headers = {
+        authorization: "Bearer route-test-key",
+        "content-type": "application/json",
+      };
+      body = { model: "auto", input: "hello", stream: true };
+      registerResponsesRoute(app, {
+        concurrencyGate: gate,
+        record,
+        auth: { resolve: async () => identity.pipeline },
+        transformer: {
+          transformRequestOut: (native) => responsesTransformer.transformRequestOut(native),
+          transformResponseOut: (ir) => responsesTransformer.transformResponseOut(ir as IRResponse),
+          transformStreamOut: (event) => {
+            const typed = event as ResponsesSSEEvent & { type: string };
+            return { event: typed.type, data: JSON.stringify(typed) };
+          },
+        },
+        pipeline: createMessagesPipeline(route, protocol),
+      });
+    } else {
+      path = "/v1beta/models/auto:streamGenerateContent?alt=sse";
+      headers = {
+        "content-type": "application/json",
+        "x-goog-api-key": "route-test-key",
+      };
+      body = {
+        contents: [{ role: "user", parts: [{ text: "hello" }] }],
+      };
+      registerGeminiRoute(app, {
+        concurrencyGate: gate,
+        record,
+        auth: { resolve: async () => identity.pipeline },
+        transformer: {
+          transformRequestOut: (native) => geminiTransformer.transformRequestOut(native),
+          transformResponseOut: (ir) => geminiTransformer.transformResponseOut(ir as IRResponse),
+          transformErrorOut: (error) =>
+            makeGeminiError({
+              error_class: errorClass(error),
+              message: error.message,
+              trace_id: error.trace_id,
+            }),
+        },
+        pipeline: createMessagesPipeline(route, protocol),
+      });
+    }
+
+    const response = await app.request(path, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    if (response.status !== 200) {
+      throw new Error(
+        `${protocol} route returned HTTP ${response.status}: ${await response.text()}; logs=${JSON.stringify(routeLogs)}`,
+      );
+    }
+    const wirePromise = response.text();
+    await providerWaiting.promise;
+    await replica.deleteCurrentLease(keyId);
+    const wire = await wirePromise;
+    await persisted.promise;
+    expect(persistedDecisions).toHaveLength(1);
+    return {
+      wire,
+      decision: persistedDecisions[0] as DecisionRecord,
+      primaryCalls,
+      fallbackCalls,
+      breakerState: breaker.getState(primaryAlias),
+      breaker: observations,
+    };
+  } finally {
+    await replica.shutdown();
+  }
+}
+
+function assertProductionRouteLeaseLoss(
+  result: ProductionRouteResult,
+  normalTerminals: readonly string[],
+): void {
+  expect(result.wire).toContain("first-visible-chunk");
+  for (const terminal of normalTerminals) expect(result.wire).not.toContain(terminal);
+  expect(result.decision.fallback_count).toBe(0);
+  expect(result.decision.provider_attempts).toHaveLength(1);
+  expect(result.primaryCalls).toBe(1);
+  expect(result.fallbackCalls).toBe(0);
+  expect(result.breakerState).toBe("CLOSED");
+  expect(result.breaker.failures).toBe(0);
+  expect(result.breaker.cooldowns).toBe(0);
+  expect(result.decision.final.status).toBe("error");
+  expect(result.decision.stream_outcome).toBe("truncated");
+  expect(result.decision.final.error_reason).toBe("concurrency_lease_lost");
+}
+
 test.describe("real PostgreSQL distributed concurrency leases", () => {
+  test("persists Chat started-stream concurrency lease loss through the production route", async () => {
+    test.setTimeout(20_000);
+    assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("openai_chat"), ["[DONE]"]);
+  });
+
+  test("persists Messages started-stream concurrency lease loss through the production route", async () => {
+    test.setTimeout(20_000);
+    assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("anthropic_messages"), [
+      "event: message_stop",
+    ]);
+  });
+
+  test("persists Responses started-stream concurrency lease loss through the production route", async () => {
+    test.setTimeout(20_000);
+    assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("openai_responses"), [
+      "event: response.completed",
+    ]);
+  });
+
+  test("persists Gemini started-stream concurrency lease loss through the production route", async () => {
+    test.setTimeout(20_000);
+    assertProductionRouteLeaseLoss(await runProductionRouteLeaseLoss("gemini"), [
+      '"finishReason":"STOP"',
+      "[DONE]",
+    ]);
+  });
+
   test("enforces one global slot across two replicas and 100 concurrent requests", async () => {
     test.setTimeout(20_000);
     const state = providerState();

--- a/apps/gateway/e2e/lease-holder-child.ts
+++ b/apps/gateway/e2e/lease-holder-child.ts
@@ -1,0 +1,31 @@
+import { createDistributedKeyedSemaphore, createPgDb, PgConcurrencyLeaseStore } from "@helm/core";
+
+const postgresUrl = process.env.PG_TEST_URL ?? process.env.HELM_TEST_POSTGRES_URL;
+const keyId = process.env.LEASE_TEST_KEY_ID;
+const ttlMs = Number(process.env.LEASE_TEST_TTL_MS ?? "0");
+const ownerId = `child-replica-${process.pid}-${crypto.randomUUID()}`;
+
+if (!postgresUrl || !keyId || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+  throw new Error("child replica requires PostgreSQL URL, LEASE_TEST_KEY_ID and LEASE_TEST_TTL_MS");
+}
+
+const db = await createPgDb(postgresUrl);
+const manager = createDistributedKeyedSemaphore({
+  store: new PgConcurrencyLeaseStore(db),
+  ownerId,
+  leaseTtlMs: ttlMs,
+  heartbeatIntervalMs: Math.max(25, Math.floor(ttlMs / 3)),
+  random: () => 0,
+  createLeaseId: () => `${ownerId}-lease`,
+});
+const held = await manager.acquire({
+  key: keyId,
+  limit: 1,
+  maxQueue: 0,
+  timeoutMs: 2_000,
+});
+if (!held.ok) throw new Error(`child replica failed to acquire lease: ${held.reason}`);
+
+process.stdout.write(`${JSON.stringify({ event: "lease-held", ownerId })}\n`);
+setInterval(() => {}, 60_000);
+await new Promise<never>(() => {});

--- a/apps/gateway/e2e/run-with-postgres.sh
+++ b/apps/gateway/e2e/run-with-postgres.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Real PostgreSQL E2E URL precedence:
+#   1. PG_TEST_URL (canonical CI/test harness input)
+#   2. HELM_TEST_POSTGRES_URL (backward-compatible local input)
+#   3. a hermetic digest-pinned PostgreSQL 17 + pgvector container
+PGVECTOR_IMAGE="pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21"
+CONTAINER_ID=""
+CONTAINER_NAME="helm-api-e2e-pg-${$}-${RANDOM}"
+
+cleanup() {
+  if [[ -n "${CONTAINER_ID}" ]]; then
+    docker rm -f "${CONTAINER_ID}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [[ -n "${PG_TEST_URL:-}" ]]; then
+  TEST_POSTGRES_URL="${PG_TEST_URL}"
+  echo "[real-pg] using PG_TEST_URL"
+elif [[ -n "${HELM_TEST_POSTGRES_URL:-}" ]]; then
+  TEST_POSTGRES_URL="${HELM_TEST_POSTGRES_URL}"
+  echo "[real-pg] using HELM_TEST_POSTGRES_URL"
+else
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "[real-pg] ERROR: neither PG_TEST_URL nor HELM_TEST_POSTGRES_URL is set, and Docker is not installed" >&2
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "[real-pg] ERROR: neither PG_TEST_URL nor HELM_TEST_POSTGRES_URL is set, and Docker is unavailable" >&2
+    exit 1
+  fi
+
+  echo "[real-pg] starting digest-pinned PostgreSQL 17 + pgvector test container"
+  CONTAINER_ID="$(docker run --detach --rm \
+    --name "${CONTAINER_NAME}" \
+    --env POSTGRES_USER=helmtest \
+    --env POSTGRES_PASSWORD=helmtest \
+    --env POSTGRES_DB=helm_api_lease_test \
+    --publish 127.0.0.1::5432 \
+    "${PGVECTOR_IMAGE}")"
+
+  PORT_MAPPING="$(docker port "${CONTAINER_ID}" 5432/tcp)"
+  TEST_POSTGRES_PORT="${PORT_MAPPING##*:}"
+  if [[ -z "${TEST_POSTGRES_PORT}" || "${TEST_POSTGRES_PORT}" == "${PORT_MAPPING}" ]]; then
+    echo "[real-pg] ERROR: Docker did not publish a random PostgreSQL port" >&2
+    exit 1
+  fi
+
+  ready=0
+  for _ in $(seq 1 60); do
+    if docker exec "${CONTAINER_ID}" pg_isready \
+      --username helmtest --dbname helm_api_lease_test >/dev/null 2>&1; then
+      ready=1
+      break
+    fi
+    sleep 1
+  done
+  if [[ "${ready}" != "1" ]]; then
+    echo "[real-pg] ERROR: PostgreSQL container failed its health check within 60s" >&2
+    docker logs "${CONTAINER_ID}" >&2 || true
+    exit 1
+  fi
+
+  TEST_POSTGRES_URL="postgresql://helmtest:helmtest@127.0.0.1:${TEST_POSTGRES_PORT}/helm_api_lease_test"
+  echo "[real-pg] hermetic PostgreSQL is ready"
+fi
+
+# Export both names so the Playwright real-PG suite and the older Vitest store
+# contract use the same ephemeral database without logging credentials.
+export PG_TEST_URL="${TEST_POSTGRES_URL}"
+export HELM_TEST_POSTGRES_URL="${TEST_POSTGRES_URL}"
+
+pnpm exec playwright test "$@"

--- a/apps/gateway/e2e/run-with-postgres.sh
+++ b/apps/gateway/e2e/run-with-postgres.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 #   1. PG_TEST_URL (canonical CI/test harness input)
 #   2. HELM_TEST_POSTGRES_URL (backward-compatible local input)
 #   3. a hermetic digest-pinned PostgreSQL 17 + pgvector container
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PGVECTOR_IMAGE="pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21"
 CONTAINER_ID=""
 CONTAINER_NAME="helm-api-e2e-pg-${$}-${RANDOM}"
@@ -67,9 +68,13 @@ else
   echo "[real-pg] hermetic PostgreSQL is ready"
 fi
 
-# Export both names so the Playwright real-PG suite and the older Vitest store
+# Export both names so the Playwright suite and the dedicated no-skip Vitest
 # contract use the same ephemeral database without logging credentials.
 export PG_TEST_URL="${TEST_POSTGRES_URL}"
 export HELM_TEST_POSTGRES_URL="${TEST_POSTGRES_URL}"
+
+REPOSITORY_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+pnpm --dir "$REPOSITORY_ROOT" exec vitest run \
+  --config apps/gateway/e2e/vitest.real-postgres.config.ts
 
 pnpm exec playwright test "$@"

--- a/apps/gateway/e2e/vitest.real-postgres.config.ts
+++ b/apps/gateway/e2e/vitest.real-postgres.config.ts
@@ -1,0 +1,17 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+
+export default defineConfig({
+  test: {
+    include: [
+      resolve(
+        repositoryRoot,
+        "packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts",
+      ),
+    ],
+    environment: "node",
+    fileParallelism: false,
+  },
+});

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "tsc -p tsconfig.build.json && cp src/oauth/codex-models.json dist/oauth/codex-models.json",
-    "test:e2e": "playwright test"
+    "test:e2e": "bash e2e/run-with-postgres.sh"
   },
   "dependencies": {
     "@helm/core": "workspace:*",

--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -37,6 +37,9 @@ export type AppEnv = {
     trace_id: string;
     logger: Logger;
     request_timeout?: RequestTimeoutState;
+    // Added by concurrency gate after lease acquisition. Combines timeout/client
+    // disconnect with distributed lease ownership loss for every route.
+    concurrency_signal?: AbortSignal;
   };
 };
 

--- a/apps/gateway/src/middleware/concurrency.test.ts
+++ b/apps/gateway/src/middleware/concurrency.test.ts
@@ -6,6 +6,7 @@ import {
   concurrencyMiddleware,
   createConcurrencyGate,
 } from "./concurrency.js";
+import { requestSignal } from "./limits.js";
 
 // Per-key concurrency overflow queue (issue #93, feature A). Real semaphore +
 // real timers: the waits in play are tiny (handler-controlled), no fake clock.
@@ -168,6 +169,89 @@ describe("concurrencyMiddleware", () => {
     expect((await app.request("/boom")).status).toBe(500);
     // The slot must have been released by the middleware finally.
     expect((await app.request("/ok")).status).toBe(200);
+  });
+
+  it("acquires chat concurrency with the composed request timeout signal", async () => {
+    const timeoutController = new AbortController();
+    let acquiredSignal: AbortSignal | undefined;
+    const gate = {
+      acquire: async ({ signal }: { signal: AbortSignal }) => {
+        acquiredSignal = signal;
+        return { ok: true as const, signal, release: async () => {} };
+      },
+    };
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal context stubs for test
+      (c as any).set("identity", { keyId: "k1", caps: { concurrencyLimit: 1 } });
+      // biome-ignore lint/suspicious/noExplicitAny: minimal context stubs for test
+      (c as any).set("request_timeout", { signal: timeoutController.signal, timedOut: false });
+      await next();
+    });
+    app.use("*", concurrencyMiddleware(gate));
+    app.get("/signal", (c) => c.json({ ok: true }));
+
+    expect((await app.request("/signal")).status).toBe(200);
+    expect(acquiredSignal).toBe(timeoutController.signal);
+  });
+
+  it("combines request timeout/client abort with a lease-loss signal", async () => {
+    const gate = {
+      acquire: async () => {
+        const controller = new AbortController();
+        queueMicrotask(() => controller.abort("lease_lost"));
+        return { ok: true as const, signal: controller.signal, release: async () => {} };
+      },
+    };
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal identity stub for test
+      (c as any).set("identity", { keyId: "k1", caps: { concurrencyLimit: 1 } });
+      await next();
+    });
+    app.use("*", concurrencyMiddleware(gate));
+    let downstreamSignal: AbortSignal | undefined;
+    app.get("/signal", async (c) => {
+      downstreamSignal = requestSignal(c as never);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return c.json({ aborted: downstreamSignal.aborted, reason: String(downstreamSignal.reason) });
+    });
+    const response = await app.request("/signal");
+    expect(await response.json()).toEqual({ aborted: true, reason: "lease_lost" });
+  });
+
+  it("returns fail-closed 503 without calling downstream when lease store unavailable", async () => {
+    const gate = {
+      acquire: async () => ({
+        ok: false as const,
+        reason: "unavailable" as const,
+        retryAfterSeconds: 5,
+      }),
+    };
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      // biome-ignore lint/suspicious/noExplicitAny: minimal identity stub for test
+      (c as any).set("identity", { keyId: "k1", caps: { concurrencyLimit: 1 } });
+      await next();
+    });
+    app.use("*", concurrencyMiddleware(gate));
+    const provider = { called: false };
+    app.get("/provider", (c) => {
+      provider.called = true;
+      return c.json({ ok: true });
+    });
+    const response = await app.request("/provider");
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as {
+      error: { type: string; code: string; trace_id: string };
+    };
+    expect(body.error).toEqual({
+      message: "concurrency lease unavailable",
+      type: "api_error",
+      code: "lane_unavailable",
+      trace_id: "unknown",
+    });
+    expect(provider.called).toBe(false);
   });
 
   it("a claimed lease is NOT released by the middleware (stream handoff)", async () => {

--- a/apps/gateway/src/middleware/concurrency.ts
+++ b/apps/gateway/src/middleware/concurrency.ts
@@ -1,6 +1,9 @@
-import type { KeyedSemaphore } from "@helm/core";
-import type { MiddlewareHandler } from "hono";
+import type { DistributedKeyedSemaphore, KeyedSemaphore } from "@helm/core";
+import type { Context, MiddlewareHandler } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AppEnv } from "../app.js";
+import { openAIErrorEnvelope } from "./error-handler.js";
+import { requestSignal } from "./limits.js";
 
 // Per-API-key concurrency overflow queue (issue #93, feature A). Glue ONLY: the
 // counting semaphore (FIFO handoff, timeout, abort, watchdog) lives in core;
@@ -21,8 +24,12 @@ export interface ConcurrencyGateConfig {
 }
 
 export type ConcurrencyAcquireResult =
-  | { ok: true; release: () => void }
-  | { ok: false; reason: "queue_full" | "timeout" | "aborted"; retryAfterSeconds: number };
+  | { ok: true; signal?: AbortSignal; release: () => void | Promise<void> }
+  | {
+      ok: false;
+      reason: "queue_full" | "timeout" | "aborted" | "unavailable";
+      retryAfterSeconds: number;
+    };
 
 // Injected into the self-auth routes (messages / responses / gemini) the same
 // way their RateLimiterPort is — and consumed by concurrencyMiddleware for the
@@ -36,13 +43,17 @@ export interface ConcurrencyGatePort {
 }
 
 export interface ConcurrencyGateDeps {
-  semaphore: KeyedSemaphore;
+  semaphore: KeyedSemaphore | DistributedKeyedSemaphore;
   // Live settings thunk (re-bound by the admin PUT) — read fresh on every
   // acquire so the toggle/knobs apply without a restart.
   getConfig: () => ConcurrencyGateConfig;
 }
 
-const NOOP_LEASE = { ok: true as const, release: (): void => {} };
+const NOOP_LEASE = {
+  ok: true as const,
+  signal: new AbortController().signal,
+  release: async (): Promise<void> => {},
+};
 
 export function createConcurrencyGate(deps: ConcurrencyGateDeps): ConcurrencyGatePort {
   return {
@@ -61,10 +72,17 @@ export function createConcurrencyGate(deps: ConcurrencyGateDeps): ConcurrencyGat
         timeoutMs: cfg.waitTimeoutMs,
         signal,
       });
-      if (result.ok) return result;
-      // queue_full: the queue itself is saturated — retry almost immediately
-      // (slots churn fast). timeout: the key is persistently over capacity —
-      // suggest a slightly longer backoff.
+      if (result.ok) {
+        return {
+          ok: true,
+          signal: "signal" in result ? result.signal : signal,
+          release: async () => {
+            await result.release();
+          },
+        };
+      }
+      // queue_full: queue itself saturated. PostgreSQL unavailability is a
+      // fail-closed boundary, rendered as 503 before provider execution.
       return {
         ok: false,
         reason: result.reason,
@@ -82,13 +100,13 @@ declare module "hono" {
     // before returning streamSSE and releases it inside the stream's finally;
     // an unclaimed lease (non-stream, or a throw before the stream started) is
     // released by the middleware. Releases are idempotent either way.
-    concurrencyClaim?: () => () => void;
+    concurrencyClaim?: () => () => void | Promise<void>;
     // Self-auth surfaces (messages / responses / gemini): the HANDLER acquires
     // (auth happens inside it) and parks the release here; the route-scoped
     // concurrencyReleaseGuard frees an unclaimed lease on ANY exit path. A
     // stream handler claims by clearing this var and releasing in its own
     // finally instead.
-    concurrencyRelease?: (() => void) | undefined;
+    concurrencyRelease?: (() => void | Promise<void>) | undefined;
   }
 }
 
@@ -99,12 +117,18 @@ declare module "hono" {
 // onError. Stream handlers claim the lease (clear the var) and release in their
 // own finally, since this guard runs as soon as the Response is returned —
 // before the stream body has finished. Releases are idempotent.
-export function concurrencyReleaseGuard(): MiddlewareHandler {
+async function releaseClaim(c: Context<AppEnv>): Promise<void> {
+  const release = c.get("concurrencyRelease");
+  c.set("concurrencyRelease", undefined);
+  await release?.();
+}
+
+export function concurrencyReleaseGuard(): MiddlewareHandler<AppEnv> {
   return async (c, next) => {
     try {
       await next();
     } finally {
-      c.get("concurrencyRelease")?.();
+      await releaseClaim(c);
     }
   };
 }
@@ -123,9 +147,17 @@ export function concurrencyMiddleware(gate: ConcurrencyGatePort): MiddlewareHand
     const acquired = await gate.acquire({
       keyId,
       limit: identity?.caps?.concurrencyLimit ?? null,
-      signal: c.req.raw.signal,
+      signal: requestSignal(c as never),
     });
     if (!acquired.ok) {
+      if (acquired.reason === "unavailable") {
+        const { status, body } = openAIErrorEnvelope({
+          error_class: "lane_unavailable",
+          message: "concurrency lease unavailable",
+          trace_id: c.get("trace_id") ?? "unknown",
+        });
+        return c.json(body, status as ContentfulStatusCode);
+      }
       c.header("retry-after", String(acquired.retryAfterSeconds));
       return c.json(
         {
@@ -142,6 +174,12 @@ export function concurrencyMiddleware(gate: ConcurrencyGatePort): MiddlewareHand
         429 as ContentfulStatusCode,
       );
     }
+    // The lease manager's signal includes ownership loss. Compose it with the
+    // preexisting timeout/client signal so all downstream paths use one signal.
+    c.set(
+      "concurrency_signal",
+      AbortSignal.any([requestSignal(c as never), acquired.signal ?? c.req.raw.signal]),
+    );
     let claimed = false;
     c.set("concurrencyClaim", () => {
       claimed = true;
@@ -150,7 +188,7 @@ export function concurrencyMiddleware(gate: ConcurrencyGatePort): MiddlewareHand
     try {
       await next();
     } finally {
-      if (!claimed) acquired.release();
+      if (!claimed) await acquired.release();
     }
   };
 }

--- a/apps/gateway/src/middleware/limits.test.ts
+++ b/apps/gateway/src/middleware/limits.test.ts
@@ -10,6 +10,19 @@ function buildApp() {
     await new Promise((r) => setTimeout(r, 200));
     return c.text("done");
   });
+  app.get("/stream", (c) => {
+    const signal = c.get("request_timeout")?.signal;
+    return new Response(
+      new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new TextEncoder().encode("first"));
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          controller.enqueue(new TextEncoder().encode(signal?.aborted ? "aborted" : "late"));
+          controller.close();
+        },
+      }),
+    );
+  });
   return app;
 }
 
@@ -44,6 +57,39 @@ describe("timeout middleware", () => {
     expect(res.status).toBe(504);
     const body = (await res.json()) as { error: Record<string, string> };
     expect(body.error.code).toBe("timeout");
+  });
+
+  it("keeps timeout signal armed until a streaming body completes", async () => {
+    const app = buildApp();
+    const res = await app.request("/stream");
+    expect(await res.text()).toBe("firstaborted");
+  });
+
+  it("cancels the wrapped source body when the client cancels", async () => {
+    let cancelled = false;
+    const app = createApp({
+      logger: { log: () => {} },
+      limits: { requestTimeoutMs: 500 },
+    });
+    app.get(
+      "/cancel",
+      () =>
+        new Response(
+          new ReadableStream({
+            pull(controller) {
+              controller.enqueue(new TextEncoder().encode("chunk"));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+        ),
+    );
+    const res = await app.request("/cancel");
+    const reader = res.body?.getReader();
+    await reader?.read();
+    await reader?.cancel();
+    expect(cancelled).toBe(true);
   });
 
   it("does not time out a fast handler", async () => {

--- a/apps/gateway/src/middleware/limits.ts
+++ b/apps/gateway/src/middleware/limits.ts
@@ -13,7 +13,7 @@ export interface RequestTimeoutState {
 }
 
 export function requestSignal(c: Context<AppEnv>): AbortSignal {
-  return c.get("request_timeout")?.signal ?? c.req.raw.signal;
+  return c.get("concurrency_signal") ?? c.get("request_timeout")?.signal ?? c.req.raw.signal;
 }
 
 export function requestTimedOut(c: Context<AppEnv>): boolean {
@@ -55,8 +55,52 @@ export function timeout(cfg: LimitsConfig): MiddlewareHandler<AppEnv> {
           });
         }),
       ]);
-    } finally {
+    } catch (error) {
       clearTimeout(timer);
+      throw error;
     }
+
+    const response = c.res;
+    if (response.body === null) {
+      clearTimeout(timer);
+      return;
+    }
+    const reader = response.body.getReader();
+    let finished = false;
+    const finish = (): void => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      reader.releaseLock();
+    };
+    const body = new ReadableStream<Uint8Array>({
+      async pull(streamController) {
+        try {
+          const chunk = await reader.read();
+          if (chunk.done) {
+            finish();
+            streamController.close();
+          } else {
+            streamController.enqueue(chunk.value);
+          }
+        } catch (error) {
+          finish();
+          streamController.error(error);
+        }
+      },
+      async cancel(reason) {
+        clearTimeout(timer);
+        try {
+          await reader.cancel(reason);
+        } finally {
+          finish();
+        }
+      },
+    });
+    c.res = new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
   };
 }

--- a/apps/gateway/src/middleware/limits.ts
+++ b/apps/gateway/src/middleware/limits.ts
@@ -1,6 +1,7 @@
 import { makeHelmError } from "@helm/shared";
 import type { Context, MiddlewareHandler } from "hono";
 import type { AppEnv } from "../app.js";
+import { REQUEST_TIMEOUT_REASON } from "../request-cancellation.js";
 import { HelmHttpError } from "./error-handler.js";
 
 export interface LimitsConfig {
@@ -34,7 +35,7 @@ export function timeout(cfg: LimitsConfig): MiddlewareHandler<AppEnv> {
     c.set("request_timeout", state);
     const timer = setTimeout(() => {
       state.timedOut = true;
-      controller.abort();
+      controller.abort(REQUEST_TIMEOUT_REASON);
     }, cfg.requestTimeoutMs);
     try {
       await Promise.race([
@@ -57,7 +58,30 @@ export function timeout(cfg: LimitsConfig): MiddlewareHandler<AppEnv> {
       ]);
     } catch (error) {
       clearTimeout(timer);
+      // The downstream abort listener can reject in the same turn as the timeout
+      // promise. Keep the timeout classification authoritative instead of letting
+      // that race surface a generic AbortError/client-abort 499.
+      if (state.timedOut && !c.req.raw.signal.aborted) {
+        throw new HelmHttpError(
+          makeHelmError({
+            error_class: "timeout",
+            message: "request timed out",
+            trace_id: traceId,
+          }),
+        );
+      }
       throw error;
+    }
+
+    if (state.timedOut && !c.req.raw.signal.aborted) {
+      clearTimeout(timer);
+      throw new HelmHttpError(
+        makeHelmError({
+          error_class: "timeout",
+          message: "request timed out",
+          trace_id: traceId,
+        }),
+      );
     }
 
     const response = c.res;

--- a/apps/gateway/src/request-cancellation.ts
+++ b/apps/gateway/src/request-cancellation.ts
@@ -1,0 +1,14 @@
+export const CONCURRENCY_LEASE_LOST_REASON = "concurrency_lease_lost" as const;
+export const REQUEST_TIMEOUT_REASON = "request_timeout" as const;
+
+export type RequestCancellationReason =
+  | "client_abort"
+  | typeof REQUEST_TIMEOUT_REASON
+  | typeof CONCURRENCY_LEASE_LOST_REASON;
+
+export function requestCancellationReason(signal: AbortSignal): RequestCancellationReason | null {
+  if (!signal.aborted) return null;
+  if (signal.reason === CONCURRENCY_LEASE_LOST_REASON) return CONCURRENCY_LEASE_LOST_REASON;
+  if (signal.reason === REQUEST_TIMEOUT_REASON) return REQUEST_TIMEOUT_REASON;
+  return "client_abort";
+}

--- a/apps/gateway/src/request-cancellation.ts
+++ b/apps/gateway/src/request-cancellation.ts
@@ -1,3 +1,5 @@
+import type { DecisionRecord } from "@helm/core";
+
 export const CONCURRENCY_LEASE_LOST_REASON = "concurrency_lease_lost" as const;
 export const REQUEST_TIMEOUT_REASON = "request_timeout" as const;
 
@@ -6,9 +8,35 @@ export type RequestCancellationReason =
   | typeof REQUEST_TIMEOUT_REASON
   | typeof CONCURRENCY_LEASE_LOST_REASON;
 
-export function requestCancellationReason(signal: AbortSignal): RequestCancellationReason | null {
-  if (!signal.aborted) return null;
-  if (signal.reason === CONCURRENCY_LEASE_LOST_REASON) return CONCURRENCY_LEASE_LOST_REASON;
-  if (signal.reason === REQUEST_TIMEOUT_REASON) return REQUEST_TIMEOUT_REASON;
-  return "client_abort";
+export function requestCancellationReason(
+  signal: AbortSignal,
+  caught?: unknown,
+): RequestCancellationReason | null {
+  if (signal.aborted) {
+    if (signal.reason === CONCURRENCY_LEASE_LOST_REASON) return CONCURRENCY_LEASE_LOST_REASON;
+    if (signal.reason === REQUEST_TIMEOUT_REASON) return REQUEST_TIMEOUT_REASON;
+    return "client_abort";
+  }
+  return caught instanceof Error &&
+    (caught.name === "AbortError" || caught.message.includes("aborted"))
+    ? "client_abort"
+    : null;
+}
+
+export function markStartedStreamCancellation(
+  decision: DecisionRecord,
+  reason: RequestCancellationReason,
+): void {
+  const streamOutcome =
+    reason === CONCURRENCY_LEASE_LOST_REASON
+      ? "truncated"
+      : reason === REQUEST_TIMEOUT_REASON
+        ? "failed"
+        : "client_aborted";
+  decision.stream_outcome = streamOutcome;
+  decision.final = {
+    ...decision.final,
+    status: "error",
+    error_reason: reason === REQUEST_TIMEOUT_REASON ? "timeout" : reason,
+  };
 }

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -930,7 +930,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         } catch (err) {
           // A client disconnect / abort is NOT a provider fault: do not 5xx, do
           // not surface an error frame — the executor layer already recorded it.
-          if (!isAbort(err, c.req.raw.signal)) {
+          if (!isAbort(err, requestSignal(c))) {
             // Preserve a mid-stream idle timeout (UpstreamError("timeout")) instead
             // of flattening it to a generic upstream_error frame.
             const timedOut = isUpstreamTimeout(err);
@@ -944,7 +944,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         } finally {
           // Free the concurrency slot FIRST — the bytes are done; the
           // persist/settle bookkeeping below must not extend the hold.
-          releaseConcurrency?.();
+          await releaseConcurrency?.();
           try {
             await withSseCaptureRelease(captured, async () => {
               // Streamed completion-cost backfill (#6): parse the trailing usage and

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -36,6 +36,10 @@ import { INTERNAL_API_KEY_ID } from "../internal-key.js";
 import { HelmHttpError } from "../middleware/error-handler.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import {
+  markStartedStreamCancellation,
+  requestCancellationReason,
+} from "../request-cancellation.js";
+import {
   type BodyMemoryAdmission,
   memoryAdmissionReleaseGuard,
   RequestAdmissionError,
@@ -335,13 +339,6 @@ function invalidRequest(message: string, traceId: string): HelmHttpError {
   return new HelmHttpError(
     makeHelmError({ error_class: "invalid_request", message, trace_id: traceId }),
   );
-}
-
-// Client disconnect / abort detection — mirrors the executor + error-handler
-// semantics. Used only to suppress an error frame for a benign disconnect.
-function isAbort(err: unknown, signal: AbortSignal): boolean {
-  if (signal.aborted) return true;
-  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
 }
 
 // Extract the assistant message (+ any tool messages) from a non-stream OpenAI
@@ -928,9 +925,10 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
             lastWrite = tail;
           }
         } catch (err) {
-          // A client disconnect / abort is NOT a provider fault: do not 5xx, do
-          // not surface an error frame — the executor layer already recorded it.
-          if (!isAbort(err, requestSignal(c))) {
+          const cancellation = requestCancellationReason(requestSignal(c), err);
+          if (cancellation !== null) {
+            markStartedStreamCancellation(result.decision, cancellation);
+          } else {
             // Preserve a mid-stream idle timeout (UpstreamError("timeout")) instead
             // of flattening it to a generic upstream_error frame.
             const timedOut = isUpstreamTimeout(err);

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   type CatalogEntry,
   createNativePassthroughCarrier,
+  ERROR_CLASS_HTTP_STATUS,
   type InternalRequest,
   type NativePassthroughCarrier,
   nativePassthroughBody,
@@ -6655,5 +6656,90 @@ describe("createExecute — stripEmptyAnthropicTextBlocks null/primitive message
       (callArg as Record<string, unknown>).messages) as unknown[];
     // null and array entries pass through verbatim; the real message is unchanged
     expect(msgs.length).toBe(3);
+  });
+});
+
+describe("createExecute — concurrency lease loss", () => {
+  it("classifies pre-response lease loss as terminal 503 without fallback or breaker failure", async () => {
+    const controller = new AbortController();
+    const provider = {
+      chatCompletion: vi.fn().mockImplementation(async () => {
+        controller.abort("concurrency_lease_lost");
+        throw Object.assign(new Error("lease lost"), { name: "AbortError" });
+      }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordAbort = vi.spyOn(cb, "recordAbort");
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ primary: "m-primary", fallback: "m-fallback" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: controller.signal,
+    });
+
+    const out = await execute(plan(["primary", "fallback"]), req());
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected terminal error");
+    expect(out.final.error.error_class).toBe("lane_unavailable");
+    expect(ERROR_CLASS_HTTP_STATUS[out.final.error.error_class]).toBe(503);
+    expect(out.attempts[0]).toMatchObject({
+      alias: "primary",
+      skip_reason: "concurrency_lease_lost",
+      error_class: "lane_unavailable",
+    });
+    expect(recordAbort).toHaveBeenCalledWith("primary");
+    expect(recordFailure).not.toHaveBeenCalled();
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("terminates a started stream without a normal terminal event and logs structured lease loss", async () => {
+    const controller = new AbortController();
+    async function* leaseLostStream(): AsyncGenerator<string> {
+      yield 'data: {"choices":[{"delta":{"content":"first"}}]}\n\n';
+      controller.abort("concurrency_lease_lost");
+      throw Object.assign(new Error("lease lost"), { name: "AbortError" });
+    }
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn().mockReturnValue(leaseLostStream()),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const logs: Array<{ msg: string; fields: Record<string, unknown> }> = [];
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ primary: "m-primary" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: controller.signal,
+      log: (_level, msg, fields) => logs.push({ msg, fields }),
+    });
+
+    const out = await execute(plan(["primary"]), req({ stream: true }));
+    expect(out.final.status).toBe("ok");
+    const chunks: string[] = [];
+    await expect(async () => {
+      for await (const chunk of out.stream as AsyncIterable<string>) chunks.push(chunk);
+    }).rejects.toThrow("lease lost");
+
+    expect(chunks).toEqual(['data: {"choices":[{"delta":{"content":"first"}}]}\n\n']);
+    expect(chunks.join("")).not.toContain("[DONE]");
+    expect(recordFailure).not.toHaveBeenCalled();
+    expect(logs).toContainEqual({
+      msg: "stream.truncated",
+      fields: {
+        alias: "primary",
+        error_class: "lane_unavailable",
+        reason: "concurrency_lease_lost",
+      },
+    });
   });
 });

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -47,6 +47,10 @@ import {
   nativePassthroughMutations,
 } from "@helm/shared";
 import {
+  CONCURRENCY_LEASE_LOST_REASON,
+  requestCancellationReason,
+} from "../request-cancellation.js";
+import {
   usageFromAnthropicResponse,
   usageFromGeminiResponse,
   usageFromResponsesResponse,
@@ -1937,6 +1941,36 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           responseMetadata: capturedResponseMetadata,
         };
       } catch (err) {
+        const cancellation = requestCancellationReason(signal);
+        if (cancellation === CONCURRENCY_LEASE_LOST_REASON || cancellation === "request_timeout") {
+          const leaseLost = cancellation === CONCURRENCY_LEASE_LOST_REASON;
+          const errorClass = leaseLost ? "lane_unavailable" : "timeout";
+          breaker.recordAbort(alias);
+          attempts.push({
+            alias,
+            skipped: false,
+            skip_reason: cancellation,
+            status: "error",
+            error_class: errorClass,
+            latency_ms: elapsed(),
+            cost_usd: null,
+            error_detail: null,
+            ...defaultPassthroughTelemetry(),
+          });
+          return {
+            attempts,
+            final: {
+              status: "error",
+              error: makeHelmError({
+                error_class: errorClass,
+                message: leaseLost ? "concurrency lease lost" : "request timed out",
+                trace_id: correlationTraceId(req),
+              }),
+            },
+            body: null,
+            stream: null,
+          };
+        }
         // Client abort: non-provider fault. Terminate the chain WITHOUT marking a
         // breaker failure or counting it as all_providers_failed.
         if (isAbort(err, signal)) {
@@ -2229,8 +2263,17 @@ async function peekStream(
       // Truncated stream: the attempt was already recorded ok (success fires on
       // the first chunk — breaker semantics unchanged). Emit a structured log so
       // the truncation is observable despite the clean telemetry row. Safe fields
-      // only — alias + error_class, NEVER key/payload/raw error (principle 7).
-      log?.("warn", "stream.truncated", { alias, error_class: errorClassOf(err) });
+      // only — alias + classification, NEVER key/payload/raw error (principle 7).
+      const cancellation = requestCancellationReason(_signal);
+      if (cancellation === CONCURRENCY_LEASE_LOST_REASON) {
+        log?.("warn", "stream.truncated", {
+          alias,
+          error_class: "lane_unavailable",
+          reason: CONCURRENCY_LEASE_LOST_REASON,
+        });
+      } else {
+        log?.("warn", "stream.truncated", { alias, error_class: errorClassOf(err) });
+      }
       throw err;
     }
   })();

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -11,6 +11,10 @@ import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import {
+  markStartedStreamCancellation,
+  requestCancellationReason,
+} from "../request-cancellation.js";
+import {
   type BodyMemoryAdmission,
   memoryAdmissionReleaseGuard,
   RequestAdmissionError,
@@ -142,13 +146,6 @@ function extractCredential(googKey: string | undefined, auth: string | undefined
     if (m?.[1]) return m[1];
   }
   return null;
-}
-
-// Client disconnect / abort detection — mirrors messages.ts. Used to suppress a
-// terminal error frame for a benign disconnect (NOT a provider fault, docs/02).
-function isAbort(err: unknown, signal: AbortSignal): boolean {
-  if (signal.aborted) return true;
-  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
 }
 
 export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): void {
@@ -470,10 +467,10 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
             }
           }
         } catch (err) {
-          // A client disconnect / abort is a benign non-provider fault (docs/02):
-          // emit NO error frame. Any other throw emits ONE terminal Gemini error
-          // frame so the client never sees a silently truncated stream.
-          if (!isAbort(err, requestSignal(c))) {
+          const cancellation = requestCancellationReason(requestSignal(c), err);
+          if (cancellation !== null) {
+            markStartedStreamCancellation(result.decision, cancellation);
+          } else {
             const re: RouteError =
               err instanceof PipelineError
                 ? { error_class: err.error_class, message: err.message, trace_id: traceId }

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -260,6 +260,13 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
         signal: requestSignal(c),
       });
       if (!acquired.ok) {
+        if (acquired.reason === "unavailable") {
+          return sendError(c, {
+            error_class: "lane_unavailable",
+            message: "concurrency lease unavailable",
+            trace_id: traceId,
+          });
+        }
         c.header("retry-after", String(acquired.retryAfterSeconds));
         return sendError(c, {
           error_class: "rate_limited",
@@ -270,6 +277,10 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
           trace_id: traceId,
         });
       }
+      c.set(
+        "concurrency_signal",
+        AbortSignal.any([requestSignal(c), acquired.signal ?? requestSignal(c)]),
+      );
       c.set("concurrencyRelease", acquired.release);
     }
 
@@ -462,7 +473,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
           // A client disconnect / abort is a benign non-provider fault (docs/02):
           // emit NO error frame. Any other throw emits ONE terminal Gemini error
           // frame so the client never sees a silently truncated stream.
-          if (!isAbort(err, c.req.raw.signal)) {
+          if (!isAbort(err, requestSignal(c))) {
             const re: RouteError =
               err instanceof PipelineError
                 ? { error_class: err.error_class, message: err.message, trace_id: traceId }
@@ -478,7 +489,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
             await sse.writeSSE({ data });
           }
         } finally {
-          releaseConcurrency?.();
+          await releaseConcurrency?.();
           try {
             await withSseCaptureRelease(captured, async () => {
               // Record AFTER releaseConcurrency (never extend the hold) and AFTER the

--- a/apps/gateway/src/routes/image-chain.test.ts
+++ b/apps/gateway/src/routes/image-chain.test.ts
@@ -125,6 +125,39 @@ describe("runImageChain", () => {
     expect(attempt).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    "openai",
+    "gemini",
+  ] as const)("lease loss is terminal 503 for the production %s image chain without fallback or breaker fault", async (kind) => {
+    const ac = new AbortController();
+    ac.abort("concurrency_lease_lost");
+    const breaker = fakeBreaker();
+    const attempt: ImageAttempt = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("lease lost"), { name: "AbortError" }));
+
+    const res = await runImageChain(
+      [target("primary", kind), target("fallback", kind)],
+      breaker,
+      attempt,
+      ac.signal,
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected terminal");
+    expect(res.aborted).toBe(false);
+    expect(res.errorClass).toBe("lane_unavailable");
+    expect(res.httpStatus).toBe(503);
+    expect(res.attempts[0]).toMatchObject({
+      alias: "primary",
+      skip_reason: "concurrency_lease_lost",
+      error_class: "lane_unavailable",
+    });
+    expect(breaker.recordAbort).toHaveBeenCalledWith("primary");
+    expect(breaker.recordFailure).not.toHaveBeenCalled();
+    expect(attempt).toHaveBeenCalledTimes(1);
+  });
+
   it("all providers failing → all_providers_failed (502)", async () => {
     const breaker = fakeBreaker();
     const attempt: ImageAttempt = vi

--- a/apps/gateway/src/routes/image-chain.ts
+++ b/apps/gateway/src/routes/image-chain.ts
@@ -1,5 +1,9 @@
 import type { CircuitBreaker, ProviderClient } from "@helm/core";
 import { ERROR_CLASS_HTTP_STATUS, type ProviderAttempt } from "@helm/shared";
+import {
+  CONCURRENCY_LEASE_LOST_REASON,
+  requestCancellationReason,
+} from "../request-cancellation.js";
 import { errorClassOf, errorDetailOf, isAbort, isUpstreamRequestRejection } from "./execute.js";
 
 // Image-generation candidate-chain executor. The model-pinned image routes
@@ -116,6 +120,31 @@ export async function runImageChain(
       });
       return { ok: true, served: target, result, attempts };
     } catch (err) {
+      const cancellation = requestCancellationReason(signal);
+      if (cancellation === CONCURRENCY_LEASE_LOST_REASON || cancellation === "request_timeout") {
+        const leaseLost = cancellation === CONCURRENCY_LEASE_LOST_REASON;
+        const errorClass = leaseLost ? "lane_unavailable" : "timeout";
+        breaker.recordAbort(target.alias);
+        attempts.push({
+          alias: target.alias,
+          skipped: false,
+          skip_reason: cancellation,
+          status: "error",
+          error_class: errorClass,
+          latency_ms: Date.now() - started,
+          cost_usd: null,
+          error_detail: null,
+        });
+        return {
+          ok: false,
+          errorClass,
+          httpStatus: ERROR_CLASS_HTTP_STATUS[errorClass],
+          message: leaseLost ? "concurrency lease lost" : "request timed out",
+          providerRaw: null,
+          aborted: false,
+          attempts,
+        };
+      }
       // Client abort: NON-provider fault — terminate WITHOUT a breaker failure and
       // WITHOUT recording it as a provider error (mirrors execute.ts's recordAbort).
       if (isAbort(err, signal)) {

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -162,6 +162,9 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         signal: requestSignal(c),
       });
       if (!acquired.ok) {
+        if (acquired.reason === "unavailable") {
+          return errorJson(c, 503, "server_error", "concurrency lease unavailable");
+        }
         c.header("retry-after", String(acquired.retryAfterSeconds));
         return errorJson(
           c,
@@ -172,6 +175,10 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
             : "timed out waiting for a concurrency slot",
         );
       }
+      c.set(
+        "concurrency_signal",
+        AbortSignal.any([requestSignal(c), acquired.signal ?? requestSignal(c)]),
+      );
       c.set("concurrencyRelease", acquired.release);
     }
 

--- a/apps/gateway/src/routes/interactions.ts
+++ b/apps/gateway/src/routes/interactions.ts
@@ -233,6 +233,9 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
         signal: requestSignal(c),
       });
       if (!acquired.ok) {
+        if (acquired.reason === "unavailable") {
+          return errorJson(c, 503, "concurrency lease unavailable", "UNAVAILABLE");
+        }
         c.header("retry-after", String(acquired.retryAfterSeconds));
         return errorJson(
           c,
@@ -243,6 +246,10 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
           "RESOURCE_EXHAUSTED",
         );
       }
+      c.set(
+        "concurrency_signal",
+        AbortSignal.any([requestSignal(c), acquired.signal ?? requestSignal(c)]),
+      );
       c.set("concurrencyRelease", acquired.release);
     }
 

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -34,6 +34,10 @@ import {
   isNativePassthroughCarrier,
   nativePassthroughBody,
 } from "@helm/shared";
+import {
+  markStartedStreamCancellation,
+  requestCancellationReason,
+} from "../request-cancellation.js";
 import type { ServingAccount } from "../runtime/serving-account.js";
 import type { WriteQueue } from "../runtime/write-queue.js";
 import { downgradeClientFastModeIfDisallowed } from "./fast-mode.js";
@@ -1203,15 +1207,19 @@ export function createMessagesPipeline(
               const finalAlias =
                 result.decision.final?.status === "ok" ? result.decision.final.model_alias : null;
               if (protocol === "openai_responses") {
-                const outcome =
-                  responsesDeltas.outcome() ?? (signal.aborted ? "client_aborted" : "truncated");
-                result.decision.stream_outcome = outcome;
-                if (outcome === "client_aborted" || outcome === "truncated") {
-                  result.decision.final = {
-                    ...result.decision.final,
-                    status: "error",
-                    error_reason: outcome === "client_aborted" ? "client_abort" : "upstream_error",
-                  };
+                const cancellation = requestCancellationReason(signal);
+                if (cancellation !== null) {
+                  markStartedStreamCancellation(result.decision, cancellation);
+                } else {
+                  const settledOutcome = responsesDeltas.outcome() ?? "truncated";
+                  result.decision.stream_outcome = settledOutcome;
+                  if (settledOutcome === "truncated") {
+                    result.decision.final = {
+                      ...result.decision.final,
+                      status: "error",
+                      error_reason: "upstream_error",
+                    };
+                  }
                 }
               }
               if (memory !== undefined) {
@@ -1326,6 +1334,12 @@ export function createMessagesPipeline(
               }
             }
           } finally {
+            if (protocol === "openai_responses") {
+              const cancellation = requestCancellationReason(signal);
+              if (cancellation !== null) {
+                markStartedStreamCancellation(result.decision, cancellation);
+              }
+            }
             // Called UNCONDITIONALLY (even when no assistant text was
             // reconstructed — e.g. a tool-call-only stream) so the served-model
             // stamp still lands for auto-compaction pricing; empty

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -15,6 +15,10 @@ import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import {
+  markStartedStreamCancellation,
+  requestCancellationReason,
+} from "../request-cancellation.js";
+import {
   type BodyMemoryAdmission,
   memoryAdmissionReleaseGuard,
   RequestAdmissionError,
@@ -252,13 +256,6 @@ function estimateAnthropicInputTokens(value: unknown): number {
     .filter((s) => s.length > 0)
     .join("\n");
   return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
-}
-
-// Client disconnect / abort detection — mirrors chat.ts. Used to suppress a
-// terminal error frame for a benign disconnect (NOT a provider fault, docs/02).
-function isAbort(err: unknown, signal: AbortSignal): boolean {
-  if (signal.aborted) return true;
-  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
 }
 
 function markStreamDecisionError(decision: DecisionRecord, errorClass: string): void {
@@ -649,11 +646,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
             }
           }
         } catch (err) {
-          // A client disconnect / abort is a benign non-provider fault (docs/02):
-          // emit NO error frame. Any other throw — incl. a PipelineError when all
-          // providers failed before the stream started — emits a TERMINAL Anthropic
-          // error event so the client never sees a silently truncated stream.
-          if (!isAbort(err, requestSignal(c))) {
+          const cancellation = requestCancellationReason(requestSignal(c), err);
+          if (cancellation !== null) {
+            markStartedStreamCancellation(result.decision, cancellation);
+          } else {
             const errorClass =
               err instanceof PipelineError
                 ? err.error_class

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -423,6 +423,13 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         signal: requestSignal(c),
       });
       if (!acquired.ok) {
+        if (acquired.reason === "unavailable") {
+          return sendError(c, {
+            error_class: "lane_unavailable",
+            message: "concurrency lease unavailable",
+            trace_id: traceId,
+          });
+        }
         c.header("retry-after", String(acquired.retryAfterSeconds));
         return sendError(c, {
           error_class: "rate_limited",
@@ -433,6 +440,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
           trace_id: traceId,
         });
       }
+      c.set(
+        "concurrency_signal",
+        AbortSignal.any([requestSignal(c), acquired.signal ?? requestSignal(c)]),
+      );
       c.set("concurrencyRelease", acquired.release);
     }
 
@@ -642,7 +653,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
           // emit NO error frame. Any other throw — incl. a PipelineError when all
           // providers failed before the stream started — emits a TERMINAL Anthropic
           // error event so the client never sees a silently truncated stream.
-          if (!isAbort(err, c.req.raw.signal)) {
+          if (!isAbort(err, requestSignal(c))) {
             const errorClass =
               err instanceof PipelineError
                 ? err.error_class
@@ -665,7 +676,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
             await sse.writeSSE({ event: "error", data });
           }
         } finally {
-          releaseConcurrency?.();
+          await releaseConcurrency?.();
           try {
             await withSseCaptureRelease(captured, async () => {
               // Record AFTER releaseConcurrency (never extend the hold) and AFTER the

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -9,6 +9,7 @@ import {
   createSessionHeadCache,
   createSseCapture,
   createStreamGenerationTimer,
+  decisionForTimedOutRequest,
   estimateInterruptedResponsesUsage,
   type PayloadCaptureDeps,
   persistPayload,
@@ -1320,6 +1321,26 @@ describe("persistPayload", () => {
   });
 });
 
+describe("timeout-after-lease-loss persistence classification", () => {
+  it("decisionForTimedOutRequest preserves an authoritative truncated concurrency lease loss", () => {
+    const leaseLostDecision = decision();
+    leaseLostDecision.stream_outcome = "truncated";
+    leaseLostDecision.final = {
+      ...leaseLostDecision.final,
+      status: "error",
+      error_reason: "concurrency_lease_lost",
+    };
+
+    expect(decisionForTimedOutRequest(leaseLostDecision)).toMatchObject({
+      stream_outcome: "truncated",
+      final: {
+        status: "error",
+        error_reason: "concurrency_lease_lost",
+      },
+    });
+  });
+});
+
 describe("recordServed — deferred write queue (the three pipeline faces)", () => {
   function sink() {
     const inserted: DecisionRecord[] = [];
@@ -1394,6 +1415,42 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     expect(s.inserted[0]?.serving_account).toBeNull();
     expect(s.payloads[0]?.responseJson).toBeNull();
     expect(args.decision.final.status).toBe("ok");
+  });
+
+  it("preserves an authoritative truncated concurrency lease loss when timeout follows lease loss before persistence", async () => {
+    const s = sink();
+    const leaseLostDecision = decision();
+    leaseLostDecision.stream_outcome = "truncated";
+    leaseLostDecision.final = {
+      ...leaseLostDecision.final,
+      status: "error",
+      error_reason: "concurrency_lease_lost",
+    };
+    const d: RecordServedDeps = {
+      telemetry: s.telemetry,
+      redact: (x) => x,
+      now: () => 5000,
+      capturePayloads: () => false,
+    };
+
+    await recordServed(
+      d,
+      {
+        ...args,
+        requestId: "req_lease_loss_then_timeout",
+        decision: leaseLostDecision,
+        timedOut: true,
+      },
+      () => {},
+    );
+
+    expect(s.inserted[0]).toMatchObject({
+      stream_outcome: "truncated",
+      final: {
+        status: "error",
+        error_reason: "concurrency_lease_lost",
+      },
+    });
   });
 
   it("stores an incremental session revision when full payload capture is off", async () => {

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -9,6 +9,7 @@ import {
 } from "@helm/core";
 import type { TokenUsageBreakdown } from "@helm/shared";
 import { countTokens as countO200kHarmonyTokens } from "gpt-tokenizer/encoding/o200k_harmony";
+import { CONCURRENCY_LEASE_LOST_REASON } from "../request-cancellation.js";
 import type { WriteQueue } from "../runtime/write-queue.js";
 
 // Shared full request/response capture + streamed-cost backfill helpers, used by
@@ -755,6 +756,12 @@ export interface RecordServedDeps extends PayloadCaptureDeps {
 }
 
 export function decisionForTimedOutRequest(decision: DecisionRecord): DecisionRecord {
+  if (
+    decision.stream_outcome === "truncated" &&
+    decision.final.error_reason === CONCURRENCY_LEASE_LOST_REASON
+  ) {
+    return decision;
+  }
   return {
     ...decision,
     final: {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1519,6 +1519,33 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(order).not.toContain("route");
   });
 
+  it("returns a Responses-shaped 503 when the concurrency lease store is unavailable, without routing", async () => {
+    const acquire = vi.fn().mockResolvedValue({
+      ok: false as const,
+      reason: "unavailable" as const,
+      retryAfterSeconds: 0,
+    });
+    const { deps, order } = makeDeps({ concurrencyGate: { acquire } });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+
+    expect(res.status).toBe(503);
+    expect((await res.json()) as unknown).toMatchObject({
+      error: {
+        type: "api_error",
+        code: "lane_unavailable",
+        message: "concurrency lease unavailable",
+      },
+    });
+    expect(acquire).toHaveBeenCalledOnce();
+    expect(order).not.toContain("route");
+  });
+
   it("rejects a malformed JSON body with 400 invalid_request, without routing", async () => {
     const { deps, order } = makeDeps();
     const app = buildApp(deps);
@@ -1554,6 +1581,35 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(frames.at(-1)?.event).toBe("response.completed");
     // No [DONE] sentinel on the Responses surface.
     expect(frames.some((f) => f.data === "[DONE]")).toBe(false);
+  });
+
+  it("awaits asynchronous concurrency release after a streaming response closes", async () => {
+    const releaseStarted = deferred<void>();
+    let finishRelease!: () => void;
+    const releaseMayFinish = new Promise<void>((resolve) => {
+      finishRelease = resolve;
+    });
+    const release = vi.fn(async () => {
+      releaseStarted.resolve(undefined);
+      await releaseMayFinish;
+    });
+    const { deps } = makeDeps({
+      concurrencyGate: { acquire: async () => ({ ok: true as const, release }) },
+      transformRequestOut: () => ({ stream: true, model: "auto", metadata: {} }),
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+
+    const bodyDone = res.text();
+    await releaseStarted.promise;
+    expect(await Promise.race([bodyDone, shortTimeout()])).toBe("timeout");
+    finishRelease();
+    await bodyDone;
+    expect(release).toHaveBeenCalledOnce();
   });
 
   it("stream:true does not duplicate the Responses prelude produced by the pipeline", async () => {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -40,7 +40,7 @@ describe("settleResponsesStreamOutcome", () => {
     const outcome = settleResponsesStreamOutcome({
       decision,
       streamStatus: null,
-      caughtAbort: true,
+      cancellationReason: "client_abort",
       caughtErrorReason: null,
       timedOut: true,
     });

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -792,6 +792,15 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       signal: requestSignal(c),
     });
     if (!acquired.ok) {
+      if (acquired.reason === "unavailable") {
+        throw new HelmHttpError(
+          makeHelmError({
+            error_class: "lane_unavailable",
+            message: "concurrency lease unavailable",
+            trace_id: c.get("trace_id"),
+          }),
+        );
+      }
       c.header("retry-after", String(acquired.retryAfterSeconds));
       throw new HelmHttpError(
         makeHelmError({
@@ -804,6 +813,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         }),
       );
     }
+    c.set(
+      "concurrency_signal",
+      AbortSignal.any([requestSignal(c), acquired.signal ?? requestSignal(c)]),
+    );
     c.set("concurrencyRelease", acquired.release);
   };
 
@@ -1234,7 +1247,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           // before the stream started — writes a SINGLE terminal Responses-shaped
           // error event DIRECTLY into the stream. We CANNOT throw here (the stream
           // has already started; onError would never see it).
-          if (isAbort(err, c.req.raw.signal)) {
+          if (isAbort(err, requestSignal(c))) {
             caughtAbort = true;
           } else {
             caughtErrorReason =
@@ -1263,7 +1276,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
             await sse.writeSSE({ event: "error", data });
           }
         } finally {
-          releaseConcurrency?.();
+          await releaseConcurrency?.();
           const streamOutcome =
             result === null
               ? null

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -25,6 +25,13 @@ import { HelmHttpError } from "../middleware/error-handler.js";
 import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import { normalizeOpenAICodexClientVersion } from "../oauth/codex-client-version.js";
+import {
+  CONCURRENCY_LEASE_LOST_REASON,
+  markStartedStreamCancellation,
+  REQUEST_TIMEOUT_REASON,
+  type RequestCancellationReason,
+  requestCancellationReason,
+} from "../request-cancellation.js";
 import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "../responses-websocket-internal.js";
 import {
   type BodyMemoryAdmission,
@@ -228,13 +235,6 @@ export interface ResponsesRouteDeps {
   sseCaptureFactory?: (full: boolean) => SseCapture;
 }
 
-// Client disconnect / abort detection — mirrors messages.ts. Used to suppress a
-// terminal error frame for a benign disconnect (NOT a provider fault, docs/02).
-function isAbort(err: unknown, signal: AbortSignal): boolean {
-  if (signal.aborted) return true;
-  return err instanceof Error && (err.name === "AbortError" || err.message.includes("aborted"));
-}
-
 function extractCredential(auth: string | undefined): string | null {
   if (auth) {
     const m = /^Bearer\s+(.+)$/.exec(auth);
@@ -418,33 +418,48 @@ type ResponsesStreamOutcome = NonNullable<DecisionRecord["stream_outcome"]>;
 export function settleResponsesStreamOutcome(args: {
   decision: DecisionRecord;
   streamStatus: string | null;
-  caughtAbort: boolean;
+  cancellationReason: RequestCancellationReason | null;
   caughtErrorReason: string | null;
   timedOut: boolean;
 }): ResponsesStreamOutcome {
-  const outcome: ResponsesStreamOutcome = args.timedOut
-    ? "failed"
-    : args.caughtAbort
+  if (
+    args.decision.stream_outcome === "truncated" &&
+    args.decision.final?.error_reason === CONCURRENCY_LEASE_LOST_REASON
+  ) {
+    return "truncated";
+  }
+  if (args.cancellationReason === CONCURRENCY_LEASE_LOST_REASON) {
+    markStartedStreamCancellation(args.decision, CONCURRENCY_LEASE_LOST_REASON);
+    return "truncated";
+  }
+  if (args.timedOut) {
+    markStartedStreamCancellation(args.decision, REQUEST_TIMEOUT_REASON);
+    return "failed";
+  }
+  if (args.cancellationReason !== null) {
+    markStartedStreamCancellation(args.decision, args.cancellationReason);
+    return args.cancellationReason === "client_abort"
       ? "client_aborted"
-      : args.caughtErrorReason !== null
+      : args.cancellationReason === REQUEST_TIMEOUT_REASON
         ? "failed"
-        : args.streamStatus === "completed"
-          ? "completed"
-          : args.streamStatus === "incomplete"
-            ? "incomplete"
-            : args.streamStatus === "failed" || args.streamStatus === "cancelled"
-              ? "failed"
-              : "truncated";
+        : "truncated";
+  }
+  const outcome: ResponsesStreamOutcome =
+    args.caughtErrorReason !== null
+      ? "failed"
+      : args.streamStatus === "completed"
+        ? "completed"
+        : args.streamStatus === "incomplete"
+          ? "incomplete"
+          : args.streamStatus === "failed" || args.streamStatus === "cancelled"
+            ? "failed"
+            : "truncated";
   args.decision.stream_outcome = outcome;
-  if (outcome === "client_aborted" || outcome === "truncated" || outcome === "failed") {
+  if (outcome === "truncated" || outcome === "failed") {
     args.decision.final = {
       ...args.decision.final,
       status: "error",
-      error_reason: args.timedOut
-        ? "timeout"
-        : outcome === "client_aborted"
-          ? "client_abort"
-          : (args.caughtErrorReason ?? "upstream_error"),
+      error_reason: args.caughtErrorReason ?? "upstream_error",
     };
   }
   return outcome;
@@ -1193,7 +1208,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         let lastWrite: string | null = null;
         let streamResponseId: string | null = null;
         let streamStatus: string | null = null;
-        let caughtAbort = false;
+        let cancellationReason: RequestCancellationReason | null = null;
         let caughtErrorReason: string | null = null;
         try {
           if (initialError !== null) throw initialError;
@@ -1247,8 +1262,9 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           // before the stream started — writes a SINGLE terminal Responses-shaped
           // error event DIRECTLY into the stream. We CANNOT throw here (the stream
           // has already started; onError would never see it).
-          if (isAbort(err, requestSignal(c))) {
-            caughtAbort = true;
+          cancellationReason = requestCancellationReason(requestSignal(c), err);
+          if (cancellationReason !== null) {
+            // Cancellation ends the wire without a fabricated terminal event.
           } else {
             caughtErrorReason =
               err instanceof PipelineError
@@ -1283,7 +1299,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
               : settleResponsesStreamOutcome({
                   decision: result.decision,
                   streamStatus,
-                  caughtAbort,
+                  cancellationReason,
                   caughtErrorReason,
                   timedOut: requestTimedOut(c),
                 });

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -21,6 +21,7 @@ import {
   createCachedKeyStore,
   createCircuitBreaker,
   createCodexResponsesClient,
+  createDistributedKeyedSemaphore,
   createGeminiClient,
   createGenericOpenAIResponsesClient,
   createKeyedSemaphore,
@@ -3005,10 +3006,19 @@ export async function buildServer(
   // ONE process-wide gate shared with the self-auth routes (messages / responses
   // / gemini) so a key's in-flight count spans every entrypoint. No-op while
   // concurrency_queue_enabled is OFF or for keys without a concurrency_limit.
+  const distributedSemaphore = store.concurrencyLeases
+    ? createDistributedKeyedSemaphore({
+        store: store.concurrencyLeases,
+        ownerId: `${process.env.HOSTNAME ?? "gateway"}:${process.pid}:${randomUUID()}`,
+        log: (lvl, msg, fields) => logger.log(lvl, msg, fields),
+      })
+    : null;
   const concurrencyGate = createConcurrencyGate({
-    semaphore: createKeyedSemaphore({
-      log: (lvl, msg, fields) => logger.log(lvl, msg, fields),
-    }),
+    semaphore:
+      distributedSemaphore ??
+      createKeyedSemaphore({
+        log: (lvl, msg, fields) => logger.log(lvl, msg, fields),
+      }),
     getConfig: () => ({
       enabled: settings.concurrency_queue_enabled,
       minSize: settings.concurrency_queue_min_size,
@@ -4294,6 +4304,7 @@ export async function buildServer(
       // Drain the deferred write queue BEFORE closing the DB so a graceful shutdown
       // persists every buffered telemetry/payload/observe write (no loss on deploy).
       await writeQueue.stop();
+      await distributedSemaphore?.shutdown();
       // Close the underlying DB connection (sqlite file handle / pg pool). Best
       // effort: a close error must not mask a clean shutdown.
       await store.close().catch(() => {});

--- a/docs/06-auth-and-rate-limits.md
+++ b/docs/06-auth-and-rate-limits.md
@@ -140,6 +140,17 @@ The stored record (`ApiKeyRecord`, single source of truth in
 All of these are resolved at auth time onto `AuthIdentity.caps` and threaded
 through the request — downstream code reads the caps, never the store.
 
+### Distributed concurrency leases
+
+SQLite keeps process-local FIFO concurrency enforcement. With `store.driver: supabase`,
+PostgreSQL leases make each `key_id` limit cluster-global across gateway replicas. A
+lease is owned by one replica, renewed every 10s, and expires after 30s by default;
+expiry and reclamation use PostgreSQL time, not replica clocks. A crash can therefore
+hold capacity until TTL expiry. Lease-store acquisition failure fails closed with 503
+before provider routing; it never falls back to local admission. Lowering a limit does
+not revoke existing leases. Roll back gateway code only after all replicas are stopped;
+the additive lease tables may remain safely and expire stale rows automatically.
+
 - **Hash-auth + encrypted recovery.** The store port's `CreateKeyInput` has no
   plaintext field, so the persistence layer is structurally unable to store a raw
   key. It may store `secret_enc`, an AES-GCM ciphertext encrypted with

--- a/docs/10-deployment.md
+++ b/docs/10-deployment.md
@@ -16,6 +16,13 @@ deployment is **Docker**.
   [02 · Architecture](02-architecture.md)).
 - **No extra services required.** Helm needs no Redis or message queue; rate
   limiting, caches, and the background workers are in-process / store-backed.
+- **Replica topology.** SQLite concurrency caps are single-container/process only.
+  Multiple gateway replicas require `store.driver: supabase`: PostgreSQL leases then
+  enforce API-key concurrency cluster-wide. A dead replica's slots expire after the
+  lease TTL (30s default), so plan rollout/crash capacity for that window. Lease DB
+  failure rejects new limited requests with 503 rather than degrading to per-replica
+  limits. Lease schema is additive; rollback gateway binaries after draining/stopping
+  replicas, while leaving tables in place is safe.
 
 ## Docker
 
@@ -251,6 +258,19 @@ Node's native `--env-file-if-exists` flag. With no complete Admin credentials it
 opens the same `/setup` flow as Docker. `pnpm dev` starts only the Admin Vite
 server and is not a complete Helm runtime. For automation, pre-populate `.env`
 from `.env.example`; a provider key is still optional.
+
+### Real PostgreSQL E2E
+
+`pnpm test:e2e` always runs the distributed-concurrency acceptance suite against
+real PostgreSQL; PGlite does not satisfy that gate. The harness resolves its test
+URL in this order: `PG_TEST_URL`, then the backward-compatible
+`HELM_TEST_POSTGRES_URL`. If neither is set, it starts a disposable PostgreSQL 17
++ pgvector container on a random local port using the immutable image
+`pgvector/pgvector:0.8.1-pg17@sha256:3e8b3adfd27b5707128f60956f62a793c3c9326ea8cfaf0eab7adccb5d700b21`,
+waits for `pg_isready`, and removes the container on every exit path. With no
+external URL and no usable Docker daemon, the suite fails explicitly instead of
+skipping real-PostgreSQL coverage. Test URLs and generated credentials are never
+printed.
 
 ## Startup behavior
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-23 · PostgreSQL API-key 分布式并发 lease（Phase 1，docs/06/10，原则 1/3/7）
+
+- **一致性边界**：仅 `supabase`/PostgreSQL 使用 state-row `FOR UPDATE` + DB `clock_timestamp()` 的 lease 表实现跨 replica 上限；SQLite 保持既有 process-local FIFO。statement-time clock 避免等待 row lock 后仍使用事务开始时间；lease 过期回收不依赖 Node clock，也不维护独立 active counter。
+- **本地调度边界**：每 replica/key 只让本地队首轮询 DB；默认 TTL 30s、heartbeat 10s，失败轮询使用可注入的 100–250ms jitter。manager 同时以 DB 返回 `expiresAtMs` 和本地 RPC 开始时间 + TTL 的较早值作为 ownership deadline，防止 acquire/renew 响应延迟或挂起越过已知租期。renew 失败使持有者 signal 以 `lease_lost` abort，release 为 async/idempotent best-effort，gateway 将它与 client abort/request timeout 合并；流 lease 到 body final close/cancel 才释放。shutdown 会等待正在进行的 acquire，并在返回前清理 late-success orphan。
+- **真实 PG 验收**：`apps/gateway/e2e/concurrency-postgres.spec.ts` 用两个独立 postgres-js pool、两个 distributed manager 和两个请求级 Hono app 验证 100 并发全局上限、key 隔离、TTL crash recovery、heartbeat、lease-loss no-cooldown、stream final/cancel 与 DB-unavailable 503。`pnpm test:e2e` 的 launcher 按 `PG_TEST_URL` > `HELM_TEST_POSTGRES_URL` 取外部测试库；无 URL 时自动启动 digest-pinned PostgreSQL 17 + pgvector 并 finally 清理，Docker 不可用则明确失败。PGlite 仍只算 SQL/contract coverage，不计真实多 pool AC。
+
 ## 2026-07-23 · Session 恢复与在线响应共享内存池（Admin requests，docs/07/11，原则 3/7）
 
 - **恢复窗口**：Admin Session 恢复单次最多预占 response-work 池的一半，允许两次有界恢复并行，也为在线 API 响应保留容量；第三次并发恢复或超过半窗口的会话继续返回 `session_recovery_limited`。保留先准入、后物化正文的顺序，不新增队列、配置或独立内存池。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -684,6 +684,13 @@ export {
   type TokenManagerDeps,
   TokenRefreshError,
 } from "./provider/token-manager.js";
+export {
+  createDistributedKeyedSemaphore,
+  type DistributedAcquireArgs,
+  type DistributedAcquireResult,
+  type DistributedKeyedSemaphore,
+  type DistributedKeyedSemaphoreOptions,
+} from "./queue/distributed-keyed-semaphore.js";
 // In-memory request queueing primitives (issue #93): per-key counting semaphore
 // with FIFO overflow queue (feature A), per-key serial gate with inter-request
 // delay (feature B), and the user-turn detector. Single-process by design.
@@ -827,6 +834,7 @@ export {
   PERSISTED_SESSION_MAX_REVISIONS,
   PERSISTED_SESSION_MAX_STORED_BYTES,
   PgBudgetStore,
+  PgConcurrencyLeaseStore,
   PgConfigStore,
   type PgDb,
   PgKeyStore,
@@ -860,6 +868,7 @@ export type {
   BudgetDim,
   BudgetPeekResult,
   BudgetStore,
+  ConcurrencyLeaseStore,
   ConfigStore,
   CreateKeyInput,
   InsertPayloadInput,

--- a/packages/core/src/queue/distributed-keyed-semaphore.test.ts
+++ b/packages/core/src/queue/distributed-keyed-semaphore.test.ts
@@ -8,7 +8,7 @@ interface LeaseStore {
     ownerId: string;
     limit: number;
     ttlMs: number;
-  }): Promise<{ acquired: boolean; expiresAtMs: number }>;
+  }): Promise<{ acquired: boolean; expiresAtMs: number; reclaimedCount?: number }>;
   renew(input: {
     keyId: string;
     leaseId: string;
@@ -41,6 +41,7 @@ interface FactoryOptions {
   pollIntervalMs: number;
   createLeaseId: () => string;
   random?: () => number;
+  log?: (level: "warn" | "info", message: string, fields: Record<string, unknown>) => void;
 }
 
 type DistributedSemaphoreFactory = (options: FactoryOptions) => DistributedSemaphore;
@@ -65,16 +66,32 @@ class FakeLeaseStore implements LeaseStore {
   releaseThrows = false;
   acquireDelayMs = 0;
   acquireResponseDelayMs = 0;
+  reclaimedCount = 0;
+  dbNow = () => Date.now();
 
   async tryAcquire(input: Parameters<LeaseStore["tryAcquire"]>[0]) {
     this.tryAcquireCalls.push(input);
     if (this.acquireDelayMs > 0) await delay(this.acquireDelayMs);
-    if (this.throwAcquire) throw new Error("database unavailable");
+    if (this.throwAcquire) {
+      throw new Error(
+        "database unavailable Authorization: Bearer plaintext-key secret_enc prompt response",
+      );
+    }
     const active = this.active.get(input.keyId) ?? new Set<string>();
     this.active.set(input.keyId, active);
-    if (active.size >= input.limit) return { acquired: false, expiresAtMs: Date.now() };
+    if (active.size >= input.limit) {
+      return {
+        acquired: false,
+        expiresAtMs: this.dbNow(),
+        reclaimedCount: this.reclaimedCount,
+      };
+    }
     active.add(input.leaseId);
-    const result = { acquired: true, expiresAtMs: Date.now() + input.ttlMs };
+    const result = {
+      acquired: true,
+      expiresAtMs: this.dbNow() + input.ttlMs,
+      reclaimedCount: this.reclaimedCount,
+    };
     if (this.acquireResponseDelayMs > 0) await delay(this.acquireResponseDelayMs);
     return result;
   }
@@ -82,7 +99,7 @@ class FakeLeaseStore implements LeaseStore {
   async renew(input: Parameters<LeaseStore["renew"]>[0]) {
     this.renewCalls.push(input);
     if (this.hangRenew) await new Promise<never>(() => {});
-    return { renewed: this.renews, expiresAtMs: Date.now() + input.ttlMs };
+    return { renewed: this.renews, expiresAtMs: this.dbNow() + input.ttlMs };
   }
 
   async release(input: Parameters<LeaseStore["release"]>[0]): Promise<void> {
@@ -94,6 +111,7 @@ class FakeLeaseStore implements LeaseStore {
 }
 
 const openManagers: DistributedSemaphore[] = [];
+const realDateNow = Date.now.bind(Date);
 let nextLeaseId = 0;
 
 function manager(store = new FakeLeaseStore(), overrides: Partial<FactoryOptions> = {}) {
@@ -125,6 +143,7 @@ async function delay(ms: number): Promise<void> {
 describe("createDistributedKeyedSemaphore", () => {
   afterEach(async () => {
     await Promise.all(openManagers.splice(0).map((semaphore) => semaphore.shutdown()));
+    vi.restoreAllMocks();
   });
 
   it("does not touch the lease store when disabled by an unlimited limit", async () => {
@@ -137,6 +156,85 @@ describe("createDistributedKeyedSemaphore", () => {
     expect(store.tryAcquireCalls).toEqual([]);
     expect(store.renewCalls).toEqual([]);
     expect(store.releaseCalls).toEqual([]);
+  });
+
+  it.each([
+    5 * 60_000,
+    -5 * 60_000,
+  ])("uses a monotonic local TTL after acquire with Node wall-clock skew %i ms", async (skewMs) => {
+    const store = new FakeLeaseStore();
+    store.dbNow = realDateNow;
+    vi.spyOn(Date, "now").mockImplementation(() => realDateNow() + skewMs);
+    const { semaphore } = manager(store, {
+      leaseTtlMs: 60,
+      heartbeatIntervalMs: 1_000,
+    });
+
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+
+    await delay(5);
+    expect(held.signal.aborted).toBe(false);
+    await delay(70);
+    expect(held.signal.aborted).toBe(true);
+    expect(held.signal.reason).toBe("concurrency_lease_lost");
+  });
+
+  it.each([
+    5 * 60_000,
+    -5 * 60_000,
+  ])("uses a monotonic local TTL after renew with Node wall-clock skew %i ms", async (skewMs) => {
+    const store = new FakeLeaseStore();
+    store.dbNow = realDateNow;
+    const { semaphore } = manager(store, {
+      leaseTtlMs: 80,
+      heartbeatIntervalMs: 15,
+    });
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+
+    vi.spyOn(Date, "now").mockImplementation(() => realDateNow() + skewMs);
+    await delay(25);
+
+    expect(store.renewCalls.length).toBeGreaterThan(0);
+    expect(held.signal.aborted).toBe(false);
+    await held.release();
+  });
+
+  it("lets maxQueue=0 perform one immediate probe without continuous polling", async () => {
+    const store = new FakeLeaseStore();
+    store.active.set("key-one", new Set(["other-replica-lease"]));
+    const { semaphore } = manager(store);
+
+    expect(await semaphore.acquire(args({ maxQueue: 0, timeoutMs: 100 }))).toEqual({
+      ok: false,
+      reason: "queue_full",
+    });
+    expect(store.tryAcquireCalls).toHaveLength(1);
+    await delay(30);
+    expect(store.tryAcquireCalls).toHaveLength(1);
+  });
+
+  it("counts one polling head separately from maxQueue=1 FIFO waiters", async () => {
+    const store = new FakeLeaseStore();
+    store.acquireDelayMs = 20;
+    const { semaphore } = manager(store);
+
+    const firstPromise = semaphore.acquire(args({ maxQueue: 1 }));
+    await delay(2);
+    const secondPromise = semaphore.acquire(args({ maxQueue: 1 }));
+    const third = await semaphore.acquire(args({ maxQueue: 1 }));
+    expect(third).toEqual({ ok: false, reason: "queue_full" });
+
+    const first = await firstPromise;
+    expect(first.ok).toBe(true);
+    if (first.ok) await first.release();
+
+    const second = await secondPromise;
+    expect(second.ok).toBe(true);
+    if (second.ok) await second.release();
   });
 
   it("keeps a per-replica FIFO and lets only its queue head poll the database", async () => {
@@ -228,6 +326,83 @@ describe("createDistributedKeyedSemaphore", () => {
     store.throwAcquire = true;
     const { semaphore } = manager(store);
     expect(await semaphore.acquire(args())).toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("emits the exact lease event contract with whitelisted secret-safe fields", async () => {
+    const logs: Array<{
+      level: "warn" | "info";
+      message: string;
+      fields: Record<string, unknown>;
+    }> = [];
+    const log: NonNullable<FactoryOptions["log"]> = (level, message, fields) => {
+      logs.push({ level, message, fields });
+    };
+
+    const fullStore = new FakeLeaseStore();
+    fullStore.active.set("key-one", new Set(["other-lease"]));
+    const full = manager(fullStore, { log }).semaphore;
+    expect(await full.acquire(args({ maxQueue: 0 }))).toEqual({
+      ok: false,
+      reason: "queue_full",
+    });
+
+    const unavailableStore = new FakeLeaseStore();
+    unavailableStore.throwAcquire = true;
+    const unavailable = manager(unavailableStore, { log }).semaphore;
+    expect(await unavailable.acquire(args({ key: "key-unavailable" }))).toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+
+    const lifecycleStore = new FakeLeaseStore();
+    lifecycleStore.reclaimedCount = 2;
+    lifecycleStore.releaseThrows = true;
+    const lifecycle = manager(lifecycleStore, { log }).semaphore;
+    const held = await lifecycle.acquire(args({ key: "key-lifecycle" }));
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+    lifecycleStore.renews = false;
+    await delay(25);
+    expect(held.signal.reason).toBe("concurrency_lease_lost");
+    await held.release();
+
+    const expectedEvents = new Set([
+      "concurrency.lease_acquire_failed",
+      "concurrency.lease_lost",
+      "concurrency.expired_reclaimed",
+      "concurrency.store_unavailable",
+      "concurrency.lease_release_failed",
+    ]);
+    expect(new Set(logs.map((entry) => entry.message))).toEqual(expectedEvents);
+
+    const allowedFields = new Set([
+      "key_id",
+      "lease_id",
+      "owner_id",
+      "reason",
+      "wait_ms",
+      "reclaimed_count",
+    ]);
+    for (const entry of logs) {
+      expect(expectedEvents.has(entry.message)).toBe(true);
+      expect(Object.keys(entry.fields).every((field) => allowedFields.has(field))).toBe(true);
+      expect(entry.fields.reason).toEqual(expect.any(String));
+    }
+    expect(
+      logs.find((entry) => entry.message === "concurrency.expired_reclaimed")?.fields,
+    ).toMatchObject({ key_id: "key-lifecycle", owner_id: "replica-a", reclaimed_count: 2 });
+
+    const serialized = JSON.stringify(logs);
+    for (const forbidden of [
+      "plaintext-key",
+      "secret_enc",
+      "Authorization",
+      "prompt",
+      "response",
+      "Bearer",
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
   });
 
   it("makes concurrent release callers await the same asynchronous DB release", async () => {

--- a/packages/core/src/queue/distributed-keyed-semaphore.test.ts
+++ b/packages/core/src/queue/distributed-keyed-semaphore.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as coreExports from "../index.js";
+
+interface LeaseStore {
+  tryAcquire(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    limit: number;
+    ttlMs: number;
+  }): Promise<{ acquired: boolean; expiresAtMs: number }>;
+  renew(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    ttlMs: number;
+  }): Promise<{ renewed: boolean; expiresAtMs: number }>;
+  release(input: { keyId: string; leaseId: string; ownerId: string }): Promise<void>;
+}
+
+type AcquireResult =
+  | { ok: true; signal: AbortSignal; release: () => Promise<void> }
+  | { ok: false; reason: "queue_full" | "timeout" | "aborted" | "unavailable" };
+
+interface DistributedSemaphore {
+  acquire(input: {
+    key: string;
+    limit: number | null;
+    maxQueue: number;
+    timeoutMs: number;
+    signal?: AbortSignal;
+  }): Promise<AcquireResult>;
+  shutdown(): Promise<void>;
+}
+
+interface FactoryOptions {
+  store: LeaseStore;
+  ownerId: string;
+  leaseTtlMs: number;
+  heartbeatIntervalMs: number;
+  pollIntervalMs: number;
+  createLeaseId: () => string;
+  random?: () => number;
+}
+
+type DistributedSemaphoreFactory = (options: FactoryOptions) => DistributedSemaphore;
+
+function distributedSemaphore(options: FactoryOptions): DistributedSemaphore {
+  const factory = Reflect.get(coreExports, "createDistributedKeyedSemaphore");
+  expect(factory, "core must expose the distributed keyed semaphore manager").toBeTypeOf(
+    "function",
+  );
+  return (factory as DistributedSemaphoreFactory)(options);
+}
+
+class FakeLeaseStore implements LeaseStore {
+  readonly tryAcquireCalls: Array<Parameters<LeaseStore["tryAcquire"]>[0]> = [];
+  readonly renewCalls: Array<Parameters<LeaseStore["renew"]>[0]> = [];
+  readonly releaseCalls: Array<Parameters<LeaseStore["release"]>[0]> = [];
+  readonly active = new Map<string, Set<string>>();
+  throwAcquire = false;
+  renews = true;
+  hangRenew = false;
+  releaseDelayMs = 0;
+  releaseThrows = false;
+  acquireDelayMs = 0;
+  acquireResponseDelayMs = 0;
+
+  async tryAcquire(input: Parameters<LeaseStore["tryAcquire"]>[0]) {
+    this.tryAcquireCalls.push(input);
+    if (this.acquireDelayMs > 0) await delay(this.acquireDelayMs);
+    if (this.throwAcquire) throw new Error("database unavailable");
+    const active = this.active.get(input.keyId) ?? new Set<string>();
+    this.active.set(input.keyId, active);
+    if (active.size >= input.limit) return { acquired: false, expiresAtMs: Date.now() };
+    active.add(input.leaseId);
+    const result = { acquired: true, expiresAtMs: Date.now() + input.ttlMs };
+    if (this.acquireResponseDelayMs > 0) await delay(this.acquireResponseDelayMs);
+    return result;
+  }
+
+  async renew(input: Parameters<LeaseStore["renew"]>[0]) {
+    this.renewCalls.push(input);
+    if (this.hangRenew) await new Promise<never>(() => {});
+    return { renewed: this.renews, expiresAtMs: Date.now() + input.ttlMs };
+  }
+
+  async release(input: Parameters<LeaseStore["release"]>[0]): Promise<void> {
+    this.releaseCalls.push(input);
+    if (this.releaseDelayMs > 0) await delay(this.releaseDelayMs);
+    if (this.releaseThrows) throw new Error("release unavailable");
+    this.active.get(input.keyId)?.delete(input.leaseId);
+  }
+}
+
+const openManagers: DistributedSemaphore[] = [];
+let nextLeaseId = 0;
+
+function manager(store = new FakeLeaseStore(), overrides: Partial<FactoryOptions> = {}) {
+  const semaphore = distributedSemaphore({
+    store,
+    ownerId: "replica-a",
+    leaseTtlMs: 60,
+    heartbeatIntervalMs: 15,
+    pollIntervalMs: 5,
+    createLeaseId: () => `lease-${++nextLeaseId}`,
+    ...overrides,
+  });
+  openManagers.push(semaphore);
+  return { semaphore, store };
+}
+
+const args = (overrides: Partial<Parameters<DistributedSemaphore["acquire"]>[0]> = {}) => ({
+  key: "key-one",
+  limit: 1 as number | null,
+  maxQueue: 5,
+  timeoutMs: 200,
+  ...overrides,
+});
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("createDistributedKeyedSemaphore", () => {
+  afterEach(async () => {
+    await Promise.all(openManagers.splice(0).map((semaphore) => semaphore.shutdown()));
+  });
+
+  it("does not touch the lease store when disabled by an unlimited limit", async () => {
+    const { semaphore, store } = manager();
+    for (const limit of [null, 0, -1]) {
+      const acquired = await semaphore.acquire(args({ limit }));
+      expect(acquired.ok).toBe(true);
+      if (acquired.ok) await acquired.release();
+    }
+    expect(store.tryAcquireCalls).toEqual([]);
+    expect(store.renewCalls).toEqual([]);
+    expect(store.releaseCalls).toEqual([]);
+  });
+
+  it("keeps a per-replica FIFO and lets only its queue head poll the database", async () => {
+    const { semaphore, store } = manager();
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+
+    const order: string[] = [];
+    const second = semaphore.acquire(args()).then((result) => {
+      order.push("second");
+      return result;
+    });
+    const third = semaphore.acquire(args()).then((result) => {
+      order.push("third");
+      return result;
+    });
+    await delay(20);
+
+    const waitingLeaseIds = new Set(store.tryAcquireCalls.slice(1).map((call) => call.leaseId));
+    expect(waitingLeaseIds.size).toBe(1);
+    if (held.ok) await held.release();
+
+    const secondLease = await second;
+    expect(order).toEqual(["second"]);
+    if (secondLease.ok) await secondLease.release();
+    const thirdLease = await third;
+    expect(order).toEqual(["second", "third"]);
+    if (thirdLease.ok) await thirdLease.release();
+  });
+
+  it("removes a timed-out or aborted waiter without disturbing the holder", async () => {
+    const { semaphore } = manager();
+    const held = await semaphore.acquire(args());
+    const timedOut = semaphore.acquire(args({ timeoutMs: 15 }));
+    expect(await timedOut).toEqual({ ok: false, reason: "timeout" });
+
+    const controller = new AbortController();
+    const aborted = semaphore.acquire(args({ signal: controller.signal }));
+    controller.abort();
+    expect(await aborted).toEqual({ ok: false, reason: "aborted" });
+    if (held.ok) await held.release();
+  });
+
+  it("releases an orphan lease acquired after its waiter timed out", async () => {
+    const store = new FakeLeaseStore();
+    store.acquireDelayMs = 25;
+    const { semaphore } = manager(store);
+
+    expect(await semaphore.acquire(args({ timeoutMs: 5 }))).toEqual({
+      ok: false,
+      reason: "timeout",
+    });
+    await delay(35);
+
+    expect(store.releaseCalls).toHaveLength(1);
+    expect(store.active.get("key-one")?.size ?? 0).toBe(0);
+  });
+
+  it("heartbeats a holder and aborts its unified signal when ownership is lost", async () => {
+    const { semaphore, store } = manager();
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+
+    store.renews = false;
+    await delay(25);
+
+    expect(store.renewCalls.length).toBeGreaterThan(0);
+    expect(held.signal.aborted).toBe(true);
+    expect(String(held.signal.reason)).toContain("lease_lost");
+    await held.release();
+  });
+
+  it("aborts before expiry when a heartbeat never proves continued ownership", async () => {
+    const { semaphore, store } = manager();
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+
+    store.hangRenew = true;
+    await delay(70);
+
+    expect(held.signal.aborted).toBe(true);
+    expect(String(held.signal.reason)).toContain("lease_lost");
+  });
+
+  it("returns unavailable before admission when the lease database fails", async () => {
+    const store = new FakeLeaseStore();
+    store.throwAcquire = true;
+    const { semaphore } = manager(store);
+    expect(await semaphore.acquire(args())).toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("makes concurrent release callers await the same asynchronous DB release", async () => {
+    const store = new FakeLeaseStore();
+    store.releaseDelayMs = 25;
+    const { semaphore } = manager(store);
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+
+    let secondDone = false;
+    const first = held.release();
+    const second = held.release().then(() => {
+      secondDone = true;
+    });
+    await delay(5);
+    expect(secondDone).toBe(false);
+    await Promise.all([first, second]);
+    expect(store.releaseCalls).toHaveLength(1);
+  });
+
+  it("uses DB expiry minus response latency as ownership deadline", async () => {
+    const store = new FakeLeaseStore();
+    store.acquireResponseDelayMs = 35;
+    const { semaphore } = manager(store, { leaseTtlMs: 60, heartbeatIntervalMs: 1_000 });
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+
+    await delay(30);
+    expect(held.signal.aborted).toBe(true);
+  });
+
+  it("allows only one in-flight poll per key and cancels stale poll timers", async () => {
+    const store = new FakeLeaseStore();
+    store.acquireDelayMs = 20;
+    const { semaphore } = manager(store, { pollIntervalMs: 1 });
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    const waiting = semaphore.acquire(args({ timeoutMs: 8 }));
+    expect(await waiting).toEqual({ ok: false, reason: "timeout" });
+    await delay(35);
+
+    const waitingCalls = store.tryAcquireCalls.slice(1);
+    expect(waitingCalls).toHaveLength(1);
+    if (held.ok) await held.release();
+  });
+
+  it("drains an in-flight acquire orphan before shutdown resolves", async () => {
+    const store = new FakeLeaseStore();
+    store.acquireDelayMs = 25;
+    const { semaphore } = manager(store);
+    const pending = semaphore.acquire(args());
+    await delay(2);
+    await semaphore.shutdown();
+
+    expect(await pending).toEqual({ ok: false, reason: "unavailable" });
+    expect(store.releaseCalls).toHaveLength(1);
+  });
+
+  it("adds injectable jitter to unsuccessful polls", async () => {
+    const store = new FakeLeaseStore();
+    const random = vi.fn(() => 0.5);
+    const { semaphore } = manager(store, { random, pollIntervalMs: 10 });
+    const held = await semaphore.acquire(args());
+    const waiting = semaphore.acquire(args({ timeoutMs: 30 }));
+    await delay(15);
+
+    expect(random).toHaveBeenCalled();
+    if (held.ok) await held.release();
+    const next = await waiting;
+    if (next.ok) await next.release();
+  });
+
+  it("shutdown waits for a release already in flight", async () => {
+    const store = new FakeLeaseStore();
+    store.releaseDelayMs = 25;
+    const { semaphore } = manager(store);
+    const held = await semaphore.acquire(args());
+    expect(held.ok).toBe(true);
+    if (!held.ok) return;
+
+    void held.release();
+    let shutdownDone = false;
+    const shutdown = semaphore.shutdown().then(() => {
+      shutdownDone = true;
+    });
+    await delay(5);
+    expect(shutdownDone).toBe(false);
+    await shutdown;
+  });
+
+  it("makes async release idempotent and shutdown best-effort releases every holder", async () => {
+    const { semaphore, store } = manager();
+    const first = await semaphore.acquire(args({ key: "key-a" }));
+    const second = await semaphore.acquire(args({ key: "key-b" }));
+    expect(first.ok && second.ok).toBe(true);
+
+    if (first.ok) await Promise.all([first.release(), first.release()]);
+    expect(store.releaseCalls.filter((call) => call.keyId === "key-a")).toHaveLength(1);
+
+    await semaphore.shutdown();
+    expect(store.releaseCalls.filter((call) => call.keyId === "key-b")).toHaveLength(1);
+  });
+});

--- a/packages/core/src/queue/distributed-keyed-semaphore.ts
+++ b/packages/core/src/queue/distributed-keyed-semaphore.ts
@@ -85,8 +85,8 @@ export function createDistributedKeyedSemaphore(
         return;
       }
       const leaseId = waiter.leaseId;
-      let acquired: { acquired: boolean; expiresAtMs: number };
-      const acquireStartedAt = Date.now();
+      let acquired: { acquired: boolean; expiresAtMs: number; reclaimedCount: number };
+      const acquireStartedAt = performance.now();
       try {
         acquired = await options.store.tryAcquire({
           keyId: key,
@@ -96,12 +96,27 @@ export function createDistributedKeyedSemaphore(
           ttlMs,
         });
       } catch {
+        options.log?.("warn", "concurrency.store_unavailable", {
+          key_id: key,
+          lease_id: leaseId,
+          owner_id: options.ownerId,
+          reason: "acquire_error",
+          wait_ms: Math.max(0, Math.round(performance.now() - acquireStartedAt)),
+        });
         if (queues.get(key)?.[0] === waiter) {
           removeWaiter(key, waiter);
           waiter.cleanup();
           waiter.resolve({ ok: false, reason: "unavailable" });
         }
         return;
+      }
+      if (acquired.reclaimedCount > 0) {
+        options.log?.("info", "concurrency.expired_reclaimed", {
+          key_id: key,
+          owner_id: options.ownerId,
+          reason: "expired_reclaimed",
+          reclaimed_count: acquired.reclaimedCount,
+        });
       }
       // Timeout, abort, or shutdown may remove this waiter while DB transaction is
       // in flight. If it acquired anyway, delete orphan immediately; never create a
@@ -111,7 +126,7 @@ export function createDistributedKeyedSemaphore(
           try {
             await options.store.release({ keyId: key, leaseId, ownerId: options.ownerId });
           } catch {
-            options.log?.("warn", "concurrency.lease.release_failed", {
+            options.log?.("warn", "concurrency.lease_release_failed", {
               key_id: key,
               lease_id: leaseId,
               owner_id: options.ownerId,
@@ -122,7 +137,20 @@ export function createDistributedKeyedSemaphore(
         return;
       }
       if (!acquired.acquired) {
-        retry = true;
+        options.log?.("info", "concurrency.lease_acquire_failed", {
+          key_id: key,
+          lease_id: leaseId,
+          owner_id: options.ownerId,
+          reason: "capacity_unavailable",
+          wait_ms: Math.max(0, Math.round(performance.now() - acquireStartedAt)),
+        });
+        if (args.maxQueue === 0) {
+          removeWaiter(key, waiter);
+          waiter.cleanup();
+          waiter.resolve({ ok: false, reason: "queue_full" });
+        } else {
+          retry = true;
+        }
         return;
       }
       removeWaiter(key, waiter);
@@ -143,7 +171,7 @@ export function createDistributedKeyedSemaphore(
             try {
               await options.store.release({ keyId: key, leaseId, ownerId: options.ownerId });
             } catch {
-              options.log?.("warn", "concurrency.lease.release_failed", {
+              options.log?.("warn", "concurrency.lease_release_failed", {
                 key_id: key,
                 lease_id: leaseId,
                 owner_id: options.ownerId,
@@ -158,42 +186,51 @@ export function createDistributedKeyedSemaphore(
         },
       };
       holders.add(holder);
-      const loseOwnership = (): void => {
-        if (released) return;
-        controller.abort("lease_lost");
+      let ownershipLost = false;
+      const loseOwnership = (reason: string): void => {
+        if (released || ownershipLost) return;
+        ownershipLost = true;
+        options.log?.("warn", "concurrency.lease_lost", {
+          key_id: key,
+          lease_id: leaseId,
+          owner_id: options.ownerId,
+          reason,
+        });
+        controller.abort("concurrency_lease_lost");
         void holder.release();
       };
-      const armOwnershipDeadline = (expiresAtMs: number): void => {
+      const armOwnershipDeadline = (operationStartedAt: number): void => {
         if (ownershipDeadline) clearTimeout(ownershipDeadline);
-        const remainingMs = expiresAtMs - Date.now();
+        // PostgreSQL remains authoritative for absolute expiry. The replica only
+        // enforces a conservative local bound using monotonic elapsed time, so Node
+        // wall-clock skew cannot immediately invalidate a freshly acquired lease.
+        const remainingMs = ttlMs - (performance.now() - operationStartedAt);
         if (remainingMs <= 0) {
-          loseOwnership();
+          loseOwnership("ownership_deadline");
           return;
         }
-        ownershipDeadline = setTimeout(loseOwnership, remainingMs);
+        ownershipDeadline = setTimeout(() => loseOwnership("ownership_deadline"), remainingMs);
         ownershipDeadline.unref?.();
       };
-      // DB timestamp is authoritative, but replica/DB clocks may differ. Never trust
-      // more than one local TTL from request start; response latency consumes TTL.
-      armOwnershipDeadline(Math.min(acquired.expiresAtMs, acquireStartedAt + ttlMs));
+      armOwnershipDeadline(acquireStartedAt);
       heartbeat = setInterval(() => {
         if (renewInFlight || released) return;
         renewInFlight = true;
-        const renewStartedAt = Date.now();
+        const renewStartedAt = performance.now();
         void options.store
           .renew({ keyId: key, leaseId, ownerId: options.ownerId, ttlMs })
           .then((renewed) => {
             renewInFlight = false;
             if (released) return;
             if (!renewed.renewed) {
-              loseOwnership();
+              loseOwnership("renew_rejected");
               return;
             }
-            armOwnershipDeadline(Math.min(renewed.expiresAtMs, renewStartedAt + ttlMs));
+            armOwnershipDeadline(renewStartedAt);
           })
           .catch(() => {
             renewInFlight = false;
-            loseOwnership();
+            loseOwnership("renew_error");
           });
       }, heartbeatMs);
       heartbeat.unref?.();
@@ -237,7 +274,9 @@ export function createDistributedKeyedSemaphore(
       if (args.signal?.aborted) return { ok: false, reason: "aborted" };
       const queue = queues.get(args.key) ?? [];
       queues.set(args.key, queue);
-      if (queue.length >= args.maxQueue) return { ok: false, reason: "queue_full" };
+      // One pending entry is the polling head. maxQueue counts only overflow
+      // waiters behind it, matching the local semaphore's queue-capacity contract.
+      if (queue.length > args.maxQueue) return { ok: false, reason: "queue_full" };
       return new Promise<DistributedAcquireResult>((resolve) => {
         const waiter: Waiter = {
           args,

--- a/packages/core/src/queue/distributed-keyed-semaphore.ts
+++ b/packages/core/src/queue/distributed-keyed-semaphore.ts
@@ -1,0 +1,282 @@
+import { randomUUID } from "node:crypto";
+import type { ConcurrencyLeaseStore } from "../store/ports.js";
+
+export type DistributedAcquireResult =
+  | { ok: true; signal: AbortSignal; release: () => Promise<void> }
+  | { ok: false; reason: "queue_full" | "timeout" | "aborted" | "unavailable" };
+
+export interface DistributedAcquireArgs {
+  key: string;
+  limit: number | null;
+  maxQueue: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}
+
+export interface DistributedKeyedSemaphore {
+  acquire(args: DistributedAcquireArgs): Promise<DistributedAcquireResult>;
+  shutdown(): Promise<void>;
+}
+
+export interface DistributedKeyedSemaphoreOptions {
+  store: ConcurrencyLeaseStore;
+  ownerId: string;
+  leaseTtlMs?: number;
+  heartbeatIntervalMs?: number;
+  /** @deprecated Poll delay uses bounded jitter; retained for source compatibility. */
+  pollIntervalMs?: number;
+  /** Bounded 100–250ms random backoff for unsuccessful distributed polls. */
+  random?: () => number;
+  createLeaseId?: () => string;
+  log?: (level: "warn" | "info", message: string, fields: Record<string, unknown>) => void;
+}
+
+interface Waiter {
+  args: DistributedAcquireArgs;
+  leaseId: string;
+  resolve: (result: DistributedAcquireResult) => void;
+  cleanup: () => void;
+}
+
+interface Holder {
+  release: () => Promise<void>;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+const DEFAULT_HEARTBEAT_MS = 10_000;
+
+export function createDistributedKeyedSemaphore(
+  options: DistributedKeyedSemaphoreOptions,
+): DistributedKeyedSemaphore {
+  const ttlMs = options.leaseTtlMs ?? DEFAULT_TTL_MS;
+  const heartbeatMs = options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS;
+  const queues = new Map<string, Waiter[]>();
+  const holders = new Set<Holder>();
+  const polls = new Map<string, Promise<void>>();
+  const pollTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const inFlightAcquires = new Set<Promise<void>>();
+  let stopped = false;
+
+  const removeWaiter = (key: string, waiter: Waiter): void => {
+    const queue = queues.get(key);
+    if (!queue) return;
+    const index = queue.indexOf(waiter);
+    if (index >= 0) queue.splice(index, 1);
+    if (queue.length === 0) queues.delete(key);
+  };
+
+  const processHead = async (key: string): Promise<void> => {
+    if (polls.has(key)) return;
+    const staleTimer = pollTimers.get(key);
+    if (staleTimer) {
+      clearTimeout(staleTimer);
+      pollTimers.delete(key);
+    }
+    let retry = false;
+    const run = (async () => {
+      const queue = queues.get(key);
+      const waiter = queue?.[0];
+      if (!waiter || stopped) return;
+      const { args } = waiter;
+      if (args.signal?.aborted) {
+        removeWaiter(key, waiter);
+        waiter.cleanup();
+        waiter.resolve({ ok: false, reason: "aborted" });
+        return;
+      }
+      const leaseId = waiter.leaseId;
+      let acquired: { acquired: boolean; expiresAtMs: number };
+      const acquireStartedAt = Date.now();
+      try {
+        acquired = await options.store.tryAcquire({
+          keyId: key,
+          leaseId,
+          ownerId: options.ownerId,
+          limit: args.limit as number,
+          ttlMs,
+        });
+      } catch {
+        if (queues.get(key)?.[0] === waiter) {
+          removeWaiter(key, waiter);
+          waiter.cleanup();
+          waiter.resolve({ ok: false, reason: "unavailable" });
+        }
+        return;
+      }
+      // Timeout, abort, or shutdown may remove this waiter while DB transaction is
+      // in flight. If it acquired anyway, delete orphan immediately; never create a
+      // holder/heartbeat for caller whose promise already resolved.
+      if (queues.get(key)?.[0] !== waiter || stopped) {
+        if (acquired.acquired) {
+          try {
+            await options.store.release({ keyId: key, leaseId, ownerId: options.ownerId });
+          } catch {
+            options.log?.("warn", "concurrency.lease.release_failed", {
+              key_id: key,
+              lease_id: leaseId,
+              owner_id: options.ownerId,
+              reason: "release_failed",
+            });
+          }
+        }
+        return;
+      }
+      if (!acquired.acquired) {
+        retry = true;
+        return;
+      }
+      removeWaiter(key, waiter);
+      waiter.cleanup();
+      const controller = new AbortController();
+      let released = false;
+      let releasePromise: Promise<void> | undefined;
+      let heartbeat: ReturnType<typeof setInterval> | undefined;
+      let ownershipDeadline: ReturnType<typeof setTimeout> | undefined;
+      let renewInFlight = false;
+      const holder: Holder = {
+        release: () => {
+          if (releasePromise) return releasePromise;
+          released = true;
+          if (heartbeat) clearInterval(heartbeat);
+          if (ownershipDeadline) clearTimeout(ownershipDeadline);
+          releasePromise = (async () => {
+            try {
+              await options.store.release({ keyId: key, leaseId, ownerId: options.ownerId });
+            } catch {
+              options.log?.("warn", "concurrency.lease.release_failed", {
+                key_id: key,
+                lease_id: leaseId,
+                owner_id: options.ownerId,
+                reason: "release_failed",
+              });
+            } finally {
+              holders.delete(holder);
+            }
+            void processHead(key);
+          })();
+          return releasePromise;
+        },
+      };
+      holders.add(holder);
+      const loseOwnership = (): void => {
+        if (released) return;
+        controller.abort("lease_lost");
+        void holder.release();
+      };
+      const armOwnershipDeadline = (expiresAtMs: number): void => {
+        if (ownershipDeadline) clearTimeout(ownershipDeadline);
+        const remainingMs = expiresAtMs - Date.now();
+        if (remainingMs <= 0) {
+          loseOwnership();
+          return;
+        }
+        ownershipDeadline = setTimeout(loseOwnership, remainingMs);
+        ownershipDeadline.unref?.();
+      };
+      // DB timestamp is authoritative, but replica/DB clocks may differ. Never trust
+      // more than one local TTL from request start; response latency consumes TTL.
+      armOwnershipDeadline(Math.min(acquired.expiresAtMs, acquireStartedAt + ttlMs));
+      heartbeat = setInterval(() => {
+        if (renewInFlight || released) return;
+        renewInFlight = true;
+        const renewStartedAt = Date.now();
+        void options.store
+          .renew({ keyId: key, leaseId, ownerId: options.ownerId, ttlMs })
+          .then((renewed) => {
+            renewInFlight = false;
+            if (released) return;
+            if (!renewed.renewed) {
+              loseOwnership();
+              return;
+            }
+            armOwnershipDeadline(Math.min(renewed.expiresAtMs, renewStartedAt + ttlMs));
+          })
+          .catch(() => {
+            renewInFlight = false;
+            loseOwnership();
+          });
+      }, heartbeatMs);
+      heartbeat.unref?.();
+      waiter.resolve({ ok: true, signal: controller.signal, release: holder.release });
+    })();
+    polls.set(key, run);
+    inFlightAcquires.add(run);
+    void run.finally(() => {
+      polls.delete(key);
+      inFlightAcquires.delete(run);
+      if (retry) schedulePoll(key);
+      else if (!stopped && queues.get(key)?.length) void processHead(key);
+    });
+  };
+
+  const schedulePoll = (key: string): void => {
+    // A replica may have many FIFO waiters behind its queue head. Only the head
+    // talks to PostgreSQL, but it must keep polling while any waiter remains;
+    // requiring exactly one waiter strands a loaded replica after its first
+    // failed acquire and eventually times out the entire local queue.
+    if (stopped || polls.has(key) || pollTimers.has(key) || !queues.get(key)?.length) return;
+    const delay = 100 + Math.floor((options.random?.() ?? Math.random()) * 151);
+    const timer = setTimeout(() => {
+      pollTimers.delete(key);
+      void processHead(key);
+    }, delay);
+    timer.unref?.();
+    pollTimers.set(key, timer);
+  };
+
+  return {
+    async acquire(args): Promise<DistributedAcquireResult> {
+      if (args.limit === null || args.limit <= 0) {
+        return {
+          ok: true,
+          signal: args.signal ?? new AbortController().signal,
+          release: async () => {},
+        };
+      }
+      if (stopped) return { ok: false, reason: "unavailable" };
+      if (args.signal?.aborted) return { ok: false, reason: "aborted" };
+      const queue = queues.get(args.key) ?? [];
+      queues.set(args.key, queue);
+      if (queue.length >= args.maxQueue) return { ok: false, reason: "queue_full" };
+      return new Promise<DistributedAcquireResult>((resolve) => {
+        const waiter: Waiter = {
+          args,
+          leaseId: (options.createLeaseId ?? randomUUID)(),
+          resolve,
+          cleanup: () => {},
+        };
+        const fail = (reason: "timeout" | "aborted"): void => {
+          removeWaiter(args.key, waiter);
+          waiter.cleanup();
+          resolve({ ok: false, reason });
+          void processHead(args.key);
+        };
+        const timeout = setTimeout(() => fail("timeout"), args.timeoutMs);
+        timeout.unref?.();
+        const abort = () => fail("aborted");
+        args.signal?.addEventListener("abort", abort, { once: true });
+        waiter.cleanup = () => {
+          clearTimeout(timeout);
+          args.signal?.removeEventListener("abort", abort);
+        };
+        queue.push(waiter);
+        if (queue.length === 1) void processHead(args.key);
+      });
+    },
+
+    async shutdown(): Promise<void> {
+      stopped = true;
+      for (const timer of pollTimers.values()) clearTimeout(timer);
+      pollTimers.clear();
+      for (const queue of queues.values()) {
+        for (const waiter of queue.splice(0)) {
+          waiter.cleanup();
+          waiter.resolve({ ok: false, reason: "unavailable" });
+        }
+      }
+      queues.clear();
+      await Promise.all([...inFlightAcquires]);
+      await Promise.all([...holders].map((holder) => holder.release()));
+    },
+  };
+}

--- a/packages/core/src/store/factory.test.ts
+++ b/packages/core/src/store/factory.test.ts
@@ -22,6 +22,7 @@ describe("createStore factory", () => {
     expect(store.telemetry).toBeDefined();
     expect(store.signals).toBeDefined();
     expect(store.rateLimit).toBeDefined();
+    expect(store.concurrencyLeases).toBeNull();
     expect(store.memory).toBeDefined();
     expect(store.config).toBeDefined();
     await store.close();

--- a/packages/core/src/store/factory.ts
+++ b/packages/core/src/store/factory.ts
@@ -4,6 +4,7 @@ import type { StoreConfig } from "@helm/shared";
 import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
 import type {
   BudgetStore,
+  ConcurrencyLeaseStore,
   ConfigStore,
   KeyStore,
   MemoryStore,
@@ -15,6 +16,7 @@ import type {
   TelemetryStore,
 } from "./ports.js";
 import { PgBudgetStore } from "./postgres/budget.js";
+import { PgConcurrencyLeaseStore } from "./postgres/concurrency-leases.js";
 import { PgConfigStore } from "./postgres/config-store.js";
 import { PgKeyStore } from "./postgres/keystore.js";
 import { PgMemoryStore } from "./postgres/memory-store.js";
@@ -52,6 +54,8 @@ export interface StoreSet {
   readonly budget: BudgetStore;
   readonly memory: MemoryStore;
   readonly config: ConfigStore;
+  // Null for SQLite: only PostgreSQL coordinates leases across replicas.
+  readonly concurrencyLeases: ConcurrencyLeaseStore | null;
   readonly oauthTokens: OAuthTokenStore;
   // Per-account OAuth subscription observability (providers page). usage = today's
   // served traffic; quota = latest rate-limit window snapshot. Both fail-open.
@@ -95,6 +99,7 @@ export async function createStore(opts: CreateStoreOptions): Promise<StoreSet> {
         budget: new SqliteBudgetStore(db),
         memory: new SqliteMemoryStore(db),
         config: new SqliteConfigStore(db),
+        concurrencyLeases: null,
         oauthTokens: new SqliteOAuthTokenStore(db),
         oauthUsage: new SqliteOAuthUsageStore(db),
         oauthQuota: new SqliteOAuthQuotaStore(db),
@@ -125,6 +130,7 @@ export async function createStore(opts: CreateStoreOptions): Promise<StoreSet> {
         budget: new PgBudgetStore(db),
         memory: new PgMemoryStore(db),
         config: new PgConfigStore(db),
+        concurrencyLeases: new PgConcurrencyLeaseStore(db),
         oauthTokens: new PgOAuthTokenStore(db),
         oauthUsage: new PgOAuthUsageStore(db),
         oauthQuota: new PgOAuthQuotaStore(db),

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -4,6 +4,7 @@ export type {
   BudgetDim,
   BudgetPeekResult,
   BudgetStore,
+  ConcurrencyLeaseStore,
   ConfigStore,
   CreateKeyInput,
   InsertPayloadInput,
@@ -36,6 +37,7 @@ export {
 // reached via postgres-js; the same adapters run against in-process PGlite in
 // tests (drizzle pg dialect), validating the supabase path without a server.
 export { PgBudgetStore } from "./postgres/budget.js";
+export { PgConcurrencyLeaseStore } from "./postgres/concurrency-leases.js";
 export { PgConfigStore } from "./postgres/config-store.js";
 export { PgKeyStore } from "./postgres/keystore.js";
 export { PgMemoryStore } from "./postgres/memory-store.js";

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -89,7 +89,7 @@ export interface ConcurrencyLeaseStore {
     ownerId: string;
     limit: number;
     ttlMs: number;
-  }): Promise<{ acquired: boolean; expiresAtMs: number }>;
+  }): Promise<{ acquired: boolean; expiresAtMs: number; reclaimedCount: number }>;
   renew(input: {
     keyId: string;
     leaseId: string;

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -80,6 +80,25 @@ export interface RateLimitConsumeResult {
   resetSeconds: number;
 }
 
+// Global API-key concurrency leases. PostgreSQL adapters use the database clock for
+// every expiry decision; callers never pass a Node timestamp.
+export interface ConcurrencyLeaseStore {
+  tryAcquire(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    limit: number;
+    ttlMs: number;
+  }): Promise<{ acquired: boolean; expiresAtMs: number }>;
+  renew(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    ttlMs: number;
+  }): Promise<{ renewed: boolean; expiresAtMs: number }>;
+  release(input: { keyId: string; leaseId: string; ownerId: string }): Promise<void>;
+}
+
 export interface RateLimitStore {
   // Atomically refill + try to consume `cost` tokens from the (keyId, dim)
   // bucket. `state` is the caller's last-known state hint; adapters that persist

--- a/packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts
+++ b/packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts
@@ -1,0 +1,140 @@
+import { sql } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+import { PgConcurrencyLeaseStore } from "./concurrency-leases.js";
+import { createPgDb, type PgDb, runPgMigrations } from "./migrate.js";
+
+const postgresUrl: string =
+  process.env.PG_TEST_URL ??
+  process.env.HELM_TEST_POSTGRES_URL ??
+  (() => {
+    throw new Error(
+      "real PostgreSQL lease tests require PG_TEST_URL or HELM_TEST_POSTGRES_URL; run through apps/gateway/e2e/run-with-postgres.sh",
+    );
+  })();
+
+const openDbs: PgDb[] = [];
+afterEach(async () => {
+  await Promise.all(openDbs.splice(0).map((db) => db.$close()));
+});
+
+function rowsOf(result: unknown): unknown[] {
+  if (Array.isArray(result)) return result;
+  if (result && typeof result === "object" && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: unknown[] }).rows;
+  }
+  return [];
+}
+
+async function db(): Promise<PgDb> {
+  const connection = await createPgDb(postgresUrl);
+  openDbs.push(connection);
+  return connection;
+}
+
+describe("real PostgreSQL concurrency lease contract", () => {
+  it("bases expiry on statement time after waiting for a row lock across two pools", async () => {
+    const dbA = await db();
+    const dbB = await db();
+    const store = new PgConcurrencyLeaseStore(dbB);
+    const keyId = `real-clock-${crypto.randomUUID()}`;
+    let releaseLock!: () => void;
+    const lockHeld = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    let locked!: () => void;
+    const lockedReady = new Promise<void>((resolve) => {
+      locked = resolve;
+    });
+
+    const blocker = dbA.transaction(async (tx) => {
+      await tx.execute(sql`
+        INSERT INTO api_key_concurrency_state (key_id)
+        VALUES (${keyId})
+        ON CONFLICT (key_id) DO NOTHING
+      `);
+      await tx.execute(sql`
+        SELECT key_id FROM api_key_concurrency_state
+        WHERE key_id = ${keyId}
+        FOR UPDATE
+      `);
+      locked();
+      await lockHeld;
+    });
+
+    try {
+      await lockedReady;
+      const startedAt = Date.now();
+      const acquire = store.tryAcquire({
+        keyId,
+        leaseId: `lease-${crypto.randomUUID()}`,
+        ownerId: "real-pool-b",
+        limit: 1,
+        ttlMs: 180,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 260));
+      releaseLock();
+      await blocker;
+      const acquired = await acquire;
+      expect(acquired.acquired).toBe(true);
+      expect(acquired.expiresAtMs - startedAt).toBeGreaterThanOrEqual(350);
+    } finally {
+      releaseLock();
+      await blocker.catch(() => {});
+      await dbA.execute(sql`DELETE FROM api_key_concurrency_leases WHERE key_id = ${keyId}`);
+      await dbA.execute(sql`DELETE FROM api_key_concurrency_state WHERE key_id = ${keyId}`);
+    }
+  });
+
+  it("migrates an old v40 seed to v41 without losing api key telemetry rate or budget data", async () => {
+    const connection = await db();
+    const suffix = crypto.randomUUID();
+    const keyId = `old-key-${suffix}`;
+    const requestId = `old-request-${suffix}`;
+    const rateKey = `old-rate-${suffix}`;
+    const budgetKey = `old-budget-${suffix}`;
+
+    await connection.execute(sql`
+      INSERT INTO api_keys (key_id, hash, prefix, account_id, role, created_at)
+      VALUES (${keyId}, 'old-hash', 'old-prefix', 'default', 'user', 1)
+    `);
+    await connection.execute(sql`
+      INSERT INTO telemetry (id, request_id, api_key_id, decision_json, created_at)
+      VALUES (${`telemetry-${suffix}`}, ${requestId}, ${keyId}, '{"status":"success"}', 4)
+    `);
+    await connection.execute(sql`
+      INSERT INTO rate_limit_buckets (key_id, dim, tokens, last_refill_ms)
+      VALUES (${rateKey}, 'rpm', 7, 8)
+    `);
+    await connection.execute(sql`
+      INSERT INTO usage_budget_buckets (key_id, dim, tokens, last_refill_ms)
+      VALUES (${budgetKey}, 'usd', 9, 10)
+    `);
+    await connection.execute(sql`DROP TABLE api_key_concurrency_leases`);
+    await connection.execute(sql`DROP TABLE api_key_concurrency_state`);
+    await connection.execute(sql`DELETE FROM _migrations WHERE version = 41`);
+
+    await runPgMigrations(connection);
+
+    const key = await connection.execute(
+      sql`SELECT key_id, hash, prefix FROM api_keys WHERE key_id = ${keyId}`,
+    );
+    const telemetry = await connection.execute(
+      sql`SELECT request_id, decision_json FROM telemetry WHERE request_id = ${requestId}`,
+    );
+    const rate = await connection.execute(
+      sql`SELECT key_id, tokens FROM rate_limit_buckets WHERE key_id = ${rateKey}`,
+    );
+    const budget = await connection.execute(
+      sql`SELECT key_id, tokens FROM usage_budget_buckets WHERE key_id = ${budgetKey}`,
+    );
+    expect(rowsOf(key)).toHaveLength(1);
+    expect(rowsOf(telemetry)).toHaveLength(1);
+    expect(rowsOf(rate)).toHaveLength(1);
+    expect(rowsOf(budget)).toHaveLength(1);
+
+    await connection.execute(sql`DELETE FROM telemetry WHERE request_id = ${requestId}`);
+    await connection.execute(sql`DELETE FROM api_keys WHERE key_id = ${keyId}`);
+    await connection.execute(sql`DELETE FROM rate_limit_buckets WHERE key_id = ${rateKey}`);
+    await connection.execute(sql`DELETE FROM usage_budget_buckets WHERE key_id = ${budgetKey}`);
+  });
+});

--- a/packages/core/src/store/postgres/concurrency-leases.test.ts
+++ b/packages/core/src/store/postgres/concurrency-leases.test.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as storeExports from "../index.js";
 import type { PgDb } from "./migrate.js";
-import { createPgDb, createPgliteDb, runPgMigrations } from "./migrate.js";
+import { createPgliteDb, runPgMigrations } from "./migrate.js";
 
 interface LeaseStore {
   tryAcquire(input: {
@@ -11,7 +11,7 @@ interface LeaseStore {
     ownerId: string;
     limit: number;
     ttlMs: number;
-  }): Promise<{ acquired: boolean; expiresAtMs: number }>;
+  }): Promise<{ acquired: boolean; expiresAtMs: number; reclaimedCount?: number }>;
   renew(input: {
     keyId: string;
     leaseId: string;
@@ -50,9 +50,6 @@ async function close(db: PgDb): Promise<void> {
 }
 
 // Canonical e2e input wins; keep the original local-test variable compatible.
-const realPostgresUrl = process.env.PG_TEST_URL ?? process.env.HELM_TEST_POSTGRES_URL;
-const realPostgresIt = realPostgresUrl ? it : it.skip;
-
 describe("PgConcurrencyLeaseStore", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -170,47 +167,6 @@ describe("PgConcurrencyLeaseStore", () => {
     }
   });
 
-  realPostgresIt(
-    "bases expiry on statement time after waiting for a row lock across two pools",
-    async () => {
-      const dbA = await createPgDb(realPostgresUrl as string);
-      const dbB = await createPgDb(realPostgresUrl as string);
-      const keyId = `clock-lock-${crypto.randomUUID()}`;
-      try {
-        const lockHeld = dbA.transaction(async (tx) => {
-          await tx.execute(sql`
-            INSERT INTO api_key_concurrency_state (key_id) VALUES (${keyId})
-            ON CONFLICT (key_id) DO NOTHING
-          `);
-          await tx.execute(sql`
-            SELECT key_id FROM api_key_concurrency_state
-            WHERE key_id = ${keyId} FOR UPDATE
-          `);
-          await new Promise((resolve) => setTimeout(resolve, 150));
-        });
-        await new Promise((resolve) => setTimeout(resolve, 25));
-        const startedAt = Date.now();
-        const attempt = leaseStore(dbB).tryAcquire({
-          keyId,
-          leaseId: "delayed-lease",
-          ownerId: "replica-b",
-          limit: 1,
-          ttlMs: 200,
-        });
-        await lockHeld;
-        const acquired = await attempt;
-
-        expect(acquired.acquired).toBe(true);
-        expect(acquired.expiresAtMs).toBeGreaterThanOrEqual(startedAt + 300);
-      } finally {
-        await dbA.execute(sql`DELETE FROM api_key_concurrency_leases WHERE key_id = ${keyId}`);
-        await dbA.execute(sql`DELETE FROM api_key_concurrency_state WHERE key_id = ${keyId}`);
-        await Promise.all([close(dbA), close(dbB)]);
-      }
-    },
-    30_000,
-  );
-
   it("reclaims an expired lease before counting active holders", async () => {
     const db = await createPgliteDb();
     try {
@@ -228,17 +184,15 @@ describe("PgConcurrencyLeaseStore", () => {
       ).toBe(true);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
-      expect(
-        (
-          await store.tryAcquire({
-            keyId: "reclaim-key",
-            leaseId: "replacement-lease",
-            ownerId: "live-replica",
-            limit: 1,
-            ttlMs: 30_000,
-          })
-        ).acquired,
-      ).toBe(true);
+      const replacement = await store.tryAcquire({
+        keyId: "reclaim-key",
+        leaseId: "replacement-lease",
+        ownerId: "live-replica",
+        limit: 1,
+        ttlMs: 30_000,
+      });
+      expect(replacement.acquired).toBe(true);
+      expect(replacement.reclaimedCount).toBe(1);
     } finally {
       await close(db);
     }

--- a/packages/core/src/store/postgres/concurrency-leases.test.ts
+++ b/packages/core/src/store/postgres/concurrency-leases.test.ts
@@ -1,0 +1,334 @@
+import { sql } from "drizzle-orm";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as storeExports from "../index.js";
+import type { PgDb } from "./migrate.js";
+import { createPgDb, createPgliteDb, runPgMigrations } from "./migrate.js";
+
+interface LeaseStore {
+  tryAcquire(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    limit: number;
+    ttlMs: number;
+  }): Promise<{ acquired: boolean; expiresAtMs: number }>;
+  renew(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    ttlMs: number;
+  }): Promise<{ renewed: boolean; expiresAtMs: number }>;
+  release(input: { keyId: string; leaseId: string; ownerId: string }): Promise<void>;
+}
+
+type LeaseStoreConstructor = new (db: PgDb) => LeaseStore;
+
+function leaseStore(db: PgDb): LeaseStore {
+  const adapter = Reflect.get(storeExports, "PgConcurrencyLeaseStore");
+  expect(adapter, "Postgres must expose its distributed concurrency lease adapter").toBeTypeOf(
+    "function",
+  );
+  return new (adapter as LeaseStoreConstructor)(db);
+}
+
+async function tableNames(db: PgDb): Promise<string[]> {
+  const result = await db.execute(sql`
+    SELECT table_name
+      FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND table_name IN ('api_key_concurrency_state', 'api_key_concurrency_leases')
+     ORDER BY table_name
+  `);
+  const rows = Array.isArray(result)
+    ? (result as unknown as Array<{ table_name: string }>)
+    : ((result as unknown as { rows?: Array<{ table_name: string }> }).rows ?? []);
+  return rows.map((row) => row.table_name);
+}
+
+async function close(db: PgDb): Promise<void> {
+  await db.$close();
+}
+
+// Canonical e2e input wins; keep the original local-test variable compatible.
+const realPostgresUrl = process.env.PG_TEST_URL ?? process.env.HELM_TEST_POSTGRES_URL;
+const realPostgresIt = realPostgresUrl ? it : it.skip;
+
+describe("PgConcurrencyLeaseStore", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("installs both lease tables through a repeatable additive migration", async () => {
+    const db = await createPgliteDb();
+    try {
+      expect(await tableNames(db)).toEqual([
+        "api_key_concurrency_leases",
+        "api_key_concurrency_state",
+      ]);
+      await runPgMigrations(db);
+      expect(await tableNames(db)).toEqual([
+        "api_key_concurrency_leases",
+        "api_key_concurrency_state",
+      ]);
+    } finally {
+      await close(db);
+    }
+  });
+
+  it("atomically admits no more than limit concurrent leases", async () => {
+    const db = await createPgliteDb();
+    try {
+      const store = leaseStore(db);
+      const attempts = await Promise.all(
+        Array.from({ length: 25 }, (_, index) =>
+          store.tryAcquire({
+            keyId: "key-one",
+            leaseId: `lease-${index}`,
+            ownerId: `replica-${index % 2}`,
+            limit: 3,
+            ttlMs: 30_000,
+          }),
+        ),
+      );
+      expect(attempts.filter((attempt) => attempt.acquired)).toHaveLength(3);
+    } finally {
+      await close(db);
+    }
+  });
+
+  it("shares one Postgres limit across two replica stores under 100 concurrent attempts", async () => {
+    const db = await createPgliteDb();
+    try {
+      const replicaA = leaseStore(db);
+      const replicaB = leaseStore(db);
+      let active = 0;
+      let maxActive = 0;
+      await Promise.all(
+        Array.from({ length: 100 }, async (_, index) => {
+          const store = index % 2 === 0 ? replicaA : replicaB;
+          const leaseId = `replica-lease-${index}`;
+          const acquired = await store.tryAcquire({
+            keyId: "shared-key",
+            leaseId,
+            ownerId: index % 2 === 0 ? "replica-a" : "replica-b",
+            limit: 1,
+            ttlMs: 30_000,
+          });
+          if (!acquired.acquired) return;
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await Promise.resolve();
+          active -= 1;
+          await store.release({
+            keyId: "shared-key",
+            leaseId,
+            ownerId: index % 2 === 0 ? "replica-a" : "replica-b",
+          });
+        }),
+      );
+      expect(maxActive).toBe(1);
+    } finally {
+      await close(db);
+    }
+  });
+
+  it("uses database time rather than the replica's Node clock", async () => {
+    const db = await createPgliteDb();
+    try {
+      const store = leaseStore(db);
+      vi.spyOn(Date, "now").mockReturnValue(1);
+
+      const acquired = await store.tryAcquire({
+        keyId: "clock-key",
+        leaseId: "clock-lease",
+        ownerId: "clock-skewed-replica",
+        limit: 1,
+        ttlMs: 30_000,
+      });
+
+      expect(acquired.acquired).toBe(true);
+      expect(acquired.expiresAtMs).toBeGreaterThan(25_000);
+    } finally {
+      await close(db);
+    }
+  });
+
+  it("returns a database-derived future expiry for the statement-clock SQL path", async () => {
+    const db = await createPgliteDb();
+    try {
+      const store = leaseStore(db);
+      const acquired = await store.tryAcquire({
+        keyId: "statement-clock-key",
+        leaseId: "statement-clock-lease",
+        ownerId: "replica-a",
+        limit: 1,
+        ttlMs: 100,
+      });
+      expect(acquired.expiresAtMs).toBeGreaterThan(Date.now() + 50);
+    } finally {
+      await close(db);
+    }
+  });
+
+  realPostgresIt(
+    "bases expiry on statement time after waiting for a row lock across two pools",
+    async () => {
+      const dbA = await createPgDb(realPostgresUrl as string);
+      const dbB = await createPgDb(realPostgresUrl as string);
+      const keyId = `clock-lock-${crypto.randomUUID()}`;
+      try {
+        const lockHeld = dbA.transaction(async (tx) => {
+          await tx.execute(sql`
+            INSERT INTO api_key_concurrency_state (key_id) VALUES (${keyId})
+            ON CONFLICT (key_id) DO NOTHING
+          `);
+          await tx.execute(sql`
+            SELECT key_id FROM api_key_concurrency_state
+            WHERE key_id = ${keyId} FOR UPDATE
+          `);
+          await new Promise((resolve) => setTimeout(resolve, 150));
+        });
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        const startedAt = Date.now();
+        const attempt = leaseStore(dbB).tryAcquire({
+          keyId,
+          leaseId: "delayed-lease",
+          ownerId: "replica-b",
+          limit: 1,
+          ttlMs: 200,
+        });
+        await lockHeld;
+        const acquired = await attempt;
+
+        expect(acquired.acquired).toBe(true);
+        expect(acquired.expiresAtMs).toBeGreaterThanOrEqual(startedAt + 300);
+      } finally {
+        await dbA.execute(sql`DELETE FROM api_key_concurrency_leases WHERE key_id = ${keyId}`);
+        await dbA.execute(sql`DELETE FROM api_key_concurrency_state WHERE key_id = ${keyId}`);
+        await Promise.all([close(dbA), close(dbB)]);
+      }
+    },
+    30_000,
+  );
+
+  it("reclaims an expired lease before counting active holders", async () => {
+    const db = await createPgliteDb();
+    try {
+      const store = leaseStore(db);
+      expect(
+        (
+          await store.tryAcquire({
+            keyId: "reclaim-key",
+            leaseId: "dead-lease",
+            ownerId: "dead-replica",
+            limit: 1,
+            ttlMs: 1,
+          })
+        ).acquired,
+      ).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(
+        (
+          await store.tryAcquire({
+            keyId: "reclaim-key",
+            leaseId: "replacement-lease",
+            ownerId: "live-replica",
+            limit: 1,
+            ttlMs: 30_000,
+          })
+        ).acquired,
+      ).toBe(true);
+    } finally {
+      await close(db);
+    }
+  });
+
+  it("honors a lowered limit without revoking existing holders and isolates keys", async () => {
+    const db = await createPgliteDb();
+    try {
+      const store = leaseStore(db);
+      for (const leaseId of ["a", "b", "c"]) {
+        expect(
+          (
+            await store.tryAcquire({
+              keyId: "lowered-key",
+              leaseId,
+              ownerId: "replica-a",
+              limit: 3,
+              ttlMs: 30_000,
+            })
+          ).acquired,
+        ).toBe(true);
+      }
+
+      expect(
+        (
+          await store.tryAcquire({
+            keyId: "lowered-key",
+            leaseId: "blocked",
+            ownerId: "replica-b",
+            limit: 1,
+            ttlMs: 30_000,
+          })
+        ).acquired,
+      ).toBe(false);
+      expect(
+        (
+          await store.tryAcquire({
+            keyId: "independent-key",
+            leaseId: "independent",
+            ownerId: "replica-b",
+            limit: 1,
+            ttlMs: 30_000,
+          })
+        ).acquired,
+      ).toBe(true);
+    } finally {
+      await close(db);
+    }
+  });
+
+  it("fences renew and release by key, lease, and owner", async () => {
+    const db = await createPgliteDb();
+    try {
+      const store = leaseStore(db);
+      await store.tryAcquire({
+        keyId: "fenced-key",
+        leaseId: "owned-lease",
+        ownerId: "owner-a",
+        limit: 1,
+        ttlMs: 30_000,
+      });
+
+      expect(
+        (
+          await store.renew({
+            keyId: "fenced-key",
+            leaseId: "owned-lease",
+            ownerId: "owner-b",
+            ttlMs: 30_000,
+          })
+        ).renewed,
+      ).toBe(false);
+      await store.release({
+        keyId: "fenced-key",
+        leaseId: "owned-lease",
+        ownerId: "owner-b",
+      });
+      expect(
+        (
+          await store.tryAcquire({
+            keyId: "fenced-key",
+            leaseId: "still-blocked",
+            ownerId: "owner-b",
+            limit: 1,
+            ttlMs: 30_000,
+          })
+        ).acquired,
+      ).toBe(false);
+    } finally {
+      await close(db);
+    }
+  });
+});

--- a/packages/core/src/store/postgres/concurrency-leases.ts
+++ b/packages/core/src/store/postgres/concurrency-leases.ts
@@ -21,7 +21,7 @@ export class PgConcurrencyLeaseStore implements ConcurrencyLeaseStore {
     ownerId: string;
     limit: number;
     ttlMs: number;
-  }): Promise<{ acquired: boolean; expiresAtMs: number }> {
+  }): Promise<{ acquired: boolean; expiresAtMs: number; reclaimedCount: number }> {
     return this.db.transaction(async (tx) => {
       await tx.execute(sql`
         INSERT INTO api_key_concurrency_state (key_id) VALUES (${input.keyId})
@@ -31,10 +31,12 @@ export class PgConcurrencyLeaseStore implements ConcurrencyLeaseStore {
         SELECT key_id FROM api_key_concurrency_state
         WHERE key_id = ${input.keyId} FOR UPDATE
       `);
-      await tx.execute(sql`
+      const reclaimed = await tx.execute(sql`
         DELETE FROM api_key_concurrency_leases
         WHERE key_id = ${input.keyId} AND expires_at <= clock_timestamp()
+        RETURNING lease_id
       `);
+      const reclaimedCount = resultRows<{ lease_id: string }>(reclaimed).length;
       const active = await tx.execute(sql`
         SELECT count(*)::integer AS count
         FROM api_key_concurrency_leases
@@ -45,14 +47,22 @@ export class PgConcurrencyLeaseStore implements ConcurrencyLeaseStore {
         const now = await tx.execute(
           sql`SELECT (extract(epoch FROM clock_timestamp()) * 1000)::bigint AS expires_at_ms`,
         );
-        return { acquired: false, expiresAtMs: epochMs(resultRows<TimestampRow>(now)[0]) };
+        return {
+          acquired: false,
+          expiresAtMs: epochMs(resultRows<TimestampRow>(now)[0]),
+          reclaimedCount,
+        };
       }
       const inserted = await tx.execute(sql`
         INSERT INTO api_key_concurrency_leases (lease_id, key_id, owner_id, expires_at)
         VALUES (${input.leaseId}, ${input.keyId}, ${input.ownerId}, clock_timestamp() + (${input.ttlMs} * interval '1 millisecond'))
         RETURNING (extract(epoch FROM expires_at) * 1000)::bigint AS expires_at_ms
       `);
-      return { acquired: true, expiresAtMs: epochMs(resultRows<TimestampRow>(inserted)[0]) };
+      return {
+        acquired: true,
+        expiresAtMs: epochMs(resultRows<TimestampRow>(inserted)[0]),
+        reclaimedCount,
+      };
     });
   }
 

--- a/packages/core/src/store/postgres/concurrency-leases.ts
+++ b/packages/core/src/store/postgres/concurrency-leases.ts
@@ -1,0 +1,93 @@
+import { sql } from "drizzle-orm";
+import type { ConcurrencyLeaseStore } from "../ports.js";
+import type { PgDb } from "./migrate.js";
+
+interface TimestampRow {
+  expires_at_ms: number | string;
+}
+
+function epochMs(row: TimestampRow | undefined): number {
+  return Number(row?.expires_at_ms ?? 0);
+}
+
+// Cluster-wide lease adapter. All expiry comparisons and timestamps execute in
+// PostgreSQL; no replica wall clock participates in correctness decisions.
+export class PgConcurrencyLeaseStore implements ConcurrencyLeaseStore {
+  constructor(private readonly db: PgDb) {}
+
+  async tryAcquire(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    limit: number;
+    ttlMs: number;
+  }): Promise<{ acquired: boolean; expiresAtMs: number }> {
+    return this.db.transaction(async (tx) => {
+      await tx.execute(sql`
+        INSERT INTO api_key_concurrency_state (key_id) VALUES (${input.keyId})
+        ON CONFLICT (key_id) DO NOTHING
+      `);
+      await tx.execute(sql`
+        SELECT key_id FROM api_key_concurrency_state
+        WHERE key_id = ${input.keyId} FOR UPDATE
+      `);
+      await tx.execute(sql`
+        DELETE FROM api_key_concurrency_leases
+        WHERE key_id = ${input.keyId} AND expires_at <= clock_timestamp()
+      `);
+      const active = await tx.execute(sql`
+        SELECT count(*)::integer AS count
+        FROM api_key_concurrency_leases
+        WHERE key_id = ${input.keyId} AND expires_at > clock_timestamp()
+      `);
+      const rows = resultRows<{ count: number | string }>(active);
+      if (Number(rows[0]?.count ?? 0) >= input.limit) {
+        const now = await tx.execute(
+          sql`SELECT (extract(epoch FROM clock_timestamp()) * 1000)::bigint AS expires_at_ms`,
+        );
+        return { acquired: false, expiresAtMs: epochMs(resultRows<TimestampRow>(now)[0]) };
+      }
+      const inserted = await tx.execute(sql`
+        INSERT INTO api_key_concurrency_leases (lease_id, key_id, owner_id, expires_at)
+        VALUES (${input.leaseId}, ${input.keyId}, ${input.ownerId}, clock_timestamp() + (${input.ttlMs} * interval '1 millisecond'))
+        RETURNING (extract(epoch FROM expires_at) * 1000)::bigint AS expires_at_ms
+      `);
+      return { acquired: true, expiresAtMs: epochMs(resultRows<TimestampRow>(inserted)[0]) };
+    });
+  }
+
+  async renew(input: {
+    keyId: string;
+    leaseId: string;
+    ownerId: string;
+    ttlMs: number;
+  }): Promise<{ renewed: boolean; expiresAtMs: number }> {
+    const result = await this.db.execute(sql`
+      UPDATE api_key_concurrency_leases
+         SET heartbeat_at = clock_timestamp(),
+             expires_at = clock_timestamp() + (${input.ttlMs} * interval '1 millisecond')
+       WHERE key_id = ${input.keyId}
+         AND lease_id = ${input.leaseId}
+         AND owner_id = ${input.ownerId}
+         AND expires_at > clock_timestamp()
+      RETURNING (extract(epoch FROM expires_at) * 1000)::bigint AS expires_at_ms
+    `);
+    const row = resultRows<TimestampRow>(result)[0];
+    return { renewed: row !== undefined, expiresAtMs: epochMs(row) };
+  }
+
+  async release(input: { keyId: string; leaseId: string; ownerId: string }): Promise<void> {
+    await this.db.execute(sql`
+      DELETE FROM api_key_concurrency_leases
+      WHERE key_id = ${input.keyId}
+        AND lease_id = ${input.leaseId}
+        AND owner_id = ${input.ownerId}
+    `);
+  }
+}
+
+function resultRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const maybe = result as { rows?: T[] };
+  return Array.isArray(maybe.rows) ? maybe.rows : [];
+}

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1148,6 +1148,27 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // PostgreSQL-only cluster-wide API-key concurrency leases. Expiry timestamps
+    // deliberately use timestamptz and are evaluated with the database clock.
+    // No FK: key deletion must not block lease expiry/reclamation.
+    version: 41,
+    sql: `
+      CREATE TABLE IF NOT EXISTS api_key_concurrency_state (
+        key_id TEXT PRIMARY KEY
+      );
+      CREATE TABLE IF NOT EXISTS api_key_concurrency_leases (
+        lease_id TEXT PRIMARY KEY,
+        key_id TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        expires_at TIMESTAMPTZ NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_api_key_concurrency_leases_key_expires
+        ON api_key_concurrency_leases (key_id, expires_at);
+    `,
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
             // `$lib`/`$app` aliases, no .svelte imports) run in the node project.
             "apps/portal/src/lib/**/*.test.ts",
           ],
+          exclude: [
+            "**/node_modules/**",
+            "**/dist/**",
+            "packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts",
+          ],
           // The postgres store suite opens an in-process PGlite (WASM Postgres)
           // per test. Under a full parallel run, many WASM cold-starts contend for
           // CPU and the default 5s ceiling is occasionally exceeded — a load flake,


### PR DESCRIPTION
## 改了什么

- 保留 Retry 1 已关闭的 PostgreSQL row-lock/DB-clock、clock skew、`maxQueue`、五事件、real-PG/SIGKILL/迁移等能力；Retry 2 只关闭 started-stream 持久化分类与 AC 证据两项 blocker。
- Chat、Messages、Responses、Gemini production route/pipeline 统一复用 exact reason-aware cancellation；`concurrency_lease_lost` 的 wire 保持截断、不伪造正常 terminal，持久化统一为 `error/truncated/concurrency_lease_lost`。
- true client disconnect 继续为 `client_aborted/client_abort`，request timeout 继续为 `failed/timeout`；lease loss 仍不 fallback、不计 provider failure/cooldown。
- 新增四协议真实 PostgreSQL production-route 回归：都经过 route registration + production `createExecute` / `createMessagesPipeline` + telemetry persistence，逐项断言 wire / decision / fallback-breaker 三组结果。
- PR body 已改为存在的 exact test names，并统一采用 exact-head CI 的 `385 files / 6414 tests / 0 skip`、dedicated real-PG `2/2`、Playwright `89/89`。

## 为什么改

Trent 在 exact head `51088888a58fd191ba46005af991bf8872cd04e7` 的 [Retry 1 NEEDS WORK review](https://github.com/EasyMetaAu/helm-api/pull/627#pullrequestreview-4768050340) 确认旧五组主体已关闭，但指出两项剩余 blocker：四协议 started-stream lease loss 仍被持久化为 success/client abort；PR body 引用了不存在的测试名并写错 full-gate 文件数。Retry 2 只关闭这两项，不实现 non-blocking suggestions，不扩 scope。

- Task Spec revision 2：Helm API 单租户 API key 底层系统改造（Phase 1：分布式并发租约）
- exact base：`6ab6981440aaf5b0d03698a96c3a6c7bad8455a1`
- Retry 2 head：`262bef4865d62c8aca6699db647586f0c3e71a61`
- 新 CI：[run #30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)

## Acceptance Criteria（Task Spec revision 2 一对一）

- [x] **基线一致**：实现仍基于 exact base `6ab6981440...`，Retry 2 head 为 `262bef48...`，未冒充更新基线 — 验收：`packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts::bases expiry on statement time after waiting for a row lock across two pools` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **PostgreSQL 全局上限**：两个独立 replica/pool、同 key limit=1、100 并发时 `max_active=1` — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::enforces one global slot across two replicas and 100 concurrent requests` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **key 隔离**：key A limit=1 不阻塞 key B — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::does not let key A limit=1 block key B` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **原子竞争**：两个 replica 同时空表 acquire 只有一个成功，仍为单事务 row-lock — 验收：`packages/core/src/store/postgres/concurrency-leases.test.ts::atomically admits no more than limit concurrent leases` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **DB clock / Node ±5min skew**：acquire/renew 不立即误 abort，且本地不超过保守 TTL — 验收：`packages/core/src/queue/distributed-keyed-semaphore.test.ts::uses a monotonic local TTL after acquire with Node wall-clock skew`、`packages/core/src/queue/distributed-keyed-semaphore.test.ts::uses a monotonic local TTL after renew with Node wall-clock skew`、`packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts::bases expiry on statement time after waiting for a row lock across two pools` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **crash recovery**：child replica 实持 lease 后收到 `SIGKILL`，无需人工清表，TTL+5s 内恢复 — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::recovers capacity after a child replica holding the lease is SIGKILLed` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **heartbeat**：请求超过 2×TTL 仍只占一个有效 lease，不超发 — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::heartbeats a request beyond two TTLs without oversubscribing` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **lease loss**：Chat/Messages/Responses/Gemini started-stream wire 截断；即使全局 timeout 在 lease loss 之后、持久化之前到点，仍保留 `error/truncated/concurrency_lease_lost`，failure/cooldown/fallback=0 — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::preserves Chat lease loss when timeout follows lease loss before independent persistence`、`apps/gateway/e2e/concurrency-postgres.spec.ts::preserves Messages lease loss when timeout follows lease loss before shared persistence`、`apps/gateway/e2e/concurrency-postgres.spec.ts::preserves Responses lease loss when timeout follows lease loss before shared persistence`、`apps/gateway/e2e/concurrency-postgres.spec.ts::preserves Gemini lease loss when timeout follows lease loss before shared persistence` + CI [#30057349009](https://github.com/EasyMetaAu/helm-api/actions/runs/30057349009)。
- [x] **stream 生命周期**：slot 持有到 final event/client cancel，Response 返回时不提前释放 — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::holds a streaming slot until the final event and reader cancel` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **全出口释放**：真实 PG provider error/request timeout/client abort/stream error 后均可立刻以 limit=1 reacquire，残留 0；重复 release 幂等 — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::leaves zero real-PG leases after provider error timeout client abort and stream error`、`packages/core/src/queue/distributed-keyed-semaphore.test.ts::makes async release idempotent and shutdown best-effort releases every holder` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **DB 不可用**：provider 调用 0、OpenAI-shaped 503、无 local fallback — 验收：`apps/gateway/e2e/concurrency-postgres.spec.ts::fails closed with protocol 503 and zero provider calls when the DB is unavailable` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **limit 动态降低**：5→1 不强杀已持有 lease，新 acquire 在 active<1 前失败 — 验收：`packages/core/src/store/postgres/concurrency-leases.test.ts::honors a lowered limit without revoking existing holders and isolates keys` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **queue 语义**：per-replica FIFO/timeout/abort 保持；`maxQueue=0` 一次 probe 后 queue_full；`maxQueue=1` 第二 waiter 合法、第三才 full — 验收：`packages/core/src/queue/distributed-keyed-semaphore.test.ts::lets maxQueue=0 perform one immediate probe without continuous polling`、`packages/core/src/queue/distributed-keyed-semaphore.test.ts::counts one polling head separately from maxQueue=1 FIFO waiters`、`packages/core/src/queue/distributed-keyed-semaphore.test.ts::keeps a per-replica FIFO and lets only its queue head poll the database` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **SQLite 回归**：factory 精确返回 `concurrencyLeases === null`，既有 local semaphore 行为保持 — 验收：`packages/core/src/store/factory.test.ts::selects the sqlite adapter set for driver=sqlite (default)`、`packages/core/src/queue/distributed-keyed-semaphore.test.ts::does not touch the lease store when disabled by an unlimited limit` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **migration**：新库/重复 migration 成功；真实 PostgreSQL v40 seed→v41 后 api_keys/telemetry/rate/budget 数据保留 — 验收：`packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts::migrates an old v40 seed to v41 without losing api key telemetry rate or budget data` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **安全 / 可观测性**：五个精确 event、字段仅 whitelist，无 plaintext key/hash/secret_enc/Authorization/prompt/response 泄漏 — 验收：`packages/core/src/queue/distributed-keyed-semaphore.test.ts::emits the exact lease event contract with whitelisted secret-safe fields` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)。
- [x] **全量门禁**：generic Vitest 385 files / 6414 tests / 0 skip；dedicated real-PG Vitest 2/2 + Playwright 89/89 均由 hermetic harness 强制执行 — 验收：`packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts::bases expiry on statement time after waiting for a row lock across two pools` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668) 的 `verify/e2e/docker`。
- [x] **PR scope**：无 tenant/RBAC/billing、rotation grace、Embeddings、usage export、evidence binary、新 workflow — 验收：`packages/core/src/store/factory.test.ts::selects the sqlite adapter set for driver=sqlite (default)` + CI [#30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)；`git diff --check`、binary/workflow diff 均为空。

## Retry 2 RED → GREEN 证据

1. **started-stream persistence RED**：四协议 production route 都已到达 provider、转发首 chunk、删除真实 PG lease、wire 无正常 terminal、`fallback_count=0`、breaker `CLOSED`；但 Chat/Messages/Gemini `final.status=ok`，Responses `stream_outcome=client_aborted/error_reason=client_abort`。**GREEN**：上述四个 exact production-route tests `4/4`，统一持久化 `error/truncated/concurrency_lease_lost`，每例单 provider call/attempt、failure=0、cooldown=0、fallback=0。
2. **AC evidence RED**：AC #4/#12/#14/#18 引用了不存在的测试名；PR body 两处误写 `386 files`。**GREEN**：改为实际存在的 `atomically admits no more than limit concurrent leases`、`honors a lowered limit without revoking existing holders and isolates keys`、`selects the sqlite adapter set for driver=sqlite (default)`；exact-head CI 为 `385 files / 6414 tests / 0 skip`。
3. **旧五组 blocker**：clock skew、`maxQueue`、pre-response classification、observability、real-PG/SIGKILL/migration 均保持 CLOSED；本 Retry 未实现 suggestions、未扩 scope。

## 验证证据

- `pnpm test`：385 files / 6414 tests，0 skip。
- `pnpm typecheck`：GREEN。
- `pnpm lint`：exit 0（仅仓库既有 `packages/shared/src/ci-workflow.test.ts` 37 个 `noTemplateCurlyInString` warnings）。
- `pnpm build`：GREEN。
- `PG_TEST_URL=... pnpm test:e2e`：dedicated real-PG Vitest 2/2 + Playwright 89/89 GREEN；四协议 production-route persistence 4/4。
- real-PG：100 requests / `max_active=1`；child `SIGKILL` recovery 347ms（TTL 250ms）；exit matrix residual=0；production lease-loss failure/cooldown/fallback=0。
- `git diff --check`：GREEN；evidence binary / `.github/workflows` diff：空。
- CI：[run #30048727668](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668)；[verify](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668/job/89345826187)、[e2e](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668/job/89345826174)、[docker](https://github.com/EasyMetaAu/helm-api/actions/runs/30048727668/job/89345826164) 全绿。

## Migration 与回滚

- migration v41 仍是 additive/idempotent；`DELETE ... RETURNING` 仅把同事务过期回收数返回 manager，不削弱 state-row lock/DB-clock 不变量。
- 回滚代码时保留 `api_key_concurrency_state` / `api_key_concurrency_leases`，不做 destructive down migration。
- 多副本 PostgreSQL 不可静默回退 process-local gate；生产回滚/部署必须另走 Human Gate。本 Retry 未部署、未写生产 DB。

## 风险点

- **DB 可用性**：acquire unavailable 继续 provider 前 503 fail-closed。
- **TTL / skew**：DB clock 是存储真相源；Node 只用 monotonic local conservative bound。
- **queue**：每 replica FIFO，跨 replica 仍仅 best-effort fairness。
- **stream**：started stream lease loss 终止且记录 structured reason，不伪造正常 terminal event。
- **日志**：capacity contention 会产生 safe structured acquire-failed event；字段严格 whitelist。

## 人类 review 关注点

请 Trent 对 exact head `262bef4865d62c8aca6699db647586f0c3e71a61` focused re-review：

1. Chat/Messages/Responses/Gemini 的 exact cancellation reason 是否都在 route/pipeline persistence 前保留；
2. `concurrency_lease_lost` 是否始终 wire 截断、无正常 terminal，且 decision 为 `error/truncated/exact reason`；
3. true client abort/request timeout 是否继续保持原分类，lease loss 是否无 fallback/provider failure/cooldown；
4. AC #4/#8/#12/#14/#17/#18 的 test names、385/6414/0 与 Playwright 89/89 是否和 exact-head CI 一致。

## 合并策略

- [ ] 开发阶段可自合
- [x] 需要 Human Gate
- [x] 需要生产部署确认

原因：包含 DB migration 与 auth/request admission 核心路径。禁止自行 merge/deploy/生产 DB 写。

Wiki delta: none（仓库 docs 既有 Phase 1 说明仍有效）。


