### PR TITLE
Fix Responses WebSocket recovery and request pressure

### DIFF
--- a/apps/gateway/src/request-cancellation.ts
+++ b/apps/gateway/src/request-cancellation.ts
@@ -40,3 +40,12 @@ export function markStartedStreamCancellation(
     error_reason: reason === REQUEST_TIMEOUT_REASON ? "timeout" : reason,
   };
 }
+
+export function markStartedStreamError(decision: DecisionRecord, errorReason: string): void {
+  decision.stream_outcome = "failed";
+  decision.final = {
+    ...decision.final,
+    status: "error",
+    error_reason: errorReason,
+  };
+}

--- a/apps/gateway/src/responses-websocket-internal.ts
+++ b/apps/gateway/src/responses-websocket-internal.ts
@@ -1,1 +1,14 @@
 export const CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER = "x-helm-codex-responses-websocket-proof";
+
+const requestMaterialized = new WeakMap<Request, () => void>();
+
+export function trackResponsesWebSocketRequest(request: Request, materialized: () => void): void {
+  requestMaterialized.set(request, materialized);
+}
+
+export function markResponsesWebSocketRequestParsed(request: Request): void {
+  const materialized = requestMaterialized.get(request);
+  if (materialized === undefined) return;
+  requestMaterialized.delete(request);
+  materialized();
+}

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -280,6 +280,44 @@ describe("Responses websocket bridge", () => {
     expect(memoryAdmission.pendingBytes).toBe(0);
   });
 
+  it("materializes parsed request leases before a stalled internal fetch admits peers", async () => {
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 100,
+      capacityBytes: () => 100,
+      jsonAmplification: 1,
+      minRequestChargeBytes: 100,
+    });
+    const pendingResponses: Array<(response: Response) => void> = [];
+    const baseUrl = await startBridge(
+      () => new Promise<Response>((resolve) => pendingResponses.push(resolve)),
+      undefined,
+      { memoryAdmission },
+    );
+    const sockets = await Promise.all([
+      connect(`${baseUrl}/v1/responses`),
+      connect(`${baseUrl}/v1/responses`),
+      connect(`${baseUrl}/v1/responses`),
+    ]);
+    const turns = sockets.map((socket) =>
+      collectTurn(socket, { type: "response.create", input: [], stream: true }),
+    );
+
+    for (let attempt = 0; attempt < 40 && pendingResponses.length < sockets.length; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(pendingResponses).toHaveLength(sockets.length);
+    expect(memoryAdmission.pendingBytes).toBe(0);
+
+    const completed = () =>
+      new Response(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    for (const resolve of pendingResponses) resolve(completed());
+    await Promise.all(turns);
+  });
+
   it.each([
     "/v1/responses",
     "/responses",
@@ -1008,6 +1046,27 @@ describe("Responses websocket bridge", () => {
         response: { id: "resp-terminal", status: "completed" },
       },
     ]);
+  });
+
+  it("treats response.cancelled as terminal without adding a bridge error", async () => {
+    const baseUrl = await startBridge(
+      () =>
+        new Response(
+          'event: response.cancelled\ndata: {"type":"response.cancelled","response":{"status":"cancelled"}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    const events: Record<string, unknown>[] = [];
+    socket.on("message", (data) =>
+      events.push(JSON.parse(data.toString()) as Record<string, unknown>),
+    );
+    const closed = once(socket, "close");
+
+    socket.send(JSON.stringify({ type: "response.create", input: [], stream: true }));
+    await closed;
+
+    expect(events).toEqual([{ type: "response.cancelled", response: { status: "cancelled" } }]);
   });
 
   it("does not wait for internal stream cancellation before handling the next turn", async () => {

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -9,6 +9,7 @@ import {
   type ResponsesWebSocketUpgradeServer,
   responsesWebSocketPreflightPending,
 } from "./responses-websocket.js";
+import { markResponsesWebSocketRequestParsed } from "./responses-websocket-internal.js";
 import { createBodyMemoryAdmission } from "./runtime/memory-admission.js";
 
 interface CapturedRequest {
@@ -258,13 +259,11 @@ describe("Responses websocket bridge", () => {
     const baseUrl = await startBridge(
       (request) => {
         fetched();
-        return new Response(
-          new ReadableStream<Uint8Array>({
-            start(controller) {
-              request.signal.addEventListener("abort", () => controller.close(), { once: true });
-            },
+        markResponsesWebSocketRequestParsed(request);
+        return new Promise<Response>((_resolve, reject) =>
+          request.signal.addEventListener("abort", () => reject(request.signal.reason), {
+            once: true,
           }),
-          { headers: { "content-type": "text/event-stream" } },
         );
       },
       undefined,
@@ -280,7 +279,7 @@ describe("Responses websocket bridge", () => {
     expect(memoryAdmission.pendingBytes).toBe(0);
   });
 
-  it("materializes parsed request leases before a stalled internal fetch admits peers", async () => {
+  it("keeps request admission until the internal parser finishes", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 100,
       capacityBytes: () => 100,
@@ -288,26 +287,52 @@ describe("Responses websocket bridge", () => {
       minRequestChargeBytes: 100,
     });
     const pendingResponses: Array<(response: Response) => void> = [];
+    const parsedRequests: Request[] = [];
     const baseUrl = await startBridge(
-      () => new Promise<Response>((resolve) => pendingResponses.push(resolve)),
+      (request) => {
+        parsedRequests.push(request);
+        return new Promise<Response>((resolve) => pendingResponses.push(resolve));
+      },
       undefined,
       { memoryAdmission },
     );
-    const sockets = await Promise.all([
+    const [first, second, third] = await Promise.all([
       connect(`${baseUrl}/v1/responses`),
       connect(`${baseUrl}/v1/responses`),
       connect(`${baseUrl}/v1/responses`),
     ]);
-    const turns = sockets.map((socket) =>
-      collectTurn(socket, { type: "response.create", input: [], stream: true }),
-    );
+    const firstTurn = collectTurn(first, {
+      type: "response.create",
+      input: [],
+      stream: true,
+    });
 
-    for (let attempt = 0; attempt < 40 && pendingResponses.length < sockets.length; attempt += 1) {
+    for (let attempt = 0; attempt < 40 && parsedRequests.length < 1; attempt += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(parsedRequests).toHaveLength(1);
+    expect(memoryAdmission.pendingBytes).toBe(100);
+
+    await expect(
+      collectTurn(second, { type: "response.create", input: [], stream: true }),
+    ).resolves.toMatchObject([{ type: "error", status: 503 }]);
+    expect(parsedRequests).toHaveLength(1);
+
+    const firstRequest = parsedRequests[0];
+    if (firstRequest === undefined) throw new Error("internal request did not reach the parser");
+    markResponsesWebSocketRequestParsed(firstRequest);
+    expect(memoryAdmission.pendingBytes).toBe(0);
+
+    const thirdTurn = collectTurn(third, {
+      type: "response.create",
+      input: [],
+      stream: true,
+    });
+    for (let attempt = 0; attempt < 40 && parsedRequests.length < 2; attempt += 1) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
 
-    expect(pendingResponses).toHaveLength(sockets.length);
-    expect(memoryAdmission.pendingBytes).toBe(0);
+    expect(parsedRequests).toHaveLength(2);
 
     const completed = () =>
       new Response(
@@ -315,7 +340,7 @@ describe("Responses websocket bridge", () => {
         { headers: { "content-type": "text/event-stream" } },
       );
     for (const resolve of pendingResponses) resolve(completed());
-    await Promise.all(turns);
+    await Promise.all([firstTurn, thirdTurn]);
   });
 
   it.each([

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -333,14 +333,15 @@ async function forwardResponse(
   }
   let response: Response;
   try {
-    response = await fetch(
-      new Request(requestUrl(request), {
-        method: "POST",
-        headers,
-        body: JSON.stringify(websocketRequestBody(data)),
-        signal,
-      }),
-    );
+    const body = websocketRequestBody(data);
+    const internalRequest = new Request(requestUrl(request), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+    materialized();
+    response = await fetch(internalRequest);
   } finally {
     materialized();
   }
@@ -368,6 +369,7 @@ async function forwardResponse(
     }
     if (
       type === "response.completed" ||
+      type === "response.cancelled" ||
       type === "response.failed" ||
       type === "response.incomplete" ||
       type === "error"

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -4,7 +4,11 @@ import type { Duplex } from "node:stream";
 import { CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER, readSSE, runtimeMemoryBudget } from "@helm/core";
 import WebSocket, { WebSocketServer } from "ws";
 import { normalizeOpenAICodexClientVersion } from "./oauth/codex-client-version.js";
-import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "./responses-websocket-internal.js";
+import {
+  CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER,
+  markResponsesWebSocketRequestParsed,
+  trackResponsesWebSocketRequest,
+} from "./responses-websocket-internal.js";
 import {
   type BodyMemoryAdmission,
   createBodyMemoryAdmission,
@@ -331,19 +335,19 @@ async function forwardResponse(
   if (sessionProof !== undefined) {
     headers.set(CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER, sessionProof);
   }
+  const requestBody = websocketRequestBody(data);
+  const internalRequest = new Request(requestUrl(request), {
+    method: "POST",
+    headers,
+    body: JSON.stringify(requestBody),
+    signal,
+  });
+  trackResponsesWebSocketRequest(internalRequest, materialized);
   let response: Response;
   try {
-    const body = websocketRequestBody(data);
-    const internalRequest = new Request(requestUrl(request), {
-      method: "POST",
-      headers,
-      body: JSON.stringify(body),
-      signal,
-    });
-    materialized();
     response = await fetch(internalRequest);
   } finally {
-    materialized();
+    markResponsesWebSocketRequestParsed(internalRequest);
   }
   if (!response.ok) {
     await sendEnvelope(socket, await responseErrorEnvelope(response));

--- a/apps/gateway/src/routes/chat.route.test.ts
+++ b/apps/gateway/src/routes/chat.route.test.ts
@@ -583,7 +583,8 @@ describe("POST /v1/chat/completions (routing pipeline)", () => {
       yield first;
       throw new UpstreamError("timeout", "upstream stream produced no data for 1500ms");
     }
-    const { deps: d, harness } = deps();
+    const insert = vi.fn(async (_input: { decision: unknown }) => ({ id: "1" }));
+    const { deps: d, harness } = deps({ telemetry: { insert } as unknown as TelemetryStore });
     harness.execute.mockResolvedValue({
       ...nonStreamOutcome(null),
       body: null,
@@ -606,6 +607,14 @@ describe("POST /v1/chat/completions (routing pipeline)", () => {
       error: { error_class: string };
     };
     expect(parsed.error.error_class).toBe("timeout");
+    const recorded = insert.mock.calls[0]?.[0] as {
+      decision: {
+        final: { status: string; error_reason: string | null };
+        stream_outcome: string | null;
+      };
+    };
+    expect(recorded.decision.final).toMatchObject({ status: "error", error_reason: "timeout" });
+    expect(recorded.decision.stream_outcome).toBe("failed");
   });
 
   it("does NOT bypass the pipeline (Phase 0 passthrough is gone)", async () => {

--- a/apps/gateway/src/routes/chat.ts
+++ b/apps/gateway/src/routes/chat.ts
@@ -37,6 +37,7 @@ import { HelmHttpError } from "../middleware/error-handler.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import {
   markStartedStreamCancellation,
+  markStartedStreamError,
   requestCancellationReason,
 } from "../request-cancellation.js";
 import {
@@ -950,8 +951,10 @@ export function registerChatRoutes(app: Hono<AppEnv>, deps: ChatRouteDeps): void
             // Preserve a mid-stream idle timeout (UpstreamError("timeout")) instead
             // of flattening it to a generic upstream_error frame.
             const timedOut = isUpstreamTimeout(err);
+            const errorClass = timedOut ? "timeout" : "upstream_error";
+            markStartedStreamError(result.decision, errorClass);
             const errBody = makeHelmError({
-              error_class: timedOut ? "timeout" : "upstream_error",
+              error_class: errorClass,
               message: timedOut ? "upstream timed out" : "upstream error",
               trace_id: traceId,
             });

--- a/apps/gateway/src/routes/gemini.test.ts
+++ b/apps/gateway/src/routes/gemini.test.ts
@@ -1,4 +1,4 @@
-import type { TelemetryStore, UpsertSessionRevisionInput } from "@helm/core";
+import type { DecisionRecord, TelemetryStore, UpsertSessionRevisionInput } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
@@ -50,6 +50,7 @@ function makeDeps(
     countTokens?: GeminiRouteDeps["countTokens"];
     record?: RecordServedDeps;
     memoryAdmission?: GeminiRouteDeps["memoryAdmission"];
+    decision?: DecisionRecord;
   } = {},
 ): { deps: GeminiRouteDeps; harness: Harness } {
   const harness: Harness = { order: [], pipelineSawIR: null, pipelineSawAbort: false };
@@ -110,7 +111,7 @@ function makeDeps(
           });
         }
         return {
-          decision: FAKE_DECISION,
+          decision: over.decision ?? FAKE_DECISION,
           collect: over.collect ?? (async () => ({ id: "ir-resp" })),
           streamIR:
             over.streamEvents ??
@@ -648,8 +649,11 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
       yield { candidates: [{ content: { role: "model", parts: [{ text: "Hi" }] } }] };
       throw new PipelineError("all_providers_failed", "all providers failed", "trace-1");
     }
-    const { record, insertPayload } = makeRecord({ capturePayloads: true });
-    const { deps } = makeDeps({ record, streamEvents: events });
+    const { record, insert, insertPayload } = makeRecord({ capturePayloads: true });
+    const decision = {
+      final: { status: "ok", model_alias: "gemini-2.0-flash", error_reason: null },
+    } as never;
+    const { deps } = makeDeps({ record, streamEvents: events, decision });
     const app = buildApp(deps);
 
     const res = await app.request("/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse", {
@@ -663,6 +667,17 @@ describe("POST /v1beta/models/{model}:generateContent (Gemini inbound)", () => {
     const arg = insertPayload.mock.calls[0]?.[0] as { responseJson: string };
     expect(arg.responseJson).toContain("UNAVAILABLE");
     expect(arg.responseJson).toContain("all providers failed");
+    const recorded = insert.mock.calls[0]?.[0] as {
+      decision: {
+        final: { status: string; error_reason: string | null };
+        stream_outcome: string | null;
+      };
+    };
+    expect(recorded.decision.final).toMatchObject({
+      status: "error",
+      error_reason: "all_providers_failed",
+    });
+    expect(recorded.decision.stream_outcome).toBe("failed");
   });
 });
 

--- a/apps/gateway/src/routes/gemini.ts
+++ b/apps/gateway/src/routes/gemini.ts
@@ -12,6 +12,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import {
   markStartedStreamCancellation,
+  markStartedStreamError,
   requestCancellationReason,
 } from "../request-cancellation.js";
 import {
@@ -501,6 +502,7 @@ export function registerGeminiRoute(app: Hono<AppEnv>, deps: GeminiRouteDeps): v
                     message: isUpstreamTimeout(err) ? "upstream timed out" : "upstream error",
                     trace_id: traceId,
                   };
+            markStartedStreamError(result.decision, re.error_class);
             const out = transformer.transformErrorOut(re);
             const data = JSON.stringify(out.body);
             captured?.push(`data: ${data}\n\n`);

--- a/apps/gateway/src/routes/messages.test.ts
+++ b/apps/gateway/src/routes/messages.test.ts
@@ -1163,9 +1163,13 @@ describe("POST /v1/messages (Anthropic inbound)", () => {
 
     expect(insert).toHaveBeenCalledOnce();
     const arg = insert.mock.calls[0]?.[0] as {
-      decision: { final: { status: string; error_reason: string | null } };
+      decision: {
+        final: { status: string; error_reason: string | null };
+        stream_outcome: string | null;
+      };
     };
     expect(arg.decision.final.status).toBe("error");
     expect(arg.decision.final.error_reason).toBe("upstream_error");
+    expect(arg.decision.stream_outcome).toBe("failed");
   });
 });

--- a/apps/gateway/src/routes/messages.ts
+++ b/apps/gateway/src/routes/messages.ts
@@ -16,6 +16,7 @@ import { estimateRequestTokens } from "../middleware/estimate-tokens.js";
 import { requestSignal, requestTimedOut } from "../middleware/limits.js";
 import {
   markStartedStreamCancellation,
+  markStartedStreamError,
   requestCancellationReason,
 } from "../request-cancellation.js";
 import {
@@ -259,14 +260,6 @@ function estimateAnthropicInputTokens(value: unknown): number {
     .filter((s) => s.length > 0)
     .join("\n");
   return Math.max(1, Math.ceil(Buffer.byteLength(text, "utf8") / 4));
-}
-
-function markStreamDecisionError(decision: DecisionRecord, errorClass: string): void {
-  decision.final = {
-    ...decision.final,
-    status: "error",
-    error_reason: errorClass,
-  };
 }
 
 export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps): void {
@@ -688,7 +681,7 @@ export function registerMessagesRoute(app: Hono<AppEnv>, deps: MessagesRouteDeps
                     message: isUpstreamTimeout(err) ? "upstream timed out" : "upstream error",
                     trace_id: traceId,
                   };
-            markStreamDecisionError(result.decision, errorClass);
+            markStartedStreamError(result.decision, errorClass);
             const out = anthropic.transformErrorOut(re);
             const data = JSON.stringify(out.body);
             captured?.push(`event: error\ndata: ${data}\n\n`);

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -70,6 +70,43 @@ describe("per-key request content mode", () => {
 });
 
 describe("Session queue admission", () => {
+  it("does nothing when Session capture is disabled", async () => {
+    const enqueueSession = vi.fn();
+    const getSessionByRef = vi.fn();
+    const upsertSessionRevision = vi.fn();
+    const log = vi.fn();
+
+    await queueOrPersistSessionRequest(
+      {
+        telemetry: {
+          getSessionByRef,
+          upsertSessionRevision,
+        } as unknown as PayloadCaptureDeps["telemetry"],
+        writes: { enqueueSession } as unknown as WriteQueue,
+        captureSessions: () => false,
+        captureBodyLimitBytes: 10,
+      },
+      {
+        requestId: "request-disabled",
+        accountId: "account-1",
+        apiKeyId: "key-1",
+        decision: {
+          session: { ref: "session-disabled", label: "thread-disabled", source: "x-session-key" },
+        } as unknown as DecisionRecord,
+        requestJson: "x".repeat(11),
+        responseId: null,
+        responseJson: "x".repeat(11),
+        now: 1,
+      },
+      log,
+    );
+
+    expect(log).not.toHaveBeenCalled();
+    expect(enqueueSession).not.toHaveBeenCalled();
+    expect(getSessionByRef).not.toHaveBeenCalled();
+    expect(upsertSessionRevision).not.toHaveBeenCalled();
+  });
+
   it("rejects an oversized retained body before creating the deferred closure", async () => {
     const enqueueSession = vi.fn();
     const writes = { enqueueSession } as unknown as WriteQueue;

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -490,6 +490,7 @@ export async function queueOrPersistSessionRequest(
   args: Parameters<typeof persistSessionRequest>[1],
   log: (msg: string) => void,
 ): Promise<void> {
+  if (!sessionCaptureEnabled(deps)) return;
   if (Buffer.byteLength(args.requestJson, "utf8") > captureBodyLimitBytes(deps)) {
     log("session.capture_limited");
     return;

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -9,7 +9,10 @@ import {
 } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
-import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "../responses-websocket-internal.js";
+import {
+  CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER,
+  trackResponsesWebSocketRequest,
+} from "../responses-websocket-internal.js";
 import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
 import type { MessagesIdentity } from "./messages.js";
 import { createMessagesPipeline, PipelineError, type RouteFn } from "./messages-pipeline.js";
@@ -2543,6 +2546,71 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       ?.metadata?.native_request as { headers?: Record<string, string> } | undefined;
     expect(native?.headers?.[CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER]).toBe("session-ok");
     expect(native?.headers?.[CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER]).toBeUndefined();
+  });
+
+  it("materializes a trusted internal websocket request after JSON parsing", async () => {
+    const materialized = vi.fn();
+    const { deps } = makeDeps({
+      transformRequestOut: () => {
+        expect(materialized).toHaveBeenCalledOnce();
+        return { stream: false };
+      },
+    });
+    deps.responsesWebSocketSessionProof = "proof-ok";
+    const app = buildApp(deps);
+    const request = new Request("http://helm.internal/v1/responses", {
+      method: "POST",
+      headers: {
+        ...AUTH,
+        [CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER]: "proof-ok",
+      },
+      body: JSON.stringify(REQ),
+    });
+    trackResponsesWebSocketRequest(request, materialized);
+
+    const res = await app.fetch(request);
+
+    expect(res.status).toBe(200);
+    expect(materialized).toHaveBeenCalledOnce();
+  });
+
+  it("materializes a trusted internal websocket request when JSON parsing fails", async () => {
+    const materialized = vi.fn();
+    const { deps } = makeDeps();
+    deps.responsesWebSocketSessionProof = "proof-ok";
+    const app = buildApp(deps);
+    const request = new Request("http://helm.internal/v1/responses", {
+      method: "POST",
+      headers: {
+        ...AUTH,
+        [CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER]: "proof-ok",
+      },
+      body: "{",
+    });
+    trackResponsesWebSocketRequest(request, materialized);
+
+    const res = await app.fetch(request);
+
+    expect(res.status).toBe(400);
+    expect(materialized).toHaveBeenCalledOnce();
+  });
+
+  it("does not materialize a tracked request without the internal proof", async () => {
+    const materialized = vi.fn();
+    const { deps } = makeDeps();
+    deps.responsesWebSocketSessionProof = "proof-ok";
+    const app = buildApp(deps);
+    const request = new Request("http://helm.internal/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify(REQ),
+    });
+    trackResponsesWebSocketRequest(request, materialized);
+
+    const res = await app.fetch(request);
+
+    expect(res.status).toBe(200);
+    expect(materialized).not.toHaveBeenCalled();
   });
 
   it("strips spoofed websocket session headers from ordinary HTTP requests", async () => {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -32,7 +32,10 @@ import {
   type RequestCancellationReason,
   requestCancellationReason,
 } from "../request-cancellation.js";
-import { CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER } from "../responses-websocket-internal.js";
+import {
+  CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER,
+  markResponsesWebSocketRequestParsed,
+} from "../responses-websocket-internal.js";
 import {
   type BodyMemoryAdmission,
   memoryAdmissionReleaseGuard,
@@ -893,17 +896,21 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       deps.memoryAdmission === undefined || trustedWebSocketSelfCall
         ? null
         : await readAdmittedRequestBody(c.req.raw, deps.memoryAdmission);
-    const rawBody = admitted?.text ?? (await c.req.text());
-    if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
     try {
-      const native: unknown = JSON.parse(rawBody);
-      return {
-        native,
-        rawBody,
-        ...(admitted === null ? {} : { materialized: admitted.materialized }),
-      };
-    } catch {
-      throw helmError("invalid_request", "malformed JSON request body", traceId);
+      const rawBody = admitted?.text ?? (await c.req.text());
+      if (admitted !== null) c.set("requestMemoryRelease", admitted.release);
+      try {
+        const native: unknown = JSON.parse(rawBody);
+        return {
+          native,
+          rawBody,
+          ...(admitted === null ? {} : { materialized: admitted.materialized }),
+        };
+      } catch {
+        throw helmError("invalid_request", "malformed JSON request body", traceId);
+      }
+    } finally {
+      if (trustedWebSocketSelfCall) markResponsesWebSocketRequestParsed(c.req.raw);
     }
   };
 

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1688,6 +1688,7 @@ function createProviderClient(
               ensureReasoningEncryptedContent: true,
               ensureInstructions: true,
               rejectPreviousResponseId: true,
+              rejectObjectInput: true,
               resolveModelRequestDefaults: (model: string) => {
                 const metadata = xaiRuntime?.modelsByWireModel.get(model);
                 return metadata

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -9,7 +9,7 @@
 
 ## 2026-08-02 · Responses WebSocket 首输出前恢复并提前释放物化准入（Protocol / Gateway runtime，docs/05/07/10，原则 3/5/8）
 
-- **恢复边界**：上游 WebSocket 只产生 `response.created` / `response.in_progress` 后关闭时，丢弃未提交的 preamble，按既有连接重试预算重连，耗尽后回退 HTTP/SSE；真实输出一旦开始则绝不重放。`response.cancelled` 在 provider parser 与 ingress bridge 都是失败终态，不再追加伪 bridge error。
+- **恢复边界**：上游 WebSocket 只产生 `response.created` / `response.in_progress` 后关闭时，丢弃未提交的 preamble，按既有连接重试预算重连，耗尽后回退 HTTP/SSE；最多缓冲协议正常需要的两个 preamble，第三个重复 preamble 立即提交为已开始输出，避免异常上游造成无界缓存。真实输出一旦开始则绝不重放。`response.cancelled` 在 provider parser 与 ingress bridge 都是失败终态，不再追加伪 bridge error。
 - **准入生命周期**：Responses WebSocket bridge 用进程内 `WeakMap<Request, callback>` 把 request-body lease 交给可信内部路由；只有随机 proof 匹配的内部请求会在第二次 JSON parse 成功或失败后立即标为已物化，provider 等待不再长期持有 6 倍预留，而 parser 完成前的并发大请求仍受动态 headroom 保护。没有恢复固定请求、WebSocket 或 Session 大小上限。
 - **保留边界**：bridge 到内部 Responses 路由仍有一次 `JSON.stringify` 与再次 parse；本次先修已证实的 503 放大根因，不抽取会绕过鉴权、schema、rate limit、并发与 telemetry 的第二条执行通道。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,7 +10,7 @@
 ## 2026-08-02 · Responses WebSocket 首输出前恢复并提前释放物化准入（Protocol / Gateway runtime，docs/05/07/10，原则 3/5/8）
 
 - **恢复边界**：上游 WebSocket 只产生 `response.created` / `response.in_progress` 后关闭时，丢弃未提交的 preamble，按既有连接重试预算重连，耗尽后回退 HTTP/SSE；真实输出一旦开始则绝不重放。`response.cancelled` 在 provider parser 与 ingress bridge 都是失败终态，不再追加伪 bridge error。
-- **准入生命周期**：Responses WebSocket bridge 在解析消息并构造可信内部 `Request` 后立即把 request-body lease 标为已物化，真实堆/RSS 继续由动态协调器观测；不再把 6 倍 JSON 预留一直持有到 provider 首输出或 fallback 链耗尽。没有恢复固定请求、WebSocket 或 Session 大小上限。
+- **准入生命周期**：Responses WebSocket bridge 用进程内 `WeakMap<Request, callback>` 把 request-body lease 交给可信内部路由；只有随机 proof 匹配的内部请求会在第二次 JSON parse 成功或失败后立即标为已物化，provider 等待不再长期持有 6 倍预留，而 parser 完成前的并发大请求仍受动态 headroom 保护。没有恢复固定请求、WebSocket 或 Session 大小上限。
 - **保留边界**：bridge 到内部 Responses 路由仍有一次 `JSON.stringify` 与再次 parse；本次先修已证实的 503 放大根因，不抽取会绕过鉴权、schema、rate limit、并发与 telemetry 的第二条执行通道。
 
 ## 2026-08-02 · 流式错误的 telemetry 终态与 metadata-only 捕获短路（Gateway / Telemetry，docs/05/07，原则 3/7/8）

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-02 · 流式错误的 telemetry 终态与 metadata-only 捕获短路（Gateway / Telemetry，docs/05/07，原则 3/7/8）
+
+- **流式终态**：Chat、Messages 与 Gemini 在已经开始写 SSE 后遇到非取消错误时，共用取消边界旁的 helper，把同一份 `DecisionRecord` 标为 `final.status=error`、保留协议映射使用的 `error_reason`，并写入 `stream_outcome=failed`；客户端主动断连仍只走原有 `client_aborted` 语义。
+- **metadata-only**：Session capture 关闭时，队列入口在计算 request/response 字节、查询饱和 cache 或创建 deferred DB write 前直接返回；不会产生 `session.capture_limited` 或 Session 存储工作，脱敏 telemetry 的正常记录不受影响。
+
 ## 2026-08-02 · Session 正文改为原子分块存储并以机器压力协调后台工作（Telemetry / Gateway runtime，docs/02/07/11，原则 3/7）
 
 - **存储格式**：新 Session 正文按 UTF-8 安全的 256 KiB 原始块逐块 gzip/raw 写入，最多 4 块一批；revision 用请求/响应两个 generation 指针原子发布，响应回填不重写大请求正文，并发重试不会把一份元数据配到另一份正文。历史正文不扫描、不回填；legacy 行继续读取，首次响应回填记录准确的逻辑 `body_bytes`。Admin 恢复先按机器动态 response-work 预算分页，只读取已发布 generation；旧二进制正文在缺少可靠原始字节数时 fail-closed。
@@ -66,17 +71,9 @@
 - **修复**：共享 `isUpstreamRequestRejection` 在原有 `400/413/422` 状态白名单内识别 `invalid_params`；图片链复用现有上游消息提取，Images 路由返回 OpenAI 形状的 `invalid_request_error / invalid_request / 400`。不按错误字符串或具体参数名特判，也不删除客户端字段。
 - **边界不变**：`401/403/404/429`、provider `5xx`、网络/超时、熔断与真实链耗尽仍走原有认证、重试、breaker、fallback 和 `5xx` 语义；回归测试覆盖 ZenMux 形状、provider `500`、网络失败与链耗尽。
 
-## 2026-07-25 · 上游过载（529/503）在 fetch 边界退避重试（Provider，docs/02/04，原则 3/5/8）
-
-- **根因**：`provider/retry.ts` 的重试分类是严格白名单，只覆盖裸 socket/连接失败；HTTP 529（Anthropic Overloaded）/503 直接变成 `UpstreamError` 抛出，**零延迟零重试**。OAuth 账号池确实把 `status >= 500` 当作可换兄弟账号的瞬时故障，但那也是立即换、无退避；单账号或普通 API key 的 provider 根本没有这条通路，一次 529 就烧掉一个候选，单候选链直接 502 给客户端——而同样的请求体隔一秒重发通常就成功。
-- **修复**：新增 `overloadRetryDelayMs` + `withOverloadRetry`，包在四个 provider client 的 fetch 边界外层（anthropic、openai、codex-responses、generic-responses、gemini）。过载答复是**正常 Response 而非 throw**，所以过载重试必须套在 `withConnectionRetry` 外面，而不是塞进它的 `shouldRetry`。首字节前才重试、body 从未消费，因此幂等（原则 8）；被丢弃的 response 会 `body.cancel()` 释放 socket，codex 那条延迟到 body 的 timeout 定时器通过 `release` 钩子显式清理。
-- **刻意收窄**：只认 **529 + 503**。500/502 是不明服务端故障，重试只是拖延真正的失败；429 是真限流，账号池 park 账号后走链才对。退避 **1s → 3s**（共 2 次重试）；上游给出数字 `Retry-After` 则优先，但**钳制在 10s**——一个上游不该占住客户端 socket 十分钟，那时换候选才是更快的答案路径。HTTP-date 形式的 `Retry-After` 不解析，退回默认表。
-- **下游不变**：重试耗尽后仍抛原来的 `UpstreamError(upstreamStatus: 529)`，账号池换号、熔断计数、fallback 链、遥测字段**逻辑一行未改**——只是现在它们只在真的持续过载时才启动。客户端断连时立刻停止，不再多烧一次上游（此时返回的 response body 已被 drain，error detail 退化为 null；无人在听，可接受）。
-- **测试影响**：三个老测试用 503 当"随便一个 5xx"占位（openai 401 分支、gemini/codex 非 JSON body 保留、generic 首 chunk 前抛错），503 现在会触发重试，已改成 500 并注明原因；意图不变，provider 套件同时从 9s 回到 2.5s。
-- **TODO / 边界**：退避参数目前是代码常量，未做成配置（与原则 2 的"会撒谎的旋钮比没有旋钮更糟"一致，先观察线上真实 529 分布再决定）；OAuth 池**换账号之间**仍无延迟，本次未动——换号本身就是在换容量，加睡眠反而拖慢。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-25 · 上游过载（529/503）在 fetch 边界退避重试**：只在首字节前对 529/503 做两次有界退避，保留账号池、熔断、fallback 与终态 telemetry 语义；客户端断连立即停止，完整原文通过 git history 回溯。
 - **2026-07-25 · Responses WebSocket terminal 立即释放并关闭失效连接**：成功终态立即释放请求与 ingress lease，失败终态关闭失效连接；Codex 增量续接保持 registry/provider/account/lane provenance 与 abort 边界，完整原文通过 git history 回溯。
 - **2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面**：Realtime V1/V2/V3、Responses 音频与 Images edits 复用既有鉴权、路由、账号和遥测链；Voice attestation 与单实例 call registry 保持收窄边界，完整原文通过 git history 回溯。
 - **2026-07-24 · 请求准入增加实时 V8 堆高水位**：曾以 live heap + 分池余量拒绝高风险请求；后被 2026-07-27 的启发式拒绝拆除与 2026-07-28 的请求大小上限删除取代，完整原文通过 git history 回溯。

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,10 +7,21 @@
 
 ---
 
+## 2026-08-02 · Responses WebSocket 首输出前恢复并提前释放物化准入（Protocol / Gateway runtime，docs/05/07/10，原则 3/5/8）
+
+- **恢复边界**：上游 WebSocket 只产生 `response.created` / `response.in_progress` 后关闭时，丢弃未提交的 preamble，按既有连接重试预算重连，耗尽后回退 HTTP/SSE；真实输出一旦开始则绝不重放。`response.cancelled` 在 provider parser 与 ingress bridge 都是失败终态，不再追加伪 bridge error。
+- **准入生命周期**：Responses WebSocket bridge 在解析消息并构造可信内部 `Request` 后立即把 request-body lease 标为已物化，真实堆/RSS 继续由动态协调器观测；不再把 6 倍 JSON 预留一直持有到 provider 首输出或 fallback 链耗尽。没有恢复固定请求、WebSocket 或 Session 大小上限。
+- **保留边界**：bridge 到内部 Responses 路由仍有一次 `JSON.stringify` 与再次 parse；本次先修已证实的 503 放大根因，不抽取会绕过鉴权、schema、rate limit、并发与 telemetry 的第二条执行通道。
+
 ## 2026-08-02 · 流式错误的 telemetry 终态与 metadata-only 捕获短路（Gateway / Telemetry，docs/05/07，原则 3/7/8）
 
 - **流式终态**：Chat、Messages 与 Gemini 在已经开始写 SSE 后遇到非取消错误时，共用取消边界旁的 helper，把同一份 `DecisionRecord` 标为 `final.status=error`、保留协议映射使用的 `error_reason`，并写入 `stream_outcome=failed`；客户端主动断连仍只走原有 `client_aborted` 语义。
 - **metadata-only**：Session capture 关闭时，队列入口在计算 request/response 字节、查询饱和 cache 或创建 deferred DB write 前直接返回；不会产生 `session.capture_limited` 或 Session 存储工作，脱敏 telemetry 的正常记录不受影响。
+
+## 2026-08-02 · xAI Responses 对象 input 在本地拒绝（Protocol / provider execution，docs/04/05/07，原则 3/5/8）
+
+- **确定性边界**：xAI `grok-4.5` 对 `input` 对象返回 `invalid type: map, expected a sequence`；只为 xAI 的 generic Responses contract 增加对象形态预检，返回结构化 `invalid_request / 400` 且不发起上游请求。数组保持可用；未证实 string 形态，不猜测也不改写。
+- **资源边界**：未修改 response-work admission、错误正文预算或 Session 容量。xAI 的 `error_body_capacity_exhausted` 是独立的上游正文边界，本次没有足够的稳定请求契约可做本地预判，仍保留其真实 provider 诊断而不虚构 Helm 固定上限。
 
 ## 2026-08-02 · Session 正文改为原子分块存储并以机器压力协调后台工作（Telemetry / Gateway runtime，docs/02/07/11，原则 3/7）
 
@@ -57,24 +68,11 @@
 - **自动维护保持开启**：未关闭 `vacuum_enabled`，也未改低峰小时。自动 VACUUM 的开关、小时与日期在进入串行维护队列后重新读取；busy 时只记录 `vacuum.auto_skip_busy`、不暂停入口、不记当天成功，并在下一次 10 分钟 tick 重试。空闲路径由外层唯一持有 HTTP gate，其他 worker/write activity 排空和 `store.vacuum()` 完成后才统一恢复入口；Postgres/Supabase 使用原生 autovacuum，不安装这个 SQLite scheduler。数据清理继续由原有容器内 scheduler 直接调用 Store，VACUUM 不再重复先跑清理，以缩短独占维护窗口。
 - **只观测不拒绝**：每 60 秒记录 process memory、event-loop delay、pending preflight 与 OAuth refresh queue depth；这些指标不进入 `/healthz`、readiness、admission、限流或 503 判定。Docker cgroup 上限保持部署现状。
 
-## 2026-07-27 · 拆除启发式请求内存拒绝并保留硬边界（Gateway runtime，docs/02/05/07，用户明确要求）
-
-- **决定**：按用户要求删除请求体/WebSocket 的 `active_capacity` 与 `live_heap` 启发式拒绝，避免健康流量因重复计账再出现 503。保留确定性的单请求/单帧 `wire_limit`（超限 413 / WebSocket 1009），防止一个合法 key 用超大正文拖垮整个容器。
-- **维护 pause 保留**：vacuum 仍通过 `pause()` + `waitForIdle()` 排空 in-flight lease；paused 期间新请求返回 `database_maintenance`，已持有 lease 可完成 resize/release。既有 WebSocket 也得到维护错误，不再误报“内存耗尽”。
-- **可观测性**：启动日志明确 `request_admission_mode=wire_limit_only`，只报告仍实际执行的 wire/WebSocket 上限；拒绝日志区分 `request.body_rejected` 与 `request.maintenance_rejected`，不再输出已删除的 active/heap 阈值。
-- **仍保留**：写队列、Session 恢复、response-work、鉴权、并发 lease 与 rate limit 不变。高并发聚合压力仍可能由 V8/cgroup 终止进程，但单请求硬边界不允许被取消。
-- **测试**：覆盖 aggregate capacity 不拒绝、HTTP/Responses WebSocket 硬上限、maintenance pause drain 与已建立 WebSocket 的维护错误，并逐协议验证 413/成功路径。
-
-## 2026-07-25 · 图片上游参数拒绝保持客户端 400（Gateway / Provider execution，docs/05/07，原则 3/5）
-
-- **根因**：OpenAI provider 已把 ZenMux 的真实 HTTP `400` 保存到 `UpstreamError.upstreamStatus`，但共享请求拒绝分类只识别 `invalid_request_error`、`413` 与超大图片提示，遗漏 ZenMux 的结构化 `invalid_params`，导致图片链继续按 provider 故障耗尽并返回 `all_providers_failed / 502`。
-- **修复**：共享 `isUpstreamRequestRejection` 在原有 `400/413/422` 状态白名单内识别 `invalid_params`；图片链复用现有上游消息提取，Images 路由返回 OpenAI 形状的 `invalid_request_error / invalid_request / 400`。不按错误字符串或具体参数名特判，也不删除客户端字段。
-- **边界不变**：`401/403/404/429`、provider `5xx`、网络/超时、熔断与真实链耗尽仍走原有认证、重试、breaker、fallback 和 `5xx` 语义；回归测试覆盖 ZenMux 形状、provider `500`、网络失败与链耗尽。
-
 ## 历史条目摘要（最新要点）
 
 - **2026-07-25 · 上游过载（529/503）在 fetch 边界退避重试**：只在首字节前对 529/503 做两次有界退避，保留账号池、熔断、fallback 与终态 telemetry 语义；客户端断连立即停止，完整原文通过 git history 回溯。
 - **2026-07-25 · Responses WebSocket terminal 立即释放并关闭失效连接**：成功终态立即释放请求与 ingress lease，失败终态关闭失效连接；Codex 增量续接保持 registry/provider/account/lane provenance 与 abort 边界，完整原文通过 git history 回溯。
+- **2026-07-25 · 图片上游参数拒绝保持客户端 400**：ZenMux 的结构化 `invalid_params` 在共享边界转为 `invalid_request / 400`，provider 5xx、网络、限流与真实链耗尽语义不变，完整原文通过 git history回溯。
 - **2026-07-24 · Codex Voice、Responses 音频与图片编辑补齐代理面**：Realtime V1/V2/V3、Responses 音频与 Images edits 复用既有鉴权、路由、账号和遥测链；Voice attestation 与单实例 call registry 保持收窄边界，完整原文通过 git history 回溯。
 - **2026-07-24 · 请求准入增加实时 V8 堆高水位**：曾以 live heap + 分池余量拒绝高风险请求；后被 2026-07-27 的启发式拒绝拆除与 2026-07-28 的请求大小上限删除取代，完整原文通过 git history 回溯。
 - **2026-07-24 · Admin 登录同源证明兼容代理 Host 改写**：登录/登出优先接受浏览器不可伪造的 `Sec-Fetch-Site: same-origin`，同时保留 Origin/Host 与 cross-site 拒绝边界；完整原文通过 git history 回溯。

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -2763,6 +2763,113 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(chunks.join("")).toContain("response.completed");
   });
 
+  it("reconnects after a preamble-only websocket close without replaying its preamble", async () => {
+    let firstCloseCalls = 0;
+    let firstReceiveCalls = 0;
+    const first: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {},
+      async receive() {
+        firstReceiveCalls += 1;
+        return firstReceiveCalls === 1
+          ? JSON.stringify({ type: "response.created", response: { id: "resp-closed" } })
+          : null;
+      },
+      async close() {
+        firstCloseCalls += 1;
+      },
+    };
+    const second = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-recovered" } },
+        { type: "response.output_text.delta", delta: "recovered" },
+        {
+          type: "response.completed",
+          response: { id: "resp-recovered", status: "completed", usage: {} },
+        },
+      ],
+    ]);
+    const connect = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_preamble_reconnect")}`,
+        responsesWebSocketConnector: connect,
+        connectRetries: 1,
+        connectRetryBackoffMs: [0],
+      },
+    });
+    const chunks: string[] = [];
+
+    for await (const chunk of client.nativePassthroughStream?.(
+      carrier("ingress-preamble-reconnect", {
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    const output = chunks.join("");
+    expect(firstCloseCalls).toBe(1);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(output.match(/event: response\.created/g)).toHaveLength(1);
+    expect(output).toContain("response.completed");
+  });
+
+  it("falls back to HTTP after preamble-only websocket closes exhaust retries", async () => {
+    let closeCalls = 0;
+    const connect = vi.fn(async (): Promise<CodexResponsesWebSocketConnection> => {
+      let receiveCalls = 0;
+      return {
+        responseHeaders: new Headers(),
+        async send() {},
+        async receive() {
+          receiveCalls += 1;
+          return receiveCalls === 1 ? JSON.stringify({ type: "response.created" }) : null;
+        },
+        async close() {
+          closeCalls += 1;
+        },
+      };
+    });
+    const fetchMock = vi.fn(async () =>
+      rawSSEResponse(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n\n',
+      ),
+    );
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_preamble_fallback")}`,
+        responsesWebSocketConnector: connect,
+        connectRetries: 1,
+        connectRetryBackoffMs: [0],
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const chunks: string[] = [];
+
+    for await (const chunk of client.nativePassthroughStream?.(
+      carrier("ingress-preamble-fallback", {
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(closeCalls).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(chunks.join("")).not.toContain("response.created");
+    expect(chunks.join("")).toContain("response.completed");
+  });
+
   it("requeues a same-session request after an ECANCELED connection is replaced", async () => {
     let releaseFirstSend = () => {};
     let markFirstSendStarted = () => {};
@@ -2902,7 +3009,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       async receive() {
         receiveCalls += 1;
         if (receiveCalls === 1) {
-          return JSON.stringify({ type: "response.created", response: { id: "resp-started" } });
+          return JSON.stringify({ type: "response.output_text.delta", delta: "started" });
         }
         throw boom;
       },
@@ -2931,7 +3038,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       )
       [Symbol.asyncIterator]();
 
-    expect((await iterator?.next())?.value).toContain("response.created");
+    expect((await iterator?.next())?.value).toContain("response.output_text.delta");
     await expect(iterator?.next()).rejects.toBe(boom);
     expect(connect).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
@@ -3143,6 +3250,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
   it.each([
     "response.failed",
     "response.incomplete",
+    "response.cancelled",
     "error",
   ] as const)("closes the upstream websocket before yielding %s and reconnects after iterator.return", async (terminalType) => {
     const first = fakeConnection([
@@ -3153,7 +3261,12 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
             ? { code: "synthetic_error", message: "synthetic websocket error" }
             : {
                 response: {
-                  status: terminalType === "response.failed" ? "failed" : "incomplete",
+                  status:
+                    terminalType === "response.failed"
+                      ? "failed"
+                      : terminalType === "response.cancelled"
+                        ? "cancelled"
+                        : "incomplete",
                 },
               }),
         },

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -4364,6 +4364,32 @@ describe("createGenericOpenAIResponsesClient — native passthrough", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects an object native input when the provider contract requires a sequence", async () => {
+    const fetchMock = vi.fn();
+    const client = createGenericOpenAIResponsesClient({
+      config: { baseUrl: "https://stream-only.test/v1", apiKey: "sk-test" },
+      requestContract: {
+        forceSse: true,
+        rejectObjectInput: true,
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await expect(
+      client.nativePassthrough?.({
+        model: "grok-4.5",
+        input: { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      }),
+    ).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: expect.objectContaining({
+        type: "invalid_request_error",
+        code: "responses_input_sequence_required",
+      }),
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("adapts a unary chat call to a stream-only upstream and aggregates its SSE", async () => {
     let seenHeaders = new Headers();
     let seenBody: Record<string, unknown> = {};

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -2539,7 +2539,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       },
       async receiveWithWork() {
         return {
-          text: JSON.stringify({ type: "response.created", response: { id: "resp-held" } }),
+          text: JSON.stringify({ type: "response.output_text.delta", delta: "held" }),
           release() {
             releaseCalls += 1;
           },
@@ -2567,7 +2567,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
 
     const yielded = await iterator?.next();
 
-    expect(yielded?.value).toContain("response.created");
+    expect(yielded?.value).toContain("response.output_text.delta");
     expect(releaseCalls).toBe(0);
     await iterator?.return?.();
     expect(releaseCalls).toBe(1);
@@ -2817,6 +2817,49 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(connect).toHaveBeenCalledTimes(2);
     expect(output.match(/event: response\.created/g)).toHaveLength(1);
     expect(output).toContain("response.completed");
+  });
+
+  it("commits repeated websocket preambles instead of buffering them without bound", async () => {
+    let receiveCalls = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {},
+      async receive() {
+        receiveCalls += 1;
+        return receiveCalls <= 3
+          ? JSON.stringify({ type: "response.created", response: { id: `resp-${receiveCalls}` } })
+          : null;
+      },
+      async close() {},
+    };
+    const fetchMock = vi.fn(async () =>
+      rawSSEResponse(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n\n',
+      ),
+    );
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_repeated_preamble")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+        connectRetries: 0,
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-repeated-preamble", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    expect((await iterator?.next())?.value).toContain("response.created");
+    expect(fetchMock).not.toHaveBeenCalled();
+    await iterator?.return?.();
   });
 
   it("falls back to HTTP after preamble-only websocket closes exhaust retries", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1736,6 +1736,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     | {
         kind: "frame";
         frame: string;
+        preamble: boolean;
         terminal: boolean;
         reusable: boolean;
       }
@@ -1894,10 +1895,12 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     return {
       kind: "frame",
       frame: `event: ${type}\ndata: ${text}\n\n`,
+      preamble: type === "response.created" || type === "response.in_progress",
       terminal:
         type === "response.completed" ||
         type === "response.failed" ||
         type === "response.incomplete" ||
+        type === "response.cancelled" ||
         type === "error",
       reusable: type === "response.completed",
     };
@@ -2049,6 +2052,8 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
           let retryConnection = false;
           let fallbackToHttp = false;
           let sendingRequest = false;
+          let outputStarted = false;
+          const preambleFrames: string[] = [];
           try {
             if (!websocketMetadataFired.has(lease.connection)) {
               websocketMetadataFired.add(lease.connection);
@@ -2066,10 +2071,19 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
               const received = await receiveWebSocketMessage(lease.connection, opts?.signal);
               if (received === null) {
                 await closeWebSocketSession(sessionId);
-                throw new UpstreamError(
-                  "upstream_error",
-                  "upstream websocket closed before a terminal response event",
-                );
+                if (outputStarted) {
+                  throw new UpstreamError(
+                    "upstream_error",
+                    "upstream websocket closed before a terminal response event",
+                  );
+                }
+                if (retries < maxRetries) {
+                  retryConnection = true;
+                } else {
+                  websocketHttpFallbackSessions.add(sessionId);
+                  fallbackToHttp = true;
+                }
+                break;
               }
               try {
                 const event = websocketSseFrame(received.text);
@@ -2081,16 +2095,26 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                   fireResponseMetaHeaders(event.headers, opts?.onResponseMeta);
                   if (isWebsocketConnectionLimitError(event.error)) {
                     await closeWebSocketSession(sessionId);
-                    if (retries < maxRetries) {
+                    if (!outputStarted && retries < maxRetries) {
                       retryConnection = true;
-                    } else {
+                    } else if (!outputStarted) {
                       websocketHttpFallbackSessions.add(sessionId);
                       fallbackToHttp = true;
+                    } else {
+                      throw event.error;
                     }
                     break;
                   }
                   await closeWebSocketSession(sessionId);
                   throw event.error;
+                }
+                if (!outputStarted && event.preamble) {
+                  preambleFrames.push(event.frame);
+                  continue;
+                }
+                if (!outputStarted) {
+                  outputStarted = true;
+                  yield* preambleFrames;
                 }
                 if (event.terminal && !event.reusable) {
                   await closeWebSocketSession(sessionId);

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -2111,7 +2111,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                   await closeWebSocketSession(sessionId);
                   throw event.error;
                 }
-                if (!outputStarted && event.preamble) {
+                if (!outputStarted && event.preamble && preambleFrames.length < 2) {
                   preambleFrames.push(event.frame);
                   continue;
                 }

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -145,6 +145,9 @@ export interface GenericOpenAIResponsesRequestContract {
   // continuation. Reject deterministically before network I/O instead of surfacing
   // the proxy's eventual 404 as an all-providers-failed 502.
   rejectPreviousResponseId?: boolean;
+  // Some providers accept only the Responses item sequence form; reject the
+  // proven object form locally instead of sending a deterministic upstream 422.
+  rejectObjectInput?: boolean;
   // Account-scoped model metadata discovered from the upstream catalog. The
   // resolver receives the final wire model; no provider-wide defaults are guessed.
   resolveModelRequestDefaults?: (
@@ -2230,6 +2233,7 @@ export function createGenericOpenAIResponsesClient(
       contract?.ensureReasoningEncryptedContent !== true &&
       contract?.ensureInstructions !== true &&
       contract?.rejectPreviousResponseId !== true &&
+      contract?.rejectObjectInput !== true &&
       contract?.resolveModelRequestDefaults === undefined
     ) {
       return body;
@@ -2278,6 +2282,20 @@ export function createGenericOpenAIResponsesClient(
         "upstream_error",
         message,
         { type: "invalid_request_error", code: "previous_response_id_unsupported", message },
+        400,
+      );
+    }
+    if (
+      contract.rejectObjectInput === true &&
+      next.input !== null &&
+      typeof next.input === "object" &&
+      !Array.isArray(next.input)
+    ) {
+      const message = "input must be an array of Responses items for this subscription provider";
+      throw new UpstreamError(
+        "upstream_error",
+        message,
+        { type: "invalid_request_error", code: "responses_input_sequence_required", message },
         400,
       );
     }


### PR DESCRIPTION
## Root cause

A roughly 52 MiB Responses request could hold a 6x JSON admission reservation until provider first output or chain exhaustion, creating a burst of `server_overloaded` rejections. Separately, Codex upstream WebSocket sessions that closed after preamble events were treated as terminal provider failures, xAI object-shaped `input` was forwarded into deterministic 422s, and post-start stream errors were not persisted consistently across protocols.

## Changes

- retry Codex WebSocket closes only before real output; discard stale preambles and fall back to HTTP after retry exhaustion
- treat `response.cancelled` as terminal and never replay after real output
- keep the request lease through the trusted internal JSON parser, then release it before provider wait using a process-local Request WeakMap; malformed JSON and early route failures release idempotently
- reject xAI object-shaped Responses `input` locally as structured 400 while preserving string and array forms
- persist Chat, Messages, and Gemini post-start stream failures as failed telemetry
- short-circuit Session work immediately in metadata-only mode

No fixed request, WebSocket, or Session size ceiling was added.

## Verification

- focused WebSocket admission parser-boundary tests: pass
- trusted, malformed, and spoofed-proof route tests: pass
- provider Responses suite: 187 pass
- focused Chat, Messages, Gemini, and payload-capture suites: pass
- core and gateway typecheck plus Biome checks passed in implementation worktrees
- independent final review: no P0-P3 findings

A full local file rerun was resource-gated by the runtime memory protector while unrelated Xcode tests reduced host available memory. Required GitHub CI jobs remain the release gate.