### PR TITLE
fix(memory): preaggregate SQLite decay sweep timestamps

### DIFF
--- a/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
+++ b/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
@@ -320,6 +320,37 @@ describe("SqliteMemoryStore.listDecayCandidateAccounts (P5 buffer-flush gate)", 
     expect(due).toEqual(["acct-a"]);
   });
 
+  it("extracts each decay job scope once instead of once per observation", async () => {
+    const t0 = new Date("2026-06-05T00:00:00.000Z");
+    const { store, db, set } = clockStore(t0);
+    await store.ensureThread({ id: "t-a", ownerId: "acct-a" });
+    await store.enqueueJob({ type: "decay", scope: { accountId: "acct-a" } });
+    set(new Date(t0.getTime() + 1000));
+    for (let i = 0; i < 20; i += 1) {
+      await store.appendObservation({
+        threadId: "t-a",
+        sourceMessageRange: [`m${i}`, `m${i}`],
+        observationText: `observation ${i}`,
+        observedAt: new Date(t0.getTime() + 1000),
+      });
+    }
+
+    let jsonExtractCalls = 0;
+    db.$sqlite.function("json_extract", { deterministic: true }, (raw: unknown, path: unknown) => {
+      jsonExtractCalls += 1;
+      if (typeof raw !== "string" || path !== "$.accountId") return null;
+      const parsed = JSON.parse(raw) as { accountId?: unknown };
+      return typeof parsed.accountId === "string" ? parsed.accountId : null;
+    });
+
+    await store.listDecayCandidateAccounts({
+      triggerObservations: 50,
+      triggerIntervalS: 3600,
+      nowMs: t0.getTime() + 60_000,
+    });
+    expect(jsonExtractCalls).toBeLessThan(10);
+  });
+
   it("ignores accounts whose only observations are already archived", async () => {
     const t0 = new Date("2026-06-05T00:00:00.000Z");
     const { store } = clockStore(t0);

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -915,21 +915,24 @@ export class SqliteMemoryStore implements MemoryStore {
     const intervalCutoff = input.nowMs - input.triggerIntervalS * 1000;
     const rows = this.db.$sqlite
       .prepare(
-        `SELECT mt.owner_id AS owner_id,
-                (SELECT MAX(j.created_at) FROM memory_jobs j
-                  WHERE j.type = 'decay'
-                    AND json_extract(j.scope_id, '$.accountId') = mt.owner_id) AS last_sweep,
+        `WITH decay_sweeps AS MATERIALIZED (
+           SELECT json_extract(scope_id, '$.accountId') AS owner_id,
+                  MAX(created_at) AS last_sweep
+             FROM memory_jobs
+            WHERE type = 'decay'
+            GROUP BY json_extract(scope_id, '$.accountId')
+         )
+         SELECT mt.owner_id AS owner_id,
+                ds.last_sweep AS last_sweep,
                 COUNT(o.id) AS active_total,
-                SUM(CASE WHEN o.observed_at > COALESCE(
-                  (SELECT MAX(j2.created_at) FROM memory_jobs j2
-                    WHERE j2.type = 'decay'
-                      AND json_extract(j2.scope_id, '$.accountId') = mt.owner_id), 0)
+                SUM(CASE WHEN o.observed_at > COALESCE(ds.last_sweep, 0)
                   THEN 1 ELSE 0 END) AS new_since_sweep
            FROM memory_observations o
            JOIN memory_threads mt ON mt.id = o.thread_id
+           LEFT JOIN decay_sweeps ds ON ds.owner_id = mt.owner_id
           WHERE o.status = 'active'
             AND mt.owner_id IS NOT NULL
-          GROUP BY mt.owner_id`,
+          GROUP BY mt.owner_id, ds.last_sweep`,
       )
       .all() as Array<{
       owner_id: string;


### PR DESCRIPTION
## Root cause
The 60-second memory worker tick ran `listDecayCandidateAccounts()` synchronously on the Node main thread. Its correlated decay-job subquery was evaluated once per active observation. On production data (17,236 active observations / 936 decay jobs), the read took 7.913s and produced a recurring ~3.0–3.4s event-loop stall every minute.

## Fix
- materialize the latest decay sweep once per decoded account
- join that small result into the active-observation aggregate
- preserve the existing count gate, time gate, special-character account handling, and tenant boundary
- add a deterministic regression that catches per-observation `json_extract` amplification

## Evidence
- production read-only equivalent query: 7.913s → 0.156s
- focused memory tests: 72 passed
- full typecheck: passed
- full build: passed
- lint: no errors; existing repository warnings only
- independent SQL and production-runtime reviews: no blockers