### PR TITLE
chore(release): v0.28.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.19",
+  "version": "0.28.20",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API version to 0.28.20
- release the SQLite idle-flush Worker Thread fix merged in #656

## Validation
- version-only diff
- feature PR #656 passed verify, e2e, and docker CI