### PR TITLE
[codex] fallback after Anthropic tool result protocol rejection

### DIFF
--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -195,6 +195,8 @@ describe("admin OAuth routes — read endpoints", () => {
     const HOUR = 3_600_000;
     const DAY = 86_400_000;
     const WEEK = 7 * DAY;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-25T12:00:00.000Z"));
     const now = Date.now();
     const todayReset = now - HOUR;
     const saturdayReset = todayReset - 3 * DAY;
@@ -282,6 +284,7 @@ describe("admin OAuth routes — read endpoints", () => {
     }).request(
       "/admin/api/oauth/usage/periods?provider=openai-codex&account=a%40x.com&tzOffsetMinutes=0",
     );
+    vi.useRealTimers();
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       current: Array<{ windowKey: string; periodStartMs: number; tokens: number }>;

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -2498,6 +2498,69 @@ describe("createExecute — gateway execution adapter", () => {
     expect(recordFailure).not.toHaveBeenCalled();
   });
 
+  it("falls back when Anthropic rejects a translated tool result", async () => {
+    const provider = {
+      chatCompletion: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new UpstreamError(
+            "upstream_error",
+            "upstream returned 400",
+            {
+              type: "error",
+              error: {
+                type: "invalid_request_error",
+                message: "Advisor tool result content could not be processed.",
+              },
+            },
+            400,
+          ),
+        )
+        .mockResolvedValueOnce({ id: "codex-fallback" }),
+      chatCompletionStream: vi.fn(),
+    } as unknown as ProviderClient;
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["mock", provider]]),
+      registry: protocolRegistry({
+        opus: {
+          providerName: "mock",
+          providerModel: "claude-opus-4-8",
+          targetProviderProtocol: "anthropic_messages",
+        },
+        codex: {
+          providerName: "mock",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+    });
+
+    const out = await execute(plan(["opus", "codex"]), req());
+
+    expect(out.final).toEqual({
+      status: "ok",
+      alias: "codex",
+      providerModel: "gpt-5.6-sol",
+    });
+    expect(out.attempts[0]).toMatchObject({
+      alias: "opus",
+      skipped: true,
+      status: "error",
+      skip_reason: "provider_protocol_incompatible",
+      error_class: null,
+      error_detail: { upstream_status: 400 },
+    });
+    expect(provider.chatCompletion).toHaveBeenCalledTimes(2);
+    expect(recordFailure).not.toHaveBeenCalled();
+  });
+
   it("short-circuits the real overflow 400 before an unrelated sibling is tried (box c211e4a1)", async () => {
     // Anthropic (head of chain) returns a REAL 400 "prompt is too long: N > M maximum".
     // The chain short-circuits: the grok sibling is NEVER tried, and the 400 is surfaced

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -1333,6 +1333,16 @@ export function isUpstreamRequestRejection(err: unknown): boolean {
   return text.includes("max allowed size");
 }
 
+// Anthropic can reject a translated tool_result even though the source request is
+// valid for another protocol. This is candidate-specific, so let the chain try the
+// next compatible target without treating Anthropic as unhealthy.
+export function isCandidateSpecificProtocolRejection(err: unknown): boolean {
+  if (!(err instanceof UpstreamError)) return false;
+  if (err.upstreamStatus !== 400 && err.upstreamStatus !== 422) return false;
+  const text = `${err.message} ${upstreamErrorMessage(err.providerRaw) ?? ""}`.toLowerCase();
+  return text.includes("tool result content could not be processed");
+}
+
 function isReasoningHistoryRejection(err: unknown): boolean {
   if (!(err instanceof UpstreamError)) return false;
   if (err.upstreamStatus !== 400) return false;
@@ -2361,6 +2371,22 @@ export function createExecute(deps: ExecuteAdapterDeps) {
               alias,
               skipped: true,
               skip_reason: "reasoning_history_incompatible",
+              status: "error",
+              error_class: null,
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: errorDetailOf(err),
+              ...attemptTelemetry,
+            });
+            continue;
+          }
+
+          if (isCandidateSpecificProtocolRejection(err)) {
+            capabilityPruned = true;
+            attempts.push({
+              alias,
+              skipped: true,
+              skip_reason: "provider_protocol_incompatible",
               status: "error",
               error_class: null,
               latency_ms: elapsed(),

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-25 · Anthropic tool_result 400 允许协议级 fallback（协议互译 / docs/05、07，原则 3/5/8）
+
+- Anthropic 的 `Advisor tool result content could not be processed` 是目标 provider 的工具结果格式拒绝，不等价于跨 provider 的全局请求非法；该候选现在记录 `provider_protocol_incompatible` 并继续尝试下一个兼容 lane，不处罚共享 breaker。
+- 只识别这个稳定、精确的上游消息；context overflow、413 和其他确定性请求形状错误仍保持 fail-closed 400，避免把客户端应修复的问题静默转移到 fallback。
+- 当前限制：未开启 payload capture 的历史请求无法定位具体工具字段；修复覆盖路由级 fallback 语义，仍需后续针对真实 Responses→Anthropic tool schema 的 fixture 扩展协议测试。
+
 ## 2026-08-25 · Responses 续接只在原账号不可用时搜索 sibling（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
 
 - **生产根因**：`v0.28.83` 会在原账号已明确返回 `Invalid previous_response_id` 后继续遍历其余账号；每个账号内部又会原样重试一次，六个失败请求因此在返回 SSE error 前静默约 24–26 秒。现在已知原账号实际接到请求后若仍返回精确 invalid-ID，立即 fail-closed；只有持久化原账号已不可调度或 ID 尚无归属时，才保留同 provider/model 的 sibling 搜索。


### PR DESCRIPTION
## What changed

- Treat Anthropic `Advisor tool result content could not be processed` as a candidate-specific protocol rejection.
- Preserve the redacted upstream diagnostic, skip only that candidate, and continue to the next compatible lane without tripping the shared breaker.
- Keep context overflow, 413, and other deterministic request-shape errors fail-closed as client-visible 400 responses.

## Root cause

The gateway classified every upstream `invalid_request_error` as invalid for every provider. Anthropic can reject a translated `tool_result` shape that another protocol can still serve, so the configured fallback chain was never reached.

## Validation

- `CI=true pnpm exec vitest run apps/gateway/src/routes/execute.test.ts --project node` (177 passed)
- `CI=true pnpm --filter @helm/gateway typecheck`
- `pnpm --filter @helm/gateway build`
- `pnpm exec biome check apps/gateway/src/routes/execute.ts apps/gateway/src/routes/execute.test.ts`
