### PR TITLE
fix(gateway): release HALF_OPEN probe lock on non-failure exits

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -6897,7 +6897,9 @@ describe("createExecute — HALF_OPEN probe lock release", () => {
     const { cb, now } = openThenCooldownElapsed(alias);
     const recordAbort = vi.spyOn(cb, "recordAbort");
     const recordFailure = vi.spyOn(cb, "recordFailure");
-    const oauth429 = rejects(new UpstreamError("upstream_error", "upstream returned 429", null, 429));
+    const oauth429 = rejects(
+      new UpstreamError("upstream_error", "upstream returned 429", null, 429),
+    );
     const ok = resolves({ id: "fallback-ok" });
     const mk = () =>
       createExecute({
@@ -6934,8 +6936,8 @@ describe("createExecute — HALF_OPEN probe lock release", () => {
     expect(next.attempts[0]?.alias).toBe(alias);
     expect(next.attempts[0]?.skip_reason).not.toBe("circuit_open");
     expect(
-      (oauth429 as unknown as { chatCompletion: ReturnType<typeof vi.fn> }).chatCompletion.mock.calls
-        .length,
+      (oauth429 as unknown as { chatCompletion: ReturnType<typeof vi.fn> }).chatCompletion.mock
+        .calls.length,
     ).toBeGreaterThanOrEqual(2);
   });
 

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -6856,6 +6856,179 @@ describe("createExecute — onOAuthSubscription429 (auto-park)", () => {
   });
 });
 
+// HALF_OPEN probe lock must be released on every non-success exit after canAttempt
+// allowed the alias. Production incident 2026-08-06: OAuth 429 skipped recordFailure
+// (correct — account-scoped) but never recordAbort, so inFlightProbe stayed true and
+// anthropic/claude-opus-4-8 returned circuit_open for hours while other Anthropic
+// models served fine. Same leak exists for post-canAttempt capability/protocol skips
+// and other "do not trip breaker" continues.
+describe("createExecute — HALF_OPEN probe lock release", () => {
+  const rejects = (err: unknown) =>
+    ({
+      chatCompletion: vi.fn().mockRejectedValue(err),
+      chatCompletionStream: vi.fn(),
+    }) as unknown as ProviderClient;
+  const resolves = (body: unknown = { id: "ok" }) =>
+    ({
+      chatCompletion: vi.fn().mockResolvedValue(body),
+      chatCompletionStream: vi.fn(),
+    }) as unknown as ProviderClient;
+
+  function openThenCooldownElapsed(alias: string): {
+    cb: CircuitBreaker;
+    now: () => number;
+  } {
+    let t = 0;
+    const now = () => t;
+    // cooldownMs=1000 matches breaker(); advance past cooldown after tripping.
+    const cb = createCircuitBreaker({
+      config: { failureThreshold: 5, cooldownMs: 1000 },
+      now,
+    });
+    for (let i = 0; i < 5; i += 1) cb.recordFailure(alias);
+    expect(cb.getState(alias)).toBe("OPEN");
+    t = 1000; // cooldown elapsed → next canAttempt becomes HALF_OPEN probe
+    return { cb, now };
+  }
+
+  it("releases the probe lock when a HALF_OPEN OAuth probe hits account-scoped 429 (no recordFailure)", async () => {
+    const alias = "anthropic/claude-opus-4-8";
+    const fallback = "openai-codex/gpt-5.6-sol";
+    const { cb, now } = openThenCooldownElapsed(alias);
+    const recordAbort = vi.spyOn(cb, "recordAbort");
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const oauth429 = rejects(new UpstreamError("upstream_error", "upstream returned 429", null, 429));
+    const ok = resolves({ id: "fallback-ok" });
+    const mk = () =>
+      createExecute({
+        defaultProvider: ok,
+        providers: new Map([
+          ["anthropic", oauth429],
+          ["openai-codex", ok],
+        ]),
+        knownOAuthPrefixes: new Set(["anthropic", "openai-codex"]),
+        oauthAliases: () => new Set([alias, fallback]),
+        registry: registryWithProviders({
+          [alias]: { providerName: "anthropic", providerModel: "claude-opus-4-8" },
+          [fallback]: { providerName: "openai-codex", providerModel: "gpt-5.6-sol" },
+        }),
+        breaker: cb,
+        catalog: new Map(),
+        now,
+        signal: new AbortController().signal,
+      });
+
+    // Probe request: 429 is account-scoped → must NOT recordFailure, MUST recordAbort
+    // so the alias does not stay stuck HALF_OPEN forever.
+    const probeOut = await mk()(plan([alias, fallback]), req());
+    expect(probeOut.final.status).toBe("ok");
+    expect(recordFailure).not.toHaveBeenCalledWith(alias);
+    expect(recordAbort).toHaveBeenCalledWith(alias);
+    // Design lock: abort releases the probe lock WITHOUT re-OPENing. Re-trip would
+    // punish a healthy alias for a per-account throttle (the reason recordFailure is
+    // skipped). Staying HALF_OPEN lets the next request re-probe immediately.
+    expect(cb.getState(alias)).toBe("HALF_OPEN");
+
+    // Next request must be allowed to attempt Anthropic again (not permanent circuit_open).
+    const next = await mk()(plan([alias, fallback]), req());
+    expect(next.attempts[0]?.alias).toBe(alias);
+    expect(next.attempts[0]?.skip_reason).not.toBe("circuit_open");
+    expect(
+      (oauth429 as unknown as { chatCompletion: ReturnType<typeof vi.fn> }).chatCompletion.mock.calls
+        .length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("releases the probe lock when a HALF_OPEN candidate is skipped by capability after canAttempt", async () => {
+    const alias = "anthropic/claude-opus-4-8";
+    const fallback = "mock/ok";
+    const { cb, now } = openThenCooldownElapsed(alias);
+    const recordAbort = vi.spyOn(cb, "recordAbort");
+    const ok = resolves({ id: "fallback-ok" });
+    // Force tools capability miss so checkCapability skips after canAttempt allowed the probe.
+    const noTools: CatalogEntry = {
+      modelKey: alias,
+      capabilities: {
+        supportsTools: false,
+        jsonOutput: "schema",
+        supportsVision: true,
+        supportsStreaming: true,
+        maxContextTokens: 100000,
+        maxOutputTokens: 4096,
+      },
+      pricing: {
+        inputPerMTokUsd: null,
+        outputPerMTokUsd: null,
+        cacheReadPerMTokUsd: null,
+        cacheWritePerMTokUsd: null,
+      },
+      source: "generated",
+    };
+    const mk = () =>
+      createExecute({
+        defaultProvider: ok,
+        providers: new Map([
+          ["anthropic", ok],
+          ["mock", ok],
+        ]),
+        knownOAuthPrefixes: new Set(["anthropic"]),
+        oauthAliases: () => new Set([alias]),
+        registry: registryWithProviders({
+          [alias]: { providerName: "anthropic", providerModel: "claude-opus-4-8" },
+          [fallback]: { providerName: "mock", providerModel: "ok" },
+        }),
+        breaker: cb,
+        catalog: new Map([[alias, noTools]]),
+        now,
+        signal: new AbortController().signal,
+      });
+
+    const toolReq = req({ tools: [{ type: "function" }] });
+    const probeOut = await mk()(plan([alias, fallback]), toolReq);
+    expect(probeOut.attempts[0]?.skip_reason).toBe("no_tool_support");
+    expect(recordAbort).toHaveBeenCalledWith(alias);
+
+    // Without tools, the same alias must not still be circuit_open from a leaked probe.
+    const plain = await mk()(plan([alias, fallback]), req());
+    expect(plain.attempts[0]?.skip_reason).not.toBe("circuit_open");
+    expect(plain.final.status).toBe("ok");
+  });
+
+  it("releases the probe lock on free-tier 429 continue (no recordFailure)", async () => {
+    const alias = "openrouter/free-model:free";
+    const fallback = "mock/ok";
+    const { cb, now } = openThenCooldownElapsed(alias);
+    const recordAbort = vi.spyOn(cb, "recordAbort");
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const free429 = rejects(new UpstreamError("upstream_error", "rate limited", null, 429));
+    const ok = resolves({ id: "ok" });
+    const mk = () =>
+      createExecute({
+        defaultProvider: ok,
+        providers: new Map([
+          ["mock", free429],
+          ["mock-ok", ok],
+        ]),
+        registry: registryWithProviders({
+          [alias]: { providerName: "mock", providerModel: "free-model" },
+          [fallback]: { providerName: "mock-ok", providerModel: "ok" },
+        }),
+        breaker: cb,
+        catalog: new Map(),
+        now,
+        signal: new AbortController().signal,
+      });
+
+    const out = await mk()(plan([alias, fallback]), req());
+    expect(out.attempts[0]?.skip_reason).toBe("free_429");
+    expect(recordFailure).not.toHaveBeenCalledWith(alias);
+    expect(recordAbort).toHaveBeenCalledWith(alias);
+
+    const next = await mk()(plan([alias, fallback]), req());
+    expect(next.attempts[0]?.skip_reason).not.toBe("circuit_open");
+  });
+});
+
 // ── Additional branch-coverage tests ────────────────────────────────────────
 
 describe("createExecute — empty candidate chain", () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1671,368 +1671,139 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       };
 
       try {
-      // 2) Capability filter. Missing catalog data remains fail-open for generic
-      // requests, but not for cached_content: that field is a required Gemini/LiteLLM
-      // cached context handle, not an optional affinity hint.
-      const catalogEntry = xaiCatalogEntry(alias, providerModel);
-      const caps = catalogEntry?.capabilities;
-      const exactContextLimit = effectiveContextLimit(catalogEntry, providerModel);
-      const canUseExactContextPreflight =
-        target.targetProviderProtocol === "anthropic_messages" &&
-        req.native_request !== undefined &&
-        provider.countTokens !== undefined &&
-        exactContextLimit !== null;
-      if (!caps && isOAuthSubscriptionAlias(alias) && alias.startsWith("xai/")) {
-        capabilityPruned = true;
-        attempts.push(skipRow(alias, "capability_metadata_missing", elapsed()));
-        continue;
-      }
-      if (!caps && needsCachedContent) {
-        capabilityPruned = true;
-        attempts.push(skipRow(alias, "no_cached_content_support", elapsed()));
-        continue;
-      }
-      if (caps) {
-        const estimatedPromptTokens = approxPromptTokens(req);
-        const verdict = checkCapability(caps, {
-          needsTools: Array.isArray(req.tools) && req.tools.length > 0,
-          needsJson: isJson(req.response_format),
-          needsResponseSchema: isJsonSchema(req.response_format),
-          needsVision:
-            (Array.isArray(req.attachments) && req.attachments.length > 0) || reqModalities.image,
-          needsStreaming: req.stream,
-          needsCachedContent,
-          // Prefer Anthropic's exact native count when available. Passing zero only
-          // defers the approximate input gate; max_tokens and every other capability
-          // check still run here.
-          estimatedPromptTokens: canUseExactContextPreflight ? 0 : estimatedPromptTokens,
-          maxTokens: req.max_tokens,
-          needsAudio: reqModalities.audio,
-          needsVideo: reqModalities.video,
-          needsDocument: reqModalities.document,
-        });
-        if (!verdict.ok) {
+        // 2) Capability filter. Missing catalog data remains fail-open for generic
+        // requests, but not for cached_content: that field is a required Gemini/LiteLLM
+        // cached context handle, not an optional affinity hint.
+        const catalogEntry = xaiCatalogEntry(alias, providerModel);
+        const caps = catalogEntry?.capabilities;
+        const exactContextLimit = effectiveContextLimit(catalogEntry, providerModel);
+        const canUseExactContextPreflight =
+          target.targetProviderProtocol === "anthropic_messages" &&
+          req.native_request !== undefined &&
+          provider.countTokens !== undefined &&
+          exactContextLimit !== null;
+        if (!caps && isOAuthSubscriptionAlias(alias) && alias.startsWith("xai/")) {
           capabilityPruned = true;
-          if (verdict.skipReason === "context_too_small") {
-            const limit = exactContextLimit ?? caps.maxContextTokens;
-            const estimatedTotal = estimatedPromptTokens + (req.max_tokens ?? 0);
-            rememberContextOverflow(
-              `prompt is too long: ${Math.trunc(estimatedTotal)} tokens > ${Math.trunc(
-                limit,
-              )} maximum`,
-              null,
-            );
-          }
-          attempts.push(skipRow(alias, verdict.skipReason ?? "capability", elapsed()));
+          attempts.push(skipRow(alias, "capability_metadata_missing", elapsed()));
           continue;
         }
-      }
-
-      const protocolSkip = protocolGuardSkipReason(req, target.targetProviderProtocol);
-      if (protocolSkip !== null) {
-        capabilityPruned = true;
-        attempts.push(skipRow(alias, protocolSkip, elapsed()));
-        continue;
-      }
-
-      const candidateSkip = candidateGuardSkipReason(req, target, alias);
-      if (candidateSkip !== null) {
-        capabilityPruned = true;
-        attempts.push(skipRow(alias, candidateSkip, elapsed()));
-        continue;
-      }
-
-      // Native protocol passthrough decision for THIS attempt (issue #217), computed
-      // before the Anthropic count_tokens preflight so visual compression can reduce
-      // an over-window native request before we decide to skip the candidate.
-      const passthrough = decideNativePassthroughForAttempt({
-        req,
-        target,
-        enabled: nativeProtocolPassthroughEnabled?.() === true,
-      });
-      if (req.provider_raw?.generate === false && !passthrough.passthrough_used) {
-        capabilityPruned = true;
-        attempts.push(
-          skipRow(alias, "responses_generate_false_requires_native_passthrough", elapsed()),
-        );
-        continue;
-      }
-      let visualCompressionMutation: VisualContextCompressionMutation | undefined;
-      let optimizedNativeBody: Record<string, unknown> | null = null;
-      const optimizeAnthropicBodyForAttempt = async (
-        body: Record<string, unknown>,
-      ): Promise<Record<string, unknown>> => {
-        if (target.targetProviderProtocol !== "anthropic_messages") return body;
-        try {
-          const optimized = await visualContextCompressor({
-            mode: visualContextCompressionMode?.() ?? "off",
-            targetProviderProtocol: target.targetProviderProtocol,
-            model: providerModel,
-            body,
-            capabilities: caps,
-            requestId: req.request_id,
-          });
-          visualCompressionMutation = optimized.mutation;
-          return optimized.body;
-        } catch (err) {
-          log?.("warn", "visual_context_compression.failed_open", {
-            alias,
-            error_class: errorClassOf(err),
-          });
-          return body;
+        if (!caps && needsCachedContent) {
+          capabilityPruned = true;
+          attempts.push(skipRow(alias, "no_cached_content_support", elapsed()));
+          continue;
         }
-      };
-      const optimizeNativeBodyForAttempt = async (
-        input: NativePassthroughCarrier | Record<string, unknown>,
-      ): Promise<NativePassthroughCarrier | Record<string, unknown>> => {
-        if (!passthrough.passthrough_used) return input;
-        const body = nativePassthroughBody(input);
-        if (optimizedNativeBody === null) {
-          optimizedNativeBody = await optimizeAnthropicBodyForAttempt(body);
-        }
-        return isNativePassthroughCarrier(input)
-          ? cloneCarrierWithBody(input, optimizedNativeBody)
-          : optimizedNativeBody;
-      };
-
-      if (
-        target.targetProviderProtocol === "anthropic_messages" &&
-        req.native_request !== undefined &&
-        provider.countTokens !== undefined &&
-        exactContextLimit !== null
-      ) {
-        try {
-          const countInput = prepareNativeRequestForUpstream(
-            { ...nativePassthroughBody(req.native_request) },
-            providerModel,
-            req.protocol,
-            false,
-            provider.nativeProtocolProfile,
-            req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
-            caps,
-            req.reasoning_effort,
-          );
-          const optimizedCountInput = await optimizeNativeBodyForAttempt(countInput);
-          const countBody = { ...nativePassthroughBody(optimizedCountInput) };
-          delete countBody.stream;
-          const tokenCount = await provider.countTokens(countBody, { signal });
-          const inputTokens = countTokensInputTokens(tokenCount);
-          if (inputTokens !== null && inputTokens > exactContextLimit) {
+        if (caps) {
+          const estimatedPromptTokens = approxPromptTokens(req);
+          const verdict = checkCapability(caps, {
+            needsTools: Array.isArray(req.tools) && req.tools.length > 0,
+            needsJson: isJson(req.response_format),
+            needsResponseSchema: isJsonSchema(req.response_format),
+            needsVision:
+              (Array.isArray(req.attachments) && req.attachments.length > 0) || reqModalities.image,
+            needsStreaming: req.stream,
+            needsCachedContent,
+            // Prefer Anthropic's exact native count when available. Passing zero only
+            // defers the approximate input gate; max_tokens and every other capability
+            // check still run here.
+            estimatedPromptTokens: canUseExactContextPreflight ? 0 : estimatedPromptTokens,
+            maxTokens: req.max_tokens,
+            needsAudio: reqModalities.audio,
+            needsVideo: reqModalities.video,
+            needsDocument: reqModalities.document,
+          });
+          if (!verdict.ok) {
             capabilityPruned = true;
-            rememberContextOverflow(
-              `prompt is too long: ${Math.trunc(inputTokens)} tokens > ${Math.trunc(
-                exactContextLimit,
-              )} maximum`,
-              null,
-              contextConfirmationKey,
-            );
-            attempts.push(skipRow(alias, "context_too_small", elapsed()));
+            if (verdict.skipReason === "context_too_small") {
+              const limit = exactContextLimit ?? caps.maxContextTokens;
+              const estimatedTotal = estimatedPromptTokens + (req.max_tokens ?? 0);
+              rememberContextOverflow(
+                `prompt is too long: ${Math.trunc(estimatedTotal)} tokens > ${Math.trunc(
+                  limit,
+                )} maximum`,
+                null,
+              );
+            }
+            attempts.push(skipRow(alias, verdict.skipReason ?? "capability", elapsed()));
             continue;
           }
-        } catch (err) {
-          log?.("warn", "anthropic.count_tokens_preflight_failed", {
-            alias,
-            error_class: errorClassOf(err),
-            upstream_status: upstreamStatusOf(err),
-          });
         }
-      }
-      // Past the gates → this candidate is attempted against the upstream. A
-      // failure from here on is a PROVIDER fault, not a capability gap.
-      attemptedAny = true;
 
-      let attemptTelemetry: PassthroughTelemetry = passthrough;
+        const protocolSkip = protocolGuardSkipReason(req, target.targetProviderProtocol);
+        if (protocolSkip !== null) {
+          capabilityPruned = true;
+          attempts.push(skipRow(alias, protocolSkip, elapsed()));
+          continue;
+        }
 
-      // 3) Invoke the provider (stream or non-stream). We send the RESOLVED
-      //    provider model (not the originally-requested alias) — the gateway
-      //    picked this model, so the upstream must be told which one to run.
-      try {
-        // Capture sink for the EXACT bytes forwarded upstream (AFTER memory injection +
-        // protocol translation). Each provider fires this just before its HTTP POST with
-        // the serialized provider-native body; the value the SERVED attempt captured
-        // becomes ExecuteOutcome.upstreamRequest. Scoped per candidate (reset each loop).
-        let capturedUpstream: string | null = null;
-        const captureUpstream = (wireBody: string): void => {
-          capturedUpstream = wireBody;
-        };
-        let capturedResponseMetadata: Record<string, string> | undefined;
-        const onResponseMeta = (headers: Headers): void => {
-          capturedResponseMetadata = safeResponseMetadata(headers);
-        };
-        if (req.stream && passthrough.passthrough_used) {
-          // Native STREAMING passthrough (issue #217, Phase 2): forward the client's
-          // VERBATIM native body (which ALREADY carries stream:true) to the upstream and
-          // BYTE-RELAY the upstream SSE back — NO translation. peekStream peeks the first
-          // chunk for the breaker contract (pre-first-chunk failure → recordFailure +
-          // chain advance below; healthy → recordSuccess), only the SOURCE iterable
-          // differs (nativePassthroughStream vs chatCompletionStream). The method +
-          // native body are guaranteed present (the guard's providerSupportsPassthrough
-          // feature-detected nativePassthroughStream, hasNativeRequest proved the body);
-          // narrow defensively for type-safety (unreachable after the guard).
-          const passthroughStream = provider.nativePassthroughStream;
-          const nativeBody = req.native_request;
-          if (!passthroughStream || !nativeBody) {
-            throw new Error(
-              "native streaming passthrough invoked without a native request or client method",
-            );
-          }
-          // Patch ONLY `model` to the RESOLVED upstream id (issue #217): the gateway
-          // chose this provider/model, so the upstream must be told which one to run —
-          // the client's `model` is the routing alias (e.g. `anthropic/claude-…`), not
-          // a real upstream model id. Everything else is forwarded verbatim. Mirrors
-          // stripInternal's `model: providerModel`; without it the upstream 404s.
-          const passthroughBody = await optimizeNativeBodyForAttempt(
-            prepareNativeRequestForUpstream(
-              nativeBody,
-              providerModel,
-              req.protocol,
-              true,
-              provider.nativeProtocolProfile,
-              req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
-              caps,
-              req.reasoning_effort,
-            ),
-          );
-          if (hasResponsesContinuation(req)) {
-            const mutations = nativePassthroughMutations(passthroughBody);
-            if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
-          }
-          passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
-          attemptTelemetry = withRequestMutations(
-            passthrough,
-            visualCompressionMutationLedger(visualCompressionMutation),
-          );
-          // Pre-output failover guard (principle 5 + 8): a same-protocol byte-relay
-          // that 200s then fails IN-BAND before any output (e.g. Responses
-          // `response.failed`/server_is_overloaded after only the `response.created`
-          // preamble) must fall back, not stream the error as success. The guard
-          // buffers preamble and turns a pre-output error frame into a pre-first-chunk
-          // throw → peekStream records a breaker failure and advances the chain. null
-          // classifier (gemini) → unchanged commit-on-first behavior.
-          const passthroughClassifier = preOutputClassifierFor(req.protocol);
-          const stream = await withAttemptDeadline(
-            req.attempt_timeout_ms,
-            signal,
-            (attemptSignal) =>
-              peekStream(
-                () => {
-                  const raw = passthroughStream(passthroughBody, {
-                    signal: attemptSignal,
-                    ...(req.metadata.stateful_provider_account
-                      ? { statefulAccount: req.metadata.stateful_provider_account }
-                      : {}),
-                    captureUpstream,
-                    onResponseMeta,
-                    toolCallXmlRecovery:
-                      target.targetProviderProtocol === "anthropic_messages" &&
-                      (toolCallXmlRecoveryEnabled?.() ?? true),
-                  });
-                  return passthroughClassifier
-                    ? guardPreOutputFailure(raw, passthroughClassifier)
-                    : raw;
-                },
-                attemptSignal,
-                alias,
-                log,
-              ),
-          );
-          settleBreaker("success");
-          // Streamed usage is not known at peek time → cost null, backfilled later.
-          attempts.push(okRow(alias, elapsed(), null, attemptTelemetry));
-          return {
-            attempts,
-            final: { status: "ok", alias, providerModel },
-            body: null,
-            stream,
-            nativePassthrough: true,
-            upstreamRequest: capturedUpstream,
-            responseMetadata: capturedResponseMetadata,
-          };
+        const candidateSkip = candidateGuardSkipReason(req, target, alias);
+        if (candidateSkip !== null) {
+          capabilityPruned = true;
+          attempts.push(skipRow(alias, candidateSkip, elapsed()));
+          continue;
         }
-        if (req.stream) {
-          // Translate stream path (passthrough disabled): the existing byte-for-byte
-          // forward. peekStream opens chatCompletionStream(stripInternal); the row
-          // carries the (used:false) passthrough telemetry. No nativePassthrough marker.
-          const rendered = stripInternal(
-            req,
-            providerModel,
-            target.targetProviderProtocol,
-            caps,
-            target.provider?.nativeProtocolProfile === "generic_openai_responses",
+
+        // Native protocol passthrough decision for THIS attempt (issue #217), computed
+        // before the Anthropic count_tokens preflight so visual compression can reduce
+        // an over-window native request before we decide to skip the candidate.
+        const passthrough = decideNativePassthroughForAttempt({
+          req,
+          target,
+          enabled: nativeProtocolPassthroughEnabled?.() === true,
+        });
+        if (req.provider_raw?.generate === false && !passthrough.passthrough_used) {
+          capabilityPruned = true;
+          attempts.push(
+            skipRow(alias, "responses_generate_false_requires_native_passthrough", elapsed()),
           );
-          // Pre-output failover guard (principle 5 + 8): the translate generators
-          // ALREADY throw on a terminal error frame, but they yield an empty role
-          // preamble chunk first, so peekStream would commit success before the throw.
-          // The guard buffers that preamble so the commit lands on the first REAL
-          // output; a pre-output error (thrown by the generator, or an in-band error
-          // frame) stays a pre-first-chunk failure → fallback. Translate output is
-          // always OpenAI-Chat framed, so the chat classifier is always correct.
-          const translateClassifier = preOutputClassifierFor("openai_chat");
-          const stream = await withAttemptDeadline(
-            req.attempt_timeout_ms,
-            signal,
-            (attemptSignal) =>
-              peekStream(
-                () => {
-                  const raw = provider.chatCompletionStream(rendered.body, {
-                    signal: attemptSignal,
-                    ...(req.metadata.stateful_provider_account
-                      ? { statefulAccount: req.metadata.stateful_provider_account }
-                      : {}),
-                    captureUpstream,
-                    onResponseMeta,
-                    optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
-                  });
-                  return translateClassifier
-                    ? guardPreOutputFailure(raw, translateClassifier)
-                    : raw;
-                },
-                attemptSignal,
-                alias,
-                log,
-              ),
-          );
-          settleBreaker("success");
-          attemptTelemetry = withRequestMutations(
-            passthrough,
-            mergeRequestMutations(
-              rendered.request_mutations,
-              provider.streamReframed === true ? { stream_reframed: true } : undefined,
-              visualCompressionMutationLedger(visualCompressionMutation),
-            ),
-          );
-          // Streamed usage is not known at peek time → cost null (not measured).
-          attempts.push(okRow(alias, elapsed(), null, attemptTelemetry));
-          return {
-            attempts,
-            final: { status: "ok", alias, providerModel },
-            body: null,
-            stream,
-            upstreamRequest: capturedUpstream,
-            responseMetadata: capturedResponseMetadata,
-          };
+          continue;
         }
-        if (passthrough.passthrough_used) {
-          // Native passthrough: forward the client's VERBATIM native body to the
-          // upstream (NO OpenAI-Chat translation) and return the native response
-          // untouched. provider.nativePassthrough is guaranteed present here — the
-          // guard's providerSupportsPassthrough feature-detected it. Cost is priced
-          // off the native usage, normalized to OpenAI shape (usageFromAnthropicResponse)
-          // so resolveCostUsd applies the same token math as a translated attempt.
-          const passthroughInvoke = provider.nativePassthrough;
-          const nativeBody = req.native_request;
-          if (!passthroughInvoke || !nativeBody) {
-            // Unreachable: the guard's providerSupportsPassthrough + hasNativeRequest
-            // checks already proved both present. Narrow defensively for type-safety.
-            throw new Error("native passthrough invoked without a native request or client method");
+        let visualCompressionMutation: VisualContextCompressionMutation | undefined;
+        let optimizedNativeBody: Record<string, unknown> | null = null;
+        const optimizeAnthropicBodyForAttempt = async (
+          body: Record<string, unknown>,
+        ): Promise<Record<string, unknown>> => {
+          if (target.targetProviderProtocol !== "anthropic_messages") return body;
+          try {
+            const optimized = await visualContextCompressor({
+              mode: visualContextCompressionMode?.() ?? "off",
+              targetProviderProtocol: target.targetProviderProtocol,
+              model: providerModel,
+              body,
+              capabilities: caps,
+              requestId: req.request_id,
+            });
+            visualCompressionMutation = optimized.mutation;
+            return optimized.body;
+          } catch (err) {
+            log?.("warn", "visual_context_compression.failed_open", {
+              alias,
+              error_class: errorClassOf(err),
+            });
+            return body;
           }
-          // Patch ONLY `model` to the RESOLVED upstream id (issue #217): the client's
-          // `model` is the routing alias (e.g. `anthropic/claude-…`), but the gateway
-          // picked this upstream model — forward it so the upstream doesn't 404 on the
-          // alias. Everything else verbatim. Mirrors stripInternal's `model: providerModel`.
-          const passthroughBody = await optimizeNativeBodyForAttempt(
-            prepareNativeRequestForUpstream(
-              nativeBody,
+        };
+        const optimizeNativeBodyForAttempt = async (
+          input: NativePassthroughCarrier | Record<string, unknown>,
+        ): Promise<NativePassthroughCarrier | Record<string, unknown>> => {
+          if (!passthrough.passthrough_used) return input;
+          const body = nativePassthroughBody(input);
+          if (optimizedNativeBody === null) {
+            optimizedNativeBody = await optimizeAnthropicBodyForAttempt(body);
+          }
+          return isNativePassthroughCarrier(input)
+            ? cloneCarrierWithBody(input, optimizedNativeBody)
+            : optimizedNativeBody;
+        };
+
+        if (
+          target.targetProviderProtocol === "anthropic_messages" &&
+          req.native_request !== undefined &&
+          provider.countTokens !== undefined &&
+          exactContextLimit !== null
+        ) {
+          try {
+            const countInput = prepareNativeRequestForUpstream(
+              { ...nativePassthroughBody(req.native_request) },
               providerModel,
               req.protocol,
               false,
@@ -2040,317 +1811,554 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
               caps,
               req.reasoning_effort,
-            ),
-          );
-          if (hasResponsesContinuation(req)) {
-            const mutations = nativePassthroughMutations(passthroughBody);
-            if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
+            );
+            const optimizedCountInput = await optimizeNativeBodyForAttempt(countInput);
+            const countBody = { ...nativePassthroughBody(optimizedCountInput) };
+            delete countBody.stream;
+            const tokenCount = await provider.countTokens(countBody, { signal });
+            const inputTokens = countTokensInputTokens(tokenCount);
+            if (inputTokens !== null && inputTokens > exactContextLimit) {
+              capabilityPruned = true;
+              rememberContextOverflow(
+                `prompt is too long: ${Math.trunc(inputTokens)} tokens > ${Math.trunc(
+                  exactContextLimit,
+                )} maximum`,
+                null,
+                contextConfirmationKey,
+              );
+              attempts.push(skipRow(alias, "context_too_small", elapsed()));
+              continue;
+            }
+          } catch (err) {
+            log?.("warn", "anthropic.count_tokens_preflight_failed", {
+              alias,
+              error_class: errorClassOf(err),
+              upstream_status: upstreamStatusOf(err),
+            });
           }
-          passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
-          attemptTelemetry = withRequestMutations(
-            passthrough,
-            visualCompressionMutationLedger(visualCompressionMutation),
+        }
+        // Past the gates → this candidate is attempted against the upstream. A
+        // failure from here on is a PROVIDER fault, not a capability gap.
+        attemptedAny = true;
+
+        let attemptTelemetry: PassthroughTelemetry = passthrough;
+
+        // 3) Invoke the provider (stream or non-stream). We send the RESOLVED
+        //    provider model (not the originally-requested alias) — the gateway
+        //    picked this model, so the upstream must be told which one to run.
+        try {
+          // Capture sink for the EXACT bytes forwarded upstream (AFTER memory injection +
+          // protocol translation). Each provider fires this just before its HTTP POST with
+          // the serialized provider-native body; the value the SERVED attempt captured
+          // becomes ExecuteOutcome.upstreamRequest. Scoped per candidate (reset each loop).
+          let capturedUpstream: string | null = null;
+          const captureUpstream = (wireBody: string): void => {
+            capturedUpstream = wireBody;
+          };
+          let capturedResponseMetadata: Record<string, string> | undefined;
+          const onResponseMeta = (headers: Headers): void => {
+            capturedResponseMetadata = safeResponseMetadata(headers);
+          };
+          if (req.stream && passthrough.passthrough_used) {
+            // Native STREAMING passthrough (issue #217, Phase 2): forward the client's
+            // VERBATIM native body (which ALREADY carries stream:true) to the upstream and
+            // BYTE-RELAY the upstream SSE back — NO translation. peekStream peeks the first
+            // chunk for the breaker contract (pre-first-chunk failure → recordFailure +
+            // chain advance below; healthy → recordSuccess), only the SOURCE iterable
+            // differs (nativePassthroughStream vs chatCompletionStream). The method +
+            // native body are guaranteed present (the guard's providerSupportsPassthrough
+            // feature-detected nativePassthroughStream, hasNativeRequest proved the body);
+            // narrow defensively for type-safety (unreachable after the guard).
+            const passthroughStream = provider.nativePassthroughStream;
+            const nativeBody = req.native_request;
+            if (!passthroughStream || !nativeBody) {
+              throw new Error(
+                "native streaming passthrough invoked without a native request or client method",
+              );
+            }
+            // Patch ONLY `model` to the RESOLVED upstream id (issue #217): the gateway
+            // chose this provider/model, so the upstream must be told which one to run —
+            // the client's `model` is the routing alias (e.g. `anthropic/claude-…`), not
+            // a real upstream model id. Everything else is forwarded verbatim. Mirrors
+            // stripInternal's `model: providerModel`; without it the upstream 404s.
+            const passthroughBody = await optimizeNativeBodyForAttempt(
+              prepareNativeRequestForUpstream(
+                nativeBody,
+                providerModel,
+                req.protocol,
+                true,
+                provider.nativeProtocolProfile,
+                req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
+                caps,
+                req.reasoning_effort,
+              ),
+            );
+            if (hasResponsesContinuation(req)) {
+              const mutations = nativePassthroughMutations(passthroughBody);
+              if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
+            }
+            passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
+            attemptTelemetry = withRequestMutations(
+              passthrough,
+              visualCompressionMutationLedger(visualCompressionMutation),
+            );
+            // Pre-output failover guard (principle 5 + 8): a same-protocol byte-relay
+            // that 200s then fails IN-BAND before any output (e.g. Responses
+            // `response.failed`/server_is_overloaded after only the `response.created`
+            // preamble) must fall back, not stream the error as success. The guard
+            // buffers preamble and turns a pre-output error frame into a pre-first-chunk
+            // throw → peekStream records a breaker failure and advances the chain. null
+            // classifier (gemini) → unchanged commit-on-first behavior.
+            const passthroughClassifier = preOutputClassifierFor(req.protocol);
+            const stream = await withAttemptDeadline(
+              req.attempt_timeout_ms,
+              signal,
+              (attemptSignal) =>
+                peekStream(
+                  () => {
+                    const raw = passthroughStream(passthroughBody, {
+                      signal: attemptSignal,
+                      ...(req.metadata.stateful_provider_account
+                        ? { statefulAccount: req.metadata.stateful_provider_account }
+                        : {}),
+                      captureUpstream,
+                      onResponseMeta,
+                      toolCallXmlRecovery:
+                        target.targetProviderProtocol === "anthropic_messages" &&
+                        (toolCallXmlRecoveryEnabled?.() ?? true),
+                    });
+                    return passthroughClassifier
+                      ? guardPreOutputFailure(raw, passthroughClassifier)
+                      : raw;
+                  },
+                  attemptSignal,
+                  alias,
+                  log,
+                ),
+            );
+            settleBreaker("success");
+            // Streamed usage is not known at peek time → cost null, backfilled later.
+            attempts.push(okRow(alias, elapsed(), null, attemptTelemetry));
+            return {
+              attempts,
+              final: { status: "ok", alias, providerModel },
+              body: null,
+              stream,
+              nativePassthrough: true,
+              upstreamRequest: capturedUpstream,
+              responseMetadata: capturedResponseMetadata,
+            };
+          }
+          if (req.stream) {
+            // Translate stream path (passthrough disabled): the existing byte-for-byte
+            // forward. peekStream opens chatCompletionStream(stripInternal); the row
+            // carries the (used:false) passthrough telemetry. No nativePassthrough marker.
+            const rendered = stripInternal(
+              req,
+              providerModel,
+              target.targetProviderProtocol,
+              caps,
+              target.provider?.nativeProtocolProfile === "generic_openai_responses",
+            );
+            // Pre-output failover guard (principle 5 + 8): the translate generators
+            // ALREADY throw on a terminal error frame, but they yield an empty role
+            // preamble chunk first, so peekStream would commit success before the throw.
+            // The guard buffers that preamble so the commit lands on the first REAL
+            // output; a pre-output error (thrown by the generator, or an in-band error
+            // frame) stays a pre-first-chunk failure → fallback. Translate output is
+            // always OpenAI-Chat framed, so the chat classifier is always correct.
+            const translateClassifier = preOutputClassifierFor("openai_chat");
+            const stream = await withAttemptDeadline(
+              req.attempt_timeout_ms,
+              signal,
+              (attemptSignal) =>
+                peekStream(
+                  () => {
+                    const raw = provider.chatCompletionStream(rendered.body, {
+                      signal: attemptSignal,
+                      ...(req.metadata.stateful_provider_account
+                        ? { statefulAccount: req.metadata.stateful_provider_account }
+                        : {}),
+                      captureUpstream,
+                      onResponseMeta,
+                      optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
+                    });
+                    return translateClassifier
+                      ? guardPreOutputFailure(raw, translateClassifier)
+                      : raw;
+                  },
+                  attemptSignal,
+                  alias,
+                  log,
+                ),
+            );
+            settleBreaker("success");
+            attemptTelemetry = withRequestMutations(
+              passthrough,
+              mergeRequestMutations(
+                rendered.request_mutations,
+                provider.streamReframed === true ? { stream_reframed: true } : undefined,
+                visualCompressionMutationLedger(visualCompressionMutation),
+              ),
+            );
+            // Streamed usage is not known at peek time → cost null (not measured).
+            attempts.push(okRow(alias, elapsed(), null, attemptTelemetry));
+            return {
+              attempts,
+              final: { status: "ok", alias, providerModel },
+              body: null,
+              stream,
+              upstreamRequest: capturedUpstream,
+              responseMetadata: capturedResponseMetadata,
+            };
+          }
+          if (passthrough.passthrough_used) {
+            // Native passthrough: forward the client's VERBATIM native body to the
+            // upstream (NO OpenAI-Chat translation) and return the native response
+            // untouched. provider.nativePassthrough is guaranteed present here — the
+            // guard's providerSupportsPassthrough feature-detected it. Cost is priced
+            // off the native usage, normalized to OpenAI shape (usageFromAnthropicResponse)
+            // so resolveCostUsd applies the same token math as a translated attempt.
+            const passthroughInvoke = provider.nativePassthrough;
+            const nativeBody = req.native_request;
+            if (!passthroughInvoke || !nativeBody) {
+              // Unreachable: the guard's providerSupportsPassthrough + hasNativeRequest
+              // checks already proved both present. Narrow defensively for type-safety.
+              throw new Error(
+                "native passthrough invoked without a native request or client method",
+              );
+            }
+            // Patch ONLY `model` to the RESOLVED upstream id (issue #217): the client's
+            // `model` is the routing alias (e.g. `anthropic/claude-…`), but the gateway
+            // picked this upstream model — forward it so the upstream doesn't 404 on the
+            // alias. Everything else verbatim. Mirrors stripInternal's `model: providerModel`.
+            const passthroughBody = await optimizeNativeBodyForAttempt(
+              prepareNativeRequestForUpstream(
+                nativeBody,
+                providerModel,
+                req.protocol,
+                false,
+                provider.nativeProtocolProfile,
+                req.reasoning_effort_forced === true ? req.reasoning_effort : undefined,
+                caps,
+                req.reasoning_effort,
+              ),
+            );
+            if (hasResponsesContinuation(req)) {
+              const mutations = nativePassthroughMutations(passthroughBody);
+              if (mutations) mutations.responses_previous_response_id_native_passthrough = true;
+            }
+            passthrough.passthrough_mutations = nativePassthroughMutations(passthroughBody);
+            attemptTelemetry = withRequestMutations(
+              passthrough,
+              visualCompressionMutationLedger(visualCompressionMutation),
+            );
+            const body = await withAttemptDeadline(
+              req.attempt_timeout_ms,
+              signal,
+              (attemptSignal) =>
+                passthroughInvoke(passthroughBody, {
+                  signal: attemptSignal,
+                  ...(req.metadata.stateful_provider_account
+                    ? { statefulAccount: req.metadata.stateful_provider_account }
+                    : {}),
+                  captureUpstream,
+                  onResponseMeta,
+                  toolCallXmlRecovery:
+                    target.targetProviderProtocol === "anthropic_messages" &&
+                    (toolCallXmlRecoveryEnabled?.() ?? true),
+                }),
+            );
+            settleBreaker("success");
+            const usage =
+              req.protocol === "openai_responses"
+                ? usageFromResponsesResponse(body)
+                : req.protocol === "gemini"
+                  ? usageFromGeminiResponse(body)
+                  : usageFromAnthropicResponse(body);
+            const pricedBody = usage ? { ...body, usage } : body;
+            attempts.push(
+              okRow(alias, elapsed(), costOf(alias, providerModel, pricedBody), attemptTelemetry),
+            );
+            return {
+              attempts,
+              final: { status: "ok", alias, providerModel },
+              body,
+              stream: null,
+              nativePassthrough: true,
+              upstreamRequest: capturedUpstream,
+              responseMetadata: capturedResponseMetadata,
+            };
+          }
+          const bodyReq = stripInternal(
+            req,
+            providerModel,
+            target.targetProviderProtocol,
+            caps,
+            target.provider?.nativeProtocolProfile === "generic_openai_responses",
           );
           const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
-            passthroughInvoke(passthroughBody, {
+            provider.chatCompletion(bodyReq.body, {
               signal: attemptSignal,
               ...(req.metadata.stateful_provider_account
                 ? { statefulAccount: req.metadata.stateful_provider_account }
                 : {}),
               captureUpstream,
               onResponseMeta,
-              toolCallXmlRecovery:
-                target.targetProviderProtocol === "anthropic_messages" &&
-                (toolCallXmlRecoveryEnabled?.() ?? true),
+              optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
             }),
           );
+          attemptTelemetry = withRequestMutations(
+            passthrough,
+            mergeRequestMutations(
+              bodyReq.request_mutations,
+              visualCompressionMutationLedger(visualCompressionMutation),
+            ),
+          );
           settleBreaker("success");
-          const usage =
-            req.protocol === "openai_responses"
-              ? usageFromResponsesResponse(body)
-              : req.protocol === "gemini"
-                ? usageFromGeminiResponse(body)
-                : usageFromAnthropicResponse(body);
-          const pricedBody = usage ? { ...body, usage } : body;
           attempts.push(
-            okRow(alias, elapsed(), costOf(alias, providerModel, pricedBody), attemptTelemetry),
+            okRow(alias, elapsed(), costOf(alias, providerModel, body), attemptTelemetry),
           );
           return {
             attempts,
             final: { status: "ok", alias, providerModel },
             body,
             stream: null,
-            nativePassthrough: true,
             upstreamRequest: capturedUpstream,
             responseMetadata: capturedResponseMetadata,
           };
-        }
-        const bodyReq = stripInternal(
-          req,
-          providerModel,
-          target.targetProviderProtocol,
-          caps,
-          target.provider?.nativeProtocolProfile === "generic_openai_responses",
-        );
-        const body = await withAttemptDeadline(req.attempt_timeout_ms, signal, (attemptSignal) =>
-          provider.chatCompletion(bodyReq.body, {
-            signal: attemptSignal,
-            ...(req.metadata.stateful_provider_account
-              ? { statefulAccount: req.metadata.stateful_provider_account }
-              : {}),
-            captureUpstream,
-            onResponseMeta,
-            optimizeAnthropicBody: optimizeAnthropicBodyForAttempt,
-          }),
-        );
-        attemptTelemetry = withRequestMutations(
-          passthrough,
-          mergeRequestMutations(
-            bodyReq.request_mutations,
-            visualCompressionMutationLedger(visualCompressionMutation),
-          ),
-        );
-        settleBreaker("success");
-        attempts.push(
-          okRow(alias, elapsed(), costOf(alias, providerModel, body), attemptTelemetry),
-        );
-        return {
-          attempts,
-          final: { status: "ok", alias, providerModel },
-          body,
-          stream: null,
-          upstreamRequest: capturedUpstream,
-          responseMetadata: capturedResponseMetadata,
-        };
-      } catch (err) {
-        const cancellation = requestCancellationReason(signal);
-        if (cancellation === CONCURRENCY_LEASE_LOST_REASON || cancellation === "request_timeout") {
-          const leaseLost = cancellation === CONCURRENCY_LEASE_LOST_REASON;
-          const errorClass = leaseLost ? "lane_unavailable" : "timeout";
-          settleBreaker("abort");
-          attempts.push({
-            alias,
-            skipped: false,
-            skip_reason: cancellation,
-            status: "error",
-            error_class: errorClass,
-            latency_ms: elapsed(),
-            cost_usd: null,
-            error_detail: null,
-            ...defaultPassthroughTelemetry(),
-          });
-          return {
-            attempts,
-            final: {
+        } catch (err) {
+          const cancellation = requestCancellationReason(signal);
+          if (
+            cancellation === CONCURRENCY_LEASE_LOST_REASON ||
+            cancellation === "request_timeout"
+          ) {
+            const leaseLost = cancellation === CONCURRENCY_LEASE_LOST_REASON;
+            const errorClass = leaseLost ? "lane_unavailable" : "timeout";
+            settleBreaker("abort");
+            attempts.push({
+              alias,
+              skipped: false,
+              skip_reason: cancellation,
               status: "error",
-              error: makeHelmError({
-                error_class: errorClass,
-                message: leaseLost ? "concurrency lease lost" : "request timed out",
-                trace_id: correlationTraceId(req),
-              }),
-            },
-            body: null,
-            stream: null,
-          };
-        }
-        // Client abort: non-provider fault. Terminate the chain WITHOUT marking a
-        // breaker failure or counting it as all_providers_failed.
-        if (isAbort(err, signal)) {
-          settleBreaker("abort");
-          attempts.push({
-            alias,
-            skipped: false,
-            skip_reason: "aborted",
-            status: "error",
-            error_class: "client_abort",
-            latency_ms: elapsed(),
-            cost_usd: null,
-            error_detail: null,
-            ...defaultPassthroughTelemetry(),
-          });
-          return {
-            attempts,
-            final: {
+              error_class: errorClass,
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: null,
+              ...defaultPassthroughTelemetry(),
+            });
+            return {
+              attempts,
+              final: {
+                status: "error",
+                error: makeHelmError({
+                  error_class: errorClass,
+                  message: leaseLost ? "concurrency lease lost" : "request timed out",
+                  trace_id: correlationTraceId(req),
+                }),
+              },
+              body: null,
+              stream: null,
+            };
+          }
+          // Client abort: non-provider fault. Terminate the chain WITHOUT marking a
+          // breaker failure or counting it as all_providers_failed.
+          if (isAbort(err, signal)) {
+            settleBreaker("abort");
+            attempts.push({
+              alias,
+              skipped: false,
+              skip_reason: "aborted",
               status: "error",
-              error: makeHelmError({
-                // C2: client disconnect is a NON-provider fault — surface the
-                // dedicated client_abort class (499), never upstream_error (502),
-                // so telemetry/dashboards don't count a disconnect as a provider
-                // failure. Matches the per-attempt row above (docs/02, docs/07).
-                error_class: "client_abort",
-                message: "client aborted request",
-                trace_id: correlationTraceId(req),
-              }),
-            },
-            body: null,
-            stream: null,
-          };
-        }
-        // Per-account user-message queue timeout (issue #93, feature B):
-        // BACKPRESSURE, not provider health — release any probe lock WITHOUT a
-        // breaker failure. Terminal (no chain advance): the queue protects THIS
-        // subscription's rate limits; spilling onto the next candidate would
-        // defeat the throttle the operator deliberately turned on. 503 via
-        // lane_unavailable (retryable in the client's eyes).
-        if (isQueueTimeout(err)) {
-          settleBreaker("abort");
-          attempts.push({
-            alias,
-            skipped: false,
-            skip_reason: "user_message_queue_timeout",
-            status: "error",
-            error_class: "lane_unavailable",
-            latency_ms: elapsed(),
-            cost_usd: null,
-            error_detail: null,
-            ...defaultPassthroughTelemetry(),
-          });
-          return {
-            attempts,
-            final: {
+              error_class: "client_abort",
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: null,
+              ...defaultPassthroughTelemetry(),
+            });
+            return {
+              attempts,
+              final: {
+                status: "error",
+                error: makeHelmError({
+                  // C2: client disconnect is a NON-provider fault — surface the
+                  // dedicated client_abort class (499), never upstream_error (502),
+                  // so telemetry/dashboards don't count a disconnect as a provider
+                  // failure. Matches the per-attempt row above (docs/02, docs/07).
+                  error_class: "client_abort",
+                  message: "client aborted request",
+                  trace_id: correlationTraceId(req),
+                }),
+              },
+              body: null,
+              stream: null,
+            };
+          }
+          // Per-account user-message queue timeout (issue #93, feature B):
+          // BACKPRESSURE, not provider health — release any probe lock WITHOUT a
+          // breaker failure. Terminal (no chain advance): the queue protects THIS
+          // subscription's rate limits; spilling onto the next candidate would
+          // defeat the throttle the operator deliberately turned on. 503 via
+          // lane_unavailable (retryable in the client's eyes).
+          if (isQueueTimeout(err)) {
+            settleBreaker("abort");
+            attempts.push({
+              alias,
+              skipped: false,
+              skip_reason: "user_message_queue_timeout",
               status: "error",
-              error: makeHelmError({
-                error_class: "lane_unavailable",
-                message: "user message queue wait timed out; retry shortly",
-                trace_id: correlationTraceId(req),
-              }),
-            },
-            body: null,
-            stream: null,
-          };
-        }
-        // `:free` candidate 429 — ported llm-router semantics (principle 5):
-        // skip to the next candidate, do NOT record a breaker failure (free-tier
-        // throttling is not a provider-health signal). Distinct log field from
-        // execution-fallback: skip_reason 'free_429', error_class 'rate_limited'.
-        if (isFreeAlias(alias) && upstreamStatusOf(err) === 429) {
+              error_class: "lane_unavailable",
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: null,
+              ...defaultPassthroughTelemetry(),
+            });
+            return {
+              attempts,
+              final: {
+                status: "error",
+                error: makeHelmError({
+                  error_class: "lane_unavailable",
+                  message: "user message queue wait timed out; retry shortly",
+                  trace_id: correlationTraceId(req),
+                }),
+              },
+              body: null,
+              stream: null,
+            };
+          }
+          // `:free` candidate 429 — ported llm-router semantics (principle 5):
+          // skip to the next candidate, do NOT record a breaker failure (free-tier
+          // throttling is not a provider-health signal). Distinct log field from
+          // execution-fallback: skip_reason 'free_429', error_class 'rate_limited'.
+          if (isFreeAlias(alias) && upstreamStatusOf(err) === 429) {
+            onlyContextOrCapabilitySkips = false;
+            attempts.push({
+              alias,
+              skipped: true,
+              skip_reason: "free_429",
+              status: "error",
+              error_class: "rate_limited",
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: errorDetailOf(err),
+              ...defaultPassthroughTelemetry(),
+            });
+            continue;
+          }
+
+          // Model context window overflow: THIS candidate cannot serve the request,
+          // but a later fallback with a larger window can. Treat it like a late-discovered
+          // capability skip, not provider health: no breaker failure, no red provider
+          // error row, and no execution-fallback count.
+          if (isContextWindowRejection(err)) {
+            capabilityPruned = true;
+            const detail = errorDetailOf(err);
+            rememberContextOverflow(
+              upstreamErrorMessage(detail.provider_raw) ?? detail.message,
+              detail.provider_raw,
+              upstreamErrorCode(detail.provider_raw)?.toLowerCase() === "context_length_exceeded"
+                ? contextConfirmationKey
+                : undefined,
+            );
+            attempts.push({
+              alias,
+              skipped: true,
+              skip_reason: "context_too_small",
+              status: "error",
+              error_class: null,
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: detail,
+              ...attemptTelemetry,
+            });
+            continue;
+          }
+
+          // DeepSeek-style thinking mode is candidate-specific: when a fallback target
+          // requires OpenAI `reasoning_content` history that the source protocol cannot
+          // supply, another candidate may still serve the request. Do not surface this
+          // as a terminal client 400 and do not fault provider health.
+          if (isReasoningHistoryRejection(err)) {
+            capabilityPruned = true;
+            attempts.push({
+              alias,
+              skipped: true,
+              skip_reason: "reasoning_history_incompatible",
+              status: "error",
+              error_class: null,
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: errorDetailOf(err),
+              ...attemptTelemetry,
+            });
+            continue;
+          }
+
+          // Deterministic request-shape rejection (oversized image, bad param): the
+          // body is invalid for EVERY candidate, so do NOT advance the chain and do NOT
+          // fault the breaker (the upstream is healthy — the request is what's wrong).
+          // Surface the upstream's structured error VERBATIM as a 400 invalid_request.
+          if (isUpstreamRequestRejection(err)) {
+            const detail = errorDetailOf(err);
+            attempts.push({
+              alias,
+              skipped: false,
+              skip_reason: null,
+              status: "error",
+              error_class: "invalid_request",
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: detail,
+              ...attemptTelemetry,
+            });
+            return {
+              attempts,
+              final: {
+                status: "error",
+                error: makeHelmError({
+                  error_class: "invalid_request",
+                  message: upstreamErrorMessage(detail.provider_raw) ?? detail.message,
+                  trace_id: correlationTraceId(req),
+                  provider_raw: detail.provider_raw,
+                }),
+              },
+              body: null,
+              stream: null,
+            };
+          }
+
+          // Genuine pre-first-chunk failure: record on the alias breaker — EXCEPT an OAuth
+          // subscription fault the pool already isolates per-account (credential 401/403 or
+          // a 429). Those are pooled-account state, never an alias-wide signal, so one bad
+          // account must not open the model alias. A server/transport fault (5xx / overload /
+          // timeout) that survived the pool's sibling retry means the WHOLE pool is down →
+          // record it so the breaker backs the alias off, just like a configured provider.
+          if (!(isOAuthSubscriptionAlias(alias) && isAccountScopedFault(err))) {
+            settleBreaker("failure");
+          }
+          // Account-scoped OAuth faults leave breakerSettled=false so the finally
+          // block releases any HALF_OPEN probe lock without counting a failure.
           onlyContextOrCapabilitySkips = false;
-          attempts.push({
-            alias,
-            skipped: true,
-            skip_reason: "free_429",
-            status: "error",
-            error_class: "rate_limited",
-            latency_ms: elapsed(),
-            cost_usd: null,
-            error_detail: errorDetailOf(err),
-            ...defaultPassthroughTelemetry(),
-          });
-          continue;
-        }
-
-        // Model context window overflow: THIS candidate cannot serve the request,
-        // but a later fallback with a larger window can. Treat it like a late-discovered
-        // capability skip, not provider health: no breaker failure, no red provider
-        // error row, and no execution-fallback count.
-        if (isContextWindowRejection(err)) {
-          capabilityPruned = true;
-          const detail = errorDetailOf(err);
-          rememberContextOverflow(
-            upstreamErrorMessage(detail.provider_raw) ?? detail.message,
-            detail.provider_raw,
-            upstreamErrorCode(detail.provider_raw)?.toLowerCase() === "context_length_exceeded"
-              ? contextConfirmationKey
-              : undefined,
-          );
-          attempts.push({
-            alias,
-            skipped: true,
-            skip_reason: "context_too_small",
-            status: "error",
-            error_class: null,
-            latency_ms: elapsed(),
-            cost_usd: null,
-            error_detail: detail,
-            ...attemptTelemetry,
-          });
-          continue;
-        }
-
-        // DeepSeek-style thinking mode is candidate-specific: when a fallback target
-        // requires OpenAI `reasoning_content` history that the source protocol cannot
-        // supply, another candidate may still serve the request. Do not surface this
-        // as a terminal client 400 and do not fault provider health.
-        if (isReasoningHistoryRejection(err)) {
-          capabilityPruned = true;
-          attempts.push({
-            alias,
-            skipped: true,
-            skip_reason: "reasoning_history_incompatible",
-            status: "error",
-            error_class: null,
-            latency_ms: elapsed(),
-            cost_usd: null,
-            error_detail: errorDetailOf(err),
-            ...attemptTelemetry,
-          });
-          continue;
-        }
-
-        // Deterministic request-shape rejection (oversized image, bad param): the
-        // body is invalid for EVERY candidate, so do NOT advance the chain and do NOT
-        // fault the breaker (the upstream is healthy — the request is what's wrong).
-        // Surface the upstream's structured error VERBATIM as a 400 invalid_request.
-        if (isUpstreamRequestRejection(err)) {
-          const detail = errorDetailOf(err);
+          // Auto-park a subscription account that hit its rate/usage limit. A genuine
+          // (non-`:free`, handled above) 429 on an OAuth alias means the served account
+          // is throttled — signal the gateway to park it so the pool routes around it.
+          // Pure side-channel: chain advancement below is unchanged.
+          if (upstreamStatusOf(err) === 429 && isOAuthSubscriptionAlias(alias)) {
+            onOAuthSubscription429?.(alias, err);
+          }
           attempts.push({
             alias,
             skipped: false,
             skip_reason: null,
             status: "error",
-            error_class: "invalid_request",
+            error_class: errorClassOf(err),
             latency_ms: elapsed(),
             cost_usd: null,
-            error_detail: detail,
+            error_detail: errorDetailOf(err),
             ...attemptTelemetry,
           });
-          return {
-            attempts,
-            final: {
-              status: "error",
-              error: makeHelmError({
-                error_class: "invalid_request",
-                message: upstreamErrorMessage(detail.provider_raw) ?? detail.message,
-                trace_id: correlationTraceId(req),
-                provider_raw: detail.provider_raw,
-              }),
-            },
-            body: null,
-            stream: null,
-          };
         }
-
-        // Genuine pre-first-chunk failure: record on the alias breaker — EXCEPT an OAuth
-        // subscription fault the pool already isolates per-account (credential 401/403 or
-        // a 429). Those are pooled-account state, never an alias-wide signal, so one bad
-        // account must not open the model alias. A server/transport fault (5xx / overload /
-        // timeout) that survived the pool's sibling retry means the WHOLE pool is down →
-        // record it so the breaker backs the alias off, just like a configured provider.
-        if (!(isOAuthSubscriptionAlias(alias) && isAccountScopedFault(err))) {
-          settleBreaker("failure");
-        }
-        // Account-scoped OAuth faults leave breakerSettled=false so the finally
-        // block releases any HALF_OPEN probe lock without counting a failure.
-        onlyContextOrCapabilitySkips = false;
-        // Auto-park a subscription account that hit its rate/usage limit. A genuine
-        // (non-`:free`, handled above) 429 on an OAuth alias means the served account
-        // is throttled — signal the gateway to park it so the pool routes around it.
-        // Pure side-channel: chain advancement below is unchanged.
-        if (upstreamStatusOf(err) === 429 && isOAuthSubscriptionAlias(alias)) {
-          onOAuthSubscription429?.(alias, err);
-        }
-        attempts.push({
-          alias,
-          skipped: false,
-          skip_reason: null,
-          status: "error",
-          error_class: errorClassOf(err),
-          latency_ms: elapsed(),
-          cost_usd: null,
-          error_detail: errorDetailOf(err),
-          ...attemptTelemetry,
-        });
-      }
       } finally {
         // Release a HALF_OPEN probe lock on any path that allowed the attempt but
         // never settled success/failure/abort (capability skip after canAttempt,

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1647,6 +1647,14 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       // must still back the alias off + half-open-probe. Per-account faults never reach
       // here — the pool absorbs them, and the recordFailure skip below keeps the rare
       // surfaced one off the breaker.
+      //
+      // canAttempt may grab the HALF_OPEN probe lock. Every exit from this candidate
+      // after allow:true MUST settle the breaker (success / failure / abort). Paths that
+      // intentionally skip recordFailure (OAuth account-scoped 429, capability skip after
+      // the gate, free_429, context overflow, …) still release the probe via recordAbort;
+      // otherwise inFlightProbe stays true and the alias returns circuit_open forever
+      // (prod 2026-08-06: anthropic/claude-opus-4-8 stuck for hours while other Anthropic
+      // models kept serving).
       const gate = breaker.canAttempt(alias);
       if (!gate.allow) {
         circuitSkipped = true;
@@ -1654,7 +1662,15 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         attempts.push(skipRow(alias, gate.reason ?? "circuit_open", elapsed()));
         continue;
       }
+      let breakerSettled = false;
+      const settleBreaker = (kind: "success" | "failure" | "abort"): void => {
+        if (kind === "success") breaker.recordSuccess(alias);
+        else if (kind === "failure") breaker.recordFailure(alias);
+        else breaker.recordAbort(alias);
+        breakerSettled = true;
+      };
 
+      try {
       // 2) Capability filter. Missing catalog data remains fail-open for generic
       // requests, but not for cached_content: that field is a required Gemini/LiteLLM
       // cached context handle, not an optional affinity hint.
@@ -1920,7 +1936,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 log,
               ),
           );
-          breaker.recordSuccess(alias);
+          settleBreaker("success");
           // Streamed usage is not known at peek time → cost null, backfilled later.
           attempts.push(okRow(alias, elapsed(), null, attemptTelemetry));
           return {
@@ -1976,7 +1992,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 log,
               ),
           );
-          breaker.recordSuccess(alias);
+          settleBreaker("success");
           attemptTelemetry = withRequestMutations(
             passthrough,
             mergeRequestMutations(
@@ -2048,7 +2064,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 (toolCallXmlRecoveryEnabled?.() ?? true),
             }),
           );
-          breaker.recordSuccess(alias);
+          settleBreaker("success");
           const usage =
             req.protocol === "openai_responses"
               ? usageFromResponsesResponse(body)
@@ -2094,7 +2110,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             visualCompressionMutationLedger(visualCompressionMutation),
           ),
         );
-        breaker.recordSuccess(alias);
+        settleBreaker("success");
         attempts.push(
           okRow(alias, elapsed(), costOf(alias, providerModel, body), attemptTelemetry),
         );
@@ -2111,7 +2127,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         if (cancellation === CONCURRENCY_LEASE_LOST_REASON || cancellation === "request_timeout") {
           const leaseLost = cancellation === CONCURRENCY_LEASE_LOST_REASON;
           const errorClass = leaseLost ? "lane_unavailable" : "timeout";
-          breaker.recordAbort(alias);
+          settleBreaker("abort");
           attempts.push({
             alias,
             skipped: false,
@@ -2140,7 +2156,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         // Client abort: non-provider fault. Terminate the chain WITHOUT marking a
         // breaker failure or counting it as all_providers_failed.
         if (isAbort(err, signal)) {
-          breaker.recordAbort(alias);
+          settleBreaker("abort");
           attempts.push({
             alias,
             skipped: false,
@@ -2177,7 +2193,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         // defeat the throttle the operator deliberately turned on. 503 via
         // lane_unavailable (retryable in the client's eyes).
         if (isQueueTimeout(err)) {
-          breaker.recordAbort(alias);
+          settleBreaker("abort");
           attempts.push({
             alias,
             skipped: false,
@@ -2311,8 +2327,10 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         // timeout) that survived the pool's sibling retry means the WHOLE pool is down →
         // record it so the breaker backs the alias off, just like a configured provider.
         if (!(isOAuthSubscriptionAlias(alias) && isAccountScopedFault(err))) {
-          breaker.recordFailure(alias);
+          settleBreaker("failure");
         }
+        // Account-scoped OAuth faults leave breakerSettled=false so the finally
+        // block releases any HALF_OPEN probe lock without counting a failure.
         onlyContextOrCapabilitySkips = false;
         // Auto-park a subscription account that hit its rate/usage limit. A genuine
         // (non-`:free`, handled above) 429 on an OAuth alias means the served account
@@ -2332,6 +2350,14 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           error_detail: errorDetailOf(err),
           ...attemptTelemetry,
         });
+      }
+      } finally {
+        // Release a HALF_OPEN probe lock on any path that allowed the attempt but
+        // never settled success/failure/abort (capability skip after canAttempt,
+        // free_429, context/reasoning skip, OAuth account-scoped 429/401/403).
+        // recordAbort is a no-op when the alias was never HALF_OPEN or the lock was
+        // already cleared by success/failure/abort above.
+        if (!breakerSettled) settleBreaker("abort");
       }
     }
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-08-06 · HALF_OPEN 探测锁泄漏导致 alias 永久 circuit_open（Provider execution / circuit breaker，docs/02/04，原则 3/5）
+
+- **现场**：`anthropic/claude-opus-4-8` 连续数小时 `skip_reason=circuit_open`（0ms），同 Anthropic OAuth 池的 haiku/sonnet 仍正常；账号配额未 limited。请求 `5c27cf5d…` 正确 fallback 到 `openai-codex/gpt-5.6-sol`。
+- **根因**：`canAttempt` 在 cooldown 结束后把 alias 置 `HALF_OPEN` 并持有 `inFlightProbe`。随后路径若**故意不** `recordFailure`（OAuth 账号级 429/401/403、capability/protocol skip、`free_429`、context overflow 等）也**不** `recordAbort`，锁永不释放 → 后续全部 `circuit_open`。生产序列：`no schedulable account`×5 打开 OPEN → HALF_OPEN probe 撞 429（account-scoped，跳过 failure）→ 锁卡死。
+- **修复**：`execute.ts` 在 `canAttempt` allow 后用 `settleBreaker` + `try/finally`：任何未 success/failure/abort 的退出都 `recordAbort` 释放探测锁；OAuth 账号级故障仍不计 alias failure。ops 侧已 `docker restart helm` 清内存状态。
+- **测试**：新增 3 个 HALF_OPEN 用例（OAuth 429 / capability skip / free_429）。不改 breaker 默认阈值（5 / 30s）。
+
 ## 2026-08-04 · 修复 per-key 请求内容存储覆盖的优先级回归（Gateway / Telemetry，docs/06/07/11，原则 2/7）
 
 - **回归根因**：`withRequestContentMode`（payload-capture.ts）自 PR #677（`52bb5f9b`，v0.28.29）起把 key 覆盖包在 `globallyEnabled() && …` 内——全局关闭即成 hard-off，强制所有 key 关闭，与 #675 承诺的“key 显式值 > 全局值”完全相反。测试也被同步改成断言这个错误语义，故 CI 一直绿。生产实测：WW 落库 `request_content_mode='payload'` 但全局关闭后 38 个请求全部无 payload。
@@ -75,14 +82,9 @@
 - **回滚兼容**：fallback 沿用旧版已接受的通用 `session-id` 持久化来源，不新增 DecisionRecord 枚举值；内部 ref 使用独立 `request_id` 哈希域，外部 ID 使用客户端不可占用的 `helm-request:` 保留前缀加请求哈希，避免与真实 `session-id` 的 ref 或数据库唯一键碰撞。v0.28.26 回滚后仍能读取新版写入的遥测记录。
 - **边界**：单次请求/响应仍受进程动态 capture-body 内存预算保护，避免一个在途正文直接造成 OOM；10,000 revision 计数上限与既有 retention cleanup 保持不变。本次不补写已经漏掉的历史 revision，因为正文未保存时无法可靠恢复。生产必须切换到 `capture_sessions=true`、`capture_payloads=false` 才会使用该增量模式。
 
-## 2026-07-31 · 请求列表记录并显示客户端正文大小（Telemetry / Admin requests，docs/07/11，原则 1/7）
-
-- **计量口径**：新增可选 `request_body_bytes`，记录网关实际收到的客户端请求正文 UTF-8 字节数；不信任可能缺失或经过 transfer encoding 的 `Content-Length`，也不以字符数、Token 数、压缩后存储量或转换后的上游正文替代。该数字随脱敏 `DecisionRecord` 保存，不受正文捕获开关影响，不保存正文，因此无需 SQLite/Postgres 迁移。
-- **协议边界**：共享记录路径覆盖 Responses、Messages、Gemini、Interactions 与 Images，OpenAI Chat 和 Admin Replay 的独立写入路径显式补齐；multipart 图片使用原始 wire bytes 覆盖其后生成的元数据 JSON 大小。尚不产生 `DecisionRecord` 的预路由拒绝、count-tokens 与 Realtime 请求不伪造该指标。
-- **兼容与展示**：Admin 共享请求表按二进制阈值显示 `B / KB / MB`；旧记录不回填并显示 `—`，避免读取或扫描历史私密正文。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-07-31 · 请求列表记录并显示客户端正文大小**：新增可选 `request_body_bytes`（客户端 wire UTF-8 字节，非 Content-Length/token/压缩量），随脱敏 DecisionRecord 保存；Admin 表按 B/KB/MB 展示，旧记录显示 `—`；完整原文通过 git history 回溯。
 - **2026-07-29 · 生产韧性：持续小批清理 + 无丢弃背压 + 执行 Token 租约 + 完整错误诊断**：SQLite retention 每批≤10 行让出事件循环、Session prune claim 可续；写队列删除 OOM shedding 改统一串行 admission 背压 FIFO；OAuth 保存真实 `expires`、执行 client 6 分钟提前刷新、刷新失败重读共享 Store 只用他实例轮换出的有效 credential；Provider 错误有界诊断（64 KiB body / 128 KiB 总预算），完整原文通过 git history 回溯。
 - **2026-07-28 · 删除 HTTP 与 WebSocket 请求大小上限**：删除应用与 Remote Nginx 固定正文上限，继续由动态内存准入、鉴权、schema、maintenance drain 和 provider timeout 保护运行时；完整原文通过 git history回溯。
 - **2026-07-28 · preflight/registry 内存放大与自动 VACUUM 空闲门禁**：Responses preflight 增加 deadline/abort，catalog 与 registry 改为有界热路径；自动 VACUUM 仅在空闲 drain 后执行，完整原文通过 git history 回溯。


### PR DESCRIPTION
## Summary

- Fix a production stuck-breaker bug: after `canAttempt` takes the HALF_OPEN probe lock, paths that intentionally skip `recordFailure` (OAuth account-scoped 429/401/403, capability/protocol skips, `free_429`, context/reasoning skips) now always `recordAbort` in a `try/finally`, so `inFlightProbe` cannot stay true forever.
- Incident: `anthropic/claude-opus-4-8` returned `circuit_open` for hours while haiku/sonnet on the same Anthropic OAuth pool kept working; traffic fell back to Codex. Ops cleared state with `docker restart helm`; this change prevents recurrence.
- Design: account-scoped faults still do **not** trip the alias breaker; abort only releases the probe lock and leaves HALF_OPEN so the next request can re-probe immediately (account parking handles throttle, not the breaker).

## Test plan

- [x] New unit tests: OAuth HALF_OPEN 429 → `recordAbort` + state stays `HALF_OPEN` + next request not `circuit_open`
- [x] New unit tests: capability skip after `canAttempt` releases lock
- [x] New unit tests: `free_429` continue releases lock without `recordFailure`
- [x] Related existing breaker/abort/OAuth tests pass (`CI=true pnpm exec vitest run apps/gateway/src/routes/execute.test.ts -t "HALF_OPEN|onOAuthSubscription429|…"`)
- [x] Dual review: self-review + Claude CLI Opus (2 rounds → approve, no remaining worth-fixing issues)
- [ ] CI green on PR
- [ ] Deploy so production gets the code fix (restart alone only cleared in-memory state)

## Reviews

1. **Self-review**: traced all post-`canAttempt` exits; finally covers continues + returns; double-settle guarded by `breakerSettled`.
2. **Claude Opus (round 1)**: approve with one recommended test pin (`getState === HALF_OPEN`) + comment wording — applied.
3. **Claude Opus (round 2)**: `APPROVE — no worth-fixing issues`.