### PR TITLE
chore: release v0.28.64

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.63",
+  "version": "0.28.64",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API to v0.28.64
- release the bounded in-memory Codex model cache fix from #736

## Verification
- version-only diff
- #736 CI passed: verify, store, e2e, docker