### PR TITLE
Fix metadata-only request transcript loading

### DIFF
--- a/apps/admin/src/lib/api/requests.test.ts
+++ b/apps/admin/src/lib/api/requests.test.ts
@@ -23,6 +23,7 @@ function rawRecord(overrides: Record<string, unknown> = {}): Record<string, unkn
     requested_model: 'gpt-4o',
     requested_reasoning_effort: 'low',
     reasoning_effort: 'high',
+    request_content_mode: 'session',
     key_prefix: 'helm_live_ab12',
     classifier: {
       task_type: 'coding',
@@ -128,6 +129,7 @@ describe('toDetail', () => {
       requested_model: 'gpt-4o',
       reasoning_effort: 'high',
       policy_reason: 'matched',
+      request_content_mode: 'session',
     });
   });
 });

--- a/apps/admin/src/lib/api/requests.ts
+++ b/apps/admin/src/lib/api/requests.ts
@@ -262,6 +262,7 @@ interface RawDecisionRecord {
   requested_reasoning_effort?: string | null;
   reasoning_effort?: string | null;
   request_body_bytes?: number | null;
+  request_content_mode?: 'none' | 'payload' | 'session';
   // Display prefix only (helm_live_ab12) — the record NEVER carries the plaintext
   // key (Principle 7). Null/absent on legacy (pre-enrichment) records.
   key_prefix?: string | null;
@@ -619,6 +620,7 @@ function buildRequestMeta(raw: RawDecisionRecord): Record<string, unknown> {
     requested_model: raw.requested_model ?? null,
     reasoning_effort: raw.reasoning_effort ?? null,
     policy_reason: raw.policy?.reason ?? null,
+    ...(raw.request_content_mode ? { request_content_mode: raw.request_content_mode } : {}),
   };
 }
 
@@ -855,11 +857,13 @@ export interface RequestPayloadView {
   source?: 'payload' | 'session' | 'unavailable';
   reason?:
     | 'no_session'
+    | 'metadata_only'
     | 'session_unavailable'
     | 'session_incomplete'
     | 'session_recovery_limited'
     | 'response_unavailable';
   exact?: boolean;
+  browser_recoverable?: boolean;
   fidelity?: 'exact' | 'semantic' | 'partial' | string;
   request?: unknown;
   response?: unknown;
@@ -882,6 +886,7 @@ export interface RequestPayloadPartView {
   source?: 'payload' | 'session' | 'unavailable';
   reason?:
     | 'no_session'
+    | 'metadata_only'
     | 'session_unavailable'
     | 'session_incomplete'
     | 'session_recovery_limited'
@@ -1024,7 +1029,7 @@ export interface SessionRevisionView extends SessionRevisionForRestore {
 
 export interface SessionRevisionsPageView {
   captured: boolean;
-  reason?: 'no_session' | 'session_unavailable';
+  reason?: 'no_session' | 'metadata_only' | 'session_unavailable' | 'session_recovery_limited';
   sessionRef?: string;
   targetRequestId?: string;
   nextSequence?: number | null;

--- a/apps/admin/src/routes/requests/[traceId]/+page.svelte
+++ b/apps/admin/src/routes/requests/[traceId]/+page.svelte
@@ -534,7 +534,7 @@
         </p>
         <!-- Before rebuild: offer the button. On success transcriptLoaded flips and the
              captured-path branch above reuses the normal Conversation/Raw lenses. -->
-        {#if data.payload?.reason === 'session_recovery_limited'}
+        {#if data.payload?.reason === 'session_recovery_limited' && data.payload.browser_recoverable === true}
           <div class="mt-3 rounded border border-dashed border-border bg-canvas p-3">
             <p class="field-help mb-2">
               {$t('Rebuild the transcript in your browser instead of on the server.')}

--- a/apps/admin/src/routes/requests/requests.test.ts
+++ b/apps/admin/src/routes/requests/requests.test.ts
@@ -709,7 +709,11 @@ describe('requests detail page', () => {
     render(DetailPage, {
       data: {
         detail: detail(),
-        payload: { captured: false, reason: 'session_recovery_limited' },
+        payload: {
+          captured: false,
+          reason: 'session_recovery_limited',
+          browser_recoverable: true,
+        },
         requestId: 'tr_big',
       },
     });
@@ -877,6 +881,7 @@ describe('requests detail page', () => {
           captured: false,
           source: 'unavailable',
           reason: 'session_recovery_limited',
+          browser_recoverable: true,
         },
         requestId: 'tr_session_limited',
       },
@@ -890,6 +895,26 @@ describe('requests detail page', () => {
     expect(screen.queryByTestId('load-conversation')).not.toBeInTheDocument();
     expect(screen.queryByTestId('load-request-body')).not.toBeInTheDocument();
     expect(screen.getByTestId('load-transcript')).toBeInTheDocument();
+  });
+
+  it('hides transcript loading when the browser cannot safely page the recorded Session', () => {
+    render(DetailPage, {
+      data: {
+        detail: detail(),
+        payload: {
+          captured: false,
+          source: 'unavailable',
+          reason: 'session_recovery_limited',
+          browser_recoverable: false,
+        },
+        requestId: 'tr_session_browser_limited',
+      },
+    });
+
+    expect(screen.getByTestId('payload-summary')).toHaveTextContent(
+      'The session transcript is too large to rebuild on the server.',
+    );
+    expect(screen.queryByTestId('load-transcript')).not.toBeInTheDocument();
   });
 
   it('hides transcript loading when the recorded Session is unavailable', () => {

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -366,6 +366,7 @@ test.describe("admin request payload view", () => {
           captured: false,
           source: "unavailable",
           reason: "session_recovery_limited",
+          browser_recoverable: true,
         }),
       }),
     );

--- a/apps/gateway/src/routes/admin/admin.test.ts
+++ b/apps/gateway/src/routes/admin/admin.test.ts
@@ -2005,6 +2005,80 @@ describe("admin.api request payload", () => {
     });
   });
 
+  it("treats an explicitly metadata-only request as authoritative over orphan content rows", async () => {
+    const rec = {
+      ...decision("req_metadata_only", "balanced"),
+      request_content_mode: "none" as const,
+      session: { ref: "session-ref", label: "thread-1", source: "x-thread-id" as const },
+    };
+    const getPayloadMeta = vi.fn(async () => ({
+      requestId: "req_metadata_only",
+      createdAt: new Date(1234),
+      parts: { request: true, response: true, upstreamRequest: true },
+    }));
+    const getSessionRevisionMeta = vi.fn(async () => ({
+      requestId: "req_metadata_only",
+      sessionRef: "session-ref",
+      responseBodyStored: true,
+      recoveryWireBytes: 1_000_000,
+      fidelity: "semantic",
+      createdAt: new Date(1234),
+    }));
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayloadMeta,
+      getSessionRevisionMeta,
+    } as unknown as TelemetryStore;
+
+    const app = buildApp(buildDeps({ telemetry }));
+    const meta = await app.request("/admin/api/requests/req_metadata_only/payload?part=meta");
+    expect(await meta.json()).toEqual({
+      captured: false,
+      source: "unavailable",
+      reason: "metadata_only",
+    });
+    const revisions = await app.request("/admin/api/requests/req_metadata_only/session-revisions");
+    expect(await revisions.json()).toEqual({ captured: false, reason: "metadata_only" });
+    expect(getPayloadMeta).not.toHaveBeenCalled();
+    expect(getSessionRevisionMeta).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { maxRevisionWireBytes: 100_000, browserRecoverable: true },
+    { maxRevisionWireBytes: 2_000_000, browserRecoverable: false },
+  ])("advertises browser recovery only when every revision fits its JSON response bound", async ({
+    maxRevisionWireBytes,
+    browserRecoverable,
+  }) => {
+    const rec = {
+      ...decision("req_session_browser", "balanced"),
+      request_content_mode: "session" as const,
+      session: { ref: "session-ref", label: "thread-1", source: "x-thread-id" as const },
+    };
+    const telemetry = {
+      ...makeTelemetry([rec]),
+      getPayloadMeta: async () => null,
+      getSessionRevisionMeta: async () => ({
+        requestId: "req_session_browser",
+        sessionRef: "session-ref",
+        responseBodyStored: true,
+        recoveryWireBytes: 1_000_000,
+        maxRevisionWireBytes,
+        fidelity: "semantic",
+        createdAt: new Date(1234),
+      }),
+    } as unknown as TelemetryStore;
+
+    const response = await buildApp(buildDeps({ telemetry })).request(
+      "/admin/api/requests/req_session_browser/payload?part=meta",
+    );
+    expect(await response.json()).toMatchObject({
+      captured: false,
+      reason: "session_recovery_limited",
+      browser_recoverable: browserRecoverable,
+    });
+  });
+
   it.each([
     null,
     1_000_000,
@@ -2037,6 +2111,7 @@ describe("admin.api request payload", () => {
       captured: false,
       source: "unavailable",
       reason: "session_recovery_limited",
+      browser_recoverable: false,
     });
   });
 

--- a/apps/gateway/src/routes/admin/requests.ts
+++ b/apps/gateway/src/routes/admin/requests.ts
@@ -150,12 +150,16 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
     const traceId = c.req.param("traceId");
     const part = parsePayloadPart(c.req.query("part"));
     if (part === "invalid") return c.json({ error: "invalid payload part" }, 400);
+    const recordedDecision = await deps.telemetry.getByRequestId(traceId);
+    if (recordedDecision?.request_content_mode === "none") {
+      return c.json({ captured: false, source: "unavailable", reason: "metadata_only" });
+    }
     if (part === "meta") {
       const meta = await getPayloadMeta(deps, traceId);
       if (!meta) {
         const sessionMeta = await deps.telemetry.getSessionRevisionMeta?.(traceId);
         if (sessionMeta) {
-          const decision = await deps.telemetry.getByRequestId(traceId);
+          const decision = recordedDecision;
           if (decision?.session?.ref !== sessionMeta.sessionRef) {
             return c.json({
               captured: false,
@@ -172,6 +176,11 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
               captured: false,
               source: "unavailable",
               reason: "session_recovery_limited",
+              browser_recoverable:
+                sessionMeta.maxRevisionWireBytes !== null &&
+                sessionMeta.maxRevisionWireBytes !== undefined &&
+                sessionMeta.maxRevisionWireBytes * runtimeMemoryBudget().jsonAmplification <=
+                  SESSION_REVISION_PAGE_MAX_BYTES,
             });
           }
           return c.json({
@@ -370,6 +379,9 @@ export function registerRequestsRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): v
     // no_session (not a session request at all) is more fundamental than the store's
     // paging capability, so resolve the session ref FIRST.
     const decision = await deps.telemetry.getByRequestId(traceId);
+    if (decision?.request_content_mode === "none") {
+      return c.json({ captured: false, reason: "metadata_only" });
+    }
     const sessionRef = decision?.session?.ref;
     if (!sessionRef) return c.json({ captured: false, reason: "no_session" });
     // Streaming variant (NOT the all-or-nothing listSessionRevisionsPage the server-side

--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -1590,6 +1590,27 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     expect(s.payloads).toHaveLength(1);
   });
 
+  it.each([
+    { mode: "none", capturePayloads: false, captureSessions: false },
+    { mode: "payload", capturePayloads: true, captureSessions: false },
+    { mode: "session", capturePayloads: false, captureSessions: true },
+  ] as const)("records the effective $mode content mode in body-free telemetry", async (row) => {
+    const s = sink();
+    await recordServed(
+      {
+        telemetry: s.telemetry,
+        redact: (x) => x,
+        now: () => 5000,
+        capturePayloads: () => row.capturePayloads,
+        captureSessions: () => row.captureSessions,
+      },
+      { ...args, requestId: `req_${row.mode}` },
+      () => {},
+    );
+
+    expect(s.inserted[0]?.request_content_mode).toBe(row.mode);
+  });
+
   it("records a timed-out request as an error even if the provider later completed", async () => {
     const s = sink();
     const d: RecordServedDeps = {

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -320,6 +320,12 @@ export function sessionCaptureEnabled(deps: PayloadCaptureDeps): boolean {
   return deps.captureSessions?.() === true;
 }
 
+function effectiveRequestContentMode(deps: PayloadCaptureDeps): RequestContentMode {
+  if (captureEnabled(deps)) return "payload";
+  if (sessionCaptureEnabled(deps)) return "session";
+  return "none";
+}
+
 function capturedResponseObject(value: unknown): {
   responseId: string;
   responseJson: string;
@@ -744,6 +750,7 @@ export async function recordServed(
   const storageDecision: DecisionRecord = {
     ...stampRequestBodyBytes(args.decision, args.requestJson, args.requestBodyBytes),
     request_id: args.requestId,
+    request_content_mode: effectiveRequestContentMode(deps),
   };
   const decision =
     args.timedOut === true ? decisionForTimedOutRequest(storageDecision) : storageDecision;

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-15 · 请求级正文模式成为历史读取权威（Telemetry / Admin requests，docs/07/11，原则 3/7）
+
+- **根因与修复**：Admin 只按 `request_payloads` / `session_revisions` 是否存在推断历史请求的正文模式，无法证明请求发生时 Key 与系统设置的实际合并结果；大型 Session 的元数据也只证明服务端整体恢复超限，却仍无条件展示浏览器加载按钮，即使某条 revision 会被同一分页接口的 JSON 内存上限拒绝。每条新 telemetry 现在保存 body-free 的有效 `request_content_mode`；明确 `none` 时任何孤立正文行都不可读取、也不显示加载入口，旧记录继续按存储事实兼容推断。
+- **加载边界**：SQLite/Postgres 在既有 Session 元数据聚合中同时返回目标链最大单 revision 字节数；Admin 用分页端点相同的 JSON amplification 与 8 MiB 上限决定 `browser_recoverable`，不可安全分页时不再提供必然失败的按钮。该元数据不读取正文、不改变正文格式、无需 migration；当前设置仍不追溯删除历史内容。
+
 ## 2026-08-15 · 大型完整载荷改由浏览器解压与恢复图片（Store / Admin requests，docs/07/11，原则 1/3/7）
 
 - **根因与修复**：SQLite `request_payloads` 的单列 gzip 读取沿用了 Session 单块 256 KiB 解压上限，超过该值的真实正文被映射为 `null`，Admin 随后错误回退到 Session 恢复。Admin 现在优先请求存储态正文；SQLite 原样返回 gzip BLOB，Postgres 返回 raw TEXT，由浏览器通过 HTTP `Content-Encoding` 流式解压并拼装，不再在网关内物化放大的正文。
@@ -59,15 +64,9 @@
 - **实现**：复用既有 `oauth_reset_period`，统一记录刚结束的 `[previousStart,actualResetAt)`；PULL、Codex header PUSH、手动/自动 reset-credit 共用记录入口。quota snapshot 按 `capturedAt` 单调更新，晚到的旧采样既不覆盖新状态，也不写伪 reset。旧版 `detectedAtMs < periodEndMs` 行只在读取时忽略，不改写历史库；本地“Reset usage”仍只清 Helm cooldown，不冒充上游重置。
 - **精度边界**：usage 继续按小时聚合，但真实重置发生在小时中间时，新请求的 bucket 起点提升到最近 reset point，因此不会再跨边界混入上一周期。部署前已经落入旧整点 bucket 的历史数据不可逆，继续标 `≈`/`partial`；新记录到的真实边界作为精确周期返回。Admin 默认显示 Period，并保留 Daily / Weekly 兼容视图。
 
-## 2026-08-10 · 大 Session 客户端重建按记录时间展示并提前停止分页（Admin / requests debug，docs/07/11，原则 1/3/7）
-
-- **现场与根因**：生产 v0.28.56 的目标详情点击后约 46 秒才完成，普通 Conversation 把重建后的请求 `input` 与最终响应折成一条聊天；现场原始 `input` 自身就是角色分段排列，因此 UI 没有再次排序，但这种折叠不能代表 Session 的真实请求/响应发生顺序。大 Session 客户端路径还丢弃了目标 revision 已保存的 `responseJson`，所以最终响应只能退化成脱敏 metadata。
-- **展示修复**：raw revision API 增加已有的 `sequence` 与 `createdAt`；浏览器把每个 revision 的 request delta / response snapshot 组成记录，按 `createdAt` 升序、`sequence` 稳定打破同毫秒并列。目标请求和目标响应继续进入原有 Conversation/Response viewer；额外时间线使用 `JsonViewer` 展示持久化 revision 记录，避免把“请求文档顺序”误称为“会话时间线”。
-- **加载加速**：浏览器一旦收到目标 revision 就停止游标分页，不再下载该目标之后的同 Session revision；行上限从 50 恢复到 100，单页 `maxBytes=8 MiB` 不变，所以服务端单请求正文物化上限不扩大。没有改成多进程/并发请求，因为下一页游标依赖上一页的 soft-byte 结果，并发会产生跳页或重复读取风险。
-- **边界**：时间线展示的是持久化的增量 request delta 与可用 response snapshot，不伪装成原始 HTTP body；Session 恢复仍是 `exact=false`、不可精确 Retry。响应为空表示当时没有可用快照，不补造内容。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-10 · 大 Session 客户端重建按记录时间展示并提前停止分页**：目标 revision 到达即停，按 `createdAt`/`sequence` 展示持久化增量请求与响应快照；Session 仍为 `exact=false` 且不可精确 Retry，完整原文经 git history 回溯。
 - **2026-08-08 · Grok Imagine 仅复用 SuperGrok OAuth 媒体链路**：媒体执行复用 xAI 订阅 OAuth，付费 POST 单写且不跨账号重试，未知价格对美元预算 fail-closed；完整原文经 git history 回溯。
 - **2026-08-08 · 会话转录客户端重建，绕开服务端内存阀**：长 Session 以 4 MiB/100 行游标分页传给浏览器本地重建，小 Session 保留服务端快路径；共享纯重建函数留在浏览器安全的 `@helm/shared`，完整原文经 git history 回溯。
 - **2026-08-07 · 真上游上下文溢出短路直返 400**：确定性上游 400/413/422 上下文溢出立即返回客户端并保留原始错误；预检估算仍允许 fallback，可重试状态不误判为客户端错误，完整原文经 git history 回溯。

--- a/packages/core/src/store/ports.ts
+++ b/packages/core/src/store/ports.ts
@@ -441,6 +441,9 @@ export interface SessionRevisionMetaRecord extends SessionContinuationRecord {
   // UTF-8 bytes the current recovery path must materialize through this revision.
   // null means legacy storage cannot be measured safely, so callers fail closed.
   recoveryWireBytes: number | null;
+  // Largest decoded revision through the target. Admin uses the same JSON
+  // amplification bound as its paging endpoint before offering browser recovery.
+  maxRevisionWireBytes: number | null;
   fidelity: string;
   createdAt: Date;
 }

--- a/packages/core/src/store/postgres/telemetry.ts
+++ b/packages/core/src/store/postgres/telemetry.ts
@@ -627,7 +627,10 @@ export class PgTelemetryStore implements TelemetryStore {
     const row = rows[0];
     if (!row) return null;
     const recoveryRows = await this.db
-      .select({ bytes: sql<number>`sum(${sessionRevisionWireBytes})` })
+      .select({
+        bytes: sql<number>`sum(${sessionRevisionWireBytes})`,
+        maxBytes: sql<number>`max(${sessionRevisionWireBytes})`,
+      })
       .from(sessionRevisions)
       .where(
         and(
@@ -636,6 +639,7 @@ export class PgTelemetryStore implements TelemetryStore {
         ),
       );
     const recoveryWireBytes = Number(recoveryRows[0]?.bytes);
+    const maxRevisionWireBytes = Number(recoveryRows[0]?.maxBytes);
     return {
       requestId: row.requestId,
       sessionRef: row.sessionRef,
@@ -643,6 +647,10 @@ export class PgTelemetryStore implements TelemetryStore {
       recoveryWireBytes:
         Number.isSafeInteger(recoveryWireBytes) && recoveryWireBytes >= 0
           ? recoveryWireBytes
+          : null,
+      maxRevisionWireBytes:
+        Number.isSafeInteger(maxRevisionWireBytes) && maxRevisionWireBytes >= 0
+          ? maxRevisionWireBytes
           : null,
       fidelity: row.fidelity,
       createdAt: new Date(row.createdAt),

--- a/packages/core/src/store/sqlite/telemetry.ts
+++ b/packages/core/src/store/sqlite/telemetry.ts
@@ -715,6 +715,14 @@ export class SqliteTelemetryStore implements TelemetryStore {
           ) THEN 1 ELSE 0 END) > 0 THEN NULL
           ELSE sum(${sessionRevisionWireBytes})
         END`,
+        maxBytes: sql<number | null>`CASE
+          WHEN sum(CASE WHEN ${sessionRevisions.bodyBytes} IS NULL AND (
+            typeof(${sessionRevisions.requestDeltaJson}) = 'blob' OR
+            typeof(${sessionRevisions.requestEnvelopeJson}) = 'blob' OR
+            typeof(${sessionRevisions.responseJson}) = 'blob'
+          ) THEN 1 ELSE 0 END) > 0 THEN NULL
+          ELSE max(${sessionRevisionWireBytes})
+        END`,
       })
       .from(sessionRevisions)
       .where(
@@ -725,6 +733,7 @@ export class SqliteTelemetryStore implements TelemetryStore {
       )
       .get();
     const recoveryWireBytes = Number(recovery?.bytes);
+    const maxRevisionWireBytes = Number(recovery?.maxBytes);
     return {
       requestId: row.requestId,
       sessionRef: row.sessionRef,
@@ -734,6 +743,12 @@ export class SqliteTelemetryStore implements TelemetryStore {
         Number.isSafeInteger(recoveryWireBytes) &&
         recoveryWireBytes >= 0
           ? recoveryWireBytes
+          : null,
+      maxRevisionWireBytes:
+        recovery?.maxBytes !== null &&
+        Number.isSafeInteger(maxRevisionWireBytes) &&
+        maxRevisionWireBytes >= 0
+          ? maxRevisionWireBytes
           : null,
       fidelity: row.fidelity,
       createdAt: row.createdAt,

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -648,6 +648,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         sessionRef: "s_1",
         responseBodyStored: true,
         recoveryWireBytes: expectedR1RecoveryBytes,
+        maxRevisionWireBytes: expectedR1RecoveryBytes,
         fidelity: "verbatim",
         createdAt: new Date(1000),
       });
@@ -659,6 +660,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
         64;
       expect(await t.getSessionRevisionMeta("r2")).toMatchObject({
         recoveryWireBytes: expectedR2RecoveryBytes,
+        maxRevisionWireBytes: expectedR2RecoveryBytes - expectedR1RecoveryBytes,
       });
       expect(await t.listSessionRevisions("s_1")).toEqual([
         expect.objectContaining({

--- a/packages/shared/src/decision/schema.test.ts
+++ b/packages/shared/src/decision/schema.test.ts
@@ -92,6 +92,17 @@ function passthroughRecord(model = "gpt-4o-mini") {
 }
 
 describe("DecisionRecordSchema", () => {
+  it("records the effective request content mode while keeping legacy rows valid", () => {
+    expect(DecisionRecordSchema.parse(fullRecord()).request_content_mode).toBeUndefined();
+    expect(
+      DecisionRecordSchema.parse({ ...fullRecord(), request_content_mode: "none" })
+        .request_content_mode,
+    ).toBe("none");
+    expect(
+      DecisionRecordSchema.safeParse({ ...fullRecord(), request_content_mode: "invalid" }).success,
+    ).toBe(false);
+  });
+
   it("records the UTF-8 request body byte count while keeping legacy rows valid", () => {
     expect(DecisionRecordSchema.parse(fullRecord()).request_body_bytes).toBeUndefined();
     expect(

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { RequestContentModeSchema } from "../key/schema.js";
 import {
   NativePassthroughMutationLedgerSchema,
   ProtocolSchema,
@@ -286,6 +287,9 @@ export const DecisionRecordSchema = z.object({
   // Body-free telemetry only: the bytes themselves remain governed by capture mode.
   // null/absent for legacy rows that predate measurement.
   request_body_bytes: z.number().int().nonnegative().nullable().optional(),
+  // Effective content-retention mode for this request. Unlike the mutable key/system
+  // settings, this body-free marker makes historical Admin reads authoritative.
+  request_content_mode: RequestContentModeSchema.optional(),
   // Total served latency = Σ provider_attempts.latency_ms (docs/07 latency).
   // `.default(0)` so legacy records validate; the builder computes the real sum.
   latency_total_ms: z.number().nonnegative().default(0),


### PR DESCRIPTION
## Summary
- persist the effective request content mode in body-free telemetry
- treat recorded metadata-only mode as authoritative over orphan payload/session rows
- expose browser transcript rebuild only when each revision fits the Admin paging memory bound

## Validation
- `CI=true pnpm exec vitest run packages/shared/src/decision/schema.test.ts apps/gateway/src/routes/payload-capture.test.ts packages/core/src/store/store-contract.test.ts apps/gateway/src/routes/admin/admin.test.ts apps/admin/src/lib/api/requests.test.ts apps/admin/src/routes/requests/requests.test.ts` (503 passed)
- `pnpm typecheck`
- `pnpm --filter @helm/admin check`
- targeted Biome and Prettier checks
- `git diff --check`