### PR TITLE
Release v0.28.73

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.72",
+  "version": "0.28.73",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from `0.28.72` to `0.28.73`
- release the metadata-only request transcript-loader fix merged in #756

## Release assessment
Patch release: user-visible Admin correctness fix with additive body-free telemetry metadata and Store response metadata; no database migration or config change.