### PR TITLE
[codex] reject requests under live heap pressure

### DIFF
--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -57,6 +57,29 @@ describe("body memory admission", () => {
     expect(admission.reservedBytes).toBe(0);
   });
 
+  it("rejects new bodies when live heap pressure has consumed protected headroom", () => {
+    let heapUsedBytes = 71;
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      maxWireBytes: 100,
+      jsonAmplification: 2,
+      minRequestChargeBytes: 10,
+      heapLimitBytes: 100,
+      protectedHeapBytes: 20,
+      heapUsedBytes: () => heapUsedBytes,
+    });
+
+    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy" });
+    heapUsedBytes = 60;
+    const admitted = admission.acquire(1);
+    expect(admitted.ok).toBe(true);
+    if (admitted.ok) {
+      heapUsedBytes = 71;
+      expect(admitted.lease.resize(1)).toMatchObject({ ok: false, reason: "busy" });
+      admitted.lease.release();
+    }
+  });
+
   it("bounds a streaming body before JSON parsing and returns its lease", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 120,

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -17,6 +17,9 @@ export function createBodyMemoryAdmission(options: {
   maxWireBytes: number;
   jsonAmplification: number;
   minRequestChargeBytes?: number;
+  heapLimitBytes?: number;
+  protectedHeapBytes?: number;
+  heapUsedBytes?: () => number;
 }) {
   let reservedBytes = 0;
   let paused = false;
@@ -29,6 +32,19 @@ export function createBodyMemoryAdmission(options: {
     options.minRequestChargeBytes ?? Math.max(1, Math.floor(options.activeRequestBytes * 0.01));
   const charge = (wireBytes: number): number =>
     Math.max(minRequestChargeBytes, Math.ceil(Math.max(0, wireBytes) * options.jsonAmplification));
+  const heapCeilingBytes = Math.max(
+    0,
+    (options.heapLimitBytes ?? Number.POSITIVE_INFINITY) - (options.protectedHeapBytes ?? 0),
+  );
+  const exceedsLiveHeap = (nextReservedBytes: number): boolean => {
+    const heapUsedBytes = options.heapUsedBytes?.();
+    return (
+      heapUsedBytes !== undefined &&
+      Number.isFinite(heapUsedBytes) &&
+      heapUsedBytes >= 0 &&
+      heapUsedBytes + nextReservedBytes > heapCeilingBytes
+    );
+  };
   const rejection = (wireBytes: number) =>
     wireBytes > options.maxWireBytes
       ? { ok: false as const, reason: "too_large" as const }
@@ -39,7 +55,11 @@ export function createBodyMemoryAdmission(options: {
     acquire(wireBytes: number) {
       if (paused) return { ok: false as const, reason: "busy" as const };
       let held = charge(wireBytes);
-      if (wireBytes > options.maxWireBytes || reservedBytes + held > options.activeRequestBytes) {
+      if (
+        wireBytes > options.maxWireBytes ||
+        reservedBytes + held > options.activeRequestBytes ||
+        exceedsLiveHeap(reservedBytes + held)
+      ) {
         return rejection(wireBytes);
       }
       reservedBytes += held;
@@ -52,7 +72,8 @@ export function createBodyMemoryAdmission(options: {
             const next = charge(nextWireBytes);
             if (
               nextWireBytes > options.maxWireBytes ||
-              reservedBytes - held + next > options.activeRequestBytes
+              reservedBytes - held + next > options.activeRequestBytes ||
+              exceedsLiveHeap(reservedBytes - held + next)
             ) {
               return rejection(nextWireBytes);
             }

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1767,6 +1767,12 @@ export async function buildServer(
   const logger = opts.logger ?? createJsonLogger();
   const responsesWebSocketSessionProof = randomUUID();
   const memoryBudget = runtimeMemoryBudget();
+  const requestProtectedHeapBytes =
+    memoryBudget.responseWorkBytes +
+    memoryBudget.writeQueueBytes +
+    memoryBudget.sessionCacheBytes +
+    memoryBudget.responseCaptureBytes +
+    Math.floor(memoryBudget.heapLimitBytes * 0.05);
   const maintenanceActivityGate = createMaintenanceActivityGate();
   const backgroundTasks = createTrackedBackgroundTasks();
   const requestBodyMemoryAdmission = createBodyMemoryAdmission({
@@ -1774,6 +1780,9 @@ export async function buildServer(
     maxWireBytes: memoryBudget.maxWireBytes,
     jsonAmplification: memoryBudget.jsonAmplification,
     minRequestChargeBytes: memoryBudget.minRequestChargeBytes,
+    heapLimitBytes: memoryBudget.heapLimitBytes,
+    protectedHeapBytes: requestProtectedHeapBytes,
+    heapUsedBytes: () => process.memoryUsage().heapUsed,
   });
   logger.log("info", "runtime.memory_budget", {
     heap_limit_bytes: memoryBudget.heapLimitBytes,
@@ -1781,6 +1790,7 @@ export async function buildServer(
     active_request_bytes: memoryBudget.activeRequestBytes,
     max_wire_bytes: memoryBudget.maxWireBytes,
     min_request_charge_bytes: memoryBudget.minRequestChargeBytes,
+    request_heap_ceiling_bytes: memoryBudget.heapLimitBytes - requestProtectedHeapBytes,
     write_queue_bytes: memoryBudget.writeQueueBytes,
     session_cache_bytes: memoryBudget.sessionCacheBytes,
     response_capture_bytes: memoryBudget.responseCaptureBytes,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-24 · 请求准入增加实时 V8 堆高水位（Gateway runtime，docs/02/07/10，原则 3/7）
+
+- **线上根因**：`v0.28.7` 已限制请求、响应、写队列、Session cache 与 SSE capture 各自的静态容量，但生产容器仍在 12 小时内因 V8 heap OOM 重启 8 次；崩溃前 Mark-Compact 后仍有约 647 MiB live heap，而 heap limit 约 674 MiB。分池上限没有把当前 live heap 与其他分池尚可增长的容量合并判断，因此下一次 UTF-8 请求正文转换仍可触发进程级 OOM。
+- **统一边界**：复用所有 HTTP JSON 与 Responses WebSocket 内部请求已经经过的 `BodyMemoryAdmission`，在读取、扩容和 `JSON.parse` 前同时检查 `heapUsed + active reservations`。高水位为 heap limit 扣除 response work、write queue、Session cache、response capture 与 5% GC 余量；超过时沿用现有协议形状返回 503，单请求 wire 上限仍返回 413。未新增配置、依赖、队列或并发限制。
+- **运维边界**：该保护把聚合内存压力转成可恢复的拒绝，不负责物理缩小生产 20 GiB SQLite；历史正文清理与 VACUUM 仍必须通过既有维护 drain、磁盘与内存门禁执行，不能在线手工 VACUUM。
+
 ## 2026-07-24 · Admin 登录在 Host 被代理改写时复用浏览器同源证明（Admin auth，docs/10/11，原则 3/7）
 
 - **根因与修复**：Admin 登录/登出的 CSRF 校验原本只比较 `Origin` 与请求 `Host` / `X-Forwarded-Host`；部分反向代理或 NAT 会把 `Host` 改成内部地址且不补 `X-Forwarded-Host`，导致浏览器从同一外部 origin 提交表单也稳定返回 403。校验现在优先接受浏览器提供的 `Sec-Fetch-Site: same-origin`，再保留原有 Host 比较与 opaque-origin 边界；`cross-site` 仍拒绝。该 header 不能由网页脚本伪造，而无 `Origin` 的非浏览器客户端原本就允许，因此不新增配置、代理白名单或信任任意 forwarded header。


### PR DESCRIPTION
## What changed

- check current V8 heap use at the shared JSON body admission boundary
- reserve room for provider responses, write queue, Session cache, response capture, and GC
- reject new HTTP or Responses WebSocket work with the existing structured 503 before body conversion can reset the process

## Root cause

The static per-component budgets added in #621 were individually bounded but did not compare aggregate live heap use with the remaining work those components could still allocate. Production `v0.28.7` therefore still restarted 8 times in 12 hours. The OOM trace showed about 647 MiB surviving Mark-Compact against a roughly 674 MiB V8 heap limit, followed by failure while converting the next UTF-8 request body.

## Impact

Normal requests are unchanged below the live high-water mark. Under aggregate memory pressure, new JSON work gets the existing protocol-shaped 503 and can retry after retained work drains. The existing per-request 413 boundary is unchanged.

This does not shrink the production SQLite file; cleanup and VACUUM remain behind their existing maintenance safety gates.

Related to #619.

## Validation

- `CI=true pnpm exec vitest run apps/gateway/src/responses-websocket.test.ts apps/gateway/src/routes/chat.route.test.ts apps/gateway/src/routes/gemini.test.ts apps/gateway/src/routes/images.test.ts apps/gateway/src/routes/interactions.test.ts apps/gateway/src/routes/messages.test.ts apps/gateway/src/routes/responses.test.ts apps/gateway/src/runtime/memory-admission.test.ts` (273 passed)
- `CI=true pnpm exec vitest run apps/gateway/src/runtime/memory-admission.test.ts apps/gateway/src/server.test.ts` (20 passed)
- `CI=true pnpm --filter @helm/gateway typecheck`
- `pnpm exec biome check apps/gateway/src/runtime/memory-admission.ts apps/gateway/src/runtime/memory-admission.test.ts apps/gateway/src/server.ts`
- `git diff --check`
