### PR TITLE
feat: support Grok Imagine video 1.5

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -153,7 +153,11 @@
 
   function mediaBadge(model: string): 'Image' | 'Video' | null {
     if (model === 'grok-imagine-image-quality') return 'Image';
-    if (model === 'grok-imagine-video-1.5-preview' || model === 'grok-imagine-video') {
+    if (
+      model === 'grok-imagine-video-1.5-preview' ||
+      model === 'grok-imagine-video' ||
+      model === 'grok-imagine-video-1.5'
+    ) {
       return 'Video';
     }
     return null;

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -219,12 +219,9 @@ describe('providers page', () => {
               schedulable: true,
               proxy: null,
               models: [
-                'grok-composer-2.5-fast',
-                'grok-4.5',
-                'grok-4.5-fast',
                 'grok-imagine-image-quality',
-                'grok-imagine-video-1.5-preview',
                 'grok-imagine-video',
+                'grok-imagine-video-1.5',
               ],
             },
           ],
@@ -920,6 +917,7 @@ describe('providers page', () => {
                 'grok-imagine-image-quality',
                 'grok-imagine-video-1.5-preview',
                 'grok-imagine-video',
+                'grok-imagine-video-1.5',
               ],
             },
           ],
@@ -942,6 +940,9 @@ describe('providers page', () => {
     ).not.toBeInTheDocument();
     expect(
       within(dialog).queryByRole('option', { name: 'grok-imagine-video' }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole('option', { name: 'grok-imagine-video-1.5' }),
     ).not.toBeInTheDocument();
   });
 

--- a/apps/gateway/e2e/fixtures/mock-upstream.ts
+++ b/apps/gateway/e2e/fixtures/mock-upstream.ts
@@ -246,6 +246,7 @@ export function createMockUpstream() {
   // OAUTH_RESET_PATH between spec cases.
   let oauth401Fired = false;
   let videoCapture: VideoCapture = { images: [], starts: [], polls: [] };
+  let videoStartCount = 0;
   const videoOwners = new Map<string, string>();
   const videoPollCounts = new Map<string, number>();
 
@@ -299,7 +300,7 @@ export function createMockUpstream() {
       return c.json({ error: { message: "missing xAI OAuth bearer" } }, 401);
     }
     const body = (await c.req.json()) as Record<string, unknown>;
-    const requestId = `video_${account}_${videoCapture.starts.length + 1}`;
+    const requestId = `video_${account}_${++videoStartCount}`;
     videoOwners.set(requestId, account);
     videoCapture.starts.push({ requestId, account, body });
     return c.json({ request_id: requestId, status: "queued" });

--- a/apps/gateway/e2e/videos.spec.ts
+++ b/apps/gateway/e2e/videos.spec.ts
@@ -237,7 +237,7 @@ test("start, owner isolation, OAuth pinning, and restart recovery stay on one du
   });
   expect((await videoCapture()).images).toEqual([
     {
-      account: "a",
+      account: expect.any(String),
       body: expect.objectContaining({
         model: "grok-imagine-image-quality",
         resolution: "1k",

--- a/apps/gateway/e2e/videos.spec.ts
+++ b/apps/gateway/e2e/videos.spec.ts
@@ -203,6 +203,7 @@ test("routes the current Grok Build 1.5 model through the SuperGrok OAuth video 
   expect(await response.json()).toMatchObject({ request_id: expect.any(String) });
   expect((await videoCapture()).starts).toEqual([
     {
+      requestId: expect.any(String),
       account: expect.any(String),
       body: expect.objectContaining({
         model: "grok-imagine-video-1.5",

--- a/apps/gateway/e2e/videos.spec.ts
+++ b/apps/gateway/e2e/videos.spec.ts
@@ -59,7 +59,7 @@ async function createVideo(key: string, prompt: string): Promise<Response> {
       method: "POST",
       headers: AUTH(key),
       body: JSON.stringify({
-        model: "grok-imagine-video-1.5-preview",
+        model: "grok-imagine-video-1.5",
         prompt,
         image: { url: "data:image/png;base64,aGVsbQ==" },
         duration: 6,
@@ -193,6 +193,26 @@ test("rejects a configured static outputVideo alias at the closed Imagine reques
   expect(response.status).toBe(400);
   expect(await response.json()).toMatchObject({ error: { code: "invalid_request" } });
   expect((await videoCapture()).starts).toHaveLength(0);
+});
+
+test("routes the current Grok Build 1.5 model through the SuperGrok OAuth video client", async () => {
+  await nativeFetch(`${MOCK}${VIDEO_RESET_PATH}`, { method: "POST" });
+
+  const response = await createVideo(KEY_A, "camera slowly pushes toward the subject");
+  expect(response.status).toBe(200);
+  expect(await response.json()).toMatchObject({ request_id: expect.any(String) });
+  expect((await videoCapture()).starts).toEqual([
+    {
+      account: expect.any(String),
+      body: expect.objectContaining({
+        model: "grok-imagine-video-1.5",
+        duration: 6,
+        resolution: "480p",
+      }),
+    },
+  ]);
+
+  await nativeFetch(`${MOCK}${VIDEO_RESET_PATH}`, { method: "POST" });
 });
 
 test("start, owner isolation, OAuth pinning, and restart recovery stay on one durable journey", async () => {

--- a/apps/gateway/src/oauth/effective-models.test.ts
+++ b/apps/gateway/src/oauth/effective-models.test.ts
@@ -222,11 +222,13 @@ describe("effectiveOAuthModelOptions", () => {
           { alias: "xai/grok-imagine-image-quality", accounts: ["supergrok-a"] },
           { alias: "xai/grok-imagine-video-1.5-preview", accounts: ["supergrok-a"] },
           { alias: "xai/grok-imagine-video", accounts: ["supergrok-a"] },
+          { alias: "xai/grok-imagine-video-1.5", accounts: ["supergrok-a"] },
         ],
       }),
     ).resolves.toEqual([
       { alias: "xai/grok-imagine-image-quality", accounts: ["supergrok-a"] },
       { alias: "xai/grok-imagine-video", accounts: ["supergrok-a"] },
+      { alias: "xai/grok-imagine-video-1.5", accounts: ["supergrok-a"] },
       { alias: "xai/grok-imagine-video-1.5-preview", accounts: ["supergrok-a"] },
     ]);
   });

--- a/apps/gateway/src/routes/videos.test.ts
+++ b/apps/gateway/src/routes/videos.test.ts
@@ -198,6 +198,34 @@ describe("registerVideosRoute", () => {
     );
   });
 
+  it("forwards the current Grok Build 1.5 reference contract unchanged", async () => {
+    const create = vi.fn().mockResolvedValue({ request_id: "vid_1", status: "queued" });
+    const { app } = setup({
+      resolver: {
+        create: async () => ({
+          providerAlias: "xai/grok-imagine-video-1.5",
+          providerName: "xai",
+          providerModel: "grok-imagine-video-1.5",
+          providerAccount: "oauth-a",
+          client: { create },
+        }),
+        poll: async () => null,
+      },
+    });
+    const body = {
+      model: "grok-imagine-video-1.5",
+      prompt: "the subject from <IMAGE_0> speaks with <AUDIO_0>",
+      reference_images: [{ url: "https://example.test/subject.png" }],
+      reference_audios: [{ voice_id: "eve" }],
+      aspect_ratio: "3:4",
+      duration: 15,
+      resolution: "480p",
+    };
+
+    expect((await post(app, body)).status).toBe(200);
+    expect(create).toHaveBeenCalledWith(body, expect.any(AbortSignal), expect.any(Function));
+  });
+
   it("records an outcome_unknown video create under the Helm request id without a retry", async () => {
     const { app, create, enqueueTelemetry, enqueuePayload } = setup();
     create.mockRejectedValueOnce(new Error("socket closed after POST"));

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1049,7 +1049,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     );
     expect(logs).toContainEqual({
       msg: "oauth.autoroute",
-      fields: expect.objectContaining({ providerId: "xai", accounts: 2, models: 4 }),
+      fields: expect.objectContaining({ providerId: "xai", accounts: 2, models: 5 }),
     });
   });
 

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -538,6 +538,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       provider_model: "grok-imagine-video-1.5-preview",
     },
     { alias: "xai/grok-imagine-video", provider_model: "grok-imagine-video" },
+    { alias: "xai/grok-imagine-video-1.5", provider_model: "grok-imagine-video-1.5" },
   ];
   const runInBackground = (task: () => Promise<unknown>) => {
     void task();
@@ -698,6 +699,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
           provider_model: "grok-imagine-video-1.5-preview",
         },
         { alias: "xai/grok-imagine-video", provider_model: "grok-imagine-video" },
+        { alias: "xai/grok-imagine-video-1.5", provider_model: "grok-imagine-video-1.5" },
       ]),
     );
     const pool = enabled.poolClients.get("xai");
@@ -705,7 +707,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       pool?.imageGeneration?.({ model: "grok-imagine-image-quality", prompt: "draw" }),
     ).resolves.toEqual({ data: [{ b64_json: "image" }] });
     await expect(
-      pool?.videoGeneration?.({ model: "grok-imagine-video", prompt: "move" }),
+      pool?.videoGeneration?.({ model: "grok-imagine-video-1.5", prompt: "move" }),
     ).resolves.toEqual({ request_id: "video_1" });
     await expect(
       pool?.videoRetrieve?.("video_1", { providerAccount: "media" }),
@@ -713,6 +715,26 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect(calls).toContain("POST https://api.x.ai/v1/images/generations");
     expect(calls).toContain("POST https://api.x.ai/v1/videos/generations");
     expect(calls).toContain("GET https://api.x.ai/v1/videos/video_1");
+  });
+
+  it("exposes the current Grok Build 1.5 video alias from the synthesized OAuth pool", async () => {
+    const { ctx, config } = oauthStores();
+    await seedXai(ctx, "media-current");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ data: [] }));
+
+    const enabled = await synthesizeOAuthProviders(
+      [],
+      ctx,
+      config,
+      "https://fallback/v1",
+      60_000,
+      noop,
+    );
+
+    expect(enabled.providers[0]?.models).toContainEqual({
+      alias: "xai/grok-imagine-video-1.5",
+      provider_model: "grok-imagine-video-1.5",
+    });
   });
 
   it("honors each xAI account's manual media allowlist", async () => {

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -134,6 +134,15 @@ xai/grok-imagine-video:
   outputVideo: true
   maxContextTokens: 32768
   maxOutputTokens: null
+xai/grok-imagine-video-1.5:
+  supportsTools: false
+  jsonOutput: none
+  supportsVision: true
+  supportsStreaming: false
+  supportsCachedContent: false
+  outputVideo: true
+  maxContextTokens: 32768
+  maxOutputTokens: null
 #
 # GPT-5.6 fallback metadata mirrors the bundled Codex model catalog. At runtime the
 # authenticated `/models` response is authoritative per account; these entries are

--- a/config/lanes.yaml
+++ b/config/lanes.yaml
@@ -287,3 +287,8 @@ grok-imagine-video:
   purpose: Grok Imagine multi-reference video generation via SuperGrok OAuth
   primary: xai/grok-imagine-video
   fallback: []
+
+grok-imagine-video-1.5:
+  purpose: Current Grok Imagine image/reference video generation via SuperGrok OAuth
+  primary: xai/grok-imagine-video-1.5
+  fallback: []

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -73,6 +73,11 @@ xai/grok-imagine-video:
   outputPerMTokUsd: null
   cacheReadPerMTokUsd: null
   cacheWritePerMTokUsd: null
+xai/grok-imagine-video-1.5:
+  inputPerMTokUsd: null
+  outputPerMTokUsd: null
+  cacheReadPerMTokUsd: null
+  cacheWritePerMTokUsd: null
 # Codex auto-review is a dynamic internal route with no published fixed API rate.
 openai-codex/codex-auto-review:
   inputPerMTokUsd: null

--- a/docs/grok-imagine-media-spec.md
+++ b/docs/grok-imagine-media-spec.md
@@ -2,7 +2,7 @@
 
 > 状态：**MVP 已实现；发布仍为 No-Go**
 >
-> 证据基线：2026-08-08 的 `helm-api` 与本机 `grok-build` 源码
+> 证据基线：2026-08-15 的 `helm-api` 与本机最新 `grok-build` 源码
 >
 > 目标：让 Grok CLI 使用 Helm API key，通过 Helm 后台已经连接的 SuperGrok OAuth 订阅池完成图片生成、单图生视频和多参考图生视频。
 
@@ -20,8 +20,8 @@
 - [x] `grok-imagine-image-quality` 可通过 Helm 已连接的 SuperGrok OAuth 账号生成图片。
 - [x] 新增 `POST /v1/videos/generations`，兼容 Grok 的异步视频 start 协议。
 - [x] 新增 `GET /v1/videos/{request_id}`，兼容 Grok 的异步视频 poll 协议。
-- [x] `grok-imagine-video-1.5-preview` 支持单图生视频。
-- [x] `grok-imagine-video` 支持 2–7 张参考图生视频。
+- [x] `grok-imagine-video-1.5` 支持单图生视频，以及参考图片/预设声音驱动的视频生成。
+- [x] 旧的 `grok-imagine-video-1.5-preview` 与 `grok-imagine-video` 请求形状继续兼容。
 - [ ] 使用真实 Grok CLI 验证 `/imagine-video` 默认流程：先生成首帧，再生成视频。
 - [x] 图片和视频创建遵守“单写”规则：结果不明时不自动重试、不切 provider、不切 OAuth 账号。
 - [x] 视频 poll 始终绑定创建任务时的 Helm owner、provider 和 OAuth account。
@@ -39,7 +39,7 @@
 - [ ] 支持视频 ZDR 的 `output.upload_url` 原样透传。
 - [ ] ZDR 模式的完成响应允许没有 `video.url`。
 - [x] 后台用 Image / Video badge 区分媒体模型与文本模型。
-- [x] 后台提供商账号卡片和“管理模型”列表显示三个 Grok Imagine 媒体 alias。
+- [x] 后台提供商账号卡片和“管理模型”列表显示四个 Grok Imagine 媒体 alias。
 - [x] “发送短消息”的聊天连通性测试排除媒体 alias，服务端也在上游调用前拒绝伪造请求，避免误触发付费媒体生成。
 
 ### 2.3 明确不做
@@ -59,7 +59,7 @@
 - 媒体基址默认是 `https://api.x.ai/v1`，不是 `cli-chat-proxy.grok.com/v1`。
 - `GROK_XAI_API_BASE_URL` 决定 Imagine 请求地址；`GROK_MODELS_BASE_URL` 不参与媒体 URL 选择。
 - 图片默认模型完整 ID 是 `grok-imagine-image-quality`；`quality` 是模型名后缀，实际清晰度字段是 `resolution: "1k"`。
-- 视频模型不能混用：单图使用 `grok-imagine-video-1.5-preview`，多参考图使用 `grok-imagine-video`。
+- 最新 Grok Build 的单图与参考输入统一使用 `grok-imagine-video-1.5`；两个旧模型名仅作为兼容入口保留。
 - video start 返回字段是 `request_id`；poll 只有 `done`、`failed`、`expired` 是已知终态，其他状态继续等待。
 - `/imagine-video` 是 `image_gen → image_to_video` 的客户端编排，不是新的 HTTP endpoint。
 
@@ -179,7 +179,7 @@ POST {xai_api_base_url}/videos/generations
 
 ```json
 {
-  "model": "grok-imagine-video-1.5-preview",
+  "model": "grok-imagine-video-1.5",
   "prompt": "short motion description",
   "image": { "url": "https://... 或 data:image/..." },
   "duration": 6,
@@ -194,18 +194,18 @@ POST {xai_api_base_url}/videos/generations
 - `resolution` 只能是 `480p` 或 `720p`。
 - 该形状不发送 `reference_images`。
 
-### 4.4 多参考图生视频
+### 4.4 参考图片或预设声音生视频
 
 ```json
 {
-  "model": "grok-imagine-video",
-  "prompt": "...",
+  "model": "grok-imagine-video-1.5",
+  "prompt": "The subject from <IMAGE_0> speaks with <AUDIO_0>",
   "reference_images": [
-    { "url": "https://... 或 data:image/..." },
     { "url": "https://... 或 data:image/..." }
   ],
+  "reference_audios": [{ "voice_id": "eve" }],
   "aspect_ratio": "16:9",
-  "duration": 6,
+  "duration": 15,
   "resolution": "480p"
 }
 ```
@@ -213,9 +213,9 @@ POST {xai_api_base_url}/videos/generations
 约束：
 
 - `prompt` 不能为空。
-- `reference_images` 数量为 2–7。
-- `aspect_ratio` 只能是 `1:1`、`16:9`、`9:16`、`3:2`、`2:3`。
-- `duration` 和 `resolution` 与单图模式相同。
+- `reference_images` 最多 7 张，`reference_audios` 最多 3 个；两者至少提供一项。
+- `aspect_ratio` 只能是 `1:1`、`16:9`、`9:16`、`4:3`、`3:4`、`3:2`、`2:3`。
+- `duration` 是 1–15 秒整数；`resolution` 仍只能是 `480p` 或 `720p`。
 
 ### 4.5 视频 start / poll
 
@@ -357,7 +357,7 @@ flowchart LR
 
 - [x] 注册 `POST /v1/videos/generations`。
 - [x] 复用图片入口的 auth、rate、concurrency、blocked model、memory admission 和 budget gate。
-- [x] 用严格 Zod schema 校验 image/reference_images、duration、resolution、aspect ratio；当前阶段明确拒绝 ZDR `output`。
+- [x] 用严格 Zod schema 校验 image/reference_images/reference_audios、duration、resolution、aspect ratio；当前阶段明确拒绝 ZDR `output`。
 - [x] resolver 只接受 `outputVideo: true` 的 target。
 - [x] upstream 成功后校验非空 `request_id`。
 - [x] 用 insert-if-absent 写入内部 `video:${request_id}` registry 记录，禁止覆盖不同 owner/provider/account 的已有行。
@@ -489,7 +489,7 @@ Helm 不会把任意 xAI bearer 当成自己的 API key。
 ### 12.3 Gateway 单测
 
 - [x] 扩展 `images.test.ts`：Grok OAuth generation、serving account、single write。
-- [x] 新增 `videos-schema.test.ts`：单图、多图、边界和拒绝路径。
+- [x] 新增 `videos-schema.test.ts`：单图、参考图/声音、时长边界和拒绝路径。
 - [x] 新增 `videos.test.ts`：auth、blocked model、budget、concurrency、start/poll。
 - [x] 同 key 可 poll；不同 key、不同 Helm account 均不能 poll。
 - [x] 过期记录由复用的 registry owner/TTL 合同拒绝。
@@ -565,6 +565,7 @@ CI=true pnpm test:e2e
 - [x] video data URL 外置与 capture/error 脱敏。
 - [x] OAuth video unit/e2e 通过。
 - [x] 使用本机测试 SuperGrok 账号完成受控视频 canary（start HTTP 200，poll 到 `done`，未重试媒体 POST）。
+- [ ] 使用真实 SuperGrok OAuth 对 `grok-imagine-video-1.5` 完成一次受控 canary；旧模型 canary 不能代替新 wire model 的生产证据。
 
 ### P3：完整对等与发布
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-15 · Grok Imagine 视频统一到 1.5 wire model（OAuth media / video schema，Grok Imagine spec，原则 2/3/7）
+
+- **上游变化**：最新 `grok-build`（`eb267fe`）删除 `grok-imagine-video-1.5-preview` / `grok-imagine-video` 的分工，单图与参考图/预设声音工具统一发送 `grok-imagine-video-1.5`；单图仍只允许 6/10 秒，参考输入允许 1–15 秒并新增 `reference_audios[].voice_id`。
+- **兼容与边界**：Helm 新增 1.5 的 OAuth 媒体 allowlist、能力/价格/lane 与严格请求 schema，同时保留两个旧模型入口，避免破坏已部署客户端。新版参考请求至少包含一张图片或一个声音，最多 7 图/3 声；ZDR `output` 继续 fail-closed，付费 POST 单写语义不变。
+- **未完成证据**：本次不执行付费请求；旧模型 canary 不能证明新 wire model 已在生产账号可用，部署前仍需一次明确批准的 1.5 start/poll canary。
+
 ## 2026-08-15 · 大型完整载荷改由浏览器解压与恢复图片（Store / Admin requests，docs/07/11，原则 1/3/7）
 
 - **根因与修复**：SQLite `request_payloads` 的单列 gzip 读取沿用了 Session 单块 256 KiB 解压上限，超过该值的真实正文被映射为 `null`，Admin 随后错误回退到 Session 恢复。Admin 现在优先请求存储态正文；SQLite 原样返回 gzip BLOB，Postgres 返回 raw TEXT，由浏览器通过 HTTP `Content-Encoding` 流式解压并拼装，不再在网关内物化放大的正文。
@@ -59,15 +65,9 @@
 - **实现**：复用既有 `oauth_reset_period`，统一记录刚结束的 `[previousStart,actualResetAt)`；PULL、Codex header PUSH、手动/自动 reset-credit 共用记录入口。quota snapshot 按 `capturedAt` 单调更新，晚到的旧采样既不覆盖新状态，也不写伪 reset。旧版 `detectedAtMs < periodEndMs` 行只在读取时忽略，不改写历史库；本地“Reset usage”仍只清 Helm cooldown，不冒充上游重置。
 - **精度边界**：usage 继续按小时聚合，但真实重置发生在小时中间时，新请求的 bucket 起点提升到最近 reset point，因此不会再跨边界混入上一周期。部署前已经落入旧整点 bucket 的历史数据不可逆，继续标 `≈`/`partial`；新记录到的真实边界作为精确周期返回。Admin 默认显示 Period，并保留 Daily / Weekly 兼容视图。
 
-## 2026-08-10 · 大 Session 客户端重建按记录时间展示并提前停止分页（Admin / requests debug，docs/07/11，原则 1/3/7）
-
-- **现场与根因**：生产 v0.28.56 的目标详情点击后约 46 秒才完成，普通 Conversation 把重建后的请求 `input` 与最终响应折成一条聊天；现场原始 `input` 自身就是角色分段排列，因此 UI 没有再次排序，但这种折叠不能代表 Session 的真实请求/响应发生顺序。大 Session 客户端路径还丢弃了目标 revision 已保存的 `responseJson`，所以最终响应只能退化成脱敏 metadata。
-- **展示修复**：raw revision API 增加已有的 `sequence` 与 `createdAt`；浏览器把每个 revision 的 request delta / response snapshot 组成记录，按 `createdAt` 升序、`sequence` 稳定打破同毫秒并列。目标请求和目标响应继续进入原有 Conversation/Response viewer；额外时间线使用 `JsonViewer` 展示持久化 revision 记录，避免把“请求文档顺序”误称为“会话时间线”。
-- **加载加速**：浏览器一旦收到目标 revision 就停止游标分页，不再下载该目标之后的同 Session revision；行上限从 50 恢复到 100，单页 `maxBytes=8 MiB` 不变，所以服务端单请求正文物化上限不扩大。没有改成多进程/并发请求，因为下一页游标依赖上一页的 soft-byte 结果，并发会产生跳页或重复读取风险。
-- **边界**：时间线展示的是持久化的增量 request delta 与可用 response snapshot，不伪装成原始 HTTP body；Session 恢复仍是 `exact=false`、不可精确 Retry。响应为空表示当时没有可用快照，不补造内容。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-10 · 大 Session 客户端重建按记录时间展示并提前停止分页**：浏览器按 `createdAt/sequence` 展示持久化 revision 时间线，收到目标 revision 后停止继续分页；恢复结果仍标记 `exact=false`，完整原文经 git history 回溯。
 - **2026-08-08 · Grok Imagine 仅复用 SuperGrok OAuth 媒体链路**：媒体执行复用 xAI 订阅 OAuth，付费 POST 单写且不跨账号重试，未知价格对美元预算 fail-closed；完整原文经 git history 回溯。
 - **2026-08-08 · 会话转录客户端重建，绕开服务端内存阀**：长 Session 以 4 MiB/100 行游标分页传给浏览器本地重建，小 Session 保留服务端快路径；共享纯重建函数留在浏览器安全的 `@helm/shared`，完整原文经 git history 回溯。
 - **2026-08-07 · 真上游上下文溢出短路直返 400**：确定性上游 400/413/422 上下文溢出立即返回客户端并保留原始错误；预检估算仍允许 fallback，可重试状态不误判为客户端错误，完整原文经 git history 回溯。

--- a/packages/core/src/catalog/load.test.ts
+++ b/packages/core/src/catalog/load.test.ts
@@ -454,6 +454,7 @@ describe("loadRuntimeCatalog", () => {
       "xai/grok-imagine-image-quality",
       "xai/grok-imagine-video-1.5-preview",
       "xai/grok-imagine-video",
+      "xai/grok-imagine-video-1.5",
       "xai/grok-composer-2.5-fast",
       "zenmux/auto",
       "openrouter/auto",

--- a/packages/core/src/config/samples.test.ts
+++ b/packages/core/src/config/samples.test.ts
@@ -207,7 +207,11 @@ describe("checked-in config samples", () => {
 
     expect(capabilities["xai/grok-imagine-image-quality"]?.outputImage).toBe(true);
     expect(capabilities["xai/grok-imagine-image-quality"]?.outputVideo).toBeUndefined();
-    for (const model of ["grok-imagine-video-1.5-preview", "grok-imagine-video"]) {
+    for (const model of [
+      "grok-imagine-video-1.5-preview",
+      "grok-imagine-video",
+      "grok-imagine-video-1.5",
+    ]) {
       expect(capabilities[`xai/${model}`]?.outputVideo).toBe(true);
       expect(capabilities[`xai/${model}`]?.outputImage).toBeUndefined();
       expect(lanes[model]?.primary).toBe(`xai/${model}`);

--- a/packages/core/src/provider/oauth/models.test.ts
+++ b/packages/core/src/provider/oauth/models.test.ts
@@ -68,6 +68,7 @@ describe("discoverOAuthModels", () => {
       "grok-imagine-image-quality",
       "grok-imagine-video-1.5-preview",
       "grok-imagine-video",
+      "grok-imagine-video-1.5",
     ]);
     expect(CURATED_OAUTH_MODELS.xai).toBeUndefined();
   });

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -44,6 +44,7 @@ export const GROK_OAUTH_MEDIA_MODELS = [
   "grok-imagine-image-quality",
   "grok-imagine-video-1.5-preview",
   "grok-imagine-video",
+  "grok-imagine-video-1.5",
 ] as const;
 
 const OPENAI_CODEX_MODEL_ALIASES: Readonly<Record<string, string>> = {

--- a/packages/shared/src/request/videos-schema.test.ts
+++ b/packages/shared/src/request/videos-schema.test.ts
@@ -35,6 +35,29 @@ describe("VideoGenerationRequestSchema", () => {
     ).toBe(true);
   });
 
+  it("accepts current Grok Build 1.5 single-image and reference contracts", () => {
+    expect(
+      VideoGenerationRequestSchema.safeParse({
+        model: "grok-imagine-video-1.5",
+        prompt: "",
+        image: { url: "https://example.test/first-frame.png" },
+        duration: 10,
+        resolution: "720p",
+      }).success,
+    ).toBe(true);
+    expect(
+      VideoGenerationRequestSchema.safeParse({
+        model: "grok-imagine-video-1.5",
+        prompt: "the subject from <IMAGE_0> speaks with <AUDIO_0>",
+        reference_images: [{ url: "https://example.test/subject.png" }],
+        reference_audios: [{ voice_id: "eve" }],
+        aspect_ratio: "4:3",
+        duration: 15,
+        resolution: "480p",
+      }).success,
+    ).toBe(true);
+  });
+
   it("rejects unsupported shapes and ZDR output instead of silently forwarding them", () => {
     expect(
       VideoGenerationRequestSchema.safeParse({
@@ -85,6 +108,25 @@ describe("VideoGenerationRequestSchema", () => {
         duration: 6,
         resolution: "480p",
         output: { upload_url: "https://example.test/upload" },
+      }).success,
+    ).toBe(false);
+    expect(
+      VideoGenerationRequestSchema.safeParse({
+        model: "grok-imagine-video-1.5",
+        prompt: "missing every reference",
+        aspect_ratio: "16:9",
+        duration: 15,
+        resolution: "480p",
+      }).success,
+    ).toBe(false);
+    expect(
+      VideoGenerationRequestSchema.safeParse({
+        model: "grok-imagine-video-1.5",
+        prompt: "too long",
+        reference_audios: [{ voice_id: "eve" }],
+        aspect_ratio: "16:9",
+        duration: 16,
+        resolution: "480p",
       }).success,
     ).toBe(false);
   });

--- a/packages/shared/src/request/videos-schema.ts
+++ b/packages/shared/src/request/videos-schema.ts
@@ -5,10 +5,11 @@ import { z } from "zod";
 // being silently forwarded before Helm has an end-to-end redaction contract for it.
 const VideoSourceSchema = z.strictObject({ url: z.string().min(1) });
 const VideoDurationSchema = z.union([z.literal(6), z.literal(10)]);
+const CurrentVideoModelSchema = z.literal("grok-imagine-video-1.5");
 const VideoResolutionSchema = z.enum(["480p", "720p"]);
 
 const SingleImageVideoRequestSchema = z.strictObject({
-  model: z.literal("grok-imagine-video-1.5-preview"),
+  model: z.union([z.literal("grok-imagine-video-1.5-preview"), CurrentVideoModelSchema]),
   // xAI permits an empty motion prompt for the single-image workflow.
   prompt: z.string(),
   image: VideoSourceSchema,
@@ -25,9 +26,35 @@ const ReferenceImageVideoRequestSchema = z.strictObject({
   resolution: VideoResolutionSchema,
 });
 
+const CurrentReferenceVideoRequestSchema = z
+  .strictObject({
+    model: CurrentVideoModelSchema,
+    prompt: z.string().min(1),
+    reference_images: z.array(VideoSourceSchema).max(7).optional(),
+    reference_audios: z
+      .array(
+        z.strictObject({
+          voice_id: z
+            .string()
+            .refine((value) => value.trim().length > 0, "voice_id must not be blank"),
+        }),
+      )
+      .max(3)
+      .optional(),
+    aspect_ratio: z.enum(["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]),
+    duration: z.number().int().min(1).max(15),
+    resolution: VideoResolutionSchema,
+  })
+  .refine(
+    (value) =>
+      (value.reference_images?.length ?? 0) > 0 || (value.reference_audios?.length ?? 0) > 0,
+    "at least one reference image or audio is required",
+  );
+
 export const VideoGenerationRequestSchema = z.union([
   SingleImageVideoRequestSchema,
   ReferenceImageVideoRequestSchema,
+  CurrentReferenceVideoRequestSchema,
 ]);
 
 // The provider body may contain extra task metadata. Helm validates only the


### PR DESCRIPTION
## Summary

- add OAuth routing, capability, pricing, lane, and Admin UI support for `grok-imagine-video-1.5`
- support image-to-video requests for 6 or 10 seconds
- support reference-image / preset-voice requests for 1–15 seconds, with up to 7 images and 3 voices
- add `reference_audios[].voice_id` validation
- retain `grok-imagine-video-1.5-preview` and `grok-imagine-video` aliases for compatibility
- update the Grok Imagine media specification and implementation notes

## Safety and compatibility

- xAI video routing remains OAuth-only
- single-write media semantics and fail-closed validation are unchanged
- ZDR `output` remains rejected
- existing preview and legacy model identifiers remain supported

## Verification

Passed locally:

- targeted Vitest suites: 28 passed, 125 skipped
- Admin provider tests: 2 passed
- shared, core, and gateway typechecks
- Admin `svelte-check`: 0 errors, 0 warnings
- Biome and Prettier checks
- `git diff --check`

Playwright did not complete locally: both the existing video journey and the new 1.5 case reached the xAI OAuth path, then the local dynamic-memory admission check returned HTTP 503 while reading the mocked upstream response. The failure was not retried blindly.

A paid SuperGrok canary was not run; production wire-model availability still requires an explicitly approved live verification.