### PR TITLE
Release v0.28.84

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.83",
+  "version": "0.28.84",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- release Helm API v0.28.84
- includes the Responses continuation affinity and retry-stall repair from PR #785

## Scope

- version-only change: package.json

## Validation

- version readback: 0.28.84
- git diff --check
- feature PR #785 exact-head CI passed verify, store, e2e, and docker