### PR TITLE
[codex] release 0.28.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.11",
+  "version": "0.28.12",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump Helm API patch version from 0.28.11 to 0.28.12
- publish the merged OAuth Realtime serialization and image-edit fallback fixes

## Source

- base main: `fb65c3e8d95952ed5e2b711b2f85858349ecb790`
- feature PR: #639

## Validation

- `node -p "require('./package.json').version"` -> `0.28.12`
- version-only diff; required CI must pass before merge