### PR TITLE
release: v0.28.91

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.90",
+  "version": "0.28.91",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release for the Codex Responses WebSocket continuation recovery fix merged in #800.\n\nThis PR changes only the package version from 0.28.90 to 0.28.91.