### PR TITLE
[codex] release 0.28.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.22",
+  "version": "0.28.23",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump the root Helm API version from `0.28.22` to `0.28.23` after merging production resilience fixes in PR #662.

## Scope

- version-only root `package.json` change
- release base: `781caa73c5bdd016c3b72d891402f8531083c847`
- no runtime or dependency changes beyond PR #662

## Validation

PR #662 passed `PR / verify`, `PR / e2e`, and `PR / docker`. The release PR must pass the same three checks before merge; the resulting main SHA will drive the automatic image/tag/GitHub Release workflow.
