### PR TITLE
fix: pace Codex affinity recovery after rate limits

### DIFF
--- a/apps/gateway/src/responses-websocket.test.ts
+++ b/apps/gateway/src/responses-websocket.test.ts
@@ -1193,6 +1193,80 @@ describe("Responses websocket bridge", () => {
     expect(closedSessionId).not.toBe("");
   });
 
+  it("paces a trusted pre-send recovery until its short account cooldown expires", async () => {
+    const baseUrl = await startBridge(
+      async () =>
+        new Response(
+          'event: error\ndata: {"type":"error","code":"response_create_not_sent","message":"retry original account","recovery":{"safe_to_replay":true,"lifecycle_phase":"before_send","retry_after_ms":50}}\n\n',
+          {
+            headers: {
+              "content-type": "text/event-stream",
+              [CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER]: TEST_SESSION_PROOF,
+            },
+          },
+        ),
+      undefined,
+      {
+        responseWorkAdmission: createResponseWorkAdmission({
+          capacityBytes: 1_000_000,
+          jsonAmplification: 1,
+          minChargeBytes: 1,
+        }),
+      },
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    const startedAt = Date.now();
+    const closed = once(socket, "close");
+    socket.send(JSON.stringify({ type: "response.create", model: "gpt-5.6-sol", input: [] }));
+
+    const [code] = await closed;
+
+    expect(code).toBe(1012);
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(40);
+  });
+
+  it("caps a trusted recovery delay before closing once", async () => {
+    const baseUrl = await startBridge(
+      async () =>
+        new Response(
+          'event: error\ndata: {"type":"error","code":"response_create_not_sent","message":"retry original account","recovery":{"safe_to_replay":true,"lifecycle_phase":"before_send","retry_after_ms":50000}}\n\n',
+          {
+            headers: {
+              "content-type": "text/event-stream",
+              [CODEX_RESPONSES_WEBSOCKET_RECOVERY_PROOF_HEADER]: TEST_SESSION_PROOF,
+            },
+          },
+        ),
+      undefined,
+      {
+        responseWorkAdmission: createResponseWorkAdmission({
+          capacityBytes: 1_000_000,
+          jsonAmplification: 1,
+          minChargeBytes: 1,
+        }),
+      },
+    );
+    const socket = await connect(`${baseUrl}/v1/responses`);
+    let closeCode: number | undefined;
+    socket.once("close", (code) => {
+      closeCode = code;
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      socket.send(JSON.stringify({ type: "response.create", model: "gpt-5.6-sol", input: [] }));
+      await vi.waitFor(() => expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000));
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(closeCode).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(closeCode).toBe(1012));
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("turns a non-OK nested recovery marker into a retryable disconnect", async () => {
     const baseUrl = await startBridge(async () =>
       Response.json(

--- a/apps/gateway/src/responses-websocket.ts
+++ b/apps/gateway/src/responses-websocket.ts
@@ -28,6 +28,7 @@ const RESPONSES_WEBSOCKET_PATHS = new Set(["/v1/responses", "/responses", "/open
 const DEFAULT_PREFLIGHT_TIMEOUT_MS = 6_000;
 const DEFAULT_IDLE_SESSION_TIMEOUT_MS = 30 * 60_000;
 const DEFAULT_MAX_PREFLIGHT_REQUESTS = 128;
+const MAX_RECOVERY_DELAY_MS = 10_000;
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -335,9 +336,42 @@ function recoverableDisconnectCode(value: unknown): string | null {
   return null;
 }
 
-function closeForFullHistoryRecovery(socket: WebSocket): void {
-  if (socket.readyState === WebSocket.OPEN)
+function recoveryDelayMs(value: unknown): number {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return 0;
+  const recovery = (value as { recovery?: unknown }).recovery;
+  if (recovery === null || typeof recovery !== "object" || Array.isArray(recovery)) return 0;
+  const record = recovery as Record<string, unknown>;
+  const delay = record.retry_after_ms;
+  return record.safe_to_replay === true &&
+    record.lifecycle_phase === "before_send" &&
+    Number.isSafeInteger(delay) &&
+    (delay as number) > 0
+    ? Math.min(delay as number, MAX_RECOVERY_DELAY_MS)
+    : 0;
+}
+
+function waitForRecoveryDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (delayMs <= 0 || signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timer = setTimeout(done, delayMs);
+    signal.addEventListener("abort", done, { once: true });
+  });
+}
+
+async function closeForFullHistoryRecovery(
+  socket: WebSocket,
+  recovery: unknown,
+  signal: AbortSignal,
+): Promise<void> {
+  await waitForRecoveryDelay(recoveryDelayMs(recovery), signal);
+  if (!signal.aborted && socket.readyState === WebSocket.OPEN) {
     socket.close(1012, "upstream response stream disconnected");
+  }
 }
 
 function websocketPayload(event: string | undefined, data: string): string | null {
@@ -399,7 +433,7 @@ async function forwardResponse(
   if (!response.ok) {
     const envelope = await responseErrorEnvelope(response);
     if (trustedRecovery && recoverableDisconnectCode(envelope) !== null) {
-      closeForFullHistoryRecovery(socket);
+      await closeForFullHistoryRecovery(socket, envelope, signal);
       return true;
     }
     await sendEnvelope(socket, envelope);
@@ -422,7 +456,7 @@ async function forwardResponse(
       type = parsed.type;
       if (trustedRecovery && recoverableDisconnectCode(parsed) !== null) {
         void body.cancel().catch(() => {});
-        closeForFullHistoryRecovery(socket);
+        await closeForFullHistoryRecovery(socket, parsed, signal);
         return true;
       }
     } catch {

--- a/apps/gateway/src/routes/responses.test.ts
+++ b/apps/gateway/src/routes/responses.test.ts
@@ -2380,6 +2380,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       streamIR: async function* () {
         throw new PipelineError("lane_unavailable", "response.create was not sent", "trace-1", {
           error: { code: "response_create_not_sent" },
+          recovery: { retry_after_ms: 6_000 },
         });
       },
     });
@@ -2395,6 +2396,7 @@ describe("POST /v1/responses (OpenAI Responses inbound)", () => {
       {
         type: "error",
         code: "response_create_not_sent",
+        recovery: { retry_after_ms: 6_000 },
       },
     );
   });

--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -597,6 +597,23 @@ function codexResponsesLifecycleFailureCode(providerRaw: unknown): string | null
     : null;
 }
 
+function codexResponsesRecovery(providerRaw: unknown): Record<string, unknown> | undefined {
+  if (providerRaw === null || typeof providerRaw !== "object" || Array.isArray(providerRaw)) {
+    return undefined;
+  }
+  const recovery = (providerRaw as { recovery?: unknown }).recovery;
+  if (recovery === null || typeof recovery !== "object" || Array.isArray(recovery)) {
+    return undefined;
+  }
+  const retryAfterMs = (recovery as { retry_after_ms?: unknown }).retry_after_ms;
+  if (!Number.isSafeInteger(retryAfterMs) || (retryAfterMs as number) <= 0) return undefined;
+  return {
+    safe_to_replay: true,
+    lifecycle_phase: "before_send",
+    retry_after_ms: retryAfterMs,
+  };
+}
+
 function scrubUntrustedRecoveryCode(data: string): string | null {
   let changed = false;
   try {
@@ -622,6 +639,7 @@ function responsesStreamError(args: {
   message: string;
   traceId: string;
   sequenceNumber: number;
+  recovery?: Record<string, unknown>;
 }): Record<string, unknown> {
   return {
     type: "error",
@@ -630,6 +648,7 @@ function responsesStreamError(args: {
     param: null,
     sequence_number: args.sequenceNumber,
     trace_id: args.traceId,
+    ...(args.recovery === undefined ? {} : { recovery: args.recovery }),
   };
 }
 
@@ -1516,6 +1535,17 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     ? codexResponsesLifecycleFailureCode(err.providerRaw)
                     : null
                   : null;
+            const lifecycleProviderRaw =
+              err instanceof PipelineError
+                ? err.provider_raw
+                : err instanceof UpstreamError
+                  ? err.providerRaw
+                  : null;
+            const lifecycleRecovery = isCodexResponsesRecoverableDisconnectCode(
+              lifecycleFailureCode,
+            )
+              ? codexResponsesRecovery(lifecycleProviderRaw)
+              : undefined;
             const body =
               err instanceof PipelineError
                 ? responsesStreamError({
@@ -1523,6 +1553,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     message: err.message,
                     traceId,
                     sequenceNumber: nextErrorSequence,
+                    recovery: lifecycleRecovery,
                   })
                 : responsesStreamError({
                     // Preserve a mid-stream idle timeout instead of internal_error.
@@ -1532,6 +1563,7 @@ export function registerResponsesRoute(app: Hono<AppEnv>, deps: ResponsesRouteDe
                     message: err instanceof Error ? err.message : "upstream error",
                     traceId,
                     sequenceNumber: nextErrorSequence,
+                    recovery: lifecycleRecovery,
                   });
             const data = JSON.stringify(body);
             captured?.push(`event: error\ndata: ${data}\n\n`);

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-08-29 · Codex 429 短冷却在安全恢复前精确等待（OAuth provider / Responses / Gateway，docs/04/05/07，原则 3/5/8）
+
+- **根因与冷却语义**：Codex 上游已用数值型 `Retry-After` 声明短暂限流，但 OAuth pool 仍按固定 60 秒停车；严格 `x-codex-turn-state` 亲和在原账号停车期间连续产生本地 400。pool 现在复用既有重试解析规则、大小写不敏感读取 HTTP 与 WebSocket 包装 header，并以严格 delta-seconds 设置账号或模型冷却；异常超大值最多停车 24 小时，已有更晚的精确 quota reset 继续 extend-only，不会被缩短。
+- **安全恢复边界**：严格亲和仍不切 sibling；仅 provider 调用前即可证明未发送的 `response_create_not_sent` 携带原账号剩余 `retry_after_ms`。Gateway 只接受内部 recovery proof 与类型化字段，Responses WebSocket 对短冷却做可中止等待，超过 10 秒的等待封顶为 10 秒，再沿用一次 `1012` 完整历史恢复；未知或过期冷却立即恢复，发送后或结果不明的 `response.create` 仍禁止重放。
+- 没有新增 schema、migration、配置或依赖；10 秒上限只约束网关本地等待，不改变 provider/account/WebSocket 亲和合同。
+
 ## 2026-08-28 · 终端失败强制保留原始载荷与 Session（Gateway / observability，docs/07，原则 3/7）
 
 - 终端 `DecisionRecord.final.status=error`（含请求总超时）在共享 `recordServed` 持久化边界强制写入完整客户端请求、可用的 provider-native 请求及响应/错误正文，同时追加 Session revision；该次 telemetry 标为 `request_content_mode=payload`，因此 Admin 可直接读取精确载荷。成功请求仍严格服从 key 级或全局 `none` / `payload` / `session` 设置。
@@ -56,14 +62,9 @@
 - **transport 边界**：Codex continuation 必须复用产生该 response ID 的当前活动原 WebSocket；原 session 缺失/不匹配、连接关闭、426/connection-limit、模糊 send failure 均禁止重连和 HTTP fallback，返回 `previous_response_id_session_unavailable` 并要求完整会话。精确 invalid-ID 仍只在同一活动 WebSocket 上原样重试一次。
 - **registry 边界**：`completed` 与协议允许的 `incomplete` registry 记录可作为续接父节点；`failed`、`cancelled`、内部 `truncated` 与其他状态在路由前 fail-closed。OAuth 记录还必须带原账号，避免旧空 owner 被 turn-state 绕过；静态 Responses provider 继续允许空账号。没有新增 schema、迁移、配置或正文持久化。
 
-## 2026-08-25 · Anthropic tool_result 400 允许协议级 fallback（协议互译 / docs/05、07，原则 3/5/8）
-
-- Anthropic 的 `Advisor tool result content could not be processed` 是目标 provider 的工具结果格式拒绝，不等价于跨 provider 的全局请求非法；该候选现在记录 `provider_protocol_incompatible` 并继续尝试下一个兼容 lane，不处罚共享 breaker。
-- 只识别这个稳定、精确的上游消息；context overflow、413 和其他确定性请求形状错误仍保持 fail-closed 400，避免把客户端应修复的问题静默转移到 fallback。
-- 当前限制：未开启 payload capture 的历史请求无法定位具体工具字段；修复覆盖路由级 fallback 语义，仍需后续针对真实 Responses→Anthropic tool schema 的 fixture 扩展协议测试。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-25 · Anthropic tool_result 400 允许协议级 fallback**：仅精确的 `Advisor tool result content could not be processed` 记为候选协议不兼容并继续 fallback；其他确定性客户端错误仍 fail-closed，完整原文经 git history 回溯。
 - **2026-08-25 · Responses 续接只在原账号不可用时搜索 sibling**：已知原账号实际收到请求后若仍返回 invalid-ID 立即 fail-closed；只有原账号已不可调度或 ID 尚无归属时才搜索 sibling，turn-state 与活动 WebSocket 始终不迁移；完整原文经 git history 回溯。
 - **2026-08-25 · 持久化 Responses 亲和失效时先探测 sibling 且隔离模型熔断**：原账号 parked/limited 时有界探测 sibling，严格 turn-state 仍不迁移，账号级不可用不污染共享 breaker；完整原文经 git history 回溯。
 - **2026-08-24 · Codex Responses 续接 ID 可在账号池内有界找回原账号**：只在尚无可靠归属且没有客户端可见输出时有界探测同 provider/model sibling，并同步修复 sticky/registry；其他状态型失败保持 fail-closed，完整原文经 git history 回溯。

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -1953,14 +1953,24 @@ describe("createOAuthPoolClient — nativePassthroughStream", () => {
     }
     pool.setUsageLimit("a", 50_000);
 
-    expect(() =>
+    let caught: unknown;
+    try {
       pool.nativePassthroughStream?.({
         protocol: "openai_responses",
         body: { model: "gpt-5.6-sol", stream: true, input: "continue" },
         headers: { "x-codex-turn-state": "strict-turn-state" },
         mutations: {},
-      }),
-    ).toThrow(/x-codex-turn-state.*original account.*unavailable/i);
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(CodexResponsesBeforeSendError);
+    expect((caught as CodexResponsesBeforeSendError).message).toMatch(
+      /x-codex-turn-state.*original account.*unavailable/i,
+    );
+    expect((caught as CodexResponsesBeforeSendError).providerRaw).toMatchObject({
+      recovery: { retry_after_ms: 49_000 },
+    });
     expect(calls).toEqual(["a"]);
   });
 
@@ -2365,10 +2375,16 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     const served: string[] = [];
     const limited: Array<{ account: string; untilMs: number }> = [];
     const selected: string[] = [];
+    const rateWithRetryAfter = new UpstreamError("upstream_error", "usage limit", null, 429, {
+      "Retry-After": "6",
+    });
     const pool = createOAuthPoolClient({
-      members: [faultMember("a", 10, served, RATE), faultMember("b", 50, served, null)],
+      members: [
+        faultMember("a", 10, served, rateWithRetryAfter),
+        faultMember("b", 50, served, null),
+      ],
       now: () => 1_000,
-      accountRateLimitCooldownMs: 250,
+      accountRateLimitCooldownMs: 60_000,
       onAccountRateLimit: (account, untilMs) => limited.push({ account, untilMs }),
       onSelect: (account) => selected.push(account),
     });
@@ -2377,7 +2393,7 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     await expect(pool.chatCompletion(REQ)).resolves.toEqual({ served_by: "b" });
     expect(served).toEqual(["b", "b"]);
     expect(selected).toEqual(["a", "b", "b"]);
-    expect(limited).toEqual([{ account: "a", untilMs: 1_250 }]);
+    expect(limited).toEqual([{ account: "a", untilMs: 7_000 }]);
   });
 
   it("treats an account queue timeout as sibling capacity failover", async () => {

--- a/packages/core/src/provider/oauth/pool.ts
+++ b/packages/core/src/provider/oauth/pool.ts
@@ -38,6 +38,7 @@ import {
   CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER,
   CodexResponsesBeforeSendError,
 } from "../openai-responses.js";
+import { numericRetryAfterMs } from "../retry.js";
 import { TokenRefreshError } from "../token-manager.js";
 import { DEFAULT_429_COOLDOWN_MS } from "./usage-limit.js";
 
@@ -354,16 +355,26 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
   }
 
   function modelLimited(account: string, model: string | null, nowMs: number): boolean {
-    if (model === null) return false;
-    let limited = false;
+    return modelLimitUntilMs(account, model, nowMs) !== null;
+  }
+
+  function modelLimitUntilMs(account: string, model: string | null, nowMs: number): number | null {
+    if (model === null) return null;
+    let untilMs: number | null = null;
     for (const [key, cooldown] of scopedRateLimits) {
       if (cooldown.untilMs <= nowMs) {
         scopedRateLimits.delete(key);
         continue;
       }
-      if (cooldown.account === account && cooldown.model === model) limited = true;
+      if (
+        cooldown.account === account &&
+        cooldown.model === model &&
+        (untilMs === null || cooldown.untilMs > untilMs)
+      ) {
+        untilMs = cooldown.untilMs;
+      }
     }
-    return limited;
+    return untilMs;
   }
 
   function headerValue(headers: Record<string, string | string[]>, name: string): string | null {
@@ -931,11 +942,13 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     };
     let stickyEntry: PoolEntry | undefined;
     let knownSticky = false;
+    let knownStickyAccount: string | null = null;
     const stickyOnly = isStrictAccountSticky(stickyKey ?? null);
     if (stickyKey) {
       const sticky = stickySessions.get(stickyKey);
       if (sticky !== undefined && sticky.expiresAt > nowMs) {
         knownSticky = true;
+        knownStickyAccount = sticky.account;
         const stickyCandidates = stickyOnly ? eligible : capacityTier.candidates;
         const entry = stickyCandidates.find(
           (candidate) => candidate.member.account === sticky.account,
@@ -962,9 +975,22 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
     }
     if (stickyOnly && knownSticky) {
       const source = affinityKeySource(stickyKey ?? null) ?? "stateful continuation";
+      const stickyMember = entries.find(
+        (entry) => entry.member.account === knownStickyAccount,
+      )?.member;
+      const accountLimit =
+        stickyMember?.allowSpendRemainingCredits === true
+          ? null
+          : (stickyMember?.usageLimitedUntilMs ?? null);
+      const modelLimit =
+        knownStickyAccount === null ? null : modelLimitUntilMs(knownStickyAccount, model, nowMs);
+      const limitUntilMs = Math.max(accountLimit ?? 0, modelLimit ?? 0);
       throw new CodexResponsesBeforeSendError(
         `oauth pool: ${source} original account is unavailable`,
-        { reason: "oauth_affinity_unavailable" },
+        {
+          reason: "oauth_affinity_unavailable",
+          ...(limitUntilMs > nowMs ? { retry_after_ms: limitUntilMs - nowMs } : {}),
+        },
       );
     }
     const { entry: best, reason } = chooseByStrategy(
@@ -1038,9 +1064,14 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
 
   function parkRateLimitedAccount(entry: PoolEntry, err: unknown, model: string | null): void {
     const scope = rateLimitScope(entry, err, model);
+    const retryAfter =
+      err instanceof UpstreamError && err.upstreamHeaders !== null
+        ? headerValue(err.upstreamHeaders, "retry-after")
+        : null;
+    const cooldownMs = numericRetryAfterMs(retryAfter) ?? accountRateLimitCooldownMs;
     if (scope.scope === "model") {
       const key = scopedRateLimitKey(entry.member.account, scope.model, scope.limitId);
-      const candidate = now() + accountRateLimitCooldownMs;
+      const candidate = now() + cooldownMs;
       const current = scopedRateLimits.get(key);
       scopedRateLimits.set(key, {
         account: entry.member.account,
@@ -1051,7 +1082,7 @@ export function createOAuthPoolClient(deps: OAuthPoolDeps): OAuthPoolClient {
       forgetStickyAccount(entry.member.account, true);
       return;
     }
-    const candidate = now() + accountRateLimitCooldownMs;
+    const candidate = now() + cooldownMs;
     // Extend-only: a precise upstream quota reset (e.g. a Codex weekly limit, captured
     // from response headers before the 429 threw) may already sit far in the future —
     // the generic short fallback must never pull it back in. Propagate the kept value to

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -4116,6 +4116,9 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(connection.closeCalls).toBe(1);
     expect(connect).toHaveBeenCalledTimes(1);
     if (status === 429) {
+      expect((caught as UpstreamError).upstreamHeaders).toMatchObject({
+        "retry-after": "17",
+      });
       expect((caught as UpstreamError).providerRaw).toMatchObject({
         headers: {
           "retry-after": "17",

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1991,7 +1991,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     const providerRaw =
       Object.keys(selectedHeaders).length > 0 ? { body, headers: scrub(selectedHeaders) } : body;
     return {
-      error: new UpstreamError("upstream_error", message, providerRaw, rawStatus),
+      error: new UpstreamError("upstream_error", message, providerRaw, rawStatus, selectedHeaders),
       headers,
     };
   }

--- a/packages/core/src/provider/retry.test.ts
+++ b/packages/core/src/provider/retry.test.ts
@@ -2,9 +2,23 @@ import { describe, expect, it, vi } from "vitest";
 import {
   isFetchTransportError,
   isTransientConnectionError,
+  numericRetryAfterMs,
   overloadRetryDelayMs,
   withConnectionRetry,
 } from "./retry.js";
+
+describe("numericRetryAfterMs", () => {
+  it("parses positive delta-seconds and rejects unusable values", () => {
+    expect(numericRetryAfterMs("6")).toBe(6_000);
+    expect(numericRetryAfterMs("0.5")).toBeNull();
+    expect(numericRetryAfterMs("soon")).toBeNull();
+    expect(numericRetryAfterMs("0")).toBeNull();
+    expect(numericRetryAfterMs("-1")).toBeNull();
+    expect(numericRetryAfterMs("999999999999999999999999999999999999999999999999999999")).toBe(
+      86_400_000,
+    );
+  });
+});
 
 // A transient connection error is one safe to retry BEFORE any bytes reached the
 // client (idempotent: no upstream response consumed). The classifier is a strict

--- a/packages/core/src/provider/retry.ts
+++ b/packages/core/src/provider/retry.ts
@@ -104,6 +104,17 @@ const OVERLOAD_BACKOFF_MS = [1_000, 3_000] as const;
 // must not hold the client's socket open — past this we give up and let the executor
 // fall back to another candidate, which is the faster path to an answer.
 const OVERLOAD_MAX_DELAY_MS = 10_000;
+const MAX_NUMERIC_RETRY_AFTER_MS = 24 * 60 * 60_000;
+
+export function numericRetryAfterMs(value: string | null | undefined): number | null {
+  const raw = value?.trim();
+  if (raw === undefined || !/^\d+$/.test(raw)) return null;
+  const seconds = Number(raw);
+  if (seconds <= 0) return null;
+  return Number.isFinite(seconds)
+    ? Math.min(seconds * 1_000, MAX_NUMERIC_RETRY_AFTER_MS)
+    : MAX_NUMERIC_RETRY_AFTER_MS;
+}
 
 /**
  * Backoff (ms) before re-issuing an overloaded upstream request, or null when this
@@ -120,10 +131,8 @@ export function overloadRetryDelayMs(args: {
   if (!OVERLOAD_STATUSES.has(args.status)) return null;
   const fallback = OVERLOAD_BACKOFF_MS[args.attempt];
   if (fallback === undefined) return null;
-  const seconds = Number(args.retryAfter?.trim());
-  if (Number.isFinite(seconds) && seconds > 0) {
-    return Math.min(seconds * 1000, OVERLOAD_MAX_DELAY_MS);
-  }
+  const retryAfterMs = numericRetryAfterMs(args.retryAfter);
+  if (retryAfterMs !== null) return Math.min(retryAfterMs, OVERLOAD_MAX_DELAY_MS);
   return fallback;
 }
 


### PR DESCRIPTION
## Summary
- honor numeric Codex Retry-After on HTTP and wrapped WebSocket 429s
- preserve strict provider/account/WebSocket affinity while carrying trusted pre-send cooldown metadata
- wait abortably before the existing 1012 full-history recovery, capped at 10 seconds
- keep post-send or ambiguous response.create outcomes non-replayable

## Verification
- `CI=true pnpm exec vitest run packages/core/src/provider/retry.test.ts packages/core/src/provider/oauth/pool.test.ts --pool=threads --maxWorkers=1` (147 passed)
- wrapped WebSocket 429 focused tests (2 passed)
- Responses route recovery seam (1 passed)
- WebSocket pacing/no-replay tests (3 passed)
- `CI=true pnpm --filter @helm/core exec tsc --noEmit --pretty false`
- `CI=true pnpm --filter @helm/gateway exec tsc --noEmit --pretty false`
- focused Biome checks and `git diff --check`

## Known baseline
The existing lost-continuation WebSocket test times out identically on clean `origin/main@6ec14c9d`; the directly affected pacing and no-replay cases pass.