### PR TITLE
chore: release v0.28.67

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.66",
+  "version": "0.28.67",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

- bump root version from 0.28.66 to 0.28.67
- release source main SHA: bbf7bc8675684c31e3a1c2d6cc9e0ac4cca5aa11
- includes PR #742 Memory lifecycle bounds and fencing fixes

Version-only release change; feature CI was green before merge.