### PR TITLE
fix(memory): bound lifecycle processing and fence stale workers

### DIFF
--- a/apps/admin/src/lib/api/memory.ts
+++ b/apps/admin/src/lib/api/memory.ts
@@ -19,6 +19,12 @@ export interface MemoryScope {
   lastUpdated: string | null;
 }
 
+export interface MemoryScopeQuery {
+  accountId?: string;
+  limit?: number;
+  offset?: number;
+}
+
 // Lifecycle status shared by facts (active|archived|pruned) and reflections
 // (active|archived). 'pruned' never appears on a reflection.
 export type MemoryStatus = 'active' | 'archived' | 'pruned';
@@ -216,11 +222,13 @@ function queryString(params: Record<string, string | number | boolean | undefine
 }
 
 // GET /admin/api/memory/scopes -> one row per (account,project,resource,thread).
-export async function listScopes(accountId?: string): Promise<MemoryScope[]> {
-  const res = await fetch(`${BASE}/scopes${queryString({ accountId })}`, {
+export async function listScopes(
+  params: MemoryScopeQuery = {},
+): Promise<{ rows: MemoryScope[]; total: number }> {
+  const res = await fetch(`${BASE}/scopes${queryString({ ...params })}`, {
     headers: { accept: 'application/json' },
   });
-  return asJson<MemoryScope[]>(res);
+  return asJson<{ rows: MemoryScope[]; total: number }>(res);
 }
 
 // GET /admin/api/memory/by-key/:keyId -> the key's memory scope (account +

--- a/apps/admin/src/routes/memory/+page.svelte
+++ b/apps/admin/src/routes/memory/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import type { ApiKeyView } from '$lib/api/keys.js';
+  import { listKeys, type ApiKeyView } from '$lib/api/keys.js';
   import {
     deleteFact,
     deleteReflection,
@@ -11,6 +11,7 @@
     getMemoryStats,
     listFacts,
     listReflections,
+    listScopes,
     type MemoryScope,
     type MemoryStats,
     type Reflection,
@@ -31,25 +32,33 @@
   // is a MANAGEMENT surface — it can show superseded/archived/pruned rows (status
   // filter) and soft-deletes (facts → pruned, reflections → archived) so an
   // operator can curate what the gateway remembers. Pure consumer of
-  // /admin/api/memory/* (CLAUDE.md Principle 1); the loader seeds scopes + keys,
-  // facts/reflections load on selection.
+  // /admin/api/memory/* (CLAUDE.md Principle 1); the loader seeds one scope page,
+  // while keys and facts/reflections load only on interaction.
   let {
     data,
   }: {
     data: {
-      scopes: MemoryScope[];
-      keys: ApiKeyView[];
+      scopePage: { rows: MemoryScope[]; total: number };
       initialStats?: MemoryStats;
       initialKeyId?: string | null;
     };
   } = $props();
 
-  const scopes = untrack(() => data.scopes);
-  const keys = untrack(() => data.keys);
+  const initialScopePage = untrack(() => data.scopePage);
   const initialStats = untrack(() => data.initialStats ?? null);
 
   type Tab = 'scope' | 'key';
   let tab = $state<Tab>('scope');
+
+  const SCOPE_PAGE_SIZE = 50;
+  let scopes = $state<MemoryScope[]>(initialScopePage.rows);
+  let scopesTotal = $state(initialScopePage.total);
+  let scopePage = $state(1);
+  let loadingScopes = $state(false);
+
+  let keys = $state<ApiKeyView[]>([]);
+  let keysLoaded = $state(false);
+  let loadingKeys = $state(false);
 
   // The scope currently selected (its facts/reflections fill the tables below).
   // accountId + project/resource/thread together address one memory scope; null
@@ -194,6 +203,39 @@
   // Pager: total pages from the server count, plus the number/ellipsis row.
   const factTotalPages = $derived(Math.max(1, Math.ceil(factsTotal / FACT_PAGE_SIZE)));
   const factPageItems = $derived(paginationItems(factPage, factTotalPages));
+
+  const scopeTotalPages = $derived(Math.max(1, Math.ceil(scopesTotal / SCOPE_PAGE_SIZE)));
+
+  async function goScopePage(n: number): Promise<void> {
+    if (n < 1 || n > scopeTotalPages || n === scopePage) return;
+    loadingScopes = true;
+    error = null;
+    try {
+      const page = await listScopes({ limit: SCOPE_PAGE_SIZE, offset: (n - 1) * SCOPE_PAGE_SIZE });
+      scopes = page.rows;
+      scopesTotal = page.total;
+      scopePage = n;
+    } catch (e) {
+      error = e instanceof Error ? e.message : $t('Failed to load memory scopes');
+    } finally {
+      loadingScopes = false;
+    }
+  }
+
+  async function openKeyTab(): Promise<void> {
+    tab = 'key';
+    if (keysLoaded || loadingKeys) return;
+    loadingKeys = true;
+    error = null;
+    try {
+      keys = await listKeys();
+      keysLoaded = true;
+    } catch (e) {
+      error = e instanceof Error ? e.message : $t('Failed to load keys');
+    } finally {
+      loadingKeys = false;
+    }
+  }
 
   // Any change that alters the result set resets to page 1 before reloading.
   function reloadFactsFromFirstPage(): void {
@@ -364,11 +406,11 @@
   }
 
   // Deep link from a key's detail page (/memory?key=<keyId>): open on the By Key tab
-  // pre-selected to that key and load its memory — the same path as picking it from
-  // the dropdown. Ignored when the key isn't in the list (stale link / deleted key).
+  // pre-selected to that key and load its memory directly. Do not fetch every key
+  // merely to validate one id; the keyed route returns 404 for a stale link.
   onMount(() => {
     const id = data.initialKeyId;
-    if (id && keys.some((k) => k.key_id === id)) {
+    if (id) {
       tab = 'key';
       void pickKey(id);
     } else if (initialStats === null) {
@@ -533,12 +575,14 @@
       role="tab"
       aria-selected={tab === 'key'}
       class={tab === 'key' ? 'btn-primary-sm' : 'btn-secondary'}
-      onclick={() => (tab = 'key')}>{$t('By Key')}</button
+      onclick={() => void openKeyTab()}>{$t('By Key')}</button
     >
   </div>
 
   {#if tab === 'scope'}
-    {#if scopes.length === 0}
+    {#if loadingScopes}
+      <p class="section-desc">{$t('Loading…')}</p>
+    {:else if scopes.length === 0}
       <div class="empty-state">
         <p>{$t('No memory yet. The gateway forms facts and reflections as it serves traffic.')}</p>
       </div>
@@ -597,6 +641,27 @@
           </tbody>
         </table>
       </div>
+      {#if scopeTotalPages > 1}
+        <nav class="flex items-center justify-end gap-2" aria-label={$t('Pagination')}>
+          <button
+            type="button"
+            class="btn-secondary"
+            data-testid="scope-pager-prev"
+            disabled={scopePage === 1}
+            onclick={() => void goScopePage(scopePage - 1)}>{$t('Previous')}</button
+          >
+          <span data-testid="scope-pager-status" class="text-sm text-ink-muted">
+            {$t('Page {page} of {pages}', { page: scopePage, pages: scopeTotalPages })}
+          </span>
+          <button
+            type="button"
+            class="btn-secondary"
+            data-testid="scope-pager-next"
+            disabled={scopePage === scopeTotalPages}
+            onclick={() => void goScopePage(scopePage + 1)}>{$t('Next')}</button
+          >
+        </nav>
+      {/if}
     {/if}
   {:else}
     <div class="card flex flex-col gap-2">
@@ -606,9 +671,13 @@
         class="select"
         aria-label={$t('Key')}
         value={selectedKeyId}
+        onfocus={() => void openKeyTab()}
         onchange={(e) => pickKey((e.currentTarget as HTMLSelectElement).value)}
       >
         <option value="">{$t('Select a key…')}</option>
+        {#if selectedKeyId !== '' && !keys.some((key) => key.key_id === selectedKeyId)}
+          <option value={selectedKeyId}>{selectionLabel || selectedKeyId}</option>
+        {/if}
         {#each keys as key (key.key_id)}
           <option value={key.key_id}
             >{key.name && key.name.length > 0 ? key.name : key.prefix}</option

--- a/apps/admin/src/routes/memory/+page.ts
+++ b/apps/admin/src/routes/memory/+page.ts
@@ -1,18 +1,15 @@
-import { listKeys } from '$lib/api/keys.js';
 import { getMemoryStats, listScopes } from '$lib/api/memory.js';
 import type { PageLoad } from './$types.js';
 
-// SPA load: fetch the memory scope groups (the "By Scope" tab) plus the redacted
-// key list (the "By Key" tab's selector — prefix only, never plaintext) from the
-// gateway admin API. Facts + reflections for a chosen scope load client-side on
-// selection (the table below is driven by user interaction, not the initial load).
+// SPA load: fetch only the first memory-scope page plus status. The redacted key
+// list stays lazy until the operator opens "By Key" so this route never starts
+// two potentially large reads together.
 export const load: PageLoad = async ({ url }) => {
-  const [scopes, keys, initialStats] = await Promise.all([
-    listScopes(),
-    listKeys(),
+  const [scopePage, initialStats] = await Promise.all([
+    listScopes({ limit: 50, offset: 0 }),
     getMemoryStats(),
   ]);
   // Deep link from a key's detail page (/memory?key=<keyId>): the page opens on the
   // "By Key" tab pre-selected to that key. null when navigated to directly.
-  return { scopes, keys, initialStats, initialKeyId: url.searchParams.get('key') };
+  return { scopePage, initialStats, initialKeyId: url.searchParams.get('key') };
 };

--- a/apps/admin/src/routes/memory/memory-load.test.ts
+++ b/apps/admin/src/routes/memory/memory-load.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getMemoryStats: vi.fn(),
+  listScopes: vi.fn(),
+  listKeys: vi.fn(),
+}));
+
+vi.mock('$lib/api/memory.js', () => ({
+  getMemoryStats: (...args: unknown[]) => mocks.getMemoryStats(...args),
+  listScopes: (...args: unknown[]) => mocks.listScopes(...args),
+}));
+vi.mock('$lib/api/keys.js', () => ({
+  listKeys: (...args: unknown[]) => mocks.listKeys(...args),
+}));
+
+import { load } from './+page.js';
+
+describe('memory page loader', () => {
+  beforeEach(() => {
+    mocks.getMemoryStats.mockReset().mockResolvedValue({ generatedAt: 'now' });
+    mocks.listScopes.mockReset().mockResolvedValue({ rows: [], total: 0 });
+    mocks.listKeys.mockReset().mockResolvedValue([]);
+  });
+
+  it('loads only the first scope page and stats, leaving keys lazy', async () => {
+    const data = await load({ url: new URL('https://helm.test/memory') } as never);
+
+    expect(mocks.listScopes).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    expect(mocks.getMemoryStats).toHaveBeenCalledWith();
+    expect(mocks.listKeys).not.toHaveBeenCalled();
+    expect(data).toMatchObject({ scopePage: { rows: [], total: 0 }, initialKeyId: null });
+  });
+});

--- a/apps/admin/src/routes/memory/memory.test.ts
+++ b/apps/admin/src/routes/memory/memory.test.ts
@@ -11,6 +11,8 @@ import MemoryPage from './+page.svelte';
 
 const listFacts = vi.fn();
 const listReflections = vi.fn();
+const listScopes = vi.fn();
+const listKeys = vi.fn();
 const getMemoryStats = vi.fn();
 const resolveKey = vi.fn();
 const createFact = vi.fn();
@@ -22,12 +24,16 @@ vi.mock('$lib/api/memory.js', () => ({
   getMemoryStats: (...args: unknown[]) => getMemoryStats(...args),
   listFacts: (...args: unknown[]) => listFacts(...args),
   listReflections: (...args: unknown[]) => listReflections(...args),
+  listScopes: (...args: unknown[]) => listScopes(...args),
   resolveKey: (...args: unknown[]) => resolveKey(...args),
   createFact: (...args: unknown[]) => createFact(...args),
   updateFact: (...args: unknown[]) => updateFact(...args),
   updateReflection: (...args: unknown[]) => updateReflection(...args),
   deleteFact: (...args: unknown[]) => deleteFact(...args),
   deleteReflection: (...args: unknown[]) => deleteReflection(...args),
+}));
+vi.mock('$lib/api/keys.js', () => ({
+  listKeys: (...args: unknown[]) => listKeys(...args),
 }));
 
 function scope(overrides: Partial<MemoryScope> = {}): MemoryScope {
@@ -152,7 +158,10 @@ function stats(overrides: Partial<MemoryStats> = {}): MemoryStats {
 }
 
 function renderPage(scopes: MemoryScope[], keys: ApiKeyView[] = [key('k1')]) {
-  return render(MemoryPage, { data: { scopes, keys, initialStats: stats() } });
+  listKeys.mockResolvedValue(keys);
+  return render(MemoryPage, {
+    data: { scopePage: { rows: scopes, total: scopes.length }, initialStats: stats() },
+  });
 }
 
 describe('memory page', () => {
@@ -160,6 +169,8 @@ describe('memory page', () => {
     localStorage.clear();
     listFacts.mockReset();
     listReflections.mockReset();
+    listScopes.mockReset();
+    listKeys.mockReset();
     getMemoryStats.mockReset();
     resolveKey.mockReset();
     createFact.mockReset();
@@ -169,6 +180,8 @@ describe('memory page', () => {
     deleteReflection.mockReset();
     listFacts.mockResolvedValue({ rows: [fact('f1'), fact('f2')], total: 2 });
     listReflections.mockResolvedValue({ rows: [reflection('r1')], total: 1 });
+    listScopes.mockResolvedValue({ rows: [], total: 0 });
+    listKeys.mockResolvedValue([key('k1')]);
     getMemoryStats.mockResolvedValue(stats());
     resolveKey.mockResolvedValue({ key_id: 'k1', accountId: 'acct', projectId: 'proj-a' });
   });
@@ -221,11 +234,13 @@ describe('memory page', () => {
 
   it('switching to the By Key tab shows a key selector and resolves a scope on pick', async () => {
     renderPage([scope()], [key('k1', { name: 'Prod backend' })]);
+    expect(listKeys).not.toHaveBeenCalled();
     await fireEvent.click(screen.getByRole('tab', { name: /by key/i }));
 
     const select = screen.getByLabelText(/^key$/i);
     expect(select).toBeInTheDocument();
-    expect(within(select).getByText('Prod backend')).toBeInTheDocument();
+    await waitFor(() => expect(within(select).getByText('Prod backend')).toBeInTheDocument());
+    expect(listKeys).toHaveBeenCalledTimes(1);
 
     await fireEvent.change(select, { target: { value: 'k1' } });
     await waitFor(() => expect(resolveKey).toHaveBeenCalledWith('k1'));
@@ -250,7 +265,10 @@ describe('memory page', () => {
   });
 
   it('delete on an ARCHIVED reflection warns it is permanent and purges it', async () => {
-    listReflections.mockResolvedValue({ rows: [reflection('r1', { status: 'archived' })], total: 1 });
+    listReflections.mockResolvedValue({
+      rows: [reflection('r1', { status: 'archived' })],
+      total: 1,
+    });
     deleteReflection.mockResolvedValue(undefined);
     renderPage([scope()]);
     await fireEvent.click(screen.getAllByTestId('scope-row')[0]);
@@ -272,7 +290,10 @@ describe('memory page', () => {
 
   it('deep link (initialKeyId) lands on the By Key tab pre-selected and loads that key', async () => {
     render(MemoryPage, {
-      data: { scopes: [scope()], keys: [key('k1', { name: 'Prod backend' })], initialKeyId: 'k1' },
+      data: {
+        scopePage: { rows: [scope()], total: 1 },
+        initialKeyId: 'k1',
+      },
     });
     // Opens on By Key (not the default By Scope) with the key resolved + facts loaded.
     await waitFor(() =>
@@ -284,14 +305,25 @@ describe('memory page', () => {
     await waitFor(() => expect(listFacts).toHaveBeenCalled());
   });
 
-  it('ignores an initialKeyId that is not in the key list (no crash, stays on By Scope)', async () => {
+  it('surfaces an unknown deep-linked key without loading every key first', async () => {
+    resolveKey.mockRejectedValue(new Error('key not found'));
     render(MemoryPage, {
-      data: { scopes: [scope()], keys: [key('k1')], initialKeyId: 'ghost' },
+      data: { scopePage: { rows: [scope()], total: 1 }, initialKeyId: 'ghost' },
     });
-    expect(screen.getByRole('tab', { name: /by scope/i }).getAttribute('aria-selected')).toBe(
-      'true',
-    );
-    expect(resolveKey).not.toHaveBeenCalled();
+    await waitFor(() => expect(resolveKey).toHaveBeenCalledWith('ghost'));
+    expect(listKeys).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('key not found');
+  });
+
+  it('paginates scopes on demand', async () => {
+    listScopes.mockResolvedValue({ rows: [scope({ projectId: 'proj-b' })], total: 51 });
+    render(MemoryPage, {
+      data: { scopePage: { rows: [scope()], total: 51 }, initialStats: stats() },
+    });
+
+    await fireEvent.click(screen.getByTestId('scope-pager-next'));
+    await waitFor(() => expect(listScopes).toHaveBeenCalledWith({ limit: 50, offset: 50 }));
+    await waitFor(() => expect(screen.getByText('proj-b')).toBeInTheDocument());
   });
 
   it('renders Reflections ABOVE Facts (the overview comes first)', async () => {
@@ -301,9 +333,7 @@ describe('memory page', () => {
     // The reflection card must appear earlier in the DOM than the first fact row.
     const reflectionEl = screen.getByText('The user is a backend engineer working on a gateway.');
     const factEl = screen.getAllByText('User prefers blue')[0];
-    expect(reflectionEl.compareDocumentPosition(factEl)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
+    expect(reflectionEl.compareDocumentPosition(factEl)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('exposes a Superseded status option that filters facts to status=superseded', async () => {

--- a/apps/gateway/src/memory-embedder.test.ts
+++ b/apps/gateway/src/memory-embedder.test.ts
@@ -1,3 +1,4 @@
+import { createResponseWorkAdmission } from "@helm/core";
 import { describe, expect, it, vi } from "vitest";
 import { createMemoryEmbedder } from "./memory-embedder.js";
 
@@ -7,11 +8,9 @@ const PROVIDERS = [
 ];
 
 function okFetch(vectors: number[][]) {
-  return vi.fn(async () => ({
-    ok: true,
-    status: 200,
-    json: async () => ({ data: vectors.map((embedding) => ({ embedding })) }),
-  })) as unknown as typeof fetch;
+  return vi.fn(async () =>
+    Response.json({ data: vectors.map((embedding) => ({ embedding })) }),
+  ) as unknown as typeof fetch;
 }
 
 describe("createMemoryEmbedder (docs/14)", () => {
@@ -53,6 +52,11 @@ describe("createMemoryEmbedder (docs/14)", () => {
       providers: PROVIDERS,
       env: { EMB_KEY: "secret-key" },
       fetchImpl,
+      responseWorkAdmission: createResponseWorkAdmission({
+        capacityBytes: 1024,
+        jsonAmplification: 1,
+        minChargeBytes: 1,
+      }),
     });
     expect(embedder).toBeDefined();
     const out = await embedder?.embed(["hello", "world"]);
@@ -94,5 +98,30 @@ describe("createMemoryEmbedder (docs/14)", () => {
       fetchImpl,
     });
     await expect(embedder?.embed(["x"])).rejects.toThrow();
+  });
+
+  it("rejects an oversized successful embeddings body before JSON materialization", async () => {
+    const responseWorkAdmission = createResponseWorkAdmission({
+      capacityBytes: 8,
+      jsonAmplification: 1,
+      minChargeBytes: 1,
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("{}", {
+          headers: { "content-type": "application/json", "content-length": "9" },
+        }),
+    );
+    const embedder = createMemoryEmbedder({
+      embeddingModel: "openai/bge-m3",
+      providers: PROVIDERS,
+      fetchImpl,
+      responseWorkAdmission,
+    });
+
+    await expect(embedder?.embed(["x"])).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_body_too_large", limit_bytes: 8 } },
+    });
+    expect(responseWorkAdmission.reservedBytes).toBe(0);
   });
 });

--- a/apps/gateway/src/memory-embedder.ts
+++ b/apps/gateway/src/memory-embedder.ts
@@ -1,4 +1,8 @@
-import type { Embedder } from "@helm/core";
+import {
+  type Embedder,
+  type ResponseWorkAdmission,
+  readUpstreamJsonWithinBudget,
+} from "@helm/core";
 
 // docs/14 — the embedding port impl for hybrid recall's vector leg. helm has no
 // /v1/embeddings route and ProviderClient has no embeddings method, so this is a thin
@@ -26,6 +30,7 @@ export function createMemoryEmbedder(deps: {
   providers: readonly EmbedderProvider[];
   env?: Record<string, string | undefined>;
   fetchImpl?: typeof fetch;
+  responseWorkAdmission?: ResponseWorkAdmission;
   // Bounds every embeddings request so a stalled endpoint can't hang memory_recall
   // (it fails open to FTS+score) or wedge an embedding worker. Defaults to 30s.
   timeoutMs?: number;
@@ -67,7 +72,10 @@ export function createMemoryEmbedder(deps: {
         signal: AbortSignal.timeout(timeoutMs),
       });
       if (!res.ok) throw new Error(`embeddings request failed: ${res.status}`);
-      const json = (await res.json()) as OpenAiEmbeddingsResponse;
+      const json = await readUpstreamJsonWithinBudget<OpenAiEmbeddingsResponse>(
+        res,
+        deps.responseWorkAdmission,
+      );
       // Preserve input order (OpenAI returns data in request order); be defensive.
       return json.data.map((d) => Float32Array.from(d.embedding));
     },

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -123,6 +123,9 @@ function makeKeyStore(): KeyStore & { rows: TestKeyRecord[] } {
     async getByHash(hash) {
       return rows.find((r) => r.hash === hash) ?? null;
     },
+    async getById(keyId) {
+      return rows.find((r) => r.key_id === keyId) ?? null;
+    },
     async list() {
       return [...rows];
     },

--- a/apps/gateway/src/routes/admin/memory.test.ts
+++ b/apps/gateway/src/routes/admin/memory.test.ts
@@ -52,13 +52,22 @@ function addFact(
   });
 }
 
-function buildApp(memoryStore: MemoryStore | undefined, keyRows: ApiKeyRecord[] = []) {
+function buildApp(
+  memoryStore: MemoryStore | undefined,
+  keyStore: {
+    getById: (keyId: string) => Promise<ApiKeyRecord | null>;
+    list: () => Promise<ApiKeyRecord[]>;
+  } = {
+    getById: async () => null,
+    list: async () => [],
+  },
+) {
   const app = new Hono<AppEnv>();
   const deps = {
     memoryStore,
     accountId: "acct",
     estimateTokens: (t: string) => Math.ceil(t.length / 4),
-    keyStore: { list: async () => keyRows },
+    keyStore,
   } as unknown as AdminApiDeps;
   registerMemoryRoutes(app, deps);
   return app;
@@ -85,14 +94,24 @@ describe("/admin/api/memory routes (docs/13)", () => {
     const app = buildApp(store);
     const res = await app.request("/admin/api/memory/scopes");
     expect(res.status).toBe(200);
-    const scopes = (await res.json()) as Array<{
-      projectId: string | null;
-      factCount: number;
-      reflectionCount: number;
-    }>;
-    const byProject = new Map(scopes.map((s) => [s.projectId, s]));
+    const scopes = (await res.json()) as {
+      rows: Array<{
+        projectId: string | null;
+        factCount: number;
+        reflectionCount: number;
+      }>;
+      total: number;
+    };
+    const byProject = new Map(scopes.rows.map((s) => [s.projectId, s]));
+    expect(scopes.total).toBe(2);
     expect(byProject.get("p1")?.factCount).toBe(1);
     expect(byProject.get("p2")?.reflectionCount).toBe(1);
+
+    const countOnly = (await (await app.request("/admin/api/memory/scopes?limit=0")).json()) as {
+      rows: unknown[];
+      total: number;
+    };
+    expect(countOnly).toEqual({ rows: [], total: 2 });
   });
 
   it("round-trips client thread ids through By Scope", async () => {
@@ -128,8 +147,8 @@ describe("/admin/api/memory routes (docs/13)", () => {
 
     const scopes = (await (
       await app.request("/admin/api/memory/scopes?accountId=acct")
-    ).json()) as Array<{ projectId: string | null; threadId: string | null }>;
-    expect(scopes).toContainEqual(
+    ).json()) as { rows: Array<{ projectId: string | null; threadId: string | null }> };
+    expect(scopes.rows).toContainEqual(
       expect.objectContaining({ projectId: "p1", threadId: "client-thread" }),
     );
 
@@ -522,7 +541,13 @@ describe("/admin/api/memory routes (docs/13)", () => {
       account_id: "acct",
       memory_project_id: null,
     } as unknown as ApiKeyRecord;
-    const app = buildApp(store, [sharedKey, isolatedKey]);
+    const getById = vi.fn(
+      async (keyId: string) => [sharedKey, isolatedKey].find((key) => key.key_id === keyId) ?? null,
+    );
+    const list = vi.fn(async (): Promise<ApiKeyRecord[]> => {
+      throw new Error("by-key must not scan the key list");
+    });
+    const app = buildApp(store, { getById, list });
     const ok = (await (await app.request("/admin/api/memory/by-key/k1")).json()) as {
       accountId: string;
       projectId: string | null;
@@ -533,6 +558,8 @@ describe("/admin/api/memory routes (docs/13)", () => {
     };
     expect(isolated.projectId).toBe("k2");
     expect((await app.request("/admin/api/memory/by-key/missing")).status).toBe(404);
+    expect(getById).toHaveBeenCalledTimes(3);
+    expect(list).not.toHaveBeenCalled();
   });
 
   it("GET /memory/facts/:id returns the fact or 404", async () => {
@@ -680,11 +707,26 @@ describe("/admin/api/memory routes (docs/13)", () => {
     // With accountId param → lists for that account
     const scoped = (await (
       await app.request("/admin/api/memory/scopes?accountId=acct")
-    ).json()) as unknown[];
-    expect(scoped.length).toBeGreaterThan(0);
+    ).json()) as { rows: unknown[]; total: number };
+    expect(scoped.rows.length).toBeGreaterThan(0);
     // Without accountId param → lists all (same store, same result)
-    const all = (await (await app.request("/admin/api/memory/scopes")).json()) as unknown[];
-    expect(all.length).toBeGreaterThan(0);
+    const all = (await (await app.request("/admin/api/memory/scopes")).json()) as {
+      rows: unknown[];
+      total: number;
+    };
+    expect(all.rows.length).toBeGreaterThan(0);
+  });
+
+  it("listScopes applies default and bounded pagination", async () => {
+    const { store } = seededStore();
+    const listMemoryScopes = vi.spyOn(store, "listMemoryScopes");
+    const app = buildApp(store);
+
+    await app.request("/admin/api/memory/scopes");
+    expect(listMemoryScopes).toHaveBeenLastCalledWith({ limit: 50, offset: 0 });
+
+    await app.request("/admin/api/memory/scopes?accountId=acct&limit=999&offset=7");
+    expect(listMemoryScopes).toHaveBeenLastCalledWith({ accountId: "acct", limit: 200, offset: 7 });
   });
 
   it("PATCH fact: non-collision error is re-thrown (line 141-142)", async () => {

--- a/apps/gateway/src/routes/admin/memory.ts
+++ b/apps/gateway/src/routes/admin/memory.ts
@@ -136,8 +136,12 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
     const store = resolveStore(c, deps);
     if (store instanceof Response) return store;
     const accountId = c.req.query("accountId") ?? undefined;
-    const scopes = await store.listMemoryScopes(accountId !== undefined ? { accountId } : {});
-    return c.json(scopes.map(scopeForAdmin));
+    const page = await store.listMemoryScopes({
+      ...(accountId !== undefined ? { accountId } : {}),
+      limit: intParam(c.req.query("limit"), DEFAULT_LIMIT, MAX_LIMIT),
+      offset: intParam(c.req.query("offset"), 0, Number.MAX_SAFE_INTEGER),
+    });
+    return c.json({ ...page, rows: page.rows.map(scopeForAdmin) });
   });
 
   // GET /memory/stats — operational snapshot for the top status panels: queue
@@ -168,8 +172,8 @@ export function registerMemoryRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): voi
   // 404 on unknown key.
   app.get("/admin/api/memory/by-key/:keyId", async (c) => {
     const keyId = c.req.param("keyId");
-    const key = (await deps.keyStore.list()).find((r) => r.key_id === keyId);
-    if (key === undefined) return c.json({ error: "key not found" }, 404);
+    const key = await deps.keyStore.getById(keyId);
+    if (key === null) return c.json({ error: "key not found" }, 404);
     return c.json({
       key_id: key.key_id,
       accountId: key.account_id,

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -3163,6 +3163,7 @@ export async function buildServer(
     embeddingModel: config.memory.llm.embedding_model,
     providers: config.providers,
     timeoutMs: config.memory.llm.timeout_ms,
+    responseWorkAdmission: runtimeResponseWorkAdmission(),
   });
   const embeddingModel = config.memory.llm.embedding_model;
   const embeddingDim = config.memory.llm.embedding_dimensions;

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -11,8 +11,9 @@
 #                               # uncovered segment reaches this many tokens
 #   idle_flush_s: 3600          # fold a quiet thread's whole uncovered history
 #                               # after this many seconds without a new message
-#   idle_flush_max_age_s: 86400 # optional: skip idle backfill older than this
-#                               # many seconds (unset = process all history)
+#   idle_flush_max_age_s: 86400 # optional: skip old started backfills after this
+#                               # many seconds; null-frontier legacy rows still
+#                               # drain once (unset = process all history)
 #   force_context_ratio: 0.8    # force compaction once the active footprint
 #                               # reaches this fraction of the model's window
 #   min_recent_messages: 4      # keep floor: at least this many recent messages…

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -18,6 +18,7 @@
 - **生产根因**：2026-07-29 的外部 purge 脚本重建 `memory_messages` 却未重算 `memory_threads.message_count/last_message_at`，Admin 因此把约 18.5 万真实 raw 行显示成约 208 万；三天 cleanup 实际有效。真正的 OOM 路径是 Observer/Reflector/注入及部分 cleanup 会一次物化大线程/大结果，pure `observe` 又不直接形成 observation，最大线程累积到 51,116 行。
 - **有界生命周期**：pure `observe` outbound 也 enqueue；Observer 按服务端 `(created_at,id)` 每页最多 512 行/1 MiB/64K tokens，超大单行用带 SHA-256 的 placeholder，Observation 与 durable frontier CAS 同事务提交并继续排下一页。Reflector 只取最新 512 条 active/unexpired observation；forgetting rebuild 不再带旧 reflection，最终注入含 header 也严格服从 token budget。
 - **清理与遗忘**：raw cleanup 只删 frontier 已覆盖行，Postgres cleanup/telemetry/OAuth usage 使用小批次；decay 会在同一事务立即归档受影响 reflection、fence 正在运行的旧 Reflector，并为 project/resource 各自排 successor。Reflector 的 facts + reflection + job completion 也由 job 状态 fence 后原子提交，避免遗忘后复活。SQLite/Postgres migration 会重算 stale counters、补索引，legacy raw 保持 null frontier 后按有界页回放。
+- **升级兼容**：lease generation migration 仅在 `memory_jobs` 已存在时加列；历史上的精简/部分 schema 仍可继续升级，完整生产 schema 则照常初始化 generation 0。不能用无条件 `ALTER TABLE`，否则会让无 Memory 表的旧安装启动失败。
 - **取舍/限制**：`message_index` 仍只用于当前 ingest dedup，不能作为线程顺序；没有客户端稳定 turn id 时无法同时保证跨请求精确去重和保留合法重复。legacy bounded backfill 可能与旧 Observation 暂时重叠，因为旧 range 的错误顺序无法精确还原；这里选择宁可短期过度保留，也不静默丢失未覆盖 raw。Reflection 使用 bounded latest-set，而非持久 rolling draft。生产恢复 worker 必须 concurrency=1 灰度，先验证 migration/frontier/RSS/restart/OOM/502，再开启 raw cleanup。
 
 ## 2026-08-10 · 大 Session 客户端重建恢复服务端同款 Conversation 展示（Admin / requests debug，docs/07/11，原则 1/3/7）

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-11 · Admin Memory 范围分页与 Key 点查（Admin / Store，docs/11/13，原则 1/7）
+
+- **分页契约**：`/admin/api/memory/scopes` 采用与 facts/reflections 一致的 `{ rows, total }` 响应；默认 50、最大 200。SQLite/Postgres 都在聚合结果上执行服务端 `LIMIT/OFFSET`，并以 scope tuple 作为 `lastUpdated` 并列时的稳定次序，避免翻页重复或遗漏。
+- **加载边界**：Memory 首屏只并发加载第一批 scopes 与轻量 stats；完整 redacted key 列表仅在用户打开 By Key 时加载。`?key=` 深链直接走单 key 解析，不为校验一个 id 扫描全部 keys。
+- **Store 取舍**：`KeyStore` 新增按不可变 `key_id` 的 `getById`，SQLite/Postgres 使用索引点查，缓存包装器只透传；不缓存 admin 低频 id 查询，也不改变全局 Keys 页面既有列表契约。
+
 ## 2026-08-11 · Memory 大线程有界形成与遗忘原子性（Memory Observer / Reflector / cleanup，docs/08/12，原则 3/7）
 
 - **生产根因**：2026-07-29 的外部 purge 脚本重建 `memory_messages` 却未重算 `memory_threads.message_count/last_message_at`，Admin 因此把约 18.5 万真实 raw 行显示成约 208 万；三天 cleanup 实际有效。真正的 OOM 路径是 Observer/Reflector/注入及部分 cleanup 会一次物化大线程/大结果，pure `observe` 又不直接形成 observation，最大线程累积到 51,116 行。
@@ -76,20 +82,11 @@
 - **测试**：三向锁定——翻译 strip 到 generic xai（mutation `provider_raw_stripped_for_target`）+ 非 generic Codex-official 保留 + 同协议 passthrough strip（mutation `context_management_stripped_for_generic`）。execute.test.ts 169 全绿；execute/pipeline/responses/core-responses 合计 539 全绿。
 - **遗留**：allowlist 里 `text`/`reasoning_config`/`truncation`/`logit_bias`/`include`/`responses_tools`/`container` 等对 generic provider 是否有同类 array/object 形状风险，Codex 抽查未确认第二例，未逐一核；本次只修实测触发的 `context_management`。
 
-## 2026-08-07 · OAuth 账号「限流后继续用剩余点数」每账号开关（OAuth pool / account settings，docs/06，原则 3/6）
-
-- **需求**：账号周限 100%（`已限流`）但仍想榨干剩余点数——加一个每账号开关，开了就别把它从池里 park 掉。
-- **实现**：`AccountSettings.allowSpendRemainingCredits`（可选布尔）→ 合成时喂进 `OAuthPoolMember.allowSpendRemainingCredits` → pool 的 `usageLimited()` 首行：`if (member.allowSpendRemainingCredits) return false`。整条读侧只有这一处 gate（`eligibleEntries` 的 `!usageLimited`），所以一处 bypass 即全覆盖（chat/stream/native/responses/realtime 都走 `select()`）。
-- **刻意的边界**：只绕过**账号级 usage-limit park**（`usageLimitedUntilMs`）。model-scoped（`scopedRateLimits`）与 transient retryable（`retryableAccountFailures`）冷却**不动**——它们是不同轴，绕过会误伤。写侧（park 的记录）也不碰：账号真没预算时上游照样 429，pool 正常 in-pool failover 到兄弟账号，不会死循环打爆上游。
-- **拍板（AskUserQuestion）**：① 忽略**全部** usage-limit park（不只周限）；② **每账号**开关，跟 `autoReset`/`fastMode` 并列。开关对所有 OAuth provider 生效（非 Codex 专属），所以 ManageAccountDialog 里是无条件 toggle。
-- **布线**镜像 `autoReset`：account-settings → server 合成 → admin-oauth 的 `getAccountSchedule`/`setAccountSchedule` seam → deps.ts 三处类型（list-item / setAccountSchedule 入参 / `AccountScheduleView`）→ PUT 路由校验（非布尔 400）→ admin client `oauth.ts`（list-item 可选、schedule 必填，跟 `autoReset?`/`autoReset` 的可选/必填分裂一致）→ Svelte toggle + 3 条 i18n 串（7 语已对齐；`i18n:translate` 离线失败无碍，key 已由 `i18n:update` 填英文占位）。
-- **TDD**：pool.test 先加失败用例（parked 成员带 flag 仍应被选中→原本落到兄弟）→ Red→加 flag+bypass→Green（99/99）。admin-oauth/oauth 路由测试补 round-trip 与 400 校验。
-- **坑**：worktree 内编辑必须用 worktree 绝对路径——首次 Edit 误落主库（共享 checkout），已 `git checkout --` 干净回退后在 worktree 重做。
-
 - **2026-08-07 · 真实上游超长溢出链耗尽终态**：真实 `prompt is too long: N > M` 在链耗尽时胜出为客户端 400，但仍允许更大窗口候选继续 fallback；弱措辞只认结构化 error message，完整原文经 git history 回溯。
 
 ## 历史条目摘要（最新要点）
 
+- **2026-08-07 · OAuth 账号限流后继续用剩余点数**：每账号开关只绕过 usage-limit park，model-scoped 与 transient 冷却保持不变；完整原文经 git history 回溯。
 - **2026-08-07 · per-key `max_reasoning_effort` 上限**：统一三协议身份 caps 映射，避免内联副本漂移导致上限静默失效，完整原文经 git history 回溯。
 - **2026-08-06 · HALF_OPEN 探测锁释放与所有权令牌**：所有被允许的 provider/image 尝试都结算 breaker，HALF_OPEN abort 仅凭匹配的 probe token 释放对应探针，避免锁永久卡住或旧请求误清新探针；完整原文经 git history 回溯。
 - **2026-08-04 · per-key 请求内容存储覆盖优先级**：显式 `none`/`payload`/`session` 无条件覆盖实时全局设置，仅 `null`/`undefined` 继承；共享 capture helper 一处修复覆盖全部协议入口，完整原文经 git history 回溯。

--- a/packages/core/src/auth/bootstrap.test.ts
+++ b/packages/core/src/auth/bootstrap.test.ts
@@ -164,6 +164,7 @@ describe("bootstrapRootKey", () => {
       list: vi.fn().mockRejectedValue(new Error("db down")),
       createKey: vi.fn(),
       getByHash: vi.fn(),
+      getById: vi.fn(),
       disable: vi.fn(),
       deleteKey: vi.fn(),
       updateKey: vi.fn(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -642,6 +642,7 @@ export {
   type RealtimeCallRequest,
   type RealtimeCallResult,
   type RealtimeSidebandTarget,
+  readUpstreamJsonWithinBudget,
   UpstreamError,
 } from "./provider/openai.js";
 export {

--- a/packages/core/src/memory/forgetting/decay.test.ts
+++ b/packages/core/src/memory/forgetting/decay.test.ts
@@ -42,6 +42,7 @@ function makeStore(rows: ScorableObservation[], reflectionScopes: unknown[] = []
     }),
     archiveObservations: vi.fn(async (input: { accountId: string; ids: string[]; now: Date }) => {
       archived.push(...input.ids);
+      return true;
     }),
     // docs/12 (Codex review fix) — decay enqueues a reflector rebuild per active
     // reflection scope after it archives observations.
@@ -119,6 +120,20 @@ describe("runDecayJob", () => {
     expect(archived).toEqual(["stale"]);
     expect(archived).not.toContain("fresh");
     expect(jobUpdates).toContainEqual({ jobId: "d1", status: "done" });
+  });
+
+  it("stops without completing when the archive publication lease is stale", async () => {
+    const { store, jobUpdates } = makeStore([row("stale", 100)]);
+    store.archiveObservations.mockResolvedValueOnce(false);
+    const deps = makeDeps(store, NOW);
+
+    await runDecayJob({ jobId: "d1", leaseGeneration: 7, scope: { accountId: "acct-a" } }, deps);
+
+    expect(store.archiveObservations).toHaveBeenCalledWith(
+      expect.objectContaining({ job: { id: "d1", leaseGeneration: 7 } }),
+    );
+    expect(jobUpdates).toEqual([]);
+    expect(deps.log).toHaveBeenCalledWith("memory.decay.stale", { account_id: "acct-a" });
   });
 
   it("scopes the read + archive to the swept account (two-account isolation)", async () => {

--- a/packages/core/src/memory/forgetting/decay.ts
+++ b/packages/core/src/memory/forgetting/decay.ts
@@ -1,5 +1,6 @@
 import type { ForgettingConfig, ReflectionScope } from "@helm/shared";
 import type { MemoryStore } from "../../store/ports.js";
+import { updateClaimedJobStatus } from "../job-lease.js";
 import { forgettingScore } from "./score.js";
 
 // The decay SWEEP (docs/12 "Eviction, demotion, promotion", pass 1 — memory_jobs.
@@ -32,6 +33,7 @@ import { forgettingScore } from "./score.js";
 // open decay row per account (docs/12 "buffer-flush … never per request").
 export interface DecayJob {
   jobId: string;
+  leaseGeneration?: number;
   scope: ReflectionScope;
 }
 
@@ -81,7 +83,7 @@ export async function runDecayJob(job: DecayJob, deps: DecayDeps): Promise<void>
     // Mark it done (a no-op, not a failure: nothing is wrong, the operator turned
     // forgetting off) so it never lingers pending. enabled:false ⇒ zero archives.
     if (deps.config.enabled !== true) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       deps.log("memory.decay.noop_disabled", { account_id: accountId });
       return;
     }
@@ -91,8 +93,9 @@ export async function runDecayJob(job: DecayJob, deps: DecayDeps): Promise<void>
     const list = deps.memoryStore.listScorableObservations;
     const archive = deps.memoryStore.archiveObservations;
     if (list === undefined || archive === undefined) {
-      await deps.memoryStore.updateJobStatus(
-        job.jobId,
+      await updateClaimedJobStatus(
+        deps.memoryStore,
+        job,
         "failed",
         "decay: store lacks sweep methods",
       );
@@ -146,7 +149,7 @@ export async function runDecayJob(job: DecayJob, deps: DecayDeps): Promise<void>
     }
 
     if (condemned.length === 0) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       deps.log("memory.decay.noop_nothing_below_threshold", {
         account_id: accountId,
         scanned: rows.length,
@@ -244,7 +247,7 @@ export async function runDecayJob(job: DecayJob, deps: DecayDeps): Promise<void>
       }
     }
 
-    await deps.memoryStore.updateJobStatus(job.jobId, "done");
+    await updateClaimedJobStatus(deps.memoryStore, job, "done");
     deps.log("memory.decay.swept", {
       account_id: accountId,
       scanned: rows.length,
@@ -256,7 +259,7 @@ export async function runDecayJob(job: DecayJob, deps: DecayDeps): Promise<void>
     // runs entirely off the request path (the trigger that enqueued it is long gone).
     const message = err instanceof Error ? err.message : String(err);
     try {
-      await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
+      await updateClaimedJobStatus(deps.memoryStore, job, "failed", message);
     } catch (updateErr) {
       // Even the failure bookkeeping is best-effort — still never throw.
       deps.log("memory.decay.job_update_failed", {

--- a/packages/core/src/memory/forgetting/decay.ts
+++ b/packages/core/src/memory/forgetting/decay.ts
@@ -181,7 +181,18 @@ export async function runDecayJob(job: DecayJob, deps: DecayDeps): Promise<void>
       iterations += 1;
       const ids = condemned.slice(offset, offset + ARCHIVE_CHUNK);
       try {
-        await archive.call(deps.memoryStore, { accountId, ids, now });
+        const accepted = await archive.call(deps.memoryStore, {
+          accountId,
+          ids,
+          now,
+          ...(job.leaseGeneration !== undefined
+            ? { job: { id: job.jobId, leaseGeneration: job.leaseGeneration } }
+            : {}),
+        });
+        if (accepted === false) {
+          deps.log("memory.decay.stale", { account_id: accountId });
+          return;
+        }
         archivedCount += ids.length;
         consecutiveErrors = 0;
       } catch (chunkErr) {

--- a/packages/core/src/memory/inject.test.ts
+++ b/packages/core/src/memory/inject.test.ts
@@ -162,7 +162,13 @@ describe("assembleInjectedContext — memory TEXT BLOCK (trailing-reminder model
     );
     store.findRedundantInjectionObservations = vi.fn(async () => new Set<string>());
 
-    const out = await assembleInjectedContext(baseInput({ tokenBudget: 11 }), makeDeps(store));
+    const out = await assembleInjectedContext(
+      baseInput({
+        tokenBudget: 11,
+        windowContentHashCounts: new Map([[sha256Hex("live"), 1]]),
+      }),
+      makeDeps(store),
+    );
 
     expect(out.memoryBlock).toContain("newest");
     expect(out.memoryBlock).not.toContain("older");
@@ -216,11 +222,22 @@ describe("assembleInjectedContext — memory TEXT BLOCK (trailing-reminder model
     store.findRedundantInjectionObservations = vi.fn(async () => new Set<string>());
 
     await assembleInjectedContext(
-      baseInput({ tokenBudget: 1 }),
+      baseInput({
+        tokenBudget: 1,
+        windowContentHashCounts: new Map([[sha256Hex("live"), 1]]),
+      }),
       makeDeps(store, { estimateTokens: () => 0 }),
     );
 
     expect(store.listInjectionObservationsPage).toHaveBeenCalledTimes(32);
+    expect(store.findRedundantInjectionObservations).toHaveBeenCalledTimes(1);
+    expect(store.findRedundantInjectionObservations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateLimit: 32 * 64,
+        maxCoverageMessages: 512,
+        order: "newest",
+      }),
+    );
   });
 
   it("assembles a single system-level block with section headers in deterministic order", async () => {

--- a/packages/core/src/memory/inject.ts
+++ b/packages/core/src/memory/inject.ts
@@ -2,7 +2,7 @@ import type { Fact, Observation, RawMessage, Reflection } from "@helm/shared";
 import type { MemoryStore } from "../store/ports.js";
 import { forgettingScore, type ScoreConfig } from "./forgetting/score.js";
 import { sha256Hex } from "./message-hash.js";
-import { alreadyObservedMessageIds } from "./observer.js";
+import { alreadyObservedMessageIds, OBSERVER_PAGE_MESSAGES } from "./observer.js";
 
 // Memory middleware — INJECT phase (docs/08 Phase 2, #217 Phase 4 TRAILING-REMINDER
 // model). When x-memory-mode=inject, this runs SYNCHRONOUSLY on the main request path,
@@ -512,6 +512,25 @@ export async function assembleInjectedContext(
           scoreMode = false;
         }
       }
+      // Resolve coverage once for the whole bounded candidate horizon. The store
+      // selects only ids/ranges and returns at most that many ids; page bodies remain
+      // incremental below, so neither the transcript nor 2,048 observation bodies are
+      // materialized in Node merely to avoid 32 repeated full-thread coverage scans.
+      const redundantIds =
+        deps.memoryStore.findRedundantInjectionObservations !== undefined &&
+        windowContentHashCounts.size > 0
+          ? await deps.memoryStore.findRedundantInjectionObservations({
+              accountId: input.scope.accountId,
+              threadId: input.scope.threadId,
+              candidateLimit: MAX_INJECTION_CANDIDATE_PAGES * INJECTION_CANDIDATE_PAGE_SIZE,
+              maxCoverageMessages: OBSERVER_PAGE_MESSAGES,
+              order: scoreMode ? "score" : "newest",
+              ...(score !== undefined && scoreNowMs !== undefined
+                ? { score: { nowMs: scoreNowMs, ...score } }
+                : {}),
+              windowContentHashCounts,
+            })
+          : new Set<string>();
       for (
         let pageNumber = 0;
         pageNumber < MAX_INJECTION_CANDIDATE_PAGES && remaining > 0;
@@ -529,18 +548,6 @@ export async function assembleInjectedContext(
         });
         if (page.length === 0) break;
         offset += page.length;
-        const redundantIds =
-          deps.memoryStore.findRedundantInjectionObservations !== undefined
-            ? await deps.memoryStore.findRedundantInjectionObservations({
-                accountId: input.scope.accountId,
-                threadId: input.scope.threadId,
-                observations: page.map((observation) => ({
-                  id: observation.id,
-                  sourceMessageRange: observation.sourceMessageRange,
-                })),
-                windowContentHashCounts,
-              })
-            : new Set<string>();
         for (const observation of page) {
           if (remaining === 0) break;
           const redundant =

--- a/packages/core/src/memory/job-lease.ts
+++ b/packages/core/src/memory/job-lease.ts
@@ -1,0 +1,20 @@
+import type { MemoryJobStatus, MemoryStore } from "../store/ports.js";
+
+export interface ClaimedMemoryJob {
+  jobId: string;
+  leaseGeneration?: number;
+}
+
+export function updateClaimedJobStatus(
+  store: MemoryStore,
+  job: ClaimedMemoryJob,
+  status: MemoryJobStatus,
+  error?: string,
+): Promise<void> {
+  if (job.leaseGeneration !== undefined) {
+    return store.updateJobStatus(job.jobId, status, error, job.leaseGeneration);
+  }
+  return error === undefined
+    ? store.updateJobStatus(job.jobId, status)
+    : store.updateJobStatus(job.jobId, status, error);
+}

--- a/packages/core/src/memory/memory-loop.test.ts
+++ b/packages/core/src/memory/memory-loop.test.ts
@@ -206,7 +206,9 @@ describe("memory background loop (observer → reflector → inject)", () => {
         }),
     });
 
-    // Tick 1: both observers run + promote. Tick 2: the reflector(s) merge.
+    // concurrency=1 claims only immediately runnable capacity: two Observer ticks,
+    // then one Reflector tick aggregates both observations.
+    await vi.advanceTimersByTimeAsync(100);
     await vi.advanceTimersByTimeAsync(100);
     await vi.advanceTimersByTimeAsync(100);
     handle.stop();

--- a/packages/core/src/memory/observer.test.ts
+++ b/packages/core/src/memory/observer.test.ts
@@ -390,6 +390,31 @@ describe("runObserverJob — eager fact extraction", () => {
     });
   });
 
+  it("passes the lease guard and does not report stale eager facts as published", async () => {
+    const { store } = makeFakeStore(makeShortThread());
+    (store.insertFactsReconciled as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      insertedIds: [],
+      supersededIds: [],
+      accepted: false,
+    });
+    const deps = makeDeps(store, {
+      extractFactsFromMessages: vi.fn(async () => [eagerFact]),
+    });
+
+    await runObserverJob({ ...JOB, leaseGeneration: 7, projectId: "proj-x" }, deps);
+
+    expect(store.insertFactsReconciled).toHaveBeenCalledWith(
+      expect.objectContaining({ job: { id: "job-1", leaseGeneration: 7 } }),
+    );
+    expect(deps.log).toHaveBeenCalledWith("memory.observer.eager_facts_stale", {
+      thread_id: "thread-1",
+    });
+    expect(deps.log).not.toHaveBeenCalledWith(
+      "memory.observer.eager_facts_extracted",
+      expect.anything(),
+    );
+  });
+
   it("feeds ONLY user messages to the extractor (assistant/tool noise excluded)", async () => {
     // deepseek drops the user's stated fact when the wire body is full of agent
     // tool/file noise (e.g. Mimi reading/writing its own MEMORY.md). Only user turns

--- a/packages/core/src/memory/observer.test.ts
+++ b/packages/core/src/memory/observer.test.ts
@@ -741,17 +741,80 @@ describe("runObserverJob — re-enqueue on a turn that arrives during the run", 
       nextCursor: { createdAtMs: page[7]?.createdAt.getTime() ?? 0, id: "m8" },
       hasMore: true,
     }));
-    store.appendObservationAndAdvanceFrontier = vi.fn(async () => "obs-gap");
+    store.commitObserverPage = vi.fn(async () => ({ observationId: "obs-gap" }));
 
-    const out = await runObserverJob(JOB, makeDeps(store));
+    const out = await runObserverJob({ ...JOB, leaseGeneration: 1 }, makeDeps(store));
 
     expect(out).toEqual({ observationId: "obs-gap", sourceMessageRange: ["m4", "m4"] });
     expect(store.listObservations).not.toHaveBeenCalled();
-    expect(store.appendObservationAndAdvanceFrontier).toHaveBeenCalledWith(
+    expect(store.commitObserverPage).toHaveBeenCalledWith(
       expect.objectContaining({
+        action: "observe",
         observation: expect.objectContaining({ sourceMessageRange: ["m4", "m4"] }),
         nextFrontier: expect.objectContaining({ id: "m4" }),
       }),
     );
+  });
+
+  it("uses one atomic page commit for the observation, job completion, and remainder", async () => {
+    const page = makeMessages(8);
+    const { store } = makeFakeStore(page);
+    store.getThreadMeta = vi.fn(async () => ({
+      lastServedModel: null,
+      messageCount: 51_116,
+      observationCount: 513,
+    }));
+    store.listObserverMessagesPage = vi.fn(async () => ({
+      messages: page,
+      expectedFrontier: null,
+      nextCursor: { createdAtMs: page[7]?.createdAt.getTime() ?? 0, id: "m8" },
+      hasMore: true,
+    }));
+    store.commitObserverPage = vi.fn(async () => ({ observationId: "obs-atomic" }));
+
+    const out = await runObserverJob({ ...JOB, leaseGeneration: 1 }, makeDeps(store));
+
+    expect(out.observationId).toBe("obs-atomic");
+    expect(store.commitObserverPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "observe",
+        job: {
+          id: JOB.jobId,
+          scope: { accountId: "acct-a", threadId: "thread-1" },
+          leaseGeneration: 1,
+        },
+        successorScope: { accountId: "acct-a", threadId: "thread-1" },
+      }),
+    );
+    expect(store.updateJobStatus).not.toHaveBeenCalled();
+    expect(store.enqueueJob).not.toHaveBeenCalled();
+  });
+
+  it("atomically advances a fully covered page without another observation", async () => {
+    const page = makeMessages(2, 10);
+    const { store } = makeFakeStore(page);
+    store.listObserverMessagesPage = vi.fn(async () => ({
+      messages: page,
+      coveredMessageIds: page.map((message) => message.id),
+      expectedFrontier: null,
+      nextCursor: { createdAtMs: page[1]?.createdAt.getTime() ?? 0, id: "m2" },
+      hasMore: true,
+    }));
+    store.commitObserverPage = vi.fn(async () => ({ observationId: null }));
+    const deps = makeDeps(store);
+
+    const out = await runObserverJob({ ...JOB, leaseGeneration: 1 }, deps);
+
+    expect(out).toEqual({ observationId: null, sourceMessageRange: null });
+    expect(deps.summarize).not.toHaveBeenCalled();
+    expect(store.commitObserverPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "advance",
+        nextFrontier: expect.objectContaining({ id: "m2" }),
+        successorScope: { accountId: "acct-a", threadId: "thread-1" },
+      }),
+    );
+    expect(store.updateJobStatus).not.toHaveBeenCalled();
+    expect(store.enqueueJob).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/memory/observer.test.ts
+++ b/packages/core/src/memory/observer.test.ts
@@ -730,4 +730,28 @@ describe("runObserverJob — re-enqueue on a turn that arrives during the run", 
       scope: { accountId: "acct-a", threadId: "thread-1" },
     });
   });
+
+  it("compresses only the oldest uncovered gap from an all-status bounded coverage page", async () => {
+    const page = makeMessages(8);
+    const { store } = makeFakeStore(page);
+    store.listObserverMessagesPage = vi.fn(async () => ({
+      messages: page,
+      coveredMessageIds: ["m1", "m2", "m3", "m5", "m6", "m7", "m8"],
+      expectedFrontier: null,
+      nextCursor: { createdAtMs: page[7]?.createdAt.getTime() ?? 0, id: "m8" },
+      hasMore: true,
+    }));
+    store.appendObservationAndAdvanceFrontier = vi.fn(async () => "obs-gap");
+
+    const out = await runObserverJob(JOB, makeDeps(store));
+
+    expect(out).toEqual({ observationId: "obs-gap", sourceMessageRange: ["m4", "m4"] });
+    expect(store.listObservations).not.toHaveBeenCalled();
+    expect(store.appendObservationAndAdvanceFrontier).toHaveBeenCalledWith(
+      expect.objectContaining({
+        observation: expect.objectContaining({ sourceMessageRange: ["m4", "m4"] }),
+        nextFrontier: expect.objectContaining({ id: "m4" }),
+      }),
+    );
+  });
 });

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -185,9 +185,11 @@ async function maybeReenqueueForLateMessages(
 // (the idle backstop) is decided at RUN TIME from message ages, not a job flag.
 export interface ObserverJob {
   jobId: string;
-  leaseGeneration?: number;
   accountId: string;
   threadId: string;
+  // Claim generation fences a worker that keeps running after its lease is reclaimed.
+  // Optional only for direct unit fixtures; claimed production jobs always carry it.
+  leaseGeneration?: number;
   // Salient-fact fast path (Change A): the thread's cross-thread scope, carried
   // verbatim from the enqueued job (the worker already has it — observer jobs are
   // enqueued with the full {accountId, projectId?, resourceId?, threadId} scope).
@@ -362,9 +364,14 @@ export async function runObserverJob(
         : await deps.memoryStore
             .getThreadMeta({ accountId: job.accountId, threadId: job.threadId })
             .catch(() => null);
+    const leaseGeneration = job.leaseGeneration;
+    const atomicBounded =
+      deps.memoryStore.listObserverMessagesPage !== undefined &&
+      deps.memoryStore.commitObserverPage !== undefined &&
+      leaseGeneration !== undefined;
     const bounded =
       deps.memoryStore.listObserverMessagesPage !== undefined &&
-      deps.memoryStore.appendObservationAndAdvanceFrontier !== undefined;
+      (atomicBounded || deps.memoryStore.appendObservationAndAdvanceFrontier !== undefined);
     if (
       !bounded &&
       ((readMeta?.messageCount ?? 0) > MAX_OBSERVER_THREAD_MESSAGES ||
@@ -494,6 +501,34 @@ export async function runObserverJob(
           )
         : decisions.find(({ decision }) => decision.shouldCompact);
     if (selected === undefined) {
+      const pageFullyCovered =
+        atomicBounded &&
+        observerPage !== undefined &&
+        observerPage.messages.length > 0 &&
+        observerPage.coveredMessageIds?.length === observerPage.messages.length &&
+        observerPage.nextCursor !== null;
+      if (pageFullyCovered && observerPage.nextCursor !== null) {
+        const observerScope = {
+          accountId: job.accountId,
+          threadId: job.threadId,
+          ...(job.projectId !== undefined ? { projectId: job.projectId } : {}),
+          ...(job.resourceId !== undefined ? { resourceId: job.resourceId } : {}),
+        };
+        const commit = await deps.memoryStore.commitObserverPage?.({
+          accountId: job.accountId,
+          job: { id: job.jobId, scope: observerScope, leaseGeneration: leaseGeneration ?? 0 },
+          action: "advance",
+          expectedFrontier: observerPage.expectedFrontier,
+          nextFrontier: observerPage.nextCursor,
+          ...(observerPage.hasMore ? { successorScope: observerScope } : {}),
+        });
+        if (commit === null) {
+          deps.log("memory.observer.frontier_stale", { thread_id: job.threadId });
+          return { observationId: null, sourceMessageRange: null };
+        }
+        deps.log("memory.observer.coverage_advanced", { thread_id: job.threadId });
+        return { observationId: null, sourceMessageRange: null };
+      }
       // No compaction this run → mine the uncovered turns for durable facts.
       await maybeEagerExtractFacts(job, all, covered, deps);
       await updateClaimedJobStatus(deps.memoryStore, job, "done");
@@ -564,41 +599,55 @@ export async function runObserverJob(
       ...(importance !== undefined ? { importance } : {}),
       ...(tags !== undefined ? { tags } : {}),
     };
-    const observationId = bounded
-      ? await deps.memoryStore.appendObservationAndAdvanceFrontier?.({
+    const hasRemainder = observerPage?.hasMore === true || compressed.length < all.length;
+    const observerScope = {
+      accountId: job.accountId,
+      threadId: job.threadId,
+      ...(job.projectId !== undefined ? { projectId: job.projectId } : {}),
+      ...(job.resourceId !== undefined ? { resourceId: job.resourceId } : {}),
+    };
+    const commit = atomicBounded
+      ? await deps.memoryStore.commitObserverPage?.({
           accountId: job.accountId,
+          job: { id: job.jobId, scope: observerScope, leaseGeneration: leaseGeneration ?? 0 },
+          action: "observe",
           observation: observationInput,
           expectedFrontier: observerPage?.expectedFrontier ?? null,
           nextFrontier: {
             createdAtMs: last.createdAt.getTime(),
             id: last.id,
           },
+          ...(hasRemainder ? { successorScope: observerScope } : {}),
         })
-      : await deps.memoryStore.appendObservation(observationInput);
-    if (observationId == null) {
-      await updateClaimedJobStatus(deps.memoryStore, job, "done");
+      : bounded
+        ? await deps.memoryStore.appendObservationAndAdvanceFrontier?.({
+            accountId: job.accountId,
+            observation: observationInput,
+            expectedFrontier: observerPage?.expectedFrontier ?? null,
+            nextFrontier: {
+              createdAtMs: last.createdAt.getTime(),
+              id: last.id,
+            },
+          })
+        : await deps.memoryStore.appendObservation(observationInput);
+    if (commit == null) {
+      if (!atomicBounded) await updateClaimedJobStatus(deps.memoryStore, job, "done");
       deps.log("memory.observer.frontier_stale", { thread_id: job.threadId });
       return { observationId: null, sourceMessageRange: null };
     }
+    const observationId = typeof commit === "string" ? commit : commit.observationId;
 
     // Book Observer tokens into their OWN bucket — never the provider/actor one.
     deps.costSink("observer", estimateObserverTokens(compressed, observationText));
 
-    await updateClaimedJobStatus(deps.memoryStore, job, "done");
-    if (bounded) {
-      if (observerPage?.hasMore === true || compressed.length < all.length) {
+    if (!atomicBounded) {
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
+      if (bounded && hasRemainder) {
         await deps.memoryStore.enqueueJob({
           type: "observer",
-          scope: {
-            accountId: job.accountId,
-            threadId: job.threadId,
-            ...(job.projectId !== undefined ? { projectId: job.projectId } : {}),
-            ...(job.resourceId !== undefined ? { resourceId: job.resourceId } : {}),
-          },
+          scope: observerScope,
         });
       }
-    } else {
-      await maybeReenqueueForLateMessages(job, snapshotMessageIds, deps);
     }
     deps.log("memory.observer.compressed", {
       thread_id: job.threadId,

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -7,6 +7,7 @@ import {
   resolveCompactionTunables,
 } from "./compaction-policy.js";
 import { buildReconciledFactBatch } from "./forgetting/facts.js";
+import { updateClaimedJobStatus } from "./job-lease.js";
 import type { ExtractedFact } from "./reflector.js";
 
 // consolidate.max_facts_per_subject schema default — used when the composition root
@@ -184,6 +185,7 @@ async function maybeReenqueueForLateMessages(
 // (the idle backstop) is decided at RUN TIME from message ages, not a job flag.
 export interface ObserverJob {
   jobId: string;
+  leaseGeneration?: number;
   accountId: string;
   threadId: string;
   // Salient-fact fast path (Change A): the thread's cross-thread scope, carried
@@ -368,7 +370,7 @@ export async function runObserverJob(
       ((readMeta?.messageCount ?? 0) > MAX_OBSERVER_THREAD_MESSAGES ||
         (readMeta?.observationCount ?? 0) > MAX_OBSERVER_THREAD_OBSERVATIONS)
     ) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       deps.log("memory.observer.history_skipped", {
         thread_id: job.threadId,
         max_messages: MAX_OBSERVER_THREAD_MESSAGES,
@@ -494,7 +496,7 @@ export async function runObserverJob(
     if (selected === undefined) {
       // No compaction this run → mine the uncovered turns for durable facts.
       await maybeEagerExtractFacts(job, all, covered, deps);
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       if (!bounded) await maybeReenqueueForLateMessages(job, snapshotMessageIds, deps);
       const lastDecision = decisions.at(-1)?.decision;
       deps.log("memory.observer.noop_compaction_skipped", {
@@ -514,7 +516,7 @@ export async function runObserverJob(
       // Idempotent / nothing to do — never write an empty observation. Still a
       // no-compaction run, so the eager fact pass applies.
       await maybeEagerExtractFacts(job, all, covered, deps);
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       if (!bounded) await maybeReenqueueForLateMessages(job, snapshotMessageIds, deps);
       deps.log("memory.observer.noop_no_old_messages", { thread_id: job.threadId });
       return { observationId: null, sourceMessageRange: null };
@@ -574,7 +576,7 @@ export async function runObserverJob(
         })
       : await deps.memoryStore.appendObservation(observationInput);
     if (observationId == null) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       deps.log("memory.observer.frontier_stale", { thread_id: job.threadId });
       return { observationId: null, sourceMessageRange: null };
     }
@@ -582,7 +584,7 @@ export async function runObserverJob(
     // Book Observer tokens into their OWN bucket — never the provider/actor one.
     deps.costSink("observer", estimateObserverTokens(compressed, observationText));
 
-    await deps.memoryStore.updateJobStatus(job.jobId, "done");
+    await updateClaimedJobStatus(deps.memoryStore, job, "done");
     if (bounded) {
       if (observerPage?.hasMore === true || compressed.length < all.length) {
         await deps.memoryStore.enqueueJob({
@@ -619,7 +621,7 @@ export async function runObserverJob(
     // it on the job + log; the request that enqueued this job is long gone.
     const message = err instanceof Error ? err.message : String(err);
     try {
-      await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
+      await updateClaimedJobStatus(deps.memoryStore, job, "failed", message);
     } catch (updateErr) {
       // Even the failure bookkeeping is best-effort — still never throw.
       deps.log("memory.observer.job_update_failed", {

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -85,7 +85,19 @@ async function maybeEagerExtractFacts(
     // so a bare `insert(...)` would lose `this` and throw "reading 'db'" (fail-open ⇒
     // silent no-write). Mirror the `.call(deps.memoryStore, ...)` pattern used by the
     // idle-flush / decay-trigger optional-method call sites.
-    await insert.call(deps.memoryStore, { accountId: job.accountId, scope, facts, now });
+    const reconciled = await insert.call(deps.memoryStore, {
+      accountId: job.accountId,
+      scope,
+      facts,
+      now,
+      ...(job.leaseGeneration !== undefined
+        ? { job: { id: job.jobId, leaseGeneration: job.leaseGeneration } }
+        : {}),
+    });
+    if (reconciled.accepted === false) {
+      deps.log("memory.observer.eager_facts_stale", { thread_id: job.threadId });
+      return;
+    }
     deps.log("memory.observer.eager_facts_extracted", {
       thread_id: job.threadId,
       fact_count: facts.length,

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -17,7 +17,9 @@ const DEFAULT_MAX_FACTS_PER_SUBJECT = 8;
 // keyset page below and never materialize a whole thread.
 const MAX_OBSERVER_THREAD_MESSAGES = 4_096;
 const MAX_OBSERVER_THREAD_OBSERVATIONS = 512;
-const OBSERVER_PAGE_MESSAGES = 512;
+// Also bounds inject's coverage lookup: production observations cannot cover more
+// raw rows than the Observer page that created them.
+export const OBSERVER_PAGE_MESSAGES = 512;
 const OBSERVER_PAGE_BYTES = 1 * 1024 * 1024;
 const OBSERVER_PAGE_TOKENS = 64 * 1024;
 

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -402,10 +402,12 @@ export async function runObserverJob(
           accountId: job.accountId,
           threadId: job.threadId,
         });
-    const covered = alreadyObservedMessageIds(
-      all,
-      existing.map((o) => o.sourceMessageRange),
-    );
+    const covered = bounded
+      ? new Set(observerPage?.coveredMessageIds ?? [])
+      : alreadyObservedMessageIds(
+          all,
+          existing.map((o) => o.sourceMessageRange),
+        );
 
     // Auto-compaction inputs — all DERIVED, none configured (the whole point):
     //   model    → thread's last served alias, stamped by observeOutbound; the
@@ -474,19 +476,21 @@ export async function runObserverJob(
     // observations: tiny one-message gaps before a large uncovered tail. Pick the
     // largest compactable segment first so one quiet thread cannot burn one LLM
     // call per tiny gap while still keeping every source range exact.
-    const selected = idle
-      ? decisions.reduce<(typeof decisions)[number] | undefined>(
-          (best, item) =>
-            item.decision.shouldCompact &&
-            (best === undefined ||
-              item.decision.compressedTokens > best.decision.compressedTokens ||
-              (item.decision.compressedTokens === best.decision.compressedTokens &&
-                item.decision.compressedCount > best.decision.compressedCount))
-              ? item
-              : best,
-          undefined,
-        )
-      : decisions.find(({ decision }) => decision.shouldCompact);
+    const selected = bounded
+      ? decisions.find(({ decision }) => decision.shouldCompact)
+      : idle
+        ? decisions.reduce<(typeof decisions)[number] | undefined>(
+            (best, item) =>
+              item.decision.shouldCompact &&
+              (best === undefined ||
+                item.decision.compressedTokens > best.decision.compressedTokens ||
+                (item.decision.compressedTokens === best.decision.compressedTokens &&
+                  item.decision.compressedCount > best.decision.compressedCount))
+                ? item
+                : best,
+            undefined,
+          )
+        : decisions.find(({ decision }) => decision.shouldCompact);
     if (selected === undefined) {
       // No compaction this run → mine the uncovered turns for durable facts.
       await maybeEagerExtractFacts(job, all, covered, deps);

--- a/packages/core/src/memory/recall/embedding-job.test.ts
+++ b/packages/core/src/memory/recall/embedding-job.test.ts
@@ -1,5 +1,5 @@
 import type { MemoryFactInput } from "@helm/shared";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SqliteMemoryStore } from "../../store/sqlite/memory-store.js";
 import { createSqliteDb } from "../../store/sqlite/migrate.js";
 import { factContentHash } from "../forgetting/facts.js";
@@ -41,11 +41,11 @@ function deps(store: SqliteMemoryStore, embedder: Embedder = fakeEmbedder) {
 
 async function claimOne(
   store: SqliteMemoryStore,
-): Promise<{ jobId: string; scope: { accountId: string } }> {
+): Promise<{ jobId: string; leaseGeneration?: number; scope: { accountId: string } }> {
   await store.enqueueJob({ type: "embedding", scope: { accountId: "a" } });
   const [job] = await store.claimPendingJobs(10);
   if (job === undefined) throw new Error("no job claimed");
-  return { jobId: job.jobId, scope: job.scope };
+  return { jobId: job.jobId, leaseGeneration: job.leaseGeneration, scope: job.scope };
 }
 
 describe("runEmbeddingJob (docs/14)", () => {
@@ -111,6 +111,31 @@ describe("runEmbeddingJob (docs/14)", () => {
       limit: 10,
     });
     expect(pending).toHaveLength(1);
+  });
+
+  it("stops without completing or re-enqueueing when embedding publication is stale", async () => {
+    const store = new SqliteMemoryStore(createSqliteDb(":memory:"));
+    await store.insertFactsReconciled({
+      accountId: "a",
+      scope: {},
+      now: NOW,
+      facts: [makeFact("stale embedding")],
+    });
+    const sink = vi.spyOn(store, "setFactEmbeddings").mockResolvedValueOnce(false);
+    const log = vi.fn();
+    const job = await claimOne(store);
+
+    await runEmbeddingJob(job, { ...deps(store), log });
+
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        job: { id: job.jobId, leaseGeneration: job.leaseGeneration },
+      }),
+    );
+    expect(log).toHaveBeenCalledWith("memory.embedding.stale", { account_id: "a" });
+    expect((await store.claimPendingJobs(10)).some((next) => next.type === "embedding")).toBe(
+      false,
+    );
   });
 
   it("re-enqueues a follow-up job after a FULL batch so the backlog drains", async () => {

--- a/packages/core/src/memory/recall/embedding-job.ts
+++ b/packages/core/src/memory/recall/embedding-job.ts
@@ -1,5 +1,6 @@
 import type { ReflectionScope } from "@helm/shared";
 import type { MemoryStore } from "../../store/ports.js";
+import { updateClaimedJobStatus } from "../job-lease.js";
 import type { Embedder } from "./embedder.js";
 
 // docs/14 — the background embedding job: fill memory_facts.embedding (+ the sqlite-vec
@@ -11,6 +12,7 @@ import type { Embedder } from "./embedder.js";
 
 export interface EmbeddingJob {
   readonly jobId: string;
+  readonly leaseGeneration?: number;
   readonly scope: ReflectionScope; // account-scoped (scope.accountId)
 }
 
@@ -29,7 +31,12 @@ export async function runEmbeddingJob(job: EmbeddingJob, deps: EmbeddingJobDeps)
     const list = deps.memoryStore.listFactsNeedingEmbedding;
     const sink = deps.memoryStore.setFactEmbeddings;
     if (list === undefined || sink === undefined) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "failed", "embedding: store lacks methods");
+      await updateClaimedJobStatus(
+        deps.memoryStore,
+        job,
+        "failed",
+        "embedding: store lacks methods",
+      );
       return;
     }
     const facts = await list.call(deps.memoryStore, {
@@ -39,7 +46,7 @@ export async function runEmbeddingJob(job: EmbeddingJob, deps: EmbeddingJobDeps)
       limit: deps.batchSize,
     });
     if (facts.length === 0) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       return;
     }
     const vectors = await deps.embedder.embed(facts.map((f) => f.factText));
@@ -52,7 +59,7 @@ export async function runEmbeddingJob(job: EmbeddingJob, deps: EmbeddingJobDeps)
           it.embedding !== undefined && it.embedding.length === deps.dim,
       );
     if (items.length > 0) await sink.call(deps.memoryStore, { accountId, items });
-    await deps.memoryStore.updateJobStatus(job.jobId, "done");
+    await updateClaimedJobStatus(deps.memoryStore, job, "done");
     deps.log("memory.embedding.done", { account_id: accountId, embedded: items.length });
     // A FULL batch likely leaves more unembedded facts (common right after enabling
     // embeddings or changing models on an existing store). Re-enqueue so the worker
@@ -69,7 +76,7 @@ export async function runEmbeddingJob(job: EmbeddingJob, deps: EmbeddingJobDeps)
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
+    await updateClaimedJobStatus(deps.memoryStore, job, "failed", message);
     deps.log("memory.embedding.failed", { account_id: accountId, error: message });
   }
 }

--- a/packages/core/src/memory/recall/embedding-job.ts
+++ b/packages/core/src/memory/recall/embedding-job.ts
@@ -58,7 +58,19 @@ export async function runEmbeddingJob(job: EmbeddingJob, deps: EmbeddingJobDeps)
         (it): it is { factId: string; embedding: Float32Array; dim: number; model: string } =>
           it.embedding !== undefined && it.embedding.length === deps.dim,
       );
-    if (items.length > 0) await sink.call(deps.memoryStore, { accountId, items });
+    if (items.length > 0) {
+      const accepted = await sink.call(deps.memoryStore, {
+        accountId,
+        items,
+        ...(job.leaseGeneration !== undefined
+          ? { job: { id: job.jobId, leaseGeneration: job.leaseGeneration } }
+          : {}),
+      });
+      if (accepted === false) {
+        deps.log("memory.embedding.stale", { account_id: accountId });
+        return;
+      }
+    }
     await updateClaimedJobStatus(deps.memoryStore, job, "done");
     deps.log("memory.embedding.done", { account_id: accountId, embedded: items.length });
     // A FULL batch likely leaves more unembedded facts (common right after enabling

--- a/packages/core/src/memory/reflector.ts
+++ b/packages/core/src/memory/reflector.ts
@@ -1,6 +1,7 @@
 import type { MemoryFactInput, Observation, Reflection, ReflectionScope } from "@helm/shared";
 import type { MemoryFactReconcileResult, MemoryStore } from "../store/ports.js";
 import { buildReconciledFactBatch } from "./forgetting/facts.js";
+import { updateClaimedJobStatus } from "./job-lease.js";
 
 // ponytail: skip oversized legacy scopes; replace with bounded incremental merging when required.
 const MAX_REFLECTOR_OBSERVATIONS = 512;
@@ -20,6 +21,7 @@ const MAX_REFLECTOR_OBSERVATIONS = 512;
 // model). Enqueued by the periodic scheduler, consumed asynchronously by a worker.
 export interface ReflectorJob {
   jobId: string;
+  leaseGeneration?: number;
   scope: ReflectionScope;
 }
 
@@ -150,6 +152,7 @@ export async function runReflectorJob(
     ) {
       if (deps.memoryStore.commitReflectionJob !== undefined) {
         const committed = await deps.memoryStore.commitReflectionJob(job.jobId, {
+          leaseGeneration: job.leaseGeneration ?? 0,
           target,
           reflection: { action: "unchanged" },
           facts: [],
@@ -160,7 +163,7 @@ export async function runReflectorJob(
           return { reflectionId: null, version: null, changed: false };
         }
       } else {
-        await deps.memoryStore.updateJobStatus(job.jobId, "done");
+        await updateClaimedJobStatus(deps.memoryStore, job, "done");
       }
       deps.log("memory.reflector.history_skipped", {
         scope: job.scope,
@@ -201,6 +204,7 @@ export async function runReflectorJob(
       const shouldArchive = deps.forgetting?.enabled === true && previousReflection !== null;
       if (deps.memoryStore.commitReflectionJob !== undefined) {
         const committed = await deps.memoryStore.commitReflectionJob(job.jobId, {
+          leaseGeneration: job.leaseGeneration ?? 0,
           target,
           reflection: { action: shouldArchive ? "archive" : "unchanged" },
           facts: [],
@@ -231,7 +235,7 @@ export async function runReflectorJob(
         deps.memoryStore.archiveReflections !== undefined
       ) {
         await deps.memoryStore.archiveReflections(target);
-        await deps.memoryStore.updateJobStatus(job.jobId, "done");
+        await updateClaimedJobStatus(deps.memoryStore, job, "done");
         deps.log("memory.reflector.archived_empty_scope", {
           scope: job.scope,
           target_scope: target,
@@ -240,7 +244,7 @@ export async function runReflectorJob(
         return { reflectionId: null, version: null, changed: true };
       }
       // No previous reflection (or no archive support) — nothing to merge or clear.
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       deps.log("memory.reflector.noop_no_observations", { scope: job.scope });
       return {
         reflectionId: previousReflection?.id ?? null,
@@ -279,6 +283,7 @@ export async function runReflectorJob(
 
     if (deps.memoryStore.commitReflectionJob !== undefined) {
       const committed = await deps.memoryStore.commitReflectionJob(job.jobId, {
+        leaseGeneration: job.leaseGeneration ?? 0,
         target,
         reflection: unchanged
           ? { action: "unchanged" }
@@ -319,7 +324,7 @@ export async function runReflectorJob(
     // implement commitReflectionJob and never take this non-atomic fallback.
     await persistFactsLegacy(deps, target, facts, now);
     if (unchanged) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "done");
+      await updateClaimedJobStatus(deps.memoryStore, job, "done");
       deps.log("memory.reflector.unchanged", { scope: job.scope, version: nextVersion });
       return {
         reflectionId: previousReflection.id,
@@ -334,7 +339,7 @@ export async function runReflectorJob(
       tokenEstimate,
       updatedAt: now,
     });
-    await deps.memoryStore.updateJobStatus(job.jobId, "done");
+    await updateClaimedJobStatus(deps.memoryStore, job, "done");
     deps.log("memory.reflector.merged", {
       scope: job.scope,
       target_scope: target,
@@ -348,7 +353,7 @@ export async function runReflectorJob(
     // it on the job + log; this runs off the main request path entirely.
     const message = err instanceof Error ? err.message : String(err);
     try {
-      await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
+      await updateClaimedJobStatus(deps.memoryStore, job, "failed", message);
     } catch (updateErr) {
       // Even the failure bookkeeping is best-effort — still never throw.
       deps.log("memory.reflector.job_update_failed", {

--- a/packages/core/src/memory/scheduler.test.ts
+++ b/packages/core/src/memory/scheduler.test.ts
@@ -157,6 +157,15 @@ describe("startMemoryWorker", () => {
     expect(runObserver).toHaveBeenCalledWith({ jobId: "j1", accountId: "acct-a", threadId: "t1" });
   });
 
+  it("claims only the capacity it can run now", async () => {
+    const { store, claim } = makeStore([]);
+    const handle = startMemoryWorker(makeDeps(store, { batchSize: 50, concurrency: 1 }));
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(claim).toHaveBeenCalledWith(1);
+    await handle.stop();
+  });
+
   it("can drain multiple full batches in one tick for backlog catch-up", async () => {
     const batches: MemoryJobRow[][] = [
       [{ jobId: "j1", type: "observer", scope: { accountId: "acct-a", threadId: "t1" } }],

--- a/packages/core/src/memory/scheduler.ts
+++ b/packages/core/src/memory/scheduler.ts
@@ -1,6 +1,7 @@
 import type { MemoryJobRow, ReflectionScope } from "@helm/shared";
 import type { MemoryStore } from "../store/ports.js";
 import type { DecayJob } from "./forgetting/decay.js";
+import { updateClaimedJobStatus } from "./job-lease.js";
 import type { ObserverJob, ObserverResult } from "./observer.js";
 import type { EmbeddingJob } from "./recall/embedding-job.js";
 import { type ReflectorJob, type ReflectorResult, reflectionTargetScope } from "./reflector.js";
@@ -107,7 +108,11 @@ async function maybeEnqueueEmbedding(
 async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<void> {
   if (job.type === "reflector") {
     // reflector: the whole scope drives the merge.
-    await deps.runReflector({ jobId: job.jobId, scope: job.scope });
+    await deps.runReflector({
+      jobId: job.jobId,
+      ...(job.leaseGeneration !== undefined ? { leaseGeneration: job.leaseGeneration } : {}),
+      scope: job.scope,
+    });
     await maybeEnqueueEmbedding(job.scope, deps);
     return;
   }
@@ -117,15 +122,20 @@ async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<vo
     // if it is not (a worker built without forgetting), fail the row cleanly instead of
     // crashing or mis-routing.
     if (deps.runDecay === undefined) {
-      await deps.memoryStore.updateJobStatus(
-        job.jobId,
+      await updateClaimedJobStatus(
+        deps.memoryStore,
+        job,
         "failed",
         "decay job but worker has no runDecay",
       );
       deps.log("memory.worker.decay_unsupported", { job_id: job.jobId });
       return;
     }
-    await deps.runDecay({ jobId: job.jobId, scope: job.scope });
+    await deps.runDecay({
+      jobId: job.jobId,
+      ...(job.leaseGeneration !== undefined ? { leaseGeneration: job.leaseGeneration } : {}),
+      scope: job.scope,
+    });
     return;
   }
   if (job.type === "embedding") {
@@ -133,15 +143,20 @@ async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<vo
     // enqueued when the embedder is wired (runEmbedding set); a stray row on a worker
     // without it is failed cleanly, never mis-routed.
     if (deps.runEmbedding === undefined) {
-      await deps.memoryStore.updateJobStatus(
-        job.jobId,
+      await updateClaimedJobStatus(
+        deps.memoryStore,
+        job,
         "failed",
         "embedding job but worker has no runEmbedding",
       );
       deps.log("memory.worker.embedding_unsupported", { job_id: job.jobId });
       return;
     }
-    await deps.runEmbedding({ jobId: job.jobId, scope: job.scope });
+    await deps.runEmbedding({
+      jobId: job.jobId,
+      ...(job.leaseGeneration !== undefined ? { leaseGeneration: job.leaseGeneration } : {}),
+      scope: job.scope,
+    });
     return;
   }
   if (job.type === "observer") {
@@ -150,12 +165,18 @@ async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<vo
     // thread anchor is unrunnable, so mark it failed and skip it.
     const threadId = job.scope.threadId;
     if (threadId === undefined) {
-      await deps.memoryStore.updateJobStatus(job.jobId, "failed", "observer job missing threadId");
+      await updateClaimedJobStatus(
+        deps.memoryStore,
+        job,
+        "failed",
+        "observer job missing threadId",
+      );
       deps.log("memory.worker.observer_missing_thread", { job_id: job.jobId });
       return;
     }
     const result = await deps.runObserver({
       jobId: job.jobId,
+      ...(job.leaseGeneration !== undefined ? { leaseGeneration: job.leaseGeneration } : {}),
       accountId: job.scope.accountId,
       threadId,
       // Carry the cross-thread scope through so the Observer's salient-fact fast
@@ -199,8 +220,9 @@ async function processJob(job: MemoryJobRow, deps: MemoryWorkerDeps): Promise<vo
   // forever) rather than dispatching it to the wrong worker — the P5 dispatch
   // requirement (no reflector fall-through). `never` on a clean enum widening means a
   // newly-added MemoryJobType would surface here at compile time too.
-  await deps.memoryStore.updateJobStatus(
-    job.jobId,
+  await updateClaimedJobStatus(
+    deps.memoryStore,
+    job,
     "failed",
     `unknown memory job type: ${String((job as { type: string }).type)}`,
   );
@@ -245,7 +267,7 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
       // closing the row would block this scope's queue FOREVER. Best-effort:
       // even the failure bookkeeping must never escape the tick.
       try {
-        await deps.memoryStore.updateJobStatus(job.jobId, "failed", message);
+        await updateClaimedJobStatus(deps.memoryStore, job, "failed", message);
       } catch (updateErr) {
         deps.log("memory.worker.job_update_failed", {
           job_id: job.jobId,
@@ -271,7 +293,8 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
   };
 
   const drainJobs = async (): Promise<number> => {
-    const jobs = await deps.memoryStore.claimPendingJobs(deps.batchSize);
+    const claimLimit = Math.min(Math.max(1, Math.floor(deps.batchSize)), workerConcurrency);
+    const jobs = await deps.memoryStore.claimPendingJobs(claimLimit);
     await processClaimedJobs(jobs);
     return jobs.length;
   };
@@ -302,13 +325,14 @@ export function startMemoryWorker(deps: MemoryWorkerDeps): MemoryWorkerHandle {
           if (!(await shouldRun())) break;
           lastClaimed = await drainJobs();
           batches += 1;
-          if (lastClaimed < deps.batchSize) break;
+          if (lastClaimed < Math.min(deps.batchSize, workerConcurrency)) break;
           if (maxDrainMs !== null && deps.now() - startedAt >= maxDrainMs) break;
           if (batches < maxBatches) await deps.yieldBetweenBatches?.();
         } while (batches < maxBatches);
-        if (lastClaimed >= deps.batchSize && batches >= maxBatches) {
-          deps.log("memory.worker.drain_batch_cap", { batches, batch_size: deps.batchSize });
-        } else if (lastClaimed >= deps.batchSize && maxDrainMs !== null) {
+        const claimLimit = Math.min(deps.batchSize, workerConcurrency);
+        if (lastClaimed >= claimLimit && batches >= maxBatches) {
+          deps.log("memory.worker.drain_batch_cap", { batches, batch_size: claimLimit });
+        } else if (lastClaimed >= claimLimit && maxDrainMs !== null) {
           deps.log("memory.worker.drain_time_cap", { batches, max_drain_ms: maxDrainMs });
         }
       } while (rerun);

--- a/packages/core/src/provider/anthropic.ts
+++ b/packages/core/src/provider/anthropic.ts
@@ -50,6 +50,7 @@ import {
   type ChatCompletionResponse,
   type ProviderClient,
   readUpstreamErrorBody,
+  readUpstreamJsonWithinBudget,
   safeUpstreamHeaders,
   UpstreamError,
   upstreamTransportError,
@@ -86,6 +87,7 @@ export interface AnthropicClientConfig {
 export interface AnthropicClientDeps {
   config: AnthropicClientConfig;
   fetch?: typeof globalThis.fetch;
+  responseWorkAdmission?: ResponseWorkAdmission;
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -1706,7 +1708,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await readUpstreamErrorBody(res, scrub);
+    const providerRaw = await readUpstreamErrorBody(res, scrub, deps.responseWorkAdmission);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
@@ -1735,7 +1737,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         true,
       );
       if (!res.ok) throw await errorFromResponse(res);
-      const anthResp = (await res.json()) as Record<string, unknown>;
+      const anthResp = await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
       return anthropicToOpenAIResponse(anthResp, model, toolNameMap);
     },
 
@@ -1780,7 +1782,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         false,
       );
       if (!res.ok) throw await errorFromResponse(res);
-      const nativeResponse = (await res.json()) as Record<string, unknown>;
+      const nativeResponse = await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
       return opts?.toolCallXmlRecovery === true
         ? recoverNativeAnthropicJSON(nativeResponse, declaredTools)
         : nativeResponse;
@@ -1791,7 +1793,7 @@ export function createAnthropicClient(deps: AnthropicClientDeps): ProviderClient
         TOKEN_COUNTING_BETA,
       ]);
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
     },
 
     // Streaming native passthrough (issue #217, Phase 2). The native body from a

--- a/packages/core/src/provider/gemini.ts
+++ b/packages/core/src/provider/gemini.ts
@@ -7,12 +7,16 @@ import { geminiTransformer } from "../protocol/gemini/gemini-transformer.js";
 import type { GeminiSSEEvent } from "../protocol/gemini/gemini-types.js";
 import { openaiTransformer } from "../protocol/openai.js";
 import { createSSEIncompleteFrameGuard, splitCompleteSSEFrames } from "../protocol/streaming.js";
-import { runtimeResponseWorkAdmission } from "../runtime/response-work-admission.js";
+import {
+  type ResponseWorkAdmission,
+  runtimeResponseWorkAdmission,
+} from "../runtime/response-work-admission.js";
 import {
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   type ProviderClient,
   readUpstreamErrorBody,
+  readUpstreamJsonWithinBudget,
   safeUpstreamHeaders,
   UpstreamError,
   upstreamTransportError,
@@ -171,6 +175,7 @@ export interface GeminiRemoteMediaFetchConfig {
 export interface GeminiClientDeps {
   config: GeminiClientConfig;
   fetch?: typeof globalThis.fetch;
+  responseWorkAdmission?: ResponseWorkAdmission;
   /** Override hostname resolution for the remote-media SSRF guard (tests). */
   dnsLookup?: HostnameLookup;
   /** Override the remote-media fetcher (tests). Production uses the pinned node:https
@@ -626,7 +631,7 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
   }
 
   async function errorFromResponse(res: Response): Promise<UpstreamError> {
-    const providerRaw = await readUpstreamErrorBody(res, scrub);
+    const providerRaw = await readUpstreamErrorBody(res, scrub, deps.responseWorkAdmission);
     return new UpstreamError(
       "upstream_error",
       `upstream returned ${res.status}`,
@@ -674,7 +679,9 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
         opts?.captureUpstream,
       );
       if (!res.ok) throw await errorFromResponse(res);
-      return geminiResponseToOpenAIChat(await res.json());
+      return geminiResponseToOpenAIChat(
+        await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission),
+      );
     },
 
     async *chatCompletionStream(req, opts) {
@@ -704,7 +711,7 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
         opts?.captureUpstream,
       );
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
     },
 
     async *nativePassthroughStream(input, opts) {
@@ -721,7 +728,7 @@ export function createGeminiClient(deps: GeminiClientDeps): ProviderClient {
     async countTokens(req: ChatCompletionRequest, opts) {
       const res = await requestWithAuthRetry("countTokens", req, opts?.signal);
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
     },
   };
 }

--- a/packages/core/src/provider/oauth/anthropic.ts
+++ b/packages/core/src/provider/oauth/anthropic.ts
@@ -11,6 +11,7 @@
 // the operator opts in (see README disclaimer, issue #38).
 
 import { createServer, type Server } from "node:http";
+import { consumeUpstreamBodyWithinBudget } from "../openai.js";
 import {
   buildOAuthRequestSignal,
   generateOAuthState,
@@ -134,7 +135,7 @@ async function postJson(
   // so the token exchange / refresh can tunnel through the SAME hop as execution —
   // the bind-time call must never leak the operator's real IP (issue #38).
   fetchImpl: typeof globalThis.fetch = fetch,
-): Promise<string> {
+): Promise<OAuthCredentials> {
   throwIfOAuthLoginAborted(signal);
   const res = await fetchImpl(url, {
     method: "POST",
@@ -142,13 +143,13 @@ async function postJson(
     body: JSON.stringify(body),
     signal: buildOAuthRequestSignal({ signal, timeoutMs: 30_000 }),
   });
-  const text = await res.text();
   if (!res.ok) {
     // Never echo the body — an OAuth error body can carry credential material. The
     // status alone is safe and lets the token manager surface a diagnosable reason.
+    await res.body?.cancel().catch(() => {});
     throw new OAuthHttpError("Anthropic", res.status);
   }
-  return text;
+  return await consumeUpstreamBodyWithinBudget(res, parseTokenCredentials);
 }
 
 async function exchangeAuthorizationCode(
@@ -161,7 +162,7 @@ async function exchangeAuthorizationCode(
   signal?: AbortSignal,
   fetchImpl: typeof globalThis.fetch = fetch,
 ): Promise<OAuthCredentials> {
-  const body = await postJson(
+  return await postJson(
     TOKEN_URL,
     {
       grant_type: "authorization_code",
@@ -174,7 +175,6 @@ async function exchangeAuthorizationCode(
     signal,
     fetchImpl,
   );
-  return parseTokenCredentials(body);
 }
 
 // Interactive login: open the authorize URL, wait for the localhost callback, and
@@ -332,7 +332,7 @@ export async function refreshAnthropicToken(
   refreshToken: string,
   fetchImpl: typeof globalThis.fetch = fetch,
 ): Promise<OAuthCredentials> {
-  const body = await postJson(
+  return await postJson(
     TOKEN_URL,
     {
       grant_type: "refresh_token",
@@ -342,7 +342,6 @@ export async function refreshAnthropicToken(
     undefined,
     fetchImpl,
   );
-  return parseTokenCredentials(body);
 }
 
 export const anthropicOAuthProvider: OAuthProviderInterface = {

--- a/packages/core/src/provider/oauth/bounded-responses.test.ts
+++ b/packages/core/src/provider/oauth/bounded-responses.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  createResponseWorkAdmission,
+  runtimeResponseWorkAdmission,
+} from "../../runtime/response-work-admission.js";
+import { createTokenManager, TokenRefreshError } from "../token-manager.js";
+import { refreshAnthropicToken } from "./anthropic.js";
+import { refreshGitHubCopilotToken } from "./github-copilot.js";
+import { listAnthropicModels, listOpenAICodexModels } from "./models.js";
+import { refreshOpenAICodexToken } from "./openai-codex.js";
+
+const CONFIDENTIAL_OAUTH = {
+  grant: "refresh_token" as const,
+  tokenUrl: "https://oauth.test/token",
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  refreshToken: "refresh-secret",
+  scopes: [],
+};
+
+function declaredOversizedResponse(status = 200) {
+  let cancelled = false;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("{}"));
+      controller.close();
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  return {
+    response: new Response(body, {
+      status,
+      headers: { "content-length": String(runtimeResponseWorkAdmission().capacityBytes + 1) },
+    }),
+    cancelled: () => cancelled,
+  };
+}
+
+type ResponseCall = (response: Response) => Promise<unknown>;
+
+const successCalls: Array<[string, ResponseCall]> = [
+  [
+    "confidential token refresh",
+    (response) =>
+      createTokenManager({
+        oauth: CONFIDENTIAL_OAUTH,
+        fetch: async () => response,
+      }).getAuthHeader(),
+  ],
+  [
+    "OpenAI Codex token refresh",
+    (response) => refreshOpenAICodexToken("refresh", async () => response),
+  ],
+  ["Anthropic token refresh", (response) => refreshAnthropicToken("refresh", async () => response)],
+  [
+    "GitHub Copilot token refresh",
+    (response) => refreshGitHubCopilotToken("github", undefined, async () => response),
+  ],
+  [
+    "OpenAI Codex model discovery",
+    (response) => listOpenAICodexModels("access", { fetchImpl: async () => response }),
+  ],
+  ["Anthropic model discovery", (response) => listAnthropicModels("access", async () => response)],
+];
+
+describe("bounded OAuth success responses", () => {
+  it.each(successCalls)("cancels a declared oversized %s body", async (_name, run) => {
+    const fixture = declaredOversizedResponse();
+
+    await expect(run(fixture.response)).rejects.toThrow();
+    expect(fixture.cancelled()).toBe(true);
+  });
+
+  it("cancels chunked overflow, unlocks the stream, and releases response work", async () => {
+    const work = createResponseWorkAdmission({
+      capacityBytes: 32,
+      jsonAmplification: 1,
+      minChargeBytes: 1,
+    });
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ access_token: "a".repeat(64), expires_in: 3600 }),
+    );
+    let cancelled = false;
+    let chunk = 0;
+    const body = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          controller.enqueue(chunk++ === 0 ? bytes.subarray(0, 16) : bytes.subarray(16));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      },
+      { highWaterMark: 0 },
+    );
+    const manager = createTokenManager({
+      oauth: CONFIDENTIAL_OAUTH,
+      fetch: async () => new Response(body),
+      responseWorkAdmission: work,
+    });
+
+    await expect(manager.getAuthHeader()).rejects.toBeInstanceOf(TokenRefreshError);
+    expect(cancelled).toBe(true);
+    expect(body.locked).toBe(false);
+    expect(work.reservedBytes).toBe(0);
+  });
+});
+
+describe("bounded OAuth error responses", () => {
+  it.each(
+    successCalls,
+  )("keeps the scrubbed %s error contract and cancels its body", async (_name, run) => {
+    const fixture = declaredOversizedResponse(401);
+
+    await expect(run(fixture.response)).rejects.toThrow(/401|HTTP|token request failed/i);
+    expect(fixture.cancelled()).toBe(true);
+  });
+});

--- a/packages/core/src/provider/oauth/github-copilot.ts
+++ b/packages/core/src/provider/oauth/github-copilot.ts
@@ -9,6 +9,7 @@
 //
 // ⚠️ ToS: reverse-engineered first-party client; operator opts in (issue #38).
 
+import { readUpstreamJsonWithinBudget } from "../openai.js";
 import {
   nonNegativeSecondsToSafeMs,
   OAuthHttpError,
@@ -83,10 +84,10 @@ async function fetchJson(
       : AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!res.ok) {
-    await res.text().catch(() => "");
+    await res.body?.cancel().catch(() => {});
     throw new OAuthHttpError("GitHub Copilot", res.status);
   }
-  return res.json();
+  return await readUpstreamJsonWithinBudget(res);
 }
 
 interface DeviceCode {

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -9,6 +9,8 @@
 // (that wins).
 
 import { arch, platform, release } from "node:os";
+import type { ResponseWorkAdmission } from "../../runtime/response-work-admission.js";
+import { readUpstreamJsonWithinBudget } from "../openai.js";
 import { type CodexModelInfo, CodexModelsResponseSchema } from "./codex-model-info.js";
 import { listGitHubCopilotModels } from "./github-copilot.js";
 import { parseOpenAICodexIdentity } from "./openai-codex.js";
@@ -101,6 +103,7 @@ export interface OpenAICodexModelsOptions {
   fetchImpl?: typeof globalThis.fetch;
   timeoutMs?: number;
   signal?: AbortSignal;
+  responseWorkAdmission?: ResponseWorkAdmission;
 }
 
 export interface OpenAICodexModelsResult {
@@ -210,13 +213,13 @@ export async function listOpenAICodexModels(
     signal: buildOAuthRequestSignal({ signal: options.signal, timeoutMs }),
   });
   if (!response.ok) {
-    await response.text().catch(() => "");
+    await response.body?.cancel().catch(() => {});
     throw new OpenAICodexModelsError(response.status);
   }
 
   let body: unknown;
   try {
-    body = await response.json();
+    body = await readUpstreamJsonWithinBudget(response, options.responseWorkAdmission);
   } catch {
     throw new Error("OpenAI Codex /models returned invalid JSON");
   }
@@ -256,8 +259,11 @@ export async function listAnthropicModels(
     },
     signal: AbortSignal.timeout(timeoutMs),
   });
-  if (!res.ok) throw new Error(`anthropic /v1/models HTTP ${res.status}`);
-  const body = (await res.json()) as { data?: Array<{ id?: unknown }> };
+  if (!res.ok) {
+    await res.body?.cancel().catch(() => {});
+    throw new Error(`anthropic /v1/models HTTP ${res.status}`);
+  }
+  const body = await readUpstreamJsonWithinBudget<{ data?: Array<{ id?: unknown }> }>(res);
   const ids = (body.data ?? [])
     .map((m) => (typeof m.id === "string" ? m.id.trim() : ""))
     .filter((id) => id.length > 0);

--- a/packages/core/src/provider/oauth/openai-codex.ts
+++ b/packages/core/src/provider/oauth/openai-codex.ts
@@ -9,6 +9,7 @@
 //
 // ⚠️ ToS: reverse-engineered first-party Codex client; operator opts in (issue #38).
 
+import { readUpstreamJsonWithinBudget } from "../openai.js";
 import {
   buildOAuthRequestSignal,
   generateOAuthState,
@@ -165,10 +166,10 @@ async function postToken(
     signal: buildOAuthRequestSignal({ signal, timeoutMs: 30_000 }),
   });
   if (!res.ok) {
-    await res.text().catch(() => "");
+    await res.body?.cancel().catch(() => {});
     throw new OAuthHttpError("OpenAI Codex", res.status);
   }
-  return (await res.json()) as TokenResponseJson;
+  return await readUpstreamJsonWithinBudget<TokenResponseJson>(res);
 }
 
 function postTokenForm(

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -376,6 +376,44 @@ export async function readUpstreamErrorBody(
   }
 }
 
+export async function consumeUpstreamBodyWithinBudget<T>(
+  response: Response,
+  consume: (text: string) => T | Promise<T>,
+  admission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
+): Promise<T> {
+  try {
+    return await consumeResponseTextWithinBudget(
+      response,
+      admission.capacityBytes,
+      consume,
+      admission,
+    );
+  } catch (error) {
+    if (error instanceof ResponseBodyTooLargeError) {
+      throw new UpstreamError("upstream_error", error.message, {
+        error: { code: "response_body_too_large", limit_bytes: error.limitBytes },
+      });
+    }
+    if (error instanceof ResponseWorkCapacityError) {
+      throw new UpstreamError("upstream_error", error.message, {
+        error: { code: "response_work_capacity_exhausted", limit_bytes: error.capacityBytes },
+      });
+    }
+    throw error;
+  }
+}
+
+export async function readUpstreamJsonWithinBudget<T = Record<string, unknown>>(
+  response: Response,
+  admission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
+): Promise<T> {
+  return await consumeUpstreamBodyWithinBudget(
+    response,
+    (text) => JSON.parse(text) as T,
+    admission,
+  );
+}
+
 const DEFAULT_TIMEOUT_MS = 60_000;
 
 function normalizeOpenAIReasoningPayload(value: unknown): boolean {
@@ -765,8 +803,9 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
   async function mediaJsonResponse(res: Response, requiredField: "request_id" | "status") {
     let body: unknown;
     try {
-      body = await res.json();
-    } catch {
+      body = await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
+    } catch (error) {
+      if (error instanceof UpstreamError) throw error;
       throw invalidMediaResponse(res, null, "upstream returned invalid media JSON");
     }
     if (
@@ -831,7 +870,10 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
     async chatCompletion(req, opts) {
       const res = await requestWithAuthRetry(req, opts?.signal, opts?.captureUpstream);
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as ChatCompletionResponse;
+      return await readUpstreamJsonWithinBudget<ChatCompletionResponse>(
+        res,
+        deps.responseWorkAdmission,
+      );
     },
 
     async imageGeneration(req, opts) {
@@ -844,7 +886,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
     },
 
     async imageEdit(req, opts) {
@@ -878,7 +920,7 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
         signal: opts?.signal,
       });
       if (!res.ok) throw await errorFromResponse(res);
-      return (await res.json()) as Record<string, unknown>;
+      return await readUpstreamJsonWithinBudget(res, deps.responseWorkAdmission);
     },
 
     async videoGeneration(req, opts) {
@@ -936,7 +978,11 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
         signal: opts?.signal,
       });
       if (!response.ok) throw await realtimeErrorFromResponse(response);
-      const sdp = await response.text();
+      const sdp = await consumeUpstreamBodyWithinBudget(
+        response,
+        (text) => text,
+        deps.responseWorkAdmission,
+      );
       const location = response.headers.get("location") ?? "";
       const callId = realtimeCallId(location);
       if (callId === null) {

--- a/packages/core/src/provider/token-manager.ts
+++ b/packages/core/src/provider/token-manager.ts
@@ -18,11 +18,13 @@
 // rotated refresh token survives restarts.
 
 import { createHash } from "node:crypto";
+import type { ResponseWorkAdmission } from "../runtime/response-work-admission.js";
 import { decryptSecret, encryptSecret } from "../store/crypto/token-cipher.js";
 import type { OAuthTokenStore } from "../store/ports.js";
 import { OpenAICodexIdentityMismatchError } from "./oauth/openai-codex.js";
 import { buildOAuthRequestSignal, OAuthHttpError } from "./oauth/runtime.js";
 import type { OAuthCredentials, OAuthProviderInterface } from "./oauth/types.js";
+import { readUpstreamJsonWithinBudget } from "./openai.js";
 import { isFetchTransportError } from "./retry.js";
 
 // Cross-instance refresh serialization for PRESET credentials. The composition root
@@ -117,6 +119,7 @@ export interface TokenManagerDeps {
   expirySkewMs?: number;
   /** Internal deadline for the shared refresh fetch. */
   refreshTimeoutMs?: number;
+  responseWorkAdmission?: ResponseWorkAdmission;
   // ── preset-kind deps (REQUIRED when oauth.kind === "preset") ────────────────
   /** Persistent credential store (read on first use, rotation write-back on refresh). */
   tokenStore?: OAuthTokenStore;
@@ -263,13 +266,16 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
       throw new TokenRefreshError("oauth token request failed (network error)");
     }
     if (!res.ok) {
-      // Drain + discard the body: an OAuth error body can echo the credential.
-      await res.text().catch(() => "");
+      // Discard without decoding: an OAuth error body can echo the credential.
+      await res.body?.cancel().catch(() => {});
       throw new TokenRefreshError(`oauth token request failed (status ${res.status})`, res.status);
     }
     let parsed: TokenEndpointResponse;
     try {
-      parsed = (await res.json()) as TokenEndpointResponse;
+      parsed = await readUpstreamJsonWithinBudget<TokenEndpointResponse>(
+        res,
+        deps.responseWorkAdmission,
+      );
     } catch {
       throw new TokenRefreshError("oauth token response was not valid JSON", res.status);
     }

--- a/packages/core/src/provider/unary-response-bounds.test.ts
+++ b/packages/core/src/provider/unary-response-bounds.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from "vitest";
+import { createResponseWorkAdmission } from "../runtime/response-work-admission.js";
+import { createAnthropicClient } from "./anthropic.js";
+import { createGeminiClient } from "./gemini.js";
+import { createOpenAIClient, type ProviderClient, type UpstreamError } from "./openai.js";
+
+const CAPACITY_BYTES = 32;
+
+function admission() {
+  return createResponseWorkAdmission({
+    capacityBytes: CAPACITY_BYTES,
+    jsonAmplification: 1,
+    minChargeBytes: 1,
+  });
+}
+
+function declaredOversizedResponse(status = 200) {
+  let cancelled = false;
+  const body = new ReadableStream<Uint8Array>({
+    cancel() {
+      cancelled = true;
+    },
+  });
+  return {
+    response: new Response(body, {
+      status,
+      headers: {
+        "content-type": status === 201 ? "application/sdp" : "application/json",
+        "content-length": String(CAPACITY_BYTES + 1),
+        ...(status === 201 ? { location: "/v1/realtime/calls/rtc_test" } : {}),
+      },
+    }),
+    cancelled: () => cancelled,
+  };
+}
+
+function chunkedOversizedResponse() {
+  let cancelled = false;
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(`{"text":"${"x".repeat(CAPACITY_BYTES)}`));
+      controller.enqueue(encoder.encode('"}'));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  return {
+    response: new Response(body, { headers: { "content-type": "application/json" } }),
+    cancelled: () => cancelled,
+  };
+}
+
+async function expectBoundedFailure(
+  run: (client: ProviderClient) => Promise<unknown>,
+  makeClient: (
+    fetch: typeof globalThis.fetch,
+    work: ReturnType<typeof admission>,
+  ) => ProviderClient,
+  response: ReturnType<typeof declaredOversizedResponse>,
+) {
+  const work = admission();
+  const fetch = vi.fn(async () => response.response);
+  const client = makeClient(fetch, work);
+
+  await expect(run(client)).rejects.toMatchObject({
+    errorClass: "upstream_error",
+    providerRaw: { error: { code: "response_body_too_large", limit_bytes: CAPACITY_BYTES } },
+  } satisfies Partial<UpstreamError>);
+  expect(response.cancelled()).toBe(true);
+  expect(work.reservedBytes).toBe(0);
+}
+
+const openAIUnaryCalls: Array<[string, (client: ProviderClient) => Promise<unknown>, number]> = [
+  ["chat completion", (client) => client.chatCompletion({ model: "m", messages: [] }), 200],
+  [
+    "image generation",
+    (client) => {
+      if (!client.imageGeneration) throw new Error("missing imageGeneration");
+      return client.imageGeneration({ model: "image" });
+    },
+    200,
+  ],
+  [
+    "image edit",
+    (client) => {
+      if (!client.imageEdit) throw new Error("missing imageEdit");
+      return client.imageEdit({ kind: "json", body: { model: "image" } });
+    },
+    200,
+  ],
+  [
+    "video generation",
+    (client) => {
+      if (!client.videoGeneration) throw new Error("missing videoGeneration");
+      return client.videoGeneration({ model: "video" });
+    },
+    200,
+  ],
+  [
+    "video retrieve",
+    (client) => {
+      if (!client.videoRetrieve) throw new Error("missing videoRetrieve");
+      return client.videoRetrieve("video_1");
+    },
+    200,
+  ],
+  [
+    "Realtime SDP",
+    (client) => {
+      if (!client.realtimeCall) throw new Error("missing realtimeCall");
+      return client.realtimeCall({
+        endpoint: "realtime",
+        query: "",
+        sdp: "v=0",
+        session: { model: "gpt-realtime" },
+        headers: {},
+      });
+    },
+    201,
+  ],
+];
+
+describe("bounded unary provider responses", () => {
+  it.each(
+    openAIUnaryCalls,
+  )("rejects oversized OpenAI %s bodies before reading", async (_name, run, status) => {
+    await expectBoundedFailure(
+      run,
+      (fetch, responseWorkAdmission) =>
+        createOpenAIClient({
+          config: { baseUrl: "https://openai.test/v1", apiKey: "key" },
+          fetch,
+          responseWorkAdmission,
+        }),
+      declaredOversizedResponse(status),
+    );
+  });
+
+  it.each([
+    [
+      "chat completion",
+      (client: ProviderClient) => client.chatCompletion({ model: "m", messages: [] }),
+    ],
+    [
+      "native passthrough",
+      (client: ProviderClient) => {
+        if (!client.nativePassthrough) throw new Error("missing nativePassthrough");
+        return client.nativePassthrough({ model: "m", messages: [] });
+      },
+    ],
+    [
+      "token count",
+      (client: ProviderClient) => {
+        if (!client.countTokens) throw new Error("missing countTokens");
+        return client.countTokens({ model: "m", messages: [] });
+      },
+    ],
+  ])("rejects oversized Anthropic %s bodies before reading", async (_name, run) => {
+    await expectBoundedFailure(
+      run,
+      (fetch, responseWorkAdmission) =>
+        createAnthropicClient({
+          config: { baseUrl: "https://anthropic.test", apiKey: "key" },
+          fetch,
+          responseWorkAdmission,
+        }),
+      declaredOversizedResponse(),
+    );
+  });
+
+  it.each([
+    [
+      "chat completion",
+      (client: ProviderClient) => client.chatCompletion({ model: "m", messages: [] }),
+    ],
+    [
+      "native passthrough",
+      (client: ProviderClient) => {
+        if (!client.nativePassthrough) throw new Error("missing nativePassthrough");
+        return client.nativePassthrough({ model: "m", contents: [] });
+      },
+    ],
+    [
+      "token count",
+      (client: ProviderClient) => {
+        if (!client.countTokens) throw new Error("missing countTokens");
+        return client.countTokens({ model: "m", contents: [] });
+      },
+    ],
+  ])("rejects oversized Gemini %s bodies before reading", async (_name, run) => {
+    await expectBoundedFailure(
+      run,
+      (fetch, responseWorkAdmission) =>
+        createGeminiClient({
+          config: { baseUrl: "https://gemini.test/v1beta", apiKey: "key" },
+          fetch,
+          responseWorkAdmission,
+        }),
+      declaredOversizedResponse(),
+    );
+  });
+
+  it.each([
+    [
+      "OpenAI",
+      (fetch: typeof globalThis.fetch, responseWorkAdmission: ReturnType<typeof admission>) =>
+        createOpenAIClient({
+          config: { baseUrl: "https://openai.test/v1", apiKey: "key" },
+          fetch,
+          responseWorkAdmission,
+        }),
+    ],
+    [
+      "Anthropic",
+      (fetch: typeof globalThis.fetch, responseWorkAdmission: ReturnType<typeof admission>) =>
+        createAnthropicClient({
+          config: { baseUrl: "https://anthropic.test", apiKey: "key" },
+          fetch,
+          responseWorkAdmission,
+        }),
+    ],
+    [
+      "Gemini",
+      (fetch: typeof globalThis.fetch, responseWorkAdmission: ReturnType<typeof admission>) =>
+        createGeminiClient({
+          config: { baseUrl: "https://gemini.test/v1beta", apiKey: "key" },
+          fetch,
+          responseWorkAdmission,
+        }),
+    ],
+  ])("cancels chunked %s overflow and releases shared capacity", async (_name, makeClient) => {
+    const response = chunkedOversizedResponse();
+    await expectBoundedFailure(
+      (client) => client.chatCompletion({ model: "m", messages: [] }),
+      makeClient,
+      response,
+    );
+  });
+});

--- a/packages/core/src/store/cached-keystore.test.ts
+++ b/packages/core/src/store/cached-keystore.test.ts
@@ -24,6 +24,9 @@ function rec(keyId: string, hash: string): ApiKeyRecord {
 function makeInner(rows: Map<string, ApiKeyRecord | null> = new Map()): KeyStore {
   return {
     getByHash: vi.fn(async (hash: string) => rows.get(hash) ?? null),
+    getById: vi.fn(
+      async (keyId: string) => [...rows.values()].find((row) => row?.key_id === keyId) ?? null,
+    ),
     createKey: vi.fn(async (input: CreateKeyInput) => rec(input.keyId, input.hash)),
     list: vi.fn(async () => [...rows.values()].filter((r): r is ApiKeyRecord => r !== null)),
     disable: vi.fn(async (_keyId: string) => {}),
@@ -52,6 +55,16 @@ describe("createCachedKeyStore", () => {
     expect(a?.key_id).toBe("k1");
     expect(b).toEqual(a);
     expect(inner.getByHash).toHaveBeenCalledTimes(1);
+  });
+
+  it("delegates getById without scanning list", async () => {
+    const rows = new Map<string, ApiKeyRecord | null>([["h1", rec("k1", "h1")]]);
+    const inner = makeInner(rows);
+    const cached = createCachedKeyStore(inner, { ttlMs: 30_000, maxEntries: 100, now });
+
+    expect((await cached.getById("k1"))?.hash).toBe("h1");
+    expect(inner.getById).toHaveBeenCalledWith("k1");
+    expect(inner.list).not.toHaveBeenCalled();
   });
 
   it("caches a negative (null) result so an invalid-key flood does not hammer the DB", async () => {

--- a/packages/core/src/store/cached-keystore.ts
+++ b/packages/core/src/store/cached-keystore.ts
@@ -62,6 +62,10 @@ export function createCachedKeyStore(inner: KeyStore, opts: CachedKeyStoreOption
       return value;
     },
 
+    getById(keyId: string): Promise<ApiKeyRecord | null> {
+      return inner.getById(keyId);
+    },
+
     list(): Promise<ApiKeyRecord[]> {
       return inner.list();
     },

--- a/packages/core/src/store/payload-codec.test.ts
+++ b/packages/core/src/store/payload-codec.test.ts
@@ -13,6 +13,23 @@ describe("payload-codec", () => {
     expect(decodePayloadValue(encodePayloadText(text))).toBe(text);
   });
 
+  it("reads a legacy gzip row at the raw chunk boundary", () => {
+    const text = "x".repeat(PAYLOAD_TEXT_CHUNK_RAW_BYTES);
+    expect(decodePayloadValue(encodePayloadText(text))).toBe(text);
+  });
+
+  it("treats a legacy gzip row one byte over the raw chunk boundary as unavailable", () => {
+    const compressed = encodePayloadText("x".repeat(PAYLOAD_TEXT_CHUNK_RAW_BYTES + 1));
+    expect(decodePayloadValue(compressed)).toBeNull();
+  });
+
+  it("rejects a highly compressed legacy gzip bomb without returning its output", () => {
+    const rawBytes = PAYLOAD_TEXT_CHUNK_RAW_BYTES * 8;
+    const compressed = encodePayloadText("x".repeat(rawBytes));
+    expect(compressed.length).toBeLessThan(rawBytes / 100);
+    expect(decodePayloadValue(compressed)).toBeNull();
+  });
+
   it("actually shrinks repetitive transcript text", () => {
     const text = "the quick brown fox ".repeat(2000);
     expect(encodePayloadText(text).length).toBeLessThan(text.length / 5);

--- a/packages/core/src/store/payload-codec.ts
+++ b/packages/core/src/store/payload-codec.ts
@@ -33,7 +33,7 @@ export function decodePayloadValue(value: unknown): string | null {
   const buf = Buffer.isBuffer(value) ? value : Buffer.from(value as Uint8Array);
   if (buf.length >= 2 && buf[0] === GZIP_MAGIC_0 && buf[1] === GZIP_MAGIC_1) {
     try {
-      return gunzipSync(buf).toString("utf8");
+      return gunzipSync(buf, { maxOutputLength: PAYLOAD_TEXT_CHUNK_RAW_BYTES }).toString("utf8");
     } catch {
       return null;
     }

--- a/packages/core/src/store/ports.test.ts
+++ b/packages/core/src/store/ports.test.ts
@@ -60,6 +60,9 @@ class InMemoryKeyStore implements KeyStore {
     }
     return null;
   }
+  async getById(keyId: string): Promise<ApiKeyRecord | null> {
+    return this.byId.get(keyId) ?? null;
+  }
   async list(): Promise<ApiKeyRecord[]> {
     return [...this.byId.values()];
   }

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -805,6 +805,37 @@ export interface MemoryObserverPage {
   hasMore: boolean;
 }
 
+export interface MemoryObserverJobFence {
+  id: string;
+  scope: ReflectionScope;
+  // Incremented by claim; the commit CAS rejects a worker whose lease was
+  // reclaimed while it was summarizing.
+  leaseGeneration: number;
+}
+
+export type MemoryObserverPageCommitInput =
+  | {
+      accountId: string;
+      job: MemoryObserverJobFence;
+      action: "observe";
+      observation: MemoryObservationInput;
+      expectedFrontier: MemoryObserverCursor | null;
+      nextFrontier: MemoryObserverCursor;
+      successorScope?: ReflectionScope;
+    }
+  | {
+      accountId: string;
+      job: MemoryObserverJobFence;
+      action: "advance";
+      expectedFrontier: MemoryObserverCursor | null;
+      nextFrontier: MemoryObserverCursor;
+      successorScope?: ReflectionScope;
+    };
+
+export interface MemoryObserverPageCommitResult {
+  observationId: string | null;
+}
+
 export interface MemoryStore {
   // Idempotent upsert of a thread; safe to call on every observed request.
   ensureThread(input: MemoryThreadInput): Promise<void>;
@@ -854,6 +885,12 @@ export interface MemoryStore {
     expectedFrontier: MemoryObserverCursor | null;
     nextFrontier: MemoryObserverCursor;
   }): Promise<string | null>;
+  // Commit one bounded Observer page as one recovery-safe unit: frontier CAS,
+  // observation insert, current running-job completion, and any successor job.
+  // null rejects a stale frontier or job fence without changing durable state.
+  commitObserverPage?(
+    input: MemoryObserverPageCommitInput,
+  ): Promise<MemoryObserverPageCommitResult | null>;
   // POST-MVP Phase 2 (Reflector). Read a scope's ACTIVE observations so the
   // background Reflector can merge them into a stable reflection. Two read
   // shapes: a THREAD scope returns that thread's rows (inject/observer); a

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -795,6 +795,10 @@ export interface MemoryObserverCursor {
 
 export interface MemoryObserverPage {
   messages: RawMessage[];
+  // Any-status historical observations remain coverage after archive/prune.
+  // Real adapters return only ids from this bounded page; optional keeps older
+  // test/third-party stores source-compatible.
+  coveredMessageIds?: string[];
   expectedFrontier: MemoryObserverCursor | null;
   nextCursor: MemoryObserverCursor | null;
   hasMore: boolean;

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -777,6 +777,7 @@ export type MemoryReflectionCommitAction =
   | { action: "unchanged" };
 
 export interface MemoryReflectionJobCommitInput {
+  leaseGeneration: number;
   target: ReflectionScope;
   reflection: MemoryReflectionCommitAction;
   facts: MemoryFactInput[];
@@ -901,7 +902,12 @@ export interface MemoryStore {
   // Update a background job's lifecycle status (+ optional error on failure).
   // The Observer/Reflector mark their job done/failed; failure is recorded here,
   // never bubbled to the main request path (fail-open).
-  updateJobStatus(jobId: string, status: MemoryJobStatus, error?: string): Promise<void>;
+  updateJobStatus(
+    jobId: string,
+    status: MemoryJobStatus,
+    error?: string,
+    leaseGeneration?: number,
+  ): Promise<void>;
   // POST-MVP Phase 2 (queue). Enqueue a background job (observer | reflector) for
   // a scope. The scope is encoded into the single scope_id column (canonical JSON,
   // D1). DEDUPE (D6): if an OPEN (pending) job of the same (type, scope_id) already

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -763,6 +763,9 @@ export interface MemoryFactReconcileResult {
   insertedIds: string[];
   supersededIds: string[];
   resurrectedIds?: string[];
+  // False only when a background worker lost its lease before publication.
+  // Optional so existing adapters and direct/manual fact writes stay compatible.
+  accepted?: boolean;
 }
 
 export type MemoryReflectionCommitAction =
@@ -1045,7 +1048,12 @@ export interface MemoryStore {
   // owner_id (defence in depth; the ids already came from an account-scoped read).
   // Empty id lists are a no-op. OPTIONAL (`?`): additive + gated, same contract as
   // listScorableObservations / bumpReferences.
-  archiveObservations?(input: { accountId: string; ids: string[]; now: Date }): Promise<void>;
+  archiveObservations?(input: {
+    accountId: string;
+    ids: string[];
+    now: Date;
+    job?: { id: string; leaseGeneration: number };
+  }): Promise<boolean> | Promise<void>;
   // Production adapters atomically enqueue reflector rebuilds for the exact
   // scopes affected by archiveObservations. Older adapters may omit this marker;
   // decay retains the bounded account-scan fallback for them.
@@ -1124,6 +1132,7 @@ export interface MemoryStore {
     scope: { projectId?: string; resourceId?: string; threadId?: string };
     facts: MemoryFactInput[];
     now: Date;
+    job?: { id: string; leaseGeneration: number };
   }): Promise<MemoryFactReconcileResult>;
   // docs/12 "Supersede within long" — the fact READ half. Return the account's
   // facts that are still alive: owner_id = accountId AND status='active' AND
@@ -1323,7 +1332,8 @@ export interface MemoryStore {
   setFactEmbeddings?(input: {
     accountId: string;
     items: Array<{ factId: string; embedding: Float32Array; model: string; dim: number }>;
-  }): Promise<void>;
+    job?: { id: string; leaseGeneration: number };
+  }): Promise<boolean> | Promise<void>;
 
   // docs/14 — the embedding job's READ half: ACTIVE facts that still need a (re-)
   // embedding for the vector leg — NULL embedding, OR one from a DIFFERENT model, OR

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -218,6 +218,8 @@ export interface KeyStore {
   // Used by the Auth Resolver. A disabled key is still returned (with
   // disabled:true) so the caller — not the store — decides to reject it.
   getByHash(hash: string): Promise<ApiKeyRecord | null>;
+  // Direct admin lookup by immutable key id. Never scan list() for one key.
+  getById(keyId: string): Promise<ApiKeyRecord | null>;
   // Used for bootstrap emptiness check / admin display. Never includes plaintext.
   list(): Promise<ApiKeyRecord[]>;
   // Soft revoke: set disabled=true. Never physically deletes, never rewrites
@@ -1281,7 +1283,11 @@ export interface MemoryStore {
   // reflections via a UNION of grouped subqueries (SQLite has no FULL OUTER JOIN);
   // reflections are guarded owner_id IS NOT NULL (nullable column — legacy/global
   // rows must never surface under an account).
-  listMemoryScopes?(input: { accountId?: string }): Promise<MemoryScopeSummary[]>;
+  listMemoryScopes?(input: {
+    accountId?: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ rows: MemoryScopeSummary[]; total: number }>;
 
   // Operational snapshot for the admin Memory page. This is READ-ONLY
   // observability: queue depth, stale running leases, raw/derived row counts, and

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -920,12 +920,24 @@ export interface MemoryStore {
       access_weight: number;
     };
   }): Promise<Observation[]>;
-  // Bounded page counterpart: resolve all window-dedup ranges in ONE store query,
-  // returning only the redundant observation ids (never transcript bodies).
+  // Resolve window-dedup coverage for the whole bounded injection candidate set in
+  // ONE store query, returning only redundant observation ids (never transcript
+  // bodies). Candidate selection uses the same priority order as the paged body read.
+  // Each inclusive source range is resolved by canonical (created_at,id) tuple order;
+  // unresolved or over-limit legacy ranges are conservatively kept.
   findRedundantInjectionObservations?(input: {
     accountId: string;
     threadId: string;
-    observations: Array<{ id: string; sourceMessageRange: [string, string] }>;
+    candidateLimit: number;
+    maxCoverageMessages: number;
+    order: "newest" | "score";
+    score?: {
+      nowMs: number;
+      half_life_s: number;
+      importance_floor: number;
+      importance_ceil: number;
+      access_weight: number;
+    };
     windowContentHashCounts: ReadonlyMap<string, number>;
   }): Promise<ReadonlySet<string>>;
   // Read the current (latest) ACTIVE reflection for a scope, or null if none yet.

--- a/packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts
+++ b/packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts
@@ -93,7 +93,8 @@ describe("real PostgreSQL concurrency contracts", () => {
     });
     const scope = { accountId, projectId };
     const jobId = await setupStore.enqueueJob({ type: "reflector", scope });
-    expect((await setupStore.claimPendingJobs(1))[0]?.jobId).toBe(jobId);
+    const claimedJob = (await setupStore.claimPendingJobs(1))[0];
+    expect(claimedJob?.jobId).toBe(jobId);
 
     let releaseReflectionLock!: () => void;
     const holdReflectionLock = new Promise<void>((resolve) => {
@@ -119,6 +120,7 @@ describe("real PostgreSQL concurrency contracts", () => {
       await waitForBlockedQuery(probeDb, decayApplication, "update memory_reflections");
 
       const staleCommit = reflectorStore.commitReflectionJob(jobId, {
+        leaseGeneration: claimedJob?.leaseGeneration ?? 0,
         target: scope,
         reflection: {
           action: "upsert",

--- a/packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts
+++ b/packages/core/src/store/postgres/concurrency-leases.real-postgres.test.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import { afterEach, describe, expect, it } from "vitest";
 import { PgConcurrencyLeaseStore } from "./concurrency-leases.js";
+import { PgMemoryStore } from "./memory-store.js";
 import { createPgDb, type PgDb, runPgMigrations } from "./migrate.js";
 
 const postgresUrl: string =
@@ -8,7 +9,7 @@ const postgresUrl: string =
   process.env.HELM_TEST_POSTGRES_URL ??
   (() => {
     throw new Error(
-      "real PostgreSQL lease tests require PG_TEST_URL or HELM_TEST_POSTGRES_URL; run through apps/gateway/e2e/run-with-postgres.sh",
+      "real PostgreSQL concurrency tests require PG_TEST_URL or HELM_TEST_POSTGRES_URL; run through apps/gateway/e2e/run-with-postgres.sh",
     );
   })();
 
@@ -31,7 +32,135 @@ async function db(): Promise<PgDb> {
   return connection;
 }
 
-describe("real PostgreSQL concurrency lease contract", () => {
+async function namedDb(applicationName: string): Promise<PgDb> {
+  const url = new URL(postgresUrl);
+  url.searchParams.set("application_name", applicationName);
+  const connection = await createPgDb(url.toString());
+  openDbs.push(connection);
+  return connection;
+}
+
+async function waitForBlockedQuery(
+  db: PgDb,
+  applicationName: string,
+  fragment: string,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = rowsOf(
+      await db.execute(sql`
+        SELECT query, wait_event_type
+          FROM pg_stat_activity
+         WHERE application_name = ${applicationName} AND state = 'active'
+      `),
+    ) as Array<{ query: string; wait_event_type: string | null }>;
+    if (
+      rows.some(
+        (row) => row.wait_event_type === "Lock" && row.query.toLowerCase().includes(fragment),
+      )
+    ) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for blocked query: ${fragment}`);
+}
+
+describe("real PostgreSQL concurrency contracts", () => {
+  it("prevents a stale Reflector from publishing after decay wins the job fence", async () => {
+    const suffix = crypto.randomUUID();
+    const accountId = `decay-account-${suffix}`;
+    const projectId = `decay-project-${suffix}`;
+    const threadId = `decay-thread-${suffix}`;
+    const setupDb = await db();
+    const lockDb = await db();
+    const reflectorApplication = `helm-reflector-${suffix}`;
+    const reflectorDb = await namedDb(reflectorApplication);
+    const decayApplication = `helm-decay-${suffix}`;
+    const decayDb = await namedDb(decayApplication);
+    const probeDb = await db();
+    const setupStore = new PgMemoryStore(setupDb);
+    const reflectorStore = new PgMemoryStore(reflectorDb);
+    const decayStore = new PgMemoryStore(decayDb);
+    const probeStore = new PgMemoryStore(probeDb);
+
+    await setupStore.ensureThread({ id: threadId, ownerId: accountId, projectId });
+    const observationId = await setupStore.appendObservation({
+      threadId,
+      sourceMessageRange: [`m1-${suffix}`, `m2-${suffix}`],
+      observationText: "must be forgotten",
+      observedAt: new Date(1_000),
+    });
+    const scope = { accountId, projectId };
+    const jobId = await setupStore.enqueueJob({ type: "reflector", scope });
+    expect((await setupStore.claimPendingJobs(1))[0]?.jobId).toBe(jobId);
+
+    let releaseReflectionLock!: () => void;
+    const holdReflectionLock = new Promise<void>((resolve) => {
+      releaseReflectionLock = resolve;
+    });
+    let reflectionLocked!: () => void;
+    const reflectionLockReady = new Promise<void>((resolve) => {
+      reflectionLocked = resolve;
+    });
+    const blocker = lockDb.transaction(async (tx) => {
+      await tx.execute(sql.raw("LOCK TABLE memory_reflections IN ACCESS EXCLUSIVE MODE"));
+      reflectionLocked();
+      await holdReflectionLock;
+    });
+
+    try {
+      await reflectionLockReady;
+      const decay = decayStore.archiveObservations({
+        accountId,
+        ids: [observationId],
+        now: new Date(3_000),
+      });
+      await waitForBlockedQuery(probeDb, decayApplication, "update memory_reflections");
+
+      const staleCommit = reflectorStore.commitReflectionJob(jobId, {
+        target: scope,
+        reflection: {
+          action: "upsert",
+          reflectionText: "stale reflection",
+          version: 1,
+          tokenEstimate: 4,
+          updatedAt: new Date(2_000),
+        },
+        facts: [
+          {
+            ownerId: accountId,
+            projectId,
+            subjectKey: "stale",
+            factText: "stale fact",
+            contentHash: suffix.replaceAll("-", "").padEnd(64, "a"),
+            validFrom: new Date(1_000),
+          },
+        ],
+        now: new Date(2_000),
+      });
+      await waitForBlockedQuery(probeDb, reflectorApplication, "update memory_jobs");
+
+      releaseReflectionLock();
+      await blocker;
+      await decay;
+      await expect(staleCommit).resolves.toBeNull();
+
+      expect(await probeStore.getReflection(scope)).toBeNull();
+      expect(await probeStore.listActiveFacts({ accountId, projectId })).toEqual([]);
+    } finally {
+      releaseReflectionLock();
+      await blocker.catch(() => {});
+      await setupDb.execute(
+        sql`DELETE FROM memory_jobs WHERE scope_id::jsonb ->> 'accountId' = ${accountId}`,
+      );
+      await setupDb.execute(sql`DELETE FROM memory_reflections WHERE owner_id = ${accountId}`);
+      await setupDb.execute(sql`DELETE FROM memory_facts WHERE owner_id = ${accountId}`);
+      await setupDb.execute(sql`DELETE FROM memory_observations WHERE thread_id = ${threadId}`);
+      await setupDb.execute(sql`DELETE FROM memory_threads WHERE id = ${threadId}`);
+    }
+  }, 20_000);
+
   it("bases expiry on statement time after waiting for a row lock across two pools", async () => {
     const dbA = await db();
     const dbB = await db();

--- a/packages/core/src/store/postgres/keystore.test.ts
+++ b/packages/core/src/store/postgres/keystore.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { PgKeyStore } from "./keystore.js";
+import { createPgliteDb } from "./migrate.js";
+
+describe("PgKeyStore", () => {
+  it("getById performs a direct keyed lookup", async () => {
+    const store = new PgKeyStore(await createPgliteDb());
+    await store.createKey({ keyId: "k1", hash: "h1", prefix: "p1", accountId: "a", role: "user" });
+    expect((await store.getById("k1"))?.hash).toBe("h1");
+    expect(await store.getById("missing")).toBeNull();
+  });
+});

--- a/packages/core/src/store/postgres/keystore.ts
+++ b/packages/core/src/store/postgres/keystore.ts
@@ -66,6 +66,12 @@ export class PgKeyStore implements KeyStore {
     return row ? this.toRecord(row) : null;
   }
 
+  async getById(keyId: string): Promise<ApiKeyRecord | null> {
+    const rows = await this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).limit(1);
+    const row = rows[0];
+    return row ? this.toRecord(row) : null;
+  }
+
   async list(): Promise<ApiKeyRecord[]> {
     // Deterministic order: creation time, key_id as the unique tiebreaker. Without an
     // explicit ORDER BY Postgres returns rows in an unspecified order that shifts as

--- a/packages/core/src/store/postgres/memory-admin.test.ts
+++ b/packages/core/src/store/postgres/memory-admin.test.ts
@@ -63,8 +63,15 @@ describe("PgMemoryStore admin/MCP surface (docs/13)", () => {
       tokenEstimate: 1,
       updatedAt: NOW,
     });
-    const scopes = await store.listMemoryScopes({ accountId: "a" });
-    const byProject = new Map(scopes.map((s) => [s.projectId, s]));
+    const scopes = await store.listMemoryScopes({ accountId: "a", limit: 1, offset: 1 });
+    expect(scopes.total).toBe(2);
+    expect(scopes.rows).toHaveLength(1);
+    const beyond = await store.listMemoryScopes({ accountId: "a", limit: 1, offset: 5 });
+    expect(beyond).toMatchObject({ rows: [], total: 2 });
+    const countOnly = await store.listMemoryScopes({ accountId: "a", limit: 0, offset: 0 });
+    expect(countOnly).toMatchObject({ rows: [], total: 2 });
+    const allScopes = await store.listMemoryScopes({ accountId: "a", limit: 50, offset: 0 });
+    const byProject = new Map(allScopes.rows.map((s) => [s.projectId, s]));
     expect(byProject.get("p1")).toMatchObject({ factCount: 2, reflectionCount: 0 });
     expect(byProject.get("p2")).toMatchObject({ factCount: 0, reflectionCount: 1 });
     expect(byProject.get("p1")?.lastUpdated).toBeInstanceOf(Date);

--- a/packages/core/src/store/postgres/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/postgres/memory-auto-compaction.test.ts
@@ -296,3 +296,134 @@ describe("PgMemoryStore — idle-flush candidates", () => {
     await db.$close();
   });
 });
+
+describe("PgMemoryStore — atomic Observer page commit", () => {
+  it("commits observation/frontier, completes the current job, and enqueues its remainder together", async () => {
+    const { store, db, clock } = await newStore();
+    const scope = { accountId: "acct-a", threadId: "t1" };
+    await store.ensureThread({ id: scope.threadId, ownerId: scope.accountId });
+    const firstId = await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "first",
+      tokenEstimate: 1,
+    });
+    await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "remainder",
+      tokenEstimate: 1,
+    });
+    const jobId = await store.enqueueJob({ type: "observer", scope });
+    expect((await store.claimPendingJobs(1)).map((job) => job.jobId)).toEqual([jobId]);
+    const page = await store.listObserverMessagesPage({
+      ...scope,
+      limit: 1,
+      maxBytes: 1024,
+      maxTokens: 1024,
+    });
+    const message = page.messages[0];
+    if (message === undefined) throw new Error("expected Observer page");
+
+    const observationId = await store.commitObserverPage({
+      accountId: scope.accountId,
+      job: { id: jobId, scope, leaseGeneration: 1 },
+      action: "observe",
+      observation: {
+        threadId: scope.threadId,
+        sourceMessageRange: [firstId, firstId],
+        observationText: "first observed",
+        observedAt: new Date(clock() + 1),
+      },
+      expectedFrontier: page.expectedFrontier,
+      nextFrontier: { createdAtMs: message.createdAt.getTime(), id: message.id },
+      successorScope: scope,
+    });
+
+    expect(observationId).toMatchObject({ observationId: expect.any(String) });
+    expect(await store.listObservations(scope)).toHaveLength(1);
+    expect((await store.claimPendingJobs(1)).map((job) => job.scope)).toEqual([scope]);
+    await db.$close();
+  });
+
+  it("advances an already-covered page without inserting another observation", async () => {
+    const { store, db } = await newStore();
+    const scope = { accountId: "acct-a", threadId: "t1" };
+    await store.ensureThread({ id: scope.threadId, ownerId: scope.accountId });
+    await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "already covered",
+      tokenEstimate: 1,
+    });
+    const jobId = await store.enqueueJob({ type: "observer", scope });
+    await store.claimPendingJobs(1);
+    const page = await store.listObserverMessagesPage({
+      ...scope,
+      limit: 1,
+      maxBytes: 1024,
+      maxTokens: 1024,
+    });
+    const cursor = page.nextCursor;
+    if (cursor === null) throw new Error("expected Observer page cursor");
+
+    await expect(
+      store.commitObserverPage({
+        accountId: scope.accountId,
+        job: { id: jobId, scope, leaseGeneration: 1 },
+        action: "advance",
+        expectedFrontier: page.expectedFrontier,
+        nextFrontier: cursor,
+        successorScope: scope,
+      }),
+    ).resolves.toEqual({ observationId: null });
+
+    expect(await store.listObservations(scope)).toEqual([]);
+    expect(
+      (
+        await store.listObserverMessagesPage({
+          ...scope,
+          limit: 1,
+          maxBytes: 1024,
+          maxTokens: 1024,
+        })
+      ).messages,
+    ).toEqual([]);
+    expect((await store.claimPendingJobs(1)).map((job) => job.scope)).toEqual([scope]);
+    await db.$close();
+  });
+
+  it("rolls back a stale frontier/job fence without an observation or successor", async () => {
+    const { store, db } = await newStore();
+    const scope = { accountId: "acct-a", threadId: "t1" };
+    await store.ensureThread({ id: scope.threadId, ownerId: scope.accountId });
+    const messageId = await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "first",
+      tokenEstimate: 1,
+    });
+    const jobId = await store.enqueueJob({ type: "observer", scope });
+    await store.claimPendingJobs(1);
+
+    await expect(
+      store.commitObserverPage({
+        accountId: scope.accountId,
+        job: { id: jobId, scope, leaseGeneration: 1 },
+        action: "observe",
+        observation: {
+          threadId: scope.threadId,
+          sourceMessageRange: [messageId, messageId],
+          observationText: "must not persist",
+          observedAt: new Date(1),
+        },
+        expectedFrontier: { createdAtMs: 1, id: "stale" },
+        nextFrontier: { createdAtMs: 1, id: messageId },
+        successorScope: scope,
+      }),
+    ).resolves.toBeNull();
+    expect(await store.listObservations(scope)).toEqual([]);
+    expect(await store.enqueueJob({ type: "observer", scope })).toBe(jobId);
+    await db.$close();
+  });
+});

--- a/packages/core/src/store/postgres/memory-decay-concurrency.test.ts
+++ b/packages/core/src/store/postgres/memory-decay-concurrency.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { PgMemoryStore } from "./memory-store.js";
+import { createPgliteDb } from "./migrate.js";
+
+interface TraceablePgliteDb {
+  session: {
+    options: {
+      logger?: { logQuery(query: string, params: unknown[]): void };
+    };
+  };
+}
+
+// PGlite has one database session, so it cannot reproduce the two-connection
+// READ COMMITTED race. Recording the real transaction SQL still proves the
+// required serialization order: scope lock + job fence, archive, successor.
+describe("PgMemoryStore decay/Reflector serialization", () => {
+  it("locks and closes open Reflectors before archiving, then enqueues successors", async () => {
+    const db = await createPgliteDb();
+    try {
+      let seq = 0;
+      const store = new PgMemoryStore(
+        db,
+        () => `id-${++seq}`,
+        () => new Date(2_000),
+      );
+      await store.ensureThread({ id: "thread", ownerId: "account", projectId: "project" });
+      const observationId = await store.appendObservation({
+        threadId: "thread",
+        sourceMessageRange: ["m1", "m2"],
+        observationText: "forget me",
+        observedAt: new Date(1_000),
+      });
+      await store.enqueueJob({
+        type: "reflector",
+        scope: { accountId: "account", projectId: "project" },
+      });
+
+      const statements: string[] = [];
+      const traceable = db as unknown as TraceablePgliteDb;
+      traceable.session.options.logger = {
+        logQuery(query) {
+          statements.push(query.replace(/\s+/g, " ").trim().toLowerCase());
+        },
+      };
+
+      await store.archiveObservations({
+        accountId: "account",
+        ids: [observationId],
+        now: new Date(2_000),
+      });
+
+      const scopeLockAt = statements.findIndex((query) => query.includes("pg_advisory_xact_lock"));
+      const jobFenceAt = statements.findIndex(
+        (query) =>
+          query.includes("update memory_jobs") &&
+          query.includes("status = 'failed'") &&
+          query.includes("status in ('pending', 'running')"),
+      );
+      const observationArchiveAt = statements.findIndex(
+        (query) => query.includes("update memory_observations") && query.includes("archived_at"),
+      );
+      const reflectionArchiveAt = statements.findIndex(
+        (query) =>
+          query.includes("update memory_reflections") && query.includes("status = 'archived'"),
+      );
+      const successorAt = statements.findIndex(
+        (query, index) => index > jobFenceAt && query.includes("insert into memory_jobs"),
+      );
+
+      expect(scopeLockAt).toBeGreaterThanOrEqual(0);
+      expect(jobFenceAt).toBeGreaterThan(scopeLockAt);
+      expect(observationArchiveAt).toBeGreaterThan(jobFenceAt);
+      expect(reflectionArchiveAt).toBeGreaterThan(observationArchiveAt);
+      expect(successorAt).toBeGreaterThan(reflectionArchiveAt);
+    } finally {
+      await db.$close();
+    }
+  });
+});

--- a/packages/core/src/store/postgres/memory-decay-sweep.test.ts
+++ b/packages/core/src/store/postgres/memory-decay-sweep.test.ts
@@ -70,11 +70,13 @@ describe("PgMemoryStore decay sweep", () => {
       expect.arrayContaining([
         {
           jobId: expect.any(String),
+          leaseGeneration: 1,
           type: "reflector",
           scope: { accountId: "acct-a", projectId: "p-a" },
         },
         {
           jobId: expect.any(String),
+          leaseGeneration: 1,
           type: "reflector",
           scope: { accountId: "acct-a", resourceId: "r-a" },
         },

--- a/packages/core/src/store/postgres/memory-jobs.test.ts
+++ b/packages/core/src/store/postgres/memory-jobs.test.ts
@@ -187,4 +187,102 @@ describe("PgMemoryStore job queue", () => {
     expect((await store.getReflection(target))?.reflectionText).toBe("current");
     await db.$close();
   });
+
+  it("fences stale decay, embedding, and eager-fact publication after reclaim", async () => {
+    let nowMs = 1_000_000;
+    const db = await createPgliteDb();
+    const store = new PgMemoryStore(db, undefined, () => new Date(nowMs));
+    await store.ensureThread({ id: "t1", ownerId: "acct-a" });
+    const observationId = await store.appendObservation({
+      threadId: "t1",
+      sourceMessageRange: ["m1", "m1"],
+      observationText: "keep me",
+      observedAt: new Date(nowMs),
+    });
+
+    const staleLease = async (type: "decay" | "embedding" | "observer") => {
+      const jobId = await store.enqueueJob({
+        type,
+        scope: { accountId: "acct-a", ...(type === "observer" ? { threadId: "t1" } : {}) },
+      });
+      const first = (await store.claimPendingJobs(1))[0];
+      nowMs += 11 * 60_000;
+      await store.claimPendingJobs(10);
+      return { id: jobId, leaseGeneration: first?.leaseGeneration ?? 0 };
+    };
+
+    const decay = await staleLease("decay");
+    expect(
+      await store.archiveObservations({
+        accountId: "acct-a",
+        ids: [observationId],
+        now: new Date(nowMs),
+        job: decay,
+      }),
+    ).toBe(false);
+    expect(await store.listScorableObservations({ accountId: "acct-a" })).toHaveLength(1);
+
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      facts: [
+        {
+          ownerId: "acct-a",
+          subjectKey: "existing",
+          factText: "existing fact",
+          contentHash: "existing-hash",
+          validFrom: new Date(nowMs),
+        },
+      ],
+      now: new Date(nowMs),
+    });
+    const existing = (await store.listActiveFacts({ accountId: "acct-a" }))[0];
+    if (existing === undefined) throw new Error("expected existing fact");
+    const embedding = await staleLease("embedding");
+    expect(
+      await store.setFactEmbeddings({
+        accountId: "acct-a",
+        items: [
+          {
+            factId: existing.id,
+            embedding: new Float32Array([1, 0]),
+            model: "test",
+            dim: 2,
+          },
+        ],
+        job: embedding,
+      }),
+    ).toBe(false);
+    expect(
+      await store.listFactsNeedingEmbedding({
+        accountId: "acct-a",
+        model: "test",
+        dim: 2,
+        limit: 10,
+      }),
+    ).toHaveLength(1);
+
+    const observer = await staleLease("observer");
+    const reconciled = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: { threadId: "t1" },
+      facts: [
+        {
+          ownerId: "acct-a",
+          threadId: "t1",
+          subjectKey: "stale",
+          factText: "stale fact",
+          contentHash: "stale-hash",
+          validFrom: new Date(nowMs),
+        },
+      ],
+      now: new Date(nowMs),
+      job: observer,
+    });
+    expect(reconciled.accepted).toBe(false);
+    expect(
+      (await store.listActiveFacts({ accountId: "acct-a" })).map((fact) => fact.factText),
+    ).toEqual(["existing fact"]);
+    await db.$close();
+  });
 });

--- a/packages/core/src/store/postgres/memory-jobs.test.ts
+++ b/packages/core/src/store/postgres/memory-jobs.test.ts
@@ -62,6 +62,7 @@ describe("PgMemoryStore job queue", () => {
     expect(claimed).toEqual([
       {
         jobId: id,
+        leaseGeneration: 1,
         type: "reflector",
         scope: { accountId: "acct-a", projectId: "p1", threadId: "t1" },
       },
@@ -123,9 +124,67 @@ describe("PgMemoryStore job queue", () => {
     const reclaimed = await store.claimPendingJobs(10);
     expect(reclaimed).toHaveLength(1);
     expect(reclaimed[0]?.jobId).toBe(first[0]?.jobId);
+    expect(reclaimed[0]?.leaseGeneration).toBe((first[0]?.leaseGeneration ?? 0) + 1);
+
+    await store.updateJobStatus(
+      first[0]?.jobId ?? "",
+      "failed",
+      "stale owner",
+      first[0]?.leaseGeneration,
+    );
+    const statusRows = await db.execute(
+      sql`SELECT status FROM memory_jobs WHERE id = ${first[0]?.jobId ?? ""}`,
+    );
+    expect((statusRows as { rows?: Array<{ status: string }> }).rows?.[0]?.status).toBe("running");
 
     nowMs += 60_000;
     expect(await store.claimPendingJobs(10)).toEqual([]);
+    await db.$close();
+  });
+
+  it("fences stale atomic reflector publication after reclaim", async () => {
+    let nowMs = 1_000_000;
+    const db = await createPgliteDb();
+    const store = new PgMemoryStore(db, undefined, () => new Date(nowMs));
+    const target = { accountId: "acct-a", projectId: "p1" };
+    const jobId = await store.enqueueJob({ type: "reflector", scope: target });
+    const first = (await store.claimPendingJobs(1))[0];
+    nowMs += 11 * 60_000;
+    const reclaimed = (await store.claimPendingJobs(1))[0];
+
+    expect(
+      await store.commitReflectionJob(jobId, {
+        leaseGeneration: first?.leaseGeneration ?? 0,
+        target,
+        reflection: {
+          action: "upsert",
+          reflectionText: "stale",
+          version: 1,
+          tokenEstimate: 1,
+          updatedAt: new Date(nowMs),
+        },
+        facts: [],
+        now: new Date(nowMs),
+      }),
+    ).toBeNull();
+    expect(await store.getReflection(target)).toBeNull();
+
+    expect(
+      await store.commitReflectionJob(jobId, {
+        leaseGeneration: reclaimed?.leaseGeneration ?? 0,
+        target,
+        reflection: {
+          action: "upsert",
+          reflectionText: "current",
+          version: 1,
+          tokenEstimate: 1,
+          updatedAt: new Date(nowMs),
+        },
+        facts: [],
+        now: new Date(nowMs),
+      }),
+    ).not.toBeNull();
+    expect((await store.getReflection(target))?.reflectionText).toBe("current");
     await db.$close();
   });
 });

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -996,6 +996,7 @@ export class PgMemoryStore implements MemoryStore {
              AND type = 'reflector'
              AND scope_id = ${scopeId}
              AND status = 'running'
+             AND lease_generation = ${input.leaseGeneration}
           RETURNING id
         `),
       );
@@ -1046,7 +1047,12 @@ export class PgMemoryStore implements MemoryStore {
     });
   }
 
-  async updateJobStatus(jobId: string, status: MemoryJobStatus, error?: string): Promise<void> {
+  async updateJobStatus(
+    jobId: string,
+    status: MemoryJobStatus,
+    error?: string,
+    leaseGeneration?: number,
+  ): Promise<void> {
     await this.db
       .update(memoryJobs)
       .set({
@@ -1054,7 +1060,15 @@ export class PgMemoryStore implements MemoryStore {
         error: error ?? null,
         updatedAt: this.now().getTime(),
       })
-      .where(eq(memoryJobs.id, jobId));
+      .where(
+        leaseGeneration === undefined
+          ? eq(memoryJobs.id, jobId)
+          : and(
+              eq(memoryJobs.id, jobId),
+              eq(memoryJobs.status, "running"),
+              eq(memoryJobs.leaseGeneration, leaseGeneration),
+            ),
+      );
   }
 
   // Enqueue a background job. DEDUPE (D6): the partial unique index on OPEN
@@ -1115,7 +1129,8 @@ export class PgMemoryStore implements MemoryStore {
     const staleBefore = updatedAt - RUNNING_LEASE_MS;
     const result = (await this.db.execute(sql`
       UPDATE memory_jobs
-         SET status = 'running', updated_at = ${updatedAt}
+         SET status = 'running', updated_at = ${updatedAt},
+             lease_generation = lease_generation + 1
        WHERE id IN (
          SELECT id FROM memory_jobs
           WHERE status = 'pending'
@@ -1124,17 +1139,26 @@ export class PgMemoryStore implements MemoryStore {
           LIMIT ${limit}
           FOR UPDATE SKIP LOCKED
        )
-      RETURNING id, type, scope_id
+      RETURNING id, type, scope_id, lease_generation
     `)) as
-      | { rows?: Array<{ id: string; type: string; scope_id: string }> }
+      | {
+          rows?: Array<{
+            id: string;
+            type: string;
+            scope_id: string;
+            lease_generation: number;
+          }>;
+        }
       | Array<{
           id: string;
           type: string;
           scope_id: string;
+          lease_generation: number;
         }>;
     const rows = Array.isArray(result) ? result : (result.rows ?? []);
     return rows.map((row) => ({
       jobId: row.id,
+      leaseGeneration: Number(row.lease_generation),
       type: row.type as MemoryJobRow["type"],
       scope: decodeScopeId(row.scope_id),
     }));

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -582,6 +582,38 @@ export class PgMemoryStore implements MemoryStore {
       if (oversized) break;
     }
     const safeIds = selected.filter((row) => !row.oversized).map((row) => row.id);
+    const selectedIds = selected.map((row) => row.id);
+    const coveredMessageIds =
+      selectedIds.length === 0
+        ? []
+        : pgRows<{ id: string }>(
+            await this.db.execute(sql`
+              SELECT m.id
+                FROM memory_messages m
+               WHERE m.id IN (${sql.join(
+                 selectedIds.map((id) => sql`${id}`),
+                 sql`, `,
+               )})
+                 AND EXISTS (
+                   SELECT 1
+                     FROM memory_observations o
+                     JOIN memory_messages first_message
+                       ON first_message.id = o.source_message_range ->> 0
+                      AND first_message.thread_id = o.thread_id
+                     JOIN memory_messages last_message
+                       ON last_message.id = o.source_message_range ->> 1
+                      AND last_message.thread_id = o.thread_id
+                    WHERE o.thread_id = m.thread_id
+                      AND (
+                        ((first_message.created_at, first_message.id) <= (m.created_at, m.id)
+                         AND (m.created_at, m.id) <= (last_message.created_at, last_message.id))
+                        OR
+                        ((last_message.created_at, last_message.id) <= (m.created_at, m.id)
+                         AND (m.created_at, m.id) <= (first_message.created_at, first_message.id))
+                      )
+                 )
+            `),
+          ).map((row) => row.id);
     const contentRows =
       safeIds.length === 0
         ? []
@@ -604,6 +636,7 @@ export class PgMemoryStore implements MemoryStore {
     const nextCursor = last === undefined ? null : { createdAtMs: last.createdAt, id: last.id };
     return {
       messages,
+      coveredMessageIds,
       expectedFrontier,
       nextCursor,
       hasMore: selected.length < rows.length,
@@ -2486,7 +2519,8 @@ export class PgMemoryStore implements MemoryStore {
          WHERE t.owner_id IS NOT NULL
            AND t.last_message_at <= ${input.idleBeforeMs}
            AND (${idleAfterMs}::bigint IS NULL OR
-                t.last_message_at >= ${idleAfterMs})
+                t.last_message_at >= ${idleAfterMs} OR
+                t.observer_frontier_at IS NULL)
            AND EXISTS (
              SELECT 1 FROM memory_messages m
               WHERE m.thread_id = t.id

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -1098,6 +1098,23 @@ export class PgMemoryStore implements MemoryStore {
     return rows[0]?.version ?? 0;
   }
 
+  private async hasCurrentJobLease(
+    tx: { execute: (query: SQL) => Promise<unknown> },
+    job: { id: string; leaseGeneration: number },
+  ): Promise<boolean> {
+    return (
+      pgRows<{ id: string }>(
+        await tx.execute(sql`
+          SELECT id FROM memory_jobs
+           WHERE id = ${job.id}
+             AND status = 'running'
+             AND lease_generation = ${job.leaseGeneration}
+           FOR UPDATE
+        `),
+      )[0] !== undefined
+    );
+  }
+
   async commitReflectionJob(
     jobId: string,
     input: MemoryReflectionJobCommitInput,
@@ -1445,16 +1462,21 @@ export class PgMemoryStore implements MemoryStore {
   async setFactEmbeddings(input: {
     accountId: string;
     items: Array<{ factId: string; embedding: Float32Array; model: string; dim: number }>;
-  }): Promise<void> {
-    if (input.items.length === 0) return;
-    for (const it of input.items) {
-      const vecLiteral = `[${Array.from(it.embedding).join(",")}]`;
-      await this.db.execute(sql`
-        UPDATE memory_facts
-           SET embedding = ${vecLiteral}::vector, embedding_model = ${it.model}, embedding_dim = ${it.dim}
-         WHERE id = ${it.factId} AND owner_id = ${input.accountId}
-      `);
-    }
+    job?: { id: string; leaseGeneration: number };
+  }): Promise<boolean> {
+    if (input.items.length === 0) return true;
+    return this.db.transaction(async (tx) => {
+      if (input.job !== undefined && !(await this.hasCurrentJobLease(tx, input.job))) return false;
+      for (const it of input.items) {
+        const vecLiteral = `[${Array.from(it.embedding).join(",")}]`;
+        await tx.execute(sql`
+          UPDATE memory_facts
+             SET embedding = ${vecLiteral}::vector, embedding_model = ${it.model}, embedding_dim = ${it.dim}
+           WHERE id = ${it.factId} AND owner_id = ${input.accountId}
+        `);
+      }
+      return true;
+    });
   }
 
   // docs/14 — embedding job READ half (pg). ACTIVE facts with no embedding, one from a
@@ -1558,14 +1580,20 @@ export class PgMemoryStore implements MemoryStore {
   // observations (status='archived', archived_at=now) — NEVER a DELETE. ACCOUNT-GUARDED
   // via the thread's owner_id; empty id list → no statement; touches ONLY the
   // observation status/archived_at, never raw messages nor other accounts' rows.
-  async archiveObservations(input: { accountId: string; ids: string[]; now: Date }): Promise<void> {
-    if (input.ids.length === 0) return;
+  async archiveObservations(input: {
+    accountId: string;
+    ids: string[];
+    now: Date;
+    job?: { id: string; leaseGeneration: number };
+  }): Promise<boolean> {
+    if (input.ids.length === 0) return true;
     const nowMs = input.now.getTime();
     const ids = sql.join(
       input.ids.map((id) => sql`${id}`),
       sql`, `,
     );
-    await this.db.transaction(async (tx) => {
+    return this.db.transaction(async (tx) => {
+      if (input.job !== undefined && !(await this.hasCurrentJobLease(tx, input.job))) return false;
       const rows = pgRows<{
         project_id: string | null;
         resource_id: string | null;
@@ -1636,6 +1664,7 @@ export class PgMemoryStore implements MemoryStore {
           ON CONFLICT (type, scope_id) WHERE status IN ('pending', 'running') DO NOTHING
         `);
       }
+      return true;
     });
   }
 
@@ -1711,6 +1740,7 @@ export class PgMemoryStore implements MemoryStore {
     scope: { projectId?: string; resourceId?: string; threadId?: string };
     facts: MemoryFactInput[];
     now: Date;
+    job?: { id: string; leaseGeneration: number };
   }): Promise<MemoryFactReconcileResult> {
     // docs/12 P6 (Codex review fix #3) — insert + supersede must be ATOMIC. The pg
     // adapter previously ran them as two un-wrapped statements: a crash AFTER the
@@ -1733,10 +1763,14 @@ export class PgMemoryStore implements MemoryStore {
       scope: { projectId?: string; resourceId?: string; threadId?: string };
       facts: MemoryFactInput[];
       now: Date;
+      job?: { id: string; leaseGeneration: number };
     },
   ): Promise<MemoryFactReconcileResult> {
     if (input.facts.length === 0) {
       return { insertedIds: [], supersededIds: [], resurrectedIds: [] };
+    }
+    if (input.job !== undefined && !(await this.hasCurrentJobLease(tx, input.job))) {
+      return { insertedIds: [], supersededIds: [], resurrectedIds: [], accepted: false };
     }
     const nowMs = input.now.getTime();
     const insertedIds: string[] = [];

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -48,6 +48,8 @@ import {
   type MemoryMessageArchiveRow,
   type MemoryObserverCursor,
   type MemoryObserverPage,
+  type MemoryObserverPageCommitInput,
+  type MemoryObserverPageCommitResult,
   type MemoryReflectionJobCommitInput,
   type MemoryReflectionJobCommitResult,
   type MemoryStore,
@@ -728,6 +730,120 @@ export class PgMemoryStore implements MemoryStore {
           : {}),
       });
       return id;
+    });
+  }
+
+  async commitObserverPage(
+    input: MemoryObserverPageCommitInput,
+  ): Promise<MemoryObserverPageCommitResult | null> {
+    const threadId =
+      input.action === "observe" ? input.observation.threadId : input.job.scope.threadId;
+    if (
+      threadId === undefined ||
+      input.job.scope.accountId !== input.accountId ||
+      input.job.scope.threadId !== threadId ||
+      (input.successorScope !== undefined &&
+        (input.successorScope.accountId !== input.accountId ||
+          input.successorScope.threadId !== threadId))
+    ) {
+      return null;
+    }
+    const id = input.action === "observe" ? this.genId() : null;
+    const successorId = input.successorScope === undefined ? null : this.genId();
+    const jobScopeId = encodeScopeId(input.job.scope);
+    const successorScopeId =
+      input.successorScope === undefined ? null : encodeScopeId(input.successorScope);
+    const observedAt = input.action === "observe" ? input.observation.observedAt.getTime() : null;
+    return this.db.transaction(async (tx) => {
+      const currentJob = await tx
+        .select({ id: memoryJobs.id })
+        .from(memoryJobs)
+        .where(
+          and(
+            eq(memoryJobs.id, input.job.id),
+            eq(memoryJobs.type, "observer"),
+            eq(memoryJobs.scopeId, jobScopeId),
+            eq(memoryJobs.status, "running"),
+            eq(memoryJobs.leaseGeneration, input.job.leaseGeneration),
+          ),
+        )
+        .for("update");
+      if (currentJob.length === 0) return null;
+      const expected = input.expectedFrontier;
+      const update =
+        input.action === "observe"
+          ? {
+              observerFrontierAt: input.nextFrontier.createdAtMs,
+              observerFrontierId: input.nextFrontier.id,
+              observationCount: sql`${memoryThreads.observationCount} + 1`,
+              lastObservationAt: sql`CASE
+                WHEN ${memoryThreads.lastObservationAt} IS NULL OR ${memoryThreads.lastObservationAt} < ${observedAt}
+                  THEN ${observedAt}
+                ELSE ${memoryThreads.lastObservationAt}
+              END`,
+            }
+          : {
+              observerFrontierAt: input.nextFrontier.createdAtMs,
+              observerFrontierId: input.nextFrontier.id,
+            };
+      const updated = await tx
+        .update(memoryThreads)
+        .set(update)
+        .where(
+          and(
+            eq(memoryThreads.id, threadId),
+            eq(memoryThreads.ownerId, input.accountId),
+            expected === null
+              ? and(
+                  isNull(memoryThreads.observerFrontierAt),
+                  isNull(memoryThreads.observerFrontierId),
+                )
+              : and(
+                  eq(memoryThreads.observerFrontierAt, expected.createdAtMs),
+                  eq(memoryThreads.observerFrontierId, expected.id),
+                ),
+          ),
+        )
+        .returning();
+      if (updated.length === 0) return null;
+      if (input.action === "observe" && id !== null && observedAt !== null) {
+        await tx.insert(memoryObservations).values({
+          id,
+          threadId,
+          sourceMessageRange: input.observation.sourceMessageRange,
+          observationText: input.observation.observationText,
+          observedAt,
+          referencedAt: null,
+          priority: input.observation.priority ?? null,
+          tags: input.observation.tags ?? null,
+          ...(input.observation.importance !== undefined
+            ? { importance: input.observation.importance }
+            : {}),
+        });
+      }
+      const completed = await tx
+        .update(memoryJobs)
+        .set({ status: "done", error: null, updatedAt: this.now().getTime() })
+        .where(
+          and(
+            eq(memoryJobs.id, input.job.id),
+            eq(memoryJobs.type, "observer"),
+            eq(memoryJobs.scopeId, jobScopeId),
+            eq(memoryJobs.status, "running"),
+            eq(memoryJobs.leaseGeneration, input.job.leaseGeneration),
+          ),
+        )
+        .returning();
+      if (completed.length !== 1) throw new Error("observer job fence changed during commit");
+      if (successorId !== null && successorScopeId !== null) {
+        const ts = this.now().getTime();
+        await tx.execute(sql`
+          INSERT INTO memory_jobs (id, type, scope_id, status, error, created_at, updated_at)
+          VALUES (${successorId}, 'observer', ${successorScopeId}, 'pending', NULL, ${ts}, ${ts})
+          ON CONFLICT (type, scope_id) WHERE status IN ('pending', 'running') DO NOTHING
+        `);
+      }
+      return { observationId: id };
     });
   }
 

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -84,6 +84,7 @@ function reflectionScopeWhere(scope: ReflectionScope): SQL {
 // How long a claimed (`running`) job stays exclusively leased — pg mirror of the
 // sqlite adapter's constant (same contract, see its comment).
 const RUNNING_LEASE_MS = 5 * 60_000;
+const REFLECTOR_JOB_LOCK_SEED = 740;
 
 function dateOrNull(ms: number | string | null | undefined): Date | null {
   return ms === null || ms === undefined ? null : new Date(Number(ms));
@@ -1026,31 +1027,44 @@ export class PgMemoryStore implements MemoryStore {
   // Enqueue a background job. DEDUPE (D6): the partial unique index on OPEN
   // (pending/running) jobs owns the concurrency boundary; this method tries the
   // insert first, then reads the existing open row when another request won.
+  // Reflectors also share a scope advisory lock with decay so no new open row can
+  // slip between decay's fence and successor enqueue.
   async enqueueJob(input: MemoryJobEnqueueInput): Promise<string> {
     const scopeId = encodeScopeId(input.scope);
     const id = this.genId();
     const ts = this.now().getTime();
-    const inserted = (await this.db.execute(sql`
-      INSERT INTO memory_jobs (id, type, scope_id, status, error, created_at, updated_at)
-      VALUES (${id}, ${input.type}, ${scopeId}, 'pending', NULL, ${ts}, ${ts})
-      ON CONFLICT (type, scope_id) WHERE status IN ('pending', 'running') DO NOTHING
-      RETURNING id
-    `)) as { rows?: Array<{ id: string }> } | Array<{ id: string }>;
-    const insertedRows = Array.isArray(inserted) ? inserted : (inserted.rows ?? []);
-    if (insertedRows[0] !== undefined) return insertedRows[0].id;
+    const enqueue = async (executor: { execute: (query: SQL) => Promise<unknown> }) => {
+      const insertedRows = pgRows<{ id: string }>(
+        await executor.execute(sql`
+          INSERT INTO memory_jobs (id, type, scope_id, status, error, created_at, updated_at)
+          VALUES (${id}, ${input.type}, ${scopeId}, 'pending', NULL, ${ts}, ${ts})
+          ON CONFLICT (type, scope_id) WHERE status IN ('pending', 'running') DO NOTHING
+          RETURNING id
+        `),
+      );
+      if (insertedRows[0] !== undefined) return insertedRows[0].id;
 
-    const existing = (await this.db.execute(sql`
-      SELECT id FROM memory_jobs
-       WHERE type = ${input.type}
-         AND scope_id = ${scopeId}
-         AND status IN ('pending', 'running')
-       ORDER BY created_at ASC, id ASC
-       LIMIT 1
-    `)) as { rows?: Array<{ id: string }> } | Array<{ id: string }>;
-    const existingRows = Array.isArray(existing) ? existing : (existing.rows ?? []);
-    if (existingRows[0] !== undefined) return existingRows[0].id;
+      const existingRows = pgRows<{ id: string }>(
+        await executor.execute(sql`
+          SELECT id FROM memory_jobs
+           WHERE type = ${input.type}
+             AND scope_id = ${scopeId}
+             AND status IN ('pending', 'running')
+           ORDER BY created_at ASC, id ASC
+           LIMIT 1
+        `),
+      );
+      if (existingRows[0] !== undefined) return existingRows[0].id;
+      throw new Error("memory job enqueue conflict without existing open row");
+    };
 
-    throw new Error("memory job enqueue conflict without existing open row");
+    if (input.type !== "reflector") return enqueue(this.db);
+    return this.db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtextextended(${scopeId}, ${REFLECTOR_JOB_LOCK_SEED}))`,
+      );
+      return enqueue({ execute: (query) => tx.execute(query) });
+    });
   }
 
   // Atomically claim up to `limit` open jobs (oldest-first). Postgres uses
@@ -1392,15 +1406,6 @@ export class PgMemoryStore implements MemoryStore {
              AND o.status = 'active' AND t.owner_id = ${input.accountId}
         `),
       );
-      await tx.execute(sql`
-        UPDATE memory_observations
-           SET status = 'archived', archived_at = ${nowMs}
-         WHERE id IN (${ids})
-           AND status = 'active'
-           AND thread_id IN (
-             SELECT id FROM memory_threads WHERE owner_id = ${input.accountId}
-           )
-      `);
       const scopes = new Map<string, ReflectionScope>();
       for (const row of rows) {
         const targets: ReflectionScope[] = [];
@@ -1415,6 +1420,33 @@ export class PgMemoryStore implements MemoryStore {
         }
         for (const target of targets) scopes.set(encodeScopeId(target), target);
       }
+      const scopeIds = [...scopes.keys()].sort();
+      // Serialize enqueue + publication around each affected scope. Close every
+      // old open execution before hiding its inputs, then publish successors only
+      // after observations and reflections have been archived in this transaction.
+      for (const scopeId of scopeIds) {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtextextended(${scopeId}, ${REFLECTOR_JOB_LOCK_SEED}))`,
+        );
+      }
+      for (const scopeId of scopeIds) {
+        await tx.execute(sql`
+          UPDATE memory_jobs
+             SET status = 'failed', error = 'superseded by observation archive', updated_at = ${nowMs}
+           WHERE type = 'reflector'
+             AND scope_id = ${scopeId}
+             AND status IN ('pending', 'running')
+        `);
+      }
+      await tx.execute(sql`
+        UPDATE memory_observations
+           SET status = 'archived', archived_at = ${nowMs}
+         WHERE id IN (${ids})
+           AND status = 'active'
+           AND thread_id IN (
+             SELECT id FROM memory_threads WHERE owner_id = ${input.accountId}
+           )
+      `);
       for (const [scopeId, target] of scopes) {
         await tx.execute(sql`
           UPDATE memory_reflections
@@ -1424,11 +1456,6 @@ export class PgMemoryStore implements MemoryStore {
              AND resource_id IS NOT DISTINCT FROM ${target.resourceId ?? null}
              AND thread_id IS NOT DISTINCT FROM ${target.threadId ?? null}
              AND status = 'active'
-        `);
-        await tx.execute(sql`
-          UPDATE memory_jobs
-             SET status = 'failed', error = 'superseded by observation archive', updated_at = ${nowMs}
-           WHERE type = 'reflector' AND scope_id = ${scopeId} AND status = 'running'
         `);
         await tx.execute(sql`
           INSERT INTO memory_jobs (id, type, scope_id, status, error, created_at, updated_at)

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -1999,13 +1999,17 @@ export class PgMemoryStore implements MemoryStore {
 
   // Admin "By Scope" view. facts ⊎ reflections via a UNION of grouped subqueries
   // (kept for dialect parity with sqlite); reflections guarded owner_id IS NOT NULL.
-  async listMemoryScopes(input: { accountId?: string }): Promise<MemoryScopeSummary[]> {
+  async listMemoryScopes(input: {
+    accountId?: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ rows: MemoryScopeSummary[]; total: number }> {
     const acct = input.accountId ?? null;
-    const result = (await this.db.execute(sql`
+    const aggregate = sql`
       SELECT owner_id AS "accountId", project_id AS "projectId", resource_id AS "resourceId",
              thread_id AS "threadId",
              SUM(fc)::bigint AS "factCount", SUM(rc)::bigint AS "reflectionCount",
-             MAX(lu)::bigint AS "lastUpdated"
+             MAX(lu)::bigint AS "lastUpdated", COUNT(*) OVER()::bigint AS total
         FROM (
           SELECT owner_id, project_id, resource_id, thread_id,
                  COUNT(*) AS fc, 0 AS rc, MAX(updated_at) AS lu
@@ -2020,20 +2024,44 @@ export class PgMemoryStore implements MemoryStore {
            WHERE status = 'active' AND owner_id IS NOT NULL
              AND (${acct}::text IS NULL OR owner_id = ${acct})
            GROUP BY owner_id, project_id, resource_id, thread_id
-        ) g
+       ) g
        GROUP BY owner_id, project_id, resource_id, thread_id
-       ORDER BY "lastUpdated" DESC
-    `)) as { rows?: ScopeAggRow[] } | ScopeAggRow[];
+    `;
+    const result = (await this.db.execute(sql`
+      ${aggregate}
+      ORDER BY MAX(lu) DESC, owner_id ASC,
+               CASE WHEN project_id IS NULL THEN 0 ELSE 1 END, project_id ASC,
+               CASE WHEN resource_id IS NULL THEN 0 ELSE 1 END, resource_id ASC,
+               CASE WHEN thread_id IS NULL THEN 0 ELSE 1 END, thread_id ASC
+      LIMIT ${input.limit} OFFSET ${input.offset}
+    `)) as
+      | { rows?: Array<ScopeAggRow & { total: number | string }> }
+      | Array<ScopeAggRow & { total: number | string }>;
     const rows = Array.isArray(result) ? result : (result.rows ?? []);
-    return rows.map((r) => ({
-      accountId: r.accountId,
-      projectId: r.projectId,
-      resourceId: r.resourceId,
-      threadId: r.threadId,
-      factCount: Number(r.factCount),
-      reflectionCount: Number(r.reflectionCount),
-      lastUpdated: r.lastUpdated !== null ? new Date(Number(r.lastUpdated)) : null,
-    }));
+    const total =
+      rows[0] !== undefined
+        ? Number(rows[0].total)
+        : input.offset === 0 && input.limit > 0
+          ? 0
+          : Number(
+              pgRows<{ total: number | string }>(
+                await this.db.execute(
+                  sql`SELECT COUNT(*)::bigint AS total FROM (${aggregate}) scopes`,
+                ),
+              )[0]?.total ?? 0,
+            );
+    return {
+      rows: rows.map((r) => ({
+        accountId: r.accountId,
+        projectId: r.projectId,
+        resourceId: r.resourceId,
+        threadId: r.threadId,
+        factCount: Number(r.factCount),
+        reflectionCount: Number(r.reflectionCount),
+        lastUpdated: r.lastUpdated !== null ? new Date(Number(r.lastUpdated)) : null,
+      })),
+      total,
+    };
   }
 
   async getMemoryAdminStats(

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -965,45 +965,87 @@ export class PgMemoryStore implements MemoryStore {
   async findRedundantInjectionObservations(input: {
     accountId: string;
     threadId: string;
-    observations: Array<{ id: string; sourceMessageRange: [string, string] }>;
+    candidateLimit: number;
+    maxCoverageMessages: number;
+    order: "newest" | "score";
+    score?: {
+      nowMs: number;
+      half_life_s: number;
+      importance_floor: number;
+      importance_ceil: number;
+      access_weight: number;
+    };
     windowContentHashCounts: ReadonlyMap<string, number>;
   }): Promise<ReadonlySet<string>> {
-    if (input.observations.length === 0 || input.windowContentHashCounts.size === 0)
+    const candidateLimit = Math.max(0, Math.floor(input.candidateLimit));
+    const maxCoverageMessages = Math.max(0, Math.floor(input.maxCoverageMessages));
+    if (
+      candidateLimit === 0 ||
+      maxCoverageMessages === 0 ||
+      input.windowContentHashCounts.size === 0
+    ) {
       return new Set();
-    const requested = JSON.stringify(
-      input.observations.map(({ id, sourceMessageRange: [startId, endId] }) => ({
-        id,
-        startId,
-        endId,
-      })),
-    );
+    }
     const live = JSON.stringify(Object.fromEntries(input.windowContentHashCounts));
+    const score = input.order === "score" ? input.score : undefined;
+    const candidateOrder =
+      score === undefined
+        ? sql`${memoryObservations.observedAt} DESC, ${memoryObservations.id} DESC`
+        : sql`power(0.5, GREATEST(0, (${score.nowMs} - COALESCE(${memoryObservations.referencedAt}, ${memoryObservations.observedAt})) / 1000.0) / ${score.half_life_s})
+              * (LEAST(GREATEST(${memoryObservations.importance}, ${score.importance_floor}), ${score.importance_ceil}) + ${score.access_weight} * ln(1 + ${memoryObservations.referenceCount})) DESC,
+              ${memoryObservations.observedAt} DESC, ${memoryObservations.id} DESC`;
     const rows = pgRows<{ id: string }>(
       await this.db.execute(sql`
-        WITH requested AS (
-          SELECT id, "startId" AS start_id, "endId" AS end_id
-            FROM jsonb_to_recordset(${requested}::jsonb) AS r(id text, "startId" text, "endId" text)
-        ), live AS (SELECT key, value::integer AS n FROM jsonb_each_text(${live}::jsonb)),
-        ordered AS (
-          SELECT id, content_hash, ROW_NUMBER() OVER (ORDER BY CASE WHEN message_index IS NULL THEN 1 ELSE 0 END, message_index, created_at, id) AS n
-            FROM memory_messages WHERE thread_id = ${input.threadId}
-        ), endpoints AS (
-          SELECT r.id, r.start_id, r.end_id, MIN(o.n) AS first_n, MAX(o.n) AS last_n,
-                 COUNT(DISTINCT o.id) AS found
-            FROM requested r LEFT JOIN ordered o ON o.id = r.start_id OR o.id = r.end_id
-           GROUP BY r.id, r.start_id, r.end_id
-        ), required AS (
-          SELECT e.id, o.content_hash, COUNT(*) AS n FROM endpoints e JOIN ordered o
-            ON o.n BETWEEN e.first_n AND e.last_n
-           WHERE e.found = CASE WHEN e.start_id = e.end_id THEN 1 ELSE 2 END
-           GROUP BY e.id, o.content_hash
+        WITH live AS (
+          SELECT key, value::integer AS n FROM jsonb_each_text(${live}::jsonb)
+        ), candidates AS MATERIALIZED (
+          SELECT ${memoryObservations.id} AS id,
+                 ${memoryObservations.sourceMessageRange} ->> 0 AS start_id,
+                 ${memoryObservations.sourceMessageRange} ->> 1 AS end_id
+            FROM ${memoryObservations}
+            JOIN ${memoryThreads}
+              ON ${memoryThreads.id} = ${memoryObservations.threadId}
+             AND ${memoryThreads.ownerId} = ${input.accountId}
+           WHERE ${memoryObservations.threadId} = ${input.threadId}
+             AND ${memoryObservations.status} = 'active'
+             AND ${memoryObservations.expiredAt} IS NULL
+           ORDER BY ${candidateOrder}
+           LIMIT ${candidateLimit}
+        ), endpoints AS MATERIALIZED (
+          SELECT c.id,
+                 CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                   THEN s.created_at ELSE e.created_at END AS first_at,
+                 CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                   THEN s.id ELSE e.id END AS first_id,
+                 CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                   THEN e.created_at ELSE s.created_at END AS last_at,
+                 CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                   THEN e.id ELSE s.id END AS last_id
+            FROM candidates c
+            JOIN memory_messages s ON s.id = c.start_id AND s.thread_id = ${input.threadId}
+            JOIN memory_messages e ON e.id = c.end_id AND e.thread_id = ${input.threadId}
+        ), bounded AS MATERIALIZED (
+          SELECT e.* FROM endpoints e
+           WHERE (
+             SELECT COUNT(*) FROM (
+               SELECT 1 FROM memory_messages m
+                WHERE m.thread_id = ${input.threadId}
+                  AND (m.created_at, m.id) >= (e.first_at, e.first_id)
+                  AND (m.created_at, m.id) <= (e.last_at, e.last_id)
+                ORDER BY m.created_at, m.id
+                LIMIT ${maxCoverageMessages + 1}
+             ) covered_limit
+           ) <= ${maxCoverageMessages}
         )
-        SELECT e.id FROM endpoints e
-         WHERE e.found = CASE WHEN e.start_id = e.end_id THEN 1 ELSE 2 END
-           AND EXISTS (SELECT 1 FROM memory_threads WHERE id = ${input.threadId} AND owner_id = ${input.accountId})
-           AND NOT EXISTS (
-             SELECT 1 FROM required r LEFT JOIN live l ON l.key = r.content_hash
-              WHERE r.id = e.id AND (r.content_hash IS NULL OR l.n IS NULL OR l.n < r.n)
+        SELECT b.id FROM bounded b
+         WHERE NOT EXISTS (
+             SELECT 1 FROM memory_messages m
+             LEFT JOIN live l ON l.key = m.content_hash
+              WHERE m.thread_id = ${input.threadId}
+                AND (m.created_at, m.id) >= (b.first_at, b.first_id)
+                AND (m.created_at, m.id) <= (b.last_at, b.last_id)
+              GROUP BY m.content_hash, l.n
+             HAVING m.content_hash IS NULL OR l.n IS NULL OR l.n < COUNT(*)
            )
       `),
     );

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -1340,3 +1340,25 @@ describe("runPgMigrations — per-migration atomicity", () => {
     await db.$close();
   });
 });
+
+describe("runPgMigrations — memory job lease generation", () => {
+  it("v49 preserves existing jobs and initializes their lease generation to zero", async () => {
+    const db = await createPgliteDb();
+    await db.execute(
+      sql.raw(`
+      INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at)
+      VALUES ('legacy', 'observer', '{"accountId":"a","threadId":"t"}', 'pending', 1, 1)
+    `),
+    );
+    await db.execute(sql.raw("ALTER TABLE memory_jobs DROP COLUMN lease_generation"));
+    await db.execute(sql.raw("DELETE FROM _migrations WHERE version = 49"));
+
+    await runPgMigrations(db);
+
+    const rows = (await db.execute(
+      sql.raw("SELECT status, lease_generation FROM memory_jobs WHERE id = 'legacy'"),
+    )) as { rows: Array<{ status: string; lease_generation: number }> };
+    expect(rows.rows).toEqual([{ status: "pending", lease_generation: 0 }]);
+    await db.$close();
+  });
+});

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1333,6 +1333,13 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Pg mirror of SQLite v50: one monotonic fencing generation per job row.
+    version: 49,
+    sql: `
+      ALTER TABLE memory_jobs ADD COLUMN IF NOT EXISTS lease_generation INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1336,9 +1336,15 @@ const MIGRATIONS: readonly Migration[] = [
   {
     // Pg mirror of SQLite v50: one monotonic fencing generation per job row.
     version: 49,
-    sql: `
-      ALTER TABLE memory_jobs ADD COLUMN IF NOT EXISTS lease_generation INTEGER NOT NULL DEFAULT 0;
-    `,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "memory_jobs", ["id"])) {
+        await db.execute(
+          sql.raw(
+            "ALTER TABLE memory_jobs ADD COLUMN IF NOT EXISTS lease_generation INTEGER NOT NULL DEFAULT 0",
+          ),
+        );
+      }
+    },
   },
 ];
 

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -344,6 +344,7 @@ export const memoryJobs = pgTable("memory_jobs", {
   type: text("type").notNull(),
   scopeId: text("scope_id").notNull(),
   status: text("status").notNull(),
+  leaseGeneration: integer("lease_generation").notNull().default(0),
   error: text("error"),
   createdAt: bigint("created_at", { mode: "number" }).notNull(),
   updatedAt: bigint("updated_at", { mode: "number" }).notNull(),

--- a/packages/core/src/store/sqlite/idle-flush-candidates.ts
+++ b/packages/core/src/store/sqlite/idle-flush-candidates.ts
@@ -34,7 +34,7 @@ const candidateSql = `WITH candidates AS (
    WHERE t.owner_id IS NOT NULL
      AND last_activity IS NOT NULL
      AND last_activity <= ?
-     AND (? IS NULL OR last_activity >= ?)
+     AND (? IS NULL OR last_activity >= ? OR t.observer_frontier_at IS NULL)
      AND EXISTS (
        SELECT 1 FROM memory_messages m
         WHERE m.thread_id = t.id

--- a/packages/core/src/store/sqlite/keystore.test.ts
+++ b/packages/core/src/store/sqlite/keystore.test.ts
@@ -136,6 +136,13 @@ describe("SqliteKeyStore", () => {
     expect(await store.getByHash("unknown")).toBeNull();
   });
 
+  it("getById performs a direct keyed lookup", async () => {
+    const store = freshStore();
+    await store.createKey({ keyId: "k1", hash: "h1", prefix: "p1", accountId: "a", role: "user" });
+    expect((await store.getById("k1"))?.hash).toBe("h1");
+    expect(await store.getById("missing")).toBeNull();
+  });
+
   it("restores boolean/array dialect on read", async () => {
     const store = freshStore();
     await store.createKey({

--- a/packages/core/src/store/sqlite/keystore.ts
+++ b/packages/core/src/store/sqlite/keystore.ts
@@ -64,6 +64,11 @@ export class SqliteKeyStore implements KeyStore {
     return row ? this.toRecord(row) : null;
   }
 
+  async getById(keyId: string): Promise<ApiKeyRecord | null> {
+    const row = this.db.select().from(apiKeys).where(eq(apiKeys.keyId, keyId)).get();
+    return row ? this.toRecord(row) : null;
+  }
+
   async list(): Promise<ApiKeyRecord[]> {
     // Deterministic order: creation time, key_id as the unique tiebreaker. Without an
     // explicit ORDER BY the engine returns rows in an unspecified order that shifts as

--- a/packages/core/src/store/sqlite/memory-admin.test.ts
+++ b/packages/core/src/store/sqlite/memory-admin.test.ts
@@ -142,8 +142,9 @@ describe("SqliteMemoryStore.listMemoryScopes (docs/13)", () => {
       updatedAt: NOW,
     });
 
-    const scopes = await store.listMemoryScopes({ accountId: "a" });
-    const byProject = new Map(scopes.map((s) => [s.projectId, s]));
+    const scopes = await store.listMemoryScopes({ accountId: "a", limit: 50, offset: 0 });
+    const byProject = new Map(scopes.rows.map((s) => [s.projectId, s]));
+    expect(scopes.total).toBe(3);
     expect(byProject.get("p1")).toMatchObject({ factCount: 2, reflectionCount: 0 });
     expect(byProject.get("p2")).toMatchObject({ factCount: 0, reflectionCount: 1 });
     expect(byProject.get("p3")).toMatchObject({ factCount: 1, reflectionCount: 1 });
@@ -153,11 +154,17 @@ describe("SqliteMemoryStore.listMemoryScopes (docs/13)", () => {
     const { store } = newStore(NOW);
     await addFact(store, { accountId: "a", projectId: "p1", factText: "fa", now: NOW });
     await addFact(store, { accountId: "b", projectId: "p1", factText: "fb", now: NOW });
-    const onlyA = await store.listMemoryScopes({ accountId: "a" });
-    expect(onlyA).toHaveLength(1);
-    expect(onlyA[0]?.accountId).toBe("a");
-    const all = await store.listMemoryScopes({});
-    expect(all.map((s) => s.accountId).sort()).toEqual(["a", "b"]);
+    const onlyA = await store.listMemoryScopes({ accountId: "a", limit: 50, offset: 0 });
+    expect(onlyA.rows).toHaveLength(1);
+    expect(onlyA.rows[0]?.accountId).toBe("a");
+    const all = await store.listMemoryScopes({ limit: 1, offset: 1 });
+    expect(all.total).toBe(2);
+    expect(all.rows).toHaveLength(1);
+    expect(all.rows[0]?.accountId).toBe("b");
+    const beyond = await store.listMemoryScopes({ limit: 1, offset: 5 });
+    expect(beyond).toMatchObject({ rows: [], total: 2 });
+    const countOnly = await store.listMemoryScopes({ limit: 0, offset: 0 });
+    expect(countOnly).toMatchObject({ rows: [], total: 2 });
   });
 });
 

--- a/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
@@ -451,3 +451,131 @@ describe("SqliteMemoryStore — idle-flush candidates", () => {
     expect(limited.map((c) => c.threadId)).toEqual(["a1", "b1"]);
   });
 });
+
+describe("SqliteMemoryStore — atomic Observer page commit", () => {
+  it("commits observation/frontier, completes the current job, and enqueues its remainder together", async () => {
+    const { store, clock } = newStore();
+    const scope = { accountId: "acct-a", threadId: "t1" };
+    await store.ensureThread({ id: scope.threadId, ownerId: scope.accountId });
+    const firstId = await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "first",
+      tokenEstimate: 1,
+    });
+    await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "remainder",
+      tokenEstimate: 1,
+    });
+    const jobId = await store.enqueueJob({ type: "observer", scope });
+    expect((await store.claimPendingJobs(1)).map((job) => job.jobId)).toEqual([jobId]);
+    const page = await store.listObserverMessagesPage({
+      ...scope,
+      limit: 1,
+      maxBytes: 1024,
+      maxTokens: 1024,
+    });
+    const message = page.messages[0];
+    if (message === undefined) throw new Error("expected Observer page");
+
+    const observationId = await store.commitObserverPage({
+      accountId: scope.accountId,
+      job: { id: jobId, scope, leaseGeneration: 1 },
+      action: "observe",
+      observation: {
+        threadId: scope.threadId,
+        sourceMessageRange: [firstId, firstId],
+        observationText: "first observed",
+        observedAt: new Date(clock() + 1),
+      },
+      expectedFrontier: page.expectedFrontier,
+      nextFrontier: { createdAtMs: message.createdAt.getTime(), id: message.id },
+      successorScope: scope,
+    });
+
+    expect(observationId).toMatchObject({ observationId: expect.any(String) });
+    expect(await store.listObservations(scope)).toHaveLength(1);
+    expect((await store.claimPendingJobs(1)).map((job) => job.scope)).toEqual([scope]);
+  });
+
+  it("advances an already-covered page without inserting another observation", async () => {
+    const { store } = newStore();
+    const scope = { accountId: "acct-a", threadId: "t1" };
+    await store.ensureThread({ id: scope.threadId, ownerId: scope.accountId });
+    await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "already covered",
+      tokenEstimate: 1,
+    });
+    const jobId = await store.enqueueJob({ type: "observer", scope });
+    await store.claimPendingJobs(1);
+    const page = await store.listObserverMessagesPage({
+      ...scope,
+      limit: 1,
+      maxBytes: 1024,
+      maxTokens: 1024,
+    });
+    const cursor = page.nextCursor;
+    if (cursor === null) throw new Error("expected Observer page cursor");
+
+    await expect(
+      store.commitObserverPage({
+        accountId: scope.accountId,
+        job: { id: jobId, scope, leaseGeneration: 1 },
+        action: "advance",
+        expectedFrontier: page.expectedFrontier,
+        nextFrontier: cursor,
+        successorScope: scope,
+      }),
+    ).resolves.toEqual({ observationId: null });
+
+    expect(await store.listObservations(scope)).toEqual([]);
+    expect(
+      (
+        await store.listObserverMessagesPage({
+          ...scope,
+          limit: 1,
+          maxBytes: 1024,
+          maxTokens: 1024,
+        })
+      ).messages,
+    ).toEqual([]);
+    expect((await store.claimPendingJobs(1)).map((job) => job.scope)).toEqual([scope]);
+  });
+
+  it("rolls back a stale frontier/job fence without an observation or successor", async () => {
+    const { store } = newStore();
+    const scope = { accountId: "acct-a", threadId: "t1" };
+    await store.ensureThread({ id: scope.threadId, ownerId: scope.accountId });
+    const messageId = await store.appendMessage({
+      threadId: scope.threadId,
+      role: "user",
+      content: "first",
+      tokenEstimate: 1,
+    });
+    const jobId = await store.enqueueJob({ type: "observer", scope });
+    await store.claimPendingJobs(1);
+
+    await expect(
+      store.commitObserverPage({
+        accountId: scope.accountId,
+        job: { id: jobId, scope, leaseGeneration: 1 },
+        action: "observe",
+        observation: {
+          threadId: scope.threadId,
+          sourceMessageRange: [messageId, messageId],
+          observationText: "must not persist",
+          observedAt: new Date(1),
+        },
+        expectedFrontier: { createdAtMs: 1, id: "stale" },
+        nextFrontier: { createdAtMs: 1, id: messageId },
+        successorScope: scope,
+      }),
+    ).resolves.toBeNull();
+    expect(await store.listObservations(scope)).toEqual([]);
+    expect(await store.enqueueJob({ type: "observer", scope })).toBe(jobId);
+  });
+});

--- a/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
+++ b/packages/core/src/store/sqlite/memory-auto-compaction.test.ts
@@ -151,7 +151,38 @@ describe("SqliteMemoryStore — idle-flush candidates", () => {
   it("returns an idle thread with uncovered messages; respects the idle cutoff", async () => {
     const { store, clock } = newStore();
     await store.ensureThread({ id: "t1", ownerId: "acct-a" });
-    await store.appendMessage({ threadId: "t1", role: "user", content: "hi", tokenEstimate: 2 });
+    const covered = await store.appendMessage({
+      threadId: "t1",
+      role: "user",
+      content: "covered prefix",
+      tokenEstimate: 2,
+    });
+    const page = await store.listObserverMessagesPage({
+      accountId: "acct-a",
+      threadId: "t1",
+      limit: 10,
+      maxBytes: 1024,
+      maxTokens: 1024,
+    });
+    const last = page.messages.at(-1);
+    if (last === undefined) throw new Error("expected Observer page");
+    await store.appendObservationAndAdvanceFrontier({
+      accountId: "acct-a",
+      observation: {
+        threadId: "t1",
+        sourceMessageRange: [covered, covered],
+        observationText: "covered",
+        observedAt: new Date(clock() + 1),
+      },
+      expectedFrontier: page.expectedFrontier,
+      nextFrontier: { createdAtMs: last.createdAt.getTime(), id: last.id },
+    });
+    await store.appendMessage({
+      threadId: "t1",
+      role: "user",
+      content: "uncovered tail",
+      tokenEstimate: 2,
+    });
 
     const afterActivity = clock() + 1;
     // Not yet idle (cutoff before the thread's last activity) → no candidates.

--- a/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
+++ b/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
@@ -171,11 +171,13 @@ describe("SqliteMemoryStore decay sweep (listScorableObservations / archiveObser
       expect.arrayContaining([
         {
           jobId: expect.any(String),
+          leaseGeneration: 1,
           type: "reflector",
           scope: { accountId: "acct-a", projectId: "p-a" },
         },
         {
           jobId: expect.any(String),
+          leaseGeneration: 1,
           type: "reflector",
           scope: { accountId: "acct-a", resourceId: "r-a" },
         },

--- a/packages/core/src/store/sqlite/memory-jobs.test.ts
+++ b/packages/core/src/store/sqlite/memory-jobs.test.ts
@@ -218,4 +218,104 @@ describe("SqliteMemoryStore job queue", () => {
     ).not.toBeNull();
     expect((await store.getReflection(target))?.reflectionText).toBe("current");
   });
+
+  it("fences stale decay, embedding, and eager-fact publication after reclaim", async () => {
+    let nowMs = 1_000_000;
+    const store = new SqliteMemoryStore(
+      createSqliteDb(":memory:"),
+      undefined,
+      () => new Date(nowMs),
+    );
+    await store.ensureThread({ id: "t1", ownerId: "acct-a" });
+    const observationId = await store.appendObservation({
+      threadId: "t1",
+      sourceMessageRange: ["m1", "m1"],
+      observationText: "keep me",
+      observedAt: new Date(nowMs),
+    });
+
+    const staleLease = async (type: "decay" | "embedding" | "observer") => {
+      const jobId = await store.enqueueJob({
+        type,
+        scope: { accountId: "acct-a", ...(type === "observer" ? { threadId: "t1" } : {}) },
+      });
+      const first = (await store.claimPendingJobs(1))[0];
+      nowMs += 11 * 60_000;
+      await store.claimPendingJobs(10);
+      return { id: jobId, leaseGeneration: first?.leaseGeneration ?? 0 };
+    };
+
+    const decay = await staleLease("decay");
+    expect(
+      await store.archiveObservations({
+        accountId: "acct-a",
+        ids: [observationId],
+        now: new Date(nowMs),
+        job: decay,
+      }),
+    ).toBe(false);
+    expect(await store.listScorableObservations({ accountId: "acct-a" })).toHaveLength(1);
+
+    await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: {},
+      facts: [
+        {
+          ownerId: "acct-a",
+          subjectKey: "existing",
+          factText: "existing fact",
+          contentHash: "existing-hash",
+          validFrom: new Date(nowMs),
+        },
+      ],
+      now: new Date(nowMs),
+    });
+    const existing = (await store.listActiveFacts({ accountId: "acct-a" }))[0];
+    if (existing === undefined) throw new Error("expected existing fact");
+    const embedding = await staleLease("embedding");
+    expect(
+      await store.setFactEmbeddings({
+        accountId: "acct-a",
+        items: [
+          {
+            factId: existing.id,
+            embedding: new Float32Array([1, 0]),
+            model: "test",
+            dim: 2,
+          },
+        ],
+        job: embedding,
+      }),
+    ).toBe(false);
+    expect(
+      await store.listFactsNeedingEmbedding({
+        accountId: "acct-a",
+        model: "test",
+        dim: 2,
+        limit: 10,
+      }),
+    ).toHaveLength(1);
+
+    const observer = await staleLease("observer");
+    const reconciled = await store.insertFactsReconciled({
+      accountId: "acct-a",
+      scope: { threadId: "t1" },
+      facts: [
+        {
+          ownerId: "acct-a",
+          threadId: "t1",
+          subjectKey: "stale",
+          factText: "stale fact",
+          contentHash: "stale-hash",
+          validFrom: new Date(nowMs),
+        },
+      ],
+      now: new Date(nowMs),
+      job: observer,
+    });
+    expect(reconciled.accepted).toBe(false);
+    expect(
+      (await store.listActiveFacts({ accountId: "acct-a" })).map((fact) => fact.factText),
+    ).toEqual(["existing fact"]);
+  });
 });

--- a/packages/core/src/store/sqlite/memory-jobs.test.ts
+++ b/packages/core/src/store/sqlite/memory-jobs.test.ts
@@ -90,6 +90,7 @@ describe("SqliteMemoryStore job queue", () => {
     expect(claimed).toEqual([
       {
         jobId: id,
+        leaseGeneration: 1,
         type: "reflector",
         scope: { accountId: "acct-a", projectId: "p1", threadId: "t1" },
       },
@@ -132,8 +133,9 @@ describe("SqliteMemoryStore job queue", () => {
     // row as reclaimable, and re-claiming must refresh the lease.
     let nowMs = 1_000_000;
     let seq = 0;
+    const db = createSqliteDb(":memory:");
     const store = new SqliteMemoryStore(
-      createSqliteDb(":memory:"),
+      db,
       () => `id-${++seq}`,
       () => new Date(nowMs),
     );
@@ -150,9 +152,70 @@ describe("SqliteMemoryStore job queue", () => {
     const reclaimed = await store.claimPendingJobs(10);
     expect(reclaimed).toHaveLength(1);
     expect(reclaimed[0]?.jobId).toBe(first[0]?.jobId);
+    expect(reclaimed[0]?.leaseGeneration).toBe((first[0]?.leaseGeneration ?? 0) + 1);
+
+    await store.updateJobStatus(
+      first[0]?.jobId ?? "",
+      "failed",
+      "stale owner",
+      first[0]?.leaseGeneration,
+    );
+    expect(
+      db.$sqlite.prepare("SELECT status FROM memory_jobs WHERE id = ?").get(first[0]?.jobId) as {
+        status: string;
+      },
+    ).toEqual({ status: "running" });
 
     // The re-claim refreshed updated_at, so the lease restarts.
     nowMs += 60_000;
     expect(await store.claimPendingJobs(10)).toEqual([]);
+  });
+
+  it("fences stale atomic reflector publication after reclaim", async () => {
+    let nowMs = 1_000_000;
+    const store = new SqliteMemoryStore(
+      createSqliteDb(":memory:"),
+      undefined,
+      () => new Date(nowMs),
+    );
+    const target = { accountId: "acct-a", projectId: "p1" };
+    const jobId = await store.enqueueJob({ type: "reflector", scope: target });
+    const first = (await store.claimPendingJobs(1))[0];
+    nowMs += 11 * 60_000;
+    const reclaimed = (await store.claimPendingJobs(1))[0];
+
+    expect(
+      await store.commitReflectionJob(jobId, {
+        leaseGeneration: first?.leaseGeneration ?? 0,
+        target,
+        reflection: {
+          action: "upsert",
+          reflectionText: "stale",
+          version: 1,
+          tokenEstimate: 1,
+          updatedAt: new Date(nowMs),
+        },
+        facts: [],
+        now: new Date(nowMs),
+      }),
+    ).toBeNull();
+    expect(await store.getReflection(target)).toBeNull();
+
+    expect(
+      await store.commitReflectionJob(jobId, {
+        leaseGeneration: reclaimed?.leaseGeneration ?? 0,
+        target,
+        reflection: {
+          action: "upsert",
+          reflectionText: "current",
+          version: 1,
+          tokenEstimate: 1,
+          updatedAt: new Date(nowMs),
+        },
+        facts: [],
+        now: new Date(nowMs),
+      }),
+    ).not.toBeNull();
+    expect((await store.getReflection(target))?.reflectionText).toBe("current");
   });
 });

--- a/packages/core/src/store/sqlite/memory-observer-drain.integration.test.ts
+++ b/packages/core/src/store/sqlite/memory-observer-drain.integration.test.ts
@@ -1,0 +1,263 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MemoryJobRow } from "@helm/shared";
+import { describe, expect, it } from "vitest";
+import type { ObserverDeps, ObserverJob } from "../../memory/observer.js";
+import { runObserverJob } from "../../memory/observer.js";
+import type { MemoryObserverCursor, MemoryObserverPage } from "../ports.js";
+import { SqliteMemoryStore } from "./memory-store.js";
+import { createSqliteDb } from "./migrate.js";
+
+const ROW_COUNT = 51_116;
+const PAGE_ROWS = 512;
+const PAGE_BYTES = 1024 * 1024;
+const PAGE_TOKENS = 64 * 1024;
+const ROW_BYTES = PAGE_BYTES / PAGE_ROWS;
+const ROW_TOKENS = PAGE_TOKENS / PAGE_ROWS;
+const RSS_DRAIN_DELTA_LIMIT = 128 * 1024 * 1024;
+const COVERED_ROWS = 20;
+
+const NULL_PRICING = {
+  modelKey: null,
+  inputPerMtok: null,
+  outputPerMtok: null,
+  cacheReadPerMtok: null,
+  cacheWritePerMtok: null,
+  maxContextTokens: null,
+};
+
+function messageId(index: number): string {
+  return `message-${String(index).padStart(6, "0")}`;
+}
+
+function compareCursor(left: MemoryObserverCursor, right: MemoryObserverCursor): number {
+  return left.createdAtMs - right.createdAtMs || left.id.localeCompare(right.id);
+}
+
+function observerJob(claimed: MemoryJobRow): ObserverJob {
+  const { accountId, threadId, projectId, resourceId } = claimed.scope;
+  if (threadId === undefined) throw new Error("claimed Observer job has no thread");
+  const lease = claimed as MemoryJobRow & { leaseGeneration?: number };
+  return {
+    jobId: claimed.jobId,
+    accountId,
+    threadId,
+    ...(projectId !== undefined ? { projectId } : {}),
+    ...(resourceId !== undefined ? { resourceId } : {}),
+    ...(lease.leaseGeneration !== undefined ? { leaseGeneration: lease.leaseGeneration } : {}),
+  } as ObserverJob;
+}
+
+function seedMessages(db: ReturnType<typeof createSqliteDb>, threadId: string): void {
+  const insert = db.$sqlite.prepare(`INSERT INTO memory_messages
+    (id, thread_id, role, content, token_estimate, created_at, message_index, content_hash)
+    VALUES (?, ?, 'user', ?, ?, ?, ?, ?)`);
+  const insertBatch = db.$sqlite.transaction((start: number, end: number) => {
+    for (let index = start; index < end; index += 1) {
+      const prefix = `${messageId(index)}:`;
+      const content = prefix + "x".repeat(ROW_BYTES - prefix.length);
+      insert.run(
+        messageId(index),
+        threadId,
+        content,
+        ROW_TOKENS,
+        index + 1,
+        index,
+        `fixture-${index}`,
+      );
+    }
+  });
+  for (let start = 0; start < ROW_COUNT; start += 1_000) {
+    insertBatch(start, Math.min(start + 1_000, ROW_COUNT));
+  }
+  db.$sqlite
+    .prepare(
+      `UPDATE memory_threads
+          SET message_count = ?, last_message_at = ?, updated_at = ?
+        WHERE id = ?`,
+    )
+    .run(ROW_COUNT, ROW_COUNT, ROW_COUNT, threadId);
+}
+
+function seedForgottenCoverage(
+  db: ReturnType<typeof createSqliteDb>,
+  threadId: string,
+): Set<string> {
+  const covered = new Set(Array.from({ length: COVERED_ROWS }, (_, index) => messageId(index)));
+  const insert = db.$sqlite.prepare(`INSERT INTO memory_observations
+    (id, thread_id, source_message_range, observation_text, observed_at,
+     referenced_at, priority, tags, reference_count, importance, status, archived_at, expired_at)
+    VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, 0, 0.5, ?, ?, NULL)`);
+  insert.run(
+    "archived-coverage",
+    threadId,
+    JSON.stringify([messageId(0), messageId(9)]),
+    "archived coverage",
+    100,
+    "archived",
+    200,
+  );
+  insert.run(
+    "pruned-coverage",
+    threadId,
+    JSON.stringify([messageId(10), messageId(19)]),
+    "[pruned]",
+    101,
+    "pruned",
+    201,
+  );
+  db.$sqlite
+    .prepare(
+      `UPDATE memory_threads SET observation_count = 2, last_observation_at = 101 WHERE id = ?`,
+    )
+    .run(threadId);
+  return covered;
+}
+
+describe("SQLite Observer production-scale drain", () => {
+  it("drains 51,116 real rows within every page/input/RSS bound and resumes a crashed claim", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-observer-drain-"));
+    const db = createSqliteDb(join(dir, "observer.db"));
+    let sequence = 0;
+    let nowMs = 10_000_000;
+    const store = new SqliteMemoryStore(
+      db,
+      () => `generated-${++sequence}`,
+      () => new Date(nowMs),
+    );
+    const scope = { accountId: "observer-drain-account", threadId: "observer-drain-thread" };
+
+    try {
+      await store.ensureThread({ id: scope.threadId, ownerId: scope.accountId });
+      seedMessages(db, scope.threadId);
+      const forgottenIds = seedForgottenCoverage(db, scope.threadId);
+      expect(
+        (db.$sqlite.prepare(`SELECT COUNT(*) AS n FROM memory_messages`).get() as { n: number }).n,
+      ).toBe(ROW_COUNT);
+
+      // Keep SQLite's own cache out of the JS-drain RSS assertion.
+      db.$sqlite.pragma("cache_size = -8192");
+      db.$sqlite.pragma("shrink_memory");
+      const rssBaseline = process.memoryUsage().rss;
+      let maxRss = rssBaseline;
+      let previousFrontier: MemoryObserverCursor | null = null;
+      let pageCount = 0;
+      let pageMessageCount = 0;
+      let summaryMessageCount = 0;
+      let maxSummaryMessages = 0;
+      let maxSummaryBytes = 0;
+      let maxSummaryTokens = 0;
+      let coveragePortSeen = false;
+
+      const readPage = store.listObserverMessagesPage.bind(store);
+      store.listObserverMessagesPage = async (input): Promise<MemoryObserverPage> => {
+        const page = await readPage(input);
+        const pageBytes = page.messages.reduce(
+          (sum, message) => sum + Buffer.byteLength(message.content, "utf8"),
+          0,
+        );
+        const pageTokens = page.messages.reduce((sum, message) => sum + message.tokenEstimate, 0);
+        expect(page.messages.length).toBeLessThanOrEqual(PAGE_ROWS);
+        expect(pageBytes).toBeLessThanOrEqual(PAGE_BYTES);
+        expect(pageTokens).toBeLessThanOrEqual(PAGE_TOKENS);
+        if (page.messages.length > 0) {
+          expect(page.expectedFrontier).toEqual(previousFrontier);
+          expect(page.nextCursor).not.toBeNull();
+          if (page.nextCursor === null) throw new Error("non-empty Observer page has no cursor");
+          if (previousFrontier !== null) {
+            expect(compareCursor(page.nextCursor, previousFrontier)).toBeGreaterThan(0);
+          }
+          previousFrontier = page.nextCursor;
+          pageCount += 1;
+          pageMessageCount += page.messages.length;
+        }
+        const coveredMessageIds = (page as MemoryObserverPage & { coveredMessageIds?: string[] })
+          .coveredMessageIds;
+        if (coveredMessageIds !== undefined) {
+          coveragePortSeen = true;
+          expect(coveredMessageIds.length).toBeLessThanOrEqual(page.messages.length);
+        }
+        maxRss = Math.max(maxRss, process.memoryUsage().rss);
+        return page;
+      };
+
+      const deps: ObserverDeps = {
+        memoryStore: store,
+        summarize: async ({ messages }) => {
+          const inputBytes = messages.reduce(
+            (sum, message) => sum + Buffer.byteLength(message.content, "utf8"),
+            0,
+          );
+          const inputTokens = messages.reduce((sum, message) => sum + message.tokenEstimate, 0);
+          expect(messages.length).toBeLessThanOrEqual(PAGE_ROWS);
+          expect(inputBytes).toBeLessThanOrEqual(PAGE_BYTES);
+          expect(inputTokens).toBeLessThanOrEqual(PAGE_TOKENS);
+          if (coveragePortSeen) {
+            expect(messages.some((message) => forgottenIds.has(message.id))).toBe(false);
+          }
+          summaryMessageCount += messages.length;
+          maxSummaryMessages = Math.max(maxSummaryMessages, messages.length);
+          maxSummaryBytes = Math.max(maxSummaryBytes, inputBytes);
+          maxSummaryTokens = Math.max(maxSummaryTokens, inputTokens);
+          maxRss = Math.max(maxRss, process.memoryUsage().rss);
+          return { observationText: `bounded page ${summaryMessageCount}` };
+        },
+        costSink: () => {},
+        resolvePricing: () => NULL_PRICING,
+        now: () => new Date(nowMs),
+        log: () => {},
+      };
+
+      const jobId = await store.enqueueJob({ type: "observer", scope });
+      expect((await store.claimPendingJobs(1))[0]?.jobId).toBe(jobId);
+      nowMs += 6 * 60_000;
+      const reclaimed = (await store.claimPendingJobs(1))[0];
+      expect(reclaimed?.jobId).toBe(jobId);
+      if (reclaimed === undefined) throw new Error("stale Observer job was not reclaimed");
+      let claimed = reclaimed;
+
+      for (;;) {
+        const result = await runObserverJob(observerJob(claimed), deps);
+        expect(result.observationId).not.toBeNull();
+        const next = await store.claimPendingJobs(1);
+        if (next.length === 0) break;
+        const nextClaimed = next[0];
+        if (nextClaimed === undefined) throw new Error("non-empty claim page has no job");
+        claimed = nextClaimed;
+        expect(claimed.type).toBe("observer");
+        expect(pageCount).toBeLessThanOrEqual(Math.ceil(ROW_COUNT / PAGE_ROWS));
+      }
+
+      const drained = await readPage({
+        ...scope,
+        limit: PAGE_ROWS,
+        maxBytes: PAGE_BYTES,
+        maxTokens: PAGE_TOKENS,
+      });
+      expect(drained.messages).toEqual([]);
+      expect(drained.expectedFrontier).toEqual(previousFrontier);
+      expect(pageMessageCount).toBe(ROW_COUNT);
+      expect(summaryMessageCount).toBe(coveragePortSeen ? ROW_COUNT - COVERED_ROWS : ROW_COUNT);
+      expect(pageCount).toBe(Math.ceil(ROW_COUNT / PAGE_ROWS));
+      expect(maxSummaryMessages).toBe(PAGE_ROWS);
+      expect(maxSummaryBytes).toBe(PAGE_BYTES);
+      expect(maxSummaryTokens).toBe(PAGE_TOKENS);
+      expect(maxRss - rssBaseline).toBeLessThan(RSS_DRAIN_DELTA_LIMIT);
+
+      const forgotten = db.$sqlite
+        .prepare(
+          `SELECT id, status, observation_text FROM memory_observations
+              WHERE id IN ('archived-coverage', 'pruned-coverage') ORDER BY id`,
+        )
+        .all() as Array<{ id: string; status: string; observation_text: string }>;
+      expect(forgotten).toEqual([
+        { id: "archived-coverage", status: "archived", observation_text: "archived coverage" },
+        { id: "pruned-coverage", status: "pruned", observation_text: "[pruned]" },
+      ]);
+    } finally {
+      db.$sqlite.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120_000);
+});

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -155,15 +155,23 @@ describe("sqlite memory schema + migrations", () => {
       content: "one turn",
       tokenEstimate: 2,
     });
+    const observationId = await store.appendObservation({
+      threadId: "t1",
+      sourceMessageRange: [messageId, messageId],
+      observationText: "one turn summary",
+      observedAt: new Date(),
+    });
 
     const redundant = await store.findRedundantInjectionObservations({
       accountId: "acct-a",
       threadId: "t1",
-      observations: [{ id: "obs-1", sourceMessageRange: [messageId, messageId] }],
+      candidateLimit: 8,
+      maxCoverageMessages: 512,
+      order: "newest",
       windowContentHashCounts: new Map([[sha256Hex("one turn"), 1]]),
     });
 
-    expect(redundant).toEqual(new Set(["obs-1"]));
+    expect(redundant).toEqual(new Set([observationId]));
     db.$sqlite.close();
   });
 

--- a/packages/core/src/store/sqlite/memory-schema.test.ts
+++ b/packages/core/src/store/sqlite/memory-schema.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { sha256Hex } from "../../memory/message-hash.js";
+import { encodePayloadText, PAYLOAD_TEXT_CHUNK_RAW_BYTES } from "../payload-codec.js";
 import { SqliteMemoryStore } from "./memory-store.js";
 import { createSqliteDb, runMigrations } from "./migrate.js";
 
@@ -209,6 +210,16 @@ describe("sqlite memory schema + migrations", () => {
     expect((await store.selectMessagesOlderThan(3_000, 10)).map((m) => m.content).sort()).toEqual(
       [content, "legacy text"].sort(),
     );
+
+    const bomb = encodePayloadText("x".repeat(PAYLOAD_TEXT_CHUNK_RAW_BYTES + 1));
+    db.$sqlite
+      .prepare("UPDATE memory_messages SET content = ? WHERE id = 'legacy-message'")
+      .run(bomb);
+    expect(
+      (await store.listMessages({ accountId: "o1", threadId: "t1" })).find(
+        (message) => message.id === "legacy-message",
+      )?.content,
+    ).toBe("");
     db.$sqlite.close();
   });
 

--- a/packages/core/src/store/sqlite/memory-schema.ts
+++ b/packages/core/src/store/sqlite/memory-schema.ts
@@ -135,6 +135,7 @@ export const memoryJobs = sqliteTable("memory_jobs", {
   type: text("type").notNull(), // 'observer' | 'reflector'
   scopeId: text("scope_id").notNull(), // thread/resource/project id
   status: text("status").notNull(), // 'pending' | 'running' | 'done' | 'failed'
+  leaseGeneration: integer("lease_generation").notNull().default(0),
   error: text("error"), // nullable
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -48,6 +48,8 @@ import {
   type MemoryMessageArchiveRow,
   type MemoryObserverCursor,
   type MemoryObserverPage,
+  type MemoryObserverPageCommitInput,
+  type MemoryObserverPageCommitResult,
   type MemoryReflectionJobCommitInput,
   type MemoryReflectionJobCommitResult,
   type MemoryStore,
@@ -715,6 +717,123 @@ export class SqliteMemoryStore implements MemoryStore {
       return true;
     })();
     return committed ? id : null;
+  }
+
+  async commitObserverPage(
+    input: MemoryObserverPageCommitInput,
+  ): Promise<MemoryObserverPageCommitResult | null> {
+    const threadId =
+      input.action === "observe" ? input.observation.threadId : input.job.scope.threadId;
+    if (
+      threadId === undefined ||
+      input.job.scope.accountId !== input.accountId ||
+      input.job.scope.threadId !== threadId ||
+      (input.successorScope !== undefined &&
+        (input.successorScope.accountId !== input.accountId ||
+          input.successorScope.threadId !== threadId))
+    ) {
+      return null;
+    }
+    const id = input.action === "observe" ? this.genId() : null;
+    const successorId = input.successorScope === undefined ? null : this.genId();
+    const jobScopeId = encodeScopeId(input.job.scope);
+    const successorScopeId =
+      input.successorScope === undefined ? null : encodeScopeId(input.successorScope);
+    const db = this.db.$sqlite;
+    const committed = db.transaction(() => {
+      const currentJob = db
+        .prepare(
+          `SELECT id FROM memory_jobs
+            WHERE id = ? AND type = 'observer' AND scope_id = ? AND status = 'running'
+              AND lease_generation = ?`,
+        )
+        .get(input.job.id, jobScopeId, input.job.leaseGeneration) as { id: string } | undefined;
+      if (currentJob === undefined) return false;
+      const current = db
+        .prepare(
+          `SELECT observer_frontier_at AS frontier_at, observer_frontier_id AS frontier_id
+             FROM memory_threads WHERE id = ? AND owner_id = ?`,
+        )
+        .get(threadId, input.accountId) as
+        | { frontier_at: number | null; frontier_id: string | null }
+        | undefined;
+      const expected = input.expectedFrontier;
+      if (
+        current === undefined ||
+        current.frontier_at !== (expected?.createdAtMs ?? null) ||
+        current.frontier_id !== (expected?.id ?? null)
+      ) {
+        return false;
+      }
+      if (input.action === "observe" && id !== null) {
+        db.prepare(
+          `INSERT INTO memory_observations (
+             id, thread_id, source_message_range, observation_text, observed_at,
+             referenced_at, priority, tags, importance
+           ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
+        ).run(
+          id,
+          threadId,
+          JSON.stringify(input.observation.sourceMessageRange),
+          input.observation.observationText,
+          input.observation.observedAt.getTime(),
+          input.observation.priority ?? null,
+          input.observation.tags === undefined ? null : JSON.stringify(input.observation.tags),
+          input.observation.importance ?? 0.5,
+        );
+        db.prepare(
+          `UPDATE memory_threads
+              SET observer_frontier_at = ?, observer_frontier_id = ?,
+                  observation_count = observation_count + 1,
+                  last_observation_at = CASE
+                    WHEN last_observation_at IS NULL OR last_observation_at < ? THEN ?
+                    ELSE last_observation_at END
+            WHERE id = ? AND owner_id = ?`,
+        ).run(
+          input.nextFrontier.createdAtMs,
+          input.nextFrontier.id,
+          input.observation.observedAt.getTime(),
+          input.observation.observedAt.getTime(),
+          threadId,
+          input.accountId,
+        );
+      } else {
+        db.prepare(
+          `UPDATE memory_threads SET observer_frontier_at = ?, observer_frontier_id = ?
+            WHERE id = ? AND owner_id = ?`,
+        ).run(input.nextFrontier.createdAtMs, input.nextFrontier.id, threadId, input.accountId);
+      }
+      const finished = db
+        .prepare(
+          `UPDATE memory_jobs SET status = 'done', error = NULL, updated_at = ?
+            WHERE id = ? AND type = 'observer' AND scope_id = ? AND status = 'running'
+              AND lease_generation = ?`,
+        )
+        .run(this.now().getTime(), input.job.id, jobScopeId, input.job.leaseGeneration);
+      if (finished.changes !== 1) throw new Error("observer job fence changed during commit");
+      if (successorId !== null && successorScopeId !== null) {
+        const ts = this.now().getTime();
+        const inserted = db
+          .prepare(
+            `INSERT OR IGNORE INTO memory_jobs
+               (id, type, scope_id, status, error, created_at, updated_at)
+             VALUES (?, 'observer', ?, 'pending', NULL, ?, ?)`,
+          )
+          .run(successorId, successorScopeId, ts, ts);
+        if (inserted.changes !== 1) {
+          const existing = db
+            .prepare(
+              `SELECT id FROM memory_jobs
+                WHERE type = 'observer' AND scope_id = ? AND status IN ('pending', 'running')
+                LIMIT 1`,
+            )
+            .get(successorScopeId) as { id: string } | undefined;
+          if (existing === undefined) throw new Error("observer successor enqueue conflict");
+        }
+      }
+      return true;
+    })();
+    return committed ? { observationId: id } : null;
   }
 
   // POST-MVP Phase 2: read a scope's active observations oldest-first. Thread

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -963,48 +963,108 @@ export class SqliteMemoryStore implements MemoryStore {
   async findRedundantInjectionObservations(input: {
     accountId: string;
     threadId: string;
-    observations: Array<{ id: string; sourceMessageRange: [string, string] }>;
+    candidateLimit: number;
+    maxCoverageMessages: number;
+    order: "newest" | "score";
+    score?: {
+      nowMs: number;
+      half_life_s: number;
+      importance_floor: number;
+      importance_ceil: number;
+      access_weight: number;
+    };
     windowContentHashCounts: ReadonlyMap<string, number>;
   }): Promise<ReadonlySet<string>> {
-    if (input.observations.length === 0 || input.windowContentHashCounts.size === 0)
+    const candidateLimit = Math.max(0, Math.floor(input.candidateLimit));
+    const maxCoverageMessages = Math.max(0, Math.floor(input.maxCoverageMessages));
+    if (
+      candidateLimit === 0 ||
+      maxCoverageMessages === 0 ||
+      input.windowContentHashCounts.size === 0
+    ) {
       return new Set();
-    const requested = JSON.stringify(
-      input.observations.map(({ id, sourceMessageRange: [startId, endId] }) => ({
-        id,
-        startId,
-        endId,
-      })),
-    );
+    }
     const live = JSON.stringify(Object.fromEntries(input.windowContentHashCounts));
+    const score = input.order === "score" ? input.score : undefined;
+    const scoreOrder =
+      score === undefined
+        ? "o.observed_at DESC, o.id DESC"
+        : `pow(0.5, max(0, (? - COALESCE(o.referenced_at, o.observed_at)) / 1000.0) / ?)
+             * (min(max(o.importance, ?), ?) + ? * ln(1 + o.reference_count)) DESC,
+           o.observed_at DESC, o.id DESC`;
+    const scoreArgs =
+      score === undefined
+        ? []
+        : [
+            score.nowMs,
+            score.half_life_s,
+            score.importance_floor,
+            score.importance_ceil,
+            score.access_weight,
+          ];
     const rows = this.db.$sqlite
       .prepare(
-        `WITH requested AS (
-           SELECT json_extract(value, '$.id') AS id, json_extract(value, '$.startId') AS start_id,
-                  json_extract(value, '$.endId') AS end_id FROM json_each(?)
-         ), live AS (SELECT key, CAST(value AS INTEGER) AS n FROM json_each(?)),
-         ordered AS (
-           SELECT id, content_hash, ROW_NUMBER() OVER (ORDER BY CASE WHEN message_index IS NULL THEN 1 ELSE 0 END, message_index, created_at, id) AS n
-             FROM memory_messages WHERE thread_id = ?
-         ), endpoints AS (
-           SELECT r.id, r.start_id, r.end_id, MIN(o.n) AS first_n, MAX(o.n) AS last_n,
-                  COUNT(DISTINCT o.id) AS found
-             FROM requested r LEFT JOIN ordered o ON o.id = r.start_id OR o.id = r.end_id
-            GROUP BY r.id, r.start_id, r.end_id
-         ), required AS (
-           SELECT e.id, o.content_hash, COUNT(*) AS n FROM endpoints e JOIN ordered o
-             ON o.n BETWEEN e.first_n AND e.last_n
-            WHERE e.found = CASE WHEN e.start_id = e.end_id THEN 1 ELSE 2 END
-            GROUP BY e.id, o.content_hash
+        `WITH live AS (
+           SELECT key, CAST(value AS INTEGER) AS n FROM json_each(?)
+         ), candidates AS MATERIALIZED (
+           SELECT o.id,
+                  json_extract(o.source_message_range, '$[0]') AS start_id,
+                  json_extract(o.source_message_range, '$[1]') AS end_id
+             FROM memory_observations o
+             JOIN memory_threads t ON t.id = o.thread_id AND t.owner_id = ?
+            WHERE o.thread_id = ? AND o.status = 'active' AND o.expired_at IS NULL
+            ORDER BY ${scoreOrder}
+            LIMIT ?
+         ), endpoints AS MATERIALIZED (
+           SELECT c.id,
+                  CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                    THEN s.created_at ELSE e.created_at END AS first_at,
+                  CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                    THEN s.id ELSE e.id END AS first_id,
+                  CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                    THEN e.created_at ELSE s.created_at END AS last_at,
+                  CASE WHEN (s.created_at, s.id) <= (e.created_at, e.id)
+                    THEN e.id ELSE s.id END AS last_id
+             FROM candidates c
+             JOIN memory_messages s ON s.id = c.start_id AND s.thread_id = ?
+             JOIN memory_messages e ON e.id = c.end_id AND e.thread_id = ?
+         ), bounded AS MATERIALIZED (
+           SELECT e.* FROM endpoints e
+            WHERE (
+              SELECT COUNT(*) FROM (
+                SELECT 1 FROM memory_messages m
+                 WHERE m.thread_id = ?
+                   AND (m.created_at, m.id) >= (e.first_at, e.first_id)
+                   AND (m.created_at, m.id) <= (e.last_at, e.last_id)
+                 ORDER BY m.created_at, m.id
+                 LIMIT ?
+              ) covered_limit
+            ) <= ?
          )
-         SELECT e.id FROM endpoints e
-          WHERE e.found = CASE WHEN e.start_id = e.end_id THEN 1 ELSE 2 END
-            AND EXISTS (SELECT 1 FROM memory_threads WHERE id = ? AND owner_id = ?)
-            AND NOT EXISTS (
-              SELECT 1 FROM required r LEFT JOIN live l ON l.key = r.content_hash
-               WHERE r.id = e.id AND (r.content_hash IS NULL OR l.n IS NULL OR l.n < r.n)
+         SELECT b.id FROM bounded b
+          WHERE NOT EXISTS (
+              SELECT 1 FROM memory_messages m
+              LEFT JOIN live l ON l.key = m.content_hash
+               WHERE m.thread_id = ?
+                 AND (m.created_at, m.id) >= (b.first_at, b.first_id)
+                 AND (m.created_at, m.id) <= (b.last_at, b.last_id)
+               GROUP BY m.content_hash, l.n
+              HAVING m.content_hash IS NULL OR l.n IS NULL OR l.n < COUNT(*)
             )`,
       )
-      .all(requested, live, input.threadId, input.threadId, input.accountId) as Array<{
+      .all(
+        live,
+        input.accountId,
+        input.threadId,
+        ...scoreArgs,
+        candidateLimit,
+        input.threadId,
+        input.threadId,
+        input.threadId,
+        maxCoverageMessages + 1,
+        maxCoverageMessages,
+        input.threadId,
+      ) as Array<{
       id: string;
     }>;
     return new Set(rows.map((row) => row.id));

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -1008,9 +1008,12 @@ export class SqliteMemoryStore implements MemoryStore {
           `UPDATE memory_jobs
               SET status = 'done', error = NULL, updated_at = ?
             WHERE id = ? AND type = 'reflector' AND scope_id = ? AND status = 'running'
+              AND lease_generation = ?
           RETURNING id`,
         )
-        .get(input.now.getTime(), jobId, scopeId) as { id: string } | undefined;
+        .get(input.now.getTime(), jobId, scopeId, input.leaseGeneration) as
+        | { id: string }
+        | undefined;
       if (claimed === undefined) return null;
 
       const facts = this.reconcileFactsSync({
@@ -1053,15 +1056,24 @@ export class SqliteMemoryStore implements MemoryStore {
   }
 
   // Update a background job's lifecycle status (+ optional error on failure).
-  async updateJobStatus(jobId: string, status: MemoryJobStatus, error?: string): Promise<void> {
+  async updateJobStatus(
+    jobId: string,
+    status: MemoryJobStatus,
+    error?: string,
+    leaseGeneration?: number,
+  ): Promise<void> {
     this.db
       .update(memoryJobs)
-      .set({
-        status,
-        error: error ?? null,
-        updatedAt: this.now(),
-      })
-      .where(eq(memoryJobs.id, jobId))
+      .set({ status, error: error ?? null, updatedAt: this.now() })
+      .where(
+        leaseGeneration === undefined
+          ? eq(memoryJobs.id, jobId)
+          : and(
+              eq(memoryJobs.id, jobId),
+              eq(memoryJobs.status, "running"),
+              eq(memoryJobs.leaseGeneration, leaseGeneration),
+            ),
+      )
       .run();
   }
 
@@ -1122,7 +1134,7 @@ export class SqliteMemoryStore implements MemoryStore {
     const rows = this.db.$sqlite
       .prepare(
         `UPDATE memory_jobs
-            SET status = 'running', updated_at = ?
+            SET status = 'running', updated_at = ?, lease_generation = lease_generation + 1
           WHERE id IN (
             SELECT id FROM memory_jobs
              WHERE status = 'pending'
@@ -1130,11 +1142,17 @@ export class SqliteMemoryStore implements MemoryStore {
              ORDER BY created_at ASC, id ASC
              LIMIT ?
           )
-        RETURNING id, type, scope_id`,
+        RETURNING id, type, scope_id, lease_generation`,
       )
-      .all(updatedAt, staleBefore, limit) as Array<{ id: string; type: string; scope_id: string }>;
+      .all(updatedAt, staleBefore, limit) as Array<{
+      id: string;
+      type: string;
+      scope_id: string;
+      lease_generation: number;
+    }>;
     return rows.map((row) => ({
       jobId: row.id,
+      leaseGeneration: row.lease_generation,
       // The type column is constrained to the enum at enqueue time; widen back.
       type: row.type as MemoryJobRow["type"],
       scope: decodeScopeId(row.scope_id),

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -1891,13 +1891,17 @@ export class SqliteMemoryStore implements MemoryStore {
   // updatedAt. facts ⊎ reflections via a UNION of grouped subqueries (SQLite has
   // no FULL OUTER JOIN); reflections guarded owner_id IS NOT NULL (nullable
   // column). An optional accountId narrows to one tenant.
-  async listMemoryScopes(input: { accountId?: string }): Promise<MemoryScopeSummary[]> {
+  async listMemoryScopes(input: {
+    accountId?: string;
+    limit: number;
+    offset: number;
+  }): Promise<{ rows: MemoryScopeSummary[]; total: number }> {
     const acct = input.accountId ?? null;
-    const rows = this.db.$sqlite
-      .prepare(
-        `SELECT owner_id AS accountId, project_id AS projectId, resource_id AS resourceId,
+    const aggregateSql = `SELECT owner_id AS accountId, project_id AS projectId,
+                resource_id AS resourceId,
                 thread_id AS threadId,
-                SUM(fc) AS factCount, SUM(rc) AS reflectionCount, MAX(lu) AS lastUpdated
+                SUM(fc) AS factCount, SUM(rc) AS reflectionCount, MAX(lu) AS lastUpdated,
+                COUNT(*) OVER() AS total
            FROM (
              SELECT owner_id, project_id, resource_id, thread_id,
                     COUNT(*) AS fc, 0 AS rc, MAX(updated_at) AS lu
@@ -1913,10 +1917,17 @@ export class SqliteMemoryStore implements MemoryStore {
                 AND (? IS NULL OR owner_id = ?)
               GROUP BY owner_id, project_id, resource_id, thread_id
            )
-          GROUP BY owner_id, project_id, resource_id, thread_id
-          ORDER BY lastUpdated DESC`,
+          GROUP BY owner_id, project_id, resource_id, thread_id`;
+    const rows = this.db.$sqlite
+      .prepare(
+        `${aggregateSql}
+          ORDER BY lastUpdated DESC, accountId ASC,
+                   CASE WHEN projectId IS NULL THEN 0 ELSE 1 END, projectId ASC,
+                   CASE WHEN resourceId IS NULL THEN 0 ELSE 1 END, resourceId ASC,
+                   CASE WHEN threadId IS NULL THEN 0 ELSE 1 END, threadId ASC
+          LIMIT ? OFFSET ?`,
       )
-      .all(acct, acct, acct, acct) as Array<{
+      .all(acct, acct, acct, acct, input.limit, input.offset) as Array<{
       accountId: string;
       projectId: string | null;
       resourceId: string | null;
@@ -1924,16 +1935,29 @@ export class SqliteMemoryStore implements MemoryStore {
       factCount: number;
       reflectionCount: number;
       lastUpdated: number | null;
+      total: number;
     }>;
-    return rows.map((r) => ({
-      accountId: r.accountId,
-      projectId: r.projectId,
-      resourceId: r.resourceId,
-      threadId: r.threadId,
-      factCount: r.factCount,
-      reflectionCount: r.reflectionCount,
-      lastUpdated: r.lastUpdated !== null ? new Date(r.lastUpdated) : null,
-    }));
+    const total =
+      rows[0]?.total ??
+      (input.offset === 0 && input.limit > 0
+        ? 0
+        : (
+            this.db.$sqlite
+              .prepare(`SELECT COUNT(*) AS total FROM (${aggregateSql}) scopes`)
+              .get(acct, acct, acct, acct) as { total: number }
+          ).total);
+    return {
+      rows: rows.map((r) => ({
+        accountId: r.accountId,
+        projectId: r.projectId,
+        resourceId: r.resourceId,
+        threadId: r.threadId,
+        factCount: r.factCount,
+        reflectionCount: r.reflectionCount,
+        lastUpdated: r.lastUpdated !== null ? new Date(r.lastUpdated) : null,
+      })),
+      total,
+    };
   }
 
   async getMemoryAdminStats(

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -559,6 +559,37 @@ export class SqliteMemoryStore implements MemoryStore {
       if (oversized) break;
     }
     const safeIds = selected.filter((row) => !row.oversized).map((row) => row.id);
+    const selectedIds = selected.map((row) => row.id);
+    const coveredMessageIds =
+      selectedIds.length === 0
+        ? []
+        : (
+            this.db.$sqlite
+              .prepare(
+                `SELECT m.id
+                   FROM memory_messages m
+                  WHERE m.id IN (${selectedIds.map(() => "?").join(",")})
+                    AND EXISTS (
+                      SELECT 1
+                        FROM memory_observations o
+                        JOIN memory_messages first_message
+                          ON first_message.id = json_extract(o.source_message_range, '$[0]')
+                         AND first_message.thread_id = o.thread_id
+                        JOIN memory_messages last_message
+                          ON last_message.id = json_extract(o.source_message_range, '$[1]')
+                         AND last_message.thread_id = o.thread_id
+                       WHERE o.thread_id = m.thread_id
+                         AND (
+                           ((first_message.created_at, first_message.id) <= (m.created_at, m.id)
+                            AND (m.created_at, m.id) <= (last_message.created_at, last_message.id))
+                           OR
+                           ((last_message.created_at, last_message.id) <= (m.created_at, m.id)
+                            AND (m.created_at, m.id) <= (first_message.created_at, first_message.id))
+                         )
+                    )`,
+              )
+              .all(...selectedIds) as Array<{ id: string }>
+          ).map((row) => row.id);
     const contentById = new Map<string, unknown>();
     if (safeIds.length > 0) {
       const placeholders = safeIds.map(() => "?").join(",");
@@ -581,6 +612,7 @@ export class SqliteMemoryStore implements MemoryStore {
     const nextCursor = last === undefined ? null : { createdAtMs: last.created_at, id: last.id };
     return {
       messages,
+      coveredMessageIds,
       expectedFrontier,
       nextCursor,
       hasMore: selected.length < rows.length,

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -1115,6 +1115,16 @@ export class SqliteMemoryStore implements MemoryStore {
     return row?.version ?? 0;
   }
 
+  private hasCurrentJobLease(job: { id: string; leaseGeneration: number }): boolean {
+    return (
+      this.db.$sqlite
+        .prepare(
+          "SELECT 1 FROM memory_jobs WHERE id = ? AND status = 'running' AND lease_generation = ?",
+        )
+        .get(job.id, job.leaseGeneration) !== undefined
+    );
+  }
+
   async commitReflectionJob(
     jobId: string,
     input: MemoryReflectionJobCommitInput,
@@ -1420,11 +1430,17 @@ export class SqliteMemoryStore implements MemoryStore {
   // GUARDED via the thread's owner_id (defence in depth — the ids already came from an
   // account-scoped read). Empty id list → no statement. Touches ONLY memory_observations
   // status/archived_at; raw messages and other accounts' rows are never affected.
-  async archiveObservations(input: { accountId: string; ids: string[]; now: Date }): Promise<void> {
-    if (input.ids.length === 0) return;
+  async archiveObservations(input: {
+    accountId: string;
+    ids: string[];
+    now: Date;
+    job?: { id: string; leaseGeneration: number };
+  }): Promise<boolean> {
+    if (input.ids.length === 0) return true;
     const placeholders = input.ids.map(() => "?").join(", ");
     const db = this.db.$sqlite;
-    db.transaction(() => {
+    return db.transaction(() => {
+      if (input.job !== undefined && !this.hasCurrentJobLease(input.job)) return false;
       const rows = db
         .prepare(
           `SELECT DISTINCT t.project_id, t.resource_id, t.id AS thread_id
@@ -1486,6 +1502,7 @@ export class SqliteMemoryStore implements MemoryStore {
            VALUES (?, 'reflector', ?, 'pending', NULL, ?, ?)`,
         ).run(this.genId(), scopeId, input.now.getTime(), input.now.getTime());
       }
+      return true;
     })();
   }
 
@@ -1567,6 +1584,7 @@ export class SqliteMemoryStore implements MemoryStore {
     scope: { projectId?: string; resourceId?: string; threadId?: string };
     facts: MemoryFactInput[];
     now: Date;
+    job?: { id: string; leaseGeneration: number };
   }): MemoryFactReconcileResult {
     if (input.facts.length === 0) return { insertedIds: [], supersededIds: [], resurrectedIds: [] };
     const nowMs = input.now.getTime();
@@ -1615,6 +1633,9 @@ export class SqliteMemoryStore implements MemoryStore {
     // without its supersede applied (or vice versa). Returns the ids inserted +
     // superseded + resurrected (docs/13 — the MCP `memory_add` tool echoes them).
     const runBatch = this.db.$sqlite.transaction((facts: MemoryFactInput[]) => {
+      if (input.job !== undefined && !this.hasCurrentJobLease(input.job)) {
+        return { insertedIds: [], supersededIds: [], resurrectedIds: [], accepted: false };
+      }
       const insertedIds: string[] = [];
       const supersededIds: string[] = [];
       const resurrectedIds: string[] = [];
@@ -1727,6 +1748,7 @@ export class SqliteMemoryStore implements MemoryStore {
     scope: { projectId?: string; resourceId?: string; threadId?: string };
     facts: MemoryFactInput[];
     now: Date;
+    job?: { id: string; leaseGeneration: number };
   }): Promise<MemoryFactReconcileResult> {
     return this.reconcileFactsSync(input);
   }
@@ -2252,8 +2274,9 @@ export class SqliteMemoryStore implements MemoryStore {
   async setFactEmbeddings(input: {
     accountId: string;
     items: Array<{ factId: string; embedding: Float32Array; model: string; dim: number }>;
-  }): Promise<void> {
-    if (input.items.length === 0) return;
+    job?: { id: string; leaseGeneration: number };
+  }): Promise<boolean> {
+    if (input.items.length === 0) return true;
     const selectRowid = this.db.$sqlite.prepare(
       "SELECT rowid AS rowid FROM memory_facts WHERE id = ? AND owner_id = ?",
     );
@@ -2261,6 +2284,7 @@ export class SqliteMemoryStore implements MemoryStore {
       "UPDATE memory_facts SET embedding = ?, embedding_model = ?, embedding_dim = ? WHERE rowid = ?",
     );
     const run = this.db.$sqlite.transaction(() => {
+      if (input.job !== undefined && !this.hasCurrentJobLease(input.job)) return false;
       for (const it of input.items) {
         const row = selectRowid.get(it.factId, input.accountId) as { rowid: number } | undefined;
         if (row === undefined) continue;
@@ -2284,8 +2308,9 @@ export class SqliteMemoryStore implements MemoryStore {
           }
         }
       }
+      return true;
     });
-    run();
+    return run();
   }
 
   // docs/14 — the embedding job's read half. ACTIVE facts with no embedding, or one

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1376,6 +1376,14 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Fence reclaimed memory jobs. Existing rows start at generation 0; the next
+    // claim atomically increments to 1 before any worker can publish.
+    version: 50,
+    sql: `
+      ALTER TABLE memory_jobs ADD COLUMN lease_generation INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1380,9 +1380,14 @@ const MIGRATIONS: readonly Migration[] = [
     // Fence reclaimed memory jobs. Existing rows start at generation 0; the next
     // claim atomically increments to 1 before any worker can publish.
     version: 50,
-    sql: `
-      ALTER TABLE memory_jobs ADD COLUMN lease_generation INTEGER NOT NULL DEFAULT 0;
-    `,
+    run: (db) => {
+      if (
+        sqliteTableHasColumns(db, "memory_jobs", ["id"]) &&
+        !sqliteTableHasColumns(db, "memory_jobs", ["lease_generation"])
+      ) {
+        db.exec("ALTER TABLE memory_jobs ADD COLUMN lease_generation INTEGER NOT NULL DEFAULT 0");
+      }
+    },
   },
 ];
 

--- a/packages/core/src/store/sqlite/payload-cas.test.ts
+++ b/packages/core/src/store/sqlite/payload-cas.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { encodePayloadText, PAYLOAD_TEXT_CHUNK_RAW_BYTES } from "../payload-codec.js";
 import { createSqliteDb } from "./migrate.js";
 import { SqliteTelemetryStore } from "./telemetry.js";
 
@@ -60,6 +61,23 @@ describe("SqliteTelemetryStore — image CAS + gzip", () => {
     const got = await store.getPayload("r1");
     expect(JSON.parse(got?.requestJson ?? "")).toEqual(JSON.parse(body));
     expect(got?.responseJson).toBe('{"ok":true}');
+  });
+
+  it("returns null for an oversized legacy gzip payload body", async () => {
+    const { db, store } = setup();
+    await store.insertPayload({
+      requestId: "legacy-gzip-bomb",
+      requestJson: "{}",
+      responseJson: null,
+      createdAt: new Date(1_000),
+    });
+    const bomb = encodePayloadText("x".repeat(PAYLOAD_TEXT_CHUNK_RAW_BYTES + 1));
+    db.$sqlite
+      .prepare("UPDATE request_payloads SET request_json = ? WHERE request_id = ?")
+      .run(bomb, "legacy-gzip-bomb");
+
+    await expect(store.getPayload("legacy-gzip-bomb")).resolves.toMatchObject({ requestJson: "" });
+    db.$sqlite.close();
   });
 
   it("externalizes an image-GEN RESPONSE (data[].b64_json) off-row + rehydrates it for the admin view", async () => {

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -79,6 +79,32 @@ describe("sqlite schema + migrations", () => {
     }
   });
 
+  it("v50 preserves existing jobs and initializes their lease generation to zero", () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v50-job-lease-"));
+    const path = join(dir, "helm.db");
+    try {
+      runMigrations(path);
+      const seed = new Database(path);
+      seed.exec(`
+        INSERT INTO memory_jobs (id, type, scope_id, status, created_at, updated_at)
+        VALUES ('legacy', 'observer', '{"accountId":"a","threadId":"t"}', 'pending', 1, 1);
+        ALTER TABLE memory_jobs DROP COLUMN lease_generation;
+        DELETE FROM _migrations WHERE version = 50;
+      `);
+      seed.close();
+
+      runMigrations(path);
+
+      const after = new Database(path);
+      expect(
+        after.prepare("SELECT status, lease_generation FROM memory_jobs WHERE id = 'legacy'").get(),
+      ).toEqual({ status: "pending", lease_generation: 0 });
+      after.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("upgrades a real pre-unique-index memory_jobs table with duplicate open jobs", () => {
     const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v13-memory-jobs-"));
     const path = join(dir, "helm.db");

--- a/packages/core/src/store/sqlite/telemetry.test.ts
+++ b/packages/core/src/store/sqlite/telemetry.test.ts
@@ -1,5 +1,6 @@
 import type { DecisionRecord } from "@helm/shared";
 import { describe, expect, it } from "vitest";
+import { encodePayloadText, PAYLOAD_TEXT_CHUNK_RAW_BYTES } from "../payload-codec.js";
 import { createSqliteDb } from "./migrate.js";
 import { SqliteTelemetryStore } from "./telemetry.js";
 
@@ -203,6 +204,45 @@ describe("SqliteTelemetryStore", () => {
       )
       .run(legacy);
     expect((await store.listSessionRevisions("s1"))[0]?.requestDeltaJson).toBe(legacy);
+    db.$sqlite.close();
+  });
+
+  it("maps oversized legacy gzip Session bodies to existing unavailable placeholders", async () => {
+    const db = createSqliteDb(":memory:");
+    const store = new SqliteTelemetryStore(db);
+    await store.upsertSessionRevision({
+      sessionRef: "s-gzip-bomb",
+      accountId: "a1",
+      apiKeyId: "k1",
+      source: "header",
+      externalSessionId: "external-gzip-bomb",
+      requestId: "r-gzip-bomb",
+      parentRequestId: null,
+      retainCount: 0,
+      requestDeltaJson: "[]",
+      requestEnvelopeJson: "{}",
+      responseId: "resp-gzip-bomb",
+      responseJson: "{}",
+      fidelity: "semantic",
+      createdAt: new Date(1_000),
+    });
+    const bomb = encodePayloadText("x".repeat(PAYLOAD_TEXT_CHUNK_RAW_BYTES + 1));
+    db.$sqlite
+      .prepare(
+        `UPDATE session_revisions
+            SET request_delta_json = ?, request_envelope_json = ?, response_json = ?,
+                request_body_generation = NULL, response_body_generation = NULL, body_bytes = NULL
+          WHERE request_id = 'r-gzip-bomb'`,
+      )
+      .run(bomb, bomb, bomb);
+
+    await expect(store.listSessionRevisions("s-gzip-bomb")).resolves.toEqual([
+      expect.objectContaining({
+        requestDeltaJson: "",
+        requestEnvelopeJson: "",
+        responseJson: null,
+      }),
+    ]);
     db.$sqlite.close();
   });
 

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -2087,6 +2087,157 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(second.hasMore).toBe(false);
     });
 
+    it("keeps archived/pruned cross-page ranges covered without making a gap cleanup-eligible", async () => {
+      ctx = await make();
+      const store = ctx.stores.memory;
+      if (
+        !store.listObserverMessagesPage ||
+        !store.appendObservationAndAdvanceFrontier ||
+        !store.archiveObservations ||
+        !store.pruneExpiredMemory ||
+        !store.pruneMessagesOlderThan
+      ) {
+        throw new Error("adapter must implement bounded Observer coverage and cleanup");
+      }
+      await store.ensureThread({ id: "observer-legacy-t", ownerId: "acct-a" });
+      await store.appendMessages?.(
+        Array.from({ length: 12 }, (_, messageIndex) => ({
+          threadId: "observer-legacy-t",
+          messageIndex,
+          role: "user" as const,
+          content: `legacy-${messageIndex}`,
+          tokenEstimate: 1,
+        })),
+      );
+      const ordered = await store.listMessages({
+        threadId: "observer-legacy-t",
+        accountId: "acct-a",
+      });
+      expect(ordered).toHaveLength(12);
+      const archived = await store.appendObservation({
+        threadId: "observer-legacy-t",
+        sourceMessageRange: [ordered[0]?.id ?? "", ordered[4]?.id ?? ""],
+        observationText: "archived prefix crossing page one",
+        observedAt: new Date(1_000),
+      });
+      const pruned = await store.appendObservation({
+        threadId: "observer-legacy-t",
+        sourceMessageRange: [ordered[6]?.id ?? "", ordered[10]?.id ?? ""],
+        observationText: "pruned range crossing page two",
+        observedAt: new Date(1_000),
+      });
+      await store.archiveObservations({
+        accountId: "acct-a",
+        ids: [archived, pruned],
+        now: new Date(2_000),
+      });
+      await store.pruneExpiredMemory({
+        archivedObservationsBeforeMs: 3_000,
+        expiredFactsBeforeMs: 0,
+      });
+
+      const first = await store.listObserverMessagesPage({
+        threadId: "observer-legacy-t",
+        accountId: "acct-a",
+        limit: 4,
+        maxBytes: 1024,
+        maxTokens: 100,
+      });
+      expect(first.messages).toHaveLength(4);
+      expect(new Set(first.coveredMessageIds)).toEqual(
+        new Set(first.messages.map((message) => message.id)),
+      );
+      if (first.nextCursor === null) throw new Error("expected first page cursor");
+      await store.appendObservationAndAdvanceFrontier({
+        accountId: "acct-a",
+        observation: {
+          threadId: "observer-legacy-t",
+          sourceMessageRange: [first.messages[0]?.id ?? "", first.messages[3]?.id ?? ""],
+          observationText: "test-only frontier marker",
+          observedAt: new Date(4_000),
+        },
+        expectedFrontier: first.expectedFrontier,
+        nextFrontier: first.nextCursor,
+      });
+
+      const second = await store.listObserverMessagesPage({
+        threadId: "observer-legacy-t",
+        accountId: "acct-a",
+        limit: 4,
+        maxBytes: 1024,
+        maxTokens: 100,
+      });
+      expect(second.messages.map((message) => message.content)).toEqual([
+        "legacy-4",
+        "legacy-5",
+        "legacy-6",
+        "legacy-7",
+      ]);
+      expect(new Set(second.coveredMessageIds)).toEqual(
+        new Set([second.messages[0]?.id, second.messages[2]?.id, second.messages[3]?.id]),
+      );
+      expect(second.coveredMessageIds).not.toContain(second.messages[1]?.id);
+      await store.pruneMessagesOlderThan(Number.MAX_SAFE_INTEGER);
+      expect(
+        (await store.listMessages({ threadId: "observer-legacy-t", accountId: "acct-a" })).some(
+          (message) => message.content === "legacy-5",
+        ),
+      ).toBe(true);
+    });
+
+    it("discovers a cold null-frontier legacy backlog once despite the normal max-age floor", async () => {
+      ctx = await make();
+      const store = ctx.stores.memory;
+      if (!store.listIdleFlushCandidates || !store.appendObservationAndAdvanceFrontier) {
+        throw new Error("adapter must implement legacy backfill discovery");
+      }
+      await store.ensureThread({ id: "cold-null-frontier", ownerId: "acct-a" });
+      await store.appendMessage({
+        threadId: "cold-null-frontier",
+        role: "user",
+        content: "cold legacy raw",
+        tokenEstimate: 1,
+      });
+      await store.ensureThread({ id: "cold-started", ownerId: "acct-a" });
+      await store.appendMessages?.(
+        ["covered", "successor-owned tail"].map((content, messageIndex) => ({
+          threadId: "cold-started",
+          messageIndex,
+          role: "user" as const,
+          content,
+          tokenEstimate: 1,
+        })),
+      );
+      const startedPage = await store.listObserverMessagesPage?.({
+        threadId: "cold-started",
+        accountId: "acct-a",
+        limit: 1,
+        maxBytes: 1024,
+        maxTokens: 100,
+      });
+      const startedMessage = startedPage?.messages[0];
+      if (!startedPage?.nextCursor || !startedMessage) throw new Error("expected started page");
+      await store.appendObservationAndAdvanceFrontier({
+        accountId: "acct-a",
+        observation: {
+          threadId: "cold-started",
+          sourceMessageRange: [startedMessage.id, startedMessage.id],
+          observationText: "started",
+          observedAt: new Date(1_000),
+        },
+        expectedFrontier: startedPage.expectedFrontier,
+        nextFrontier: startedPage.nextCursor,
+      });
+
+      expect(
+        await store.listIdleFlushCandidates({
+          idleBeforeMs: Number.MAX_SAFE_INTEGER,
+          idleAfterMs: Number.MAX_SAFE_INTEGER - 1,
+          limit: 10,
+        }),
+      ).toEqual([{ accountId: "acct-a", threadId: "cold-null-frontier" }]);
+    });
+
     it("replaces one oversized Observer row with a bounded digest placeholder", async () => {
       ctx = await make();
       const store = ctx.stores.memory;

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -1,5 +1,6 @@
 import type { ApiKeyRecord, DecisionRecord, RoutingSignal } from "@helm/shared";
 import { afterEach, describe, expect, it } from "vitest";
+import { sha256Hex } from "../memory/message-hash.js";
 import type {
   ConfigStore,
   KeyStore,
@@ -2019,6 +2020,66 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         "first-batch-index-1",
         "second-batch-index-0",
       ]);
+    });
+
+    it("resolves bounded injection coverage by chronological tuple with occurrence counts", async () => {
+      ctx = await make();
+      const store = ctx.stores.memory;
+      if (!store.findRedundantInjectionObservations) {
+        throw new Error("adapter must implement bounded injection coverage");
+      }
+      await store.ensureThread({ id: "inject-coverage-t", ownerId: "acct-a" });
+      const contents = Array.from({ length: 520 }, (_, index) => `history-${index}`);
+      contents.splice(400, 3, "yes", "ok", "yes");
+      const messageIds = await store.appendMessages?.(
+        contents.map((content, messageIndex) => ({
+          threadId: "inject-coverage-t",
+          // The current request-local index resets after the covered range. A range
+          // ordered by message_index would pull this later batch into the middle.
+          messageIndex:
+            messageIndex < 400
+              ? messageIndex + 10
+              : messageIndex <= 402
+                ? messageIndex - 400
+                : messageIndex - 403,
+          role: "user" as const,
+          content,
+          tokenEstimate: 1,
+        })),
+      );
+      if (!messageIds || messageIds.length !== contents.length) {
+        throw new Error("adapter must persist the long-history fixture");
+      }
+      const boundedObservationId = await store.appendObservation({
+        threadId: "inject-coverage-t",
+        // Legacy rows may store reversed endpoints; coverage remains inclusive.
+        sourceMessageRange: [messageIds[402] ?? "", messageIds[400] ?? ""],
+        observationText: "bounded repeated turns",
+        observedAt: new Date(2_000),
+      });
+      await store.appendObservation({
+        threadId: "inject-coverage-t",
+        sourceMessageRange: [messageIds[0] ?? "", messageIds[519] ?? ""],
+        observationText: "legacy oversized range",
+        observedAt: new Date(1_000),
+      });
+
+      const lookup = (accountId: string, yesCount: number) =>
+        store.findRedundantInjectionObservations?.({
+          accountId,
+          threadId: "inject-coverage-t",
+          candidateLimit: 8,
+          maxCoverageMessages: 512,
+          order: "newest",
+          windowContentHashCounts: new Map([
+            [sha256Hex("yes"), yesCount],
+            [sha256Hex("ok"), 1],
+          ]),
+        });
+
+      expect(await lookup("acct-a", 2)).toEqual(new Set([boundedObservationId]));
+      expect(await lookup("acct-a", 1)).toEqual(new Set());
+      expect(await lookup("other-account", 2)).toEqual(new Set());
     });
 
     it("pages Observer input with a durable CAS frontier", async () => {

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -2779,6 +2779,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
 
       await expect(
         m.commitReflectionJob(staleJob.jobId, {
+          leaseGeneration: staleJob.leaseGeneration ?? 0,
           target: { accountId: "acct-a", projectId: "p-race" },
           reflection: {
             action: "upsert",
@@ -2828,7 +2829,8 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         updatedAt: new Date(1000),
       });
       const jobId = await m.enqueueJob({ type: "reflector", scope: target });
-      expect((await m.claimPendingJobs(1))[0]?.jobId).toBe(jobId);
+      const claimed = (await m.claimPendingJobs(1))[0];
+      expect(claimed?.jobId).toBe(jobId);
       const fact = {
         ownerId: "acct-a",
         projectId: "p-atomic",
@@ -2844,6 +2846,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       };
       await expect(
         m.commitReflectionJob(jobId, {
+          leaseGeneration: claimed?.leaseGeneration ?? 0,
           target,
           reflection: {
             action: "upsert",
@@ -2860,6 +2863,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
 
       await expect(
         m.commitReflectionJob(jobId, {
+          leaseGeneration: claimed?.leaseGeneration ?? 0,
           target,
           reflection: {
             action: "upsert",

--- a/packages/shared/src/memory/jobs.test.ts
+++ b/packages/shared/src/memory/jobs.test.ts
@@ -60,6 +60,7 @@ describe("MemoryJobRowSchema", () => {
   it("round-trips a claimed observer row", () => {
     const row = {
       jobId: "job-1",
+      leaseGeneration: 3,
       type: "observer" as const,
       scope: { accountId: "acct-a", threadId: "t1" },
     };

--- a/packages/shared/src/memory/jobs.ts
+++ b/packages/shared/src/memory/jobs.ts
@@ -31,6 +31,9 @@ export const MemoryJobEnqueueInputSchema = z.object({
 // the scope_id column. The worker dispatches on `type` and consumes `scope`.
 export const MemoryJobRowSchema = z.object({
   jobId: z.string().min(1),
+  // Incremented atomically on every claim/reclaim. Optional only so older
+  // in-process fixtures remain parseable; production claims always return it.
+  leaseGeneration: z.number().int().positive().optional(),
   type: MemoryJobTypeSchema,
   scope: ReflectionScopeSchema,
 });


### PR DESCRIPTION
## 问题

v0.28.66 已通过禁用 Memory worker 止住生产 OOM/502，但 worker 恢复仍存在大线程全历史成本、遗忘后复活、stale lease 重复发布、Observer continuation crash gap，以及多个无界响应读取路径。

## 修复

- Observer 按 512 rows / 1 MiB / 64K tokens 有界分页，frontier、observation、job completion 与 successor 原子提交
- lease generation 覆盖 Observer、Reflector、decay、embedding 与 eager facts publication
- PostgreSQL decay/Reflector advisory-lock fencing，保留 archived/pruned legacy coverage，发现冷 null-frontier backlog
- injection coverage 改为一次有界查询；Admin scopes 默认 50、最大 200 分页并延迟加载 keys
- OpenAI/Anthropic/Gemini unary、OAuth/token/model helpers 和 legacy gzip 解码全部有界
- migration 保持 partial/legacy schema 升级兼容

## 验证

- 35 个聚焦文件，745 tests passed
- 真实 51,116 行 SQLite Observer drain + crash resume passed
- PostgreSQL 并发 decay/Reflector 与 lease fencing passed
- CI=true pnpm typecheck passed
- CI=true pnpm lint passed
- CI=true pnpm build passed
- git diff --check passed

## 发布边界

合并与发布后，生产首次部署仍保持 HELM_MEMORY_WORKER_DISABLED=1；再以 batch=1、concurrency=1、cleanup disabled 做单页 canary，验证 frontier/RSS/PSI/5xx/OOM 后才扩大。