### PR TITLE
release: v0.28.88

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.87",
+  "version": "0.28.88",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
Bump Helm API from `0.28.87` to `0.28.88` after the merged Codex continuation hot-refresh fix in #794.

## Scope
- Version-only release change in `package.json`.
- No schema, migration, dependency, or configuration changes.

## Verification
- `git diff --check`
- Full required PR CI must pass for exact head `8c4a19f0` before merge.
