### PR TITLE
[codex] close Grok media entitlement gaps

### DIFF
--- a/apps/gateway/e2e/videos.spec.ts
+++ b/apps/gateway/e2e/videos.spec.ts
@@ -75,18 +75,14 @@ async function createVideo(key: string, prompt: string): Promise<Response> {
   );
 }
 
-async function createPromptVideo(key: string, prompt: string): Promise<Response> {
+async function createPromptVideo(key: string, prompt: string, model = "grok-imagine-video") {
   return gateway().fetch(
     new Request("http://gateway.test/v1/videos/generations", {
       method: "POST",
       headers: AUTH(key),
       body: JSON.stringify({
-        model: "grok-imagine-video",
+        model,
         prompt,
-        aspect_ratio: "16:9",
-        duration: 15,
-        resolution: "1080p",
-        audio: true,
       }),
     }),
   );
@@ -139,10 +135,10 @@ static/video:
 
   const db = createSqliteDb(join(dataDir, "helm.db"));
   const keys = new SqliteKeyStore(db);
-  for (const [keyId, key, accountId] of [
-    ["video_key_a", KEY_A, HELM_ACCOUNT],
-    ["video_key_b", KEY_B, HELM_ACCOUNT],
-    ["video_key_c", KEY_C, "acct_video_other"],
+  for (const [keyId, key, accountId, allowCustomModel] of [
+    ["video_key_a", KEY_A, HELM_ACCOUNT, true],
+    ["video_key_b", KEY_B, HELM_ACCOUNT, false],
+    ["video_key_c", KEY_C, "acct_video_other", false],
   ] as const) {
     await keys.createKey({
       keyId,
@@ -150,6 +146,7 @@ static/video:
       prefix: key.slice(0, 16),
       accountId,
       role: "user",
+      allowCustomModel,
     });
   }
   const oauth = new SqliteOAuthTokenStore(db);
@@ -263,7 +260,11 @@ test("start, owner isolation, OAuth pinning, and restart recovery stay on one du
     },
   ]);
 
-  const first = await createPromptVideo(KEY_A, "camera pushes toward the subject");
+  const first = await createPromptVideo(
+    KEY_A,
+    "camera pushes toward the subject",
+    "xai/grok-imagine-video",
+  );
   const second = await createVideo(KEY_B, "wind moves the subject's coat");
   expect(first.status).toBe(200);
   expect(second.status).toBe(200);

--- a/apps/gateway/src/routes/admin/deps.ts
+++ b/apps/gateway/src/routes/admin/deps.ts
@@ -27,6 +27,7 @@ import type { PayloadCaptureDeps } from "../payload-capture.js";
 import type { OAuthTester } from "./oauth-test.js";
 
 export type UsageLimitWriteMode = "extend" | "replace";
+export type OAuthMutationOptions = { xaiMediaEmergency?: "disable" | "restore" };
 
 // Injected dependency contracts for the admin API. Per CLAUDE.md principle 1 the
 // route files are PURE HTTP glue — they own no business logic and never touch the
@@ -521,7 +522,7 @@ export interface AdminApiDeps {
   // rebuild failed — the route then returns a 503 "saved but not applied" rather than
   // a false 204, honoring the Save == applied contract. Optional: absent in unit tests
   // (treated as applied).
-  onOAuthMutation?: (options?: { disableXaiMedia?: boolean }) => Promise<{ applied: boolean }>;
+  onOAuthMutation?: (options?: OAuthMutationOptions) => Promise<{ applied: boolean }>;
   // Auto-park control (OAuth usage limit). Sets (untilMs) / clears (null) one
   // account's usage-limit cooldown on BOTH the live pool member (in place — no
   // rebuild) and the persisted snapshot. The reset route passes null ("Reset usage");

--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -775,16 +775,21 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(oauthQuota?.upsert).toHaveBeenCalledWith(
       expect.objectContaining({ providerId: "anthropic", account: "default" }),
     );
-    expect(oauthQuota?.upsert).not.toHaveBeenCalledWith(
-      expect.objectContaining({ providerId: "xai" }),
+    expect(oauthQuota?.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "xai",
+        account: "subscription",
+        windows: [],
+        source: "xai",
+      }),
     );
-    expect(oauthQuota?.delete).toHaveBeenCalledWith("xai", "subscription");
+    expect(oauthQuota?.delete).not.toHaveBeenCalledWith("xai", "subscription");
     expect(oauthQuota?.delete).toHaveBeenCalledWith("xai", "orphan");
     expect(onOAuthMutation).toHaveBeenNthCalledWith(1, undefined);
-    expect(onOAuthMutation).toHaveBeenNthCalledWith(2, { disableXaiMedia: true });
+    expect(onOAuthMutation).toHaveBeenNthCalledWith(2, { xaiMediaEmergency: "disable" });
   });
 
-  it("POST /oauth/refresh disables live xAI media when stale entitlement deletion fails", async () => {
+  it("POST /oauth/refresh disables live xAI media when entitlement revocation persistence fails", async () => {
     const stale = {
       providerId: "xai",
       account: "subscription",
@@ -802,10 +807,12 @@ describe("admin OAuth routes — read endpoints", () => {
     const oauthQuota = {
       get: vi.fn(async () => stale),
       getAll: vi.fn(async () => [stale]),
-      upsert: vi.fn(async () => {}),
-      delete: vi.fn(async () => {
-        throw new Error("sqlite busy");
+      upsert: vi.fn(async (snapshot) => {
+        if (snapshot.providerId === "xai" && snapshot.windows.length === 0) {
+          throw new Error("sqlite busy");
+        }
       }),
+      delete: vi.fn(async () => {}),
     } as unknown as AdminApiDeps["oauthQuota"];
     const seam = fullSeam({
       listStatus: vi.fn(async () => ({
@@ -820,8 +827,40 @@ describe("admin OAuth routes — read endpoints", () => {
 
     await enqueueRefresh(app({ oauth: seam, oauthQuota, onOAuthMutation }), "failed");
 
-    expect(onOAuthMutation).toHaveBeenNthCalledWith(1, undefined);
-    expect(onOAuthMutation).toHaveBeenNthCalledWith(2, { disableXaiMedia: true });
+    expect(onOAuthMutation).toHaveBeenNthCalledWith(1, { xaiMediaEmergency: "disable" });
+    expect(onOAuthMutation).toHaveBeenNthCalledWith(2, undefined);
+  });
+
+  it("POST /oauth/refresh restores xAI media only after fresh entitlement persists", async () => {
+    const oauthQuota = {
+      get: vi.fn(async () => null),
+      getAll: vi.fn(async () => []),
+      upsert: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const seam = fullSeam({
+      listStatus: vi.fn(async () => ({
+        selectionStrategy: "balanced",
+        providers: [{ id: "xai", name: "Grok", accounts: [{ account: "subscription" }] }],
+      })) as never,
+      fetchXaiQuota: vi.fn(async () => [
+        {
+          key: "7d",
+          usedPercent: 1,
+          resetsAtMs: Date.now() + 86_400_000,
+          windowMinutes: 10_080,
+        },
+      ]),
+    });
+    const onOAuthMutation = vi.fn(async () => ({ applied: true }));
+
+    await enqueueRefresh(app({ oauth: seam, oauthQuota, onOAuthMutation }));
+
+    expect(oauthQuota?.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "xai", account: "subscription" }),
+    );
+    expect(onOAuthMutation).toHaveBeenCalledOnce();
+    expect(onOAuthMutation).toHaveBeenCalledWith({ xaiMediaEmergency: "restore" });
   });
 
   it("POST /oauth/refresh extends an active cooldown to the saturated window reset", async () => {

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -34,6 +34,7 @@ import type {
   CodexQuotaResult,
   OAuthAdminAccess,
   OAuthAdminStatusResponse,
+  OAuthMutationOptions,
   OAuthSelectionStrategy,
 } from "./deps.js";
 
@@ -226,7 +227,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
   // re-synthesis), the persist still SUCCEEDED, so the caller returns a 503
   // "saved but not applied" rather than a false 204 — the change takes effect on the
   // next successful mutation or a restart. No hook wired (unit tests) ⇒ applied.
-  const afterMutation = async (options?: { disableXaiMedia?: boolean }): Promise<boolean> => {
+  const afterMutation = async (options?: OAuthMutationOptions): Promise<boolean> => {
     if (!deps.onOAuthMutation) return true;
     try {
       return (await deps.onOAuthMutation(options)).applied;
@@ -395,6 +396,16 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     const failures: string[] = [];
     let xaiEntitlementUncertain = false;
     let xaiEntitlementCleanupFailed = false;
+    let xaiAccountsToRefresh = 0;
+    let xaiEntitlementsPersisted = 0;
+    const revokeXaiEntitlement = (account: string) =>
+      store.upsert({
+        providerId: "xai",
+        account,
+        windows: [],
+        capturedAt: Date.now(),
+        source: "xai",
+      });
     const syncCooldownFromWindows = async (
       providerId: string,
       account: string,
@@ -482,7 +493,9 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
         // media fails closed; ordinary xAI text routing remains independent.
         const fetchXai = s.fetchXaiQuota;
         if (fetchXai) {
-          for (const a of acctsOf("xai")) {
+          const xaiAccounts = acctsOf("xai");
+          xaiAccountsToRefresh = xaiAccounts.length;
+          for (const a of xaiAccounts) {
             tasks.push({
               label: `xai/${a.account}`,
               run: async () => {
@@ -500,16 +513,17 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
                     capturedAt,
                     source: "xai",
                   });
+                  xaiEntitlementsPersisted += 1;
                   deps.applyQuotaSnapshot?.("xai", a.account, windows, capturedAt);
                   await syncCooldownFromWindows("xai", a.account, windows);
                 } catch (error) {
                   xaiEntitlementUncertain = true;
                   try {
-                    await store.delete("xai", a.account);
-                  } catch (deleteError) {
+                    await revokeXaiEntitlement(a.account);
+                  } catch (cleanupError) {
                     xaiEntitlementCleanupFailed = true;
                     failures.push(
-                      `xai/${a.account} entitlement cleanup: ${errMessage(deleteError)}`,
+                      `xai/${a.account} entitlement cleanup: ${errMessage(cleanupError)}`,
                     );
                   }
                   throw error;
@@ -608,7 +622,7 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
       const results = await Promise.allSettled(
         all
           .filter((snapshot) => snapshot.providerId === "xai")
-          .map((snapshot) => store.delete("xai", snapshot.account)),
+          .map((snapshot) => revokeXaiEntitlement(snapshot.account)),
       );
       if (results.some((result) => result.status === "rejected")) {
         xaiEntitlementCleanupFailed = true;
@@ -628,9 +642,18 @@ export function registerOAuthRoutes(app: Hono<AppEnv>, deps: AdminApiDeps): void
     // not hide a different account whose fresh entitlement refresh succeeded. If the
     // rebuild itself fails after entitlement became uncertain, immediately remove
     // every live xAI media alias so stale positive evidence cannot keep serving.
-    const rebuilt = await afterMutation();
-    if (xaiEntitlementCleanupFailed || (!rebuilt && xaiEntitlementUncertain)) {
-      await afterMutation({ disableXaiMedia: true });
+    if (xaiEntitlementCleanupFailed) {
+      await afterMutation({ xaiMediaEmergency: "disable" });
+    }
+    const restoreXaiMedia =
+      xaiAccountsToRefresh > 0 &&
+      xaiEntitlementsPersisted === xaiAccountsToRefresh &&
+      !xaiEntitlementUncertain;
+    const rebuilt = await afterMutation(
+      restoreXaiMedia ? { xaiMediaEmergency: "restore" } : undefined,
+    );
+    if (!rebuilt && xaiEntitlementUncertain) {
+      await afterMutation({ xaiMediaEmergency: "disable" });
     }
     if (!rebuilt) {
       failures.push("oauth pool: refreshed entitlement not applied");

--- a/apps/gateway/src/routes/images.test.ts
+++ b/apps/gateway/src/routes/images.test.ts
@@ -203,7 +203,8 @@ describe("registerImagesRoute", () => {
     const response = await post(app, {
       model: "grok-imagine-image",
       prompt: "a cat",
-      resolution: "2k",
+      n: 2,
+      aspect_ratio: "16:9",
     });
 
     expect(response.status).toBe(400);

--- a/apps/gateway/src/routes/images.ts
+++ b/apps/gateway/src/routes/images.ts
@@ -353,7 +353,7 @@ export function registerImagesRoute(app: Hono<AppEnv>, deps: ImagesRouteDeps): v
       const grokTarget = operationTargets.find((target) =>
         GROK_IMAGE_MODELS.has(target.providerModel),
       );
-      if (grokTarget) {
+      if (grokTarget?.providerModel === "grok-imagine-image") {
         const parsed = GrokImagineImageGenerationRequestSchema.safeParse({
           ...generationBody,
           model: grokTarget.providerModel,

--- a/apps/gateway/src/routes/videos.test.ts
+++ b/apps/gateway/src/routes/videos.test.ts
@@ -28,7 +28,11 @@ function record(responseId: string, status = "in_progress"): ResponsesRegistryRe
 function setup(over: Partial<VideosRouteDeps> = {}) {
   const records = new Map<string, ResponsesRegistryRecord>();
   const create = vi.fn().mockResolvedValue({ request_id: "vid_1", status: "queued" });
-  const retrieve = vi.fn().mockResolvedValue({ request_id: "vid_1", status: "done" });
+  const retrieve = vi.fn().mockResolvedValue({
+    request_id: "vid_1",
+    status: "done",
+    video: { url: "https://cdn.example.test/video.mp4" },
+  });
   const enqueuePayload = vi.fn();
   const enqueueTelemetry = vi.fn();
   const record = {
@@ -324,7 +328,11 @@ describe("registerVideosRoute", () => {
       headers: { Authorization: "Bearer k" },
     });
     expect(polled.status).toBe(200);
-    expect(await polled.json()).toEqual({ request_id: "vid_1", status: "done" });
+    expect(await polled.json()).toEqual({
+      request_id: "vid_1",
+      status: "done",
+      video: { url: "https://cdn.example.test/video.mp4" },
+    });
     expect(retrieve).toHaveBeenCalledWith("vid_1", expect.any(AbortSignal));
     expect(put).toHaveBeenCalledWith(
       expect.objectContaining({ responseId: "video:vid_1", status: "done" }),
@@ -376,7 +384,7 @@ describe("registerVideosRoute", () => {
     expect(create).toHaveBeenCalledOnce();
   });
 
-  it("accepts prompt-only Grok video and forwards one paid create", async () => {
+  it("rejects unverified prompt-only Grok video options before reservation", async () => {
     const { app, create, putIfAbsent } = setup();
     const response = await app.request("/v1/videos/generations", {
       method: "POST",
@@ -391,20 +399,41 @@ describe("registerVideosRoute", () => {
       }),
     });
 
+    expect(response.status).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+    expect(putIfAbsent).not.toHaveBeenCalled();
+  });
+
+  it("accepts a concrete xAI video alias for a custom-model key with one paid create", async () => {
+    const customIdentity: MessagesIdentity = {
+      ...identity,
+      caps: { allowCustomModel: true },
+    };
+    const { app, create, putIfAbsent } = setup({
+      auth: { resolve: async () => customIdentity },
+    });
+
+    const response = await post(app, {
+      model: "xai/grok-imagine-video",
+      prompt: "waves rolling across a neon ocean",
+    });
+
     expect(response.status).toBe(200);
     expect(create).toHaveBeenCalledOnce();
-    expect(create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: "grok-imagine-video",
-        prompt: "waves rolling across a neon ocean",
-        duration: 15,
-        resolution: "1080p",
-        audio: true,
-      }),
-      expect.any(AbortSignal),
-      expect.any(Function),
-    );
     expect(putIfAbsent).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a concrete xAI video alias for a normal key before reservation", async () => {
+    const { app, create, putIfAbsent } = setup();
+
+    const response = await post(app, {
+      model: "xai/grok-imagine-video",
+      prompt: "waves rolling across a neon ocean",
+    });
+
+    expect(response.status).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+    expect(putIfAbsent).not.toHaveBeenCalled();
   });
 
   it("keeps bearer and prompt out of regular logs and DecisionRecord", async () => {
@@ -443,6 +472,19 @@ describe("registerVideosRoute", () => {
     });
 
     expect(response.status).toBe(200);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed done without persisting a terminal state", async () => {
+    const { app, retrieve, put } = setup();
+    retrieve.mockResolvedValueOnce({ request_id: "vid_1", status: "done" });
+    await post(app);
+
+    const response = await app.request("/v1/videos/vid_1", {
+      headers: { Authorization: "Bearer k" },
+    });
+
+    expect(response.status).toBe(502);
     expect(put).not.toHaveBeenCalled();
   });
 

--- a/apps/gateway/src/routes/videos.ts
+++ b/apps/gateway/src/routes/videos.ts
@@ -7,7 +7,11 @@ import {
   type DecisionRecord,
   type ResponsesRegistryRecord,
 } from "@helm/core";
-import { type ProviderAttempt, VideoGenerationRequestSchema } from "@helm/shared";
+import {
+  type ProviderAttempt,
+  VideoGenerationRequestSchema,
+  VideoRetrieveResponseSchema,
+} from "@helm/shared";
 import type { Context, Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv } from "../app.js";
@@ -273,11 +277,14 @@ export function registerVideosRoute(app: Hono<AppEnv>, deps: VideosRouteDeps): v
       return errorJson(c, 400, "malformed video generation request", "invalid_request");
     }
 
+    const requestedModel = typeof body.model === "string" ? body.model : "";
+    if (requestedModel.includes("/") && identity.caps?.allowCustomModel !== true) {
+      return errorJson(c, 400, "video model is not available to this key", "model_not_found");
+    }
     const target = await deps.resolver.create(body, identity);
     if (target === null)
       return errorJson(c, 503, "video provider is unavailable", "provider_unavailable");
     const blocked = createBlockedModelMatcher(identity.caps?.blockedModels);
-    const requestedModel = typeof body.model === "string" ? body.model : "";
     if (
       blocked !== null &&
       (blocked.matches(requestedModel) || blocked.matches(target.providerAlias))
@@ -448,7 +455,20 @@ export function registerVideosRoute(app: Hono<AppEnv>, deps: VideosRouteDeps): v
       });
       return errorJson(c, 502, "video poll failed", "upstream_error");
     }
-    const status = typeof upstream.status === "string" ? upstream.status : "unknown";
+    const parsed = VideoRetrieveResponseSchema.safeParse(upstream);
+    if (!parsed.success) {
+      deps.log?.("video.poll.lifecycle", {
+        request_id: pollRequestId,
+        video_request_id: requestId,
+        provider_alias: record.providerAlias,
+        provider_account: record.providerAccount,
+        status: "upstream_error",
+        terminal: false,
+      });
+      return errorJson(c, 502, "video poll returned an invalid response", "upstream_error");
+    }
+    upstream = parsed.data;
+    const status = upstream.status;
     deps.log?.("video.poll.lifecycle", {
       request_id: pollRequestId,
       video_request_id: requestId,

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -29,10 +29,24 @@ import {
   normalizeCodexNativeClientVersion,
   type OAuthRuntimeCtx,
   resolveProviderTransportProfile,
+  resolveXaiMediaEmergencyState,
   runCodexCompactProviderCall,
   synthesizeOAuthProviders,
   tlsTransportProviders,
 } from "./server.js";
+
+describe("xAI media emergency latch", () => {
+  it("survives ordinary and failed restore rebuilds until a successful restore", () => {
+    let disabled = resolveXaiMediaEmergencyState(false, "disable", true);
+    expect(disabled).toBe(true);
+    disabled = resolveXaiMediaEmergencyState(disabled, undefined, true);
+    expect(disabled).toBe(true);
+    disabled = resolveXaiMediaEmergencyState(disabled, "restore", false);
+    expect(disabled).toBe(true);
+    disabled = resolveXaiMediaEmergencyState(disabled, "restore", true);
+    expect(disabled).toBe(false);
+  });
+});
 
 function sseResponse(events: object[]): Response {
   const body = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -204,6 +204,7 @@ import { createRealtimeCallRegistry, type RealtimeCallRegistry } from "./realtim
 import { createResponsesRegistry } from "./responses-registry.js";
 import { responsesWebSocketPreflightPending } from "./responses-websocket.js";
 import { createArchiveFsAccess } from "./routes/admin/cleanup-fs.js";
+import type { OAuthMutationOptions } from "./routes/admin/deps.js";
 import { registerAdminApi } from "./routes/admin/index.js";
 import { createOAuthAccountTester, type OAuthTester } from "./routes/admin/oauth-test.js";
 import { createRuntimeRuleStore } from "./routes/admin/rule-store.js";
@@ -1866,6 +1867,16 @@ export function supportsAutomaticVacuum(driver: "sqlite" | "supabase"): boolean 
   return driver === "sqlite";
 }
 
+export function resolveXaiMediaEmergencyState(
+  current: boolean,
+  command: OAuthMutationOptions["xaiMediaEmergency"],
+  rebuildApplied: boolean,
+): boolean {
+  if (command === "disable") return true;
+  if (command === "restore" && rebuildApplied) return false;
+  return current;
+}
+
 // Full wiring: config -> store -> bootstrap key -> provider -> routing pipeline.
 // Fail-closed: an invalid config throws (caller exits non-zero). The HTTP listen
 // is performed by the caller (index.ts) so this stays testable. Async because the
@@ -1987,7 +1998,7 @@ export async function buildServer(
     ? { store: store.oauthTokens, encKey: oauthEncKey }
     : undefined;
   let rebuildOAuthPool:
-    | ((options?: { disableXaiMedia?: boolean }) => Promise<{ applied: boolean }>)
+    | ((options?: OAuthMutationOptions) => Promise<{ applied: boolean }>)
     | undefined;
   const codexModelsEtagTracker = createCodexModelsEtagTracker();
   const oauthModelDiscoveryCache = createOAuthModelDiscoveryCache();
@@ -2949,6 +2960,21 @@ export async function buildServer(
     ...configuredClients,
     ...oauthPoolClients,
   ]);
+  let xaiMediaEmergencyDisabled = false;
+  const removeXaiMediaAliases = (
+    aliasSet: typeof oauthAliasSet,
+    wireModelMap: typeof oauthWireModelMap,
+    modelMap: typeof xaiOAuthModelMap,
+    modelAccounts: typeof xaiOAuthModelAccounts,
+  ) => {
+    for (const model of GROK_OAUTH_MEDIA_MODELS) {
+      const alias = `xai/${model}`;
+      aliasSet.delete(alias);
+      wireModelMap.delete(alias);
+      modelMap.delete(alias);
+      modelAccounts.delete(alias);
+    }
+  };
   // Serialize rebuilds onto a chain so two rapid admin saves can't interleave a stale
   // read with a fresh assign — each link re-reads the CURRENT account settings + bound
   // credentials, re-synthesizes, and swaps the map + alias set. The chain itself never
@@ -2959,14 +2985,18 @@ export async function buildServer(
   rebuildOAuthPool = async (options): Promise<{ applied: boolean }> => {
     let applied = true;
     rebuildChain = rebuildChain.then(async () => {
-      if (options?.disableXaiMedia) {
-        for (const model of GROK_OAUTH_MEDIA_MODELS) {
-          const alias = `xai/${model}`;
-          oauthAliasSet.delete(alias);
-          oauthWireModelMap.delete(alias);
-          xaiOAuthModelMap.delete(alias);
-          xaiOAuthModelAccounts.delete(alias);
-        }
+      if (options?.xaiMediaEmergency === "disable") {
+        xaiMediaEmergencyDisabled = resolveXaiMediaEmergencyState(
+          xaiMediaEmergencyDisabled,
+          "disable",
+          true,
+        );
+        removeXaiMediaAliases(
+          oauthAliasSet,
+          oauthWireModelMap,
+          xaiOAuthModelMap,
+          xaiOAuthModelAccounts,
+        );
         logger.log("warn", "oauth.xai_media.disabled", {
           reason: "entitlement refresh was inconclusive",
         });
@@ -2988,15 +3018,37 @@ export async function buildServer(
           codexRuntime,
           oauthModelDiscoveryCache,
         );
+        const nextAliasSet = aliasSetOf(next);
+        const nextWireModelMap = wireModelsOf(next);
+        const nextXaiModelMap = next.xaiModels;
+        const nextXaiModelAccounts = next.xaiModelAccounts;
+        if (xaiMediaEmergencyDisabled && options?.xaiMediaEmergency !== "restore") {
+          removeXaiMediaAliases(
+            nextAliasSet,
+            nextWireModelMap,
+            nextXaiModelMap,
+            nextXaiModelAccounts,
+          );
+        }
         oauthPoolClients = next.poolClients;
-        oauthAliasSet = aliasSetOf(next);
-        oauthWireModelMap = wireModelsOf(next);
-        xaiOAuthModelMap = next.xaiModels;
-        xaiOAuthModelAccounts = next.xaiModelAccounts;
+        oauthAliasSet = nextAliasSet;
+        oauthWireModelMap = nextWireModelMap;
+        xaiOAuthModelMap = nextXaiModelMap;
+        xaiOAuthModelAccounts = nextXaiModelAccounts;
         providerClients = new Map<string, ProviderClient>([
           ...configuredClients,
           ...oauthPoolClients,
         ]);
+        if (options?.xaiMediaEmergency === "restore") {
+          xaiMediaEmergencyDisabled = resolveXaiMediaEmergencyState(
+            xaiMediaEmergencyDisabled,
+            "restore",
+            true,
+          );
+          logger.log("info", "oauth.xai_media.restored", {
+            reason: "fresh entitlement was persisted",
+          });
+        }
         codexModelTokenManagers.clear();
         codexModelsEtagTracker.invalidate();
         logger.log("info", "oauth.pool.rebuilt", {
@@ -3004,6 +3056,11 @@ export async function buildServer(
         });
       } catch (err) {
         applied = false;
+        xaiMediaEmergencyDisabled = resolveXaiMediaEmergencyState(
+          xaiMediaEmergencyDisabled,
+          options?.xaiMediaEmergency,
+          false,
+        );
         logger.log("warn", "oauth.pool.rebuild_failed", {
           line: err instanceof Error ? err.message : String(err),
         });

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,13 @@
 
 ---
 
+## 2026-08-18 · Grok Imagine 合并后收紧 entitlement 与媒体协议边界（OAuth / Images / Videos，Phase 1 spec §4–9，原则 3/6/7/8）
+
+- **撤权与 cooldown**：xAI billing 刷新失败不再删除整条 quota；改写入 `windows: []` 的 entitlement tombstone，复用两种 Store 已有的 upsert 语义保留 `usageLimitedUntilMs`。若 tombstone 无法持久化，进程级紧急 latch 会先摘除全部 xAI 媒体 alias，并在任何普通 OAuth pool rebuild 后继续生效；只有权威 billing 刷新成功持久化且对应 rebuild 成功后才恢复。
+- **公开合同**：`/v1/models` 已公开的 `xai/grok-imagine-video*` alias 现在可由 `allow_custom_model` key 直接调用，普通 key 仍在付费 reservation 前拒绝。新 fast image 与 prompt-only video 只接受已证明的 `model + prompt`；合并前已有的 quality image、single-image video 和 reference-video 合同保持兼容，不从一次默认 canary 外推细粒度付费能力。
+- **视频终态**：共享 Zod response schema、provider 客户端和 gateway poll 边界共同要求非空 `status`，且 `done` 必须带非空 `video.url`；畸形完成响应返回 502，不写入 durable terminal state。
+- **限制**：紧急 latch 是进程内状态；quota Store 完全不可写且进程在下一次成功刷新前重启时，无法把该瞬时失败跨进程持久化。正常失败路径会优先写 tombstone，因此不新增 migration、配置项或依赖。
+
 ## 2026-08-18 · Grok.com Imagine 复用 OAuth 媒体链并以短期 billing 证据授权（OAuth / Images / Videos，Phase 1 spec §4–9，原则 2/3/6/7）
 
 - **账号资格**：不新增 entitlement 表；复用 SQLite/Postgres 已持久化的 xAI 周 billing snapshot。媒体正向授权必须同时满足“24 小时内的新鲜周 billing”与“当前 OAuth JWT 是明确的已知付费 tier”，opaque、缺失、未知、`free`、`x_basic` 均 fail-closed；有效期取 `capturedAt + 24h` 与周窗口 reset 的较早者。普通 Grok 文本模型不读取此媒体 gate。
@@ -61,16 +68,9 @@
 - **加载边界**：Memory 首屏只并发加载第一批 scopes 与轻量 stats；完整 redacted key 列表仅在用户打开 By Key 时加载。`?key=` 深链直接走单 key 解析，不为校验一个 id 扫描全部 keys。
 - **Store 取舍**：`KeyStore` 新增按不可变 `key_id` 的 `getById`，SQLite/Postgres 使用索引点查，缓存包装器只透传；不缓存 admin 低频 id 查询，也不改变全局 Keys 页面既有列表契约。
 
-## 2026-08-11 · Memory 大线程有界形成与遗忘原子性（Memory Observer / Reflector / cleanup，docs/08/12，原则 3/7）
-
-- **生产根因**：2026-07-29 的外部 purge 脚本重建 `memory_messages` 却未重算 `memory_threads.message_count/last_message_at`，Admin 因此把约 18.5 万真实 raw 行显示成约 208 万；三天 cleanup 实际有效。真正的 OOM 路径是 Observer/Reflector/注入及部分 cleanup 会一次物化大线程/大结果，pure `observe` 又不直接形成 observation，最大线程累积到 51,116 行。
-- **有界生命周期**：pure `observe` outbound 也 enqueue；Observer 按服务端 `(created_at,id)` 每页最多 512 行/1 MiB/64K tokens，超大单行用带 SHA-256 的 placeholder，Observation 与 durable frontier CAS 同事务提交并继续排下一页。Reflector 只取最新 512 条 active/unexpired observation；forgetting rebuild 不再带旧 reflection，最终注入含 header 也严格服从 token budget。
-- **清理与遗忘**：raw cleanup 只删 frontier 已覆盖行，Postgres cleanup/telemetry/OAuth usage 使用小批次；decay 会在同一事务立即归档受影响 reflection、fence 正在运行的旧 Reflector，并为 project/resource 各自排 successor。Reflector 的 facts + reflection + job completion 也由 job 状态 fence 后原子提交，避免遗忘后复活。SQLite/Postgres migration 会重算 stale counters、补索引，legacy raw 保持 null frontier 后按有界页回放。
-- **升级兼容**：lease generation migration 仅在 `memory_jobs` 已存在时加列；历史上的精简/部分 schema 仍可继续升级，完整生产 schema 则照常初始化 generation 0。不能用无条件 `ALTER TABLE`，否则会让无 Memory 表的旧安装启动失败。
-- **取舍/限制**：`message_index` 仍只用于当前 ingest dedup，不能作为线程顺序；没有客户端稳定 turn id 时无法同时保证跨请求精确去重和保留合法重复。legacy bounded backfill 可能与旧 Observation 暂时重叠，因为旧 range 的错误顺序无法精确还原；这里选择宁可短期过度保留，也不静默丢失未覆盖 raw。Reflection 使用 bounded latest-set，而非持久 rolling draft。生产恢复 worker 必须 concurrency=1 灰度，先验证 migration/frontier/RSS/restart/OOM/502，再开启 raw cleanup。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-11 · Memory 大线程有界形成与遗忘原子性**：Observer/Reflector/cleanup 改为有界分页、frontier/fence 与原子提交，避免超大线程 OOM、遗忘后复活和 stale counter 漂移；完整原文经 git history 回溯。
 - **2026-08-10 · 配额统计按真实重置点切分**：PULL、Codex header 与 reset-credit 共用真实周期边界，晚到采样不写伪 reset；旧整点历史不可逆并继续标记为近似/部分数据，完整原文经 git history 回溯。
 - **2026-08-10 · 大 Session 客户端重建按记录时间展示并提前停止分页**：目标 revision 到达即停，按 `createdAt`/`sequence` 展示持久化增量请求与响应快照；Session 仍为 `exact=false` 且不可精确 Retry，完整原文经 git history 回溯。
 - **2026-08-08 · Grok Imagine 仅复用 SuperGrok OAuth 媒体链路**：媒体执行复用 xAI 订阅 OAuth，付费 POST 单写且不跨账号重试，未知价格对美元预算 fail-closed；完整原文经 git history 回溯。

--- a/packages/core/src/provider/openai.images.test.ts
+++ b/packages/core/src/provider/openai.images.test.ts
@@ -235,6 +235,16 @@ describe("createOpenAIClient.videoRetrieve", () => {
     });
   });
 
+  it("rejects a completed poll response without a playable video URL", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse({ status: "done" }));
+    const client = createOpenAIClient({ config: CONFIG, fetch });
+
+    await expect(client.videoRetrieve?.("req_123")).rejects.toMatchObject({
+      name: "UpstreamError",
+      upstreamStatus: 200,
+    });
+  });
+
   it("scrubs an echoed credential from a poll error", async () => {
     const fetch = vi
       .fn()

--- a/packages/core/src/provider/openai.ts
+++ b/packages/core/src/provider/openai.ts
@@ -4,7 +4,11 @@
 // injected config (env-sourced) and are never logged or echoed. See docs/02.
 
 import { Buffer } from "node:buffer";
-import type { NativePassthroughInput } from "@helm/shared";
+import {
+  type NativePassthroughInput,
+  VideoGenerationResponseSchema,
+  VideoRetrieveResponseSchema,
+} from "@helm/shared";
 import { createSSEIncompleteFrameGuard, nextSSEFrameBoundary } from "../protocol/streaming.js";
 import {
   consumeResponseTextWithinBudget,
@@ -808,21 +812,18 @@ export function createOpenAIClient(deps: OpenAIClientDeps): ProviderClient {
       if (error instanceof UpstreamError) throw error;
       throw invalidMediaResponse(res, null, "upstream returned invalid media JSON");
     }
-    if (
-      body === null ||
-      typeof body !== "object" ||
-      Array.isArray(body) ||
-      typeof (body as Record<string, unknown>)[requiredField] !== "string" ||
-      (requiredField === "request_id" &&
-        ((body as Record<string, unknown>).request_id as string).trim().length === 0)
-    ) {
+    const parsed =
+      requiredField === "request_id"
+        ? VideoGenerationResponseSchema.safeParse(body)
+        : VideoRetrieveResponseSchema.safeParse(body);
+    if (!parsed.success) {
       throw invalidMediaResponse(
         res,
         body,
         `upstream media response omitted valid ${requiredField}`,
       );
     }
-    return body as Record<string, unknown>;
+    return parsed.data as Record<string, unknown>;
   }
 
   async function realtimeErrorFromResponse(res: Response): Promise<UpstreamError> {

--- a/packages/core/src/store/postgres/oauth-quota.test.ts
+++ b/packages/core/src/store/postgres/oauth-quota.test.ts
@@ -62,4 +62,25 @@ describe("PgOAuthQuotaStore (pglite)", () => {
     expect(got?.planType ?? null).toBeNull();
     expect(got?.credits ?? null).toBeNull();
   });
+
+  it("preserves an active cooldown when an xAI entitlement tombstone replaces windows", async () => {
+    const db: PgDb = await createPgliteDb();
+    const store = new PgOAuthQuotaStore(db);
+    await store.setUsageLimit("xai", "subscription", 9_000);
+
+    await store.upsert(
+      snap({
+        providerId: "xai",
+        account: "subscription",
+        source: "xai",
+        capturedAt: 1_234,
+        windows: [],
+      }),
+    );
+
+    expect(await store.get("xai", "subscription")).toMatchObject({
+      windows: [],
+      usageLimitedUntilMs: 9_000,
+    });
+  });
 });

--- a/packages/shared/src/request/images-schema.test.ts
+++ b/packages/shared/src/request/images-schema.test.ts
@@ -88,22 +88,29 @@ describe("ImageGenerationRequestSchema", () => {
 });
 
 describe("GrokImagineImageGenerationRequestSchema", () => {
-  it("accepts both Grok web image modes and the observed count/aspect-ratio controls", () => {
-    for (const model of ["grok-imagine-image", "grok-imagine-image-quality"]) {
-      expect(
-        GrokImagineImageGenerationRequestSchema.safeParse({ model, prompt: "a cat" }).success,
-      ).toBe(true);
-      expect(
-        GrokImagineImageGenerationRequestSchema.safeParse({
-          model,
-          prompt: "a cat",
-          n: 4,
-          aspect_ratio: "16:9",
-          resolution: "1k",
-          response_format: "b64_json",
-        }).success,
-      ).toBe(true);
-    }
+  it("accepts only the proven prompt-only fast-image contract", () => {
+    expect(
+      GrokImagineImageGenerationRequestSchema.safeParse({
+        model: "grok-imagine-image",
+        prompt: "a cat",
+      }).success,
+    ).toBe(true);
+    expect(
+      GrokImagineImageGenerationRequestSchema.safeParse({
+        model: "grok-imagine-image",
+        prompt: "a cat",
+        n: 4,
+        aspect_ratio: "16:9",
+        resolution: "1k",
+        response_format: "b64_json",
+      }).success,
+    ).toBe(false);
+    expect(
+      GrokImagineImageGenerationRequestSchema.safeParse({
+        model: "grok-imagine-image-quality",
+        prompt: "a cat",
+      }).success,
+    ).toBe(false);
   });
 
   it("rejects unverified Grok web image fields before a paid create", () => {

--- a/packages/shared/src/request/images-schema.ts
+++ b/packages/shared/src/request/images-schema.ts
@@ -21,16 +21,12 @@ export const ImageGenerationRequestSchema = z.looseObject({
   user: z.string().optional(),
 });
 
-// Grok.com Imagine keeps a deliberately smaller contract than the generic OpenAI
-// Images surface. These are the web controls observed for the fast/quality modes;
-// unknown fields fail before the paid create instead of riding through loosely.
+// Fast Imagine is new and only its prompt-only path is proven account-wide.
+// Keep it closed until the entitlement boundary can prove paid options per account.
+// The older quality model stays on the generic compatibility path in the route.
 export const GrokImagineImageGenerationRequestSchema = z.strictObject({
-  model: z.enum(["grok-imagine-image", "grok-imagine-image-quality"]),
+  model: z.literal("grok-imagine-image"),
   prompt: z.string().min(1),
-  n: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]).optional(),
-  aspect_ratio: z.enum(["auto", "1:1", "16:9", "9:16", "3:2", "2:3"]).optional(),
-  resolution: z.literal("1k").optional(),
-  response_format: z.literal("b64_json").optional(),
 });
 
 const ImageEditCommonShape = {

--- a/packages/shared/src/request/videos-schema.test.ts
+++ b/packages/shared/src/request/videos-schema.test.ts
@@ -8,15 +8,17 @@ import {
 
 describe("VideoGenerationRequestSchema", () => {
   it("accepts the minimal Sub2API-compatible prompt-only video contract", () => {
-    expect(
-      VideoGenerationRequestSchema.safeParse({
-        model: "grok-imagine-video",
-        prompt: "waves rolling across a neon ocean",
-      }).success,
-    ).toBe(true);
+    for (const model of ["grok-imagine-video", "xai/grok-imagine-video"]) {
+      expect(
+        VideoGenerationRequestSchema.safeParse({
+          model,
+          prompt: "waves rolling across a neon ocean",
+        }).success,
+      ).toBe(true);
+    }
   });
 
-  it("accepts the Grok prompt-only video contract and current web options", () => {
+  it("rejects unverified prompt-only video options", () => {
     expect(
       VideoGenerationRequestSchema.safeParse({
         model: "grok-imagine-video",
@@ -26,13 +28,22 @@ describe("VideoGenerationRequestSchema", () => {
         resolution: "1080p",
         audio: true,
       }).success,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("accepts the single-image Grok video contract, including an empty prompt", () => {
     expect(
       VideoGenerationRequestSchema.safeParse({
         model: "grok-imagine-video-1.5-preview",
+        prompt: "",
+        image: { url: "data:image/png;base64,AAA=" },
+        duration: 6,
+        resolution: "480p",
+      }).success,
+    ).toBe(true);
+    expect(
+      VideoGenerationRequestSchema.safeParse({
+        model: "xai/grok-imagine-video-1.5-preview",
         prompt: "",
         image: { url: "data:image/png;base64,AAA=" },
         duration: 6,
@@ -139,6 +150,20 @@ describe("video response schemas", () => {
     expect(parsed.success).toBe(true);
     if (parsed.success) expect(parsed.data.progress).toBe(40);
     expect(VideoRetrieveResponseSchema.safeParse({ status: 202 }).success).toBe(false);
+  });
+
+  it("requires a non-blank video URL for a completed task", () => {
+    expect(
+      VideoRetrieveResponseSchema.safeParse({
+        status: "done",
+        video: { url: "https://cdn.example.test/video.mp4" },
+      }).success,
+    ).toBe(true);
+    expect(VideoRetrieveResponseSchema.safeParse({ status: "done" }).success).toBe(false);
+    expect(
+      VideoRetrieveResponseSchema.safeParse({ status: "done", video: { url: "  " } }).success,
+    ).toBe(false);
+    expect(VideoRetrieveResponseSchema.safeParse({ status: " " }).success).toBe(false);
   });
 });
 

--- a/packages/shared/src/request/videos-schema.ts
+++ b/packages/shared/src/request/videos-schema.ts
@@ -7,21 +7,22 @@ const VideoSourceSchema = z.strictObject({ url: z.string().min(1) });
 const VideoDurationSchema = z.union([z.literal(6), z.literal(10)]);
 const VideoResolutionSchema = z.enum(["480p", "720p"]);
 const VideoAspectRatioSchema = z.enum(["1:1", "16:9", "9:16", "3:2", "2:3"]);
+const PromptVideoModelSchema = z.enum(["grok-imagine-video", "xai/grok-imagine-video"]);
+const SingleImageVideoModelSchema = z.enum([
+  "grok-imagine-video-1.5-preview",
+  "xai/grok-imagine-video-1.5-preview",
+]);
 
 // Sub2API's proven forwarding contract uses the base Imagine model for a native
 // prompt-only create. Keep this separate from 1.5, whose upstream contract still
 // requires an input image.
 const PromptOnlyVideoRequestSchema = z.strictObject({
-  model: z.literal("grok-imagine-video"),
+  model: PromptVideoModelSchema,
   prompt: z.string().min(1),
-  aspect_ratio: VideoAspectRatioSchema.optional(),
-  duration: z.union([VideoDurationSchema, z.literal(15)]).optional(),
-  resolution: z.union([VideoResolutionSchema, z.literal("1080p")]).optional(),
-  audio: z.boolean().optional(),
 });
 
 const SingleImageVideoRequestSchema = z.strictObject({
-  model: z.literal("grok-imagine-video-1.5-preview"),
+  model: SingleImageVideoModelSchema,
   // xAI permits an empty motion prompt for the single-image workflow.
   prompt: z.string(),
   image: VideoSourceSchema,
@@ -30,7 +31,7 @@ const SingleImageVideoRequestSchema = z.strictObject({
 });
 
 const ReferenceImageVideoRequestSchema = z.strictObject({
-  model: z.literal("grok-imagine-video"),
+  model: PromptVideoModelSchema,
   prompt: z.string().min(1),
   reference_images: z.array(VideoSourceSchema).min(2).max(7),
   aspect_ratio: VideoAspectRatioSchema,
@@ -50,11 +51,28 @@ export const VideoGenerationResponseSchema = z.looseObject({
   request_id: z.string().refine((value) => value.trim().length > 0, "request_id must not be blank"),
 });
 
-export const VideoRetrieveResponseSchema = z.looseObject({
-  // Unknown states intentionally stay untouched; only the client knows whether to
-  // continue polling, while Helm merely proves the response is a video task body.
-  status: z.string(),
-});
+export const VideoRetrieveResponseSchema = z
+  .looseObject({
+    // Unknown states intentionally stay untouched; only the client knows whether to
+    // continue polling, while Helm merely proves the response is a video task body.
+    status: z.string().refine((value) => value.trim().length > 0, "status must not be blank"),
+  })
+  .superRefine((body, ctx) => {
+    if (body.status !== "done") return;
+    const video = body.video;
+    if (
+      video === null ||
+      typeof video !== "object" ||
+      Array.isArray(video) ||
+      typeof (video as Record<string, unknown>).url !== "string" ||
+      ((video as Record<string, unknown>).url as string).trim().length === 0
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "done video response requires a non-blank video.url",
+      });
+    }
+  });
 
 export type VideoGenerationRequest = z.infer<typeof VideoGenerationRequestSchema>;
 export type VideoGenerationResponse = z.infer<typeof VideoGenerationResponseSchema>;


### PR DESCRIPTION
## What changed

- preserve xAI account cooldowns when entitlement refresh fails by storing an empty-window tombstone
- keep emergency media disable sticky across ordinary OAuth pool rebuilds until a fresh persisted refresh restores it
- accept advertised concrete xAI video aliases only for custom-model keys
- keep new fast-image and prompt-only-video paths to the proven `model + prompt` contract
- reject malformed completed video polls without a non-empty `video.url`

## Why

The post-merge review of #761 found five P1 gaps: stale entitlement could return after rebuild, refresh failure could erase account cooldown, advertised aliases were rejected, unverified paid options were accepted, and malformed terminal video responses could be persisted as complete.

## Validation

- `CI=true pnpm exec vitest run ...` — 230 focused tests passed
- `CI=true pnpm --filter @helm/gateway exec playwright test e2e/videos.spec.ts` — 2/2 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

No migration or new dependency.
