### PR TITLE
chore: release v0.28.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.64",
+  "version": "0.28.65",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API to v0.28.65
- release the oversized Memory observer/reflector guard from #738

## Production evidence
- one running observer targeted 51,116 raw messages
- worker materialization repeatedly crashed V8 and caused 502s
- production is temporarily running with the memory worker disabled until this version is deployed

## Verification
- #738 verify, store, e2e, docker all passed
- full local store suite: 596 passed