### PR TITLE
chore(release): v0.28.74

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.73",
+  "version": "0.28.74",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump Helm API patch version to 0.28.74
- release the parent-backed automatic Memory scope fix from #758

## Validation

- exact feature merge SHA `c9f97a7905564a2c0f950e08e3b8b8444628e5a2` passed main CI run `31895293508`
- this PR is version-only; required PR checks must pass before merge