### PR TITLE
fix(admin): render rebuilt transcript in the real Request view

### DIFF
--- a/apps/admin/src/lib/i18n/request-detail-locales.test.ts
+++ b/apps/admin/src/lib/i18n/request-detail-locales.test.ts
@@ -23,6 +23,7 @@ const requestDetailPayloadKeys = [
   'The forwarded upstream body matched the client request body.',
   'Load transcript',
   'Rebuild the transcript in your browser instead of on the server.',
+  'Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.',
   'The session transcript is too large to rebuild on the server.',
   'The session transcript could not be rebuilt.',
 ] as const;

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -88,21 +88,23 @@
 
   // Client-side transcript rebuild for sessions the server refuses to reconstruct
   // (session_recovery_limited). Loaded only on click — a large transcript can be many
-  // MB, so we stream the raw revisions and rebuild in the browser.
-  let transcriptStatus = $state<'idle' | 'loading' | 'loaded' | 'error'>('idle');
-  let transcriptValue = $state<unknown>(null);
-  let transcriptError = $state<string | undefined>(undefined);
+  // MB, so we stream the raw revisions and rebuild in the browser. On success the
+  // rebuilt body is written into the NORMAL request slot so the whole Request section
+  // renders it through the exact same Chat/Raw lenses + JsonViewer as a captured
+  // request — no separate viewer.
+  let transcriptLoaded = $state(false);
 
   async function loadTranscript(): Promise<void> {
-    if (transcriptStatus === 'loading' || transcriptStatus === 'loaded') return;
-    transcriptStatus = 'loading';
-    transcriptError = undefined;
+    if (payloadStatus.request === 'loading' || transcriptLoaded) return;
+    payloadStatus.request = 'loading';
+    payloadErrors.request = undefined;
     try {
-      transcriptValue = await rebuildSessionTranscript(data.requestId);
-      transcriptStatus = 'loaded';
+      payloadValues.request = await rebuildSessionTranscript(data.requestId);
+      payloadStatus.request = 'loaded';
+      transcriptLoaded = true;
     } catch {
-      transcriptStatus = 'error';
-      transcriptError = $t('The session transcript could not be rebuilt.');
+      payloadStatus.request = 'error';
+      payloadErrors.request = $t('The session transcript could not be rebuilt.');
     }
   }
 
@@ -411,8 +413,8 @@
       <h2 class="section-header">
         {upstreamDiffers ? $t('Request (from client)') : $t('Request')}
       </h2>
-      {#if data.payload?.captured}
-        {#if data.payload.source === 'session'}
+      {#if data.payload?.captured || transcriptLoaded}
+        {#if data.payload?.source === 'session' || transcriptLoaded}
           <p
             data-testid="session-recovery-warning"
             class="mb-3 rounded border border-amber-200 bg-amber-50 p-3 text-amber-800"
@@ -423,7 +425,11 @@
           </p>
         {/if}
         <p class="field-help mb-2">
-          {#if upstreamDiffers}
+          {#if transcriptLoaded}
+            {$t(
+              'Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.',
+            )}
+          {:else if upstreamDiffers}
             {$t(
               'The request body as received from the client — before memory injection and translation.',
             )}
@@ -523,31 +529,28 @@
             {$t('Full request/response not recorded (payload capture was off for this request).')}
           {/if}
         </p>
+        <!-- Before rebuild: offer the button. On success transcriptLoaded flips and the
+             captured-path branch above renders the body in the normal Request view
+             (Chat/Raw + the same JsonViewer as any captured request). -->
         {#if data.payload?.reason === 'session_recovery_limited'}
-          {#if transcriptStatus === 'loaded'}
-            <!-- Reuse the same JsonViewer as a captured/recovered request body; the
-                 rebuilt transcript IS the request, so it needs no separate display. -->
-            <JsonViewer value={transcriptValue} testid="request-body" />
-          {:else}
-            <div class="mt-3 rounded border border-dashed border-border bg-canvas p-3">
-              <p class="field-help mb-2">
-                {$t('Rebuild the transcript in your browser instead of on the server.')}
-              </p>
-              <button
-                type="button"
-                data-testid="load-transcript"
-                class="btn-secondary"
-                disabled={transcriptStatus === 'loading'}
-                onclick={loadTranscript}
-                >{transcriptStatus === 'loading'
-                  ? $t('Loading')
-                  : $t('Load transcript')}</button
-              >
-              {#if transcriptError}
-                <p class="mt-2 text-sm text-red-600">{transcriptError}</p>
-              {/if}
-            </div>
-          {/if}
+          <div class="mt-3 rounded border border-dashed border-border bg-canvas p-3">
+            <p class="field-help mb-2">
+              {$t('Rebuild the transcript in your browser instead of on the server.')}
+            </p>
+            <button
+              type="button"
+              data-testid="load-transcript"
+              class="btn-secondary"
+              disabled={payloadStatus.request === 'loading'}
+              onclick={loadTranscript}
+              >{payloadStatus.request === 'loading'
+                ? $t('Loading')
+                : $t('Load transcript')}</button
+            >
+            {#if payloadErrors.request}
+              <p class="mt-2 text-sm text-red-600">{payloadErrors.request}</p>
+            {/if}
+          </div>
         {/if}
       {/if}
     </section>

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -703,15 +703,17 @@ describe('requests detail page', () => {
       },
     });
 
-    // Not loaded up front — the button is present, no request body yet.
+    // Not loaded up front — the button is present, the normal request lenses are not.
     expect(rebuildSessionTranscript).not.toHaveBeenCalled();
-    expect(screen.queryByTestId('request-body')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('request-view-raw')).not.toBeInTheDocument();
     await fireEvent.click(screen.getByTestId('load-transcript'));
-
-    // Rebuilt transcript renders through the SAME request-body JsonViewer as a
-    // captured/recovered request — no separate viewer.
-    expect(await screen.findByTestId('request-body')).toHaveTextContent(/"model": "auto"/);
     expect(rebuildSessionTranscript).toHaveBeenCalledWith('tr_big');
+
+    // After rebuild the whole Request section renders through the SAME captured-path
+    // lenses (Chat/Raw) — the rebuilt body is in the normal request slot, no separate
+    // viewer. Switch to Raw and assert the standard request-body JsonViewer shows it.
+    await fireEvent.click(await screen.findByTestId('request-view-raw'));
+    expect(await screen.findByTestId('request-body')).toHaveTextContent(/"model": "auto"/);
   });
 
   // A 1×1 PNG (bare base64) — the form a generated/input image takes inside a body.

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -366,14 +366,16 @@ test.describe("admin request payload view", () => {
     await expect(page.getByTestId("payload-summary")).toContainText(
       /too large to rebuild on the server/i,
     );
-    // The server-side payload-part buttons stay absent; the client rebuild is offered,
-    // and nothing renders in the request-body viewer until the button is clicked.
+    // The server-side payload-part buttons and the normal request lenses stay absent
+    // until the rebuild button is clicked.
     await expect(page.getByTestId("load-conversation")).toHaveCount(0);
     await expect(page.getByTestId("load-request-body")).toHaveCount(0);
-    await expect(page.getByTestId("request-body")).toHaveCount(0);
+    await expect(page.getByTestId("request-view-raw")).toHaveCount(0);
 
     await page.getByTestId("load-transcript").click();
-    // Rebuilt transcript renders through the SAME request-body JsonViewer.
+    // After rebuild the whole Request section renders through the SAME captured-path
+    // lenses; switch to Raw and assert the standard request-body JsonViewer shows it.
+    await page.getByTestId("request-view-raw").click();
     await expect(page.getByTestId("request-body")).toContainText("rebuilt-in-browser");
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.55",
+  "version": "0.28.56",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## 问题（Lukin 反馈：上次没改好）

上次只改了 testid，重建的转录**还是渲染在一个独立的第二个 JsonViewer 里**（在「请求元数据」块下面），不是真正的 Request 视图。

## 真正的复用

客户端重建成功后，把结果写进**正常的 request 槽**（`payloadValues.request`）并翻 `transcriptLoaded` 标志 → 整个 Request 区当作「已捕获请求」渲染，走**完全相同的 Conversation / Raw 双视图 + 标准 request-body JsonViewer**。「Load transcript」按钮留在原位；独立的第二个 viewer 及其块全部删除。

## 已用截图确认

点击后 Request 卡片显示「Conversation / Raw」切换 + 转录恢复提示条 + 把消息当正常对话渲染（`User: rebuilt-in-browser`），和一个正常捕获的请求一模一样。

svelte-check / lint / admin 单测(53) / e2e 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)