### PR TITLE
[codex] Release v0.28.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.28",
+  "version": "0.28.29",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Bump the root Helm API version from 0.28.28 to 0.28.29.

This release contains the Session storage, bounded pruning, metadata-only hard-off, and runtime resource-pressure fixes merged in #677.

## Scope

Version-only change: package.json.