### PR TITLE
ci: allow fast suite measured runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,14 @@ jobs:
       # Keep PGlite-backed Store tests on two workers without slowing every
       # unrelated unit test to the same concurrency.
       - run: pnpm test:ci:fast
-        timeout-minutes: 5
+        timeout-minutes: 7
 
   # PGlite starts an in-process WASM Postgres and runs migrations for each fresh
-  # database. Isolate every Store test in its own bounded job so it cannot delay
-  # unrelated unit checks or inherit their workers.
+  # database. Isolate every Store test on a fresh hosted runner so it cannot
+  # contend with unrelated jobs on the persistent runner pool.
   store:
     timeout-minutes: 8
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request_target' && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","docker"]') }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "pnpm -r typecheck && pnpm typecheck:ops",
     "typecheck:ops": "tsc --noEmit -p scripts/ops/tsconfig.json",
     "test": "vitest run",
-    "test:ci:fast": "vitest run --exclude='packages/core/src/store/**' --maxWorkers=1 --bail=1",
+    "test:ci:fast": "HELM_CI_FAST=1 vitest run --maxWorkers=2 --bail=1",
     "test:ci:store": "vitest run packages/core/src/store --maxWorkers=2 --bail=1",
     "test:watch": "vitest",
     "test:e2e": "pnpm --filter @helm/gateway test:e2e",

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -10,6 +10,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 const ciPath = resolve(repoRoot, ".github/workflows/ci.yml");
 const publishPath = resolve(repoRoot, ".github/workflows/publish.yml");
+const vitestConfigRaw = readFileSync(resolve(repoRoot, "vitest.config.ts"), "utf8");
+const packageJson = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8")) as {
+  scripts: Record<string, string>;
+};
 
 function jobBlock(raw: string, name: string): string {
   const start = raw.indexOf(`\n  ${name}:`);
@@ -34,6 +38,13 @@ describe("CI workflow", () => {
     for (const gate of ["pnpm typecheck", "pnpm lint", "pnpm test", "pnpm build"]) {
       expect(raw).toContain(gate);
     }
+  });
+
+  it("keeps Store tests out of the fast suite and in their isolated suite", () => {
+    expect(packageJson.scripts["test:ci:fast"]).toContain("HELM_CI_FAST=1");
+    expect(packageJson.scripts["test:ci:store"]).toContain("vitest run packages/core/src/store");
+    expect(vitestConfigRaw).toContain('process.env.HELM_CI_FAST === "1"');
+    expect(vitestConfigRaw).toContain('"**/src/store/**"');
   });
 
   it("uses the default-branch workflow for pull requests and still runs on main pushes", () => {
@@ -97,8 +108,13 @@ describe("CI workflow", () => {
       const job = jobBlock(raw, name);
       expect(job, `${name} job must exist`).not.toBe("");
       expect(job).toContain("github.event_name == 'pull_request_target'");
-      expect(job).toContain('["ubuntu-24.04"]');
-      expect(job).toContain('["self-hosted","Linux","X64","docker"]');
+      if (name === "store") {
+        expect(job).toContain("runs-on: ubuntu-24.04");
+        expect(job).not.toContain('["self-hosted","Linux","X64","docker"]');
+      } else {
+        expect(job).toContain('["ubuntu-24.04"]');
+        expect(job).toContain('["self-hosted","Linux","X64","docker"]');
+      }
       expect(job).toContain("refs/pull/{0}/merge");
       expect(job).toContain("fetch-depth: 2");
       expect(job).toContain(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
+const excludeStoreTests = process.env.HELM_CI_FAST === "1";
+
 export default defineConfig({
   test: {
     // Sixteen self-hosted runners share the 32-core host. Limit the top-level
@@ -26,6 +28,7 @@ export default defineConfig({
           exclude: [
             "**/node_modules/**",
             "**/dist/**",
+            ...(excludeStoreTests ? ["**/src/store/**"] : []),
             "packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts",
           ],
           // PGlite starts a WASM Postgres and runs every migration for each fresh


### PR DESCRIPTION
Root cause from the first post-merge run: the fast-suite exclude was scoped incorrectly, so Store/Postgres tests still ran twice. This PR fixes the glob to exclude Store tests from verify, keeps them in a dedicated hosted Store job, restores the non-Store suite to the existing two-worker fair share, and sets a bounded 7-minute step limit. Store passed 580 tests on the hosted runner in 3m58s; hard job caps and bail-on-first-failure remain.