### PR TITLE
release v0.28.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.31",
+  "version": "0.28.32",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

- bump Helm API from `0.28.31` to `0.28.32`
- includes PR #683: constrained-cgroup request memory headroom fix
- version-only release commit based on verified `main@0feb644bc8a5d90842648e3e9853b17da0fca0f5`

Full required CI must pass before merge. Deployment will use the published immutable digest for the exact release SHA.
