### PR TITLE
发布 v0.29.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helm-api",
-  "version": "0.29.11",
+  "version": "0.29.12",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## 发布内容

将 Helm API 版本从 `0.29.11` 提升到 `0.29.12`，发布已合并的失败请求订阅账号遥测修复。

失败请求在实际选择并请求订阅账号后，会记录最后一次上游尝试的账号；选账号前被跳过的请求仍保持为空，跨 provider fallback 不会误标旧账号。

## 发布评估

这是向后兼容的遥测修复，无数据库迁移、配置变更或公开 API 破坏，适合 patch release。

## 验证

业务 PR #854 的 `verify`、`store`、`e2e`、`docker` 与聚合 `Core CI` 已全部通过。本 PR 仅修改根 `package.json` 版本号。
