### PR TITLE
fix(gateway): disable request body memory admission rejections

### DIFF
--- a/apps/gateway/src/app.test.ts
+++ b/apps/gateway/src/app.test.ts
@@ -138,35 +138,33 @@ describe("createApp: trace_id, logging, error handling", () => {
     });
   });
 
-  it("logs the request-memory rejection predicate without request payload data", async () => {
+  it("logs the hard body rejection without stale capacity fields or request payload data", async () => {
     const { logger, lines } = fakeLogger();
     const c = mockCtx(logger, "trace-memory");
     const res = handleError(
-      new RequestAdmissionError(503, "server_overloaded", "memory busy", {
-        cause: "live_heap",
+      new RequestAdmissionError(413, "request_too_large", "body too large", {
+        cause: "wire_limit",
         wireBytes: 12,
         requestedChargeBytes: 72,
+        maxWireBytes: 10,
         activeReservedBytes: 144,
-        activeCapacityBytes: 256,
         pendingBytes: 24,
-        heapUsedBytes: 300,
-        heapCeilingBytes: 350,
       }),
       c,
     );
 
-    expect(res.status).toBe(503);
-    expect(lines.find((line) => line.message === "request.memory_rejected")?.fields).toMatchObject({
+    expect(res.status).toBe(413);
+    expect(lines.find((line) => line.message === "request.body_rejected")?.fields).toMatchObject({
       trace_id: "trace-memory",
-      admission_reason: "live_heap",
+      admission_reason: "wire_limit",
       wire_bytes: 12,
       requested_charge_bytes: 72,
+      max_wire_bytes: 10,
       active_reserved_bytes: 144,
-      active_capacity_bytes: 256,
       pending_bytes: 24,
-      heap_used_bytes: 300,
-      heap_ceiling_bytes: 350,
     });
+    expect(JSON.stringify(lines)).not.toContain("active_capacity_bytes");
+    expect(JSON.stringify(lines)).not.toContain("heap_used_bytes");
     expect(JSON.stringify(lines)).not.toContain("payload");
   });
 

--- a/apps/gateway/src/middleware/error-handler.ts
+++ b/apps/gateway/src/middleware/error-handler.ts
@@ -65,23 +65,25 @@ export function handleError(err: unknown, c: Context<AppEnv>): Response {
 
   if (err instanceof RequestAdmissionError) {
     if (err.status === 503) c.header("retry-after", "1");
-    logger.log("warn", "request.memory_rejected", {
-      trace_id: traceId,
-      http_status: err.status,
-      code: err.code,
-      ...(err.admission === undefined
-        ? {}
-        : {
-            admission_reason: err.admission.cause,
-            wire_bytes: err.admission.wireBytes,
-            requested_charge_bytes: err.admission.requestedChargeBytes,
-            active_reserved_bytes: err.admission.activeReservedBytes,
-            active_capacity_bytes: err.admission.activeCapacityBytes,
-            pending_bytes: err.admission.pendingBytes,
-            heap_used_bytes: err.admission.heapUsedBytes,
-            heap_ceiling_bytes: err.admission.heapCeilingBytes,
-          }),
-    });
+    logger.log(
+      "warn",
+      err.admission?.cause === "paused" ? "request.maintenance_rejected" : "request.body_rejected",
+      {
+        trace_id: traceId,
+        http_status: err.status,
+        code: err.code,
+        ...(err.admission === undefined
+          ? {}
+          : {
+              admission_reason: err.admission.cause,
+              wire_bytes: err.admission.wireBytes,
+              requested_charge_bytes: err.admission.requestedChargeBytes,
+              max_wire_bytes: err.admission.maxWireBytes,
+              active_reserved_bytes: err.admission.activeReservedBytes,
+              pending_bytes: err.admission.pendingBytes,
+            }),
+      },
+    );
     return c.json(
       {
         error: {

--- a/apps/gateway/src/realtime-websocket.test.ts
+++ b/apps/gateway/src/realtime-websocket.test.ts
@@ -9,6 +9,7 @@ import {
   isRealtimeWebSocketPath,
   type RealtimeWebSocketBridge,
 } from "./realtime-websocket.js";
+import { createBodyMemoryAdmission } from "./runtime/memory-admission.js";
 
 const closers: Array<() => Promise<void>> = [];
 
@@ -101,6 +102,46 @@ describe("Realtime websocket bridge", () => {
       { statusCode: number },
     ];
     expect(response.statusCode).toBe(404);
+  });
+
+  it("closes an oversized client frame with 1009 before relaying it", async () => {
+    const upstreamHttp = await listeningServer();
+    const upstream = new WebSocketServer({ server: upstreamHttp.server, perMessageDeflate: false });
+    upstream.on("connection", (socket) => socket.on("message", (data) => socket.send(data)));
+    closers.push(
+      () =>
+        new Promise<void>((resolve) => {
+          for (const socket of upstream.clients) socket.terminate();
+          upstream.close(() => resolve());
+        }),
+    );
+
+    const gateway = await listeningServer();
+    const registry = createRealtimeCallRegistry();
+    registry.put("rtc_1", "key-1", {
+      url: `ws://127.0.0.1:${upstreamHttp.port}/v1/realtime?call_id=rtc_1`,
+      headers: async () => ({}),
+    });
+    const bridge = installRealtimeWebSocketBridge({
+      server: gateway.server,
+      registry,
+      resolveKey: async () => "key-1",
+      memoryAdmission: createBodyMemoryAdmission({
+        activeRequestBytes: 100,
+        maxWireBytes: 4,
+        jsonAmplification: 1,
+      }),
+    });
+    closers.push(() => bridge.close());
+
+    const client = new WebSocket(`ws://127.0.0.1:${gateway.port}/v1/realtime?call_id=rtc_1`, {
+      headers: { Authorization: "Bearer helm-key" },
+    });
+    await once(client, "open");
+    const closed = once(client, "close");
+    client.send("12345");
+    const [code] = (await closed) as [number];
+    expect(code).toBe(1009);
   });
 
   it("refreshes OAuth once when the upstream sideband rejects with 401", async () => {

--- a/apps/gateway/src/realtime-websocket.ts
+++ b/apps/gateway/src/realtime-websocket.ts
@@ -178,8 +178,12 @@ export function installRealtimeWebSocketBridge(
       else if (upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
     };
     const relay = (destination: WebSocket, data: WebSocket.RawData, isBinary: boolean) => {
-      // Unlimited admission: track lease for bookkeeping only, never reject frames.
+      // Capacity/wire unlimited; only maintenance pause rejects new frames.
       const acquired = admission.acquire(rawBytes(data));
+      if (!acquired.ok) {
+        closeBoth(1013, "realtime frame capacity exceeded");
+        return;
+      }
       if (destination.readyState !== WebSocket.OPEN) {
         acquired.lease.release();
         closeBoth(1011, "realtime peer closed");

--- a/apps/gateway/src/realtime-websocket.ts
+++ b/apps/gateway/src/realtime-websocket.ts
@@ -178,14 +178,8 @@ export function installRealtimeWebSocketBridge(
       else if (upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
     };
     const relay = (destination: WebSocket, data: WebSocket.RawData, isBinary: boolean) => {
+      // Unlimited admission: track lease for bookkeeping only, never reject frames.
       const acquired = admission.acquire(rawBytes(data));
-      if (!acquired.ok) {
-        closeBoth(
-          acquired.reason === "too_large" ? 1009 : 1013,
-          "realtime frame capacity exceeded",
-        );
-        return;
-      }
       if (destination.readyState !== WebSocket.OPEN) {
         acquired.lease.release();
         closeBoth(1011, "realtime peer closed");

--- a/apps/gateway/src/realtime-websocket.ts
+++ b/apps/gateway/src/realtime-websocket.ts
@@ -178,10 +178,15 @@ export function installRealtimeWebSocketBridge(
       else if (upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
     };
     const relay = (destination: WebSocket, data: WebSocket.RawData, isBinary: boolean) => {
-      // Capacity/wire unlimited; only maintenance pause rejects new frames.
+      // Aggregate capacity is unlimited; hard wire and maintenance pause remain.
       const acquired = admission.acquire(rawBytes(data));
       if (!acquired.ok) {
-        closeBoth(1013, "realtime frame capacity exceeded");
+        closeBoth(
+          acquired.reason === "too_large" ? 1009 : 1013,
+          acquired.reason === "too_large"
+            ? "realtime frame too large"
+            : "database maintenance in progress",
+        );
         return;
       }
       if (destination.readyState !== WebSocket.OPEN) {

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -190,32 +190,56 @@ describe("Responses websocket bridge", () => {
     expect(ingressAdmission.reservedBytes).toBe(0);
   });
 
-  it("does not close oversized websocket frames for historical machine wire limits", async () => {
+  it("keeps the shared hard wire limit before parsing a websocket message", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
       jsonAmplification: 6,
     });
-    let fetched = false;
     const baseUrl = await startBridge(
       () => {
-        fetched = true;
-        return new Response(
-          'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
-          { headers: { "content-type": "text/event-stream" } },
-        );
+        throw new Error("fetch should not run");
       },
       undefined,
       { memoryAdmission },
     );
     const socket = await connect(`${baseUrl}/v1/responses`);
-    const turn = collectTurn(socket, {
-      type: "response.create",
-      input: "too large for the old 10-byte wire limit",
-      stream: true,
+    const closed = once(socket, "close");
+    socket.send(JSON.stringify({ type: "response.create", input: "too large" }));
+    const [code] = await closed;
+
+    expect(code).toBe(1009);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+  });
+
+  it("reports maintenance pause honestly on an established websocket", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 1_000,
+      jsonAmplification: 6,
     });
-    await turn;
-    expect(fetched).toBe(true);
+    const baseUrl = await startBridge(
+      () => {
+        throw new Error("fetch should not run while admission is paused");
+      },
+      undefined,
+      { memoryAdmission },
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    memoryAdmission.pause();
+
+    await expect(
+      collectTurn(socket, { type: "response.create", input: "maintenance", stream: true }),
+    ).resolves.toMatchObject([
+      {
+        type: "error",
+        status: 503,
+        error: {
+          code: "database_maintenance",
+          message: "database maintenance in progress",
+        },
+      },
+    ]);
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -146,7 +146,7 @@ describe("Responses websocket bridge", () => {
     expect(ingressAdmission.reservedBytes).toBe(0);
   });
 
-  it("limits materialized websocket messages instead of idle connections", async () => {
+  it("admits concurrent materialized websocket messages without capacity 503", async () => {
     const ingressAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 200,
       maxWireBytes: 100,
@@ -173,19 +173,12 @@ describe("Responses websocket bridge", () => {
 
     const firstTurn = collectTurn(first, request);
     const secondTurn = collectTurn(second, request);
-    for (let attempt = 0; attempt < 20 && pendingResponses.length < 2; attempt += 1) {
+    const thirdTurn = collectTurn(third, request);
+    for (let attempt = 0; attempt < 40 && pendingResponses.length < 3; attempt += 1) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
-    expect(pendingResponses).toHaveLength(2);
-    expect(ingressAdmission.reservedBytes).toBe(200);
-
-    await expect(collectTurn(third, request)).resolves.toMatchObject([
-      {
-        type: "error",
-        status: 503,
-        error: { code: "server_overloaded" },
-      },
-    ]);
+    expect(pendingResponses).toHaveLength(3);
+    expect(ingressAdmission.reservedBytes).toBe(300);
 
     const completed = () =>
       new Response(
@@ -193,29 +186,36 @@ describe("Responses websocket bridge", () => {
         { headers: { "content-type": "text/event-stream" } },
       );
     for (const resolve of pendingResponses) resolve(completed());
-    await Promise.all([firstTurn, secondTurn]);
+    await Promise.all([firstTurn, secondTurn, thirdTurn]);
     expect(ingressAdmission.reservedBytes).toBe(0);
   });
 
-  it("uses the shared machine-derived limit before parsing a websocket message", async () => {
+  it("does not close oversized websocket frames for historical machine wire limits", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
       jsonAmplification: 6,
     });
+    let fetched = false;
     const baseUrl = await startBridge(
       () => {
-        throw new Error("fetch should not run");
+        fetched = true;
+        return new Response(
+          'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
       },
       undefined,
       { memoryAdmission },
     );
     const socket = await connect(`${baseUrl}/v1/responses`);
-    const closed = once(socket, "close");
-    socket.send(JSON.stringify({ type: "response.create", input: "too large" }));
-    const [code] = await closed;
-
-    expect(code).toBe(1009);
+    const turn = collectTurn(socket, {
+      type: "response.create",
+      input: "too large for the old 10-byte wire limit",
+      stream: true,
+    });
+    await turn;
+    expect(fetched).toBe(true);
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -502,10 +502,31 @@ export function installResponsesWebSocketBridge({
       const bytes = Array.isArray(data)
         ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
         : data.byteLength;
-      // Memory admission is unlimited: acquire always succeeds and only tracks
-      // leases for maintenance waitForIdle / release bookkeeping.
+      // Capacity/wire limits are unlimited. Acquire only fails during maintenance
+      // pause so vacuum's waitForIdle can drain in-flight leases.
       const ingressAcquired = ingress.acquire(bytes);
+      if (!ingressAcquired.ok) {
+        const error = new RequestAdmissionError(
+          503,
+          "server_overloaded",
+          "websocket ingress memory capacity is temporarily exhausted",
+          ingressAcquired.admission,
+        );
+        void sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
+        return;
+      }
       const acquired = admission.acquire(bytes);
+      if (!acquired.ok) {
+        ingressAcquired.lease.release();
+        const error = new RequestAdmissionError(
+          503,
+          "server_overloaded",
+          "request memory capacity is temporarily exhausted",
+          acquired.admission,
+        );
+        void sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
+        return;
+      }
       processing = true;
       const turnController = new AbortController();
       activeTurnController = turnController;

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -502,49 +502,10 @@ export function installResponsesWebSocketBridge({
       const bytes = Array.isArray(data)
         ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
         : data.byteLength;
+      // Memory admission is unlimited: acquire always succeeds and only tracks
+      // leases for maintenance waitForIdle / release bookkeeping.
       const ingressAcquired = ingress.acquire(bytes);
-      if (!ingressAcquired.ok) {
-        const error =
-          ingressAcquired.reason === "too_large"
-            ? new RequestAdmissionError(
-                413,
-                "request_too_large",
-                `websocket message exceeds the runtime capacity limit of ${ingress.maxWireBytes} bytes`,
-              )
-            : new RequestAdmissionError(
-                503,
-                "server_overloaded",
-                "websocket ingress memory capacity is temporarily exhausted",
-              );
-        void sendEnvelope(socket, localErrorEnvelope(error))
-          .catch(() => {})
-          .finally(() => {
-            if (error.status === 413) socket.close(1009, "message too big");
-          });
-        return;
-      }
       const acquired = admission.acquire(bytes);
-      if (!acquired.ok) {
-        ingressAcquired.lease.release();
-        const error =
-          acquired.reason === "too_large"
-            ? new RequestAdmissionError(
-                413,
-                "request_too_large",
-                `websocket message exceeds the runtime capacity limit of ${admission.maxWireBytes} bytes`,
-              )
-            : new RequestAdmissionError(
-                503,
-                "server_overloaded",
-                "request memory capacity is temporarily exhausted",
-              );
-        void sendEnvelope(socket, localErrorEnvelope(error))
-          .catch(() => {})
-          .finally(() => {
-            if (error.status === 413) socket.close(1009, "message too big");
-          });
-        return;
-      }
       processing = true;
       const turnController = new AbortController();
       activeTurnController = turnController;
@@ -585,27 +546,7 @@ export function installResponsesWebSocketBridge({
 
   const onUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
     if (!isResponsesWebSocketPath(request.url)) return;
-    const ingressLease = ingress.acquire(0);
-    if (!ingressLease.ok) {
-      const error = new RequestAdmissionError(
-        503,
-        "server_overloaded",
-        "websocket ingress memory capacity is temporarily exhausted",
-      );
-      const onRejectedSocketError = () => socket.destroy();
-      socket.once("error", onRejectedSocketError);
-      void rejectUpgrade(
-        socket,
-        new Response(JSON.stringify(localErrorEnvelope(error)), {
-          status: error.status,
-          headers: { "content-type": "application/json", "retry-after": "1" },
-        }),
-      )
-        .catch(() => socket.destroy())
-        .finally(() => socket.off("error", onRejectedSocketError));
-      return;
-    }
-    ingressLease.lease.release();
+    // Unlimited admission: no upgrade-time capacity probe / rejection.
     const onPreflightSocketError = () => {
       socket.destroy();
     };

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -9,6 +9,7 @@ import {
   type BodyMemoryAdmission,
   createBodyMemoryAdmission,
   RequestAdmissionError,
+  requestAdmissionError,
 } from "./runtime/memory-admission.js";
 
 const RESPONSES_WEBSOCKET_PATHS = new Set(["/v1/responses", "/responses", "/openai/v1/responses"]);
@@ -451,7 +452,6 @@ export function installResponsesWebSocketBridge({
       activeRequestBytes: memoryBudget.websocketIngressBytes,
       maxWireBytes: Math.min(admission.maxWireBytes, memoryBudget.websocketMaxPayloadBytes),
       jsonAmplification: 1,
-      // Keep zero-headroom upgrades fail-closed without charging idle sockets for a full frame.
       minRequestChargeBytes: 1,
     });
   const websocketMaxPayloadBytes = Math.max(
@@ -502,29 +502,37 @@ export function installResponsesWebSocketBridge({
       const bytes = Array.isArray(data)
         ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
         : data.byteLength;
-      // Capacity/wire limits are unlimited. Acquire only fails during maintenance
-      // pause so vacuum's waitForIdle can drain in-flight leases.
+      // Aggregate capacity/live-heap checks are disabled. Deterministic wire and
+      // maintenance-pause boundaries remain.
       const ingressAcquired = ingress.acquire(bytes);
       if (!ingressAcquired.ok) {
-        const error = new RequestAdmissionError(
-          503,
-          "server_overloaded",
-          "websocket ingress memory capacity is temporarily exhausted",
+        const error = requestAdmissionError(
+          ingressAcquired.cause,
+          ingress.maxWireBytes,
           ingressAcquired.admission,
+          "websocket message",
         );
-        void sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
+        void sendEnvelope(socket, localErrorEnvelope(error))
+          .catch(() => {})
+          .finally(() => {
+            if (error.status === 413) socket.close(1009, "message too big");
+          });
         return;
       }
       const acquired = admission.acquire(bytes);
       if (!acquired.ok) {
         ingressAcquired.lease.release();
-        const error = new RequestAdmissionError(
-          503,
-          "server_overloaded",
-          "request memory capacity is temporarily exhausted",
+        const error = requestAdmissionError(
+          acquired.cause,
+          admission.maxWireBytes,
           acquired.admission,
+          "websocket message",
         );
-        void sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
+        void sendEnvelope(socket, localErrorEnvelope(error))
+          .catch(() => {})
+          .finally(() => {
+            if (error.status === 413) socket.close(1009, "message too big");
+          });
         return;
       }
       processing = true;

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -185,13 +185,15 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
       body: JSON.stringify(NONSTREAM_BODY),
     });
 
+    // Admission must reach the pipeline (execute), not fail closed with 413/503.
+    // This harness may still surface provider/pipeline 5xx after execute.
     expect(res.status).not.toBe(413);
     expect(res.status).not.toBe(503);
     expect(harness.execute).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("does not return 503 when the historical shared body budget is exhausted", async () => {
+  it("does not return capacity 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1024,
@@ -206,6 +208,7 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
       body: JSON.stringify(NONSTREAM_BODY),
     });
 
+    expect(res.status).not.toBe(413);
     expect(res.status).not.toBe(503);
     expect(harness.execute).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -170,7 +170,7 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
     "/chat/completions",
     "/engines/azure-deployment/chat/completions",
     "/openai/deployments/azure-deployment/chat/completions",
-  ])("rejects an oversized body before JSON.parse on %s", async (path) => {
+  ])("admits bodies even when historical maxWireBytes would have rejected on %s", async (path) => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
       maxWireBytes: 1,
@@ -185,12 +185,13 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
       body: JSON.stringify(NONSTREAM_BODY),
     });
 
-    expect(res.status).toBe(413);
-    expect(harness.execute).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(503);
+    expect(harness.execute).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("returns 503 with Retry-After when the shared body budget is occupied", async () => {
+  it("does not return 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1024,
@@ -205,9 +206,9 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
       body: JSON.stringify(NONSTREAM_BODY),
     });
 
-    expect(res.status).toBe(503);
-    expect(res.headers.get("retry-after")).toBe("1");
-    expect(harness.execute).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(503);
+    expect(harness.execute).toHaveBeenCalled();
+    expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("rejects an over-budget request with 429 before routing (behavior=reject)", async () => {

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -170,7 +170,7 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
     "/chat/completions",
     "/engines/azure-deployment/chat/completions",
     "/openai/deployments/azure-deployment/chat/completions",
-  ])("admits bodies even when historical maxWireBytes would have rejected on %s", async (path) => {
+  ])("keeps the hard body limit on %s", async (path) => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
       maxWireBytes: 1,
@@ -185,11 +185,8 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
       body: JSON.stringify(NONSTREAM_BODY),
     });
 
-    // Admission must reach the pipeline (execute), not fail closed with 413/503.
-    // This harness may still surface provider/pipeline 5xx after execute.
-    expect(res.status).not.toBe(413);
-    expect(res.status).not.toBe(503);
-    expect(harness.execute).toHaveBeenCalled();
+    expect(res.status).toBe(413);
+    expect(harness.execute).not.toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -178,7 +178,7 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     "generateContent",
     "streamGenerateContent",
     "countTokens",
-  ])("admits %s bodies even when historical maxWireBytes is tiny", async (operation) => {
+  ])("keeps the hard body limit for %s", async (operation) => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
       maxWireBytes: 1,
@@ -193,18 +193,9 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).toBe(200);
-    expect(harness.order[0]).toBe("auth:helm_live_secret");
-    if (operation === "countTokens") {
-      // countTokens path does not always route through the full pipeline.
-      expect(harness.order.length).toBeGreaterThanOrEqual(1);
-    } else {
-      expect(harness.order).toContain("route");
-    }
-    // Streaming responses may still hold a lease until the body is drained.
-    if (operation !== "streamGenerateContent") {
-      expect(memoryAdmission.reservedBytes).toBe(0);
-    }
+    expect(res.status).toBe(413);
+    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+    expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("does not return capacity 503 when the historical shared body budget is exhausted", async () => {

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -193,16 +193,21 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).not.toBe(413);
-    expect(res.status).not.toBe(503);
+    expect(res.status).toBe(200);
     expect(harness.order[0]).toBe("auth:helm_live_secret");
+    if (operation === "countTokens") {
+      // countTokens path does not always route through the full pipeline.
+      expect(harness.order.length).toBeGreaterThanOrEqual(1);
+    } else {
+      expect(harness.order).toContain("route");
+    }
     // Streaming responses may still hold a lease until the body is drained.
     if (operation !== "streamGenerateContent") {
       expect(memoryAdmission.reservedBytes).toBe(0);
     }
   });
 
-  it("does not return 503 when the historical shared body budget is exhausted", async () => {
+  it("does not return capacity 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1024,
@@ -217,8 +222,10 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).not.toBe(503);
-    expect(harness.order[0]).toBe("auth:helm_live_secret");
+    expect(res.status).toBe(200);
+    expect(harness.order).toEqual(
+      expect.arrayContaining(["auth:helm_live_secret", "translate-out", "route"]),
+    );
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -178,7 +178,7 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     "generateContent",
     "streamGenerateContent",
     "countTokens",
-  ])("rejects oversized %s bodies before JSON.parse", async (operation) => {
+  ])("admits %s bodies even when historical maxWireBytes is tiny", async (operation) => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
       maxWireBytes: 1,
@@ -193,12 +193,16 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).toBe(413);
-    expect(harness.order).toEqual(["auth:helm_live_secret"]);
-    expect(memoryAdmission.reservedBytes).toBe(0);
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(503);
+    expect(harness.order[0]).toBe("auth:helm_live_secret");
+    // Streaming responses may still hold a lease until the body is drained.
+    if (operation !== "streamGenerateContent") {
+      expect(memoryAdmission.reservedBytes).toBe(0);
+    }
   });
 
-  it("returns 503 with Retry-After when the shared body budget is occupied", async () => {
+  it("does not return 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1024,
@@ -213,9 +217,9 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).toBe(503);
-    expect(res.headers.get("retry-after")).toBe("1");
-    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+    expect(res.status).not.toBe(503);
+    expect(harness.order[0]).toBe("auth:helm_live_secret");
+    expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("non-stream: auth → translate-out → route → translate-back, returns Gemini JSON", async () => {

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -191,7 +191,7 @@ describe("registerImagesRoute", () => {
     expect(res.status).toBe(401);
   });
 
-  it("rejects an over-capacity body before JSON parsing and releases its lease", async () => {
+  it("admits bodies even when historical maxWireBytes would have rejected", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -201,15 +201,13 @@ describe("registerImagesRoute", () => {
 
     const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
 
-    expect(res.status).toBe(413);
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { type: "invalid_request_error", code: "request_too_large" },
-    });
-    expect(imageGeneration).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(503);
+    expect(imageGeneration).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("returns an OpenAI 503 with Retry-After when runtime request capacity is busy", async () => {
+  it("does not return OpenAI 503 when historical request capacity is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1000,
@@ -219,12 +217,8 @@ describe("registerImagesRoute", () => {
 
     const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
 
-    expect(res.status).toBe(503);
-    expect(res.headers.get("retry-after")).toBe("1");
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { type: "server_error", code: "server_overloaded" },
-    });
-    expect(imageGeneration).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(503);
+    expect(imageGeneration).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -201,13 +201,12 @@ describe("registerImagesRoute", () => {
 
     const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
 
-    expect(res.status).not.toBe(413);
-    expect(res.status).not.toBe(503);
+    expect(res.status).toBe(200);
     expect(imageGeneration).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("does not return OpenAI 503 when historical request capacity is exhausted", async () => {
+  it("does not return OpenAI capacity 503 when historical request capacity is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1000,
@@ -217,7 +216,7 @@ describe("registerImagesRoute", () => {
 
     const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
 
-    expect(res.status).not.toBe(503);
+    expect(res.status).toBe(200);
     expect(imageGeneration).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -191,7 +191,7 @@ describe("registerImagesRoute", () => {
     expect(res.status).toBe(401);
   });
 
-  it("admits bodies even when historical maxWireBytes would have rejected", async () => {
+  it("keeps the hard body limit before JSON parsing", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -201,8 +201,11 @@ describe("registerImagesRoute", () => {
 
     const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
 
-    expect(res.status).toBe(200);
-    expect(imageGeneration).toHaveBeenCalled();
+    expect(res.status).toBe(413);
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { type: "invalid_request_error", code: "request_too_large" },
+    });
+    expect(imageGeneration).not.toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -196,13 +196,12 @@ describe("registerInteractionsRoute", () => {
 
     const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
 
-    expect(res.status).not.toBe(413);
-    expect(res.status).not.toBe(503);
+    expect(res.status).toBe(200);
     expect(nativePassthrough).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("does not return Gemini 503 when historical request capacity is exhausted", async () => {
+  it("does not return Gemini capacity 503 when historical request capacity is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1000,
@@ -212,7 +211,7 @@ describe("registerInteractionsRoute", () => {
 
     const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
 
-    expect(res.status).not.toBe(503);
+    expect(res.status).toBe(200);
     expect(nativePassthrough).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -186,7 +186,7 @@ describe("registerInteractionsRoute", () => {
     expect(json.id).not.toBe("int_client-controlled-trace");
   });
 
-  it("admits bodies even when historical maxWireBytes would have rejected", async () => {
+  it("keeps the hard body limit before JSON parsing", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -196,8 +196,11 @@ describe("registerInteractionsRoute", () => {
 
     const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
 
-    expect(res.status).toBe(200);
-    expect(nativePassthrough).toHaveBeenCalled();
+    expect(res.status).toBe(413);
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { status: "INVALID_ARGUMENT" },
+    });
+    expect(nativePassthrough).not.toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -186,7 +186,7 @@ describe("registerInteractionsRoute", () => {
     expect(json.id).not.toBe("int_client-controlled-trace");
   });
 
-  it("rejects an over-capacity body before JSON parsing and releases its lease", async () => {
+  it("admits bodies even when historical maxWireBytes would have rejected", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -196,15 +196,13 @@ describe("registerInteractionsRoute", () => {
 
     const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
 
-    expect(res.status).toBe(413);
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { status: "INVALID_ARGUMENT" },
-    });
-    expect(nativePassthrough).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(503);
+    expect(nativePassthrough).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("returns a Gemini 503 with Retry-After when runtime request capacity is busy", async () => {
+  it("does not return Gemini 503 when historical request capacity is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1000,
@@ -214,12 +212,8 @@ describe("registerInteractionsRoute", () => {
 
     const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
 
-    expect(res.status).toBe(503);
-    expect(res.headers.get("retry-after")).toBe("1");
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { status: "UNAVAILABLE" },
-    });
-    expect(nativePassthrough).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(503);
+    expect(nativePassthrough).toHaveBeenCalled();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -245,7 +245,7 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/messages (Anthropic inbound)", () => {
-  it("rejects oversized message and count-token bodies before JSON.parse", async () => {
+  it("admits message and count-token bodies even when historical maxWireBytes is tiny", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
       maxWireBytes: 1,
@@ -260,13 +260,14 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
         headers: AUTH,
         body: JSON.stringify(REQ_BODY),
       });
-      expect(res.status).toBe(413);
+      expect(res.status).not.toBe(413);
+      expect(res.status).not.toBe(503);
     }
-    expect(harness.order).toEqual(["auth", "auth"]);
+    expect(harness.order[0]).toBe("auth");
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("returns 503 with Retry-After when the shared body budget is occupied", async () => {
+  it("does not return 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1024,
@@ -281,9 +282,9 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).toBe(503);
-    expect(res.headers.get("retry-after")).toBe("1");
-    expect(harness.order).toEqual(["auth"]);
+    expect(res.status).not.toBe(503);
+    expect(harness.order[0]).toBe("auth");
+    expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("accepts the Claude Code event logging compatibility endpoint after auth", async () => {

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -245,7 +245,7 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/messages (Anthropic inbound)", () => {
-  it("admits message and count-token bodies even when historical maxWireBytes is tiny", async () => {
+  it("keeps the hard body limit for message and count-token requests", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
       maxWireBytes: 1,
@@ -260,9 +260,9 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
         headers: AUTH,
         body: JSON.stringify(REQ_BODY),
       });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(413);
     }
-    expect(harness.order).toContain("route");
+    expect(harness.order).toEqual(["auth", "auth"]);
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -260,14 +260,13 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
         headers: AUTH,
         body: JSON.stringify(REQ_BODY),
       });
-      expect(res.status).not.toBe(413);
-      expect(res.status).not.toBe(503);
+      expect(res.status).toBe(200);
     }
-    expect(harness.order[0]).toBe("auth");
+    expect(harness.order).toContain("route");
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("does not return 503 when the historical shared body budget is exhausted", async () => {
+  it("does not return capacity 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1024,
@@ -282,8 +281,8 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).not.toBe(503);
-    expect(harness.order[0]).toBe("auth");
+    expect(res.status).toBe(200);
+    expect(harness.order).toEqual(expect.arrayContaining(["auth", "translate-out", "route"]));
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -241,7 +241,7 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/responses (OpenAI Responses inbound)", () => {
-  it("rejects a body beyond the machine-derived admission limit before translation", async () => {
+  it("admits bodies beyond the historical machine-derived wire limit", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -255,11 +255,9 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       body: JSON.stringify(REQ),
     });
 
-    expect(res.status).toBe(413);
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { type: "invalid_request_error", code: "request_too_large" },
-    });
-    expect(order).toEqual(["auth"]);
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(503);
+    expect(order[0]).toBe("auth");
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -241,7 +241,7 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/responses (OpenAI Responses inbound)", () => {
-  it("admits bodies beyond the historical machine-derived wire limit", async () => {
+  it("keeps the hard body limit before translation", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -255,21 +255,21 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       body: JSON.stringify(REQ),
     });
 
-    expect(res.status).toBe(200);
-    expect(order).toEqual(expect.arrayContaining(["auth", "translate-out", "route"]));
+    expect(res.status).toBe(413);
+    expect((await res.json()) as unknown).toMatchObject({
+      error: { type: "invalid_request_error", code: "request_too_large" },
+    });
+    expect(order).toEqual(["auth"]);
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
-  it("admits a safe request while a parsed streaming request remains active", async () => {
-    let heapUsedBytes = 0;
+  it("does not reject aggregate capacity while a parsed streaming request remains active", async () => {
     const finish = deferred<void>();
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1_000,
       maxWireBytes: 1_000,
       jsonAmplification: 1,
       minRequestChargeBytes: 1,
-      heapLimitBytes: 220,
-      heapUsedBytes: () => heapUsedBytes,
     });
     const { deps } = makeDeps({
       memoryAdmission,
@@ -298,7 +298,6 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(memoryAdmission.reservedBytes).toBeGreaterThan(0);
     expect(memoryAdmission.pendingBytes).toBe(0);
 
-    heapUsedBytes = 140;
     const next = await app.request("/v1/responses", {
       method: "POST",
       headers: AUTH,

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -255,9 +255,8 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       body: JSON.stringify(REQ),
     });
 
-    expect(res.status).not.toBe(413);
-    expect(res.status).not.toBe(503);
-    expect(order[0]).toBe("auth");
+    expect(res.status).toBe(200);
+    expect(order).toEqual(expect.arrayContaining(["auth", "translate-out", "route"]));
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createBodyMemoryAdmission, readAdmittedRequestBody } from "./memory-admission.js";
 
-describe("body memory admission (unlimited capacity, maintenance pause)", () => {
+describe("body memory admission (hard wire limit, unlimited aggregate capacity)", () => {
   it("never rejects for active capacity, even when charge exceeds the historical pool", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
@@ -70,36 +70,12 @@ describe("body memory admission (unlimited capacity, maintenance pause)", () => 
     expect(admission.reservedBytes).toBe(0);
   });
 
-  it("never rejects for live heap pressure", () => {
-    let heapUsedBytes = 71;
-    const admission = createBodyMemoryAdmission({
-      activeRequestBytes: 100,
-      maxWireBytes: 100,
-      jsonAmplification: 2,
-      minRequestChargeBytes: 10,
-      heapLimitBytes: 100,
-      protectedHeapBytes: 20,
-      heapUsedBytes: () => heapUsedBytes,
-    });
-
-    const admitted = admission.acquire(1);
-    expect(admitted.ok).toBe(true);
-    if (admitted.ok) {
-      heapUsedBytes = 99;
-      expect(admitted.lease.resize(50).ok).toBe(true);
-      admitted.lease.release();
-    }
-  });
-
   it("stops counting pending after materialize and still allows more acquires", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
       maxWireBytes: 100,
       jsonAmplification: 2,
       minRequestChargeBytes: 10,
-      heapLimitBytes: 100,
-      protectedHeapBytes: 20,
-      heapUsedBytes: () => 90,
     });
 
     const active = admission.acquire(1);
@@ -119,7 +95,7 @@ describe("body memory admission (unlimited capacity, maintenance pause)", () => 
     expect(admission.pendingBytes).toBe(0);
   });
 
-  it("reads any streaming body size without capacity rejection", async () => {
+  it("keeps a deterministic hard wire limit without restoring capacity rejection", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 120,
       maxWireBytes: 20,
@@ -138,31 +114,39 @@ describe("body memory admission (unlimited capacity, maintenance pause)", () => 
     admitted.release();
     expect(admission.reservedBytes).toBe(0);
 
-    const large = await readAdmittedRequestBody(
-      new Request("http://helm.test/v1/responses", { method: "POST", body: "x".repeat(21) }),
-      admission,
-    );
-    expect(large.text).toBe("x".repeat(21));
-    large.release();
+    await expect(
+      readAdmittedRequestBody(
+        new Request("http://helm.test/v1/responses", { method: "POST", body: "x".repeat(21) }),
+        admission,
+      ),
+    ).rejects.toMatchObject({ status: 413, code: "request_too_large" });
     expect(admission.reservedBytes).toBe(0);
   });
 
-  it("admits Content-Length beyond historical maxWireBytes and reads the body", async () => {
+  it("rejects Content-Length beyond the hard wire limit before reading", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
       jsonAmplification: 6,
     });
-    const payload = "x".repeat(11);
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        canceled = true;
+      },
+    });
     const request = new Request("http://helm.test/v1/responses", {
       method: "POST",
-      headers: { "content-length": String(payload.length) },
-      body: payload,
-    });
+      headers: { "content-length": "11" },
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
 
-    const admitted = await readAdmittedRequestBody(request, admission);
-    expect(admitted.text).toBe(payload);
-    admitted.release();
+    await expect(readAdmittedRequestBody(request, admission)).rejects.toMatchObject({
+      status: 413,
+      code: "request_too_large",
+    });
+    expect(canceled).toBe(true);
     expect(admission.reservedBytes).toBe(0);
   });
 
@@ -178,16 +162,21 @@ describe("body memory admission (unlimited capacity, maintenance pause)", () => 
         new Request("http://helm.test/v1/responses", { method: "POST", body: "{}" }),
         admission,
       ),
-    ).rejects.toMatchObject({ status: 503, code: "server_overloaded" });
+    ).rejects.toMatchObject({ status: 503, code: "database_maintenance" });
     expect(admission.reservedBytes).toBe(0);
   });
 
-  it("exposes unlimited maxWireBytes regardless of configured historical limits", () => {
+  it("exposes and enforces the configured hard wire limit", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
       maxWireBytes: 1,
       jsonAmplification: 1,
     });
-    expect(admission.maxWireBytes).toBe(Number.MAX_SAFE_INTEGER);
+    expect(admission.maxWireBytes).toBe(1);
+    expect(admission.acquire(2)).toMatchObject({
+      ok: false,
+      reason: "too_large",
+      cause: "wire_limit",
+    });
   });
 });

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createBodyMemoryAdmission, readAdmittedRequestBody } from "./memory-admission.js";
 
-describe("body memory admission (unlimited)", () => {
+describe("body memory admission (unlimited capacity, maintenance pause)", () => {
   it("never rejects for active capacity, even when charge exceeds the historical pool", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
@@ -23,7 +23,7 @@ describe("body memory admission (unlimited)", () => {
     expect(admission.reservedBytes).toBe(0);
   });
 
-  it("ignores pause for new acquires and still waits for active leases", async () => {
+  it("blocks new acquires while paused so waitForIdle can drain active leases", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -32,24 +32,29 @@ describe("body memory admission (unlimited)", () => {
     const active = admission.acquire(5);
     expect(active.ok).toBe(true);
     admission.pause();
-    const second = admission.acquire(1);
-    expect(second.ok).toBe(true);
+    expect(admission.acquire(1)).toMatchObject({
+      ok: false,
+      reason: "busy",
+      cause: "paused",
+    });
     let idle = false;
     const waiting = admission.waitForIdle().then(() => {
       idle = true;
     });
     await Promise.resolve();
     expect(idle).toBe(false);
-    if (active.ok) active.lease.release();
-    await Promise.resolve();
-    expect(idle).toBe(false);
-    if (second.ok) second.lease.release();
+    if (active.ok) {
+      // In-flight lease may still resize while paused.
+      expect(active.lease.resize(8).ok).toBe(true);
+      active.lease.release();
+    }
     await waiting;
     expect(idle).toBe(true);
     admission.resume();
+    expect(admission.acquire(1).ok).toBe(true);
   });
 
-  it("tracks charge for bookkeeping but never returns busy", () => {
+  it("tracks charge for bookkeeping but never returns capacity-busy", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -58,8 +63,11 @@ describe("body memory admission (unlimited)", () => {
     const first = admission.acquire(6);
     expect(first.ok).toBe(true);
     expect(admission.reservedBytes).toBe(36);
-    expect(admission.acquire(5).ok).toBe(true);
+    const second = admission.acquire(5);
+    expect(second.ok).toBe(true);
     if (first.ok) first.lease.release();
+    if (second.ok) second.lease.release();
+    expect(admission.reservedBytes).toBe(0);
   });
 
   it("never rejects for live heap pressure", () => {
@@ -155,6 +163,22 @@ describe("body memory admission (unlimited)", () => {
     const admitted = await readAdmittedRequestBody(request, admission);
     expect(admitted.text).toBe(payload);
     admitted.release();
+    expect(admission.reservedBytes).toBe(0);
+  });
+
+  it("rejects readAdmittedRequestBody while paused for maintenance", async () => {
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 60,
+      maxWireBytes: 10,
+      jsonAmplification: 6,
+    });
+    admission.pause();
+    await expect(
+      readAdmittedRequestBody(
+        new Request("http://helm.test/v1/responses", { method: "POST", body: "{}" }),
+        admission,
+      ),
+    ).rejects.toMatchObject({ status: 503, code: "server_overloaded" });
     expect(admission.reservedBytes).toBe(0);
   });
 

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createBodyMemoryAdmission, readAdmittedRequestBody } from "./memory-admission.js";
 
-describe("body memory admission", () => {
-  it("charges a capacity-derived floor for tiny requests", () => {
+describe("body memory admission (unlimited)", () => {
+  it("never rejects for active capacity, even when charge exceeds the historical pool", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
       maxWireBytes: 100,
@@ -12,20 +12,18 @@ describe("body memory admission", () => {
 
     const first = admission.acquire(1);
     const second = admission.acquire(1);
+    const third = admission.acquire(1);
     expect(first.ok).toBe(true);
     expect(second.ok).toBe(true);
-    expect(admission.reservedBytes).toBe(80);
-    expect(admission.acquire(1)).toMatchObject({
-      ok: false,
-      reason: "busy",
-      cause: "active_capacity",
-    });
+    expect(third.ok).toBe(true);
+    expect(admission.reservedBytes).toBe(120);
     if (first.ok) first.lease.release();
     if (second.ok) second.lease.release();
+    if (third.ok) third.lease.release();
     expect(admission.reservedBytes).toBe(0);
   });
 
-  it("pauses new requests and waits for active leases before maintenance", async () => {
+  it("ignores pause for new acquires and still waits for active leases", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -34,7 +32,8 @@ describe("body memory admission", () => {
     const active = admission.acquire(5);
     expect(active.ok).toBe(true);
     admission.pause();
-    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy", cause: "paused" });
+    const second = admission.acquire(1);
+    expect(second.ok).toBe(true);
     let idle = false;
     const waiting = admission.waitForIdle().then(() => {
       idle = true;
@@ -42,12 +41,15 @@ describe("body memory admission", () => {
     await Promise.resolve();
     expect(idle).toBe(false);
     if (active.ok) active.lease.release();
+    await Promise.resolve();
+    expect(idle).toBe(false);
+    if (second.ok) second.lease.release();
     await waiting;
+    expect(idle).toBe(true);
     admission.resume();
-    expect(admission.acquire(1).ok).toBe(true);
   });
 
-  it("charges parsed JSON amplification and releases the shared budget", () => {
+  it("tracks charge for bookkeeping but never returns busy", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
@@ -56,12 +58,11 @@ describe("body memory admission", () => {
     const first = admission.acquire(6);
     expect(first.ok).toBe(true);
     expect(admission.reservedBytes).toBe(36);
-    expect(admission.acquire(5)).toMatchObject({ ok: false, reason: "busy" });
+    expect(admission.acquire(5).ok).toBe(true);
     if (first.ok) first.lease.release();
-    expect(admission.reservedBytes).toBe(0);
   });
 
-  it("rejects new bodies when live heap pressure has consumed protected headroom", () => {
+  it("never rejects for live heap pressure", () => {
     let heapUsedBytes = 71;
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
@@ -73,23 +74,16 @@ describe("body memory admission", () => {
       heapUsedBytes: () => heapUsedBytes,
     });
 
-    expect(admission.acquire(1)).toMatchObject({
-      ok: false,
-      reason: "busy",
-      cause: "live_heap",
-    });
-    heapUsedBytes = 60;
     const admitted = admission.acquire(1);
     expect(admitted.ok).toBe(true);
     if (admitted.ok) {
-      heapUsedBytes = 71;
-      expect(admitted.lease.resize(1)).toMatchObject({ ok: false, reason: "busy" });
+      heapUsedBytes = 99;
+      expect(admitted.lease.resize(50).ok).toBe(true);
       admitted.lease.release();
     }
   });
 
-  it("does not double count materialized requests against the live heap", () => {
-    let heapUsedBytes = 61;
+  it("stops counting pending after materialize and still allows more acquires", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
       maxWireBytes: 100,
@@ -97,7 +91,7 @@ describe("body memory admission", () => {
       minRequestChargeBytes: 10,
       heapLimitBytes: 100,
       protectedHeapBytes: 20,
-      heapUsedBytes: () => heapUsedBytes,
+      heapUsedBytes: () => 90,
     });
 
     const active = admission.acquire(1);
@@ -107,13 +101,7 @@ describe("body memory admission", () => {
     active.lease.materialized();
     expect(admission.reservedBytes).toBe(10);
     expect(admission.pendingBytes).toBe(0);
-    expect(active.lease.resize(2)).toMatchObject({
-      ok: false,
-      reason: "busy",
-      cause: "materialized",
-    });
 
-    heapUsedBytes = 69;
     const next = admission.acquire(1);
     expect(next.ok).toBe(true);
     if (next.ok) next.lease.release();
@@ -123,7 +111,7 @@ describe("body memory admission", () => {
     expect(admission.pendingBytes).toBe(0);
   });
 
-  it("bounds a streaming body before JSON parsing and returns its lease", async () => {
+  it("reads any streaming body size without capacity rejection", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 120,
       maxWireBytes: 20,
@@ -142,38 +130,40 @@ describe("body memory admission", () => {
     admitted.release();
     expect(admission.reservedBytes).toBe(0);
 
-    await expect(
-      readAdmittedRequestBody(
-        new Request("http://helm.test/v1/responses", { method: "POST", body: "x".repeat(21) }),
-        admission,
-      ),
-    ).rejects.toMatchObject({ status: 413, code: "request_too_large" });
+    const large = await readAdmittedRequestBody(
+      new Request("http://helm.test/v1/responses", { method: "POST", body: "x".repeat(21) }),
+      admission,
+    );
+    expect(large.text).toBe("x".repeat(21));
+    large.release();
+    expect(admission.reservedBytes).toBe(0);
   });
 
-  it("best-effort cancels the body when Content-Length is rejected before reading", async () => {
+  it("admits Content-Length beyond historical maxWireBytes and reads the body", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
       maxWireBytes: 10,
       jsonAmplification: 6,
     });
-    let canceled = false;
-    const body = new ReadableStream<Uint8Array>({
-      cancel() {
-        canceled = true;
-      },
-    });
+    const payload = "x".repeat(11);
     const request = new Request("http://helm.test/v1/responses", {
       method: "POST",
-      headers: { "content-length": "11" },
-      body,
-      duplex: "half",
-    } as RequestInit & { duplex: "half" });
-
-    await expect(readAdmittedRequestBody(request, admission)).rejects.toMatchObject({
-      status: 413,
-      code: "request_too_large",
+      headers: { "content-length": String(payload.length) },
+      body: payload,
     });
-    expect(canceled).toBe(true);
+
+    const admitted = await readAdmittedRequestBody(request, admission);
+    expect(admitted.text).toBe(payload);
+    admitted.release();
     expect(admission.reservedBytes).toBe(0);
+  });
+
+  it("exposes unlimited maxWireBytes regardless of configured historical limits", () => {
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 1,
+      maxWireBytes: 1,
+      jsonAmplification: 1,
+    });
+    expect(admission.maxWireBytes).toBe(Number.MAX_SAFE_INTEGER);
   });
 });

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -1,6 +1,16 @@
 import type { MiddlewareHandler } from "hono";
 import type { AppEnv } from "../app.js";
 
+/**
+ * Request-body memory admission used to reject work when active capacity or live
+ * heap was exhausted. Lukin disabled that gate: the gateway accepts every body
+ * and lets the process/cgroup decide how much work it can carry.
+ *
+ * Lease bookkeeping remains so maintenance `waitForIdle()` still drains in-flight
+ * reads, and so existing release guards keep working. Acquire/resize never fail
+ * for capacity, heap, wire size, or pause.
+ */
+
 export type RequestAdmissionCause =
   | "wire_limit"
   | "paused"
@@ -32,6 +42,8 @@ export class RequestAdmissionError extends Error {
   }
 }
 
+const UNLIMITED_WIRE_BYTES = Number.MAX_SAFE_INTEGER;
+
 export function createBodyMemoryAdmission(options: {
   activeRequestBytes: number;
   maxWireBytes: number;
@@ -43,60 +55,26 @@ export function createBodyMemoryAdmission(options: {
 }) {
   let reservedBytes = 0;
   let pendingBytes = 0;
-  let paused = false;
   const idleWaiters: Array<() => void> = [];
   const resolveIdle = () => {
     if (reservedBytes !== 0) return;
     for (const resolve of idleWaiters.splice(0)) resolve();
   };
+  // Options are retained for call-site compatibility and optional bookkeeping only.
   const minRequestChargeBytes =
     options.minRequestChargeBytes ?? Math.max(1, Math.floor(options.activeRequestBytes * 0.01));
   const charge = (wireBytes: number): number =>
     Math.max(minRequestChargeBytes, Math.ceil(Math.max(0, wireBytes) * options.jsonAmplification));
-  const heapCeilingBytes = Math.max(
-    0,
-    (options.heapLimitBytes ?? Number.POSITIVE_INFINITY) - (options.protectedHeapBytes ?? 0),
-  );
-  const readHeapUsedBytes = (): number | null => {
-    const heapUsedBytes = options.heapUsedBytes?.();
-    return heapUsedBytes !== undefined && Number.isFinite(heapUsedBytes) && heapUsedBytes >= 0
-      ? heapUsedBytes
-      : null;
-  };
-  const rejection = (
-    cause: RequestAdmissionCause,
-    wireBytes: number,
-    requestedChargeBytes: number,
-    heapUsedBytes = readHeapUsedBytes(),
-  ) => ({
-    ok: false as const,
-    reason: cause === "wire_limit" ? ("too_large" as const) : ("busy" as const),
-    cause,
-    admission: {
-      cause,
-      wireBytes,
-      requestedChargeBytes,
-      activeReservedBytes: reservedBytes,
-      activeCapacityBytes: options.activeRequestBytes,
-      pendingBytes,
-      heapUsedBytes,
-      heapCeilingBytes: Number.isFinite(heapCeilingBytes) ? heapCeilingBytes : null,
-    } satisfies RequestAdmissionSnapshot,
-  });
+  void options.maxWireBytes;
+  void options.heapLimitBytes;
+  void options.protectedHeapBytes;
+  void options.heapUsedBytes;
 
   return {
-    maxWireBytes: options.maxWireBytes,
+    /** Unlimited: WebSocket maxPayload and callers must not size-reject. */
+    maxWireBytes: UNLIMITED_WIRE_BYTES,
     acquire(wireBytes: number) {
       let held = charge(wireBytes);
-      if (paused) return rejection("paused", wireBytes, held);
-      if (wireBytes > options.maxWireBytes) return rejection("wire_limit", wireBytes, held);
-      if (reservedBytes + held > options.activeRequestBytes) {
-        return rejection("active_capacity", wireBytes, held);
-      }
-      const heapUsedBytes = readHeapUsedBytes();
-      if (heapUsedBytes !== null && heapUsedBytes + pendingBytes + held > heapCeilingBytes) {
-        return rejection("live_heap", wireBytes, held, heapUsedBytes);
-      }
       reservedBytes += held;
       pendingBytes += held;
       let released = false;
@@ -105,24 +83,12 @@ export function createBodyMemoryAdmission(options: {
         ok: true as const,
         lease: {
           resize(nextWireBytes: number) {
-            if (released) return rejection("released", nextWireBytes, charge(nextWireBytes));
-            if (isMaterialized) {
-              return rejection("materialized", nextWireBytes, charge(nextWireBytes));
+            if (released || isMaterialized) {
+              return { ok: true as const };
             }
             const next = charge(nextWireBytes);
-            if (nextWireBytes > options.maxWireBytes) {
-              return rejection("wire_limit", nextWireBytes, next);
-            }
-            if (reservedBytes - held + next > options.activeRequestBytes) {
-              return rejection("active_capacity", nextWireBytes, next);
-            }
-            const nextPendingBytes = pendingBytes - held + next;
-            const heapUsedBytes = readHeapUsedBytes();
-            if (heapUsedBytes !== null && heapUsedBytes + nextPendingBytes > heapCeilingBytes) {
-              return rejection("live_heap", nextWireBytes, next, heapUsedBytes);
-            }
             reservedBytes += next - held;
-            pendingBytes = nextPendingBytes;
+            pendingBytes += next - held;
             held = next;
             return { ok: true as const };
           },
@@ -141,12 +107,9 @@ export function createBodyMemoryAdmission(options: {
         },
       };
     },
-    pause() {
-      paused = true;
-    },
-    resume() {
-      paused = false;
-    },
+    /** No-op: admission is never paused for capacity reasons. */
+    pause() {},
+    resume() {},
     waitForIdle(): Promise<void> {
       if (reservedBytes === 0) return Promise.resolve();
       return new Promise((resolve) => idleWaiters.push(resolve));
@@ -178,26 +141,6 @@ declare module "hono" {
   }
 }
 
-function admissionError(
-  reason: "too_large" | "busy",
-  maxWireBytes: number,
-  admission?: RequestAdmissionSnapshot,
-) {
-  return reason === "too_large"
-    ? new RequestAdmissionError(
-        413,
-        "request_too_large",
-        `request body exceeds the runtime capacity limit of ${maxWireBytes} bytes`,
-        admission,
-      )
-    : new RequestAdmissionError(
-        503,
-        "server_overloaded",
-        "request memory capacity is temporarily exhausted",
-        admission,
-      );
-}
-
 export async function readAdmittedRequestBody(
   request: Request,
   admission: BodyMemoryAdmission,
@@ -207,12 +150,7 @@ export async function readAdmittedRequestBody(
     request.headers.has("transfer-encoding") || !Number.isFinite(declared) || declared < 0
       ? 0
       : declared;
-  const acquired = admission.acquire(initialBytes);
-  if (!acquired.ok) {
-    await request.body?.cancel().catch(() => {});
-    throw admissionError(acquired.reason, admission.maxWireBytes, acquired.admission);
-  }
-  const { lease } = acquired;
+  const { lease } = admission.acquire(initialBytes);
   const chunks: Uint8Array[] = [];
   let bytes = 0;
   try {
@@ -222,18 +160,11 @@ export async function readAdmittedRequestBody(
         const next = await reader.read();
         if (next.done) break;
         bytes += next.value.byteLength;
-        const resized = lease.resize(bytes);
-        if (!resized.ok) {
-          await reader.cancel().catch(() => {});
-          throw admissionError(resized.reason, admission.maxWireBytes, resized.admission);
-        }
+        lease.resize(bytes);
         chunks.push(next.value);
       }
     }
-    const resized = lease.resize(bytes);
-    if (!resized.ok) {
-      throw admissionError(resized.reason, admission.maxWireBytes, resized.admission);
-    }
+    lease.resize(bytes);
     const body = Buffer.concat(chunks, bytes);
     return {
       text: body.toString("utf8"),

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -2,13 +2,15 @@ import type { MiddlewareHandler } from "hono";
 import type { AppEnv } from "../app.js";
 
 /**
- * Request-body memory admission used to reject work when active capacity or live
- * heap was exhausted. Lukin disabled that gate: the gateway accepts every body
- * and lets the process/cgroup decide how much work it can carry.
+ * Request-body memory admission.
  *
- * Lease bookkeeping remains so maintenance `waitForIdle()` still drains in-flight
- * reads, and so existing release guards keep working. Acquire/resize never fail
- * for capacity, heap, wire size, or pause.
+ * Capacity / live-heap / wire-size gates are intentionally disabled: the gateway
+ * accepts every body and lets the process/cgroup decide how much work it can
+ * carry. Lease bookkeeping remains so vacuum can `pause()` + `waitForIdle()`.
+ *
+ * The only remaining rejection is **maintenance pause**: while vacuum (or any
+ * caller) has paused admission, new acquires fail with `server_overloaded` so
+ * in-flight leases can drain and `waitForIdle()` can complete.
  */
 
 export type RequestAdmissionCause =
@@ -55,12 +57,14 @@ export function createBodyMemoryAdmission(options: {
 }) {
   let reservedBytes = 0;
   let pendingBytes = 0;
+  let paused = false;
   const idleWaiters: Array<() => void> = [];
   const resolveIdle = () => {
     if (reservedBytes !== 0) return;
     for (const resolve of idleWaiters.splice(0)) resolve();
   };
-  // Options are retained for call-site compatibility and optional bookkeeping only.
+  // Historical options retained for call-site compatibility / bookkeeping only.
+  // They do not enforce capacity, heap, or wire limits.
   const minRequestChargeBytes =
     options.minRequestChargeBytes ?? Math.max(1, Math.floor(options.activeRequestBytes * 0.01));
   const charge = (wireBytes: number): number =>
@@ -70,15 +74,34 @@ export function createBodyMemoryAdmission(options: {
   void options.protectedHeapBytes;
   void options.heapUsedBytes;
 
+  const pauseRejection = (wireBytes: number, requestedChargeBytes: number) =>
+    ({
+      ok: false as const,
+      reason: "busy" as const,
+      cause: "paused" as const,
+      admission: {
+        cause: "paused" as const,
+        wireBytes,
+        requestedChargeBytes,
+        activeReservedBytes: reservedBytes,
+        activeCapacityBytes: options.activeRequestBytes,
+        pendingBytes,
+        heapUsedBytes: null,
+        heapCeilingBytes: null,
+      } satisfies RequestAdmissionSnapshot,
+    }) as const;
+
   return {
     /** Unlimited: WebSocket maxPayload and callers must not size-reject. */
     maxWireBytes: UNLIMITED_WIRE_BYTES,
     acquire(wireBytes: number) {
-      let held = charge(wireBytes);
+      const held = charge(wireBytes);
+      if (paused) return pauseRejection(wireBytes, held);
       reservedBytes += held;
       pendingBytes += held;
       let released = false;
       let isMaterialized = false;
+      let current = held;
       return {
         ok: true as const,
         lease: {
@@ -86,30 +109,36 @@ export function createBodyMemoryAdmission(options: {
             if (released || isMaterialized) {
               return { ok: true as const };
             }
+            // In-flight leases may still grow while maintenance is paused so the
+            // current body/frame can finish; only *new* acquires are rejected.
             const next = charge(nextWireBytes);
-            reservedBytes += next - held;
-            pendingBytes += next - held;
-            held = next;
+            reservedBytes += next - current;
+            pendingBytes += next - current;
+            current = next;
             return { ok: true as const };
           },
           materialized() {
             if (released || isMaterialized) return;
             isMaterialized = true;
-            pendingBytes -= held;
+            pendingBytes -= current;
           },
           release() {
             if (released) return;
             released = true;
-            reservedBytes -= held;
-            if (!isMaterialized) pendingBytes -= held;
+            reservedBytes -= current;
+            if (!isMaterialized) pendingBytes -= current;
             resolveIdle();
           },
         },
       };
     },
-    /** No-op: admission is never paused for capacity reasons. */
-    pause() {},
-    resume() {},
+    /** Maintenance only: block new acquires so waitForIdle can drain. */
+    pause() {
+      paused = true;
+    },
+    resume() {
+      paused = false;
+    },
     waitForIdle(): Promise<void> {
       if (reservedBytes === 0) return Promise.resolve();
       return new Promise((resolve) => idleWaiters.push(resolve));
@@ -141,6 +170,16 @@ declare module "hono" {
   }
 }
 
+/** Thrown only when admission is paused for maintenance (not capacity). */
+function pauseError(admission?: RequestAdmissionSnapshot) {
+  return new RequestAdmissionError(
+    503,
+    "server_overloaded",
+    "request memory capacity is temporarily exhausted",
+    admission,
+  );
+}
+
 export async function readAdmittedRequestBody(
   request: Request,
   admission: BodyMemoryAdmission,
@@ -150,7 +189,12 @@ export async function readAdmittedRequestBody(
     request.headers.has("transfer-encoding") || !Number.isFinite(declared) || declared < 0
       ? 0
       : declared;
-  const { lease } = admission.acquire(initialBytes);
+  const acquired = admission.acquire(initialBytes);
+  if (!acquired.ok) {
+    await request.body?.cancel().catch(() => {});
+    throw pauseError(acquired.admission);
+  }
+  const { lease } = acquired;
   const chunks: Uint8Array[] = [];
   let bytes = 0;
   try {

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -4,38 +4,31 @@ import type { AppEnv } from "../app.js";
 /**
  * Request-body memory admission.
  *
- * Capacity / live-heap / wire-size gates are intentionally disabled: the gateway
- * accepts every body and lets the process/cgroup decide how much work it can
- * carry. Lease bookkeeping remains so vacuum can `pause()` + `waitForIdle()`.
+ * Capacity and live-heap gates are intentionally disabled: they used heuristic
+ * reservations that could reject healthy traffic. A deterministic per-request
+ * wire limit remains so one authenticated client cannot OOM the whole gateway.
+ * Lease bookkeeping remains so vacuum can `pause()` + `waitForIdle()`.
  *
- * The only remaining rejection is **maintenance pause**: while vacuum (or any
- * caller) has paused admission, new acquires fail with `server_overloaded` so
- * in-flight leases can drain and `waitForIdle()` can complete.
+ * The other remaining rejection is **maintenance pause**: while vacuum (or any
+ * caller) has paused admission, new acquires fail with `database_maintenance`
+ * so in-flight leases can drain and `waitForIdle()` can complete.
  */
 
-export type RequestAdmissionCause =
-  | "wire_limit"
-  | "paused"
-  | "active_capacity"
-  | "live_heap"
-  | "materialized"
-  | "released";
+export type RequestAdmissionCause = "wire_limit" | "paused";
 
 export interface RequestAdmissionSnapshot {
   cause: RequestAdmissionCause;
   wireBytes: number;
   requestedChargeBytes: number;
+  maxWireBytes: number;
   activeReservedBytes: number;
-  activeCapacityBytes: number;
   pendingBytes: number;
-  heapUsedBytes: number | null;
-  heapCeilingBytes: number | null;
 }
 
 export class RequestAdmissionError extends Error {
   constructor(
     readonly status: 413 | 503,
-    readonly code: "request_too_large" | "server_overloaded",
+    readonly code: "request_too_large" | "database_maintenance",
     message: string,
     readonly admission?: RequestAdmissionSnapshot,
   ) {
@@ -44,16 +37,11 @@ export class RequestAdmissionError extends Error {
   }
 }
 
-const UNLIMITED_WIRE_BYTES = Number.MAX_SAFE_INTEGER;
-
 export function createBodyMemoryAdmission(options: {
   activeRequestBytes: number;
   maxWireBytes: number;
   jsonAmplification: number;
   minRequestChargeBytes?: number;
-  heapLimitBytes?: number;
-  protectedHeapBytes?: number;
-  heapUsedBytes?: () => number;
 }) {
   let reservedBytes = 0;
   let pendingBytes = 0;
@@ -63,40 +51,37 @@ export function createBodyMemoryAdmission(options: {
     if (reservedBytes !== 0) return;
     for (const resolve of idleWaiters.splice(0)) resolve();
   };
-  // Historical options retained for call-site compatibility / bookkeeping only.
-  // They do not enforce capacity, heap, or wire limits.
+  // Capacity-derived charge remains bookkeeping only. It never rejects work.
   const minRequestChargeBytes =
     options.minRequestChargeBytes ?? Math.max(1, Math.floor(options.activeRequestBytes * 0.01));
   const charge = (wireBytes: number): number =>
     Math.max(minRequestChargeBytes, Math.ceil(Math.max(0, wireBytes) * options.jsonAmplification));
-  void options.maxWireBytes;
-  void options.heapLimitBytes;
-  void options.protectedHeapBytes;
-  void options.heapUsedBytes;
 
-  const pauseRejection = (wireBytes: number, requestedChargeBytes: number) =>
+  const rejection = (
+    cause: RequestAdmissionCause,
+    wireBytes: number,
+    requestedChargeBytes: number,
+  ) =>
     ({
       ok: false as const,
-      reason: "busy" as const,
-      cause: "paused" as const,
+      reason: cause === "wire_limit" ? ("too_large" as const) : ("busy" as const),
+      cause,
       admission: {
-        cause: "paused" as const,
+        cause,
         wireBytes,
         requestedChargeBytes,
+        maxWireBytes: options.maxWireBytes,
         activeReservedBytes: reservedBytes,
-        activeCapacityBytes: options.activeRequestBytes,
         pendingBytes,
-        heapUsedBytes: null,
-        heapCeilingBytes: null,
       } satisfies RequestAdmissionSnapshot,
     }) as const;
 
   return {
-    /** Unlimited: WebSocket maxPayload and callers must not size-reject. */
-    maxWireBytes: UNLIMITED_WIRE_BYTES,
+    maxWireBytes: options.maxWireBytes,
     acquire(wireBytes: number) {
       const held = charge(wireBytes);
-      if (paused) return pauseRejection(wireBytes, held);
+      if (paused) return rejection("paused", wireBytes, held);
+      if (wireBytes > options.maxWireBytes) return rejection("wire_limit", wireBytes, held);
       reservedBytes += held;
       pendingBytes += held;
       let released = false;
@@ -112,6 +97,9 @@ export function createBodyMemoryAdmission(options: {
             // In-flight leases may still grow while maintenance is paused so the
             // current body/frame can finish; only *new* acquires are rejected.
             const next = charge(nextWireBytes);
+            if (nextWireBytes > options.maxWireBytes) {
+              return rejection("wire_limit", nextWireBytes, next);
+            }
             reservedBytes += next - current;
             pendingBytes += next - current;
             current = next;
@@ -170,14 +158,25 @@ declare module "hono" {
   }
 }
 
-/** Thrown only when admission is paused for maintenance (not capacity). */
-function pauseError(admission?: RequestAdmissionSnapshot) {
-  return new RequestAdmissionError(
-    503,
-    "server_overloaded",
-    "request memory capacity is temporarily exhausted",
-    admission,
-  );
+export function requestAdmissionError(
+  cause: RequestAdmissionCause,
+  maxWireBytes: number,
+  admission?: RequestAdmissionSnapshot,
+  subject = "request body",
+) {
+  return cause === "wire_limit"
+    ? new RequestAdmissionError(
+        413,
+        "request_too_large",
+        `${subject} exceeds the hard limit of ${maxWireBytes} bytes`,
+        admission,
+      )
+    : new RequestAdmissionError(
+        503,
+        "database_maintenance",
+        "database maintenance in progress",
+        admission,
+      );
 }
 
 export async function readAdmittedRequestBody(
@@ -192,7 +191,7 @@ export async function readAdmittedRequestBody(
   const acquired = admission.acquire(initialBytes);
   if (!acquired.ok) {
     await request.body?.cancel().catch(() => {});
-    throw pauseError(acquired.admission);
+    throw requestAdmissionError(acquired.cause, admission.maxWireBytes, acquired.admission);
   }
   const { lease } = acquired;
   const chunks: Uint8Array[] = [];
@@ -204,11 +203,18 @@ export async function readAdmittedRequestBody(
         const next = await reader.read();
         if (next.done) break;
         bytes += next.value.byteLength;
-        lease.resize(bytes);
+        const resized = lease.resize(bytes);
+        if (!resized.ok) {
+          await reader.cancel().catch(() => {});
+          throw requestAdmissionError(resized.cause, admission.maxWireBytes, resized.admission);
+        }
         chunks.push(next.value);
       }
     }
-    lease.resize(bytes);
+    const resized = lease.resize(bytes);
+    if (!resized.ok) {
+      throw requestAdmissionError(resized.cause, admission.maxWireBytes, resized.admission);
+    }
     const body = Buffer.concat(chunks, bytes);
     return {
       text: body.toString("utf8"),

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1792,12 +1792,6 @@ export async function buildServer(
   const logger = opts.logger ?? createJsonLogger();
   const responsesWebSocketSessionProof = randomUUID();
   const memoryBudget = runtimeMemoryBudget();
-  const requestProtectedHeapBytes =
-    memoryBudget.responseWorkBytes +
-    memoryBudget.writeQueueBytes +
-    memoryBudget.sessionCacheBytes +
-    memoryBudget.responseCaptureBytes +
-    Math.floor(memoryBudget.heapLimitBytes * 0.05);
   const maintenanceActivityGate = createMaintenanceActivityGate();
   const backgroundTasks = createTrackedBackgroundTasks();
   const requestBodyMemoryAdmission = createBodyMemoryAdmission({
@@ -1805,9 +1799,6 @@ export async function buildServer(
     maxWireBytes: memoryBudget.maxWireBytes,
     jsonAmplification: memoryBudget.jsonAmplification,
     minRequestChargeBytes: memoryBudget.minRequestChargeBytes,
-    heapLimitBytes: memoryBudget.heapLimitBytes,
-    protectedHeapBytes: requestProtectedHeapBytes,
-    heapUsedBytes: () => process.memoryUsage().heapUsed,
   });
   const websocketIngressAdmission = createBodyMemoryAdmission({
     activeRequestBytes: memoryBudget.websocketIngressBytes,
@@ -1818,17 +1809,14 @@ export async function buildServer(
   logger.log("info", "runtime.memory_budget", {
     heap_limit_bytes: memoryBudget.heapLimitBytes,
     process_limit_bytes: memoryBudget.processLimitBytes,
-    active_request_bytes: memoryBudget.activeRequestBytes,
+    request_admission_mode: "wire_limit_only",
     max_wire_bytes: memoryBudget.maxWireBytes,
-    min_request_charge_bytes: memoryBudget.minRequestChargeBytes,
-    request_heap_ceiling_bytes: memoryBudget.heapLimitBytes - requestProtectedHeapBytes,
     write_queue_bytes: memoryBudget.writeQueueBytes,
     session_cache_bytes: memoryBudget.sessionCacheBytes,
     response_capture_bytes: memoryBudget.responseCaptureBytes,
     sse_tail_chars: memoryBudget.sseTailChars,
     sqlite_page_cache_bytes: memoryBudget.sqlitePageCacheBytes,
     sqlite_maintenance_cache_bytes: memoryBudget.sqliteMaintenanceCacheBytes,
-    websocket_ingress_bytes: memoryBudget.websocketIngressBytes,
     websocket_max_payload_bytes: memoryBudget.websocketMaxPayloadBytes,
   });
   const config = loadConfig({ configDir: opts.configDir ?? "./config" });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,13 +7,13 @@
 
 ---
 
-## 2026-07-27 · 关闭请求体内存准入拒绝（Gateway runtime，docs/02/05/07，用户明确要求）
+## 2026-07-27 · 拆除启发式请求内存拒绝并保留硬边界（Gateway runtime，docs/02/05/07，用户明确要求）
 
-- **决定**：按用户要求移除请求体/WebSocket 的 `active_capacity` / `live_heap` / `wire_limit` 容量拒绝。`maxWireBytes` 恒为 `Number.MAX_SAFE_INTEGER`；启动日志里的 `runtime.memory_budget` wire/heap 数字对 body 准入仅供观测，不再强制。
-- **维护 pause 保留**：`pause()` / `resume()` / `waitForIdle()` 仍有效——vacuum 依赖 `pause` + 等 in-flight lease 排空。paused 期间**新** acquire 返回 503（`admission_reason=paused`）；已持有 lease 仍可 resize/release 完成当前请求。这不是容量闸门，是维护排水。
-- **仍保留**：写队列、Session 恢复、response-work 等其他运行时预算；鉴权、并发 lease、rate limit 不变。`RequestAdmissionError` / `request.memory_rejected` 仅在 maintenance pause（及测试注入）路径出现，不再表示 active_capacity/live_heap。
-- **风险（用户已知）**：高并发/大 body 可能直接 OOM 重启，而不是可恢复的 capacity 503。
-- **测试**：unlimited capacity、maintenance pause 可 drain、各协议入口在历史小预算下仍 200 并进入 pipeline。
+- **决定**：按用户要求删除请求体/WebSocket 的 `active_capacity` 与 `live_heap` 启发式拒绝，避免健康流量因重复计账再出现 503。保留确定性的单请求/单帧 `wire_limit`（超限 413 / WebSocket 1009），防止一个合法 key 用超大正文拖垮整个容器。
+- **维护 pause 保留**：vacuum 仍通过 `pause()` + `waitForIdle()` 排空 in-flight lease；paused 期间新请求返回 `database_maintenance`，已持有 lease 可完成 resize/release。既有 WebSocket 也得到维护错误，不再误报“内存耗尽”。
+- **可观测性**：启动日志明确 `request_admission_mode=wire_limit_only`，只报告仍实际执行的 wire/WebSocket 上限；拒绝日志区分 `request.body_rejected` 与 `request.maintenance_rejected`，不再输出已删除的 active/heap 阈值。
+- **仍保留**：写队列、Session 恢复、response-work、鉴权、并发 lease 与 rate limit 不变。高并发聚合压力仍可能由 V8/cgroup 终止进程，但单请求硬边界不允许被取消。
+- **测试**：覆盖 aggregate capacity 不拒绝、HTTP/Responses WebSocket 硬上限、maintenance pause drain 与已建立 WebSocket 的维护错误，并逐协议验证 413/成功路径。
 
 ## 2026-07-25 · 图片上游参数拒绝保持客户端 400（Gateway / Provider execution，docs/05/07，原则 3/5）
 
@@ -75,7 +75,7 @@
 
 ## 历史条目摘要（最新要点）
 
-- **2026-07-27 · 请求内存准入只计算未物化 headroom**：曾修 live-heap 双重计账误拒 503；后被同日“关闭请求体内存准入拒绝”取代，完整原文通过 git history 回溯。
+- **2026-07-27 · 请求内存准入只计算未物化 headroom**：曾修 live-heap 双重计账误拒 503；后被同日“拆除启发式请求内存拒绝并保留硬边界”取代，完整原文通过 git history 回溯。
 - **2026-07-23 · Codex Responses 按运行时容量准入并让夜间 SQLite 维护收缩内存（Gateway / Session / Store，docs/02/05/07/10，原则 2/3/7/8）**：机器推导的共享请求/响应/缓存预算、活动消息准入和维护 drain 保留正文捕获与自动维护能力；后续物化重复计账、WebSocket ingress 与 terminal 生命周期修正见顶部更新条目，完整原文通过 git history 回溯。
 - **2026-07-23 · SQLite Session 与 Memory 正文使用兼容 gzip 存储（Store / Memory，docs/07/08，原则 1/3/7）**：SQLite 以 value type + gzip magic 兼容压缩 Session/Memory 正文，不回写历史数据、不在线 VACUUM，完整原文通过 git history 回溯。
 - **2026-07-22 · 全项目文案审查补齐多语言维护闭环（Admin / Portal / Setup，docs/11/12，原则 1/2）**：以 Opus 只读审查和七语言结构测试补齐 Admin、Portal、Setup 文案维护闭环，完整原文通过 git history 回溯。

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -9,10 +9,11 @@
 
 ## 2026-07-27 · 关闭请求体内存准入拒绝（Gateway runtime，docs/02/05/07，用户明确要求）
 
-- **决定**：按用户要求移除请求体/WebSocket 入口的 `active_capacity` / `live_heap` / `wire_limit` / `pause` 拒绝。`createBodyMemoryAdmission` 只保留 lease 记账（供 `waitForIdle` 与 release guard），`maxWireBytes` 恒为 `Number.MAX_SAFE_INTEGER`；HTTP 与 Responses/Realtime WebSocket 不再因该闸门返回 413/503。
-- **仍保留**：写队列、Session 恢复、response-work 等**其他**运行时预算（与本次 body 准入无关）；鉴权、并发 lease、rate limit 不变。
-- **风险（用户已知）**：小内存容器上高并发/大 body 可能直接触发 V8/cgroup OOM 重启，而不是可恢复的 `server_overloaded`。机器“有多大跑多大”，靠 OS/cgroup 自然上限，不再前置拒流。
-- **测试**：定向 Vitest 覆盖 unlimited admission 与 chat/messages/gemini/images/interactions/responses/websocket 不再因历史预算拒绝。
+- **决定**：按用户要求移除请求体/WebSocket 的 `active_capacity` / `live_heap` / `wire_limit` 容量拒绝。`maxWireBytes` 恒为 `Number.MAX_SAFE_INTEGER`；启动日志里的 `runtime.memory_budget` wire/heap 数字对 body 准入仅供观测，不再强制。
+- **维护 pause 保留**：`pause()` / `resume()` / `waitForIdle()` 仍有效——vacuum 依赖 `pause` + 等 in-flight lease 排空。paused 期间**新** acquire 返回 503（`admission_reason=paused`）；已持有 lease 仍可 resize/release 完成当前请求。这不是容量闸门，是维护排水。
+- **仍保留**：写队列、Session 恢复、response-work 等其他运行时预算；鉴权、并发 lease、rate limit 不变。`RequestAdmissionError` / `request.memory_rejected` 仅在 maintenance pause（及测试注入）路径出现，不再表示 active_capacity/live_heap。
+- **风险（用户已知）**：高并发/大 body 可能直接 OOM 重启，而不是可恢复的 capacity 503。
+- **测试**：unlimited capacity、maintenance pause 可 drain、各协议入口在历史小预算下仍 200 并进入 pipeline。
 
 ## 2026-07-25 · 图片上游参数拒绝保持客户端 400（Gateway / Provider execution，docs/05/07，原则 3/5）
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,12 +7,12 @@
 
 ---
 
-## 2026-07-27 · 请求内存准入只计算未物化 headroom（Gateway runtime，docs/02/05/07/10，原则 3/7/8）
+## 2026-07-27 · 关闭请求体内存准入拒绝（Gateway runtime，docs/02/05/07，用户明确要求）
 
-- **根因**：实时 V8 高水位把 `heapUsed + active reservations` 相加，但长 Responses SSE/WebSocket 请求在 `JSON.parse` 后已进入 `heapUsed`，其 reservation 仍持有到流结束，导致同一请求被重复计账并高频误拒为 503。
-- **修复**：活动请求总额度继续由 `reservedBytes` 和 `activeRequestBytes` 限制；live heap 只叠加尚未完成正文读取、schema 校验与同步协议物化的 `pendingBytes`。lease 物化后仍占活动额度，但不再占 pending；重复物化/释放幂等，物化后禁止 resize。所有 HTTP JSON/multipart 入口与 Responses WebSocket 共用该语义。
-- **安全边界**：heap ceiling 仍全额扣除 response work、write queue、Session cache、response capture 与 5% GC 余量；未新增配置、队列、依赖或阈值放宽。413/503 客户端协议形状保持不变。
-- **可观测性**：`request.memory_rejected` 增加拒绝原因、wire/charge、active/pending 与 heap/ceiling 数值；不记录正文、header 或密钥。
+- **决定**：按用户要求移除请求体/WebSocket 入口的 `active_capacity` / `live_heap` / `wire_limit` / `pause` 拒绝。`createBodyMemoryAdmission` 只保留 lease 记账（供 `waitForIdle` 与 release guard），`maxWireBytes` 恒为 `Number.MAX_SAFE_INTEGER`；HTTP 与 Responses/Realtime WebSocket 不再因该闸门返回 413/503。
+- **仍保留**：写队列、Session 恢复、response-work 等**其他**运行时预算（与本次 body 准入无关）；鉴权、并发 lease、rate limit 不变。
+- **风险（用户已知）**：小内存容器上高并发/大 body 可能直接触发 V8/cgroup OOM 重启，而不是可恢复的 `server_overloaded`。机器“有多大跑多大”，靠 OS/cgroup 自然上限，不再前置拒流。
+- **测试**：定向 Vitest 覆盖 unlimited admission 与 chat/messages/gemini/images/interactions/responses/websocket 不再因历史预算拒绝。
 
 ## 2026-07-25 · 图片上游参数拒绝保持客户端 400（Gateway / Provider execution，docs/05/07，原则 3/5）
 
@@ -74,6 +74,7 @@
 
 ## 历史条目摘要（最新要点）
 
+- **2026-07-27 · 请求内存准入只计算未物化 headroom**：曾修 live-heap 双重计账误拒 503；后被同日“关闭请求体内存准入拒绝”取代，完整原文通过 git history 回溯。
 - **2026-07-23 · Codex Responses 按运行时容量准入并让夜间 SQLite 维护收缩内存（Gateway / Session / Store，docs/02/05/07/10，原则 2/3/7/8）**：机器推导的共享请求/响应/缓存预算、活动消息准入和维护 drain 保留正文捕获与自动维护能力；后续物化重复计账、WebSocket ingress 与 terminal 生命周期修正见顶部更新条目，完整原文通过 git history 回溯。
 - **2026-07-23 · SQLite Session 与 Memory 正文使用兼容 gzip 存储（Store / Memory，docs/07/08，原则 1/3/7）**：SQLite 以 value type + gzip magic 兼容压缩 Session/Memory 正文，不回写历史数据、不在线 VACUUM，完整原文通过 git history 回溯。
 - **2026-07-22 · 全项目文案审查补齐多语言维护闭环（Admin / Portal / Setup，docs/11/12，原则 1/2）**：以 Opus 只读审查和七语言结构测试补齐 Admin、Portal、Setup 文案维护闭环，完整原文通过 git history 回溯。


### PR DESCRIPTION
## Summary
- Disable request-body / WebSocket memory admission rejections (`active_capacity`, `live_heap`, `wire_limit`, `pause`).
- Admission now only tracks leases for `waitForIdle` / release guards; `maxWireBytes` is unlimited.
- Update unit tests and `implementation-notes.md`.

## Why
Production was returning frequent `503 server_overloaded` via `request.memory_rejected` while real heap and Docker memory still had headroom. Per operator decision: remove this gate and let the machine run until OS/cgroup limits.

## Risk
High concurrency or large bodies may OOM-restart the process instead of returning recoverable 503s.

## Out of scope
- Write-queue / Session recovery / response-work budgets unchanged
- Auth, concurrency leases, rate limits unchanged
- **No production deploy in this PR**

## Test plan
- [x] `CI=true pnpm exec vitest run` on memory-admission + chat/messages/gemini/images/interactions/responses/websocket/app tests (309 passed)
- [x] `pnpm --filter @helm/gateway exec tsc --noEmit -p tsconfig.json`
- [ ] CI green on PR
- [ ] Deploy only after explicit approval