### PR TITLE
chore(release): v0.28.101

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.100",
+  "version": "0.28.101",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API patch version from 0.28.100 to 0.28.101
- release merged WebSocket-to-HTTP fallback lifecycle fix from PR #821

## Release scope
- version-only change on top of exact merged main c57f99ba897cb34d94a955a7de5175dd408026eb
- no schema, migration, configuration, or dependency changes

## Verification
- package.json parses and reports 0.28.101
- version-only diff passes git diff --check
- feature PR #821 required CI passed before merge