### PR TITLE
Enforce subscription model auto/manual authority

### DIFF
--- a/apps/gateway/src/oauth/admin-oauth.ts
+++ b/apps/gateway/src/oauth/admin-oauth.ts
@@ -1054,8 +1054,7 @@ export function createOAuthAdmin(deps: OAuthAdminDeps): OAuthAdminAccess {
       // SUGGESTIONS to seed from.
       // In manual mode `enabled` is the operator's AUTHORITATIVE list (verbatim,
       // NOT intersected), so a custom id survives stale discovery. In auto mode it
-      // is the exact discovery projection; runtime composition separately retains
-      // its curated fail-open safety net.
+      // is the exact official discovery projection.
       const modelsMode = resolveAccountModelsMode(providerId, settings);
       const enabled = enabledAccountModels(providerId, settings, discovered);
       // `canPull` tells the UI whether account-scoped model refresh is meaningful.

--- a/apps/gateway/src/oauth/effective-models.test.ts
+++ b/apps/gateway/src/oauth/effective-models.test.ts
@@ -76,13 +76,8 @@ describe("effectiveAccountModels", () => {
     ).toEqual(["claude-future-9", "claude-opus-4-6"]);
   });
 
-  it("falls back to the provider's curated set when enabledModels is unset", () => {
-    expect(effectiveAccountModels({}, "anthropic")).toEqual([
-      "claude-opus-5",
-      "claude-fable-5-1",
-      "claude-sonnet-5",
-      "claude-haiku-4-5",
-    ]);
+  it("returns no models when auto discovery has no official snapshot", () => {
+    expect(effectiveAccountModels({}, "anthropic")).toEqual([]);
   });
 
   it("uses the durable auto-discovery snapshot after the process cache is lost", () => {
@@ -94,8 +89,8 @@ describe("effectiveAccountModels", () => {
     ).toEqual(["claude-fable-5", "claude-sonnet-4-7"]);
   });
 
-  it("offers the verified xAI catalog when a bound account stays in auto mode", () => {
-    expect(effectiveAccountModels({}, "xai")).toEqual(["grok-4.5", "grok-composer-2.5-fast"]);
+  it("returns no xAI models when auto discovery has no official snapshot", () => {
+    expect(effectiveAccountModels({}, "xai")).toEqual([]);
   });
 
   it("returns [] for an unknown provider with no curated set + no enabled list", () => {
@@ -156,16 +151,11 @@ describe("effectiveOAuthAliases", () => {
     ]);
   });
 
-  it("uses the curated fallback for a bound-but-never-curated account", async () => {
+  it("does not invent models for a bound account without an official snapshot", async () => {
     const { tokens, config } = makeStores();
     await bind(tokens, "anthropic", "default");
     const aliases = await effectiveOAuthAliases({ store: tokens, encKey: KEY }, config, ROUTABLE);
-    expect(aliases).toEqual([
-      "anthropic/claude-fable-5-1",
-      "anthropic/claude-haiku-4-5",
-      "anthropic/claude-opus-5",
-      "anthropic/claude-sonnet-5",
-    ]);
+    expect(aliases).toEqual([]);
   });
 
   it("excludes providers NOT in the routable set (e.g. before its executor is wired)", async () => {
@@ -225,7 +215,6 @@ describe("effectiveOAuthModelOptions", () => {
     ).resolves.toEqual([
       { alias: "openai-codex/gpt-5.6", accounts: ["default"] },
       { alias: "openai-codex/gpt-5.6-sol", accounts: ["default"] },
-      { alias: "openai-codex/gpt-image-2", accounts: ["default"] },
     ]);
   });
 
@@ -441,11 +430,10 @@ describe("effectiveOAuthModelOptions", () => {
       { alias: "openai-codex/codex-auto-review", accounts: ["default"] },
       { alias: "openai-codex/gpt-5.6", accounts: ["default"] },
       { alias: "openai-codex/gpt-5.6-sol", accounts: ["default"] },
-      { alias: "openai-codex/gpt-image-2", accounts: ["default"] },
     ]);
   });
 
-  it("keeps the image alias when an auto-mode Codex account has no catalog snapshot", async () => {
+  it("returns no models when an auto-mode Codex account has no official catalog snapshot", async () => {
     const { tokens, config } = makeStores();
     await bind(tokens, "openai-codex", "default", { accountId: "acc-default" });
 
@@ -453,7 +441,7 @@ describe("effectiveOAuthModelOptions", () => {
       effectiveOAuthModelOptions({ store: tokens, encKey: KEY }, config, ROUTABLE, {
         codexCatalog: codexCatalog({}),
       }),
-    ).resolves.toEqual([{ alias: "openai-codex/gpt-image-2", accounts: ["default"] }]);
+    ).resolves.toEqual([]);
   });
 
   it("keeps manual Codex ids routable without a catalog snapshot", async () => {

--- a/apps/gateway/src/oauth/effective-models.ts
+++ b/apps/gateway/src/oauth/effective-models.ts
@@ -1,11 +1,9 @@
 import type { OAuthTokenStore } from "@helm/core";
 import {
   type ConfigStore,
-  CURATED_OAUTH_MODELS,
   DEFAULT_OPENAI_CODEX_CLIENT_VERSION,
   decryptSecret,
   expandOpenAICodexModelAliases,
-  OPENAI_CODEX_IMAGE_MODEL,
   openAICodexIdentityFingerprint,
   parseOpenAICodexIdentity,
 } from "@helm/core";
@@ -38,19 +36,9 @@ export interface OAuthRuntimeCtxLike {
   encKey: Buffer;
 }
 
-// Network-free suggestions for a BOUND subscription account. xAI deliberately
-// stays out of core's CURATED_OAUTH_MODELS: runtime pool synthesis must continue
-// to fail closed when its live `/models` entitlement discovery has no result.
-// The picker fallback only repairs the Admin projection for the two models Helm
-// has already verified through the authenticated Grok CLI catalog.
-const ACCOUNT_MODEL_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
-  ...CURATED_OAUTH_MODELS,
-  xai: ["grok-4.5", "grok-composer-2.5-fast"],
-};
-
 // The effective enabled models for ONE account (no network): Manual uses the
 // saved `enabledModels` verbatim; Auto uses the durable discovery snapshot when
-// available, then the provider's curated fallback (else []).
+// available, else [] when no official list has been obtained.
 export function effectiveAccountModels(
   settings: Pick<AccountSettings, "modelsMode" | "enabledModels" | "discoveredModels">,
   providerId: string,
@@ -61,12 +49,11 @@ export function effectiveAccountModels(
   if (providerId === "openai-codex") return [];
   return settings.discoveredModels && settings.discoveredModels.length > 0
     ? [...settings.discoveredModels]
-    : [...(ACCOUNT_MODEL_FALLBACKS[providerId] ?? [])];
+    : [];
 }
 
 // Every routable `${providerId}/${model}` alias across all bound accounts, deduped
-// and sorted. Fail-open: a missing/corrupt settings blob yields the curated
-// fallback (loadAccountSettings already swallows decrypt errors to {}).
+// and sorted. A missing/corrupt settings blob yields no automatic models.
 
 // One routable model alias + which subscription account(s) currently expose it.
 // `accounts` lets the Lanes picker show, under each model, the bound account(s)
@@ -136,10 +123,9 @@ async function automaticCodexModels(
       clientVersion: options.codexClientVersion ?? DEFAULT_OPENAI_CODEX_CLIENT_VERSION,
     };
     const snapshot = options.codexCatalog.snapshot(key);
-    if (!snapshot) return [OPENAI_CODEX_IMAGE_MODEL];
+    if (!snapshot) return [];
     const models = [...snapshot.models].sort((left, right) => left.priority - right.priority);
     const aliases = expandOpenAICodexModelAliases(models.map((model) => model.slug));
-    if (!aliases.includes(OPENAI_CODEX_IMAGE_MODEL)) aliases.push(OPENAI_CODEX_IMAGE_MODEL);
     return aliases;
   } catch {
     return undefined;
@@ -183,9 +169,8 @@ export async function effectiveOAuthModelOptions(
               account: row.account,
             })
           : undefined;
-      // Auto follows the exact account catalog when a successful discovery has
-      // populated the shared cache. A missing/negative snapshot keeps the existing
-      // curated fail-open projection; Manual remains the operator's saved list.
+      // Auto follows only the official account catalog (live cache or durable
+      // last-known-good snapshot); Manual remains the operator's saved list.
       models =
         discovered && discovered.length > 0
           ? discovered

--- a/apps/gateway/src/server.oauth.test.ts
+++ b/apps/gateway/src/server.oauth.test.ts
@@ -974,7 +974,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     });
     await setAccountSettings(config, ENC_KEY, "xai", "text-only", {
       modelsMode: "manual",
-      enabledModels: ["grok-4.5"],
+      enabledModels: ["grok-4.5", "grok-custom-9"],
     });
     const mediaAuth: string[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
@@ -1010,6 +1010,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect((enabled.providers[0]?.models ?? []).map((model) => model.alias)).toEqual([
       "xai/grok-imagine-image-quality",
       "xai/grok-4.5",
+      "xai/grok-custom-9",
     ]);
     await enabled.poolClients
       .get("xai")
@@ -1756,7 +1757,7 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
         { catalog, runInBackground },
       );
       const aliases = (result.providers[0]?.models ?? []).map((model) => model.alias);
-      expect(aliases).toContain("openai-codex/gpt-image-2");
+      expect(aliases).not.toContain("openai-codex/gpt-image-2");
     }
   });
 
@@ -2007,7 +2008,6 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       "openai-codex/gpt-5.6-sol",
       "openai-codex/codex-auto-review",
       "openai-codex/gpt-5.6",
-      "openai-codex/gpt-image-2",
     ]);
     await poolClients.get("openai-codex")?.chatCompletion({
       model: "gpt-5.6-sol",
@@ -2476,10 +2476,8 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
       { catalog, runInBackground },
     );
 
-    expect((result.providers[0]?.models ?? []).map((model) => model.alias)).toEqual([
-      "openai-codex/gpt-image-2",
-    ]);
-    expect(result.poolClients.get("openai-codex")?.hasAvailableModel("gpt-image-2")).toBe(true);
+    expect((result.providers[0]?.models ?? []).map((model) => model.alias)).toEqual([]);
+    expect(result.poolClients.get("openai-codex")?.hasAvailableModel("gpt-image-2")).toBeFalsy();
   });
 
   it("refreshes once and retries /models after a 401 without changing account identity", async () => {
@@ -2563,7 +2561,6 @@ describe("synthesizeOAuthProviders (Stage 3 account pool)", () => {
     expect((result.providers[0]?.models ?? []).map((model) => model.alias)).toEqual([
       "openai-codex/gpt-5.6-sol",
       "openai-codex/gpt-5.6",
-      "openai-codex/gpt-image-2",
     ]);
   });
 

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -13,7 +13,6 @@ import {
   type CodexResponsesWebSocketConnector,
   type ConfigStore,
   type CreateKeyInput,
-  CURATED_OAUTH_MODELS,
   checkTlsTransportAvailable,
   codexActiveLimitIdFromProviderRaw,
   createAnthropicClient,
@@ -83,7 +82,6 @@ import {
   type OAuthTokenStore,
   type ObserveDeps,
   type ObserverDeps,
-  OPENAI_CODEX_IMAGE_MODEL,
   type OpenAICodexIdentity,
   OpenAICodexModelsError,
   type OpenAICodexModelsResult,
@@ -925,8 +923,8 @@ function buildOAuthAccountClient(
 // account gets its own per-account client (token manager + egress proxy + executor
 // type); the pool selects one per request by priority (asc) then LRU round-robin
 // (Stage 3). The synthetic provider config exposes the UNION of the accounts'
-// enabled models to Lanes. Discovery is live where possible (Copilot /models),
-// else curated. Fail-open (principle 3): a dead credential / empty model list skips
+// enabled models to Lanes. Discovery uses the provider's official catalog (live
+// or last-known-good). Fail-open (principle 3): a dead credential / empty model list skips
 // THAT account (logged); a provider with no live account is skipped entirely;
 // startup is never blocked.
 export async function synthesizeOAuthProviders(
@@ -1090,8 +1088,26 @@ export async function synthesizeOAuthProviders(
           log("warn", "oauth.models.snapshot_write_failed", { providerId, account });
         }
         const routable = catalog.filter(isRoutableXaiOAuthModel);
+        const mediaModels = new Set<string>(GROK_OAUTH_MEDIA_MODELS);
         const enabled = modelsMode === "manual" ? new Set(s.enabledModels ?? []) : undefined;
-        const selected = enabled ? routable.filter((model) => enabled.has(model.id)) : routable;
+        const selected =
+          modelsMode === "manual"
+            ? [...new Set(s.enabledModels ?? [])]
+                .filter((id) => !mediaModels.has(id))
+                .map(
+                  (id) =>
+                    routable.find((model) => model.id === id) ?? {
+                      id,
+                      model: id,
+                      apiBackend: "responses" as const,
+                      contextWindow: 256_000,
+                      hidden: false,
+                      supportedInApi: true,
+                      supportsReasoningEffort: false,
+                      reasoningEfforts: [],
+                    },
+                )
+            : routable;
         const entitlementValidUntil = xaiGrokMediaEntitlementValidUntil(
           quotaSeed,
           Date.now(),
@@ -1137,8 +1153,6 @@ export async function synthesizeOAuthProviders(
           ? [...loaded.snapshot.models].sort((left, right) => left.priority - right.priority)
           : [];
         discovered = expandOpenAICodexModelAliases(catalogModels.map((model) => model.slug));
-        if (!discovered.includes(OPENAI_CODEX_IMAGE_MODEL))
-          discovered.push(OPENAI_CODEX_IMAGE_MODEL);
         if (loaded) codexKeys.push(loaded.key);
         accountCodexRuntime = loaded?.runtime;
       } else {
@@ -1165,7 +1179,7 @@ export async function synthesizeOAuthProviders(
         ) {
           log("warn", "oauth.models.snapshot_write_failed", { providerId, account });
         }
-        discovered = exact.length > 0 ? exact : (CURATED_OAUTH_MODELS[providerId] ?? []);
+        discovered = exact;
       }
       // Auto follows the authenticated account catalog. Manual is authoritative,
       // including custom ids that a newly released upstream catalog does not report yet.

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-09-06 · 订阅模型自动/手动列表统一按官方目录与数据库权威（OAuth provider / routing / Admin，docs/04/11，原则 2/3/6）
+
+- Automatic mode now exposes only the provider's live or durable last-known-good official discovery; curated guesses and forced Codex image aliases are no longer injected when discovery is empty.
+- Manual mode remains the exact saved `enabledModels` list across Admin, Lanes, OpenAI-compatible `/v1/models`, native Codex listings, and runtime pools. xAI custom manual IDs use an identity wire mapping when absent from the structured catalog; the provider remains the final capability authority.
+- No schema, migration, configuration, or dependency changes.
+
 ## 2026-09-06 · Codex 原生模型列表保留手动自定义 ID（OAuth provider / Codex discovery，docs/04/05，原则 3/6）
 
 - 原生 `GET /v1/models?client_version=...` 已把手动账号模型作为权威输入；当 ID 尚未出现在上游目录时，使用该账号目录中最低 priority 模型的兼容元数据生成条目，并将 `slug`/`display_name` 改为手动 ID。自动模式仍只输出上游发现项。


### PR DESCRIPTION
## Summary\n- automatic subscription model lists use only live or durable official discovery\n- manual lists use the exact saved enabledModels across Admin, Lanes, standard/native model APIs, and runtime pools\n- preserve custom xAI manual IDs with identity wire mapping and remove forced Codex image/curated fallbacks\n\n## Verification\n- CI=true pnpm exec vitest run apps/gateway/src/oauth/effective-models.test.ts apps/gateway/src/server.oauth.test.ts\n- pnpm typecheck\n- pnpm lint\n- pnpm build