### PR TITLE
fix(ci): make Docker dependency install resilient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,27 @@ RUN corepack enable && apt-get update && apt-get install -y --no-install-recomme
     python3 make g++ \
  && rm -rf /var/lib/apt/lists/*
 
-# Copy lockfile + workspace manifests first for maximal layer caching.
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Download dependencies in a lockfile-only layer so release version bumps do not
+# invalidate the network cache. Extra retries tolerate transient registry resets.
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN corepack prepare pnpm@10.25.0 --activate \
+ && pnpm config set fetch-retries 5 \
+ && pnpm config set fetch-timeout 120000 \
+ && pnpm fetch --frozen-lockfile
+
+# Link the fetched packages only after copying workspace manifests.
+COPY package.json ./
 COPY apps/gateway/package.json apps/gateway/
 COPY apps/admin/package.json apps/admin/
 COPY apps/portal/package.json apps/portal/
 COPY packages/core/package.json packages/core/
 COPY packages/shared/package.json packages/shared/
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --offline --frozen-lockfile
 
 COPY . .
 RUN pnpm build
 # Flatten the gateway + its prod dependencies into /app/out.
-RUN pnpm deploy --filter=@helm/gateway --prod --legacy /app/out
+RUN pnpm deploy --filter=@helm/gateway --prod --legacy --prefer-offline /app/out
 
 # ---- runtime ----
 FROM node:22-slim AS runtime

--- a/packages/shared/src/dockerfile.test.ts
+++ b/packages/shared/src/dockerfile.test.ts
@@ -32,6 +32,17 @@ describe("Dockerfile contract", () => {
     expect(dockerfile).toContain("--frozen-lockfile");
   });
 
+  it("caches dependency downloads independently of package metadata", () => {
+    const fetch = dockerfile.indexOf("pnpm fetch --frozen-lockfile");
+    const manifests = dockerfile.indexOf("COPY package.json ./");
+    const install = dockerfile.indexOf("RUN pnpm install --offline --frozen-lockfile");
+
+    expect(fetch).toBeGreaterThanOrEqual(0);
+    expect(fetch).toBeLessThan(manifests);
+    expect(install).toBeGreaterThan(manifests);
+    expect(dockerfile).toMatch(/pnpm deploy .*--prefer-offline/);
+  });
+
   it("creates the config and data mount points owned by the runtime user", () => {
     expect(dockerfile).toMatch(/mkdir -p \/app\/config \/app\/data/);
     expect(dockerfile).toMatch(/chown -R helm:helm \/app/);


### PR DESCRIPTION
## Summary
- prefetch pnpm dependencies in a lockfile-only Docker layer
- install from the prefetched store offline
- prefer cached metadata during legacy deploy and retry transient registry failures

## Incident
Main CI for v0.28.23 failed twice while registry.npmjs.org reset or timed out tarball downloads. This keeps release version changes from invalidating the network-heavy layer.

## Verification
- CI=true pnpm exec vitest run packages/shared/src/dockerfile.test.ts (8/8)
- CI=true pnpm exec biome check packages/shared/src/dockerfile.test.ts
- real docker build succeeded
- built container healthy; /healthz ready; /version reports 0.28.23 and injected SHA