### PR TITLE
[codex] release 0.28.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.9",
+  "version": "0.28.10",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the Helm API package version from 0.28.9 to 0.28.10

## Why

Release the Realtime Voice, Responses audio, model audio modality, and image edits proxy support merged in PR #630 as a new immutable image. The existing 0.28.9 release predates those APIs.

## Validation

- package.json parses and reports 0.28.10
- git diff --check
- full required CI will run on this PR