### PR TITLE
[codex] show live and historical provider usage

### DIFF
--- a/apps/admin/src/routes/providers/[accountId]/+page.svelte
+++ b/apps/admin/src/routes/providers/[accountId]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { invalidateAll } from '$app/navigation';
   import { base } from '$app/paths';
   import type { OAuthQuotaWindow, OAuthUsagePeriod } from '$lib/api/oauth.js';
+  import RefreshControl from '$lib/components/RefreshControl.svelte';
   import { formatCount, formatTokens, formatUsd } from '$lib/format.js';
   import { t } from '$lib/i18n';
   import type { AccountDetailData } from './+page.js';
@@ -45,9 +47,8 @@
     return parts.join(' ');
   }
 
-  // Reset-window keys present in the CURRENT summary (Anthropic: 5h then 7d…). Each is
-  // a tab for the current-period summary card. History does NOT use these — it's by
-  // natural calendar day/week (see below).
+  // Reset-window keys present in the current summary/history (Anthropic: 5h then 7d…).
+  // Natural calendar day/week views remain account-wide.
   const windowKeys = $derived.by(() => {
     const seen = new Set<string>();
     const keys: string[] = [];
@@ -86,7 +87,9 @@
   let granularity = $state<'period' | 'day' | 'week'>('period');
   const history = $derived.by(() =>
     granularity === 'period'
-      ? data.periods.periods.filter((p) => p.windowKey === activeKey)
+      ? [...data.periods.current, ...data.periods.periods].filter(
+          (p) => p.windowKey === activeKey,
+        )
       : granularity === 'day'
         ? data.periods.daily
         : data.periods.weekly,
@@ -140,6 +143,9 @@
     <p class="mt-1 text-sm text-ink-muted">
       {$t('Token usage per quota reset period. Periods marked ≈ have approximate boundaries.')}
     </p>
+    <div class="mt-3">
+      <RefreshControl onRefresh={invalidateAll} />
+    </div>
   </header>
 
   {#if windowKeys.length === 0 && history.length === 0}
@@ -268,7 +274,7 @@
           {#each trend as p, i (i)}
             <div class="flex h-full flex-1 items-end">
               <div
-                class={`w-full rounded-t ${p.partial ? 'bg-slate-300' : 'bg-indigo-400'}`}
+                class={`w-full rounded-t ${p === currentPeriod ? 'bg-emerald-400' : p.partial ? 'bg-slate-300' : 'bg-indigo-400'}`}
                 style={`height: ${Math.max(2, (p.tokens / trendMax) * 100)}%`}
                 title={`${periodLabel(p)} — ${formatTokens(p.tokens)} tokens${p.partial ? ' (partial)' : ''}`}
               ></div>
@@ -302,6 +308,11 @@
             <tr>
               <td data-label={$t('Period')} class="px-3 py-2">
                 {periodLabel(p)}
+                {#if p === currentPeriod}
+                  <span class="ml-1 rounded bg-emerald-100 px-1.5 py-0.5 text-xs text-emerald-700"
+                    >{$t('Current period')}</span
+                  >
+                {/if}
                 {#if p.approximate}
                   <span class="ml-1 text-xs text-ink-muted">≈</span>
                 {/if}

--- a/apps/admin/src/routes/providers/[accountId]/account-detail.test.ts
+++ b/apps/admin/src/routes/providers/[accountId]/account-detail.test.ts
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invalidateAll } from '$app/navigation';
+import type { AccountDetailData } from './+page.js';
+import AccountDetailPage from './+page.svelte';
+
+const invalidateAllMock = vi.mocked(invalidateAll);
+
+const data: AccountDetailData = {
+  providerId: 'openai-codex',
+  account: 'account@example.com',
+  periods: {
+    current: [
+      {
+        windowKey: 'primary',
+        periodStartMs: Date.UTC(2026, 7, 13, 4, 44, 41),
+        periodEndMs: Date.UTC(2026, 7, 18, 14, 0),
+        requests: 3_600,
+        tokens: 383_000_000,
+        costUsd: 369.37,
+        approximate: false,
+        partial: false,
+      },
+    ],
+    periods: [
+      {
+        windowKey: 'primary',
+        periodStartMs: Date.UTC(2026, 7, 13, 3, 32, 4),
+        periodEndMs: Date.UTC(2026, 7, 13, 4, 44, 41),
+        requests: 0,
+        tokens: 0,
+        costUsd: null,
+        approximate: false,
+        partial: false,
+      },
+    ],
+    daily: [],
+    weekly: [],
+  },
+  quota: {
+    providerId: 'openai-codex',
+    account: 'account@example.com',
+    windows: [
+      {
+        key: 'primary',
+        usedPercent: 80,
+        resetsAtMs: Date.UTC(2026, 7, 20, 4, 44, 41),
+        windowMinutes: 10_080,
+      },
+    ],
+    capturedAt: Date.UTC(2026, 7, 18, 14, 0),
+    source: 'codex',
+    usageLimitedUntilMs: null,
+  },
+};
+
+describe('provider account detail', () => {
+  beforeEach(() => invalidateAllMock.mockReset());
+
+  it('includes the live current period in the period history', () => {
+    render(AccountDetailPage, { data });
+
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('Current period')).toBeInTheDocument();
+    expect(within(table).getByText('383M')).toBeInTheDocument();
+    expect(within(table).getByText('3.6K')).toBeInTheDocument();
+    expect(within(table).getAllByRole('row')).toHaveLength(3);
+  });
+
+  it('can reload the cache-only period aggregate from the shared refresh control', async () => {
+    render(AccountDetailPage, { data });
+
+    await fireEvent.click(screen.getByTestId('refresh-now'));
+
+    expect(invalidateAllMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What changed

- include the in-progress quota period in the provider usage chart and history table
- mark the live period with a green bar and a localized current-period badge
- reuse the shared manual/automatic refresh control on the account detail page
- add a focused component regression test for live and historical rows

## Why

The gateway already persisted and aggregated current-period usage, but the account detail history filtered out `periods.current` and rendered only closed periods. This made every account appear to have no newest-period data even though the current summary cards were correct.

## Validation

- `CI=true pnpm exec vitest run 'apps/admin/src/lib/components/RefreshControl.test.ts' 'apps/admin/src/routes/providers/[accountId]/account-detail.test.ts' 'apps/admin/src/routes/providers/page-load.test.ts'` — 19 passed
- `pnpm --filter @helm/admin check` — 0 errors, 0 warnings
- `pnpm --filter @helm/admin build` — passed
- rendered desktop QA in the in-app browser — current and historical rows visible, 5-second refresh selectable, no console warnings/errors
