### PR TITLE
release: v0.28.89

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.88",
+  "version": "0.28.89",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump the Helm API patch version to `0.28.89`
- release the Responses WebSocket recovery fix merged in #796

## Verification

- version-only diff
- `git diff --check`
- exact-head CI required before merge