### PR TITLE
fix: prevent ambiguous Responses replays

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -6555,20 +6555,14 @@ describe("createExecute — native protocol STREAMING passthrough (#217 Phase 2)
     expect(out.nativePassthrough).toBe(true);
   });
 
-  it("does not advance the chain when a sent response.create has an unknown outcome", async () => {
-    // biome-ignore lint/correctness/useYield: pre-first-chunk failure throws before any yield
-    async function* unknownOutcome(): AsyncGenerator<string> {
-      throw new UpstreamError(
-        "upstream_error",
-        "upstream websocket closed after send",
-        { error: { code: "response_create_outcome_unknown" } },
-        400,
-      );
+  it("does not advance the chain after HTTP response.created then EOF", async () => {
+    async function* acceptedThenEof(): AsyncGenerator<string> {
+      yield 'event: response.created\ndata: {"type":"response.created"}\n\n';
     }
     const head = {
       chatCompletion: vi.fn(),
       chatCompletionStream: vi.fn(),
-      nativePassthroughStream: vi.fn().mockReturnValue(unknownOutcome()),
+      nativePassthroughStream: vi.fn().mockReturnValue(acceptedThenEof()),
     } as unknown as ProviderClient & { nativePassthroughStream: ReturnType<typeof vi.fn> };
     const tail = {
       chatCompletion: vi.fn(),

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-09-02 · Codex Responses HTTP 只重放明确拒绝的请求（Responses / provider execution，docs/04/05/07，原则 3/5/8）
+
+- Codex HTTP POST 在 `fetch()` 抛出连接错误或首字节超时后无法证明上游未接收请求；这类结果现在单次终止为 `response_create_outcome_unknown`，记录 `after_send_before_response`，不再由 fetch 层、OAuth sibling 或候选链重放。外部客户端取消保持原分类。
+- HTTP 200 后在终态前发生 EOF、读超时/异常、本地 response-work 拒绝、空 body 或缺少 SSE 结尾分隔符，都属于上游可能已接收但结果不明，记录 `after_response_before_terminal`（已解析 preamble 的外层 guard 记录 `after_response_created_before_output`）并停止 sibling/provider fallback；即使缺少末尾空行且随后读失败，完整可解析的 `response.failed` / `error` 仍作为明确拒绝保留，可在无真实输出时 fallback。
+- 明确拒绝仍保留既有安全恢复：401 刷新后一次重发、503/529 最多三次总尝试、WebSocket 握手及可证明发送前关闭总计三次尝试。无 schema、migration、配置或依赖变化。
+
 ## 2026-09-01 · Codex 超大完整历史在发送前缩图并压缩（Responses / docs/05，原则 3/7/8）
 
 - 生产失败请求在单个完整历史中重复携带 11–24 张内联 Base64 图片，正文达到 46–49 MiB；Codex 客户端按 token 而非 wire bytes 触发自动压缩，Helm 的后台 Memory compaction 也不修改当前请求，因此会先撞上 WebSocket/HTTP 传输上限。
@@ -58,18 +64,10 @@
 - provider 通过两个结构化 recovery code 把该状态保留到 Responses SSE，包括已经输出后的流内错误与非 2xx 嵌套错误；下游 WebSocket bridge 不先发送 400/error frame，而以 `1012` 关闭连接。Codex 0.145.0 的原生 retry loop 会把 transport close 视为可重试，并在新连接上清空增量 `previous_response_id`、用客户端持有的完整当前会话重建请求；Helm 本身仍只发送上游一次。
 - telemetry 在本地 teardown 前快照上游 close code/reason，并记录 `before_send` / `send_callback_error` / `after_send_before_event` / `after_send_after_preamble` / `after_send_after_output` 生命周期，避免把 Helm 自己的 close `1000` 冒充上游事实。该恢复与直连 Codex 的断流语义一致，但上游没有幂等键时无法承诺 exactly-once；重试决定仍由持有完整历史的客户端负责。无 schema、migration、依赖或配置变化。
 
-## 2026-08-27 · 仅恢复发送前已关闭的 Responses WebSocket（Responses / Gateway，docs/05/07，原则 3/8）
-
-- `send()` 在调用底层 `socket.send()` 前若已确认连接不是 `OPEN`，抛出专用错误；续接请求最多重连并原样发送一次。发送回调失败仍视为结果不明，继续 fail-closed 返回 `previous_response_id_session_unavailable`，不重放、不切 sibling、不回落 HTTP。
-- 该边界只解决可证明“尚未调用发送”的安全恢复；无法证明上游是否收到字节的错误仍要求客户端带完整历史重新发起请求。
-
-## 2026-08-26 · Codex Responses WebSocket 保活与已确认请求禁止重放（Responses / Gateway，docs/05/07，原则 3/8）
-
-- **空闲连接恢复**：上游 Codex WebSocket 现在每 60 秒发送协议 Ping，并要求 15 秒内收到 Pong；超时立即终止半开连接，让仍未发送的新请求在本地明确失败。测试可缩短两个时限，生产配置与协议正文不变。
-- **会话与单写边界**：`response.incomplete` 与 core 已有语义一致，继续保留同一上游 session 供 `previous_response_id` 续接；`failed`、`cancelled` 与 `error` 仍关闭。上游一旦发出 `response.created`/`response.in_progress` 即视为已接收 `response.create`，随后断连不再重连或回落 HTTP 重放，避免重复推理、工具副作用与计费；已有状态丢失仍要求客户端发送完整历史。
-
 ## 历史条目摘要（最新要点）
 
+- **2026-08-27 · 仅恢复发送前已关闭的 Responses WebSocket**：只有底层 `socket.send()` 尚未调用时允许安全恢复；发送回调失败与其他不确定结果保持 fail-closed，完整原文经 git history 回溯。
+- **2026-08-26 · Codex Responses WebSocket 保活与已确认请求禁止重放**：空闲 socket 用 Ping/Pong 检测半开连接，`response.created` / `response.in_progress` 后断连不重放，完整原文经 git history 回溯。
 - **2026-08-26 · OAuth 热刷新保留未变化的 Codex continuation transport**：重建后拓扑与 transport 身份签名完全相同时复用原 pool/client 与 continuation 状态；真实账号、代理、模型或执行配置变化仍新建并保持失效 fail-closed，完整原文经 git history 回溯。
 - **2026-08-25 · Providers 配额缓存一小时后后台重验证**：Providers 首屏保持 cache-only；缺失或满一小时的 quota snapshot 仅在页面可见时复用既有后台 refresh job，失败保留旧数据且不改变路由/鉴权，完整原文经 git history 回溯。
 - **2026-08-25 · Responses continuation 不跨账号或 transport 恢复**：续接只允许可调度的原账号与产生该 ID 的活动原 WebSocket；失配、关闭和模糊发送失败均 fail-closed，完整原文经 git history 回溯。

--- a/packages/core/src/provider/failover-guard.test.ts
+++ b/packages/core/src/provider/failover-guard.test.ts
@@ -30,7 +30,7 @@ const chat = preOutputClassifierFor("openai_chat");
 if (!responses || !anthropic || !chat) throw new Error("classifier missing");
 
 describe("guardPreOutputFailure — openai_responses", () => {
-  it("rejects an oversized pre-output buffer before retaining more raw chunks", async () => {
+  it("does not replay an accepted Responses request when its pre-output buffer overflows", async () => {
     const chunk = `event: response.created\ndata: {"type":"response.created"}\n\n${"x".repeat(
       Math.floor(MAX_PRE_OUTPUT_BUFFER_BYTES / 2),
     )}`;
@@ -44,9 +44,9 @@ describe("guardPreOutputFailure — openai_responses", () => {
       yield "z";
     }
 
-    await expect(collect(guardPreOutputFailure(src(), responses))).rejects.toThrow(
-      "upstream pre-output buffer exceeds the memory budget",
-    );
+    await expect(collect(guardPreOutputFailure(src(), responses))).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
     expect(yielded).toBe(2);
   });
 
@@ -139,12 +139,72 @@ describe("guardPreOutputFailure — openai_responses", () => {
     expect(out.join("")).toBe(chunks.join(""));
   });
 
-  it("preamble-only stream that ends with no output and no error → throws (fallback)", async () => {
+  it("response.created then EOF is outcome-unknown and must not fall back", async () => {
     const src = fromChunks([
       'event: response.created\ndata: {"type":"response.created"}\n\n',
       'event: response.in_progress\ndata: {"type":"response.in_progress"}\n\n',
     ]);
-    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toThrow(UpstreamError);
+    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        http: { lifecycle_phase: "after_response_created_before_output" },
+      },
+    });
+  });
+
+  it("response.created then a reader failure is outcome-unknown and must not fall back", async () => {
+    async function* src(): AsyncGenerator<string> {
+      yield 'event: response.created\ndata: {"type":"response.created"}\n\n';
+      throw new Error("socket reset while reading");
+    }
+
+    await expect(collect(guardPreOutputFailure(src(), responses))).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        http: { lifecycle_phase: "after_response_created_before_output" },
+      },
+    });
+  });
+
+  it("recognizes an unterminated response.created frame before EOF", async () => {
+    const src = fromChunks(['event: response.created\ndata: {"type":"response.created"}']);
+
+    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
+  });
+
+  it("recognizes an unterminated response.created frame before a reader failure", async () => {
+    async function* src(): AsyncGenerator<string> {
+      yield 'event: response.created\ndata: {"type":"response.created"}';
+      throw new Error("socket reset while reading");
+    }
+
+    await expect(collect(guardPreOutputFailure(src(), responses))).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
+  });
+
+  it("preserves an unterminated explicit response.failed as a safe fallback signal", async () => {
+    const src = fromChunks([
+      'event: response.failed\ndata: {"type":"response.failed","response":{"error":{"message":"overloaded"}}}',
+    ]);
+
+    await expect(collect(guardPreOutputFailure(src, responses))).rejects.toMatchObject({
+      upstreamStatus: null,
+      message: "overloaded",
+    });
+  });
+
+  it("treats an empty HTTP 200 Responses stream as outcome-unknown", async () => {
+    await expect(collect(guardPreOutputFailure(fromChunks([]), responses))).rejects.toMatchObject({
+      upstreamStatus: 400,
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
   });
 });
 

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -6,7 +6,17 @@ import { UpstreamError } from "./openai.js";
 // The guard must retain preamble bytes verbatim until the first real output, so
 // cap that replay window independently of the upstream's total response size.
 export const MAX_PRE_OUTPUT_BUFFER_BYTES = 1_048_576;
+export const CODEX_RESPONSES_BEFORE_SEND = Symbol("CodexResponsesBeforeSendError");
 export const CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE = "response_create_outcome_unknown";
+
+export function isTrustedCodexResponsesBeforeSendError(error: unknown): boolean {
+  return (
+    error instanceof UpstreamError &&
+    (error as UpstreamError & { [CODEX_RESPONSES_BEFORE_SEND]?: boolean })[
+      CODEX_RESPONSES_BEFORE_SEND
+    ] === true
+  );
+}
 
 // provider.failover-guard — pre-output streaming failure detector (CLAUDE.md
 // principle 5 + 8: streaming correctness is the #1 risk; classification fallback ≠
@@ -327,6 +337,7 @@ export async function* guardPreOutputFailure(
   } catch (error) {
     const tailError = unterminatedError();
     if (tailError) throw tailError;
+    if (isTrustedCodexResponsesBeforeSendError(error)) throw error;
     if (classifier === responsesClassifier && !committed && !explicitPreOutputError) {
       throw responsesOutcomeUnknown(error);
     }

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -6,17 +6,7 @@ import { UpstreamError } from "./openai.js";
 // The guard must retain preamble bytes verbatim until the first real output, so
 // cap that replay window independently of the upstream's total response size.
 export const MAX_PRE_OUTPUT_BUFFER_BYTES = 1_048_576;
-export const CODEX_RESPONSES_BEFORE_SEND = Symbol("CodexResponsesBeforeSendError");
 export const CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE = "response_create_outcome_unknown";
-
-export function isTrustedCodexResponsesBeforeSendError(error: unknown): boolean {
-  return (
-    error instanceof UpstreamError &&
-    (error as UpstreamError & { [CODEX_RESPONSES_BEFORE_SEND]?: boolean })[
-      CODEX_RESPONSES_BEFORE_SEND
-    ] === true
-  );
-}
 
 // provider.failover-guard — pre-output streaming failure detector (CLAUDE.md
 // principle 5 + 8: streaming correctness is the #1 risk; classification fallback ≠
@@ -303,10 +293,7 @@ export async function* guardPreOutputFailure(
       }
       const nextBufferedBytes = bufferedBytes + Buffer.byteLength(chunk);
       if (nextBufferedBytes > MAX_PRE_OUTPUT_BUFFER_BYTES) {
-        throw new UpstreamError(
-          "upstream_error",
-          "upstream pre-output buffer exceeds the memory budget",
-        );
+        throw new Error("upstream pre-output buffer exceeds the memory budget");
       }
       // Hold the raw bytes for verbatim replay; accumulate a parallel text buffer only
       // to frame complete SSE events (split on the blank-line terminator).
@@ -337,7 +324,7 @@ export async function* guardPreOutputFailure(
   } catch (error) {
     const tailError = unterminatedError();
     if (tailError) throw tailError;
-    if (isTrustedCodexResponsesBeforeSendError(error)) throw error;
+    if (error instanceof UpstreamError) throw error;
     if (classifier === responsesClassifier && !committed && !explicitPreOutputError) {
       throw responsesOutcomeUnknown(error);
     }

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -6,6 +6,7 @@ import { UpstreamError } from "./openai.js";
 // The guard must retain preamble bytes verbatim until the first real output, so
 // cap that replay window independently of the upstream's total response size.
 export const MAX_PRE_OUTPUT_BUFFER_BYTES = 1_048_576;
+export const CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE = "response_create_outcome_unknown";
 
 // provider.failover-guard — pre-output streaming failure detector (CLAUDE.md
 // principle 5 + 8: streaming correctness is the #1 risk; classification fallback ≠
@@ -125,6 +126,25 @@ const responsesClassifier: PreOutputClassifier = {
     return top.message || nested.message || "upstream responses stream error";
   },
 };
+
+function responsesOutcomeUnknown(cause?: unknown): UpstreamError {
+  const message = "upstream response stream ended after request acceptance before producing output";
+  return new UpstreamError(
+    "upstream_error",
+    message,
+    {
+      error: {
+        type: "invalid_request_error",
+        code: CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE,
+        message,
+      },
+      http: { lifecycle_phase: "after_response_created_before_output" },
+    },
+    400,
+    null,
+    cause,
+  );
+}
 
 // ── Anthropic Messages ───────────────────────────────────────────────────────
 // Preamble: message_start / ping / empty block lifecycle events. Error: error.
@@ -255,47 +275,71 @@ export async function* guardPreOutputFailure(
   let bufferedBytes = 0;
   let sse = "";
   let committed = false;
+  let explicitPreOutputError = false;
 
-  for await (const chunk of source) {
-    if (committed) {
-      yield chunk;
-      continue;
-    }
-    const nextBufferedBytes = bufferedBytes + Buffer.byteLength(chunk);
-    if (nextBufferedBytes > MAX_PRE_OUTPUT_BUFFER_BYTES) {
-      throw new UpstreamError(
-        "upstream_error",
-        "upstream pre-output buffer exceeds the memory budget",
-      );
-    }
-    // Hold the raw bytes for verbatim replay; accumulate a parallel text buffer only
-    // to frame complete SSE events (split on the blank-line terminator).
-    buffered.push(chunk);
-    bufferedBytes = nextBufferedBytes;
-    sse += chunk;
-    let boundary = nextSSEFrameBoundary(sse);
-    while (boundary !== null) {
-      const data = extractData(sse.slice(0, boundary.index));
-      sse = sse.slice(boundary.index + boundary.length);
-      if (data !== null) {
-        const cls = classifier.classify(data);
-        if (cls === "error") throw streamErrorFromData(classifier, data);
-        if (cls === "output") {
-          committed = true;
-          for (const b of buffered) yield b;
-          buffered.length = 0;
-          bufferedBytes = 0;
-          break;
-        }
+  const unterminatedError = (): UpstreamError | null => {
+    if (classifier !== responsesClassifier) return null;
+    const data = extractData(sse);
+    return data !== null && classifier.classify(data) === "error"
+      ? streamErrorFromData(classifier, data)
+      : null;
+  };
+
+  try {
+    for await (const chunk of source) {
+      if (committed) {
+        yield chunk;
+        continue;
       }
-      boundary = nextSSEFrameBoundary(sse);
+      const nextBufferedBytes = bufferedBytes + Buffer.byteLength(chunk);
+      if (nextBufferedBytes > MAX_PRE_OUTPUT_BUFFER_BYTES) {
+        throw new UpstreamError(
+          "upstream_error",
+          "upstream pre-output buffer exceeds the memory budget",
+        );
+      }
+      // Hold the raw bytes for verbatim replay; accumulate a parallel text buffer only
+      // to frame complete SSE events (split on the blank-line terminator).
+      buffered.push(chunk);
+      bufferedBytes = nextBufferedBytes;
+      sse += chunk;
+      let boundary = nextSSEFrameBoundary(sse);
+      while (boundary !== null) {
+        const data = extractData(sse.slice(0, boundary.index));
+        sse = sse.slice(boundary.index + boundary.length);
+        if (data !== null) {
+          const cls = classifier.classify(data);
+          if (cls === "error") {
+            explicitPreOutputError = true;
+            throw streamErrorFromData(classifier, data);
+          }
+          if (cls === "output") {
+            committed = true;
+            for (const b of buffered) yield b;
+            buffered.length = 0;
+            bufferedBytes = 0;
+            break;
+          }
+        }
+        boundary = nextSSEFrameBoundary(sse);
+      }
     }
+  } catch (error) {
+    const tailError = unterminatedError();
+    if (tailError) throw tailError;
+    if (classifier === responsesClassifier && !committed && !explicitPreOutputError) {
+      throw responsesOutcomeUnknown(error);
+    }
+    throw error;
   }
 
   // Source ended having emitted only preamble (no output, no error): an abnormal
-  // close. Throw so the caller records a failure and falls back, rather than serving
-  // an empty body as success.
+  // close. An HTTP 200 Responses stream means the POST may already have been accepted,
+  // even when the body is empty or its final SSE delimiter never arrived.
   if (!committed) {
+    const tailError = unterminatedError();
+    if (tailError) throw tailError;
+    if (classifier === responsesClassifier) throw responsesOutcomeUnknown();
     throw new UpstreamError("upstream_error", "upstream stream ended before producing any output");
   }
 }

--- a/packages/core/src/provider/oauth/pool.test.ts
+++ b/packages/core/src/provider/oauth/pool.test.ts
@@ -2924,7 +2924,7 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
     expect(served).toEqual(["b"]);
   });
 
-  it("rotates to a sibling Codex account after an exhausted raw fetch failure", async () => {
+  it("does not replay a Codex HTTP POST on a sibling after a raw fetch failure", async () => {
     const selected: string[] = [];
     const raw = Object.assign(new TypeError("fetch failed"), {
       cause: Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" }),
@@ -2970,11 +2970,16 @@ describe("createOAuthPoolClient — in-pool retry on transient upstream fault", 
       mutations: {},
     };
 
-    const chunks: string[] = [];
-    for await (const chunk of pool.nativePassthroughStream?.(request) ?? []) chunks.push(chunk);
-
-    expect(selected).toEqual(["a", "b"]);
-    expect(chunks.join("")).toContain('"id":"resp-b"');
+    await expect(
+      (async () => {
+        for await (const _ of pool.nativePassthroughStream?.(request) ?? []) {
+          /* drain */
+        }
+      })(),
+    ).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
+    expect(selected).toEqual(["a"]);
   });
 
   it("cools a Codex model-scoped 429 on native streaming without parking sibling models", async () => {
@@ -3212,7 +3217,7 @@ describe("createOAuthPoolClient — in-band pre-output failover (preamble then e
     expect(chunks.filter((c) => c === ERROR)).toEqual([]); // the error frame was never relayed
   });
 
-  it("also fails over when the first account closes after only a preamble", async () => {
+  it("does not replay on a sibling after response.created then EOF", async () => {
     const pool = createOAuthPoolClient({
       members: [
         nativeStreamMember("a", 10, "preamble_only"),
@@ -3220,9 +3225,15 @@ describe("createOAuthPoolClient — in-band pre-output failover (preamble then e
       ],
       nativeStreamPreambleClassifier: responses,
     });
-    const chunks: string[] = [];
-    for await (const c of pool.nativePassthroughStream?.(NATIVE) ?? []) chunks.push(c);
-    expect(chunks).toContain(OUTPUT);
+    await expect(
+      (async () => {
+        for await (const _ of pool.nativePassthroughStream?.(NATIVE) ?? []) {
+          /* drain */
+        }
+      })(),
+    ).rejects.toMatchObject({
+      providerRaw: { error: { code: "response_create_outcome_unknown" } },
+    });
   });
 
   it("commits (no spurious retry) when the only account reaches real output", async () => {

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -42,6 +42,32 @@ function rawSSEResponse(body: string): Response {
   return new Response(body, { status: 200, headers: { "Content-Type": "text/event-stream" } });
 }
 
+function responseThatErrorsAfter(body: string, error: Error, contentType: string): Response {
+  let pulled = false;
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        if (!pulled) {
+          pulled = true;
+          controller.enqueue(new TextEncoder().encode(body));
+        } else {
+          controller.error(error);
+        }
+      },
+    },
+    { highWaterMark: 0 },
+  );
+  return new Response(stream, { status: 200, headers: { "Content-Type": contentType } });
+}
+
+function isolatedResponseWorkAdmission() {
+  return createResponseWorkAdmission({
+    capacityBytes: 1_000_000,
+    jsonAmplification: 1,
+    minChargeBytes: 1,
+  });
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -1392,6 +1418,7 @@ describe("createCodexResponsesClient", () => {
         currentSecrets: () => [token],
       },
       fetch: fetchMock as unknown as typeof fetch,
+      responseWorkAdmission: isolatedResponseWorkAdmission(),
     });
     const resp = (await client.chatCompletion({
       model: "gpt-5.5",
@@ -1671,7 +1698,7 @@ describe("createCodexResponsesClient", () => {
     expect(seenUrl).toBe("https://chatgpt.com/backend-api/codex/responses");
   });
 
-  it("maps a connect/TTFB timeout (internal abort, no external signal) to UpstreamError(timeout)", async () => {
+  it("does not replay a Responses POST after an ambiguous connect/TTFB timeout", async () => {
     vi.useFakeTimers();
     try {
       const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
@@ -1693,7 +1720,13 @@ describe("createCodexResponsesClient", () => {
         fetch: fetchMock as unknown as typeof fetch,
       });
       const run = client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] });
-      const assertion = expect(run).rejects.toMatchObject({ errorClass: "timeout" });
+      const assertion = expect(run).rejects.toMatchObject({
+        upstreamStatus: 400,
+        providerRaw: {
+          error: { code: "response_create_outcome_unknown" },
+          http: { lifecycle_phase: "after_send_before_response" },
+        },
+      });
       await vi.advanceTimersByTimeAsync(50);
       await assertion;
     } finally {
@@ -1731,9 +1764,8 @@ describe("createCodexResponsesClient", () => {
     expect(caught).not.toBeInstanceOf(UpstreamError);
   });
 
-  it("retries write ECANCELED then wraps it for account-pool failover", async () => {
-    // A pre-response Node socket cancellation is transient → retried at the fetch
-    // boundary; exhaustion is then classified for account-pool failover.
+  it("does not replay a Responses POST when fetch fails before returning headers", async () => {
+    // No response headers does not prove the POST was not accepted upstream.
     const boom = Object.assign(new Error("write ECANCELED"), { code: "ECANCELED" });
     const fetch = vi.fn(async () => {
       throw boom;
@@ -1742,6 +1774,7 @@ describe("createCodexResponsesClient", () => {
       config: {
         baseUrl: "https://chatgpt.com/backend-api/codex",
         getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        connectRetries: 2,
         connectRetryBackoffMs: [0, 0],
       },
       fetch: fetch as unknown as typeof globalThis.fetch,
@@ -1750,10 +1783,200 @@ describe("createCodexResponsesClient", () => {
       client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] }),
     ).rejects.toMatchObject({
       errorClass: "upstream_error",
-      upstreamStatus: null,
-      providerRaw: { error: { name: "Error", message: "write ECANCELED", code: "ECANCELED" } },
+      upstreamStatus: 400,
+      providerRaw: {
+        error: { code: "response_create_outcome_unknown" },
+        http: { lifecycle_phase: "after_send_before_response" },
+      },
     });
-    expect(fetch).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks translated unary and streaming read failures after HTTP 200 as outcome-unknown", async () => {
+    const preamble = 'data: {"type":"response.created","response":{"id":"resp-read"}}\n\n';
+    for (const method of ["unary", "stream"] as const) {
+      const client = createCodexResponsesClient({
+        config: {
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        },
+        fetch: (async () =>
+          responseThatErrorsAfter(
+            preamble,
+            new Error(`stream broke: ${method}`),
+            "text/event-stream",
+          )) as unknown as typeof fetch,
+        responseWorkAdmission: isolatedResponseWorkAdmission(),
+      });
+      const run = async () => {
+        if (method === "unary") {
+          await client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] });
+          return;
+        }
+        for await (const _ of client.chatCompletionStream({
+          model: "m",
+          messages: [{ role: "user", content: "x" }],
+        })) {
+          // drain
+        }
+      };
+
+      await expect(run()).rejects.toMatchObject({
+        upstreamStatus: 400,
+        providerRaw: {
+          error: { code: "response_create_outcome_unknown" },
+          http: { lifecycle_phase: "after_response_before_terminal" },
+        },
+      });
+    }
+  });
+
+  it("marks native unary and raw-stream read failures after HTTP 200 as outcome-unknown", async () => {
+    const nativeBody = { model: "m", input: [], store: false };
+    for (const method of ["unary", "stream"] as const) {
+      const body =
+        method === "stream"
+          ? 'data: {"type":"response.created","response":{"id":"resp-native-read"}}\n\n'
+          : "";
+      const client = createCodexResponsesClient({
+        config: {
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        },
+        fetch: (async () =>
+          responseThatErrorsAfter(
+            body,
+            new Error(`native stream broke: ${method}`),
+            method === "stream" ? "text/event-stream" : "application/json",
+          )) as unknown as typeof fetch,
+        responseWorkAdmission: isolatedResponseWorkAdmission(),
+      });
+      const run = async () => {
+        if (method === "unary") {
+          await client.nativePassthrough?.(nativeBody);
+          return;
+        }
+        for await (const _ of client.nativePassthroughStream?.({ ...nativeBody, stream: true }) ??
+          []) {
+          // drain
+        }
+      };
+
+      await expect(run()).rejects.toMatchObject({
+        upstreamStatus: 400,
+        providerRaw: {
+          error: { code: "response_create_outcome_unknown" },
+          http: { lifecycle_phase: "after_response_before_terminal" },
+        },
+      });
+    }
+  });
+
+  it("preserves an explicit response.failed as a safe fallback signal", async () => {
+    const client = createCodexResponsesClient({
+      config: {
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+      },
+      fetch: (async () =>
+        sseResponse([
+          { type: "response.created", response: { id: "resp-failed" } },
+          {
+            type: "response.failed",
+            response: { error: { code: "server_error", message: "explicit failure" } },
+          },
+        ])) as unknown as typeof fetch,
+      responseWorkAdmission: isolatedResponseWorkAdmission(),
+    });
+
+    await expect(
+      client.chatCompletion({ model: "m", messages: [{ role: "user", content: "x" }] }),
+    ).rejects.toMatchObject({
+      upstreamStatus: null,
+      message: "explicit failure",
+      providerRaw: { type: "response.failed" },
+    });
+  });
+
+  it("preserves unterminated explicit failure frames before a reader error", async () => {
+    for (const method of ["unary", "stream"] as const) {
+      for (const event of [
+        {
+          type: "response.failed",
+          response: { error: { code: "server_error", message: "explicit failure" } },
+        },
+        { type: "error", code: "server_error", message: "explicit failure" },
+      ]) {
+        const client = createCodexResponsesClient({
+          config: {
+            baseUrl: "https://chatgpt.com/backend-api/codex",
+            getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+          },
+          fetch: (async () =>
+            responseThatErrorsAfter(
+              `data: ${JSON.stringify(event)}`,
+              new Error("stream broke after explicit failure"),
+              "text/event-stream",
+            )) as unknown as typeof fetch,
+          responseWorkAdmission: isolatedResponseWorkAdmission(),
+        });
+        const run = async () => {
+          if (method === "unary") {
+            await client.chatCompletion({
+              model: "m",
+              messages: [{ role: "user", content: "x" }],
+            });
+            return;
+          }
+          for await (const _ of client.chatCompletionStream({
+            model: "m",
+            messages: [{ role: "user", content: "x" }],
+          })) {
+            // drain
+          }
+        };
+
+        await expect(run()).rejects.toMatchObject({
+          upstreamStatus: null,
+          message: "explicit failure",
+          providerRaw: { type: event.type },
+        });
+      }
+    }
+  });
+
+  it("keeps explicit 503/529 overload retries bounded to three attempts", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response("overloaded", { status: 503 }))
+        .mockResolvedValueOnce(new Response("overloaded", { status: 529 }))
+        .mockResolvedValueOnce(
+          sseResponse([
+            { type: "response.output_text.delta", delta: "ok" },
+            { type: "response.completed", response: { status: "completed", usage: {} } },
+          ]),
+        );
+      const client = createCodexResponsesClient({
+        config: {
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          getAuthHeader: async () => `Bearer ${jwt("acct")}`,
+        },
+        fetch: fetchMock as unknown as typeof fetch,
+        responseWorkAdmission: isolatedResponseWorkAdmission(),
+      });
+      const run = client.chatCompletion({
+        model: "m",
+        messages: [{ role: "user", content: "x" }],
+      });
+
+      await vi.advanceTimersByTimeAsync(4_000);
+      await expect(run).resolves.toMatchObject({ choices: [{ message: { content: "ok" } }] });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("preserves a non-JSON upstream error body as raw text in the UpstreamError", async () => {

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -5490,7 +5490,7 @@ describe("createCodexResponsesClient — nativePassthrough", () => {
     expect(JSON.stringify(err.providerRaw)).toContain("[redacted]");
   });
 
-  it("wraps an exhausted raw fetch failure with scrubbed nested cause details", async () => {
+  it("marks an exhausted raw fetch failure outcome-unknown with scrubbed cause details", async () => {
     const secret = "proxy-secret-1234";
     const raw = Object.assign(new TypeError("fetch failed"), {
       cause: Object.assign(new Error(`other side closed ${secret}`), {
@@ -5519,15 +5519,19 @@ describe("createCodexResponsesClient — nativePassthrough", () => {
     expect(caught).toBeInstanceOf(UpstreamError);
     expect(caught).toMatchObject({
       errorClass: "upstream_error",
-      upstreamStatus: null,
+      upstreamStatus: 400,
       providerRaw: {
-        error: {
-          name: "TypeError",
-          message: "fetch failed",
-          cause: {
-            name: "Error",
-            code: "UND_ERR_SOCKET",
-            message: "other side closed [redacted]",
+        error: { code: "response_create_outcome_unknown" },
+        http: { lifecycle_phase: "after_send_before_response" },
+        transport: {
+          error: {
+            name: "TypeError",
+            message: "fetch failed",
+            cause: {
+              name: "Error",
+              code: "UND_ERR_SOCKET",
+              message: "other side closed [redacted]",
+            },
           },
         },
       },

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -5725,7 +5725,7 @@ describe("createCodexResponsesClient — responsesCompact", () => {
   it.each([
     "nativePassthrough",
     "responsesCompact",
-  ] as const)("keeps the timeout active while %s reads the complete unary response body", async (method) => {
+  ] as const)("handles a %s unary body timeout after HTTP 200 according to replay safety", async (method) => {
     vi.useFakeTimers();
     try {
       const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
@@ -5751,6 +5751,7 @@ describe("createCodexResponsesClient — responsesCompact", () => {
           timeoutMs: 50,
         },
         fetch: fetchMock as unknown as typeof fetch,
+        responseWorkAdmission: isolatedResponseWorkAdmission(),
       });
       const run =
         method === "nativePassthrough"
@@ -5770,7 +5771,18 @@ describe("createCodexResponsesClient — responsesCompact", () => {
       await Promise.resolve();
 
       expect(outcome).toBeInstanceOf(UpstreamError);
-      expect(outcome).toMatchObject({ errorClass: "timeout" });
+      expect(outcome).toMatchObject(
+        method === "nativePassthrough"
+          ? {
+              errorClass: "upstream_error",
+              upstreamStatus: 400,
+              providerRaw: {
+                error: { code: "response_create_outcome_unknown" },
+                http: { lifecycle_phase: "after_response_before_terminal" },
+              },
+            }
+          : { errorClass: "timeout" },
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -38,11 +38,7 @@ import {
   ResponseWorkCapacityError,
   runtimeResponseWorkAdmission,
 } from "../runtime/response-work-admission.js";
-import {
-  CODEX_RESPONSES_BEFORE_SEND,
-  CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE,
-  isTrustedCodexResponsesBeforeSendError,
-} from "./failover-guard.js";
+import { CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE } from "./failover-guard.js";
 import {
   type PreparedNativePassthroughRequest,
   prepareNativePassthroughRequest,
@@ -195,8 +191,6 @@ export function isCodexResponsesPostSendFailureCode(code: unknown): boolean {
 
 /** The current response.create is proven not to have reached an upstream provider. */
 export class CodexResponsesBeforeSendError extends UpstreamError {
-  readonly [CODEX_RESPONSES_BEFORE_SEND] = true;
-
   constructor(message: string, recovery: Record<string, unknown> = {}) {
     super(
       "upstream_error",
@@ -220,7 +214,7 @@ export class CodexResponsesBeforeSendError extends UpstreamError {
 }
 
 export function isCodexResponsesBeforeSendError(error: unknown): boolean {
-  return isTrustedCodexResponsesBeforeSendError(error);
+  return error instanceof CodexResponsesBeforeSendError;
 }
 
 export interface CodexResponsesWebSocketConnectInput {

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -38,6 +38,7 @@ import {
   ResponseWorkCapacityError,
   runtimeResponseWorkAdmission,
 } from "../runtime/response-work-admission.js";
+import { CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE } from "./failover-guard.js";
 import {
   type PreparedNativePassthroughRequest,
   prepareNativePassthroughRequest,
@@ -174,7 +175,6 @@ export interface GenericOpenAIResponsesRequestContract {
 }
 
 export const CODEX_RESPONSES_WEBSOCKET_SESSION_HEADER = "x-helm-codex-responses-websocket-session";
-const CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE = "response_create_outcome_unknown";
 const CODEX_RESPONSES_SESSION_UNAVAILABLE_CODE = "previous_response_id_session_unavailable";
 const CODEX_RESPONSES_NOT_SENT_CODE = "response_create_not_sent";
 
@@ -1640,6 +1640,46 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     turnKey?: string;
   }
 
+  function httpResponseOutcomeUnknown(
+    cause: unknown,
+    lifecyclePhase = "after_send_before_response",
+  ): UpstreamError {
+    const message =
+      lifecyclePhase === "after_send_before_response"
+        ? "upstream HTTP connection failed after Responses POST; outcome unknown"
+        : "upstream HTTP response ended before a terminal Responses event; outcome unknown";
+    return new UpstreamError(
+      "upstream_error",
+      message,
+      {
+        error: {
+          type: "invalid_request_error",
+          code: CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE,
+          message,
+        },
+        http: { lifecycle_phase: lifecyclePhase },
+        ...(cause instanceof UpstreamError ? { transport: cause.providerRaw } : {}),
+      },
+      400,
+      null,
+      cause,
+    );
+  }
+
+  function throwAcceptedResponseError(error: unknown, signal?: AbortSignal): never {
+    const raw =
+      error instanceof UpstreamError && isRecord(error.providerRaw) ? error.providerRaw : null;
+    if (
+      signal?.aborted ||
+      raw?.type === "error" ||
+      raw?.type === "response.failed" ||
+      raw?.type === "response.incomplete"
+    ) {
+      throw error;
+    }
+    throw httpResponseOutcomeUnknown(error, "after_response_before_terminal");
+  }
+
   async function prepareRequest(
     input: NativePassthroughInput,
     modelInfo: CodexModelInfo | undefined,
@@ -1696,6 +1736,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       capture?: (wireBody: string) => void;
       timeoutThroughBody?: boolean;
       retry?: boolean;
+      outcomeUnknownOnTransport?: boolean;
     },
   ): Promise<CodexHttpResponse> {
     const { prepared, turnKey } = await prepareRequest(
@@ -1707,13 +1748,13 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
     // The exact Responses-native bytes POSTed upstream (translate path: OpenAI→Responses
     // re-serialization; native passthrough: verbatim, model patched) — surfaced for capture.
     init.capture?.(prepared.bodyText);
-    // Retry transient connection blips at the fetch boundary (pre-first-byte → idempotent);
-    // a timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
+    // A timeout becomes a non-transient UpstreamError and a client abort rethrows as-is.
+    // Do not retry a thrown fetch: no response headers does not prove the POST was not
+    // accepted upstream, so replaying it can duplicate inference, tools, or billing.
     try {
-      // withOverloadRetry wraps the connection retry: an overloaded 529/503 answer is a
-      // normal Response (never a throw), so it re-issues the whole attempt after a pause
-      // rather than burning a candidate on transient upstream capacity pressure. A
-      // discarded attempt's deferred body-timeout timer is released explicitly.
+      // An overloaded 529/503 answer is an explicit rejection, so it is safe to re-issue
+      // the same body after a pause. A discarded attempt's deferred body-timeout timer is
+      // released explicitly.
       const send = async (): Promise<CodexHttpResponse> => {
         const t = withTimeout(timeoutMs, init.signal);
         try {
@@ -1735,25 +1776,26 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         }
       };
       if (init.retry === false) return await send();
-      return await withOverloadRetry(
-        () =>
-          withConnectionRetry(send, {
-            retries: cfg.connectRetries,
-            backoffMs: cfg.connectRetryBackoffMs,
-            signal: init.signal,
-          }),
-        {
-          signal: init.signal,
-          pick: (value) => value.response,
-          release: (value) => value.bodyTimeout?.cleanup(),
-        },
-      );
+      return await withOverloadRetry(send, {
+        signal: init.signal,
+        pick: (value) => value.response,
+        release: (value) => value.bodyTimeout?.cleanup(),
+      });
     } catch (error) {
       // An external abort is client-owned even when fetch happens to surface a
-      // transport-shaped TypeError. Explicit provider timeouts are already
-      // UpstreamError("timeout") and therefore fail this raw-transport guard.
-      if (init.signal?.aborted || !isFetchTransportError(error)) throw error;
-      throw upstreamTransportError(error, scrub);
+      // transport-shaped TypeError.
+      if (init.signal?.aborted) throw error;
+      if (
+        init.outcomeUnknownOnTransport === true &&
+        error instanceof UpstreamError &&
+        error.errorClass === "timeout"
+      ) {
+        throw httpResponseOutcomeUnknown(error);
+      }
+      if (!isFetchTransportError(error)) throw error;
+      const transport = upstreamTransportError(error, scrub);
+      if (init.outcomeUnknownOnTransport !== true) throw transport;
+      throw httpResponseOutcomeUnknown(transport);
     }
   }
 
@@ -1850,6 +1892,7 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       signal: init.signal,
       capture: init.capture,
       timeoutThroughBody: init.timeoutThroughBody,
+      outcomeUnknownOnTransport: (init.endpoint ?? url) === url,
     };
     const first = await request(body, modelInfo, requestInit);
     if (first.response.status === 401 && cfg.onUnauthorized !== undefined) {
@@ -2574,7 +2617,14 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
       );
       if (!result.response.ok) throw await errorFromResponse(result);
       // Codex is stream-only → aggregate the SSE into a single Chat response.
-      return await aggregateResponsesStream(result.response, model, timeoutMs);
+      try {
+        return await aggregateResponsesStream(result.response, model, timeoutMs, {
+          workAdmission: deps.responseWorkAdmission,
+          signal: opts?.signal,
+        });
+      } catch (error) {
+        throwAcceptedResponseError(error, opts?.signal);
+      }
     },
 
     async *chatCompletionStream(req, opts) {
@@ -2590,7 +2640,14 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         },
       );
       if (!result.response.ok) throw await errorFromResponse(result);
-      yield* translateResponsesSSE(result.response, model, timeoutMs);
+      try {
+        yield* translateResponsesSSE(result.response, model, timeoutMs, {
+          workAdmission: deps.responseWorkAdmission,
+          signal: opts?.signal,
+        });
+      } catch (error) {
+        throwAcceptedResponseError(error, opts?.signal);
+      }
     },
 
     // Native protocol passthrough (issue #217, Phase 3): the inbound /v1/responses body
@@ -2612,7 +2669,11 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         timeoutThroughBody: true,
       });
       if (!result.response.ok) throw await errorFromResponse(result);
-      return await readUnaryJson(result);
+      try {
+        return await readUnaryJson(result);
+      } catch (error) {
+        throwAcceptedResponseError(error, opts?.signal);
+      }
     },
 
     // Streaming native passthrough (issue #217, Phase 3). The native body from a STREAMING
@@ -2885,11 +2946,15 @@ export function createCodexResponsesClient(deps: CodexResponsesClientDeps): Prov
         onResponseMeta: opts?.onResponseMeta,
       });
       if (!result.response.ok) throw await errorFromResponse(result);
-      yield* readResponsesSSERaw(
-        result.response,
-        timeoutMs,
-        deps.responseWorkAdmission ?? runtimeResponseWorkAdmission(),
-      );
+      try {
+        yield* readResponsesSSERaw(
+          result.response,
+          timeoutMs,
+          deps.responseWorkAdmission ?? runtimeResponseWorkAdmission(),
+        );
+      } catch (error) {
+        throwAcceptedResponseError(error, opts?.signal);
+      }
     },
 
     closeResponsesWebSocketSession: closeWebSocketSession,
@@ -3395,12 +3460,28 @@ export async function* readResponsesEvents(
   const decoder = new TextDecoder();
   let buffer = "";
   const frameGuard = createSSEIncompleteFrameGuard(workAdmission);
+  const bufferedTerminalEvent = (): Record<string, unknown> | null => {
+    if (buffer.trim() === "") return null;
+    const event = parseResponsesSSEFrame(buffer);
+    return event !== null &&
+      (event.type === "response.completed" ||
+        event.type === "response.failed" ||
+        event.type === "response.incomplete" ||
+        event.type === "error")
+      ? event
+      : null;
+  };
   try {
     while (true) {
       let read: { done: boolean; value?: Uint8Array };
       try {
         read = await readChunkWithIdle(reader, idleMs, signal);
       } catch (err) {
+        const terminal = bufferedTerminalEvent();
+        if (terminal !== null) {
+          yield terminal;
+          return;
+        }
         if (err instanceof StreamStalledError) throw new UpstreamError("timeout", err.message);
         throw err;
       }
@@ -3647,7 +3728,11 @@ export async function* translateResponsesSSE(
   res: Response,
   model: string,
   idleMs = 0,
-  options: { strictTerminal?: boolean } = {},
+  options: {
+    strictTerminal?: boolean;
+    workAdmission?: ResponseWorkAdmission;
+    signal?: AbortSignal;
+  } = {},
 ): AsyncGenerator<string> {
   const strictTerminal = options.strictTerminal ?? true;
   let started = false;
@@ -3676,7 +3761,7 @@ export async function* translateResponsesSSE(
     return state;
   };
 
-  for await (const evt of readResponsesEvents(res, idleMs)) {
+  for await (const evt of readResponsesEvents(res, idleMs, options.workAdmission, options.signal)) {
     const type = evt.type;
     if (type === "error" || type === "response.failed") {
       throw responseEventError(evt);
@@ -3829,7 +3914,11 @@ export async function aggregateResponsesStream(
   res: Response,
   model: string,
   idleMs = 0,
-  options: { allowIncomplete?: boolean } = {},
+  options: {
+    allowIncomplete?: boolean;
+    workAdmission?: ResponseWorkAdmission;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<ChatCompletionResponse> {
   const allowIncomplete = options.allowIncomplete ?? false;
   let text = "";
@@ -3867,7 +3956,7 @@ export async function aggregateResponsesStream(
     return tool;
   };
 
-  for await (const evt of readResponsesEvents(res, idleMs)) {
+  for await (const evt of readResponsesEvents(res, idleMs, options.workAdmission, options.signal)) {
     const type = evt.type;
     if (
       type === "error" ||

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -38,7 +38,11 @@ import {
   ResponseWorkCapacityError,
   runtimeResponseWorkAdmission,
 } from "../runtime/response-work-admission.js";
-import { CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE } from "./failover-guard.js";
+import {
+  CODEX_RESPONSES_BEFORE_SEND,
+  CODEX_RESPONSES_OUTCOME_UNKNOWN_CODE,
+  isTrustedCodexResponsesBeforeSendError,
+} from "./failover-guard.js";
 import {
   type PreparedNativePassthroughRequest,
   prepareNativePassthroughRequest,
@@ -191,6 +195,8 @@ export function isCodexResponsesPostSendFailureCode(code: unknown): boolean {
 
 /** The current response.create is proven not to have reached an upstream provider. */
 export class CodexResponsesBeforeSendError extends UpstreamError {
+  readonly [CODEX_RESPONSES_BEFORE_SEND] = true;
+
   constructor(message: string, recovery: Record<string, unknown> = {}) {
     super(
       "upstream_error",
@@ -214,7 +220,7 @@ export class CodexResponsesBeforeSendError extends UpstreamError {
 }
 
 export function isCodexResponsesBeforeSendError(error: unknown): boolean {
-  return error instanceof CodexResponsesBeforeSendError;
+  return isTrustedCodexResponsesBeforeSendError(error);
 }
 
 export interface CodexResponsesWebSocketConnectInput {


### PR DESCRIPTION
## Summary
- stop replaying Codex Responses POSTs when fetch, TTFB, or accepted-body consumption has an unknown outcome
- preserve explicit response.failed/error and bounded 401/503/529 recovery
- treat empty and unterminated HTTP 200 Responses streams as accepted-but-ambiguous

## Verification
- 139 focused failover and OAuth pool tests
- 6 focused Codex HTTP retry-safety tests
- gateway no-candidate-fallback integration test
- pnpm typecheck
- core build
- Biome and git diff checks