### PR TITLE
[codex] Enforce Responses continuation lifecycle

### DIFF
--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1512,6 +1512,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       providerName: "openai-codex",
       providerModel: "gpt-5.6-sol",
       providerProtocol: "openai_responses" as const,
+      providerAccount: "oauth-a",
       createdAt: 1,
       expiresAt: Date.now() + 60_000,
       status: "completed",
@@ -1536,7 +1537,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
   it.each([
     "failed",
     "truncated",
-    "incomplete",
+    "cancelled",
   ])("rejects a previous_response_id whose registry status is %s", async (status) => {
     const get = vi.fn().mockResolvedValue({
       responseId: "resp_unusable",
@@ -1564,6 +1565,62 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(await res.json()).toMatchObject({
       error: { type: "invalid_request_error" },
     });
+    expect(harness.pipelineSawIR).toBeNull();
+  });
+
+  it("allows an incomplete previous_response_id to preserve the Responses terminal contract", async () => {
+    const get = vi.fn().mockResolvedValue({
+      responseId: "resp_incomplete",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "responses/gpt-5.5",
+      providerName: "openai",
+      providerModel: "gpt-5.5",
+      providerProtocol: "openai_responses" as const,
+      providerAccount: null,
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      status: "incomplete",
+    });
+    const { deps, harness } = makeDeps({ registry: { put: vi.fn(), get } });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, previous_response_id: "resp_incomplete" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(harness.pipelineSawIR).toMatchObject({
+      metadata: { stateful_provider_alias: "responses/gpt-5.5" },
+    });
+  });
+
+  it("rejects an OAuth previous_response_id with no persisted owner before routing", async () => {
+    const get = vi.fn().mockResolvedValue({
+      responseId: "resp_ownerless",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "openai-codex/gpt-5.6-sol",
+      providerName: "openai-codex",
+      providerModel: "gpt-5.6-sol",
+      providerProtocol: "openai_responses" as const,
+      providerAccount: null,
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      status: "completed",
+    });
+    const { deps, harness } = makeDeps({ registry: { put: vi.fn(), get } });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { ...AUTH, "x-codex-turn-state": "turn-ownerless" },
+      body: JSON.stringify({ ...REQ, previous_response_id: "resp_ownerless" }),
+    });
+
+    expect(res.status).toBe(400);
     expect(harness.pipelineSawIR).toBeNull();
   });
 
@@ -1649,6 +1706,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       providerName: "openai-codex",
       providerModel: "gpt-5.6-sol",
       providerProtocol: "openai_responses" as const,
+      providerAccount: "oauth-a",
       createdAt: 1,
       expiresAt: Date.now() + 60_000,
       status: "completed",
@@ -1715,6 +1773,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       providerName: "openai-codex",
       providerModel: "gpt-5.6-sol",
       providerProtocol: "openai_responses" as const,
+      providerAccount: "oauth-a",
       createdAt: 1,
       expiresAt: Date.now() + 60_000,
       status: "completed",

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -1533,6 +1533,40 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     });
   });
 
+  it.each([
+    "failed",
+    "truncated",
+    "incomplete",
+  ])("rejects a previous_response_id whose registry status is %s", async (status) => {
+    const get = vi.fn().mockResolvedValue({
+      responseId: "resp_unusable",
+      accountId: "acct",
+      keyId: "k1",
+      providerAlias: "openai-codex/gpt-5.6-sol",
+      providerName: "openai-codex",
+      providerModel: "gpt-5.6-sol",
+      providerProtocol: "openai_responses" as const,
+      providerAccount: "oauth-a",
+      createdAt: 1,
+      expiresAt: Date.now() + 60_000,
+      status,
+    });
+    const { deps, harness } = makeDeps({ registry: { put: vi.fn(), get } });
+    const app = buildApp(deps);
+
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, previous_response_id: "resp_unusable" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+    expect(harness.pipelineSawIR).toBeNull();
+  });
+
   it("persists a recovered previous_response_id account", async () => {
     const put = vi.fn();
     const registryRecord = {

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -1208,7 +1208,11 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     if (previousResponseId !== null) {
       const previous =
         deps.registry === undefined ? null : await deps.registry.get(previousResponseId, identity);
-      if (previous?.providerAlias === null || previous?.providerProtocol !== "openai_responses") {
+      if (
+        previous?.providerAlias === null ||
+        previous?.providerProtocol !== "openai_responses" ||
+        previous.status !== "completed"
+      ) {
         throw helmError(
           "invalid_request",
           `previous_response_id '${previousResponseId}' cannot be continued safely; send the full conversation input instead`,

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -5,6 +5,7 @@ import {
   type BudgetProbe,
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   type DecisionRecord,
+  getOAuthProvider,
   preOutputClassifierFor,
   type RateLimitProbe,
   type RateLimitResult,
@@ -561,6 +562,11 @@ function responseSnapshotFromStreamFrame(
 function isUsableRegistryRecord(record: ResponsesRegistryRecord): boolean {
   if (record.expiresAt <= Date.now()) return false;
   return record.status !== "deleted";
+}
+
+function isOAuthSubscriptionAlias(alias: string): boolean {
+  const slash = alias.indexOf("/");
+  return slash > 0 && getOAuthProvider(alias.slice(0, slash)) !== undefined;
 }
 
 // Validate a PipelineError's free-form `error_class` against the known ErrorClass
@@ -1208,10 +1214,15 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
     if (previousResponseId !== null) {
       const previous =
         deps.registry === undefined ? null : await deps.registry.get(previousResponseId, identity);
+      const continuableStatus =
+        previous?.status === "completed" || previous?.status === "incomplete";
       if (
         previous?.providerAlias === null ||
         previous?.providerProtocol !== "openai_responses" ||
-        previous.status !== "completed"
+        !continuableStatus ||
+        (typeof previous.providerAlias === "string" &&
+          isOAuthSubscriptionAlias(previous.providerAlias) &&
+          !previous.providerAccount)
       ) {
         throw helmError(
           "invalid_request",

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1380,12 +1380,17 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       noop,
     );
     await expect(
-      enabled.poolClients.get("xai")?.nativePassthrough?.({
-        model: "grok-4.5",
-        previous_response_id: "resp-prev",
-        instructions: "Follow the repository policy.",
-        input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "next" }] }],
-      }),
+      enabled.poolClients.get("xai")?.nativePassthrough?.(
+        {
+          model: "grok-4.5",
+          previous_response_id: "resp-prev",
+          instructions: "Follow the repository policy.",
+          input: [
+            { type: "message", role: "user", content: [{ type: "input_text", text: "next" }] },
+          ],
+        },
+        { statefulAccount: "heavy" },
+      ),
     ).rejects.toMatchObject({
       upstreamStatus: 400,
       providerRaw: expect.objectContaining({ code: "previous_response_id_unsupported" }),

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,8 +10,8 @@
 ## 2026-08-25 · Responses continuation 不跨账号或 transport 恢复（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
 
 - **根因修正**：`previous_response_id` 的持久化 provider/account 归属不能证明上游 WebSocket 状态仍存在。OAuth pool 现在只允许已知且可调度的原账号执行；原账号缺失、不可用或过期时在 provider dispatch 前拒绝，不再搜索 sibling。其他无状态请求的账号级 failover 保持不变。
-- **transport 边界**：Codex continuation 必须复用当前活动的原 WebSocket；原 session 缺失、连接关闭、426/connection-limit、模糊 send failure 均禁止重连和 HTTP fallback，返回 `previous_response_id_session_unavailable` 并要求完整会话。精确 invalid-ID 仍只在同一活动 WebSocket 上原样重试一次。
-- **registry 边界**：只有 `completed` response registry 记录可作为续接父节点；`failed`、`truncated`、`incomplete` 与其他状态在路由前 fail-closed。没有新增 schema、迁移、配置或正文持久化。
+- **transport 边界**：Codex continuation 必须复用产生该 response ID 的当前活动原 WebSocket；原 session 缺失/不匹配、连接关闭、426/connection-limit、模糊 send failure 均禁止重连和 HTTP fallback，返回 `previous_response_id_session_unavailable` 并要求完整会话。精确 invalid-ID 仍只在同一活动 WebSocket 上原样重试一次。
+- **registry 边界**：`completed` 与协议允许的 `incomplete` registry 记录可作为续接父节点；`failed`、`cancelled`、内部 `truncated` 与其他状态在路由前 fail-closed。OAuth 记录还必须带原账号，避免旧空 owner 被 turn-state 绕过；静态 Responses provider 继续允许空账号。没有新增 schema、迁移、配置或正文持久化。
 
 ## 2026-08-25 · Anthropic tool_result 400 允许协议级 fallback（协议互译 / docs/05、07，原则 3/5/8）
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-25 · Responses continuation 不跨账号或 transport 恢复（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
+
+- **根因修正**：`previous_response_id` 的持久化 provider/account 归属不能证明上游 WebSocket 状态仍存在。OAuth pool 现在只允许已知且可调度的原账号执行；原账号缺失、不可用或过期时在 provider dispatch 前拒绝，不再搜索 sibling。其他无状态请求的账号级 failover 保持不变。
+- **transport 边界**：Codex continuation 必须复用当前活动的原 WebSocket；原 session 缺失、连接关闭、426/connection-limit、模糊 send failure 均禁止重连和 HTTP fallback，返回 `previous_response_id_session_unavailable` 并要求完整会话。精确 invalid-ID 仍只在同一活动 WebSocket 上原样重试一次。
+- **registry 边界**：只有 `completed` response registry 记录可作为续接父节点；`failed`、`truncated`、`incomplete` 与其他状态在路由前 fail-closed。没有新增 schema、迁移、配置或正文持久化。
+
 ## 2026-08-25 · Anthropic tool_result 400 允许协议级 fallback（协议互译 / docs/05、07，原则 3/5/8）
 
 - Anthropic 的 `Advisor tool result content could not be processed` 是目标 provider 的工具结果格式拒绝，不等价于跨 provider 的全局请求非法；该候选现在记录 `provider_protocol_incompatible` 并继续尝试下一个兼容 lane，不处罚共享 breaker。
@@ -54,26 +60,10 @@
 - **兼容决定**：用户确认 fast image 与 prompt-only video 的已公开选项不得移除。`grok-imagine-image` 继续接受并透传 `n=1..4`、六种 `aspect_ratio`、`resolution=1k` 与 `response_format=b64_json`；`grok-imagine-video` 继续接受并透传 `aspect_ratio`、`duration=6/10/15`、`resolution=480p/720p/1080p` 与 `audio`。合同仍为严格对象，不开放任意未知字段或 ZDR `output`。
 - **边界不变**：此次只恢复请求 schema 兼容性；model/key 授权、blocked model、预算 fail-closed、OAuth 账号选择与固定账号轮询、付费 POST 单写，以及视频 `done` 必须带非空 `video.url` 均保持不变。旧 quality image、single-image video 与 reference-video 路径不改。
 
-## 2026-08-18 · Grok Imagine 合并后收紧 entitlement 与媒体协议边界（OAuth / Images / Videos，Phase 1 spec §4–9，原则 3/6/7/8）
-
-- **撤权与 cooldown**：xAI billing 刷新失败不再删除整条 quota；改写入 `windows: []` 的 entitlement tombstone，复用两种 Store 已有的 upsert 语义保留 `usageLimitedUntilMs`。若 tombstone 无法持久化，进程级紧急 latch 会先摘除全部 xAI 媒体 alias，并在任何普通 OAuth pool rebuild 后继续生效；只有权威 billing 刷新成功持久化且对应 rebuild 成功后才恢复。
-- **公开合同**：`/v1/models` 已公开的 `xai/grok-imagine-video*` alias 现在可由 `allow_custom_model` key 直接调用，普通 key 仍在付费 reservation 前拒绝。新 fast image 与 prompt-only video 只接受已证明的 `model + prompt`；合并前已有的 quality image、single-image video 和 reference-video 合同保持兼容，不从一次默认 canary 外推细粒度付费能力。
-- **视频终态**：共享 Zod response schema、provider 客户端和 gateway poll 边界共同要求非空 `status`，且 `done` 必须带非空 `video.url`；畸形完成响应返回 502，不写入 durable terminal state。
-- **限制**：紧急 latch 是进程内状态；quota Store 完全不可写且进程在下一次成功刷新前重启时，无法把该瞬时失败跨进程持久化。正常失败路径会优先写 tombstone，因此不新增 migration、配置项或依赖。
-
-## 2026-08-18 · Grok.com Imagine 复用 OAuth 媒体链并以短期 billing 证据授权（OAuth / Images / Videos，Phase 1 spec §4–9，原则 2/3/6/7）
-
-- **账号资格**：不新增 entitlement 表；复用 SQLite/Postgres 已持久化的 xAI 周 billing snapshot。媒体正向授权必须同时满足“24 小时内的新鲜周 billing”与“当前 OAuth JWT 是明确的已知付费 tier”，opaque、缺失、未知、`free`、`x_basic` 均 fail-closed；有效期取 `capturedAt + 24h` 与周窗口 reset 的较早者。普通 Grok 文本模型不读取此媒体 gate。
-- **动态撤权与混合账号池**：每个媒体模型把 `validUntilMs` 带进账号池，选择、图片/视频 resolver 和 `/v1/models` 都按实时 clock 重评估，无需重启或定时 sweep；只指向已失效 OAuth leaf 的媒体 lane 也同步从 discovery 隐藏。OAuth 完成后异步拉取 xAI billing；空结果或失败会删除旧快照并重建。若删除失败，即使普通 rebuild 成功也立即摘除全部 live xAI 媒体 alias，避免旧行重新授权；单账号失败不遮蔽其他有新鲜证据的账号。
-- **媒体合同**：图片继续使用原 `/v1/images/generations` 与单写保护，只给 Grok 快速/质量模型增加严格的 `n=1..4`、六种宽高比合同，并把空数组、空字符串或纯空白图片载体视为 `outcome_unknown`；其他图片 provider 保持宽松 OpenAI 兼容合同。纯文字视频复用原 `/v1/videos/generations`、任务 registry 与固定账号 poll，不新增文字转图片的两步 workflow。
-- **真实 canary 与运行边界**：用户批准的本机 canary 恰好执行一次默认 fast 图片 create 和一次默认 prompt-only 视频 create，均未重试；图片得到 1 个非空结果，视频取得 receipt 后由原账号 6 次 GET 轮询到 `done` 和非空结果。候选镜像 `sha256:2940600c…`、`/version` dirty SHA、entitlement、serving account、registry、telemetry 与普通日志脱敏回读一致，旧 v0.28.74 容器保留为停止态回滚点。宿主 Playwright 因真实 `response_work_capacity_exhausted` 保护无法解析 mock 响应，未削弱生产保护；同一 `videos.spec.ts` 在 Docker builder 中 2/2 通过。现有 recovery key 没有低 cap，因此完整 Go 门禁仍未满足。
-- **可重复 live smoke**：新增默认跳过的 `apps/gateway/src/live-grok-imagine.test.ts`，必须同时提供 loopback Helm 地址、环境变量 key 与 `I_ACCEPT_EXACTLY_2_MEDIA_CREATES` 才会执行；每次只发 1 次默认图片 create 和 1 次纯文字视频 create，POST 无重试，视频只做有界同 receipt GET poll，测试输出不包含 key、prompt、receipt、正文或签名 URL。用户同日明确要求的实跑为 2/2 通过：图片结果可读；视频一次接受后经 5 次只读 poll 到 `done`，且结果字节可读取。
-- **完整 CI 本机复刻**：在不再调用付费媒体接口的前提下，以 Docker 隔离环境逐项复刻 `.github/workflows/ci.yml`：typecheck、lint、build 通过；fast suite 355/355 文件、6417/6417 用例通过；Store suite 60/60 文件、650/650 用例通过；真实 PostgreSQL 合约与完整 Playwright e2e 95/95 通过；正式多阶段镜像 `sha256:fbfa07f3…` 的 `/healthz` 回读 `ready:true`，`/version` 回读 `0.28.74` 与非 `unknown` Git SHA。最初的缺 `.github`、root 权限、OpenSSL 和容器内 Docker 都是本地测试壳与 GitHub Ubuntu runner 的环境差异，补齐同等前置条件后均全绿；临时数据库、网络、浏览器缓存和 smoke 容器已清理，现有 `helm` 候选容器未受影响。
-- **交付边界**：正式 PR #761 已创建；实现提交 `29ff7655` 的托管 GitHub Actions run `32142663949` 已回读 `verify`、`store`、`e2e`、`docker` 与四个稳定 required checks 全部成功。本轮不合并或部署；P1 细粒度媒体选项、低 cap key 前置条件与“关闭新能力但保留已接受视频 poll”的回滚门禁仍未完成，因此整体发布 Go 门禁仍是 No-Go。
-- **剩余限制**：当前只有账号级媒体开关；默认 fast 图片已经真实验证，但仍没有可靠的上游细粒度 entitlement 分别证明 quality、数量、宽高比、6/10/15s、480p/720p/1080p 或 audio 对该套餐都可用。这些 P1 选项继续保持关闭/未完成，不能从一次默认 canary 外推。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-18 · Grok Imagine 合并后收紧 entitlement 与媒体协议边界**：billing 失败以 tombstone/latch fail-closed，公开 alias 与严格视频终态合同保持兼容；完整原文经 git history 回溯。
+- **2026-08-18 · Grok.com Imagine 复用 OAuth 媒体链并以短期 billing 证据授权**：复用新鲜 billing snapshot、付费单写和固定账号轮询，真实 canary 与完整 CI 证据边界经 git history 回溯。
 - **2026-08-15 · 自动 Memory 形成必须挂在项目或资源下**：缺少 project/resource 的入站观察与 eager extraction 跳过，历史孤立 Reflector job 标记失败；完整原文经 git history 回溯。
 - **2026-08-15 · 请求级正文模式成为历史读取权威**：telemetry 保存有效正文模式，Session 元数据以单 revision 上限决定浏览器可恢复性；完整原文经 git history 回溯。
 - **2026-08-15 · 大型完整载荷改由浏览器解压与恢复图片**：Admin 优先读取 gzip/raw 存储态正文并由浏览器解压，外置图片按 `sha256` 经鉴权端点恢复，避免网关内存化放大；完整原文经 git history 回溯。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -543,7 +543,7 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(selected).toEqual(["a", "a"]);
   });
 
-  it("recovers a translated continuation when its persisted account is unavailable", async () => {
+  it("rejects a translated continuation when its persisted account is unavailable", async () => {
     const calls: string[] = [];
     const pool = createOAuthPoolClient({
       members: [
@@ -552,16 +552,13 @@ describe("createOAuthPoolClient — account selection", () => {
       ],
     });
 
-    const chunks: string[] = [];
-    for await (const chunk of pool.chatCompletionStream(
-      { ...USER_REQ, previous_response_id: "resp-a" },
-      { statefulAccount: "a" },
-    )) {
-      chunks.push(chunk);
-    }
-
-    expect(calls).toEqual(["b"]);
-    expect(chunks).toEqual(["data: b\n\n"]);
+    expect(() =>
+      pool.chatCompletionStream(
+        { ...USER_REQ, previous_response_id: "resp-a" },
+        { statefulAccount: "a" },
+      ),
+    ).toThrow("previous_response_id original account is unavailable");
+    expect(calls).toEqual([]);
   });
 
   it("spreads distinct sticky sessions across equal-priority accounts", async () => {
@@ -710,7 +707,7 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(calls).toEqual(["a", "a"]);
   });
 
-  it("probes a sibling when a known previous_response_id original account is unavailable", async () => {
+  it("rejects when a known previous_response_id original account is unavailable", async () => {
     const calls: string[] = [];
     const responseMember = (account: string): OAuthPoolMember => ({
       account,
@@ -737,8 +734,8 @@ describe("createOAuthPoolClient — account selection", () => {
 
     await expect(
       pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-a" }),
-    ).resolves.toEqual({ id: "resp-b", served_by: "b" });
-    expect(calls).toEqual(["a", "b"]);
+    ).rejects.toThrow("previous_response_id original account is unavailable");
+    expect(calls).toEqual(["a"]);
   });
 
   it("never retries a known previous_response_id on a sibling after a transient fault", async () => {
@@ -773,16 +770,16 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(calls).toEqual(["a", "a"]);
   });
 
-  it("does not hash an unknown previous_response_id as a fake stable account key", async () => {
+  it("rejects an unknown previous_response_id without calling any account", async () => {
     const calls: string[] = [];
     const pool = createOAuthPoolClient({
       members: [member("a", 50, true, calls), member("b", 50, true, calls)],
     });
 
-    await pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-1" });
-    await pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-2" });
-
-    expect(calls).toEqual(["a", "b"]);
+    await expect(
+      pool.chatCompletion({ ...USER_REQ, previous_response_id: "resp-1" }),
+    ).rejects.toThrow("previous_response_id original account is unavailable");
+    expect(calls).toEqual([]);
   });
 
   it("restores a persisted previous_response_id account pin after pool restart", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -900,7 +900,6 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     opts: {
       avoidBusy?: boolean;
       model?: string | null;
-      recoverStrictSticky?: boolean;
     } = {},
   ): PoolEntry {
     const nowMs = now();
@@ -944,7 +943,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         reason: "sticky_hit",
       });
     }
-    if (stickyOnly && knownSticky && opts.recoverStrictSticky !== true) {
+    if (stickyKey?.startsWith("previous_response_id:") && !knownSticky) {
+      throw new Error("oauth pool: previous_response_id original account is unavailable");
+    }
+    if (stickyOnly && knownSticky) {
       const source = affinityKeySource(stickyKey ?? null) ?? "stateful continuation";
       throw new Error(`oauth pool: ${source} original account is unavailable`);
     }
@@ -1062,35 +1064,15 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   ): Promise<R> {
     const tried = new Set<string>();
     const statefulContinuation = isStrictAccountSticky(stickyKey);
-    // A persisted previous_response_id pin can point at an account that is now
-    // parked/limited after a pool rebuild. Probe siblings immediately; waiting for
-    // an upstream 400 would otherwise fail before any account search occurs.
-    let recoveringPreviousResponseAccount = stickyKey?.startsWith("previous_response_id:") === true;
-    let firstSelection = true;
-    const knownPreviousResponseAccount =
-      stickyKey?.startsWith("previous_response_id:") === true
-        ? stickySessions.get(stickyKey)?.account
-        : undefined;
     let lastErr: unknown;
     for (;;) {
       let entry: PoolEntry;
       try {
-        entry = select(stickyKey, tried, {
-          avoidBusy,
-          model,
-          recoverStrictSticky: recoveringPreviousResponseAccount,
-        });
+        entry = select(stickyKey, tried, { avoidBusy, model });
       } catch (selErr) {
         throw lastErr ?? selErr;
       }
       tried.add(entry.member.account);
-      if (firstSelection) {
-        firstSelection = false;
-        recoveringPreviousResponseAccount =
-          stickyKey?.startsWith("previous_response_id:") === true &&
-          (knownPreviousResponseAccount === undefined ||
-            knownPreviousResponseAccount !== entry.member.account);
-      }
       try {
         const result = await call(entry.member.client, entry);
         if (stickyKey?.startsWith("previous_response_id:")) {
@@ -1099,14 +1081,6 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         rememberResponseAffinity(result, entry);
         return result;
       } catch (err) {
-        if (
-          isInvalidPreviousResponseIdFailure(stickyKey, err) &&
-          recoveringPreviousResponseAccount
-        ) {
-          recoveringPreviousResponseAccount = true;
-          lastErr = err;
-          continue;
-        }
         if (isRetryableAccountFailure(err)) {
           coolRetryableAccount(entry);
           if (statefulContinuation) throw err;
@@ -1164,17 +1138,8 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   ): AsyncIterable<string> {
     const tried = new Set<string>([firstEntry.member.account]);
     const statefulContinuation = isStrictAccountSticky(stickyKey);
-    let recoveringPreviousResponseAccount = false;
-    const knownPreviousResponseAccount =
-      stickyKey?.startsWith("previous_response_id:") === true
-        ? stickySessions.get(stickyKey)?.account
-        : undefined;
     let entry = firstEntry;
     let lastErr: unknown;
-    recoveringPreviousResponseAccount =
-      stickyKey?.startsWith("previous_response_id:") === true &&
-      (knownPreviousResponseAccount === undefined ||
-        knownPreviousResponseAccount !== firstEntry.member.account);
     for (;;) {
       let iterator: AsyncIterator<string> | undefined;
       let first: IteratorResult<string>;
@@ -1187,10 +1152,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       } catch (err) {
         if (iterator) await iterator.return?.().catch(() => {});
         const invalidPreviousResponseId = isInvalidPreviousResponseIdFailure(stickyKey, err);
-        if (invalidPreviousResponseId && recoveringPreviousResponseAccount) {
-          recoveringPreviousResponseAccount = true;
-          lastErr = err;
-        } else if (isRetryableAccountFailure(err)) {
+        if (isRetryableAccountFailure(err)) {
           coolRetryableAccount(entry);
           lastErr = err;
         } else if (isCredentialAccountFailure(err, upstreamCredentialFailureStatuses)) {
@@ -1208,11 +1170,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
         if (statefulContinuation && !invalidPreviousResponseId) throw lastErr;
         let next: PoolEntry;
         try {
-          next = select(stickyKey, tried, {
-            avoidBusy,
-            model,
-            recoverStrictSticky: recoveringPreviousResponseAccount,
-          });
+          next = select(stickyKey, tried, { avoidBusy, model });
         } catch {
           throw lastErr; // no sibling left → surface the real upstream cause
         }
@@ -1303,11 +1261,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       const stickyKey = stickyKeyFromChat(req);
       restorePersistedAffinity(stickyKey, opts?.statefulAccount);
       const avoidBusy = isUserMessageRequest(req);
-      const first = select(stickyKey, undefined, {
-        avoidBusy,
-        model: modelFromChat(req),
-        recoverStrictSticky: stickyKey?.startsWith("previous_response_id:") === true,
-      });
+      const first = select(stickyKey, undefined, { avoidBusy, model: modelFromChat(req) });
       return streamWithRetry(
         first,
         stickyKey,
@@ -1362,11 +1316,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       const avoidBusy = isUserMessageRequest(nativePassthroughBody(body));
       // Pick + fail-closed check SYNCHRONOUSLY on the call turn (rotation + onSelect, and a
       // synchronous throw if the picked member can't passthrough-stream), exactly as before.
-      const first = select(stickyKey, undefined, {
-        avoidBusy,
-        model: modelFromNative(body),
-        recoverStrictSticky: stickyKey?.startsWith("previous_response_id:") === true,
-      });
+      const first = select(stickyKey, undefined, { avoidBusy, model: modelFromNative(body) });
       if (!first.member.client.nativePassthroughStream) {
         throw new Error("oauth pool member does not support native passthrough streaming");
       }

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -3495,6 +3495,62 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects a previous_response_id created on another live websocket session", async () => {
+    const sessionA = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-session-a" } },
+        { type: "response.completed", response: { id: "resp-session-a", status: "completed" } },
+      ],
+    ]);
+    const sessionB = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-session-b" } },
+        { type: "response.completed", response: { id: "resp-session-b", status: "completed" } },
+      ],
+    ]);
+    const connect = vi.fn().mockResolvedValueOnce(sessionA).mockResolvedValueOnce(sessionB);
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_cross_session")}`,
+        responsesWebSocketConnector: connect,
+      },
+    });
+    for (const sessionId of ["ingress-session-a", "ingress-session-b"]) {
+      for await (const _chunk of client.nativePassthroughStream?.(
+        carrier(sessionId, {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      ) ?? []) {
+        // Establish one response on each live websocket.
+      }
+    }
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-session-b", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+          previous_response_id: "resp-session-a",
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: {
+        error: { code: "previous_response_id_session_unavailable" },
+      },
+    });
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(sessionA.sent).toHaveLength(1);
+    expect(sessionB.sent).toHaveLength(1);
+  });
+
   it("does not reconnect or fall back to HTTP when a continuation websocket closes", async () => {
     const replies: Array<Array<Record<string, unknown>>> = [
       [

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -3221,7 +3221,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(connect).toHaveBeenCalledTimes(1);
   });
 
-  it("reuses one upstream websocket for prewarm and previous_response_id continuation", async () => {
+  it("reuses one upstream websocket for completed and incomplete continuations", async () => {
     const connection = fakeConnection([
       [
         { type: "response.created", response: { id: "warm-1" } },
@@ -3237,8 +3237,8 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
           item: { type: "function_call", call_id: "call-1", name: "exec_command" },
         },
         {
-          type: "response.completed",
-          response: { id: "resp-1", status: "completed", usage: {} },
+          type: "response.incomplete",
+          response: { id: "resp-1", status: "incomplete" },
         },
       ],
       [
@@ -3337,6 +3337,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     ]);
     expect(turns[0]).toContain("response.completed");
     expect(turns[1]).toContain("function_call");
+    expect(turns[1]).toContain("response.incomplete");
     expect(turns[2]).toContain('"delta":"done"');
     expect(responseMetadata).toHaveLength(1);
     expect(responseMetadata[0]?.get("x-models-etag")).toBe('"models-ws-1"');
@@ -3657,7 +3658,6 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
 
   it.each([
     "response.failed",
-    "response.incomplete",
     "response.cancelled",
     "error",
   ] as const)("closes the upstream websocket before yielding %s and reconnects after iterator.return", async (terminalType) => {

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -3414,7 +3414,14 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
         message: "Invalid `previous_response_id`.",
       },
     };
-    const connection = fakeConnection([[invalidPreviousResponseId], [invalidPreviousResponseId]]);
+    const connection = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-missing" } },
+        { type: "response.completed", response: { id: "resp-missing", status: "completed" } },
+      ],
+      [invalidPreviousResponseId],
+      [invalidPreviousResponseId],
+    ]);
     const connect = vi.fn(async () => connection);
     const client = createCodexResponsesClient({
       config: {
@@ -3424,6 +3431,16 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
         connectRetryBackoffMs: [0],
       },
     });
+    for await (const _chunk of client.nativePassthroughStream?.(
+      carrier("ingress-invalid-previous-repeat", {
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      // Establish the parent on the original websocket.
+    }
     const iterator = client
       .nativePassthroughStream?.(
         carrier("ingress-invalid-previous-repeat", {
@@ -3441,8 +3458,106 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       message: "Invalid `previous_response_id`.",
     });
     expect(connect).toHaveBeenCalledTimes(1);
-    expect(connection.sent).toHaveLength(2);
+    expect(connection.sent).toHaveLength(3);
     expect(connection.closeCalls).toBe(1);
+  });
+
+  it("rejects a previous_response_id when its original websocket session is absent", async () => {
+    const connect = vi.fn();
+    const fetchMock = vi.fn();
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_missing_session")}`,
+        responsesWebSocketConnector: connect,
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-missing-session", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+          previous_response_id: "resp-old",
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: {
+        error: { code: "previous_response_id_session_unavailable" },
+      },
+    });
+    expect(connect).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not reconnect or fall back to HTTP when a continuation websocket closes", async () => {
+    const replies: Array<Array<Record<string, unknown>>> = [
+      [
+        { type: "response.created", response: { id: "resp-parent" } },
+        { type: "response.completed", response: { id: "resp-parent", status: "completed" } },
+      ],
+      [],
+    ];
+    let turn = -1;
+    let eventIndex = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {
+        turn += 1;
+        eventIndex = 0;
+      },
+      async receive() {
+        const event = replies[turn]?.[eventIndex++];
+        return event === undefined ? null : JSON.stringify(event);
+      },
+      async close() {},
+    };
+    const connect = vi.fn(async () => connection);
+    const fetchMock = vi.fn();
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_closed_continuation")}`,
+        responsesWebSocketConnector: connect,
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    for await (const _chunk of client.nativePassthroughStream?.(
+      carrier("ingress-closed-continuation", {
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      // Establish the original response on the live websocket.
+    }
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-closed-continuation", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+          previous_response_id: "resp-parent",
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: {
+        error: { code: "previous_response_id_session_unavailable" },
+      },
+    });
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("falls back to HTTP after a websocket 426 and keeps the named session on HTTP", async () => {
@@ -3832,6 +3947,10 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
   it("preserves a Responses Lite incremental continuation without re-inserting tools", async () => {
     const connection = fakeConnection([
       [
+        { type: "response.created", response: { id: "resp-1" } },
+        { type: "response.completed", response: { id: "resp-1", status: "completed" } },
+      ],
+      [
         { type: "response.created", response: { id: "resp-2" } },
         { type: "response.output_text.delta", delta: "done" },
         {
@@ -3859,6 +3978,17 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     for await (const _chunk of client.nativePassthroughStream?.(
       carrier("ingress-lite-continuation", {
         model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      // Establish resp-1 on the original websocket.
+    }
+
+    for await (const _chunk of client.nativePassthroughStream?.(
+      carrier("ingress-lite-continuation", {
+        model: "gpt-5.6-sol",
         input: [output],
         stream: true,
         store: false,
@@ -3871,7 +4001,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       // drain
     }
 
-    expect(connection.sent.map((text) => JSON.parse(text))).toEqual([
+    expect(connection.sent.slice(1).map((text) => JSON.parse(text))).toEqual([
       expect.objectContaining({
         type: "response.create",
         previous_response_id: "resp-1",

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1946,7 +1946,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         type === "response.incomplete" ||
         type === "response.cancelled" ||
         type === "error",
-      reusable: type === "response.completed",
+      reusable: type === "response.completed" || type === "response.incomplete",
       responseId:
         isRecord(event.response) && typeof event.response.id === "string"
           ? event.response.id

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1694,6 +1694,21 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     return nested.type === "invalid_request_error";
   }
 
+  function continuationSessionUnavailable(message: string): UpstreamError {
+    return new UpstreamError(
+      "upstream_error",
+      message,
+      {
+        error: {
+          type: "invalid_request_error",
+          code: "previous_response_id_session_unavailable",
+          message,
+        },
+      },
+      400,
+    );
+  }
+
   function websocketSessionId(input: NativePassthroughInput): string | undefined {
     return nativeHeader(input, CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER);
   }
@@ -2038,15 +2053,26 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     async *nativePassthroughStream(body, opts) {
       const modelInfo = await resolveModelInfo(nativeInputModel(body));
       const sessionId = websocketSessionId(body);
+      const nativeBody = isNativePassthroughCarrier(body) ? body.body : body;
+      const previousResponseId = nativeBody.previous_response_id;
+      const hasPreviousResponseId =
+        typeof previousResponseId === "string" && previousResponseId.trim().length > 0;
+      if (
+        hasPreviousResponseId &&
+        (!cfg.responsesWebSocketConnector ||
+          !sessionId ||
+          websocketHttpFallbackSessions.has(sessionId) ||
+          !websocketSessions.has(sessionId))
+      ) {
+        throw continuationSessionUnavailable(
+          "previous_response_id cannot be continued because its original websocket session is unavailable; send the full conversation input instead",
+        );
+      }
       if (
         cfg.responsesWebSocketConnector &&
         sessionId &&
         !websocketHttpFallbackSessions.has(sessionId)
       ) {
-        const nativeBody = isNativePassthroughCarrier(body) ? body.body : body;
-        const previousResponseId = nativeBody.previous_response_id;
-        const hasPreviousResponseId =
-          typeof previousResponseId === "string" && previousResponseId.trim().length > 0;
         const { prepared, turnKey } = await prepareRequest(
           body,
           modelInfo,
@@ -2072,6 +2098,11 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
               (error.upstreamStatus === 426 || error.upstreamStatus === null) &&
               !opts?.signal?.aborted
             ) {
+              if (hasPreviousResponseId) {
+                throw continuationSessionUnavailable(
+                  "previous_response_id cannot be continued because its original websocket connection failed; send the full conversation input instead",
+                );
+              }
               websocketHttpFallbackSessions.add(sessionId);
               break;
             }
@@ -2107,6 +2138,11 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                     "upstream websocket closed before a terminal response event",
                   );
                 }
+                if (hasPreviousResponseId) {
+                  throw continuationSessionUnavailable(
+                    "previous_response_id cannot be continued because its original websocket closed; send the full conversation input instead",
+                  );
+                }
                 if (retries < maxRetries) {
                   retryConnection = true;
                 } else {
@@ -2135,6 +2171,11 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                   }
                   if (isWebsocketConnectionLimitError(event.error)) {
                     await closeWebSocketSession(sessionId);
+                    if (hasPreviousResponseId) {
+                      throw continuationSessionUnavailable(
+                        "previous_response_id cannot be continued because its original websocket cannot accept another turn; send the full conversation input instead",
+                      );
+                    }
                     if (!outputStarted && retries < maxRetries) {
                       retryConnection = true;
                     } else if (!outputStarted) {
@@ -2171,6 +2212,11 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
             await closeWebSocketSession(sessionId);
             if (opts?.signal?.aborted) throw opts.signal.reason ?? error;
             if (sendingRequest && isTransientConnectionError(error)) {
+              if (hasPreviousResponseId) {
+                throw continuationSessionUnavailable(
+                  "previous_response_id continuation has an ambiguous websocket send outcome; send the full conversation input instead",
+                );
+              }
               if (retries < maxRetries) {
                 retryConnection = true;
               } else {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1167,6 +1167,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   const turnStates = new Map<string, string>();
   const websocketMetadataFired = new WeakSet<CodexResponsesWebSocketConnection>();
   const websocketHttpFallbackSessions = new Set<string>();
+  const responseWebsocketSessions = new Map<string, string>();
   const websocketSessions = new Map<
     string,
     {
@@ -1761,6 +1762,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
 
   async function closeWebSocketSession(sessionId: string): Promise<void> {
     websocketHttpFallbackSessions.delete(sessionId);
+    for (const [responseId, ownerSessionId] of responseWebsocketSessions) {
+      if (ownerSessionId === sessionId) responseWebsocketSessions.delete(responseId);
+    }
     const state = websocketSessions.get(sessionId);
     if (!state) return;
     websocketSessions.delete(sessionId);
@@ -1778,6 +1782,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         preamble: boolean;
         terminal: boolean;
         reusable: boolean;
+        responseId: string | null;
       }
     | {
         kind: "rate_limits";
@@ -1942,7 +1947,24 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         type === "response.cancelled" ||
         type === "error",
       reusable: type === "response.completed",
+      responseId:
+        isRecord(event.response) && typeof event.response.id === "string"
+          ? event.response.id
+          : null,
     };
+  }
+
+  function rememberResponseWebSocketSession(responseId: string, sessionId: string): void {
+    // ponytail: recent branches only; raise this existing turn-state-sized bound if
+    // clients prove they legitimately continue responses older than 128 turns.
+    if (
+      !responseWebsocketSessions.has(responseId) &&
+      responseWebsocketSessions.size >= MAX_CODEX_TURN_STATES
+    ) {
+      const oldest = responseWebsocketSessions.keys().next().value;
+      if (oldest !== undefined) responseWebsocketSessions.delete(oldest);
+    }
+    responseWebsocketSessions.set(responseId, sessionId);
   }
 
   async function receiveWebSocketMessage(
@@ -2062,7 +2084,8 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         (!cfg.responsesWebSocketConnector ||
           !sessionId ||
           websocketHttpFallbackSessions.has(sessionId) ||
-          !websocketSessions.has(sessionId))
+          !websocketSessions.has(sessionId) ||
+          responseWebsocketSessions.get(previousResponseId.trim()) !== sessionId)
       ) {
         throw continuationSessionUnavailable(
           "previous_response_id cannot be continued because its original websocket session is unavailable; send the full conversation input instead",
@@ -2188,6 +2211,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                   }
                   await closeWebSocketSession(sessionId);
                   throw event.error;
+                }
+                if (event.responseId !== null) {
+                  rememberResponseWebSocketSession(event.responseId, sessionId);
                 }
                 if (!outputStarted && event.preamble && preambleFrames.length < 2) {
                   preambleFrames.push(event.frame);


### PR DESCRIPTION
## What changed

- keep previous_response_id on its persisted OAuth owner and never probe sibling accounts
- bind each Codex response ID to the exact live upstream WebSocket session that created it
- prevent continuation reconnects, ambiguous replay, and HTTP fallback when state is lost
- reject ownerless OAuth and failed/cancelled/truncated registry parents while preserving completed/incomplete protocol terminals

## Root cause

The durable response registry outlived account-local, WebSocket-local upstream continuation state. Earlier recovery could therefore select another account or a new transport even though neither owned the opaque response ID.

## Impact

Healthy same-WebSocket continuations still work and keep one bounded exact invalid-ID retry. Stateless requests retain normal account failover. Lost or mismatched continuation state now returns an immediate structured invalid request requiring full conversation input, without sibling fanout or silent context loss.

## Validation

- CI=true pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts packages/core/src/provider/openai-responses.test.ts apps/gateway/src/routes/responses.test.ts: 417 passed
- pnpm typecheck
- pnpm lint
- pnpm build
- independent P0/P1 state-machine and adversarial review