### PR TITLE
feat(config): add Claude Opus 5 pricing and capabilities

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -370,6 +370,22 @@ google/gemini-3-pro-image:
   outputImage: true
   maxContextTokens: 32768
   maxOutputTokens: 32768
+zenmux-anthropic/claude-opus-5:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: true
+      levels: [low, medium, high, xhigh, max]
+      map:
+        minimal: low
+    anthropicThinking:
+      supported: false
+  modalities: [document]
+  maxContextTokens: 1000000
+  maxOutputTokens: 128000
 zenmux-anthropic/claude-opus-4.8:
   supportsTools: true
   jsonOutput: schema
@@ -431,6 +447,28 @@ zenmux-anthropic/claude-haiku-4.5:
 # (maxContextTokens: 0) and the filter would prune EVERY request as context_too_small
 # (catalog/index.ts). So caps + pricing must be added together. Limits are the real
 # per-model Anthropic figures (Opus/Sonnet/Fable 1M; Haiku 200K).
+# Claude Opus 5: same request surface as Opus 4.8 — 1M context, 128K output, the full
+# low/medium/high/xhigh/max effort set, no manual budget_tokens mode. Thinking is ON by
+# default (omitting `thinking` runs adaptive, unlike 4.8), and `{type:"disabled"}` is
+# accepted only at effort high or below, so `anthropicThinking.supported` stays false —
+# helm routes effort through anthropicOutputConfig exactly as for 4.8.
+# https://platform.claude.com/docs/en/about-claude/models/overview
+anthropic/claude-opus-5:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    anthropicOutputConfig:
+      supported: true
+      levels: [low, medium, high, xhigh, max]
+      map:
+        minimal: low
+    anthropicThinking:
+      supported: false
+  modalities: [document]
+  maxContextTokens: 1000000
+  maxOutputTokens: 128000
 anthropic/claude-opus-4-8:
   supportsTools: true
   jsonOutput: schema

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -494,6 +494,12 @@ google/gemini-3-pro-image:
       inputPerMTokUsd: 3.6
       outputPerMTokUsd: 21.6
       imageOutputPerMTokUsd: 216.0
+zenmux-anthropic/claude-opus-5:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 25.0
+  cacheReadPerMTokUsd: 0.5
+  cacheWritePerMTokUsd: 6.25
+  cacheWrite1hPerMTokUsd: 10.0
 zenmux-anthropic/claude-opus-4.8:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 25.0
@@ -523,6 +529,27 @@ zenmux-anthropic/claude-haiku-4.5:
 # output, $1/M cache hit, $12.50/M 5-min cache write). Load-bearing: Claude Code
 # caches heavily, and without these computeCostUsd bills cached tokens at full
 # input rate (large over-estimate). MUST stay in sync with the capabilities.yaml caps.
+# Claude Opus 5: a drop-in upgrade at Opus 4.8's pricing — $5/M input, $25/M output,
+# $0.50/M cache read, $6.25/M 5-min cache write, $10/M 1h cache write, and the same
+# $10/$50 fast-mode tier. Verified 2026-07-25 against the ZenMux catalog
+# (anthropic/claude-opus-5) and the Anthropic pricing page; identical to the 4.8 block
+# below, so any future divergence must be applied to BOTH.
+anthropic/claude-opus-5:
+  inputPerMTokUsd: 5.0
+  outputPerMTokUsd: 25.0
+  cacheReadPerMTokUsd: 0.5
+  cacheWritePerMTokUsd: 6.25
+  cacheWrite1hPerMTokUsd: 10.0
+  inferenceGeoMultipliers:
+    global: 1.0
+    us: 1.1
+  serviceTiers:
+    fast:
+      inputPerMTokUsd: 10.0
+      outputPerMTokUsd: 50.0
+      cacheReadPerMTokUsd: 1.0
+      cacheWritePerMTokUsd: 12.5
+      cacheWrite1hPerMTokUsd: 20.0
 anthropic/claude-opus-4-8:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 25.0

--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -154,6 +154,8 @@ providers:
     base_url: https://zenmux.ai/api/anthropic
     api_key_env: ZENMUX_API_KEY
     models:
+      - alias: zenmux-anthropic/claude-opus-5
+        provider_model: anthropic/claude-opus-5
       - alias: zenmux-anthropic/claude-opus-4.8
         provider_model: anthropic/claude-opus-4.8
       - alias: zenmux-anthropic/claude-sonnet-4.6


### PR DESCRIPTION
## 背景

Opus 5 已发布。查证结论：**价格与 Opus 4.8 完全一致**，所以按 4.8 配。

| | Opus 5 | Opus 4.8 |
|---|---|---|
| 输入 | $5 / M | $5 / M |
| 输出 | $25 / M | $25 / M |
| Cache read | $0.50 / M | $0.50 / M |
| Cache write (5min) | $6.25 / M | $6.25 / M |
| Cache write (1h) | $10 / M | $10 / M |
| Fast mode | $10 / $50 | $10 / $50 |
| 上下文 | 1M | 1M |
| 最大输出 | 128K | 128K |

数据来源：ZenMux catalog `anthropic/claude-opus-5`（publish_time 2026-07-24）+ Anthropic 官方定价页。

## 改动

按 4.8 的接线方式加三处别名：

- **`anthropic/claude-opus-5`** —— 原生 Claude Pro/Max 订阅别名。Anthropic OAuth pool 是**实时发现**模型的，所以这个别名本来就会自动可路由；没有 catalog 条目的话，它的 cached token 会按**完整输入价**计费（严重高估）。
- **`zenmux-anthropic/claude-opus-5`** —— 原生 Anthropic 协议 passthrough。
- **providers.yaml** 对应别名，让这条路由能解析。

⚠️ **capabilities.yaml 必须和 pricing.yaml 一起加**：只加 pricing 行而没有 caps 条目，merge 会合成 `EMPTY_CAPABILITIES`（`maxContextTokens: 0`），能力过滤器会把**每个**请求都以 `context_too_small` 剪掉。这是 `catalog/index.ts` 里既有的坑，注释已在文件里说明。

能力与 4.8 相同：1M 上下文、128K 输出、`low/medium/high/xhigh/max` 走 `anthropicOutputConfig`。Opus 5 默认开启 thinking、且 disabled-thinking 只在 effort ≤ high 时可用，但这两点都不改变 helm 发送 effort 的方式，所以 `anthropicThinking.supported` 保持 `false`。

## 验证

- 加载**真实 runtime catalog** 确认两个新别名都能解析，价格与 4.8 逐项一致：
  ```
  anthropic/claude-opus-5         ctx=1000000 in=$5 out=$25 cacheRd=$0.5 cacheWr=$6.25
  zenmux-anthropic/claude-opus-5  ctx=1000000 in=$5 out=$25 cacheRd=$0.5 cacheWr=$6.25
  anthropic/claude-opus-4-8       ctx=1000000 in=$5 out=$25 cacheRd=$0.5 cacheWr=$6.25
  ```
- config + catalog 套件 **139 测试全绿**（含 `samples.test.ts`，它固定了 shipped-config 的路由行为）
- 纯 config 改动，无代码变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)