### PR TITLE
chore(release): v0.28.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.18",
+  "version": "0.28.19",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Version-only patch release for the memory/preflight fixes merged in #654.

- bumps root `package.json` from `0.28.18` to `0.28.19`
- no other source, config, dependency, or deployment-limit changes

## Validation

- #654 passed all required CI checks before merge
- release workflow contract: 25 passed
- this PR will run the full required CI matrix before merge