### PR TITLE
release: v0.28.90

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.89",
+  "version": "0.28.90",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bump the package version to v0.28.90 so the merged safe Responses continuation fix is published by the immutable-image release workflow.