### PR TITLE
fix(images): preserve Codex output cardinality and abort streams

### DIFF
--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -4629,6 +4629,30 @@ describe("createCodexResponsesClient — Images API bridge", () => {
     });
   });
 
+  it("preserves duplicate image payloads when the upstream returns n > 1", async () => {
+    const fetchMock = vi.fn(async () =>
+      sseResponse([
+        {
+          type: "response.completed",
+          response: {
+            output: [
+              { type: "image_generation_call", result: "same-image" },
+              { type: "image_generation_call", result: "same-image" },
+            ],
+          },
+        },
+      ]),
+    ) as unknown as typeof fetch;
+
+    const out = await clientFor(fetchMock).imageGeneration?.({
+      model: "gpt-image-2",
+      prompt: "draw two identical icons",
+      n: 2,
+    });
+
+    expect(out?.data).toHaveLength(2);
+  });
+
   it("maps JSON and multipart edits to input images and a mask", async () => {
     const sent: Record<string, unknown>[] = [];
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1349,23 +1349,22 @@ async function readCodexImageResponse(
   responseFormat: string,
   idleMs: number,
   workAdmission: ResponseWorkAdmission,
+  signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
-  const data: Record<string, unknown>[] = [];
-  const seen = new Set<string>();
+  let data: Record<string, unknown>[] = [];
   let created = Math.floor(Date.now() / 1_000);
   let usage: Record<string, unknown> | undefined;
   let completed = false;
-  const append = (value: unknown): void => {
+  const append = (value: unknown, target: Record<string, unknown>[]): void => {
     if (!isRecord(value)) return;
     const result = imageString(value.result);
-    if (!result || seen.has(result)) return;
+    if (!result) return;
     const item = codexImageData(value, responseFormat);
     if (!item) return;
-    seen.add(result);
-    data.push(item);
+    target.push(item);
   };
 
-  for await (const event of readResponsesEvents(response, idleMs, workAdmission)) {
+  for await (const event of readResponsesEvents(response, idleMs, workAdmission, signal)) {
     if (
       event.type === "error" ||
       event.type === "response.failed" ||
@@ -1373,11 +1372,21 @@ async function readCodexImageResponse(
     ) {
       throw responseEventError(event);
     }
-    if (event.type === "response.output_item.done") append(event.item);
+    if (event.type === "response.output_item.done") {
+      const item: Record<string, unknown>[] = [];
+      append(event.item, item);
+      data.push(...item);
+    }
     if (event.type !== "response.completed") continue;
     const final = isRecord(event.response) ? event.response : {};
     if (typeof final.created_at === "number" && final.created_at > 0) created = final.created_at;
-    if (Array.isArray(final.output)) final.output.forEach(append);
+    if (Array.isArray(final.output)) {
+      const completedData: Record<string, unknown>[] = [];
+      for (const value of final.output) append(value, completedData);
+      // The completed response is authoritative when present. Do not deduplicate
+      // by base64 payload: two valid generated images may intentionally be identical.
+      if (completedData.length > 0) data = completedData;
+    }
     const toolUsage = isRecord(final.tool_usage) ? final.tool_usage : {};
     if (isRecord(toolUsage.image_gen)) usage = toolUsage.image_gen;
     completed = true;
@@ -1810,6 +1819,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       requestBody.responseFormat,
       timeoutMs,
       deps.responseWorkAdmission ?? runtimeResponseWorkAdmission(),
+      opts?.signal,
     );
   }
 
@@ -3120,6 +3130,7 @@ export async function* readResponsesEvents(
   // (connect/TTFB timeout was already cleared at headers).
   idleMs = 0,
   workAdmission: ResponseWorkAdmission = runtimeResponseWorkAdmission(),
+  signal?: AbortSignal,
 ): AsyncGenerator<Record<string, unknown>> {
   const body = res.body;
   if (!body) return;
@@ -3131,7 +3142,7 @@ export async function* readResponsesEvents(
     while (true) {
       let read: { done: boolean; value?: Uint8Array };
       try {
-        read = await readChunkWithIdle(reader, idleMs);
+        read = await readChunkWithIdle(reader, idleMs, signal);
       } catch (err) {
         if (err instanceof StreamStalledError) throw new UpstreamError("timeout", err.message);
         throw err;

--- a/packages/core/src/provider/stream-idle.test.ts
+++ b/packages/core/src/provider/stream-idle.test.ts
@@ -53,6 +53,15 @@ describe("readChunkWithIdle", () => {
     expect(reader.cancelReasons).toHaveLength(0);
   });
 
+  it("cancels a pending read when the caller aborts", async () => {
+    const reader = fakeReader([() => new Promise<ReadResult>(() => {})]);
+    const controller = new AbortController();
+    const pending = readChunkWithIdle(reader, 0, controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(reader.cancelReasons).toHaveLength(1);
+  });
+
   describe("with fake timers", () => {
     beforeEach(() => vi.useFakeTimers());
     afterEach(() => vi.useRealTimers());

--- a/packages/core/src/provider/stream-idle.ts
+++ b/packages/core/src/provider/stream-idle.ts
@@ -57,13 +57,28 @@ export interface IdleReader<T> {
 export async function readChunkWithIdle<T>(
   reader: IdleReader<T>,
   idleMs: number,
+  signal?: AbortSignal,
 ): Promise<IdleReadResult<T>> {
-  if (!(idleMs > 0)) return reader.read();
+  if (signal?.aborted)
+    throw signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+  if (!(idleMs > 0) && signal === undefined) return reader.read();
 
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const idle = new Promise<typeof STALLED>((resolve) => {
-    timer = setTimeout(() => resolve(STALLED), idleMs);
-  });
+  const idle =
+    idleMs > 0
+      ? new Promise<typeof STALLED>((resolve) => {
+          timer = setTimeout(() => resolve(STALLED), idleMs);
+        })
+      : null;
+  let abort: Promise<never> | null = null;
+  let onAbort: (() => void) | undefined;
+  if (signal !== undefined) {
+    abort = new Promise<never>((_, reject) => {
+      onAbort = () =>
+        reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
 
   const read = reader.read();
   // If the deadline wins, `read` is still pending; swallow any later rejection so
@@ -71,7 +86,7 @@ export async function readChunkWithIdle<T>(
   read.catch(() => {});
 
   try {
-    const raced = await Promise.race([read, idle]);
+    const raced = await Promise.race([read, ...(idle ? [idle] : []), ...(abort ? [abort] : [])]);
     if (raced === STALLED) {
       const err = new StreamStalledError(idleMs);
       // Fire-and-forget: a slow or never-resolving cancel must NOT delay the
@@ -81,7 +96,11 @@ export async function readChunkWithIdle<T>(
       throw err;
     }
     return raced;
+  } catch (error) {
+    if (signal?.aborted) void reader.cancel(error).catch(() => {});
+    throw error;
   } finally {
     if (timer) clearTimeout(timer);
+    if (signal !== undefined && onAbort !== undefined) signal.removeEventListener("abort", onAbort);
   }
 }


### PR DESCRIPTION
Follow-up to merged PR #810 (ChatGPT OAuth image generation).

Fixes two reproducible issues in the Codex image bridge:
- preserve duplicate image payloads so `n > 1` keeps the upstream cardinality;
- propagate caller aborts into the SSE reader and cancel a pending read after headers.

Verification:
- `CI=true pnpm exec vitest run packages/core/src/provider/stream-idle.test.ts packages/core/src/provider/openai-responses.test.ts -t "Images API bridge|readChunkWithIdle"`
- `CI=true pnpm --filter @helm/core typecheck`
- `CI=true pnpm --filter @helm/gateway typecheck`
- `pnpm exec biome check packages/core/src/provider/openai-responses.ts packages/core/src/provider/openai-responses.test.ts packages/core/src/provider/stream-idle.ts packages/core/src/provider/stream-idle.test.ts`
