### PR TITLE
[codex] Proxy Realtime voice and missing multimodal APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,10 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
+| `POST /v1/realtime/calls` · `POST /v1/live` | OpenAI Realtime Voice (V1/V2 · V3) | ✅ WebRTC + WebSocket sideband |
 | `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅ (via `:streamGenerateContent`; auth via `x-goog-api-key`) |
 | `POST /v1/images/generations` | OpenAI Images API ([image generation](#image-generation)) | — (image model/lane, any key) |
+| `POST /v1/images/edits` | OpenAI Images API (JSON or multipart edits) | — (image model/lane, any key) |
 | `POST /v1beta/interactions` | Gemini Interactions API ([image generation](#image-generation)) | — (image model/lane, any key) |
 
 **What to put in `model`:**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,8 +225,10 @@ curl http://localhost:8080/v1/chat/completions \
 | `POST /v1/chat/completions` | OpenAI Chat Completions | ✅ |
 | `POST /v1/messages` | Anthropic Messages | ✅ |
 | `POST /v1/responses` | OpenAI Responses | ✅ |
+| `POST /v1/realtime/calls` · `POST /v1/live` | OpenAI Realtime Voice（V1/V2 · V3） | ✅ WebRTC + WebSocket sideband |
 | `POST /v1beta/models/{model}:generateContent` | Google Gemini | ✅（走 `:streamGenerateContent`；用 `x-goog-api-key` 鉴权） |
 | `POST /v1/images/generations` | OpenAI Images API（[图片生成](#图片生成)） | —（图片模型/lane，任意 key 可用） |
+| `POST /v1/images/edits` | OpenAI Images API（JSON 或 multipart 编辑） | —（图片模型/lane，任意 key 可用） |
 | `POST /v1beta/interactions` | Gemini Interactions API（[图片生成](#图片生成)） | —（图片模型/lane，任意 key 可用） |
 
 **如何填写 `model`：**

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -3,12 +3,20 @@
 // non-zero rather than starting in a degraded state.
 
 import { readFile } from "node:fs/promises";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
 import { loadConfig } from "@helm/core";
 import { serve } from "@hono/node-server";
 import { createApp } from "./app.js";
 import { createJsonLogger } from "./logging.js";
 import {
+  installRealtimeWebSocketBridge,
+  isRealtimeWebSocketPath,
+  type RealtimeWebSocketBridge,
+} from "./realtime-websocket.js";
+import {
   installResponsesWebSocketBridge,
+  isResponsesWebSocketPath,
   type ResponsesWebSocketBridge,
 } from "./responses-websocket.js";
 import { configureEgress } from "./runtime/egress.js";
@@ -33,6 +41,12 @@ export {
   type RateLimitMiddlewareDeps,
   rateLimitMiddleware,
 } from "./middleware/rate-limit.js";
+export {
+  installRealtimeWebSocketBridge,
+  isRealtimeWebSocketPath,
+  type RealtimeWebSocketBridge,
+  type RealtimeWebSocketBridgeOptions,
+} from "./realtime-websocket.js";
 export {
   installResponsesWebSocketBridge,
   isResponsesWebSocketPath,
@@ -79,17 +93,37 @@ async function main(): Promise<void> {
 
     let handle: ServerHandle;
     let responsesWebSocket: ResponsesWebSocketBridge | undefined;
+    let realtimeWebSocket: RealtimeWebSocketBridge | undefined;
     let server: ReturnType<typeof serve> | undefined;
+    let rejectUnknownUpgrade: ((request: IncomingMessage, socket: Duplex) => void) | undefined;
 
-    const attachResponsesWebSocket = (next: ServerHandle): void => {
-      if (!server || responsesWebSocket) return;
-      responsesWebSocket = installResponsesWebSocketBridge({
-        server,
-        fetch: (request) => handle.app.fetch(request),
-        closeSession: next.closeResponsesWebSocketSession,
-        sessionProof: next.responsesWebSocketSessionProof,
-        memoryAdmission: next.responsesMemoryAdmission,
-      });
+    const attachWebSockets = (next: ServerHandle): void => {
+      if (!server) return;
+      if (!responsesWebSocket) {
+        responsesWebSocket = installResponsesWebSocketBridge({
+          server,
+          fetch: (request) => handle.app.fetch(request),
+          closeSession: next.closeResponsesWebSocketSession,
+          sessionProof: next.responsesWebSocketSessionProof,
+          memoryAdmission: next.responsesMemoryAdmission,
+        });
+      }
+      if (!realtimeWebSocket && next.realtimeCallRegistry && next.resolveRealtimeKey) {
+        realtimeWebSocket = installRealtimeWebSocketBridge({
+          server,
+          registry: next.realtimeCallRegistry,
+          resolveKey: next.resolveRealtimeKey,
+          memoryAdmission: next.responsesMemoryAdmission,
+        });
+      }
+      if (!rejectUnknownUpgrade) {
+        rejectUnknownUpgrade = (request, socket) => {
+          if (!isResponsesWebSocketPath(request.url) && !isRealtimeWebSocketPath(request.url)) {
+            socket.destroy();
+          }
+        };
+        server.on("upgrade", rejectUnknownUpgrade);
+      }
     };
 
     if (setupRequired(process.env)) {
@@ -123,7 +157,7 @@ async function main(): Promise<void> {
         buildFullServer: () => buildServer({ logger }),
         activate: (next) => {
           handle = next;
-          attachResponsesWebSocket(next);
+          attachWebSockets(next);
           logger.log("info", "gateway.setup_completed", { host: next.host, port: next.port });
         },
         readRootKey: async () => {
@@ -145,7 +179,7 @@ async function main(): Promise<void> {
       port: handle.port,
       hostname: handle.host,
     });
-    if (!setupRequired(process.env)) attachResponsesWebSocket(handle);
+    if (!setupRequired(process.env)) attachWebSockets(handle);
     logger.log("info", "gateway.listening", {
       host: handle.host,
       port: handle.port,
@@ -167,6 +201,8 @@ async function main(): Promise<void> {
       logger.log("info", "gateway.shutdown", { signal });
       try {
         await responsesWebSocket?.close();
+        await realtimeWebSocket?.close();
+        if (rejectUnknownUpgrade) server?.off("upgrade", rejectUnknownUpgrade);
         await closeServer(server as unknown as ClosableServer, drainMs);
         await handle.dispose?.();
       } catch (err) {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -106,6 +106,7 @@ async function main(): Promise<void> {
           closeSession: next.closeResponsesWebSocketSession,
           sessionProof: next.responsesWebSocketSessionProof,
           memoryAdmission: next.responsesMemoryAdmission,
+          ingressAdmission: next.websocketIngressAdmission,
         });
       }
       if (!realtimeWebSocket && next.realtimeCallRegistry && next.resolveRealtimeKey) {
@@ -113,7 +114,7 @@ async function main(): Promise<void> {
           server,
           registry: next.realtimeCallRegistry,
           resolveKey: next.resolveRealtimeKey,
-          memoryAdmission: next.responsesMemoryAdmission,
+          memoryAdmission: next.websocketIngressAdmission,
         });
       }
       if (!rejectUnknownUpgrade) {

--- a/apps/gateway/src/realtime-call-registry.test.ts
+++ b/apps/gateway/src/realtime-call-registry.test.ts
@@ -1,0 +1,29 @@
+import type { RealtimeSidebandTarget } from "@helm/core";
+import { describe, expect, it } from "vitest";
+import { createRealtimeCallRegistry } from "./realtime-call-registry.js";
+
+const TARGET: RealtimeSidebandTarget = {
+  url: "wss://upstream.test/v1/realtime?call_id=rtc_1",
+  headers: async () => ({ Authorization: "Bearer upstream" }),
+};
+
+describe("createRealtimeCallRegistry", () => {
+  it("binds a call to the Helm key that created it and consumes it once", () => {
+    const registry = createRealtimeCallRegistry({ ttlMs: 1_000, now: () => 10 });
+    registry.put("rtc_1", "key-a", TARGET);
+
+    expect(registry.take("rtc_1", "key-b")).toEqual({ ok: false, reason: "not_found" });
+    expect(registry.take("rtc_1", "key-a")).toEqual({ ok: true, target: TARGET });
+    expect(registry.take("rtc_1", "key-a")).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  it("expires abandoned calls lazily", () => {
+    let now = 10;
+    const registry = createRealtimeCallRegistry({ ttlMs: 5, now: () => now });
+    registry.put("rtc_1", "key-a", TARGET);
+    now = 16;
+
+    expect(registry.take("rtc_1", "key-a")).toEqual({ ok: false, reason: "not_found" });
+    expect(registry.size).toBe(0);
+  });
+});

--- a/apps/gateway/src/realtime-call-registry.ts
+++ b/apps/gateway/src/realtime-call-registry.ts
@@ -1,0 +1,45 @@
+import type { RealtimeSidebandTarget } from "@helm/core";
+
+export interface RealtimeCallRegistry {
+  put(callId: string, keyId: string, target: RealtimeSidebandTarget): void;
+  take(
+    callId: string,
+    keyId: string,
+  ): { ok: true; target: RealtimeSidebandTarget } | { ok: false; reason: "not_found" };
+  readonly size: number;
+}
+
+export function createRealtimeCallRegistry(
+  options: { ttlMs?: number; now?: () => number } = {},
+): RealtimeCallRegistry {
+  // ponytail: process-local registry matches today's single gateway replica; use a
+  // shared atomic claim store before horizontally scaling Realtime ingress.
+  const ttlMs = options.ttlMs ?? 5 * 60_000;
+  const now = options.now ?? Date.now;
+  const calls = new Map<
+    string,
+    { keyId: string; target: RealtimeSidebandTarget; expiresAt: number }
+  >();
+  const prune = (nowMs: number) => {
+    for (const [callId, call] of calls) if (call.expiresAt <= nowMs) calls.delete(callId);
+  };
+
+  return {
+    put(callId, keyId, target) {
+      const nowMs = now();
+      prune(nowMs);
+      calls.set(callId, { keyId, target, expiresAt: nowMs + ttlMs });
+    },
+    take(callId, keyId) {
+      prune(now());
+      const call = calls.get(callId);
+      if (!call || call.keyId !== keyId) return { ok: false, reason: "not_found" };
+      calls.delete(callId);
+      return { ok: true, target: call.target };
+    },
+    get size() {
+      prune(now());
+      return calls.size;
+    },
+  };
+}

--- a/apps/gateway/src/realtime-websocket.test.ts
+++ b/apps/gateway/src/realtime-websocket.test.ts
@@ -1,0 +1,158 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
+import { createRealtimeCallRegistry } from "./realtime-call-registry.js";
+import {
+  installRealtimeWebSocketBridge,
+  isRealtimeWebSocketPath,
+  type RealtimeWebSocketBridge,
+} from "./realtime-websocket.js";
+
+const closers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(closers.splice(0).map((close) => close()));
+});
+
+async function listeningServer() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("missing server address");
+  closers.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  return { server, port: address.port };
+}
+
+describe("Realtime websocket bridge", () => {
+  it.each(["/v1/realtime?call_id=rtc_1", "/v1/live/rtc_1"])("matches %s", (path) =>
+    expect(isRealtimeWebSocketPath(path)).toBe(true));
+
+  it("relays immediate upstream events plus text and binary frames", async () => {
+    const upstreamHttp = await listeningServer();
+    const upstream = new WebSocketServer({ server: upstreamHttp.server, perMessageDeflate: false });
+    upstream.on("connection", (socket) => {
+      socket.send('{"type":"session.started"}');
+      socket.on("message", (data, isBinary) => socket.send(data, { binary: isBinary }));
+    });
+    closers.push(
+      () =>
+        new Promise<void>((resolve) => {
+          for (const socket of upstream.clients) socket.terminate();
+          upstream.close(() => resolve());
+        }),
+    );
+
+    const gateway = await listeningServer();
+    const registry = createRealtimeCallRegistry();
+    registry.put("rtc_1", "key-1", {
+      url: `ws://127.0.0.1:${upstreamHttp.port}/v1/realtime?call_id=rtc_1`,
+      headers: async () => ({ Authorization: "Bearer upstream" }),
+    });
+    const bridge: RealtimeWebSocketBridge = installRealtimeWebSocketBridge({
+      server: gateway.server,
+      registry,
+      resolveKey: async (credential) => (credential === "helm-key" ? "key-1" : null),
+    });
+    closers.push(() => bridge.close());
+
+    const client = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/realtime?call_id=rtc_1`, {
+      headers: { Authorization: "Bearer helm-key" },
+    });
+    const firstMessage = once(client, "message");
+    await once(client, "open");
+    const [started] = (await firstMessage) as [WebSocket.RawData, boolean];
+    expect(started.toString()).toContain("session.started");
+
+    const textMessage = once(client, "message");
+    client.send("hello");
+    const [text] = (await textMessage) as [WebSocket.RawData, boolean];
+    expect(text.toString()).toBe("hello");
+    const binaryMessage = once(client, "message");
+    client.send(new Uint8Array([1, 2, 3]));
+    const [binary, isBinary] = (await binaryMessage) as [WebSocket.RawData, boolean];
+    expect(isBinary).toBe(true);
+    expect([...new Uint8Array(binary as Buffer)]).toEqual([1, 2, 3]);
+    const closed = once(client, "close");
+    client.close();
+    await closed;
+  });
+
+  it("rejects a call created by another Helm key", async () => {
+    const gateway = await listeningServer();
+    const registry = createRealtimeCallRegistry();
+    registry.put("rtc_1", "key-1", {
+      url: "ws://127.0.0.1:1/v1/realtime?call_id=rtc_1",
+      headers: async () => ({}),
+    });
+    const bridge = installRealtimeWebSocketBridge({
+      server: gateway.server,
+      registry,
+      resolveKey: async () => "key-2",
+    });
+    closers.push(() => bridge.close());
+    const client = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/realtime?call_id=rtc_1`, {
+      headers: { Authorization: "Bearer another-key" },
+    });
+    const [, response] = (await once(client, "unexpected-response")) as [
+      unknown,
+      { statusCode: number },
+    ];
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("refreshes OAuth once when the upstream sideband rejects with 401", async () => {
+    const upstreamHttp = await listeningServer();
+    const upstream = new WebSocketServer({ noServer: true, perMessageDeflate: false });
+    let upgrades = 0;
+    let refreshed = 0;
+    const authHeaders: Array<string | undefined> = [];
+    upstreamHttp.server.on("upgrade", (request, socket, head) => {
+      upgrades += 1;
+      authHeaders.push(request.headers.authorization);
+      if (upgrades === 1) {
+        socket.end("HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n");
+        return;
+      }
+      upstream.handleUpgrade(request, socket, head, (websocket) => {
+        websocket.send("ready");
+        upstream.emit("connection", websocket, request);
+      });
+    });
+    closers.push(
+      () =>
+        new Promise<void>((resolve) => {
+          for (const socket of upstream.clients) socket.terminate();
+          upstream.close(() => resolve());
+        }),
+    );
+
+    const gateway = await listeningServer();
+    const registry = createRealtimeCallRegistry();
+    registry.put("rtc_1", "key-1", {
+      url: `ws://127.0.0.1:${upstreamHttp.port}/v1/realtime?call_id=rtc_1`,
+      headers: async () => ({ Authorization: `Bearer token-${refreshed + 1}` }),
+      onUnauthorized: () => {
+        refreshed += 1;
+      },
+    });
+    const bridge = installRealtimeWebSocketBridge({
+      server: gateway.server,
+      registry,
+      resolveKey: async () => "key-1",
+    });
+    closers.push(() => bridge.close());
+
+    const client = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/realtime?call_id=rtc_1`, {
+      headers: { Authorization: "Bearer helm-key" },
+    });
+    const ready = once(client, "message");
+    await once(client, "open");
+    expect(((await ready) as [WebSocket.RawData])[0].toString()).toBe("ready");
+    expect(upgrades).toBe(2);
+    expect(refreshed).toBe(1);
+    expect(authHeaders).toEqual(["Bearer token-1", "Bearer token-2"]);
+    client.terminate();
+  });
+});

--- a/apps/gateway/src/realtime-websocket.test.ts
+++ b/apps/gateway/src/realtime-websocket.test.ts
@@ -1,5 +1,6 @@
 import { once } from "node:events";
 import { createServer } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import WebSocket, { WebSocketServer } from "ws";
 import { createRealtimeCallRegistry } from "./realtime-call-registry.js";
@@ -107,12 +108,19 @@ describe("Realtime websocket bridge", () => {
     const upstream = new WebSocketServer({ noServer: true, perMessageDeflate: false });
     let upgrades = 0;
     let refreshed = 0;
+    let rejectedSocketEnded = Promise.resolve(false);
     const authHeaders: Array<string | undefined> = [];
     upstreamHttp.server.on("upgrade", (request, socket, head) => {
       upgrades += 1;
       authHeaders.push(request.headers.authorization);
       if (upgrades === 1) {
-        socket.end("HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n");
+        rejectedSocketEnded = once(socket, "end").then(() => true);
+        closers.push(async () => {
+          socket.destroy();
+        });
+        socket.write(
+          "HTTP/1.1 401 Unauthorized\r\nConnection: keep-alive\r\nContent-Length: 0\r\n\r\n",
+        );
         return;
       }
       upstream.handleUpgrade(request, socket, head, (websocket) => {
@@ -154,5 +162,6 @@ describe("Realtime websocket bridge", () => {
     expect(refreshed).toBe(1);
     expect(authHeaders).toEqual(["Bearer token-1", "Bearer token-2"]);
     client.terminate();
+    expect(await Promise.race([rejectedSocketEnded, delay(500, false)])).toBe(true);
   });
 });

--- a/apps/gateway/src/realtime-websocket.ts
+++ b/apps/gateway/src/realtime-websocket.ts
@@ -1,0 +1,257 @@
+import { type IncomingMessage, STATUS_CODES } from "node:http";
+import type { Duplex } from "node:stream";
+import { type RealtimeSidebandTarget, runtimeMemoryBudget } from "@helm/core";
+import WebSocket, { WebSocketServer } from "ws";
+import { codexWebSocketAgent } from "./codex-responses-websocket.js";
+import type { RealtimeCallRegistry } from "./realtime-call-registry.js";
+import { type BodyMemoryAdmission, createBodyMemoryAdmission } from "./runtime/memory-admission.js";
+
+export interface RealtimeWebSocketBridge {
+  close(): Promise<void>;
+}
+
+export interface RealtimeWebSocketUpgradeServer {
+  on(event: "upgrade", listener: UpgradeListener): unknown;
+  off(event: "upgrade", listener: UpgradeListener): unknown;
+}
+
+type UpgradeListener = (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
+
+export interface RealtimeWebSocketBridgeOptions {
+  server: RealtimeWebSocketUpgradeServer;
+  registry: RealtimeCallRegistry;
+  resolveKey(credential: string | null): Promise<string | null>;
+  memoryAdmission?: BodyMemoryAdmission;
+}
+
+interface PendingUpstream {
+  socket: WebSocket;
+  pending: Array<{ data: WebSocket.RawData; isBinary: boolean }>;
+  stopQueue(): void;
+}
+
+class UpstreamUpgradeError extends Error {
+  constructor(readonly status: number) {
+    super(`realtime upstream websocket rejected the upgrade (${status})`);
+  }
+}
+
+function callIdFromUrl(raw: string | undefined): string | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw, "http://helm.internal");
+    if (url.pathname === "/v1/realtime") return url.searchParams.get("call_id");
+    const live = /^\/v1\/live\/([^/]+)$/.exec(url.pathname);
+    return live ? decodeURIComponent(live[1] ?? "") : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isRealtimeWebSocketPath(raw: string | undefined): boolean {
+  return callIdFromUrl(raw) !== null;
+}
+
+function bearer(request: IncomingMessage): string | null {
+  const raw = request.headers.authorization;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value ? (/^Bearer\s+(.+)$/.exec(value)?.[1] ?? null) : null;
+}
+
+async function rejectUpgrade(socket: Duplex, status: number, message: string): Promise<void> {
+  const body = JSON.stringify({ error: { type: "invalid_request_error", message } });
+  const response = [
+    `HTTP/1.1 ${status} ${STATUS_CODES[status] ?? "Error"}`,
+    "Connection: close",
+    "Content-Type: application/json",
+    `Content-Length: ${Buffer.byteLength(body)}`,
+    "",
+    body,
+  ].join("\r\n");
+  await new Promise<void>((resolve) => socket.end(response, resolve));
+}
+
+function rawBytes(data: WebSocket.RawData): number {
+  return Array.isArray(data)
+    ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
+    : data.byteLength;
+}
+
+function forwardedCloseCode(code: number): number {
+  return code === 1000 ||
+    (code >= 1001 && code <= 1014 && ![1004, 1005, 1006].includes(code)) ||
+    (code >= 3000 && code <= 4999)
+    ? code
+    : 1000;
+}
+
+async function openUpstream(
+  target: RealtimeSidebandTarget,
+  maxPayload: number,
+): Promise<PendingUpstream> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const headers = await target.headers();
+      return await new Promise<PendingUpstream>((resolve, reject) => {
+        const pending: PendingUpstream["pending"] = [];
+        let pendingBytes = 0;
+        const socket = new WebSocket(target.url, {
+          headers,
+          agent: codexWebSocketAgent(target.proxy),
+          perMessageDeflate: false,
+          maxPayload,
+          handshakeTimeout: 60_000,
+        });
+        const queue = (data: WebSocket.RawData, isBinary: boolean) => {
+          pendingBytes += rawBytes(data);
+          if (pendingBytes > maxPayload) {
+            socket.close(1009, "pending response too large");
+            return;
+          }
+          pending.push({ data, isBinary });
+        };
+        socket.on("message", queue);
+        socket.once("open", () =>
+          resolve({
+            socket,
+            pending,
+            stopQueue: () => socket.off("message", queue),
+          }),
+        );
+        socket.once("unexpected-response", (_request, response) => {
+          response.resume();
+          reject(new UpstreamUpgradeError(response.statusCode ?? 502));
+        });
+        socket.once("error", reject);
+      });
+    } catch (cause) {
+      if (
+        attempt === 0 &&
+        cause instanceof UpstreamUpgradeError &&
+        cause.status === 401 &&
+        target.onUnauthorized
+      ) {
+        target.onUnauthorized();
+        continue;
+      }
+      throw cause;
+    }
+  }
+}
+
+export function installRealtimeWebSocketBridge(
+  options: RealtimeWebSocketBridgeOptions,
+): RealtimeWebSocketBridge {
+  const memoryBudget = runtimeMemoryBudget();
+  const admission =
+    options.memoryAdmission ??
+    createBodyMemoryAdmission({
+      activeRequestBytes: memoryBudget.websocketIngressBytes,
+      maxWireBytes: memoryBudget.websocketMaxPayloadBytes,
+      jsonAmplification: 1,
+      minRequestChargeBytes: 1,
+    });
+  const websocketServer = new WebSocketServer({
+    noServer: true,
+    perMessageDeflate: false,
+    maxPayload: admission.maxWireBytes,
+  });
+  const upstreams = new Set<WebSocket>();
+  let closed = false;
+
+  const bind = (client: WebSocket, pending: PendingUpstream) => {
+    const upstream = pending.socket;
+    pending.stopQueue();
+    upstreams.add(upstream);
+    let closing = false;
+    const closeBoth = (code: number, reason: string) => {
+      if (closing) return;
+      closing = true;
+      const forwardedCode = forwardedCloseCode(code);
+      if (client.readyState === WebSocket.OPEN) client.close(forwardedCode, reason);
+      else if (client.readyState !== WebSocket.CLOSED) client.terminate();
+      if (upstream.readyState === WebSocket.OPEN) upstream.close(forwardedCode, reason);
+      else if (upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
+    };
+    const relay = (destination: WebSocket, data: WebSocket.RawData, isBinary: boolean) => {
+      const acquired = admission.acquire(rawBytes(data));
+      if (!acquired.ok) {
+        closeBoth(
+          acquired.reason === "too_large" ? 1009 : 1013,
+          "realtime frame capacity exceeded",
+        );
+        return;
+      }
+      if (destination.readyState !== WebSocket.OPEN) {
+        acquired.lease.release();
+        closeBoth(1011, "realtime peer closed");
+        return;
+      }
+      destination.send(data, { binary: isBinary }, (error) => {
+        acquired.lease.release();
+        if (error) closeBoth(1011, "realtime relay failed");
+      });
+    };
+    client.on("message", (data, isBinary) => relay(upstream, data, isBinary));
+    upstream.on("message", (data, isBinary) => relay(client, data, isBinary));
+    client.on("close", (code, reason) => closeBoth(code, reason.toString()));
+    upstream.on("close", (code, reason) => closeBoth(code, reason.toString()));
+    client.on("error", () => closeBoth(1011, "realtime client error"));
+    upstream.on("error", () => closeBoth(1011, "realtime upstream error"));
+    upstream.on("close", () => upstreams.delete(upstream));
+    for (const frame of pending.pending) relay(client, frame.data, frame.isBinary);
+  };
+
+  const onUpgrade: UpgradeListener = (request, socket, head) => {
+    const callId = callIdFromUrl(request.url);
+    if (callId === null) return;
+    const onSocketError = () => socket.destroy();
+    socket.on("error", onSocketError);
+    void (async () => {
+      const keyId = await options.resolveKey(bearer(request));
+      if (!keyId) {
+        await rejectUpgrade(socket, 401, "missing or invalid API key");
+        return;
+      }
+      const call = options.registry.take(callId, keyId);
+      if (!call.ok) {
+        await rejectUpgrade(socket, 404, "realtime call not found");
+        return;
+      }
+      let upstream: PendingUpstream;
+      try {
+        upstream = await openUpstream(call.target, admission.maxWireBytes);
+      } catch (cause) {
+        options.registry.put(callId, keyId, call.target);
+        throw cause;
+      }
+      if (closed || socket.destroyed) {
+        upstream.socket.terminate();
+        options.registry.put(callId, keyId, call.target);
+        return;
+      }
+      websocketServer.handleUpgrade(request, socket, head, (client) => {
+        websocketServer.emit("connection", client, request);
+        bind(client, upstream);
+      });
+    })()
+      .catch(async (cause: unknown) => {
+        if (socket.destroyed) return;
+        const message = cause instanceof Error ? cause.message : "realtime websocket failed";
+        await rejectUpgrade(socket, 502, message).catch(() => socket.destroy());
+      })
+      .finally(() => socket.off("error", onSocketError));
+  };
+  options.server.on("upgrade", onUpgrade);
+
+  return {
+    async close() {
+      if (closed) return;
+      closed = true;
+      options.server.off("upgrade", onUpgrade);
+      for (const socket of websocketServer.clients) socket.terminate();
+      for (const socket of upstreams) socket.terminate();
+      await new Promise<void>((resolve) => websocketServer.close(() => resolve()));
+    },
+  };
+}

--- a/apps/gateway/src/realtime-websocket.ts
+++ b/apps/gateway/src/realtime-websocket.ts
@@ -118,8 +118,9 @@ async function openUpstream(
             stopQueue: () => socket.off("message", queue),
           }),
         );
-        socket.once("unexpected-response", (_request, response) => {
+        socket.once("unexpected-response", (request, response) => {
           response.resume();
+          request.socket?.destroy();
           reject(new UpstreamUpgradeError(response.statusCode ?? 502));
         });
         socket.once("error", reject);

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -558,10 +558,7 @@ export function installResponsesWebSocketBridge({
   });
 
   const onUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
-    if (!isResponsesWebSocketPath(request.url)) {
-      socket.destroy();
-      return;
-    }
+    if (!isResponsesWebSocketPath(request.url)) return;
     const ingressLease = ingress.acquire(0);
     if (!ingressLease.ok) {
       const error = new RequestAdmissionError(

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -38,7 +38,8 @@ const BUDGET_CAPS = {
 
 function setup(over: Partial<ImagesRouteDeps> = {}) {
   const imageGeneration = vi.fn().mockResolvedValue(UPSTREAM);
-  const client = { imageGeneration } as unknown as ProviderClient;
+  const imageEdit = vi.fn().mockResolvedValue(UPSTREAM);
+  const client = { imageGeneration, imageEdit } as unknown as ProviderClient;
   const enqueuePayload = vi.fn();
   const enqueueTelemetry = vi.fn();
   const record = {
@@ -80,7 +81,7 @@ function setup(over: Partial<ImagesRouteDeps> = {}) {
 
   const app = new Hono<AppEnv>();
   registerImagesRoute(app, deps);
-  return { app, imageGeneration, enqueuePayload, enqueueTelemetry };
+  return { app, imageGeneration, imageEdit, enqueuePayload, enqueueTelemetry };
 }
 
 function post(app: Hono<AppEnv>, body: unknown, auth = "Bearer k") {
@@ -118,6 +119,57 @@ describe("registerImagesRoute", () => {
     expect(decision.cost_breakdown.total_usd).toBe(0.006);
     expect(decision.usage.completion_tokens).toBe(196);
     expect(decision.usage.prompt_tokens).toBe(15);
+  });
+
+  it("forwards Codex JSON image edits through the existing image chain", async () => {
+    const { app, imageEdit } = setup();
+    const res = await app.request("/v1/images/edits", {
+      method: "POST",
+      headers: { Authorization: "Bearer k", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-image-2",
+        prompt: "add a red hat",
+        images: [{ image_url: "data:image/png;base64,AAA=" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(imageEdit).toHaveBeenCalledWith(
+      {
+        kind: "json",
+        body: expect.objectContaining({ model: "openai/gpt-image-2", prompt: "add a red hat" }),
+      },
+      expect.anything(),
+    );
+  });
+
+  it("forwards multipart image edits without losing binary bytes", async () => {
+    const { app, imageEdit } = setup();
+    const body = new FormData();
+    body.set("model", "gpt-image-2");
+    body.set("prompt", "add snow");
+    body.append("image[]", new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }), "a.png");
+
+    const res = await app.request("/v1/images/edits", {
+      method: "POST",
+      headers: { Authorization: "Bearer k" },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    const edit = imageEdit.mock.calls[0]?.[0] as {
+      kind: string;
+      fields: Array<{ name: string; value: string | Uint8Array }>;
+    };
+    expect(edit.kind).toBe("multipart");
+    expect(edit.fields).toEqual(
+      expect.arrayContaining([
+        { name: "model", value: "openai/gpt-image-2" },
+        expect.objectContaining({ name: "image[]", filename: "a.png" }),
+      ]),
+    );
+    const image = edit.fields.find((field) => field.name === "image[]");
+    expect([...((image?.value as Uint8Array) ?? [])]).toEqual([1, 2, 3]);
   });
 
   it("captures the FULL image verbatim (the store externalizes it to payload_blobs)", async () => {

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -4,8 +4,9 @@ import {
   type BudgetProbe,
   type CircuitBreaker,
   createBlockedModelMatcher,
+  type ImageEditInput,
 } from "@helm/core";
-import { ImageGenerationRequestSchema } from "@helm/shared";
+import { ImageEditRequestSchema, ImageGenerationRequestSchema } from "@helm/shared";
 import type { Context, Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv } from "../app.js";
@@ -107,10 +108,13 @@ function mapGeminiToImages(native: Record<string, unknown>): Record<string, unkn
 }
 
 export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): void {
-  app.use("/v1/images/generations", concurrencyReleaseGuard());
-  app.use("/v1/images/generations", memoryAdmissionReleaseGuard());
+  for (const path of ["/v1/images/generations", "/v1/images/edits"]) {
+    app.use(path, concurrencyReleaseGuard());
+    app.use(path, memoryAdmissionReleaseGuard());
+  }
 
-  app.post("/v1/images/generations", async (c) => {
+  const handle = async (c: Context<AppEnv>): Promise<Response> => {
+    const editing = c.req.path === "/v1/images/edits";
     // Production always receives both ids from createApp. The UUID fallback keeps
     // this route safely usable in isolated/headless Hono composition tests without
     // ever consulting a client header for the storage key.
@@ -182,17 +186,89 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
       c.set("concurrencyRelease", acquired.release);
     }
 
-    // 4) Parse + validate. Malformed JSON / invalid body → 400 (client error).
+    // 4) Parse + validate. Edits support both the Codex JSON carrier and the public
+    // multipart carrier. The admitted bytes make multipart fallback attempts replayable.
     let requestJson = "";
-    let raw: unknown;
+    let model = "";
+    let prompt = "";
+    let generationBody: Record<string, unknown> | null = null;
+    let editInput: ImageEditInput | null = null;
     try {
       const admitted =
         deps.memoryAdmission === undefined
           ? null
           : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
-      requestJson = admitted?.text ?? (await c.req.text());
+      const bytes = admitted?.bytes ?? new Uint8Array(await c.req.arrayBuffer());
+      requestJson = admitted?.text ?? Buffer.from(bytes).toString("utf8");
       if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
-      raw = JSON.parse(requestJson);
+      const contentType = c.req.header("Content-Type")?.toLowerCase() ?? "";
+      if (editing && contentType.startsWith("multipart/form-data")) {
+        const form = await new Request("http://helm.internal/v1/images/edits", {
+          method: "POST",
+          headers: { "content-type": c.req.header("Content-Type") ?? "" },
+          body: Buffer.from(bytes),
+        }).formData();
+        const fields: ImageEditInput & { kind: "multipart" } = {
+          kind: "multipart",
+          fields: await Promise.all(
+            [...form.entries()].map(async ([name, value]) =>
+              typeof value === "string"
+                ? { name, value }
+                : {
+                    name,
+                    value: new Uint8Array(await value.arrayBuffer()),
+                    filename: value.name,
+                    contentType: value.type || "application/octet-stream",
+                  },
+            ),
+          ),
+        };
+        model = form.get("model")?.toString().trim() ?? "";
+        prompt = form.get("prompt")?.toString().trim() ?? "";
+        const hasImage = fields.fields.some(
+          (field) =>
+            (field.name === "image" || field.name === "image[]") &&
+            typeof field.value !== "string" &&
+            field.value.byteLength > 0,
+        );
+        if (model.length === 0 || prompt.length === 0 || !hasImage) {
+          return errorJson(
+            c,
+            400,
+            "invalid_request_error",
+            "multipart image edit requires model, prompt, and at least one image file",
+          );
+        }
+        editInput = fields;
+        requestJson = JSON.stringify({
+          model,
+          prompt,
+          files: fields.fields
+            .filter((field) => typeof field.value !== "string")
+            .map((field) => ({
+              name: field.name,
+              filename: "filename" in field ? field.filename : "",
+            })),
+        });
+      } else {
+        const raw = JSON.parse(requestJson) as unknown;
+        const parsed = (editing ? ImageEditRequestSchema : ImageGenerationRequestSchema).safeParse(
+          raw,
+        );
+        if (!parsed.success) {
+          return errorJson(
+            c,
+            400,
+            "invalid_request_error",
+            parsed.error.issues[0]?.message ??
+              `invalid image ${editing ? "edit" : "generation"} request`,
+          );
+        }
+        model = parsed.data.model;
+        prompt = parsed.data.prompt;
+        if (editing) editInput = { kind: "json", body: parsed.data };
+        else generationBody = parsed.data;
+      }
     } catch (error) {
       if (error instanceof RequestAdmissionError) {
         if (error.status === 503) c.header("retry-after", "1");
@@ -204,56 +280,62 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
           error.code,
         );
       }
-      return errorJson(c, 400, "invalid_request_error", "malformed JSON request body");
-    }
-    const parsed = ImageGenerationRequestSchema.safeParse(raw);
-    if (!parsed.success) {
-      return errorJson(
-        c,
-        400,
-        "invalid_request_error",
-        parsed.error.issues[0]?.message ?? "invalid image generation request",
-      );
+      return errorJson(c, 400, "invalid_request_error", "malformed image request body");
     }
 
     // 5) Resolve the model/lane → the ordered provider chain.
-    const chain = deps.resolveImageChain(parsed.data.model);
+    const chain = deps.resolveImageChain(model);
     if (!chain.ok) {
       return chain.status === 404
         ? errorJson(
             c,
             404,
             "invalid_request_error",
-            `model '${parsed.data.model}' is not a configured image model`,
+            `model '${model}' is not a configured image model`,
             "model_not_found",
           )
         : errorJson(
             c,
             503,
             "api_error",
-            `image provider for '${parsed.data.model}' is unavailable (missing credential)`,
+            `image provider for '${model}' is unavailable (missing credential)`,
             "provider_unavailable",
           );
+    }
+    const operationTargets = editing
+      ? chain.targets.filter(
+          (target) => target.kind === "openai" && typeof target.client.imageEdit === "function",
+        )
+      : chain.targets;
+    if (operationTargets.length === 0) {
+      return errorJson(
+        c,
+        400,
+        "invalid_request_error",
+        `model '${model}' does not support image edits`,
+        "unsupported_operation",
+      );
     }
     const blockedModels = createBlockedModelMatcher(identity.caps?.blockedModels);
     const permittedTargets =
       blockedModels === null
-        ? chain.targets
-        : chain.targets.filter((target) => !blockedModels.matches(target.alias));
+        ? operationTargets
+        : operationTargets.filter((target) => !blockedModels.matches(target.alias));
     const permittedCandidateChain =
       blockedModels === null
-        ? chain.candidateChain
-        : chain.candidateChain.filter((alias) => !blockedModels.matches(alias));
+        ? operationTargets.map((target) => target.alias)
+        : operationTargets
+            .map((target) => target.alias)
+            .filter((alias) => !blockedModels.matches(alias));
     if (permittedTargets.length === 0) {
-      const directBlocked =
-        chain.laneName !== parsed.data.model && blockedModels?.matches(parsed.data.model) === true;
+      const directBlocked = chain.laneName !== model && blockedModels?.matches(model) === true;
       return errorJson(
         c,
         400,
         "invalid_request_error",
         directBlocked
-          ? `model '${parsed.data.model}' is blocked for this key`
-          : `all image candidate models for '${parsed.data.model}' are blocked for this key`,
+          ? `model '${model}' is blocked for this key`
+          : `all image candidate models for '${model}' are blocked for this key`,
         "model_blocked",
       );
     }
@@ -284,11 +366,30 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         upstreamRequestJson = b;
       };
       let upstream: Record<string, unknown>;
-      if (target.kind === "gemini") {
+      if (editing) {
+        if (!editInput || !target.client.imageEdit) {
+          throw new Error("image edit provider is unavailable");
+        }
+        const providerInput: ImageEditInput =
+          editInput.kind === "json"
+            ? { kind: "json", body: { ...editInput.body, model: target.providerModel } }
+            : {
+                kind: "multipart",
+                fields: editInput.fields.map((field) =>
+                  field.name === "model" && typeof field.value === "string"
+                    ? { name: field.name, value: target.providerModel }
+                    : field,
+                ),
+              };
+        upstream = await target.client.imageEdit(providerInput, {
+          signal: requestSignal(c),
+          captureUpstream,
+        });
+      } else if (target.kind === "gemini") {
         const native = await target.client.nativePassthrough?.(
           {
             model: target.providerModel,
-            contents: [{ role: "user", parts: [{ text: parsed.data.prompt }] }],
+            contents: [{ role: "user", parts: [{ text: prompt }] }],
             generationConfig: { responseModalities: ["TEXT", "IMAGE"] },
           },
           { signal: requestSignal(c), captureUpstream },
@@ -296,7 +397,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         upstream = mapGeminiToImages((native ?? {}) as Record<string, unknown>);
       } else {
         upstream = (await target.client.imageGeneration?.(
-          { ...parsed.data, model: target.providerModel },
+          { ...generationBody, model: target.providerModel },
           { signal: requestSignal(c), captureUpstream },
         )) as Record<string, unknown>;
       }
@@ -324,7 +425,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
           requestId,
           traceId,
           keyPrefix,
-          requested: parsed.data.model,
+          requested: model,
           selectedLane: permittedChain.laneName,
           candidateChain: permittedChain.candidateChain,
           attempts: outcome.attempts,
@@ -361,7 +462,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         requestId,
         traceId,
         keyPrefix,
-        requested: parsed.data.model,
+        requested: model,
         selectedLane: permittedChain.laneName,
         candidateChain: permittedChain.candidateChain,
         attempts: outcome.attempts,
@@ -412,5 +513,8 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
     c.header("x-helm-final-model", served.alias);
     c.header("x-helm-provider-model", served.providerModel);
     return c.json(result.clientBody);
-  });
+  };
+
+  app.post("/v1/images/generations", handle);
+  app.post("/v1/images/edits", handle);
 }

--- a/apps/gateway/src/routes/openapi.test.ts
+++ b/apps/gateway/src/routes/openapi.test.ts
@@ -27,6 +27,9 @@ describe("OpenAPI docs", () => {
       "/v1/messages",
       "/v1/responses",
       "/v1/images/generations",
+      "/v1/images/edits",
+      "/v1/realtime/calls",
+      "/v1/live",
       "/v1beta/interactions",
       "/v1beta/models/{model}:generateContent",
     ]) {
@@ -39,9 +42,11 @@ describe("OpenAPI docs", () => {
     // Image/interactions bodies reuse their Zod schemas (single source of truth).
     for (const name of [
       "ImageGenerationRequest",
+      "ImageEditRequest",
       "ImageGenerationResponse",
       "InteractionsRequest",
       "InteractionsResponse",
+      "RealtimeSession",
     ]) {
       expect(doc.components.schemas[name]).toBeDefined();
     }

--- a/apps/gateway/src/routes/openapi.ts
+++ b/apps/gateway/src/routes/openapi.ts
@@ -1,4 +1,5 @@
 import {
+  ImageEditRequestSchema,
   ImageGenerationRequestSchema,
   ImageGenerationResponseSchema,
   InteractionsRequestSchema,
@@ -6,6 +7,7 @@ import {
   ModelObjectSchema,
   ModelsListSchema,
   OpenAIChatRequestSchema,
+  RealtimeSessionSchema,
 } from "@helm/shared";
 import { swaggerUI } from "@hono/swagger-ui";
 import type { Hono } from "hono";
@@ -115,10 +117,12 @@ export function buildOpenApiDocument(buildInfo?: BuildInfo): JsonSchema {
         ModelsList: component(ModelsListSchema),
         ModelObject: component(ModelObjectSchema),
         ChatCompletionRequest: component(OpenAIChatRequestSchema),
+        ImageEditRequest: component(ImageEditRequestSchema),
         ImageGenerationRequest: component(ImageGenerationRequestSchema),
         ImageGenerationResponse: component(ImageGenerationResponseSchema),
         InteractionsRequest: component(InteractionsRequestSchema),
         InteractionsResponse: component(InteractionsResponseSchema),
+        RealtimeSession: component(RealtimeSessionSchema),
         UsageStats: {
           type: "object",
           properties: {
@@ -417,6 +421,109 @@ export function buildOpenApiDocument(buildInfo?: BuildInfo): JsonSchema {
             "401": errorResponse("Missing or invalid API key"),
             "404": errorResponse("Model is not a configured image model"),
             "503": errorResponse("Image provider unavailable (missing credential)"),
+          },
+        },
+      },
+      "/v1/images/edits": {
+        post: {
+          tags: ["Inference"],
+          summary: "OpenAI-compatible image edit",
+          description:
+            "Edit one or more images through the same authenticated image provider chain. " +
+            "Codex JSON `images[].image_url` carriers and OpenAI multipart `image` files are supported.",
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/ImageEditRequest" },
+              },
+              "multipart/form-data": {
+                schema: {
+                  type: "object",
+                  required: ["model", "prompt", "image"],
+                  properties: {
+                    model: { type: "string" },
+                    prompt: { type: "string" },
+                    image: { type: "array", items: { type: "string", format: "binary" } },
+                    mask: { type: "string", format: "binary" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Edited image(s).",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ImageGenerationResponse" },
+                },
+              },
+            },
+            "400": errorResponse("Invalid image edit request"),
+            "401": errorResponse("Missing or invalid API key"),
+            "404": errorResponse("Model is not a configured image model"),
+          },
+        },
+      },
+      "/v1/realtime/calls": {
+        post: {
+          tags: ["Inference"],
+          summary: "Create a Realtime V1/V2 WebRTC call",
+          description:
+            "Returns the answer SDP and binds the call id to this Helm key. Join the sideband at " +
+            "`wss://<helm>/v1/realtime?call_id=<id>` with the same key.",
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "multipart/form-data": {
+                schema: {
+                  type: "object",
+                  required: ["sdp", "session"],
+                  properties: {
+                    sdp: { type: "string", contentMediaType: "application/sdp" },
+                    session: { $ref: "#/components/schemas/RealtimeSession" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": { description: "Answer SDP", content: { "application/sdp": {} } },
+            "400": errorResponse("Invalid call request"),
+            "401": errorResponse("Missing or invalid API key"),
+          },
+        },
+      },
+      "/v1/live": {
+        post: {
+          tags: ["Inference"],
+          summary: "Create a Realtime V3 Frameless call",
+          description:
+            "Creates a Frameless call. Join its sideband at `wss://<helm>/v1/live/<call_id>` " +
+            "with the same Helm key.",
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "multipart/form-data": {
+                schema: {
+                  type: "object",
+                  required: ["sdp", "session"],
+                  properties: {
+                    sdp: { type: "string", contentMediaType: "application/sdp" },
+                    session: { $ref: "#/components/schemas/RealtimeSession" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": { description: "Answer SDP", content: { "application/sdp": {} } },
+            "400": errorResponse("Invalid call request"),
+            "401": errorResponse("Missing or invalid API key"),
           },
         },
       },

--- a/apps/gateway/src/routes/realtime.test.ts
+++ b/apps/gateway/src/routes/realtime.test.ts
@@ -2,6 +2,7 @@ import type { ProviderClient, RealtimeCallResult } from "@helm/core";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../app.js";
+import type { ConcurrencyGatePort } from "../middleware/concurrency.js";
 import { createRealtimeCallRegistry } from "../realtime-call-registry.js";
 import { registerRealtimeRoutes } from "./realtime.js";
 
@@ -16,7 +17,7 @@ function multipart(session: Record<string, unknown>): FormData {
   return body;
 }
 
-function setup(blockedModels: string[] = []) {
+function setup(blockedModels: string[] = [], concurrencyGate?: ConcurrencyGatePort) {
   const sideband = {
     url: "wss://upstream.test/v1/realtime?call_id=rtc_1",
     headers: async () => ({ Authorization: "Bearer upstream" }),
@@ -44,6 +45,7 @@ function setup(blockedModels: string[] = []) {
           ? { client, providerModel: model, alias: `openai-codex/${model}` }
           : null,
     registry,
+    concurrencyGate,
   });
   return { app, realtimeCall, registry, sideband };
 }
@@ -118,5 +120,47 @@ describe("registerRealtimeRoutes", () => {
     });
     expect(response.status).toBe(400);
     expect(realtimeCall).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the distributed concurrency lease store is unavailable", async () => {
+    const concurrencyGate: ConcurrencyGatePort = {
+      acquire: vi.fn().mockResolvedValue({
+        ok: false,
+        reason: "unavailable",
+        retryAfterSeconds: 5,
+      }),
+    };
+    const { app, realtimeCall } = setup([], concurrencyGate);
+    const response = await app.request("/v1/realtime/calls", {
+      method: "POST",
+      headers: { Authorization: "Bearer helm-key" },
+      body: multipart({ model: "gpt-realtime-1.5" }),
+    });
+
+    expect(response.status).toBe(503);
+    expect(realtimeCall).not.toHaveBeenCalled();
+  });
+
+  it("forwards distributed lease loss through the call-create signal", async () => {
+    const controller = new AbortController();
+    controller.abort("concurrency_lease_lost");
+    const concurrencyGate: ConcurrencyGatePort = {
+      acquire: vi.fn().mockResolvedValue({
+        ok: true,
+        signal: controller.signal,
+        release: vi.fn(),
+      }),
+    };
+    const { app, realtimeCall } = setup([], concurrencyGate);
+    const response = await app.request("/v1/realtime/calls", {
+      method: "POST",
+      headers: { Authorization: "Bearer helm-key" },
+      body: multipart({ model: "gpt-realtime-1.5" }),
+    });
+
+    expect(response.status).toBe(201);
+    const options = realtimeCall.mock.calls[0]?.[1];
+    expect(options?.signal?.aborted).toBe(true);
+    expect(options?.signal?.reason).toBe("concurrency_lease_lost");
   });
 });

--- a/apps/gateway/src/routes/realtime.test.ts
+++ b/apps/gateway/src/routes/realtime.test.ts
@@ -1,0 +1,122 @@
+import type { ProviderClient, RealtimeCallResult } from "@helm/core";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "../app.js";
+import { createRealtimeCallRegistry } from "../realtime-call-registry.js";
+import { registerRealtimeRoutes } from "./realtime.js";
+
+function multipart(session: Record<string, unknown>): FormData {
+  const body = new FormData();
+  body.set("sdp", new Blob(["v=offer\r\n"], { type: "application/sdp" }), "sdp");
+  body.set(
+    "session",
+    new Blob([JSON.stringify(session)], { type: "application/json" }),
+    "session.json",
+  );
+  return body;
+}
+
+function setup(blockedModels: string[] = []) {
+  const sideband = {
+    url: "wss://upstream.test/v1/realtime?call_id=rtc_1",
+    headers: async () => ({ Authorization: "Bearer upstream" }),
+  };
+  const realtimeCall = vi.fn().mockResolvedValue({
+    status: 201,
+    sdp: "v=answer\r\n",
+    contentType: "application/sdp",
+    location: "/v1/realtime/calls/rtc_1",
+    callId: "rtc_1",
+    sideband,
+  } satisfies RealtimeCallResult);
+  const client = { realtimeCall } as unknown as ProviderClient;
+  const registry = createRealtimeCallRegistry();
+  const app = new Hono<AppEnv>();
+  registerRealtimeRoutes(app, {
+    auth: {
+      resolve: async (credential) =>
+        credential === "helm-key" ? { keyId: "key-1", blockedModels } : null,
+    },
+    resolve: (model) =>
+      model === "gpt-realtime-1.5"
+        ? { client, providerModel: model, alias: `openai-codex/${model}` }
+        : model === "gpt-live-1-boulder-alpha"
+          ? { client, providerModel: model, alias: `openai-codex/${model}` }
+          : null,
+    registry,
+  });
+  return { app, realtimeCall, registry, sideband };
+}
+
+describe("registerRealtimeRoutes", () => {
+  it("creates a V1/V2 call, forwards allowed metadata, and binds its sideband", async () => {
+    const { app, realtimeCall, registry, sideband } = setup();
+    const response = await app.request("/v1/realtime/calls?intent=quicksilver&architecture=avas", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer helm-key",
+        "openai-alpha": "quicksilver=v1",
+        "session-id": "sess-1",
+        "x-secret": "do-not-forward",
+      },
+      body: multipart({ model: "gpt-realtime-1.5", type: "quicksilver" }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(await response.text()).toBe("v=answer\r\n");
+    expect(response.headers.get("location")).toBe("/v1/realtime/calls/rtc_1");
+    expect(realtimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "realtime",
+        query: "intent=quicksilver&architecture=avas",
+        sdp: "v=offer\r\n",
+        session: expect.objectContaining({ model: "gpt-realtime-1.5" }),
+        headers: {
+          "openai-alpha": "quicksilver=v1",
+          "session-id": "sess-1",
+        },
+      }),
+      expect.anything(),
+    );
+    expect(registry.take("rtc_1", "key-1")).toEqual({ ok: true, target: sideband });
+  });
+
+  it("maps the Frameless endpoint and rewrites only the provider model", async () => {
+    const { app, realtimeCall } = setup();
+    const response = await app.request("/v1/live", {
+      method: "POST",
+      headers: { Authorization: "Bearer helm-key", "openai-alpha": "quicksilver=v2" },
+      body: multipart({
+        model: "gpt-live-1-boulder-alpha",
+        delegation: { type: "client" },
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(realtimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: "live", query: "" }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects an invalid Helm key before calling upstream", async () => {
+    const { app, realtimeCall } = setup();
+    const response = await app.request("/v1/realtime/calls", {
+      method: "POST",
+      body: multipart({ model: "gpt-realtime-1.5" }),
+    });
+    expect(response.status).toBe(401);
+    expect(realtimeCall).not.toHaveBeenCalled();
+  });
+
+  it("enforces blocked_models against the resolved provider alias", async () => {
+    const { app, realtimeCall } = setup(["openai-codex/*"]);
+    const response = await app.request("/v1/realtime/calls", {
+      method: "POST",
+      headers: { Authorization: "Bearer helm-key" },
+      body: multipart({ model: "gpt-realtime-1.5" }),
+    });
+    expect(response.status).toBe(400);
+    expect(realtimeCall).not.toHaveBeenCalled();
+  });
+});

--- a/apps/gateway/src/routes/realtime.ts
+++ b/apps/gateway/src/routes/realtime.ts
@@ -1,0 +1,215 @@
+import { createBlockedModelMatcher, type ProviderClient, UpstreamError } from "@helm/core";
+import { RealtimeSessionSchema } from "@helm/shared";
+import type { Context, Hono } from "hono";
+import type { AppEnv } from "../app.js";
+import { type ConcurrencyGatePort, concurrencyReleaseGuard } from "../middleware/concurrency.js";
+import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
+import { requestSignal } from "../middleware/limits.js";
+import type { RealtimeCallRegistry } from "../realtime-call-registry.js";
+import {
+  type BodyMemoryAdmission,
+  memoryAdmissionReleaseGuard,
+  RequestAdmissionError,
+  readAdmittedRequestBody,
+} from "../runtime/memory-admission.js";
+import type { GeminiRateLimiterPort } from "./gemini.js";
+
+const FORWARDED_HEADERS = [
+  "openai-alpha",
+  "originator",
+  "session-id",
+  "thread-id",
+  "version",
+  "x-client-request-id",
+  "x-codex-client-version",
+] as const;
+
+export interface RealtimeRouteDeps {
+  auth: {
+    resolve(credential: string | null): Promise<{
+      keyId: string;
+      blockedModels?: string[] | null;
+      concurrencyLimit?: number | null;
+      rateLimit?: { rpm: number | null; tpm: number | null };
+    } | null>;
+  };
+  resolve(model: string): { client: ProviderClient; providerModel: string; alias: string } | null;
+  registry: RealtimeCallRegistry;
+  rateLimiter?: GeminiRateLimiterPort;
+  concurrencyGate?: ConcurrencyGatePort;
+  memoryAdmission?: BodyMemoryAdmission;
+}
+
+function bearer(value: string | undefined): string | null {
+  const match = value ? /^Bearer\s+(.+)$/.exec(value) : null;
+  return match?.[1] ?? null;
+}
+
+function error(
+  c: Context<AppEnv>,
+  status: 400 | 401 | 404 | 413 | 429 | 502 | 503,
+  message: string,
+  code: string,
+) {
+  return c.json({ error: { type: "invalid_request_error", message, code, param: null } }, status);
+}
+
+async function partText(value: string | File | null): Promise<string> {
+  if (typeof value === "string") return value;
+  return value ? await value.text() : "";
+}
+
+export function registerRealtimeRoutes(app: Hono<AppEnv>, deps: RealtimeRouteDeps): void {
+  for (const path of ["/v1/realtime/calls", "/v1/live"]) {
+    app.use(path, concurrencyReleaseGuard());
+    app.use(path, memoryAdmissionReleaseGuard());
+  }
+
+  const handle = async (c: Context<AppEnv>): Promise<Response> => {
+    const identity = await deps.auth.resolve(bearer(c.req.header("Authorization")));
+    if (!identity) return error(c, 401, "missing or invalid API key", "invalid_api_key");
+
+    if (deps.rateLimiter) {
+      const result = await deps.rateLimiter.check({
+        keyId: identity.keyId,
+        estimatedTokens: estimateRequestTokens(c),
+        now: Date.now(),
+        override: identity.rateLimit,
+      });
+      if (!result.allowed) {
+        c.header("retry-after", String(result.retryAfterSeconds));
+        return error(c, 429, `rate limit exceeded (${result.limitedBy})`, "rate_limit_exceeded");
+      }
+    }
+
+    if (deps.concurrencyGate) {
+      const acquired = await deps.concurrencyGate.acquire({
+        keyId: identity.keyId,
+        limit: identity.concurrencyLimit ?? null,
+        signal: requestSignal(c),
+      });
+      if (!acquired.ok) {
+        c.header("retry-after", String(acquired.retryAfterSeconds));
+        return error(
+          c,
+          429,
+          "realtime call concurrency queue is unavailable",
+          "rate_limit_exceeded",
+        );
+      }
+      c.set("concurrencyRelease", acquired.release);
+    }
+
+    let bytes: Uint8Array;
+    try {
+      const admitted = deps.memoryAdmission
+        ? await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission)
+        : null;
+      bytes = admitted?.bytes ?? new Uint8Array(await c.req.arrayBuffer());
+      if (admitted) c.set("requestMemoryRelease", admitted.release);
+    } catch (cause) {
+      if (cause instanceof RequestAdmissionError) {
+        if (cause.status === 503) c.header("retry-after", "1");
+        return error(c, cause.status, cause.message, cause.code);
+      }
+      return error(c, 400, "invalid realtime call body", "invalid_request");
+    }
+
+    const contentType = c.req.header("Content-Type") ?? "";
+    if (!contentType.toLowerCase().startsWith("multipart/form-data")) {
+      return error(c, 400, "realtime call requires multipart/form-data", "invalid_request");
+    }
+
+    let sdp = "";
+    let model = "";
+    let session: Record<string, unknown>;
+    try {
+      const form = await new Request("http://helm.internal/v1/realtime/calls", {
+        method: "POST",
+        headers: { "content-type": contentType },
+        body: Buffer.from(bytes),
+      }).formData();
+      sdp = await partText(form.get("sdp"));
+      const parsed = RealtimeSessionSchema.safeParse(
+        JSON.parse(await partText(form.get("session"))),
+      );
+      if (!parsed.success || sdp.trim().length === 0) {
+        return error(
+          c,
+          400,
+          "realtime call requires valid sdp and session fields",
+          "invalid_request",
+        );
+      }
+      session = parsed.data;
+      model = parsed.data.model;
+    } catch {
+      return error(c, 400, "realtime call contains malformed multipart fields", "invalid_request");
+    }
+
+    const target = deps.resolve(model);
+    if (!target?.client.realtimeCall) {
+      return error(
+        c,
+        404,
+        `model '${model}' is not a configured realtime model`,
+        "model_not_found",
+      );
+    }
+    const blocked = createBlockedModelMatcher(identity.blockedModels);
+    if (blocked?.matches(model) || blocked?.matches(target.alias)) {
+      return error(c, 400, `model '${model}' is blocked for this key`, "model_blocked");
+    }
+
+    const headers: Record<string, string> = {};
+    for (const name of FORWARDED_HEADERS) {
+      const value = c.req.header(name);
+      if (value) headers[name] = value;
+    }
+
+    try {
+      const result = await target.client.realtimeCall(
+        {
+          endpoint: c.req.path === "/v1/live" ? "live" : "realtime",
+          query: new URL(c.req.url).searchParams.toString(),
+          sdp,
+          session: { ...session, model: target.providerModel },
+          headers,
+        },
+        { signal: requestSignal(c) },
+      );
+      deps.registry.put(result.callId, identity.keyId, result.sideband);
+      return new Response(result.sdp, {
+        status: result.status,
+        headers: {
+          "content-type": result.contentType ?? "application/sdp",
+          location: result.location,
+        },
+      });
+    } catch (cause) {
+      const status =
+        cause instanceof UpstreamError &&
+        cause.upstreamStatus !== null &&
+        cause.upstreamStatus >= 400 &&
+        cause.upstreamStatus < 600
+          ? cause.upstreamStatus
+          : 502;
+      return error(
+        c,
+        status === 400 ||
+          status === 401 ||
+          status === 404 ||
+          status === 413 ||
+          status === 429 ||
+          status === 503
+          ? status
+          : 502,
+        cause instanceof Error ? cause.message : "realtime upstream failed",
+        "upstream_error",
+      );
+    }
+  };
+
+  app.post("/v1/realtime/calls", handle);
+  app.post("/v1/live", handle);
+}

--- a/apps/gateway/src/routes/realtime.ts
+++ b/apps/gateway/src/routes/realtime.ts
@@ -89,6 +89,9 @@ export function registerRealtimeRoutes(app: Hono<AppEnv>, deps: RealtimeRouteDep
         signal: requestSignal(c),
       });
       if (!acquired.ok) {
+        if (acquired.reason === "unavailable") {
+          return error(c, 503, "concurrency lease unavailable", "server_overloaded");
+        }
         c.header("retry-after", String(acquired.retryAfterSeconds));
         return error(
           c,
@@ -97,6 +100,10 @@ export function registerRealtimeRoutes(app: Hono<AppEnv>, deps: RealtimeRouteDep
           "rate_limit_exceeded",
         );
       }
+      c.set(
+        "concurrency_signal",
+        AbortSignal.any([requestSignal(c), acquired.signal ?? requestSignal(c)]),
+      );
       c.set("concurrencyRelease", acquired.release);
     }
 

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -91,6 +91,7 @@ describe("body memory admission", () => {
       admission,
     );
     expect(admitted.text).toBe('{"ok":true}');
+    expect(Buffer.from(admitted.bytes).toString("utf8")).toBe('{"ok":true}');
     expect(admission.reservedBytes).toBeGreaterThan(0);
     admitted.release();
     expect(admission.reservedBytes).toBe(0);

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -141,7 +141,7 @@ function admissionError(reason: "too_large" | "busy", maxWireBytes: number) {
 export async function readAdmittedRequestBody(
   request: Request,
   admission: BodyMemoryAdmission,
-): Promise<{ text: string; release: () => void }> {
+): Promise<{ text: string; bytes: Uint8Array; release: () => void }> {
   const declared = Number(request.headers.get("content-length"));
   const initialBytes =
     request.headers.has("transfer-encoding") || !Number.isFinite(declared) || declared < 0
@@ -172,8 +172,10 @@ export async function readAdmittedRequestBody(
     }
     const resized = lease.resize(bytes);
     if (!resized.ok) throw admissionError(resized.reason, admission.maxWireBytes);
+    const body = Buffer.concat(chunks, bytes);
     return {
-      text: Buffer.concat(chunks).toString("utf8"),
+      text: body.toString("utf8"),
+      bytes: body,
       release: lease.release,
     };
   } catch (error) {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -248,6 +248,7 @@ export interface ServerHandle {
   closeResponsesWebSocketSession?: (sessionId: string) => Promise<void>;
   responsesWebSocketSessionProof?: string;
   responsesMemoryAdmission?: BodyMemoryAdmission;
+  websocketIngressAdmission?: BodyMemoryAdmission;
   realtimeCallRegistry?: RealtimeCallRegistry;
   resolveRealtimeKey?: (credential: string | null) => Promise<string | null>;
   // Stop background workers (e.g. the Agentic Signals scheduler). Optional and
@@ -1805,6 +1806,12 @@ export async function buildServer(
     protectedHeapBytes: requestProtectedHeapBytes,
     heapUsedBytes: () => process.memoryUsage().heapUsed,
   });
+  const websocketIngressAdmission = createBodyMemoryAdmission({
+    activeRequestBytes: memoryBudget.websocketIngressBytes,
+    maxWireBytes: memoryBudget.websocketMaxPayloadBytes,
+    jsonAmplification: 1,
+    minRequestChargeBytes: 1,
+  });
   logger.log("info", "runtime.memory_budget", {
     heap_limit_bytes: memoryBudget.heapLimitBytes,
     process_limit_bytes: memoryBudget.processLimitBytes,
@@ -1818,6 +1825,8 @@ export async function buildServer(
     sse_tail_chars: memoryBudget.sseTailChars,
     sqlite_page_cache_bytes: memoryBudget.sqlitePageCacheBytes,
     sqlite_maintenance_cache_bytes: memoryBudget.sqliteMaintenanceCacheBytes,
+    websocket_ingress_bytes: memoryBudget.websocketIngressBytes,
+    websocket_max_payload_bytes: memoryBudget.websocketMaxPayloadBytes,
   });
   const config = loadConfig({ configDir: opts.configDir ?? "./config" });
   // Validate the optional Grok proxy protocol override before opening stores or
@@ -4369,6 +4378,7 @@ export async function buildServer(
     host: config.server.host,
     responsesWebSocketSessionProof,
     responsesMemoryAdmission: requestBodyMemoryAdmission,
+    websocketIngressAdmission,
     realtimeCallRegistry,
     resolveRealtimeKey: async (credential) => (await resolveIdentity(credential))?.keyId ?? null,
     closeResponsesWebSocketSession: async (sessionId) => {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -190,6 +190,7 @@ import {
   type OAuthModelDiscoveryCache,
 } from "./oauth/model-discovery-cache.js";
 import { createResetCreditGuard, resetCreditGuardHash } from "./oauth/reset-credit-guard.js";
+import { createRealtimeCallRegistry, type RealtimeCallRegistry } from "./realtime-call-registry.js";
 import { createResponsesRegistry } from "./responses-registry.js";
 import { createArchiveFsAccess } from "./routes/admin/cleanup-fs.js";
 import { registerAdminApi } from "./routes/admin/index.js";
@@ -215,6 +216,7 @@ import { registerModelsRoute } from "./routes/models.js";
 import { clearSessionCaptureCache } from "./routes/payload-capture.js";
 import { registerPortalApi } from "./routes/portal/index.js";
 import { mountPortalStatic, PORTAL_BUILD_ROOT } from "./routes/portal-static.js";
+import { registerRealtimeRoutes } from "./routes/realtime.js";
 import {
   type ResponsesCompactExecution,
   type ResponsesRouteDeps,
@@ -246,6 +248,8 @@ export interface ServerHandle {
   closeResponsesWebSocketSession?: (sessionId: string) => Promise<void>;
   responsesWebSocketSessionProof?: string;
   responsesMemoryAdmission?: BodyMemoryAdmission;
+  realtimeCallRegistry?: RealtimeCallRegistry;
+  resolveRealtimeKey?: (credential: string | null) => Promise<string | null>;
   // Stop background workers (e.g. the Agentic Signals scheduler). Optional and
   // safe to skip — the timers are unref'd so they never block process exit.
   dispose?: () => void | Promise<void>;
@@ -1538,6 +1542,21 @@ function createProviderClient(
       },
       fetch: providerFetch,
     });
+    const realtimeClient = createOpenAIClient({
+      config: {
+        ...base,
+        ...cred,
+        realtimeProxy: proxy,
+        extraHeaders: (): Record<string, string> => {
+          const identity = {
+            ...codexRuntime?.accountIdentity,
+            ...codexIdentityFromMetadata(cred.currentMetadata()),
+          };
+          return identity.accountId ? { "chatgpt-account-id": identity.accountId } : {};
+        },
+      },
+      fetch: providerFetch,
+    });
     const prepareNative = (input: NativePassthroughInput): NativePassthroughInput => {
       const versionedInput = normalizeCodexNativeClientVersion(input);
       const body = nativePassthroughBody(versionedInput);
@@ -1583,6 +1602,7 @@ function createProviderClient(
     };
     return {
       ...client,
+      realtimeCall: realtimeClient.realtimeCall,
       async nativePassthrough(body, opts) {
         if (!client.nativePassthrough) {
           throw new Error("Codex native passthrough is unavailable");
@@ -1695,6 +1715,7 @@ function createProviderClient(
     config: {
       ...base,
       ...cred,
+      realtimeProxy: proxy,
       mapDeveloperRoleToSystem: p.map_developer_role_to_system,
       normalizeReasoningDeltaAlias: p.normalize_reasoning_delta_alias,
     },
@@ -3969,6 +3990,58 @@ export async function buildServer(
     };
   };
 
+  const realtimeCallRegistry = createRealtimeCallRegistry();
+  const resolveRealtimeTarget = (
+    requestedModel: string,
+  ): { client: ProviderClient; providerModel: string; alias: string } | null => {
+    const bareModel = requestedModel.includes("/")
+      ? requestedModel.slice(requestedModel.indexOf("/") + 1)
+      : requestedModel;
+    if (!(bareModel.startsWith("gpt-realtime") || bareModel.startsWith("gpt-live-"))) return null;
+
+    const oauthAlias = requestedModel.startsWith("openai-codex/")
+      ? requestedModel
+      : `openai-codex/${bareModel}`;
+    const oauthClient = providerClients.get("openai-codex");
+    if (oauthClient?.realtimeCall) {
+      return {
+        client: oauthClient,
+        providerModel: oauthWireModelMap.get(oauthAlias) ?? bareModel,
+        alias: oauthAlias,
+      };
+    }
+
+    const staticAlias = requestedModel.startsWith("openai/")
+      ? requestedModel
+      : `openai/${bareModel}`;
+    const resolved = registry.resolve(staticAlias);
+    if (!resolved.ok) return null;
+    const client = providerClients.get(resolved.value.providerName);
+    return client?.realtimeCall
+      ? { client, providerModel: resolved.value.providerModel, alias: resolved.value.alias }
+      : null;
+  };
+  registerRealtimeRoutes(app, {
+    memoryAdmission: requestBodyMemoryAdmission,
+    rateLimiter,
+    concurrencyGate,
+    registry: realtimeCallRegistry,
+    resolve: resolveRealtimeTarget,
+    auth: {
+      resolve: async (credential) => {
+        const identity = await resolveIdentity(credential);
+        return identity
+          ? {
+              keyId: identity.keyId,
+              blockedModels: identity.caps?.blockedModels,
+              concurrencyLimit: identity.caps?.concurrencyLimit,
+              rateLimit: identity.caps?.rateLimit,
+            }
+          : null;
+      },
+    },
+  });
+
   registerGeminiRoute(app, {
     memoryAdmission: requestBodyMemoryAdmission,
     rateLimiter,
@@ -4296,6 +4369,8 @@ export async function buildServer(
     host: config.server.host,
     responsesWebSocketSessionProof,
     responsesMemoryAdmission: requestBodyMemoryAdmission,
+    realtimeCallRegistry,
+    resolveRealtimeKey: async (credential) => (await resolveIdentity(credential))?.keyId ?? null,
     closeResponsesWebSocketSession: async (sessionId) => {
       await Promise.all(
         [...providerClients.values()].map(

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -202,6 +202,12 @@ providers:
         provider_model: gpt-5.6-terra
       - alias: openai/gpt-5.6-luna
         provider_model: gpt-5.6-luna
+      - alias: openai/gpt-realtime
+        provider_model: gpt-realtime
+      - alias: openai/gpt-realtime-1.5
+        provider_model: gpt-realtime-1.5
+      - alias: openai/gpt-live-1-boulder-alpha
+        provider_model: gpt-live-1-boulder-alpha
       - alias: openai/gpt-image-2
         provider_model: gpt-image-2
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -68,13 +68,17 @@ governance:
   on the creation endpoint), plus the implemented compact, input-token, retrieve,
   input-items, cancel, and delete lifecycle routes. `/responses` and
   `/openai/v1/responses` are compatibility prefixes for the same surface.
+- **OpenAI Realtime Voice** — WebRTC call creation on `POST /v1/realtime/calls`
+  (V1/V2) or `POST /v1/live` (V3 Frameless), followed by an authenticated
+  WebSocket sideband on `/v1/realtime?call_id=...` or `/v1/live/{call_id}`.
 - **Google Gemini** — `POST /v1beta/models/{model}:generateContent` (non-streaming)
   and `:streamGenerateContent` (streaming via `?alt=sse`); `/models/{model}:...`
   is also accepted for Gemini SDK compatibility.
 
 Alongside those four translated text protocols, Helm exposes separate **image-generation**
 surfaces. The first is **OpenAI-Images-compatible** — `POST /v1/images/generations`
-(non-streaming). Image generation is also available natively to **Gemini SDK
+and `POST /v1/images/edits` (JSON `image_url` or multipart files, non-streaming).
+Image generation is also available natively to **Gemini SDK
 clients**: the existing `:generateContent` endpoint now serves image models
 (`gemini-3.1-flash-image`, `gemini-3-pro-image`), and a dedicated
 **`POST /v1beta/interactions`** endpoint (the Gemini Interactions API) is translated

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -62,6 +62,8 @@ unknown top-level request fields are not guaranteed to survive schema parsing.
 | Anthropic token count | `POST /v1/messages/count_tokens` | JSON |
 | Anthropic CLI event acknowledgement | `POST /api/event_logging/batch` | JSON |
 | OpenAI Responses | `POST /v1/responses`, `POST /responses`, `POST /openai/v1/responses` | JSON, Responses SSE, or WebSocket upgrade |
+| OpenAI Realtime V1/V2 | `POST /v1/realtime/calls`, then `/v1/realtime?call_id=...` | WebRTC SDP + WebSocket sideband |
+| OpenAI Realtime V3 | `POST /v1/live`, then `/v1/live/{call_id}` | WebRTC SDP + Frameless WebSocket sideband |
 | Gemini GenerateContent | `POST /v1beta/models/{model}:generateContent` and `POST /models/{model}:generateContent` | JSON |
 | Gemini StreamGenerateContent | the same two prefixes with `:streamGenerateContent` | Gemini SSE |
 | Gemini token count | the same two prefixes with `:countTokens` | JSON |
@@ -97,6 +99,7 @@ Image generation is routed separately from the four-protocol text IR:
 | Route | Client shape | Provider behavior |
 |---|---|---|
 | `POST /v1/images/generations` | OpenAI Images | Uses an image model or homogeneous image lane; Gemini image providers are adapted to/from `generateContent`. |
+| `POST /v1/images/edits` | OpenAI Images | Accepts Codex JSON `images[].image_url` and OpenAI multipart `image`/`mask`; edit-capable OpenAI targets use the existing image fallback chain. |
 | `POST /v1beta/interactions` | Gemini Interactions | Converts `{model,input,response_format}` to Gemini `generateContent` and maps generated text/images to `steps[].content[]`. |
 | Gemini `:generateContent` with an output-image model | Native Gemini | Uses native Gemini generation, including `responseModalities` and returned `inlineData`. |
 

--- a/docs/06-auth-and-rate-limits.md
+++ b/docs/06-auth-and-rate-limits.md
@@ -7,7 +7,8 @@
 Helm never allows anonymous access to a protected data or inference surface.
 Every request to the API surface
 (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`,
-`/v1beta/models/...:generateContent`, `/v1/images/generations`,
+`/v1/realtime/calls`, `/v1/live`, their WebSocket sidebands,
+`/v1beta/models/...:generateContent`, `/v1/images/generations`, `/v1/images/edits`,
 `/v1beta/interactions`, `/v1/models`, `/v1/usage`, `/portal/api`, and the
 optional `/mcp`) must carry a valid API key or the explicitly configured MCP
 OAuth token. The landing page, health/version probes, and headline OpenAPI/Swagger
@@ -39,10 +40,15 @@ shared middleware, so they can emit their own error envelopes: `/v1/messages`,
 their native protocol shape. The Anthropic face accepts either `x-api-key` or
 `Authorization: Bearer`.
 
-`/v1/images/generations` is likewise a self-authenticating route: it runs the
+`/v1/images/generations` and `/v1/images/edits` are likewise self-authenticating routes: they run the
 same key lookup using `Authorization: Bearer` (like the OpenAI Chat face). It
 does **not** require `allow_custom_model` — a standard key can call it even
 though it names an exact image model or image lane.
+
+Realtime call creation uses the same Bearer lookup. The returned `call_id` is
+stored briefly with the creating key id and its exact provider/account sideband;
+the WebSocket upgrade must present the same Helm key. Helm never forwards that
+credential upstream and never reselects an OAuth account after call creation.
 
 `/v1beta/interactions` (the Gemini Interactions image-generation surface)
 self-authenticates the same way, but using `x-goog-api-key` (the Gemini SDK

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面（Gateway / Protocol / Provider，docs/01/05/06，原则 1/2/3/7/8）
+
+- **Realtime V1/V2/V3**：新增 `/v1/realtime/calls`、`/v1/live` 与对应 WebSocket sideband。Call-create 复用现有 static/OpenAI-Codex provider client、OAuth pool、账号 token 与 egress proxy；ChatGPT backend 继续使用 JSON call shape，官方 OpenAI 使用 multipart。`call_id` 以进程内短 TTL 绑定创建它的 Helm key 与实际 provider/account sideband，WebSocket 必须使用同一 key，且不会重新选账号；OAuth HTTP/WS 401 各只刷新重试一次。双向文本/二进制帧按实际字节占用动态内存预算，关闭压缩并保留 close code。当前部署为单 gateway replica；水平扩容前必须把 registry 换成支持原子 claim 的共享存储。
+- **Responses 与模型目录**：Responses `input_audio.audio_url` data URL 进入统一 audio IR；provider 明确声明 `responses_audio_url` 时恢复同一 carrier，旧 `input_audio:{data,format}` 保持兼容。Codex 模型目录的 `input_modalities` 接受 `audio`，不再因新目录字段丢弃模型。
+- **Images edits**：`/v1/images/edits` 复用现有 Images 的鉴权、限流、并发、预算、blocked-model、breaker/fallback、成本与 payload/telemetry 链；支持 Codex JSON `images[].image_url|file_id` 和 OpenAI multipart `image`/`image[]`、`mask`，binary bytes 在 fallback 间可重放。Gemini edit 未发现兼容契约，确定性返回 unsupported，不做有损转换。
+- **暂缓边界**：按用户确认不代理 `alpha/search` 与 `memories/trace_summarize`；未引入新依赖、媒体存储、共享 registry 或第二套路由器。
+
 ## 2026-07-24 · 请求准入增加实时 V8 堆高水位（Gateway runtime，docs/02/07/10，原则 3/7）
 
 - **线上根因**：`v0.28.7` 已限制请求、响应、写队列、Session cache 与 SSE capture 各自的静态容量，但生产容器仍在 12 小时内因 V8 heap OOM 重启 8 次；崩溃前 Mark-Compact 后仍有约 647 MiB live heap，而 heap limit 约 674 MiB。分池上限没有把当前 live heap 与其他分池尚可增长的容量合并判断，因此下一次 UTF-8 请求正文转换仍可触发进程级 OOM。
@@ -64,14 +71,9 @@
 - **Responses 续接与保真边界**：普通多轮请求只存客户端 request 增量；OpenAI Responses 为展开 `previous_response_id` 的隐藏状态，额外保存产生该 ID 的规范 response output，并以 Session 内唯一 `response_id → request_id` 建真实父边。chain、fork 与并发分支因此不会误借最新 head；恢复按「父请求 input + 父 response output + 当前 input」展开，保留 reasoning/tool-call items、删除已展开的 opaque ID，且当前顶层 instructions 不继承旧值。找不到父 response 的 revision 会以 `partial` 留痕，但恢复必须 fail-closed 为 `session_incomplete`；父 ID 不匹配、continuation 的 `retain_count` 非零、response output 缺失或损坏同样拒绝恢复，不猜测历史。
 - **清理与运维边界**：Session 恢复是语义等价 JSON，不保留原始空白、headers 或翻译后的 upstream body；完整 payload 仍是唯一可精确 Retry 的来源，Admin 明示 `source=session`、`exact=false` 并禁用 Retry。Session 是 cleanup 报告中的独立 action，但 MVP 与完整 payload 共用 `payloads_cleanup_enabled` / `payload_retention_days` 这组“内容留存”设置；payload 可归档，Session 不归档并在最后活动超过窗口后整组删除。列表 Session 可一键切到 `range=all` 的 opaque-ref 筛选；恢复失败明确区分无 Session ID、转录不可用/已清理、转录链损坏。
 
-## 2026-07-22 · Lanes 批量保存、拖拽回退与可配置默认通道删除边界（Routing / Admin lanes，docs/03/04/11，原则 2/3/5/6）
-
-- **整组写入**：Lanes 页面不再由每张卡分别 PUT；所有编辑、fallback 顺序和待删除 lane 由一个底部保存按钮通过 `PUT /admin/api/lanes` 一次提交，Gateway 用共享 `LanesConfigSchema` 校验完整 map 后原子写回 `lanes.yaml` 并热更新，失败时整组不落盘。单 lane API 保留兼容，不新增依赖。
-- **排序与删除**：fallback 的上下按钮改为复用 Policies 页交互语义的拖拽手柄，并保留方向键排序；每张 lane 卡提供删除按钮，删除先进入页面工作集，统一保存时才持久化。页面从 runtime settings 读取当前 `default_lane`，只保护当前默认 lane，不把 `balanced` 写死。
-- **配置边界修正**：`LanesConfigSchema` 改为要求至少一个有效 lane；`runtime.default_lane` 与 lane 集合的交叉约束在 Gateway 边界及启动组合层 fail-closed 校验。因而用户先把默认通道改成其他 lane 后可删除 `balanced`；Settings 选项与默认配置说明也不再把 `balanced` 当作强制终点。若手工配置令默认通道不存在，Gateway 拒绝启动；Resolver 仍对异常调用防御性地回退到存在的 `balanced` 或第一个 lane。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-22 · Lanes 批量保存、拖拽回退与可配置默认通道删除边界（Routing / Admin lanes，docs/03/04/11，原则 2/3/5/6）**：Lanes 整组原子保存、拖拽排序并只保护当前默认通道，非法默认配置 fail-closed，完整原文通过 git history 回溯。
 - **2026-07-22 · Responses 状态续接严格绑定原 provider 与账号（Protocol translation / provider execution，docs/04/05/07，原则 2/3/5/8）**：`previous_response_id` 只允许同 account/key、原 provider 与原账号继续执行；未知、跨协议或不可用状态 fail-closed，完整原文通过 git history 回溯。
 - **2026-07-22 · Codex 客户端默认启用 Responses WebSocket，并补齐反向代理边界（Deployment / Protocol / Admin client setup，docs/05/10/11，原则 3/5/8）**：Admin 的 Codex 配置复用既有 Responses WebSocket；代理只在真实 Upgrade 时转发 hop-by-hop header，Claude 图片 shim 延后，完整原文通过 git history 回溯。
 - **2026-07-21 · 首次安装改为令牌保护的浏览器向导并允许订阅-only 启动（Deployment / bootstrap / Admin，docs/10/11，原则 2/3/7）**：无完整 Admin 凭据时只开放令牌保护的浏览器向导与健康端点，完成后同进程启用 Gateway；凭据保存到 `0600` managed env，CLI/无 `.env`/OAuth-only Linux 安装路径均完成实测，完整原文通过 git history 回溯。

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -9,7 +9,7 @@
 
 ## 2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面（Gateway / Protocol / Provider，docs/01/05/06，原则 1/2/3/7/8）
 
-- **Realtime V1/V2/V3**：新增 `/v1/realtime/calls`、`/v1/live` 与对应 WebSocket sideband。Call-create 复用现有 static/OpenAI-Codex provider client、OAuth pool、账号 token 与 egress proxy；ChatGPT backend 继续使用 JSON call shape，官方 OpenAI 使用 multipart。`call_id` 以进程内短 TTL 绑定创建它的 Helm key 与实际 provider/account sideband，WebSocket 必须使用同一 key，且不会重新选账号；OAuth HTTP/WS 401 各只刷新重试一次。双向文本/二进制帧按实际字节占用动态内存预算，关闭压缩并保留 close code。当前部署为单 gateway replica；水平扩容前必须把 registry 换成支持原子 claim 的共享存储。
+- **Realtime V1/V2/V3**：新增 `/v1/realtime/calls`、`/v1/live` 与对应 WebSocket sideband。Call-create 复用现有 static/OpenAI-Codex provider client、OAuth pool、账号 token 与 egress proxy；ChatGPT backend 继续使用 JSON call shape，官方 OpenAI 使用 multipart。`call_id` 以进程内短 TTL 绑定创建它的 Helm key 与实际 provider/account sideband，WebSocket 必须使用同一 key，且不会重新选账号；OAuth HTTP/WS 401 各只刷新重试一次。Call-create 接入现有进程内或 PostgreSQL 分布式并发 lease，DB 不可用时 fail-closed 为 503，持有期间 lease 丢失会中止上游请求。双向文本/二进制帧按实际字节占用动态内存预算，关闭压缩并保留 close code。当前部署为单 gateway replica；水平扩容前必须把 registry 换成支持原子 claim 的共享存储。
 - **Responses 与模型目录**：Responses `input_audio.audio_url` data URL 进入统一 audio IR；provider 明确声明 `responses_audio_url` 时恢复同一 carrier，旧 `input_audio:{data,format}` 保持兼容。Codex 模型目录的 `input_modalities` 接受 `audio`，不再因新目录字段丢弃模型。
 - **Images edits**：`/v1/images/edits` 复用现有 Images 的鉴权、限流、并发、预算、blocked-model、breaker/fallback、成本与 payload/telemetry 链；支持 Codex JSON `images[].image_url|file_id` 和 OpenAI multipart `image`/`image[]`、`mask`，binary bytes 在 fallback 间可重放。Gemini edit 未发现兼容契约，确定性返回 unsupported，不做有损转换。
 - **暂缓边界**：按用户确认不代理 `alpha/search` 与 `memories/trace_summarize`；未引入新依赖、媒体存储、共享 registry 或第二套路由器。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -612,9 +612,14 @@ export {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   createOpenAIClient,
+  type ImageEditInput,
+  type ImageEditMultipartField,
   type OpenAIClientDeps,
   type ProviderClient,
   type ProviderConfig,
+  type RealtimeCallRequest,
+  type RealtimeCallResult,
+  type RealtimeSidebandTarget,
   UpstreamError,
 } from "./provider/openai.js";
 export {

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -79,6 +79,30 @@ describe("responsesTransformer — input_audio content (RESP-01)", () => {
     expect(parts).toContainEqual({ type: "audio", data: "AUDIO64", format: "mp3" });
   });
 
+  it("accepts Codex input_audio.audio_url and preserves the data URL on render", async () => {
+    const audioUrl = "data:audio/wav;base64,AUDIO64";
+    const ir = await responsesTransformer.transformRequestOut({
+      model: "gpt-5.6-sol",
+      input: [
+        {
+          role: "user",
+          content: [{ type: "input_audio", audio_url: audioUrl }],
+        },
+      ],
+    });
+    const userMsg = ir.messages.find((message) => message.role === "user");
+    const parts = Array.isArray(userMsg?.content) ? userMsg.content : [];
+    expect(parts).toContainEqual({ type: "audio", data: "AUDIO64", format: "wav" });
+
+    const native = (await responsesTransformer.transformRequestIn(ir)) as {
+      input: Array<{ content?: Array<Record<string, unknown>> }>;
+    };
+    expect(native.input[0]?.content).toContainEqual({
+      type: "input_audio",
+      audio_url: audioUrl,
+    });
+  });
+
   it("renders an IR audio part back to native Responses input_audio", async () => {
     const native = (await responsesTransformer.transformRequestIn({
       model: "gpt-4o-audio",

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -78,6 +78,7 @@ const ResponsesInputFileSchema = z
 const ResponsesInputAudioSchema = z
   .object({
     type: z.literal("input_audio"),
+    audio_url: z.string().optional(),
     input_audio: z
       .object({ data: z.string().optional(), format: z.string().optional() })
       .passthrough()
@@ -371,10 +372,25 @@ function foldContentPart(part: z.infer<typeof ResponsesContentPartSchema>): IRCo
     case "input_audio": {
       const p = part as z.infer<typeof ResponsesInputAudioSchema>;
       const ia = p.input_audio ?? {};
+      const audioUrl = typeof p.audio_url === "string" ? p.audio_url : null;
+      const dataUrl =
+        audioUrl === null ? null : /^data:audio\/([^;,]+)(?:;[^,]*)?;base64,(.*)$/s.exec(audioUrl);
       return {
         type: "audio",
-        data: typeof ia.data === "string" ? ia.data : "",
-        format: typeof ia.format === "string" ? ia.format : "wav",
+        data:
+          typeof ia.data === "string"
+            ? ia.data
+            : dataUrl?.[2] !== undefined
+              ? dataUrl[2]
+              : (audioUrl ?? ""),
+        format:
+          typeof ia.format === "string"
+            ? ia.format
+            : dataUrl?.[1] !== undefined
+              ? dataUrl[1]
+              : audioUrl === null
+                ? "wav"
+                : "url",
       };
     }
     case "input_file": {
@@ -502,6 +518,19 @@ function toIRRequest(req: NativeRequest): IRRequest {
   }
 
   const providerRaw: Record<string, unknown> = {};
+  if (
+    Array.isArray(parsed.input) &&
+    parsed.input.some(
+      (item) =>
+        item.type === "message" &&
+        Array.isArray(item.content) &&
+        item.content.some(
+          (part) => part.type === "input_audio" && typeof part.audio_url === "string",
+        ),
+    )
+  ) {
+    providerRaw.responses_audio_url = true;
+  }
   if (rawReasoning.length > 0) providerRaw.reasoning = rawReasoning;
   if (unknownItems.length > 0) providerRaw.unknown_items = unknownItems;
   if (
@@ -597,6 +626,7 @@ function toResponsesRequest(ir: IRRequest): NativeRequest {
   const parsed = IRRequestSchema.parse(ir);
   const input: Array<Record<string, unknown>> = [];
   let instructions: string | undefined;
+  const raw = parsed.provider_raw;
 
   const rawReasoning = parsed.provider_raw?.reasoning;
   if (Array.isArray(rawReasoning)) {
@@ -647,11 +677,14 @@ function toResponsesRequest(ir: IRRequest): NativeRequest {
     input.push({
       type: "message",
       role: m.role,
-      content: contentToResponsesParts(m.content, m.role === "assistant"),
+      content: contentToResponsesParts(
+        m.content,
+        m.role === "assistant",
+        raw?.responses_audio_url === true,
+      ),
     });
   }
 
-  const raw = parsed.provider_raw;
   // Structured output: prefer the lossless raw Responses `text` (responses origin);
   // else synthesize it from the canonical IR.response_format (chat/anthropic/gemini
   // origin) so structured output is honored on the Responses wire either way.
@@ -743,6 +776,7 @@ function contentToFunctionCallOutput(
 function contentToResponsesParts(
   content: IRMessage["content"],
   isAssistant: boolean,
+  useAudioUrl = false,
 ): Array<Record<string, unknown>> {
   const textType = isAssistant ? "output_text" : "input_text";
   if (content === null) return [{ type: textType, text: "" }];
@@ -757,10 +791,17 @@ function contentToResponsesParts(
         ...(p.detail !== undefined ? { detail: p.detail } : {}),
       });
     } else if (p.type === "audio") {
-      parts.push({
-        type: "input_audio",
-        input_audio: { data: p.data, format: p.format },
-      });
+      parts.push(
+        useAudioUrl
+          ? {
+              type: "input_audio",
+              audio_url: p.format === "url" ? p.data : `data:audio/${p.format};base64,${p.data}`,
+            }
+          : {
+              type: "input_audio",
+              input_audio: { data: p.data, format: p.format },
+            },
+      );
     } else if (p.type === "document") {
       const name = p.filename !== undefined ? { filename: p.filename } : {};
       if (p.fileId !== undefined) parts.push({ type: "input_file", file_id: p.fileId, ...name });

--- a/packages/core/src/provider/oauth/codex-model-info.test.ts
+++ b/packages/core/src/provider/oauth/codex-model-info.test.ts
@@ -139,6 +139,14 @@ describe("CodexModelInfoSchema", () => {
     expect(parsed.use_responses_lite).toBe(false);
   });
 
+  it("accepts audio in the Codex model input modalities", () => {
+    const parsed = CodexModelInfoSchema.parse(
+      modelInfo({ input_modalities: ["text", "image", "audio"] }),
+    );
+
+    expect(parsed.input_modalities).toEqual(["text", "image", "audio"]);
+  });
+
   it("treats future tool selectors as omitted like Codex", () => {
     const parsed = CodexModelInfoSchema.parse(
       modelInfo({

--- a/packages/core/src/provider/oauth/codex-model-info.ts
+++ b/packages/core/src/provider/oauth/codex-model-info.ts
@@ -115,7 +115,7 @@ export const CodexModelInfoSchema = z
     comp_hash: z.string().nullable().optional(),
     effective_context_window_percent: z.number().int().default(95),
     experimental_supported_tools: z.array(z.string()),
-    input_modalities: z.array(z.enum(["text", "image"])).default(["text", "image"]),
+    input_modalities: z.array(z.enum(["text", "image", "audio"])).default(["text", "image"]),
     supports_search_tool: z.boolean().default(false),
     use_responses_lite: z.boolean().default(false),
     auto_review_model_override: z.string().nullable().optional(),

--- a/packages/core/src/provider/oauth/models.test.ts
+++ b/packages/core/src/provider/oauth/models.test.ts
@@ -78,6 +78,9 @@ describe("discoverOAuthModels", () => {
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
+      "gpt-realtime",
+      "gpt-realtime-1.5",
+      "gpt-live-1-boulder-alpha",
     ]);
   });
 

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -28,6 +28,9 @@ export const CURATED_OAUTH_MODELS: Record<string, string[]> = {
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
+    "gpt-realtime",
+    "gpt-realtime-1.5",
+    "gpt-live-1-boulder-alpha",
   ],
 };
 

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { preOutputClassifierFor } from "../failover-guard.js";
-import { type ChatCompletionRequest, type ProviderClient, UpstreamError } from "../openai.js";
+import {
+  type ChatCompletionRequest,
+  type ProviderClient,
+  type RealtimeCallResult,
+  UpstreamError,
+} from "../openai.js";
 import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   createCodexResponsesClient,
@@ -37,6 +42,51 @@ const USER_REQ: ChatCompletionRequest = {
   model: "m",
   messages: [{ role: "user", content: "hi" }],
 };
+
+describe("createOAuthPoolClient — Realtime account binding", () => {
+  it("returns the sideband target from the account that created each call", async () => {
+    const served: string[] = [];
+    const realtimeClient = (account: string): ProviderClient => ({
+      ...stubClient(account, served),
+      async realtimeCall(_req): Promise<RealtimeCallResult> {
+        served.push(account);
+        return {
+          status: 201,
+          sdp: `answer-${account}`,
+          contentType: "application/sdp",
+          location: `/v1/realtime/calls/rtc_${account}`,
+          callId: `rtc_${account}`,
+          sideband: {
+            url: `wss://${account}.test/v1/realtime?call_id=rtc_${account}`,
+            headers: async () => ({ Authorization: `Bearer ${account}` }),
+          },
+        };
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [
+        { account: "a", priority: 10, schedulable: true, client: realtimeClient("a") },
+        { account: "b", priority: 10, schedulable: true, client: realtimeClient("b") },
+      ],
+      now: () => 1,
+    });
+    const request = {
+      endpoint: "realtime" as const,
+      query: "",
+      sdp: "offer",
+      session: { model: "gpt-realtime-1.5" },
+      headers: {},
+    };
+
+    const first = await pool.realtimeCall?.(request);
+    const second = await pool.realtimeCall?.(request);
+
+    expect(served).toEqual(["a", "b"]);
+    expect(first?.sideband.url).toContain("a.test");
+    expect(await first?.sideband.headers()).toEqual({ Authorization: "Bearer a" });
+    expect(second?.sideband.url).toContain("b.test");
+  });
+});
 
 describe("createOAuthPoolClient — account selection", () => {
   it("exposes a shared native protocol profile from homogeneous members", () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -29,6 +29,8 @@ import {
   type ChatCompletionResponse,
   type ProviderCallOptions,
   type ProviderClient,
+  type RealtimeCallRequest,
+  type RealtimeCallResult,
   UpstreamError,
 } from "../openai.js";
 import { CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER } from "../openai-responses.js";
@@ -1161,6 +1163,24 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         deps.nativeStreamPreambleClassifier,
       );
     },
+    ...(entries.length > 0 &&
+    entries.every((entry) => typeof entry.member.client.realtimeCall === "function")
+      ? {
+          async realtimeCall(
+            req: RealtimeCallRequest,
+            opts?: ProviderCallOptions,
+          ): Promise<RealtimeCallResult> {
+            // Realtime models are selected by the voice endpoint, not the Codex
+            // text-model catalog used for per-account entitlement filtering.
+            return completeWithRetry(null, null, false, (client, entry) => {
+              if (!client.realtimeCall) {
+                throw new Error("oauth pool member does not support Realtime calls");
+              }
+              return client.realtimeCall(req, callOptionsForEntry(opts, entry));
+            });
+          },
+        }
+      : {}),
     ...(entries.length > 0 &&
     entries.every((entry) => typeof entry.member.client.responsesCompact === "function")
       ? {

--- a/packages/core/src/provider/openai.images.test.ts
+++ b/packages/core/src/provider/openai.images.test.ts
@@ -55,3 +55,55 @@ describe("createOpenAIClient.imageGeneration", () => {
     });
   });
 });
+
+describe("createOpenAIClient.imageEdit", () => {
+  it("forwards the Codex JSON edit body to /images/edits", async () => {
+    const upstream = { created: 0, data: [{ b64_json: "EDITED" }] };
+    const fetch = vi.fn().mockResolvedValue(jsonResponse(upstream));
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+    const body = {
+      model: "gpt-image-2",
+      prompt: "add a red hat",
+      images: [{ image_url: "data:image/png;base64,AAA=" }],
+    };
+
+    const out = await client.imageEdit?.({ kind: "json", body });
+
+    expect(out).toEqual(upstream);
+    const [url, init] = fetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers: Record<string, string> },
+    ];
+    expect(url).toBe("https://upstream.test/v1/images/edits");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual(body);
+  });
+
+  it("rebuilds a repeatable multipart edit with binary files", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ data: [] }));
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+
+    await client.imageEdit?.({
+      kind: "multipart",
+      fields: [
+        { name: "model", value: "gpt-image-2" },
+        { name: "prompt", value: "add snow" },
+        {
+          name: "image[]",
+          value: new Uint8Array([1, 2, 3]),
+          filename: "source.png",
+          contentType: "image/png",
+        },
+      ],
+    });
+
+    const [url, init] = fetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://upstream.test/v1/images/edits");
+    expect(init.body).toBeInstanceOf(FormData);
+    const form = init.body as FormData;
+    expect(form.get("prompt")).toBe("add snow");
+    const image = form.get("image[]") as File;
+    expect(image.name).toBe("source.png");
+    expect([...new Uint8Array(await image.arrayBuffer())]).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/core/src/provider/openai.realtime.test.ts
+++ b/packages/core/src/provider/openai.realtime.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpenAIClient } from "./openai.js";
+
+const SESSION = { type: "quicksilver", model: "gpt-realtime-1.5" };
+
+describe("createOpenAIClient.realtimeCall", () => {
+  it("forwards the public Realtime call as multipart and returns a bound sideband target", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response("v=answer\r\n", {
+        status: 201,
+        headers: {
+          "content-type": "application/sdp",
+          location: "/v1/realtime/calls/rtc_public",
+        },
+      }),
+    );
+    const client = createOpenAIClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-secret" },
+      fetch,
+    });
+
+    const result = await client.realtimeCall?.({
+      endpoint: "realtime",
+      query: "intent=quicksilver&architecture=avas",
+      sdp: "v=offer\r\n",
+      session: SESSION,
+      headers: { "openai-alpha": "quicksilver=v1", "x-session-id": "sess-1" },
+    });
+
+    expect(result).toMatchObject({
+      status: 201,
+      sdp: "v=answer\r\n",
+      location: "/v1/realtime/calls/rtc_public",
+      callId: "rtc_public",
+      sideband: {
+        url: "wss://api.openai.test/v1/realtime?intent=quicksilver&architecture=avas&call_id=rtc_public",
+      },
+    });
+    const [url, init] = fetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.openai.test/v1/realtime/calls?intent=quicksilver&architecture=avas",
+    );
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    const form = init.body as FormData;
+    expect(await (form.get("sdp") as File).text()).toBe("v=offer\r\n");
+    expect(JSON.parse(await (form.get("session") as File).text())).toEqual(SESSION);
+    expect((init.headers as Record<string, string>)["openai-alpha"]).toBe("quicksilver=v1");
+    expect(await result?.sideband.headers()).toMatchObject({
+      Authorization: "Bearer sk-secret",
+      "openai-alpha": "quicksilver=v1",
+      "x-session-id": "sess-1",
+    });
+  });
+
+  it("translates ChatGPT OAuth calls to JSON and keeps Frameless sideband on the bound account", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response("v=answer\r\n", {
+        status: 201,
+        headers: { location: "/v1/live/rtc_backend", "content-type": "application/sdp" },
+      }),
+    );
+    const getAuthHeader = vi.fn().mockResolvedValue("Bearer oauth-token");
+    const client = createOpenAIClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader,
+        extraHeaders: () => ({ "chatgpt-account-id": "acct-1" }),
+      },
+      fetch,
+    });
+
+    const result = await client.realtimeCall?.({
+      endpoint: "live",
+      query: "intent=quicksilver&architecture=avas",
+      sdp: "v=offer\r\n",
+      session: { ...SESSION, delegation: { type: "client" } },
+      headers: { "openai-alpha": "quicksilver=v2" },
+    });
+
+    const [url, init] = fetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers: Record<string, string> },
+    ];
+    expect(url).toBe(
+      "https://chatgpt.com/backend-api/codex/realtime/calls?intent=quicksilver&architecture=avas",
+    );
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body as string)).toEqual({
+      sdp: "v=offer\r\n",
+      session: { ...SESSION, delegation: { type: "client" } },
+    });
+    expect(result?.sideband.url).toBe("wss://chatgpt.com/backend-api/codex/rtc_backend");
+    expect(await result?.sideband.headers()).toMatchObject({
+      Authorization: "Bearer oauth-token",
+      "chatgpt-account-id": "acct-1",
+    });
+  });
+
+  it("preserves a non-2xx upstream response as an UpstreamError", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "bad session" } }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = createOpenAIClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-secret" },
+      fetch,
+    });
+
+    await expect(
+      client.realtimeCall?.({
+        endpoint: "realtime",
+        query: "",
+        sdp: "v=offer\r\n",
+        session: SESSION,
+        headers: {},
+      }),
+    ).rejects.toMatchObject({ name: "UpstreamError", upstreamStatus: 400 });
+  });
+
+  it("refreshes OAuth once after a 401 call-create response", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response("v=answer\r\n", {
+          status: 201,
+          headers: { location: "/v1/realtime/calls/rtc_refreshed" },
+        }),
+      );
+    let token = 1;
+    const onUnauthorized = vi.fn(() => {
+      token = 2;
+    });
+    const client = createOpenAIClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer token-${token}`,
+        onUnauthorized,
+      },
+      fetch,
+    });
+
+    const result = await client.realtimeCall?.({
+      endpoint: "realtime",
+      query: "",
+      sdp: "v=offer\r\n",
+      session: SESSION,
+      headers: {},
+    });
+
+    expect(result?.callId).toBe("rtc_refreshed");
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(
+      fetch.mock.calls.map((call) => (call[1]?.headers as Record<string, string>).Authorization),
+    ).toEqual(["Bearer token-1", "Bearer token-2"]);
+  });
+});

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -4,6 +4,7 @@
 // injected config (env-sourced) and are never logged or echoed. See docs/02.
 
 import type { NativePassthroughInput } from "@helm/shared";
+import type { ProxyConfig } from "./proxy.js";
 // Provider credential: EXACTLY ONE of a static `apiKey` or a dynamic
 // `getAuthHeader` (issue #38 OAuth). The dynamic path also accepts:
 //   - `onUnauthorized`: invoked once on an upstream 401 to force a token refresh
@@ -45,6 +46,8 @@ export interface ProviderConfig {
   // does not burn a candidate or 502 a single-candidate chain.
   connectRetries?: number;
   connectRetryBackoffMs?: readonly number[];
+  // Realtime sideband WebSockets must use the same egress hop as the HTTP call.
+  realtimeProxy?: ProxyConfig;
 }
 
 export interface OpenAIClientDeps {
@@ -54,6 +57,42 @@ export interface OpenAIClientDeps {
 
 export type ChatCompletionRequest = Record<string, unknown>;
 export type ChatCompletionResponse = Record<string, unknown>;
+export type ImageEditInput =
+  | { kind: "json"; body: Record<string, unknown> }
+  | { kind: "multipart"; fields: readonly ImageEditMultipartField[] };
+export type ImageEditMultipartField =
+  | { name: string; value: string }
+  | {
+      name: string;
+      value: Uint8Array;
+      filename: string;
+      contentType: string;
+    };
+
+export interface RealtimeCallRequest {
+  endpoint: "realtime" | "live";
+  query: string;
+  sdp: string;
+  session: Record<string, unknown>;
+  /** Already allowlisted client metadata; never contains the Helm credential. */
+  headers: Record<string, string>;
+}
+
+export interface RealtimeSidebandTarget {
+  url: string;
+  headers(): Promise<Record<string, string>>;
+  onUnauthorized?: () => void;
+  proxy?: ProxyConfig;
+}
+
+export interface RealtimeCallResult {
+  status: number;
+  sdp: string;
+  contentType: string | null;
+  location: string;
+  callId: string;
+  sideband: RealtimeSidebandTarget;
+}
 export type NativeProtocolProfile =
   | "anthropic_messages"
   | "codex_responses"
@@ -138,6 +177,8 @@ export interface ProviderClient {
     req: Record<string, unknown>,
     opts?: ProviderCallOptions,
   ): Promise<Record<string, unknown>>;
+  imageEdit?(req: ImageEditInput, opts?: ProviderCallOptions): Promise<Record<string, unknown>>;
+  realtimeCall?(req: RealtimeCallRequest, opts?: ProviderCallOptions): Promise<RealtimeCallResult>;
   responsesInputTokens?(
     req: ChatCompletionRequest,
     opts?: { signal?: AbortSignal },
@@ -287,6 +328,11 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     return `${base}/images/generations`;
   }
 
+  async function imageEditsUrl(): Promise<string> {
+    const base = cfg.resolveBaseUrl ? await cfg.resolveBaseUrl() : cfg.baseUrl;
+    return `${base}/images/edits`;
+  }
+
   // Fail-closed credential guard (principle 2): EXACTLY ONE of static apiKey or
   // dynamic getAuthHeader. A client built with both / neither cannot resolve an
   // unambiguous auth header, so refuse construction rather than silently pick one.
@@ -310,6 +356,12 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       "Content-Type": "application/json",
       ...(cfg.extraHeaders ? cfg.extraHeaders() : {}),
     };
+  }
+
+  async function headersWithoutContentType(): Promise<Record<string, string>> {
+    const next = await headers();
+    delete next["Content-Type"];
+    return next;
   }
 
   function prepareRequest(req: ChatCompletionRequest): ChatCompletionRequest {
@@ -420,6 +472,45 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     return res;
   }
 
+  async function rawRequestWithAuthRetry(options: {
+    url: () => Promise<string>;
+    body: () => NonNullable<RequestInit["body"]>;
+    headers: () => Promise<Record<string, string>>;
+    signal?: AbortSignal;
+  }): Promise<Response> {
+    const attempt = async (): Promise<Response> =>
+      withConnectionRetry(
+        async () => {
+          const t = withTimeout(timeoutMs, options.signal);
+          try {
+            return await doFetch(await options.url(), {
+              method: "POST",
+              headers: await options.headers(),
+              body: options.body(),
+              signal: t.signal,
+            });
+          } catch (error) {
+            if (t.isTimeout() && !t.isExternalAbort()) {
+              throw new UpstreamError("timeout", "upstream request timed out");
+            }
+            throw error;
+          } finally {
+            t.cleanup();
+          }
+        },
+        {
+          retries: cfg.connectRetries,
+          backoffMs: cfg.connectRetryBackoffMs,
+          signal: options.signal,
+        },
+      );
+    const response = await attempt();
+    if (response.status !== 401 || cfg.onUnauthorized === undefined) return response;
+    await response.body?.cancel().catch(() => {});
+    cfg.onUnauthorized();
+    return await attempt();
+  }
+
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
     const providerRaw = await res
       .json()
@@ -454,6 +545,100 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       );
       if (!res.ok) throw await errorFromResponse(res);
       return (await res.json()) as Record<string, unknown>;
+    },
+
+    async imageEdit(req, opts) {
+      let captured = false;
+      const body = (): NonNullable<RequestInit["body"]> => {
+        if (req.kind === "json") {
+          const wire = JSON.stringify(req.body);
+          if (!captured) {
+            captured = true;
+            opts?.captureUpstream?.(wire);
+          }
+          return wire;
+        }
+        const form = new FormData();
+        for (const field of req.fields) {
+          if (!("filename" in field)) form.append(field.name, field.value);
+          else {
+            form.append(
+              field.name,
+              new Blob([field.value], { type: field.contentType }),
+              field.filename,
+            );
+          }
+        }
+        return form;
+      };
+      const res = await rawRequestWithAuthRetry({
+        url: imageEditsUrl,
+        body,
+        headers: req.kind === "json" ? headers : headersWithoutContentType,
+        signal: opts?.signal,
+      });
+      if (!res.ok) throw await errorFromResponse(res);
+      return (await res.json()) as Record<string, unknown>;
+    },
+
+    async realtimeCall(req, opts) {
+      const base = cfg.resolveBaseUrl ? await cfg.resolveBaseUrl() : cfg.baseUrl;
+      const backendShape = base.includes("/backend-api/");
+      const callPath = backendShape || req.endpoint === "realtime" ? "realtime/calls" : "live";
+      const query = req.query.length > 0 ? `?${req.query}` : "";
+      const url = `${base}/${callPath}${query}`;
+      const forwardedHeaders = async (): Promise<Record<string, string>> => ({
+        ...(await headersWithoutContentType()),
+        ...req.headers,
+      });
+      const body = (): NonNullable<RequestInit["body"]> => {
+        if (backendShape) return JSON.stringify({ sdp: req.sdp, session: req.session });
+        const form = new FormData();
+        form.append("sdp", new Blob([req.sdp], { type: "application/sdp" }), "sdp");
+        form.append(
+          "session",
+          new Blob([JSON.stringify(req.session)], { type: "application/json" }),
+          "session.json",
+        );
+        return form;
+      };
+      const response = await rawRequestWithAuthRetry({
+        url: async () => url,
+        body,
+        headers: backendShape
+          ? async () => ({ ...(await forwardedHeaders()), "Content-Type": "application/json" })
+          : forwardedHeaders,
+        signal: opts?.signal,
+      });
+      if (!response.ok) throw await errorFromResponse(response);
+      const sdp = await response.text();
+      const location = response.headers.get("location") ?? "";
+      const callId = location.split("/").filter(Boolean).at(-1) ?? "";
+      if (callId.length === 0) {
+        throw new UpstreamError("upstream_error", "upstream Realtime response omitted call id");
+      }
+      const sideband = new URL(base);
+      sideband.protocol = sideband.protocol === "http:" ? "ws:" : "wss:";
+      if (!backendShape) sideband.pathname = req.endpoint === "live" ? "/v1/live" : "/v1/realtime";
+      if (req.endpoint === "live") {
+        sideband.pathname = `${sideband.pathname.replace(/\/$/, "")}/${callId}`;
+      } else {
+        sideband.search = req.query;
+        sideband.searchParams.set("call_id", callId);
+      }
+      return {
+        status: response.status,
+        sdp,
+        contentType: response.headers.get("content-type"),
+        location,
+        callId,
+        sideband: {
+          url: sideband.toString(),
+          headers: forwardedHeaders,
+          ...(cfg.onUnauthorized ? { onUnauthorized: cfg.onUnauthorized } : {}),
+          ...(cfg.realtimeProxy ? { proxy: cfg.realtimeProxy } : {}),
+        },
+      };
     },
 
     async *chatCompletionStream(req, opts) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -293,6 +293,8 @@ export {
   selectCodexAccountWeeklyQuotaWindows,
 } from "./oauth/usage-schema.js";
 export {
+  type ImageEditRequest,
+  ImageEditRequestSchema,
   type ImageGenerationRequest,
   ImageGenerationRequestSchema,
   type ImageGenerationResponse,
@@ -309,6 +311,10 @@ export {
   type InteractionsResponse,
   InteractionsResponseSchema,
 } from "./request/interactions-schema.js";
+export {
+  type RealtimeSession,
+  RealtimeSessionSchema,
+} from "./request/realtime-schema.js";
 // Internal request structure (docs/02).
 export {
   type InternalRequest,

--- a/packages/shared/src/request/images-schema.test.ts
+++ b/packages/shared/src/request/images-schema.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { ImageGenerationRequestSchema, ImageGenerationResponseSchema } from "./images-schema.js";
+import {
+  ImageEditRequestSchema,
+  ImageGenerationRequestSchema,
+  ImageGenerationResponseSchema,
+} from "./images-schema.js";
+
+describe("ImageEditRequestSchema", () => {
+  it("accepts the Codex JSON image_url carrier", () => {
+    expect(
+      ImageEditRequestSchema.safeParse({
+        model: "gpt-image-2",
+        prompt: "add a hat",
+        images: [{ image_url: "data:image/png;base64,AAA=" }],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("requires at least one image", () => {
+    expect(
+      ImageEditRequestSchema.safeParse({ model: "gpt-image-2", prompt: "add a hat", images: [] })
+        .success,
+    ).toBe(false);
+  });
+});
 
 describe("ImageGenerationRequestSchema", () => {
   it("parses a minimal {model, prompt}", () => {

--- a/packages/shared/src/request/images-schema.ts
+++ b/packages/shared/src/request/images-schema.ts
@@ -21,6 +21,24 @@ export const ImageGenerationRequestSchema = z.looseObject({
   user: z.string().optional(),
 });
 
+export const ImageEditRequestSchema = z.looseObject({
+  model: z.string().min(1),
+  prompt: z.string().min(1),
+  images: z
+    .array(
+      z.union([
+        z.looseObject({ image_url: z.string().min(1) }),
+        z.looseObject({ file_id: z.string().min(1) }),
+      ]),
+    )
+    .min(1),
+  n: z.number().int().positive().optional(),
+  size: z.string().optional(),
+  quality: z.string().optional(),
+  background: z.string().optional(),
+  output_format: z.string().optional(),
+});
+
 // Upstream usage shape (OpenAI Images): the generated image is billed as
 // output_tokens (= output_tokens_details.image_tokens). Loose — typing only for
 // the cost path; the route forwards the upstream body verbatim, never reshapes it.
@@ -39,4 +57,5 @@ export const ImageGenerationResponseSchema = z.looseObject({
 });
 
 export type ImageGenerationRequest = z.infer<typeof ImageGenerationRequestSchema>;
+export type ImageEditRequest = z.infer<typeof ImageEditRequestSchema>;
 export type ImageGenerationResponse = z.infer<typeof ImageGenerationResponseSchema>;

--- a/packages/shared/src/request/realtime-schema.test.ts
+++ b/packages/shared/src/request/realtime-schema.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { RealtimeSessionSchema } from "./realtime-schema.js";
+
+describe("RealtimeSessionSchema", () => {
+  it("keeps provider-specific session fields while requiring a model", () => {
+    const parsed = RealtimeSessionSchema.parse({
+      model: "gpt-realtime-1.5",
+      type: "quicksilver",
+      audio: { output: { voice: "cove" } },
+    });
+    expect(parsed.audio).toEqual({ output: { voice: "cove" } });
+  });
+
+  it("rejects a session without a model", () => {
+    expect(RealtimeSessionSchema.safeParse({ type: "quicksilver" }).success).toBe(false);
+  });
+});

--- a/packages/shared/src/request/realtime-schema.ts
+++ b/packages/shared/src/request/realtime-schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const RealtimeSessionSchema = z.looseObject({
+  model: z.string().min(1),
+});
+
+export type RealtimeSession = z.infer<typeof RealtimeSessionSchema>;


### PR DESCRIPTION
## What changed

- proxy Realtime Voice V1/V2/V3 call creation and authenticated WebSocket sidebands
- preserve the selected OAuth account, token refresh path, and egress proxy across HTTP and WebSocket
- accept Responses input_audio.audio_url and audio model-discovery metadata
- proxy /v1/images/edits for Codex JSON and OpenAI multipart carriers through the existing image execution chain
- document the new API surface and the process-local registry scaling ceiling

## Why

The ChatGPT desktop client now uses Realtime Voice and related multimodal request shapes that Helm did not fully proxy. Requests either had no matching route or lost protocol-specific carriers.

## Validation

- 19 targeted Vitest files, 376 tests passed
- CI=true pnpm typecheck
- CI=true pnpm lint (37 pre-existing warnings in packages/shared/src/ci-workflow.test.ts)
- CI=true pnpm build
- git diff --check

## Deferred

- alpha/search
- memories/trace_summarize

These remain intentionally out of scope pending a confirmed client contract.