### PR TITLE
fix: prevent memory worker OOM on oversized histories

### DIFF
--- a/packages/core/src/memory/observer.test.ts
+++ b/packages/core/src/memory/observer.test.ts
@@ -678,4 +678,22 @@ describe("runObserverJob — re-enqueue on a turn that arrives during the run", 
       thread_id: "thread-1",
     });
   });
+
+  it("does not materialize an oversized thread history", async () => {
+    const { store, jobUpdates } = makeFakeStore(makeShortThread());
+    store.getThreadMeta = vi.fn(async () => ({
+      lastServedModel: null,
+      messageCount: 4_097,
+      observationCount: 0,
+    }));
+    const deps = makeDeps(store);
+
+    await expect(runObserverJob(JOB, deps)).resolves.toEqual({
+      observationId: null,
+      sourceMessageRange: null,
+    });
+    expect(store.listMessages).not.toHaveBeenCalled();
+    expect(store.listObservations).not.toHaveBeenCalled();
+    expect(jobUpdates).toEqual([{ jobId: JOB.jobId, status: "done" }]);
+  });
 });

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -12,6 +12,9 @@ import type { ExtractedFact } from "./reflector.js";
 // consolidate.max_facts_per_subject schema default — used when the composition root
 // wires the eager extractor without an explicit cap.
 const DEFAULT_MAX_FACTS_PER_SUBJECT = 8;
+// ponytail: skip oversized legacy histories; replace with cursor paging when they must compact.
+const MAX_OBSERVER_THREAD_MESSAGES = 4_096;
+const MAX_OBSERVER_THREAD_OBSERVATIONS = 512;
 
 // Salient-fact fast path (salient-fact-memory-spec Change A). Mine the thread's
 // UNCOVERED raw turns for durable facts and persist them at the thread's
@@ -347,6 +350,24 @@ export async function runObserverJob(
   deps: ObserverDeps,
 ): Promise<ObserverResult> {
   try {
+    const readMeta =
+      deps.memoryStore.getThreadMeta === undefined
+        ? null
+        : await deps.memoryStore
+            .getThreadMeta({ accountId: job.accountId, threadId: job.threadId })
+            .catch(() => null);
+    if (
+      (readMeta?.messageCount ?? 0) > MAX_OBSERVER_THREAD_MESSAGES ||
+      (readMeta?.observationCount ?? 0) > MAX_OBSERVER_THREAD_OBSERVATIONS
+    ) {
+      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      deps.log("memory.observer.history_skipped", {
+        thread_id: job.threadId,
+        max_messages: MAX_OBSERVER_THREAD_MESSAGES,
+        max_observations: MAX_OBSERVER_THREAD_OBSERVATIONS,
+      });
+      return { observationId: null, sourceMessageRange: null };
+    }
     const all = await deps.memoryStore.listMessages({
       accountId: job.accountId,
       threadId: job.threadId,
@@ -374,10 +395,7 @@ export async function runObserverJob(
     //   priorCompactionCount → the thread's actual observation count (the v1
     //              static 0 never engaged the distortion brake).
     //   retention → measured output/source ratio of prior observations.
-    const threadMeta = await deps.memoryStore
-      .getThreadMeta?.({ accountId: job.accountId, threadId: job.threadId })
-      .catch(() => null);
-    const modelAlias = threadMeta?.lastServedModel ?? null;
+    const modelAlias = readMeta?.lastServedModel ?? null;
     const pricing = deps.resolvePricing(modelAlias);
     const tunables = resolveCompactionTunables(deps.compaction);
     // Idle is derived HERE, at run time, from the newest message's age — NOT from

--- a/packages/core/src/memory/reflector.test.ts
+++ b/packages/core/src/memory/reflector.test.ts
@@ -479,3 +479,23 @@ describe("runReflectorJob — reflection target scope (readable by inject)", () 
     expect(upserts[0]?.threadId).toBeUndefined();
   });
 });
+
+describe("runReflectorJob — materialization guard", () => {
+  it("does not load an oversized cross-thread observation set", async () => {
+    const { store, jobUpdates } = makeFakeStore(makeObservations(["obs A"]));
+    store.getObservationCount = vi.fn(async () => 513);
+    const deps = makeDeps(store);
+    const job: ReflectorJob = {
+      jobId: "job-large",
+      scope: { accountId: "acct-a", projectId: "proj-1" },
+    };
+
+    await expect(runReflectorJob(job, deps)).resolves.toEqual({
+      reflectionId: null,
+      version: null,
+      changed: false,
+    });
+    expect(store.listObservations).not.toHaveBeenCalled();
+    expect(jobUpdates).toEqual([{ jobId: "job-large", status: "done" }]);
+  });
+});

--- a/packages/core/src/memory/reflector.ts
+++ b/packages/core/src/memory/reflector.ts
@@ -2,6 +2,9 @@ import type { Observation, Reflection, ReflectionScope } from "@helm/shared";
 import type { MemoryStore } from "../store/ports.js";
 import { buildReconciledFactBatch } from "./forgetting/facts.js";
 
+// ponytail: skip oversized legacy scopes; replace with bounded incremental merging when required.
+const MAX_REFLECTOR_OBSERVATIONS = 512;
+
 // Background Reflector (docs/08 Phase 2 "observational-memory MVP"). This is an OFF-the-main-
 // request-path job: a scheduler triggers it PERIODICALLY to merge a scope's many
 // observations into ONE stable, slowly-changing, VERSIONED reflection — the
@@ -135,6 +138,19 @@ export async function runReflectorJob(
     // only the promoting thread's observations would make the project reflection
     // last-writer-wins per thread.
     const target = reflectionTargetScope(job.scope);
+    const observationCount =
+      deps.memoryStore.getObservationCount === undefined
+        ? null
+        : await deps.memoryStore.getObservationCount(target);
+    if (observationCount !== null && observationCount > MAX_REFLECTOR_OBSERVATIONS) {
+      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      deps.log("memory.reflector.history_skipped", {
+        scope: job.scope,
+        target_scope: target,
+        max_observations: MAX_REFLECTOR_OBSERVATIONS,
+      });
+      return { reflectionId: null, version: null, changed: false };
+    }
     // docs/12 (P5/P6 correctness) — the Reflector merges + extracts facts from
     // ACTIVE observations ONLY. `listObservations` returns every status (the
     // archived/pruned rows still serve as raw-coverage markers for inject/observer),

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -1048,10 +1048,14 @@ export interface MemoryStore {
   }): Promise<void>;
   // Auto-compaction — the read half. Return the thread's stamped model alias
   // (null when never stamped / unknown thread). OPTIONAL (`?`), same contract.
-  getThreadMeta?(input: {
-    accountId: string;
-    threadId: string;
-  }): Promise<{ lastServedModel: string | null } | null>;
+  getThreadMeta?(input: { accountId: string; threadId: string }): Promise<{
+    lastServedModel: string | null;
+    messageCount?: number;
+    observationCount?: number;
+  } | null>;
+  // Scalar guard for cross-thread reflector reads, avoiding unbounded heap
+  // materialization of project/resource observation sets.
+  getObservationCount?(scope: ReflectionScope): Promise<number>;
   // Idle-flush sweep (memory formation backstop) — run on the worker tick, never
   // per request. Return threads that went QUIET with uncompacted history: last
   // activity ≤ idleBeforeMs AND at least one message NEWER than the thread's

--- a/packages/core/src/store/postgres/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/postgres/memory-auto-compaction.test.ts
@@ -31,6 +31,8 @@ describe("PgMemoryStore — thread model stamp", () => {
 
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "t1" })).toEqual({
       lastServedModel: null,
+      messageCount: 0,
+      observationCount: 0,
     });
     await store.stampThreadModel({
       accountId: "acct-a",
@@ -39,6 +41,8 @@ describe("PgMemoryStore — thread model stamp", () => {
     });
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "t1" })).toEqual({
       lastServedModel: "anthropic/claude-x",
+      messageCount: 0,
+      observationCount: 0,
     });
     await db.$close();
   });
@@ -49,6 +53,8 @@ describe("PgMemoryStore — thread model stamp", () => {
     await store.stampThreadModel({ accountId: "acct-b", threadId: "t1", modelAlias: "evil" });
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "t1" })).toEqual({
       lastServedModel: null,
+      messageCount: 0,
+      observationCount: 0,
     });
     expect(await store.getThreadMeta({ accountId: "acct-b", threadId: "t1" })).toBeNull();
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "nope" })).toBeNull();

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -1811,20 +1811,41 @@ export class PgMemoryStore implements MemoryStore {
   }
 
   // Read half: the thread's stamped model alias, account-guarded.
-  async getThreadMeta(input: {
-    accountId: string;
-    threadId: string;
-  }): Promise<{ lastServedModel: string | null } | null> {
+  async getThreadMeta(input: { accountId: string; threadId: string }): Promise<{
+    lastServedModel: string | null;
+    messageCount: number;
+    observationCount: number;
+  } | null> {
     const result = (await this.db.execute(sql`
-      SELECT last_served_model
+      SELECT last_served_model, message_count, observation_count
         FROM memory_threads
        WHERE id = ${input.threadId} AND owner_id = ${input.accountId}
     `)) as unknown;
     const rows = (
       Array.isArray(result) ? result : ((result as { rows?: unknown[] }).rows ?? [])
-    ) as Array<{ last_served_model: string | null }>;
+    ) as Array<{
+      last_served_model: string | null;
+      message_count: number;
+      observation_count: number;
+    }>;
     const row = rows[0];
-    return row === undefined ? null : { lastServedModel: row.last_served_model };
+    return row === undefined
+      ? null
+      : {
+          lastServedModel: row.last_served_model,
+          messageCount: Number(row.message_count),
+          observationCount: Number(row.observation_count),
+        };
+  }
+
+  async getObservationCount(scope: ReflectionScope): Promise<number> {
+    const where = observationScopeWhere(scope);
+    if (where === null) return 0;
+    const rows = await this.db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(memoryObservations)
+      .where(where);
+    return Number(rows[0]?.n ?? 0);
   }
 
   // Idle-flush sweep candidates — pg mirror of the sqlite adapter. Idleness =

--- a/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
@@ -36,6 +36,8 @@ describe("SqliteMemoryStore — thread model stamp", () => {
     // Never stamped → null alias (not a missing row).
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "t1" })).toEqual({
       lastServedModel: null,
+      messageCount: 0,
+      observationCount: 0,
     });
 
     await store.stampThreadModel({
@@ -45,6 +47,8 @@ describe("SqliteMemoryStore — thread model stamp", () => {
     });
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "t1" })).toEqual({
       lastServedModel: "anthropic/claude-x",
+      messageCount: 0,
+      observationCount: 0,
     });
 
     // A later turn served by a different model overwrites the stamp.
@@ -55,6 +59,8 @@ describe("SqliteMemoryStore — thread model stamp", () => {
     });
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "t1" })).toEqual({
       lastServedModel: "openai/gpt-x",
+      messageCount: 0,
+      observationCount: 0,
     });
   });
 
@@ -68,6 +74,8 @@ describe("SqliteMemoryStore — thread model stamp", () => {
     });
     expect(await store.getThreadMeta({ accountId: "acct-a", threadId: "t1" })).toEqual({
       lastServedModel: null,
+      messageCount: 0,
+      observationCount: 0,
     });
     // Wrong-owner read → null (indistinguishable from an unknown thread).
     expect(await store.getThreadMeta({ accountId: "acct-b", threadId: "t1" })).toBeNull();

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -2047,18 +2047,38 @@ export class SqliteMemoryStore implements MemoryStore {
 
   // Read half: the thread's stamped model alias, account-guarded. null row =
   // unknown thread; null alias = never stamped (the policy's heuristics apply).
-  async getThreadMeta(input: {
-    accountId: string;
-    threadId: string;
-  }): Promise<{ lastServedModel: string | null } | null> {
+  async getThreadMeta(input: { accountId: string; threadId: string }): Promise<{
+    lastServedModel: string | null;
+    messageCount: number;
+    observationCount: number;
+  } | null> {
     const row = this.db.$sqlite
       .prepare(
-        `SELECT last_served_model AS last_served_model
+        `SELECT last_served_model AS last_served_model,
+                message_count AS message_count,
+                observation_count AS observation_count
            FROM memory_threads
           WHERE id = ? AND owner_id = ?`,
       )
-      .get(input.threadId, input.accountId) as { last_served_model: string | null } | undefined;
-    return row === undefined ? null : { lastServedModel: row.last_served_model };
+      .get(input.threadId, input.accountId) as
+      | { last_served_model: string | null; message_count: number; observation_count: number }
+      | undefined;
+    return row === undefined
+      ? null
+      : {
+          lastServedModel: row.last_served_model,
+          messageCount: row.message_count,
+          observationCount: row.observation_count,
+        };
+  }
+
+  async getObservationCount(scope: ReflectionScope): Promise<number> {
+    const where = observationScopeWhere(scope);
+    if (where === null) return 0;
+    return (
+      this.db.select({ n: sql<number>`count(*)` }).from(memoryObservations).where(where).get()?.n ??
+      0
+    );
   }
 
   // Idle-flush sweep candidates: threads quiet since `idleBeforeMs` that still


### PR DESCRIPTION
## Root cause
Production has 125,260 memory threads and 2,085,142 raw messages. One running observer job targeted a thread with 51,116 messages; the worker called unbounded `listMessages()`, materialized the full body set, and crashed V8 at ~763 MiB live heap. The crash repeated after each worker tick and produced 502s.

## Fix
- preflight per-thread message/observation counters before observer materialization
- skip oversized legacy histories instead of loading them into the gateway heap
- preflight reflector observation counts before cross-thread materialization
- implement scalar count reads for SQLite and PostgreSQL

## Verification
- 43 focused observer/reflector tests passed
- `pnpm --filter @helm/core typecheck` passed
- focused Biome and `git diff --check` passed

## Operational note
Production memory worker is temporarily disabled until this exact fix is deployed and accepted.