### PR TITLE
[codex] Fix Responses continuation affinity stalls

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -7139,6 +7139,11 @@ describe("isAccountScopedFault — classifier", () => {
         new Error("oauth pool: x-codex-turn-state original account is unavailable"),
       ),
     ).toBe(true);
+    expect(
+      isAccountScopedFault(
+        new Error("oauth pool: responses_websocket_session original account is unavailable"),
+      ),
+    ).toBe(true);
   });
 
   it("FALSE for server/transport + request-shape faults that belong on the breaker", () => {
@@ -7216,10 +7221,13 @@ describe("createExecute — onOAuthSubscription429 (auto-park)", () => {
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
-  it("does NOT record a breaker failure for unavailable strict account affinity", async () => {
+  it.each([
+    "x-codex-turn-state",
+    "responses_websocket_session",
+  ])("does NOT record a breaker failure for unavailable %s affinity", async (affinity) => {
     const cb = breaker();
     const recordFailure = vi.spyOn(cb, "recordFailure");
-    const unavailable = new Error("oauth pool: x-codex-turn-state original account is unavailable");
+    const unavailable = new Error(`oauth pool: ${affinity} original account is unavailable`);
     const execute = createExecute({
       defaultProvider: rejects(unavailable),
       providers: new Map([["openai-codex", rejects(unavailable)]]),

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -890,7 +890,7 @@ export function isAccountScopedFault(err: unknown): boolean {
   // open the alias breaker and strand otherwise healthy sibling accounts.
   if (
     err instanceof Error &&
-    /^oauth pool: (?:previous_response_id|x-codex-turn-state) original account is unavailable$/i.test(
+    /^oauth pool: (?:previous_response_id|x-codex-turn-state|responses_websocket_session) original account is unavailable$/i.test(
       err.message,
     )
   ) {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-25 · Responses 续接只在原账号不可用时搜索 sibling（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
+
+- **生产根因**：`v0.28.83` 会在原账号已明确返回 `Invalid previous_response_id` 后继续遍历其余账号；每个账号内部又会原样重试一次，六个失败请求因此在返回 SSE error 前静默约 24–26 秒。现在已知原账号实际接到请求后若仍返回精确 invalid-ID，立即 fail-closed；只有持久化原账号已不可调度或 ID 尚无归属时，才保留同 provider/model 的 sibling 搜索。
+- **亲和优先级**：同一请求同时携带 `x-codex-turn-state` 与 `previous_response_id` 时，以不可迁移的 turn state 为最高优先级；Responses WebSocket session 首次成功后也固定到其账号，即使账号繁忙也不把同一上游 socket 状态切到 sibling。translated streaming 补齐原账号不可用时的 previous-ID 恢复入口。无 schema、配置、迁移或依赖变化。
+
 ## 2026-08-25 · 持久化 Responses 亲和失效时先探测 sibling 且隔离模型熔断（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
 
 - **根因与修复**：pool rebuild 后，`previous_response_id` 仍指向已 parked/limited 的原账号时，旧逻辑在访问上游前直接抛出 `original account is unavailable`，没有尝试其他账号；现在该类续接从初始选择即进入有界 sibling 探测，成功后继续沿用既有 sticky/registry 修复链。`x-codex-turn-state` 仍保持严格原账号绑定，避免把不可迁移的上游会话状态串到其他账号。
@@ -61,18 +66,10 @@
 - **交付边界**：正式 PR #761 已创建；实现提交 `29ff7655` 的托管 GitHub Actions run `32142663949` 已回读 `verify`、`store`、`e2e`、`docker` 与四个稳定 required checks 全部成功。本轮不合并或部署；P1 细粒度媒体选项、低 cap key 前置条件与“关闭新能力但保留已接受视频 poll”的回滚门禁仍未完成，因此整体发布 Go 门禁仍是 No-Go。
 - **剩余限制**：当前只有账号级媒体开关；默认 fast 图片已经真实验证，但仍没有可靠的上游细粒度 entitlement 分别证明 quality、数量、宽高比、6/10/15s、480p/720p/1080p 或 audio 对该套餐都可用。这些 P1 选项继续保持关闭/未完成，不能从一次默认 canary 外推。
 
-## 2026-08-15 · 自动 Memory 形成必须挂在项目或资源下（Memory Observer / Reflector / Store，docs/08/12，原则 3/7）
-
-- **根因与修复**：历史 quarantine thread 没有项目/资源；decay 归档 observation 时把它回退成 thread-only Reflector scope，随后生成 Admin「按范围」里没有父级的 active reflection。请求 observe writeback 与 eager fact 路径也允许相同的孤立范围。现在入站/出站观察在缺少项目和资源时直接 fail-open 跳过，eager extraction 不调用模型，Reflector 对已持久化的孤立 job 在任何读写前标记失败。
-- **遗忘与兼容**：SQLite/Postgres 仍会软归档历史孤立 observation，但不再排 thread-only rebuild；正常 project/resource rebuild 与直接管理的历史数据格式不变，无 schema/migration 或新依赖。现有孤立 active facts/reflections 不由升级代码猜测删除，需按运维范围显式清理。
-
-## 2026-08-15 · 请求级正文模式成为历史读取权威（Telemetry / Admin requests，docs/07/11，原则 3/7）
-
-- **根因与修复**：Admin 只按 `request_payloads` / `session_revisions` 是否存在推断历史请求的正文模式，无法证明请求发生时 Key 与系统设置的实际合并结果；大型 Session 的元数据也只证明服务端整体恢复超限，却仍无条件展示浏览器加载按钮，即使某条 revision 会被同一分页接口的 JSON 内存上限拒绝。每条新 telemetry 现在保存 body-free 的有效 `request_content_mode`；明确 `none` 时任何孤立正文行都不可读取、也不显示加载入口，旧记录继续按存储事实兼容推断。
-- **加载边界**：SQLite/Postgres 在既有 Session 元数据聚合中同时返回目标链最大单 revision 字节数；Admin 用分页端点相同的 JSON amplification 与 8 MiB 上限决定 `browser_recoverable`，不可安全分页时不再提供必然失败的按钮。该元数据不读取正文、不改变正文格式、无需 migration；当前设置仍不追溯删除历史内容。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-15 · 自动 Memory 形成必须挂在项目或资源下**：缺少 project/resource 的入站观察与 eager extraction 跳过，历史孤立 Reflector job 标记失败；完整原文经 git history 回溯。
+- **2026-08-15 · 请求级正文模式成为历史读取权威**：telemetry 保存有效正文模式，Session 元数据以单 revision 上限决定浏览器可恢复性；完整原文经 git history 回溯。
 - **2026-08-15 · 大型完整载荷改由浏览器解压与恢复图片**：Admin 优先读取 gzip/raw 存储态正文并由浏览器解压，外置图片按 `sha256` 经鉴权端点恢复，避免网关内存化放大；完整原文经 git history 回溯。
 - **2026-08-13 · OAuth 永久失效只认明确凭证拒绝**：仅标准 `invalid_grant`、Copilot mint 401 与 Codex refresh 身份变化永久摘除账号，裸 refresh 403 只短暂冷却；完整原文经 git history 回溯。
 - **2026-08-13 · Grok 4.6 补齐 Agent 能力、价格与 lane 投影**：手工 catalog 补齐已验证的 tools/SSE/常用 reasoning 与 API 等价估价，subscription vision/JSON/xhigh 继续 fail-closed；完整原文经 git history 回溯。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -543,6 +543,27 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(selected).toEqual(["a", "a"]);
   });
 
+  it("recovers a translated continuation when its persisted account is unavailable", async () => {
+    const calls: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...member("a", 50, true, calls), schedulable: false },
+        member("b", 50, true, calls),
+      ],
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of pool.chatCompletionStream(
+      { ...USER_REQ, previous_response_id: "resp-a" },
+      { statefulAccount: "a" },
+    )) {
+      chunks.push(chunk);
+    }
+
+    expect(calls).toEqual(["b"]);
+    expect(chunks).toEqual(["data: b\n\n"]);
+  });
+
   it("spreads distinct sticky sessions across equal-priority accounts", async () => {
     const calls: string[] = [];
     const pool = createOAuthPoolClient({
@@ -1507,6 +1528,62 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     expect(chunks).toEqual(["data: b\n\n"]);
   });
 
+  it("keeps a Responses websocket session on its owning account under capacity", async () => {
+    const pt: string[] = [];
+    let aBusy = false;
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...ptStreamMember("a", 50, pt), isAtCapacity: () => aBusy },
+        ptStreamMember("b", 50, pt),
+      ],
+    });
+    const session = {
+      protocol: "openai_responses" as const,
+      body: { model: "gpt-5.6-sol", stream: true, input: "turn" },
+      headers: { [CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER]: "ws-1" },
+      mutations: {},
+    };
+
+    for await (const _chunk of pool.nativePassthroughStream?.(session) ?? []) {
+    }
+    aBusy = true;
+    for await (const _chunk of pool.nativePassthroughStream?.(session) ?? []) {
+    }
+
+    expect(pt).toEqual(["a", "a"]);
+  });
+
+  it("does not let previous_response_id override a strict Codex turn state", async () => {
+    const pt: string[] = [];
+    const pool = createOAuthPoolClient({
+      members: [
+        { ...ptStreamMember("a", 50, pt), schedulable: false },
+        ptStreamMember("b", 50, pt),
+      ],
+    });
+
+    await expect(
+      (async () => {
+        for await (const _chunk of pool.nativePassthroughStream?.(
+          {
+            protocol: "openai_responses" as const,
+            body: {
+              model: "gpt-5.6-sol",
+              stream: true,
+              input: "turn",
+              previous_response_id: "resp-a",
+            },
+            headers: { "x-codex-turn-state": "turn-a" },
+            mutations: {},
+          },
+          { statefulAccount: "a" },
+        ) ?? []) {
+        }
+      })(),
+    ).rejects.toThrow(/original account is unavailable/);
+    expect(pt).toEqual([]);
+  });
+
   it("binds a streamed Responses response id to the account that produced it", async () => {
     const calls: string[] = [];
     const responseMember = (account: string): OAuthPoolMember => ({
@@ -1560,7 +1637,7 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     expect(calls).toEqual(["a", "a"]);
   });
 
-  it("recovers an invalid previous_response_id on a sibling and remembers its account", async () => {
+  it("does not move a known previous_response_id to a sibling after an upstream invalid-id", async () => {
     const calls: string[] = [];
     const invalidPreviousResponseId = new UpstreamError(
       "upstream_error",
@@ -1610,10 +1687,9 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
       }
     };
 
-    await drain("a");
-    await drain();
+    await expect(drain("a")).rejects.toThrow("Invalid `previous_response_id`.");
 
-    expect(calls).toEqual(["a", "b", "b"]);
+    expect(calls).toEqual(["a"]);
   });
 
   it("prioritizes previous_response_id affinity over websocket session affinity", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -414,15 +414,15 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
 
   function stickyKeyFromNative(input: NativePassthroughInput): string | null {
     const body = nativePassthroughBody(input);
+    if (isNativePassthroughCarrier(input)) {
+      const turnState = headerValue(input.headers, "x-codex-turn-state");
+      if (turnState !== null) return `x-codex-turn-state:${turnState}`;
+    }
     const previousResponseId = bodyString(body, "previous_response_id");
     if (previousResponseId !== null) return `previous_response_id:${previousResponseId}`;
     if (isNativePassthroughCarrier(input)) {
       const websocketSession = headerValue(input.headers, CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER);
       if (websocketSession !== null) return `responses_websocket_session:${websocketSession}`;
-    }
-    if (isNativePassthroughCarrier(input)) {
-      const turnState = headerValue(input.headers, "x-codex-turn-state");
-      if (turnState !== null) return `x-codex-turn-state:${turnState}`;
     }
     const bodyDeviceKey = deviceAffinityKeyFromBody(body);
     if (bodyDeviceKey !== null) return bodyDeviceKey;
@@ -852,6 +852,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     return (
       stickyKey?.startsWith("previous_response_id:") === true ||
       stickyKey?.startsWith("x-codex-turn-state:") === true ||
+      stickyKey?.startsWith("responses_websocket_session:") === true ||
       stickyKey?.startsWith("provider_account:") === true
     );
   }
@@ -1065,6 +1066,11 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     // parked/limited after a pool rebuild. Probe siblings immediately; waiting for
     // an upstream 400 would otherwise fail before any account search occurs.
     let recoveringPreviousResponseAccount = stickyKey?.startsWith("previous_response_id:") === true;
+    let firstSelection = true;
+    const knownPreviousResponseAccount =
+      stickyKey?.startsWith("previous_response_id:") === true
+        ? stickySessions.get(stickyKey)?.account
+        : undefined;
     let lastErr: unknown;
     for (;;) {
       let entry: PoolEntry;
@@ -1078,6 +1084,13 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         throw lastErr ?? selErr;
       }
       tried.add(entry.member.account);
+      if (firstSelection) {
+        firstSelection = false;
+        recoveringPreviousResponseAccount =
+          stickyKey?.startsWith("previous_response_id:") === true &&
+          (knownPreviousResponseAccount === undefined ||
+            knownPreviousResponseAccount !== entry.member.account);
+      }
       try {
         const result = await call(entry.member.client, entry);
         if (stickyKey?.startsWith("previous_response_id:")) {
@@ -1086,7 +1099,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         rememberResponseAffinity(result, entry);
         return result;
       } catch (err) {
-        if (isInvalidPreviousResponseIdFailure(stickyKey, err)) {
+        if (
+          isInvalidPreviousResponseIdFailure(stickyKey, err) &&
+          recoveringPreviousResponseAccount
+        ) {
           recoveringPreviousResponseAccount = true;
           lastErr = err;
           continue;
@@ -1149,8 +1165,16 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     const tried = new Set<string>([firstEntry.member.account]);
     const statefulContinuation = isStrictAccountSticky(stickyKey);
     let recoveringPreviousResponseAccount = false;
+    const knownPreviousResponseAccount =
+      stickyKey?.startsWith("previous_response_id:") === true
+        ? stickySessions.get(stickyKey)?.account
+        : undefined;
     let entry = firstEntry;
     let lastErr: unknown;
+    recoveringPreviousResponseAccount =
+      stickyKey?.startsWith("previous_response_id:") === true &&
+      (knownPreviousResponseAccount === undefined ||
+        knownPreviousResponseAccount !== firstEntry.member.account);
     for (;;) {
       let iterator: AsyncIterator<string> | undefined;
       let first: IteratorResult<string>;
@@ -1163,7 +1187,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       } catch (err) {
         if (iterator) await iterator.return?.().catch(() => {});
         const invalidPreviousResponseId = isInvalidPreviousResponseIdFailure(stickyKey, err);
-        if (invalidPreviousResponseId) {
+        if (invalidPreviousResponseId && recoveringPreviousResponseAccount) {
           recoveringPreviousResponseAccount = true;
           lastErr = err;
         } else if (isRetryableAccountFailure(err)) {
@@ -1198,6 +1222,9 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       }
       // First chunk obtained (or a clean empty stream) → COMMIT to this account.
       if (stickyKey?.startsWith("previous_response_id:")) {
+        rememberSticky(stickyKey, entry.member.account, now() + stickyTtlMs);
+      }
+      if (stickyKey?.startsWith("responses_websocket_session:")) {
         rememberSticky(stickyKey, entry.member.account, now() + stickyTtlMs);
       }
       const trackResponseAffinity = streamResponseAffinityTracker(entry);
@@ -1276,7 +1303,11 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       const stickyKey = stickyKeyFromChat(req);
       restorePersistedAffinity(stickyKey, opts?.statefulAccount);
       const avoidBusy = isUserMessageRequest(req);
-      const first = select(stickyKey, undefined, { avoidBusy, model: modelFromChat(req) });
+      const first = select(stickyKey, undefined, {
+        avoidBusy,
+        model: modelFromChat(req),
+        recoverStrictSticky: stickyKey?.startsWith("previous_response_id:") === true,
+      });
       return streamWithRetry(
         first,
         stickyKey,


### PR DESCRIPTION
## What changed

- keep a known previous_response_id on its recorded account after an upstream invalid-ID instead of scanning every sibling
- keep sibling recovery only for unavailable/unknown owners, including translated streaming
- prioritize strict x-codex-turn-state and pin Responses WebSocket sessions to one account
- keep unavailable WebSocket-session affinity failures off the shared model breaker

## Root cause

v0.28.83 combined a same-account retry inside each Codex client with pool-wide sibling probing after the recorded owner returned Invalid previous_response_id. In production this multiplied into five-account retry waves and about 25 seconds without terminal SSE output. Co-present x-codex-turn-state could also be ignored for affinity, and WebSocket sessions were soft-sticky.

## Impact

Known-owner invalid IDs now fail promptly after the bounded same-account recovery. Account search remains available only when the recorded owner is unavailable or the ID has no known owner. Strict state is never moved across accounts.

## Validation

- CI=true pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts apps/gateway/src/routes/execute.test.ts apps/gateway/src/routes/responses.test.ts (389 passed)
- pnpm --filter @helm/core typecheck
- pnpm --filter @helm/gateway typecheck
- Biome check on changed TypeScript files