### PR TITLE
chore(release): v0.28.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.14",
+  "version": "0.28.15",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- release Helm API v0.28.15
- includes the hardened Responses WebSocket lifecycle and Realtime Voice proxy support from #646

## Verification
- version-only change based on current origin/main
- feature PR #646 required checks passed