### PR TITLE
chore(release): v0.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.29.4 for PR #834.

The publish workflow will build the immutable image and create the GitHub Release from the exact merged SHA.