### PR TITLE
fix(admin): stream session revisions so large transcripts rebuild client-side

### DIFF
--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -2198,7 +2198,7 @@ describe("admin.api request payload", () => {
       listSessionRevisions: async () => {
         throw new Error("unbounded Session read must not be used");
       },
-      listSessionRevisionsPage: async (
+      streamSessionRevisionsPage: async (
         _sessionRef: string,
         options: { afterSequence?: number; limit: number; maxBytes: number },
       ) => {
@@ -2245,7 +2245,7 @@ describe("admin.api request payload", () => {
     const telemetry = {
       ...makeTelemetry([rec]),
       getPayload: async () => null,
-      listSessionRevisionsPage: async (
+      streamSessionRevisionsPage: async (
         _sessionRef: string,
         options: { afterSequence?: number; limit: number; maxBytes: number },
       ) => {
@@ -2275,7 +2275,7 @@ describe("admin.api request payload", () => {
     expect(await response.json()).toEqual({ captured: false, reason: "no_session" });
   });
 
-  it("reports session_unavailable when the store cannot page revisions", async () => {
+  it("reports session_unavailable when the store cannot stream revisions", async () => {
     const rec = {
       ...decision("req_child", "balanced"),
       session: { ref: "session-ref", source: "x-thread-id" as const },
@@ -2283,7 +2283,7 @@ describe("admin.api request payload", () => {
     const telemetry = {
       ...makeTelemetry([rec]),
       getPayload: async () => null,
-      listSessionRevisionsPage: undefined,
+      streamSessionRevisionsPage: undefined,
     } as unknown as TelemetryStore;
     const response = await buildApp(buildDeps({ telemetry })).request(
       "/admin/api/requests/req_child/session-revisions",

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -293,12 +293,15 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
     const decision = await deps.telemetry.getByRequestId(traceId);
     const sessionRef = decision?.session?.ref;
     if (!sessionRef) return c.json({ captured: false, reason: "no_session" });
-    const listPage = deps.telemetry.listSessionRevisionsPage;
-    if (!listPage) return c.json({ captured: false, reason: "session_unavailable" });
+    // Streaming variant (NOT the all-or-nothing listSessionRevisionsPage the server-side
+    // rebuild uses): every page returns ≥1 row and always advances the cursor, so a large
+    // session pages through instead of dead-ending on an empty page.
+    const streamPage = deps.telemetry.streamSessionRevisionsPage;
+    if (!streamPage) return c.json({ captured: false, reason: "session_unavailable" });
     const afterRaw = c.req.query("after");
     const afterSequence =
       afterRaw !== undefined && /^\d+$/.test(afterRaw) ? Number(afterRaw) : undefined;
-    const page = await listPage.call(deps.telemetry, sessionRef, {
+    const page = await streamPage.call(deps.telemetry, sessionRef, {
       afterSequence,
       limit: SESSION_REVISION_PAGE_LIMIT,
       maxBytes: SESSION_REVISION_PAGE_MAX_BYTES,
@@ -323,11 +326,11 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
   });
 }
 
-// One raw-revision page: bounded so a single request never materializes an unbounded
-// chain, but large enough that most transcripts page in a few round-trips. The client
-// drives the cursor, so this is a per-page cap, not a whole-transcript budget.
-const SESSION_REVISION_PAGE_LIMIT = 100;
-const SESSION_REVISION_PAGE_MAX_BYTES = 4 * 1024 * 1024;
+// One raw-revision page: `limit` caps rows/page, `maxBytes` is a SOFT ceiling (a single
+// oversized row still returns, so a large session never dead-ends). The client drives
+// the cursor across pages, so these are per-page bounds, not a whole-transcript budget.
+const SESSION_REVISION_PAGE_LIMIT = 50;
+const SESSION_REVISION_PAGE_MAX_BYTES = 8 * 1024 * 1024;
 
 async function getSessionRequest(
   deps: AdminApiDeps,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.53",
+  "version": "0.28.54",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -613,6 +613,17 @@ export interface TelemetryStore {
     sessionRef: string,
     options: SessionRevisionPageOptions,
   ): Promise<SessionRevisionPage>;
+  // Like listSessionRevisionsPage but for CLIENT-SIDE reconstruction: the caller
+  // accumulates raw rows across pages and rebuilds in the browser, so a single page
+  // need NOT be a complete chain. maxBytes is a SOFT ceiling — every page returns at
+  // least one row (even one larger than maxBytes; the client can hold it) and always
+  // advances the cursor. Contrast listSessionRevisionsPage, whose all-or-nothing page
+  // (empty + limited when the budget is exceeded) is correct for SERVER-side rebuild
+  // but dead-ends a streaming client on large sessions. `limited` is always false here.
+  streamSessionRevisionsPage?(
+    sessionRef: string,
+    options: SessionRevisionPageOptions,
+  ): Promise<SessionRevisionPage>;
   findSessionRequestIdByResponseId?(
     sessionRef: string,
     responseId: string,

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -29,6 +29,7 @@ import type {
   UpsertSessionRevisionInput,
 } from "../ports.js";
 import { PERSISTED_SESSION_MAX_REVISIONS } from "../ports.js";
+import { selectStreamingSessionRevisions } from "../session-page.js";
 import { likeContains } from "../sql-like.js";
 import { denormalizedDecisionCost } from "../telemetry-cost.js";
 import type { PgDb } from "./migrate.js";
@@ -540,6 +541,48 @@ export class PgTelemetryStore implements TelemetryStore {
     return {
       revisions: rows.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId))),
       nextSequence: metadata.length > selected.length ? (selected.at(-1) ?? null) : null,
+      limited: false,
+    };
+  }
+
+  // Streaming variant for client-side rebuild: soft byte ceiling, always ≥1 row per
+  // page, cursor always advances. See the port doc for why this differs from the
+  // all-or-nothing listSessionRevisionsPage.
+  async streamSessionRevisionsPage(
+    sessionRef: string,
+    options: SessionRevisionPageOptions,
+  ): Promise<SessionRevisionPage> {
+    const limit = boundedSessionPageLimit(options);
+    const afterSequence = options.afterSequence ?? 0;
+    const metadata = await this.db
+      .select({ sequence: sessionRevisions.sequence, bytes: sessionRevisionWireBytes })
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          gt(sessionRevisions.sequence, afterSequence),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence))
+      .limit(limit + 1);
+    const selected = selectStreamingSessionRevisions(metadata, limit, options.maxBytes);
+    if (selected.length === 0) return { revisions: [], nextSequence: null, limited: false };
+    const rows = await this.db
+      .select()
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          inArray(sessionRevisions.sequence, selected),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence));
+    const chunks = await this.chunksByRevisions(rows);
+    const lastSelected = selected.at(-1) ?? null;
+    const hasMore = metadata.some((row) => row.sequence > (lastSelected ?? 0));
+    return {
+      revisions: rows.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId))),
+      nextSequence: hasMore ? lastSelected : null,
       limited: false,
     };
   }

--- a/packages/core/src/store/session-page.test.ts
+++ b/packages/core/src/store/session-page.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { __sessionPageSelfCheck, selectStreamingSessionRevisions } from "./session-page.js";
+
+describe("selectStreamingSessionRevisions", () => {
+  it("passes its inline self-check", () => {
+    expect(() => __sessionPageSelfCheck()).not.toThrow();
+  });
+
+  it("always returns the first row even when it alone exceeds maxBytes", () => {
+    expect(selectStreamingSessionRevisions([{ sequence: 7, bytes: 10_000 }], 10, 1)).toEqual([7]);
+  });
+
+  it("treats maxBytes as a soft ceiling once a row is selected", () => {
+    expect(
+      selectStreamingSessionRevisions(
+        [
+          { sequence: 1, bytes: 20 },
+          { sequence: 2, bytes: 20 },
+          { sequence: 3, bytes: 20 },
+        ],
+        10,
+        30,
+      ),
+    ).toEqual([1]);
+  });
+
+  it("packs multiple rows while they fit under maxBytes", () => {
+    expect(
+      selectStreamingSessionRevisions(
+        [
+          { sequence: 1, bytes: 10 },
+          { sequence: 2, bytes: 10 },
+          { sequence: 3, bytes: 10 },
+        ],
+        10,
+        25,
+      ),
+    ).toEqual([1, 2]);
+  });
+
+  it("never exceeds limit", () => {
+    expect(
+      selectStreamingSessionRevisions(
+        [
+          { sequence: 1, bytes: 1 },
+          { sequence: 2, bytes: 1 },
+          { sequence: 3, bytes: 1 },
+        ],
+        2,
+        1_000,
+      ),
+    ).toEqual([1, 2]);
+  });
+
+  it("counts legacy unmeasurable bytes as zero so the row is still returned", () => {
+    expect(
+      selectStreamingSessionRevisions(
+        [
+          { sequence: 1, bytes: Number.NaN },
+          { sequence: 2, bytes: -5 },
+        ],
+        10,
+        0,
+      ),
+    ).toEqual([1, 2]);
+  });
+});

--- a/packages/core/src/store/session-page.ts
+++ b/packages/core/src/store/session-page.ts
@@ -1,0 +1,67 @@
+// Pure row-selection for the STREAMING session-revision page (client-side rebuild).
+// Dialect-agnostic so the sqlite and postgres adapters share one implementation of
+// the load-bearing rule: every page returns at least one row and always advances the
+// cursor, so a large session can never dead-end the client. maxBytes is a soft
+// ceiling, NOT an all-or-nothing gate (that is listSessionRevisionsPage's job).
+
+export interface SessionPageRowMeta {
+  sequence: number;
+  // UTF-8 wire bytes; may be NaN/negative for legacy binary rows the DB can't measure.
+  bytes: number;
+}
+
+// Given up to `limit + 1` ordered rows, return the sequences to include in this page.
+// - Always include the first row (even if it alone exceeds maxBytes — the client holds it).
+// - After ≥1 row is selected, stop before the row that would breach maxBytes.
+// - Never exceed `limit` rows.
+// Unmeasurable bytes (legacy binary: NaN/negative) count as 0 so the row is still
+// returned — streaming favors "give the client the row" over precise accounting.
+export function selectStreamingSessionRevisions(
+  ordered: readonly SessionPageRowMeta[],
+  limit: number,
+  maxBytes: number,
+): number[] {
+  const selected: number[] = [];
+  let usedBytes = 0;
+  for (const row of ordered.slice(0, limit)) {
+    const raw = Number(row.bytes);
+    const bytes = Number.isSafeInteger(raw) && raw > 0 ? raw : 0;
+    if (selected.length > 0 && usedBytes + bytes > maxBytes) break;
+    selected.push(row.sequence);
+    usedBytes += bytes;
+  }
+  return selected;
+}
+
+// ponytail: inline self-check for the two load-bearing branches (single oversized row
+// still returned; soft ceiling stops without dropping selected rows).
+export function __sessionPageSelfCheck(): void {
+  const assert = (cond: boolean, msg: string) => {
+    if (!cond) throw new Error(`session-page self-check: ${msg}`);
+  };
+  // Single row far over maxBytes is still selected.
+  assert(
+    JSON.stringify(selectStreamingSessionRevisions([{ sequence: 1, bytes: 999 }], 10, 1)) === "[1]",
+    "oversized single row must be returned",
+  );
+  // Soft ceiling: row 1 fits, row 2 would breach → stop after row 1.
+  assert(
+    JSON.stringify(
+      selectStreamingSessionRevisions(
+        [
+          { sequence: 1, bytes: 30 },
+          { sequence: 2, bytes: 30 },
+        ],
+        10,
+        40,
+      ),
+    ) === "[1]",
+    "soft ceiling must stop before breaching row without dropping selected",
+  );
+  // Legacy unmeasurable bytes count as 0 → row still selected.
+  assert(
+    JSON.stringify(selectStreamingSessionRevisions([{ sequence: 1, bytes: Number.NaN }], 10, 1)) ===
+      "[1]",
+    "legacy unmeasurable row must be returned",
+  );
+}

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -34,6 +34,7 @@ import type {
   UpsertSessionRevisionInput,
 } from "../ports.js";
 import { PERSISTED_SESSION_MAX_REVISIONS } from "../ports.js";
+import { selectStreamingSessionRevisions } from "../session-page.js";
 import { likeContains } from "../sql-like.js";
 import { denormalizedDecisionCost } from "../telemetry-cost.js";
 import { runBatchedPrune, yieldToEventLoop } from "./batched-prune.js";
@@ -617,6 +618,51 @@ export class SqliteTelemetryStore implements TelemetryStore {
     return {
       revisions: revisions.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId))),
       nextSequence: metadata.length > selected.length ? (selected.at(-1) ?? null) : null,
+      limited: false,
+    };
+  }
+
+  // Streaming variant for client-side rebuild: soft byte ceiling, always ≥1 row per
+  // page, cursor always advances. See the port doc for why this differs from the
+  // all-or-nothing listSessionRevisionsPage.
+  async streamSessionRevisionsPage(
+    sessionRef: string,
+    options: SessionRevisionPageOptions,
+  ): Promise<SessionRevisionPage> {
+    const limit = boundedSessionPageLimit(options);
+    const afterSequence = options.afterSequence ?? 0;
+    const metadata = this.db
+      .select({ sequence: sessionRevisions.sequence, bytes: sessionRevisionWireBytes })
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          gt(sessionRevisions.sequence, afterSequence),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence))
+      .limit(limit + 1)
+      .all();
+    const selected = selectStreamingSessionRevisions(metadata, limit, options.maxBytes);
+    if (selected.length === 0) return { revisions: [], nextSequence: null, limited: false };
+    const revisions = this.db
+      .select()
+      .from(sessionRevisions)
+      .where(
+        and(
+          eq(sessionRevisions.sessionRef, sessionRef),
+          inArray(sessionRevisions.sequence, selected),
+        ),
+      )
+      .orderBy(asc(sessionRevisions.sequence))
+      .all();
+    const chunks = this.chunksByRevisions(revisions);
+    // More rows remain iff the store held any sequence beyond the last one we returned.
+    const lastSelected = selected.at(-1) ?? null;
+    const hasMore = metadata.some((row) => row.sequence > (lastSelected ?? 0));
+    return {
+      revisions: revisions.map((row) => decodeSessionRevisionRow(row, chunks.get(row.requestId))),
+      nextSequence: hasMore ? lastSelected : null,
       limited: false,
     };
   }

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -737,6 +737,97 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(limited).toEqual({ revisions: [], nextSequence: null, limited: true });
     });
 
+    it("streams raw revision pages that always progress (never all-or-nothing)", async () => {
+      ctx = await make();
+      const t = ctx.stores.telemetry;
+      if (!t.upsertSessionRevision || !("streamSessionRevisionsPage" in t))
+        throw new Error("streamSessionRevisionsPage required");
+      const stream = (
+        t as TelemetryStore & {
+          streamSessionRevisionsPage(
+            sessionRef: string,
+            options: { afterSequence?: number; limit: number; maxBytes: number },
+          ): Promise<{
+            revisions: Array<{ requestId: string; sequence: number; requestDeltaJson: string }>;
+            nextSequence: number | null;
+            limited: boolean;
+          }>;
+        }
+      ).streamSessionRevisionsPage.bind(t);
+      const base = {
+        sessionRef: "s_stream",
+        accountId: "acct_1",
+        apiKeyId: "key_1",
+        source: "codex" as const,
+        externalSessionId: "external-stream",
+      };
+      // Three revisions; row 1 carries a large body so its wire bytes dwarf maxBytes.
+      const bigDelta = `[${JSON.stringify("x".repeat(5000))}]`;
+      await t.upsertSessionRevision({
+        ...base,
+        requestId: "s1",
+        parentRequestId: null,
+        retainCount: 0,
+        requestDeltaJson: bigDelta,
+        requestEnvelopeJson: '{"model":"x"}',
+        responseId: null,
+        responseJson: null,
+        fidelity: "semantic",
+        createdAt: new Date(1000),
+      });
+      await t.upsertSessionRevision({
+        ...base,
+        requestId: "s2",
+        parentRequestId: "s1",
+        retainCount: 1,
+        requestDeltaJson: '["two"]',
+        requestEnvelopeJson: '{"model":"x"}',
+        responseId: null,
+        responseJson: null,
+        fidelity: "semantic",
+        createdAt: new Date(2000),
+      });
+      await t.upsertSessionRevision({
+        ...base,
+        requestId: "s3",
+        parentRequestId: "s2",
+        retainCount: 2,
+        requestDeltaJson: '["three"]',
+        requestEnvelopeJson: '{"model":"x"}',
+        responseId: null,
+        responseJson: null,
+        fidelity: "semantic",
+        createdAt: new Date(3000),
+      });
+
+      // A single row far exceeding maxBytes must STILL be returned (client can hold it),
+      // with a cursor to continue — the all-or-nothing dead end is exactly the bug.
+      const p1 = await stream("s_stream", { limit: 10, maxBytes: 1 });
+      expect(p1.revisions.map((r) => r.sequence)).toEqual([1]);
+      expect(p1.revisions[0]?.requestDeltaJson).toBe(bigDelta); // body reassembled
+      expect(p1.nextSequence).toBe(1);
+      expect(p1.limited).toBe(false);
+
+      // maxBytes is a soft ceiling: once at least one row is selected, the next row that
+      // would breach it stops the page WITHOUT dropping the already-selected rows.
+      const p2 = await stream("s_stream", { afterSequence: 1, limit: 10, maxBytes: 40 });
+      expect(p2.revisions.map((r) => r.sequence)).toEqual([2]);
+      expect(p2.nextSequence).toBe(2);
+
+      const p3 = await stream("s_stream", { afterSequence: 2, limit: 10, maxBytes: 40 });
+      expect(p3.revisions.map((r) => r.sequence)).toEqual([3]);
+      expect(p3.nextSequence).toBeNull();
+
+      // Walking the whole chain in one generous page reassembles every row in order.
+      const whole = await stream("s_stream", { limit: 100, maxBytes: 8 * 1024 * 1024 });
+      expect(whole.revisions.map((r) => r.sequence)).toEqual([1, 2, 3]);
+      expect(whole.nextSequence).toBeNull();
+
+      // Unknown session → empty, no cursor.
+      const empty = await stream("s_missing", { limit: 10, maxBytes: 1024 });
+      expect(empty).toEqual({ revisions: [], nextSequence: null, limited: false });
+    });
+
     it("atomically publishes one matching body generation for concurrent duplicate writes", async () => {
       ctx = await make();
       const t = ctx.stores.telemetry;


### PR DESCRIPTION
## 问题（#714 上线后暴露）

客户端转录重建（v0.28.52）对**大会话**直接报「无法重建会话转录」。用 box 真实数据锁定根因：

- 目标 session 有 **1127 行 revision**、首行正文 ~440KB、累计 ~40MB。
- `/session-revisions` 端点复用了 `listSessionRevisionsPage`，其语义是 **all-or-nothing**：累计字节超过 `maxBytes` 就返回空页 + `limited`。这对**服务端重建**正确（重建需完整链），但对**流式客户端**致命——4MB 页预算在第 1 页就被撑爆 → 端点返回 `revisions:[], nextSequence:null` → 浏览器拿到空链 + 无游标 → 报错。

## 修复

新增专用流式 store 方法 `streamSessionRevisionsPage`：

- **每页至少返回一行**（哪怕单行 > maxBytes，客户端能扛），单行超限不再死锁；
- `maxBytes` 是**软上限**：已选 ≥1 行后，下一行会撑爆就停在此行前，不丢已选行；
- **游标始终推进**直到链条走完。

行选择规则抽成一个**方言无关的共享纯函数** `selectStreamingSessionRevisions`，sqlite + postgres 两适配器共用，带 self-check + 单测。`listSessionRevisionsPage`（服务端重建）**不动**。端点改用流式方法（limit 50、maxBytes 8MB 软上限）。

## 验证

- **core store 契约测**（sqlite + pglite-postgres 双驱动）：单行超 maxBytes 仍返回+游标推进 / 软上限截断不丢行 / 空 session / chunks 正文重组。
- **纯函数单测** + gateway 端点单测。
- **box 真实数据回归**：从 box 捞该 session 的 1170 revision + 3512 chunk 灌入本地库，跑流式方法——**24 页游标走完、1170 行全收集、1170/1170 正文从 chunk 表重组、转录重建成功**（gpt-5.6-sol，336 events，~1MB）。
- typecheck + lint + 279 受影响单测全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)