### PR TITLE
[codex] release v0.28.77

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.76",
+  "version": "0.28.77",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Patch release 0.28.77.

## Included

- retry one transient upstream Invalid previous_response_id response on the same Codex WebSocket before client-visible output
- preserve the continuation ID, OAuth account, model, request body, and connection retry budget
- bound the recovery to one retry and surface repeated invalid IDs normally

## Provenance

Feature PR #768 merged as 70dfa47b74468084b85dbc67c495f184533accf9 after all required CI passed.

## Scope

Version-only change to root package.json.