### PR TITLE
Release v0.28.80

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.79",
+  "version": "0.28.80",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release

Patch release `0.28.80` for the Responses WebSocket upstream-error propagation fix merged in #774.

This PR changes only the root package version. After merge and complete main CI, the publish workflow will build the exact release SHA, publish its immutable image, promote `0.28.80`, and create the matching GitHub Release.
