### PR TITLE
chore(release): bump version to 0.28.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.45",
+  "version": "0.28.46",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Cuts the release containing #706: enforce per-key `max_reasoning_effort` on all self-auth routes.

The v0.28.39 per-key reasoning-effort cap never actually reached the clamp — three inline record→caps copies in `server.ts` (chat/messages/responses resolvers) omitted the new field, so `identity.caps.maxReasoningEffort` was `undefined` and the clamp was a silent no-op on both the Anthropic and Responses paths. #706 routes them through a single `capsFromRecord()`.

**Behavior change:** keys with a configured cap now actually have their client reasoning effort clamped down (previously the cap had no effect in production).

On merge, `publish.yml` auto-cuts the tag, GitHub Release, and `:0.28.46` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)