### PR TITLE
ci: remove temporary PR trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   # Keep the workflow definition under default-branch control. The test jobs
   # explicitly check out the PR merge ref below, on disposable hosted runners.
-  "pull_request":
   pull_request_target:
   push:
     branches: [main]
@@ -114,7 +113,7 @@ jobs:
   # preconfigured self-hosted pool.
   e2e:
     timeout-minutes: 10
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request_target' || github.event_name == 'pull_request') && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","docker"]') }}
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request_target' && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","docker"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -228,7 +227,7 @@ jobs:
   # separate default-branch-controlled job never checks out or executes PR code;
   # it is the only job allowed to publish stable required checks on the PR head.
   report_pr_checks:
-    if: always() && github.event_name == 'pull_request_target' || (always() && github.event_name == 'pull_request')
+    if: always() && github.event_name == 'pull_request_target'
     needs: [verify, store, e2e, docker]
     runs-on: ubuntu-24.04
     permissions:
@@ -304,7 +303,7 @@ jobs:
           [[ "${E2E_RESULT}" == "success" ]] || { echo "::error::e2e: ${E2E_RESULT}"; exit 1; }
           [[ "${DOCKER_RESULT}" == "success" ]] || { echo "::error::docker: ${DOCKER_RESULT}"; exit 1; }
 
-          if [[ "${EVENT_NAME}" == "pull_request_target" || "${EVENT_NAME}" == "pull_request" ]]; then
+          if [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
             [[ "${REPORT_RESULT}" == "success" ]] || { echo "::error::report_pr_checks: ${REPORT_RESULT}"; exit 1; }
           else
             [[ "${REPORT_RESULT}" == "skipped" ]] || { echo "::error::unexpected report_pr_checks result: ${REPORT_RESULT}"; exit 1; }


### PR DESCRIPTION
Remove the temporary pull_request trigger used only to recover required checks while main workflow parsing was broken. Keep pull_request_target, and retain the per-run Playwright browser directory fix.