### PR TITLE
fix(gateway): short-circuit real upstream context overflow so clients compact (v0.28.51)

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1980,10 +1980,12 @@ describe("createExecute — gateway execution adapter", () => {
     });
   });
 
-  it("skips a candidate on context_length_exceeded without tripping the breaker", async () => {
+  it("short-circuits an in-band stream context_length_exceeded without tripping the breaker", async () => {
     // Some upstreams report model-window overflow as an in-band stream error without an
-    // HTTP 400 status. That is a candidate capability miss, not provider health.
-    // Helm should try the next model and render the failed candidate as skipped.
+    // HTTP 400 status. That is still a REAL upstream confirming the request is over the
+    // ceiling, so short-circuit with the 400 VERBATIM — do NOT fall back to a larger model
+    // that would "catch" the oversized request and hide the compaction signal. No breaker
+    // fault (the upstream is healthy — the request is what's wrong).
     // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
     async function* contextWindowError(): AsyncGenerator<string> {
       throw new UpstreamError(
@@ -2003,12 +2005,13 @@ describe("createExecute — gateway execution adapter", () => {
         null,
       );
     }
+    const opusStream = vi.fn();
     const provider = {
       chatCompletion: vi.fn(),
       chatCompletionStream: vi
         .fn()
         .mockReturnValueOnce(contextWindowError())
-        .mockReturnValueOnce(gen(['data: {"ok":1}\n\n', "data: [DONE]\n\n"])),
+        .mockImplementation(opusStream),
     } as unknown as ProviderClient;
     const cb = breaker();
     const recordFailure = vi.spyOn(cb, "recordFailure");
@@ -2035,13 +2038,17 @@ describe("createExecute — gateway execution adapter", () => {
 
     const out = await execute(plan(["codex", "opus"]), req({ stream: true }));
 
-    expect(out.final).toEqual({ status: "ok", alias: "opus", providerModel: "claude-opus-4-8" });
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "invalid_request",
+      http_status: 400,
+    });
+    expect(out.attempts).toHaveLength(1);
     expect(out.attempts[0]).toMatchObject({
       alias: "codex",
-      skipped: true,
-      skip_reason: "context_too_small",
-      status: "error",
-      error_class: null,
+      skipped: false,
+      error_class: "invalid_request",
     });
     expect(out.attempts[0]?.error_detail).toMatchObject({
       provider_raw: {
@@ -2050,11 +2057,71 @@ describe("createExecute — gateway execution adapter", () => {
         },
       },
     });
-    expect(out.attempts[1]?.status).toBe("ok");
+    // The larger-window sibling is never even opened — the chain short-circuited.
+    expect(opusStream).not.toHaveBeenCalled();
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
-  it("preserves an upstream context error when every candidate is exhausted", async () => {
+  it("short-circuits a REAL upstream context overflow instead of falling back (box 12a22879)", async () => {
+    // Reproduces the production incident: the head candidate returns a REAL upstream 400
+    // "prompt is too long: N > M". Older behavior skipped it and fell back all the way to a
+    // larger-window model (deepseek), which returned 200 — so the client never saw a 4xx and
+    // never triggered its own context compaction. A real upstream overflow means the request
+    // as sent is over a hard ceiling: surface the 400 VERBATIM immediately and DO NOT try any
+    // later candidate (no larger-window "catch" that hides the compaction signal).
+    const raw = {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "prompt is too long: 1033542 tokens > 1000000 maximum",
+      },
+      request_id: "req_011CdoYiHHe3pg8rYTPqHABp",
+    };
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError("upstream_error", "upstream returned 400", raw, 400),
+        )
+        // Later candidates must NEVER be invoked once a real overflow short-circuits.
+        .mockResolvedValueOnce({ id: "should-not-be-reached" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ opus: "claude-opus-4-8", deepseek: "deepseek-v4-pro" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "deepseek"]), req());
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "invalid_request",
+      http_status: 400,
+      message: "prompt is too long: 1033542 tokens > 1000000 maximum",
+      provider_raw: raw,
+    });
+    // Only the first candidate was attempted; the chain short-circuited (no fall-back).
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
+    expect(out.attempts).toHaveLength(1);
+    expect(out.attempts[0]).toMatchObject({
+      alias: "opus",
+      skipped: false,
+      error_class: "invalid_request",
+    });
+    // Upstream is healthy — the request is what's wrong. No breaker fault.
+    expect(recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an upstream context error VERBATIM as a 400", async () => {
     const raw = {
       type: "error",
       error: {
@@ -2092,8 +2159,8 @@ describe("createExecute — gateway execution adapter", () => {
       provider_raw: raw,
     });
     expect(out.attempts[0]).toMatchObject({
-      skipped: true,
-      skip_reason: "context_too_small",
+      skipped: false,
+      error_class: "invalid_request",
       error_detail: {
         upstream_status: 400,
         provider_raw: raw,
@@ -2102,74 +2169,42 @@ describe("createExecute — gateway execution adapter", () => {
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
-  it("prefers an exact compaction message while retaining the first upstream context detail", async () => {
-    const raw = {
-      error: {
-        type: "invalid_request_error",
-        code: "context_length_exceeded",
-        message: "This model's context window is too small.",
-      },
-    };
+  it("does NOT short-circuit an approximate context estimate — a larger sibling still serves", async () => {
+    // The head candidate is skipped by the APPROXIMATE capability-filter estimate (its tiny
+    // window can't hold the prompt). That is a per-model estimate, NOT a real upstream verdict,
+    // so it must FALL BACK (not short-circuit) — a larger-window sibling can still serve the
+    // request and succeed. Contrast with a REAL upstream overflow, which short-circuits.
     const provider = {
-      countTokens: vi.fn().mockResolvedValue({ input_tokens: 1_001_854 }),
-      chatCompletion: vi
-        .fn()
-        .mockRejectedValueOnce(
-          new UpstreamError("upstream_error", "upstream returned 400", raw, 400),
-        ),
+      chatCompletion: vi.fn().mockResolvedValue({ id: "big-window-ok" }),
       chatCompletionStream: vi.fn(),
     } as unknown as ProviderClient;
     const execute = createExecute({
       defaultProvider: provider,
       providers: new Map([["mock", provider]]),
-      registry: protocolRegistry({
-        codex: {
-          providerName: "mock",
-          providerModel: "gpt-5.6-sol",
-          targetProviderProtocol: "openai_responses",
-        },
-        opus: {
-          providerName: "mock",
-          providerModel: "claude-opus-4-8",
-          targetProviderProtocol: "anthropic_messages",
-        },
-      }),
+      registry: registry({ small: "small-model", big: "big-model" }),
       breaker: breaker(),
-      catalog: new Map(),
+      // `small` has a tiny window → the long prompt trips the approximate pre-flight gate.
+      // `big` has no catalog entry → fail-open, attempted, and succeeds.
+      catalog: new Map([["small", entry("small", { maxContextTokens: 20 })]]),
       now: clock(),
       signal: new AbortController().signal,
     });
 
     const out = await execute(
-      plan(["codex", "opus"]),
-      req({
-        protocol: "anthropic_messages",
-        native_request: createNativePassthroughCarrier({
-          protocol: "anthropic_messages",
-          body: {
-            model: "claude-opus-4-8",
-            messages: [{ role: "user", content: "huge" }],
-            max_tokens: 64,
-          },
-          headers: {},
-        }),
-      }),
+      plan(["small", "big"]),
+      req({ messages: [{ role: "user", content: "x".repeat(100) }] }),
     );
 
-    expect(out.final.status).toBe("error");
-    if (out.final.status !== "error") throw new Error("expected a terminal error");
-    expect(out.final.error).toMatchObject({
-      error_class: "invalid_request",
-      message: "prompt is too long: 1001854 tokens > 1000000 maximum",
-      provider_raw: raw,
-    });
+    // The approximate estimate skip fell back to the larger sibling, which succeeded.
+    expect(out.final.status).toBe("ok");
+    expect(out.attempts[0]).toMatchObject({ skipped: true, skip_reason: "context_too_small" });
+    expect(out.attempts[1]?.status).toBe("ok");
   });
 
-  it("returns the shaped overflow 400 at exhaustion even when a later candidate has a provider failure", async () => {
-    // The head candidate reports a shaped overflow ("prompt is too long: N > M maximum",
-    // here with a `context_length_exceeded` code). A sibling is still tried, but fails with
-    // an unrelated 500. At exhaustion the terminal must surface the compaction-compatible
-    // 400 VERBATIM, not demote it to all_providers_failed because of the 500 (box c211e4a1).
+  it("short-circuits on the FIRST real upstream overflow, before a later sibling is tried", async () => {
+    // The head candidate reports a shaped overflow ("prompt is too long: N > M maximum").
+    // The chain short-circuits immediately: the tail candidate is NEVER invoked, and the
+    // 400 is surfaced VERBATIM so the client can compact.
     const raw = {
       error: {
         code: "context_length_exceeded",
@@ -2207,11 +2242,15 @@ describe("createExecute — gateway execution adapter", () => {
       message: "prompt is too long: 1200000 tokens > 1000000 maximum",
       provider_raw: raw,
     });
-    // Both candidates attempted — the shaped overflow wins the terminal at exhaustion.
-    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+    // Only the head candidate ran — the overflow short-circuited before the tail.
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
+    expect(out.attempts).toHaveLength(1);
   });
 
-  it("returns a compaction 400 when multiple candidates confirm context overflow", async () => {
+  it("short-circuits on the first overflow even when later candidates would also overflow", async () => {
+    // Mirrors the production incident (box 12a22879): chain = [overflow, unrelated-fail,
+    // overflow]. The FIRST real overflow returns the 400 immediately — the unrelated sibling
+    // and the second overflow candidate are never reached.
     const raw = {
       type: "error",
       error: {
@@ -2265,48 +2304,10 @@ describe("createExecute — gateway execution adapter", () => {
       message: raw.error.message,
       provider_raw: raw,
     });
-    expect(out.attempts.map((attempt) => attempt.skip_reason)).toEqual([
-      "context_too_small",
-      null,
-      "context_too_small",
-    ]);
-  });
-
-  it("does not count duplicate provider/model context errors as independent confirmations", async () => {
-    const raw = {
-      error: {
-        code: "context_length_exceeded",
-        message: "Your input exceeds the context window of this model.",
-      },
-    };
-    const provider = {
-      chatCompletion: vi
-        .fn()
-        .mockRejectedValueOnce(new UpstreamError("upstream_error", "overflow", raw, 400))
-        .mockRejectedValueOnce(new UpstreamError("upstream_error", "overflow", raw, 400))
-        .mockRejectedValueOnce(
-          new UpstreamError("upstream_error", "upstream returned 500", {}, 500),
-        ),
-      chatCompletionStream: vi.fn(),
-    } as unknown as ProviderClient;
-    const execute = createExecute({
-      defaultProvider: provider,
-      providers: new Map([["mock", provider]]),
-      registry: registry({ first: "same-model", duplicate: "same-model", tail: "tail-model" }),
-      breaker: breaker(),
-      catalog: new Map(),
-      now: clock(),
-      signal: new AbortController().signal,
-    });
-
-    const out = await execute(plan(["first", "duplicate", "tail"]), req());
-
-    expect(out.final.status).toBe("error");
-    if (out.final.status !== "error") throw new Error("expected a terminal error");
-    expect(out.final.error).toMatchObject({
-      error_class: "all_providers_failed",
-      http_status: 502,
-    });
+    // Short-circuited on the first candidate; xai + terra never invoked.
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
+    expect(out.attempts).toHaveLength(1);
+    expect(out.attempts[0]).toMatchObject({ alias: "sol", error_class: "invalid_request" });
   });
 
   it("maps Anthropic output_config.effort through the target model policy instead of skipping", async () => {
@@ -2497,13 +2498,11 @@ describe("createExecute — gateway execution adapter", () => {
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
-  it("returns the compaction 400 at exhaustion even when an unrelated sibling fails (box c211e4a1)", async () => {
-    // Anthropic (the LARGEST-window candidate, head of chain) returns a REAL 400
-    // "prompt is too long: N > M maximum". A smaller sibling is still tried (a larger
-    // window could in principle serve it), but here it fails with an UNRELATED 422. The
-    // chain-exhausted terminal must surface the shaped overflow VERBATIM as invalid_request
-    // (400) — NOT bury it as all_providers_failed just because grok also failed — so Claude
-    // Code / Codex receive the 4xx and trigger their own context compaction.
+  it("short-circuits the real overflow 400 before an unrelated sibling is tried (box c211e4a1)", async () => {
+    // Anthropic (head of chain) returns a REAL 400 "prompt is too long: N > M maximum".
+    // The chain short-circuits: the grok sibling is NEVER tried, and the 400 is surfaced
+    // VERBATIM so Claude Code / Codex receive the 4xx and trigger their own compaction —
+    // instead of falling back to a model that would "catch" the oversized request.
     const raw = {
       type: "error",
       error: {
@@ -2551,29 +2550,29 @@ describe("createExecute — gateway execution adapter", () => {
       message: "prompt is too long: 1022145 tokens > 1000000 maximum",
       provider_raw: raw,
     });
-    // Both candidates were attempted (the overflow does NOT short-circuit — a bigger
-    // sibling could serve it); the terminal still prefers the compaction 400.
-    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+    // Only the head candidate ran — the overflow short-circuited before grok.
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
   });
 
-  it("prefers a larger-window sibling over a shaped context overflow instead of short-circuiting", async () => {
-    // The head candidate reports "prompt is too long: N > M" (its OWN window; 200k models
-    // emit the same shape). A later, larger-window sibling can still serve the request, so
-    // the gateway must fall back and succeed — the shaped overflow must NOT be treated as a
-    // whole-chain ceiling that terminates early.
+  it("short-circuits a real overflow rather than letting a larger-window sibling catch it", async () => {
+    // The head candidate reports a REAL "prompt is too long: N > M". A later, larger-window
+    // sibling COULD serve the oversized request — but that would hide the compaction signal
+    // (the client gets 200 and never compacts). So the gateway short-circuits with the 400
+    // and does NOT fall back.
     const raw = {
       error: {
         code: "context_length_exceeded",
         message: "prompt is too long: 210000 tokens > 200000 maximum",
       },
     };
+    const bigCompletion = vi.fn().mockResolvedValue({ id: "big-window" });
     const provider = {
       chatCompletion: vi
         .fn()
         .mockRejectedValueOnce(
           new UpstreamError("upstream_error", "upstream returned 400", raw, 400),
         )
-        .mockResolvedValueOnce({ id: "big-window" }),
+        .mockImplementation(bigCompletion),
       chatCompletionStream: vi.fn(),
     } as unknown as ProviderClient;
     const execute = createExecute({
@@ -2588,10 +2587,18 @@ describe("createExecute — gateway execution adapter", () => {
 
     const out = await execute(plan(["small", "big"]), req());
 
-    expect(out.final).toEqual({ status: "ok", alias: "big", providerModel: "claude-opus-4-8" });
-    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
-    expect(out.attempts[0]).toMatchObject({ skipped: true, skip_reason: "context_too_small" });
-    expect(out.attempts[1]?.status).toBe("ok");
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "invalid_request",
+      http_status: 400,
+      message: "prompt is too long: 210000 tokens > 200000 maximum",
+      provider_raw: raw,
+    });
+    // The bigger-window sibling is never invoked.
+    expect(bigCompletion).not.toHaveBeenCalled();
+    expect(out.attempts).toHaveLength(1);
+    expect(out.attempts[0]).toMatchObject({ skipped: false, error_class: "invalid_request" });
   });
 
   it("does not let a pre-flight approximate shaped estimate override a real provider failure via the bypass", async () => {
@@ -2632,9 +2639,9 @@ describe("createExecute — gateway execution adapter", () => {
     expect(out.final.error.http_status).toBe(502);
   });
 
-  it("returns the compaction 400 for an authoritative shaped overflow with comma-grouped counts", async () => {
-    // Real upstreams format the counts with commas ("1,022,145"). The shape matcher must
-    // tolerate grouping so a genuine overflow still surfaces the compaction 400 at exhaustion.
+  it("surfaces a comma-grouped overflow message VERBATIM on short-circuit", async () => {
+    // Real upstreams format the counts with commas ("1,022,145"). The message is passed
+    // through unchanged when the real overflow short-circuits.
     const raw = {
       type: "error",
       error: {
@@ -2673,6 +2680,8 @@ describe("createExecute — gateway execution adapter", () => {
       message: "prompt is too long: 1,022,145 tokens > 1,000,000 maximum",
       provider_raw: raw,
     });
+    // Short-circuited before the tail candidate.
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(1);
   });
 
   it("does not synthesize a compaction 400 from the phrase echoed in a provider-failure body", async () => {
@@ -2711,6 +2720,85 @@ describe("createExecute — gateway execution adapter", () => {
     // The echoed phrase must not fabricate a client-visible 400.
     expect(out.final.error.error_class).toBe("all_providers_failed");
     expect(out.final.error.http_status).toBe(502);
+  });
+
+  it("does NOT short-circuit a retryable 5xx whose body happens to carry a context_length_exceeded marker", async () => {
+    // A REAL HTTP 5xx (or 429) is a transient/retryable provider fault, NOT a client context
+    // overflow — even if the error body coincidentally carries `context_length_exceeded` (e.g.
+    // an upstream wrapping a context-related overload as a 500). Short-circuiting it to a 400
+    // would strand the request: no fall-back to a healthy sibling, no breaker fault. The
+    // overflow short-circuit ALLOWLISTS only deterministic 400/413/422 (+ null in-band).
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError(
+            "upstream_error",
+            "upstream returned 500",
+            { error: { code: "context_length_exceeded", message: "overloaded" } },
+            500,
+          ),
+        )
+        .mockResolvedValueOnce({ id: "healthy-sibling" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ opus: "claude-opus-4-8", tail: "tail-model" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "tail"]), req());
+
+    // The 5xx faults the breaker and the chain falls back to the healthy sibling.
+    expect(out.final).toEqual({ status: "ok", alias: "tail", providerModel: "tail-model" });
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+    expect(out.attempts[0]).toMatchObject({ alias: "opus", skipped: false, status: "error" });
+    expect(recordFailure).toHaveBeenCalledWith("opus");
+  });
+
+  it("does NOT short-circuit a retryable 408 that coincidentally carries a context marker", async () => {
+    // 408 Request Timeout is retryable, not a deterministic client overflow. The overflow
+    // short-circuit ALLOWLISTS only deterministic request-shape statuses (400/413/422) + null
+    // (in-band, no HTTP status); every other numeric status — 408 included — must fall back and
+    // fault the breaker, even if the body coincidentally carries an overflow marker.
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError(
+            "upstream_error",
+            "upstream returned 408",
+            { error: { code: "context_length_exceeded", message: "request timeout" } },
+            408,
+          ),
+        )
+        .mockResolvedValueOnce({ id: "healthy-sibling" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: registry({ opus: "claude-opus-4-8", tail: "tail-model" }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "tail"]), req());
+
+    expect(out.final).toEqual({ status: "ok", alias: "tail", providerModel: "tail-model" });
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+    expect(recordFailure).toHaveBeenCalledWith("opus");
   });
 
   it("falls back when an OpenAI-compatible thinking target requires missing reasoning_content history", async () => {
@@ -6354,7 +6442,10 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.nativePassthrough).toBe(true);
   });
 
-  it("maps two native Responses context errors around another failure to compaction 400", async () => {
+  it("short-circuits a native Responses in-band context error to a scrubbed 400", async () => {
+    // The head passthrough stream reports an in-band context overflow (response.failed with
+    // context_length_exceeded). It short-circuits to a 400 with the provider_raw SCRUBBED of
+    // private request content — the later candidates are never opened.
     const contextStream = (model: string) =>
       gen([
         'event: response.created\ndata: {"type":"response.created"}\n\n',
@@ -6370,15 +6461,6 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
           },
         })}\n\n`,
       ]);
-    // biome-ignore lint/correctness/useYield: pre-output provider rejection
-    async function* xaiFailure(): AsyncGenerator<string> {
-      throw new UpstreamError(
-        "upstream_error",
-        "upstream returned 422",
-        { error: "invalid type: map, expected a sequence" },
-        422,
-      );
-    }
     const sol = {
       chatCompletion: vi.fn(),
       chatCompletionStream: vi.fn(),
@@ -6387,12 +6469,12 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     const xai = {
       chatCompletion: vi.fn(),
       chatCompletionStream: vi.fn(),
-      nativePassthroughStream: vi.fn().mockReturnValue(xaiFailure()),
+      nativePassthroughStream: vi.fn(),
     } as unknown as ProviderClient;
     const terra = {
       chatCompletion: vi.fn(),
       chatCompletionStream: vi.fn(),
-      nativePassthroughStream: vi.fn().mockReturnValue(contextStream("terra")),
+      nativePassthroughStream: vi.fn(),
     } as unknown as ProviderClient;
     const cb = breaker();
     const recordFailure = vi.spyOn(cb, "recordFailure");
@@ -6450,14 +6532,13 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
         response: { error: { code: "context_length_exceeded" } },
       },
     });
-    expect(out.attempts.map((attempt) => attempt.skip_reason)).toEqual([
-      "context_too_small",
-      null,
-      "context_too_small",
-    ]);
+    // Short-circuited on the head candidate; xai + terra never opened.
+    expect(out.attempts).toHaveLength(1);
+    expect(out.attempts[0]).toMatchObject({ alias: "sol", error_class: "invalid_request" });
     expect(out.attempts[0]?.error_detail?.provider_raw).not.toHaveProperty("response.instructions");
-    expect(recordFailure).toHaveBeenCalledTimes(1);
-    expect(recordFailure).toHaveBeenCalledWith("xai");
+    expect(xai.nativePassthroughStream).not.toHaveBeenCalled();
+    expect(terra.nativePassthroughStream).not.toHaveBeenCalled();
+    expect(recordFailure).not.toHaveBeenCalled();
   });
 
   it("an Anthropic passthrough stream that ends with no real output records a failure and advances the chain", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1269,12 +1269,18 @@ export function upstreamErrorMessage(raw: unknown): string | null {
   return null;
 }
 
-// A model-specific context-window rejection means THIS candidate cannot serve the
-// request, but a later fallback with a larger window may still succeed. Some streaming
-// providers emit this as an in-band SSE error with no HTTP status, so classify from the
-// provider error body/message rather than relying on status alone.
+// A REAL upstream rejection that the request is over the model's context window. This
+// SHORT-CIRCUITS to a client 400 (the request as sent is over a hard ceiling), so it must
+// never fire on a transient/retryable fault: 429 (rate limit), 408 (request timeout), 5xx
+// (server error) are all retryable on a healthy sibling and must fault the breaker — even if
+// the body coincidentally carries an overflow marker (an upstream wrapping a context-related
+// overload as a 500). So ALLOWLIST the deterministic request-shape statuses (400/413/422),
+// exactly like `isUpstreamRequestRejection`, plus `null` for in-band SSE overflow errors that
+// carry no HTTP status. Every other numeric status falls through to normal fallback.
 export function isContextWindowRejection(err: unknown): boolean {
   if (!(err instanceof UpstreamError)) return false;
+  const status = err.upstreamStatus;
+  if (status !== null && status !== 400 && status !== 413 && status !== 422) return false;
   if (upstreamErrorCode(err.providerRaw) === "context_length_exceeded") return true;
   // Strong, unambiguous markers may be matched anywhere in the body — they don't occur as
   // innocent echoed request content (some in-band SSE errors only surface them in the raw
@@ -1315,16 +1321,6 @@ export function isUpstreamRequestRejection(err: unknown): boolean {
   const text = `${err.message} ${rawErrorText(err.providerRaw)}`.toLowerCase();
   return text.includes("max allowed size");
 }
-
-// Anthropic's authoritative hard-maximum phrasing: "prompt is too long: N tokens > M
-// maximum" (comma grouping in the counts tolerated). This is an actionable compaction
-// signal — the request as sent is over a real ceiling — so once the candidate chain is
-// exhausted the terminal selector returns it as a client-visible `invalid_request` (400)
-// even if an UNRELATED sibling also failed, instead of burying it as all_providers_failed
-// (box c211e4a1). It does NOT short-circuit the chain: a larger-window sibling may still
-// serve the request (the same shape is emitted by 200k models, not only the 1M ceiling),
-// so fallback continues; this only governs which structured error wins at exhaustion.
-const ABSOLUTE_CONTEXT_MAX_PATTERN = /prompt is too long[^0-9]*[\d,]+\s*tokens?\s*>\s*[\d,]+/i;
 
 function isReasoningHistoryRejection(err: unknown): boolean {
   if (!(err instanceof UpstreamError)) return false;
@@ -1612,45 +1608,27 @@ export function createExecute(deps: ExecuteAdapterDeps) {
     // the retryable aggregate instead of claiming compaction is guaranteed to help.
     let onlyContextOrCapabilitySkips = true;
     const contextConfirmations = new Set<string>();
+    // A per-model context overflow discovered by a PRE-FLIGHT estimate (approximate token
+    // count or exact count_tokens). A real upstream overflow no longer flows here — it
+    // short-circuits with a verbatim 400 at the attempt site. So `contextOverflow` only
+    // records conservative estimates: the terminal below turns them into a compaction 400
+    // ONLY when every rejection was a context/capability skip, or when ≥2 candidates
+    // independently confirm the same overflow.
     let contextOverflow:
       | {
           message: string;
           providerRaw: Record<string, unknown> | null;
         }
       | undefined;
-    // The shaped "prompt is too long: N > M" message + raw from a REAL upstream response,
-    // if one was seen. Tracked SEPARATELY from `contextOverflow` (which also collects
-    // pre-flight approximate estimates that synthesize the same phrasing) so the terminal
-    // bypass — "return a compaction 400 even when mixed with an unrelated provider failure"
-    // (box c211e4a1) — can never be satisfied by an approximate estimate. Both the shape AND
-    // the authoritative provenance must belong to the SAME record, which is exactly what this
-    // captures. A real 5xx alongside a mere estimate therefore still yields all_providers_failed.
-    let authoritativeShapedOverflow:
-      | { message: string; providerRaw: Record<string, unknown> | null }
-      | undefined;
     const rememberContextOverflow = (
       message: string,
       providerRaw: Record<string, unknown> | null,
       confirmationKey: string | undefined,
-      authoritative: boolean,
     ): void => {
       if (confirmationKey !== undefined) contextConfirmations.add(confirmationKey);
-      if (
-        authoritative &&
-        authoritativeShapedOverflow === undefined &&
-        ABSOLUTE_CONTEXT_MAX_PATTERN.test(message)
-      ) {
-        authoritativeShapedOverflow = { message, providerRaw };
-      }
       if (contextOverflow === undefined) {
         contextOverflow = { message, providerRaw };
         return;
-      }
-      if (
-        !ABSOLUTE_CONTEXT_MAX_PATTERN.test(contextOverflow.message) &&
-        ABSOLUTE_CONTEXT_MAX_PATTERN.test(message)
-      ) {
-        contextOverflow.message = message;
       }
       if (contextOverflow.providerRaw === null && providerRaw !== null) {
         contextOverflow.providerRaw = providerRaw;
@@ -1782,7 +1760,6 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                 )} maximum`,
                 null,
                 undefined,
-                false, // approximate estimate, not an authoritative upstream verdict
               );
             }
             attempts.push(skipRow(alias, verdict.skipReason ?? "capability", elapsed()));
@@ -1881,13 +1858,15 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             const inputTokens = countTokensInputTokens(tokenCount);
             if (inputTokens !== null && inputTokens > exactContextLimit) {
               capabilityPruned = true;
+              // per-model count_tokens preflight; a larger sibling may still fit, so this
+              // is a fall-back skip (NOT a short-circuit). ≥2 such confirmations at the
+              // terminal still yield a compaction 400.
               rememberContextOverflow(
                 `prompt is too long: ${Math.trunc(inputTokens)} tokens > ${Math.trunc(
                   exactContextLimit,
                 )} maximum`,
                 null,
                 contextConfirmationKey,
-                false, // per-model count_tokens preflight; a larger sibling may still fit
               );
               attempts.push(skipRow(alias, "context_too_small", elapsed()));
               continue;
@@ -2310,36 +2289,44 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             continue;
           }
 
-          // Model context window overflow: THIS candidate cannot serve the request,
-          // but a later fallback with a LARGER window can (the same "prompt is too long:
-          // N > M" shape is emitted by 200k models too, not only the 1M ceiling — so this
-          // is NOT proof the whole chain overflows). Treat it like a late-discovered
-          // capability skip, not provider health: no breaker failure, no red provider
-          // error row, and no execution-fallback count. The chain-exhausted terminal below
-          // returns the compaction-compatible 400 once no larger sibling can serve it.
+          // A REAL upstream confirmed the request is over a hard context ceiling
+          // ("prompt is too long: N > M"). Do NOT fall back: a later, larger-window
+          // candidate would just "catch" the oversized request and return 200, so the
+          // client never sees a 4xx and never triggers its own context compaction (fatal
+          // under native passthrough — Claude Code / Codex rely on the 400 to compact).
+          // Short-circuit with the upstream's structured error VERBATIM as 400
+          // invalid_request. No breaker fault (the upstream is healthy — the request is
+          // what's wrong), no execution-fallback count. This mirrors the
+          // isUpstreamRequestRejection short-circuit directly below; a per-model
+          // count_tokens/approximate preflight (which may be conservative) is handled
+          // separately and still falls back.
           if (isContextWindowRejection(err)) {
-            capabilityPruned = true;
             const detail = errorDetailOf(err);
-            rememberContextOverflow(
-              upstreamErrorMessage(detail.provider_raw) ?? detail.message,
-              detail.provider_raw,
-              upstreamErrorCode(detail.provider_raw)?.toLowerCase() === "context_length_exceeded"
-                ? contextConfirmationKey
-                : undefined,
-              true, // authoritative: a real upstream response reported the overflow
-            );
             attempts.push({
               alias,
-              skipped: true,
-              skip_reason: "context_too_small",
+              skipped: false,
+              skip_reason: null,
               status: "error",
-              error_class: null,
+              error_class: "invalid_request",
               latency_ms: elapsed(),
               cost_usd: null,
               error_detail: detail,
               ...attemptTelemetry,
             });
-            continue;
+            return {
+              attempts,
+              final: {
+                status: "error",
+                error: makeHelmError({
+                  error_class: "invalid_request",
+                  message: upstreamErrorMessage(detail.provider_raw) ?? detail.message,
+                  trace_id: correlationTraceId(req),
+                  provider_raw: detail.provider_raw,
+                }),
+              },
+              body: null,
+              stream: null,
+            };
           }
 
           // DeepSeek-style thinking mode is candidate-specific: when a fallback target
@@ -2466,22 +2453,12 @@ export function createExecute(deps: ExecuteAdapterDeps) {
       contextOverflow !== undefined &&
       (onlyContextOrCapabilitySkips || contextConfirmations.size >= 2)
     ) {
+      // Only PRE-FLIGHT estimates reach here (a real upstream overflow already short-circuited
+      // with a verbatim 400 at the attempt site). A conservative estimate becomes a compaction
+      // 400 only when every rejection was a context/capability skip, or ≥2 candidates confirm.
       errorClass = "invalid_request";
       message = contextOverflow.message;
       providerRaw = contextOverflow.providerRaw;
-    } else if (authoritativeShapedOverflow !== undefined) {
-      // A REAL upstream response carried the exact hard-maximum shape "prompt is too long:
-      // N > M". Emit the compaction-compatible 400 VERBATIM even when the chain also had an
-      // UNRELATED provider failure (box c211e4a1: a grok 422 must NOT bury it as
-      // all_providers_failed and leave Claude Code / Codex unable to compact). The
-      // shape AND the authoritative provenance belong to the same record, so a pre-flight
-      // APPROXIMATE estimate (which synthesizes the same phrasing) can never reach here and
-      // override a genuine provider 5xx. Larger-window fallback already ran first (a shaped
-      // overflow is a context skip, not a short-circuit); this only picks the terminal once
-      // the chain is truly exhausted.
-      errorClass = "invalid_request";
-      message = authoritativeShapedOverflow.message;
-      providerRaw = authoritativeShapedOverflow.providerRaw;
     } else if (
       !attemptedAny &&
       capabilityPruned &&

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,17 @@
 
 ---
 
+## 2026-08-07 · 真上游上下文溢出短路直返 400，不再 fall back（Gateway / execution chain，docs/03/04/07，原则 3/5）
+
+- **现场（box 12a22879）**：客户端请求 `claude-opus-5`（anthropic passthrough），链上 anthropic/opus-4-8 与 sonnet-5 都真上游 400 `prompt is too long: N > 1000000`，被当作 `context_too_small` skip，一路 fall back 到 `openrouter/deepseek-v4-pro`（更大窗口）**成功返回 200**。客户端拿到成功响应→永不触发 context compaction→下一轮请求只会更长。透传场景尤其致命：Claude Code / Codex 靠收到 4xx 才压缩。
+- **根因**：`#702`（v0.28.43）的设计是「真上游溢出当 skip 继续 fall back，只在**链条耗尽**时由 `authoritativeShapedOverflow` 返回 400」。但只要链上有一个更大窗口模型兜住（deepseek 返回 200），链条就没耗尽，那段终态逻辑永远走不到。「让更大 sibling 试」的假设直接破坏了压缩语义。
+- **修复（Lukin 拍板"遇到一个上下文太大就直接返回，不要往后走"）**：`isContextWindowRejection(err)` 命中的分支从 `skip + continue` 改为**短路返回 400**（`error_class:invalid_request`，原样透传上游 `provider_raw`），形态对齐紧邻的 `isUpstreamRequestRejection` 短路模板。不记熔断（上游健康、错的是请求），不算 execution-fallback。
+- **刻意的边界（AskUserQuestion 敲定）**：**仅真上游 400 短路**。预检估算两条路径——能力过滤近似估算（`execute.ts` ~1776）与 `count_tokens` 精确预检（~1863）——**仍 skip 继续 fall back**，因为估算可能偏保守，更大真实窗口的模型也许真能服务。这两条继续走 `contextOverflow` + `contextConfirmations`（≥2 确认）的链条耗尽终态。
+- **清理死代码**：真上游溢出短路后不再进终态判定，删除只服务旧机制的 `authoritativeShapedOverflow` 变量、`rememberContextOverflow` 的 `authoritative` 形参、`ABSOLUTE_CONTEXT_MAX_PATTERN`、终态 `else if (authoritativeShapedOverflow)` 分支。`contextOverflow` 择优逻辑同步简化（两个预检调用点 message 都是 shaped，择优永不触发）。
+- **可观测影响**：这类请求 `provider_attempts` 从多条变 1 条、`fallback_count` 从 1 变 0、admin「提供商尝试」面板只显示第一个候选返回 400。这是短路的直接结果，预期内。
+- **Codex review 补的 gate（round 1-2 HIGH）**：短路把一个潜伏 bug 放大了——`isContextWindowRejection` 原本纯靠 error body/message 标记判定，**不看 `err.upstreamStatus`**。一个可重试的 429/5xx/408 若 body 恰好含 `context_length_exceeded` 标记（如上游把上下文相关的过载包成 500），会被短路成客户端 400 → 不再 fall back 到健康兄弟、不记熔断。round-1 用黑名单（`status === 429 || status >= 500`）；round-2 Codex 指出漏了 408 → 改成**白名单** `if (status !== null && status !== 400 && status !== 413 && status !== 422) return false;`。只有确定性请求-shape 4xx（400/413/422）+ `null`（in-band 流式，无 HTTP 状态）短路；其余所有 numeric status（408/409/425/429/5xx…）走正常 fall back + 记熔断。与 `isUpstreamRequestRejection` 的 4xx 白名单一致，未来新增可重试 status 天然被排除，不用补黑名单。旧的 skip-and-continue 设计下这个误判无害（只少试一个候选），是短路抬高了代价。
+- **测试**：9 个围绕旧「skip+耗尽才返回/多候选确认/让位给更大 sibling」的 case 全部重写为「第一个真上游溢出即短路、后续候选从不被调用」（含 in-band 流式溢出、native Responses 脱敏、逗号分组、box c211e4a1）；新增复现线上 case 的短路测试 + 预检估算不短路的正向证明 + 5xx-gate 测试（500 带溢出标记必须 fall back 而非短路）。execute.test.ts 170 全绿；route-request 92 全绿；typecheck + lint 全绿。
+
 ## 2026-08-07 · Codex 配额富元数据持久化（providers page Tier 3，docs/11，原则 7）
 
 - **现场**：providers 页某 Codex 账号卡片"显示不全"——只有"周限 100%"进度条 + resetCredits 0，缺 Plan 类型、Credits 点数、Reset limit 按钮点数、individualLimit。box 刚重启到 0.28.46 后**所有** Codex 账号都这样；手动 refresh 后未限流账号立即恢复出 planType/credits，已限流账号（其 `/wham/usage` PULL 拿不到富数据）仍缺。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.50",
+  "version": "0.28.51",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## 问题（box 12a22879）

客户端请求 `claude-opus-5`（anthropic passthrough），prompt ~103 万 token 超过窗口。链上 anthropic/opus-4-8 与 sonnet-5 都真实上游返回 400 `prompt is too long: N > 1000000`，被当作 `context_too_small` skip，一路 fall back 到 `openrouter/deepseek-v4-pro`（更大窗口）**成功返回 200**。

结果：**客户端拿到成功响应，永远不知道要压缩上下文（context compaction），下一轮请求只会更长**。透传场景尤其致命——Claude Code / Codex 靠收到 4xx 才触发自身压缩。

`#702`（v0.28.43）的设计是「真上游溢出当 skip 继续 fall back，只在**链条耗尽**时返回 400」，但只要链上有一个更大窗口的模型兜住（deepseek 返回 200），链条就没耗尽，那段终态逻辑永远走不到。

## 修复

`isContextWindowRejection(err)` 命中真实上游窗口溢出 → **短路返回 400 invalid_request**，原样透传上游 `provider_raw`，不再 fall back，不记熔断，后续候选不再尝试。形态对齐紧邻的 `isUpstreamRequestRejection` 短路分支。

**边界（刻意保留）**：预检估算两条路径（能力过滤近似估算 + Anthropic `count_tokens` 精确预检）**仍 skip 继续 fall back**——估算可能保守，更大真实窗口的模型也许真能服务。只有**真实上游**溢出短路。

**status gate（Codex review 加固）**：`isContextWindowRejection` 原本纯靠 error body 判定、不看 `upstreamStatus`，导致可重试的 408/429/5xx（body 恰好含 `context_length_exceeded` 标记）会被误判短路 → 不 fall back、不记熔断。改成**白名单**：只放行确定性请求-shape status（400/413/422）+ `null`（in-band 流式，无 HTTP 状态），其余所有 numeric status 走正常 fall back + 记熔断。与 `isUpstreamRequestRejection` 一致。

**清理死代码**：删除只服务旧「链条耗尽才返回」机制的 `authoritativeShapedOverflow` / `ABSOLUTE_CONTEXT_MAX_PATTERN` / 终态分支。

## 可观测影响

这类请求 `provider_attempts` 从多条变 1 条、`fallback_count` 从 1 变 0、admin「提供商尝试」面板只显示第一个候选返回 400。预期内。

## 测试

- 9 个围绕旧「skip+耗尽才返回/多候选确认/让位给更大 sibling」的 case 重写为「第一个真上游溢出即短路、后续候选从不被调用」（含 in-band 流式溢出、native Responses 脱敏、逗号分组、box c211e4a1）。
- 新增：短路复现测试（box 12a22879）、预检估算不短路的正向证明、5xx-gate 测试、408-gate 测试。
- execute.test.ts **171 全绿**；route-request 92 全绿；typecheck + lint 干净。

## Codex review

三轮循环收敛：round-1 发现 status gate 缺失（HIGH，已修）→ round-2 发现黑名单漏 408（已改白名单）→ round-3 "no issues"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)