### PR TITLE
release: v0.28.96

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.95",
+  "version": "0.28.96",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Patch release for the merged ChatGPT OAuth image bridge follow-up.

Release scope:
- preserve `n > 1` image output cardinality even when payloads are identical;
- cancel pending Codex image SSE reads on caller abort.

This PR changes only the root package version from `0.28.95` to `0.28.96`.
