### PR TITLE
fix(config): price GPT-6 Astra Codex alias

### DIFF
--- a/config/capabilities.yaml
+++ b/config/capabilities.yaml
@@ -148,6 +148,17 @@ xai/grok-imagine-video:
 # GPT-5.6 fallback metadata mirrors the bundled Codex model catalog. At runtime the
 # authenticated `/models` response is authoritative per account; these entries are
 # only the last-resort fallback when no fresh or last-known-good remote catalog exists.
+openai-codex/gpt-6-astra:
+  supportsTools: true
+  jsonOutput: schema
+  supportsVision: true
+  supportsStreaming: true
+  reasoningEffort:
+    openaiReasoning:
+      supported: true
+      levels: [low, medium, high, xhigh, max]
+  maxContextTokens: 1050000
+  maxOutputTokens: 128000
 openai-codex/gpt-5.6:
   supportsTools: true
   jsonOutput: schema

--- a/config/pricing.yaml
+++ b/config/pricing.yaml
@@ -61,6 +61,42 @@ openai-codex/codex-auto-review:
   outputPerMTokUsd: null
   cacheReadPerMTokUsd: null
   cacheWritePerMTokUsd: null
+# ChatGPT/Codex subscription requests use the official API-equivalent GPT-6
+# Astra rate card for telemetry and historical cost reconstruction.
+openai-codex/gpt-6-astra:
+  inputPerMTokUsd: 10.0
+  outputPerMTokUsd: 50.0
+  cacheReadPerMTokUsd: 1.0
+  cacheWritePerMTokUsd: 12.5
+  contextTiers:
+    - minPromptTokens: 272001
+      inputPerMTokUsd: 20.0
+      outputPerMTokUsd: 75.0
+      cacheReadPerMTokUsd: 2.0
+      cacheWritePerMTokUsd: 25.0
+  serviceTiers:
+    flex:
+      inputPerMTokUsd: 5.0
+      outputPerMTokUsd: 25.0
+      cacheReadPerMTokUsd: 0.5
+      cacheWritePerMTokUsd: 6.25
+      contextTiers:
+        - minPromptTokens: 272001
+          inputPerMTokUsd: 10.0
+          outputPerMTokUsd: 37.5
+          cacheReadPerMTokUsd: 1.0
+          cacheWritePerMTokUsd: 12.5
+    priority:
+      inputPerMTokUsd: 20.0
+      outputPerMTokUsd: 100.0
+      cacheReadPerMTokUsd: 2.0
+      cacheWritePerMTokUsd: 25.0
+      contextTiers:
+        - minPromptTokens: 272001
+          inputPerMTokUsd: 40.0
+          outputPerMTokUsd: 150.0
+          cacheReadPerMTokUsd: 4.0
+          cacheWritePerMTokUsd: 50.0
 openai-codex/gpt-5.6:
   inputPerMTokUsd: 5.0
   outputPerMTokUsd: 30.0

--- a/packages/core/src/catalog/load.test.ts
+++ b/packages/core/src/catalog/load.test.ts
@@ -278,6 +278,30 @@ describe("loadRuntimeCatalog", () => {
     });
     expect(catalog.get("deepseek/deepseek-v4-pro")?.pricing.cacheReadPerMTokUsd).toBe(0.003625);
     expect(catalog.get("openai-codex/gpt-5.4-mini")?.pricing.cacheReadPerMTokUsd).toBe(0.075);
+    const gpt6 = catalog.get("openai-codex/gpt-6-astra");
+    expect(gpt6).toMatchObject({
+      capabilities: {
+        supportsTools: true,
+        jsonOutput: "schema",
+        supportsVision: true,
+        supportsStreaming: true,
+      },
+      pricing: {
+        inputPerMTokUsd: 10,
+        outputPerMTokUsd: 50,
+        cacheReadPerMTokUsd: 1,
+        cacheWritePerMTokUsd: 12.5,
+      },
+    });
+    expect(
+      resolveCostUsd(gpt6?.pricing, {
+        usage: {
+          input_tokens: 1_000,
+          output_tokens: 50,
+          input_tokens_details: { cached_tokens: 200 },
+        },
+      }),
+    ).toBeCloseTo((800 * 10 + 200 * 1 + 50 * 50) / 1_000_000, 12);
     expect(catalog.get("openai-codex/gpt-image-2")).toMatchObject({
       capabilities: { outputImage: true },
       pricing: { inputPerMTokUsd: null, outputPerMTokUsd: null },


### PR DESCRIPTION
## Summary
- add GPT-6 Astra capabilities and official API-equivalent pricing under the served openai-codex alias
- keep the gpt-6-astra lane mapped to openai-codex/gpt-6-astra
- add a shipped-config regression test covering capability lookup and cost calculation

## Official pricing
OpenAI pricing checked 2026-09-06: short-context input/cached/cache-write/output = USD 10/1/12.50/50 per 1M tokens; long-context = USD 20/2/25/75.

## Verification
- CI=true pnpm exec vitest run packages/core/src/catalog/load.test.ts packages/core/src/store/sqlite/historical-cost-reprice.test.ts packages/core/src/config/rules-routing.test.ts (36 passed)
- pnpm --filter @helm/core typecheck
- pnpm exec biome check packages/core/src/catalog/load.test.ts
- git diff --check