### PR TITLE
[codex] release v0.28.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.10",
+  "version": "0.28.11",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.28.10` to `0.28.11` after merging PR #636.

## Validation

- `CI=true pnpm exec vitest run packages/shared/src/ci-workflow.test.ts`
- package version readback: `0.28.11`