### PR TITLE
fix(gateway): preserve HALF_OPEN probe lock ownership

### DIFF
--- a/apps/gateway/e2e/concurrency-postgres.spec.ts
+++ b/apps/gateway/e2e/concurrency-postgres.spec.ts
@@ -405,7 +405,7 @@ function trackedBreaker(): {
         inner.recordFailure(model);
       },
       recordSuccess: (model) => inner.recordSuccess(model),
-      recordAbort: (model) => inner.recordAbort(model),
+      recordAbort: (model, probeToken) => inner.recordAbort(model, probeToken),
       getState: (model) => inner.getState(model),
     },
   };

--- a/apps/gateway/src/routes/execute.errors.test.ts
+++ b/apps/gateway/src/routes/execute.errors.test.ts
@@ -296,6 +296,58 @@ describe("createExecute — circuit-open skip is transient (not capability_unsat
     }
     expect(provider.chatCompletion).not.toHaveBeenCalled();
   });
+
+  it("releases a HALF_OPEN probe lock when the probe request is capability-skipped (no permanent circuit_open)", async () => {
+    // Production bug: canAttempt() acquires the single-probe lock (OPEN → HALF_OPEN),
+    // then a later capability gate continues without recordAbort/Success/Failure.
+    // The lock stays held forever → every subsequent request sees circuit_open until
+    // process restart. A real breaker + capability prune must release the probe.
+    let t = 0;
+    const cb = createCircuitBreaker({
+      config: { failureThreshold: 5, cooldownMs: 1000 },
+      now: () => t,
+    });
+    for (let i = 0; i < 5; i++) cb.recordFailure("a");
+    expect(cb.getState("a")).toBe("OPEN");
+    t = 1000; // cooldown elapsed → next canAttempt becomes the probe
+
+    const provider = {
+      chatCompletion: vi.fn().mockResolvedValue({ id: "from-b" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ a: "m-a", b: "m-b" }),
+      breaker: cb,
+      catalog: new Map([
+        [
+          "a",
+          noToolsEntry("a"), // tools request → capability skip on the probe candidate
+        ],
+      ]),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const toolsReq = req({
+      tools: [{ type: "function", function: { name: "f", parameters: {} } }],
+    });
+    const first = await execute(plan(["a", "b"]), toolsReq);
+    expect(first.attempts[0]?.skip_reason).toBe("no_tool_support");
+    expect(first.final.status).toBe("ok");
+    // Probe must NOT stay locked forever. Capability skip releases the lock while
+    // leaving HALF_OPEN so the next real request can re-acquire the probe.
+    // Do NOT call canAttempt() here — that would steal the probe from the next execute.
+    expect(cb.getState("a")).toBe("HALF_OPEN");
+
+    const second = await execute(plan(["a"]), req()); // no tools → capability ok
+    expect(second.attempts[0]?.skip_reason).not.toBe("circuit_open");
+    expect(second.final.status).toBe("ok");
+    if (second.final.status === "ok") expect(second.final.alias).toBe("a");
+    expect(cb.getState("a")).toBe("CLOSED");
+    expect(provider.chatCompletion).toHaveBeenCalled();
+  });
 });
 
 describe("createExecute — error_detail provider_raw wrapping", () => {

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -6925,7 +6925,7 @@ describe("createExecute — HALF_OPEN probe lock release", () => {
     const probeOut = await mk()(plan([alias, fallback]), req());
     expect(probeOut.final.status).toBe("ok");
     expect(recordFailure).not.toHaveBeenCalledWith(alias);
-    expect(recordAbort).toHaveBeenCalledWith(alias);
+    expect(recordAbort).toHaveBeenCalledWith(alias, expect.any(Symbol));
     // Design lock: abort releases the probe lock WITHOUT re-OPENing. Re-trip would
     // punish a healthy alias for a per-account throttle (the reason recordFailure is
     // skipped). Staying HALF_OPEN lets the next request re-probe immediately.
@@ -6988,7 +6988,7 @@ describe("createExecute — HALF_OPEN probe lock release", () => {
     const toolReq = req({ tools: [{ type: "function" }] });
     const probeOut = await mk()(plan([alias, fallback]), toolReq);
     expect(probeOut.attempts[0]?.skip_reason).toBe("no_tool_support");
-    expect(recordAbort).toHaveBeenCalledWith(alias);
+    expect(recordAbort).toHaveBeenCalledWith(alias, expect.any(Symbol));
 
     // Without tools, the same alias must not still be circuit_open from a leaked probe.
     const plain = await mk()(plan([alias, fallback]), req());
@@ -7024,7 +7024,7 @@ describe("createExecute — HALF_OPEN probe lock release", () => {
     const out = await mk()(plan([alias, fallback]), req());
     expect(out.attempts[0]?.skip_reason).toBe("free_429");
     expect(recordFailure).not.toHaveBeenCalledWith(alias);
-    expect(recordAbort).toHaveBeenCalledWith(alias);
+    expect(recordAbort).toHaveBeenCalledWith(alias, expect.any(Symbol));
 
     const next = await mk()(plan([alias, fallback]), req());
     expect(next.attempts[0]?.skip_reason).not.toBe("circuit_open");

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1648,13 +1648,13 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       // here — the pool absorbs them, and the recordFailure skip below keeps the rare
       // surfaced one off the breaker.
       //
-      // canAttempt may grab the HALF_OPEN probe lock. Every exit from this candidate
-      // after allow:true MUST settle the breaker (success / failure / abort). Paths that
-      // intentionally skip recordFailure (OAuth account-scoped 429, capability skip after
-      // the gate, free_429, context overflow, …) still release the probe via recordAbort;
-      // otherwise inFlightProbe stays true and the alias returns circuit_open forever
-      // (prod 2026-08-06: anthropic/claude-opus-4-8 stuck for hours while other Anthropic
-      // models kept serving).
+      // canAttempt may grab the HALF_OPEN probe lock (+ opaque probeToken). Every exit
+      // from this candidate after allow:true MUST settle the breaker (success / failure /
+      // abort). Paths that intentionally skip recordFailure (OAuth account-scoped 429,
+      // capability skip after the gate, free_429, context overflow, …) still release the
+      // probe via recordAbort with the matching token; otherwise the lock stays held and
+      // the alias returns circuit_open forever (prod 2026-08-06). Abort must pass the
+      // token so a stale CLOSED request cannot release a later probe it never owned.
       const gate = breaker.canAttempt(alias);
       if (!gate.allow) {
         circuitSkipped = true;
@@ -1666,6 +1666,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       const settleBreaker = (kind: "success" | "failure" | "abort"): void => {
         if (kind === "success") breaker.recordSuccess(alias);
         else if (kind === "failure") breaker.recordFailure(alias);
+        else if (gate.probeToken !== undefined) breaker.recordAbort(alias, gate.probeToken);
         else breaker.recordAbort(alias);
         breakerSettled = true;
       };
@@ -2363,8 +2364,8 @@ export function createExecute(deps: ExecuteAdapterDeps) {
         // Release a HALF_OPEN probe lock on any path that allowed the attempt but
         // never settled success/failure/abort (capability skip after canAttempt,
         // free_429, context/reasoning skip, OAuth account-scoped 429/401/403).
-        // recordAbort is a no-op when the alias was never HALF_OPEN or the lock was
-        // already cleared by success/failure/abort above.
+        // Token-scoped abort is a no-op when the alias was never HALF_OPEN, the lock
+        // was already cleared, or this attempt does not own the in-flight probe.
         if (!breakerSettled) settleBreaker("abort");
       }
     }

--- a/apps/gateway/src/routes/image-chain.test.ts
+++ b/apps/gateway/src/routes/image-chain.test.ts
@@ -1,5 +1,5 @@
 import type { CircuitBreaker, ProviderClient } from "@helm/core";
-import { UpstreamError } from "@helm/core";
+import { createCircuitBreaker, UpstreamError } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import { type ImageAttempt, type ImageChainTarget, runImageChain } from "./image-chain.js";
 
@@ -30,6 +30,16 @@ function okResult(cost: number | null = 0.01) {
     cost,
     upstreamRequestJson: "{}",
   };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("runImageChain", () => {
@@ -105,6 +115,81 @@ describe("runImageChain", () => {
     expect(res.providerRaw).toEqual(raw); // surfaced verbatim
     expect(attempt).toHaveBeenCalledTimes(1); // did NOT advance to the fallback
     expect(breaker.recordFailure).not.toHaveBeenCalled(); // request is wrong, upstream is healthy
+  });
+
+  it("does not let a stale invalid_request release another request's HALF_OPEN probe", async () => {
+    let now = 0;
+    const breaker = createCircuitBreaker({
+      config: { failureThreshold: 5, cooldownMs: 1000 },
+      now: () => now,
+    });
+    const stale = deferred<Awaited<ReturnType<ImageAttempt>>>();
+    const probe = deferred<Awaited<ReturnType<ImageAttempt>>>();
+
+    const staleRun = runImageChain([target("a")], breaker, () => stale.promise, signal);
+    for (let i = 0; i < 5; i += 1) breaker.recordFailure("a");
+    expect(breaker.getState("a")).toBe("OPEN");
+
+    now = 1000;
+    const probeAttempt: ImageAttempt = vi.fn().mockReturnValue(probe.promise);
+    const probeRun = runImageChain([target("a")], breaker, probeAttempt, signal);
+    expect(probeAttempt).toHaveBeenCalledTimes(1);
+    expect(breaker.getState("a")).toBe("HALF_OPEN");
+
+    stale.reject(
+      new UpstreamError(
+        "upstream_error",
+        "bad request",
+        { error: { type: "invalid_request_error", message: "image too large" } },
+        400,
+      ),
+    );
+    const staleResult = await staleRun;
+    expect(staleResult.ok).toBe(false);
+    if (!staleResult.ok) expect(staleResult.errorClass).toBe("invalid_request");
+    expect(breaker.canAttempt("a")).toEqual({
+      allow: false,
+      probe: false,
+      reason: "circuit_open",
+    });
+
+    probe.resolve(okResult());
+    expect((await probeRun).ok).toBe(true);
+    expect(breaker.getState("a")).toBe("CLOSED");
+  });
+
+  it("releases its own HALF_OPEN probe on invalid_request", async () => {
+    let now = 0;
+    const breaker = createCircuitBreaker({
+      config: { failureThreshold: 5, cooldownMs: 1000 },
+      now: () => now,
+    });
+    for (let i = 0; i < 5; i += 1) breaker.recordFailure("a");
+    now = 1000;
+
+    const attempt: ImageAttempt = vi
+      .fn()
+      .mockRejectedValue(
+        new UpstreamError(
+          "upstream_error",
+          "bad request",
+          { error: { type: "invalid_request_error", message: "image too large" } },
+          400,
+        ),
+      );
+    const first = await runImageChain([target("a")], breaker, attempt, signal);
+    expect(first.ok).toBe(false);
+    if (!first.ok) expect(first.errorClass).toBe("invalid_request");
+    expect(breaker.getState("a")).toBe("HALF_OPEN");
+
+    const second = await runImageChain(
+      [target("a")],
+      breaker,
+      vi.fn().mockResolvedValue(okResult()),
+      signal,
+    );
+    expect(second.ok).toBe(true);
+    expect(breaker.getState("a")).toBe("CLOSED");
   });
 
   it("a ZenMux invalid_params 400 is terminal with the upstream message", async () => {

--- a/apps/gateway/src/routes/image-chain.ts
+++ b/apps/gateway/src/routes/image-chain.ts
@@ -109,6 +109,16 @@ export async function runImageChain(
       attempts.push(skipRow(target.alias, gate.reason ?? "circuit_open"));
       continue;
     }
+    // Mirror execute.ts: canAttempt may hold a HALF_OPEN probe lock. Paths that
+    // exit without recordSuccess/recordFailure must release its matching token or the
+    // alias stays permanently circuit_open until process restart.
+    const releaseProbeLock = (): void => {
+      if (gate.probeToken !== undefined) {
+        breaker.recordAbort(target.alias, gate.probeToken);
+      } else {
+        breaker.recordAbort(target.alias);
+      }
+    };
 
     const started = Date.now();
     try {
@@ -130,7 +140,7 @@ export async function runImageChain(
       if (cancellation === CONCURRENCY_LEASE_LOST_REASON || cancellation === "request_timeout") {
         const leaseLost = cancellation === CONCURRENCY_LEASE_LOST_REASON;
         const errorClass = leaseLost ? "lane_unavailable" : "timeout";
-        breaker.recordAbort(target.alias);
+        releaseProbeLock();
         attempts.push({
           alias: target.alias,
           skipped: false,
@@ -154,7 +164,7 @@ export async function runImageChain(
       // Client abort: NON-provider fault — terminate WITHOUT a breaker failure and
       // WITHOUT recording it as a provider error (mirrors execute.ts's recordAbort).
       if (isAbort(err, signal)) {
-        breaker.recordAbort(target.alias);
+        releaseProbeLock();
         return {
           ok: false,
           errorClass: "client_abort",
@@ -171,6 +181,7 @@ export async function runImageChain(
       // the upstream's structured error verbatim as a 400 invalid_request.
       if (isUpstreamRequestRejection(err)) {
         const detail = errorDetailOf(err);
+        releaseProbeLock();
         attempts.push({
           alias: target.alias,
           skipped: false,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,12 +7,13 @@
 
 ---
 
-## 2026-08-06 · HALF_OPEN 探测锁泄漏导致 alias 永久 circuit_open（Provider execution / circuit breaker，docs/02/04，原则 3/5）
+## 2026-08-06 · HALF_OPEN 探测锁：释放路径 + 探针所有权令牌（Provider execution / circuit breaker，docs/02/04，原则 3/5）
 
 - **现场**：`anthropic/claude-opus-4-8` 连续数小时 `skip_reason=circuit_open`（0ms），同 Anthropic OAuth 池的 haiku/sonnet 仍正常；账号配额未 limited。请求 `5c27cf5d…` 正确 fallback 到 `openai-codex/gpt-5.6-sol`。
-- **根因**：`canAttempt` 在 cooldown 结束后把 alias 置 `HALF_OPEN` 并持有 `inFlightProbe`。随后路径若**故意不** `recordFailure`（OAuth 账号级 429/401/403、capability/protocol skip、`free_429`、context overflow 等）也**不** `recordAbort`，锁永不释放 → 后续全部 `circuit_open`。生产序列：`no schedulable account`×5 打开 OPEN → HALF_OPEN probe 撞 429（account-scoped，跳过 failure）→ 锁卡死。
-- **修复**：`execute.ts` 在 `canAttempt` allow 后用 `settleBreaker` + `try/finally`：任何未 success/failure/abort 的退出都 `recordAbort` 释放探测锁；OAuth 账号级故障仍不计 alias failure。ops 侧已 `docker restart helm` 清内存状态。
-- **测试**：新增 3 个 HALF_OPEN 用例（OAuth 429 / capability skip / free_429）。不改 breaker 默认阈值（5 / 30s）。
+- **根因 1（#698）**：`canAttempt` 在 cooldown 后置 `HALF_OPEN` 并持锁；随后路径故意不 `recordFailure`（OAuth 账号级 429/401/403、capability skip、`free_429` 等）也未 `recordAbort` → 锁永不释放。
+- **根因 2（#700 加固）**：无主的 `recordAbort(model)` 会释放**任意** in-flight probe。若 CLOSED 请求晚结束，而新 probe 已启动，旧 abort 会误清新 probe 的锁，或相反地形成竞态。
+- **修复**：`execute.ts` / `image-chain.ts` 在 allow 后 `settleBreaker` + `try/finally`（或等价显式 release）；`recordAbort(model, probeToken?)` 仅当 `probeToken` 与 entry 匹配时清锁；`canAttempt` 对 probe 返回 opaque `probeToken`。
+- **测试**：HALF_OPEN OAuth 429 / capability / free_429；breaker 单测「stale CLOSED abort 不释放新 probe」；image-chain invalid-request / capability 恢复。阈值仍 5 / 30s。
 
 ## 2026-08-04 · 修复 per-key 请求内容存储覆盖的优先级回归（Gateway / Telemetry，docs/06/07/11，原则 2/7）
 

--- a/packages/core/src/circuit/breaker.test.ts
+++ b/packages/core/src/circuit/breaker.test.ts
@@ -76,7 +76,9 @@ describe("createCircuitBreaker", () => {
     const { breaker, clock } = makeBreaker();
     fail(breaker, "m", config.failureThreshold);
     clock.advance(config.cooldownMs);
-    expect(breaker.canAttempt("m")).toEqual({ allow: true, probe: true });
+    const probe = breaker.canAttempt("m");
+    expect(probe).toMatchObject({ allow: true, probe: true });
+    expect(probe.probeToken).toBeTypeOf("symbol");
     expect(breaker.getState("m")).toBe("HALF_OPEN");
   });
 
@@ -85,7 +87,8 @@ describe("createCircuitBreaker", () => {
     fail(breaker, "m", config.failureThreshold);
     clock.advance(config.cooldownMs);
     const first = breaker.canAttempt("m");
-    expect(first).toEqual({ allow: true, probe: true });
+    expect(first).toMatchObject({ allow: true, probe: true });
+    expect(first.probeToken).toBeTypeOf("symbol");
     // Second concurrent attempt while probe in flight is treated as OPEN.
     expect(breaker.canAttempt("m")).toEqual({
       allow: false,
@@ -99,7 +102,8 @@ describe("createCircuitBreaker", () => {
     const { breaker, clock } = makeBreaker();
     fail(breaker, "m", config.failureThreshold);
     clock.advance(config.cooldownMs);
-    breaker.canAttempt("m"); // acquire probe
+    const probe = breaker.canAttempt("m"); // acquire probe
+    expect(probe.probeToken).toBeTypeOf("symbol");
     breaker.recordSuccess("m");
     expect(breaker.getState("m")).toBe("CLOSED");
     // Lock released, counter cleared -> allows again.
@@ -113,7 +117,8 @@ describe("createCircuitBreaker", () => {
     const { breaker, clock } = makeBreaker();
     fail(breaker, "m", config.failureThreshold);
     clock.advance(config.cooldownMs);
-    breaker.canAttempt("m"); // HALF_OPEN, acquire probe
+    const probe = breaker.canAttempt("m"); // HALF_OPEN, acquire probe
+    expect(probe.probeToken).toBeTypeOf("symbol");
     breaker.recordFailure("m"); // probe fails
     expect(breaker.getState("m")).toBe("OPEN");
     // Cooldown origin refreshed at the time of probe failure: still OPEN now.
@@ -124,7 +129,7 @@ describe("createCircuitBreaker", () => {
     });
     // After a fresh full cooldown a new probe is permitted (lock was released).
     clock.advance(config.cooldownMs);
-    expect(breaker.canAttempt("m")).toEqual({ allow: true, probe: true });
+    expect(breaker.canAttempt("m")).toMatchObject({ allow: true, probe: true });
   });
 
   it("8. failure-before-first-chunk / success-after contract", () => {
@@ -154,12 +159,39 @@ describe("createCircuitBreaker", () => {
 
     // abort while HALF_OPEN holding the probe lock must release it (no deadlock).
     clock.advance(config.cooldownMs);
-    expect(breaker.canAttempt("m")).toEqual({ allow: true, probe: true });
+    const probe = breaker.canAttempt("m");
+    expect(probe).toMatchObject({ allow: true, probe: true });
+    expect(probe.probeToken).toBeTypeOf("symbol");
     expect(breaker.getState("m")).toBe("HALF_OPEN");
-    breaker.recordAbort("m");
+    breaker.recordAbort("m", probe.probeToken);
     // Lock released -> another probe can be acquired (still HALF_OPEN, not reset
     // to OPEN since abort is not a fault).
-    expect(breaker.canAttempt("m")).toEqual({ allow: true, probe: true });
+    expect(breaker.canAttempt("m")).toMatchObject({ allow: true, probe: true });
+  });
+
+  it("does not let a stale CLOSED attempt release a later HALF_OPEN probe", () => {
+    const { breaker, clock } = makeBreaker();
+    const ordinaryAttempt = breaker.canAttempt("m");
+    expect(ordinaryAttempt).toEqual({ allow: true, probe: false });
+
+    fail(breaker, "m", config.failureThreshold);
+    clock.advance(config.cooldownMs);
+    const probe = breaker.canAttempt("m");
+    expect(probe).toMatchObject({ allow: true, probe: true });
+    expect(probe.probeToken).toBeTypeOf("symbol");
+
+    // The old CLOSED request finishes after a newer request acquired the probe.
+    // Its missing token must not release a lock that it never owned.
+    breaker.recordAbort("m", ordinaryAttempt.probeToken);
+    expect(breaker.canAttempt("m")).toEqual({
+      allow: false,
+      probe: false,
+      reason: "circuit_open",
+    });
+
+    // The actual probe owner can release its lock and let the next probe in.
+    breaker.recordAbort("m", probe.probeToken);
+    expect(breaker.canAttempt("m")).toMatchObject({ allow: true, probe: true });
   });
 
   it("10. per-model isolation — model A OPEN does not affect model B", () => {
@@ -181,7 +213,7 @@ describe("createCircuitBreaker", () => {
     // 1ms later the ORIGINAL cooldown elapses → a probe is allowed. If the stray failure
     // had reset openedAt, this would still be SKIP and the breaker would never recover.
     clock.advance(1);
-    expect(breaker.canAttempt("m")).toEqual({ allow: true, probe: true });
+    expect(breaker.canAttempt("m")).toMatchObject({ allow: true, probe: true });
   });
 
   it("fail-open: an internal fault degrades to allow:true (treated as CLOSED)", () => {

--- a/packages/core/src/circuit/breaker.ts
+++ b/packages/core/src/circuit/breaker.ts
@@ -6,8 +6,8 @@
 //     / early upstream errors); successes only AFTER the first valid chunk —
 //     mid-stream breakage cannot count as success;
 //   - client abort is a NON-provider fault: records neither failure nor success
-//     (does not pollute health, does not trip the breaker), but releases any
-//     held probe lock so HALF_OPEN never deadlocks;
+//     (does not pollute health, does not trip the breaker), but releases its
+//     own probe lock so HALF_OPEN never deadlocks;
 //   - HALF_OPEN uses a per-model probe lock so only one probe request is in
 //     flight; all other concurrent requests are treated as OPEN (skipped).
 //
@@ -39,6 +39,8 @@ export interface BreakerDeps {
 export interface AttemptDecision {
   allow: boolean;
   probe: boolean;
+  /** Opaque owner token for a HALF_OPEN probe; absent for ordinary attempts. */
+  probeToken?: symbol;
   reason?: string;
 }
 
@@ -47,7 +49,7 @@ export interface CircuitBreaker {
    * Asked before each attempt: may this model be called right now?
    *   CLOSED                          -> { allow:true,  probe:false }
    *   OPEN & within cooldown          -> { allow:false, probe:false, reason:"circuit_open" }
-   *   OPEN & cooldown elapsed         -> grab probe lock: won  -> HALF_OPEN, { allow:true, probe:true }
+   *   OPEN & cooldown elapsed         -> grab probe lock: won  -> HALF_OPEN, { allow:true, probe:true, probeToken }
    *                                                       lost -> { allow:false, probe:false, reason:"circuit_open" }
    *   HALF_OPEN (probe already in flight) -> { allow:false, probe:false, reason:"circuit_open" }
    */
@@ -59,8 +61,8 @@ export interface CircuitBreaker {
   /** Call ONLY after a first valid chunk / valid response is received. */
   recordSuccess(model: string): void;
 
-  /** Client abort: record nothing (non-provider fault), but release any probe lock. */
-  recordAbort(model: string): void;
+  /** Client abort: record nothing; release only the caller's HALF_OPEN probe lock. */
+  recordAbort(model: string, probeToken?: symbol): void;
 
   getState(model: string): CircuitState;
 }
@@ -69,8 +71,8 @@ interface ModelEntry {
   state: CircuitState;
   failures: number;
   openedAt: number;
-  /** HALF_OPEN single-probe lock: only the holder gets allow:true, probe:true. */
-  inFlightProbe: boolean;
+  /** HALF_OPEN single-probe ownership; only the holder may release it. */
+  probeToken: symbol | null;
 }
 
 const CIRCUIT_OPEN = "circuit_open";
@@ -79,7 +81,7 @@ const ALLOW: AttemptDecision = { allow: true, probe: false };
 const PROBE: AttemptDecision = { allow: true, probe: true };
 
 function freshEntry(): ModelEntry {
-  return { state: "CLOSED", failures: 0, openedAt: 0, inFlightProbe: false };
+  return { state: "CLOSED", failures: 0, openedAt: 0, probeToken: null };
 }
 
 export function createCircuitBreaker(deps: BreakerDeps): CircuitBreaker {
@@ -98,13 +100,13 @@ export function createCircuitBreaker(deps: BreakerDeps): CircuitBreaker {
   function reset(e: ModelEntry): void {
     e.state = "CLOSED";
     e.failures = 0;
-    e.inFlightProbe = false;
+    e.probeToken = null;
   }
 
   function trip(e: ModelEntry): void {
     e.state = "OPEN";
     e.openedAt = now();
-    e.inFlightProbe = false;
+    e.probeToken = null;
   }
 
   return {
@@ -118,16 +120,16 @@ export function createCircuitBreaker(deps: BreakerDeps): CircuitBreaker {
             // A probe is already in flight — everyone else is skipped. If the
             // lock was released without resolution (e.g. after an abort), the
             // next caller may acquire it for a fresh probe.
-            if (e.inFlightProbe) return SKIP;
-            e.inFlightProbe = true;
-            return PROBE;
+            if (e.probeToken !== null) return SKIP;
+            e.probeToken = Symbol(model);
+            return { ...PROBE, probeToken: e.probeToken };
           case "OPEN": {
             if (now() - e.openedAt < config.cooldownMs) return SKIP;
             // Cooldown elapsed — grab the probe lock and transition to HALF_OPEN.
             // (Single-threaded JS: the first synchronous caller wins the lock.)
             e.state = "HALF_OPEN";
-            e.inFlightProbe = true;
-            return PROBE;
+            e.probeToken = Symbol(model);
+            return { ...PROBE, probeToken: e.probeToken };
           }
           default:
             return ALLOW;
@@ -170,15 +172,16 @@ export function createCircuitBreaker(deps: BreakerDeps): CircuitBreaker {
       }
     },
 
-    recordAbort(model) {
+    recordAbort(model, probeToken) {
       try {
         // Non-provider fault: record neither failure nor success. Release the probe
-        // lock so HALF_OPEN never deadlocks into a phantom OPEN — but ONLY when actually
-        // HALF_OPEN (the only state that holds a lock). Clearing it in CLOSED/OPEN is a
-        // no-op today (trip/reset already cleared it); gating keeps a stray abort from
-        // ever releasing a lock it doesn't own if the state model grows (review M4).
+        // lock so HALF_OPEN never deadlocks into a phantom OPEN — but only for the
+        // probe owner. A stale CLOSED request may finish after a newer probe starts;
+        // accepting an unowned abort would release that newer request's lock.
         const e = get(model);
-        if (e.state === "HALF_OPEN") e.inFlightProbe = false;
+        if (e.state === "HALF_OPEN" && probeToken !== undefined && e.probeToken === probeToken) {
+          e.probeToken = null;
+        }
       } catch {
         // fail-open.
       }


### PR DESCRIPTION
## Summary

- Add an opaque probe token to HALF_OPEN circuit-breaker decisions.
- Release a probe lock only from the attempt that owns the matching token.
- Thread token-aware abort/neutral settlement through chat and image execution paths.
- Add regressions for capability skips, image invalid requests, stale requests, and probe recovery.

## Validation

- `CI=true pnpm exec vitest run packages/core/src/circuit/breaker.test.ts apps/gateway/src/routes/execute.errors.test.ts apps/gateway/src/routes/image-chain.test.ts --maxWorkers=1` — 42 passed.
- `pnpm --filter @helm/core typecheck` — passed.
- `pnpm --filter @helm/gateway typecheck` — passed.
- Biome check and diff check — passed.
- Shared/core/gateway builds — passed.

## Local verification notes

The full local execute suite still reports one unrelated cross-protocol output_config.effort failure (157/158 passed). The image Playwright spec starts with the local mock but currently returns existing 503 provider/config responses (1/5 passed); no probe-token assertion failed.
