### PR TITLE
[codex] release v0.28.76

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.75",
+  "version": "0.28.76",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

- bump Helm API from `0.28.75` to `0.28.76`
- include merged compatibility fix from PR #765

## Assessment

Patch release: the change restores backward-compatible Grok media request options and adds no migration, configuration change, or breaking API change.

## Validation

- release branch starts at current `origin/main` merge `7c7c03893649aff89277ceeaf522ce21a78bb95f`
- diff is version-only (`package.json`)
- PR #765 required CI passed: verify, store, e2e, docker
