### PR TITLE
Release v0.28.83

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.82",
+  "version": "0.28.83",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- release Helm API v0.28.83
- includes Responses account affinity recovery and PostgreSQL E2E startup stability

## Scope
- version-only change: `package.json`

## Validation
- version readback: `0.28.83`
- `git diff --check`
- exact head: `baa588b334a141484f9529e6f9d14bb51927ac4a`