### PR TITLE
[codex] release v0.28.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.23",
+  "version": "0.28.24",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the Helm API release version from `0.28.23` to `0.28.24`

## Release scope

- recover transient Node `ECANCELED` failures at the HTTP fetch boundary
- recover pre-output Responses WebSocket `send()` failures with the existing bounded retry budget, then HTTP fallback
- prevent stale same-session leases and aborted queued requests from sending upstream
- preserve the no-replay boundary after WebSocket output starts

## Evidence

- fix PR #665 merged as `6a05824acbd3c4792b4d548ba5128d3767c194a7`
- main CI run 30575523203 passed `verify`, `e2e`, and `docker`

After merge, the publish workflow must create `v0.28.24` and an immutable image digest before Remote deployment.
