### PR TITLE
chore(release): v0.28.61

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.60",
+  "version": "0.28.61",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

- Bump Helm API from `0.28.60` to `0.28.61`.
- Includes PR #729: recover a closed Codex Responses WebSocket by retrying the same pinned account, then falling back to HTTP on that same account.

## Risk

Patch release. No schema, config, or public API migration. Stateful continuation affinity remains fail-closed across OAuth accounts.