### PR TITLE
fix(gateway): surface upstream prompt-too-long so clients compact

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1981,22 +1981,22 @@ describe("createExecute — gateway execution adapter", () => {
     });
   });
 
-  it("does not misreport context overflow when another candidate has a provider failure", async () => {
+  it("returns the shaped overflow 400 at exhaustion even when a later candidate has a provider failure", async () => {
+    // The head candidate reports a shaped overflow ("prompt is too long: N > M maximum",
+    // here with a `context_length_exceeded` code). A sibling is still tried, but fails with
+    // an unrelated 500. At exhaustion the terminal must surface the compaction-compatible
+    // 400 VERBATIM, not demote it to all_providers_failed because of the 500 (box c211e4a1).
+    const raw = {
+      error: {
+        code: "context_length_exceeded",
+        message: "prompt is too long: 1200000 tokens > 1000000 maximum",
+      },
+    };
     const provider = {
       chatCompletion: vi
         .fn()
         .mockRejectedValueOnce(
-          new UpstreamError(
-            "upstream_error",
-            "upstream returned 400",
-            {
-              error: {
-                code: "context_length_exceeded",
-                message: "prompt is too long: 1200000 tokens > 1000000 maximum",
-              },
-            },
-            400,
-          ),
+          new UpstreamError("upstream_error", "upstream returned 400", raw, 400),
         )
         .mockRejectedValueOnce(
           new UpstreamError("upstream_error", "upstream returned 500", {}, 500),
@@ -2018,10 +2018,13 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.final.status).toBe("error");
     if (out.final.status !== "error") throw new Error("expected a terminal error");
     expect(out.final.error).toMatchObject({
-      error_class: "all_providers_failed",
-      http_status: 502,
-      provider_raw: null,
+      error_class: "invalid_request",
+      http_status: 400,
+      message: "prompt is too long: 1200000 tokens > 1000000 maximum",
+      provider_raw: raw,
     });
+    // Both candidates attempted — the shaped overflow wins the terminal at exhaustion.
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
   });
 
   it("returns a compaction 400 when multiple candidates confirm context overflow", async () => {
@@ -2308,6 +2311,222 @@ describe("createExecute — gateway execution adapter", () => {
     });
     expect(provider.chatCompletion).toHaveBeenCalledOnce();
     expect(recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("returns the compaction 400 at exhaustion even when an unrelated sibling fails (box c211e4a1)", async () => {
+    // Anthropic (the LARGEST-window candidate, head of chain) returns a REAL 400
+    // "prompt is too long: N > M maximum". A smaller sibling is still tried (a larger
+    // window could in principle serve it), but here it fails with an UNRELATED 422. The
+    // chain-exhausted terminal must surface the shaped overflow VERBATIM as invalid_request
+    // (400) — NOT bury it as all_providers_failed just because grok also failed — so Claude
+    // Code / Codex receive the 4xx and trigger their own context compaction.
+    const raw = {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "prompt is too long: 1022145 tokens > 1000000 maximum",
+      },
+    };
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "upstream returned 400", raw, 400),
+        )
+        .mockRejectedValueOnce(
+          new UpstreamError(
+            "upstream_error",
+            "upstream returned 422",
+            {
+              error:
+                "Failed to deserialize the JSON body into the target type: invalid type: map, expected a sequence",
+            },
+            422,
+          ),
+        ),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ opus: "claude-opus-4-8", grok: "grok-4.5" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "grok"]), req());
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "invalid_request",
+      http_status: 400,
+      message: "prompt is too long: 1022145 tokens > 1000000 maximum",
+      provider_raw: raw,
+    });
+    // Both candidates were attempted (the overflow does NOT short-circuit — a bigger
+    // sibling could serve it); the terminal still prefers the compaction 400.
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+  });
+
+  it("prefers a larger-window sibling over a shaped context overflow instead of short-circuiting", async () => {
+    // The head candidate reports "prompt is too long: N > M" (its OWN window; 200k models
+    // emit the same shape). A later, larger-window sibling can still serve the request, so
+    // the gateway must fall back and succeed — the shaped overflow must NOT be treated as a
+    // whole-chain ceiling that terminates early.
+    const raw = {
+      error: {
+        code: "context_length_exceeded",
+        message: "prompt is too long: 210000 tokens > 200000 maximum",
+      },
+    };
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "upstream returned 400", raw, 400),
+        )
+        .mockResolvedValueOnce({ id: "big-window" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ small: "claude-sonnet-5", big: "claude-opus-4-8" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["small", "big"]), req());
+
+    expect(out.final).toEqual({ status: "ok", alias: "big", providerModel: "claude-opus-4-8" });
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+    expect(out.attempts[0]).toMatchObject({ skipped: true, skip_reason: "context_too_small" });
+    expect(out.attempts[1]?.status).toBe("ok");
+  });
+
+  it("does not let a pre-flight approximate shaped estimate override a real provider failure via the bypass", async () => {
+    // The head candidate is pre-flight-skipped for exceeding its small window — this
+    // SYNTHESIZES a "prompt is too long: N > M" message with authoritative=false. A later
+    // candidate then fails with a REAL 500 (a genuine provider fault, NOT an overflow), so
+    // `onlyContextOrCapabilitySkips` is false and there are no ≥2 confirmations. Only the
+    // authoritative-shape bypass could still fire — and it must NOT, because the shape came
+    // from an ESTIMATE, not a real upstream verdict. A real 5xx must win: all_providers_failed.
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        // head `small` is pre-flight-skipped (never invoked); tail returns a real 500.
+        .mockRejectedValue(new UpstreamError("upstream_error", "upstream returned 500", {}, 500)),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ small: "small-model", tail: "tail-model" }),
+      breaker: breaker(),
+      // `small` has a tiny window → the 100-char prompt trips the approximate pre-flight gate.
+      catalog: new Map([["small", entry("small", { maxContextTokens: 20 })]]),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan(["small", "tail"]),
+      req({ messages: [{ role: "user", content: "x".repeat(100) }] }),
+    );
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    // The synthetic shaped estimate must NOT masquerade as an authoritative hard-maximum
+    // verdict and bury the genuine 5xx behind a fabricated compaction 400.
+    expect(out.final.error.error_class).toBe("all_providers_failed");
+    expect(out.final.error.http_status).toBe(502);
+  });
+
+  it("returns the compaction 400 for an authoritative shaped overflow with comma-grouped counts", async () => {
+    // Real upstreams format the counts with commas ("1,022,145"). The shape matcher must
+    // tolerate grouping so a genuine overflow still surfaces the compaction 400 at exhaustion.
+    const raw = {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "prompt is too long: 1,022,145 tokens > 1,000,000 maximum",
+      },
+    };
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "upstream returned 400", raw, 400),
+        )
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "upstream returned 500", {}, 500),
+        ),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ opus: "claude-opus-4-8", tail: "tail-model" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "tail"]), req());
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "invalid_request",
+      http_status: 400,
+      message: "prompt is too long: 1,022,145 tokens > 1,000,000 maximum",
+      provider_raw: raw,
+    });
+  });
+
+  it("does not synthesize a compaction 400 from the phrase echoed in a provider-failure body", async () => {
+    // The terminal shape-bypass keys on the STRUCTURED error message (`error.message`), not
+    // the JSON-stringified raw body. So a genuine provider failure whose body merely echoes
+    // request content containing "prompt is too long: N > M" must NOT be promoted to a
+    // compaction 400 — with the whole chain failing, the terminal stays all_providers_failed.
+    const provider = {
+      chatCompletion: vi.fn().mockRejectedValue(
+        new UpstreamError(
+          "upstream_error",
+          "upstream returned 500",
+          {
+            error: { type: "server_error", message: "internal error" },
+            echoed_input: "the user wrote: prompt is too long: 5 tokens > 3 maximum",
+          },
+          500,
+        ),
+      ),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ opus: "claude-opus-4-8", tail: "tail-model" }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "tail"]), req());
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    // The echoed phrase must not fabricate a client-visible 400.
+    expect(out.final.error.error_class).toBe("all_providers_failed");
+    expect(out.final.error.http_status).toBe(502);
   });
 
   it("falls back when an OpenAI-compatible thinking target requires missing reasoning_content history", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1254,15 +1254,22 @@ export function upstreamErrorMessage(raw: unknown): string | null {
 export function isContextWindowRejection(err: unknown): boolean {
   if (!(err instanceof UpstreamError)) return false;
   if (upstreamErrorCode(err.providerRaw) === "context_length_exceeded") return true;
-  const text = `${err.message} ${upstreamErrorMessage(err.providerRaw) ?? ""} ${rawErrorText(
-    err.providerRaw,
-  )}`.toLowerCase();
+  // Strong, unambiguous markers may be matched anywhere in the body — they don't occur as
+  // innocent echoed request content (some in-band SSE errors only surface them in the raw
+  // envelope, not a structured `error.message`).
+  const rawText = rawErrorText(err.providerRaw).toLowerCase();
+  if (rawText.includes("context_length_exceeded") || rawText.includes("maximum context")) {
+    return true;
+  }
+  // Weaker phrases ("prompt is too long", "context window/length") are matched ONLY in the
+  // structured error string, never the stringified raw body: a provider-failure body that
+  // echoes the user's prompt could otherwise be misclassified as an overflow (and, worse,
+  // fabricate a client-visible compaction 400 at the terminal).
+  const structured = `${err.message} ${upstreamErrorMessage(err.providerRaw) ?? ""}`.toLowerCase();
   return (
-    text.includes("context_length_exceeded") ||
-    text.includes("context window") ||
-    text.includes("context length") ||
-    text.includes("maximum context") ||
-    text.includes("prompt is too long")
+    structured.includes("context window") ||
+    structured.includes("context length") ||
+    structured.includes("prompt is too long")
   );
 }
 
@@ -1286,6 +1293,16 @@ export function isUpstreamRequestRejection(err: unknown): boolean {
   const text = `${err.message} ${rawErrorText(err.providerRaw)}`.toLowerCase();
   return text.includes("max allowed size");
 }
+
+// Anthropic's authoritative hard-maximum phrasing: "prompt is too long: N tokens > M
+// maximum" (comma grouping in the counts tolerated). This is an actionable compaction
+// signal — the request as sent is over a real ceiling — so once the candidate chain is
+// exhausted the terminal selector returns it as a client-visible `invalid_request` (400)
+// even if an UNRELATED sibling also failed, instead of burying it as all_providers_failed
+// (box c211e4a1). It does NOT short-circuit the chain: a larger-window sibling may still
+// serve the request (the same shape is emitted by 200k models, not only the 1M ceiling),
+// so fallback continues; this only governs which structured error wins at exhaustion.
+const ABSOLUTE_CONTEXT_MAX_PATTERN = /prompt is too long[^0-9]*[\d,]+\s*tokens?\s*>\s*[\d,]+/i;
 
 function isReasoningHistoryRejection(err: unknown): boolean {
   if (!(err instanceof UpstreamError)) return false;
@@ -1579,18 +1596,38 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           providerRaw: Record<string, unknown> | null;
         }
       | undefined;
+    // The shaped "prompt is too long: N > M" message + raw from a REAL upstream response,
+    // if one was seen. Tracked SEPARATELY from `contextOverflow` (which also collects
+    // pre-flight approximate estimates that synthesize the same phrasing) so the terminal
+    // bypass — "return a compaction 400 even when mixed with an unrelated provider failure"
+    // (box c211e4a1) — can never be satisfied by an approximate estimate. Both the shape AND
+    // the authoritative provenance must belong to the SAME record, which is exactly what this
+    // captures. A real 5xx alongside a mere estimate therefore still yields all_providers_failed.
+    let authoritativeShapedOverflow:
+      | { message: string; providerRaw: Record<string, unknown> | null }
+      | undefined;
     const rememberContextOverflow = (
       message: string,
       providerRaw: Record<string, unknown> | null,
-      confirmationKey?: string,
+      confirmationKey: string | undefined,
+      authoritative: boolean,
     ): void => {
       if (confirmationKey !== undefined) contextConfirmations.add(confirmationKey);
+      if (
+        authoritative &&
+        authoritativeShapedOverflow === undefined &&
+        ABSOLUTE_CONTEXT_MAX_PATTERN.test(message)
+      ) {
+        authoritativeShapedOverflow = { message, providerRaw };
+      }
       if (contextOverflow === undefined) {
         contextOverflow = { message, providerRaw };
         return;
       }
-      const compactionPattern = /prompt is too long[^0-9]*\d+\s*tokens?\s*>\s*\d+/i;
-      if (!compactionPattern.test(contextOverflow.message) && compactionPattern.test(message)) {
+      if (
+        !ABSOLUTE_CONTEXT_MAX_PATTERN.test(contextOverflow.message) &&
+        ABSOLUTE_CONTEXT_MAX_PATTERN.test(message)
+      ) {
         contextOverflow.message = message;
       }
       if (contextOverflow.providerRaw === null && providerRaw !== null) {
@@ -1722,6 +1759,8 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                   limit,
                 )} maximum`,
                 null,
+                undefined,
+                false, // approximate estimate, not an authoritative upstream verdict
               );
             }
             attempts.push(skipRow(alias, verdict.skipReason ?? "capability", elapsed()));
@@ -1826,6 +1865,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 )} maximum`,
                 null,
                 contextConfirmationKey,
+                false, // per-model count_tokens preflight; a larger sibling may still fit
               );
               attempts.push(skipRow(alias, "context_too_small", elapsed()));
               continue;
@@ -2249,9 +2289,12 @@ export function createExecute(deps: ExecuteAdapterDeps) {
           }
 
           // Model context window overflow: THIS candidate cannot serve the request,
-          // but a later fallback with a larger window can. Treat it like a late-discovered
+          // but a later fallback with a LARGER window can (the same "prompt is too long:
+          // N > M" shape is emitted by 200k models too, not only the 1M ceiling — so this
+          // is NOT proof the whole chain overflows). Treat it like a late-discovered
           // capability skip, not provider health: no breaker failure, no red provider
-          // error row, and no execution-fallback count.
+          // error row, and no execution-fallback count. The chain-exhausted terminal below
+          // returns the compaction-compatible 400 once no larger sibling can serve it.
           if (isContextWindowRejection(err)) {
             capabilityPruned = true;
             const detail = errorDetailOf(err);
@@ -2261,6 +2304,7 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               upstreamErrorCode(detail.provider_raw)?.toLowerCase() === "context_length_exceeded"
                 ? contextConfirmationKey
                 : undefined,
+              true, // authoritative: a real upstream response reported the overflow
             );
             attempts.push({
               alias,
@@ -2403,6 +2447,19 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       errorClass = "invalid_request";
       message = contextOverflow.message;
       providerRaw = contextOverflow.providerRaw;
+    } else if (authoritativeShapedOverflow !== undefined) {
+      // A REAL upstream response carried the exact hard-maximum shape "prompt is too long:
+      // N > M". Emit the compaction-compatible 400 VERBATIM even when the chain also had an
+      // UNRELATED provider failure (box c211e4a1: a grok 422 must NOT bury it as
+      // all_providers_failed and leave Claude Code / Codex unable to compact). The
+      // shape AND the authoritative provenance belong to the same record, so a pre-flight
+      // APPROXIMATE estimate (which synthesizes the same phrasing) can never reach here and
+      // override a genuine provider 5xx. Larger-window fallback already ran first (a shaped
+      // overflow is a context skip, not a short-circuit); this only picks the terminal once
+      // the chain is truly exhausted.
+      errorClass = "invalid_request";
+      message = authoritativeShapedOverflow.message;
+      providerRaw = authoritativeShapedOverflow.providerRaw;
     } else if (
       !attemptedAny &&
       capabilityPruned &&

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,17 @@
 
 ---
 
+## 2026-08-07 · 真实上游超长溢出在链耗尽时胜出终态，修复客户端无法压缩（Provider execution / protocol errors，docs/04/05/07，原则 3/5/8）
+
+- **现场（box `c211e4a1`，v0.28.42）**：Claude Code 发 ~102 万 token，Anthropic（链首、最大窗口）返回真实 400 `prompt is too long: 1022145 tokens > 1000000 maximum`（**无** `context_length_exceeded` code）。helm 把它当可重试 `context_too_small` 继续 fallback；`xai/grok-4.5` 因独立翻译 bug 返回 422，把 `onlyContextOrCapabilitySkips` 打成 false，终态选择器降级为合成 `all_providers_failed / 502`。客户端拿不到真实 400 → 认不出该压缩 → 卡死。
+- **根因**：2026-08-03 的终态优先级（下方同标题条目）只在“整链仅上下文/能力 skip”或“≥2 个 `context_length_exceeded` code 确认”时才回 `invalid_request / 400`。Anthropic 绝对上限用 `prompt is too long: N > M` 措辞、不带该 code，一个无关兄弟失败就翻掉守卫。
+- **关键教训（Codex review 纠偏，避免过修）**：初版曾想“命中即短路、不再 fallback”，**错**——`N > M` 只证明**该候选**的窗口，200k 模型也用同一措辞；若链后面有更大窗口候选，短路会误杀可成功的 fallback。正解是**继续 fallback 试更大窗口**，仅在**链耗尽**时让这个溢出胜出终态。
+- **修复（拍板：所有协议一致；不短路，改终态守卫）**：单独追踪 `authoritativeShapedOverflow`——**只有真实上游响应**报的、且消息形如 `prompt is too long: N > M`（逗号分组容错）的溢出才记入；预检估算（char / `count_tokens`）绝不进。终态在原两条件（`onlyContextOrCapabilitySkips` / `≥2` 确认）后新增：`authoritativeShapedOverflow !== undefined` → 即使夹有无关 provider failure 也回 `invalid_request / 400` 保留其 `provider_raw`。把「形状」与「真实来源」绑在同一条记录，杜绝近似估算冒充硬上限压过真实 5xx（守住既有 “approximate estimate override provider failure” 用例）。
+- **Codex 对抗式 review 的价值**：Codex 曾提「短路会误杀更大窗口兄弟」（真，已改为不短路）、「近似估算的 shape 经 boolean 合并冒充 authoritative」（合理担忧，实测该路径下 `onlyContextOrCapabilitySkips` 仍为 true、第一条守卫本就触发，不会错翻 error class——属 plausible-but-not-reachable，但仍按其建议重构成 provenance 绑定，更干净且消息来源正确）、「回显内容误判」（真，已收窄 `isContextWindowRejection` 弱措辞只匹配结构化 message）。遗留：强标记 `context_length_exceeded`/“maximum context” 仍全 body 匹配（API 专有 token，正文混入概率极低，ponytail 上限）；真实溢出行仍记 `skipped:true`（既有全体 context-overflow 约定，`fallback_count` 少计一次，非本次回归，另议）。
+- **顺带加固 `isContextWindowRejection`（Codex #2 回显内容误判）**：强信号（`context_length_exceeded` code / “maximum context”）仍全 body 匹配；弱措辞（“prompt is too long”/“context window/length”）只在**结构化 error message** 匹配，不扫 `rawErrorText`——否则 provider-failure body 里回显的用户 prompt 会被误判为溢出，甚至在终态**伪造**一个客户端 400。
+- **测试**：box 回归（`N>M` 首 + 兄弟 422 → 两候选都试、终态 400）；`context_length_exceeded` 变体同理；“更大窗口兄弟胜过 shaped 溢出”（不短路、fallback 成功）；“回显内容不伪造 400”（全链失败 → `all_providers_failed`）；per-model / 流式 / 多候选确认 / 近似估算不压真实故障用例全绿。execute.test.ts 164 全绿；messages/chat/gemini/responses/image-chain/pipeline 相关 239 全绿。
+- **遗留（本次不修）**：`xai/grok-4.5` 的 422 `invalid type: map, expected a sequence` 是独立的 anthropic→openai_responses 翻译缺陷；另开 change。
+
 ## 2026-08-06 · HALF_OPEN 探测锁：释放路径 + 探针所有权令牌（Provider execution / circuit breaker，docs/02/04，原则 3/5）
 
 - **现场**：`anthropic/claude-opus-4-8` 连续数小时 `skip_reason=circuit_open`（0ms），同 Anthropic OAuth 池的 haiku/sonnet 仍正常；账号配额未 limited。请求 `5c27cf5d…` 正确 fallback 到 `openai-codex/gpt-5.6-sol`。
@@ -70,12 +81,6 @@
 - **维护边界**：SQLite Session prune 继续小批续跑；PostgreSQL 每次 cleanup tick 最多处理 128 个物理行、每批 16 行，并用持久 marker 续跑。scheduled cleanup 与 auto-VACUUM 在开始前检查压力，VACUUM 排空活动后、真正重写数据库前再次检查；压力恶化时不执行也不误记当天成功。手动维护语义保持不变。
 - **模式切换**：切换全局 capture generation 后，已排队但尚未 flush 的 payload/Session 正文写入会被丢弃，脱敏 telemetry 仍保存。`part=meta` 不读取正文。（原先此处误把“全局 metadata-only 视为 hard-off、任何 key override 都不能绕过”写成契约——与 #675 的 per-key 覆盖优先级冲突，已于 2026-08-04 更正，见顶部条目。）
 
-## 2026-07-31 · API key 单独覆盖请求内容存储模式（Key Store / Telemetry / Admin，docs/06/07/11，原则 2/7）
-
-- **继承与优先级**：`api_keys.request_content_mode` 是 SQLite/PostgreSQL 的 nullable 枚举列；`NULL` 表示继承实时全局模式，`none` / `payload` / `session` 显式覆盖。历史 key 迁移后保持 `NULL`，不会因升级改变正文留存行为。
-- **覆盖面**：鉴权身份把覆盖值传到 Chat、Messages、Responses（含 compact）、Gemini、Images、Interactions 与 Admin Replay，并复用同一个 capture helper；只替换本次请求的 capture getter，不冻结或修改全局设置。
-- **保留边界**：`payload_retention_days` 仍是全局值，未增加 per-key retention。Admin Create/Edit/详情支持设置和清除覆盖；隐私提示与系统设置共用现有文案。
-
 ## 2026-07-31 · 保证 Session 捕获且删除累计字节上限（Telemetry / Session Store，docs/07/11，用户明确要求）
 
 - **决定**：按用户要求删除单 Session 64 MiB 累计存储上限，不用更大的常量替代。共享 Session 捕获、SQLite 与 PostgreSQL adapter 都不再因 `stored_bytes` 拒绝新 revision 或响应回填；`stored_bytes` 只继续用于观测。现有 SQLite `INTEGER` 与 PostgreSQL `BIGINT` 均无需迁移。
@@ -85,6 +90,7 @@
 
 ## 历史条目摘要（最新要点）
 
+- **2026-07-31 · API key 单独覆盖请求内容存储模式**：`api_keys.request_content_mode` nullable 枚举列，`NULL` 继承实时全局、`none`/`payload`/`session` 显式覆盖；鉴权身份把覆盖值传到 Chat/Messages/Responses(含 compact)/Gemini/Images/Interactions/Admin Replay 复用同一 capture helper，只换本次请求 getter；`payload_retention_days` 仍全局，无 per-key retention（2026-08-04 修正其优先级回归，见顶部）。完整原文经 git history 回溯。
 - **2026-07-31 · 请求列表记录并显示客户端正文大小**：新增可选 `request_body_bytes`（客户端 wire UTF-8 字节，非 Content-Length/token/压缩量），随脱敏 DecisionRecord 保存；Admin 表按 B/KB/MB 展示，旧记录显示 `—`；完整原文通过 git history 回溯。
 - **2026-07-29 · 生产韧性：持续小批清理 + 无丢弃背压 + 执行 Token 租约 + 完整错误诊断**：SQLite retention 每批≤10 行让出事件循环、Session prune claim 可续；写队列删除 OOM shedding 改统一串行 admission 背压 FIFO；OAuth 保存真实 `expires`、执行 client 6 分钟提前刷新、刷新失败重读共享 Store 只用他实例轮换出的有效 credential；Provider 错误有界诊断（64 KiB body / 128 KiB 总预算），完整原文通过 git history 回溯。
 - **2026-07-28 · 删除 HTTP 与 WebSocket 请求大小上限**：删除应用与 Remote Nginx 固定正文上限，继续由动态内存准入、鉴权、schema、maintenance drain 和 provider timeout 保护运行时；完整原文通过 git history回溯。


### PR DESCRIPTION
## Problem

Box request `c211e4a1` (v0.28.42): Claude Code sent ~1.02M tokens. Anthropic returned a real 400 `invalid_request_error: prompt is too long: 1022145 tokens > 1000000 maximum` (no `context_length_exceeded` code). The gateway treated it as a retryable `context_too_small` skip and kept falling back; a sibling `xai/grok-4.5` then failed with an unrelated 422, flipping `onlyContextOrCapabilitySkips=false`, so the terminal selector demoted the whole chain to a synthetic `all_providers_failed` (502).

Native clients (Claude Code / Codex) rely on receiving that 4xx to trigger their own **context compaction**. Buried as a 502, the client can't tell it needs to compact and gets stuck. This is a regression of the earlier "helm swallows 400 invalid_request breaks compaction" area — the handling existed but the terminal guard was too strict (only fired on `onlyContextOrCapabilitySkips` or ≥2 `context_length_exceeded`-code confirmations; Anthropic's absolute-max phrasing carries neither).

## Fix

- Track `authoritativeShapedOverflow`: the `prompt is too long: N > M` message + `provider_raw` from a **real upstream response** (comma-grouped counts tolerated). At chain exhaustion, return it verbatim as `invalid_request` (400) **even when mixed with an unrelated provider failure**.
- It does **not** short-circuit the chain. A larger-window sibling may still serve the request (the same `N > M` shape is emitted by 200k models, not only the 1M ceiling), so fallback runs first; this only picks the terminal once the chain is exhausted.
- Binding the shape **and** the authoritative provenance to one record keeps a pre-flight **approximate** estimate (which synthesizes the same phrasing) from overriding a genuine provider 5xx (preserves the existing "approximate estimate must not override a provider failure" behavior).
- Harden `isContextWindowRejection` against echoed-content false positives: strong markers (`context_length_exceeded` code / "maximum context") still match anywhere in the body; the weaker phrases match only the structured error message, never the JSON-stringified raw body.

Applies to all protocols. No config change.

## Review

Independently reviewed by Codex (adversarial). All actionable findings addressed:
- "short-circuit skips a larger-window sibling" → changed to fallback-then-terminal (never short-circuits).
- echoed-content false positive → `isContextWindowRejection` weak phrases now structured-message-only.
- message/provenance provenance mismatch + comma format → single `authoritativeShapedOverflow` record with a comma-aware matcher.

## Tests

`apps/gateway/src/routes/execute.test.ts` — 166 pass. New/updated cases: box regression (shaped 400 + sibling 422 → both attempted, terminal 400); `context_length_exceeded`-code variant; larger-window sibling preferred over a shaped overflow (no early terminate); comma-grouped counts still surface the 400; approximate shaped estimate must not override a real 5xx; echoed phrase must not fabricate a 400. Related suites (messages/chat/gemini/responses/image-chain/pipeline) green — 405 total.

## Out of scope

The `xai/grok-4.5` 422 `invalid type: map, expected a sequence` is a separate anthropic→openai_responses translation defect. After this fix an oversized prompt no longer reaches grok, but the defect remains for other requests — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)