### PR TITLE
fix(admin): show "still spending credits" for rate-limited accounts with the spend-remaining toggle on

### DIFF
--- a/apps/admin/src/app.css
+++ b/apps/admin/src/app.css
@@ -188,6 +188,9 @@
   .badge-error {
     @apply inline-flex items-center rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700;
   }
+  .badge-warning {
+    @apply inline-flex items-center rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700;
+  }
   .badge-neutral {
     @apply inline-flex items-center rounded bg-slate-200 px-2 py-0.5 text-xs font-medium text-slate-600;
   }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -704,6 +704,7 @@
   "Rate limit": "Rate limit",
   "Rate limit reached": "Rate limit reached",
   "Rate limited": "Rate limited",
+  "Rate limited · still spending credits": "Rate limited · still spending credits",
   "Rate limiting": "Rate limiting",
   "Raw": "Raw",
   "Raw conversation messages": "Raw conversation messages",

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -704,6 +704,7 @@
   "Rate limit": "Límite de tasa",
   "Rate limit reached": "Se alcanzó el límite de solicitudes",
   "Rate limited": "Limitado por tasa",
+  "Rate limited · still spending credits": "Con límite de tasa · sigue gastando créditos",
   "Rate limiting": "Limitación de tasa",
   "Raw": "Sin procesar",
   "Raw conversation messages": "Mensajes de conversación sin procesar",

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -704,6 +704,7 @@
   "Rate limit": "レート制限",
   "Rate limit reached": "レート制限に達しました",
   "Rate limited": "レート制限中",
+  "Rate limited · still spending credits": "レート制限中 · 残りのクレジットを消費中",
   "Rate limiting": "レート制限",
   "Raw": "生データ",
   "Raw conversation messages": "生の会話メッセージ",

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -704,6 +704,7 @@
   "Rate limit": "속도 제한",
   "Rate limit reached": "속도 제한에 도달함",
   "Rate limited": "속도 제한됨",
+  "Rate limited · still spending credits": "속도 제한 중 · 남은 크레딧 사용 중",
   "Rate limiting": "속도 제한",
   "Raw": "원본",
   "Raw conversation messages": "원시 대화 메시지",

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -704,6 +704,7 @@
   "Rate limit": "Limite de taxa",
   "Rate limit reached": "Limite de requisições atingido",
   "Rate limited": "Limitado por taxa",
+  "Rate limited · still spending credits": "Com limite de taxa · ainda gastando créditos",
   "Rate limiting": "Limitação de taxa",
   "Raw": "Bruto",
   "Raw conversation messages": "Mensagens brutas da conversa",

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -704,6 +704,7 @@
   "Rate limit": "速率限制",
   "Rate limit reached": "已达到速率限制",
   "Rate limited": "已限流",
+  "Rate limited · still spending credits": "限流中 · 仍在消耗额度",
   "Rate limiting": "速率限制",
   "Raw": "原始",
   "Raw conversation messages": "原始对话消息",

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -704,6 +704,7 @@
   "Rate limit": "速率限制",
   "Rate limit reached": "已達速率限制",
   "Rate limited": "已限流",
+  "Rate limited · still spending credits": "限流中 · 仍在消耗額度",
   "Rate limiting": "速率限制",
   "Raw": "原始",
   "Raw conversation messages": "原始對話訊息",

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -978,7 +978,14 @@
                 {/if}
                 {#if usageLimit}
                   <div class="mt-1">
-                    <span class="badge-error">{$t('Rate limited')}</span>
+                    {#if row.account.allowSpendRemainingCredits}
+                      <!-- Toggle on: the account still serves off its remaining credits
+                           despite the limit, so the pill reflects that instead of a plain
+                           "parked" rate-limited state. -->
+                      <span class="badge-warning">{$t('Rate limited · still spending credits')}</span>
+                    {:else}
+                      <span class="badge-error">{$t('Rate limited')}</span>
+                    {/if}
                     {#if usageLimitRecovery}
                       <div class="text-[10px] text-ink-muted">
                         {usageLimit.label

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.48",
+  "version": "0.28.49",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Problem

An account with **"Keep spending remaining credits when rate-limited"** ticked keeps serving off its remaining credits — `pool.usageLimited()` returns `false` for it, so it stays in rotation. But the providers card still rendered a plain red **"Rate limited"** pill, making it look parked when it was actually working. Reported with the toggle visibly on and the account still showing 已限流.

## Fix

Frontend-only. The account status payload already carries `allowSpendRemainingCredits`, so the providers page just needs to use it: when the account is limited **and** the toggle is on, render an amber **"Rate limited · still spending credits"** pill instead of the red one. The weekly window still shows 100% (that's the honest upstream fact), but the badge now reflects Helm's actual scheduling behavior.

- New `badge-warning` (amber) class in `app.css`.
- New string translated in all 7 locales.

## Not a state reset

By design the toggle does **not** clear `usageLimitedUntilMs` — it only keeps the account eligible. This PR fixes the *display* so that's no longer confusing; it does not change runtime behavior.

## Tests

- i18n alignment gate (7 locales) — 12 tests pass.
- `svelte-check` — 0 errors.
- admin build green (Tailwind amber classes emitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)