### PR TITLE
fix(oauth): keep Codex model cache process-local

### DIFF
--- a/apps/gateway/src/oauth/codex-model-cache.test.ts
+++ b/apps/gateway/src/oauth/codex-model-cache.test.ts
@@ -1,4 +1,4 @@
-import { type ConfigStore, decryptSecret, encryptSecret } from "@helm/core";
+import type { ConfigStore } from "@helm/core";
 import { describe, expect, it } from "vitest";
 import {
   CODEX_MODEL_CACHE_CONFIG_KEY,
@@ -40,36 +40,8 @@ function entry(overrides: Partial<CodexModelCacheEntry> = {}): CodexModelCacheEn
   };
 }
 
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
-
-class DelayedFirstSetConfig implements ConfigStore {
-  readonly values = new Map<string, string>();
-  readonly firstSetStarted = deferred();
-  readonly releaseFirstSet = deferred();
-  private setCount = 0;
-
-  async get(key: string): Promise<string | null> {
-    return this.values.get(key) ?? null;
-  }
-
-  async set(key: string, value: string): Promise<void> {
-    this.setCount += 1;
-    if (this.setCount === 1) {
-      this.firstSetStarted.resolve();
-      await this.releaseFirstSet.promise;
-    }
-    this.values.set(key, value);
-  }
-}
-
 describe("createCodexModelCache", () => {
-  it("fails open when the cache is missing, corrupt, or unreadable", async () => {
+  it("never reads or writes ConfigStore", async () => {
     const missing = createCodexModelCache(fakeConfigStore(), ENC_KEY);
     await expect(missing.get(BASE_KEY)).resolves.toBeNull();
 
@@ -90,21 +62,47 @@ describe("createCodexModelCache", () => {
     const unavailable = createCodexModelCache(unreadable, ENC_KEY);
     await expect(unavailable.get(BASE_KEY)).resolves.toBeNull();
     await expect(unavailable.upsert(entry())).resolves.toEqual(entry());
+    await expect(unavailable.get(BASE_KEY)).resolves.toMatchObject({ entry: entry() });
+    await expect(unavailable.renew(BASE_KEY, '"models-v1"')).resolves.toMatchObject({
+      etag: '"models-v1"',
+    });
   });
 
-  it("persists an encrypted blob and returns an exact fresh match", async () => {
+  it("ignores the aggregate legacy blob and stays hot-only", async () => {
+    const values = new Map<string, string>([
+      [CODEX_MODEL_CACHE_CONFIG_KEY, "legacy-aggregate-blob"],
+    ]);
+    let legacyReads = 0;
+    const store: ConfigStore = {
+      get: async (key) => {
+        if (key === CODEX_MODEL_CACHE_CONFIG_KEY) legacyReads += 1;
+        return values.get(key) ?? null;
+      },
+      set: async (key, value) => {
+        values.set(key, value);
+      },
+    };
+    const cache = createCodexModelCache(store, ENC_KEY, { now: () => 1_100 });
+
+    await expect(cache.get(BASE_KEY)).resolves.toBeNull();
+    expect(legacyReads).toBe(0);
+    await expect(cache.upsert(entry())).resolves.toEqual(entry());
+
+    const exactKeys = [...values.keys()].filter((key) => key !== CODEX_MODEL_CACHE_CONFIG_KEY);
+    expect(exactKeys).toHaveLength(0);
+    await expect(
+      createCodexModelCache(store, ENC_KEY, { now: () => 1_100 }).get(BASE_KEY),
+    ).resolves.toBeNull();
+    expect(legacyReads).toBe(0);
+  });
+
+  it("returns an exact fresh match from the hot cache", async () => {
     const store = fakeConfigStore();
     const cache = createCodexModelCache(store, ENC_KEY, { now: () => 1_100 });
 
     await cache.upsert(entry());
 
-    const blob = store.values.get(CODEX_MODEL_CACHE_CONFIG_KEY);
-    expect(blob).toMatch(/^v1:/);
-    expect(blob).not.toContain("gpt-5.6-sol");
-    expect(JSON.parse(decryptSecret(blob ?? "", ENC_KEY))).toEqual({
-      version: 1,
-      entries: [entry()],
-    });
+    expect(store.values.size).toBe(0);
     await expect(cache.get(BASE_KEY)).resolves.toEqual({
       entry: entry(),
       fresh: true,
@@ -126,48 +124,14 @@ describe("createCodexModelCache", () => {
     });
   });
 
-  it("hydrates the encrypted blob once and serves repeated hot gets from memory", async () => {
-    let reads = 0;
-    const persisted = encryptSecret(JSON.stringify({ version: 1, entries: [entry()] }), ENC_KEY);
-    const base = fakeConfigStore({ [CODEX_MODEL_CACHE_CONFIG_KEY]: persisted });
-    const store: ConfigStore = {
-      get: async (key) => {
-        reads += 1;
-        return base.get(key);
-      },
-      set: (key, value) => base.set(key, value),
-    };
-    const cache = createCodexModelCache(store, ENC_KEY, { now: () => 1_100 });
-
-    await expect(cache.get(BASE_KEY)).resolves.toMatchObject({ fresh: true });
-    await expect(cache.get(BASE_KEY)).resolves.toMatchObject({ fresh: true });
-    expect(reads).toBe(1);
-  });
-
-  it("keeps one underlying hydration when the first caller disconnects", async () => {
-    let reads = 0;
-    const loading = deferred();
-    const persisted = encryptSecret(JSON.stringify({ version: 1, entries: [entry()] }), ENC_KEY);
-    const store: ConfigStore = {
-      get: async () => {
-        reads += 1;
-        await loading.promise;
-        return persisted;
-      },
-      set: async () => {},
-    };
-    const cache = createCodexModelCache(store, ENC_KEY, { now: () => 1_100 });
+  it("honors an already-aborted get without touching the hot cache", async () => {
+    const cache = createCodexModelCache(fakeConfigStore(), ENC_KEY, { now: () => 1_100 });
+    await cache.upsert(entry());
     const caller = new AbortController();
-    const first = cache.get(BASE_KEY, caller.signal);
     caller.abort(new Error("caller disconnected"));
 
-    await expect(first).rejects.toThrow("caller disconnected");
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    const second = cache.get(BASE_KEY);
-    loading.resolve();
-
-    await expect(second).resolves.toMatchObject({ fresh: true });
-    expect(reads).toBe(1);
+    await expect(cache.get(BASE_KEY, caller.signal)).rejects.toThrow("caller disconnected");
+    await expect(cache.get(BASE_KEY)).resolves.toMatchObject({ fresh: true });
   });
 
   it("requires provider, account, identity, and client version to all match", async () => {
@@ -198,13 +162,10 @@ describe("createCodexModelCache", () => {
       entry: { clientVersion: "0.145.0" },
     });
 
-    const blob = store.values.get(CODEX_MODEL_CACHE_CONFIG_KEY);
-    expect(JSON.parse(decryptSecret(blob ?? "", ENC_KEY))).toMatchObject({
-      entries: [{ clientVersion: "0.145.0" }],
-    });
+    expect(store.values.size).toBe(0);
   });
 
-  it("fails closed without persisting malformed or oversized client versions", async () => {
+  it("fails closed for malformed or oversized client versions", async () => {
     const store = fakeConfigStore();
     const cache = createCodexModelCache(store, ENC_KEY);
 
@@ -274,15 +235,14 @@ describe("createCodexModelCache", () => {
     });
   });
 
-  it("renews a hot entry without rereading or rewriting the persistent cache", async () => {
+  it("renews a hot entry without reading or writing ConfigStore", async () => {
     let now = 9_000;
     let reads = 0;
     let writes = 0;
-    const persisted = encryptSecret(JSON.stringify({ version: 1, entries: [entry()] }), ENC_KEY);
     const store: ConfigStore = {
       get: async () => {
         reads += 1;
-        return persisted;
+        return null;
       },
       set: async () => {
         writes += 1;
@@ -290,6 +250,7 @@ describe("createCodexModelCache", () => {
     };
     const cache = createCodexModelCache(store, ENC_KEY, { now: () => now });
 
+    await cache.upsert(entry());
     await expect(cache.get(BASE_KEY)).resolves.toMatchObject({ fresh: true });
     now = 10_000;
     await expect(cache.renew(BASE_KEY, '"models-v1"')).resolves.toMatchObject({
@@ -300,25 +261,19 @@ describe("createCodexModelCache", () => {
       fresh: true,
     });
 
-    expect(reads).toBe(1);
+    expect(reads).toBe(0);
     expect(writes).toBe(0);
   });
 
-  it("serializes concurrent upserts so unrelated accounts are not lost", async () => {
-    const store = new DelayedFirstSetConfig();
-    const cache = createCodexModelCache(store, ENC_KEY, { now: () => 2_000 });
-    const personal = cache.upsert(entry());
-    await store.firstSetStarted.promise;
+  it("keeps unrelated account entries across concurrent upserts", async () => {
+    const cache = createCodexModelCache(fakeConfigStore(), ENC_KEY, { now: () => 2_000 });
     const teamEntry = entry({
       account: "team",
       accountIdentity: "workspace-9",
       etag: '"team-v1"',
       models: [{ slug: "gpt-5.6-terra" }],
     });
-    const team = cache.upsert(teamEntry);
-
-    store.releaseFirstSet.resolve();
-    await Promise.all([personal, team]);
+    await Promise.all([cache.upsert(entry()), cache.upsert(teamEntry)]);
 
     await expect(cache.get(BASE_KEY)).resolves.toMatchObject({ entry: entry() });
     await expect(
@@ -331,9 +286,8 @@ describe("createCodexModelCache", () => {
     ).resolves.toMatchObject({ entry: teamEntry });
   });
 
-  it("bounds the encrypted persistent cache by newest fetchedAtMs entries", async () => {
-    const store = fakeConfigStore();
-    const cache = createCodexModelCache(store, ENC_KEY, { maxEntries: 3 });
+  it("bounds the hot cache by newest fetchedAtMs entries", async () => {
+    const cache = createCodexModelCache(fakeConfigStore(), ENC_KEY, { maxEntries: 3 });
 
     for (let index = 1; index <= 5; index += 1) {
       await cache.upsert(
@@ -346,44 +300,30 @@ describe("createCodexModelCache", () => {
       );
     }
 
-    const blob = store.values.get(CODEX_MODEL_CACHE_CONFIG_KEY);
-    const persisted = JSON.parse(decryptSecret(blob ?? "", ENC_KEY)) as {
-      entries: CodexModelCacheEntry[];
-    };
-    expect(persisted.entries).toHaveLength(3);
-    expect(persisted.entries.map((item) => item.fetchedAtMs).sort()).toEqual([3, 4, 5]);
-    expect(DEFAULT_CODEX_MODEL_CACHE_MAX_ENTRIES).toBe(64);
-  });
-
-  it("drops invalid and excess legacy entries while loading an existing blob", async () => {
-    const persisted = {
-      version: 1,
-      entries: [
-        entry({ account: "old", fetchedAtMs: 1 }),
-        entry({ account: "new", fetchedAtMs: 3 }),
-        entry({ account: "middle", fetchedAtMs: 2 }),
-        entry({ account: "invalid", clientVersion: "latest", fetchedAtMs: 4 }),
-      ],
-    };
-    const store = fakeConfigStore({
-      [CODEX_MODEL_CACHE_CONFIG_KEY]: encryptSecret(JSON.stringify(persisted), ENC_KEY),
-    });
-    const cache = createCodexModelCache(store, ENC_KEY, { maxEntries: 2 });
-
-    await expect(cache.get({ ...BASE_KEY, account: "new" })).resolves.toMatchObject({
-      entry: { account: "new" },
-    });
-    await expect(cache.get({ ...BASE_KEY, account: "middle" })).resolves.toMatchObject({
-      entry: { account: "middle" },
-    });
-    await expect(cache.get({ ...BASE_KEY, account: "old" })).resolves.toBeNull();
     await expect(
-      cache.get({ ...BASE_KEY, account: "invalid", clientVersion: "latest" }),
+      cache.get({
+        ...BASE_KEY,
+        account: "account-1",
+        accountIdentity: "identity-1",
+        clientVersion: "0.1.0",
+      }),
     ).resolves.toBeNull();
-
-    const cleaned = JSON.parse(
-      decryptSecret(store.values.get(CODEX_MODEL_CACHE_CONFIG_KEY) ?? "", ENC_KEY),
-    ) as { entries: CodexModelCacheEntry[] };
-    expect(cleaned.entries.map((item) => item.account)).toEqual(["new", "middle"]);
+    await expect(
+      cache.get({
+        ...BASE_KEY,
+        account: "account-3",
+        accountIdentity: "identity-3",
+        clientVersion: "0.3.0",
+      }),
+    ).resolves.toMatchObject({ entry: { fetchedAtMs: 3 } });
+    await expect(
+      cache.get({
+        ...BASE_KEY,
+        account: "account-5",
+        accountIdentity: "identity-5",
+        clientVersion: "0.5.0",
+      }),
+    ).resolves.toMatchObject({ entry: { fetchedAtMs: 5 } });
+    expect(DEFAULT_CODEX_MODEL_CACHE_MAX_ENTRIES).toBe(64);
   });
 });

--- a/apps/gateway/src/oauth/codex-model-cache.ts
+++ b/apps/gateway/src/oauth/codex-model-cache.ts
@@ -1,4 +1,4 @@
-import { type ConfigStore, decryptSecret, encryptSecret } from "@helm/core";
+import type { ConfigStore } from "@helm/core";
 import { normalizeOpenAICodexClientVersion } from "./codex-client-version.js";
 
 export const CODEX_MODEL_CACHE_CONFIG_KEY = "oauth.codex_model_cache";
@@ -37,18 +37,6 @@ export interface CodexModelCacheOptions {
   maxEntries?: number;
   now?: () => number;
 }
-
-interface PersistedCodexModelCache {
-  version: 1;
-  entries: CodexModelCacheEntry[];
-}
-
-interface LoadedCodexModelCache {
-  entries: CodexModelCacheEntry[];
-  needsCleanup: boolean;
-}
-
-const mutationQueues = new WeakMap<ConfigStore, Promise<void>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -89,15 +77,6 @@ function normalizeKey(key: CodexModelCacheKey): CodexModelCacheKey | null {
   return clientVersion === null ? null : { ...key, clientVersion };
 }
 
-function sameKey(left: CodexModelCacheKey, right: CodexModelCacheKey): boolean {
-  return (
-    left.providerId === right.providerId &&
-    left.account === right.account &&
-    left.accountIdentity === right.accountIdentity &&
-    left.clientVersion === right.clientVersion
-  );
-}
-
 function keyId(key: CodexModelCacheKey): string {
   return JSON.stringify([key.providerId, key.account, key.accountIdentity, key.clientVersion]);
 }
@@ -109,100 +88,9 @@ function cloneEntry(entry: CodexModelCacheEntry): CodexModelCacheEntry {
   };
 }
 
-function boundEntries(values: readonly unknown[], maxEntries: number): CodexModelCacheEntry[] {
-  const sorted = values
-    .map(parseEntry)
-    .filter((entry): entry is CodexModelCacheEntry => entry !== null)
-    .sort((left, right) => right.fetchedAtMs - left.fetchedAtMs);
-  const seen = new Set<string>();
-  const bounded: CodexModelCacheEntry[] = [];
-  for (const entry of sorted) {
-    const id = keyId(entry);
-    if (seen.has(id)) continue;
-    seen.add(id);
-    bounded.push(entry);
-    if (bounded.length >= maxEntries) break;
-  }
-  return bounded;
-}
-
-async function loadEntries(
-  config: ConfigStore,
-  encKey: Buffer,
-  maxEntries: number,
-): Promise<LoadedCodexModelCache> {
-  try {
-    const blob = await config.get(CODEX_MODEL_CACHE_CONFIG_KEY);
-    if (!blob) return { entries: [], needsCleanup: false };
-    const parsed: unknown = JSON.parse(decryptSecret(blob, encKey));
-    if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
-      return { entries: [], needsCleanup: false };
-    }
-    const entries = boundEntries(parsed.entries, maxEntries);
-    return {
-      entries,
-      needsCleanup: JSON.stringify(parsed.entries) !== JSON.stringify(entries),
-    };
-  } catch {
-    return { entries: [], needsCleanup: false };
-  }
-}
-
-async function saveEntries(
-  config: ConfigStore,
-  encKey: Buffer,
-  entries: CodexModelCacheEntry[],
-): Promise<void> {
-  try {
-    const payload: PersistedCodexModelCache = {
-      version: 1,
-      entries: entries.map(cloneEntry),
-    };
-    await config.set(CODEX_MODEL_CACHE_CONFIG_KEY, encryptSecret(JSON.stringify(payload), encKey));
-  } catch {
-    // Model discovery is an optimization; persistence failure must not block routing.
-  }
-}
-
-function waitForSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-  if (!signal) return promise;
-  if (signal.aborted) return Promise.reject(signal.reason);
-  return new Promise<T>((resolve, reject) => {
-    const aborted = () => reject(signal.reason);
-    signal.addEventListener("abort", aborted, { once: true });
-    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", aborted));
-  });
-}
-
-function serializeMutation<T>(
-  config: ConfigStore,
-  work: () => Promise<T>,
-  signal?: AbortSignal,
-): Promise<T> {
-  const previous = mutationQueues.get(config) ?? Promise.resolve();
-  const run = previous.then(
-    () => {
-      signal?.throwIfAborted();
-      return work();
-    },
-    () => {
-      signal?.throwIfAborted();
-      return work();
-    },
-  );
-  mutationQueues.set(
-    config,
-    run.then(
-      () => undefined,
-      () => undefined,
-    ),
-  );
-  return waitForSignal(run, signal);
-}
-
 export function createCodexModelCache(
-  config: ConfigStore,
-  encKey: Buffer,
+  _config: ConfigStore,
+  _encKey: Buffer,
   options: CodexModelCacheOptions = {},
 ): CodexModelCache {
   const now = options.now ?? (() => Date.now());
@@ -211,30 +99,34 @@ export function createCodexModelCache(
     options.maxEntries === undefined || !Number.isFinite(options.maxEntries)
       ? DEFAULT_CODEX_MODEL_CACHE_MAX_ENTRIES
       : Math.max(1, Math.floor(options.maxEntries));
-  let hotEntries: CodexModelCacheEntry[] | null = null;
-  let hydration: Promise<CodexModelCacheEntry[]> | null = null;
+  // Model discovery is an optimization. Keep it process-local so the legacy
+  // aggregate encrypted blob can never be materialized on a request path.
+  const hotEntries = new Map<string, CodexModelCacheEntry>();
 
-  const hydrate = (signal?: AbortSignal): Promise<CodexModelCacheEntry[]> => {
-    if (hotEntries !== null) return Promise.resolve(hotEntries);
-    if (hydration === null) {
-      hydration = serializeMutation(config, async () => {
-        const loaded = await loadEntries(config, encKey, maxEntries);
-        if (loaded.needsCleanup) await saveEntries(config, encKey, loaded.entries);
-        hotEntries = loaded.entries;
-        return loaded.entries;
-      }).finally(() => {
-        hydration = null;
-      });
+  const remember = (entry: CodexModelCacheEntry): void => {
+    const id = keyId(entry);
+    hotEntries.delete(id);
+    hotEntries.set(id, entry);
+    while (hotEntries.size > maxEntries) {
+      let oldestId: string | undefined;
+      let oldestAt = Number.POSITIVE_INFINITY;
+      for (const [candidateId, candidate] of hotEntries) {
+        if (candidate.fetchedAtMs < oldestAt) {
+          oldestId = candidateId;
+          oldestAt = candidate.fetchedAtMs;
+        }
+      }
+      if (oldestId === undefined) break;
+      hotEntries.delete(oldestId);
     }
-    return waitForSignal(hydration, signal);
   };
 
   return {
     async get(key, signal) {
+      signal?.throwIfAborted();
       const normalizedKey = normalizeKey(key);
       if (normalizedKey === null) return null;
-      const entries = await hydrate(signal);
-      const entry = entries.find((candidate) => sameKey(candidate, normalizedKey));
+      const entry = hotEntries.get(keyId(normalizedKey));
       if (!entry) return null;
       return {
         entry: cloneEntry(entry),
@@ -245,38 +137,19 @@ export function createCodexModelCache(
     async upsert(entry) {
       const normalized = parseEntry(entry);
       if (normalized === null) return null;
-      return serializeMutation(config, async () => {
-        const { entries } = await loadEntries(config, encKey, maxEntries);
-        const next = cloneEntry(normalized);
-        const index = entries.findIndex((candidate) => sameKey(candidate, next));
-        if (index === -1) entries.push(next);
-        else entries[index] = next;
-        const bounded = boundEntries(entries, maxEntries);
-        await saveEntries(config, encKey, bounded);
-        hotEntries = bounded;
-        return cloneEntry(next);
-      });
+      remember(normalized);
+      return cloneEntry(normalized);
     },
 
     async renew(key, etag) {
       const normalizedKey = normalizeKey(key);
       if (normalizedKey === null) return null;
-      return serializeMutation(config, async () => {
-        const entries = hotEntries ?? (await loadEntries(config, encKey, maxEntries)).entries;
-        const index = entries.findIndex((candidate) => sameKey(candidate, normalizedKey));
-        if (index === -1 || entries[index]?.etag !== etag) return null;
-        const renewed = cloneEntry({
-          ...entries[index],
-          fetchedAtMs: now(),
-        });
-        entries[index] = renewed;
-        const bounded = boundEntries(entries, maxEntries);
-        // Same-ETag renewal is only a process-local freshness optimization. Persisting
-        // the whole encrypted catalog every TTL window creates a large periodic heap
-        // spike; after a restart, a stale timestamp safely causes one network refresh.
-        hotEntries = bounded;
-        return cloneEntry(renewed);
-      });
+      const id = keyId(normalizedKey);
+      const entry = hotEntries.get(id);
+      if (!entry || entry.etag !== etag) return null;
+      const renewed = cloneEntry({ ...entry, fetchedAtMs: now() });
+      hotEntries.set(id, renewed);
+      return cloneEntry(renewed);
     },
   };
 }


### PR DESCRIPTION
P0 production OOM fix. v0.28.63 still restarted with V8 heap OOM about every five minutes because cache get/upsert/renew could materialize the 15.7 MB encrypted legacy aggregate blob. This removes aggregate persistence and keeps an exact-key, 64-entry process-local cache; cold misses retain existing network refresh and bundled fallback. Focused cache/catalog tests: 33 passed. Gateway typecheck and build passed. Production v0.28.63 monitor observed 3 restarts and 91 new proxy errors in 11 minutes.