### PR TITLE
[codex] release v0.28.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.26",
+  "version": "0.28.27",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump Helm API from 0.28.26 to 0.28.27 after #673.

## Included fix

- Session capture continues past the former 64 MiB aggregate cap
- requests without a trusted Session identifier receive a tenant-scoped request-only Session
- SQLite and PostgreSQL enforce the same behavior

## Scope

Version-only package.json change, following the existing release convention.