### PR TITLE
Remove HTTP and WebSocket size limits

### DIFF
--- a/apps/gateway/src/app.test.ts
+++ b/apps/gateway/src/app.test.ts
@@ -138,28 +138,28 @@ describe("createApp: trace_id, logging, error handling", () => {
     });
   });
 
-  it("logs the hard body rejection without stale capacity fields or request payload data", async () => {
+  it("logs maintenance admission without stale capacity fields or request payload data", async () => {
     const { logger, lines } = fakeLogger();
     const c = mockCtx(logger, "trace-memory");
     const res = handleError(
-      new RequestAdmissionError(413, "request_too_large", "body too large", {
-        cause: "wire_limit",
+      new RequestAdmissionError(503, "database_maintenance", "database maintenance in progress", {
+        cause: "paused",
         wireBytes: 12,
         requestedChargeBytes: 72,
-        maxWireBytes: 10,
         activeReservedBytes: 144,
         pendingBytes: 24,
       }),
       c,
     );
 
-    expect(res.status).toBe(413);
-    expect(lines.find((line) => line.message === "request.body_rejected")?.fields).toMatchObject({
+    expect(res.status).toBe(503);
+    expect(
+      lines.find((line) => line.message === "request.maintenance_rejected")?.fields,
+    ).toMatchObject({
       trace_id: "trace-memory",
-      admission_reason: "wire_limit",
+      admission_reason: "paused",
       wire_bytes: 12,
       requested_charge_bytes: 72,
-      max_wire_bytes: 10,
       active_reserved_bytes: 144,
       pending_bytes: 24,
     });

--- a/apps/gateway/src/codex-responses-websocket.ts
+++ b/apps/gateway/src/codex-responses-websocket.ts
@@ -7,7 +7,6 @@ import {
   type ProxyConfig,
   proxyConfigToUrl,
   type ResponseWorkAdmission,
-  runtimeMemoryBudget,
   runtimeResponseWorkAdmission,
 } from "@helm/core";
 import { HttpsProxyAgent } from "https-proxy-agent";
@@ -122,7 +121,7 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
       waiter.resolve(message);
       return;
     }
-    if (this.pendingBytes + bytes > this.maxPendingBytes) {
+    if (this.maxPendingBytes > 0 && this.pendingBytes + bytes > this.maxPendingBytes) {
       this.failCapacity(message.release);
       return;
     }
@@ -211,7 +210,7 @@ async function unexpectedResponseBody(
     for await (const chunk of response) {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       bytes += buffer.byteLength;
-      if (bytes > maxBytes) {
+      if (maxBytes > 0 && bytes > maxBytes) {
         const error = new UnexpectedResponseBodyError(
           "too_large",
           `Codex Responses websocket unexpected response body exceeded ${maxBytes} bytes`,
@@ -232,11 +231,8 @@ export function createCodexResponsesWebSocketConnector(
 ): CodexResponsesWebSocketConnector {
   const agent = codexWebSocketAgent(options.proxy);
   const connectTimeoutMs = codexWebSocketConnectTimeoutMs(options.timeoutMs);
-  const maxPayloadBytes = Math.max(
-    1,
-    Math.floor(options.maxPayloadBytes ?? runtimeMemoryBudget().maxWireBytes),
-  );
-  const maxPendingBytes = Math.max(1, Math.floor(options.maxPendingBytes ?? maxPayloadBytes));
+  const maxPayloadBytes = Math.max(0, Math.floor(options.maxPayloadBytes ?? 0));
+  const maxPendingBytes = Math.max(0, Math.floor(options.maxPendingBytes ?? 0));
   const responseWorkAdmission = options.responseWorkAdmission ?? runtimeResponseWorkAdmission();
 
   return async ({ url, headers, signal }) =>

--- a/apps/gateway/src/middleware/error-handler.ts
+++ b/apps/gateway/src/middleware/error-handler.ts
@@ -64,31 +64,26 @@ export function handleError(err: unknown, c: Context<AppEnv>): Response {
   const logger = c.get("logger");
 
   if (err instanceof RequestAdmissionError) {
-    if (err.status === 503) c.header("retry-after", "1");
-    logger.log(
-      "warn",
-      err.admission?.cause === "paused" ? "request.maintenance_rejected" : "request.body_rejected",
-      {
-        trace_id: traceId,
-        http_status: err.status,
-        code: err.code,
-        ...(err.admission === undefined
-          ? {}
-          : {
-              admission_reason: err.admission.cause,
-              wire_bytes: err.admission.wireBytes,
-              requested_charge_bytes: err.admission.requestedChargeBytes,
-              max_wire_bytes: err.admission.maxWireBytes,
-              active_reserved_bytes: err.admission.activeReservedBytes,
-              pending_bytes: err.admission.pendingBytes,
-            }),
-      },
-    );
+    c.header("retry-after", "1");
+    logger.log("warn", "request.maintenance_rejected", {
+      trace_id: traceId,
+      http_status: err.status,
+      code: err.code,
+      ...(err.admission === undefined
+        ? {}
+        : {
+            admission_reason: err.admission.cause,
+            wire_bytes: err.admission.wireBytes,
+            requested_charge_bytes: err.admission.requestedChargeBytes,
+            active_reserved_bytes: err.admission.activeReservedBytes,
+            pending_bytes: err.admission.pendingBytes,
+          }),
+    });
     return c.json(
       {
         error: {
           message: err.message,
-          type: err.status === 413 ? "invalid_request_error" : "server_error",
+          type: "server_error",
           code: err.code,
           trace_id: traceId,
         },

--- a/apps/gateway/src/realtime-websocket.test.ts
+++ b/apps/gateway/src/realtime-websocket.test.ts
@@ -104,7 +104,7 @@ describe("Realtime websocket bridge", () => {
     expect(response.statusCode).toBe(404);
   });
 
-  it("closes an oversized client frame with 1009 before relaying it", async () => {
+  it("relays a client frame larger than the former admission limit", async () => {
     const upstreamHttp = await listeningServer();
     const upstream = new WebSocketServer({ server: upstreamHttp.server, perMessageDeflate: false });
     upstream.on("connection", (socket) => socket.on("message", (data) => socket.send(data)));
@@ -128,7 +128,6 @@ describe("Realtime websocket bridge", () => {
       resolveKey: async () => "key-1",
       memoryAdmission: createBodyMemoryAdmission({
         activeRequestBytes: 100,
-        maxWireBytes: 4,
         jsonAmplification: 1,
       }),
     });
@@ -138,10 +137,10 @@ describe("Realtime websocket bridge", () => {
       headers: { Authorization: "Bearer helm-key" },
     });
     await once(client, "open");
-    const closed = once(client, "close");
+    const echoed = once(client, "message");
     client.send("12345");
-    const [code] = (await closed) as [number];
-    expect(code).toBe(1009);
+    const [data] = (await echoed) as [WebSocket.RawData, boolean];
+    expect(data.toString()).toBe("12345");
   });
 
   it("refreshes OAuth once when the upstream sideband rejects with 401", async () => {

--- a/apps/gateway/src/realtime-websocket.ts
+++ b/apps/gateway/src/realtime-websocket.ts
@@ -104,7 +104,7 @@ async function openUpstream(
         });
         const queue = (data: WebSocket.RawData, isBinary: boolean) => {
           pendingBytes += rawBytes(data);
-          if (pendingBytes > maxPayload) {
+          if (maxPayload > 0 && pendingBytes > maxPayload) {
             socket.close(1009, "pending response too large");
             return;
           }
@@ -151,14 +151,13 @@ export function installRealtimeWebSocketBridge(
     options.memoryAdmission ??
     createBodyMemoryAdmission({
       activeRequestBytes: memoryBudget.websocketIngressBytes,
-      maxWireBytes: memoryBudget.websocketMaxPayloadBytes,
       jsonAmplification: 1,
       minRequestChargeBytes: 1,
     });
   const websocketServer = new WebSocketServer({
     noServer: true,
     perMessageDeflate: false,
-    maxPayload: admission.maxWireBytes,
+    maxPayload: 0,
   });
   const upstreams = new Set<WebSocket>();
   let closed = false;
@@ -178,15 +177,10 @@ export function installRealtimeWebSocketBridge(
       else if (upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
     };
     const relay = (destination: WebSocket, data: WebSocket.RawData, isBinary: boolean) => {
-      // Aggregate capacity is unlimited; hard wire and maintenance pause remain.
+      // Size/capacity checks are disabled; maintenance pause remains.
       const acquired = admission.acquire(rawBytes(data));
       if (!acquired.ok) {
-        closeBoth(
-          acquired.reason === "too_large" ? 1009 : 1013,
-          acquired.reason === "too_large"
-            ? "realtime frame too large"
-            : "database maintenance in progress",
-        );
+        closeBoth(1013, "database maintenance in progress");
         return;
       }
       if (destination.readyState !== WebSocket.OPEN) {
@@ -227,7 +221,7 @@ export function installRealtimeWebSocketBridge(
       }
       let upstream: PendingUpstream;
       try {
-        upstream = await openUpstream(call.target, admission.maxWireBytes);
+        upstream = await openUpstream(call.target, 0);
       } catch (cause) {
         options.registry.put(callId, keyId, call.target);
         throw cause;

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -128,7 +128,6 @@ describe("Responses websocket bridge", () => {
   it("does not reserve a maximum frame for idle websocket connections", async () => {
     const ingressAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 20,
-      maxWireBytes: 10,
       jsonAmplification: 1,
       minRequestChargeBytes: 10,
     });
@@ -152,7 +151,6 @@ describe("Responses websocket bridge", () => {
   it("admits concurrent materialized websocket messages without capacity 503", async () => {
     const ingressAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 200,
-      maxWireBytes: 100,
       jsonAmplification: 1,
       minRequestChargeBytes: 100,
     });
@@ -193,32 +191,33 @@ describe("Responses websocket bridge", () => {
     expect(ingressAdmission.reservedBytes).toBe(0);
   });
 
-  it("keeps the shared hard wire limit before parsing a websocket message", async () => {
+  it("accepts a websocket message larger than the former shared hard wire limit", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
     });
     const baseUrl = await startBridge(
-      () => {
-        throw new Error("fetch should not run");
-      },
+      () =>
+        new Response(
+          'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        ),
       undefined,
       { memoryAdmission },
     );
     const socket = await connect(`${baseUrl}/v1/responses`);
-    const closed = once(socket, "close");
-    socket.send(JSON.stringify({ type: "response.create", input: "too large" }));
-    const [code] = await closed;
+    const events = await collectTurn(socket, {
+      type: "response.create",
+      input: "larger than ten bytes",
+    });
 
-    expect(code).toBe(1009);
+    expect(events.at(-1)).toMatchObject({ type: "response.completed" });
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("reports maintenance pause honestly on an established websocket", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 1_000,
       jsonAmplification: 6,
     });
     const baseUrl = await startBridge(
@@ -249,7 +248,6 @@ describe("Responses websocket bridge", () => {
   it("materializes the shared request lease after the internal HTTP parser returns", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1_000,
-      maxWireBytes: 1_000,
       jsonAmplification: 1,
       minRequestChargeBytes: 1,
     });

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -244,11 +244,11 @@ function localErrorEnvelope(error: unknown): Record<string, unknown> {
       status: error.status,
       status_code: error.status,
       error: {
-        type: error.status === 413 ? "invalid_request_error" : "server_error",
+        type: "server_error",
         code: error.code,
         message: error.message,
       },
-      headers: error.status === 503 ? { "retry-after": "1" } : {},
+      headers: { "retry-after": "1" },
     };
   }
   if (error instanceof WebSocketRequestError) {
@@ -507,21 +507,16 @@ export function installResponsesWebSocketBridge({
     memoryAdmission ??
     createBodyMemoryAdmission({
       activeRequestBytes: memoryBudget.activeRequestBytes,
-      maxWireBytes: memoryBudget.maxWireBytes,
       jsonAmplification: memoryBudget.jsonAmplification,
     });
   const ingress =
     ingressAdmission ??
     createBodyMemoryAdmission({
       activeRequestBytes: memoryBudget.websocketIngressBytes,
-      maxWireBytes: Math.min(admission.maxWireBytes, memoryBudget.websocketMaxPayloadBytes),
       jsonAmplification: 1,
       minRequestChargeBytes: 1,
     });
-  const websocketMaxPayloadBytes = Math.max(
-    1,
-    Math.min(admission.maxWireBytes, ingress.maxWireBytes),
-  );
+  const websocketMaxPayloadBytes = 0;
   const metadataByRequest = new WeakMap<IncomingMessage, UpgradeMetadata>();
   const websocketServer = new WebSocketServer({
     noServer: true,
@@ -567,37 +562,19 @@ export function installResponsesWebSocketBridge({
       const bytes = Array.isArray(data)
         ? data.reduce((total, chunk) => total + chunk.byteLength, 0)
         : data.byteLength;
-      // Aggregate capacity/live-heap checks are disabled. Deterministic wire and
-      // maintenance-pause boundaries remain.
+      // Size/capacity checks are disabled. Admission remains only so database
+      // maintenance can pause new work and drain active leases.
       const ingressAcquired = ingress.acquire(bytes);
       if (!ingressAcquired.ok) {
-        const error = requestAdmissionError(
-          ingressAcquired.cause,
-          ingress.maxWireBytes,
-          ingressAcquired.admission,
-          "websocket message",
-        );
-        void sendEnvelope(socket, localErrorEnvelope(error))
-          .catch(() => {})
-          .finally(() => {
-            if (error.status === 413) socket.close(1009, "message too big");
-          });
+        const error = requestAdmissionError(ingressAcquired.admission);
+        void sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
         return;
       }
       const acquired = admission.acquire(bytes);
       if (!acquired.ok) {
         ingressAcquired.lease.release();
-        const error = requestAdmissionError(
-          acquired.cause,
-          admission.maxWireBytes,
-          acquired.admission,
-          "websocket message",
-        );
-        void sendEnvelope(socket, localErrorEnvelope(error))
-          .catch(() => {})
-          .finally(() => {
-            if (error.status === 413) socket.close(1009, "message too big");
-          });
+        const error = requestAdmissionError(acquired.admission);
+        void sendEnvelope(socket, localErrorEnvelope(error)).catch(() => {});
         return;
       }
       processing = true;

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -277,13 +277,17 @@ async function getSessionRequest(
   if (!sessionRef) return { status: "unavailable", reason: "no_session" };
   if (!listPage) return { status: "unavailable", reason: "session_unavailable" };
   const budget = runtimeMemoryBudget();
+  const responseAdmission = runtimeResponseWorkAdmission();
   // ponytail: half a response-work window lets inspection coexist with live API
   // traffic; add metadata-first admission if larger concurrent restores are needed.
-  const recoveryMaxWireBytes = Math.max(1, Math.floor(budget.maxWireBytes / 2));
+  const recoveryMaxWireBytes = Math.max(
+    1,
+    Math.floor(responseAdmission.capacityBytes / budget.jsonAmplification / 2),
+  );
   // Reserve one whole safe recovery window before the adapter materializes even
   // the first page. Reserving after listPage() would let concurrent readers each
   // allocate a large page before either one became visible to the shared budget.
-  const acquired = runtimeResponseWorkAdmission().acquire(recoveryMaxWireBytes);
+  const acquired = responseAdmission.acquire(recoveryMaxWireBytes);
   if (!acquired.ok) return { status: "unavailable", reason: "session_recovery_limited" };
   const revisions: SessionRevisionRecord[] = [];
   let afterSequence: number | undefined;

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -170,10 +170,9 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
     "/chat/completions",
     "/engines/azure-deployment/chat/completions",
     "/openai/deployments/azure-deployment/chat/completions",
-  ])("keeps the hard body limit on %s", async (path) => {
+  ])("does not enforce the former hard body limit on %s", async (path) => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
-      maxWireBytes: 1,
       jsonAmplification: 1,
     });
     const { deps: d, harness } = deps({ memoryAdmission });
@@ -185,15 +184,14 @@ describe("POST /v1/chat/completions — usage budgets + OAuth usage + eval overr
       body: JSON.stringify(NONSTREAM_BODY),
     });
 
-    expect(res.status).toBe(413);
-    expect(harness.execute).not.toHaveBeenCalled();
+    expect(res.status).not.toBe(413);
+    expect(harness.execute).toHaveBeenCalledOnce();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("does not return capacity 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
-      maxWireBytes: 1024,
       jsonAmplification: 1,
     });
     const { deps: d, harness } = deps({ memoryAdmission });

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -465,12 +465,12 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       raw = JSON.parse(requestJson);
     } catch (error) {
       if (error instanceof RequestAdmissionError) {
-        if (error.status === 503) c.header("retry-after", "1");
+        c.header("retry-after", "1");
         return c.json(
           {
             error: {
               message: error.message,
-              type: error.status === 413 ? "invalid_request_error" : "api_error",
+              type: "api_error",
               code: error.code,
               param: null,
             },

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -178,10 +178,9 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     "generateContent",
     "streamGenerateContent",
     "countTokens",
-  ])("keeps the hard body limit for %s", async (operation) => {
+  ])("does not enforce the former hard body limit for %s", async (operation) => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
-      maxWireBytes: 1,
       jsonAmplification: 1,
     });
     const { deps, harness } = makeDeps({ memoryAdmission });
@@ -193,15 +192,15 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       body: JSON.stringify(REQ_BODY),
     });
 
-    expect(res.status).toBe(413);
-    expect(harness.order).toEqual(["auth:helm_live_secret"]);
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(harness.order).toContain("auth:helm_live_secret");
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("does not return capacity 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
-      maxWireBytes: 1024,
       jsonAmplification: 1,
     });
     const { deps, harness } = makeDeps({ memoryAdmission });

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -156,16 +156,16 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     return c.json(out.body as Record<string, unknown>, out.status as 400 | 401 | 404 | 429 | 502);
   };
   const sendAdmissionError = (c: Context<AppEnv>, error: RequestAdmissionError): Response => {
-    if (error.status === 503) c.header("retry-after", "1");
+    c.header("retry-after", "1");
     const out = transformer.transformErrorOut({
-      error_class: error.status === 413 ? "invalid_request" : "lane_unavailable",
+      error_class: "lane_unavailable",
       message: error.message,
       trace_id: c.get("trace_id"),
     });
     const body = out.body as { error?: Record<string, unknown> };
     return c.json(
       body.error === undefined ? body : { ...body, error: { ...body.error, code: error.status } },
-      error.status as 413 | 503,
+      error.status,
     );
   };
 

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -191,28 +191,23 @@ describe("registerImagesRoute", () => {
     expect(res.status).toBe(401);
   });
 
-  it("keeps the hard body limit before JSON parsing", async () => {
+  it("does not enforce the former hard body limit before JSON parsing", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
     });
     const { app, imageGeneration } = setup({ memoryAdmission });
 
     const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
 
-    expect(res.status).toBe(413);
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { type: "invalid_request_error", code: "request_too_large" },
-    });
-    expect(imageGeneration).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(imageGeneration).toHaveBeenCalledOnce();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("does not return OpenAI capacity 503 when historical request capacity is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
-      maxWireBytes: 1000,
       jsonAmplification: 1,
     });
     const { app, imageGeneration } = setup({ memoryAdmission });
@@ -227,7 +222,6 @@ describe("registerImagesRoute", () => {
   it("releases its memory lease after a successful image request", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1000,
-      maxWireBytes: 1000,
       jsonAmplification: 1,
     });
     const { app } = setup({ memoryAdmission });
@@ -239,7 +233,6 @@ describe("registerImagesRoute", () => {
   it("releases its memory lease when image JSON is malformed", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1000,
-      maxWireBytes: 1000,
       jsonAmplification: 1,
     });
     const { app } = setup({ memoryAdmission });

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -272,14 +272,8 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
       admitted?.materialized();
     } catch (error) {
       if (error instanceof RequestAdmissionError) {
-        if (error.status === 503) c.header("retry-after", "1");
-        return errorJson(
-          c,
-          error.status,
-          error.status === 413 ? "invalid_request_error" : "server_error",
-          error.message,
-          error.code,
-        );
+        c.header("retry-after", "1");
+        return errorJson(c, error.status, "server_error", error.message, error.code);
       }
       return errorJson(c, 400, "invalid_request_error", "malformed image request body");
     }

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -186,28 +186,23 @@ describe("registerInteractionsRoute", () => {
     expect(json.id).not.toBe("int_client-controlled-trace");
   });
 
-  it("keeps the hard body limit before JSON parsing", async () => {
+  it("does not enforce the former hard body limit before JSON parsing", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
     });
     const { app, nativePassthrough } = setup({ memoryAdmission });
 
     const res = await post(app, { model: "gemini-3.1-flash-image", input: "a red apple" });
 
-    expect(res.status).toBe(413);
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { status: "INVALID_ARGUMENT" },
-    });
-    expect(nativePassthrough).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(nativePassthrough).toHaveBeenCalledOnce();
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("does not return Gemini capacity 503 when historical request capacity is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
-      maxWireBytes: 1000,
       jsonAmplification: 1,
     });
     const { app, nativePassthrough } = setup({ memoryAdmission });
@@ -222,7 +217,6 @@ describe("registerInteractionsRoute", () => {
   it("releases its memory lease after a successful interactions request", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1000,
-      maxWireBytes: 1000,
       jsonAmplification: 1,
     });
     const { app } = setup({ memoryAdmission });
@@ -236,7 +230,6 @@ describe("registerInteractionsRoute", () => {
   it("releases its memory lease when interactions JSON is malformed", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1000,
-      maxWireBytes: 1000,
       jsonAmplification: 1,
     });
     const { app } = setup({ memoryAdmission });

--- a/apps/gateway/src/routes/interactions.ts
+++ b/apps/gateway/src/routes/interactions.ts
@@ -270,13 +270,8 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
       raw = JSON.parse(requestJson);
     } catch (error) {
       if (error instanceof RequestAdmissionError) {
-        if (error.status === 503) c.header("retry-after", "1");
-        return errorJson(
-          c,
-          error.status,
-          error.message,
-          error.status === 413 ? "INVALID_ARGUMENT" : "UNAVAILABLE",
-        );
+        c.header("retry-after", "1");
+        return errorJson(c, error.status, error.message, "UNAVAILABLE");
       }
       return errorJson(c, 400, "malformed JSON request body", "INVALID_ARGUMENT");
     }

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -24,7 +24,6 @@ import {
   type ResponseWorkAdmission,
   type RouteOptions,
   resolveMemoryMode,
-  runtimeMemoryBudget,
   runtimeResponseWorkAdmission,
   UpstreamError,
 } from "@helm/core";
@@ -558,13 +557,13 @@ function nextSSEBoundary(buffer: string): { index: number; length: number } | nu
 }
 
 function assertNativeSSEFrameFits(frame: string, maxFrameBytes: number): void {
-  if (Buffer.byteLength(frame) <= maxFrameBytes) return;
+  if (maxFrameBytes === 0 || Buffer.byteLength(frame) <= maxFrameBytes) return;
   throw new UpstreamError("upstream_error", "upstream SSE frame exceeds the runtime memory budget");
 }
 
 export async function* splitSSEFrames(
   raw: AsyncIterable<string>,
-  maxFrameBytes = runtimeMemoryBudget().maxWireBytes,
+  maxFrameBytes = 0,
   workAdmission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
 ): AsyncIterable<RawSSEFrame> {
   const acquired = workAdmission.acquire(0);

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -245,10 +245,9 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/messages (Anthropic inbound)", () => {
-  it("keeps the hard body limit for message and count-token requests", async () => {
+  it("does not enforce the former hard body limit for message and count-token requests", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1024,
-      maxWireBytes: 1,
       jsonAmplification: 1,
     });
     const { deps, harness } = makeDeps({ memoryAdmission });
@@ -260,16 +259,15 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
         headers: AUTH,
         body: JSON.stringify(REQ_BODY),
       });
-      expect(res.status).toBe(413);
+      expect(res.status).toBe(200);
     }
-    expect(harness.order).toEqual(["auth", "auth"]);
+    expect(harness.order.filter((entry) => entry === "auth")).toHaveLength(2);
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
   it("does not return capacity 503 when the historical shared body budget is exhausted", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
-      maxWireBytes: 1024,
       jsonAmplification: 1,
     });
     const { deps, harness } = makeDeps({ memoryAdmission });

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -275,9 +275,9 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     return c.json(out.body as Record<string, unknown>, out.status as ContentfulStatusCode);
   };
   const sendAdmissionError = (c: Context<AppEnv>, error: RequestAdmissionError): Response => {
-    if (error.status === 503) c.header("retry-after", "1");
+    c.header("retry-after", "1");
     const out = anthropic.transformErrorOut({
-      error_class: error.status === 413 ? "invalid_request" : "lane_unavailable",
+      error_class: "lane_unavailable",
       message: error.message,
       trace_id: c.get("trace_id"),
     });

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -370,7 +370,7 @@ function hasResponsesOutput(raw: string | null | undefined): boolean {
 const defaultMemoryBudget = runtimeMemoryBudget();
 
 function captureBodyLimitBytes(deps: PayloadCaptureDeps): number {
-  return deps.captureBodyLimitBytes ?? defaultMemoryBudget.maxWireBytes;
+  return deps.captureBodyLimitBytes ?? defaultMemoryBudget.responseCaptureBytes;
 }
 
 function sessionCacheBytes(deps: PayloadCaptureDeps): number {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -241,10 +241,9 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/responses (OpenAI Responses inbound)", () => {
-  it("keeps the hard body limit before translation", async () => {
+  it("accepts a body larger than the former hard body limit", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
     });
     const { deps, order } = makeDeps({ memoryAdmission });
@@ -255,11 +254,9 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       body: JSON.stringify(REQ),
     });
 
-    expect(res.status).toBe(413);
-    expect((await res.json()) as unknown).toMatchObject({
-      error: { type: "invalid_request_error", code: "request_too_large" },
-    });
-    expect(order).toEqual(["auth"]);
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(order).toContain("auth");
     expect(memoryAdmission.reservedBytes).toBe(0);
   });
 
@@ -267,7 +264,6 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     const finish = deferred<void>();
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 1_000,
-      maxWireBytes: 1_000,
       jsonAmplification: 1,
       minRequestChargeBytes: 1,
     });

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { createBodyMemoryAdmission, readAdmittedRequestBody } from "./memory-admission.js";
 
-describe("body memory admission (hard wire limit, unlimited aggregate capacity)", () => {
+describe("body memory admission (unlimited body size and aggregate capacity)", () => {
   it("never rejects for active capacity, even when charge exceeds the historical pool", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
-      maxWireBytes: 100,
       jsonAmplification: 2,
       minRequestChargeBytes: 40,
     });
@@ -26,7 +25,6 @@ describe("body memory admission (hard wire limit, unlimited aggregate capacity)"
   it("blocks new acquires while paused so waitForIdle can drain active leases", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
     });
     const active = admission.acquire(5);
@@ -57,7 +55,6 @@ describe("body memory admission (hard wire limit, unlimited aggregate capacity)"
   it("tracks charge for bookkeeping but never returns capacity-busy", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
     });
     const first = admission.acquire(6);
@@ -73,7 +70,6 @@ describe("body memory admission (hard wire limit, unlimited aggregate capacity)"
   it("stops counting pending after materialize and still allows more acquires", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
-      maxWireBytes: 100,
       jsonAmplification: 2,
       minRequestChargeBytes: 10,
     });
@@ -95,10 +91,9 @@ describe("body memory admission (hard wire limit, unlimited aggregate capacity)"
     expect(admission.pendingBytes).toBe(0);
   });
 
-  it("keeps a deterministic hard wire limit without restoring capacity rejection", async () => {
+  it("admits a body larger than the former hard wire limit", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 120,
-      maxWireBytes: 20,
       jsonAmplification: 6,
     });
     const admitted = await readAdmittedRequestBody(
@@ -114,46 +109,35 @@ describe("body memory admission (hard wire limit, unlimited aggregate capacity)"
     admitted.release();
     expect(admission.reservedBytes).toBe(0);
 
-    await expect(
-      readAdmittedRequestBody(
-        new Request("http://helm.test/v1/responses", { method: "POST", body: "x".repeat(21) }),
-        admission,
-      ),
-    ).rejects.toMatchObject({ status: 413, code: "request_too_large" });
+    const large = await readAdmittedRequestBody(
+      new Request("http://helm.test/v1/responses", { method: "POST", body: "x".repeat(21) }),
+      admission,
+    );
+    expect(large.text).toBe("x".repeat(21));
+    large.release();
     expect(admission.reservedBytes).toBe(0);
   });
 
-  it("rejects Content-Length beyond the hard wire limit before reading", async () => {
+  it("admits Content-Length beyond the former hard wire limit", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
-    });
-    let canceled = false;
-    const body = new ReadableStream<Uint8Array>({
-      cancel() {
-        canceled = true;
-      },
     });
     const request = new Request("http://helm.test/v1/responses", {
       method: "POST",
       headers: { "content-length": "11" },
-      body,
-      duplex: "half",
-    } as RequestInit & { duplex: "half" });
-
-    await expect(readAdmittedRequestBody(request, admission)).rejects.toMatchObject({
-      status: 413,
-      code: "request_too_large",
+      body: "x".repeat(11),
     });
-    expect(canceled).toBe(true);
+
+    const admitted = await readAdmittedRequestBody(request, admission);
+    expect(admitted.text).toBe("x".repeat(11));
+    admitted.release();
     expect(admission.reservedBytes).toBe(0);
   });
 
   it("rejects readAdmittedRequestBody while paused for maintenance", async () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 60,
-      maxWireBytes: 10,
       jsonAmplification: 6,
     });
     admission.pause();
@@ -166,17 +150,13 @@ describe("body memory admission (hard wire limit, unlimited aggregate capacity)"
     expect(admission.reservedBytes).toBe(0);
   });
 
-  it("exposes and enforces the configured hard wire limit", () => {
+  it("does not enforce the legacy configured hard wire limit", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 1,
-      maxWireBytes: 1,
       jsonAmplification: 1,
     });
-    expect(admission.maxWireBytes).toBe(1);
-    expect(admission.acquire(2)).toMatchObject({
-      ok: false,
-      reason: "too_large",
-      cause: "wire_limit",
-    });
+    const acquired = admission.acquire(2);
+    expect(acquired.ok).toBe(true);
+    if (acquired.ok) acquired.lease.release();
   });
 });

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -4,31 +4,29 @@ import type { AppEnv } from "../app.js";
 /**
  * Request-body memory admission.
  *
- * Capacity and live-heap gates are intentionally disabled: they used heuristic
- * reservations that could reject healthy traffic. A deterministic per-request
- * wire limit remains so one authenticated client cannot OOM the whole gateway.
- * Lease bookkeeping remains so vacuum can `pause()` + `waitForIdle()`.
+ * Capacity, live-heap and per-request wire gates are intentionally disabled:
+ * they used heuristic reservations that rejected healthy traffic. Lease
+ * bookkeeping remains so vacuum can `pause()` + `waitForIdle()`.
  *
  * The other remaining rejection is **maintenance pause**: while vacuum (or any
  * caller) has paused admission, new acquires fail with `database_maintenance`
  * so in-flight leases can drain and `waitForIdle()` can complete.
  */
 
-export type RequestAdmissionCause = "wire_limit" | "paused";
+export type RequestAdmissionCause = "paused";
 
 export interface RequestAdmissionSnapshot {
   cause: RequestAdmissionCause;
   wireBytes: number;
   requestedChargeBytes: number;
-  maxWireBytes: number;
   activeReservedBytes: number;
   pendingBytes: number;
 }
 
 export class RequestAdmissionError extends Error {
   constructor(
-    readonly status: 413 | 503,
-    readonly code: "request_too_large" | "database_maintenance",
+    readonly status: 503,
+    readonly code: "database_maintenance",
     message: string,
     readonly admission?: RequestAdmissionSnapshot,
   ) {
@@ -39,7 +37,6 @@ export class RequestAdmissionError extends Error {
 
 export function createBodyMemoryAdmission(options: {
   activeRequestBytes: number;
-  maxWireBytes: number;
   jsonAmplification: number;
   minRequestChargeBytes?: number;
 }) {
@@ -64,24 +61,21 @@ export function createBodyMemoryAdmission(options: {
   ) =>
     ({
       ok: false as const,
-      reason: cause === "wire_limit" ? ("too_large" as const) : ("busy" as const),
+      reason: "busy" as const,
       cause,
       admission: {
         cause,
         wireBytes,
         requestedChargeBytes,
-        maxWireBytes: options.maxWireBytes,
         activeReservedBytes: reservedBytes,
         pendingBytes,
       } satisfies RequestAdmissionSnapshot,
     }) as const;
 
   return {
-    maxWireBytes: options.maxWireBytes,
     acquire(wireBytes: number) {
       const held = charge(wireBytes);
       if (paused) return rejection("paused", wireBytes, held);
-      if (wireBytes > options.maxWireBytes) return rejection("wire_limit", wireBytes, held);
       reservedBytes += held;
       pendingBytes += held;
       let released = false;
@@ -97,9 +91,6 @@ export function createBodyMemoryAdmission(options: {
             // In-flight leases may still grow while maintenance is paused so the
             // current body/frame can finish; only *new* acquires are rejected.
             const next = charge(nextWireBytes);
-            if (nextWireBytes > options.maxWireBytes) {
-              return rejection("wire_limit", nextWireBytes, next);
-            }
             reservedBytes += next - current;
             pendingBytes += next - current;
             current = next;
@@ -158,25 +149,13 @@ declare module "hono" {
   }
 }
 
-export function requestAdmissionError(
-  cause: RequestAdmissionCause,
-  maxWireBytes: number,
-  admission?: RequestAdmissionSnapshot,
-  subject = "request body",
-) {
-  return cause === "wire_limit"
-    ? new RequestAdmissionError(
-        413,
-        "request_too_large",
-        `${subject} exceeds the hard limit of ${maxWireBytes} bytes`,
-        admission,
-      )
-    : new RequestAdmissionError(
-        503,
-        "database_maintenance",
-        "database maintenance in progress",
-        admission,
-      );
+export function requestAdmissionError(admission?: RequestAdmissionSnapshot) {
+  return new RequestAdmissionError(
+    503,
+    "database_maintenance",
+    "database maintenance in progress",
+    admission,
+  );
 }
 
 export async function readAdmittedRequestBody(
@@ -191,7 +170,7 @@ export async function readAdmittedRequestBody(
   const acquired = admission.acquire(initialBytes);
   if (!acquired.ok) {
     await request.body?.cancel().catch(() => {});
-    throw requestAdmissionError(acquired.cause, admission.maxWireBytes, acquired.admission);
+    throw requestAdmissionError(acquired.admission);
   }
   const { lease } = acquired;
   const chunks: Uint8Array[] = [];
@@ -203,18 +182,11 @@ export async function readAdmittedRequestBody(
         const next = await reader.read();
         if (next.done) break;
         bytes += next.value.byteLength;
-        const resized = lease.resize(bytes);
-        if (!resized.ok) {
-          await reader.cancel().catch(() => {});
-          throw requestAdmissionError(resized.cause, admission.maxWireBytes, resized.admission);
-        }
+        lease.resize(bytes);
         chunks.push(next.value);
       }
     }
-    const resized = lease.resize(bytes);
-    if (!resized.ok) {
-      throw requestAdmissionError(resized.cause, admission.maxWireBytes, resized.admission);
-    }
+    lease.resize(bytes);
     const body = Buffer.concat(chunks, bytes);
     return {
       text: body.toString("utf8"),

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1832,28 +1832,25 @@ export async function buildServer(
   const backgroundTasks = createTrackedBackgroundTasks();
   const requestBodyMemoryAdmission = createBodyMemoryAdmission({
     activeRequestBytes: memoryBudget.activeRequestBytes,
-    maxWireBytes: memoryBudget.maxWireBytes,
     jsonAmplification: memoryBudget.jsonAmplification,
     minRequestChargeBytes: memoryBudget.minRequestChargeBytes,
   });
   const websocketIngressAdmission = createBodyMemoryAdmission({
     activeRequestBytes: memoryBudget.websocketIngressBytes,
-    maxWireBytes: memoryBudget.websocketMaxPayloadBytes,
     jsonAmplification: 1,
     minRequestChargeBytes: 1,
   });
   logger.log("info", "runtime.memory_budget", {
     heap_limit_bytes: memoryBudget.heapLimitBytes,
     process_limit_bytes: memoryBudget.processLimitBytes,
-    request_admission_mode: "wire_limit_only",
-    max_wire_bytes: memoryBudget.maxWireBytes,
+    request_admission_mode: "unlimited",
     write_queue_bytes: memoryBudget.writeQueueBytes,
     session_cache_bytes: memoryBudget.sessionCacheBytes,
     response_capture_bytes: memoryBudget.responseCaptureBytes,
     sse_tail_chars: memoryBudget.sseTailChars,
     sqlite_page_cache_bytes: memoryBudget.sqlitePageCacheBytes,
     sqlite_maintenance_cache_bytes: memoryBudget.sqliteMaintenanceCacheBytes,
-    websocket_max_payload_bytes: memoryBudget.websocketMaxPayloadBytes,
+    websocket_max_payload_bytes: 0,
   });
   const config = loadConfig({ configDir: opts.configDir ?? "./config" });
   // Validate the optional Grok proxy protocol override before opening stores or

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-07-28 · 删除 HTTP 与 WebSocket 请求大小上限（Gateway runtime / Deployment，docs/02/05/07/10，用户明确要求）
+
+- **决定**：删除由 `activeRequestBytes / JSON_AMPLIFICATION` 推导的共享 wire 上限；HTTP 请求体不再执行 `wire_limit` 拒绝，Responses/Realtime 和上游 Codex WebSocket 的 `ws.maxPayload` 使用 `0`（无限制），HTTP/SSE 响应读取也不再复用该请求上限。原先约 25.8 MiB 的隐藏上限会把约 31 MiB 的 Codex 上下文压缩请求表现成 HTTP 413 或 `websocket closed by server before response.completed`。
+- **部署边界**：Remote Nginx 必须同步使用 `client_max_body_size 0`，不能以 100 MiB 替代已删除的应用限制。鉴权、schema 校验、maintenance drain、provider timeout、正文留存边界和缓存/写队列预算不变。
+
 ## 2026-07-28 · 消除 preflight/registry 内存放大并让自动 VACUUM 只在空闲启动（Gateway / OAuth / Store，docs/02/05/07/10，原则 1/3/7/8）
 
 - **连接超时根因**：Responses WebSocket 的内部 models preflight 原先没有独立 deadline，也没有把 socket/request abort 贯穿 models、OAuth token、catalog/cache 与上游 fetch；现在 versioned 与 auth-only fallback 各有 6 秒边界，bridge 对内部 fetch Promise 做硬 race，即使 Store/鉴权忽略 signal 也会终止握手并取消晚到 body；断连同样立即取消，避免辅助目录阻断 101 或永久占住维护 activity。相同账号的 TokenManager 在 models 请求间复用，首次 Store 读取 singleflight，等待者可取消；共享 preset refresh 不接受单个等待者取消，但底层 fetch 固定在 30 秒内终止且 settled gate 会清理。
@@ -70,14 +75,9 @@
 - **握手错误正文**：一旦上游已经返回非 101 HTTP response，关闭 `ws` 的 opening-handshake socket timeout，改由既有的有界 response-body timeout 接管；避免两个同期限时器竞争，把确定性 timeout 偶发误报为 generic body failure。正文大小上限、socket 销毁与客户端错误形状保持不变。
 - **安全边界**：`ws.maxPayload` 继续按运行时机器容量动态限制单帧，超限仍以 1009/413 失败；活动消息超过 native ingress 池仍返回结构化 503，超过共享请求池也继续拒绝。没有新增固定连接数、队列、配置或依赖；定向测试同时覆盖“第三条空闲连接可建立”和“第三条并发活动消息被预算拒绝”。
 
-## 2026-07-23 · PostgreSQL API-key 分布式并发 lease（Phase 1，docs/06/10，原则 1/3/7）
-
-- **一致性边界**：仅 `supabase`/PostgreSQL 使用 state-row `FOR UPDATE` + DB `clock_timestamp()` 的 lease 表实现跨 replica 上限；SQLite 保持既有 process-local FIFO。statement-time clock 避免等待 row lock 后仍使用事务开始时间；lease 过期回收不依赖 Node clock，也不维护独立 active counter。
-- **本地调度边界**：每 replica/key 只让本地队首轮询 DB；默认 TTL 30s、heartbeat 10s，失败轮询使用可注入的 100–250ms jitter。manager 同时以 DB 返回 `expiresAtMs` 和本地 RPC 开始时间 + TTL 的较早值作为 ownership deadline，防止 acquire/renew 响应延迟或挂起越过已知租期。renew 失败使持有者 signal 以 `concurrency_lease_lost` abort，release 为 async/idempotent best-effort，gateway 将它与 client abort/request timeout 合并；流 lease 到 body final close/cancel 才释放。shutdown 会等待正在进行的 acquire，并在返回前清理 late-success orphan。
-- **真实 PG 验收**：`apps/gateway/e2e/concurrency-postgres.spec.ts` 用两个独立 postgres-js pool、两个 distributed manager 和两个请求级 Hono app 验证 100 并发全局上限、key 隔离、TTL crash recovery、heartbeat、lease-loss no-cooldown、stream final/cancel 与 DB-unavailable 503。`pnpm test:e2e` 的 launcher 按 `PG_TEST_URL` > `HELM_TEST_POSTGRES_URL` 取外部测试库；无 URL 时自动启动 digest-pinned PostgreSQL 17 + pgvector 并 finally 清理，Docker 不可用则明确失败。PGlite 仍只算 SQL/contract coverage，不计真实多 pool AC。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-23 · PostgreSQL API-key 分布式并发 lease**：PostgreSQL 用 DB 时钟和 state-row lease 实现跨 replica 并发上限、心跳与 crash recovery，真实多 pool e2e 作为验收边界；完整原文通过 git history 回溯。
 - **2026-07-23 · Session 恢复与在线响应共享内存池**：Admin Session 恢复单次最多占 response-work 池一半，保留在线响应容量并坚持先准入后物化；完整原文通过 git history 回溯。
 - **2026-07-27 · 请求内存准入只计算未物化 headroom**：曾修 live-heap 双重计账误拒 503；后被同日“拆除启发式请求内存拒绝并保留硬边界”取代，完整原文通过 git history 回溯。
 - **2026-07-23 · Codex Responses 按运行时容量准入并让夜间 SQLite 维护收缩内存（Gateway / Session / Store，docs/02/05/07/10，原则 2/3/7/8）**：机器推导的共享请求/响应/缓存预算、活动消息准入和维护 drain 保留正文捕获与自动维护能力；后续物化重复计账、WebSocket ingress 与 terminal 生命周期修正见顶部更新条目，完整原文通过 git history 回溯。

--- a/packages/core/src/protocol/streaming.ts
+++ b/packages/core/src/protocol/streaming.ts
@@ -1,6 +1,5 @@
 import { Buffer } from "node:buffer";
 import { UpstreamError } from "../provider/openai.js";
-import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
 import {
   type ResponseWorkAdmission,
   runtimeResponseWorkAdmission,
@@ -39,7 +38,7 @@ export interface SSEFrame {
 }
 
 function assertSSEFrameFits(frame: string, maxFrameBytes: number): void {
-  if (Buffer.byteLength(frame) <= maxFrameBytes) return;
+  if (maxFrameBytes === 0 || Buffer.byteLength(frame) <= maxFrameBytes) return;
   throw new UpstreamError("upstream_error", "upstream SSE frame exceeds the runtime memory budget");
 }
 
@@ -78,7 +77,7 @@ function parseFrame(block: string): SSEFrame | null {
  */
 export async function* readSSE(
   stream: ReadableStream<Uint8Array>,
-  maxFrameBytes = runtimeMemoryBudget().maxWireBytes,
+  maxFrameBytes = 0,
   workAdmission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
 ): AsyncIterable<SSEFrame> {
   const reader = stream.getReader();

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import { transformRequestOut as anthropicToIRRequest } from "../protocol/anthropic/request.js";
-import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
 import type { CodexModelInfo } from "./oauth/codex-model-info.js";
 import { UpstreamError } from "./openai.js";
 import {
@@ -3450,31 +3449,6 @@ describe("createCodexResponsesClient — nativePassthrough", () => {
     expect(out).toEqual(upstream);
   });
 
-  it.each([
-    "nativePassthrough",
-    "responsesCompact",
-  ] as const)("maps an oversized unary %s body into fallback-eligible UpstreamError", async (method) => {
-    const limit = runtimeMemoryBudget().maxWireBytes;
-    const client = createCodexResponsesClient({
-      config: {
-        baseUrl: "https://chatgpt.com/backend-api/codex",
-        getAuthHeader: async () => `Bearer ${jwt("acct")}`,
-      },
-      fetch: (async () =>
-        new Response("{}", { headers: { "content-length": String(limit + 1) } })) as typeof fetch,
-    });
-
-    const run =
-      method === "nativePassthrough"
-        ? client.nativePassthrough?.(nativeBody())
-        : client.responsesCompact?.(nativeBody());
-    await expect(run).rejects.toMatchObject({
-      errorClass: "upstream_error",
-      upstreamStatus: null,
-      providerRaw: { error: { code: "response_body_too_large", limit_bytes: limit } },
-    });
-  });
-
   it("throws UpstreamError with upstreamStatus + scrubbed body on a non-2xx", async () => {
     const token = jwt("acct_secret_value_1234");
     const client = createCodexResponsesClient({
@@ -3782,30 +3756,6 @@ describe("createCodexResponsesClient — passthrough methods are defined (pool f
 });
 
 describe("createGenericOpenAIResponsesClient — native passthrough", () => {
-  it("maps every JSON unary Responses endpoint over the dynamic body budget to UpstreamError", async () => {
-    const limit = runtimeMemoryBudget().maxWireBytes;
-    const client = createGenericOpenAIResponsesClient({
-      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-test" },
-      fetch: (async () =>
-        new Response("{}", { headers: { "content-length": String(limit + 1) } })) as typeof fetch,
-    });
-    const expectTooLarge = (run: Promise<unknown> | undefined) =>
-      expect(run).rejects.toMatchObject({
-        errorClass: "upstream_error",
-        upstreamStatus: null,
-        providerRaw: { error: { code: "response_body_too_large", limit_bytes: limit } },
-      });
-
-    await expectTooLarge(client.chatCompletion({ model: "m", messages: [] }));
-    await expectTooLarge(client.nativePassthrough?.({ model: "m", input: [] }));
-    await expectTooLarge(client.responsesRetrieve?.("resp_1"));
-    await expectTooLarge(client.responsesDelete?.("resp_1"));
-    await expectTooLarge(client.responsesCancel?.("resp_1"));
-    await expectTooLarge(client.responsesInputItems?.("resp_1"));
-    await expectTooLarge(client.responsesCompact?.({ model: "m", input: [] }));
-    await expectTooLarge(client.responsesInputTokens?.({ model: "m", input: [] }));
-  });
-
   it("injects default native instructions when the opt-in contract requires them", async () => {
     let seenBody: Record<string, unknown> = {};
     const client = createGenericOpenAIResponsesClient({

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -27,7 +27,6 @@ import {
   consumeResponseTextWithinBudget,
   ResponseBodyTooLargeError,
 } from "../runtime/bounded-response.js";
-import { runtimeMemoryBudget } from "../runtime/memory-budget.js";
 import { ResponseWorkCapacityError } from "../runtime/response-work-admission.js";
 import {
   type PreparedNativePassthroughRequest,
@@ -1417,11 +1416,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     consume: (text: string) => T | Promise<T>,
   ): Promise<T> {
     try {
-      return await consumeResponseTextWithinBudget(
-        result.response,
-        runtimeMemoryBudget().maxWireBytes,
-        consume,
-      );
+      return await consumeResponseTextWithinBudget(result.response, 0, consume);
     } catch (err) {
       if (result.bodyTimeout?.isTimeout() && !result.bodyTimeout.isExternalAbort()) {
         throw new UpstreamError("timeout", "upstream request timed out");
@@ -2333,17 +2328,13 @@ export function createGenericOpenAIResponsesClient(
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await consumeResponseTextWithinBudget(
-      res,
-      runtimeMemoryBudget().maxWireBytes,
-      (text) => {
-        try {
-          return scrub(JSON.parse(text));
-        } catch {
-          return scrub(text);
-        }
-      },
-    ).catch(() => null);
+    const providerRaw = await consumeResponseTextWithinBudget(res, 0, (text) => {
+      try {
+        return scrub(JSON.parse(text));
+      } catch {
+        return scrub(text);
+      }
+    }).catch(() => null);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
@@ -2356,7 +2347,7 @@ export function createGenericOpenAIResponsesClient(
     try {
       return await consumeResponseTextWithinBudget(
         res,
-        runtimeMemoryBudget().maxWireBytes,
+        0,
         (text) => JSON.parse(text) as Record<string, unknown>,
       );
     } catch (error) {

--- a/packages/core/src/runtime/bounded-response.test.ts
+++ b/packages/core/src/runtime/bounded-response.test.ts
@@ -47,6 +47,15 @@ describe("readResponseTextWithinBudget", () => {
     ).toBe(body);
   });
 
+  it("treats zero as unlimited", async () => {
+    await expect(
+      readResponseTextWithinBudget(
+        new Response("unread", { headers: { "content-length": "6" } }),
+        0,
+      ),
+    ).resolves.toBe("unread");
+  });
+
   it("holds the shared amplified reservation through consumption and releases it", async () => {
     const admission = createResponseWorkAdmission({
       capacityBytes: 12,

--- a/packages/core/src/runtime/bounded-response.ts
+++ b/packages/core/src/runtime/bounded-response.ts
@@ -18,6 +18,7 @@ export class ResponseBodyTooLargeError extends Error {
 }
 
 function exceedsBudget(contentLength: string | null, maxBytes: number): boolean {
+  if (maxBytes === 0) return false;
   if (contentLength === null || !/^\d+$/.test(contentLength)) return false;
   const bytes = Number(contentLength);
   return !Number.isSafeInteger(bytes) || bytes > maxBytes;
@@ -72,7 +73,7 @@ export async function consumeResponseTextWithinBudget<T>(
         if (done) break;
         if (!value) continue;
         totalBytes += value.byteLength;
-        if (totalBytes > maxBytes) {
+        if (maxBytes > 0 && totalBytes > maxBytes) {
           await reader.cancel().catch(() => {});
           throw new ResponseBodyTooLargeError(maxBytes);
         }

--- a/packages/core/src/runtime/memory-budget.test.ts
+++ b/packages/core/src/runtime/memory-budget.test.ts
@@ -18,7 +18,6 @@ describe("deriveRuntimeMemoryBudget", () => {
 
     expect(large.activeRequestBytes).toBe(small.activeRequestBytes * 2);
     expect(large.responseWorkBytes).toBe(small.responseWorkBytes * 2);
-    expect(large.maxWireBytes).toBe(small.maxWireBytes * 2);
     expect(
       Math.abs(large.minRequestChargeBytes - small.minRequestChargeBytes * 2),
     ).toBeLessThanOrEqual(1);
@@ -37,9 +36,6 @@ describe("deriveRuntimeMemoryBudget", () => {
     expect(
       Math.abs(large.websocketIngressBytes - small.websocketIngressBytes * 2),
     ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs(large.websocketMaxPayloadBytes - small.websocketMaxPayloadBytes * 2),
-    ).toBeLessThanOrEqual(1);
   });
 
   it("uses rss plus available memory as the process limit without cgroup constraints", () => {
@@ -53,7 +49,6 @@ describe("deriveRuntimeMemoryBudget", () => {
 
     expect(budget.processLimitBytes).toBe(2_000);
     expect(budget.websocketIngressBytes).toBeGreaterThan(0);
-    expect(budget.websocketMaxPayloadBytes).toBeGreaterThan(0);
   });
 
   it("ignores the no-limit sentinel returned by process.constrainedMemory", () => {
@@ -85,7 +80,7 @@ describe("deriveRuntimeMemoryBudget", () => {
     expect(busy.websocketIngressBytes).toBeLessThan(quiet.websocketIngressBytes);
   });
 
-  it("shrinks websocket max payload to native headroom and fails closed only at zero", () => {
+  it("does not derive a websocket payload limit from native headroom", () => {
     const narrow = deriveRuntimeMemoryBudget({
       heapLimitBytes: 1_000,
       constrainedMemoryBytes: 1_050,
@@ -100,10 +95,7 @@ describe("deriveRuntimeMemoryBudget", () => {
     });
 
     expect(narrow.websocketIngressBytes).toBeGreaterThan(0);
-    expect(narrow.websocketMaxPayloadBytes).toBe(narrow.websocketIngressBytes);
-    expect(narrow.websocketMaxPayloadBytes).toBeLessThan(narrow.maxWireBytes);
     expect(none.websocketIngressBytes).toBe(0);
-    expect(none.websocketMaxPayloadBytes).toBe(0);
   });
 
   it("uses the tighter process capacity for every runtime allocation", () => {
@@ -123,16 +115,12 @@ describe("deriveRuntimeMemoryBudget", () => {
     expect(budget.sqlitePageCacheBytes).toBe(Math.floor(budget.processLimitBytes * 0.03));
   });
 
-  it("admits the production-proven request at the observed constrained heap capacity", () => {
+  it("keeps managed allocations within the observed process capacity", () => {
     const budget = deriveRuntimeMemoryBudget({
       heapLimitBytes: 706_740_224,
       constrainedMemoryBytes: 706_740_224,
     });
 
-    expect(budget.maxWireBytes).toBeGreaterThanOrEqual(22_020_096);
-    expect(budget.responseWorkBytes).toBeGreaterThanOrEqual(
-      budget.maxWireBytes * budget.jsonAmplification,
-    );
     expect(
       budget.activeRequestBytes +
         budget.responseWorkBytes +

--- a/packages/core/src/runtime/memory-budget.ts
+++ b/packages/core/src/runtime/memory-budget.ts
@@ -8,7 +8,6 @@ export interface RuntimeMemoryBudget {
   jsonAmplification: number;
   activeRequestBytes: number;
   responseWorkBytes: number;
-  maxWireBytes: number;
   minRequestChargeBytes: number;
   writeQueueBytes: number;
   sessionCacheBytes: number;
@@ -17,7 +16,6 @@ export interface RuntimeMemoryBudget {
   sqlitePageCacheBytes: number;
   sqliteMaintenanceCacheBytes: number;
   websocketIngressBytes: number;
-  websocketMaxPayloadBytes: number;
 }
 
 export function deriveRuntimeMemoryBudget(input: {
@@ -51,7 +49,6 @@ export function deriveRuntimeMemoryBudget(input: {
   const responseCaptureBytes = Math.floor(allocationLimitBytes * 0.06);
   const sqlitePageCacheBytes = Math.floor(processLimitBytes * 0.03);
   const sqliteMaintenanceCacheBytes = Math.floor(sqlitePageCacheBytes / 4);
-  const maxWireBytes = Math.floor(activeRequestBytes / JSON_AMPLIFICATION);
   const hasNativeMeasurement = hasConstrainedLimit || hasAvailableMemory;
   const heapTotalBytes = Math.min(
     rssBytes,
@@ -95,7 +92,6 @@ export function deriveRuntimeMemoryBudget(input: {
     jsonAmplification: JSON_AMPLIFICATION,
     activeRequestBytes,
     responseWorkBytes,
-    maxWireBytes,
     minRequestChargeBytes: Math.max(1, Math.floor(activeRequestBytes * 0.01)),
     writeQueueBytes,
     sessionCacheBytes,
@@ -104,7 +100,6 @@ export function deriveRuntimeMemoryBudget(input: {
     sqlitePageCacheBytes,
     sqliteMaintenanceCacheBytes,
     websocketIngressBytes,
-    websocketMaxPayloadBytes: Math.min(maxWireBytes, websocketIngressBytes),
   };
 }
 


### PR DESCRIPTION
## Summary
- remove the heap-derived HTTP wire limit and its 413 path
- set Responses, Realtime, and upstream Codex WebSocket payload limits to unlimited
- stop reusing the request wire budget for HTTP/SSE response reads
- report request admission mode as unlimited

## Verification
- CI=true pnpm exec vitest run --no-file-parallelism (15 affected files, 538 tests)
- CI=true pnpm typecheck
- CI=true pnpm lint
- CI=true pnpm build

## Deployment
- set Remote Nginx client_max_body_size to 0 during rollout so the edge does not retain the old 100 MiB limit