### PR TITLE
chore(release): v0.28.69

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.68",
+  "version": "0.28.69",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API to v0.28.69
- release the quota reset observation correctness fix from #747

## Release scope
- usage-percentage drops without a deadline change remain approximate
- exact deadline/reset-credit observations keep precedence