### PR TITLE
fix: bound session payload recovery

### DIFF
--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -832,7 +832,12 @@ export async function getRequest(requestId: string): Promise<RequestDetail> {
 export interface RequestPayloadView {
   captured: boolean;
   source?: 'payload' | 'session' | 'unavailable';
-  reason?: 'no_session' | 'session_unavailable' | 'session_incomplete' | 'response_unavailable';
+  reason?:
+    | 'no_session'
+    | 'session_unavailable'
+    | 'session_incomplete'
+    | 'session_recovery_limited'
+    | 'response_unavailable';
   exact?: boolean;
   fidelity?: 'exact' | 'semantic' | 'partial' | string;
   request?: unknown;
@@ -854,7 +859,12 @@ export type RequestPayloadPartName = 'request' | 'response' | 'upstream_request'
 export interface RequestPayloadPartView {
   captured: boolean;
   source?: 'payload' | 'session' | 'unavailable';
-  reason?: 'no_session' | 'session_unavailable' | 'session_incomplete' | 'response_unavailable';
+  reason?:
+    | 'no_session'
+    | 'session_unavailable'
+    | 'session_incomplete'
+    | 'session_recovery_limited'
+    | 'response_unavailable';
   exact?: boolean;
   fidelity?: 'exact' | 'semantic' | 'partial' | string;
   part?: RequestPayloadPartName;

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -915,6 +915,7 @@
   "The request body as received from the client — before memory injection and translation.": "The request body as received from the client — before memory injection and translation.",
   "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.",
   "The session transcript is incomplete and this request cannot be recovered.": "The session transcript is incomplete and this request cannot be recovered.",
+  "The session transcript is too large to recover safely.": "The session transcript is too large to recover safely.",
   "The session transcript is unavailable or has been cleaned up.": "The session transcript is unavailable or has been cleaned up.",
   "The subject is fixed — it identifies which fact a newer one supersedes.": "The subject is fixed — it identifies which fact a newer one supersedes.",
   "The subscription account that served this request, when applicable.": "The subscription account that served this request, when applicable.",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -915,6 +915,7 @@
   "The request body as received from the client — before memory injection and translation.": "El cuerpo de la solicitud tal como se recibió del cliente: antes de la inyección de memoria y la traducción.",
   "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "El servidor usa el transporte MCP Streamable HTTP en el origen sin ruta + /mcp y se autentica con tu API key como bearer token. Actívalo en el gateway con memory.mcp.enabled; hasta entonces /mcp devuelve 404.",
   "The session transcript is incomplete and this request cannot be recovered.": "La transcripción de la sesión está incompleta y esta solicitud no se puede recuperar.",
+  "The session transcript is too large to recover safely.": "La transcripción de la sesión es demasiado grande para recuperarla de forma segura.",
   "The session transcript is unavailable or has been cleaned up.": "La transcripción de la sesión no está disponible o se ha eliminado.",
   "The subject is fixed — it identifies which fact a newer one supersedes.": "El asunto es fijo: identifica qué hecho sustituye uno más nuevo.",
   "The subscription account that served this request, when applicable.": "La cuenta de suscripción que sirvió esta solicitud, cuando corresponda.",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -915,6 +915,7 @@
   "The request body as received from the client — before memory injection and translation.": "クライアントから受信したリクエスト本文 — メモリ注入と変換の前。",
   "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "サーバーはベースとなるオリジン + /mcp で MCP Streamable HTTP トランスポートを使用し、API キーを Bearer トークンとして認証します。ゲートウェイで memory.mcp.enabled を有効にしてください。それまで /mcp は 404 を返します。",
   "The session transcript is incomplete and this request cannot be recovered.": "セッショントランスクリプトが不完全なため、このリクエストは復元できません。",
+  "The session transcript is too large to recover safely.": "セッショントランスクリプトが大きすぎるため、安全に復元できません。",
   "The session transcript is unavailable or has been cleaned up.": "セッショントランスクリプトは利用できないか、クリーンアップ済みです。",
   "The subject is fixed — it identifies which fact a newer one supersedes.": "サブジェクトは固定です — 新しいファクトがどのファクトを置き換えるかを識別します。",
   "The subscription account that served this request, when applicable.": "該当する場合、このリクエストを処理したサブスクリプションアカウント。",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -915,6 +915,7 @@
   "The request body as received from the client — before memory injection and translation.": "클라이언트에서 수신된 요청 본문 — 메모리 주입 및 번역 이전.",
   "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "서버는 베이스 오리진 + /mcp에서 MCP Streamable HTTP 전송을 사용하며, API 키를 Bearer 토큰으로 인증합니다. 게이트웨이에서 memory.mcp.enabled로 활성화하세요. 그 전까지 /mcp는 404를 반환합니다.",
   "The session transcript is incomplete and this request cannot be recovered.": "세션 기록이 불완전하여 이 요청을 복원할 수 없습니다.",
+  "The session transcript is too large to recover safely.": "세션 기록이 너무 커서 안전하게 복원할 수 없습니다.",
   "The session transcript is unavailable or has been cleaned up.": "세션 기록을 사용할 수 없거나 이미 정리되었습니다.",
   "The subject is fixed — it identifies which fact a newer one supersedes.": "주제는 고정되어 있습니다 — 어떤 사실이 더 새로운 사실로 대체되는지 식별합니다.",
   "The subscription account that served this request, when applicable.": "해당하는 경우 이 요청을 처리한 구독 계정입니다.",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -915,6 +915,7 @@
   "The request body as received from the client — before memory injection and translation.": "O corpo da solicitação como recebido do cliente: antes da injeção de memória e da tradução.",
   "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "O servidor usa o transporte MCP Streamable HTTP na origem sem caminho + /mcp e autentica com sua API key como bearer token. Ative no gateway com memory.mcp.enabled; até lá /mcp retorna 404.",
   "The session transcript is incomplete and this request cannot be recovered.": "A transcrição da sessão está incompleta e esta solicitação não pode ser recuperada.",
+  "The session transcript is too large to recover safely.": "A transcrição da sessão é grande demais para ser recuperada com segurança.",
   "The session transcript is unavailable or has been cleaned up.": "A transcrição da sessão não está disponível ou foi limpa.",
   "The subject is fixed — it identifies which fact a newer one supersedes.": "O assunto é fixo: ele identifica qual fato uma versão mais nova substitui.",
   "The subscription account that served this request, when applicable.": "A conta de assinatura que serviu esta solicitação, quando aplicável.",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -915,6 +915,7 @@
   "The request body as received from the client — before memory injection and translation.": "从客户端收到的请求正文——在记忆注入和转换之前。",
   "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "服务器在裸源地址 + /mcp 上使用 MCP Streamable HTTP 传输，并以 Bearer 令牌形式用你的 API 密钥进行认证。需在网关上通过 memory.mcp.enabled 启用——在此之前 /mcp 返回 404。",
   "The session transcript is incomplete and this request cannot be recovered.": "会话转录不完整，无法恢复此请求。",
+  "The session transcript is too large to recover safely.": "会话转录过大，无法安全恢复。",
   "The session transcript is unavailable or has been cleaned up.": "会话转录不可用或已被清理。",
   "The subject is fixed — it identifies which fact a newer one supersedes.": "主题是固定的——它标识较新的事实取代了哪个事实。",
   "The subscription account that served this request, when applicable.": "实际处理此请求的订阅账号（如适用）。",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -915,6 +915,7 @@
   "The request body as received from the client — before memory injection and translation.": "從用戶端收到的請求正文——在記憶注入和轉換之前。",
   "The server uses the MCP Streamable HTTP transport at the bare origin + /mcp and authenticates with your API key as a bearer token. Enable it on the gateway with memory.mcp.enabled — until then /mcp returns 404.": "伺服器在裸源位址 + /mcp 上使用 MCP Streamable HTTP 傳輸，並以 Bearer 權杖形式用你的 API 金鑰進行認證。需在閘道上透過 memory.mcp.enabled 啟用——在此之前 /mcp 回傳 404。",
   "The session transcript is incomplete and this request cannot be recovered.": "工作階段轉錄不完整，無法還原此請求。",
+  "The session transcript is too large to recover safely.": "工作階段轉錄過大，無法安全還原。",
   "The session transcript is unavailable or has been cleaned up.": "工作階段轉錄不可用或已被清理。",
   "The subject is fixed — it identifies which fact a newer one supersedes.": "主題是固定的——它標識較新的事實取代了哪個事實。",
   "The subscription account that served this request, when applicable.": "實際處理此請求的訂閱帳號（如適用）。",

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -494,6 +494,8 @@
             {$t('The session transcript is unavailable or has been cleaned up.')}
           {:else if data.payload?.reason === 'session_incomplete'}
             {$t('The session transcript is incomplete and this request cannot be recovered.')}
+          {:else if data.payload?.reason === 'session_recovery_limited'}
+            {$t('The session transcript is too large to recover safely.')}
           {:else if data.payload?.reason === 'no_session'}
             {$t('This request has no captured Session ID, so no session transcript is available.')}
           {:else}

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -831,6 +831,26 @@ describe('requests detail page', () => {
     expect(screen.getByTestId('retry-request')).toBeDisabled();
   });
 
+  it('does not offer payload loading when Session recovery exceeds the safe limit', () => {
+    render(DetailPage, {
+      data: {
+        detail: detail(),
+        payload: {
+          captured: false,
+          source: 'unavailable',
+          reason: 'session_recovery_limited',
+        },
+        requestId: 'tr_session_limited',
+      },
+    });
+
+    expect(screen.getByTestId('payload-summary')).toHaveTextContent(
+      'The session transcript is too large to recover safely.',
+    );
+    expect(screen.queryByTestId('load-conversation')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('load-request-body')).not.toBeInTheDocument();
+  });
+
   it('surfaces a structured error with class, status, redacted message and redacted provider_raw', () => {
     render(DetailPage, {
       data: {

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -325,4 +325,22 @@ test.describe("admin request payload view", () => {
     await page.goto(`${BASE}/admin/requests/${SEED_TRACE_ID}`);
     await expect(page.getByTestId("payload-summary")).toContainText(/no captured Session ID/i);
   });
+
+  test("does not offer loading when Session recovery exceeds the safe limit", async ({ page }) => {
+    await page.route(`**/admin/api/requests/${SEED_TRACE_ID}/payload?part=meta`, async (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          captured: false,
+          source: "unavailable",
+          reason: "session_recovery_limited",
+        }),
+      }),
+    );
+
+    await page.goto(`${BASE}/admin/requests/${SEED_TRACE_ID}`);
+    await expect(page.getByTestId("payload-summary")).toContainText(/too large to recover safely/i);
+    await expect(page.getByTestId("load-conversation")).toHaveCount(0);
+    await expect(page.getByTestId("load-request-body")).toHaveCount(0);
+  });
 });

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1771,6 +1771,7 @@ describe("admin.api request payload", () => {
         requestId: "req_session",
         sessionRef: "session-ref",
         responseBodyStored: true,
+        recoveryWireBytes: 100,
         fidelity: "semantic",
         createdAt: new Date(1234),
       }),
@@ -1847,6 +1848,7 @@ describe("admin.api request payload", () => {
         requestId: "req_session_meta",
         sessionRef: "session-ref",
         responseBodyStored: true,
+        recoveryWireBytes: 100,
         fidelity: "semantic",
         createdAt: new Date(1234),
       }),
@@ -1866,6 +1868,74 @@ describe("admin.api request payload", () => {
       fidelity: "semantic",
       created_at: 1234,
       parts: { request: true, response: true, upstream_request: false },
+    });
+  });
+
+  it.each([
+    null,
+    1_000_000,
+  ] as const)("does not advertise a Session payload with unsafe recovery bytes (%s)", async (recoveryWireBytes) => {
+    const rec = {
+      ...decision("req_session_limited", "balanced"),
+      session: { ref: "session-ref", label: "thread-1", source: "x-thread-id" as const },
+    };
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayloadMeta: async () => null,
+      getSessionRevisionMeta: async () => ({
+        requestId: "req_session_limited",
+        sessionRef: "session-ref",
+        responseBodyStored: true,
+        recoveryWireBytes,
+        fidelity: "semantic",
+        createdAt: new Date(1234),
+      }),
+      listSessionRevisionsPage: async () => {
+        throw new Error("Session body must not be read for part=meta");
+      },
+    } as unknown as TelemetryStore;
+
+    const response = await buildApp(buildDeps({ telemetry })).request(
+      "/admin/api/requests/req_session_limited/payload?part=meta",
+    );
+
+    expect(await response.json()).toEqual({
+      captured: false,
+      source: "unavailable",
+      reason: "session_recovery_limited",
+    });
+  });
+
+  it("does not advertise a Session response for a failed request", async () => {
+    const rec = {
+      ...decision("req_session_failed", "balanced"),
+      session: { ref: "session-ref", label: "thread-1", source: "x-thread-id" as const },
+      final: {
+        ...decision("req_session_failed", "balanced").final,
+        status: "error" as const,
+        error_reason: "provider_error",
+      },
+    };
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayloadMeta: async () => null,
+      getSessionRevisionMeta: async () => ({
+        requestId: "req_session_failed",
+        sessionRef: "session-ref",
+        responseBodyStored: true,
+        recoveryWireBytes: 100,
+        fidelity: "semantic",
+        createdAt: new Date(1234),
+      }),
+    } as unknown as TelemetryStore;
+
+    const response = await buildApp(buildDeps({ telemetry })).request(
+      "/admin/api/requests/req_session_failed/payload?part=meta",
+    );
+
+    expect(await response.json()).toMatchObject({
+      captured: true,
+      parts: { request: true, response: false, upstream_request: false },
     });
   });
 

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -3,6 +3,7 @@ import type {
   RequestPayloadMeta,
   RequestPayloadPart,
   RequestPayloadPartRecord,
+  ResponseWorkAdmission,
   SessionRevisionRecord,
 } from "@helm/core";
 import {
@@ -142,6 +143,18 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
       if (!meta) {
         const sessionMeta = await deps.telemetry.getSessionRevisionMeta?.(traceId);
         if (sessionMeta) {
+          const responseAdmission = deps.responseWorkAdmission ?? runtimeResponseWorkAdmission();
+          if (
+            sessionMeta.recoveryWireBytes === null ||
+            sessionMeta.recoveryWireBytes > sessionRecoveryMaxWireBytes(responseAdmission)
+          ) {
+            return c.json({
+              captured: false,
+              source: "unavailable",
+              reason: "session_recovery_limited",
+            });
+          }
+          const decision = await deps.telemetry.getByRequestId(traceId);
           return c.json({
             captured: true,
             source: "session",
@@ -150,7 +163,7 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
             created_at: sessionMeta.createdAt.getTime(),
             parts: {
               request: true,
-              response: sessionMeta.responseBodyStored,
+              response: decision?.final.status === "ok" && sessionMeta.responseBodyStored,
               upstream_request: false,
             },
           });
@@ -295,9 +308,9 @@ async function getSessionRequest(
   const responseAdmission = deps.responseWorkAdmission ?? runtimeResponseWorkAdmission();
   // ponytail: half a response-work window lets inspection coexist with live API
   // traffic; add metadata-first admission if larger concurrent restores are needed.
-  const recoveryMaxWireBytes = Math.max(
-    1,
-    Math.floor(responseAdmission.capacityBytes / budget.jsonAmplification / 2),
+  const recoveryMaxWireBytes = sessionRecoveryMaxWireBytes(
+    responseAdmission,
+    budget.jsonAmplification,
   );
   // Reserve one whole safe recovery window before the adapter materializes even
   // the first page. Reserving after listPage() would let concurrent readers each
@@ -348,6 +361,13 @@ async function getSessionRequest(
   } finally {
     if (!releaseTransferred) acquired.lease.release();
   }
+}
+
+function sessionRecoveryMaxWireBytes(
+  responseAdmission: ResponseWorkAdmission,
+  jsonAmplification = runtimeMemoryBudget().jsonAmplification,
+): number {
+  return Math.max(1, Math.floor(responseAdmission.capacityBytes / jsonAmplification / 2));
 }
 
 function sessionRevisionWireBytes(revision: SessionRevisionRecord): number {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.39",
+  "version": "0.28.40",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -422,6 +422,9 @@ export interface SessionContinuationRecord {
 
 export interface SessionRevisionMetaRecord extends SessionContinuationRecord {
   sessionRef: string;
+  // UTF-8 bytes the current recovery path must materialize through this revision.
+  // null means legacy storage cannot be measured safely, so callers fail closed.
+  recoveryWireBytes: number | null;
   fidelity: string;
   createdAt: Date;
 }

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type DecisionRecord, DecisionRecordSchema } from "@helm/shared";
-import { and, asc, count, desc, eq, gt, gte, inArray, lt, type SQL, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, gte, inArray, lt, lte, type SQL, sql } from "drizzle-orm";
 import { shapeTelemetryAggregate, shapeTelemetryKeyUsage } from "../aggregate-shape.js";
 import { externalizeImages, type PayloadBlob, rehydrateImages } from "../payload-blobs.js";
 import { decodePayloadTextChunks, iteratePayloadTextChunks } from "../payload-codec.js";
@@ -63,6 +63,19 @@ const SESSION_PRUNE_MARKER = "__helm_pruning__";
 const PG_PRUNE_BATCH_ROWS = 16;
 const PG_PRUNE_TICK_ROWS = 128;
 const ORPHAN_CHUNK_TTL_MS = 86_400_000;
+const sessionRevisionWireBytes = sql<number>`
+  octet_length(${sessionRevisions.sessionRef}) +
+  octet_length(${sessionRevisions.requestId}) +
+  octet_length(coalesce(${sessionRevisions.parentRequestId}, '')) +
+  coalesce(
+    ${sessionRevisions.bodyBytes},
+    octet_length(${sessionRevisions.requestDeltaJson}) +
+    octet_length(${sessionRevisions.requestEnvelopeJson}) +
+    octet_length(coalesce(${sessionRevisions.responseJson}, ''))
+  ) +
+  octet_length(coalesce(${sessionRevisions.responseId}, '')) +
+  octet_length(${sessionRevisions.fidelity}) + 64
+`;
 
 function resultRows<T>(result: unknown): T[] {
   if (Array.isArray(result)) return result as T[];
@@ -491,21 +504,8 @@ export class PgTelemetryStore implements TelemetryStore {
   ): Promise<SessionRevisionPage> {
     const limit = boundedSessionPageLimit(options);
     const afterSequence = options.afterSequence ?? 0;
-    const rowBytes = sql<number>`
-      octet_length(${sessionRevisions.sessionRef}) +
-      octet_length(${sessionRevisions.requestId}) +
-      octet_length(coalesce(${sessionRevisions.parentRequestId}, '')) +
-      coalesce(
-        ${sessionRevisions.bodyBytes},
-        octet_length(${sessionRevisions.requestDeltaJson}) +
-        octet_length(${sessionRevisions.requestEnvelopeJson}) +
-        octet_length(coalesce(${sessionRevisions.responseJson}, ''))
-      ) +
-      octet_length(coalesce(${sessionRevisions.responseId}, '')) +
-      octet_length(${sessionRevisions.fidelity}) + 64
-    `;
     const metadata = await this.db
-      .select({ sequence: sessionRevisions.sequence, bytes: rowBytes })
+      .select({ sequence: sessionRevisions.sequence, bytes: sessionRevisionWireBytes })
       .from(sessionRevisions)
       .where(
         and(
@@ -571,6 +571,7 @@ export class PgTelemetryStore implements TelemetryStore {
         requestId: sessionRevisions.requestId,
         sessionRef: sessionRevisions.sessionRef,
         responseBodyStored: sql<boolean>`${sessionRevisions.responseJson} IS NOT NULL`,
+        sequence: sessionRevisions.sequence,
         fidelity: sessionRevisions.fidelity,
         createdAt: sessionRevisions.createdAt,
       })
@@ -578,7 +579,28 @@ export class PgTelemetryStore implements TelemetryStore {
       .where(eq(sessionRevisions.requestId, requestId))
       .limit(1);
     const row = rows[0];
-    return row ? { ...row, createdAt: new Date(row.createdAt) } : null;
+    if (!row) return null;
+    const recoveryRows = await this.db
+      .select({ bytes: sql<number>`sum(${sessionRevisionWireBytes})` })
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, row.sessionRef),
+          lte(sessionRevisions.sequence, row.sequence),
+        ),
+      );
+    const recoveryWireBytes = Number(recoveryRows[0]?.bytes);
+    return {
+      requestId: row.requestId,
+      sessionRef: row.sessionRef,
+      responseBodyStored: row.responseBodyStored,
+      recoveryWireBytes:
+        Number.isSafeInteger(recoveryWireBytes) && recoveryWireBytes >= 0
+          ? recoveryWireBytes
+          : null,
+      fidelity: row.fidelity,
+      createdAt: new Date(row.createdAt),
+    };
   }
 
   private async finishClaimedSessionPrune(

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -206,6 +206,45 @@ describe("SqliteTelemetryStore", () => {
     db.$sqlite.close();
   });
 
+  it("fails closed when Session recovery includes a legacy binary revision", async () => {
+    const db = createSqliteDb(":memory:");
+    const store = new SqliteTelemetryStore(db);
+    const first = {
+      sessionRef: "s-legacy-binary",
+      accountId: "a1",
+      apiKeyId: "k1",
+      source: "header",
+      externalSessionId: "external-legacy-binary",
+      requestId: "r1",
+      parentRequestId: null,
+      retainCount: 0,
+      requestDeltaJson: '["first"]',
+      requestEnvelopeJson: "{}",
+      responseId: null,
+      responseJson: null,
+      fidelity: "semantic",
+      createdAt: new Date(1_000),
+    } as const;
+    await store.upsertSessionRevision(first);
+    await store.upsertSessionRevision({
+      ...first,
+      requestId: "r2",
+      parentRequestId: "r1",
+      requestDeltaJson: '["second"]',
+      createdAt: new Date(2_000),
+    });
+    db.$sqlite
+      .prepare(
+        "UPDATE session_revisions SET request_delta_json = x'1f8b00', body_bytes = NULL WHERE request_id = 'r1'",
+      )
+      .run();
+
+    await expect(store.getSessionRevisionMeta("r2")).resolves.toMatchObject({
+      recoveryWireBytes: null,
+    });
+    db.$sqlite.close();
+  });
+
   it("pages mixed Session rows by uncompressed bytes and returns decoded text", async () => {
     const db = createSqliteDb(":memory:");
     const store = new SqliteTelemetryStore(db);

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type DecisionRecord, DecisionRecordSchema } from "@helm/shared";
-import { and, asc, count, desc, eq, gt, gte, inArray, lt, type SQL, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, gte, inArray, lt, lte, type SQL, sql } from "drizzle-orm";
 import { shapeTelemetryAggregate, shapeTelemetryKeyUsage } from "../aggregate-shape.js";
 import { externalizeImages, type PayloadBlob, rehydrateImages } from "../payload-blobs.js";
 import {
@@ -54,6 +54,19 @@ type SessionBodyChunkInsert = typeof sessionRevisionBodyChunks.$inferInsert;
 type SessionBodyPart = "request_delta" | "request_envelope" | "response";
 const SESSION_PRUNE_MARKER = "__helm_pruning__";
 const SESSION_CHUNKS_PER_WRITE = 4;
+const sessionRevisionWireBytes = sql<number>`
+  length(CAST(${sessionRevisions.sessionRef} AS BLOB)) +
+  length(CAST(${sessionRevisions.requestId} AS BLOB)) +
+  coalesce(length(CAST(${sessionRevisions.parentRequestId} AS BLOB)), 0) +
+  coalesce(
+    ${sessionRevisions.bodyBytes},
+    length(CAST(${sessionRevisions.requestDeltaJson} AS BLOB)) +
+    length(CAST(${sessionRevisions.requestEnvelopeJson} AS BLOB)) +
+    coalesce(length(CAST(${sessionRevisions.responseJson} AS BLOB)), 0)
+  ) +
+  coalesce(length(CAST(${sessionRevisions.responseId} AS BLOB)), 0) +
+  length(CAST(${sessionRevisions.fidelity} AS BLOB)) + 64
+`;
 
 function decodeSessionRevisionRow(
   row: SessionRevisionRow,
@@ -553,23 +566,10 @@ export class SqliteTelemetryStore implements TelemetryStore {
   ): Promise<SessionRevisionPage> {
     const limit = boundedSessionPageLimit(options);
     const afterSequence = options.afterSequence ?? 0;
-    const rowBytes = sql<number>`
-      length(CAST(${sessionRevisions.sessionRef} AS BLOB)) +
-      length(CAST(${sessionRevisions.requestId} AS BLOB)) +
-      coalesce(length(CAST(${sessionRevisions.parentRequestId} AS BLOB)), 0) +
-      coalesce(
-        ${sessionRevisions.bodyBytes},
-        length(CAST(${sessionRevisions.requestDeltaJson} AS BLOB)) +
-        length(CAST(${sessionRevisions.requestEnvelopeJson} AS BLOB)) +
-        coalesce(length(CAST(${sessionRevisions.responseJson} AS BLOB)), 0)
-      ) +
-      coalesce(length(CAST(${sessionRevisions.responseId} AS BLOB)), 0) +
-      length(CAST(${sessionRevisions.fidelity} AS BLOB)) + 64
-    `;
     const metadata = this.db
       .select({
         sequence: sessionRevisions.sequence,
-        bytes: rowBytes,
+        bytes: sessionRevisionWireBytes,
         legacyBinary: sql<number>`${sessionRevisions.bodyBytes} IS NULL AND (
           typeof(${sessionRevisions.requestDeltaJson}) = 'blob' OR
           typeof(${sessionRevisions.requestEnvelopeJson}) = 'blob' OR
@@ -649,21 +649,47 @@ export class SqliteTelemetryStore implements TelemetryStore {
         requestId: sessionRevisions.requestId,
         sessionRef: sessionRevisions.sessionRef,
         responseBodyStored: sql<number>`${sessionRevisions.responseJson} IS NOT NULL`,
+        sequence: sessionRevisions.sequence,
         fidelity: sessionRevisions.fidelity,
         createdAt: sessionRevisions.createdAt,
       })
       .from(sessionRevisions)
       .where(eq(sessionRevisions.requestId, requestId))
       .get();
-    return row
-      ? {
-          requestId: row.requestId,
-          sessionRef: row.sessionRef,
-          responseBodyStored: Boolean(row.responseBodyStored),
-          fidelity: row.fidelity,
-          createdAt: row.createdAt,
-        }
-      : null;
+    if (!row) return null;
+    const recovery = this.db
+      .select({
+        bytes: sql<number | null>`CASE
+          WHEN sum(CASE WHEN ${sessionRevisions.bodyBytes} IS NULL AND (
+            typeof(${sessionRevisions.requestDeltaJson}) = 'blob' OR
+            typeof(${sessionRevisions.requestEnvelopeJson}) = 'blob' OR
+            typeof(${sessionRevisions.responseJson}) = 'blob'
+          ) THEN 1 ELSE 0 END) > 0 THEN NULL
+          ELSE sum(${sessionRevisionWireBytes})
+        END`,
+      })
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, row.sessionRef),
+          lte(sessionRevisions.sequence, row.sequence),
+        ),
+      )
+      .get();
+    const recoveryWireBytes = Number(recovery?.bytes);
+    return {
+      requestId: row.requestId,
+      sessionRef: row.sessionRef,
+      responseBodyStored: Boolean(row.responseBodyStored),
+      recoveryWireBytes:
+        recovery?.bytes !== null &&
+        Number.isSafeInteger(recoveryWireBytes) &&
+        recoveryWireBytes >= 0
+          ? recoveryWireBytes
+          : null,
+      fidelity: row.fidelity,
+      createdAt: row.createdAt,
+    };
   }
 
   async pruneInactiveSessions(olderThanMs: number): Promise<number> {

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -637,12 +637,27 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         responseBodyStored: true,
       });
       expect(await t.findSessionRequestIdByResponseId("s_1", "resp_malicious")).toBeNull();
+      const expectedR1RecoveryBytes =
+        Buffer.byteLength("s_1r1", "utf8") +
+        Buffer.byteLength('["one"]{"model":"x"}{"output":["one"]}', "utf8") +
+        Buffer.byteLength("resp_1verbatim", "utf8") +
+        64;
       expect(await t.getSessionRevisionMeta("r1")).toEqual({
         requestId: "r1",
         sessionRef: "s_1",
         responseBodyStored: true,
+        recoveryWireBytes: expectedR1RecoveryBytes,
         fidelity: "verbatim",
         createdAt: new Date(1000),
+      });
+      const expectedR2RecoveryBytes =
+        expectedR1RecoveryBytes +
+        Buffer.byteLength("s_1r2r1", "utf8") +
+        Buffer.byteLength('["two"]{"model":"x"}{"output":["two"]}', "utf8") +
+        Buffer.byteLength("resp_2verbatim", "utf8") +
+        64;
+      expect(await t.getSessionRevisionMeta("r2")).toMatchObject({
+        recoveryWireBytes: expectedR2RecoveryBytes,
       });
       expect(await t.listSessionRevisions("s_1")).toEqual([
         expect.objectContaining({


### PR DESCRIPTION
## Summary
- measure cumulative Session recovery bytes before advertising payload availability
- fail closed for oversized or legacy-unmeasurable transcripts and hide unavailable load actions
- stop advertising response bodies for failed requests
- bump patch version to 0.28.40

## Verification
- CI=true pnpm exec vitest run packages/core/src/store/sqlite/telemetry.test.ts packages/core/src/store/store-contract.test.ts apps/gateway/src/routes/admin/admin.test.ts (267 passed)
- CI=true pnpm --filter @helm/gateway exec playwright test e2e/admin.spec.ts --grep "does not offer loading when Session recovery exceeds the safe limit" (1 passed)
- CI=true pnpm typecheck
- pnpm --filter @helm/admin check
- pnpm build
- pnpm lint
- targeted Admin tests and locale checks