### PR TITLE
[codex] 加固 Responses WebSocket 并补齐 Realtime Voice 代理

### DIFF
--- a/apps/gateway/src/codex-responses-websocket.test.ts
+++ b/apps/gateway/src/codex-responses-websocket.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { type WebSocket, WebSocketServer } from "ws";
 import {
   codexWebSocketAgent,
+  codexWebSocketConnectTimeoutMs,
   createCodexResponsesWebSocketConnector,
 } from "./codex-responses-websocket.js";
 
@@ -49,6 +50,11 @@ async function settlePromptly<T>(promise: Promise<T>): Promise<T> {
 }
 
 describe("createCodexResponsesWebSocketConnector", () => {
+  it("caps handshake and unexpected-response body waits without shortening smaller timeouts", () => {
+    expect(codexWebSocketConnectTimeoutMs(900_000)).toBe(60_000);
+    expect(codexWebSocketConnectTimeoutMs(25)).toBe(25);
+  });
+
   it("connects with Codex headers and relays multiple text events", async () => {
     const server = createServer();
     const websocketServer = new WebSocketServer({ noServer: true });

--- a/apps/gateway/src/codex-responses-websocket.ts
+++ b/apps/gateway/src/codex-responses-websocket.ts
@@ -43,6 +43,10 @@ export function codexWebSocketAgent(proxy: ProxyConfig | undefined): HttpAgent |
     : (new HttpsProxyAgent(proxyUrl) as HttpAgent);
 }
 
+export function codexWebSocketConnectTimeoutMs(timeoutMs: number | undefined): number {
+  return Math.min(60_000, Math.max(1, Math.floor(timeoutMs ?? 60_000)));
+}
+
 class WsCodexConnection implements CodexResponsesWebSocketConnection {
   readonly responseHeaders: Headers;
   private readonly pending: Array<CodexResponsesWebSocketReceivedMessage & { bytes: number }> = [];
@@ -227,7 +231,7 @@ export function createCodexResponsesWebSocketConnector(
   options: CodexResponsesWebSocketConnectorOptions = {},
 ): CodexResponsesWebSocketConnector {
   const agent = codexWebSocketAgent(options.proxy);
-  const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? 60_000));
+  const connectTimeoutMs = codexWebSocketConnectTimeoutMs(options.timeoutMs);
   const maxPayloadBytes = Math.max(
     1,
     Math.floor(options.maxPayloadBytes ?? runtimeMemoryBudget().maxWireBytes),
@@ -244,7 +248,7 @@ export function createCodexResponsesWebSocketConnector(
         headers,
         agent,
         perMessageDeflate: false,
-        handshakeTimeout: timeoutMs,
+        handshakeTimeout: connectTimeoutMs,
         maxPayload: maxPayloadBytes,
       });
 
@@ -288,7 +292,7 @@ export function createCodexResponsesWebSocketConnector(
         request.setTimeout(0);
         const status = response.statusCode ?? null;
         const headers = responseHeaders(response);
-        void unexpectedResponseBody(response, maxPayloadBytes, timeoutMs)
+        void unexpectedResponseBody(response, maxPayloadBytes, connectTimeoutMs)
           .then((body) => {
             fail(
               new CodexResponsesWebSocketConnectError(

--- a/apps/gateway/src/realtime-websocket.test.ts
+++ b/apps/gateway/src/realtime-websocket.test.ts
@@ -164,4 +164,41 @@ describe("Realtime websocket bridge", () => {
     client.terminate();
     expect(await Promise.race([rejectedSocketEnded, delay(500, false)])).toBe(true);
   });
+
+  it("reports a second upstream sideband 401 as a permanent credential failure", async () => {
+    const upstreamHttp = await listeningServer();
+    let upgrades = 0;
+    upstreamHttp.server.on("upgrade", (_request, socket) => {
+      upgrades += 1;
+      socket.end("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+    });
+
+    const gateway = await listeningServer();
+    const registry = createRealtimeCallRegistry();
+    const failures: number[] = [];
+    registry.put("rtc_1", "key-1", {
+      url: `ws://127.0.0.1:${upstreamHttp.port}/v1/realtime?call_id=rtc_1`,
+      headers: async () => ({ Authorization: "Bearer token" }),
+      onUnauthorized: () => {},
+      onCredentialFailure: (status) => failures.push(status),
+    });
+    const bridge = installRealtimeWebSocketBridge({
+      server: gateway.server,
+      registry,
+      resolveKey: async () => "key-1",
+    });
+    closers.push(() => bridge.close());
+
+    const client = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/realtime?call_id=rtc_1`, {
+      headers: { Authorization: "Bearer helm-key" },
+    });
+    const [, response] = (await once(client, "unexpected-response")) as [
+      unknown,
+      { statusCode: number },
+    ];
+
+    expect(response.statusCode).toBe(502);
+    expect(upgrades).toBe(2);
+    expect(failures).toEqual([401]);
+  });
 });

--- a/apps/gateway/src/realtime-websocket.ts
+++ b/apps/gateway/src/realtime-websocket.ts
@@ -135,6 +135,9 @@ async function openUpstream(
         target.onUnauthorized();
         continue;
       }
+      if (cause instanceof UpstreamUpgradeError && cause.status === 401) {
+        target.onCredentialFailure?.(401);
+      }
       throw cause;
     }
   }

--- a/apps/gateway/src/responses-registry.test.ts
+++ b/apps/gateway/src/responses-registry.test.ts
@@ -28,6 +28,8 @@ function record(over: Partial<ResponsesRegistryRecord> = {}): ResponsesRegistryR
     providerName: "openai",
     providerModel: "gpt-5.5",
     providerProtocol: "openai_responses",
+    providerAccount: "oauth-a",
+    selectedLane: "coding",
     createdAt: 1000,
     expiresAt: 2000,
     status: "completed",
@@ -45,6 +47,8 @@ describe("createResponsesRegistry", () => {
       responseId: "resp_1",
       providerName: "openai",
       providerProtocol: "openai_responses",
+      providerAccount: "oauth-a",
+      selectedLane: "coding",
     });
   });
 

--- a/apps/gateway/src/responses-registry.ts
+++ b/apps/gateway/src/responses-registry.ts
@@ -45,6 +45,8 @@ function parseRecord(value: unknown): ResponsesRegistryRecord | null {
     providerName: stringOrNull(row.providerName),
     providerModel: stringOrNull(row.providerModel),
     providerProtocol: row.providerProtocol,
+    providerAccount: stringOrNull(row.providerAccount),
+    selectedLane: stringOrNull(row.selectedLane),
     createdAt: row.createdAt,
     expiresAt: row.expiresAt,
     status: row.status,

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -741,7 +741,39 @@ describe("Responses websocket bridge", () => {
     ]);
   });
 
-  it("drains the internal HTTP stream after the terminal event without forwarding trailing data", async () => {
+  it("cancels an unexpected successful non-SSE response body", async () => {
+    let cancelled = false;
+    const baseUrl = await startBridge(
+      () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"unexpected":true}'));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+
+    const events = await collectTurn(socket, {
+      type: "response.create",
+      model: "gpt-5.6-sol",
+      input: [],
+      stream: true,
+    });
+
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      error: { code: "websocket_bridge_error" },
+    });
+    expect(cancelled).toBe(true);
+  });
+
+  it("stops at the terminal event and cancels the internal HTTP stream", async () => {
     let cancelled = false;
     let trailingTimer: ReturnType<typeof setTimeout> | null = null;
     const encoder = new TextEncoder();
@@ -789,7 +821,7 @@ describe("Responses websocket bridge", () => {
     await once(socket, "message");
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    expect(cancelled).toBe(false);
+    expect(cancelled).toBe(true);
     expect(events).toEqual([
       {
         type: "response.completed",
@@ -798,12 +830,66 @@ describe("Responses websocket bridge", () => {
     ]);
   });
 
+  it("does not wait for internal stream cancellation before handling the next turn", async () => {
+    let requestCount = 0;
+    let cancelled = false;
+    let turnAborted = false;
+    const encoder = new TextEncoder();
+    const completedFrame =
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-completed","status":"completed"}}\n\n';
+    const baseUrl = await startBridge((request) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        request.signal.addEventListener("abort", () => {
+          turnAborted = true;
+        });
+      }
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(completedFrame));
+            if (requestCount > 1) controller.close();
+          },
+          cancel() {
+            cancelled = true;
+            return new Promise<void>(() => {});
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    });
+    const socket = await connect(`${baseUrl}/v1/responses`);
+
+    await collectTurn(socket, {
+      type: "response.create",
+      model: "gpt-5.6-sol",
+      input: [],
+      stream: true,
+    });
+    socket.send(
+      JSON.stringify({
+        type: "response.create",
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+      }),
+    );
+    for (let attempt = 0; attempt < 20 && requestCount < 2; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(cancelled).toBe(true);
+    expect(turnAborted).toBe(true);
+    expect(requestCount).toBe(2);
+  });
+
   it.each([
     "response.failed",
     "response.incomplete",
     "error",
-  ] as const)("destroys the internal upstream session after %s", async (terminalType) => {
+  ] as const)("closes downstream normally without waiting for session cleanup after %s", async (terminalType) => {
     let closedSessionId = "";
+    let closeSessionCalls = 0;
     let resolveClosed!: () => void;
     const closed = new Promise<void>((resolve) => {
       resolveClosed = resolve;
@@ -822,12 +908,15 @@ describe("Responses websocket bridge", () => {
       undefined,
       {
         closeSession: (sessionId) => {
+          closeSessionCalls += 1;
           closedSessionId = sessionId;
           resolveClosed();
+          return new Promise<void>(() => {});
         },
       },
     );
     const socket = await connect(`${baseUrl}/v1/responses`);
+    const socketClosed = once(socket, "close");
 
     const events = await collectTurn(socket, {
       type: "response.create",
@@ -843,6 +932,41 @@ describe("Responses websocket bridge", () => {
     expect(events.at(-1)?.type).toBe(terminalType);
     expect(closeResult).toBe("closed");
     expect(closedSessionId).not.toBe("");
+    const [code] = (await Promise.race([
+      socketClosed,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("downstream close waited for session cleanup")), 100),
+      ),
+    ])) as [number, Buffer];
+    expect(code).toBe(1000);
+    expect(closeSessionCalls).toBe(1);
+  });
+
+  it("swallows a synchronous session cleanup failure", async () => {
+    const baseUrl = await startBridge(
+      () =>
+        new Response(
+          'event: response.failed\ndata: {"type":"response.failed","response":{"status":"failed"}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      undefined,
+      {
+        closeSession: () => {
+          throw new Error("synthetic synchronous cleanup failure");
+        },
+      },
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    const socketClosed = once(socket, "close");
+
+    await collectTurn(socket, {
+      type: "response.create",
+      model: "gpt-5.6-sol",
+      input: [],
+      stream: true,
+    });
+    await socketClosed;
+    await new Promise((resolve) => setImmediate(resolve));
   });
 
   it("returns a structured 400 for malformed websocket messages", async () => {

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -336,12 +336,12 @@ async function forwardResponse(
   const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
   const body = response.body;
   if (body === null || !contentType.includes("text/event-stream")) {
+    if (body !== null) void body.cancel().catch(() => {});
     throw new Error("Responses websocket bridge expected a text/event-stream response");
   }
 
   let terminalType: unknown;
   for await (const frame of readSSE(body)) {
-    if (terminalType !== undefined) continue;
     const payload = websocketPayload(frame.event, frame.data);
     if (payload === null) continue;
     await sendText(socket, payload);
@@ -358,9 +358,11 @@ async function forwardResponse(
       type === "error"
     ) {
       terminalType = type;
+      break;
     }
   }
   if (terminalType !== undefined) {
+    void body.cancel().catch(() => {});
     return terminalType !== "response.completed";
   }
   if (!signal.aborted) {
@@ -469,19 +471,25 @@ export function installResponsesWebSocketBridge({
     const sessionId = randomUUID();
     let sessionClosed = false;
     let processing = false;
+    let activeTurnController: AbortController | null = null;
     const closeUpstreamSession = async () => {
-      await Promise.resolve(closeSession?.(sessionId)).catch(() => {});
+      if (sessionClosed) return;
+      sessionClosed = true;
+      await Promise.resolve()
+        .then(() => closeSession?.(sessionId))
+        .catch(() => {});
     };
     const abort = () => {
       controller.abort();
-      if (sessionClosed) return;
-      sessionClosed = true;
+      activeTurnController?.abort();
       void closeUpstreamSession();
     };
     socket.on("close", abort);
     socket.on("error", abort);
     socket.on("message", (data) => {
+      if (controller.signal.aborted || socket.readyState !== WebSocket.OPEN) return;
       if (processing) {
+        abort();
         socket.close(1008, "one active response per connection");
         return;
       }
@@ -532,6 +540,10 @@ export function installResponsesWebSocketBridge({
         return;
       }
       processing = true;
+      const turnController = new AbortController();
+      activeTurnController = turnController;
+      const abortTurn = () => turnController.abort();
+      controller.signal.addEventListener("abort", abortTurn, { once: true });
       void (async () => {
         try {
           const invalidatesSession = await forwardResponse(
@@ -539,16 +551,23 @@ export function installResponsesWebSocketBridge({
             request,
             fetch,
             data,
-            controller.signal,
+            turnController.signal,
             sessionId,
             sessionProof,
           );
-          if (invalidatesSession) await closeUpstreamSession();
+          if (invalidatesSession) {
+            socket.close(1000, "upstream session reset");
+            void closeUpstreamSession();
+          }
         } catch (error) {
           if (controller.signal.aborted || socket.readyState !== WebSocket.OPEN) return;
           await sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
-          await closeUpstreamSession();
+          socket.close(1000, "upstream session reset");
+          void closeUpstreamSession();
         } finally {
+          turnController.abort();
+          controller.signal.removeEventListener("abort", abortTurn);
+          if (activeTurnController === turnController) activeTurnController = null;
           processing = false;
           acquired.lease.release();
           ingressAcquired.lease.release();

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -896,6 +896,48 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.attempts[0]?.skip_reason).toBe("responses_previous_response_id_provider_mismatch");
   });
 
+  it("rejects generate:false when native Responses passthrough is unavailable", async () => {
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "must-not-generate" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["responses", provider]]),
+      registry: protocolRegistry({
+        "responses/gpt": {
+          providerName: "responses",
+          providerModel: "gpt",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["responses/gpt"]),
+      req({
+        protocol: "openai_responses",
+        provider_raw: { generate: false },
+        native_request: {
+          protocol: "openai_responses",
+          body: { model: "gpt", input: [], generate: false, stream: false },
+          headers: {},
+          mutations: {},
+        },
+      }),
+    );
+
+    expect(provider.chatCompletion).not.toHaveBeenCalled();
+    expect(out.final.status).toBe("error");
+    expect(out.attempts[0]?.skip_reason).toBe(
+      "responses_generate_false_requires_native_passthrough",
+    );
+  });
+
   it.each([
     ["mcp", { type: "mcp", server_label: "local" }],
     ["file_search", { type: "file_search", vector_store_ids: ["vs_1"] }],
@@ -2369,6 +2411,43 @@ describe("createExecute — gateway execution adapter", () => {
     // Safe fields only — no key/payload/raw error object leaked.
     const serialized = JSON.stringify(truncated?.fields);
     expect(serialized).not.toContain("connection reset");
+  });
+
+  it("classifies a post-first-chunk AbortError as a client abort without breaker failure", async () => {
+    async function* aborted(): AsyncGenerator<string> {
+      yield 'data: {"a":1}\n\n';
+      throw Object.assign(new Error("stream aborted"), { name: "AbortError" });
+    }
+    const provider = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn().mockReturnValue(aborted()),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const logs: Array<{ msg: string; fields: Record<string, unknown> }> = [];
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ a: "m-a" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      log: (_level, msg, fields) => logs.push({ msg, fields }),
+    });
+
+    const out = await execute(plan(["a"]), req({ stream: true }));
+    await expect(async () => {
+      for await (const _ of out.stream as AsyncIterable<string>) {
+        // drain
+      }
+    }).rejects.toThrow("stream aborted");
+
+    expect(recordFailure).not.toHaveBeenCalled();
+    expect(logs).toContainEqual({
+      msg: "stream.truncated",
+      fields: { alias: "a", error_class: "client_abort", reason: "client_abort" },
+    });
   });
 
   it("crosses providers: a fallback chain spanning two providers invokes both in order", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -48,6 +48,7 @@ import {
 } from "@helm/shared";
 import {
   CONCURRENCY_LEASE_LOST_REASON,
+  REQUEST_TIMEOUT_REASON,
   requestCancellationReason,
 } from "../request-cancellation.js";
 import {
@@ -1600,6 +1601,13 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         target,
         enabled: nativeProtocolPassthroughEnabled?.() === true,
       });
+      if (req.provider_raw?.generate === false && !passthrough.passthrough_used) {
+        capabilityPruned = true;
+        attempts.push(
+          skipRow(alias, "responses_generate_false_requires_native_passthrough", elapsed()),
+        );
+        continue;
+      }
       let visualCompressionMutation: VisualContextCompressionMutation | undefined;
       let optimizedNativeBody: Record<string, unknown> | null = null;
       const optimizeAnthropicBodyForAttempt = async (
@@ -1760,6 +1768,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 () => {
                   const raw = passthroughStream(passthroughBody, {
                     signal: attemptSignal,
+                    ...(req.metadata.stateful_provider_account
+                      ? { statefulAccount: req.metadata.stateful_provider_account }
+                      : {}),
                     captureUpstream,
                     onResponseMeta,
                     toolCallXmlRecovery:
@@ -1809,6 +1820,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 () => {
                   const raw = provider.chatCompletionStream(rendered.body, {
                     signal: attemptSignal,
+                    ...(req.metadata.stateful_provider_account
+                      ? { statefulAccount: req.metadata.stateful_provider_account }
+                      : {}),
                     captureUpstream,
                     onResponseMeta,
                     optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
@@ -1884,6 +1898,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
             passthroughInvoke(passthroughBody, {
               signal: attemptSignal,
+              ...(req.metadata.stateful_provider_account
+                ? { statefulAccount: req.metadata.stateful_provider_account }
+                : {}),
               captureUpstream,
               onResponseMeta,
               toolCallXmlRecovery:
@@ -1916,6 +1933,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
           provider.chatCompletion(bodyReq.body, {
             signal: attemptSignal,
+            ...(req.metadata.stateful_provider_account
+              ? { statefulAccount: req.metadata.stateful_provider_account }
+              : {}),
             captureUpstream,
             onResponseMeta,
             optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
@@ -2264,12 +2284,18 @@ async function peekStream(
       // the first chunk — breaker semantics unchanged). Emit a structured log so
       // the truncation is observable despite the clean telemetry row. Safe fields
       // only — alias + classification, NEVER key/payload/raw error (principle 7).
-      const cancellation = requestCancellationReason(_signal);
+      const cancellation = requestCancellationReason(_signal, err);
       if (cancellation === CONCURRENCY_LEASE_LOST_REASON) {
         log?.("warn", "stream.truncated", {
           alias,
           error_class: "lane_unavailable",
           reason: CONCURRENCY_LEASE_LOST_REASON,
+        });
+      } else if (cancellation !== null) {
+        log?.("warn", "stream.truncated", {
+          alias,
+          error_class: cancellation === REQUEST_TIMEOUT_REASON ? "timeout" : "client_abort",
+          reason: cancellation,
         });
       } else {
         log?.("warn", "stream.truncated", { alias, error_class: errorClassOf(err) });

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -395,6 +395,112 @@ describe("createMessagesPipeline — failure surfaces", () => {
     ).rejects.toMatchObject({ error_class: "invalid_request" });
   });
 
+  it("routes an empty native Responses continuation without inventing a placeholder", async () => {
+    let routed: InternalRequest | null = null;
+    const route: RouteFn = async (request) => {
+      routed = request;
+      return okResult({ id: "x" });
+    };
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const native = createNativePassthroughCarrier({
+      protocol: "openai_responses",
+      body: { model: "gpt-5.6-sol", input: [], previous_response_id: "resp-1", stream: true },
+      headers: {},
+    });
+
+    await pipeline.run(
+      irOf({
+        messages: [],
+        stream: true,
+        provider_raw: { previous_response_id: "resp-1" },
+        metadata: {
+          trace_id: "trace-1",
+          native_request: native,
+          stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+        },
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+
+    expect((routed as InternalRequest | null)?.messages).toEqual([]);
+    expect((routed as InternalRequest | null)?.metadata.stateful_provider_alias).toBe(
+      "openai-codex/gpt-5.6-sol",
+    );
+  });
+
+  it("routes a strict empty native Responses prewarm without inventing a placeholder", async () => {
+    let routed: InternalRequest | null = null;
+    const route: RouteFn = async (request) => {
+      routed = request;
+      return okResult({ id: "x" });
+    };
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const native = createNativePassthroughCarrier({
+      protocol: "openai_responses",
+      body: { model: "gpt-5.6-sol", input: [], generate: false, stream: true },
+      headers: {},
+    });
+
+    await pipeline.run(
+      irOf({
+        messages: [],
+        stream: true,
+        provider_raw: { generate: false },
+        metadata: { trace_id: "trace-1", native_request: native },
+      }),
+      IDENTITY,
+      new AbortController().signal,
+    );
+
+    expect((routed as InternalRequest | null)?.messages).toEqual([]);
+    expect((routed as InternalRequest | null)?.provider_raw?.generate).toBe(false);
+  });
+
+  it("rejects an empty continuation whose native and normalized ids disagree", async () => {
+    const route: RouteFn = async () => okResult({ id: "x" });
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const native = createNativePassthroughCarrier({
+      protocol: "openai_responses",
+      body: { model: "gpt-5.6-sol", input: [], previous_response_id: "resp-1", stream: true },
+      headers: {},
+    });
+
+    await expect(
+      pipeline.run(
+        irOf({
+          messages: [],
+          provider_raw: { previous_response_id: "resp-other" },
+          metadata: {
+            trace_id: "trace-1",
+            native_request: native,
+            stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+          },
+        }),
+        IDENTITY,
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ error_class: "invalid_request" });
+  });
+
+  it("rejects an empty native Responses request without a continuation id", async () => {
+    const route: RouteFn = async () => okResult({ id: "x" });
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const native = createNativePassthroughCarrier({
+      protocol: "openai_responses",
+      body: { model: "gpt-5.6-sol", input: [], stream: true },
+      headers: {},
+    });
+
+    await expect(
+      pipeline.run(
+        irOf({ messages: [], metadata: { trace_id: "trace-1", native_request: native } }),
+        IDENTITY,
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ error_class: "invalid_request" });
+  });
+
   it("threads per-key lane caps from identity.caps into the route options", async () => {
     let sawOpts: RouteOptions | null = null;
     const route: RouteFn = async (_req, opts) => {

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -31,6 +31,8 @@ import {
 import type { InternalRequest, MemoryDecision, Protocol } from "@helm/shared";
 import {
   cloneCarrierWithBody,
+  isEmptyNativeResponsesContinuation,
+  isEmptyNativeResponsesPrewarm,
   isNativePassthroughCarrier,
   nativePassthroughBody,
 } from "@helm/shared";
@@ -229,8 +231,8 @@ function toInternalRequest(
   traceId: string,
   protocol: Protocol,
 ): InternalRequest {
-  // `run` already rejected an empty/non-array messages with invalid_request, so
-  // this is a non-empty array here (no placeholder synthesis — see PipelineError).
+  // `run` already rejected empty messages except a pinned Responses continuation or
+  // strict generate:false prewarm; no path synthesizes a placeholder (see PipelineError).
   const messages = ir.messages as InternalRequest["messages"];
   const model = typeof ir.model === "string" && ir.model.length > 0 ? ir.model : "auto";
   const accountId = typeof identity.accountId === "string" ? identity.accountId : "";
@@ -291,6 +293,13 @@ function toInternalRequest(
       ...(typeof ir.metadata?.stateful_provider_alias === "string" &&
       ir.metadata.stateful_provider_alias.length > 0
         ? { stateful_provider_alias: ir.metadata.stateful_provider_alias }
+        : {}),
+      ...(typeof ir.metadata?.stateful_provider_account === "string" &&
+      ir.metadata.stateful_provider_account.length > 0
+        ? { stateful_provider_account: ir.metadata.stateful_provider_account }
+        : {}),
+      ...(typeof ir.metadata?.stateful_lane === "string" && ir.metadata.stateful_lane.length > 0
+        ? { stateful_lane: ir.metadata.stateful_lane }
         : {}),
       // The CLI's captured billing identity (anthropic route stamps it; absent on the
       // OpenAI/Gemini surfaces). The native-Anthropic executor reads it to re-emit the
@@ -748,7 +757,23 @@ export function createMessagesPipeline(
       // (principle 2 fail-closed); the route maps it to a 400 in the right
       // protocol envelope. Raised here (not in toInternalRequest) so it carries
       // the request trace_id.
-      if (!Array.isArray(ir.messages) || ir.messages.length === 0) {
+      if (
+        !Array.isArray(ir.messages) ||
+        (ir.messages.length === 0 &&
+          !isEmptyNativeResponsesContinuation({
+            protocol,
+            messages: ir.messages,
+            provider_raw: ir.provider_raw,
+            native_request: ir.metadata?.native_request,
+            metadata: ir.metadata,
+          }) &&
+          !isEmptyNativeResponsesPrewarm({
+            protocol,
+            messages: ir.messages,
+            provider_raw: ir.provider_raw,
+            native_request: ir.metadata?.native_request,
+          }))
+      ) {
         throw new PipelineError("invalid_request", "messages must be a non-empty array", traceId);
       }
       const internal = downgradeClientFastModeIfDisallowed(

--- a/apps/gateway/src/routes/realtime.test.ts
+++ b/apps/gateway/src/routes/realtime.test.ts
@@ -1,4 +1,4 @@
-import type { ProviderClient, RealtimeCallResult } from "@helm/core";
+import { type ProviderClient, type RealtimeCallResult, UpstreamError } from "@helm/core";
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "../app.js";
@@ -58,6 +58,7 @@ describe("registerRealtimeRoutes", () => {
       headers: {
         Authorization: "Bearer helm-key",
         "openai-alpha": "quicksilver=v1",
+        "x-oai-attestation": "v1.test-attestation",
         "x-session-id": "sess-1",
         "x-secret": "do-not-forward",
       },
@@ -75,6 +76,7 @@ describe("registerRealtimeRoutes", () => {
         session: expect.objectContaining({ model: "gpt-realtime-1.5" }),
         headers: {
           "openai-alpha": "quicksilver=v1",
+          "x-oai-attestation": "v1.test-attestation",
           "x-session-id": "sess-1",
         },
       }),
@@ -109,6 +111,23 @@ describe("registerRealtimeRoutes", () => {
     });
     expect(response.status).toBe(401);
     expect(realtimeCall).not.toHaveBeenCalled();
+  });
+
+  it("preserves a deterministic upstream voice-access denial", async () => {
+    const { app, realtimeCall } = setup();
+    realtimeCall.mockRejectedValue(
+      new UpstreamError("upstream_error", "Voice session access denied.", null, 403),
+    );
+    const response = await app.request("/v1/realtime/calls", {
+      method: "POST",
+      headers: { Authorization: "Bearer helm-key" },
+      body: multipart({ model: "gpt-realtime-1.5" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { code: "upstream_error", message: "Voice session access denied." },
+    });
   });
 
   it("enforces blocked_models against the resolved provider alias", async () => {

--- a/apps/gateway/src/routes/realtime.ts
+++ b/apps/gateway/src/routes/realtime.ts
@@ -23,6 +23,7 @@ const FORWARDED_HEADERS = [
   "version",
   "x-client-request-id",
   "x-codex-client-version",
+  "x-oai-attestation",
 ] as const;
 
 export interface RealtimeRouteDeps {
@@ -48,7 +49,7 @@ function bearer(value: string | undefined): string | null {
 
 function error(
   c: Context<AppEnv>,
-  status: 400 | 401 | 404 | 413 | 429 | 502 | 503,
+  status: 400 | 401 | 403 | 404 | 413 | 429 | 502 | 503,
   message: string,
   code: string,
 ) {
@@ -206,6 +207,7 @@ export function registerRealtimeRoutes(app: Hono<AppEnv>, deps: RealtimeRouteDep
         c,
         status === 400 ||
           status === 401 ||
+          status === 403 ||
           status === 404 ||
           status === 413 ||
           status === 429 ||

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1,6 +1,8 @@
 import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   type DecisionRecord,
+  type ExecutionResult,
+  responsesTransformer,
   type TelemetryStore,
   type UpsertSessionRevisionInput,
   UpstreamError,
@@ -10,7 +12,7 @@ import { createApp } from "../app.js";
 import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "../responses-websocket-internal.js";
 import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import type { MessagesIdentity } from "./messages.js";
-import { PipelineError } from "./messages-pipeline.js";
+import { createMessagesPipeline, PipelineError, type RouteFn } from "./messages-pipeline.js";
 import type { RecordServedDeps, SseCapture } from "./payload-capture.js";
 import {
   type ResponsesRouteDeps,
@@ -48,6 +50,25 @@ describe("settleResponsesStreamOutcome", () => {
     expect(outcome).toBe("failed");
     expect(decision.stream_outcome).toBe("failed");
     expect(decision.final).toMatchObject({ status: "error", error_reason: "timeout" });
+  });
+
+  it("keeps an observed terminal failure when the bridge aborts during teardown", () => {
+    const decision = {
+      final: { status: "ok", model_alias: "gpt-4o", error_reason: null },
+      stream_outcome: null,
+    } as unknown as DecisionRecord;
+
+    const outcome = settleResponsesStreamOutcome({
+      decision,
+      streamStatus: "failed",
+      cancellationReason: "client_abort",
+      caughtErrorReason: null,
+      timedOut: false,
+    });
+
+    expect(outcome).toBe("failed");
+    expect(decision.stream_outcome).toBe("failed");
+    expect(decision.final).toMatchObject({ status: "error", error_reason: "upstream_error" });
   });
 });
 
@@ -1297,6 +1318,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       collect: async () => ({ id: "resp_persisted", object: "response", status: "completed" }),
       run: async () => ({
         decision,
+        servingAccount: { providerId: "openai-codex", account: "stale-oauth-account" },
         nativePassthrough: true,
         collect: async () => ({ id: "resp_persisted", object: "response", status: "completed" }),
         streamIR: async function* () {},
@@ -1321,6 +1343,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
         providerName: "openai",
         providerModel: "gpt-5.5",
         providerProtocol: "openai_responses",
+        providerAccount: null,
         status: "completed",
       }),
     );
@@ -1354,6 +1377,174 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(harness.pipelineSawIR).toMatchObject({
       metadata: { stateful_provider_alias: "openai-codex/gpt-5.6-sol" },
     });
+  });
+
+  it("serves a native WebSocket-style continuation whose incremental input is empty", async () => {
+    const routeHarness: { routed: Parameters<RouteFn>[0] | null } = { routed: null };
+    const route: RouteFn = async (request) => {
+      routeHarness.routed = request;
+      return {
+        decision: FAKE_DECISION,
+        final: { status: "ok", alias: "openai-codex/gpt-5.6-sol" },
+        body: null,
+        stream: (async function* () {
+          yield 'event: response.created\ndata: {"type":"response.created","response":{"id":"resp-next"}}\n\n';
+          yield 'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-next","status":"completed"}}\n\n';
+        })(),
+        error: null,
+        nativePassthrough: true,
+      } as ExecutionResult;
+    };
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const registryRecord = {
+      responseId: "resp_previous",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "openai-codex/gpt-5.6-sol",
+      providerName: "openai-codex",
+      providerModel: "gpt-5.6-sol",
+      providerProtocol: "openai_responses" as const,
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      status: "completed",
+    };
+    const { deps } = makeDeps({
+      transformRequestOut: (native) =>
+        responsesTransformer.transformRequestOut(native) as {
+          stream?: boolean;
+          metadata?: Record<string, unknown>;
+        },
+      run: pipeline.run,
+      registry: { put: vi.fn(), get: vi.fn().mockResolvedValue(registryRecord) },
+    });
+    const app = buildApp(deps);
+    const body = {
+      model: "gpt-5.6-sol",
+      input: [],
+      previous_response_id: "resp_previous",
+      stream: true,
+      store: false,
+    };
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("response.completed");
+    expect(routeHarness.routed?.messages).toEqual([]);
+    expect(routeHarness.routed?.metadata.stateful_provider_alias).toBe("openai-codex/gpt-5.6-sol");
+    expect((routeHarness.routed?.native_request as { body?: unknown } | undefined)?.body).toEqual(
+      body,
+    );
+  });
+
+  it("serves a native WebSocket prewarm with empty input and generate:false", async () => {
+    const routeHarness: { routed: Parameters<RouteFn>[0] | null } = { routed: null };
+    const route: RouteFn = async (request) => {
+      routeHarness.routed = request;
+      return {
+        decision: FAKE_DECISION,
+        final: { status: "ok", alias: "openai-codex/gpt-5.6-sol" },
+        body: null,
+        stream: (async function* () {
+          yield 'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp-warm","status":"completed"}}\n\n';
+        })(),
+        error: null,
+        nativePassthrough: true,
+      } as ExecutionResult;
+    };
+    const pipeline = createMessagesPipeline(route, "openai_responses");
+    const { deps } = makeDeps({
+      transformRequestOut: (native) =>
+        responsesTransformer.transformRequestOut(native) as {
+          stream?: boolean;
+          metadata?: Record<string, unknown>;
+        },
+      run: pipeline.run,
+    });
+    const app = buildApp(deps);
+    const body = {
+      model: "gpt-5.6-sol",
+      input: [],
+      generate: false,
+      reasoning: { effort: "medium", context: "all_turns" },
+      stream: true,
+      store: false,
+    };
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("response.completed");
+    expect(routeHarness.routed?.messages).toEqual([]);
+    expect(routeHarness.routed?.provider_raw?.generate).toBe(false);
+  });
+
+  it("commits a streamed response binding before exposing its terminal frame", async () => {
+    const saved = deferred<void>();
+    const put = vi.fn(() => saved.promise);
+    const decision = {
+      lane: { selected_lane: "coding", candidate_chain: ["openai-codex/gpt-5.6-sol"] },
+      provider_attempts: [
+        {
+          alias: "openai-codex/gpt-5.6-sol",
+          provider_name: "openai-codex",
+          provider_model: "gpt-5.6-sol",
+          target_provider_protocol: "openai_responses",
+          status: "ok",
+          skipped: false,
+        },
+      ],
+      final: { status: "ok", model_alias: "openai-codex/gpt-5.6-sol" },
+      stream_outcome: null,
+    } as unknown as DecisionRecord;
+    const { deps } = makeDeps({
+      registry: { put, get: vi.fn() },
+      transformRequestOut: () => ({ stream: true, metadata: {} }),
+      run: async () => ({
+        decision,
+        servingAccount: { providerId: "openai-codex", account: "oauth-a" },
+        collect: async () => ({}),
+        streamIR: async function* () {
+          yield {
+            type: "response.completed",
+            response: { id: "resp-fast", status: "completed" },
+            sequence_number: 0,
+          };
+        },
+      }),
+    });
+    const app = buildApp(deps);
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("missing response stream");
+    const firstRead = reader.read();
+    const firstResult = await Promise.race([
+      firstRead.then(() => "frame" as const),
+      shortTimeout(),
+    ]);
+    saved.resolve(undefined);
+
+    expect(firstResult).toBe("timeout");
+    expect(put).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseId: "resp-fast",
+        providerAccount: "oauth-a",
+        selectedLane: "coding",
+      }),
+    );
+    expect(new TextDecoder().decode((await firstRead).value)).toContain("response.completed");
   });
 
   it("rejects an unknown previous_response_id instead of routing it without history", async () => {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -38,7 +38,7 @@ import {
   memoryAdmissionReleaseGuard,
   readAdmittedRequestBody,
 } from "../runtime/memory-admission.js";
-import { stampServingAccount } from "../runtime/serving-account.js";
+import { servedByAccount, stampServingAccount } from "../runtime/serving-account.js";
 import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
@@ -161,6 +161,8 @@ export interface ResponsesRegistryRecord {
   providerName: string | null;
   providerModel: string | null;
   providerProtocol: "openai_chat" | "anthropic_messages" | "openai_responses" | "gemini" | null;
+  providerAccount?: string | null;
+  selectedLane?: string | null;
   createdAt: number;
   expiresAt: number;
   status: string;
@@ -382,6 +384,42 @@ function successfulAttempt(decision: unknown): Record<string, unknown> | null {
   return attempts.find((attempt) => attempt.status === "ok" && attempt.skipped !== true) ?? null;
 }
 
+function responsesRegistryRecord(args: {
+  responseId: string;
+  identity: MessagesIdentity;
+  result: PipelineRunResult;
+  status: string;
+}): ResponsesRegistryRecord {
+  const attempt = successfulAttempt(args.result.decision);
+  const providerAlias = typeof attempt?.alias === "string" ? attempt.alias : null;
+  const servingAccount = args.result.servingAccount ?? null;
+  const selectedLane = (args.result.decision as { lane?: { selected_lane?: unknown } }).lane
+    ?.selected_lane;
+  const now = Date.now();
+  return {
+    responseId: args.responseId,
+    accountId: args.identity.accountId,
+    keyId: args.identity.keyId,
+    providerAlias,
+    providerName: typeof attempt?.provider_name === "string" ? attempt.provider_name : null,
+    providerModel: typeof attempt?.provider_model === "string" ? attempt.provider_model : null,
+    providerProtocol:
+      attempt?.target_provider_protocol === "openai_chat" ||
+      attempt?.target_provider_protocol === "anthropic_messages" ||
+      attempt?.target_provider_protocol === "openai_responses" ||
+      attempt?.target_provider_protocol === "gemini"
+        ? attempt.target_provider_protocol
+        : null,
+    providerAccount: servedByAccount(servingAccount, providerAlias)
+      ? (servingAccount?.account ?? null)
+      : null,
+    selectedLane: typeof selectedLane === "string" ? selectedLane : null,
+    createdAt: now,
+    expiresAt: now + 86_400_000,
+    status: args.status,
+  };
+}
+
 function statusFromResponseBody(body: Record<string, unknown>): string {
   return typeof body.status === "string" && body.status.length > 0 ? body.status : "completed";
 }
@@ -422,6 +460,12 @@ export function settleResponsesStreamOutcome(args: {
   caughtErrorReason: string | null;
   timedOut: boolean;
 }): ResponsesStreamOutcome {
+  const terminalObserved =
+    args.streamStatus === "completed" ||
+    args.streamStatus === "incomplete" ||
+    args.streamStatus === "failed" ||
+    args.streamStatus === "cancelled";
+  const teardownAbortAfterTerminal = terminalObserved && args.cancellationReason === "client_abort";
   if (
     args.decision.stream_outcome === "truncated" &&
     args.decision.final?.error_reason === CONCURRENCY_LEASE_LOST_REASON
@@ -436,7 +480,7 @@ export function settleResponsesStreamOutcome(args: {
     markStartedStreamCancellation(args.decision, REQUEST_TIMEOUT_REASON);
     return "failed";
   }
-  if (args.cancellationReason !== null) {
+  if (args.cancellationReason !== null && !teardownAbortAfterTerminal) {
     markStartedStreamCancellation(args.decision, args.cancellationReason);
     return args.cancellationReason === "client_abort"
       ? "client_aborted"
@@ -444,8 +488,13 @@ export function settleResponsesStreamOutcome(args: {
         ? "failed"
         : "truncated";
   }
-  const outcome: ResponsesStreamOutcome =
-    args.caughtErrorReason !== null
+  const outcome: ResponsesStreamOutcome = teardownAbortAfterTerminal
+    ? args.streamStatus === "completed"
+      ? "completed"
+      : args.streamStatus === "incomplete"
+        ? "incomplete"
+        : "failed"
+    : args.caughtErrorReason !== null
       ? "failed"
       : args.streamStatus === "completed"
         ? "completed"
@@ -1132,6 +1181,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       ir.metadata = {
         ...ir.metadata,
         stateful_provider_alias: previous.providerAlias,
+        ...(previous.providerAccount
+          ? { stateful_provider_account: previous.providerAccount }
+          : {}),
+        ...(previous.selectedLane ? { stateful_lane: previous.selectedLane } : {}),
       };
     }
 
@@ -1210,6 +1263,32 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         let streamStatus: string | null = null;
         let cancellationReason: RequestCancellationReason | null = null;
         let caughtErrorReason: string | null = null;
+        let registryCommitted = false;
+        const commitRegistry = async (status: string): Promise<void> => {
+          if (
+            registryCommitted ||
+            deps.registry === undefined ||
+            result === null ||
+            streamResponseId === null
+          ) {
+            return;
+          }
+          registryCommitted = true;
+          try {
+            await deps.registry.put(
+              responsesRegistryRecord({
+                responseId: streamResponseId,
+                identity,
+                result,
+                status,
+              }),
+            );
+          } catch {
+            c.get("logger").log("warn", "responses.registry_put_failed", {
+              trace_id: traceId,
+            });
+          }
+        };
         try {
           if (initialError !== null) throw initialError;
           if (result === null) throw new Error("Responses pipeline did not return a result");
@@ -1248,6 +1327,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                 if (terminal.responseJson !== null) sessionResponseJson = terminal.responseJson;
               }
             }
+            if (terminalEvent) await commitRegistry(streamStatus ?? "truncated");
             if (raw !== undefined) {
               await sse.write(raw);
               lastWrite = raw;
@@ -1333,29 +1413,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
             }
           } finally {
             try {
-              if (deps.registry !== undefined && result !== null && streamResponseId !== null) {
-                const attempt = successfulAttempt(result.decision);
-                await deps.registry.put({
-                  responseId: streamResponseId,
-                  accountId: identity.accountId,
-                  keyId: identity.keyId,
-                  providerAlias: typeof attempt?.alias === "string" ? attempt.alias : null,
-                  providerName:
-                    typeof attempt?.provider_name === "string" ? attempt.provider_name : null,
-                  providerModel:
-                    typeof attempt?.provider_model === "string" ? attempt.provider_model : null,
-                  providerProtocol:
-                    attempt?.target_provider_protocol === "openai_chat" ||
-                    attempt?.target_provider_protocol === "anthropic_messages" ||
-                    attempt?.target_provider_protocol === "openai_responses" ||
-                    attempt?.target_provider_protocol === "gemini"
-                      ? attempt.target_provider_protocol
-                      : null,
-                  createdAt: Date.now(),
-                  expiresAt: Date.now() + 86_400_000,
-                  status: streamOutcome ?? "truncated",
-                });
-              }
+              await commitRegistry(streamOutcome ?? "truncated");
             } finally {
               captured?.release();
               sessionTerminalCapture?.release();
@@ -1423,25 +1481,18 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       throw err;
     }
     if (deps.registry !== undefined && typeof body.id === "string" && body.id.length > 0) {
-      const attempt = successfulAttempt(result.decision);
-      await deps.registry.put({
-        responseId: body.id,
-        accountId: identity.accountId,
-        keyId: identity.keyId,
-        providerAlias: typeof attempt?.alias === "string" ? attempt.alias : null,
-        providerName: typeof attempt?.provider_name === "string" ? attempt.provider_name : null,
-        providerModel: typeof attempt?.provider_model === "string" ? attempt.provider_model : null,
-        providerProtocol:
-          attempt?.target_provider_protocol === "openai_chat" ||
-          attempt?.target_provider_protocol === "anthropic_messages" ||
-          attempt?.target_provider_protocol === "openai_responses" ||
-          attempt?.target_provider_protocol === "gemini"
-            ? attempt.target_provider_protocol
-            : null,
-        createdAt: Date.now(),
-        expiresAt: Date.now() + 86_400_000,
-        status: statusFromResponseBody(body),
-      });
+      try {
+        await deps.registry.put(
+          responsesRegistryRecord({
+            responseId: body.id,
+            identity,
+            result,
+            status: statusFromResponseBody(body),
+          }),
+        );
+      } catch {
+        c.get("logger").log("warn", "responses.registry_put_failed", { trace_id: traceId });
+      }
     }
     // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
     // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1333,7 +1333,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
         realtimeRequests.push(headers);
         return new Response("v=answer\\r\\n", {
           status: 201,
-          headers: { Location: "/v1/live/rtc-1" },
+          headers: { Location: "/v1/live/rtc_1" },
         });
       }
       responseRequests.push({

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -16,10 +16,19 @@
 - **测试影响**：三个老测试用 503 当"随便一个 5xx"占位（openai 401 分支、gemini/codex 非 JSON body 保留、generic 首 chunk 前抛错），503 现在会触发重试，已改成 500 并注明原因；意图不变，provider 套件同时从 9s 回到 2.5s。
 - **TODO / 边界**：退避参数目前是代码常量，未做成配置（与原则 2 的"会撒谎的旋钮比没有旋钮更糟"一致，先观察线上真实 529 分布再决定）；OAuth 池**换账号之间**仍无延迟，本次未动——换号本身就是在换容量，加睡眠反而拖慢。
 
+## 2026-07-25 · Responses WebSocket terminal 立即释放并关闭失效连接（Gateway / Protocol，docs/02/05/07，原则 3/8）
+
+- **成功终态**：内部 SSE 一旦转发 `response.completed` 就停止读取并异步取消正文，不再等待 provider body EOF；请求与 ingress lease 随即释放，同一 downstream WebSocket 可以立即处理下一 turn，避免长期 `processing=true` 导致 1008、中断或卡住。
+- **每轮取消边界**：downstream 连接只保留 connection controller，每个 `response.create` 另建 turn controller；终态后主动 abort 当前内部 fetch，但不 abort 可复用连接。客户端断连、bridge error 或并发发送第二个 active turn 时同时 abort 当前 turn 与 session，释放内存/并发 lease，不等待可能挂起的 body cancel。已观察到的 `completed` / `incomplete` / `failed` 优先于随后发生的 teardown `client_abort`，避免把真实结果误记为客户端中断。
+- **失败终态**：`response.failed`、`response.incomplete`、`error`、非 2xx 与本地桥接错误均先发送协议终态，再幂等销毁 connection-local 上游 Session，并以 1000 正常关闭 downstream socket；终态本身已携带失败事实，不再用 1011 诱发客户端错误退避。Codex 下一次请求会新建连接并清除旧 `previous_response_id`，不会在已失效 Session 上续接。
+- **Codex 增量续接**：真实客户端既会发送带完整 input 的 `generate:false` 预热帧，也会在启动预连接时发送严格的 `input:[] + generate:false` 预热帧；后一形状只有 normalized/native 两层都明确 `generate:false` 时才允许空 IR messages。下一帧可只带 `previous_response_id` 与空 `input`，此时仅当 Responses registry 已验证该 id 并固定原 provider 时放行；registry 在对客户端发送 terminal frame 前先持久化实际 provider alias、与成功 alias 相符的 OAuth account 及 selected lane，重启后仍恢复同一账号，fallback 前选中过但未实际服务的账号不会被写入。该持久化不伪造上游 connection-local state：Codex 在 WebSocket 重连时会清除旧增量状态并重发完整 input。续接在分类前固定为单 provider，真实 lane 继续受 `allowed_lanes` 约束，显式 custom-model 延续首轮既有语义；旧 registry 行缺少 lane provenance 时保持 fail-closed，`blocked_models` 与预算 degrade 同样不可绕过。普通空请求、未知 id、无 provider pin 与跨协议请求仍拒绝。`generate:false` 无 native Responses passthrough 时直接拒绝，不允许翻译路径意外产生计费输出。首 chunk 后的 `AbortError` 只记录为 `client_abort`，不误报上游截断，也不触发 breaker failure。
+- **连接超时边界**：Codex 上游 WebSocket handshake 与非 101 error body 的等待上限为 `min(request_timeout_ms, 60s)`；正常流式请求仍使用既有 request/idle timeout，不因连接建立保护而缩短。没有新增配置、依赖、后台 drain 或 graceful-shutdown 重构。
+
 ## 2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面（Gateway / Protocol / Provider，docs/01/05/06，原则 1/2/3/7/8）
 
 - **Realtime V1/V2/V3**：新增 `/v1/realtime/calls`、`/v1/live` 与对应 WebSocket sideband。Call-create 复用现有 static/OpenAI-Codex provider client、OAuth pool、账号 token 与 egress proxy；ChatGPT backend 继续使用 JSON call shape，官方 OpenAI 使用 multipart。`call_id` 以进程内短 TTL 绑定创建它的 Helm key 与实际 provider/account sideband，WebSocket 必须使用同一 key，且不会重新选账号；OAuth HTTP/WS 401 各只刷新重试一次。Call-create 接入现有进程内或 PostgreSQL 分布式并发 lease，DB 不可用时 fail-closed 为 503，持有期间 lease 丢失会中止上游请求。双向文本/二进制帧按实际字节占用动态内存预算，关闭压缩并保留 close code。当前部署为单 gateway replica；水平扩容前必须把 registry 换成支持原子 claim 的共享存储。
-- **Codex upstream 线缆**：Codex 实际 WebRTC 请求使用 `x-session-id`，因此仅保留旧 `session-id` 会丢失会话身份；Realtime 只转发这一个额外的显式安全 header。ChatGPT backend 的 V3 `/v1/live` 不携带 query，但上游仍要求 `intent=quicksilver&architecture=avas`，只在 backend shape 且 query 为空时补该固定值；同时复用目录运行时已生成的 Codex User-Agent，不信任或透传调用方任意 User-Agent。
+- **Codex upstream 线缆**：Codex 实际 WebRTC 请求使用 `x-session-id`，因此仅保留旧 `session-id` 会丢失会话身份；Realtime 只额外转发 `x-session-id` 与 `x-oai-attestation` 两个明确安全 header。ChatGPT backend 的 V3 `/v1/live` 不携带 query，但上游仍要求 `intent=quicksilver&architecture=avas`，只在 backend shape 且 query 为空时补该固定值；V1 sideband 使用 `/v1/realtime?intent=quicksilver&call_id=...`，V3 使用 `/v1/live/{call_id}`，custom/public base URL 保留已有路径前缀。同时复用目录运行时已生成的 Codex User-Agent，不信任或透传调用方任意 User-Agent。
+- **Voice 授权边界**：ChatGPT Desktop 宿主会为 Realtime call-create 即时生成 `x-oai-attestation`，Helm 仅将该明确 header 转发到创建调用的 ChatGPT backend 与同一 `call_id` sideband，不接受或透传任意扩展 header。OpenAI OAuth 对 Voice 返回的推理 403 属于产品访问拒绝：账号池会尝试尚未试过的兄弟账号，全部拒绝后保留真实 403，但不会持久禁用仍可服务文本 Responses 的账号；真正的 401 与永久 token-refresh 失败仍按原策略隔离账号。
 - **Responses 与模型目录**：Responses `input_audio.audio_url` data URL 进入统一 audio IR；provider 明确声明 `responses_audio_url` 时恢复同一 carrier，旧 `input_audio:{data,format}` 保持兼容。Codex 模型目录的 `input_modalities` 接受 `audio`，不再因新目录字段丢弃模型。
 - **Images edits**：`/v1/images/edits` 复用现有 Images 的鉴权、限流、并发、预算、blocked-model、breaker/fallback、成本与 payload/telemetry 链；支持 Codex JSON `images[].image_url|file_id` 和 OpenAI multipart `image`/`image[]`、`mask`，binary bytes 在 fallback 间可重放。线上验证发现 ZenMux 虽在 `/models` 发布 `openai/gpt-image-2`，但 `/images/edits` 对它返回 `404 invalid_model`，而 OpenAI 官方对同一 JSON/multipart 请求均成功；因此客户端 `gpt-image-2` 改为 ZenMux 优先、OpenAI 官方操作回退。Gemini edit 未发现兼容契约，确定性返回 unsupported，不做有损转换。
 - **暂缓边界**：按用户确认不代理 `alpha/search` 与 `memories/trace_summarize`；未引入新依赖、媒体存储、共享 registry 或第二套路由器。
@@ -53,7 +62,7 @@
 ## 2026-07-23 · Codex Responses 按运行时容量准入并让夜间 SQLite 维护收缩内存（Gateway / Session / Store，docs/02/05/07/10，原则 2/3/7/8）
 
 - **功能边界不降级**：按 operator 要求保留正文/Session 捕获、自动 cleanup/VACUUM 和不限 key 并发；不再用关闭正文、关闭维护或固定并发作为稳定手段。Node 启动时从 V8 heap limit 与 cgroup/process constrained memory 推导活动请求、response work、单条 wire message、写队列、Session head cache、SQLite page cache 与维护 cache；活动请求和 response work 各占动态可分配容量的 20%，部署值随机器容量自动缩放，不写死 MiB。
-- **请求、输出与 Session 热路径**：所有 JSON 入口在 `JSON.parse` 前按真实流式字节申请进程级预算，超出单请求容量返回结构化 413，暂时无余量返回 503；`maxPayload` 与上游 Codex connector 同样随运行时容量变化。客户端 WebSocket 另从 cgroup 或 `RSS + availableMemory` 扣除未来 heap 增长和 SQLite 预留，得到 native ingress 池；本条最初采用的连接生命周期最坏帧预留已由 2026-07-24 条目修正为活动消息真实字节计费。WS 每连接只保留一个正在执行的 `response.create`，terminal 后排空内部流再释放 lease；所有上游 Codex WS 会话共用 response-work 池，每条消息从入队、等待、`JSON.parse` 到 frame 被消费全程持有 lease。四种 SSE 出口共用有界正文捕获器，容量耗尽只省略该响应 payload、记录 `payload.capture_limited` 并继续转发与保存 telemetry。Session 热写不再重建完整历史；Admin Session 恢复由 SQLite/Postgres 先查行字节元数据、再按 sequence 分页物化，并占用共享 recovery window。Store 的 64 MiB/10,000 revision 仍是跨实例一致的持久数据完整性上限，不是运行时内存值。
+- **请求、输出与 Session 热路径**：所有 JSON 入口在 `JSON.parse` 前按真实流式字节申请进程级预算，超出单请求容量返回结构化 413，暂时无余量返回 503；`maxPayload` 与上游 Codex connector 同样随运行时容量变化。客户端 WebSocket 另从 cgroup 或 `RSS + availableMemory` 扣除未来 heap 增长和 SQLite 预留，得到 native ingress 池；本条最初采用的连接生命周期最坏帧预留已由 2026-07-24 条目修正为活动消息真实字节计费，terminal 后 drain 的实现也已由 2026-07-25 条目修正为立即停止并取消内部流。WS 每连接只保留一个正在执行的 `response.create`；所有上游 Codex WS 会话共用 response-work 池，每条消息从入队、等待、`JSON.parse` 到 frame 被消费全程持有 lease。四种 SSE 出口共用有界正文捕获器，容量耗尽只省略该响应 payload、记录 `payload.capture_limited` 并继续转发与保存 telemetry。Session 热写不再重建完整历史；Admin Session 恢复由 SQLite/Postgres 先查行字节元数据、再按 sequence 分页物化，并占用共享 recovery window。Store 的 64 MiB/10,000 revision 仍是跨实例一致的持久数据完整性上限，不是运行时内存值。
 - **夜间维护**：自动 cleanup、自动 VACUUM 与 Admin 手工维护复用同一 Promise 串行链；VACUUM 前进程级 gate 暂停新工作并依次等待 HTTP/body、Memory/Signal producer、OAuth/MCP/Admin cache 后台任务与正文写队列静止，结束或失败都逆序恢复。维护期间除 `/healthz`、`/version` 外的新请求统一返回带 `Retry-After` 的 503，并按 OpenAI、Anthropic、Gemini 或普通 Admin 路径输出对应错误形状；维护 drain 上限为 `min(request_timeout_ms, 120s)`。自动任务每 10 分钟检查一次，只有整段成功才记录当日完成。SQLite 仅在 freelist 至少占总页数 5% 时执行全库重写；worker 启动前要求 `availableMemory()` 至少为动态 process limit 的 25%，并按数据库与 WAL 实际大小检查磁盘。worker 使用独立连接、`temp_store=FILE` 与机器推导的低维护 cache；Compose 默认给 shutdown 30 分钟 grace。未引入守护进程、Redis、消息队列或新依赖。
 
 ## 2026-07-23 · SQLite Session 与 Memory 正文使用兼容 gzip 存储（Store / Memory，docs/07/08，原则 1/3/7）
@@ -62,14 +71,9 @@
 - **Memory 存储**：SQLite 仅对不少于 256 UTF-8 字节且 gzip 后确实更小的 `memory_messages.content` 保存 BLOB；短消息和不可压缩正文仍保存 TEXT。去重 hash 始终基于原文，常规读取与归档出口统一解码，Memory 注入、Observer、租户范围和归档格式不变。生产小样本显示该门槛保留约 71.5% 的正文节省，同时避免小消息膨胀。
 - **历史数据边界**：代码不在启动或请求路径回写历史正文，也不在线执行 VACUUM。旧 Session、完整 payload 与关联图片 blob 的删除继续暂停；SQLite 物理文件缩减必须另行安排维护窗口。
 
-## 2026-07-22 · 全项目文案审查补齐多语言维护闭环（Admin / Portal / Setup，docs/11/12，原则 1/2）
-
-- **审查边界**：Claude CLI Opus 对 Admin、Portal、Gateway 公开页面、README、当前 docs、脚本输出和客户端可见错误做了只读审查；不改协议字段、配置键、模型 ID、命令或历史事实。README 中文版已是自然意译，当前 docs 没有值得用大范围重写换取的明确收益。
-- **维护闭环**：Admin 与 Portal 的翻译脚本补齐西班牙语和葡萄牙语，根级 `i18n:*` 命令同时覆盖两套应用；Portal 为仅动态引用的四个 key 增加静态 extraction anchors。新增结构测试统一验证两套应用七种语言的 key 集、非空值、placeholder、多语言脚本与动态 key，避免同步后静默回退英文。
-- **术语取舍**：简繁中文用户界面的 `lane` 统一意译为「通道」，不改真实 lane ID 或代码字段；分类失败继续使用「系统兜底通道」，执行 fallback 在简体统一为「兜底」、繁体按本地习惯统一为「備援」。首次设置页维持英文单语，移除唯一一处中英混排。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-22 · 全项目文案审查补齐多语言维护闭环（Admin / Portal / Setup，docs/11/12，原则 1/2）**：以 Opus 只读审查和七语言结构测试补齐 Admin、Portal、Setup 文案维护闭环，完整原文通过 git history 回溯。
 - **2026-07-22 · Session 恢复补齐响应快照并限制默认留存范围（Telemetry / Admin requests，docs/07/11，原则 1/3/7/8）**：复用 `session_revisions.response_json` 不新增迁移，四种协议的成功非流式请求保存客户端形态响应快照，流式不新增 SSE 缓冲；单快照 16 MiB、Session 64 MiB 上限，来源恒为 `exact=false` 故 Retry 禁用，完整原文通过 git history 回溯。
 - **2026-07-22 · 按会话增量保存请求正文并诚实区分恢复保真度（Telemetry / Admin requests / Store，docs/07/11，原则 1/3/7/8）**：新增 `capture_sessions` 与 `capture_payloads` 构成三种互斥留存模式（同时为 true 则 fail-closed），只解析高置信客户端会话信号并以不可猜测 `session_ref` 存储；Session head + 单调 sequence + 不可变 revision 按最长公共前缀存增量，Responses 续接建真实 `response_id → request_id` 父边、找不到父 response 时恢复 fail-closed 为 `session_incomplete`，完整原文通过 git history 回溯。
 - **2026-07-22 · Lanes 批量保存、拖拽回退与可配置默认通道删除边界（Routing / Admin lanes，docs/03/04/11，原则 2/3/5/6）**：Lanes 整组原子保存、拖拽排序并只保护当前默认通道，非法默认配置 fail-closed，完整原文通过 git history 回溯。

--- a/packages/core/src/protocol/responses.test.ts
+++ b/packages/core/src/protocol/responses.test.ts
@@ -1149,12 +1149,13 @@ describe("responsesTransformer — request sampling/control params (litellm pari
     expect(ir.web_search_options).toEqual({ search_context_size: "low" });
   });
 
-  it("stashes Responses-only params (store/previous_response_id/metadata/logit_bias/context_management/include/background) in provider_raw", async () => {
+  it("stashes Responses-only params (store/previous_response_id/generate/metadata/logit_bias/context_management/include/background) in provider_raw", async () => {
     const ir = await responsesTransformer.transformRequestOut({
       model: "gpt-4o",
       input: "hi",
       store: true,
       previous_response_id: "resp_prev",
+      generate: false,
       metadata: { trace: "abc" },
       logit_bias: { "123": -100 },
       context_management: { truncation: "auto" },
@@ -1163,6 +1164,7 @@ describe("responsesTransformer — request sampling/control params (litellm pari
     });
     expect(ir.provider_raw?.store).toBe(true);
     expect(ir.provider_raw?.previous_response_id).toBe("resp_prev");
+    expect(ir.provider_raw?.generate).toBe(false);
     expect(ir.provider_raw?.metadata).toEqual({ trace: "abc" });
     expect(ir.provider_raw?.logit_bias).toEqual({ "123": -100 });
     expect(ir.provider_raw?.context_management).toEqual({ truncation: "auto" });

--- a/packages/core/src/protocol/responses.ts
+++ b/packages/core/src/protocol/responses.ts
@@ -228,6 +228,9 @@ const ResponsesRequestSchema = z
     context_management: z.unknown().optional(),
     include: z.array(z.string()).optional(),
     background: z.boolean().optional(),
+    // Responses WebSocket prewarm control. It is safe only on native passthrough;
+    // the executor fails closed instead of translating it into a billable generation.
+    generate: z.boolean().optional(),
     store: z.boolean().optional(),
     previous_response_id: z.string().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
@@ -560,6 +563,7 @@ function toIRRequest(req: NativeRequest): IRRequest {
     providerRaw.context_management = parsed.context_management;
   if (parsed.include !== undefined) providerRaw.include = parsed.include;
   if (parsed.background !== undefined) providerRaw.background = parsed.background;
+  if (parsed.generate !== undefined) providerRaw.generate = parsed.generate;
   if (parsed.prompt_cache_options !== undefined)
     providerRaw.prompt_cache_options = parsed.prompt_cache_options;
   if (normalizedTools.rawTools !== undefined)

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -86,6 +86,92 @@ describe("createOAuthPoolClient — Realtime account binding", () => {
     expect(await first?.sideband.headers()).toEqual({ Authorization: "Bearer a" });
     expect(second?.sideband.url).toContain("b.test");
   });
+
+  it("does not disable a text-capable account when Realtime voice access is denied", async () => {
+    const denied = new UpstreamError("upstream_error", "Voice session access denied.", null, 403);
+    const credentialFailures: string[] = [];
+    const calls: string[] = [];
+    const client = (account: string, allowed: boolean): ProviderClient => ({
+      ...stubClient(account, calls),
+      async realtimeCall() {
+        calls.push(account);
+        if (!allowed) throw denied;
+        return {
+          status: 201,
+          sdp: `answer-${account}`,
+          contentType: "application/sdp",
+          location: `/v1/realtime/calls/rtc_${account}`,
+          callId: `rtc_${account}`,
+          sideband: {
+            url: `wss://${account}.test/v1/realtime?call_id=rtc_${account}`,
+            headers: async () => ({ Authorization: `Bearer ${account}` }),
+          },
+        };
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [
+        { account: "a", priority: 10, schedulable: true, client: client("a", false) },
+        { account: "b", priority: 10, schedulable: true, client: client("b", true) },
+      ],
+      now: () => 1,
+      onAccountCredentialFailure: (account) => credentialFailures.push(account),
+    });
+
+    await expect(
+      pool.realtimeCall?.({
+        endpoint: "realtime",
+        query: "",
+        sdp: "offer",
+        session: { model: "gpt-realtime-1.5" },
+        headers: {},
+      }),
+    ).resolves.toMatchObject({ callId: "rtc_b" });
+
+    expect(calls).toEqual(["a", "b"]);
+    expect(credentialFailures).toEqual([]);
+  });
+
+  it("parks the selected account when sideband token refresh permanently fails", async () => {
+    const credentialFailures: string[] = [];
+    const refreshFailure = new TokenRefreshError("oauth refresh failed (status 401)", 401);
+    const client = (account: string): ProviderClient => ({
+      ...stubClient(account, []),
+      async realtimeCall() {
+        return {
+          status: 201,
+          sdp: "answer",
+          contentType: "application/sdp",
+          location: `/v1/realtime/calls/rtc_${account}`,
+          callId: `rtc_${account}`,
+          sideband: {
+            url: `wss://${account}.test/v1/realtime?call_id=rtc_${account}`,
+            headers: async () => {
+              throw refreshFailure;
+            },
+          },
+        };
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [
+        { account: "a", priority: 10, schedulable: true, client: client("a") },
+        { account: "b", priority: 10, schedulable: true, client: client("b") },
+      ],
+      onAccountCredentialFailure: (account) => credentialFailures.push(account),
+    });
+
+    const result = await pool.realtimeCall?.({
+      endpoint: "realtime",
+      query: "",
+      sdp: "offer",
+      session: { model: "gpt-realtime-1.5" },
+      headers: {},
+    });
+    await expect(result?.sideband.headers()).rejects.toBe(refreshFailure);
+
+    expect(credentialFailures).toEqual(["a"]);
+  });
 });
 
 describe("createOAuthPoolClient — account selection", () => {
@@ -649,6 +735,35 @@ describe("createOAuthPoolClient — account selection", () => {
     await pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-2" });
 
     expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("restores a persisted previous_response_id account pin after pool restart", async () => {
+    const calls: string[] = [];
+    const nativeMember = (account: string): OAuthPoolMember => ({
+      account,
+      priority: 50,
+      schedulable: true,
+      client: {
+        ...stubClient(account, calls),
+        async nativePassthrough() {
+          calls.push(account);
+          return { id: `resp-${account}` };
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({ members: [nativeMember("a"), nativeMember("b")] });
+
+    await pool.nativePassthrough?.(
+      {
+        protocol: "openai_responses",
+        body: { model: "gpt", input: [], previous_response_id: "resp-old" },
+        headers: {},
+        mutations: {},
+      },
+      { statefulAccount: "b" },
+    );
+
+    expect(calls).toEqual(["b"]);
   });
 
   it("keeps a known previous_response_id on its original account even with a stable user key", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -751,11 +751,16 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return separator > 0 ? stickyKey.slice(0, separator) : "unknown";
   }
 
-  function isStrictAccountSticky(stickyKey: string | null): boolean {
+  function isStrictAccountSticky(stickyKey: string | null): stickyKey is string {
     return (
       stickyKey?.startsWith("previous_response_id:") === true ||
       stickyKey?.startsWith("x-codex-turn-state:") === true
     );
+  }
+
+  function restorePersistedAffinity(stickyKey: string | null, account: string | undefined): void {
+    if (!isStrictAccountSticky(stickyKey) || !account) return;
+    stickySessions.set(stickyKey, { account, expiresAt: now() + stickyTtlMs });
   }
 
   function commitSelection(
@@ -930,6 +935,8 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     model: string | null,
     avoidBusy: boolean,
     call: (client: ProviderClient, entry: PoolEntry) => Promise<R>,
+    credentialFailureStatuses = upstreamCredentialFailureStatuses,
+    retryForbiddenWithoutParking = false,
   ): Promise<R> {
     const tried = new Set<string>();
     const statefulContinuation = isStrictAccountSticky(stickyKey);
@@ -947,9 +954,17 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         rememberResponseAffinity(result, entry);
         return result;
       } catch (err) {
-        if (isCredentialAccountFailure(err, upstreamCredentialFailureStatuses)) {
+        if (isCredentialAccountFailure(err, credentialFailureStatuses)) {
           parkCredentialFailedAccount(entry, err);
           if (statefulContinuation) throw err;
+          lastErr = err;
+          continue;
+        }
+        if (
+          retryForbiddenWithoutParking &&
+          err instanceof UpstreamError &&
+          err.upstreamStatus === 403
+        ) {
           lastErr = err;
           continue;
         }
@@ -1078,8 +1093,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       req: ChatCompletionRequest,
       opts?: ProviderCallOptions,
     ): Promise<ChatCompletionResponse> {
+      const stickyKey = stickyKeyFromChat(req);
+      restorePersistedAffinity(stickyKey, opts?.statefulAccount);
       return completeWithRetry(
-        stickyKeyFromChat(req),
+        stickyKey,
         modelFromChat(req),
         isUserMessageRequest(req),
         (client, entry) => client.chatCompletion(req, callOptionsForEntry(opts, entry)),
@@ -1092,6 +1109,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       // Pick SYNCHRONOUSLY (one pick per call) before opening the stream so rotation +
       // onSelect fire on the call turn; streamWithRetry only adds sibling fallbacks.
       const stickyKey = stickyKeyFromChat(req);
+      restorePersistedAffinity(stickyKey, opts?.statefulAccount);
       const avoidBusy = isUserMessageRequest(req);
       const first = select(stickyKey, undefined, { avoidBusy, model: modelFromChat(req) });
       return streamWithRetry(
@@ -1120,8 +1138,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       // rotation + onSelect fire on the call turn exactly like the other methods. A member
       // missing the method throws a NON-transient error → surfaced at once (fail-closed,
       // never silently routed to a translating sibling), not retried.
+      const stickyKey = stickyKeyFromNative(body);
+      restorePersistedAffinity(stickyKey, opts?.statefulAccount);
       return completeWithRetry(
-        stickyKeyFromNative(body),
+        stickyKey,
         modelFromNative(body),
         isUserMessageRequest(nativePassthroughBody(body)),
         (client, entry) => {
@@ -1142,6 +1162,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       opts?: ProviderCallOptions,
     ): AsyncIterable<string> {
       const stickyKey = stickyKeyFromNative(body);
+      restorePersistedAffinity(stickyKey, opts?.statefulAccount);
       const avoidBusy = isUserMessageRequest(nativePassthroughBody(body));
       // Pick + fail-closed check SYNCHRONOUSLY on the call turn (rotation + onSelect, and a
       // synchronous throw if the picked member can't passthrough-stream), exactly as before.
@@ -1172,12 +1193,51 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
           ): Promise<RealtimeCallResult> {
             // Realtime models are selected by the voice endpoint, not the Codex
             // text-model catalog used for per-account entitlement filtering.
-            return completeWithRetry(null, null, false, (client, entry) => {
-              if (!client.realtimeCall) {
-                throw new Error("oauth pool member does not support Realtime calls");
-              }
-              return client.realtimeCall(req, callOptionsForEntry(opts, entry));
-            });
+            return completeWithRetry(
+              null,
+              null,
+              false,
+              (client, entry) => {
+                if (!client.realtimeCall) {
+                  throw new Error("oauth pool member does not support Realtime calls");
+                }
+                return client.realtimeCall(req, callOptionsForEntry(opts, entry)).then((result) => {
+                  const target = result.sideband;
+                  return {
+                    ...result,
+                    sideband: {
+                      ...target,
+                      headers: async () => {
+                        try {
+                          return await target.headers();
+                        } catch (error) {
+                          if (isCredentialAccountFailure(error, new Set([401]))) {
+                            parkCredentialFailedAccount(entry, error);
+                          }
+                          throw error;
+                        }
+                      },
+                      onCredentialFailure: (status: number) => {
+                        target.onCredentialFailure?.(status);
+                        if (status === 401) {
+                          parkCredentialFailedAccount(
+                            entry,
+                            new UpstreamError(
+                              "upstream_error",
+                              "realtime sideband authentication failed",
+                              null,
+                              status,
+                            ),
+                          );
+                        }
+                      },
+                    },
+                  };
+                });
+              },
+              new Set([401]),
+              true,
+            );
           },
         }
       : {}),
@@ -1188,8 +1248,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
             req: NativePassthroughInput,
             opts?: ProviderCallOptions,
           ): Promise<Record<string, unknown>> {
+            const stickyKey = stickyKeyFromNative(req);
+            restorePersistedAffinity(stickyKey, opts?.statefulAccount);
             return completeWithRetry(
-              stickyKeyFromNative(req),
+              stickyKey,
               modelFromNative(req),
               isUserMessageRequest(nativePassthroughBody(req)),
               (client, entry) => {

--- a/packages/core/src/provider/openai.realtime.test.ts
+++ b/packages/core/src/provider/openai.realtime.test.ts
@@ -15,7 +15,7 @@ describe("createOpenAIClient.realtimeCall", () => {
       }),
     );
     const client = createOpenAIClient({
-      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-secret" },
+      config: { baseUrl: "https://api.openai.test/openai/v1", apiKey: "sk-secret" },
       fetch,
     });
 
@@ -33,12 +33,12 @@ describe("createOpenAIClient.realtimeCall", () => {
       location: "/v1/realtime/calls/rtc_public",
       callId: "rtc_public",
       sideband: {
-        url: "wss://api.openai.test/v1/realtime?intent=quicksilver&architecture=avas&call_id=rtc_public",
+        url: "wss://api.openai.test/openai/v1/realtime?intent=quicksilver&call_id=rtc_public",
       },
     });
     const [url, init] = fetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(
-      "https://api.openai.test/v1/realtime/calls?intent=quicksilver&architecture=avas",
+      "https://api.openai.test/openai/v1/realtime/calls?intent=quicksilver&architecture=avas",
     );
     expect(init.method).toBe("POST");
     expect(init.body).toBeInstanceOf(FormData);
@@ -54,11 +54,12 @@ describe("createOpenAIClient.realtimeCall", () => {
   });
 
   it("uses the required AVAS query for ChatGPT Frameless calls and keeps its Codex identity", async () => {
-    const fetch = vi.fn().mockResolvedValue(
-      new Response("v=answer\r\n", {
-        status: 201,
-        headers: { location: "/v1/live/rtc_backend", "content-type": "application/sdp" },
-      }),
+    const fetch = vi.fn().mockImplementation(
+      async () =>
+        new Response("v=answer\r\n", {
+          status: 201,
+          headers: { location: "/v1/live/rtc_backend", "content-type": "application/sdp" },
+        }),
     );
     const getAuthHeader = vi.fn().mockResolvedValue("Bearer oauth-token");
     const client = createOpenAIClient({
@@ -94,11 +95,99 @@ describe("createOpenAIClient.realtimeCall", () => {
       sdp: "v=offer\r\n",
       session: { ...SESSION, delegation: { type: "client" } },
     });
-    expect(result?.sideband.url).toBe("wss://chatgpt.com/backend-api/codex/rtc_backend");
+    expect(result?.sideband.url).toBe("wss://api.openai.com/v1/live/rtc_backend");
     expect(await result?.sideband.headers()).toMatchObject({
       Authorization: "Bearer oauth-token",
       "chatgpt-account-id": "acct-1",
     });
+
+    const v1 = await client.realtimeCall?.({
+      endpoint: "realtime",
+      query: "intent=quicksilver&architecture=avas",
+      sdp: "v=offer\r\n",
+      session: SESSION,
+      headers: { "openai-alpha": "quicksilver=v1" },
+    });
+    expect(v1?.sideband.url).toBe(
+      "wss://api.openai.com/v1/realtime?intent=quicksilver&call_id=rtc_backend",
+    );
+  });
+
+  it("fills missing backend AVAS parameters without dropping client query values", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response("v=answer\r\n", {
+        status: 201,
+        headers: { location: "/v1/realtime/calls/rtc_backend" },
+      }),
+    );
+    const client = createOpenAIClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => "Bearer oauth-token",
+      },
+      fetch,
+    });
+
+    await client.realtimeCall?.({
+      endpoint: "realtime",
+      query: "trace=1",
+      sdp: "v=offer\r\n",
+      session: SESSION,
+      headers: {},
+    });
+
+    expect(fetch.mock.calls[0]?.[0]).toBe(
+      "https://chatgpt.com/backend-api/codex/realtime/calls?trace=1&intent=quicksilver&architecture=avas",
+    );
+  });
+
+  it("strips call-create-only AVAS architecture from public V1 sideband URLs", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response("v=answer\r\n", {
+        status: 201,
+        headers: { location: "/v1/realtime/calls/rtc_public" },
+      }),
+    );
+    const client = createOpenAIClient({
+      config: { baseUrl: "https://api.openai.test/openai/v1", apiKey: "sk-secret" },
+      fetch,
+    });
+
+    const result = await client.realtimeCall?.({
+      endpoint: "realtime",
+      query: "intent=quicksilver&architecture=avas&trace=1",
+      sdp: "v=offer\r\n",
+      session: SESSION,
+      headers: {},
+    });
+
+    expect(result?.sideband.url).toBe(
+      "wss://api.openai.test/openai/v1/realtime?intent=quicksilver&trace=1&call_id=rtc_public",
+    );
+  });
+
+  it("parses and validates the call id independently of Location query parameters", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response("v=answer\r\n", {
+        status: 201,
+        headers: { location: "/v1/live/rtc_query?trace=1#fragment" },
+      }),
+    );
+    const client = createOpenAIClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-secret" },
+      fetch,
+    });
+
+    const result = await client.realtimeCall?.({
+      endpoint: "live",
+      query: "",
+      sdp: "v=offer\r\n",
+      session: SESSION,
+      headers: {},
+    });
+
+    expect(result?.callId).toBe("rtc_query");
+    expect(result?.sideband.url).toBe("wss://api.openai.test/v1/live/rtc_query");
   });
 
   it("preserves a non-2xx upstream response as an UpstreamError", async () => {
@@ -122,6 +211,29 @@ describe("createOpenAIClient.realtimeCall", () => {
         headers: {},
       }),
     ).rejects.toMatchObject({ name: "UpstreamError", upstreamStatus: 400 });
+  });
+
+  it("surfaces the scrubbed Realtime upstream error message", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "Voice session access denied." } }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = createOpenAIClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-secret" },
+      fetch,
+    });
+
+    await expect(
+      client.realtimeCall?.({
+        endpoint: "realtime",
+        query: "",
+        sdp: "v=offer\r\n",
+        session: SESSION,
+        headers: {},
+      }),
+    ).rejects.toMatchObject({ message: "Voice session access denied.", upstreamStatus: 403 });
   });
 
   it("refreshes OAuth once after a 401 call-create response", async () => {
@@ -160,5 +272,9 @@ describe("createOpenAIClient.realtimeCall", () => {
     expect(
       fetch.mock.calls.map((call) => (call[1]?.headers as Record<string, string>).Authorization),
     ).toEqual(["Bearer token-1", "Bearer token-2"]);
+    expect(fetch.mock.calls.map((call) => call[0])).toEqual([
+      "https://chatgpt.com/backend-api/codex/realtime/calls?intent=quicksilver&architecture=avas",
+      "https://chatgpt.com/backend-api/codex/realtime/calls?intent=quicksilver&architecture=avas",
+    ]);
   });
 });

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -82,6 +82,8 @@ export interface RealtimeSidebandTarget {
   url: string;
   headers(): Promise<Record<string, string>>;
   onUnauthorized?: () => void;
+  /** Called only after a refreshed sideband still returns an auth failure. */
+  onCredentialFailure?: (status: number) => void;
   proxy?: ProxyConfig;
 }
 
@@ -109,6 +111,8 @@ export type NativeProtocolProfile =
 // across connection / 401 retries — same body). MUST NOT throw (capture is fail-open).
 export interface ProviderCallOptions {
   signal?: AbortSignal;
+  /** Trusted persisted account pin for opaque stateful Responses continuations. */
+  statefulAccount?: string;
   captureUpstream?: (wireBody: string) => void;
   /** Request-scoped Anthropic defensive recovery switch. The gateway owns the live
    * runtime setting and passes its current value per attempt; provider clients keep
@@ -531,6 +535,42 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     );
   }
 
+  async function realtimeErrorFromResponse(res: Response): Promise<UpstreamError> {
+    const providerRaw = await res
+      .json()
+      .catch(() => null)
+      .then(scrub);
+    const outer =
+      providerRaw !== null && typeof providerRaw === "object" && !Array.isArray(providerRaw)
+        ? (providerRaw as Record<string, unknown>)
+        : null;
+    const nested =
+      outer?.error !== null && typeof outer?.error === "object" && !Array.isArray(outer.error)
+        ? (outer.error as Record<string, unknown>)
+        : null;
+    const message =
+      typeof nested?.message === "string" && nested.message.length > 0
+        ? nested.message
+        : `upstream returned ${res.status}`;
+    return new UpstreamError("upstream_error", message, providerRaw, res.status);
+  }
+
+  function realtimeCallId(location: string): string | null {
+    let path: string;
+    try {
+      path = new URL(location, "https://realtime.invalid").pathname;
+    } catch {
+      return null;
+    }
+    for (const segment of path.split("/").reverse()) {
+      if (segment.startsWith("rtc_") && segment.length > 4) return segment;
+      if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(segment)) {
+        return segment;
+      }
+    }
+    return null;
+  }
+
   return {
     ...(cfg.normalizeReasoningDeltaAlias ? { streamReframed: true } : {}),
 
@@ -592,12 +632,13 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       const base = cfg.resolveBaseUrl ? await cfg.resolveBaseUrl() : cfg.baseUrl;
       const backendShape = base.includes("/backend-api/");
       const callPath = backendShape || req.endpoint === "realtime" ? "realtime/calls" : "live";
-      const query =
-        req.query.length > 0
-          ? `?${req.query}`
-          : backendShape && req.endpoint === "live"
-            ? "?intent=quicksilver&architecture=avas"
-            : "";
+      const callQuery = new URLSearchParams(req.query);
+      if (backendShape) {
+        if (!callQuery.has("intent")) callQuery.set("intent", "quicksilver");
+        if (!callQuery.has("architecture")) callQuery.set("architecture", "avas");
+      }
+      const queryText = callQuery.toString();
+      const query = queryText.length > 0 ? `?${queryText}` : "";
       const url = `${base}/${callPath}${query}`;
       const forwardedHeaders = async (): Promise<Record<string, string>> => ({
         ...(await headersWithoutContentType()),
@@ -622,20 +663,25 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
           : forwardedHeaders,
         signal: opts?.signal,
       });
-      if (!response.ok) throw await errorFromResponse(response);
+      if (!response.ok) throw await realtimeErrorFromResponse(response);
       const sdp = await response.text();
       const location = response.headers.get("location") ?? "";
-      const callId = location.split("/").filter(Boolean).at(-1) ?? "";
-      if (callId.length === 0) {
+      const callId = realtimeCallId(location);
+      if (callId === null) {
         throw new UpstreamError("upstream_error", "upstream Realtime response omitted call id");
       }
-      const sideband = new URL(base);
+      const sideband = new URL(backendShape ? "https://api.openai.com/v1" : base);
       sideband.protocol = sideband.protocol === "http:" ? "ws:" : "wss:";
-      if (!backendShape) sideband.pathname = req.endpoint === "live" ? "/v1/live" : "/v1/realtime";
+      sideband.pathname = `${sideband.pathname.replace(/\/$/, "")}/${
+        req.endpoint === "live" ? "live" : "realtime"
+      }`;
       if (req.endpoint === "live") {
         sideband.pathname = `${sideband.pathname.replace(/\/$/, "")}/${callId}`;
       } else {
-        sideband.search = req.query;
+        const sidebandQuery = new URLSearchParams(backendShape ? "" : req.query);
+        sidebandQuery.delete("architecture");
+        sidebandQuery.set("intent", "quicksilver");
+        sideband.search = sidebandQuery.toString();
         sideband.searchParams.set("call_id", callId);
       }
       return {

--- a/packages/core/src/routing/route-request.test.ts
+++ b/packages/core/src/routing/route-request.test.ts
@@ -116,6 +116,145 @@ function deps(over: Partial<RouteDeps> = {}): RouteDeps {
 // ── tests ───────────────────────────────────────────────────────────────────
 
 describe("routeRequest — orchestration", () => {
+  it("pins a registry-validated Responses continuation before classification", async () => {
+    const d = deps();
+    const input = req({
+      protocol: "openai_responses",
+      requested_model: "gpt-5.6-sol",
+      messages: [],
+      provider_raw: { previous_response_id: "resp-1" },
+      metadata: {
+        conversation_id: null,
+        thread_id: null,
+        resource_id: null,
+        project_id: null,
+        memory_mode: "off",
+        stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+      },
+    });
+
+    await routeRequest(input, d, { allowCustomModel: false });
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan).toEqual({
+      selected_lane: "openai-codex/gpt-5.6-sol",
+      candidate_chain: ["openai-codex/gpt-5.6-sol"],
+      explicit_model: "openai-codex/gpt-5.6-sol",
+    });
+    expect(d.classify).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pinned Responses continuation outside the key lane cap", async () => {
+    const d = deps();
+    const input = req({
+      protocol: "openai_responses",
+      provider_raw: { previous_response_id: "resp-1" },
+      metadata: {
+        conversation_id: null,
+        thread_id: null,
+        resource_id: null,
+        project_id: null,
+        memory_mode: "off",
+        stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+        stateful_lane: "coding",
+      },
+    });
+
+    const result = await routeRequest(input, d, {
+      keyCaps: { allowedLanes: ["economy"] },
+    });
+
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(d.execute).not.toHaveBeenCalled();
+    expect(d.classify).not.toHaveBeenCalled();
+  });
+
+  it("preserves an allowed custom-model continuation whose selected lane is the model alias", async () => {
+    const d = deps();
+    const alias = "openai-codex/gpt-custom";
+    const input = req({
+      protocol: "openai_responses",
+      requested_model: alias,
+      messages: [],
+      provider_raw: { previous_response_id: "resp-1" },
+      metadata: {
+        conversation_id: null,
+        thread_id: null,
+        resource_id: null,
+        project_id: null,
+        memory_mode: "off",
+        stateful_provider_alias: alias,
+        stateful_lane: alias,
+      },
+    });
+
+    await routeRequest(input, d, {
+      allowCustomModel: true,
+      keyCaps: { allowedLanes: ["coding"] },
+    });
+
+    const plan = (d.execute as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as ExecutionPlan;
+    expect(plan).toEqual({
+      selected_lane: alias,
+      candidate_chain: [alias],
+      explicit_model: alias,
+    });
+    expect(d.classify).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pinned Responses continuation whose provider is blocked", async () => {
+    const d = deps();
+    const input = req({
+      protocol: "openai_responses",
+      provider_raw: { previous_response_id: "resp-1" },
+      metadata: {
+        conversation_id: null,
+        thread_id: null,
+        resource_id: null,
+        project_id: null,
+        memory_mode: "off",
+        stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+        stateful_lane: "coding",
+      },
+    });
+
+    const result = await routeRequest(input, d, {
+      keyCaps: { allowedLanes: null, blockedModels: ["openai-codex/*"] },
+    });
+
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(d.execute).not.toHaveBeenCalled();
+    expect(d.classify).not.toHaveBeenCalled();
+  });
+
+  it("rejects a pinned Responses continuation that cannot honor budget degradation", async () => {
+    const d = deps();
+    const input = req({
+      protocol: "openai_responses",
+      provider_raw: { previous_response_id: "resp-1" },
+      metadata: {
+        conversation_id: null,
+        thread_id: null,
+        resource_id: null,
+        project_id: null,
+        memory_mode: "off",
+        stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+        stateful_lane: "coding",
+      },
+    });
+
+    const result = await routeRequest(input, d, {
+      keyCaps: { allowedLanes: null, degradeLane: "economy" },
+    });
+
+    expect(result.final.status).toBe("error");
+    expect(result.error?.error_class).toBe("invalid_request");
+    expect(d.execute).not.toHaveBeenCalled();
+    expect(d.classify).not.toHaveBeenCalled();
+  });
+
   it("records the effective reasoning effort in the body-free decision", async () => {
     const d = deps();
     const result = await routeRequest(req({ reasoning_effort: "high" }), d);

--- a/packages/core/src/routing/route-request.ts
+++ b/packages/core/src/routing/route-request.ts
@@ -707,6 +707,70 @@ async function plan(
     };
   }
 
+  const previousResponseId = req.provider_raw?.previous_response_id;
+  const statefulAlias = req.metadata.stateful_provider_alias;
+  if (
+    req.protocol === "openai_responses" &&
+    typeof previousResponseId === "string" &&
+    previousResponseId.length > 0 &&
+    typeof statefulAlias === "string" &&
+    statefulAlias.length > 0
+  ) {
+    const statefulLane = req.metadata.stateful_lane ?? null;
+    const allowed = opts.keyCaps?.allowedLanes;
+    const explicitStatefulModel =
+      opts.allowCustomModel === true &&
+      statefulLane === statefulAlias &&
+      !Object.hasOwn(deps.lanes, statefulLane);
+    if (
+      allowed != null &&
+      !explicitStatefulModel &&
+      (statefulLane === null || !allowed.includes(statefulLane))
+    ) {
+      return noPermittedLanesRejection({
+        req,
+        selectedLane: statefulLane ?? statefulAlias,
+        classifier: passthroughClassifier(),
+        policy: { matched_policy_id: null, reason: "stateful continuation rejected" },
+        forcedReasoningEffort: null,
+        evalUsd: null,
+      });
+    }
+    const degradeLane = opts.keyCaps?.degradeLane;
+    if (degradeLane != null && statefulLane !== degradeLane) {
+      return noPermittedLanesRejection({
+        req,
+        selectedLane: statefulLane ?? statefulAlias,
+        classifier: passthroughClassifier(),
+        policy: { matched_policy_id: null, reason: "stateful continuation rejected" },
+        forcedReasoningEffort: null,
+        evalUsd: null,
+        message: `stateful continuation cannot move to required degrade lane "${degradeLane}"`,
+      });
+    }
+    if (filterBlockedModels([statefulAlias], opts).length === 0) {
+      return noPermittedModelsRejection({
+        req,
+        selectedLane: statefulLane ?? statefulAlias,
+        classifier: passthroughClassifier(),
+        policy: { matched_policy_id: null, reason: "stateful continuation rejected" },
+        forcedReasoningEffort: null,
+        evalUsd: null,
+      });
+    }
+    return {
+      plan: {
+        selected_lane: statefulLane ?? statefulAlias,
+        candidate_chain: [statefulAlias],
+        explicit_model: statefulAlias,
+      },
+      classifier: passthroughClassifier(),
+      policy: { matched_policy_id: null, reason: "stateful Responses continuation" },
+      forcedReasoningEffort: null,
+      evalUsd: null,
+    };
+  }
+
   // 0pre) IMAGE-GENERATION models are ALWAYS model-pinned to their exact alias —
   //    for ANY key, regardless of allow_custom_model, and AHEAD of the alias-glob
   //    shim (§0a) and classification (§2). An image model has no "auto"/classify

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -319,6 +319,8 @@ export {
 export {
   type InternalRequest,
   InternalRequestSchema,
+  isEmptyNativeResponsesContinuation,
+  isEmptyNativeResponsesPrewarm,
   type MemoryMode,
   MemoryModeSchema,
   type NativePassthroughCarrier,
@@ -331,6 +333,7 @@ export {
   ProtocolSchema,
   type RequestMetadata,
   RequestMetadataSchema,
+  responsesContinuationId,
   type TargetProviderProtocol,
   TargetProviderProtocolSchema,
 } from "./request/schema.js";

--- a/packages/shared/src/request/schema.test.ts
+++ b/packages/shared/src/request/schema.test.ts
@@ -106,6 +106,97 @@ describe("InternalRequestSchema", () => {
       expect(res.error.issues[0]?.path).toEqual(["messages"]);
     }
   });
+
+  it("accepts an empty native Responses continuation", () => {
+    const continuation = {
+      ...validRequest(),
+      protocol: "openai_responses",
+      messages: [],
+      provider_raw: { previous_response_id: "resp-1" },
+      metadata: {
+        ...validRequest().metadata,
+        stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+      },
+      native_request: {
+        protocol: "openai_responses",
+        body: { model: "gpt-5.6-sol", input: [], previous_response_id: "resp-1" },
+        headers: {},
+        mutations: {},
+      },
+    };
+
+    expect(InternalRequestSchema.safeParse(continuation).success).toBe(true);
+  });
+
+  it("accepts a strict empty native Responses prewarm", () => {
+    const prewarm = {
+      ...validRequest(),
+      protocol: "openai_responses",
+      messages: [],
+      provider_raw: { generate: false },
+      native_request: {
+        protocol: "openai_responses",
+        body: { model: "gpt-5.6-sol", input: [], generate: false },
+        headers: {},
+        mutations: {},
+      },
+    };
+
+    expect(InternalRequestSchema.safeParse(prewarm).success).toBe(true);
+  });
+
+  it("rejects an empty continuation whose native and normalized ids disagree", () => {
+    const bad = {
+      ...validRequest(),
+      protocol: "openai_responses",
+      messages: [],
+      provider_raw: { previous_response_id: "resp-other" },
+      metadata: {
+        ...validRequest().metadata,
+        stateful_provider_alias: "openai-codex/gpt-5.6-sol",
+      },
+      native_request: {
+        protocol: "openai_responses",
+        body: { model: "gpt-5.6-sol", input: [], previous_response_id: "resp-1" },
+        headers: {},
+        mutations: {},
+      },
+    };
+
+    expect(InternalRequestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects an empty native Responses request without a continuation id", () => {
+    const bad = {
+      ...validRequest(),
+      protocol: "openai_responses",
+      messages: [],
+      native_request: {
+        protocol: "openai_responses",
+        body: { model: "gpt-5.6-sol", input: [] },
+        headers: {},
+        mutations: {},
+      },
+    };
+
+    expect(InternalRequestSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects an empty prewarm whose normalized generate flag is missing", () => {
+    const bad = {
+      ...validRequest(),
+      protocol: "openai_responses",
+      messages: [],
+      native_request: {
+        protocol: "openai_responses",
+        body: { model: "gpt-5.6-sol", input: [], generate: false },
+        headers: {},
+        mutations: {},
+      },
+    };
+
+    expect(InternalRequestSchema.safeParse(bad).success).toBe(false);
+  });
 });
 
 describe("TargetProviderProtocolSchema", () => {

--- a/packages/shared/src/request/schema.ts
+++ b/packages/shared/src/request/schema.ts
@@ -94,6 +94,13 @@ export const RequestMetadataSchema = z.object({
   // Trusted gateway-only pin resolved from the Responses registry. Stateful
   // previous_response_id turns may use only the provider alias that created the id.
   stateful_provider_alias: z.string().min(1).optional(),
+  // Durable OAuth-account affinity for a registry-validated Responses continuation.
+  // Trusted gateway metadata only; provider pools use it to restore the original
+  // subscription account after a restart instead of rotating opaque state to a sibling.
+  stateful_provider_account: z.string().min(1).optional(),
+  // The lane that originally served the response, retained so current allowed_lanes
+  // can still fail closed before the continuation is provider-pinned.
+  stateful_lane: z.string().min(1).optional(),
   // The inbound client's Claude-Code billing-attribution prefix —
   // "cc_version=<v>.<3hex>; cc_entrypoint=<entry>" with the per-request `cch` dropped
   // — captured at the Anthropic route from the real CLI's system[0] block before it
@@ -105,7 +112,7 @@ export const RequestMetadataSchema = z.object({
   client_billing_header: z.string().nullish(),
 });
 
-export const InternalRequestSchema = z.object({
+const InternalRequestObjectSchema = z.object({
   request_id: z.string().min(1),
   protocol: ProtocolSchema,
   account_id: z.string().min(1),
@@ -113,7 +120,7 @@ export const InternalRequestSchema = z.object({
   user_id: z.string().nullable(),
   org_id: z.string().nullable(),
   requested_model: z.string().min(1),
-  messages: z.array(MessageSchema).min(1),
+  messages: z.array(MessageSchema),
   tools: z.array(z.unknown()).nullable(),
   response_format: z.record(z.string(), z.unknown()).nullable(),
   attachments: z.array(z.unknown()).nullable(),
@@ -173,6 +180,68 @@ export const InternalRequestSchema = z.object({
   native_request: NativeRequestSchema.optional(),
   stream: z.boolean(),
   metadata: RequestMetadataSchema,
+});
+
+type ResponsesContinuationLike = {
+  protocol?: unknown;
+  messages?: unknown;
+  provider_raw?: unknown;
+  native_request?: unknown;
+  metadata?: unknown;
+};
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Return the trusted opaque response id only when every normalized/native pin agrees. */
+export function responsesContinuationId(request: ResponsesContinuationLike): string | null {
+  if (request.protocol !== "openai_responses") return null;
+  const providerRaw = record(request.provider_raw);
+  const normalizedId = providerRaw?.previous_response_id;
+  const native = record(request.native_request);
+  const nativeBody = native?.protocol === "openai_responses" ? record(native.body) : null;
+  const nativeId = nativeBody?.previous_response_id;
+  const metadata = record(request.metadata);
+  const alias = metadata?.stateful_provider_alias;
+  return typeof normalizedId === "string" &&
+    normalizedId.length > 0 &&
+    nativeId === normalizedId &&
+    typeof alias === "string" &&
+    alias.length > 0
+    ? normalizedId
+    : null;
+}
+
+/** Empty input is legal only for a fully pinned native Responses continuation. */
+export function isEmptyNativeResponsesContinuation(request: ResponsesContinuationLike): boolean {
+  if (!Array.isArray(request.messages) || request.messages.length !== 0) return false;
+  if (responsesContinuationId(request) === null) return false;
+  const native = record(request.native_request);
+  const body = record(native?.body);
+  return Array.isArray(body?.input) && body.input.length === 0;
+}
+
+/** Empty input is also legal for the exact native Responses generate:false prewarm. */
+export function isEmptyNativeResponsesPrewarm(request: ResponsesContinuationLike): boolean {
+  if (request.protocol !== "openai_responses") return false;
+  if (!Array.isArray(request.messages) || request.messages.length !== 0) return false;
+  if (record(request.provider_raw)?.generate !== false) return false;
+  const native = record(request.native_request);
+  const body = native?.protocol === "openai_responses" ? record(native.body) : null;
+  return body?.generate === false && Array.isArray(body.input) && body.input.length === 0;
+}
+
+export const InternalRequestSchema = InternalRequestObjectSchema.superRefine((request, ctx) => {
+  if (request.messages.length > 0) return;
+  if (isEmptyNativeResponsesContinuation(request) || isEmptyNativeResponsesPrewarm(request)) return;
+  ctx.addIssue({
+    code: "custom",
+    path: ["messages"],
+    message: "messages must be a non-empty array",
+  });
 });
 
 // ── Inbound OpenAI Chat Completions request validation (boundary guard) ─────────


### PR DESCRIPTION
## 变更

- 补齐 ChatGPT/Codex Realtime V1/V2/V3 call-create 与 WebSocket sideband 代理契约，包括 `Location`、query、`x-oai-attestation`、401 refresh 和 403 Voice 权限隔离。
- 加固 Responses WebSocket：每轮独立取消、并发 turn 立即中止、terminal 后可复用连接、上游 connect 有界、避免 teardown abort 覆盖真实终态。
- 支持 Codex Responses v2 的严格 `input:[] + generate:false` prewarm，以及同一连接内的空增量 continuation。
- 在 terminal frame 前持久化 `response_id` 的 provider/account/lane 绑定；continuation 在分类前固定原 provider，同时保持 `allowed_lanes`、`blocked_models`、预算 degrade 和跨协议边界 fail-closed。
- `generate:false` 无原生 Responses passthrough 时拒绝，避免翻译路径产生意外计费输出。

## 根因

现有 HTTP/SSE 代理没有覆盖 ChatGPT Desktop 新增的 Realtime/Responses WebSocket 线缆；同时 WebSocket terminal、取消、registry 提交和 OAuth affinity 的生命周期存在竞态，可能造成客户端卡住、错误重连、continuation 找不到绑定或落到错误账号。

## 验证

- `CI=true pnpm exec vitest run ...`：13 个相关文件，703/703 通过。
- Shared/Core/Gateway typecheck 全绿；Biome 检查 27 个变更 TS 文件全绿；`git diff --check` 全绿。
- 本地 Docker 使用 OAuth 加密配置完成真实业务 smoke：50 个 idle WebSocket、严格 prewarm → 空 continuation → 第三轮、8 路并发推理、主动断连后重连恢复，均到达 `response.completed`。
- 候选容器保持 healthy、restart=0、OOM=false，RSS 约 208 MiB，无 capacity/fatal/error 日志。
- Realtime call-create 已确认到达 ChatGPT upstream，明确 403 Voice 拒绝不会停车仍可服务文本的 OAuth 账号；随后文本 Responses 仍正常完成。真实 Voice 成功仍需正式 Desktop 客户端提供设备绑定的 `x-oai-attestation`。
- Grok 以 `bypassPermissions + always-approve`、无 `max-turns` 完整复审当前树，最终无可执行 P0-P2 findings。

## 兼容性

普通 OpenAI/Anthropic HTTP、SSE 与非 Responses 空请求校验保持原行为；客户端断连仍不计为 provider 故障。
