### PR TITLE
[codex] record request body size

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -84,6 +84,15 @@ describe('toDetail', () => {
 });
 
 describe('toListItem', () => {
+  it('maps the recorded request body byte count without inventing legacy values', () => {
+    const measured = toListItem(rawRecord({ request_body_bytes: 1_572_864 })) as unknown as {
+      request_body_bytes: number | null;
+    };
+    const legacy = toListItem(rawRecord()) as unknown as { request_body_bytes: number | null };
+    expect(measured.request_body_bytes).toBe(1_572_864);
+    expect(legacy.request_body_bytes).toBeNull();
+  });
+
   it('keeps the unique storage request id separate from reusable client correlation', () => {
     const raw = rawRecord({ request_id: 'req_internal_1', trace_id: 'client_shared_trace' });
     const row = toListItem(raw);

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -68,6 +68,8 @@ export interface RequestListItem {
   // rendered as '—'. A number is a real cost. Crucially distinct from 0 so an
   // unmeasured request never looks like a free one (#6).
   cost_usd: number | null;
+  // Exact UTF-8 byte length of the client request body. null for legacy rows.
+  request_body_bytes: number | null;
   // Served-completion token counts (see TokenUsageView). Every leaf is null on a
   // legacy/un-stamped record → the cell renders '—'.
   usage: TokenUsageView;
@@ -249,6 +251,7 @@ interface RawDecisionRecord {
   requested_model?: string;
   requested_reasoning_effort?: string | null;
   reasoning_effort?: string | null;
+  request_body_bytes?: number | null;
   // Display prefix only (helm_live_ab12) — the record NEVER carries the plaintext
   // key (Principle 7). Null/absent on legacy (pre-enrichment) records.
   key_prefix?: string | null;
@@ -555,6 +558,12 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     latency_ms:
       typeof raw.latency_total_ms === 'number' ? raw.latency_total_ms : sumLatency(attempts),
     cost_usd: listCost(raw, attempts),
+    request_body_bytes:
+      typeof raw.request_body_bytes === 'number' &&
+      Number.isFinite(raw.request_body_bytes) &&
+      raw.request_body_bytes >= 0
+        ? raw.request_body_bytes
+        : null,
     usage: toUsage(raw),
     // True throughput (output ÷ generation time); null → '—' for non-streaming/legacy.
     tps: computeTps(raw),

--- a/apps/admin/src/lib/components/RequestsTable.svelte
+++ b/apps/admin/src/lib/components/RequestsTable.svelte
@@ -2,7 +2,13 @@
   import { goto } from '$app/navigation';
   import type { RequestListItem } from '$lib/api/requests.js';
   import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
-  import { formatDurationMs, formatTimestamp, formatTps, formatUsd } from '$lib/format.js';
+  import {
+    formatBytes,
+    formatDurationMs,
+    formatTimestamp,
+    formatTps,
+    formatUsd,
+  } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import TokensCell from './TokensCell.svelte';
 
@@ -322,6 +328,7 @@
         <th class="px-3 py-2" title={$t('Token usage: input / output, with cached input tokens.')}
           >{$t('Tokens')}</th
         >
+        <th class="px-3 py-2" title={$t('Request body')}>{$t('Request body')}</th>
         <th class="px-3 py-2" title={$t('End-to-end latency and streamed generation throughput.')}
           >{$t('Performance')}</th
         >
@@ -404,6 +411,11 @@
             {/if}
           </td>
           <td data-label={$t('Tokens')} class="px-3 py-2"><TokensCell usage={r.usage} /></td>
+          <td
+            data-testid="cell-request-body"
+            data-label={$t('Request body')}
+            class="px-3 py-2 font-mono text-ink-body"
+          >{formatBytes(r.request_body_bytes)}</td>
           <td data-label={$t('Performance')} class="px-3 py-2">
             {@render performanceCell(r)}
           </td>

--- a/apps/admin/src/lib/components/RequestsTable.test.ts
+++ b/apps/admin/src/lib/components/RequestsTable.test.ts
@@ -31,6 +31,7 @@ function item(overrides: Partial<RequestListItem> = {}): RequestListItem {
     stream_outcome: 'completed',
     latency_ms: 460,
     cost_usd: 0.0123,
+    request_body_bytes: null,
     usage: {
       measurement: 'reported',
       input: 1200,
@@ -81,6 +82,21 @@ describe('RequestsTable key cell', () => {
 });
 
 describe('RequestsTable variants', () => {
+  it('shows the recorded request body size and keeps legacy rows unknown', () => {
+    const { unmount } = render(RequestsTable, {
+      items: [
+        item({ request_body_bytes: 1_572_864 }),
+      ],
+      detailHref,
+    });
+    expect(screen.getByText('Request body')).toBeInTheDocument();
+    expect(screen.getByTestId('cell-request-body')).toHaveTextContent('1.5 MB');
+    unmount();
+
+    render(RequestsTable, { items: [item()], detailHref });
+    expect(screen.getByTestId('cell-request-body')).toHaveTextContent('—');
+  });
+
   it('makes Session a filter button or canonical link when the caller provides one', async () => {
     const session = { ref: 'session_abc', label: 'Support case 42', source: 'header' };
     const onSessionFilter = vi.fn();

--- a/apps/admin/src/lib/format.test.ts
+++ b/apps/admin/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   durationParts,
+  formatBytes,
   formatCount,
   formatDurationMs,
   formatTimestamp,
@@ -8,6 +9,15 @@ import {
   formatTps,
   formatUsd,
 } from './format.js';
+
+describe('formatBytes — request body size', () => {
+  it('uses binary B, KB, and MB thresholds and preserves unknown values', () => {
+    expect(formatBytes(null)).toBe('—');
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1_572_864)).toBe('1.5 MB');
+  });
+});
 
 describe('formatDurationMs — compact duration', () => {
   it('keeps sub-second durations in milliseconds', () => {

--- a/apps/admin/src/lib/format.ts
+++ b/apps/admin/src/lib/format.ts
@@ -1,6 +1,13 @@
 // Shared display formatters for the admin UI. Read-only presentation — never
 // re-computes backend figures, only renders them.
 
+export function formatBytes(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return '—';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 // Format a USD cost for the requests table / cost breakdown.
 //
 // WHY adaptive precision: relay models can be extraordinarily cheap (a DeepSeek

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -194,6 +194,7 @@ function requestItem(traceId: string): RequestListItem {
     stream_outcome: 'completed',
     latency_ms: 1200,
     cost_usd: 0.004,
+    request_body_bytes: null,
     usage: {
       measurement: 'reported',
       input: 100,

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -56,6 +56,7 @@ function item(traceId: string, overrides: Partial<RequestListItem> = {}): Reques
     stream_outcome: 'completed',
     latency_ms: 460,
     cost_usd: 0.0123,
+    request_body_bytes: null,
     usage: {
       measurement: 'reported',
       input: 1200,

--- a/apps/admin/src/routes/settings/+page.svelte
+++ b/apps/admin/src/routes/settings/+page.svelte
@@ -16,7 +16,7 @@
     saveSettings,
   } from '$lib/api/settings.js';
   import Modal from '$lib/components/Modal.svelte';
-  import { formatTimestamp } from '$lib/format.js';
+  import { formatBytes, formatTimestamp } from '$lib/format.js';
   import { t } from '$lib/i18n';
 
   // System Settings — runtime-mutable config that applies WITHOUT a restart
@@ -156,11 +156,6 @@
     }
   }
 
-  function formatBytes(n: number): string {
-    if (n < 1024) return `${n} B`;
-    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
-  }
 </script>
 
 <section class="flex w-full flex-col gap-6 px-4 py-6 md:px-8">

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -114,6 +114,7 @@ test.describe("admin request debugging", () => {
     await expect(row).toBeVisible();
     // Classification-stage decision layer is shown (decided_by column, Principle 5).
     await expect(row.getByTestId("decided-by")).toHaveText("rules");
+    await expect(row.getByTestId("cell-request-body")).toHaveText("1.5 MB");
 
     // Drill into the detail by deep-linking the trace id (SPA fallback route).
     await page.goto(`${BASE}/admin/requests/${SEED_TRACE_ID}`);

--- a/apps/gateway/e2e/fixtures/test-server.ts
+++ b/apps/gateway/e2e/fixtures/test-server.ts
@@ -92,6 +92,7 @@ await telemetry.insert({
   decision: {
     request_id: SEED_TRACE_ID,
     trace_id: SEED_TRACE_ID,
+    request_body_bytes: 1_572_864,
     requested_model: "gpt-4o-mini",
     classifier: {
       task_type: "coding",

--- a/apps/gateway/src/routes/admin/replay.test.ts
+++ b/apps/gateway/src/routes/admin/replay.test.ts
@@ -730,6 +730,7 @@ describe("registerReplayRoutes", () => {
 
   it("POST returns { trace_id } for a captured request", async () => {
     const rec = emptyRec();
+    const requestBody = JSON.stringify({ request: okBody }, null, 2);
     const route: ReplayWiring["route"] = async (req) => ({
       decision: decision(req.request_id),
       final: { status: "ok", alias: "openai/gpt-4" },
@@ -740,10 +741,13 @@ describe("registerReplayRoutes", () => {
     const res = await appWith(wiring(route, rec), rec).request("/admin/api/requests/orig/replay", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ request: okBody }),
+      body: requestBody,
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ trace_id: "new_trace" });
+    expect(rec.inserts[0]?.decision.request_body_bytes).toBe(
+      Buffer.byteLength(requestBody, "utf8"),
+    );
   });
 
   it("503s when replay is not wired", async () => {

--- a/apps/gateway/src/routes/admin/replay.ts
+++ b/apps/gateway/src/routes/admin/replay.ts
@@ -24,6 +24,7 @@ import {
   backfillCompletionCost,
   type PayloadCaptureDeps,
   persistPayload,
+  stampRequestBodyBytes,
   usageFromSSE,
 } from "../payload-capture.js";
 import type { AdminApiDeps, ReplayWiring } from "./deps.js";
@@ -69,6 +70,7 @@ export async function runReplay(
   args: {
     originalTraceId: string;
     body: unknown;
+    requestBodyBytes?: number;
     signal: AbortSignal;
     log: (msg: string) => void;
   },
@@ -154,7 +156,9 @@ export async function runReplay(
   // contract: fail the endpoint instead.
   try {
     await deps.telemetry.insert({
-      decision: deps.replay.redact(prepared.decision) as DecisionRecord,
+      decision: deps.replay.redact(
+        stampRequestBodyBytes(prepared.decision, prepared.requestJson, args.requestBodyBytes),
+      ) as DecisionRecord,
       // Attribute the NEW trace to the key ACTUALLY used — on a root-key
       // fallback that is the root key, not the dead original (honest audit
       // trail, no dangling key_id reference).
@@ -453,7 +457,14 @@ export function registerReplayRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
   app.post("/admin/api/requests/:traceId/replay", async (c) => {
     if (deps.replay === undefined) return c.json({ error: "replay not available" }, 503);
     const originalTraceId = c.req.param("traceId");
-    const raw = (await c.req.json().catch(() => null)) as { request?: unknown } | null;
+    let requestBytes = new Uint8Array();
+    let raw: { request?: unknown } | null = null;
+    try {
+      requestBytes = new Uint8Array(await c.req.arrayBuffer());
+      raw = JSON.parse(Buffer.from(requestBytes).toString("utf8")) as { request?: unknown };
+    } catch {
+      // Invalid JSON is handled by the existing missing-body response below.
+    }
     if (raw === null || typeof raw !== "object" || !("request" in raw)) {
       return c.json({ error: "missing request body" }, 400);
     }
@@ -466,7 +477,13 @@ export function registerReplayRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
     };
     const outcome = await runReplay(
       { replay: deps.replay, telemetry: deps.telemetry, keyStore: deps.keyStore },
-      { originalTraceId, body: raw.request, signal: c.req.raw.signal, log },
+      {
+        originalTraceId,
+        body: raw.request,
+        requestBodyBytes: requestBytes.byteLength,
+        signal: c.req.raw.signal,
+        log,
+      },
     );
     if (!outcome.ok) return c.json({ error: outcome.error }, outcome.status);
     return c.json({ trace_id: outcome.traceId });

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -761,16 +761,21 @@ describe("POST /v1/chat/completions (routing pipeline)", () => {
     harness.execute.mockResolvedValue(nonStreamOutcome({ ok: true }));
     const app = buildApp(d);
 
+    const requestJson = JSON.stringify({
+      ...NONSTREAM_BODY,
+      messages: [{ role: "user", content: "你好" }],
+    });
     await app.request("/v1/chat/completions", {
       method: "POST",
       headers: AUTH,
-      body: JSON.stringify(NONSTREAM_BODY),
+      body: requestJson,
     });
 
     expect(redact).toHaveBeenCalled();
     expect(d.telemetry.insert).toHaveBeenCalledOnce();
     const arg = (d.telemetry.insert as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     expect(arg.apiKeyId).toBe("k1");
+    expect(arg.decision.request_body_bytes).toBe(Buffer.byteLength(requestJson, "utf8"));
     expect(JSON.stringify(arg)).not.toContain("helm_live_secret");
   });
 

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -61,6 +61,7 @@ import {
   persistPayload,
   queueOrPersistSessionRequest,
   redactDecisionForTelemetry,
+  stampRequestBodyBytes,
   tokensFromUsage,
   usageFromBody,
   usageFromSSE,
@@ -544,7 +545,10 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     // With a write queue wired, the insert is deferred + batched off the hot path.
     const persist = async (decision: DecisionRecord, responseJson: string | null = null) => {
       const timedOut = requestTimedOut(c);
-      const decisionSnapshot = timedOut ? decisionForTimedOutRequest(decision) : decision;
+      const decisionSnapshot = stampRequestBodyBytes(
+        timedOut ? decisionForTimedOutRequest(decision) : decision,
+        requestJson,
+      );
       const sessionResponseJson = timedOut ? null : responseJson;
       const input: InsertTelemetryInput = {
         decision: redactDecisionForTelemetry(deps.redact, decisionSnapshot),

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -144,17 +144,19 @@ describe("registerImagesRoute", () => {
   });
 
   it("forwards multipart image edits without losing binary bytes", async () => {
-    const { app, imageEdit } = setup();
+    const { app, imageEdit, enqueueTelemetry } = setup();
     const body = new FormData();
     body.set("model", "gpt-image-2");
     body.set("prompt", "add snow");
     body.append("image[]", new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }), "a.png");
 
-    const res = await app.request("/v1/images/edits", {
+    const request = new Request("http://helm.test/v1/images/edits", {
       method: "POST",
       headers: { Authorization: "Bearer k" },
       body,
     });
+    const wireBytes = (await request.clone().arrayBuffer()).byteLength;
+    const res = await app.request(request);
 
     expect(res.status).toBe(200);
     const edit = imageEdit.mock.calls[0]?.[0] as {
@@ -170,6 +172,7 @@ describe("registerImagesRoute", () => {
     );
     const image = edit.fields.find((field) => field.name === "image[]");
     expect([...((image?.value as Uint8Array) ?? [])]).toEqual([1, 2, 3]);
+    expect(enqueueTelemetry.mock.calls[0]?.[0].decision.request_body_bytes).toBe(wireBytes);
   });
 
   it("captures the FULL image verbatim (the store externalizes it to payload_blobs)", async () => {

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -189,6 +189,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
     // 4) Parse + validate. Edits support both the Codex JSON carrier and the public
     // multipart carrier. The admitted bytes make multipart fallback attempts replayable.
     let requestJson = "";
+    let requestBodyBytes = 0;
     let model = "";
     let prompt = "";
     let generationBody: Record<string, unknown> | null = null;
@@ -199,6 +200,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
           ? null
           : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
       const bytes = admitted?.bytes ?? new Uint8Array(await c.req.arrayBuffer());
+      requestBodyBytes = bytes.byteLength;
       requestJson = admitted?.text ?? Buffer.from(bytes).toString("utf8");
       if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
       const contentType = c.req.header("Content-Type")?.toLowerCase() ?? "";
@@ -435,6 +437,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
             apiKeyId: identity.keyId,
             decision,
             requestJson,
+            requestBodyBytes,
             responseJson: null,
             timedOut: requestTimedOut(c),
             upstreamRequestJson: null,
@@ -478,6 +481,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
           apiKeyId: identity.keyId,
           decision,
           requestJson,
+          requestBodyBytes,
           responseJson,
           timedOut: requestTimedOut(c),
           upstreamRequestJson: result.upstreamRequestJson,

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -1393,8 +1393,13 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
       now: () => 5000,
       capturePayloads: () => true,
     };
-    await recordServed(d, { ...args, requestId: "req_2" }, () => {});
+    await recordServed(
+      d,
+      { ...args, requestId: "req_2", requestJson: '{"text":"你好"}' },
+      () => {},
+    );
     expect(s.inserted).toHaveLength(1);
+    expect(s.inserted[0]?.request_body_bytes).toBe(17);
     expect(s.payloads).toHaveLength(1);
   });
 

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -787,6 +787,14 @@ export function redactDecisionForTelemetry(
   return redact(bodyFreeDecision) as DecisionRecord;
 }
 
+export function stampRequestBodyBytes(
+  decision: DecisionRecord,
+  requestJson: string,
+  requestBodyBytes = Buffer.byteLength(requestJson, "utf8"),
+): DecisionRecord {
+  return { ...decision, request_body_bytes: requestBodyBytes };
+}
+
 // Record ONE served request: the telemetry row (always — this is what makes the
 // request appear in /admin/requests) plus the verbatim request/response payload
 // (gated by capture_payloads). Shared by the three pipeline faces (/v1/responses,
@@ -801,6 +809,7 @@ export async function recordServed(
     apiKeyId: string;
     decision: DecisionRecord;
     requestJson: string;
+    requestBodyBytes?: number;
     responseJson: string | null;
     timedOut?: boolean;
     // The exact body forwarded upstream (post inject + translation); null when no
@@ -814,7 +823,7 @@ export async function recordServed(
   // but telemetry.request_id and request_payloads.request_id must always use the
   // server-generated context request_id passed in args.
   const storageDecision: DecisionRecord = {
-    ...args.decision,
+    ...stampRequestBodyBytes(args.decision, args.requestJson, args.requestBodyBytes),
     request_id: args.requestId,
   };
   const decision =

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-31 · 请求列表记录并显示客户端正文大小（Telemetry / Admin requests，docs/07/11，原则 1/7）
+
+- **计量口径**：新增可选 `request_body_bytes`，记录网关实际收到的客户端请求正文 UTF-8 字节数；不信任可能缺失或经过 transfer encoding 的 `Content-Length`，也不以字符数、Token 数、压缩后存储量或转换后的上游正文替代。该数字随脱敏 `DecisionRecord` 保存，不受正文捕获开关影响，不保存正文，因此无需 SQLite/Postgres 迁移。
+- **协议边界**：共享记录路径覆盖 Responses、Messages、Gemini、Interactions 与 Images，OpenAI Chat 和 Admin Replay 的独立写入路径显式补齐；multipart 图片使用原始 wire bytes 覆盖其后生成的元数据 JSON 大小。尚不产生 `DecisionRecord` 的预路由拒绝、count-tokens 与 Realtime 请求不伪造该指标。
+- **兼容与展示**：Admin 共享请求表按二进制阈值显示 `B / KB / MB`；旧记录不回填并显示 `—`，避免读取或扫描历史私密正文。
+
 ## 2026-07-29 · 生产韧性改为持续小批、无丢弃背压、执行 Token 租约与完整错误诊断（Store / Gateway / OAuth / Telemetry，docs/02/04/07/10/11，原则 1/3/5/7/8）
 
 - **SQLite 持续清理**：七类 SQLite retention mutation 统一为每批最多 10 行，满批后 `setImmediate` 让出事件循环，不再执行无界 DELETE。Session cleanup 先用既有 `head_request_id` 写入持久 prune claim，再按每批最多 10 个 revision 推进；进程中断后可继续完成，批间到达的同 Session 写入会等待过期链删完并以新 root 恢复。写入在真正落库的同步事务内再次检查 claim，关闭“先检查、await 让出、随后写进删除链”的竞态。该机制只减少未来增长和清理停顿，不替代整库重写；大库 `VACUUM` 仍必须由既有维护 drain 和低峰调度单独执行。
@@ -72,12 +78,9 @@
 - **统一边界**：复用所有 HTTP JSON 与 Responses WebSocket 内部请求已经经过的 `BodyMemoryAdmission`，在读取、扩容和 `JSON.parse` 前同时检查 `heapUsed + active reservations`。高水位为 heap limit 扣除 response work、write queue、Session cache、response capture 与 5% GC 余量；超过时沿用现有协议形状返回 503，单请求 wire 上限仍返回 413。未新增配置、依赖、队列或并发限制。
 - **运维边界**：该保护把聚合内存压力转成可恢复的拒绝，不负责物理缩小生产 20 GiB SQLite；历史正文清理与 VACUUM 仍必须通过既有维护 drain、磁盘与内存门禁执行，不能在线手工 VACUUM。
 
-## 2026-07-24 · Admin 登录在 Host 被代理改写时复用浏览器同源证明（Admin auth，docs/10/11，原则 3/7）
-
-- **根因与修复**：Admin 登录/登出的 CSRF 校验原本只比较 `Origin` 与请求 `Host` / `X-Forwarded-Host`；部分反向代理或 NAT 会把 `Host` 改成内部地址且不补 `X-Forwarded-Host`，导致浏览器从同一外部 origin 提交表单也稳定返回 403。校验现在优先接受浏览器提供的 `Sec-Fetch-Site: same-origin`，再保留原有 Host 比较与 opaque-origin 边界；`cross-site` 仍拒绝。该 header 不能由网页脚本伪造，而无 `Origin` 的非浏览器客户端原本就允许，因此不新增配置、代理白名单或信任任意 forwarded header。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-24 · Admin 登录同源证明兼容代理 Host 改写**：登录/登出优先接受浏览器不可伪造的 `Sec-Fetch-Site: same-origin`，同时保留 Origin/Host 与 cross-site 拒绝边界；完整原文通过 git history 回溯。
 - **2026-07-24 · Responses WebSocket ingress 改为按活动消息计费**：空闲连接不再预留完整帧容量，活动 `response.create` 才按真实 wire/JSON bytes 申请并释放 ingress lease；上游非 101 body 统一由有界响应超时接管，完整原文通过 git history 回溯。
 - **2026-07-23 · PostgreSQL API-key 分布式并发 lease**：PostgreSQL 用 DB 时钟和 state-row lease 实现跨 replica 并发上限、心跳与 crash recovery，真实多 pool e2e 作为验收边界；完整原文通过 git history 回溯。
 - **2026-07-23 · Session 恢复与在线响应共享内存池**：Admin Session 恢复单次最多占 response-work 池一半，保留在线响应容量并坚持先准入后物化；完整原文通过 git history 回溯。

--- a/packages/shared/src/decision/schema.test.ts
+++ b/packages/shared/src/decision/schema.test.ts
@@ -92,6 +92,16 @@ function passthroughRecord(model = "gpt-4o-mini") {
 }
 
 describe("DecisionRecordSchema", () => {
+  it("records the UTF-8 request body byte count while keeping legacy rows valid", () => {
+    expect(DecisionRecordSchema.parse(fullRecord()).request_body_bytes).toBeUndefined();
+    expect(
+      DecisionRecordSchema.parse({ ...fullRecord(), request_body_bytes: 17 }).request_body_bytes,
+    ).toBe(17);
+    expect(
+      DecisionRecordSchema.safeParse({ ...fullRecord(), request_body_bytes: -1 }).success,
+    ).toBe(false);
+  });
+
   it("preserves body-free reasoning effort metadata", () => {
     const parsed = DecisionRecordSchema.parse({
       ...fullRecord(),

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -272,6 +272,10 @@ export const DecisionRecordSchema = z.object({
   // non-subscription providers, legacy rows, failed requests, or stale selections
   // that later fell back to a different provider. Body-free routing metadata only.
   serving_account: ServingAccountDecisionSchema.nullable().default(null),
+  // Exact UTF-8 byte length of the client request body as received by the gateway.
+  // Body-free telemetry only: the bytes themselves remain governed by capture mode.
+  // null/absent for legacy rows that predate measurement.
+  request_body_bytes: z.number().int().nonnegative().nullable().optional(),
   // Total served latency = Σ provider_attempts.latency_ms (docs/07 latency).
   // `.default(0)` so legacy records validate; the builder computes the real sum.
   latency_total_ms: z.number().nonnegative().default(0),


### PR DESCRIPTION
## Summary

- record the exact client request body size in bytes on request telemetry
- cover shared inference routes, Chat, Admin Replay, and multipart image wire bodies
- show the value in the Admin requests table as B, KB, or MB; legacy rows remain unknown

## Why

Operators can inspect token usage and latency today, but cannot tell how large the incoming request body was. This adds body-free telemetry without enabling payload capture or backfilling historical private bodies.

## Validation

- `CI=true pnpm exec vitest run` on the 10 affected test files: 347 passed
- focused Admin Playwright boundary: 6 passed
- `CI=true pnpm typecheck`
- `CI=true pnpm --filter @helm/admin check`: 0 errors, 0 warnings
- Gateway, Core, Shared, and Admin builds
- `git diff --check`

## Notes

- JSON requests use their actual UTF-8 body bytes as received by the gateway.
- Multipart image requests use the original wire bytes.
- No database migration is required; the nullable field is stored with the existing decision record.
