### PR TITLE
[codex] release v0.28.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.7",
+  "version": "0.28.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.28.7` to `0.28.8` after #631 fixed Admin login behind reverse proxies that rewrite `Host`.

The version-driven publish workflow will create:

- immutable `sha-<full-SHA>` image
- `0.28.8` image tag
- `latest` promotion
- Git tag and GitHub Release `v0.28.8`

## Validation

- #631 complete CI: verify, e2e, Docker, and required-check aggregation all passed
- release version is currently unreleased
- this PR changes only the root package version
