### PR TITLE
fix(oauth): backfill approximate reset boundaries

### DIFF
--- a/apps/gateway/src/oauth/quota-reset-period.ts
+++ b/apps/gateway/src/oauth/quota-reset-period.ts
@@ -54,6 +54,7 @@ export async function recordQuotaResetCreditPeriods(input: {
           periodStartMs,
           periodEndMs: input.occurredAtMs,
           detectedAtMs: input.occurredAtMs,
+          approximate: false,
         })
         .catch(() => {});
     }),

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -198,6 +198,7 @@ describe("admin OAuth routes — read endpoints", () => {
     const now = Date.now();
     const todayReset = now - HOUR;
     const saturdayReset = todayReset - 3 * DAY;
+    const announcementReset = saturdayReset + DAY;
     const reset = todayReset + WEEK;
     const buckets = Array.from({ length: 10 * 24 }, (_, i) => ({
       bucketMs: now - (10 * 24 - i) * HOUR,
@@ -229,6 +230,27 @@ describe("admin OAuth routes — read endpoints", () => {
           periodStartMs: saturdayReset + DAY,
           periodEndMs: todayReset,
           detectedAtMs: todayReset,
+        },
+        {
+          // A historical public announcement fills the otherwise-missing boundary.
+          providerId: "openai-codex",
+          account: "a@x.com",
+          windowKey: "primary",
+          periodStartMs: saturdayReset,
+          periodEndMs: announcementReset,
+          detectedAtMs: announcementReset,
+          approximate: true,
+        },
+        {
+          // An estimate for the same reset must yield to the account's exact header
+          // observation nearby rather than create a tiny duplicate period.
+          providerId: "openai-codex",
+          account: "a@x.com",
+          windowKey: "primary",
+          periodStartMs: announcementReset,
+          periodEndMs: todayReset - 30 * 60_000,
+          detectedAtMs: todayReset - 30 * 60_000,
+          approximate: true,
         },
         {
           providerId: "openai-codex",
@@ -286,13 +308,13 @@ describe("admin OAuth routes — read endpoints", () => {
     );
     expect(body.periods[0]).toMatchObject({
       windowKey: "primary",
-      periodStartMs: saturdayReset,
+      periodStartMs: announcementReset,
       periodEndMs: todayReset,
-      approximate: false,
+      approximate: true,
     });
     expect(body.periods[1]).toMatchObject({
-      periodStartMs: saturdayReset - WEEK,
-      periodEndMs: saturdayReset,
+      periodStartMs: saturdayReset,
+      periodEndMs: announcementReset,
       approximate: true,
     });
     // daily: natural-day buckets, most recent first, each a 24h span, windowKey "day".

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -48,39 +48,68 @@ import type {
 //   - device_code (Copilot): start -> show user code -> poll until done.
 
 const DEFAULT_ACCOUNT = "default";
+const ESTIMATE_SUPERSEDE_MS = 3 * 60 * 60_000;
 
 function resetEventBoundaries(
   rows: OAuthResetPeriod[],
   nextResetAtMs: number | null,
   nowMs: number,
   windowMs: number | null,
-): Array<{ startMs: number; endMs: number }> {
+): Array<{ startMs: number; endMs: number; approximate: boolean }> {
   // The old writer stored [oldReset, projectedNextReset); the current writer stores a
   // closed period ending at the observed reset. Reduce both shapes to proven events.
+  const rawPoints = rows
+    .flatMap((row) => {
+      const atMs =
+        row.detectedAtMs >= row.periodEndMs
+          ? row.periodEndMs
+          : row.periodStartMs <= row.detectedAtMs
+            ? row.periodStartMs
+            : null;
+      return atMs === null ? [] : [{ atMs, approximate: row.approximate ?? false }];
+    })
+    .filter((point) => point.atMs <= nowMs);
+  const exactPoints = rawPoints.filter((point) => !point.approximate);
   const points = [
-    ...new Set(
-      rows.flatMap((row) => {
-        if (row.detectedAtMs >= row.periodEndMs) return [row.periodEndMs];
-        return row.periodStartMs <= row.detectedAtMs ? [row.periodStartMs] : [];
-      }),
-    ),
-  ]
-    .filter((point) => point <= nowMs)
-    .sort((a, b) => a - b);
+    ...new Map(
+      rawPoints
+        .filter(
+          (point) =>
+            !point.approximate ||
+            !exactPoints.some(
+              (exact) => Math.abs(exact.atMs - point.atMs) <= ESTIMATE_SUPERSEDE_MS,
+            ),
+        )
+        .sort((a, b) => Number(b.approximate) - Number(a.approximate))
+        .map((point) => [point.atMs, point] as const),
+    ).values(),
+  ].sort((a, b) => a.atMs - b.atMs);
   const plausible = (startMs: number, endMs: number) =>
     windowMs !== null && endMs - startMs <= windowMs * 1.5;
-  const boundaries = points.slice(1).flatMap((endMs, index) => {
-    const startMs = points[index] ?? endMs;
-    return plausible(startMs, endMs) ? [{ startMs, endMs }] : [];
+  const boundaries = points.slice(1).flatMap((end, index) => {
+    const start = points[index] ?? end;
+    return plausible(start.atMs, end.atMs)
+      ? [
+          {
+            startMs: start.atMs,
+            endMs: end.atMs,
+            approximate: start.approximate || end.approximate,
+          },
+        ]
+      : [];
   });
   const latest = points.at(-1);
   if (
     latest !== undefined &&
     nextResetAtMs !== null &&
     nextResetAtMs > nowMs &&
-    plausible(latest, nextResetAtMs)
+    plausible(latest.atMs, nextResetAtMs)
   ) {
-    boundaries.push({ startMs: latest, endMs: nextResetAtMs });
+    boundaries.push({
+      startMs: latest.atMs,
+      endMs: nextResetAtMs,
+      approximate: latest.approximate,
+    });
   }
   return boundaries;
 }

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-13 · 历史配额周期使用公开公告补齐近似边界（OAuth quota / Admin providers，docs/04/11，原则 3/7）
+
+- **来源边界**：`codex-reset.com` 的公开 timeline 没有个人账号的 `effective_at`；历史确认公告使用 `announced_at`，带官方窗口的预告使用窗口中点，均只能标记为 `approximate=true`，不能冒充账号真实重置时间。Helm 已记录的 header/reset-credit 时间继续保持精确，并在 ±3 小时内覆盖公告估算。
+- **存储与读取**：复用 `oauth_reset_period`，SQLite/Postgres 只增加 `approximate` 列；估算边界仅参与历史周期切分，不进入 `latestResetAt`，因此不会改变实时请求 bucket 或 reset-credit 判断。同一主键后来收到精确观测时，只允许 `approximate=true → false` 单向升级，估算数据不能覆盖精确事实。
+- **重算方式**：`oauth_usage` 是保留时间戳的小时/边界 bucket，周期 totals 在 Admin API 读取时按边界动态聚合，因此历史修复只需追加缺失的近似 reset facts，不重写或复制请求计数。发布后生产回填必须先备份数据库、预演候选/冲突，并验证拆分前后 requests/tokens/cost 守恒。
+
 ## 2026-08-11 · Admin Memory 范围分页与 Key 点查（Admin / Store，docs/11/13，原则 1/7）
 
 - **分页契约**：`/admin/api/memory/scopes` 采用与 facts/reflections 一致的 `{ rows, total }` 响应；默认 50、最大 200。SQLite/Postgres 都在聚合结果上执行服务端 `LIMIT/OFFSET`，并以 scope tuple 作为 `lastUpdated` 并列时的稳定次序，避免翻页重复或遗漏。
@@ -75,18 +81,11 @@
 - **未修的次要项**：已限流账号（weekly 100%）的 `/wham/usage` PULL 本身拿不到富数据，是 OpenAI 上游对限流账号的行为，非 helm bug；weekly 重置后自愈。
 - **测试**：sqlite round-trip + header-PUSH 保留；pg（pglite）round-trip + 保留 + fail-open；admin route 冷缓存 fallback（fullSeam 无 getCachedCodexQuota → 用行持久化 metadata）。core store 807 全绿；admin oauth route 86 全绿；typecheck + lint 全绿。
 
-## 2026-08-07 · context_management 转发给 generic responses 导致 grok 422（Protocol / provider execution，docs/04/05，原则 3/5/8）
-
-- **现场**：anthropic_messages 请求 fallback 到 xAI grok-4.5（generic openai_responses profile）时，`context_management` 以 Anthropic 对象形状 `{ edits: [...] }` 发出，xAI Responses 反序列化要 array → 422 `invalid type: map, expected a sequence`（正是上一条 prompt-too-long 现场里 grok 那个无关 422）。
-- **根因**：`context_management` 是 Anthropic 原生上下文编辑控制，因 Codex GPT-5.6 订阅工作（`680e570a`）被加进 `openai_responses` 转发 allowlist——供 **Codex 官方**端点消费；但 **generic** profile（grok）继承同一 allowlist，不认这个字段且形状不符。
-- **修复（两条路径都堵）**：(1) **翻译路径** `renderProviderRawForTarget`：对 `targetIsGenericResponsesProfile` 从 allowed 删除 `context_management`，与其上方既有 `responses_input_items` 删除同理同位。(2) **同协议 passthrough 路径**（Codex review 补漏）：`openai_responses → generic grok` 同协议可 verbatim passthrough 绕过 allowlist；在 `prepareNativeRequestForUpstream`（native body 唯一 chokepoint，已有 Codex/Anthropic sanitizer）新增：generic profile 时删除 body 里的 `context_management`（任何形状；对 generic 都是不可执行的 Anthropic 控制），mutation 记 `context_management_stripped_for_generic`。Codex 官方（非 generic）两路都保留。
-- **测试**：三向锁定——翻译 strip 到 generic xai（mutation `provider_raw_stripped_for_target`）+ 非 generic Codex-official 保留 + 同协议 passthrough strip（mutation `context_management_stripped_for_generic`）。execute.test.ts 169 全绿；execute/pipeline/responses/core-responses 合计 539 全绿。
-- **遗留**：allowlist 里 `text`/`reasoning_config`/`truncation`/`logit_bias`/`include`/`responses_tools`/`container` 等对 generic provider 是否有同类 array/object 形状风险，Codex 抽查未确认第二例，未逐一核；本次只修实测触发的 `context_management`。
-
 - **2026-08-07 · 真实上游超长溢出链耗尽终态**：真实 `prompt is too long: N > M` 在链耗尽时胜出为客户端 400，但仍允许更大窗口候选继续 fallback；弱措辞只认结构化 error message，完整原文经 git history 回溯。
 
 ## 历史条目摘要（最新要点）
 
+- **2026-08-07 · generic Responses 剥离 Anthropic `context_management`**：翻译与同协议 passthrough 都在 generic profile 边界删除不兼容字段，Codex official 保留；完整原文经 git history 回溯。
 - **2026-08-07 · OAuth 账号限流后继续用剩余点数**：每账号开关只绕过 usage-limit park，model-scoped 与 transient 冷却保持不变；完整原文经 git history 回溯。
 - **2026-08-07 · per-key `max_reasoning_effort` 上限**：统一三协议身份 caps 映射，避免内联副本漂移导致上限静默失效，完整原文经 git history 回溯。
 - **2026-08-06 · HALF_OPEN 探测锁释放与所有权令牌**：所有被允许的 provider/image 尝试都结算 breaker，HALF_OPEN abort 仅凭匹配的 probe token 释放对应探针，避免锁永久卡住或旧请求误清新探针；完整原文经 git history 回溯。

--- a/packages/core/src/provider/oauth/usage-periods.test.ts
+++ b/packages/core/src/provider/oauth/usage-periods.test.ts
@@ -267,6 +267,31 @@ describe("computeUsagePeriods", () => {
     expect(out.periods[2]?.periodStartMs).toBe(90 * HOUR);
   });
 
+  it("keeps announcement-estimated reset boundaries approximate", () => {
+    const now = 107 * HOUR;
+    const reset = 110 * HOUR;
+    const out = computeUsagePeriods({
+      windows: [win("5h", reset, null)],
+      buckets: buckets(95 * HOUR, 12, 100),
+      nowMs: now,
+      dataStartMs: 0,
+      limit: 2,
+      recordedBoundaries: {
+        "5h": [{ startMs: 101 * HOUR, endMs: 106 * HOUR, approximate: true }],
+      },
+    });
+
+    expect(currentFor(out, "5h")).toMatchObject({
+      periodStartMs: 106 * HOUR,
+      approximate: true,
+    });
+    expect(out.periods[0]).toMatchObject({
+      periodStartMs: 101 * HOUR,
+      periodEndMs: 106 * HOUR,
+      approximate: true,
+    });
+  });
+
   it("ignores recorded boundaries that overlap or postdate the current period", () => {
     const now = 107 * HOUR;
     const reset = 110 * HOUR; // current starts at 105h

--- a/packages/core/src/provider/oauth/usage-periods.ts
+++ b/packages/core/src/provider/oauth/usage-periods.ts
@@ -49,6 +49,7 @@ export function detectQuotaResetPeriods(input: {
       periodStartMs: oldStart,
       periodEndMs: resetAtMs,
       detectedAtMs: input.observedAtMs,
+      approximate: false,
     });
   }
 
@@ -67,11 +68,13 @@ export interface ComputeUsagePeriodsInput {
   dataStartMs: number;
   // Max historical periods to roll back per window.
   limit: number;
-  // Optional REAL reset boundaries per window key (from oauth_reset_period), each a
-  // half-open [startMs, endMs). When present, history uses these exact boundaries
-  // (approximate:false) and only rolls back the fixed-window approximation for the
-  // GAP older than the earliest recorded boundary. Absent/empty → all-approximate.
-  recordedBoundaries?: Record<string, Array<{ startMs: number; endMs: number }>>;
+  // Optional recorded reset boundaries per window key (from oauth_reset_period), each
+  // a half-open [startMs, endMs). Exact observations remain exact; public-announcement
+  // estimates keep their approximate marker. Older gaps use fixed-window rollback.
+  recordedBoundaries?: Record<
+    string,
+    Array<{ startMs: number; endMs: number; approximate?: boolean }>
+  >;
 }
 
 // Cadence-derived boundaries are exact only on an hour floor. Recorded reset points can
@@ -160,18 +163,21 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
     let recIdx = 0;
     // Skip recordings that end AFTER reset (future / already-superseded).
     while (recIdx < recorded.length && (recorded[recIdx]?.endMs ?? 0) > reset + tol) recIdx++;
-    let curBoundaryReal = false;
+    let curBoundaryRecorded = false;
+    let curBoundaryApproximate = false;
     const openRow = recorded[recIdx];
     if (openRow && abuts(openRow.endMs, reset)) {
       curStart = openRow.startMs;
-      curBoundaryReal = true; // start came from a real recorded boundary
+      curBoundaryRecorded = true;
+      curBoundaryApproximate = openRow.approximate ?? false;
       recIdx++;
     } else if (openRow && openRow.endMs <= nowMs && openRow.endMs > curStart) {
       // A provider/reset-credit can cut a window short without changing its next reset
       // deadline. The newest CLOSED period then ends at the real reset point inside the
       // cadence-derived current span; start current usage there.
       curStart = openRow.endMs;
-      curBoundaryReal = true;
+      curBoundaryRecorded = true;
+      curBoundaryApproximate = openRow.approximate ?? false;
     }
 
     // Current: [curStart, min(reset, now)). Exact only when the START boundary is a
@@ -182,7 +188,9 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
     // review P2R3-1). A real recorded curStart still needs hour-alignment.
     const curEnd = Math.min(reset, nowMs);
     const curExact =
-      !boundaryAdvanced && (curBoundaryReal || (isHourAligned(reset) && isHourAligned(curStart)));
+      !boundaryAdvanced &&
+      !curBoundaryApproximate &&
+      (curBoundaryRecorded || (isHourAligned(reset) && isHourAligned(curStart)));
     if (curEnd > curStart) {
       const sums = sumWindow(buckets, curStart, curEnd);
       current.push({
@@ -220,7 +228,7 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
       // start is strictly older — its real start becomes the next cursor.
       if (rec && cursor - rec.endMs <= tol && rec.startMs < cursor) {
         start = rec.startMs;
-        approximate = false;
+        approximate = rec.approximate ?? false;
         recIdx++;
       } else {
         start = cursor - winMs;

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -1563,8 +1563,8 @@ export interface OAuthQuotaStore {
 // same reset folds to one row). OBSERVABILITY only — writes are FAIL-OPEN at the call
 // site (a missed reset just leaves that span on the approximate path). No secret column.
 export interface OAuthResetPeriodStore {
-  // Persist one detected reset boundary; a repeat of the same (provider, account,
-  // window, start) is a no-op.
+  // Persist one detected reset boundary. Repeats are no-ops except that an exact
+  // observation may replace an estimate with the same identity.
   record(row: OAuthResetPeriod): Promise<void>;
   // Recorded boundaries for one account/window, most recent first, capped by `limit`.
   // Feeds the usage-period read so history slices on true boundaries where available.

--- a/packages/core/src/store/postgres/migrate.test.ts
+++ b/packages/core/src/store/postgres/migrate.test.ts
@@ -1361,4 +1361,23 @@ describe("runPgMigrations — memory job lease generation", () => {
     expect(rows.rows).toEqual([{ status: "pending", lease_generation: 0 }]);
     await db.$close();
   });
+
+  it("v50 preserves reset rows and marks legacy boundaries exact", async () => {
+    const db = await createPgliteDb();
+    await db.execute(
+      sql.raw(`INSERT INTO oauth_reset_period (
+        provider_id, account, window_key, period_start_ms, period_end_ms, detected_at_ms
+      ) VALUES ('openai-codex', 'a', 'primary', 1, 2, 2)`),
+    );
+    await db.execute(sql.raw("ALTER TABLE oauth_reset_period DROP COLUMN approximate"));
+    await db.execute(sql.raw("DELETE FROM _migrations WHERE version = 50"));
+
+    await runPgMigrations(db);
+
+    const rows = (await db.execute(sql.raw("SELECT approximate FROM oauth_reset_period"))) as {
+      rows: Array<{ approximate: boolean }>;
+    };
+    expect(rows.rows).toEqual([{ approximate: false }]);
+    await db.$close();
+  });
 });

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1346,6 +1346,19 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Pg mirror of SQLite v51: retain whether a historical reset boundary is estimated.
+    version: 50,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "oauth_reset_period", ["provider_id"])) {
+        await db.execute(
+          sql.raw(
+            "ALTER TABLE oauth_reset_period ADD COLUMN IF NOT EXISTS approximate BOOLEAN NOT NULL DEFAULT FALSE",
+          ),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {
@@ -1365,6 +1378,7 @@ async function pgTableHasColumns(
     | "memory_facts"
     | "memory_jobs"
     | "oauth_quota"
+    | "oauth_reset_period"
     | "session_revisions"
     | "telemetry",
   requiredColumns: readonly string[],

--- a/packages/core/src/store/postgres/oauth-reset-period.ts
+++ b/packages/core/src/store/postgres/oauth-reset-period.ts
@@ -5,30 +5,40 @@ import type { PgDb } from "./migrate.js";
 import { oauthResetPeriod } from "./schema.js";
 
 // PgOAuthResetPeriodStore — pg mirror of the sqlite adapter. Idempotent append via
-// onConflictDoNothing; bigint columns marshal as strings, so Number()-normalize before
-// the shared schema parse.
+// onConflictDoNothing for estimates; a later exact observation may replace one. Bigint
+// columns marshal as strings, so Number()-normalize before the shared schema parse.
 export class PgOAuthResetPeriodStore implements OAuthResetPeriodStore {
   constructor(private readonly db: PgDb) {}
 
   async record(row: OAuthResetPeriod): Promise<void> {
-    await this.db
-      .insert(oauthResetPeriod)
-      .values({
-        providerId: row.providerId,
-        account: row.account,
-        windowKey: row.windowKey,
-        periodStartMs: row.periodStartMs,
+    const insert = this.db.insert(oauthResetPeriod).values({
+      providerId: row.providerId,
+      account: row.account,
+      windowKey: row.windowKey,
+      periodStartMs: row.periodStartMs,
+      periodEndMs: row.periodEndMs,
+      detectedAtMs: row.detectedAtMs,
+      approximate: row.approximate,
+    });
+    const target = [
+      oauthResetPeriod.providerId,
+      oauthResetPeriod.account,
+      oauthResetPeriod.windowKey,
+      oauthResetPeriod.periodStartMs,
+    ];
+    if (row.approximate) {
+      await insert.onConflictDoNothing({ target });
+      return;
+    }
+    await insert.onConflictDoUpdate({
+      target,
+      set: {
         periodEndMs: row.periodEndMs,
         detectedAtMs: row.detectedAtMs,
-      })
-      .onConflictDoNothing({
-        target: [
-          oauthResetPeriod.providerId,
-          oauthResetPeriod.account,
-          oauthResetPeriod.windowKey,
-          oauthResetPeriod.periodStartMs,
-        ],
-      });
+        approximate: false,
+      },
+      setWhere: eq(oauthResetPeriod.approximate, true),
+    });
   }
 
   async queryPeriods(
@@ -57,6 +67,7 @@ export class PgOAuthResetPeriodStore implements OAuthResetPeriodStore {
         periodStartMs: Number(r.periodStartMs),
         periodEndMs: Number(r.periodEndMs),
         detectedAtMs: Number(r.detectedAtMs),
+        approximate: r.approximate,
       }),
     );
   }
@@ -76,6 +87,7 @@ export class PgOAuthResetPeriodStore implements OAuthResetPeriodStore {
           eq(oauthResetPeriod.account, account),
           ...(windowKey === undefined ? [] : [eq(oauthResetPeriod.windowKey, windowKey)]),
           lte(oauthResetPeriod.periodEndMs, beforeMs),
+          eq(oauthResetPeriod.approximate, false),
           sql`${oauthResetPeriod.detectedAtMs} >= ${oauthResetPeriod.periodEndMs}`,
         ),
       )

--- a/packages/core/src/store/postgres/oauth-usage.test.ts
+++ b/packages/core/src/store/postgres/oauth-usage.test.ts
@@ -243,6 +243,7 @@ describe("PgOAuthResetPeriodStore (pglite)", () => {
       account: "a@x.com",
       windowKey: "5h",
       detectedAtMs: 19500,
+      approximate: false,
     };
     await store.record({ ...base, periodStartMs: 1000, periodEndMs: 19000 });
     await store.record({ ...base, periodStartMs: 1000, periodEndMs: 19000, detectedAtMs: 99999 }); // dup PK → no-op
@@ -253,7 +254,21 @@ describe("PgOAuthResetPeriodStore (pglite)", () => {
     // numbers, not pg bigint strings; descending by periodEndMs
     expect(rows.map((r) => r.periodEndMs)).toEqual([37000, 19000]);
     expect(rows[1]?.detectedAtMs).toBe(19500); // first write wins
+    await store.record({
+      ...base,
+      periodStartMs: 37000,
+      periodEndMs: 38000,
+      approximate: true,
+    });
+    expect((await store.queryPeriods("anthropic", "a@x.com", "5h", 1))[0]?.approximate).toBe(true);
     expect(await store.queryPeriods("anthropic", "nobody", "5h", 10)).toHaveLength(0);
+
+    await store.record({ ...base, periodStartMs: 39000, periodEndMs: 40000, approximate: true });
+    await store.record({ ...base, periodStartMs: 39000, periodEndMs: 41000, approximate: false });
+    await store.record({ ...base, periodStartMs: 39000, periodEndMs: 42000, approximate: true });
+    expect(await store.queryPeriods("anthropic", "a@x.com", "5h", 1)).toMatchObject([
+      { periodEndMs: 41000, approximate: false },
+    ]);
 
     await store.record({
       ...base,
@@ -268,6 +283,14 @@ describe("PgOAuthResetPeriodStore (pglite)", () => {
       periodStartMs: 55000,
       periodEndMs: 90000,
       detectedAtMs: 60000,
+    });
+    await store.record({
+      ...base,
+      windowKey: "7d",
+      periodStartMs: 60000,
+      periodEndMs: 65000,
+      detectedAtMs: 65000,
+      approximate: true,
     });
     expect(await store.latestResetAt("anthropic", "a@x.com", 70000)).toBe(55000);
     expect(await store.latestResetAt("anthropic", "a@x.com", 70000, "5h")).toBe(19000);

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -478,8 +478,8 @@ export const oauthQuota = pgTable(
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );
 
-// Per-account RESET-PERIOD boundaries — pg mirror of the sqlite oauth_reset_period
-// table. Append-only history of real reset events; PK makes re-detection idempotent.
+// Per-account RESET-PERIOD boundaries — pg mirror of SQLite, including explicitly
+// marked public-announcement estimates. The PK makes re-detection idempotent.
 export const oauthResetPeriod = pgTable(
   "oauth_reset_period",
   {
@@ -489,6 +489,7 @@ export const oauthResetPeriod = pgTable(
     periodStartMs: bigint("period_start_ms", { mode: "number" }).notNull(), // prior resetsAtMs
     periodEndMs: bigint("period_end_ms", { mode: "number" }).notNull(), // new resetsAtMs
     detectedAtMs: bigint("detected_at_ms", { mode: "number" }).notNull(),
+    approximate: boolean("approximate").notNull().default(false),
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account, t.windowKey, t.periodStartMs] })],
 );

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1389,6 +1389,18 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Public reset announcements can fill historical gaps, but remain estimates.
+    version: 51,
+    run: (db) => {
+      if (
+        sqliteTableHasColumns(db, "oauth_reset_period", ["provider_id"]) &&
+        !sqliteTableHasColumns(db, "oauth_reset_period", ["approximate"])
+      ) {
+        db.exec("ALTER TABLE oauth_reset_period ADD COLUMN approximate INTEGER NOT NULL DEFAULT 0");
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/oauth-reset-period.test.ts
+++ b/packages/core/src/store/sqlite/oauth-reset-period.test.ts
@@ -16,6 +16,7 @@ function period(over: Partial<OAuthResetPeriod> = {}): OAuthResetPeriod {
     periodStartMs: 1000,
     periodEndMs: 19000,
     detectedAtMs: 19500,
+    approximate: false,
     ...over,
   };
 }
@@ -30,6 +31,27 @@ describe("SqliteOAuthResetPeriodStore", () => {
     const rows = await store.queryPeriods("anthropic", "a@x.com", "5h", 10);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.detectedAtMs).toBe(19500);
+    close();
+  });
+
+  it("round-trips an announcement-estimated boundary", async () => {
+    const { store, close } = freshStore();
+    await store.record(period({ approximate: true }));
+    expect(await store.queryPeriods("anthropic", "a@x.com", "5h", 10)).toMatchObject([
+      { approximate: true },
+    ]);
+    close();
+  });
+
+  it("lets an exact observation replace an estimate with the same period start", async () => {
+    const { store, close } = freshStore();
+    await store.record(period({ periodEndMs: 18000, approximate: true }));
+    await store.record(period({ periodEndMs: 19000, approximate: false }));
+    await store.record(period({ periodEndMs: 20000, approximate: true }));
+
+    expect(await store.queryPeriods("anthropic", "a@x.com", "5h", 10)).toMatchObject([
+      { periodEndMs: 19000, approximate: false },
+    ]);
     close();
   });
 
@@ -76,6 +98,15 @@ describe("SqliteOAuthResetPeriodStore", () => {
     );
     await store.record(
       period({ windowKey: "7d", periodStartMs: 3000, periodEndMs: 9000, detectedAtMs: 4000 }),
+    );
+    await store.record(
+      period({
+        windowKey: "7d",
+        periodStartMs: 4000,
+        periodEndMs: 4500,
+        detectedAtMs: 4500,
+        approximate: true,
+      }),
     );
 
     expect(await store.latestResetAt("anthropic", "a@x.com", 5000)).toBe(3000);

--- a/packages/core/src/store/sqlite/oauth-reset-period.ts
+++ b/packages/core/src/store/sqlite/oauth-reset-period.ts
@@ -5,29 +5,40 @@ import type { SqliteDb } from "./migrate.js";
 import { oauthResetPeriod } from "./schema.js";
 
 // SqliteOAuthResetPeriodStore — append-only history of real reset boundaries. `record`
-// is idempotent via onConflictDoNothing on the composite PK, so a reset re-seen by
-// repeated quota refreshes lands once. Pure observability — no key/payload.
+// is idempotent on the composite PK; a later exact observation may replace an estimate.
+// Pure observability — no key/payload.
 export class SqliteOAuthResetPeriodStore implements OAuthResetPeriodStore {
   constructor(private readonly db: SqliteDb) {}
 
   async record(row: OAuthResetPeriod): Promise<void> {
-    this.db
-      .insert(oauthResetPeriod)
-      .values({
-        providerId: row.providerId,
-        account: row.account,
-        windowKey: row.windowKey,
-        periodStartMs: row.periodStartMs,
-        periodEndMs: row.periodEndMs,
-        detectedAtMs: row.detectedAtMs,
-      })
-      .onConflictDoNothing({
-        target: [
-          oauthResetPeriod.providerId,
-          oauthResetPeriod.account,
-          oauthResetPeriod.windowKey,
-          oauthResetPeriod.periodStartMs,
-        ],
+    const insert = this.db.insert(oauthResetPeriod).values({
+      providerId: row.providerId,
+      account: row.account,
+      windowKey: row.windowKey,
+      periodStartMs: row.periodStartMs,
+      periodEndMs: row.periodEndMs,
+      detectedAtMs: row.detectedAtMs,
+      approximate: row.approximate,
+    });
+    const target = [
+      oauthResetPeriod.providerId,
+      oauthResetPeriod.account,
+      oauthResetPeriod.windowKey,
+      oauthResetPeriod.periodStartMs,
+    ];
+    if (row.approximate) {
+      insert.onConflictDoNothing({ target }).run();
+      return;
+    }
+    insert
+      .onConflictDoUpdate({
+        target,
+        set: {
+          periodEndMs: row.periodEndMs,
+          detectedAtMs: row.detectedAtMs,
+          approximate: false,
+        },
+        setWhere: eq(oauthResetPeriod.approximate, true),
       })
       .run();
   }
@@ -69,6 +80,7 @@ export class SqliteOAuthResetPeriodStore implements OAuthResetPeriodStore {
           eq(oauthResetPeriod.account, account),
           ...(windowKey === undefined ? [] : [eq(oauthResetPeriod.windowKey, windowKey)]),
           lte(oauthResetPeriod.periodEndMs, beforeMs),
+          eq(oauthResetPeriod.approximate, false),
           sql`${oauthResetPeriod.detectedAtMs} >= ${oauthResetPeriod.periodEndMs}`,
         ),
       )

--- a/packages/core/src/store/sqlite/schema.test.ts
+++ b/packages/core/src/store/sqlite/schema.test.ts
@@ -105,6 +105,33 @@ describe("sqlite schema + migrations", () => {
     }
   });
 
+  it("v51 preserves reset rows and marks legacy boundaries exact", () => {
+    const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v51-reset-estimates-"));
+    const path = join(dir, "helm.db");
+    try {
+      runMigrations(path);
+      const seed = new Database(path);
+      seed.exec(`
+        INSERT INTO oauth_reset_period (
+          provider_id, account, window_key, period_start_ms, period_end_ms, detected_at_ms
+        ) VALUES ('openai-codex', 'a', 'primary', 1, 2, 2);
+        ALTER TABLE oauth_reset_period DROP COLUMN approximate;
+        DELETE FROM _migrations WHERE version = 51;
+      `);
+      seed.close();
+
+      runMigrations(path);
+
+      const after = new Database(path);
+      expect(after.prepare("SELECT approximate FROM oauth_reset_period").get()).toEqual({
+        approximate: 0,
+      });
+      after.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("upgrades a real pre-unique-index memory_jobs table with duplicate open jobs", () => {
     const dir = mkdtempSync(join(tmpdir(), "helm-sqlite-v13-memory-jobs-"));
     const path = join(dir, "helm.db");

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -354,12 +354,9 @@ export const oauthQuota = sqliteTable(
   (t) => [primaryKey({ columns: [t.providerId, t.account] })],
 );
 
-// Per-account RESET-PERIOD boundaries — the append-only history the latest-wins
-// oauth_quota snapshot lacks. One row per real reset event detected during a quota
-// refresh: [period_start_ms, period_end_ms) is the window that just ended (its start
-// = the prior resetsAtMs, its end = the new resetsAtMs). Lets the usage-period read
-// slice history on TRUE boundaries going forward instead of rolling back a fixed
-// window length. Pure observability, no secret column (principle 7).
+// Per-account RESET-PERIOD boundaries — the history the latest-wins oauth_quota
+// snapshot lacks. Exact observations and explicitly marked public-announcement
+// estimates share the table. Pure observability, no secret column (principle 7).
 export const oauthResetPeriod = sqliteTable(
   "oauth_reset_period",
   {
@@ -369,6 +366,7 @@ export const oauthResetPeriod = sqliteTable(
     periodStartMs: integer("period_start_ms").notNull(), // prior resetsAtMs
     periodEndMs: integer("period_end_ms").notNull(), // new resetsAtMs
     detectedAtMs: integer("detected_at_ms").notNull(), // when the refresh saw it
+    approximate: integer("approximate", { mode: "boolean" }).notNull().default(false),
   },
   // PK on (provider, account, window, start) makes re-detection idempotent — the same
   // reset seen by repeated refreshes folds to one row.

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -545,9 +545,8 @@ export const OAuthUsagePeriodsSchema = z
 
 export type OAuthUsagePeriods = z.infer<typeof OAuthUsagePeriodsSchema>;
 
-// One RECORDED reset period — an append-only fact captured when an upstream snapshot or
-// reset-credit action closes the prior allowance window. [periodStartMs, periodEndMs)
-// is the window that actually ended.
+// One recorded reset period. Exact rows come from an upstream snapshot/reset-credit;
+// approximate rows may come from a public announcement when account evidence is absent.
 export const OAuthResetPeriodSchema = z
   .object({
     providerId: z.string(),
@@ -556,6 +555,7 @@ export const OAuthResetPeriodSchema = z
     periodStartMs: z.number().int(),
     periodEndMs: z.number().int(),
     detectedAtMs: z.number().int(),
+    approximate: z.boolean().default(false),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- persist whether OAuth reset boundaries are exact or announcement-estimated
- prefer account-observed reset timestamps within three hours and keep estimates out of live reset-credit/bucket decisions
- recompute historical period totals on read while preserving the approximate marker

## Verification
- `CI=true pnpm exec vitest run packages/core/src/provider/oauth/usage-periods.test.ts packages/core/src/store/sqlite/oauth-reset-period.test.ts packages/core/src/store/postgres/oauth-usage.test.ts apps/gateway/src/routes/admin/oauth.test.ts packages/core/src/store/sqlite/schema.test.ts packages/core/src/store/postgres/migrate.test.ts --coverage.enabled=false` (169 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Production backfill plan
After release deployment, add only high-confidence public announcement boundaries missing an account exact observation within +/-3h, mark them approximate, and verify requests/tokens/cost conservation before and after.