### PR TITLE
[codex] Fix constrained memory admission headroom

### DIFF
--- a/apps/gateway/e2e/fixtures/test-server.ts
+++ b/apps/gateway/e2e/fixtures/test-server.ts
@@ -145,7 +145,13 @@ const { buildServer } = process.env.NODE_V8_COVERAGE
 const repoConfigDir = new URL("../../../../config", import.meta.url).pathname;
 const configDir = `${DATA_DIR}/config`;
 cpSync(repoConfigDir, configDir, { recursive: true });
-const { app, port, host } = await buildServer({ configDir });
+const { app, port, host } = await buildServer({
+  configDir,
+  resourcePressure: {
+    shouldRun: async () => true,
+    shouldRunHeavy: async () => false,
+  },
+});
 serve({ fetch: app.fetch, port, hostname: host });
 process.stdout.write(`e2e gateway listening on ${host}:${port}\n`);
 

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1,6 +1,8 @@
 import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
+  createRuntimeMemoryCoordinator,
   type DecisionRecord,
+  deriveSafeWorkingMemoryCapacity,
   type ExecutionResult,
   responsesTransformer,
   type TelemetryStore,
@@ -244,6 +246,42 @@ function expectNativeCarrier(
 }
 
 describe("POST /v1/responses (OpenAI Responses inbound)", () => {
+  it("admits the production 25.64 MiB request under healthy cgroup headroom", async () => {
+    const capacityBytes = () =>
+      deriveSafeWorkingMemoryCapacity({
+        heapLimitBytes: 4 * 1024 * 1024 * 1024,
+        heapUsedBytes: 512 * 1024 * 1024,
+        availableMemoryBytes: 480_205_864,
+        hostTotalMemoryBytes: 64 * 1024 * 1024 * 1024,
+        constrainedMemoryBytes: 1_536 * 1024 * 1024,
+      });
+    const coordinator = createRuntimeMemoryCoordinator({ capacityBytes });
+    const memoryAdmission = createBodyMemoryAdmission({
+      activeRequestBytes: 1,
+      jsonAmplification: 6,
+      minRequestChargeBytes: 1,
+      coordinator,
+    });
+    const { deps } = makeDeps({ memoryAdmission });
+    const app = buildApp(deps);
+    const wireBytes = 26_888_188;
+    const emptyBody = JSON.stringify({ ...REQ, input: "" });
+    const body = JSON.stringify({ ...REQ, input: "x".repeat(wireBytes - emptyBody.length) });
+    expect(Buffer.byteLength(body)).toBe(wireBytes);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(coordinator.reservedBytes).toBe(0);
+    expect(memoryAdmission.reservedBytes).toBe(0);
+    expect(memoryAdmission.pendingBytes).toBe(0);
+  });
+
   it("accepts a body larger than the former hard body limit", async () => {
     const memoryAdmission = createBodyMemoryAdmission({
       activeRequestBytes: 60,

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1836,7 +1836,14 @@ export function supportsAutomaticVacuum(driver: "sqlite" | "supabase"): boolean 
 // Store factory may open a remote Postgres (supabase driver); the sqlite default
 // resolves synchronously under the await.
 export async function buildServer(
-  opts: { logger?: Logger; configDir?: string } = {},
+  opts: {
+    logger?: Logger;
+    configDir?: string;
+    resourcePressure?: Pick<
+      ReturnType<typeof createRuntimeResourcePressureGate>,
+      "shouldRun" | "shouldRunHeavy"
+    >;
+  } = {},
 ): Promise<ServerHandle> {
   const logger = opts.logger ?? createJsonLogger();
   const responsesWebSocketSessionProof = randomUUID();
@@ -2041,9 +2048,9 @@ export async function buildServer(
   let vacuumScheduler: ReturnType<typeof startCleanupScheduler> | null = null;
   let signalScheduler: ReturnType<typeof startSignalScheduler> | null = null;
   let memoryWorker: ReturnType<typeof startMemoryWorker> | null = null;
-  const resourcePressure = createRuntimeResourcePressureGate((message, fields) =>
-    logger.log("info", message, fields),
-  );
+  const resourcePressure =
+    opts.resourcePressure ??
+    createRuntimeResourcePressureGate((message, fields) => logger.log("info", message, fields));
   // Apply a new settings object live: re-bind `settings`, push the log level into
   // the logger, flip the rate-limit master switch, and retune the system-default
   // quota. Cleanup cadence is also rescheduled live so the admin setting is not

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-03 · 受限容器不再重复套用宿主机固定内存预留（Gateway runtime，docs/02/05/10，原则 3/7/8）
+
+- **现场根因**：1.5 GiB cgroup 当时仍有约 457.96 MiB 可用内存，但动态准入先扣除面向非受限宿主机的 384 MiB 固定预留，再只使用剩余量的 70%，把安全工作容量压到约 51.78 MiB；一个 25.64 MiB Responses 请求按 6 倍 JSON 放大计为约 153.86 MiB，即使共享协调器没有任何活动 lease 也会稳定返回 503。
+- **最小修复**：受 cgroup 约束时只按容器总量的 5%（最多 1 GiB）保留 native headroom；未受约束进程继续使用原有 384 MiB 下限。V8 128 MiB emergency reserve、70% utilization、HTTP/WebSocket/response-work 共享协调器和 maintenance drain 均保持不变。事故快照下容量变为约 266.81 MiB，单请求可通过，而两个同体积并发请求仍超过共享容量。
+- **边界**：不恢复固定 HTTP/WebSocket/Session 大小上限，不为空闲协调器增加超额旁路，也不以扩大容器替代算法修复。有限进程仍可能对真正超过实时安全 headroom 的请求返回结构化过载错误。
+
 ## 2026-08-03 · 多候选上下文溢出优先恢复客户端压缩信号（Provider execution / protocol errors，docs/04/05/07，原则 3/5/8）
 
 - **终态优先级**：单个候选的上下文溢出若混有真实 provider failure，仍返回 `all_providers_failed / 502`；同一链中至少两个不同 provider/model 通过精确 `count_tokens` 或结构化 `context_length_exceeded` 分别确认溢出时，即使夹有其他候选故障，也返回 `invalid_request / 400` 并保留上游消息，让 Claude/Codex 客户端进入既有自动压缩路径。
@@ -62,13 +68,9 @@
 - **执行 Token 租约**：OAuth Provider 统一保存上游真实 `expires`，不再在各 Provider 解析时篡改到期时间；执行 client 在 `request_timeout_ms` 之外保留 5 分钟提前刷新余量（默认共 6 分钟），Admin discovery/quota 保持既有 60 秒余量。网络、408/425/5xx 刷新失败会按账号稳定抖动等待 1–3 秒并重读共享 Store：只采用其他实例已经轮换出的有效 credential，绝不重放结果不确定的旧 rotating refresh token；Store 未变化时当前请求转健康兄弟账号，失败账号在本进程短冷却 30 秒后自动恢复。确定性凭证错误与 429 继续进入既有重连/限流分流。刷新后 Token 若覆盖不了整段租约就不用于请求，但先加密持久化旋转后的 refresh token；短租约账号不会被永久标记为凭证失效。
 - **完整但有界的错误诊断**：Provider HTTP/transport 错误保存 64 KiB body、16 KiB 非凭证 headers、嵌套 cause、16 KiB stack，并用 128 KiB/256 节点总预算防止诊断本身放大内存。Telemetry 不再因字段名含 `token` 就误隐藏 `token_count` 或 rate-limit token 指标；只过滤 API key、OAuth access/refresh/id token、Authorization、Cookie、密码和代理凭证。请求/响应正文仍遵守 `capture_payloads` / Session 留存边界，不塞进 DecisionRecord。
 
-## 2026-07-28 · 删除 HTTP 与 WebSocket 请求大小上限（Gateway runtime / Deployment，docs/02/05/07/10，用户明确要求）
-
-- **决定**：删除由 `activeRequestBytes / JSON_AMPLIFICATION` 推导的共享 wire 上限；HTTP 请求体不再执行 `wire_limit` 拒绝，Responses/Realtime 和上游 Codex WebSocket 的 `ws.maxPayload` 使用 `0`（无限制），HTTP/SSE 响应读取也不再复用该请求上限。原先约 25.8 MiB 的隐藏上限会把约 31 MiB 的 Codex 上下文压缩请求表现成 HTTP 413 或 `websocket closed by server before response.completed`。
-- **部署边界**：Remote Nginx 必须同步使用 `client_max_body_size 0`，不能以 100 MiB 替代已删除的应用限制。鉴权、schema 校验、maintenance drain、provider timeout、正文留存边界和缓存/写队列预算不变。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-28 · 删除 HTTP 与 WebSocket 请求大小上限**：删除应用与 Remote Nginx 固定正文上限，继续由动态内存准入、鉴权、schema、maintenance drain 和 provider timeout 保护运行时；完整原文通过 git history回溯。
 - **2026-07-28 · preflight/registry 内存放大与自动 VACUUM 空闲门禁**：Responses preflight 增加 deadline/abort，catalog 与 registry 改为有界热路径；自动 VACUUM 仅在空闲 drain 后执行，完整原文通过 git history 回溯。
 - **2026-07-25 · 上游过载（529/503）在 fetch 边界退避重试**：只在首字节前对 529/503 做两次有界退避，保留账号池、熔断、fallback 与终态 telemetry 语义；客户端断连立即停止，完整原文通过 git history 回溯。
 - **2026-07-25 · Responses WebSocket terminal 立即释放并关闭失效连接**：成功终态立即释放请求与 ingress lease，失败终态关闭失效连接；Codex 增量续接保持 registry/provider/account/lane provenance 与 abort 边界，完整原文通过 git history 回溯。

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -11,6 +11,7 @@
 
 - **现场根因**：1.5 GiB cgroup 当时仍有约 457.96 MiB 可用内存，但动态准入先扣除面向非受限宿主机的 384 MiB 固定预留，再只使用剩余量的 70%，把安全工作容量压到约 51.78 MiB；一个 25.64 MiB Responses 请求按 6 倍 JSON 放大计为约 153.86 MiB，即使共享协调器没有任何活动 lease 也会稳定返回 503。
 - **最小修复**：受 cgroup 约束时只按容器总量的 5%（最多 1 GiB）保留 native headroom；未受约束进程继续使用原有 384 MiB 下限。V8 128 MiB emergency reserve、70% utilization、HTTP/WebSocket/response-work 共享协调器和 maintenance drain 均保持不变。事故快照下容量变为约 266.81 MiB，单请求可通过，而两个同体积并发请求仍超过共享容量。
+- **e2e 边界**：Playwright gateway 注入确定性压力门，普通后台观察始终允许，重型维护始终禁止，避免 hosted runner 的瞬时 PSI 暂停 60 秒 Memory worker。生产入口不注入，继续读取真实 cgroup、可用内存与 PSI；request、WebSocket 与 response work 仍共享同一个全局 coordinator。
 - **边界**：不恢复固定 HTTP/WebSocket/Session 大小上限，不为空闲协调器增加超额旁路，也不以扩大容器替代算法修复。有限进程仍可能对真正超过实时安全 headroom 的请求返回结构化过载错误。
 
 ## 2026-08-03 · 多候选上下文溢出优先恢复客户端压缩信号（Provider execution / protocol errors，docs/04/05/07，原则 3/5/8）

--- a/packages/core/src/runtime/memory-budget.test.ts
+++ b/packages/core/src/runtime/memory-budget.test.ts
@@ -39,6 +39,20 @@ describe("deriveRuntimeMemoryBudget", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("does not apply the host reserve floor inside a constrained container", () => {
+    const capacity = deriveSafeWorkingMemoryCapacity({
+      heapLimitBytes: 4 * 1024 * 1024 * 1024,
+      heapUsedBytes: 512 * 1024 * 1024,
+      availableMemoryBytes: 480_205_864,
+      hostTotalMemoryBytes: 64 * 1024 * 1024 * 1024,
+      constrainedMemoryBytes: 1_536 * 1024 * 1024,
+    });
+
+    expect(capacity).toBe(279_772_659);
+    expect(capacity).toBeGreaterThanOrEqual(26_888_188 * 6);
+    expect(capacity).toBeLessThan(26_888_188 * 12);
+  });
+
   it("scales every in-memory budget from the detected runtime capacity", () => {
     const small = deriveRuntimeMemoryBudget({
       heapLimitBytes: 1_000,

--- a/packages/core/src/runtime/memory-budget.ts
+++ b/packages/core/src/runtime/memory-budget.ts
@@ -108,10 +108,10 @@ export function deriveSafeWorkingMemoryCapacity(input: {
   const effectiveTotalMemoryBytes = hasConstrainedLimit
     ? Math.min(input.hostTotalMemoryBytes, constrainedMemoryBytes)
     : input.hostTotalMemoryBytes;
-  const hostReserve = Math.max(
-    hostReserveMinBytes,
-    Math.min(1024 * MIB, Math.floor(effectiveTotalMemoryBytes * 0.05)),
-  );
+  const proportionalReserve = Math.min(1024 * MIB, Math.floor(effectiveTotalMemoryBytes * 0.05));
+  const hostReserve = hasConstrainedLimit
+    ? proportionalReserve
+    : Math.max(hostReserveMinBytes, proportionalReserve);
   const heapHeadroom = Math.max(
     0,
     input.heapLimitBytes - input.heapUsedBytes - emergencyReserveBytes,


### PR DESCRIPTION
## What changed

- use the cgroup's proportional reserve for constrained processes instead of also imposing the 384 MiB host floor
- preserve the existing V8 emergency reserve, 70% utilization, shared coordinator, and maintenance drain
- add the exact production incident arithmetic and a real 26,888,188-byte `/v1/responses` regression test
- make the Playwright gateway's background pressure gate deterministic while production keeps the real cgroup/PSI gate
- record the runtime decision and limits in `implementation-notes.md`

## Root cause

In the 1.5 GiB production cgroup, `process.availableMemory()` already reported container-local headroom. The capacity calculation then subtracted the 384 MiB reserve intended for unconstrained hosts. With 457.96 MiB available, this reduced safe working capacity to 51.78 MiB and rejected a 25.64 MiB request charged at 6x (153.86 MiB), even with zero active leases.

The corrected calculation yields 266.81 MiB for the same snapshot. One incident-sized request is admitted, while two concurrent requests still exceed the shared capacity and the second remains blocked.

## Validation

- Red: incident unit fixture returned `54,286,876`, expected `279,772,659`
- Red: 26,888,188-byte route request returned HTTP 503, expected 200
- Green: 25 related unit tests passed
- Green: real incident-sized `/v1/responses` route regression passed and released all leases
- Green: focused Memory Playwright spec passed after deterministic pressure-gate injection
- Green: gateway typecheck, Biome on changed TypeScript, and `git diff --check`

The existing `responses-websocket.test.ts` failures were reproduced unchanged on a detached `origin/main` worktree and are not introduced by this PR. Full required CI must pass before merge.
