### PR TITLE
fix(responses): preserve safe HTTP fallback lifecycle

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,10 +7,11 @@
 
 ---
 
-## 2026-09-01 · Codex Responses 超大首轮 WebSocket 改走 HTTP（Responses / docs/05，原则 3/5/8）
+## 2026-09-01 · Codex Responses 超大首轮 WebSocket 的 HTTP 生命周期（Responses / docs/05，原则 3/5/8）
 
-- 上游以 WebSocket close `1009` 拒绝无 `previous_response_id` 的完整历史请求时，Helm 只在尚未收到任何事件且尚未开始输出的窗口关闭该 socket，并单次切换到 HTTP Responses；不对有状态续接、已产生输出或其他关闭码做重放。
-- 这是传输兜底，不是服务端历史重建：客户端仍负责首轮完整 baseline、后续 `previous_response_id + delta`，compaction 仍应走专用 compact 流程。这样避免重复执行工具调用，同时保留既有 native passthrough 语义。
+- 上游以 WebSocket close `1009` 拒绝无 `previous_response_id` 的完整历史请求时，Helm 只在尚未收到任何上游 frame 的窗口关闭该 socket，并单次切换到 HTTP Responses；rate-limit、无法解析及未知类型 frame 也会把结果标记为不确定，因此禁止 HTTP 重放。
+- 首轮安全回落成功后，该 ingress session 的后续 `previous_response_id` 增量继续走同一 HTTP transport，而不是再进入只适用于活动 WebSocket 的 response/session registry 校验；其他 session、跨账号与活动 WebSocket 续接仍 fail-closed。
+- 这是传输兜底，不是服务端历史重建：客户端仍负责首轮完整 baseline、后续 `previous_response_id + delta`，compaction 仍走专用 compact 流程。HTTP SSE 读取复用 client 已配置的 response-work admission，不新增缓存、schema、配置或依赖。
 
 ## 2026-08-30 · ChatGPT 生图能力由单次上游调用判定（OAuth provider / Images / Routing，docs/04/05/07，原则 3/5/7）
 

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -3171,6 +3171,133 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps continuations on HTTP after an oversized websocket request falls back", async () => {
+    let sends = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {
+        sends += 1;
+      },
+      async receive() {
+        return null;
+      },
+      closeInfo() {
+        return { code: 1009, reason: "" };
+      },
+      async close() {},
+    };
+    const sentBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      sentBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      const responseId = sentBodies.length === 1 ? "resp-http-parent" : "resp-http-child";
+      return rawSSEResponse(
+        [
+          `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: responseId } })}\n\n`,
+          `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { id: responseId, status: "completed", usage: {} } })}\n\n`,
+        ].join(""),
+      );
+    });
+    const connect = vi.fn(async () => connection);
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_oversized_http_session")}`,
+        responsesWebSocketConnector: connect,
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+      responseWorkAdmission: createResponseWorkAdmission({
+        capacityBytes: 1_000_000,
+        jsonAmplification: 1,
+        minChargeBytes: 1,
+      }),
+    });
+
+    for await (const _ of client.nativePassthroughStream?.(
+      carrier("ingress-oversized-http-session", {
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      // Establish the HTTP fallback response.
+    }
+    for await (const _ of client.nativePassthroughStream?.(
+      carrier("ingress-oversized-http-session", {
+        model: "gpt-5.6-sol",
+        input: [],
+        stream: true,
+        store: false,
+        previous_response_id: "resp-http-parent",
+      }),
+    ) ?? []) {
+      // Continue the same provider-owned response over HTTP.
+    }
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(sends).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sentBodies[1]?.previous_response_id).toBe("resp-http-parent");
+  });
+
+  it.each([
+    ["rate-limit", JSON.stringify({ type: "codex.rate_limits", rate_limits: {} })],
+    ["malformed", "not-json"],
+    ["untyped", JSON.stringify({ unexpected: true })],
+  ])("does not fall back to HTTP after receiving a %s websocket frame", async (_label, frame) => {
+    let receiveCalls = 0;
+    const connection: CodexResponsesWebSocketConnection = {
+      responseHeaders: new Headers(),
+      async send() {},
+      async receive() {
+        receiveCalls += 1;
+        return receiveCalls === 1 ? frame : null;
+      },
+      closeInfo() {
+        return { code: 1009, reason: "" };
+      },
+      async close() {},
+    };
+    const fetchMock = vi.fn(async () =>
+      rawSSEResponse(
+        [
+          'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","usage":{}}}\n\n',
+        ].join(""),
+      ),
+    );
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_frame_before_1009")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+      responseWorkAdmission: createResponseWorkAdmission({
+        capacityBytes: 1_000_000,
+        jsonAmplification: 1,
+        minChargeBytes: 1,
+      }),
+    });
+    const iterator = client
+      .nativePassthroughStream?.(
+        carrier(`ingress-frame-before-1009-${_label}`, {
+          model: "gpt-5.6-sol",
+          input: [],
+          stream: true,
+          store: false,
+        }),
+      )
+      [Symbol.asyncIterator]();
+
+    await expect(iterator?.next()).rejects.toMatchObject({
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        websocket: { lifecycle_phase: "after_send_before_event", close_code: 1009 },
+      },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not report Helm's local close as upstream close metadata", async () => {
     let closeDetails: { code: number; reason: string } | null = null;
     const connection: CodexResponsesWebSocketConnection = {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -2391,24 +2391,22 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       const previousResponseId = nativeBody.previous_response_id;
       const hasPreviousResponseId =
         typeof previousResponseId === "string" && previousResponseId.trim().length > 0;
+      const usingHttpFallback =
+        sessionId !== undefined && websocketHttpFallbackSessions.has(sessionId);
       if (
         hasPreviousResponseId &&
         (!cfg.responsesWebSocketConnector ||
           !sessionId ||
-          websocketHttpFallbackSessions.has(sessionId) ||
-          !websocketSessions.has(sessionId) ||
-          responseWebsocketSessions.get(previousResponseId.trim()) !== sessionId)
+          (!usingHttpFallback &&
+            (!websocketSessions.has(sessionId) ||
+              responseWebsocketSessions.get(previousResponseId.trim()) !== sessionId)))
       ) {
         throw new CodexResponsesBeforeSendError(
           "previous_response_id cannot be continued because its original websocket session is unavailable; send the full conversation input instead",
           { reason: "websocket_session_unavailable" },
         );
       }
-      if (
-        cfg.responsesWebSocketConnector &&
-        sessionId &&
-        !websocketHttpFallbackSessions.has(sessionId)
-      ) {
+      if (cfg.responsesWebSocketConnector && sessionId && !usingHttpFallback) {
         const { prepared, turnKey } = await prepareRequest(
           body,
           modelInfo,
@@ -2451,10 +2449,12 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
           let fallbackToHttp = false;
           let sendingRequest = false;
           let outputStarted = false;
+          let receivedAnyFrame = false;
           const preambleFrames: string[] = [];
           const fallbackOversizedRequestToHttp = async (): Promise<boolean> => {
             if (
               hasPreviousResponseId ||
+              receivedAnyFrame ||
               outputStarted ||
               preambleFrames.length > 0 ||
               lease?.connection.closeInfo?.()?.code !== 1009
@@ -2509,6 +2509,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
                       : "after_send_before_event",
                 );
               }
+              receivedAnyFrame = true;
               try {
                 let event: ParsedWebSocketEvent;
                 try {
@@ -2638,7 +2639,11 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         onResponseMeta: opts?.onResponseMeta,
       });
       if (!result.response.ok) throw await errorFromResponse(result);
-      yield* readResponsesSSERaw(result.response, timeoutMs);
+      yield* readResponsesSSERaw(
+        result.response,
+        timeoutMs,
+        deps.responseWorkAdmission ?? runtimeResponseWorkAdmission(),
+      );
     },
 
     closeResponsesWebSocketSession: closeWebSocketSession,


### PR DESCRIPTION
## Summary
- keep a WebSocket session on HTTP after a safe close-1009 fallback so previous_response_id continuations do not re-enter the WebSocket registry guard
- block HTTP replay after any upstream WebSocket frame, including rate-limit, malformed, and untyped frames
- reuse the configured response-work admission for fallback HTTP SSE

## Verification
- CI=true pnpm exec vitest run packages/core/src/provider/openai-responses.test.ts -t focused WebSocket lifecycle cases (9 passed)
- CI=true pnpm --filter @helm/core typecheck
- pnpm exec biome check packages/core/src/provider/openai-responses.ts packages/core/src/provider/openai-responses.test.ts
- git diff --check

## Safety
- no replay after any upstream frame or output
- no account, provider, previous_response_id, or client-history reconstruction changes
- no schema, migration, configuration, or dependency changes