### PR TITLE
[codex] Stabilize PostgreSQL child replica E2E startup

### DIFF
--- a/apps/gateway/e2e/concurrency-postgres.spec.ts
+++ b/apps/gateway/e2e/concurrency-postgres.spec.ts
@@ -285,7 +285,7 @@ async function spawnLeaseHolderChild(
     let stderr = "";
     const timer = setTimeout(
       () => reject(new Error(`child replica readiness timeout: ${stderr}`)),
-      5_000,
+      15_000,
     );
     child.stdout.on("data", (chunk) => {
       stdout += String(chunk);
@@ -875,7 +875,7 @@ test.describe("real PostgreSQL distributed concurrency leases", () => {
   });
 
   test("recovers capacity after a child replica holding the lease is SIGKILLed", async () => {
-    test.setTimeout(10_000);
+    test.setTimeout(20_000);
     const ttlMs = 250;
     const state = providerState();
     const replicaB = await createReplica({


### PR DESCRIPTION
## Summary
- increase child replica readiness allowance from 5s to 15s
- align the SIGKILL recovery test timeout with the slower startup allowance

## Evidence
- release SHA `887e7681` failed only this existing test twice: 95/96 passed, child replica readiness timeout
- no production/runtime code changed
- exact head: `df7c441d0daad84fece0619d1407a4f07c89e397`