### PR TITLE
release: v0.28.87

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.86",
+  "version": "0.28.87",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump Helm API version from `0.28.86` to `0.28.87`
- release the Providers quota auto-refresh and restored `Core CI` aggregate gate merged in #791

## Verification

- `git diff --check`
- parsed `package.json` and confirmed version `0.28.87`
- post-merge CI for #791 passed on `f444ac734912daab798ded8bdc3c0f23e9fd31c5`, including the real `Core CI` job
