### PR TITLE
chore(release): v0.29.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.7",
+  "version": "0.29.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- bump package version to 0.29.8
- release the merged GPT-6 Astra/config sync and Responses telemetry fix

## Verification
- version-only diff from exact current main