### PR TITLE
ci: cap Node test workers

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
           // majority, sub-ms) are unaffected. hookTimeout covers DB setup in hooks.
           testTimeout: 15_000,
           hookTimeout: 15_000,
+          // Self-hosted runners expose 32 host CPUs. Letting Vitest match that
+          // count cold-starts too many PGlite instances at once and makes valid
+          // queries miss the timeout under shared-host load.
+          maxWorkers: 4,
           environment: "node",
           // Native addons (better-sqlite3) must be loaded by Node's require, not
           // transformed by Vite — otherwise the .node bindings cannot be located.


### PR DESCRIPTION
## Summary
- cap Vitest Node workers at 4 on self-hosted runners
- prevent simultaneous PGlite cold starts from exhausting the shared host
- keep the existing 15-second timeout and full test coverage unchanged

## Evidence
- main CI attempts 1-3 timed out across unrelated PGlite tests with no assertion failures
- focused capped run passed 4 files / 165 tests in 86.54s
- complete SQLite/Postgres store contract passed before this CI-only change