### PR TITLE
chore(release): v0.28.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.41",
+  "version": "0.28.42",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- Bump `package.json` **0.28.41 → 0.28.42** for a formal GitHub Release + GHCR tag.
- Includes already-merged **#700**: HALF_OPEN probe ownership tokens (stale abort cannot clear another request's probe).

## Deploy

After Publish succeeds, pin digest on `la.atmy.work` `/opt/helm-api` and `docker compose up -d`.