### PR TITLE
[codex] preserve context overflow compaction signal

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1576,6 +1576,39 @@ describe("createExecute — gateway execution adapter", () => {
     });
   });
 
+  it("does not let approximate context estimates override a real provider failure", async () => {
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValue(new UpstreamError("upstream_error", "upstream returned 500", {}, 500)),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ first: "small-a", second: "small-b", tail: "tail-model" }),
+      breaker: breaker(),
+      catalog: new Map([
+        ["first", entry("first", { maxContextTokens: 20 })],
+        ["second", entry("second", { maxContextTokens: 20 })],
+      ]),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["first", "second", "tail"]),
+      req({ messages: [{ role: "user", content: "x".repeat(100) }] }),
+    );
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "all_providers_failed",
+      http_status: 502,
+    });
+  });
+
   it("skips a candidate on context_length_exceeded without tripping the breaker", async () => {
     // Some upstreams report model-window overflow as an in-band stream error without an
     // HTTP 400 status. That is a candidate capability miss, not provider health.
@@ -1801,6 +1834,104 @@ describe("createExecute — gateway execution adapter", () => {
       error_class: "all_providers_failed",
       http_status: 502,
       provider_raw: null,
+    });
+  });
+
+  it("returns a compaction 400 when multiple candidates confirm context overflow", async () => {
+    const raw = {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+        message:
+          "Your input exceeds the context window of this model. Please adjust your input and try again.",
+        param: "input",
+      },
+      sequence_number: 2,
+    };
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "codex responses stream error", raw, null),
+        )
+        .mockRejectedValueOnce(
+          new UpstreamError(
+            "upstream_error",
+            "upstream returned 422",
+            {
+              error:
+                "Failed to deserialize the JSON body into the target type: invalid type: map, expected a sequence",
+            },
+            422,
+          ),
+        )
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "codex responses stream error", raw, null),
+        ),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ sol: "gpt-5.6-sol", xai: "grok-4.5", terra: "gpt-5.6-terra" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["sol", "xai", "terra"]), req());
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "invalid_request",
+      http_status: 400,
+      message: raw.error.message,
+      provider_raw: raw,
+    });
+    expect(out.attempts.map((attempt) => attempt.skip_reason)).toEqual([
+      "context_too_small",
+      null,
+      "context_too_small",
+    ]);
+  });
+
+  it("does not count duplicate provider/model context errors as independent confirmations", async () => {
+    const raw = {
+      error: {
+        code: "context_length_exceeded",
+        message: "Your input exceeds the context window of this model.",
+      },
+    };
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(new UpstreamError("upstream_error", "overflow", raw, 400))
+        .mockRejectedValueOnce(new UpstreamError("upstream_error", "overflow", raw, 400))
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "upstream returned 500", {}, 500),
+        ),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ first: "same-model", duplicate: "same-model", tail: "tail-model" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["first", "duplicate", "tail"]), req());
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "all_providers_failed",
+      http_status: 502,
     });
   });
 
@@ -5631,6 +5762,112 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.final.status).toBe("ok");
     expect(out.stream).not.toBeNull();
     expect(out.nativePassthrough).toBe(true);
+  });
+
+  it("maps two native Responses context errors around another failure to compaction 400", async () => {
+    const contextStream = (model: string) =>
+      gen([
+        'event: response.created\ndata: {"type":"response.created"}\n\n',
+        `event: response.failed\ndata: ${JSON.stringify({
+          type: "response.failed",
+          response: {
+            instructions: "private request content",
+            error: {
+              type: "invalid_request_error",
+              code: "context_length_exceeded",
+              message: `Your input exceeds the context window of ${model}.`,
+            },
+          },
+        })}\n\n`,
+      ]);
+    // biome-ignore lint/correctness/useYield: pre-output provider rejection
+    async function* xaiFailure(): AsyncGenerator<string> {
+      throw new UpstreamError(
+        "upstream_error",
+        "upstream returned 422",
+        { error: "invalid type: map, expected a sequence" },
+        422,
+      );
+    }
+    const sol = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(contextStream("sol")),
+    } as unknown as ProviderClient;
+    const xai = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(xaiFailure()),
+    } as unknown as ProviderClient;
+    const terra = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(contextStream("terra")),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: sol,
+      providers: new Map([
+        ["codex", sol],
+        ["xai", xai],
+        ["codex-terra", terra],
+      ]),
+      registry: protocolRegistry({
+        sol: {
+          providerName: "codex",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+        xai: {
+          providerName: "xai",
+          providerModel: "grok-4.5",
+          targetProviderProtocol: "openai_responses",
+        },
+        terra: {
+          providerName: "codex-terra",
+          providerModel: "gpt-5.6-terra",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["sol", "xai", "terra"]),
+      req({
+        protocol: "openai_responses",
+        stream: true,
+        native_request: createNativePassthroughCarrier({
+          protocol: "openai_responses",
+          body: { model: "auto", input: "large request", stream: true },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "invalid_request",
+      http_status: 400,
+      provider_raw: {
+        type: "response.failed",
+        response: { error: { code: "context_length_exceeded" } },
+      },
+    });
+    expect(out.attempts.map((attempt) => attempt.skip_reason)).toEqual([
+      "context_too_small",
+      null,
+      "context_too_small",
+    ]);
+    expect(out.attempts[0]?.error_detail?.provider_raw).not.toHaveProperty("response.instructions");
+    expect(recordFailure).toHaveBeenCalledTimes(1);
+    expect(recordFailure).toHaveBeenCalledWith("xai");
   });
 
   it("an Anthropic passthrough stream that ends with no real output records a failure and advances the chain", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1196,6 +1196,14 @@ function upstreamErrorCode(raw: unknown): string | null {
     const code = (inner as { code?: unknown }).code;
     if (typeof code === "string") return code;
   }
+  const response = (raw as { response?: unknown }).response;
+  if (response !== null && typeof response === "object") {
+    const responseError = (response as { error?: unknown }).error;
+    if (responseError !== null && typeof responseError === "object") {
+      const code = (responseError as { code?: unknown }).code;
+      if (typeof code === "string") return code;
+    }
+  }
   const top = (raw as { code?: unknown }).code;
   return typeof top === "string" ? top : null;
 }
@@ -1532,11 +1540,12 @@ export function createExecute(deps: ExecuteAdapterDeps) {
     let capabilityPruned = false;
     let attemptedAny = false;
     let circuitSkipped = false;
-    // A terminal context error is actionable only when every other candidate was
-    // rejected for context/capability reasons. Availability and provider failures
-    // keep the existing retryable aggregate instead of falsely telling the client
-    // that compaction is guaranteed to fix the request.
+    // A terminal context error is actionable when every other candidate was rejected
+    // for context/capability reasons, or when two candidates independently confirm
+    // the same overflow. One context rejection mixed with a provider failure keeps
+    // the retryable aggregate instead of claiming compaction is guaranteed to help.
     let onlyContextOrCapabilitySkips = true;
+    const contextConfirmations = new Set<string>();
     let contextOverflow:
       | {
           message: string;
@@ -1546,7 +1555,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
     const rememberContextOverflow = (
       message: string,
       providerRaw: Record<string, unknown> | null,
+      confirmationKey?: string,
     ): void => {
+      if (confirmationKey !== undefined) contextConfirmations.add(confirmationKey);
       if (contextOverflow === undefined) {
         contextOverflow = { message, providerRaw };
         return;
@@ -1596,6 +1607,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         oauthProviderProtocols,
       });
       const { provider, providerModel } = target;
+      const contextConfirmationKey = `${target.providerName ?? "<default>"}\0${providerModel}`;
       if (!provider) {
         onlyContextOrCapabilitySkips = false;
         attempts.push(skipRow(alias, "provider_unavailable", elapsed()));
@@ -1769,6 +1781,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 exactContextLimit,
               )} maximum`,
               null,
+              contextConfirmationKey,
             );
             attempts.push(skipRow(alias, "context_too_small", elapsed()));
             continue;
@@ -2181,6 +2194,9 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           rememberContextOverflow(
             upstreamErrorMessage(detail.provider_raw) ?? detail.message,
             detail.provider_raw,
+            upstreamErrorCode(detail.provider_raw)?.toLowerCase() === "context_length_exceeded"
+              ? contextConfirmationKey
+              : undefined,
           );
           attempts.push({
             alias,
@@ -2306,7 +2322,10 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       errorClass = "lane_unavailable";
       message =
         "no provider is configured; add an API key or connect a subscription in Admin → Providers";
-    } else if (contextOverflow !== undefined && onlyContextOrCapabilitySkips) {
+    } else if (
+      contextOverflow !== undefined &&
+      (onlyContextOrCapabilitySkips || contextConfirmations.size >= 2)
+    ) {
       errorClass = "invalid_request";
       message = contextOverflow.message;
       providerRaw = contextOverflow.providerRaw;

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-03 · 多候选上下文溢出优先恢复客户端压缩信号（Provider execution / protocol errors，docs/04/05/07，原则 3/5/8）
+
+- **终态优先级**：单个候选的上下文溢出若混有真实 provider failure，仍返回 `all_providers_failed / 502`；同一链中至少两个不同 provider/model 通过精确 `count_tokens` 或结构化 `context_length_exceeded` 分别确认溢出时，即使夹有其他候选故障，也返回 `invalid_request / 400` 并保留上游消息，让 Claude/Codex 客户端进入既有自动压缩路径。
+- **流式诊断保真**：首输出前的原生 Responses SSE 错误现在只把 `type/code/message/param` 与嵌套 error envelope 放入 `UpstreamError.providerRaw`，并读取 top-level `message`；既保留 fallback 分类依据，又不让 `response.failed.response` 中的 instructions、tools、metadata 或 output 进入常规 telemetry。
+- **保守边界**：近似字符/token 估算和自由文本错误仍可用于“整链只有上下文/能力 skip”的既有 400，但不能压过真实 5xx/422；没有增加请求、Session 或上下文固定上限。top-level `error` 的 exact-once 终态统一和 CRLF SSE framing 属于独立协议问题，本次不扩大修改面。
+
 ## 2026-08-02 · Responses WebSocket 首输出前恢复并提前释放物化准入（Protocol / Gateway runtime，docs/05/07/10，原则 3/5/8）
 
 - **恢复边界**：上游 WebSocket 只产生 `response.created` / `response.in_progress` 后关闭时，丢弃未提交的 preamble，按既有连接重试预算重连，耗尽后回退 HTTP/SSE；最多缓冲协议正常需要的两个 preamble，第三个重复 preamble 立即提交为已开始输出，避免异常上游造成无界缓存。真实输出一旦开始则绝不重放。`response.cancelled` 在 provider parser 与 ingress bridge 都是失败终态，不再追加伪 bridge error。
@@ -61,15 +67,9 @@
 - **决定**：删除由 `activeRequestBytes / JSON_AMPLIFICATION` 推导的共享 wire 上限；HTTP 请求体不再执行 `wire_limit` 拒绝，Responses/Realtime 和上游 Codex WebSocket 的 `ws.maxPayload` 使用 `0`（无限制），HTTP/SSE 响应读取也不再复用该请求上限。原先约 25.8 MiB 的隐藏上限会把约 31 MiB 的 Codex 上下文压缩请求表现成 HTTP 413 或 `websocket closed by server before response.completed`。
 - **部署边界**：Remote Nginx 必须同步使用 `client_max_body_size 0`，不能以 100 MiB 替代已删除的应用限制。鉴权、schema 校验、maintenance drain、provider timeout、正文留存边界和缓存/写队列预算不变。
 
-## 2026-07-28 · 消除 preflight/registry 内存放大并让自动 VACUUM 只在空闲启动（Gateway / OAuth / Store，docs/02/05/07/10，原则 1/3/7/8）
-
-- **连接超时根因**：Responses WebSocket 的内部 models preflight 原先没有独立 deadline，也没有把 socket/request abort 贯穿 models、OAuth token、catalog/cache 与上游 fetch；现在 versioned 与 auth-only fallback 各有 6 秒边界，bridge 对内部 fetch Promise 做硬 race，即使 Store/鉴权忽略 signal 也会终止握手并取消晚到 body；断连同样立即取消，避免辅助目录阻断 101 或永久占住维护 activity。相同账号的 TokenManager 在 models 请求间复用，首次 Store 读取 singleflight，等待者可取消；共享 preset refresh 不接受单个等待者取消，但底层 fetch 固定在 30 秒内终止且 settled gate 会清理。
-- **内存与 I/O 放大**：Codex catalog 增加进程内热快照，相同 ETag 每 300 秒最多续期一次；首次 hydration 不归单个 caller 所有，断连只停止等待，不会再触发第二次大 blob 读取。Responses registry 改为 SQLite/Postgres keyed row 单行 upsert/tenant lookup，并保留一版 legacy blob read-through；全局裁剪从写入热路径拆出，每进程五分钟最多一次、每类最多 1,000 行并使用真实当前时间。流式 registry 必须先持久化再暴露 terminal frame，跨 replica 的立即 continuation 不依赖进程内 pending map。
-- **自动维护保持开启**：未关闭 `vacuum_enabled`，也未改低峰小时。自动 VACUUM 的开关、小时与日期在进入串行维护队列后重新读取；busy 时只记录 `vacuum.auto_skip_busy`、不暂停入口、不记当天成功，并在下一次 10 分钟 tick 重试。空闲路径由外层唯一持有 HTTP gate，其他 worker/write activity 排空和 `store.vacuum()` 完成后才统一恢复入口；Postgres/Supabase 使用原生 autovacuum，不安装这个 SQLite scheduler。数据清理继续由原有容器内 scheduler 直接调用 Store，VACUUM 不再重复先跑清理，以缩短独占维护窗口。
-- **只观测不拒绝**：每 60 秒记录 process memory、event-loop delay、pending preflight 与 OAuth refresh queue depth；这些指标不进入 `/healthz`、readiness、admission、限流或 503 判定。Docker cgroup 上限保持部署现状。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-28 · preflight/registry 内存放大与自动 VACUUM 空闲门禁**：Responses preflight 增加 deadline/abort，catalog 与 registry 改为有界热路径；自动 VACUUM 仅在空闲 drain 后执行，完整原文通过 git history 回溯。
 - **2026-07-25 · 上游过载（529/503）在 fetch 边界退避重试**：只在首字节前对 529/503 做两次有界退避，保留账号池、熔断、fallback 与终态 telemetry 语义；客户端断连立即停止，完整原文通过 git history 回溯。
 - **2026-07-25 · Responses WebSocket terminal 立即释放并关闭失效连接**：成功终态立即释放请求与 ingress lease，失败终态关闭失效连接；Codex 增量续接保持 registry/provider/account/lane provenance 与 abort 边界，完整原文通过 git history 回溯。
 - **2026-07-25 · 图片上游参数拒绝保持客户端 400**：ZenMux 的结构化 `invalid_params` 在共享边界转为 `invalid_request / 400`，provider 5xx、网络、限流与真实链耗尽语义不变，完整原文通过 git history回溯。

--- a/packages/core/src/provider/failover-guard.test.ts
+++ b/packages/core/src/provider/failover-guard.test.ts
@@ -45,6 +45,32 @@ describe("guardPreOutputFailure — openai_responses", () => {
     await expect(collect(guardPreOutputFailure(src, responses))).rejects.toThrow(UpstreamError);
   });
 
+  it("preserves the structured terminal error for fallback classification", async () => {
+    const raw = {
+      type: "error",
+      code: "context_length_exceeded",
+      message: "Please reduce the input",
+      response: { instructions: "private request content" },
+    };
+    const src = fromChunks([
+      'event: response.created\ndata: {"type":"response.created"}\n\n',
+      `event: error\ndata: ${JSON.stringify(raw)}\n\n`,
+    ]);
+
+    try {
+      await collect(guardPreOutputFailure(src, responses));
+      throw new Error("expected a terminal error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(UpstreamError);
+      expect(error).toMatchObject({ message: raw.message });
+      expect((error as UpstreamError).providerRaw).toEqual({
+        type: raw.type,
+        code: raw.code,
+        message: raw.message,
+      });
+    }
+  });
+
   it("preamble then real output → commits, replays every byte in order (preamble kept)", async () => {
     const chunks = [
       'event: response.created\ndata: {"type":"response.created"}\n\n',

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -65,6 +65,29 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
 }
 
+function errorFields(value: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of ["type", "code", "message", "param"] as const) {
+    const field = value[key];
+    if (typeof field === "string" || typeof field === "number" || field === null) {
+      out[key] = field;
+    }
+  }
+  return out;
+}
+
+function errorProviderRaw(data: string): Record<string, unknown> | null {
+  const obj = tryParse(data);
+  if (!obj) return null;
+  const out = errorFields(obj);
+  const error = asRecord(obj.error);
+  if (error) out.error = errorFields(error);
+  else if (typeof obj.error === "string") out.error = obj.error;
+  const responseError = asRecord(asRecord(obj.response)?.error);
+  if (responseError) out.response = { error: errorFields(responseError) };
+  return out;
+}
+
 function nonEmptyString(value: unknown): boolean {
   return typeof value === "string" && value.length > 0;
 }
@@ -85,7 +108,7 @@ const responsesClassifier: PreOutputClassifier = {
   },
   errorMessage(data) {
     const obj = tryParse(data) ?? {};
-    const top = (obj.error ?? {}) as { message?: string };
+    const top = (obj.error ?? obj) as { message?: string };
     const nested = (((obj.response ?? {}) as Record<string, unknown>).error ?? {}) as {
       message?: string;
     };
@@ -238,7 +261,11 @@ export async function* guardPreOutputFailure(
       if (data !== null) {
         const cls = classifier.classify(data);
         if (cls === "error") {
-          throw new UpstreamError("upstream_error", classifier.errorMessage(data));
+          throw new UpstreamError(
+            "upstream_error",
+            classifier.errorMessage(data),
+            errorProviderRaw(data),
+          );
         }
         if (cls === "output") {
           committed = true;


### PR DESCRIPTION
## What changed

- Return `invalid_request / 400` when two distinct provider/model candidates independently confirm context overflow through exact token counting or structured `context_length_exceeded` errors.
- Keep mixed chains conservative when only one candidate confirms overflow or the evidence is approximate.
- Preserve only the minimal streaming error envelope needed for fallback classification, excluding request-derived response fields from telemetry.

## Root cause

Trace `05f0d636-b3ea-46ba-94b0-1bf74279114d` had two Codex candidates reject the request with `context_length_exceeded`, but an unrelated xAI 422 made the chain terminate as `all_providers_failed / 502`. The Anthropic client therefore received `api_error` instead of the standard invalid-request signal used for automatic context compaction.

Native Responses pre-output failures also discarded structured error codes, making some SSE/WebSocket paths depend on message heuristics.

## Impact

After release, confirmed context-overflow chains return a compaction-compatible Anthropic error while genuine provider failures remain retryable 502s. No request, Session, or context-size limit is added.

## Validation

- Context/compaction executor regressions, including production-shaped `response.failed` SSE: pass
- Anthropic `/v1/messages` error boundary tests: pass
- Core and Gateway typecheck: pass
- Biome and `git diff --check`: pass
- Independent final review: no P0/P1/P2 blockers
