### PR TITLE
[codex] harden production cleanup, writes, OAuth refresh, and diagnostics

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -357,7 +357,7 @@ describe('toDetail', () => {
     expect(d.cost_breakdown.total_usd).toBeCloseTo(0.01);
   });
 
-  it('surfaces a failed attempt error_detail (status + message + raw body); null elsewhere', () => {
+  it('surfaces complete provider diagnostics; null elsewhere', () => {
     const raw = rawRecord();
     // The first attempt failed at the upstream but the second served — so this
     // detail is the only record of WHY the first failed.
@@ -365,12 +365,18 @@ describe('toDetail', () => {
       upstream_status: 429,
       message: 'upstream returned 429',
       provider_raw: { error: { message: 'rate limit exceeded' } },
+      provider_headers: { 'x-request-id': 'req_upstream_1' },
+      cause: { code: 'ECONNRESET', message: 'socket closed' },
+      stack: 'UpstreamError: upstream returned 429',
     };
     const d = toDetail(raw);
     expect(d.provider_attempts[0]?.error_detail).toEqual({
       upstream_status: 429,
       message: 'upstream returned 429',
       provider_raw: { error: { message: 'rate limit exceeded' } },
+      provider_headers: { 'x-request-id': 'req_upstream_1' },
+      cause: { code: 'ECONNRESET', message: 'socket closed' },
+      stack: 'UpstreamError: upstream returned 429',
     });
     // The ok attempt carries no detail.
     expect(d.provider_attempts[1]?.error_detail ?? null).toBeNull();

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -115,13 +115,14 @@ export interface SessionView {
   source: string;
 }
 
-// Redacted per-attempt upstream failure detail (admin-debug-error-detail).
-// Present only for an attempt that failed at the upstream; the backend has
-// already key-scrubbed `provider_raw` (Principle 7), so this is safe to display.
+// Complete credential-safe per-attempt upstream failure detail.
 export interface AttemptErrorDetail {
   upstream_status: number | null; // real upstream HTTP status (e.g. 429); null for timeout/network
-  message: string; // redacted, human-readable
-  provider_raw: unknown; // upstream error body (redacted), or null
+  message: string;
+  provider_raw: unknown;
+  provider_headers: Record<string, string> | null;
+  cause: unknown;
+  stack: string | null;
 }
 
 export interface ProviderAttempt {
@@ -233,6 +234,9 @@ interface RawAttempt {
     upstream_status?: number | null;
     message?: string;
     provider_raw?: unknown;
+    provider_headers?: Record<string, string> | null;
+    cause?: unknown;
+    stack?: string | null;
   } | null;
 }
 
@@ -370,6 +374,9 @@ function attemptErrorDetail(a: RawAttempt): AttemptErrorDetail | null {
     upstream_status: typeof d.upstream_status === 'number' ? d.upstream_status : null,
     message: typeof d.message === 'string' ? d.message : '',
     provider_raw: d.provider_raw ?? null,
+    provider_headers: d.provider_headers ?? null,
+    cause: d.cause ?? null,
+    stack: typeof d.stack === 'string' ? d.stack : null,
   };
 }
 

--- a/apps/admin/src/lib/components/DecisionChain.svelte
+++ b/apps/admin/src/lib/components/DecisionChain.svelte
@@ -275,8 +275,8 @@
               >{/if}
           </div>
           <!-- Expandable upstream failure detail for THIS attempt — the only
-               record of WHY a candidate failed when a later one served. Already
-               redacted by the backend (Principle 7). -->
+               record of WHY a candidate failed when a later one served. The backend
+               removes credentials but keeps diagnostic body/headers/cause/stack. -->
           {#if a.error_detail}
             {@const ed = a.error_detail}
             <details
@@ -288,10 +288,15 @@
                   ? ` · HTTP ${ed.upstream_status}`
                   : ''}{ed.message ? ` — ${ed.message}` : ''}
               </summary>
-              {#if ed.provider_raw !== null && ed.provider_raw !== undefined}
+              {#if ed.provider_raw !== null || ed.provider_headers !== null || ed.cause !== null || ed.stack !== null}
                 <pre
                   class="mt-1 max-h-64 overflow-auto whitespace-pre-wrap break-all text-red-900">{showRaw(
-                    ed.provider_raw,
+                    {
+                      body: ed.provider_raw,
+                      headers: ed.provider_headers,
+                      cause: ed.cause,
+                      stack: ed.stack,
+                    },
                   )}</pre>
               {:else}
                 <p class="mt-1 italic text-ink-muted">{$t('No raw upstream body recorded.')}</p>

--- a/apps/admin/src/lib/components/DecisionChain.test.ts
+++ b/apps/admin/src/lib/components/DecisionChain.test.ts
@@ -59,6 +59,9 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
           upstream_status: 429,
           message: 'upstream returned 429',
           provider_raw: { error: { message: 'rate limit exceeded', type: 'rate_limit_error' } },
+          provider_headers: { 'x-request-id': 'req_upstream_1' },
+          cause: { code: 'ECONNRESET', message: 'socket closed' },
+          stack: 'UpstreamError: upstream returned 429',
         },
       },
       {
@@ -303,7 +306,7 @@ describe('DecisionChain', () => {
     expect(within(rows[2]).getByTitle('capability_unsatisfiable')).toBeInTheDocument();
   });
 
-  it('exposes a failed attempt error_detail (upstream status + message + raw body) as an expandable panel', () => {
+  it('exposes complete provider diagnostics as an expandable panel', () => {
     render(DecisionChain, { detail: detail() });
     const attempts = screen.getByTestId('chain-attempts');
     const rows = within(attempts).getAllByTestId('attempt-row');
@@ -312,8 +315,11 @@ describe('DecisionChain', () => {
     expect(detailEl).toBeInTheDocument();
     expect(detailEl).toHaveTextContent('429');
     expect(detailEl).toHaveTextContent('upstream returned 429');
-    // The redacted raw upstream body is shown (already key-scrubbed by backend).
+    // The credential-safe raw upstream body is shown.
     expect(detailEl).toHaveTextContent('rate limit exceeded');
+    expect(detailEl).toHaveTextContent('req_upstream_1');
+    expect(detailEl).toHaveTextContent('ECONNRESET');
+    expect(detailEl).toHaveTextContent('UpstreamError');
     // A successful attempt has no detail panel.
     expect(within(rows[1]).queryByTestId('attempt-error-detail')).toBeNull();
   });

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -552,7 +552,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         createdAt: new Date(),
       };
       if (deps.writes !== undefined) {
-        deps.writes.enqueueTelemetry(input);
+        await deps.writes.enqueueTelemetry(input);
         await queueOrPersistSessionRequest(
           deps,
           {
@@ -602,7 +602,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       const capturedResponseJson = requestTimedOut(c) ? null : responseJson;
       if (deps.writes !== undefined) {
         if (!captureEnabled(deps)) return;
-        deps.writes.enqueuePayload({
+        await deps.writes.enqueuePayload({
           requestId,
           requestJson,
           responseJson: capturedResponseJson,
@@ -639,7 +639,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     const observeRetainedBytes = Buffer.byteLength(requestJson, "utf8");
     const runObserve = async (task: () => Promise<unknown>, wake = true) => {
       if (deps.writes !== undefined) {
-        deps.writes.enqueueTask(
+        await deps.writes.enqueueTask(
           async () => {
             await task();
           },

--- a/apps/gateway/src/routes/execute.errors.test.ts
+++ b/apps/gateway/src/routes/execute.errors.test.ts
@@ -2,7 +2,7 @@ import type { CircuitBreaker, ExecutionPlan, ProviderClient, ProviderRegistry } 
 import { createCircuitBreaker, UpstreamError } from "@helm/core";
 import type { CatalogEntry, InternalRequest } from "@helm/shared";
 import { describe, expect, it, vi } from "vitest";
-import { createExecute } from "./execute.js";
+import { createExecute, errorDetailOf } from "./execute.js";
 
 // Supplemental error/edge coverage for the gateway execution adapter. Pins the
 // branches execute.test.ts leaves open: the per-account user-message queue-timeout
@@ -351,5 +351,69 @@ describe("createExecute — error_detail provider_raw wrapping", () => {
     const out = await execute(plan(["a"]), req());
     const detail = out.attempts[0]?.error_detail;
     expect(detail?.provider_raw).toEqual({ code: "x", detail: "y" });
+  });
+
+  it("preserves bounded stack and nested transport causes without credentials", async () => {
+    const cause = Object.assign(new Error("getaddrinfo EAI_AGAIN api.example.test"), {
+      code: "EAI_AGAIN",
+      authorization: "Bearer must-not-survive",
+      x_proxy_authorization: "Basic proxy-must-not-survive",
+      x_google_api_key: "google-must-not-survive",
+      x_access_token: "oauth-must-not-survive",
+      token_count: 123,
+    });
+    cause.message =
+      "Authorization: Basic YmFzaWMtc2VjcmV0; Cookie: session=cookie-secret\ngetaddrinfo EAI_AGAIN api.example.test";
+    const error = new TypeError("fetch failed", { cause });
+    error.stack = `TypeError: fetch failed\n${"at retry (execute.ts:1:1)\n".repeat(800)}`;
+    const provider = {
+      chatCompletion: vi.fn().mockRejectedValue(error),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ a: "m-a" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["a"]), req());
+    const detail = out.attempts[0]?.error_detail;
+    expect(detail?.message).toBe("fetch failed");
+    expect(detail?.cause).toMatchObject({
+      name: "Error",
+      code: "EAI_AGAIN",
+      message: expect.stringContaining("getaddrinfo EAI_AGAIN api.example.test"),
+      authorization: "[redacted]",
+      x_proxy_authorization: "[redacted]",
+      x_google_api_key: "[redacted]",
+      x_access_token: "[redacted]",
+      token_count: 123,
+    });
+    expect(detail?.stack).toContain("TypeError: fetch failed");
+    expect(detail?.stack?.length).toBeLessThanOrEqual(16_384);
+    expect(JSON.stringify(detail)).not.toContain("must-not-survive");
+    expect(JSON.stringify(detail)).not.toContain("YmFzaWMtc2VjcmV0");
+    expect(JSON.stringify(detail)).not.toContain("cookie-secret");
+  });
+
+  it("bounds the complete nested diagnostic, not only each individual string", () => {
+    const providerRaw = Array.from({ length: 64 }, (_, row) =>
+      Object.fromEntries(
+        Array.from({ length: 64 }, (_, column) => [
+          `field_${row}_${column}`,
+          "diagnostic".repeat(64),
+        ]),
+      ),
+    );
+
+    const detail = errorDetailOf(
+      new UpstreamError("upstream_error", "large diagnostic", providerRaw, 502),
+    );
+
+    expect(Buffer.byteLength(JSON.stringify(detail))).toBeLessThanOrEqual(160 * 1024);
   });
 });

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1313,7 +1313,7 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.attempts[1]?.status).toBe("ok");
   });
 
-  it("captures per-attempt error_detail (upstream status + message + raw body) on a failed attempt", async () => {
+  it("captures complete per-attempt error_detail on a failed attempt", async () => {
     const rawBody = { error: { message: "rate limit exceeded", type: "rate_limit_error" } };
     const provider = {
       chatCompletion: vi
@@ -1342,6 +1342,9 @@ describe("createExecute — gateway execution adapter", () => {
       upstream_status: 429,
       message: "upstream returned 429",
       provider_raw: rawBody,
+      provider_headers: null,
+      cause: null,
+      stack: expect.stringContaining("UpstreamError: upstream returned 429"),
     });
     // ok / skipped rows must NOT carry a detail.
     expect(out.attempts[1]?.error_detail ?? null).toBeNull();

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1264,29 +1264,122 @@ function isReasoningHistoryRejection(err: unknown): boolean {
 // Coerce an already-scrubbed upstream error body into the schema's record|null
 // shape. A plain object passes through; a primitive/array (e.g. an HTML or text
 // error page) is wrapped so the detail is preserved, not silently dropped.
-function toRawRecord(raw: unknown): Record<string, unknown> | null {
+function toRawRecord(raw: unknown, budget: DiagnosticBudget): Record<string, unknown> | null {
   if (raw === null || raw === undefined) return null;
-  if (typeof raw === "object" && !Array.isArray(raw)) return raw as Record<string, unknown>;
-  return { raw };
+  const bounded = diagnosticValue(raw, budget);
+  if (typeof bounded === "object" && bounded !== null && !Array.isArray(bounded)) {
+    return bounded as Record<string, unknown>;
+  }
+  return { raw: bounded };
 }
 
-// Build the redacted per-attempt error_detail (admin-debug-error-detail) from a
-// genuine upstream failure. An UpstreamError carries the real upstream status,
-// a message, and the key-scrubbed body; any other error degrades to its message
-// with no status/body. The telemetry redact gate scrubs this again before it is
-// persisted (principle 7), so a key echoed in the body never survives.
+const DIAGNOSTIC_STRING_MAX = 16_384;
+const DIAGNOSTIC_COLLECTION_MAX = 64;
+const DIAGNOSTIC_TOTAL_STRING_MAX = 128 * 1024;
+const DIAGNOSTIC_NODE_MAX = 256;
+const CREDENTIAL_FIELD =
+  /^(authorization|(?:x[_-]?)?proxy[_-]?authorization|cookie|set[_-]?cookie|api[_-]?key|x[_-]?(?:goog(?:le)?[_-]?)?api[_-]?key|token|(?:x[_-]?)?access[_-]?token|refresh[_-]?token|id[_-]?token|password|client[_-]?secret|secret|credential)$/i;
+
+interface DiagnosticBudget {
+  remainingChars: number;
+  remainingNodes: number;
+}
+
+function diagnosticString(value: string, budget: DiagnosticBudget): string {
+  if (budget.remainingChars <= 0) return "[diagnostic truncated]";
+  const safe = value
+    .replace(
+      /\b(authorization|(?:x[_-]?)?proxy[_-]?authorization)\s*[:=]\s*(?:(?:Bearer|Basic)\s+)?(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;\r\n]+)/gi,
+      "$1=[redacted]",
+    )
+    .replace(/\b(cookie|set[_-]?cookie)\s*[:=]\s*[^\r\n]*/gi, "$1=[redacted]")
+    .replace(
+      /(api[_-]?key|x[_-]?(?:goog(?:le)?[_-]?)?api[_-]?key|token|(?:x[_-]?)?access[_-]?token|refresh[_-]?token|password|secret|credential)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;\r\n]+)/gi,
+      "$1=[redacted]",
+    );
+  const bounded = safe.slice(0, Math.min(DIAGNOSTIC_STRING_MAX, budget.remainingChars));
+  budget.remainingChars -= bounded.length;
+  return bounded;
+}
+
+function diagnosticValue(
+  value: unknown,
+  budget: DiagnosticBudget,
+  depth = 0,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (budget.remainingNodes <= 0) return "[node limit]";
+  budget.remainingNodes--;
+  if (typeof value === "string") return diagnosticString(value, budget);
+  if (value === null || typeof value !== "object") return value;
+  if (depth >= 6) return "[depth limit]";
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+
+  if (value instanceof Error) {
+    const out: Record<string, unknown> = {
+      name: value.name,
+      message: diagnosticString(value.message, budget),
+    };
+    const code = (value as Error & { code?: unknown }).code;
+    if (typeof code === "string" || typeof code === "number") out.code = code;
+    if (value.stack) out.stack = diagnosticString(value.stack, budget);
+    if (value.cause !== undefined)
+      out.cause = diagnosticValue(value.cause, budget, depth + 1, seen);
+    for (const [key, child] of Object.entries(value).slice(0, DIAGNOSTIC_COLLECTION_MAX)) {
+      out[key] = CREDENTIAL_FIELD.test(key)
+        ? "[redacted]"
+        : diagnosticValue(child, budget, depth + 1, seen);
+    }
+    return out;
+  }
+
+  if (Array.isArray(value)) {
+    const out: unknown[] = [];
+    for (const item of value.slice(0, DIAGNOSTIC_COLLECTION_MAX)) {
+      if (budget.remainingNodes <= 0 || budget.remainingChars <= 0) break;
+      out.push(diagnosticValue(item, budget, depth + 1, seen));
+    }
+    return out;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value).slice(0, DIAGNOSTIC_COLLECTION_MAX)) {
+    if (budget.remainingNodes <= 0 || budget.remainingChars <= 0) break;
+    out[key] = CREDENTIAL_FIELD.test(key)
+      ? "[redacted]"
+      : diagnosticValue(child, budget, depth + 1, seen);
+  }
+  return out;
+}
+
+// Build the credential-safe per-attempt error_detail. Keep status/body/headers and
+// transport cause/stack; remove only actual credentials before persistence.
 export function errorDetailOf(err: unknown): AttemptErrorDetail {
+  const budget: DiagnosticBudget = {
+    remainingChars: DIAGNOSTIC_TOTAL_STRING_MAX,
+    remainingNodes: DIAGNOSTIC_NODE_MAX,
+  };
+  const message = diagnosticString(err instanceof Error ? err.message : String(err), budget);
+  const stack = err instanceof Error && err.stack ? diagnosticString(err.stack, budget) : null;
+  const cause =
+    err instanceof Error && err.cause !== undefined ? diagnosticValue(err.cause, budget) : null;
   if (err instanceof UpstreamError) {
     return {
       upstream_status: err.upstreamStatus,
-      message: err.message,
-      provider_raw: toRawRecord(err.providerRaw),
+      message,
+      provider_raw: toRawRecord(err.providerRaw, budget),
+      provider_headers: toRawRecord(err.upstreamHeaders, budget) as Record<string, string> | null,
+      cause,
+      stack,
     };
   }
   return {
     upstream_status: null,
-    message: err instanceof Error ? err.message : String(err),
+    message,
     provider_raw: null,
+    provider_headers: null,
+    cause,
+    stack,
   };
 }
 

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -786,7 +786,7 @@ export function createMessagesPipeline(
       // amplification; inline mode remains unchanged.
       const runObserve = async (task: () => Promise<unknown>, wake = true): Promise<void> => {
         if (writes !== undefined) {
-          writes.enqueueTask(
+          await writes.enqueueTask(
             async () => {
               await task();
             },

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -1704,7 +1704,7 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     });
   });
 
-  it("charges retained Responses output to the persisted Session byte quota", async () => {
+  it("backpressures an oversized retained Responses output instead of dropping the Session", async () => {
     const upsertSessionRevision = vi.fn(async (_input: UpsertSessionRevisionInput) => {});
     const insert = vi.fn(async () => ({ id: "1" }));
     const telemetry = {
@@ -1747,6 +1747,6 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     );
     await writes.flush();
     expect(insert).toHaveBeenCalledOnce();
-    expect(upsertSessionRevision).not.toHaveBeenCalled();
+    expect(upsertSessionRevision).toHaveBeenCalledOnce();
   });
 });

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -610,7 +610,7 @@ export async function queueOrPersistSessionRequest(
   if (args.responseJson !== null && responseJson === null) log("session.response_limited");
   const boundedArgs = responseJson === args.responseJson ? args : { ...args, responseJson };
   if (deps.writes && sessionCaptureEnabled(deps) && args.decision.session?.label) {
-    deps.writes.enqueueSession(
+    await deps.writes.enqueueSession(
       () => persistSessionRequest(deps, boundedArgs, log),
       Buffer.byteLength(args.requestJson, "utf8") +
         (responseJson === null ? 0 : Buffer.byteLength(responseJson, "utf8")),
@@ -839,14 +839,14 @@ export async function recordServed(
   // independent of anything that touches the decision later.
   const w = deps.writes;
   if (w !== undefined) {
-    w.enqueueTelemetry({
+    await w.enqueueTelemetry({
       decision: redactDecisionForTelemetry(deps.redact, decision),
       apiKeyId: args.apiKeyId,
       createdAt: new Date(deps.now()),
     });
     await queueOrPersistSessionRequest(deps, sessionArgs, log);
     if (captureEnabled(deps)) {
-      w.enqueuePayload({
+      await w.enqueuePayload({
         requestId: args.requestId,
         requestJson: args.requestJson,
         responseJson,

--- a/apps/gateway/src/runtime/write-queue.test.ts
+++ b/apps/gateway/src/runtime/write-queue.test.ts
@@ -206,75 +206,118 @@ describe("createWriteQueue", () => {
     expect(sink.manyCalls).toBe(0); // no batch method available
   });
 
-  it("bounds depth: drops + logs under overflow, never throws", async () => {
+  it("backpressures telemetry at maxDepth and preserves every row", async () => {
     const sink = fakeSink();
     const logs: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    (sink.insertMany as ReturnType<typeof vi.fn>).mockImplementation(
+      async (inputs: InsertTelemetryInput[]) => {
+        await gate;
+        sink.inserts.push(...inputs);
+      },
+    );
     const q = createWriteQueue({
       telemetry: sink,
       log: (m) => logs.push(m),
       flushIntervalMs: 10_000,
       maxDepth: 2,
     });
-    expect(() => {
-      q.enqueueTelemetry(tele("a"));
-      q.enqueueTelemetry(tele("b"));
-      q.enqueueTelemetry(tele("c")); // over depth → drop, log
-      q.enqueueTelemetry(tele("d"));
-    }).not.toThrow();
+    await q.enqueueTelemetry(tele("a"));
+    await q.enqueueTelemetry(tele("b"));
+    let admitted = false;
+    const third = q.enqueueTelemetry(tele("c")).then(() => {
+      admitted = true;
+    });
+    await Promise.resolve();
+    expect(admitted).toBe(false);
+    expect(q.depth).toBe(2);
+
+    release();
+    await third;
     await q.flush();
-    expect(sink.inserts.length).toBeLessThanOrEqual(2);
-    expect(logs.some((l) => l.includes("overflow"))).toBe(true);
+    expect(sink.inserts.map((i) => (i.decision as { request_id: string }).request_id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(logs.some((line) => line.includes("overflow"))).toBe(false);
   });
 
-  it("drops new buffered writes when pending tasks already fill maxDepth", async () => {
+  it("serializes concurrent admissions so waking producers cannot stampede past maxDepth", async () => {
     const sink = fakeSink();
-    const logs: string[] = [];
     let release!: () => void;
-    const blocker = new Promise<void>((resolve) => {
+    const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
+    (sink.insertMany as ReturnType<typeof vi.fn>).mockImplementation(
+      async (inputs: InsertTelemetryInput[]) => {
+        await gate;
+        sink.inserts.push(...inputs);
+      },
+    );
     const q = createWriteQueue({
       telemetry: sink,
-      log: (m) => logs.push(m),
+      log: () => {},
       flushIntervalMs: 10_000,
       maxDepth: 1,
     });
 
-    q.enqueueTask(async () => {
-      await blocker;
-    });
-    q.enqueueTelemetry(tele("dropped-telemetry"));
-    q.enqueuePayload(payload("dropped-payload"));
+    await q.enqueueTelemetry(tele("a"));
+    const waiting = ["b", "c", "d"].map((id) => q.enqueueTelemetry(tele(id)));
+    await Promise.resolve();
+    expect(q.depth).toBe(1);
 
     release();
+    await Promise.all(waiting);
+    expect(q.depth).toBe(1);
     await q.flush();
-
-    expect(sink.inserts).toHaveLength(0);
-    expect(sink.payloadCalls).toHaveLength(0);
-    expect(logs.filter((l) => l.includes("overflow"))).toHaveLength(2);
+    expect(sink.inserts.map((i) => (i.decision as { request_id: string }).request_id)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
   });
 
-  it("sheds on the BYTE budget even when row depth is nowhere near maxDepth", async () => {
-    // Production payloads are 6-7MB each. A handful of them blows the heap long
-    // before the 10k-row maxDepth. The byte budget must trip on size, not count.
+  it("backpressures payloads on the byte budget and preserves every body", async () => {
     const sink = fakeSink();
     const logs: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    (sink.insertPayloads as ReturnType<typeof vi.fn>).mockImplementation(
+      async (inputs: InsertPayloadInput[]) => {
+        await gate;
+        sink.payloadCalls.push(...inputs);
+      },
+    );
     const q = createWriteQueue({
       telemetry: sink,
       log: (m) => logs.push(m),
       flushIntervalMs: 10_000,
-      maxDepth: 10_000, // far out of reach
-      maxBytes: 1_500, // one retained 600-char payload fits; two do not
-      flushBytes: 10_000_000, // park eager byte-flush so we observe shedding, not flushing
+      maxDepth: 10_000,
+      maxBytes: 1_500,
+      flushBytes: 10_000_000,
     });
 
-    q.enqueuePayload(bigPayload("p1", 600));
-    q.enqueuePayload(bigPayload("p2", 600)); // total would be 1200B > 1000 → shed oldest
+    await q.enqueuePayload(bigPayload("p1", 600));
+    let admitted = false;
+    const second = q.enqueuePayload(bigPayload("p2", 600)).then(() => {
+      admitted = true;
+    });
+    await Promise.resolve();
+    expect(admitted).toBe(false);
+    expect(q.depth).toBe(1);
 
+    release();
+    await second;
     await q.flush();
-    // Only the newest fits under budget; the older one was shed (not a row-count drop).
-    expect(sink.payloadCalls.map((p) => p.requestId)).toEqual(["p2"]);
-    expect(logs.some((l) => l.includes("overflow"))).toBe(true);
+    expect(sink.payloadCalls.map((p) => p.requestId)).toEqual(["p1", "p2"]);
+    expect(logs.some((line) => line.includes("overflow"))).toBe(false);
   });
 
   it("charges retained strings by worst-case V8 bytes instead of UTF-16 code units", async () => {
@@ -288,7 +331,7 @@ describe("createWriteQueue", () => {
       flushBytes: 10_000,
     });
 
-    q.enqueuePayload({
+    await q.enqueuePayload({
       requestId: "unicode",
       requestJson: "😀😀😀",
       responseJson: null,
@@ -297,51 +340,8 @@ describe("createWriteQueue", () => {
     });
     await q.flush();
 
-    expect(sink.payloadCalls).toHaveLength(0);
-    expect(logs).toContain("writequeue.overflow");
-  });
-
-  it("on byte overflow, sheds PAYLOAD (debug) first and keeps TELEMETRY (audit)", async () => {
-    const sink = fakeSink();
-    const q = createWriteQueue({
-      telemetry: sink,
-      log: () => {},
-      flushIntervalMs: 10_000,
-      maxDepth: 10_000,
-      maxBytes: 1_500,
-      flushBytes: 10_000_000,
-    });
-
-    q.enqueueTelemetry(tele("audit")); // cheap, must survive
-    q.enqueuePayload(bigPayload("debug-1", 600));
-    q.enqueuePayload(bigPayload("debug-2", 600)); // overflow → drop a payload, not the telemetry
-
-    await q.flush();
-    // Telemetry (audit) is preserved; a payload (debug料) was the one shed.
-    expect(sink.inserts.map((i) => (i.decision as { request_id: string }).request_id)).toEqual([
-      "audit",
-    ]);
-    expect(sink.payloadCalls.map((p) => p.requestId)).toEqual(["debug-2"]);
-  });
-
-  it("keeps the byte count accurate across push/shed: a stream of big payloads stays bounded", async () => {
-    // If the byte accounting under-counted on shed, the buffer would creep up and
-    // eventually exceed the budget without ever flushing — the OOM we're fixing.
-    const sink = fakeSink();
-    const q = createWriteQueue({
-      telemetry: sink,
-      log: () => {},
-      flushIntervalMs: 10_000,
-      maxDepth: 10_000,
-      maxBytes: 1_500,
-      flushBytes: 10_000_000, // never byte-flush; force the budget to hold via shedding alone
-    });
-
-    // 50 payloads of ~600B each: only ~one fits at a time under a 1KB budget.
-    for (let i = 0; i < 50; i++) q.enqueuePayload(bigPayload(`p${i}`, 600));
-
-    // depth never ran away (a single 600B row + headroom; certainly not 50).
-    expect(q.depth).toBeLessThanOrEqual(2);
+    expect(sink.payloadCalls.map((input) => input.requestId)).toEqual(["unicode"]);
+    expect(logs.some((line) => line.includes("overflow"))).toBe(false);
   });
 
   it("byte threshold (flushBytes) flushes early before a few rows balloon into a huge txn", async () => {
@@ -357,55 +357,11 @@ describe("createWriteQueue", () => {
       flushBytes: 1_000, // ~1KB → flush after the first big payload
     });
 
-    q.enqueuePayload(bigPayload("p1", 1_500)); // exceeds flushBytes alone → eager flush
+    await q.enqueuePayload(bigPayload("p1", 1_500)); // exceeds flushBytes alone → eager flush
     // Drain the in-flight threshold flush.
     await q.flush();
     expect(sink.payloadsManyCalls).toBeGreaterThanOrEqual(1);
     expect(sink.payloadCalls.map((p) => p.requestId)).toContain("p1");
-  });
-
-  it("counts IN-FLIGHT batches toward the byte budget so a stalled writer can't pile up unbounded memory", async () => {
-    // The OOM scenario this whole change exists to fix: the DB writer is blocked (4am
-    // VACUUM holds the write lock). doFlush hands batches to the write chain, but they
-    // still occupy the heap until the commit lands. Counting only the live buffer would
-    // let repeated flushBytes triggers queue unbounded 6-7MB batches behind the first
-    // blocked write. In-flight bytes must count toward maxBytes so admit() rejects once
-    // the cap is reached — otherwise the byte budget doesn't actually bound the heap.
-    let release!: () => void;
-    const gate = new Promise<void>((r) => {
-      release = r;
-    });
-    const received: string[] = [];
-    const stalled: WriteQueueTelemetry = {
-      insert: async () => ({ id: "x" }),
-      insertMany: async () => {},
-      insertPayload: async (i) => {
-        received.push(i.requestId);
-      },
-      insertPayloads: async (xs) => {
-        received.push(...xs.map((x) => x.requestId));
-        await gate; // writer is stalled until released
-      },
-    };
-    const logs: string[] = [];
-    const q = createWriteQueue({
-      telemetry: stalled,
-      log: (m) => logs.push(m),
-      flushIntervalMs: 10_000,
-      maxDepth: 10_000, // row backstop far out of reach — only bytes can gate
-      maxBytes: 2_000,
-      flushBytes: 500, // eager-flush each big payload into the (stalled) chain
-    });
-
-    // 100 × 600B payloads at a stalled writer. With in-flight accounting the budget
-    // trips and most are rejected; without it every one would flush and the heap balloon.
-    for (let i = 0; i < 100; i++) q.enqueuePayload(bigPayload(`p${i}`, 600));
-    expect(logs.filter((l) => l.includes("overflow")).length).toBeGreaterThan(0);
-
-    release();
-    await q.flush();
-    // Only a bounded prefix (~maxBytes worth) ever reached the writer — not all 100.
-    expect(received.length).toBeLessThanOrEqual(5);
   });
 
   it("runs admitted session writes fail-open on the deferred task chain", async () => {
@@ -417,7 +373,7 @@ describe("createWriteQueue", () => {
       flushIntervalMs: 10_000,
       maxBytes: 1_500,
     });
-    q.enqueueSession(async () => {
+    await q.enqueueSession(async () => {
       ran.push("session");
     }, 100);
     expect(q.depth).toBe(1);
@@ -426,7 +382,7 @@ describe("createWriteQueue", () => {
     expect(q.depth).toBe(0);
   });
 
-  it("charges retained task closures until they settle, then releases their dynamic budget", async () => {
+  it("backpressures retained tasks until capacity is free without dropping them", async () => {
     const sink = fakeSink();
     const logs: string[] = [];
     let release!: () => void;
@@ -443,7 +399,7 @@ describe("createWriteQueue", () => {
     });
     const ran: string[] = [];
 
-    q.enqueueTask(
+    await q.enqueueTask(
       async () => {
         await blocker;
         ran.push("first");
@@ -451,27 +407,29 @@ describe("createWriteQueue", () => {
       { retainedBytes: 100 },
     );
     await Promise.resolve(); // let the first task become active
-    q.enqueueTask(
-      async () => {
-        ran.push("rejected");
-      },
-      { retainedBytes: 100 },
-    );
-    expect(logs).toContain("writequeue.task_overflow");
+    let admitted = false;
+    const second = Promise.resolve(
+      q.enqueueTask(
+        async () => {
+          ran.push("second");
+        },
+        { retainedBytes: 100 },
+      ),
+    ).then(() => {
+      admitted = true;
+    });
+    await Promise.resolve();
+    expect(admitted).toBe(false);
+    expect(q.depth).toBe(1);
 
     release();
+    await second;
     await q.flush();
-    q.enqueueTask(
-      async () => {
-        ran.push("after-release");
-      },
-      { retainedBytes: 100 },
-    );
-    await q.flush();
-    expect(ran).toEqual(["first", "after-release"]);
+    expect(ran).toEqual(["first", "second"]);
+    expect(logs.some((line) => line.includes("overflow"))).toBe(false);
   });
 
-  it("sheds payload capture before admitting a retained side-effect task", async () => {
+  it("drains payload capture before admitting a retained side-effect task", async () => {
     const sink = fakeSink();
     const q = createWriteQueue({
       telemetry: sink,
@@ -481,8 +439,8 @@ describe("createWriteQueue", () => {
       flushBytes: 10_000,
     });
     const ran: string[] = [];
-    q.enqueuePayload(bigPayload("payload", 700));
-    q.enqueueTask(
+    await q.enqueuePayload(bigPayload("payload", 700));
+    await q.enqueueTask(
       async () => {
         ran.push("observe");
       },
@@ -490,10 +448,10 @@ describe("createWriteQueue", () => {
     );
     await q.flush();
     expect(ran).toEqual(["observe"]);
-    expect(sink.payloadCalls).toHaveLength(0);
+    expect(sink.payloadCalls.map((input) => input.requestId)).toEqual(["payload"]);
   });
 
-  it("rejects an oversized session without dropping audit telemetry", async () => {
+  it("admits one oversized session after draining prior audit telemetry", async () => {
     const sink = fakeSink();
     const logs: string[] = [];
     const ran: string[] = [];
@@ -503,31 +461,14 @@ describe("createWriteQueue", () => {
       flushIntervalMs: 10_000,
       maxBytes: 500,
     });
-    q.enqueueTelemetry(tele("audit"));
-    q.enqueueSession(async () => {
+    await q.enqueueTelemetry(tele("audit"));
+    await q.enqueueSession(async () => {
       ran.push("session");
     }, 1_000);
     await q.flush();
-    expect(ran).toEqual([]);
+    expect(ran).toEqual(["session"]);
     expect(sink.inserts).toHaveLength(1);
-    expect(logs).toContain("writequeue.session_overflow");
-  });
-
-  it("sheds full payload before admitting a semantic session transcript", async () => {
-    const sink = fakeSink();
-    const q = createWriteQueue({
-      telemetry: sink,
-      log: () => {},
-      flushIntervalMs: 10_000,
-      maxBytes: 1_500,
-      flushBytes: 10_000,
-    });
-    q.enqueueTelemetry(tele("audit"));
-    q.enqueuePayload(bigPayload("payload", 700));
-    q.enqueueSession(async () => {}, 400);
-    await q.flush();
-    expect(sink.inserts).toHaveLength(1);
-    expect(sink.payloadCalls).toHaveLength(0);
+    expect(logs.some((line) => line.includes("overflow"))).toBe(false);
   });
 
   it("stop() flushes pending writes and stops the timer", async () => {
@@ -559,6 +500,103 @@ describe("createWriteQueue", () => {
       sink.inserts.map((input) => (input.decision as { request_id: string }).request_id),
     ).toEqual(["before", "after"]);
     expect(logs).toContain("writequeue.paused");
+  });
+
+  it("persists admissions that started before the maintenance pause barrier", async () => {
+    const sink = fakeSink();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    (sink.insertMany as ReturnType<typeof vi.fn>).mockImplementation(
+      async (inputs: InsertTelemetryInput[]) => {
+        await gate;
+        sink.inserts.push(...inputs);
+      },
+    );
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxDepth: 1,
+    });
+    await q.enqueueTelemetry(tele("before"));
+    const waiting = [q.enqueueTelemetry(tele("queued-1")), q.enqueueTelemetry(tele("queued-2"))];
+    await Promise.resolve();
+
+    const paused = q.pauseAndFlush();
+    release();
+    await Promise.all([...waiting, paused]);
+    q.resume();
+    await q.enqueueTelemetry(tele("after"));
+    await q.flush();
+
+    expect(
+      sink.inserts.map((input) => (input.decision as { request_id: string }).request_id),
+    ).toEqual(["before", "queued-1", "queued-2", "after"]);
+  });
+
+  it("persists admissions that started before stop", async () => {
+    const sink = fakeSink();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    (sink.insertMany as ReturnType<typeof vi.fn>).mockImplementation(
+      async (inputs: InsertTelemetryInput[]) => {
+        await gate;
+        sink.inserts.push(...inputs);
+      },
+    );
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxDepth: 1,
+    });
+    await q.enqueueTelemetry(tele("before"));
+    const waiting = [q.enqueueTelemetry(tele("queued-1")), q.enqueueTelemetry(tele("queued-2"))];
+    await Promise.resolve();
+
+    const stopped = q.stop();
+    release();
+    await Promise.all([...waiting, stopped]);
+
+    expect(
+      sink.inserts.map((input) => (input.decision as { request_id: string }).request_id),
+    ).toEqual(["before", "queued-1", "queued-2"]);
+    expect(q.depth).toBe(0);
+  });
+
+  it("flush waits for queued admissions and persists them before returning", async () => {
+    const sink = fakeSink();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    (sink.insertMany as ReturnType<typeof vi.fn>).mockImplementation(
+      async (inputs: InsertTelemetryInput[]) => {
+        await gate;
+        sink.inserts.push(...inputs);
+      },
+    );
+    const q = createWriteQueue({
+      telemetry: sink,
+      log: () => {},
+      flushIntervalMs: 10_000,
+      maxDepth: 1,
+    });
+    await q.enqueueTelemetry(tele("a"));
+    const waiting = [q.enqueueTelemetry(tele("b")), q.enqueueTelemetry(tele("c"))];
+    const flushed = q.flush();
+    release();
+
+    await Promise.all([...waiting, flushed]);
+
+    expect(
+      sink.inserts.map((input) => (input.decision as { request_id: string }).request_id),
+    ).toEqual(["a", "b", "c"]);
+    expect(q.depth).toBe(0);
   });
 
   it("fires onTaskDrain ONLY for tasks flagged wakeOnSettle (inbound observe must not wake)", async () => {

--- a/apps/gateway/src/runtime/write-queue.ts
+++ b/apps/gateway/src/runtime/write-queue.ts
@@ -21,15 +21,13 @@ export interface WriteQueueDeps {
   // Flush a buffer eagerly once it reaches this many rows. Default 256.
   maxBatch?: number;
   // Hard cap on in-memory backlog (telemetry + payloads + queued tasks). Past it,
-  // the oldest buffered write is dropped (logged) so a write stall can never grow
-  // the heap without bound. Default 10_000.
+  // producers wait for the current bounded backlog to drain. Default 10_000.
   maxDepth?: number;
   // Hard cap on the in-memory BYTE footprint of the buffered inserts. The real OOM
   // risk isn't row count — a single payload is 6-7MB, so 10_000 rows × 7MB ≈ 70GB.
-  // Past this budget the queue sheds buffered writes (payload first — see
-  // shedBufferedWrite) so a downstream stall (e.g. the 4am VACUUM holding the write
-  // lock) can never balloon the heap. maxDepth stays as a row-count backstop; EITHER
-  // limit tripping triggers a shed/reject. Default scales from the V8 heap limit.
+  // Past this budget producers wait for the current backlog to drain, so a downstream
+  // stall (e.g. the 4am VACUUM holding the write lock) cannot balloon the heap or lose
+  // accepted work. maxDepth stays as a row-count backstop. Default scales from V8.
   maxBytes?: number;
   // Flush a buffer eagerly once its accumulated bytes reach this, so a few giant
   // payloads can't coalesce into a multi-hundred-MB single transaction (maxBatch=256
@@ -46,13 +44,13 @@ export interface WriteQueueDeps {
 
 export interface WriteQueue {
   // Defer a telemetry decision insert (batched, fail-open, runs after the response).
-  enqueueTelemetry(input: InsertTelemetryInput): void;
+  enqueueTelemetry(input: InsertTelemetryInput): Promise<void>;
   // Defer a payload upsert (batched, fail-open).
-  enqueuePayload(input: InsertPayloadInput): void;
+  enqueuePayload(input: InsertPayloadInput): Promise<void>;
   // Defer a session transcript write while charging the retained request body
-  // against the same byte/depth budget. Payload rows are shed first; if that is
-  // insufficient, the session write itself is rejected before audit telemetry.
-  enqueueSession(task: () => Promise<void>, bytes: number): void;
+  // against the same byte/depth budget. When full, admission waits for the bounded
+  // backlog instead of retaining another closure or dropping the transcript.
+  enqueueSession(task: () => Promise<void>, bytes: number): Promise<void>;
   // Defer a fail-open side-effect (memory observe, retention prune, …). Tasks run
   // sequentially in FIFO order, so callers can rely on inbound-before-outbound.
   // `wakeOnSettle` fires onTaskDrain after THIS task settles — set it only on the
@@ -61,10 +59,11 @@ export interface WriteQueue {
   enqueueTask(
     task: () => Promise<void>,
     opts?: { wakeOnSettle?: boolean; retainedBytes?: number },
-  ): void;
+  ): Promise<void>;
   // Drain everything currently buffered/queued and resolve when the DB has it.
   flush(): Promise<void>;
-  // Maintenance barrier: reject new deferred writes, then drain everything admitted.
+  // Maintenance barrier: reject new deferred writes, then drain everything whose
+  // admission started before the barrier.
   pauseAndFlush(): Promise<void>;
   resume(): void;
   // Stop the idle timer and flush once. Idempotent. For graceful shutdown.
@@ -93,14 +92,9 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
 
   let telemetryBuf: InsertTelemetryInput[] = [];
   let payloadBuf: InsertPayloadInput[] = [];
-  // Parallel byte-cost arrays kept in lock-step with the buffers above (same index =
-  // same row). We never re-stringify a buffered entry to weigh it: the cost is
-  // computed ONCE at enqueue (a cheap .length sum of the already-serialized JSON
-  // fields) and the running total is adjusted by +cost on push / -cost on
-  // shed|flush. That keeps backpressure O(1) amortized instead of turning the admit
-  // check into an O(buffer) CPU hotspot.
-  let telemetryBytes: number[] = [];
-  let payloadBytes: number[] = [];
+  // Costs are computed once at admission and accumulated until the whole buffer moves
+  // to the in-flight batch. No per-row cost arrays are needed because rows are never
+  // shed after admission.
   let bufferedBytes = 0;
   // Bytes that have been flushed into the write chain but whose commit hasn't landed
   // yet — they still occupy the heap (the batch closures retain them). Counted toward
@@ -108,6 +102,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   // let repeated flushes pile up unbounded batches behind the first blocked write.
   // Incremented at flush, released when each commit settles.
   let inFlightBytes = 0;
+  let inFlightDepth = 0;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
   let paused = false;
@@ -119,8 +114,14 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   let pendingTasks = 0;
   let pendingSessionBytes = 0;
   let pendingTaskBytes = 0;
+  // Serialize only the capacity check + append. Waiting work remains on the producing
+  // request's async frame; it is not appended to the bounded write/task chains until
+  // capacity is available.
+  let admissionTail: Promise<void> = Promise.resolve();
+  let pendingAdmissions = 0;
 
-  const depth = (): number => telemetryBuf.length + payloadBuf.length + pendingTasks;
+  const depth = (): number =>
+    telemetryBuf.length + payloadBuf.length + inFlightDepth + pendingTasks;
 
   // Cheap, allocation-free worst-case V8 estimate: retained JS strings may occupy
   // two bytes per UTF-16 code unit. Object/array overhead is small beside the bodies.
@@ -145,6 +146,10 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   // strings. Charge their wire-size estimate using the process-derived multiplier.
   const retainedTaskCost = (bytes: number): number =>
     Number.isFinite(bytes) && bytes > 0 ? Math.ceil(bytes * jsonAmplification) : 0;
+
+  // Awaited admission must not pull deferred better-sqlite3 work back onto the
+  // response path. Start side-effect tasks on the next event-loop turn.
+  const deferTask = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
   const clearTimer = (): void => {
     if (timer !== null) {
@@ -218,15 +223,15 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
     const pBatch = payloadBuf;
     telemetryBuf = [];
     payloadBuf = [];
-    telemetryBytes = [];
-    payloadBytes = [];
     // The bytes don't leave memory at flush — they move into the batch closures the
     // write chain retains until the commit lands. Move them from buffered → in-flight
     // (NOT zeroed) so admit() keeps counting them against maxBytes while the writer is
     // stalled; released when this batch's commit settles (success or failure).
     const flushedBytes = bufferedBytes;
+    const flushedDepth = tBatch.length + pBatch.length;
     bufferedBytes = 0;
     inFlightBytes += flushedBytes;
+    inFlightDepth += flushedDepth;
     writeChain = writeChain
       .then(async () => {
         await writeTelemetry(tBatch);
@@ -234,168 +239,155 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
       })
       .finally(() => {
         inFlightBytes -= flushedBytes;
+        inFlightDepth -= flushedDepth;
       });
     return writeChain;
   };
 
-  // Would admitting a row costing `incomingBytes` breach either limit? The row budget
-  // is checked LAGGING (depth already at the cap) to preserve the original row-shed
-  // behaviour; the byte budget is checked LOOKING-AHEAD over buffered + IN-FLIGHT +
-  // incoming, so a single oversized payload is shed against BEFORE it lands AND a
-  // stalled writer's queued-but-uncommitted batches still count — one 7MB row must not
-  // overshoot the budget, and a write stall must not pile up batches past the cap.
+  // Would admitting a row costing `incomingBytes` breach either limit? Both buffered
+  // and IN-FLIGHT batches count: flushing into a stalled write chain must not create an
+  // unbounded hidden queue of closures.
   const overBudget = (incomingBytes: number): boolean =>
     depth() >= maxDepth ||
     bufferedBytes + inFlightBytes + pendingSessionBytes + pendingTaskBytes + incomingBytes >
       maxBytes;
 
-  const shedPayload = (): boolean => {
-    if (payloadBuf.length === 0) return false;
-    payloadBuf.shift();
-    bufferedBytes -= payloadBytes.shift() ?? 0;
-    log("writequeue.overflow");
-    return true;
+  const waitForCapacity = async (incomingBytes: number): Promise<void> => {
+    while (overBudget(incomingBytes) && depth() > 0) {
+      // Backpressure stays on the producing request. Only already-admitted work lives
+      // in the queue; waiting producers do not append closures behind a stalled writer.
+      const currentTaskTail = taskChain;
+      await Promise.all([doFlush(), currentTaskTail]);
+    }
+    // One item may exceed the derived byte budget, but it is the only admitted item.
+    // Its body already exists on the request path; admitting exactly one avoids a
+    // deadlock while keeping the queue bounded by one item rather than an unbounded
+    // chain of oversized closures.
   };
 
-  // Drop the oldest buffered insert to relieve a depth/byte overflow. Tasks are never
-  // dropped mid-chain (they're already scheduled); only buffered inserts are shed.
-  // Priority: shed PAYLOAD (debug capture) before TELEMETRY (audit-critical). When a
-  // stall forces a choice we keep the decision record and sacrifice the verbatim body
-  // — and payloads are also where the bytes are (6-7MB each), so dropping them first
-  // reclaims the most heap per shed. Byte counts are decremented in lock-step so the
-  // running total never drifts.
-  const shedBufferedWrite = (): boolean => {
-    if (shedPayload()) return true;
-    if (telemetryBuf.length > 0) {
-      telemetryBuf.shift();
-      bufferedBytes -= telemetryBytes.shift() ?? 0;
-    } else {
-      return false;
+  const admit = async (incomingBytes: number, append: () => void): Promise<void> => {
+    // The uncontended hot path is synchronous: the check and append are one JS turn.
+    if (pendingAdmissions === 0 && !overBudget(incomingBytes)) {
+      append();
+      return;
     }
-    log("writequeue.overflow");
-    return true;
-  };
 
-  const admitBufferedWrite = (incomingBytes: number): boolean => {
-    if (!overBudget(incomingBytes)) return true;
-    // Keep shedding until BOTH limits clear (a single 7MB payload can blow the byte
-    // budget while many tiny rows blow the row budget). Stop if nothing is left to drop
-    // (the incoming write alone is larger than the whole budget).
-    while (overBudget(incomingBytes) && shedBufferedWrite()) {
-      /* shed until under budget or empty */
+    let release!: () => void;
+    const previous = admissionTail;
+    admissionTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    pendingAdmissions++;
+    await previous;
+    try {
+      if (overBudget(incomingBytes)) await waitForCapacity(incomingBytes);
+      append();
+    } finally {
+      pendingAdmissions--;
+      release();
     }
-    if (!overBudget(incomingBytes)) return true;
-    log("writequeue.overflow");
-    return false;
   };
 
   return {
-    enqueueTelemetry(input: InsertTelemetryInput): void {
+    async enqueueTelemetry(input: InsertTelemetryInput): Promise<void> {
       if (stopped) return;
       if (paused) {
         log("writequeue.paused");
         return;
       }
       const cost = telemetryCost(input);
-      if (!admitBufferedWrite(cost)) return;
-      telemetryBuf.push(input);
-      telemetryBytes.push(cost);
-      bufferedBytes += cost;
-      // Eager flush on EITHER the row threshold or the byte threshold, so neither a
-      // burst of rows nor a few giant rows can grow an oversized single transaction.
-      if (telemetryBuf.length >= maxBatch || bufferedBytes >= flushBytes) void doFlush();
-      else scheduleTimer();
+      await admit(cost, () => {
+        telemetryBuf.push(input);
+        bufferedBytes += cost;
+        // Eager flush on EITHER the row threshold or the byte threshold, so neither a
+        // burst of rows nor a few giant rows can grow an oversized single transaction.
+        if (telemetryBuf.length >= maxBatch || bufferedBytes >= flushBytes) void doFlush();
+        else scheduleTimer();
+      });
     },
 
-    enqueuePayload(input: InsertPayloadInput): void {
+    async enqueuePayload(input: InsertPayloadInput): Promise<void> {
       if (stopped) return;
       if (paused) {
         log("writequeue.paused");
         return;
       }
       const cost = payloadCost(input);
-      if (!admitBufferedWrite(cost)) return;
-      payloadBuf.push(input);
-      payloadBytes.push(cost);
-      bufferedBytes += cost;
-      if (payloadBuf.length >= maxBatch || bufferedBytes >= flushBytes) void doFlush();
-      else scheduleTimer();
+      await admit(cost, () => {
+        payloadBuf.push(input);
+        bufferedBytes += cost;
+        if (payloadBuf.length >= maxBatch || bufferedBytes >= flushBytes) void doFlush();
+        else scheduleTimer();
+      });
     },
 
-    enqueueSession(task: () => Promise<void>, bytes: number): void {
+    async enqueueSession(task: () => Promise<void>, bytes: number): Promise<void> {
       if (stopped) return;
       if (paused) {
         log("writequeue.paused");
         return;
       }
       const cost = retainedTaskCost(bytes);
-      while (overBudget(cost) && shedPayload()) {
-        /* payload is less valuable than a semantic session transcript */
-      }
-      if (overBudget(cost)) {
-        log("writequeue.session_overflow");
-        return;
-      }
-      pendingTasks++;
-      pendingSessionBytes += cost;
-      taskChain = taskChain.then(async () => {
-        try {
-          await task();
-        } catch {
-          log("writequeue.session_failed");
-        } finally {
-          pendingTasks--;
-          pendingSessionBytes -= cost;
-        }
+      await admit(cost, () => {
+        pendingTasks++;
+        pendingSessionBytes += cost;
+        taskChain = taskChain.then(async () => {
+          try {
+            await deferTask();
+            await task();
+          } catch {
+            log("writequeue.session_failed");
+          } finally {
+            pendingTasks--;
+            pendingSessionBytes -= cost;
+          }
+        });
       });
     },
 
-    enqueueTask(
+    async enqueueTask(
       task: () => Promise<void>,
       opts?: { wakeOnSettle?: boolean; retainedBytes?: number },
-    ): void {
+    ): Promise<void> {
       if (stopped) return;
       if (paused) {
         log("writequeue.paused");
         return;
       }
       const cost = retainedTaskCost(opts?.retainedBytes ?? 0);
-      while (overBudget(cost) && shedPayload()) {
-        /* payload capture is less valuable than a deferred semantic write */
-      }
-      if (overBudget(cost)) {
-        log("writequeue.task_overflow");
-        return;
-      }
       const wakeOnSettle = opts?.wakeOnSettle === true;
-      pendingTasks++;
-      pendingTaskBytes += cost;
-      taskChain = taskChain.then(async () => {
-        try {
-          await task();
-        } catch {
-          log("writequeue.task_failed");
-        } finally {
-          pendingTasks--;
-          pendingTaskBytes -= cost;
-          // Fire the post-task hook (memory-worker wake) ONLY for tasks that opted in
-          // — the turn's final/outbound observe. Waking after the inbound-only write
-          // could drain the observer job before the assistant turn is persisted.
-          // Fail-open: a throwing hook must never poison the FIFO chain.
-          if (wakeOnSettle && deps.onTaskDrain !== undefined) {
-            try {
-              deps.onTaskDrain();
-            } catch {
-              log("writequeue.on_task_drain_failed");
+      await admit(cost, () => {
+        pendingTasks++;
+        pendingTaskBytes += cost;
+        taskChain = taskChain.then(async () => {
+          try {
+            await deferTask();
+            await task();
+          } catch {
+            log("writequeue.task_failed");
+          } finally {
+            pendingTasks--;
+            pendingTaskBytes -= cost;
+            // Fire the post-task hook (memory-worker wake) ONLY for tasks that opted in
+            // — the turn's final/outbound observe. Waking after the inbound-only write
+            // could drain the observer job before the assistant turn is persisted.
+            // Fail-open: a throwing hook must never poison the FIFO chain.
+            if (wakeOnSettle && deps.onTaskDrain !== undefined) {
+              try {
+                deps.onTaskDrain();
+              } catch {
+                log("writequeue.on_task_drain_failed");
+              }
             }
           }
-        }
+        });
       });
     },
 
     async flush(): Promise<void> {
-      // Flush buffers into the write chain, then await both chains. Tasks never
-      // enqueue inserts, so a single drain pass settles everything.
+      // Let every producer already waiting on capacity finish admission first, then
+      // flush what they appended. Tasks never enqueue inserts, so one drain settles all.
+      await admissionTail;
       await doFlush();
       await writeChain;
       await taskChain;
@@ -404,6 +396,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
     async pauseAndFlush(): Promise<void> {
       paused = true;
       clearTimer();
+      await admissionTail;
       await doFlush();
       await writeChain;
       await taskChain;
@@ -416,6 +409,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
     async stop(): Promise<void> {
       stopped = true;
       clearTimer();
+      await admissionTail;
       await doFlush();
       await writeChain;
       await taskChain;

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -457,13 +457,17 @@ async function seedAnthropic(ctx: OAuthRuntimeCtx, account: string): Promise<voi
   });
 }
 
-async function seedXai(ctx: OAuthRuntimeCtx, account: string): Promise<void> {
+async function seedXai(
+  ctx: OAuthRuntimeCtx,
+  account: string,
+  expiresAt = FAR_FUTURE,
+): Promise<void> {
   await ctx.store.upsert({
     providerId: "xai",
     account,
     accessEnc: encryptSecret(`xai-access-${account}`, ENC_KEY),
     refreshEnc: encryptSecret(`xai-refresh-${account}`, ENC_KEY),
-    expiresAt: FAR_FUTURE,
+    expiresAt,
     meta: JSON.stringify({
       tokenEndpoint: "https://auth.x.ai/oauth2/token",
       accountId: `xai-user-${account}`,
@@ -528,6 +532,32 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     void task();
     return true;
   };
+
+  it("refreshes a subscription token before the request-timeout lease begins", async () => {
+    const { ctx, config } = oauthStores();
+    await seedXai(ctx, "lease", Date.now() + 90_000);
+    const refreshedAccess = codexJwt({ sub: "xai-user-lease", email: "lease@example.test" });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+      const target = String(url);
+      if (target === "https://auth.x.ai/oauth2/token") {
+        return Response.json({
+          access_token: refreshedAccess,
+          refresh_token: "xai-refresh-rotated",
+          expires_in: 3_600,
+        });
+      }
+      if (target.endsWith("/models")) {
+        expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${refreshedAccess}`);
+        return Response.json({
+          data: [{ id: "grok-4.5", apiBackend: "responses", streamToolCalls: true }],
+        });
+      }
+      throw new Error(`unexpected URL ${target}`);
+    });
+
+    await synthesizeOAuthProviders([], ctx, config, "https://fallback/v1", 60_000, noop);
+    expect(fetchMock).toHaveBeenCalledWith("https://auth.x.ai/oauth2/token", expect.any(Object));
+  });
 
   it("routes xAI subscription OAuth through the generic Responses proxy by default", async () => {
     const { ctx, config } = oauthStores();

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -43,6 +43,7 @@ import {
   discoverOAuthModels,
   type EmbeddingJob,
   encryptSecret,
+  executionTokenExpirySkewMs,
   expandLaneChain,
   expandOpenAICodexModelAliases,
   filterRetiredOpenAICodexLimits,
@@ -870,7 +871,7 @@ function buildOAuthAccountClient(
     targetProviderProtocol: spec.targetProviderProtocol,
     providerRequiresCompatibilityRewrite: spec.providerRequiresCompatibilityRewrite,
   } as unknown as ProviderConfigShared;
-  const cred = buildCredential(accountConfig, oauthCtx, proxy);
+  const cred = buildCredential(accountConfig, oauthCtx, proxy, base.timeoutMs);
   if (!cred) return null;
   // Stable per-account anti-ban identity (never rotates): Anthropic gets a
   // metadata.user_id; Codex a stable session_id. Both deterministic from
@@ -1014,6 +1015,7 @@ export async function synthesizeOAuthProviders(
         oauthProvider: provider,
         fetch: proxyFetch,
         now: () => Date.now(),
+        expirySkewMs: executionTokenExpirySkewMs(timeoutMs),
       });
       let accessToken: string;
       try {
@@ -1401,7 +1403,12 @@ export function buildCredential(
   // manager so a proxied account's token REFRESH leaves through the same hop as its
   // execution traffic — never the real IP (issue #38). undefined ⇒ direct.
   proxy?: ProxyConfig,
+  requestTimeoutMs?: number,
 ): ProviderCredential | null {
+  const executionSkew =
+    requestTimeoutMs === undefined
+      ? {}
+      : { expirySkewMs: executionTokenExpirySkewMs(requestTimeoutMs) };
   if (p.oauth) {
     const o = p.oauth;
     // ── PRESET subscription OAuth: credentials live in the OAuthTokenStore,
@@ -1418,6 +1425,7 @@ export function buildCredential(
         oauthProvider: provider,
         fetch: proxy ? makeProxyFetch(proxy) : undefined,
         now: () => Date.now(),
+        ...executionSkew,
       });
       return {
         getAuthHeader: () => tm.getAuthHeader(),
@@ -1444,6 +1452,7 @@ export function buildCredential(
         audience: o.audience,
       },
       now: () => Date.now(),
+      ...executionSkew,
     });
     return {
       getAuthHeader: () => tm.getAuthHeader(),
@@ -1480,7 +1489,7 @@ export function buildProviderClients(
   for (const p of providers) {
     const proxy = resolveProviderProxy(p, accountSettings);
     const fastMode = resolveProviderFastMode(p, accountSettings);
-    const cred = buildCredential(p, oauthCtx, proxy);
+    const cred = buildCredential(p, oauthCtx, proxy, timeoutMs);
     if (!cred) continue; // no credential → cannot build a client; skip.
     const baseUrl = p.base_url ?? fallbackBaseUrl;
     clients.set(
@@ -2256,13 +2265,13 @@ export async function buildServer(
   // a preset-OAuth primary must not leak the real IP on the eval/default/401 path
   // (issue #38). Reused at the createProviderClient call below.
   const primaryProxy = resolveProviderProxy(first, accountSettings);
-  const primaryCred = buildCredential(first, oauthCtx, primaryProxy);
+  const timeoutMs = config.runtime.request_timeout_ms;
+  const primaryCred = buildCredential(first, oauthCtx, primaryProxy, timeoutMs);
   // HELM_PROVIDER_BASE_URL (test/e2e) overrides EVERY provider's base_url so the
   // mock upstream serves all of them; otherwise each provider uses its own.
   const baseUrlOverride = process.env.HELM_PROVIDER_BASE_URL;
   const fallbackBaseUrl = baseUrlOverride ?? "https://api.openai.com/v1";
   const baseUrl = baseUrlOverride ?? first.base_url ?? fallbackBaseUrl;
-  const timeoutMs = config.runtime.request_timeout_ms;
 
   // Bound subscriptions become routable providers (issue #38, Stage 3). For each
   // routable subscription NOT declared in providers.yaml, synthesize a provider

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-07-29 · 生产韧性改为持续小批、无丢弃背压、执行 Token 租约与完整错误诊断（Store / Gateway / OAuth / Telemetry，docs/02/04/07/10/11，原则 1/3/5/7/8）
+
+- **SQLite 持续清理**：七类 SQLite retention mutation 统一为每批最多 10 行，满批后 `setImmediate` 让出事件循环，不再执行无界 DELETE。Session cleanup 先用既有 `head_request_id` 写入持久 prune claim，再按每批最多 10 个 revision 推进；进程中断后可继续完成，批间到达的同 Session 写入会等待过期链删完并以新 root 恢复。写入在真正落库的同步事务内再次检查 claim，关闭“先检查、await 让出、随后写进删除链”的竞态。该机制只减少未来增长和清理停顿，不替代整库重写；大库 `VACUUM` 仍必须由既有维护 drain 和低峰调度单独执行。
+- **写队列不再丢数据**：删除 `overflow`、`task_overflow`、`session_overflow` 的 OOM shedding；Telemetry、Payload、Session 与 Memory task 使用同一串行 admission 背压，已接受数据按 FIFO 落库。`flush`、maintenance pause 与 stop 都等待 admission tail 后再完成最终 drain，barrier 之前已开始等待的 admission 也会持久化；deferred task 下一事件循环才执行，避免 awaited admission 把同步 SQLite 写重新拉回请求关键路径。没有新增依赖或配置。
+- **执行 Token 租约**：OAuth Provider 统一保存上游真实 `expires`，不再在各 Provider 解析时篡改到期时间；执行 client 在 `request_timeout_ms` 之外保留 5 分钟提前刷新余量（默认共 6 分钟），Admin discovery/quota 保持既有 60 秒余量。网络、408/425/5xx 刷新失败会按账号稳定抖动等待 1–3 秒并重读共享 Store：只采用其他实例已经轮换出的有效 credential，绝不重放结果不确定的旧 rotating refresh token；Store 未变化时当前请求转健康兄弟账号，失败账号在本进程短冷却 30 秒后自动恢复。确定性凭证错误与 429 继续进入既有重连/限流分流。刷新后 Token 若覆盖不了整段租约就不用于请求，但先加密持久化旋转后的 refresh token；短租约账号不会被永久标记为凭证失效。
+- **完整但有界的错误诊断**：Provider HTTP/transport 错误保存 64 KiB body、16 KiB 非凭证 headers、嵌套 cause、16 KiB stack，并用 128 KiB/256 节点总预算防止诊断本身放大内存。Telemetry 不再因字段名含 `token` 就误隐藏 `token_count` 或 rate-limit token 指标；只过滤 API key、OAuth access/refresh/id token、Authorization、Cookie、密码和代理凭证。请求/响应正文仍遵守 `capture_payloads` / Session 留存边界，不塞进 DecisionRecord。
+
 ## 2026-07-28 · 删除 HTTP 与 WebSocket 请求大小上限（Gateway runtime / Deployment，docs/02/05/07/10，用户明确要求）
 
 - **决定**：删除由 `activeRequestBytes / JSON_AMPLIFICATION` 推导的共享 wire 上限；HTTP 请求体不再执行 `wire_limit` 拒绝，Responses/Realtime 和上游 Codex WebSocket 的 `ws.maxPayload` 使用 `0`（无限制），HTTP/SSE 响应读取也不再复用该请求上限。原先约 25.8 MiB 的隐藏上限会把约 31 MiB 的 Codex 上下文压缩请求表现成 HTTP 413 或 `websocket closed by server before response.completed`。
@@ -69,14 +76,9 @@
 
 - **根因与修复**：Admin 登录/登出的 CSRF 校验原本只比较 `Origin` 与请求 `Host` / `X-Forwarded-Host`；部分反向代理或 NAT 会把 `Host` 改成内部地址且不补 `X-Forwarded-Host`，导致浏览器从同一外部 origin 提交表单也稳定返回 403。校验现在优先接受浏览器提供的 `Sec-Fetch-Site: same-origin`，再保留原有 Host 比较与 opaque-origin 边界；`cross-site` 仍拒绝。该 header 不能由网页脚本伪造，而无 `Origin` 的非浏览器客户端原本就允许，因此不新增配置、代理白名单或信任任意 forwarded header。
 
-## 2026-07-24 · Responses WebSocket ingress 改为按活动消息计费（Gateway / Protocol，docs/02/05/07，原则 3/8）
-
-- **根因与修复**：机器推导的 native ingress 池原本在 Upgrade 时为每条连接预留一个完整最大帧，导致空闲/预热连接达到 `floor(ingressBytes / maxPayload)` 后稳定返回 503。Upgrade 现在只瞬时探测零容量或暂停状态，空闲连接不保留 ingress lease；收到 `response.create` 后按消息真实 wire bytes 申请 ingress 与既有 JSON amplification 两级预算，并在请求结束时一起释放。
-- **握手错误正文**：一旦上游已经返回非 101 HTTP response，关闭 `ws` 的 opening-handshake socket timeout，改由既有的有界 response-body timeout 接管；避免两个同期限时器竞争，把确定性 timeout 偶发误报为 generic body failure。正文大小上限、socket 销毁与客户端错误形状保持不变。
-- **安全边界**：`ws.maxPayload` 继续按运行时机器容量动态限制单帧，超限仍以 1009/413 失败；活动消息超过 native ingress 池仍返回结构化 503，超过共享请求池也继续拒绝。没有新增固定连接数、队列、配置或依赖；定向测试同时覆盖“第三条空闲连接可建立”和“第三条并发活动消息被预算拒绝”。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-24 · Responses WebSocket ingress 改为按活动消息计费**：空闲连接不再预留完整帧容量，活动 `response.create` 才按真实 wire/JSON bytes 申请并释放 ingress lease；上游非 101 body 统一由有界响应超时接管，完整原文通过 git history 回溯。
 - **2026-07-23 · PostgreSQL API-key 分布式并发 lease**：PostgreSQL 用 DB 时钟和 state-row lease 实现跨 replica 并发上限、心跳与 crash recovery，真实多 pool e2e 作为验收边界；完整原文通过 git history 回溯。
 - **2026-07-23 · Session 恢复与在线响应共享内存池**：Admin Session 恢复单次最多占 response-work 池一半，保留在线响应容量并坚持先准入后物化；完整原文通过 git history 回溯。
 - **2026-07-27 · 请求内存准入只计算未物化 headroom**：曾修 live-heap 双重计账误拒 503；后被同日“拆除启发式请求内存拒绝并保留硬边界”取代，完整原文通过 git history 回溯。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -683,6 +683,7 @@ export {
 export {
   type ConfidentialOAuth,
   createTokenManager,
+  executionTokenExpirySkewMs,
   oauthRefreshQueueDepth,
   type PresetOAuth,
   type ResolvedOAuth,

--- a/packages/core/src/provider/anthropic.test.ts
+++ b/packages/core/src/provider/anthropic.test.ts
@@ -2217,12 +2217,12 @@ describe("createAnthropicClient", () => {
     }
   });
 
-  it("retries a transient network error then re-throws it unchanged", async () => {
+  it("retries a transient network error then preserves its credential-safe cause", async () => {
     // The non-timeout catch arm: fetch rejects for a reason OTHER than the internal
     // abort. ECONNREFUSED is a transient connection error, so it is retried at the
     // fetch boundary ([0,0] backoff keeps the test instant); once the budget is
     // exhausted the ORIGINAL error propagates (executor treats it as a provider failure).
-    const boom = new Error("ECONNREFUSED");
+    const boom = Object.assign(new Error("ECONNREFUSED sk-static"), { code: "ECONNREFUSED" });
     const fetch = vi.fn(async () => {
       throw boom;
     });
@@ -2234,9 +2234,15 @@ describe("createAnthropicClient", () => {
       },
       fetch: fetch as unknown as typeof globalThis.fetch,
     });
-    await expect(
-      client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] }),
-    ).rejects.toBe(boom);
+    let caught: unknown;
+    try {
+      await client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(UpstreamError);
+    expect(JSON.stringify(caught)).not.toContain("sk-static");
+    expect(JSON.stringify(caught)).toContain("ECONNREFUSED");
     expect(fetch).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
   });
 

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -43,9 +43,12 @@ import {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   type ProviderClient,
+  readUpstreamErrorBody,
+  safeUpstreamHeaders,
   UpstreamError,
+  upstreamTransportError,
 } from "./openai.js";
-import { withConnectionRetry, withOverloadRetry } from "./retry.js";
+import { isFetchTransportError, withConnectionRetry, withOverloadRetry } from "./retry.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface AnthropicClientConfig {
@@ -1628,31 +1631,37 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
     // The overload wrapper sits OUTSIDE: a 529 answer is a valid Response (no throw), so
     // it re-issues the whole connection-retried attempt after a pause. Anthropic's 529 is
     // the single loudest source of this — a raw one here 502s the client for a blip.
-    const res = await withOverloadRetry(
-      () =>
-        withConnectionRetry(
-          async () => {
-            const t = withTimeout(timeoutMs, external);
-            try {
-              return await doFetch(endpointUrl, {
-                method: "POST",
-                headers: wireHeaders,
-                body: wireBody,
-                signal: t.signal,
-              });
-            } catch (err) {
-              if (t.isTimeout() && !t.isExternalAbort()) {
-                throw new UpstreamError("timeout", "upstream request timed out");
+    let res: Response;
+    try {
+      res = await withOverloadRetry(
+        () =>
+          withConnectionRetry(
+            async () => {
+              const t = withTimeout(timeoutMs, external);
+              try {
+                return await doFetch(endpointUrl, {
+                  method: "POST",
+                  headers: wireHeaders,
+                  body: wireBody,
+                  signal: t.signal,
+                });
+              } catch (err) {
+                if (t.isTimeout() && !t.isExternalAbort()) {
+                  throw new UpstreamError("timeout", "upstream request timed out");
+                }
+                throw err;
+              } finally {
+                t.cleanup();
               }
-              throw err;
-            } finally {
-              t.cleanup();
-            }
-          },
-          { retries: cfg.connectRetries, backoffMs: cfg.connectRetryBackoffMs, signal: external },
-        ),
-      { signal: external },
-    );
+            },
+            { retries: cfg.connectRetries, backoffMs: cfg.connectRetryBackoffMs, signal: external },
+          ),
+        { signal: external },
+      );
+    } catch (error) {
+      if (external?.aborted || !isFetchTransportError(error)) throw error;
+      throw upstreamTransportError(error, scrub);
+    }
     return toolNameMap ? { res, toolNameMap } : { res };
   }
 
@@ -1691,15 +1700,13 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await res
-      .json()
-      .catch(() => null)
-      .then(scrub);
+    const providerRaw = await readUpstreamErrorBody(res, scrub);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
       providerRaw,
       res.status,
+      scrub(safeUpstreamHeaders(res.headers)) as Record<string, string>,
     );
   }
 

--- a/packages/core/src/provider/gemini.test.ts
+++ b/packages/core/src/provider/gemini.test.ts
@@ -842,6 +842,29 @@ describe("createGeminiClient — scrub / currentSecrets", () => {
     );
     expect(JSON.stringify((caught as UpstreamError).providerRaw)).toContain("[redacted]");
   });
+
+  it("preserves transport causes without leaking the configured key", async () => {
+    const apiKey = "AIzaSy-transport-secret";
+    const client = createGeminiClient({
+      config: {
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey,
+      },
+      fetch: vi.fn(async () => {
+        throw Object.assign(new TypeError(`fetch failed ${apiKey}`), { code: "EAI_AGAIN" });
+      }),
+    });
+    let caught: unknown;
+    try {
+      await client.nativePassthrough?.({ model: "gemini-2.0-flash", contents: [] });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(UpstreamError);
+    expect(JSON.stringify(caught)).not.toContain(apiKey);
+    expect(JSON.stringify(caught)).toContain("EAI_AGAIN");
+  });
 });
 
 describe("createGeminiClient — 401 auth retry", () => {

--- a/packages/core/src/provider/gemini.ts
+++ b/packages/core/src/provider/gemini.ts
@@ -9,9 +9,12 @@ import {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   type ProviderClient,
+  readUpstreamErrorBody,
+  safeUpstreamHeaders,
   UpstreamError,
+  upstreamTransportError,
 } from "./openai.js";
-import { withOverloadRetry } from "./retry.js";
+import { isFetchTransportError, withOverloadRetry } from "./retry.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 // Resolve a hostname to its candidate addresses. Injectable so the SSRF guard can be
@@ -588,9 +591,14 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
     external?: AbortSignal,
     capture?: (wireBody: string) => void,
   ): Promise<Response> {
-    return withOverloadRetry(() => requestOnce(operation, input, external, capture), {
-      signal: external,
-    });
+    try {
+      return await withOverloadRetry(() => requestOnce(operation, input, external, capture), {
+        signal: external,
+      });
+    } catch (error) {
+      if (external?.aborted || !isFetchTransportError(error)) throw error;
+      throw upstreamTransportError(error, scrub);
+    }
   }
 
   async function requestWithAuthRetry(
@@ -609,22 +617,13 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await res
-      .text()
-      .then((text) => {
-        try {
-          return JSON.parse(text) as unknown;
-        } catch {
-          return text;
-        }
-      })
-      .catch(() => null)
-      .then(scrub);
+    const providerRaw = await readUpstreamErrorBody(res, scrub);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
       providerRaw,
       res.status,
+      scrub(safeUpstreamHeaders(res.headers)) as Record<string, string>,
     );
   }
 

--- a/packages/core/src/provider/oauth/anthropic.test.ts
+++ b/packages/core/src/provider/oauth/anthropic.test.ts
@@ -33,6 +33,19 @@ function captureAuth(): {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("refreshAnthropicToken — invalid JSON token body", () => {
+  it("stores the provider's real expiry without a provider-local skew", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ access_token: "a", refresh_token: "r", expires_in: 3600 })),
+    );
+
+    const creds = await refreshAnthropicToken("rtok");
+    expect(creds.expires).toBe(4_600_000);
+    vi.useRealTimers();
+  });
+
   it("throws a JSON-parse error when the token endpoint returns non-JSON", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/provider/oauth/anthropic.ts
+++ b/packages/core/src/provider/oauth/anthropic.ts
@@ -42,8 +42,6 @@ const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
 const CONSOLE_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback";
 const SCOPES =
   "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
-const REFRESH_SKEW_MS = 5 * 60 * 1000;
-
 interface CallbackServer {
   server: Server;
   cancelWait: () => void;
@@ -58,7 +56,7 @@ function parseTokenCredentials(responseBody: string): OAuthCredentials {
     throw new Error("Anthropic token response was not valid JSON");
   }
   const rec = (data ?? {}) as Record<string, unknown>;
-  const expires = resolveOAuthTokenExpiresAt(rec.expires_in, { refreshSkewMs: REFRESH_SKEW_MS });
+  const expires = resolveOAuthTokenExpiresAt(rec.expires_in);
   if (
     typeof rec.access_token !== "string" ||
     !rec.access_token ||

--- a/packages/core/src/provider/oauth/github-copilot.test.ts
+++ b/packages/core/src/provider/oauth/github-copilot.test.ts
@@ -57,6 +57,20 @@ describe("fetchJson error path (non-ok)", () => {
 });
 
 describe("refreshGitHubCopilotToken validation", () => {
+  it("stores the provider's real expiry without a provider-local skew", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({ token: "tid=x;proxy-ep=proxy.example.test;", expires_at: 4600 }),
+      ),
+    );
+
+    const creds = await refreshGitHubCopilotToken("gh");
+    expect(creds.expires).toBe(4_600_000);
+  });
+
   it("rejects a Copilot token response missing token/expires_at", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/provider/oauth/github-copilot.ts
+++ b/packages/core/src/provider/oauth/github-copilot.ts
@@ -32,8 +32,6 @@ export const COPILOT_HEADERS = {
 } as const;
 
 const REQUEST_TIMEOUT_MS = 30_000;
-const EPOCH_SKEW_MS = 5 * 60 * 1000;
-
 export function normalizeDomain(input: string): string | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
@@ -290,7 +288,7 @@ export async function refreshGitHubCopilotToken(
     fetchImpl,
   )) as Record<string, unknown>;
   const token = raw.token;
-  const expires = resolveExpiresAtMsFromEpochSeconds(raw.expires_at, { bufferMs: EPOCH_SKEW_MS });
+  const expires = resolveExpiresAtMsFromEpochSeconds(raw.expires_at);
   if (typeof token !== "string" || expires === undefined) {
     throw new Error("Invalid Copilot token response");
   }

--- a/packages/core/src/provider/oauth/openai-codex.test.ts
+++ b/packages/core/src/provider/oauth/openai-codex.test.ts
@@ -315,6 +315,25 @@ describe("credential validation + identity extraction", () => {
 });
 
 describe("refreshOpenAICodexToken", () => {
+  it("stores the provider's real expiry without a provider-local skew", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          access_token: codexJwt({}),
+          refresh_token: "new-rt",
+          expires_in: 3600,
+        }),
+      ),
+    );
+
+    const creds = await refreshOpenAICodexToken("old-rt");
+    expect(creds.expires).toBe(4_600_000);
+    vi.useRealTimers();
+  });
+
   it("sends a JSON refresh_token grant with NO client_secret and parses creds", async () => {
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
       expect(new Headers(init?.headers).get("Content-Type")).toBe("application/json");

--- a/packages/core/src/provider/oauth/openai-codex.ts
+++ b/packages/core/src/provider/oauth/openai-codex.ts
@@ -188,7 +188,7 @@ function postTokenJson(
 }
 
 function toCredentials(json: TokenResponseJson, previous?: OAuthCredentials): OAuthCredentials {
-  const expires = resolveOAuthTokenExpiresAt(json.expires_in, { refreshSkewMs: 5 * 60 * 1000 });
+  const expires = resolveOAuthTokenExpiresAt(json.expires_in);
   const access = nonEmptyString(json.access_token);
   const refresh = nonEmptyString(json.refresh_token) ?? previous?.refresh;
   if (!access || !refresh || expires === undefined) {

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1833,6 +1833,12 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
   const BAD = new UpstreamError("upstream_error", "bad request", null, 400);
   const REFRESH_401 = new TokenRefreshError("oauth refresh failed (openai-codex, status 401)", 401);
   const REFRESH_429 = new TokenRefreshError("oauth refresh rate-limited (status 429)", 429);
+  const SHORT_LEASE = new TokenRefreshError(
+    "oauth access token is shorter than required request lease",
+    null,
+    false,
+    true,
+  );
   const QUEUE_TIMEOUT = Object.assign(new Error("user message queue wait timed out"), {
     queueTimeout: true,
   });
@@ -2091,6 +2097,52 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "good" });
     expect(served).toEqual(["good", "good"]);
     expect(selected).toEqual(["bad", "good", "good"]); // bad stays cooled on the 2nd request
+  });
+
+  it("retries a sibling for a short token lease without permanently parking the account", async () => {
+    const served: string[] = [];
+    const selected: string[] = [];
+    const credentialFailures: string[] = [];
+    let now = 1_000;
+    const pool = createOAuthPoolClient({
+      members: [
+        faultMember("short", 10, served, SHORT_LEASE),
+        faultMember("good", 50, served, null),
+      ],
+      now: () => now,
+      onSelect: (account) => selected.push(account),
+      onAccountCredentialFailure: (account) => credentialFailures.push(account),
+    });
+
+    await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "good" });
+    await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "good" });
+    now += 60_000;
+    await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "good" });
+    expect(selected).toEqual(["short", "good", "good", "short", "good"]);
+    expect(credentialFailures).toEqual([]);
+  });
+
+  it("cools a refresh-failed account for streaming requests too", async () => {
+    const served: string[] = [];
+    const selected: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        faultMember("refreshing", 10, served, SHORT_LEASE),
+        faultMember("good", 50, served, null),
+      ],
+      now: () => 1_000,
+      onSelect: (account) => selected.push(account),
+    });
+
+    for await (const _chunk of pool.chatCompletionStream(REQ)) {
+      // drain
+    }
+    for await (const _chunk of pool.chatCompletionStream(REQ)) {
+      // drain
+    }
+
+    expect(selected).toEqual(["refreshing", "good", "good"]);
+    expect(served).toEqual(["good", "good"]);
   });
 
   it("a rate-limit park never SHORTENS a precise quota cooldown already set (extend-only)", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -37,6 +37,8 @@ import { CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER } from "../openai-responses.js
 import { TokenRefreshError } from "../token-manager.js";
 import { DEFAULT_429_COOLDOWN_MS } from "./usage-limit.js";
 
+const RETRYABLE_ACCOUNT_FAILURE_COOLDOWN_MS = 30_000;
+
 // Which PRE-FIRST-CHUNK failure justifies trying a SIBLING account in the same pool
 // before the executor advances to the next alias. A Codex (openai_responses + native
 // tools) request has NO valid cross-protocol fallback — every non-Responses alias is
@@ -84,6 +86,10 @@ function isCredentialAccountFailure(
 function isRateLimitAccountFailure(err: unknown): boolean {
   if (err instanceof TokenRefreshError) return err.httpStatus === 429;
   return err instanceof UpstreamError && err.upstreamStatus === 429;
+}
+
+function isRetryableAccountFailure(err: unknown): boolean {
+  return err instanceof TokenRefreshError && err.retryableAccountFailure;
 }
 
 // The per-account user-message queue reports backpressure with this structural flag.
@@ -241,6 +247,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     string,
     { account: string; model: string; limitId: string | null; untilMs: number }
   >();
+  const retryableAccountFailures = new Map<string, number>();
   const credentialFailureReported = new Set<string>();
   let selectionCounter = 0;
 
@@ -250,6 +257,14 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   function usageLimited(member: OAuthPoolMember, nowMs: number): boolean {
     const until = member.usageLimitedUntilMs;
     return until != null && nowMs < until;
+  }
+
+  function retryableAccountLimited(account: string, nowMs: number): boolean {
+    const until = retryableAccountFailures.get(account);
+    if (until === undefined) return false;
+    if (until > nowMs) return true;
+    retryableAccountFailures.delete(account);
+    return false;
   }
 
   function supportsModel(member: OAuthPoolMember, model: string | null): boolean {
@@ -423,6 +438,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         e.member.schedulable &&
         supportsModel(e.member, model) &&
         !usageLimited(e.member, nowMs) &&
+        !retryableAccountLimited(e.member.account, nowMs) &&
         !modelLimited(e.member.account, model, nowMs) &&
         !exclude?.has(e.member.account),
     );
@@ -876,6 +892,14 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     }
   }
 
+  function coolRetryableAccount(entry: PoolEntry): void {
+    retryableAccountFailures.set(
+      entry.member.account,
+      now() + RETRYABLE_ACCOUNT_FAILURE_COOLDOWN_MS,
+    );
+    forgetStickyAccount(entry.member.account, true);
+  }
+
   function rateLimitScope(
     entry: PoolEntry,
     err: unknown,
@@ -954,6 +978,12 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         rememberResponseAffinity(result, entry);
         return result;
       } catch (err) {
+        if (isRetryableAccountFailure(err)) {
+          coolRetryableAccount(entry);
+          if (statefulContinuation) throw err;
+          lastErr = err;
+          continue;
+        }
         if (isCredentialAccountFailure(err, credentialFailureStatuses)) {
           parkCredentialFailedAccount(entry, err);
           if (statefulContinuation) throw err;
@@ -1018,7 +1048,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         first = await iterator.next(); // pre-first-(real-)chunk fault surfaces HERE
       } catch (err) {
         if (iterator) await iterator.return?.().catch(() => {});
-        if (isCredentialAccountFailure(err, upstreamCredentialFailureStatuses)) {
+        if (isRetryableAccountFailure(err)) {
+          coolRetryableAccount(entry);
+          lastErr = err;
+        } else if (isCredentialAccountFailure(err, upstreamCredentialFailureStatuses)) {
           parkCredentialFailedAccount(entry, err);
           lastErr = err;
         } else if (isRateLimitAccountFailure(err)) {

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -3516,6 +3516,23 @@ describe("createCodexResponsesClient — nativePassthrough", () => {
     });
   });
 
+  it("preserves the bounded-body marker for an oversized Codex HTTP error", async () => {
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        connectRetries: 0,
+      },
+      fetch: vi.fn().mockResolvedValue(new Response("x".repeat(70_000), { status: 502 })),
+    });
+
+    await expect(client.nativePassthrough?.(nativeBody())).rejects.toMatchObject({
+      providerRaw: {
+        error: { code: "response_body_too_large", limit_bytes: 65_536 },
+      },
+    });
+  });
+
   it("preserves a client abort instead of wrapping it as an upstream transport failure", async () => {
     const client = createCodexResponsesClient({
       config: {
@@ -4336,6 +4353,62 @@ describe("createGenericOpenAIResponsesClient — native passthrough", () => {
       expect(raw).not.toContain("sk-secret-1234");
       expect(raw).toContain("[redacted]");
     }
+  });
+
+  it("keeps safe upstream headers and bounded error bodies for generic Responses", async () => {
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: "sk-secret-1234" },
+      fetch: vi.fn(
+        async () =>
+          new Response("upstream exploded", {
+            status: 502,
+            headers: {
+              authorization: "Bearer must-not-survive",
+              "x-request-id": "req-upstream-1",
+              "x-ratelimit-remaining-tokens": "123",
+            },
+          }),
+      ),
+    });
+    let caught: unknown;
+    try {
+      await client.nativePassthrough?.({ model: "gpt-5.5", input: "hi" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(UpstreamError);
+    expect((caught as UpstreamError).providerRaw).toBe("upstream exploded");
+    expect((caught as UpstreamError).upstreamHeaders).toMatchObject({
+      "x-ratelimit-remaining-tokens": "123",
+      "x-request-id": "req-upstream-1",
+    });
+    expect((caught as UpstreamError).upstreamHeaders).not.toHaveProperty("authorization");
+  });
+
+  it("keeps generic Responses transport cause details without known credentials", async () => {
+    const token = "sk-secret-transport";
+    const cause = Object.assign(new Error(`getaddrinfo EAI_AGAIN ${token}`), {
+      code: "EAI_AGAIN",
+    });
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://api.openai.test/v1", apiKey: token },
+      fetch: vi.fn(async () => {
+        throw new TypeError(`fetch failed ${token}`, { cause });
+      }),
+    });
+    let caught: unknown;
+    try {
+      await client.nativePassthrough?.({ model: "gpt-5.5", input: "hi" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(UpstreamError);
+    const raw = JSON.stringify(caught);
+    expect(raw).not.toContain(token);
+    expect(raw).toContain("EAI_AGAIN");
+    expect(raw).toContain("[redacted]");
   });
 
   it("rebuilds the Authorization header after a 401 so the OAuth retry uses the refreshed token", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -39,7 +39,11 @@ import {
   type ChatCompletionResponse,
   type ProviderClient,
   type ProviderConfig,
+  readUpstreamErrorBody,
+  safeUpstreamHeaders,
+  UPSTREAM_ERROR_BODY_MAX_BYTES,
   UpstreamError,
+  upstreamTransportError,
 } from "./openai.js";
 import {
   isFetchTransportError,
@@ -1244,45 +1248,6 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     return changed ? JSON.parse(value) : raw;
   }
 
-  function transportErrorNode(
-    error: unknown,
-    depth = 0,
-    seen = new WeakSet<object>(),
-  ): Record<string, unknown> {
-    if (typeof error !== "object" || error === null) return { message: String(error) };
-    if (seen.has(error)) return { message: "[circular cause]" };
-    seen.add(error);
-    const source = error as {
-      name?: unknown;
-      message?: unknown;
-      code?: unknown;
-      cause?: unknown;
-    };
-    const detail: Record<string, unknown> = {};
-    if (typeof source.name === "string" && source.name.length > 0) detail.name = source.name;
-    if (typeof source.code === "string" || typeof source.code === "number") {
-      detail.code = source.code;
-    }
-    if (typeof source.message === "string" && source.message.length > 0) {
-      detail.message = source.message;
-    }
-    if (source.cause !== undefined && depth < 4) {
-      detail.cause = transportErrorNode(source.cause, depth + 1, seen);
-    }
-    return detail;
-  }
-
-  function transportUpstreamError(error: unknown): UpstreamError {
-    const rawMessage = error instanceof Error ? error.message : "upstream fetch failed";
-    const scrubbedMessage = scrub(rawMessage);
-    return new UpstreamError(
-      "upstream_error",
-      typeof scrubbedMessage === "string" ? scrubbedMessage : "upstream fetch failed",
-      scrub({ error: transportErrorNode(error) }),
-      null,
-    );
-  }
-
   type RequestTimeout = ReturnType<typeof withTimeout>;
   interface CodexHttpResponse {
     response: Response;
@@ -1407,16 +1372,17 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       // transport-shaped TypeError. Explicit provider timeouts are already
       // UpstreamError("timeout") and therefore fail this raw-transport guard.
       if (init.signal?.aborted || !isFetchTransportError(error)) throw error;
-      throw transportUpstreamError(error);
+      throw upstreamTransportError(error, scrub);
     }
   }
 
   async function consumeUnaryBody<T>(
     result: CodexHttpResponse,
     consume: (text: string) => T | Promise<T>,
+    maxBytes = 0,
   ): Promise<T> {
     try {
-      return await consumeResponseTextWithinBudget(result.response, 0, consume);
+      return await consumeResponseTextWithinBudget(result.response, maxBytes, consume);
     } catch (err) {
       if (result.bodyTimeout?.isTimeout() && !result.bodyTimeout.isExternalAbort()) {
         throw new UpstreamError("timeout", "upstream request timed out");
@@ -1534,17 +1500,22 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   async function errorFromResponse(result: CodexHttpResponse): Promise<UpstreamError> {
     let providerRaw: unknown = null;
     try {
-      providerRaw = await consumeUnaryBody(result, (text) => {
-        let raw: unknown;
-        try {
-          raw = JSON.parse(text);
-        } catch {
-          raw = text;
-        }
-        return scrub(raw);
-      });
+      providerRaw = await consumeUnaryBody(
+        result,
+        (text) => {
+          let raw: unknown;
+          try {
+            raw = JSON.parse(text);
+          } catch {
+            raw = text;
+          }
+          return scrub(raw);
+        },
+        UPSTREAM_ERROR_BODY_MAX_BYTES,
+      );
     } catch (err) {
       if (err instanceof UpstreamError && err.errorClass === "timeout") throw err;
+      if (err instanceof UpstreamError) providerRaw = err.providerRaw;
     }
     const scrubbedBody = providerRaw;
     const selectedHeaders =
@@ -1558,6 +1529,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       `upstream returned ${result.response.status}`,
       structuredRaw,
       result.response.status,
+      scrub(safeUpstreamHeaders(result.response.headers)) as Record<string, string>,
     );
   }
 
@@ -1596,6 +1568,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         error.status === null ? error.message : `upstream websocket returned ${error.status}`,
         websocketErrorRaw(error),
         error.status,
+        scrub(safeUpstreamHeaders(error.headers)) as Record<string, string>,
       );
     }
     return new UpstreamError(
@@ -2309,37 +2282,37 @@ export function createGenericOpenAIResponsesClient(
     // A 529/503 is transient upstream capacity pressure, not a request fault — pause
     // and re-issue the SAME body (pre-first-byte → idempotent) before the executor
     // burns another candidate on it.
-    return withOverloadRetry(
-      async () => {
-        const t = withTimeout(timeoutMs, external);
-        try {
-          return await doFetch(url, { ...init, signal: t.signal });
-        } catch (err) {
-          if (t.isTimeout() && !t.isExternalAbort()) {
-            throw new UpstreamError("timeout", "upstream request timed out");
+    try {
+      return await withOverloadRetry(
+        async () => {
+          const t = withTimeout(timeoutMs, external);
+          try {
+            return await doFetch(url, { ...init, signal: t.signal });
+          } catch (err) {
+            if (t.isTimeout() && !t.isExternalAbort()) {
+              throw new UpstreamError("timeout", "upstream request timed out");
+            }
+            throw err;
+          } finally {
+            t.cleanup();
           }
-          throw err;
-        } finally {
-          t.cleanup();
-        }
-      },
-      { signal: external },
-    );
+        },
+        { signal: external },
+      );
+    } catch (error) {
+      if (external?.aborted || !isFetchTransportError(error)) throw error;
+      throw upstreamTransportError(error, scrub);
+    }
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await consumeResponseTextWithinBudget(res, 0, (text) => {
-      try {
-        return scrub(JSON.parse(text));
-      } catch {
-        return scrub(text);
-      }
-    }).catch(() => null);
+    const providerRaw = await readUpstreamErrorBody(res, scrub);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
       providerRaw,
       res.status,
+      scrub(safeUpstreamHeaders(res.headers)) as Record<string, string>,
     );
   }
 

--- a/packages/core/src/provider/openai.test.ts
+++ b/packages/core/src/provider/openai.test.ts
@@ -196,6 +196,73 @@ describe("createOpenAIClient (Phase 0 passthrough)", () => {
     });
   });
 
+  it("retains bounded safe upstream headers and rejects credential headers", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "boom" } }), {
+        status: 502,
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "req_upstream_1",
+          "x-ratelimit-remaining-tokens": "42",
+          authorization: "Bearer response-secret",
+          "x-proxy-authorization": "Basic proxy-response-secret",
+          "set-cookie": "session=response-secret",
+          "x-goog-api-key": "google-response-secret",
+          "x-access-token": "oauth-response-secret",
+        },
+      }),
+    );
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+
+    await expect(client.chatCompletion({ model: "m" })).rejects.toMatchObject({
+      upstreamStatus: 502,
+      upstreamHeaders: {
+        "content-type": "application/json",
+        "x-request-id": "req_upstream_1",
+        "x-ratelimit-remaining-tokens": "42",
+      },
+    });
+    try {
+      await client.chatCompletion({ model: "m" });
+    } catch (error) {
+      expect(JSON.stringify((error as UpstreamError).upstreamHeaders)).not.toContain(
+        "response-secret",
+      );
+      expect((error as UpstreamError).upstreamHeaders).not.toHaveProperty("x-goog-api-key");
+      expect((error as UpstreamError).upstreamHeaders).not.toHaveProperty("x-access-token");
+      expect((error as UpstreamError).upstreamHeaders).not.toHaveProperty("x-proxy-authorization");
+    }
+  });
+
+  it("bounds an oversized upstream error body instead of buffering it into telemetry", async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response("x".repeat(70_000), { status: 502 }));
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+
+    await expect(client.chatCompletion({ model: "m" })).rejects.toMatchObject({
+      providerRaw: {
+        error: { code: "error_body_too_large", limit_bytes: 65_536 },
+      },
+    });
+  });
+
+  it("scrubs credentials from an upstream error-body read failure", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(new Error("Authorization: Bearer sk-secret-key"));
+      },
+    });
+    const client = createOpenAIClient({
+      config: CONFIG,
+      fetch: vi.fn().mockResolvedValue(new Response(body, { status: 502 })),
+    });
+
+    try {
+      await client.chatCompletion({ model: "m" });
+    } catch (error) {
+      expect(JSON.stringify((error as UpstreamError).providerRaw)).not.toContain("sk-secret-key");
+    }
+  });
+
   it("maps a timeout to UpstreamError(timeout, 504)", async () => {
     // fetch that rejects with an AbortError when its signal aborts
     const fetch = vi.fn().mockImplementation(
@@ -566,5 +633,29 @@ describe("createOpenAIClient (transient-connection retry)", () => {
     });
     await expect(client.chatCompletion({ model: "m" }, { signal: ac.signal })).rejects.toThrow();
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves exhausted transport causes without leaking the configured key", async () => {
+    const cause = Object.assign(new Error(`getaddrinfo EAI_AGAIN ${CONFIG.apiKey}`), {
+      code: "EAI_AGAIN",
+    });
+    const fetch = vi.fn(async () => {
+      throw new TypeError(`fetch failed ${CONFIG.apiKey}`, { cause });
+    });
+    const client = createOpenAIClient({
+      config: { ...RETRY_CONFIG, connectRetries: 0 },
+      fetch: fetch as unknown as typeof globalThis.fetch,
+    });
+    let caught: unknown;
+    try {
+      await client.chatCompletion({ model: "m" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(UpstreamError);
+    const raw = JSON.stringify(caught);
+    expect(raw).not.toContain(CONFIG.apiKey);
+    expect(raw).toContain("EAI_AGAIN");
   });
 });

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -4,6 +4,11 @@
 // injected config (env-sourced) and are never logged or echoed. See docs/02.
 
 import type { NativePassthroughInput } from "@helm/shared";
+import {
+  consumeResponseTextWithinBudget,
+  ResponseBodyTooLargeError,
+} from "../runtime/bounded-response.js";
+import { ResponseWorkCapacityError } from "../runtime/response-work-admission.js";
 import type { ProxyConfig } from "./proxy.js";
 // Provider credential: EXACTLY ONE of a static `apiKey` or a dynamic
 // `getAuthHeader` (issue #38 OAuth). The dynamic path also accepts:
@@ -14,7 +19,7 @@ import type { ProxyConfig } from "./proxy.js";
 //   - `currentSecrets`: live access + refresh tokens, used by `scrub()` to strip
 //     any echoed credential from an upstream error body (principle 7).
 // Credentials are runtime-only: from env, never persisted/logged.
-import { withConnectionRetry, withOverloadRetry } from "./retry.js";
+import { isFetchTransportError, withConnectionRetry, withOverloadRetry } from "./retry.js";
 import { readChunkWithIdle, StreamStalledError } from "./stream-idle.js";
 
 export interface ProviderConfig {
@@ -223,18 +228,130 @@ export class UpstreamError extends Error {
   // reads this for the `:free` 429-skip rule (docs/04, principle 5).
   readonly upstreamStatus: number | null;
   readonly providerRaw: unknown | null;
+  readonly upstreamHeaders: Record<string, string> | null;
   constructor(
     errorClass: "upstream_error" | "timeout",
     message: string,
     providerRaw: unknown | null = null,
     upstreamStatus: number | null = null,
+    upstreamHeaders: Record<string, string> | null = null,
+    cause?: unknown,
   ) {
     super(message);
+    if (cause !== undefined) Object.defineProperty(this, "cause", { value: cause });
     this.name = "UpstreamError";
     this.errorClass = errorClass;
     this.httpStatus = errorClass === "timeout" ? 504 : 502;
     this.upstreamStatus = upstreamStatus;
     this.providerRaw = providerRaw;
+    this.upstreamHeaders = upstreamHeaders;
+  }
+}
+
+function transportErrorNode(
+  error: unknown,
+  depth = 0,
+  seen = new WeakSet<object>(),
+): Record<string, unknown> {
+  if (typeof error !== "object" || error === null) return { message: String(error) };
+  if (seen.has(error)) return { message: "[circular cause]" };
+  seen.add(error);
+  const source = error as {
+    name?: unknown;
+    message?: unknown;
+    code?: unknown;
+    stack?: unknown;
+    cause?: unknown;
+  };
+  const detail: Record<string, unknown> = {};
+  if (typeof source.name === "string" && source.name.length > 0) detail.name = source.name;
+  if (typeof source.message === "string" && source.message.length > 0) {
+    detail.message = source.message.slice(0, 16_384);
+  }
+  if (typeof source.code === "string" || typeof source.code === "number") detail.code = source.code;
+  if (typeof source.stack === "string" && source.stack.length > 0) {
+    detail.stack = source.stack.slice(0, 16_384);
+  }
+  if (source.cause !== undefined && depth < 4) {
+    detail.cause = transportErrorNode(source.cause, depth + 1, seen);
+  }
+  return detail;
+}
+
+export function upstreamTransportError(
+  error: unknown,
+  scrub: (raw: unknown) => unknown,
+): UpstreamError {
+  const detail = scrub(transportErrorNode(error));
+  const rawMessage = error instanceof Error ? error.message : "upstream fetch failed";
+  const message = scrub(rawMessage);
+  return new UpstreamError(
+    "upstream_error",
+    typeof message === "string" ? message : "upstream fetch failed",
+    { error: detail },
+    null,
+    null,
+    detail,
+  );
+}
+
+export const UPSTREAM_ERROR_BODY_MAX_BYTES = 64 * 1024;
+const UPSTREAM_ERROR_HEADER_MAX_BYTES = 16 * 1024;
+const UPSTREAM_ERROR_HEADER_VALUE_MAX_BYTES = 4 * 1024;
+const CREDENTIAL_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "api-key",
+  "x-api-key",
+  "x-goog-api-key",
+  "x-google-api-key",
+  "x-auth-token",
+  "x-access-token",
+]);
+
+export function safeUpstreamHeaders(headers: Headers): Record<string, string> {
+  const safe: Record<string, string> = {};
+  let bytes = 0;
+  for (const [name, rawValue] of headers) {
+    if (CREDENTIAL_HEADERS.has(name.toLowerCase())) continue;
+    const value = rawValue.slice(0, UPSTREAM_ERROR_HEADER_VALUE_MAX_BYTES);
+    const nextBytes = Buffer.byteLength(name) + Buffer.byteLength(value);
+    if (bytes + nextBytes > UPSTREAM_ERROR_HEADER_MAX_BYTES) break;
+    safe[name] = value;
+    bytes += nextBytes;
+  }
+  return safe;
+}
+
+export async function readUpstreamErrorBody(
+  response: Response,
+  scrub: (raw: unknown) => unknown,
+): Promise<unknown> {
+  try {
+    return await consumeResponseTextWithinBudget(
+      response,
+      UPSTREAM_ERROR_BODY_MAX_BYTES,
+      (text) => {
+        try {
+          return scrub(JSON.parse(text));
+        } catch {
+          return scrub(text);
+        }
+      },
+    );
+  } catch (error) {
+    if (error instanceof ResponseBodyTooLargeError) {
+      return { error: { code: "error_body_too_large", limit_bytes: error.limitBytes } };
+    }
+    if (error instanceof ResponseWorkCapacityError) {
+      return {
+        error: { code: "error_body_capacity_exhausted", limit_bytes: error.capacityBytes },
+      };
+    }
+    return scrub({ error: { code: "error_body_read_failed", message: String(error) } });
   }
 }
 
@@ -434,32 +551,37 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     // withOverloadRetry wraps it: an overloaded 529/503 is a normal Response (never a
     // throw), so it re-issues the whole attempt after a pause instead of burning a
     // candidate on transient upstream capacity pressure.
-    return withOverloadRetry(
-      () =>
-        withConnectionRetry(
-          async () => {
-            const t = withTimeout(timeoutMs, external);
-            try {
-              return await doFetch(await urlFn(), {
-                method: "POST",
-                headers: await headers(),
-                body: bodyText,
-                signal: t.signal,
-              });
-            } catch (err) {
-              if (t.isTimeout() && !t.isExternalAbort()) {
-                throw new UpstreamError("timeout", "upstream request timed out");
+    try {
+      return await withOverloadRetry(
+        () =>
+          withConnectionRetry(
+            async () => {
+              const t = withTimeout(timeoutMs, external);
+              try {
+                return await doFetch(await urlFn(), {
+                  method: "POST",
+                  headers: await headers(),
+                  body: bodyText,
+                  signal: t.signal,
+                });
+              } catch (err) {
+                if (t.isTimeout() && !t.isExternalAbort()) {
+                  throw new UpstreamError("timeout", "upstream request timed out");
+                }
+                // Client abort is NOT a provider fault — rethrow as-is for the caller.
+                throw err;
+              } finally {
+                t.cleanup();
               }
-              // Client abort is NOT a provider fault — rethrow as-is for the caller.
-              throw err;
-            } finally {
-              t.cleanup();
-            }
-          },
-          { retries: cfg.connectRetries, backoffMs: cfg.connectRetryBackoffMs, signal: external },
-        ),
-      { signal: external },
-    );
+            },
+            { retries: cfg.connectRetries, backoffMs: cfg.connectRetryBackoffMs, signal: external },
+          ),
+        { signal: external },
+      );
+    } catch (error) {
+      if (external?.aborted || !isFetchTransportError(error)) throw error;
+      throw upstreamTransportError(error, scrub);
+    }
   }
 
   // Issue the request, applying the OAuth 401 single-retry (D2): on a 401 with an
@@ -489,32 +611,38 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     headers: () => Promise<Record<string, string>>;
     signal?: AbortSignal;
   }): Promise<Response> {
-    const attempt = async (): Promise<Response> =>
-      withConnectionRetry(
-        async () => {
-          const t = withTimeout(timeoutMs, options.signal);
-          try {
-            return await doFetch(await options.url(), {
-              method: "POST",
-              headers: await options.headers(),
-              body: options.body(),
-              signal: t.signal,
-            });
-          } catch (error) {
-            if (t.isTimeout() && !t.isExternalAbort()) {
-              throw new UpstreamError("timeout", "upstream request timed out");
+    const attempt = async (): Promise<Response> => {
+      try {
+        return await withConnectionRetry(
+          async () => {
+            const t = withTimeout(timeoutMs, options.signal);
+            try {
+              return await doFetch(await options.url(), {
+                method: "POST",
+                headers: await options.headers(),
+                body: options.body(),
+                signal: t.signal,
+              });
+            } catch (error) {
+              if (t.isTimeout() && !t.isExternalAbort()) {
+                throw new UpstreamError("timeout", "upstream request timed out");
+              }
+              throw error;
+            } finally {
+              t.cleanup();
             }
-            throw error;
-          } finally {
-            t.cleanup();
-          }
-        },
-        {
-          retries: cfg.connectRetries,
-          backoffMs: cfg.connectRetryBackoffMs,
-          signal: options.signal,
-        },
-      );
+          },
+          {
+            retries: cfg.connectRetries,
+            backoffMs: cfg.connectRetryBackoffMs,
+            signal: options.signal,
+          },
+        );
+      } catch (error) {
+        if (options.signal?.aborted || !isFetchTransportError(error)) throw error;
+        throw upstreamTransportError(error, scrub);
+      }
+    };
     const response = await attempt();
     if (response.status !== 401 || cfg.onUnauthorized === undefined) return response;
     await response.body?.cancel().catch(() => {});
@@ -523,23 +651,18 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await res
-      .json()
-      .catch(() => null)
-      .then(scrub);
+    const providerRaw = await readUpstreamErrorBody(res, scrub);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
       providerRaw,
       res.status,
+      scrub(safeUpstreamHeaders(res.headers)) as Record<string, string>,
     );
   }
 
   async function realtimeErrorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await res
-      .json()
-      .catch(() => null)
-      .then(scrub);
+    const providerRaw = await readUpstreamErrorBody(res, scrub);
     const outer =
       providerRaw !== null && typeof providerRaw === "object" && !Array.isArray(providerRaw)
         ? (providerRaw as Record<string, unknown>)
@@ -552,7 +675,13 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       typeof nested?.message === "string" && nested.message.length > 0
         ? nested.message
         : `upstream returned ${res.status}`;
-    return new UpstreamError("upstream_error", message, providerRaw, res.status);
+    return new UpstreamError(
+      "upstream_error",
+      message,
+      providerRaw,
+      res.status,
+      scrub(safeUpstreamHeaders(res.headers)) as Record<string, string>,
+    );
   }
 
   function realtimeCallId(location: string): string | null {

--- a/packages/core/src/provider/retry.ts
+++ b/packages/core/src/provider/retry.ts
@@ -79,7 +79,9 @@ export function isFetchTransportError(err: unknown): boolean {
   if (isTransientConnectionError(err)) return true;
   if (typeof err !== "object" || err === null) return false;
   const e = err as { name?: unknown; message?: unknown };
-  return e.name === "TypeError" && e.message === "fetch failed";
+  return (
+    e.name === "TypeError" && typeof e.message === "string" && e.message.startsWith("fetch failed")
+  );
 }
 
 // ── Upstream overload (529 / 503) ────────────────────────────────────────────

--- a/packages/core/src/provider/token-manager.preset.test.ts
+++ b/packages/core/src/provider/token-manager.preset.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { encryptSecret } from "../store/crypto/token-cipher.js";
+import { decryptSecret, encryptSecret } from "../store/crypto/token-cipher.js";
 import type { OAuthTokenRecord, OAuthTokenStore } from "../store/ports.js";
 import { OpenAICodexIdentityMismatchError } from "./oauth/openai-codex.js";
 import { OAuthHttpError } from "./oauth/runtime.js";
 import type { OAuthCredentials, OAuthProviderInterface } from "./oauth/types.js";
 import {
   createTokenManager,
+  executionTokenExpirySkewMs,
   oauthRefreshQueueDepth,
   type PresetOAuth,
   TokenRefreshError,
@@ -113,6 +114,140 @@ function rotatingSeed(expiresAt: number): OAuthTokenRecord {
 describe("createTokenManager (preset kind)", () => {
   it("throws at construction when preset deps are missing", () => {
     expect(() => createTokenManager({ oauth: PRESET })).toThrow(/requires tokenStore/);
+  });
+
+  it("uses one request lease and refreshes at its exact expiry boundary", async () => {
+    const provider = rotatingProvider();
+    const skew = executionTokenExpirySkewMs(60_000);
+    expect(skew).toBe(6 * 60_000);
+    const usable = createTokenManager({
+      oauth: PRESET,
+      tokenStore: memStore(rotatingSeed(skew + 1)),
+      encKey: KEY,
+      oauthProvider: provider,
+      expirySkewMs: skew,
+      now: () => 0,
+    });
+    expect(await usable.getAuthHeader()).toBe("Bearer at-0");
+    expect(provider.calls).toBe(0);
+
+    const boundaryProvider = rotatingProvider();
+    const boundary = createTokenManager({
+      oauth: PRESET,
+      tokenStore: memStore(rotatingSeed(skew)),
+      encKey: KEY,
+      oauthProvider: boundaryProvider,
+      expirySkewMs: skew,
+      now: () => 0,
+    });
+    expect(await boundary.getAuthHeader()).toBe("Bearer at-1");
+    expect(boundaryProvider.calls).toBe(1);
+  });
+
+  it("waits before failover without replaying an ambiguously consumed refresh token", async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const provider: OAuthProviderInterface = {
+        id: "anthropic",
+        name: "transient",
+        async login() {
+          throw new Error("not used");
+        },
+        async refreshToken() {
+          calls += 1;
+          throw new OAuthHttpError("Anthropic", 503);
+        },
+        getApiKey: (c) => c.access,
+      };
+      const store = memStore(seedRecord({ expiresAt: 0 }));
+      const tm = createTokenManager({
+        oauth: PRESET,
+        tokenStore: store,
+        encKey: KEY,
+        oauthProvider: provider,
+        now: () => 0,
+      });
+
+      let settled = false;
+      const header = tm.getAuthHeader().finally(() => {
+        settled = true;
+      });
+      const failure = expect(header).rejects.toMatchObject({
+        httpStatus: 503,
+        retryableAccountFailure: true,
+      });
+      await vi.advanceTimersByTimeAsync(999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await failure;
+      expect(calls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("adopts a credential another instance rotated while waiting after a transient failure", async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const provider: OAuthProviderInterface = {
+        id: "anthropic",
+        name: "unavailable",
+        async login() {
+          throw new Error("not used");
+        },
+        async refreshToken() {
+          calls += 1;
+          throw new OAuthHttpError("Anthropic", 503);
+        },
+        getApiKey: (c) => c.access,
+      };
+      const store = memStore(seedRecord({ expiresAt: 0 }));
+      const tm = createTokenManager({
+        oauth: PRESET,
+        tokenStore: store,
+        encKey: KEY,
+        oauthProvider: provider,
+        now: () => 0,
+      });
+
+      const header = tm.getAuthHeader();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls).toBe(1);
+      await store.upsert({
+        ...seedRecord(),
+        accessEnc: encryptSecret("at-sibling", KEY),
+        refreshEnc: encryptSecret("rt-sibling", KEY),
+        expiresAt: 9_999_999,
+        updatedAt: 1,
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(header).resolves.toBe("Bearer at-sibling");
+      expect(calls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a newly refreshed token shorter than the required request lease", async () => {
+    const skew = executionTokenExpirySkewMs(60_000);
+    const provider = stubProvider(); // returns expires=10_000, shorter than the 120s lease
+    const store = memStore(seedRecord({ expiresAt: 0 }));
+    const tm = createTokenManager({
+      oauth: PRESET,
+      tokenStore: store,
+      encKey: KEY,
+      oauthProvider: provider,
+      expirySkewMs: skew,
+      now: () => 0,
+    });
+
+    await expect(tm.getAuthHeader()).rejects.toThrow(/shorter than required request lease/);
+    const rotated = await store.get("anthropic", "default");
+    expect(rotated?.refreshEnc && decryptSecret(rotated.refreshEnc, KEY)).toBe("rt-1");
   });
 
   it("reuses a still-valid stored access token WITHOUT calling the provider", async () => {

--- a/packages/core/src/provider/token-manager.ts
+++ b/packages/core/src/provider/token-manager.ts
@@ -17,11 +17,13 @@
 // grants (issue #38) are persisted to the OAuthTokenStore — encrypted — so a
 // rotated refresh token survives restarts.
 
+import { createHash } from "node:crypto";
 import { decryptSecret, encryptSecret } from "../store/crypto/token-cipher.js";
 import type { OAuthTokenStore } from "../store/ports.js";
 import { OpenAICodexIdentityMismatchError } from "./oauth/openai-codex.js";
 import { buildOAuthRequestSignal, OAuthHttpError } from "./oauth/runtime.js";
 import type { OAuthCredentials, OAuthProviderInterface } from "./oauth/types.js";
+import { isFetchTransportError } from "./retry.js";
 
 // Cross-instance refresh serialization for PRESET credentials. The composition root
 // builds MANY TokenManager instances for the SAME (providerId, account) — the
@@ -141,20 +143,26 @@ export interface TokenManager {
 export class TokenRefreshError extends Error {
   readonly httpStatus: number | null;
   readonly permanentCredentialFailure: boolean;
+  readonly retryableAccountFailure: boolean;
   constructor(
     message: string,
     httpStatus: number | null = null,
     permanentCredentialFailure = false,
+    retryableAccountFailure = false,
   ) {
     super(message);
     this.name = "TokenRefreshError";
     this.httpStatus = httpStatus;
     this.permanentCredentialFailure = permanentCredentialFailure;
+    this.retryableAccountFailure = retryableAccountFailure;
   }
 }
 
 const DEFAULT_EXPIRY_SKEW_MS = 60_000;
+const TOKEN_REFRESH_HEADROOM_MS = 5 * 60_000;
 const DEFAULT_REFRESH_TIMEOUT_MS = 30_000;
+const REFRESH_FAILURE_WAIT_MS = 1_000;
+const REFRESH_FAILURE_JITTER_MS = 2_000;
 // Fallback lifetime when the token endpoint omits expires_in (rare). Short so a
 // missing TTL degrades to "refresh often", never "cache a token forever".
 const DEFAULT_EXPIRES_IN_S = 3600;
@@ -165,10 +173,32 @@ interface TokenEndpointResponse {
   refresh_token?: unknown;
 }
 
+export function executionTokenExpirySkewMs(requestTimeoutMs: number): number {
+  const timeout =
+    Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0 ? Math.ceil(requestTimeoutMs) : 0;
+  return timeout + TOKEN_REFRESH_HEADROOM_MS;
+}
+
+function presetRefreshFailureWaitMs(providerId: string, account: string): number {
+  return (
+    REFRESH_FAILURE_WAIT_MS +
+    (createHash("sha256").update(`${providerId}\0${account}`).digest().readUInt16BE(0) %
+      REFRESH_FAILURE_JITTER_MS)
+  );
+}
+
+function isRetryableRefreshError(err: unknown): boolean {
+  if (err instanceof OAuthHttpError) {
+    return err.httpStatus === 408 || err.httpStatus === 425 || err.httpStatus >= 500;
+  }
+  return isFetchTransportError(err);
+}
+
 export function createTokenManager(deps: TokenManagerDeps): TokenManager {
   const doFetch = deps.fetch ?? globalThis.fetch;
   const now = deps.now ?? (() => Date.now());
   const skew = deps.expirySkewMs ?? DEFAULT_EXPIRY_SKEW_MS;
+  const enforceRequestLease = deps.expirySkewMs !== undefined;
   const refreshTimeoutMs = Math.max(1, deps.refreshTimeoutMs ?? DEFAULT_REFRESH_TIMEOUT_MS);
   const oauth = deps.oauth;
   const isPreset = oauth.kind === "preset";
@@ -246,15 +276,24 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
     if (typeof parsed.access_token !== "string" || parsed.access_token.length === 0) {
       throw new TokenRefreshError("oauth token response missing access_token", res.status);
     }
-    accessToken = parsed.access_token;
     const expiresInS =
       typeof parsed.expires_in === "number" && parsed.expires_in > 0
         ? parsed.expires_in
         : DEFAULT_EXPIRES_IN_S;
-    expiresAt = now() + expiresInS * 1000;
+    const nextExpiresAt = now() + expiresInS * 1000;
+    accessToken = parsed.access_token;
+    expiresAt = nextExpiresAt;
     // Rotated refresh token: adopt the new value for subsequent refreshes.
     if (typeof parsed.refresh_token === "string" && parsed.refresh_token.length > 0) {
       refreshToken = parsed.refresh_token;
+    }
+    if (enforceRequestLease && expiresAt <= now() + skew) {
+      throw new TokenRefreshError(
+        "oauth access token is shorter than required request lease",
+        null,
+        false,
+        true,
+      );
     }
   }
 
@@ -305,7 +344,9 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
     const p = oauth as PresetOAuth;
     const provider = deps.oauthProvider as OAuthProviderInterface;
     const encKey = deps.encKey as Buffer;
-    if (refreshToken === undefined) {
+    const currentRefreshToken = refreshToken;
+    const currentAccessToken = accessToken;
+    if (currentRefreshToken === undefined) {
       throw new TokenRefreshError(
         `no stored OAuth credential for ${p.providerId} (run \`helm oauth login ${p.providerId}\`)`,
       );
@@ -317,7 +358,7 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
       creds = await provider.refreshToken(
         {
           access: accessToken ?? "",
-          refresh: refreshToken,
+          refresh: currentRefreshToken,
           expires: expiresAt,
           ...presetExtra,
         },
@@ -337,6 +378,19 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
       // 429 ⇒ rate limited; 5xx ⇒ upstream down).
       const status = err instanceof OAuthHttpError ? err.httpStatus : null;
       const identityMismatch = err instanceof OpenAICodexIdentityMismatchError;
+      const retryableAccountFailure = isRetryableRefreshError(err);
+      if (retryableAccountFailure) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, presetRefreshFailureWaitMs(p.providerId, p.account)),
+        );
+        await loadFromStore();
+        if (
+          !isExpired() &&
+          (accessToken !== currentAccessToken || refreshToken !== currentRefreshToken)
+        ) {
+          return;
+        }
+      }
       throw new TokenRefreshError(
         identityMismatch
           ? `oauth refresh identity changed (${p.providerId}); reconnect the account`
@@ -345,6 +399,7 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
             : `oauth refresh failed (${p.providerId}, status ${status})`,
         status,
         identityMismatch,
+        retryableAccountFailure,
       );
     }
     accessToken = provider.getApiKey(creds);
@@ -363,6 +418,16 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
       meta: metaFrom(creds),
       updatedAt: now(),
     });
+    if (enforceRequestLease && expiresAt <= now() + skew) {
+      // Persist a rotated refresh token even when the accompanying access token is
+      // too short for this request. Otherwise a single-use rotation would be lost.
+      throw new TokenRefreshError(
+        "oauth access token is shorter than required request lease",
+        null,
+        false,
+        true,
+      );
+    }
   }
 
   function isExpired(): boolean {

--- a/packages/core/src/store/sqlite/batched-cleanup.test.ts
+++ b/packages/core/src/store/sqlite/batched-cleanup.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { SQLITE_PRUNE_BATCH_SIZE } from "./batched-prune.js";
+import { SqliteMemoryStore } from "./memory-store.js";
+import { createSqliteDb } from "./migrate.js";
+import { SqliteOAuthUsageStore } from "./oauth-usage.js";
+import { SqliteTelemetryStore } from "./telemetry.js";
+
+const dbs: ReturnType<typeof createSqliteDb>[] = [];
+
+afterEach(() => {
+  for (const db of dbs.splice(0)) db.$sqlite.close();
+});
+
+async function expectEventLoopYield(work: () => Promise<unknown>): Promise<void> {
+  let yielded = false;
+  setImmediate(() => {
+    yielded = true;
+  });
+  await work();
+  expect(yielded).toBe(true);
+}
+
+function seedExpiredRows() {
+  const db = createSqliteDb(":memory:");
+  dbs.push(db);
+  const rows = SQLITE_PRUNE_BATCH_SIZE + 1;
+  const insert = db.$sqlite.transaction(() => {
+    for (let i = 0; i < rows; i += 1) {
+      const id = `old-${i}`;
+      db.$sqlite
+        .prepare(
+          "INSERT INTO telemetry (id, request_id, api_key_id, decision_json, created_at) VALUES (?, ?, 'key', '{}', 1000)",
+        )
+        .run(id, id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO request_payloads (request_id, request_json, created_at) VALUES (?, '{}', 1000)",
+        )
+        .run(id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO sessions (session_ref, account_id, api_key_id, source, external_session_id, created_at, last_seen_at) VALUES (?, 'account', 'key', 'header', ?, 1000, 1000)",
+        )
+        .run(id, id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO session_revisions (request_id, session_ref, sequence, retain_count, request_delta_json, request_envelope_json, fidelity, created_at) VALUES (?, ?, 1, 1, '{}', '{}', 'semantic', 1000)",
+        )
+        .run(`revision-${id}`, id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO memory_messages (id, thread_id, role, content, token_estimate, created_at) VALUES (?, 'thread', 'user', 'body', 1, 1000)",
+        )
+        .run(id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO memory_observations (id, thread_id, source_message_range, observation_text, observed_at, status, archived_at) VALUES (?, 'thread', '[]', 'body', 1000, 'archived', 1000)",
+        )
+        .run(id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO memory_facts (id, owner_id, subject_key, fact_text, content_hash, valid_from, expired_at, created_at, updated_at) VALUES (?, 'account', 'subject', 'fact', ?, 1000, 1000, 1000, 1000)",
+        )
+        .run(id, id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at) VALUES (?, 'observer', 'thread', 'done', 1000, 1000)",
+        )
+        .run(id);
+      db.$sqlite
+        .prepare(
+          "INSERT INTO oauth_usage (provider_id, account, bucket_ms, requests, tokens, first_seen_ms, updated_at) VALUES ('provider', ?, 1000, 1, 1, 1000, 1000)",
+        )
+        .run(id);
+    }
+  });
+  db.$sqlite
+    .prepare(
+      "INSERT INTO memory_threads (id, message_count, last_message_at, observation_count, created_at, updated_at) VALUES ('thread', ?, 1000, ?, 1000, 1000)",
+    )
+    .run(rows, rows);
+  insert();
+  return {
+    db,
+    rows,
+    telemetry: new SqliteTelemetryStore(db),
+    memory: new SqliteMemoryStore(db),
+    oauth: new SqliteOAuthUsageStore(db),
+  };
+}
+
+describe("SQLite retention cleanup", () => {
+  it("prunes every cleanup action in small batches with event-loop yields", async () => {
+    const { db, rows, telemetry, memory, oauth } = seedExpiredRows();
+
+    await expectEventLoopYield(async () => expect(await telemetry.pruneTelemetry(2000)).toBe(rows));
+    await expectEventLoopYield(async () => telemetry.prunePayloads(2000));
+    await expectEventLoopYield(async () =>
+      expect(await telemetry.pruneInactiveSessions(2000)).toBe(rows),
+    );
+    await expectEventLoopYield(async () =>
+      expect(await memory.pruneMessagesOlderThan(2000)).toBe(rows),
+    );
+    await expectEventLoopYield(async () =>
+      expect(await oauth.pruneUsageOlderThan(2000)).toBe(rows),
+    );
+    await expectEventLoopYield(async () =>
+      expect(await memory.pruneFinishedJobsOlderThan(2000)).toBe(rows),
+    );
+    await expectEventLoopYield(async () =>
+      expect(
+        await memory.pruneExpiredMemory({
+          archivedObservationsBeforeMs: 2000,
+          expiredFactsBeforeMs: 2000,
+        }),
+      ).toEqual({ observationsDeleted: rows, factsDeleted: rows }),
+    );
+
+    expect(db.$sqlite.prepare("SELECT COUNT(*) AS value FROM session_revisions").get()).toEqual({
+      value: 0,
+    });
+    expect(db.$sqlite.prepare("SELECT message_count AS value FROM memory_threads").get()).toEqual({
+      value: 0,
+    });
+  });
+
+  it("finishes a claimed expired session before admitting a reactivation", async () => {
+    const db = createSqliteDb(":memory:");
+    dbs.push(db);
+    const telemetry = new SqliteTelemetryStore(db);
+    const revisions = SQLITE_PRUNE_BATCH_SIZE * 2 + 1;
+    db.$sqlite
+      .prepare(
+        "INSERT INTO sessions (session_ref, account_id, api_key_id, source, external_session_id, created_at, last_seen_at) VALUES ('old', 'account', 'key', 'header', 'old', 1000, 1000)",
+      )
+      .run();
+    const insert = db.$sqlite.prepare(
+      "INSERT INTO session_revisions (request_id, session_ref, sequence, retain_count, request_delta_json, request_envelope_json, fidelity, created_at) VALUES (?, 'old', ?, 1, '{}', '{}', 'semantic', 1000)",
+    );
+    db.$sqlite.transaction(() => {
+      for (let sequence = 1; sequence <= revisions; sequence += 1) {
+        insert.run(`revision-${sequence}`, sequence);
+      }
+    })();
+    const reactivated = new Promise<void>((resolve, reject) => {
+      setImmediate(async () => {
+        try {
+          await telemetry.upsertSessionRevision({
+            sessionRef: "old",
+            accountId: "account",
+            apiKeyId: "key",
+            source: "header",
+            externalSessionId: "old",
+            requestId: "reactivated",
+            parentRequestId: `revision-${revisions}`,
+            retainCount: 1,
+            requestDeltaJson: "{}",
+            requestEnvelopeJson: "{}",
+            responseId: null,
+            responseJson: null,
+            fidelity: "semantic",
+            createdAt: new Date(3000),
+          });
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    await expect(telemetry.pruneInactiveSessions(2000)).resolves.toBe(1);
+    await reactivated;
+
+    expect(db.$sqlite.prepare("SELECT COUNT(*) AS value FROM sessions").get()).toEqual({
+      value: 1,
+    });
+    expect(
+      db.$sqlite
+        .prepare(
+          "SELECT request_id AS requestId, parent_request_id AS parentRequestId FROM session_revisions",
+        )
+        .get(),
+    ).toEqual({ requestId: "reactivated", parentRequestId: null });
+  });
+
+  it("rechecks a prune claim after an earlier writer yielded before its transaction", async () => {
+    const db = createSqliteDb(":memory:");
+    dbs.push(db);
+    const telemetry = new SqliteTelemetryStore(db);
+    const revisions = SQLITE_PRUNE_BATCH_SIZE * 2 + 1;
+    db.$sqlite
+      .prepare(
+        "INSERT INTO sessions (session_ref, account_id, api_key_id, source, external_session_id, created_at, last_seen_at) VALUES ('old', 'account', 'key', 'header', 'old', 1000, 1000)",
+      )
+      .run();
+    const insert = db.$sqlite.prepare(
+      "INSERT INTO session_revisions (request_id, session_ref, sequence, retain_count, request_delta_json, request_envelope_json, fidelity, created_at) VALUES (?, 'old', ?, 1, '{}', '{}', 'semantic', 1000)",
+    );
+    db.$sqlite.transaction(() => {
+      for (let sequence = 1; sequence <= revisions; sequence += 1) {
+        insert.run(`revision-${sequence}`, sequence);
+      }
+    })();
+
+    const reactivated = telemetry.upsertSessionRevision({
+      sessionRef: "old",
+      accountId: "account",
+      apiKeyId: "key",
+      source: "header",
+      externalSessionId: "old",
+      requestId: "reactivated",
+      parentRequestId: `revision-${revisions}`,
+      retainCount: 1,
+      requestDeltaJson: "{}",
+      requestEnvelopeJson: "{}",
+      responseId: null,
+      responseJson: null,
+      fidelity: "semantic",
+      createdAt: new Date(3000),
+    });
+    const pruned = telemetry.pruneInactiveSessions(2000);
+
+    await expect(pruned).resolves.toBe(1);
+    await reactivated;
+
+    expect(
+      db.$sqlite
+        .prepare(
+          "SELECT request_id AS requestId, parent_request_id AS parentRequestId FROM session_revisions",
+        )
+        .all(),
+    ).toEqual([{ requestId: "reactivated", parentRequestId: null }]);
+  });
+
+  it("finishes a persisted session-prune claim before accepting new history", async () => {
+    const db = createSqliteDb(":memory:");
+    dbs.push(db);
+    const telemetry = new SqliteTelemetryStore(db);
+    db.$sqlite
+      .prepare(
+        "INSERT INTO sessions (session_ref, account_id, api_key_id, source, external_session_id, head_request_id, revision_count, created_at, last_seen_at) VALUES ('old', 'account', 'key', 'header', 'old', '__helm_pruning__', 2, 1000, 1000)",
+      )
+      .run();
+    db.$sqlite
+      .prepare(
+        "INSERT INTO session_revisions (request_id, session_ref, sequence, retain_count, request_delta_json, request_envelope_json, fidelity, created_at) VALUES (?, 'old', ?, 1, '{}', '{}', 'semantic', 1000)",
+      )
+      .run("revision-1", 1);
+    db.$sqlite
+      .prepare(
+        "INSERT INTO session_revisions (request_id, session_ref, sequence, retain_count, request_delta_json, request_envelope_json, fidelity, created_at) VALUES (?, 'old', ?, 1, '{}', '{}', 'semantic', 1000)",
+      )
+      .run("revision-2", 2);
+
+    await telemetry.upsertSessionRevision({
+      sessionRef: "old",
+      accountId: "account",
+      apiKeyId: "key",
+      source: "header",
+      externalSessionId: "old",
+      requestId: "reactivated",
+      parentRequestId: "revision-2",
+      retainCount: 1,
+      requestDeltaJson: "{}",
+      requestEnvelopeJson: "{}",
+      responseId: null,
+      responseJson: null,
+      fidelity: "semantic",
+      createdAt: new Date(3000),
+    });
+
+    expect(
+      db.$sqlite
+        .prepare(
+          "SELECT request_id AS requestId, parent_request_id AS parentRequestId FROM session_revisions",
+        )
+        .all(),
+    ).toEqual([{ requestId: "reactivated", parentRequestId: null }]);
+  });
+});

--- a/packages/core/src/store/sqlite/batched-prune.test.ts
+++ b/packages/core/src/store/sqlite/batched-prune.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { runBatchedPrune, SQLITE_PRUNE_BATCH_SIZE } from "./batched-prune.js";
+
+describe("runBatchedPrune", () => {
+  it("keeps deleting in small batches and yields between full batches", async () => {
+    const batches = [SQLITE_PRUNE_BATCH_SIZE, SQLITE_PRUNE_BATCH_SIZE, 3];
+    const deleteBatch = vi.fn(() => batches.shift() ?? 0);
+    const yieldToEventLoop = vi.fn(async () => {});
+
+    await expect(runBatchedPrune(deleteBatch, yieldToEventLoop)).resolves.toBe(
+      SQLITE_PRUNE_BATCH_SIZE * 2 + 3,
+    );
+    expect(deleteBatch).toHaveBeenCalledTimes(3);
+    expect(deleteBatch).toHaveBeenNthCalledWith(1, SQLITE_PRUNE_BATCH_SIZE);
+    expect(deleteBatch).toHaveBeenNthCalledWith(2, SQLITE_PRUNE_BATCH_SIZE);
+    expect(deleteBatch).toHaveBeenNthCalledWith(3, SQLITE_PRUNE_BATCH_SIZE);
+    expect(yieldToEventLoop).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/store/sqlite/batched-prune.ts
+++ b/packages/core/src/store/sqlite/batched-prune.ts
@@ -1,0 +1,17 @@
+export const SQLITE_PRUNE_BATCH_SIZE = 10;
+
+export const yieldToEventLoop = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+export async function runBatchedPrune(
+  deleteBatch: (limit: number) => number,
+  yieldBatch: () => Promise<void> = yieldToEventLoop,
+): Promise<number> {
+  let deleted = 0;
+  for (;;) {
+    const changes = deleteBatch(SQLITE_PRUNE_BATCH_SIZE);
+    deleted += changes;
+    if (changes < SQLITE_PRUNE_BATCH_SIZE) return deleted;
+    await yieldBatch();
+  }
+}

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -47,6 +47,7 @@ import {
   type MemoryMessageArchiveRow,
   type MemoryStore,
 } from "../ports.js";
+import { runBatchedPrune } from "./batched-prune.js";
 import { listSqliteIdleFlushCandidates } from "./idle-flush-candidates.js";
 import {
   memoryFacts,
@@ -1916,25 +1917,28 @@ export class SqliteMemoryStore implements MemoryStore {
     // DELETE would orphan that coverage and resurrect the raw into the prefix /
     // re-compression. So we free the bulky text + tags but KEEP the row with
     // status='pruned' (invisible to content reads, still seen by coverage reads).
-    const obs = this.db.$sqlite
-      .prepare(
-        `UPDATE memory_observations
-            SET status = 'pruned', observation_text = '[pruned]', tags = NULL
-          WHERE status = 'archived'
-            AND archived_at IS NOT NULL
-            AND archived_at < ?`,
-      )
-      .run(input.archivedObservationsBeforeMs);
+    const db = this.db.$sqlite;
+    const observationsBatch = db.prepare(`UPDATE memory_observations
+      SET status = 'pruned', observation_text = '[pruned]', tags = NULL
+      WHERE id IN (
+        SELECT id FROM memory_observations
+        WHERE status = 'archived' AND archived_at IS NOT NULL AND archived_at < ?
+        ORDER BY archived_at, id LIMIT ?
+      )`);
+    const observationsDeleted = await runBatchedPrune(
+      (limit) => observationsBatch.run(input.archivedObservationsBeforeMs, limit).changes,
+    );
     // Facts carry NO coverage role → a true hard DELETE is correct (the only
     // DELETE in the forgetting system). expired_at IS NOT NULL keeps live facts.
-    const facts = this.db.$sqlite
-      .prepare(
-        `DELETE FROM memory_facts
-          WHERE expired_at IS NOT NULL
-            AND expired_at < ?`,
-      )
-      .run(input.expiredFactsBeforeMs);
-    return { observationsDeleted: obs.changes, factsDeleted: facts.changes };
+    const factsBatch = db.prepare(`DELETE FROM memory_facts WHERE id IN (
+      SELECT id FROM memory_facts
+      WHERE expired_at IS NOT NULL AND expired_at < ?
+      ORDER BY expired_at, id LIMIT ?
+    )`);
+    const factsDeleted = await runBatchedPrune(
+      (limit) => factsBatch.run(input.expiredFactsBeforeMs, limit).changes,
+    );
+    return { observationsDeleted, factsDeleted };
   }
 
   // ——— Cleanup/archival (raw transcript + job log) ———
@@ -1977,24 +1981,28 @@ export class SqliteMemoryStore implements MemoryStore {
     // Keep the summary exact in the SAME transaction. A TEMP key table avoids
     // returning every deleted body row to JS and lets one set-based UPDATE repair
     // only affected threads after the delete (including the new MAX timestamp).
-    return this.db.$sqlite.transaction(() => {
-      this.db.$sqlite.exec(`
-        CREATE TEMP TABLE IF NOT EXISTS _helm_pruned_message_threads (
-          thread_id TEXT PRIMARY KEY
-        ) WITHOUT ROWID;
-        DELETE FROM _helm_pruned_message_threads;
-      `);
-      this.db.$sqlite
+    const db = this.db.$sqlite;
+    db.exec(`CREATE TEMP TABLE IF NOT EXISTS _helm_pruned_message_threads (
+      thread_id TEXT PRIMARY KEY
+    ) WITHOUT ROWID;`);
+    const pruneBatch = db.transaction((limit: number) => {
+      db.exec("DELETE FROM _helm_pruned_message_threads");
+      db.prepare(
+        `INSERT OR IGNORE INTO _helm_pruned_message_threads (thread_id)
+         SELECT DISTINCT thread_id FROM memory_messages WHERE id IN (
+           SELECT id FROM memory_messages WHERE created_at < ?
+           ORDER BY created_at, id LIMIT ?
+         )`,
+      ).run(olderThanMs, limit);
+      const res = db
         .prepare(
-          `INSERT OR IGNORE INTO _helm_pruned_message_threads (thread_id)
-           SELECT thread_id FROM memory_messages WHERE created_at < ?`,
+          `DELETE FROM memory_messages WHERE id IN (
+             SELECT id FROM memory_messages WHERE created_at < ?
+             ORDER BY created_at, id LIMIT ?
+           )`,
         )
-        .run(olderThanMs);
-      const res = this.db
-        .delete(memoryMessages)
-        .where(lt(memoryMessages.createdAt, new Date(olderThanMs)))
-        .run();
-      this.db.$sqlite.exec(`
+        .run(olderThanMs, limit);
+      db.exec(`
         UPDATE memory_threads AS t
            SET message_count = (
                  SELECT COUNT(*) FROM memory_messages m WHERE m.thread_id = t.id
@@ -2006,18 +2014,17 @@ export class SqliteMemoryStore implements MemoryStore {
         DELETE FROM _helm_pruned_message_threads;
       `);
       return res.changes;
-    })();
+    });
+    return runBatchedPrune(pruneBatch);
   }
 
   async pruneFinishedJobsOlderThan(olderThanMs: number): Promise<number> {
-    const res = this.db.$sqlite
-      .prepare(
-        `DELETE FROM memory_jobs
-          WHERE status IN ('done', 'failed')
-            AND updated_at < ?`,
-      )
-      .run(olderThanMs);
-    return res.changes;
+    const batch = this.db.$sqlite.prepare(`DELETE FROM memory_jobs WHERE id IN (
+      SELECT id FROM memory_jobs
+      WHERE status IN ('done', 'failed') AND updated_at < ?
+      ORDER BY updated_at, id LIMIT ?
+    )`);
+    return runBatchedPrune((limit) => batch.run(olderThanMs, limit).changes);
   }
 
   // Auto-compaction model→price resolution, write half: stamp the served model

--- a/packages/core/src/store/sqlite/oauth-usage.ts
+++ b/packages/core/src/store/sqlite/oauth-usage.ts
@@ -1,6 +1,7 @@
 import { type OAuthUsageRow, OAuthUsageRowSchema } from "@helm/shared";
 import { and, count, gte, lt, sql } from "drizzle-orm";
 import type { OAuthUsageStore } from "../ports.js";
+import { runBatchedPrune } from "./batched-prune.js";
 import type { SqliteDb } from "./migrate.js";
 import { oauthUsage } from "./schema.js";
 
@@ -84,8 +85,10 @@ export class SqliteOAuthUsageStore implements OAuthUsageStore {
   }
 
   async pruneUsageOlderThan(olderThanMs: number): Promise<number> {
-    const res = this.db.delete(oauthUsage).where(lt(oauthUsage.bucketMs, olderThanMs)).run();
-    return res.changes;
+    const batch = this.db.$sqlite.prepare(`DELETE FROM oauth_usage WHERE rowid IN (
+      SELECT rowid FROM oauth_usage WHERE bucket_ms < ? ORDER BY bucket_ms, rowid LIMIT ?
+    )`);
+    return runBatchedPrune((limit) => batch.run(olderThanMs, limit).changes);
   }
 
   // Aggregated row -> OAuthUsageRow. Re-validates through the shared schema so a

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -28,11 +28,13 @@ import type {
 import { PERSISTED_SESSION_MAX_REVISIONS, PERSISTED_SESSION_MAX_STORED_BYTES } from "../ports.js";
 import { likeContains } from "../sql-like.js";
 import { denormalizedDecisionCost } from "../telemetry-cost.js";
+import { runBatchedPrune, yieldToEventLoop } from "./batched-prune.js";
 import type { SqliteDb } from "./migrate.js";
-import { payloadBlobs, requestPayloads, sessionRevisions, sessions, telemetry } from "./schema.js";
+import { requestPayloads, sessionRevisions, sessions, telemetry } from "./schema.js";
 
 type TelemetryRow = typeof telemetry.$inferSelect;
 type SessionRevisionRow = typeof sessionRevisions.$inferSelect;
+const SESSION_PRUNE_MARKER = "__helm_pruning__";
 
 function decodeSessionRevisionRow(row: SessionRevisionRow): SessionRevisionRecord {
   const { bodyBytes: _, ...revision } = row;
@@ -71,6 +73,46 @@ export class SqliteTelemetryStore implements TelemetryStore {
   private sessionPreparedStmts:
     | ReturnType<SqliteTelemetryStore["buildSessionWriteStmts"]>
     | undefined;
+  private readonly sessionPrunes = new Map<string, Promise<number>>();
+
+  private async finishClaimedSessionPrune(sessionRef: string): Promise<number> {
+    const active = this.sessionPrunes.get(sessionRef);
+    if (active) return active;
+    const db = this.db.$sqlite;
+    const work = (async () => {
+      const revisions = db.prepare(`DELETE FROM session_revisions WHERE request_id IN (
+        SELECT request_id FROM session_revisions WHERE session_ref = ?
+        ORDER BY sequence, request_id LIMIT ?
+      )`);
+      await runBatchedPrune((limit) => revisions.run(sessionRef, limit).changes);
+      return db
+        .prepare(
+          "DELETE FROM sessions WHERE session_ref = ? AND head_request_id = ? AND NOT EXISTS (SELECT 1 FROM session_revisions WHERE session_ref = ?)",
+        )
+        .run(sessionRef, SESSION_PRUNE_MARKER, sessionRef).changes;
+    })();
+    this.sessionPrunes.set(sessionRef, work);
+    try {
+      return await work;
+    } finally {
+      if (this.sessionPrunes.get(sessionRef) === work) this.sessionPrunes.delete(sessionRef);
+    }
+  }
+
+  private async waitForClaimedSessionPrune(sessionRef: string): Promise<boolean> {
+    const active = this.sessionPrunes.get(sessionRef);
+    if (active) {
+      await active;
+      return true;
+    }
+    const claimed = this.db.$sqlite
+      .prepare("SELECT 1 FROM sessions WHERE session_ref = ? AND head_request_id = ?")
+      .get(sessionRef, SESSION_PRUNE_MARKER);
+    if (!claimed) return false;
+    await this.finishClaimedSessionPrune(sessionRef);
+    return true;
+  }
+
   private buildSessionWriteStmts() {
     const db = this.db.$sqlite;
     return {
@@ -149,118 +191,140 @@ export class SqliteTelemetryStore implements TelemetryStore {
   }
 
   async upsertSessionRevision(input: UpsertSessionRevisionInput): Promise<void> {
+    // A persisted marker makes a multi-batch prune crash-safe. Reactivation waits for
+    // the expired capture to finish, then starts a fresh root instead of reviving a
+    // partially deleted revision chain.
+    let resumedAfterPrune = false;
     const at = input.createdAt;
     const atMs = at.getTime();
     const storedBytes = Buffer.byteLength(
       input.requestDeltaJson + input.requestEnvelopeJson + (input.responseJson ?? ""),
       "utf8",
     );
-    this.db.$sqlite.transaction(() => {
-      this.db
-        .insert(sessions)
-        .values({
-          sessionRef: input.sessionRef,
-          accountId: input.accountId,
-          apiKeyId: input.apiKeyId,
-          source: input.source,
-          externalSessionId: input.externalSessionId,
-          createdAt: at,
-          lastSeenAt: at,
-        })
-        .onConflictDoNothing()
-        .run();
+    for (;;) {
+      resumedAfterPrune =
+        (await this.waitForClaimedSessionPrune(input.sessionRef)) || resumedAfterPrune;
+      const admitted = this.db.$sqlite.transaction(() => {
+        // The await above can yield after observing no claim. Recheck inside the
+        // synchronous write transaction so a prune that claimed in that gap wins.
+        const pruning = this.db.$sqlite
+          .prepare("SELECT 1 FROM sessions WHERE session_ref = ? AND head_request_id = ?")
+          .get(input.sessionRef, SESSION_PRUNE_MARKER);
+        if (pruning) return false;
+        this.db
+          .insert(sessions)
+          .values({
+            sessionRef: input.sessionRef,
+            accountId: input.accountId,
+            apiKeyId: input.apiKeyId,
+            source: input.source,
+            externalSessionId: input.externalSessionId,
+            createdAt: at,
+            lastSeenAt: at,
+          })
+          .onConflictDoNothing()
+          .run();
 
-      const existing = this.db
-        .select({
-          requestId: sessionRevisions.requestId,
-          sessionRef: sessionRevisions.sessionRef,
-          responseJson: sessionRevisions.responseJson,
-        })
-        .from(sessionRevisions)
-        .where(eq(sessionRevisions.requestId, input.requestId))
-        .get();
-      if (existing) {
-        if (existing.sessionRef !== input.sessionRef) throw new Error("request session mismatch");
-        const responseJson = input.responseJson;
-        const responseBytes =
-          responseJson !== null && existing.responseJson === null
-            ? Buffer.byteLength(responseJson, "utf8")
-            : 0;
-        if (responseBytes === 0 || responseJson === null) return;
+        const existing = this.db
+          .select({
+            requestId: sessionRevisions.requestId,
+            sessionRef: sessionRevisions.sessionRef,
+            responseJson: sessionRevisions.responseJson,
+          })
+          .from(sessionRevisions)
+          .where(eq(sessionRevisions.requestId, input.requestId))
+          .get();
+        if (existing) {
+          if (existing.sessionRef !== input.sessionRef) throw new Error("request session mismatch");
+          const responseJson = input.responseJson;
+          const responseBytes =
+            responseJson !== null && existing.responseJson === null
+              ? Buffer.byteLength(responseJson, "utf8")
+              : 0;
+          if (responseBytes === 0 || responseJson === null) return true;
+          const session = this.db
+            .select({ storedBytes: sessions.storedBytes })
+            .from(sessions)
+            .where(eq(sessions.sessionRef, input.sessionRef))
+            .get();
+          if (!session) throw new Error("session row missing after insert");
+          if (session.storedBytes + responseBytes > PERSISTED_SESSION_MAX_STORED_BYTES)
+            throw new Error("session capture limit exceeded");
+          this.db
+            .update(sessions)
+            .set({
+              storedBytes: sql`${sessions.storedBytes} + ${responseBytes}`,
+              lastSeenAt: sql`max(${sessions.lastSeenAt}, ${atMs})`,
+            })
+            .where(eq(sessions.sessionRef, input.sessionRef))
+            .run();
+          this.sessionWriteStmts().updateResponse.run({
+            requestId: input.requestId,
+            responseId: input.responseId ?? null,
+            responseJson: encodePayloadText(responseJson),
+            responseBytes,
+            fidelity: input.fidelity,
+          });
+          return true;
+        }
+
+        let parentRequestId = input.parentRequestId;
+        if (parentRequestId !== null) {
+          const parent = this.db
+            .select({ sessionRef: sessionRevisions.sessionRef })
+            .from(sessionRevisions)
+            .where(eq(sessionRevisions.requestId, parentRequestId))
+            .get();
+          if ((!parent || parent.sessionRef !== input.sessionRef) && resumedAfterPrune) {
+            parentRequestId = null;
+          } else if (!parent || parent.sessionRef !== input.sessionRef) {
+            throw new Error("session parent mismatch");
+          }
+        }
+
         const session = this.db
-          .select({ storedBytes: sessions.storedBytes })
+          .select({ revisionCount: sessions.revisionCount, storedBytes: sessions.storedBytes })
           .from(sessions)
           .where(eq(sessions.sessionRef, input.sessionRef))
           .get();
         if (!session) throw new Error("session row missing after insert");
-        if (session.storedBytes + responseBytes > PERSISTED_SESSION_MAX_STORED_BYTES)
+        if (
+          session.revisionCount >= PERSISTED_SESSION_MAX_REVISIONS ||
+          session.storedBytes + storedBytes > PERSISTED_SESSION_MAX_STORED_BYTES
+        ) {
           throw new Error("session capture limit exceeded");
+        }
+        const sequence = session.revisionCount + 1;
+        this.sessionWriteStmts().insert.run({
+          requestId: input.requestId,
+          sessionRef: input.sessionRef,
+          sequence,
+          parentRequestId,
+          retainCount: input.retainCount,
+          requestDeltaJson: encodePayloadText(input.requestDeltaJson),
+          requestEnvelopeJson: encodePayloadText(input.requestEnvelopeJson),
+          bodyBytes: storedBytes,
+          responseId: input.responseId ?? null,
+          responseJson: input.responseJson === null ? null : encodePayloadText(input.responseJson),
+          fidelity: input.fidelity,
+          createdAt: atMs,
+        });
         this.db
           .update(sessions)
           .set({
-            storedBytes: sql`${sessions.storedBytes} + ${responseBytes}`,
+            headRequestId: input.requestId,
+            revisionCount: sequence,
+            storedBytes: sql`${sessions.storedBytes} + ${storedBytes}`,
             lastSeenAt: sql`max(${sessions.lastSeenAt}, ${atMs})`,
           })
           .where(eq(sessions.sessionRef, input.sessionRef))
           .run();
-        this.sessionWriteStmts().updateResponse.run({
-          requestId: input.requestId,
-          responseId: input.responseId ?? null,
-          responseJson: encodePayloadText(responseJson),
-          responseBytes,
-          fidelity: input.fidelity,
-        });
-        return;
-      }
-
-      if (input.parentRequestId !== null) {
-        const parent = this.db
-          .select({ sessionRef: sessionRevisions.sessionRef })
-          .from(sessionRevisions)
-          .where(eq(sessionRevisions.requestId, input.parentRequestId))
-          .get();
-        if (!parent || parent.sessionRef !== input.sessionRef)
-          throw new Error("session parent mismatch");
-      }
-
-      const session = this.db
-        .select({ revisionCount: sessions.revisionCount, storedBytes: sessions.storedBytes })
-        .from(sessions)
-        .where(eq(sessions.sessionRef, input.sessionRef))
-        .get();
-      if (!session) throw new Error("session row missing after insert");
-      if (
-        session.revisionCount >= PERSISTED_SESSION_MAX_REVISIONS ||
-        session.storedBytes + storedBytes > PERSISTED_SESSION_MAX_STORED_BYTES
-      ) {
-        throw new Error("session capture limit exceeded");
-      }
-      const sequence = session.revisionCount + 1;
-      this.sessionWriteStmts().insert.run({
-        requestId: input.requestId,
-        sessionRef: input.sessionRef,
-        sequence,
-        parentRequestId: input.parentRequestId,
-        retainCount: input.retainCount,
-        requestDeltaJson: encodePayloadText(input.requestDeltaJson),
-        requestEnvelopeJson: encodePayloadText(input.requestEnvelopeJson),
-        bodyBytes: storedBytes,
-        responseId: input.responseId ?? null,
-        responseJson: input.responseJson === null ? null : encodePayloadText(input.responseJson),
-        fidelity: input.fidelity,
-        createdAt: atMs,
-      });
-      this.db
-        .update(sessions)
-        .set({
-          headRequestId: input.requestId,
-          revisionCount: sequence,
-          storedBytes: sql`${sessions.storedBytes} + ${storedBytes}`,
-          lastSeenAt: sql`max(${sessions.lastSeenAt}, ${atMs})`,
-        })
-        .where(eq(sessions.sessionRef, input.sessionRef))
-        .run();
-    })();
+        return true;
+      })();
+      if (admitted) return;
+      resumedAfterPrune = true;
+      await this.finishClaimedSessionPrune(input.sessionRef);
+    }
   }
 
   async getSessionByRef(sessionRef: string): Promise<SessionRecord | null> {
@@ -381,12 +445,23 @@ export class SqliteTelemetryStore implements TelemetryStore {
 
   async pruneInactiveSessions(olderThanMs: number): Promise<number> {
     const db = this.db.$sqlite;
-    return db.transaction(() => {
-      db.prepare(
-        "DELETE FROM session_revisions WHERE session_ref IN (SELECT session_ref FROM sessions WHERE last_seen_at < ?)",
-      ).run(olderThanMs);
-      return db.prepare("DELETE FROM sessions WHERE last_seen_at < ?").run(olderThanMs).changes;
-    })();
+    let deletedSessions = 0;
+    for (;;) {
+      const candidate = db
+        .prepare(`SELECT session_ref AS sessionRef FROM sessions
+          WHERE last_seen_at < ? ORDER BY last_seen_at, session_ref LIMIT 1`)
+        .get(olderThanMs) as { sessionRef: string } | undefined;
+      if (!candidate) break;
+      const claimed = db
+        .prepare(
+          "UPDATE sessions SET head_request_id = ? WHERE session_ref = ? AND last_seen_at < ?",
+        )
+        .run(SESSION_PRUNE_MARKER, candidate.sessionRef, olderThanMs);
+      if (claimed.changes === 0) continue;
+      deletedSessions += await this.finishClaimedSessionPrune(candidate.sessionRef);
+      await yieldToEventLoop();
+    }
+    return deletedSessions;
   }
 
   async queryRecent(limit: number): Promise<RecentDecisionRecord[]> {
@@ -766,27 +841,29 @@ export class SqliteTelemetryStore implements TelemetryStore {
   // Retention auto-prune: drop rows strictly older than the cutoff. The
   // created_at index keeps this cheap enough to call opportunistically.
   async prunePayloads(olderThanMs: number): Promise<void> {
-    this.db
-      .delete(requestPayloads)
-      .where(lt(requestPayloads.createdAt, new Date(olderThanMs)))
-      .run();
+    const db = this.db.$sqlite;
+    const payloadBatch = db.prepare(`DELETE FROM request_payloads WHERE request_id IN (
+      SELECT request_id FROM request_payloads WHERE created_at < ?
+      ORDER BY created_at, request_id LIMIT ?
+    )`);
+    await runBatchedPrune((limit) => payloadBatch.run(olderThanMs, limit).changes);
     // Same-cutoff blob prune. Safe because an in-use image's created_at is touched
     // on every referencing write, so blob.created_at >= every surviving payload's
     // created_at → a kept payload never references a pruned blob.
-    this.db
-      .delete(payloadBlobs)
-      .where(lt(payloadBlobs.createdAt, new Date(olderThanMs)))
-      .run();
+    const blobBatch = db.prepare(`DELETE FROM payload_blobs WHERE sha256 IN (
+      SELECT sha256 FROM payload_blobs WHERE created_at < ?
+      ORDER BY created_at, sha256 LIMIT ?
+    )`);
+    await runBatchedPrune((limit) => blobBatch.run(olderThanMs, limit).changes);
   }
 
   // Telemetry retention prune — the decision table's equivalent of prunePayloads
   // (it had none before, hence unbounded growth). Strict lower bound on created_at.
   async pruneTelemetry(olderThanMs: number): Promise<number> {
-    const res = this.db
-      .delete(telemetry)
-      .where(lt(telemetry.createdAt, new Date(olderThanMs)))
-      .run();
-    return res.changes;
+    const batch = this.db.$sqlite.prepare(`DELETE FROM telemetry WHERE id IN (
+      SELECT id FROM telemetry WHERE created_at < ? ORDER BY created_at, id LIMIT ?
+    )`);
+    return runBatchedPrune((limit) => batch.run(olderThanMs, limit).changes);
   }
 
   async countTelemetryOlderThan(olderThanMs: number): Promise<number> {

--- a/packages/core/src/telemetry/decision.ts
+++ b/packages/core/src/telemetry/decision.ts
@@ -118,9 +118,9 @@ function providerAttemptRecord(a: AttemptRecord): DecisionRecord["provider_attem
     error_class: a.error_class,
     latency_ms: a.latency_ms,
     cost_usd: a.cost_usd,
-    // Per-attempt upstream failure detail (admin-debug-error-detail). The whole
-    // record is run through `redact` below, so any key echoed in provider_raw
-    // is irreversibly fingerprinted before persistence (principle 7).
+    // Per-attempt upstream failure detail (admin-debug-error-detail). Provider clients
+    // keep the bounded raw diagnostics while removing actual credentials; the final
+    // telemetry gate remains defense in depth for credential fields and payloads.
     error_detail: a.error_detail,
     ...(a.passthrough_considered !== undefined
       ? { passthrough_considered: a.passthrough_considered }

--- a/packages/core/src/telemetry/redaction.test.ts
+++ b/packages/core/src/telemetry/redaction.test.ts
@@ -94,6 +94,34 @@ describe("redact", () => {
     expect(redact(input)).toEqual(input);
   });
 
+  it("preserves string token metrics and rate-limit headers while filtering real token fields", () => {
+    const out = redact({
+      provider_headers: {
+        "x-ratelimit-remaining-tokens": "123",
+        "x-request-id": "req-1",
+      },
+      token_count: "456",
+      access_token: "oauth-secret-value",
+      x_google_api_key: "google-secret-value",
+      x_access_token: "oauth-header-secret-value",
+      x_proxy_authorization: "proxy-header-secret-value",
+    });
+
+    expect(out.provider_headers).toEqual({
+      "x-ratelimit-remaining-tokens": "123",
+      "x-request-id": "req-1",
+    });
+    expect(out.token_count).toBe("456");
+    expect(out.access_token).toMatch(/^sha256:/);
+    expect(out.x_google_api_key).toMatch(/^sha256:/);
+    expect(out.x_access_token).toMatch(/^sha256:/);
+    expect(out.x_proxy_authorization).toMatch(/^sha256:/);
+    expect(JSON.stringify(out)).not.toContain("oauth-secret-value");
+    expect(JSON.stringify(out)).not.toContain("google-secret-value");
+    expect(JSON.stringify(out)).not.toContain("oauth-header-secret-value");
+    expect(JSON.stringify(out)).not.toContain("proxy-header-secret-value");
+  });
+
   it("boolean/null under a secret-matching key pass through; strings/objects stay redacted", () => {
     const out = redact({
       token_present: true, // boolean — not a credential

--- a/packages/core/src/telemetry/redaction.ts
+++ b/packages/core/src/telemetry/redaction.ts
@@ -8,7 +8,8 @@ import { createHash } from "node:crypto";
 
 const DEFAULT_KEY_PREFIX_LEN = 12;
 const DEFAULT_PAYLOAD_KEYS = ["messages", "attachments", "prompt", "content", "input"];
-const DEFAULT_SECRET_PATTERN = /(api[_-]?key|authorization|password|secret|token|credential)/i;
+const DEFAULT_SECRET_PATTERN =
+  /^(?:api[_-]?key|x[_-]?(?:goog(?:le)?[_-]?)?api[_-]?key|authorization|(?:x[_-]?)?proxy[_-]?authorization|cookie|set[_-]?cookie|password|client[_-]?secret|secret(?:[_-]?(?:key|enc))?|credential(?:s)?|token|token[_-]?bundle|(?:x[_-]?)?access[_-]?token|refresh[_-]?token|id[_-]?token|auth[_-]?token|oauth[_-]?token|x[_-]?auth[_-]?token)$/i;
 
 export interface RedactOptions {
   keyPrefixLen?: number;

--- a/packages/shared/src/decision/schema.test.ts
+++ b/packages/shared/src/decision/schema.test.ts
@@ -294,7 +294,7 @@ describe("DecisionRecordSchema", () => {
     expect(DecisionRecordSchema.safeParse(r).success).toBe(false);
   });
 
-  it("accepts a per-attempt error_detail (upstream status + message + raw body)", () => {
+  it("accepts a per-attempt error_detail with transport and upstream diagnostics", () => {
     const r = fullRecord();
     r.provider_attempts[0] = {
       alias: "coding_model",
@@ -308,6 +308,9 @@ describe("DecisionRecordSchema", () => {
         upstream_status: 429,
         message: "upstream returned 429",
         provider_raw: { error: { message: "rate limit exceeded", type: "rate_limit_error" } },
+        provider_headers: { "x-request-id": "req_upstream_1" },
+        cause: { name: "Error", code: "ECONNRESET", message: "socket closed" },
+        stack: "UpstreamError: upstream returned 429\n    at request",
       },
     };
     const parsed = DecisionRecordSchema.parse(r);
@@ -316,6 +319,11 @@ describe("DecisionRecordSchema", () => {
     expect(parsed.provider_attempts[0]?.error_detail?.provider_raw).toEqual({
       error: { message: "rate limit exceeded", type: "rate_limit_error" },
     });
+    expect(parsed.provider_attempts[0]?.error_detail?.provider_headers).toEqual({
+      "x-request-id": "req_upstream_1",
+    });
+    expect(parsed.provider_attempts[0]?.error_detail?.cause).toMatchObject({ code: "ECONNRESET" });
+    expect(parsed.provider_attempts[0]?.error_detail?.stack).toContain("UpstreamError");
   });
 
   it("defaults error_detail to null when omitted (legacy records round-trip)", () => {

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -73,16 +73,19 @@ export const LaneDecisionSchema = z.object({
 // for attempts that actually failed at the upstream — it carries WHY a single
 // candidate failed even when a LATER candidate served the request (so the
 // failure is no longer visible in the terminal `final` error). Mirrors
-// HelmError's redacted shape; principle 7: `message`/`provider_raw` are already
-// key-scrubbed by the producer and pass through the telemetry `redact` gate.
+// HelmError's diagnostic shape; `message`/`provider_raw` retain upstream detail after
+// the producer removes actual credentials and the telemetry gate protects payloads.
 //   • upstream_status — the REAL upstream HTTP status (e.g. 429/500); null for a
 //     timeout / network error with no response.
-//   • message         — short, redacted, human-readable (e.g. "upstream returned 429").
-//   • provider_raw    — the upstream error body (key-scrubbed), or null when absent.
+//   • message         — bounded, human-readable (e.g. "upstream returned 429").
+//   • provider_raw    — the bounded upstream error body, or null when absent.
 export const AttemptErrorDetailSchema = z.object({
   upstream_status: z.number().int().nullable(),
   message: z.string(),
   provider_raw: z.record(z.string(), z.unknown()).nullable(),
+  provider_headers: z.record(z.string(), z.string()).nullable().optional(),
+  cause: z.unknown().nullable().optional(),
+  stack: z.string().nullable().optional(),
 });
 
 export const ProviderAttemptSchema = z.object({

--- a/packages/shared/src/error/schema.ts
+++ b/packages/shared/src/error/schema.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 // Structured error model. core produces a unified internal error; the Protocol
 // Adapter's responseOut translates it into each client protocol's error shape
 // (docs/05, 07). The error_class -> HTTP status table is the single source of
-// truth (no magic numbers scattered in the gateway). Per CLAUDE.md principle 7,
-// message/provider_raw must already be redacted by the producer.
+// truth (no magic numbers scattered in the gateway). message/provider_raw keep
+// diagnostic detail but must not contain API keys, OAuth tokens, or auth cookies.
 
 // The error classes from docs/07, in document order.
 export const ErrorClassSchema = z.enum([
@@ -27,9 +27,9 @@ export type ErrorClass = z.infer<typeof ErrorClassSchema>;
 export const HelmErrorSchema = z.object({
   error_class: ErrorClassSchema,
   http_status: z.number().int(), // must equal the mapped value (see factory + tests)
-  message: z.string(), // redacted, human-readable
+  message: z.string(), // credential-safe, human-readable
   trace_id: z.string().min(1), // links the decision record; restorable in the Debug UI
-  provider_raw: z.record(z.string(), z.unknown()).nullable(), // upstream raw error (redacted)
+  provider_raw: z.record(z.string(), z.unknown()).nullable(), // upstream raw error body
 });
 
 export type HelmError = z.infer<typeof HelmErrorSchema>;


### PR DESCRIPTION
## What changed

- prune SQLite retention continuously in batches of 10 with event-loop yields and a durable session-prune claim
- replace WriteQueue overflow shedding with awaited lossless backpressure
- refresh execution OAuth credentials with request timeout plus five minutes of headroom
- after ambiguous refresh failures, wait with stable 1-3s jitter, re-read the shared store, never replay the old rotating refresh token, and cool the failed account for 30s while trying a sibling
- preserve real upstream expiry for Anthropic, OpenAI Codex, GitHub Copilot, and xAI credentials
- persist bounded upstream body, safe headers, cause, code, and stack for internal diagnostics while still excluding actual credentials

## Root causes

Large one-shot SQLite retention deletes blocked the event loop long enough to overflow deferred writes. The old overflow path silently discarded telemetry and Memory tasks. Provider telemetry also collapsed transport failures to fetch failed and discarded nested causes. Subscription refresh used too little execution headroom, and automatic replay of a rotating refresh token after an ambiguous 5xx/transport result could invalidate the token family.

## Validation

- 853 affected Vitest tests
- 202 SQLite/Postgres store contract tests
- shared/core/gateway TypeScript checks
- admin svelte-check: 0 errors, 0 warnings
- full pnpm build
- Admin Playwright: 9/9
- Biome on all changed TS/JSON files
- git diff --check
