### PR TITLE
[codex] release v0.28.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.30",
+  "version": "0.28.31",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the root package version from 0.28.30 to 0.28.31

## Why

- publish the context-overflow compaction-signal fix merged in PR #681
- this is a backward-compatible bug fix, so a patch release is appropriate

## Validation

- package version readback: 0.28.31
- version-only diff; repository CI is the release gate