### PR TITLE
chore(release): v0.28.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.62",
+  "version": "0.28.63",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version-only release bump from 0.28.62 to 0.28.63. Includes merged PR #733 and the Codex model-cache OOM fix from PR #734.