### PR TITLE
fix: harden Responses websocket recovery

### DIFF
--- a/apps/gateway/src/codex-responses-websocket.test.ts
+++ b/apps/gateway/src/codex-responses-websocket.test.ts
@@ -151,6 +151,58 @@ describe("createCodexResponsesWebSocketConnector", () => {
     await expect(settlePromptly(connection.receive())).rejects.toThrow(Error);
   });
 
+  it("keeps an idle upstream websocket alive with ping and pong", async () => {
+    const server = createServer();
+    const websocketServer = new WebSocketServer({ noServer: true });
+    server.on("upgrade", (request, socket, head) => {
+      websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+        websocketServer.emit("connection", websocket, request);
+      });
+    });
+    const serverConnection = once(websocketServer, "connection");
+    const port = await listen(server);
+    const connector = createCodexResponsesWebSocketConnector({
+      timeoutMs: 2_000,
+      keepAliveIntervalMs: 20,
+      keepAliveTimeoutMs: 100,
+    });
+    const connection = await connector({
+      url: `ws://127.0.0.1:${port}/responses`,
+      headers: {},
+    });
+    connections.push(connection);
+    const [serverSocket] = (await serverConnection) as [WebSocket];
+
+    await settlePromptly(once(serverSocket, "ping"));
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    await expect(connection.send('{"type":"response.create"}')).resolves.toBeUndefined();
+  });
+
+  it("terminates an idle upstream websocket that does not pong", async () => {
+    const server = createServer();
+    const websocketServer = new WebSocketServer({ noServer: true, autoPong: false });
+    server.on("upgrade", (request, socket, head) => {
+      websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+        websocketServer.emit("connection", websocket, request);
+      });
+    });
+    const port = await listen(server);
+    const connector = createCodexResponsesWebSocketConnector({
+      timeoutMs: 2_000,
+      keepAliveIntervalMs: 20,
+      keepAliveTimeoutMs: 30,
+    });
+    const connection = await connector({
+      url: `ws://127.0.0.1:${port}/responses`,
+      headers: {},
+    });
+    connections.push(connection);
+
+    await expect(settlePromptly(connection.receive())).rejects.toThrow(
+      "Codex Responses websocket keepalive timed out",
+    );
+  });
+
   it("closes an upstream connection when unread messages exceed the dynamic pending budget", async () => {
     const server = createServer();
     const websocketServer = new WebSocketServer({ noServer: true });

--- a/apps/gateway/src/codex-responses-websocket.ts
+++ b/apps/gateway/src/codex-responses-websocket.ts
@@ -17,6 +17,8 @@ import WebSocket, { type RawData } from "ws";
 export interface CodexResponsesWebSocketConnectorOptions {
   proxy?: ProxyConfig;
   timeoutMs?: number;
+  keepAliveIntervalMs?: number;
+  keepAliveTimeoutMs?: number;
   maxPayloadBytes?: number;
   maxPendingBytes?: number;
   responseWorkAdmission?: ResponseWorkAdmission;
@@ -56,21 +58,28 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
     reject: (error: Error) => void;
   }> = [];
   private terminal: Error | null | undefined;
+  private keepAliveTimer: ReturnType<typeof setTimeout> | undefined;
+  private keepAliveTimeout: ReturnType<typeof setTimeout> | undefined;
 
   constructor(
     private readonly socket: WebSocket,
     headers: Headers,
     private readonly maxPendingBytes: number,
     private readonly responseWorkAdmission: ResponseWorkAdmission,
+    private readonly keepAliveIntervalMs: number,
+    private readonly keepAliveTimeoutMs: number,
   ) {
     this.responseHeaders = headers;
     socket.on("message", (data) => this.enqueueMessage(data));
     socket.on("close", () => this.terminate(null));
     socket.on("error", (error) => this.terminate(error));
+    socket.on("pong", () => this.handlePong());
+    this.scheduleKeepAlive();
   }
 
   private terminate(value: Error | null): void {
     if (this.terminal !== undefined) return;
+    this.clearKeepAlive();
     this.terminal = value;
     for (const pending of this.pending.splice(0)) pending.release();
     this.pendingBytes = 0;
@@ -78,6 +87,39 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
       if (value instanceof Error) waiter.reject(value);
       else waiter.resolve(value);
     }
+  }
+
+  private clearKeepAlive(): void {
+    clearTimeout(this.keepAliveTimer);
+    clearTimeout(this.keepAliveTimeout);
+    this.keepAliveTimer = undefined;
+    this.keepAliveTimeout = undefined;
+  }
+
+  private scheduleKeepAlive(): void {
+    this.keepAliveTimer = setTimeout(() => {
+      if (this.terminal !== undefined || this.socket.readyState !== WebSocket.OPEN) return;
+      this.keepAliveTimeout = setTimeout(() => {
+        const error = new Error("Codex Responses websocket keepalive timed out");
+        this.terminate(error);
+        this.socket.terminate();
+      }, this.keepAliveTimeoutMs);
+      this.keepAliveTimeout.unref?.();
+      try {
+        this.socket.ping();
+      } catch (error) {
+        this.terminate(error instanceof Error ? error : new Error("websocket ping failed"));
+        this.socket.terminate();
+      }
+    }, this.keepAliveIntervalMs);
+    this.keepAliveTimer.unref?.();
+  }
+
+  private handlePong(): void {
+    if (this.keepAliveTimeout === undefined) return;
+    clearTimeout(this.keepAliveTimeout);
+    this.keepAliveTimeout = undefined;
+    this.scheduleKeepAlive();
   }
 
   private capacityError(): Error {
@@ -167,6 +209,7 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
   }
 
   async close(): Promise<void> {
+    this.clearKeepAlive();
     if (this.socket.readyState === WebSocket.CLOSED) return;
     await new Promise<void>((resolve) => {
       const timer = setTimeout(() => {
@@ -238,6 +281,8 @@ export function createCodexResponsesWebSocketConnector(
   );
   const maxPendingBytes = Math.max(1, Math.floor(options.maxPendingBytes ?? maxPayloadBytes));
   const responseWorkAdmission = options.responseWorkAdmission ?? runtimeResponseWorkAdmission();
+  const keepAliveIntervalMs = Math.max(1, Math.floor(options.keepAliveIntervalMs ?? 60_000));
+  const keepAliveTimeoutMs = Math.max(1, Math.floor(options.keepAliveTimeoutMs ?? 15_000));
 
   return async ({ url, headers, signal }) =>
     await new Promise<CodexResponsesWebSocketConnection>((resolve, reject) => {
@@ -284,7 +329,14 @@ export function createCodexResponsesWebSocketConnector(
         settled = true;
         cleanup();
         resolve(
-          new WsCodexConnection(socket, upgradeHeaders, maxPendingBytes, responseWorkAdmission),
+          new WsCodexConnection(
+            socket,
+            upgradeHeaders,
+            maxPendingBytes,
+            responseWorkAdmission,
+            keepAliveIntervalMs,
+            keepAliveTimeoutMs,
+          ),
         );
       });
       socket.once("unexpected-response", (request, response) => {

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -1351,10 +1351,10 @@ describe("Responses websocket bridge", () => {
   });
 
   it.each([
-    "response.failed",
-    "response.incomplete",
-    "error",
-  ] as const)("keeps the downstream websocket reusable after %s", async (terminalType) => {
+    ["response.failed", 1],
+    ["response.incomplete", 0],
+    ["error", 1],
+  ] as const)("keeps the downstream websocket reusable after %s", async (terminalType, closes) => {
     let closedSessionId = "";
     let closeSessionCalls = 0;
     let requestCount = 0;
@@ -1411,8 +1411,8 @@ describe("Responses websocket bridge", () => {
     expect(failed.at(-1)?.type).toBe(terminalType);
     expect(recovered.at(-1)?.type).toBe("response.completed");
     expect(socket.readyState).toBe(WebSocket.OPEN);
-    expect(closedSessionId).not.toBe("");
-    expect(closeSessionCalls).toBe(1);
+    expect(closedSessionId === "").toBe(closes === 0);
+    expect(closeSessionCalls).toBe(closes);
   });
 
   it("swallows a synchronous session cleanup failure", async () => {

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -403,7 +403,7 @@ async function forwardResponse(
   }
   if (terminalType !== undefined) {
     void body.cancel().catch(() => {});
-    return terminalType !== "response.completed";
+    return terminalType !== "response.completed" && terminalType !== "response.incomplete";
   }
   if (!signal.aborted) {
     throw new Error("Responses stream ended before a terminal event");

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-26 · Codex Responses WebSocket 保活与已确认请求禁止重放（Responses / Gateway，docs/05/07，原则 3/8）
+
+- **空闲连接恢复**：上游 Codex WebSocket 现在每 60 秒发送协议 Ping，并要求 15 秒内收到 Pong；超时立即终止半开连接，让仍未发送的新请求在本地明确失败。测试可缩短两个时限，生产配置与协议正文不变。
+- **会话与单写边界**：`response.incomplete` 与 core 已有语义一致，继续保留同一上游 session 供 `previous_response_id` 续接；`failed`、`cancelled` 与 `error` 仍关闭。上游一旦发出 `response.created`/`response.in_progress` 即视为已接收 `response.create`，随后断连不再重连或回落 HTTP 重放，避免重复推理、工具副作用与计费；已有状态丢失仍要求客户端发送完整历史。
+
 ## 2026-08-26 · OAuth 热刷新保留未变化的 Codex continuation transport（OAuth provider / Responses，docs/04/05/07/11，原则 3/5/8）
 
 - **生产根因与修复**：全局 `POST /admin/api/oauth/refresh` 会重建所有 OAuth pool；即使 Codex 账号、代理、模型与执行设置均未变化，也会替换持有上游 WebSocket 和 `response_id → session` 映射的 `openai-codex` client，使仍活跃的下游 session 下一轮在本地收到 `previous_response_id_session_unavailable`。composition root 现在保留一个进程级复用缓存；重建后的 Codex pool 拓扑与 transport 身份签名完全相同时复用原 pool/client，并原位刷新 quota/cooldown 信号。
@@ -55,13 +60,9 @@
 - 重置边界记录新增可空 `usedPercent`，仅在以后观测到周期关闭时从上游快照写入；旧行不回填，无法证明的近似/日周聚合继续显示空值。
 - SQLite/Postgres 各新增一次可空列迁移；当前周期仅使用未过期快照，避免把上一周期百分比套到新周期。
 
-## 2026-08-19 · Codex Responses 续接 ID 在原 WebSocket 上做一次有界恢复（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
-
-- **根因与修复**：生产证据显示多个刚成功的同账号续接约一秒后收到上游 `400 Invalid previous_response_id`，且成功与失败请求使用相同 native sanitizer；这不是账号轮换或正文变换。provider 现在只在首个客户端可见输出前、只针对该精确 400，在同一上游 WebSocket 上原样重发一次，吸收短暂的上游状态传播竞态。
-- **安全边界**：重试不删除 `previous_response_id`、不换账号/模型、不重建正文，也不占用连接重建预算；第二次相同错误继续关闭 session 并 fail-closed，避免确定性坏 ID 循环或上下文串线。无 schema、配置或依赖变化。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-19 · Codex Responses 续接 ID 在原 WebSocket 上做一次有界恢复**：仅在首个客户端可见输出前、针对精确 `Invalid previous_response_id` 在同一活动 WebSocket 原样重发一次；第二次仍失败则 fail-closed，完整原文经 git history 回溯。
 - **2026-08-19 · Grok 视频统一时长并复用单写链增加扩展接口**：generation/extension 共用严格媒体合同、付费单写与固定账号轮询；真实 canary 只证明 15 秒纯文本、单图和多图，30 秒与 extension 仍未获能力证明；完整原文经 git history 回溯。
 - **2026-08-19 · 保留已公开的 Grok Imagine 媒体选项**：恢复 fast image 与 prompt-only video 的既有有界字段，同时保持严格 schema、授权、预算与付费单写边界；完整原文经 git history 回溯。
 - **2026-08-18 · Grok Imagine 合并后收紧 entitlement 与媒体协议边界**：billing 失败以 tombstone/latch fail-closed，公开 alias 与严格视频终态合同保持兼容；完整原文经 git history 回溯。

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -2854,7 +2854,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(chunks.join("")).toContain("response.completed");
   });
 
-  it("reconnects after a preamble-only websocket close without replaying its preamble", async () => {
+  it("does not replay a response.create after the upstream acknowledged it", async () => {
     let firstCloseCalls = 0;
     let firstReceiveCalls = 0;
     const first: CodexResponsesWebSocketConnection = {
@@ -2890,24 +2890,122 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
         connectRetryBackoffMs: [0],
       },
     });
-    const chunks: string[] = [];
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-preamble-reconnect", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
 
-    for await (const chunk of client.nativePassthroughStream?.(
-      carrier("ingress-preamble-reconnect", {
+    await expect(iterator?.next()).rejects.toThrow(
+      "upstream websocket closed after acknowledging response.create",
+    );
+    expect(firstCloseCalls).toBe(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry invalid previous_response_id after the upstream acknowledged it", async () => {
+    const connection = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-parent" } },
+        { type: "response.completed", response: { id: "resp-parent", status: "completed" } },
+      ],
+      [
+        { type: "response.created", response: { id: "resp-acknowledged" } },
+        {
+          type: "error",
+          status: 400,
+          error: {
+            type: "invalid_request_error",
+            message: "Invalid `previous_response_id`.",
+          },
+        },
+      ],
+    ]);
+    const connect = vi.fn(async () => connection);
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_acknowledged_invalid_previous")}`,
+        responsesWebSocketConnector: connect,
+      },
+    });
+    for await (const _chunk of client.nativePassthroughStream?.(
+      carrier("ingress-acknowledged-invalid-previous", {
         model: "gpt-5.6-sol",
         input: [],
         stream: true,
         store: false,
       }),
     ) ?? []) {
-      chunks.push(chunk);
+      // Establish the parent on the original websocket.
     }
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-acknowledged-invalid-previous", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+          previous_response_id: "resp-parent",
+        }),
+      )
+      [Symbol.asyncIterator]();
 
-    const output = chunks.join("");
-    expect(firstCloseCalls).toBe(1);
-    expect(connect).toHaveBeenCalledTimes(2);
-    expect(output.match(/event: response\.created/g)).toHaveLength(1);
-    expect(output).toContain("response.completed");
+    await expect(iterator?.next()).rejects.toThrow(
+      "upstream websocket closed after acknowledging response.create",
+    );
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connection.sent).toHaveLength(2);
+  });
+
+  it("does not reconnect after an acknowledged websocket connection-limit error", async () => {
+    const first = fakeConnection([
+      [
+        { type: "response.in_progress" },
+        {
+          type: "error",
+          status: 400,
+          error: {
+            code: "websocket_connection_limit_reached",
+            message: "Create a new websocket connection to continue.",
+          },
+        },
+      ],
+    ]);
+    const second = fakeConnection([]);
+    const connect = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    const fetchMock = vi.fn();
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_acknowledged_connection_limit")}`,
+        responsesWebSocketConnector: connect,
+        connectRetries: 1,
+        connectRetryBackoffMs: [0],
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-acknowledged-connection-limit", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toThrow(
+      "upstream websocket closed after acknowledging response.create",
+    );
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("commits repeated websocket preambles instead of buffering them without bound", async () => {
@@ -2951,57 +3049,6 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect((await iterator?.next())?.value).toContain("response.created");
     expect(fetchMock).not.toHaveBeenCalled();
     await iterator?.return?.();
-  });
-
-  it("falls back to HTTP after preamble-only websocket closes exhaust retries", async () => {
-    let closeCalls = 0;
-    const connect = vi.fn(async (): Promise<CodexResponsesWebSocketConnection> => {
-      let receiveCalls = 0;
-      return {
-        responseHeaders: new Headers(),
-        async send() {},
-        async receive() {
-          receiveCalls += 1;
-          return receiveCalls === 1 ? JSON.stringify({ type: "response.created" }) : null;
-        },
-        async close() {
-          closeCalls += 1;
-        },
-      };
-    });
-    const fetchMock = vi.fn(async () =>
-      rawSSEResponse(
-        'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n\n',
-      ),
-    );
-    const client = createCodexResponsesClient({
-      config: {
-        baseUrl: "https://chatgpt.com/backend-api/codex",
-        getAuthHeader: async () => `Bearer ${jwt("acct_preamble_fallback")}`,
-        responsesWebSocketConnector: connect,
-        connectRetries: 1,
-        connectRetryBackoffMs: [0],
-      },
-      fetch: fetchMock as unknown as typeof fetch,
-    });
-    const chunks: string[] = [];
-
-    for await (const chunk of client.nativePassthroughStream?.(
-      carrier("ingress-preamble-fallback", {
-        model: "gpt-5.6-sol",
-        input: [],
-        stream: true,
-        store: false,
-      }),
-    ) ?? []) {
-      chunks.push(chunk);
-    }
-
-    expect(connect).toHaveBeenCalledTimes(2);
-    expect(closeCalls).toBe(2);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(chunks.join("")).not.toContain("response.created");
-    expect(chunks.join("")).toContain("response.completed");
   });
 
   it("requeues a same-session request after an ECANCELED connection is replaced", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1710,6 +1710,13 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     );
   }
 
+  function acknowledgedResponseCreateError(): UpstreamError {
+    return new UpstreamError(
+      "upstream_error",
+      "upstream websocket closed after acknowledging response.create",
+    );
+  }
+
   function websocketSessionId(input: NativePassthroughInput): string | undefined {
     return nativeHeader(input, CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER);
   }
@@ -2161,6 +2168,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                     "upstream websocket closed before a terminal response event",
                   );
                 }
+                if (preambleFrames.length > 0) {
+                  throw acknowledgedResponseCreateError();
+                }
                 if (hasPreviousResponseId) {
                   throw continuationSessionUnavailable(
                     "previous_response_id cannot be continued because its original websocket closed; send the full conversation input instead",
@@ -2188,12 +2198,19 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                     !retriedInvalidPreviousResponseId &&
                     isInvalidPreviousResponseIdError(event.error)
                   ) {
+                    if (preambleFrames.length > 0) {
+                      await closeWebSocketSession(sessionId);
+                      throw acknowledgedResponseCreateError();
+                    }
                     retriedInvalidPreviousResponseId = true;
                     retryTurn = true;
                     break;
                   }
                   if (isWebsocketConnectionLimitError(event.error)) {
                     await closeWebSocketSession(sessionId);
+                    if (preambleFrames.length > 0) {
+                      throw acknowledgedResponseCreateError();
+                    }
                     if (hasPreviousResponseId) {
                       throw continuationSessionUnavailable(
                         "previous_response_id cannot be continued because its original websocket cannot accept another turn; send the full conversation input instead",


### PR DESCRIPTION
## Summary

- keep Codex Responses websocket sessions reusable after `response.incomplete`
- add protocol Ping/Pong keepalive to detect idle half-open upstream sockets
- never replay or HTTP-fallback a `response.create` after `response.created`/`response.in_progress`, including invalid-ID and connection-limit error branches

## Verification

- six focused regression tests pass
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`

Full relevant files passed before the final adversarial additions; the post-review local full-file rerun was blocked only by the runtime memory admission gate while host available memory was below its 1 GiB reserve. Exact-head CI remains the merge authority.