### PR TITLE
fix(oauth): persist Codex quota metadata so the providers card survives a restart

### DIFF
--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -349,6 +349,52 @@ describe("admin OAuth routes — read endpoints", () => {
     ]);
   });
 
+  it("GET /oauth/quota falls back to PERSISTED Codex metadata when the in-process cache is cold (post-restart)", async () => {
+    const capturedAt = 2_000_000;
+    // The row carries metadata persisted by a prior refresh; fullSeam has NO
+    // getCachedCodexQuota (cold cache, as right after a container restart).
+    const oauthQuota = {
+      getAll: vi.fn(async () => [
+        {
+          providerId: "openai-codex",
+          account: "default",
+          windows: [
+            {
+              key: "primary",
+              usedPercent: 100,
+              resetsAtMs: capturedAt + 500_000,
+              windowMinutes: 10_080,
+            },
+          ],
+          capturedAt,
+          source: "codex",
+          usageLimitedUntilMs: null,
+          resetCredits: 2,
+          planType: "pro",
+          credits: { hasCredits: false, unlimited: false, balance: "0" },
+          individualLimit: null,
+          additionalLimits: [],
+          resetCreditDetails: null,
+          rateLimitReachedType: null,
+        },
+      ]),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      listCachedStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [{ id: "openai-codex", name: "Codex", accounts: [{ account: "default" }] }],
+      })) as never,
+    });
+
+    const res = await app({ oauth: seam, oauthQuota }).request("/admin/api/oauth/quota");
+    const body = (await res.json()) as {
+      quota: Array<{ planType?: string; credits?: { balance: string }; resetCredits?: number }>;
+    };
+    expect(body.quota[0]?.planType).toBe("pro");
+    expect(body.quota[0]?.credits?.balance).toBe("0");
+    expect(body.quota[0]?.resetCredits).toBe(2);
+  });
+
   it("POST /oauth/refresh refreshes xAI, updates the pool snapshot, and syncs cooldown", async () => {
     const now = Date.now();
     const resetAt = now + 3 * 86_400_000;

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -471,6 +471,15 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                     capturedAt,
                     source: "codex",
                     resetCredits: activeResult.resetCredits,
+                    // Persist the live metadata so the providers card survives a
+                    // restart (the in-process cache alone is lost). readCachedQuota
+                    // falls back to these when getCachedCodexQuota is cold.
+                    planType: activeResult.planType,
+                    credits: activeResult.credits,
+                    resetCreditDetails: activeResult.resetCreditDetails,
+                    individualLimit: activeResult.individualLimit,
+                    additionalLimits: activeResult.additionalLimits,
+                    rateLimitReachedType: activeResult.rateLimitReachedType,
                   });
                   deps.applyQuotaSnapshot?.(
                     "openai-codex",
@@ -570,10 +579,27 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       for (const row of await store.getAll()) {
         const key = acctKey(row.providerId, row.account);
         if (bound && !bound.has(key)) continue;
-        const metadata =
+        // In-process cache (fresh, richest) wins; when it is cold — e.g. right after
+        // a restart — fall back to the metadata PERSISTED on the row so the card
+        // renders plan/credits/reset-details instead of blanking until a refresh.
+        const liveMetadata =
           row.providerId === "openai-codex"
             ? await seam()?.getCachedCodexQuota?.({ account: row.account })
             : null;
+        const metadata =
+          liveMetadata !== null && liveMetadata !== undefined
+            ? liveMetadata
+            : row.providerId === "openai-codex"
+              ? {
+                  resetCredits: row.resetCredits ?? null,
+                  resetCreditDetails: row.resetCreditDetails ?? null,
+                  credits: row.credits ?? null,
+                  individualLimit: row.individualLimit ?? null,
+                  additionalLimits: row.additionalLimits ?? [],
+                  planType: row.planType ?? null,
+                  rateLimitReachedType: row.rateLimitReachedType ?? null,
+                }
+              : null;
         const identity = identities.get(key);
         result.push({
           ...row,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-08-07 · Codex 配额富元数据持久化（providers page Tier 3，docs/11，原则 7）
+
+- **现场**：providers 页某 Codex 账号卡片"显示不全"——只有"周限 100%"进度条 + resetCredits 0，缺 Plan 类型、Credits 点数、Reset limit 按钮点数、individualLimit。box 刚重启到 0.28.46 后**所有** Codex 账号都这样；手动 refresh 后未限流账号立即恢复出 planType/credits，已限流账号（其 `/wham/usage` PULL 拿不到富数据）仍缺。
+- **根因**：Codex 富元数据（planType/credits/resetCreditDetails/individualLimit/additionalLimits/rateLimitReachedType）此前**只存在 `admin-oauth.ts` 的进程内 `quotaCache` Map**，从不落库——`oauth_quota` 的 `store.upsert` 只写 windows + resetCredits（`oauth.ts:467`）。重启即清空进程缓存；持久化 store 只剩 windows（→ 周限进度条能显示），`getCachedCodexQuota` 返回 null → 富字段全丢，直到下次 refresh 重填进程缓存。
+- **修复（Lukin 拍板"扩 store schema"）**：给 `oauth_quota` 加一列 `metadata`（sqlite TEXT / pg JSONB，nullable）。① shared 新增 `CodexQuotaMetadataSchema` + `packCodexQuotaMetadata`（header PUSH 无富数据时返回 `undefined` → upsert 里省略该列，保留上次 PULL，与 resetCredits 同 preserve-on-omit 契约）+ `unpackCodexQuotaMetadata`（null/损坏 → `{}` fail-open）。② 两个适配器 upsert 写 metadata、toSnapshot 读回。③ sqlite migration v48 / pg migration v47（都 `ADD COLUMN IF NOT EXISTS`）。④ 刷新路径 `oauth.ts` 把 activeResult 的富字段一并 upsert。⑤ 读取路径 `readCachedQuota`：进程缓存（最新最全）优先，**冷缓存时 fallback 到行上持久化的 metadata**——重启后卡片即完整，无需等 refresh。
+- **未修的次要项**：已限流账号（weekly 100%）的 `/wham/usage` PULL 本身拿不到富数据，是 OpenAI 上游对限流账号的行为，非 helm bug；weekly 重置后自愈。
+- **测试**：sqlite round-trip + header-PUSH 保留；pg（pglite）round-trip + 保留 + fail-open；admin route 冷缓存 fallback（fullSeam 无 getCachedCodexQuota → 用行持久化 metadata）。core store 807 全绿；admin oauth route 86 全绿；typecheck + lint 全绿。
+
 ## 2026-08-07 · context_management 转发给 generic responses 导致 grok 422（Protocol / provider execution，docs/04/05，原则 3/5/8）
 
 - **现场**：anthropic_messages 请求 fallback 到 xAI grok-4.5（generic openai_responses profile）时，`context_management` 以 Anthropic 对象形状 `{ edits: [...] }` 发出，xAI Responses 反序列化要 array → 422 `invalid type: map, expected a sequence`（正是上一条 prompt-too-long 现场里 grok 那个无关 422）。
@@ -84,13 +92,9 @@
 - **流式诊断保真**：首输出前的原生 Responses SSE 错误现在只把 `type/code/message/param` 与嵌套 error envelope 放入 `UpstreamError.providerRaw`，并读取 top-level `message`；既保留 fallback 分类依据，又不让 `response.failed.response` 中的 instructions、tools、metadata 或 output 进入常规 telemetry。
 - **保守边界**：近似字符/token 估算和自由文本错误仍可用于“整链只有上下文/能力 skip”的既有 400，但不能压过真实 5xx/422；没有增加请求、Session 或上下文固定上限。top-level `error` 的 exact-once 终态统一和 CRLF SSE framing 属于独立协议问题，本次不扩大修改面。
 
-## 2026-08-02 · Responses WebSocket 首输出前恢复并提前释放物化准入（Protocol / Gateway runtime，docs/05/07/10，原则 3/5/8）
-
-- **恢复边界**：上游 WebSocket 只产生 `response.created` / `response.in_progress` 后关闭时，丢弃未提交的 preamble，按既有连接重试预算重连，耗尽后回退 HTTP/SSE；最多缓冲协议正常需要的两个 preamble，第三个重复 preamble 立即提交为已开始输出，避免异常上游造成无界缓存。真实输出一旦开始则绝不重放。`response.cancelled` 在 provider parser 与 ingress bridge 都是失败终态，不再追加伪 bridge error。
-- **准入生命周期**：Responses WebSocket bridge 用进程内 `WeakMap<Request, callback>` 把 request-body lease 交给可信内部路由；只有随机 proof 匹配的内部请求会在第二次 JSON parse 成功或失败后立即标为已物化，provider 等待不再长期持有 6 倍预留，而 parser 完成前的并发大请求仍受动态 headroom 保护。没有恢复固定请求、WebSocket 或 Session 大小上限。
-- **保留边界**：bridge 到内部 Responses 路由仍有一次 `JSON.stringify` 与再次 parse；本次先修已证实的 503 放大根因，不抽取会绕过鉴权、schema、rate limit、并发与 telemetry 的第二条执行通道。
-
 ## 历史条目摘要（最新要点）
+
+- **2026-08-02 · Responses WebSocket 首输出前恢复并提前释放物化准入**：上游 WebSocket 只产生 created/in_progress 后关闭时丢弃未提交 preamble 并按连接重试预算重连、耗尽回退 HTTP/SSE，最多缓冲两个 preamble、第三个重复立即提交为已开始输出，真实输出绝不重放，`response.cancelled` 两处均为失败终态；bridge 用进程内 `WeakMap<Request,callback>` 把 request-body lease 交给可信内部路由、随机 proof 匹配后第二次 parse 完即标物化，避免长期持有 6 倍预留，并发大请求仍受动态 headroom 保护，未恢复任何固定大小上限，完整原文经 git history 回溯。
 
 - **2026-08-02 · 流式错误的 telemetry 终态与 metadata-only 捕获短路**：Chat/Messages/Gemini 已开始写 SSE 后遇非取消错误，共用取消边界旁 helper 把同一 `DecisionRecord` 标 `final.status=error`、保留 `error_reason`、写 `stream_outcome=failed`，客户端断连仍走 `client_aborted`；Session capture 关闭时队列入口在算字节/查 cache/建 deferred write 前直接返回，不产生 `session.capture_limited` 或存储工作，脱敏 telemetry 不受影响，完整原文经 git history 回溯。
 - **2026-08-02 · xAI Responses 对象 input 在本地拒绝**：xAI `grok-4.5` 对 `input` 对象返回 `invalid type: map, expected a sequence`；只为 xAI generic Responses contract 加对象形态预检 → 结构化 `invalid_request / 400` 不发上游，数组保持可用、string 形态未证实不猜测；未动 admission/错误正文预算/Session 容量，`error_body_capacity_exhausted` 是独立上游边界保留真实诊断，完整原文经 git history 回溯。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.46",
+  "version": "0.28.47",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1270,6 +1270,19 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Persist Codex live quota metadata (planType/credits/individualLimit/…) as a
+    // JSONB blob so the providers page renders the full card after a restart instead
+    // of losing everything but windows until the next refresh. Pg mirror of sqlite v48.
+    version: 47,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "oauth_quota", ["provider_id"])) {
+        await db.execute(
+          sql.raw("ALTER TABLE oauth_quota ADD COLUMN IF NOT EXISTS metadata JSONB"),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {

--- a/packages/core/src/store/postgres/oauth-quota.test.ts
+++ b/packages/core/src/store/postgres/oauth-quota.test.ts
@@ -1,0 +1,57 @@
+import type { OAuthQuotaSnapshot } from "@helm/shared";
+import { describe, expect, it } from "vitest";
+import { createPgliteDb, type PgDb } from "./migrate.js";
+import { PgOAuthQuotaStore } from "./oauth-quota.js";
+
+// pglite runs the SAME pg-dialect adapter in-process — validates the supabase path
+// (incl. the jsonb metadata column added in pg-migration v47) with no server.
+const snap = (over: Partial<OAuthQuotaSnapshot> = {}): OAuthQuotaSnapshot => ({
+  providerId: "openai-codex",
+  account: "a",
+  windows: [{ key: "primary", usedPercent: 100, resetsAtMs: 1_000, windowMinutes: 10_080 }],
+  capturedAt: 500,
+  source: "codex",
+  usageLimitedUntilMs: null,
+  ...over,
+});
+
+describe("PgOAuthQuotaStore (pglite)", () => {
+  it("round-trips Codex live metadata and preserves it when a header snapshot omits it", async () => {
+    const db: PgDb = await createPgliteDb();
+    const store = new PgOAuthQuotaStore(db);
+
+    await store.upsert(
+      snap({
+        planType: "pro",
+        credits: { hasCredits: false, unlimited: false, balance: "0" },
+        individualLimit: { limit: "100", used: "40", remainingPercent: 60, resetsAtMs: 9_000 },
+        additionalLimits: [{ limitId: "web_search", limitName: "Web search" }],
+        rateLimitReachedType: "rate_limit_reached",
+        resetCredits: 3,
+      }),
+    );
+    const got = await store.get("openai-codex", "a");
+    expect(got?.planType).toBe("pro");
+    expect(got?.credits).toMatchObject({ balance: "0", unlimited: false });
+    expect(got?.individualLimit).toMatchObject({ remainingPercent: 60 });
+    expect(got?.additionalLimits).toHaveLength(1);
+    expect(got?.rateLimitReachedType).toBe("rate_limit_reached");
+    expect(got?.resetCredits).toBe(3);
+
+    // A header PUSH carries no live metadata → must not wipe the persisted blob.
+    await store.upsert(snap({ source: "codex-headers", capturedAt: 999 }));
+    const after = await store.get("openai-codex", "a");
+    expect(after?.planType).toBe("pro");
+    expect(after?.resetCredits).toBe(3);
+    expect(after?.capturedAt).toBe(999); // windows still refreshed
+  });
+
+  it("a corrupt/absent metadata column reads as no metadata (fail-open, non-Codex)", async () => {
+    const db: PgDb = await createPgliteDb();
+    const store = new PgOAuthQuotaStore(db);
+    await store.upsert(snap({ providerId: "anthropic", source: "anthropic" }));
+    const got = await store.get("anthropic", "a");
+    expect(got?.planType ?? null).toBeNull();
+    expect(got?.credits ?? null).toBeNull();
+  });
+});

--- a/packages/core/src/store/postgres/oauth-quota.ts
+++ b/packages/core/src/store/postgres/oauth-quota.ts
@@ -1,4 +1,9 @@
-import { type OAuthQuotaSnapshot, OAuthQuotaSnapshotSchema } from "@helm/shared";
+import {
+  type OAuthQuotaSnapshot,
+  OAuthQuotaSnapshotSchema,
+  packCodexQuotaMetadata,
+  unpackCodexQuotaMetadata,
+} from "@helm/shared";
 import { and, eq } from "drizzle-orm";
 import type { OAuthQuotaStore } from "../ports.js";
 import type { PgDb } from "./migrate.js";
@@ -13,6 +18,11 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
   constructor(private readonly db: PgDb) {}
 
   async upsert(snapshot: Omit<OAuthQuotaSnapshot, "usageLimitedUntilMs">): Promise<void> {
+    // jsonb stores the object; pack→undefined on a header PUSH so it is omitted and
+    // the last fresh PULL's metadata is preserved (same contract as resetCredits).
+    const packed = packCodexQuotaMetadata(snapshot);
+    const metadata =
+      packed === undefined ? undefined : (JSON.parse(packed) as Record<string, unknown>);
     const values = {
       providerId: snapshot.providerId,
       account: snapshot.account,
@@ -20,17 +30,19 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
       capturedAt: snapshot.capturedAt,
       source: snapshot.source,
       ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
     };
     const set = {
       windows: snapshot.windows,
       capturedAt: snapshot.capturedAt,
       source: snapshot.source,
       ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
     };
     // usage_limited_until_ms is intentionally absent from BOTH insert values (NULL on
     // a new row) and the conflict SET — a window refresh must not clobber a cooldown.
-    // reset_credits is updated only when the caller has a fresh Codex PULL count;
-    // Codex header PUSHes preserve it.
+    // reset_credits and metadata are updated only when the caller has a fresh Codex
+    // PULL; Codex header PUSHes preserve them.
     await this.db
       .insert(oauthQuota)
       .values(values)
@@ -91,6 +103,7 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
       source: row.source,
       usageLimitedUntilMs: row.usageLimitedUntilMs ?? null,
       resetCredits: row.resetCredits ?? null,
+      ...unpackCodexQuotaMetadata(row.metadata == null ? null : JSON.stringify(row.metadata)),
     });
   }
 }

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -466,6 +466,11 @@ export const oauthQuota = pgTable(
     usageLimitedUntilMs: bigint("usage_limited_until_ms", { mode: "number" }), // nullable
     // Codex only: available rate-limit reset credits captured from the usage PULL.
     resetCredits: integer("reset_credits"), // nullable
+    // Codex only: JSON blob of the live metadata folded onto the Admin quota
+    // response (planType, credits, resetCreditDetails, individualLimit,
+    // additionalLimits, rateLimitReachedType). Persisted so the providers page
+    // renders the full card after a restart instead of waiting for a refresh.
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(), // nullable
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1317,6 +1317,20 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Persist Codex live quota metadata (planType/credits/individualLimit/…) as a
+    // JSON blob so the providers page renders the full card after a restart instead
+    // of losing everything but windows until the next refresh.
+    version: 48,
+    run: (db) => {
+      if (
+        sqliteTableHasColumns(db, "oauth_quota", ["provider_id"]) &&
+        !sqliteTableHasColumns(db, "oauth_quota", ["metadata"])
+      ) {
+        db.exec("ALTER TABLE oauth_quota ADD COLUMN metadata TEXT;");
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota-migrate.test.ts
@@ -67,11 +67,15 @@ describe("oauth_quota usage_limited_until_ms migration (v26)", () => {
         .all()
         .map((c) => (c as { name: string }).name);
       expect(cols).toContain("usage_limited_until_ms");
+      // v48 also adds the Codex metadata column on the same legacy table.
+      expect(cols).toContain("metadata");
 
-      // The legacy row survives and reads a null cooldown through the store.
+      // The legacy row survives and reads a null cooldown + null metadata through the store.
       const store = new SqliteOAuthQuotaStore(db);
       const got = await store.get("openai-codex", "default");
       expect(got?.usageLimitedUntilMs).toBeNull();
+      expect(got?.planType ?? null).toBeNull();
+      expect(got?.credits ?? null).toBeNull();
       // And the new write path works against the upgraded table.
       await store.setUsageLimit("openai-codex", "default", 12_345);
       expect((await store.get("openai-codex", "default"))?.usageLimitedUntilMs).toBe(12_345);

--- a/packages/core/src/store/sqlite/oauth-quota.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.test.ts
@@ -72,6 +72,35 @@ describe("SqliteOAuthQuotaStore", () => {
     close();
   });
 
+  it("round-trips Codex live metadata (planType/credits/individualLimit) and preserves it when a header snapshot omits it", async () => {
+    const { store, close } = freshStore();
+    await store.upsert(
+      snap({
+        providerId: "openai-codex",
+        source: "codex",
+        planType: "pro",
+        credits: { hasCredits: false, unlimited: false, balance: "0" },
+        individualLimit: { limit: "100", used: "40", remainingPercent: 60, resetsAtMs: 9_000 },
+        additionalLimits: [{ limitId: "web_search", limitName: "Web search" }],
+        rateLimitReachedType: "rate_limit_reached",
+      }),
+    );
+    const got = await store.get("openai-codex", "a");
+    expect(got?.planType).toBe("pro");
+    expect(got?.credits).toMatchObject({ balance: "0", unlimited: false });
+    expect(got?.individualLimit).toMatchObject({ remainingPercent: 60 });
+    expect(got?.additionalLimits).toHaveLength(1);
+    expect(got?.rateLimitReachedType).toBe("rate_limit_reached");
+
+    // A Codex header PUSH carries no live metadata (undefined) → must NOT wipe it,
+    // same preserve-on-omit contract as resetCredits.
+    await store.upsert(
+      snap({ providerId: "openai-codex", source: "codex-headers", capturedAt: 999 }),
+    );
+    expect((await store.get("openai-codex", "a"))?.planType).toBe("pro");
+    close();
+  });
+
   it("getAll returns every account's latest snapshot; get is null when absent", async () => {
     const { store, close } = freshStore();
     expect(await store.get("anthropic", "missing")).toBeNull();

--- a/packages/core/src/store/sqlite/oauth-quota.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.ts
@@ -1,4 +1,9 @@
-import { type OAuthQuotaSnapshot, OAuthQuotaSnapshotSchema } from "@helm/shared";
+import {
+  type OAuthQuotaSnapshot,
+  OAuthQuotaSnapshotSchema,
+  packCodexQuotaMetadata,
+  unpackCodexQuotaMetadata,
+} from "@helm/shared";
 import { and, eq } from "drizzle-orm";
 import type { OAuthQuotaStore } from "../ports.js";
 import type { SqliteDb } from "./migrate.js";
@@ -15,6 +20,10 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
   constructor(private readonly db: SqliteDb) {}
 
   async upsert(snapshot: Omit<OAuthQuotaSnapshot, "usageLimitedUntilMs">): Promise<void> {
+    // JSON blob of the Codex live metadata, or undefined when the snapshot carries
+    // none (a header PUSH) — in which case it is omitted from the SET so the last
+    // fresh PULL's metadata is preserved, exactly like resetCredits.
+    const metadata = packCodexQuotaMetadata(snapshot);
     const row = {
       providerId: snapshot.providerId,
       account: snapshot.account,
@@ -22,17 +31,19 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
       capturedAt: snapshot.capturedAt,
       source: snapshot.source,
       ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
     };
     const set = {
       windows: row.windows,
       capturedAt: row.capturedAt,
       source: row.source,
       ...(snapshot.resetCredits !== undefined ? { resetCredits: snapshot.resetCredits } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
     };
     // Note: usage_limited_until_ms is intentionally absent from BOTH the insert values
     // (defaults to NULL on a brand-new row) and the conflict SET — an observability
-    // refresh must never overwrite an active cooldown. reset_credits is updated only
-    // when the caller has a fresh Codex PULL count; Codex header PUSHes preserve it.
+    // refresh must never overwrite an active cooldown. reset_credits and metadata are
+    // updated only when the caller has a fresh Codex PULL; Codex header PUSHes preserve them.
     this.db
       .insert(oauthQuota)
       .values(row)
@@ -101,6 +112,7 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
       source: row.source,
       usageLimitedUntilMs: row.usageLimitedUntilMs ?? null,
       resetCredits: row.resetCredits ?? null,
+      ...unpackCodexQuotaMetadata(row.metadata),
     });
   }
 }

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -345,6 +345,11 @@ export const oauthQuota = sqliteTable(
     usageLimitedUntilMs: integer("usage_limited_until_ms"), // nullable
     // Codex only: available rate-limit reset credits captured from the usage PULL.
     resetCredits: integer("reset_credits"), // nullable
+    // Codex only: JSON blob of the live metadata folded onto the Admin quota
+    // response (planType, credits, resetCreditDetails, individualLimit,
+    // additionalLimits, rateLimitReachedType). Persisted so the providers page
+    // renders the full card after a restart instead of waiting for a refresh.
+    metadata: text("metadata"), // nullable JSON text
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -282,6 +282,8 @@ export {
   AnthropicOAuthUsageSchema,
   type CodexOAuthUsage,
   CodexOAuthUsageSchema,
+  type CodexQuotaMetadata,
+  CodexQuotaMetadataSchema,
   type CodexResetResult,
   CodexResetResultSchema,
   isCodexAccountWeeklyQuotaWindow,
@@ -300,7 +302,9 @@ export {
   OAuthUsagePeriodsSchema,
   type OAuthUsageRow,
   OAuthUsageRowSchema,
+  packCodexQuotaMetadata,
   selectCodexAccountWeeklyQuotaWindows,
+  unpackCodexQuotaMetadata,
 } from "./oauth/usage-schema.js";
 export {
   type ImageEditRequest,

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -223,6 +223,75 @@ export const OAuthQuotaSnapshotSchema = z
 
 export type OAuthQuotaSnapshot = z.infer<typeof OAuthQuotaSnapshotSchema>;
 
+// ── Persisted Codex live-metadata blob (oauth_quota.metadata JSON column) ─────
+// The quota stores keep windows + cooldown + resetCredits as first-class columns.
+// Everything else the Admin providers card shows for Codex (plan, credits, monthly
+// spend-control limit, reset-credit details, additional limits, the rate-limit
+// reason) is folded into ONE nullable JSON column so a restart doesn't blank the
+// card until the next refresh. planType/credits are OPTIONAL fields (nullable),
+// so `.default(null)` keeps them explicit on the wire.
+export const CodexQuotaMetadataSchema = z
+  .object({
+    planType: z.string().nullable().default(null),
+    credits: CodexQuotaCreditsSchema.nullable().default(null),
+    resetCreditDetails: z.array(CodexResetCreditDetailSchema).nullable().default(null),
+    individualLimit: CodexIndividualLimitSchema.nullable().default(null),
+    additionalLimits: z.array(CodexAdditionalLimitSchema).default([]),
+    rateLimitReachedType: CodexRateLimitReachedTypeSchema.nullable().default(null),
+  })
+  .strict();
+
+export type CodexQuotaMetadata = z.infer<typeof CodexQuotaMetadataSchema>;
+
+// Serialize the Codex live metadata off a snapshot into the JSON blob stored in
+// oauth_quota.metadata. Returns `undefined` when the snapshot carries NO live
+// metadata (e.g. a Codex header PUSH or a non-Codex provider) so the caller can
+// omit the column from the SET and preserve the last fresh PULL — same
+// preserve-on-omit contract as resetCredits.
+export function packCodexQuotaMetadata(
+  snapshot: Pick<
+    OAuthQuotaSnapshot,
+    | "planType"
+    | "credits"
+    | "resetCreditDetails"
+    | "individualLimit"
+    | "additionalLimits"
+    | "rateLimitReachedType"
+  >,
+): string | undefined {
+  const carries =
+    snapshot.planType !== undefined ||
+    snapshot.credits !== undefined ||
+    snapshot.resetCreditDetails !== undefined ||
+    snapshot.individualLimit !== undefined ||
+    snapshot.additionalLimits !== undefined ||
+    snapshot.rateLimitReachedType !== undefined;
+  if (!carries) return undefined;
+  return JSON.stringify({
+    planType: snapshot.planType ?? null,
+    credits: snapshot.credits ?? null,
+    resetCreditDetails: snapshot.resetCreditDetails ?? null,
+    individualLimit: snapshot.individualLimit ?? null,
+    additionalLimits: snapshot.additionalLimits ?? [],
+    rateLimitReachedType: snapshot.rateLimitReachedType ?? null,
+  } satisfies CodexQuotaMetadata);
+}
+
+// Parse the stored blob back into the snapshot fields. Fail-open: a null/absent or
+// corrupt blob yields `{}` (no metadata) so a bad row renders "—" rather than
+// throwing. The returned object is spread onto the snapshot before schema.parse.
+export function unpackCodexQuotaMetadata(
+  raw: string | null | undefined,
+): Partial<CodexQuotaMetadata> {
+  if (raw === null || raw === undefined || raw === "") return {};
+  try {
+    const parsed = CodexQuotaMetadataSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : {};
+  } catch {
+    return {};
+  }
+}
+
 // ── Anthropic usage-endpoint response (GET /api/oauth/usage) ─────────────────
 
 // The (untrusted) shape Anthropic's OAuth usage endpoint returns. Parsed


### PR DESCRIPTION
## Problem

On the providers page a Codex account card rendered **incomplete** — only the weekly progress bar + `resetCredits: 0`, missing the plan type, credits, `Reset limit` credit count, and monthly spend-control limit. After the box redeployed to 0.28.46, **every** Codex account showed this; a manual refresh restored the metadata for non-rate-limited accounts.

## Root cause

The Codex live metadata (`planType`, `credits`, `resetCreditDetails`, `individualLimit`, `additionalLimits`, `rateLimitReachedType`) lived **only in the in-process `quotaCache` Map** and was never persisted. `oauth_quota.upsert` stored only `windows` + `resetCredits`. A restart wipes the in-process cache; the durable row still has `windows` (→ weekly bar shows) but the rich fields are gone until the next refresh repopulates the memory cache. Verified live on the box: all Codex rows returned `planType:null, credits:null` post-restart; a refresh restored `planType:"pro"` for a non-limited account.

## Fix

- Add a nullable `metadata` column to `oauth_quota` — SQLite `TEXT`, Postgres `JSONB` (sqlite migration **v48**, pg migration **v47**, both `ADD COLUMN IF NOT EXISTS`, no-loss on existing DBs).
- `shared`: `CodexQuotaMetadataSchema` + `packCodexQuotaMetadata` (returns `undefined` on a header PUSH → column omitted from the SET, preserving the last fresh PULL, same contract as `resetCredits`) + `unpackCodexQuotaMetadata` (fail-open: null/corrupt → `{}`).
- Both adapters persist + read back the blob.
- Refresh path upserts the full metadata; `readCachedQuota` prefers the fresh in-process cache and **falls back to the persisted metadata when the cache is cold** → card is complete immediately after a restart, no refresh needed.

## Not fixed here

A rate-limited account's own `/wham/usage` PULL can't return the rich metadata (OpenAI upstream behavior for limited accounts); self-heals on weekly reset. This PR makes every *non-limited* account render fully after a restart.

## Tests (TDD)

- SQLite + Postgres (pglite) round-trip + header-PUSH preserve + fail-open.
- Real legacy-DB migration test asserts the new column + null read-back.
- Admin route: cold in-process cache → response uses the row-persisted metadata.
- Full: core store 807, admin oauth route 86; typecheck + lint + build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)