### PR TITLE
chore(release): v0.28.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.61",
+  "version": "0.28.62",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump Helm API from `0.28.61` to `0.28.62`
- includes reset-period reconstruction fix from PR #731
- version-only diff; no database migration or backfill

## Gate
Merge only after required CI passes. Deploy only after main CI and `Publish image` succeed for the exact release merge SHA.

Co-Authored-By: Codex <noreply@openai.com>