### PR TITLE
fix(oauth): avoid false reconnect state from proxy 403 responses

### DIFF
--- a/apps/gateway/src/oauth/admin-oauth.test.ts
+++ b/apps/gateway/src/oauth/admin-oauth.test.ts
@@ -642,6 +642,42 @@ describe("createOAuthAdmin", () => {
     expect(settings.schedulable).toBe(false);
   });
 
+  it("does not persist a bare Codex refresh 403 as a dead credential", async () => {
+    const { tokens, config } = makeStores();
+    await tokens.upsert({
+      providerId: "openai-codex",
+      account: "proxied",
+      accessEnc: encryptSecret("expired", KEY),
+      refreshEnc: encryptSecret("still-present", KEY),
+      expiresAt: 1_000,
+      meta: null,
+      updatedAt: 1,
+    });
+    const admin = createOAuthAdmin({
+      store: tokens,
+      encKey: KEY,
+      config,
+      now: () => 10_000_000,
+      makeFetch: () => vi.fn(async () => json({ error: "access_denied" }, 403)),
+    });
+
+    const account = (await admin.listStatus()).providers.find((p) => p.id === "openai-codex")
+      ?.accounts[0];
+    const settings = getAccountSettings(
+      await loadAccountSettings(config, KEY),
+      "openai-codex",
+      "proxied",
+    );
+
+    expect(account).toMatchObject({
+      healthy: false,
+      credentialFailed: false,
+      schedulable: true,
+    });
+    expect(settings.credentialFailedAt).toBeUndefined();
+    expect(settings.schedulable).toBeUndefined();
+  });
+
   it("listStatus treats a persisted credential failure as reconnect-only and does not refresh", async () => {
     const { tokens, config } = makeStores();
     await tokens.upsert({

--- a/apps/gateway/src/oauth/credential-failure.ts
+++ b/apps/gateway/src/oauth/credential-failure.ts
@@ -2,11 +2,10 @@ import { TokenRefreshError, UpstreamError } from "@helm/core";
 
 export function isPermanentOAuthCredentialFailure(err: unknown): boolean {
   if (err instanceof TokenRefreshError) {
-    if (err.permanentCredentialFailure) return true;
-    return err.httpStatus === 400 || err.httpStatus === 401 || err.httpStatus === 403;
+    return err.permanentCredentialFailure;
   }
   if (err instanceof UpstreamError) {
-    return err.upstreamStatus === 401 || err.upstreamStatus === 403;
+    return err.upstreamStatus === 401;
   }
   return false;
 }

--- a/apps/gateway/src/routes/admin/oauth-test-route.test.ts
+++ b/apps/gateway/src/routes/admin/oauth-test-route.test.ts
@@ -175,6 +175,7 @@ describe("POST /admin/api/oauth/:provider/test", () => {
                   throw new TokenRefreshError(
                     "oauth refresh failed (openai-codex, status 401)",
                     401,
+                    true,
                   );
                 },
               };

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1269,10 +1269,6 @@ export async function synthesizeOAuthProviders(
       members,
       now: () => Date.now(),
       selectionStrategy,
-      // grok-build treats only inference 401 as an invalid xAI credential. A 403 can
-      // be a policy/content denial and must reach normal fallback without parking the
-      // subscription account. Other OAuth providers keep the legacy 401/403 policy.
-      upstreamCredentialFailureStatuses: providerId === "xai" ? [401] : undefined,
       onSelect: (account, selection) => {
         log("info", "oauth.pool.select", {
           providerId,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-13 · OAuth 永久失效只认明确凭证拒绝（OAuth provider pool / Admin providers，docs/04/11，原则 3/7）
+
+- **根因与修复**：旧逻辑仅按 HTTP 状态把 refresh `400/401/403` 与 inference `401/403` 全部持久化为 `needs reconnect`；代理、地域或 WAF 返回的裸 `403` 因此会永久摘除仍有有效 refresh token 的账号。现在 provider token 边界只把有界解析出的标准 `invalid_grant`、Copilot token mint `401` 与 Codex refresh 身份变化标为永久凭证拒绝；裸 refresh `403` 只短暂冷却，inference `403` 走正常错误/fallback，不写 `credentialFailedAt`。错误正文仍不进入消息、日志或存储。
+- **兼容与恢复**：真正永久失效仍 fail-closed 停止调度，成功 reconnect 继续清除标记；不批量清除升级前的历史失败标记，因为无法证明它们都是误判，受影响账号需在修复代理后按原标签重连。无 schema/migration、新依赖或 UI 契约变化。
+
 ## 2026-08-13 · Grok 4.6 补齐 Agent 能力、价格与 lane 投影（Catalog / routing，docs/04/07，原则 2/3/6）
 
 - **根因**：xAI OAuth 实时 catalog 已把 `grok-4.6` 合成为可执行 alias，但签入的手工 catalog 没有对应条目；执行层对只有实时元数据的新 xAI 模型保守合成 `supportsTools:false`，所以裸 chat 可过，Grok Build 默认携带 `tools` 时在 provider 调用前被能力过滤为 `capability_unsatisfiable`。`/v1/models` 同样只能列出 id，无法附带 capabilities/pricing/lane membership。
@@ -66,15 +71,9 @@
 - **审查后收紧**：媒体 alias 在 auto 模式默认可用，但 manual 模式严格服从每个账号的 `enabledModels`；视频模型和单图/多参考图 schema 一一绑定，聊天协议在执行前拒绝 xAI `outputImage` 与所有 `outputVideo` 模型，同时保留 Gemini 等供应商通过原生聊天协议返回图片的既有能力。OAuth pool 在付费 POST 前回报所选账号，视频 reservation 先持久化账号，图片/视频的 `outcome_unknown` telemetry 也保留账号归因；原子媒体 reservation 复用 registry 的节流 prune，但 reservation 已成功后 prune 失败按辅助维护 fail-open，避免把成功的付费单写误报为 `outcome_unknown`；Providers 卡片优先展示媒体 badge。
 - **刻意延后**：ZDR `output.upload_url` 在 request/upstream/response/error 四类正文都完成预签名 query 脱敏前由严格 schema 拒绝；本机 SuperGrok 图片/视频真实 canary 已通过，staging canary、GitHub Docker CI 与生产单副本观察仍是发布 No-Go 门禁。
 
-## 2026-08-08 · 会话转录客户端重建，绕开服务端内存阀（Admin / requests debug，docs/07，原则 1）
-
-- **现场**：未捕获正文的长 Codex/Responses 会话，请求详情页显示「会话转录过大，无法安全恢复」。数据都在（`session_revisions` 纯 TEXT 增量），但服务端重建 `getSessionRequest`（`apps/gateway/src/routes/admin/requests.ts`）在拉第一页前就 `responseAdmission.acquire(recoveryMaxWireBytes=响应窗口/放大/2)` 预留整窗内存；长链超阀 → `session_recovery_limited`。这是**故意保守**：admin 看后台不该和线上流量抢内存。
-- **方案（Lukin 拍板"吐给客户端自己重建"）**：新增 `GET /admin/api/requests/:id/session-revisions?after=<seq>`，只分页流式吐 raw revision 行（固定 `maxBytes=4MB`/页 + `limit=100`，`nextSequence` 游标），**不做服务端重建、不预留整窗**。前端 `session_recovery_limited` 分支换成「点击加载」懒加载按钮 → 循环拉页攒链 → 浏览器本地重建 → `JsonViewer` 渲染。服务端常驻内存降到「一页」。旧服务端重建路径保留（小转录仍走它，快）。
-- **架构取舍（AskUserQuestion 敲定）**：重建纯函数 `restoreSessionRevisionJson` 从 `packages/core/src/store/session-delta.ts` 抽到 **`@helm/shared`**（零 node 依赖、浏览器安全），core 反向 re-export（barrel 与调用方无感）；写入侧 `splitSessionRequestJson`/`hashEvents`（依赖 `node:crypto`）留在 core。admin `lib/api/requests.ts` **破例 import** shared 的这一个纯函数——打破该文件「零 core/gateway 业务逻辑」红线，理由：复制重建逻辑违反 DRY 更糟。破例已在两处注释标明。
-- **坑**：① 不能让 admin `import "@helm/core"`——core barrel 拽入 better-sqlite3/postgres/undici，浏览器 bundle 炸。② `session-revisions` 端点检查顺序：先取 sessionRef（`no_session` 更根本）再 null-check `listSessionRevisionsPage`（`session_unavailable`）。③ e2e/单测跑前须 `pnpm --filter @helm/{shared,core} build`——gateway e2e test-server 从 dist 解析 `@helm/core`，改 shared 后 core dist 会过期报 `runtimeResponseWorkAdmission` 缺失（红鲱鱼，非本改动）。④ 新增 5 个 UI 字符串须同步 7 locale + 加进 `request-detail-locales.test.ts` 的 `requestDetailPayloadKeys`（CI 门槛，要求 zh/ja/ko 真译文 ≠ 英文）；旧 key `...recover safely.` 变成孤儿但对齐无害（未跑 i18n:extract 清理）。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-08 · 会话转录客户端重建，绕开服务端内存阀**：长 Session 以 4 MiB/100 行游标分页传给浏览器本地重建，小 Session 保留服务端快路径；共享纯重建函数留在浏览器安全的 `@helm/shared`，完整原文经 git history 回溯。
 - **2026-08-07 · 真上游上下文溢出短路直返 400**：确定性上游 400/413/422 上下文溢出立即返回客户端并保留原始错误；预检估算仍允许 fallback，可重试状态不误判为客户端错误，完整原文经 git history 回溯。
 - **2026-08-07 · Codex 配额富元数据持久化**：`oauth_quota.metadata` 保存 plan/credits/limits，冷缓存读取 durable metadata；限流账号上游缺富数据时待窗口重置后自愈，完整原文经 git history 回溯。
 - **2026-08-07 · generic Responses 剥离 Anthropic `context_management`**：翻译与同协议 passthrough 都在 generic profile 边界删除不兼容字段，Codex official 保留；完整原文经 git history 回溯。

--- a/packages/core/src/provider/oauth/anthropic.ts
+++ b/packages/core/src/provider/oauth/anthropic.ts
@@ -21,6 +21,7 @@ import {
   oauthSuccessHtml,
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
+  responseIsOAuthInvalidGrant,
   throwIfOAuthLoginAborted,
   withOAuthLoginAbort,
 } from "./runtime.js";
@@ -144,10 +145,7 @@ async function postJson(
     signal: buildOAuthRequestSignal({ signal, timeoutMs: 30_000 }),
   });
   if (!res.ok) {
-    // Never echo the body — an OAuth error body can carry credential material. The
-    // status alone is safe and lets the token manager surface a diagnosable reason.
-    await res.body?.cancel().catch(() => {});
-    throw new OAuthHttpError("Anthropic", res.status);
+    throw new OAuthHttpError("Anthropic", res.status, await responseIsOAuthInvalidGrant(res));
   }
   return await consumeUpstreamBodyWithinBudget(res, parseTokenCredentials);
 }

--- a/packages/core/src/provider/oauth/github-copilot.ts
+++ b/packages/core/src/provider/oauth/github-copilot.ts
@@ -85,7 +85,7 @@ async function fetchJson(
   });
   if (!res.ok) {
     await res.body?.cancel().catch(() => {});
-    throw new OAuthHttpError("GitHub Copilot", res.status);
+    throw new OAuthHttpError("GitHub Copilot", res.status, res.status === 401);
   }
   return await readUpstreamJsonWithinBudget(res);
 }

--- a/packages/core/src/provider/oauth/openai-codex.test.ts
+++ b/packages/core/src/provider/oauth/openai-codex.test.ts
@@ -9,6 +9,7 @@ import {
   parseOpenAICodexIdentity,
   refreshOpenAICodexToken,
 } from "./openai-codex.js";
+import { OAuthHttpError } from "./runtime.js";
 import type { OAuthLoginCallbacks } from "./types.js";
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -27,12 +28,27 @@ function codexJwt(payload: Record<string, unknown>): string {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("OpenAI Codex token request error handling", () => {
-  it("throws a scrubbed HTTP error (no body echo) on a non-ok token response", async () => {
+  it("marks only an explicit invalid_grant as a permanent credential rejection", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse({ error: "invalid_grant", leak: "secret" }, 400)),
     );
-    await expect(refreshOpenAICodexToken("rt")).rejects.toThrow(/OpenAI Codex OAuth HTTP 400/);
+    await expect(refreshOpenAICodexToken("rt")).rejects.toMatchObject({
+      name: "OAuthHttpError",
+      httpStatus: 400,
+      permanentCredentialFailure: true,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "access_denied", leak: "secret" }, 403)),
+    );
+    await expect(refreshOpenAICodexToken("rt")).rejects.toMatchObject({
+      name: "OAuthHttpError",
+      httpStatus: 403,
+      permanentCredentialFailure: false,
+    });
+    await expect(refreshOpenAICodexToken("rt")).rejects.toBeInstanceOf(OAuthHttpError);
     await expect(refreshOpenAICodexToken("rt")).rejects.not.toThrow(/secret/);
   });
 });

--- a/packages/core/src/provider/oauth/openai-codex.ts
+++ b/packages/core/src/provider/oauth/openai-codex.ts
@@ -17,6 +17,7 @@ import {
   OAuthHttpError,
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
+  responseIsOAuthInvalidGrant,
   throwIfOAuthLoginAborted,
 } from "./runtime.js";
 import type {
@@ -166,8 +167,7 @@ async function postToken(
     signal: buildOAuthRequestSignal({ signal, timeoutMs: 30_000 }),
   });
   if (!res.ok) {
-    await res.body?.cancel().catch(() => {});
-    throw new OAuthHttpError("OpenAI Codex", res.status);
+    throw new OAuthHttpError("OpenAI Codex", res.status, await responseIsOAuthInvalidGrant(res));
   }
   return await readUpstreamJsonWithinBudget<TokenResponseJson>(res);
 }

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -134,7 +134,7 @@ describe("createOAuthPoolClient — Realtime account binding", () => {
 
   it("parks the selected account when sideband token refresh permanently fails", async () => {
     const credentialFailures: string[] = [];
-    const refreshFailure = new TokenRefreshError("oauth refresh failed (status 401)", 401);
+    const refreshFailure = new TokenRefreshError("oauth refresh failed (status 401)", 401, true);
     const client = (account: string): ProviderClient => ({
       ...stubClient(account, []),
       async realtimeCall() {
@@ -2044,7 +2044,11 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
   const AUTH_401 = new UpstreamError("upstream_error", "unauthorized", null, 401);
   const AUTH_403 = new UpstreamError("upstream_error", "forbidden", null, 403);
   const BAD = new UpstreamError("upstream_error", "bad request", null, 400);
-  const REFRESH_401 = new TokenRefreshError("oauth refresh failed (openai-codex, status 401)", 401);
+  const REFRESH_401 = new TokenRefreshError(
+    "oauth refresh failed (openai-codex, status 401)",
+    401,
+    true,
+  );
   const REFRESH_429 = new TokenRefreshError("oauth refresh rate-limited (status 429)", 429);
   const SHORT_LEASE = new TokenRefreshError(
     "oauth access token is shorter than required request lease",
@@ -2486,7 +2490,7 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     expect(credentialFailures).toEqual([]);
   });
 
-  it("keeps inference 403 as a permanent credential failure by default", async () => {
+  it("does not park inference 403 as a permanent credential failure by default", async () => {
     const served: string[] = [];
     const selected: string[] = [];
     const credentialFailures: Array<{ account: string; error: unknown }> = [];
@@ -2498,11 +2502,12 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
       },
     });
 
-    await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "good" });
+    await expect(pool.chatCompletion(REQ)).rejects.toThrow(/forbidden/);
+    await expect(pool.chatCompletion(REQ)).rejects.toThrow(/forbidden/);
 
-    expect(served).toEqual(["good"]);
-    expect(selected).toEqual(["bad", "good"]);
-    expect(credentialFailures).toEqual([{ account: "bad", error: AUTH_403 }]);
+    expect(served).toEqual([]);
+    expect(selected).toEqual(["bad", "bad"]);
+    expect(credentialFailures).toEqual([]);
   });
 
   it("does not park a provider-excluded inference 403 on the streaming path", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -50,8 +50,8 @@ const RETRYABLE_ACCOUNT_FAILURE_COOLDOWN_MS = 30_000;
 // identically, so surface them immediately for executor classification. Account-local
 // OAuth credential/rate-limit statuses are handled by the dedicated helpers below,
 // because those statuses can say something about the selected subscription account,
-// not about the model alias. The credential statuses are provider-configurable: for
-// example, xAI defines inference 403 as an authenticated policy/content denial.
+// not about the model alias. Credential statuses remain provider-configurable for
+// providers that explicitly document a different authentication status contract.
 // Non-UpstreamError (client abort, programmer error) is never retried.
 function isRetryableTransientError(err: unknown): boolean {
   if (!(err instanceof UpstreamError)) return false;
@@ -69,9 +69,7 @@ function isCredentialAccountFailure(
   upstreamCredentialFailureStatuses: ReadonlySet<number>,
 ): boolean {
   if (err instanceof TokenRefreshError) {
-    if (err.permanentCredentialFailure) return true;
-    const status = err.httpStatus;
-    return status === 400 || status === 401 || status === 403;
+    return err.permanentCredentialFailure;
   }
   if (err instanceof UpstreamError) {
     return err.upstreamStatus !== null && upstreamCredentialFailureStatuses.has(err.upstreamStatus);
@@ -248,7 +246,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   const selectionStrategy = deps.selectionStrategy ?? "balanced";
   const quotaFreshMs = deps.quotaFreshMs ?? 10 * 60 * 1000;
   const upstreamCredentialFailureStatuses = new Set(
-    deps.upstreamCredentialFailureStatuses ?? [401, 403],
+    deps.upstreamCredentialFailureStatuses ?? [401],
   );
   const entries: PoolEntry[] = deps.members.map((member) => ({ member, lastUsedAt: 0 }));
   const firstNativeProtocolProfile = entries[0]?.member.client.nativeProtocolProfile;

--- a/packages/core/src/provider/oauth/runtime.ts
+++ b/packages/core/src/provider/oauth/runtime.ts
@@ -6,6 +6,8 @@
 // dependency is inlined below so this kit pulls in NOTHING from openclaw.
 
 import { createHash, randomBytes } from "node:crypto";
+import { readResponseTextWithinBudget } from "../../runtime/bounded-response.js";
+import { createResponseWorkAdmission } from "../../runtime/response-work-admission.js";
 import type { OAuthAuthorizationInput } from "./types.js";
 
 // A token-endpoint HTTP failure (non-2xx) raised by a provider's login/refresh
@@ -15,10 +17,50 @@ import type { OAuthAuthorizationInput } from "./types.js";
 // scrubbed) reason instead of an opaque "refresh failed".
 export class OAuthHttpError extends Error {
   readonly httpStatus: number;
-  constructor(provider: string, httpStatus: number) {
+  readonly permanentCredentialFailure: boolean;
+  constructor(provider: string, httpStatus: number, permanentCredentialFailure = false) {
     super(`${provider} OAuth HTTP ${httpStatus}`);
     this.name = "OAuthHttpError";
     this.httpStatus = httpStatus;
+    this.permanentCredentialFailure = permanentCredentialFailure;
+  }
+}
+
+const OAUTH_ERROR_BODY_MAX_BYTES = 8 * 1024;
+const oauthErrorBodyAdmission = createResponseWorkAdmission({
+  capacityBytes: OAUTH_ERROR_BODY_MAX_BYTES,
+  jsonAmplification: 1,
+  minChargeBytes: 1,
+});
+
+export function isOAuthInvalidGrant(body: unknown): boolean {
+  if (typeof body === "string") {
+    try {
+      return isOAuthInvalidGrant(JSON.parse(body) as unknown);
+    } catch {
+      return false;
+    }
+  }
+  return (
+    body !== null &&
+    typeof body === "object" &&
+    !Array.isArray(body) &&
+    (body as { error?: unknown }).error === "invalid_grant"
+  );
+}
+
+export async function responseIsOAuthInvalidGrant(response: Response): Promise<boolean> {
+  try {
+    return isOAuthInvalidGrant(
+      await readResponseTextWithinBudget(
+        response,
+        OAUTH_ERROR_BODY_MAX_BYTES,
+        oauthErrorBodyAdmission,
+      ),
+    );
+  } catch {
+    await response.body?.cancel().catch(() => {});
+    return false;
   }
 }
 

--- a/packages/core/src/provider/oauth/xai.ts
+++ b/packages/core/src/provider/oauth/xai.ts
@@ -7,6 +7,7 @@
 
 import {
   buildOAuthRequestSignal,
+  isOAuthInvalidGrant,
   OAuthHttpError,
   resolveExpiresAtMsFromDurationSeconds,
   resolveExpiresAtMsFromEpochSeconds,
@@ -340,7 +341,9 @@ export async function refreshXaiOAuthToken(
     signal: buildOAuthRequestSignal({ timeoutMs: FETCH_TIMEOUT_MS }),
   });
   const body = await readJson(response);
-  if (!response.ok) throw new OAuthHttpError("xAI refresh", response.status);
+  if (!response.ok) {
+    throw new OAuthHttpError("xAI refresh", response.status, isOAuthInvalidGrant(body));
+  }
   return {
     ...credentials,
     ...parseTokenResponse(body, tokenEndpoint, now, credentials.refresh),

--- a/packages/core/src/provider/token-manager.preset.test.ts
+++ b/packages/core/src/provider/token-manager.preset.test.ts
@@ -594,12 +594,47 @@ describe("createTokenManager (preset kind)", () => {
     await expect(tm.getAuthHeader()).rejects.toMatchObject({
       name: "TokenRefreshError",
       httpStatus: 400,
+      permanentCredentialFailure: false,
     });
     await expect(tm.getAuthHeader()).rejects.toThrow(
       /oauth refresh failed \(anthropic, status 400\)/,
     );
     // Still scrubbed — no token material leaks into the diagnosable message.
     await expect(tm.getAuthHeader()).rejects.not.toThrow(/at-stored|rt-stored/);
+  });
+
+  it("preserves explicit credential rejection and treats a bare 403 as retryable", async () => {
+    const failing = (error: OAuthHttpError) =>
+      createTokenManager({
+        oauth: PRESET,
+        tokenStore: memStore(seedRecord({ expiresAt: 100 })),
+        encKey: KEY,
+        oauthProvider: {
+          id: "anthropic",
+          name: "failing",
+          async login() {
+            throw new Error("not used");
+          },
+          async refreshToken() {
+            throw error;
+          },
+          getApiKey: (credentials) => credentials.access,
+        },
+        now: () => 1_000_000,
+      });
+
+    await expect(
+      failing(new OAuthHttpError("Anthropic", 400, true)).getAuthHeader(),
+    ).rejects.toMatchObject({
+      permanentCredentialFailure: true,
+      retryableAccountFailure: false,
+    });
+    await expect(
+      failing(new OAuthHttpError("Anthropic", 403)).getAuthHeader(),
+    ).rejects.toMatchObject({
+      permanentCredentialFailure: false,
+      retryableAccountFailure: true,
+    });
   });
 
   it("preserves a permanent credential marker when Codex refresh changes account identity", async () => {

--- a/packages/core/src/provider/token-manager.ts
+++ b/packages/core/src/provider/token-manager.ts
@@ -192,7 +192,13 @@ function presetRefreshFailureWaitMs(providerId: string, account: string): number
 
 function isRetryableRefreshError(err: unknown): boolean {
   if (err instanceof OAuthHttpError) {
-    return err.httpStatus === 408 || err.httpStatus === 425 || err.httpStatus >= 500;
+    if (err.permanentCredentialFailure) return false;
+    return (
+      err.httpStatus === 403 ||
+      err.httpStatus === 408 ||
+      err.httpStatus === 425 ||
+      err.httpStatus >= 500
+    );
   }
   return isFetchTransportError(err);
 }
@@ -384,6 +390,8 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
       // 429 ⇒ rate limited; 5xx ⇒ upstream down).
       const status = err instanceof OAuthHttpError ? err.httpStatus : null;
       const identityMismatch = err instanceof OpenAICodexIdentityMismatchError;
+      const permanentCredentialFailure =
+        identityMismatch || (err instanceof OAuthHttpError && err.permanentCredentialFailure);
       const retryableAccountFailure = isRetryableRefreshError(err);
       if (retryableAccountFailure) {
         await new Promise<void>((resolve) =>
@@ -404,7 +412,7 @@ export function createTokenManager(deps: TokenManagerDeps): TokenManager {
             ? `oauth refresh failed (${p.providerId})`
             : `oauth refresh failed (${p.providerId}, status ${status})`,
         status,
-        identityMismatch,
+        permanentCredentialFailure,
         retryableAccountFailure,
       );
     }


### PR DESCRIPTION
## Root cause

OAuth refresh 400/401/403 and inference 401/403 were treated as permanent credential failures based only on status. A proxy, WAF, or regional policy returning a bare 403 could therefore persist credentialFailedAt and remove a valid account from scheduling.

## Fix

- Persist credential failure only when the provider explicitly confirms invalid_grant, Copilot token mint returns 401, or Codex identity changes.
- Treat a bare refresh 403 as a temporary account failure/cooldown.
- Keep inference 401 as credential failure; inference 403 now follows normal upstream fallback without parking the account.
- Bound OAuth error-body inspection to 8 KiB and never expose the body in logs/errors.

## Verification

- 6 focused OAuth/pool/admin regression tests passed.
- pnpm typecheck passed.
- pnpm lint passed.
- pnpm build passed.
- A broader combined Vitest run hit the existing response-memory admission while the machine had about 0.9 GB available; the focused affected tests pass under constrained workers.

## Release assessment

Recommended as an urgent patch release after CI/review because it fixes a production availability regression without schema, migration, dependency, or public API changes.