### PR TITLE
[codex] Bound Session storage and runtime memory pressure

### DIFF
--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -223,7 +223,7 @@ test.describe("admin system settings", () => {
 });
 
 test.describe("per-key request-content storage", () => {
-  test("a key override wins over the system mode and clearing it restores inheritance", async () => {
+  test("global metadata-only remains a hard-off over key overrides", async () => {
     const admin = await playwrightRequest.newContext({
       baseURL: BASE,
       extraHTTPHeaders: { Authorization: basicHeader(ADMIN_USER, ADMIN_PASSWORD) },
@@ -276,7 +276,7 @@ test.describe("per-key request-content storage", () => {
         })
         .toBeGreaterThanOrEqual(1);
       const captured = await admin.get(`/admin/api/requests/${requestIds[0]}/payload?part=meta`);
-      expect(await captured.json()).toMatchObject({ captured: true, source: "payload" });
+      expect(await captured.json()).toMatchObject({ captured: false });
 
       const cleared = await admin.patch(`/admin/api/keys/${keyId}`, {
         data: { request_content_mode: null },

--- a/apps/gateway/src/app.test.ts
+++ b/apps/gateway/src/app.test.ts
@@ -168,6 +168,25 @@ describe("createApp: trace_id, logging, error handling", () => {
     expect(JSON.stringify(lines)).not.toContain("payload");
   });
 
+  it("logs capacity rejection separately from database maintenance", async () => {
+    const { logger, lines } = fakeLogger();
+    const c = mockCtx(logger, "trace-capacity");
+    const res = handleError(
+      new RequestAdmissionError(503, "server_overloaded", "capacity exhausted", {
+        cause: "capacity",
+        wireBytes: 12,
+        requestedChargeBytes: 72,
+        activeReservedBytes: 144,
+        pendingBytes: 24,
+      }),
+      c,
+    );
+
+    expect(res.status).toBe(503);
+    expect(lines.find((line) => line.message === "request.capacity_rejected")).toBeDefined();
+    expect(lines.find((line) => line.message === "request.maintenance_rejected")).toBeUndefined();
+  });
+
   it("marks the request context as timed out while late route work continues", async () => {
     const { logger } = fakeLogger();
     const app = createApp({

--- a/apps/gateway/src/middleware/error-handler.ts
+++ b/apps/gateway/src/middleware/error-handler.ts
@@ -65,20 +65,26 @@ export function handleError(err: unknown, c: Context<AppEnv>): Response {
 
   if (err instanceof RequestAdmissionError) {
     c.header("retry-after", "1");
-    logger.log("warn", "request.maintenance_rejected", {
-      trace_id: traceId,
-      http_status: err.status,
-      code: err.code,
-      ...(err.admission === undefined
-        ? {}
-        : {
-            admission_reason: err.admission.cause,
-            wire_bytes: err.admission.wireBytes,
-            requested_charge_bytes: err.admission.requestedChargeBytes,
-            active_reserved_bytes: err.admission.activeReservedBytes,
-            pending_bytes: err.admission.pendingBytes,
-          }),
-    });
+    logger.log(
+      "warn",
+      err.admission?.cause === "capacity"
+        ? "request.capacity_rejected"
+        : "request.maintenance_rejected",
+      {
+        trace_id: traceId,
+        http_status: err.status,
+        code: err.code,
+        ...(err.admission === undefined
+          ? {}
+          : {
+              admission_reason: err.admission.cause,
+              wire_bytes: err.admission.wireBytes,
+              requested_charge_bytes: err.admission.requestedChargeBytes,
+              active_reserved_bytes: err.admission.activeReservedBytes,
+              pending_bytes: err.admission.pendingBytes,
+            }),
+      },
+    );
     return c.json(
       {
         error: {

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -6,7 +6,7 @@ import type {
   SessionRevisionRecord,
   TelemetryStore,
 } from "@helm/core";
-import { DEFAULT_LANES, parseLanesConfig } from "@helm/core";
+import { createResponseWorkAdmission, DEFAULT_LANES, parseLanesConfig } from "@helm/core";
 import type { ApiKeyRecord, ClassifierConfig, DecisionRecord, RuntimeSettings } from "@helm/shared";
 import { ClassifierConfigSchema, RuntimeSettingsSchema } from "@helm/shared";
 import { Hono } from "hono";
@@ -328,6 +328,11 @@ function buildDeps(over: Partial<AdminApiDeps> = {}): AdminApiDeps {
     rules,
     keyStore,
     telemetry: makeTelemetry(),
+    responseWorkAdmission: createResponseWorkAdmission({
+      capacityBytes: 1_200_000,
+      jsonAmplification: 6,
+      minChargeBytes: 1,
+    }),
     genKey: () => ({
       plaintext: "helm_live_PLAINTEXT_SECRET",
       hash: "hash_of_plaintext_full",
@@ -1722,6 +1727,13 @@ describe("admin.api request payload", () => {
     const telemetry = {
       ...makeTelemetry([rec]),
       getPayload: async () => null,
+      getSessionRevisionMeta: async () => ({
+        requestId: "req_session",
+        sessionRef: "session-ref",
+        responseBodyStored: true,
+        fidelity: "semantic",
+        createdAt: new Date(1234),
+      }),
       listSessionRevisionsPage: async () => ({
         revisions: [
           {
@@ -1780,6 +1792,40 @@ describe("admin.api request payload", () => {
       captured: false,
       source: "unavailable",
       reason: "response_unavailable",
+    });
+  });
+
+  it("returns Session metadata without reading or decoding any Session body", async () => {
+    const rec = {
+      ...decision("req_session_meta", "balanced"),
+      session: { ref: "session-ref", label: "thread-1", source: "x-thread-id" as const },
+    };
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayloadMeta: async () => null,
+      getSessionRevisionMeta: async () => ({
+        requestId: "req_session_meta",
+        sessionRef: "session-ref",
+        responseBodyStored: true,
+        fidelity: "semantic",
+        createdAt: new Date(1234),
+      }),
+      listSessionRevisionsPage: async () => {
+        throw new Error("Session body must not be read for part=meta");
+      },
+    } as unknown as TelemetryStore;
+
+    const response = await buildApp(buildDeps({ telemetry })).request(
+      "/admin/api/requests/req_session_meta/payload?part=meta",
+    );
+
+    expect(await response.json()).toEqual({
+      captured: true,
+      source: "session",
+      exact: false,
+      fidelity: "semantic",
+      created_at: 1234,
+      parts: { request: true, response: true, upstream_request: false },
     });
   });
 

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -8,6 +8,7 @@ import type {
   OAuthSelectionStrategy,
   OAuthUsageStore,
   PoliciesConfig,
+  ResponseWorkAdmission,
   RouteOptions,
   StoredCleanupReport,
   TelemetryStore,
@@ -438,6 +439,7 @@ export interface AdminApiDeps {
   rules: RuleStore;
   keyStore: KeyStore;
   telemetry: TelemetryStore;
+  responseWorkAdmission?: ResponseWorkAdmission;
   runInBackground?: (task: () => Promise<unknown>, onError?: (error: unknown) => void) => boolean;
   // Automatic data cleanup / retention / archival (admin "Data cleanup"). Optional —
   // absent in unit tests; the cleanup routes 503 when not wired.

--- a/apps/gateway/src/routes/admin/replay.test.ts
+++ b/apps/gateway/src/routes/admin/replay.test.ts
@@ -444,7 +444,7 @@ describe("runReplay", () => {
     expect(rec.inserts).toHaveLength(1);
   });
 
-  it("per-key payload mode overrides disabled system capture for replay", async () => {
+  it("global metadata-only mode remains off for replay despite a per-key override", async () => {
     const rec = emptyRec();
     const route: ReplayWiring["route"] = async (req) => ({
       decision: decision(req.request_id),
@@ -462,7 +462,7 @@ describe("runReplay", () => {
       { originalTraceId: "orig", body: okBody, signal: new AbortController().signal, log: noop },
     );
 
-    expect(rec.payloads).toHaveLength(1);
+    expect(rec.payloads).toHaveLength(0);
   });
 
   it("persists the partial stream + telemetry when the stream throws mid-drain", async () => {

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -140,6 +140,21 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
     if (part === "meta") {
       const meta = await getPayloadMeta(deps, traceId);
       if (!meta) {
+        const sessionMeta = await deps.telemetry.getSessionRevisionMeta?.(traceId);
+        if (sessionMeta) {
+          return c.json({
+            captured: true,
+            source: "session",
+            exact: false,
+            fidelity: sessionMeta.fidelity,
+            created_at: sessionMeta.createdAt.getTime(),
+            parts: {
+              request: true,
+              response: sessionMeta.responseBodyStored,
+              upstream_request: false,
+            },
+          });
+        }
         const recovered = await getSessionRequest(deps, traceId);
         if (recovered.status === "unavailable")
           return c.json({ captured: false, source: "unavailable", reason: recovered.reason });
@@ -277,7 +292,7 @@ async function getSessionRequest(
   if (!sessionRef) return { status: "unavailable", reason: "no_session" };
   if (!listPage) return { status: "unavailable", reason: "session_unavailable" };
   const budget = runtimeMemoryBudget();
-  const responseAdmission = runtimeResponseWorkAdmission();
+  const responseAdmission = deps.responseWorkAdmission ?? runtimeResponseWorkAdmission();
   // ponytail: half a response-work window lets inspection coexist with live API
   // traffic; add metadata-first admission if larger concurrent restores are needed.
   const recoveryMaxWireBytes = Math.max(

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -1290,7 +1290,7 @@ describe("POST /v1/chat/completions — payload capture + streamed cost", () => 
     expect(cap.payloads[0]?.responseJson).toBe(JSON.stringify(upstream));
   });
 
-  it("lets a key enable full payload capture over a global metadata-only mode", async () => {
+  it("keeps global metadata-only mode off despite a per-key payload override", async () => {
     const cap = captureTelemetry();
     const { deps: d, harness } = deps({
       telemetry: cap.telemetry,
@@ -1306,7 +1306,7 @@ describe("POST /v1/chat/completions — payload capture + streamed cost", () => 
       headers: AUTH,
       body: JSON.stringify(NONSTREAM_BODY),
     });
-    expect(cap.payloads).toHaveLength(1);
+    expect(cap.payloads).toHaveLength(0);
   });
 
   it("lets a key disable full payload capture over a global payload mode", async () => {

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -121,6 +121,7 @@ export interface ChatRouteDeps {
    *  and streamed completion-cost backfill (#6). */
   capturePayloads?: PayloadCaptureDeps["capturePayloads"];
   captureSessions?: PayloadCaptureDeps["captureSessions"];
+  captureGeneration?: PayloadCaptureDeps["captureGeneration"];
   costOf?: PayloadCaptureDeps["costOf"];
   /** When true, honor the e2e-only `x-helm-eval` / `x-helm-rules-threshold`
    *  headers to toggle Layer-2 eval and raise the Layer-1 gate per request.

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -624,7 +624,7 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     expect(insertPayload).not.toHaveBeenCalled();
   });
 
-  it("per-key payload mode overrides the disabled system setting", async () => {
+  it("global metadata-only mode remains off despite a per-key payload override", async () => {
     const { record, insertPayload } = makeRecord({ capturePayloads: false });
     const { deps } = makeDeps({
       record,
@@ -637,7 +637,7 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(insertPayload).toHaveBeenCalledOnce();
+    expect(insertPayload).not.toHaveBeenCalled();
   });
 
   // ── Terminal stream error frame must be appended to the captured body (review

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -866,7 +866,7 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     expect(insertPayload).not.toHaveBeenCalled();
   });
 
-  it("per-key payload mode overrides the disabled system setting", async () => {
+  it("global metadata-only mode remains off despite a per-key payload override", async () => {
     const { record, insertPayload } = makeRecord({ capturePayloads: false });
     const { deps } = makeDeps({
       record,
@@ -879,7 +879,7 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(insertPayload).toHaveBeenCalledOnce();
+    expect(insertPayload).not.toHaveBeenCalled();
   });
 
   // ── Native protocol passthrough (#217 C3). When the pipeline reports

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -1,4 +1,9 @@
-import type { DecisionRecord, InsertPayloadInput, UpsertSessionRevisionInput } from "@helm/core";
+import {
+  type DecisionRecord,
+  type InsertPayloadInput,
+  splitSessionRequestJson,
+  type UpsertSessionRevisionInput,
+} from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import type { WriteQueue } from "../runtime/write-queue.js";
 import { createWriteQueue } from "../runtime/write-queue.js";
@@ -6,7 +11,6 @@ import {
   backfillCompletionCost,
   capturedResponsesResponse,
   createResponsesDeltaAccumulator,
-  createSessionHeadCache,
   createSseCapture,
   createStreamGenerationTimer,
   decisionForTimedOutRequest,
@@ -46,33 +50,22 @@ describe("per-key request content mode", () => {
     expect(scoped.capturePayloads?.()).toBe(payloads);
     expect(scoped.captureSessions?.()).toBe(sessions);
   });
-});
 
-describe("session head cache", () => {
-  it("evicts by retained UTF-8 bytes, not only by Session count", () => {
-    const cache = createSessionHeadCache(1_000, 20);
-    cache.set("one", { requestId: "r1", requestJson: "123456789012345" });
-    cache.set("two", { requestId: "r2", requestJson: "abcdefghijklmno" });
-    expect(cache.get("one")).toBeUndefined();
-    expect(cache.get("two")?.requestId).toBe("r2");
-    expect(cache.retainedBytes).toBeLessThanOrEqual(20);
-  });
+  it("keeps global metadata-only as a live hard-off over every key override", () => {
+    let globallyEnabled = true;
+    const scoped = withRequestContentMode(
+      {
+        telemetry: {} as PayloadCaptureDeps["telemetry"],
+        capturePayloads: () => false,
+        captureSessions: () => globallyEnabled,
+      },
+      "payload",
+    );
 
-  it("tracks replacement bytes, touches LRU order, and resets on clear", () => {
-    const cache = createSessionHeadCache(10, 20);
-    cache.set("one", { requestId: "r1", requestJson: "11111111" });
-    cache.set("two", { requestId: "r2", requestJson: "22222222" });
-    expect(cache.retainedBytes).toBe(16);
-    expect(cache.get("one")?.requestId).toBe("r1");
-    cache.set("three", { requestId: "r3", requestJson: "33333333" });
-    expect(cache.get("two")).toBeUndefined();
-    cache.set("one", { requestId: "r1-new", requestJson: "1" });
-    expect(cache.retainedBytes).toBe(9);
-    expect(cache.get("one")?.requestId).toBe("r1-new");
-    cache.clear();
-    expect(cache.retainedBytes).toBe(0);
-    expect(cache.get("one")).toBeUndefined();
-    expect(cache.get("three")).toBeUndefined();
+    expect(scoped.capturePayloads?.()).toBe(true);
+    globallyEnabled = false;
+    expect(scoped.capturePayloads?.()).toBe(false);
+    expect(scoped.captureSessions?.()).toBe(false);
   });
 });
 
@@ -109,47 +102,83 @@ describe("Session queue admission", () => {
     expect(log).toHaveBeenCalledWith("session.capture_limited");
   });
 
-  it("bounds saturated Session metadata by the dynamic cache capacity", async () => {
+  it("drops a queued Session body after metadata-only is enabled", async () => {
+    let task: (() => Promise<void>) | undefined;
+    const writes = {
+      enqueueSession: vi.fn(async (queued: () => Promise<void>) => {
+        task = queued;
+      }),
+    } as unknown as WriteQueue;
+    const upsertSessionRevision = vi.fn();
+    let capture = true;
+    let generation = 0;
+
+    await queueOrPersistSessionRequest(
+      {
+        telemetry: { upsertSessionRevision } as unknown as PayloadCaptureDeps["telemetry"],
+        writes,
+        captureSessions: () => capture,
+        captureGeneration: () => generation,
+      },
+      {
+        requestId: "request-disabled-before-flush",
+        accountId: "account-1",
+        apiKeyId: "key-1",
+        decision: {
+          session: { ref: "session-1", label: "thread-1", source: "x-session-key" },
+        } as unknown as DecisionRecord,
+        requestJson: '{"input":"hello"}',
+        responseId: null,
+        responseJson: null,
+        now: 1,
+      },
+      vi.fn(),
+    );
+
+    capture = false;
+    generation++;
+    await task?.();
+    expect(upsertSessionRevision).not.toHaveBeenCalled();
+  });
+
+  it("uses the persisted head hash instead of retaining the previous request JSON", async () => {
+    const first = splitSessionRequestJson('{"messages":["one"]}');
+    const upsertSessionRevision = vi.fn();
     const telemetry = {
       getSessionByRef: vi.fn(async () => ({
-        revisionCount: Number.MAX_SAFE_INTEGER,
-        storedBytes: 0,
+        headRequestId: "r1",
+        revisionCount: 1,
+        storedBytes: 10,
+        eventHead: {
+          requestId: "r1",
+          eventKey: first.eventKey,
+          eventCount: first.eventCount,
+          eventHash: first.eventHash,
+        },
       })),
-      upsertSessionRevision: vi.fn(),
+      upsertSessionRevision,
     } as unknown as PayloadCaptureDeps["telemetry"];
-    const deps = {
-      telemetry,
-      captureSessions: () => true,
-      captureBodyLimitBytes: 1_024,
-      sessionCacheBytes: 2_048,
-    } satisfies PayloadCaptureDeps;
-    const args = (sessionRef: string) => ({
-      requestId: `request-${sessionRef}`,
-      accountId: "account-1",
-      apiKeyId: "key-1",
-      decision: {
-        session: { ref: sessionRef, label: sessionRef, source: "x-session-key" },
-      } as unknown as DecisionRecord,
-      requestJson: '{"input":"hello"}',
-      responseId: null,
-      responseJson: null,
-      now: 1,
-    });
 
-    for (const sessionRef of ["session-one", "session-two", "session-three"]) {
-      await persistSessionRequest(deps, args(sessionRef), vi.fn());
-    }
+    await persistSessionRequest(
+      { telemetry, captureSessions: () => true },
+      {
+        requestId: "r2",
+        accountId: "account-1",
+        apiKeyId: "key-1",
+        decision: {
+          session: { ref: "session-1", label: "thread-1", source: "x-session-key" },
+        } as unknown as DecisionRecord,
+        requestJson: '{"messages":["one","two"]}',
+        responseId: null,
+        responseJson: null,
+        now: 2,
+      },
+      vi.fn(),
+    );
 
-    const enqueueSession = vi.fn();
-    const queuedDeps = {
-      ...deps,
-      writes: { enqueueSession } as unknown as WriteQueue,
-    };
-    await queueOrPersistSessionRequest(queuedDeps, args("session-one"), vi.fn());
-    await queueOrPersistSessionRequest(queuedDeps, args("session-three"), vi.fn());
-
-    expect(enqueueSession).toHaveBeenCalledTimes(1);
-    expect(enqueueSession).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
+    expect(upsertSessionRevision).toHaveBeenCalledWith(
+      expect.objectContaining({ retainCount: 1, requestDeltaJson: '["two"]' }),
+    );
   });
 
   it("keeps appending after a Session exceeds the former 64 MiB aggregate cap", async () => {
@@ -1437,6 +1466,30 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     expect(s.payloads[0]?.requestId).toBe("req_1");
   });
 
+  it("drops queued body capture after a live hard-off while retaining telemetry", async () => {
+    const s = sink();
+    const q = createWriteQueue({ telemetry: s.telemetry, log: () => {}, flushIntervalMs: 10_000 });
+    let capture = true;
+    let generation = 0;
+    const d = {
+      telemetry: s.telemetry,
+      writes: q,
+      redact: (x: unknown) => x,
+      now: () => 5000,
+      capturePayloads: () => capture,
+      captureSessions: () => false,
+      captureGeneration: () => generation,
+    } as RecordServedDeps & { captureGeneration: () => number };
+
+    await recordServed(d, args, () => {});
+    capture = false;
+    generation++;
+    await q.flush();
+
+    expect(s.inserted).toHaveLength(1);
+    expect(s.payloads).toHaveLength(0);
+  });
+
   it("writes inline (today's behavior) when no queue is wired", async () => {
     const s = sink();
     const d: RecordServedDeps = {
@@ -1625,13 +1678,12 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
           sequence: sequence + 1,
         })),
       ),
-      getSessionRevisionByResponseId: vi.fn(async (_sessionRef: string, responseId: string) => {
+      findSessionRequestIdByResponseId: vi.fn(async (_sessionRef: string, responseId: string) => {
         const revision = revisions.find((item) => item.responseId === responseId);
         if (!revision) return null;
         return {
-          ...revision,
-          responseId: revision.responseId ?? null,
-          sequence: revisions.indexOf(revision) + 1,
+          requestId: revision.requestId,
+          responseBodyStored: revision.responseJson !== null,
         };
       }),
       upsertSessionRevision: vi.fn(async (input: UpsertSessionRevisionInput) => {
@@ -1723,7 +1775,7 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
         storedBytes: 1,
       })),
       listSessionRevisions: vi.fn(async () => []),
-      getSessionRevisionByResponseId: vi.fn(async () => null),
+      findSessionRequestIdByResponseId: vi.fn(async () => null),
       upsertSessionRevision: vi.fn(async (input: UpsertSessionRevisionInput) => {
         revisions.push(input);
       }),
@@ -1768,7 +1820,7 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
       insert,
       getSessionByRef: vi.fn(async () => null),
       listSessionRevisions: vi.fn(async () => []),
-      getSessionRevisionByResponseId: vi.fn(async () => null),
+      findSessionRequestIdByResponseId: vi.fn(async () => null),
       upsertSessionRevision,
     } as unknown as RecordServedDeps["telemetry"];
     const writes = createWriteQueue({

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -28,10 +28,11 @@ export interface PayloadCaptureDeps {
   capturePayloads?: () => boolean;
   /** Live getter for the incremental per-session request transcript setting. */
   captureSessions?: () => boolean;
+  /** Monotonic generation for live capture-mode changes. Deferred body writes
+   * from an older generation are discarded while telemetry still lands. */
+  captureGeneration?: () => number;
   /** Optional test/embedding override. Production derives this from the V8 heap. */
   captureBodyLimitBytes?: number;
-  /** Optional test/embedding override. Production derives this from the V8 heap. */
-  sessionCacheBytes?: number;
   /** Resolve the served attempt's USD cost from the trailing usage chunk: an
    *  upstream-BILLED cost in it (`cost_usd` / OpenRouter `cost`) OVERRIDES the
    *  catalog estimate, else tokens × `alias`'s pricing; null when neither is
@@ -45,10 +46,12 @@ export function withRequestContentMode<T extends PayloadCaptureDeps>(
   mode: RequestContentMode | null | undefined,
 ): T {
   if (mode == null) return deps;
+  const globallyEnabled = () =>
+    deps.capturePayloads?.() === true || deps.captureSessions?.() === true;
   return {
     ...deps,
-    capturePayloads: () => mode === "payload",
-    captureSessions: () => mode === "session",
+    capturePayloads: () => globallyEnabled() && mode === "payload",
+    captureSessions: () => globallyEnabled() && mode === "session",
   };
 }
 
@@ -364,82 +367,12 @@ export function capturedResponsesResponse(
   return { responseId: null, responseJson: null };
 }
 
-function hasResponsesOutput(raw: string | null | undefined): boolean {
-  if (!raw) return false;
-  try {
-    const value = JSON.parse(raw) as unknown;
-    return (
-      value !== null &&
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      Array.isArray((value as Record<string, unknown>).output)
-    );
-  } catch {
-    return false;
-  }
-}
-
 const defaultMemoryBudget = runtimeMemoryBudget();
 
 function captureBodyLimitBytes(deps: PayloadCaptureDeps): number {
   return deps.captureBodyLimitBytes ?? defaultMemoryBudget.responseCaptureBytes;
 }
 
-function sessionCacheBytes(deps: PayloadCaptureDeps): number {
-  return deps.sessionCacheBytes ?? defaultMemoryBudget.sessionCacheBytes;
-}
-
-export interface SessionHeadCache {
-  get(sessionRef: string): { requestId: string; requestJson: string } | undefined;
-  set(sessionRef: string, head: { requestId: string; requestJson: string }): void;
-  clear(): void;
-  readonly retainedBytes: number;
-}
-
-export function createSessionHeadCache(
-  maxEntries = Math.max(1, Math.floor(defaultMemoryBudget.sessionCacheBytes / 1024)),
-  maxBytes = defaultMemoryBudget.sessionCacheBytes,
-): SessionHeadCache {
-  const entries = new Map<
-    string,
-    { requestId: string; requestJson: string; retainedBytes: number }
-  >();
-  let retainedBytes = 0;
-  return {
-    get(sessionRef) {
-      const value = entries.get(sessionRef);
-      if (!value) return undefined;
-      entries.delete(sessionRef);
-      entries.set(sessionRef, value);
-      return { requestId: value.requestId, requestJson: value.requestJson };
-    },
-    set(sessionRef, head) {
-      const previous = entries.get(sessionRef);
-      if (previous) retainedBytes -= previous.retainedBytes;
-      entries.delete(sessionRef);
-      const bytes = Buffer.byteLength(head.requestJson, "utf8");
-      entries.set(sessionRef, { ...head, retainedBytes: bytes });
-      retainedBytes += bytes;
-      while (entries.size > maxEntries || retainedBytes > maxBytes) {
-        const oldest = entries.entries().next().value as
-          | [string, { retainedBytes: number }]
-          | undefined;
-        if (!oldest) break;
-        entries.delete(oldest[0]);
-        retainedBytes -= oldest[1].retainedBytes;
-      }
-    },
-    clear() {
-      entries.clear();
-      retainedBytes = 0;
-    },
-    get retainedBytes() {
-      return retainedBytes;
-    },
-  };
-}
-
-const sessionHeadCaches = new WeakMap<TelemetryStore, SessionHeadCache>();
 const saturatedSessionRefs = new WeakMap<TelemetryStore, Set<string>>();
 
 function saturatedSessions(store: TelemetryStore): Set<string> {
@@ -462,25 +395,7 @@ function markSaturatedSession(store: TelemetryStore, sessionRef: string, maxByte
   }
 }
 
-function sessionHeadCache(store: TelemetryStore, maxBytes: number): SessionHeadCache {
-  const existing = sessionHeadCaches.get(store);
-  if (existing) return existing;
-  const created = createSessionHeadCache(Math.max(1, Math.floor(maxBytes / 1024)), maxBytes);
-  sessionHeadCaches.set(store, created);
-  return created;
-}
-
-function cacheSessionHead(
-  store: TelemetryStore,
-  sessionRef: string,
-  head: { requestId: string; requestJson: string },
-  maxBytes: number,
-): void {
-  sessionHeadCache(store, maxBytes).set(sessionRef, head);
-}
-
 export function clearSessionCaptureCache(store: TelemetryStore): void {
-  sessionHeadCaches.delete(store);
   saturatedSessionRefs.delete(store);
 }
 
@@ -500,7 +415,7 @@ export async function persistSessionRequest(
 ): Promise<void> {
   const session = args.decision.session;
   const get = deps.telemetry.getSessionByRef;
-  const getByResponseId = deps.telemetry.getSessionRevisionByResponseId;
+  const getByResponseId = deps.telemetry.findSessionRequestIdByResponseId;
   const upsert = deps.telemetry.upsertSessionRevision;
   if (!sessionCaptureEnabled(deps)) {
     clearSessionCaptureCache(deps.telemetry);
@@ -514,38 +429,33 @@ export async function persistSessionRequest(
     }
     const head = await get.call(deps.telemetry, session.ref);
     if (head && head.revisionCount >= PERSISTED_SESSION_MAX_REVISIONS) {
-      markSaturatedSession(deps.telemetry, session.ref, sessionCacheBytes(deps));
+      markSaturatedSession(deps.telemetry, session.ref, defaultMemoryBudget.sessionCacheBytes);
       log("session.capture_limited");
       return;
     }
-    const currentBase = splitSessionRequestJson(args.requestJson);
+    const currentBase = splitSessionRequestJson(
+      args.requestJson,
+      head?.eventHead && head.eventHead.requestId === head.headRequestId
+        ? {
+            eventKey: head.eventHead.eventKey,
+            eventCount: head.eventHead.eventCount,
+            eventHash: head.eventHead.eventHash,
+          }
+        : undefined,
+    );
     const previousResponseId = currentBase.previousResponseId;
     let parentRequestId: string | null = null;
-    let previousEvents: string | undefined;
     let fidelity: "semantic" | "partial" = "semantic";
     if (previousResponseId !== null) {
       const parent = getByResponseId
         ? await getByResponseId.call(deps.telemetry, session.ref, previousResponseId)
         : null;
       parentRequestId = parent?.requestId ?? null;
-      if (!hasResponsesOutput(parent?.responseJson)) fidelity = "partial";
+      if (parent?.responseBodyStored !== true) fidelity = "partial";
     } else {
       parentRequestId = head?.headRequestId ?? null;
-      const cached = sessionHeadCache(deps.telemetry, sessionCacheBytes(deps)).get(session.ref);
-      const parentRequest =
-        parentRequestId === null
-          ? null
-          : cached?.requestId === parentRequestId
-            ? cached.requestJson
-            : null;
-      const parentDelta = parentRequest ? splitSessionRequestJson(parentRequest) : null;
-      previousEvents =
-        parentDelta?.eventKey === currentBase.eventKey ? parentDelta.eventsJson : undefined;
     }
-    const delta =
-      previousEvents === undefined
-        ? currentBase
-        : splitSessionRequestJson(args.requestJson, previousEvents);
+    const delta = currentBase;
     await upsert.call(deps.telemetry, {
       sessionRef: session.ref,
       accountId: args.accountId,
@@ -561,19 +471,15 @@ export async function persistSessionRequest(
       responseJson: args.responseJson,
       fidelity: fidelity === "partial" ? fidelity : delta.fidelity,
       createdAt: new Date(args.now),
+      eventHead: {
+        eventKey: delta.eventKey,
+        eventCount: delta.eventCount,
+        eventHash: delta.eventHash,
+      },
     });
     if ((head?.revisionCount ?? 0) + 1 >= PERSISTED_SESSION_MAX_REVISIONS) {
-      markSaturatedSession(deps.telemetry, session.ref, sessionCacheBytes(deps));
+      markSaturatedSession(deps.telemetry, session.ref, defaultMemoryBudget.sessionCacheBytes);
     }
-    cacheSessionHead(
-      deps.telemetry,
-      session.ref,
-      {
-        requestId: args.requestId,
-        requestJson: args.requestJson,
-      },
-      sessionCacheBytes(deps),
-    );
   } catch {
     log("session.capture_failed");
   }
@@ -601,8 +507,16 @@ export async function queueOrPersistSessionRequest(
   if (args.responseJson !== null && responseJson === null) log("session.response_limited");
   const boundedArgs = responseJson === args.responseJson ? args : { ...args, responseJson };
   if (deps.writes && sessionCaptureEnabled(deps) && args.decision.session?.label) {
+    const generation = deps.captureGeneration?.();
     await deps.writes.enqueueSession(
-      () => persistSessionRequest(deps, boundedArgs, log),
+      () => {
+        if (
+          generation !== undefined &&
+          (deps.captureGeneration?.() !== generation || !sessionCaptureEnabled(deps))
+        )
+          return Promise.resolve();
+        return persistSessionRequest(deps, boundedArgs, log);
+      },
       Buffer.byteLength(args.requestJson, "utf8") +
         (responseJson === null ? 0 : Buffer.byteLength(responseJson, "utf8")),
     );
@@ -846,13 +760,19 @@ export async function recordServed(
     });
     await queueOrPersistSessionRequest(deps, sessionArgs, log);
     if (captureEnabled(deps)) {
-      await w.enqueuePayload({
-        requestId: args.requestId,
-        requestJson: args.requestJson,
-        responseJson,
-        upstreamRequestJson: args.upstreamRequestJson ?? null,
-        createdAt: new Date(deps.now()),
-      });
+      const generation = deps.captureGeneration?.();
+      await w.enqueuePayload(
+        {
+          requestId: args.requestId,
+          requestJson: args.requestJson,
+          responseJson,
+          upstreamRequestJson: args.upstreamRequestJson ?? null,
+          createdAt: new Date(deps.now()),
+        },
+        generation === undefined
+          ? undefined
+          : () => deps.captureGeneration?.() === generation && captureEnabled(deps),
+      );
       // Retention is NOT pruned on the request path — the scheduled cleanup runner
       // owns payload retention (archive-first), governed by the cleanup settings.
     }

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -900,7 +900,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
   });
 
-  it("/compact honors a per-key payload override when system capture is off", async () => {
+  it("/compact keeps global metadata-only mode off despite a per-key payload override", async () => {
     const { record, insertPayload } = makeRecord({ capturePayloads: false });
     const compact = vi.fn().mockResolvedValue({ id: "resp_compact", output: [] });
     const { deps } = makeDeps({
@@ -916,7 +916,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(insertPayload).toHaveBeenCalledOnce();
+    expect(insertPayload).not.toHaveBeenCalled();
   });
 
   it("/compact rejects an exhausted per-key usage budget before subscription dispatch", async () => {
@@ -2326,7 +2326,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       insertPayload,
       getSessionByRef: vi.fn(async () => null),
       listSessionRevisions: vi.fn(async () => []),
-      getSessionRevisionByResponseId: vi.fn(async () => null),
+      findSessionRequestIdByResponseId: vi.fn(async () => null),
       upsertSessionRevision,
     } as unknown as TelemetryStore;
     const record: RecordServedDeps = {
@@ -2398,7 +2398,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       telemetry: {
         insert: vi.fn().mockResolvedValue({ id: "1" }),
         getSessionByRef: vi.fn(async () => null),
-        getSessionRevisionByResponseId: vi.fn(async () => null),
+        findSessionRequestIdByResponseId: vi.fn(async () => null),
         upsertSessionRevision,
       } as unknown as TelemetryStore,
       redact: (value) => value,

--- a/apps/gateway/src/runtime/memory-admission.test.ts
+++ b/apps/gateway/src/runtime/memory-admission.test.ts
@@ -1,7 +1,99 @@
+import { createResponseWorkAdmission, createRuntimeMemoryCoordinator } from "@helm/core";
 import { describe, expect, it } from "vitest";
 import { createBodyMemoryAdmission, readAdmittedRequestBody } from "./memory-admission.js";
 
 describe("body memory admission (unlimited body size and aggregate capacity)", () => {
+  it("shares one live capacity across HTTP, websocket ingress, and response work", () => {
+    const coordinator = createRuntimeMemoryCoordinator({ capacityBytes: () => 100 });
+    const http = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      jsonAmplification: 1,
+      minRequestChargeBytes: 1,
+      coordinator,
+    });
+    const websocket = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      jsonAmplification: 1,
+      minRequestChargeBytes: 1,
+      coordinator,
+    });
+    const response = createResponseWorkAdmission({
+      capacityBytes: 100,
+      jsonAmplification: 1,
+      minChargeBytes: 1,
+      coordinator,
+    });
+
+    const httpLease = http.acquire(60);
+    const websocketLease = websocket.acquire(30);
+    expect(httpLease.ok).toBe(true);
+    expect(websocketLease.ok).toBe(true);
+    expect(response.acquire(20)).toMatchObject({ ok: false, reason: "busy" });
+    if (httpLease.ok) httpLease.lease.release();
+    const responseLease = response.acquire(20);
+    expect(responseLease.ok).toBe(true);
+    if (responseLease.ok) responseLease.lease.release();
+    if (websocketLease.ok) websocketLease.lease.release();
+  });
+
+  it("always permits a lease to shrink when live capacity falls", () => {
+    let capacity = 100;
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      jsonAmplification: 2,
+      minRequestChargeBytes: 1,
+      capacityBytes: () => capacity,
+    });
+    const acquired = admission.acquire(40);
+    expect(acquired.ok).toBe(true);
+    if (!acquired.ok) return;
+
+    capacity = 30;
+    expect(acquired.lease.resize(20)).toEqual({ ok: true });
+    expect(admission.reservedBytes).toBe(40);
+    acquired.lease.release();
+  });
+
+  it("reports the amplified requested charge when a streamed resize is rejected", async () => {
+    let capacityChecks = 0;
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      jsonAmplification: 2,
+      minRequestChargeBytes: 1,
+      capacityBytes: () => (++capacityChecks === 1 ? 100 : 5),
+    });
+
+    await expect(
+      readAdmittedRequestBody(
+        new Request("http://helm.test/v1/responses", { method: "POST", body: "abc" }),
+        admission,
+      ),
+    ).rejects.toMatchObject({
+      code: "server_overloaded",
+      admission: { wireBytes: 3, requestedChargeBytes: 6 },
+    });
+    expect(admission.reservedBytes).toBe(0);
+    expect(admission.pendingBytes).toBe(0);
+  });
+
+  it("shrinks and recovers admission from live safe capacity without a fixed wire limit", () => {
+    let capacity = 100;
+    const admission = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      jsonAmplification: 2,
+      minRequestChargeBytes: 10,
+      capacityBytes: () => capacity,
+    } as never);
+
+    const first = admission.acquire(20);
+    expect(first.ok).toBe(true);
+    capacity = 30;
+    expect(admission.acquire(1)).toMatchObject({ ok: false, cause: "capacity" });
+    if (first.ok) first.lease.release();
+    capacity = 200;
+    expect(admission.acquire(80).ok).toBe(true);
+  });
+
   it("never rejects for active capacity, even when charge exceeds the historical pool", () => {
     const admission = createBodyMemoryAdmission({
       activeRequestBytes: 100,

--- a/apps/gateway/src/runtime/memory-admission.ts
+++ b/apps/gateway/src/runtime/memory-admission.ts
@@ -1,19 +1,20 @@
+import type { RuntimeMemoryCoordinator, RuntimeMemoryLease } from "@helm/core";
 import type { MiddlewareHandler } from "hono";
 import type { AppEnv } from "../app.js";
 
 /**
  * Request-body memory admission.
  *
- * Capacity, live-heap and per-request wire gates are intentionally disabled:
- * they used heuristic reservations that rejected healthy traffic. Lease
- * bookkeeping remains so vacuum can `pause()` + `waitForIdle()`.
+ * There is no fixed per-request wire limit. A shared, live-headroom coordinator
+ * bounds aggregate pending memory across HTTP, websocket ingress, and response
+ * work, while lease bookkeeping also lets vacuum `pause()` + `waitForIdle()`.
  *
  * The other remaining rejection is **maintenance pause**: while vacuum (or any
  * caller) has paused admission, new acquires fail with `database_maintenance`
  * so in-flight leases can drain and `waitForIdle()` can complete.
  */
 
-export type RequestAdmissionCause = "paused";
+export type RequestAdmissionCause = "paused" | "capacity";
 
 export interface RequestAdmissionSnapshot {
   cause: RequestAdmissionCause;
@@ -26,7 +27,7 @@ export interface RequestAdmissionSnapshot {
 export class RequestAdmissionError extends Error {
   constructor(
     readonly status: 503,
-    readonly code: "database_maintenance",
+    readonly code: "database_maintenance" | "server_overloaded",
     message: string,
     readonly admission?: RequestAdmissionSnapshot,
   ) {
@@ -37,8 +38,10 @@ export class RequestAdmissionError extends Error {
 
 export function createBodyMemoryAdmission(options: {
   activeRequestBytes: number;
+  capacityBytes?: () => number;
   jsonAmplification: number;
   minRequestChargeBytes?: number;
+  coordinator?: RuntimeMemoryCoordinator;
 }) {
   let reservedBytes = 0;
   let pendingBytes = 0;
@@ -48,11 +51,13 @@ export function createBodyMemoryAdmission(options: {
     if (reservedBytes !== 0) return;
     for (const resolve of idleWaiters.splice(0)) resolve();
   };
-  // Capacity-derived charge remains bookkeeping only. It never rejects work.
+  // Estimate retained memory rather than treating wire bytes as heap bytes.
   const minRequestChargeBytes =
     options.minRequestChargeBytes ?? Math.max(1, Math.floor(options.activeRequestBytes * 0.01));
   const charge = (wireBytes: number): number =>
     Math.max(minRequestChargeBytes, Math.ceil(Math.max(0, wireBytes) * options.jsonAmplification));
+  const capacityBytes = (): number =>
+    Math.max(0, Math.floor(options.capacityBytes?.() ?? Number.MAX_SAFE_INTEGER));
 
   const rejection = (
     cause: RequestAdmissionCause,
@@ -76,11 +81,18 @@ export function createBodyMemoryAdmission(options: {
     acquire(wireBytes: number) {
       const held = charge(wireBytes);
       if (paused) return rejection("paused", wireBytes, held);
+      const shared = options.coordinator?.acquire(held);
+      if (shared !== undefined && !shared.ok) return rejection("capacity", wireBytes, held);
+      if (shared === undefined && pendingBytes + held > capacityBytes()) {
+        return rejection("capacity", wireBytes, held);
+      }
       reservedBytes += held;
       pendingBytes += held;
       let released = false;
       let isMaterialized = false;
       let current = held;
+      let sharedLease: RuntimeMemoryLease | undefined =
+        shared?.ok === true ? shared.lease : undefined;
       return {
         ok: true as const,
         lease: {
@@ -91,6 +103,19 @@ export function createBodyMemoryAdmission(options: {
             // In-flight leases may still grow while maintenance is paused so the
             // current body/frame can finish; only *new* acquires are rejected.
             const next = charge(nextWireBytes);
+            if (sharedLease !== undefined) {
+              if (!sharedLease.resize(next).ok) {
+                return {
+                  ok: false as const,
+                  admission: rejection("capacity", nextWireBytes, next).admission,
+                };
+              }
+            } else if (next > current && pendingBytes - current + next > capacityBytes()) {
+              return {
+                ok: false as const,
+                admission: rejection("capacity", nextWireBytes, next).admission,
+              };
+            }
             reservedBytes += next - current;
             pendingBytes += next - current;
             current = next;
@@ -100,10 +125,14 @@ export function createBodyMemoryAdmission(options: {
             if (released || isMaterialized) return;
             isMaterialized = true;
             pendingBytes -= current;
+            sharedLease?.release();
+            sharedLease = undefined;
           },
           release() {
             if (released) return;
             released = true;
+            sharedLease?.release();
+            sharedLease = undefined;
             reservedBytes -= current;
             if (!isMaterialized) pendingBytes -= current;
             resolveIdle();
@@ -150,6 +179,14 @@ declare module "hono" {
 }
 
 export function requestAdmissionError(admission?: RequestAdmissionSnapshot) {
+  if (admission?.cause === "capacity") {
+    return new RequestAdmissionError(
+      503,
+      "server_overloaded",
+      "request memory capacity is temporarily exhausted",
+      admission,
+    );
+  }
   return new RequestAdmissionError(
     503,
     "database_maintenance",
@@ -182,11 +219,18 @@ export async function readAdmittedRequestBody(
         const next = await reader.read();
         if (next.done) break;
         bytes += next.value.byteLength;
-        lease.resize(bytes);
+        const resized = lease.resize(bytes);
+        if (!resized.ok) {
+          await reader.cancel().catch(() => {});
+          throw requestAdmissionError(resized.admission);
+        }
         chunks.push(next.value);
       }
     }
-    lease.resize(bytes);
+    const resized = lease.resize(bytes);
+    if (!resized.ok) {
+      throw requestAdmissionError(resized.admission);
+    }
     const body = Buffer.concat(chunks, bytes);
     return {
       text: body.toString("utf8"),

--- a/apps/gateway/src/runtime/resource-pressure.test.ts
+++ b/apps/gateway/src/runtime/resource-pressure.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyResourcePressure,
+  createResourcePressureGate,
+  type ResourcePressureSample,
+  readResourcePressureSample,
+} from "./resource-pressure.js";
+
+const MIB = 1024 * 1024;
+
+function healthy(): ResourcePressureSample {
+  return {
+    effectiveTotalMemoryBytes: 2_048 * MIB,
+    availableMemoryBytes: 900 * MIB,
+    heapUsedBytes: 300 * MIB,
+    heapLimitBytes: 800 * MIB,
+    cgroupCurrentBytes: 700 * MIB,
+    cgroupMaxBytes: 1_500 * MIB,
+    memoryPsiFullAvg10: 0,
+    ioPsiFullAvg10: 0,
+  };
+}
+
+describe("resource pressure gate", () => {
+  it("classifies any high memory or I/O signal as pressured", () => {
+    expect(classifyResourcePressure({ ...healthy(), ioPsiFullAvg10: 10 })).toBe("pressured");
+    expect(classifyResourcePressure({ ...healthy(), memoryPsiFullAvg10: 1 })).toBe("pressured");
+    expect(classifyResourcePressure({ ...healthy(), availableMemoryBytes: 400 * MIB })).toBe(
+      "pressured",
+    );
+  });
+
+  it("pauses immediately and resumes only after a continuous healthy window", async () => {
+    let now = 0;
+    let sample: ResourcePressureSample = { ...healthy(), ioPsiFullAvg10: 20 };
+    const log = vi.fn();
+    const gate = createResourcePressureGate({
+      sample: async () => sample,
+      now: () => now,
+      recoveryMs: 60_000,
+      minSampleIntervalMs: 0,
+      log,
+    });
+
+    expect(await gate.shouldRun()).toBe(false);
+    sample = healthy();
+    expect(await gate.shouldRun()).toBe(false);
+    now = 59_999;
+    expect(await gate.shouldRun()).toBe(false);
+    now = 60_000;
+    expect(await gate.shouldRun()).toBe(true);
+    expect(log.mock.calls.map((call) => call[0])).toEqual([
+      "resource_pressure.background_paused",
+      "resource_pressure.background_resumed",
+    ]);
+  });
+
+  it("resets recovery on renewed pressure and holds state when sampling fails", async () => {
+    let now = 0;
+    let sample: ResourcePressureSample | null = { ...healthy(), ioPsiFullAvg10: 20 };
+    const gate = createResourcePressureGate({
+      sample: async () => sample,
+      now: () => now,
+      recoveryMs: 60_000,
+      minSampleIntervalMs: 0,
+    });
+
+    expect(await gate.shouldRun()).toBe(false);
+    sample = healthy();
+    await gate.shouldRun();
+    now = 30_000;
+    sample = { ...healthy(), ioPsiFullAvg10: 20 };
+    expect(await gate.shouldRun()).toBe(false);
+    sample = null;
+    now = 120_000;
+    expect(await gate.shouldRun()).toBe(false);
+  });
+
+  it("fails open when every sensor is unavailable at startup", async () => {
+    const log = vi.fn();
+    const gate = createResourcePressureGate({
+      sample: async () => null,
+      now: () => 0,
+      minSampleIntervalMs: 0,
+      log,
+    });
+
+    expect(await gate.shouldRun()).toBe(true);
+    expect(await gate.shouldRun()).toBe(true);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith("resource_pressure.sample_unavailable", {});
+  });
+
+  it("fails closed for heavy maintenance unless the sample is healthy", async () => {
+    let sample: ResourcePressureSample | null = null;
+    const gate = createResourcePressureGate({
+      sample: async () => sample,
+      now: () => 0,
+      minSampleIntervalMs: 0,
+    });
+
+    expect(await gate.shouldRunHeavy()).toBe(false);
+    sample = { ...healthy(), ioPsiFullAvg10: 4 };
+    expect(await gate.shouldRunHeavy()).toBe(false);
+    sample = healthy();
+    expect(await gate.shouldRunHeavy()).toBe(true);
+  });
+
+  it("shares an in-flight sample between concurrent consumers", async () => {
+    let resolveSample = (_sample: ResourcePressureSample | null) => {};
+    const sample = vi.fn(
+      () =>
+        new Promise<ResourcePressureSample | null>((resolve) => {
+          resolveSample = resolve;
+        }),
+    );
+    const gate = createResourcePressureGate({ sample, now: () => 0 });
+
+    const first = gate.shouldRun();
+    const second = gate.shouldRun();
+    resolveSample({ ...healthy(), ioPsiFullAvg10: 20 });
+    expect(await Promise.all([first, second])).toEqual([false, false]);
+    expect(sample).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads cgroup and PSI scalars without treating max as a byte value", async () => {
+    const files = new Map([
+      [
+        "/sys/fs/cgroup/memory.pressure",
+        "some avg10=1.00 avg60=0 avg300=0 total=1\nfull avg10=0.25 avg60=0 avg300=0 total=1\n",
+      ],
+      [
+        "/sys/fs/cgroup/io.pressure",
+        "some avg10=2.00 avg60=0 avg300=0 total=1\nfull avg10=3.50 avg60=0 avg300=0 total=1\n",
+      ],
+      ["/sys/fs/cgroup/memory.current", "1234\n"],
+      ["/sys/fs/cgroup/memory.max", "max\n"],
+    ]);
+    const sample = await readResourcePressureSample({
+      readText: async (path) => files.get(path) ?? null,
+      availableMemory: () => 8_000,
+      totalMemory: () => 10_000,
+      constrainedMemory: () => 0,
+      heap: () => ({ used: 2_000, limit: 6_000 }),
+    });
+
+    expect(sample).toMatchObject({
+      availableMemoryBytes: 8_000,
+      effectiveTotalMemoryBytes: 10_000,
+      heapUsedBytes: 2_000,
+      heapLimitBytes: 6_000,
+      cgroupCurrentBytes: 1_234,
+      memoryPsiFullAvg10: 0.25,
+      ioPsiFullAvg10: 3.5,
+    });
+    expect(sample?.cgroupMaxBytes).toBeUndefined();
+  });
+});

--- a/apps/gateway/src/runtime/resource-pressure.ts
+++ b/apps/gateway/src/runtime/resource-pressure.ts
@@ -1,0 +1,208 @@
+import { readFile } from "node:fs/promises";
+import { totalmem } from "node:os";
+import { getHeapStatistics } from "node:v8";
+
+const MIB = 1024 * 1024;
+
+export interface ResourcePressureSample {
+  effectiveTotalMemoryBytes?: number;
+  availableMemoryBytes?: number;
+  heapUsedBytes?: number;
+  heapLimitBytes?: number;
+  cgroupCurrentBytes?: number;
+  cgroupMaxBytes?: number;
+  memoryPsiFullAvg10?: number;
+  ioPsiFullAvg10?: number;
+}
+
+export type ResourcePressureState = "pressured" | "healthy" | "neutral" | "unknown";
+
+function finite(value: number | undefined): value is number {
+  return value !== undefined && Number.isFinite(value) && value >= 0;
+}
+
+export function classifyResourcePressure(sample: ResourcePressureSample): ResourcePressureState {
+  const total = sample.effectiveTotalMemoryBytes;
+  const pauseAvailable = finite(total)
+    ? Math.min(total * 0.8, Math.max(512 * MIB, total * 0.1))
+    : 512 * MIB;
+  const resumeAvailable = finite(total)
+    ? Math.min(total * 0.9, pauseAvailable + Math.max(128 * MIB, total * 0.05))
+    : 640 * MIB;
+  const heapRatio =
+    finite(sample.heapUsedBytes) && finite(sample.heapLimitBytes) && sample.heapLimitBytes > 0
+      ? sample.heapUsedBytes / sample.heapLimitBytes
+      : undefined;
+  const cgroupRatio =
+    finite(sample.cgroupCurrentBytes) && finite(sample.cgroupMaxBytes) && sample.cgroupMaxBytes > 0
+      ? sample.cgroupCurrentBytes / sample.cgroupMaxBytes
+      : undefined;
+  const known = [
+    sample.availableMemoryBytes,
+    heapRatio,
+    cgroupRatio,
+    sample.memoryPsiFullAvg10,
+    sample.ioPsiFullAvg10,
+  ].some(finite);
+  if (!known) return "unknown";
+  if (
+    (finite(sample.availableMemoryBytes) && sample.availableMemoryBytes < pauseAvailable) ||
+    (finite(heapRatio) && heapRatio >= 0.7) ||
+    (finite(cgroupRatio) && cgroupRatio >= 0.75) ||
+    (finite(sample.memoryPsiFullAvg10) && sample.memoryPsiFullAvg10 >= 1) ||
+    (finite(sample.ioPsiFullAvg10) && sample.ioPsiFullAvg10 >= 5)
+  ) {
+    return "pressured";
+  }
+  const healthy =
+    (!finite(sample.availableMemoryBytes) || sample.availableMemoryBytes >= resumeAvailable) &&
+    (!finite(heapRatio) || heapRatio <= 0.6) &&
+    (!finite(cgroupRatio) || cgroupRatio <= 0.65) &&
+    (!finite(sample.memoryPsiFullAvg10) || sample.memoryPsiFullAvg10 <= 0.2) &&
+    (!finite(sample.ioPsiFullAvg10) || sample.ioPsiFullAvg10 <= 3);
+  return healthy ? "healthy" : "neutral";
+}
+
+export function createResourcePressureGate(options: {
+  sample: () => Promise<ResourcePressureSample | null>;
+  now?: () => number;
+  recoveryMs?: number;
+  minSampleIntervalMs?: number;
+  log?: (message: string, fields: Record<string, unknown>) => void;
+}) {
+  const now = options.now ?? Date.now;
+  const recoveryMs = options.recoveryMs ?? 60_000;
+  const minSampleIntervalMs = options.minSampleIntervalMs ?? 5_000;
+  const log = options.log ?? (() => {});
+  let blocked = false;
+  let recoverySince: number | null = null;
+  let lastSampleAt = Number.NEGATIVE_INFINITY;
+  let lastState: ResourcePressureState = "unknown";
+  let inFlight: Promise<ResourcePressureState> | null = null;
+  let unavailableLogged = false;
+
+  const sampleState = async (): Promise<ResourcePressureState> => {
+    if (inFlight) return inFlight;
+    const at = now();
+    if (at - lastSampleAt < minSampleIntervalMs) return lastState;
+    inFlight = (async () => {
+      let sample: ResourcePressureSample | null = null;
+      try {
+        sample = await options.sample();
+      } catch {
+        sample = null;
+      }
+      lastState = sample === null ? "unknown" : classifyResourcePressure(sample);
+      lastSampleAt = now();
+      return lastState;
+    })();
+    try {
+      return await inFlight;
+    } finally {
+      inFlight = null;
+    }
+  };
+
+  const decide = async (requireHealthy: boolean): Promise<boolean> => {
+    const at = now();
+    const state = await sampleState();
+    if (state === "unknown") {
+      if (!unavailableLogged) {
+        unavailableLogged = true;
+        log("resource_pressure.sample_unavailable", {});
+      }
+      return !blocked && !requireHealthy;
+    }
+    unavailableLogged = false;
+    if (state === "pressured") {
+      recoverySince = null;
+      if (!blocked) {
+        blocked = true;
+        log("resource_pressure.background_paused", {});
+      }
+      return false;
+    }
+    if (!blocked) return requireHealthy ? state === "healthy" : true;
+    if (state !== "healthy") {
+      recoverySince = null;
+      return false;
+    }
+    recoverySince ??= at;
+    if (at - recoverySince < recoveryMs) return false;
+    blocked = false;
+    recoverySince = null;
+    log("resource_pressure.background_resumed", {});
+    return true;
+  };
+
+  return {
+    shouldRun: () => decide(false),
+    shouldRunHeavy: () => decide(true),
+  };
+}
+
+function number(text: string | null): number | undefined {
+  if (text === null || text.trim() === "max") return undefined;
+  const value = Number(text.trim());
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function fullAvg10(text: string | null): number | undefined {
+  const match = text?.match(/^full\s+avg10=([0-9.]+)/m);
+  return match ? number(match[1] ?? null) : undefined;
+}
+
+async function defaultReadText(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export async function readResourcePressureSample(
+  options: {
+    readText?: (path: string) => Promise<string | null>;
+    availableMemory?: () => number;
+    totalMemory?: () => number;
+    constrainedMemory?: () => number;
+    heap?: () => { used: number; limit: number };
+  } = {},
+): Promise<ResourcePressureSample> {
+  const readText = options.readText ?? defaultReadText;
+  const [cgroupMemoryPsi, cgroupIoPsi, hostMemoryPsi, hostIoPsi, cgroupCurrent, cgroupMax] =
+    await Promise.all([
+      readText("/sys/fs/cgroup/memory.pressure"),
+      readText("/sys/fs/cgroup/io.pressure"),
+      readText("/proc/pressure/memory"),
+      readText("/proc/pressure/io"),
+      readText("/sys/fs/cgroup/memory.current"),
+      readText("/sys/fs/cgroup/memory.max"),
+    ]);
+  const hostTotal = (options.totalMemory ?? totalmem)();
+  const constrained = (options.constrainedMemory ?? (() => process.constrainedMemory()))();
+  const effectiveTotal = constrained > 0 ? Math.min(hostTotal, constrained) : hostTotal;
+  const heap = (
+    options.heap ??
+    (() => {
+      const statistics = getHeapStatistics();
+      return { used: process.memoryUsage().heapUsed, limit: statistics.heap_size_limit };
+    })
+  )();
+  return {
+    effectiveTotalMemoryBytes: effectiveTotal,
+    availableMemoryBytes: (options.availableMemory ?? (() => process.availableMemory()))(),
+    heapUsedBytes: heap.used,
+    heapLimitBytes: heap.limit,
+    cgroupCurrentBytes: number(cgroupCurrent),
+    cgroupMaxBytes: number(cgroupMax),
+    memoryPsiFullAvg10: fullAvg10(cgroupMemoryPsi ?? hostMemoryPsi),
+    ioPsiFullAvg10: fullAvg10(cgroupIoPsi ?? hostIoPsi),
+  };
+}
+
+export function createRuntimeResourcePressureGate(
+  log: (message: string, fields: Record<string, unknown>) => void,
+) {
+  return createResourcePressureGate({ sample: readResourcePressureSample, log });
+}

--- a/apps/gateway/src/runtime/write-queue.ts
+++ b/apps/gateway/src/runtime/write-queue.ts
@@ -46,7 +46,7 @@ export interface WriteQueue {
   // Defer a telemetry decision insert (batched, fail-open, runs after the response).
   enqueueTelemetry(input: InsertTelemetryInput): Promise<void>;
   // Defer a payload upsert (batched, fail-open).
-  enqueuePayload(input: InsertPayloadInput): Promise<void>;
+  enqueuePayload(input: InsertPayloadInput, isCurrent?: () => boolean): Promise<void>;
   // Defer a session transcript write while charging the retained request body
   // against the same byte/depth budget. When full, admission waits for the bounded
   // backlog instead of retaining another closure or dropping the transcript.
@@ -91,7 +91,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
   const jsonAmplification = runtimeMemoryBudget().jsonAmplification;
 
   let telemetryBuf: InsertTelemetryInput[] = [];
-  let payloadBuf: InsertPayloadInput[] = [];
+  let payloadBuf: Array<{ input: InsertPayloadInput; isCurrent?: () => boolean }> = [];
   // Costs are computed once at admission and accumulated until the whole buffer moves
   // to the in-flight batch. No per-row cost arrays are needed because rows are never
   // shed after admission.
@@ -195,17 +195,22 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
 
   // Same batch-then-per-row resilience for payloads (their upsert tolerates a
   // duplicate request_id, but any other batch error must not drop the window).
-  const writePayloads = async (batch: InsertPayloadInput[]): Promise<void> => {
-    if (batch.length === 0) return;
+  const writePayloads = async (
+    batch: Array<{ input: InsertPayloadInput; isCurrent?: () => boolean }>,
+  ): Promise<void> => {
+    const current = batch
+      .filter((queued) => queued.isCurrent?.() !== false)
+      .map((queued) => queued.input);
+    if (current.length === 0) return;
     if (telemetry.insertPayloads) {
       try {
-        await telemetry.insertPayloads(batch);
+        await telemetry.insertPayloads(current);
         return;
       } catch {
         log("writequeue.payload_batch_fallback");
       }
     }
-    for (const input of batch) {
+    for (const input of current) {
       try {
         await telemetry.insertPayload(input);
       } catch {
@@ -306,7 +311,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
       });
     },
 
-    async enqueuePayload(input: InsertPayloadInput): Promise<void> {
+    async enqueuePayload(input: InsertPayloadInput, isCurrent?: () => boolean): Promise<void> {
       if (stopped) return;
       if (paused) {
         log("writequeue.paused");
@@ -314,7 +319,7 @@ export function createWriteQueue(deps: WriteQueueDeps): WriteQueue {
       }
       const cost = payloadCost(input);
       await admit(cost, () => {
-        payloadBuf.push(input);
+        payloadBuf.push({ input, isCurrent });
         bufferedBytes += cost;
         if (payloadBuf.length >= maxBatch || bufferedBytes >= flushBytes) void doFlush();
         else scheduleTimer();

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -112,6 +112,8 @@ import {
   runObserverJob,
   runReflectorJob,
   runtimeMemoryBudget,
+  runtimeMemoryCoordinator,
+  runtimeResponseWorkAdmission,
   type StoreSet,
   saveRuntimeSettings,
   settleBudget,
@@ -235,6 +237,7 @@ import {
   withPausedActivities,
 } from "./runtime/maintenance-gate.js";
 import { type BodyMemoryAdmission, createBodyMemoryAdmission } from "./runtime/memory-admission.js";
+import { createRuntimeResourcePressureGate } from "./runtime/resource-pressure.js";
 import { startRuntimeStatsLogger } from "./runtime/runtime-stats.js";
 import {
   markServingAccount,
@@ -1839,20 +1842,23 @@ export async function buildServer(
   const memoryBudget = runtimeMemoryBudget();
   const maintenanceActivityGate = createMaintenanceActivityGate();
   const backgroundTasks = createTrackedBackgroundTasks();
+  const memoryCoordinator = runtimeMemoryCoordinator();
   const requestBodyMemoryAdmission = createBodyMemoryAdmission({
     activeRequestBytes: memoryBudget.activeRequestBytes,
     jsonAmplification: memoryBudget.jsonAmplification,
     minRequestChargeBytes: memoryBudget.minRequestChargeBytes,
+    coordinator: memoryCoordinator,
   });
   const websocketIngressAdmission = createBodyMemoryAdmission({
     activeRequestBytes: memoryBudget.websocketIngressBytes,
     jsonAmplification: 1,
     minRequestChargeBytes: 1,
+    coordinator: memoryCoordinator,
   });
   logger.log("info", "runtime.memory_budget", {
     heap_limit_bytes: memoryBudget.heapLimitBytes,
     process_limit_bytes: memoryBudget.processLimitBytes,
-    request_admission_mode: "unlimited",
+    request_admission_mode: "dynamic_safe_headroom",
     write_queue_bytes: memoryBudget.writeQueueBytes,
     session_cache_bytes: memoryBudget.sessionCacheBytes,
     response_capture_bytes: memoryBudget.responseCaptureBytes,
@@ -2015,6 +2021,7 @@ export async function buildServer(
   let settings = await loadRuntimeSettings(store.config, config, (lvl, msg, fields) =>
     logger.log(lvl, msg, fields),
   );
+  let captureGeneration = 0;
   logger.setLevel?.(settings.log_level);
   // A MUTABLE copy of the rate-limit config: the limiter reads `.enabled` and
   // `.default` fresh on every check(), so flipping the master switch OR retuning
@@ -2033,11 +2040,20 @@ export async function buildServer(
   let vacuumScheduler: ReturnType<typeof startCleanupScheduler> | null = null;
   let signalScheduler: ReturnType<typeof startSignalScheduler> | null = null;
   let memoryWorker: ReturnType<typeof startMemoryWorker> | null = null;
+  const resourcePressure = createRuntimeResourcePressureGate((message, fields) =>
+    logger.log("info", message, fields),
+  );
   // Apply a new settings object live: re-bind `settings`, push the log level into
   // the logger, flip the rate-limit master switch, and retune the system-default
   // quota. Cleanup cadence is also rescheduled live so the admin setting is not
   // restart-only. Called by the admin settings route after it validates + persists.
   const applySettings = (next: RuntimeSettings): void => {
+    if (
+      settings.capture_payloads !== next.capture_payloads ||
+      settings.capture_sessions !== next.capture_sessions
+    ) {
+      captureGeneration++;
+    }
     settings = next;
     logger.setLevel?.(next.log_level);
     rateLimitConfig.enabled = next.rate_limit_enabled;
@@ -2074,7 +2090,9 @@ export async function buildServer(
   };
   const runCleanupPassNow = (trigger: "scheduled" | "manual") =>
     maintenanceQueue.run(() => executeCleanupPass(trigger));
-  const executeVacuum = async (options: { httpAlreadyPaused?: boolean } = {}) => {
+  const executeVacuum = async (
+    options: { httpAlreadyPaused?: boolean; shouldProceed?: () => Promise<boolean> } = {},
+  ) => {
     const activities: PausableActivity[] = [
       ...(options.httpAlreadyPaused ? [] : [maintenanceActivityGate]),
       {
@@ -2095,18 +2113,20 @@ export async function buildServer(
       backgroundTasks,
       { pauseAndWait: writeQueue.pauseAndFlush, resume: writeQueue.resume },
     ];
-    await withPausedActivities(
+    return withPausedActivities(
       activities,
       async () => {
         clearSessionCaptureCache(telemetry);
+        if (options.shouldProceed && !(await options.shouldProceed())) return false;
         await store.vacuum();
+        return true;
       },
       { pauseTimeoutMs: maintenanceDrainTimeoutMs(config.runtime.request_timeout_ms) },
     );
   };
-  const runVacuumNow = () => {
+  const runVacuumNow = async (): Promise<void> => {
     maintenanceActivityGate.releaseCurrent();
-    return maintenanceQueue.run(executeVacuum);
+    await maintenanceQueue.run(executeVacuum);
   };
   // Agentic Signals (docs/02). The collector consumes ALREADY-persisted telemetry
   // and writes aggregated, REDACTED signals in the background. The optional
@@ -3408,6 +3428,7 @@ export async function buildServer(
     // retention is owned by the scheduled cleanup runner, not the capture path.
     capturePayloads: () => settings.capture_payloads,
     captureSessions: () => settings.capture_sessions,
+    captureGeneration: () => captureGeneration,
     costOf,
     // Per-key usage budgets (docs/06): the pre-route gate (degrade/reject) + the
     // post-served settle, threaded from the composition root.
@@ -3524,6 +3545,7 @@ export async function buildServer(
       rules: ruleStore,
       keyStore,
       telemetry,
+      responseWorkAdmission: runtimeResponseWorkAdmission(),
       runInBackground: backgroundTasks.run,
       // Data cleanup / retention / archival surface (admin "Data cleanup").
       cleanup: {
@@ -3771,6 +3793,7 @@ export async function buildServer(
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
       captureSessions: () => settings.capture_sessions,
+      captureGeneration: () => captureGeneration,
     },
   } as Parameters<typeof registerMessagesRoute>[1] & { rateLimiter: RateLimiterPort });
 
@@ -3978,6 +4001,7 @@ export async function buildServer(
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
       captureSessions: () => settings.capture_sessions,
+      captureGeneration: () => captureGeneration,
       costOf,
     },
   } as Parameters<typeof registerResponsesRoute>[1] & { rateLimiter: RateLimiterPort });
@@ -4141,6 +4165,7 @@ export async function buildServer(
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
       captureSessions: () => settings.capture_sessions,
+      captureGeneration: () => captureGeneration,
     },
   } as Parameters<typeof registerGeminiRoute>[1] & { rateLimiter: RateLimiterPort });
 
@@ -4223,6 +4248,7 @@ export async function buildServer(
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
       captureSessions: () => settings.capture_sessions,
+      captureGeneration: () => captureGeneration,
     },
   });
 
@@ -4246,6 +4272,7 @@ export async function buildServer(
       now: () => Date.now(),
       capturePayloads: () => settings.capture_payloads,
       captureSessions: () => settings.capture_sessions,
+      captureGeneration: () => captureGeneration,
     },
   });
 
@@ -4261,6 +4288,7 @@ export async function buildServer(
       collector: signalCollector,
       intervalMs: Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : 60_000,
       now: () => Date.now(),
+      shouldRun: resourcePressure.shouldRun,
       log: (level, msg, fields) => logger.log(level, msg, fields),
     });
   }
@@ -4308,6 +4336,7 @@ export async function buildServer(
       maxDrainMs: memoryWorkerMaxDrainMs,
       yieldBetweenBatches: () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
       now: () => Date.now(),
+      shouldRun: resourcePressure.shouldRun,
       log: memoryLog,
       runObserver: (job) => runObserverJob(job, observerDeps),
       runReflector: (job) => runReflectorJob(job, reflectorDeps),
@@ -4381,7 +4410,10 @@ export async function buildServer(
       intervalMs: hours * 3_600_000,
       runTick: async () => {
         if (!settings.cleanup_enabled) return; // live master switch
-        await runCleanupPassNow("scheduled");
+        await maintenanceQueue.run(async () => {
+          if (!(await resourcePressure.shouldRunHeavy())) return;
+          await executeCleanupPass("scheduled");
+        });
       },
       log: (level, msg, fields) => logger.log(level, msg, fields),
     });
@@ -4400,8 +4432,9 @@ export async function buildServer(
       vacuumScheduler = startCleanupScheduler({
         intervalMs: AUTO_VACUUM_CHECK_INTERVAL_MS,
         runTick: async () => {
-          await maintenanceQueue.run(() =>
-            autoVacuum.run(
+          await maintenanceQueue.run(async () => {
+            if (!(await resourcePressure.shouldRunHeavy())) return;
+            await autoVacuum.run(
               () => {
                 const now = new Date();
                 return {
@@ -4418,15 +4451,19 @@ export async function buildServer(
                 }
                 try {
                   logger.log("info", "vacuum.auto_start", { hour: settings.vacuum_hour });
-                  await executeVacuum({ httpAlreadyPaused: true });
+                  const completed = await executeVacuum({
+                    httpAlreadyPaused: true,
+                    shouldProceed: resourcePressure.shouldRunHeavy,
+                  });
+                  if (!completed) return false;
                   logger.log("info", "vacuum.auto_done", {});
                   return true;
                 } finally {
                   maintenanceActivityGate.resume();
                 }
               },
-            ),
-          );
+            );
+          });
         },
         log: (level, msg, fields) => logger.log(level, msg, fields),
       });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-08-02 · Session 正文改为原子分块存储并以机器压力协调后台工作（Telemetry / Gateway runtime，docs/02/07/11，原则 3/7）
+
+- **存储格式**：新 Session 正文按 UTF-8 安全的 256 KiB 原始块逐块 gzip/raw 写入，最多 4 块一批；revision 用请求/响应两个 generation 指针原子发布，响应回填不重写大请求正文，并发重试不会把一份元数据配到另一份正文。历史正文不扫描、不回填；legacy 行继续读取，首次响应回填记录准确的逻辑 `body_bytes`。Admin 恢复先按机器动态 response-work 预算分页，只读取已发布 generation；旧二进制正文在缺少可靠原始字节数时 fail-closed。
+- **无 Session 容量上限**：不恢复 64 MiB 或其他累计上限；单次正文、写队列、HTTP/WebSocket 与响应解析共享基于 V8/cgroup/可用内存的动态协调器，允许更大机器自动使用更多内存，但在 PSI/内存压力下暂停 Memory、Signals 与 scheduled cleanup。健康连续 60 秒后才恢复，避免抖动。
+- **维护边界**：SQLite Session prune 继续小批续跑；PostgreSQL 每次 cleanup tick 最多处理 128 个物理行、每批 16 行，并用持久 marker 续跑。scheduled cleanup 与 auto-VACUUM 在开始前检查压力，VACUUM 排空活动后、真正重写数据库前再次检查；压力恶化时不执行也不误记当天成功。手动维护语义保持不变。
+- **模式切换**：全局 metadata-only 是 hard-off，任何 key override 都不能绕过；切换 generation 后，已排队的 payload/Session 正文写入会被丢弃，脱敏 telemetry 仍保存。`part=meta` 不读取正文。
+
 ## 2026-07-31 · API key 单独覆盖请求内容存储模式（Key Store / Telemetry / Admin，docs/06/07/11，原则 2/7）
 
 - **继承与优先级**：`api_keys.request_content_mode` 是 SQLite/PostgreSQL 的 nullable 枚举列；`NULL` 表示继承实时全局模式，`none` / `payload` / `session` 显式覆盖。历史 key 迁移后保持 `NULL`，不会因升级改变正文留存行为。
@@ -68,16 +75,9 @@
 - **测试影响**：三个老测试用 503 当"随便一个 5xx"占位（openai 401 分支、gemini/codex 非 JSON body 保留、generic 首 chunk 前抛错），503 现在会触发重试，已改成 500 并注明原因；意图不变，provider 套件同时从 9s 回到 2.5s。
 - **TODO / 边界**：退避参数目前是代码常量，未做成配置（与原则 2 的"会撒谎的旋钮比没有旋钮更糟"一致，先观察线上真实 529 分布再决定）；OAuth 池**换账号之间**仍无延迟，本次未动——换号本身就是在换容量，加睡眠反而拖慢。
 
-## 2026-07-25 · Responses WebSocket terminal 立即释放并关闭失效连接（Gateway / Protocol，docs/02/05/07，原则 3/8）
-
-- **成功终态**：内部 SSE 一旦转发 `response.completed` 就停止读取并异步取消正文，不再等待 provider body EOF；请求与 ingress lease 随即释放，同一 downstream WebSocket 可以立即处理下一 turn，避免长期 `processing=true` 导致 1008、中断或卡住。
-- **每轮取消边界**：downstream 连接只保留 connection controller，每个 `response.create` 另建 turn controller；终态后主动 abort 当前内部 fetch，但不 abort 可复用连接。客户端断连、bridge error 或并发发送第二个 active turn 时同时 abort 当前 turn 与 session，释放内存/并发 lease，不等待可能挂起的 body cancel。已观察到的 `completed` / `incomplete` / `failed` 优先于随后发生的 teardown `client_abort`，避免把真实结果误记为客户端中断。
-- **失败终态**：`response.failed`、`response.incomplete`、`error`、非 2xx 与本地桥接错误均先发送协议终态，再幂等销毁 connection-local 上游 Session，并以 1000 正常关闭 downstream socket；终态本身已携带失败事实，不再用 1011 诱发客户端错误退避。Codex 下一次请求会新建连接并清除旧 `previous_response_id`，不会在已失效 Session 上续接。
-- **Codex 增量续接**：真实客户端既会发送带完整 input 的 `generate:false` 预热帧，也会在启动预连接时发送严格的 `input:[] + generate:false` 预热帧；后一形状只有 normalized/native 两层都明确 `generate:false` 时才允许空 IR messages。下一帧可只带 `previous_response_id` 与空 `input`，此时仅当 Responses registry 已验证该 id 并固定原 provider 时放行；registry 在对客户端发送 terminal frame 前先持久化实际 provider alias、与成功 alias 相符的 OAuth account 及 selected lane，重启后仍恢复同一账号，fallback 前选中过但未实际服务的账号不会被写入。该持久化不伪造上游 connection-local state：Codex 在 WebSocket 重连时会清除旧增量状态并重发完整 input。续接在分类前固定为单 provider，真实 lane 继续受 `allowed_lanes` 约束，显式 custom-model 延续首轮既有语义；旧 registry 行缺少 lane provenance 时保持 fail-closed，`blocked_models` 与预算 degrade 同样不可绕过。普通空请求、未知 id、无 provider pin 与跨协议请求仍拒绝。`generate:false` 无 native Responses passthrough 时直接拒绝，不允许翻译路径意外产生计费输出。首 chunk 后的 `AbortError` 只记录为 `client_abort`，不误报上游截断，也不触发 breaker failure。
-- **连接超时边界**：Codex 上游 WebSocket handshake 与非 101 error body 的等待上限为 `min(request_timeout_ms, 60s)`；正常流式请求仍使用既有 request/idle timeout，不因连接建立保护而缩短。没有新增配置、依赖、后台 drain 或 graceful-shutdown 重构。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-25 · Responses WebSocket terminal 立即释放并关闭失效连接**：成功终态立即释放请求与 ingress lease，失败终态关闭失效连接；Codex 增量续接保持 registry/provider/account/lane provenance 与 abort 边界，完整原文通过 git history 回溯。
 - **2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面**：Realtime V1/V2/V3、Responses 音频与 Images edits 复用既有鉴权、路由、账号和遥测链；Voice attestation 与单实例 call registry 保持收窄边界，完整原文通过 git history 回溯。
 - **2026-07-24 · 请求准入增加实时 V8 堆高水位**：曾以 live heap + 分池余量拒绝高风险请求；后被 2026-07-27 的启发式拒绝拆除与 2026-07-28 的请求大小上限删除取代，完整原文通过 git history 回溯。
 - **2026-07-24 · Admin 登录同源证明兼容代理 Host 改写**：登录/登出优先接受浏览器不可伪造的 `Sec-Fetch-Site: same-origin`，同时保留 Origin/Host 与 cross-site 拒绝边界；完整原文通过 git history 回溯。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -783,9 +783,15 @@ export {
   routeRequest,
 } from "./routing/route-request.js";
 export {
+  createRuntimeMemoryCoordinator,
   deriveRuntimeMemoryBudget,
+  deriveSafeWorkingMemoryCapacity,
   type RuntimeMemoryBudget,
+  type RuntimeMemoryCoordinator,
+  type RuntimeMemoryLease,
   runtimeMemoryBudget,
+  runtimeMemoryCoordinator,
+  runtimeSafeWorkingMemoryCapacity,
 } from "./runtime/memory-budget.js";
 export {
   acquireResponseWork,

--- a/packages/core/src/memory/scheduler.test.ts
+++ b/packages/core/src/memory/scheduler.test.ts
@@ -72,6 +72,77 @@ describe("startMemoryWorker", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
+  it("does not run interval or wake work while the resource gate is closed", async () => {
+    const { store, claim } = makeStore([]);
+    let allowed = false;
+    const onTick = vi.fn(async () => {});
+    const handle = startMemoryWorker(
+      makeDeps(store, { shouldRun: async () => allowed, coalesceMs: 1, onTick }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    handle.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onTick).not.toHaveBeenCalled();
+    expect(claim).not.toHaveBeenCalled();
+
+    allowed = true;
+    handle.wake();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(claim).toHaveBeenCalledTimes(1);
+    await handle.stop();
+  });
+
+  it("does not cross a pause fence while an asynchronous resource check is pending", async () => {
+    const { store, claim } = makeStore([]);
+    const onTick = vi.fn(async () => {});
+    let resolveGate = (_allowed: boolean) => {};
+    const shouldRun = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveGate = resolve;
+        }),
+    );
+    const handle = startMemoryWorker(makeDeps(store, { shouldRun, onTick }));
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(shouldRun).toHaveBeenCalledTimes(1);
+    await handle.pauseAndWait();
+    resolveGate(true);
+    await vi.waitFor(() => expect(onTick).not.toHaveBeenCalled());
+    expect(claim).not.toHaveBeenCalled();
+    await handle.stop();
+  });
+
+  it("finishes a claimed batch but checks pressure again before the next claim", async () => {
+    const { store } = makeStore([]);
+    const claim = store.claimPendingJobs as ReturnType<typeof vi.fn>;
+    claim
+      .mockResolvedValueOnce([
+        { jobId: "j1", type: "observer", scope: { accountId: "acct-a", threadId: "t1" } },
+      ])
+      .mockResolvedValueOnce([]);
+    const shouldRun = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+    const runObserver = vi.fn(async (): Promise<ObserverResult> => OBS_NOOP);
+    const handle = startMemoryWorker(
+      makeDeps(store, {
+        batchSize: 1,
+        maxBatchesPerDrain: 10,
+        shouldRun,
+        runObserver,
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(runObserver).toHaveBeenCalledTimes(1);
+    expect(claim).toHaveBeenCalledTimes(1);
+    await handle.stop();
+  });
+
   it("claims a batch each tick and dispatches an observer row to runObserver", async () => {
     const { store } = makeStore([
       { jobId: "j1", type: "observer", scope: { accountId: "acct-a", threadId: "t1" } },

--- a/packages/core/src/memory/scheduler.ts
+++ b/packages/core/src/memory/scheduler.ts
@@ -66,6 +66,9 @@ export interface MemoryWorkerDeps {
   // request). Itself fail-open + guarded by the tick wrapper; with forgetting off it is
   // either unset or a no-op, so the tick is byte-identical to today.
   onTick?: () => Promise<void>;
+  // Resource-pressure gate for optional background work. It is checked before a
+  // trigger and between catch-up batches; already claimed jobs always finish.
+  shouldRun?: () => boolean | Promise<boolean>;
 }
 
 export interface MemoryWorkerHandle {
@@ -212,6 +215,18 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
   // (that is the interval's job). Shared by the interval tick and the wake drain.
   const workerConcurrency = Math.max(1, Math.floor(deps.concurrency ?? 1));
 
+  const shouldRun = async (): Promise<boolean> => {
+    if (deps.shouldRun === undefined) return true;
+    try {
+      return (await deps.shouldRun()) !== false;
+    } catch (err) {
+      deps.log("memory.worker.resource_gate_failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+  };
+
   const runOneJob = async (job: MemoryJobRow): Promise<void> => {
     // Per-job guard: a single failing job must not abort the rest of the batch
     // nor stop the timer (principle 3). The runners record their own outcome on
@@ -284,6 +299,7 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
         let batches = 0;
         let lastClaimed = 0;
         do {
+          if (!(await shouldRun())) break;
           lastClaimed = await drainJobs();
           batches += 1;
           if (lastClaimed < deps.batchSize) break;
@@ -325,6 +341,8 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
   let activeRuns = 0;
   const idleWaiters: Array<() => void> = [];
   const runWhileActive = async (run: () => Promise<void>): Promise<void> => {
+    if (paused || stopped) return;
+    if (!(await shouldRun())) return;
     if (paused || stopped) return;
     activeRuns += 1;
     try {

--- a/packages/core/src/runtime/memory-budget.test.ts
+++ b/packages/core/src/runtime/memory-budget.test.ts
@@ -1,7 +1,44 @@
 import { describe, expect, it } from "vitest";
-import { deriveRuntimeMemoryBudget } from "./memory-budget.js";
+import { deriveRuntimeMemoryBudget, deriveSafeWorkingMemoryCapacity } from "./memory-budget.js";
 
 describe("deriveRuntimeMemoryBudget", () => {
+  it("reserves bounded host and V8 emergency memory while scaling with live headroom", () => {
+    expect(
+      deriveSafeWorkingMemoryCapacity({
+        heapLimitBytes: 1_000,
+        heapUsedBytes: 200,
+        availableMemoryBytes: 900,
+        hostTotalMemoryBytes: 2_000,
+        hostReserveMinBytes: 100,
+        emergencyReserveBytes: 100,
+        utilization: 0.7,
+      }),
+    ).toBe(489);
+    expect(
+      deriveSafeWorkingMemoryCapacity({
+        heapLimitBytes: 1_000,
+        heapUsedBytes: 200,
+        availableMemoryBytes: 50,
+        hostTotalMemoryBytes: 2_000,
+        hostReserveMinBytes: 100,
+        emergencyReserveBytes: 100,
+        utilization: 0.7,
+      }),
+    ).toBe(0);
+  });
+
+  it("bases the proportional reserve on the cgroup total instead of the host total", () => {
+    expect(
+      deriveSafeWorkingMemoryCapacity({
+        heapLimitBytes: 512 * 1024 * 1024,
+        heapUsedBytes: 64 * 1024 * 1024,
+        availableMemoryBytes: 400 * 1024 * 1024,
+        hostTotalMemoryBytes: 64 * 1024 * 1024 * 1024,
+        constrainedMemoryBytes: 512 * 1024 * 1024,
+      }),
+    ).toBeGreaterThan(0);
+  });
+
   it("scales every in-memory budget from the detected runtime capacity", () => {
     const small = deriveRuntimeMemoryBudget({
       heapLimitBytes: 1_000,

--- a/packages/core/src/runtime/memory-budget.ts
+++ b/packages/core/src/runtime/memory-budget.ts
@@ -1,4 +1,7 @@
+import { totalmem } from "node:os";
 import { getHeapStatistics } from "node:v8";
+
+const MIB = 1024 * 1024;
 
 const JSON_AMPLIFICATION = 6;
 
@@ -16,6 +19,105 @@ export interface RuntimeMemoryBudget {
   sqlitePageCacheBytes: number;
   sqliteMaintenanceCacheBytes: number;
   websocketIngressBytes: number;
+}
+
+export interface RuntimeMemoryLease {
+  resize(bytes: number): { ok: true } | { ok: false; capacityBytes: number };
+  release(): void;
+}
+
+export interface RuntimeMemoryCoordinator {
+  acquire(
+    bytes: number,
+  ): { ok: true; lease: RuntimeMemoryLease } | { ok: false; capacityBytes: number };
+  readonly capacityBytes: number;
+  readonly reservedBytes: number;
+}
+
+function normalizedBytes(bytes: number): number {
+  return Number.isSafeInteger(bytes) && bytes >= 0 ? bytes : Number.MAX_SAFE_INTEGER;
+}
+
+export function createRuntimeMemoryCoordinator(options: {
+  capacityBytes: () => number;
+}): RuntimeMemoryCoordinator {
+  let reservedBytes = 0;
+  const capacityBytes = (): number => {
+    const capacity = options.capacityBytes();
+    return Number.isSafeInteger(capacity) && capacity >= 0 ? capacity : 0;
+  };
+
+  return {
+    acquire(bytes) {
+      let held = normalizedBytes(bytes);
+      const capacity = capacityBytes();
+      if (reservedBytes + held > capacity) {
+        return { ok: false as const, capacityBytes: capacity };
+      }
+      reservedBytes += held;
+      let released = false;
+      return {
+        ok: true as const,
+        lease: {
+          resize(nextBytes) {
+            if (released) return { ok: false as const, capacityBytes: capacityBytes() };
+            const next = normalizedBytes(nextBytes);
+            if (next > held) {
+              const capacity = capacityBytes();
+              if (reservedBytes - held + next > capacity) {
+                return { ok: false as const, capacityBytes: capacity };
+              }
+            }
+            reservedBytes += next - held;
+            held = next;
+            return { ok: true as const };
+          },
+          release() {
+            if (released) return;
+            released = true;
+            reservedBytes -= held;
+          },
+        },
+      };
+    },
+    get capacityBytes() {
+      return capacityBytes();
+    },
+    get reservedBytes() {
+      return reservedBytes;
+    },
+  };
+}
+
+export function deriveSafeWorkingMemoryCapacity(input: {
+  heapLimitBytes: number;
+  heapUsedBytes: number;
+  availableMemoryBytes: number;
+  hostTotalMemoryBytes: number;
+  constrainedMemoryBytes?: number;
+  hostReserveMinBytes?: number;
+  emergencyReserveBytes?: number;
+  utilization?: number;
+}): number {
+  const hostReserveMinBytes = input.hostReserveMinBytes ?? 384 * MIB;
+  const emergencyReserveBytes = input.emergencyReserveBytes ?? 128 * MIB;
+  const utilization = input.utilization ?? 0.7;
+  const constrainedMemoryBytes = input.constrainedMemoryBytes ?? 0;
+  const hasConstrainedLimit =
+    Number.isSafeInteger(constrainedMemoryBytes) && constrainedMemoryBytes > 0;
+  const effectiveTotalMemoryBytes = hasConstrainedLimit
+    ? Math.min(input.hostTotalMemoryBytes, constrainedMemoryBytes)
+    : input.hostTotalMemoryBytes;
+  const hostReserve = Math.max(
+    hostReserveMinBytes,
+    Math.min(1024 * MIB, Math.floor(effectiveTotalMemoryBytes * 0.05)),
+  );
+  const heapHeadroom = Math.max(
+    0,
+    input.heapLimitBytes - input.heapUsedBytes - emergencyReserveBytes,
+  );
+  const nativeHeadroom = Math.max(0, input.availableMemoryBytes - hostReserve);
+  return Math.max(0, Math.floor(Math.min(heapHeadroom, nativeHeadroom) * utilization));
 }
 
 export function deriveRuntimeMemoryBudget(input: {
@@ -115,4 +217,27 @@ export function runtimeMemoryBudget(): RuntimeMemoryBudget {
     availableMemoryBytes: process.availableMemory(),
   });
   return detected;
+}
+
+/** Live process/cgroup-aware capacity. It scales with the machine and current
+ * pressure; it is an operation budget, never a cumulative Session byte limit. */
+export function runtimeSafeWorkingMemoryCapacity(): number {
+  const heap = getHeapStatistics();
+  const memory = process.memoryUsage();
+  return deriveSafeWorkingMemoryCapacity({
+    heapLimitBytes: heap.heap_size_limit,
+    heapUsedBytes: memory.heapUsed,
+    availableMemoryBytes: process.availableMemory(),
+    hostTotalMemoryBytes: totalmem(),
+    constrainedMemoryBytes: process.constrainedMemory(),
+  });
+}
+
+let runtimeCoordinator: RuntimeMemoryCoordinator | undefined;
+
+export function runtimeMemoryCoordinator(): RuntimeMemoryCoordinator {
+  runtimeCoordinator ??= createRuntimeMemoryCoordinator({
+    capacityBytes: runtimeSafeWorkingMemoryCapacity,
+  });
+  return runtimeCoordinator;
 }

--- a/packages/core/src/runtime/response-work-admission.test.ts
+++ b/packages/core/src/runtime/response-work-admission.test.ts
@@ -2,6 +2,42 @@ import { describe, expect, it } from "vitest";
 import { createResponseWorkAdmission } from "./response-work-admission.js";
 
 describe("response work admission", () => {
+  it("uses the current safe capacity on every acquire", () => {
+    let capacity = 60;
+    const admission = createResponseWorkAdmission({
+      capacityBytes: 60,
+      dynamicCapacityBytes: () => capacity,
+      jsonAmplification: 2,
+      minChargeBytes: 6,
+    } as never);
+
+    const first = admission.acquire(10);
+    expect(first.ok).toBe(true);
+    capacity = 10;
+    expect(admission.acquire(1)).toMatchObject({ ok: false, reason: "busy" });
+    if (first.ok) first.lease.release();
+    capacity = 100;
+    expect(admission.acquire(30).ok).toBe(true);
+  });
+
+  it("always permits a lease to shrink when live capacity falls", () => {
+    let capacity = 100;
+    const admission = createResponseWorkAdmission({
+      capacityBytes: 100,
+      dynamicCapacityBytes: () => capacity,
+      jsonAmplification: 2,
+      minChargeBytes: 1,
+    });
+    const acquired = admission.acquire(40);
+    expect(acquired.ok).toBe(true);
+    if (!acquired.ok) return;
+
+    capacity = 30;
+    expect(acquired.lease.resize(20)).toEqual({ ok: true });
+    expect(admission.reservedBytes).toBe(40);
+    acquired.lease.release();
+  });
+
   it("shares one amplified byte budget and releases resized leases", () => {
     const admission = createResponseWorkAdmission({
       capacityBytes: 60,

--- a/packages/core/src/runtime/response-work-admission.ts
+++ b/packages/core/src/runtime/response-work-admission.ts
@@ -1,4 +1,9 @@
-import { runtimeMemoryBudget } from "./memory-budget.js";
+import {
+  type RuntimeMemoryCoordinator,
+  type RuntimeMemoryLease,
+  runtimeMemoryBudget,
+  runtimeMemoryCoordinator,
+} from "./memory-budget.js";
 
 export class ResponseWorkCapacityError extends Error {
   constructor(readonly capacityBytes: number) {
@@ -22,10 +27,14 @@ export interface ResponseWorkAdmission {
 
 export function createResponseWorkAdmission(options: {
   capacityBytes: number;
+  dynamicCapacityBytes?: () => number;
   jsonAmplification: number;
   minChargeBytes: number;
+  coordinator?: RuntimeMemoryCoordinator;
 }): ResponseWorkAdmission {
-  const capacityBytes = Math.max(1, Math.floor(options.capacityBytes));
+  const configuredCapacityBytes = Math.max(1, Math.floor(options.capacityBytes));
+  const capacityBytes = (): number =>
+    Math.max(0, Math.floor(options.dynamicCapacityBytes?.() ?? configuredCapacityBytes));
   const minChargeBytes = Math.max(1, Math.floor(options.minChargeBytes));
   let reservedBytes = 0;
   const charge = (wireBytes: number): number =>
@@ -34,9 +43,15 @@ export function createResponseWorkAdmission(options: {
   return {
     acquire(wireBytes) {
       let held = charge(wireBytes);
-      if (reservedBytes + held > capacityBytes) {
+      const shared = options.coordinator?.acquire(held);
+      if (shared !== undefined && !shared.ok) {
         return { ok: false as const, reason: "busy" as const };
       }
+      if (shared === undefined && reservedBytes + held > capacityBytes()) {
+        return { ok: false as const, reason: "busy" as const };
+      }
+      let sharedLease: RuntimeMemoryLease | undefined =
+        shared?.ok === true ? shared.lease : undefined;
       reservedBytes += held;
       let released = false;
       return {
@@ -45,7 +60,11 @@ export function createResponseWorkAdmission(options: {
           resize(nextWireBytes) {
             if (released) return { ok: false as const, reason: "busy" as const };
             const next = charge(nextWireBytes);
-            if (reservedBytes - held + next > capacityBytes) {
+            if (sharedLease !== undefined) {
+              if (!sharedLease.resize(next).ok) {
+                return { ok: false as const, reason: "busy" as const };
+              }
+            } else if (next > held && reservedBytes - held + next > capacityBytes()) {
               return { ok: false as const, reason: "busy" as const };
             }
             reservedBytes += next - held;
@@ -55,13 +74,15 @@ export function createResponseWorkAdmission(options: {
           release() {
             if (released) return;
             released = true;
+            sharedLease?.release();
+            sharedLease = undefined;
             reservedBytes -= held;
           },
         },
       };
     },
     get capacityBytes() {
-      return capacityBytes;
+      return capacityBytes();
     },
     get reservedBytes() {
       return reservedBytes;
@@ -78,6 +99,7 @@ export function runtimeResponseWorkAdmission(): ResponseWorkAdmission {
     capacityBytes: budget.responseWorkBytes,
     jsonAmplification: budget.jsonAmplification,
     minChargeBytes: budget.minRequestChargeBytes,
+    coordinator: runtimeMemoryCoordinator(),
   });
   return detected;
 }

--- a/packages/core/src/signals/scheduler.test.ts
+++ b/packages/core/src/signals/scheduler.test.ts
@@ -14,6 +14,57 @@ function fakeCollector(): SignalCollector & { calls: Array<[number, number]> } {
 }
 
 describe("startSignalScheduler", () => {
+  it("keeps the elapsed window pending while the resource gate is closed", async () => {
+    vi.useFakeTimers();
+    try {
+      const collector = fakeCollector();
+      let allowed = false;
+      let t = 100_000;
+      const handle = startSignalScheduler({
+        collector,
+        intervalMs: 1_000,
+        now: () => t,
+        shouldRun: async () => allowed,
+      });
+
+      t = 101_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(collector.calls).toEqual([]);
+      allowed = true;
+      t = 102_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(collector.calls).toEqual([[100_000, 102_000]]);
+      await handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds a recovered catch-up window", async () => {
+    vi.useFakeTimers();
+    try {
+      const collector = fakeCollector();
+      let allowed = false;
+      let t = 100_000;
+      const handle = startSignalScheduler({
+        collector,
+        intervalMs: 1_000,
+        maxCatchupWindowMs: 5_000,
+        now: () => t,
+        shouldRun: async () => allowed,
+      });
+
+      t = 200_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      allowed = true;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(collector.calls).toEqual([[100_000, 105_000]]);
+      await handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stop waits for an active collection before resolving", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/signals/scheduler.ts
+++ b/packages/core/src/signals/scheduler.ts
@@ -16,7 +16,9 @@ import type { SignalCollector } from "./collector.js";
 export interface SignalSchedulerDeps {
   collector: SignalCollector;
   intervalMs: number;
+  maxCatchupWindowMs?: number;
   now: () => number; // epoch ms; injectable for tests
+  shouldRun?: () => boolean | Promise<boolean>;
   log?: (level: "warn" | "info", msg: string, fields?: Record<string, unknown>) => void;
 }
 
@@ -28,6 +30,10 @@ export interface SignalSchedulerHandle {
 
 export function startSignalScheduler(deps: SignalSchedulerDeps): SignalSchedulerHandle {
   const log = deps.log ?? (() => {});
+  const maxCatchupWindowMs = Math.max(
+    deps.intervalMs,
+    deps.maxCatchupWindowMs ?? deps.intervalMs * 5,
+  );
   let prevTick = deps.now();
   let retryWindow: [number, number] | null = null;
   let inFlight = false;
@@ -36,14 +42,20 @@ export function startSignalScheduler(deps: SignalSchedulerDeps): SignalScheduler
 
   const timer = setInterval(() => {
     if (paused || inFlight) return;
-    const [windowStart, windowEnd] = retryWindow ?? [prevTick, deps.now()];
     inFlight = true;
-    // Fire-and-forget; collect() is fail-open in normal operation, but the scheduler
-    // still treats ok:false or a rejection as a non-advanced window so telemetry is
-    // retried instead of skipped permanently.
-    void deps.collector
-      .collect(windowStart, windowEnd)
+    let windowStart = prevTick;
+    let windowEnd = prevTick;
+    void Promise.resolve()
+      .then(async () => {
+        if (deps.shouldRun !== undefined && (await deps.shouldRun()) === false) return null;
+        [windowStart, windowEnd] = retryWindow ?? [
+          prevTick,
+          Math.min(deps.now(), prevTick + maxCatchupWindowMs),
+        ];
+        return deps.collector.collect(windowStart, windowEnd);
+      })
       .then((res) => {
+        if (res === null) return;
         if (res.ok) {
           retryWindow = null;
           prevTick = windowEnd;
@@ -53,7 +65,7 @@ export function startSignalScheduler(deps: SignalSchedulerDeps): SignalScheduler
         log("warn", "signals.scheduler_tick_failed", { windowStart, windowEnd });
       })
       .catch((err: unknown) => {
-        retryWindow = [windowStart, windowEnd];
+        if (windowEnd !== prevTick) retryWindow = [windowStart, windowEnd];
         log("warn", "signals.scheduler_tick_failed", {
           windowStart,
           windowEnd,

--- a/packages/core/src/store/payload-codec.test.ts
+++ b/packages/core/src/store/payload-codec.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { decodePayloadValue, encodePayloadText } from "./payload-codec.js";
+import {
+  decodePayloadTextChunks,
+  decodePayloadValue,
+  encodePayloadText,
+  encodePayloadTextChunks,
+  PAYLOAD_TEXT_CHUNK_RAW_BYTES,
+} from "./payload-codec.js";
 
 describe("payload-codec", () => {
   it("gzip round-trips arbitrary unicode text", () => {
@@ -28,5 +34,43 @@ describe("payload-codec", () => {
 
   it("treats a truncated gzip BLOB as unavailable instead of throwing", () => {
     expect(decodePayloadValue(Buffer.from([0x1f, 0x8b, 0x08]))).toBeNull();
+  });
+
+  it("splits at the raw-byte boundary and round-trips unicode across chunks", () => {
+    const text = `${"a".repeat(PAYLOAD_TEXT_CHUNK_RAW_BYTES - 1)}🌍世界`;
+    const chunks = encodePayloadTextChunks(text);
+    expect(chunks.map((chunk) => chunk.chunkIndex)).toEqual([0, 1]);
+    expect(chunks[0]?.rawBytes).toBe(PAYLOAD_TEXT_CHUNK_RAW_BYTES - 1);
+    expect(chunks[1]?.rawBytes).toBe(Buffer.byteLength("🌍世界", "utf8"));
+    expect(chunks.every((chunk) => chunk.rawBytes <= PAYLOAD_TEXT_CHUNK_RAW_BYTES)).toBe(true);
+    expect(chunks.every((chunk) => chunk.bytes.length <= chunk.rawBytes)).toBe(true);
+    expect(decodePayloadTextChunks(chunks)).toBe(text);
+  });
+
+  it("stores an empty string as one valid zero-byte chunk", () => {
+    const chunks = encodePayloadTextChunks("");
+    expect(chunks).toEqual([expect.objectContaining({ chunkIndex: 0, codec: "raw", rawBytes: 0 })]);
+    expect(chunks[0]?.bytes).toHaveLength(0);
+    expect(decodePayloadTextChunks(chunks)).toBe("");
+  });
+
+  it("rejects missing, duplicate, reordered, oversized, and corrupt chunks", () => {
+    const [first, second] = encodePayloadTextChunks(
+      `${"x".repeat(PAYLOAD_TEXT_CHUNK_RAW_BYTES)}tail`,
+    );
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    if (!first || !second) throw new Error("expected two chunks");
+
+    expect(decodePayloadTextChunks([second])).toBeNull();
+    expect(decodePayloadTextChunks([first, first])).toBeNull();
+    expect(decodePayloadTextChunks([second, first])).toBeNull();
+    expect(
+      decodePayloadTextChunks([{ ...first, rawBytes: PAYLOAD_TEXT_CHUNK_RAW_BYTES + 1 }]),
+    ).toBeNull();
+    expect(
+      decodePayloadTextChunks([{ ...first, bytes: Buffer.from([0x1f, 0x8b, 0x08]) }]),
+    ).toBeNull();
+    expect(decodePayloadTextChunks([{ ...first, rawBytes: first.rawBytes - 1 }])).toBeNull();
   });
 });

--- a/packages/core/src/store/payload-codec.ts
+++ b/packages/core/src/store/payload-codec.ts
@@ -12,6 +12,14 @@ import { gunzipSync, gzipSync } from "node:zlib";
 
 const GZIP_MAGIC_0 = 0x1f;
 const GZIP_MAGIC_1 = 0x8b;
+export const PAYLOAD_TEXT_CHUNK_RAW_BYTES = 256 * 1024;
+
+export interface PayloadTextChunk {
+  chunkIndex: number;
+  codec: "gzip" | "raw";
+  rawBytes: number;
+  bytes: Buffer;
+}
 
 export function encodePayloadText(text: string): Buffer {
   return gzipSync(Buffer.from(text, "utf8"));
@@ -31,4 +39,70 @@ export function decodePayloadValue(value: unknown): string | null {
     }
   }
   return buf.toString("utf8"); // defensive: raw bytes stored without gzip
+}
+
+export function* iteratePayloadTextChunks(text: string): Generator<PayloadTextChunk> {
+  const encoder = new TextEncoder();
+  const rawBuffer = new Uint8Array(PAYLOAD_TEXT_CHUNK_RAW_BYTES);
+  let charOffset = 0;
+  let chunkIndex = 0;
+  do {
+    let windowEnd = Math.min(text.length, charOffset + PAYLOAD_TEXT_CHUNK_RAW_BYTES);
+    const lastCodeUnit = text.charCodeAt(windowEnd - 1);
+    const nextCodeUnit = text.charCodeAt(windowEnd);
+    if (
+      windowEnd < text.length &&
+      lastCodeUnit >= 0xd800 &&
+      lastCodeUnit <= 0xdbff &&
+      nextCodeUnit >= 0xdc00 &&
+      nextCodeUnit <= 0xdfff
+    ) {
+      windowEnd += 1;
+    }
+    const window = text.slice(charOffset, windowEnd);
+    const { read, written } = encoder.encodeInto(window, rawBuffer);
+    if (text.length > 0 && read === 0) throw new Error("unable to encode payload text chunk");
+    const raw = Buffer.from(rawBuffer.subarray(0, written));
+    const compressed = gzipSync(raw);
+    yield compressed.length < raw.length
+      ? { chunkIndex, codec: "gzip", rawBytes: raw.length, bytes: compressed }
+      : { chunkIndex, codec: "raw", rawBytes: raw.length, bytes: raw };
+    charOffset += read;
+    chunkIndex += 1;
+  } while (charOffset < text.length);
+}
+
+export function encodePayloadTextChunks(text: string): PayloadTextChunk[] {
+  return [...iteratePayloadTextChunks(text)];
+}
+
+export function decodePayloadTextChunks(
+  chunks: readonly Pick<PayloadTextChunk, "chunkIndex" | "codec" | "rawBytes" | "bytes">[],
+): string | null {
+  if (chunks.length === 0) return null;
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  const decoded: string[] = [];
+  try {
+    for (const [index, chunk] of chunks.entries()) {
+      if (
+        chunk.chunkIndex !== index ||
+        !Number.isSafeInteger(chunk.rawBytes) ||
+        chunk.rawBytes < 0 ||
+        chunk.rawBytes > PAYLOAD_TEXT_CHUNK_RAW_BYTES ||
+        (chunk.codec !== "gzip" && chunk.codec !== "raw") ||
+        chunk.bytes.length > chunk.rawBytes
+      ) {
+        return null;
+      }
+      const raw =
+        chunk.codec === "gzip"
+          ? gunzipSync(chunk.bytes, { maxOutputLength: PAYLOAD_TEXT_CHUNK_RAW_BYTES + 1 })
+          : Buffer.from(chunk.bytes);
+      if (raw.length !== chunk.rawBytes) return null;
+      decoded.push(decoder.decode(raw, { stream: index < chunks.length - 1 }));
+    }
+    return decoded.join("");
+  } catch {
+    return null;
+  }
 }

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -361,6 +361,16 @@ export interface UpsertSessionRevisionInput {
   responseJson: string | null;
   fidelity: string;
   createdAt: Date;
+  eventHead?: Omit<SessionEventHead, "requestId">;
+}
+
+export type SessionEventKey = "messages" | "contents" | "input";
+
+export interface SessionEventHead {
+  requestId: string;
+  eventKey: SessionEventKey;
+  eventCount: number;
+  eventHash: string;
 }
 
 export interface SessionRecord {
@@ -374,6 +384,7 @@ export interface SessionRecord {
   headRequestId: string | null;
   revisionCount: number;
   storedBytes: number;
+  eventHead: SessionEventHead | null;
 }
 
 // Persistent per-Session revision quota. This bounds retained revision count;
@@ -393,6 +404,17 @@ export interface SessionRevisionRecord {
   requestEnvelopeJson: string;
   responseId: string | null;
   responseJson: string | null;
+  fidelity: string;
+  createdAt: Date;
+}
+
+export interface SessionContinuationRecord {
+  requestId: string;
+  responseBodyStored: boolean;
+}
+
+export interface SessionRevisionMetaRecord extends SessionContinuationRecord {
+  sessionRef: string;
   fidelity: string;
   createdAt: Date;
 }
@@ -581,10 +603,11 @@ export interface TelemetryStore {
     sessionRef: string,
     options: SessionRevisionPageOptions,
   ): Promise<SessionRevisionPage>;
-  getSessionRevisionByResponseId?(
+  findSessionRequestIdByResponseId?(
     sessionRef: string,
     responseId: string,
-  ): Promise<SessionRevisionRecord | null>;
+  ): Promise<SessionContinuationRecord | null>;
+  getSessionRevisionMeta?(requestId: string): Promise<SessionRevisionMetaRecord | null>;
   // Deletes whole sessions whose last activity is strictly older than the cutoff;
   // revisions follow through their FK, so no orphan transcript rows survive.
   pruneInactiveSessions?(olderThanMs: number): Promise<number>;

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -135,11 +135,29 @@ describe("runPgMigrations — per-migration atomicity", () => {
         "retain_count",
         "request_delta_json",
         "request_envelope_json",
+        "body_bytes",
+        "request_body_generation",
+        "response_body_generation",
         "response_id",
         "response_json",
         "fidelity",
       ]),
     );
+    const sessionStorageTables = (await db.execute(
+      sql.raw(`
+        SELECT table_name
+          FROM information_schema.tables
+         WHERE table_name IN (
+           'session_head_event_hashes',
+           'session_revision_body_chunks'
+         )
+         ORDER BY table_name
+      `),
+    )) as { rows: Array<{ table_name: string }> };
+    expect(sessionStorageTables.rows.map((row) => row.table_name)).toEqual([
+      "session_head_event_hashes",
+      "session_revision_body_chunks",
+    ]);
     await db.execute(
       sql.raw(`
         INSERT INTO sessions
@@ -157,6 +175,35 @@ describe("runPgMigrations — per-migration atomicity", () => {
         `),
       ),
     ).rejects.toThrow();
+    await db.execute(
+      sql.raw(`
+        INSERT INTO session_revisions
+          (request_id, session_ref, sequence, retain_count, request_delta_json,
+           request_envelope_json, fidelity, created_at)
+        VALUES ('r-valid', 's-check', 1, 0, '[]', '{}', 'semantic', 1)
+      `),
+    );
+    await db.execute(
+      sql.raw(`
+        INSERT INTO session_revision_body_chunks
+          (request_id, generation, part, chunk_index, codec, raw_bytes, bytes, created_at)
+        VALUES ('r-valid', 'g1', 'request_delta', 0, 'raw', 2, decode('7b7d', 'hex'), 1)
+      `),
+    );
+    await expect(
+      db.execute(
+        sql.raw(`
+          INSERT INTO session_revision_body_chunks
+            (request_id, generation, part, chunk_index, codec, raw_bytes, bytes, created_at)
+          VALUES ('r-valid', 'g1', 'invalid', 1, 'raw', 2, decode('7b7d', 'hex'), 1)
+        `),
+      ),
+    ).rejects.toThrow();
+    await db.execute(sql.raw("DELETE FROM session_revisions WHERE request_id = 'r-valid'"));
+    const chunkCount = (await db.execute(
+      sql.raw("SELECT COUNT(*)::int AS count FROM session_revision_body_chunks"),
+    )) as { rows: Array<{ count: number }> };
+    expect(chunkCount.rows[0]?.count).toBe(1);
     await db.$close();
   });
 
@@ -340,6 +387,97 @@ describe("runPgMigrations — per-migration atomicity", () => {
       sql.raw("SELECT request_content_mode FROM api_keys WHERE key_id = 'legacy'"),
     )) as { rows: Array<{ request_content_mode: string | null }> };
     expect(row.rows[0]?.request_content_mode).toBeNull();
+    await db.$close();
+  });
+
+  it("v44 adds empty chunk tables without scanning legacy Session bodies", async () => {
+    const client = new PGlite();
+    const db = Object.assign(drizzlePglite(client), { $close: () => client.close() });
+    await db.execute(
+      sql.raw("CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at BIGINT NOT NULL)"),
+    );
+    await db.execute(
+      sql.raw(`
+        CREATE TABLE sessions (
+          session_ref TEXT PRIMARY KEY,
+          account_id TEXT NOT NULL,
+          api_key_id TEXT NOT NULL,
+          source TEXT NOT NULL,
+          external_session_id TEXT NOT NULL,
+          head_request_id TEXT,
+          revision_count INTEGER NOT NULL DEFAULT 0,
+          stored_bytes BIGINT NOT NULL DEFAULT 0,
+          created_at BIGINT NOT NULL,
+          last_seen_at BIGINT NOT NULL
+        )
+      `),
+    );
+    await db.execute(
+      sql.raw(`
+        CREATE TABLE session_revisions (
+          request_id TEXT PRIMARY KEY,
+          session_ref TEXT NOT NULL REFERENCES sessions(session_ref) ON DELETE CASCADE,
+          sequence INTEGER NOT NULL,
+          parent_request_id TEXT,
+          retain_count INTEGER NOT NULL,
+          request_delta_json TEXT NOT NULL,
+          request_envelope_json TEXT NOT NULL,
+          response_id TEXT,
+          response_json TEXT,
+          fidelity TEXT NOT NULL,
+          created_at BIGINT NOT NULL
+        )
+      `),
+    );
+    await db.execute(
+      sql.raw(`
+        INSERT INTO sessions
+          (session_ref, account_id, api_key_id, source, external_session_id, created_at, last_seen_at)
+        VALUES ('s1', 'a1', 'k1', 'test', 'external', 1, 1)
+      `),
+    );
+    await db.execute(
+      sql.raw(`
+        INSERT INTO session_revisions
+          (request_id, session_ref, sequence, retain_count, request_delta_json,
+           request_envelope_json, response_json, fidelity, created_at)
+        VALUES ('r1', 's1', 1, 0, '["legacy"]', '{"model":"x"}', '{"ok":true}', 'semantic', 1)
+      `),
+    );
+    for (let version = 1; version <= 43; version++) {
+      await db.execute(
+        sql.raw(`INSERT INTO _migrations (version, applied_at) VALUES (${version}, 1000)`),
+      );
+    }
+
+    await expect(runPgMigrations(db)).resolves.toBeUndefined();
+
+    const legacy = (await db.execute(
+      sql.raw(`
+        SELECT request_delta_json, request_envelope_json, response_json, body_bytes
+        FROM session_revisions WHERE request_id = 'r1'
+      `),
+    )) as {
+      rows: Array<{
+        request_delta_json: string;
+        request_envelope_json: string;
+        response_json: string;
+        body_bytes: number | null;
+      }>;
+    };
+    expect(legacy.rows[0]).toEqual({
+      request_delta_json: '["legacy"]',
+      request_envelope_json: '{"model":"x"}',
+      response_json: '{"ok":true}',
+      body_bytes: null,
+    });
+    const counts = (await db.execute(
+      sql.raw(`
+        SELECT
+          (SELECT COUNT(*)::int FROM session_revision_body_chunks) AS chunks
+      `),
+    )) as { rows: Array<{ chunks: number }> };
+    expect(counts.rows[0]).toEqual({ chunks: 0 });
     await db.$close();
   });
 

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1203,6 +1203,40 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Additive Session chunk storage. Legacy bodies stay where they are and are
+    // never scanned or backfilled during deployment.
+    version: 44,
+    run: async (db) => {
+      if (!(await pgTableHasColumns(db, "session_revisions", ["request_id"]))) return;
+      const ddl = `
+        ALTER TABLE session_revisions ADD COLUMN IF NOT EXISTS body_bytes BIGINT;
+        ALTER TABLE session_revisions ADD COLUMN IF NOT EXISTS request_body_generation TEXT;
+        ALTER TABLE session_revisions ADD COLUMN IF NOT EXISTS response_body_generation TEXT;
+        CREATE TABLE IF NOT EXISTS session_head_event_hashes (
+          session_ref TEXT PRIMARY KEY REFERENCES sessions(session_ref) ON DELETE CASCADE,
+          request_id TEXT NOT NULL,
+          event_key TEXT NOT NULL CHECK (event_key IN ('messages', 'contents', 'input')),
+          event_count INTEGER NOT NULL CHECK (event_count >= 0),
+          event_hash TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS session_revision_body_chunks (
+          request_id TEXT NOT NULL,
+          generation TEXT NOT NULL,
+          part TEXT NOT NULL CHECK (part IN ('request_delta', 'request_envelope', 'response')),
+          chunk_index INTEGER NOT NULL CHECK (chunk_index >= 0),
+          codec TEXT NOT NULL CHECK (codec IN ('gzip', 'raw')),
+          raw_bytes INTEGER NOT NULL CHECK (raw_bytes >= 0 AND raw_bytes <= 262144),
+          bytes BYTEA NOT NULL,
+          created_at BIGINT NOT NULL,
+          PRIMARY KEY (request_id, generation, part, chunk_index)
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_revision_body_chunks_created
+          ON session_revision_body_chunks (created_at);
+      `;
+      for (const statement of splitStatements(ddl)) await db.execute(sql.raw(statement));
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {
@@ -1222,6 +1256,7 @@ async function pgTableHasColumns(
     | "memory_facts"
     | "memory_jobs"
     | "oauth_quota"
+    | "session_revisions"
     | "telemetry",
   requiredColumns: readonly string[],
 ): Promise<boolean> {

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -129,6 +129,9 @@ export const sessionRevisions = pgTable(
     retainCount: integer("retain_count").notNull(),
     requestDeltaJson: text("request_delta_json").notNull(),
     requestEnvelopeJson: text("request_envelope_json").notNull(),
+    bodyBytes: bigint("body_bytes", { mode: "number" }),
+    requestBodyGeneration: text("request_body_generation"),
+    responseBodyGeneration: text("response_body_generation"),
     responseId: text("response_id"),
     responseJson: text("response_json"),
     fidelity: text("fidelity").notNull(),
@@ -138,6 +141,34 @@ export const sessionRevisions = pgTable(
     uniqueIndex("uniq_session_revisions_sequence").on(t.sessionRef, t.sequence),
     uniqueIndex("uniq_session_revisions_response").on(t.sessionRef, t.responseId),
     index("idx_session_revisions_session_created").on(t.sessionRef, t.createdAt),
+  ],
+);
+
+export const sessionHeadEventHashes = pgTable("session_head_event_hashes", {
+  sessionRef: text("session_ref")
+    .primaryKey()
+    .references(() => sessions.sessionRef, { onDelete: "cascade" }),
+  requestId: text("request_id").notNull(),
+  eventKey: text("event_key").notNull(),
+  eventCount: integer("event_count").notNull(),
+  eventHash: text("event_hash").notNull(),
+});
+
+export const sessionRevisionBodyChunks = pgTable(
+  "session_revision_body_chunks",
+  {
+    requestId: text("request_id").notNull(),
+    generation: text("generation").notNull(),
+    part: text("part").$type<"request_delta" | "request_envelope" | "response">().notNull(),
+    chunkIndex: integer("chunk_index").notNull(),
+    codec: text("codec").$type<"gzip" | "raw">().notNull(),
+    rawBytes: integer("raw_bytes").notNull(),
+    bytes: bytea("bytes").notNull(),
+    createdAt: bigint("created_at", { mode: "number" }).notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.requestId, t.generation, t.part, t.chunkIndex] }),
+    index("idx_session_revision_body_chunks_created").on(t.createdAt),
   ],
 );
 

--- a/packages/core/src/store/postgres/telemetry.test.ts
+++ b/packages/core/src/store/postgres/telemetry.test.ts
@@ -51,4 +51,39 @@ describe("PgTelemetryStore", () => {
     );
     await db.$close();
   });
+
+  it("continues a large Session prune across bounded cleanup ticks", async () => {
+    const db = await createPgliteDb();
+    const store = new PgTelemetryStore(db);
+    await store.upsertSessionRevision({
+      sessionRef: "s-prune",
+      accountId: "a1",
+      apiKeyId: "k1",
+      source: "header",
+      externalSessionId: "external-prune",
+      requestId: "r-prune",
+      parentRequestId: null,
+      retainCount: 0,
+      requestDeltaJson: "[]",
+      requestEnvelopeJson: "{}",
+      responseId: null,
+      responseJson: null,
+      fidelity: "semantic",
+      createdAt: new Date(1_000),
+    });
+    await db.execute(
+      sql.raw(`
+      INSERT INTO session_revision_body_chunks
+        (request_id, generation, part, chunk_index, codec, raw_bytes, bytes, created_at)
+      SELECT 'r-prune', 'orphan', 'request_delta', value, 'raw', 1, decode('78', 'hex'), 1
+      FROM generate_series(0, 129) AS value
+    `),
+    );
+
+    await expect(store.pruneInactiveSessions(2_000)).resolves.toBe(0);
+    expect(await store.getSessionByRef("s-prune")).not.toBeNull();
+    await expect(store.pruneInactiveSessions(2_000)).resolves.toBe(1);
+    expect(await store.getSessionByRef("s-prune")).toBeNull();
+    await db.$close();
+  });
 });

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -3,6 +3,7 @@ import { type DecisionRecord, DecisionRecordSchema } from "@helm/shared";
 import { and, asc, count, desc, eq, gt, gte, inArray, lt, type SQL, sql } from "drizzle-orm";
 import { shapeTelemetryAggregate, shapeTelemetryKeyUsage } from "../aggregate-shape.js";
 import { externalizeImages, type PayloadBlob, rehydrateImages } from "../payload-blobs.js";
+import { decodePayloadTextChunks, iteratePayloadTextChunks } from "../payload-codec.js";
 import type {
   InsertPayloadInput,
   InsertTelemetryInput,
@@ -12,7 +13,10 @@ import type {
   RequestPayloadMeta,
   RequestPayloadPart,
   RequestPayloadPartRecord,
+  SessionContinuationRecord,
+  SessionEventHead,
   SessionRecord,
+  SessionRevisionMetaRecord,
   SessionRevisionPage,
   SessionRevisionPageOptions,
   SessionRevisionRecord,
@@ -28,7 +32,15 @@ import { PERSISTED_SESSION_MAX_REVISIONS } from "../ports.js";
 import { likeContains } from "../sql-like.js";
 import { denormalizedDecisionCost } from "../telemetry-cost.js";
 import type { PgDb } from "./migrate.js";
-import { payloadBlobs, requestPayloads, sessionRevisions, sessions, telemetry } from "./schema.js";
+import {
+  payloadBlobs,
+  requestPayloads,
+  sessionHeadEventHashes,
+  sessionRevisionBodyChunks,
+  sessionRevisions,
+  sessions,
+  telemetry,
+} from "./schema.js";
 
 // Sentinel left in the slimmed text by externalizeImages; we scan for these to
 // know which blobs a stored payload references, so we can pre-fetch them before
@@ -42,6 +54,82 @@ const BLOB_SHA_RE = /helm-blob:sha256:([0-9a-f]{64})/g;
 type PgWriter = Pick<PgDb, "insert">;
 
 type TelemetryRow = typeof telemetry.$inferSelect;
+type SessionRevisionRow = typeof sessionRevisions.$inferSelect;
+type SessionBodyChunkRow = typeof sessionRevisionBodyChunks.$inferSelect;
+type SessionBodyChunkInsert = typeof sessionRevisionBodyChunks.$inferInsert;
+type SessionBodyPart = "request_delta" | "request_envelope" | "response";
+const SESSION_CHUNKS_PER_WRITE = 4;
+const SESSION_PRUNE_MARKER = "__helm_pruning__";
+const PG_PRUNE_BATCH_ROWS = 16;
+const PG_PRUNE_TICK_ROWS = 128;
+const ORPHAN_CHUNK_TTL_MS = 86_400_000;
+
+function resultRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown }).rows;
+    if (Array.isArray(rows)) return rows as T[];
+  }
+  return [];
+}
+
+function* sessionBodyRows(
+  input: UpsertSessionRevisionInput,
+  parts: readonly SessionBodyPart[],
+  generation: string,
+): Generator<SessionBodyChunkInsert> {
+  const text = {
+    request_delta: input.requestDeltaJson,
+    request_envelope: input.requestEnvelopeJson,
+    response: input.responseJson,
+  } as const;
+  for (const part of parts) {
+    const value = text[part];
+    if (value === null) continue;
+    for (const chunk of iteratePayloadTextChunks(value)) {
+      yield {
+        requestId: input.requestId,
+        generation,
+        part,
+        chunkIndex: chunk.chunkIndex,
+        codec: chunk.codec,
+        rawBytes: chunk.rawBytes,
+        bytes: chunk.bytes,
+        createdAt: input.createdAt.getTime(),
+      };
+    }
+  }
+}
+
+function decodeSessionRevisionRow(
+  row: SessionRevisionRow,
+  chunks: readonly SessionBodyChunkRow[] = [],
+): SessionRevisionRecord {
+  const { bodyBytes: _, requestBodyGeneration: __, responseBodyGeneration: ___, ...revision } = row;
+  const body = (part: SessionBodyPart): string | null => {
+    const selected = chunks
+      .filter(
+        (chunk) =>
+          chunk.part === part &&
+          chunk.generation ===
+            (part === "response" ? row.responseBodyGeneration : row.requestBodyGeneration),
+      )
+      .sort((left, right) => left.chunkIndex - right.chunkIndex);
+    return selected.length === 0 ? null : decodePayloadTextChunks(selected);
+  };
+  const chunkedDelta = body("request_delta");
+  const chunkedEnvelope = body("request_envelope");
+  const chunkedResponse = body("response");
+  return {
+    ...revision,
+    requestDeltaJson:
+      row.requestBodyGeneration === null ? row.requestDeltaJson : (chunkedDelta ?? ""),
+    requestEnvelopeJson:
+      row.requestBodyGeneration === null ? row.requestEnvelopeJson : (chunkedEnvelope ?? ""),
+    responseJson: row.responseBodyGeneration === null ? row.responseJson : chunkedResponse,
+    createdAt: new Date(row.createdAt),
+  };
+}
 
 function boundedSessionPageLimit(options: SessionRevisionPageOptions): number {
   if (!Number.isSafeInteger(options.limit) || options.limit <= 0)
@@ -66,6 +154,56 @@ export class PgTelemetryStore implements TelemetryStore {
     private readonly db: PgDb,
     private readonly genId: () => string = randomUUID,
   ) {}
+
+  private async stageSessionBodyChunks(
+    input: UpsertSessionRevisionInput,
+    parts: readonly SessionBodyPart[],
+  ): Promise<string> {
+    const generation = this.genId();
+    const batch: SessionBodyChunkInsert[] = [];
+    for (const row of sessionBodyRows(input, parts, generation)) {
+      batch.push(row);
+      if (batch.length < SESSION_CHUNKS_PER_WRITE) continue;
+      await this.db.insert(sessionRevisionBodyChunks).values(batch).onConflictDoNothing();
+      batch.length = 0;
+    }
+    if (batch.length > 0)
+      await this.db.insert(sessionRevisionBodyChunks).values(batch).onConflictDoNothing();
+    return generation;
+  }
+
+  private async chunksByRevisions(
+    rows: readonly SessionRevisionRow[],
+  ): Promise<Map<string, SessionBodyChunkRow[]>> {
+    const grouped = new Map<string, SessionBodyChunkRow[]>();
+    const requestIds = rows.map((row) => row.requestId);
+    const generations = rows.flatMap((row) =>
+      [row.requestBodyGeneration, row.responseBodyGeneration].filter(
+        (generation): generation is string => generation !== null,
+      ),
+    );
+    if (requestIds.length === 0 || generations.length === 0) return grouped;
+    const chunks = await this.db
+      .select()
+      .from(sessionRevisionBodyChunks)
+      .where(
+        and(
+          inArray(sessionRevisionBodyChunks.requestId, requestIds),
+          inArray(sessionRevisionBodyChunks.generation, generations),
+        ),
+      )
+      .orderBy(
+        asc(sessionRevisionBodyChunks.requestId),
+        asc(sessionRevisionBodyChunks.part),
+        asc(sessionRevisionBodyChunks.chunkIndex),
+      );
+    for (const row of chunks) {
+      const existing = grouped.get(row.requestId) ?? [];
+      existing.push(row);
+      grouped.set(row.requestId, existing);
+    }
+    return grouped;
+  }
 
   // Build one telemetry row (fresh id + denormalized status/cost). Shared by the
   // single and batch inserts so they can never drift. jsonb stored natively.
@@ -113,105 +251,167 @@ export class PgTelemetryStore implements TelemetryStore {
       input.requestDeltaJson + input.requestEnvelopeJson + (input.responseJson ?? ""),
       "utf8",
     );
-    await this.db.transaction(async (tx) => {
-      await tx
-        .insert(sessions)
-        .values({
-          sessionRef: input.sessionRef,
-          accountId: input.accountId,
-          apiKeyId: input.apiKeyId,
-          source: input.source,
-          externalSessionId: input.externalSessionId,
-          createdAt: at,
-          lastSeenAt: at,
-        })
-        .onConflictDoNothing();
-
-      const lockedSessions = await tx
-        .select({ revisionCount: sessions.revisionCount })
+    let resumedAfterPrune = false;
+    for (;;) {
+      const existingSession = await this.db
+        .select({ headRequestId: sessions.headRequestId })
         .from(sessions)
         .where(eq(sessions.sessionRef, input.sessionRef))
-        .limit(1)
-        .for("update");
-      const lockedSession = lockedSessions[0];
-      if (!lockedSession) throw new Error("session row missing after insert");
-
-      const existing = await tx
+        .limit(1);
+      if (existingSession[0]?.headRequestId === SESSION_PRUNE_MARKER) {
+        await this.finishClaimedSessionPrune(input.sessionRef, Number.MAX_SAFE_INTEGER);
+        resumedAfterPrune = true;
+        continue;
+      }
+      const before = await this.db
         .select({
-          requestId: sessionRevisions.requestId,
           sessionRef: sessionRevisions.sessionRef,
-          responseJson: sessionRevisions.responseJson,
+          responseBodyStored: sql<boolean>`${sessionRevisions.responseJson} IS NOT NULL`,
         })
         .from(sessionRevisions)
         .where(eq(sessionRevisions.requestId, input.requestId))
         .limit(1);
-      if (existing.length > 0) {
-        if (existing[0]?.sessionRef !== input.sessionRef)
-          throw new Error("request session mismatch");
-        const responseBytes =
-          input.responseJson !== null && existing[0]?.responseJson === null
-            ? Buffer.byteLength(input.responseJson, "utf8")
-            : 0;
-        if (responseBytes === 0) return;
+      if (before[0]?.sessionRef !== undefined && before[0].sessionRef !== input.sessionRef)
+        throw new Error("request session mismatch");
+      if (before[0]?.responseBodyStored || (before[0] && input.responseJson === null)) return;
+      const generation = await this.stageSessionBodyChunks(
+        input,
+        before[0]
+          ? ["response"]
+          : input.responseJson === null
+            ? ["request_delta", "request_envelope"]
+            : ["request_delta", "request_envelope", "response"],
+      );
+      const admitted = await this.db.transaction(async (tx) => {
         await tx
+          .insert(sessions)
+          .values({
+            sessionRef: input.sessionRef,
+            accountId: input.accountId,
+            apiKeyId: input.apiKeyId,
+            source: input.source,
+            externalSessionId: input.externalSessionId,
+            createdAt: at,
+            lastSeenAt: at,
+          })
+          .onConflictDoNothing();
+        const lockedSession = (
+          await tx
+            .select({
+              revisionCount: sessions.revisionCount,
+              headRequestId: sessions.headRequestId,
+            })
+            .from(sessions)
+            .where(eq(sessions.sessionRef, input.sessionRef))
+            .limit(1)
+            .for("update")
+        )[0];
+        if (!lockedSession) throw new Error("session row missing after insert");
+        if (lockedSession.headRequestId === SESSION_PRUNE_MARKER) return false;
+
+        const existing = await tx
+          .select({
+            requestId: sessionRevisions.requestId,
+            sessionRef: sessionRevisions.sessionRef,
+            responseBodyStored: sql<boolean>`${sessionRevisions.responseJson} IS NOT NULL`,
+          })
+          .from(sessionRevisions)
+          .where(eq(sessionRevisions.requestId, input.requestId))
+          .limit(1);
+        if (existing.length > 0) {
+          if (existing[0]?.sessionRef !== input.sessionRef)
+            throw new Error("request session mismatch");
+          const responseBytes =
+            input.responseJson !== null && !existing[0]?.responseBodyStored
+              ? Buffer.byteLength(input.responseJson, "utf8")
+              : 0;
+          if (responseBytes === 0) return true;
+          await tx
+            .update(sessions)
+            .set({
+              storedBytes: sql`${sessions.storedBytes} + ${responseBytes}`,
+              lastSeenAt: sql`GREATEST(${sessions.lastSeenAt}, ${at})`,
+            })
+            .where(eq(sessions.sessionRef, input.sessionRef));
+          await tx
+            .update(sessionRevisions)
+            .set({
+              responseId: input.responseId ?? null,
+              responseJson: "",
+              bodyBytes: storedBytes,
+              responseBodyGeneration: generation,
+              fidelity: input.fidelity,
+            })
+            .where(eq(sessionRevisions.requestId, input.requestId));
+          return true;
+        }
+
+        const parentRequestId = resumedAfterPrune ? null : input.parentRequestId;
+        if (parentRequestId !== null) {
+          const parent = await tx
+            .select({ sessionRef: sessionRevisions.sessionRef })
+            .from(sessionRevisions)
+            .where(eq(sessionRevisions.requestId, parentRequestId))
+            .limit(1);
+          if (!parent[0] || parent[0].sessionRef !== input.sessionRef)
+            throw new Error("session parent mismatch");
+        }
+        const updated = await tx
           .update(sessions)
           .set({
-            storedBytes: sql`${sessions.storedBytes} + ${responseBytes}`,
+            headRequestId: input.requestId,
+            revisionCount: sql`${sessions.revisionCount} + 1`,
+            storedBytes: sql`${sessions.storedBytes} + ${storedBytes}`,
             lastSeenAt: sql`GREATEST(${sessions.lastSeenAt}, ${at})`,
           })
-          .where(eq(sessions.sessionRef, input.sessionRef));
-        await tx
-          .update(sessionRevisions)
-          .set({
-            responseId: input.responseId ?? null,
-            responseJson: input.responseJson,
-            fidelity: input.fidelity,
-          })
-          .where(eq(sessionRevisions.requestId, input.requestId));
-        return;
-      }
-
-      if (input.parentRequestId !== null) {
-        const parent = await tx
-          .select({ sessionRef: sessionRevisions.sessionRef })
-          .from(sessionRevisions)
-          .where(eq(sessionRevisions.requestId, input.parentRequestId))
-          .limit(1);
-        if (!parent[0] || parent[0].sessionRef !== input.sessionRef)
-          throw new Error("session parent mismatch");
-      }
-
-      const updated = await tx
-        .update(sessions)
-        .set({
-          headRequestId: input.requestId,
-          revisionCount: sql`${sessions.revisionCount} + 1`,
-          storedBytes: sql`${sessions.storedBytes} + ${storedBytes}`,
-          lastSeenAt: sql`GREATEST(${sessions.lastSeenAt}, ${at})`,
-        })
-        .where(
-          and(
-            eq(sessions.sessionRef, input.sessionRef),
-            lt(sessions.revisionCount, PERSISTED_SESSION_MAX_REVISIONS),
-          ),
-        )
-        .returning();
-      const sequence = updated[0]?.revisionCount;
-      if (sequence === undefined) throw new Error("session row missing after insert");
-      await tx.insert(sessionRevisions).values({
-        requestId: input.requestId,
-        sessionRef: input.sessionRef,
-        sequence,
-        parentRequestId: input.parentRequestId,
-        retainCount: input.retainCount,
-        requestDeltaJson: input.requestDeltaJson,
-        requestEnvelopeJson: input.requestEnvelopeJson,
-        responseId: input.responseId ?? null,
-        responseJson: input.responseJson,
-        fidelity: input.fidelity,
-        createdAt: at,
+          .where(
+            and(
+              eq(sessions.sessionRef, input.sessionRef),
+              lt(sessions.revisionCount, PERSISTED_SESSION_MAX_REVISIONS),
+            ),
+          )
+          .returning();
+        const sequence = updated[0]?.revisionCount;
+        if (sequence === undefined) throw new Error("session row missing after insert");
+        await tx.insert(sessionRevisions).values({
+          requestId: input.requestId,
+          sessionRef: input.sessionRef,
+          sequence,
+          parentRequestId,
+          retainCount: input.retainCount,
+          requestDeltaJson: "",
+          requestEnvelopeJson: "",
+          bodyBytes: storedBytes,
+          requestBodyGeneration: generation,
+          responseBodyGeneration: input.responseJson === null ? null : generation,
+          responseId: input.responseId ?? null,
+          responseJson: input.responseJson === null ? null : "",
+          fidelity: input.fidelity,
+          createdAt: at,
+        });
+        if (input.eventHead) {
+          await tx
+            .insert(sessionHeadEventHashes)
+            .values({
+              sessionRef: input.sessionRef,
+              requestId: input.requestId,
+              ...input.eventHead,
+            })
+            .onConflictDoUpdate({
+              target: sessionHeadEventHashes.sessionRef,
+              set: { requestId: input.requestId, ...input.eventHead },
+            });
+        } else {
+          await tx
+            .delete(sessionHeadEventHashes)
+            .where(eq(sessionHeadEventHashes.sessionRef, input.sessionRef));
+        }
+        return true;
       });
-    });
+      if (admitted) return;
+      await this.finishClaimedSessionPrune(input.sessionRef, Number.MAX_SAFE_INTEGER);
+      resumedAfterPrune = true;
+    }
   }
 
   async getSessionByRef(sessionRef: string): Promise<SessionRecord | null> {
@@ -221,6 +421,14 @@ export class PgTelemetryStore implements TelemetryStore {
       .where(eq(sessions.sessionRef, sessionRef))
       .limit(1);
     const row = rows[0];
+    const heads = row
+      ? await this.db
+          .select()
+          .from(sessionHeadEventHashes)
+          .where(eq(sessionHeadEventHashes.sessionRef, sessionRef))
+          .limit(1)
+      : [];
+    const head = heads[0];
     return row
       ? {
           sessionRef: row.sessionRef,
@@ -233,6 +441,15 @@ export class PgTelemetryStore implements TelemetryStore {
           headRequestId: row.headRequestId,
           revisionCount: row.revisionCount,
           storedBytes: row.storedBytes,
+          eventHead:
+            head && head.requestId === row.headRequestId
+              ? {
+                  requestId: head.requestId,
+                  eventKey: head.eventKey as SessionEventHead["eventKey"],
+                  eventCount: head.eventCount,
+                  eventHash: head.eventHash,
+                }
+              : null,
         }
       : null;
   }
@@ -254,6 +471,7 @@ export class PgTelemetryStore implements TelemetryStore {
       headRequestId: row.headRequestId,
       revisionCount: row.revisionCount,
       storedBytes: row.storedBytes,
+      eventHead: null,
     }));
   }
 
@@ -263,10 +481,8 @@ export class PgTelemetryStore implements TelemetryStore {
       .from(sessionRevisions)
       .where(eq(sessionRevisions.sessionRef, sessionRef))
       .orderBy(asc(sessionRevisions.sequence));
-    return rows.map((row) => ({
-      ...row,
-      createdAt: new Date(row.createdAt),
-    }));
+    const chunks = await this.chunksByRevisions(rows);
+    return rows.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId)));
   }
 
   async listSessionRevisionsPage(
@@ -279,10 +495,13 @@ export class PgTelemetryStore implements TelemetryStore {
       octet_length(${sessionRevisions.sessionRef}) +
       octet_length(${sessionRevisions.requestId}) +
       octet_length(coalesce(${sessionRevisions.parentRequestId}, '')) +
-      octet_length(${sessionRevisions.requestDeltaJson}) +
-      octet_length(${sessionRevisions.requestEnvelopeJson}) +
+      coalesce(
+        ${sessionRevisions.bodyBytes},
+        octet_length(${sessionRevisions.requestDeltaJson}) +
+        octet_length(${sessionRevisions.requestEnvelopeJson}) +
+        octet_length(coalesce(${sessionRevisions.responseJson}, ''))
+      ) +
       octet_length(coalesce(${sessionRevisions.responseId}, '')) +
-      octet_length(coalesce(${sessionRevisions.responseJson}, '')) +
       octet_length(${sessionRevisions.fidelity}) + 64
     `;
     const metadata = await this.db
@@ -317,19 +536,23 @@ export class PgTelemetryStore implements TelemetryStore {
         ),
       )
       .orderBy(asc(sessionRevisions.sequence));
+    const chunks = await this.chunksByRevisions(rows);
     return {
-      revisions: rows.map((row) => ({ ...row, createdAt: new Date(row.createdAt) })),
+      revisions: rows.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId))),
       nextSequence: metadata.length > selected.length ? (selected.at(-1) ?? null) : null,
       limited: false,
     };
   }
 
-  async getSessionRevisionByResponseId(
+  async findSessionRequestIdByResponseId(
     sessionRef: string,
     responseId: string,
-  ): Promise<SessionRevisionRecord | null> {
+  ): Promise<SessionContinuationRecord | null> {
     const rows = await this.db
-      .select()
+      .select({
+        requestId: sessionRevisions.requestId,
+        responseBodyStored: sql<boolean>`${sessionRevisions.responseJson} IS NOT NULL`,
+      })
       .from(sessionRevisions)
       .where(
         and(
@@ -339,15 +562,144 @@ export class PgTelemetryStore implements TelemetryStore {
       )
       .limit(1);
     const row = rows[0];
+    return row ?? null;
+  }
+
+  async getSessionRevisionMeta(requestId: string): Promise<SessionRevisionMetaRecord | null> {
+    const rows = await this.db
+      .select({
+        requestId: sessionRevisions.requestId,
+        sessionRef: sessionRevisions.sessionRef,
+        responseBodyStored: sql<boolean>`${sessionRevisions.responseJson} IS NOT NULL`,
+        fidelity: sessionRevisions.fidelity,
+        createdAt: sessionRevisions.createdAt,
+      })
+      .from(sessionRevisions)
+      .where(eq(sessionRevisions.requestId, requestId))
+      .limit(1);
+    const row = rows[0];
     return row ? { ...row, createdAt: new Date(row.createdAt) } : null;
   }
 
+  private async finishClaimedSessionPrune(
+    sessionRef: string,
+    maxRows: number,
+  ): Promise<{ workRows: number; deletedSession: number }> {
+    let workRows = 0;
+    while (workRows < maxRows) {
+      const limit = Math.min(PG_PRUNE_BATCH_ROWS, maxRows - workRows);
+      const deletedChunks = resultRows(
+        await this.db.execute(sql`
+          WITH doomed AS (
+            SELECT chunks.ctid
+            FROM session_revision_body_chunks AS chunks
+            JOIN session_revisions AS revisions ON revisions.request_id = chunks.request_id
+            WHERE revisions.session_ref = ${sessionRef}
+            ORDER BY revisions.sequence, chunks.part, chunks.chunk_index
+            LIMIT ${limit}
+            FOR UPDATE OF chunks SKIP LOCKED
+          )
+          DELETE FROM session_revision_body_chunks AS chunks
+          USING doomed WHERE chunks.ctid = doomed.ctid
+          RETURNING 1
+        `),
+      ).length;
+      workRows += deletedChunks;
+      if (deletedChunks === limit) continue;
+      const remaining = Math.min(PG_PRUNE_BATCH_ROWS, maxRows - workRows);
+      if (remaining <= 0) break;
+      const deletedRevisions = resultRows(
+        await this.db.execute(sql`
+          WITH doomed AS (
+            SELECT revisions.request_id
+            FROM session_revisions AS revisions
+            WHERE revisions.session_ref = ${sessionRef}
+              AND NOT EXISTS (
+                SELECT 1 FROM session_revision_body_chunks AS chunks
+                WHERE chunks.request_id = revisions.request_id
+              )
+            ORDER BY revisions.sequence, revisions.request_id
+            LIMIT ${remaining}
+            FOR UPDATE OF revisions SKIP LOCKED
+          )
+          DELETE FROM session_revisions AS revisions
+          USING doomed WHERE revisions.request_id = doomed.request_id
+          RETURNING 1
+        `),
+      ).length;
+      workRows += deletedRevisions;
+      if (deletedChunks === 0 && deletedRevisions === 0) break;
+    }
+    if (workRows >= maxRows) return { workRows, deletedSession: 0 };
+    const deletedSession = resultRows(
+      await this.db.execute(sql`
+        DELETE FROM sessions
+        WHERE session_ref = ${sessionRef}
+          AND head_request_id = ${SESSION_PRUNE_MARKER}
+          AND NOT EXISTS (
+            SELECT 1 FROM session_revisions
+            WHERE session_revisions.session_ref = sessions.session_ref
+          )
+        RETURNING 1
+      `),
+    ).length;
+    return { workRows, deletedSession };
+  }
+
   async pruneInactiveSessions(olderThanMs: number): Promise<number> {
-    const rows = await this.db
-      .delete(sessions)
-      .where(lt(sessions.lastSeenAt, olderThanMs))
-      .returning();
-    return rows.length;
+    let budget = PG_PRUNE_TICK_ROWS;
+    let deletedSessions = 0;
+    while (budget > 0) {
+      const sessionRef = await this.db.transaction(async (tx) => {
+        const candidates = await tx.execute(sql`
+          SELECT session_ref
+          FROM sessions
+          WHERE last_seen_at < ${olderThanMs}
+          ORDER BY CASE WHEN head_request_id = ${SESSION_PRUNE_MARKER} THEN 0 ELSE 1 END,
+                   last_seen_at, session_ref
+          LIMIT 1
+          FOR UPDATE SKIP LOCKED
+        `);
+        const candidate = resultRows<{ session_ref: string }>(candidates)[0]?.session_ref;
+        if (!candidate) return null;
+        await tx.execute(sql`
+          UPDATE sessions SET head_request_id = ${SESSION_PRUNE_MARKER}
+          WHERE session_ref = ${candidate} AND last_seen_at < ${olderThanMs}
+        `);
+        return candidate;
+      });
+      if (!sessionRef) break;
+      const result = await this.finishClaimedSessionPrune(sessionRef, budget);
+      budget -= result.workRows;
+      deletedSessions += result.deletedSession;
+      if (result.workRows === 0 && result.deletedSession === 0) break;
+    }
+    if (budget > 0) {
+      const limit = Math.min(PG_PRUNE_BATCH_ROWS, budget);
+      await this.db.execute(sql`
+        WITH doomed AS (
+          SELECT chunks.ctid
+          FROM session_revision_body_chunks AS chunks
+          WHERE chunks.created_at < ${Date.now() - ORPHAN_CHUNK_TTL_MS}
+            AND NOT EXISTS (
+              SELECT 1 FROM session_revisions AS revisions
+              WHERE revisions.request_id = chunks.request_id
+                AND (
+                  (chunks.part = 'response' AND revisions.response_body_generation = chunks.generation)
+                  OR
+                  (chunks.part <> 'response' AND revisions.request_body_generation = chunks.generation)
+                )
+            )
+          ORDER BY chunks.created_at, chunks.request_id, chunks.generation,
+                   chunks.part, chunks.chunk_index
+          LIMIT ${limit}
+          FOR UPDATE OF chunks SKIP LOCKED
+        )
+        DELETE FROM session_revision_body_chunks AS chunks
+        USING doomed WHERE chunks.ctid = doomed.ctid
+      `);
+    }
+    return deletedSessions;
   }
 
   async queryRecent(limit: number): Promise<RecentDecisionRecord[]> {

--- a/packages/core/src/store/session-delta.test.ts
+++ b/packages/core/src/store/session-delta.test.ts
@@ -12,7 +12,11 @@ describe("session request delta", () => {
     );
     const second = splitSessionRequestJson(
       '{"model":"x","messages":[{"role":"user","content":"one"},{"role":"assistant","content":"two"}]}',
-      first.eventsJson,
+      {
+        eventKey: first.eventKey,
+        eventCount: first.eventCount,
+        eventHash: first.eventHash,
+      },
     );
     expect(second).toMatchObject({ eventKey: "messages", retainCount: 1 });
     expect(second.eventsJson).toBe('[{"role":"assistant","content":"two"}]');
@@ -26,10 +30,29 @@ describe("session request delta", () => {
     );
   });
 
+  it("falls back to a full delta when the persisted head hash is not a prefix", () => {
+    const first = splitSessionRequestJson('{"messages":["one","two"]}');
+    const changed = splitSessionRequestJson('{"messages":["changed","two","three"]}', {
+      eventKey: first.eventKey,
+      eventCount: first.eventCount,
+      eventHash: first.eventHash,
+    });
+    expect(changed).toMatchObject({
+      retainCount: 0,
+      eventCount: 3,
+      eventsJson: '["changed","two","three"]',
+    });
+  });
+
   it("restores a branch from its explicit parent rather than its newest sibling", () => {
     const root = splitSessionRequestJson('{"messages":["one"]}');
-    const left = splitSessionRequestJson('{"messages":["one","left"]}', root.eventsJson);
-    const right = splitSessionRequestJson('{"messages":["one","right"]}', root.eventsJson);
+    const head = {
+      eventKey: root.eventKey,
+      eventCount: root.eventCount,
+      eventHash: root.eventHash,
+    };
+    const left = splitSessionRequestJson('{"messages":["one","left"]}', head);
+    const right = splitSessionRequestJson('{"messages":["one","right"]}', head);
     expect(
       restoreSessionRevisionJson(
         [
@@ -63,7 +86,7 @@ describe("session request delta", () => {
   it("does not inherit input before a previous_response_id baseline", () => {
     const delta = splitSessionRequestJson(
       '{"previous_response_id":"resp_1","input":[{"role":"user","content":"next"}]}',
-      '[{"role":"user","content":"old"}]',
+      { eventKey: "input", eventCount: 1, eventHash: "ignored-for-continuation" },
     );
     expect(delta).toMatchObject({
       eventKey: "input",
@@ -78,7 +101,7 @@ describe("session request delta", () => {
     );
     const child = splitSessionRequestJson(
       '{"model":"gpt-5","previous_response_id":"resp_1","input":[{"role":"user","content":"two"}]}',
-      root.eventsJson,
+      { eventKey: root.eventKey, eventCount: root.eventCount, eventHash: root.eventHash },
     );
     expect(
       restoreSessionRevisionJson(

--- a/packages/core/src/store/session-delta.ts
+++ b/packages/core/src/store/session-delta.ts
@@ -1,4 +1,5 @@
-import { isDeepStrictEqual } from "node:util";
+import { createHash } from "node:crypto";
+import type { SessionEventHead } from "./ports.js";
 
 export interface SessionRequestDelta {
   eventKey: "messages" | "contents" | "input";
@@ -7,6 +8,8 @@ export interface SessionRequestDelta {
   envelopeJson: string;
   fidelity: "verbatim" | "semantic";
   previousResponseId: string | null;
+  eventCount: number;
+  eventHash: string;
 }
 
 const EVENT_KEYS = ["messages", "contents", "input"] as const;
@@ -27,18 +30,22 @@ function array(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [value];
 }
 
-function prefixLength(previous: unknown[], current: unknown[]): number {
-  let n = 0;
-  while (n < previous.length && n < current.length && isDeepStrictEqual(previous[n], current[n]))
-    n++;
-  return n;
+function hashEvents(events: readonly unknown[], count = events.length): string {
+  const hash = createHash("sha256");
+  hash.update("[");
+  for (let index = 0; index < count; index++) {
+    if (index > 0) hash.update(",");
+    hash.update(JSON.stringify(events[index]) ?? "null");
+  }
+  hash.update("]");
+  return hash.digest("hex");
 }
 
 // Split only the client event carrier; every other request field remains in the
 // envelope. This deliberately preserves semantics rather than original whitespace.
 export function splitSessionRequestJson(
   requestJson: string,
-  previousEventsJson?: string,
+  previousHead?: Omit<SessionEventHead, "requestId">,
 ): SessionRequestDelta {
   const request = record(JSON.parse(requestJson));
   const key = eventKey(request);
@@ -46,8 +53,14 @@ export function splitSessionRequestJson(
   const hasPreviousResponse =
     typeof request.previous_response_id === "string" && request.previous_response_id.trim() !== "";
   const previousResponseId = hasPreviousResponse ? (request.previous_response_id as string) : null;
-  const previous = previousEventsJson === undefined ? [] : array(JSON.parse(previousEventsJson));
-  const retainCount = hasPreviousResponse ? 0 : prefixLength(previous, current);
+  const retainCount =
+    !hasPreviousResponse &&
+    previousHead !== undefined &&
+    previousHead.eventKey === key &&
+    previousHead.eventCount <= current.length &&
+    hashEvents(current, previousHead.eventCount) === previousHead.eventHash
+      ? previousHead.eventCount
+      : 0;
   // Keep the carrier with an empty array so recovery can identify its protocol
   // shape without another column (and without a reserved JSON metadata field).
   const envelope = { ...request, [key]: [] };
@@ -58,6 +71,8 @@ export function splitSessionRequestJson(
     envelopeJson: JSON.stringify(envelope),
     fidelity: "semantic",
     previousResponseId,
+    eventCount: current.length,
+    eventHash: hashEvents(current),
   };
 }
 

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1251,6 +1251,38 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // New Session bodies are staged as bounded chunks. Existing rows remain in
+    // their legacy columns and are decoded lazily; no startup scan or backfill.
+    version: 45,
+    run: (db) => {
+      if (!sqliteTableHasColumns(db, "session_revisions", ["request_id"])) return;
+      db.exec(`
+      CREATE TABLE IF NOT EXISTS session_head_event_hashes (
+        session_ref TEXT PRIMARY KEY REFERENCES sessions(session_ref) ON DELETE CASCADE,
+        request_id TEXT NOT NULL,
+        event_key TEXT NOT NULL CHECK (event_key IN ('messages', 'contents', 'input')),
+        event_count INTEGER NOT NULL CHECK (event_count >= 0),
+        event_hash TEXT NOT NULL
+      );
+      ALTER TABLE session_revisions ADD COLUMN request_body_generation TEXT;
+      ALTER TABLE session_revisions ADD COLUMN response_body_generation TEXT;
+      CREATE TABLE IF NOT EXISTS session_revision_body_chunks (
+        request_id TEXT NOT NULL,
+        generation TEXT NOT NULL,
+        part TEXT NOT NULL CHECK (part IN ('request_delta', 'request_envelope', 'response')),
+        chunk_index INTEGER NOT NULL CHECK (chunk_index >= 0),
+        codec TEXT NOT NULL CHECK (codec IN ('gzip', 'raw')),
+        raw_bytes INTEGER NOT NULL CHECK (raw_bytes >= 0 AND raw_bytes <= 262144),
+        bytes BLOB NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (request_id, generation, part, chunk_index)
+      );
+      CREATE INDEX IF NOT EXISTS idx_session_revision_body_chunks_created
+        ON session_revision_body_chunks (created_at);
+      `);
+    },
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -144,6 +144,10 @@ describe("sqlite schema + migrations", () => {
       .prepare("PRAGMA table_info(session_revisions)")
       .all()
       .map((c) => (c as { name: string }).name);
+    const tables = raw
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .all()
+      .map((row) => (row as { name: string }).name);
 
     for (const c of [
       "key_id",
@@ -192,12 +196,16 @@ describe("sqlite schema + migrations", () => {
       "request_delta_json",
       "request_envelope_json",
       "body_bytes",
+      "request_body_generation",
+      "response_body_generation",
       "response_id",
       "response_json",
       "fidelity",
     ]) {
       expect(sessionRevisionCols).toContain(c);
     }
+    expect(tables).toContain("session_head_event_hashes");
+    expect(tables).toContain("session_revision_body_chunks");
     const telemetryIndexes = raw
       .prepare("PRAGMA index_list(telemetry)")
       .all()
@@ -218,10 +226,26 @@ describe("sqlite schema + migrations", () => {
     expect(() => insertRevision.run("r-valid", 1, 0)).not.toThrow();
     expect(() => insertRevision.run("r-negative", 2, -1)).toThrow();
     expect(() => insertRevision.run("r-fractional", 2, 1.5)).toThrow();
+    raw
+      .prepare(
+        "INSERT INTO session_revision_body_chunks (request_id, generation, part, chunk_index, codec, raw_bytes, bytes, created_at) VALUES ('r-valid', 'g1', 'request_delta', 0, 'raw', 2, x'7b7d', 1)",
+      )
+      .run();
+    expect(() =>
+      raw
+        .prepare(
+          "INSERT INTO session_revision_body_chunks (request_id, generation, part, chunk_index, codec, raw_bytes, bytes, created_at) VALUES ('r-valid', 'g1', 'invalid', 1, 'raw', 2, x'7b7d', 1)",
+        )
+        .run(),
+    ).toThrow();
+    raw.prepare("DELETE FROM session_revisions WHERE request_id = 'r-valid'").run();
+    expect(raw.prepare("SELECT COUNT(*) AS count FROM session_revision_body_chunks").get()).toEqual(
+      { count: 1 },
+    );
     raw.close();
   });
 
-  it("v42 adds Session body-byte metadata without scanning old bodies", () => {
+  it("v45 adds empty Session chunk storage without scanning old bodies", () => {
     const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v42-session-bytes-"));
     const path = join(dir, "helm.db");
     try {
@@ -290,6 +314,80 @@ describe("sqlite schema + migrations", () => {
         .prepare("SELECT request_content_mode FROM api_keys WHERE key_id = 'legacy'")
         .get() as { request_content_mode: string | null };
       expect(row.request_content_mode).toBeNull();
+      after.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("v45 adds empty chunk tables without touching legacy Session bodies", () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v45-session-chunks-"));
+    const path = join(dir, "helm.db");
+    try {
+      const seed = new Database(path);
+      seed.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE _migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);
+        CREATE TABLE sessions (
+          session_ref TEXT PRIMARY KEY,
+          account_id TEXT NOT NULL,
+          api_key_id TEXT NOT NULL,
+          source TEXT NOT NULL,
+          external_session_id TEXT NOT NULL,
+          head_request_id TEXT,
+          revision_count INTEGER NOT NULL DEFAULT 0,
+          stored_bytes INTEGER NOT NULL DEFAULT 0,
+          created_at INTEGER NOT NULL,
+          last_seen_at INTEGER NOT NULL
+        );
+        CREATE TABLE session_revisions (
+          request_id TEXT PRIMARY KEY,
+          session_ref TEXT NOT NULL REFERENCES sessions(session_ref) ON DELETE CASCADE,
+          sequence INTEGER NOT NULL,
+          parent_request_id TEXT,
+          retain_count INTEGER NOT NULL,
+          request_delta_json TEXT NOT NULL,
+          request_envelope_json TEXT NOT NULL,
+          body_bytes INTEGER,
+          response_id TEXT,
+          response_json TEXT,
+          fidelity TEXT NOT NULL,
+          created_at INTEGER NOT NULL
+        );
+        INSERT INTO sessions
+          (session_ref, account_id, api_key_id, source, external_session_id, created_at, last_seen_at)
+        VALUES ('s1', 'a1', 'k1', 'test', 'external', 1, 1);
+        INSERT INTO session_revisions
+          (request_id, session_ref, sequence, retain_count, request_delta_json,
+           request_envelope_json, response_json, fidelity, created_at)
+        VALUES ('r1', 's1', 1, 0, '["legacy"]', '{"model":"x"}', '{"ok":true}', 'semantic', 1);
+        CREATE TRIGGER forbid_legacy_session_update
+          BEFORE UPDATE ON session_revisions BEGIN SELECT RAISE(ABORT, 'legacy row touched'); END;
+        CREATE TRIGGER forbid_legacy_session_delete
+          BEFORE DELETE ON session_revisions BEGIN SELECT RAISE(ABORT, 'legacy row touched'); END;
+      `);
+      const record = seed.prepare("INSERT INTO _migrations (version, applied_at) VALUES (?, ?)");
+      for (let version = 1; version <= 44; version++) record.run(version, 1);
+      seed.close();
+
+      expect(() => runMigrations(path)).not.toThrow();
+
+      const after = new Database(path);
+      expect(
+        after
+          .prepare(
+            "SELECT request_delta_json, request_envelope_json, response_json, body_bytes FROM session_revisions WHERE request_id = 'r1'",
+          )
+          .get(),
+      ).toEqual({
+        request_delta_json: '["legacy"]',
+        request_envelope_json: '{"model":"x"}',
+        response_json: '{"ok":true}',
+        body_bytes: null,
+      });
+      expect(
+        after.prepare("SELECT COUNT(*) AS count FROM session_revision_body_chunks").get(),
+      ).toEqual({ count: 0 });
       after.close();
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -119,6 +119,8 @@ export const sessionRevisions = sqliteTable(
     requestDeltaJson: text("request_delta_json").notNull(),
     requestEnvelopeJson: text("request_envelope_json").notNull(),
     bodyBytes: integer("body_bytes"),
+    requestBodyGeneration: text("request_body_generation"),
+    responseBodyGeneration: text("response_body_generation"),
     responseId: text("response_id"),
     responseJson: text("response_json"),
     fidelity: text("fidelity").notNull(),
@@ -128,6 +130,34 @@ export const sessionRevisions = sqliteTable(
     uniqueIndex("uniq_session_revisions_sequence").on(t.sessionRef, t.sequence),
     uniqueIndex("uniq_session_revisions_response").on(t.sessionRef, t.responseId),
     index("idx_session_revisions_session_created").on(t.sessionRef, t.createdAt),
+  ],
+);
+
+export const sessionHeadEventHashes = sqliteTable("session_head_event_hashes", {
+  sessionRef: text("session_ref")
+    .primaryKey()
+    .references(() => sessions.sessionRef, { onDelete: "cascade" }),
+  requestId: text("request_id").notNull(),
+  eventKey: text("event_key").notNull(),
+  eventCount: integer("event_count").notNull(),
+  eventHash: text("event_hash").notNull(),
+});
+
+export const sessionRevisionBodyChunks = sqliteTable(
+  "session_revision_body_chunks",
+  {
+    requestId: text("request_id").notNull(),
+    generation: text("generation").notNull(),
+    part: text("part").$type<"request_delta" | "request_envelope" | "response">().notNull(),
+    chunkIndex: integer("chunk_index").notNull(),
+    codec: text("codec").$type<"gzip" | "raw">().notNull(),
+    rawBytes: integer("raw_bytes").notNull(),
+    bytes: blob("bytes").$type<Buffer>().notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.requestId, t.generation, t.part, t.chunkIndex] }),
+    index("idx_session_revision_body_chunks_created").on(t.createdAt),
   ],
 );
 

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -110,7 +110,7 @@ describe("SqliteTelemetryStore", () => {
     db.$sqlite.close();
   });
 
-  it("stores session bodies as gzip BLOBs and still reads legacy TEXT", async () => {
+  it("stores new session bodies in bounded chunks and still reads legacy TEXT", async () => {
     const db = createSqliteDb(":memory:");
     const store = new SqliteTelemetryStore(db);
     const requestDeltaJson = JSON.stringify(["event ".repeat(2_000)]);
@@ -145,13 +145,24 @@ describe("SqliteTelemetryStore", () => {
              FROM session_revisions WHERE request_id = 'r1'`,
         )
         .get(),
-    ).toEqual({ delta: "blob", envelope: "blob", response: "blob" });
+    ).toEqual({ delta: "text", envelope: "text", response: "text" });
+    const chunks = db.$sqlite
+      .prepare(
+        "SELECT part, chunk_index AS chunkIndex, codec, raw_bytes AS rawBytes, length(bytes) AS storedBytes FROM session_revision_body_chunks WHERE request_id = 'r1' ORDER BY part, chunk_index",
+      )
+      .all() as Array<{
+      part: string;
+      chunkIndex: number;
+      codec: string;
+      rawBytes: number;
+      storedBytes: number;
+    }>;
+    expect(chunks.length).toBeGreaterThanOrEqual(3);
+    expect(chunks.every((chunk) => chunk.rawBytes <= 256 * 1024)).toBe(true);
+    expect(chunks.every((chunk) => chunk.storedBytes <= chunk.rawBytes)).toBe(true);
     expect(await store.listSessionRevisions("s1")).toEqual([
       expect.objectContaining({ requestDeltaJson, requestEnvelopeJson, responseJson }),
     ]);
-    expect(await store.getSessionRevisionByResponseId("s1", "resp_1")).toEqual(
-      expect.objectContaining({ requestDeltaJson, requestEnvelopeJson, responseJson }),
-    );
     expect((await store.getSessionByRef("s1"))?.storedBytes).toBe(
       Buffer.byteLength(requestDeltaJson + requestEnvelopeJson + responseJson, "utf8"),
     );
@@ -166,9 +177,30 @@ describe("SqliteTelemetryStore", () => {
       limited: false,
     });
 
+    db.$sqlite
+      .prepare(
+        `UPDATE session_revisions
+            SET request_delta_json = x'1f8b00',
+                request_envelope_json = x'1f8b00',
+                response_json = x'1f8b00'
+          WHERE request_id = 'r1'`,
+      )
+      .run();
+    await expect(store.findSessionRequestIdByResponseId("s1", "resp_1")).resolves.toEqual({
+      requestId: "r1",
+      responseBodyStored: true,
+    });
+
     const legacy = '["legacy text"]';
     db.$sqlite
-      .prepare("UPDATE session_revisions SET request_delta_json = ? WHERE request_id = 'r1'")
+      .prepare(
+        "DELETE FROM session_revision_body_chunks WHERE request_id = 'r1' AND part = 'request_delta'",
+      )
+      .run();
+    db.$sqlite
+      .prepare(
+        "UPDATE session_revisions SET request_delta_json = ?, request_body_generation = NULL WHERE request_id = 'r1'",
+      )
       .run(legacy);
     expect((await store.listSessionRevisions("s1"))[0]?.requestDeltaJson).toBe(legacy);
     db.$sqlite.close();
@@ -243,6 +275,62 @@ describe("SqliteTelemetryStore", () => {
       nextSequence: null,
       limited: false,
     });
+    db.$sqlite.close();
+  });
+
+  it("accounts the full logical size when a legacy Session response is backfilled", async () => {
+    const db = createSqliteDb(":memory:");
+    const store = new SqliteTelemetryStore(db);
+    const requestDeltaJson = '["legacy"]';
+    const requestEnvelopeJson = '{"model":"x"}';
+    const responseJson = JSON.stringify({ output: "x".repeat(300_000) });
+    db.$sqlite
+      .prepare(
+        "INSERT INTO sessions (session_ref, account_id, api_key_id, source, external_session_id, head_request_id, revision_count, stored_bytes, created_at, last_seen_at) VALUES ('legacy', 'a1', 'k1', 'header', 'external', 'r1', 1, ?, 1, 1)",
+      )
+      .run(Buffer.byteLength(requestDeltaJson + requestEnvelopeJson, "utf8"));
+    db.$sqlite
+      .prepare(
+        "INSERT INTO session_revisions (request_id, session_ref, sequence, retain_count, request_delta_json, request_envelope_json, response_json, fidelity, created_at) VALUES ('r1', 'legacy', 1, 0, ?, ?, NULL, 'semantic', 1)",
+      )
+      .run(requestDeltaJson, requestEnvelopeJson);
+
+    await store.upsertSessionRevision({
+      sessionRef: "legacy",
+      accountId: "a1",
+      apiKeyId: "k1",
+      source: "header",
+      externalSessionId: "external",
+      requestId: "r1",
+      parentRequestId: null,
+      retainCount: 0,
+      requestDeltaJson,
+      requestEnvelopeJson,
+      responseId: "resp_1",
+      responseJson,
+      fidelity: "semantic",
+      createdAt: new Date(2),
+    });
+
+    const expectedBytes = Buffer.byteLength(
+      requestDeltaJson + requestEnvelopeJson + responseJson,
+      "utf8",
+    );
+    expect(
+      db.$sqlite
+        .prepare(
+          "SELECT body_bytes AS bodyBytes, request_body_generation AS requestGeneration, response_body_generation AS responseGeneration FROM session_revisions WHERE request_id = 'r1'",
+        )
+        .get(),
+    ).toEqual({
+      bodyBytes: expectedBytes,
+      requestGeneration: null,
+      responseGeneration: expect.any(String),
+    });
+    await expect(
+      store.listSessionRevisionsPage("legacy", { limit: 1, maxBytes: expectedBytes - 1 }),
+    ).resolves.toEqual({ revisions: [], nextSequence: null, limited: true });
+    expect((await store.listSessionRevisions("legacy"))[0]?.responseJson).toBe(responseJson);
     db.$sqlite.close();
   });
 

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -3,7 +3,12 @@ import { type DecisionRecord, DecisionRecordSchema } from "@helm/shared";
 import { and, asc, count, desc, eq, gt, gte, inArray, lt, type SQL, sql } from "drizzle-orm";
 import { shapeTelemetryAggregate, shapeTelemetryKeyUsage } from "../aggregate-shape.js";
 import { externalizeImages, type PayloadBlob, rehydrateImages } from "../payload-blobs.js";
-import { decodePayloadValue, encodePayloadText } from "../payload-codec.js";
+import {
+  decodePayloadTextChunks,
+  decodePayloadValue,
+  encodePayloadText,
+  iteratePayloadTextChunks,
+} from "../payload-codec.js";
 import type {
   InsertPayloadInput,
   InsertTelemetryInput,
@@ -13,7 +18,10 @@ import type {
   RequestPayloadMeta,
   RequestPayloadPart,
   RequestPayloadPartRecord,
+  SessionContinuationRecord,
+  SessionEventHead,
   SessionRecord,
+  SessionRevisionMetaRecord,
   SessionRevisionPage,
   SessionRevisionPageOptions,
   SessionRevisionRecord,
@@ -30,20 +38,83 @@ import { likeContains } from "../sql-like.js";
 import { denormalizedDecisionCost } from "../telemetry-cost.js";
 import { runBatchedPrune, yieldToEventLoop } from "./batched-prune.js";
 import type { SqliteDb } from "./migrate.js";
-import { requestPayloads, sessionRevisions, sessions, telemetry } from "./schema.js";
+import {
+  requestPayloads,
+  sessionHeadEventHashes,
+  sessionRevisionBodyChunks,
+  sessionRevisions,
+  sessions,
+  telemetry,
+} from "./schema.js";
 
 type TelemetryRow = typeof telemetry.$inferSelect;
 type SessionRevisionRow = typeof sessionRevisions.$inferSelect;
+type SessionBodyChunkRow = typeof sessionRevisionBodyChunks.$inferSelect;
+type SessionBodyChunkInsert = typeof sessionRevisionBodyChunks.$inferInsert;
+type SessionBodyPart = "request_delta" | "request_envelope" | "response";
 const SESSION_PRUNE_MARKER = "__helm_pruning__";
+const SESSION_CHUNKS_PER_WRITE = 4;
 
-function decodeSessionRevisionRow(row: SessionRevisionRow): SessionRevisionRecord {
-  const { bodyBytes: _, ...revision } = row;
+function decodeSessionRevisionRow(
+  row: SessionRevisionRow,
+  chunks: readonly SessionBodyChunkRow[] = [],
+): SessionRevisionRecord {
+  const { bodyBytes: _, requestBodyGeneration: __, responseBodyGeneration: ___, ...revision } = row;
+  const body = (part: SessionBodyPart): string | null => {
+    const selected = chunks
+      .filter(
+        (chunk) =>
+          chunk.part === part &&
+          chunk.generation ===
+            (part === "response" ? row.responseBodyGeneration : row.requestBodyGeneration),
+      )
+      .sort((left, right) => left.chunkIndex - right.chunkIndex);
+    return selected.length === 0 ? null : decodePayloadTextChunks(selected);
+  };
+  const chunkedDelta = body("request_delta");
+  const chunkedEnvelope = body("request_envelope");
+  const chunkedResponse = body("response");
   return {
     ...revision,
-    requestDeltaJson: decodePayloadValue(row.requestDeltaJson) ?? "",
-    requestEnvelopeJson: decodePayloadValue(row.requestEnvelopeJson) ?? "",
-    responseJson: decodePayloadValue(row.responseJson),
+    requestDeltaJson:
+      row.requestBodyGeneration === null
+        ? (decodePayloadValue(row.requestDeltaJson) ?? "")
+        : (chunkedDelta ?? ""),
+    requestEnvelopeJson:
+      row.requestBodyGeneration === null
+        ? (decodePayloadValue(row.requestEnvelopeJson) ?? "")
+        : (chunkedEnvelope ?? ""),
+    responseJson:
+      row.responseBodyGeneration === null ? decodePayloadValue(row.responseJson) : chunkedResponse,
   };
+}
+
+function* sessionBodyRows(
+  input: UpsertSessionRevisionInput,
+  parts: readonly SessionBodyPart[],
+  generation: string,
+): Generator<SessionBodyChunkInsert> {
+  const text = {
+    request_delta: input.requestDeltaJson,
+    request_envelope: input.requestEnvelopeJson,
+    response: input.responseJson,
+  } as const;
+  for (const part of parts) {
+    const value = text[part];
+    if (value === null) continue;
+    for (const chunk of iteratePayloadTextChunks(value)) {
+      yield {
+        requestId: input.requestId,
+        generation,
+        part,
+        chunkIndex: chunk.chunkIndex,
+        codec: chunk.codec,
+        rawBytes: chunk.rawBytes,
+        bytes: chunk.bytes,
+        createdAt: input.createdAt.getTime(),
+      };
+    }
+  }
 }
 
 function boundedSessionPageLimit(options: SessionRevisionPageOptions): number {
@@ -75,16 +146,82 @@ export class SqliteTelemetryStore implements TelemetryStore {
     | undefined;
   private readonly sessionPrunes = new Map<string, Promise<number>>();
 
+  private async stageSessionBodyChunks(
+    input: UpsertSessionRevisionInput,
+    parts: readonly SessionBodyPart[],
+  ): Promise<string> {
+    const db = this.db.$sqlite;
+    const generation = this.genId();
+    const insert = db.prepare(`INSERT INTO session_revision_body_chunks
+      (request_id, generation, part, chunk_index, codec, raw_bytes, bytes, created_at)
+      VALUES (@requestId, @generation, @part, @chunkIndex, @codec, @rawBytes, @bytes, @createdAt)`);
+    const writeBatch = db.transaction((rows: readonly SessionBodyChunkInsert[]) => {
+      for (const row of rows) insert.run(row);
+    });
+    const batch: SessionBodyChunkInsert[] = [];
+    for (const row of sessionBodyRows(input, parts, generation)) {
+      batch.push(row);
+      if (batch.length < SESSION_CHUNKS_PER_WRITE) continue;
+      writeBatch(batch);
+      batch.length = 0;
+      await yieldToEventLoop();
+    }
+    if (batch.length > 0) writeBatch(batch);
+    return generation;
+  }
+
+  private chunksByRevisions(
+    rows: readonly SessionRevisionRow[],
+  ): Map<string, SessionBodyChunkRow[]> {
+    const grouped = new Map<string, SessionBodyChunkRow[]>();
+    const requestIds = rows.map((row) => row.requestId);
+    const generations = rows.flatMap((row) =>
+      [row.requestBodyGeneration, row.responseBodyGeneration].filter(
+        (generation): generation is string => generation !== null,
+      ),
+    );
+    if (requestIds.length === 0 || generations.length === 0) return grouped;
+    const chunks = this.db
+      .select()
+      .from(sessionRevisionBodyChunks)
+      .where(
+        and(
+          inArray(sessionRevisionBodyChunks.requestId, requestIds),
+          inArray(sessionRevisionBodyChunks.generation, generations),
+        ),
+      )
+      .orderBy(
+        asc(sessionRevisionBodyChunks.requestId),
+        asc(sessionRevisionBodyChunks.part),
+        asc(sessionRevisionBodyChunks.chunkIndex),
+      )
+      .all();
+    for (const row of chunks) {
+      const existing = grouped.get(row.requestId) ?? [];
+      existing.push(row);
+      grouped.set(row.requestId, existing);
+    }
+    return grouped;
+  }
+
   private async finishClaimedSessionPrune(sessionRef: string): Promise<number> {
     const active = this.sessionPrunes.get(sessionRef);
     if (active) return active;
     const db = this.db.$sqlite;
     const work = (async () => {
+      const chunks = db.prepare(`DELETE FROM session_revision_body_chunks WHERE request_id IN (
+          SELECT request_id FROM session_revisions WHERE session_ref = ?
+          ORDER BY sequence, request_id LIMIT ?
+        )`);
       const revisions = db.prepare(`DELETE FROM session_revisions WHERE request_id IN (
-        SELECT request_id FROM session_revisions WHERE session_ref = ?
-        ORDER BY sequence, request_id LIMIT ?
-      )`);
-      await runBatchedPrune((limit) => revisions.run(sessionRef, limit).changes);
+          SELECT request_id FROM session_revisions WHERE session_ref = ?
+          ORDER BY sequence, request_id LIMIT ?
+        )`);
+      const pruneBatch = db.transaction((limit: number) => {
+        chunks.run(sessionRef, limit);
+        return revisions.run(sessionRef, limit).changes;
+      });
+      await runBatchedPrune(pruneBatch);
       return db
         .prepare(
           "DELETE FROM sessions WHERE session_ref = ? AND head_request_id = ? AND NOT EXISTS (SELECT 1 FROM session_revisions WHERE session_ref = ?)",
@@ -119,22 +256,21 @@ export class SqliteTelemetryStore implements TelemetryStore {
       insert: db.prepare(
         `INSERT INTO session_revisions
            (request_id, session_ref, sequence, parent_request_id, retain_count,
-            request_delta_json, request_envelope_json, body_bytes, response_id, response_json,
-            fidelity, created_at)
+            request_delta_json, request_envelope_json, body_bytes,
+            request_body_generation, response_body_generation,
+            response_id, response_json, fidelity, created_at)
          VALUES
            (@requestId, @sessionRef, @sequence, @parentRequestId, @retainCount,
-            @requestDeltaJson, @requestEnvelopeJson, @bodyBytes, @responseId, @responseJson,
-            @fidelity, @createdAt)`,
+            @requestDeltaJson, @requestEnvelopeJson, @bodyBytes,
+            @requestBodyGeneration, @responseBodyGeneration,
+            @responseId, @responseJson, @fidelity, @createdAt)`,
       ),
       updateResponse: db.prepare(
         `UPDATE session_revisions
             SET response_id = @responseId,
-                response_json = @responseJson,
-                body_bytes = coalesce(
-                  body_bytes,
-                  length(CAST(request_delta_json AS BLOB)) +
-                  length(CAST(request_envelope_json AS BLOB))
-                ) + @responseBytes,
+                response_json = '',
+                body_bytes = @bodyBytes,
+                response_body_generation = @responseBodyGeneration,
                 fidelity = @fidelity
           WHERE request_id = @requestId`,
       ),
@@ -204,6 +340,25 @@ export class SqliteTelemetryStore implements TelemetryStore {
     for (;;) {
       resumedAfterPrune =
         (await this.waitForClaimedSessionPrune(input.sessionRef)) || resumedAfterPrune;
+      const before = this.db
+        .select({
+          sessionRef: sessionRevisions.sessionRef,
+          responseBodyStored: sql<number>`${sessionRevisions.responseJson} IS NOT NULL`,
+        })
+        .from(sessionRevisions)
+        .where(eq(sessionRevisions.requestId, input.requestId))
+        .get();
+      if (before?.sessionRef !== undefined && before.sessionRef !== input.sessionRef)
+        throw new Error("request session mismatch");
+      if (before?.responseBodyStored || (before && input.responseJson === null)) return;
+      const generation = await this.stageSessionBodyChunks(
+        input,
+        before
+          ? ["response"]
+          : input.responseJson === null
+            ? ["request_delta", "request_envelope"]
+            : ["request_delta", "request_envelope", "response"],
+      );
       const admitted = this.db.$sqlite.transaction(() => {
         // The await above can yield after observing no claim. Recheck inside the
         // synchronous write transaction so a prune that claimed in that gap wins.
@@ -229,7 +384,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
           .select({
             requestId: sessionRevisions.requestId,
             sessionRef: sessionRevisions.sessionRef,
-            responseJson: sessionRevisions.responseJson,
+            responseBodyStored: sql<number>`${sessionRevisions.responseJson} IS NOT NULL`,
           })
           .from(sessionRevisions)
           .where(eq(sessionRevisions.requestId, input.requestId))
@@ -238,7 +393,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
           if (existing.sessionRef !== input.sessionRef) throw new Error("request session mismatch");
           const responseJson = input.responseJson;
           const responseBytes =
-            responseJson !== null && existing.responseJson === null
+            responseJson !== null && !existing.responseBodyStored
               ? Buffer.byteLength(responseJson, "utf8")
               : 0;
           if (responseBytes === 0 || responseJson === null) return true;
@@ -253,8 +408,8 @@ export class SqliteTelemetryStore implements TelemetryStore {
           this.sessionWriteStmts().updateResponse.run({
             requestId: input.requestId,
             responseId: input.responseId ?? null,
-            responseJson: encodePayloadText(responseJson),
-            responseBytes,
+            bodyBytes: storedBytes,
+            responseBodyGeneration: generation,
             fidelity: input.fidelity,
           });
           return true;
@@ -290,11 +445,13 @@ export class SqliteTelemetryStore implements TelemetryStore {
           sequence,
           parentRequestId,
           retainCount: input.retainCount,
-          requestDeltaJson: encodePayloadText(input.requestDeltaJson),
-          requestEnvelopeJson: encodePayloadText(input.requestEnvelopeJson),
+          requestDeltaJson: "",
+          requestEnvelopeJson: "",
           bodyBytes: storedBytes,
+          requestBodyGeneration: generation,
+          responseBodyGeneration: input.responseJson === null ? null : generation,
           responseId: input.responseId ?? null,
-          responseJson: input.responseJson === null ? null : encodePayloadText(input.responseJson),
+          responseJson: input.responseJson === null ? null : "",
           fidelity: input.fidelity,
           createdAt: atMs,
         });
@@ -308,6 +465,25 @@ export class SqliteTelemetryStore implements TelemetryStore {
           })
           .where(eq(sessions.sessionRef, input.sessionRef))
           .run();
+        if (input.eventHead) {
+          this.db
+            .insert(sessionHeadEventHashes)
+            .values({
+              sessionRef: input.sessionRef,
+              requestId: input.requestId,
+              ...input.eventHead,
+            })
+            .onConflictDoUpdate({
+              target: sessionHeadEventHashes.sessionRef,
+              set: { requestId: input.requestId, ...input.eventHead },
+            })
+            .run();
+        } else {
+          this.db
+            .delete(sessionHeadEventHashes)
+            .where(eq(sessionHeadEventHashes.sessionRef, input.sessionRef))
+            .run();
+        }
         return true;
       })();
       if (admitted) return;
@@ -318,6 +494,13 @@ export class SqliteTelemetryStore implements TelemetryStore {
 
   async getSessionByRef(sessionRef: string): Promise<SessionRecord | null> {
     const row = this.db.select().from(sessions).where(eq(sessions.sessionRef, sessionRef)).get();
+    const head = row
+      ? this.db
+          .select()
+          .from(sessionHeadEventHashes)
+          .where(eq(sessionHeadEventHashes.sessionRef, sessionRef))
+          .get()
+      : undefined;
     return row
       ? {
           sessionRef: row.sessionRef,
@@ -330,6 +513,15 @@ export class SqliteTelemetryStore implements TelemetryStore {
           headRequestId: row.headRequestId,
           revisionCount: row.revisionCount,
           storedBytes: row.storedBytes,
+          eventHead:
+            head && head.requestId === row.headRequestId
+              ? {
+                  requestId: head.requestId,
+                  eventKey: head.eventKey as SessionEventHead["eventKey"],
+                  eventCount: head.eventCount,
+                  eventHash: head.eventHash,
+                }
+              : null,
         }
       : null;
   }
@@ -341,17 +533,18 @@ export class SqliteTelemetryStore implements TelemetryStore {
       .from(sessions)
       .where(inArray(sessions.sessionRef, [...sessionRefs]))
       .all()
-      .map((row) => ({ ...row }));
+      .map((row) => ({ ...row, eventHead: null }));
   }
 
   async listSessionRevisions(sessionRef: string): Promise<SessionRevisionRecord[]> {
-    return this.db
+    const rows = this.db
       .select()
       .from(sessionRevisions)
       .where(eq(sessionRevisions.sessionRef, sessionRef))
       .orderBy(asc(sessionRevisions.sequence))
-      .all()
-      .map(decodeSessionRevisionRow);
+      .all();
+    const chunks = this.chunksByRevisions(rows);
+    return rows.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId)));
   }
 
   async listSessionRevisionsPage(
@@ -374,7 +567,15 @@ export class SqliteTelemetryStore implements TelemetryStore {
       length(CAST(${sessionRevisions.fidelity} AS BLOB)) + 64
     `;
     const metadata = this.db
-      .select({ sequence: sessionRevisions.sequence, bytes: rowBytes })
+      .select({
+        sequence: sessionRevisions.sequence,
+        bytes: rowBytes,
+        legacyBinary: sql<number>`${sessionRevisions.bodyBytes} IS NULL AND (
+          typeof(${sessionRevisions.requestDeltaJson}) = 'blob' OR
+          typeof(${sessionRevisions.requestEnvelopeJson}) = 'blob' OR
+          typeof(${sessionRevisions.responseJson}) = 'blob'
+        )`,
+      })
       .from(sessionRevisions)
       .where(
         and(
@@ -389,7 +590,12 @@ export class SqliteTelemetryStore implements TelemetryStore {
     let usedBytes = 0;
     for (const row of metadata.slice(0, limit)) {
       const bytes = Number(row.bytes);
-      if (!Number.isSafeInteger(bytes) || bytes < 0 || usedBytes + bytes > options.maxBytes) {
+      if (
+        row.legacyBinary ||
+        !Number.isSafeInteger(bytes) ||
+        bytes < 0 ||
+        usedBytes + bytes > options.maxBytes
+      ) {
         return { revisions: [], nextSequence: null, limited: true };
       }
       selected.push(row.sequence);
@@ -406,21 +612,24 @@ export class SqliteTelemetryStore implements TelemetryStore {
         ),
       )
       .orderBy(asc(sessionRevisions.sequence))
-      .all()
-      .map(decodeSessionRevisionRow);
+      .all();
+    const chunks = this.chunksByRevisions(revisions);
     return {
-      revisions,
+      revisions: revisions.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId))),
       nextSequence: metadata.length > selected.length ? (selected.at(-1) ?? null) : null,
       limited: false,
     };
   }
 
-  async getSessionRevisionByResponseId(
+  async findSessionRequestIdByResponseId(
     sessionRef: string,
     responseId: string,
-  ): Promise<SessionRevisionRecord | null> {
+  ): Promise<SessionContinuationRecord | null> {
     const row = this.db
-      .select()
+      .select({
+        requestId: sessionRevisions.requestId,
+        responseBodyStored: sql<number>`${sessionRevisions.responseJson} IS NOT NULL`,
+      })
       .from(sessionRevisions)
       .where(
         and(
@@ -429,7 +638,32 @@ export class SqliteTelemetryStore implements TelemetryStore {
         ),
       )
       .get();
-    return row ? decodeSessionRevisionRow(row) : null;
+    return row
+      ? { requestId: row.requestId, responseBodyStored: Boolean(row.responseBodyStored) }
+      : null;
+  }
+
+  async getSessionRevisionMeta(requestId: string): Promise<SessionRevisionMetaRecord | null> {
+    const row = this.db
+      .select({
+        requestId: sessionRevisions.requestId,
+        sessionRef: sessionRevisions.sessionRef,
+        responseBodyStored: sql<number>`${sessionRevisions.responseJson} IS NOT NULL`,
+        fidelity: sessionRevisions.fidelity,
+        createdAt: sessionRevisions.createdAt,
+      })
+      .from(sessionRevisions)
+      .where(eq(sessionRevisions.requestId, requestId))
+      .get();
+    return row
+      ? {
+          requestId: row.requestId,
+          sessionRef: row.sessionRef,
+          responseBodyStored: Boolean(row.responseBodyStored),
+          fidelity: row.fidelity,
+          createdAt: row.createdAt,
+        }
+      : null;
   }
 
   async pruneInactiveSessions(olderThanMs: number): Promise<number> {
@@ -450,6 +684,21 @@ export class SqliteTelemetryStore implements TelemetryStore {
       deletedSessions += await this.finishClaimedSessionPrune(candidate.sessionRef);
       await yieldToEventLoop();
     }
+    const orphanChunks = db.prepare(`DELETE FROM session_revision_body_chunks WHERE rowid IN (
+      SELECT chunks.rowid FROM session_revision_body_chunks AS chunks
+      WHERE chunks.created_at < ? AND NOT EXISTS (
+        SELECT 1 FROM session_revisions AS revisions
+        WHERE revisions.request_id = chunks.request_id
+          AND (
+            (chunks.part = 'response' AND revisions.response_body_generation = chunks.generation)
+            OR
+            (chunks.part <> 'response' AND revisions.request_body_generation = chunks.generation)
+          )
+      )
+      ORDER BY chunks.created_at, chunks.request_id, chunks.generation,
+               chunks.part, chunks.chunk_index LIMIT ?
+    )`);
+    await runBatchedPrune((limit) => orphanChunks.run(Date.now() - 86_400_000, limit).changes);
     return deletedSessions;
   }
 

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -524,7 +524,8 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         !t.getSessionByRef ||
         !t.listSessionRevisions ||
         !("listSessionRevisionsPage" in t) ||
-        !t.getSessionRevisionByResponseId
+        !t.findSessionRequestIdByResponseId ||
+        !t.getSessionRevisionMeta
       )
         throw new Error("session revision methods required");
       const base = {
@@ -543,6 +544,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         requestEnvelopeJson: '{"model":"x"}',
         responseId: "resp_1",
         responseJson: '{"output":["one"]}',
+        eventHead: { eventKey: "messages", eventCount: 1, eventHash: "hash-one" },
         fidelity: "verbatim",
         createdAt: new Date(1000),
       });
@@ -555,6 +557,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         requestEnvelopeJson: '{"model":"x"}',
         responseId: "resp_2",
         responseJson: '{"output":["two"]}',
+        eventHead: { eventKey: "messages", eventCount: 2, eventHash: "hash-two" },
         fidelity: "verbatim",
         createdAt: new Date(2000),
       });
@@ -566,6 +569,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         requestDeltaJson: '["branch"]',
         requestEnvelopeJson: '{"model":"x"}',
         responseJson: null,
+        eventHead: { eventKey: "messages", eventCount: 2, eventHash: "hash-branch" },
         fidelity: "partial",
         createdAt: new Date(3000),
       });
@@ -621,12 +625,25 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         lastSeenAt: new Date(4000),
         revisionCount: 3,
         storedBytes: afterBackfill?.storedBytes,
+        eventHead: {
+          requestId: "r3",
+          eventKey: "messages",
+          eventCount: 2,
+          eventHash: "hash-branch",
+        },
       });
-      expect(await t.getSessionRevisionByResponseId("s_1", "resp_1")).toMatchObject({
+      expect(await t.findSessionRequestIdByResponseId("s_1", "resp_1")).toEqual({
         requestId: "r1",
-        responseId: "resp_1",
+        responseBodyStored: true,
       });
-      expect(await t.getSessionRevisionByResponseId("s_1", "resp_malicious")).toBeNull();
+      expect(await t.findSessionRequestIdByResponseId("s_1", "resp_malicious")).toBeNull();
+      expect(await t.getSessionRevisionMeta("r1")).toEqual({
+        requestId: "r1",
+        sessionRef: "s_1",
+        responseBodyStored: true,
+        fidelity: "verbatim",
+        createdAt: new Date(1000),
+      });
       expect(await t.listSessionRevisions("s_1")).toEqual([
         expect.objectContaining({
           requestId: "r1",
@@ -703,6 +720,45 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         }
       ).listSessionRevisionsPage("s_1", { limit: 10, maxBytes: 1 });
       expect(limited).toEqual({ revisions: [], nextSequence: null, limited: true });
+    });
+
+    it("atomically publishes one matching body generation for concurrent duplicate writes", async () => {
+      ctx = await make();
+      const t = ctx.stores.telemetry;
+      if (!t.upsertSessionRevision || !t.listSessionRevisions)
+        throw new Error("session revision methods required");
+      const write = (marker: string) =>
+        t.upsertSessionRevision?.({
+          sessionRef: "s_concurrent",
+          accountId: "acct_1",
+          apiKeyId: "key_1",
+          source: "codex",
+          externalSessionId: "external-concurrent",
+          requestId: "r_concurrent",
+          parentRequestId: null,
+          retainCount: 0,
+          requestDeltaJson: JSON.stringify([{ marker, text: "x".repeat(1_100_000) }]),
+          requestEnvelopeJson: JSON.stringify({ marker }),
+          responseId: marker,
+          responseJson: JSON.stringify({ marker }),
+          fidelity: "verbatim",
+          createdAt: new Date(1000),
+        });
+
+      await Promise.all([write("A"), write("B")]);
+      const revisions = await t.listSessionRevisions("s_concurrent");
+      expect(revisions).toHaveLength(1);
+      const revision = revisions[0];
+      const requestMarker = (
+        JSON.parse(revision?.requestDeltaJson ?? "[]") as Array<{ marker: string }>
+      )[0]?.marker;
+      const responseMarker = (JSON.parse(revision?.responseJson ?? "{}") as { marker: string })
+        .marker;
+      expect([requestMarker, responseMarker, revision?.responseId]).toEqual([
+        revision?.responseId,
+        revision?.responseId,
+        revision?.responseId,
+      ]);
     });
 
     it("prunes an entire inactive session without touching a recent one", async () => {


### PR DESCRIPTION
## What changed

- makes global metadata-only mode a hard-off and fences queued payload/session writes after mode changes
- stores Session bodies in UTF-8-safe gzip/raw chunks with atomic generation publication and bounded short transactions
- narrows continuation/Admin reads so metadata paths never load large JSON bodies
- makes SQLite and Postgres pruning bounded and resumable; Postgres uses SKIP LOCKED and persistent markers
- coordinates HTTP, WebSocket, and response-work memory against live heap/cgroup/host headroom
- pauses cleanup, memory/signals work, and auto-VACUUM under memory or I/O pressure

## Root cause

Large Session JSON was repeatedly read, parsed, rewritten, compressed, and deleted in large units. Cleanup and Postgres pruning could create unbounded I/O/WAL bursts, while independent memory budgets could overcommit the process. The first dynamic reserve formula also reserved 25% of host RAM and could reject all requests on a busy machine; it is now bounded to 384 MiB–1 GiB (5% of effective memory).

## Validation

- focused storage/adapter/store contract: 217/217
- resource pressure, Memory/Signals, Admin, payload capture: 462/462
- Responses/WebSocket/memory budget: 140/140
- Playwright Admin + protocol boundary: 23/23
- pnpm typecheck
- pnpm lint (37 existing warnings, exit 0)
- pnpm build
- git diff --check

Production data cleanup is intentionally excluded: session_revisions was already cleared and helm.db was already compacted by the operator.