### PR TITLE
[codex] complete Codex realtime upstream wiring

### DIFF
--- a/apps/gateway/src/routes/realtime.test.ts
+++ b/apps/gateway/src/routes/realtime.test.ts
@@ -58,7 +58,7 @@ describe("registerRealtimeRoutes", () => {
       headers: {
         Authorization: "Bearer helm-key",
         "openai-alpha": "quicksilver=v1",
-        "session-id": "sess-1",
+        "x-session-id": "sess-1",
         "x-secret": "do-not-forward",
       },
       body: multipart({ model: "gpt-realtime-1.5", type: "quicksilver" }),
@@ -75,7 +75,7 @@ describe("registerRealtimeRoutes", () => {
         session: expect.objectContaining({ model: "gpt-realtime-1.5" }),
         headers: {
           "openai-alpha": "quicksilver=v1",
-          "session-id": "sess-1",
+          "x-session-id": "sess-1",
         },
       }),
       expect.anything(),

--- a/apps/gateway/src/routes/realtime.ts
+++ b/apps/gateway/src/routes/realtime.ts
@@ -18,6 +18,7 @@ const FORWARDED_HEADERS = [
   "openai-alpha",
   "originator",
   "session-id",
+  "x-session-id",
   "thread-id",
   "version",
   "x-client-request-id",

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1304,6 +1304,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     });
     const modelRequests: Headers[] = [];
     const responseRequests: Array<{ headers: Headers; body: Record<string, unknown> }> = [];
+    const realtimeRequests: Headers[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = typeof input === "string" ? input : input.toString();
       const headers = new Headers(init?.headers);
@@ -1327,6 +1328,13 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
             headers: { "Content-Type": "application/json", ETag: '"catalog-v1"' },
           },
         );
+      }
+      if (url.includes("/realtime/calls")) {
+        realtimeRequests.push(headers);
+        return new Response("v=answer\\r\\n", {
+          status: 201,
+          headers: { Location: "/v1/live/rtc-1" },
+        });
       }
       responseRequests.push({
         headers,
@@ -1378,6 +1386,17 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect(responseRequests[0]?.headers.get("X-OpenAI-Fedramp")).toBe("true");
     expect(responseRequests[0]?.headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
     expect(responseRequests[0]?.body.parallel_tool_calls).toBe(false);
+
+    await poolClients.get("openai-codex")?.realtimeCall?.({
+      endpoint: "live",
+      query: "",
+      sdp: "v=offer\\r\\n",
+      session: { type: "quicksilver", model: "gpt-live-1-boulder-alpha" },
+      headers: {},
+    });
+    expect(realtimeRequests[0]?.get("user-agent")).toContain(
+      `codex_cli_rs/${DEFAULT_OPENAI_CODEX_CLIENT_VERSION}`,
+    );
   });
 
   it("normalizes prerelease discovery to the Codex whole version and reuses its cache", async () => {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1553,7 +1553,10 @@ function createProviderClient(
             ...codexRuntime?.accountIdentity,
             ...codexIdentityFromMetadata(cred.currentMetadata()),
           };
-          return identity.accountId ? { "chatgpt-account-id": identity.accountId } : {};
+          return {
+            ...(identity.accountId ? { "chatgpt-account-id": identity.accountId } : {}),
+            ...(codexRuntime?.userAgent ? { "User-Agent": codexRuntime.userAgent } : {}),
+          };
         },
       },
       fetch: providerFetch,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,6 +10,7 @@
 ## 2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面（Gateway / Protocol / Provider，docs/01/05/06，原则 1/2/3/7/8）
 
 - **Realtime V1/V2/V3**：新增 `/v1/realtime/calls`、`/v1/live` 与对应 WebSocket sideband。Call-create 复用现有 static/OpenAI-Codex provider client、OAuth pool、账号 token 与 egress proxy；ChatGPT backend 继续使用 JSON call shape，官方 OpenAI 使用 multipart。`call_id` 以进程内短 TTL 绑定创建它的 Helm key 与实际 provider/account sideband，WebSocket 必须使用同一 key，且不会重新选账号；OAuth HTTP/WS 401 各只刷新重试一次。Call-create 接入现有进程内或 PostgreSQL 分布式并发 lease，DB 不可用时 fail-closed 为 503，持有期间 lease 丢失会中止上游请求。双向文本/二进制帧按实际字节占用动态内存预算，关闭压缩并保留 close code。当前部署为单 gateway replica；水平扩容前必须把 registry 换成支持原子 claim 的共享存储。
+- **Codex upstream 线缆**：Codex 实际 WebRTC 请求使用 `x-session-id`，因此仅保留旧 `session-id` 会丢失会话身份；Realtime 只转发这一个额外的显式安全 header。ChatGPT backend 的 V3 `/v1/live` 不携带 query，但上游仍要求 `intent=quicksilver&architecture=avas`，只在 backend shape 且 query 为空时补该固定值；同时复用目录运行时已生成的 Codex User-Agent，不信任或透传调用方任意 User-Agent。
 - **Responses 与模型目录**：Responses `input_audio.audio_url` data URL 进入统一 audio IR；provider 明确声明 `responses_audio_url` 时恢复同一 carrier，旧 `input_audio:{data,format}` 保持兼容。Codex 模型目录的 `input_modalities` 接受 `audio`，不再因新目录字段丢弃模型。
 - **Images edits**：`/v1/images/edits` 复用现有 Images 的鉴权、限流、并发、预算、blocked-model、breaker/fallback、成本与 payload/telemetry 链；支持 Codex JSON `images[].image_url|file_id` 和 OpenAI multipart `image`/`image[]`、`mask`，binary bytes 在 fallback 间可重放。Gemini edit 未发现兼容契约，确定性返回 unsupported，不做有损转换。
 - **暂缓边界**：按用户确认不代理 `alpha/search` 与 `memories/trace_summarize`；未引入新依赖、媒体存储、共享 registry 或第二套路由器。

--- a/packages/core/src/provider/openai.realtime.test.ts
+++ b/packages/core/src/provider/openai.realtime.test.ts
@@ -53,7 +53,7 @@ describe("createOpenAIClient.realtimeCall", () => {
     });
   });
 
-  it("translates ChatGPT OAuth calls to JSON and keeps Frameless sideband on the bound account", async () => {
+  it("uses the required AVAS query for ChatGPT Frameless calls and keeps its Codex identity", async () => {
     const fetch = vi.fn().mockResolvedValue(
       new Response("v=answer\r\n", {
         status: 201,
@@ -65,14 +65,17 @@ describe("createOpenAIClient.realtimeCall", () => {
       config: {
         baseUrl: "https://chatgpt.com/backend-api/codex",
         getAuthHeader,
-        extraHeaders: () => ({ "chatgpt-account-id": "acct-1" }),
+        extraHeaders: () => ({
+          "chatgpt-account-id": "acct-1",
+          "User-Agent": "codex_cli_rs/0.145.0",
+        }),
       },
       fetch,
     });
 
     const result = await client.realtimeCall?.({
       endpoint: "live",
-      query: "intent=quicksilver&architecture=avas",
+      query: "",
       sdp: "v=offer\r\n",
       session: { ...SESSION, delegation: { type: "client" } },
       headers: { "openai-alpha": "quicksilver=v2" },
@@ -86,6 +89,7 @@ describe("createOpenAIClient.realtimeCall", () => {
       "https://chatgpt.com/backend-api/codex/realtime/calls?intent=quicksilver&architecture=avas",
     );
     expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers["User-Agent"]).toBe("codex_cli_rs/0.145.0");
     expect(JSON.parse(init.body as string)).toEqual({
       sdp: "v=offer\r\n",
       session: { ...SESSION, delegation: { type: "client" } },

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -585,7 +585,12 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       const base = cfg.resolveBaseUrl ? await cfg.resolveBaseUrl() : cfg.baseUrl;
       const backendShape = base.includes("/backend-api/");
       const callPath = backendShape || req.endpoint === "realtime" ? "realtime/calls" : "live";
-      const query = req.query.length > 0 ? `?${req.query}` : "";
+      const query =
+        req.query.length > 0
+          ? `?${req.query}`
+          : backendShape && req.endpoint === "live"
+            ? "?intent=quicksilver&architecture=avas"
+            : "";
       const url = `${base}/${callPath}${query}`;
       const forwardedHeaders = async (): Promise<Record<string, string>> => ({
         ...(await headersWithoutContentType()),


### PR DESCRIPTION
## What changed

- Forward Codex `x-session-id` on Realtime call creation.
- Supply the required AVAS query for ChatGPT backend V3 calls when Codex sends none.
- Reuse the trusted runtime Codex User-Agent upstream.

## Why

ChatGPT upstream accepted direct calls but Helm calls returned 400 because these protocol fields were missing.

## Validation

- `CI=true pnpm exec vitest run apps/gateway/src/server.oauth.test.ts apps/gateway/src/routes/realtime.test.ts packages/core/src/provider/openai.realtime.test.ts`
- `pnpm typecheck`
- `pnpm lint` (37 pre-existing warnings; no errors)
- `pnpm build`
- Claude CLI Opus review: no actionable findings.