### PR TITLE
release: v0.28.93

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.92",
+  "version": "0.28.93",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version-only release for the changes currently on main.

- Bump root package version from 0.28.92 to 0.28.93.
- Publish workflow will create the matching tag, GitHub Release, and immutable image after main CI.