### PR TITLE
fix(admin): keep long-form save actions visible

### DIFF
--- a/apps/admin/src/routes/lanes/+page.svelte
+++ b/apps/admin/src/routes/lanes/+page.svelte
@@ -90,7 +90,7 @@
   {/if}
 
   <div
-    class="sticky bottom-0 -mx-4 flex items-center justify-end gap-3 border-t border-border bg-canvas/95 px-4 py-3 backdrop-blur sm:static sm:m-0 sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none"
+    class="fixed right-4 bottom-4 z-20 flex items-center gap-3 rounded-lg border border-border bg-canvas/95 p-3 shadow-lg backdrop-blur"
   >
     {#if saved}
       <span class="badge-ok" data-testid="lanes-saved" role="status">{$t('Saved')}</span>

--- a/apps/admin/src/routes/policies/+page.svelte
+++ b/apps/admin/src/routes/policies/+page.svelte
@@ -303,7 +303,7 @@
   </div>
 
   <div
-    class="sticky bottom-0 -mx-4 flex items-center justify-between gap-3 border-t border-border bg-canvas/95 px-4 py-3 backdrop-blur sm:static sm:m-0 sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none"
+    class="fixed right-4 bottom-4 z-20 flex items-center justify-between gap-3 rounded-lg border border-border bg-canvas/95 p-3 shadow-lg backdrop-blur"
   >
     <button type="button" class="btn-secondary" onclick={addRow}>{$t('Add policy')}</button>
     <div class="flex items-center gap-3">

--- a/apps/gateway/e2e/admin.spec.ts
+++ b/apps/gateway/e2e/admin.spec.ts
@@ -78,6 +78,9 @@ test.describe("admin lane editing", () => {
     const newPrimary = `e2e_edited_${Date.now()}`;
 
     await page.goto(`${BASE}/admin/lanes`);
+    const saveButton = page.getByRole("button", { name: /^save$/i });
+    await expect(saveButton.locator("..")).toHaveCSS("position", "fixed");
+    await expect(saveButton).toBeInViewport();
     // Scope the card by its heading so a lane that merely lists "economy" as a
     // fallback does not also match (the balanced card references economy).
     const card = page
@@ -87,7 +90,7 @@ test.describe("admin lane editing", () => {
 
     const primary = card.locator("input[name='primary']");
     await primary.fill(newPrimary);
-    await page.getByRole("button", { name: /^save$/i }).click();
+    await saveButton.click();
 
     // The one page-level success indicator appears after the atomic write-back.
     await expect(page.getByTestId("lanes-saved")).toBeVisible();
@@ -98,6 +101,19 @@ test.describe("admin lane editing", () => {
       .getByTestId("lane-card")
       .filter({ has: page.getByRole("heading", { name: "economy", exact: true }) });
     await expect(reloaded.locator("input[name='primary']")).toHaveValue(newPrimary);
+  });
+});
+
+test.describe("admin policy editing", () => {
+  test("policy save controls stay available on the long form", async ({ page }) => {
+    await page.goto(`${BASE}/admin/policies`);
+    const saveButton = page.getByRole("button", { name: /^save policies$/i });
+    const actions = saveButton.locator("..").locator("..");
+    await expect(actions).toHaveCSS("position", "fixed");
+    await expect(saveButton).toBeInViewport();
+
+    await saveButton.click();
+    await expect(page.getByTestId("policies-saved")).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- keep Lanes save controls fixed at the bottom-right
- keep Policies add/save controls fixed at the bottom-right
- cover both long-form save controls in the real Admin Playwright flow

## Verification
- `CI=true pnpm exec vitest run apps/admin/src/routes/lanes/lanes.test.ts` (9 passed)
- `CI=true pnpm exec vitest run apps/admin/src/routes/policies/policies.test.ts` (7 passed)
- Admin Playwright focused flows (2 passed)
- `pnpm --filter @helm/admin build`
- `pnpm --filter @helm/admin check`
- Browser QA: desktop, scrolled long forms, mobile, save success, zero console warnings/errors

## Release assessment
Backward-compatible Admin UI fix; patch release.