### PR TITLE
fix: recover Codex affinity loss before send

### DIFF
--- a/apps/gateway/src/responses-websocket-internal.ts
+++ b/apps/gateway/src/responses-websocket-internal.ts
@@ -1,4 +1,6 @@
 export const CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER = "x-helm-codex-responses-websocket-proof";
+export const CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER =
+  "x-helm-codex-responses-websocket-recovery-proof";
 
 const requestMaterialized = new WeakMap<Request, () => void>();
 

--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -10,7 +10,10 @@ import {
   type ResponsesWebSocketUpgradeServer,
   responsesWebSocketPreflightPending,
 } from "./responses-websocket.js";
-import { markResponsesWebSocketRequestParsed } from "./responses-websocket-internal.js";
+import {
+  CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER,
+  markResponsesWebSocketRequestParsed,
+} from "./responses-websocket-internal.js";
 import { createBodyMemoryAdmission } from "./runtime/memory-admission.js";
 
 interface CapturedRequest {
@@ -21,6 +24,7 @@ interface CapturedRequest {
 const openBridges: Array<{ close(): Promise<void> }> = [];
 const openServers: ReturnType<typeof createServer>[] = [];
 const openSockets: WebSocket[] = [];
+const TEST_SESSION_PROOF = "responses-websocket-test-proof";
 
 afterEach(async () => {
   for (const socket of openSockets.splice(0)) {
@@ -106,6 +110,7 @@ async function startBridge(
       return fetch(request);
     },
     closeSession: options.closeSession,
+    sessionProof: TEST_SESSION_PROOF,
     memoryAdmission: options.memoryAdmission,
     ingressAdmission: options.ingressAdmission,
     responseWorkAdmission: options.responseWorkAdmission,
@@ -1135,8 +1140,13 @@ describe("Responses websocket bridge", () => {
         bodies.push(body);
         return body.previous_response_id
           ? new Response(
-              'event: error\ndata: {"type":"error","code":"previous_response_id_session_unavailable","message":"send full history"}\n\n',
-              { headers: { "content-type": "text/event-stream" } },
+              'event: error\ndata: {"type":"error","code":"response_create_not_sent","message":"send full history"}\n\n',
+              {
+                headers: {
+                  "content-type": "text/event-stream",
+                  [CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER]: TEST_SESSION_PROOF,
+                },
+              },
             )
           : new Response(
               'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
@@ -1189,10 +1199,15 @@ describe("Responses websocket bridge", () => {
         {
           error: {
             code: "lane_unavailable",
-            provider_raw: { error: { code: "response_create_outcome_unknown" } },
+            provider_raw: { error: { code: "response_create_not_sent" } },
           },
         },
-        { status: 503 },
+        {
+          status: 503,
+          headers: {
+            [CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER]: TEST_SESSION_PROOF,
+          },
+        },
       ),
     );
     const socket = await connect(`${baseUrl}/v1/responses`);
@@ -1202,6 +1217,62 @@ describe("Responses websocket bridge", () => {
     const [code, reason] = await closed;
     expect(code).toBe(1012);
     expect(reason.toString()).toBe("upstream response stream disconnected");
+  });
+
+  it("does not close for an unproven private recovery code", async () => {
+    const baseUrl = await startBridge(
+      async () =>
+        new Response(
+          'event: error\ndata: {"type":"error","code":"response_create_not_sent","message":"untrusted upstream marker"}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    const events = await collectTurn(socket, {
+      type: "response.create",
+      model: "gpt-5.6-sol",
+      input: [],
+    });
+
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      code: "response_create_not_sent",
+    });
+    expect(socket.readyState).toBe(WebSocket.OPEN);
+  });
+
+  it("forwards an ambiguous post-send outcome without closing or replaying", async () => {
+    const baseUrl = await startBridge(
+      async () =>
+        new Response(
+          'event: error\ndata: {"type":"error","code":"response_create_outcome_unknown","message":"outcome unknown"}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      undefined,
+      {
+        responseWorkAdmission: createResponseWorkAdmission({
+          capacityBytes: 1_000_000,
+          jsonAmplification: 1,
+          minChargeBytes: 1,
+        }),
+      },
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+
+    const events = await collectTurn(socket, {
+      type: "response.create",
+      model: "gpt-5.6-sol",
+      input: [],
+    });
+
+    expect(events).toEqual([
+      {
+        type: "error",
+        code: "response_create_outcome_unknown",
+        message: "outcome unknown",
+      },
+    ]);
+    expect(socket.readyState).toBe(WebSocket.OPEN);
   });
 
   it("cancels an unexpected successful non-SSE response body", async () => {

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -13,6 +13,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import { normalizeOpenAICodexClientVersion } from "./oauth/codex-client-version.js";
 import {
   CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER,
+  CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER,
   markResponsesWebSocketRequestParsed,
   trackResponsesWebSocketRequest,
 } from "./responses-websocket-internal.js";
@@ -392,9 +393,12 @@ async function forwardResponse(
   } finally {
     markResponsesWebSocketRequestParsed(internalRequest);
   }
+  const trustedRecovery =
+    sessionProof !== undefined &&
+    response.headers.get(CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER) === sessionProof;
   if (!response.ok) {
     const envelope = await responseErrorEnvelope(response);
-    if (recoverableDisconnectCode(envelope) !== null) {
+    if (trustedRecovery && recoverableDisconnectCode(envelope) !== null) {
       closeForFullHistoryRecovery(socket);
       return true;
     }
@@ -416,7 +420,7 @@ async function forwardResponse(
     try {
       const parsed = JSON.parse(payload) as { type?: unknown };
       type = parsed.type;
-      if (recoverableDisconnectCode(parsed) !== null) {
+      if (trustedRecovery && recoverableDisconnectCode(parsed) !== null) {
         void body.cancel().catch(() => {});
         closeForFullHistoryRecovery(socket);
         return true;

--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -1,5 +1,6 @@
 import type { CircuitBreaker, ExecutionPlan, ProviderClient, ProviderRegistry } from "@helm/core";
 import {
+  CodexResponsesBeforeSendError,
   createAnthropicClient,
   createCircuitBreaker,
   createGeminiClient,
@@ -6624,6 +6625,137 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.attempts).toHaveLength(1);
     expect(tail.nativePassthroughStream).not.toHaveBeenCalled();
     expect(recordFailure).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "previous_response_id",
+    "x-codex-turn-state",
+    "responses_websocket_session",
+  ])("requires full-history recovery before fallback when %s affinity is unavailable", async (affinity) => {
+    // biome-ignore lint/correctness/useYield: pool selection fails before provider invocation
+    async function* unavailableAffinity(): AsyncGenerator<string> {
+      throw new CodexResponsesBeforeSendError(
+        `oauth pool: ${affinity} original account is unavailable`,
+      );
+    }
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(unavailableAffinity()),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const tail = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(gen(SSE)),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map([
+        ["codex-a", head],
+        ["codex-b", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "codex-a",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+        b: {
+          providerName: "codex-b",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      req({
+        protocol: "openai_responses",
+        stream: true,
+        native_request: createNativePassthroughCarrier({
+          protocol: "openai_responses",
+          body: { model: "auto", input: [], stream: true },
+          headers: { "x-codex-turn-state": "strict-turn-state" },
+        }),
+      }),
+    );
+
+    expect(out.final.status).toBe("error");
+    if (out.final.status !== "error") throw new Error("expected a terminal error");
+    expect(out.final.error).toMatchObject({
+      error_class: "lane_unavailable",
+      provider_raw: { error: { code: "response_create_not_sent" } },
+    });
+    expect(out.attempts).toHaveLength(1);
+    expect(tail.nativePassthroughStream).not.toHaveBeenCalled();
+  });
+
+  it("does not trust an upstream error that copies an OAuth affinity message", async () => {
+    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
+    async function* forgedAffinityError(): AsyncGenerator<string> {
+      throw new UpstreamError(
+        "upstream_error",
+        "oauth pool: previous_response_id original account is unavailable",
+        { error: { code: "upstream_overloaded" } },
+        503,
+      );
+    }
+    const head = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(forgedAffinityError()),
+    } as unknown as ProviderClient;
+    const tail = {
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: vi.fn().mockReturnValue(gen(SSE)),
+    } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
+    const execute = createExecute({
+      defaultProvider: head,
+      providers: new Map([
+        ["codex-a", head],
+        ["codex-b", tail],
+      ]),
+      registry: protocolRegistry({
+        a: {
+          providerName: "codex-a",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+        b: {
+          providerName: "codex-b",
+          providerModel: "gpt-5.6-sol",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+
+    const out = await execute(
+      plan(["a", "b"]),
+      req({
+        protocol: "openai_responses",
+        stream: true,
+        native_request: createNativePassthroughCarrier({
+          protocol: "openai_responses",
+          body: { model: "auto", input: [], stream: true },
+          headers: {},
+        }),
+      }),
+    );
+
+    expect(out.final.status).toBe("ok");
+    expect(tail.nativePassthroughStream).toHaveBeenCalledTimes(1);
   });
 
   it("short-circuits a native Responses in-band context error to a scrubbed 400", async () => {

--- a/apps/gateway/src/routes/execute.ts
+++ b/apps/gateway/src/routes/execute.ts
@@ -18,7 +18,8 @@ import {
   checkCapability,
   correlationTraceId,
   guardPreOutputFailure,
-  isCodexResponsesRecoverableDisconnectCode,
+  isCodexResponsesBeforeSendError,
+  isCodexResponsesPostSendFailureCode,
   type NativePassthroughDisableReason,
   openaiTransformer,
   optimizeVisualContext,
@@ -2303,13 +2304,17 @@ export function createExecute(deps: ExecuteAdapterDeps) {
             };
           }
 
-          // `response.create` may already be running upstream. Never replay it on a
-          // sibling provider: the Responses WebSocket bridge converts this marker into
-          // a transport disconnect so Codex can rebuild from its own full history.
-          if (
+          // Strict Codex affinity is resolved before provider invocation. If the pinned
+          // account/session is unavailable, stop the chain and let the downstream client
+          // rebuild from full history; never send the stateful delta to another provider.
+          const beforeSendRecovery =
+            req.protocol === "openai_responses" && isCodexResponsesBeforeSendError(err);
+          // Post-send lifecycle failures are also terminal, but are not safe to replay:
+          // response.create may already be running upstream.
+          const postSendFailure =
             err instanceof UpstreamError &&
-            isCodexResponsesRecoverableDisconnectCode(upstreamErrorCode(err.providerRaw))
-          ) {
+            isCodexResponsesPostSendFailureCode(upstreamErrorCode(err.providerRaw));
+          if (beforeSendRecovery || postSendFailure) {
             settleBreaker("abort");
             const detail = errorDetailOf(err);
             attempts.push({

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../app.js";
 import {
   CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER,
+  CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER,
   trackResponsesWebSocketRequest,
 } from "../responses-websocket-internal.js";
 import { createBodyMemoryAdmission } from "../runtime/memory-admission.js";
@@ -111,6 +112,7 @@ function makeDeps(
     modelsEtagForKey?: ResponsesRouteDeps["modelsEtagForKey"];
     memoryAdmission?: ResponsesRouteDeps["memoryAdmission"];
     sseCaptureFactory?: ResponsesRouteDeps["sseCaptureFactory"];
+    responsesWebSocketSessionProof?: string;
   } = {},
 ): { deps: ResponsesRouteDeps; order: string[]; harness: { pipelineSawIR: unknown } } {
   const order: string[] = [];
@@ -125,6 +127,7 @@ function makeDeps(
     registry: over.registry,
     memoryAdmission: over.memoryAdmission,
     sseCaptureFactory: over.sseCaptureFactory,
+    responsesWebSocketSessionProof: over.responsesWebSocketSessionProof,
     ...(over.modelsEtagForKey !== undefined
       ? { modelsEtagForKey: over.modelsEtagForKey }
       : over.modelsEtag === undefined
@@ -2363,7 +2366,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(env).toMatchObject({ type: "error", code: "all_providers_failed", param: null });
   });
 
-  it("preserves the recoverable Codex disconnect code across the pipeline seam", async () => {
+  it("preserves a proven pre-send Codex recovery code across the pipeline seam", async () => {
     const { deps } = makeDeps({
       transformRequestOut: () => ({
         stream: true,
@@ -2373,12 +2376,9 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       }),
       // biome-ignore lint/correctness/useYield: throw-only generator (failure before first event)
       streamIR: async function* () {
-        throw new PipelineError(
-          "lane_unavailable",
-          "upstream websocket closed after send",
-          "trace-1",
-          { error: { code: "response_create_outcome_unknown" } },
-        );
+        throw new PipelineError("lane_unavailable", "response.create was not sent", "trace-1", {
+          error: { code: "response_create_not_sent" },
+        });
       },
     });
     const app = buildApp(deps);
@@ -2392,12 +2392,69 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     expect(JSON.parse(frames.find((frame) => frame.event === "error")?.data ?? "{}")).toMatchObject(
       {
         type: "error",
-        code: "response_create_outcome_unknown",
+        code: "response_create_not_sent",
       },
     );
   });
 
-  it("preserves a recoverable Codex disconnect after streamed output", async () => {
+  it("proves a recovery marker only to the trusted in-process websocket bridge", async () => {
+    const proof = "test-recovery-proof";
+    const { deps } = makeDeps({
+      responsesWebSocketSessionProof: proof,
+      transformRequestOut: () => ({ stream: true, model: "auto", metadata: {} }),
+      // biome-ignore lint/correctness/useYield: throw-only generator (failure before first event)
+      streamIR: async function* () {
+        throw new PipelineError("lane_unavailable", "response.create was not sent", "trace-1", {
+          error: { code: "response_create_not_sent" },
+        });
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: {
+        ...AUTH,
+        [CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER]: proof,
+      },
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    await res.text();
+
+    expect(res.headers.get(CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER)).toBe(proof);
+  });
+
+  it("does not trust a safe-replay code carried by an ordinary upstream error", async () => {
+    const { deps } = makeDeps({
+      transformRequestOut: () => ({
+        stream: true,
+        model: "auto",
+        messages: [{ role: "user", content: "hi" }],
+        metadata: {},
+      }),
+      // biome-ignore lint/correctness/useYield: throw-only generator (failure before first event)
+      streamIR: async function* () {
+        throw new PipelineError("invalid_request", "untrusted upstream marker", "trace-1", {
+          error: { code: "response_create_not_sent" },
+        });
+      },
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    const frames = parseSSE(await res.text());
+
+    expect(JSON.parse(frames.find((frame) => frame.event === "error")?.data ?? "{}")).toMatchObject(
+      {
+        type: "error",
+        code: "invalid_request",
+      },
+    );
+  });
+
+  it("preserves an ambiguous Codex outcome after streamed output without marking it replayable", async () => {
     const { deps } = makeDeps({
       transformRequestOut: () => ({
         stream: true,
@@ -3722,6 +3779,34 @@ describe("stream: raw frame forwarding via sse.write(raw) (lines 589-591, 610-61
     const arg = insertPayload.mock.calls[0]?.[0] as { responseJson: string };
     // The raw bytes should be captured as-is, NOT re-formatted
     expect(arg.responseJson).toContain("event: response.completed");
+  });
+
+  it("rewrites an upstream frame that copies Helm's private replay code", async () => {
+    const rawFrame = 'event: error\ndata: {"type":"error","code":"response_create_not_sent"}\n\n';
+    async function* events(): AsyncIterable<Record<string, unknown>> {
+      yield {
+        event: "error",
+        data: '{"type":"error","code":"response_create_not_sent"}',
+        raw: rawFrame,
+      };
+    }
+    const { deps } = makeDeps({
+      nativePassthrough: true,
+      transformRequestOut: () => ({ stream: true, model: "auto", metadata: {} }),
+      streamIR: events,
+    });
+    const app = buildApp(deps);
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: AUTH,
+      body: JSON.stringify({ ...REQ, stream: true }),
+    });
+    const frames = parseSSE(await res.text());
+
+    expect(JSON.parse(frames[0]?.data ?? "{}")).toMatchObject({
+      type: "error",
+      code: "upstream_error",
+    });
   });
 });
 

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -6,6 +6,8 @@ import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   type DecisionRecord,
   getOAuthProvider,
+  isCodexResponsesBeforeSendError,
+  isCodexResponsesPostSendFailureCode,
   isCodexResponsesRecoverableDisconnectCode,
   preOutputClassifierFor,
   type RateLimitProbe,
@@ -39,6 +41,7 @@ import {
 } from "../request-cancellation.js";
 import {
   CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER,
+  CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER,
   markResponsesWebSocketRequestParsed,
 } from "../responses-websocket-internal.js";
 import {
@@ -579,7 +582,7 @@ function coerceErrorClass(value: string): ErrorClass {
   return parsed.success ? parsed.data : "upstream_error";
 }
 
-function recoverableDisconnectCode(providerRaw: unknown): string | null {
+function codexResponsesLifecycleFailureCode(providerRaw: unknown): string | null {
   const nested =
     providerRaw !== null && typeof providerRaw === "object" && !Array.isArray(providerRaw)
       ? (providerRaw as { error?: unknown }).error
@@ -588,7 +591,26 @@ function recoverableDisconnectCode(providerRaw: unknown): string | null {
     nested !== null && typeof nested === "object" && !Array.isArray(nested)
       ? (nested as { code?: unknown }).code
       : null;
-  return typeof code === "string" && isCodexResponsesRecoverableDisconnectCode(code) ? code : null;
+  return typeof code === "string" &&
+    (isCodexResponsesRecoverableDisconnectCode(code) || isCodexResponsesPostSendFailureCode(code))
+    ? code
+    : null;
+}
+
+function scrubUntrustedRecoveryCode(data: string): string | null {
+  let changed = false;
+  try {
+    const parsed = JSON.parse(data, (key, value: unknown) => {
+      if (key === "code" && isCodexResponsesRecoverableDisconnectCode(value)) {
+        changed = true;
+        return "upstream_error";
+      }
+      return value;
+    }) as unknown;
+    return changed ? JSON.stringify(parsed) : null;
+  } catch {
+    return null;
+  }
 }
 
 // A PipelineError surfaced across the pipeline seam → a throwable HelmHttpError so
@@ -1146,6 +1168,15 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
   const handleResponses = async (c: Context<AppEnv>) => {
     const traceId = c.get("trace_id");
     const requestId = c.get("request_id");
+    if (
+      deps.responsesWebSocketSessionProof !== undefined &&
+      c.req.header(CODEX_RESPONSES_WEBSOCKET_PROOF_HEADER) === deps.responsesWebSocketSessionProof
+    ) {
+      c.header(
+        CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER,
+        deps.responsesWebSocketSessionProof,
+      );
+    }
 
     // 1) Auth FIRST (docs/02 pipeline order).
     const identity = await authenticateResponsesRequest(c);
@@ -1420,7 +1451,9 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     raw: (event as { raw?: string }).raw,
                   }
                 : { ...deps.transformer.transformStreamOut(event), raw: undefined };
-            const raw = frame.raw;
+            const scrubbedData = scrubUntrustedRecoveryCode(frame.data);
+            if (scrubbedData !== null) frame.data = scrubbedData;
+            const raw = scrubbedData === null ? frame.raw : undefined;
             const serializedFrame = raw ?? `event: ${frame.event}\ndata: ${frame.data}\n\n`;
             captured?.push(serializedFrame);
             const terminalEvent = isResponsesTerminalEvent(frame.event);
@@ -1470,23 +1503,32 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                 : isUpstreamTimeout(err)
                   ? "timeout"
                   : "upstream_error";
-            const recoveryCode =
+            const lifecycleFailureCode =
               err instanceof PipelineError
-                ? recoverableDisconnectCode(err.provider_raw)
+                ? err.error_class === "lane_unavailable"
+                  ? codexResponsesLifecycleFailureCode(err.provider_raw)
+                  : null
                 : err instanceof UpstreamError
-                  ? recoverableDisconnectCode(err.providerRaw)
+                  ? isCodexResponsesBeforeSendError(err) ||
+                    isCodexResponsesPostSendFailureCode(
+                      codexResponsesLifecycleFailureCode(err.providerRaw),
+                    )
+                    ? codexResponsesLifecycleFailureCode(err.providerRaw)
+                    : null
                   : null;
             const body =
               err instanceof PipelineError
                 ? responsesStreamError({
-                    code: recoveryCode ?? coerceErrorClass(err.error_class),
+                    code: lifecycleFailureCode ?? coerceErrorClass(err.error_class),
                     message: err.message,
                     traceId,
                     sequenceNumber: nextErrorSequence,
                   })
                 : responsesStreamError({
                     // Preserve a mid-stream idle timeout instead of internal_error.
-                    code: recoveryCode ?? (isUpstreamTimeout(err) ? "timeout" : "internal_error"),
+                    code:
+                      lifecycleFailureCode ??
+                      (isUpstreamTimeout(err) ? "timeout" : "internal_error"),
                     message: err instanceof Error ? err.message : "upstream error",
                     traceId,
                     sequenceNumber: nextErrorSequence,

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-27 · Responses 只在可证明未发送时触发完整历史恢复（Responses / OAuth provider / Gateway，docs/04/05/07，原则 3/5/8）
+
+- **生产根因**：`v0.28.91` 上线后的 64 个严格亲和失败（110 个 provider attempts）均紧跟两次真实 Codex 账号级 429；账号按 `Retry-After` 暂停期间，`x-codex-turn-state` / `previous_response_id` 仍正确绑定原账号，但 pool 在调用 provider 前抛出的 `original account is unavailable` 被 executor 当作普通失败继续 fallback，最终形成 400/502，甚至可能把状态型增量交给无原上下文的候选。
+- **唯一安全恢复边界**：三个严格亲和源（`previous_response_id`、`x-codex-turn-state`、`responses_websocket_session`）在 provider 调用前不可用时，pool 抛出类型化内部错误，executor 立即终止执行链并生成 `response_create_not_sent`，同时记录 `safe_to_replay:true` / `lifecycle_phase:before_send`；Responses WebSocket bridge 只在进程内 proof 匹配时对这一 code 关闭 `1012`，让 Codex 用完整历史重建。普通错误 message 不再被识别为安全来源，上游原样 SSE 若复制私有 code 会改写成 `upstream_error`；真实 429 本身仍按原账号限流处理，不伪装成未发送。
+- **禁止模糊重放**：`response_create_outcome_unknown` 与发送后产生的 `previous_response_id_session_unavailable` 不再属于可恢复断连 code；它们继续终止 provider/fallback，但以错误事件留在原下游 socket，不触发 `1012` 或自动重放，避免重复推理、工具副作用与计费。本条收紧并取代同日早先“所有结构化 recovery code 均关闭 1012”的决定；无 schema、migration、配置或依赖变化。
+
 ## 2026-08-27 · 将不可安全重放的 Responses 断流交还 Codex 恢复（Responses / Gateway，docs/05/07，原则 3/5/8）
 
 - `response.create` 一旦进入 WebSocket `send()`，发送回调失败、读超时/异常、EOF，以及收到输出后但终态前断连都属于结果不明：Helm 不再重放、不回落 HTTP、不切 sibling，也不处罚 breaker；只有专用错误能证明底层 `socket.send()` 尚未调用时，初始无状态请求才可重试。无法解析的单个上游事件与直连 Codex 一致，释放资源后忽略并继续等待，不因协议扩展重放整轮。续接在发送前发现原 socket 已关闭时同样不把 opaque `previous_response_id` 搬到新连接。本条取代同日早先“续接发送前关闭后重连一次”的决定。
@@ -56,13 +62,9 @@
 - **根因与修复**：pool rebuild 后，`previous_response_id` 仍指向已 parked/limited 的原账号时，旧逻辑在访问上游前直接抛出 `original account is unavailable`，没有尝试其他账号；现在该类续接从初始选择即进入有界 sibling 探测，成功后继续沿用既有 sticky/registry 修复链。`x-codex-turn-state` 仍保持严格原账号绑定，避免把不可迁移的上游会话状态串到其他账号。
 - **熔断边界**：两种严格亲和的“原账号不可用”均按账号级故障处理，不再累积到共享 model breaker，防止少数失效 pin 把健康 sibling 一起变成 `circuit_open`；服务器/传输故障仍照常计入 breaker。无 schema、配置或依赖变化。
 
-## 2026-08-24 · Codex Responses 续接 ID 可在账号池内有界找回原账号（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
-
-- **恢复边界**：同一账号、同一 WebSocket 的一次原样重试仍优先；只有它再次返回精确的 `400 Invalid previous_response_id` 且尚未产生客户端可见输出时，OAuth pool 才逐个尝试其余同 provider、同 model 的可调度账号。其他 4xx、限流、凭证、超时、断连与已开始输出的错误继续保持原有 fail-closed 语义，搜索次数天然受账号数限制。
-- **亲和修复**：找到能继续该 ID 的账号后，同时更新进程内 sticky 映射与 durable Responses registry 中旧 ID 的 `provider_account`；后续续接优先回到这个实际拥有状态的原账号。全部账号都报告不存在时仍返回最后一个上游错误，不删除 ID、不伪造历史，也不跨 provider/协议。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-24 · Codex Responses 续接 ID 可在账号池内有界找回原账号**：只在尚无可靠归属且没有客户端可见输出时有界探测同 provider/model sibling，并同步修复 sticky/registry；其他状态型失败保持 fail-closed，完整原文经 git history 回溯。
 - **2026-08-20 · Grok 视频输入对齐 xAI 官方 reference-to-video 合同**：stable 视频合同扩展 1–7 张参考图、七种画幅、最多 3 个预设 voice，并保留已公开的 30 秒兼容值；付费单写与 entitlement 边界不变，完整原文经 git history 回溯。
 - **2026-08-20 · 配额周期历史新增已用百分比**：仅在以后真实观测周期关闭时保存可空 `usedPercent`，旧行和不可证明的近似历史不回填，完整原文经 git history 回溯。
 - **2026-08-19 · Codex Responses 续接 ID 在原 WebSocket 上做一次有界恢复**：仅在首个客户端可见输出前、针对精确 `Invalid previous_response_id` 在同一活动 WebSocket 原样重发一次；第二次仍失败则 fail-closed，完整原文经 git history 回溯。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -651,6 +651,7 @@ export {
 export {
   aggregateResponsesStream,
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
+  CodexResponsesBeforeSendError,
   type CodexResponsesClientConfig,
   type CodexResponsesClientDeps,
   type CodexResponsesNativeBodyFix,
@@ -665,6 +666,8 @@ export {
   createGenericOpenAIResponsesClient,
   type GenericOpenAIResponsesClientDeps,
   hoistResponsesInstructions,
+  isCodexResponsesBeforeSendError,
+  isCodexResponsesPostSendFailureCode,
   isCodexResponsesRecoverableDisconnectCode,
   openaiToResponsesRequest,
   type ResponsesInstructionsFix,

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../openai.js";
 import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
+  CodexResponsesBeforeSendError,
   createCodexResponsesClient,
 } from "../openai-responses.js";
 import { TokenRefreshError } from "../token-manager.js";
@@ -557,7 +558,7 @@ describe("createOAuthPoolClient — account selection", () => {
         { ...USER_REQ, previous_response_id: "resp-a" },
         { statefulAccount: "a" },
       ),
-    ).toThrow("previous_response_id original account is unavailable");
+    ).toThrow(CodexResponsesBeforeSendError);
     expect(calls).toEqual([]);
   });
 

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -34,7 +34,10 @@ import {
   type RealtimeCallResult,
   UpstreamError,
 } from "../openai.js";
-import { CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER } from "../openai-responses.js";
+import {
+  CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
+  CodexResponsesBeforeSendError,
+} from "../openai-responses.js";
 import { TokenRefreshError } from "../token-manager.js";
 import { DEFAULT_429_COOLDOWN_MS } from "./usage-limit.js";
 
@@ -947,11 +950,17 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       });
     }
     if (stickyKey?.startsWith("previous_response_id:") && !knownSticky) {
-      throw new Error("oauth pool: previous_response_id original account is unavailable");
+      throw new CodexResponsesBeforeSendError(
+        "oauth pool: previous_response_id original account is unavailable",
+        { reason: "oauth_affinity_unavailable" },
+      );
     }
     if (stickyOnly && knownSticky) {
       const source = affinityKeySource(stickyKey ?? null) ?? "stateful continuation";
-      throw new Error(`oauth pool: ${source} original account is unavailable`);
+      throw new CodexResponsesBeforeSendError(
+        `oauth pool: ${source} original account is unavailable`,
+        { reason: "oauth_affinity_unavailable" },
+      );
     }
     const { entry: best, reason } = chooseByStrategy(
       capacityTier.candidates,

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -2909,7 +2909,11 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       [Symbol.asyncIterator]();
 
     await expect(iterator?.next()).rejects.toMatchObject({
-      providerRaw: { error: { code: "previous_response_id_session_unavailable" } },
+      upstreamStatus: null,
+      providerRaw: {
+        error: { code: "response_create_not_sent" },
+        recovery: { safe_to_replay: true, lifecycle_phase: "before_send" },
+      },
     });
     expect(connect).toHaveBeenCalledTimes(1);
   });
@@ -3812,9 +3816,10 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       [Symbol.asyncIterator]();
 
     await expect(iterator?.next()).rejects.toMatchObject({
-      upstreamStatus: 400,
+      upstreamStatus: null,
       providerRaw: {
-        error: { code: "previous_response_id_session_unavailable" },
+        error: { code: "response_create_not_sent" },
+        recovery: { safe_to_replay: true, lifecycle_phase: "before_send" },
       },
     });
     expect(connect).not.toHaveBeenCalled();
@@ -3867,9 +3872,10 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       [Symbol.asyncIterator]();
 
     await expect(iterator?.next()).rejects.toMatchObject({
-      upstreamStatus: 400,
+      upstreamStatus: null,
       providerRaw: {
-        error: { code: "previous_response_id_session_unavailable" },
+        error: { code: "response_create_not_sent" },
+        recovery: { safe_to_replay: true, lifecycle_phase: "before_send" },
       },
     });
     expect(connect).toHaveBeenCalledTimes(2);
@@ -3935,7 +3941,8 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     await expect(iterator?.next()).rejects.toMatchObject({
       upstreamStatus: 400,
       providerRaw: {
-        error: { code: "previous_response_id_session_unavailable" },
+        error: { code: "response_create_outcome_unknown" },
+        websocket: { lifecycle_phase: "after_send_before_event" },
       },
     });
     expect(connect).toHaveBeenCalledTimes(1);

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -170,12 +170,45 @@ export interface GenericOpenAIResponsesRequestContract {
 export const CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER = "x-helm-codex-responses-websocket-session";
 const CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE = "response_create_outcome_unknown";
 const CODEX_RESPONSES_SESSION_UNAVAILABLE_CODE = "previous_response_id_session_unavailable";
+const CODEX_RESPONSES_NOT_SENT_CODE = "response_create_not_sent";
 
 export function isCodexResponsesRecoverableDisconnectCode(code: unknown): boolean {
+  return code === CODEX_RESPONSES_NOT_SENT_CODE;
+}
+
+export function isCodexResponsesPostSendFailureCode(code: unknown): boolean {
   return (
     code === CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE ||
     code === CODEX_RESPONSES_SESSION_UNAVAILABLE_CODE
   );
+}
+
+/** The current response.create is proven not to have reached an upstream provider. */
+export class CodexResponsesBeforeSendError extends UpstreamError {
+  constructor(message: string, recovery: Record<string, unknown> = {}) {
+    super(
+      "upstream_error",
+      message,
+      {
+        error: {
+          type: "server_error",
+          code: CODEX_RESPONSES_NOT_SENT_CODE,
+          message,
+        },
+        recovery: {
+          safe_to_replay: true,
+          lifecycle_phase: "before_send",
+          ...recovery,
+        },
+      },
+      null,
+    );
+    this.name = "CodexResponsesBeforeSendError";
+  }
+}
+
+export function isCodexResponsesBeforeSendError(error: unknown): boolean {
+  return error instanceof CodexResponsesBeforeSendError;
 }
 
 export interface CodexResponsesWebSocketConnectInput {
@@ -2142,8 +2175,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
           !websocketSessions.has(sessionId) ||
           responseWebsocketSessions.get(previousResponseId.trim()) !== sessionId)
       ) {
-        throw continuationSessionUnavailable(
+        throw new CodexResponsesBeforeSendError(
           "previous_response_id cannot be continued because its original websocket session is unavailable; send the full conversation input instead",
+          { reason: "websocket_session_unavailable" },
         );
       }
       if (
@@ -2177,8 +2211,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
               !opts?.signal?.aborted
             ) {
               if (hasPreviousResponseId) {
-                throw continuationSessionUnavailable(
+                throw new CodexResponsesBeforeSendError(
                   "previous_response_id cannot be continued because its original websocket connection failed; send the full conversation input instead",
+                  { reason: "websocket_connection_failed" },
                 );
               }
               websocketHttpFallbackSessions.add(sessionId);
@@ -2222,15 +2257,8 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                 );
               }
               if (received === null) {
-                const websocket = websocketCloseDetails(
-                  lease.connection,
-                  "after_send_before_event",
-                );
                 if (hasPreviousResponseId && !outputStarted && preambleFrames.length === 0) {
-                  throw continuationSessionUnavailable(
-                    "previous_response_id cannot be continued because its original websocket closed; send the full conversation input instead",
-                    websocket,
-                  );
+                  throw responseCreateOutcomeUnknown(lease.connection, "after_send_before_event");
                 }
                 throw responseCreateOutcomeUnknown(
                   lease.connection,
@@ -2327,9 +2355,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
               const websocket = websocketCloseDetails(lease.connection, "before_send");
               await closeWebSocketSession(sessionId);
               if (hasPreviousResponseId) {
-                throw continuationSessionUnavailable(
+                throw new CodexResponsesBeforeSendError(
                   "previous_response_id cannot be continued because its websocket closed before send; send the full conversation input instead",
-                  websocket,
+                  { ...websocket, reason: "websocket_closed_before_send" },
                 );
               } else if (retries < maxRetries) {
                 retryConnection = true;


### PR DESCRIPTION
## Summary
- terminate strict Codex affinity loss before provider fallback
- replay only when `response.create` is proven not sent
- keep post-send ambiguous failures terminal without replay
- authenticate the internal WebSocket recovery marker and rewrite forged upstream markers

## Production evidence
- 64 affected requests / 110 provider attempts after v0.28.91
- failures clustered immediately after two real account-level 429 cooldowns
- affected attempts completed in 0–3 ms, before provider invocation

## Verification
- 19 focused replay-safety, executor, route, bridge, provider, and OAuth-pool tests
- `pnpm --filter @helm/core typecheck`
- `pnpm --filter @helm/gateway typecheck`
- targeted Biome check
- `git diff --check`