### PR TITLE
chore: release v0.28.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.65",
+  "version": "0.28.66",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump Helm API to v0.28.66
- release the bounded Memory/OOM fixes merged in #740
- keep the production Memory worker disabled until the new image is migrated and gray-verified

## Verification inherited from #740

- CI verify, store, e2e, docker all passed
- 535 affected tests passed locally
- typecheck, lint, build passed locally
