### PR TITLE
chore: release v0.29.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.8",
+  "version": "0.29.9",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.29.9 includes GPT-6 Astra pricing/capability routing and the memory e2e race fix already merged to main.

This PR only bumps the package version.