### PR TITLE
chore(release): v0.28.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.12",
+  "version": "0.28.13",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release: 上游过载（529/503）在 fetch 边界退避重试。

## 本版内容

- **#641** `fix(provider)`: 529 Overloaded / 503 现在会在 provider 的 fetch 边界**退避后重发同一请求**（1s → 3s，2 次重试），而不是立刻烧掉一个 fallback 候选、或把单候选链 502 给客户端。

  收窄到 529 + 503：500/502 是不明服务端故障（重试只是拖延真正的失败），429 是真限流（账号池 park 账号后走链）。上游给数字 `Retry-After` 则优先，钳制在 10s。仅首字节前重试（幂等），客户端断连立刻停。

  下游逻辑一行未改——重试耗尽后仍抛原来的 `UpstreamError(upstreamStatus: 529)`，账号池换号 / 熔断 / fallback 链 / 遥测行为完全一致。

## 风险评估

- **无新接口、无新配置项、无迁移、无新依赖**——纯 provider 层行为修正
- 面向客户端的失败**语义不变**，只是延后 ~4s 才可能发生（且多数情况下不再发生）
- 唯一可观察的副作用：真实持续过载时，单个候选的耗时上限增加约 4s

## 版本号

`0.28.12` → `0.28.13`（patch：无新网关接口，纯 fix）

🤖 Generated with [Claude Code](https://claude.com/claude-code)