### PR TITLE
Fix parentless automatic Memory scopes

### DIFF
--- a/apps/gateway/src/routes/messages-pipeline.errors.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.errors.test.ts
@@ -142,7 +142,9 @@ describe("createMessagesPipeline — translate collect() governance", () => {
     );
 
     const run = await pipeline.run(
-      irOf({ metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" } }),
+      irOf({
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
+      }),
       BUDGET_IDENTITY,
       new AbortController().signal,
     );
@@ -182,7 +184,7 @@ describe("createMessagesPipeline — translate streamIR() governance finally", (
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       BUDGET_IDENTITY,
       new AbortController().signal,
@@ -314,7 +316,9 @@ describe("createMessagesPipeline — deferred observe via write queue", () => {
     );
 
     const run = await pipeline.run(
-      irOf({ metadata: { trace_id: "t", thread_id: "th-q", memory_mode: "observe" } }),
+      irOf({
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-q", memory_mode: "observe" },
+      }),
       IDENTITY,
       new AbortController().signal,
     );
@@ -343,7 +347,9 @@ describe("createMessagesPipeline — passthrough collect() OAuth + observe", () 
     );
 
     const run = await pipeline.run(
-      irOf({ metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" } }),
+      irOf({
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
+      }),
       IDENTITY,
       new AbortController().signal,
     );
@@ -414,7 +420,7 @@ describe("createMessagesPipeline — passthrough streamIR() OAuth + observe fina
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       BUDGET_IDENTITY,
       new AbortController().signal,

--- a/apps/gateway/src/routes/messages-pipeline.test.ts
+++ b/apps/gateway/src/routes/messages-pipeline.test.ts
@@ -742,7 +742,9 @@ describe("createMessagesPipeline — native passthrough collect()", () => {
     const route: RouteFn = async () => passthroughOkResult();
     const pipeline = createMessagesPipeline(route, "anthropic_messages", { observe });
     const run = await pipeline.run(
-      irOf({ metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" } }),
+      irOf({
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
+      }),
       IDENTITY,
       new AbortController().signal,
     );
@@ -994,7 +996,7 @@ describe("createMessagesPipeline — native passthrough streamIR()", () => {
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       IDENTITY,
       new AbortController().signal,
@@ -1269,7 +1271,7 @@ describe("createMessagesPipeline — openai_responses native passthrough streamI
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       IDENTITY,
       new AbortController().signal,
@@ -1359,7 +1361,9 @@ describe("createMessagesPipeline — openai_responses native passthrough collect
       { observe },
     );
     const run = await pipeline.run(
-      irOf({ metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" } }),
+      irOf({
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
+      }),
       IDENTITY,
       new AbortController().signal,
     );
@@ -1496,7 +1500,9 @@ describe("createMessagesPipeline — gemini native passthrough collect()", () =>
       { observe },
     );
     const run = await pipeline.run(
-      irOf({ metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" } }),
+      irOf({
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
+      }),
       IDENTITY,
       new AbortController().signal,
     );
@@ -1565,7 +1571,7 @@ describe("createMessagesPipeline — gemini native passthrough streamIR()", () =
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       IDENTITY,
       new AbortController().signal,
@@ -2267,7 +2273,9 @@ describe("createMessagesPipeline — writes queue (line 635-641)", () => {
       writes,
     );
     const run = await pipeline.run(
-      irOf({ metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" } }),
+      irOf({
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
+      }),
       IDENTITY,
       new AbortController().signal,
     );
@@ -2286,7 +2294,7 @@ describe("createMessagesPipeline — accumulateAssistantText via streamIR (lines
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       IDENTITY,
       new AbortController().signal,
@@ -2306,7 +2314,7 @@ describe("createMessagesPipeline — accumulateAssistantText via streamIR (lines
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       IDENTITY,
       new AbortController().signal,
@@ -2341,7 +2349,7 @@ describe("createMessagesPipeline — accumulateAnthropicAssistantText edge cases
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       IDENTITY,
       new AbortController().signal,
@@ -2372,7 +2380,7 @@ describe("createMessagesPipeline — accumulateAnthropicAssistantText edge cases
     const run = await pipeline.run(
       irOf({
         stream: true,
-        metadata: { trace_id: "t", thread_id: "th-1", memory_mode: "observe" },
+        metadata: { trace_id: "t", project_id: "p1", thread_id: "th-1", memory_mode: "observe" },
       }),
       IDENTITY,
       new AbortController().signal,

--- a/docs/08-memory-middleware.md
+++ b/docs/08-memory-middleware.md
@@ -65,6 +65,10 @@ Resolution is centralized in
    resolves to no thread and suppresses automatic thread derivation for that
    request.
 
+Automatic persistence requires a thread plus at least one project or resource
+parent. A parentless scope is logged and skipped, so it cannot create a top-level
+thread in the Memory scope list.
+
 New user keys are minted with:
 
 ```text
@@ -166,9 +170,10 @@ the protocol-native cached prefix.
 
 Only non-empty sections are emitted. There is no thread-reflection slot in the
 automatic inject path: it reads exact project and resource reflections plus
-thread observations. A thread-only reflection can exist through direct
-management calls, but the automatic worker does not promote thread-only
-observer jobs to a reflector and inject does not load that reflection.
+thread observations. A thread-only reflection can exist through historical or
+direct management data, but automatic persistence does not create one. The
+worker rejects a persisted thread-only Reflector job before reading or writing
+memory, and inject does not load that reflection.
 
 ### Stored raw rows are not re-injected
 
@@ -285,6 +290,9 @@ rebuilds from that bounded active set without feeding the old reflection back to
 the model. Reconciled facts, the reflection write/archive action, and job
 completion publish in one fenced transaction, so an in-flight stale Reflector
 cannot resurrect archived text.
+
+Decay still archives a historical parentless observation, but does not enqueue
+a thread-only reflection rebuild.
 
 When forgetting is enabled and the active-observation token sum reaches
 `consolidate.trigger_tokens`, the Reflector also extracts facts. Observation

--- a/docs/12-memory-forgetting-and-tiering.md
+++ b/docs/12-memory-forgetting-and-tiering.md
@@ -70,7 +70,7 @@ threads:
 ```text
 uncovered user raw turns
   -> background Observer fact extraction
-  -> project/resource fact, or thread fact when no broader scope exists
+  -> project/resource fact; skip when neither parent exists
 ```
 
 No transition deletes raw messages. Separate cleanup settings may archive/prune
@@ -210,7 +210,8 @@ The sweep:
 4. stops at `max_iterations`, `max_wallclock_s`, or
    `max_consecutive_errors`;
 5. in the same database transaction, enqueues coalesced reflector rebuilds for
-   the exact project/resource/thread scopes whose observations were archived.
+   the exact project/resource scopes whose observations were archived; a
+   parentless historical observation is archived without a rebuild.
 
 The scan itself is bounded at `max_iterations * 50`. Failures over-retain and
 log; they do not affect an in-flight model request.

--- a/docs/salient-fact-memory-spec.md
+++ b/docs/salient-fact-memory-spec.md
@@ -126,8 +126,8 @@ The model returns raw `{subjectText, factText}`. Core then uses
 - supply `validFrom` from the extraction run time.
 
 The write scope carries both project and resource when both exist. If neither
-exists, it falls back to the storage thread id. It never writes an account-wide
-empty-scope fact.
+exists, eager extraction is skipped; it never creates a thread-only or
+account-wide fact.
 
 Persistence calls `insertFactsReconciled.call(memoryStore, ...)`. The explicit
 receiver binding is required because real store methods read `this.db`; an older

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-15 · 自动 Memory 形成必须挂在项目或资源下（Memory Observer / Reflector / Store，docs/08/12，原则 3/7）
+
+- **根因与修复**：历史 quarantine thread 没有项目/资源；decay 归档 observation 时把它回退成 thread-only Reflector scope，随后生成 Admin「按范围」里没有父级的 active reflection。请求 observe writeback 与 eager fact 路径也允许相同的孤立范围。现在入站/出站观察在缺少项目和资源时直接 fail-open 跳过，eager extraction 不调用模型，Reflector 对已持久化的孤立 job 在任何读写前标记失败。
+- **遗忘与兼容**：SQLite/Postgres 仍会软归档历史孤立 observation，但不再排 thread-only rebuild；正常 project/resource rebuild 与直接管理的历史数据格式不变，无 schema/migration 或新依赖。现有孤立 active facts/reflections 不由升级代码猜测删除，需按运维范围显式清理。
+
 ## 2026-08-15 · 请求级正文模式成为历史读取权威（Telemetry / Admin requests，docs/07/11，原则 3/7）
 
 - **根因与修复**：Admin 只按 `request_payloads` / `session_revisions` 是否存在推断历史请求的正文模式，无法证明请求发生时 Key 与系统设置的实际合并结果；大型 Session 的元数据也只证明服务端整体恢复超限，却仍无条件展示浏览器加载按钮，即使某条 revision 会被同一分页接口的 JSON 内存上限拒绝。每条新 telemetry 现在保存 body-free 的有效 `request_content_mode`；明确 `none` 时任何孤立正文行都不可读取、也不显示加载入口，旧记录继续按存储事实兼容推断。
@@ -58,14 +63,9 @@
 - **回归**：上一版为了展示时间线，把 `transcriptLoaded` 后的主请求区域强制切到 `JsonViewer`，隐藏了服务端恢复路径使用的 Conversation/Raw tabs，导致客户端加载后的可读性明显下降。
 - **修复**：客户端只替换数据获取与重建方式；重建完成后继续走同一套 Conversation、Raw `JsonViewer`、Response `StreamViewer/JsonViewer` 路径。按记录时间排序的 revision 时间线仍作为额外审计视图保留。
 
-## 2026-08-10 · 配额统计按真实重置点切分（OAuth quota / Admin providers，docs/04/11，原则 3/7）
-
-- **根因**：旧 writer 在 `resetsAtMs` 推进时写入 `[oldReset,newReset)`，把新周期误当成已结束历史；自然周 UI 又掩盖了 OpenAI 提前重置、reset-credit 重置和非整点边界，所以“每周”并不等于真实额度周期。
-- **实现**：复用既有 `oauth_reset_period`，统一记录刚结束的 `[previousStart,actualResetAt)`；PULL、Codex header PUSH、手动/自动 reset-credit 共用记录入口。quota snapshot 按 `capturedAt` 单调更新，晚到的旧采样既不覆盖新状态，也不写伪 reset。旧版 `detectedAtMs < periodEndMs` 行只在读取时忽略，不改写历史库；本地“Reset usage”仍只清 Helm cooldown，不冒充上游重置。
-- **精度边界**：usage 继续按小时聚合，但真实重置发生在小时中间时，新请求的 bucket 起点提升到最近 reset point，因此不会再跨边界混入上一周期。部署前已经落入旧整点 bucket 的历史数据不可逆，继续标 `≈`/`partial`；新记录到的真实边界作为精确周期返回。Admin 默认显示 Period，并保留 Daily / Weekly 兼容视图。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-10 · 配额统计按真实重置点切分**：PULL、Codex header 与 reset-credit 共用真实周期边界，晚到采样不写伪 reset；旧整点历史不可逆并继续标记为近似/部分数据，完整原文经 git history 回溯。
 - **2026-08-10 · 大 Session 客户端重建按记录时间展示并提前停止分页**：目标 revision 到达即停，按 `createdAt`/`sequence` 展示持久化增量请求与响应快照；Session 仍为 `exact=false` 且不可精确 Retry，完整原文经 git history 回溯。
 - **2026-08-08 · Grok Imagine 仅复用 SuperGrok OAuth 媒体链路**：媒体执行复用 xAI 订阅 OAuth，付费 POST 单写且不跨账号重试，未知价格对美元预算 fail-closed；完整原文经 git history 回溯。
 - **2026-08-08 · 会话转录客户端重建，绕开服务端内存阀**：长 Session 以 4 MiB/100 行游标分页传给浏览器本地重建，小 Session 保留服务端快路径；共享纯重建函数留在浏览器安全的 `@helm/shared`，完整原文经 git history 回溯。

--- a/packages/core/src/memory/observe.test.ts
+++ b/packages/core/src/memory/observe.test.ts
@@ -182,6 +182,25 @@ describe("observeInbound", () => {
     expect(messages).toHaveLength(0);
   });
 
+  it("does not create a thread without a project or resource", async () => {
+    const { store, threads, messages } = makeFakeStore();
+    const log = vi.fn();
+    const deps = makeDeps(store, { log });
+
+    const out = await observeInbound(
+      deps,
+      scope({ projectId: null, resourceId: null }),
+      SAMPLE_MESSAGES,
+    );
+
+    expect(out.persisted).toBe(false);
+    expect(threads).toEqual([]);
+    expect(messages).toEqual([]);
+    expect(log).toHaveBeenCalledWith("memory.observe.skip_no_parent_scope", {
+      memory_mode: "observe",
+    });
+  });
+
   it("reports memoryMeta with memory_hydrated=false and the docs/08 debug field set", async () => {
     const { store } = makeFakeStore();
     const deps = makeDeps(store);
@@ -219,6 +238,27 @@ describe("observeInbound", () => {
 });
 
 describe("observeOutbound", () => {
+  it("does not write or enqueue without a project or resource", async () => {
+    const { store, messages, stamps } = makeFakeStore();
+    const enqueueObserverJob = vi.fn(async () => "observer-job");
+    const log = vi.fn();
+    const deps = makeDeps(store, { enqueueObserverJob, log });
+
+    await observeOutbound(
+      deps,
+      scope({ projectId: null, resourceId: null }),
+      { responseMessages: [{ role: "assistant", content: "hi" }], toolResults: [] },
+      "openai/gpt-x",
+    );
+
+    expect(messages).toEqual([]);
+    expect(stamps).toEqual([]);
+    expect(enqueueObserverJob).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith("memory.observe.skip_no_parent_scope", {
+      memory_mode: "observe",
+    });
+  });
+
   it("enqueues one coalesced observer job in pure observe mode", async () => {
     const { store } = makeFakeStore();
     const enqueueObserverJob = vi.fn(async () => "observer-job");

--- a/packages/core/src/memory/observe.ts
+++ b/packages/core/src/memory/observe.ts
@@ -141,6 +141,10 @@ export async function observeInbound(
   if (scope.mode === "off") {
     return { persisted: false, memoryMeta: meta };
   }
+  if (scope.projectId === null && scope.resourceId === null) {
+    deps.log("memory.observe.skip_no_parent_scope", { memory_mode: scope.mode });
+    return { persisted: false, memoryMeta: meta };
+  }
   // observe requires a thread scope; without one there is nothing to attach
   // messages to — degrade to no-op rather than fabricating an id.
   if (scope.threadId === null) {
@@ -194,6 +198,10 @@ export async function observeOutbound(
   servedModel?: string | null,
 ): Promise<void> {
   if (scope.mode === "off") return;
+  if (scope.projectId === null && scope.resourceId === null) {
+    deps.log("memory.observe.skip_no_parent_scope", { memory_mode: scope.mode });
+    return;
+  }
   const threadId = storageThreadId(scope);
   if (threadId === null) return;
 

--- a/packages/core/src/memory/observer.test.ts
+++ b/packages/core/src/memory/observer.test.ts
@@ -516,10 +516,7 @@ describe("runObserverJob — eager fact extraction", () => {
     expect(boundInput).not.toBeNull();
   });
 
-  it("scopes a thread-only job's fact to the thread (never account-wide)", async () => {
-    // Job with NO project/resource (a valid default when no project header/default
-    // is set). The fact must carry threadId — writing it scopeless would leak a
-    // thread-local statement into every other conversation in the account.
+  it("does not extract or persist facts for a thread-only job", async () => {
     const { store, factCalls } = makeFakeStore(makeShortThread());
     const extractFactsFromMessages = vi.fn(async () => [eagerFact]);
     const deps = makeDeps(store, { extractFactsFromMessages });
@@ -527,10 +524,8 @@ describe("runObserverJob — eager fact extraction", () => {
 
     await runObserverJob(job, deps);
 
-    expect(factCalls).toHaveLength(1);
-    expect(factCalls[0]).toMatchObject({ accountId: "acct-a", scope: { threadId: "thread-1" } });
-    expect(factCalls[0]?.scope).not.toHaveProperty("projectId");
-    expect(factCalls[0]?.facts[0]).toMatchObject({ ownerId: "acct-a", threadId: "thread-1" });
+    expect(extractFactsFromMessages).not.toHaveBeenCalled();
+    expect(factCalls).toEqual([]);
   });
 
   it("skips the LLM call when the uncovered turns contain no user message", async () => {

--- a/packages/core/src/memory/observer.ts
+++ b/packages/core/src/memory/observer.ts
@@ -39,6 +39,7 @@ async function maybeEagerExtractFacts(
   covered: Set<string>,
   deps: ObserverDeps,
 ): Promise<void> {
+  if (job.projectId === undefined && job.resourceId === undefined) return;
   const extract = deps.extractFactsFromMessages;
   const insert = deps.memoryStore.insertFactsReconciled;
   if (extract === undefined || insert === undefined) return;
@@ -65,16 +66,10 @@ async function maybeEagerExtractFacts(
       extracted = await extract({ messages: userMessages, now });
     }
     if (extracted.length === 0) return;
-    // Scope the fact at the broadest cross-thread level the job carries. With NEITHER
-    // project nor resource (a valid thread-only job), fall back to the THREAD — never
-    // an empty scope, which would persist an account-wide fact and leak a thread-local
-    // statement into unrelated conversations (Codex review fix).
+    // Scope the fact at the broadest cross-thread level the job carries.
     const scope: { projectId?: string; resourceId?: string; threadId?: string } = {};
     if (job.projectId !== undefined) scope.projectId = job.projectId;
     if (job.resourceId !== undefined) scope.resourceId = job.resourceId;
-    if (scope.projectId === undefined && scope.resourceId === undefined) {
-      scope.threadId = job.threadId;
-    }
     const facts = buildReconciledFactBatch({
       extracted,
       ownerId: job.accountId,
@@ -208,7 +203,7 @@ export interface ObserverJob {
   // verbatim from the enqueued job (the worker already has it — observer jobs are
   // enqueued with the full {accountId, projectId?, resourceId?, threadId} scope).
   // Eager facts are written at this scope so they are recallable in a NEW thread.
-  // Absent ⇒ thread-only; the eager pass then writes a thread-scoped fact.
+  // Absent ⇒ thread-only; the eager pass skips fact extraction.
   projectId?: string;
   resourceId?: string;
 }

--- a/packages/core/src/memory/reflector.test.ts
+++ b/packages/core/src/memory/reflector.test.ts
@@ -81,7 +81,11 @@ function makeObservations(texts: string[]): Observation[] {
 }
 
 const NOW = new Date("2026-05-30T12:00:00.000Z");
-const JOB: ReflectorJob = { jobId: "job-1", scope: { accountId: "acct-a", threadId: "thread-1" } };
+const JOB: ReflectorJob = { jobId: "job-1", scope: { accountId: "acct-a", projectId: "proj-1" } };
+const THREAD_ONLY_JOB: ReflectorJob = {
+  jobId: "job-1",
+  scope: { accountId: "acct-a", threadId: "thread-1" },
+};
 
 // Deterministic merge stub: joins the observation texts (+ optional previous
 // reflection prefix). Stands in for an LLM — same input → same output.
@@ -101,6 +105,24 @@ function makeDeps(store: MemoryStore, overrides: Partial<ReflectorDeps> = {}): R
 }
 
 describe("runReflectorJob", () => {
+  it("rejects a thread-only scope before reading or writing memory", async () => {
+    const { store, upserts, jobUpdates } = makeFakeStore(makeObservations(["legacy"]));
+    const deps = makeDeps(store);
+
+    const out = await runReflectorJob(THREAD_ONLY_JOB, deps);
+
+    expect(out).toEqual({ reflectionId: null, version: null, changed: false });
+    expect(store.listObservations).not.toHaveBeenCalled();
+    expect(upserts).toEqual([]);
+    expect(jobUpdates).toEqual([
+      {
+        jobId: "job-1",
+        status: "failed",
+        error: "reflector scope requires projectId or resourceId",
+      },
+    ]);
+  });
+
   it("merges observations into a version=1 reflection when the scope has none", async () => {
     const obs = makeObservations(["likes terse answers", "prefers TypeScript"]);
     const { store, upserts } = makeFakeStore(obs);
@@ -121,7 +143,8 @@ describe("runReflectorJob", () => {
     // updatedAt is exactly now().
     expect(up.updatedAt).toEqual(NOW);
     // Scope propagated.
-    expect(up.threadId).toBe("thread-1");
+    expect(up.projectId).toBe("proj-1");
+    expect(up.threadId).toBeUndefined();
   });
 
   // docs/12 (Codex review fix #2) — a decayed (archived) or retention-tombstoned
@@ -157,9 +180,9 @@ describe("runReflectorJob", () => {
     const active = makeObservations(["still active"]);
     const existing: Reflection = {
       id: "refl-stale",
-      projectId: null,
+      projectId: "proj-1",
       resourceId: null,
-      threadId: "thread-1",
+      threadId: null,
       reflectionText: "forgotten old content",
       version: 3,
       tokenEstimate: 5,
@@ -199,9 +222,9 @@ describe("runReflectorJob", () => {
     // Existing reflection whose text already equals what merge would produce.
     const existing: Reflection = {
       id: "refl-existing",
-      projectId: null,
+      projectId: "proj-1",
       resourceId: null,
-      threadId: "thread-1",
+      threadId: null,
       reflectionText: "a | b",
       version: 7,
       tokenEstimate: 1,
@@ -233,9 +256,9 @@ describe("runReflectorJob", () => {
     const obs = makeObservations(["a", "b", "c"]); // new observation 'c'
     const existing: Reflection = {
       id: "refl-existing",
-      projectId: null,
+      projectId: "proj-1",
       resourceId: null,
-      threadId: "thread-1",
+      threadId: null,
       reflectionText: "a | b",
       version: 1,
       tokenEstimate: 1,
@@ -267,9 +290,9 @@ describe("runReflectorJob", () => {
     const obs = makeObservations(["fresh insight"]);
     const existing: Reflection = {
       id: "refl-existing",
-      projectId: null,
+      projectId: "proj-1",
       resourceId: null,
-      threadId: "thread-1",
+      threadId: null,
       reflectionText: "old stable summary",
       version: 3,
       tokenEstimate: 1,

--- a/packages/core/src/memory/reflector.ts
+++ b/packages/core/src/memory/reflector.ts
@@ -108,8 +108,7 @@ export interface ReflectorResult {
 // docs/08 assembly order has only those two reflection slots). A job scope may
 // also carry a thread anchor: writing it verbatim would pin the reflection to
 // the thread and make it permanently invisible to the next inject. project >
-// resource; a scope with neither keeps the legacy thread-level target (direct
-// callers only — the worker no longer promotes thread-only scopes). EXPORTED so
+// resource; a scope with neither is rejected by runReflectorJob. EXPORTED so
 // the worker promotes reflector jobs ALREADY at the target level (cross-thread
 // promotions for the same project then dedupe to one queue row).
 export function reflectionTargetScope(scope: ReflectionScope): ReflectionScope {
@@ -134,6 +133,9 @@ export async function runReflectorJob(
   deps: ReflectorDeps,
 ): Promise<ReflectorResult> {
   try {
+    if (job.scope.projectId === undefined && job.scope.resourceId === undefined) {
+      throw new Error("reflector scope requires projectId or resourceId");
+    }
     // BOTH reads happen at the TARGET level: the reflection slot the next inject
     // hydrates from, and the observations AGGREGATED ACROSS every thread of that
     // project/resource (the store joins threads by owner + scope id). Merging

--- a/packages/core/src/store/postgres/memory-decay-sweep.test.ts
+++ b/packages/core/src/store/postgres/memory-decay-sweep.test.ts
@@ -88,6 +88,14 @@ describe("PgMemoryStore decay sweep", () => {
     const now = new Date("2026-06-05T00:00:00.000Z");
     const { store } = await newStore(now);
     await store.ensureThread({ id: "legacy-thread", ownerId: "acct-a" });
+    await store.upsertReflection({
+      accountId: "acct-a",
+      threadId: "legacy-thread",
+      reflectionText: "legacy reflection",
+      version: 1,
+      tokenEstimate: 4,
+      updatedAt: now,
+    });
     const observationId = await store.appendObservation({
       threadId: "legacy-thread",
       sourceMessageRange: ["m1", "m2"],
@@ -98,6 +106,9 @@ describe("PgMemoryStore decay sweep", () => {
     await store.archiveObservations({ accountId: "acct-a", ids: [observationId], now });
 
     expect(await store.listScorableObservations({ accountId: "acct-a" })).toEqual([]);
+    expect(
+      await store.getReflection({ accountId: "acct-a", threadId: "legacy-thread" }),
+    ).toBeNull();
     expect(await store.claimPendingJobs(10)).toEqual([]);
   });
 

--- a/packages/core/src/store/postgres/memory-decay-sweep.test.ts
+++ b/packages/core/src/store/postgres/memory-decay-sweep.test.ts
@@ -84,6 +84,23 @@ describe("PgMemoryStore decay sweep", () => {
     );
   });
 
+  it("archives a parentless observation without enqueueing a thread-only reflector", async () => {
+    const now = new Date("2026-06-05T00:00:00.000Z");
+    const { store } = await newStore(now);
+    await store.ensureThread({ id: "legacy-thread", ownerId: "acct-a" });
+    const observationId = await store.appendObservation({
+      threadId: "legacy-thread",
+      sourceMessageRange: ["m1", "m2"],
+      observationText: "legacy",
+      observedAt: now,
+    });
+
+    await store.archiveObservations({ accountId: "acct-a", ids: [observationId], now });
+
+    expect(await store.listScorableObservations({ accountId: "acct-a" })).toEqual([]);
+    expect(await store.claimPendingJobs(10)).toEqual([]);
+  });
+
   // docs/12 (Codex review fix II — starvation; pg mirror) — with `candidates` the
   // forgetting score runs IN SQL, so a limit-sized page can never fill with survivors
   // and starve condemned rows beyond it.

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -1639,10 +1639,9 @@ export class PgMemoryStore implements MemoryStore {
       const rows = pgRows<{
         project_id: string | null;
         resource_id: string | null;
-        thread_id: string;
       }>(
         await tx.execute(sql`
-          SELECT DISTINCT t.project_id, t.resource_id, t.id AS thread_id
+          SELECT DISTINCT t.project_id, t.resource_id
             FROM memory_observations o
             JOIN memory_threads t ON t.id = o.thread_id
            WHERE o.id IN (${ids})
@@ -1657,9 +1656,6 @@ export class PgMemoryStore implements MemoryStore {
         }
         if (row.resource_id !== null) {
           targets.push({ accountId: input.accountId, resourceId: row.resource_id });
-        }
-        if (targets.length === 0) {
-          targets.push({ accountId: input.accountId, threadId: row.thread_id });
         }
         for (const target of targets) scopes.set(encodeScopeId(target), target);
       }

--- a/packages/core/src/store/postgres/memory-store.ts
+++ b/packages/core/src/store/postgres/memory-store.ts
@@ -1639,9 +1639,10 @@ export class PgMemoryStore implements MemoryStore {
       const rows = pgRows<{
         project_id: string | null;
         resource_id: string | null;
+        thread_id: string;
       }>(
         await tx.execute(sql`
-          SELECT DISTINCT t.project_id, t.resource_id
+          SELECT DISTINCT t.project_id, t.resource_id, t.id AS thread_id
             FROM memory_observations o
             JOIN memory_threads t ON t.id = o.thread_id
            WHERE o.id IN (${ids})
@@ -1656,6 +1657,9 @@ export class PgMemoryStore implements MemoryStore {
         }
         if (row.resource_id !== null) {
           targets.push({ accountId: input.accountId, resourceId: row.resource_id });
+        }
+        if (targets.length === 0) {
+          targets.push({ accountId: input.accountId, threadId: row.thread_id });
         }
         for (const target of targets) scopes.set(encodeScopeId(target), target);
       }
@@ -1696,11 +1700,13 @@ export class PgMemoryStore implements MemoryStore {
              AND thread_id IS NOT DISTINCT FROM ${target.threadId ?? null}
              AND status = 'active'
         `);
-        await tx.execute(sql`
-          INSERT INTO memory_jobs (id, type, scope_id, status, error, created_at, updated_at)
-          VALUES (${this.genId()}, 'reflector', ${scopeId}, 'pending', NULL, ${nowMs}, ${nowMs})
-          ON CONFLICT (type, scope_id) WHERE status IN ('pending', 'running') DO NOTHING
-        `);
+        if (target.projectId !== undefined || target.resourceId !== undefined) {
+          await tx.execute(sql`
+            INSERT INTO memory_jobs (id, type, scope_id, status, error, created_at, updated_at)
+            VALUES (${this.genId()}, 'reflector', ${scopeId}, 'pending', NULL, ${nowMs}, ${nowMs})
+            ON CONFLICT (type, scope_id) WHERE status IN ('pending', 'running') DO NOTHING
+          `);
+        }
       }
       return true;
     });

--- a/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
+++ b/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
@@ -215,6 +215,23 @@ describe("SqliteMemoryStore decay sweep (listScorableObservations / archiveObser
       .get(msgId) as { id: string; content: string } | undefined;
     expect(raw).toEqual({ id: msgId, content: "hello" });
   });
+
+  it("archives a parentless observation without enqueueing a thread-only reflector", async () => {
+    const now = new Date("2026-06-05T00:00:00.000Z");
+    const { store, db } = newStore(now);
+    await store.ensureThread({ id: "legacy-thread", ownerId: "acct-a" });
+    const observationId = await store.appendObservation({
+      threadId: "legacy-thread",
+      sourceMessageRange: ["m1", "m2"],
+      observationText: "legacy",
+      observedAt: now,
+    });
+
+    await store.archiveObservations({ accountId: "acct-a", ids: [observationId], now });
+
+    expect(readStatus(db, observationId)?.status).toBe("archived");
+    expect(await store.claimPendingJobs(10)).toEqual([]);
+  });
 });
 
 describe("SqliteMemoryStore.listDecayCandidateAccounts (P5 buffer-flush gate)", () => {

--- a/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
+++ b/packages/core/src/store/sqlite/memory-decay-sweep.test.ts
@@ -220,6 +220,14 @@ describe("SqliteMemoryStore decay sweep (listScorableObservations / archiveObser
     const now = new Date("2026-06-05T00:00:00.000Z");
     const { store, db } = newStore(now);
     await store.ensureThread({ id: "legacy-thread", ownerId: "acct-a" });
+    await store.upsertReflection({
+      accountId: "acct-a",
+      threadId: "legacy-thread",
+      reflectionText: "legacy reflection",
+      version: 1,
+      tokenEstimate: 4,
+      updatedAt: now,
+    });
     const observationId = await store.appendObservation({
       threadId: "legacy-thread",
       sourceMessageRange: ["m1", "m2"],
@@ -230,6 +238,9 @@ describe("SqliteMemoryStore decay sweep (listScorableObservations / archiveObser
     await store.archiveObservations({ accountId: "acct-a", ids: [observationId], now });
 
     expect(readStatus(db, observationId)?.status).toBe("archived");
+    expect(
+      await store.getReflection({ accountId: "acct-a", threadId: "legacy-thread" }),
+    ).toBeNull();
     expect(await store.claimPendingJobs(10)).toEqual([]);
   });
 });

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -1503,7 +1503,7 @@ export class SqliteMemoryStore implements MemoryStore {
       if (input.job !== undefined && !this.hasCurrentJobLease(input.job)) return false;
       const rows = db
         .prepare(
-          `SELECT DISTINCT t.project_id, t.resource_id
+          `SELECT DISTINCT t.project_id, t.resource_id, t.id AS thread_id
              FROM memory_observations o
              JOIN memory_threads t ON t.id = o.thread_id
             WHERE o.id IN (${placeholders})
@@ -1512,6 +1512,7 @@ export class SqliteMemoryStore implements MemoryStore {
         .all(...input.ids, input.accountId) as Array<{
         project_id: string | null;
         resource_id: string | null;
+        thread_id: string;
       }>;
       db.prepare(
         `UPDATE memory_observations
@@ -1531,6 +1532,9 @@ export class SqliteMemoryStore implements MemoryStore {
         }
         if (row.resource_id !== null) {
           targets.push({ accountId: input.accountId, resourceId: row.resource_id });
+        }
+        if (targets.length === 0) {
+          targets.push({ accountId: input.accountId, threadId: row.thread_id });
         }
         for (const target of targets) scopes.set(encodeScopeId(target), target);
       }
@@ -1552,11 +1556,13 @@ export class SqliteMemoryStore implements MemoryStore {
               SET status = 'failed', error = 'superseded by observation archive', updated_at = ?
             WHERE type = 'reflector' AND scope_id = ? AND status = 'running'`,
         ).run(input.now.getTime(), scopeId);
-        db.prepare(
-          `INSERT OR IGNORE INTO memory_jobs
-             (id, type, scope_id, status, error, created_at, updated_at)
-           VALUES (?, 'reflector', ?, 'pending', NULL, ?, ?)`,
-        ).run(this.genId(), scopeId, input.now.getTime(), input.now.getTime());
+        if (target.projectId !== undefined || target.resourceId !== undefined) {
+          db.prepare(
+            `INSERT OR IGNORE INTO memory_jobs
+               (id, type, scope_id, status, error, created_at, updated_at)
+             VALUES (?, 'reflector', ?, 'pending', NULL, ?, ?)`,
+          ).run(this.genId(), scopeId, input.now.getTime(), input.now.getTime());
+        }
       }
       return true;
     })();

--- a/packages/core/src/store/sqlite/memory-store.ts
+++ b/packages/core/src/store/sqlite/memory-store.ts
@@ -1503,7 +1503,7 @@ export class SqliteMemoryStore implements MemoryStore {
       if (input.job !== undefined && !this.hasCurrentJobLease(input.job)) return false;
       const rows = db
         .prepare(
-          `SELECT DISTINCT t.project_id, t.resource_id, t.id AS thread_id
+          `SELECT DISTINCT t.project_id, t.resource_id
              FROM memory_observations o
              JOIN memory_threads t ON t.id = o.thread_id
             WHERE o.id IN (${placeholders})
@@ -1512,7 +1512,6 @@ export class SqliteMemoryStore implements MemoryStore {
         .all(...input.ids, input.accountId) as Array<{
         project_id: string | null;
         resource_id: string | null;
-        thread_id: string;
       }>;
       db.prepare(
         `UPDATE memory_observations
@@ -1532,9 +1531,6 @@ export class SqliteMemoryStore implements MemoryStore {
         }
         if (row.resource_id !== null) {
           targets.push({ accountId: input.accountId, resourceId: row.resource_id });
-        }
-        if (targets.length === 0) {
-          targets.push({ accountId: input.accountId, threadId: row.thread_id });
         }
         for (const target of targets) scopes.set(encodeScopeId(target), target);
       }

--- a/packages/core/src/store/store-contract.test.ts
+++ b/packages/core/src/store/store-contract.test.ts
@@ -2777,7 +2777,7 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(revived?.reflectionText).toBe("p-v3 (revived)");
     });
 
-    it("decay fences stale Reflector reflection/fact commits and queues every aggregate target", async () => {
+    it("decay archives every affected reflection and queues only parent aggregate targets", async () => {
       ctx = await make();
       const m = ctx.stores.memory;
       if (m.archiveObservations === undefined || m.commitReflectionJob === undefined) {
@@ -2868,13 +2868,17 @@ describe.each(drivers)("Store port contract — $name", ({ make }) => {
       expect(await m.getReflection({ accountId: "acct-a", resourceId: "r-race" })).toBeNull();
       expect(await m.getReflection({ accountId: "acct-a", threadId: "t-thread-only" })).toBeNull();
       expect(await m.listActiveFacts?.({ accountId: "acct-a", projectId: "p-race" })).toEqual([]);
-      expect((await m.claimPendingJobs(10)).map((job) => job.scope)).toEqual(
+      const queuedScopes = (await m.claimPendingJobs(10)).map((job) => job.scope);
+      expect(queuedScopes).toEqual(
         expect.arrayContaining([
           { accountId: "acct-a", projectId: "p-race" },
           { accountId: "acct-a", resourceId: "r-race" },
-          { accountId: "acct-a", threadId: "t-thread-only" },
         ]),
       );
+      expect(queuedScopes).not.toContainEqual({
+        accountId: "acct-a",
+        threadId: "t-thread-only",
+      });
     });
 
     it("rolls back the job fence and every output when publication fails", async () => {


### PR DESCRIPTION
## Summary
- skip automatic inbound/outbound Memory persistence when neither project nor resource exists
- skip eager facts and reject persisted parentless Reflector jobs before memory reads/writes
- archive legacy parentless observations and thread reflections without enqueueing dead thread-only rebuilds in SQLite or Postgres
- align Memory docs and implementation notes

## Root cause
Decay archival fell back to a thread-only Reflector target for quarantined legacy threads whose project/resource parents were cleared. That job produced the active top-level thread reflection shown in Admin. Request writeback and eager facts also lacked the same parent invariant.

## Validation
- `CI=true pnpm test:ci:store` (60 files, 650 tests passed)
- focused Memory lifecycle suite (11 files, 170 tests passed)
- `pnpm --filter @helm/core typecheck`
- focused `biome check` on all changed TypeScript files
- `git diff --check`

## Release
Patch-level behavior fix; release after merge so production can deploy the exact immutable SHA image.