### PR TITLE
fix(images): remove Codex catalog admission gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,10 @@ curl http://localhost:8080/v1/images/generations \
   -d '{ "model": "gpt-image-2", "prompt": "a single red apple on a plain white background", "size": "1024x1024" }'
 ```
 
-With a connected ChatGPT OAuth account, Helm exposes a separate `chatgpt-image`
-lane when that account's live Codex catalog explicitly advertises non-Lite
-`gpt-5.4-mini` with the `image_generation` tool. Generation keeps the route above;
-editing uses the Images edit route:
+With a schedulable ChatGPT OAuth account, Helm exposes a separate `chatgpt-image`
+lane. Codex catalog tool metadata is advisory rather than an admission gate; the
+single client-requested upstream call determines whether that account can use the
+tool. Generation keeps the route above; editing uses the Images edit route:
 
 ```bash
 curl http://localhost:8080/v1/images/edits \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -256,9 +256,10 @@ curl http://localhost:8080/v1/images/generations \
   -d '{ "model": "gpt-image-2", "prompt": "纯白背景上的一颗红苹果", "size": "1024x1024" }'
 ```
 
-连接 ChatGPT OAuth 账号后，若该账号的实时 Codex 模型目录明确开放非 Lite 的
-`gpt-5.4-mini` 和 `image_generation` 工具，Helm 会提供独立的 `chatgpt-image`
-lane。生成仍调用上面的路径；编辑调用同一套 Images 协议的编辑路径：
+存在可调度的 ChatGPT OAuth 账号时，Helm 会提供独立的 `chatgpt-image` lane。
+Codex 模型目录中的工具元数据只作参考，不作为准入门槛；该账号是否真正支持
+生图，由客户端发起的那一次上游调用判定。生成仍调用上面的路径；编辑调用同一套
+Images 协议的编辑路径：
 
 ```bash
 curl http://localhost:8080/v1/images/edits \

--- a/apps/gateway/src/oauth/effective-models.test.ts
+++ b/apps/gateway/src/oauth/effective-models.test.ts
@@ -212,6 +212,21 @@ describe("effectiveOAuthAliases", () => {
 });
 
 describe("effectiveOAuthModelOptions", () => {
+  it("projects the ChatGPT image alias without requiring catalog tool metadata", async () => {
+    const { tokens, config } = makeStores();
+    await bind(tokens, "openai-codex", "default", { accountId: "acc-default" });
+
+    await expect(
+      effectiveOAuthModelOptions({ store: tokens, encKey: KEY }, config, ROUTABLE, {
+        codexCatalog: codexCatalog({ default: [{ slug: "gpt-5.6-sol" }] }),
+      }),
+    ).resolves.toEqual([
+      { alias: "openai-codex/gpt-5.6", accounts: ["default"] },
+      { alias: "openai-codex/gpt-5.6-sol", accounts: ["default"] },
+      { alias: "openai-codex/gpt-image-2", accounts: ["default"] },
+    ]);
+  });
+
   it("projects verified xAI media aliases only from the synthesized runtime pool", async () => {
     const { tokens, config } = makeStores();
     await bind(tokens, "xai", "supergrok-a");
@@ -421,10 +436,22 @@ describe("effectiveOAuthModelOptions", () => {
       { alias: "openai-codex/codex-auto-review", accounts: ["default"] },
       { alias: "openai-codex/gpt-5.6", accounts: ["default"] },
       { alias: "openai-codex/gpt-5.6-sol", accounts: ["default"] },
+      { alias: "openai-codex/gpt-image-2", accounts: ["default"] },
     ]);
   });
 
-  it("exposes no Codex aliases when the account has no exact catalog or stale LKG", async () => {
+  it("keeps the image alias when an auto-mode Codex account has no catalog snapshot", async () => {
+    const { tokens, config } = makeStores();
+    await bind(tokens, "openai-codex", "default", { accountId: "acc-default" });
+
+    await expect(
+      effectiveOAuthModelOptions({ store: tokens, encKey: KEY }, config, ROUTABLE, {
+        codexCatalog: codexCatalog({}),
+      }),
+    ).resolves.toEqual([{ alias: "openai-codex/gpt-image-2", accounts: ["default"] }]);
+  });
+
+  it("does not grant manual Codex text aliases without an exact catalog or stale LKG", async () => {
     const { tokens, config } = makeStores();
     await bind(tokens, "openai-codex", "default", { accountId: "acc-default" });
     await setAccountSettings(config, KEY, "openai-codex", "default", {

--- a/apps/gateway/src/oauth/effective-models.ts
+++ b/apps/gateway/src/oauth/effective-models.ts
@@ -8,7 +8,6 @@ import {
   OPENAI_CODEX_IMAGE_MODEL,
   openAICodexIdentityFingerprint,
   parseOpenAICodexIdentity,
-  supportsOpenAICodexImageGeneration,
 } from "@helm/core";
 import {
   type AccountSettings,
@@ -136,10 +135,10 @@ async function automaticCodexModels(
       clientVersion: options.codexClientVersion ?? DEFAULT_OPENAI_CODEX_CLIENT_VERSION,
     };
     const snapshot = options.codexCatalog.snapshot(key);
-    if (!snapshot) return undefined;
+    if (!snapshot) return [OPENAI_CODEX_IMAGE_MODEL];
     const models = [...snapshot.models].sort((left, right) => left.priority - right.priority);
     const aliases = expandOpenAICodexModelAliases(models.map((model) => model.slug));
-    if (supportsOpenAICodexImageGeneration(models)) aliases.push(OPENAI_CODEX_IMAGE_MODEL);
+    if (!aliases.includes(OPENAI_CODEX_IMAGE_MODEL)) aliases.push(OPENAI_CODEX_IMAGE_MODEL);
     return aliases;
   } catch {
     return undefined;

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -1708,11 +1708,12 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect(aliases).toEqual(["openai-codex/gpt-5.6-luna", "openai-codex/gpt-5.6-sol"]);
   });
 
-  it("exposes the ChatGPT image alias only when gpt-5.4-mini advertises the full image tool", async () => {
+  it("exposes the ChatGPT image alias without treating Codex catalog tool metadata as admission", async () => {
     const variants = [
-      { tool: true, lite: false, image: true },
-      { tool: false, lite: false, image: false },
-      { tool: true, lite: true, image: false },
+      { slug: "gpt-5.4-mini", tool: true, lite: false },
+      { slug: "gpt-5.4-mini", tool: false, lite: false },
+      { slug: "gpt-5.4-mini", tool: true, lite: true },
+      { slug: "gpt-5.6-sol", tool: false, lite: false },
     ];
     for (const [index, variant] of variants.entries()) {
       const { ctx, config } = oauthStores();
@@ -1730,7 +1731,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
         new Response(
           JSON.stringify({
             models: [
-              codexModel("gpt-5.4-mini", {
+              codexModel(variant.slug, {
                 experimental_supported_tools: variant.tool ? ["image_generation"] : [],
                 use_responses_lite: variant.lite,
               }),
@@ -1755,7 +1756,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
         { catalog, runInBackground },
       );
       const aliases = (result.providers[0]?.models ?? []).map((model) => model.alias);
-      expect(aliases.includes("openai-codex/gpt-image-2")).toBe(variant.image);
+      expect(aliases).toContain("openai-codex/gpt-image-2");
     }
   });
 
@@ -2006,6 +2007,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       "openai-codex/gpt-5.6-sol",
       "openai-codex/codex-auto-review",
       "openai-codex/gpt-5.6",
+      "openai-codex/gpt-image-2",
     ]);
     await poolClients.get("openai-codex")?.chatCompletion({
       model: "gpt-5.6-sol",
@@ -2405,6 +2407,43 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect(result.poolClients.size).toBe(0);
   });
 
+  it("keeps ChatGPT image routable when an auto-mode account catalog is unavailable", async () => {
+    const { ctx, config } = oauthStores();
+    await ctx.store.upsert({
+      providerId: "openai-codex",
+      account: "default",
+      accessEnc: encryptSecret("codex-access", ENC_KEY),
+      refreshEnc: encryptSecret("codex-refresh", ENC_KEY),
+      expiresAt: FAR_FUTURE,
+      meta: JSON.stringify({ accountId: "workspace-1" }),
+      updatedAt: 1,
+    });
+    const catalog = createCodexModelCatalog({ cache: createCodexModelCache(config, ENC_KEY) });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
+    );
+
+    const result = await synthesizeOAuthProviders(
+      [],
+      ctx,
+      config,
+      "https://fallback/v1",
+      60_000,
+      noop,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { catalog, runInBackground },
+    );
+
+    expect((result.providers[0]?.models ?? []).map((model) => model.alias)).toEqual([
+      "openai-codex/gpt-image-2",
+    ]);
+    expect(result.poolClients.get("openai-codex")?.hasAvailableModel("gpt-image-2")).toBe(true);
+  });
+
   it("refreshes once and retries /models after a 401 without changing account identity", async () => {
     const { ctx, config } = oauthStores();
     await ctx.store.upsert({
@@ -2486,6 +2525,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect((result.providers[0]?.models ?? []).map((model) => model.alias)).toEqual([
       "openai-codex/gpt-5.6-sol",
       "openai-codex/gpt-5.6",
+      "openai-codex/gpt-image-2",
     ]);
   });
 

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -123,7 +123,6 @@ import {
   startCleanupScheduler,
   startMemoryWorker,
   startSignalScheduler,
-  supportsOpenAICodexImageGeneration,
   type TransportProfile,
   toRegistryProviders,
   validateModelAliasTargets,
@@ -1139,9 +1138,8 @@ export async function synthesizeOAuthProviders(
           ? [...loaded.snapshot.models].sort((left, right) => left.priority - right.priority)
           : [];
         discovered = expandOpenAICodexModelAliases(catalogModels.map((model) => model.slug));
-        if (supportsOpenAICodexImageGeneration(catalogModels)) {
+        if (!discovered.includes(OPENAI_CODEX_IMAGE_MODEL))
           discovered.push(OPENAI_CODEX_IMAGE_MODEL);
-        }
         if (loaded) codexKeys.push(loaded.key);
         accountCodexRuntime = loaded?.runtime;
       } else {

--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -225,8 +225,9 @@ openai-codex/gpt-5.4-mini:
       levels: [low, medium, high, xhigh]
   maxContextTokens: 272000
   maxOutputTokens: 65536
-# Synthesized only when the authenticated Codex catalog says gpt-5.4-mini can
-# invoke the full image_generation tool. This alias is media-only.
+# Synthesized for schedulable ChatGPT OAuth accounts. Codex catalog tool metadata
+# is advisory; the one client-requested upstream write determines actual support.
+# This alias is media-only.
 openai-codex/gpt-image-2:
   supportsTools: false
   jsonOutput: none

--- a/docs/05-protocol-translation.md
+++ b/docs/05-protocol-translation.md
@@ -109,14 +109,14 @@ network, timeout, and eligible upstream failures can advance; client errors and
 client aborts are terminal. A lane must not mix OpenAI-Images and Gemini member
 kinds because their verbatim parameter surfaces differ.
 
-When a connected ChatGPT OAuth account's live Codex catalog explicitly exposes
-the non-Lite `gpt-5.4-mini` controller with the `image_generation` tool, Helm also
-publishes `openai-codex/gpt-image-2` through the `chatgpt-image` lane. Generation
-and editing keep the public Images routes above; the provider adapter converts
-both operations to one Responses tool call (`action: generate|edit`) and maps the
-completed base64 result back to `data[].b64_json`. This paid POST is sent once:
-transport errors, overload responses, and 401s are not replayed or moved to a
-sibling OAuth account.
+With a schedulable ChatGPT OAuth account, Helm publishes
+`openai-codex/gpt-image-2` through the `chatgpt-image` lane. Codex catalog tool
+metadata is advisory rather than an admission gate; the client-requested upstream
+call determines actual account support. Generation and editing keep the public
+Images routes above; the provider adapter converts both operations to one Responses
+tool call (`action: generate|edit`) and maps the completed base64 result back to
+`data[].b64_json`. This paid POST is sent once: transport errors, overload responses,
+and 401s are not replayed or moved to a sibling OAuth account.
 
 ## Protocol behavior
 

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,9 +7,14 @@
 
 ---
 
+## 2026-08-30 · ChatGPT 生图能力由单次上游调用判定（OAuth provider / Images / Routing，docs/04/05/07，原则 3/5/7）
+
+- **目录不再准入**：Codex `/models` 的 `supported_in_api`、`use_responses_lite` 与 `experimental_supported_tools` 不是 ChatGPT 图片工具的权威能力合同；可调度的 `openai-codex` 账号现在合成 `gpt-image-2` alias，执行前也不再按这些目录字段本地拒绝，实际支持状态由客户端请求触发的上游调用返回。
+- **单写边界与实测**：没有新增自动探测或后台付费 probe；图片生成/编辑仍只选择一个 OAuth 账号、只发送一次，连接错误、过载、401、超时与结果不明均不重试、不切 sibling。2026-08-30 本机 Docker 经明确授权执行一次 `chatgpt-image` canary：单次账号选择、HTTP 200、返回一张非空 PNG（21 input tokens、229 image output tokens）；请求 `1024x1024`，上游实际返回 `1254x1254`，尺寸并非严格兑现。
+
 ## 2026-08-29 · ChatGPT OAuth 图片生成与编辑复用 Images 协议（OAuth provider / Images / Routing，docs/04/05/07，原则 2/3/5/7/8）
 
-- **协议与准入**：保留既有 `POST /v1/images/generations` 与 `POST /v1/images/edits`，新增独立 `chatgpt-image → openai-codex/gpt-image-2` lane；只有账号实时 Codex 目录中的 `gpt-5.4-mini` 同时声明 `supported_in_api`、非 Responses Lite 和 `experimental_supported_tools:image_generation` 时才合成该媒体 alias，未知能力不猜测。
+- **协议与准入**：保留既有 `POST /v1/images/generations` 与 `POST /v1/images/edits`，新增独立 `chatgpt-image → openai-codex/gpt-image-2` lane；当时采用的 Codex 目录硬准入已由 2026-08-30 条目纠正。
 - **执行与单写边界**：生成、JSON 编辑和 multipart 编辑共用一个 Responses 图片适配器，以 `action:generate|edit` 区分，并把 `image_generation_call.result` 映射回 Images `data[]`。这是订阅额度付费单写；连接错误、过载、401、超时或断线均不重试、不切 OAuth 账号，结果不明继续由现有图片链返回 `outcome_unknown`。
 - **计价限制**：ChatGPT 订阅图片没有可信美元价目，catalog 显式记录 null pricing；请求数预算仍可工作，配置美元支出上限的 key 在付费调用前 fail-closed。实现独立参考 Sub2API 当前协议行为与测试，没有复制其 LGPL 源码；未执行真实付费生图。
 
@@ -56,14 +61,9 @@
 - **生产根因与修复**：全局 `POST /admin/api/oauth/refresh` 会重建所有 OAuth pool；即使 Codex 账号、代理、模型与执行设置均未变化，也会替换持有上游 WebSocket 和 `response_id → session` 映射的 `openai-codex` client，使仍活跃的下游 session 下一轮在本地收到 `previous_response_id_session_unavailable`。composition root 现在保留一个进程级复用缓存；重建后的 Codex pool 拓扑与 transport 身份签名完全相同时复用原 pool/client，并原位刷新 quota/cooldown 信号。
 - **失效边界**：账号集合、模型、优先级、Fast mode、剩余额度策略、代理、ChatGPT account identity、Codex client identity、base URL、timeout 或 selection strategy 任一变化都会创建新 pool；真正的配置/身份变化、进程重启、原 WebSocket 关闭仍保持原有 fail-closed 400，不跨账号、不重连 opaque ID、不伪造完整历史。无 schema、migration、依赖或配置字段变化。
 
-## 2026-08-25 · Providers 配额缓存一小时后后台重验证（Admin OAuth providers，docs/11，原则 3/7）
-
-- **刷新语义**：Providers 首屏继续只读取本地缓存，保证上游慢或不可用时仍立即渲染；Anthropic、Codex、xAI 任一已连接账号的 quota snapshot 缺失或 `capturedAt` 达到 60 分钟后，页面在可见状态自动提交既有全局 refresh job，并继续用 cache-only 轮询接收结果。手动 Refresh 仍是立即强制刷新，用户选择的短周期自动刷新仍不产生 provider 流量。
-- **限流与失败边界**：自动重验证复用后端单任务合并、串行账号 PULL 与 60 秒冷却；同一挂载页面在 snapshot 未变化或刷新失败时最多每小时重试一次，后台隐藏期间不发起同步，重新可见后再按 TTL 判断。旧数据在失败时继续保留并显示既有错误，不把观测缓存过期升级为路由或鉴权失败。未新增 Store、migration、依赖或配置字段。
-- **交付门禁**：组织规则仍要求历史 `Core CI` context，因此 CI 恢复同名 checkout-free 聚合 job；它不重复运行代码，只在 verify、store、e2e、docker 全部成功，并且 PR 场景的可信 head reporter 成功后通过。现有四道独立边界与最小权限保持不变。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-25 · Providers 配额缓存一小时后后台重验证**：Providers 首屏保持 cache-only；缺失或满一小时的 quota snapshot 仅在页面可见时复用既有后台 refresh job，失败保留旧数据且不改变路由/鉴权，完整原文经 git history 回溯。
 - **2026-08-25 · Responses continuation 不跨账号或 transport 恢复**：续接只允许可调度的原账号与产生该 ID 的活动原 WebSocket；失配、关闭和模糊发送失败均 fail-closed，完整原文经 git history 回溯。
 - **2026-08-25 · Anthropic tool_result 400 允许协议级 fallback**：仅精确的 `Advisor tool result content could not be processed` 记为候选协议不兼容并继续 fallback；其他确定性客户端错误仍 fail-closed，完整原文经 git history 回溯。
 - **2026-08-25 · Responses 续接只在原账号不可用时搜索 sibling**：已知原账号实际收到请求后若仍返回 invalid-ID 立即 fail-closed；只有原账号已不可调度或 ID 尚无归属时才搜索 sibling，turn-state 与活动 WebSocket 始终不迁移；完整原文经 git history 回溯。

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -610,7 +610,6 @@ export {
   resolveXaiGrokClientVersion,
   type SerializeClientDeps,
   selectCodexActiveLimitWindows,
-  supportsOpenAICodexImageGeneration,
   type UsagePeriodsResult,
   windowMinutesForKey,
   windowsToActiveUsageRecovery,

--- a/packages/core/src/provider/oauth/index.ts
+++ b/packages/core/src/provider/oauth/index.ts
@@ -70,7 +70,6 @@ export {
   parseXaiOAuthModels,
   resolveOpenAICodexClientVersion,
   resolveOpenAICodexModelAlias,
-  supportsOpenAICodexImageGeneration,
   type XaiApiBackend,
   type XaiOAuthModel,
   type XaiReasoningEffort,

--- a/packages/core/src/provider/oauth/models.ts
+++ b/packages/core/src/provider/oauth/models.ts
@@ -52,17 +52,6 @@ const OPENAI_CODEX_MODEL_ALIASES: Readonly<Record<string, string>> = {
 };
 
 export const OPENAI_CODEX_IMAGE_MODEL = "gpt-image-2";
-const OPENAI_CODEX_IMAGE_CONTROLLER_MODEL = "gpt-5.4-mini";
-
-export function supportsOpenAICodexImageGeneration(models: readonly CodexModelInfo[]): boolean {
-  return models.some(
-    (model) =>
-      model.slug === OPENAI_CODEX_IMAGE_CONTROLLER_MODEL &&
-      model.supported_in_api &&
-      !model.use_responses_lite &&
-      model.experimental_supported_tools.includes("image_generation"),
-  );
-}
 
 const RETIRED_OPENAI_CODEX_MODELS = new Set(["gpt-5.3-codex-spark"]);
 

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -58,6 +58,7 @@ function codexModelInfo(
     supported_reasoning_levels: Array<{ effort: string; description: string }>;
     service_tiers: Array<{ id: string; name: string; description: string }>;
     supports_parallel_tool_calls: boolean;
+    experimental_supported_tools: string[];
   }> = {},
 ): CodexModelInfo {
   return {
@@ -4531,12 +4532,17 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
 });
 
 describe("createCodexResponsesClient — Images API bridge", () => {
-  const clientFor = (fetchMock: typeof fetch, onUnauthorized?: () => void) =>
+  const clientFor = (
+    fetchMock: typeof fetch,
+    onUnauthorized?: () => void,
+    resolveModelInfo?: () => CodexModelInfo,
+  ) =>
     createCodexResponsesClient({
       config: {
         baseUrl: "https://chatgpt.com/backend-api/codex",
         getAuthHeader: async () => `Bearer ${jwt("acct")}`,
         onUnauthorized,
+        resolveModelInfo,
       },
       fetch: fetchMock,
       responseWorkAdmission: createResponseWorkAdmission({
@@ -4545,6 +4551,24 @@ describe("createCodexResponsesClient — Images API bridge", () => {
         minChargeBytes: 1,
       }),
     });
+
+  it("treats Codex catalog tool metadata as advisory and attempts one upstream image write", async () => {
+    const fetchMock = vi.fn(async () =>
+      sseResponse([
+        {
+          type: "response.completed",
+          response: { output: [{ type: "image_generation_call", result: "aW1hZ2U=" }] },
+        },
+      ]),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      clientFor(fetchMock, undefined, () =>
+        codexModelInfo({ use_responses_lite: true, experimental_supported_tools: [] }),
+      ).imageGeneration?.({ model: "gpt-image-2", prompt: "draw" }),
+    ).resolves.toMatchObject({ data: [{ b64_json: "aW1hZ2U=" }] });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
 
   it("maps generation to the image_generation tool and maps the completed image back", async () => {
     let sent: Record<string, unknown> = {};

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -1792,16 +1792,6 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   ): Promise<Record<string, unknown>> {
     const requestBody = buildCodexImageRequest(action, input);
     const modelInfo = await resolveModelInfo(CODEX_IMAGE_CONTROLLER_MODEL);
-    if (
-      modelInfo &&
-      (modelInfo.use_responses_lite ||
-        !modelInfo.experimental_supported_tools.includes("image_generation"))
-    ) {
-      throw new UpstreamError(
-        "upstream_error",
-        "ChatGPT account does not expose the image_generation tool",
-      );
-    }
     // A subscription image create/edit is billable and may have succeeded before a
     // disconnect. Deliberately bypass connection, overload, and 401 replay here.
     const result = await request(requestBody.body, modelInfo, {


### PR DESCRIPTION
## Summary

- expose `openai-codex/gpt-image-2` for schedulable ChatGPT OAuth accounts even when `/models` omits image tool metadata or is unavailable
- treat Codex catalog fields as advisory and let the single client-requested upstream image call determine actual support
- remove the duplicate execution-time rejection while preserving manual model allowlists

This is a follow-up to #810.

## Paid-write safety

- no background probe or automatic paid capability check
- one selected OAuth account and one upstream request per image create/edit
- no transport, overload, 401, timeout, or sibling-account retry

## Verification

- `CI=true pnpm exec vitest run apps/gateway/src/server.oauth.test.ts`
- `CI=true pnpm exec vitest run apps/gateway/src/oauth/effective-models.test.ts`
- `CI=true pnpm exec vitest run packages/core/src/provider/openai-responses.test.ts -t "Images API bridge"`
- `CI=true pnpm exec vitest run packages/core/src/provider/oauth/pool.test.ts -t "selects one account for a paid media create"`
- `CI=true pnpm exec vitest run packages/core/src/catalog/load.test.ts`
- `CI=true pnpm exec vitest run apps/gateway/src/routes/images.test.ts`
- `CI=true pnpm exec vitest run apps/gateway/src/routes/image-chain.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

An explicitly authorized local Docker canary made exactly one paid upstream call and returned HTTP 200 with one non-empty PNG (21 input tokens, 229 image output tokens). The request asked for `1024x1024`; the upstream image was `1254x1254`, so requested dimensions are not strictly honored.