### PR TITLE
chore(release): bump version to 0.28.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.44",
+  "version": "0.28.45",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Cuts the release containing #705: drops Anthropic `context_management` for generic Responses upstreams (xAI grok) on both the translation and same-protocol passthrough paths, fixing the HTTP 422 "invalid type: map, expected a sequence" that surfaced as grok's unrelated failure in box `c211e4a1`. Also carries #704 (per-account "spend remaining credits while rate-limited" toggle), already on main.

On merge, `publish.yml` auto-cuts the tag, GitHub Release, and `:0.28.45` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)