### PR TITLE
chore(release): v0.28.71

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.70",
+  "version": "0.28.71",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump the root package version from 0.28.70 to 0.28.71
- publish the merged OAuth retryable-cooldown recovery fix

## Scope
- version-only release PR
- no configuration, schema, migration, or API changes

## Validation
- git diff --check
- package version readback: 0.28.71
- merged feature main CI: verify, store, docker, and e2e passed