### PR TITLE
fix(oauth): preserve first quota period percentage

### DIFF
--- a/apps/gateway/src/routes/admin/oauth.test.ts
+++ b/apps/gateway/src/routes/admin/oauth.test.ts
@@ -337,6 +337,72 @@ describe("admin OAuth routes — read endpoints", () => {
     expect(dayTotal).toBe(24_000);
   });
 
+  it("keeps the used percentage from the first closed Anthropic quota period", async () => {
+    const HOUR = 3_600_000;
+    const WEEK = 7 * 86_400_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T12:00:00.000Z"));
+    const now = Date.now();
+    const currentStart = now - HOUR;
+    const closedStart = currentStart - WEEK;
+    const oauthUsage = {
+      queryBuckets: vi.fn(async () => [
+        { bucketMs: closedStart, requests: 1, tokens: 100, costUsd: null },
+      ]),
+    } as unknown as AdminApiDeps["oauthUsage"];
+    const oauthQuota = {
+      get: vi.fn(async () => ({
+        providerId: "anthropic",
+        account: "claude@example.com",
+        windows: [
+          {
+            key: "7d",
+            usedPercent: 2,
+            resetsAtMs: currentStart + WEEK,
+            windowMinutes: 10_080,
+          },
+        ],
+        capturedAt: now,
+        source: "anthropic",
+        usageLimitedUntilMs: null,
+      })),
+    } as unknown as AdminApiDeps["oauthQuota"];
+    const oauthResetPeriod = {
+      queryPeriods: vi.fn(async () => [
+        {
+          providerId: "anthropic",
+          account: "claude@example.com",
+          windowKey: "7d",
+          periodStartMs: closedStart,
+          periodEndMs: currentStart,
+          detectedAtMs: currentStart,
+          usedPercent: 100,
+          approximate: false,
+        },
+      ]),
+    } as unknown as AdminApiDeps["oauthResetPeriod"];
+    const settings = {
+      get: () => ({ oauth_usage_retention_days: 180 }),
+    } as unknown as AdminApiDeps["settings"];
+
+    const res = await app({
+      oauth: fullSeam(),
+      oauthUsage,
+      oauthQuota,
+      oauthResetPeriod,
+      settings,
+    }).request("/admin/api/oauth/usage/periods?provider=anthropic&account=claude%40example.com");
+    vi.useRealTimers();
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      current: Array<{ usedPercent?: number | null }>;
+      periods: Array<{ usedPercent?: number | null }>;
+    };
+    expect(body.current[0]?.usedPercent).toBe(2);
+    expect(body.periods[0]?.usedPercent).toBe(100);
+  });
+
   it("GET /oauth/usage/periods fails open to empty when the quota snapshot is missing", async () => {
     const oauthUsage = {
       queryBuckets: vi.fn(async () => []),

--- a/apps/gateway/src/routes/admin/oauth.ts
+++ b/apps/gateway/src/routes/admin/oauth.ts
@@ -58,7 +58,8 @@ function resetEventBoundaries(
   windowMs: number | null,
 ): Array<{ startMs: number; endMs: number; approximate: boolean; usedPercent?: number | null }> {
   // The old writer stored [oldReset, projectedNextReset); the current writer stores a
-  // closed period ending at the observed reset. Reduce both shapes to proven events.
+  // complete closed period ending at the observed reset. Keep complete periods intact;
+  // only the legacy shape needs reconstructing from proven reset events.
   const rawPoints = rows
     .flatMap((row) => {
       const atMs =
@@ -88,7 +89,7 @@ function resetEventBoundaries(
     ).values(),
   ].sort((a, b) => a.atMs - b.atMs);
   const plausible = (startMs: number, endMs: number) =>
-    windowMs !== null && endMs - startMs <= windowMs * 1.5;
+    windowMs !== null && startMs < endMs && endMs - startMs <= windowMs * 1.5;
   const boundaries = points.slice(1).flatMap((end, index) => {
     const start = points[index] ?? end;
     return plausible(start.atMs, end.atMs)
@@ -102,6 +103,25 @@ function resetEventBoundaries(
         ]
       : [];
   });
+  for (const row of rows) {
+    if (
+      row.usedPercent == null ||
+      row.detectedAtMs < row.periodEndMs ||
+      row.periodEndMs > nowMs ||
+      !plausible(row.periodStartMs, row.periodEndMs)
+    ) {
+      continue;
+    }
+    const closed = {
+      startMs: row.periodStartMs,
+      endMs: row.periodEndMs,
+      approximate: row.approximate ?? false,
+      usedPercent: row.usedPercent,
+    };
+    const index = boundaries.findIndex((boundary) => boundary.endMs === row.periodEndMs);
+    if (index < 0) boundaries.push(closed);
+    else boundaries[index] = closed;
+  }
   const latest = points.at(-1);
   if (
     latest !== undefined &&


### PR DESCRIPTION
## Summary
- preserve complete closed quota periods that already carry `usedPercent`
- keep legacy reset-event reconstruction unchanged
- cover the first closed Anthropic period (`100%`) beside the current period (`2%`)

## Verification
- `CI=true pnpm exec vitest run apps/gateway/src/routes/admin/oauth.test.ts packages/core/src/provider/oauth/usage-periods.test.ts apps/gateway/src/oauth/quota-reset-period.test.ts`
- `pnpm --filter @helm/gateway typecheck`
- `pnpm exec biome check apps/gateway/src/routes/admin/oauth.ts apps/gateway/src/routes/admin/oauth.test.ts`

## Production evidence (read-only)
- v0.28.98 SQLite still contains the exact Anthropic 7d `used_percent=100` row
- the current production API returns current `2%` but historical `null`, confirming a read-path loss rather than deleted data