### PR TITLE
feat: capture failed request diagnostics

### DIFF
--- a/apps/gateway/src/routes/payload-capture.test.ts
+++ b/apps/gateway/src/routes/payload-capture.test.ts
@@ -1611,6 +1611,66 @@ describe("recordServed — deferred write queue (the three pipeline faces)", () 
     expect(s.inserted[0]?.request_content_mode).toBe(row.mode);
   });
 
+  it("captures the exact payload and Session revision for a failed request even in metadata-only mode", async () => {
+    const s = sink();
+    const revisions: UpsertSessionRevisionInput[] = [];
+    const telemetry = {
+      ...s.telemetry,
+      getSessionByRef: vi.fn(async () => null),
+      upsertSessionRevision: vi.fn(async (input: UpsertSessionRevisionInput) => {
+        revisions.push(input);
+      }),
+    } as unknown as RecordServedDeps["telemetry"];
+    const writes = createWriteQueue({ telemetry, log: () => {}, flushIntervalMs: 10_000 });
+    const failed = decision();
+    failed.final = { ...failed.final, status: "error", error_reason: "upstream_error" };
+    failed.session = {
+      ref: "failed-session-ref",
+      label: "failed-thread",
+      source: "x-thread-id",
+    };
+
+    await recordServed(
+      {
+        telemetry,
+        writes,
+        redact: (value) => value,
+        now: () => 5000,
+        capturePayloads: () => false,
+        captureSessions: () => false,
+      },
+      {
+        ...args,
+        requestId: "req_failed",
+        accountId: "account-1",
+        decision: failed,
+        requestJson: '{"messages":[{"role":"user","content":"original"}]}',
+        responseJson: '{"error":{"message":"provider failed"}}',
+        upstreamRequestJson: '{"model":"provider-model","messages":[]}',
+      },
+      () => {},
+    );
+    await writes.flush();
+
+    expect(s.inserted[0]?.request_content_mode).toBe("payload");
+    expect(s.payloads).toEqual([
+      expect.objectContaining({
+        requestId: "req_failed",
+        requestJson: '{"messages":[{"role":"user","content":"original"}]}',
+        responseJson: '{"error":{"message":"provider failed"}}',
+        upstreamRequestJson: '{"model":"provider-model","messages":[]}',
+      }),
+    ]);
+    expect(revisions).toEqual([
+      expect.objectContaining({
+        sessionRef: "failed-session-ref",
+        requestId: "req_failed",
+        requestDeltaJson: '[{"role":"user","content":"original"}]',
+        responseJson: '{"error":{"message":"provider failed"}}',
+      }),
+    ]);
+  });
+
   it("records a timed-out request as an error even if the provider later completed", async () => {
     const s = sink();
     const d: RecordServedDeps = {

--- a/apps/gateway/src/routes/payload-capture.ts
+++ b/apps/gateway/src/routes/payload-capture.ts
@@ -721,9 +721,10 @@ export function stampRequestBodyBytes(
 }
 
 // Record ONE served request: the telemetry row (always — this is what makes the
-// request appear in /admin/requests) plus the verbatim request/response payload
-// (gated by capture_payloads). Shared by the three pipeline faces (/v1/responses,
-// /v1/messages, gemini) so the recording logic can never drift between them again.
+// request appear in /admin/requests) plus the verbatim request/response payload.
+// Successful requests follow the configured content mode; terminal failures force
+// both exact payload and Session capture for diagnosis. Shared by the pipeline faces
+// (/v1/responses, /v1/messages, gemini) so the recording logic cannot drift.
 // Fully FAIL-OPEN: a telemetry/payload failure must never turn a served response
 // into a 5xx or break a stream.
 export async function recordServed(
@@ -747,13 +748,27 @@ export async function recordServed(
   // pipelines may carry a separate client trace_id for response/log correlation,
   // but telemetry.request_id and request_payloads.request_id must always use the
   // server-generated context request_id passed in args.
-  const storageDecision: DecisionRecord = {
-    ...stampRequestBodyBytes(args.decision, args.requestJson, args.requestBodyBytes),
-    request_id: args.requestId,
-    request_content_mode: effectiveRequestContentMode(deps),
-  };
-  const decision =
+  const storageDecision = stampRequestBodyBytes(
+    args.decision,
+    args.requestJson,
+    args.requestBodyBytes,
+  );
+  const finalDecision =
     args.timedOut === true ? decisionForTimedOutRequest(storageDecision) : storageDecision;
+  const failed = finalDecision.final.status === "error";
+  const captureDeps: RecordServedDeps = failed
+    ? {
+        ...deps,
+        capturePayloads: () => true,
+        captureSessions: () => true,
+        captureGeneration: undefined,
+      }
+    : deps;
+  const decision: DecisionRecord = {
+    ...finalDecision,
+    request_id: args.requestId,
+    request_content_mode: failed ? "payload" : effectiveRequestContentMode(deps),
+  };
   const responseJson = args.timedOut === true ? null : args.responseJson;
   const sessionResponse =
     decision.protocol === "openai_responses"
@@ -779,9 +794,9 @@ export async function recordServed(
       apiKeyId: args.apiKeyId,
       createdAt: new Date(deps.now()),
     });
-    await queueOrPersistSessionRequest(deps, sessionArgs, log);
-    if (captureEnabled(deps)) {
-      const generation = deps.captureGeneration?.();
+    await queueOrPersistSessionRequest(captureDeps, sessionArgs, log);
+    if (captureEnabled(captureDeps)) {
+      const generation = captureDeps.captureGeneration?.();
       await w.enqueuePayload(
         {
           requestId: args.requestId,
@@ -792,7 +807,7 @@ export async function recordServed(
         },
         generation === undefined
           ? undefined
-          : () => deps.captureGeneration?.() === generation && captureEnabled(deps),
+          : () => captureDeps.captureGeneration?.() === generation && captureEnabled(captureDeps),
       );
       // Retention is NOT pruned on the request path — the scheduled cleanup runner
       // owns payload retention (archive-first), governed by the cleanup settings.
@@ -801,9 +816,9 @@ export async function recordServed(
   }
 
   // Inline path (no write queue): today's behavior, byte-for-byte.
-  await queueOrPersistSessionRequest(deps, sessionArgs, log);
+  await queueOrPersistSessionRequest(captureDeps, sessionArgs, log);
   await persistPayload(
-    deps,
+    captureDeps,
     {
       requestId: args.requestId,
       requestJson: args.requestJson,

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -37,7 +37,9 @@ const AUTH = { Authorization: "Bearer helm_live_secret", "Content-Type": "applic
 // to recordServed → redact → telemetry.insert (it never inspects fields). The
 // `model_alias` marker lets a test assert the redacted decision actually rode the
 // insert call.
-const FAKE_DECISION = { final: { status: "ok", model_alias: "gpt-4o" } } as never;
+function fakeDecision(): never {
+  return { final: { status: "ok", model_alias: "gpt-4o" } } as never;
+}
 
 describe("settleResponsesStreamOutcome", () => {
   it("gives an overall request timeout precedence over an AbortError", () => {
@@ -165,7 +167,7 @@ function makeDeps(
           order.push("route");
           harness.pipelineSawIR = ir;
           return {
-            decision: FAKE_DECISION,
+            decision: fakeDecision(),
             ...(over.nativePassthrough === true ? { nativePassthrough: true } : {}),
             ...(over.responseMetadata !== undefined
               ? { responseMetadata: over.responseMetadata }
@@ -379,7 +381,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       run: async (_ir, _identity, signal) => {
         pipelineSignal = signal;
         return {
-          decision: FAKE_DECISION,
+          decision: fakeDecision(),
           collect: async () => ({}),
           streamIR: async function* () {
             started.resolve(undefined);
@@ -568,7 +570,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       run: async () => {
         pipelineOpened = true;
         return {
-          decision: FAKE_DECISION,
+          decision: fakeDecision(),
           responseMetadata: {
             "openai-model": "gpt-5.6-sol",
             "x-codex-turn-state": "stream-turn-state",
@@ -1689,7 +1691,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     const route: RouteFn = async (request) => {
       routeHarness.routed = request;
       return {
-        decision: FAKE_DECISION,
+        decision: fakeDecision(),
         final: { status: "ok", alias: "openai-codex/gpt-5.6-sol" },
         body: null,
         stream: (async function* () {
@@ -1757,7 +1759,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     const route: RouteFn = async (request) => {
       routeHarness.routed = request;
       return {
-        decision: FAKE_DECISION,
+        decision: fakeDecision(),
         final: { status: "ok", alias: "openai-codex/gpt-5.6-sol" },
         body: null,
         stream: (async function* () {
@@ -1853,7 +1855,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
     const route: RouteFn = async (request) => {
       routeHarness.routed = request;
       return {
-        decision: FAKE_DECISION,
+        decision: fakeDecision(),
         final: { status: "ok", alias: "openai-codex/gpt-5.6-sol" },
         body: null,
         stream: (async function* () {
@@ -2256,7 +2258,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
         routeStarted.resolve(undefined);
         await routeMayFinish;
         return {
-          decision: FAKE_DECISION,
+          decision: fakeDecision(),
           collect: async () => ({ id: "ir-resp", choices: [] }),
           streamIR: async function* () {
             yield { type: "response.completed", sequence_number: 2 };

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -183,6 +183,13 @@ and never bloat the decision JSON.
 - `capture_payloads` defaults to **OFF** and stores complete per-request bodies when
   exact inspection or Retry is required. The two modes are mutually exclusive;
   operators can also select metadata-only.
+- A terminally failed request overrides the per-key and global content mode for that
+  request only: Helm stores its verbatim client request, available provider-native
+  request and response/error body in `request_payloads`, and also appends its Session
+  revision. The redacted decision continues to carry the bounded per-attempt upstream
+  status, headers, body, cause, and stack. Successful requests still follow the selected
+  `none` / `payload` / `session` mode. Diagnostic captures use the normal retention and
+  runtime body-size limits and never include authorization headers.
 - Runtime settings are stored in `config_kv`. If that persisted blob is malformed
   or no longer matches the schema, settings load fail-open to safe defaults with
   **both content modes forced off** until the operator saves a valid object; an

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-08-28 · 终端失败强制保留原始载荷与 Session（Gateway / observability，docs/07，原则 3/7）
+
+- 终端 `DecisionRecord.final.status=error`（含请求总超时）在共享 `recordServed` 持久化边界强制写入完整客户端请求、可用的 provider-native 请求及响应/错误正文，同时追加 Session revision；该次 telemetry 标为 `request_content_mode=payload`，因此 Admin 可直接读取精确载荷。成功请求仍严格服从 key 级或全局 `none` / `payload` / `session` 设置。
+- 失败诊断留存明确高于用户/全局正文关闭设置，但仍复用原有敏感数据库、定时 retention、单请求正文内存上限、授权头不入库与 fail-open 写入边界；没有可用 Session identity、provider 尚未生成某段正文或正文超过安全上限时，不伪造缺失数据。无 schema、migration、配置或依赖变化。
+
 ## 2026-08-28 · Grok 4.6 Vision 对齐官方模型合同（Provider catalog / routing，docs/02/04，原则 2/3）
 
 - xAI 当前官方模型页与发布说明明确 `grok-4.6` 接受 text/image 输入并输出 text；Sub2API 当前 OAuth relay 也只对官方 Grok base URL 把该模型声明为 `input_modalities:["text","image"]`，并将图片以 Responses `input_image` 发往 `cli-chat-proxy.grok.com/v1/responses`。因此手工 catalog 将 `xai/grok-4.6.supportsVision` 从 `false` 改为 `true`，避免 Helm 在 provider 调用前误报 `capability_unsatisfiable`；provider executor、lane 与 fallback 均不改。
@@ -57,13 +62,9 @@
 - 只识别这个稳定、精确的上游消息；context overflow、413 和其他确定性请求形状错误仍保持 fail-closed 400，避免把客户端应修复的问题静默转移到 fallback。
 - 当前限制：未开启 payload capture 的历史请求无法定位具体工具字段；修复覆盖路由级 fallback 语义，仍需后续针对真实 Responses→Anthropic tool schema 的 fixture 扩展协议测试。
 
-## 2026-08-25 · Responses 续接只在原账号不可用时搜索 sibling（OAuth provider / Responses，docs/04/05/07，原则 3/5/8）
-
-- **生产根因**：`v0.28.83` 会在原账号已明确返回 `Invalid previous_response_id` 后继续遍历其余账号；每个账号内部又会原样重试一次，六个失败请求因此在返回 SSE error 前静默约 24–26 秒。现在已知原账号实际接到请求后若仍返回精确 invalid-ID，立即 fail-closed；只有持久化原账号已不可调度或 ID 尚无归属时，才保留同 provider/model 的 sibling 搜索。
-- **亲和优先级**：同一请求同时携带 `x-codex-turn-state` 与 `previous_response_id` 时，以不可迁移的 turn state 为最高优先级；Responses WebSocket session 首次成功后也固定到其账号，即使账号繁忙也不把同一上游 socket 状态切到 sibling。translated streaming 补齐原账号不可用时的 previous-ID 恢复入口。无 schema、配置、迁移或依赖变化。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-25 · Responses 续接只在原账号不可用时搜索 sibling**：已知原账号实际收到请求后若仍返回 invalid-ID 立即 fail-closed；只有原账号已不可调度或 ID 尚无归属时才搜索 sibling，turn-state 与活动 WebSocket 始终不迁移；完整原文经 git history 回溯。
 - **2026-08-25 · 持久化 Responses 亲和失效时先探测 sibling 且隔离模型熔断**：原账号 parked/limited 时有界探测 sibling，严格 turn-state 仍不迁移，账号级不可用不污染共享 breaker；完整原文经 git history 回溯。
 - **2026-08-24 · Codex Responses 续接 ID 可在账号池内有界找回原账号**：只在尚无可靠归属且没有客户端可见输出时有界探测同 provider/model sibling，并同步修复 sticky/registry；其他状态型失败保持 fail-closed，完整原文经 git history 回溯。
 - **2026-08-22 · xAI OAuth TTS 端点**：新增只绑定实时媒体 entitlement 的 xAI OAuth voices 查询与音频生成端点；付费生成单写、不重试、不切账号，并接入请求预算、用量与脱敏 telemetry；无可信 TTS 价格合同时美元限额 key fail-closed，完整原文经 git history 回溯。


### PR DESCRIPTION
## Summary
- always persist the verbatim client and available upstream/error payload for terminal failures
- append the failed request to its Session transcript even when normal capture is disabled
- keep successful requests on the configured per-key/global content mode

## Verification
- `CI=true pnpm exec vitest run apps/gateway/src/routes/payload-capture.test.ts`
- `CI=true pnpm exec vitest run apps/gateway/src/routes/messages.test.ts apps/gateway/src/routes/gemini.test.ts`
- focused Responses capture-off regression
- `CI=true pnpm --filter @helm/gateway typecheck`
- Biome + `git diff --check`