### PR TITLE
refactor(admin): render rebuilt transcript in the existing request JsonViewer

### DIFF
--- a/apps/admin/src/lib/i18n/request-detail-locales.test.ts
+++ b/apps/admin/src/lib/i18n/request-detail-locales.test.ts
@@ -23,7 +23,6 @@ const requestDetailPayloadKeys = [
   'The forwarded upstream body matched the client request body.',
   'Load transcript',
   'Rebuild the transcript in your browser instead of on the server.',
-  'Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.',
   'The session transcript is too large to rebuild on the server.',
   'The session transcript could not be rebuilt.',
 ] as const;

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -525,12 +525,9 @@
         </p>
         {#if data.payload?.reason === 'session_recovery_limited'}
           {#if transcriptStatus === 'loaded'}
-            <p class="field-help mb-2 mt-3">
-              {$t(
-                'Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.',
-              )}
-            </p>
-            <JsonViewer value={transcriptValue} testid="transcript-body" />
+            <!-- Reuse the same JsonViewer as a captured/recovered request body; the
+                 rebuilt transcript IS the request, so it needs no separate display. -->
+            <JsonViewer value={transcriptValue} testid="request-body" />
           {:else}
             <div class="mt-3 rounded border border-dashed border-border bg-canvas p-3">
               <p class="field-help mb-2">

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -703,12 +703,14 @@ describe('requests detail page', () => {
       },
     });
 
-    // Not loaded up front — the button is present, no transcript body yet.
+    // Not loaded up front — the button is present, no request body yet.
     expect(rebuildSessionTranscript).not.toHaveBeenCalled();
-    expect(screen.queryByTestId('transcript-body')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('request-body')).not.toBeInTheDocument();
     await fireEvent.click(screen.getByTestId('load-transcript'));
 
-    expect(await screen.findByTestId('transcript-body')).toHaveTextContent(/"model": "auto"/);
+    // Rebuilt transcript renders through the SAME request-body JsonViewer as a
+    // captured/recovered request — no separate viewer.
+    expect(await screen.findByTestId('request-body')).toHaveTextContent(/"model": "auto"/);
     expect(rebuildSessionTranscript).toHaveBeenCalledWith('tr_big');
   });
 

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -366,12 +366,14 @@ test.describe("admin request payload view", () => {
     await expect(page.getByTestId("payload-summary")).toContainText(
       /too large to rebuild on the server/i,
     );
-    // The server-side payload-part buttons stay absent; the client rebuild is offered.
+    // The server-side payload-part buttons stay absent; the client rebuild is offered,
+    // and nothing renders in the request-body viewer until the button is clicked.
     await expect(page.getByTestId("load-conversation")).toHaveCount(0);
     await expect(page.getByTestId("load-request-body")).toHaveCount(0);
-    await expect(page.getByTestId("transcript-body")).toHaveCount(0);
+    await expect(page.getByTestId("request-body")).toHaveCount(0);
 
     await page.getByTestId("load-transcript").click();
-    await expect(page.getByTestId("transcript-body")).toContainText("rebuilt-in-browser");
+    // Rebuilt transcript renders through the SAME request-body JsonViewer.
+    await expect(page.getByTestId("request-body")).toContainText("rebuilt-in-browser");
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.54",
+  "version": "0.28.55",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
按 Lukin 反馈：客户端重建的转录**就是请求正文**，没必要单开一个展示区。

- 删掉独立的 `transcript-body` JsonViewer + 那段「已在浏览器重建…」说明文案；
- 重建结果直接喂进**与「已捕获/已恢复请求」相同的 `request-body` JsonViewer**，走同一条渲染路径；
- 「Load transcript」懒加载按钮保留（它是触发器）；
- 测试 + e2e 改用 `request-body` testid；不再引用的 i18n 文案从 locale-coverage 门槛移除。

svelte-check / lint / typecheck / admin 单测(53) / e2e 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)