### PR TITLE
test(e2e): isolate foreground upstream capture

### DIFF
--- a/apps/gateway/e2e/fixtures/mock-upstream.ts
+++ b/apps/gateway/e2e/fixtures/mock-upstream.ts
@@ -399,8 +399,12 @@ export function createMockUpstream() {
       });
     }
 
+    // Background memory calls can race the foreground request after its response.
+    // They are internal work, so keep them from replacing the main-request capture.
+    if (promptText.includes("<memory_")) return c.json(echoResponse(model));
+
     // Record the normalized request so the e2e can assert nativeIn → IR → nativeOut.
-    // (eval calls are excluded — capture tracks the MAIN routed request only.)
+    // (internal eval/memory calls are excluded — capture tracks the MAIN routed request only.)
     lastCapture = {
       body: body as UpstreamCapture["body"],
       count: lastCapture.count + 1,


### PR DESCRIPTION
## Root cause
The background memory worker could overwrite the mock upstream last-request capture after a foreground request completed. The fail-open memory assertion then read the internal compaction prompt instead of its own request.

## Fix
Exclude internal memory LLM calls from the foreground request capture, matching the existing exclusion for classifier eval calls. Runtime behavior is unchanged.

## Verification
- CI=true pnpm --filter @helm/gateway exec playwright test e2e/memory.spec.ts --repeat-each=3 (12 passed)
- pnpm exec biome check apps/gateway/e2e/fixtures/mock-upstream.ts
- git diff --check