### PR TITLE
fix(codex): keep heartbeat frames eligible for recovery (v0.29.11)

### DIFF
--- a/implementation-notes.md
+++ b/implementation-notes.md
@@ -10,7 +10,7 @@
 ## 2026-09-06 · 对齐 Codex Lite 身份与流式控制事件（Provider / Responses，docs/04/05/07，原则 3/5/8）
 
 - 对照 Codex `008bbd5884122dc95aaece19ecfe0fc6a59dcf36`：Lite 完整请求和增量续接保留带前缀的输入项 ID；Helm 旧 `store:false` 清理会删除它们。现用已有 Lite 识别逻辑排除旧清理，保留原生历史；普通 Responses 的兼容清理不变。
-- `response.metadata`、`codex.response.metadata`、`codex.rate_limits` 和 `responsesapi.websocket_timing` 属于控制信息。它们不再提前提交执行尝试；正常响应逐字节保留，输出前明确过载沿既有有界策略恢复。真实输出、工具调用、加密 reasoning、未知事件及结果不明断连的禁止重放边界不变。
+- `response.metadata`、`codex.response.metadata`、`codex.rate_limits`、`responsesapi.websocket_timing` 和 `keepalive` 属于控制信息。它们不再提前提交执行尝试；正常响应逐字节保留，输出前明确过载沿既有有界策略恢复。真实输出、工具调用、加密 reasoning、未知事件及结果不明断连的禁止重放边界不变。v0.29.10 部署后重放第二条原请求时，生产流明确出现 `keepalive` 后跟过载，补齐了先前缺失的线上事件证据。
 - 两条生产失败请求确实分别丢失 157/239 个 ID；控制事件导致错误直接下传已由本地网关与账号池回归用例复现，但生产未保留这些失败的完整 SSE，因此不能把两项差异直接认定为全部线上故障的唯一原因。补丁尚未部署，真实会话恢复仍须单独验证。
 
 ## 2026-09-06 · Remote 配置同步后的目录与 e2e 一致性（Config sync，docs/04/05，原则 2/3/6）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.10",
+  "version": "0.29.11",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/core/src/provider/failover-guard.test.ts
+++ b/packages/core/src/provider/failover-guard.test.ts
@@ -36,6 +36,7 @@ describe("guardPreOutputFailure — openai_responses", () => {
     { type: "codex.response.metadata", metadata: {} },
     { type: "responsesapi.websocket_timing", duration_ms: 1 },
     { type: "codex.rate_limits", rate_limits: { allowed: true, limit_reached: false } },
+    { type: "keepalive" },
   ])("keeps Codex control event $type before output eligible for recovery", async (event) => {
     const forwarded: string[] = [];
     const frames = [

--- a/packages/core/src/provider/failover-guard.ts
+++ b/packages/core/src/provider/failover-guard.ts
@@ -138,7 +138,8 @@ const responsesClassifier: PreOutputClassifier = {
       t === "response.metadata" ||
       t === "codex.response.metadata" ||
       t === "codex.rate_limits" ||
-      t === "responsesapi.websocket_timing"
+      t === "responsesapi.websocket_timing" ||
+      t === "keepalive"
     )
       return "preamble";
     if (t === "error" || t === "response.failed") return "error";


### PR DESCRIPTION
A post-deployment replay of the original failing Codex request produced `response.created`, `response.in_progress`, `keepalive`, then `server_is_overloaded`. Helm treated `keepalive` as output, prematurely disabling bounded recovery.

Classify this heartbeat alongside the existing control events. The regression fails before the one-line classifier change and passes afterward. Successful streams remain byte-preserving; unknown events, actual output and uncertain outcomes retain replay protections.

Includes the v0.29.11 patch bump to release this production-confirmed omission in v0.29.10. No config, dependencies, schema or migrations change.

Validation: 257 targeted guard/recovery/gateway tests passed; core/gateway typecheck and targeted Biome passed. v0.29.10 live replay of the first original request completed successfully; the second identified this missing control event. Its successful recovery remains to be verified after deployment.
