### PR TITLE
chore(release): v0.29.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump Helm API from v0.29.2 to v0.29.3
- release custom manual subscription model IDs from #832

## Scope
Version-only release PR based on origin/main at 33703c499d68845f67867812706e4f8b0c584c75.
