### PR TITLE
修复流式终止错误与请求详情不一致

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -80,6 +80,39 @@ function rawRecord(overrides: Record<string, unknown> = {}): Record<string, unkn
 }
 
 describe('toDetail', () => {
+  it('uses the recorded terminal stream error instead of fabricating HTTP 0', () => {
+    const detail = toDetail(
+      rawRecord({
+        final: {
+          model_alias: 'premium',
+          provider_model: 'claude-x',
+          status: 'error',
+          error_reason: 'upstream_error',
+          error_detail: {
+            upstream_status: null,
+            message: 'The prompt is invalid.',
+            provider_raw: {
+              type: 'response.failed',
+              response: {
+                error: { code: 'invalid_prompt', message: 'The prompt is invalid.' },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(detail.error).toEqual({
+      error_class: 'upstream_error',
+      upstream_status: null,
+      message: 'The prompt is invalid.',
+      provider_raw: {
+        type: 'response.failed',
+        response: { error: { code: 'invalid_prompt', message: 'The prompt is invalid.' } },
+      },
+    });
+  });
+
   it('maps the recorded request body byte count without inventing legacy values', () => {
     const measured = toDetail(rawRecord({ request_body_bytes: 1_572_864 }));
     const legacy = toDetail(rawRecord());

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -203,7 +203,7 @@ export interface RequestDetail {
   response_meta: Record<string, unknown> | null;
   error: {
     error_class: string;
-    http_status: number;
+    upstream_status: number | null;
     message: string;
     provider_raw: unknown;
   } | null;
@@ -322,6 +322,11 @@ interface RawDecisionRecord {
     provider_model?: string | null;
     status?: string;
     error_reason?: string | null;
+    error_detail?: {
+      upstream_status?: number | null;
+      message?: string;
+      provider_raw?: unknown;
+    } | null;
   };
   serving_account?: {
     provider_id?: string | null;
@@ -731,9 +736,14 @@ export function toDetail(raw: RawDecisionRecord): RequestDetail {
       status === 'error'
         ? {
             error_class: String(raw.final?.error_reason ?? 'upstream_error'),
-            http_status: 0, // backend does not record the upstream http status yet
-            message: String(raw.final?.error_reason ?? 'request failed'), // already redacted
-            provider_raw: null, // redacted — never surface raw upstream bodies (Principle 7)
+            upstream_status:
+              typeof raw.final?.error_detail?.upstream_status === 'number'
+                ? raw.final.error_detail.upstream_status
+                : null,
+            message:
+              nonEmptyString(raw.final?.error_detail?.message) ??
+              String(raw.final?.error_reason ?? 'request failed'),
+            provider_raw: raw.final?.error_detail?.provider_raw ?? null,
           }
         : null,
     // Cost split from the record (docs/07 "cost breakdown (incl. eval cost)"): eval self-cost is

--- a/apps/admin/src/lib/components/DecisionChain.svelte
+++ b/apps/admin/src/lib/components/DecisionChain.svelte
@@ -249,6 +249,10 @@
     </p>
     <ul class="flex flex-col gap-2">
       {#each detail.provider_attempts as a, i (i)}
+        {@const partial =
+          a.outcome === 'success' &&
+          detail.status === 'error' &&
+          (detail.stream_outcome === 'failed' || detail.stream_outcome === 'truncated')}
         <li data-testid="attempt-row" class="flex flex-col gap-1 text-sm">
           <div class="flex flex-wrap items-center gap-2">
             <span class="font-mono text-ink-strong">{a.provider ?? '—'}</span>
@@ -263,8 +267,10 @@
                 >{$t('wire:')} {a.provider_model}</span
               >
             {/if}
-            <span class={outcomeBadge(a.outcome)} title={a.outcome}
-              >{$t(attemptCodeLabel(a.outcome))}</span
+            <span
+              class={partial ? 'badge-warning' : outcomeBadge(a.outcome)}
+              title={partial ? detail.stream_outcome : a.outcome}
+              >{$t(partial ? 'partial' : attemptCodeLabel(a.outcome))}</span
             >
             <span class="text-ink-muted">{formatDurationMs(a.latency_ms)}</span>
             {#if a.error_class}<span class="text-red-600" title={a.error_class}

--- a/apps/admin/src/lib/components/DecisionChain.test.ts
+++ b/apps/admin/src/lib/components/DecisionChain.test.ts
@@ -105,6 +105,16 @@ function detail(overrides: Partial<RequestDetail> = {}): RequestDetail {
 }
 
 describe('DecisionChain', () => {
+  it('labels a committed attempt as partial when its stream later fails', () => {
+    render(DecisionChain, {
+      detail: detail({ status: 'error', stream_outcome: 'failed' }),
+    });
+
+    const servedAttempt = screen.getAllByTestId('attempt-row')[1];
+    expect(within(servedAttempt).getByText('partial')).toBeInTheDocument();
+    expect(within(servedAttempt).queryByText('Success')).not.toBeInTheDocument();
+  });
+
   it('renders classifier output with confidence and matched dimensions', () => {
     render(DecisionChain, { detail: detail() });
     const cls = screen.getByTestId('chain-classifier');

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -656,16 +656,17 @@
     {#if d.error}
       <section data-testid="request-error" role="alert" class="alert-error text-sm">
         <h2 class="section-header text-red-700">{$t('Error')}</h2>
-        <p class="field-help mb-2 text-red-600">
-          {$t(
-            'This request ended in an error after all attempts. Details below are recorded as-is.',
-          )}
-        </p>
         <div>
           {$t('Error type')}:
           <span title={d.error.error_class}>{$t(attemptCodeLabel(d.error.error_class))}</span>
         </div>
-        <div>{$t('HTTP status')}: <span class="font-mono">{d.error.http_status}</span></div>
+        <div>
+          {$t('Provider')}
+          {$t('HTTP status')}:
+          <span class="font-mono"
+            >{d.error.upstream_status === null ? '—' : d.error.upstream_status}</span
+          >
+        </div>
         <div>{$t('Message')}: {d.error.message}</div>
         <div class="mt-1 text-xs text-red-500">
           {$t('Raw provider response')}: {d.error.provider_raw === null

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -899,7 +899,7 @@ describe('requests detail page', () => {
           status_is_error_marker: undefined,
           error: {
             error_class: 'all_providers_failed',
-            http_status: 502,
+            upstream_status: 502,
             message: 'all providers failed',
             provider_raw: null,
           },
@@ -914,6 +914,29 @@ describe('requests detail page', () => {
     expect(err).toHaveTextContent(/all providers failed/);
     // trace_id is copyable.
     expect(screen.getByTestId('copy-trace')).toBeInTheDocument();
+  });
+
+  it('shows an in-stream failure without inventing HTTP 0 or claiming every attempt failed', () => {
+    render(DetailPage, {
+      data: {
+        detail: detail({
+          error: {
+            error_class: 'upstream_error',
+            upstream_status: null,
+            message: 'The prompt is invalid.',
+            provider_raw: { error: { code: 'invalid_prompt' } },
+          },
+        }),
+        payload: { captured: false },
+        requestId: 'tr_stream_err',
+      },
+    });
+
+    const err = screen.getByTestId('request-error');
+    expect(err).toHaveTextContent('The prompt is invalid.');
+    expect(err).toHaveTextContent('Provider HTTP status: —');
+    expect(err).not.toHaveTextContent('Provider HTTP status: 0');
+    expect(err).not.toHaveTextContent('all attempts');
   });
 
   it('shows reasoning effort metadata when full payload capture is off', () => {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -3081,18 +3081,37 @@ describe("streamStatusFromEventName — incomplete / failed / cancelled cases (l
   });
 
   it("records status='failed' when the stream emits a response.failed event", async () => {
+    const { record, insert } = makeRecord();
     const put = vi.fn();
     const failedData = JSON.stringify({
       type: "response.failed",
-      response: { id: "resp_fail_1", status: "failed" },
+      response: {
+        id: "resp_fail_1",
+        status: "failed",
+        error: { code: "invalid_prompt", message: "The prompt is invalid." },
+      },
     });
     async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield {
+        event: "response.output_text.delta",
+        data: JSON.stringify({ type: "response.output_text.delta", delta: "partial" }),
+      };
       yield { event: "response.failed", data: failedData };
     }
+    const decision = {
+      provider_attempts: [{ status: "ok" }],
+      final: { status: "ok", model_alias: "gpt-5.6-sol", error_reason: null },
+      stream_outcome: null,
+    } as unknown as DecisionRecord;
     const { deps } = makeDeps({
-      nativePassthrough: true,
+      record,
       transformRequestOut: () => ({ stream: true, model: "auto", metadata: {} }),
-      streamIR: events,
+      run: async () => ({
+        decision,
+        nativePassthrough: true,
+        collect: async () => ({}),
+        streamIR: events,
+      }),
       registry: { put, get: vi.fn() },
     });
     const app = buildApp(deps);
@@ -3105,6 +3124,66 @@ describe("streamStatusFromEventName — incomplete / failed / cancelled cases (l
     expect(put).toHaveBeenCalledWith(
       expect.objectContaining({ responseId: "resp_fail_1", status: "failed" }),
     );
+    expect(insert).toHaveBeenCalledOnce();
+    const persisted = insert.mock.calls[0]?.[0].decision as DecisionRecord;
+    expect(persisted.provider_attempts[0]?.status).toBe("ok");
+    expect(persisted.stream_outcome).toBe("failed");
+    expect(persisted.final).toMatchObject({
+      status: "error",
+      error_reason: "upstream_error",
+      error_detail: {
+        upstream_status: null,
+        message: "The prompt is invalid.",
+        provider_raw: {
+          type: "response.failed",
+          response: { error: { code: "invalid_prompt", message: "The prompt is invalid." } },
+        },
+      },
+    });
+  });
+
+  it("keeps an exact error frame when the upstream then throws a generic EOF error", async () => {
+    const { record, insert } = makeRecord();
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield {
+        event: "response.output_text.delta",
+        data: JSON.stringify({ type: "response.output_text.delta", delta: "partial" }),
+      };
+      yield {
+        event: "error",
+        data: JSON.stringify({
+          type: "error",
+          error: { code: "invalid_prompt", message: "The prompt is invalid." },
+        }),
+      };
+      throw new UpstreamError("upstream_error", "stream closed before response.completed");
+    }
+    const decision = {
+      provider_attempts: [{ status: "ok" }],
+      final: { status: "ok", model_alias: "gpt-5.6-sol", error_reason: null },
+      stream_outcome: null,
+    } as unknown as DecisionRecord;
+    const { deps } = makeDeps({
+      record,
+      transformRequestOut: () => ({ stream: true, model: "auto", metadata: {} }),
+      run: async () => ({
+        decision,
+        nativePassthrough: true,
+        collect: async () => ({}),
+        streamIR: events,
+      }),
+    });
+
+    await (
+      await buildApp(deps).request("/v1/responses", {
+        method: "POST",
+        headers: AUTH,
+        body: JSON.stringify({ ...REQ, stream: true }),
+      })
+    ).text();
+
+    const persisted = insert.mock.calls[0]?.[0].decision as DecisionRecord;
+    expect(persisted.final.error_detail?.message).toBe("The prompt is invalid.");
   });
 
   it("normalizes response.cancelled to the failed stream outcome", async () => {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -5,11 +5,14 @@ import {
   type BudgetProbe,
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   type DecisionRecord,
+  preOutputClassifierFor,
   type RateLimitProbe,
   type RateLimitResult,
+  streamErrorFromData,
   UpstreamError,
 } from "@helm/core";
 import {
+  type AttemptErrorDetail,
   cloneCarrierWithBody,
   type ErrorClass,
   ErrorClassSchema,
@@ -42,6 +45,7 @@ import {
   readAdmittedRequestBody,
 } from "../runtime/memory-admission.js";
 import { servedByAccount, stampServingAccount } from "../runtime/serving-account.js";
+import { errorDetailOf } from "./execute.js";
 import { atEventBoundary, HEARTBEAT_COMMENT, withHeartbeat } from "./heartbeat.js";
 import { resolveMemoryScope } from "./memory-scope.js";
 import type { MessagesIdentity, PipelineRunResult } from "./messages.js";
@@ -448,12 +452,20 @@ function isResponsesTerminalEvent(eventName: string): boolean {
 
 type ResponsesStreamOutcome = NonNullable<DecisionRecord["stream_outcome"]>;
 
+function responsesFrameErrorDetail(eventName: string, data: string): AttemptErrorDetail | null {
+  if (eventName !== "error" && eventName !== "response.failed") return null;
+  const classifier = preOutputClassifierFor("openai_responses");
+  if (classifier === null) return null;
+  return errorDetailOf(streamErrorFromData(classifier, data));
+}
+
 export function settleResponsesStreamOutcome(args: {
   decision: DecisionRecord;
   streamStatus: string | null;
   cancellationReason: RequestCancellationReason | null;
   caughtErrorReason: string | null;
   timedOut: boolean;
+  errorDetail?: AttemptErrorDetail | null;
 }): ResponsesStreamOutcome {
   const terminalObserved =
     args.streamStatus === "completed" ||
@@ -504,6 +516,7 @@ export function settleResponsesStreamOutcome(args: {
       ...args.decision.final,
       status: "error",
       error_reason: args.caughtErrorReason ?? "upstream_error",
+      ...(args.errorDetail ? { error_detail: args.errorDetail } : {}),
     };
   }
   return outcome;
@@ -1281,6 +1294,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         let streamStatus: string | null = null;
         let cancellationReason: RequestCancellationReason | null = null;
         let caughtErrorReason: string | null = null;
+        let finalErrorDetail: AttemptErrorDetail | null = null;
         let registryCommit: Promise<void> | null = null;
         const commitRegistry = async (status: string): Promise<void> => {
           if (deps.registry === undefined || result === null || streamResponseId === null) {
@@ -1334,6 +1348,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
             const snapshot = responseSnapshotFromStreamFrame(frame.event, frame.data);
             if (snapshot.responseId !== null) streamResponseId = snapshot.responseId;
             if (snapshot.status !== null) streamStatus = snapshot.status;
+            finalErrorDetail ??= responsesFrameErrorDetail(frame.event, frame.data);
             if (captureSessionResponse && terminalEvent && !captureBodies) {
               if (sessionTerminalCapture?.limited()) {
                 c.get("logger").log("warn", "session.response_limited", { trace_id: traceId });
@@ -1366,6 +1381,9 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           if (cancellationReason !== null) {
             // Cancellation ends the wire without a fabricated terminal event.
           } else {
+            if (err instanceof UpstreamError || err instanceof PipelineError) {
+              finalErrorDetail ??= errorDetailOf(err);
+            }
             caughtErrorReason =
               err instanceof PipelineError
                 ? err.error_class
@@ -1402,6 +1420,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                   cancellationReason,
                   caughtErrorReason,
                   timedOut: requestTimedOut(c),
+                  errorDetail: finalErrorDetail,
                 });
           // Record AFTER releaseConcurrency so the bookkeeping never extends the
           // concurrency hold, and AFTER the for-await loop ended so the pipeline's

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -496,6 +496,7 @@ export {
   guardPreOutputFailure,
   type PreOutputClassifier,
   preOutputClassifierFor,
+  streamErrorFromData,
 } from "./provider/failover-guard.js";
 export {
   createGeminiClient,

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -88,6 +88,10 @@ function errorProviderRaw(data: string): Record<string, unknown> | null {
   return out;
 }
 
+export function streamErrorFromData(classifier: PreOutputClassifier, data: string): UpstreamError {
+  return new UpstreamError("upstream_error", classifier.errorMessage(data), errorProviderRaw(data));
+}
+
 function nonEmptyString(value: unknown): boolean {
   return typeof value === "string" && value.length > 0;
 }
@@ -260,13 +264,7 @@ export async function* guardPreOutputFailure(
       sse = sse.slice(sep + 2);
       if (data !== null) {
         const cls = classifier.classify(data);
-        if (cls === "error") {
-          throw new UpstreamError(
-            "upstream_error",
-            classifier.errorMessage(data),
-            errorProviderRaw(data),
-          );
-        }
+        if (cls === "error") throw streamErrorFromData(classifier, data);
         if (cls === "output") {
           committed = true;
           for (const b of buffered) yield b;

--- a/packages/shared/src/decision/schema.test.ts
+++ b/packages/shared/src/decision/schema.test.ts
@@ -117,6 +117,26 @@ describe("DecisionRecordSchema", () => {
     expect(DecisionRecordSchema.safeParse(fullRecord()).success).toBe(true);
   });
 
+  it("preserves a terminal stream error separately from the committed attempt", () => {
+    const parsed = DecisionRecordSchema.parse({
+      ...fullRecord(),
+      final: {
+        model_alias: "premium",
+        provider_model: "claude-x",
+        status: "error",
+        error_reason: "upstream_error",
+        error_detail: {
+          upstream_status: null,
+          message: "The prompt is invalid.",
+          provider_raw: { error: { code: "invalid_prompt" } },
+        },
+      },
+    });
+
+    expect(parsed.provider_attempts[1]?.status).toBe("ok");
+    expect(parsed.final.error_detail?.message).toBe("The prompt is invalid.");
+  });
+
   it("round-trips body-free session linkage and keeps legacy rows valid", () => {
     expect(DecisionRecordSchema.parse(fullRecord()).session).toBeUndefined();
     const parsed = DecisionRecordSchema.parse({

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -131,6 +131,9 @@ export const FinalDecisionSchema = z.object({
   provider_model: z.string().nullable(),
   status: AttemptStatusSchema,
   error_reason: z.string().nullable(),
+  // A stream can fail after the provider attempt has committed its first real
+  // output. Preserve that terminal diagnostic without rewriting attempt status.
+  error_detail: AttemptErrorDetailSchema.nullable().optional(),
 });
 
 export const ServingAccountDecisionSchema = z.object({


### PR DESCRIPTION
## 问题

流式响应输出首个有效 chunk 后，provider attempt 会正确提交为 ok；但后续 response.failed 或 error 事件的具体错误未进入最终 DecisionRecord。管理界面因此把未知状态伪造成 HTTP 0，并将部分输出后的失败 attempt 显示为 Success。

## 修复

- 在 final.error_detail 中保留经过长度限制与字段白名单脱敏的终止错误
- 保留最早的具体错误，不让后续通用 EOF 错误覆盖
- 管理界面显示真实错误信息；未知 provider HTTP 状态显示 —
- 已提交输出但流最终失败或截断时，将 attempt 显示为 partial

## 验证

- Admin 相关测试：105 通过
- core/shared 相关测试：53 通过
- Gateway 新增回归：2 通过
- TypeScript、Svelte check、Biome、Prettier、git diff --check 已通过
- 全量 Responses 文件另有 2 个既存 WebSocket memory-admission 失败；其余 98 项通过，失败与本次改动无关，原因是测试进程报告 response-memory capacity exhausted

## Release 评估

这是向后兼容、用户可见的错误诊断正确性修复，建议在合并后发布 patch 版本 v0.28.60。