### PR TITLE
ci: isolate verify from shared runner load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
   verify:
     # Bound a genuinely stuck verify run; GitHub's default is six hours.
     timeout-minutes: 10
-    # Untrusted pull-request code must never reach the persistent runner pool.
-    # Trusted main pushes retain the labelled self-hosted pool for throughput.
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request_target' && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","docker"]') }}
+    # Keep the broad unit suite off the shared self-hosted machine: concurrent
+    # runner processes there can consume this job's entire bounded runtime.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -108,7 +108,7 @@ describe("CI workflow", () => {
       const job = jobBlock(raw, name);
       expect(job, `${name} job must exist`).not.toBe("");
       expect(job).toContain("github.event_name == 'pull_request_target'");
-      if (name === "store") {
+      if (name === "verify" || name === "store") {
         expect(job).toContain("runs-on: ubuntu-24.04");
         expect(job).not.toContain('["self-hosted","Linux","X64","docker"]');
       } else {


### PR DESCRIPTION
The first post-merge main run proved the filtered verify suite still lost its 10-minute job budget because 16 self-hosted runner processes share one machine: setup consumed about four minutes before tests started. Run verify on a fresh hosted runner, keeping the existing 7-minute test and 10-minute job hard caps. Store remains separately hosted; e2e and Docker stay on the main self-hosted pool.