### PR TITLE
chore(release): v0.28.99

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.98",
+  "version": "0.28.99",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Release
- bump Helm API from `0.28.98` to `0.28.99`
- includes PR #817: preserve the first closed OAuth quota-period percentage

## Scope
- version-only release commit
- no schema or configuration changes