### PR TITLE
chore(release): v0.29.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.9",
+  "version": "0.29.10",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v0.29.10 with the Codex protocol fixes merged in #851 (`722b861b376daabc59cdaaee660461b1956915b4`): preserve Responses Lite item IDs and keep known control events eligible for bounded pre-output overload recovery.

This PR changes only the root package version. The fix passed all PR CI checks and 596 focused regression tests. No migrations, dependencies, or runtime configuration changes are included. Publish and Remote deployment will use the exact merged revision and immutable image digest; original-task recovery remains a separate live acceptance check.
