### PR TITLE
fix: fall back from oversized Responses websocket

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,11 @@
 
 ---
 
+## 2026-09-01 · Codex Responses 超大首轮 WebSocket 改走 HTTP（Responses / docs/05，原则 3/5/8）
+
+- 上游以 WebSocket close `1009` 拒绝无 `previous_response_id` 的完整历史请求时，Helm 只在尚未收到任何事件且尚未开始输出的窗口关闭该 socket，并单次切换到 HTTP Responses；不对有状态续接、已产生输出或其他关闭码做重放。
+- 这是传输兜底，不是服务端历史重建：客户端仍负责首轮完整 baseline、后续 `previous_response_id + delta`，compaction 仍应走专用 compact 流程。这样避免重复执行工具调用，同时保留既有 native passthrough 语义。
+
 ## 2026-08-30 · ChatGPT 生图能力由单次上游调用判定（OAuth provider / Images / Routing，docs/04/05/07，原则 3/5/7）
 
 - **目录不再准入**：Codex `/models` 的 `supported_in_api`、`use_responses_lite` 与 `experimental_supported_tools` 不是 ChatGPT 图片工具的权威能力合同；可调度的 `openai-codex` 账号现在合成 `gpt-image-2` alias，执行前也不再按这些目录字段本地拒绝，实际支持状态由客户端请求触发的上游调用返回。

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -3129,6 +3129,48 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(connect).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to HTTP when the websocket rejects a full-history request as too large", async () => {
+    let sends = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {
+        sends += 1;
+      },
+      async receive() {
+        return null;
+      },
+      closeInfo() {
+        return { code: 1009, reason: "" };
+      },
+      async close() {},
+    };
+    const fetchMock = vi.fn(async () => new Response(null, { status: 400 }));
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_oversized_ws")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+        connectRetries: 2,
+        connectRetryBackoffMs: [0],
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier("ingress-oversized-ws", {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({ upstreamStatus: 400 });
+    expect(sends).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not report Helm's local close as upstream close metadata", async () => {
     let closeDetails: { code: number; reason: string } | null = null;
     const connection: CodexResponsesWebSocketConnection = {
@@ -3903,6 +3945,9 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
       async receive() {
         const event = replies[turn]?.[eventIndex++];
         return event === undefined ? null : JSON.stringify(event);
+      },
+      closeInfo() {
+        return turn === 1 ? { code: 1009, reason: "" } : null;
       },
       async close() {},
     };

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -2452,6 +2452,20 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
           let sendingRequest = false;
           let outputStarted = false;
           const preambleFrames: string[] = [];
+          const fallbackOversizedRequestToHttp = async (): Promise<boolean> => {
+            if (
+              hasPreviousResponseId ||
+              outputStarted ||
+              preambleFrames.length > 0 ||
+              lease?.connection.closeInfo?.()?.code !== 1009
+            ) {
+              return false;
+            }
+            await closeWebSocketSession(sessionId);
+            websocketHttpFallbackSessions.add(sessionId);
+            fallbackToHttp = true;
+            return true;
+          };
           try {
             if (!websocketMetadataFired.has(lease.connection)) {
               websocketMetadataFired.add(lease.connection);
@@ -2471,6 +2485,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                 received = await receiveWebSocketMessage(lease.connection, opts?.signal);
               } catch (error) {
                 if (opts?.signal?.aborted) throw opts.signal.reason ?? error;
+                if (await fallbackOversizedRequestToHttp()) break;
                 throw responseCreateOutcomeUnknown(
                   lease.connection,
                   outputStarted
@@ -2481,6 +2496,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                 );
               }
               if (received === null) {
+                if (await fallbackOversizedRequestToHttp()) break;
                 if (hasPreviousResponseId && !outputStarted && preambleFrames.length === 0) {
                   throw responseCreateOutcomeUnknown(lease.connection, "after_send_before_event");
                 }


### PR DESCRIPTION
## Summary
- fall back once to HTTP when a first Responses WebSocket request is rejected with close code 1009 before any event
- keep continuation requests fail-closed; never replay or cross transports when previous_response_id is present
- add focused regression tests and document the boundary

## Validation
- CI=true pnpm exec vitest run packages/core/src/provider/openai-responses.test.ts -t "falls back to HTTP when the websocket rejects a full-history request as too large|does not reconnect or fall back to HTTP when a continuation websocket closes"
- CI=true pnpm --filter @helm/core typecheck
- pnpm exec biome check packages/core/src/provider/openai-responses.ts packages/core/src/provider/openai-responses.test.ts
- git diff --check