### PR TITLE
chore: release v0.29.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.6",
+  "version": "0.29.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bump the root package version to 0.29.7 to release #840: safe retry of explicit Responses overloads after empty preamble events, with a shared two-retry budget and preserved replay protections.

Version-only change, based on merged fix 4add826a149b70a7fd3411e2e952be49bb87ea54. The fix passed 621 focused tests and full PR CI (the unrelated real-Postgres queue-load e2e passed on rerun). Version parsing and diff checks pass; full CI must pass before merging. After exact-SHA publishing, deploy the immutable digest to Remote and verify version, health and packaged runtime recovery.
