### PR TITLE
chore(release): v0.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from v0.29.1 to v0.29.2
- release the Providers account-test custom model ID UI from #830

## Scope
Version-only release PR based on `origin/main` at `10dd29de32dacd501913e884ca6ad8d93daf030f`.
