### PR TITLE
fix: record upstream Responses stream error events

### DIFF
--- a/apps/gateway/src/routes/responses.ts
+++ b/apps/gateway/src/routes/responses.ts
@@ -467,7 +467,7 @@ function responsesFrameErrorDetail(eventName: string, data: string): AttemptErro
   if (eventName !== "error" && eventName !== "response.failed") return null;
   const classifier = preOutputClassifierFor("openai_responses");
   if (classifier === null) return null;
-  return errorDetailOf(streamErrorFromData(classifier, data));
+  return { ...errorDetailOf(streamErrorFromData(classifier, data)), upstream_event: eventName };
 }
 
 export function settleResponsesStreamOutcome(args: {

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-09-06 · 记录 Responses 流内上游错误事件（docs/07，原则 8）
+
+- Decision error detail now records `upstream_event` (`error` or `response.failed`) for in-band SSE failures. HTTP status remains nullable because the upstream may return the error after opening an HTTP 200 stream.
+- This is additive and preserves the raw provider payload; it makes Codex overload failures distinguishable from Helm-generated admission errors in Admin telemetry.
+
+
 ## 2026-09-06 · Responses 空准备事件保留安全恢复窗口（Provider execution / Responses，docs/04/05，原则 3/5/8）
 
 - 空 message/reasoning item、空文本/思考摘要 part 和空 delta 继续缓冲；只有真实内容才提交流，使随后明确的过载错误可以进入既有 OAuth sibling retry 与模型 fallback。正常响应仍逐字节回放原始事件。

--- a/packages/shared/src/decision/schema.ts
+++ b/packages/shared/src/decision/schema.ts
@@ -87,6 +87,9 @@ export const AttemptErrorDetailSchema = z.object({
   provider_headers: z.record(z.string(), z.string()).nullable().optional(),
   cause: z.unknown().nullable().optional(),
   stack: z.string().nullable().optional(),
+  // For in-band SSE failures, identify the provider event that carried the error.
+  // HTTP status can be null when the response stream was already open.
+  upstream_event: z.string().nullable().optional(),
 });
 
 export const ProviderAttemptSchema = z.object({


### PR DESCRIPTION
## Problem
In-band Responses SSE failures such as Codex `server_is_overloaded` were recorded without identifying which upstream event carried the error. The Admin view showed a null HTTP status, making upstream stream errors harder to distinguish from gateway-generated failures.

## Change
Record the upstream SSE event name (`error` or `response.failed`) in `AttemptErrorDetail.upstream_event`, while preserving the raw provider payload and nullable HTTP status semantics.

## Validation
- `pnpm --filter @helm/gateway exec tsc --noEmit`
