### PR TITLE
[codex] recover unavailable Responses account affinity

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -7129,6 +7129,16 @@ describe("isAccountScopedFault — classifier", () => {
     expect(isAccountScopedFault(new UpstreamError("upstream_error", "x", null, 401))).toBe(true);
     expect(isAccountScopedFault(new UpstreamError("upstream_error", "x", null, 403))).toBe(true);
     expect(isAccountScopedFault(new UpstreamError("upstream_error", "x", null, 429))).toBe(true);
+    expect(
+      isAccountScopedFault(
+        new Error("oauth pool: previous_response_id original account is unavailable"),
+      ),
+    ).toBe(true);
+    expect(
+      isAccountScopedFault(
+        new Error("oauth pool: x-codex-turn-state original account is unavailable"),
+      ),
+    ).toBe(true);
   });
 
   it("FALSE for server/transport + request-shape faults that belong on the breaker", () => {
@@ -7193,6 +7203,26 @@ describe("createExecute — onOAuthSubscription429 (auto-park)", () => {
     const execute = createExecute({
       defaultProvider: rejects(e429()),
       providers: new Map([["openai-codex", rejects(e429())]]),
+      knownOAuthPrefixes: new Set(["openai-codex"]),
+      oauthAliases: () => new Set(["openai-codex/gpt-5"]),
+      registry: registry({}),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+    const out = await execute(plan(["openai-codex/gpt-5"]), req());
+    expect(out.final.status).toBe("error");
+    expect(recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("does NOT record a breaker failure for unavailable strict account affinity", async () => {
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const unavailable = new Error("oauth pool: x-codex-turn-state original account is unavailable");
+    const execute = createExecute({
+      defaultProvider: rejects(unavailable),
+      providers: new Map([["openai-codex", rejects(unavailable)]]),
       knownOAuthPrefixes: new Set(["openai-codex"]),
       oauthAliases: () => new Set(["openai-codex/gpt-5"]),
       registry: registry({}),

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -885,6 +885,17 @@ export function upstreamStatusOf(err: unknown): number | null {
 // — they survive the pool's sibling retry only when the WHOLE pool is unhealthy, so they DO
 // belong on the breaker (back off + half-open probe), exactly like a configured provider.
 export function isAccountScopedFault(err: unknown): boolean {
+  // Pool affinity failures identify one unavailable subscription account. They are
+  // not evidence that the shared model alias is unhealthy; counting them here can
+  // open the alias breaker and strand otherwise healthy sibling accounts.
+  if (
+    err instanceof Error &&
+    /^oauth pool: (?:previous_response_id|x-codex-turn-state) original account is unavailable$/i.test(
+      err.message,
+    )
+  ) {
+    return true;
+  }
   if (err instanceof TokenRefreshError) {
     const s = err.httpStatus;
     return s === 400 || s === 401 || s === 403 || s === 429;

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-25 · 持久化 Responses 亲和失效时先探测 sibling 且隔离模型熔断（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
+
+- **根因与修复**：pool rebuild 后，`previous_response_id` 仍指向已 parked/limited 的原账号时，旧逻辑在访问上游前直接抛出 `original account is unavailable`，没有尝试其他账号；现在该类续接从初始选择即进入有界 sibling 探测，成功后继续沿用既有 sticky/registry 修复链。`x-codex-turn-state` 仍保持严格原账号绑定，避免把不可迁移的上游会话状态串到其他账号。
+- **熔断边界**：两种严格亲和的“原账号不可用”均按账号级故障处理，不再累积到共享 model breaker，防止少数失效 pin 把健康 sibling 一起变成 `circuit_open`；服务器/传输故障仍照常计入 breaker。无 schema、配置或依赖变化。
+
 ## 2026-08-24 · Codex Responses 续接 ID 可在账号池内有界找回原账号（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
 
 - **恢复边界**：同一账号、同一 WebSocket 的一次原样重试仍优先；只有它再次返回精确的 `400 Invalid previous_response_id` 且尚未产生客户端可见输出时，OAuth pool 才逐个尝试其余同 provider、同 model 的可调度账号。其他 4xx、限流、凭证、超时、断连与已开始输出的错误继续保持原有 fail-closed 语义，搜索次数天然受账号数限制。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -689,7 +689,7 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(calls).toEqual(["a", "a"]);
   });
 
-  it("fails a known previous_response_id when its original account is unavailable", async () => {
+  it("probes a sibling when a known previous_response_id original account is unavailable", async () => {
     const calls: string[] = [];
     const responseMember = (account: string): OAuthPoolMember => ({
       account,
@@ -716,8 +716,8 @@ describe("createOAuthPoolClient — account selection", () => {
 
     await expect(
       pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-a" }),
-    ).rejects.toThrow(/previous_response_id.*original account.*unavailable/i);
-    expect(calls).toEqual(["a"]);
+    ).resolves.toEqual({ id: "resp-b", served_by: "b" });
+    expect(calls).toEqual(["a", "b"]);
   });
 
   it("never retries a known previous_response_id on a sibling after a transient fault", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -1061,7 +1061,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   ): Promise<R> {
     const tried = new Set<string>();
     const statefulContinuation = isStrictAccountSticky(stickyKey);
-    let recoveringPreviousResponseAccount = false;
+    // A persisted previous_response_id pin can point at an account that is now
+    // parked/limited after a pool rebuild. Probe siblings immediately; waiting for
+    // an upstream 400 would otherwise fail before any account search occurs.
+    let recoveringPreviousResponseAccount = stickyKey?.startsWith("previous_response_id:") === true;
     let lastErr: unknown;
     for (;;) {
       let entry: PoolEntry;
@@ -1328,7 +1331,11 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       const avoidBusy = isUserMessageRequest(nativePassthroughBody(body));
       // Pick + fail-closed check SYNCHRONOUSLY on the call turn (rotation + onSelect, and a
       // synchronous throw if the picked member can't passthrough-stream), exactly as before.
-      const first = select(stickyKey, undefined, { avoidBusy, model: modelFromNative(body) });
+      const first = select(stickyKey, undefined, {
+        avoidBusy,
+        model: modelFromNative(body),
+        recoverStrictSticky: stickyKey?.startsWith("previous_response_id:") === true,
+      });
       if (!first.member.client.nativePassthroughStream) {
         throw new Error("oauth pool member does not support native passthrough streaming");
       }


### PR DESCRIPTION
## What changed

- Recover `previous_response_id` from sibling OAuth accounts when the persisted original account is no longer eligible.
- Keep `x-codex-turn-state` strict, but classify unavailable-account affinity errors as account-scoped so they cannot open the shared model breaker.
- Add focused pool and executor regression tests.

## Root cause

After an OAuth pool rebuild, a durable Responses account pin could point at a parked, limited, or otherwise ineligible account. The pool threw before probing siblings. The executor then counted that account-local error against the model-level circuit breaker, causing healthy accounts to be skipped as `circuit_open`.

## Validation

- `CI=true pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts apps/gateway/src/routes/execute.test.ts --config vitest.config.ts`
- 283 tests passed.
- `pnpm exec biome check` on changed files.
- `CI=true pnpm typecheck` (shared, core, gateway, ops).
