### PR TITLE
chore(release): v0.28.53

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.52",
+  "version": "0.28.53",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.28.53 — bumps `package.json` to trigger `publish.yml` (tag + GitHub Release + `:0.28.53` image) for the Grok Imagine media feature merged in #715.

## Included since v0.28.52
- **#715** feat: add Grok Imagine media via SuperGrok OAuth
  - `POST /v1/images/generations` now routes Grok Imagine image models (generic OpenAI Images surface).
  - New `POST /v1/videos/generations` + `GET /v1/videos/{request_id}` mirror Grok's native async video contract.
  - Reuses the connected SuperGrok OAuth pool; paid media POST is a single-write path (no failover, no sibling switch, no replay); read-only poll is account-pinned.
  - Provider admin shows Image/Video badges; connectivity "Test" excludes paid media models; telemetry strips presigned-URL query strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)