### PR TITLE
Release v0.28.82

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.81",
+  "version": "0.28.82",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- release Helm API v0.28.82
- includes unavailable Responses account affinity recovery from PR #781

## Scope
- version-only change: `package.json`

## Validation
- JSON version readback: `0.28.82`
- `git diff --check`
- exact head: `5fa27271eb5d85eb48c3f37201b77c743fb2e663`