### PR TITLE
chore(release): v0.28.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.40",
+  "version": "0.28.41",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- Bump root `package.json` version **0.28.40 → 0.28.41** so Publish can cut a new GitHub Release + `v0.28.41` GHCR tag.
- Carries the already-merged fix: HALF_OPEN probe lock release (`#698`) so production no longer depends only on a process restart.

## Why release now

| Factor | Assessment |
|---|---|
| Severity | Production stuck breaker (alias unusable until restart) |
| Risk of change | Low — finally-guarded lock release; dual-reviewed; unit tests |
| Deploy urgency | High — restart already cleared memory; code still old on host |
| Scope | Single correctness fix (+ version bump) |

## Deploy plan (la.atmy.work)

After Publish succeeds:

```bash
cd /opt/helm-api
cp -a .env .env.pre-v0.28.41-$(date -u +%Y%m%dT%H%M%SZ)
# pin HELM_IMAGE to the release digest (preferred) or v0.28.41
docker compose pull
docker compose up -d
curl -sS http://127.0.0.1:8787/version
```

## Test plan

- [ ] CI green on this PR
- [ ] Merge → main CI green
- [ ] Publish image creates `v0.28.41` + updates `latest`
- [ ] la.atmy.work `/version` shows `0.28.41` and new `gitSha`