### PR TITLE
[codex] Release v0.28.86

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.85",
+  "version": "0.28.86",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump Helm API from `0.28.85` to `0.28.86`
- publish the merged Responses continuation lifecycle fix from PR #789

## Impact

This is a version-only release PR. The release artifact will contain the already-reviewed continuation fixes from exact main SHA `7423e238e126e86582d35fbfff79dcf2a7674595`.

## Validation

- PR #789 exact-head verify, store, e2e, and docker checks passed
- package version readback: `0.28.86`
- `git diff --check`
