### PR TITLE
fix: recover Codex response stream disconnects

### DIFF
--- a/apps/gateway/src/codex-responses-websocket.test.ts
+++ b/apps/gateway/src/codex-responses-websocket.test.ts
@@ -133,12 +133,13 @@ describe("createCodexResponsesWebSocketConnector", () => {
     const currentReceiveA = connection.receive();
     const currentReceiveB = connection.receive();
 
-    serverSocket.close(1000);
+    serverSocket.close(1000, "upstream maintenance");
 
     expect(await settlePromptly(currentReceiveA)).toBeNull();
     expect(await settlePromptly(currentReceiveB)).toBeNull();
     expect(await settlePromptly(connection.receive())).toBeNull();
     expect(await settlePromptly(connection.receive())).toBeNull();
+    expect(connection.closeInfo?.()).toEqual({ code: 1000, reason: "upstream maintenance" });
   });
 
   it("keeps error terminal state stable for current and future receivers", async () => {

--- a/apps/gateway/src/codex-responses-websocket.ts
+++ b/apps/gateway/src/codex-responses-websocket.ts
@@ -59,6 +59,7 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
     reject: (error: Error) => void;
   }> = [];
   private terminal: Error | null | undefined;
+  private closeDetails: { code: number; reason: string } | null = null;
   private keepAliveTimer: ReturnType<typeof setTimeout> | undefined;
   private keepAliveTimeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -72,7 +73,10 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
   ) {
     this.responseHeaders = headers;
     socket.on("message", (data) => this.enqueueMessage(data));
-    socket.on("close", () => this.terminate(null));
+    socket.on("close", (code, reason) => {
+      this.closeDetails = { code, reason: reason.toString("utf8") };
+      this.terminate(null);
+    });
     socket.on("error", (error) => this.terminate(error));
     socket.on("pong", () => this.handlePong());
     this.scheduleKeepAlive();
@@ -207,6 +211,10 @@ class WsCodexConnection implements CodexResponsesWebSocketConnection {
     return await new Promise<CodexResponsesWebSocketReceivedMessage | null>((resolve, reject) => {
       this.waiters.push({ resolve, reject });
     });
+  }
+
+  closeInfo(): { code: number; reason: string } | null {
+    return this.closeDetails;
   }
 
   async close(): Promise<void> {

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -1126,6 +1126,84 @@ describe("Responses websocket bridge", () => {
     ]);
   });
 
+  it("turns a lost continuation session into a retryable disconnect, then accepts full history", async () => {
+    const bodies: Record<string, unknown>[] = [];
+    let closedSessionId = "";
+    const baseUrl = await startBridge(
+      async (request) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        bodies.push(body);
+        return body.previous_response_id
+          ? new Response(
+              'event: error\ndata: {"type":"error","code":"previous_response_id_session_unavailable","message":"send full history"}\n\n',
+              { headers: { "content-type": "text/event-stream" } },
+            )
+          : new Response(
+              'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+              { headers: { "content-type": "text/event-stream" } },
+            );
+      },
+      undefined,
+      {
+        closeSession: (sessionId) => {
+          closedSessionId = sessionId;
+        },
+      },
+    );
+    const first = await connect(`${baseUrl}/v1/responses`);
+    const closed = once(first, "close");
+    first.send(
+      JSON.stringify({
+        type: "response.create",
+        model: "gpt-5.6-sol",
+        previous_response_id: "resp-parent",
+        input: [{ role: "user", content: "incremental" }],
+      }),
+    );
+
+    const [code, reason] = await closed;
+    expect(code).toBe(1012);
+    expect(reason.toString()).toBe("upstream response stream disconnected");
+
+    const second = await connect(`${baseUrl}/v1/responses`);
+    const recovered = await collectTurn(second, {
+      type: "response.create",
+      model: "gpt-5.6-sol",
+      input: [
+        { role: "user", content: "parent" },
+        { role: "assistant", content: "parent response" },
+        { role: "user", content: "incremental" },
+      ],
+    });
+
+    expect(recovered.at(-1)?.type).toBe("response.completed");
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]?.previous_response_id).toBe("resp-parent");
+    expect(bodies[1]?.previous_response_id).toBeUndefined();
+    expect(closedSessionId).not.toBe("");
+  });
+
+  it("turns a non-OK nested recovery marker into a retryable disconnect", async () => {
+    const baseUrl = await startBridge(async () =>
+      Response.json(
+        {
+          error: {
+            code: "lane_unavailable",
+            provider_raw: { error: { code: "response_create_outcome_unknown" } },
+          },
+        },
+        { status: 503 },
+      ),
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    const closed = once(socket, "close");
+    socket.send(JSON.stringify({ type: "response.create", model: "gpt-5.6-sol", input: [] }));
+
+    const [code, reason] = await closed;
+    expect(code).toBe(1012);
+    expect(reason.toString()).toBe("upstream response stream disconnected");
+  });
+
   it("cancels an unexpected successful non-SSE response body", async () => {
     let cancelled = false;
     const baseUrl = await startBridge(

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -3,6 +3,7 @@ import { type IncomingMessage, STATUS_CODES } from "node:http";
 import type { Duplex } from "node:stream";
 import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
+  isCodexResponsesRecoverableDisconnectCode,
   type ResponseWorkAdmission,
   readSSE,
   runtimeMemoryBudget,
@@ -249,11 +250,14 @@ async function responseErrorEnvelope(response: Response): Promise<Record<string,
   } catch {
     body = null;
   }
+  const error = errorShape(body, `HTTP ${response.status}`);
+  const recoverableCode = recoverableDisconnectCode(body);
+  if (recoverableCode !== null) error.code = recoverableCode;
   return {
     type: "error",
     status: response.status,
     status_code: response.status,
-    error: errorShape(body, `HTTP ${response.status}`),
+    error,
     headers: selectedResponseHeaders(response.headers),
   };
 }
@@ -315,6 +319,26 @@ async function sendEnvelope(socket: WebSocket, envelope: Record<string, unknown>
   await sendText(socket, JSON.stringify(envelope));
 }
 
+function recoverableDisconnectCode(value: unknown): string | null {
+  let current = value;
+  while (current !== null && typeof current === "object" && !Array.isArray(current)) {
+    const record = current as Record<string, unknown>;
+    if (isCodexResponsesRecoverableDisconnectCode(record.code)) return record.code as string;
+    current =
+      record.error !== undefined
+        ? record.error
+        : record.provider_raw !== undefined
+          ? record.provider_raw
+          : null;
+  }
+  return null;
+}
+
+function closeForFullHistoryRecovery(socket: WebSocket): void {
+  if (socket.readyState === WebSocket.OPEN)
+    socket.close(1012, "upstream response stream disconnected");
+}
+
 function websocketPayload(event: string | undefined, data: string): string | null {
   const trimmed = data.trim();
   if (trimmed === "" || trimmed === "[DONE]") return null;
@@ -369,7 +393,12 @@ async function forwardResponse(
     markResponsesWebSocketRequestParsed(internalRequest);
   }
   if (!response.ok) {
-    await sendEnvelope(socket, await responseErrorEnvelope(response));
+    const envelope = await responseErrorEnvelope(response);
+    if (recoverableDisconnectCode(envelope) !== null) {
+      closeForFullHistoryRecovery(socket);
+      return true;
+    }
+    await sendEnvelope(socket, envelope);
     return true;
   }
   const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
@@ -383,13 +412,19 @@ async function forwardResponse(
   for await (const frame of readSSE(body, maxSseFrameBytes, responseWorkAdmission)) {
     const payload = websocketPayload(frame.event, frame.data);
     if (payload === null) continue;
-    await sendText(socket, payload);
     let type: unknown;
     try {
-      type = (JSON.parse(payload) as { type?: unknown }).type;
+      const parsed = JSON.parse(payload) as { type?: unknown };
+      type = parsed.type;
+      if (recoverableDisconnectCode(parsed) !== null) {
+        void body.cancel().catch(() => {});
+        closeForFullHistoryRecovery(socket);
+        return true;
+      }
     } catch {
       type = undefined;
     }
+    await sendText(socket, payload);
     if (
       type === "response.completed" ||
       type === "response.cancelled" ||

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -6554,6 +6554,78 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.nativePassthrough).toBe(true);
   });
 
+  it("does not advance the chain when a sent response.create has an unknown outcome", async () => {
+    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
+    async function* unknownOutcome(): AsyncGenerator<string> {
+      throw new UpstreamError(
+        "upstream_error",
+        "upstream websocket closed after send",
+        { error: { code: "response_create_outcome_unknown" } },
+        400,
+      );
+    }
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(unknownOutcome()),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const tail = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(gen(SSE)),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const cb = breaker();
+    const recordFailure = vi.spyOn(cb, "recordFailure");
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map([
+        ["codex-a", head],
+        ["codex-b", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "codex-a",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+        b: {
+          providerName: "codex-b",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: cb,
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      req({
+        protocol: "openai_responses",
+        stream: true,
+        native_request: createNativePassthroughCarrier({
+          protocol: "openai_responses",
+          body: { model: "auto", input: [], stream: true },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "lane_unavailable",
+      http_status: 503,
+      provider_raw: { error: { code: "response_create_outcome_unknown" } },
+    });
+    expect(out.attempts).toHaveLength(1);
+    expect(tail.nativePassthroughStream).not.toHaveBeenCalled();
+    expect(recordFailure).not.toHaveBeenCalled();
+  });
+
   it("short-circuits a native Responses in-band context error to a scrubbed 400", async () => {
     // The head passthrough stream reports an in-band context overflow (response.failed with
     // context_length_exceeded). It short-circuits to a 400 with the provider_raw SCRUBBED of

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -18,6 +18,7 @@ import {
   checkCapability,
   correlationTraceId,
   guardPreOutputFailure,
+  isCodexResponsesRecoverableDisconnectCode,
   type NativePassthroughDisableReason,
   openaiTransformer,
   optimizeVisualContext,
@@ -2295,6 +2296,42 @@ export function createExecute(deps: ExecuteAdapterDeps) {
                   error_class: "lane_unavailable",
                   message: "user message queue wait timed out; retry shortly",
                   trace_id: correlationTraceId(req),
+                }),
+              },
+              body: null,
+              stream: null,
+            };
+          }
+
+          // `response.create` may already be running upstream. Never replay it on a
+          // sibling provider: the Responses WebSocket bridge converts this marker into
+          // a transport disconnect so Codex can rebuild from its own full history.
+          if (
+            err instanceof UpstreamError &&
+            isCodexResponsesRecoverableDisconnectCode(upstreamErrorCode(err.providerRaw))
+          ) {
+            settleBreaker("abort");
+            const detail = errorDetailOf(err);
+            attempts.push({
+              alias,
+              skipped: false,
+              skip_reason: null,
+              status: "error",
+              error_class: "lane_unavailable",
+              latency_ms: elapsed(),
+              cost_usd: null,
+              error_detail: detail,
+              ...attemptTelemetry,
+            });
+            return {
+              attempts,
+              final: {
+                status: "error",
+                error: makeHelmError({
+                  error_class: "lane_unavailable",
+                  message: detail.message,
+                  trace_id: correlationTraceId(req),
+                  provider_raw: detail.provider_raw,
                 }),
               },
               body: null,

--- a/apps/gateway/src/routes/messages-pipeline.ts
+++ b/apps/gateway/src/routes/messages-pipeline.ts
@@ -216,11 +216,18 @@ export type RecordOAuthUsageFn = (
 export class PipelineError extends Error {
   readonly error_class: string;
   readonly trace_id: string;
-  constructor(error_class: string, message: string, trace_id: string) {
+  readonly provider_raw: Record<string, unknown> | null;
+  constructor(
+    error_class: string,
+    message: string,
+    trace_id: string,
+    provider_raw: Record<string, unknown> | null = null,
+  ) {
     super(message);
     this.name = "PipelineError";
     this.error_class = error_class;
     this.trace_id = trace_id;
+    this.provider_raw = provider_raw;
   }
 }
 
@@ -1028,6 +1035,7 @@ export function createMessagesPipeline(
               result.error?.error_class ?? "all_providers_failed",
               result.error?.message ?? "all providers failed",
               traceId,
+              result.error?.provider_raw ?? null,
             )
           : null;
 

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -2363,6 +2363,74 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(env).toMatchObject({ type: "error", code: "all_providers_failed", param: null });
   });
 
+  it("preserves the recoverable Codex disconnect code across the pipeline seam", async () => {
+    const { deps } = makeDeps({
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      // biome-ignore lint/correctness/useYield: throw-only generator (failure before first event)
+      streamIR: async function* () {
+        throw new PipelineError(
+          "lane_unavailable",
+          "upstream websocket closed after send",
+          "trace-1",
+          { error: { code: "response_create_outcome_unknown" } },
+        );
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    const frames = parseSSE(await res.text());
+
+    expect(JSON.parse(frames.find((frame) => frame.event === "error")?.data ?? "{}")).toMatchObject(
+      {
+        type: "error",
+        code: "response_create_outcome_unknown",
+      },
+    );
+  });
+
+  it("preserves a recoverable Codex disconnect after streamed output", async () => {
+    const { deps } = makeDeps({
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      streamIR: async function* () {
+        yield { type: "response.output_text.delta", delta: "partial", sequence_number: 0 };
+        throw new UpstreamError(
+          "upstream_error",
+          "upstream websocket closed before completion",
+          { error: { code: "response_create_outcome_unknown" } },
+          400,
+        );
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    const frames = parseSSE(await res.text());
+
+    expect(JSON.parse(frames.find((frame) => frame.event === "error")?.data ?? "{}")).toMatchObject(
+      {
+        type: "error",
+        code: "response_create_outcome_unknown",
+      },
+    );
+  });
+
   it("client abort emits NO error frame (benign non-provider fault)", async () => {
     const ac = new AbortController();
     const { record, insert } = makeRecord();

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -6,6 +6,7 @@ import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   type DecisionRecord,
   getOAuthProvider,
+  isCodexResponsesRecoverableDisconnectCode,
   preOutputClassifierFor,
   type RateLimitProbe,
   type RateLimitResult,
@@ -578,6 +579,18 @@ function coerceErrorClass(value: string): ErrorClass {
   return parsed.success ? parsed.data : "upstream_error";
 }
 
+function recoverableDisconnectCode(providerRaw: unknown): string | null {
+  const nested =
+    providerRaw !== null && typeof providerRaw === "object" && !Array.isArray(providerRaw)
+      ? (providerRaw as { error?: unknown }).error
+      : null;
+  const code =
+    nested !== null && typeof nested === "object" && !Array.isArray(nested)
+      ? (nested as { code?: unknown }).code
+      : null;
+  return typeof code === "string" && isCodexResponsesRecoverableDisconnectCode(code) ? code : null;
+}
+
 // A PipelineError surfaced across the pipeline seam → a throwable HelmHttpError so
 // the global onError serializes it in the OpenAI envelope (all_providers_failed →
 // 502, invalid_request → 400, …) instead of degrading to an empty 200.
@@ -609,6 +622,7 @@ function pipelineToHelm(err: PipelineError, traceId: string): HelmHttpError {
       error_class: coerceErrorClass(err.error_class),
       message: err.message,
       trace_id: traceId,
+      provider_raw: err.provider_raw,
     }),
   );
 }
@@ -1456,17 +1470,23 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                 : isUpstreamTimeout(err)
                   ? "timeout"
                   : "upstream_error";
+            const recoveryCode =
+              err instanceof PipelineError
+                ? recoverableDisconnectCode(err.provider_raw)
+                : err instanceof UpstreamError
+                  ? recoverableDisconnectCode(err.providerRaw)
+                  : null;
             const body =
               err instanceof PipelineError
                 ? responsesStreamError({
-                    code: coerceErrorClass(err.error_class),
+                    code: recoveryCode ?? coerceErrorClass(err.error_class),
                     message: err.message,
                     traceId,
                     sequenceNumber: nextErrorSequence,
                   })
                 : responsesStreamError({
                     // Preserve a mid-stream idle timeout instead of internal_error.
-                    code: isUpstreamTimeout(err) ? "timeout" : "internal_error",
+                    code: recoveryCode ?? (isUpstreamTimeout(err) ? "timeout" : "internal_error"),
                     message: err instanceof Error ? err.message : "upstream error",
                     traceId,
                     sequenceNumber: nextErrorSequence,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-27 · 将不可安全重放的 Responses 断流交还 Codex 恢复（Responses / Gateway，docs/05/07，原则 3/5/8）
+
+- `response.create` 一旦进入 WebSocket `send()`，发送回调失败、读超时/异常、EOF，以及收到输出后但终态前断连都属于结果不明：Helm 不再重放、不回落 HTTP、不切 sibling，也不处罚 breaker；只有专用错误能证明底层 `socket.send()` 尚未调用时，初始无状态请求才可重试。无法解析的单个上游事件与直连 Codex 一致，释放资源后忽略并继续等待，不因协议扩展重放整轮。续接在发送前发现原 socket 已关闭时同样不把 opaque `previous_response_id` 搬到新连接。本条取代同日早先“续接发送前关闭后重连一次”的决定。
+- provider 通过两个结构化 recovery code 把该状态保留到 Responses SSE，包括已经输出后的流内错误与非 2xx 嵌套错误；下游 WebSocket bridge 不先发送 400/error frame，而以 `1012` 关闭连接。Codex 0.145.0 的原生 retry loop 会把 transport close 视为可重试，并在新连接上清空增量 `previous_response_id`、用客户端持有的完整当前会话重建请求；Helm 本身仍只发送上游一次。
+- telemetry 在本地 teardown 前快照上游 close code/reason，并记录 `before_send` / `send_callback_error` / `after_send_before_event` / `after_send_after_preamble` / `after_send_after_output` 生命周期，避免把 Helm 自己的 close `1000` 冒充上游事实。该恢复与直连 Codex 的断流语义一致，但上游没有幂等键时无法承诺 exactly-once；重试决定仍由持有完整历史的客户端负责。无 schema、migration、依赖或配置变化。
+
 ## 2026-08-27 · 仅恢复发送前已关闭的 Responses WebSocket（Responses / Gateway，docs/05/07，原则 3/8）
 
 - `send()` 在调用底层 `socket.send()` 前若已确认连接不是 `OPEN`，抛出专用错误；续接请求最多重连并原样发送一次。发送回调失败仍视为结果不明，继续 fail-closed 返回 `previous_response_id_session_unavailable`，不重放、不切 sibling、不回落 HTTP。
@@ -55,18 +61,10 @@
 - **恢复边界**：同一账号、同一 WebSocket 的一次原样重试仍优先；只有它再次返回精确的 `400 Invalid previous_response_id` 且尚未产生客户端可见输出时，OAuth pool 才逐个尝试其余同 provider、同 model 的可调度账号。其他 4xx、限流、凭证、超时、断连与已开始输出的错误继续保持原有 fail-closed 语义，搜索次数天然受账号数限制。
 - **亲和修复**：找到能继续该 ID 的账号后，同时更新进程内 sticky 映射与 durable Responses registry 中旧 ID 的 `provider_account`；后续续接优先回到这个实际拥有状态的原账号。全部账号都报告不存在时仍返回最后一个上游错误，不删除 ID、不伪造历史，也不跨 provider/协议。
 
-## 2026-08-20 · Grok 视频输入对齐 xAI 官方 reference-to-video 合同（Videos，Imagine spec §4 / Phase 1 §2–5，原则 2/3/6/7）
-
-- **官方合同与最小修复**：2026-08-20 复核 xAI Videos 文档与 Sub2API `49504adc` 后，确认 stable `grok-imagine-video-1.5` 接受 1–7 张 `reference_images`、七种画幅，以及最多 3 个预设 `{ voice_id }` `reference_audios`；image-to-video 接受可选画幅并支持 1080p。共享严格 schema 在同一边界扩展这些字段，`images` 兼容输入仍只在付费 POST 前规范成 `reference_images`。
-- **兼容、实测与限制**：generation/extension 时长扩大为官方 `1–15` 秒整数，同时保留已公开的 `30` 兼容值；reference-to-video 仍限 480p/720p。当前只开放普遍可用的预设 voice ID，不开放需 partner 权限且会引入大正文处理的自定义音频 URL；既有 prompt-only `audio` 仅作为历史兼容，不把它宣称为官方 REST 字段。付费单写、账号 entitlement、receipt 绑定和 `outcome_unknown` 边界不变。本机 SuperGrok OAuth 单写 canary 已验证 1 张参考图 + `eve`、16:9/9:16、720p、8 秒和 AAC 音轨；1080p、其他时长与其他画幅未做付费穷举。
-
-## 2026-08-20 · 配额周期历史新增已用百分比（OAuth providers，原则 3/7）
-
-- 重置边界记录新增可空 `usedPercent`，仅在以后观测到周期关闭时从上游快照写入；旧行不回填，无法证明的近似/日周聚合继续显示空值。
-- SQLite/Postgres 各新增一次可空列迁移；当前周期仅使用未过期快照，避免把上一周期百分比套到新周期。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-20 · Grok 视频输入对齐 xAI 官方 reference-to-video 合同**：stable 视频合同扩展 1–7 张参考图、七种画幅、最多 3 个预设 voice，并保留已公开的 30 秒兼容值；付费单写与 entitlement 边界不变，完整原文经 git history 回溯。
+- **2026-08-20 · 配额周期历史新增已用百分比**：仅在以后真实观测周期关闭时保存可空 `usedPercent`，旧行和不可证明的近似历史不回填，完整原文经 git history 回溯。
 - **2026-08-19 · Codex Responses 续接 ID 在原 WebSocket 上做一次有界恢复**：仅在首个客户端可见输出前、针对精确 `Invalid previous_response_id` 在同一活动 WebSocket 原样重发一次；第二次仍失败则 fail-closed，完整原文经 git history 回溯。
 - **2026-08-19 · Grok 视频统一时长并复用单写链增加扩展接口**：generation/extension 共用严格媒体合同、付费单写与固定账号轮询；真实 canary 只证明 15 秒纯文本、单图和多图，30 秒与 extension 仍未获能力证明；完整原文经 git history 回溯。
 - **2026-08-19 · 保留已公开的 Grok Imagine 媒体选项**：恢复 fast image 与 prompt-only video 的既有有界字段，同时保持严格 schema、授权、预算与付费单写边界；完整原文经 git history 回溯。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -665,6 +665,7 @@ export {
   createGenericOpenAIResponsesClient,
   type GenericOpenAIResponsesClientDeps,
   hoistResponsesInstructions,
+  isCodexResponsesRecoverableDisconnectCode,
   openaiToResponsesRequest,
   type ResponsesInstructionsFix,
   sanitizeCodexResponsesNativeBody,

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -2663,8 +2663,9 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(releaseCalls).toBe(1);
   });
 
-  it("releases websocket response-work after malformed JSON", async () => {
+  it("ignores a malformed websocket event without replaying the request", async () => {
     let releaseCalls = 0;
+    let receiveCalls = 0;
     const connection: CodexResponsesWebSocketConnection = {
       responseHeaders: new Headers(),
       async send() {},
@@ -2672,8 +2673,15 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
         throw new Error("legacy receive should not be used");
       },
       async receiveWithWork() {
+        receiveCalls += 1;
         return {
-          text: "not-json",
+          text:
+            receiveCalls === 1
+              ? "not-json"
+              : JSON.stringify({
+                  type: "response.completed",
+                  response: { id: "resp-after-malformed", status: "completed" },
+                }),
           release() {
             releaseCalls += 1;
           },
@@ -2699,11 +2707,13 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       )
       [Symbol.asyncIterator]();
 
-    await expect(iterator?.next()).rejects.toMatchObject({ name: "UpstreamError" });
+    expect((await iterator?.next())?.value).toContain("response.completed");
     expect(releaseCalls).toBe(1);
+    expect((await iterator?.next())?.done).toBe(true);
+    expect(releaseCalls).toBe(2);
   });
 
-  it("releases a late websocket response when the receive timeout wins", async () => {
+  it("marks a post-send receive timeout without replaying the request", async () => {
     let resolveReceive: ((value: { text: string; release(): void } | null) => void) | undefined;
     let releaseCalls = 0;
     const connection: CodexResponsesWebSocketConnection = {
@@ -2739,8 +2749,10 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       [Symbol.asyncIterator]();
 
     await expect(iterator?.next()).rejects.toMatchObject({
-      name: "UpstreamError",
-      errorClass: "timeout",
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        websocket: { lifecycle_phase: "after_send_before_event" },
+      },
     });
     resolveReceive?.({
       text: JSON.stringify({ type: "response.created" }),
@@ -2752,7 +2764,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(releaseCalls).toBe(1);
   });
 
-  it("reconnects after a pre-output websocket write ECANCELED", async () => {
+  it("does not replay after an ambiguous pre-output websocket write ECANCELED", async () => {
     let firstCloseCalls = 0;
     const first: CodexResponsesWebSocketConnection = {
       responseHeaders: new Headers(),
@@ -2785,25 +2797,66 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
         connectRetryBackoffMs: [0],
       },
     });
-    const chunks: string[] = [];
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-ecanceled", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
 
-    for await (const chunk of client.nativePassthroughStream?.(
-      carrier("ingress-ecanceled", {
-        model: "gpt-5.6-sol",
-        input: [],
-        stream: true,
-        store: false,
-      }),
-    ) ?? []) {
-      chunks.push(chunk);
-    }
-
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
     expect(firstCloseCalls).toBe(1);
-    expect(connect).toHaveBeenCalledTimes(2);
-    expect(chunks.join("")).toContain("response.completed");
+    expect(connect).toHaveBeenCalledTimes(1);
   });
 
-  it("reconnects a continuation when the websocket is closed before send", async () => {
+  it("does not replay after a non-transient websocket send callback error", async () => {
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {
+        throw new Error("send callback failed");
+      },
+      async receive() {
+        return null;
+      },
+      async close() {},
+    };
+    const connect = vi.fn(async () => connection);
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_send_callback")}`,
+        responsesWebSocketConnector: connect,
+        connectRetries: 2,
+        connectRetryBackoffMs: [0],
+      },
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-send-callback", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        websocket: { lifecycle_phase: "send_callback_error" },
+      },
+    });
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks the client to recover when a continuation websocket is closed before send", async () => {
     let sendCalls = 0;
     const first = fakeConnection([
       [
@@ -2843,21 +2896,22 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       // drain parent
     }
 
-    const chunks: string[] = [];
-    for await (const chunk of client.nativePassthroughStream?.(
-      carrier("ingress-closed-before-send", {
-        model: "gpt-5.6-sol",
-        input: [],
-        previous_response_id: "resp-parent",
-        stream: true,
-        store: false,
-      }),
-    ) ?? []) {
-      chunks.push(chunk);
-    }
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-closed-before-send", {
+          model: "gpt-5.6-sol",
+          input: [],
+          previous_response_id: "resp-parent",
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
 
-    expect(connect).toHaveBeenCalledTimes(2);
-    expect(chunks.join("")).toContain("response.completed");
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: { error: { code: "previous_response_id_session_unavailable" } },
+    });
+    expect(connect).toHaveBeenCalledTimes(1);
   });
 
   it("keeps an ambiguous continuation send fail-closed", async () => {
@@ -2909,17 +2963,17 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     await expect(continuationIterator?.next()).rejects.toMatchObject({
       errorClass: "upstream_error",
       upstreamStatus: 400,
-      providerRaw: { error: { code: "previous_response_id_session_unavailable" } },
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
     });
   });
 
-  it("falls back to HTTP after a closed websocket exhausts the retry budget", async () => {
+  it("falls back to HTTP after a websocket proven closed before send exhausts retries", async () => {
     let closeCalls = 0;
     const connect = vi.fn(
       async (): Promise<CodexResponsesWebSocketConnection> => ({
         responseHeaders: new Headers(),
         async send() {
-          throw new Error("Codex Responses websocket is closed");
+          throw new CodexResponsesWebSocketNotOpenError();
         },
         async receive() {
           return null;
@@ -3012,11 +3066,112 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       )
       [Symbol.asyncIterator]();
 
-    await expect(iterator?.next()).rejects.toThrow(
-      "upstream websocket closed after acknowledging response.create",
-    );
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
     expect(firstCloseCalls).toBe(1);
     expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay a response.create when the websocket closes after send but before any event", async () => {
+    let sends = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {
+        sends += 1;
+      },
+      async receive() {
+        return null;
+      },
+      closeInfo() {
+        return { code: 1012, reason: "upstream restart" };
+      },
+      async close() {},
+    };
+    const connect = vi.fn(async () => connection);
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_post_send_close")}`,
+        responsesWebSocketConnector: connect,
+        connectRetries: 2,
+        connectRetryBackoffMs: [0],
+      },
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-post-send-close", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        websocket: {
+          lifecycle_phase: "after_send_before_event",
+          close_code: 1012,
+          close_reason: "upstream restart",
+        },
+      },
+    });
+    expect(sends).toBe(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report Helm's local close as upstream close metadata", async () => {
+    let closeDetails: { code: number; reason: string } | null = null;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {},
+      async receive() {
+        return null;
+      },
+      closeInfo() {
+        return closeDetails;
+      },
+      async close() {
+        closeDetails = { code: 1000, reason: "" };
+      },
+    };
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_local_close")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+      },
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-local-close", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    let caught: unknown;
+    try {
+      await iterator?.next();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        websocket: { lifecycle_phase: "after_send_before_event" },
+      },
+    });
+    expect((caught as UpstreamError).providerRaw).not.toMatchObject({
+      websocket: { close_code: 1000 },
+    });
   });
 
   it("does not retry invalid previous_response_id after the upstream acknowledged it", async () => {
@@ -3067,9 +3222,9 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       )
       [Symbol.asyncIterator]();
 
-    await expect(iterator?.next()).rejects.toThrow(
-      "upstream websocket closed after acknowledging response.create",
-    );
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
     expect(connect).toHaveBeenCalledTimes(1);
     expect(connection.sent).toHaveLength(2);
   });
@@ -3112,9 +3267,9 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       )
       [Symbol.asyncIterator]();
 
-    await expect(iterator?.next()).rejects.toThrow(
-      "upstream websocket closed after acknowledging response.create",
-    );
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
     expect(connect).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -3162,7 +3317,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     await iterator?.return?.();
   });
 
-  it("requeues a same-session request after an ECANCELED connection is replaced", async () => {
+  it("recovers a queued same-session request without replaying the ambiguous one", async () => {
     let releaseFirstSend = () => {};
     let markFirstSendStarted = () => {};
     const firstSendStarted = new Promise<void>((resolve) => {
@@ -3224,11 +3379,18 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     releaseFirstSend();
 
-    const output = await Promise.all([firstTurn, secondTurn]);
+    const output = await Promise.allSettled([firstTurn, secondTurn]);
     expect(firstSendCalls).toBe(1);
     expect(connect).toHaveBeenCalledTimes(2);
-    expect(second.sent).toHaveLength(2);
-    expect(output.every((text) => text.includes("response.completed"))).toBe(true);
+    expect(second.sent).toHaveLength(1);
+    expect(output[0]).toMatchObject({
+      status: "rejected",
+      reason: { providerRaw: { error: { code: "response_create_outcome_unknown" } } },
+    });
+    expect(output[1]).toMatchObject({ status: "fulfilled" });
+    if (output[1]?.status === "fulfilled") {
+      expect(output[1].value).toContain("response.completed");
+    }
   });
 
   it("does not send a same-session request aborted while waiting for its lease", async () => {
@@ -3292,7 +3454,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(connection.sent).toHaveLength(1);
   });
 
-  it("does not retry ECANCELED after websocket output starts", async () => {
+  it("marks a websocket read ECANCELED after output without retrying", async () => {
     const boom = Object.assign(new Error("read ECANCELED"), { code: "ECANCELED" });
     let receiveCalls = 0;
     const connection: CodexResponsesWebSocketConnection = {
@@ -3331,7 +3493,12 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       [Symbol.asyncIterator]();
 
     expect((await iterator?.next())?.value).toContain("response.output_text.delta");
-    await expect(iterator?.next()).rejects.toBe(boom);
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        websocket: { lifecycle_phase: "after_send_after_output" },
+      },
+    });
     expect(connect).toHaveBeenCalledTimes(1);
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -4284,10 +4284,10 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
   it.each([
     ["invalid JSON", "not-json"],
     ["an untyped JSON event", JSON.stringify({ response: { status: "in_progress" } })],
-  ])("destroys the upstream websocket session after %s", async (_label, malformedEvent) => {
-    const first = fakeConnection([[malformedEvent]]);
-    const second = fakeConnection([
+  ])("ignores %s on the upstream websocket", async (_label, malformedEvent) => {
+    const connection = fakeConnection([
       [
+        malformedEvent,
         { type: "response.created", response: { id: "resp-next" } },
         {
           type: "response.completed",
@@ -4295,7 +4295,7 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
         },
       ],
     ]);
-    const connect = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    const connect = vi.fn(async () => connection);
     const client = createCodexResponsesClient({
       config: {
         baseUrl: "https://chatgpt.com/backend-api/codex",
@@ -4310,19 +4310,14 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       store: false,
     });
 
-    const firstIterator = client.nativePassthroughStream?.(request)[Symbol.asyncIterator]();
-    await expect(firstIterator?.next()).rejects.toMatchObject({
-      name: "UpstreamError",
-      errorClass: "upstream_error",
-    });
-    const secondTurn: string[] = [];
+    const chunks: string[] = [];
     for await (const chunk of client.nativePassthroughStream?.(request) ?? []) {
-      secondTurn.push(chunk);
+      chunks.push(chunk);
     }
 
-    expect(first.closeCalls).toBe(1);
-    expect(connect).toHaveBeenCalledTimes(2);
-    expect(secondTurn.join("")).toContain("response.completed");
+    expect(connection.closeCalls).toBe(0);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(chunks.join("")).toContain("response.completed");
   });
 
   it("preserves a Responses Lite incremental continuation without re-inserting tools", async () => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -168,6 +168,15 @@ export interface GenericOpenAIResponsesRequestContract {
 }
 
 export const CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER = "x-helm-codex-responses-websocket-session";
+const CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE = "response_create_outcome_unknown";
+const CODEX_RESPONSES_SESSION_UNAVAILABLE_CODE = "previous_response_id_session_unavailable";
+
+export function isCodexResponsesRecoverableDisconnectCode(code: unknown): boolean {
+  return (
+    code === CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE ||
+    code === CODEX_RESPONSES_SESSION_UNAVAILABLE_CODE
+  );
+}
 
 export interface CodexResponsesWebSocketConnectInput {
   url: string;
@@ -185,6 +194,7 @@ export interface CodexResponsesWebSocketConnection {
   send(text: string): Promise<void>;
   receive(): Promise<string | null>;
   receiveWithWork?(): Promise<CodexResponsesWebSocketReceivedMessage | null>;
+  closeInfo?(): { code: number; reason: string } | null;
   close(): Promise<void>;
 }
 
@@ -1703,25 +1713,55 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     return nested.type === "invalid_request_error";
   }
 
-  function continuationSessionUnavailable(message: string): UpstreamError {
+  function websocketCloseDetails(
+    connection: CodexResponsesWebSocketConnection,
+    lifecyclePhase: string,
+  ): Record<string, unknown> {
+    const close = connection.closeInfo?.();
+    return {
+      lifecycle_phase: lifecyclePhase,
+      ...(close === null || close === undefined
+        ? {}
+        : { close_code: close.code, close_reason: close.reason }),
+    };
+  }
+
+  function continuationSessionUnavailable(
+    message: string,
+    websocket?: Record<string, unknown>,
+  ): UpstreamError {
     return new UpstreamError(
       "upstream_error",
       message,
       {
         error: {
           type: "invalid_request_error",
-          code: "previous_response_id_session_unavailable",
+          code: CODEX_RESPONSES_SESSION_UNAVAILABLE_CODE,
           message,
         },
+        ...(websocket === undefined ? {} : { websocket }),
       },
       400,
     );
   }
 
-  function acknowledgedResponseCreateError(): UpstreamError {
+  function responseCreateOutcomeUnknown(
+    connection: CodexResponsesWebSocketConnection,
+    lifecyclePhase: string,
+  ): UpstreamError {
+    const message = "upstream websocket closed after response.create was sent";
     return new UpstreamError(
       "upstream_error",
-      "upstream websocket closed after acknowledging response.create",
+      message,
+      {
+        error: {
+          type: "invalid_request_error",
+          code: CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE,
+          message,
+        },
+        websocket: websocketCloseDetails(connection, lifecyclePhase),
+      },
+      400,
     );
   }
 
@@ -2120,7 +2160,6 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         const maxRetries = websocketRetryCount();
         let retries = 0;
         let retriedInvalidPreviousResponseId = false;
-        let retriedClosedBeforeSend = false;
         while (!websocketHttpFallbackSessions.has(sessionId)) {
           let lease:
             | {
@@ -2168,33 +2207,47 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
             await lease.connection.send(requestText);
             sendingRequest = false;
             while (true) {
-              const received = await receiveWebSocketMessage(lease.connection, opts?.signal);
+              let received: CodexResponsesWebSocketReceivedMessage | null;
+              try {
+                received = await receiveWebSocketMessage(lease.connection, opts?.signal);
+              } catch (error) {
+                if (opts?.signal?.aborted) throw opts.signal.reason ?? error;
+                throw responseCreateOutcomeUnknown(
+                  lease.connection,
+                  outputStarted
+                    ? "after_send_after_output"
+                    : preambleFrames.length > 0
+                      ? "after_send_after_preamble"
+                      : "after_send_before_event",
+                );
+              }
               if (received === null) {
-                await closeWebSocketSession(sessionId);
-                if (outputStarted) {
-                  throw new UpstreamError(
-                    "upstream_error",
-                    "upstream websocket closed before a terminal response event",
-                  );
-                }
-                if (preambleFrames.length > 0) {
-                  throw acknowledgedResponseCreateError();
-                }
-                if (hasPreviousResponseId) {
+                const websocket = websocketCloseDetails(
+                  lease.connection,
+                  "after_send_before_event",
+                );
+                if (hasPreviousResponseId && !outputStarted && preambleFrames.length === 0) {
                   throw continuationSessionUnavailable(
                     "previous_response_id cannot be continued because its original websocket closed; send the full conversation input instead",
+                    websocket,
                   );
                 }
-                if (retries < maxRetries) {
-                  retryConnection = true;
-                } else {
-                  websocketHttpFallbackSessions.add(sessionId);
-                  fallbackToHttp = true;
-                }
-                break;
+                throw responseCreateOutcomeUnknown(
+                  lease.connection,
+                  outputStarted
+                    ? "after_send_after_output"
+                    : preambleFrames.length > 0
+                      ? "after_send_after_preamble"
+                      : "after_send_before_event",
+                );
               }
               try {
-                const event = websocketSseFrame(received.text);
+                let event: ParsedWebSocketEvent;
+                try {
+                  event = websocketSseFrame(received.text);
+                } catch {
+                  continue;
+                }
                 if (event.kind === "rate_limits") {
                   fireResponseMetaHeaders(event.headers, opts?.onResponseMeta);
                   continue;
@@ -2208,18 +2261,23 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                     isInvalidPreviousResponseIdError(event.error)
                   ) {
                     if (preambleFrames.length > 0) {
-                      await closeWebSocketSession(sessionId);
-                      throw acknowledgedResponseCreateError();
+                      throw responseCreateOutcomeUnknown(
+                        lease.connection,
+                        "after_send_after_preamble",
+                      );
                     }
                     retriedInvalidPreviousResponseId = true;
                     retryTurn = true;
                     break;
                   }
                   if (isWebsocketConnectionLimitError(event.error)) {
-                    await closeWebSocketSession(sessionId);
                     if (preambleFrames.length > 0) {
-                      throw acknowledgedResponseCreateError();
+                      throw responseCreateOutcomeUnknown(
+                        lease.connection,
+                        "after_send_after_preamble",
+                      );
                     }
+                    await closeWebSocketSession(sessionId);
                     if (hasPreviousResponseId) {
                       throw continuationSessionUnavailable(
                         "previous_response_id cannot be continued because its original websocket cannot accept another turn; send the full conversation input instead",
@@ -2261,34 +2319,33 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
               }
             }
           } catch (error) {
-            await closeWebSocketSession(sessionId);
-            if (opts?.signal?.aborted) throw opts.signal.reason ?? error;
-            if (
-              error instanceof CodexResponsesWebSocketNotOpenError &&
-              hasPreviousResponseId &&
-              !retriedClosedBeforeSend
-            ) {
-              if (retries < maxRetries) {
-                retriedClosedBeforeSend = true;
-                retryConnection = true;
-              } else {
-                throw continuationSessionUnavailable(
-                  "previous_response_id cannot be continued because its websocket closed before send; send the full conversation input instead",
-                );
-              }
-            } else if (sendingRequest && isTransientConnectionError(error)) {
+            if (opts?.signal?.aborted) {
+              await closeWebSocketSession(sessionId);
+              throw opts.signal.reason ?? error;
+            }
+            if (error instanceof CodexResponsesWebSocketNotOpenError) {
+              const websocket = websocketCloseDetails(lease.connection, "before_send");
+              await closeWebSocketSession(sessionId);
               if (hasPreviousResponseId) {
                 throw continuationSessionUnavailable(
-                  "previous_response_id continuation has an ambiguous websocket send outcome; send the full conversation input instead",
+                  "previous_response_id cannot be continued because its websocket closed before send; send the full conversation input instead",
+                  websocket,
                 );
-              }
-              if (retries < maxRetries) {
+              } else if (retries < maxRetries) {
                 retryConnection = true;
               } else {
                 websocketHttpFallbackSessions.add(sessionId);
                 fallbackToHttp = true;
               }
+            } else if (sendingRequest) {
+              const outcomeUnknown = responseCreateOutcomeUnknown(
+                lease.connection,
+                "send_callback_error",
+              );
+              await closeWebSocketSession(sessionId);
+              throw outcomeUnknown;
             } else {
+              await closeWebSocketSession(sessionId);
               throw error;
             }
           } finally {


### PR DESCRIPTION
## Summary\n\n- never replay or route a response.create after its WebSocket send outcome becomes ambiguous\n- preserve recoverable disconnect markers through executor, pipeline, Responses SSE, and the downstream bridge\n- close downstream Responses WebSockets with code 1012 so official Codex can rebuild from full history without a stale previous_response_id\n- record upstream close code, reason, and lifecycle before local teardown\n\n## Safety\n\n- typed pre-send NotOpen remains retryable only for initial stateless requests\n- continuations never move an opaque response ID to a fresh socket\n- no sibling fallback, HTTP fallback, or breaker penalty after an ambiguous send\n- malformed upstream events follow direct Codex behavior and are ignored without replay\n\n## Verification\n\n- focused provider recovery cases: 15 passed\n- executor marker terminality: passed\n- pipeline pre-output and post-output marker preservation: passed\n- streamed and non-OK WebSocket bridge recovery: passed\n- typecheck: passed\n- lint: passed\n- affected core and gateway builds: passed\n- Claude CLI Opus final P0/P1 review: CLEAN\n\nOne unchanged HTTP-fallback unit could not run locally while the runtime memory admission gate was active under machine pressure; exact-head CI is required before merge.