### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   # Every Action is pinned to an audited full SHA and uses a Node 24 runtime.
   # The persistent runner pool is on 2.335.1 (newer than the required 2.329.0).


### PR DESCRIPTION
## Summary

- group CI runs by pull request number
- cancel only superseded pull_request_target runs
- preserve every main CI run and the downstream Publish image release chain

## Validation

- parsed .github/workflows/ci.yml with Ruby YAML parser
- git diff --check