### PR TITLE
chore(release): v0.28.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.15",
+  "version": "0.28.16",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump the Helm API release version from `0.28.15` to `0.28.16`
- publish the image-routing client-error fix merged in #648

## Scope

Version-only release commit based on current `origin/main` (`067c4aa44c73e310cff49d8d10129d83e92c7aed`).
