### PR TITLE
feat(admin): allow custom model IDs in account tests

### DIFF
--- a/apps/admin/src/lib/components/TestAccountDialog.svelte
+++ b/apps/admin/src/lib/components/TestAccountDialog.svelte
@@ -39,7 +39,7 @@
   let controller: AbortController | null = null;
 
   const running = $derived(status === 'running');
-  const canRun = $derived(model.length > 0 && !running);
+  const canRun = $derived(model.trim().length > 0 && !running);
 
   async function run(): Promise<void> {
     if (!canRun) return;
@@ -53,7 +53,7 @@
     try {
       for await (const ev of streamAccountTest(
         provider,
-        { account, model, prompt: prompt.trim() || undefined },
+        { account, model: model.trim(), prompt: prompt.trim() || undefined },
         controller.signal,
       )) {
         if (ev.type === 'content') {
@@ -109,18 +109,29 @@
       </div>
     </div>
 
-    {#if models.length === 0}
-      <p class="alert-warn">{$t('No routable models for this account.')}</p>
-    {:else}
-      <label class="flex flex-col gap-1 text-sm">
-        <span class="field-label">{$t('Model')}</span>
-        <select class="input" bind:value={model} disabled={running}>
-          {#each models as m (m)}
-            <option value={m}>{m}</option>
-          {/each}
-        </select>
-      </label>
-    {/if}
+    <div class="flex flex-col gap-1 text-sm">
+      <label class="field-label" for="account-test-model">{$t('Model')}</label>
+      <input
+        id="account-test-model"
+        type="text"
+        class="input font-mono"
+        list="account-test-models"
+        aria-describedby="account-test-model-help"
+        placeholder={$t('Enter a model ID')}
+        bind:value={model}
+        disabled={running}
+        spellcheck="false"
+        autocomplete="off"
+      />
+      <span id="account-test-model-help" class="field-help">
+        {$t('Choose an account model or enter a custom model ID for this test only.')}
+      </span>
+      <datalist id="account-test-models">
+        {#each models as m (m)}
+          <option value={m}></option>
+        {/each}
+      </datalist>
+    </div>
 
     <label class="flex flex-col gap-1 text-sm">
       <span class="field-label">{$t('Message')}</span>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1066,5 +1066,7 @@
   "Rebuild the transcript in your browser instead of on the server.": "Rebuild the transcript in your browser instead of on the server.",
   "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.": "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.",
   "The session transcript is too large to rebuild on the server.": "The session transcript is too large to rebuild on the server.",
-  "The session transcript could not be rebuilt.": "The session transcript could not be rebuilt."
+  "The session transcript could not be rebuilt.": "The session transcript could not be rebuilt.",
+  "Choose an account model or enter a custom model ID for this test only.": "Choose an account model or enter a custom model ID for this test only.",
+  "Enter a model ID": "Enter a model ID"
 }

--- a/apps/admin/src/locales/es.json
+++ b/apps/admin/src/locales/es.json
@@ -1066,5 +1066,7 @@
   "Rebuild the transcript in your browser instead of on the server.": "Reconstruye la transcripción en tu navegador en lugar de en el servidor.",
   "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.": "Reconstruido a partir de la transcripción de la sesión en tu navegador: semánticamente igual a la solicitud original, no el cuerpo HTTP exacto.",
   "The session transcript is too large to rebuild on the server.": "La transcripción de la sesión es demasiado grande para reconstruirla en el servidor.",
-  "The session transcript could not be rebuilt.": "No se pudo reconstruir la transcripción de la sesión."
+  "The session transcript could not be rebuilt.": "No se pudo reconstruir la transcripción de la sesión.",
+  "Choose an account model or enter a custom model ID for this test only.": "Elige un modelo de la cuenta o ingresa un ID de modelo personalizado solo para esta prueba.",
+  "Enter a model ID": "Ingresa un ID de modelo"
 }

--- a/apps/admin/src/locales/ja.json
+++ b/apps/admin/src/locales/ja.json
@@ -1066,5 +1066,7 @@
   "Rebuild the transcript in your browser instead of on the server.": "サーバーではなくブラウザーでトランスクリプトを再構築します。",
   "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.": "ブラウザーでセッショントランスクリプトから再構築しました。元のリクエストと意味的に同等ですが、正確な HTTP ボディではありません。",
   "The session transcript is too large to rebuild on the server.": "セッショントランスクリプトが大きすぎて、サーバーで再構築できません。",
-  "The session transcript could not be rebuilt.": "セッショントランスクリプトを再構築できませんでした。"
+  "The session transcript could not be rebuilt.": "セッショントランスクリプトを再構築できませんでした。",
+  "Choose an account model or enter a custom model ID for this test only.": "アカウントのモデルを選択するか、このテストでのみ使用するカスタムモデル ID を入力します。",
+  "Enter a model ID": "モデル ID を入力"
 }

--- a/apps/admin/src/locales/ko.json
+++ b/apps/admin/src/locales/ko.json
@@ -1066,5 +1066,7 @@
   "Rebuild the transcript in your browser instead of on the server.": "서버가 아닌 브라우저에서 트랜스크립트를 다시 만듭니다.",
   "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.": "브라우저에서 세션 트랜스크립트로부터 재구성했습니다. 원래 요청과 의미상 동일하지만 정확한 HTTP 본문은 아닙니다.",
   "The session transcript is too large to rebuild on the server.": "세션 트랜스크립트가 너무 커서 서버에서 재구성할 수 없습니다.",
-  "The session transcript could not be rebuilt.": "세션 트랜스크립트를 재구성할 수 없습니다."
+  "The session transcript could not be rebuilt.": "세션 트랜스크립트를 재구성할 수 없습니다.",
+  "Choose an account model or enter a custom model ID for this test only.": "계정 모델을 선택하거나 이번 테스트에만 사용할 사용자 지정 모델 ID를 입력하세요.",
+  "Enter a model ID": "모델 ID 입력"
 }

--- a/apps/admin/src/locales/pt.json
+++ b/apps/admin/src/locales/pt.json
@@ -1066,5 +1066,7 @@
   "Rebuild the transcript in your browser instead of on the server.": "Reconstrua a transcrição no seu navegador em vez de no servidor.",
   "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.": "Reconstruído a partir da transcrição da sessão no seu navegador — semanticamente igual à solicitação original, não o corpo HTTP exato.",
   "The session transcript is too large to rebuild on the server.": "A transcrição da sessão é grande demais para reconstruir no servidor.",
-  "The session transcript could not be rebuilt.": "Não foi possível reconstruir a transcrição da sessão."
+  "The session transcript could not be rebuilt.": "Não foi possível reconstruir a transcrição da sessão.",
+  "Choose an account model or enter a custom model ID for this test only.": "Escolha um modelo da conta ou insira um ID de modelo personalizado apenas para este teste.",
+  "Enter a model ID": "Insira um ID de modelo"
 }

--- a/apps/admin/src/locales/zh-hans.json
+++ b/apps/admin/src/locales/zh-hans.json
@@ -1066,5 +1066,7 @@
   "Rebuild the transcript in your browser instead of on the server.": "在浏览器中重建转录，而不是在服务器上重建。",
   "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.": "已在浏览器中从会话转录重建——与原始请求语义等价，但不是精确的 HTTP 正文。",
   "The session transcript is too large to rebuild on the server.": "会话转录过大，无法在服务器上重建。",
-  "The session transcript could not be rebuilt.": "无法重建会话转录。"
+  "The session transcript could not be rebuilt.": "无法重建会话转录。",
+  "Choose an account model or enter a custom model ID for this test only.": "选择账号模型，或输入仅用于本次测试的自定义模型 ID。",
+  "Enter a model ID": "输入模型 ID"
 }

--- a/apps/admin/src/locales/zh-hant.json
+++ b/apps/admin/src/locales/zh-hant.json
@@ -1066,5 +1066,7 @@
   "Rebuild the transcript in your browser instead of on the server.": "在瀏覽器中重建轉錄，而不是在伺服器上重建。",
   "Rebuilt from the session transcript in your browser — semantically equal to the original request, not the exact HTTP body.": "已在瀏覽器中從工作階段轉錄重建——與原始請求語意等價，但不是精確的 HTTP 內文。",
   "The session transcript is too large to rebuild on the server.": "工作階段轉錄過大，無法在伺服器上重建。",
-  "The session transcript could not be rebuilt.": "無法重建工作階段轉錄。"
+  "The session transcript could not be rebuilt.": "無法重建工作階段轉錄。",
+  "Choose an account model or enter a custom model ID for this test only.": "選擇帳號模型，或輸入僅用於本次測試的自訂模型 ID。",
+  "Enter a model ID": "輸入模型 ID"
 }

--- a/apps/admin/src/routes/providers/providers.test.ts
+++ b/apps/admin/src/routes/providers/providers.test.ts
@@ -1026,7 +1026,10 @@ describe('providers page', () => {
     const dialog = screen.getByRole('dialog', { name: /test connection/i });
     expect(within(dialog).getByText('acct-claude')).toBeInTheDocument();
     // The picker offers the row's effective models; the first is selected by default.
-    expect(within(dialog).getByRole('option', { name: 'claude-opus-4-6' })).toBeInTheDocument();
+    expect(within(dialog).getByRole('combobox', { name: /^model$/i })).toHaveValue(
+      'claude-opus-4-6',
+    );
+    expect(dialog.querySelector('option[value="claude-opus-4-6"]')).not.toBeNull();
     expect(within(dialog).getByRole('button', { name: /run test/i })).toBeInTheDocument();
   });
 
@@ -1063,19 +1066,11 @@ describe('providers page', () => {
       within(screen.getByTestId('provider-account-row')).getByRole('button', { name: /^test$/i }),
     );
     const dialog = screen.getByRole('dialog', { name: /test connection/i });
-    expect(within(dialog).getByRole('option', { name: 'grok-4.5' })).toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole('option', { name: 'grok-imagine-image' }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole('option', { name: 'grok-imagine-image-quality' }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole('option', { name: 'grok-imagine-video-1.5-preview' }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole('option', { name: 'grok-imagine-video' }),
-    ).not.toBeInTheDocument();
+    expect(dialog.querySelector('option[value="grok-4.5"]')).not.toBeNull();
+    expect(dialog.querySelector('option[value="grok-imagine-image"]')).toBeNull();
+    expect(dialog.querySelector('option[value="grok-imagine-image-quality"]')).toBeNull();
+    expect(dialog.querySelector('option[value="grok-imagine-video-1.5-preview"]')).toBeNull();
+    expect(dialog.querySelector('option[value="grok-imagine-video"]')).toBeNull();
   });
 
   it('streams the test reply through the gateway and reports success', async () => {
@@ -1108,6 +1103,30 @@ describe('providers page', () => {
     await fireEvent.click(within(dialog).getByRole('button', { name: /close/i }));
 
     expect(screen.queryByRole('dialog', { name: /test connection/i })).not.toBeInTheDocument();
+  });
+
+  it('tests a custom model id without adding it to the account allowlist', async () => {
+    streamAccountTest.mockImplementation(async function* () {
+      yield { type: 'done', durationMs: 100 };
+    });
+    renderPage();
+    await fireEvent.click(
+      within(screen.getByTestId('provider-account-row')).getByRole('button', { name: /^test$/i }),
+    );
+    const dialog = screen.getByRole('dialog', { name: /test connection/i });
+
+    await fireEvent.input(within(dialog).getByRole('combobox', { name: /^model$/i }), {
+      target: { value: 'gpt-6-astra' },
+    });
+    await fireEvent.click(within(dialog).getByRole('button', { name: /run test/i }));
+
+    await waitFor(() =>
+      expect(streamAccountTest).toHaveBeenCalledWith(
+        'anthropic',
+        { account: 'acct-claude', model: 'gpt-6-astra', prompt: undefined },
+        expect.any(AbortSignal),
+      ),
+    );
   });
 
   it('confirms and disconnects a stored account credential', async () => {


### PR DESCRIPTION
## Summary
- allow arbitrary model IDs in the Providers account test dialog
- keep existing account models as datalist suggestions
- trim and submit custom IDs for this test only without changing the account allowlist
- add localized labels and regression coverage

## Validation
- `CI=true pnpm exec vitest run apps/admin/src/routes/providers/providers.test.ts`
- `CI=true pnpm --filter @helm/admin check`
- `CI=true pnpm --filter @helm/shared build && CI=true pnpm --filter @helm/admin build`
- Playwright mocked UI flow: enter `gpt-6-astra`, run test, observe Success and submitted model
