### PR TITLE
[codex] revalidate stale provider quota cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,3 +274,35 @@ jobs:
           publish_check "PR / store" "${STORE_RESULT}"
           publish_check "PR / e2e" "${E2E_RESULT}"
           publish_check "PR / docker" "${DOCKER_RESULT}"
+
+  # Organization policy retains this legacy aggregate context. Keep it as a
+  # checkout-free summary of the four distinct gates instead of duplicating their
+  # repository-code work. On PRs it also requires the trusted PR-head reporter;
+  # on main pushes that reporter is intentionally skipped.
+  core_ci:
+    name: Core CI
+    if: always()
+    needs: [verify, store, e2e, docker, report_pr_checks]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require every essential CI boundary
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          STORE_RESULT: ${{ needs.store.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+          DOCKER_RESULT: ${{ needs.docker.result }}
+          REPORT_RESULT: ${{ needs.report_pr_checks.result }}
+        run: |
+          set -euo pipefail
+
+          [[ "${VERIFY_RESULT}" == "success" ]] || { echo "::error::verify: ${VERIFY_RESULT}"; exit 1; }
+          [[ "${STORE_RESULT}" == "success" ]] || { echo "::error::store: ${STORE_RESULT}"; exit 1; }
+          [[ "${E2E_RESULT}" == "success" ]] || { echo "::error::e2e: ${E2E_RESULT}"; exit 1; }
+          [[ "${DOCKER_RESULT}" == "success" ]] || { echo "::error::docker: ${DOCKER_RESULT}"; exit 1; }
+
+          if [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+            [[ "${REPORT_RESULT}" == "success" ]] || { echo "::error::report_pr_checks: ${REPORT_RESULT}"; exit 1; }
+          else
+            [[ "${REPORT_RESULT}" == "skipped" ]] || { echo "::error::unexpected report_pr_checks result: ${REPORT_RESULT}"; exit 1; }
+          fi

--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, untrack } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { invalidateAll } from '$app/navigation';
   import { base } from '$app/paths';
   import { accountDetailHref } from '$lib/oauth-account-id.js';
@@ -102,6 +102,7 @@
   $effect(() => {
     overview = { ...data };
     if (data.loadError) error = data.loadError;
+    scheduleProviderRevalidation();
   });
 
   const keyOf = (providerId: string, account: string): string => `${providerId}/${account}`;
@@ -485,11 +486,77 @@
 
   const REFRESH_POLL_MS = 750;
   const REFRESH_POLL_LIMIT = 160;
+  const PROVIDER_REFRESH_TTL_MS = 60 * 60_000;
+  const QUOTA_PROVIDER_IDS = new Set(['anthropic', 'openai-codex', 'xai']);
   let destroyed = false;
+  let mounted = false;
   let pollGeneration = 0;
+  let providerRevalidationTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastProviderRefreshAttemptAt: number | null = null;
+
+  function clearProviderRevalidationTimer(): void {
+    if (providerRevalidationTimer !== null) {
+      clearTimeout(providerRevalidationTimer);
+      providerRevalidationTimer = null;
+    }
+  }
+
+  function oldestQuotaCapture(): number | null {
+    const snapshots = new Map(
+      overview.quota.map((snapshot) => [keyOf(snapshot.providerId, snapshot.account), snapshot]),
+    );
+    let oldest: number | null = null;
+    for (const provider of overview.providers) {
+      if (!QUOTA_PROVIDER_IDS.has(provider.id)) continue;
+      for (const account of provider.accounts) {
+        const capturedAt = snapshots.get(keyOf(provider.id, account.account))?.capturedAt ?? 0;
+        oldest = oldest === null ? capturedAt : Math.min(oldest, capturedAt);
+      }
+    }
+    return oldest;
+  }
+
+  function scheduleProviderRevalidation(): void {
+    if (!mounted || destroyed) return;
+    clearProviderRevalidationTimer();
+    const capturedAt = oldestQuotaCapture();
+    if (capturedAt === null) return;
+    const staleAt = capturedAt + PROVIDER_REFRESH_TTL_MS;
+    const retryAt = (lastProviderRefreshAttemptAt ?? 0) + PROVIDER_REFRESH_TTL_MS;
+    const delayMs = Math.max(0, Math.max(staleAt, retryAt) - Date.now());
+    providerRevalidationTimer = setTimeout(() => {
+      providerRevalidationTimer = null;
+      void revalidateStaleProviders();
+    }, delayMs);
+  }
+
+  async function revalidateStaleProviders(): Promise<void> {
+    if (destroyed) return;
+    if (document.visibilityState === 'hidden') return;
+    const capturedAt = oldestQuotaCapture();
+    if (capturedAt === null || Date.now() - capturedAt < PROVIDER_REFRESH_TTL_MS) {
+      scheduleProviderRevalidation();
+      return;
+    }
+    await refresh();
+    scheduleProviderRevalidation();
+  }
+
+  function onVisibilityChange(): void {
+    if (document.visibilityState !== 'hidden') scheduleProviderRevalidation();
+  }
+
+  onMount(() => {
+    mounted = true;
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    scheduleProviderRevalidation();
+  });
+
   onDestroy(() => {
     destroyed = true;
     pollGeneration += 1;
+    clearProviderRevalidationTimer();
+    document.removeEventListener('visibilitychange', onVisibilityChange);
   });
 
   function refreshActive(status: OAuthAdminRefreshStatus): boolean {
@@ -506,6 +573,7 @@
       if (!destroyed) {
         overview = next;
         error = null;
+        scheduleProviderRevalidation();
       }
       return next;
     } catch (e) {
@@ -534,6 +602,7 @@
   // is rendered at once, then cache-only polling picks up the completed snapshot.
   async function refresh(): Promise<void> {
     error = null;
+    lastProviderRefreshAttemptAt = Date.now();
     try {
       const queued = await requestOAuthRefresh();
       overview = { ...overview, refresh: queued.status };

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -526,6 +526,95 @@ describe('providers page', () => {
     expect(screen.getByTestId('refresh-interval-10')).toHaveTextContent('10s');
   });
 
+  it('automatically requests one upstream refresh when the cached quota is one hour old', async () => {
+    vi.useFakeTimers();
+    try {
+      const now = Date.UTC(2026, 7, 25, 15, 0);
+      vi.setSystemTime(now);
+      renderPage({
+        quota: [
+          {
+            ...quota[0]!,
+            capturedAt: now - 60 * 60_000,
+          },
+        ],
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(requestOAuthRefresh).toHaveBeenCalledOnce();
+      expect(getOAuthOverview).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('treats a missing quota snapshot for a quota provider as stale', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.UTC(2026, 7, 25, 15, 0));
+      renderPage({ quota: [] });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(requestOAuthRefresh).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waits for a stale background tab to become visible before refreshing upstream', async () => {
+    vi.useFakeTimers();
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    try {
+      const now = Date.UTC(2026, 7, 25, 15, 0);
+      vi.setSystemTime(now);
+      renderPage({
+        quota: [
+          {
+            ...quota[0]!,
+            capturedAt: now - 60 * 60_000,
+          },
+        ],
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(requestOAuthRefresh).not.toHaveBeenCalled();
+
+      visibility.mockReturnValue('visible');
+      await fireEvent(document, new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(requestOAuthRefresh).toHaveBeenCalledOnce();
+    } finally {
+      visibility.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a fresh quota cache until its one-hour freshness window expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const now = Date.UTC(2026, 7, 25, 15, 0);
+      vi.setSystemTime(now);
+      renderPage({
+        quota: [
+          {
+            ...quota[0]!,
+            capturedAt: now,
+          },
+        ],
+      });
+
+      await vi.advanceTimersByTimeAsync(60 * 60_000 - 1);
+      expect(requestOAuthRefresh).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(requestOAuthRefresh).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('shows the latest cached data after the queued refresh completes', async () => {
     const refreshedAt = Date.now();
     getOAuthOverview.mockResolvedValue({
@@ -553,6 +642,29 @@ describe('providers page', () => {
     expect(screen.getByTestId('provider-refresh-status')).toHaveTextContent(
       'refresh available again in 1.5min',
     );
+  });
+
+  it('does not enqueue a second automatic refresh after a manual refresh of stale data', async () => {
+    vi.useFakeTimers();
+    try {
+      const now = Date.UTC(2026, 7, 25, 15, 0);
+      vi.setSystemTime(now);
+      renderPage({
+        quota: [
+          {
+            ...quota[0]!,
+            capturedAt: now - 60 * 60_000,
+          },
+        ],
+      });
+
+      await fireEvent.click(screen.getByTestId('refresh-now'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(requestOAuthRefresh).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('keeps timer-driven auto refresh cache-only', async () => {

--- a/docs/11-admin-ui.md
+++ b/docs/11-admin-ui.md
@@ -171,8 +171,10 @@ never diverge.
     Strategies use sticky sessions, priority, live quota windows, usage cooldowns,
     and reset-credit soft scoring without exposing account labels as client
     models.
-  - **Quota controls** — the page opens from cache-only overview reads; an explicit
-    refresh is globally coordinated and serializes account pulls. It shows today's
+  - **Quota controls** — the page opens from cache-only overview reads; after rendering,
+    a visible page automatically joins the globally coordinated refresh job when any
+    connected quota snapshot is missing or at least one hour old. An explicit refresh
+    remains immediate, and account pulls stay serialized. It shows today's
     served traffic, live quota windows, usage-limit cooldowns, Codex reset-credit
     count, **Test** account action, local **Reset usage**, and guarded Codex
     **Reset limit**. A fresh saturated Codex weekly PULL can enter guarded

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -11,6 +11,7 @@
 
 - **刷新语义**：Providers 首屏继续只读取本地缓存，保证上游慢或不可用时仍立即渲染；Anthropic、Codex、xAI 任一已连接账号的 quota snapshot 缺失或 `capturedAt` 达到 60 分钟后，页面在可见状态自动提交既有全局 refresh job，并继续用 cache-only 轮询接收结果。手动 Refresh 仍是立即强制刷新，用户选择的短周期自动刷新仍不产生 provider 流量。
 - **限流与失败边界**：自动重验证复用后端单任务合并、串行账号 PULL 与 60 秒冷却；同一挂载页面在 snapshot 未变化或刷新失败时最多每小时重试一次，后台隐藏期间不发起同步，重新可见后再按 TTL 判断。旧数据在失败时继续保留并显示既有错误，不把观测缓存过期升级为路由或鉴权失败。未新增 Store、migration、依赖或配置字段。
+- **交付门禁**：组织规则仍要求历史 `Core CI` context，因此 CI 恢复同名 checkout-free 聚合 job；它不重复运行代码，只在 verify、store、e2e、docker 全部成功，并且 PR 场景的可信 head reporter 成功后通过。现有四道独立边界与最小权限保持不变。
 
 ## 2026-08-25 · Responses continuation 不跨账号或 transport 恢复（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-25 · Providers 配额缓存一小时后后台重验证（Admin OAuth providers，docs/11，原则 3/7）
+
+- **刷新语义**：Providers 首屏继续只读取本地缓存，保证上游慢或不可用时仍立即渲染；Anthropic、Codex、xAI 任一已连接账号的 quota snapshot 缺失或 `capturedAt` 达到 60 分钟后，页面在可见状态自动提交既有全局 refresh job，并继续用 cache-only 轮询接收结果。手动 Refresh 仍是立即强制刷新，用户选择的短周期自动刷新仍不产生 provider 流量。
+- **限流与失败边界**：自动重验证复用后端单任务合并、串行账号 PULL 与 60 秒冷却；同一挂载页面在 snapshot 未变化或刷新失败时最多每小时重试一次，后台隐藏期间不发起同步，重新可见后再按 TTL 判断。旧数据在失败时继续保留并显示既有错误，不把观测缓存过期升级为路由或鉴权失败。未新增 Store、migration、依赖或配置字段。
+
 ## 2026-08-25 · Responses continuation 不跨账号或 transport 恢复（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
 
 - **根因修正**：`previous_response_id` 的持久化 provider/account 归属不能证明上游 WebSocket 状态仍存在。OAuth pool 现在只允许已知且可调度的原账号执行；原账号缺失、不可用或过期时在 provider dispatch 前拒绝，不再搜索 sibling。其他无状态请求的账号级 failover 保持不变。
@@ -55,13 +60,9 @@
 - **执行边界**：`POST /v1/videos/extensions` 复用 generation 的鉴权、预算、付费单写 reservation、telemetry、receipt registry 与固定账号 poll；provider 精确发送 `/videos/extensions`，任何 transport/5xx/无 receipt 都返回 `503 outcome_unknown`，不重试、不换账号。未新增 Store、migration、无版本别名或内容代理。
 - **验收与限制**：shared/provider/OAuth/route/OpenAPI 定向测试及 `e2e/videos.spec.ts` 通过；离线 e2e 覆盖四种 30 秒 body、单次 POST、跨 key、账号亲和与重启恢复。2026-08-19 获授权后，本机账号的 30 秒纯文本生成仅 POST 一次，上游链返回 `503 outcome_unknown` 且无 receipt；按单写边界没有重试，extension POST 为 0 次。用户随后确认该环境账号不支持 30 秒；新的 15 秒纯文本 canary 仅 POST 一次，取得 receipt 后经同账号 18 次只读轮询到 `done`，结果 URL 有效，`ffprobe` 实测 15.041667 秒。15 秒单图 canary 使用 `grok-imagine-video-1.5-preview + image` 仅 POST 一次，经 8 次同账号 GET 到 `done`，下载结果同样实测 15.041667 秒。修正前的多图 `grok-imagine-video + reference_images` canary 返回 `503 outcome_unknown` 且无 receipt，没有重放；按 Grok Build 当前合同改为 `grok-imagine-video-1.5 + reference_images` 后，一次本机入站鉴权错误被 Helm 以 401 拒绝且未进入付费链，随后一次有效鉴权的付费 POST 取得 receipt，经同账号 6 次 GET 到 `done`，结果实测 15.041667 秒、1280×720。当前真实证据证明 15 秒纯文本、单图与多图 generation；仍不证明 30 秒或 extension 的真实能力。
 
-## 2026-08-19 · 保留已公开的 Grok Imagine 媒体选项（Images / Videos，Phase 1 spec §4–9，原则 3/6/7）
-
-- **兼容决定**：用户确认 fast image 与 prompt-only video 的已公开选项不得移除。`grok-imagine-image` 继续接受并透传 `n=1..4`、六种 `aspect_ratio`、`resolution=1k` 与 `response_format=b64_json`；`grok-imagine-video` 继续接受并透传 `aspect_ratio`、`duration=6/10/15`、`resolution=480p/720p/1080p` 与 `audio`。合同仍为严格对象，不开放任意未知字段或 ZDR `output`。
-- **边界不变**：此次只恢复请求 schema 兼容性；model/key 授权、blocked model、预算 fail-closed、OAuth 账号选择与固定账号轮询、付费 POST 单写，以及视频 `done` 必须带非空 `video.url` 均保持不变。旧 quality image、single-image video 与 reference-video 路径不改。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-19 · 保留已公开的 Grok Imagine 媒体选项**：恢复 fast image 与 prompt-only video 的既有有界字段，同时保持严格 schema、授权、预算与付费单写边界；完整原文经 git history 回溯。
 - **2026-08-18 · Grok Imagine 合并后收紧 entitlement 与媒体协议边界**：billing 失败以 tombstone/latch fail-closed，公开 alias 与严格视频终态合同保持兼容；完整原文经 git history 回溯。
 - **2026-08-18 · Grok.com Imagine 复用 OAuth 媒体链并以短期 billing 证据授权**：复用新鲜 billing snapshot、付费单写和固定账号轮询，真实 canary 与完整 CI 证据边界经 git history 回溯。
 - **2026-08-15 · 自动 Memory 形成必须挂在项目或资源下**：缺少 project/resource 的入站观察与 eager extraction 跳过，历史孤立 Reflector job 标记失败；完整原文经 git history 回溯。

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -138,6 +138,25 @@ describe("CI workflow", () => {
     expect(report).not.toContain("actions/checkout@");
   });
 
+  it("restores Core CI as a fail-closed aggregate without re-running repository code", () => {
+    const core = jobBlock(raw, "core_ci");
+    expect(core).toContain("name: Core CI");
+    expect(core).toContain("if: always()");
+    expect(core).toContain("needs: [verify, store, e2e, docker, report_pr_checks]");
+    expect(core).toContain("runs-on: ubuntu-24.04");
+    expect(core).toContain("VERIFY_RESULT: ${{ needs.verify.result }}");
+    expect(core).toContain("STORE_RESULT: ${{ needs.store.result }}");
+    expect(core).toContain("E2E_RESULT: ${{ needs.e2e.result }}");
+    expect(core).toContain("DOCKER_RESULT: ${{ needs.docker.result }}");
+    expect(core).toContain("REPORT_RESULT: ${{ needs.report_pr_checks.result }}");
+    expect(core).toContain('[[ "${VERIFY_RESULT}" == "success" ]]');
+    expect(core).toContain('[[ "${STORE_RESULT}" == "success" ]]');
+    expect(core).toContain('[[ "${E2E_RESULT}" == "success" ]]');
+    expect(core).toContain('[[ "${DOCKER_RESULT}" == "success" ]]');
+    expect(core).toContain('[[ "${REPORT_RESULT}" == "success" ]]');
+    expect(core).not.toContain("actions/checkout@");
+  });
+
   it("disables package-manager caching explicitly without enabling pnpm cache", () => {
     expect(raw.match(/package-manager-cache:\s*false/g)).toHaveLength(3);
     expect(raw).not.toMatch(/^\s+cache:\s*(?:pnpm|true)\s*$/m);


### PR DESCRIPTION
## What changed

- keep the Providers first paint cache-only, then automatically enqueue the existing provider refresh job when a connected Anthropic, Codex, or xAI quota snapshot is missing or at least one hour old
- defer upstream work while the Admin tab is hidden and re-evaluate freshness when it becomes visible
- preserve cache-only short-interval polling and prevent a manual refresh from causing a duplicate automatic request
- document the one-hour stale-while-revalidate contract and implementation boundary
- restore the organization-required `Core CI` context as a checkout-free, fail-closed aggregate over `verify`, `store`, `e2e`, `docker`, and the trusted PR-head reporter

## Why

The page previously treated durable quota snapshots as valid forever. Opening or reloading the page only read the cached overview, so provider quota could remain stale indefinitely unless an operator clicked Refresh.

## User impact

Providers still renders immediately from cache. Stale quota now refreshes in the background through the existing globally coalesced, serial provider-refresh coordinator, and the page replaces the snapshot when the job completes.

## Validation

- `CI=true pnpm exec vitest run apps/admin/src/routes/providers/providers.test.ts apps/admin/src/routes/providers/page-load.test.ts apps/admin/src/lib/components/RefreshControl.test.ts apps/admin/src/lib/api/oauth.test.ts` — 89 passed
- `pnpm --filter @helm/admin check` — 0 errors, 0 warnings
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `CI=true pnpm exec vitest run packages/shared/src/ci-workflow.test.ts` — 29 passed
- workflow YAML parse and aggregate success/failure shell-path checks
- Browser QA against the built Admin bundle: stale 81% snapshot automatically changed to fresh 42%, refresh status completed, and console warnings/errors were empty
