### PR TITLE
[codex] release v0.28.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.24",
+  "version": "0.28.25",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump the Helm API release version from `0.28.24` to `0.28.25`.

This version publishes the request-body size telemetry and Admin requests-table display merged in #669.

## Scope

- version-only change in the root `package.json`
- no database migration

## Validation

- feature PR #669 passed `verify`, `e2e`, and `docker` for exact head `ec03d727f8670ff3109875bc5ef679edcfc879ee`
- this release PR must pass its own CI before merge
