### PR TITLE
fix(codex): compact oversized image histories

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-09-01 · Codex 超大完整历史在发送前缩图并压缩（Responses / docs/05，原则 3/7/8）
+
+- 生产失败请求在单个完整历史中重复携带 11–24 张内联 Base64 图片，正文达到 46–49 MiB；Codex 客户端按 token 而非 wire bytes 触发自动压缩，Helm 的后台 Memory compaction 也不修改当前请求，因此会先撞上 WebSocket/HTTP 传输上限。
+- 仅对没有 `previous_response_id`、准备走 Codex WebSocket 的完整历史做 32 MiB 发送前保护：先将 PNG/JPEG/WebP 内联图片转成最长边 2048px、质量 82 的 WebP（不放大，单图输入像素上限 1600 万），仍超限再调用同账号 `/responses/compact` 并用其 `output` 替换历史；小请求和增量续接保持原样。官方 Responses 图片输入合同支持 WebP data URL。
+- 缩图或 compact 失败均 fail-open 到既有 `1009 → HTTP` 兜底，不删除图片或私有 Responses item；compact 结果只有比当前正文更小时才采用。缩图在 Base64 解码前预留源文件字节，并在变换期间另行预留解码像素内存；每请求最多处理 12 张/3200 万总像素及单图 1600 万像素，并在图片之间响应客户端取消。新增 `sharp` 是唯一依赖，生产镜像必须验证 native addon 可加载。
+
 ## 2026-09-01 · Codex Responses 超大首轮 WebSocket 的 HTTP 生命周期（Responses / docs/05，原则 3/5/8）
 
 - 上游以 WebSocket close `1009` 拒绝无 `previous_response_id` 的完整历史请求时，Helm 只在尚未收到任何上游 frame 的窗口关闭该 socket，并单次切换到 HTTP Responses；rate-limit、无法解析及未知类型 frame 也会把结果标记为不确定，因此禁止 HTTP 重放。
@@ -62,13 +68,9 @@
 - **空闲连接恢复**：上游 Codex WebSocket 现在每 60 秒发送协议 Ping，并要求 15 秒内收到 Pong；超时立即终止半开连接，让仍未发送的新请求在本地明确失败。测试可缩短两个时限，生产配置与协议正文不变。
 - **会话与单写边界**：`response.incomplete` 与 core 已有语义一致，继续保留同一上游 session 供 `previous_response_id` 续接；`failed`、`cancelled` 与 `error` 仍关闭。上游一旦发出 `response.created`/`response.in_progress` 即视为已接收 `response.create`，随后断连不再重连或回落 HTTP 重放，避免重复推理、工具副作用与计费；已有状态丢失仍要求客户端发送完整历史。
 
-## 2026-08-26 · OAuth 热刷新保留未变化的 Codex continuation transport（OAuth provider / Responses，docs/04/05/07/11，原则 3/5/8）
-
-- **生产根因与修复**：全局 `POST /admin/api/oauth/refresh` 会重建所有 OAuth pool；即使 Codex 账号、代理、模型与执行设置均未变化，也会替换持有上游 WebSocket 和 `response_id → session` 映射的 `openai-codex` client，使仍活跃的下游 session 下一轮在本地收到 `previous_response_id_session_unavailable`。composition root 现在保留一个进程级复用缓存；重建后的 Codex pool 拓扑与 transport 身份签名完全相同时复用原 pool/client，并原位刷新 quota/cooldown 信号。
-- **失效边界**：账号集合、模型、优先级、Fast mode、剩余额度策略、代理、ChatGPT account identity、Codex client identity、base URL、timeout 或 selection strategy 任一变化都会创建新 pool；真正的配置/身份变化、进程重启、原 WebSocket 关闭仍保持原有 fail-closed 400，不跨账号、不重连 opaque ID、不伪造完整历史。无 schema、migration、依赖或配置字段变化。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-26 · OAuth 热刷新保留未变化的 Codex continuation transport**：重建后拓扑与 transport 身份签名完全相同时复用原 pool/client 与 continuation 状态；真实账号、代理、模型或执行配置变化仍新建并保持失效 fail-closed，完整原文经 git history 回溯。
 - **2026-08-25 · Providers 配额缓存一小时后后台重验证**：Providers 首屏保持 cache-only；缺失或满一小时的 quota snapshot 仅在页面可见时复用既有后台 refresh job，失败保留旧数据且不改变路由/鉴权，完整原文经 git history 回溯。
 - **2026-08-25 · Responses continuation 不跨账号或 transport 恢复**：续接只允许可调度的原账号与产生该 ID 的活动原 WebSocket；失配、关闭和模糊发送失败均 fail-closed，完整原文经 git history 回溯。
 - **2026-08-25 · Anthropic tool_result 400 允许协议级 fallback**：仅精确的 `Advisor tool result content could not be processed` 记为候选协议不兼容并继续 fallback；其他确定性客户端错误仍 fail-closed，完整原文经 git history 回溯。

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3",
-      "esbuild"
+      "esbuild",
+      "sharp"
     ]
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9",
     "pxpipe-proxy": "0.8.0",
+    "sharp": "0.34.5",
     "socks": "^2.8.9",
     "sqlite-vec": "^0.1.9",
     "undici": "^8.3.0",

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -1,3 +1,4 @@
+import sharp from "sharp";
 import { describe, expect, it, vi } from "vitest";
 import { transformRequestOut as anthropicToIRRequest } from "../protocol/anthropic/request.js";
 import { createResponseWorkAdmission } from "../runtime/response-work-admission.js";
@@ -16,6 +17,7 @@ import {
   hoistResponsesInstructions,
   openaiToGenericResponsesRequest,
   openaiToResponsesRequest,
+  optimizeCodexInlineImages,
   readResponsesEvents,
   readResponsesSSERaw,
   sanitizeCodexResponsesNativeBody,
@@ -2619,6 +2621,235 @@ describe("createCodexResponsesClient — native Responses WebSocket", () => {
     };
     return connection;
   }
+
+  it("downscales oversized inline images without changing non-image input", async () => {
+    const pixels = Buffer.alloc(4096 * 64 * 3);
+    let seed = 0x1234_5678;
+    for (let index = 0; index < pixels.length; index += 1) {
+      seed = (seed * 1_664_525 + 1_013_904_223) >>> 0;
+      pixels[index] = seed & 0xff;
+    }
+    const source = await sharp(pixels, {
+      raw: { width: 4096, height: 64, channels: 3 },
+    })
+      .png()
+      .toBuffer();
+    const untouched = { type: "input_text", text: "keep me" };
+
+    const optimized = await optimizeCodexInlineImages(
+      {
+        input: [
+          untouched,
+          {
+            type: "input_image",
+            image_url: `data:image/png;base64,${source.toString("base64")}`,
+          },
+        ],
+      },
+      {
+        admission: createResponseWorkAdmission({
+          capacityBytes: 10_000_000,
+          jsonAmplification: 1,
+          minChargeBytes: 1,
+        }),
+        maxEdge: 2048,
+      },
+    );
+
+    expect(optimized.optimizedImages).toBe(1);
+    expect((optimized.value as { input: unknown[] }).input[0]).toBe(untouched);
+    const imageUrl =
+      (optimized.value as { input: Array<{ image_url?: string }> }).input[1]?.image_url ?? "";
+    expect(imageUrl).toMatch(/^data:image\/webp;base64,/);
+    const metadata = await sharp(
+      Buffer.from(imageUrl.replace(/^data:image\/webp;base64,/, ""), "base64"),
+    ).metadata();
+    expect(metadata.width).toBe(2048);
+    expect(metadata.height).toBe(32);
+    expect(metadata.format).toBe("webp");
+    expect(
+      Buffer.from(imageUrl.replace(/^data:image\/webp;base64,/, ""), "base64").byteLength,
+    ).toBeLessThan(source.byteLength);
+
+    const denied = await optimizeCodexInlineImages(
+      {
+        type: "input_image",
+        image_url: `data:image/png;base64,${source.toString("base64")}`,
+      },
+      {
+        admission: createResponseWorkAdmission({
+          capacityBytes: 1,
+          jsonAmplification: 1,
+          minChargeBytes: 1,
+        }),
+      },
+    );
+    expect(denied.optimizedImages).toBe(0);
+
+    const charges: number[] = [];
+    await optimizeCodexInlineImages(
+      {
+        type: "input_image",
+        image_url: `data:image/png;base64,${source.toString("base64")}`,
+      },
+      {
+        admission: {
+          acquire(wireBytes) {
+            charges.push(wireBytes);
+            return { ok: false, reason: "busy" };
+          },
+          capacityBytes: 1,
+          reservedBytes: 0,
+        },
+      },
+    );
+    expect(charges).toEqual([source.byteLength]);
+  });
+
+  it("leaves requests below the safety threshold untouched", async () => {
+    const imageUrl = "data:image/png;base64,aGVsbG8=";
+    const connection = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-small" } },
+        { type: "response.completed", response: { id: "resp-small", status: "completed" } },
+      ],
+    ]);
+    const fetchMock = vi.fn();
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_small_request")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+      autoCompactRequestBytes: 10_000,
+    });
+
+    for await (const _ of client.nativePassthroughStream?.(
+      carrier("ingress-small-request", {
+        model: "gpt-5.6-sol",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_image", image_url: imageUrl }],
+          },
+        ],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      // drain
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(connection.sent).toHaveLength(1);
+    expect(connection.sent[0]).toContain(imageUrl);
+  });
+
+  it("auto-compacts an oversized full-history request before response.create", async () => {
+    const captured: string[] = [];
+    const connection = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-compacted" } },
+        { type: "response.completed", response: { id: "resp-compacted", status: "completed" } },
+      ],
+    ]);
+    const compactOutput = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "latest" }] },
+      { type: "compaction", encrypted_content: "compact-context" },
+    ];
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("https://chatgpt.com/backend-api/codex/responses/compact");
+      return jsonResponse({ output: compactOutput });
+    });
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_auto_compact")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+        resolveModelInfo: () => codexModelInfo({ use_responses_lite: true }),
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+      autoCompactRequestBytes: 512,
+      responseWorkAdmission: createResponseWorkAdmission({
+        capacityBytes: 1_000_000,
+        jsonAmplification: 1,
+        minChargeBytes: 1,
+      }),
+    });
+    const request = carrier("ingress-auto-compact", {
+      model: "gpt-5.6-sol",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "x".repeat(2_000) }],
+        },
+      ],
+      tools: [{ type: "function", name: "search" }],
+      stream: true,
+      store: false,
+    });
+
+    for await (const _ of client.nativePassthroughStream?.(request, {
+      captureUpstream: (body) => captured.push(body),
+    }) ?? []) {
+      // drain
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(captured).toHaveLength(2);
+    expect(connection.sent).toHaveLength(1);
+    const sent = JSON.parse(connection.sent[0] ?? "{}") as {
+      input?: Array<Record<string, unknown>>;
+    };
+    expect(sent.input?.map((item) => item.type)).toEqual([
+      "additional_tools",
+      "message",
+      "compaction",
+    ]);
+    expect(JSON.stringify(sent)).not.toContain("x".repeat(100));
+    expect(request.mutations).toMatchObject({
+      body_shims_applied: expect.arrayContaining(["codex_oversized_request_auto_compacted"]),
+    });
+  });
+
+  it("keeps the existing transport fallback when automatic compaction fails", async () => {
+    const connection = fakeConnection([
+      [
+        { type: "response.created", response: { id: "resp-original" } },
+        { type: "response.completed", response: { id: "resp-original", status: "completed" } },
+      ],
+    ]);
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ error: { message: "compact failed" } }, 400),
+    );
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct_compact_fail_open")}`,
+        responsesWebSocketConnector: vi.fn(async () => connection),
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+      autoCompactRequestBytes: 128,
+    });
+
+    for await (const _ of client.nativePassthroughStream?.(
+      carrier("ingress-compact-fail-open", {
+        model: "gpt-5.6-sol",
+        input: [{ type: "message", role: "user", content: "x".repeat(1_000) }],
+        stream: true,
+        store: false,
+      }),
+    ) ?? []) {
+      // drain
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(connection.sent).toHaveLength(1);
+    expect(connection.sent[0]).toContain("x".repeat(100));
+  });
 
   it("holds a websocket response-work lease until the yielded frame is consumed", async () => {
     let releaseCalls = 0;

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -23,6 +23,7 @@ import {
   isNativePassthroughCarrier,
   type NativePassthroughInput,
 } from "@helm/shared";
+import sharp from "sharp";
 import {
   createSSEIncompleteFrameGuard,
   nextSSEFrameBoundary,
@@ -120,6 +121,8 @@ export interface CodexResponsesClientDeps {
   config: CodexResponsesClientConfig;
   fetch?: typeof globalThis.fetch;
   responseWorkAdmission?: ResponseWorkAdmission;
+  /** Test seam for the provider's fixed pre-send safety threshold. */
+  autoCompactRequestBytes?: number;
 }
 
 export interface GenericOpenAIResponsesClientDeps {
@@ -278,6 +281,11 @@ const RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite";
 const CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata";
 const CODEX_TURN_STATE_HEADER = "x-codex-turn-state";
 const MAX_CODEX_TURN_STATES = 128;
+const DEFAULT_CODEX_AUTO_COMPACT_REQUEST_BYTES = 32 * 1024 * 1024;
+const DEFAULT_CODEX_IMAGE_MAX_EDGE = 2048;
+const MAX_CODEX_IMAGE_PIXELS = 16_000_000;
+const MAX_CODEX_IMAGE_OPTIMIZATION_PIXELS = 32_000_000;
+const MAX_CODEX_IMAGE_OPTIMIZATION_COUNT = 12;
 
 function responseBodyTooLargeUpstreamError(error: ResponseBodyTooLargeError): UpstreamError {
   return new UpstreamError("upstream_error", error.message, {
@@ -517,6 +525,123 @@ export type CodexResponsesNativeBodyFix =
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type CodexImageOptimizationState = {
+  admission: ResponseWorkAdmission;
+  maxEdge: number;
+  remainingImages: number;
+  remainingPixels: number;
+  signal?: AbortSignal;
+};
+
+async function optimizeCodexInlineImagesInner(
+  value: unknown,
+  state: CodexImageOptimizationState,
+): Promise<{ value: unknown; optimizedImages: number }> {
+  if (state.signal?.aborted) throw state.signal.reason ?? new Error("client aborted");
+  if (Array.isArray(value)) {
+    let next: unknown[] = value;
+    let optimizedImages = 0;
+    for (let index = 0; index < value.length; index += 1) {
+      const optimized = await optimizeCodexInlineImagesInner(value[index], state);
+      optimizedImages += optimized.optimizedImages;
+      if (optimized.value !== value[index]) {
+        if (next === value) next = [...value];
+        next[index] = optimized.value;
+      }
+    }
+    return { value: next, optimizedImages };
+  }
+  if (!isRecord(value)) return { value, optimizedImages: 0 };
+
+  let next = value;
+  let optimizedImages = 0;
+  if (
+    value.type === "input_image" &&
+    typeof value.image_url === "string" &&
+    state.remainingImages > 0 &&
+    state.remainingPixels > 0
+  ) {
+    const match = /^data:(image\/(?:png|jpe?g|webp));base64,([a-z\d+/=]+)$/i.exec(value.image_url);
+    if (match?.[2]) {
+      state.remainingImages -= 1;
+      const sourceAcquired = state.admission.acquire(Buffer.byteLength(match[2], "base64"));
+      if (sourceAcquired.ok) {
+        try {
+          const source = Buffer.from(match[2], "base64");
+          const pipeline = sharp(source, {
+            failOn: "error",
+            limitInputPixels: MAX_CODEX_IMAGE_PIXELS,
+          });
+          const metadata = await pipeline.metadata();
+          if (state.signal?.aborted) throw state.signal.reason ?? new Error("client aborted");
+          const pixels = (metadata.width ?? 0) * (metadata.height ?? 0);
+          if (Number.isSafeInteger(pixels) && pixels > 0 && pixels <= state.remainingPixels) {
+            state.remainingPixels -= pixels;
+            const pixelsAcquired = state.admission.acquire(pixels * 4);
+            if (pixelsAcquired.ok) {
+              try {
+                const optimized = await pipeline
+                  .rotate()
+                  .resize({
+                    width: state.maxEdge,
+                    height: state.maxEdge,
+                    fit: "inside",
+                    withoutEnlargement: true,
+                  })
+                  .webp({ quality: 82 })
+                  .toBuffer();
+                if (state.signal?.aborted) {
+                  throw state.signal.reason ?? new Error("client aborted");
+                }
+                if (optimized.byteLength < source.byteLength) {
+                  next = {
+                    ...value,
+                    image_url: `data:image/webp;base64,${optimized.toString("base64")}`,
+                  };
+                  optimizedImages = 1;
+                }
+              } finally {
+                pixelsAcquired.lease.release();
+              }
+            }
+          }
+        } catch (error) {
+          if (state.signal?.aborted) throw state.signal.reason ?? error;
+        } finally {
+          sourceAcquired.lease.release();
+        }
+      }
+    }
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "image_url" && value.type === "input_image") continue;
+    const optimized = await optimizeCodexInlineImagesInner(child, state);
+    optimizedImages += optimized.optimizedImages;
+    if (optimized.value !== child) {
+      if (next === value) next = { ...value };
+      next[key] = optimized.value;
+    }
+  }
+  return { value: next, optimizedImages };
+}
+
+export async function optimizeCodexInlineImages(
+  value: unknown,
+  options: {
+    admission?: ResponseWorkAdmission;
+    maxEdge?: number;
+    signal?: AbortSignal;
+  } = {},
+): Promise<{ value: unknown; optimizedImages: number }> {
+  return await optimizeCodexInlineImagesInner(value, {
+    admission: options.admission ?? runtimeResponseWorkAdmission(),
+    maxEdge: options.maxEdge ?? DEFAULT_CODEX_IMAGE_MAX_EDGE,
+    remainingImages: MAX_CODEX_IMAGE_OPTIMIZATION_COUNT,
+    remainingPixels: MAX_CODEX_IMAGE_OPTIMIZATION_PIXELS,
+    signal: options.signal,
+  });
 }
 
 function hasNonEmptyArray(value: unknown): boolean {
@@ -1402,6 +1527,10 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
   const doFetch = deps.fetch ?? globalThis.fetch;
   const cfg = deps.config;
   const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const autoCompactRequestBytes = Math.max(
+    1,
+    Math.floor(deps.autoCompactRequestBytes ?? DEFAULT_CODEX_AUTO_COMPACT_REQUEST_BYTES),
+  );
   // baseUrl may or may not already end in /responses (mirror openclaw normalize).
   const url = cfg.baseUrl.endsWith("/responses")
     ? cfg.baseUrl
@@ -1634,7 +1763,12 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     maxBytes = 0,
   ): Promise<T> {
     try {
-      return await consumeResponseTextWithinBudget(result.response, maxBytes, consume);
+      return await consumeResponseTextWithinBudget(
+        result.response,
+        maxBytes,
+        consume,
+        deps.responseWorkAdmission ?? runtimeResponseWorkAdmission(),
+      );
     } catch (err) {
       if (result.bodyTimeout?.isTimeout() && !result.bodyTimeout.isExternalAbort()) {
         throw new UpstreamError("timeout", "upstream request timed out");
@@ -1783,6 +1917,109 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       result.response.status,
       scrub(safeUpstreamHeaders(result.response.headers)) as Record<string, string>,
     );
+  }
+
+  function inputWithBody(
+    input: NativePassthroughInput,
+    body: Record<string, unknown>,
+  ): NativePassthroughInput {
+    return isNativePassthroughCarrier(input) ? cloneCarrierWithBody(input, body) : body;
+  }
+
+  function compactRequestBody(body: Record<string, unknown>): Record<string, unknown> {
+    const compact: Record<string, unknown> = {};
+    for (const key of [
+      "model",
+      "input",
+      "instructions",
+      "parallel_tool_calls",
+      "reasoning",
+      "prompt_cache_key",
+    ]) {
+      if (body[key] !== undefined) compact[key] = body[key];
+    }
+    return compact;
+  }
+
+  function compactedResponseBody(
+    body: Record<string, unknown>,
+    output: unknown[],
+  ): Record<string, unknown> {
+    const input = Array.isArray(body.input) ? body.input : [];
+    const prefix = input[0];
+    const outputStartsWithTools = isRecord(output[0]) && output[0].type === "additional_tools";
+    return {
+      ...body,
+      input:
+        isRecord(prefix) && prefix.type === "additional_tools" && !outputStartsWithTools
+          ? [prefix, ...output]
+          : output,
+    };
+  }
+
+  async function prepareOversizedNativeStreamRequest(
+    input: NativePassthroughInput,
+    modelInfo: CodexModelInfo | undefined,
+    opts: ProviderCallOptions | undefined,
+  ): Promise<{
+    input: NativePassthroughInput;
+    prepared: PreparedNativePassthroughRequest;
+    turnKey: string | undefined;
+  }> {
+    let currentInput = input;
+    let current = await prepareRequest(currentInput, modelInfo, "text/event-stream", true);
+    let currentBytes = Buffer.byteLength(current.prepared.bodyText);
+    if (currentBytes <= autoCompactRequestBytes) return { input: currentInput, ...current };
+
+    const optimized = await optimizeCodexInlineImages(current.prepared.body, {
+      ...(deps.responseWorkAdmission ? { admission: deps.responseWorkAdmission } : {}),
+      ...(opts?.signal ? { signal: opts.signal } : {}),
+    });
+    if (optimized.optimizedImages > 0 && isRecord(optimized.value)) {
+      if (isNativePassthroughCarrier(input)) {
+        appendMutationList(input.mutations, "body_shims_applied", [
+          "codex_oversized_images_optimized",
+        ]);
+      }
+      currentInput = inputWithBody(input, optimized.value);
+      current = await prepareRequest(currentInput, modelInfo, "text/event-stream", true);
+      currentBytes = Buffer.byteLength(current.prepared.bodyText);
+      if (currentBytes <= autoCompactRequestBytes) return { input: currentInput, ...current };
+    }
+
+    try {
+      const compactInput = inputWithBody(currentInput, compactRequestBody(current.prepared.body));
+      const result = await requestWithRetry(compactInput, modelInfo, {
+        endpoint: compactUrl,
+        accept: "application/json",
+        signal: opts?.signal,
+        capture: opts?.captureUpstream,
+        onResponseMeta: opts?.onResponseMeta,
+        timeoutThroughBody: true,
+      });
+      if (!result.response.ok) throw await errorFromResponse(result);
+      const compacted = await readUnaryJson(result);
+      if (!Array.isArray(compacted.output) || compacted.output.length === 0) {
+        return { input: currentInput, ...current };
+      }
+      const compactedInput = inputWithBody(
+        currentInput,
+        compactedResponseBody(current.prepared.body, compacted.output),
+      );
+      const next = await prepareRequest(compactedInput, modelInfo, "text/event-stream", true);
+      if (Buffer.byteLength(next.prepared.bodyText) >= currentBytes) {
+        return { input: currentInput, ...current };
+      }
+      if (isNativePassthroughCarrier(input)) {
+        appendMutationList(input.mutations, "body_shims_applied", [
+          "codex_oversized_request_auto_compacted",
+        ]);
+      }
+      return { input: compactedInput, ...next };
+    } catch (error) {
+      if (opts?.signal?.aborted) throw opts.signal.reason ?? error;
+      return { input: currentInput, ...current };
+    }
   }
 
   async function runCodexImageTool(
@@ -2393,6 +2630,18 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         typeof previousResponseId === "string" && previousResponseId.trim().length > 0;
       const usingHttpFallback =
         sessionId !== undefined && websocketHttpFallbackSessions.has(sessionId);
+      let outboundBody = body;
+      let preparedRequest:
+        | {
+            prepared: PreparedNativePassthroughRequest;
+            turnKey: string | undefined;
+          }
+        | undefined;
+      if (cfg.responsesWebSocketConnector && sessionId && !hasPreviousResponseId) {
+        const guarded = await prepareOversizedNativeStreamRequest(body, modelInfo, opts);
+        outboundBody = guarded.input;
+        preparedRequest = { prepared: guarded.prepared, turnKey: guarded.turnKey };
+      }
       if (
         hasPreviousResponseId &&
         (!cfg.responsesWebSocketConnector ||
@@ -2407,12 +2656,9 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         );
       }
       if (cfg.responsesWebSocketConnector && sessionId && !usingHttpFallback) {
-        const { prepared, turnKey } = await prepareRequest(
-          body,
-          modelInfo,
-          "text/event-stream",
-          true,
-        );
+        const { prepared, turnKey } =
+          preparedRequest ??
+          (await prepareRequest(outboundBody, modelInfo, "text/event-stream", true));
         const maxRetries = websocketRetryCount();
         let retries = 0;
         let retriedInvalidPreviousResponseId = false;
@@ -2633,7 +2879,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
           break;
         }
       }
-      const result = await requestWithRetry(body, modelInfo, {
+      const result = await requestWithRetry(outboundBody, modelInfo, {
         signal: opts?.signal,
         capture: opts?.captureUpstream,
         onResponseMeta: opts?.onResponseMeta,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       pxpipe-proxy:
         specifier: 0.8.0
         version: 0.8.0
+      sharp:
+        specifier: 0.34.5
+        version: 0.34.5
       socks:
         specifier: ^2.8.9
         version: 2.8.9
@@ -422,6 +425,9 @@ packages:
 
   '@electric-sql/pglite@0.4.6':
     resolution: {integrity: sha512-qmlmfN8UyKCee35qkV0r/MBp+Znl8FjBz7OpoglNvww3GJpw0/DLP0o1ZymvLNmcD5DTLOQdzKPtF8Hd3mdl1w==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -754,6 +760,143 @@ packages:
     resolution: {integrity: sha512-sJTvldu1GPeEPfyeLG7gRj+W4vEuD+JDi+JjJ3TJs/DvMUtBLs0KJO5yokGegWWdy5qrbdnQGekbhgNRmPmYKQ==}
     peerDependencies:
       hono: '>=4.0.0'
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2493,6 +2636,10 @@ packages:
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3059,6 +3206,11 @@ snapshots:
 
   '@electric-sql/pglite@0.4.6': {}
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -3233,6 +3385,102 @@ snapshots:
   '@hono/swagger-ui@0.6.1(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4919,6 +5167,37 @@ snapshots:
   semver@7.8.1: {}
 
   set-cookie-parser@3.1.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.1
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- resize eligible inline PNG/JPEG/WebP images before oversized Codex WebSocket sends
- call the same account responses/compact endpoint when the prepared body remains above 32 MiB
- preserve continuation behavior and the existing fail-open WebSocket-to-HTTP fallback
- bound source bytes, decoded pixels, image count, and total pixels through runtime memory admission

## Validation

- focused image optimization and auto-compaction regressions: 4 passed
- core typecheck and core/gateway builds passed
- Biome and git diff checks passed
- Docker image built and runtime @helm/core import loaded sharp

## Risk assessment

Release candidate: yes. The path is limited to full-history Codex WebSocket requests without previous_response_id and only activates above 32 MiB. Independent P0/P1 reliability review found no remaining actionable findings after source-byte and decoded-pixel admission were added.