### PR TITLE
[codex] release v0.28.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API to v0.28.7 for the WebSocket ingress accounting fix merged in #628.

## Release assessment

Patch release: runtime behavior is corrected without configuration, schema, API, capture, cleanup, or dependency changes.

## Expected publish result

After CI and merge, the existing Publish image workflow must build the exact merge SHA, publish immutable and v0.28.7 tags, create the GitHub Release, and promote latest from the verified digest.