### PR TITLE
ci: publish GHCR images on hosted runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
-    runs-on: [self-hosted, Linux, X64, docker]
+    runs-on: ubuntu-24.04
     permissions:
       contents: write   # create the tag + GitHub Release on a version bump
       packages: write

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -159,7 +159,13 @@ describe("release workflow policy", () => {
     expect(publishRaw).not.toContain("allow-unsafe-pr-checkout");
   });
 
-  it("keeps the package-write Docker credential run-scoped on the persistent runner", () => {
+  it("keeps GHCR publishing off the self-hosted runner egress", () => {
+    const publishJob = jobBlock(publishRaw, "publish");
+    expect(publishJob).toContain("runs-on: ubuntu-24.04");
+    expect(publishJob).not.toContain("runs-on: [self-hosted, Linux, X64, docker]");
+  });
+
+  it("keeps the package-write Docker credential run-scoped", () => {
     const publishJob = jobBlock(publishRaw, "publish");
     const jobHeader = publishJob.slice(0, publishJob.indexOf("\n    steps:"));
     expect(jobHeader).not.toMatch(/\$\{\{\s*runner\./);


### PR DESCRIPTION
## Summary
- run the privileged GHCR publish job on GitHub-hosted `ubuntu-24.04`
- keep main CI on the self-hosted 199.4 runner pool
- add a policy regression test for the publish runner boundary

## Root cause
The 199.4 runner previously forced `ghcr.io` to the HTTP-only 192.168.199.254 pull cache. After removing that mapping, direct GHCR access works but authenticated image upload still stalled for several minutes with no traffic. The .254 cache cannot proxy official GHCR authentication or push.

## Verification
- `CI=true pnpm exec vitest run packages/shared/src/ci-workflow.test.ts` (27/27)
- `git diff --check`
- workflow YAML parse