### PR TITLE
fix(oauth): clear retryable cooldown after account test

### DIFF
--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -2339,6 +2339,36 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     expect(credentialFailures).toEqual([]);
   });
 
+  it("clears a retryable refresh cooldown when an account test succeeds", async () => {
+    let refreshFails = true;
+    const pool = createOAuthPoolClient({
+      members: [
+        {
+          account: "a",
+          priority: 10,
+          schedulable: true,
+          client: {
+            async chatCompletion() {
+              if (refreshFails) {
+                refreshFails = false;
+                throw SHORT_LEASE;
+              }
+              return { served_by: "a" };
+            },
+            chatCompletionStream(): AsyncIterable<string> {
+              return (async function* () {})();
+            },
+          },
+        },
+      ],
+      now: () => 1_000,
+    });
+
+    await expect(pool.chatCompletion(REQ)).rejects.toThrow(/shorter than required request lease/);
+    pool.setUsageLimit("a", null);
+    await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "a" });
+  });
+
   it("cools a refresh-failed account for streaming requests too", async () => {
     const served: string[] = [];
     const selected: string[] = [];

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -143,7 +143,8 @@ export type OAuthSelectionStrategy = "balanced" | "manual_priority" | "low_risk"
 // The pool's ProviderClient plus an out-of-band mutator the gateway uses to park /
 // un-park a single account in O(1) — a single 429 must NOT rebuild the whole pool
 // (which re-refreshes every token). `setUsageLimit` on an unknown account is a no-op
-// (the member may have been dropped by a concurrent rebuild).
+// (the member may have been dropped by a concurrent rebuild). Passing null after
+// a successful account test clears every soft cooldown for that account.
 export interface OAuthPoolClient extends ProviderClient {
   setUsageLimit(account: string, untilMs: number | null): void;
   // The account's current auto-park cooldown (epoch ms), or null if eligible now. Lets
@@ -1168,6 +1169,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       const entry = entries.find((e) => e.member.account === account);
       if (entry) entry.member.usageLimitedUntilMs = untilMs;
       if (untilMs === null) {
+        retryableAccountFailures.delete(account);
         for (const [key, cooldown] of scopedRateLimits) {
           if (cooldown.account === account) scopedRateLimits.delete(key);
         }


### PR DESCRIPTION
## Summary

- clear the pool-private retryable refresh cooldown when a successful Admin account test resets soft account cooldowns
- keep permanent credential failures and operator schedulable=false parks fail-closed
- add a regression for the exact test-success followed by no-schedulable-account state

## Why

A retryable OAuth refresh failure parks the selected account for 30 seconds. The Admin connection test uses a fresh client and can succeed immediately, but its existing cooldown reset only cleared durable usage and model-scoped cooldowns. The live pool therefore continued returning oauth pool has no schedulable account until the private retry cooldown expired.

## Validation

- CI=true pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts -t clears-a-retryable-refresh-cooldown equivalent filter: passed
- CI=true pnpm exec vitest run apps/gateway/src/routes/admin/oauth-test-route.test.ts: 7 passed
- CI=true pnpm typecheck: passed
- CI=true pnpm lint: passed

Broader local pool.test.ts run reached 105 passing tests and one unrelated Codex raw-fetch test failed because the current machine response-memory admission was exhausted; that same test also failed when run alone. The changed regression passes in isolation and the PR CI should provide the authoritative full-suite result.