### PR TITLE
chore(release): v0.28.98

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.97",
+  "version": "0.28.98",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from 0.28.97 to 0.28.98
- release the Admin long-form floating save controls merged in PR #815

## Scope
Version-only patch release: root `package.json` is the only changed file.

## Release plan
After required CI and merge, wait for the `Publish image` run tied to the exact release merge SHA, record the immutable GHCR digest, then deploy that digest to Remote.