### PR TITLE
[codex] Record quota period usage percentage

### DIFF
--- a/apps/admin/src/routes/providers/[accountId]/+page.svelte
+++ b/apps/admin/src/routes/providers/[accountId]/+page.svelte
@@ -301,6 +301,7 @@
             <th class="px-3 py-2 text-right">{$t('Requests')}</th>
             <th class="px-3 py-2 text-right">{$t('Tokens')}</th>
             <th class="px-3 py-2 text-right">{$t('Cost')}</th>
+            <th class="px-3 py-2 text-right">{$t('Used')} %</th>
           </tr>
         </thead>
         <tbody>
@@ -329,6 +330,11 @@
               <td data-label={$t('Cost')} class="px-3 py-2 text-right font-mono"
                 >{formatUsd(p.costUsd)}</td
               >
+              <td data-label={`${$t('Used')} %`} class="px-3 py-2 text-right font-mono">
+                {granularity === 'period' && p.usedPercent != null
+                  ? `${Math.round(p.usedPercent)}%`
+                  : '—'}
+              </td>
             </tr>
           {/each}
         </tbody>

--- a/apps/admin/src/routes/providers/[accountId]/account-detail.test.ts
+++ b/apps/admin/src/routes/providers/[accountId]/account-detail.test.ts
@@ -18,6 +18,7 @@ const data: AccountDetailData = {
         requests: 3_600,
         tokens: 383_000_000,
         costUsd: 369.37,
+        usedPercent: 80,
         approximate: false,
         partial: false,
       },
@@ -30,6 +31,7 @@ const data: AccountDetailData = {
         requests: 0,
         tokens: 0,
         costUsd: null,
+        usedPercent: null,
         approximate: false,
         partial: false,
       },
@@ -64,6 +66,7 @@ describe('provider account detail', () => {
     expect(within(table).getByText('Current period')).toBeInTheDocument();
     expect(within(table).getByText('383M')).toBeInTheDocument();
     expect(within(table).getByText('3.6K')).toBeInTheDocument();
+    expect(within(table).getByText('80%')).toBeInTheDocument();
     expect(within(table).getAllByRole('row')).toHaveLength(3);
   });
 

--- a/apps/gateway/src/oauth/quota-reset-period.ts
+++ b/apps/gateway/src/oauth/quota-reset-period.ts
@@ -54,6 +54,7 @@ export async function recordQuotaResetCreditPeriods(input: {
           periodStartMs,
           periodEndMs: input.occurredAtMs,
           detectedAtMs: input.occurredAtMs,
+          usedPercent: window.usedPercent,
           approximate: false,
         })
         .catch(() => {});

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -56,7 +56,7 @@ function resetEventBoundaries(
   nextResetAtMs: number | null,
   nowMs: number,
   windowMs: number | null,
-): Array<{ startMs: number; endMs: number; approximate: boolean }> {
+): Array<{ startMs: number; endMs: number; approximate: boolean; usedPercent?: number | null }> {
   // The old writer stored [oldReset, projectedNextReset); the current writer stores a
   // closed period ending at the observed reset. Reduce both shapes to proven events.
   const rawPoints = rows
@@ -67,7 +67,9 @@ function resetEventBoundaries(
           : row.periodStartMs <= row.detectedAtMs
             ? row.periodStartMs
             : null;
-      return atMs === null ? [] : [{ atMs, approximate: row.approximate ?? false }];
+      return atMs === null
+        ? []
+        : [{ atMs, approximate: row.approximate ?? false, usedPercent: row.usedPercent ?? null }];
     })
     .filter((point) => point.atMs <= nowMs);
   const exactPoints = rawPoints.filter((point) => !point.approximate);
@@ -95,6 +97,7 @@ function resetEventBoundaries(
             startMs: start.atMs,
             endMs: end.atMs,
             approximate: start.approximate || end.approximate,
+            usedPercent: end.usedPercent,
           },
         ]
       : [];
@@ -110,6 +113,7 @@ function resetEventBoundaries(
       startMs: latest.atMs,
       endMs: nextResetAtMs,
       approximate: latest.approximate,
+      usedPercent: null,
     });
   }
   return boundaries;

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-20 · 配额周期历史新增已用百分比（OAuth providers，原则 3/7）
+
+- 重置边界记录新增可空 `usedPercent`，仅在以后观测到周期关闭时从上游快照写入；旧行不回填，无法证明的近似/日周聚合继续显示空值。
+- SQLite/Postgres 各新增一次可空列迁移；当前周期仅使用未过期快照，避免把上一周期百分比套到新周期。
+
 ## 2026-08-19 · Codex Responses 续接 ID 在原 WebSocket 上做一次有界恢复（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
 
 - **根因与修复**：生产证据显示多个刚成功的同账号续接约一秒后收到上游 `400 Invalid previous_response_id`，且成功与失败请求使用相同 native sanitizer；这不是账号轮换或正文变换。provider 现在只在首个客户端可见输出前、只针对该精确 400，在同一上游 WebSocket 上原样重发一次，吸收短暂的上游状态传播竞态。

--- a/packages/core/src/provider/oauth/usage-periods.test.ts
+++ b/packages/core/src/provider/oauth/usage-periods.test.ts
@@ -246,7 +246,7 @@ describe("computeUsagePeriods", () => {
       limit: 5,
       recordedBoundaries: {
         "5h": [
-          { startMs: 100 * HOUR, endMs: 105 * HOUR },
+          { startMs: 100 * HOUR, endMs: 105 * HOUR, usedPercent: 88 },
           { startMs: 95 * HOUR, endMs: 100 * HOUR },
         ],
       },
@@ -255,6 +255,7 @@ describe("computeUsagePeriods", () => {
     expect(out.periods[0]).toMatchObject({
       periodStartMs: 100 * HOUR,
       periodEndMs: 105 * HOUR,
+      usedPercent: 88,
       approximate: false,
     });
     expect(out.periods[1]).toMatchObject({
@@ -539,6 +540,7 @@ describe("detectQuotaResetPeriods", () => {
       expect.objectContaining({
         periodStartMs: reset - WEEK,
         periodEndMs: observedAtMs,
+        usedPercent: 91,
         approximate: true,
       }),
     ]);

--- a/packages/core/src/provider/oauth/usage-periods.ts
+++ b/packages/core/src/provider/oauth/usage-periods.ts
@@ -49,6 +49,7 @@ export function detectQuotaResetPeriods(input: {
       periodStartMs: oldStart,
       periodEndMs: resetAtMs,
       detectedAtMs: input.observedAtMs,
+      usedPercent: previous.usedPercent,
       approximate: !resetDeadlineAdvanced,
     });
   }
@@ -73,7 +74,7 @@ export interface ComputeUsagePeriodsInput {
   // estimates keep their approximate marker. Older gaps use fixed-window rollback.
   recordedBoundaries?: Record<
     string,
-    Array<{ startMs: number; endMs: number; approximate?: boolean }>
+    Array<{ startMs: number; endMs: number; approximate?: boolean; usedPercent?: number | null }>
   >;
 }
 
@@ -198,6 +199,7 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
         periodStartMs: curStart,
         periodEndMs: curEnd,
         ...sums,
+        usedPercent: boundaryAdvanced ? null : w.usedPercent,
         approximate: !curExact,
         partial: curStart < dataStartMs,
       });
@@ -224,11 +226,13 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
       const end = cursor; // ALWAYS the cursor — guarantees contiguity, no overlap
       let start: number;
       let approximate: boolean;
+      let usedPercent: number | null | undefined;
       // Usable when the recording's end sits at/just under the cursor (gap ≤ tol) and its
       // start is strictly older — its real start becomes the next cursor.
       if (rec && cursor - rec.endMs <= tol && rec.startMs < cursor) {
         start = rec.startMs;
         approximate = rec.approximate ?? false;
+        usedPercent = rec.usedPercent;
         recIdx++;
       } else {
         start = cursor - winMs;
@@ -240,6 +244,7 @@ export function computeUsagePeriods(input: ComputeUsagePeriodsInput): UsagePerio
         periodStartMs: start,
         periodEndMs: end,
         ...sums,
+        usedPercent: usedPercent ?? null,
         approximate,
         partial: start < dataStartMs,
       });

--- a/packages/core/src/store/postgres/migrate.ts
+++ b/packages/core/src/store/postgres/migrate.ts
@@ -1359,6 +1359,19 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Pg mirror of SQLite v52: capture usage percentage at observed reset time.
+    version: 51,
+    run: async (db) => {
+      if (await pgTableHasColumns(db, "oauth_reset_period", ["provider_id"])) {
+        await db.execute(
+          sql.raw(
+            "ALTER TABLE oauth_reset_period ADD COLUMN IF NOT EXISTS used_percent DOUBLE PRECISION",
+          ),
+        );
+      }
+    },
+  },
 ];
 
 function resultRows<T>(result: unknown): T[] {

--- a/packages/core/src/store/postgres/oauth-reset-period.ts
+++ b/packages/core/src/store/postgres/oauth-reset-period.ts
@@ -18,6 +18,7 @@ export class PgOAuthResetPeriodStore implements OAuthResetPeriodStore {
       periodStartMs: row.periodStartMs,
       periodEndMs: row.periodEndMs,
       detectedAtMs: row.detectedAtMs,
+      usedPercent: row.usedPercent ?? null,
       approximate: row.approximate,
     });
     const target = [
@@ -35,6 +36,7 @@ export class PgOAuthResetPeriodStore implements OAuthResetPeriodStore {
       set: {
         periodEndMs: row.periodEndMs,
         detectedAtMs: row.detectedAtMs,
+        usedPercent: row.usedPercent ?? null,
         approximate: false,
       },
       setWhere: eq(oauthResetPeriod.approximate, true),
@@ -67,6 +69,7 @@ export class PgOAuthResetPeriodStore implements OAuthResetPeriodStore {
         periodStartMs: Number(r.periodStartMs),
         periodEndMs: Number(r.periodEndMs),
         detectedAtMs: Number(r.detectedAtMs),
+        usedPercent: r.usedPercent == null ? null : Number(r.usedPercent),
         approximate: r.approximate,
       }),
     );

--- a/packages/core/src/store/postgres/schema.ts
+++ b/packages/core/src/store/postgres/schema.ts
@@ -489,6 +489,7 @@ export const oauthResetPeriod = pgTable(
     periodStartMs: bigint("period_start_ms", { mode: "number" }).notNull(), // prior resetsAtMs
     periodEndMs: bigint("period_end_ms", { mode: "number" }).notNull(), // new resetsAtMs
     detectedAtMs: bigint("detected_at_ms", { mode: "number" }).notNull(),
+    usedPercent: doublePrecision("used_percent"), // nullable; legacy rows have no snapshot
     approximate: boolean("approximate").notNull().default(false),
   },
   (t) => [primaryKey({ columns: [t.providerId, t.account, t.windowKey, t.periodStartMs] })],

--- a/packages/core/src/store/sqlite/migrate.ts
+++ b/packages/core/src/store/sqlite/migrate.ts
@@ -1401,6 +1401,19 @@ const MIGRATIONS: readonly Migration[] = [
       }
     },
   },
+  {
+    // Capture the upstream percentage when a reset boundary is observed. Legacy
+    // rows stay NULL and are intentionally not backfilled.
+    version: 52,
+    run: (db) => {
+      if (
+        sqliteTableHasColumns(db, "oauth_reset_period", ["provider_id"]) &&
+        !sqliteTableHasColumns(db, "oauth_reset_period", ["used_percent"])
+      ) {
+        db.exec("ALTER TABLE oauth_reset_period ADD COLUMN used_percent REAL");
+      }
+    },
+  },
 ];
 
 function sqliteTableHasColumns(

--- a/packages/core/src/store/sqlite/oauth-reset-period.ts
+++ b/packages/core/src/store/sqlite/oauth-reset-period.ts
@@ -18,6 +18,7 @@ export class SqliteOAuthResetPeriodStore implements OAuthResetPeriodStore {
       periodStartMs: row.periodStartMs,
       periodEndMs: row.periodEndMs,
       detectedAtMs: row.detectedAtMs,
+      usedPercent: row.usedPercent ?? null,
       approximate: row.approximate,
     });
     const target = [
@@ -36,6 +37,7 @@ export class SqliteOAuthResetPeriodStore implements OAuthResetPeriodStore {
         set: {
           periodEndMs: row.periodEndMs,
           detectedAtMs: row.detectedAtMs,
+          usedPercent: row.usedPercent ?? null,
           approximate: false,
         },
         setWhere: eq(oauthResetPeriod.approximate, true),

--- a/packages/core/src/store/sqlite/schema.ts
+++ b/packages/core/src/store/sqlite/schema.ts
@@ -366,6 +366,7 @@ export const oauthResetPeriod = sqliteTable(
     periodStartMs: integer("period_start_ms").notNull(), // prior resetsAtMs
     periodEndMs: integer("period_end_ms").notNull(), // new resetsAtMs
     detectedAtMs: integer("detected_at_ms").notNull(), // when the refresh saw it
+    usedPercent: real("used_percent"), // nullable; legacy rows have no snapshot
     approximate: integer("approximate", { mode: "boolean" }).notNull().default(false),
   },
   // PK on (provider, account, window, start) makes re-detection idempotent — the same

--- a/packages/shared/src/oauth/usage-schema.ts
+++ b/packages/shared/src/oauth/usage-schema.ts
@@ -520,6 +520,9 @@ export const OAuthUsagePeriodSchema = z
     requests: z.number().int().nonnegative(),
     tokens: z.number().int().nonnegative(),
     costUsd: z.number().nullable(),
+    // Upstream quota usage at the end of this reset period. Legacy rows have no
+    // snapshot and remain null.
+    usedPercent: z.number().min(0).nullable().optional(),
     approximate: z.boolean(),
     partial: z.boolean(),
   })
@@ -555,6 +558,9 @@ export const OAuthResetPeriodSchema = z
     periodStartMs: z.number().int(),
     periodEndMs: z.number().int(),
     detectedAtMs: z.number().int(),
+    // Usage percentage captured from the quota snapshot that closed this period.
+    // Nullable for legacy boundary rows and reset events without a snapshot.
+    usedPercent: z.number().min(0).nullable().optional(),
     approximate: z.boolean().default(false),
   })
   .strict();


### PR DESCRIPTION
## What changed

- persist the upstream used percentage when a quota reset closes a period
- expose that percentage in reset-period history while leaving legacy and unprovable rows blank
- add nullable SQLite/Postgres migrations and an Admin `Used %` column

## Why

Token and cost history alone cannot show how much of the provider allowance each reset period consumed. The latest quota snapshot was not historical evidence and could not safely be reused for older periods.

## Validation

- focused Vitest: 26/26
- SQLite/Postgres store and migration Vitest: 52/52
- `pnpm typecheck`
- `pnpm --filter @helm/admin check`
- `pnpm lint`
- `pnpm build`