### PR TITLE
[codex] Show request body size in request details

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -72,6 +72,13 @@ function rawRecord(overrides: Record<string, unknown> = {}): Record<string, unkn
 }
 
 describe('toDetail', () => {
+  it('maps the recorded request body byte count without inventing legacy values', () => {
+    const measured = toDetail(rawRecord({ request_body_bytes: 1_572_864 }));
+    const legacy = toDetail(rawRecord());
+    expect(measured.request_body_bytes).toBe(1_572_864);
+    expect(legacy.request_body_bytes).toBeNull();
+  });
+
   it('surfaces body-free reasoning effort in redacted request metadata', () => {
     const detail = toDetail(rawRecord());
     expect(detail.reasoning_effort).toBe('high');

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -161,6 +161,8 @@ export interface RequestDetail {
   stream_outcome: StreamOutcome;
   // Total wall-clock latency (Σ attempt latency, ms); null on a legacy record.
   latency_ms: number | null;
+  // Exact client request body size; null on a legacy record.
+  request_body_bytes: number | null;
   request_meta: Record<string, unknown>;
   payload_summary: string; // redacted summary — NOT the full payload
   classifier_output: {
@@ -446,6 +448,12 @@ function servedProvider(raw: RawDecisionRecord, attempts: RawAttempt[]): string 
 function num(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
 }
+
+function requestBodyBytes(raw: RawDecisionRecord): number | null {
+  const bytes = num(raw.request_body_bytes);
+  return bytes !== null && bytes >= 0 ? bytes : null;
+}
+
 export function toUsage(raw: RawDecisionRecord): TokenUsageView {
   const u = raw.usage ?? undefined;
   const input = num(u?.prompt_tokens);
@@ -558,12 +566,7 @@ export function toListItem(raw: RawDecisionRecord): RequestListItem {
     latency_ms:
       typeof raw.latency_total_ms === 'number' ? raw.latency_total_ms : sumLatency(attempts),
     cost_usd: listCost(raw, attempts),
-    request_body_bytes:
-      typeof raw.request_body_bytes === 'number' &&
-      Number.isFinite(raw.request_body_bytes) &&
-      raw.request_body_bytes >= 0
-        ? raw.request_body_bytes
-        : null,
+    request_body_bytes: requestBodyBytes(raw),
     usage: toUsage(raw),
     // True throughput (output ÷ generation time); null → '—' for non-streaming/legacy.
     tps: computeTps(raw),
@@ -663,6 +666,7 @@ export function toDetail(raw: RawDecisionRecord): RequestDetail {
     status,
     stream_outcome: normalizeStreamOutcome(raw.stream_outcome),
     latency_ms: typeof raw.latency_total_ms === 'number' ? raw.latency_total_ms : null,
+    request_body_bytes: requestBodyBytes(raw),
     request_meta: buildRequestMeta(raw),
     // The backend does not persist a payload; we render a redaction placeholder so
     // the operator knows it was intentionally withheld (Principle 7).

--- a/apps/admin/src/lib/components/DecisionChain.test.ts
+++ b/apps/admin/src/lib/components/DecisionChain.test.ts
@@ -28,6 +28,7 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
     status: 'ok',
     stream_outcome: 'completed',
     latency_ms: 460,
+    request_body_bytes: null,
     request_meta: {},
     payload_summary: 'payload withheld (redacted)',
     classifier_output: {

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -9,7 +9,7 @@
   } from '$lib/api/requests.js';
   import { deepEqual } from '$lib/deep-equal.js';
   import { attemptCodeLabel } from '$lib/format/attempt-codes.js';
-  import { formatDurationMs, formatTimestamp, formatTps } from '$lib/format.js';
+  import { formatBytes, formatDurationMs, formatTimestamp, formatTps } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import Conversation from '$lib/components/Conversation.svelte';
   import CostBreakdown from '$lib/components/CostBreakdown.svelte';
@@ -342,6 +342,12 @@
           <dt class="text-xs uppercase tracking-wide text-slate-400">{$t('Latency')}</dt>
           <dd class="mt-0.5 font-mono text-ink-body">
             {d.latency_ms === null ? '—' : formatDurationMs(d.latency_ms)}
+          </dd>
+        </div>
+        <div>
+          <dt class="text-xs uppercase tracking-wide text-slate-400">{$t('Request body')}</dt>
+          <dd data-testid="request-body-size" class="mt-0.5 font-mono text-ink-body">
+            {formatBytes(d.request_body_bytes)}
           </dd>
         </div>
       </dl>

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -136,6 +136,7 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
     status: 'ok',
     stream_outcome: 'completed',
     latency_ms: 460,
+    request_body_bytes: null,
     request_meta: { requested_model: 'gpt-4o' },
     payload_summary: 'payload withheld (redacted — only routing metadata is stored)',
     classifier_output: {
@@ -562,10 +563,10 @@ describe('requests detail page', () => {
     expect(screen.getByTestId('payload-summary')).toHaveTextContent(/not recorded/i);
   });
 
-  it('renders a Request summary card with key, provider/account, requested+served model, lane, status, latency', () => {
+  it('renders a Request summary card with identity, routing, latency, and request body size', () => {
     render(DetailPage, {
       data: {
-        detail: detail({ latency_ms: 6911 }),
+        detail: detail({ latency_ms: 6911, request_body_bytes: 1_572_864 }),
         payload: { captured: false },
         requestId: 'tr_1',
       },
@@ -579,6 +580,8 @@ describe('requests detail page', () => {
     expect(summary).toHaveTextContent('claude-x'); // served model
     expect(summary).toHaveTextContent('premium'); // lane
     expect(summary).toHaveTextContent('6.9s'); // total latency
+    expect(within(summary).getByText('Request body')).toBeInTheDocument();
+    expect(within(summary).getByTestId('request-body-size')).toHaveTextContent('1.5 MB');
   });
 
   it('shows a partial stream status and approximate cost/usage provenance on detail', () => {
@@ -612,6 +615,7 @@ describe('requests detail page', () => {
     // and never a fabricated value (Principle 7).
     expect(summary).toHaveTextContent('—');
     expect(summary).not.toHaveTextContent('Production backend');
+    expect(within(summary).getByTestId('request-body-size')).toHaveTextContent('—');
   });
 
   it('renders the throughput card: true TPS, time-to-first-token, and the generation window', () => {

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -118,6 +118,7 @@ test.describe("admin request debugging", () => {
 
     // Drill into the detail by deep-linking the trace id (SPA fallback route).
     await page.goto(`${BASE}/admin/requests/${SEED_TRACE_ID}`);
+    await expect(page.getByTestId("request-body-size")).toHaveText("1.5 MB");
 
     // Decision chain blocks must be visible (docs/07): classifier output, lane
     // candidate chain, provider attempts, cost breakdown, trace_id.


### PR DESCRIPTION
## What changed

- map the recorded request body byte count into request details
- show the formatted size in the Request summary card
- render legacy or invalid values as an em dash

## Why

Request body size was visible in the requests list but missing after opening a request, so operators lost that context during drill-down.

## Validation

- 3 focused Vitest files: 96 tests passed
- Admin Svelte check: 0 errors, 0 warnings
- Admin production build passed
- focused Admin Playwright e2e: 1 passed
- git diff --check