### PR TITLE
feat: add per-key request content storage override

### DIFF
--- a/apps/admin/src/lib/api/keys.test.ts
+++ b/apps/admin/src/lib/api/keys.test.ts
@@ -318,6 +318,22 @@ describe('keys api client', () => {
     expect(body.blocked_models).toBeNull();
   });
 
+  it('normalizes and updates the per-key request-content override', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify([summaryRow('k1', { request_content_mode: 'session' })]), {
+        status: 200,
+      }),
+    );
+    expect((await listKeys())[0]?.request_content_mode).toBe('session');
+
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ key_id: 'k1' }), { status: 200 }),
+    );
+    await updateKey('k1', { request_content_mode: null });
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(JSON.parse(init.body as string).request_content_mode).toBeNull();
+  });
+
   it('updateKey rejects on a non-2xx response (404)', async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       new Response(JSON.stringify({ error: 'key not found' }), { status: 404 }),

--- a/apps/admin/src/lib/api/keys.ts
+++ b/apps/admin/src/lib/api/keys.ts
@@ -39,6 +39,7 @@ export interface ApiKeyView {
   memory_mode: 'off' | 'observe' | 'inject';
   memory_project_id: string | null;
   memory_thread_source: 'header' | 'auto';
+  request_content_mode: 'none' | 'payload' | 'session' | null;
 }
 
 // Operator-specified caps for a new key. The plaintext is minted server-side; the
@@ -71,6 +72,7 @@ export interface CreateKeyInput {
   memory_mode?: 'off' | 'observe' | 'inject';
   memory_project_id?: string;
   memory_thread_source?: 'header' | 'auto';
+  request_content_mode?: 'none' | 'payload' | 'session';
 }
 
 // Editable caps for an existing key (PATCH). Mirrors the server
@@ -99,6 +101,7 @@ export interface UpdateKeyInput {
   memory_mode?: 'off' | 'observe' | 'inject';
   memory_project_id?: string | null;
   memory_thread_source?: 'header' | 'auto';
+  request_content_mode?: 'none' | 'payload' | 'session' | null;
 }
 
 // Create/rotate responses intentionally carry plaintext so the operator can copy
@@ -209,6 +212,12 @@ function normalizeView(raw: Record<string, unknown>): ApiKeyView {
       raw.memory_mode === 'inject' ? 'inject' : raw.memory_mode === 'observe' ? 'observe' : 'off',
     memory_project_id: typeof raw.memory_project_id === 'string' ? raw.memory_project_id : null,
     memory_thread_source: raw.memory_thread_source === 'auto' ? 'auto' : 'header',
+    request_content_mode:
+      raw.request_content_mode === 'none' ||
+      raw.request_content_mode === 'payload' ||
+      raw.request_content_mode === 'session'
+        ? raw.request_content_mode
+        : null,
   };
 }
 
@@ -255,6 +264,9 @@ function toServerBody(input: CreateKeyInput): Record<string, unknown> {
   }
   if (input.memory_thread_source !== undefined) {
     out.memory_thread_source = input.memory_thread_source;
+  }
+  if (input.request_content_mode !== undefined) {
+    out.request_content_mode = input.request_content_mode;
   }
   return out;
 }

--- a/apps/admin/src/lib/components/CreateKeyDialog.svelte
+++ b/apps/admin/src/lib/components/CreateKeyDialog.svelte
@@ -71,6 +71,9 @@
     if (form.budgetWindow != null) input.budget_window_seconds = form.budgetWindow;
     input.over_budget_behavior = form.overBudgetBehavior;
     if (form.degradeLane.length > 0) input.degrade_lane = form.degradeLane;
+    if (form.requestContentMode !== 'inherit') {
+      input.request_content_mode = form.requestContentMode;
+    }
     // Concurrency limit: send only when set (blank => unlimited).
     if (form.concurrencyLimit != null) input.concurrency_limit = form.concurrencyLimit;
     if (form.memoryMode !== 'off') input.memory_mode = form.memoryMode;
@@ -125,6 +128,8 @@
         budget_window_seconds: form.budgetWindow ?? null,
         over_budget_behavior: form.overBudgetBehavior,
         degrade_lane: form.degradeLane.length > 0 ? form.degradeLane : null,
+        request_content_mode:
+          form.requestContentMode === 'inherit' ? null : form.requestContentMode,
         concurrency_limit: form.concurrencyLimit ?? null,
         memory_mode: form.memoryMode,
         memory_project_id: form.memoryProject.length > 0 ? form.memoryProject : null,

--- a/apps/admin/src/lib/components/CreateKeyDialog.test.ts
+++ b/apps/admin/src/lib/components/CreateKeyDialog.test.ts
@@ -77,6 +77,16 @@ describe('CreateKeyDialog', () => {
     expect(input.rate_limit_tpm).toBeUndefined();
   });
 
+  it('submits a request-content override when selected', async () => {
+    setup();
+    await fireEvent.change(screen.getByLabelText('Request content storage'), {
+      target: { value: 'payload' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /create key/i }));
+    await waitFor(() => expect(createKey).toHaveBeenCalledTimes(1));
+    expect(createKey.mock.calls[0][0].request_content_mode).toBe('payload');
+  });
+
   it('collapses the optional cap sections by default, basics stay visible', async () => {
     setup();
     // Basics (lanes + blacklist + passthrough) are immediately visible — not inside a section.
@@ -86,7 +96,7 @@ describe('CreateKeyDialog', () => {
     expect(screen.getByLabelText('allow client-requested Fast mode')).toBeInTheDocument();
     // The three optional groups render as <details> sections, all closed.
     const sections = document.querySelectorAll('details');
-    expect(sections).toHaveLength(3);
+    expect(sections).toHaveLength(4);
     for (const section of sections) expect(section.open).toBe(false);
     // Each closed section carries a one-line state summary so the operator can
     // see "nothing configured" without expanding.

--- a/apps/admin/src/lib/components/EditKeyDialog.svelte
+++ b/apps/admin/src/lib/components/EditKeyDialog.svelte
@@ -57,6 +57,8 @@
       budget_window_seconds: form.budgetWindow ?? null,
       over_budget_behavior: form.overBudgetBehavior,
       degrade_lane: form.degradeLane.length > 0 ? form.degradeLane : null,
+      request_content_mode:
+        form.requestContentMode === 'inherit' ? null : form.requestContentMode,
       concurrency_limit: form.concurrencyLimit ?? null,
       memory_mode: form.memoryMode,
       memory_project_id: form.memoryProject.length > 0 ? form.memoryProject : null,
@@ -83,6 +85,7 @@
         budget_window_seconds: patch.budget_window_seconds ?? null,
         over_budget_behavior: form.overBudgetBehavior,
         degrade_lane: patch.degrade_lane ?? null,
+        request_content_mode: patch.request_content_mode ?? null,
         concurrency_limit: patch.concurrency_limit ?? null,
         memory_mode: form.memoryMode,
         memory_project_id: patch.memory_project_id ?? null,

--- a/apps/admin/src/lib/components/KeyCapsForm.svelte
+++ b/apps/admin/src/lib/components/KeyCapsForm.svelte
@@ -22,6 +22,7 @@
     budgetWindow: number | null;
     overBudgetBehavior: 'degrade' | 'reject';
     degradeLane: string;
+    requestContentMode: 'inherit' | 'none' | 'payload' | 'session';
     memoryMode: 'off' | 'observe' | 'inject';
     memoryProject: string;
     memoryThreadSource: 'header' | 'auto';
@@ -44,6 +45,7 @@
       budgetWindow: null,
       overBudgetBehavior: 'degrade',
       degradeLane: '',
+      requestContentMode: 'inherit',
       memoryMode: 'off',
       memoryProject: '',
       // Mirrors the keystore mint-default: a new key derives its thread automatically
@@ -69,6 +71,7 @@
       budgetWindow: key.budget_window_seconds,
       overBudgetBehavior: key.over_budget_behavior,
       degradeLane: key.degrade_lane ?? '',
+      requestContentMode: key.request_content_mode ?? 'inherit',
       memoryMode: key.memory_mode,
       memoryProject: key.memory_project_id ?? '',
       memoryThreadSource: key.memory_thread_source,
@@ -127,6 +130,9 @@
           form.budgetWindow != null),
     ),
   );
+  let openRequestContent = $state(
+    untrack(() => expandConfigured && form.requestContentMode !== 'inherit'),
+  );
   let openMemory = $state(untrack(() => expandConfigured && form.memoryMode !== 'off'));
 
   function toggleLane(lane: string, checked: boolean): void {
@@ -158,6 +164,15 @@
     parts.push(form.overBudgetBehavior === 'degrade' ? $t('degrade') : $t('reject'));
     return parts.join(' · ');
   });
+  const requestContentSummary = $derived(
+    form.requestContentMode === 'none'
+      ? $t('Metadata only')
+      : form.requestContentMode === 'payload'
+        ? $t('Full payload for every request')
+        : form.requestContentMode === 'session'
+          ? $t('Incremental transcript per session')
+          : $t('Inherit system setting'),
+  );
   const memorySummary = $derived.by(() => {
     if (form.memoryMode === 'off') return $t('Off');
     const parts = [form.memoryMode === 'observe' ? $t('Observe') : $t('Inject')];
@@ -398,6 +413,36 @@
     <span class="field-help"
       >{$t(
         'Cap usage over a rolling window. Over budget, the key is degraded to a cheaper lane (cost-controlled, service continues) or rejected. Leave caps blank for no budget.',
+      )}</span
+    >
+  </div>
+</details>
+
+<details class="form-section" bind:open={openRequestContent}>
+  <summary class="form-section-summary">
+    {@render sectionHead(
+      $t('Request content storage'),
+      openRequestContent,
+      requestContentSummary,
+    )}
+  </summary>
+  <div class="form-section-body">
+    <label class="flex flex-col gap-1 text-sm">
+      <span class="field-label">{$t('Request content storage')}</span>
+      <select
+        class="select"
+        aria-label={$t('Request content storage')}
+        bind:value={form.requestContentMode}
+      >
+        <option value="inherit">{$t('Inherit system setting')}</option>
+        <option value="none">{$t('Metadata only')}</option>
+        <option value="payload">{$t('Full payload for every request')}</option>
+        <option value="session">{$t('Incremental transcript per session')}</option>
+      </select>
+    </label>
+    <span class="field-help"
+      >{$t(
+        'Privacy note: full payload and session modes store request and response content, which may include tool arguments, reasoning, and media. Choose metadata only to store no bodies.',
       )}</span
     >
   </div>

--- a/apps/admin/src/lib/i18n/settings-locales.test.ts
+++ b/apps/admin/src/lib/i18n/settings-locales.test.ts
@@ -9,6 +9,7 @@ import zhHant from '../../locales/zh-hant.json';
 const settingsKeys = [
   'Compact database automatically',
   'Full payload for every request',
+  'Inherit system setting',
   'Incremental transcript per session',
   'Metadata only',
   'Privacy note: full payload and session modes store request and response content, which may include tool arguments, reasoning, and media. Choose metadata only to store no bodies.',

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -414,6 +414,7 @@
   "Inject (record + hydrate)": "Inject (record + hydrate)",
   "input {input} · output {output} · cached {cached} · non-cached {nonCached}": "input {input} · output {output} · cached {cached} · non-cached {nonCached}",
   "Input tokens": "Input tokens",
+  "Inherit system setting": "Inherit system setting",
   "Interval changes take effect on the next restart.": "Interval changes take effect on the next restart.",
   "Invalid JSON in request body": "Invalid JSON in request body",
   "Invalid request": "Invalid request",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -414,6 +414,7 @@
   "Inject (record + hydrate)": "Inyectar (registrar + hidratar)",
   "input {input} · output {output} · cached {cached} · non-cached {nonCached}": "entrada {input} · salida {output} · en caché {cached} · sin caché {nonCached}",
   "Input tokens": "Tokens de entrada",
+  "Inherit system setting": "Heredar la configuración del sistema",
   "Interval changes take effect on the next restart.": "Los cambios de intervalo se aplican en el próximo reinicio.",
   "Invalid JSON in request body": "JSON no válido en el cuerpo de la solicitud",
   "Invalid request": "Solicitud no válida",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -414,6 +414,7 @@
   "Inject (record + hydrate)": "注入（記録 + ハイドレート）",
   "input {input} · output {output} · cached {cached} · non-cached {nonCached}": "入力 {input} · 出力 {output} · キャッシュ {cached} · 非キャッシュ {nonCached}",
   "Input tokens": "入力トークン数",
+  "Inherit system setting": "システム設定を継承",
   "Interval changes take effect on the next restart.": "間隔の変更は次回の再起動時に反映されます。",
   "Invalid JSON in request body": "リクエスト本文の JSON が不正です",
   "Invalid request": "無効なリクエスト",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -414,6 +414,7 @@
   "Inject (record + hydrate)": "주입(기록 + 하이드레이트)",
   "input {input} · output {output} · cached {cached} · non-cached {nonCached}": "입력 {input} · 출력 {output} · 캐시 {cached} · 비캐시 {nonCached}",
   "Input tokens": "입력 토큰",
+  "Inherit system setting": "시스템 설정 상속",
   "Interval changes take effect on the next restart.": "간격 변경 사항은 다음 재시작 시 적용됩니다.",
   "Invalid JSON in request body": "요청 본문의 JSON 형식이 올바르지 않습니다",
   "Invalid request": "잘못된 요청",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -414,6 +414,7 @@
   "Inject (record + hydrate)": "Injetar (registrar + hidratar)",
   "input {input} · output {output} · cached {cached} · non-cached {nonCached}": "entrada {input} · saída {output} · em cache {cached} · sem cache {nonCached}",
   "Input tokens": "Tokens de entrada",
+  "Inherit system setting": "Herdar configuração do sistema",
   "Interval changes take effect on the next restart.": "Alterações de intervalo entram em vigor na próxima reinicialização.",
   "Invalid JSON in request body": "JSON inválido no corpo da solicitação",
   "Invalid request": "Solicitação inválida",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -414,6 +414,7 @@
   "Inject (record + hydrate)": "注入（记录 + 召回注入）",
   "input {input} · output {output} · cached {cached} · non-cached {nonCached}": "输入 {input} · 输出 {output} · 缓存 {cached} · 非缓存 {nonCached}",
   "Input tokens": "输入 Token",
+  "Inherit system setting": "继承系统设置",
   "Interval changes take effect on the next restart.": "间隔更改将在下次重启时生效。",
   "Invalid JSON in request body": "请求体 JSON 格式有误",
   "Invalid request": "请求无效",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -414,6 +414,7 @@
   "Inject (record + hydrate)": "注入（記錄 + 召回注入）",
   "input {input} · output {output} · cached {cached} · non-cached {nonCached}": "輸入 {input} · 輸出 {output} · 快取 {cached} · 非快取 {nonCached}",
   "Input tokens": "輸入權杖",
+  "Inherit system setting": "繼承系統設定",
   "Interval changes take effect on the next restart.": "間隔變更將在下次重新啟動時生效。",
   "Invalid JSON in request body": "請求內容 JSON 格式有誤",
   "Invalid request": "請求無效",

--- a/apps/admin/src/routes/keys/[keyId]/+page.svelte
+++ b/apps/admin/src/routes/keys/[keyId]/+page.svelte
@@ -303,6 +303,20 @@
           >
         </dd>
       </div>
+      <div>
+        <dt class="text-xs uppercase tracking-wide text-slate-400">
+          {$t('Request content storage')}
+        </dt>
+        <dd class="mt-0.5 text-ink-body">
+          {key.request_content_mode === 'none'
+            ? $t('Metadata only')
+            : key.request_content_mode === 'payload'
+              ? $t('Full payload for every request')
+              : key.request_content_mode === 'session'
+                ? $t('Incremental transcript per session')
+                : $t('Inherit system setting')}
+        </dd>
+      </div>
     </dl>
   </section>
 

--- a/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
+++ b/apps/admin/src/routes/keys/[keyId]/key-detail.test.ts
@@ -70,6 +70,7 @@ function keyView(overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     memory_mode: 'off',
     memory_project_id: null,
     memory_thread_source: 'header',
+    request_content_mode: null,
     ...overrides,
   };
 }
@@ -280,6 +281,17 @@ describe('key detail page', () => {
     expect(screen.getByRole('link', { name: /manage memory/i }).getAttribute('href')).toBe(
       '/memory?key=k1',
     );
+  });
+
+  it('shows whether request-content storage inherits or overrides the system setting', () => {
+    const { unmount } = render(KeyDetailPage, {
+      data: pageData({ key: keyView({ request_content_mode: 'payload' }) }),
+    });
+    expect(screen.getByText('Full payload for every request')).toBeInTheDocument();
+    unmount();
+
+    render(KeyDetailPage, { data: pageData({ key: keyView({ request_content_mode: null }) }) });
+    expect(screen.getByText('Inherit system setting')).toBeInTheDocument();
   });
 
   it('shows a "view all" link to the global requests list filtered by key and active window', () => {

--- a/apps/admin/src/routes/keys/keys.test.ts
+++ b/apps/admin/src/routes/keys/keys.test.ts
@@ -45,6 +45,7 @@ function key(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     memory_mode: 'off' as const,
     memory_project_id: null,
     memory_thread_source: 'header' as const,
+    request_content_mode: null,
     ...overrides,
   };
 }
@@ -413,6 +414,7 @@ describe('keys page', () => {
         budget_window_seconds: null,
         over_budget_behavior: 'degrade',
         degrade_lane: null,
+        request_content_mode: null,
         // Concurrency untouched → still unlimited (null).
         concurrency_limit: null,
         // Memory defaults untouched → off / none / header (issue #97).
@@ -441,6 +443,25 @@ describe('keys page', () => {
       expect(updateKey).toHaveBeenCalledWith(
         'k1',
         expect.objectContaining({ rate_limit_rpm: null }),
+      ),
+    );
+  });
+
+  it('clears a request-content override back to the system setting', async () => {
+    renderPage([key('k1', { request_content_mode: 'payload' })]);
+    await fireEvent.click(
+      within(screen.getByTestId('key-row')).getByRole('button', { name: /^edit$/i }),
+    );
+    const dialog = screen.getByRole('dialog', { name: /edit key/i });
+    await fireEvent.change(within(dialog).getByLabelText('Request content storage'), {
+      target: { value: 'inherit' },
+    });
+    await fireEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(updateKey).toHaveBeenCalledWith(
+        'k1',
+        expect.objectContaining({ request_content_mode: null }),
       ),
     );
   });

--- a/apps/admin/src/routes/memory/memory.test.ts
+++ b/apps/admin/src/routes/memory/memory.test.ts
@@ -106,6 +106,7 @@ function key(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView {
     memory_mode: 'inject' as const,
     memory_project_id: 'proj-a',
     memory_thread_source: 'auto' as const,
+    request_content_mode: null,
     ...overrides,
   };
 }

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -116,6 +116,7 @@ function apiKey(keyId: string, overrides: Partial<ApiKeyView> = {}): ApiKeyView 
     memory_mode: 'off',
     memory_project_id: null,
     memory_thread_source: 'header',
+    request_content_mode: null,
     ...overrides,
   };
 }

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -275,9 +275,7 @@ test.describe("per-key request-content storage", () => {
           return requestIds.length;
         })
         .toBeGreaterThanOrEqual(1);
-      const captured = await admin.get(
-        `/admin/api/requests/${requestIds[0]}/payload?part=meta`,
-      );
+      const captured = await admin.get(`/admin/api/requests/${requestIds[0]}/payload?part=meta`);
       expect(await captured.json()).toMatchObject({ captured: true, source: "payload" });
 
       const cleared = await admin.patch(`/admin/api/keys/${keyId}`, {
@@ -302,9 +300,7 @@ test.describe("per-key request-content storage", () => {
           return requestIds.length;
         })
         .toBeGreaterThanOrEqual(2);
-      const inherited = await admin.get(
-        `/admin/api/requests/${requestIds[0]}/payload?part=meta`,
-      );
+      const inherited = await admin.get(`/admin/api/requests/${requestIds[0]}/payload?part=meta`);
       expect(await inherited.json()).toMatchObject({ captured: false });
     } finally {
       await api?.dispose();

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -222,6 +222,102 @@ test.describe("admin system settings", () => {
   });
 });
 
+test.describe("per-key request-content storage", () => {
+  test("a key override wins over the system mode and clearing it restores inheritance", async () => {
+    const admin = await playwrightRequest.newContext({
+      baseURL: BASE,
+      extraHTTPHeaders: { Authorization: basicHeader(ADMIN_USER, ADMIN_PASSWORD) },
+    });
+    const current = await admin.get("/admin/api/settings");
+    expect(current.ok()).toBeTruthy();
+    const originalSettings = await current.json();
+    let keyId: string | undefined;
+    let api: Awaited<ReturnType<typeof playwrightRequest.newContext>> | undefined;
+
+    try {
+      const metadataOnly = await admin.put("/admin/api/settings", {
+        data: { ...originalSettings, capture_payloads: false, capture_sessions: false },
+      });
+      expect(metadataOnly.ok()).toBeTruthy();
+
+      const created = await admin.post("/admin/api/keys", {
+        data: {
+          role: "user",
+          name: "e2e per-key content override",
+          request_content_mode: "payload",
+        },
+      });
+      expect(created.status()).toBe(201);
+      const minted = (await created.json()) as { key_id: string; plaintext: string };
+      keyId = minted.key_id;
+      api = await playwrightRequest.newContext({
+        baseURL: BASE,
+        extraHTTPHeaders: {
+          Authorization: `Bearer ${minted.plaintext}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      const first = await api.post("/v1/chat/completions", {
+        data: {
+          model: "auto",
+          messages: [{ role: "user", content: "hi from per-key payload e2e" }],
+        },
+      });
+      expect(first.ok()).toBeTruthy();
+
+      let requestIds: string[] = [];
+      await expect
+        .poll(async () => {
+          const requests = await admin.get(`/admin/api/requests?key_id=${keyId}&pageSize=10`);
+          const body = (await requests.json()) as { items: Array<{ request_id: string }> };
+          requestIds = body.items.map((item) => item.request_id);
+          return requestIds.length;
+        })
+        .toBeGreaterThanOrEqual(1);
+      const captured = await admin.get(
+        `/admin/api/requests/${requestIds[0]}/payload?part=meta`,
+      );
+      expect(await captured.json()).toMatchObject({ captured: true, source: "payload" });
+
+      const cleared = await admin.patch(`/admin/api/keys/${keyId}`, {
+        data: { request_content_mode: null },
+      });
+      expect(cleared.ok()).toBeTruthy();
+      const key = await admin.get(`/admin/api/keys/${keyId}`);
+      expect(await key.json()).toMatchObject({ request_content_mode: null });
+
+      const second = await api.post("/v1/chat/completions", {
+        data: {
+          model: "auto",
+          messages: [{ role: "user", content: "hi after clearing per-key payload e2e" }],
+        },
+      });
+      expect(second.ok()).toBeTruthy();
+      await expect
+        .poll(async () => {
+          const requests = await admin.get(`/admin/api/requests?key_id=${keyId}&pageSize=10`);
+          const body = (await requests.json()) as { items: Array<{ request_id: string }> };
+          requestIds = body.items.map((item) => item.request_id);
+          return requestIds.length;
+        })
+        .toBeGreaterThanOrEqual(2);
+      const inherited = await admin.get(
+        `/admin/api/requests/${requestIds[0]}/payload?part=meta`,
+      );
+      expect(await inherited.json()).toMatchObject({ captured: false });
+    } finally {
+      await api?.dispose();
+      if (keyId !== undefined) {
+        await admin.delete(`/admin/api/keys/${keyId}`);
+        await admin.delete(`/admin/api/keys/${keyId}?purge=true`);
+      }
+      await admin.put("/admin/api/settings", { data: originalSettings });
+      await admin.dispose();
+    }
+  });
+});
+
 // ── 6. Payload view: the seeded request was stored WITHOUT a captured body ────
 test.describe("admin request payload view", () => {
   test("shows a no-session notice when no payload or Session ID was captured", async ({ page }) => {

--- a/apps/gateway/src/middleware/auth.test.ts
+++ b/apps/gateway/src/middleware/auth.test.ts
@@ -31,6 +31,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...overrides,
   };
 }
@@ -96,6 +97,16 @@ describe("authMiddleware", () => {
       role: "user",
       caps: { allowedLanes: ["economy", "balanced"], allowCustomModel: false },
     });
+  });
+
+  it("attaches the per-key request-content override", async () => {
+    const getByHash = vi.fn().mockResolvedValue(record({ request_content_mode: "payload" }));
+    const { app } = buildApp({ keyStore: { getByHash }, log: () => {} });
+    const res = await app.request("/protected", {
+      headers: { Authorization: "Bearer helm_live_secret" },
+    });
+    const body = (await res.json()) as { identity: { caps: { requestContentMode: string } } };
+    expect(body.identity.caps.requestContentMode).toBe("payload");
   });
 
   it("hashes the plaintext with the same hashKey the keygen uses", async () => {

--- a/apps/gateway/src/middleware/auth.ts
+++ b/apps/gateway/src/middleware/auth.ts
@@ -43,6 +43,7 @@ export interface AuthIdentity {
       projectName?: string | null;
       threadSource: "header" | "auto";
     };
+    requestContentMode: ApiKeyRecord["request_content_mode"];
   };
 }
 
@@ -139,6 +140,7 @@ export function authMiddleware(deps: AuthDeps): MiddlewareHandler<AppEnv> {
           projectName: record.memory_project_id,
           threadSource: record.memory_thread_source,
         },
+        requestContentMode: record.request_content_mode,
       },
     };
     c.set("identity", identity);

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -114,6 +114,7 @@ function makeKeyStore(): KeyStore & { rows: TestKeyRecord[] } {
         memory_mode: input.memoryMode ?? "off",
         memory_project_id: input.memoryProjectId ?? null,
         memory_thread_source: input.memoryThreadSource ?? "auto",
+        request_content_mode: input.requestContentMode ?? null,
       };
       rows.push(rec);
       return rec;
@@ -160,6 +161,8 @@ function makeKeyStore(): KeyStore & { rows: TestKeyRecord[] } {
       if (patch.memoryProjectId !== undefined) row.memory_project_id = patch.memoryProjectId;
       if (patch.memoryThreadSource !== undefined)
         row.memory_thread_source = patch.memoryThreadSource;
+      if (patch.requestContentMode !== undefined)
+        row.request_content_mode = patch.requestContentMode;
     },
     async rotateKey(keyId, input) {
       const row = rows.find((r) => r.key_id === keyId);
@@ -888,6 +891,31 @@ describe("admin.api keys", () => {
       Record<string, unknown>
     >;
     expect(list[0]?.allow_fast_mode).toBe(true);
+  });
+
+  it("creates, lists, updates, and clears a per-key request-content override", async () => {
+    const deps = buildDeps();
+    const app = buildApp(deps);
+    const created = await app.request("/admin/api/keys", {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ role: "user", request_content_mode: "payload" }),
+    });
+    expect(created.status).toBe(201);
+    expect(keyStore.rows[0]?.request_content_mode).toBe("payload");
+
+    const list = (await (await app.request("/admin/api/keys")).json()) as Array<
+      Record<string, unknown>
+    >;
+    expect(list[0]?.request_content_mode).toBe("payload");
+
+    const cleared = await app.request("/admin/api/keys/key_1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ request_content_mode: null }),
+    });
+    expect(cleared.status).toBe(200);
+    expect(keyStore.rows[0]?.request_content_mode).toBeNull();
   });
 
   it("PATCH edits a key's rate limits (number sets, null clears) without touching caps", async () => {

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -592,6 +592,8 @@ export interface KeySummary {
   memory_mode: "off" | "observe" | "inject";
   memory_project_id: string | null;
   memory_thread_source: "header" | "auto";
+  // null inherits the live System Settings request-content mode.
+  request_content_mode: "none" | "payload" | "session" | null;
 }
 
 // New-key/rotated-key response: carries plaintext intentionally so the operator

--- a/apps/gateway/src/routes/admin/keys.ts
+++ b/apps/gateway/src/routes/admin/keys.ts
@@ -48,6 +48,7 @@ function toSummary(rec: {
   memory_mode: "off" | "observe" | "inject";
   memory_project_id: string | null;
   memory_thread_source: "header" | "auto";
+  request_content_mode: "none" | "payload" | "session" | null;
 }): KeySummary {
   return {
     key_id: rec.key_id,
@@ -71,6 +72,7 @@ function toSummary(rec: {
     memory_mode: rec.memory_mode,
     memory_project_id: rec.memory_project_id,
     memory_thread_source: rec.memory_thread_source,
+    request_content_mode: rec.request_content_mode,
   };
 }
 
@@ -226,6 +228,7 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       memoryMode: parsed.data.memory_mode,
       memoryProjectId: parsed.data.memory_project_id,
       memoryThreadSource: parsed.data.memory_thread_source,
+      requestContentMode: parsed.data.request_content_mode,
     });
     // The ONLY place plaintext is ever returned. `prefix` is the server-minted
     // non-sensitive display prefix (already persisted) — returned so the SPA need
@@ -278,6 +281,7 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
       memoryMode?: "off" | "observe" | "inject";
       memoryProjectId?: string | null;
       memoryThreadSource?: "header" | "auto";
+      requestContentMode?: "none" | "payload" | "session" | null;
     } = {};
     if (d.name !== undefined) patch.name = d.name;
     if (d.allowed_lanes !== undefined) patch.allowedLanes = d.allowed_lanes;
@@ -296,6 +300,7 @@ export function registerKeysRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void 
     if (d.memory_mode !== undefined) patch.memoryMode = d.memory_mode;
     if (d.memory_project_id !== undefined) patch.memoryProjectId = d.memory_project_id;
     if (d.memory_thread_source !== undefined) patch.memoryThreadSource = d.memory_thread_source;
+    if (d.request_content_mode !== undefined) patch.requestContentMode = d.request_content_mode;
     try {
       await deps.keyStore.updateKey(id, patch);
     } catch {

--- a/apps/gateway/src/routes/admin/replay.test.ts
+++ b/apps/gateway/src/routes/admin/replay.test.ts
@@ -33,6 +33,7 @@ function fakeKey(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off",
     memory_project_id: null,
     memory_thread_source: "header",
+    request_content_mode: null,
     ...overrides,
   };
 }
@@ -441,6 +442,27 @@ describe("runReplay", () => {
     );
     expect(rec.payloads).toHaveLength(0);
     expect(rec.inserts).toHaveLength(1);
+  });
+
+  it("per-key payload mode overrides disabled system capture for replay", async () => {
+    const rec = emptyRec();
+    const route: ReplayWiring["route"] = async (req) => ({
+      decision: decision(req.request_id),
+      final: { status: "ok", alias: "openai/gpt-4" },
+      body: { ok: true },
+      stream: null,
+      error: null,
+    });
+    await runReplay(
+      {
+        replay: wiring(route, rec, { capturePayloads: () => false }),
+        telemetry: fakeTelemetry("key_1", rec),
+        keyStore: fakeKeyStore([fakeKey({ request_content_mode: "payload" })]),
+      },
+      { originalTraceId: "orig", body: okBody, signal: new AbortController().signal, log: noop },
+    );
+
+    expect(rec.payloads).toHaveLength(1);
   });
 
   it("persists the partial stream + telemetry when the stream throws mid-drain", async () => {

--- a/apps/gateway/src/routes/admin/replay.ts
+++ b/apps/gateway/src/routes/admin/replay.ts
@@ -26,6 +26,7 @@ import {
   persistPayload,
   stampRequestBodyBytes,
   usageFromSSE,
+  withRequestContentMode,
 } from "../payload-capture.js";
 import type { AdminApiDeps, ReplayWiring } from "./deps.js";
 
@@ -134,11 +135,14 @@ export async function runReplay(
   //    a decision (the error trail) so even a failed retry is viewable. Payload
   //    capture stays fail-open (like the live routes); the telemetry insert is
   //    fail-CLOSED — see below.
-  const captureDeps: PayloadCaptureDeps = {
-    telemetry: deps.telemetry,
-    capturePayloads: deps.replay.capturePayloads,
-    costOf: deps.replay.costOf,
-  };
+  const captureDeps = withRequestContentMode<PayloadCaptureDeps>(
+    {
+      telemetry: deps.telemetry,
+      capturePayloads: deps.replay.capturePayloads,
+      costOf: deps.replay.costOf,
+    },
+    key.request_content_mode,
+  );
   await persistPayload(
     captureDeps,
     {

--- a/apps/gateway/src/routes/chat.errors.test.ts
+++ b/apps/gateway/src/routes/chat.errors.test.ts
@@ -49,6 +49,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.inject.test.ts
+++ b/apps/gateway/src/routes/chat.inject.test.ts
@@ -52,6 +52,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.memory.test.ts
+++ b/apps/gateway/src/routes/chat.memory.test.ts
@@ -45,6 +45,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -49,6 +49,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...over,
   };
 }
@@ -1287,6 +1288,44 @@ describe("POST /v1/chat/completions — payload capture + streamed cost", () => 
     expect(cap.payloads).toHaveLength(1);
     expect(cap.payloads[0]?.requestJson).toBe(rawRequest);
     expect(cap.payloads[0]?.responseJson).toBe(JSON.stringify(upstream));
+  });
+
+  it("lets a key enable full payload capture over a global metadata-only mode", async () => {
+    const cap = captureTelemetry();
+    const { deps: d, harness } = deps({
+      telemetry: cap.telemetry,
+      capturePayloads: () => false,
+      captureSessions: () => false,
+    });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "override-on", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d, { record: { request_content_mode: "payload" } });
+    await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(cap.payloads).toHaveLength(1);
+  });
+
+  it("lets a key disable full payload capture over a global payload mode", async () => {
+    const cap = captureTelemetry();
+    const { deps: d, harness } = deps({
+      telemetry: cap.telemetry,
+      capturePayloads: () => true,
+      captureSessions: () => false,
+    });
+    harness.execute.mockResolvedValue(
+      nonStreamOutcome({ id: "override-off", choices: [{ message: { content: "ok" } }] }),
+    );
+    const app = buildApp(d, { record: { request_content_mode: "none" } });
+    await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(NONSTREAM_BODY),
+    });
+    expect(cap.payloads).toHaveLength(0);
   });
 });
 

--- a/apps/gateway/src/routes/chat.session-key.test.ts
+++ b/apps/gateway/src/routes/chat.session-key.test.ts
@@ -48,6 +48,7 @@ function keyRecord(over: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...over,
   };
 }

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -65,6 +65,7 @@ import {
   tokensFromUsage,
   usageFromBody,
   usageFromSSE,
+  withRequestContentMode,
   withSseCaptureRelease,
 } from "./payload-capture.js";
 import { resolveSessionCapture, stampSessionCapture } from "./session-capture.js";
@@ -249,6 +250,7 @@ interface ChatIdentity {
     budget?: BudgetCaps;
     /** Per-key memory defaults (issue #97); absent = memory off unless headers say otherwise. */
     memory?: MemoryKeyDefaults;
+    requestContentMode?: "none" | "payload" | "session" | null;
   };
 }
 
@@ -444,6 +446,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     const traceId = c.get("trace_id");
     const requestId = c.get("request_id");
     const identity = c.get("identity") as unknown as ChatIdentity;
+    const captureDeps = withRequestContentMode(deps, identity.caps.requestContentMode);
 
     // Boundary validation (docs/07, principle 2 fail-closed): a malformed JSON
     // body or an invalid request (e.g. empty `messages`) is a CLIENT error → 400
@@ -563,7 +566,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       if (deps.writes !== undefined) {
         await deps.writes.enqueueTelemetry(input);
         await queueOrPersistSessionRequest(
-          deps,
+          captureDeps,
           {
             requestId,
             accountId: identity.accountId,
@@ -579,7 +582,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         return;
       }
       await queueOrPersistSessionRequest(
-        deps,
+        captureDeps,
         {
           requestId,
           accountId: identity.accountId,
@@ -610,7 +613,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
     ) => {
       const capturedResponseJson = requestTimedOut(c) ? null : responseJson;
       if (deps.writes !== undefined) {
-        if (!captureEnabled(deps)) return;
+        if (!captureEnabled(captureDeps)) return;
         await deps.writes.enqueuePayload({
           requestId,
           requestJson,
@@ -621,7 +624,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
         return;
       }
       await persistPayload(
-        deps,
+        captureDeps,
         {
           requestId,
           requestJson,
@@ -890,7 +893,7 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
       // whether the buffered body is PERSISTED, not whether it is collected — so
       // when capture is OFF we retain only a bounded TAIL (enough for usageFromSSE),
       // not the whole response, capping per-stream memory under high concurrency.
-      const captureOn = captureEnabled(deps);
+      const captureOn = captureEnabled(captureDeps);
       const captured = createSseCapture(captureOn);
       const streamModelRestamper =
         (deps.responseModelPolicy ?? "provider") === "requested_alias"

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -624,6 +624,22 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     expect(insertPayload).not.toHaveBeenCalled();
   });
 
+  it("per-key payload mode overrides the disabled system setting", async () => {
+    const { record, insertPayload } = makeRecord({ capturePayloads: false });
+    const { deps } = makeDeps({
+      record,
+      identity: { ...IDENTITY, caps: { requestContentMode: "payload" } },
+    });
+    const res = await buildApp(deps).request("/v1beta/models/gemini-2.0-flash:generateContent", {
+      method: "POST",
+      headers: GEMINI_AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertPayload).toHaveBeenCalledOnce();
+  });
+
   // ── Terminal stream error frame must be appended to the captured body (review
   //    P2). A mid-stream error writes a nameless `data:` error frame to the
   //    client; that frame has to land in the persisted responseJson too.

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -32,6 +32,7 @@ import {
   type RecordServedDeps,
   recordServed,
   sessionCaptureEnabled,
+  withRequestContentMode,
   withSseCaptureRelease,
 } from "./payload-capture.js";
 import { resolveSessionCapture, stampSessionCapture } from "./session-capture.js";
@@ -220,6 +221,10 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
         trace_id: traceId,
       });
     }
+    const captureRecord =
+      deps.record === undefined
+        ? undefined
+        : withRequestContentMode(deps.record, identity.caps?.requestContentMode);
 
     // 1b) Rate limit AFTER auth (needs the resolved key_id), BEFORE translate/route.
     if (deps.rateLimiter !== undefined) {
@@ -429,8 +434,9 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     // (the telemetry row is always written regardless). Gating the buffering here
     // stops long/concurrent streams from accumulating the full body when capture is
     // off (review P2).
-    const captureBodies = deps.record !== undefined && captureEnabled(deps.record);
-    const captureSessionResponse = deps.record !== undefined && sessionCaptureEnabled(deps.record);
+    const captureBodies = captureRecord !== undefined && captureEnabled(captureRecord);
+    const captureSessionResponse =
+      captureRecord !== undefined && sessionCaptureEnabled(captureRecord);
 
     // 4) Protocol Adapter (outbound). Gemini streaming events are incremental deltas,
     //    written as nameless `data:` frames — NO `event:` name, NO `[DONE]`.
@@ -508,13 +514,13 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
               // for-await loop ended so the pipeline's own streamIR finally (cost
               // backfill) already mutated result.decision. result.decision exists even
               // on a pre-stream failure, so a failed stream still records. Fail-open.
-              if (deps.record) {
+              if (captureRecord) {
                 stampServingAccount(result.decision, result.servingAccount ?? null);
                 if (captured?.limited()) {
                   c.get("logger").log("warn", "payload.capture_limited", { trace_id: traceId });
                 }
                 await recordServed(
-                  deps.record,
+                  captureRecord,
                   {
                     requestId,
                     accountId: identity.accountId,
@@ -548,10 +554,10 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
       // chat.ts) so an all-providers-failed request still appears in
       // /admin/requests. responseJson null = no body. result.decision exists even
       // on failure. Fail-open inside recordServed.
-      if (deps.record) {
+      if (captureRecord) {
         stampServingAccount(result.decision, result.servingAccount ?? null);
         await recordServed(
-          deps.record,
+          captureRecord,
           {
             requestId,
             accountId: identity.accountId,
@@ -576,10 +582,10 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
     }
     // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
     // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
-    if (deps.record) {
+    if (captureRecord) {
       stampServingAccount(result.decision, result.servingAccount ?? null);
       await recordServed(
-        deps.record,
+        captureRecord,
         {
           requestId,
           accountId: identity.accountId,

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -36,7 +36,10 @@ const BUDGET_CAPS = {
   degradeLane: null,
 };
 
-function setup(over: Partial<ImagesRouteDeps> = {}) {
+function setup(
+  over: Partial<ImagesRouteDeps> = {},
+  requestContentMode?: "none" | "payload" | "session",
+) {
   const imageGeneration = vi.fn().mockResolvedValue(UPSTREAM);
   const imageEdit = vi.fn().mockResolvedValue(UPSTREAM);
   const client = { imageGeneration, imageEdit } as unknown as ProviderClient;
@@ -58,7 +61,7 @@ function setup(over: Partial<ImagesRouteDeps> = {}) {
               keyId: "key1",
               accountId: "acct",
               keyPrefix: "helm_live_xy",
-              caps: { budget: BUDGET_CAPS },
+              caps: { budget: BUDGET_CAPS, requestContentMode },
             } as MessagesIdentity)
           : null,
     },
@@ -186,6 +189,14 @@ describe("registerImagesRoute", () => {
     const stored = JSON.parse(payload.responseJson) as typeof UPSTREAM;
     expect(stored.data[0]?.b64_json).toBe("REALIMAGEBYTES"); // full image handed to capture
     expect(stored.usage.output_tokens).toBe(196); // metadata/usage preserved
+  });
+
+  it("per-key metadata-only mode overrides enabled system payload capture", async () => {
+    const { app, enqueuePayload } = setup({}, "none");
+    const res = await post(app, { model: "gpt-image-2", prompt: "a cat" });
+
+    expect(res.status).toBe(200);
+    expect(enqueuePayload).not.toHaveBeenCalled();
   });
 
   it("returns 401 without a valid key", async () => {

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -29,7 +29,12 @@ import {
 import { buildImageDecision, numField } from "./image-telemetry.js";
 import { geminiImageUsageBody } from "./image-usage.js";
 import type { MessagesIdentity } from "./messages.js";
-import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
+import {
+  captureEnabled,
+  type RecordServedDeps,
+  recordServed,
+  withRequestContentMode,
+} from "./payload-capture.js";
 
 // POST /v1/images/generations — OpenAI Images API (the gpt-image-* / DALL·E surface).
 // A model-pinned endpoint distinct from the chat/messages/responses/gemini pipeline,
@@ -134,6 +139,10 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
         "invalid_api_key",
       );
     }
+    const captureRecord =
+      deps.record === undefined
+        ? undefined
+        : withRequestContentMode(deps.record, identity.caps?.requestContentMode);
     const keyPrefix = typeof identity.keyPrefix === "string" ? identity.keyPrefix : null;
 
     // 2) Rate limit AFTER auth.
@@ -417,7 +426,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
     // 6b) Terminal failure. A client abort is a NON-provider fault → no record, no 5xx.
     if (!outcome.ok) {
       if (outcome.aborted) return errorJson(c, 400, "invalid_request_error", "client disconnected");
-      if (deps.record !== undefined) {
+      if (captureRecord !== undefined) {
         const decision = buildImageDecision({
           requestId,
           traceId,
@@ -431,7 +440,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
           usage: null,
         });
         await recordServed(
-          deps.record,
+          captureRecord,
           {
             requestId,
             apiKeyId: identity.keyId,
@@ -456,7 +465,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
 
     // 7) Cost + telemetry. Capture the response body (image stripped) only when on.
     const { served, result } = outcome;
-    if (deps.record !== undefined) {
+    if (captureRecord !== undefined) {
       const decision = buildImageDecision({
         requestId,
         traceId,
@@ -473,9 +482,9 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
       // content-addresses the base64 image into payload_blobs (deduped + retention-
       // pruned) and rehydrates it for the admin detail view. request_payloads keeps
       // only a sentinel, so it stays lean while the image stays viewable.
-      const responseJson = captureEnabled(deps.record) ? JSON.stringify(result.clientBody) : null;
+      const responseJson = captureEnabled(captureRecord) ? JSON.stringify(result.clientBody) : null;
       await recordServed(
-        deps.record,
+        captureRecord,
         {
           requestId,
           apiKeyId: identity.keyId,

--- a/apps/gateway/src/routes/interactions.test.ts
+++ b/apps/gateway/src/routes/interactions.test.ts
@@ -45,6 +45,7 @@ const BUDGET_CAPS = {
 function setup(
   over: Partial<InteractionsRouteDeps> = {},
   contextIds?: { requestId: string; traceId: string },
+  requestContentMode?: "none" | "payload" | "session",
 ) {
   const nativePassthrough = vi.fn().mockResolvedValue(NATIVE);
   const client = { nativePassthrough } as unknown as ProviderClient;
@@ -66,7 +67,7 @@ function setup(
               keyId: "key1",
               accountId: "acct",
               keyPrefix: "helm_live_xy",
-              caps: { budget: BUDGET_CAPS },
+              caps: { budget: BUDGET_CAPS, requestContentMode },
             } as MessagesIdentity)
           : null,
     },
@@ -297,6 +298,14 @@ describe("registerInteractionsRoute", () => {
     };
     const img = stored.steps[0]?.content.find((b) => b.type === "image");
     expect(img?.data).toBe("GEMIMG"); // full image handed to capture
+  });
+
+  it("per-key metadata-only mode overrides enabled system payload capture", async () => {
+    const { app, enqueuePayload } = setup({}, undefined, "none");
+    const res = await post(app, { model: "gemini-3.1-flash-image", input: "a cat" });
+
+    expect(res.status).toBe(200);
+    expect(enqueuePayload).not.toHaveBeenCalled();
   });
 
   it("returns 401 without a valid key", async () => {

--- a/apps/gateway/src/routes/interactions.ts
+++ b/apps/gateway/src/routes/interactions.ts
@@ -28,7 +28,12 @@ import {
 import { buildImageDecision, numField } from "./image-telemetry.js";
 import { geminiImageUsageBody } from "./image-usage.js";
 import type { MessagesIdentity } from "./messages.js";
-import { captureEnabled, type RecordServedDeps, recordServed } from "./payload-capture.js";
+import {
+  captureEnabled,
+  type RecordServedDeps,
+  recordServed,
+  withRequestContentMode,
+} from "./payload-capture.js";
 
 // POST /v1beta/interactions — Google Gemini Interactions API (the modern image-gen
 // surface for the gemini-*-image "Nano Banana" models; the SDK's
@@ -202,6 +207,10 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
     if (identity === null) {
       return errorJson(c, 401, "missing or invalid API key", "UNAUTHENTICATED");
     }
+    const captureRecord =
+      deps.record === undefined
+        ? undefined
+        : withRequestContentMode(deps.record, identity.caps?.requestContentMode);
     const keyPrefix = typeof identity.keyPrefix === "string" ? identity.keyPrefix : null;
 
     // 2) Rate limit AFTER auth.
@@ -385,7 +394,7 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
     // 6b) Terminal failure. A client abort is a NON-provider fault → no record.
     if (!outcome.ok) {
       if (outcome.aborted) return errorJson(c, 400, "client disconnected", "CANCELLED");
-      if (deps.record !== undefined) {
+      if (captureRecord !== undefined) {
         const decision = buildImageDecision({
           requestId,
           traceId,
@@ -399,7 +408,7 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
           usage: null,
         });
         await recordServed(
-          deps.record,
+          captureRecord,
           {
             requestId,
             apiKeyId: identity.keyId,
@@ -422,7 +431,7 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
 
     // 7) Cost + telemetry. Capture a copy with the base64 image stripped.
     const { served, result } = outcome;
-    if (deps.record !== undefined) {
+    if (captureRecord !== undefined) {
       const decision = buildImageDecision({
         requestId,
         traceId,
@@ -438,9 +447,9 @@ export function registerInteractionsRoute(app: Hono<AppEnv>, deps: InteractionsR
       // Capture the FULL body — the store's externalizeImages content-addresses the
       // base64 image into payload_blobs (deduped + retention-pruned) and rehydrates it
       // for the admin detail view; request_payloads keeps only a sentinel.
-      const responseJson = captureEnabled(deps.record) ? JSON.stringify(result.clientBody) : null;
+      const responseJson = captureEnabled(captureRecord) ? JSON.stringify(result.clientBody) : null;
       await recordServed(
-        deps.record,
+        captureRecord,
         {
           requestId,
           apiKeyId: identity.keyId,

--- a/apps/gateway/src/routes/mcp/mcp.test.ts
+++ b/apps/gateway/src/routes/mcp/mcp.test.ts
@@ -40,6 +40,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...overrides,
   };
 }

--- a/apps/gateway/src/routes/mcp/oauth.test.ts
+++ b/apps/gateway/src/routes/mcp/oauth.test.ts
@@ -34,6 +34,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "inject",
     memory_project_id: "proj-9",
     memory_thread_source: "header",
+    request_content_mode: null,
     ...overrides,
   };
 }

--- a/apps/gateway/src/routes/mcp/oauth.ts
+++ b/apps/gateway/src/routes/mcp/oauth.ts
@@ -212,6 +212,7 @@ function identityFromClaims(claims: Record<string, unknown>): AuthIdentity {
         projectId: typeof claims.pid === "string" ? claims.pid : null,
         threadSource: "header",
       },
+      requestContentMode: null,
     },
   };
 }

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -866,6 +866,22 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expect(insertPayload).not.toHaveBeenCalled();
   });
 
+  it("per-key payload mode overrides the disabled system setting", async () => {
+    const { record, insertPayload } = makeRecord({ capturePayloads: false });
+    const { deps } = makeDeps({
+      record,
+      identity: { ...IDENTITY, caps: { requestContentMode: "payload" } },
+    });
+    const res = await buildApp(deps).request("/v1/messages", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertPayload).toHaveBeenCalledOnce();
+  });
+
   // ── Native protocol passthrough (#217 C3). When the pipeline reports
   //    nativePassthrough the route MUST return collect()'s body UNTOUCHED (skip
   //    transformResponseOut), so the verbatim Anthropic upstream body reaches the

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -35,6 +35,7 @@ import {
   type RecordServedDeps,
   recordServed,
   sessionCaptureEnabled,
+  withRequestContentMode,
   withSseCaptureRelease,
 } from "./payload-capture.js";
 import { resolveSessionCapture, stampSessionCapture } from "./session-capture.js";
@@ -81,6 +82,8 @@ export interface MessagesIdentity {
     /** Per-key memory defaults (issue #97), read by the route's memory scope
      *  resolver; absent = memory off unless headers say otherwise. */
     memory?: MemoryKeyDefaults;
+    /** Per-key request-content override; null/absent inherits the system mode. */
+    requestContentMode?: "none" | "payload" | "session" | null;
     [k: string]: unknown;
   };
   [k: string]: unknown;
@@ -380,6 +383,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
         trace_id: traceId,
       });
     }
+    const captureRecord =
+      deps.record === undefined
+        ? undefined
+        : withRequestContentMode(deps.record, identity.caps?.requestContentMode);
 
     // 1b) Rate limit AFTER auth (needs the resolved key_id) and BEFORE translate/
     //     route (cut off cost before classification/eval). Mirrors the OpenAI chat
@@ -602,8 +609,9 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     // (the telemetry row is always written regardless). Gating the buffering here
     // stops long/concurrent streams from accumulating the full body when capture is
     // off (review P2).
-    const captureBodies = deps.record !== undefined && captureEnabled(deps.record);
-    const captureSessionResponse = deps.record !== undefined && sessionCaptureEnabled(deps.record);
+    const captureBodies = captureRecord !== undefined && captureEnabled(captureRecord);
+    const captureSessionResponse =
+      captureRecord !== undefined && sessionCaptureEnabled(captureRecord);
 
     // 4) Protocol Adapter (outbound): stream vs non-stream, isomorphic shape.
     if (ir.stream === true) {
@@ -694,13 +702,13 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
               // for-await loop ended so the pipeline's own streamIR finally (cost
               // backfill) already mutated result.decision. result.decision exists even
               // on a pre-stream failure, so a failed stream still records. Fail-open.
-              if (deps.record) {
+              if (captureRecord) {
                 stampServingAccount(result.decision, result.servingAccount ?? null);
                 if (captured?.limited()) {
                   c.get("logger").log("warn", "payload.capture_limited", { trace_id: traceId });
                 }
                 await recordServed(
-                  deps.record,
+                  captureRecord,
                   {
                     requestId,
                     accountId: identity.accountId,
@@ -744,10 +752,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
       // chat.ts) so an all-providers-failed request still appears in
       // /admin/requests. responseJson null = no body. result.decision exists even
       // on failure. Fail-open inside recordServed.
-      if (deps.record) {
+      if (captureRecord) {
         stampServingAccount(result.decision, result.servingAccount ?? null);
         await recordServed(
-          deps.record,
+          captureRecord,
           {
             requestId,
             accountId: identity.accountId,
@@ -772,10 +780,10 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
     }
     // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
     // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
-    if (deps.record) {
+    if (captureRecord) {
       stampServingAccount(result.decision, result.servingAccount ?? null);
       await recordServed(
-        deps.record,
+        captureRecord,
         {
           requestId,
           accountId: identity.accountId,

--- a/apps/gateway/src/routes/models.test.ts
+++ b/apps/gateway/src/routes/models.test.ts
@@ -67,6 +67,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...overrides,
   };
 }

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -25,8 +25,28 @@ import {
   usageFromResponsesResponse,
   usageFromResponsesSSE,
   usageFromSSE,
+  withRequestContentMode,
   withSseCaptureRelease,
 } from "./payload-capture.js";
+
+describe("per-key request content mode", () => {
+  const global = {
+    telemetry: {} as PayloadCaptureDeps["telemetry"],
+    capturePayloads: () => false,
+    captureSessions: () => true,
+  } satisfies PayloadCaptureDeps;
+
+  it.each([
+    [null, false, true],
+    ["none", false, false],
+    ["payload", true, false],
+    ["session", false, true],
+  ] as const)("resolves %s over the global mode", (mode, payloads, sessions) => {
+    const scoped = withRequestContentMode(global, mode);
+    expect(scoped.capturePayloads?.()).toBe(payloads);
+    expect(scoped.captureSessions?.()).toBe(sessions);
+  });
+});
 
 describe("session head cache", () => {
   it("evicts by retained UTF-8 bytes, not only by Session count", () => {

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -6,7 +6,7 @@ import {
   runtimeMemoryBudget,
   splitSessionRequestJson,
 } from "@helm/core";
-import type { TokenUsageBreakdown } from "@helm/shared";
+import type { RequestContentMode, TokenUsageBreakdown } from "@helm/shared";
 import { countTokens as countO200kHarmonyTokens } from "gpt-tokenizer/encoding/o200k_harmony";
 import { CONCURRENCY_LEASE_LOST_REASON } from "../request-cancellation.js";
 import type { WriteQueue } from "../runtime/write-queue.js";
@@ -37,6 +37,19 @@ export interface PayloadCaptureDeps {
    *  catalog estimate, else tokens × `alias`'s pricing; null when neither is
    *  available. Closed over the catalog + resolveCostUsd in the composition root. */
   costOf?: (alias: string, usage: StreamUsage) => number | null;
+}
+
+/** Apply one authenticated key's override without mutating the shared live deps. */
+export function withRequestContentMode<T extends PayloadCaptureDeps>(
+  deps: T,
+  mode: RequestContentMode | null | undefined,
+): T {
+  if (mode == null) return deps;
+  return {
+    ...deps,
+    capturePayloads: () => mode === "payload",
+    captureSessions: () => mode === "session",
+  };
 }
 
 export interface StreamUsage {

--- a/apps/gateway/src/routes/portal/index.test.ts
+++ b/apps/gateway/src/routes/portal/index.test.ts
@@ -42,6 +42,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "inject",
     memory_project_id: null,
     memory_thread_source: "header",
+    request_content_mode: null,
     ...overrides,
   };
 }

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -900,6 +900,25 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
   });
 
+  it("/compact honors a per-key payload override when system capture is off", async () => {
+    const { record, insertPayload } = makeRecord({ capturePayloads: false });
+    const compact = vi.fn().mockResolvedValue({ id: "resp_compact", output: [] });
+    const { deps } = makeDeps({
+      lifecycle: { compact },
+      record,
+      identity: { keyId: "k1", accountId: "acct", caps: { requestContentMode: "payload" } },
+    });
+
+    const res = await buildApp(deps).request("/v1/responses/compact", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+
+    expect(res.status).toBe(200);
+    expect(insertPayload).toHaveBeenCalledOnce();
+  });
+
   it("/compact rejects an exhausted per-key usage budget before subscription dispatch", async () => {
     const compact = vi.fn().mockResolvedValue({ output: [] });
     const check = vi.fn().mockResolvedValue({

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -56,6 +56,7 @@ import {
   tokenBreakdownFromUsage,
   tokensFromUsage,
   usageFromResponsesResponse,
+  withRequestContentMode,
 } from "./payload-capture.js";
 import { resolveSessionCapture, stampSessionCapture } from "./session-capture.js";
 import { isUpstreamTimeout } from "./stream-error.js";
@@ -939,6 +940,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     const traceId = c.get("trace_id");
     const requestId = c.get("request_id");
     const identity = await authenticateResponsesRequest(c);
+    const captureRecord =
+      deps.record === undefined
+        ? undefined
+        : withRequestContentMode(deps.record, identity.caps?.requestContentMode);
     await enforceRateLimit(c, identity);
     await acquireConcurrency(c, identity);
     const { native, rawBody, materialized } = await parseJsonBodyWithRaw(c, traceId);
@@ -995,7 +1000,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       const costUsd =
         usage === null
           ? null
-          : (deps.budget?.costOf?.(alias, usage) ?? deps.record?.costOf?.(alias, usage) ?? null);
+          : (deps.budget?.costOf?.(alias, usage) ?? captureRecord?.costOf?.(alias, usage) ?? null);
       const tokens = tokensFromUsage(usage);
       if (deps.budget !== undefined && budgetCaps !== undefined) {
         try {
@@ -1010,9 +1015,9 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         }
       }
       deps.recordOAuthUsage?.(execution?.servingAccount ?? null, alias, { tokens, costUsd });
-      if (deps.record !== undefined) {
+      if (captureRecord !== undefined) {
         await recordServed(
-          deps.record,
+          captureRecord,
           {
             requestId,
             apiKeyId: identity.keyId,
@@ -1032,7 +1037,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
               costUsd,
             }),
             requestJson: rawBody,
-            responseJson: captureEnabled(deps.record) ? JSON.stringify(body) : null,
+            responseJson: captureEnabled(captureRecord) ? JSON.stringify(body) : null,
             timedOut: requestTimedOut(c),
             upstreamRequestJson: execution?.upstreamRequest ?? null,
           },
@@ -1042,12 +1047,12 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       applyResponseMetadata(c, responseMetadata, modelsEtagForRequest(c, deps, identity.keyId));
       return c.json(body);
     } catch (err) {
-      if (deps.record !== undefined) {
+      if (captureRecord !== undefined) {
         const requestedModel = compactModelFromBody(carrier.body);
         const execution = executionState.value;
         const providerModel = execution?.providerModel ?? requestedModel;
         await recordServed(
-          deps.record,
+          captureRecord,
           {
             requestId,
             apiKeyId: identity.keyId,
@@ -1097,6 +1102,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
 
     // 1) Auth FIRST (docs/02 pipeline order).
     const identity = await authenticateResponsesRequest(c);
+    const captureRecord =
+      deps.record === undefined
+        ? undefined
+        : withRequestContentMode(deps.record, identity.caps?.requestContentMode);
 
     // 1b) Rate limit AFTER auth (needs the resolved key_id) and BEFORE translate/
     //     route. OpenAI surface → the structured rate_limited envelope via onError
@@ -1205,8 +1214,9 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     // (the telemetry row is always written regardless). Gating the buffering here
     // stops long/concurrent streams from accumulating the full body when capture is
     // off (review P2).
-    const captureBodies = deps.record !== undefined && captureEnabled(deps.record);
-    const captureSessionResponse = deps.record !== undefined && sessionCaptureEnabled(deps.record);
+    const captureBodies = captureRecord !== undefined && captureEnabled(captureRecord);
+    const captureSessionResponse =
+      captureRecord !== undefined && sessionCaptureEnabled(captureRecord);
 
     // 4) Outbound: stream vs non-stream, isomorphic shape.
     if (ir.stream === true) {
@@ -1391,13 +1401,13 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           // result.decision exists even on a pre-stream failure, so a failed stream
           // still records. Fail-open inside recordServed.
           try {
-            if (deps.record && result !== null) {
+            if (captureRecord && result !== null) {
               stampServingAccount(result.decision, result.servingAccount ?? null);
               if (captured?.limited()) {
                 c.get("logger").log("warn", "payload.capture_limited", { trace_id: traceId });
               }
               await recordServed(
-                deps.record,
+                captureRecord,
                 {
                   requestId,
                   accountId: identity.accountId,
@@ -1462,10 +1472,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       // chat.ts, which records failures too) so an all-providers-failed request
       // still appears in /admin/requests. responseJson null = no body produced.
       // result.decision exists even on failure. Fail-open inside recordServed.
-      if (deps.record) {
+      if (captureRecord) {
         stampServingAccount(result.decision, result.servingAccount ?? null);
         await recordServed(
-          deps.record,
+          captureRecord,
           {
             requestId,
             accountId: identity.accountId,
@@ -1498,10 +1508,10 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     }
     // Record the served (non-stream) request: telemetry row (→ /admin/requests) +
     // verbatim request/response body. Mirrors chat.ts. Fail-open inside recordServed.
-    if (deps.record) {
+    if (captureRecord) {
       stampServingAccount(result.decision, result.servingAccount ?? null);
       await recordServed(
-        deps.record,
+        captureRecord,
         {
           requestId,
           accountId: identity.accountId,

--- a/apps/gateway/src/routes/usage.test.ts
+++ b/apps/gateway/src/routes/usage.test.ts
@@ -31,6 +31,7 @@ function record(overrides: Partial<ApiKeyRecord> = {}): ApiKeyRecord {
     memory_mode: "off" as const,
     memory_project_id: null,
     memory_thread_source: "header" as const,
+    request_content_mode: null,
     ...overrides,
   };
 }

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -3724,6 +3724,7 @@ export async function buildServer(
               projectId: effectiveMemoryProjectId(record),
               threadSource: record.memory_thread_source,
             },
+            requestContentMode: record.request_content_mode,
           },
         };
       },
@@ -3942,6 +3943,7 @@ export async function buildServer(
               projectId: effectiveMemoryProjectId(record),
               threadSource: record.memory_thread_source,
             },
+            requestContentMode: record.request_content_mode,
           },
         };
       },
@@ -4041,6 +4043,7 @@ export async function buildServer(
           projectId: effectiveMemoryProjectId(record),
           threadSource: record.memory_thread_source,
         },
+        requestContentMode: record.request_content_mode,
       },
     };
   };

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-07-31 · API key 单独覆盖请求内容存储模式（Key Store / Telemetry / Admin，docs/06/07/11，原则 2/7）
+
+- **继承与优先级**：`api_keys.request_content_mode` 是 SQLite/PostgreSQL 的 nullable 枚举列；`NULL` 表示继承实时全局模式，`none` / `payload` / `session` 显式覆盖。历史 key 迁移后保持 `NULL`，不会因升级改变正文留存行为。
+- **覆盖面**：鉴权身份把覆盖值传到 Chat、Messages、Responses（含 compact）、Gemini、Images、Interactions 与 Admin Replay，并复用同一个 capture helper；只替换本次请求的 capture getter，不冻结或修改全局设置。
+- **保留边界**：`payload_retention_days` 仍是全局值，未增加 per-key retention。Admin Create/Edit/详情支持设置和清除覆盖；隐私提示与系统设置共用现有文案。
+
 ## 2026-07-31 · 保证 Session 捕获且删除累计字节上限（Telemetry / Session Store，docs/07/11，用户明确要求）
 
 - **决定**：按用户要求删除单 Session 64 MiB 累计存储上限，不用更大的常量替代。共享 Session 捕获、SQLite 与 PostgreSQL adapter 都不再因 `stored_bytes` 拒绝新 revision 或响应回填；`stored_bytes` 只继续用于观测。现有 SQLite `INTEGER` 与 PostgreSQL `BIGINT` 均无需迁移。
@@ -70,17 +76,9 @@
 - **Codex 增量续接**：真实客户端既会发送带完整 input 的 `generate:false` 预热帧，也会在启动预连接时发送严格的 `input:[] + generate:false` 预热帧；后一形状只有 normalized/native 两层都明确 `generate:false` 时才允许空 IR messages。下一帧可只带 `previous_response_id` 与空 `input`，此时仅当 Responses registry 已验证该 id 并固定原 provider 时放行；registry 在对客户端发送 terminal frame 前先持久化实际 provider alias、与成功 alias 相符的 OAuth account 及 selected lane，重启后仍恢复同一账号，fallback 前选中过但未实际服务的账号不会被写入。该持久化不伪造上游 connection-local state：Codex 在 WebSocket 重连时会清除旧增量状态并重发完整 input。续接在分类前固定为单 provider，真实 lane 继续受 `allowed_lanes` 约束，显式 custom-model 延续首轮既有语义；旧 registry 行缺少 lane provenance 时保持 fail-closed，`blocked_models` 与预算 degrade 同样不可绕过。普通空请求、未知 id、无 provider pin 与跨协议请求仍拒绝。`generate:false` 无 native Responses passthrough 时直接拒绝，不允许翻译路径意外产生计费输出。首 chunk 后的 `AbortError` 只记录为 `client_abort`，不误报上游截断，也不触发 breaker failure。
 - **连接超时边界**：Codex 上游 WebSocket handshake 与非 101 error body 的等待上限为 `min(request_timeout_ms, 60s)`；正常流式请求仍使用既有 request/idle timeout，不因连接建立保护而缩短。没有新增配置、依赖、后台 drain 或 graceful-shutdown 重构。
 
-## 2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面（Gateway / Protocol / Provider，docs/01/05/06，原则 1/2/3/7/8）
-
-- **Realtime V1/V2/V3**：新增 `/v1/realtime/calls`、`/v1/live` 与对应 WebSocket sideband。Call-create 复用现有 static/OpenAI-Codex provider client、OAuth pool、账号 token 与 egress proxy；ChatGPT backend 继续使用 JSON call shape，官方 OpenAI 使用 multipart。`call_id` 以进程内短 TTL 绑定创建它的 Helm key 与实际 provider/account sideband，WebSocket 必须使用同一 key，且不会重新选账号；OAuth HTTP/WS 401 各只刷新重试一次。Call-create 接入现有进程内或 PostgreSQL 分布式并发 lease，DB 不可用时 fail-closed 为 503，持有期间 lease 丢失会中止上游请求。双向文本/二进制帧按实际字节占用动态内存预算，关闭压缩并保留 close code。当前部署为单 gateway replica；水平扩容前必须把 registry 换成支持原子 claim 的共享存储。
-- **Codex upstream 线缆**：Codex 实际 WebRTC 请求使用 `x-session-id`，因此仅保留旧 `session-id` 会丢失会话身份；Realtime 只额外转发 `x-session-id` 与 `x-oai-attestation` 两个明确安全 header。ChatGPT backend 的 V3 `/v1/live` 不携带 query，但上游仍要求 `intent=quicksilver&architecture=avas`，只在 backend shape 且 query 为空时补该固定值；V1 sideband 使用 `/v1/realtime?intent=quicksilver&call_id=...`，V3 使用 `/v1/live/{call_id}`，custom/public base URL 保留已有路径前缀。同时复用目录运行时已生成的 Codex User-Agent，不信任或透传调用方任意 User-Agent。
-- **Voice 授权边界**：ChatGPT Desktop 宿主会为 Realtime call-create 即时生成 `x-oai-attestation`，Helm 仅将该明确 header 转发到创建调用的 ChatGPT backend 与同一 `call_id` sideband，不接受或透传任意扩展 header。OpenAI OAuth 对 Voice 返回的推理 403 属于产品访问拒绝：账号池会尝试尚未试过的兄弟账号，全部拒绝后保留真实 403，但不会持久禁用仍可服务文本 Responses 的账号；真正的 401 与永久 token-refresh 失败仍按原策略隔离账号。
-- **Responses 与模型目录**：Responses `input_audio.audio_url` data URL 进入统一 audio IR；provider 明确声明 `responses_audio_url` 时恢复同一 carrier，旧 `input_audio:{data,format}` 保持兼容。Codex 模型目录的 `input_modalities` 接受 `audio`，不再因新目录字段丢弃模型。
-- **Images edits**：`/v1/images/edits` 复用现有 Images 的鉴权、限流、并发、预算、blocked-model、breaker/fallback、成本与 payload/telemetry 链；支持 Codex JSON `images[].image_url|file_id` 和 OpenAI multipart `image`/`image[]`、`mask`，binary bytes 在 fallback 间可重放。线上验证发现 ZenMux 虽在 `/models` 发布 `openai/gpt-image-2`，但 `/images/edits` 对它返回 `404 invalid_model`，而 OpenAI 官方对同一 JSON/multipart 请求均成功；因此客户端 `gpt-image-2` 改为 ZenMux 优先、OpenAI 官方操作回退。Gemini edit 未发现兼容契约，确定性返回 unsupported，不做有损转换。
-- **暂缓边界**：按用户确认不代理 `alpha/search` 与 `memories/trace_summarize`；未引入新依赖、媒体存储、共享 registry 或第二套路由器。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面**：Realtime V1/V2/V3、Responses 音频与 Images edits 复用既有鉴权、路由、账号和遥测链；Voice attestation 与单实例 call registry 保持收窄边界，完整原文通过 git history 回溯。
 - **2026-07-24 · 请求准入增加实时 V8 堆高水位**：曾以 live heap + 分池余量拒绝高风险请求；后被 2026-07-27 的启发式拒绝拆除与 2026-07-28 的请求大小上限删除取代，完整原文通过 git history 回溯。
 - **2026-07-24 · Admin 登录同源证明兼容代理 Host 改写**：登录/登出优先接受浏览器不可伪造的 `Sec-Fetch-Site: same-origin`，同时保留 Origin/Host 与 cross-site 拒绝边界；完整原文通过 git history 回溯。
 - **2026-07-24 · Responses WebSocket ingress 改为按活动消息计费**：空闲连接不再预留完整帧容量，活动 `response.create` 才按真实 wire/JSON bytes 申请并释放 ingress lease；上游非 101 body 统一由有界响应超时接管，完整原文通过 git history 回溯。

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -48,6 +48,7 @@ class InMemoryKeyStore implements KeyStore {
       memory_mode: input.memoryMode ?? "off",
       memory_project_id: input.memoryProjectId ?? null,
       memory_thread_source: input.memoryThreadSource ?? "header",
+      request_content_mode: input.requestContentMode ?? null,
     };
     this.byId.set(record.key_id, record);
     return record;
@@ -86,6 +87,8 @@ class InMemoryKeyStore implements KeyStore {
     if (patch.overBudgetBehavior !== undefined)
       next.over_budget_behavior = patch.overBudgetBehavior;
     if (patch.degradeLane !== undefined) next.degrade_lane = patch.degradeLane;
+    if (patch.requestContentMode !== undefined)
+      next.request_content_mode = patch.requestContentMode;
     this.byId.set(keyId, next);
   }
   async rotateKey(keyId: string, input: RotateKeyInput): Promise<void> {
@@ -406,6 +409,7 @@ describe("port type contracts", () => {
       | "memoryMode"
       | "memoryProjectId"
       | "memoryThreadSource"
+      | "requestContentMode"
     >();
   });
 

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -205,6 +205,8 @@ export interface CreateKeyInput {
   memoryMode?: "off" | "observe" | "inject";
   memoryProjectId?: string;
   memoryThreadSource?: "header" | "auto";
+  // Per-key request-content retention override. Omitted => inherit system mode.
+  requestContentMode?: "none" | "payload" | "session";
 }
 
 export interface KeyStore {
@@ -273,6 +275,8 @@ export interface KeyPatch {
   memoryMode?: "off" | "observe" | "inject";
   memoryProjectId?: string | null;
   memoryThreadSource?: "header" | "auto";
+  // null clears the override back to the live system mode.
+  requestContentMode?: "none" | "payload" | "session" | null;
 }
 
 export interface RotateKeyInput {

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -52,6 +52,7 @@ export class PgKeyStore implements KeyStore {
       // undefined => "auto": a memory-on key derives its thread from client signals
       // out of the box (issue #97). Pass "header" explicitly to opt out.
       memoryThreadSource: input.memoryThreadSource ?? "auto",
+      requestContentMode: input.requestContentMode ?? null,
       createdAt: this.now().getTime(),
     };
     await this.db.insert(apiKeys).values(row);
@@ -120,6 +121,7 @@ export class PgKeyStore implements KeyStore {
         | "memoryMode"
         | "memoryProjectId"
         | "memoryThreadSource"
+        | "requestContentMode"
       >
     > = {};
     // Rename (null clears back to unnamed). Cosmetic only.
@@ -142,6 +144,7 @@ export class PgKeyStore implements KeyStore {
     if (patch.memoryMode !== undefined) set.memoryMode = patch.memoryMode;
     if (patch.memoryProjectId !== undefined) set.memoryProjectId = patch.memoryProjectId;
     if (patch.memoryThreadSource !== undefined) set.memoryThreadSource = patch.memoryThreadSource;
+    if (patch.requestContentMode !== undefined) set.requestContentMode = patch.requestContentMode;
     if (Object.keys(set).length === 0) {
       // No-op patch: still verify the key exists (fail-loud on unknown id).
       const rows = await this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).limit(1);
@@ -211,6 +214,12 @@ export class PgKeyStore implements KeyStore {
         row.memoryMode === "inject" ? "inject" : row.memoryMode === "observe" ? "observe" : "off",
       memory_project_id: row.memoryProjectId ?? null,
       memory_thread_source: row.memoryThreadSource === "auto" ? "auto" : "header",
+      request_content_mode:
+        row.requestContentMode === "none" ||
+        row.requestContentMode === "payload" ||
+        row.requestContentMode === "session"
+          ? row.requestContentMode
+          : null,
     };
   }
 }

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -320,6 +320,29 @@ describe("runPgMigrations — per-migration atomicity", () => {
     await db.$close();
   });
 
+  it("v43 adds a nullable per-key request-content override", async () => {
+    const client = new PGlite();
+    const db = Object.assign(drizzlePglite(client), { $close: () => client.close() });
+    await db.execute(
+      sql.raw("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at BIGINT NOT NULL)"),
+    );
+    await db.execute(sql.raw("CREATE TABLE api_keys (key_id TEXT PRIMARY KEY)"));
+    await db.execute(sql.raw("INSERT INTO api_keys (key_id) VALUES ('legacy')"));
+    for (let version = 1; version <= 42; version++) {
+      await db.execute(
+        sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
+      );
+    }
+
+    await expect(runPgMigrations(db)).resolves.toBeUndefined();
+
+    const row = (await db.execute(
+      sql.raw("SELECT request_content_mode FROM api_keys WHERE key_id = 'legacy'"),
+    )) as { rows: Array<{ request_content_mode: string | null }> };
+    expect(row.rows[0]?.request_content_mode).toBeNull();
+    await db.$close();
+  });
+
   it("v38 adds and backfills per-thread admin activity summaries", async () => {
     const client = new PGlite();
     const db = Object.assign(drizzlePglite(client), { $close: () => client.close() });

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1192,6 +1192,17 @@ const MIGRATIONS: readonly Migration[] = [
         ON responses_registry (created_at, response_id);
     `,
   },
+  {
+    // Per-key request-content retention override. NULL inherits the system mode.
+    version: 43,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "api_keys", ["key_id"])) {
+        await db.execute(
+          sql.raw("ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS request_content_mode TEXT"),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -65,6 +65,7 @@ export const apiKeys = pgTable("api_keys", {
   memoryMode: text("memory_mode").notNull().default("off"),
   memoryProjectId: text("memory_project_id"),
   memoryThreadSource: text("memory_thread_source").notNull().default("header"),
+  requestContentMode: text("request_content_mode"),
   createdAt: bigint("created_at", { mode: "number" }).notNull(), // epoch ms
 });
 

--- a/packages/core/src/store/sqlite/keystore.test.ts
+++ b/packages/core/src/store/sqlite/keystore.test.ts
@@ -20,6 +20,7 @@ describe("SqliteKeyStore", () => {
       allowCustomModel: true,
       blockedModels: ["gpt-4o"],
       allowFastMode: true,
+      requestContentMode: "payload",
     });
     const got = await store.getByHash("sha256_h1");
     expect(got).not.toBeNull();
@@ -33,6 +34,7 @@ describe("SqliteKeyStore", () => {
       allow_custom_model: true,
       blocked_models: ["gpt-4o"],
       allow_fast_mode: true,
+      request_content_mode: "payload",
       disabled: false,
     });
   });
@@ -170,6 +172,16 @@ describe("SqliteKeyStore", () => {
     const got = await store.getByHash("h1");
     expect(got?.rate_limit_rpm).toBeNull();
     expect(got?.rate_limit_tpm).toBeNull();
+  });
+
+  it("updates and clears the per-key request-content override", async () => {
+    const store = freshStore();
+    await store.createKey({ keyId: "k1", hash: "h1", prefix: "p1", accountId: "a", role: "user" });
+    expect((await store.getByHash("h1"))?.request_content_mode).toBeNull();
+    await store.updateKey("k1", { requestContentMode: "session" });
+    expect((await store.getByHash("h1"))?.request_content_mode).toBe("session");
+    await store.updateKey("k1", { requestContentMode: null });
+    expect((await store.getByHash("h1"))?.request_content_mode).toBeNull();
   });
 
   it("round-trips per-key rate limits set at creation (0 = explicit unlimited)", async () => {

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -51,6 +51,7 @@ export class SqliteKeyStore implements KeyStore {
       // undefined => "auto": a memory-on key derives its thread from client signals
       // out of the box (issue #97). Pass "header" explicitly to opt out.
       memoryThreadSource: input.memoryThreadSource ?? "auto",
+      requestContentMode: input.requestContentMode ?? null,
       createdAt: this.now(),
     };
     this.db.insert(apiKeys).values(row).run();
@@ -119,6 +120,7 @@ export class SqliteKeyStore implements KeyStore {
         | "memoryMode"
         | "memoryProjectId"
         | "memoryThreadSource"
+        | "requestContentMode"
       >
     > = {};
     // Rename (null clears back to unnamed). Cosmetic only.
@@ -145,6 +147,7 @@ export class SqliteKeyStore implements KeyStore {
     if (patch.memoryMode !== undefined) set.memoryMode = patch.memoryMode;
     if (patch.memoryProjectId !== undefined) set.memoryProjectId = patch.memoryProjectId;
     if (patch.memoryThreadSource !== undefined) set.memoryThreadSource = patch.memoryThreadSource;
+    if (patch.requestContentMode !== undefined) set.requestContentMode = patch.requestContentMode;
     if (Object.keys(set).length === 0) {
       // No-op patch: still verify the key exists (fail-loud on unknown id).
       const row = this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).get();
@@ -212,6 +215,12 @@ export class SqliteKeyStore implements KeyStore {
         row.memoryMode === "inject" ? "inject" : row.memoryMode === "observe" ? "observe" : "off",
       memory_project_id: row.memoryProjectId ?? null,
       memory_thread_source: row.memoryThreadSource === "auto" ? "auto" : "header",
+      request_content_mode:
+        row.requestContentMode === "none" ||
+        row.requestContentMode === "payload" ||
+        row.requestContentMode === "session"
+          ? row.requestContentMode
+          : null,
     };
   }
 }

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1239,6 +1239,18 @@ const MIGRATIONS: readonly Migration[] = [
         ON responses_registry (created_at, response_id);
     `,
   },
+  {
+    // Per-key request-content retention override. NULL inherits the system mode.
+    version: 44,
+    run: (db) => {
+      if (
+        sqliteTableHasColumns(db, "api_keys", ["key_id"]) &&
+        !sqliteTableHasColumns(db, "api_keys", ["request_content_mode"])
+      ) {
+        db.exec("ALTER TABLE api_keys ADD COLUMN request_content_mode TEXT;");
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -156,6 +156,7 @@ describe("sqlite schema + migrations", () => {
       "allow_custom_model",
       "blocked_models",
       "allow_fast_mode",
+      "request_content_mode",
       "disabled",
       "created_at",
     ]) {
@@ -262,6 +263,33 @@ describe("sqlite schema + migrations", () => {
       ).sql;
       expect(schemaSql).toContain("body_bytes INTEGER");
       expect(schemaSql).not.toContain("body_bytes INTEGER CHECK");
+      after.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("v44 adds a nullable per-key request-content override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v44-key-content-mode-"));
+    const path = join(dir, "helm.db");
+    try {
+      const seed = new Database(path);
+      seed.exec(`
+        CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);
+        CREATE TABLE api_keys (key_id TEXT PRIMARY KEY);
+        INSERT INTO api_keys (key_id) VALUES ('legacy');
+      `);
+      const record = seed.prepare("INSERT INTO _migrations (version, applied_at) VALUES (?, ?)");
+      for (let version = 1; version <= 43; version++) record.run(version, 1);
+      seed.close();
+
+      runMigrations(path);
+
+      const after = new Database(path);
+      const row = after
+        .prepare("SELECT request_content_mode FROM api_keys WHERE key_id = 'legacy'")
+        .get() as { request_content_mode: string | null };
+      expect(row.request_content_mode).toBeNull();
       after.close();
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -53,6 +53,7 @@ export const apiKeys = sqliteTable("api_keys", {
   memoryMode: text("memory_mode").notNull().default("off"),
   memoryProjectId: text("memory_project_id"),
   memoryThreadSource: text("memory_thread_source").notNull().default("header"),
+  requestContentMode: text("request_content_mode"),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
 });
 

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -209,6 +209,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         allowedLanes: ["economy", "balanced"],
         allowCustomModel: true,
         allowFastMode: true,
+        requestContentMode: "payload",
       });
       const got = await ctx.stores.keys.getByHash("sha256_h1");
       expect(got).toMatchObject<Partial<ApiKeyRecord>>({
@@ -220,6 +221,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         allowed_lanes: ["economy", "balanced"],
         allow_custom_model: true,
         allow_fast_mode: true,
+        request_content_mode: "payload",
         disabled: false,
       });
     });
@@ -411,6 +413,24 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       got = await ctx.stores.keys.getByHash("h1");
       expect(got?.concurrency_limit).toBeNull();
       expect(got?.rate_limit_rpm).toBe(9);
+    });
+
+    it("request-content mode: omitted inherits, updateKey overrides and clears", async () => {
+      ctx = await make();
+      await ctx.stores.keys.createKey({
+        keyId: "k1",
+        hash: "h1",
+        prefix: "p1",
+        accountId: "a",
+        role: "user",
+      });
+      expect((await ctx.stores.keys.getByHash("h1"))?.request_content_mode).toBeNull();
+
+      await ctx.stores.keys.updateKey("k1", { requestContentMode: "session" });
+      expect((await ctx.stores.keys.getByHash("h1"))?.request_content_mode).toBe("session");
+
+      await ctx.stores.keys.updateKey("k1", { requestContentMode: null });
+      expect((await ctx.stores.keys.getByHash("h1"))?.request_content_mode).toBeNull();
     });
 
     it("memory defaults: omitted -> off/null/auto, set at create round-trips, updateKey edits + clears", async () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -200,6 +200,8 @@ export {
   OverBudgetBehaviorSchema,
   type PortalMemorySettingsRequest,
   PortalMemorySettingsRequestSchema,
+  type RequestContentMode,
+  RequestContentModeSchema,
   type UpdateKeyRequest,
   UpdateKeyRequestSchema,
 } from "./key/schema.js";

--- a/packages/shared/src/key/schema.test.ts
+++ b/packages/shared/src/key/schema.test.ts
@@ -5,6 +5,7 @@ import {
   effectiveMemoryProjectId,
   KeyRoleSchema,
   PortalMemorySettingsRequestSchema,
+  RequestContentModeSchema,
   UpdateKeyRequestSchema,
 } from "./schema.js";
 
@@ -24,6 +25,20 @@ function fullKey() {
 }
 
 describe("ApiKeyRecordSchema", () => {
+  it("supports a nullable per-key request-content override", () => {
+    expect(RequestContentModeSchema.options).toEqual(["none", "payload", "session"]);
+    expect(ApiKeyRecordSchema.parse(fullKey()).request_content_mode).toBeNull();
+    expect(
+      CreateKeyRequestSchema.parse({ request_content_mode: "payload" }).request_content_mode,
+    ).toBe("payload");
+    expect(
+      UpdateKeyRequestSchema.parse({ request_content_mode: null }).request_content_mode,
+    ).toBeNull();
+    expect(UpdateKeyRequestSchema.safeParse({ request_content_mode: "invalid" }).success).toBe(
+      false,
+    );
+  });
+
   it("accepts a full key record (docs/06 fields)", () => {
     expect(ApiKeyRecordSchema.safeParse(fullKey()).success).toBe(true);
   });

--- a/packages/shared/src/key/schema.ts
+++ b/packages/shared/src/key/schema.ts
@@ -21,6 +21,11 @@ export const OverBudgetBehaviorSchema = z.enum(["degrade", "reject"]);
 // keys are minted with `auto` in the keystores; moot while memory is off.
 export const MemoryThreadSourceSchema = z.enum(["header", "auto"]);
 
+// Per-key request/response body retention override. null on the key record means
+// inherit the live system setting; an explicit value selects one of the same
+// three modes exposed by Admin System Settings.
+export const RequestContentModeSchema = z.enum(["none", "payload", "session"]);
+
 // Human-readable key label (docs/06) — cosmetic only, never an auth/routing input.
 // `.trim()` runs BEFORE the length checks, so a whitespace-only label collapses to
 // "" and fails min(1) (fail-closed, Principle 2) instead of masquerading as a real
@@ -95,11 +100,13 @@ export const ApiKeyRecordSchema = z.object({
   // are minted with `auto` in the keystores, so a memory-on key derives its thread
   // out of the box; existing keys keep their stored value.
   memory_thread_source: MemoryThreadSourceSchema.default("header"),
+  request_content_mode: RequestContentModeSchema.nullable().default(null),
 });
 
 export type KeyRole = z.infer<typeof KeyRoleSchema>;
 export type OverBudgetBehavior = z.infer<typeof OverBudgetBehaviorSchema>;
 export type MemoryThreadSource = z.infer<typeof MemoryThreadSourceSchema>;
+export type RequestContentMode = z.infer<typeof RequestContentModeSchema>;
 export type ApiKeyRecord = z.infer<typeof ApiKeyRecordSchema>;
 
 // A key's EFFECTIVE memory project scope. `memory_project_id` is the explicit
@@ -150,6 +157,7 @@ export const CreateKeyRequestSchema = z
     memory_mode: MemoryModeSchema.optional(),
     memory_project_id: z.string().min(1).optional(),
     memory_thread_source: MemoryThreadSourceSchema.optional(),
+    request_content_mode: RequestContentModeSchema.optional(),
   })
   .strict();
 
@@ -193,6 +201,8 @@ export const UpdateKeyRequestSchema = z
     memory_mode: MemoryModeSchema.optional(),
     memory_project_id: z.string().min(1).nullable().optional(),
     memory_thread_source: MemoryThreadSourceSchema.optional(),
+    // null clears the override and resumes inheriting the live system setting.
+    request_content_mode: RequestContentModeSchema.nullable().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- add an optional per-API-key request content storage mode that inherits the global setting when unset
- apply the effective mode across Chat, Messages, Responses, Gemini, Images, Interactions, and Admin Replay
- expose create, edit, clear, and effective-state readback in Admin
- add SQLite/PostgreSQL migrations and locale coverage

## Modes
- inherit global (`null`)
- metadata only (`none`)
- full request payload (`payload`)
- incremental session transcript (`session`)

Global payload retention remains authoritative.

## Verification
- 837 focused Vitest tests passed
- focused Playwright Admin/API override and clear-to-inherit flow passed
- `CI=true pnpm typecheck`
- `CI=true pnpm lint` (37 existing `ci-workflow.test.ts` warnings)
- `CI=true pnpm build`
- `git diff --check`
