### PR TITLE
[codex] release v0.28.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.77",
+  "version": "0.28.78",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the root package version from `0.28.77` to `0.28.78`

## Why

- release the Grok video duration, multi-reference, and extension API work merged in #767

## Validation

- PR #767 rebased-head CI passed all required checks
- merge SHA `3e033bd07a0b5e3dd8b7b59e964065e8c97aa3ab` main CI run `32223936624` passed store, verify, e2e, and Docker smoke
- this PR is version-only; `package.json` parses and reports `0.28.78`
