### PR TITLE
chore(release): bump version to 0.28.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.42",
+  "version": "0.28.43",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Cuts the release containing #702: surfaces upstream `prompt is too long: N > M` (Anthropic 400) as a verbatim `invalid_request` at chain exhaustion — even alongside an unrelated sibling failure — so Claude Code / Codex receive the 4xx and trigger their own context compaction instead of a buried `all_providers_failed` (box c211e4a1).

On merge, `publish.yml` auto-cuts the tag, GitHub Release, and `:0.28.43` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)