### PR TITLE
[codex] Release v0.28.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.25",
+  "version": "0.28.26",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from `0.28.25` to `0.28.26`.

## Included

- show recorded request body size in the request details summary
- preserve `—` for legacy or invalid measurements

## Validation

- feature PR #671 CI passed: verify, e2e, docker
- version diff is limited to root `package.json`
- `git diff --check` passed