### PR TITLE
fix(oauth): track exact quota reset periods

### DIFF
--- a/apps/admin/src/lib/api/oauth.ts
+++ b/apps/admin/src/lib/api/oauth.ts
@@ -249,7 +249,7 @@ export async function getOAuthQuota(): Promise<OAuthQuotaSnapshot[]> {
 export type OAuthUsagePeriod = SharedOAuthUsagePeriod;
 export type OAuthUsagePeriods = SharedOAuthUsagePeriods;
 
-const EMPTY_PERIODS: OAuthUsagePeriods = { current: [], daily: [], weekly: [] };
+const EMPTY_PERIODS: OAuthUsagePeriods = { current: [], periods: [], daily: [], weekly: [] };
 
 // GET /oauth/usage/periods -> the account-detail page: current reset-period summary +
 // natural day/week history (bucketed in the viewer's local tz). FAIL-OPEN: any failure

--- a/apps/admin/src/routes/providers/[accountId]/+page.svelte
+++ b/apps/admin/src/routes/providers/[accountId]/+page.svelte
@@ -51,7 +51,7 @@
   const windowKeys = $derived.by(() => {
     const seen = new Set<string>();
     const keys: string[] = [];
-    for (const p of data.periods.current) {
+    for (const p of [...data.periods.current, ...data.periods.periods]) {
       if (!seen.has(p.windowKey)) {
         seen.add(p.windowKey);
         keys.push(p.windowKey);
@@ -83,11 +83,14 @@
     return data.periods.current.find((p) => p.windowKey === activeKey) ?? null;
   });
 
-  // History granularity toggle: natural DAYS or WEEKS (local tz), account-wide. Default
-  // to daily — the accounts here can burn billions of tokens in a day, so per-day best
-  // surfaces a spike or a provider quietly cutting the allowance.
-  let granularity = $state<'day' | 'week'>('day');
-  const history = $derived(granularity === 'day' ? data.periods.daily : data.periods.weekly);
+  let granularity = $state<'period' | 'day' | 'week'>('period');
+  const history = $derived.by(() =>
+    granularity === 'period'
+      ? data.periods.periods.filter((p) => p.windowKey === activeKey)
+      : granularity === 'day'
+        ? data.periods.daily
+        : data.periods.weekly,
+  );
 
   // Bar-chart data (oldest → newest so the trend reads left-to-right).
   const trend = $derived([...history].reverse());
@@ -117,6 +120,9 @@
   // doesn't imply a full Mon–Sun span that hasn't happened yet.
   function periodLabel(p: OAuthUsagePeriod): string {
     const start = new Date(p.periodStartMs);
+    if (granularity === 'period') {
+      return `${start.toLocaleString()} – ${new Date(p.periodEndMs).toLocaleString()}`;
+    }
     if (granularity === 'day') return start.toLocaleDateString();
     const endMs = Math.min(p.periodEndMs, Date.now());
     const end = new Date(endMs - 1); // inclusive last day
@@ -132,7 +138,7 @@
       <code class="font-mono text-sm text-ink-muted">{data.providerId}</code>
     </div>
     <p class="mt-1 text-sm text-ink-muted">
-      {$t('Current quota window usage, plus token history by calendar day or week.')}
+      {$t('Token usage per quota reset period. Periods marked ≈ have approximate boundaries.')}
     </p>
   </header>
 
@@ -164,7 +170,11 @@
     <!-- (a) Current reset-window summary — the real resetsAtMs boundary, exact. -->
     <section class="mb-6">
       <div class="mb-2 flex items-baseline justify-between">
-        <h2 class="section-header">{$t('Current period')}</h2>
+        <h2 class="section-header">
+          {$t('Current period')}
+          {#if currentPeriod?.approximate}<span class="text-xs text-ink-muted">≈</span>{/if}
+          {#if currentPeriod?.partial}<span class="text-xs text-amber-600">{$t('(partial)')}</span>{/if}
+        </h2>
         {#if quotaWindow && !snapshotStale && resetIn(quotaWindow.resetsAtMs)}
           <span class="text-sm text-ink-muted"
             >{$t('resets in {t}', { t: resetIn(quotaWindow.resetsAtMs) })}</span
@@ -227,13 +237,15 @@
     </section>
     {/if}
 
-    <!-- History: token usage by NATURAL calendar day/week (exact, account-wide). This
-         replaces reset-period slicing — real reset windows drift and get cut short by
-         reset-credit, so calendar buckets are the honest way to spot a spike or a
-         shrinking allowance. -->
+    <!-- Reset periods are primary; natural day/week remain as compatibility views. -->
     <div class="mb-3 flex items-center justify-between">
       <h2 class="section-header">{$t('Usage history')}</h2>
       <div class="flex gap-1" role="tablist">
+        <button
+          type="button"
+          class={granularity === 'period' ? 'btn-primary' : 'btn-secondary'}
+          onclick={() => (granularity = 'period')}>{$t('Period')}</button
+        >
         <button
           type="button"
           class={granularity === 'day' ? 'btn-primary' : 'btn-secondary'}
@@ -273,7 +285,13 @@
       <table class="cards-table">
         <thead class="table-head">
           <tr>
-            <th class="px-3 py-2 text-left">{granularity === 'day' ? $t('Day') : $t('Week')}</th>
+            <th class="px-3 py-2 text-left">
+              {granularity === 'period'
+                ? $t('Period')
+                : granularity === 'day'
+                  ? $t('Day')
+                  : $t('Week')}
+            </th>
             <th class="px-3 py-2 text-right">{$t('Requests')}</th>
             <th class="px-3 py-2 text-right">{$t('Tokens')}</th>
             <th class="px-3 py-2 text-right">{$t('Cost')}</th>
@@ -282,8 +300,11 @@
         <tbody>
           {#each history as p (p.periodStartMs)}
             <tr>
-              <td data-label={granularity === 'day' ? $t('Day') : $t('Week')} class="px-3 py-2">
+              <td data-label={$t('Period')} class="px-3 py-2">
                 {periodLabel(p)}
+                {#if p.approximate}
+                  <span class="ml-1 text-xs text-ink-muted">≈</span>
+                {/if}
                 {#if p.partial}
                   <span class="ml-1 text-xs text-amber-600">{$t('(partial)')}</span>
                 {/if}

--- a/apps/gateway/src/oauth/quota-reset-period.test.ts
+++ b/apps/gateway/src/oauth/quota-reset-period.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { recordObservedQuotaResetPeriods } from "./quota-reset-period.js";
+
+describe("recordObservedQuotaResetPeriods", () => {
+  it("ignores an observation older than the stored quota snapshot", async () => {
+    const record = vi.fn(async () => {});
+    await recordObservedQuotaResetPeriods({
+      quotaStore: {
+        get: vi.fn(async () => ({
+          providerId: "openai-codex",
+          account: "a",
+          windows: [{ key: "7d", usedPercent: 90, resetsAtMs: 700, windowMinutes: 10_080 }],
+          capturedAt: 200,
+          source: "codex",
+          usageLimitedUntilMs: null,
+        })),
+      } as never,
+      periodStore: { record } as never,
+      providerId: "openai-codex",
+      account: "a",
+      windows: [{ key: "7d", usedPercent: 0, resetsAtMs: 800, windowMinutes: 10_080 }],
+      observedAtMs: 100,
+    });
+    expect(record).not.toHaveBeenCalled();
+  });
+});

--- a/apps/gateway/src/oauth/quota-reset-period.ts
+++ b/apps/gateway/src/oauth/quota-reset-period.ts
@@ -1,0 +1,61 @@
+import type { OAuthQuotaStore, OAuthResetPeriodStore } from "@helm/core";
+import { detectQuotaResetPeriods, windowMinutesForKey } from "@helm/core";
+import { type OAuthQuotaWindow, selectCodexAccountWeeklyQuotaWindows } from "@helm/shared";
+
+export async function recordObservedQuotaResetPeriods(input: {
+  quotaStore: OAuthQuotaStore;
+  periodStore?: OAuthResetPeriodStore;
+  providerId: string;
+  account: string;
+  windows: OAuthQuotaWindow[];
+  observedAtMs: number;
+}): Promise<void> {
+  if (!input.periodStore) return;
+  const previous = await input.quotaStore.get(input.providerId, input.account).catch(() => null);
+  if (!previous || previous.capturedAt > input.observedAtMs) return;
+  const periods = detectQuotaResetPeriods({
+    providerId: input.providerId,
+    account: input.account,
+    previous: previous.windows,
+    next: input.windows,
+    observedAtMs: input.observedAtMs,
+  });
+  await Promise.all(periods.map((period) => input.periodStore?.record(period).catch(() => {})));
+}
+
+export async function recordQuotaResetCreditPeriods(input: {
+  periodStore?: OAuthResetPeriodStore;
+  providerId: "openai-codex";
+  account: string;
+  windows: OAuthQuotaWindow[];
+  occurredAtMs: number;
+}): Promise<void> {
+  if (!input.periodStore) return;
+  const windows = selectCodexAccountWeeklyQuotaWindows(input.windows);
+  await Promise.all(
+    windows.map(async (window) => {
+      if (window.resetsAtMs === null) return;
+      const minutes = windowMinutesForKey(window.key, window.windowMinutes);
+      if (minutes === null) return;
+      const inferredStart = window.resetsAtMs - minutes * 60_000;
+      const latestResetAt =
+        typeof input.periodStore?.latestResetAt === "function"
+          ? await input.periodStore
+              .latestResetAt(input.providerId, input.account, input.occurredAtMs, window.key)
+              .catch(() => null)
+          : null;
+      const periodStartMs = Math.max(inferredStart, latestResetAt ?? Number.NEGATIVE_INFINITY);
+      if (periodStartMs >= input.occurredAtMs) return;
+      await input.periodStore
+        ?.record({
+          providerId: input.providerId,
+          account: input.account,
+          windowKey: window.key,
+          periodStartMs,
+          periodEndMs: input.occurredAtMs,
+          detectedAtMs: input.occurredAtMs,
+        })
+        .catch(() => {});
+    }),
+  );
+}

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -555,6 +555,13 @@ export interface AdminApiDeps {
     capturedAtMs: number,
     rateLimitReachedType: CodexRateLimitReachedType | null,
   ) => Promise<boolean>;
+  onCodexQuotaResetConsumed?: (
+    providerId: "openai-codex",
+    account: string,
+    windows: OAuthQuotaWindow[],
+    mode: "manual" | "auto",
+    occurredAtMs: number | null,
+  ) => Promise<void>;
   // Durable OAuth credential failure. A refresh 400/401/403 or persistent upstream
   // 401/403 means the account needs reconnecting, not just a short cooldown. The
   // gateway persists that state and rebuilds the pool so admin status and routing agree.

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -217,15 +217,34 @@ describe("admin OAuth routes — read endpoints", () => {
         resetCredits: null,
       })),
     } as unknown as AdminApiDeps["oauthQuota"];
+    const oauthResetPeriod = {
+      queryPeriods: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "a@x.com",
+          windowKey: "5h",
+          periodStartMs: reset - 10 * HOUR,
+          periodEndMs: reset - 5 * HOUR,
+          detectedAtMs: reset - 5 * HOUR,
+        },
+      ]),
+    } as unknown as AdminApiDeps["oauthResetPeriod"];
     const settings = {
       get: () => ({ oauth_usage_retention_days: 180 }),
     } as unknown as AdminApiDeps["settings"];
-    const res = await app({ oauth: fullSeam(), oauthUsage, oauthQuota, settings }).request(
+    const res = await app({
+      oauth: fullSeam(),
+      oauthUsage,
+      oauthQuota,
+      oauthResetPeriod,
+      settings,
+    }).request(
       "/admin/api/oauth/usage/periods?provider=anthropic&account=a%40x.com&tzOffsetMinutes=0",
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       current: Array<{ windowKey: string; tokens: number }>;
+      periods: Array<{ windowKey: string; periodStartMs: number; periodEndMs: number }>;
       daily: Array<{
         windowKey: string;
         tokens: number;
@@ -239,6 +258,12 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(body.current).toHaveLength(1);
     expect(body.current[0]?.windowKey).toBe("5h");
     expect(body.current[0]?.tokens ?? 0).toBeGreaterThan(0);
+    expect(oauthResetPeriod?.queryPeriods).toHaveBeenCalledWith("anthropic", "a@x.com", "5h", 53);
+    expect(body.periods[0]).toMatchObject({
+      windowKey: "5h",
+      periodStartMs: reset - 10 * HOUR,
+      periodEndMs: reset - 5 * HOUR,
+    });
     // daily: natural-day buckets, most recent first, each a 24h span, windowKey "day".
     expect(body.daily.length).toBeGreaterThanOrEqual(2);
     expect(body.daily[0]?.windowKey).toBe("day");
@@ -268,7 +293,7 @@ describe("admin OAuth routes — read endpoints", () => {
       "/admin/api/oauth/usage/periods?provider=xai&account=nobody",
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ current: [], daily: [], weekly: [] });
+    expect(await res.json()).toEqual({ current: [], periods: [], daily: [], weekly: [] });
   });
 
   it("GET /oauth/quota returns cached rows without pulling upstream", async () => {
@@ -465,7 +490,7 @@ describe("admin OAuth routes — read endpoints", () => {
     });
   });
 
-  it("POST /oauth/refresh records a reset-period boundary when resetsAtMs advances", async () => {
+  it("POST /oauth/refresh records the period that actually ended when resetsAtMs advances", async () => {
     const now = Date.now();
     const oldReset = now - 86_400_000; // yesterday
     const newReset = now + 6 * 86_400_000; // next week
@@ -505,8 +530,55 @@ describe("admin OAuth routes — read endpoints", () => {
         providerId: "xai",
         account: "subscription",
         windowKey: "7d",
-        periodStartMs: oldReset,
-        periodEndMs: newReset,
+        periodStartMs: oldReset - 7 * 86_400_000,
+        periodEndMs: oldReset,
+      }),
+    );
+  });
+
+  it("POST /oauth/refresh records an upstream early reset before the old deadline", async () => {
+    const now = Date.now();
+    const week = 7 * 86_400_000;
+    const oldReset = now + 2 * 86_400_000;
+    const newReset = now + week;
+    const oldStart = oldReset - week;
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "openai-codex",
+        account: "subscription",
+        windows: [{ key: "7d", usedPercent: 73, resetsAtMs: oldReset, windowMinutes: 10_080 }],
+        capturedAt: now - 1_000,
+        source: "codex",
+        usageLimitedUntilMs: null,
+        resetCredits: 1,
+      })),
+      getAll: vi.fn(async () => []),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const oauthResetPeriod = {
+      record: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthResetPeriod"];
+    const seam = fullSeam({
+      listStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [{ id: "openai-codex", name: "Codex", accounts: [{ account: "subscription" }] }],
+      })) as never,
+      fetchCodexQuota: vi.fn(async () => ({
+        windows: [{ key: "7d", usedPercent: 0, resetsAtMs: newReset, windowMinutes: 10_080 }],
+        resetCredits: 1,
+      })) as never,
+    });
+
+    await enqueueRefresh(app({ oauth: seam, oauthQuota, oauthResetPeriod }));
+
+    expect(oauthResetPeriod?.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "openai-codex",
+        account: "subscription",
+        windowKey: "7d",
+        periodStartMs: oldStart,
+        periodEndMs: expect.closeTo(now, -3),
       }),
     );
   });
@@ -1666,6 +1738,7 @@ describe("admin OAuth routes — reset credit", () => {
       redeemRequestId: "idem-1",
     }));
     const guard = allowResetCredit();
+    const onCodexQuotaResetConsumed = vi.fn(async () => {});
     const seam = fullSeam({
       fetchCodexQuota: vi.fn(async () => ({
         windows: codexWindows(100),
@@ -1681,6 +1754,7 @@ describe("admin OAuth routes — reset credit", () => {
       oauth: seam,
       oauthQuota: quotaStore(),
       resetCreditGuard: guard,
+      onCodexQuotaResetConsumed,
     }).request("/admin/api/oauth/openai-codex/reset-credit", {
       method: "POST",
       headers: JSONH,
@@ -1713,6 +1787,13 @@ describe("admin OAuth routes — reset credit", () => {
     });
     expect(guard.commit).toHaveBeenCalledOnce();
     expect(guard.rollback).not.toHaveBeenCalled();
+    expect(onCodexQuotaResetConsumed).toHaveBeenCalledWith(
+      "openai-codex",
+      "default",
+      expect.arrayContaining([expect.objectContaining({ key: "secondary" })]),
+      "manual",
+      expect.any(Number),
+    );
   });
 
   it.each([
@@ -1721,6 +1802,7 @@ describe("admin OAuth routes — reset credit", () => {
     ["already_redeemed", "alreadyRedeemed", true],
   ] as const)("200 preserves the %s reset-credit outcome", async (code, outcome, consumed) => {
     const guard = allowResetCredit();
+    const onCodexQuotaResetConsumed = vi.fn(async () => {});
     const seam = fullSeam({
       fetchCodexQuota: vi.fn(async () => ({
         windows: codexWindows(100),
@@ -1742,6 +1824,7 @@ describe("admin OAuth routes — reset credit", () => {
       oauth: seam,
       oauthQuota: quotaStore(codexWindows(100)),
       resetCreditGuard: guard,
+      onCodexQuotaResetConsumed,
     }).request("/admin/api/oauth/openai-codex/reset-credit", {
       method: "POST",
       headers: JSONH,
@@ -1752,6 +1835,16 @@ describe("admin OAuth routes — reset credit", () => {
     expect(await res.json()).toMatchObject({ code, outcome, windowsReset: 0 });
     expect(guard.commit).toHaveBeenCalledTimes(consumed ? 1 : 0);
     expect(guard.rollback).toHaveBeenCalledTimes(consumed ? 0 : 1);
+    expect(onCodexQuotaResetConsumed).toHaveBeenCalledTimes(consumed ? 1 : 0);
+    if (consumed) {
+      expect(onCodexQuotaResetConsumed).toHaveBeenCalledWith(
+        "openai-codex",
+        "default",
+        expect.any(Array),
+        "manual",
+        null,
+      );
+    }
   });
 
   it("passes an explicit account through to the seam", async () => {
@@ -2319,12 +2412,15 @@ describe("admin OAuth routes — POST /oauth/:provider/reset (Reset usage)", () 
 
   it("204 and clears the cooldown (untilMs null) for the default account", async () => {
     const applyUsageLimit = vi.fn(async () => {});
-    const res = await app({ oauth: fullSeam(), applyUsageLimit }).request(
-      "/admin/api/oauth/openai-codex/reset",
-      { method: "POST" },
-    );
+    const onCodexQuotaResetConsumed = vi.fn(async () => {});
+    const res = await app({
+      oauth: fullSeam(),
+      applyUsageLimit,
+      onCodexQuotaResetConsumed,
+    }).request("/admin/api/oauth/openai-codex/reset", { method: "POST" });
     expect(res.status).toBe(204);
     expect(applyUsageLimit).toHaveBeenCalledWith("openai-codex", "default", null);
+    expect(onCodexQuotaResetConsumed).not.toHaveBeenCalled();
   });
 
   it("rejects Anthropic reset because Claude usage windows are not resettable", async () => {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -3,7 +3,6 @@ import {
   computeUsagePeriods,
   filterRetiredOpenAICodexLimits,
   GROK_OAUTH_MEDIA_MODELS,
-  windowMinutesForKey,
   windowsToActiveUsageRecovery,
   windowsToUsageLimit,
 } from "@helm/core";
@@ -23,6 +22,7 @@ import {
   isPermanentOAuthCredentialFailure,
   oauthCredentialFailureReason,
 } from "../../oauth/credential-failure.js";
+import { recordObservedQuotaResetPeriods } from "../../oauth/quota-reset-period.js";
 import type {
   AccountProxyInput,
   AdminApiDeps,
@@ -240,12 +240,12 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   // silently shrinking an allowance (per-period token totals trending down). Token
   // totals are exact; historical boundaries are approximate (rolled back a fixed
   // window length — flagged per period). Cache-only + FAIL-OPEN: any gap → empty.
-  const EMPTY_PERIODS = { current: [], daily: [], weekly: [] };
+  const EMPTY_PERIODS = { current: [], periods: [], daily: [], weekly: [] };
   const readPeriods = async (
     providerId: string,
     account: string,
     rawTz: unknown,
-  ): Promise<{ current: unknown[]; daily: unknown[]; weekly: unknown[] }> => {
+  ): Promise<{ current: unknown[]; periods: unknown[]; daily: unknown[]; weekly: unknown[] }> => {
     const usage = deps.oauthUsage;
     const quotaStore = deps.oauthQuota;
     if (!usage || !quotaStore) return EMPTY_PERIODS;
@@ -264,12 +264,27 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       // "this window has burned X so far" summary. limit 1: we only want the current one.
       const earliestBucketMs = buckets[0]?.bucketMs ?? now; // ascending → [0] is earliest
       const dataStartMs = Math.max(retentionFloorMs, earliestBucketMs);
-      const { current } = computeUsagePeriods({
+      const recordedBoundaries = Object.fromEntries(
+        await Promise.all(
+          snapshot.windows.map(async (window) => [
+            window.key,
+            (
+              await deps.oauthResetPeriod
+                ?.queryPeriods(providerId, account, window.key, 53)
+                .catch(() => [])
+            )
+              ?.filter((row) => row.detectedAtMs >= row.periodEndMs)
+              .map((row) => ({ startMs: row.periodStartMs, endMs: row.periodEndMs })) ?? [],
+          ]),
+        ),
+      );
+      const { current, periods } = computeUsagePeriods({
         windows: snapshot.windows,
         buckets,
         nowMs: now,
         dataStartMs,
-        limit: 1,
+        limit: 52,
+        recordedBoundaries,
       });
       // History: NATURAL calendar day/week in the admin's local tz — exact, honest, and
       // free of the reset-period drift/reset-credit distortion. A period is `partial`
@@ -283,7 +298,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         rows.map((r) =>
           r.periodStartMs < dataStartMs || r.periodEndMs > now ? { ...r, partial: true } : r,
         );
-      return { current, daily: markPartial(daily), weekly: markPartial(weekly) };
+      return { current, periods, daily: markPartial(daily), weekly: markPartial(weekly) };
     } catch {
       return EMPTY_PERIODS;
     }
@@ -326,56 +341,19 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       if (currentUntil === quotaUntil) return;
       await deps.applyUsageLimit(providerId, account, quotaUntil, "replace").catch(() => {});
     };
-    // Detect real reset boundaries by diffing the OLD snapshot against the NEW windows,
-    // per window key: when resetsAtMs advances (old and new both present, new > old), the
-    // window that ended at the old reset just closed — record [oldReset, newReset). Must
-    // run BEFORE store.upsert overwrites the snapshot. FAIL-OPEN: a missed record only
-    // leaves that span on the approximate path (never breaks the refresh).
-    //
-    // Only record a SINGLE-window advance. If the refresh lagged by 2+ windows (the
-    // reset jumped by a multiple of the window length), [oldReset, newReset) would span
-    // several real periods; recording that as one exact period would sum tokens across
-    // them and fake a huge/empty allowance — a false shrink signal. Oversized jumps are
-    // skipped and stay on the approximate path (grok review P2R-1).
     const recordResetBoundaries = async (
       providerId: string,
       account: string,
       newWindows: OAuthQuotaWindow[],
-    ): Promise<void> => {
-      const sink = deps.oauthResetPeriod;
-      if (!sink) return;
-      const prior = await store.get(providerId, account).catch(() => null);
-      if (!prior) return;
-      const nowMs = Date.now();
-      const oldByKey = new Map(
-        prior.windows.map(
-          (w) => [w.key, { resetsAtMs: w.resetsAtMs, windowMinutes: w.windowMinutes }] as const,
-        ),
-      );
-      for (const w of newWindows) {
-        const old = oldByKey.get(w.key);
-        const oldReset = old?.resetsAtMs;
-        if (oldReset == null || w.resetsAtMs == null || w.resetsAtMs <= oldReset) continue;
-        // Require the advance to be one window long (within half a window's tolerance).
-        const winMinutes = windowMinutesForKey(
-          w.key,
-          w.windowMinutes ?? old?.windowMinutes ?? null,
-        );
-        if (winMinutes === null) continue; // unknown length → can't validate a single step
-        const winMs = winMinutes * 60_000;
-        if (Math.abs(w.resetsAtMs - oldReset - winMs) > winMs / 2) continue; // multi-window jump → skip
-        await sink
-          .record({
-            providerId,
-            account,
-            windowKey: w.key,
-            periodStartMs: oldReset,
-            periodEndMs: w.resetsAtMs,
-            detectedAtMs: nowMs,
-          })
-          .catch(() => {});
-      }
-    };
+    ): Promise<void> =>
+      recordObservedQuotaResetPeriods({
+        quotaStore: store,
+        periodStore: deps.oauthResetPeriod,
+        providerId,
+        account,
+        windows: newWindows,
+        observedAtMs: Date.now(),
+      });
     if (s) {
       try {
         const status = await s.listStatus({ forceRefresh: true, serial: true });
@@ -804,6 +782,14 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
             ...(creditId === undefined ? {} : { creditId }),
             idempotencyKey: reservation.idempotencyKey,
           }),
+        onConsumed: (result) =>
+          deps.onCodexQuotaResetConsumed?.(
+            "openai-codex",
+            account,
+            windows,
+            "manual",
+            result.outcome === "reset" ? Date.now() : null,
+          ),
       });
       return c.json(result, 200);
     } catch (e) {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -193,6 +193,10 @@ import {
   createOAuthModelDiscoveryCache,
   type OAuthModelDiscoveryCache,
 } from "./oauth/model-discovery-cache.js";
+import {
+  recordObservedQuotaResetPeriods,
+  recordQuotaResetCreditPeriods,
+} from "./oauth/quota-reset-period.js";
 import { createResetCreditGuard, resetCreditGuardHash } from "./oauth/reset-credit-guard.js";
 import { createRealtimeCallRegistry, type RealtimeCallRegistry } from "./realtime-call-registry.js";
 import { createResponsesRegistry } from "./responses-registry.js";
@@ -2493,7 +2497,7 @@ export async function buildServer(
   });
 
   const maybeAutoReset = (
-    providerId: string,
+    providerId: "openai-codex",
     account: string,
     windows: OAuthQuotaWindow[],
     rateLimitReachedType: CodexRateLimitReachedType | null,
@@ -2561,29 +2565,13 @@ export async function buildServer(
                 code: r.code ?? null,
                 windows_reset: r.windowsReset ?? null,
               });
-              // The consume restored the shared window for EVERY sibling on this login — unpark
-              // them all (the trigger account included), or a sibling parked by its own
-              // saturated reply would stay out of rotation until its window's natural reset.
-              const codexAccounts = (await store.oauthTokens.list()).filter(
-                (t) => t.providerId === providerId,
+              await onCodexQuotaResetConsumed(
+                providerId,
+                account,
+                windows,
+                "auto",
+                r.outcome === "reset" ? Date.now() : null,
               );
-              const unparkResults = await Promise.allSettled(
-                codexAccounts.map(async (t) => {
-                  if ((await resolveCodexAccountKey(t.providerId, t.account)) === sharedKey) {
-                    await applyUsageLimit(t.providerId, t.account, null);
-                  }
-                }),
-              );
-              const unparkFailed = unparkResults.filter((x) => x.status === "rejected").length;
-              if (unparkFailed > 0) {
-                logger.log("error", "oauth.auto_reset.unpark_failed", {
-                  provider_id: providerId,
-                  account,
-                  guard: guardHash,
-                  failed_accounts: unparkFailed,
-                  redeem_request_id: r.redeemRequestId ?? null,
-                });
-              }
             },
           });
           if (!attempt.consumed) {
@@ -2638,6 +2626,84 @@ export async function buildServer(
       ?.setQuotaSnapshot(account, windows, capturedAtMs, resetCredits);
   };
 
+  async function onCodexQuotaResetConsumed(
+    providerId: "openai-codex",
+    account: string,
+    windows: OAuthQuotaWindow[],
+    mode: "manual" | "auto",
+    occurredAtMs: number | null,
+  ): Promise<void> {
+    const sharedKey = await resolveCodexAccountKey(providerId, account);
+    const connected = (await store.oauthTokens.list().catch(() => [])).filter(
+      (token) => token.providerId === providerId,
+    );
+    const siblings = new Set<string>([account]);
+    await Promise.all(
+      connected.map(async (token) => {
+        if ((await resolveCodexAccountKey(providerId, token.account)) === sharedKey) {
+          siblings.add(token.account);
+        }
+      }),
+    );
+
+    const results = await Promise.allSettled(
+      [...siblings].map(async (sibling) => {
+        const previous = await store.oauthQuota.get(providerId, sibling).catch(() => null);
+        if (occurredAtMs !== null) {
+          await recordQuotaResetCreditPeriods({
+            periodStore: store.oauthResetPeriod,
+            providerId,
+            account: sibling,
+            windows: previous?.windows.length
+              ? previous.windows
+              : sibling === account
+                ? windows
+                : [],
+            occurredAtMs,
+          });
+        }
+        await applyUsageLimit(providerId, sibling, null).catch(() => {});
+
+        const fresh = await oauthAdmin?.fetchCodexQuota?.({ account: sibling, force: true });
+        if (!fresh) return;
+        const freshWindows = filterRetiredOpenAICodexLimits(fresh.windows);
+        const capturedAt = Date.now();
+        await recordObservedQuotaResetPeriods({
+          quotaStore: store.oauthQuota,
+          periodStore: store.oauthResetPeriod,
+          providerId,
+          account: sibling,
+          windows: freshWindows,
+          observedAtMs: capturedAt,
+        });
+        await store.oauthQuota.upsert({
+          providerId,
+          account: sibling,
+          windows: freshWindows,
+          capturedAt,
+          source: "codex",
+          resetCredits: fresh.resetCredits,
+          planType: fresh.planType,
+          credits: fresh.credits,
+          resetCreditDetails: fresh.resetCreditDetails,
+          individualLimit: fresh.individualLimit,
+          additionalLimits: filterRetiredOpenAICodexLimits(fresh.additionalLimits),
+          rateLimitReachedType: fresh.rateLimitReachedType,
+        });
+        applyQuotaSnapshot(providerId, sibling, freshWindows, capturedAt, fresh.resetCredits);
+      }),
+    );
+    const failed = results.filter((result) => result.status === "rejected").length;
+    if (failed > 0) {
+      logger.log("warn", "oauth.reset_credit.post_consume_failed", {
+        provider_id: providerId,
+        account,
+        mode,
+        failed_accounts: failed,
+      });
+    }
+  }
+
   // Every AUTHORITATIVE fresh Codex snapshot must feed the same auto-reset path.
   // Header PUSHes and explicit upstream PULL refreshes are both fresh truth;
   // cache-only admin reads never call this hook. Without the PULL trigger, a 100%
@@ -2655,23 +2721,46 @@ export async function buildServer(
   // Codex quota-window scrape (providers page Tier 3): parse the `x-codex-*` headers
   // off each Codex reply and snapshot them per account. FAIL-OPEN — a parse/store
   // failure is swallowed (an observability scrape never breaks a served request).
+  const quotaObservationInFlight = new Map<string, Promise<void>>();
   const captureCodexQuota = (providerId: string, account: string, headers: Headers): void => {
     const nowMs = Date.now();
     const details = parseCodexQuotaHeaderDetails(headers, nowMs);
     const windows = details.windows;
     if (windows.length === 0) return; // no quota headers on this reply → nothing to store
     applyQuotaSnapshot(providerId, account, windows, nowMs);
-    backgroundTasks.run(
-      () =>
-        store.oauthQuota.upsert({
+    const observationKey = `${providerId}\u0000${account}`;
+    const previous = quotaObservationInFlight.get(observationKey) ?? Promise.resolve();
+    const task = previous
+      .catch(() => {})
+      .then(async () => {
+        await recordObservedQuotaResetPeriods({
+          quotaStore: store.oauthQuota,
+          periodStore: store.oauthResetPeriod,
+          providerId,
+          account,
+          windows,
+          observedAtMs: nowMs,
+        });
+        await store.oauthQuota.upsert({
           providerId,
           account,
           windows,
           capturedAt: nowMs,
           source: "codex-headers",
-        }),
+        });
+      });
+    quotaObservationInFlight.set(observationKey, task);
+    backgroundTasks.run(
+      () => task,
       () => logger.log("error", "oauth.quota.capture_failed", { provider_id: providerId }),
     );
+    void task
+      .finally(() => {
+        if (quotaObservationInFlight.get(observationKey) === task) {
+          quotaObservationInFlight.delete(observationKey);
+        }
+      })
+      .catch(() => {});
     // Auto-park when a window is saturated (≥100% with a future reset): the precise
     // long cooldown the 429 backstop can't know. Fire-and-forget (fail-open).
     const until = windowsToUsageLimit(windows, nowMs);
@@ -3427,15 +3516,22 @@ export async function buildServer(
     if (!servingAccount || !servedByAccount(servingAccount, servedAlias)) return;
     const nowMs = Date.now();
     backgroundTasks.run(
-      () =>
-        store.oauthUsage.record({
+      async () => {
+        await quotaObservationInFlight
+          .get(`${servingAccount.providerId}\u0000${servingAccount.account}`)
+          ?.catch(() => {});
+        const resetAt = await store.oauthResetPeriod
+          .latestResetAt(servingAccount.providerId, servingAccount.account, nowMs)
+          .catch(() => null);
+        await store.oauthUsage.record({
           providerId: servingAccount.providerId,
           account: servingAccount.account,
-          bucketMs: nowMs - (nowMs % 3_600_000),
+          bucketMs: Math.max(nowMs - (nowMs % 3_600_000), resetAt ?? 0),
           tokens: usage.tokens,
           costUsd: usage.costUsd,
           nowMs,
-        }),
+        });
+      },
       () =>
         logger.log("error", "oauth.usage.record_failed", {
           provider_id: servingAccount.providerId,
@@ -3653,6 +3749,7 @@ export async function buildServer(
       applyUsageLimit,
       applyQuotaSnapshot,
       onCodexQuotaSaturated,
+      onCodexQuotaResetConsumed,
       onOAuthCredentialFailure: markOAuthCredentialFailure,
     });
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-10 · 配额统计按真实重置点切分（OAuth quota / Admin providers，docs/04/11，原则 3/7）
+
+- **根因**：旧 writer 在 `resetsAtMs` 推进时写入 `[oldReset,newReset)`，把新周期误当成已结束历史；自然周 UI 又掩盖了 OpenAI 提前重置、reset-credit 重置和非整点边界，所以“每周”并不等于真实额度周期。
+- **实现**：复用既有 `oauth_reset_period`，统一记录刚结束的 `[previousStart,actualResetAt)`；PULL、Codex header PUSH、手动/自动 reset-credit 共用记录入口。quota snapshot 按 `capturedAt` 单调更新，晚到的旧采样既不覆盖新状态，也不写伪 reset。旧版 `detectedAtMs < periodEndMs` 行只在读取时忽略，不改写历史库；本地“Reset usage”仍只清 Helm cooldown，不冒充上游重置。
+- **精度边界**：usage 继续按小时聚合，但真实重置发生在小时中间时，新请求的 bucket 起点提升到最近 reset point，因此不会再跨边界混入上一周期。部署前已经落入旧整点 bucket 的历史数据不可逆，继续标 `≈`/`partial`；新记录到的真实边界作为精确周期返回。Admin 默认显示 Period，并保留 Daily / Weekly 兼容视图。
+
 ## 2026-08-10 · 大 Session 客户端重建按记录时间展示并提前停止分页（Admin / requests debug，docs/07/11，原则 1/3/7）
 
 - **现场与根因**：生产 v0.28.56 的目标详情点击后约 46 秒才完成，普通 Conversation 把重建后的请求 `input` 与最终响应折成一条聊天；现场原始 `input` 自身就是角色分段排列，因此 UI 没有再次排序，但这种折叠不能代表 Session 的真实请求/响应发生顺序。大 Session 客户端路径还丢弃了目标 revision 已保存的 `responseJson`，所以最终响应只能退化成脱敏 metadata。
@@ -87,16 +93,9 @@
 - **测试**：box 回归（`N>M` 首 + 兄弟 422 → 两候选都试、终态 400）；`context_length_exceeded` 变体同理；“更大窗口兄弟胜过 shaped 溢出”（不短路、fallback 成功）；“回显内容不伪造 400”（全链失败 → `all_providers_failed`）；per-model / 流式 / 多候选确认 / 近似估算不压真实故障用例全绿。execute.test.ts 164 全绿；messages/chat/gemini/responses/image-chain/pipeline 相关 239 全绿。
 - **遗留（本次不修）**：`xai/grok-4.5` 的 422 `invalid type: map, expected a sequence` 是独立的 anthropic→openai_responses 翻译缺陷；另开 change。
 
-## 2026-08-06 · HALF_OPEN 探测锁：释放路径 + 探针所有权令牌（Provider execution / circuit breaker，docs/02/04，原则 3/5）
-
-- **现场**：`anthropic/claude-opus-4-8` 连续数小时 `skip_reason=circuit_open`（0ms），同 Anthropic OAuth 池的 haiku/sonnet 仍正常；账号配额未 limited。请求 `5c27cf5d…` 正确 fallback 到 `openai-codex/gpt-5.6-sol`。
-- **根因 1（#698）**：`canAttempt` 在 cooldown 后置 `HALF_OPEN` 并持锁；随后路径故意不 `recordFailure`（OAuth 账号级 429/401/403、capability skip、`free_429` 等）也未 `recordAbort` → 锁永不释放。
-- **根因 2（#700 加固）**：无主的 `recordAbort(model)` 会释放**任意** in-flight probe。若 CLOSED 请求晚结束，而新 probe 已启动，旧 abort 会误清新 probe 的锁，或相反地形成竞态。
-- **修复**：`execute.ts` / `image-chain.ts` 在 allow 后 `settleBreaker` + `try/finally`（或等价显式 release）；`recordAbort(model, probeToken?)` 仅当 `probeToken` 与 entry 匹配时清锁；`canAttempt` 对 probe 返回 opaque `probeToken`。
-- **测试**：HALF_OPEN OAuth 429 / capability / free_429；breaker 单测「stale CLOSED abort 不释放新 probe」；image-chain invalid-request / capability 恢复。阈值仍 5 / 30s。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-06 · HALF_OPEN 探测锁释放与所有权令牌**：所有被允许的 provider/image 尝试都结算 breaker，HALF_OPEN abort 仅凭匹配的 probe token 释放对应探针，避免锁永久卡住或旧请求误清新探针；完整原文经 git history 回溯。
 - **2026-08-04 · per-key 请求内容存储覆盖优先级**：显式 `none`/`payload`/`session` 无条件覆盖实时全局设置，仅 `null`/`undefined` 继承；共享 capture helper 一处修复覆盖全部协议入口，完整原文经 git history 回溯。
 - **2026-08-04 · Codex 跨协议 fallback 修复**：可折叠 Responses items 走协议翻译，generic Responses 禁止 Codex 私有 passthrough，多账号池恢复 runtime profile；unknown/caller-linked/encrypted sub-agent items 继续 fail-closed，完整原文经 git history 回溯。
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -542,6 +542,7 @@ export {
   createSerializingClient,
   DEFAULT_429_COOLDOWN_MS,
   DEFAULT_OPENAI_CODEX_CLIENT_VERSION,
+  detectQuotaResetPeriods,
   discoverOAuthModels,
   expandOpenAICodexModelAliases,
   filterRetiredOpenAICodexLimits,

--- a/packages/core/src/provider/oauth/index.ts
+++ b/packages/core/src/provider/oauth/index.ts
@@ -132,6 +132,7 @@ export {
 export {
   type ComputeUsagePeriodsInput,
   computeUsagePeriods,
+  detectQuotaResetPeriods,
   type UsagePeriodsResult,
 } from "./usage-periods.js";
 export { ANTHROPIC_WINDOW_MINUTES, windowMinutesForKey } from "./window-minutes.js";

--- a/packages/core/src/provider/oauth/usage-periods.test.ts
+++ b/packages/core/src/provider/oauth/usage-periods.test.ts
@@ -1,6 +1,6 @@
 import type { OAuthQuotaWindow, OAuthUsageBucket, OAuthUsagePeriod } from "@helm/shared";
 import { describe, expect, it } from "vitest";
-import { computeUsagePeriods } from "./usage-periods.js";
+import { computeUsagePeriods, detectQuotaResetPeriods } from "./usage-periods.js";
 
 // Helper: the single current period for a given window key (the function returns an
 // array — one per anchorable window; tests below pass one window at a time mostly).
@@ -277,8 +277,8 @@ describe("computeUsagePeriods", () => {
       nowMs: now,
       dataStartMs: 0,
       limit: 3,
-      // endMs 106h > curStart 105h → must be ignored (would overlap current).
-      recordedBoundaries: { "5h": [{ startMs: 101 * HOUR, endMs: 106 * HOUR }] },
+      // endMs 108h is still in the FUTURE → it cannot be a completed reset period.
+      recordedBoundaries: { "5h": [{ startMs: 103 * HOUR, endMs: 108 * HOUR }] },
     });
     // No exact history period from the overlapping boundary; all history is approximate.
     expect(out.periods.every((p) => p.approximate)).toBe(true);
@@ -323,7 +323,7 @@ describe("computeUsagePeriods", () => {
     }
   });
 
-  it("marks a NON-hour-aligned recorded boundary as approximate (hour-bucket quantization)", () => {
+  it("treats a recorded non-hour reset as exact once usage buckets split at that reset", () => {
     const now = 107 * HOUR;
     const reset = 110 * HOUR; // current starts at 105h
     const bs = buckets(90 * HOUR, 17, 100);
@@ -336,8 +336,7 @@ describe("computeUsagePeriods", () => {
       limit: 2,
       recordedBoundaries: { "5h": [{ startMs: 100 * HOUR + 1_800_000, endMs: 105 * HOUR }] },
     });
-    // start not hour-aligned → approximate despite being a real recorded boundary
-    expect(out.periods[0]).toMatchObject({ periodEndMs: 105 * HOUR, approximate: true });
+    expect(out.periods[0]).toMatchObject({ periodEndMs: 105 * HOUR, approximate: false });
   });
 
   it("anchors the current period on a recorded boundary whose length differs from winMs", () => {
@@ -370,6 +369,33 @@ describe("computeUsagePeriods", () => {
     expect(out.periods[0]).toMatchObject({
       periodStartMs: 100 * HOUR,
       periodEndMs: 105 * HOUR + HALF,
+    });
+  });
+
+  it("anchors current usage after an early reset that closed the prior period", () => {
+    const reset = 110 * HOUR;
+    const now = 107 * HOUR;
+    const earlyResetAt = 106 * HOUR;
+    const out = computeUsagePeriods({
+      windows: [win("5h", reset, null)],
+      buckets: buckets(95 * HOUR, 12, 100),
+      nowMs: now,
+      dataStartMs: 0,
+      limit: 2,
+      recordedBoundaries: {
+        "5h": [{ startMs: 101 * HOUR, endMs: earlyResetAt }],
+      },
+    });
+
+    expect(currentFor(out, "5h")).toMatchObject({
+      periodStartMs: earlyResetAt,
+      periodEndMs: now,
+      tokens: 100,
+    });
+    expect(out.periods[0]).toMatchObject({
+      periodStartMs: 101 * HOUR,
+      periodEndMs: earlyResetAt,
+      approximate: false,
     });
   });
 
@@ -437,5 +463,55 @@ describe("computeUsagePeriods", () => {
     }
     // And no period ends above the current period's start (105h).
     expect(out.periods.every((p) => p.periodEndMs <= 105 * HOUR)).toBe(true);
+  });
+});
+
+describe("detectQuotaResetPeriods", () => {
+  const WEEK = 7 * 24 * HOUR;
+
+  it("records the period that ended when the provider advances the deadline", () => {
+    const observedAtMs = 20 * WEEK + HOUR;
+    const oldReset = 20 * WEEK;
+    expect(
+      detectQuotaResetPeriods({
+        providerId: "openai-codex",
+        account: "a",
+        previous: [win("7d", oldReset, 10_080)],
+        next: [win("7d", oldReset + WEEK, 10_080)],
+        observedAtMs,
+      }),
+    ).toEqual([expect.objectContaining({ periodStartMs: oldReset - WEEK, periodEndMs: oldReset })]);
+  });
+
+  it("records an early provider reset at the observed new-window start", () => {
+    const observedAtMs = 20 * WEEK;
+    const oldReset = observedAtMs + 2 * 24 * HOUR;
+    expect(
+      detectQuotaResetPeriods({
+        providerId: "openai-codex",
+        account: "a",
+        previous: [{ ...win("7d", oldReset, 10_080), usedPercent: 73 }],
+        next: [{ ...win("7d", observedAtMs + WEEK, 10_080), usedPercent: 0 }],
+        observedAtMs,
+      }),
+    ).toEqual([
+      expect.objectContaining({ periodStartMs: oldReset - WEEK, periodEndMs: observedAtMs }),
+    ]);
+  });
+
+  it("records a reset when usage drops even if the provider keeps the same deadline", () => {
+    const observedAtMs = 20 * WEEK;
+    const reset = observedAtMs + 2 * 24 * HOUR;
+    expect(
+      detectQuotaResetPeriods({
+        providerId: "openai-codex",
+        account: "a",
+        previous: [{ ...win("7d", reset, 10_080), usedPercent: 91 }],
+        next: [{ ...win("7d", reset, 10_080), usedPercent: 4 }],
+        observedAtMs,
+      }),
+    ).toEqual([
+      expect.objectContaining({ periodStartMs: reset - WEEK, periodEndMs: observedAtMs }),
+    ]);
   });
 });

--- a/packages/core/src/provider/oauth/usage-periods.ts
+++ b/packages/core/src/provider/oauth/usage-periods.ts
@@ -1,8 +1,59 @@
-import type { OAuthQuotaWindow, OAuthUsageBucket, OAuthUsagePeriod } from "@helm/shared";
+import type {
+  OAuthQuotaWindow,
+  OAuthResetPeriod,
+  OAuthUsageBucket,
+  OAuthUsagePeriod,
+} from "@helm/shared";
 import { windowMinutesForKey } from "./window-minutes.js";
 
 const MINUTE_MS = 60_000;
 const HOUR_MS = 3_600_000;
+const RESET_JITTER_MS = 30 * MINUTE_MS;
+
+export function detectQuotaResetPeriods(input: {
+  providerId: string;
+  account: string;
+  previous: OAuthQuotaWindow[];
+  next: OAuthQuotaWindow[];
+  observedAtMs: number;
+}): OAuthResetPeriod[] {
+  const oldByKey = new Map(input.previous.map((window) => [window.key, window] as const));
+  const periods: OAuthResetPeriod[] = [];
+
+  for (const next of input.next) {
+    const previous = oldByKey.get(next.key);
+    if (previous?.resetsAtMs == null || next.resetsAtMs == null) continue;
+    const oldMinutes = windowMinutesForKey(previous.key, previous.windowMinutes);
+    const nextMinutes = windowMinutesForKey(next.key, next.windowMinutes);
+    if (oldMinutes === null || nextMinutes === null) continue;
+
+    const oldStart = previous.resetsAtMs - oldMinutes * MINUTE_MS;
+    const nextStart = next.resetsAtMs - nextMinutes * MINUTE_MS;
+    const resetDeadlineAdvanced = next.resetsAtMs - previous.resetsAtMs > RESET_JITTER_MS;
+    const usageDropped = next.usedPercent + 1 < previous.usedPercent;
+    const resetAtMs = resetDeadlineAdvanced ? nextStart : usageDropped ? input.observedAtMs : null;
+    if (
+      resetAtMs === null ||
+      resetAtMs <= oldStart ||
+      resetAtMs > input.observedAtMs + RESET_JITTER_MS
+    ) {
+      continue;
+    }
+
+    const maxWindowMs = Math.max(oldMinutes, nextMinutes) * MINUTE_MS;
+    if (resetAtMs - oldStart > maxWindowMs * 1.5) continue;
+    periods.push({
+      providerId: input.providerId,
+      account: input.account,
+      windowKey: next.key,
+      periodStartMs: oldStart,
+      periodEndMs: resetAtMs,
+      detectedAtMs: input.observedAtMs,
+    });
+  }
+
+  return periods;
+}
 
 export interface ComputeUsagePeriodsInput {
   // The account's current quota windows (each names a reset cadence: 5h / 7d / ...).
@@ -23,10 +74,8 @@ export interface ComputeUsagePeriodsInput {
   recordedBoundaries?: Record<string, Array<{ startMs: number; endMs: number }>>;
 }
 
-// A period's boundary is "exact" only when it comes from a real upstream resetsAtMs
-// AND lands on an hour floor — because usage lives in whole UTC-hour buckets, a
-// mid-hour boundary can mis-bin up to one hour of tokens on each side, so those
-// totals are approximate too (grok review: current mustn't claim exactness it lacks).
+// Cadence-derived boundaries are exact only on an hour floor. Recorded reset points can
+// be exact at any timestamp because the writer starts a new sub-hour usage bucket there.
 function isHourAligned(ms: number): boolean {
   return ms % HOUR_MS === 0;
 }
@@ -117,17 +166,23 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
       curStart = openRow.startMs;
       curBoundaryReal = true; // start came from a real recorded boundary
       recIdx++;
+    } else if (openRow && openRow.endMs <= nowMs && openRow.endMs > curStart) {
+      // A provider/reset-credit can cut a window short without changing its next reset
+      // deadline. The newest CLOSED period then ends at the real reset point inside the
+      // cadence-derived current span; start current usage there.
+      curStart = openRow.endMs;
+      curBoundaryReal = true;
     }
 
     // Current: [curStart, min(reset, now)). Exact only when the START boundary is a
-    // confirmed reset (not advanced) AND hour-aligned — hour-bucket quantization makes a
-    // mid-hour START approximate. curEnd is `now`, a LIVE cap on an in-progress period,
+    // confirmed reset (not advanced). A recorded mid-hour start is exact because usage
+    // buckets split there. curEnd is `now`, a LIVE cap on an in-progress period,
     // not a period-grid cut, so its (almost never hour-aligned) value must NOT force the
     // period approximate — else current would be ≈ forever and defeat phase 2 (grok
     // review P2R3-1). A real recorded curStart still needs hour-alignment.
     const curEnd = Math.min(reset, nowMs);
     const curExact =
-      !boundaryAdvanced && (curBoundaryReal || isHourAligned(reset)) && isHourAligned(curStart);
+      !boundaryAdvanced && (curBoundaryReal || (isHourAligned(reset) && isHourAligned(curStart)));
     if (curEnd > curStart) {
       const sums = sumWindow(buckets, curStart, curEnd);
       current.push({
@@ -165,7 +220,7 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
       // start is strictly older — its real start becomes the next cursor.
       if (rec && cursor - rec.endMs <= tol && rec.startMs < cursor) {
         start = rec.startMs;
-        approximate = !(isHourAligned(rec.startMs) && isHourAligned(rec.endMs));
+        approximate = false;
         recIdx++;
       } else {
         start = cursor - winMs;

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -1385,6 +1385,14 @@ export interface OAuthResetPeriodStore {
     windowKey: string,
     limit: number,
   ): Promise<OAuthResetPeriod[]>;
+  // Latest trustworthy reset point at/before `beforeMs`. Legacy rows from the old
+  // [oldReset,newReset) writer have detectedAtMs < periodEndMs and are ignored.
+  latestResetAt(
+    providerId: string,
+    account: string,
+    beforeMs: number,
+    windowKey?: string,
+  ): Promise<number | null>;
 }
 
 export interface OAuthTokenStore {

--- a/packages/core/src/store/postgres/oauth-quota.test.ts
+++ b/packages/core/src/store/postgres/oauth-quota.test.ts
@@ -16,6 +16,14 @@ const snap = (over: Partial<OAuthQuotaSnapshot> = {}): OAuthQuotaSnapshot => ({
 });
 
 describe("PgOAuthQuotaStore (pglite)", () => {
+  it("ignores a snapshot captured before the stored snapshot", async () => {
+    const db: PgDb = await createPgliteDb();
+    const store = new PgOAuthQuotaStore(db);
+    await store.upsert(snap({ capturedAt: 999, windows: [] }));
+    await store.upsert(snap({ capturedAt: 500 }));
+    expect(await store.get("openai-codex", "a")).toMatchObject({ capturedAt: 999, windows: [] });
+  });
+
   it("round-trips Codex live metadata and preserves it when a header snapshot omits it", async () => {
     const db: PgDb = await createPgliteDb();
     const store = new PgOAuthQuotaStore(db);

--- a/packages/core/src/store/postgres/oauth-quota.ts
+++ b/packages/core/src/store/postgres/oauth-quota.ts
@@ -4,7 +4,7 @@ import {
   packCodexQuotaMetadata,
   unpackCodexQuotaMetadata,
 } from "@helm/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, lte } from "drizzle-orm";
 import type { OAuthQuotaStore } from "../ports.js";
 import type { PgDb } from "./migrate.js";
 import { oauthQuota } from "./schema.js";
@@ -49,6 +49,7 @@ export class PgOAuthQuotaStore implements OAuthQuotaStore {
       .onConflictDoUpdate({
         target: [oauthQuota.providerId, oauthQuota.account],
         set,
+        setWhere: lte(oauthQuota.capturedAt, snapshot.capturedAt),
       });
   }
 

--- a/packages/core/src/store/postgres/oauth-reset-period.ts
+++ b/packages/core/src/store/postgres/oauth-reset-period.ts
@@ -1,5 +1,5 @@
 import { type OAuthResetPeriod, OAuthResetPeriodSchema } from "@helm/shared";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, lte, sql } from "drizzle-orm";
 import type { OAuthResetPeriodStore } from "../ports.js";
 import type { PgDb } from "./migrate.js";
 import { oauthResetPeriod } from "./schema.js";
@@ -59,5 +59,28 @@ export class PgOAuthResetPeriodStore implements OAuthResetPeriodStore {
         detectedAtMs: Number(r.detectedAtMs),
       }),
     );
+  }
+
+  async latestResetAt(
+    providerId: string,
+    account: string,
+    beforeMs: number,
+    windowKey?: string,
+  ): Promise<number | null> {
+    const rows = await this.db
+      .select({ periodEndMs: oauthResetPeriod.periodEndMs })
+      .from(oauthResetPeriod)
+      .where(
+        and(
+          eq(oauthResetPeriod.providerId, providerId),
+          eq(oauthResetPeriod.account, account),
+          ...(windowKey === undefined ? [] : [eq(oauthResetPeriod.windowKey, windowKey)]),
+          lte(oauthResetPeriod.periodEndMs, beforeMs),
+          sql`${oauthResetPeriod.detectedAtMs} >= ${oauthResetPeriod.periodEndMs}`,
+        ),
+      )
+      .orderBy(desc(oauthResetPeriod.periodEndMs))
+      .limit(1);
+    return rows[0] ? Number(rows[0].periodEndMs) : null;
   }
 }

--- a/packages/core/src/store/postgres/oauth-usage.test.ts
+++ b/packages/core/src/store/postgres/oauth-usage.test.ts
@@ -243,6 +243,24 @@ describe("PgOAuthResetPeriodStore (pglite)", () => {
     expect(rows.map((r) => r.periodEndMs)).toEqual([37000, 19000]);
     expect(rows[1]?.detectedAtMs).toBe(19500); // first write wins
     expect(await store.queryPeriods("anthropic", "nobody", "5h", 10)).toHaveLength(0);
+
+    await store.record({
+      ...base,
+      windowKey: "7d",
+      periodStartMs: 37000,
+      periodEndMs: 55000,
+      detectedAtMs: 55000,
+    });
+    await store.record({
+      ...base,
+      windowKey: "7d",
+      periodStartMs: 55000,
+      periodEndMs: 90000,
+      detectedAtMs: 60000,
+    });
+    expect(await store.latestResetAt("anthropic", "a@x.com", 70000)).toBe(55000);
+    expect(await store.latestResetAt("anthropic", "a@x.com", 70000, "5h")).toBe(19000);
+    expect(await store.latestResetAt("anthropic", "nobody", 70000)).toBeNull();
     await db.$close();
   });
 });

--- a/packages/core/src/store/sqlite/oauth-quota.test.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.test.ts
@@ -48,6 +48,14 @@ describe("SqliteOAuthQuotaStore", () => {
     close();
   });
 
+  it("ignores a snapshot captured before the stored snapshot", async () => {
+    const { store, close } = freshStore();
+    await store.upsert(snap({ capturedAt: 999, windows: [] }));
+    await store.upsert(snap({ capturedAt: 500 }));
+    expect(await store.get("anthropic", "a")).toMatchObject({ capturedAt: 999, windows: [] });
+    close();
+  });
+
   it("round-trips reset credits and preserves them when a header snapshot omits the count", async () => {
     const { store, close } = freshStore();
     await store.upsert(

--- a/packages/core/src/store/sqlite/oauth-quota.ts
+++ b/packages/core/src/store/sqlite/oauth-quota.ts
@@ -4,7 +4,7 @@ import {
   packCodexQuotaMetadata,
   unpackCodexQuotaMetadata,
 } from "@helm/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, lte } from "drizzle-orm";
 import type { OAuthQuotaStore } from "../ports.js";
 import type { SqliteDb } from "./migrate.js";
 import { oauthQuota } from "./schema.js";
@@ -50,6 +50,7 @@ export class SqliteOAuthQuotaStore implements OAuthQuotaStore {
       .onConflictDoUpdate({
         target: [oauthQuota.providerId, oauthQuota.account],
         set,
+        setWhere: lte(oauthQuota.capturedAt, snapshot.capturedAt),
       })
       .run();
   }

--- a/packages/core/src/store/sqlite/oauth-reset-period.test.ts
+++ b/packages/core/src/store/sqlite/oauth-reset-period.test.ts
@@ -65,4 +65,22 @@ describe("SqliteOAuthResetPeriodStore", () => {
     expect(await store.queryPeriods("anthropic", "nobody", "5h", 10)).toHaveLength(0);
     close();
   });
+
+  it("latestResetAt ignores legacy future-period rows and can filter one window", async () => {
+    const { store, close } = freshStore();
+    await store.record(
+      period({ windowKey: "5h", periodStartMs: 1000, periodEndMs: 2000, detectedAtMs: 2000 }),
+    );
+    await store.record(
+      period({ windowKey: "7d", periodStartMs: 2000, periodEndMs: 3000, detectedAtMs: 3000 }),
+    );
+    await store.record(
+      period({ windowKey: "7d", periodStartMs: 3000, periodEndMs: 9000, detectedAtMs: 4000 }),
+    );
+
+    expect(await store.latestResetAt("anthropic", "a@x.com", 5000)).toBe(3000);
+    expect(await store.latestResetAt("anthropic", "a@x.com", 5000, "5h")).toBe(2000);
+    expect(await store.latestResetAt("anthropic", "nobody", 5000)).toBeNull();
+    close();
+  });
 });

--- a/packages/core/src/store/sqlite/oauth-reset-period.ts
+++ b/packages/core/src/store/sqlite/oauth-reset-period.ts
@@ -1,5 +1,5 @@
 import { type OAuthResetPeriod, OAuthResetPeriodSchema } from "@helm/shared";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, lte, sql } from "drizzle-orm";
 import type { OAuthResetPeriodStore } from "../ports.js";
 import type { SqliteDb } from "./migrate.js";
 import { oauthResetPeriod } from "./schema.js";
@@ -52,5 +52,29 @@ export class SqliteOAuthResetPeriodStore implements OAuthResetPeriodStore {
       .limit(limit)
       .all();
     return rows.map((r) => OAuthResetPeriodSchema.parse(r));
+  }
+
+  async latestResetAt(
+    providerId: string,
+    account: string,
+    beforeMs: number,
+    windowKey?: string,
+  ): Promise<number | null> {
+    const row = this.db
+      .select({ periodEndMs: oauthResetPeriod.periodEndMs })
+      .from(oauthResetPeriod)
+      .where(
+        and(
+          eq(oauthResetPeriod.providerId, providerId),
+          eq(oauthResetPeriod.account, account),
+          ...(windowKey === undefined ? [] : [eq(oauthResetPeriod.windowKey, windowKey)]),
+          lte(oauthResetPeriod.periodEndMs, beforeMs),
+          sql`${oauthResetPeriod.detectedAtMs} >= ${oauthResetPeriod.periodEndMs}`,
+        ),
+      )
+      .orderBy(desc(oauthResetPeriod.periodEndMs))
+      .limit(1)
+      .get();
+    return row?.periodEndMs ?? null;
   }
 }

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -531,16 +531,13 @@ export type OAuthUsagePeriod = z.infer<typeof OAuthUsagePeriodSchema>;
 // per reset window (exact upstream boundary — the "this window has burned X so far"
 // summary; a window with no anchorable resetsAtMs is omitted), grouped by windowKey.
 //
-// History is NOT sliced by reset period: real reset boundaries drift and are cut short
-// by reset-credit consumption (an account can burn a weekly allowance in a day), and
-// the true boundaries were never recorded — so rolling back a fixed window length is
-// misleading. Instead history is aggregated by NATURAL CALENDAR day and week in the
-// admin's local timezone (`daily` / `weekly`), which are exact and honest. Both are
-// most-recent first; the caller marks the oldest as `partial` if it precedes retained
-// data. `windowKey` on these carries the granularity ("day" / "week"), not a window.
+// `periods` is the primary history, sliced on recorded upstream/reset-credit boundaries
+// and falling back to approximate fixed-length windows before such facts exist. Natural
+// calendar `daily` / `weekly` views remain available for compatibility and operations.
 export const OAuthUsagePeriodsSchema = z
   .object({
     current: z.array(OAuthUsagePeriodSchema),
+    periods: z.array(OAuthUsagePeriodSchema).default([]),
     daily: z.array(OAuthUsagePeriodSchema),
     weekly: z.array(OAuthUsagePeriodSchema),
   })
@@ -548,10 +545,9 @@ export const OAuthUsagePeriodsSchema = z
 
 export type OAuthUsagePeriods = z.infer<typeof OAuthUsagePeriodsSchema>;
 
-// One RECORDED reset boundary — an append-only fact captured when a quota refresh saw
-// resetsAtMs advance. [periodStartMs, periodEndMs) is the window that just ended
-// (start = prior resetsAtMs, end = new resetsAtMs). Lets the usage-period read slice
-// history on TRUE boundaries instead of rolling back a fixed window length.
+// One RECORDED reset period — an append-only fact captured when an upstream snapshot or
+// reset-credit action closes the prior allowance window. [periodStartMs, periodEndMs)
+// is the window that actually ended.
 export const OAuthResetPeriodSchema = z
   .object({
     providerId: z.string(),


### PR DESCRIPTION
## Summary

- record every observed quota reset as the period that actually ended
- cover provider deadline advances, early resets, manual/automatic reset credits, and Codex header pushes
- split usage buckets at real reset timestamps and show reset periods by default in Admin
- keep quota snapshots monotonic by capturedAt so late observations cannot overwrite or create false resets
- preserve daily/weekly compatibility views and ignore legacy invalid period rows without rewriting data

## Verification

- `CI=true pnpm exec vitest run packages/core/src/provider/oauth/usage-periods.test.ts packages/core/src/store/sqlite/oauth-quota.test.ts packages/core/src/store/sqlite/oauth-reset-period.test.ts packages/core/src/store/postgres/oauth-quota.test.ts packages/core/src/store/postgres/oauth-usage.test.ts apps/gateway/src/oauth/quota-reset-period.test.ts apps/gateway/src/routes/admin/oauth.test.ts apps/gateway/src/server.oauth.test.ts` (185 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @helm/admin check`
- `pnpm build`