### PR TITLE
chore(release): v0.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.28.103",
+  "version": "0.29.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- start the v0.29 release line after 103 v0.28 patch releases
- include the merged connectivity-dialog fix from PR #827

## Version assessment
- v0.28.0 → v0.28.103 accumulated 18 `feat` and 121 `fix` commits
- the repository previously moved v0.27.28 → v0.28.0 with a version-only release commit after a feature merge
- v0.29.0 marks a new compatible feature baseline without claiming v1 stability

## Verification
- package.json parses and reports `0.29.0`
- `git diff --check` passed
- version-only change; full required CI is authoritative