### PR TITLE
fix(admin): close successful connectivity test dialog

### DIFF
--- a/apps/admin/src/routes/providers/+page.svelte
+++ b/apps/admin/src/routes/providers/+page.svelte
@@ -102,7 +102,7 @@
   $effect(() => {
     overview = { ...data };
     if (data.loadError) error = data.loadError;
-    scheduleProviderRevalidation();
+    untrack(scheduleProviderRevalidation);
   });
 
   const keyOf = (providerId: string, account: string): string => `${providerId}/${account}`;

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -176,6 +176,23 @@ describe('providers page', () => {
     });
   });
 
+  it('accepts refreshed route data without entering a reactive update loop', async () => {
+    const view = renderPage();
+
+    await view.rerender({
+      data: {
+        configured: true,
+        selectionStrategy: 'balanced',
+        providers: [provider()],
+        usage: [{ ...usage[0], requests: 43 }],
+        quota,
+        refresh: idleRefresh,
+      },
+    });
+
+    expect(screen.getByText('43 req')).toBeInTheDocument();
+  });
+
   it('labels the Grok subscription provider as experimental', () => {
     renderPage({
       providers: [
@@ -1087,6 +1104,10 @@ describe('providers page', () => {
     );
     expect(within(dialog).getByText('Success')).toBeInTheDocument();
     expect(within(dialog).getByText('Done in 1.2s')).toBeInTheDocument();
+
+    await fireEvent.click(within(dialog).getByRole('button', { name: /close/i }));
+
+    expect(screen.queryByRole('dialog', { name: /test connection/i })).not.toBeInTheDocument();
   });
 
   it('confirms and disconnects a stored account credential', async () => {


### PR DESCRIPTION
## Summary
- stop provider refresh scheduling from being captured as a reactive dependency
- cover route-data refresh loops and closing a successful connectivity result

## Verification
- `CI=true pnpm exec vitest run apps/admin/src/routes/providers/providers.test.ts` (54 passed)
- `CI=true pnpm --filter @helm/admin check` (0 errors, 0 warnings)
- `pnpm --filter @helm/admin exec prettier --check src/routes/providers/+page.svelte src/routes/providers/providers.test.ts`
- production-mode browser QA with mocked SSE: Success → Close works on first click; no console errors