### PR TITLE
[codex] release v0.28.75

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.74",
+  "version": "0.28.75",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the release version from `0.28.74` to `0.28.75`

## Why

Publish the fixes merged in #763 as a distinct GitHub Release and GHCR version tag.

## Validation

- `git diff --check`
- parsed `package.json` with Node 24 and confirmed `0.28.75`
- exact base SHA `8ed0713727bfa99186ba66c563328eaf486e55d8` passed main CI run `32151850114`
- its immutable GHCR image and `latest` resolved to `sha256:21c0a68617d6db1eb9feca961b764daa31eebbdbde3e408c01f7dd377b11fcab`
