### PR TITLE
chore(release): v0.28.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.71",
+  "version": "0.28.72",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump Helm API from `0.28.71` to `0.28.72`
- includes PR #753: large captured payloads are decompressed/reassembled in the Admin browser
- also retains the already-released v0.28.71 OAuth retryable-cooldown fix

## Validation
- release branch is based on feature merge `58ddff274aa3968ffb9c6e6ae39a58dc853bf7e8`
- version-only diff (`package.json`)
- feature PR #753 required CI passed before merge