### PR TITLE
[codex] release 0.28.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.8",
+  "version": "0.28.9",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the Helm API package version from 0.28.8 to 0.28.9

## Why

Release the live V8 heap-pressure admission fix merged in PR #632 as a new immutable image. The existing 0.28.8 release predates that fix.

## Validation

- package.json parses and reports 0.28.9
- git diff --check
- full required CI will run on this PR