### PR TITLE
chore(release): v0.28.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.17",
+  "version": "0.28.18",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump Helm API from `0.28.17` to `0.28.18`

## Why

Release the request admission root-cause fix merged in PR #652. The gateway removes heuristic aggregate-capacity/live-heap 503 rejections while retaining deterministic HTTP body and WebSocket frame limits plus database-maintenance draining.

## Validation

- PR #652 immutable checks: verify, e2e, docker
- release diff is version-only
- `git diff --check`