### PR TITLE
[codex] align Grok video inputs with xAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ curl http://localhost:8080/v1beta/interactions \
 
 > The OpenAI Images endpoint serves both OpenAI and Gemini image models (Helm translates Gemini to/from `generateContent`). The two Gemini-native entrypoints serve only Gemini image models. `gpt-image-2` on `/v1beta/interactions` is a 400 → use `/v1/images/generations`.
 
-With a connected SuperGrok account, the same Images endpoint also accepts `grok-imagine-image-quality`. Grok video uses `grok-imagine-video-1.5-preview` with one `image`, or `grok-imagine-video` with 2–7 `reference_images`; start with `POST /v1/videos/generations`, then poll the returned `request_id` at `GET /v1/videos/{request_id}`. Media creates are paid single writes: Helm never retries a result-unknown POST or switches OAuth accounts, and each video task remains bound to its original Helm account, API key, provider, and SuperGrok account.
+With a connected SuperGrok account, the same Images endpoint also accepts `grok-imagine-image-quality`. Grok video supports prompt-only `grok-imagine-video`, `grok-imagine-video-1.5[-preview]` with one first-frame `image`, and stable `grok-imagine-video-1.5` with 1–7 `reference_images` plus optional preset `reference_audios`; start with `POST /v1/videos/generations`, then poll the returned `request_id` at `GET /v1/videos/{request_id}`. Media creates are paid single writes: Helm never retries a result-unknown POST or switches OAuth accounts, and each video task remains bound to its original Helm account, API key, provider, and SuperGrok account.
 
 #### Image provider lanes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -275,7 +275,7 @@ curl http://localhost:8080/v1beta/interactions \
 
 > OpenAI Images 端点可调用 OpenAI 和 Gemini 图片模型，Helm 会在内部与 Gemini `generateContent` 做双向转换；两个 Gemini 原生入口则只接受 Gemini 图片模型。在 `/v1beta/interactions` 请求 `gpt-image-2` 会返回 400，请改用 `/v1/images/generations`。
 
-连接 SuperGrok 账号后，同一个 Images 端点还可使用 `grok-imagine-image-quality`。Grok 视频分成两种严格请求：`grok-imagine-video-1.5-preview` 搭配单个 `image`，`grok-imagine-video` 搭配 2–7 个 `reference_images`；先调用 `POST /v1/videos/generations`，再用返回的 `request_id` 轮询 `GET /v1/videos/{request_id}`。媒体创建属于付费单写：结果不明时 Helm 不会重试 POST 或切换 OAuth 账号；视频任务始终绑定原 Helm account、API key、provider 和 SuperGrok 账号。
+连接 SuperGrok 账号后，同一个 Images 端点还可使用 `grok-imagine-image-quality`。Grok 视频支持三种严格请求：`grok-imagine-video` 纯文字生成；`grok-imagine-video-1.5[-preview]` 搭配单个首帧 `image`；stable `grok-imagine-video-1.5` 搭配 1–7 个 `reference_images`，并可附带预设声音 `reference_audios`。先调用 `POST /v1/videos/generations`，再用返回的 `request_id` 轮询 `GET /v1/videos/{request_id}`。媒体创建属于付费单写：结果不明时 Helm 不会重试 POST 或切换 OAuth 账号；视频任务始终绑定原 Helm account、API key、provider 和 SuperGrok 账号。
 
 #### 图片 Provider Lane
 

--- a/apps/gateway/e2e/videos.spec.ts
+++ b/apps/gateway/e2e/videos.spec.ts
@@ -249,25 +249,24 @@ test("rejects a configured static outputVideo alias at the closed Imagine reques
   expect((await videoCapture()).starts).toHaveLength(0);
 });
 
-test("forwards every 30-second generation shape and one extension exactly once", async () => {
+test("forwards official and compatibility generation shapes plus one extension exactly once", async () => {
   const generationBodies = [
     { model: "grok-imagine-video", prompt: "text only", duration: 30 },
     {
       model: "grok-imagine-video-1.5",
       prompt: "single image",
       image: { url: "https://example.test/source.png" },
-      duration: 30,
-      resolution: "720p",
+      aspect_ratio: "4:3",
+      duration: 12,
+      resolution: "1080p",
     },
     {
       model: "grok-imagine-video-1.5",
-      prompt: "reference <IMAGE_0> and <IMAGE_1>",
-      reference_images: [
-        { url: "https://example.test/one.png" },
-        { url: "https://example.test/two.png" },
-      ],
-      aspect_ratio: "16:9",
-      duration: 30,
+      prompt: "reference <IMAGE_0> with <AUDIO_0>",
+      reference_images: [{ url: "https://example.test/one.png" }],
+      reference_audios: [{ voice_id: "eve" }],
+      aspect_ratio: "3:4",
+      duration: 8,
       resolution: "720p",
     },
     {

--- a/apps/gateway/src/routes/openapi.test.ts
+++ b/apps/gateway/src/routes/openapi.test.ts
@@ -58,6 +58,16 @@ describe("OpenAPI docs", () => {
     ]) {
       expect(doc.components.schemas[name]).toBeDefined();
     }
+    const videoGenerationSchema = JSON.stringify(doc.components.schemas.VideoGenerationRequest);
+    for (const officialVideoField of [
+      '"reference_audios"',
+      '"voice_id"',
+      '"4:3"',
+      '"3:4"',
+      '"1080p"',
+    ]) {
+      expect(videoGenerationSchema).toContain(officialVideoField);
+    }
     // The Gemini-native endpoints advertise the `x-goog-api-key` auth scheme.
     expect(doc.components.securitySchemes.googleApiKey).toMatchObject({
       type: "apiKey",

--- a/apps/gateway/src/routes/videos.test.ts
+++ b/apps/gateway/src/routes/videos.test.ts
@@ -130,25 +130,24 @@ describe("registerVideosRoute", () => {
         model: "grok-imagine-video-1.5",
         prompt: "move",
         image: { url: "https://example.test/source.png" },
-        duration: 30,
-        resolution: "720p",
+        aspect_ratio: "4:3",
+        duration: 12,
+        resolution: "1080p",
       },
     ],
     [
       "reference_images",
       {
         model: "grok-imagine-video-1.5",
-        prompt: "connect <IMAGE_0> and <IMAGE_1>",
-        reference_images: [
-          { url: "https://example.test/one.png" },
-          { url: "https://example.test/two.png" },
-        ],
-        aspect_ratio: "16:9",
-        duration: 30,
+        prompt: "have <IMAGE_0> speak with <AUDIO_0>",
+        reference_images: [{ url: "https://example.test/one.png" }],
+        reference_audios: [{ voice_id: "eve" }],
+        aspect_ratio: "3:4",
+        duration: 8,
         resolution: "720p",
       },
     ],
-  ])("forwards one 30-second %s generation with the resolved wire model", async (_name, body) => {
+  ])("forwards one supported %s generation with the resolved wire model", async (_name, body) => {
     const { app, create } = setup();
 
     expect((await post(app, body)).status).toBe(200);
@@ -158,19 +157,18 @@ describe("registerVideosRoute", () => {
 
   it("normalizes the compatible images field to reference_images before the paid POST", async () => {
     const { app, create } = setup();
-    const references = [
-      { url: "https://example.test/one.png" },
-      { url: "https://example.test/two.png" },
-    ];
+    const references = [{ url: "https://example.test/one.png" }];
+    const referenceAudios = [{ voice_id: "eve" }];
 
     expect(
       (
         await post(app, {
           model: "grok-imagine-video-1.5",
-          prompt: "connect <IMAGE_0> and <IMAGE_1>",
+          prompt: "have <IMAGE_0> speak with <AUDIO_0>",
           images: references,
-          aspect_ratio: "16:9",
-          duration: 15,
+          reference_audios: referenceAudios,
+          aspect_ratio: "3:4",
+          duration: 8,
           resolution: "720p",
         })
       ).status,
@@ -179,10 +177,11 @@ describe("registerVideosRoute", () => {
     expect(create).toHaveBeenCalledWith(
       {
         model: "grok-imagine-video-1.5",
-        prompt: "connect <IMAGE_0> and <IMAGE_1>",
+        prompt: "have <IMAGE_0> speak with <AUDIO_0>",
         reference_images: references,
-        aspect_ratio: "16:9",
-        duration: 15,
+        reference_audios: referenceAudios,
+        aspect_ratio: "3:4",
+        duration: 8,
         resolution: "720p",
       },
       expect.any(AbortSignal),

--- a/docs/grok-imagine-media-spec.md
+++ b/docs/grok-imagine-media-spec.md
@@ -22,9 +22,10 @@
 - [x] 新增 `GET /v1/videos/{request_id}`，兼容 Grok 的异步视频 poll 协议。
 - [x] `grok-imagine-video-1.5-preview` 支持单图生视频。
 - [x] `grok-imagine-video-1.5` 兼容同一单图能力池，并保留 stable wire model。
-- [x] `grok-imagine-video` 支持 2–7 张参考图生视频。
-- [x] 所有视频写入统一支持 `duration: 6 | 10 | 15 | 30`。
-- [x] 多参考图兼容 `reference_images` 与 `images`，两者严格互斥。
+- [x] `grok-imagine-video-1.5` 支持 1–7 张参考图生视频，并可附带最多 3 个预设声音引用。
+- [x] 视频 generation 支持官方 `1–15` 秒整数并兼容既有 `30`；extension 复用同一输入域。
+- [x] 参考图模式兼容 `reference_images` 与 `images`，两者严格互斥。
+- [x] 本机 SuperGrok OAuth 单写 canary 已验证 1 张参考图 + `eve` 预设声音、16:9/9:16、720p、8 秒，产物均含 AAC 音轨。
 - [x] 新增 `POST /v1/videos/extensions`，复用现有单写与任务轮询链路。
 - [ ] 使用真实 Grok CLI 验证 `/imagine-video` 默认流程：先生成首帧，再生成视频。
 - [x] 图片和视频创建遵守“单写”规则：结果不明时不自动重试、不切 provider、不切 OAuth 账号。
@@ -63,7 +64,7 @@
 - 媒体基址默认是 `https://api.x.ai/v1`，不是 `cli-chat-proxy.grok.com/v1`。
 - `GROK_XAI_API_BASE_URL` 决定 Imagine 请求地址；`GROK_MODELS_BASE_URL` 不参与媒体 URL 选择。
 - 图片默认模型完整 ID 是 `grok-imagine-image-quality`；`quality` 是模型名后缀，实际清晰度字段是 `resolution: "1k"`。
-- 视频模型不能混用：单图使用 `grok-imagine-video-1.5-preview`，多参考图使用 `grok-imagine-video`。
+- 视频模型不能混用：首帧单图使用 `grok-imagine-video-1.5-preview` 或 stable 1.5，参考图模式只使用 stable `grok-imagine-video-1.5`。
 - video start 返回字段是 `request_id`；poll 只有 `done`、`failed`、`expired` 是已知终态，其他状态继续等待。
 - `/imagine-video` 是 `image_gen → image_to_video` 的客户端编排，不是新的 HTTP endpoint。
 
@@ -186,41 +187,46 @@ POST {xai_api_base_url}/videos/generations
   "model": "grok-imagine-video-1.5-preview",
   "prompt": "short motion description",
   "image": { "url": "https://... 或 data:image/..." },
-  "duration": 6,
-  "resolution": "480p"
+  "aspect_ratio": "4:3",
+  "duration": 12,
+  "resolution": "1080p"
 }
 ```
 
 约束：
 
 - `prompt` 可以是空字符串。
-- `duration` 只能是 `6`、`10`、`15` 或 `30`。
-- `resolution` 只能是 `480p` 或 `720p`。
+- `duration` 接受官方 `1–15` 秒整数；为兼容已公开合同继续接受 `30`，但 30 秒仍需账号 entitlement 与真实 canary。
+- `resolution` 可为 `480p`、`720p` 或 `1080p`。
+- `aspect_ratio` 可选；省略时沿用输入图片比例，传入时由上游覆盖输出比例。
 - 该形状不发送 `reference_images`。
 
-### 4.4 多参考图生视频
+### 4.4 参考图生视频
 
 ```json
 {
   "model": "grok-imagine-video-1.5",
-  "prompt": "让 <IMAGE_0> 平滑过渡到 <IMAGE_1> 的机位",
+  "prompt": "让 <IMAGE_0> 用 <AUDIO_0> 的声音介绍产品",
   "reference_images": [
-    { "url": "https://... 或 data:image/..." },
     { "url": "https://... 或 data:image/..." }
   ],
-  "aspect_ratio": "16:9",
-  "duration": 6,
-  "resolution": "480p"
+  "reference_audios": [
+    { "voice_id": "eve" }
+  ],
+  "aspect_ratio": "3:4",
+  "duration": 8,
+  "resolution": "720p"
 }
 ```
 
 约束：
 
 - `prompt` 不能为空。
-- `reference_images` 或兼容字段 `images` 数量为 2–7，两者不能同时出现；兼容字段会在付费 POST 前统一转成上游 `reference_images`。
-- 多图只接受 stable `grok-imagine-video-1.5` 及对应 `xai/` alias；prompt 建议用 `<IMAGE_0>`、`<IMAGE_1>` 标注引用。
-- `aspect_ratio` 只能是 `1:1`、`16:9`、`9:16`、`3:2`、`2:3`。
-- `duration` 和 `resolution` 与单图模式相同。
+- `reference_images` 或兼容字段 `images` 数量为 1–7，两者不能同时出现；兼容字段会在付费 POST 前统一转成上游 `reference_images`。
+- 参考图模式只接受 stable `grok-imagine-video-1.5` 及对应 `xai/` alias；prompt 用 `<IMAGE_0>`…标注图片引用。
+- 可选 `reference_audios` 接受 1–3 个严格 `{ voice_id }` 预设声音；prompt 用 `<AUDIO_0>`…标注声音引用。自定义音频 URL 属于受限 partner 能力，本阶段不开放。
+- `aspect_ratio` 可为 `1:1`、`16:9`、`9:16`、`4:3`、`3:4`、`3:2`、`2:3`。
+- `duration` 接受 `1–15` 秒整数以及兼容值 `30`；reference-to-video 仍限 `480p | 720p`。
 
 ### 4.5 视频扩展
 

--- a/docs/grok-oauth-entitlement-video-phase1-spec.md
+++ b/docs/grok-oauth-entitlement-video-phase1-spec.md
@@ -106,6 +106,8 @@
 
 网页控件只能证明产品能力存在，不能单独证明底层 endpoint、请求字段或生成步骤。
 
+2026-08-20 复核 xAI 官方 [reference-to-video](https://docs.x.ai/developers/model-capabilities/video/reference-to-video)、[image-to-video](https://docs.x.ai/developers/model-capabilities/video/image-to-video)、[generation](https://docs.x.ai/developers/model-capabilities/video/generation) 与 [Videos REST](https://docs.x.ai/developers/rest-api-reference/inference/videos) 文档后，公共 API 合同已经明确：`grok-imagine-video-1.5` 的 `reference_images` 可只含 1 张图，支持七种 `aspect_ratio`；`reference_audios` 可携带最多 3 个预设 `voice_id`；image-to-video 支持画幅覆盖与 1080p。Helm 已据此扩展严格 schema。官方 API-key 文档仍不等于任意 Grok.com OAuth 账号的 entitlement；本机账号随后用单写 canary 验证了 1 张参考图 + `eve`、16:9/9:16、720p、8 秒和 AAC 音轨，1080p、其他时长与其他画幅仍只以官方合同和离线测试为证据。
+
 ## 3. 证据边界与实现路线
 
 ### 3.1 四个证据来源分别能证明什么
@@ -205,7 +207,7 @@ GET  /v1/videos/:request_id
 
 - [x] 图片请求使用共享 Zod schema；Grok.com 专有选项只在 xAI OAuth 分支严格校验。
 - [x] 视频 schema 新增严格的 prompt-only 形状：最小请求只要求 `model + prompt`，已确认的网页选项才加入枚举。
-- [x] 现有单图/多参考图视频合同保持兼容。
+- [x] 现有单图/参考图视频合同保持兼容，并补齐官方单张参考图、完整画幅、预设 `reference_audios`、单图画幅与 1080p 输入。
 - [x] 不把 provider 内部 model/endpoint 暴露为新的公共市场；公开参数表达用户可理解的模式和选项。
 
 ### 5.2 账号能力投影

--- a/docs/grok-video-duration-and-extension-plan.md
+++ b/docs/grok-video-duration-and-extension-plan.md
@@ -5,9 +5,12 @@
 > Helm 证据基线：`967b9f9f8ee22e39f21aec9ac8d11376b44a4aed`
 > Sub2API 证据基线：`49504adc98d2b6d539491e865a340e644548979e`（本地 `main` 与 `origin/main` 一致）
 
+> 2026-08-20 官方合同校准：xAI 当前 Videos 文档确认 generation 时长为 `1–15` 秒、默认 8 秒；Helm 在此基础上保留既有 `30` 兼容值。image-to-video 新增可选 `aspect_ratio` 与 1080p；reference-to-video 改为 1–7 张参考图、七种画幅，并支持最多 3 个严格 `{ voice_id }` 预设 `reference_audios`。
+> 同日本机 SuperGrok OAuth 单写 canary 已验证 1 张参考图 + `eve`、16:9/9:16、720p、8 秒和 AAC 音轨；1080p、其他时长与其他画幅未做付费穷举。
+
 ## 实施状态
 
-- [x] 纯文本、单图、多图与 extension 统一接受 `duration: 6 | 10 | 15 | 30`。
+- [x] 纯文本、单图、参考图与 extension 统一接受 `duration: 1–15 | 30`。
 - [x] 单图兼容 stable/preview 及对应 `xai/` alias，并继续使用 `image`。
 - [x] 多图只使用 stable 1.5 模型；客户端兼容 `reference_images` 与 `images`，两者严格互斥，`images` 在付费 POST 前统一转成上游 `reference_images`。
 - [x] 增加 `POST /v1/videos/extensions`、严格 schema、OpenAPI 与上游 provider 方法。
@@ -23,7 +26,7 @@
 
 本次只扩展现有 Grok/SuperGrok OAuth 视频链路，不新增通用媒体队列或第二套 provider 架构：
 
-1. 所有视频写入模式统一使用 `duration: 6 | 10 | 15 | 30`，不再按纯文本、单图、多图或扩展维护不同枚举。
+1. 所有视频写入模式统一使用 `duration: 1–15 | 30`，不再按纯文本、单图、参考图或扩展维护不同枚举。
 2. 为纯文本、单图、多图和视频扩展分别增加一条 30 秒原样转发测试。
 3. 增加视频扩展入口；Helm 客户端入口为 `POST /v1/videos/extensions`，上游请求为 `POST https://api.x.ai/v1/videos/extensions`。
 
@@ -49,9 +52,9 @@
 ### 2.1 协议与 API 语义专家
 
 - 当前单图 schema 位于 `packages/shared/src/request/videos-schema.ts`，要求 `image` 且只接受 6/10 秒；15/30 秒会在 provider 选择和付费 POST 前被严格拒绝。
-- 当前多参考图 schema 要求 `reference_images`；还不接受 Sub2API 已兼容的 `images`。单图的 `image` 与多图的 `reference_images/images` 必须保持互斥，避免请求被错误分型。
+- 参考图 schema 使用 `reference_images`，并兼容 Sub2API 的 `images`；单图的 `image` 与参考图的 `reference_images/images` 必须保持互斥，避免请求被错误分型。
 - 当前 Helm 只注册 `grok-imagine-video-1.5-preview` 单图别名；还需把 `grok-imagine-video-1.5` 作为同一 1.5 能力族的兼容输入，同时保留客户端选择的 stable/preview 上游 wire model，不能仅靠改模型名判断请求模式。
-- 当前纯文本 schema 已接受 6/10/15 秒；多图仍只有 6/10，extension 尚无 Helm schema。目标状态是四种模式统一复用同一个 6/10/15/30 schema。
+- 四种模式统一复用同一个 `1–15 | 30` schema；官方范围之外只保留已有的 30 秒兼容值。
 - 实施后的转发层保留 `image`、`reference_images`、`duration` 与 `resolution`；仅把兼容入参 `images` 规范成 Grok Build 已证明的上游 `reference_images`，不做单图/多图升降级。
 - Helm 当前没有 `/videos/extensions` 路由、schema、provider 方法或 OpenAPI 合同，不能只加一个 Hono 路由就宣称完成。
 
@@ -87,7 +90,7 @@
 
 | 项目 | 代码开发 | 离线验收 | 生产能力结论 |
 |---|---|---|---|
-| 所有视频模式统一 6/10/15/30 秒 | Go | 可完整证明原样转发 | 最高级账号支持 30 秒；部署后回读确认 |
+| 所有视频模式统一 1–15 秒并兼容 30 秒 | Go | 可完整证明原样转发 | 30 秒仍需账号能力与部署后回读确认 |
 | 单图/多图字段判别与 `images` 兼容 | Go | 可完整证明 | 不改变上游端点 |
 | `/videos/extensions` | Go，但先冻结严格请求合同 | 可证明路由、单写、receipt 与轮询绑定 | 当前 No-Go；Sub2API 本地实现不能替代真实上游验收 |
 
@@ -106,64 +109,66 @@
   "image": {
     "url": "https://example.com/source.png"
   },
-  "duration": 30,
-  "resolution": "720p"
+  "aspect_ratio": "4:3",
+  "duration": 12,
+  "resolution": "1080p"
 }
 ```
 
 保持现有 prompt、image 与 resolution 合同，duration 使用统一 schema：
 
 ```ts
-duration: 6 | 10 | 15 | 30
+duration: 1..15 | 30
 ```
 
 - 适用 model 为 `grok-imagine-video-1.5-preview`、`grok-imagine-video-1.5` 及对应 `xai/` concrete alias。
 - stable/preview 名称共用同一 1.5 capability/account pool，不新增重复 lane/catalog；provider wire body 与 telemetry 都保留客户端选择的具体名称。
 - `prompt` 继续允许空字符串。
-- `resolution` 继续仅允许 `480p | 720p`。
-- 除 6/10/15/30 以外的数值、小数和字符串仍在本地返回 400 `invalid_request`，且上游写次数为 0。
+- `aspect_ratio` 可选，支持官方七种画幅；`resolution` 允许 `480p | 720p | 1080p`。
+- 除 1–15 整数与兼容值 30 以外的数值、小数和字符串仍在本地返回 400 `invalid_request`，且上游写次数为 0。
 
 ### 4.2 纯文本生视频
 
 保持现有字段，复用同一个 duration schema：
 
 ```ts
-duration?: 6 | 10 | 15 | 30
+duration?: 1..15 | 30
 ```
 
 - 适用 model 继续为 `grok-imagine-video` 与 `xai/grok-imagine-video`。
 - 不传 duration 时保持现有上游默认行为，Helm 不注入默认值。
 - 6/10/15 秒现有合同及测试保留；30 秒增加相同级别的 schema 与原样转发覆盖。
-- 除 6/10/15/30 以外的数值、小数和字符串仍拒绝。
+- 除 1–15 整数与兼容值 30 以外的数值、小数和字符串仍拒绝。
 
-### 4.3 多参考图生视频
+### 4.3 参考图生视频
 
-多参考图与单图使用同一个 endpoint，但必须使用数组字段。规范字段为 `reference_images`：
+参考图与首帧单图使用同一个 endpoint，但必须使用数组字段。规范字段为 `reference_images`：
 
 ```json
 {
   "model": "grok-imagine-video-1.5",
-  "prompt": "让 <IMAGE_0> 中的纸船平滑移动到 <IMAGE_1> 的机位",
+  "prompt": "让 <IMAGE_0> 中的人用 <AUDIO_0> 的声音介绍产品",
   "reference_images": [
     {
       "url": "https://example.com/one.png"
-    },
-    {
-      "url": "https://example.com/two.png"
     }
   ],
-  "aspect_ratio": "16:9",
-  "duration": 30,
+  "reference_audios": [
+    { "voice_id": "eve" }
+  ],
+  "aspect_ratio": "3:4",
+  "duration": 8,
   "resolution": "720p"
 }
 ```
 
 兼容请求可把 `reference_images` 改为 `images`，其余合同相同：
 
-- 两个字段都要求 2–7 个严格 `{ url }` 对象。
+- 两个字段都要求 1–7 个严格 `{ url }` 对象。
 - 一次请求只能出现 `reference_images` 或 `images` 其中一个；同时出现、两者都缺失或误用单个 `image` 均返回 400 `invalid_request`，上游写次数为 0。
 - Helm 把兼容入参 `images` 统一转换为上游 `reference_images`；不会把单图 `image` 自动提升为数组，也不会把多图数组压成单图。
-- model 只接受 `grok-imagine-video-1.5 | xai/grok-imagine-video-1.5`；prompt 建议用 `<IMAGE_0>`、`<IMAGE_1>` 对应引用。duration 继续复用 Helm 的 6/10/15/30 合同。
+- 可选 `reference_audios` 接受 1–3 个严格 `{ voice_id }` 预设声音；自定义音频 URL 暂不开放。
+- model 只接受 `grok-imagine-video-1.5 | xai/grok-imagine-video-1.5`；prompt 用 `<IMAGE_0>`…对应图片引用，预设声音用 `<AUDIO_0>`…对应引用。duration 继续复用 Helm 的 `1–15 | 30` 合同。
 
 ### 4.4 视频扩展
 
@@ -191,7 +196,7 @@ Content-Type: application/json
 - `model`：`grok-imagine-video | xai/grok-imagine-video`。
 - `prompt`：非空字符串。
 - `video`：严格对象，只接受非空 `url`。
-- `duration`：与其他视频写入统一接受 6/10/15/30；不复制 Sub2API 的计费 clamp，也不为 extension 单独维护枚举。
+- `duration`：与其他视频写入统一接受 1–15 整数与兼容值 30；不复制 Sub2API 的计费 clamp，也不为 extension 单独维护枚举。
 - 未知字段 fail-closed；不接受原任务 ID 代替 source video URL，除非实施前取得明确上游合同与测试证据。
 - 成功响应复用 `VideoGenerationResponseSchema`，必须有非空 `request_id`；其他上游字段原样保留。
 - 返回的新 `request_id` 写入现有 `video:{request_id}` registry，随后仍用 `GET /v1/videos/{request_id}` 轮询。
@@ -204,9 +209,9 @@ Content-Type: application/json
 
 在 `packages/shared/src/request/videos-schema.ts`：
 
-- 把 `VideoDurationSchema` 统一定义为 `6 | 10 | 15 | 30`，纯文本、单图、多图和 extension 全部复用；删除各 shape 上额外拼接 literal 的写法。
+- 把 `VideoDurationSchema` 统一定义为 `1–15 | 30`，纯文本、单图、参考图和 extension 全部复用；删除各 shape 上额外拼接 literal 的写法。
 - 单图 model schema 增加 `grok-imagine-video-1.5` 及对应 `xai/` alias；resolver 复用现有 1.5 capability/account pool，但 provider wire body 保留 stable/preview 名称。
-- 多参考图拆成两个严格、互斥的请求 shape：`reference_images` 或兼容 `images`；两者都保持 2–7 张、只接受 stable 1.5 model 并复用统一 duration schema。
+- 参考图拆成两个严格、互斥的请求 shape：`reference_images` 或兼容 `images`；两者都接受 1–7 张、只接受 stable 1.5 model，并可携带最多 3 个预设声音。
 - 新增并导出 `VideoExtensionRequestSchema` 与 `VideoExtensionRequest`。
 - 扩展响应复用现有 `VideoGenerationResponseSchema`，不重复定义同形 schema。
 
@@ -258,7 +263,7 @@ telemetry 的 policy reason/operation 应区分 `video_generation` 与 `video_ex
 ### P0.1：先锁定统一 duration 合同
 
 1. Shared 红测：
-   - 纯文本、单图、`reference_images` 多图、`images` 多图和 extension 均接受同一组 6/10/15/30；
+   - 纯文本、单图、`reference_images`、`images` 和 extension 均接受同一组 `1–15 | 30`；
    - preview/stable 及对应 `xai/` 单图 alias 均接受 `image + duration: 30`，并保留图片字段和值；
    - 多图分别接受 `reference_images + duration: 30` 和 `images + duration: 30`，拒绝两个字段同时出现、都不出现或误用 `image`；
    - 保留上述非法边界值拒绝测试。

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-20 · Grok 视频输入对齐 xAI 官方 reference-to-video 合同（Videos，Imagine spec §4 / Phase 1 §2–5，原则 2/3/6/7）
+
+- **官方合同与最小修复**：2026-08-20 复核 xAI Videos 文档与 Sub2API `49504adc` 后，确认 stable `grok-imagine-video-1.5` 接受 1–7 张 `reference_images`、七种画幅，以及最多 3 个预设 `{ voice_id }` `reference_audios`；image-to-video 接受可选画幅并支持 1080p。共享严格 schema 在同一边界扩展这些字段，`images` 兼容输入仍只在付费 POST 前规范成 `reference_images`。
+- **兼容、实测与限制**：generation/extension 时长扩大为官方 `1–15` 秒整数，同时保留已公开的 `30` 兼容值；reference-to-video 仍限 480p/720p。当前只开放普遍可用的预设 voice ID，不开放需 partner 权限且会引入大正文处理的自定义音频 URL；既有 prompt-only `audio` 仅作为历史兼容，不把它宣称为官方 REST 字段。付费单写、账号 entitlement、receipt 绑定和 `outcome_unknown` 边界不变。本机 SuperGrok OAuth 单写 canary 已验证 1 张参考图 + `eve`、16:9/9:16、720p、8 秒和 AAC 音轨；1080p、其他时长与其他画幅未做付费穷举。
+
 ## 2026-08-20 · 配额周期历史新增已用百分比（OAuth providers，原则 3/7）
 
 - 重置边界记录新增可空 `usedPercent`，仅在以后观测到周期关闭时从上游快照写入；旧行不回填，无法证明的近似/日周聚合继续显示空值。
@@ -61,20 +66,10 @@
 - **根因与修复**：SQLite `request_payloads` 的单列 gzip 读取沿用了 Session 单块 256 KiB 解压上限，超过该值的真实正文被映射为 `null`，Admin 随后错误回退到 Session 恢复。Admin 现在优先请求存储态正文；SQLite 原样返回 gzip BLOB，Postgres 返回 raw TEXT，由浏览器通过 HTTP `Content-Encoding` 流式解压并拼装，不再在网关内物化放大的正文。
 - **完整性边界**：存储层为去重而外置的图片继续按 `sha256` 通过受 Admin 鉴权保护的只读端点逐个恢复；缺失 blob 保持既有 fail-open sentinel 语义。旧 JSON 响应契约和自定义 Store 适配器仍可回退使用，无 migration、无依赖、无写入格式变化。
 
-## 2026-08-13 · OAuth 永久失效只认明确凭证拒绝（OAuth provider pool / Admin providers，docs/04/11，原则 3/7）
-
-- **根因与修复**：旧逻辑仅按 HTTP 状态把 refresh `400/401/403` 与 inference `401/403` 全部持久化为 `needs reconnect`；代理、地域或 WAF 返回的裸 `403` 因此会永久摘除仍有有效 refresh token 的账号。现在 provider token 边界只把有界解析出的标准 `invalid_grant`、Copilot token mint `401` 与 Codex refresh 身份变化标为永久凭证拒绝；裸 refresh `403` 只短暂冷却，inference `403` 走正常错误/fallback，不写 `credentialFailedAt`。错误正文仍不进入消息、日志或存储。
-- **兼容与恢复**：真正永久失效仍 fail-closed 停止调度，成功 reconnect 继续清除标记；不批量清除升级前的历史失败标记，因为无法证明它们都是误判，受影响账号需在修复代理后按原标签重连。无 schema/migration、新依赖或 UI 契约变化。
-
-## 2026-08-13 · Grok 4.6 补齐 Agent 能力、价格与 lane 投影（Catalog / routing，docs/04/07，原则 2/3/6）
-
-- **根因**：xAI OAuth 实时 catalog 已把 `grok-4.6` 合成为可执行 alias，但签入的手工 catalog 没有对应条目；执行层对只有实时元数据的新 xAI 模型保守合成 `supportsTools:false`，所以裸 chat 可过，Grok Build 默认携带 `tools` 时在 provider 调用前被能力过滤为 `capability_unsatisfiable`。`/v1/models` 同样只能列出 id，无法附带 capabilities/pricing/lane membership。
-- **修复边界**：为已实际出现的 `xai/grok-4.6` 增加手工能力条目，开放已验证的 tools/SSE/常用 reasoning effort，保持 subscription vision、JSON 与额外媒体能力 fail-closed；没有把任意未来 xAI alias 自动推断为支持 tools。同步线上已验证的稳定 `grok` lane（当前 `primary: xai/grok-4.6`），`economy`、`balanced`、`premium`、`vision` 统一引用它；以后升级 Grok 只需改一处，能力不满足的请求仍由既有过滤器跳过。
-- **价格口径**：SuperGrok 仍是包月订阅；预算与遥测沿用“官方 API 等价估价”。2026-08-13 xAI 官方价卡为短上下文 input/cache/output `$2/$0.5/$6`，prompt 达到 200K 后 `$4/$1/$12`，priority 为对应档位 2 倍；配置显式保存 context + priority 两层，避免长上下文预算低估。
-- **限制**：官方公开模型支持 vision/structured outputs/xhigh，但本次现场只证明 Helm/Grok Build 的 chat + tools；subscription proxy 上未做真实 vision/JSON/xhigh canary，因此这些能力没有借用 public API 声明自动放开。生产修复仍需按部署流程发布，并从 `/version`、`/v1/models` 和一条带 tools 的真实请求三处回读。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-13 · OAuth 永久失效只认明确凭证拒绝**：仅标准 `invalid_grant`、Copilot mint 401 与 Codex refresh 身份变化永久摘除账号，裸 refresh 403 只短暂冷却；完整原文经 git history 回溯。
+- **2026-08-13 · Grok 4.6 补齐 Agent 能力、价格与 lane 投影**：手工 catalog 补齐已验证的 tools/SSE/常用 reasoning 与 API 等价估价，subscription vision/JSON/xhigh 继续 fail-closed；完整原文经 git history 回溯。
 - **2026-08-13 · 使用率下降观测不得冒充精确重置**：deadline 未变化时的使用率下降只形成 `approximate=true` 事实，精确 header/reset-credit 继续优先；完整原文经 git history 回溯。
 - **2026-08-13 · 历史配额周期使用公开公告补齐近似边界**：公开公告只能形成 `approximate=true` 的历史 reset facts，精确 header/reset-credit 继续优先且实时 bucket 不受影响；完整原文经 git history 回溯。
 - **2026-08-11 · Admin Memory 范围分页与 Key 点查**：scopes 使用稳定服务端分页，首屏只加载轻量数据，Key 深链走不可变 id 索引点查；完整原文经 git history 回溯。

--- a/packages/shared/src/request/videos-schema.test.ts
+++ b/packages/shared/src/request/videos-schema.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./videos-schema.js";
 
 describe("VideoGenerationRequestSchema", () => {
-  it.each([6, 10, 15, 30])("accepts duration %s across every generation shape", (duration) => {
+  it.each([1, 8, 15, 30])("accepts duration %s across every generation shape", (duration) => {
     const bodies = [
       { model: "grok-imagine-video", prompt: "waves", duration },
       {
@@ -67,7 +67,7 @@ describe("VideoGenerationRequestSchema", () => {
     ).toBe(true);
   });
 
-  it("accepts the single-image Grok video contract, including an empty prompt", () => {
+  it("accepts the official single-image options, including an empty prompt", () => {
     for (const model of [
       "grok-imagine-video-1.5-preview",
       "xai/grok-imagine-video-1.5-preview",
@@ -79,24 +79,23 @@ describe("VideoGenerationRequestSchema", () => {
           model,
           prompt: "",
           image: { url: "data:image/png;base64,AAA=" },
-          duration: 30,
-          resolution: "480p",
+          aspect_ratio: "4:3",
+          duration: 12,
+          resolution: "1080p",
         }).success,
       ).toBe(true);
     }
   });
 
-  it("accepts 2-7 reference images for the multi-image contract", () => {
+  it("accepts one reference image with aspect ratio and a preset voice", () => {
     expect(
       VideoGenerationRequestSchema.safeParse({
         model: "grok-imagine-video-1.5",
-        prompt: "move from <IMAGE_0> toward <IMAGE_1>",
-        reference_images: [
-          { url: "https://example.test/one.png" },
-          { url: "https://example.test/two.png" },
-        ],
-        aspect_ratio: "16:9",
-        duration: 10,
+        prompt: "have <IMAGE_0> speak with <AUDIO_0>",
+        reference_images: [{ url: "https://example.test/one.png" }],
+        reference_audios: [{ voice_id: "eve" }],
+        aspect_ratio: "3:4",
+        duration: 8,
         resolution: "720p",
       }).success,
     ).toBe(true);
@@ -113,9 +112,20 @@ describe("VideoGenerationRequestSchema", () => {
     ).toBe(false);
     expect(
       VideoGenerationRequestSchema.safeParse({
+        model: "grok-imagine-video-1.5",
+        prompt: "too many voices",
+        reference_images: [{ url: "https://example.test/one.png" }],
+        reference_audios: ["ara", "eve", "leo", "rex"].map((voice_id) => ({ voice_id })),
+        aspect_ratio: "16:9",
+        duration: 6,
+        resolution: "480p",
+      }).success,
+    ).toBe(false);
+    expect(
+      VideoGenerationRequestSchema.safeParse({
         model: "grok-imagine-video",
         prompt: "unsupported duration",
-        duration: 29,
+        duration: 16,
         resolution: "720p",
       }).success,
     ).toBe(false);
@@ -143,10 +153,11 @@ describe("VideoGenerationRequestSchema", () => {
     ).toBe(false);
     expect(
       VideoGenerationRequestSchema.safeParse({
-        model: "grok-imagine-video-1.5-preview",
-        prompt: "",
-        image: { url: "https://example.test/image.png" },
-        duration: 5,
+        model: "grok-imagine-video-1.5",
+        prompt: "x",
+        reference_images: [],
+        aspect_ratio: "16:9",
+        duration: 6,
         resolution: "480p",
       }).success,
     ).toBe(false);
@@ -155,6 +166,7 @@ describe("VideoGenerationRequestSchema", () => {
         model: "grok-imagine-video-1.5",
         prompt: "x",
         reference_images: [{ url: "https://example.test/one.png" }],
+        reference_audios: [{ voice_id: "" }],
         aspect_ratio: "16:9",
         duration: 6,
         resolution: "480p",

--- a/packages/shared/src/request/videos-schema.ts
+++ b/packages/shared/src/request/videos-schema.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
-// Grok's async video surface deliberately has two strict request shapes. Keeping
+// Grok's async video surface deliberately has distinct strict request shapes. Keeping
 // this schema closed prevents unsupported paid options (notably ZDR `output`) from
 // being silently forwarded before Helm has an end-to-end redaction contract for it.
 const VideoSourceSchema = z.strictObject({ url: z.string().min(1) });
-const VideoDurationSchema = z.union([z.literal(6), z.literal(10), z.literal(15), z.literal(30)]);
+const VideoDurationSchema = z.union([z.number().int().min(1).max(15), z.literal(30)]);
 const VideoResolutionSchema = z.enum(["480p", "720p"]);
-const VideoAspectRatioSchema = z.enum(["1:1", "16:9", "9:16", "3:2", "2:3"]);
+const VideoFullResolutionSchema = z.enum(["480p", "720p", "1080p"]);
+const VideoAspectRatioSchema = z.enum(["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]);
+const PresetVoiceReferenceSchema = z.strictObject({ voice_id: z.string().trim().min(1) });
 const PromptVideoModelSchema = z.enum(["grok-imagine-video", "xai/grok-imagine-video"]);
 const SingleImageVideoModelSchema = z.enum([
   "grok-imagine-video-1.5-preview",
@@ -27,7 +29,7 @@ const PromptOnlyVideoRequestSchema = z.strictObject({
   prompt: z.string().min(1),
   aspect_ratio: VideoAspectRatioSchema.optional(),
   duration: VideoDurationSchema.optional(),
-  resolution: z.union([VideoResolutionSchema, z.literal("1080p")]).optional(),
+  resolution: VideoFullResolutionSchema.optional(),
   audio: z.boolean().optional(),
 });
 
@@ -36,8 +38,9 @@ const SingleImageVideoRequestSchema = z.strictObject({
   // xAI permits an empty motion prompt for the single-image workflow.
   prompt: z.string(),
   image: VideoSourceSchema,
+  aspect_ratio: VideoAspectRatioSchema.optional(),
   duration: VideoDurationSchema,
-  resolution: VideoResolutionSchema,
+  resolution: VideoFullResolutionSchema,
 });
 
 const ReferenceImageVideoRequestBase = {
@@ -48,16 +51,17 @@ const ReferenceImageVideoRequestBase = {
   aspect_ratio: VideoAspectRatioSchema,
   duration: VideoDurationSchema,
   resolution: VideoResolutionSchema,
+  reference_audios: z.array(PresetVoiceReferenceSchema).min(1).max(3).optional(),
 };
 
 const ReferenceImageVideoRequestSchema = z.union([
   z.strictObject({
     ...ReferenceImageVideoRequestBase,
-    reference_images: z.array(VideoSourceSchema).min(2).max(7),
+    reference_images: z.array(VideoSourceSchema).min(1).max(7),
   }),
   z.strictObject({
     ...ReferenceImageVideoRequestBase,
-    images: z.array(VideoSourceSchema).min(2).max(7),
+    images: z.array(VideoSourceSchema).min(1).max(7),
   }),
 ]);
 


### PR DESCRIPTION
## What changed

- align the strict Grok video request schema with xAI's documented video contract
- accept 1–15 second integer durations while retaining the existing 30-second compatibility value
- accept all seven documented aspect ratios and 1080p for single-image video
- accept 1–7 reference images and up to three preset `reference_audios` entries
- keep the existing `images` to `reference_images` normalization at the paid-write boundary
- update OpenAPI coverage, gateway/shared tests, e2e coverage, README, specs, and implementation notes

## Why

Helm's earlier request schema was narrower than the current xAI contract: it required at least two reference images, omitted `4:3`/`3:4`, did not expose preset voice references, and rejected documented single-image options. That caused valid requests supported by Grok.com and xAI's public video API to fail locally before reaching the provider.

## Safety and compatibility

- paid video creation remains a single write with no retry or account switching after an ambiguous outcome
- OAuth entitlement, receipt ownership, provider/account pinning, and read-only polling are unchanged
- `audio: boolean` remains only for the existing prompt-only compatibility shape; it is not presented as an official REST field
- custom audio URLs remain closed
- 30 seconds remains a compatibility value and is not claimed as universally entitled

## Evidence

Official xAI documentation:

- https://docs.x.ai/developers/model-capabilities/video/reference-to-video
- https://docs.x.ai/developers/model-capabilities/video/image-to-video
- https://docs.x.ai/developers/model-capabilities/video/generation
- https://docs.x.ai/developers/rest-api-reference/inference/videos

A local Docker canary through the connected SuperGrok OAuth account verified one reference image plus the `eve` preset voice at 8 seconds, 720p, with both 16:9 and 9:16 outputs. Both completed with H.264 video and AAC audio. Other documented combinations remain covered offline rather than by paid exhaustive testing.

## Validation

- `CI=true pnpm exec vitest run packages/shared/src/request/videos-schema.test.ts apps/gateway/src/routes/videos.test.ts apps/gateway/src/routes/openapi.test.ts` — 52 passed
- `CI=true pnpm --filter @helm/gateway exec playwright test e2e/videos.spec.ts` — 3 passed
- `CI=true pnpm typecheck` — passed
- local Docker image health/version readback — healthy (`0.28.78-local`, working tree candidate)
