### PR TITLE
chore(release): v0.28.57

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.56",
+  "version": "0.28.57",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump Helm API from 0.28.56 to 0.28.57
- release the exact current main containing quota reset-period history fix #721

## SemVer

Patch release: backward-compatible quota accounting and Admin history correctness fix; no public API removal or database migration.

## Verification

- version-only diff: root `package.json`
- feature PR #721 required CI passed: verify, store, e2e, docker