### PR TITLE
Release v0.28.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.29",
+  "version": "0.28.30",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release assessment

Patch release for merged PR #679.

- fixes Codex Responses WebSocket pre-output recovery without replaying real output
- releases large-request admission after the trusted internal JSON parser, not before it and not after provider wait
- bounds preamble buffering, normalizes stream failure telemetry, and rejects known-invalid xAI object input locally
- no database migration, config migration, API success-shape change, or fixed Session/request size ceiling

This PR intentionally changes only the root package version from 0.28.29 to 0.28.30. Deployment remains gated on CI and the exact release-merge SHA Publish image workflow.