### PR TITLE
fix(core): move SQLite idle-flush scan off event loop

### DIFF
--- a/packages/core/src/store/sqlite/idle-flush-candidates.ts
+++ b/packages/core/src/store/sqlite/idle-flush-candidates.ts
@@ -1,0 +1,218 @@
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { Worker } from "node:worker_threads";
+import type Database from "better-sqlite3";
+
+export interface IdleFlushCandidateInput {
+  idleBeforeMs: number;
+  idleAfterMs?: number;
+  limit: number;
+}
+
+interface IdleFlushCandidateRow {
+  owner_id: string;
+  thread_id: string;
+  project_id: string | null;
+  resource_id: string | null;
+}
+
+export interface IdleFlushCandidate {
+  accountId: string;
+  threadId: string;
+  projectId?: string;
+  resourceId?: string;
+}
+
+const DEFAULT_WORKER_TIMEOUT_MS = 30_000;
+const fileScans = new WeakMap<Database.Database, Promise<IdleFlushCandidate[]>>();
+
+const candidateSql = `WITH candidates AS (
+  SELECT t.owner_id AS owner_id, t.id AS thread_id,
+         t.project_id AS project_id, t.resource_id AS resource_id,
+         (SELECT MAX(m.created_at) FROM memory_messages m WHERE m.thread_id = t.id)
+           AS last_activity
+    FROM memory_threads t
+   WHERE t.owner_id IS NOT NULL
+     AND last_activity IS NOT NULL
+     AND last_activity <= ?
+     AND (? IS NULL OR last_activity >= ?)
+     AND EXISTS (
+       SELECT 1 FROM memory_messages m
+        WHERE m.thread_id = t.id
+          AND NOT EXISTS (
+            SELECT 1 FROM memory_observations o
+            JOIN memory_messages mf
+              ON mf.id = json_extract(o.source_message_range, '$[0]')
+            JOIN memory_messages ml
+              ON ml.id = json_extract(o.source_message_range, '$[1]')
+             WHERE o.thread_id = t.id
+               AND (
+                 (
+                   (CASE WHEN mf.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(mf.message_index, 9223372036854775807),
+                    mf.created_at,
+                    mf.id)
+                   <=
+                   (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(m.message_index, 9223372036854775807),
+                    m.created_at,
+                    m.id)
+                   AND
+                   (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(m.message_index, 9223372036854775807),
+                    m.created_at,
+                    m.id)
+                   <=
+                   (CASE WHEN ml.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(ml.message_index, 9223372036854775807),
+                    ml.created_at,
+                    ml.id)
+                 )
+                 OR
+                 (
+                   (CASE WHEN ml.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(ml.message_index, 9223372036854775807),
+                    ml.created_at,
+                    ml.id)
+                   <=
+                   (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(m.message_index, 9223372036854775807),
+                    m.created_at,
+                    m.id)
+                   AND
+                   (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(m.message_index, 9223372036854775807),
+                    m.created_at,
+                    m.id)
+                   <=
+                   (CASE WHEN mf.message_index IS NULL THEN 1 ELSE 0 END,
+                    COALESCE(mf.message_index, 9223372036854775807),
+                    mf.created_at,
+                    mf.id)
+                 )
+               )
+          )
+     )
+),
+ranked AS (
+  SELECT *,
+         ROW_NUMBER() OVER (
+           PARTITION BY owner_id, COALESCE(project_id, ''), COALESCE(resource_id, '')
+           ORDER BY last_activity ASC, thread_id ASC
+         ) AS scope_rank
+    FROM candidates
+)
+SELECT owner_id, thread_id, project_id, resource_id
+  FROM ranked
+ ORDER BY scope_rank ASC, last_activity ASC, thread_id ASC
+ LIMIT ?`;
+
+const workerSource = `
+const { parentPort, workerData } = require("node:worker_threads");
+const Database = require(workerData.betterSqlite3Path);
+
+const message = (error) => error instanceof Error ? error.message : String(error);
+let result;
+let sqlite;
+try {
+  sqlite = new Database(workerData.databasePath, { fileMustExist: true, readonly: true });
+  sqlite.pragma("busy_timeout = 5000");
+  sqlite.pragma("query_only = ON");
+  sqlite.pragma("temp_store = FILE");
+  sqlite.pragma("cache_size = -8192");
+  result = { ok: true, rows: sqlite.prepare(workerData.sql).all(...workerData.params) };
+} catch (error) {
+  result = { ok: false, error: message(error) };
+}
+if (sqlite) {
+  try { sqlite.close(); } catch (error) {
+    if (result && result.ok) result = { ok: false, error: "sqlite close failed: " + message(error) };
+  }
+}
+parentPort.postMessage(result);
+`;
+
+function params(input: IdleFlushCandidateInput): [number, number | null, number | null, number] {
+  return [input.idleBeforeMs, input.idleAfterMs ?? null, input.idleAfterMs ?? null, input.limit];
+}
+
+function mapRows(rows: IdleFlushCandidateRow[]): IdleFlushCandidate[] {
+  return rows.map((row) => ({
+    accountId: row.owner_id,
+    threadId: row.thread_id,
+    ...(row.project_id !== null ? { projectId: row.project_id } : {}),
+    ...(row.resource_id !== null ? { resourceId: row.resource_id } : {}),
+  }));
+}
+
+function runFileScan(
+  databasePath: string,
+  input: IdleFlushCandidateInput,
+  timeoutMs: number,
+): Promise<IdleFlushCandidateRow[]> {
+  const betterSqlite3Path = createRequire(import.meta.url).resolve("better-sqlite3");
+  return new Promise((resolvePromise, rejectPromise) => {
+    const worker = new Worker(workerSource, {
+      eval: true,
+      workerData: {
+        betterSqlite3Path,
+        databasePath,
+        sql: candidateSql,
+        params: params(input),
+      },
+    });
+    let settled = false;
+    const rejectOnce = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      rejectPromise(error);
+    };
+    const resolveOnce = (rows: IdleFlushCandidateRow[]): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolvePromise(rows);
+    };
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      rejectOnce(new Error(`sqlite idle-flush worker timed out after ${timeoutMs}ms`));
+      void worker.terminate();
+    }, timeoutMs);
+    timeout.unref();
+    worker.once(
+      "message",
+      (value: { ok?: boolean; rows?: IdleFlushCandidateRow[]; error?: string }) => {
+        if (value?.ok && Array.isArray(value.rows)) resolveOnce(value.rows);
+        else rejectOnce(new Error(value?.error ?? "sqlite idle-flush worker failed"));
+      },
+    );
+    worker.once("error", rejectOnce);
+    worker.once("exit", (code) => {
+      if (!settled)
+        rejectOnce(new Error(`sqlite idle-flush worker exited before reporting: ${code}`));
+    });
+  });
+}
+
+export function listSqliteIdleFlushCandidates(
+  sqlite: Database.Database,
+  input: IdleFlushCandidateInput,
+  options: { workerTimeoutMs?: number } = {},
+): Promise<IdleFlushCandidate[]> {
+  if (sqlite.name === ":memory:" || sqlite.name === "") {
+    return Promise.resolve(
+      mapRows(sqlite.prepare(candidateSql).all(...params(input)) as IdleFlushCandidateRow[]),
+    );
+  }
+  const active = fileScans.get(sqlite);
+  if (active !== undefined) return active;
+  const timeoutMs = options.workerTimeoutMs ?? DEFAULT_WORKER_TIMEOUT_MS;
+  const scan = runFileScan(resolve(sqlite.name), input, timeoutMs)
+    .then(mapRows)
+    .finally(() => {
+      if (fileScans.get(sqlite) === scan) fileScans.delete(sqlite);
+    });
+  fileScans.set(sqlite, scan);
+  return scan;
+}

--- a/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
@@ -1,4 +1,8 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { listSqliteIdleFlushCandidates } from "./idle-flush-candidates.js";
 import { SqliteMemoryStore } from "./memory-store.js";
 import { createSqliteDb } from "./migrate.js";
 
@@ -76,6 +80,66 @@ describe("SqliteMemoryStore — thread model stamp", () => {
 });
 
 describe("SqliteMemoryStore — idle-flush candidates", () => {
+  it("keeps the event loop moving while a file-backed candidate scan waits on SQLite", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-idle-flush-"));
+    const path = join(dir, "helm.db");
+    const db = createSqliteDb(path);
+    const store = new SqliteMemoryStore(
+      db,
+      () => "m1",
+      () => new Date(1_000_000),
+    );
+    try {
+      await store.ensureThread({ id: "t1", ownerId: "acct-a" });
+      await store.appendMessage({
+        threadId: "t1",
+        role: "user",
+        content: "hi",
+        tokenEstimate: 1,
+      });
+      db.$sqlite.pragma("journal_mode = DELETE");
+      db.$sqlite.exec("BEGIN EXCLUSIVE");
+      let lockReleased = false;
+      const release = setTimeout(() => {
+        db.$sqlite.exec("COMMIT");
+        lockReleased = true;
+      }, 50);
+
+      try {
+        await expect(
+          store.listIdleFlushCandidates({ idleBeforeMs: 2_000_000, limit: 10 }),
+        ).resolves.toEqual([{ accountId: "acct-a", threadId: "t1" }]);
+        expect(lockReleased).toBe(true);
+      } finally {
+        clearTimeout(release);
+        if (!lockReleased) db.$sqlite.exec("COMMIT");
+      }
+    } finally {
+      if (db.$sqlite.open) db.$sqlite.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("coalesces overlapping scans and terminates a stuck file worker", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-idle-flush-timeout-"));
+    const path = join(dir, "helm.db");
+    const db = createSqliteDb(path);
+    try {
+      db.$sqlite.pragma("journal_mode = DELETE");
+      db.$sqlite.exec("BEGIN EXCLUSIVE");
+      const input = { idleBeforeMs: 2_000_000, limit: 10 };
+      const first = listSqliteIdleFlushCandidates(db.$sqlite, input, { workerTimeoutMs: 25 });
+      const second = listSqliteIdleFlushCandidates(db.$sqlite, input, { workerTimeoutMs: 25 });
+
+      expect(second).toBe(first);
+      await expect(first).rejects.toThrow("sqlite idle-flush worker timed out after 25ms");
+    } finally {
+      db.$sqlite.exec("COMMIT");
+      db.$sqlite.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns an idle thread with uncovered messages; respects the idle cutoff", async () => {
     const { store, clock } = newStore();
     await store.ensureThread({ id: "t1", ownerId: "acct-a" });

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -47,6 +47,7 @@ import {
   type MemoryMessageArchiveRow,
   type MemoryStore,
 } from "../ports.js";
+import { listSqliteIdleFlushCandidates } from "./idle-flush-candidates.js";
 import {
   memoryFacts,
   memoryJobs,
@@ -2062,7 +2063,9 @@ export class SqliteMemoryStore implements MemoryStore {
   // false candidates. project_id/resource_id ride along so the observer can
   // promote the resulting observation to the project/resource reflection.
   // Candidates are interleaved by owner+project+resource, so one stale project
-  // backlog cannot monopolize the worker's small per-tick page.
+  // backlog cannot monopolize the worker's small per-tick page. File-backed
+  // databases run this global scan in a Worker so better-sqlite3 cannot block the
+  // gateway event loop; in-memory test stores keep the same SQL inline.
   async listIdleFlushCandidates(input: {
     idleBeforeMs: number;
     idleAfterMs?: number;
@@ -2070,109 +2073,6 @@ export class SqliteMemoryStore implements MemoryStore {
   }): Promise<
     Array<{ accountId: string; threadId: string; projectId?: string; resourceId?: string }>
   > {
-    const rows = this.db.$sqlite
-      .prepare(
-        `WITH candidates AS (
-           SELECT t.owner_id AS owner_id, t.id AS thread_id,
-                  t.project_id AS project_id, t.resource_id AS resource_id,
-                  (SELECT MAX(m.created_at) FROM memory_messages m WHERE m.thread_id = t.id)
-                    AS last_activity
-             FROM memory_threads t
-            WHERE t.owner_id IS NOT NULL
-              AND last_activity IS NOT NULL
-              AND last_activity <= ?
-              AND (? IS NULL OR last_activity >= ?)
-              AND EXISTS (
-                -- A message NOT covered by ANY observation's [first,last] range,
-                -- using the SAME order as listMessages/Observer. Interval
-                -- containment catches sparse gaps before later observations, and
-                -- the full tuple handles same-message-index / same-ms ties.
-                SELECT 1 FROM memory_messages m
-                 WHERE m.thread_id = t.id
-                   AND NOT EXISTS (
-                     SELECT 1 FROM memory_observations o
-                     JOIN memory_messages mf
-                       ON mf.id = json_extract(o.source_message_range, '$[0]')
-                     JOIN memory_messages ml
-                       ON ml.id = json_extract(o.source_message_range, '$[1]')
-                      WHERE o.thread_id = t.id
-                        AND (
-                          (
-                            (CASE WHEN mf.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(mf.message_index, 9223372036854775807),
-                             mf.created_at,
-                             mf.id)
-                            <=
-                            (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(m.message_index, 9223372036854775807),
-                             m.created_at,
-                             m.id)
-                            AND
-                            (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(m.message_index, 9223372036854775807),
-                             m.created_at,
-                             m.id)
-                            <=
-                            (CASE WHEN ml.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(ml.message_index, 9223372036854775807),
-                             ml.created_at,
-                             ml.id)
-                          )
-                          OR
-                          (
-                            (CASE WHEN ml.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(ml.message_index, 9223372036854775807),
-                             ml.created_at,
-                             ml.id)
-                            <=
-                            (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(m.message_index, 9223372036854775807),
-                             m.created_at,
-                             m.id)
-                            AND
-                            (CASE WHEN m.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(m.message_index, 9223372036854775807),
-                             m.created_at,
-                             m.id)
-                            <=
-                            (CASE WHEN mf.message_index IS NULL THEN 1 ELSE 0 END,
-                             COALESCE(mf.message_index, 9223372036854775807),
-                             mf.created_at,
-                             mf.id)
-                          )
-                        )
-                   )
-              )
-          ),
-          ranked AS (
-            SELECT *,
-                   ROW_NUMBER() OVER (
-                     PARTITION BY owner_id, COALESCE(project_id, ''), COALESCE(resource_id, '')
-                     ORDER BY last_activity ASC, thread_id ASC
-                   ) AS scope_rank
-              FROM candidates
-          )
-          SELECT owner_id, thread_id, project_id, resource_id
-            FROM ranked
-           ORDER BY scope_rank ASC, last_activity ASC, thread_id ASC
-           LIMIT ?`,
-      )
-      .all(
-        input.idleBeforeMs,
-        input.idleAfterMs ?? null,
-        input.idleAfterMs ?? null,
-        input.limit,
-      ) as Array<{
-      owner_id: string;
-      thread_id: string;
-      project_id: string | null;
-      resource_id: string | null;
-    }>;
-    return rows.map((row) => ({
-      accountId: row.owner_id,
-      threadId: row.thread_id,
-      ...(row.project_id !== null ? { projectId: row.project_id } : {}),
-      ...(row.resource_id !== null ? { resourceId: row.resource_id } : {}),
-    }));
+    return listSqliteIdleFlushCandidates(this.db.$sqlite, input);
   }
 }


### PR DESCRIPTION
## Summary

- run the file-backed SQLite idle-flush candidate scan in a read-only Worker Thread
- preserve the existing tenant, coverage, cutoff, ordering, fairness, and limit SQL semantics
- coalesce overlapping scans per SQLite handle and terminate a scan after 30 seconds
- keep in-memory test stores on the existing inline SQL path

## Production evidence

The v0.28.19 runtime metrics showed event-loop p99 near 22–30 ms but recurring 3–7 second maxima. The maxima align with the 60-second Memory worker tick. Production SQLite is about 26.7 GB with 122,792 memory threads and about 1.97 million tracked messages; the idle-flush query performs correlated coverage scans from synchronous `better-sqlite3`, blocking the gateway event loop.

`writequeue.task_overflow` is separate: it is fail-open shedding of deferred Memory writes at the existing queue budget, not a 503, OOM, or preflight leak.

## Verification

- Red: file-backed scan failed when the gateway SQLite handle was unavailable
- Green: 15 SQLite auto-compaction tests
- 57 focused idle-flush/scheduler/SQLite tests
- SQLite/Postgres semantic regression suite: 64 tests
- full `pnpm typecheck`
- full `pnpm lint` (existing warnings only)
- full `pnpm build`
- compiled package worker boundary: `built_worker_boundary=ok`

The Docker 1.5 GB limit, automatic VACUUM, cleanup schedule, request admission, and memory queue budget are unchanged.
