### PR TITLE
chore(release): v0.28.60

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.59",
+  "version": "0.28.60",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

将 Helm API 版本从 0.28.59 升级到 0.28.60。

这是仅包含版本号的 patch release PR；功能修复已通过 #727 合并到 main，合并提交为 41e8653785bc1d21f04e37a42b6f510299a9c7b3。

## 变更

- 修复 Responses 流在部分输出后失败时丢失真实 provider 错误的问题
- 管理界面不再伪造 HTTP 0，并将已提交但最终失败的 attempt 显示为 partial

## 发布门禁

合并并通过 main CI 后，等待 Publish image 对精确 release SHA 构建并发布不可变 digest，再部署到 la.atmy.work:/opt/helm-api。