### PR TITLE
fix(oauth): use persisted reset timestamps in usage periods

### DIFF
--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -194,11 +194,13 @@ describe("admin OAuth routes — read endpoints", () => {
   it("GET /oauth/usage/periods returns current reset summary + natural day/week history", async () => {
     const HOUR = 3_600_000;
     const DAY = 86_400_000;
-    // Current 5h reset window (real resetsAtMs in the future). Buckets span ~3 days so
-    // the calendar aggregation produces multiple day rows and at least one week row.
-    const reset = Date.now() + HOUR;
-    const buckets = Array.from({ length: 60 }, (_, i) => ({
-      bucketMs: reset - (60 - i) * HOUR, // last ~2.5 days of hourly buckets
+    const WEEK = 7 * DAY;
+    const now = Date.now();
+    const todayReset = now - HOUR;
+    const saturdayReset = todayReset - 3 * DAY;
+    const reset = todayReset + WEEK;
+    const buckets = Array.from({ length: 10 * 24 }, (_, i) => ({
+      bucketMs: now - (10 * 24 - i) * HOUR,
       requests: 1,
       tokens: 100,
       costUsd: null,
@@ -208,24 +210,41 @@ describe("admin OAuth routes — read endpoints", () => {
     } as unknown as AdminApiDeps["oauthUsage"];
     const oauthQuota = {
       get: vi.fn(async () => ({
-        providerId: "anthropic",
+        providerId: "openai-codex",
         account: "a@x.com",
-        windows: [{ key: "5h", usedPercent: 50, resetsAtMs: reset, windowMinutes: null }],
-        capturedAt: 0,
-        source: "anthropic",
+        windows: [{ key: "primary", usedPercent: 7, resetsAtMs: reset, windowMinutes: 10_080 }],
+        capturedAt: now,
+        source: "codex-headers",
         usageLimitedUntilMs: null,
-        resetCredits: null,
+        resetCredits: 0,
       })),
     } as unknown as AdminApiDeps["oauthQuota"];
     const oauthResetPeriod = {
+      // Current rows prove the end; the old writer stored the prior reset in the start.
       queryPeriods: vi.fn(async () => [
         {
-          providerId: "anthropic",
+          providerId: "openai-codex",
           account: "a@x.com",
-          windowKey: "5h",
-          periodStartMs: reset - 10 * HOUR,
-          periodEndMs: reset - 5 * HOUR,
-          detectedAtMs: reset - 5 * HOUR,
+          windowKey: "primary",
+          periodStartMs: saturdayReset + DAY,
+          periodEndMs: todayReset,
+          detectedAtMs: todayReset,
+        },
+        {
+          providerId: "openai-codex",
+          account: "a@x.com",
+          windowKey: "primary",
+          periodStartMs: saturdayReset,
+          periodEndMs: saturdayReset + WEEK,
+          detectedAtMs: saturdayReset + HOUR,
+        },
+        {
+          providerId: "openai-codex",
+          account: "a@x.com",
+          windowKey: "primary",
+          periodStartMs: saturdayReset - 4 * WEEK,
+          periodEndMs: saturdayReset - 3 * WEEK,
+          detectedAtMs: saturdayReset - 4 * WEEK + HOUR,
         },
       ]),
     } as unknown as AdminApiDeps["oauthResetPeriod"];
@@ -239,11 +258,11 @@ describe("admin OAuth routes — read endpoints", () => {
       oauthResetPeriod,
       settings,
     }).request(
-      "/admin/api/oauth/usage/periods?provider=anthropic&account=a%40x.com&tzOffsetMinutes=0",
+      "/admin/api/oauth/usage/periods?provider=openai-codex&account=a%40x.com&tzOffsetMinutes=0",
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      current: Array<{ windowKey: string; tokens: number }>;
+      current: Array<{ windowKey: string; periodStartMs: number; tokens: number }>;
       periods: Array<{ windowKey: string; periodStartMs: number; periodEndMs: number }>;
       daily: Array<{
         windowKey: string;
@@ -254,15 +273,27 @@ describe("admin OAuth routes — read endpoints", () => {
       }>;
       weekly: Array<{ windowKey: string; tokens: number; partial: boolean; periodEndMs: number }>;
     };
-    // current: the in-progress 5h reset window summary (exact resetsAtMs boundary).
+    // The newest row proves today's reset; the legacy row proves Saturday's reset.
     expect(body.current).toHaveLength(1);
-    expect(body.current[0]?.windowKey).toBe("5h");
+    expect(body.current[0]?.windowKey).toBe("primary");
+    expect(body.current[0]?.periodStartMs).toBe(todayReset);
     expect(body.current[0]?.tokens ?? 0).toBeGreaterThan(0);
-    expect(oauthResetPeriod?.queryPeriods).toHaveBeenCalledWith("anthropic", "a@x.com", "5h", 53);
+    expect(oauthResetPeriod?.queryPeriods).toHaveBeenCalledWith(
+      "openai-codex",
+      "a@x.com",
+      "primary",
+      53,
+    );
     expect(body.periods[0]).toMatchObject({
-      windowKey: "5h",
-      periodStartMs: reset - 10 * HOUR,
-      periodEndMs: reset - 5 * HOUR,
+      windowKey: "primary",
+      periodStartMs: saturdayReset,
+      periodEndMs: todayReset,
+      approximate: false,
+    });
+    expect(body.periods[1]).toMatchObject({
+      periodStartMs: saturdayReset - WEEK,
+      periodEndMs: saturdayReset,
+      approximate: true,
     });
     // daily: natural-day buckets, most recent first, each a 24h span, windowKey "day".
     expect(body.daily.length).toBeGreaterThanOrEqual(2);
@@ -276,9 +307,9 @@ describe("admin OAuth routes — read endpoints", () => {
     // weekly: at least one 7-day bucket, windowKey "week".
     expect(body.weekly.length).toBeGreaterThanOrEqual(1);
     expect(body.weekly[0]?.windowKey).toBe("week");
-    // token conservation: the day buckets cover ALL 60 hourly buckets (6000 tokens).
+    // token conservation: the day buckets cover all 240 hourly buckets.
     const dayTotal = body.daily.reduce((s, p) => s + p.tokens, 0);
-    expect(dayTotal).toBe(6000);
+    expect(dayTotal).toBe(24_000);
   });
 
   it("GET /oauth/usage/periods fails open to empty when the quota snapshot is missing", async () => {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -3,10 +3,15 @@ import {
   computeUsagePeriods,
   filterRetiredOpenAICodexLimits,
   GROK_OAUTH_MEDIA_MODELS,
+  windowMinutesForKey,
   windowsToActiveUsageRecovery,
   windowsToUsageLimit,
 } from "@helm/core";
-import { isCodexQuotaWindowPlaceholder, type OAuthQuotaWindow } from "@helm/shared";
+import {
+  isCodexQuotaWindowPlaceholder,
+  type OAuthQuotaWindow,
+  type OAuthResetPeriod,
+} from "@helm/shared";
 import type { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { AppEnv } from "../../app.js";
@@ -43,6 +48,42 @@ import type {
 //   - device_code (Copilot): start -> show user code -> poll until done.
 
 const DEFAULT_ACCOUNT = "default";
+
+function resetEventBoundaries(
+  rows: OAuthResetPeriod[],
+  nextResetAtMs: number | null,
+  nowMs: number,
+  windowMs: number | null,
+): Array<{ startMs: number; endMs: number }> {
+  // The old writer stored [oldReset, projectedNextReset); the current writer stores a
+  // closed period ending at the observed reset. Reduce both shapes to proven events.
+  const points = [
+    ...new Set(
+      rows.flatMap((row) => {
+        if (row.detectedAtMs >= row.periodEndMs) return [row.periodEndMs];
+        return row.periodStartMs <= row.detectedAtMs ? [row.periodStartMs] : [];
+      }),
+    ),
+  ]
+    .filter((point) => point <= nowMs)
+    .sort((a, b) => a - b);
+  const plausible = (startMs: number, endMs: number) =>
+    windowMs !== null && endMs - startMs <= windowMs * 1.5;
+  const boundaries = points.slice(1).flatMap((endMs, index) => {
+    const startMs = points[index] ?? endMs;
+    return plausible(startMs, endMs) ? [{ startMs, endMs }] : [];
+  });
+  const latest = points.at(-1);
+  if (
+    latest !== undefined &&
+    nextResetAtMs !== null &&
+    nextResetAtMs > nowMs &&
+    plausible(latest, nextResetAtMs)
+  ) {
+    boundaries.push({ startMs: latest, endMs: nextResetAtMs });
+  }
+  return boundaries;
+}
 
 // Narrow an unknown thrown value to a safe, already-scrubbed message. The seam's
 // errors are constructed without token material (TokenRefreshError / generic),
@@ -266,16 +307,22 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       const dataStartMs = Math.max(retentionFloorMs, earliestBucketMs);
       const recordedBoundaries = Object.fromEntries(
         await Promise.all(
-          snapshot.windows.map(async (window) => [
-            window.key,
-            (
-              await deps.oauthResetPeriod
+          snapshot.windows.map(async (window) => {
+            const rows =
+              (await deps.oauthResetPeriod
                 ?.queryPeriods(providerId, account, window.key, 53)
-                .catch(() => [])
-            )
-              ?.filter((row) => row.detectedAtMs >= row.periodEndMs)
-              .map((row) => ({ startMs: row.periodStartMs, endMs: row.periodEndMs })) ?? [],
-          ]),
+                .catch(() => [])) ?? [];
+            const minutes = windowMinutesForKey(window.key, window.windowMinutes);
+            return [
+              window.key,
+              resetEventBoundaries(
+                rows,
+                window.resetsAtMs,
+                now,
+                minutes === null ? null : minutes * 60_000,
+              ),
+            ] as const;
+          }),
         ),
       );
       const { current, periods } = computeUsagePeriods({


### PR DESCRIPTION
## Summary
- reconstruct reset boundaries from both legacy and current `oauth_reset_period` rows
- use the legacy `period_start_ms` only when it is already observed, and current `period_end_ms` for closed rows
- retain the 1.5x cadence guard so sparse observations stay approximate
- add a production-shaped `openai-codex` primary-window regression for the Saturday-to-today reset interval

## Evidence
Production currently contains the Saturday reset as a legacy row (`detected_at_ms < period_end_ms`) and today's reset as a current row. The previous reader discarded the legacy row, producing the wrong Sunday-to-today period. No migration or backfill is required.

## Verification
- `CI=true pnpm exec vitest run apps/gateway/src/routes/admin/oauth.test.ts packages/core/src/provider/oauth/usage-periods.test.ts` (109 passed)
- `CI=true pnpm typecheck`
- `CI=true pnpm lint`
- `CI=true pnpm build`
- `git diff --check`

Co-Authored-By: Codex <noreply@openai.com>