### PR TITLE
fix(admin): hide unavailable transcript loader

### DIFF
--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -892,6 +892,25 @@ describe('requests detail page', () => {
     expect(screen.getByTestId('load-transcript')).toBeInTheDocument();
   });
 
+  it('hides transcript loading when the recorded Session is unavailable', () => {
+    render(DetailPage, {
+      data: {
+        detail: detail(),
+        payload: {
+          captured: false,
+          source: 'unavailable',
+          reason: 'session_unavailable',
+        },
+        requestId: 'tr_session_unavailable',
+      },
+    });
+
+    expect(screen.getByTestId('payload-summary')).toHaveTextContent(
+      'The session transcript is unavailable or has been cleaned up.',
+    );
+    expect(screen.queryByTestId('load-transcript')).not.toBeInTheDocument();
+  });
+
   it('surfaces a structured error with class, status, redacted message and redacted provider_raw', () => {
     render(DetailPage, {
       data: {

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -326,6 +326,27 @@ test.describe("admin request payload view", () => {
     await expect(page.getByTestId("payload-summary")).toContainText(/no captured Session ID/i);
   });
 
+  test("does not offer transcript loading when the request is absent from its recorded Session", async ({
+    page,
+  }) => {
+    await page.route(`**/admin/api/requests/${SEED_TRACE_ID}/payload?part=meta`, async (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          captured: false,
+          source: "unavailable",
+          reason: "session_unavailable",
+        }),
+      }),
+    );
+
+    await page.goto(`${BASE}/admin/requests/${SEED_TRACE_ID}`);
+    await expect(page.getByTestId("payload-summary")).toContainText(
+      /session transcript is unavailable/i,
+    );
+    await expect(page.getByTestId("load-transcript")).toHaveCount(0);
+  });
+
   test("rebuilds a too-large transcript without a duplicate Session panel", async ({ page }) => {
     await page.route(`**/admin/api/requests/${SEED_TRACE_ID}/payload?part=meta`, async (route) =>
       route.fulfill({

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -1871,6 +1871,35 @@ describe("admin.api request payload", () => {
     });
   });
 
+  it("does not advertise transcript loading when the request is absent from its recorded Session", async () => {
+    const rec = {
+      ...decision("req_session_mismatch", "balanced"),
+      session: { ref: "recorded-session", label: "thread-1", source: "x-thread-id" as const },
+    };
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayloadMeta: async () => null,
+      getSessionRevisionMeta: async () => ({
+        requestId: "req_session_mismatch",
+        sessionRef: "different-session",
+        responseBodyStored: true,
+        recoveryWireBytes: 1_000_000,
+        fidelity: "semantic",
+        createdAt: new Date(1234),
+      }),
+    } as unknown as TelemetryStore;
+
+    const response = await buildApp(buildDeps({ telemetry })).request(
+      "/admin/api/requests/req_session_mismatch/payload?part=meta",
+    );
+
+    expect(await response.json()).toEqual({
+      captured: false,
+      source: "unavailable",
+      reason: "session_unavailable",
+    });
+  });
+
   it.each([
     null,
     1_000_000,

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -143,6 +143,14 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
       if (!meta) {
         const sessionMeta = await deps.telemetry.getSessionRevisionMeta?.(traceId);
         if (sessionMeta) {
+          const decision = await deps.telemetry.getByRequestId(traceId);
+          if (decision?.session?.ref !== sessionMeta.sessionRef) {
+            return c.json({
+              captured: false,
+              source: "unavailable",
+              reason: "session_unavailable",
+            });
+          }
           const responseAdmission = deps.responseWorkAdmission ?? runtimeResponseWorkAdmission();
           if (
             sessionMeta.recoveryWireBytes === null ||
@@ -154,7 +162,6 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
               reason: "session_recovery_limited",
             });
           }
-          const decision = await deps.telemetry.getByRequestId(traceId);
           return c.json({
             captured: true,
             source: "session",


### PR DESCRIPTION
## Summary
- verify the request revision belongs to the request's recorded Session before advertising transcript recovery
- return `session_unavailable` for mismatched Session references so Admin hides the loader
- cover the gateway response, Admin DOM state, and browser flow

## Root cause
The live request's recorded Session returned 91 revisions, but none matched the target request ID. Payload metadata still returned `session_recovery_limited`, so the UI offered a loader that could never succeed.

## Validation
- `CI=true pnpm exec vitest run apps/gateway/src/routes/admin/admin.test.ts` (100 passed)
- `CI=true pnpm exec vitest run apps/admin/src/routes/requests/requests.test.ts -t "hides transcript loading when the recorded Session is unavailable"`
- `pnpm --filter @helm/gateway typecheck`
- `pnpm --filter @helm/admin build`
- `pnpm exec biome check apps/gateway/src/routes/admin/requests.ts apps/gateway/src/routes/admin/admin.test.ts apps/gateway/e2e/admin.spec.ts`