### PR TITLE
chore(release): v0.28.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.69",
+  "version": "0.28.70",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Patch release for the OAuth credential-failure classification fix merged in #749.

- Prevents proxy/WAF bare 403 responses from permanently parking valid OAuth accounts.
- Preserves fail-closed reconnect for explicit invalid_grant, Copilot token-mint 401, and Codex identity mismatch.
- No schema migration, dependency, or public API change.

After merge, the verified-main publish workflow will create the immutable image, v0.28.70 tag, and GitHub Release.