### PR TITLE
fix: safely recover closed Responses continuations

### DIFF
--- a/apps/gateway/src/codex-responses-websocket.test.ts
+++ b/apps/gateway/src/codex-responses-websocket.test.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import {
   CodexResponsesWebSocketConnectError,
   type CodexResponsesWebSocketConnector,
+  CodexResponsesWebSocketNotOpenError,
   createResponseWorkAdmission,
 } from "@helm/core";
 import { HttpsProxyAgent } from "https-proxy-agent";
@@ -88,6 +89,28 @@ describe("createCodexResponsesWebSocketConnector", () => {
     await connection.send('{"type":"response.create"}');
     expect(await connection.receive()).toContain("response.created");
     expect(await connection.receive()).toContain("response.completed");
+  });
+
+  it("reports a typed error when send is attempted after the socket closes", async () => {
+    const server = createServer();
+    const websocketServer = new WebSocketServer({ noServer: true });
+    server.on("upgrade", (request, socket, head) => {
+      websocketServer.handleUpgrade(request, socket, head, (websocket) => {
+        websocketServer.emit("connection", websocket, request);
+      });
+    });
+    websocketServer.on("connection", (socket) => socket.close());
+    const port = await listen(server);
+    const connector = createCodexResponsesWebSocketConnector({ timeoutMs: 2_000 });
+    const connection = await connector({
+      url: `ws://127.0.0.1:${port}/responses`,
+      headers: { authorization: "Bearer subscription-token" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    await expect(connection.send('{"type":"response.create"}')).rejects.toBeInstanceOf(
+      CodexResponsesWebSocketNotOpenError,
+    );
   });
 
   it("keeps close terminal state stable for current and future receivers", async () => {

--- a/apps/gateway/src/codex-responses-websocket.ts
+++ b/apps/gateway/src/codex-responses-websocket.ts
@@ -3,6 +3,7 @@ import {
   CodexResponsesWebSocketConnectError,
   type CodexResponsesWebSocketConnection,
   type CodexResponsesWebSocketConnector,
+  CodexResponsesWebSocketNotOpenError,
   type CodexResponsesWebSocketReceivedMessage,
   type ProxyConfig,
   proxyConfigToUrl,
@@ -175,7 +176,7 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
   async send(text: string): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       if (this.socket.readyState !== WebSocket.OPEN) {
-        reject(new Error("Codex Responses websocket is closed"));
+        reject(new CodexResponsesWebSocketNotOpenError());
         return;
       }
       this.socket.send(text, (error) => {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-27 · 仅恢复发送前已关闭的 Responses WebSocket（Responses / Gateway，docs/05/07，原则 3/8）
+
+- `send()` 在调用底层 `socket.send()` 前若已确认连接不是 `OPEN`，抛出专用错误；续接请求最多重连并原样发送一次。发送回调失败仍视为结果不明，继续 fail-closed 返回 `previous_response_id_session_unavailable`，不重放、不切 sibling、不回落 HTTP。
+- 该边界只解决可证明“尚未调用发送”的安全恢复；无法证明上游是否收到字节的错误仍要求客户端带完整历史重新发起请求。
+
 ## 2026-08-26 · Codex Responses WebSocket 保活与已确认请求禁止重放（Responses / Gateway，docs/05/07，原则 3/8）
 
 - **空闲连接恢复**：上游 Codex WebSocket 现在每 60 秒发送协议 Ping，并要求 15 秒内收到 Pong；超时立即终止半开连接，让仍未发送的新请求在本地明确失败。测试可缩短两个时限，生产配置与协议正文不变。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -658,6 +658,7 @@ export {
   type CodexResponsesWebSocketConnectInput,
   type CodexResponsesWebSocketConnection,
   type CodexResponsesWebSocketConnector,
+  CodexResponsesWebSocketNotOpenError,
   type CodexResponsesWebSocketReceivedMessage,
   codexAccountIdFromToken,
   createCodexResponsesClient,

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -9,6 +9,7 @@ import {
   CodexResponsesWebSocketConnectError,
   type CodexResponsesWebSocketConnectInput,
   type CodexResponsesWebSocketConnection,
+  CodexResponsesWebSocketNotOpenError,
   codexAccountIdFromToken,
   createCodexResponsesClient,
   createGenericOpenAIResponsesClient,
@@ -2800,6 +2801,116 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(firstCloseCalls).toBe(1);
     expect(connect).toHaveBeenCalledTimes(2);
     expect(chunks.join("")).toContain("response.completed");
+  });
+
+  it("reconnects a continuation when the websocket is closed before send", async () => {
+    let sendCalls = 0;
+    const first = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-parent" } },
+        { type: "response.completed", response: { id: "resp-parent", status: "completed" } },
+      ],
+    ]);
+    const originalSend = first.send;
+    first.send = async (text) => {
+      sendCalls += 1;
+      if (sendCalls === 2) throw new CodexResponsesWebSocketNotOpenError();
+      await originalSend(text);
+    };
+    const second = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-child" } },
+        { type: "response.completed", response: { id: "resp-child", status: "completed" } },
+      ],
+    ]);
+    const connect = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_closed_before_send")}`,
+        responsesWebSocketConnector: connect,
+        connectRetries: 1,
+        connectRetryBackoffMs: [0],
+      },
+    });
+    const parent = carrier("ingress-closed-before-send", {
+      model: "gpt-5.6-sol",
+      input: [],
+      stream: true,
+      store: false,
+    });
+    for await (const _chunk of client.nativePassthroughStream?.(parent) ?? []) {
+      // drain parent
+    }
+
+    const chunks: string[] = [];
+    for await (const chunk of client.nativePassthroughStream?.(
+      carrier("ingress-closed-before-send", {
+        model: "gpt-5.6-sol",
+        input: [],
+        previous_response_id: "resp-parent",
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      chunks.push(chunk);
+    }
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(chunks.join("")).toContain("response.completed");
+  });
+
+  it("keeps an ambiguous continuation send fail-closed", async () => {
+    const connection = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-parent-ambiguous" } },
+        {
+          type: "response.completed",
+          response: { id: "resp-parent-ambiguous", status: "completed" },
+        },
+      ],
+    ]);
+    const originalSend = connection.send;
+    connection.send = async (text) => {
+      if (connection.sent.length > 0) {
+        throw Object.assign(new Error("write ECANCELED"), { code: "ECANCELED" });
+      }
+      await originalSend(text);
+    };
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_ambiguous_continuation")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+        connectRetries: 0,
+      },
+    });
+    for await (const _chunk of client.nativePassthroughStream?.(
+      carrier("ingress-ambiguous-continuation", {
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      // drain parent
+    }
+
+    const continuation = client.nativePassthroughStream?.(
+      carrier("ingress-ambiguous-continuation", {
+        model: "gpt-5.6-sol",
+        input: [],
+        previous_response_id: "resp-parent-ambiguous",
+        stream: true,
+        store: false,
+      }),
+    );
+    const continuationIterator = continuation?.[Symbol.asyncIterator]();
+    await expect(continuationIterator?.next()).rejects.toMatchObject({
+      errorClass: "upstream_error",
+      upstreamStatus: 400,
+      providerRaw: { error: { code: "previous_response_id_session_unavailable" } },
+    });
   });
 
   it("falls back to HTTP after a closed websocket exhausts the retry budget", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -188,6 +188,14 @@ export interface CodexResponsesWebSocketConnection {
   close(): Promise<void>;
 }
 
+/** The socket was closed before the request reached `socket.send`. */
+export class CodexResponsesWebSocketNotOpenError extends Error {
+  constructor() {
+    super("Codex Responses websocket is closed before send");
+    this.name = "CodexResponsesWebSocketNotOpenError";
+  }
+}
+
 export type CodexResponsesWebSocketConnector = (
   input: CodexResponsesWebSocketConnectInput,
 ) => Promise<CodexResponsesWebSocketConnection>;
@@ -2112,6 +2120,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         const maxRetries = websocketRetryCount();
         let retries = 0;
         let retriedInvalidPreviousResponseId = false;
+        let retriedClosedBeforeSend = false;
         while (!websocketHttpFallbackSessions.has(sessionId)) {
           let lease:
             | {
@@ -2254,7 +2263,20 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
           } catch (error) {
             await closeWebSocketSession(sessionId);
             if (opts?.signal?.aborted) throw opts.signal.reason ?? error;
-            if (sendingRequest && isTransientConnectionError(error)) {
+            if (
+              error instanceof CodexResponsesWebSocketNotOpenError &&
+              hasPreviousResponseId &&
+              !retriedClosedBeforeSend
+            ) {
+              if (retries < maxRetries) {
+                retriedClosedBeforeSend = true;
+                retryConnection = true;
+              } else {
+                throw continuationSessionUnavailable(
+                  "previous_response_id cannot be continued because its websocket closed before send; send the full conversation input instead",
+                );
+              }
+            } else if (sendingRequest && isTransientConnectionError(error)) {
               if (hasPreviousResponseId) {
                 throw continuationSessionUnavailable(
                   "previous_response_id continuation has an ambiguous websocket send outcome; send the full conversation input instead",


### PR DESCRIPTION
## What changed
- classify a WebSocket closed before `socket.send()` with a typed error
- reconnect and resend one continuation only in that provably safe case
- keep callback/write ambiguity fail-closed as HTTP 400

## Validation
- focused core regression tests
- focused gateway WebSocket regression test
- core and gateway typecheck
- core and gateway build
- Biome and git diff check