### PR TITLE
[codex] recover Responses account affinity

### DIFF
--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1533,6 +1533,63 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
   });
 
+  it("persists a recovered previous_response_id account", async () => {
+    const put = vi.fn();
+    const registryRecord = {
+      responseId: "resp_previous",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "openai-codex/gpt-5.6-sol",
+      providerName: "openai-codex",
+      providerModel: "gpt-5.6-sol",
+      providerProtocol: "openai_responses" as const,
+      providerAccount: "oauth-a",
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      status: "completed",
+    };
+    const decision = {
+      final: {
+        status: "ok",
+        model_alias: "openai-codex/gpt-5.6-sol",
+        provider_model: "gpt-5.6-sol",
+      },
+      provider_attempts: [
+        {
+          alias: "openai-codex/gpt-5.6-sol",
+          status: "ok",
+          skipped: false,
+          provider_name: "openai-codex",
+          provider_model: "gpt-5.6-sol",
+          target_provider_protocol: "openai_responses",
+        },
+      ],
+    } as never;
+    const { deps } = makeDeps({
+      run: async () => ({
+        decision,
+        servingAccount: { providerId: "openai-codex", account: "oauth-b" },
+        nativePassthrough: true,
+        collect: async () => ({ id: "resp_next", object: "response", status: "completed" }),
+        streamIR: async function* () {},
+      }),
+      registry: { put, get: vi.fn().mockResolvedValue(registryRecord) },
+    });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, previous_response_id: "resp_previous" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(put).toHaveBeenCalledWith({ ...registryRecord, providerAccount: "oauth-b" });
+    expect(put).toHaveBeenCalledWith(
+      expect.objectContaining({ responseId: "resp_next", providerAccount: "oauth-b" }),
+    );
+  });
+
   it("serves a native WebSocket-style continuation whose incremental input is empty", async () => {
     const routeHarness: { routed: Parameters<RouteFn>[0] | null } = { routed: null };
     const route: RouteFn = async (request) => {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -1204,6 +1204,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       nativeRec.previous_response_id.length > 0
         ? nativeRec.previous_response_id
         : null;
+    let previousRegistryRecord: ResponsesRegistryRecord | null = null;
     if (previousResponseId !== null) {
       const previous =
         deps.registry === undefined ? null : await deps.registry.get(previousResponseId, identity);
@@ -1214,6 +1215,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
           traceId,
         );
       }
+      previousRegistryRecord = previous;
       ir.metadata = {
         ...ir.metadata,
         stateful_provider_alias: previous.providerAlias,
@@ -1244,6 +1246,32 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     const captureBodies = captureRecord !== undefined && captureEnabled(captureRecord);
     const captureSessionResponse =
       captureRecord !== undefined && sessionCaptureEnabled(captureRecord);
+    const persistRecoveredPreviousAccount = async (result: PipelineRunResult): Promise<void> => {
+      const servingAccount = result.servingAccount ?? null;
+      if (
+        previousRegistryRecord === null ||
+        servingAccount === null ||
+        successfulAttempt(result.decision) === null ||
+        !servedByAccount(servingAccount, previousRegistryRecord.providerAlias) ||
+        previousRegistryRecord.providerAccount === servingAccount.account
+      ) {
+        return;
+      }
+      try {
+        await deps.registry?.put({
+          ...previousRegistryRecord,
+          providerAccount: servingAccount.account,
+        });
+        previousRegistryRecord = {
+          ...previousRegistryRecord,
+          providerAccount: servingAccount.account,
+        };
+      } catch {
+        c.get("logger").log("warn", "responses.registry_affinity_repair_failed", {
+          trace_id: traceId,
+        });
+      }
+    };
 
     // 4) Outbound: stream vs non-stream, isomorphic shape.
     if (ir.stream === true) {
@@ -1261,6 +1289,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
       try {
         initialResult = await deps.pipeline.run(ir, identity, streamAbort.signal);
         stampSessionCapture(initialResult.decision, sessionCapture, sessionCaptureScope);
+        await persistRecoveredPreviousAccount(initialResult);
         applyResponseMetadata(
           c,
           initialResult.responseMetadata,
@@ -1516,6 +1545,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
         result.nativePassthrough === true
           ? (collected as Record<string, unknown>)
           : (deps.transformer.transformResponseOut(collected) as Record<string, unknown>);
+      await persistRecoveredPreviousAccount(result);
     } catch (err) {
       // Record the FAILED served request before surfacing the error (mirrors
       // chat.ts, which records failures too) so an all-providers-failed request

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-24 · Codex Responses 续接 ID 可在账号池内有界找回原账号（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
+
+- **恢复边界**：同一账号、同一 WebSocket 的一次原样重试仍优先；只有它再次返回精确的 `400 Invalid previous_response_id` 且尚未产生客户端可见输出时，OAuth pool 才逐个尝试其余同 provider、同 model 的可调度账号。其他 4xx、限流、凭证、超时、断连与已开始输出的错误继续保持原有 fail-closed 语义，搜索次数天然受账号数限制。
+- **亲和修复**：找到能继续该 ID 的账号后，同时更新进程内 sticky 映射与 durable Responses registry 中旧 ID 的 `provider_account`；后续续接优先回到这个实际拥有状态的原账号。全部账号都报告不存在时仍返回最后一个上游错误，不删除 ID、不伪造历史，也不跨 provider/协议。
+
 ## 2026-08-20 · Grok 视频输入对齐 xAI 官方 reference-to-video 合同（Videos，Imagine spec §4 / Phase 1 §2–5，原则 2/3/6/7）
 
 - **官方合同与最小修复**：2026-08-20 复核 xAI Videos 文档与 Sub2API `49504adc` 后，确认 stable `grok-imagine-video-1.5` 接受 1–7 张 `reference_images`、七种画幅，以及最多 3 个预设 `{ voice_id }` `reference_audios`；image-to-video 接受可选画幅并支持 1080p。共享严格 schema 在同一边界扩展这些字段，`images` 兼容输入仍只在付费 POST 前规范成 `reference_images`。
@@ -61,13 +66,9 @@
 - **根因与修复**：Admin 只按 `request_payloads` / `session_revisions` 是否存在推断历史请求的正文模式，无法证明请求发生时 Key 与系统设置的实际合并结果；大型 Session 的元数据也只证明服务端整体恢复超限，却仍无条件展示浏览器加载按钮，即使某条 revision 会被同一分页接口的 JSON 内存上限拒绝。每条新 telemetry 现在保存 body-free 的有效 `request_content_mode`；明确 `none` 时任何孤立正文行都不可读取、也不显示加载入口，旧记录继续按存储事实兼容推断。
 - **加载边界**：SQLite/Postgres 在既有 Session 元数据聚合中同时返回目标链最大单 revision 字节数；Admin 用分页端点相同的 JSON amplification 与 8 MiB 上限决定 `browser_recoverable`，不可安全分页时不再提供必然失败的按钮。该元数据不读取正文、不改变正文格式、无需 migration；当前设置仍不追溯删除历史内容。
 
-## 2026-08-15 · 大型完整载荷改由浏览器解压与恢复图片（Store / Admin requests，docs/07/11，原则 1/3/7）
-
-- **根因与修复**：SQLite `request_payloads` 的单列 gzip 读取沿用了 Session 单块 256 KiB 解压上限，超过该值的真实正文被映射为 `null`，Admin 随后错误回退到 Session 恢复。Admin 现在优先请求存储态正文；SQLite 原样返回 gzip BLOB，Postgres 返回 raw TEXT，由浏览器通过 HTTP `Content-Encoding` 流式解压并拼装，不再在网关内物化放大的正文。
-- **完整性边界**：存储层为去重而外置的图片继续按 `sha256` 通过受 Admin 鉴权保护的只读端点逐个恢复；缺失 blob 保持既有 fail-open sentinel 语义。旧 JSON 响应契约和自定义 Store 适配器仍可回退使用，无 migration、无依赖、无写入格式变化。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-15 · 大型完整载荷改由浏览器解压与恢复图片**：Admin 优先读取 gzip/raw 存储态正文并由浏览器解压，外置图片按 `sha256` 经鉴权端点恢复，避免网关内存化放大；完整原文经 git history 回溯。
 - **2026-08-13 · OAuth 永久失效只认明确凭证拒绝**：仅标准 `invalid_grant`、Copilot mint 401 与 Codex refresh 身份变化永久摘除账号，裸 refresh 403 只短暂冷却；完整原文经 git history 回溯。
 - **2026-08-13 · Grok 4.6 补齐 Agent 能力、价格与 lane 投影**：手工 catalog 补齐已验证的 tools/SSE/常用 reasoning 与 API 等价估价，subscription vision/JSON/xhigh 继续 fail-closed；完整原文经 git history 回溯。
 - **2026-08-13 · 使用率下降观测不得冒充精确重置**：deadline 未变化时的使用率下降只形成 `approximate=true` 事实，精确 header/reset-credit 继续优先；完整原文经 git history 回溯。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -720,7 +720,7 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(calls).toEqual(["a"]);
   });
 
-  it("never retries a known previous_response_id on a sibling account", async () => {
+  it("never retries a known previous_response_id on a sibling after a transient fault", async () => {
     const calls: string[] = [];
     const pool = createOAuthPoolClient({
       members: [
@@ -1558,6 +1558,62 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     }
 
     expect(calls).toEqual(["a", "a"]);
+  });
+
+  it("recovers an invalid previous_response_id on a sibling and remembers its account", async () => {
+    const calls: string[] = [];
+    const invalidPreviousResponseId = new UpstreamError(
+      "upstream_error",
+      "Invalid `previous_response_id`.",
+      { error: { type: "invalid_request_error" } },
+      400,
+    );
+    const responseMember = (account: string): OAuthPoolMember => ({
+      account,
+      priority: 50,
+      schedulable: true,
+      client: {
+        async chatCompletion() {
+          return { served_by: account };
+        },
+        async *chatCompletionStream() {
+          yield `data: ${account}\n\n`;
+        },
+        async *nativePassthroughStream() {
+          calls.push(account);
+          if (account === "a") throw invalidPreviousResponseId;
+          yield `event: response.created\ndata: {"type":"response.created","response":{"id":"resp-next"}}\n\n`;
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [responseMember("a"), responseMember("b")],
+      now: () => 1_000,
+    });
+    const drain = async (statefulAccount?: string): Promise<void> => {
+      const stream = pool.nativePassthroughStream?.(
+        {
+          protocol: "openai_responses",
+          body: {
+            model: "gpt-5.6-sol",
+            stream: true,
+            input: "continue",
+            previous_response_id: "resp-original",
+          },
+          headers: {},
+          mutations: {},
+        },
+        statefulAccount ? { statefulAccount } : undefined,
+      );
+      for await (const _chunk of stream ?? []) {
+        // Drain until the account search completes.
+      }
+    };
+
+    await drain("a");
+    await drain();
+
+    expect(calls).toEqual(["a", "b", "b"]);
   });
 
   it("prioritizes previous_response_id affinity over websocket session affinity", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -47,7 +47,10 @@ const RETRYABLE_ACCOUNT_FAILURE_COOLDOWN_MS = 30_000;
 // retry only TRANSIENT, account-agnostic server faults (a 5xx / overload / connect
 // timeout on one account says nothing about its siblings) and DELIBERATELY exclude
 // deterministic request-shape 4xx (400/413/422) — a sibling would hit those
-// identically, so surface them immediately for executor classification. Account-local
+// identically, so surface them immediately for executor classification. The one bounded
+// exception is an exact invalid previous_response_id: the id is account-local, so the
+// pool probes each sibling until it finds and remembers the account that owns it.
+// Account-local
 // OAuth credential/rate-limit statuses are handled by the dedicated helpers below,
 // because those statuses can say something about the selected subscription account,
 // not about the model alias. Credential statuses remain provider-configurable for
@@ -371,6 +374,20 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return value !== null && typeof value === "object" && !Array.isArray(value)
       ? (value as Record<string, unknown>)
       : null;
+  }
+
+  function isInvalidPreviousResponseIdFailure(stickyKey: string | null, err: unknown): boolean {
+    if (
+      !stickyKey?.startsWith("previous_response_id:") ||
+      !(err instanceof UpstreamError) ||
+      err.upstreamStatus !== 400 ||
+      err.message !== "Invalid `previous_response_id`."
+    ) {
+      return false;
+    }
+    const raw = objectRecord(err.providerRaw);
+    const nested = objectRecord(raw?.error);
+    return nested?.type === "invalid_request_error";
   }
 
   function deviceIdFromMetadataUserId(userId: string): string | null {
@@ -879,7 +896,11 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   function select(
     stickyKey?: string | null,
     exclude?: ReadonlySet<string>,
-    opts: { avoidBusy?: boolean; model?: string | null } = {},
+    opts: {
+      avoidBusy?: boolean;
+      model?: string | null;
+      recoverStrictSticky?: boolean;
+    } = {},
   ): PoolEntry {
     const nowMs = now();
     const model = opts.model ?? null;
@@ -922,7 +943,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         reason: "sticky_hit",
       });
     }
-    if (stickyOnly && knownSticky) {
+    if (stickyOnly && knownSticky && opts.recoverStrictSticky !== true) {
       const source = affinityKeySource(stickyKey ?? null) ?? "stateful continuation";
       throw new Error(`oauth pool: ${source} original account is unavailable`);
     }
@@ -1040,20 +1061,33 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   ): Promise<R> {
     const tried = new Set<string>();
     const statefulContinuation = isStrictAccountSticky(stickyKey);
+    let recoveringPreviousResponseAccount = false;
     let lastErr: unknown;
     for (;;) {
       let entry: PoolEntry;
       try {
-        entry = select(stickyKey, tried, { avoidBusy, model });
+        entry = select(stickyKey, tried, {
+          avoidBusy,
+          model,
+          recoverStrictSticky: recoveringPreviousResponseAccount,
+        });
       } catch (selErr) {
         throw lastErr ?? selErr;
       }
       tried.add(entry.member.account);
       try {
         const result = await call(entry.member.client, entry);
+        if (stickyKey?.startsWith("previous_response_id:")) {
+          rememberSticky(stickyKey, entry.member.account, now() + stickyTtlMs);
+        }
         rememberResponseAffinity(result, entry);
         return result;
       } catch (err) {
+        if (isInvalidPreviousResponseIdFailure(stickyKey, err)) {
+          recoveringPreviousResponseAccount = true;
+          lastErr = err;
+          continue;
+        }
         if (isRetryableAccountFailure(err)) {
           coolRetryableAccount(entry);
           if (statefulContinuation) throw err;
@@ -1111,6 +1145,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   ): AsyncIterable<string> {
     const tried = new Set<string>([firstEntry.member.account]);
     const statefulContinuation = isStrictAccountSticky(stickyKey);
+    let recoveringPreviousResponseAccount = false;
     let entry = firstEntry;
     let lastErr: unknown;
     for (;;) {
@@ -1124,7 +1159,11 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         first = await iterator.next(); // pre-first-(real-)chunk fault surfaces HERE
       } catch (err) {
         if (iterator) await iterator.return?.().catch(() => {});
-        if (isRetryableAccountFailure(err)) {
+        const invalidPreviousResponseId = isInvalidPreviousResponseIdFailure(stickyKey, err);
+        if (invalidPreviousResponseId) {
+          recoveringPreviousResponseAccount = true;
+          lastErr = err;
+        } else if (isRetryableAccountFailure(err)) {
           coolRetryableAccount(entry);
           lastErr = err;
         } else if (isCredentialAccountFailure(err, upstreamCredentialFailureStatuses)) {
@@ -1139,10 +1178,14 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
           if (!isRetryableTransientError(err)) throw err;
           lastErr = err;
         }
-        if (statefulContinuation) throw lastErr;
+        if (statefulContinuation && !invalidPreviousResponseId) throw lastErr;
         let next: PoolEntry;
         try {
-          next = select(stickyKey, tried, { avoidBusy, model });
+          next = select(stickyKey, tried, {
+            avoidBusy,
+            model,
+            recoverStrictSticky: recoveringPreviousResponseAccount,
+          });
         } catch {
           throw lastErr; // no sibling left → surface the real upstream cause
         }
@@ -1151,6 +1194,9 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         continue;
       }
       // First chunk obtained (or a clean empty stream) → COMMIT to this account.
+      if (stickyKey?.startsWith("previous_response_id:")) {
+        rememberSticky(stickyKey, entry.member.account, now() + stickyTtlMs);
+      }
       const trackResponseAffinity = streamResponseAffinityTracker(entry);
       try {
         if (!first.done) {


### PR DESCRIPTION
## What changed

- retry sibling OAuth accounts only after the exact repeated `400 Invalid previous_response_id` response, before client-visible output
- keep the search bounded to eligible accounts for the same provider and model
- remember the account that owns the response ID and repair the durable Responses registry mapping
- retain fail-closed behavior for every other stateful continuation error

## Root cause

The provider already retried this exact error once on the same Codex WebSocket and account. If it repeated, the OAuth pool treated every `previous_response_id` as strictly pinned and refused to test siblings, so a missing or stale account mapping became terminal even when another connected account owned the response.

## Impact

A continuation can now recover its original subscription account instead of returning an immediate terminal error. It never crosses provider or protocol boundaries, never retries after visible output, and never loops beyond the available account count.

## Validation

- `CI=true pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts --maxWorkers=1` — 108 passed
- `CI=true pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts -t 'previous_response_id' --maxWorkers=1` — 10 passed
- `CI=true pnpm exec vitest run apps/gateway/src/routes/responses.test.ts -t 'previous_response_id' --maxWorkers=1` — 3 passed
- `CI=true pnpm exec vitest run packages/core/src/provider/openai-responses.test.ts -t 'invalid previous_response_id' --maxWorkers=1` — 2 passed
- `CI=true pnpm --filter @helm/core typecheck`
- `CI=true pnpm --filter @helm/gateway typecheck`
- Biome and `git diff --check`
