### PR TITLE
fix(admin): remove duplicate rebuilt session panel

### DIFF
--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -90,9 +90,7 @@
   // (session_recovery_limited). Loaded only on click — a large transcript can be many
   // MB, so we stream raw revisions and rebuild in the browser. Only data retrieval is
   // different: the target request and response reuse the normal server-recovery lenses.
-  // Raw revision pairs stay separate and are ordered by their persisted timestamp.
   let transcriptLoaded = $state(false);
-  let transcriptTimeline = $state<unknown[]>([]);
 
   async function loadTranscript(): Promise<void> {
     if (payloadStatus.request === 'loading' || transcriptLoaded) return;
@@ -101,7 +99,6 @@
     try {
       const rebuilt = await rebuildSessionTranscript(data.requestId);
       payloadValues.request = rebuilt.request;
-      transcriptTimeline = rebuilt.timeline;
       if (hasOwn(rebuilt, 'response')) {
         payloadValues.response = rebuilt.response;
         payloadStatus.response = 'loaded';
@@ -557,18 +554,6 @@
         {/if}
       {/if}
     </section>
-
-    {#if transcriptLoaded && transcriptTimeline.length > 0}
-      <section data-testid="session-timeline" class="card text-sm">
-        <h2 class="section-header">{$t('Session')}</h2>
-        <p class="field-help mb-2">
-          {$t(
-            'Session mode stores repeated conversation history once, reconstructs each request semantically, and keeps available response snapshots.',
-          )}
-        </p>
-        <JsonViewer value={transcriptTimeline} testid="session-timeline-body" />
-      </section>
-    {/if}
 
     <!-- Forwarded upstream request: the EXACT body sent to the provider, AFTER
          memory injection + protocol translation. Shown as a SEPARATE panel only when

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -693,7 +693,7 @@ describe('requests detail page', () => {
     expect(getRequestPayloadPart).toHaveBeenCalledWith('tr_lazy', 'request');
   });
 
-  it('rebuilds a too-large transcript client-side only on click', async () => {
+  it('rebuilds a too-large transcript without duplicating the Session timeline', async () => {
     rebuildSessionTranscript.mockResolvedValueOnce({
       request: { model: 'auto', messages: [{ role: 'user', content: 'question' }] },
       response: { ok: true },
@@ -726,7 +726,7 @@ describe('requests detail page', () => {
     await fireEvent.click(screen.getByTestId('request-view-raw'));
     expect(screen.getByTestId('request-body')).toHaveTextContent(/"model": "auto"/);
     expect(screen.getByTestId('response-body')).toHaveTextContent(/"ok": true/);
-    expect(screen.getByTestId('session-timeline-body')).toHaveTextContent('Array(1)');
+    expect(screen.queryByTestId('session-timeline')).not.toBeInTheDocument();
   });
 
   // A 1×1 PNG (bare base64) — the form a generated/input image takes inside a body.

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -326,7 +326,7 @@ test.describe("admin request payload view", () => {
     await expect(page.getByTestId("payload-summary")).toContainText(/no captured Session ID/i);
   });
 
-  test("rebuilds a too-large transcript client-side on demand", async ({ page }) => {
+  test("rebuilds a too-large transcript without a duplicate Session panel", async ({ page }) => {
     await page.route(`**/admin/api/requests/${SEED_TRACE_ID}/payload?part=meta`, async (route) =>
       route.fulfill({
         contentType: "application/json",
@@ -379,6 +379,6 @@ test.describe("admin request payload view", () => {
     await page.getByTestId("request-view-raw").click();
     await expect(page.getByTestId("request-body")).toContainText("rebuilt-in-browser");
     await expect(page.getByTestId("response-body")).toContainText("rebuilt-response");
-    await expect(page.getByTestId("session-timeline-body")).toContainText("Array(1)");
+    await expect(page.getByTestId("session-timeline")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
- remove the redundant raw Session card after a large transcript is rebuilt in the browser
- keep the normal Conversation/Raw request lenses and Response viewer unchanged
- update unit and browser regression expectations

## Verification
- `CI=true pnpm exec vitest run apps/admin/src/routes/requests/requests.test.ts` (49 passed)
- `CI=true pnpm --filter @helm/admin check` (0 errors, 0 warnings)
- targeted Prettier, Biome, and `git diff --check` passed
- local Playwright startup was blocked before test execution by shared worktree dependencies resolving an old `@helm/core`; hermetic CI remains authoritative