### PR TITLE
fix: 恢复已关闭的 Codex Responses WebSocket

### DIFF
--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -2713,13 +2713,13 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(chunks.join("")).toContain("response.completed");
   });
 
-  it("falls back to HTTP after websocket write ECANCELED exhausts the retry budget", async () => {
+  it("falls back to HTTP after a closed websocket exhausts the retry budget", async () => {
     let closeCalls = 0;
     const connect = vi.fn(
       async (): Promise<CodexResponsesWebSocketConnection> => ({
         responseHeaders: new Headers(),
         async send() {
-          throw Object.assign(new Error("write ECANCELED"), { code: "ECANCELED" });
+          throw new Error("Codex Responses websocket is closed");
         },
         async receive() {
           return null;
@@ -2729,7 +2729,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
         },
       }),
     );
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
       rawSSEResponse(
         'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n\n',
       ),
@@ -2737,9 +2737,8 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     const client = createCodexResponsesClient({
       config: {
         baseUrl: "https://chatgpt.com/backend-api/codex",
-        getAuthHeader: async () => `Bearer ${jwt("acct_ecanceled_fallback")}`,
+        getAuthHeader: async () => `Bearer ${jwt("acct_ws_closed_fallback")}`,
         responsesWebSocketConnector: connect,
-        connectRetries: 1,
         connectRetryBackoffMs: [0],
       },
       fetch: fetchMock as unknown as typeof fetch,
@@ -2747,7 +2746,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     const chunks: string[] = [];
 
     for await (const chunk of client.nativePassthroughStream?.(
-      carrier("ingress-ecanceled-fallback", {
+      carrier("ingress-ws-closed-fallback", {
         model: "gpt-5.6-sol",
         input: [],
         stream: true,
@@ -2757,9 +2756,12 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       chunks.push(chunk);
     }
 
-    expect(connect).toHaveBeenCalledTimes(2);
-    expect(closeCalls).toBe(2);
+    expect(connect).toHaveBeenCalledTimes(3);
+    expect(closeCalls).toBe(3);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    const fallbackHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(fallbackHeaders.get("authorization")).toBe(`Bearer ${jwt("acct_ws_closed_fallback")}`);
+    expect(fallbackHeaders.get("chatgpt-account-id")).toBe("acct_ws_closed_fallback");
     expect(chunks.join("")).toContain("response.completed");
   });
 

--- a/packages/core/src/provider/retry.ts
+++ b/packages/core/src/provider/retry.ts
@@ -33,6 +33,7 @@ const TRANSIENT_MESSAGE_PATTERNS = [
   "other side closed",
   "terminated",
   "socket hang up",
+  "codex responses websocket is closed",
   "socket connection was closed",
   "premature close",
 ];


### PR DESCRIPTION
## 问题

请求 `3268b916-2892-4b87-a04c-10308558c506` 在缓存的上游 WebSocket 已关闭时抛出普通 `Error: Codex Responses websocket is closed`。该消息不在瞬时连接错误白名单中，因此同账号重连和同账号 HTTP fallback 均未执行，3ms 内直接失败。

## 修复

- 精确识别 `codex responses websocket is closed` 为可重试的瞬时连接错误。
- 复用已有 WebSocket 重连预算；耗尽后使用原账号走 HTTP fallback。
- 不放宽有状态 continuation 的账号亲和性：`previous_response_id` 仍禁止跨账号 fallback。

## 验证

- Red: 修复前定向回归测试复现原始错误并失败。
- Green: WebSocket provider 29/29。
- Retry classifier 33/33。
- `pnpm typecheck` 通过。
- `pnpm lint` 通过。
- `git diff --check` 通过。

备注：本机完整 191-case provider 文件受当前机器内存压力触发既有 response-work admission，21 个不相关 unary case 失败；相关 WebSocket suite 和 hermetic PR CI 作为本次门禁。