### PR TITLE
[codex] fix request memory admission double counting

### DIFF
--- a/apps/gateway/src/app.test.ts
+++ b/apps/gateway/src/app.test.ts
@@ -6,6 +6,7 @@ import { createApp } from "./app.js";
 import type { LogFields, Logger, LogLevel } from "./logging.js";
 import { HelmHttpError, handleError, openAIErrorEnvelope } from "./middleware/error-handler.js";
 import { requestTimedOut } from "./middleware/limits.js";
+import { RequestAdmissionError } from "./runtime/memory-admission.js";
 
 interface Captured {
   level: LogLevel;
@@ -26,6 +27,7 @@ function mockCtx(logger: Logger, traceId: string): Context<AppEnv> {
   const store: Record<string, unknown> = { trace_id: traceId, logger };
   return {
     get: (k: string) => store[k],
+    header: () => {},
     json: (body: unknown, status?: number) =>
       new Response(JSON.stringify(body), {
         status: status ?? 200,
@@ -134,6 +136,38 @@ describe("createApp: trace_id, logging, error handling", () => {
       level: "error",
       fields: { fault_scope: "gateway_internal" },
     });
+  });
+
+  it("logs the request-memory rejection predicate without request payload data", async () => {
+    const { logger, lines } = fakeLogger();
+    const c = mockCtx(logger, "trace-memory");
+    const res = handleError(
+      new RequestAdmissionError(503, "server_overloaded", "memory busy", {
+        cause: "live_heap",
+        wireBytes: 12,
+        requestedChargeBytes: 72,
+        activeReservedBytes: 144,
+        activeCapacityBytes: 256,
+        pendingBytes: 24,
+        heapUsedBytes: 300,
+        heapCeilingBytes: 350,
+      }),
+      c,
+    );
+
+    expect(res.status).toBe(503);
+    expect(lines.find((line) => line.message === "request.memory_rejected")?.fields).toMatchObject({
+      trace_id: "trace-memory",
+      admission_reason: "live_heap",
+      wire_bytes: 12,
+      requested_charge_bytes: 72,
+      active_reserved_bytes: 144,
+      active_capacity_bytes: 256,
+      pending_bytes: 24,
+      heap_used_bytes: 300,
+      heap_ceiling_bytes: 350,
+    });
+    expect(JSON.stringify(lines)).not.toContain("payload");
   });
 
   it("marks the request context as timed out while late route work continues", async () => {

--- a/apps/gateway/src/middleware/error-handler.ts
+++ b/apps/gateway/src/middleware/error-handler.ts
@@ -69,6 +69,18 @@ export function handleError(err: unknown, c: Context<AppEnv>): Response {
       trace_id: traceId,
       http_status: err.status,
       code: err.code,
+      ...(err.admission === undefined
+        ? {}
+        : {
+            admission_reason: err.admission.cause,
+            wire_bytes: err.admission.wireBytes,
+            requested_charge_bytes: err.admission.requestedChargeBytes,
+            active_reserved_bytes: err.admission.activeReservedBytes,
+            active_capacity_bytes: err.admission.activeCapacityBytes,
+            pending_bytes: err.admission.pendingBytes,
+            heap_used_bytes: err.admission.heapUsedBytes,
+            heap_ceiling_bytes: err.admission.heapCeilingBytes,
+          }),
     });
     return c.json(
       {

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -219,6 +219,42 @@ describe("Responses websocket bridge", () => {
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
+  it("materializes the shared request lease after the internal HTTP parser returns", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1_000,
+      maxWireBytes: 1_000,
+      jsonAmplification: 1,
+      minRequestChargeBytes: 1,
+    });
+    let fetched!: () => void;
+    const fetchStarted = new Promise<void>((resolve) => {
+      fetched = resolve;
+    });
+    const baseUrl = await startBridge(
+      (request) => {
+        fetched();
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              request.signal.addEventListener("abort", () => controller.close(), { once: true });
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      },
+      undefined,
+      { memoryAdmission },
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+
+    socket.send(JSON.stringify({ type: "response.create", input: [], stream: true }));
+    await fetchStarted;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(memoryAdmission.reservedBytes).toBeGreaterThan(0);
+    expect(memoryAdmission.pendingBytes).toBe(0);
+  });
+
   it.each([
     "/v1/responses",
     "/responses",

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -313,6 +313,7 @@ async function forwardResponse(
   signal: AbortSignal,
   sessionId: string,
   sessionProof: string | undefined,
+  materialized: () => void,
 ): Promise<boolean> {
   const headers = normalizedFetchHeaders(request);
   headers.set("accept", "text/event-stream");
@@ -321,14 +322,19 @@ async function forwardResponse(
   if (sessionProof !== undefined) {
     headers.set(CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER, sessionProof);
   }
-  const response = await fetch(
-    new Request(requestUrl(request), {
-      method: "POST",
-      headers,
-      body: JSON.stringify(websocketRequestBody(data)),
-      signal,
-    }),
-  );
+  let response: Response;
+  try {
+    response = await fetch(
+      new Request(requestUrl(request), {
+        method: "POST",
+        headers,
+        body: JSON.stringify(websocketRequestBody(data)),
+        signal,
+      }),
+    );
+  } finally {
+    materialized();
+  }
   if (!response.ok) {
     await sendEnvelope(socket, await responseErrorEnvelope(response));
     return true;
@@ -554,6 +560,7 @@ export function installResponsesWebSocketBridge({
             turnController.signal,
             sessionId,
             sessionProof,
+            acquired.lease.materialized,
           );
           if (invalidatesSession) {
             socket.close(1000, "upstream session reset");

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -451,13 +451,17 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     // violations both map to the same structured invalid_request.
     let requestJson = "";
     let raw: unknown;
+    let requestBodyMaterialized: (() => void) | undefined;
     try {
       const admitted =
         deps.memoryAdmission === undefined
           ? null
           : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
       requestJson = admitted?.text ?? (await c.req.text());
-      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+      if (admitted !== null) {
+        c.set("requestMemoryRelease", admitted.release);
+        requestBodyMaterialized = admitted.materialized;
+      }
       raw = JSON.parse(requestJson);
     } catch (error) {
       if (error instanceof RequestAdmissionError) {
@@ -531,6 +535,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       if (Number.isFinite(ms) && ms > 0) internal.attempt_timeout_ms = Math.floor(ms);
     }
     const originalMessagesForMemory = [...(internal.messages as IRMessage[])];
+    requestBodyMaterialized?.();
 
     // Persist a (redacted) telemetry record. Fail-open: a telemetry failure must
     // never turn a successful request into a 5xx or break an in-flight stream. The

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -287,13 +287,17 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     if (route.operation === "countTokens") {
       let requestJson = "";
       let native: unknown;
+      let requestBodyMaterialized: (() => void) | undefined;
       try {
         const admitted =
           deps.memoryAdmission === undefined
             ? null
             : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
         requestJson = admitted?.text ?? (await c.req.text());
-        if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+        if (admitted !== null) {
+          c.set("requestMemoryRelease", admitted.release);
+          requestBodyMaterialized = admitted.materialized;
+        }
         native = JSON.parse(requestJson);
       } catch (error) {
         if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
@@ -310,6 +314,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
           trace_id: traceId,
         });
       }
+      requestBodyMaterialized?.();
       if (deps.countTokens !== undefined) {
         try {
           const counted = await deps.countTokens(
@@ -332,13 +337,17 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     //    400 INVALID_ARGUMENT, before routing (docs/07, principle 2 fail-closed).
     let requestJson = "";
     let native: unknown;
+    let requestBodyMaterialized: (() => void) | undefined;
     try {
       const admitted =
         deps.memoryAdmission === undefined
           ? null
           : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
       requestJson = admitted?.text ?? (await c.req.text());
-      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+      if (admitted !== null) {
+        c.set("requestMemoryRelease", admitted.release);
+        requestBodyMaterialized = admitted.materialized;
+      }
       native = JSON.parse(requestJson);
     } catch (error) {
       if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
@@ -391,6 +400,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     if (nativeCarrier !== null) {
       ir.metadata.native_request = nativeCarrier;
     }
+    requestBodyMaterialized?.();
 
     // 3) Route through the shared core. The per-request abort signal rides along so
     //    a client disconnect is a non-provider fault (docs/02). run() throws a

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -269,6 +269,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         if (editing) editInput = { kind: "json", body: parsed.data };
         else generationBody = parsed.data;
       }
+      admitted?.materialized();
     } catch (error) {
       if (error instanceof RequestAdmissionError) {
         if (error.status === 503) c.header("retry-after", "1");

--- a/apps/gateway/src/routes/interactions.ts
+++ b/apps/gateway/src/routes/interactions.ts
@@ -256,13 +256,17 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
     // 4) Parse + validate.
     let requestJson = "";
     let raw: unknown;
+    let requestBodyMaterialized: (() => void) | undefined;
     try {
       const admitted =
         deps.memoryAdmission === undefined
           ? null
           : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
       requestJson = admitted?.text ?? (await c.req.text());
-      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+      if (admitted !== null) {
+        c.set("requestMemoryRelease", admitted.release);
+        requestBodyMaterialized = admitted.materialized;
+      }
       raw = JSON.parse(requestJson);
     } catch (error) {
       if (error instanceof RequestAdmissionError) {
@@ -285,6 +289,7 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
         "INVALID_ARGUMENT",
       );
     }
+    requestBodyMaterialized?.();
 
     // 5) Resolve the model/lane → the chain, then keep only gemini-kind targets (this
     //    endpoint translates to generateContent). An openai-only id → 400 (→ images).

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -319,13 +319,17 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       });
     }
     let native: unknown;
+    let requestBodyMaterialized: (() => void) | undefined;
     try {
       const admitted =
         deps.memoryAdmission === undefined
           ? null
           : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
       const requestJson = admitted?.text ?? (await c.req.text());
-      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+      if (admitted !== null) {
+        c.set("requestMemoryRelease", admitted.release);
+        requestBodyMaterialized = admitted.materialized;
+      }
       native = JSON.parse(requestJson);
     } catch (error) {
       if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
@@ -350,6 +354,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         trace_id: traceId,
       });
     }
+    requestBodyMaterialized?.();
     if (deps.countTokens !== undefined) {
       try {
         return c.json(await deps.countTokens(obj, identity, requestSignal(c)));
@@ -451,13 +456,17 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     //    it never 5xx's as an upstream fault.
     let requestJson = "";
     let native: unknown;
+    let requestBodyMaterialized: (() => void) | undefined;
     try {
       const admitted =
         deps.memoryAdmission === undefined
           ? null
           : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
       requestJson = admitted?.text ?? (await c.req.text());
-      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+      if (admitted !== null) {
+        c.set("requestMemoryRelease", admitted.release);
+        requestBodyMaterialized = admitted.materialized;
+      }
       native = JSON.parse(requestJson);
     } catch (error) {
       if (error instanceof RequestAdmissionError) return sendAdmissionError(c, error);
@@ -561,6 +570,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       }
       ir.metadata.native_request = nativeCarrier;
     }
+    requestBodyMaterialized?.();
 
     // 3) Routing pipeline (framework-agnostic core). The per-request abort signal
     //    rides along so a client disconnect is a non-provider fault, not a breaker

--- a/apps/gateway/src/routes/realtime.ts
+++ b/apps/gateway/src/routes/realtime.ts
@@ -110,12 +110,16 @@ export function registerRealtimeRoutes(app: Hono<AppEnv>, deps: RealtimeRouteDep
     }
 
     let bytes: Uint8Array;
+    let requestBodyMaterialized: (() => void) | undefined;
     try {
       const admitted = deps.memoryAdmission
         ? await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission)
         : null;
       bytes = admitted?.bytes ?? new Uint8Array(await c.req.arrayBuffer());
-      if (admitted) c.set("requestMemoryRelease", admitted.release);
+      if (admitted) {
+        c.set("requestMemoryRelease", admitted.release);
+        requestBodyMaterialized = admitted.materialized;
+      }
     } catch (cause) {
       if (cause instanceof RequestAdmissionError) {
         if (cause.status === 503) c.header("retry-after", "1");
@@ -152,6 +156,7 @@ export function registerRealtimeRoutes(app: Hono<AppEnv>, deps: RealtimeRouteDep
       }
       session = parsed.data;
       model = parsed.data.model;
+      requestBodyMaterialized?.();
     } catch {
       return error(c, 400, "realtime call contains malformed multipart fields", "invalid_request");
     }

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -263,6 +263,57 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
+  it("admits a safe request while a parsed streaming request remains active", async () => {
+    let heapUsedBytes = 0;
+    const finish = deferred<void>();
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1_000,
+      maxWireBytes: 1_000,
+      jsonAmplification: 1,
+      minRequestChargeBytes: 1,
+      heapLimitBytes: 220,
+      heapUsedBytes: () => heapUsedBytes,
+    });
+    const { deps } = makeDeps({
+      memoryAdmission,
+      transformRequestOut: (native) => {
+        expect(memoryAdmission.pendingBytes).toBeGreaterThan(0);
+        return {
+          stream: (native as { stream?: unknown }).stream === true,
+          model: "auto",
+          metadata: {},
+        };
+      },
+      streamIR: async function* () {
+        yield { type: "response.created", sequence_number: 0 };
+        await finish.promise;
+        yield { type: "response.completed", sequence_number: 1 };
+      },
+    });
+    const app = buildApp(deps);
+
+    const active = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    expect(active.status).toBe(200);
+    expect(memoryAdmission.reservedBytes).toBeGreaterThan(0);
+    expect(memoryAdmission.pendingBytes).toBe(0);
+
+    heapUsedBytes = 140;
+    const next = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+    expect(next.status).toBe(200);
+
+    finish.resolve(undefined);
+    await active.text();
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
   it("non-stream: auth → translate-out → route → translate-back, returns Responses JSON", async () => {
     const { deps, order } = makeDeps();
     const app = buildApp(deps);

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -894,7 +894,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
   const parseJsonBodyWithRaw = async (
     c: Context<AppEnv>,
     traceId: string,
-  ): Promise<{ native: unknown; rawBody: string }> => {
+  ): Promise<{ native: unknown; rawBody: string; materialized?: () => void }> => {
     const trustedWebSocketSelfCall =
       deps.responsesWebSocketSessionProof !== undefined &&
       c.req.header(CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER) === deps.responsesWebSocketSessionProof;
@@ -905,14 +905,16 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     const rawBody = admitted?.text ?? (await c.req.text());
     if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
     try {
-      return { native: JSON.parse(rawBody), rawBody };
+      const native: unknown = JSON.parse(rawBody);
+      return {
+        native,
+        rawBody,
+        ...(admitted === null ? {} : { materialized: admitted.materialized }),
+      };
     } catch {
       throw helmError("invalid_request", "malformed JSON request body", traceId);
     }
   };
-
-  const parseJsonBody = async (c: Context<AppEnv>, traceId: string): Promise<unknown> =>
-    (await parseJsonBodyWithRaw(c, traceId)).native;
 
   const handleProviderLifecycle =
     (operation: "retrieve" | "delete" | "cancel" | "inputItems") => async (c: Context<AppEnv>) => {
@@ -949,13 +951,14 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     const identity = await authenticateResponsesRequest(c);
     await enforceRateLimit(c, identity);
     await acquireConcurrency(c, identity);
-    const { native, rawBody } = await parseJsonBodyWithRaw(c, traceId);
+    const { native, rawBody, materialized } = await parseJsonBodyWithRaw(c, traceId);
     const method = deps.lifecycle?.compact;
     if (method === undefined) throw lifecycleUnsupported("compact", traceId);
     let carrier = nativeCarrierForRequest(c, deps, native, rawBody);
     if (carrier === null) {
       throw helmError("invalid_request", "invalid Responses compact request body", traceId);
     }
+    materialized?.();
     const budgetCaps = identity.caps?.budget;
     if (deps.budget !== undefined && budgetCaps !== undefined) {
       const check = await deps.budget.gate.check({
@@ -1088,7 +1091,8 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
   const handleInputTokens = async (c: Context<AppEnv>) => {
     const traceId = c.get("trace_id");
     const identity = await authenticateResponsesRequest(c);
-    const native = await parseJsonBody(c, traceId);
+    const { native, materialized } = await parseJsonBodyWithRaw(c, traceId);
+    materialized?.();
     const providerMethod = deps.lifecycle?.inputTokens;
     if (providerMethod !== undefined) {
       const body = await providerMethod(native, identity, requestSignal(c));
@@ -1119,7 +1123,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     // 2) Parse + translate inbound. A malformed JSON body OR a structurally invalid
     //    Responses request (the transformer's Zod parse throws) is a CLIENT error →
     //    400 invalid_request, before routing (docs/07, principle 2 fail-closed).
-    const { native, rawBody: requestJson } = await parseJsonBodyWithRaw(c, traceId);
+    const { native, rawBody: requestJson, materialized } = await parseJsonBodyWithRaw(c, traceId);
     let ir: ResponsesIRLike;
     try {
       ir = deps.transformer.transformRequestOut(native);
@@ -1127,6 +1131,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       const detail = err instanceof Error ? err.message : "invalid Responses request";
       throw helmError("invalid_request", detail, traceId);
     }
+    materialized?.();
     // Memory scope (docs/08 Phase 1): parse the four memory headers at this HTTP
     // boundary and stamp them onto the IR metadata bag (mirrors /v1/messages), so
     // the SHARED pipeline's observe phase can read the scope off ir.metadata

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -15,7 +15,11 @@ describe("body memory admission", () => {
     expect(first.ok).toBe(true);
     expect(second.ok).toBe(true);
     expect(admission.reservedBytes).toBe(80);
-    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy" });
+    expect(admission.acquire(1)).toMatchObject({
+      ok: false,
+      reason: "busy",
+      cause: "active_capacity",
+    });
     if (first.ok) first.lease.release();
     if (second.ok) second.lease.release();
     expect(admission.reservedBytes).toBe(0);
@@ -30,7 +34,7 @@ describe("body memory admission", () => {
     const active = admission.acquire(5);
     expect(active.ok).toBe(true);
     admission.pause();
-    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy" });
+    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy", cause: "paused" });
     let idle = false;
     const waiting = admission.waitForIdle().then(() => {
       idle = true;
@@ -69,7 +73,11 @@ describe("body memory admission", () => {
       heapUsedBytes: () => heapUsedBytes,
     });
 
-    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy" });
+    expect(admission.acquire(1)).toMatchObject({
+      ok: false,
+      reason: "busy",
+      cause: "live_heap",
+    });
     heapUsedBytes = 60;
     const admitted = admission.acquire(1);
     expect(admitted.ok).toBe(true);
@@ -78,6 +86,41 @@ describe("body memory admission", () => {
       expect(admitted.lease.resize(1)).toMatchObject({ ok: false, reason: "busy" });
       admitted.lease.release();
     }
+  });
+
+  it("does not double count materialized requests against the live heap", () => {
+    let heapUsedBytes = 61;
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      maxWireBytes: 100,
+      jsonAmplification: 2,
+      minRequestChargeBytes: 10,
+      heapLimitBytes: 100,
+      protectedHeapBytes: 20,
+      heapUsedBytes: () => heapUsedBytes,
+    });
+
+    const active = admission.acquire(1);
+    expect(active.ok).toBe(true);
+    if (!active.ok) return;
+    active.lease.materialized();
+    active.lease.materialized();
+    expect(admission.reservedBytes).toBe(10);
+    expect(admission.pendingBytes).toBe(0);
+    expect(active.lease.resize(2)).toMatchObject({
+      ok: false,
+      reason: "busy",
+      cause: "materialized",
+    });
+
+    heapUsedBytes = 69;
+    const next = admission.acquire(1);
+    expect(next.ok).toBe(true);
+    if (next.ok) next.lease.release();
+    active.lease.release();
+    active.lease.release();
+    expect(admission.reservedBytes).toBe(0);
+    expect(admission.pendingBytes).toBe(0);
   });
 
   it("bounds a streaming body before JSON parsing and returns its lease", async () => {
@@ -93,6 +136,9 @@ describe("body memory admission", () => {
     expect(admitted.text).toBe('{"ok":true}');
     expect(Buffer.from(admitted.bytes).toString("utf8")).toBe('{"ok":true}');
     expect(admission.reservedBytes).toBeGreaterThan(0);
+    expect(admission.pendingBytes).toBe(admission.reservedBytes);
+    admitted.materialized();
+    expect(admission.pendingBytes).toBe(0);
     admitted.release();
     expect(admission.reservedBytes).toBe(0);
 

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -1,11 +1,31 @@
 import type { MiddlewareHandler } from "hono";
 import type { AppEnv } from "../app.js";
 
+export type RequestAdmissionCause =
+  | "wire_limit"
+  | "paused"
+  | "active_capacity"
+  | "live_heap"
+  | "materialized"
+  | "released";
+
+export interface RequestAdmissionSnapshot {
+  cause: RequestAdmissionCause;
+  wireBytes: number;
+  requestedChargeBytes: number;
+  activeReservedBytes: number;
+  activeCapacityBytes: number;
+  pendingBytes: number;
+  heapUsedBytes: number | null;
+  heapCeilingBytes: number | null;
+}
+
 export class RequestAdmissionError extends Error {
   constructor(
     readonly status: 413 | 503,
     readonly code: "request_too_large" | "server_overloaded",
     message: string,
+    readonly admission?: RequestAdmissionSnapshot,
   ) {
     super(message);
     this.name = "RequestAdmissionError";
@@ -22,6 +42,7 @@ export function createBodyMemoryAdmission(options: {
   heapUsedBytes?: () => number;
 }) {
   let reservedBytes = 0;
+  let pendingBytes = 0;
   let paused = false;
   const idleWaiters: Array<() => void> = [];
   const resolveIdle = () => {
@@ -36,55 +57,85 @@ export function createBodyMemoryAdmission(options: {
     0,
     (options.heapLimitBytes ?? Number.POSITIVE_INFINITY) - (options.protectedHeapBytes ?? 0),
   );
-  const exceedsLiveHeap = (nextReservedBytes: number): boolean => {
+  const readHeapUsedBytes = (): number | null => {
     const heapUsedBytes = options.heapUsedBytes?.();
-    return (
-      heapUsedBytes !== undefined &&
-      Number.isFinite(heapUsedBytes) &&
-      heapUsedBytes >= 0 &&
-      heapUsedBytes + nextReservedBytes > heapCeilingBytes
-    );
+    return heapUsedBytes !== undefined && Number.isFinite(heapUsedBytes) && heapUsedBytes >= 0
+      ? heapUsedBytes
+      : null;
   };
-  const rejection = (wireBytes: number) =>
-    wireBytes > options.maxWireBytes
-      ? { ok: false as const, reason: "too_large" as const }
-      : { ok: false as const, reason: "busy" as const };
+  const rejection = (
+    cause: RequestAdmissionCause,
+    wireBytes: number,
+    requestedChargeBytes: number,
+    heapUsedBytes = readHeapUsedBytes(),
+  ) => ({
+    ok: false as const,
+    reason: cause === "wire_limit" ? ("too_large" as const) : ("busy" as const),
+    cause,
+    admission: {
+      cause,
+      wireBytes,
+      requestedChargeBytes,
+      activeReservedBytes: reservedBytes,
+      activeCapacityBytes: options.activeRequestBytes,
+      pendingBytes,
+      heapUsedBytes,
+      heapCeilingBytes: Number.isFinite(heapCeilingBytes) ? heapCeilingBytes : null,
+    } satisfies RequestAdmissionSnapshot,
+  });
 
   return {
     maxWireBytes: options.maxWireBytes,
     acquire(wireBytes: number) {
-      if (paused) return { ok: false as const, reason: "busy" as const };
       let held = charge(wireBytes);
-      if (
-        wireBytes > options.maxWireBytes ||
-        reservedBytes + held > options.activeRequestBytes ||
-        exceedsLiveHeap(reservedBytes + held)
-      ) {
-        return rejection(wireBytes);
+      if (paused) return rejection("paused", wireBytes, held);
+      if (wireBytes > options.maxWireBytes) return rejection("wire_limit", wireBytes, held);
+      if (reservedBytes + held > options.activeRequestBytes) {
+        return rejection("active_capacity", wireBytes, held);
+      }
+      const heapUsedBytes = readHeapUsedBytes();
+      if (heapUsedBytes !== null && heapUsedBytes + pendingBytes + held > heapCeilingBytes) {
+        return rejection("live_heap", wireBytes, held, heapUsedBytes);
       }
       reservedBytes += held;
+      pendingBytes += held;
       let released = false;
+      let isMaterialized = false;
       return {
         ok: true as const,
         lease: {
           resize(nextWireBytes: number) {
-            if (released) return { ok: false as const, reason: "busy" as const };
+            if (released) return rejection("released", nextWireBytes, charge(nextWireBytes));
+            if (isMaterialized) {
+              return rejection("materialized", nextWireBytes, charge(nextWireBytes));
+            }
             const next = charge(nextWireBytes);
-            if (
-              nextWireBytes > options.maxWireBytes ||
-              reservedBytes - held + next > options.activeRequestBytes ||
-              exceedsLiveHeap(reservedBytes - held + next)
-            ) {
-              return rejection(nextWireBytes);
+            if (nextWireBytes > options.maxWireBytes) {
+              return rejection("wire_limit", nextWireBytes, next);
+            }
+            if (reservedBytes - held + next > options.activeRequestBytes) {
+              return rejection("active_capacity", nextWireBytes, next);
+            }
+            const nextPendingBytes = pendingBytes - held + next;
+            const heapUsedBytes = readHeapUsedBytes();
+            if (heapUsedBytes !== null && heapUsedBytes + nextPendingBytes > heapCeilingBytes) {
+              return rejection("live_heap", nextWireBytes, next, heapUsedBytes);
             }
             reservedBytes += next - held;
+            pendingBytes = nextPendingBytes;
             held = next;
             return { ok: true as const };
+          },
+          materialized() {
+            if (released || isMaterialized) return;
+            isMaterialized = true;
+            pendingBytes -= held;
           },
           release() {
             if (released) return;
             released = true;
             reservedBytes -= held;
+            if (!isMaterialized) pendingBytes -= held;
             resolveIdle();
           },
         },
@@ -102,6 +153,9 @@ export function createBodyMemoryAdmission(options: {
     },
     get reservedBytes() {
       return reservedBytes;
+    },
+    get pendingBytes() {
+      return pendingBytes;
     },
   };
 }
@@ -124,24 +178,30 @@ declare module "hono" {
   }
 }
 
-function admissionError(reason: "too_large" | "busy", maxWireBytes: number) {
+function admissionError(
+  reason: "too_large" | "busy",
+  maxWireBytes: number,
+  admission?: RequestAdmissionSnapshot,
+) {
   return reason === "too_large"
     ? new RequestAdmissionError(
         413,
         "request_too_large",
         `request body exceeds the runtime capacity limit of ${maxWireBytes} bytes`,
+        admission,
       )
     : new RequestAdmissionError(
         503,
         "server_overloaded",
         "request memory capacity is temporarily exhausted",
+        admission,
       );
 }
 
 export async function readAdmittedRequestBody(
   request: Request,
   admission: BodyMemoryAdmission,
-): Promise<{ text: string; bytes: Uint8Array; release: () => void }> {
+): Promise<{ text: string; bytes: Uint8Array; materialized: () => void; release: () => void }> {
   const declared = Number(request.headers.get("content-length"));
   const initialBytes =
     request.headers.has("transfer-encoding") || !Number.isFinite(declared) || declared < 0
@@ -150,7 +210,7 @@ export async function readAdmittedRequestBody(
   const acquired = admission.acquire(initialBytes);
   if (!acquired.ok) {
     await request.body?.cancel().catch(() => {});
-    throw admissionError(acquired.reason, admission.maxWireBytes);
+    throw admissionError(acquired.reason, admission.maxWireBytes, acquired.admission);
   }
   const { lease } = acquired;
   const chunks: Uint8Array[] = [];
@@ -165,17 +225,20 @@ export async function readAdmittedRequestBody(
         const resized = lease.resize(bytes);
         if (!resized.ok) {
           await reader.cancel().catch(() => {});
-          throw admissionError(resized.reason, admission.maxWireBytes);
+          throw admissionError(resized.reason, admission.maxWireBytes, resized.admission);
         }
         chunks.push(next.value);
       }
     }
     const resized = lease.resize(bytes);
-    if (!resized.ok) throw admissionError(resized.reason, admission.maxWireBytes);
+    if (!resized.ok) {
+      throw admissionError(resized.reason, admission.maxWireBytes, resized.admission);
+    }
     const body = Buffer.concat(chunks, bytes);
     return {
       text: body.toString("utf8"),
       bytes: body,
+      materialized: lease.materialized,
       release: lease.release,
     };
   } catch (error) {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-07-27 · 请求内存准入只计算未物化 headroom（Gateway runtime，docs/02/05/07/10，原则 3/7/8）
+
+- **根因**：实时 V8 高水位把 `heapUsed + active reservations` 相加，但长 Responses SSE/WebSocket 请求在 `JSON.parse` 后已进入 `heapUsed`，其 reservation 仍持有到流结束，导致同一请求被重复计账并高频误拒为 503。
+- **修复**：活动请求总额度继续由 `reservedBytes` 和 `activeRequestBytes` 限制；live heap 只叠加尚未完成正文读取、schema 校验与同步协议物化的 `pendingBytes`。lease 物化后仍占活动额度，但不再占 pending；重复物化/释放幂等，物化后禁止 resize。所有 HTTP JSON/multipart 入口与 Responses WebSocket 共用该语义。
+- **安全边界**：heap ceiling 仍全额扣除 response work、write queue、Session cache、response capture 与 5% GC 余量；未新增配置、队列、依赖或阈值放宽。413/503 客户端协议形状保持不变。
+- **可观测性**：`request.memory_rejected` 增加拒绝原因、wire/charge、active/pending 与 heap/ceiling 数值；不记录正文、header 或密钥。
+
 ## 2026-07-25 · 图片上游参数拒绝保持客户端 400（Gateway / Provider execution，docs/05/07，原则 3/5）
 
 - **根因**：OpenAI provider 已把 ZenMux 的真实 HTTP `400` 保存到 `UpstreamError.upstreamStatus`，但共享请求拒绝分类只识别 `invalid_request_error`、`413` 与超大图片提示，遗漏 ZenMux 的结构化 `invalid_params`，导致图片链继续按 provider 故障耗尽并返回 `all_providers_failed / 502`。
@@ -65,14 +72,9 @@
 
 - **恢复窗口**：Admin Session 恢复单次最多预占 response-work 池的一半，允许两次有界恢复并行，也为在线 API 响应保留容量；第三次并发恢复或超过半窗口的会话继续返回 `session_recovery_limited`。保留先准入、后物化正文的顺序，不新增队列、配置或独立内存池。
 
-## 2026-07-23 · Codex Responses 按运行时容量准入并让夜间 SQLite 维护收缩内存（Gateway / Session / Store，docs/02/05/07/10，原则 2/3/7/8）
-
-- **功能边界不降级**：按 operator 要求保留正文/Session 捕获、自动 cleanup/VACUUM 和不限 key 并发；不再用关闭正文、关闭维护或固定并发作为稳定手段。Node 启动时从 V8 heap limit 与 cgroup/process constrained memory 推导活动请求、response work、单条 wire message、写队列、Session head cache、SQLite page cache 与维护 cache；活动请求和 response work 各占动态可分配容量的 20%，部署值随机器容量自动缩放，不写死 MiB。
-- **请求、输出与 Session 热路径**：所有 JSON 入口在 `JSON.parse` 前按真实流式字节申请进程级预算，超出单请求容量返回结构化 413，暂时无余量返回 503；`maxPayload` 与上游 Codex connector 同样随运行时容量变化。客户端 WebSocket 另从 cgroup 或 `RSS + availableMemory` 扣除未来 heap 增长和 SQLite 预留，得到 native ingress 池；本条最初采用的连接生命周期最坏帧预留已由 2026-07-24 条目修正为活动消息真实字节计费，terminal 后 drain 的实现也已由 2026-07-25 条目修正为立即停止并取消内部流。WS 每连接只保留一个正在执行的 `response.create`；所有上游 Codex WS 会话共用 response-work 池，每条消息从入队、等待、`JSON.parse` 到 frame 被消费全程持有 lease。四种 SSE 出口共用有界正文捕获器，容量耗尽只省略该响应 payload、记录 `payload.capture_limited` 并继续转发与保存 telemetry。Session 热写不再重建完整历史；Admin Session 恢复由 SQLite/Postgres 先查行字节元数据、再按 sequence 分页物化，并占用共享 recovery window。Store 的 64 MiB/10,000 revision 仍是跨实例一致的持久数据完整性上限，不是运行时内存值。
-- **夜间维护**：自动 cleanup、自动 VACUUM 与 Admin 手工维护复用同一 Promise 串行链；VACUUM 前进程级 gate 暂停新工作并依次等待 HTTP/body、Memory/Signal producer、OAuth/MCP/Admin cache 后台任务与正文写队列静止，结束或失败都逆序恢复。维护期间除 `/healthz`、`/version` 外的新请求统一返回带 `Retry-After` 的 503，并按 OpenAI、Anthropic、Gemini 或普通 Admin 路径输出对应错误形状；维护 drain 上限为 `min(request_timeout_ms, 120s)`。自动任务每 10 分钟检查一次，只有整段成功才记录当日完成。SQLite 仅在 freelist 至少占总页数 5% 时执行全库重写；worker 启动前要求 `availableMemory()` 至少为动态 process limit 的 25%，并按数据库与 WAL 实际大小检查磁盘。worker 使用独立连接、`temp_store=FILE` 与机器推导的低维护 cache；Compose 默认给 shutdown 30 分钟 grace。未引入守护进程、Redis、消息队列或新依赖。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-23 · Codex Responses 按运行时容量准入并让夜间 SQLite 维护收缩内存（Gateway / Session / Store，docs/02/05/07/10，原则 2/3/7/8）**：机器推导的共享请求/响应/缓存预算、活动消息准入和维护 drain 保留正文捕获与自动维护能力；后续物化重复计账、WebSocket ingress 与 terminal 生命周期修正见顶部更新条目，完整原文通过 git history 回溯。
 - **2026-07-23 · SQLite Session 与 Memory 正文使用兼容 gzip 存储（Store / Memory，docs/07/08，原则 1/3/7）**：SQLite 以 value type + gzip magic 兼容压缩 Session/Memory 正文，不回写历史数据、不在线 VACUUM，完整原文通过 git history 回溯。
 - **2026-07-22 · 全项目文案审查补齐多语言维护闭环（Admin / Portal / Setup，docs/11/12，原则 1/2）**：以 Opus 只读审查和七语言结构测试补齐 Admin、Portal、Setup 文案维护闭环，完整原文通过 git history 回溯。
 - **2026-07-22 · Session 恢复补齐响应快照并限制默认留存范围（Telemetry / Admin requests，docs/07/11，原则 1/3/7/8）**：复用 `session_revisions.response_json` 不新增迁移，四种协议的成功非流式请求保存客户端形态响应快照，流式不新增 SSE 缓冲；单快照 16 MiB、Session 64 MiB 上限，来源恒为 `exact=false` 故 Retry 禁用，完整原文通过 git history 回溯。


### PR DESCRIPTION
## What changed

- split active request capacity from pre-materialization heap headroom
- keep active reservations until request or stream completion while removing materialized bodies from pending heap accounting
- add structured admission diagnostics without payload, header, or credential data
- cover HTTP Responses, Responses WebSocket, and every shared body-admission route

## Root cause

The live-heap guard added V8 heapUsed to all active request reservations. Long Responses requests were already materialized into the V8 heap after parsing but retained their reservation until stream completion, so the same memory was counted twice and safe requests were rejected with server_overloaded 503.

## Impact

The fix removes the false 503s while preserving the existing active-request capacity limit, protected heap budget, response-work budget, GC headroom, 413 behavior, and stream-lifetime reservations.

## Validation

- 10 focused Vitest files: 315 tests passed
- CI=true pnpm typecheck
- CI=true pnpm build
- targeted Biome check
- git diff --check
- independent safety review: no blocker
- focused Playwright Responses boundary: 2 tests passed