### PR TITLE
ci: allow bounded registry retries in docker smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,9 @@ jobs:
   # independent of `verify` (no `needs`) so the unit gates run on their own and
   # neither job blocks the other.
   docker:
-    timeout-minutes: 8
+    # Cold self-hosted builds have twice spent ~8 minutes inside pnpm's bounded
+    # npm-registry retries before the image could reach its smoke-test steps.
+    timeout-minutes: 12
     runs-on: ${{ fromJSON(github.event_name == 'pull_request_target' && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","docker"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/packages/shared/src/ci-workflow.test.ts
+++ b/packages/shared/src/ci-workflow.test.ts
@@ -99,6 +99,11 @@ describe("CI workflow", () => {
     expect(dockerJob).not.toMatch(/needs:/);
   });
 
+  it("gives the Docker smoke enough time to survive bounded registry retries", () => {
+    const dockerJob = jobBlock(raw, "docker");
+    expect(dockerJob).toContain("timeout-minutes: 12");
+  });
+
   it("fetches both parents before validating a pull-request merge ref", () => {
     expect(raw.match(/fetch-depth:\s*2/g)).toHaveLength(4);
   });


### PR DESCRIPTION
## Root cause

Two post-merge Docker jobs on exact main SHAs were cancelled by the 8-minute job timeout while `pnpm install` inside the image build was handling repeated npm registry `ECONNRESET` retries. The first build completed at roughly 8m16s but was cancelled before smoke startup; the second was still resolving packages when cancelled.

## Fix

- raise only the Docker job timeout from 8 to 12 minutes
- retain the real image build, container startup, `/healthz`, and `/version` smoke boundaries
- add a workflow contract test for the measured bound

## Verification

- red: focused workflow test rejected the old 8-minute value
- green: `CI=true pnpm exec vitest run packages/shared/src/ci-workflow.test.ts` (30 passed)
- workflow YAML parsed successfully
- `git diff --check`
