### PR TITLE
fix: preserve Codex continuations across OAuth refresh

### DIFF
--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -326,7 +326,7 @@ describe("admin OAuth routes — read endpoints", () => {
     expect((body.daily[0]?.periodEndMs ?? 0) - (body.daily[0]?.periodStartMs ?? 0)).toBe(DAY);
     // The newest day/week is IN PROGRESS (ends in the future) → marked partial so a
     // half-elapsed bar isn't misread as an allowance drop (grok review CR1).
-    expect(body.daily[0]?.periodEndMs).toBeGreaterThan(Date.now());
+    expect(body.daily[0]?.periodEndMs).toBeGreaterThan(now);
     expect(body.daily[0]?.partial).toBe(true);
     expect(body.weekly[0]?.partial).toBe(true);
     // weekly: at least one 7-day bucket, windowKey "week".

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1,6 +1,8 @@
 import {
   __setWreqModuleForTesting,
+  CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   type CodexModelInfo,
+  type CodexResponsesWebSocketConnection,
   createKeyedSerialGate,
   createRuntimeMemoryCoordinator,
   createSqliteDb,
@@ -29,6 +31,7 @@ import {
   loadCodexCatalogForClientVersion,
   makeProviderFetch,
   normalizeCodexNativeClientVersion,
+  type OAuthPoolReuseCache,
   type OAuthRuntimeCtx,
   resolveProviderTransportProfile,
   resolveXaiMediaEmergencyState,
@@ -1660,6 +1663,164 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect(poolClients.has("openai-codex")).toBe(true);
     const aliases = (providers[0]?.models ?? []).map((m) => m.alias).sort();
     expect(aliases).toEqual(["openai-codex/gpt-5.6-luna", "openai-codex/gpt-5.6-sol"]);
+  });
+
+  it("keeps a live Codex continuation websocket across an unchanged OAuth hot rebuild", async () => {
+    const { ctx, config } = oauthStores();
+    await ctx.store.upsert({
+      providerId: "openai-codex",
+      account: "default",
+      accessEnc: encryptSecret("codex-access", ENC_KEY),
+      refreshEnc: encryptSecret("codex-refresh", ENC_KEY),
+      expiresAt: FAR_FUTURE,
+      meta: JSON.stringify({ accountId: "workspace-42" }),
+      updatedAt: 1,
+    });
+    await setAccountSettings(config, ENC_KEY, "openai-codex", "default", {
+      modelsMode: "manual",
+      enabledModels: ["gpt-5.6-sol"],
+    });
+    const catalog = createCodexModelCatalog({
+      cache: createCodexModelCache(config, ENC_KEY),
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ models: [codexModel("gpt-5.6-sol"), codexModel("gpt-5.6-luna")] }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    const pending: string[] = [];
+    const waiters: Array<(value: string | null) => void> = [];
+    const replies = [
+      [
+        { type: "response.created", response: { id: "resp-parent" } },
+        {
+          type: "response.completed",
+          response: { id: "resp-parent", status: "completed", usage: {} },
+        },
+      ],
+      [
+        { type: "response.created", response: { id: "resp-child" } },
+        {
+          type: "response.completed",
+          response: { id: "resp-child", status: "completed", usage: {} },
+        },
+      ],
+    ];
+    const sent: string[] = [];
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send(text) {
+        sent.push(text);
+        for (const event of replies[sent.length - 1] ?? []) {
+          const payload = JSON.stringify(event);
+          const waiter = waiters.shift();
+          if (waiter) waiter(payload);
+          else pending.push(payload);
+        }
+      },
+      async receive() {
+        const next = pending.shift();
+        if (next !== undefined) return next;
+        return await new Promise<string | null>((resolve) => waiters.push(resolve));
+      },
+      async close() {
+        for (const waiter of waiters.splice(0)) waiter(null);
+      },
+    };
+    const connect = vi.fn(async () => connection);
+    const reuseCache: OAuthPoolReuseCache = new Map();
+    const build = () =>
+      synthesizeOAuthProviders(
+        [],
+        ctx,
+        config,
+        "https://fallback/v1",
+        60_000,
+        noop,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { catalog, runInBackground, responsesWebSocketConnector: connect },
+        undefined,
+        reuseCache,
+      );
+
+    const first = await build();
+    const sessionHeaders = {
+      [CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER]: "ingress-session",
+      "session-id": "client-session",
+    };
+    const drain = async (
+      pool: NonNullable<ReturnType<typeof reuseCache.get>>["pool"],
+      body: Record<string, unknown>,
+    ) => {
+      const chunks: string[] = [];
+      for await (const chunk of pool.nativePassthroughStream?.({
+        protocol: "openai_responses",
+        body,
+        headers: sessionHeaders,
+        mutations: {},
+      }) ?? []) {
+        chunks.push(chunk);
+      }
+      return chunks.join("");
+    };
+    const firstPool = first.poolClients.get("openai-codex");
+    if (!firstPool) throw new Error("expected synthesized Codex pool");
+    expect(
+      await drain(firstPool, {
+        model: "gpt-5.6-sol",
+        input: "parent",
+        stream: true,
+        store: false,
+      }),
+    ).toContain("resp-parent");
+    const second = await build();
+
+    const secondPool = second.poolClients.get("openai-codex");
+    expect(secondPool).toBe(firstPool);
+    if (!secondPool) throw new Error("expected reused Codex pool");
+    expect(
+      await drain(secondPool, {
+        model: "gpt-5.6-sol",
+        input: "child",
+        stream: true,
+        store: false,
+        previous_response_id: "resp-parent",
+      }),
+    ).toContain("resp-child");
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(sent.map((body) => JSON.parse(body))).toEqual([
+      expect.objectContaining({ model: "gpt-5.6-sol" }),
+      expect.objectContaining({ previous_response_id: "resp-parent" }),
+    ]);
+
+    await ctx.store.upsert({
+      providerId: "openai-codex",
+      account: "default",
+      accessEnc: encryptSecret("codex-access", ENC_KEY),
+      refreshEnc: encryptSecret("codex-refresh", ENC_KEY),
+      expiresAt: FAR_FUTURE,
+      meta: JSON.stringify({ accountId: "workspace-42", isFedramp: true }),
+      updatedAt: 2,
+    });
+    const identityChanged = await build();
+    expect(identityChanged.poolClients.get("openai-codex")).not.toBe(secondPool);
+
+    await setAccountSettings(config, ENC_KEY, "openai-codex", "default", {
+      modelsMode: "manual",
+      enabledModels: ["gpt-5.6-luna"],
+    });
+    const modelChanged = await build();
+    expect(modelChanged.poolClients.get("openai-codex")).not.toBe(
+      identityChanged.poolClients.get("openai-codex"),
+    );
   });
 
   it("wires the account-scoped Codex catalog, persisted identity, and model entitlement into the live client", async () => {

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import {
@@ -10,6 +10,7 @@ import {
   buildOpenAICodexUserAgent,
   COPILOT_HEADERS,
   type CodexRateLimitReachedType,
+  type CodexResponsesWebSocketConnector,
   type ConfigStore,
   type CreateKeyInput,
   CURATED_OAUTH_MODELS,
@@ -411,6 +412,7 @@ export interface CodexOAuthRuntime {
   clientVersion?: string;
   userAgent?: string;
   onCatalogChanged?: () => void;
+  responsesWebSocketConnector?: CodexResponsesWebSocketConnector;
 }
 
 interface CodexAccountRuntime {
@@ -422,6 +424,7 @@ interface CodexAccountRuntime {
   userAgent: string;
   runInBackground: CodexOAuthRuntime["runInBackground"];
   onCatalogChanged?: () => void;
+  responsesWebSocketConnector?: CodexResponsesWebSocketConnector;
 }
 
 interface XaiAccountRuntime {
@@ -476,6 +479,7 @@ async function loadCodexAccountCatalog(input: {
   catalog: CodexModelCatalog;
   onCatalogChanged?: () => void;
   runInBackground: CodexOAuthRuntime["runInBackground"];
+  responsesWebSocketConnector?: CodexResponsesWebSocketConnector;
   signal?: AbortSignal;
 }): Promise<LoadedCodexAccountCatalog | null> {
   const clientVersion = normalizeOpenAICodexClientVersion(input.clientVersion);
@@ -529,6 +533,7 @@ async function loadCodexAccountCatalog(input: {
       userAgent,
       runInBackground: input.runInBackground,
       onCatalogChanged: input.onCatalogChanged,
+      responsesWebSocketConnector: input.responsesWebSocketConnector,
     },
   };
 }
@@ -848,6 +853,8 @@ export interface SynthesizedOAuth {
   xaiModelAccounts: Map<string, string[]>;
 }
 
+export type OAuthPoolReuseCache = Map<string, { signature: string; pool: OAuthPoolClient }>;
+
 export interface OAuthQuotaSeed {
   windows: OAuthQuotaWindow[];
   capturedAt: number;
@@ -958,6 +965,9 @@ export async function synthesizeOAuthProviders(
   // root also gives this instance to Admin so status reads and pool rebuilds do
   // not independently call the provider's models endpoint.
   modelDiscoveryCache?: OAuthModelDiscoveryCache,
+  // Hot quota/model refreshes rebuild pool policy, but an unchanged Codex pool owns
+  // live continuation WebSockets that must survive that rebuild.
+  poolReuseCache?: OAuthPoolReuseCache,
 ): Promise<SynthesizedOAuth> {
   if (!oauthCtx) {
     return {
@@ -1001,6 +1011,7 @@ export async function synthesizeOAuthProviders(
     const members: OAuthPoolMember[] = [];
     const unionModels = new Set<string>();
     const unionWireModels = new Map<string, string>();
+    const codexMemberSignatures: Array<Record<string, unknown>> = [];
     for (const account of accounts) {
       const s = getAccountSettings(accountSettings, providerId, account);
       const queueKey = `${providerId} ${account}`;
@@ -1115,6 +1126,7 @@ export async function synthesizeOAuthProviders(
           catalog: codex.catalog,
           runInBackground: codex.runInBackground,
           onCatalogChanged: codex.onCatalogChanged,
+          responsesWebSocketConnector: codex.responsesWebSocketConnector,
         });
         discovered = loaded
           ? expandOpenAICodexModelAliases(
@@ -1210,6 +1222,19 @@ export async function synthesizeOAuthProviders(
         log("warn", "oauth.autoroute.no_models", { providerId, account });
         continue;
       }
+      if (providerId === "openai-codex") {
+        codexMemberSignatures.push({
+          account,
+          priority: s.priority ?? 50,
+          fastMode: s.fastMode === true,
+          allowSpendRemainingCredits: s.allowSpendRemainingCredits === true,
+          models: [...memberModels].sort(),
+          proxy: proxy ?? null,
+          accountIdentity: accountCodexRuntime?.accountIdentity ?? null,
+          clientVersion: accountCodexRuntime?.clientVersion ?? null,
+          userAgent: accountCodexRuntime?.userAgent ?? null,
+        });
+      }
       // Bind the quota-header scrape to THIS account (providers page Tier 3): the
       // Codex client invokes it with each reply's headers; synthesis closes over the
       // account so the snapshot is attributed correctly. undefined ⇒ no capture.
@@ -1285,7 +1310,7 @@ export async function synthesizeOAuthProviders(
     }
     // ONE pool client per provider, keyed by providerId. onSelect records the
     // serving account (Stage 3 telemetry) — a non-secret structured log line.
-    const pool = createOAuthPoolClient({
+    let pool = createOAuthPoolClient({
       members,
       now: () => Date.now(),
       selectionStrategy,
@@ -1320,6 +1345,37 @@ export async function synthesizeOAuthProviders(
       nativeStreamPreambleClassifier: preOutputClassifierFor(spec.targetProviderProtocol),
       chatStreamPreambleClassifier: preOutputClassifierFor("openai_chat"),
     });
+    if (providerId === "openai-codex" && poolReuseCache) {
+      const signature = createHash("sha256")
+        .update(
+          JSON.stringify({
+            baseUrl: spec.baseUrl ?? fallbackBaseUrl,
+            timeoutMs,
+            selectionStrategy,
+            members: codexMemberSignatures.sort((a, b) =>
+              String(a.account).localeCompare(String(b.account)),
+            ),
+          }),
+        )
+        .digest("hex");
+      const previous = poolReuseCache.get(providerId);
+      if (previous?.signature === signature) {
+        pool = previous.pool;
+        for (const member of members) {
+          pool.seedUsageLimit(member.account, member.usageLimitedUntilMs ?? null);
+          if (member.quotaWindows && member.quotaCapturedAtMs != null) {
+            pool.setQuotaSnapshot(
+              member.account,
+              member.quotaWindows,
+              member.quotaCapturedAtMs,
+              member.quotaResetCredits,
+            );
+          }
+        }
+      } else {
+        poolReuseCache.set(providerId, { signature, pool });
+      }
+    }
     poolClients.set(providerId, pool);
     providers.push({
       name: providerId,
@@ -1343,6 +1399,7 @@ export async function synthesizeOAuthProviders(
       selection_strategy: selectionStrategy,
     });
   }
+  if (!poolClients.has("openai-codex")) poolReuseCache?.delete("openai-codex");
   return { providers, poolClients, codexKeys, xaiModels, xaiModelAccounts };
 }
 
@@ -1609,10 +1666,12 @@ function createProviderClient(
               );
             }
           : undefined,
-        responsesWebSocketConnector: createCodexResponsesWebSocketConnector({
-          proxy,
-          timeoutMs: base.timeoutMs,
-        }),
+        responsesWebSocketConnector:
+          codexRuntime?.responsesWebSocketConnector ??
+          createCodexResponsesWebSocketConnector({
+            proxy,
+            timeoutMs: base.timeoutMs,
+          }),
       },
       fetch: providerFetch,
     });
@@ -2847,6 +2906,7 @@ export async function buildServer(
       timeoutMs: settings.user_message_queue_wait_timeout_ms,
     }),
   };
+  const oauthPoolReuseCache: OAuthPoolReuseCache = new Map();
   const synthesizedOAuth = await synthesizeOAuthProviders(
     config.providers,
     oauthCtx,
@@ -2861,6 +2921,7 @@ export async function buildServer(
     markOAuthCredentialFailureLater,
     codexRuntime,
     oauthModelDiscoveryCache,
+    oauthPoolReuseCache,
   );
   const routableProviders: ProviderConfigShared[] = [
     ...config.providers,
@@ -3023,6 +3084,7 @@ export async function buildServer(
           markOAuthCredentialFailureLater,
           codexRuntime,
           oauthModelDiscoveryCache,
+          oauthPoolReuseCache,
         );
         const nextAliasSet = aliasSetOf(next);
         const nextWireModelMap = wireModelsOf(next);

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-26 · OAuth 热刷新保留未变化的 Codex continuation transport（OAuth provider / Responses，docs/04/05/07/11，原则 3/5/8）
+
+- **生产根因与修复**：全局 `POST /admin/api/oauth/refresh` 会重建所有 OAuth pool；即使 Codex 账号、代理、模型与执行设置均未变化，也会替换持有上游 WebSocket 和 `response_id → session` 映射的 `openai-codex` client，使仍活跃的下游 session 下一轮在本地收到 `previous_response_id_session_unavailable`。composition root 现在保留一个进程级复用缓存；重建后的 Codex pool 拓扑与 transport 身份签名完全相同时复用原 pool/client，并原位刷新 quota/cooldown 信号。
+- **失效边界**：账号集合、模型、优先级、Fast mode、剩余额度策略、代理、ChatGPT account identity、Codex client identity、base URL、timeout 或 selection strategy 任一变化都会创建新 pool；真正的配置/身份变化、进程重启、原 WebSocket 关闭仍保持原有 fail-closed 400，不跨账号、不重连 opaque ID、不伪造完整历史。无 schema、migration、依赖或配置字段变化。
+
 ## 2026-08-25 · Providers 配额缓存一小时后后台重验证（Admin OAuth providers，docs/11，原则 3/7）
 
 - **刷新语义**：Providers 首屏继续只读取本地缓存，保证上游慢或不可用时仍立即渲染；Anthropic、Codex、xAI 任一已连接账号的 quota snapshot 缺失或 `capturedAt` 达到 60 分钟后，页面在可见状态自动提交既有全局 refresh job，并继续用 cache-only 轮询接收结果。手动 Refresh 仍是立即强制刷新，用户选择的短周期自动刷新仍不产生 provider 流量。
@@ -55,14 +60,9 @@
 - **根因与修复**：生产证据显示多个刚成功的同账号续接约一秒后收到上游 `400 Invalid previous_response_id`，且成功与失败请求使用相同 native sanitizer；这不是账号轮换或正文变换。provider 现在只在首个客户端可见输出前、只针对该精确 400，在同一上游 WebSocket 上原样重发一次，吸收短暂的上游状态传播竞态。
 - **安全边界**：重试不删除 `previous_response_id`、不换账号/模型、不重建正文，也不占用连接重建预算；第二次相同错误继续关闭 session 并 fail-closed，避免确定性坏 ID 循环或上下文串线。无 schema、配置或依赖变化。
 
-## 2026-08-19 · Grok 视频统一 30 秒并复用单写链增加扩展接口（Videos，扩展方案 §4–7，原则 2/3/6/7）
-
-- **统一合同**：纯文本、单图、多图与 extension 共用 `6 | 10 | 15 | 30` 时长；单图 stable/preview 名称复用既有 preview entitlement，但 stable 请求仍以 `grok-imagine-video-1.5` 原样发送。当前 Grok Build 证明多图上游 wire 为 stable `grok-imagine-video-1.5 + reference_images: [{ url }]`；Helm 因此只允许 stable 1.5 多图 model，并把严格互斥的兼容入参 `images` 在付费 POST 前统一转成 `reference_images`，不做单图/多图升降级。
-- **执行边界**：`POST /v1/videos/extensions` 复用 generation 的鉴权、预算、付费单写 reservation、telemetry、receipt registry 与固定账号 poll；provider 精确发送 `/videos/extensions`，任何 transport/5xx/无 receipt 都返回 `503 outcome_unknown`，不重试、不换账号。未新增 Store、migration、无版本别名或内容代理。
-- **验收与限制**：shared/provider/OAuth/route/OpenAPI 定向测试及 `e2e/videos.spec.ts` 通过；离线 e2e 覆盖四种 30 秒 body、单次 POST、跨 key、账号亲和与重启恢复。2026-08-19 获授权后，本机账号的 30 秒纯文本生成仅 POST 一次，上游链返回 `503 outcome_unknown` 且无 receipt；按单写边界没有重试，extension POST 为 0 次。用户随后确认该环境账号不支持 30 秒；新的 15 秒纯文本 canary 仅 POST 一次，取得 receipt 后经同账号 18 次只读轮询到 `done`，结果 URL 有效，`ffprobe` 实测 15.041667 秒。15 秒单图 canary 使用 `grok-imagine-video-1.5-preview + image` 仅 POST 一次，经 8 次同账号 GET 到 `done`，下载结果同样实测 15.041667 秒。修正前的多图 `grok-imagine-video + reference_images` canary 返回 `503 outcome_unknown` 且无 receipt，没有重放；按 Grok Build 当前合同改为 `grok-imagine-video-1.5 + reference_images` 后，一次本机入站鉴权错误被 Helm 以 401 拒绝且未进入付费链，随后一次有效鉴权的付费 POST 取得 receipt，经同账号 6 次 GET 到 `done`，结果实测 15.041667 秒、1280×720。当前真实证据证明 15 秒纯文本、单图与多图 generation；仍不证明 30 秒或 extension 的真实能力。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-19 · Grok 视频统一时长并复用单写链增加扩展接口**：generation/extension 共用严格媒体合同、付费单写与固定账号轮询；真实 canary 只证明 15 秒纯文本、单图和多图，30 秒与 extension 仍未获能力证明；完整原文经 git history 回溯。
 - **2026-08-19 · 保留已公开的 Grok Imagine 媒体选项**：恢复 fast image 与 prompt-only video 的既有有界字段，同时保持严格 schema、授权、预算与付费单写边界；完整原文经 git history 回溯。
 - **2026-08-18 · Grok Imagine 合并后收紧 entitlement 与媒体协议边界**：billing 失败以 tombstone/latch fail-closed，公开 alias 与严格视频终态合同保持兼容；完整原文经 git history 回溯。
 - **2026-08-18 · Grok.com Imagine 复用 OAuth 媒体链并以短期 billing 证据授权**：复用新鲜 billing snapshot、付费单写和固定账号轮询，真实 canary 与完整 CI 证据边界经 git history 回溯。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1145,6 +1145,67 @@ describe("createOAuthPoolClient — account selection", () => {
     expect(() => pool.setUsageLimit("nope", 5_000)).not.toThrow();
   });
 
+  it("re-seeds an account usage limit without clearing a live model cooldown", async () => {
+    const served: string[] = [];
+    let nowMs = 1_000;
+    let scopedFailures = 1;
+    const scoped429 = new UpstreamError(
+      "upstream_error",
+      "usage limit",
+      { headers: { "x-codex-active-limit": "codex_luna" } },
+      429,
+    );
+    const mk = (account: string, priority: number): OAuthPoolMember => ({
+      account,
+      priority,
+      schedulable: true,
+      client: {
+        async chatCompletion() {
+          return { served_by: account };
+        },
+        async *chatCompletionStream() {
+          yield `data: ${account}\n\n`;
+        },
+        nativePassthroughStream(body: Record<string, unknown>): AsyncIterable<string> {
+          return (async function* () {
+            if (account === "a" && body.model === "gpt-5.6-luna" && scopedFailures-- > 0) {
+              throw scoped429;
+            }
+            served.push(account);
+            yield `data: ${account}\n\n`;
+          })();
+        },
+      },
+    });
+    const pool = createOAuthPoolClient({
+      members: [mk("a", 10), mk("b", 50)],
+      now: () => nowMs,
+      accountRateLimitCooldownMs: 250,
+      resolveRateLimitScope: ({ model, error }) =>
+        error === scoped429
+          ? { scope: "model", model: model ?? "", limitId: "codex_luna" }
+          : { scope: "account" },
+    });
+    const drain = async (): Promise<void> => {
+      for await (const _chunk of pool.nativePassthroughStream?.({
+        model: "gpt-5.6-luna",
+        stream: true,
+        input: "hi",
+      }) ?? []) {
+        // Drain so selection and cooldown state are observable.
+      }
+    };
+
+    await drain();
+    pool.seedUsageLimit("a", null);
+    await drain();
+
+    expect(served).toEqual(["b", "b"]);
+    nowMs = 1_251;
+    await drain();
+    expect(served.at(-1)).toBe("a");
+  });
+
   it("does not pin a sticky session to a now-limited account", async () => {
     const pt: string[] = [];
     const clock = 1_000;

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -155,6 +155,9 @@ export type OAuthSelectionStrategy = "balanced" | "manual_priority" | "low_risk"
 export interface OAuthPoolClient extends ProviderClient {
   hasAvailableModel(model: string): boolean;
   setUsageLimit(account: string, untilMs: number | null): void;
+  // Restore only the persisted account-wide park after a hot rebuild. Unlike the
+  // explicit reset path above, this must preserve transient/model-scoped cooldowns.
+  seedUsageLimit(account: string, untilMs: number | null): void;
   // The account's current auto-park cooldown (epoch ms), or null if eligible now. Lets
   // the gateway make a park EXTEND-ONLY — never shorten a precise quota reset already set.
   getUsageLimit(account: string): number | null;
@@ -1223,6 +1226,10 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
           if (cooldown.account === account) scopedRateLimits.delete(key);
         }
       }
+    },
+    seedUsageLimit(account: string, untilMs: number | null): void {
+      const entry = entries.find((e) => e.member.account === account);
+      if (entry) entry.member.usageLimitedUntilMs = untilMs;
     },
     getUsageLimit(account: string): number | null {
       return entries.find((e) => e.member.account === account)?.member.usageLimitedUntilMs ?? null;


### PR DESCRIPTION
## Root cause
A global OAuth refresh rebuilt every provider pool. The rebuilt Codex Responses client lost its live WebSocket and in-memory `response_id -> session` mapping, so an otherwise valid continuation failed locally with `previous_response_id_session_unavailable` before any upstream call.

## Fix
- Reuse an unchanged Codex pool/client across OAuth hot rebuilds.
- Fingerprint transport and identity inputs, including FedRAMP identity, and replace the pool on material changes.
- Re-seed persisted account quota state without clearing transient/model-scoped cooldowns.
- Keep the strict fail-closed continuation boundary: no sibling account, reconnect, or opaque-ID replay.
- Add a real parent → hot rebuild → `previous_response_id` continuation test on one injected WebSocket.

## Verification
- `CI=true pnpm exec vitest run apps/gateway/src/server.oauth.test.ts packages/core/src/provider/oauth/pool.test.ts` — 165 passed.
- `CI=true pnpm typecheck` — passed.
- `CI=true pnpm lint` — passed.
- `CI=true pnpm build` — passed.
- `git diff --check` — passed.

The full Responses test file was also attempted locally, but the host's existing ~5.6 GB Ollama process caused the repository's runtime memory admission guard to reject unrelated cases; no source assertion failure was observed in the changed-path tests. Required CI remains the clean-environment gate.
