### PR TITLE
Release v0.28.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.21",
+  "version": "0.28.22",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- release the request-size and WebSocket payload-limit removal from PR #660
- bump the Helm API version to 0.28.22

## Verification

- PR #660 CI: typecheck, lint, build, unit, e2e, and Docker smoke passed
- release diff is limited to the root package version