### PR TITLE
release: v0.28.92

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.91",
+  "version": "0.28.92",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API version from `0.28.91` to `0.28.92`
- release the Codex affinity-loss recovery fix merged in #802

## Scope
Version-only release PR based on main `39f16c5033aa50c8fc04f8c5eee3b34c1d6bc9e8`.