### PR TITLE
chore(release): v0.28.100

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.99",
+  "version": "0.28.100",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.28.100 from merged main commit 8bd8648a5b505fefe7e0fe25470d6fb5a84f481e.

This is a version-only change; the publish workflow will create the GitHub Release and immutable GHCR image after merge.