### PR TITLE
release: v0.28.94

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.93",
+  "version": "0.28.94",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- release Helm API v0.28.94
- include failed-request diagnostic payload and session capture from #806

## Release assessment
- patch release: backward-compatible observability behavior
- no public API, schema, migration, config, or dependency changes

## Verification
- version-only diff from current main
- full CI required before merge