### PR TITLE
release: v0.28.95

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.94",
+  "version": "0.28.95",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump Helm API from `0.28.94` to `0.28.95`
- publish the Codex Retry-After pacing and strict-affinity recovery fix merged in #808

## Risk
Patch release only. No schema, migration, configuration, or dependency changes. Production will be pinned to the exact immutable GHCR digest after Publish image succeeds.