### PR TITLE
[codex] Release v0.28.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.78",
+  "version": "0.28.79",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version-only release PR for the merged quota-period usage-percentage change.

Base: `0422380ca697763ae363ba2af95451c4556d3757`
Version: `0.28.79`

The release image must be published from the exact merged release SHA after this PR is merged.