### PR TITLE
fix(oauth): avoid periodic model cache rewrites

### DIFF
--- a/apps/gateway/src/oauth/codex-model-cache.test.ts
+++ b/apps/gateway/src/oauth/codex-model-cache.test.ts
@@ -274,6 +274,36 @@ describe("createCodexModelCache", () => {
     });
   });
 
+  it("renews a hot entry without rereading or rewriting the persistent cache", async () => {
+    let now = 9_000;
+    let reads = 0;
+    let writes = 0;
+    const persisted = encryptSecret(JSON.stringify({ version: 1, entries: [entry()] }), ENC_KEY);
+    const store: ConfigStore = {
+      get: async () => {
+        reads += 1;
+        return persisted;
+      },
+      set: async () => {
+        writes += 1;
+      },
+    };
+    const cache = createCodexModelCache(store, ENC_KEY, { now: () => now });
+
+    await expect(cache.get(BASE_KEY)).resolves.toMatchObject({ fresh: true });
+    now = 10_000;
+    await expect(cache.renew(BASE_KEY, '"models-v1"')).resolves.toMatchObject({
+      fetchedAtMs: 10_000,
+    });
+    await expect(cache.get(BASE_KEY)).resolves.toMatchObject({
+      entry: { fetchedAtMs: 10_000 },
+      fresh: true,
+    });
+
+    expect(reads).toBe(1);
+    expect(writes).toBe(0);
+  });
+
   it("serializes concurrent upserts so unrelated accounts are not lost", async () => {
     const store = new DelayedFirstSetConfig();
     const cache = createCodexModelCache(store, ENC_KEY, { now: () => 2_000 });

--- a/apps/gateway/src/oauth/codex-model-cache.ts
+++ b/apps/gateway/src/oauth/codex-model-cache.ts
@@ -262,7 +262,7 @@ export function createCodexModelCache(
       const normalizedKey = normalizeKey(key);
       if (normalizedKey === null) return null;
       return serializeMutation(config, async () => {
-        const { entries } = await loadEntries(config, encKey, maxEntries);
+        const entries = hotEntries ?? (await loadEntries(config, encKey, maxEntries)).entries;
         const index = entries.findIndex((candidate) => sameKey(candidate, normalizedKey));
         if (index === -1 || entries[index]?.etag !== etag) return null;
         const renewed = cloneEntry({
@@ -271,7 +271,9 @@ export function createCodexModelCache(
         });
         entries[index] = renewed;
         const bounded = boundEntries(entries, maxEntries);
-        await saveEntries(config, encKey, bounded);
+        // Same-ETag renewal is only a process-local freshness optimization. Persisting
+        // the whole encrypted catalog every TTL window creates a large periodic heap
+        // spike; after a restart, a stale timestamp safely causes one network refresh.
         hotEntries = bounded;
         return cloneEntry(renewed);
       });


### PR DESCRIPTION
## Summary

- keep same-ETag Codex model-cache renewals process-local
- avoid rereading, decrypting, cloning, serializing, encrypting, and rewriting the full persistent cache every 300 seconds
- retain durable writes when the model catalog actually changes

## Incident evidence

Production had a 15.7 MB encrypted Codex model-cache blob and V8 heap OOM restarts at the same roughly five-minute cadence as the cache TTL. Nginx 502 clusters matched every Node exit. Large concurrent Responses requests amplified the periodic allocation spike.

## Verification

- Red: regression test observed a second ConfigStore read and a full write during same-ETag renewal
- Green: 34 focused cache/catalog tests pass
- Gateway typecheck passes
- Biome passes on both changed files
- Gateway build passes

## Scope

This fixes the confirmed periodic OOM trigger. The independent large-request admission accounting issue remains separate and should only be changed if post-deploy monitoring still shows memory failures.