### PR TITLE
fix(codex): preserve Lite identities and recover control-only overloads

### DIFF
--- a/apps/gateway/src/routes/execute.test.ts
+++ b/apps/gateway/src/routes/execute.test.ts
@@ -6017,6 +6017,79 @@ describe("createExecute — native protocol passthrough (#217)", () => {
     expect((forwarded.mutations as Record<string, unknown>).body_shims_applied).toBeUndefined();
   });
 
+  it("preserves Lite identities and falls back after a Codex control-only overload", async () => {
+    const nativeStream = vi.fn(async function* (input: NativePassthroughCarrier) {
+      yield 'data: {"type":"response.metadata","headers":{"x-codex-turn-state":"opaque-state"}}\n\n';
+      yield input.body.model === "gpt-first"
+        ? 'data: {"type":"error","error":{"code":"server_is_overloaded","message":"busy"}}\n\n'
+        : 'data: {"type":"response.output_text.delta","delta":"ok"}\n\n';
+    });
+    const provider = {
+      nativeProtocolProfile: "codex_responses",
+      chatCompletion: vi.fn(),
+      chatCompletionStream: vi.fn(),
+      nativePassthroughStream: nativeStream,
+    } as unknown as ProviderClient;
+    const execute = createExecute({
+      defaultProvider: provider,
+      providers: new Map([["codex", provider]]),
+      registry: protocolRegistry({
+        first: {
+          providerName: "codex",
+          providerModel: "gpt-first",
+          targetProviderProtocol: "openai_responses",
+        },
+        second: {
+          providerName: "codex",
+          providerModel: "gpt-second",
+          targetProviderProtocol: "openai_responses",
+        },
+      }),
+      breaker: breaker(),
+      catalog: new Map(),
+      now: clock(),
+      signal: new AbortController().signal,
+      nativeProtocolPassthroughEnabled: () => true,
+    });
+    const input = [
+      { type: "additional_tools", id: "at_stable", role: "developer", tools: [] },
+      {
+        type: "message",
+        id: "msg_stable",
+        role: "user",
+        content: [{ type: "input_text", text: "hello" }],
+      },
+    ];
+    const carrier = createNativePassthroughCarrier({
+      protocol: "openai_responses",
+      body: {
+        model: "auto",
+        stream: true,
+        store: false,
+        reasoning: { context: "all_turns" },
+        input,
+      },
+      headers: {},
+    });
+    const out = await execute(
+      plan(["first", "second"]),
+      req({
+        protocol: "openai_responses",
+        stream: true,
+        native_request: carrier,
+      }),
+    );
+    expect(out.final).toMatchObject({ status: "ok", alias: "second" });
+    expect(out.attempts.map((attempt) => attempt.status)).toEqual(["error", "ok"]);
+    expect(nativeStream.mock.calls.map(([sent]) => sent.body.input)).toEqual([input, input]);
+    const chunks: string[] = [];
+    if (out.stream) for await (const chunk of out.stream) chunks.push(chunk);
+    expect(chunks.join("")).toBe(
+      'data: {"type":"response.metadata","headers":{"x-codex-turn-state":"opaque-state"}}\n\n' +
+        'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
+    );
+  });
+
   it("sanitizes Codex passthrough bodies that came from stored Responses output items", async () => {
     const responsesBody = {
       id: "resp_sanitized",

--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -7,6 +7,12 @@
 
 ---
 
+## 2026-09-06 · 对齐 Codex Lite 身份与流式控制事件（Provider / Responses，docs/04/05/07，原则 3/5/8）
+
+- 对照 Codex `008bbd5884122dc95aaece19ecfe0fc6a59dcf36`：Lite 完整请求和增量续接保留带前缀的输入项 ID；Helm 旧 `store:false` 清理会删除它们。现用已有 Lite 识别逻辑排除旧清理，保留原生历史；普通 Responses 的兼容清理不变。
+- `response.metadata`、`codex.response.metadata`、`codex.rate_limits` 和 `responsesapi.websocket_timing` 属于控制信息。它们不再提前提交执行尝试；正常响应逐字节保留，输出前明确过载沿既有有界策略恢复。真实输出、工具调用、加密 reasoning、未知事件及结果不明断连的禁止重放边界不变。
+- 两条生产失败请求确实分别丢失 157/239 个 ID；控制事件导致错误直接下传已由本地网关与账号池回归用例复现，但生产未保留这些失败的完整 SSE，因此不能把两项差异直接认定为全部线上故障的唯一原因。补丁尚未部署，真实会话恢复仍须单独验证。
+
 ## 2026-09-06 · Remote 配置同步后的目录与 e2e 一致性（Config sync，docs/04/05，原则 2/3/6）
 
 - Remote 的通用 lane 以 `gpt-5.6-*` 子 lane 为主候选，并移除了官方 DeepSeek 直连候选；e2e 断言同步为实际的 lane 名与 OpenRouter fallback，未改运行时代码。
@@ -53,27 +59,10 @@
 - Manual 模式以运维方保存的 `enabledModels` 为权威，Codex 模型即使尚未出现在账号目录中，也会在 Admin 回读、Lanes 目录和运行时账号池中保留；Automatic 模式仍只跟随上游发现。
 - 自定义 ID 只表示“允许尝试”，不伪造账号 entitlement 或模型能力；账号实际不支持时由上游正常拒绝。没有新增 schema、migration、配置或依赖。
 
-## 2026-09-05 · GPT-6 Astra 官方 API 目录与价格（Provider catalog / routing / cost telemetry，docs/04/05/07，原则 2/3/5/6）
-
-- OpenAI 官方开发者文档现将 `gpt-6-astra` 列为 API 模型：文本+图片输入、文本输出、1,050,000 context、922,000 max input、128,000 max output，支持 reasoning（`low`–`max`，不支持 `none`）、streaming、tools、structured outputs、file/web search 与 prompt caching。
-- 官方标准价格为 input `$10`、cached input `$1`、cache writes `$12.50`、output `$50`/1M tokens；超过 272K 输入时为 `$20`/`$2`/`$25`/`$75`。Helm 将这些值加入 `openai/gpt-6-astra` 的手工 capability/pricing 覆盖，并保留 GPT-5.6 兼容别名与订阅 lane 不变。
-- GPT-6 Astra 不支持 `temperature`、`top_p`、`logprobs`，且不支持 `none` reasoning effort；现有 OpenAI reasoning-model 的 `max_completion_tokens` shim 扩展到该模型。Fast mode 在 EU data residency 下不可用；未新增服务层自动降级。
-
-## 2026-09-05 · Claude Fable 5.1 官方目录与价格（Provider catalog / routing / cost telemetry，docs/04/05/07，原则 2/3/5/6）
-
-- Anthropic 官方模型页现将 `claude-fable-5-1` 列为 Fable 最新 API ID：1M context、128K output、text+image、adaptive thinking（always on，默认 `high`）、tools/computer use/PDF 与 structured output。
-- 官方基础价格为 input `$10`、output `$50`、cache read `$0.25`、5-minute cache write `$12.50`、1-hour cache write `$20`/1M tokens。Helm 的 `claude-fable` lane 先走 5.1，保留 Fable 5 作为订阅兼容回退。
-
-## 2026-09-02 · Codex Responses HTTP 只重放明确拒绝的请求（Responses / provider execution，docs/04/05/07，原则 3/5/8）
-
-- Codex HTTP POST 在 `fetch()` 抛出连接错误或首字节超时后无法证明上游未接收请求；这类结果现在单次终止为 `response_create_outcome_unknown`，记录 `after_send_before_response`，不再由 fetch 层、OAuth sibling 或候选链重放。外部客户端取消保持原分类。
-- HTTP 200 后在终态前发生 EOF、读超时/异常、本地 response-work 拒绝、空 body 或缺少 SSE 结尾分隔符，都属于上游可能已接收但结果不明，记录 `after_response_before_terminal`（已解析 preamble 的外层 guard 记录 `after_response_created_before_output`）并停止 sibling/provider fallback；即使缺少末尾空行且随后读失败，完整可解析的 `response.failed` / `error` 仍作为明确拒绝保留，可在无真实输出时 fallback。
-- 明确拒绝仍保留既有安全恢复：401 刷新后一次重发、503/529 最多三次总尝试、WebSocket 握手及可证明发送前关闭总计三次尝试。无 schema、migration、配置或依赖变化。
-
 ## 历史条目摘要（最新要点）
 
-- **2026-09-01 · Codex 超大完整历史发送前保护**：无续接 ID 的 Codex WebSocket 历史超过 32 MiB 时，先限额缩图、仍超限再同账号 compact；仅采用更小结果，失败沿既有安全边界降级。完整记录见 Git 历史。
+- **2026-09-05 · GPT-6 Astra 官方 API 目录与价格**：官方 API capability/pricing 与 reasoning 参数兼容已加入 override，订阅 lane 保留；定价和限制按对应提交回溯。
 
 ## 更早历史总览
 
-2026-08-30 及更早工作涵盖订阅图片/视频/TTS 的 entitlement、单写与价格边界，Responses HTTP/WebSocket 生命周期、发送前恢复证明、账号与 transport 亲和、超大历史与压缩，OAuth 模型发现、额度窗口、Retry-After、冷却、轮转和缓存，协议互译与 SSE/tool-call 保真、能力/价格目录、路由/分类/fallback/熔断，Memory observe/inject/反思/压缩/保留与并发治理，payload/session 分段持久化、失败记录、SQLite/Postgres 数据完整性与资源保护，Admin/Portal/i18n/可访问性、key 权限/预算/计量，以及构建、CI、Docker、发布和生产验收。具体默认值、兼容限制与历史实测均以对应提交为准；本次压缩前的完整条目可从基线 412c7cde02288d9b33d54a87f93b43925177b294 的本文件及 Git 历史回溯。
+2026-09-05 Fable 5.1 目录/价格、2026-09-02 HTTP 结果不明禁止重放（保留明确拒绝的有界重试）、2026-09-01 超大历史发送前保护已并入历史；完整内容见基线 `8a7df80c6684b10bfa7ff7f4f07f237a92f95d58`。2026-08-30 及更早工作涵盖订阅图片/视频/TTS 的 entitlement、单写与价格边界，Responses HTTP/WebSocket 生命周期、发送前恢复证明、账号与 transport 亲和、超大历史与压缩，OAuth 模型发现、额度窗口、Retry-After、冷却、轮转和缓存，协议互译与 SSE/tool-call 保真、能力/价格目录、路由/分类/fallback/熔断，Memory observe/inject/反思/压缩/保留与并发治理，payload/session 分段持久化、失败记录、SQLite/Postgres 数据完整性与资源保护，Admin/Portal/i18n/可访问性、key 权限/预算/计量，以及构建、CI、Docker、发布和生产验收。具体默认值、兼容限制与历史实测均以对应提交为准；本次压缩前的完整条目可从基线 412c7cde02288d9b33d54a87f93b43925177b294 的本文件及 Git 历史回溯。

--- a/packages/core/src/provider/failover-guard.test.ts
+++ b/packages/core/src/provider/failover-guard.test.ts
@@ -30,6 +30,28 @@ const chat = preOutputClassifierFor("openai_chat");
 if (!responses || !anthropic || !chat) throw new Error("classifier missing");
 
 describe("guardPreOutputFailure — openai_responses", () => {
+  it.each([
+    { type: "response.metadata", headers: { "x-codex-turn-state": "opaque-state" } },
+    { type: "response.metadata", metadata: { type: "safety_buffering", retry_model: "gpt-test" } },
+    { type: "codex.response.metadata", metadata: {} },
+    { type: "responsesapi.websocket_timing", duration_ms: 1 },
+    { type: "codex.rate_limits", rate_limits: { allowed: true, limit_reached: false } },
+  ])("keeps Codex control event $type before output eligible for recovery", async (event) => {
+    const forwarded: string[] = [];
+    const frames = [
+      { type: "response.created", response: { id: "resp_test" } },
+      event,
+      { type: "error", error: { code: "server_is_overloaded", message: "busy" } },
+    ].map((value) => `data: ${JSON.stringify(value)}\n\n`);
+    await expect(
+      (async () => {
+        for await (const chunk of guardPreOutputFailure(fromChunks(frames), responses))
+          forwarded.push(chunk);
+      })(),
+    ).rejects.toMatchObject({ providerRaw: { error: { code: "server_is_overloaded" } } });
+    expect(forwarded).toEqual([]);
+  });
+
   it("does not replay an accepted Responses request when its pre-output buffer overflows", async () => {
     const chunk = `event: response.created\ndata: {"type":"response.created"}\n\n${"x".repeat(
       Math.floor(MAX_PRE_OUTPUT_BUFFER_BYTES / 2),

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -132,6 +132,15 @@ const responsesClassifier: PreOutputClassifier = {
     if (!obj) return "output";
     const t = obj.type;
     if (t === "response.created" || t === "response.in_progress") return "preamble";
+    // Codex consumes these as routing/safety/timing metadata, not generated output.
+    // Preserve their bytes for the successful attempt without committing a failed one.
+    if (
+      t === "response.metadata" ||
+      t === "codex.response.metadata" ||
+      t === "codex.rate_limits" ||
+      t === "responsesapi.websocket_timing"
+    )
+      return "preamble";
     if (t === "error" || t === "response.failed") return "error";
     if (t === "response.output_item.added" || t === "response.output_item.done") {
       const item = asRecord(obj.item);

--- a/packages/core/src/provider/openai-responses.test.ts
+++ b/packages/core/src/provider/openai-responses.test.ts
@@ -6678,6 +6678,44 @@ describe("hoistResponsesInstructions", () => {
 });
 
 describe("sanitizeCodexResponsesNativeBody", () => {
+  it.each([
+    false,
+    true,
+  ])("preserves Responses Lite item identity (continuation=%s)", (continuation) => {
+    // Codex client.rs preserves prefixed ResponseItemId values on full and delta requests.
+    const input = [
+      ...(!continuation
+        ? [{ type: "additional_tools", id: "at_stable", role: "developer", tools: [] }]
+        : []),
+      {
+        type: "message",
+        id: "msg_stable",
+        role: "user",
+        content: [{ type: "input_text", text: "next" }],
+      },
+      { type: "reasoning", id: "rs_stable", summary: [], encrypted_content: "opaque" },
+      {
+        type: "custom_tool_call",
+        id: "ctc_stable",
+        call_id: "call_stable",
+        name: "test",
+        input: "{}",
+      },
+      { type: "custom_tool_call_output", id: "ctco_stable", call_id: "call_stable", output: "ok" },
+    ];
+    const original = {
+      model: "gpt-6-astra",
+      store: false,
+      stream: true,
+      reasoning: { effort: "high", context: "all_turns" },
+      ...(continuation ? { previous_response_id: "resp_previous" } : {}),
+      input,
+    };
+    const snapshot = structuredClone(original);
+    expect(sanitizeCodexResponsesNativeBody(original)).toEqual({ body: snapshot, fixes: [] });
+    expect(original).toEqual(snapshot);
+  });
+
   it("removes Codex-unsupported caps and store:false persisted item references", () => {
     const { body, fixes } = sanitizeCodexResponsesNativeBody({
       model: "gpt-5.5",

--- a/packages/core/src/provider/openai-responses.ts
+++ b/packages/core/src/provider/openai-responses.ts
@@ -689,9 +689,10 @@ function sanitizeStoreFalseInputItems(input: unknown): {
 }
 
 // ChatGPT-account Codex Responses is stricter than the public OpenAI Responses API.
-// It rejects max_output_tokens/temperature and store:false item IDs from prior
-// responses. Keep this shim Codex-only; generic OpenAI Responses passthrough must
-// remain byte-faithful.
+// Legacy requests reject max_output_tokens/temperature and store:false item IDs
+// from prior responses. Responses Lite carries stable prefixed IDs (including its
+// additional_tools prefix); preserve that native history instead of applying the
+// legacy reference cleanup. Generic OpenAI passthrough remains byte-faithful.
 export function sanitizeCodexResponsesNativeBody(body: Record<string, unknown>): {
   body: Record<string, unknown>;
   fixes: CodexResponsesNativeBodyFix[];
@@ -711,7 +712,7 @@ export function sanitizeCodexResponsesNativeBody(body: Record<string, unknown>):
     delete ensureCopy().temperature;
     fixes.add("temperature_removed");
   }
-  if (next.store === false) {
+  if (next.store === false && !bodyUsesResponsesLite(next)) {
     const sanitized = sanitizeStoreFalseInputItems(next.input);
     if (sanitized.referencesStripped || sanitized.emptyReasoningDropped) {
       ensureCopy().input = sanitized.input;

--- a/packages/core/src/provider/overload-recovery.test.ts
+++ b/packages/core/src/provider/overload-recovery.test.ts
@@ -116,18 +116,21 @@ describe("bounded pre-output overload recovery", () => {
     expect(sends).toBe(1);
   });
 
-  it("recovers after one second without relaying the failed preamble", async () => {
+  it.each([
+    preamble,
+    'data: {"type":"response.metadata","headers":{"x-codex-turn-state":"opaque-state"}}\n\n',
+  ])("recovers after one second without relaying the failed preamble: %s", async (start) => {
     vi.useFakeTimers();
     let sends = 0;
     const account = member(async function* () {
       sends++;
-      yield preamble + (sends === 1 ? overload : output);
+      yield start + (sends === 1 ? overload : output);
     });
     const result = drain(pool(account).nativePassthroughStream!(body));
     await vi.advanceTimersByTimeAsync(999);
     expect(sends).toBe(1);
     await vi.advanceTimersByTimeAsync(1);
-    expect((await result).join("")).toBe(preamble + output);
+    expect((await result).join("")).toBe(start + output);
     expect(sends).toBe(2);
   });
 


### PR DESCRIPTION
## Problem and change
Codex Responses Lite sends stable input item IDs, including full-history and incremental requests. Helm's legacy `store:false` cleanup removed those IDs. Preserve Lite native history using the existing Lite detector while retaining legacy cleanup.

Known Codex metadata, quota, and timing events previously committed an attempt before generated output. Treat these control events as preamble so an explicit pre-output overload can use existing bounded recovery. Successful streams retain their original bytes; substantive output, unknown events, cancellation, and uncertain outcomes retain replay protections.

## Validation
- TDD: new unit and gateway-boundary regressions failed before the fix.
- 596 tests passed across Responses provider, failover guard, overload recovery, OAuth pool, and gateway execution.
- Core/gateway typecheck and targeted Biome passed (existing test warnings only).
- No dependencies, configuration, schema, or migrations changed.

Production evidence confirms ID removal in two affected requests. Failed production SSE bodies were not retained, so the metadata failure is a deterministic local reproduction, not proof of the sole incident cause. Original-task recovery requires separate live acceptance after deployment.
