### PR TITLE
[codex] retry transient GHCR manifest checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -169,16 +169,29 @@ jobs:
           IMMUTABLE_TAG: ${{ steps.meta.outputs.immutable_tag }}
         run: |
           CHECK_LOG="${RUNNER_TEMP}/helm-immutable-manifest.log"
-          if docker manifest inspect "${IMMUTABLE_TAG}" >"${CHECK_LOG}" 2>&1; then
+          IMAGE_STATE=""
+          for attempt in 1 2 3; do
+            if docker manifest inspect "${IMMUTABLE_TAG}" >"${CHECK_LOG}" 2>&1; then
+              IMAGE_STATE=exists
+              break
+            elif grep -Eiq 'manifest unknown|no such manifest' "${CHECK_LOG}"; then
+              IMAGE_STATE=missing
+              break
+            elif [ "${attempt}" -lt 3 ]; then
+              echo "::warning::GHCR manifest lookup failed; retrying (${attempt}/3)"
+              sleep 2
+            else
+              echo "::error::cannot determine whether ${IMMUTABLE_TAG} exists"
+              cat "${CHECK_LOG}"
+              exit 1
+            fi
+          done
+          if [ "${IMAGE_STATE}" = "exists" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Reusing existing immutable image ${IMMUTABLE_TAG}; metadata validation follows."
-          elif grep -Eiq 'manifest unknown|no such manifest' "${CHECK_LOG}"; then
+          else
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Immutable image ${IMMUTABLE_TAG} does not exist; it will be built once."
-          else
-            echo "::error::cannot determine whether ${IMMUTABLE_TAG} exists"
-            cat "${CHECK_LOG}"
-            exit 1
           fi
 
       - name: Build immutable image
@@ -205,14 +218,27 @@ jobs:
           # through `docker push`, so the remaining inspect/push race is reported
           # as a known registry limitation rather than pretending it is atomic.
           CHECK_LOG="${RUNNER_TEMP}/helm-immutable-pre-push.log"
-          if docker manifest inspect "${IMMUTABLE_TAG}" >"${CHECK_LOG}" 2>&1; then
+          IMAGE_STATE=""
+          for attempt in 1 2 3; do
+            if docker manifest inspect "${IMMUTABLE_TAG}" >"${CHECK_LOG}" 2>&1; then
+              IMAGE_STATE=exists
+              break
+            elif grep -Eiq 'manifest unknown|no such manifest' "${CHECK_LOG}"; then
+              IMAGE_STATE=missing
+              break
+            elif [ "${attempt}" -lt 3 ]; then
+              echo "::warning::GHCR manifest lookup failed; retrying (${attempt}/3)"
+              sleep 2
+            else
+              echo "::error::cannot safely publish ${IMMUTABLE_TAG}"
+              cat "${CHECK_LOG}"
+              exit 1
+            fi
+          done
+          if [ "${IMAGE_STATE}" = "exists" ]; then
             echo "${IMMUTABLE_TAG} appeared while building; do not overwrite it."
-          elif grep -Eiq 'manifest unknown|no such manifest' "${CHECK_LOG}"; then
-            docker push "${IMMUTABLE_TAG}"
           else
-            echo "::error::cannot safely publish ${IMMUTABLE_TAG}"
-            cat "${CHECK_LOG}"
-            exit 1
+            docker push "${IMMUTABLE_TAG}"
           fi
 
       - name: Verify immutable image
@@ -358,15 +384,23 @@ jobs:
           # release. An existing one is an interrupted prior publish and may be
           # reconciled only from strict, independently verifiable metadata.
           CHECK_LOG="${RUNNER_TEMP}/helm-orphan-version-manifest.log"
-          if docker manifest inspect "${TARGET_TAG}" >"${CHECK_LOG}" 2>&1; then
-            VERSION_EXISTS=true
-          elif grep -Eiq 'manifest unknown|no such manifest' "${CHECK_LOG}"; then
-            VERSION_EXISTS=false
-          else
-            echo "::error::cannot inspect possible interrupted release ${TARGET_TAG}"
-            cat "${CHECK_LOG}"
-            exit 1
-          fi
+          VERSION_EXISTS=""
+          for attempt in 1 2 3; do
+            if docker manifest inspect "${TARGET_TAG}" >"${CHECK_LOG}" 2>&1; then
+              VERSION_EXISTS=true
+              break
+            elif grep -Eiq 'manifest unknown|no such manifest' "${CHECK_LOG}"; then
+              VERSION_EXISTS=false
+              break
+            elif [ "${attempt}" -lt 3 ]; then
+              echo "::warning::GHCR manifest lookup failed; retrying (${attempt}/3)"
+              sleep 2
+            else
+              echo "::error::cannot inspect possible interrupted release ${TARGET_TAG}"
+              cat "${CHECK_LOG}"
+              exit 1
+            fi
+          done
 
           if [ "${VERSION_EXISTS}" = "false" ]; then
             emit_state true "${CURRENT_SHA}" "${CURRENT_DIGEST}" "${CURRENT_REF}" false false
@@ -435,15 +469,23 @@ jobs:
           manifest_exists() {
             local ref="$1"
             local log="${RUNNER_TEMP}/helm-version-manifest.log"
-            if docker manifest inspect "${ref}" >"${log}" 2>&1; then
-              return 0
-            fi
-            if grep -Eiq 'manifest unknown|no such manifest' "${log}"; then
-              return 1
-            fi
-            echo "::error::cannot inspect ${ref}"
-            cat "${log}"
-            return 2
+            local attempt
+            for attempt in 1 2 3; do
+              if docker manifest inspect "${ref}" >"${log}" 2>&1; then
+                return 0
+              fi
+              if grep -Eiq 'manifest unknown|no such manifest' "${log}"; then
+                return 1
+              fi
+              if [ "${attempt}" -lt 3 ]; then
+                echo "::warning::GHCR manifest lookup failed; retrying (${attempt}/3)"
+                sleep 2
+              else
+                echo "::error::cannot inspect ${ref}"
+                cat "${log}"
+                return 2
+              fi
+            done
           }
 
           pull_digest() {
@@ -554,15 +596,23 @@ jobs:
           manifest_exists() {
             local ref="$1"
             local log="${RUNNER_TEMP}/helm-latest-manifest.log"
-            if docker manifest inspect "${ref}" >"${log}" 2>&1; then
-              return 0
-            fi
-            if grep -Eiq 'manifest unknown|no such manifest' "${log}"; then
-              return 1
-            fi
-            echo "::error::cannot inspect ${ref}"
-            cat "${log}"
-            return 2
+            local attempt
+            for attempt in 1 2 3; do
+              if docker manifest inspect "${ref}" >"${log}" 2>&1; then
+                return 0
+              fi
+              if grep -Eiq 'manifest unknown|no such manifest' "${log}"; then
+                return 1
+              fi
+              if [ "${attempt}" -lt 3 ]; then
+                echo "::warning::GHCR manifest lookup failed; retrying (${attempt}/3)"
+                sleep 2
+              else
+                echo "::error::cannot inspect ${ref}"
+                cat "${log}"
+                return 2
+              fi
+            done
           }
 
           pull_digest() {

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -262,6 +262,39 @@ describe("release workflow policy", () => {
     expect(verifyStep).toContain('echo "digest_ref=${IMAGE}@${DIGEST}"');
   });
 
+  it("retries transient manifest lookups without treating missing tags as errors", () => {
+    expect(publishRaw.match(/docker manifest inspect/g)).toHaveLength(5);
+
+    for (const name of [
+      "Check immutable image",
+      "Push immutable image",
+      "Resolve effective release image",
+      "Promote release tag",
+      "Promote latest tag",
+    ]) {
+      const step = stepBlock(publishRaw, name);
+      expect(step, `${name} step must exist`).not.toBe("");
+      expect(step).toContain("for attempt in 1 2 3");
+      expect(step).toContain("sleep 2");
+      expect(step.indexOf("manifest unknown|no such manifest")).toBeLessThan(
+        step.indexOf("sleep 2"),
+      );
+      expect(step).toMatch(/(?:exit 1|return 2)/);
+    }
+
+    for (const name of ["Check immutable image", "Push immutable image"]) {
+      expect(stepBlock(publishRaw, name)).toMatch(/IMAGE_STATE=missing\s+break/);
+    }
+    expect(stepBlock(publishRaw, "Resolve effective release image")).toMatch(
+      /VERSION_EXISTS=false\s+break/,
+    );
+    for (const name of ["Promote release tag", "Promote latest tag"]) {
+      expect(stepBlock(publishRaw, name)).toMatch(
+        /manifest unknown\|no such manifest[\s\S]+return 1/,
+      );
+    }
+  });
+
   it("fails closed when the git tag and GitHub Release disagree", () => {
     const metaStep = stepBlock(publishRaw, "Resolve release state + deterministic build info");
     expect(metaStep).toContain("/releases/tags/v${VERSION}");


### PR DESCRIPTION
## What changed

- retry each GHCR manifest lookup up to three times with a fixed two-second delay
- keep missing manifests immediate and preserve fail-closed behavior for unknown errors
- cover all five immutable, semver, and latest manifest boundaries

## Root cause

Publish run 30576479669 reached the official GHCR endpoint after the stale runner hosts override was removed, but a pre-push manifest lookup failed with a TLS handshake timeout. The existing workflow treated any transient registry error as terminal.

## Validation

- Red: the new workflow policy test failed because no bounded retry existed
- Green: CI=true pnpm exec vitest run packages/shared/src/ci-workflow.test.ts (26/26)
- git diff --check
- publish.yml YAML parse
- independent read-only review passed