### PR TITLE
fix(oauth): sink limited-but-spending accounts below healthy ones in the pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.49",
+  "version": "0.28.50",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1003,6 +1003,82 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(calls).toEqual(["a"]);
   });
 
+  it("sinks a limited-but-spending account below a healthy sibling (all strategies)", async () => {
+    // "a": rate-limited but opted in to spend remaining credits (real money).
+    // "b": healthy subscription account. Even though "a" has BETTER priority and is
+    // less-recently-used, the pool must prefer "b" — burning credits is the last
+    // resort. Assert across every strategy so it never depends on use_expiring luck.
+    for (const strategy of ["balanced", "manual_priority", "low_risk", "use_expiring"] as const) {
+      const calls: string[] = [];
+      const pool = createOAuthPoolClient({
+        members: [
+          {
+            ...member("a", 1, true, calls), // better priority
+            usageLimitedUntilMs: 9_000,
+            allowSpendRemainingCredits: true,
+          },
+          { ...member("b", 2, true, calls) }, // healthy, worse priority
+        ],
+        selectionStrategy: strategy,
+        now: () => 1_000,
+      });
+      await pool.chatCompletion(REQ);
+      expect(calls, `strategy=${strategy}`).toEqual(["b"]);
+    }
+  });
+
+  it("falls back to the limited-but-spending account when no healthy account is left", async () => {
+    // Only the spending account is eligible (sibling is hard-limited, no opt-in) →
+    // the sink tier must still yield it rather than fail closed.
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        {
+          ...member("a", 1, true, calls),
+          usageLimitedUntilMs: 9_000,
+          allowSpendRemainingCredits: true,
+        },
+        { ...member("b", 2, true, calls), usageLimitedUntilMs: 9_000 },
+      ],
+      now: () => 1_000,
+    });
+    await pool.chatCompletion(REQ);
+    expect(calls).toEqual(["a"]);
+  });
+
+  it("a stateful previous_response_id continuation still pins to its limited-but-spending account", async () => {
+    // Correctness > waste-avoidance: a previous_response_id pinned to the spending
+    // account must NOT be diverted to a healthy sibling mid-conversation.
+    const calls: string[] = [];
+    let clock = 1_000;
+    const responseMember = (account: string, spend = false): OAuthPoolMember => ({
+      account,
+      priority: 50,
+      schedulable: true,
+      ...(spend ? { allowSpendRemainingCredits: true } : {}),
+      client: {
+        async chatCompletion(_req: ChatCompletionRequest) {
+          calls.push(account);
+          return { id: `resp-${account}`, served_by: account };
+        },
+        async *chatCompletionStream(_req: ChatCompletionRequest) {
+          calls.push(account);
+          yield `data: ${account}\n\n`;
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      // "a" opted in to spend remaining credits; "b" is a healthy sibling.
+      members: [responseMember("a", true), responseMember("b")],
+      now: () => clock,
+    });
+    await pool.chatCompletion(REQ); // → a; seeds resp-a → a affinity
+    pool.setUsageLimit("a", 50_000); // a hits its limit but keeps spending → would be sunk
+    clock = 2_000;
+    await pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-a" });
+    expect(calls).toEqual(["a", "a"]); // pinned to a, NOT diverted to healthy b
+  });
+
   it("setUsageLimit parks a live member; null un-parks it (the reset path)", async () => {
     const calls: string[] = [];
     let clock = 1_000;

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -270,6 +270,26 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return until != null && nowMs < until;
   }
 
+  // A "spend remaining credits" account that IS currently past its usage-limit park.
+  // usageLimited() waves it through the eligibility gate (returns false above), but it
+  // is serving off paid credits / a saturated plan — real money. It must sink below any
+  // healthy account so credits are the LAST resort, not a co-equal round-robin peer.
+  // This is the runtime twin of the amber "still spending credits" providers badge.
+  function spendingWhileLimited(member: OAuthPoolMember, nowMs: number): boolean {
+    if (member.allowSpendRemainingCredits !== true) return false;
+    const until = member.usageLimitedUntilMs;
+    return until != null && nowMs < until;
+  }
+
+  // Prefer healthy accounts; only expose the credit-spending sink tier when NO healthy
+  // account is eligible. Applied to the general candidate flow — a stateful sticky
+  // continuation (isStrictAccountSticky) deliberately bypasses this on the full
+  // `eligible` set so a pinned conversation is never diverted mid-flight.
+  function preferHealthyTier(eligible: PoolEntry[], nowMs: number): PoolEntry[] {
+    const healthy = eligible.filter((e) => !spendingWhileLimited(e.member, nowMs));
+    return healthy.length > 0 ? healthy : eligible;
+  }
+
   function retryableAccountLimited(account: string, nowMs: number): boolean {
     const until = retryableAccountFailures.get(account);
     if (until === undefined) return false;
@@ -823,7 +843,11 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     const nowMs = now();
     const model = opts.model ?? null;
     const eligible = eligibleEntries(nowMs, exclude, model);
-    const capacityTier = preferredCapacityTier(eligible, opts.avoidBusy === true);
+    // General selection prefers healthy accounts; the credit-spending sink tier only
+    // surfaces when no healthy account is left. A strict-sticky continuation (below)
+    // still uses the full `eligible` set so a pinned conversation is never diverted.
+    const preferred = preferHealthyTier(eligible, nowMs);
+    const capacityTier = preferredCapacityTier(preferred, opts.avoidBusy === true);
     const selectionBase = {
       affinityKeySource: affinityKeySource(stickyKey ?? null),
       capacityAvoided: capacityTier.capacityAvoided,


### PR DESCRIPTION
## Problem

An account with **"Keep spending remaining credits when rate-limited"** on is served off paid credits / a saturated plan — real money. But the pool treated it as a **co-equal scheduling peer**: `usageLimited()` returns `false` for it, so it lands in the same candidate set as healthy accounts. A better-priority or less-recently-used spending account could win over a healthy subscription sibling that still had free weekly quota. Reported: the toggle-on limited account should be the *last* resort, not preferred.

Under the box's `use_expiring` strategy it only avoided this **by luck** (a 100%-saturated window scores ~0), and under `balanced`/`manual_priority` it could actively pick the credit-burning account via LRU/sticky.

## Fix

`preferHealthyTier()` narrows the general candidate set to healthy accounts and **only exposes the credit-spending sink tier when no healthy account is eligible**. Applied once in `select()`, so it holds across **all four strategies** (balanced / manual_priority / low_risk / use_expiring).

## Preserved boundaries

- **Stateful continuation** (`previous_response_id` / `x-codex-turn-state`) still uses the full `eligible` set → a pinned conversation is never diverted mid-flight, even if its account is now spending-while-limited.
- **No fail-closed**: when the spending account is the only one eligible, it is still selected.
- Non-strict hash-sticky accounts are also sunk (won't keep burning credits when a healthy sibling exists).

This is the runtime twin of the amber "still spending credits" badge from #711.

## Tests (TDD)

- Sinks below a healthy sibling across all 4 strategies.
- Falls back to the spending account when no healthy account is left.
- `previous_response_id` continuation still pins to its spending account.
- Full pool suite 102 + oauth suite 371 green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)