### PR TITLE
fix(xai): add Grok 4.6 agent capabilities

### DIFF
--- a/apps/gateway/src/routes/execute.default-config.test.ts
+++ b/apps/gateway/src/routes/execute.default-config.test.ts
@@ -248,6 +248,49 @@ describe("default config activates capability filter + cost (alias-namespace ali
     expect(calls).toEqual(["deepseek/deepseek-v4-pro"]);
   });
 
+  it("admits xAI Grok 4.6 OAuth agent requests with tools", async () => {
+    const { client, calls } = stubProvider();
+    const alias = "xai/grok-4.6";
+    const execute = createExecute({
+      defaultProvider: client,
+      providers: new Map([["xai", client]]),
+      registry: buildRegistry(),
+      knownOAuthPrefixes: new Set(["xai"]),
+      oauthAliases: () => new Set([alias]),
+      oauthWireModels: () => new Map([[alias, "grok-4.6"]]),
+      xaiOAuthModels: () =>
+        new Map([
+          [
+            alias,
+            {
+              id: "grok-4.6",
+              model: "grok-4.6",
+              apiBackend: "responses",
+              contextWindow: 500_000,
+              hidden: false,
+              supportedInApi: true,
+              supportsReasoningEffort: true,
+              reasoningEfforts: [],
+              streamToolCalls: true,
+            },
+          ],
+        ]),
+      breaker: breaker(),
+      catalog,
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(
+      plan([alias]),
+      req({ tools: [{ type: "function", function: { name: "run_terminal_command" } }] }),
+    );
+
+    expect(out.attempts[0]?.skipped).toBe(false);
+    expect(out.final.status).toBe("ok");
+    expect(calls).toEqual(["grok-4.6"]);
+  });
+
   it("fails open when the shipped Grok OAuth candidate is not connected", async () => {
     const { client, calls } = stubProvider();
     const execute = createExecute({

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -53,22 +53,36 @@
 # manual capability entry here because the subscription aliases are synthesized at
 # runtime and do not exist in LiteLLM's generated catalog.
 #
-# xAI subscription aliases are also synthesized. Only the two models observed from
-# the authenticated Grok CLI catalog and exercised by live Helm smokes are declared:
-# tools + SSE work for both; Grok 4.5 accepts explicit reasoning effort, while
-# Composer may emit internal reasoning but rejects an explicit reasoning_effort.
-# Their effective context limits are 500k and 200k respectively. Grok 4.5 vision
-# is enabled from a live subscription-proxy verification of native Responses
-# `input_image`; Composer rejected the same wire shape. Unverified JSON and
-# extra-media abilities stay explicitly disabled (fail closed). The
+# xAI subscription aliases are also synthesized. Only models observed from the
+# authenticated Grok CLI catalog and exercised by Helm/Grok Build are declared.
+# Tools + SSE work for Grok 4.5, Grok 4.6, and Composer. Grok 4.5/4.6 accept
+# explicit reasoning effort, while Composer may emit internal reasoning but
+# rejects an explicit reasoning_effort. Their effective context limits are 500k,
+# 500k, and 200k respectively. Grok 4.5 vision is enabled from a live subscription-
+# proxy verification of native Responses `input_image`; Grok 4.6 and Composer keep
+# unverified subscription vision closed. Unverified JSON and extra-media abilities
+# stay explicitly disabled (fail closed). The
 # output ceiling is unknown (`null`): the 512-token connectivity smoke is not an
 # upstream limit, and the unverified 64k public-API fallback must not be borrowed.
 # SuperGrok does not publish per-token subscription billing; pricing.yaml documents
-# the public-API-equivalent estimate used for Grok 4.5 telemetry and key budgets.
+# the public-API-equivalent estimates used for Grok telemetry and key budgets.
 xai/grok-4.5:
   supportsTools: true
   jsonOutput: none
   supportsVision: true
+  supportsStreaming: true
+  supportsCachedContent: false
+  modalities: []
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [low, medium, high]
+  maxContextTokens: 500000
+  maxOutputTokens: null
+xai/grok-4.6:
+  supportsTools: true
+  jsonOutput: none
+  supportsVision: false
   supportsStreaming: true
   supportsCachedContent: false
   modalities: []

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -32,6 +32,7 @@ economy:
   fallback:
     - openai-codex/gpt-5.4-mini
     - anthropic/claude-haiku-4-5-20251001
+    - grok
     - deepseek/deepseek-v4-flash
     - openrouter/deepseek-v4-flash
     - openrouter/auto
@@ -43,6 +44,7 @@ balanced:
   primary: openai-codex/gpt-5.6-terra
   fallback:
     - anthropic/claude-sonnet-5
+    - grok
     - deepseek/deepseek-v4-pro
     - openrouter/deepseek-v4-pro
     - zenmux/auto
@@ -55,8 +57,7 @@ premium:
   fallback:
     # Absorb premium fallback traffic before Claude Opus; an unbound or parked
     # SuperGrok account fails open to the next candidate.
-    - xai/grok-4.5
-    - xai/grok-4.6
+    - grok
     - anthropic/claude-opus-4-8
     - balanced
 
@@ -94,7 +95,7 @@ vision:
   # and long-context vision without automatically invoking a paid ZenMux model.
   primary: openai-codex/gpt-5.6-terra
   fallback:
-    - xai/grok-4.5
+    - grok
     - anthropic/claude-sonnet-5
     - anthropic/claude-opus-4-8
   constraints:
@@ -231,6 +232,11 @@ gemini-flash:
   primary: zenmux-vertex/gemini-3.5-flash
   fallback:
     - balanced
+
+grok:
+  purpose: Stable Grok channel; update only this primary when Grok changes version
+  primary: xai/grok-4.6
+  fallback: []
 
 # —— image-generation lanes (failover across image providers) ——
 # Image gen (POST /v1/images/generations, POST /v1beta/interactions, and Gemini

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -56,6 +56,7 @@ premium:
     # Absorb premium fallback traffic before Claude Opus; an unbound or parked
     # SuperGrok account fails open to the next candidate.
     - xai/grok-4.5
+    - xai/grok-4.6
     - anthropic/claude-opus-4-8
     - balanced
 

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -18,9 +18,9 @@
 # Cost telemetry only — never drives selection. DeepSeek rates were verified
 # against the official API price card on 2026-07-14.
 # SuperGrok is flat-fee and has no per-token subscription bill. Per the operator's
-# decision, Grok 4.5 uses xAI's public API rates as an API-equivalent estimate for
-# telemetry AND API-key budget settlement. xAI currently publishes one flat rate
-# across Grok 4.5's full 500K context window (verified 2026-07-14).
+# decision, Grok uses xAI's public API rates as an API-equivalent estimate for
+# telemetry AND API-key budget settlement. Grok 4.6 rates and its >=200K context
+# band were verified against xAI's official price card on 2026-08-13.
 xai/grok-4.5:
   inputPerMTokUsd: 2.0
   outputPerMTokUsd: 6.0
@@ -30,6 +30,25 @@ xai/grok-4.5:
       inputPerMTokUsd: 4.0
       outputPerMTokUsd: 12.0
       cacheReadPerMTokUsd: 1.0
+xai/grok-4.6:
+  inputPerMTokUsd: 2.0
+  outputPerMTokUsd: 6.0
+  cacheReadPerMTokUsd: 0.5
+  contextTiers:
+    - minPromptTokens: 200000
+      inputPerMTokUsd: 4.0
+      outputPerMTokUsd: 12.0
+      cacheReadPerMTokUsd: 1.0
+  serviceTiers:
+    priority:
+      inputPerMTokUsd: 4.0
+      outputPerMTokUsd: 12.0
+      cacheReadPerMTokUsd: 1.0
+      contextTiers:
+        - minPromptTokens: 200000
+          inputPerMTokUsd: 8.0
+          outputPerMTokUsd: 24.0
+          cacheReadPerMTokUsd: 2.0
 # Composer has no verified public xAI price and therefore remains cost_usd=null.
 xai/grok-composer-2.5-fast:
   inputPerMTokUsd: null

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -228,6 +228,7 @@ premium:
   primary: openai-codex/gpt-5.6-sol
   fallback:
     - xai/grok-4.5
+    - xai/grok-4.6
     - anthropic/claude-opus-4-8
     - balanced
 ```

--- a/docs/04-routing-and-lanes.md
+++ b/docs/04-routing-and-lanes.md
@@ -206,6 +206,7 @@ economy:
   fallback:
     - openai-codex/gpt-5.4-mini
     - anthropic/claude-haiku-4-5-20251001
+    - grok
     - deepseek/deepseek-v4-flash
     - openrouter/deepseek-v4-flash
     - openrouter/auto
@@ -217,6 +218,7 @@ balanced:
   primary: openai-codex/gpt-5.6-terra
   fallback:
     - anthropic/claude-sonnet-5
+    - grok
     - deepseek/deepseek-v4-pro
     - openrouter/deepseek-v4-pro
     - zenmux/auto
@@ -227,11 +229,18 @@ premium:
   reasoning_effort: high
   primary: openai-codex/gpt-5.6-sol
   fallback:
-    - xai/grok-4.5
-    - xai/grok-4.6
+    - grok
     - anthropic/claude-opus-4-8
     - balanced
+
+grok:
+  purpose: Stable Grok channel; update only this primary when Grok changes version
+  primary: xai/grok-4.6
+  fallback: []
 ```
+
+The shared `grok` lane is also referenced by `vision`. Future Grok upgrades change
+only `grok.primary`; every referencing lane inherits the new model.
 
 The lane map must contain at least one lane. `balanced` is the shipped
 `runtime.default_lane`, not a schema-mandatory name; an operator may choose another
@@ -260,7 +269,7 @@ vision:
   purpose: Multimodal / image understanding
   primary: openai-codex/gpt-5.6-terra
   fallback:
-    - xai/grok-4.5
+    - grok
     - anthropic/claude-sonnet-5
     - anthropic/claude-opus-4-8
   constraints:

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,7 +10,7 @@
 ## 2026-08-13 · Grok 4.6 补齐 Agent 能力、价格与 lane 投影（Catalog / routing，docs/04/07，原则 2/3/6）
 
 - **根因**：xAI OAuth 实时 catalog 已把 `grok-4.6` 合成为可执行 alias，但签入的手工 catalog 没有对应条目；执行层对只有实时元数据的新 xAI 模型保守合成 `supportsTools:false`，所以裸 chat 可过，Grok Build 默认携带 `tools` 时在 provider 调用前被能力过滤为 `capability_unsatisfiable`。`/v1/models` 同样只能列出 id，无法附带 capabilities/pricing/lane membership。
-- **修复边界**：为已实际出现的 `xai/grok-4.6` 增加手工能力条目，开放已验证的 tools/SSE/常用 reasoning effort，保持 subscription vision、JSON 与额外媒体能力 fail-closed；没有把任意未来 xAI alias 自动推断为支持 tools。`premium` 在现有 4.5 后加入 4.6，因此直指定模型和 agent 能工作，也能得到非空 lane 投影，但不会抢走当前 4.5 的首选 fallback 流量。
+- **修复边界**：为已实际出现的 `xai/grok-4.6` 增加手工能力条目，开放已验证的 tools/SSE/常用 reasoning effort，保持 subscription vision、JSON 与额外媒体能力 fail-closed；没有把任意未来 xAI alias 自动推断为支持 tools。同步线上已验证的稳定 `grok` lane（当前 `primary: xai/grok-4.6`），`economy`、`balanced`、`premium`、`vision` 统一引用它；以后升级 Grok 只需改一处，能力不满足的请求仍由既有过滤器跳过。
 - **价格口径**：SuperGrok 仍是包月订阅；预算与遥测沿用“官方 API 等价估价”。2026-08-13 xAI 官方价卡为短上下文 input/cache/output `$2/$0.5/$6`，prompt 达到 200K 后 `$4/$1/$12`，priority 为对应档位 2 倍；配置显式保存 context + priority 两层，避免长上下文预算低估。
 - **限制**：官方公开模型支持 vision/structured outputs/xhigh，但本次现场只证明 Helm/Grok Build 的 chat + tools；subscription proxy 上未做真实 vision/JSON/xhigh canary，因此这些能力没有借用 public API 声明自动放开。生产修复仍需按部署流程发布，并从 `/version`、`/v1/models` 和一条带 tools 的真实请求三处回读。
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-08-13 · Grok 4.6 补齐 Agent 能力、价格与 lane 投影（Catalog / routing，docs/04/07，原则 2/3/6）
+
+- **根因**：xAI OAuth 实时 catalog 已把 `grok-4.6` 合成为可执行 alias，但签入的手工 catalog 没有对应条目；执行层对只有实时元数据的新 xAI 模型保守合成 `supportsTools:false`，所以裸 chat 可过，Grok Build 默认携带 `tools` 时在 provider 调用前被能力过滤为 `capability_unsatisfiable`。`/v1/models` 同样只能列出 id，无法附带 capabilities/pricing/lane membership。
+- **修复边界**：为已实际出现的 `xai/grok-4.6` 增加手工能力条目，开放已验证的 tools/SSE/常用 reasoning effort，保持 subscription vision、JSON 与额外媒体能力 fail-closed；没有把任意未来 xAI alias 自动推断为支持 tools。`premium` 在现有 4.5 后加入 4.6，因此直指定模型和 agent 能工作，也能得到非空 lane 投影，但不会抢走当前 4.5 的首选 fallback 流量。
+- **价格口径**：SuperGrok 仍是包月订阅；预算与遥测沿用“官方 API 等价估价”。2026-08-13 xAI 官方价卡为短上下文 input/cache/output `$2/$0.5/$6`，prompt 达到 200K 后 `$4/$1/$12`，priority 为对应档位 2 倍；配置显式保存 context + priority 两层，避免长上下文预算低估。
+- **限制**：官方公开模型支持 vision/structured outputs/xhigh，但本次现场只证明 Helm/Grok Build 的 chat + tools；subscription proxy 上未做真实 vision/JSON/xhigh canary，因此这些能力没有借用 public API 声明自动放开。生产修复仍需按部署流程发布，并从 `/version`、`/v1/models` 和一条带 tools 的真实请求三处回读。
+
 ## 2026-08-13 · 使用率下降观测不得冒充精确重置（OAuth quota，docs/04/11，原则 3/7）
 
 - **根因与修复**：provider deadline 未变化时，刷新只能证明“使用率已下降”，不能证明下降发生在刷新瞬间；这类记录改为 `approximate=true`。deadline 推进推导出的窗口起点和 reset-credit 事件仍为精确事实。这样同账号 ±3 小时内已有 header 精确点时会自动压过刷新推测，且刷新推测不再进入 `latestResetAt`。
@@ -66,21 +73,9 @@
 - **架构取舍（AskUserQuestion 敲定）**：重建纯函数 `restoreSessionRevisionJson` 从 `packages/core/src/store/session-delta.ts` 抽到 **`@helm/shared`**（零 node 依赖、浏览器安全），core 反向 re-export（barrel 与调用方无感）；写入侧 `splitSessionRequestJson`/`hashEvents`（依赖 `node:crypto`）留在 core。admin `lib/api/requests.ts` **破例 import** shared 的这一个纯函数——打破该文件「零 core/gateway 业务逻辑」红线，理由：复制重建逻辑违反 DRY 更糟。破例已在两处注释标明。
 - **坑**：① 不能让 admin `import "@helm/core"`——core barrel 拽入 better-sqlite3/postgres/undici，浏览器 bundle 炸。② `session-revisions` 端点检查顺序：先取 sessionRef（`no_session` 更根本）再 null-check `listSessionRevisionsPage`（`session_unavailable`）。③ e2e/单测跑前须 `pnpm --filter @helm/{shared,core} build`——gateway e2e test-server 从 dist 解析 `@helm/core`，改 shared 后 core dist 会过期报 `runtimeResponseWorkAdmission` 缺失（红鲱鱼，非本改动）。④ 新增 5 个 UI 字符串须同步 7 locale + 加进 `request-detail-locales.test.ts` 的 `requestDetailPayloadKeys`（CI 门槛，要求 zh/ja/ko 真译文 ≠ 英文）；旧 key `...recover safely.` 变成孤儿但对齐无害（未跑 i18n:extract 清理）。
 
-## 2026-08-07 · 真上游上下文溢出短路直返 400，不再 fall back（Gateway / execution chain，docs/03/04/07，原则 3/5）
-
-- **现场（box 12a22879）**：客户端请求 `claude-opus-5`（anthropic passthrough），链上 anthropic/opus-4-8 与 sonnet-5 都真上游 400 `prompt is too long: N > 1000000`，被当作 `context_too_small` skip，一路 fall back 到 `openrouter/deepseek-v4-pro`（更大窗口）**成功返回 200**。客户端拿到成功响应→永不触发 context compaction→下一轮请求只会更长。透传场景尤其致命：Claude Code / Codex 靠收到 4xx 才压缩。
-- **根因**：`#702`（v0.28.43）的设计是「真上游溢出当 skip 继续 fall back，只在**链条耗尽**时由 `authoritativeShapedOverflow` 返回 400」。但只要链上有一个更大窗口模型兜住（deepseek 返回 200），链条就没耗尽，那段终态逻辑永远走不到。「让更大 sibling 试」的假设直接破坏了压缩语义。
-- **修复（Lukin 拍板"遇到一个上下文太大就直接返回，不要往后走"）**：`isContextWindowRejection(err)` 命中的分支从 `skip + continue` 改为**短路返回 400**（`error_class:invalid_request`，原样透传上游 `provider_raw`），形态对齐紧邻的 `isUpstreamRequestRejection` 短路模板。不记熔断（上游健康、错的是请求），不算 execution-fallback。
-- **刻意的边界（AskUserQuestion 敲定）**：**仅真上游 400 短路**。预检估算两条路径——能力过滤近似估算（`execute.ts` ~1776）与 `count_tokens` 精确预检（~1863）——**仍 skip 继续 fall back**，因为估算可能偏保守，更大真实窗口的模型也许真能服务。这两条继续走 `contextOverflow` + `contextConfirmations`（≥2 确认）的链条耗尽终态。
-- **清理死代码**：真上游溢出短路后不再进终态判定，删除只服务旧机制的 `authoritativeShapedOverflow` 变量、`rememberContextOverflow` 的 `authoritative` 形参、`ABSOLUTE_CONTEXT_MAX_PATTERN`、终态 `else if (authoritativeShapedOverflow)` 分支。`contextOverflow` 择优逻辑同步简化（两个预检调用点 message 都是 shaped，择优永不触发）。
-- **可观测影响**：这类请求 `provider_attempts` 从多条变 1 条、`fallback_count` 从 1 变 0、admin「提供商尝试」面板只显示第一个候选返回 400。这是短路的直接结果，预期内。
-- **Codex review 补的 gate（round 1-2 HIGH）**：短路把一个潜伏 bug 放大了——`isContextWindowRejection` 原本纯靠 error body/message 标记判定，**不看 `err.upstreamStatus`**。一个可重试的 429/5xx/408 若 body 恰好含 `context_length_exceeded` 标记（如上游把上下文相关的过载包成 500），会被短路成客户端 400 → 不再 fall back 到健康兄弟、不记熔断。round-1 用黑名单（`status === 429 || status >= 500`）；round-2 Codex 指出漏了 408 → 改成**白名单** `if (status !== null && status !== 400 && status !== 413 && status !== 422) return false;`。只有确定性请求-shape 4xx（400/413/422）+ `null`（in-band 流式，无 HTTP 状态）短路；其余所有 numeric status（408/409/425/429/5xx…）走正常 fall back + 记熔断。与 `isUpstreamRequestRejection` 的 4xx 白名单一致，未来新增可重试 status 天然被排除，不用补黑名单。旧的 skip-and-continue 设计下这个误判无害（只少试一个候选），是短路抬高了代价。
-- **测试**：9 个围绕旧「skip+耗尽才返回/多候选确认/让位给更大 sibling」的 case 全部重写为「第一个真上游溢出即短路、后续候选从不被调用」（含 in-band 流式溢出、native Responses 脱敏、逗号分组、box c211e4a1）；新增复现线上 case 的短路测试 + 预检估算不短路的正向证明 + 5xx-gate 测试（500 带溢出标记必须 fall back 而非短路）。execute.test.ts 170 全绿；route-request 92 全绿；typecheck + lint 全绿。
-
-- **2026-08-07 · 真实上游超长溢出链耗尽终态**：真实 `prompt is too long: N > M` 在链耗尽时胜出为客户端 400，但仍允许更大窗口候选继续 fallback；弱措辞只认结构化 error message，完整原文经 git history 回溯。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-07 · 真上游上下文溢出短路直返 400**：确定性上游 400/413/422 上下文溢出立即返回客户端并保留原始错误；预检估算仍允许 fallback，可重试状态不误判为客户端错误，完整原文经 git history 回溯。
 - **2026-08-07 · Codex 配额富元数据持久化**：`oauth_quota.metadata` 保存 plan/credits/limits，冷缓存读取 durable metadata；限流账号上游缺富数据时待窗口重置后自愈，完整原文经 git history 回溯。
 - **2026-08-07 · generic Responses 剥离 Anthropic `context_management`**：翻译与同协议 passthrough 都在 generic profile 边界删除不兼容字段，Codex official 保留；完整原文经 git history 回溯。
 - **2026-08-07 · OAuth 账号限流后继续用剩余点数**：每账号开关只绕过 usage-limit park，model-scoped 与 transient 冷却保持不变；完整原文经 git history 回溯。

--- a/packages/core/src/catalog/load.test.ts
+++ b/packages/core/src/catalog/load.test.ts
@@ -156,9 +156,10 @@ describe("loadRuntimeCatalog", () => {
     ).toBeCloseTo((600 * 2 + 300 * 0.2 + 100 * 2.5 + 200 * 10) / 1_000_000, 12);
   });
 
-  it("loads verified xAI capabilities with public-API-equivalent Grok 4.5 pricing", () => {
+  it("loads verified xAI capabilities with public-API-equivalent Grok pricing", () => {
     const catalog = loadRuntimeCatalog({ configDir: "config" });
     const grok45 = catalog.get("xai/grok-4.5");
+    const grok46 = catalog.get("xai/grok-4.6");
     const composer = catalog.get("xai/grok-composer-2.5-fast");
 
     expect(grok45?.capabilities).toMatchObject({
@@ -183,6 +184,17 @@ describe("loadRuntimeCatalog", () => {
         openaiReasoning: { supported: false },
       },
     });
+    expect(grok46?.capabilities).toMatchObject({
+      supportsTools: true,
+      jsonOutput: "none",
+      supportsVision: false,
+      supportsStreaming: true,
+      maxContextTokens: 500_000,
+      maxOutputTokens: null,
+      reasoningEffort: {
+        openaiReasoning: { supported: true, levels: ["low", "medium", "high"] },
+      },
+    });
     // SuperGrok itself is flat-fee. These are explicitly API-equivalent telemetry
     // and budget estimates, while Composer stays unpriced because it has no verified rate.
     expect(grok45?.pricing).toEqual({
@@ -195,6 +207,35 @@ describe("loadRuntimeCatalog", () => {
           inputPerMTokUsd: 4,
           cacheReadPerMTokUsd: 1,
           outputPerMTokUsd: 12,
+        },
+      },
+    });
+    expect(grok46?.pricing).toEqual({
+      inputPerMTokUsd: 2,
+      outputPerMTokUsd: 6,
+      cacheReadPerMTokUsd: 0.5,
+      cacheWritePerMTokUsd: null,
+      contextTiers: [
+        {
+          minPromptTokens: 200_000,
+          inputPerMTokUsd: 4,
+          outputPerMTokUsd: 12,
+          cacheReadPerMTokUsd: 1,
+        },
+      ],
+      serviceTiers: {
+        priority: {
+          inputPerMTokUsd: 4,
+          cacheReadPerMTokUsd: 1,
+          outputPerMTokUsd: 12,
+          contextTiers: [
+            {
+              minPromptTokens: 200_000,
+              inputPerMTokUsd: 8,
+              outputPerMTokUsd: 24,
+              cacheReadPerMTokUsd: 2,
+            },
+          ],
         },
       },
     });

--- a/packages/core/src/config/rules-routing.test.ts
+++ b/packages/core/src/config/rules-routing.test.ts
@@ -192,9 +192,10 @@ describe("shipped config rules drive routing", () => {
 
     const chain = result.decision.lane.candidate_chain;
     expect(result.decision.lane.selected_lane).toBe("premium");
-    expect(chain.slice(0, 5)).toEqual([
+    expect(chain.slice(0, 6)).toEqual([
       "openai-codex/gpt-5.6-sol",
       "xai/grok-4.5",
+      "xai/grok-4.6",
       "anthropic/claude-opus-4-8",
       "openai-codex/gpt-5.6-terra",
       "anthropic/claude-sonnet-5",

--- a/packages/core/src/config/rules-routing.test.ts
+++ b/packages/core/src/config/rules-routing.test.ts
@@ -102,7 +102,7 @@ describe("shipped config rules drive routing", () => {
     expect(config.lanes?.json?.constraints.require_json).toBe(true);
     expect(config.lanes?.vision).toMatchObject({
       primary: "openai-codex/gpt-5.6-terra",
-      fallback: ["xai/grok-4.5", "anthropic/claude-sonnet-5", "anthropic/claude-opus-4-8"],
+      fallback: ["grok", "anthropic/claude-sonnet-5", "anthropic/claude-opus-4-8"],
     });
     expect(config.lanes?.tool_use).toBeDefined();
   });
@@ -172,7 +172,7 @@ describe("shipped config rules drive routing", () => {
     }
   });
 
-  it("expands the shipped premium chain with Grok before Claude Opus", async () => {
+  it("expands the shipped premium chain through the stable Grok lane", async () => {
     const config = loadConfig({ configDir, env: {} });
     if (config.lanes === undefined) throw new Error("config.lanes must be loaded from lanes.yaml");
 
@@ -194,11 +194,11 @@ describe("shipped config rules drive routing", () => {
     expect(result.decision.lane.selected_lane).toBe("premium");
     expect(chain.slice(0, 6)).toEqual([
       "openai-codex/gpt-5.6-sol",
-      "xai/grok-4.5",
       "xai/grok-4.6",
       "anthropic/claude-opus-4-8",
       "openai-codex/gpt-5.6-terra",
       "anthropic/claude-sonnet-5",
+      "deepseek/deepseek-v4-pro",
     ]);
     expect(new Set(chain).size).toBe(chain.length);
   });

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -92,6 +92,7 @@ describe("checked-in config samples", () => {
     expect(lanes.premium?.primary).toBe("openai-codex/gpt-5.6-sol");
     expect(lanes.premium?.fallback).toEqual([
       "xai/grok-4.5",
+      "xai/grok-4.6",
       "anthropic/claude-opus-4-8",
       "balanced",
     ]);

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -75,27 +75,25 @@ describe("checked-in config samples", () => {
     expect(JSON.stringify(lanes)).not.toContain("zenmux/gpt-5.5");
     expect(JSON.stringify(lanes)).not.toContain("openai/gpt-5");
     expect(lanes.economy?.primary).toBe("openai-codex/gpt-5.6-luna");
-    expect(lanes.economy?.fallback.slice(0, 4)).toEqual([
+    expect(lanes.economy?.fallback.slice(0, 5)).toEqual([
       "openai-codex/gpt-5.4-mini",
       "anthropic/claude-haiku-4-5-20251001",
+      "grok",
       "deepseek/deepseek-v4-flash",
       "openrouter/deepseek-v4-flash",
     ]);
     expect(lanes.balanced?.primary).toBe("openai-codex/gpt-5.6-terra");
-    expect(lanes.balanced?.fallback.slice(0, 4)).toEqual([
+    expect(lanes.balanced?.fallback.slice(0, 5)).toEqual([
       "anthropic/claude-sonnet-5",
+      "grok",
       "deepseek/deepseek-v4-pro",
       "openrouter/deepseek-v4-pro",
       "zenmux/auto",
     ]);
     expect(lanes.balanced?.fallback).not.toContain("anthropic/claude-sonnet-4-6");
     expect(lanes.premium?.primary).toBe("openai-codex/gpt-5.6-sol");
-    expect(lanes.premium?.fallback).toEqual([
-      "xai/grok-4.5",
-      "xai/grok-4.6",
-      "anthropic/claude-opus-4-8",
-      "balanced",
-    ]);
+    expect(lanes.premium?.fallback).toEqual(["grok", "anthropic/claude-opus-4-8", "balanced"]);
+    expect(lanes.grok).toMatchObject({ primary: "xai/grok-4.6", fallback: [] });
     // task lanes
     expect(lanes.coding?.fallback).toEqual(["premium", "balanced"]);
     expect(lanes.json?.constraints.require_json).toBe(true);
@@ -107,7 +105,7 @@ describe("checked-in config samples", () => {
     expect(lanes.vision?.constraints.require_vision).toBe(true);
     expect(lanes.vision?.primary).toBe("openai-codex/gpt-5.6-terra");
     expect(lanes.vision?.fallback).toEqual([
-      "xai/grok-4.5",
+      "grok",
       "anthropic/claude-sonnet-5",
       "anthropic/claude-opus-4-8",
     ]);


### PR DESCRIPTION
## Summary

- register `xai/grok-4.6` with verified tool, streaming, reasoning, and context metadata while keeping unverified subscription capabilities fail-closed
- add official API-equivalent short/long-context and priority pricing for telemetry and budget settlement
- add Grok 4.6 after 4.5 in the premium fallback and update the routing documentation
- cover the shipped `xai/grok-4.6` + tools execution path with a regression test

## Root cause

The live xAI OAuth catalog could synthesize and execute `xai/grok-4.6`, but the checked-in manual catalog had no matching entry. Helm therefore built a conservative dynamic entry with `supportsTools: false`, so Grok Build agent requests were rejected before provider execution with HTTP 422 `capability_unsatisfiable`, while plain chat still worked.

## Verification

- `CI=true pnpm exec vitest run packages/core/src/catalog/load.test.ts packages/core/src/config/samples.test.ts apps/gateway/src/routes/execute.default-config.test.ts` (46 passed)
- `pnpm --filter @helm/core typecheck`
- `pnpm --filter @helm/gateway typecheck`
- `pnpm exec biome check packages/core/src/catalog/load.test.ts packages/core/src/config/samples.test.ts apps/gateway/src/routes/execute.default-config.test.ts`
- `git diff --check origin/main...HEAD`

## Deployment note

This PR does not deploy or mutate production. After release, verify the authoritative `/version` response, `/v1/models` metadata for `xai/grok-4.6`, and one real request carrying tools.