### PR TITLE
chore(release): v0.28.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.20",
+  "version": "0.28.21",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API version to 0.28.21
- release the synchronous SQLite decay-scan fix merged in #658

## Validation
- version-only diff
- feature PR #658 passed verify, e2e, and docker CI
- production-equivalent read-only SQL benchmark improved from 7.913s to 0.156s